### PR TITLE
fix: remove nightly changes from parameters.snap

### DIFF
--- a/core/primitives/res/runtime_configs/parameters.snap
+++ b/core/primitives/res/runtime_configs/parameters.snap
@@ -166,7 +166,7 @@ account_id_validity_rules_version                          1
 disable_9393_fix                        false
 flat_storage_reads                      true
 implicit_account_creation               true
-fix_contract_loading_cost               true
+fix_contract_loading_cost               false
 math_extension                          true
 ed25519_verify                          true
 alt_bn128                               true

--- a/core/primitives/src/runtime/config_store.rs
+++ b/core/primitives/src/runtime/config_store.rs
@@ -316,6 +316,7 @@ mod tests {
     #[cfg(not(feature = "calimero_zero_storage"))]
     fn test_json_unchanged() {
         use crate::views::RuntimeConfigView;
+        use near_primitives_core::version::PROTOCOL_VERSION;
 
         let store = RuntimeConfigStore::new(None);
         let mut any_failure = false;
@@ -332,7 +333,9 @@ mod tests {
         // Store the latest values of parameters in a human-readable snapshot.
         {
             let mut params: ParameterTable = BASE_CONFIG.parse().unwrap();
-            for (_, diff_bytes) in CONFIG_DIFFS {
+            for (_, diff_bytes) in
+                CONFIG_DIFFS.iter().filter(|(version, _)| *version <= PROTOCOL_VERSION)
+            {
                 params.apply_diff(diff_bytes.parse().unwrap()).unwrap();
             }
             insta::with_settings!({


### PR DESCRIPTION
The point of this file is to quickly see the current parameters.
Showing the nightly changes is not in this spirit IMO.