### PR TITLE
fix: make `--c_memory_stats` work again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4066,6 +4066,7 @@ dependencies = [
  "bytesize",
  "futures",
  "libc",
+ "near-rust-allocator-proxy",
  "once_cell",
  "strum",
  "tokio",
@@ -4224,6 +4225,15 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.15",
+]
+
+[[package]]
+name = "near-rust-allocator-proxy"
+version = "0.4.0"
+dependencies = [
+ "backtrace",
+ "nix 0.15.0",
+ "tracing",
 ]
 
 [[package]]
@@ -4665,6 +4675,7 @@ dependencies = [
  "near-performance-metrics",
  "near-ping",
  "near-primitives",
+ "near-rust-allocator-proxy",
  "near-state-parts",
  "near-store",
  "near-undo-block",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,6 +212,7 @@ near-primitives-core = { path = "core/primitives-core" }
 near-rosetta-rpc = { path = "chain/rosetta-rpc" }
 near-rpc-error-core = { path = "tools/rpctypegen/core" }
 near-rpc-error-macro = { path = "tools/rpctypegen/macro" }
+near-rust-allocator-proxy = { path = "../near-memory-tracker/near-rust-allocator-proxy" }
 near-stable-hasher = { path = "utils/near-stable-hasher" }
 near-state-parts = { path = "tools/state-parts" }
 near-state-viewer = { path = "tools/state-viewer", package = "state-viewer" }

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -54,6 +54,8 @@ near-state-viewer.workspace = true
 near-store.workspace = true
 near-undo-block.workspace = true
 
+near-rust-allocator-proxy = { workspace = true, optional = true }
+
 [build-dependencies]
 anyhow.workspace = true
 rustc_version = "0.4"
@@ -62,7 +64,7 @@ rustc_version = "0.4"
 default = ["json_rpc", "rosetta_rpc"]
 
 performance_stats = ["nearcore/performance_stats"]
-c_memory_stats = ["nearcore/c_memory_stats"]
+c_memory_stats = ["nearcore/c_memory_stats", "near-rust-allocator-proxy"]
 test_features = ["nearcore/test_features"]
 expensive_tests = ["nearcore/expensive_tests"]
 no_cache = ["nearcore/no_cache"]

--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -32,7 +32,13 @@ fn neard_version() -> Version {
 static DEFAULT_HOME: Lazy<PathBuf> = Lazy::new(get_default_home);
 
 #[global_allocator]
+#[cfg(not(feature = "c_memory_stats"))]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+#[global_allocator]
+#[cfg(feature = "c_memory_stats")]
+static ALLOC: near_rust_allocator_proxy::ProxyAllocator<tikv_jemallocator::Jemalloc> =
+    near_rust_allocator_proxy::ProxyAllocator::new(tikv_jemallocator::Jemalloc);
 
 fn main() -> anyhow::Result<()> {
     if env::var("RUST_BACKTRACE").is_err() {

--- a/utils/near-performance-metrics/Cargo.toml
+++ b/utils/near-performance-metrics/Cargo.toml
@@ -21,6 +21,9 @@ tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
 
+near-rust-allocator-proxy = { workspace = true, optional = true }
+
+
 [features]
-c_memory_stats = []
+c_memory_stats = ["near-rust-allocator-proxy"]
 performance_stats = ["bytesize"]

--- a/utils/near-performance-metrics/src/stats_enabled.rs
+++ b/utils/near-performance-metrics/src/stats_enabled.rs
@@ -197,11 +197,7 @@ pub(crate) struct Stats {
 
 #[cfg(all(target_os = "linux", feature = "c_memory_stats"))]
 fn get_c_memory_usage_cur_thread() -> ByteSize {
-    // hack to get memory usage stats for c memory usage per thread
-    // This feature will only work if near is started with environment
-    // LD_PRELOAD=${PWD}/bins/near-c-allocator-proxy.so nearup ...
-    // from https://github.com/near/near-memory-tracker/blob/master/near-dump-analyzer
-    unsafe { ByteSize::b(libc::malloc(usize::MAX - 1) as u64) }
+    ByteSize::b(near_rust_allocator_proxy::current_thread_memory_usage() as u64)
 }
 
 #[cfg(any(not(target_os = "linux"), not(feature = "c_memory_stats")))]
@@ -211,11 +207,7 @@ fn get_c_memory_usage_cur_thread() -> ByteSize {
 
 #[cfg(all(target_os = "linux", feature = "c_memory_stats"))]
 fn get_c_memory_usage() -> ByteSize {
-    // hack to get memory usage stats for c memory usage
-    // This feature will only work if near is started with environment
-    // LD_PRELOAD=${PWD}/bins/near-c-allocator-proxy.so nearup ...
-    // from https://github.com/near/near-memory-tracker/blob/master/near-dump-analyzer
-    unsafe { ByteSize::b(libc::malloc(usize::MAX) as u64) }
+    ByteSize::b(near_rust_allocator_proxy::total_memory_usage() as u64)
 }
 
 #[cfg(any(not(target_os = "linux"), not(feature = "c_memory_stats")))]


### PR DESCRIPTION
I tried using the .so as suggested in the commetns. But it crashed, presumably due to jemalloc version mismatch.

However, we can just rely on the crate and don't need such hacks.

With this, we can observe heap memory per thread if both features "c_memory_stats" and "performance_stats" are enabled.

Example:

```
Performance stats 12 threads (min ratio = 0.02)
    ThreadId(47): ratio: 0.375 {"run_later", "near_chunks::shards_manager_actor::ShardsManagerActor"}:ThreadId(34) C mem: 1032.9 MB
        func ():0: cnt: 41 total: 1557ms max: 584ms
        func chain/chunks/src/shards_manager_actor.rs:33: cnt: 10 total: 0ms max: 0ms
    ThreadId(74): ratio: 0.191 {"run_later", "near_network::peer::peer_actor::PeerActor"}:ThreadId(34) C mem: 13.2 MB
        func ():0: cnt: 52 total: 956ms max: 125ms
    ThreadId(42): ratio: 0.366 {"near_client::client_actor::ClientActor", "run_later"}:ThreadId(34) C mem: 183.7 MB
        func ():0: cnt: 86 total: 1743ms max: 533ms
        func chain/client/src/client_actor.rs:1089: cnt: 37 total: 83ms max: 69ms
        func chain/client/src/client_actor.rs:1515: cnt: 35 total: 1ms max: 0ms
    ThreadId(62): ratio: 0.129 {"near_network::peer::peer_actor::PeerActor", "run_later"}:ThreadId(34) C mem: 13.2 MB
        func ():0: cnt: 43 total: 644ms max: 135ms
    ThreadId(73): ratio: 0.319 {"near_network::peer::peer_actor::PeerActor", "run_later"}:ThreadId(34) C mem: 97.9 MB
        func ():0: cnt: 46 total: 1595ms max: 234ms
    ThreadId(50): ratio: 0.043 {"near_network::peer_manager::peer_manager_actor::PeerManagerActor", "run_later"}:ThreadId(34) C mem: 107.8 KB
        func ():0: cnt: 74 total: 212ms max: 9ms
        func chain/network/src/peer_manager/peer_manager_actor.rs:621: cnt: 1 total: 0ms max: 0ms
        func chain/network/src/peer_manager/peer_manager_actor.rs:715: cnt: 49 total: 3ms max: 0ms
    Other threads ratio 0.000
    C alloc total memory usage: 1.6 GB
```