### PR TITLE
optimize unsafe-libyaml for tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -409,3 +409,5 @@ opt-level = 3
 opt-level = 3
 [profile.dev.package.curve25519-dalek]
 opt-level = 3
+[profile.dev.package.unsafe-libyaml]
+opt-level = 3


### PR DESCRIPTION
The runtime of the whole test suite gets down by ~2.5% with this change.
Integration tests get a similar speedup.
CI times will be confirmed to not have too much change by it running on this PR.

See #9606.