### PR TITLE
drop EXPERIMENTAL_check_tx RPC method

### DIFF
--- a/chain/jsonrpc/CHANGELOG.md
+++ b/chain/jsonrpc/CHANGELOG.md
@@ -6,9 +6,10 @@
 
 ### Breaking changes
 
-Response from `broadcast_tx_async` changed the type from String to Dict.
-The response has the same structure as in `broadcast_tx_commit`.
-It no longer contains transaction hash (which may be retrieved from Signed Transaction passed in request).
+* Response from `broadcast_tx_async` changed the type from String to Dict.
+  The response has the same structure as in `broadcast_tx_commit`.
+  It no longer contains transaction hash (which may be retrieved from Signed Transaction passed in request).
+* Removed `EXPERIMENTAL_check_tx` method. Use `tx` method instead
 
 ## 0.2.2
 

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -180,8 +180,6 @@ jsonrpc_client!(pub struct JsonRpcClient {
     pub fn broadcast_tx_commit(&self, tx: String) -> RpcRequest<RpcTransactionResponse>;
     pub fn status(&self) -> RpcRequest<StatusResponse>;
     #[allow(non_snake_case)]
-    pub fn EXPERIMENTAL_check_tx(&self, tx: String) -> RpcRequest<serde_json::Value>;
-    #[allow(non_snake_case)]
     pub fn EXPERIMENTAL_genesis_config(&self) -> RpcRequest<serde_json::Value>;
     #[allow(non_snake_case)]
     pub fn EXPERIMENTAL_broadcast_tx_sync(&self, tx: String) -> RpcRequest<serde_json::Value>;

--- a/chain/jsonrpc/jsonrpc-tests/tests/rpc_transactions.rs
+++ b/chain/jsonrpc/jsonrpc-tests/tests/rpc_transactions.rs
@@ -223,14 +223,8 @@ fn test_check_invalid_tx() {
             100,
             hash(&[1]),
         );
-        let bytes = tx.try_to_vec().unwrap();
-        match client.EXPERIMENTAL_check_tx(to_base64(&bytes)).await {
-            Err(e) => {
-                let s = serde_json::to_string(&e.data.unwrap()).unwrap();
-                println!("{}", s);
-                assert_eq!(s, "{\"TxExecutionError\":{\"InvalidTxError\":\"Expired\"}}");
-            }
-            Ok(_) => panic!("transaction should not succeed"),
+        if let Ok(_) = client.tx(tx.get_hash().to_string(), "test1".parse().unwrap()).await {
+            panic!("transaction should not succeed");
         }
     });
 }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -348,9 +348,6 @@ impl JsonRpcHandler {
             "EXPERIMENTAL_changes_in_block" => {
                 process_method_call(request, |params| self.changes_in_block(params)).await
             }
-            "EXPERIMENTAL_check_tx" => {
-                process_method_call(request, |params| self.check_tx(params)).await
-            }
             "EXPERIMENTAL_genesis_config" => {
                 process_method_call(request, |_params: ()| async {
                     Result::<_, std::convert::Infallible>::Ok(&self.genesis_config)
@@ -693,32 +690,6 @@ impl JsonRpcHandler {
             network_client_responses=> Err(
                 near_jsonrpc_primitives::types::transactions::RpcTransactionError::from_network_client_responses(
                     network_client_responses
-                )
-            )
-        }
-    }
-
-    async fn check_tx(
-        &self,
-        request_data: near_jsonrpc_primitives::types::transactions::RpcBroadcastTransactionRequest,
-    ) -> Result<
-        near_jsonrpc_primitives::types::transactions::RpcBroadcastTxSyncResponse,
-        near_jsonrpc_primitives::types::transactions::RpcTransactionError,
-    > {
-        match self.send_tx(request_data.clone().signed_transaction, true).await? {
-            ProcessTxResponse::ValidTx => {
-                Ok(near_jsonrpc_primitives::types::transactions::RpcBroadcastTxSyncResponse {
-                    transaction_hash: request_data.signed_transaction.get_hash(),
-                })
-            }
-            ProcessTxResponse::RequestRouted => {
-                Err(near_jsonrpc_primitives::types::transactions::RpcTransactionError::RequestRouted {
-                    transaction_hash: request_data.signed_transaction.get_hash(),
-                })
-            }
-            resp => Err(
-                near_jsonrpc_primitives::types::transactions::RpcTransactionError::from_network_client_responses(
-                   resp
                 )
             )
         }

--- a/integration-tests/src/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/src/tests/nearcore/rpc_nodes.rs
@@ -609,7 +609,6 @@ fn test_check_tx_on_lightclient_must_return_does_not_track_shard() {
         );
 
         let client = new_client(&format!("http://{}", rpc_addrs[1]));
-        let bytes = transaction.try_to_vec().unwrap();
 
         spawn_interruptible(async move {
             loop {
@@ -617,7 +616,7 @@ fn test_check_tx_on_lightclient_must_return_does_not_track_shard() {
                 if let Ok(Ok(block)) = res {
                     if block.header.height > 10 {
                         let _ = client
-                            .EXPERIMENTAL_check_tx(to_base64(&bytes))
+                            .tx(transaction.get_hash().to_string(), "near.1".parse().unwrap())
                             .map_err(|err| {
                                 assert_eq!(
                                     err.data.unwrap(),


### PR DESCRIPTION
This PR is a part of RPC tx methods redesign https://docs.google.com/document/d/1jGuXzBlMAGQENsUpy5x5Xd7huCLOd8k6tyMOEE41Rro/edit?usp=sharing

It has no usages on our RPC nodes, but I can't say anything about 3rd party nodes.
It is not covered by documentation in any of our sources.

If there's anyone who uses this method, I suggest switching to `tx` method instead.
The return type differs, giving more information to the user.