### PR TITLE
fix: always take gas price from previous block

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -70,7 +70,7 @@ use near_primitives::types::{
 };
 use near_primitives::unwrap_or_return;
 use near_primitives::utils::MaybeValidated;
-use near_primitives::version::PROTOCOL_VERSION;
+use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_primitives::views::{
     BlockStatusView, DroppedReason, ExecutionOutcomeWithIdView, ExecutionStatusView,
     FinalExecutionOutcomeView, FinalExecutionOutcomeWithReceiptView, FinalExecutionStatus,
@@ -4187,15 +4187,22 @@ impl Chain {
         split_state_roots: Option<HashMap<ShardUId, CryptoHash>>,
     ) -> Result<Option<ApplyChunkJob>, Error> {
         let shard_id = shard_uid.shard_id();
-        let new_extra = self.get_chunk_extra(prev_block.hash(), &shard_uid)?;
+        let prev_block_hash = *prev_block.hash();
+        let new_extra = self.get_chunk_extra(&prev_block_hash, &shard_uid)?;
 
         let block_hash = *block.hash();
         let challenges_result = block.header().challenges_result().clone();
         let block_timestamp = block.header().raw_timestamp();
-        let gas_price = block.header().gas_price();
+        let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(&prev_block_hash)?;
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
+
+        let gas_price = if protocol_version >= ProtocolFeature::FixApplyChunks.protocol_version() {
+            prev_block.header().gas_price()
+        } else {
+            block.header().gas_price()
+        };
         let random_seed = *block.header().random_value();
         let height = block.header().height();
-        let prev_block_hash = *prev_block.hash();
 
         Ok(Some(Box::new(move |parent_span| -> Result<ApplyChunkResult, Error> {
             let _span = tracing::debug_span!(

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -15,6 +15,8 @@ pub enum ProtocolFeature {
     /// Add `AccessKey` nonce range by setting nonce to `(block_height - 1) * 1e6`, see
     /// <https://github.com/near/nearcore/issues/3779>.
     AccessKeyNonceRange,
+    /// Don't process any receipts for shard when chunk is not present.
+    /// Always use gas price computed in the previous block.
     FixApplyChunks,
     LowerStorageCost,
     DeleteActionRestriction,


### PR DESCRIPTION
Part of #9618.

In post-state-root, chunk production is moved before block production, thus we don't have a `Block` during applying chunk anymore. We need to make sure that all necessary data is still propagated to `Runtime::apply`.

It should've not have been an error for gas price, as it is taken from previous block in the general case: https://github.com/near/nearcore/blob/9c8d0bbec6a71876bb3317db2ade425f0077a184/chain/chain/src/chain.rs#L4120 However, when there is no chunk, there seem to be a very old error - it is taken from the same block.

Luckily, after `ProtocolFeature::FixApplyChunks` it is not an issue: when there is no chunk, gas price is not used at all. So I just start taking it from previous block for consistency, to ensure that in post-state-root current block can be safely removed.

Full context: https://near.zulipchat.com/#narrow/stream/295302-general/topic/.E2.9C.94.20gas.20price.20inconsistency/near/394894144

## Testing

As the change must be no-op, existing tests are enough.