### PR TITLE
add status field to response in RPC methods `tx`, `EXPERIMENTAL_tx_status`, `broadcast_tx_commit`, `broadcast_tx_async`

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3750,7 +3750,7 @@ impl Chain {
 
     pub fn check_blocks_final_and_canonical(
         &self,
-        block_headers: &[&BlockHeader],
+        block_headers: &[BlockHeader],
     ) -> Result<(), Error> {
         let last_final_block_hash = *self.head_header()?.last_final_block();
         let last_final_height = self.get_block_header(&last_final_block_hash)?.height();

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -15,10 +15,9 @@ use near_primitives::types::{
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
     BlockView, ChunkView, DownloadStatusView, EpochValidatorInfo, ExecutionOutcomeWithIdView,
-    FinalExecutionOutcomeViewEnum, GasPriceView, LightClientBlockLiteView, LightClientBlockView,
-    MaintenanceWindowsView, QueryRequest, QueryResponse, ReceiptView, ShardSyncDownloadView,
-    SplitStorageInfoView, StateChangesKindsView, StateChangesRequestView, StateChangesView,
-    SyncStatusView,
+    GasPriceView, LightClientBlockLiteView, LightClientBlockView, MaintenanceWindowsView,
+    QueryRequest, QueryResponse, ReceiptView, ShardSyncDownloadView, SplitStorageInfoView,
+    StateChangesKindsView, StateChangesRequestView, StateChangesView, SyncStatusView, TxStatusView,
 };
 pub use near_primitives::views::{StatusResponse, StatusSyncInfo};
 use std::collections::HashMap;
@@ -721,7 +720,7 @@ impl From<near_chain_primitives::Error> for TxStatusError {
 }
 
 impl Message for TxStatus {
-    type Result = Result<Option<FinalExecutionOutcomeViewEnum>, TxStatusError>;
+    type Result = Result<TxStatusView, TxStatusError>;
 }
 
 #[derive(Debug)]

--- a/chain/client/src/tests/query_client.rs
+++ b/chain/client/src/tests/query_client.rs
@@ -186,8 +186,8 @@ fn test_execution_outcome_for_chunk() {
                 .await
                 .unwrap()
                 .unwrap()
-                .unwrap()
                 .into_outcome()
+                .unwrap()
                 .transaction_outcome
                 .block_hash;
 

--- a/chain/jsonrpc-primitives/src/types/transactions.rs
+++ b/chain/jsonrpc-primitives/src/types/transactions.rs
@@ -42,7 +42,8 @@ pub enum RpcTransactionError {
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct RpcTransactionResponse {
     #[serde(flatten)]
-    pub final_execution_outcome: near_primitives::views::FinalExecutionOutcomeViewEnum,
+    pub final_execution_outcome: Option<near_primitives::views::FinalExecutionOutcomeViewEnum>,
+    pub final_execution_status: near_primitives::views::TxExecutionStatus,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]

--- a/chain/jsonrpc/CHANGELOG.md
+++ b/chain/jsonrpc/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.2.3
+
+* Added `final_execution_status` field to the response of methods `tx`, `EXPERIMENTAL_tx_status`, `broadcast_tx_commit`
+
+### Breaking changes
+
+Response from `broadcast_tx_async` changed the type from String to Dict.
+The response has the same structure as in `broadcast_tx_commit`.
+It no longer contains transaction hash (which may be retrieved from Signed Transaction passed in request).
+
 ## 0.2.2
 
 * Extended error structures to be more explicit. See [#2976 decision comment for reference](https://github.com/near/nearcore/issues/2976#issuecomment-865834617)

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -5,13 +5,13 @@ use near_jsonrpc_primitives::message::{from_slice, Message};
 use near_jsonrpc_primitives::types::changes::{
     RpcStateChangesInBlockByTypeRequest, RpcStateChangesInBlockByTypeResponse,
 };
+use near_jsonrpc_primitives::types::transactions::RpcTransactionResponse;
 use near_jsonrpc_primitives::types::validator::RpcValidatorsOrderedRequest;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::{AccountId, BlockId, BlockReference, MaybeBlockId, ShardId};
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
-    BlockView, ChunkView, EpochValidatorInfo, FinalExecutionOutcomeView, GasPriceView,
-    StatusResponse,
+    BlockView, ChunkView, EpochValidatorInfo, GasPriceView, StatusResponse,
 };
 use std::time::Duration;
 
@@ -177,7 +177,7 @@ macro_rules! jsonrpc_client {
 
 jsonrpc_client!(pub struct JsonRpcClient {
     pub fn broadcast_tx_async(&self, tx: String) -> RpcRequest<String>;
-    pub fn broadcast_tx_commit(&self, tx: String) -> RpcRequest<FinalExecutionOutcomeView>;
+    pub fn broadcast_tx_commit(&self, tx: String) -> RpcRequest<RpcTransactionResponse>;
     pub fn status(&self) -> RpcRequest<StatusResponse>;
     #[allow(non_snake_case)]
     pub fn EXPERIMENTAL_check_tx(&self, tx: String) -> RpcRequest<serde_json::Value>;
@@ -186,9 +186,9 @@ jsonrpc_client!(pub struct JsonRpcClient {
     #[allow(non_snake_case)]
     pub fn EXPERIMENTAL_broadcast_tx_sync(&self, tx: String) -> RpcRequest<serde_json::Value>;
     #[allow(non_snake_case)]
-    pub fn EXPERIMENTAL_tx_status(&self, tx: String) -> RpcRequest<serde_json::Value>;
+    pub fn EXPERIMENTAL_tx_status(&self, tx: String) -> RpcRequest<RpcTransactionResponse>;
     pub fn health(&self) -> RpcRequest<()>;
-    pub fn tx(&self, hash: String, account_id: AccountId) -> RpcRequest<FinalExecutionOutcomeView>;
+    pub fn tx(&self, hash: String, account_id: AccountId) -> RpcRequest<RpcTransactionResponse>;
     pub fn chunk(&self, id: ChunkId) -> RpcRequest<ChunkView>;
     pub fn validators(&self, block_id: MaybeBlockId) -> RpcRequest<EpochValidatorInfo>;
     pub fn gas_price(&self, block_id: MaybeBlockId) -> RpcRequest<GasPriceView>;

--- a/chain/jsonrpc/jsonrpc-tests/tests/rpc_transactions.rs
+++ b/chain/jsonrpc/jsonrpc-tests/tests/rpc_transactions.rs
@@ -13,7 +13,7 @@ use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::serialize::to_base64;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::BlockReference;
-use near_primitives::views::FinalExecutionStatus;
+use near_primitives::views::{FinalExecutionStatus, TxExecutionStatus};
 
 use near_jsonrpc_tests::{self as test_utils, test_with_client};
 
@@ -62,7 +62,9 @@ fn test_send_tx_async() {
                             .tx(tx_hash.to_string(), signer_account_id)
                             .map_err(|err| println!("Error: {:?}", err))
                             .map_ok(|result| {
-                                if let FinalExecutionStatus::SuccessValue(_) = result.status {
+                                if let FinalExecutionStatus::SuccessValue(_) =
+                                    result.final_execution_outcome.unwrap().into_outcome().status
+                                {
                                     System::current().stop();
                                 }
                             })
@@ -93,7 +95,15 @@ fn test_send_tx_commit() {
         );
         let bytes = tx.try_to_vec().unwrap();
         let result = client.broadcast_tx_commit(to_base64(&bytes)).await.unwrap();
-        assert_eq!(result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
+        assert_eq!(
+            result.final_execution_outcome.unwrap().into_outcome().status,
+            FinalExecutionStatus::SuccessValue(Vec::new())
+        );
+        assert!(
+            vec![TxExecutionStatus::Executed, TxExecutionStatus::Final]
+                .contains(&result.final_execution_status),
+            "All the receipts should be already executed"
+        );
     });
 }
 

--- a/chain/jsonrpc/src/api/transactions.rs
+++ b/chain/jsonrpc/src/api/transactions.rs
@@ -5,12 +5,11 @@ use serde_with::serde_as;
 use near_client_primitives::types::TxStatusError;
 use near_jsonrpc_primitives::errors::RpcParseError;
 use near_jsonrpc_primitives::types::transactions::{
-    RpcBroadcastTransactionRequest, RpcTransactionError, RpcTransactionResponse,
-    RpcTransactionStatusCommonRequest, TransactionInfo,
+    RpcBroadcastTransactionRequest, RpcTransactionError, RpcTransactionStatusCommonRequest,
+    TransactionInfo,
 };
 use near_primitives::borsh::BorshDeserialize;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::views::FinalExecutionOutcomeViewEnum;
 
 use super::{Params, RpcFrom, RpcRequest};
 
@@ -50,12 +49,6 @@ impl RpcFrom<TxStatusError> for RpcTransactionError {
             TxStatusError::InternalError(debug_info) => Self::InternalError { debug_info },
             TxStatusError::TimeoutError => Self::TimeoutError,
         }
-    }
-}
-
-impl RpcFrom<FinalExecutionOutcomeViewEnum> for RpcTransactionResponse {
-    fn rpc_from(final_execution_outcome: FinalExecutionOutcomeViewEnum) -> Self {
-        Self { final_execution_outcome }
     }
 }
 

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -25,6 +25,7 @@ use near_jsonrpc_primitives::types::config::RpcProtocolConfigResponse;
 use near_jsonrpc_primitives::types::entity_debug::{EntityDebugHandler, EntityQuery};
 use near_jsonrpc_primitives::types::query::RpcQueryRequest;
 use near_jsonrpc_primitives::types::split_storage::RpcSplitStorageInfoResponse;
+use near_jsonrpc_primitives::types::transactions::RpcTransactionResponse;
 use near_network::tcp;
 use near_network::PeerManagerActor;
 use near_o11y::metrics::{prometheus, Encoder, TextEncoder};
@@ -32,7 +33,7 @@ use near_o11y::{WithSpanContext, WithSpanContextExt};
 use near_primitives::hash::CryptoHash;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockHeight};
-use near_primitives::views::{FinalExecutionOutcomeViewEnum, QueryRequest};
+use near_primitives::views::{QueryRequest, TxExecutionStatus};
 use serde_json::{json, Value};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -312,11 +313,7 @@ impl JsonRpcHandler {
             // Handlers ordered alphabetically
             "block" => process_method_call(request, |params| self.block(params)).await,
             "broadcast_tx_async" => {
-                process_method_call(request, |params| async {
-                    let tx = self.send_tx_async(params).await.to_string();
-                    Result::<_, std::convert::Infallible>::Ok(tx)
-                })
-                .await
+                process_method_call(request, |params| self.send_tx_async(params)).await
             }
             "broadcast_tx_commit" => {
                 process_method_call(request, |params| self.send_tx_commit(params)).await
@@ -473,9 +470,11 @@ impl JsonRpcHandler {
     async fn send_tx_async(
         &self,
         request_data: near_jsonrpc_primitives::types::transactions::RpcBroadcastTransactionRequest,
-    ) -> CryptoHash {
+    ) -> Result<
+        near_jsonrpc_primitives::types::transactions::RpcTransactionResponse,
+        near_jsonrpc_primitives::types::transactions::RpcTransactionError,
+    > {
         let tx = request_data.signed_transaction;
-        let hash = tx.get_hash();
         self.client_addr.do_send(
             ProcessTxRequest {
                 transaction: tx,
@@ -484,7 +483,10 @@ impl JsonRpcHandler {
             }
             .with_span_context(),
         );
-        hash
+        Ok(RpcTransactionResponse {
+            final_execution_outcome: None,
+            final_execution_status: TxExecutionStatus::None,
+        })
     }
 
     async fn tx_exists(
@@ -504,8 +506,10 @@ impl JsonRpcHandler {
                     })
                     .await
                 {
-                    Ok(Some(_)) => {
-                        return Ok(true);
+                    Ok(status) => {
+                        if let Some(_) = status.execution_outcome {
+                            return Ok(true);
+                        }
                     }
                     Err(near_jsonrpc_primitives::types::transactions::RpcTransactionError::UnknownTransaction {
                         ..
@@ -534,7 +538,7 @@ impl JsonRpcHandler {
         tx_info: near_jsonrpc_primitives::types::transactions::TransactionInfo,
         fetch_receipt: bool,
     ) -> Result<
-        FinalExecutionOutcomeViewEnum,
+        near_jsonrpc_primitives::types::transactions::RpcTransactionResponse,
         near_jsonrpc_primitives::types::transactions::RpcTransactionError,
     > {
         let (tx_hash, account_id) = match &tx_info {
@@ -555,8 +559,15 @@ impl JsonRpcHandler {
                     })
                     .await;
                 match tx_status_result {
-                    Ok(Some(outcome)) => break Ok(outcome),
-                    Ok(None) => {} // No such transaction recorded on chain yet
+                    Ok(result) => {
+                        if let Some(outcome) = result.execution_outcome {
+                            break Ok(RpcTransactionResponse {
+                                final_execution_outcome: Some(outcome),
+                                final_execution_status: result.status,
+                            })
+                        }
+                        // else: No such transaction recorded on chain yet
+                    },
                     Err(err @ near_jsonrpc_primitives::types::transactions::RpcTransactionError::UnknownTransaction {
                         ..
                     }) => {
@@ -601,11 +612,7 @@ impl JsonRpcHandler {
             loop {
                 match self.tx_status_fetch(tx_info.clone(), false).await {
                     Ok(tx_status) => {
-                        break Ok(
-                            near_jsonrpc_primitives::types::transactions::RpcTransactionResponse {
-                                final_execution_outcome: tx_status,
-                            },
-                        )
+                        break Ok(tx_status)
                     }
                     // If transaction is missing, keep polling.
                     Err(near_jsonrpc_primitives::types::transactions::RpcTransactionError::UnknownTransaction {
@@ -735,9 +742,7 @@ impl JsonRpcHandler {
             .await
         {
             Ok(outcome) => {
-                return Ok(near_jsonrpc_primitives::types::transactions::RpcTransactionResponse {
-                    final_execution_outcome: outcome,
-                });
+                return Ok(outcome);
             }
             Err(err @ near_jsonrpc_primitives::types::transactions::RpcTransactionError::InvalidTransaction {
                 ..

--- a/integration-tests/src/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/src/tests/nearcore/rpc_nodes.rs
@@ -138,7 +138,7 @@ fn test_get_execution_outcome(is_tx_successful: bool) {
                 spawn_interruptible(client.broadcast_tx_commit(to_base64(&bytes)).then(
                     move |res| {
                         let final_transaction_outcome = match res {
-                            Ok(outcome) => outcome,
+                            Ok(outcome) => outcome.final_execution_outcome.unwrap().into_outcome(),
                             Err(_) => return future::ready(()),
                         };
                         spawn_interruptible(sleep(Duration::from_secs(1)).then(move |_| {

--- a/integration-tests/src/user/rpc_user.rs
+++ b/integration-tests/src/user/rpc_user.rs
@@ -140,7 +140,7 @@ impl User for RpcUser {
             thread::sleep(Duration::from_millis(50));
         }
         match result {
-            Ok(outcome) => Ok(outcome),
+            Ok(outcome) => Ok(outcome.final_execution_outcome.unwrap().into_outcome()),
             Err(err) => Err(serde_json::from_value::<ServerError>(err.data.unwrap()).unwrap()),
         }
     }
@@ -186,7 +186,11 @@ impl User for RpcUser {
     fn get_transaction_final_result(&self, hash: &CryptoHash) -> FinalExecutionOutcomeView {
         let account_id = self.account_id.clone();
         let hash = hash.to_string();
-        self.actix(move |client| client.tx(hash, account_id)).unwrap()
+        self.actix(move |client| client.tx(hash, account_id))
+            .unwrap()
+            .final_execution_outcome
+            .unwrap()
+            .into_outcome()
     }
 
     fn get_state_root(&self) -> CryptoHash {


### PR DESCRIPTION
This PR is a part of RPC tx methods redesign https://docs.google.com/document/d/1jGuXzBlMAGQENsUpy5x5Xd7huCLOd8k6tyMOEE41Rro/edit?usp=sharing
Addressing point 3 in https://github.com/near/nearcore/issues/9542 and start working on https://github.com/near/nearcore/issues/6837

Changes:
- New field `status` appeared in the response of RPC methods `tx`, `EXPERIMENTAL_tx_status`, `broadcast_tx_commit`, `broadcast_tx_async`
- Added some comments with the explanations

In https://github.com/near/nearcore/issues/6837, Illia suggested to have the structure
```rust
enum BroadcastWait {
 /// Returns right away.
 None,
 /// Waits only for inclusion into the block.
 Inclusion,
 /// Waits until block with inclusion is finalized.
 InclusionFinal,
 /// Waits until all non-refund receipts are executed.
 Executed,
 /// Waits until all non-refund receipts are executed and the last of the blocks is final.
 ExecutedFinal,
 /// Waits until everything has executed and is final.
 Final,
 }
```

I've renamed it to `TxExecutionStatus` and simplified it a little by dropping all refund options:
1. We may add them later without breaking backwards compatibility
2. To support them, we need to have the access to `receipt` (it's the method `get_tx_execution_status`). We have there only `execution_outcome` by default. We created special logic to be able not to retrieve the receipts (it's the only difference between `tx` and `EXPERIMENTAL_tx_status`). I have a feeling (please correct me here if I'm wrong) that retrieving corresponding receipt may slow down the execution that we tried to optimise.
BTW, maybe the data from `execution_outcome` is enough (we have there `gas_burnt` and `tokens_burnt`). @jakmeier suggested the condition `outcome.tokens_burnt == 0 && outcome.status == Success`. Unfortunately, we need to work with any status. But maybe the first part (`outcome.tokens_burnt == 0`) is enough to say that it could be only refund receipt. I need more input here.