### PR TITLE
jsonrpc: allow parse object at tx status requests

### DIFF
--- a/chain/jsonrpc-primitives/src/errors.rs
+++ b/chain/jsonrpc-primitives/src/errors.rs
@@ -2,7 +2,7 @@ use near_primitives::errors::TxExecutionError;
 use serde_json::{to_value, Value};
 use std::fmt;
 
-#[derive(serde::Serialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct RpcParseError(pub String);
 
 /// This struct may be returned from JSON RPC server in case of error

--- a/chain/jsonrpc/src/api/mod.rs
+++ b/chain/jsonrpc/src/api/mod.rs
@@ -128,13 +128,12 @@ mod params {
             self.0.unwrap_or_else(Self::parse)
         }
 
-        /// If value hasn’t been parsed yet, tries to deserialise it directly
-        /// into `T` using given parse function.
-        pub fn unwrap_or_else(
-            self,
-            func: impl FnOnce(Value) -> Result<T, RpcParseError>,
-        ) -> Result<T, RpcParseError> {
-            self.0.unwrap_or_else(func)
+        /// Finish chain of parsing without trying of parsing to `T` directly
+        pub fn unwrap(self) -> Result<T, RpcParseError> {
+            match self.0 {
+                Ok(res) => res,
+                Err(e) => Err(RpcParseError(format!("Failed parsing args: {e}"))),
+            }
         }
 
         /// If value hasn’t been parsed yet and it’s a one-element array

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -18,16 +18,7 @@ pub use crate::action::{
 
 pub type LogEntry = String;
 
-#[derive(
-    BorshSerialize,
-    BorshDeserialize,
-    PartialEq,
-    Eq,
-    Debug,
-    Clone,
-    serde::Serialize,
-    serde::Deserialize,
-)]
+#[derive(BorshSerialize, BorshDeserialize, serde::Serialize, PartialEq, Eq, Debug, Clone)]
 pub struct Transaction {
     /// An account on which behalf transaction is signed
     pub signer_id: AccountId,
@@ -53,9 +44,7 @@ impl Transaction {
     }
 }
 
-#[derive(
-    BorshSerialize, BorshDeserialize, serde::Serialize, serde::Deserialize, Eq, Debug, Clone,
-)]
+#[derive(BorshSerialize, BorshDeserialize, serde::Serialize, Eq, Debug, Clone)]
 #[borsh(init=init)]
 pub struct SignedTransaction {
     pub transaction: Transaction,


### PR DESCRIPTION
Adding the possibility to pass object as params for tx status methods:
```
{
  "jsonrpc": "2.0",
  "id": "dontcare",
  "method": "EXPERIMENTAL_tx_status", // could be "tx"
  "params": {
    "tx_hash": "6zgh2u9DqHHiXzdy9ouTP7oGky2T4nugqzqt9wJZwNFm",
    "sender_account_id": "sender.testnet"
  }
}
```

This is just a nice improvement, it looks cleaner.
But I specifically need this as a prep step for https://github.com/near/nearcore/issues/6837
Having json params will allow me to add new request parameter easier.

I thought about adding passing object to send tx methods as well, but the user has to pack it by borsh to be able to sign it.
So, deserialising SignedTransaction by serde makes no sense, I dropped this functionality.
Serialisation can still be useful to be able to dump tx to json so that humans may read it.
