### PR TITLE
[resharding] Add logic to poll for snapshot before resharding

### DIFF
--- a/chain/chain/src/resharding.rs
+++ b/chain/chain/src/resharding.rs
@@ -223,7 +223,9 @@ impl Chain {
         tries.get_state_snapshot(prev_prev_hash).is_err_and(|err| match err {
             SnapshotError::SnapshotNotFound(_) => true,
             SnapshotError::LockWouldBlock => true,
-            _ => false,
+            SnapshotError::SnapshotConfigDisabled => false,
+            SnapshotError::IncorrectSnapshotRequested(_, _) => false,
+            SnapshotError::Other(_) => false,
         })
     }
 

--- a/chain/chain/src/resharding.rs
+++ b/chain/chain/src/resharding.rs
@@ -24,10 +24,12 @@ use near_store::{ShardTries, ShardUId, Store, Trie, TrieDBStorage, TrieStorage};
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
+use std::time::Duration;
 use tracing::debug;
 
 // This is the approx batch size of the trie key, value pair entries that are written to the child shard trie.
 const RESHARDING_BATCH_MEMORY_LIMIT: bytesize::ByteSize = bytesize::ByteSize(300 * bytesize::MIB);
+const MAX_RESHARDING_POLL_TIME: Duration = Duration::from_secs(5 * 60 * 60); // 5 hrs
 
 /// StateSplitRequest has all the information needed to start a resharding job. This message is sent
 /// from ClientActor to SyncJobsActor. We do not want to stall the ClientActor with a long running
@@ -47,6 +49,8 @@ pub struct StateSplitRequest {
     // state root of the parent shardUId. This is different from block sync_hash
     pub state_root: StateRoot,
     pub next_epoch_shard_layout: ShardLayout,
+    // Time we've spent polling for the state snapshot to be ready. We autofail after a certain time.
+    pub curr_poll_time: Duration,
 }
 
 // Skip `runtime_adapter`, because it's a complex object that has complex logic
@@ -197,6 +201,7 @@ impl Chain {
             shard_uid,
             state_root,
             next_epoch_shard_layout,
+            curr_poll_time: Duration::ZERO,
         });
 
         RESHARDING_STATUS
