### PR TITLE
nit: use correct type

### DIFF
--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -414,7 +414,7 @@ impl EpochManagerAdapter for MockEpochManager {
         self.hash_to_valset.write().unwrap().contains_key(epoch_id)
     }
 
-    fn num_shards(&self, _epoch_id: &EpochId) -> Result<ShardId, EpochError> {
+    fn num_shards(&self, _epoch_id: &EpochId) -> Result<NumShards, EpochError> {
         Ok(self.num_shards)
     }
 

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -31,7 +31,7 @@ pub trait EpochManagerAdapter: Send + Sync {
     fn epoch_exists(&self, epoch_id: &EpochId) -> bool;
 
     /// Get current number of shards.
-    fn num_shards(&self, epoch_id: &EpochId) -> Result<ShardId, EpochError>;
+    fn num_shards(&self, epoch_id: &EpochId) -> Result<NumShards, EpochError>;
 
     /// Number of Reed-Solomon parts we split each chunk into.
     ///


### PR DESCRIPTION
Even though the types are just aliases, still use correct type definitions.