### PR TITLE
nit: always show full output in run_clippy.sh

### DIFF
--- a/scripts/run_clippy.sh
+++ b/scripts/run_clippy.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-exec cargo nextest run -p style-tests clippy
+exec cargo nextest run -p style-tests clippy --no-capture


### PR DESCRIPTION
I like to see the output of clippy when it's working. Passing --no-capture to enable that. 