### PR TITLE
runtime: "normalize" VMKind as soon as it is parsed

### DIFF
--- a/core/primitives/src/runtime/config.rs
+++ b/core/primitives/src/runtime/config.rs
@@ -39,10 +39,9 @@ impl RuntimeConfig {
 
     pub fn test() -> Self {
         let config_store = super::config_store::RuntimeConfigStore::new(None);
-        let mut wasm_config = near_vm_runner::logic::Config::clone(
+        let wasm_config = near_vm_runner::logic::Config::clone(
             &config_store.get_config(PROTOCOL_VERSION).wasm_config,
         );
-        wasm_config.vm_kind = wasm_config.vm_kind.normalize();
         RuntimeConfig {
             fees: RuntimeFeesConfig::test(),
             wasm_config,
@@ -55,7 +54,6 @@ impl RuntimeConfig {
         let mut wasm_config = near_vm_runner::logic::Config::clone(
             &config_store.get_config(PROTOCOL_VERSION).wasm_config,
         );
-        wasm_config.vm_kind = wasm_config.vm_kind.normalize();
         wasm_config.make_free();
         Self {
             fees: RuntimeFeesConfig::free(),

--- a/core/primitives/src/runtime/parameter_table.rs
+++ b/core/primitives/src/runtime/parameter_table.rs
@@ -170,9 +170,10 @@ impl TryFrom<&ParameterValue> for VMKind {
 
     fn try_from(value: &ParameterValue) -> Result<Self, Self::Error> {
         match value {
-            ParameterValue::String(v) => {
-                v.parse().map_err(|e| ValueConversionError::ParseVmKind(e, value.to_string()))
-            }
+            ParameterValue::String(v) => v
+                .parse()
+                .map(|v: VMKind| v.replace_with_wasmtime_if_unsupported())
+                .map_err(|e| ValueConversionError::ParseVmKind(e, value.to_string())),
             _ => {
                 Err(ValueConversionError::ParseType(std::any::type_name::<VMKind>(), value.clone()))
             }

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -36,7 +36,7 @@ impl crate::logic::Config {
                 ExtVMKind::NearVm => VMKind::NearVm,
                 ExtVMKind::Wasmtime => VMKind::Wasmtime,
             }
-            .normalize(),
+            .replace_with_wasmtime_if_unsupported(),
             disable_9393_fix: config.disable_9393_fix,
             storage_get_mode: match config.storage_get_mode {
                 ExtStorageGetMode::Trie => StorageGetMode::Trie,

--- a/runtime/near-vm-runner/src/vm_kind.rs
+++ b/runtime/near-vm-runner/src/vm_kind.rs
@@ -32,7 +32,7 @@ pub enum VMKind {
 }
 
 impl VMKind {
-    pub fn normalize(self) -> Self {
+    pub fn replace_with_wasmtime_if_unsupported(self) -> Self {
         if cfg!(not(target_arch = "x86_64")) {
             Self::Wasmtime
         } else {


### PR DESCRIPTION
People with M1 Macs run the neard node too, not just the test suites. Unfortunately a proper regression test for this is not obvious… I’ll think about it.

(Possibly)
Fixes #9665