### PR TITLE
optimize curve25519 for tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -371,3 +371,5 @@ opt-level = 3
 opt-level = 3
 [profile.dev.package.sha2]
 opt-level = 3
+[profile.dev.package.curve25519-dalek]
+opt-level = 3


### PR DESCRIPTION
This brings down the runtime of tests involving the runtime-tester by 40%, ie. 7.5s -> 4.5s for the runtime quickcheck added in #9602. Hopefully other tests will also profit from it, though I haven’t benchmarked it all.

The overall runtime on buildkite of the `cargo test nightly not integration-tests*` test seems, on a sample of 1, to be roughly the same (+- 10s) before addition of the test from #9602, so there should not be a significant delay in CI round-trip due to it, and it should mostly impact local development that rarely sees changes from dependencies.