### PR TITLE
fix: allow tla-account creation on sandbox

### DIFF
--- a/core/primitives/src/runtime/config_store.rs
+++ b/core/primitives/src/runtime/config_store.rs
@@ -36,6 +36,7 @@ static CONFIG_DIFFS: &[(ProtocolVersion, &str)] = &[
     (61, include_config!("61.yaml")),
     (62, include_config!("62.yaml")),
     (63, include_config!("63.yaml")),
+    #[cfg(not(feature = "sandbox"))]
     (64, include_config!("64.yaml")),
     (129, include_config!("129.yaml")),
 ];

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -135,7 +135,12 @@ nightly_protocol = [
   "node-runtime/nightly_protocol",
   "testlib/nightly_protocol",
 ]
-sandbox = ["near-chain/sandbox", "node-runtime/sandbox", "near-client/sandbox"]
+sandbox = [
+  "near-chain/sandbox",
+  "node-runtime/sandbox",
+  "near-client/sandbox",
+  "near-primitives/sandbox",
+]
 no_cache = ["nearcore/no_cache"]
 calimero_zero_storage = []
 new_epoch_sync = ["nearcore/new_epoch_sync"]

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -57,7 +57,7 @@ no_cache = [
   "near-store/no_cache",
 ]
 
-sandbox = ["near-vm-runner/sandbox"]
+sandbox = ["near-vm-runner/sandbox", "near-primitives/sandbox"]
 
 [dev-dependencies]
 assert_matches.workspace = true

--- a/tools/state-viewer/Cargo.toml
+++ b/tools/state-viewer/Cargo.toml
@@ -55,6 +55,7 @@ sandbox = [
   "node-runtime/sandbox",
   "near-chain/sandbox",
   "near-client/sandbox",
+  "near-primitives/sandbox",
 ]
 nightly = [
   "nightly_protocol",


### PR DESCRIPTION
NEP 492 was stabilised https://github.com/near/nearcore/pull/9658 which breaks existing tests for `near-workspaces` 
The condition can be loosened for sandbox, suggested here https://github.com/near/nearcore/issues/9665#issuecomment-1762386851