### PR TITLE
chore: update tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6956,11 +6956,12 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.28.0"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -316,7 +316,7 @@ test-log = { version = "0.2", default-features = false, features = ["trace"] }
 thiserror = "1.0.30"
 tikv-jemallocator = "0.5.0"
 time = "0.3.9"
-tokio = { version = "~1.28", features = [
+tokio = { version = "1.28", features = [
     "fs",
     "macros",
     "net",


### PR DESCRIPTION
https://github.com/near/nearcore/pull/9524#issuecomment-1759241641
I turned `~1.28` into `1.28` and ran `cargo update -p tokio`  as @frol recommended. 

`cargo deny --all-features check bans` returns two warnings but zero errors. 

![image_2023-10-12_20-03-31](https://github.com/near/nearcore/assets/4000375/86749a39-c7e7-42ea-b57d-764cb211afd5)


I want to point out that we have several errors in the `advisories` section of `cargo-deny` output. I hope the team is well aware of those errors. 

![Screenshot 2023-10-13 at 14 49 18](https://github.com/near/nearcore/assets/4000375/21bcfa51-17c8-4783-8f6e-fe9c5b4cf3db)
![Screenshot 2023-10-13 at 14 49 30](https://github.com/near/nearcore/assets/4000375/76a50e43-7f23-482e-bbe4-7aafc452d98f)
![Screenshot 2023-10-13 at 14 50 00](https://github.com/near/nearcore/assets/4000375/c6f0650a-8921-470a-a638-937e0fc1d250)
![Screenshot 2023-10-13 at 14 50 20](https://github.com/near/nearcore/assets/4000375/73915d89-aebc-440d-8ec7-61a041136bb7)

Fixing the issue with `ed25519-dalek` requires an upgrade to crate version 2.0 and changes in codebase of nearcore