### PR TITLE
Improve the performance of flat storage when values are inlined.

### DIFF
--- a/core/store/src/trie/accounting_cache.rs
+++ b/core/store/src/trie/accounting_cache.rs
@@ -116,6 +116,22 @@ impl TrieAccountingCache {
         }
     }
 
+    /// Used to retroactively account for a node or value that was already accessed
+    /// through other means (e.g. flat storage read).
+    pub fn retroactively_account(&mut self, hash: &CryptoHash, data: Arc<[u8]>) {
+        if self.cache.contains_key(hash) {
+            self.mem_read_nodes += 1;
+        } else {
+            self.db_read_nodes += 1;
+        }
+        if self.enable {
+            self.cache.insert(*hash, data);
+            if let Some(metrics) = &self.metrics {
+                metrics.accounting_cache_size.set(self.cache.len() as i64);
+            }
+        }
+    }
+
     pub fn get_trie_nodes_count(&self) -> TrieNodesCount {
         TrieNodesCount { db_reads: self.db_read_nodes, mem_reads: self.mem_read_nodes }
     }

--- a/core/store/src/trie/accounting_cache.rs
+++ b/core/store/src/trie/accounting_cache.rs
@@ -118,14 +118,14 @@ impl TrieAccountingCache {
 
     /// Used to retroactively account for a node or value that was already accessed
     /// through other means (e.g. flat storage read).
-    pub fn retroactively_account(&mut self, hash: &CryptoHash, data: Arc<[u8]>) {
-        if self.cache.contains_key(hash) {
+    pub fn retroactively_account(&mut self, hash: CryptoHash, data: Arc<[u8]>) {
+        if self.cache.contains_key(&hash) {
             self.mem_read_nodes += 1;
         } else {
             self.db_read_nodes += 1;
         }
         if self.enable {
-            self.cache.insert(*hash, data);
+            self.cache.insert(hash, data);
             if let Some(metrics) = &self.metrics {
                 metrics.accounting_cache_size.set(self.cache.len() as i64);
             }


### PR DESCRIPTION
This is an optimization, but is also preparation work for in-memory tries. The old behavior is that no matter what, we will get_ref first, but that will always return a ValueRef, so even if a flat storage value was inlined, we would ignored the inlined value and still go and lookup the value from the trie storage. Now, we would use the inlined value where possible.

Also, refactor the flat storage fetching logic so that it is contained within a function, and trie fetching logic is in another function. This will make it easier to introduce the in-memory fetching function. Otherwise it would be a giant mess. (The end result will be simpler than the prototype code (at least what is required to make the prototype code completely correct)).