### PR TITLE
perf: don't clone all incoming `PeerMessage`s

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1086,7 +1086,14 @@ impl PeerActor {
             "handle_msg_ready")
         .entered();
 
-        match peer_msg.clone() {
+        // Clones message iff someone is listening on the sink. Should be in tests only.
+        let message_processed_event = self
+            .network_state
+            .config
+            .event_sink
+            .delayed_push(|| Event::MessageProcessed(conn.tier, peer_msg.clone()));
+
+        match peer_msg {
             PeerMessage::Disconnect(d) => {
                 tracing::debug!(target: "network", "Disconnect signal. Me: {:?} Peer: {:?}", self.my_node_info.id, self.other_peer_id());
 
@@ -1125,10 +1132,7 @@ impl PeerActor {
                         direct_peers,
                     }));
                 }
-                self.network_state
-                    .config
-                    .event_sink
-                    .push(Event::MessageProcessed(conn.tier, peer_msg));
+                message_processed_event();
             }
             PeerMessage::PeersResponse(PeersResponse { peers, direct_peers }) => {
                 tracing::debug!(target: "network", "Received peers from {}: {} peers and {} direct peers.", self.peer_info, peers.len(), direct_peers.len());
@@ -1154,11 +1158,7 @@ impl PeerActor {
                     &self.clock,
                     direct_peers.into_iter().filter(|peer_info| peer_info.id != node_id),
                 );
-
-                self.network_state
-                    .config
-                    .event_sink
-                    .push(Event::MessageProcessed(conn.tier, peer_msg));
+                message_processed_event();
             }
             PeerMessage::RequestUpdateNonce(edge_info) => {
                 let clock = self.clock.clone();
@@ -1185,10 +1185,7 @@ impl PeerActor {
                             }
                         }
                     };
-                    network_state
-                        .config
-                        .event_sink
-                        .push(Event::MessageProcessed(conn.tier, peer_msg));
+                    message_processed_event();
                 }));
             }
             PeerMessage::SyncRoutingTable(rtu) => {
@@ -1198,10 +1195,7 @@ impl PeerActor {
                 ctx.spawn(wrap_future(async move {
                     Self::handle_sync_routing_table(&clock, &network_state, conn.clone(), rtu)
                         .await;
-                    network_state
-                        .config
-                        .event_sink
-                        .push(Event::MessageProcessed(conn.tier, peer_msg));
+                    message_processed_event();
                 }));
             }
             PeerMessage::DistanceVector(dv) => {
@@ -1210,10 +1204,7 @@ impl PeerActor {
                 let network_state = self.network_state.clone();
                 ctx.spawn(wrap_future(async move {
                     Self::handle_distance_vector(&clock, &network_state, conn.clone(), dv).await;
-                    network_state
-                        .config
-                        .event_sink
-                        .push(Event::MessageProcessed(conn.tier, peer_msg));
+                    message_processed_event();
                 }));
             }
             PeerMessage::SyncAccountsData(msg) => {
@@ -1242,10 +1233,7 @@ impl PeerActor {
                 }
                 // Early exit, if there is no data in the message.
                 if msg.accounts_data.is_empty() {
-                    network_state
-                        .config
-                        .event_sink
-                        .push(Event::MessageProcessed(conn.tier, peer_msg));
+                    message_processed_event();
                     return;
                 }
                 let network_state = self.network_state.clone();
@@ -1260,10 +1248,7 @@ impl PeerActor {
                             AccountDataError::SingleAccountMultipleData => ReasonForBan::Abusive,
                         }));
                     }
-                    network_state
-                        .config
-                        .event_sink
-                        .push(Event::MessageProcessed(conn.tier, peer_msg));
+                    message_processed_event();
                 }));
             }
             PeerMessage::Routed(mut msg) => {
@@ -1332,17 +1317,11 @@ impl PeerActor {
                             // TODO(gprusak): deprecate Event::Ping/Pong in favor of
                             // MessageProcessed.
                             self.network_state.config.event_sink.push(Event::Ping(ping.clone()));
-                            self.network_state
-                                .config
-                                .event_sink
-                                .push(Event::MessageProcessed(conn.tier, PeerMessage::Routed(msg)));
+                            message_processed_event();
                         }
                         RoutedMessageBody::Pong(pong) => {
                             self.network_state.config.event_sink.push(Event::Pong(pong.clone()));
-                            self.network_state
-                                .config
-                                .event_sink
-                                .push(Event::MessageProcessed(conn.tier, PeerMessage::Routed(msg)));
+                            message_processed_event();
                         }
                         _ => self.receive_message(ctx, &conn, PeerMessage::Routed(msg)),
                     }


### PR DESCRIPTION
The clone was only there because of lifetime complaints that were due to the message being moved to the test observer after processing. We can avoid the clone entirely in non-test setup.

This is important because these messages can be 100MB+