### PR TITLE
chore: bump crossbeam-channel to 0.5.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,9 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ conqueue = "0.4.0"
 cpu-time = "1.0"
 criterion = { version = "0.3.5", default_features = false, features = ["html_reports", "cargo_bench_support"] }
 crossbeam = "0.8"
-crossbeam-channel = "0.5"
+crossbeam-channel = "0.5.8"
 crossbeam-queue = "0.3.8"
 csv = "1.2.1"
 curve25519-dalek = "3"


### PR DESCRIPTION
Versions 0.5.1 - 0.5.7 were yanked due to a race condition. See [changelog](https://github.com/crossbeam-rs/crossbeam/blob/master/crossbeam-channel/CHANGELOG.md#version-058) and [crates.io](https://crates.io/crates/crossbeam-channel/versions) and [PR with the fix](https://github.com/crossbeam-rs/crossbeam/pull/972).