### PR TITLE
WIP io actor experiment

### DIFF
--- a/chain/chain/src/blocking_io_actor.rs
+++ b/chain/chain/src/blocking_io_actor.rs
@@ -1,0 +1,36 @@
+use near_o11y::WithSpanContext;
+use near_store::StoreUpdate;
+
+/// Runs IO tasks that would block a normal arbiter for too long.
+///
+/// This actor should be running in a SyncArbiter, which means there can be
+/// multiple instances of the actor in parallel, each with its own OS thread.
+/// Compared to running in a normal arbiter, this means blocking IO requests
+/// don't stall other jobs.
+pub struct BlockingIoActor;
+
+#[derive(actix::Message)]
+#[rtype(result = "std::io::Result<()>")]
+pub(crate) enum BlockingIoActorMessage {
+    /// Take a prepared DB transaction and persist it.
+    CommitStoreUpdate(StoreUpdate),
+}
+
+impl actix::Actor for BlockingIoActor {
+    type Context = actix::SyncContext<Self>;
+}
+
+impl actix::Handler<WithSpanContext<BlockingIoActorMessage>> for BlockingIoActor {
+    type Result = std::io::Result<()>;
+
+    fn handle(
+        &mut self,
+        msg: WithSpanContext<BlockingIoActorMessage>,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        // For now there is only one message type.
+        let BlockingIoActorMessage::CommitStoreUpdate(update) = msg.msg;
+        let _span = tracing::debug_span!(target: "client", "commit_store_update");
+        update.commit()
+    }
+}

--- a/chain/chain/src/blocking_io_actor.rs
+++ b/chain/chain/src/blocking_io_actor.rs
@@ -1,4 +1,5 @@
 use near_o11y::WithSpanContext;
+use near_performance_metrics_macros::perf;
 use near_store::StoreUpdate;
 
 /// Runs IO tasks that would block a normal arbiter for too long.
@@ -23,6 +24,7 @@ impl actix::Actor for BlockingIoActor {
 impl actix::Handler<WithSpanContext<BlockingIoActorMessage>> for BlockingIoActor {
     type Result = std::io::Result<()>;
 
+    #[perf]
     fn handle(
         &mut self,
         msg: WithSpanContext<BlockingIoActorMessage>,

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1,6 +1,7 @@
 use crate::block_processing_utils::{
     BlockPreprocessInfo, BlockProcessingArtifact, BlocksInProcessing, DoneApplyChunkCallback,
 };
+use crate::blocking_io_actor::BlockingIoActor;
 use crate::blocks_delay_tracker::BlocksDelayTracker;
 use crate::crypto_hash_timer::CryptoHashTimer;
 use crate::lightclient::get_epoch_block_producers_view;
@@ -475,6 +476,8 @@ pub struct Chain {
 
     /// Lets trigger new state snapshots.
     state_snapshot_helper: Option<StateSnapshotHelper>,
+
+    blocking_io_actor: Option<actix::Addr<BlockingIoActor>>,
 }
 
 /// Lets trigger new state snapshots.
@@ -577,6 +580,7 @@ impl Chain {
             pending_state_patch: Default::default(),
             requested_state_parts: StateRequestTracker::new(),
             state_snapshot_helper: None,
+            blocking_io_actor: None,
         })
     }
 
@@ -588,6 +592,7 @@ impl Chain {
         doomslug_threshold_mode: DoomslugThresholdMode,
         chain_config: ChainConfig,
         make_snapshot_callback: Option<MakeSnapshotCallback>,
+        blocking_io_actor: Option<actix::Addr<BlockingIoActor>>,
     ) -> Result<Chain, Error> {
         // Get runtime initial state and create genesis block out of it.
         let state_roots = get_genesis_state_roots(runtime_adapter.store())?
@@ -747,6 +752,7 @@ impl Chain {
                     .state_snapshot_every_n_blocks
                     .map(|n| (0, n)),
             }),
+            blocking_io_actor,
         })
     }
 
