### PR TITLE
optimize all dependencies for tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -415,3 +415,5 @@ opt-level = 3
 opt-level = 3
 [profile.dev.package.dynasmrt]
 opt-level = 3
+[profile.dev.package."*"]
+opt-level = 1


### PR DESCRIPTION
The runtime of the whole test suite gets down, on my test VM, from 224 seconds to 138 seconds, ie. 40% faster. Single-threaded runs show a 30% speedup over the whole test suite.

Integration tests show a 35% multi-threaded speedup, and 30% single-threaded speedup.

As for the bigger simple crates:
- near-vm-runner shows a decrease from 62s to 30s, ie. 50% speedup. Single-threaded tests show a 65% speedup.
- near-chain only shows a 10% speedup
- near-store shows a 25% speedup, or 35% single-threaded
- estimator-warehouse does not change, as it already rebuilds internally with optimizations

As for the time to build, building the whole test suite, including dependencies, is 20% slower, with 18 minutes to build as opposed to 15 minutes before, so a decrease in performance of 3 minutes.

However, we only rarely build dependencies, especially considering we (should) carefully review each added or upgraded dependency. As a consequence, I think that this 3-minutes-every-week-or-so is worth the compile-and-test cycle speed improvements. Especially considering that 15 minutes is already enough for it to be a background job, whereas eg. near-vm-runner tests taking 30s instead of 68s can lead to one fewer context switch.

CI times should not change, as they already build with the quick-release profile.

The gains with `opt-level = 3` are basically the same as the ones from this PR.

Replaces #9673.