### PR TITLE
ci: do not run the CI checks after a merge queue

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,8 +3,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches: [master]
   pull_request:
   merge_group:
 


### PR DESCRIPTION
Merge queue has already verified the changes as-if integrated into master, so there's no good reason to spend any additional compute resources running the tests one extra time after the merge.

We also have sufficient branch protections in place that a direct push to master is not a concern.