### PR TITLE
Limit output for view-trie full mode

### DIFF
--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -870,9 +870,9 @@ pub(crate) fn view_trie(
     shard_version: u32,
     max_depth: u32,
     limit: Option<u32>,
-    type_str: Option<&str>,
-    from: Option<&[u8]>,
-    to: Option<&[u8]>,
+    record_type: Option<u8>,
+    from: Option<AccountId>,
+    to: Option<AccountId>,
 ) -> anyhow::Result<()> {
     let trie = get_trie(store, hash, shard_id, shard_version);
     trie.print_recursive(
@@ -880,9 +880,9 @@ pub(crate) fn view_trie(
         &hash,
         max_depth,
         limit,
-        type_str,
-        from,
-        to,
+        record_type,
+        from.as_ref(),
+        to.as_ref(),
     );
     Ok(())
 }
@@ -894,10 +894,19 @@ pub(crate) fn view_trie_leaves(
     shard_version: u32,
     max_depth: u32,
     limit: Option<u32>,
-    type_str: Option<&str>,
+    record_type: Option<u8>,
+    from: Option<AccountId>,
+    to: Option<AccountId>,
 ) -> anyhow::Result<()> {
     let trie = get_trie(store, state_root_hash, shard_id, shard_version);
-    trie.print_recursive_leaves(&mut std::io::stdout().lock(), max_depth, limit, type_str);
+    trie.print_recursive_leaves(
+        &mut std::io::stdout().lock(),
+        max_depth,
+        limit,
+        record_type,
+        from.as_ref(),
+        to.as_ref(),
+    );
     Ok(())
 }
 

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -881,8 +881,8 @@ pub(crate) fn view_trie(
         max_depth,
         limit,
         record_type,
-        from.as_ref(),
-        to.as_ref(),
+        &from.as_ref(),
+        &to.as_ref(),
     );
     Ok(())
 }
@@ -904,8 +904,8 @@ pub(crate) fn view_trie_leaves(
         max_depth,
         limit,
         record_type,
-        from.as_ref(),
-        to.as_ref(),
+        &from.as_ref(),
+        &to.as_ref(),
     );
     Ok(())
 }

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -869,9 +869,21 @@ pub(crate) fn view_trie(
     shard_id: u32,
     shard_version: u32,
     max_depth: u32,
+    limit: Option<u32>,
+    type_str: Option<&str>,
+    from: Option<&[u8]>,
+    to: Option<&[u8]>,
 ) -> anyhow::Result<()> {
     let trie = get_trie(store, hash, shard_id, shard_version);
-    trie.print_recursive(&mut std::io::stdout().lock(), &hash, max_depth);
+    trie.print_recursive(
+        &mut std::io::stdout().lock(),
+        &hash,
+        max_depth,
+        limit,
+        type_str,
+        from,
+        to,
+    );
     Ok(())
 }
 
@@ -881,9 +893,11 @@ pub(crate) fn view_trie_leaves(
     shard_id: u32,
     shard_version: u32,
     max_depth: u32,
+    limit: Option<u32>,
+    type_str: Option<&str>,
 ) -> anyhow::Result<()> {
     let trie = get_trie(store, state_root_hash, shard_id, shard_version);
-    trie.print_recursive_leaves(&mut std::io::stdout().lock(), max_depth);
+    trie.print_recursive_leaves(&mut std::io::stdout().lock(), max_depth, limit, type_str);
     Ok(())
 }
 

--- a/tools/state-viewer/src/state_parts.rs
+++ b/tools/state-viewer/src/state_parts.rs
@@ -405,7 +405,15 @@ fn print_state_part(state_root: &StateRoot, _part_id: PartId, data: &[u8]) {
     let trie_nodes: PartialState = BorshDeserialize::try_from_slice(data).unwrap();
     let trie =
         Trie::from_recorded_storage(PartialStorage { nodes: trie_nodes }, *state_root, false);
-    trie.print_recursive(&mut std::io::stdout().lock(), &state_root, u32::MAX);
+    trie.print_recursive(
+        &mut std::io::stdout().lock(),
+        &state_root,
+        u32::MAX,
+        None,
+        None,
+        None,
+        None,
+    );
 }
 
 async fn dump_state_parts(

--- a/tools/state-viewer/src/state_parts.rs
+++ b/tools/state-viewer/src/state_parts.rs
@@ -411,8 +411,8 @@ fn print_state_part(state_root: &StateRoot, _part_id: PartId, data: &[u8]) {
         u32::MAX,
         None,
         None,
-        None,
-        None,
+        &None,
+        &None,
     );
 }
 


### PR DESCRIPTION
Part of https://github.com/near/nearcore/issues/9548
This commit adds a few cmdline options to the `neard view-state view-trie` tool:
- `--limit` - limits how many entries are printed to the output
- `--record-type` - only records of given type from the state trie would be printed
- `--from` - skip nodes with key lexicographically less than `from` (unless it is a prefix of `from`)
- `--to` - skip nodes with key lexicographically greater than `to`