@@ -2249,10 +2255,16 @@ impl Chain {
         block_preprocess_info: BlockPreprocessInfo,
         apply_results: Vec<Result<ApplyChunkResult, Error>>,
     ) -> Result<Option<Tip>, Error> {
+        let addr = self.blocking_io_actor.clone().take();
         let mut chain_update = self.chain_update();
         let new_head =
             chain_update.postprocess_block(me, &block, block_preprocess_info, apply_results)?;
-        chain_update.commit()?;
+        // chain_update.commit()?; // TODO: This commit can take forever
+        if let Some(blocking_io_actor) = addr {
+            chain_update.chain_store_update.commit_async(blocking_io_actor)?;
+        } else {
+            chain_update.commit()?;
+        }
         Ok(new_head)
     }
 

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2261,7 +2261,7 @@ impl Chain {
             chain_update.postprocess_block(me, &block, block_preprocess_info, apply_results)?;
         // chain_update.commit()?; // TODO: This commit can take forever
         if let Some(blocking_io_actor) = addr {
-            // TODO
+            // TODO: also use async commit here, for now we just use sync commit
             // chain_update.chain_store_update.commit_async(
             //     self.client.client_actor.clone().expect("must have a client actor"),
             //     blocking_io_actor,

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2261,7 +2261,12 @@ impl Chain {
             chain_update.postprocess_block(me, &block, block_preprocess_info, apply_results)?;
         // chain_update.commit()?; // TODO: This commit can take forever
         if let Some(blocking_io_actor) = addr {
-            chain_update.chain_store_update.commit_async(blocking_io_actor)?;
+            // TODO
+            // chain_update.chain_store_update.commit_async(
+            //     self.client.client_actor.clone().expect("must have a client actor"),
+            //     blocking_io_actor,
+            // )?;
+            chain_update.commit()?;
         } else {
             chain_update.commit()?;
         }

--- a/chain/chain/src/lib.rs
+++ b/chain/chain/src/lib.rs
@@ -9,6 +9,7 @@ pub use store_validator::{ErrorMessage, StoreValidator};
 pub use types::{Block, BlockHeader, BlockStatus, ChainGenesis, Provenance};
 
 mod block_processing_utils;
+pub mod blocking_io_actor;
 pub mod blocks_delay_tracker;
 pub mod chain;
 pub mod chunks_store;

--- a/chain/chain/src/lib.rs
+++ b/chain/chain/src/lib.rs
@@ -4,7 +4,7 @@ pub use doomslug::{Doomslug, DoomslugBlockProductionReadiness, DoomslugThreshold
 pub use lightclient::{create_light_client_block_view, get_epoch_block_producers_view};
 pub use near_chain_primitives::{self, Error};
 pub use near_primitives::receipt::ReceiptResult;
-pub use store::{ChainStore, ChainStoreAccess, ChainStoreUpdate};
+pub use store::{ChainStore, ChainStoreAccess, ChainStoreUpdate, UpdateChainCachesMessage};
 pub use store_validator::{ErrorMessage, StoreValidator};
 pub use types::{Block, BlockHeader, BlockStatus, ChainGenesis, Provenance};
 

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -113,6 +113,7 @@ pub fn setup_with_tx_validity_period(
         DoomslugThresholdMode::NoApprovals,
         ChainConfig::test(),
         None,
+        None,
     )
     .unwrap();
 
@@ -150,6 +151,7 @@ pub fn setup_with_validators(
         DoomslugThresholdMode::NoApprovals,
         ChainConfig::test(),
         None,
+        None,
     )
     .unwrap();
     (chain, epoch_manager, runtime, signers)
@@ -185,6 +187,7 @@ pub fn setup_with_validators_and_start_time(
         },
         DoomslugThresholdMode::NoApprovals,
         ChainConfig::test(),
+        None,
         None,
     )
     .unwrap();

--- a/chain/chunks/src/logic.rs
+++ b/chain/chunks/src/logic.rs
@@ -238,23 +238,3 @@ where
     // update.commit()?;
     Ok(())
 }
-
-// pub fn persist_chunk_async(
-//     partial_chunk: PartialEncodedChunk,
-//     shard_chunk: Option<ShardChunk>,
-//     store: &mut ChainStore,
-//     blocking_io_actor: actix::Addr<BlockingIoActor>,
-// ) -> Result<(), Error> {
-//     let mut update = store.store_update();
-//     update.save_partial_chunk(partial_chunk);
-//     if let Some(shard_chunk) = shard_chunk {
-//         update.save_chunk(shard_chunk);
-//     }
-//     // TODO: do we need to wait or is persisting async okay?
-//     actix::Arbiter::current().spawn(async {
-//         // TODO: error handling
-//         update.commit_async(blocking_io_actor).await.unwrap();
-//     });
-//     // update.commit()?;
-//     Ok(())
-// }

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1358,19 +1358,6 @@ impl Client {
         )
         .expect("Could not persist chunk");
 
-        // let blocking_io_actor = self.blocking_io_actor.clone();
-        // actix::Arbiter::current().spawn(async {
-        //     let store: &mut near_chain::ChainStore = self.chain.mut_store();
-        //     let mut update = store.store_update();
-        //     update.save_partial_chunk(partial_chunk);
-        //     if let Some(shard_chunk) = shard_chunk {
-        //         update.save_chunk(shard_chunk);
-        //     }
-        //     // TODO: do we need to wait or is persisting async okay?
-        //     // TODO: error handling
-        //     update.commit_async(blocking_io_actor).await.expect("Could not persist chunk");
-        // });
-
         // We're marking chunk as accepted.
         self.chain.blocks_with_missing_chunks.accept_chunk(&chunk_header.chunk_hash());
         // If this was the last chunk that was missing for a block, it will be processed now.

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -16,7 +16,7 @@ use crate::info::{display_sync_status, InfoHelper};
 use crate::sync::state::{StateSync, StateSyncResult};
 use crate::sync_jobs_actor::{create_sync_job_scheduler, SyncJobsActor};
 use crate::{metrics, StatusResponse};
-use actix::{Actor, Addr, Arbiter, AsyncContext, Context, Handler};
+use actix::{Actor, Addr, Arbiter, AsyncContext, Context, Handler, SyncArbiter};
 use actix_rt::ArbiterHandle;
 use chrono::{DateTime, Utc};
 use near_async::messaging::{CanSend, Sender};

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1228,7 +1228,10 @@ impl ClientActor {
         chain_store_update
             .save_largest_target_height(self.client.doomslug.get_largest_target_height());
 
-        match chain_store_update.commit() {
+        let addr = self.client.blocking_io_actor.clone();
+        // this commit can take seconds! Try async commit?
+        // match chain_store_update.commit() {
+        match chain_store_update.commit_async(addr) {
             Ok(_) => {
                 let head = unwrap_or_return!(self.client.chain.head());
                 if self.client.is_validator(&head.epoch_id, &head.last_block_hash)

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -16,7 +16,7 @@ use crate::info::{display_sync_status, InfoHelper};
 use crate::sync::state::{StateSync, StateSyncResult};
 use crate::sync_jobs_actor::{create_sync_job_scheduler, SyncJobsActor};
 use crate::{metrics, StatusResponse};
-use actix::{Actor, Addr, Arbiter, AsyncContext, Context, Handler, SyncArbiter};
+use actix::{Actor, Addr, Arbiter, AsyncContext, Context, Handler};
 use actix_rt::ArbiterHandle;
 use chrono::{DateTime, Utc};
 use near_async::messaging::{CanSend, Sender};

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -246,6 +246,7 @@ pub fn setup(
             state_snapshot_every_n_blocks: None,
         },
         None,
+        None,
     )
     .unwrap();
     let genesis_block = chain.get_block(&chain.genesis().hash().clone()).unwrap();
@@ -367,6 +368,7 @@ pub fn setup_only_view(
             background_migration_threads: 1,
             state_snapshot_every_n_blocks: None,
         },
+        None,
         None,
     )
     .unwrap();
@@ -1248,6 +1250,7 @@ pub fn setup_synchronous_shards_manager(
             background_migration_threads: 1,
             state_snapshot_every_n_blocks: None,
         }, // irrelevant
+        None,
         None,
     )
     .unwrap();

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -585,10 +585,6 @@ impl NetworkState {
             }
         }
 
-        // if success {
-        //     return success;
-        // }
-
         let peer_id_from_account_data = accounts_data
             .keys_by_id
             .get(account_id)

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -585,6 +585,10 @@ impl NetworkState {
             }
         }
 
+        // if success {
+        //     return success;
+        // }
+
         let peer_id_from_account_data = accounts_data
             .keys_by_id
             .get(account_id)
@@ -617,7 +621,9 @@ impl NetworkState {
 
         let msg = RawRoutedMessage { target: PeerIdOrHash::PeerId(target), body: msg };
         let msg = self.sign_message(clock, msg);
-        if msg.body.is_important() {
+        // If we have sent it over tier 1 already, let's trust the tier 1
+        // network instead of resending 3x we resend only once.
+        if msg.body.is_important() &! success {
             for _ in 0..IMPORTANT_MESSAGE_RESENT_COUNT {
                 success |= self.send_message_to_peer(clock, tcp::Tier::T2, msg.clone());
             }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -1109,3 +1109,23 @@ mod tests {
         );
     }
 }
+
+pub struct PrintTimeOnDrop {
+    msg: &'static str,
+    start: std::time::Instant,
+}
+
+impl PrintTimeOnDrop {
+    pub fn new(msg: &'static str) -> Self {
+        Self { msg, start: std::time::Instant::now() }
+    }
+}
+
+impl Drop for PrintTimeOnDrop {
+    fn drop(&mut self) {
+        let elapsed = self.start.elapsed();
+        if elapsed.as_micros() > 1 {
+            tracing::warn!(target: "chain", " {} took: {:?}.\n", self.msg, elapsed)
+        }
+    }
+}

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -1109,23 +1109,3 @@ mod tests {
         );
     }
 }