@@ -209,9 +214,16 @@ impl Chain {
     /// Function to check whether the snapshot is ready for resharding or not. We return true if the snapshot is not
     /// ready and we need to retry/reschedule the resharding job.
     pub fn retry_build_state_for_split_shards(state_split_request: &StateSplitRequest) -> bool {
-        let StateSplitRequest { tries, prev_prev_hash, .. } = state_split_request;
-        tries.get_state_snapshot(prev_prev_hash).is_err_and(|e| {
-            e == SnapshotError::SnapshotNotFound || e == SnapshotError::LockWouldBlock
+        let StateSplitRequest { tries, prev_prev_hash, curr_poll_time, .. } = state_split_request;
+        // Do not retry if we have spent more than MAX_RESHARDING_POLL_TIME
+        // The error would be caught in build_state_for_split_shards and propagated to client actor
+        if curr_poll_time > &MAX_RESHARDING_POLL_TIME {
+            return false;
+        }
+        tries.get_state_snapshot(prev_prev_hash).is_err_and(|err| match err {
+            SnapshotError::SnapshotNotFound(_) => true,
+            SnapshotError::LockWouldBlock => true,
+            _ => false,
         })
     }
 
@@ -260,7 +272,7 @@ impl Chain {
         // changes on top of it.
         let (snapshot_store, flat_storage_manager) = tries
             .get_state_snapshot(&prev_prev_hash)
-            .map_err(|e| StorageInconsistentState(e.to_string()))?;
+            .map_err(|err| StorageInconsistentState(err.to_string()))?;
         let flat_storage_chunk_view =
             flat_storage_manager.chunk_view(shard_uid, prev_prev_hash).ok_or_else(|| {
                 StorageInconsistentState("Chunk view missing for snapshot flat storage".to_string())
@@ -272,7 +284,7 @@ impl Chain {
             });
 
         let delta = store_helper::get_delta_changes(&snapshot_store, shard_uid, prev_hash)
-            .map_err(|e| StorageInconsistentState(e.to_string()))?
+            .map_err(|err| StorageInconsistentState(err.to_string()))?
             .ok_or_else(|| {
                 StorageInconsistentState("Delta missing for snapshot flat storage".to_string())
             })?;

--- a/chain/client/src/sync_jobs_actor.rs
+++ b/chain/client/src/sync_jobs_actor.rs
@@ -1,4 +1,5 @@
 use crate::ClientActor;
+use actix::AsyncContext;
 use borsh::BorshSerialize;
 use near_chain::chain::{
     do_apply_chunks, ApplyStatePartsRequest, ApplyStatePartsResponse, BlockCatchUpRequest,
@@ -12,6 +13,9 @@ use near_primitives::state_part::PartId;
 use near_primitives::state_sync::StatePartKey;
 use near_primitives::types::ShardId;
 use near_store::DBCol;
+use std::time::Duration;
+
+const RESHARDING_RETRY_TIME: Duration = Duration::from_secs(10);
 
 pub(crate) struct SyncJobsActor {
     pub(crate) client_addr: actix::Addr<ClientActor>,
@@ -149,11 +153,17 @@ impl actix::Handler<WithSpanContext<StateSplitRequest>> for SyncJobsActor {
     fn handle(
         &mut self,
         msg: WithSpanContext<StateSplitRequest>,
-        _: &mut Self::Context,
+        context: &mut Self::Context,
     ) -> Self::Result {
-        let (_span, msg) = handler_debug_span!(target: "client", msg);
-        tracing::debug!(target: "client", ?msg);
-        let response = Chain::build_state_for_split_shards(msg);
-        self.client_addr.do_send(response.with_span_context());
+        let (_span, state_split_request) = handler_debug_span!(target: "client", msg);
+        tracing::debug!(target: "client", ?state_split_request);
+        if Chain::retry_build_state_for_split_shards(&state_split_request) {
+            // Actix implementation let's us send message to ourselves with a delay.
+            // In case snapshots are not ready yet, we will retry resharding later.
+            context.notify_later(state_split_request.with_span_context(), RESHARDING_RETRY_TIME);
+        } else {
+            let response = Chain::build_state_for_split_shards(state_split_request);
+            self.client_addr.do_send(response.with_span_context());
+        }
     }
 }

--- a/chain/client/src/sync_jobs_actor.rs
+++ b/chain/client/src/sync_jobs_actor.rs
@@ -15,7 +15,7 @@ use near_primitives::types::ShardId;
 use near_store::DBCol;
 use std::time::Duration;
 
-const RESHARDING_RETRY_TIME: Duration = Duration::from_secs(10);
+const RESHARDING_RETRY_TIME: Duration = Duration::from_secs(30);
 
 pub(crate) struct SyncJobsActor {
     pub(crate) client_addr: actix::Addr<ClientActor>,

--- a/chain/client/src/sync_jobs_actor.rs
+++ b/chain/client/src/sync_jobs_actor.rs
@@ -156,12 +156,13 @@ impl actix::Handler<WithSpanContext<StateSplitRequest>> for SyncJobsActor {
         context: &mut Self::Context,
     ) -> Self::Result {
         let (_span, state_split_request) = handler_debug_span!(target: "client", msg);
-        tracing::debug!(target: "client", ?state_split_request);
         if Chain::retry_build_state_for_split_shards(&state_split_request) {
             // Actix implementation let's us send message to ourselves with a delay.
             // In case snapshots are not ready yet, we will retry resharding later.
+            tracing::debug!(target: "client", ?state_split_request, "Snapshot missing, retrying resharding later");
             context.notify_later(state_split_request.with_span_context(), RESHARDING_RETRY_TIME);
         } else {
+            tracing::debug!(target: "client", ?state_split_request, "Starting resharding");
             let response = Chain::build_state_for_split_shards(state_split_request);
             self.client_addr.do_send(response.with_span_context());
         }

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -8,7 +8,7 @@ use crate::trie::iterator::TrieIterator;
 pub use crate::trie::nibble_slice::NibbleSlice;
 pub use crate::trie::prefetching_trie_storage::{PrefetchApi, PrefetchError};
 pub use crate::trie::shard_tries::{KeyForStateChanges, ShardTries, WrappedTrieChanges};
-pub use crate::trie::state_snapshot::{StateSnapshot, StateSnapshotConfig};
+pub use crate::trie::state_snapshot::{SnapshotError, StateSnapshot, StateSnapshotConfig};
 pub use crate::trie::trie_storage::{TrieCache, TrieCachingStorage, TrieDBStorage, TrieStorage};
 use crate::StorageError;
 use borsh::{BorshDeserialize, BorshSerialize};

--- a/core/store/src/trie/state_snapshot.rs
+++ b/core/store/src/trie/state_snapshot.rs
@@ -7,13 +7,46 @@ use crate::{Store, StoreConfig};
 use near_primitives::block::Block;
 use near_primitives::errors::EpochError;
 use near_primitives::errors::StorageError;
-use near_primitives::errors::StorageError::StorageInconsistentState;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardUId;
 
+use std::error::Error;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::TryLockError;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SnapshotError {
+    IncorrectSnapshotRequested(CryptoHash, CryptoHash),
+    SnapshotNotFound,
+    LockWouldBlock,
+    Other(String),
+}
+
+impl std::fmt::Display for SnapshotError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SnapshotError::IncorrectSnapshotRequested(requested, available) => write!(
+                f,
+                "Wrong state snapshot. Requested: {:?}, Available: {:?}",
+                requested, available
+            ),
+            SnapshotError::SnapshotNotFound => write!(f, "No state snapshot available"),
+            SnapshotError::LockWouldBlock => {
+                write!(f, "Accessing state snapshot would block. Retry in a few seconds.")
+            }
+            SnapshotError::Other(err_msg) => write!(f, "{}", err_msg),
+        }
+    }
+}
+
+impl Error for SnapshotError {}
+
+impl From<SnapshotError> for StorageError {
+    fn from(err: SnapshotError) -> Self {
+        StorageError::StorageInconsistentState(err.to_string())
+    }
+}
 
 /// Snapshot of the state at the epoch boundary.
 pub struct StateSnapshot {
@@ -86,28 +119,24 @@ impl ShardTries {
     pub fn get_state_snapshot(
         &self,
         block_hash: &CryptoHash,
-    ) -> Result<(Store, FlatStorageManager), StorageError> {
+    ) -> Result<(Store, FlatStorageManager), SnapshotError> {
         // Taking this lock can last up to 10 seconds, if the snapshot happens to be re-created.
         match self.state_snapshot().try_read() {
             Ok(guard) => {
                 if let Some(data) = guard.as_ref() {
                     if &data.prev_block_hash != block_hash {
-                        return Err(StorageInconsistentState(format!(
-                            "Wrong state snapshot. Requested: {:?}, Available: {:?}",
-                            block_hash, data.prev_block_hash
-                        )));
+                        return Err(SnapshotError::IncorrectSnapshotRequested(
+                            *block_hash,
+                            data.prev_block_hash,
+                        ));
                     }
                     Ok((data.store.clone(), data.flat_storage_manager.clone()))
                 } else {
-                    Err(StorageInconsistentState("No state snapshot available".to_string()))
+                    Err(SnapshotError::SnapshotNotFound)
                 }
             }
-            Err(TryLockError::WouldBlock) => Err(StorageInconsistentState(
-                "Accessing state snapshot would block. Retry in a few seconds.".to_string(),
-            )),
-            Err(err) => {
-                Err(StorageInconsistentState(format!("Can't access state snapshot: {err:?}")))
-            }
+            Err(TryLockError::WouldBlock) => Err(SnapshotError::LockWouldBlock),
+            Err(err) => Err(SnapshotError::Other(err.to_string())),
         }
     }
 


### PR DESCRIPTION
For resharding, the snapshots must be created. We use the flat storage from snapshots to iterate over trie key, value to create child shards.

Creating snapshots is async and handled via the `StateSnapshotActor`. This PR adds logic to poll/wait for snapshots to be created before starting resharding.

We use the actix [notify_later](https://docs.rs/actix/latest/actix/prelude/trait.AsyncContext.html#method.notify_later) call to push the same resharding message back to the queue of the `SyncJobsActor` after a time period.