### PR TITLE
V2 Routing: Refresh distance vector nonces

### DIFF
--- a/chain/network/src/routing/edge_cache/mod.rs
+++ b/chain/network/src/routing/edge_cache/mod.rs
@@ -285,8 +285,8 @@ impl EdgeCache {
     /// If we have a tree stored for the given peer,
     /// returns the min nonce among the edges in the tree.
     ///
-    /// Returns None if no tree is stored, or if no nonce
-    /// is available for any of the edges in the tree.
+    /// Returns None if no tree is stored.
+    /// Returns None if for any edge in the tree, no nonce is available.
     pub fn get_min_nonce(&mut self, peer_id: &PeerId) -> Option<u64> {
         let edge_keys = self.active_trees.get(peer_id)?;
 

--- a/chain/network/src/routing/edge_cache/mod.rs
+++ b/chain/network/src/routing/edge_cache/mod.rs
@@ -11,7 +11,7 @@ mod tests;
 
 // Connections in the network are bi-directional between a pair of peers (peer0, peer1).
 // For keys in the EdgeCache, we maintain the invariant that peer0 < peer1
-#[derive(Clone, Eq, Hash, PartialEq)]
+#[derive(Clone, Eq, Hash, PartialEq, Debug)]
 pub(crate) struct EdgeKey {
     peer0: PeerId,
     peer1: PeerId,
@@ -280,6 +280,24 @@ impl EdgeCache {
                 self.remove_active_edge(key);
             }
         }
+    }
+
+    /// If we have a tree stored for the given peer,
+    /// returns the min nonce among the edges in the tree.
+    ///
+    /// Returns None if no tree is stored, or if no nonce
+    /// is available for any of the edges in the tree.
+    pub fn get_min_nonce(&mut self, peer_id: &PeerId) -> Option<u64> {
+        let edge_keys = self.active_trees.get(peer_id)?;
+
+        let mut min_nonce: Option<u64> = None;
+
+        for key in edge_keys {
+            let nonce = *self.verified_nonces.get(key)?;
+            min_nonce = Some(min_nonce.map_or(nonce, |min_val| std::cmp::min(min_val, nonce)));
+        }
+
+        min_nonce
     }
 
     /// Removes the tree stored for the given peer, if there is one.

--- a/chain/network/src/routing/graph_v2/mod.rs
+++ b/chain/network/src/routing/graph_v2/mod.rs
@@ -353,7 +353,7 @@ impl Inner {
         for e in edges {
             // TODO(saketh): deprecate tombstones entirely
             if e.edge_type() != EdgeState::Active {
-                return false;
+                continue;
             }
 
             // TODO (saketh): After V1 routing is deprecated, we will need to actually perform

--- a/chain/network/src/routing/graph_v2/testonly.rs
+++ b/chain/network/src/routing/graph_v2/testonly.rs
@@ -56,6 +56,14 @@ impl GraphV2 {
         assert!(!oks[0]);
     }
 
+    pub(crate) async fn recompute_routes(
+        self: &Arc<Self>,
+        clock: &time::Clock,
+    ) -> Option<network_protocol::DistanceVector> {
+        let (to_broadcast, _) = self.batch_process_network_changes(&clock, vec![]).await;
+        to_broadcast
+    }
+
     // Checks that the DistanceVector message for the local node is valid
     // and correctly advertises the node's available routes.
     pub(crate) fn verify_own_distance_vector(
@@ -77,5 +85,9 @@ impl GraphV2 {
             expected_distances_by_id,
             inner.validate_routing_distances(distance_vector).unwrap()
         );
+    }
+
+    pub(crate) fn has_distance_vector(&self, peer_id: &PeerId) -> bool {
+        self.inner.lock().peer_distances.contains_key(peer_id)
     }
 }

--- a/chain/network/src/routing/graph_v2/tests.rs
+++ b/chain/network/src/routing/graph_v2/tests.rs
@@ -1,9 +1,11 @@
 use crate::network_protocol;
 use crate::network_protocol::AdvertisedPeerDistance;
+use crate::peer_manager::network_state::PRUNE_EDGES_AFTER;
 use crate::routing::{GraphConfigV2, GraphV2, NetworkTopologyChange};
 use crate::test_utils::expected_routing_tables;
 use crate::test_utils::random_peer_id;
 use crate::types::Edge;
+use near_async::time;
 use near_primitives::network::PeerId;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -610,4 +612,95 @@ async fn inconsistent_peers() {
     // There is no set of edges which produces a tree exactly consistent with `expected_routes`,
     // but we should be able to construct a valid DistanceVector anyway
     graph.verify_own_distance_vector(expected_routes, &distance_vector_update);
+}
+
+#[tokio::test]
+async fn test_distance_vector_nonce_expiration() {
+    let clock = time::FakeClock::default();
+
+    let node0 = random_peer_id();
+    let graph = Arc::new(GraphV2::new(GraphConfigV2 {
+        node_id: node0.clone(),
+        prune_edges_after: Some(PRUNE_EDGES_AFTER),
+    }));
+
+    let initial_nonce = clock.now_utc().unix_timestamp() as u64;
+
+    // Add a peer node1 which advertises node2 behind it; 0--1--2
+    let node1 = random_peer_id();
+    let node2 = random_peer_id();
+    let edge01 = Edge::make_fake_edge(node0.clone(), node1.clone(), initial_nonce);
+    let edge12 = Edge::make_fake_edge(node1.clone(), node2.clone(), initial_nonce);
+    assert!(graph.update_distance_vector(
+        node1.clone(),
+        vec![
+            AdvertisedPeerDistance { destination: node1.clone(), distance: 0 },
+            AdvertisedPeerDistance { destination: node0.clone(), distance: 1 },
+            AdvertisedPeerDistance { destination: node2, distance: 1 },
+        ],
+        vec![edge01, edge12]
+    ));
+
+    assert!(graph.has_distance_vector(&node1));
+
+    // Advance the clock until the edges in the original DistanceVector shared by node1 expire
+    clock.advance(PRUNE_EDGES_AFTER + time::Duration::seconds(1));
+
+    // Recompute routes
+    graph.recompute_routes(&clock.clock()).await;
+
+    // Check that the expired distance vector was removed
+    assert!(!graph.has_distance_vector(&node1));
+}
+
+#[tokio::test]
+async fn test_distance_vector_nonce_refresh() {
+    let clock = time::FakeClock::default();
+
+    let node0 = random_peer_id();
+    let graph = Arc::new(GraphV2::new(GraphConfigV2 {
+        node_id: node0.clone(),
+        prune_edges_after: Some(PRUNE_EDGES_AFTER),
+    }));
+
+    let initial_nonce = clock.now_utc().unix_timestamp() as u64;
+
+    // Add a peer node1 which advertises node2 behind it; 0--1--2
+    let node1 = random_peer_id();
+    let node2 = random_peer_id();
+    let edge01 = Edge::make_fake_edge(node0.clone(), node1.clone(), initial_nonce);
+    let edge12 = Edge::make_fake_edge(node1.clone(), node2.clone(), initial_nonce);
+    assert!(graph.update_distance_vector(
+        node1.clone(),
+        vec![
+            AdvertisedPeerDistance { destination: node1.clone(), distance: 0 },
+            AdvertisedPeerDistance { destination: node0.clone(), distance: 1 },
+            AdvertisedPeerDistance { destination: node2.clone(), distance: 1 },
+        ],
+        vec![edge01, edge12]
+    ));
+
+    assert!(graph.has_distance_vector(&node1));
+
+    // Advance the clock, then refresh the nonces on the stored edges;
+    clock.advance(PRUNE_EDGES_AFTER / 2);
+
+    let refreshed_nonce = clock.now_utc().unix_timestamp() as u64;
+
+    let edge01 = Edge::make_fake_edge(node0.clone(), node1.clone(), refreshed_nonce);
+    let edge12 = Edge::make_fake_edge(node1.clone(), node2, refreshed_nonce);
+
+    graph
+        .process_network_event(NetworkTopologyChange::EdgeNonceRefresh(vec![edge01, edge12]))
+        .await
+        .unwrap();
+
+    // Further advance the clock until the edges in the original DistanceVector shared by node1 expire
+    clock.advance(PRUNE_EDGES_AFTER / 2 + time::Duration::seconds(1));
+
+    // Recompute routes
+    graph.recompute_routes(&clock.clock()).await;
+
+    // Check that the distance vector did not expire
+    assert!(graph.has_distance_vector(&node1));
 }


### PR DESCRIPTION
DistanceVector messages contain timestamped edges, which by default expire after 30 minutes. However, transmission of DistanceVectors is triggered only by changes to the network topology. As a result, nodes in a stable network will needlessly expire their DistanceVectors after 30 minutes. When a DistanceVector expires, the connection with the associated peer is terminated, resulting in unnecessary churn of network connections.

RoutingTableUpdate is an existing message type used by the V1 protocol to periodically flood refreshed edge nonces to the whole network. This PR passes the refreshed nonces from RoutingTableUpdate messages into the local storage for the V2 protocol so that the timestamps for stable DistanceVectors can be kept up to date.