-
-pub struct PrintTimeOnDrop {
-    msg: &'static str,
-    start: std::time::Instant,
-}
-
-impl PrintTimeOnDrop {
-    pub fn new(msg: &'static str) -> Self {
-        Self { msg, start: std::time::Instant::now() }
-    }
-}
-
-impl Drop for PrintTimeOnDrop {
-    fn drop(&mut self) {
-        let elapsed = self.start.elapsed();
-        if elapsed.as_micros() > 1 {
-            tracing::warn!(target: "chain", " {} took: {:?}.\n", self.msg, elapsed)
-        }
-    }
-}

--- a/integration-tests/src/genesis_helpers.rs
+++ b/integration-tests/src/genesis_helpers.rs
@@ -34,6 +34,7 @@ pub fn genesis_header(genesis: &Genesis) -> BlockHeader {
         DoomslugThresholdMode::TwoThirds,
         ChainConfig::test(),
         None,
+        None,
     )
     .unwrap();
     chain.genesis().clone()
@@ -56,6 +57,7 @@ pub fn genesis_block(genesis: &Genesis) -> Block {
         &chain_genesis,
         DoomslugThresholdMode::TwoThirds,
         ChainConfig::test(),
+        None,
         None,
     )
     .unwrap();

--- a/tools/speedy_sync/src/main.rs
+++ b/tools/speedy_sync/src/main.rs
@@ -246,6 +246,7 @@ fn load_snapshot(load_cmd: LoadCmd) {
             state_snapshot_every_n_blocks: None,
         },
         None,
+        None,
     )
     .unwrap();
 


### PR DESCRIPTION
Idea: Do not block the ClientActor when committing to the DB
Note: This is a prototype. The implementation is hacky and far form ready for production.

Localnet experiments with large chunks have shown a reduction form 97% utilization of the ClientActor down to below 50%. Such a high ClientActor utilization means we are completely bottlenecked by it and may struggle to keep up with the network.

However, so far in my tests the nodes got stuck quite quickly. It could be due to other issues, or maybe something about the asynchronous commit of the new chunk breaks the processing invariants. I didn't find the time to dig deeper into it.