### PR TITLE
[Chore] Integrate external near-account-id.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3340,23 +3340,11 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "0.0.0"
+version = "0.17.0"
+source = "git+https://github.com/ruseinov/near-account-id?branch=ru/chore/len#f68ca374aa1cc52c3a2ca7bed1961af31895dee4"
 dependencies = [
- "arbitrary",
- "bolero",
  "borsh 1.0.0",
  "serde",
- "serde_json",
-]
-
-[[package]]
-name = "near-account-id-fuzz"
-version = "0.0.0"
-dependencies = [
- "borsh 1.0.0",
- "libfuzzer-sys",
- "near-account-id",
- "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,6 @@ members = [
     "chain/rosetta-rpc",
     "chain/telemetry",
     "core/async",
-    "core/account-id",
-    "core/account-id/fuzz",
     "core/chain-configs",
     "core/crypto",
     "core/dyn-configs",
@@ -174,7 +172,7 @@ lru = "0.7.2"
 memmap2 = "0.5"
 memoffset = "0.8"
 more-asserts = "0.2"
-near-account-id = { path = "core/account-id", features = ["internal_unstable"] }
+near-account-id = { git = "https://github.com/ruseinov/near-account-id", features = ["internal_unstable", "serde", "borsh"], branch = "ru/chore/len" }
 near-actix-test-utils = { path = "test-utils/actix-test-utils" }
 near-amend-genesis = { path = "tools/amend-genesis" }
 near-database-tool = { path = "tools/database" }

--- a/chain/chain/src/crypto_hash_timer.rs
+++ b/chain/chain/src/crypto_hash_timer.rs
@@ -52,8 +52,7 @@ impl Drop for CryptoHashTimer {
 
 #[test]
 fn test_crypto_hash_timer() {
-    let crypto_hash: CryptoHash =
-        "s3N6V7CNAN2Eg6vfivMVHR4hbMZeh72fTmYbrC6dXBT".parse().unwrap();
+    let crypto_hash: CryptoHash = "s3N6V7CNAN2Eg6vfivMVHR4hbMZeh72fTmYbrC6dXBT".parse().unwrap();
     // Timer should be missing.
     assert_eq!(CryptoHashTimer::get_timer_value(crypto_hash), None);
     let mock_clock_guard = near_primitives::static_clock::MockClockGuard::default();

--- a/chain/chain/src/crypto_hash_timer.rs
+++ b/chain/chain/src/crypto_hash_timer.rs
@@ -52,7 +52,8 @@ impl Drop for CryptoHashTimer {
 
 #[test]
 fn test_crypto_hash_timer() {
-    let crypto_hash: CryptoHash = "s3N6V7CNAN2Eg6vfivMVHR4hbMZeh72fTmYbrC6dXBT".parse().unwrap();
+    let crypto_hash: CryptoHash =
+        "s3N6V7CNAN2Eg6vfivMVHR4hbMZeh72fTmYbrC6dXBT".parse().unwrap();
     // Timer should be missing.
     assert_eq!(CryptoHashTimer::get_timer_value(crypto_hash), None);
     let mock_clock_guard = near_primitives::static_clock::MockClockGuard::default();

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -3370,7 +3370,7 @@ mod tests {
     use near_primitives::hash::hash;
     use near_primitives::test_utils::create_test_signer;
     use near_primitives::test_utils::TestBlockBuilder;
-    use near_primitives::types::{BlockHeight, EpochId, NumBlocks};
+    use near_primitives::types::{AccountId, BlockHeight, EpochId, NumBlocks};
     use near_primitives::utils::index_to_bytes;
     use near_primitives::validator_signer::InMemoryValidatorSigner;
     use near_store::test_utils::create_test_store;
@@ -3390,7 +3390,7 @@ mod tests {
         let store = create_test_store();
         let chain_genesis = ChainGenesis::test();
         let vs = ValidatorSchedule::new()
-            .block_producers_per_epoch(vec![vec!["test1".parse().unwrap()]]);
+            .block_producers_per_epoch(vec![vec!["test1".parse::<AccountId>().unwrap()]]);
         let epoch_manager = MockEpochManager::new_with_validators(store.clone(), vs, epoch_length);
         let shard_tracker = ShardTracker::new_empty(epoch_manager.clone());
         let runtime = KeyValueRuntime::new(store, epoch_manager.as_ref());

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -130,8 +130,8 @@ struct KVState {
 
 impl MockEpochManager {
     pub fn new(store: Store, epoch_length: u64) -> Arc<Self> {
-        let vs =
-            ValidatorSchedule::new().block_producers_per_epoch(vec![vec!["test".parse().unwrap()]]);
+        let vs = ValidatorSchedule::new()
+            .block_producers_per_epoch(vec![vec!["test".parse::<AccountId>().unwrap()]]);
         Self::new_with_validators(store, vs, epoch_length)
     }
 

--- a/chain/chain/src/tests/gc.rs
+++ b/chain/chain/src/tests/gc.rs
@@ -11,7 +11,7 @@ use near_primitives::block::Block;
 use near_primitives::merkle::PartialMerkleTree;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::test_utils::{create_test_signer, TestBlockBuilder};
-use near_primitives::types::{NumBlocks, NumShards, StateRoot};
+use near_primitives::types::{AccountId, NumBlocks, NumShards, StateRoot};
 use near_store::test_utils::{create_test_store, gen_changes};
 use near_store::{ShardTries, Trie, WrappedTrieChanges};
 use rand::Rng;
@@ -27,7 +27,7 @@ fn get_chain_with_epoch_length_and_num_shards(
     let store = create_test_store();
     let chain_genesis = ChainGenesis::test();
     let vs = ValidatorSchedule::new()
-        .block_producers_per_epoch(vec![vec!["test1".parse().unwrap()]])
+        .block_producers_per_epoch(vec![vec!["test1".parse::<AccountId>().unwrap()]])
         .num_shards(num_shards);
     let epoch_manager = MockEpochManager::new_with_validators(store.clone(), vs, epoch_length);
     let shard_tracker = ShardTracker::new_empty(epoch_manager.clone());

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -23,6 +23,7 @@ use near_primitives::state_part::PartId;
 use near_primitives::transaction::{ExecutionOutcomeWithId, SignedTransaction};
 use near_primitives::types::validator_stake::{ValidatorStake, ValidatorStakeIter};
 use near_primitives::types::{
+    AccountId,
     Balance, BlockHeight, BlockHeightDelta, EpochId, Gas, MerkleHash, NumBlocks, ShardId,
     StateChangesForSplitStates, StateRoot, StateRootNode,
 };
@@ -530,7 +531,7 @@ mod tests {
                 gas_burnt: 100,
                 compute_usage: Some(200),
                 tokens_burnt: 10000,
-                executor_id: "alice".parse().unwrap(),
+                executor_id: "alice".parse::<AccountId>().unwrap(),
                 metadata: ExecutionMetadata::V1,
             },
         };
@@ -543,7 +544,7 @@ mod tests {
                 gas_burnt: 0,
                 compute_usage: Some(0),
                 tokens_burnt: 0,
-                executor_id: "bob".parse().unwrap(),
+                executor_id: "bob".parse::<AccountId>().unwrap(),
                 metadata: ExecutionMetadata::V1,
             },
         };

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -23,9 +23,8 @@ use near_primitives::state_part::PartId;
 use near_primitives::transaction::{ExecutionOutcomeWithId, SignedTransaction};
 use near_primitives::types::validator_stake::{ValidatorStake, ValidatorStakeIter};
 use near_primitives::types::{
-    AccountId,
-    Balance, BlockHeight, BlockHeightDelta, EpochId, Gas, MerkleHash, NumBlocks, ShardId,
-    StateChangesForSplitStates, StateRoot, StateRootNode,
+    AccountId, Balance, BlockHeight, BlockHeightDelta, EpochId, Gas, MerkleHash, NumBlocks,
+    ShardId, StateChangesForSplitStates, StateRoot, StateRootNode,
 };
 use near_primitives::version::{
     ProtocolVersion, MIN_GAS_PRICE_NEP_92, MIN_GAS_PRICE_NEP_92_FIX, MIN_PROTOCOL_VERSION_NEP_92,

--- a/chain/chain/src/validate.rs
+++ b/chain/chain/src/validate.rs
@@ -410,7 +410,7 @@ mod tests {
         SignedTransaction::send_money(
             nonce,
             account_id,
-            "bob".parse().unwrap(),
+            "bob".parse::<AccountId>().unwrap(),
             &signer,
             10,
             CryptoHash::default(),

--- a/chain/chunks/src/chunk_cache.rs
+++ b/chain/chunks/src/chunk_cache.rs
@@ -274,14 +274,17 @@ mod tests {
     use near_crypto::KeyType;
     use near_primitives::hash::CryptoHash;
     use near_primitives::sharding::{PartialEncodedChunkV2, ShardChunkHeader, ShardChunkHeaderV2};
+    use near_primitives::types::AccountId;
     use near_primitives::validator_signer::InMemoryValidatorSigner;
 
     use crate::chunk_cache::EncodedChunksCache;
     use crate::ChunkRequestInfo;
 
     fn create_chunk_header(height: u64, shard_id: u64) -> ShardChunkHeader {
-        let signer =
-            InMemoryValidatorSigner::from_random("test".parse().unwrap(), KeyType::ED25519);
+        let signer = InMemoryValidatorSigner::from_random(
+            "test".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+        );
         ShardChunkHeader::V2(ShardChunkHeaderV2::new(
             CryptoHash::default(),
             CryptoHash::default(),

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -2074,7 +2074,7 @@ mod test {
         let store = create_test_store();
         let epoch_manager = setup_epoch_manager_with_block_and_chunk_producers(
             store.clone(),
-            vec!["test".parse().unwrap()],
+            vec!["test".parse::<AccountId>().unwrap()],
             vec![],
             1,
             2,
@@ -2086,7 +2086,7 @@ mod test {
         let clock = FakeClock::default();
         let mut shards_manager = ShardsManager::new(
             clock.clock(),
-            Some("test".parse().unwrap()),
+            Some("test".parse::<AccountId>().unwrap()),
             epoch_manager,
             shard_tracker,
             network_adapter.as_sender(),

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1077,9 +1077,9 @@ impl Client {
             txs.push(SignedTransaction::new(
                 near_crypto::Signature::empty(near_crypto::KeyType::ED25519),
                 near_primitives::transaction::Transaction::new(
-                    "test".parse().unwrap(),
+                    "test".parse::<AccountId>().unwrap(),
                     near_crypto::PublicKey::empty(near_crypto::KeyType::SECP256K1),
-                    "other".parse().unwrap(),
+                    "other".parse::<AccountId>().unwrap(),
                     3,
                     prev_block_hash,
                 ),

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -872,8 +872,8 @@ mod tests {
         let info_helper = InfoHelper::new(None, &config, None);
 
         let store = near_store::test_utils::create_test_store();
-        let vs =
-            ValidatorSchedule::new().block_producers_per_epoch(vec![vec!["test".parse().unwrap()]]);
+        let vs = ValidatorSchedule::new()
+            .block_producers_per_epoch(vec![vec!["test".parse::<AccountId>().unwrap()]]);
         let epoch_manager = MockEpochManager::new_with_validators(store.clone(), vs, 123);
         let shard_tracker = ShardTracker::new_empty(epoch_manager.clone());
         let runtime = KeyValueRuntime::new(store, epoch_manager.as_ref());

--- a/chain/client/src/sync/header.rs
+++ b/chain/client/src/sync/header.rs
@@ -295,7 +295,7 @@ mod test {
     use super::*;
     use near_network::types::{BlockInfo, FullPeerInfo, PeerInfo};
     use near_primitives::merkle::PartialMerkleTree;
-    use near_primitives::types::EpochId;
+    use near_primitives::types::{AccountId, EpochId};
     use near_primitives::version::PROTOCOL_VERSION;
     use num_rational::Ratio;
 
@@ -641,7 +641,7 @@ mod test {
         );
 
         let vs = ValidatorSchedule::new()
-            .block_producers_per_epoch(vec![vec!["test0".parse().unwrap()]]);
+            .block_producers_per_epoch(vec![vec!["test0".parse::<AccountId>().unwrap()]]);
         let genesis_time = StaticClock::utc();
         // Don't bother with epoch switches. It's not relevant.
         let (mut chain, _, _, _) =

--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -430,8 +430,10 @@ impl TestEnv {
         relayer: AccountId,
         receiver_id: AccountId,
     ) -> SignedTransaction {
-        let inner_signer = InMemorySigner::from_seed(sender.clone(), KeyType::ED25519, sender.as_str());
-        let relayer_signer = InMemorySigner::from_seed(relayer.clone(), KeyType::ED25519, relayer.as_str());
+        let inner_signer =
+            InMemorySigner::from_seed(sender.clone(), KeyType::ED25519, sender.as_str());
+        let relayer_signer =
+            InMemorySigner::from_seed(relayer.clone(), KeyType::ED25519, relayer.as_str());
         let tip = self.clients[0].chain.head().unwrap();
         let user_nonce = tip.height + 1;
         let relayer_nonce = tip.height + 1;

--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -430,8 +430,8 @@ impl TestEnv {
         relayer: AccountId,
         receiver_id: AccountId,
     ) -> SignedTransaction {
-        let inner_signer = InMemorySigner::from_seed(sender.clone(), KeyType::ED25519, &sender);
-        let relayer_signer = InMemorySigner::from_seed(relayer.clone(), KeyType::ED25519, &relayer);
+        let inner_signer = InMemorySigner::from_seed(sender.clone(), KeyType::ED25519, sender.as_str());
+        let relayer_signer = InMemorySigner::from_seed(relayer.clone(), KeyType::ED25519, relayer.as_str());
         let tip = self.clients[0].chain.head().unwrap();
         let user_nonce = tip.height + 1;
         let relayer_nonce = tip.height + 1;

--- a/chain/client/src/tests/bug_repros.rs
+++ b/chain/client/src/tests/bug_repros.rs
@@ -26,6 +26,7 @@ use near_o11y::testonly::init_test_logger;
 use near_o11y::WithSpanContextExt;
 use near_primitives::block::Block;
 use near_primitives::transaction::SignedTransaction;
+use near_primitives::types::AccountId;
 
 #[test]
 fn repro_1183() {
@@ -36,10 +37,10 @@ fn repro_1183() {
         let vs = ValidatorSchedule::new()
             .num_shards(4)
             .block_producers_per_epoch(vec![vec![
-                "test1".parse().unwrap(),
-                "test2".parse().unwrap(),
-                "test3".parse().unwrap(),
-                "test4".parse().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
+                "test2".parse::<AccountId>().unwrap(),
+                "test3".parse::<AccountId>().unwrap(),
+                "test4".parse::<AccountId>().unwrap(),
             ]])
             .validator_groups(2);
         let validators = vs.all_block_producers().cloned().collect::<Vec<_>>();
@@ -118,7 +119,7 @@ fn repro_1183() {
                                             &InMemorySigner::from_seed(
                                                 from.clone(),
                                                 KeyType::ED25519,
-                                                from.as_ref(),
+                                                from.as_str(),
                                             ),
                                             1,
                                             *block.header().prev_hash(),
@@ -166,10 +167,10 @@ fn repro_1183() {
 fn test_sync_from_archival_node() {
     init_test_logger();
     let vs = ValidatorSchedule::new().num_shards(4).block_producers_per_epoch(vec![vec![
-        "test1".parse().unwrap(),
-        "test2".parse().unwrap(),
-        "test3".parse().unwrap(),
-        "test4".parse().unwrap(),
+        "test1".parse::<AccountId>().unwrap(),
+        "test2".parse::<AccountId>().unwrap(),
+        "test3".parse::<AccountId>().unwrap(),
+        "test4".parse::<AccountId>().unwrap(),
     ]]);
     let key_pairs =
         vec![PeerInfo::random(), PeerInfo::random(), PeerInfo::random(), PeerInfo::random()];
@@ -274,9 +275,10 @@ fn test_sync_from_archival_node() {
 #[test]
 fn test_long_gap_between_blocks() {
     init_test_logger();
-    let vs = ValidatorSchedule::new()
-        .num_shards(2)
-        .block_producers_per_epoch(vec![vec!["test1".parse().unwrap(), "test2".parse().unwrap()]]);
+    let vs = ValidatorSchedule::new().num_shards(2).block_producers_per_epoch(vec![vec![
+        "test1".parse::<AccountId>().unwrap(),
+        "test2".parse::<AccountId>().unwrap(),
+    ]]);
     let key_pairs = vec![PeerInfo::random(), PeerInfo::random()];
     let epoch_length = 1000;
     let target_height = 600;
@@ -315,7 +317,7 @@ fn test_long_gap_between_blocks() {
                             if approval_message.approval.target_height < target_height {
                                 (NetworkResponses::NoResponse.into(), false)
                             } else {
-                                if approval_message.target.as_ref() == "test1" {
+                                if approval_message.target == "test1" {
                                     (NetworkResponses::NoResponse.into(), true)
                                 } else {
                                     (NetworkResponses::NoResponse.into(), false)

--- a/chain/client/src/tests/catching_up.rs
+++ b/chain/client/src/tests/catching_up.rs
@@ -70,7 +70,8 @@ fn send_tx(
     nonce: u64,
     block_hash: CryptoHash,
 ) {
-    let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+    let signer =
+        InMemorySigner::from_seed("test1".parse::<AccountId>().unwrap(), KeyType::ED25519, "test1");
     connector.do_send(
         ProcessTxRequest {
             transaction: SignedTransaction::send_money(
@@ -163,8 +164,8 @@ fn test_catchup_receipts_sync_common(wait_till: u64, send: u64, sync_hold: bool)
             false,
             Box::new(move |_, _account_id: _, msg: &PeerManagerMessageRequest| {
                 let msg = msg.as_network_requests_ref();
-                let account_from = "test3.3".parse().unwrap();
-                let account_to = "test1.1".parse().unwrap();
+                let account_from = "test3.3".parse::<AccountId>().unwrap();
+                let account_to = "test1.1".parse::<AccountId>().unwrap();
                 let source_shard_id = account_id_to_shard_id(&account_from, 4);
                 let destination_shard_id = account_id_to_shard_id(&account_to, 4);
 
@@ -689,8 +690,8 @@ fn test_chunk_grieving() {
         let archive = vec![false; vs.all_block_producers().count()];
         let epoch_sync_enabled = vec![true; vs.all_block_producers().count()];
 
-        let malicious_node = "test3.6".parse().unwrap();
-        let victim_node = "test3.5".parse().unwrap();
+        let malicious_node = "test3.6".parse::<AccountId>().unwrap();
+        let victim_node = "test3.5".parse::<AccountId>().unwrap();
         let phase = Arc::new(RwLock::new(ChunkGrievingPhases::FirstAttack));
         let grieving_chunk_hash = Arc::new(RwLock::new(ChunkHash::default()));
         let unaccepted_block_hash = Arc::new(RwLock::new(CryptoHash::default()));

--- a/chain/client/src/tests/cross_shard_tx.rs
+++ b/chain/client/src/tests/cross_shard_tx.rs
@@ -37,10 +37,10 @@ fn test_keyvalue_runtime_balances() {
         let vs = ValidatorSchedule::new()
             .num_shards(4)
             .block_producers_per_epoch(vec![vec![
-                "test1".parse().unwrap(),
-                "test2".parse().unwrap(),
-                "test3".parse().unwrap(),
-                "test4".parse().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
+                "test2".parse::<AccountId>().unwrap(),
+                "test3".parse::<AccountId>().unwrap(),
+                "test4".parse::<AccountId>().unwrap(),
             ]])
             .validator_groups(2);
         let validators = vs.all_block_producers().cloned().collect::<Vec<_>>();

--- a/chain/client/src/tests/doomslug.rs
+++ b/chain/client/src/tests/doomslug.rs
@@ -4,6 +4,7 @@ use near_crypto::KeyType;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::block::{Approval, ApprovalType};
 use near_primitives::hash::CryptoHash;
+use near_primitives::types::AccountId;
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 
 /// This file contains tests that test the interaction of client and doomslug, including how client handles approvals, etc.
@@ -26,8 +27,11 @@ fn test_processing_skips_on_forks() {
     assert_eq!(b1.header().prev_hash(), b2.header().prev_hash());
     env.process_block(1, b1, Provenance::NONE);
     env.process_block(1, b2, Provenance::NONE);
-    let validator_signer =
-        InMemoryValidatorSigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+    let validator_signer = InMemoryValidatorSigner::from_seed(
+        "test1".parse::<AccountId>().unwrap(),
+        KeyType::ED25519,
+        "test1",
+    );
     let approval = Approval::new(CryptoHash::default(), 1, 3, &validator_signer);
     env.clients[1].collect_block_approval(&approval, ApprovalType::SelfApproval);
     assert!(!env.clients[1].doomslug.approval_status_at_height(&3).approvals.is_empty());

--- a/chain/client/src/tests/maintenance_windows.rs
+++ b/chain/client/src/tests/maintenance_windows.rs
@@ -3,6 +3,7 @@ use actix::System;
 use futures::{future, FutureExt};
 use near_actix_test_utils::run_actix;
 use near_client_primitives::types::GetMaintenanceWindows;
+use near_primitives::types::AccountId;
 
 use near_o11y::testonly::init_test_logger;
 use near_o11y::WithSpanContextExt;
@@ -13,13 +14,14 @@ fn test_get_maintenance_windows_for_validator() {
     init_test_logger();
     run_actix(async {
         let actor_handles = setup_no_network(
-            vec!["test".parse().unwrap(), "other".parse().unwrap()],
-            "other".parse().unwrap(),
+            vec!["test".parse::<AccountId>().unwrap(), "other".parse::<AccountId>().unwrap()],
+            "other".parse::<AccountId>().unwrap(),
             true,
             true,
         );
         let actor = actor_handles.view_client_actor.send(
-            GetMaintenanceWindows { account_id: "test".parse().unwrap() }.with_span_context(),
+            GetMaintenanceWindows { account_id: "test".parse::<AccountId>().unwrap() }
+                .with_span_context(),
         );
 
         // block_height: 0 bp: test         cps: [AccountId("test")]
@@ -45,10 +47,15 @@ fn test_get_maintenance_windows_for_validator() {
 fn test_get_maintenance_windows_for_not_validator() {
     init_test_logger();
     run_actix(async {
-        let actor_handles =
-            setup_no_network(vec!["test".parse().unwrap()], "other".parse().unwrap(), true, true);
+        let actor_handles = setup_no_network(
+            vec!["test".parse::<AccountId>().unwrap()],
+            "other".parse::<AccountId>().unwrap(),
+            true,
+            true,
+        );
         let actor = actor_handles.view_client_actor.send(
-            GetMaintenanceWindows { account_id: "alice".parse().unwrap() }.with_span_context(),
+            GetMaintenanceWindows { account_id: "alice".parse::<AccountId>().unwrap() }
+                .with_span_context(),
         );
         let actor = actor.then(|res| {
             assert_eq!(res.unwrap().unwrap(), vec![0..10]);

--- a/chain/client/src/tests/process_blocks.rs
+++ b/chain/client/src/tests/process_blocks.rs
@@ -9,6 +9,7 @@ use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::sharding::ShardChunkHeaderV3;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::validator_stake::ValidatorStake;
+use near_primitives::types::AccountId;
 use near_primitives::utils::MaybeValidated;
 use std::sync::Arc;
 
@@ -24,8 +25,11 @@ fn test_not_process_height_twice() {
     env.process_block(0, block, Provenance::PRODUCED);
     let validator_signer = create_test_signer("test0");
 
-    let proposals =
-        vec![ValidatorStake::new("test1".parse().unwrap(), PublicKey::empty(KeyType::ED25519), 0)];
+    let proposals = vec![ValidatorStake::new(
+        "test1".parse::<AccountId>().unwrap(),
+        PublicKey::empty(KeyType::ED25519),
+        0,
+    )];
     duplicate_block.mut_header().get_mut().inner_rest.prev_validator_proposals = proposals;
     duplicate_block.mut_header().resign(&validator_signer);
     let dup_block_hash = *duplicate_block.hash();

--- a/chain/client/src/tests/query_client.rs
+++ b/chain/client/src/tests/query_client.rs
@@ -26,7 +26,7 @@ use near_o11y::testonly::init_test_logger;
 use near_o11y::WithSpanContextExt;
 use near_primitives::block::{Block, BlockHeader};
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{BlockId, BlockReference, EpochId};
+use near_primitives::types::{AccountId, BlockId, BlockReference, EpochId};
 use near_primitives::utils::to_timestamp;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{QueryRequest, QueryResponseKind};
@@ -37,12 +37,16 @@ use num_rational::Ratio;
 fn query_client() {
     init_test_logger();
     run_actix(async {
-        let actor_handles =
-            setup_no_network(vec!["test".parse().unwrap()], "other".parse().unwrap(), true, true);
+        let actor_handles = setup_no_network(
+            vec!["test".parse::<AccountId>().unwrap()],
+            "other".parse::<AccountId>().unwrap(),
+            true,
+            true,
+        );
         let actor = actor_handles.view_client_actor.send(
             Query::new(
                 BlockReference::latest(),
-                QueryRequest::ViewAccount { account_id: "test".parse().unwrap() },
+                QueryRequest::ViewAccount { account_id: "test".parse::<AccountId>().unwrap() },
             )
             .with_span_context(),
         );
@@ -64,8 +68,12 @@ fn query_client() {
 fn query_status_not_crash() {
     init_test_logger();
     run_actix(async {
-        let actor_handles =
-            setup_no_network(vec!["test".parse().unwrap()], "other".parse().unwrap(), true, false);
+        let actor_handles = setup_no_network(
+            vec!["test".parse::<AccountId>().unwrap()],
+            "other".parse::<AccountId>().unwrap(),
+            true,
+            false,
+        );
         let signer = create_test_signer("test");
         let actor = actor_handles
             .view_client_actor
@@ -139,9 +147,17 @@ fn query_status_not_crash() {
 fn test_execution_outcome_for_chunk() {
     init_test_logger();
     run_actix(async {
-        let actor_handles =
-            setup_no_network(vec!["test".parse().unwrap()], "test".parse().unwrap(), true, false);
-        let signer = InMemorySigner::from_seed("test".parse().unwrap(), KeyType::ED25519, "test");
+        let actor_handles = setup_no_network(
+            vec!["test".parse::<AccountId>().unwrap()],
+            "test".parse::<AccountId>().unwrap(),
+            true,
+            false,
+        );
+        let signer = InMemorySigner::from_seed(
+            "test".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test",
+        );
 
         actix::spawn(async move {
             let block_hash = actor_handles
@@ -155,8 +171,8 @@ fn test_execution_outcome_for_chunk() {
 
             let transaction = SignedTransaction::send_money(
                 1,
-                "test".parse().unwrap(),
-                "near".parse().unwrap(),
+                "test".parse::<AccountId>().unwrap(),
+                "near".parse::<AccountId>().unwrap(),
                 &signer,
                 10,
                 block_hash,
@@ -178,7 +194,7 @@ fn test_execution_outcome_for_chunk() {
                 .send(
                     TxStatus {
                         tx_hash,
-                        signer_account_id: "test".parse().unwrap(),
+                        signer_account_id: "test".parse::<AccountId>().unwrap(),
                         fetch_receipt: false,
                     }
                     .with_span_context(),
@@ -209,12 +225,12 @@ fn test_execution_outcome_for_chunk() {
 #[test]
 fn test_state_request() {
     run_actix(async {
-        let vs =
-            ValidatorSchedule::new().block_producers_per_epoch(vec![vec!["test".parse().unwrap()]]);
+        let vs = ValidatorSchedule::new()
+            .block_producers_per_epoch(vec![vec!["test".parse::<AccountId>().unwrap()]]);
         let view_client = setup_only_view(
             vs,
             10000000,
-            "test".parse().unwrap(),
+            "test".parse::<AccountId>().unwrap(),
             true,
             200,
             400,
@@ -274,8 +290,8 @@ fn test_garbage_collection() {
         let epoch_length = 5;
         let target_height = epoch_length * (DEFAULT_GC_NUM_EPOCHS_TO_KEEP + 1);
         let vs = ValidatorSchedule::new().num_shards(2).block_producers_per_epoch(vec![vec![
-            "test1".parse().unwrap(),
-            "test2".parse().unwrap(),
+            "test1".parse::<AccountId>().unwrap(),
+            "test2".parse::<AccountId>().unwrap(),
         ]]);
 
         setup_mock_all_validators(
@@ -313,7 +329,9 @@ fn test_garbage_collection() {
                                                     prev_height,
                                                 )),
                                                 QueryRequest::ViewAccount {
-                                                    account_id: "test1".parse().unwrap(),
+                                                    account_id: "test1"
+                                                        .parse::<AccountId>()
+                                                        .unwrap(),
                                                 },
                                             )
                                             .with_span_context(),
@@ -336,7 +354,7 @@ fn test_garbage_collection() {
                                         Query::new(
                                             BlockReference::BlockId(BlockId::Height(1)),
                                             QueryRequest::ViewAccount {
-                                                account_id: "test1".parse().unwrap(),
+                                                account_id: "test1".parse::<AccountId>().unwrap(),
                                             },
                                         )
                                         .with_span_context(),
@@ -361,7 +379,7 @@ fn test_garbage_collection() {
                                         Query::new(
                                             BlockReference::BlockId(BlockId::Height(1)),
                                             QueryRequest::ViewAccount {
-                                                account_id: "test1".parse().unwrap(),
+                                                account_id: "test1".parse::<AccountId>().unwrap(),
                                             },
                                         )
                                         .with_span_context(),

--- a/chain/epoch-manager/src/reward_calculator.rs
+++ b/chain/epoch-manager/src/reward_calculator.rs
@@ -166,29 +166,31 @@ mod tests {
             num_blocks_per_year: 1000000,
             epoch_length,
             protocol_reward_rate: Ratio::new(0, 1),
-            protocol_treasury_account: "near".parse().unwrap(),
+            protocol_treasury_account: "near".parse::<AccountId>().unwrap(),
             online_min_threshold: Ratio::new(9, 10),
             online_max_threshold: Ratio::new(1, 1),
             num_seconds_per_year: 1000000,
         };
         let validator_block_chunk_stats = HashMap::from([
             (
-                "test1".parse().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
                 BlockChunkValidatorStats {
                     block_stats: ValidatorStats { produced: 0, expected: 0 },
                     chunk_stats: ValidatorStats { produced: 0, expected: 0 },
                 },
             ),
             (
-                "test2".parse().unwrap(),
+                "test2".parse::<AccountId>().unwrap(),
                 BlockChunkValidatorStats {
                     block_stats: ValidatorStats { produced: 0, expected: 1 },
                     chunk_stats: ValidatorStats { produced: 0, expected: 1 },
                 },
             ),
         ]);
-        let validator_stake =
-            HashMap::from([("test1".parse().unwrap(), 100), ("test2".parse().unwrap(), 100)]);
+        let validator_stake = HashMap::from([
+            ("test1".parse::<AccountId>().unwrap(), 100),
+            ("test2".parse::<AccountId>().unwrap(), 100),
+        ]);
         let total_supply = 1_000_000_000_000;
         let result = reward_calculator.calculate_reward(
             validator_block_chunk_stats,
@@ -201,9 +203,9 @@ mod tests {
         assert_eq!(
             result.0,
             HashMap::from([
-                ("near".parse().unwrap(), 0u128),
-                ("test1".parse().unwrap(), 0u128),
-                ("test2".parse().unwrap(), 0u128)
+                ("near".parse::<AccountId>().unwrap(), 0u128),
+                ("test1".parse::<AccountId>().unwrap(), 0u128),
+                ("test2".parse::<AccountId>().unwrap(), 0u128)
             ])
         );
     }
@@ -217,28 +219,28 @@ mod tests {
             num_blocks_per_year: 1000,
             epoch_length,
             protocol_reward_rate: Ratio::new(0, 10),
-            protocol_treasury_account: "near".parse().unwrap(),
+            protocol_treasury_account: "near".parse::<AccountId>().unwrap(),
             online_min_threshold: Ratio::new(9, 10),
             online_max_threshold: Ratio::new(99, 100),
             num_seconds_per_year: 1000,
         };
         let validator_block_chunk_stats = HashMap::from([
             (
-                "test1".parse().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
                 BlockChunkValidatorStats {
                     block_stats: ValidatorStats { produced: 945, expected: 1000 },
                     chunk_stats: ValidatorStats { produced: 945, expected: 1000 },
                 },
             ),
             (
-                "test2".parse().unwrap(),
+                "test2".parse::<AccountId>().unwrap(),
                 BlockChunkValidatorStats {
                     block_stats: ValidatorStats { produced: 999, expected: 1000 },
                     chunk_stats: ValidatorStats { produced: 999, expected: 1000 },
                 },
             ),
             (
-                "test3".parse().unwrap(),
+                "test3".parse::<AccountId>().unwrap(),
                 BlockChunkValidatorStats {
                     block_stats: ValidatorStats { produced: 850, expected: 1000 },
                     chunk_stats: ValidatorStats { produced: 850, expected: 1000 },
@@ -246,9 +248,9 @@ mod tests {
             ),
         ]);
         let validator_stake = HashMap::from([
-            ("test1".parse().unwrap(), 500_000),
-            ("test2".parse().unwrap(), 500_000),
-            ("test3".parse().unwrap(), 500_000),
+            ("test1".parse::<AccountId>().unwrap(), 500_000),
+            ("test2".parse::<AccountId>().unwrap(), 500_000),
+            ("test3".parse::<AccountId>().unwrap(), 500_000),
         ]);
         let total_supply = 1_000_000_000;
         let result = reward_calculator.calculate_reward(
@@ -264,10 +266,10 @@ mod tests {
         assert_eq!(
             result.0,
             HashMap::from([
-                ("near".parse().unwrap(), 0),
-                ("test1".parse().unwrap(), 1_666_666u128),
-                ("test2".parse().unwrap(), 3_333_333u128),
-                ("test3".parse().unwrap(), 0u128)
+                ("near".parse::<AccountId>().unwrap(), 0),
+                ("test1".parse::<AccountId>().unwrap(), 1_666_666u128),
+                ("test2".parse::<AccountId>().unwrap(), 3_333_333u128),
+                ("test3".parse::<AccountId>().unwrap(), 0u128)
             ])
         );
         assert_eq!(result.1, 4_999_999u128);
@@ -282,14 +284,14 @@ mod tests {
             num_blocks_per_year: 1000,
             epoch_length,
             protocol_reward_rate: Ratio::new(0, 10),
-            protocol_treasury_account: "near".parse().unwrap(),
+            protocol_treasury_account: "near".parse::<AccountId>().unwrap(),
             online_min_threshold: Ratio::new(9, 10),
             online_max_threshold: Ratio::new(99, 100),
             num_seconds_per_year: 1000,
         };
         let validator_block_chunk_stats = HashMap::from([
             (
-                "test1".parse().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
                 BlockChunkValidatorStats {
                     block_stats: ValidatorStats { produced: 945, expected: 1000 },
                     chunk_stats: ValidatorStats { produced: 945, expected: 1000 },
@@ -297,7 +299,7 @@ mod tests {
             ),
             // chunk only producer
             (
-                "test2".parse().unwrap(),
+                "test2".parse::<AccountId>().unwrap(),
                 BlockChunkValidatorStats {
                     block_stats: ValidatorStats { produced: 0, expected: 0 },
                     chunk_stats: ValidatorStats { produced: 999, expected: 1000 },
@@ -305,7 +307,7 @@ mod tests {
             ),
             // block only producer (not implemented right now, just for testing)
             (
-                "test3".parse().unwrap(),
+                "test3".parse::<AccountId>().unwrap(),
                 BlockChunkValidatorStats {
                     block_stats: ValidatorStats { produced: 945, expected: 1000 },
                     chunk_stats: ValidatorStats { produced: 0, expected: 0 },
@@ -314,7 +316,7 @@ mod tests {
             // a validator that expected blocks and chunks are both 0 (this could occur with very
             // small probability for validators with little stakes)
             (
-                "test4".parse().unwrap(),
+                "test4".parse::<AccountId>().unwrap(),
                 BlockChunkValidatorStats {
                     block_stats: ValidatorStats { produced: 0, expected: 0 },
                     chunk_stats: ValidatorStats { produced: 0, expected: 0 },
@@ -322,10 +324,10 @@ mod tests {
             ),
         ]);
         let validator_stake = HashMap::from([
-            ("test1".parse().unwrap(), 500_000),
-            ("test2".parse().unwrap(), 500_000),
-            ("test3".parse().unwrap(), 500_000),
-            ("test4".parse().unwrap(), 500_000),
+            ("test1".parse::<AccountId>().unwrap(), 500_000),
+            ("test2".parse::<AccountId>().unwrap(), 500_000),
+            ("test3".parse::<AccountId>().unwrap(), 500_000),
+            ("test4".parse::<AccountId>().unwrap(), 500_000),
         ]);
         let total_supply = 1_000_000_000;
         let result = reward_calculator.calculate_reward(
@@ -342,11 +344,11 @@ mod tests {
             assert_eq!(
                 result.0,
                 HashMap::from([
-                    ("near".parse().unwrap(), 0),
-                    ("test1".parse().unwrap(), 1_250_000u128),
-                    ("test2".parse().unwrap(), 2_500_000u128),
-                    ("test3".parse().unwrap(), 1_250_000u128),
-                    ("test4".parse().unwrap(), 0u128)
+                    ("near".parse::<AccountId>().unwrap(), 0),
+                    ("test1".parse::<AccountId>().unwrap(), 1_250_000u128),
+                    ("test2".parse::<AccountId>().unwrap(), 2_500_000u128),
+                    ("test3".parse::<AccountId>().unwrap(), 1_250_000u128),
+                    ("test4".parse::<AccountId>().unwrap(), 0u128)
                 ])
             );
             assert_eq!(result.1, 5_000_000u128);
@@ -364,19 +366,20 @@ mod tests {
             // half a day
             epoch_length,
             protocol_reward_rate: Ratio::new(1, 10),
-            protocol_treasury_account: "near".parse().unwrap(),
+            protocol_treasury_account: "near".parse::<AccountId>().unwrap(),
             online_min_threshold: Ratio::new(9, 10),
             online_max_threshold: Ratio::new(1, 1),
             num_seconds_per_year: 60 * 60 * 24 * 365,
         };
         let validator_block_chunk_stats = HashMap::from([(
-            "test".parse().unwrap(),
+            "test".parse::<AccountId>().unwrap(),
             BlockChunkValidatorStats {
                 block_stats: ValidatorStats { produced: 43200, expected: 43200 },
                 chunk_stats: ValidatorStats { produced: 345600, expected: 345600 },
             },
         )]);
-        let validator_stake = HashMap::from([("test".parse().unwrap(), 500_000 * 10_u128.pow(24))]);
+        let validator_stake =
+            HashMap::from([("test".parse::<AccountId>().unwrap(), 500_000 * 10_u128.pow(24))]);
         // some hypothetical large total supply (100b)
         let total_supply = 100_000_000_000 * 10_u128.pow(24);
         reward_calculator.calculate_reward(

--- a/chain/epoch-manager/src/shard_tracker.rs
+++ b/chain/epoch-manager/src/shard_tracker.rs
@@ -193,7 +193,7 @@ mod tests {
     use near_primitives::hash::CryptoHash;
     use near_primitives::shard_layout::ShardLayout;
     use near_primitives::types::validator_stake::ValidatorStake;
-    use near_primitives::types::{BlockHeight, EpochId, NumShards, ProtocolVersion, ShardId};
+    use near_primitives::types::{AccountId, BlockHeight, EpochId, NumShards, ProtocolVersion, ShardId};
     use near_primitives::version::ProtocolFeature::SimpleNightshade;
     use near_primitives::version::PROTOCOL_VERSION;
     use near_store::test_utils::create_test_store;
@@ -230,7 +230,7 @@ mod tests {
             num_blocks_per_year: 1000000,
             epoch_length: 1,
             protocol_reward_rate: Ratio::from_integer(0),
-            protocol_treasury_account: "test".parse().unwrap(),
+            protocol_treasury_account: "test".parse::<AccountId>().unwrap(),
             online_max_threshold: initial_epoch_config.online_max_threshold,
             online_min_threshold: initial_epoch_config.online_min_threshold,
             num_seconds_per_year: 1000000,
@@ -241,7 +241,7 @@ mod tests {
             genesis_protocol_version,
             reward_calculator,
             vec![ValidatorStake::new(
-                "test".parse().unwrap(),
+                "test".parse::<AccountId>().unwrap(),
                 PublicKey::empty(KeyType::ED25519),
                 100,
             )],
@@ -305,14 +305,15 @@ mod tests {
         let num_shards = 4;
         let epoch_manager = get_epoch_manager(PROTOCOL_VERSION, num_shards, false);
         let shard_layout = epoch_manager.read().get_shard_layout(&EpochId::default()).unwrap();
-        let tracked_accounts = vec!["test1".parse().unwrap(), "test2".parse().unwrap()];
+        let tracked_accounts =
+            vec!["test1".parse::<AccountId>().unwrap(), "test2".parse::<AccountId>().unwrap()];
         let tracker =
             ShardTracker::new(TrackedConfig::Accounts(tracked_accounts), Arc::new(epoch_manager));
         let mut total_tracked_shards = HashSet::new();
         total_tracked_shards
-            .insert(account_id_to_shard_id(&"test1".parse().unwrap(), &shard_layout));
+            .insert(account_id_to_shard_id(&"test1".parse::<AccountId>().unwrap(), &shard_layout));
         total_tracked_shards
-            .insert(account_id_to_shard_id(&"test2".parse().unwrap(), &shard_layout));
+            .insert(account_id_to_shard_id(&"test2".parse::<AccountId>().unwrap(), &shard_layout));
 
         assert_eq!(
             get_all_shards_care_about(&tracker, num_shards, &CryptoHash::default()),
@@ -388,8 +389,11 @@ mod tests {
     fn test_track_shards_shard_layout_change() {
         let simple_nightshade_version = SimpleNightshade.protocol_version();
         let epoch_manager = get_epoch_manager(simple_nightshade_version - 1, 1, true);
-        let tracked_accounts =
-            vec!["a.near".parse().unwrap(), "near".parse().unwrap(), "zoo".parse().unwrap()];
+        let tracked_accounts = vec![
+            "a.near".parse::<AccountId>().unwrap(),
+            "near".parse::<AccountId>().unwrap(),
+            "zoo".parse::<AccountId>().unwrap(),
+        ];
         let tracker = ShardTracker::new(
             TrackedConfig::Accounts(tracked_accounts.clone()),
             Arc::new(epoch_manager.clone()),

--- a/chain/epoch-manager/src/shard_tracker.rs
+++ b/chain/epoch-manager/src/shard_tracker.rs
@@ -193,7 +193,9 @@ mod tests {
     use near_primitives::hash::CryptoHash;
     use near_primitives::shard_layout::ShardLayout;
     use near_primitives::types::validator_stake::ValidatorStake;
-    use near_primitives::types::{AccountId, BlockHeight, EpochId, NumShards, ProtocolVersion, ShardId};
+    use near_primitives::types::{
+        AccountId, BlockHeight, EpochId, NumShards, ProtocolVersion, ShardId,
+    };
     use near_primitives::version::ProtocolFeature::SimpleNightshade;
     use near_primitives::version::PROTOCOL_VERSION;
     use near_store::test_utils::create_test_store;

--- a/chain/epoch-manager/src/test_utils.rs
+++ b/chain/epoch-manager/src/test_utils.rs
@@ -190,7 +190,7 @@ pub fn default_reward_calculator() -> RewardCalculator {
         num_blocks_per_year: 1,
         epoch_length: 1,
         protocol_reward_rate: Ratio::from_integer(0),
-        protocol_treasury_account: "near".parse().unwrap(),
+        protocol_treasury_account: "near".parse::<AccountId>().unwrap(),
         online_min_threshold: Ratio::new(90, 100),
         online_max_threshold: Ratio::new(99, 100),
         num_seconds_per_year: NUM_SECONDS_IN_A_YEAR,

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -13,6 +13,7 @@ use near_primitives::challenge::SlashedValidator;
 use near_primitives::epoch_manager::EpochConfig;
 use near_primitives::hash::hash;
 use near_primitives::shard_layout::ShardLayout;
+use near_primitives::types::AccountId;
 use near_primitives::types::ValidatorKickoutReason::{NotEnoughBlocks, NotEnoughChunks};
 use near_primitives::version::ProtocolFeature::SimpleNightshade;
 use near_primitives::version::PROTOCOL_VERSION;
@@ -43,7 +44,7 @@ impl EpochManager {
 #[test]
 fn test_stake_validator() {
     let amount_staked = 1_000_000;
-    let validators = vec![("test1".parse().unwrap(), amount_staked)];
+    let validators = vec![("test1".parse::<AccountId>().unwrap(), amount_staked)];
     let mut epoch_manager = setup_default_epoch_manager(validators.clone(), 1, 1, 2, 2, 90, 60);
 
     let h = hash_range(4);
@@ -51,14 +52,14 @@ fn test_stake_validator() {
 
     let expected0 = epoch_info_with_num_seats(
         1,
-        vec![("test1".parse().unwrap(), amount_staked)],
+        vec![("test1".parse::<AccountId>().unwrap(), amount_staked)],
         vec![0, 0],
         vec![vec![0, 0]],
         vec![],
         vec![],
-        change_stake(vec![("test1".parse().unwrap(), amount_staked)]),
+        change_stake(vec![("test1".parse::<AccountId>().unwrap(), amount_staked)]),
         vec![],
-        reward(vec![("near".parse().unwrap(), 0)]),
+        reward(vec![("near".parse::<AccountId>().unwrap(), 0)]),
         0,
         4,
     );
@@ -77,7 +78,7 @@ fn test_stake_validator() {
         h[0],
         h[1],
         1,
-        vec![stake("test2".parse().unwrap(), amount_staked)],
+        vec![stake("test2".parse::<AccountId>().unwrap(), amount_staked)],
     );
     let epoch1 = epoch_manager.get_epoch_id(&h[1]).unwrap();
     assert!(compare_epoch_infos(&epoch_manager.get_epoch_info(&epoch1).unwrap(), &expected0));
@@ -92,18 +93,24 @@ fn test_stake_validator() {
 
     let expected3 = epoch_info_with_num_seats(
         2,
-        vec![("test1".parse().unwrap(), amount_staked), ("test2".parse().unwrap(), amount_staked)],
+        vec![
+            ("test1".parse::<AccountId>().unwrap(), amount_staked),
+            ("test2".parse::<AccountId>().unwrap(), amount_staked),
+        ],
         vec![0, 1],
         vec![vec![0, 1]],
         vec![],
         vec![],
         change_stake(vec![
-            ("test1".parse().unwrap(), amount_staked),
-            ("test2".parse().unwrap(), amount_staked),
+            ("test1".parse::<AccountId>().unwrap(), amount_staked),
+            ("test2".parse::<AccountId>().unwrap(), amount_staked),
         ]),
         vec![],
         // only the validator who produced the block in this epoch gets the reward since epoch length is 1
-        reward(vec![("test1".parse().unwrap(), 0), ("near".parse().unwrap(), 0)]),
+        reward(vec![
+            ("test1".parse::<AccountId>().unwrap(), 0),
+            ("near".parse::<AccountId>().unwrap(), 0),
+        ]),
         0,
         4,
     );
@@ -130,8 +137,10 @@ fn test_stake_validator() {
 fn test_validator_change_of_stake() {
     let amount_staked = 1_000_000;
     let fishermen_threshold = 100;
-    let validators =
-        vec![("test1".parse().unwrap(), amount_staked), ("test2".parse().unwrap(), amount_staked)];
+    let validators = vec![
+        ("test1".parse::<AccountId>().unwrap(), amount_staked),
+        ("test2".parse::<AccountId>().unwrap(), amount_staked),
+    ];
     let mut epoch_manager = setup_epoch_manager(
         validators,
         2,
@@ -146,7 +155,13 @@ fn test_validator_change_of_stake() {
 
     let h = hash_range(4);
     record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
-    record_block(&mut epoch_manager, h[0], h[1], 1, vec![stake("test1".parse().unwrap(), 10)]);
+    record_block(
+        &mut epoch_manager,
+        h[0],
+        h[1],
+        1,
+        vec![stake("test1".parse::<AccountId>().unwrap(), 10)],
+    );
     record_block(&mut epoch_manager, h[1], h[2], 2, vec![]);
     // New epoch starts here.
     record_block(&mut epoch_manager, h[2], h[3], 3, vec![]);
@@ -156,18 +171,21 @@ fn test_validator_change_of_stake() {
     check_fishermen(&epoch_info, &[]);
     check_stake_change(
         &epoch_info,
-        vec![("test1".parse().unwrap(), 0), ("test2".parse().unwrap(), amount_staked)],
+        vec![
+            ("test1".parse::<AccountId>().unwrap(), 0),
+            ("test2".parse::<AccountId>().unwrap(), amount_staked),
+        ],
     );
     check_reward(
         &epoch_info,
         vec![
-            ("test1".parse().unwrap(), 0),
-            ("test2".parse().unwrap(), 0),
-            ("near".parse().unwrap(), 0),
+            ("test1".parse::<AccountId>().unwrap(), 0),
+            ("test2".parse::<AccountId>().unwrap(), 0),
+            ("near".parse::<AccountId>().unwrap(), 0),
         ],
     );
     matches!(
-        epoch_info.validator_kickout().get("test1"),
+        epoch_info.validator_kickout().get(&"test1".parse::<AccountId>().unwrap()),
         Some(ValidatorKickoutReason::NotEnoughStake { stake: 10, .. })
     );
 }
@@ -183,9 +201,9 @@ fn test_validator_change_of_stake() {
 fn test_fork_finalization() {
     let amount_staked = 1_000_000;
     let validators = vec![
-        ("test1".parse().unwrap(), amount_staked),
-        ("test2".parse().unwrap(), amount_staked),
-        ("test3".parse().unwrap(), amount_staked),
+        ("test1".parse::<AccountId>().unwrap(), amount_staked),
+        ("test2".parse::<AccountId>().unwrap(), amount_staked),
+        ("test3".parse::<AccountId>().unwrap(), amount_staked),
     ];
     let epoch_length = 20;
     let mut epoch_manager =
@@ -211,7 +229,7 @@ fn test_fork_finalization() {
             let block_producer_id = EpochManager::block_producer_from_info(&epoch_info, height);
             let block_producer = epoch_info.get_validator(block_producer_id);
             let account_id = block_producer.account_id();
-            if validator_accounts.iter().any(|v| *v == account_id.as_ref()) {
+            if validator_accounts.iter().any(|v| *v == account_id.as_str()) {
                 record_block(epoch_manager, prev_block, *curr_block, height, vec![]);
                 prev_block = *curr_block;
                 branch_blocks.push(*curr_block);
@@ -226,7 +244,7 @@ fn test_fork_finalization() {
         h[0],
         h[1],
         1,
-        vec![stake("test4".parse().unwrap(), amount_staked)],
+        vec![stake("test4".parse::<AccountId>().unwrap(), amount_staked)],
     );
     let blocks_test2 = build_branch(&mut epoch_manager, h[1], &h, &["test2", "test4"]);
 
@@ -244,9 +262,9 @@ fn test_fork_finalization() {
     assert_eq!(
         bps,
         vec![
-            ("test1".parse().unwrap(), false),
-            ("test2".parse().unwrap(), false),
-            ("test3".parse().unwrap(), false)
+            ("test1".parse::<AccountId>().unwrap(), false),
+            ("test2".parse::<AccountId>().unwrap(), false),
+            ("test3".parse::<AccountId>().unwrap(), false)
         ]
     );
 
@@ -259,7 +277,10 @@ fn test_fork_finalization() {
             .iter()
             .map(|x| (x.0.account_id().clone(), x.1))
             .collect::<Vec<_>>(),
-        vec![("test2".parse().unwrap(), false), ("test4".parse().unwrap(), false)]
+        vec![
+            ("test2".parse::<AccountId>().unwrap(), false),
+            ("test4".parse::<AccountId>().unwrap(), false)
+        ]
     );
 
     let last_block = blocks_test1.last().unwrap();
@@ -271,7 +292,10 @@ fn test_fork_finalization() {
             .iter()
             .map(|x| (x.0.account_id().clone(), x.1))
             .collect::<Vec<_>>(),
-        vec![("test1".parse().unwrap(), false), ("test3".parse().unwrap(), false),]
+        vec![
+            ("test1".parse::<AccountId>().unwrap(), false),
+            ("test3".parse::<AccountId>().unwrap(), false),
+        ]
     );
 
     // Check that if we have a different epoch manager and apply only second branch we get the same results.
@@ -289,7 +313,7 @@ fn test_fork_finalization() {
 fn test_one_validator_kickout() {
     let amount_staked = 1_000;
     let mut epoch_manager = setup_default_epoch_manager(
-        vec![("test1".parse().unwrap(), amount_staked)],
+        vec![("test1".parse::<AccountId>().unwrap(), amount_staked)],
         2,
         1,
         1,
@@ -310,7 +334,7 @@ fn test_one_validator_kickout() {
     check_validators(&epoch_info, &[("test1", amount_staked)]);
     check_fishermen(&epoch_info, &[]);
     check_kickout(&epoch_info, &[]);
-    check_stake_change(&epoch_info, vec![("test1".parse().unwrap(), amount_staked)]);
+    check_stake_change(&epoch_info, vec![("test1".parse::<AccountId>().unwrap(), amount_staked)]);
 }
 
 /// When computing validator kickout, we should not kickout validators such that the union
@@ -318,8 +342,10 @@ fn test_one_validator_kickout() {
 #[test]
 fn test_validator_kickout() {
     let amount_staked = 1_000_000;
-    let validators =
-        vec![("test1".parse().unwrap(), amount_staked), ("test2".parse().unwrap(), amount_staked)];
+    let validators = vec![
+        ("test1".parse::<AccountId>().unwrap(), amount_staked),
+        ("test2".parse::<AccountId>().unwrap(), amount_staked),
+    ];
     let epoch_length = 10;
     let mut epoch_manager = setup_default_epoch_manager(validators, epoch_length, 1, 2, 0, 90, 60);
     let h = hash_range((3 * epoch_length) as usize);
@@ -332,10 +358,10 @@ fn test_validator_kickout() {
         let height = i as u64;
         let epoch_id = epoch_manager.get_epoch_id_from_prev_block(&prev_block).unwrap();
         let block_producer = epoch_manager.get_block_producer_info(&epoch_id, height).unwrap();
-        if block_producer.account_id().as_ref() == "test2" && epoch_id == init_epoch_id {
+        if block_producer.account_id().as_str() == "test2" && epoch_id == init_epoch_id {
             // test2 skips its blocks in the first epoch
             test2_expected_blocks += 1;
-        } else if block_producer.account_id().as_ref() == "test1" && epoch_id != init_epoch_id {
+        } else if block_producer.account_id().as_str() == "test1" && epoch_id != init_epoch_id {
             // test1 skips its blocks in subsequent epochs
             ()
         } else {
@@ -358,14 +384,14 @@ fn test_validator_kickout() {
     let epoch_info = &epoch_infos[2];
     check_validators(epoch_info, &[("test1", amount_staked)]);
     check_fishermen(epoch_info, &[]);
-    check_stake_change(epoch_info, vec![("test1".parse().unwrap(), amount_staked)]);
+    check_stake_change(epoch_info, vec![("test1".parse::<AccountId>().unwrap(), amount_staked)]);
     check_kickout(epoch_info, &[]);
     check_reward(
         epoch_info,
         vec![
-            ("test2".parse().unwrap(), 0),
-            ("near".parse().unwrap(), 0),
-            ("test1".parse().unwrap(), 0),
+            ("test2".parse::<AccountId>().unwrap(), 0),
+            ("near".parse::<AccountId>().unwrap(), 0),
+            ("test1".parse::<AccountId>().unwrap(), 0),
         ],
     );
 }
@@ -376,8 +402,8 @@ fn test_validator_unstake() {
     let config = epoch_config(2, 1, 2, 0, 90, 60, 0);
     let amount_staked = 1_000_000;
     let validators = vec![
-        stake("test1".parse().unwrap(), amount_staked),
-        stake("test2".parse().unwrap(), amount_staked),
+        stake("test1".parse::<AccountId>().unwrap(), amount_staked),
+        stake("test2".parse::<AccountId>().unwrap(), amount_staked),
     ];
     let mut epoch_manager =
         EpochManager::new(store, config, PROTOCOL_VERSION, default_reward_calculator(), validators)
@@ -385,7 +411,13 @@ fn test_validator_unstake() {
     let h = hash_range(8);
     record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
     // test1 unstakes in epoch 1, and should be kicked out in epoch 3 (validators stored at h2).
-    record_block(&mut epoch_manager, h[0], h[1], 1, vec![stake("test1".parse().unwrap(), 0)]);
+    record_block(
+        &mut epoch_manager,
+        h[0],
+        h[1],
+        1,
+        vec![stake("test1".parse::<AccountId>().unwrap(), 0)],
+    );
     record_block(&mut epoch_manager, h[1], h[2], 2, vec![]);
     record_block(&mut epoch_manager, h[2], h[3], 3, vec![]);
 
@@ -395,15 +427,18 @@ fn test_validator_unstake() {
     check_fishermen(&epoch_info, &[]);
     check_stake_change(
         &epoch_info,
-        vec![("test1".parse().unwrap(), 0), ("test2".parse().unwrap(), amount_staked)],
+        vec![
+            ("test1".parse::<AccountId>().unwrap(), 0),
+            ("test2".parse::<AccountId>().unwrap(), amount_staked),
+        ],
     );
     check_kickout(&epoch_info, &[("test1", ValidatorKickoutReason::Unstaked)]);
     check_reward(
         &epoch_info,
         vec![
-            ("test1".parse().unwrap(), 0),
-            ("test2".parse().unwrap(), 0),
-            ("near".parse().unwrap(), 0),
+            ("test1".parse::<AccountId>().unwrap(), 0),
+            ("test2".parse::<AccountId>().unwrap(), 0),
+            ("near".parse::<AccountId>().unwrap(), 0),
         ],
     );
 
@@ -413,14 +448,14 @@ fn test_validator_unstake() {
     let epoch_info = epoch_manager.get_epoch_info(&epoch_id).unwrap();
     check_validators(&epoch_info, &[("test2", amount_staked)]);
     check_fishermen(&epoch_info, &[]);
-    check_stake_change(&epoch_info, vec![("test2".parse().unwrap(), amount_staked)]);
+    check_stake_change(&epoch_info, vec![("test2".parse::<AccountId>().unwrap(), amount_staked)]);
     check_kickout(&epoch_info, &[]);
     check_reward(
         &epoch_info,
         vec![
-            ("test1".parse().unwrap(), 0),
-            ("test2".parse().unwrap(), 0),
-            ("near".parse().unwrap(), 0),
+            ("test1".parse::<AccountId>().unwrap(), 0),
+            ("test2".parse::<AccountId>().unwrap(), 0),
+            ("near".parse::<AccountId>().unwrap(), 0),
         ],
     );
 
@@ -430,9 +465,12 @@ fn test_validator_unstake() {
     let epoch_info = epoch_manager.get_epoch_info(&epoch_id).unwrap();
     check_validators(&epoch_info, &[("test2", amount_staked)]);
     check_fishermen(&epoch_info, &[]);
-    check_stake_change(&epoch_info, vec![("test2".parse().unwrap(), amount_staked)]);
+    check_stake_change(&epoch_info, vec![("test2".parse::<AccountId>().unwrap(), amount_staked)]);
     check_kickout(&epoch_info, &[]);
-    check_reward(&epoch_info, vec![("test2".parse().unwrap(), 0), ("near".parse().unwrap(), 0)]);
+    check_reward(
+        &epoch_info,
+        vec![("test2".parse::<AccountId>().unwrap(), 0), ("near".parse::<AccountId>().unwrap(), 0)],
+    );
 }
 
 #[test]
@@ -441,8 +479,8 @@ fn test_slashing() {
     let config = epoch_config(2, 1, 2, 0, 90, 60, 0);
     let amount_staked = 1_000_000;
     let validators = vec![
-        stake("test1".parse().unwrap(), amount_staked),
-        stake("test2".parse().unwrap(), amount_staked),
+        stake("test1".parse::<AccountId>().unwrap(), amount_staked),
+        stake("test2".parse::<AccountId>().unwrap(), amount_staked),
     ];
     let mut epoch_manager =
         EpochManager::new(store, config, PROTOCOL_VERSION, default_reward_calculator(), validators)
@@ -460,7 +498,7 @@ fn test_slashing() {
         h[1],
         1,
         vec![],
-        vec![SlashedValidator::new("test1".parse().unwrap(), false)],
+        vec![SlashedValidator::new("test1".parse::<AccountId>().unwrap(), false)],
     );
 
     let epoch_id = epoch_manager.get_epoch_id(&h[1]).unwrap();
@@ -471,7 +509,13 @@ fn test_slashing() {
         .map(|x| (x.0.account_id().clone(), x.1))
         .collect::<Vec<_>>();
     bps.sort_unstable();
-    assert_eq!(bps, vec![("test1".parse().unwrap(), true), ("test2".parse().unwrap(), false)]);
+    assert_eq!(
+        bps,
+        vec![
+            ("test1".parse::<AccountId>().unwrap(), true),
+            ("test2".parse::<AccountId>().unwrap(), false)
+        ]
+    );
 
     record_block(&mut epoch_manager, h[1], h[2], 2, vec![]);
     record_block(&mut epoch_manager, h[2], h[3], 3, vec![]);
@@ -486,7 +530,10 @@ fn test_slashing() {
     check_fishermen(&epoch_info, &[]);
     check_stake_change(
         &epoch_info,
-        vec![("test1".parse().unwrap(), 0), ("test2".parse().unwrap(), amount_staked)],
+        vec![
+            ("test1".parse::<AccountId>().unwrap(), 0),
+            ("test2".parse::<AccountId>().unwrap(), amount_staked),
+        ],
     );
     check_kickout(&epoch_info, &[("test1", ValidatorKickoutReason::Slashed)]);
 
@@ -496,9 +543,9 @@ fn test_slashing() {
         epoch_manager.get_block_info(&h[3]).unwrap().slashed().clone().into_iter().collect();
     let slashed3: Vec<_> =
         epoch_manager.get_block_info(&h[5]).unwrap().slashed().clone().into_iter().collect();
-    assert_eq!(slashed1, vec![("test1".parse().unwrap(), SlashState::Other)]);
-    assert_eq!(slashed2, vec![("test1".parse().unwrap(), SlashState::AlreadySlashed)]);
-    assert_eq!(slashed3, vec![("test1".parse().unwrap(), SlashState::AlreadySlashed)]);
+    assert_eq!(slashed1, vec![("test1".parse::<AccountId>().unwrap(), SlashState::Other)]);
+    assert_eq!(slashed2, vec![("test1".parse::<AccountId>().unwrap(), SlashState::AlreadySlashed)]);
+    assert_eq!(slashed3, vec![("test1".parse::<AccountId>().unwrap(), SlashState::AlreadySlashed)]);
 }
 
 /// Test that double sign interacts with other challenges in the correct way.
@@ -508,8 +555,8 @@ fn test_double_sign_slashing1() {
     let config = epoch_config(2, 1, 2, 0, 90, 60, 0);
     let amount_staked = 1_000_000;
     let validators = vec![
-        stake("test1".parse().unwrap(), amount_staked),
-        stake("test2".parse().unwrap(), amount_staked),
+        stake("test1".parse::<AccountId>().unwrap(), amount_staked),
+        stake("test2".parse::<AccountId>().unwrap(), amount_staked),
     ];
     let mut epoch_manager =
         EpochManager::new(store, config, PROTOCOL_VERSION, default_reward_calculator(), validators)
@@ -525,18 +572,18 @@ fn test_double_sign_slashing1() {
         2,
         vec![],
         vec![
-            SlashedValidator::new("test1".parse().unwrap(), true),
-            SlashedValidator::new("test1".parse().unwrap(), false),
+            SlashedValidator::new("test1".parse::<AccountId>().unwrap(), true),
+            SlashedValidator::new("test1".parse::<AccountId>().unwrap(), false),
         ],
     );
     let slashed: Vec<_> =
         epoch_manager.get_block_info(&h[2]).unwrap().slashed().clone().into_iter().collect();
-    assert_eq!(slashed, vec![("test1".parse().unwrap(), SlashState::Other)]);
+    assert_eq!(slashed, vec![("test1".parse::<AccountId>().unwrap(), SlashState::Other)]);
     record_block(&mut epoch_manager, h[2], h[3], 3, vec![]);
     // new epoch
     let slashed: Vec<_> =
         epoch_manager.get_block_info(&h[3]).unwrap().slashed().clone().into_iter().collect();
-    assert_eq!(slashed, vec![("test1".parse().unwrap(), SlashState::AlreadySlashed)]);
+    assert_eq!(slashed, vec![("test1".parse::<AccountId>().unwrap(), SlashState::AlreadySlashed)]);
     // slash test1 for double sign
     record_block_with_slashes(
         &mut epoch_manager,
@@ -544,7 +591,7 @@ fn test_double_sign_slashing1() {
         h[4],
         4,
         vec![],
-        vec![SlashedValidator::new("test1".parse().unwrap(), true)],
+        vec![SlashedValidator::new("test1".parse::<AccountId>().unwrap(), true)],
     );
 
     // Epoch 3 -> defined by proposals/slashes in h[1].
@@ -556,33 +603,35 @@ fn test_double_sign_slashing1() {
             .validators_iter()
             .map(|v| (v.account_id().clone(), v.stake()))
             .collect::<Vec<_>>(),
-        vec![("test2".parse().unwrap(), amount_staked)],
+        vec![("test2".parse::<AccountId>().unwrap(), amount_staked)],
     );
     assert_eq!(
         epoch_info.validator_kickout(),
-        &[("test1".parse().unwrap(), ValidatorKickoutReason::Slashed)]
+        &[("test1".parse::<AccountId>().unwrap(), ValidatorKickoutReason::Slashed)]
             .into_iter()
             .collect::<HashMap<_, _>>()
     );
     assert_eq!(
         epoch_info.stake_change(),
         &change_stake(vec![
-            ("test1".parse().unwrap(), 0),
-            ("test2".parse().unwrap(), amount_staked)
+            ("test1".parse::<AccountId>().unwrap(), 0),
+            ("test2".parse::<AccountId>().unwrap(), amount_staked)
         ]),
     );
 
     let slashed: Vec<_> =
         epoch_manager.get_block_info(&h[5]).unwrap().slashed().clone().into_iter().collect();
-    assert_eq!(slashed, vec![("test1".parse().unwrap(), SlashState::AlreadySlashed)]);
+    assert_eq!(slashed, vec![("test1".parse::<AccountId>().unwrap(), SlashState::AlreadySlashed)]);
 }
 
 /// Test that two double sign challenge in two epochs works
 #[test]
 fn test_double_sign_slashing2() {
     let amount_staked = 1_000_000;
-    let validators =
-        vec![("test1".parse().unwrap(), amount_staked), ("test2".parse().unwrap(), amount_staked)];
+    let validators = vec![
+        ("test1".parse::<AccountId>().unwrap(), amount_staked),
+        ("test2".parse::<AccountId>().unwrap(), amount_staked),
+    ];
     let mut epoch_manager = setup_default_epoch_manager(validators, 2, 1, 2, 0, 90, 60);
 
     let h = hash_range(10);
@@ -593,17 +642,17 @@ fn test_double_sign_slashing2() {
         h[1],
         1,
         vec![],
-        vec![SlashedValidator::new("test1".parse().unwrap(), true)],
+        vec![SlashedValidator::new("test1".parse::<AccountId>().unwrap(), true)],
     );
 
     let slashed: Vec<_> =
         epoch_manager.get_block_info(&h[1]).unwrap().slashed().clone().into_iter().collect();
-    assert_eq!(slashed, vec![("test1".parse().unwrap(), SlashState::DoubleSign)]);
+    assert_eq!(slashed, vec![("test1".parse::<AccountId>().unwrap(), SlashState::DoubleSign)]);
 
     record_block(&mut epoch_manager, h[1], h[2], 2, vec![]);
     let slashed: Vec<_> =
         epoch_manager.get_block_info(&h[2]).unwrap().slashed().clone().into_iter().collect();
-    assert_eq!(slashed, vec![("test1".parse().unwrap(), SlashState::DoubleSign)]);
+    assert_eq!(slashed, vec![("test1".parse::<AccountId>().unwrap(), SlashState::DoubleSign)]);
     // new epoch
     record_block_with_slashes(
         &mut epoch_manager,
@@ -611,11 +660,11 @@ fn test_double_sign_slashing2() {
         h[3],
         3,
         vec![],
-        vec![SlashedValidator::new("test1".parse().unwrap(), true)],
+        vec![SlashedValidator::new("test1".parse::<AccountId>().unwrap(), true)],
     );
     let slashed: Vec<_> =
         epoch_manager.get_block_info(&h[3]).unwrap().slashed().clone().into_iter().collect();
-    assert_eq!(slashed, vec![("test1".parse().unwrap(), SlashState::DoubleSign)]);
+    assert_eq!(slashed, vec![("test1".parse::<AccountId>().unwrap(), SlashState::DoubleSign)]);
 }
 
 /// If all current validator try to unstake, we disallow that.
@@ -623,9 +672,9 @@ fn test_double_sign_slashing2() {
 fn test_all_validators_unstake() {
     let stake_amount = 1_000;
     let validators = vec![
-        ("test1".parse().unwrap(), stake_amount),
-        ("test2".parse().unwrap(), stake_amount),
-        ("test3".parse().unwrap(), stake_amount),
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+        ("test3".parse::<AccountId>().unwrap(), stake_amount),
     ];
     let mut epoch_manager = setup_default_epoch_manager(validators, 1, 1, 3, 0, 90, 60);
     let h = hash_range(5);
@@ -637,9 +686,9 @@ fn test_all_validators_unstake() {
         h[1],
         1,
         vec![
-            stake("test1".parse().unwrap(), 0),
-            stake("test2".parse().unwrap(), 0),
-            stake("test3".parse().unwrap(), 0),
+            stake("test1".parse::<AccountId>().unwrap(), 0),
+            stake("test2".parse::<AccountId>().unwrap(), 0),
+            stake("test3".parse::<AccountId>().unwrap(), 0),
         ],
     );
     record_block(&mut epoch_manager, h[1], h[2], 2, vec![]);
@@ -647,9 +696,9 @@ fn test_all_validators_unstake() {
     assert_eq!(
         epoch_manager.get_epoch_info(&next_epoch).unwrap().validators_iter().collect::<Vec<_>>(),
         vec![
-            stake("test1".parse().unwrap(), stake_amount),
-            stake("test2".parse().unwrap(), stake_amount),
-            stake("test3".parse().unwrap(), stake_amount)
+            stake("test1".parse::<AccountId>().unwrap(), stake_amount),
+            stake("test2".parse::<AccountId>().unwrap(), stake_amount),
+            stake("test3".parse::<AccountId>().unwrap(), stake_amount)
         ],
     );
 }
@@ -659,8 +708,8 @@ fn test_validator_reward_one_validator() {
     let stake_amount = 1_000_000;
     let test1_stake_amount = 110;
     let validators = vec![
-        ("test1".parse().unwrap(), test1_stake_amount),
-        ("test2".parse().unwrap(), stake_amount),
+        ("test1".parse::<AccountId>().unwrap(), test1_stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
     ];
     let epoch_length = 2;
     let total_supply = validators.iter().map(|(_, stake)| stake).sum();
@@ -669,7 +718,7 @@ fn test_validator_reward_one_validator() {
         num_blocks_per_year: 50,
         epoch_length,
         protocol_reward_rate: Ratio::new(1, 10),
-        protocol_treasury_account: "near".parse().unwrap(),
+        protocol_treasury_account: "near".parse::<AccountId>().unwrap(),
         online_min_threshold: Ratio::new(90, 100),
         online_max_threshold: Ratio::new(99, 100),
         num_seconds_per_year: 50,
@@ -717,14 +766,14 @@ fn test_validator_reward_one_validator() {
         .unwrap();
     let mut validator_online_ratio = HashMap::new();
     validator_online_ratio.insert(
-        "test2".parse().unwrap(),
+        "test2".parse::<AccountId>().unwrap(),
         BlockChunkValidatorStats {
             block_stats: ValidatorStats { produced: 1, expected: 1 },
             chunk_stats: ValidatorStats { produced: 1, expected: 1 },
         },
     );
     let mut validator_stakes = HashMap::new();
-    validator_stakes.insert("test2".parse().unwrap(), stake_amount);
+    validator_stakes.insert("test2".parse::<AccountId>().unwrap(), stake_amount);
     let (validator_reward, inflation) = reward_calculator.calculate_reward(
         validator_online_ratio,
         &validator_stakes,
@@ -733,8 +782,8 @@ fn test_validator_reward_one_validator() {
         PROTOCOL_VERSION,
         epoch_length * NUM_NS_IN_SECOND,
     );
-    let test2_reward = *validator_reward.get("test2").unwrap();
-    let protocol_reward = *validator_reward.get("near").unwrap();
+    let test2_reward = *validator_reward.get(&"test2".parse::<AccountId>().unwrap()).unwrap();
+    let protocol_reward = *validator_reward.get(&"near".parse::<AccountId>().unwrap()).unwrap();
 
     let epoch_info = epoch_manager.get_epoch_info(&EpochId(h[2])).unwrap();
     check_validators(&epoch_info, &[("test2", stake_amount + test2_reward)]);
@@ -742,14 +791,17 @@ fn test_validator_reward_one_validator() {
     check_stake_change(
         &epoch_info,
         vec![
-            ("test1".parse().unwrap(), test1_stake_amount),
-            ("test2".parse().unwrap(), stake_amount + test2_reward),
+            ("test1".parse::<AccountId>().unwrap(), test1_stake_amount),
+            ("test2".parse::<AccountId>().unwrap(), stake_amount + test2_reward),
         ],
     );
     check_kickout(&epoch_info, &[]);
     check_reward(
         &epoch_info,
-        vec![("test2".parse().unwrap(), test2_reward), ("near".parse().unwrap(), protocol_reward)],
+        vec![
+            ("test2".parse::<AccountId>().unwrap(), test2_reward),
+            ("near".parse::<AccountId>().unwrap(), protocol_reward),
+        ],
     );
     assert_eq!(epoch_info.minted_amount(), inflation);
 }
@@ -758,8 +810,10 @@ fn test_validator_reward_one_validator() {
 fn test_validator_reward_weight_by_stake() {
     let stake_amount1 = 1_000_000;
     let stake_amount2 = 500_000;
-    let validators =
-        vec![("test1".parse().unwrap(), stake_amount1), ("test2".parse().unwrap(), stake_amount2)];
+    let validators = vec![
+        ("test1".parse::<AccountId>().unwrap(), stake_amount1),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount2),
+    ];
     let epoch_length = 2;
     let total_supply = (stake_amount1 + stake_amount2) * validators.len() as u128;
     let reward_calculator = RewardCalculator {
@@ -767,7 +821,7 @@ fn test_validator_reward_weight_by_stake() {
         num_blocks_per_year: 50,
         epoch_length,
         protocol_reward_rate: Ratio::new(1, 10),
-        protocol_treasury_account: "near".parse().unwrap(),
+        protocol_treasury_account: "near".parse::<AccountId>().unwrap(),
         online_min_threshold: Ratio::new(90, 100),
         online_max_threshold: Ratio::new(99, 100),
         num_seconds_per_year: 50,
@@ -807,22 +861,22 @@ fn test_validator_reward_weight_by_stake() {
     );
     let mut validator_online_ratio = HashMap::new();
     validator_online_ratio.insert(
-        "test1".parse().unwrap(),
+        "test1".parse::<AccountId>().unwrap(),
         BlockChunkValidatorStats {
             block_stats: ValidatorStats { produced: 1, expected: 1 },
             chunk_stats: ValidatorStats { produced: 1, expected: 1 },
         },
     );
     validator_online_ratio.insert(
-        "test2".parse().unwrap(),
+        "test2".parse::<AccountId>().unwrap(),
         BlockChunkValidatorStats {
             block_stats: ValidatorStats { produced: 1, expected: 1 },
             chunk_stats: ValidatorStats { produced: 1, expected: 1 },
         },
     );
     let mut validators_stakes = HashMap::new();
-    validators_stakes.insert("test1".parse().unwrap(), stake_amount1);
-    validators_stakes.insert("test2".parse().unwrap(), stake_amount2);
+    validators_stakes.insert("test1".parse::<AccountId>().unwrap(), stake_amount1);
+    validators_stakes.insert("test2".parse::<AccountId>().unwrap(), stake_amount2);
     let (validator_reward, inflation) = reward_calculator.calculate_reward(
         validator_online_ratio,
         &validators_stakes,
@@ -831,10 +885,10 @@ fn test_validator_reward_weight_by_stake() {
         PROTOCOL_VERSION,
         epoch_length * NUM_NS_IN_SECOND,
     );
-    let test1_reward = *validator_reward.get("test1").unwrap();
-    let test2_reward = *validator_reward.get("test2").unwrap();
+    let test1_reward = *validator_reward.get(&"test1".parse::<AccountId>().unwrap()).unwrap();
+    let test2_reward = *validator_reward.get(&"test2".parse::<AccountId>().unwrap()).unwrap();
     assert_eq!(test1_reward, test2_reward * 2);
-    let protocol_reward = *validator_reward.get("near").unwrap();
+    let protocol_reward = *validator_reward.get(&"near".parse::<AccountId>().unwrap()).unwrap();
 
     let epoch_info = epoch_manager.get_epoch_info(&EpochId(h[2])).unwrap();
     check_validators(
@@ -845,17 +899,17 @@ fn test_validator_reward_weight_by_stake() {
     check_stake_change(
         &epoch_info,
         vec![
-            ("test1".parse().unwrap(), stake_amount1 + test1_reward),
-            ("test2".parse().unwrap(), stake_amount2 + test2_reward),
+            ("test1".parse::<AccountId>().unwrap(), stake_amount1 + test1_reward),
+            ("test2".parse::<AccountId>().unwrap(), stake_amount2 + test2_reward),
         ],
     );
     check_kickout(&epoch_info, &[]);
     check_reward(
         &epoch_info,
         vec![
-            ("test1".parse().unwrap(), test1_reward),
-            ("test2".parse().unwrap(), test2_reward),
-            ("near".parse().unwrap(), protocol_reward),
+            ("test1".parse::<AccountId>().unwrap(), test1_reward),
+            ("test2".parse::<AccountId>().unwrap(), test2_reward),
+            ("near".parse::<AccountId>().unwrap(), protocol_reward),
         ],
     );
     assert_eq!(epoch_info.minted_amount(), inflation);
@@ -864,8 +918,10 @@ fn test_validator_reward_weight_by_stake() {
 #[test]
 fn test_reward_multiple_shards() {
     let stake_amount = 1_000_000;
-    let validators =
-        vec![("test1".parse().unwrap(), stake_amount), ("test2".parse().unwrap(), stake_amount)];
+    let validators = vec![
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+    ];
     let epoch_length = 10;
     let total_supply = stake_amount * validators.len() as u128;
     let reward_calculator = RewardCalculator {
@@ -873,7 +929,7 @@ fn test_reward_multiple_shards() {
         num_blocks_per_year: 1_000_000,
         epoch_length,
         protocol_reward_rate: Ratio::new(1, 10),
-        protocol_treasury_account: "near".parse().unwrap(),
+        protocol_treasury_account: "near".parse::<AccountId>().unwrap(),
         online_min_threshold: Ratio::new(90, 100),
         online_max_threshold: Ratio::new(99, 100),
         num_seconds_per_year: 1_000_000,
@@ -915,7 +971,7 @@ fn test_reward_multiple_shards() {
                 let expected_chunk_producer = epoch_manager
                     .get_chunk_producer_info(&epoch_id, height, shard_index as u64)
                     .unwrap();
-                if expected_chunk_producer.account_id().as_ref() == "test1"
+                if expected_chunk_producer.account_id().as_str() == "test1"
                     && epoch_id == init_epoch_id
                 {
                     expected_chunks += 1;
@@ -932,15 +988,15 @@ fn test_reward_multiple_shards() {
     }
     let mut validator_online_ratio = HashMap::new();
     validator_online_ratio.insert(
-        "test2".parse().unwrap(),
+        "test2".parse::<AccountId>().unwrap(),
         BlockChunkValidatorStats {
             block_stats: ValidatorStats { produced: 1, expected: 1 },
             chunk_stats: ValidatorStats { produced: 1, expected: 1 },
         },
     );
     let mut validators_stakes = HashMap::new();
-    validators_stakes.insert("test1".parse().unwrap(), stake_amount);
-    validators_stakes.insert("test2".parse().unwrap(), stake_amount);
+    validators_stakes.insert("test1".parse::<AccountId>().unwrap(), stake_amount);
+    validators_stakes.insert("test2".parse::<AccountId>().unwrap(), stake_amount);
     let (validator_reward, inflation) = reward_calculator.calculate_reward(
         validator_online_ratio,
         &validators_stakes,
@@ -949,8 +1005,8 @@ fn test_reward_multiple_shards() {
         PROTOCOL_VERSION,
         epoch_length * NUM_NS_IN_SECOND,
     );
-    let test2_reward = *validator_reward.get("test2").unwrap();
-    let protocol_reward = *validator_reward.get("near").unwrap();
+    let test2_reward = *validator_reward.get(&"test2".parse::<AccountId>().unwrap()).unwrap();
+    let protocol_reward = *validator_reward.get(&"near".parse::<AccountId>().unwrap()).unwrap();
     let epoch_infos: Vec<_> =
         h.iter().filter_map(|x| epoch_manager.get_epoch_info(&EpochId(*x)).ok()).collect();
     let epoch_info = &epoch_infos[1];
@@ -959,8 +1015,8 @@ fn test_reward_multiple_shards() {
     check_stake_change(
         epoch_info,
         vec![
-            ("test1".parse().unwrap(), 0),
-            ("test2".parse().unwrap(), stake_amount + test2_reward),
+            ("test1".parse::<AccountId>().unwrap(), 0),
+            ("test2".parse::<AccountId>().unwrap(), stake_amount + test2_reward),
         ],
     );
     check_kickout(
@@ -972,7 +1028,10 @@ fn test_reward_multiple_shards() {
     );
     check_reward(
         epoch_info,
-        vec![("test2".parse().unwrap(), test2_reward), ("near".parse().unwrap(), protocol_reward)],
+        vec![
+            ("test2".parse::<AccountId>().unwrap(), test2_reward),
+            ("near".parse::<AccountId>().unwrap(), protocol_reward),
+        ],
     );
     assert_eq!(epoch_info.minted_amount(), inflation);
 }
@@ -980,19 +1039,27 @@ fn test_reward_multiple_shards() {
 #[test]
 fn test_unstake_and_then_change_stake() {
     let amount_staked = 1_000_000;
-    let validators =
-        vec![("test1".parse().unwrap(), amount_staked), ("test2".parse().unwrap(), amount_staked)];
+    let validators = vec![
+        ("test1".parse::<AccountId>().unwrap(), amount_staked),
+        ("test2".parse::<AccountId>().unwrap(), amount_staked),
+    ];
     let mut epoch_manager = setup_default_epoch_manager(validators, 2, 1, 2, 0, 90, 60);
     let h = hash_range(8);
     record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
     // test1 unstakes in epoch 1, and should be kicked out in epoch 3 (validators stored at h2).
-    record_block(&mut epoch_manager, h[0], h[1], 1, vec![stake("test1".parse().unwrap(), 0)]);
+    record_block(
+        &mut epoch_manager,
+        h[0],
+        h[1],
+        1,
+        vec![stake("test1".parse::<AccountId>().unwrap(), 0)],
+    );
     record_block(
         &mut epoch_manager,
         h[1],
         h[2],
         2,
-        vec![stake("test1".parse().unwrap(), amount_staked)],
+        vec![stake("test1".parse::<AccountId>().unwrap(), amount_staked)],
     );
     record_block(&mut epoch_manager, h[2], h[3], 3, vec![]);
     let epoch_id = epoch_manager.get_next_epoch_id(&h[3]).unwrap();
@@ -1002,15 +1069,18 @@ fn test_unstake_and_then_change_stake() {
     check_fishermen(&epoch_info, &[]);
     check_stake_change(
         &epoch_info,
-        vec![("test1".parse().unwrap(), amount_staked), ("test2".parse().unwrap(), amount_staked)],
+        vec![
+            ("test1".parse::<AccountId>().unwrap(), amount_staked),
+            ("test2".parse::<AccountId>().unwrap(), amount_staked),
+        ],
     );
     check_kickout(&epoch_info, &[]);
     check_reward(
         &epoch_info,
         vec![
-            ("test1".parse().unwrap(), 0),
-            ("test2".parse().unwrap(), 0),
-            ("near".parse().unwrap(), 0),
+            ("test1".parse::<AccountId>().unwrap(), 0),
+            ("test2".parse::<AccountId>().unwrap(), 0),
+            ("near".parse::<AccountId>().unwrap(), 0),
         ],
     );
 }
@@ -1021,9 +1091,9 @@ fn test_unstake_and_then_change_stake() {
 fn test_expected_chunks() {
     let stake_amount = 1_000_000;
     let validators = vec![
-        ("test1".parse().unwrap(), stake_amount),
-        ("test2".parse().unwrap(), stake_amount),
-        ("test3".parse().unwrap(), stake_amount),
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+        ("test3".parse::<AccountId>().unwrap(), stake_amount),
     ];
     let epoch_length = 20;
     let total_supply = stake_amount * validators.len() as u128;
@@ -1096,9 +1166,9 @@ fn test_expected_chunks() {
 fn test_expected_chunks_prev_block_not_produced() {
     let stake_amount = 1_000_000;
     let validators = vec![
-        ("test1".parse().unwrap(), stake_amount),
-        ("test2".parse().unwrap(), stake_amount),
-        ("test3".parse().unwrap(), stake_amount),
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+        ("test3".parse::<AccountId>().unwrap(), stake_amount),
     ];
     let epoch_length = 50;
     let total_supply = stake_amount * validators.len() as u128;
@@ -1165,7 +1235,7 @@ fn test_expected_chunks_prev_block_not_produced() {
     assert_eq!(
         epoch_info.validator_kickout(),
         &[(
-            "test1".parse().unwrap(),
+            "test1".parse::<AccountId>().unwrap(),
             ValidatorKickoutReason::NotEnoughBlocks { produced: 0, expected }
         )]
         .into_iter()
@@ -1193,8 +1263,10 @@ fn update_tracker(
 #[test]
 fn test_epoch_info_aggregator() {
     let stake_amount = 1_000_000;
-    let validators =
-        vec![("test1".parse().unwrap(), stake_amount), ("test2".parse().unwrap(), stake_amount)];
+    let validators = vec![
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+    ];
     let epoch_length = 5;
     let mut em = setup_epoch_manager(
         validators,
@@ -1238,8 +1310,10 @@ fn test_epoch_info_aggregator() {
 #[test]
 fn test_epoch_info_aggregator_data_loss() {
     let stake_amount = 1_000_000;
-    let validators =
-        vec![("test1".parse().unwrap(), stake_amount), ("test2".parse().unwrap(), stake_amount)];
+    let validators = vec![
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+    ];
     let epoch_length = 5;
     let mut em = setup_epoch_manager(
         validators,
@@ -1254,11 +1328,29 @@ fn test_epoch_info_aggregator_data_loss() {
     );
     let h = hash_range(6);
     record_block(&mut em, Default::default(), h[0], 0, vec![]);
-    record_block(&mut em, h[0], h[1], 1, vec![stake("test1".parse().unwrap(), stake_amount - 10)]);
-    record_block(&mut em, h[1], h[3], 3, vec![stake("test2".parse().unwrap(), stake_amount + 10)]);
+    record_block(
+        &mut em,
+        h[0],
+        h[1],
+        1,
+        vec![stake("test1".parse::<AccountId>().unwrap(), stake_amount - 10)],
+    );
+    record_block(
+        &mut em,
+        h[1],
+        h[3],
+        3,
+        vec![stake("test2".parse::<AccountId>().unwrap(), stake_amount + 10)],
+    );
     assert_eq!(h[1], em.epoch_info_aggregator.last_block_hash);
     em.epoch_info_aggregator = EpochInfoAggregator::default();
-    record_block(&mut em, h[3], h[5], 5, vec![stake("test1".parse().unwrap(), stake_amount - 1)]);
+    record_block(
+        &mut em,
+        h[3],
+        h[5],
+        5,
+        vec![stake("test1".parse::<AccountId>().unwrap(), stake_amount - 1)],
+    );
     assert_eq!(h[3], em.epoch_info_aggregator.last_block_hash);
     let epoch_id = em.get_epoch_id(&h[5]).unwrap();
     let epoch_info = em.get_epoch_info(&epoch_id).unwrap();
@@ -1269,8 +1361,8 @@ fn test_epoch_info_aggregator_data_loss() {
     assert_eq!(
         aggregator.all_proposals,
         vec![
-            stake("test1".parse().unwrap(), stake_amount - 1),
-            stake("test2".parse().unwrap(), stake_amount + 10)
+            stake("test1".parse::<AccountId>().unwrap(), stake_amount - 1),
+            stake("test2".parse::<AccountId>().unwrap(), stake_amount + 10)
         ]
         .into_iter()
         .map(|p| (p.account_id().clone(), p))
@@ -1282,8 +1374,10 @@ fn test_epoch_info_aggregator_data_loss() {
 #[test]
 fn test_epoch_info_aggregator_reorg_past_final_block() {
     let stake_amount = 1_000_000;
-    let validators =
-        vec![("test1".parse().unwrap(), stake_amount), ("test2".parse().unwrap(), stake_amount)];
+    let validators = vec![
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+    ];
     let epoch_length = 6;
     let mut em = setup_epoch_manager(
         validators,
@@ -1306,7 +1400,7 @@ fn test_epoch_info_aggregator_reorg_past_final_block() {
         h[3],
         h[1],
         3,
-        vec![stake("test1".parse().unwrap(), stake_amount - 1)],
+        vec![stake("test1".parse::<AccountId>().unwrap(), stake_amount - 1)],
     );
     record_block_with_final_block_hash(&mut em, h[3], h[4], h[3], 4, vec![]);
     record_block_with_final_block_hash(&mut em, h[2], h[5], h[1], 5, vec![]);
@@ -1322,8 +1416,10 @@ fn test_epoch_info_aggregator_reorg_past_final_block() {
 #[test]
 fn test_epoch_info_aggregator_reorg_beginning_of_epoch() {
     let stake_amount = 1_000_000;
-    let validators =
-        vec![("test1".parse().unwrap(), stake_amount), ("test2".parse().unwrap(), stake_amount)];
+    let validators = vec![
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+    ];
     let epoch_length = 4;
     let mut em = setup_epoch_manager(
         validators,
@@ -1341,14 +1437,20 @@ fn test_epoch_info_aggregator_reorg_beginning_of_epoch() {
     for i in 1..5 {
         record_block(&mut em, h[i - 1], h[i], i as u64, vec![]);
     }
-    record_block(&mut em, h[4], h[5], 5, vec![stake("test1".parse().unwrap(), stake_amount - 1)]);
+    record_block(
+        &mut em,
+        h[4],
+        h[5],
+        5,
+        vec![stake("test1".parse::<AccountId>().unwrap(), stake_amount - 1)],
+    );
     record_block_with_final_block_hash(
         &mut em,
         h[5],
         h[6],
         h[4],
         6,
-        vec![stake("test2".parse().unwrap(), stake_amount - 100)],
+        vec![stake("test2".parse::<AccountId>().unwrap(), stake_amount - 100)],
     );
     // reorg
     record_block(&mut em, h[4], h[7], 7, vec![]);
@@ -1371,7 +1473,7 @@ fn count_missing_blocks(
     let mut result = ValidatorStats { produced: 0, expected: 0 };
     for h in height_range {
         let block_producer = epoch_manager.get_block_producer_info(epoch_id, h).unwrap();
-        if validator == block_producer.account_id().as_ref() {
+        if validator == block_producer.account_id().as_str() {
             if produced_heights.contains(&h) {
                 result.produced += 1;
             }
@@ -1384,8 +1486,10 @@ fn count_missing_blocks(
 #[test]
 fn test_num_missing_blocks() {
     let stake_amount = 1_000_000;
-    let validators =
-        vec![("test1".parse().unwrap(), stake_amount), ("test2".parse().unwrap(), stake_amount)];
+    let validators = vec![
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+    ];
     let epoch_length = 2;
     let mut em = setup_epoch_manager(
         validators,
@@ -1404,11 +1508,13 @@ fn test_num_missing_blocks() {
     record_block(&mut em, h[1], h[3], 3, vec![]);
     let epoch_id = em.get_epoch_id(&h[1]).unwrap();
     assert_eq!(
-        em.get_num_validator_blocks(&epoch_id, &h[3], &"test1".parse().unwrap()).unwrap(),
+        em.get_num_validator_blocks(&epoch_id, &h[3], &"test1".parse::<AccountId>().unwrap())
+            .unwrap(),
         count_missing_blocks(&mut em, &epoch_id, 1..4, &[1, 3], "test1"),
     );
     assert_eq!(
-        em.get_num_validator_blocks(&epoch_id, &h[3], &"test2".parse().unwrap()).unwrap(),
+        em.get_num_validator_blocks(&epoch_id, &h[3], &"test2".parse::<AccountId>().unwrap())
+            .unwrap(),
         count_missing_blocks(&mut em, &epoch_id, 1..4, &[1, 3], "test2"),
     );
 
@@ -1417,11 +1523,13 @@ fn test_num_missing_blocks() {
     let epoch_id = em.get_epoch_id(&h[4]).unwrap();
     // Block 4 is first block after genesis and starts new epoch, but we actually count how many missed blocks have happened since block 0.
     assert_eq!(
-        em.get_num_validator_blocks(&epoch_id, &h[4], &"test1".parse().unwrap()).unwrap(),
+        em.get_num_validator_blocks(&epoch_id, &h[4], &"test1".parse::<AccountId>().unwrap())
+            .unwrap(),
         count_missing_blocks(&mut em, &epoch_id, 1..5, &[4], "test1"),
     );
     assert_eq!(
-        em.get_num_validator_blocks(&epoch_id, &h[4], &"test2".parse().unwrap()).unwrap(),
+        em.get_num_validator_blocks(&epoch_id, &h[4], &"test2".parse::<AccountId>().unwrap())
+            .unwrap(),
         count_missing_blocks(&mut em, &epoch_id, 1..5, &[4], "test2"),
     );
     record_block(&mut em, h[4], h[5], 5, vec![]);
@@ -1429,7 +1537,8 @@ fn test_num_missing_blocks() {
     let epoch_id = em.get_epoch_id(&h[7]).unwrap();
     // The next epoch started after 5 with 6, and test2 missed their slot from perspective of block 7.
     assert_eq!(
-        em.get_num_validator_blocks(&epoch_id, &h[7], &"test2".parse().unwrap()).unwrap(),
+        em.get_num_validator_blocks(&epoch_id, &h[7], &"test2".parse::<AccountId>().unwrap())
+            .unwrap(),
         count_missing_blocks(&mut em, &epoch_id, 6..8, &[7], "test2"),
     );
 }
@@ -1439,8 +1548,10 @@ fn test_num_missing_blocks() {
 #[test]
 fn test_chunk_validator_kickout() {
     let stake_amount = 1_000_000;
-    let validators =
-        vec![("test1".parse().unwrap(), stake_amount), ("test2".parse().unwrap(), stake_amount)];
+    let validators = vec![
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+    ];
     let epoch_length = 10;
     let total_supply = stake_amount * validators.len() as u128;
     let mut em = setup_epoch_manager(
@@ -1515,7 +1626,7 @@ fn test_chunk_validator_kickout() {
     assert_eq!(
         last_epoch_info.unwrap().validator_kickout(),
         &[(
-            "test1".parse().unwrap(),
+            "test1".parse::<AccountId>().unwrap(),
             ValidatorKickoutReason::NotEnoughChunks { produced: 0, expected }
         )]
         .into_iter()
@@ -1526,19 +1637,27 @@ fn test_chunk_validator_kickout() {
 #[test]
 fn test_compare_epoch_id() {
     let amount_staked = 1_000_000;
-    let validators =
-        vec![("test1".parse().unwrap(), amount_staked), ("test2".parse().unwrap(), amount_staked)];
+    let validators = vec![
+        ("test1".parse::<AccountId>().unwrap(), amount_staked),
+        ("test2".parse::<AccountId>().unwrap(), amount_staked),
+    ];
     let mut epoch_manager = setup_default_epoch_manager(validators, 2, 1, 2, 0, 90, 60);
     let h = hash_range(8);
     record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
     // test1 unstakes in epoch 1, and should be kicked out in epoch 3 (validators stored at h2).
-    record_block(&mut epoch_manager, h[0], h[1], 1, vec![stake("test1".parse().unwrap(), 0)]);
+    record_block(
+        &mut epoch_manager,
+        h[0],
+        h[1],
+        1,
+        vec![stake("test1".parse::<AccountId>().unwrap(), 0)],
+    );
     record_block(
         &mut epoch_manager,
         h[1],
         h[2],
         2,
-        vec![stake("test1".parse().unwrap(), amount_staked)],
+        vec![stake("test1".parse::<AccountId>().unwrap(), amount_staked)],
     );
     record_block(&mut epoch_manager, h[2], h[3], 3, vec![]);
     let epoch_id0 = epoch_manager.get_epoch_id(&h[0]).unwrap();
@@ -1557,10 +1676,10 @@ fn test_fishermen() {
     let stake_amount = 1_000_000;
     let fishermen_threshold = 100;
     let validators = vec![
-        ("test1".parse().unwrap(), stake_amount),
-        ("test2".parse().unwrap(), stake_amount),
-        ("test3".parse().unwrap(), fishermen_threshold),
-        ("test4".parse().unwrap(), fishermen_threshold / 2),
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+        ("test3".parse::<AccountId>().unwrap(), fishermen_threshold),
+        ("test4".parse::<AccountId>().unwrap(), fishermen_threshold / 2),
     ];
     let epoch_length = 4;
     let em = setup_epoch_manager(
@@ -1580,10 +1699,10 @@ fn test_fishermen() {
     check_stake_change(
         &epoch_info,
         vec![
-            ("test1".parse().unwrap(), stake_amount),
-            ("test2".parse().unwrap(), stake_amount),
-            ("test3".parse().unwrap(), fishermen_threshold),
-            ("test4".parse().unwrap(), 0),
+            ("test1".parse::<AccountId>().unwrap(), stake_amount),
+            ("test2".parse::<AccountId>().unwrap(), stake_amount),
+            ("test3".parse::<AccountId>().unwrap(), fishermen_threshold),
+            ("test4".parse::<AccountId>().unwrap(), 0),
         ],
     );
     check_kickout(&epoch_info, &[]);
@@ -1594,9 +1713,9 @@ fn test_fishermen_unstake() {
     let stake_amount = 1_000_000;
     let fishermen_threshold = 100;
     let validators = vec![
-        ("test1".parse().unwrap(), stake_amount),
-        ("test2".parse().unwrap(), fishermen_threshold),
-        ("test3".parse().unwrap(), fishermen_threshold),
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), fishermen_threshold),
+        ("test3".parse::<AccountId>().unwrap(), fishermen_threshold),
     ];
     let mut em = setup_epoch_manager(
         validators,
@@ -1612,8 +1731,8 @@ fn test_fishermen_unstake() {
     let h = hash_range(5);
     record_block(&mut em, CryptoHash::default(), h[0], 0, vec![]);
     // fishermen unstake
-    record_block(&mut em, h[0], h[1], 1, vec![stake("test2".parse().unwrap(), 0)]);
-    record_block(&mut em, h[1], h[2], 2, vec![stake("test3".parse().unwrap(), 1)]);
+    record_block(&mut em, h[0], h[1], 1, vec![stake("test2".parse::<AccountId>().unwrap(), 0)]);
+    record_block(&mut em, h[1], h[2], 2, vec![stake("test3".parse::<AccountId>().unwrap(), 1)]);
 
     let epoch_info = em.get_epoch_info(&EpochId(h[2])).unwrap();
     check_validators(&epoch_info, &[("test1", stake_amount)]);
@@ -1621,21 +1740,23 @@ fn test_fishermen_unstake() {
     check_stake_change(
         &epoch_info,
         vec![
-            ("test1".parse().unwrap(), stake_amount),
-            ("test2".parse().unwrap(), 0),
-            ("test3".parse().unwrap(), 0),
+            ("test1".parse::<AccountId>().unwrap(), stake_amount),
+            ("test2".parse::<AccountId>().unwrap(), 0),
+            ("test3".parse::<AccountId>().unwrap(), 0),
         ],
     );
     let kickout = epoch_info.validator_kickout();
-    assert_eq!(kickout.get("test2").unwrap(), &ValidatorKickoutReason::Unstaked);
-    matches!(kickout.get("test3"), Some(ValidatorKickoutReason::NotEnoughStake { .. }));
+    assert_eq!(kickout.get(&"test2".parse::<AccountId>().unwrap()).unwrap(), &ValidatorKickoutReason::Unstaked);
+    matches!(kickout.get(&"test3".parse::<AccountId>().unwrap()), Some(ValidatorKickoutReason::NotEnoughStake { .. }));
 }
 
 #[test]
 fn test_validator_consistency() {
     let stake_amount = 1_000;
-    let validators =
-        vec![("test1".parse().unwrap(), stake_amount), ("test2".parse().unwrap(), stake_amount)];
+    let validators = vec![
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+    ];
     let mut epoch_manager = setup_default_epoch_manager(validators, 2, 1, 1, 0, 90, 60);
     let h = hash_range(5);
     record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
@@ -1660,8 +1781,10 @@ fn test_validator_consistency() {
 #[test]
 fn test_finalize_epoch_large_epoch_length() {
     let stake_amount = 1_000;
-    let validators =
-        vec![("test1".parse().unwrap(), stake_amount), ("test2".parse().unwrap(), stake_amount)];
+    let validators = vec![
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+    ];
     let mut epoch_manager =
         setup_default_epoch_manager(validators, (BLOCK_CACHE_SIZE + 1) as u64, 1, 2, 0, 90, 60);
     let h = hash_range(BLOCK_CACHE_SIZE + 2);
@@ -1672,13 +1795,16 @@ fn test_finalize_epoch_large_epoch_length() {
     let epoch_info = epoch_manager.get_epoch_info(&EpochId(h[BLOCK_CACHE_SIZE + 1])).unwrap();
     assert_eq!(
         epoch_info.validators_iter().map(|v| v.account_and_stake()).collect::<Vec<_>>(),
-        vec![("test1".parse().unwrap(), stake_amount), ("test2".parse().unwrap(), stake_amount)],
+        vec![
+            ("test1".parse::<AccountId>().unwrap(), stake_amount),
+            ("test2".parse::<AccountId>().unwrap(), stake_amount)
+        ],
     );
     assert_eq!(
         epoch_info.stake_change(),
         &change_stake(vec![
-            ("test1".parse().unwrap(), stake_amount),
-            ("test2".parse().unwrap(), stake_amount)
+            ("test1".parse::<AccountId>().unwrap(), stake_amount),
+            ("test2".parse::<AccountId>().unwrap(), stake_amount)
         ]),
     );
     assert_eq!(
@@ -1692,9 +1818,9 @@ fn test_finalize_epoch_large_epoch_length() {
 fn test_kickout_set() {
     let stake_amount = 1_000_000;
     let validators = vec![
-        ("test1".parse().unwrap(), stake_amount),
-        ("test2".parse().unwrap(), 0),
-        ("test3".parse().unwrap(), 10),
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), 0),
+        ("test3".parse::<AccountId>().unwrap(), 10),
     ];
     // have two seats to that 500 would be the threshold
     let mut epoch_manager = setup_default_epoch_manager(validators, 2, 1, 2, 0, 90, 60);
@@ -1705,20 +1831,26 @@ fn test_kickout_set() {
         h[0],
         h[1],
         1,
-        vec![stake("test2".parse().unwrap(), stake_amount)],
+        vec![stake("test2".parse::<AccountId>().unwrap(), stake_amount)],
     );
-    record_block(&mut epoch_manager, h[1], h[2], 2, vec![stake("test2".parse().unwrap(), 0)]);
+    record_block(
+        &mut epoch_manager,
+        h[1],
+        h[2],
+        2,
+        vec![stake("test2".parse::<AccountId>().unwrap(), 0)],
+    );
     let epoch_info1 = epoch_manager.get_epoch_info(&EpochId(h[2])).unwrap();
     assert_eq!(
         epoch_info1.validators_iter().map(|r| r.account_id().clone()).collect::<Vec<_>>(),
-        vec!["test1".parse().unwrap()]
+        vec!["test1".parse::<AccountId>().unwrap()]
     );
     assert_eq!(
         epoch_info1.stake_change().clone(),
         change_stake(vec![
-            ("test1".parse().unwrap(), stake_amount),
-            ("test2".parse().unwrap(), 0),
-            ("test3".parse().unwrap(), 10)
+            ("test1".parse::<AccountId>().unwrap(), stake_amount),
+            ("test2".parse::<AccountId>().unwrap(), 0),
+            ("test3".parse::<AccountId>().unwrap(), 10)
         ])
     );
     assert!(epoch_info1.validator_kickout().is_empty());
@@ -1727,7 +1859,7 @@ fn test_kickout_set() {
         h[2],
         h[3],
         3,
-        vec![stake("test2".parse().unwrap(), stake_amount)],
+        vec![stake("test2".parse::<AccountId>().unwrap(), stake_amount)],
     );
     record_block(&mut epoch_manager, h[3], h[4], 4, vec![]);
     let epoch_info = epoch_manager.get_epoch_info(&EpochId(h[4])).unwrap();
@@ -1737,9 +1869,9 @@ fn test_kickout_set() {
     check_stake_change(
         &epoch_info,
         vec![
-            ("test1".parse().unwrap(), stake_amount),
-            ("test2".parse().unwrap(), stake_amount),
-            ("test3".parse().unwrap(), 10),
+            ("test1".parse::<AccountId>().unwrap(), stake_amount),
+            ("test2".parse::<AccountId>().unwrap(), stake_amount),
+            ("test3".parse::<AccountId>().unwrap(), 10),
         ],
     );
 }
@@ -1748,14 +1880,20 @@ fn test_kickout_set() {
 fn test_epoch_height_increase() {
     let stake_amount = 1_000;
     let validators = vec![
-        ("test1".parse().unwrap(), stake_amount),
-        ("test2".parse().unwrap(), stake_amount),
-        ("test3".parse().unwrap(), stake_amount),
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+        ("test3".parse::<AccountId>().unwrap(), stake_amount),
     ];
     let mut epoch_manager = setup_default_epoch_manager(validators, 1, 1, 3, 0, 90, 60);
     let h = hash_range(5);
     record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
-    record_block(&mut epoch_manager, h[0], h[2], 2, vec![stake("test1".parse().unwrap(), 223)]);
+    record_block(
+        &mut epoch_manager,
+        h[0],
+        h[2],
+        2,
+        vec![stake("test1".parse::<AccountId>().unwrap(), 223)],
+    );
     record_block(&mut epoch_manager, h[2], h[4], 4, vec![]);
 
     let epoch_info2 = epoch_manager.get_epoch_info(&EpochId(h[2])).unwrap();
@@ -1768,21 +1906,27 @@ fn test_epoch_height_increase() {
 fn test_unstake_slash() {
     let stake_amount = 1_000;
     let validators = vec![
-        ("test1".parse().unwrap(), stake_amount),
-        ("test2".parse().unwrap(), stake_amount),
-        ("test3".parse().unwrap(), stake_amount),
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+        ("test3".parse::<AccountId>().unwrap(), stake_amount),
     ];
     let mut epoch_manager = setup_default_epoch_manager(validators, 1, 1, 3, 0, 90, 60);
     let h = hash_range(9);
     record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
-    record_block(&mut epoch_manager, h[0], h[1], 1, vec![stake("test1".parse().unwrap(), 0)]);
+    record_block(
+        &mut epoch_manager,
+        h[0],
+        h[1],
+        1,
+        vec![stake("test1".parse::<AccountId>().unwrap(), 0)],
+    );
     record_block_with_slashes(
         &mut epoch_manager,
         h[1],
         h[2],
         2,
         vec![],
-        vec![SlashedValidator::new("test1".parse().unwrap(), false)],
+        vec![SlashedValidator::new("test1".parse::<AccountId>().unwrap(), false)],
     );
     record_block(&mut epoch_manager, h[2], h[3], 3, vec![]);
     record_block(
@@ -1790,7 +1934,7 @@ fn test_unstake_slash() {
         h[3],
         h[4],
         4,
-        vec![stake("test1".parse().unwrap(), stake_amount)],
+        vec![stake("test1".parse::<AccountId>().unwrap(), stake_amount)],
     );
 
     let epoch_info1 = epoch_manager.get_epoch_info(&EpochId(h[1])).unwrap();
@@ -1798,19 +1942,19 @@ fn test_unstake_slash() {
     let epoch_info3 = epoch_manager.get_epoch_info(&EpochId(h[3])).unwrap();
     let epoch_info4 = epoch_manager.get_epoch_info(&EpochId(h[4])).unwrap();
     assert_eq!(
-        epoch_info1.validator_kickout().get("test1"),
+        epoch_info1.validator_kickout().get(&"test1".parse::<AccountId>().unwrap()),
         Some(&ValidatorKickoutReason::Unstaked)
     );
     assert_eq!(
-        epoch_info2.validator_kickout().get("test1"),
+        epoch_info2.validator_kickout().get(&"test1".parse::<AccountId>().unwrap()),
         Some(&ValidatorKickoutReason::Slashed)
     );
     assert_eq!(
-        epoch_info3.validator_kickout().get("test1"),
+        epoch_info3.validator_kickout().get(&"test1".parse::<AccountId>().unwrap()),
         Some(&ValidatorKickoutReason::Slashed)
     );
     assert!(epoch_info4.validator_kickout().is_empty());
-    assert!(epoch_info4.account_is_validator(&"test1".parse().unwrap()));
+    assert!(epoch_info4.account_is_validator(&"test1".parse::<AccountId>().unwrap()));
 }
 
 #[test]
@@ -1818,9 +1962,9 @@ fn test_unstake_slash() {
 fn test_no_unstake_slash() {
     let stake_amount = 1_000;
     let validators = vec![
-        ("test1".parse().unwrap(), stake_amount),
-        ("test2".parse().unwrap(), stake_amount),
-        ("test3".parse().unwrap(), stake_amount),
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+        ("test3".parse::<AccountId>().unwrap(), stake_amount),
     ];
     let mut epoch_manager = setup_default_epoch_manager(validators, 1, 1, 3, 0, 90, 60);
     let h = hash_range(9);
@@ -1831,7 +1975,7 @@ fn test_no_unstake_slash() {
         h[1],
         1,
         vec![],
-        vec![SlashedValidator::new("test1".parse().unwrap(), false)],
+        vec![SlashedValidator::new("test1".parse::<AccountId>().unwrap(), false)],
     );
     record_block(&mut epoch_manager, h[1], h[2], 2, vec![]);
     record_block(&mut epoch_manager, h[2], h[3], 3, vec![]);
@@ -1840,7 +1984,7 @@ fn test_no_unstake_slash() {
         h[3],
         h[4],
         4,
-        vec![stake("test1".parse().unwrap(), stake_amount)],
+        vec![stake("test1".parse::<AccountId>().unwrap(), stake_amount)],
     );
 
     let epoch_info1 = epoch_manager.get_epoch_info(&EpochId(h[1])).unwrap();
@@ -1848,19 +1992,19 @@ fn test_no_unstake_slash() {
     let epoch_info3 = epoch_manager.get_epoch_info(&EpochId(h[3])).unwrap();
     let epoch_info4 = epoch_manager.get_epoch_info(&EpochId(h[4])).unwrap();
     assert_eq!(
-        epoch_info1.validator_kickout().get("test1"),
+        epoch_info1.validator_kickout().get(&"test1".parse::<AccountId>().unwrap()),
         Some(&ValidatorKickoutReason::Slashed)
     );
     assert_eq!(
-        epoch_info2.validator_kickout().get("test1"),
+        epoch_info2.validator_kickout().get(&"test1".parse::<AccountId>().unwrap()),
         Some(&ValidatorKickoutReason::Slashed)
     );
     assert_eq!(
-        epoch_info3.validator_kickout().get("test1"),
+        epoch_info3.validator_kickout().get(&"test1".parse::<AccountId>().unwrap()),
         Some(&ValidatorKickoutReason::Slashed)
     );
     assert!(epoch_info4.validator_kickout().is_empty());
-    assert!(epoch_info4.account_is_validator(&"test1".parse().unwrap()));
+    assert!(epoch_info4.account_is_validator(&"test1".parse::<AccountId>().unwrap()));
 }
 
 #[test]
@@ -1868,14 +2012,20 @@ fn test_no_unstake_slash() {
 fn test_slash_non_validator() {
     let stake_amount = 1_000;
     let validators = vec![
-        ("test1".parse().unwrap(), stake_amount),
-        ("test2".parse().unwrap(), stake_amount),
-        ("test3".parse().unwrap(), stake_amount),
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+        ("test3".parse::<AccountId>().unwrap(), stake_amount),
     ];
     let mut epoch_manager = setup_default_epoch_manager(validators, 1, 1, 3, 0, 90, 60);
     let h = hash_range(9);
     record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
-    record_block(&mut epoch_manager, h[0], h[1], 1, vec![stake("test1".parse().unwrap(), 0)]);
+    record_block(
+        &mut epoch_manager,
+        h[0],
+        h[1],
+        1,
+        vec![stake("test1".parse::<AccountId>().unwrap(), 0)],
+    );
     record_block(&mut epoch_manager, h[1], h[2], 2, vec![]);
     record_block_with_slashes(
         &mut epoch_manager,
@@ -1883,7 +2033,7 @@ fn test_slash_non_validator() {
         h[3],
         3,
         vec![],
-        vec![SlashedValidator::new("test1".parse().unwrap(), false)],
+        vec![SlashedValidator::new("test1".parse::<AccountId>().unwrap(), false)],
     );
     record_block(&mut epoch_manager, h[3], h[4], 4, vec![]);
     record_block(
@@ -1891,7 +2041,7 @@ fn test_slash_non_validator() {
         h[4],
         h[5],
         5,
-        vec![stake("test1".parse().unwrap(), stake_amount)],
+        vec![stake("test1".parse::<AccountId>().unwrap(), stake_amount)],
     );
 
     let epoch_info1 = epoch_manager.get_epoch_info(&EpochId(h[1])).unwrap(); // Unstaked
@@ -1900,20 +2050,20 @@ fn test_slash_non_validator() {
     let epoch_info4 = epoch_manager.get_epoch_info(&EpochId(h[4])).unwrap(); // Slashed
     let epoch_info5 = epoch_manager.get_epoch_info(&EpochId(h[5])).unwrap(); // Ok
     assert_eq!(
-        epoch_info1.validator_kickout().get("test1"),
+        epoch_info1.validator_kickout().get(&"test1".parse::<AccountId>().unwrap()),
         Some(&ValidatorKickoutReason::Unstaked)
     );
     assert!(epoch_info2.validator_kickout().is_empty());
     assert_eq!(
-        epoch_info3.validator_kickout().get("test1"),
+        epoch_info3.validator_kickout().get(&"test1".parse::<AccountId>().unwrap()),
         Some(&ValidatorKickoutReason::Slashed)
     );
     assert_eq!(
-        epoch_info4.validator_kickout().get("test1"),
+        epoch_info4.validator_kickout().get(&"test1".parse::<AccountId>().unwrap()),
         Some(&ValidatorKickoutReason::Slashed)
     );
     assert!(epoch_info5.validator_kickout().is_empty());
-    assert!(epoch_info5.account_is_validator(&"test1".parse().unwrap()));
+    assert!(epoch_info5.account_is_validator(&"test1".parse::<AccountId>().unwrap()));
 }
 
 #[test]
@@ -1921,9 +2071,9 @@ fn test_slash_non_validator() {
 fn test_slash_restake() {
     let stake_amount = 1_000;
     let validators = vec![
-        ("test1".parse().unwrap(), stake_amount),
-        ("test2".parse().unwrap(), stake_amount),
-        ("test3".parse().unwrap(), stake_amount),
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+        ("test3".parse::<AccountId>().unwrap(), stake_amount),
     ];
     let mut epoch_manager = setup_default_epoch_manager(validators, 1, 1, 3, 0, 90, 60);
     let h = hash_range(9);
@@ -1934,14 +2084,14 @@ fn test_slash_restake() {
         h[1],
         1,
         vec![],
-        vec![SlashedValidator::new("test1".parse().unwrap(), false)],
+        vec![SlashedValidator::new("test1".parse::<AccountId>().unwrap(), false)],
     );
     record_block(
         &mut epoch_manager,
         h[1],
         h[2],
         2,
-        vec![stake("test1".parse().unwrap(), stake_amount)],
+        vec![stake("test1".parse::<AccountId>().unwrap(), stake_amount)],
     );
     record_block(&mut epoch_manager, h[2], h[3], 3, vec![]);
     record_block(
@@ -1949,21 +2099,21 @@ fn test_slash_restake() {
         h[3],
         h[4],
         4,
-        vec![stake("test1".parse().unwrap(), stake_amount)],
+        vec![stake("test1".parse::<AccountId>().unwrap(), stake_amount)],
     );
     let epoch_info2 = epoch_manager.get_epoch_info(&EpochId(h[2])).unwrap();
-    assert!(epoch_info2.stake_change().get("test1").is_none());
+    assert!(epoch_info2.stake_change().get(&"test1".parse::<AccountId>().unwrap()).is_none());
     let epoch_info4 = epoch_manager.get_epoch_info(&EpochId(h[4])).unwrap();
-    assert!(epoch_info4.stake_change().get("test1").is_some());
+    assert!(epoch_info4.stake_change().get(&"test1".parse::<AccountId>().unwrap()).is_some());
 }
 
 #[test]
 fn test_all_kickout_edge_case() {
     let stake_amount = 1_000;
     let validators = vec![
-        ("test1".parse().unwrap(), stake_amount),
-        ("test2".parse().unwrap(), stake_amount),
-        ("test3".parse().unwrap(), stake_amount),
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+        ("test3".parse::<AccountId>().unwrap(), stake_amount),
     ];
     const EPOCH_LENGTH: u64 = 10;
     let mut epoch_manager = setup_default_epoch_manager(validators, EPOCH_LENGTH, 1, 3, 0, 90, 60);
@@ -1979,7 +2129,7 @@ fn test_all_kickout_edge_case() {
         let block_producer = epoch_info.validator_account_id(block_producer);
         if height < EPOCH_LENGTH {
             // kickout test2 during first epoch
-            if block_producer.as_ref() == "test1" || block_producer.as_ref() == "test3" {
+            if block_producer.as_str() == "test1" || block_producer.as_str() == "test3" {
                 record_block(&mut epoch_manager, prev_block, *curr_block, height, Vec::new());
                 prev_block = *curr_block;
             }
@@ -2018,7 +2168,7 @@ fn check_validators(epoch_info: &EpochInfo, expected_validators: &[(&str, u128)]
     for (v, (account_id, stake)) in
         epoch_info.validators_iter().zip(expected_validators.into_iter())
     {
-        assert_eq!(v.account_id().as_ref(), *account_id);
+        assert_eq!(v.account_id(), *account_id);
         assert_eq!(v.stake(), *stake);
     }
 }
@@ -2026,7 +2176,7 @@ fn check_validators(epoch_info: &EpochInfo, expected_validators: &[(&str, u128)]
 fn check_fishermen(epoch_info: &EpochInfo, expected_fishermen: &[(&str, u128)]) {
     for (v, (account_id, stake)) in epoch_info.fishermen_iter().zip(expected_fishermen.into_iter())
     {
-        assert_eq!(v.account_id().as_ref(), *account_id);
+        assert_eq!(v.account_id(), *account_id);
         assert_eq!(v.stake(), *stake);
     }
 }
@@ -2051,14 +2201,20 @@ fn check_kickout(epoch_info: &EpochInfo, reasons: &[(&str, ValidatorKickoutReaso
 fn test_fisherman_kickout() {
     let stake_amount = 1_000_000;
     let validators = vec![
-        ("test1".parse().unwrap(), stake_amount),
-        ("test2".parse().unwrap(), stake_amount),
-        ("test3".parse().unwrap(), stake_amount),
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+        ("test3".parse::<AccountId>().unwrap(), stake_amount),
     ];
     let mut epoch_manager = setup_default_epoch_manager(validators, 1, 1, 3, 0, 90, 60);
     let h = hash_range(6);
     record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
-    record_block(&mut epoch_manager, h[0], h[1], 1, vec![stake("test1".parse().unwrap(), 148)]);
+    record_block(
+        &mut epoch_manager,
+        h[0],
+        h[1],
+        1,
+        vec![stake("test1".parse::<AccountId>().unwrap(), 148)],
+    );
     // test1 starts as validator,
     // - reduces stake in epoch T, will be fisherman in epoch T+2
     // - Misses a block in epoch T+1, will be kicked out in epoch T+3
@@ -2071,9 +2227,9 @@ fn test_fisherman_kickout() {
     check_stake_change(
         &epoch_info2,
         vec![
-            ("test1".parse().unwrap(), 148),
-            ("test2".parse().unwrap(), stake_amount),
-            ("test3".parse().unwrap(), stake_amount),
+            ("test1".parse::<AccountId>().unwrap(), 148),
+            ("test2".parse::<AccountId>().unwrap(), stake_amount),
+            ("test3".parse::<AccountId>().unwrap(), stake_amount),
         ],
     );
     check_kickout(&epoch_info2, &[]);
@@ -2084,9 +2240,9 @@ fn test_fisherman_kickout() {
     check_stake_change(
         &epoch_info3,
         vec![
-            ("test1".parse().unwrap(), 0),
-            ("test2".parse().unwrap(), stake_amount),
-            ("test3".parse().unwrap(), stake_amount),
+            ("test1".parse::<AccountId>().unwrap(), 0),
+            ("test2".parse::<AccountId>().unwrap(), stake_amount),
+            ("test3".parse::<AccountId>().unwrap(), stake_amount),
         ],
     );
     check_kickout(&epoch_info3, &[("test1", NotEnoughBlocks { produced: 0, expected: 1 })]);
@@ -2105,8 +2261,8 @@ fn test_protocol_version_switch() {
     let config = epoch_config(2, 1, 2, 0, 90, 60, 0);
     let amount_staked = 1_000_000;
     let validators = vec![
-        stake("test1".parse().unwrap(), amount_staked),
-        stake("test2".parse().unwrap(), amount_staked),
+        stake("test1".parse::<AccountId>().unwrap(), amount_staked),
+        stake("test2".parse::<AccountId>().unwrap(), amount_staked),
     ];
     let mut epoch_manager =
         EpochManager::new(store, config, 0, default_reward_calculator(), validators).unwrap();
@@ -2131,8 +2287,8 @@ fn test_protocol_version_switch_with_shard_layout_change() {
     let config = epoch_config_with_production_config(2, 1, 2, 0, 90, 60, 0, true);
     let amount_staked = 1_000_000;
     let validators = vec![
-        stake("test1".parse().unwrap(), amount_staked),
-        stake("test2".parse().unwrap(), amount_staked),
+        stake("test1".parse::<AccountId>().unwrap(), amount_staked),
+        stake("test2".parse::<AccountId>().unwrap(), amount_staked),
     ];
     let new_protocol_version = SimpleNightshade.protocol_version();
     let mut epoch_manager = EpochManager::new(
@@ -2210,8 +2366,8 @@ fn test_protocol_version_switch_with_many_seats() {
     let config = AllEpochConfig::new(false, epoch_config, "test-chain");
     let amount_staked = 1_000_000;
     let validators = vec![
-        stake("test1".parse().unwrap(), amount_staked),
-        stake("test2".parse().unwrap(), amount_staked / 5),
+        stake("test1".parse::<AccountId>().unwrap(), amount_staked),
+        stake("test2".parse::<AccountId>().unwrap(), amount_staked / 5),
     ];
     let mut epoch_manager =
         EpochManager::new(store, config, 0, default_reward_calculator(), validators).unwrap();
@@ -2240,8 +2396,8 @@ fn test_protocol_version_switch_after_switch() {
     let config = epoch_config(epoch_length as u64, 1, 2, 0, 90, 60, 0);
     let amount_staked = 1_000_000;
     let validators = vec![
-        stake("test1".parse().unwrap(), amount_staked),
-        stake("test2".parse().unwrap(), amount_staked),
+        stake("test1".parse::<AccountId>().unwrap(), amount_staked),
+        stake("test2".parse::<AccountId>().unwrap(), amount_staked),
     ];
     let mut epoch_manager = EpochManager::new(
         store,
@@ -2314,8 +2470,10 @@ fn test_protocol_version_switch_after_switch() {
 #[test]
 fn test_final_block_consistency() {
     let amount_staked = 1_000_000;
-    let validators =
-        vec![("test1".parse().unwrap(), amount_staked), ("test2".parse().unwrap(), amount_staked)];
+    let validators = vec![
+        ("test1".parse::<AccountId>().unwrap(), amount_staked),
+        ("test2".parse::<AccountId>().unwrap(), amount_staked),
+    ];
     let mut epoch_manager = setup_default_epoch_manager(validators, 10, 1, 3, 0, 90, 60);
 
     let h = hash_range(10);
@@ -2348,8 +2506,10 @@ fn test_final_block_consistency() {
 #[test]
 fn test_epoch_validators_cache() {
     let amount_staked = 1_000_000;
-    let validators =
-        vec![("test1".parse().unwrap(), amount_staked), ("test2".parse().unwrap(), amount_staked)];
+    let validators = vec![
+        ("test1".parse::<AccountId>().unwrap(), amount_staked),
+        ("test2".parse::<AccountId>().unwrap(), amount_staked),
+    ];
     let mut epoch_manager = setup_default_epoch_manager(validators, 2, 1, 10, 0, 90, 60);
     let h = hash_range(10);
     record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
@@ -2379,10 +2539,10 @@ fn test_chunk_producers() {
     // Make sure that last validator has at least 160/1'000'000  / num_shards of stake.
     // We're running with 2 shards and test1 + test2 has 2'000'000 tokens - so chunk_only should have over 160.
     let validators = vec![
-        ("test1".parse().unwrap(), amount_staked),
-        ("test2".parse().unwrap(), amount_staked),
-        ("chunk_only".parse().unwrap(), 200),
-        ("not_enough_producer".parse().unwrap(), 100),
+        ("test1".parse::<AccountId>().unwrap(), amount_staked),
+        ("test2".parse::<AccountId>().unwrap(), amount_staked),
+        ("chunk_only".parse::<AccountId>().unwrap(), 200),
+        ("not_enough_producer".parse::<AccountId>().unwrap(), 100),
     ];
 
     // There are 2 shards, and 2 block producers seats.
@@ -2425,11 +2585,11 @@ fn test_chunk_producers() {
 fn test_validator_kickout_sanity() {
     let epoch_config = epoch_config(5, 2, 4, 0, 90, 80, 0).for_protocol_version(PROTOCOL_VERSION);
     let accounts = vec![
-        ("test0".parse().unwrap(), 1000),
-        ("test1".parse().unwrap(), 1000),
-        ("test2".parse().unwrap(), 1000),
-        ("test3".parse().unwrap(), 1000),
-        ("test4".parse().unwrap(), 500),
+        ("test0".parse::<AccountId>().unwrap(), 1000),
+        ("test1".parse::<AccountId>().unwrap(), 1000),
+        ("test2".parse::<AccountId>().unwrap(), 1000),
+        ("test3".parse::<AccountId>().unwrap(), 1000),
+        ("test4".parse::<AccountId>().unwrap(), 500),
     ];
     let epoch_info = epoch_info(
         0,
@@ -2478,23 +2638,32 @@ fn test_validator_kickout_sanity() {
     assert_eq!(
         kickouts,
         HashMap::from([
-            ("test1".parse().unwrap(), NotEnoughChunks { produced: 159, expected: 200 }),
-            ("test2".parse().unwrap(), NotEnoughChunks { produced: 70, expected: 100 }),
-            ("test3".parse().unwrap(), NotEnoughBlocks { produced: 89, expected: 100 }),
+            (
+                "test1".parse::<AccountId>().unwrap(),
+                NotEnoughChunks { produced: 159, expected: 200 }
+            ),
+            (
+                "test2".parse::<AccountId>().unwrap(),
+                NotEnoughChunks { produced: 70, expected: 100 }
+            ),
+            (
+                "test3".parse::<AccountId>().unwrap(),
+                NotEnoughBlocks { produced: 89, expected: 100 }
+            ),
         ])
     );
     assert_eq!(
         validator_stats,
         HashMap::from([
             (
-                "test0".parse().unwrap(),
+                "test0".parse::<AccountId>().unwrap(),
                 BlockChunkValidatorStats {
                     block_stats: ValidatorStats { produced: 100, expected: 100 },
                     chunk_stats: ValidatorStats { produced: 170, expected: 200 }
                 }
             ),
             (
-                "test4".parse().unwrap(),
+                "test4".parse::<AccountId>().unwrap(),
                 BlockChunkValidatorStats {
                     block_stats: ValidatorStats { produced: 0, expected: 0 },
                     chunk_stats: ValidatorStats { produced: 100, expected: 100 }
@@ -2510,11 +2679,11 @@ fn test_max_kickout_stake_ratio() {
     let mut epoch_config =
         epoch_config(5, 2, 4, 0, 90, 80, 0).for_protocol_version(PROTOCOL_VERSION);
     let accounts = vec![
-        ("test0".parse().unwrap(), 1000),
-        ("test1".parse().unwrap(), 1000),
-        ("test2".parse().unwrap(), 1000),
-        ("test3".parse().unwrap(), 1000),
-        ("test4".parse().unwrap(), 1000),
+        ("test0".parse::<AccountId>().unwrap(), 1000),
+        ("test1".parse::<AccountId>().unwrap(), 1000),
+        ("test2".parse::<AccountId>().unwrap(), 1000),
+        ("test3".parse::<AccountId>().unwrap(), 1000),
+        ("test4".parse::<AccountId>().unwrap(), 1000),
     ];
     let epoch_info = epoch_info(
         0,
@@ -2554,7 +2723,7 @@ fn test_max_kickout_stake_ratio() {
         ),
     ]);
     let prev_validator_kickout =
-        HashMap::from([("test3".parse().unwrap(), ValidatorKickoutReason::Unstaked)]);
+        HashMap::from([("test3".parse::<AccountId>().unwrap(), ValidatorKickoutReason::Unstaked)]);
     let (kickouts, validator_stats) = EpochManager::compute_kickout_info(
         &epoch_config,
         &epoch_info,
@@ -2570,23 +2739,32 @@ fn test_max_kickout_stake_ratio() {
         // it produced the most blocks (test1 and test2 produced the same number of blocks, but test1
         // is listed before test2 in the validators list).
         HashMap::from([
-            ("test0".parse().unwrap(), NotEnoughBlocks { produced: 50, expected: 100 }),
-            ("test2".parse().unwrap(), NotEnoughBlocks { produced: 70, expected: 100 }),
-            ("test4".parse().unwrap(), NotEnoughChunks { produced: 50, expected: 100 }),
+            (
+                "test0".parse::<AccountId>().unwrap(),
+                NotEnoughBlocks { produced: 50, expected: 100 }
+            ),
+            (
+                "test2".parse::<AccountId>().unwrap(),
+                NotEnoughBlocks { produced: 70, expected: 100 }
+            ),
+            (
+                "test4".parse::<AccountId>().unwrap(),
+                NotEnoughChunks { produced: 50, expected: 100 }
+            ),
         ])
     );
     assert_eq!(
         validator_stats,
         HashMap::from([
             (
-                "test3".parse().unwrap(),
+                "test3".parse::<AccountId>().unwrap(),
                 BlockChunkValidatorStats {
                     block_stats: ValidatorStats { produced: 0, expected: 0 },
                     chunk_stats: ValidatorStats { produced: 0, expected: 0 }
                 }
             ),
             (
-                "test1".parse().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
                 BlockChunkValidatorStats {
                     block_stats: ValidatorStats { produced: 70, expected: 100 },
                     chunk_stats: ValidatorStats { produced: 0, expected: 100 }
@@ -2610,7 +2788,7 @@ fn test_max_kickout_stake_ratio() {
         // test1, test2, and test4 are exempted. Note that test3 can't be exempted because it
         // is in prev_validator_kickout.
         HashMap::from([(
-            "test0".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             NotEnoughBlocks { produced: 50, expected: 100 }
         ),])
     );
@@ -2618,28 +2796,28 @@ fn test_max_kickout_stake_ratio() {
         validator_stats,
         HashMap::from([
             (
-                "test1".parse().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
                 BlockChunkValidatorStats {
                     block_stats: ValidatorStats { produced: 70, expected: 100 },
                     chunk_stats: ValidatorStats { produced: 0, expected: 100 }
                 }
             ),
             (
-                "test2".parse().unwrap(),
+                "test2".parse::<AccountId>().unwrap(),
                 BlockChunkValidatorStats {
                     block_stats: ValidatorStats { produced: 70, expected: 100 },
                     chunk_stats: ValidatorStats { produced: 100, expected: 100 }
                 }
             ),
             (
-                "test3".parse().unwrap(),
+                "test3".parse::<AccountId>().unwrap(),
                 BlockChunkValidatorStats {
                     block_stats: ValidatorStats { produced: 0, expected: 0 },
                     chunk_stats: ValidatorStats { produced: 0, expected: 0 }
                 }
             ),
             (
-                "test4".parse().unwrap(),
+                "test4".parse::<AccountId>().unwrap(),
                 BlockChunkValidatorStats {
                     block_stats: ValidatorStats { produced: 0, expected: 0 },
                     chunk_stats: ValidatorStats { produced: 50, expected: 100 }

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -1746,8 +1746,14 @@ fn test_fishermen_unstake() {
         ],
     );
     let kickout = epoch_info.validator_kickout();
-    assert_eq!(kickout.get(&"test2".parse::<AccountId>().unwrap()).unwrap(), &ValidatorKickoutReason::Unstaked);
-    matches!(kickout.get(&"test3".parse::<AccountId>().unwrap()), Some(ValidatorKickoutReason::NotEnoughStake { .. }));
+    assert_eq!(
+        kickout.get(&"test2".parse::<AccountId>().unwrap()).unwrap(),
+        &ValidatorKickoutReason::Unstaked
+    );
+    matches!(
+        kickout.get(&"test3".parse::<AccountId>().unwrap()),
+        Some(ValidatorKickoutReason::NotEnoughStake { .. })
+    );
 }
 
 #[test]

--- a/chain/epoch-manager/src/tests/random_epochs.rs
+++ b/chain/epoch-manager/src/tests/random_epochs.rs
@@ -52,9 +52,9 @@ fn do_random_test<RngImpl: Rng>(
     let stake_amount = 1_000;
 
     let validators = vec![
-        ("test1".parse().unwrap(), stake_amount),
-        ("test2".parse().unwrap(), stake_amount),
-        ("test3".parse().unwrap(), stake_amount),
+        ("test1".parse::<AccountId>().unwrap(), stake_amount),
+        ("test2".parse::<AccountId>().unwrap(), stake_amount),
+        ("test3".parse::<AccountId>().unwrap(), stake_amount),
     ];
     let mut epoch_manager = setup_default_epoch_manager(validators, epoch_length, 1, 3, 0, 90, 60);
     let h = hash_range(num_heights as usize);

--- a/chain/epoch-manager/src/validator_selection.rs
+++ b/chain/epoch-manager/src/validator_selection.rs
@@ -496,11 +496,11 @@ mod tests {
         let kickout = epoch_info.validator_kickout();
         assert_eq!(kickout.len(), 2);
         assert_eq!(
-            kickout.get("test1").unwrap(),
+            kickout.get(&"test1".parse::<AccountId>().unwrap()).unwrap(),
             &ValidatorKickoutReason::NotEnoughStake { stake: test1_stake, threshold: 2011 },
         );
         assert_eq!(
-            kickout.get("test2").unwrap(),
+            kickout.get(&"test2".parse::<AccountId>().unwrap()).unwrap(),
             &ValidatorKickoutReason::NotEnoughStake { stake: 2002, threshold: 2011 },
         );
     }
@@ -663,7 +663,7 @@ mod tests {
 
         // stake below validator threshold, but above fishermen threshold become fishermen
         let fishermen: Vec<_> = epoch_info.fishermen_iter().map(|v| v.take_account_id()).collect();
-        assert_eq!(fishermen, vec!["test4".parse().unwrap()]);
+        assert_eq!(fishermen, vec!["test4".parse::<AccountId>().unwrap()]);
 
         // too low stakes are kicked out
         let kickout = epoch_info.validator_kickout();
@@ -673,11 +673,11 @@ mod tests {
         #[cfg(not(feature = "protocol_feature_fix_staking_threshold"))]
         let expected_threshold = 300;
         assert_eq!(
-            kickout.get("test5").unwrap(),
+            kickout.get(&"test5".parse::<AccountId>().unwrap()).unwrap(),
             &ValidatorKickoutReason::NotEnoughStake { stake: 100, threshold: expected_threshold },
         );
         assert_eq!(
-            kickout.get("test6").unwrap(),
+            kickout.get(&"test6".parse::<AccountId>().unwrap()).unwrap(),
             &ValidatorKickoutReason::NotEnoughStake { stake: 50, threshold: expected_threshold },
         );
 
@@ -743,7 +743,7 @@ mod tests {
         );
         let mut kick_out = HashMap::new();
         // test1 is kicked out
-        kick_out.insert("test1".parse().unwrap(), ValidatorKickoutReason::Unstaked);
+        kick_out.insert("test1".parse::<AccountId>().unwrap(), ValidatorKickoutReason::Unstaked);
         let epoch_info = proposals_to_epoch_info(
             &epoch_config,
             [0; 32],
@@ -758,7 +758,7 @@ mod tests {
         .unwrap();
 
         // test1 is not selected
-        assert_eq!(epoch_info.get_validator_id(&"test1".parse().unwrap()), None);
+        assert_eq!(epoch_info.get_validator_id(&"test1".parse::<AccountId>().unwrap()), None);
     }
 
     #[test]

--- a/chain/jsonrpc/jsonrpc-tests/src/lib.rs
+++ b/chain/jsonrpc/jsonrpc-tests/src/lib.rs
@@ -11,7 +11,7 @@ use near_jsonrpc_primitives::{
     types::entity_debug::DummyEntityDebugHandler,
 };
 use near_network::tcp;
-use near_primitives::types::NumBlocks;
+use near_primitives::types::{AccountId, NumBlocks};
 use once_cell::sync::Lazy;
 use serde_json::json;
 
@@ -33,11 +33,11 @@ pub fn start_all_with_validity_period_and_no_epoch_sync(
     enable_doomslug: bool,
 ) -> (Addr<ViewClientActor>, tcp::ListenerAddr) {
     let actor_handles = setup_no_network_with_validity_period_and_no_epoch_sync(
-        vec!["test1".parse().unwrap()],
+        vec!["test1".parse::<AccountId>().unwrap()],
         if let NodeType::Validator = node_type {
-            "test1".parse().unwrap()
+            "test1".parse::<AccountId>().unwrap()
         } else {
-            "other".parse().unwrap()
+            "other".parse::<AccountId>().unwrap()
         },
         true,
         transaction_validity_period,

--- a/chain/jsonrpc/jsonrpc-tests/tests/rpc_query.rs
+++ b/chain/jsonrpc/jsonrpc-tests/tests/rpc_query.rs
@@ -1,3 +1,4 @@
+
 use std::ops::ControlFlow;
 use std::str::FromStr;
 
@@ -14,7 +15,7 @@ use near_network::test_utils::wait_or_timeout;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::account::{AccessKey, AccessKeyPermission};
 use near_primitives::hash::CryptoHash;
-use near_primitives::types::{BlockId, BlockReference, EpochId, SyncCheckpoint};
+use near_primitives::types::{AccountId, BlockId, BlockReference, EpochId, SyncCheckpoint};
 use near_primitives::views::QueryRequest;
 
 use near_jsonrpc_tests::{self as test_utils, test_with_client};
@@ -24,7 +25,7 @@ use near_jsonrpc_tests::{self as test_utils, test_with_client};
 fn test_block_by_id_height() {
     test_with_client!(test_utils::NodeType::NonValidator, client, async move {
         let block = client.block_by_id(BlockId::Height(0)).await.unwrap();
-        assert_eq!(block.author, "test1".parse().unwrap());
+        assert_eq!(block.author, "test1".parse::<AccountId>().unwrap());
         assert_eq!(block.header.height, 0);
         assert_eq!(block.header.epoch_id.0.as_ref(), &[0; 32]);
         assert_eq!(block.header.hash.0.as_ref().len(), 32);
@@ -69,7 +70,7 @@ fn test_block_query() {
         for block in
             &[block_response1, block_response2, block_response3, block_response4, block_response5]
         {
-            assert_eq!(block.author, "test1".parse().unwrap());
+            assert_eq!(block.author, "test1".parse::<AccountId>().unwrap());
             assert_eq!(block.header.height, 0);
             assert_eq!(block.header.epoch_id.as_ref(), &[0; 32]);
             assert_eq!(block.header.hash.as_ref().len(), 32);
@@ -89,7 +90,7 @@ fn test_block_query() {
 fn test_chunk_by_hash() {
     test_with_client!(test_utils::NodeType::NonValidator, client, async move {
         let chunk = client.chunk(ChunkId::BlockShardId(BlockId::Height(0), 0u64)).await.unwrap();
-        assert_eq!(chunk.author, "test1".parse().unwrap());
+        assert_eq!(chunk.author, "test1".parse::<AccountId>().unwrap());
         assert_eq!(chunk.header.balance_burnt, 0);
         assert_eq!(chunk.header.chunk_hash.as_ref().len(), 32);
         assert_eq!(chunk.header.encoded_length, 8);
@@ -159,21 +160,27 @@ fn test_query_account() {
         let query_response_1 = client
             .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
                 block_reference: BlockReference::latest(),
-                request: QueryRequest::ViewAccount { account_id: "test".parse().unwrap() },
+                request: QueryRequest::ViewAccount {
+                    account_id: "test".parse::<AccountId>().unwrap(),
+                },
             })
             .await
             .unwrap();
         let query_response_2 = client
             .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
                 block_reference: BlockReference::BlockId(BlockId::Height(0)),
-                request: QueryRequest::ViewAccount { account_id: "test".parse().unwrap() },
+                request: QueryRequest::ViewAccount {
+                    account_id: "test".parse::<AccountId>().unwrap(),
+                },
             })
             .await
             .unwrap();
         let query_response_3 = client
             .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
                 block_reference: BlockReference::BlockId(BlockId::Hash(block_hash)),
-                request: QueryRequest::ViewAccount { account_id: "test".parse().unwrap() },
+                request: QueryRequest::ViewAccount {
+                    account_id: "test".parse::<AccountId>().unwrap(),
+                },
             })
             .await
             .unwrap();
@@ -222,7 +229,9 @@ fn test_query_access_keys() {
         let query_response = client
             .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
                 block_reference: BlockReference::latest(),
-                request: QueryRequest::ViewAccessKeyList { account_id: "test".parse().unwrap() },
+                request: QueryRequest::ViewAccessKeyList {
+                    account_id: "test".parse::<AccountId>().unwrap(),
+                },
             })
             .await
             .unwrap();
@@ -269,7 +278,7 @@ fn test_query_access_key() {
             .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
                 block_reference: BlockReference::latest(),
                 request: QueryRequest::ViewAccessKey {
-                    account_id: "test".parse().unwrap(),
+                    account_id: "test".parse::<AccountId>().unwrap(),
                     public_key: "ed25519:23vYngy8iL7q94jby3gszBnZ9JptpMf5Hgf7KVVa2yQ2"
                         .parse()
                         .unwrap(),
@@ -296,7 +305,7 @@ fn test_query_state() {
             .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
                 block_reference: BlockReference::latest(),
                 request: QueryRequest::ViewState {
-                    account_id: "test".parse().unwrap(),
+                    account_id: "test".parse::<AccountId>().unwrap(),
                     prefix: vec![].into(),
                     include_proof: false,
                 },
@@ -321,7 +330,7 @@ fn test_query_call_function() {
             .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
                 block_reference: BlockReference::latest(),
                 request: QueryRequest::CallFunction {
-                    account_id: "test".parse().unwrap(),
+                    account_id: "test".parse::<AccountId>().unwrap(),
                     method_name: "method".to_string(),
                     args: vec![].into(),
                 },
@@ -349,7 +358,9 @@ fn test_query_contract_code() {
         let query_response = client
             .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
                 block_reference: BlockReference::latest(),
-                request: QueryRequest::ViewCode { account_id: "test".parse().unwrap() },
+                request: QueryRequest::ViewCode {
+                    account_id: "test".parse::<AccountId>().unwrap(),
+                },
             })
             .await
             .unwrap();
@@ -454,7 +465,7 @@ fn test_validators_ordered() {
             .unwrap();
         assert_eq!(
             validators.into_iter().map(|v| v.take_account_id()).collect::<Vec<_>>(),
-            vec!["test1".parse().unwrap()]
+            vec!["test1".parse::<AccountId>().unwrap()]
         )
     });
 }
@@ -560,7 +571,7 @@ fn test_get_chunk_with_object_in_params() {
         )
         .await
         .unwrap();
-        assert_eq!(chunk.author, "test1".parse().unwrap());
+        assert_eq!(chunk.author, "test1".parse::<AccountId>().unwrap());
         assert_eq!(chunk.header.balance_burnt, 0);
         assert_eq!(chunk.header.chunk_hash.as_ref().len(), 32);
         assert_eq!(chunk.header.encoded_length, 8);

--- a/chain/jsonrpc/jsonrpc-tests/tests/rpc_query.rs
+++ b/chain/jsonrpc/jsonrpc-tests/tests/rpc_query.rs
@@ -1,4 +1,3 @@
-
 use std::ops::ControlFlow;
 use std::str::FromStr;
 

--- a/chain/jsonrpc/jsonrpc-tests/tests/rpc_transactions.rs
+++ b/chain/jsonrpc/jsonrpc-tests/tests/rpc_transactions.rs
@@ -13,7 +13,7 @@ use near_o11y::testonly::{init_integration_logger, init_test_logger};
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::serialize::to_base64;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::BlockReference;
+use near_primitives::types::{AccountId, BlockReference};
 use near_primitives::views::{FinalExecutionStatus, TxExecutionStatus};
 
 use near_jsonrpc_tests::{self as test_utils, test_with_client};
@@ -35,12 +35,15 @@ fn test_send_tx_async() {
 
         actix::spawn(client.block(BlockReference::latest()).then(move |res| {
             let block_hash = res.unwrap().header.hash;
-            let signer =
-                InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+            let signer = InMemorySigner::from_seed(
+                "test1".parse::<AccountId>().unwrap(),
+                KeyType::ED25519,
+                "test1",
+            );
             let tx = SignedTransaction::send_money(
                 1,
                 signer_account_id.parse().unwrap(),
-                "test2".parse().unwrap(),
+                "test2".parse::<AccountId>().unwrap(),
                 &signer,
                 100,
                 block_hash,
@@ -56,7 +59,7 @@ fn test_send_tx_async() {
         let client1 = new_client(&format!("http://{}", addr));
         WaitOrTimeoutActor::new(
             Box::new(move |_| {
-                let signer_account_id = "test1".parse().unwrap();
+                let signer_account_id = "test1".parse::<AccountId>().unwrap();
                 if let Some(tx_hash) = *tx_hash2_2.lock().unwrap() {
                     actix::spawn(
                         client1
@@ -91,11 +94,15 @@ fn test_send_tx_async() {
 fn test_send_tx_commit() {
     test_with_client!(test_utils::NodeType::Validator, client, async move {
         let block_hash = client.block(BlockReference::latest()).await.unwrap().header.hash;
-        let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+        let signer = InMemorySigner::from_seed(
+            "test1".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test1",
+        );
         let tx = SignedTransaction::send_money(
             1,
-            "test1".parse().unwrap(),
-            "test2".parse().unwrap(),
+            "test1".parse::<AccountId>().unwrap(),
+            "test2".parse::<AccountId>().unwrap(),
             &signer,
             100,
             block_hash,
@@ -141,14 +148,14 @@ fn test_expired_tx() {
                         if let Some(height) = height {
                             if header.height - height >= 2 {
                                 let signer = InMemorySigner::from_seed(
-                                    "test1".parse().unwrap(),
+                                    "test1".parse::<AccountId>().unwrap(),
                                     KeyType::ED25519,
                                     "test1",
                                 );
                                 let tx = SignedTransaction::send_money(
                                     1,
-                                    "test1".parse().unwrap(),
-                                    "test2".parse().unwrap(),
+                                    "test1".parse::<AccountId>().unwrap(),
+                                    "test2".parse::<AccountId>().unwrap(),
                                     &signer,
                                     100,
                                     block_hash,
@@ -188,11 +195,15 @@ fn test_expired_tx() {
 #[test]
 fn test_replay_protection() {
     test_with_client!(test_utils::NodeType::Validator, client, async move {
-        let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+        let signer = InMemorySigner::from_seed(
+            "test1".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test1",
+        );
         let tx = SignedTransaction::send_money(
             1,
-            "test1".parse().unwrap(),
-            "test2".parse().unwrap(),
+            "test1".parse::<AccountId>().unwrap(),
+            "test2".parse::<AccountId>().unwrap(),
             &signer,
             100,
             hash(&[1]),
@@ -210,7 +221,7 @@ fn test_tx_status_missing_tx() {
         let request = RpcTransactionStatusRequest {
             transaction_info: TransactionInfo::TransactionId {
                 tx_hash: CryptoHash::new(),
-                sender_account_id: "test1".parse().unwrap(),
+                sender_account_id: "test1".parse::<AccountId>().unwrap(),
             },
             wait_until: TxExecutionStatus::None,
         };
@@ -227,13 +238,17 @@ fn test_tx_status_missing_tx() {
 #[test]
 fn test_check_invalid_tx() {
     test_with_client!(test_utils::NodeType::Validator, client, async move {
-        let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+        let signer = InMemorySigner::from_seed(
+            "test1".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test1",
+        );
         // invalid base hash
         let request = RpcTransactionStatusRequest {
             transaction_info: TransactionInfo::from_signed_tx(SignedTransaction::send_money(
                 1,
-                "test1".parse().unwrap(),
-                "test2".parse().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
+                "test2".parse::<AccountId>().unwrap(),
                 &signer,
                 100,
                 hash(&[1]),

--- a/chain/network/src/announce_accounts/tests.rs
+++ b/chain/network/src/announce_accounts/tests.rs
@@ -14,7 +14,7 @@ fn announcement_same_epoch() {
     let announcements_cache = AnnounceAccountCache::new(store);
 
     let announce0 = AnnounceAccount {
-        account_id: "near0".parse().unwrap(),
+        account_id: "near0".parse::<AccountId>().unwrap(),
         peer_id: peer_id0.clone(),
         epoch_id: epoch_id0.clone(),
         signature: Signature::default(),
@@ -22,7 +22,7 @@ fn announcement_same_epoch() {
 
     // Same as announce1 but with different peer id
     let announce1 = AnnounceAccount {
-        account_id: "near0".parse().unwrap(),
+        account_id: "near0".parse::<AccountId>().unwrap(),
         peer_id: peer_id1,
         epoch_id: epoch_id0,
         signature: Signature::default(),
@@ -55,7 +55,7 @@ fn dont_load_on_build() {
     let announcements_cache = AnnounceAccountCache::new(store.clone());
 
     let announce0 = AnnounceAccount {
-        account_id: "near0".parse().unwrap(),
+        account_id: "near0".parse::<AccountId>().unwrap(),
         peer_id: peer_id0,
         epoch_id: epoch_id0,
         signature: Signature::default(),
@@ -63,7 +63,7 @@ fn dont_load_on_build() {
 
     // Same as announce1 but with different peer id
     let announce1 = AnnounceAccount {
-        account_id: "near1".parse().unwrap(),
+        account_id: "near1".parse::<AccountId>().unwrap(),
         peer_id: peer_id1,
         epoch_id: epoch_id1,
         signature: Signature::default(),
@@ -90,7 +90,7 @@ fn load_from_disk() {
     let announcements_cache1 = AnnounceAccountCache::new(store);
 
     let announce0 = AnnounceAccount {
-        account_id: "near0".parse().unwrap(),
+        account_id: "near0".parse::<AccountId>().unwrap(),
         peer_id: peer_id0.clone(),
         epoch_id: epoch_id0,
         signature: Signature::default(),

--- a/chain/network/src/store/schema/mod.rs
+++ b/chain/network/src/store/schema/mod.rs
@@ -5,7 +5,7 @@ use crate::types as primitives;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_async::time;
 use near_crypto::Signature;
-use near_primitives::account::id::{AccountId, AccountIdRef};
+use near_primitives::account::id::AccountId;
 use near_primitives::network::{AnnounceAccount, PeerId};
 use near_store::DBCol;
 use std::io;

--- a/chain/network/src/store/schema/mod.rs
+++ b/chain/network/src/store/schema/mod.rs
@@ -20,8 +20,7 @@ pub struct AccountIdFormat;
 impl Format for AccountIdFormat {
     type T = AccountId;
     fn encode<W: io::Write>(a: &AccountId, w: &mut W) -> io::Result<()> {
-        let account_id_ref: &AccountIdRef = a.as_ref();
-        w.write_all(account_id_ref.as_bytes())
+        w.write_all(a.as_bytes())
     }
     fn decode(a: &[u8]) -> Result<AccountId, Error> {
         std::str::from_utf8(a).map_err(invalid_data)?.parse().map_err(invalid_data)

--- a/chain/network/src/store/schema/mod.rs
+++ b/chain/network/src/store/schema/mod.rs
@@ -5,7 +5,7 @@ use crate::types as primitives;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_async::time;
 use near_crypto::Signature;
-use near_primitives::account::id::AccountId;
+use near_primitives::account::id::{AccountId, AccountIdRef};
 use near_primitives::network::{AnnounceAccount, PeerId};
 use near_store::DBCol;
 use std::io;
@@ -20,7 +20,8 @@ pub struct AccountIdFormat;
 impl Format for AccountIdFormat {
     type T = AccountId;
     fn encode<W: io::Write>(a: &AccountId, w: &mut W) -> io::Result<()> {
-        w.write_all(a.as_ref().as_bytes())
+        let account_id_ref: &AccountIdRef = a.as_ref();
+        w.write_all(account_id_ref.as_bytes())
     }
     fn decode(a: &[u8]) -> Result<AccountId, Error> {
         std::str::from_utf8(a).map_err(invalid_data)?.parse().map_err(invalid_data)

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -454,7 +454,10 @@ mod tests {
         }
 
         check(
-            RoutedMessageBody::TxStatusRequest("test_x".parse().unwrap(), CryptoHash([42; 32])),
+            RoutedMessageBody::TxStatusRequest(
+                "test_x".parse::<AccountId>().unwrap(),
+                CryptoHash([42; 32]),
+            ),
             &[
                 2, 6, 0, 0, 0, 116, 101, 115, 116, 95, 120, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42,
                 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42,

--- a/chain/pool/src/lib.rs
+++ b/chain/pool/src/lib.rs
@@ -5,12 +5,12 @@ use crate::types::{PoolIterator, PoolKey, TransactionGroup};
 
 use near_crypto::PublicKey;
 use near_o11y::metrics::prometheus::core::{AtomicI64, GenericGauge};
+use near_primitives::account::id::AccountIdRef;
 use near_primitives::epoch_manager::RngSeed;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::AccountId;
 use std::ops::Bound;
-use near_primitives::account::id::AccountIdRef;
 
 mod metrics;
 pub mod types;
@@ -75,8 +75,7 @@ impl TransactionPool {
     fn key(&self, account_id: &AccountId, public_key: &PublicKey) -> PoolKey {
         let mut v = borsh::to_vec(&public_key).unwrap();
         v.extend_from_slice(&self.key_seed);
-        let account_id_ref: &AccountIdRef = account_id.as_ref();
-        v.extend_from_slice(account_id_ref.as_bytes());
+        v.extend_from_slice(account_id.as_bytes());
         hash(&v)
     }
 

--- a/chain/pool/src/lib.rs
+++ b/chain/pool/src/lib.rs
@@ -10,6 +10,7 @@ use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::AccountId;
 use std::ops::Bound;
+use near_primitives::account::id::AccountIdRef;
 
 mod metrics;
 pub mod types;
@@ -74,7 +75,8 @@ impl TransactionPool {
     fn key(&self, account_id: &AccountId, public_key: &PublicKey) -> PoolKey {
         let mut v = borsh::to_vec(&public_key).unwrap();
         v.extend_from_slice(&self.key_seed);
-        v.extend_from_slice(account_id.as_ref().as_bytes());
+        let account_id_ref: &AccountIdRef = account_id.as_ref();
+        v.extend_from_slice(account_id_ref.as_bytes());
         hash(&v)
     }
 

--- a/chain/pool/src/lib.rs
+++ b/chain/pool/src/lib.rs
@@ -5,7 +5,6 @@ use crate::types::{PoolIterator, PoolKey, TransactionGroup};
 
 use near_crypto::PublicKey;
 use near_o11y::metrics::prometheus::core::{AtomicI64, GenericGauge};
-use near_primitives::account::id::AccountIdRef;
 use near_primitives::epoch_manager::RngSeed;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::transaction::SignedTransaction;

--- a/chain/pool/src/lib.rs
+++ b/chain/pool/src/lib.rs
@@ -322,7 +322,7 @@ mod tests {
                 SignedTransaction::send_money(
                     i,
                     signer_id.clone(),
-                    "bob.near".parse().unwrap(),
+                    "bob.near".parse::<AccountId>().unwrap(),
                     &*signer,
                     i as Balance,
                     CryptoHash::default(),
@@ -438,7 +438,7 @@ mod tests {
                 SignedTransaction::send_money(
                     i,
                     signer_id,
-                    "bob.near".parse().unwrap(),
+                    "bob.near".parse::<AccountId>().unwrap(),
                     &*signer,
                     i as Balance,
                     CryptoHash::default(),
@@ -533,7 +533,7 @@ mod tests {
                 SignedTransaction::send_money(
                     i,
                     signer_id,
-                    "bob.near".parse().unwrap(),
+                    "bob.near".parse::<AccountId>().unwrap(),
                     &*signer,
                     i as Balance,
                     CryptoHash::default(),

--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -837,14 +837,15 @@ mod tests {
     use near_primitives::runtime::config::RuntimeConfig;
     use near_primitives::transaction::{Action, TransferAction};
     use near_primitives::views::RuntimeConfigView;
+    use near_primitives::types::AccountId;
 
     #[test]
     fn test_convert_block_changes_to_transactions() {
         run_actix(async {
             let runtime_config: RuntimeConfigView = RuntimeConfig::test().into();
             let actor_handles = setup_no_network(
-                vec!["test".parse().unwrap()],
-                "other".parse().unwrap(),
+                vec!["test".parse::<AccountId>().unwrap()],
+                "other".parse::<AccountId>().unwrap(),
                 true,
                 false,
             );
@@ -856,7 +857,7 @@ mod tests {
                 near_primitives::views::StateChangeWithCauseView {
                     cause: near_primitives::views::StateChangeCauseView::ValidatorAccountsUpdate,
                     value: near_primitives::views::StateChangeValueView::AccountUpdate {
-                        account_id: "nfvalidator1.near".parse().unwrap(),
+                        account_id: "nfvalidator1.near".parse::<AccountId>().unwrap(),
                         account: near_primitives::views::AccountView {
                             amount: 5000000000000000000,
                             code_hash: near_primitives::hash::CryptoHash::default(),
@@ -871,7 +872,7 @@ mod tests {
                         receipt_hash: nfvalidator1_receipt_processing_hash,
                     },
                     value: near_primitives::views::StateChangeValueView::AccountUpdate {
-                        account_id: "nfvalidator1.near".parse().unwrap(),
+                        account_id: "nfvalidator1.near".parse::<AccountId>().unwrap(),
                         account: near_primitives::views::AccountView {
                             amount: 4000000000000000000,
                             code_hash: near_primitives::hash::CryptoHash::default(),
@@ -884,7 +885,7 @@ mod tests {
                 near_primitives::views::StateChangeWithCauseView {
                     cause: near_primitives::views::StateChangeCauseView::ValidatorAccountsUpdate,
                     value: near_primitives::views::StateChangeValueView::AccountUpdate {
-                        account_id: "nfvalidator2.near".parse().unwrap(),
+                        account_id: "nfvalidator2.near".parse::<AccountId>().unwrap(),
                         account: near_primitives::views::AccountView {
                             amount: 7000000000000000000,
                             code_hash: near_primitives::hash::CryptoHash::default(),
@@ -899,7 +900,7 @@ mod tests {
                         receipt_hash: nfvalidator2_action_receipt_gas_reward_hash,
                     },
                     value: near_primitives::views::StateChangeValueView::AccountUpdate {
-                        account_id: "nfvalidator2.near".parse().unwrap(),
+                        account_id: "nfvalidator2.near".parse::<AccountId>().unwrap(),
                         account: near_primitives::views::AccountView {
                             amount: 8000000000000000000,
                             code_hash: near_primitives::hash::CryptoHash::default(),
@@ -912,7 +913,7 @@ mod tests {
             ];
             let mut accounts_previous_state = std::collections::HashMap::new();
             accounts_previous_state.insert(
-                "nfvalidator1.near".parse().unwrap(),
+                "nfvalidator1.near".parse::<AccountId>().unwrap(),
                 near_primitives::views::AccountView {
                     amount: 4000000000000000000,
                     code_hash: near_primitives::hash::CryptoHash::default(),
@@ -922,7 +923,7 @@ mod tests {
                 },
             );
             accounts_previous_state.insert(
-                "nfvalidator2.near".parse().unwrap(),
+                "nfvalidator2.near".parse::<AccountId>().unwrap(),
                 near_primitives::views::AccountView {
                     amount: 6000000000000000000,
                     code_hash: near_primitives::hash::CryptoHash::default(),
@@ -975,7 +976,7 @@ mod tests {
         let create_account_actions =
             vec![near_primitives::transaction::CreateAccountAction {}.into()];
         let delete_account_actions = vec![near_primitives::transaction::DeleteAccountAction {
-            beneficiary_id: "beneficiary.near".parse().unwrap(),
+            beneficiary_id: "beneficiary.near".parse::<AccountId>().unwrap(),
         }
         .into()];
         let add_key_actions = vec![near_primitives::transaction::AddKeyAction {
@@ -1055,8 +1056,8 @@ mod tests {
 
         for actions in non_sir_compatible_actions.clone() {
             let near_actions = NearActions {
-                sender_account_id: "sender.near".parse().unwrap(),
-                receiver_account_id: "receiver.near".parse().unwrap(),
+                sender_account_id: "sender.near".parse::<AccountId>().unwrap(),
+                receiver_account_id: "receiver.near".parse::<AccountId>().unwrap(),
                 actions,
             };
             println!("NEAR Actions: {:#?}", near_actions);
@@ -1076,8 +1077,8 @@ mod tests {
         let sir_compatible_actions = [non_sir_compatible_actions, vec![stake_actions]].concat();
         for actions in sir_compatible_actions {
             let near_actions = NearActions {
-                sender_account_id: "sender-is-receiver.near".parse().unwrap(),
-                receiver_account_id: "sender-is-receiver.near".parse().unwrap(),
+                sender_account_id: "sender-is-receiver.near".parse::<AccountId>().unwrap(),
+                receiver_account_id: "sender-is-receiver.near".parse::<AccountId>().unwrap(),
                 actions,
             };
             println!("NEAR Actions: {:#?}", near_actions);
@@ -1101,12 +1102,12 @@ mod tests {
         let sk = SecretKey::from_seed(KeyType::ED25519, "");
 
         let original_near_actions = NearActions {
-            sender_account_id: "proxy.near".parse().unwrap(),
-            receiver_account_id: "account.near".parse().unwrap(),
+            sender_account_id: "proxy.near".parse::<AccountId>().unwrap(),
+            receiver_account_id: "account.near".parse::<AccountId>().unwrap(),
             actions: vec![Action::Delegate(Box::new(SignedDelegateAction {
                 delegate_action: DelegateAction {
-                    sender_id: "account.near".parse().unwrap(),
-                    receiver_id: "receiver.near".parse().unwrap(),
+                    sender_id: "account.near".parse::<AccountId>().unwrap(),
+                    receiver_id: "receiver.near".parse::<AccountId>().unwrap(),
                     actions: vec![Action::Transfer(TransferAction { deposit: 1 })
                         .try_into()
                         .unwrap()],

--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -836,8 +836,8 @@ mod tests {
     use near_primitives::action::delegate::{DelegateAction, SignedDelegateAction};
     use near_primitives::runtime::config::RuntimeConfig;
     use near_primitives::transaction::{Action, TransferAction};
-    use near_primitives::views::RuntimeConfigView;
     use near_primitives::types::AccountId;
+    use near_primitives::views::RuntimeConfigView;
 
     #[test]
     fn test_convert_block_changes_to_transactions() {

--- a/core/account-id/src/lib.rs
+++ b/core/account-id/src/lib.rs
@@ -28,7 +28,7 @@
 //! ```
 //! use near_account_id::AccountId;
 //!
-//! let alice: AccountId = "alice.near".parse().unwrap();
+//! let alice: AccountId = "alice.near".parse::<AccountId>().unwrap();
 //!
 //! assert!("ƒelicia.near".parse::<AccountId>().is_err()); // (ƒ is not f)
 //! ```
@@ -57,7 +57,7 @@ pub use errors::{ParseAccountError, ParseErrorKind};
 /// ```
 /// use near_account_id::AccountId;
 ///
-/// let alice: AccountId = "alice.near".parse().unwrap();
+/// let alice: AccountId = "alice.near".parse::<AccountId>().unwrap();
 ///
 /// assert!("ƒelicia.near".parse::<AccountId>().is_err()); // (ƒ is not f)
 /// ```
@@ -77,7 +77,7 @@ impl AccountId {
     /// ```
     /// use near_account_id::AccountId;
     ///
-    /// let carol: AccountId = "carol.near".parse().unwrap();
+    /// let carol: AccountId = "carol.near".parse::<AccountId>().unwrap();
     /// assert_eq!("carol.near", carol.as_str());
     /// ```
     pub fn as_str(&self) -> &str {
@@ -93,11 +93,11 @@ impl AccountId {
     /// ```
     /// use near_account_id::AccountId;
     ///
-    /// let near_tla: AccountId = "near".parse().unwrap();
+    /// let near_tla: AccountId = "near".parse::<AccountId>().unwrap();
     /// assert!(near_tla.is_top_level());
     ///
     /// // "alice.near" is a sub account of "near" account
-    /// let alice: AccountId = "alice.near".parse().unwrap();
+    /// let alice: AccountId = "alice.near".parse::<AccountId>().unwrap();
     /// assert!(!alice.is_top_level());
     /// ```
     pub fn is_top_level(&self) -> bool {
@@ -113,13 +113,13 @@ impl AccountId {
     /// ```
     /// use near_account_id::AccountId;
     ///
-    /// let near_tla: AccountId = "near".parse().unwrap();
+    /// let near_tla: AccountId = "near".parse::<AccountId>().unwrap();
     /// assert!(near_tla.is_top_level());
     ///
-    /// let alice: AccountId = "alice.near".parse().unwrap();
+    /// let alice: AccountId = "alice.near".parse::<AccountId>().unwrap();
     /// assert!(alice.is_sub_account_of(&near_tla));
     ///
-    /// let alice_app: AccountId = "app.alice.near".parse().unwrap();
+    /// let alice_app: AccountId = "app.alice.near".parse::<AccountId>().unwrap();
     ///
     /// // While app.alice.near is a sub account of alice.near,
     /// // app.alice.near is not a sub account of near
@@ -141,7 +141,7 @@ impl AccountId {
     /// ```
     /// use near_account_id::AccountId;
     ///
-    /// let alice: AccountId = "alice.near".parse().unwrap();
+    /// let alice: AccountId = "alice.near".parse::<AccountId>().unwrap();
     /// assert!(!alice.is_implicit());
     ///
     /// let rando = "98793cd91a3f870fb126f66285808c7e094afcfc4eda8a970f6648cdf0dbd6de"
@@ -162,10 +162,10 @@ impl AccountId {
     /// ```
     /// use near_account_id::AccountId;
     ///
-    /// let alice: AccountId = "alice.near".parse().unwrap();
+    /// let alice: AccountId = "alice.near".parse::<AccountId>().unwrap();
     /// assert!(!alice.is_system());
     ///
-    /// let system: AccountId = "system".parse().unwrap();
+    /// let system: AccountId = "system".parse::<AccountId>().unwrap();
     /// assert!(system.is_system());
     /// ```
     pub fn is_system(&self) -> bool {

--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -144,7 +144,7 @@ pub struct GenesisConfig {
     /// Expected number of blocks per year
     pub num_blocks_per_year: NumBlocks,
     /// Protocol treasury account
-    #[default("near".parse().unwrap())]
+    #[default("near".parse::<AccountId>().unwrap())]
     pub protocol_treasury_account: AccountId,
     /// Fishermen stake threshold.
     #[serde(with = "dec_format")]

--- a/core/chain-configs/src/genesis_validate.rs
+++ b/core/chain-configs/src/genesis_validate.rs
@@ -212,12 +212,12 @@ mod test {
     fn test_total_supply_not_match() {
         let mut config = GenesisConfig::default();
         config.validators = vec![AccountInfo {
-            account_id: "test".parse().unwrap(),
+            account_id: "test".parse::<AccountId>().unwrap(),
             public_key: VALID_ED25519_RISTRETTO_KEY.parse().unwrap(),
             amount: 10,
         }];
         let records = GenesisRecords(vec![StateRecord::Account {
-            account_id: "test".parse().unwrap(),
+            account_id: "test".parse::<AccountId>().unwrap(),
             account: create_account(),
         }]);
         let genesis = &Genesis::new(config, records).unwrap();
@@ -229,12 +229,12 @@ mod test {
     fn test_invalid_staking_key() {
         let mut config = GenesisConfig::default();
         config.validators = vec![AccountInfo {
-            account_id: "test".parse().unwrap(),
+            account_id: "test".parse::<AccountId>().unwrap(),
             public_key: PublicKey::empty(KeyType::ED25519),
             amount: 10,
         }];
         let records = GenesisRecords(vec![StateRecord::Account {
-            account_id: "test".parse().unwrap(),
+            account_id: "test".parse::<AccountId>().unwrap(),
             account: create_account(),
         }]);
         let genesis = &Genesis::new(config, records).unwrap();
@@ -246,13 +246,13 @@ mod test {
     fn test_validator_not_match() {
         let mut config = GenesisConfig::default();
         config.validators = vec![AccountInfo {
-            account_id: "test".parse().unwrap(),
+            account_id: "test".parse::<AccountId>().unwrap(),
             public_key: VALID_ED25519_RISTRETTO_KEY.parse().unwrap(),
             amount: 100,
         }];
         config.total_supply = 110;
         let records = GenesisRecords(vec![StateRecord::Account {
-            account_id: "test".parse().unwrap(),
+            account_id: "test".parse::<AccountId>().unwrap(),
             account: create_account(),
         }]);
         let genesis = &Genesis::new(config, records).unwrap();
@@ -264,7 +264,7 @@ mod test {
     fn test_empty_validator() {
         let config = GenesisConfig::default();
         let records = GenesisRecords(vec![StateRecord::Account {
-            account_id: "test".parse().unwrap(),
+            account_id: "test".parse::<AccountId>().unwrap(),
             account: create_account(),
         }]);
         let genesis = &Genesis::new(config, records).unwrap();
@@ -276,15 +276,18 @@ mod test {
     fn test_access_key_with_nonexistent_account() {
         let mut config = GenesisConfig::default();
         config.validators = vec![AccountInfo {
-            account_id: "test".parse().unwrap(),
+            account_id: "test".parse::<AccountId>().unwrap(),
             public_key: VALID_ED25519_RISTRETTO_KEY.parse().unwrap(),
             amount: 10,
         }];
         config.total_supply = 110;
         let records = GenesisRecords(vec![
-            StateRecord::Account { account_id: "test".parse().unwrap(), account: create_account() },
+            StateRecord::Account {
+                account_id: "test".parse::<AccountId>().unwrap(),
+                account: create_account(),
+            },
             StateRecord::AccessKey {
-                account_id: "test1".parse().unwrap(),
+                account_id: "test1".parse::<AccountId>().unwrap(),
                 public_key: PublicKey::empty(KeyType::ED25519),
                 access_key: AccessKey::full_access(),
             },
@@ -298,16 +301,22 @@ mod test {
     fn test_more_than_one_contract() {
         let mut config = GenesisConfig::default();
         config.validators = vec![AccountInfo {
-            account_id: "test".parse().unwrap(),
+            account_id: "test".parse::<AccountId>().unwrap(),
             public_key: VALID_ED25519_RISTRETTO_KEY.parse().unwrap(),
             amount: 10,
         }];
         config.total_supply = 110;
         let records = GenesisRecords(vec![
-            StateRecord::Account { account_id: "test".parse().unwrap(), account: create_account() },
-            StateRecord::Contract { account_id: "test".parse().unwrap(), code: [1, 2, 3].to_vec() },
+            StateRecord::Account {
+                account_id: "test".parse::<AccountId>().unwrap(),
+                account: create_account(),
+            },
             StateRecord::Contract {
-                account_id: "test".parse().unwrap(),
+                account_id: "test".parse::<AccountId>().unwrap(),
+                code: [1, 2, 3].to_vec(),
+            },
+            StateRecord::Contract {
+                account_id: "test".parse::<AccountId>().unwrap(),
                 code: [1, 2, 3, 4].to_vec(),
             },
         ]);

--- a/core/crypto/src/util.rs
+++ b/core/crypto/src/util.rs
@@ -6,7 +6,6 @@ use curve25519_dalek::traits::VartimeMultiscalarMul;
 
 pub use curve25519_dalek::ristretto::RistrettoPoint as Point;
 pub use curve25519_dalek::scalar::Scalar;
-use near_account_id::AccountIdRef;
 
 pub fn vmul2(s1: Scalar, p1: &Point, s2: Scalar, p2: &Point) -> Point {
     Point::vartime_multiscalar_mul(&[s1, s2], [p1, p2].iter().copied())

--- a/core/crypto/src/util.rs
+++ b/core/crypto/src/util.rs
@@ -6,6 +6,7 @@ use curve25519_dalek::traits::VartimeMultiscalarMul;
 
 pub use curve25519_dalek::ristretto::RistrettoPoint as Point;
 pub use curve25519_dalek::scalar::Scalar;
+use near_account_id::AccountIdRef;
 
 pub fn vmul2(s1: Scalar, p1: &Point, s2: Scalar, p2: &Point) -> Point {
     Point::vartime_multiscalar_mul(&[s1, s2], [p1, p2].iter().copied())
@@ -111,8 +112,9 @@ impl PublicKey {
         }
         let mut public_key_data = Vec::with_capacity(33);
         public_key_data.push(KeyType::ED25519 as u8);
+        let account_id_ref: &AccountIdRef = account_id.as_ref();
         public_key_data.extend(
-            hex::decode(account_id.as_ref().as_bytes())
+            hex::decode(account_id_ref.as_bytes())
                 .expect("account id was a valid hex of length 64 resulting in 32 bytes"),
         );
         debug_assert_eq!(public_key_data.len(), 33);

--- a/core/crypto/src/util.rs
+++ b/core/crypto/src/util.rs
@@ -112,9 +112,8 @@ impl PublicKey {
         }
         let mut public_key_data = Vec::with_capacity(33);
         public_key_data.push(KeyType::ED25519 as u8);
-        let account_id_ref: &AccountIdRef = account_id.as_ref();
         public_key_data.extend(
-            hex::decode(account_id_ref.as_bytes())
+            hex::decode(account_id.as_bytes())
                 .expect("account id was a valid hex of length 64 resulting in 32 bytes"),
         );
         debug_assert_eq!(public_key_data.len(), 33);

--- a/core/primitives/benches/serialization.rs
+++ b/core/primitives/benches/serialization.rs
@@ -26,10 +26,10 @@ fn create_transaction() -> SignedTransaction {
     SignedTransaction::new(
         Signature::empty(KeyType::ED25519),
         Transaction {
-            signer_id: "123213123123".parse().unwrap(),
+            signer_id: "123213123123".parse::<AccountId>().unwrap(),
             public_key: PublicKey::empty(KeyType::ED25519),
             nonce: 123,
-            receiver_id: "1231231232131".parse().unwrap(),
+            receiver_id: "1231231232131".parse::<AccountId>().unwrap(),
             block_hash: Default::default(),
             actions,
         },
@@ -47,7 +47,10 @@ fn create_block() -> Block {
         1_000,
         CryptoHash::default(),
     );
-    let signer = InMemoryValidatorSigner::from_random("test".parse().unwrap(), KeyType::ED25519);
+    let signer = InMemoryValidatorSigner::from_random(
+        "test".parse::<AccountId>().unwrap(),
+        KeyType::ED25519,
+    );
     Block::produce(
         PROTOCOL_VERSION,
         PROTOCOL_VERSION,

--- a/core/primitives/src/action/delegate.rs
+++ b/core/primitives/src/action/delegate.rs
@@ -150,8 +150,8 @@ mod tests {
     fn create_delegate_action(actions: Vec<Action>) -> Action {
         Action::Delegate(Box::new(SignedDelegateAction {
             delegate_action: DelegateAction {
-                sender_id: "aaa".parse().unwrap(),
-                receiver_id: "bbb".parse().unwrap(),
+                sender_id: "aaa".parse::<AccountId>().unwrap(),
+                receiver_id: "bbb".parse::<AccountId>().unwrap(),
                 actions: actions
                     .iter()
                     .map(|a| NonDelegateAction::try_from(a.clone()).unwrap())

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -659,14 +659,14 @@ pub mod epoch_info {
                 epoch_height: 10,
                 validators: vec![
                     ValidatorStakeV1 {
-                        account_id: "test".parse().unwrap(),
+                        account_id: "test".parse::<AccountId>().unwrap(),
                         public_key: "ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp"
                             .parse()
                             .unwrap(),
                         stake: 0,
                     },
                     ValidatorStakeV1 {
-                        account_id: "validator".parse().unwrap(),
+                        account_id: "validator".parse::<AccountId>().unwrap(),
                         public_key: "ed25519:9E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp"
                             .parse()
                             .unwrap(),

--- a/core/primitives/src/receipt.rs
+++ b/core/primitives/src/receipt.rs
@@ -54,12 +54,12 @@ impl Receipt {
     /// allowance of the access key. For gas refunds use `new_gas_refund`.
     pub fn new_balance_refund(receiver_id: &AccountId, refund: Balance) -> Self {
         Receipt {
-            predecessor_id: "system".parse().unwrap(),
+            predecessor_id: "system".parse::<AccountId>().unwrap(),
             receiver_id: receiver_id.clone(),
             receipt_id: CryptoHash::default(),
 
             receipt: ReceiptEnum::Action(ActionReceipt {
-                signer_id: "system".parse().unwrap(),
+                signer_id: "system".parse::<AccountId>().unwrap(),
                 signer_public_key: PublicKey::empty(KeyType::ED25519),
                 gas_price: 0,
                 output_data_receivers: vec![],
@@ -81,7 +81,7 @@ impl Receipt {
         signer_public_key: PublicKey,
     ) -> Self {
         Receipt {
-            predecessor_id: "system".parse().unwrap(),
+            predecessor_id: "system".parse::<AccountId>().unwrap(),
             receiver_id: receiver_id.clone(),
             receipt_id: CryptoHash::default(),
 

--- a/core/primitives/src/runtime/config.rs
+++ b/core/primitives/src/runtime/config.rs
@@ -81,7 +81,7 @@ impl Default for AccountCreationConfig {
     fn default() -> Self {
         Self {
             min_allowed_top_level_account_length: 0,
-            registrar_account_id: "registrar".parse().unwrap(),
+            registrar_account_id: "registrar".parse::<AccountId>().unwrap(),
         }
     }
 }

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -519,22 +519,46 @@ mod tests {
             assert_eq!(shard_layout.get_parent_shard_id(x + 3).unwrap(), 1);
         }
 
-        assert_eq!(account_id_to_shard_id(&"aurora".parse().unwrap(), &shard_layout), 1);
-        assert_eq!(account_id_to_shard_id(&"foo.aurora".parse().unwrap(), &shard_layout), 3);
-        assert_eq!(account_id_to_shard_id(&"bar.foo.aurora".parse().unwrap(), &shard_layout), 2);
-        assert_eq!(account_id_to_shard_id(&"bar".parse().unwrap(), &shard_layout), 2);
-        assert_eq!(account_id_to_shard_id(&"bar.bar".parse().unwrap(), &shard_layout), 2);
-        assert_eq!(account_id_to_shard_id(&"foo".parse().unwrap(), &shard_layout), 3);
-        assert_eq!(account_id_to_shard_id(&"baz.foo".parse().unwrap(), &shard_layout), 2);
-        assert_eq!(account_id_to_shard_id(&"foo.baz".parse().unwrap(), &shard_layout), 4);
-        assert_eq!(account_id_to_shard_id(&"a.foo.baz".parse().unwrap(), &shard_layout), 0);
+        assert_eq!(
+            account_id_to_shard_id(&"aurora".parse::<AccountId>().unwrap(), &shard_layout),
+            1
+        );
+        assert_eq!(
+            account_id_to_shard_id(&"foo.aurora".parse::<AccountId>().unwrap(), &shard_layout),
+            3
+        );
+        assert_eq!(
+            account_id_to_shard_id(&"bar.foo.aurora".parse::<AccountId>().unwrap(), &shard_layout),
+            2
+        );
+        assert_eq!(account_id_to_shard_id(&"bar".parse::<AccountId>().unwrap(), &shard_layout), 2);
+        assert_eq!(
+            account_id_to_shard_id(&"bar.bar".parse::<AccountId>().unwrap(), &shard_layout),
+            2
+        );
+        assert_eq!(account_id_to_shard_id(&"foo".parse::<AccountId>().unwrap(), &shard_layout), 3);
+        assert_eq!(
+            account_id_to_shard_id(&"baz.foo".parse::<AccountId>().unwrap(), &shard_layout),
+            2
+        );
+        assert_eq!(
+            account_id_to_shard_id(&"foo.baz".parse::<AccountId>().unwrap(), &shard_layout),
+            4
+        );
+        assert_eq!(
+            account_id_to_shard_id(&"a.foo.baz".parse::<AccountId>().unwrap(), &shard_layout),
+            0
+        );
 
-        assert_eq!(account_id_to_shard_id(&"aaa".parse().unwrap(), &shard_layout), 0);
-        assert_eq!(account_id_to_shard_id(&"abc".parse().unwrap(), &shard_layout), 0);
-        assert_eq!(account_id_to_shard_id(&"bbb".parse().unwrap(), &shard_layout), 2);
-        assert_eq!(account_id_to_shard_id(&"foo.goo".parse().unwrap(), &shard_layout), 4);
-        assert_eq!(account_id_to_shard_id(&"goo".parse().unwrap(), &shard_layout), 4);
-        assert_eq!(account_id_to_shard_id(&"zoo".parse().unwrap(), &shard_layout), 5);
+        assert_eq!(account_id_to_shard_id(&"aaa".parse::<AccountId>().unwrap(), &shard_layout), 0);
+        assert_eq!(account_id_to_shard_id(&"abc".parse::<AccountId>().unwrap(), &shard_layout), 0);
+        assert_eq!(account_id_to_shard_id(&"bbb".parse::<AccountId>().unwrap(), &shard_layout), 2);
+        assert_eq!(
+            account_id_to_shard_id(&"foo.goo".parse::<AccountId>().unwrap(), &shard_layout),
+            4
+        );
+        assert_eq!(account_id_to_shard_id(&"goo".parse::<AccountId>().unwrap(), &shard_layout), 4);
+        assert_eq!(account_id_to_shard_id(&"zoo".parse::<AccountId>().unwrap(), &shard_layout), 5);
     }
 
     // check that after removing the fixed shards from the shard layout v1

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -1,11 +1,11 @@
 use crate::hash::CryptoHash;
 use crate::types::{AccountId, NumShards};
 use borsh::{BorshDeserialize, BorshSerialize};
+use near_primitives_core::account::id::AccountIdRef;
 use near_primitives_core::types::ShardId;
 use std::cmp::Ordering::Greater;
 use std::collections::HashMap;
 use std::{fmt, str};
-use near_primitives_core::account::id::AccountIdRef;
 
 /// This file implements two data structure `ShardLayout` and `ShardUId`
 ///
@@ -241,8 +241,7 @@ impl ShardLayout {
 pub fn account_id_to_shard_id(account_id: &AccountId, shard_layout: &ShardLayout) -> ShardId {
     match shard_layout {
         ShardLayout::V0(ShardLayoutV0 { num_shards, .. }) => {
-            let account_id_ref: &AccountIdRef = account_id.as_ref();
-            let hash = CryptoHash::hash_bytes(account_id_ref.as_bytes());
+            let hash = CryptoHash::hash_bytes(account_id.as_bytes());
             let (bytes, _) = stdx::split_array::<32, 8, 24>(hash.as_bytes());
             u64::from_le_bytes(*bytes) % num_shards
         }

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -5,6 +5,7 @@ use near_primitives_core::types::ShardId;
 use std::cmp::Ordering::Greater;
 use std::collections::HashMap;
 use std::{fmt, str};
+use near_primitives_core::account::id::AccountIdRef;
 
 /// This file implements two data structure `ShardLayout` and `ShardUId`
 ///
@@ -240,7 +241,8 @@ impl ShardLayout {
 pub fn account_id_to_shard_id(account_id: &AccountId, shard_layout: &ShardLayout) -> ShardId {
     match shard_layout {
         ShardLayout::V0(ShardLayoutV0 { num_shards, .. }) => {
-            let hash = CryptoHash::hash_bytes(account_id.as_ref().as_bytes());
+            let account_id_ref: &AccountIdRef = account_id.as_ref();
+            let hash = CryptoHash::hash_bytes(account_id_ref.as_bytes());
             let (bytes, _) = stdx::split_array::<32, 8, 24>(hash.as_bytes());
             u64::from_le_bytes(*bytes) % num_shards
         }

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -1,7 +1,6 @@
 use crate::hash::CryptoHash;
 use crate::types::{AccountId, NumShards};
 use borsh::{BorshDeserialize, BorshSerialize};
-use near_primitives_core::account::id::AccountIdRef;
 use near_primitives_core::types::ShardId;
 use std::cmp::Ordering::Greater;
 use std::collections::HashMap;

--- a/core/primitives/src/signable_message.rs
+++ b/core/primitives/src/signable_message.rs
@@ -235,9 +235,9 @@ mod tests {
     // happy path for NEP-366 signature
     #[test]
     fn nep_366_ok() {
-        let sender_id: AccountId = "alice.near".parse().unwrap();
-        let receiver_id: AccountId = "bob.near".parse().unwrap();
-        let signer = create_user_test_signer(&sender_id);
+        let sender_id: AccountId = "alice.near".parse::<AccountId>().unwrap();
+        let receiver_id: AccountId = "bob.near".parse::<AccountId>().unwrap();
+        let signer = create_user_test_signer(sender_id.as_str());
 
         let delegate_action = delegate_action(sender_id, receiver_id, signer.public_key());
         let signable = SignableMessage::new(&delegate_action, SignableMessageType::DelegateAction);
@@ -249,9 +249,9 @@ mod tests {
     // Try to use a wrong nep number in NEP-366 signature verification.
     #[test]
     fn nep_366_wrong_nep() {
-        let sender_id: AccountId = "alice.near".parse().unwrap();
-        let receiver_id: AccountId = "bob.near".parse().unwrap();
-        let signer = create_user_test_signer(&sender_id);
+        let sender_id: AccountId = "alice.near".parse::<AccountId>().unwrap();
+        let receiver_id: AccountId = "bob.near".parse::<AccountId>().unwrap();
+        let signer = create_user_test_signer(sender_id.as_str());
 
         let delegate_action = delegate_action(sender_id, receiver_id, signer.public_key());
         let wrong_nep = 777;
@@ -267,9 +267,9 @@ mod tests {
     // Try to use a wrong message type in NEP-366 signature verification.
     #[test]
     fn nep_366_wrong_msg_type() {
-        let sender_id: AccountId = "alice.near".parse().unwrap();
-        let receiver_id: AccountId = "bob.near".parse().unwrap();
-        let signer = create_user_test_signer(&sender_id);
+        let sender_id: AccountId = "alice.near".parse::<AccountId>().unwrap();
+        let receiver_id: AccountId = "bob.near".parse::<AccountId>().unwrap();
+        let signer = create_user_test_signer(sender_id.as_str());
 
         let delegate_action = delegate_action(sender_id, receiver_id, signer.public_key());
         let correct_nep = 366;

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -251,8 +251,8 @@ impl SignedTransaction {
     pub fn empty(block_hash: CryptoHash) -> Self {
         Self::from_actions(
             0,
-            "test".parse().unwrap(),
-            "test".parse().unwrap(),
+            "test".parse::<AccountId>().unwrap(),
+            "test".parse::<AccountId>().unwrap(),
             &EmptySigner {},
             vec![],
             block_hash,
@@ -564,7 +564,7 @@ pub fn create_user_test_signer(account_name: &str) -> InMemorySigner {
 
 /// A fixed implicit account for which tests can know the private key.
 pub fn implicit_test_account() -> AccountId {
-    "061b1dd17603213b00e1a1e53ba060ad427cef4887bd34a5e0ef09010af23b0a".parse().unwrap()
+    "061b1dd17603213b00e1a1e53ba060ad427cef4887bd34a5e0ef09010af23b0a".parse::<AccountId>().unwrap()
 }
 
 /// Private key for the fixed implicit test account.

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -154,45 +154,39 @@ impl TrieKey {
         match self {
             TrieKey::Account { account_id } => {
                 buf.push(col::ACCOUNT);
-                let account_id_ref: &AccountIdRef = account_id.as_ref();
-                buf.extend(account_id_ref.as_bytes());
+                buf.extend(account_id.as_bytes());
             }
             TrieKey::ContractCode { account_id } => {
                 buf.push(col::CONTRACT_CODE);
-                let account_id_ref: &AccountIdRef = account_id.as_ref();
-                buf.extend(account_id_ref.as_bytes());
+                buf.extend(account_id.as_bytes());
             }
             TrieKey::AccessKey { account_id, public_key } => {
                 buf.push(col::ACCESS_KEY);
-                let account_id_ref: &AccountIdRef = account_id.as_ref();
-                buf.extend(account_id_ref.as_bytes());
+                buf.extend(account_id.as_bytes());
                 buf.push(col::ACCESS_KEY);
-                buf.extend(borsh::to_vec(&public_key).unwrap());            }
+                buf.extend(borsh::to_vec(&public_key).unwrap());
+            }
             TrieKey::ReceivedData { receiver_id, data_id } => {
                 buf.push(col::RECEIVED_DATA);
-                let account_id_ref: &AccountIdRef = receiver_id.as_ref();
-                buf.extend(account_id_ref.as_bytes());
+                buf.extend(receiver_id.as_bytes());
                 buf.push(ACCOUNT_DATA_SEPARATOR);
                 buf.extend(data_id.as_ref());
             }
             TrieKey::PostponedReceiptId { receiver_id, data_id } => {
                 buf.push(col::POSTPONED_RECEIPT_ID);
-                let account_id_ref: &AccountIdRef = receiver_id.as_ref();
-                buf.extend(account_id_ref.as_bytes());
+                buf.extend(receiver_id.as_bytes());
                 buf.push(ACCOUNT_DATA_SEPARATOR);
                 buf.extend(data_id.as_ref());
             }
             TrieKey::PendingDataCount { receiver_id, receipt_id } => {
                 buf.push(col::PENDING_DATA_COUNT);
-                let account_id_ref: &AccountIdRef = receiver_id.as_ref();
-                buf.extend(account_id_ref.as_bytes());
+                buf.extend(receiver_id.as_bytes());
                 buf.push(ACCOUNT_DATA_SEPARATOR);
                 buf.extend(receipt_id.as_ref());
             }
             TrieKey::PostponedReceipt { receiver_id, receipt_id } => {
                 buf.push(col::POSTPONED_RECEIPT);
-                let account_id_ref: &AccountIdRef = receiver_id.as_ref();
-                buf.extend(account_id_ref.as_bytes());
+                buf.extend(receiver_id.as_bytes());
                 buf.push(ACCOUNT_DATA_SEPARATOR);
                 buf.extend(receipt_id.as_ref());
             }
@@ -205,8 +199,7 @@ impl TrieKey {
             }
             TrieKey::ContractData { account_id, key } => {
                 buf.push(col::CONTRACT_DATA);
-                let account_id_ref: &AccountIdRef = account_id.as_ref();
-                buf.extend(account_id_ref.as_bytes());
+                buf.extend(account_id.as_bytes());
                 buf.push(ACCOUNT_DATA_SEPARATOR);
                 buf.extend(key);
             }

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -3,7 +3,6 @@ use std::mem::size_of;
 use borsh::{BorshDeserialize, BorshSerialize};
 
 use near_crypto::PublicKey;
-use near_primitives_core::account::id::AccountIdRef;
 
 use crate::hash::CryptoHash;
 use crate::types::AccountId;

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -3,6 +3,7 @@ use std::mem::size_of;
 use borsh::{BorshDeserialize, BorshSerialize};
 
 use near_crypto::PublicKey;
+use near_primitives_core::account::id::AccountIdRef;
 
 use crate::hash::CryptoHash;
 use crate::types::AccountId;
@@ -153,39 +154,45 @@ impl TrieKey {
         match self {
             TrieKey::Account { account_id } => {
                 buf.push(col::ACCOUNT);
-                buf.extend(account_id.as_ref().as_bytes());
+                let account_id_ref: &AccountIdRef = account_id.as_ref();
+                buf.extend(account_id_ref.as_bytes());
             }
             TrieKey::ContractCode { account_id } => {
                 buf.push(col::CONTRACT_CODE);
-                buf.extend(account_id.as_ref().as_bytes());
+                let account_id_ref: &AccountIdRef = account_id.as_ref();
+                buf.extend(account_id_ref.as_bytes());
             }
             TrieKey::AccessKey { account_id, public_key } => {
                 buf.push(col::ACCESS_KEY);
-                buf.extend(account_id.as_ref().as_bytes());
+                let account_id_ref: &AccountIdRef = account_id.as_ref();
+                buf.extend(account_id_ref.as_bytes());
                 buf.push(col::ACCESS_KEY);
-                buf.extend(borsh::to_vec(&public_key).unwrap());
-            }
+                buf.extend(borsh::to_vec(&public_key).unwrap());            }
             TrieKey::ReceivedData { receiver_id, data_id } => {
                 buf.push(col::RECEIVED_DATA);
-                buf.extend(receiver_id.as_ref().as_bytes());
+                let account_id_ref: &AccountIdRef = receiver_id.as_ref();
+                buf.extend(account_id_ref.as_bytes());
                 buf.push(ACCOUNT_DATA_SEPARATOR);
                 buf.extend(data_id.as_ref());
             }
             TrieKey::PostponedReceiptId { receiver_id, data_id } => {
                 buf.push(col::POSTPONED_RECEIPT_ID);
-                buf.extend(receiver_id.as_ref().as_bytes());
+                let account_id_ref: &AccountIdRef = receiver_id.as_ref();
+                buf.extend(account_id_ref.as_bytes());
                 buf.push(ACCOUNT_DATA_SEPARATOR);
                 buf.extend(data_id.as_ref());
             }
             TrieKey::PendingDataCount { receiver_id, receipt_id } => {
                 buf.push(col::PENDING_DATA_COUNT);
-                buf.extend(receiver_id.as_ref().as_bytes());
+                let account_id_ref: &AccountIdRef = receiver_id.as_ref();
+                buf.extend(account_id_ref.as_bytes());
                 buf.push(ACCOUNT_DATA_SEPARATOR);
                 buf.extend(receipt_id.as_ref());
             }
             TrieKey::PostponedReceipt { receiver_id, receipt_id } => {
                 buf.push(col::POSTPONED_RECEIPT);
-                buf.extend(receiver_id.as_ref().as_bytes());
+                let account_id_ref: &AccountIdRef = receiver_id.as_ref();
+                buf.extend(account_id_ref.as_bytes());
                 buf.push(ACCOUNT_DATA_SEPARATOR);
                 buf.extend(receipt_id.as_ref());
             }
@@ -198,7 +205,8 @@ impl TrieKey {
             }
             TrieKey::ContractData { account_id, key } => {
                 buf.push(col::CONTRACT_DATA);
-                buf.extend(account_id.as_ref().as_bytes());
+                let account_id_ref: &AccountIdRef = account_id.as_ref();
+                buf.extend(account_id_ref.as_bytes());
                 buf.push(ACCOUNT_DATA_SEPARATOR);
                 buf.extend(key);
             }

--- a/core/primitives/src/validator_signer.rs
+++ b/core/primitives/src/validator_signer.rs
@@ -73,7 +73,7 @@ pub trait ValidatorSigner: Sync + Send {
 /// Don't use in any production or code that requires signature verification.
 #[derive(smart_default::SmartDefault)]
 pub struct EmptyValidatorSigner {
-    #[default("test".parse().unwrap())]
+    #[default("test".parse::<AccountId>().unwrap())]
     account_id: AccountId,
 }
 

--- a/core/store/benches/finalize_bench.rs
+++ b/core/store/benches/finalize_bench.rs
@@ -83,14 +83,14 @@ fn benchmark_write_partial_encoded_chunk(bench: &mut Bencher) {
 }
 
 fn validator_signer() -> InMemoryValidatorSigner {
-    InMemoryValidatorSigner::from_random("test".parse().unwrap(), KeyType::ED25519)
+    InMemoryValidatorSigner::from_random("test".parse::<AccountId>().unwrap(), KeyType::ED25519)
 }
 
 /// All receipts together are ~24MB
 ///
 /// 24 MB isn't the norm but certainly possible.
 fn create_benchmark_receipts() -> Vec<Receipt> {
-    let account_id: AccountId = "test".parse().unwrap();
+    let account_id: AccountId = "test".parse::<AccountId>().unwrap();
     let signer = InMemorySigner::from_random(account_id.clone(), KeyType::ED25519);
     let action = Action::FunctionCall(Box::new(FunctionCallAction {
         args: vec![42u8; 2_000_000],

--- a/core/store/src/flat/delta.rs
+++ b/core/store/src/flat/delta.rs
@@ -175,14 +175,17 @@ mod tests {
     use super::FlatStateChanges;
     use near_primitives::state::FlatStateValue;
     use near_primitives::trie_key::TrieKey;
-    use near_primitives::types::{RawStateChange, RawStateChangesWithTrieKey, StateChangeCause};
+    use near_primitives::types::{AccountId, RawStateChange, RawStateChangesWithTrieKey, StateChangeCause};
 
     /// Check correctness of creating `FlatStateChanges` from state changes.
     #[test]
     fn flat_state_changes_creation() {
-        let alice_trie_key = TrieKey::ContractCode { account_id: "alice".parse().unwrap() };
-        let bob_trie_key = TrieKey::ContractCode { account_id: "bob".parse().unwrap() };
-        let carol_trie_key = TrieKey::ContractCode { account_id: "carol".parse().unwrap() };
+        let alice_trie_key =
+            TrieKey::ContractCode { account_id: "alice".parse::<AccountId>().unwrap() };
+        let bob_trie_key =
+            TrieKey::ContractCode { account_id: "bob".parse::<AccountId>().unwrap() };
+        let carol_trie_key =
+            TrieKey::ContractCode { account_id: "carol".parse::<AccountId>().unwrap() };
         let delayed_trie_key = TrieKey::DelayedReceiptIndices;
         let delayed_receipt_trie_key = TrieKey::DelayedReceipt { index: 1 };
 

--- a/core/store/src/flat/delta.rs
+++ b/core/store/src/flat/delta.rs
@@ -175,7 +175,9 @@ mod tests {
     use super::FlatStateChanges;
     use near_primitives::state::FlatStateValue;
     use near_primitives::trie_key::TrieKey;
-    use near_primitives::types::{AccountId, RawStateChange, RawStateChangesWithTrieKey, StateChangeCause};
+    use near_primitives::types::{
+        AccountId, RawStateChange, RawStateChangesWithTrieKey, StateChangeCause,
+    };
 
     /// Check correctness of creating `FlatStateChanges` from state changes.
     #[test]

--- a/core/store/src/trie/split_state.rs
+++ b/core/store/src/trie/split_state.rs
@@ -496,8 +496,8 @@ mod tests {
                     &all_receipts[new_start_index..],
                     state_roots,
                     &|account_id| ShardUId {
-                        shard_id: (hash(account_id.as_ref().as_bytes()).0[0] as NumShards
-                            % num_shards) as u32,
+                        shard_id: (hash(account_id.as_bytes()).0[0] as NumShards % num_shards)
+                            as u32,
                         version: 1,
                     },
                 );

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -170,14 +170,14 @@ impl crate::TrieAccess for TrieUpdate {
 #[cfg(test)]
 mod tests {
     use crate::test_utils::{create_tries, create_tries_complex};
-
+    use near_primitives::types::AccountId;
     use super::*;
     use crate::ShardUId;
     const SHARD_VERSION: u32 = 1;
     const COMPLEX_SHARD_UID: ShardUId = ShardUId { version: SHARD_VERSION, shard_id: 0 };
 
     fn test_key(key: Vec<u8>) -> TrieKey {
-        TrieKey::ContractData { account_id: "alice".parse().unwrap(), key }
+        TrieKey::ContractData { account_id: "alice".parse::<AccountId>().unwrap(), key }
     }
 
     #[test]

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -169,10 +169,10 @@ impl crate::TrieAccess for TrieUpdate {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_utils::{create_tries, create_tries_complex};
-    use near_primitives::types::AccountId;
     use super::*;
+    use crate::test_utils::{create_tries, create_tries_complex};
     use crate::ShardUId;
+    use near_primitives::types::AccountId;
     const SHARD_VERSION: u32 = 1;
     const COMPLEX_SHARD_UID: ShardUId = ShardUId { version: SHARD_VERSION, shard_id: 0 };
 

--- a/docs/practices/testing/test_utils.md
+++ b/docs/practices/testing/test_utils.md
@@ -10,7 +10,7 @@ unit testing in Rust.
 To create a new crypto hash:
 
 ```rust
-"ADns6sqVyFLRZbSMCGdzUiUPaDDtjTmKCWzR8HxWsfDU".parse().unwrap();
+"ADns6sqVyFLRZbSMCGdzUiUPaDDtjTmKCWzR8HxWsfDU".parse::<AccountId>().unwrap();
 ```
 
 ### Account
@@ -18,7 +18,7 @@ To create a new crypto hash:
 Also, prefer doing parse + unwrap:
 
 ```rust
-let alice: AccountId = "alice.near".parse().unwrap();
+let alice: AccountId = "alice.near".parse::<AccountId>().unwrap();
 ```
 
 ### Signatures

--- a/genesis-tools/genesis-csv-to-json/src/csv_parser.rs
+++ b/genesis-tools/genesis-csv-to-json/src/csv_parser.rs
@@ -4,7 +4,6 @@ use chrono::Utc;
 use csv::ReaderBuilder;
 use near_crypto::{KeyType, PublicKey};
 use near_network::types::PeerInfo;
-use near_primitives::account::id::AccountIdRef;
 use near_primitives::account::{AccessKey, AccessKeyPermission, Account, FunctionCallPermission};
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::receipt::{ActionReceipt, Receipt, ReceiptEnum};

--- a/genesis-tools/genesis-csv-to-json/src/csv_parser.rs
+++ b/genesis-tools/genesis-csv-to-json/src/csv_parser.rs
@@ -295,7 +295,7 @@ mod tests {
         writer
             .serialize(Row {
                 genesis_time: Some(Utc::now()),
-                account_id: "alice_near".parse().unwrap(),
+                account_id: "alice_near".parse::<AccountId>().unwrap(),
                 regular_pks: vec![
                     PublicKey::empty(KeyType::ED25519),
                     PublicKey::empty(KeyType::ED25519),
@@ -322,7 +322,7 @@ mod tests {
         writer
             .serialize(Row {
                 genesis_time: None,
-                account_id: "bob_near".parse().unwrap(),
+                account_id: "bob_near".parse::<AccountId>().unwrap(),
                 regular_pks: vec![],
                 privileged_pks: vec![PublicKey::empty(KeyType::ED25519)],
                 foundation_pks: vec![PublicKey::empty(KeyType::ED25519)],

--- a/genesis-tools/genesis-csv-to-json/src/csv_parser.rs
+++ b/genesis-tools/genesis-csv-to-json/src/csv_parser.rs
@@ -13,6 +13,7 @@ use near_primitives::types::{AccountId, AccountInfo, Balance, Gas};
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
+use near_primitives::account::id::AccountIdRef;
 
 /// Methods that can be called by a non-privileged access key.
 const REGULAR_METHOD_NAMES: &[&str] = &["stake", "transfer"];
@@ -245,11 +246,12 @@ fn account_records(row: &Row, gas_price: Balance) -> Vec<StateRecord> {
             }
             _ => unimplemented!(),
         };
+        let account_id_ref: &AccountIdRef = row.account_id.as_ref();
         let receipt = Receipt {
             predecessor_id: row.account_id.clone(),
             receiver_id: row.account_id.clone(),
             // `receipt_id` can be anything as long as it is unique.
-            receipt_id: hash(row.account_id.as_ref().as_bytes()),
+            receipt_id: hash(account_id_ref.as_bytes()),
             receipt: ReceiptEnum::Action(ActionReceipt {
                 signer_id: row.account_id.clone(),
                 // `signer_public_key` can be anything because the key checks are not applied when

--- a/genesis-tools/genesis-csv-to-json/src/csv_parser.rs
+++ b/genesis-tools/genesis-csv-to-json/src/csv_parser.rs
@@ -4,6 +4,7 @@ use chrono::Utc;
 use csv::ReaderBuilder;
 use near_crypto::{KeyType, PublicKey};
 use near_network::types::PeerInfo;
+use near_primitives::account::id::AccountIdRef;
 use near_primitives::account::{AccessKey, AccessKeyPermission, Account, FunctionCallPermission};
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::receipt::{ActionReceipt, Receipt, ReceiptEnum};
@@ -13,7 +14,6 @@ use near_primitives::types::{AccountId, AccountInfo, Balance, Gas};
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
-use near_primitives::account::id::AccountIdRef;
 
 /// Methods that can be called by a non-privileged access key.
 const REGULAR_METHOD_NAMES: &[&str] = &["stake", "transfer"];
@@ -246,12 +246,11 @@ fn account_records(row: &Row, gas_price: Balance) -> Vec<StateRecord> {
             }
             _ => unimplemented!(),
         };
-        let account_id_ref: &AccountIdRef = row.account_id.as_ref();
         let receipt = Receipt {
             predecessor_id: row.account_id.clone(),
             receiver_id: row.account_id.clone(),
             // `receipt_id` can be anything as long as it is unique.
-            receipt_id: hash(account_id_ref.as_bytes()),
+            receipt_id: hash(row.account_id.as_bytes()),
             receipt: ReceiptEnum::Action(ActionReceipt {
                 signer_id: row.account_id.clone(),
                 // `signer_public_key` can be anything because the key checks are not applied when

--- a/integration-tests/src/node/mod.rs
+++ b/integration-tests/src/node/mod.rs
@@ -14,6 +14,7 @@ use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, Balance, NumSeats};
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_primitives::views::AccountView;
+use near_primitives_core::account::id::AccountIdRef;
 use near_vm_runner::ContractCode;
 use nearcore::config::{
     create_testnet_configs, create_testnet_configs_from_seeds, Config, GenesisExt,
@@ -160,7 +161,9 @@ pub fn create_nodes_from_seeds(seeds: Vec<String>) -> Vec<NodeConfig> {
         for record in records.iter_mut() {
             if let StateRecord::Account { account_id: record_account_id, ref mut account } = record
             {
-                if record_account_id.as_ref() == seed {
+                let account_id_ref:&AccountIdRef = record_account_id.as_ref();
+
+                if account_id_ref == seed {
                     is_account_record_found = true;
                     account.set_code_hash(*ContractCode::new(code.to_vec(), None).hash());
                 }

--- a/integration-tests/src/node/mod.rs
+++ b/integration-tests/src/node/mod.rs
@@ -14,7 +14,6 @@ use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, Balance, NumSeats};
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_primitives::views::AccountView;
-use near_primitives_core::account::id::AccountIdRef;
 use near_vm_runner::ContractCode;
 use nearcore::config::{
     create_testnet_configs, create_testnet_configs_from_seeds, Config, GenesisExt,

--- a/integration-tests/src/node/mod.rs
+++ b/integration-tests/src/node/mod.rs
@@ -161,9 +161,7 @@ pub fn create_nodes_from_seeds(seeds: Vec<String>) -> Vec<NodeConfig> {
         for record in records.iter_mut() {
             if let StateRecord::Account { account_id: record_account_id, ref mut account } = record
             {
-                let account_id_ref:&AccountIdRef = record_account_id.as_ref();
-
-                if account_id_ref == seed {
+                if record_account_id.as_str().to_string() == seed {
                     is_account_record_found = true;
                     account.set_code_hash(*ContractCode::new(code.to_vec(), None).hash());
                 }

--- a/integration-tests/src/node/runtime_node.rs
+++ b/integration-tests/src/node/runtime_node.rs
@@ -53,8 +53,10 @@ impl RuntimeNode {
     }
 
     pub fn free(account_id: &AccountId) -> Self {
-        let mut genesis =
-            Genesis::test(vec![alice_account(), bob_account(), "carol.near".parse().unwrap()], 3);
+        let mut genesis = Genesis::test(
+            vec![alice_account(), bob_account(), "carol.near".parse::<AccountId>().unwrap()],
+            3,
+        );
         add_test_contract(&mut genesis, &bob_account());
         Self::new_from_genesis_and_config(account_id, genesis, RuntimeConfig::free())
     }

--- a/integration-tests/src/runtime_utils.rs
+++ b/integration-tests/src/runtime_utils.rs
@@ -17,11 +17,11 @@ pub const TEST_SHARD_UID: ShardUId = ShardUId { version: 1, shard_id: 0 };
 
 pub fn get_runtime_and_trie() -> (Runtime, ShardTries, StateRoot) {
     let mut genesis = Genesis::test_sharded_new_version(
-        vec![alice_account(), bob_account(), "carol.near".parse().unwrap()],
+        vec![alice_account(), bob_account(), "carol.near".parse::<AccountId>().unwrap()],
         3,
         vec![3],
     );
-    add_test_contract(&mut genesis, &"test.contract".parse().unwrap());
+    add_test_contract(&mut genesis, &"test.contract".parse::<AccountId>().unwrap());
     get_runtime_and_trie_from_genesis(&genesis)
 }
 

--- a/integration-tests/src/tests/client/benchmarks.rs
+++ b/integration-tests/src/tests/client/benchmarks.rs
@@ -10,6 +10,7 @@ use near_client::test_utils::{create_chunk_on_height, TestEnv};
 use near_client::ProcessTxResponse;
 use near_crypto::{InMemorySigner, KeyType};
 use near_primitives::transaction::{Action, DeployContractAction, SignedTransaction};
+use near_primitives::types::AccountId;
 use nearcore::config::GenesisExt;
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
 
@@ -28,7 +29,10 @@ fn benchmark_large_chunk_production_time() {
     let n_txes = 20;
     let tx_size = 3 * mb;
 
-    let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     let chain_genesis = ChainGenesis::new(&genesis);
     let mut env = TestEnv::builder(chain_genesis)
         .real_epoch_managers(&genesis.config)

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -76,7 +76,7 @@ fn test_block_with_challenges() {
 /// Check that attempt to process block on top of incorrect state root leads to InvalidChunkState error.
 #[test]
 fn test_invalid_chunk_state() {
-    let genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
+    let genesis = Genesis::test(vec!["test0".parse::<AccountId>().unwrap()], 1);
     let mut env = TestEnv::builder(ChainGenesis::test())
         .real_epoch_managers(&genesis.config)
         .nightshade_runtimes(&genesis)
@@ -219,7 +219,10 @@ fn test_verify_chunk_invalid_proofs_challenge() {
     let shard_id = chunk.shard_id();
     let challenge_result =
         challenge(env, shard_id as usize, MaybeEncodedShardChunk::Encoded(chunk), &block);
-    assert_eq!(challenge_result.unwrap(), (*block.hash(), vec!["test0".parse().unwrap()]));
+    assert_eq!(
+        challenge_result.unwrap(),
+        (*block.hash(), vec!["test0".parse::<AccountId>().unwrap()])
+    );
 }
 
 #[test]
@@ -234,7 +237,10 @@ fn test_verify_chunk_invalid_proofs_challenge_decoded_chunk() {
     let shard_id = chunk.shard_id();
     let challenge_result =
         challenge(env, shard_id as usize, MaybeEncodedShardChunk::Decoded(chunk), &block);
-    assert_eq!(challenge_result.unwrap(), (*block.hash(), vec!["test0".parse().unwrap()]));
+    assert_eq!(
+        challenge_result.unwrap(),
+        (*block.hash(), vec!["test0".parse::<AccountId>().unwrap()])
+    );
 }
 
 #[test]
@@ -256,23 +262,24 @@ fn test_verify_chunk_proofs_malicious_challenge_valid_order_transactions() {
     env.produce_block(0, 1);
 
     let genesis_hash = *env.clients[0].chain.genesis().hash();
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
 
     let (chunk, _merkle_paths, _receipts, block) = create_chunk_with_transactions(
         &mut env.clients[0],
         vec![
             SignedTransaction::send_money(
                 1,
-                "test0".parse().unwrap(),
-                "test1".parse().unwrap(),
+                "test0".parse::<AccountId>().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
                 &signer,
                 1000,
                 genesis_hash,
             ),
             SignedTransaction::send_money(
                 2,
-                "test0".parse().unwrap(),
-                "test1".parse().unwrap(),
+                "test0".parse::<AccountId>().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
                 &signer,
                 1000,
                 genesis_hash,
@@ -292,23 +299,24 @@ fn test_verify_chunk_proofs_challenge_transaction_order() {
     env.produce_block(0, 1);
 
     let genesis_hash = *env.clients[0].chain.genesis().hash();
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
 
     let (chunk, _merkle_paths, _receipts, block) = create_chunk_with_transactions(
         &mut env.clients[0],
         vec![
             SignedTransaction::send_money(
                 2,
-                "test0".parse().unwrap(),
-                "test1".parse().unwrap(),
+                "test0".parse::<AccountId>().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
                 &signer,
                 1000,
                 genesis_hash,
             ),
             SignedTransaction::send_money(
                 1,
-                "test0".parse().unwrap(),
-                "test1".parse().unwrap(),
+                "test0".parse::<AccountId>().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
                 &signer,
                 1000,
                 genesis_hash,
@@ -319,7 +327,10 @@ fn test_verify_chunk_proofs_challenge_transaction_order() {
     let shard_id = chunk.shard_id();
     let challenge_result =
         challenge(env, shard_id as usize, MaybeEncodedShardChunk::Encoded(chunk), &block);
-    assert_eq!(challenge_result.unwrap(), (*block.hash(), vec!["test0".parse().unwrap()]));
+    assert_eq!(
+        challenge_result.unwrap(),
+        (*block.hash(), vec!["test0".parse::<AccountId>().unwrap()])
+    );
 }
 
 fn challenge(
@@ -348,12 +359,16 @@ fn challenge(
 
 #[test]
 fn test_verify_chunk_invalid_state_challenge() {
-    let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     let mut env = TestEnv::builder(ChainGenesis::test())
         .real_epoch_managers(&genesis.config)
         .nightshade_runtimes(&genesis)
         .build();
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let validator_signer = create_test_signer("test0");
     let genesis_hash = *env.clients[0].chain.genesis().hash();
     env.produce_block(0, 1);
@@ -361,8 +376,8 @@ fn test_verify_chunk_invalid_state_challenge() {
         env.clients[0].process_tx(
             SignedTransaction::send_money(
                 1,
-                "test0".parse().unwrap(),
-                "test1".parse().unwrap(),
+                "test0".parse::<AccountId>().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
                 &signer,
                 1000,
                 genesis_hash,
@@ -498,7 +513,7 @@ fn test_verify_chunk_invalid_state_challenge() {
     //         &challenge,
     //     )
     //     .unwrap(),
-    //     (*block.hash(), vec!["test0".parse().unwrap()])
+    //     (*block.hash(), vec!["test0".parse::<AccountId>().unwrap()])
     // );
 
     // Process the block with invalid chunk and make sure it's marked as invalid at the end.
@@ -616,7 +631,11 @@ fn test_block_challenge() {
 fn test_fishermen_challenge() {
     init_test_logger();
     let mut genesis = Genesis::test(
-        vec!["test0".parse().unwrap(), "test1".parse().unwrap(), "test2".parse().unwrap()],
+        vec![
+            "test0".parse::<AccountId>().unwrap(),
+            "test1".parse::<AccountId>().unwrap(),
+            "test2".parse::<AccountId>().unwrap(),
+        ],
         1,
     );
     genesis.config.epoch_length = 5;
@@ -625,11 +644,12 @@ fn test_fishermen_challenge() {
         .real_epoch_managers(&genesis.config)
         .nightshade_runtimes(&genesis)
         .build();
-    let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+    let signer =
+        InMemorySigner::from_seed("test1".parse::<AccountId>().unwrap(), KeyType::ED25519, "test1");
     let genesis_hash = *env.clients[0].chain.genesis().hash();
     let stake_transaction = SignedTransaction::stake(
         1,
-        "test1".parse().unwrap(),
+        "test1".parse::<AccountId>().unwrap(),
         &signer,
         FISHERMEN_THRESHOLD,
         signer.public_key(),
@@ -676,7 +696,10 @@ fn test_fishermen_challenge() {
 #[ignore]
 fn test_challenge_in_different_epoch() {
     init_test_logger();
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 2);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        2,
+    );
     genesis.config.epoch_length = 3;
     //    genesis.config.validator_kickout_threshold = 10;
     let network_adapter = Arc::new(MockPeerManagerAdapter::default());

--- a/integration-tests/src/tests/client/chunks_management.rs
+++ b/integration-tests/src/tests/client/chunks_management.rs
@@ -62,32 +62,32 @@ impl Test {
             .num_shards(4)
             .block_producers_per_epoch(vec![
                 vec![
-                    "test1".parse().unwrap(),
-                    "test2".parse().unwrap(),
-                    "test3".parse().unwrap(),
-                    "test4".parse().unwrap(),
+                    "test1".parse::<AccountId>().unwrap(),
+                    "test2".parse::<AccountId>().unwrap(),
+                    "test3".parse::<AccountId>().unwrap(),
+                    "test4".parse::<AccountId>().unwrap(),
                 ],
                 vec![
-                    "test5".parse().unwrap(),
-                    "test6".parse().unwrap(),
-                    "test7".parse().unwrap(),
-                    "test8".parse().unwrap(),
+                    "test5".parse::<AccountId>().unwrap(),
+                    "test6".parse::<AccountId>().unwrap(),
+                    "test7".parse::<AccountId>().unwrap(),
+                    "test8".parse::<AccountId>().unwrap(),
                 ],
             ])
             .validator_groups(self.validator_groups);
         if self.chunk_only_producers {
             vs = vs.chunk_only_producers_per_epoch_per_shard(vec![
                 vec![
-                    vec!["cop1".parse().unwrap()],
-                    vec!["cop2".parse().unwrap()],
-                    vec!["cop3".parse().unwrap()],
-                    vec!["cop4".parse().unwrap()],
+                    vec!["cop1".parse::<AccountId>().unwrap()],
+                    vec!["cop2".parse::<AccountId>().unwrap()],
+                    vec!["cop3".parse::<AccountId>().unwrap()],
+                    vec!["cop4".parse::<AccountId>().unwrap()],
                 ],
                 vec![
-                    vec!["cop5".parse().unwrap()],
-                    vec!["cop6".parse().unwrap()],
-                    vec!["cop7".parse().unwrap()],
-                    vec!["cop8".parse().unwrap()],
+                    vec!["cop5".parse::<AccountId>().unwrap()],
+                    vec!["cop6".parse::<AccountId>().unwrap()],
+                    vec!["cop7".parse::<AccountId>().unwrap()],
+                    vec!["cop8".parse::<AccountId>().unwrap()],
                 ],
             ]);
         }
@@ -195,7 +195,7 @@ impl Test {
                     } => {
                         partial_chunk_msgs += 1;
                         if self.drop_to_4_from.contains(&from_whom.as_str())
-                            && to_whom.as_ref() == "test4"
+                            && to_whom.as_str() == "test4"
                         {
                             println!(
                                 "Dropping Partial Encoded Chunk Message from {from_whom} to test4"
@@ -209,7 +209,7 @@ impl Test {
                             return (NetworkResponses::NoResponse.into(), false);
                         }
                         if self.drop_to_4_from.contains(&from_whom.as_str())
-                            && to_whom.as_ref() == "test4"
+                            && to_whom.as_str() == "test4"
                         {
                             println!(
                             "Dropping Partial Encoded Chunk Forward Message from {from_whom} to test4"
@@ -225,14 +225,14 @@ impl Test {
                         ..
                     } => {
                         if self.drop_to_4_from.contains(&to_whom.as_str())
-                            && from_whom.as_ref() == "test4"
+                            && from_whom.as_str() == "test4"
                         {
                             info!("Dropping Partial Encoded Chunk Request from test4 to {to_whom}");
                             return (NetworkResponses::NoResponse.into(), false);
                         }
                         if !self.drop_to_4_from.is_empty()
-                            && from_whom.as_ref() == "test4"
-                            && to_whom.as_ref() == "test2"
+                            && from_whom.as_str() == "test4"
+                            && to_whom.as_str() == "test2"
                         {
                             info!("Observed Partial Encoded Chunk Request from test4 to test2");
                         }

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -76,7 +76,10 @@ fn test_storage_after_commit_of_cold_update() {
     let epoch_length = 5;
     let max_height = epoch_length * 4;
 
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
 
     genesis.config.epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
@@ -97,12 +100,16 @@ fn test_storage_after_commit_of_cold_update() {
     let state_changes_reads = test_get_store_reads(DBCol::StateChanges);
 
     for h in 1..max_height {
-        let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+        let signer = InMemorySigner::from_seed(
+            "test0".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test0",
+        );
         if h == 1 {
             let tx = SignedTransaction::from_actions(
                 h,
-                "test0".parse().unwrap(),
-                "test0".parse().unwrap(),
+                "test0".parse::<AccountId>().unwrap(),
+                "test0".parse::<AccountId>().unwrap(),
                 &signer,
                 vec![Action::DeployContract(DeployContractAction {
                     code: near_test_contracts::rs_contract().to_vec(),
@@ -118,8 +125,8 @@ fn test_storage_after_commit_of_cold_update() {
             for i in 0..5 {
                 let tx = SignedTransaction::from_actions(
                     h * 10 + i,
-                    "test0".parse().unwrap(),
-                    "test0".parse().unwrap(),
+                    "test0".parse::<AccountId>().unwrap(),
+                    "test0".parse::<AccountId>().unwrap(),
                     &signer,
                     vec![Action::FunctionCall(Box::new(FunctionCallAction {
                         method_name: "write_random_value".to_string(),
@@ -134,8 +141,8 @@ fn test_storage_after_commit_of_cold_update() {
             for i in 0..5 {
                 let tx = SignedTransaction::send_money(
                     h * 10 + i,
-                    "test0".parse().unwrap(),
-                    "test1".parse().unwrap(),
+                    "test0".parse::<AccountId>().unwrap(),
+                    "test1".parse::<AccountId>().unwrap(),
                     &signer,
                     1,
                     last_hash,
@@ -226,7 +233,10 @@ fn test_cold_db_head_update() {
     let epoch_length = 5;
     let max_height = epoch_length * 10;
 
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
 
     genesis.config.epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
@@ -271,7 +281,10 @@ fn test_cold_db_copy_with_height_skips() {
 
     let skips = HashSet::from([1, 4, 5, 7, 11, 14, 16, 19]);
 
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
 
     genesis.config.epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
@@ -289,7 +302,11 @@ fn test_cold_db_copy_with_height_skips() {
         .unwrap();
 
     for h in 1..max_height {
-        let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+        let signer = InMemorySigner::from_seed(
+            "test0".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test0",
+        );
         // It is still painful to filter out transactions in last two blocks.
         // So, as block 19 is skipped, blocks 17 and 18 shouldn't contain any transactions.
         // So, we shouldn't send any transactions between block 17 and the previous block.
@@ -299,8 +316,8 @@ fn test_cold_db_copy_with_height_skips() {
             for i in 0..5 {
                 let tx = SignedTransaction::send_money(
                     h * 10 + i,
-                    "test0".parse().unwrap(),
-                    "test1".parse().unwrap(),
+                    "test0".parse::<AccountId>().unwrap(),
+                    "test1".parse::<AccountId>().unwrap(),
                     &signer,
                     1,
                     last_hash,
@@ -389,7 +406,10 @@ fn test_initial_copy_to_cold(batch_size: usize) {
     let epoch_length = 5;
     let max_height = epoch_length * 4;
 
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
 
     genesis.config.epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
@@ -404,12 +424,16 @@ fn test_initial_copy_to_cold(batch_size: usize) {
     let mut last_hash = *env.clients[0].chain.genesis().hash();
 
     for h in 1..max_height {
-        let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+        let signer = InMemorySigner::from_seed(
+            "test0".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test0",
+        );
         for i in 0..5 {
             let tx = SignedTransaction::send_money(
                 h * 10 + i,
-                "test0".parse().unwrap(),
-                "test1".parse().unwrap(),
+                "test0".parse::<AccountId>().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
                 &signer,
                 1,
                 last_hash,
@@ -485,7 +509,10 @@ fn test_cold_loop_on_gc_boundary() {
 
     let epoch_length = 5;
 
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
 
     genesis.config.epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
@@ -507,12 +534,16 @@ fn test_cold_loop_on_gc_boundary() {
     let mut last_hash = *env.clients[0].chain.genesis().hash();
 
     for h in 1..height_delta {
-        let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+        let signer = InMemorySigner::from_seed(
+            "test0".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test0",
+        );
         for i in 0..5 {
             let tx = SignedTransaction::send_money(
                 h * 10 + i,
-                "test0".parse().unwrap(),
-                "test1".parse().unwrap(),
+                "test0".parse::<AccountId>().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
                 &signer,
                 1,
                 last_hash,
@@ -533,12 +564,16 @@ fn test_cold_loop_on_gc_boundary() {
     update_cold_head(&*store.cold_db().unwrap(), &hot_store, &(height_delta - 1)).unwrap();
 
     for h in height_delta..height_delta * 2 {
-        let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+        let signer = InMemorySigner::from_seed(
+            "test0".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test0",
+        );
         for i in 0..5 {
             let tx = SignedTransaction::send_money(
                 h * 10 + i,
-                "test0".parse().unwrap(),
-                "test1".parse().unwrap(),
+                "test0".parse::<AccountId>().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
                 &signer,
                 1,
                 last_hash,

--- a/integration-tests/src/tests/client/epoch_sync.rs
+++ b/integration-tests/src/tests/client/epoch_sync.rs
@@ -14,12 +14,13 @@ use nearcore::test_utils::TestEnvNightshadeSetupExt;
 
 fn generate_transactions(last_hash: &CryptoHash, h: BlockHeight) -> Vec<SignedTransaction> {
     let mut txs = vec![];
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     if h == 1 {
         txs.push(SignedTransaction::from_actions(
             h,
-            "test0".parse().unwrap(),
-            "test0".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             &signer,
             vec![Action::DeployContract(DeployContractAction {
                 code: near_test_contracts::rs_contract().to_vec(),
@@ -31,8 +32,8 @@ fn generate_transactions(last_hash: &CryptoHash, h: BlockHeight) -> Vec<SignedTr
     for i in 0..5 {
         txs.push(SignedTransaction::from_actions(
             h * 10 + i,
-            "test0".parse().unwrap(),
-            "test0".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             &signer,
             vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "write_random_value".to_string(),
@@ -47,8 +48,8 @@ fn generate_transactions(last_hash: &CryptoHash, h: BlockHeight) -> Vec<SignedTr
     for i in 0..5 {
         txs.push(SignedTransaction::send_money(
             h * 10 + i,
-            "test0".parse().unwrap(),
-            "test1".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
+            "test1".parse::<AccountId>().unwrap(),
             &signer,
             1,
             *last_hash,
@@ -66,7 +67,10 @@ fn test_continuous_epoch_sync_info_population() {
     let epoch_length = 5;
     let max_height = epoch_length * 4 + 1;
 
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
 
     genesis.config.epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();

--- a/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
@@ -49,7 +49,10 @@ fn check_tx_processing(
 #[test]
 fn test_transaction_hash_collision() {
     let epoch_length = 5;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(ChainGenesis::test())
         .real_epoch_managers(&genesis.config)
@@ -57,21 +60,23 @@ fn test_transaction_hash_collision() {
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
-    let signer0 = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
-    let signer1 = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+    let signer0 =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
+    let signer1 =
+        InMemorySigner::from_seed("test1".parse::<AccountId>().unwrap(), KeyType::ED25519, "test1");
     let send_money_tx = SignedTransaction::send_money(
         1,
-        "test1".parse().unwrap(),
-        "test0".parse().unwrap(),
+        "test1".parse::<AccountId>().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
         &signer1,
         100,
         *genesis_block.hash(),
     );
     let delete_account_tx = SignedTransaction::delete_account(
         2,
-        "test1".parse().unwrap(),
-        "test1".parse().unwrap(),
-        "test0".parse().unwrap(),
+        "test1".parse::<AccountId>().unwrap(),
+        "test1".parse::<AccountId>().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
         &signer1,
         *genesis_block.hash(),
     );
@@ -91,8 +96,8 @@ fn test_transaction_hash_collision() {
 
     let create_account_tx = SignedTransaction::create_account(
         1,
-        "test0".parse().unwrap(),
-        "test1".parse().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
+        "test1".parse::<AccountId>().unwrap(),
         NEAR_BASE,
         signer1.public_key(),
         &signer0,
@@ -120,7 +125,10 @@ fn get_status_of_tx_hash_collision_for_implicit_account(
     protocol_version: ProtocolVersion,
 ) -> ProcessTxResponse {
     let epoch_length = 100;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     genesis.config.protocol_version = protocol_version;
     let mut env = TestEnv::builder(ChainGenesis::test())
@@ -129,7 +137,8 @@ fn get_status_of_tx_hash_collision_for_implicit_account(
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
-    let signer1 = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+    let signer1 =
+        InMemorySigner::from_seed("test1".parse::<AccountId>().unwrap(), KeyType::ED25519, "test1");
 
     let public_key = &signer1.public_key;
     let raw_public_key = public_key.unwrap_as_ed25519().0.to_vec();
@@ -143,7 +152,7 @@ fn get_status_of_tx_hash_collision_for_implicit_account(
     // Send money to implicit account, invoking its creation.
     let send_money_tx = SignedTransaction::send_money(
         1,
-        "test1".parse().unwrap(),
+        "test1".parse::<AccountId>().unwrap(),
         implicit_account_id.clone(),
         &signer1,
         deposit_for_account_creation,
@@ -158,7 +167,7 @@ fn get_status_of_tx_hash_collision_for_implicit_account(
         (height - 1) * near_primitives::account::AccessKey::ACCESS_KEY_NONCE_RANGE_MULTIPLIER,
         implicit_account_id.clone(),
         implicit_account_id.clone(),
-        "test0".parse().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
         &implicit_account_signer,
         *block.hash(),
     );
@@ -168,7 +177,7 @@ fn get_status_of_tx_hash_collision_for_implicit_account(
     // Send money to implicit account again, invoking its second creation.
     let send_money_again_tx = SignedTransaction::send_money(
         2,
-        "test1".parse().unwrap(),
+        "test1".parse::<AccountId>().unwrap(),
         implicit_account_id.clone(),
         &signer1,
         deposit_for_account_creation,
@@ -181,7 +190,7 @@ fn get_status_of_tx_hash_collision_for_implicit_account(
     let send_money_from_implicit_account_tx = SignedTransaction::send_money(
         1,
         implicit_account_id.clone(),
-        "test0".parse().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
         &implicit_account_signer,
         100,
         *block.hash(),
@@ -192,7 +201,7 @@ fn get_status_of_tx_hash_collision_for_implicit_account(
     let send_money_from_implicit_account_tx = SignedTransaction::send_money(
         (height - 1) * AccessKey::ACCESS_KEY_NONCE_RANGE_MULTIPLIER,
         implicit_account_id,
-        "test0".parse().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
         &implicit_account_signer,
         100,
         *block.hash(),
@@ -227,18 +236,22 @@ fn test_transaction_hash_collision_for_implicit_account_ok() {
 #[test]
 fn test_chunk_transaction_validity() {
     let epoch_length = 5;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(ChainGenesis::test())
         .real_epoch_managers(&genesis.config)
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let tx = SignedTransaction::send_money(
         1,
-        "test1".parse().unwrap(),
-        "test0".parse().unwrap(),
+        "test1".parse::<AccountId>().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
         &signer,
         100,
         *genesis_block.hash(),
@@ -264,19 +277,23 @@ fn test_chunk_transaction_validity() {
 #[test]
 fn test_transaction_nonce_too_large() {
     let epoch_length = 5;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(ChainGenesis::test())
         .real_epoch_managers(&genesis.config)
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let large_nonce = AccessKey::ACCESS_KEY_NONCE_RANGE_MULTIPLIER + 1;
     let tx = SignedTransaction::send_money(
         large_nonce,
-        "test1".parse().unwrap(),
-        "test0".parse().unwrap(),
+        "test1".parse::<AccountId>().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
         &signer,
         100,
         *genesis_block.hash(),

--- a/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
+++ b/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
@@ -8,6 +8,7 @@ use near_primitives::errors::{ActionsValidationError, InvalidTxError};
 use near_primitives::hash::CryptoHash;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::transaction::{Action, AddKeyAction, Transaction};
+use near_primitives::types::AccountId;
 use nearcore::config::GenesisExt;
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
 
@@ -26,8 +27,10 @@ fn test_account_id_in_function_call_permission_upgrade() {
     // Prepare TestEnv with a contract at the old protocol version.
     let mut env = {
         let epoch_length = 5;
-        let mut genesis =
-            Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+        let mut genesis = Genesis::test(
+            vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+            1,
+        );
         genesis.config.epoch_length = epoch_length;
         genesis.config.protocol_version = old_protocol_version;
         let chain_genesis = ChainGenesis::new(&genesis);
@@ -40,10 +43,11 @@ fn test_account_id_in_function_call_permission_upgrade() {
             .build()
     };
 
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let tx = Transaction {
-        signer_id: "test0".parse().unwrap(),
-        receiver_id: "test0".parse().unwrap(),
+        signer_id: "test0".parse::<AccountId>().unwrap(),
+        receiver_id: "test0".parse::<AccountId>().unwrap(),
         public_key: signer.public_key(),
         actions: vec![Action::AddKey(Box::new(AddKeyAction {
             public_key: signer.public_key(),
@@ -93,7 +97,10 @@ fn test_account_id_in_function_call_permission_upgrade() {
 #[test]
 fn test_very_long_account_id() {
     let mut env = {
-        let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+        let genesis = Genesis::test(
+            vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+            1,
+        );
         let chain_genesis = ChainGenesis::new(&genesis);
         TestEnv::builder(chain_genesis)
             .real_epoch_managers(&genesis.config)
@@ -105,10 +112,11 @@ fn test_very_long_account_id() {
     };
 
     let tip = env.clients[0].chain.head().unwrap();
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let tx = Transaction {
-        signer_id: "test0".parse().unwrap(),
-        receiver_id: "test0".parse().unwrap(),
+        signer_id: "test0".parse::<AccountId>().unwrap(),
+        receiver_id: "test0".parse::<AccountId>().unwrap(),
         public_key: signer.public_key(),
         actions: vec![Action::AddKey(Box::new(AddKeyAction {
             public_key: signer.public_key(),

--- a/integration-tests/src/tests/client/features/chunk_nodes_cache.rs
+++ b/integration-tests/src/tests/client/features/chunk_nodes_cache.rs
@@ -12,7 +12,7 @@ use near_primitives::test_utils::encode;
 use near_primitives::transaction::{
     Action, ExecutionMetadata, FunctionCallAction, SignedTransaction,
 };
-use near_primitives::types::{BlockHeightDelta, Gas, TrieNodesCount};
+use near_primitives::types::{AccountId, BlockHeightDelta, Gas, TrieNodesCount};
 use near_primitives::version::{ProtocolFeature, ProtocolVersion};
 use near_primitives::views::FinalExecutionStatus;
 use nearcore::config::GenesisExt;
@@ -34,8 +34,8 @@ fn process_transaction(
     let gas = 20_000_000_000_000;
     let tx = SignedTransaction::from_actions(
         next_height,
-        "test0".parse().unwrap(),
-        "test0".parse().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
         signer,
         vec![
             Action::FunctionCall(Box::new(FunctionCallAction {
@@ -83,7 +83,10 @@ fn process_transaction(
 /// cache. 4nd run should give the same results, because caching must not affect different chunks.
 #[test]
 fn compare_node_counts() {
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     let epoch_length = 10;
     let num_blocks = 5;
 
@@ -101,13 +104,14 @@ fn compare_node_counts() {
 
     deploy_test_contract(
         &mut env,
-        "test0".parse().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
         near_test_contracts::backwards_compatible_rs_contract(),
         num_blocks,
         1,
     );
 
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let tx_node_counts: Vec<TrieNodesCount> = (0..4)
         .map(|i| {
             let touching_trie_node_cost: Gas = 16_101_955_926;

--- a/integration-tests/src/tests/client/features/delegate_action.rs
+++ b/integration-tests/src/tests/client/features/delegate_action.rs
@@ -45,10 +45,10 @@ fn exec_meta_transaction(
     protocol_version: ProtocolVersion,
 ) -> FinalExecutionStatus {
     near_o11y::testonly::init_test_logger();
-    let validator: AccountId = "test0".parse().unwrap();
-    let user: AccountId = "alice.near".parse().unwrap();
-    let receiver: AccountId = "bob.near".parse().unwrap();
-    let relayer: AccountId = "relayer.near".parse().unwrap();
+    let validator: AccountId = "test0".parse::<AccountId>().unwrap();
+    let user: AccountId = "alice.near".parse::<AccountId>().unwrap();
+    let receiver: AccountId = "bob.near".parse::<AccountId>().unwrap();
+    let relayer: AccountId = "relayer.near".parse::<AccountId>().unwrap();
     let mut genesis =
         Genesis::test(vec![validator, user.clone(), receiver.clone(), relayer.clone()], 1);
     genesis.config.epoch_length = 1000;
@@ -130,13 +130,13 @@ fn check_meta_tx_execution(
     let relayer_before = node_user.view_balance(&relayer).unwrap();
     let receiver_before = node_user.view_balance(&receiver).unwrap_or(0);
     let relayer_nonce_before = node_user
-        .get_access_key(&relayer, &PublicKey::from_seed(KeyType::ED25519, &relayer))
+        .get_access_key(&relayer, &PublicKey::from_seed(KeyType::ED25519, relayer.as_str()))
         .unwrap()
         .nonce;
     let user_pubk = if sender.is_implicit() {
         PublicKey::from_implicit_account(&sender).unwrap()
     } else {
-        PublicKey::from_seed(KeyType::ED25519, &sender)
+        PublicKey::from_seed(KeyType::ED25519, sender.as_str())
     };
     let user_nonce_before = node_user.get_access_key(&sender, &user_pubk).unwrap().nonce;
 
@@ -148,13 +148,13 @@ fn check_meta_tx_execution(
 
     // both nonces should be increased by 1
     let relayer_nonce = node_user
-        .get_access_key(&relayer, &PublicKey::from_seed(KeyType::ED25519, &relayer))
+        .get_access_key(&relayer, &PublicKey::from_seed(KeyType::ED25519, relayer.as_str()))
         .unwrap()
         .nonce;
     assert_eq!(relayer_nonce, relayer_nonce_before + 1);
     // user key must be checked for existence (to test DeleteKey action)
     if let Ok(user_nonce) = node_user
-        .get_access_key(&sender, &PublicKey::from_seed(KeyType::ED25519, &sender))
+        .get_access_key(&sender, &PublicKey::from_seed(KeyType::ED25519, sender.as_str()))
         .map(|key| key.nonce)
     {
         assert_eq!(user_nonce, user_nonce_before + 1);
@@ -299,7 +299,7 @@ fn meta_tx_fn_call_access_key() {
     let sender = bob_account();
     let relayer = alice_account();
     let receiver = carol_account();
-    let signer = create_user_test_signer(&sender);
+    let signer = create_user_test_signer(sender.as_str());
     let public_key = signer.public_key();
 
     let node = setup_with_access_key(
@@ -359,7 +359,7 @@ fn meta_tx_fn_call_access_key_insufficient_allowance() {
 
     // 1 yocto near, that's less than 1 gas unit
     let initial_allowance = 1;
-    let signer = create_user_test_signer(&sender);
+    let signer = create_user_test_signer(sender.as_str());
 
     let node = setup_with_access_key(
         &relayer,
@@ -392,7 +392,7 @@ fn meta_tx_fn_call_access_wrong_method() {
     let sender = bob_account();
     let relayer = alice_account();
     let receiver = carol_account();
-    let signer = create_user_test_signer(&sender);
+    let signer = create_user_test_signer(sender.as_str());
 
     let access_key_method_name = "log_something_else";
     let node = setup_with_access_key(
@@ -448,7 +448,7 @@ fn meta_tx_stake() {
     let fee_helper = fee_helper(&node);
 
     let tx_cost = fee_helper.stake_cost();
-    let public_key = create_user_test_signer(&sender).public_key;
+    let public_key = create_user_test_signer(sender.as_str()).public_key;
     let actions = vec![Action::Stake(Box::new(StakeAction { public_key, stake: 0 }))];
     check_meta_tx_no_fn_call(&node, actions, tx_cost, 0, sender, relayer, receiver);
 }
@@ -493,7 +493,7 @@ fn meta_tx_delete_key() {
     let fee_helper = fee_helper(&node);
 
     let tx_cost = fee_helper.delete_key_cost();
-    let public_key = PublicKey::from_seed(KeyType::ED25519, &receiver);
+    let public_key = PublicKey::from_seed(KeyType::ED25519, receiver.as_str());
     let actions =
         vec![Action::DeleteKey(Box::new(DeleteKeyAction { public_key: public_key.clone() }))];
     check_meta_tx_no_fn_call(&node, actions, tx_cost, 0, sender, relayer, receiver.clone());
@@ -518,7 +518,7 @@ fn meta_tx_delete_account() {
         .create_account(
             relayer.clone(),
             sender.clone(),
-            PublicKey::from_seed(KeyType::ED25519, &sender),
+            PublicKey::from_seed(KeyType::ED25519, sender.as_str()),
             balance,
         )
         .expect("account setup failed")
@@ -577,13 +577,13 @@ fn meta_tx_ft_transfer() {
         .assert_success();
 
     // register sender & receiver FT accounts
-    let actions = vec![ft_register_action(&sender), ft_register_action(&receiver)];
+    let actions = vec![ft_register_action(sender.as_str()), ft_register_action(&receiver)];
     node.user()
         .sign_and_commit_actions(relayer.clone(), ft_contract.clone(), actions)
         .expect("registering FT accounts")
         .assert_success();
     // initialize sender balance
-    let actions = vec![ft_transfer_action(&sender, 10_000).0];
+    let actions = vec![ft_transfer_action(sender.as_str(), 10_000).0];
     node.user()
         .sign_and_commit_actions(relayer.clone(), ft_contract.clone(), actions)
         .expect("initializing sender balance failed")
@@ -591,7 +591,7 @@ fn meta_tx_ft_transfer() {
 
     // START OF META TRANSACTION
     // 1% fee to the relayer
-    let (action0, bytes0) = ft_transfer_action(&relayer, 10);
+    let (action0, bytes0) = ft_transfer_action(relayer.as_str(), 10);
     // the actual transfer
     let (action1, bytes1) = ft_transfer_action(receiver, 1000);
     let actions = vec![action0, action1];
@@ -612,19 +612,19 @@ fn meta_tx_ft_transfer() {
     assert_eq!(2, fn_call_logs.len(), "expected 2 JSON events but found {fn_call_logs:?}");
     assert_eq!(
         fn_call_logs[0],
-        ft_transfer_event(&sender, &relayer, 10),
+        ft_transfer_event(sender.as_str(), relayer.as_str(), 10),
         "relayer event looks wrong"
     );
     assert_eq!(
         fn_call_logs[1],
-        ft_transfer_event(&sender, &receiver, 1000),
+        ft_transfer_event(sender.as_str(), &receiver, 1000),
         "receiver event looks wrong"
     );
 
     // Also check FT balances
     assert_ft_balance(&node, &ft_contract, &receiver, 1000);
-    assert_ft_balance(&node, &ft_contract, &sender, 10_000 - 1000 - 10);
-    assert_ft_balance(&node, &ft_contract, &relayer, 1_000_000 - 10_000 + 10);
+    assert_ft_balance(&node, &ft_contract, sender.as_str(), 10_000 - 1000 - 10);
+    assert_ft_balance(&node, &ft_contract, relayer.as_str(), 1_000_000 - 10_000 + 10);
 }
 
 /// Call the function "log_something" in the test contract.
@@ -758,7 +758,7 @@ fn meta_tx_create_named_account() {
     let fee_helper = fee_helper(&node);
     let amount = NEAR_BASE;
 
-    let public_key = PublicKey::from_seed(KeyType::ED25519, &new_account);
+    let public_key = PublicKey::from_seed(KeyType::ED25519, new_account.as_str());
 
     // That's the minimum to create a (useful) account.
     let actions = vec![

--- a/integration-tests/src/tests/client/features/fix_contract_loading_cost.rs
+++ b/integration-tests/src/tests/client/features/fix_contract_loading_cost.rs
@@ -39,7 +39,7 @@ fn unchanged_gas_cost() {
 
     let epoch_length: BlockHeight = 5;
 
-    let account: AccountId = "test0".parse().unwrap();
+    let account: AccountId = "test0".parse::<AccountId>().unwrap();
     let mut env =
         prepare_env_with_contract(epoch_length, old_protocol_version, account.clone(), contract);
 
@@ -68,7 +68,7 @@ fn preparation_error_gas_cost() {
 
     let epoch_length: BlockHeight = 5;
 
-    let account: AccountId = "test0".parse().unwrap();
+    let account: AccountId = "test0".parse::<AccountId>().unwrap();
     let mut env = prepare_env_with_contract(
         epoch_length,
         old_protocol_version,

--- a/integration-tests/src/tests/client/features/flat_storage.rs
+++ b/integration-tests/src/tests/client/features/flat_storage.rs
@@ -6,6 +6,7 @@ use near_client::ProcessTxResponse;
 use near_crypto::{InMemorySigner, KeyType, Signer};
 use near_primitives::test_utils::encode;
 use near_primitives::transaction::{Action, ExecutionMetadata, FunctionCallAction, Transaction};
+use near_primitives::types::AccountId;
 use near_primitives::version::ProtocolFeature;
 use near_primitives_core::config::ExtCosts;
 use near_primitives_core::hash::CryptoHash;
@@ -22,7 +23,10 @@ fn test_flat_storage_upgrade() {
     // the release branch where the protocol upgrade date is set.
     std::env::set_var("NEAR_TESTS_IMMEDIATE_PROTOCOL_UPGRADE", "1");
 
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     let epoch_length = 12;
     let new_protocol_version = ProtocolFeature::FlatStorageReads.protocol_version();
     let old_protocol_version = new_protocol_version - 1;
@@ -46,18 +50,19 @@ fn test_flat_storage_upgrade() {
     // Deploy contract to state.
     deploy_test_contract_with_protocol_version(
         &mut env,
-        "test0".parse().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
         near_test_contracts::backwards_compatible_rs_contract(),
         blocks_to_process_txn,
         1,
         old_protocol_version,
     );
 
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let gas = 20_000_000_000_000;
     let tx = Transaction {
-        signer_id: "test0".parse().unwrap(),
-        receiver_id: "test0".parse().unwrap(),
+        signer_id: "test0".parse::<AccountId>().unwrap(),
+        receiver_id: "test0".parse::<AccountId>().unwrap(),
         public_key: signer.public_key(),
         actions: vec![],
         nonce: 0,

--- a/integration-tests/src/tests/client/features/increase_deployment_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_deployment_cost.rs
@@ -5,6 +5,7 @@ use near_client::test_utils::TestEnv;
 use near_crypto::{InMemorySigner, KeyType};
 use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::transaction::{Action, DeployContractAction};
+use near_primitives::types::AccountId;
 use near_primitives::version::ProtocolFeature;
 use near_primitives::views::FinalExecutionStatus;
 use near_primitives_core::version::PROTOCOL_VERSION;
@@ -32,7 +33,7 @@ fn test_deploy_cost_increased() {
     // Prepare TestEnv with a contract at the old protocol version.
     let epoch_length = 5;
     let mut env = {
-        let mut genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
+        let mut genesis = Genesis::test(vec!["test0".parse::<AccountId>().unwrap()], 1);
         genesis.config.epoch_length = epoch_length;
         genesis.config.protocol_version = old_protocol_version;
         let chain_genesis = ChainGenesis::new(&genesis);
@@ -45,7 +46,8 @@ fn test_deploy_cost_increased() {
             .build()
     };
 
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let actions = vec![Action::DeployContract(DeployContractAction { code: test_contract })];
 
     let tx = env.tx_from_actions(actions.clone(), &signer, signer.account_id.clone());

--- a/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
@@ -186,8 +186,8 @@ fn assert_compute_limit_reached(
 
     // Prepare TestEnv with a contract at the old protocol version.
     let epoch_length = 100;
-    let contract_account: AccountId = "test0".parse().unwrap();
-    let user_account: AccountId = "test1".parse().unwrap();
+    let contract_account: AccountId = "test0".parse::<AccountId>().unwrap();
+    let user_account: AccountId = "test1".parse::<AccountId>().unwrap();
     let runtime_config_store = RuntimeConfigStore::new(None);
     let old_config = runtime_config_store.get_config(old_protocol_version).clone();
     let new_config = runtime_config_store.get_config(new_protocol_version).clone();
@@ -212,7 +212,7 @@ fn assert_compute_limit_reached(
         let signer = InMemorySigner::from_seed(
             contract_account.clone(),
             KeyType::ED25519,
-            &contract_account,
+            contract_account.as_str(),
         );
         let tx = env.tx_from_actions(actions, &signer, signer.account_id.clone());
         env.execute_tx(tx).unwrap().assert_success();
@@ -300,7 +300,8 @@ fn produce_saturated_chunk(
         gas,
         deposit: 0,
     }))];
-    let signer = InMemorySigner::from_seed(user_account.clone(), KeyType::ED25519, user_account);
+    let signer =
+        InMemorySigner::from_seed(user_account.clone(), KeyType::ED25519, user_account.as_str());
 
     let tip = env.clients[0].chain.head().unwrap();
     let mut tx_factory = || {

--- a/integration-tests/src/tests/client/features/limit_contract_functions_number.rs
+++ b/integration-tests/src/tests/client/features/limit_contract_functions_number.rs
@@ -7,6 +7,7 @@ use near_primitives::errors::{
     ActionErrorKind, CompilationError, FunctionCallError, PrepareError, TxExecutionError,
 };
 use near_primitives::runtime::config_store::RuntimeConfigStore;
+use near_primitives::types::AccountId;
 use near_primitives::version::ProtocolFeature;
 use near_primitives::views::FinalExecutionStatus;
 use nearcore::config::GenesisExt;
@@ -24,8 +25,10 @@ fn verify_contract_limits_upgrade(
     let epoch_length = 5;
     // Prepare TestEnv with a contract at the old protocol version.
     let mut env = {
-        let mut genesis =
-            Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+        let mut genesis = Genesis::test(
+            vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+            1,
+        );
         genesis.config.epoch_length = epoch_length;
         genesis.config.protocol_version = old_protocol_version;
         let chain_genesis = ChainGenesis::new(&genesis);
@@ -39,7 +42,7 @@ fn verify_contract_limits_upgrade(
 
         deploy_test_contract(
             &mut env,
-            "test0".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             &near_test_contracts::LargeContract {
                 functions: function_limit + 1,
                 locals_per_function: local_limit + 1,
@@ -52,7 +55,7 @@ fn verify_contract_limits_upgrade(
         env
     };
 
-    let account = "test0".parse().unwrap();
+    let account = "test0".parse::<AccountId>().unwrap();
     let old_outcome = env.call_main(&account);
 
     env.upgrade_protocol(new_protocol_version);

--- a/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
+++ b/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
@@ -9,7 +9,7 @@ use near_primitives::errors::TxExecutionError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::transaction::{Action, FunctionCallAction, Transaction};
-use near_primitives::types::BlockHeight;
+use near_primitives::types::{AccountId, BlockHeight};
 use near_primitives::views::FinalExecutionStatus;
 use nearcore::config::GenesisExt;
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
@@ -39,8 +39,10 @@ fn protocol_upgrade() {
 
     // Prepare TestEnv with a contract at the old protocol version.
     let mut env = {
-        let mut genesis =
-            Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+        let mut genesis = Genesis::test(
+            vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+            1,
+        );
         genesis.config.epoch_length = epoch_length;
         genesis.config.protocol_version = old_protocol_version;
         let chain_genesis = ChainGenesis::new(&genesis);
@@ -55,7 +57,7 @@ fn protocol_upgrade() {
 
         deploy_test_contract_with_protocol_version(
             &mut env,
-            "test0".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             near_test_contracts::backwards_compatible_rs_contract(),
             epoch_length,
             1,
@@ -64,10 +66,11 @@ fn protocol_upgrade() {
         env
     };
 
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let tx = Transaction {
-        signer_id: "test0".parse().unwrap(),
-        receiver_id: "test0".parse().unwrap(),
+        signer_id: "test0".parse::<AccountId>().unwrap(),
+        receiver_id: "test0".parse::<AccountId>().unwrap(),
         public_key: signer.public_key(),
         actions: vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "write_key_value".to_string(),
@@ -126,8 +129,8 @@ fn protocol_upgrade() {
             .chain(near_primitives::test_utils::encode(&[20u64]).into_iter())
             .collect();
         let tx = Transaction {
-            signer_id: "test0".parse().unwrap(),
-            receiver_id: "test0".parse().unwrap(),
+            signer_id: "test0".parse::<AccountId>().unwrap(),
+            receiver_id: "test0".parse::<AccountId>().unwrap(),
             public_key: signer.public_key(),
             actions: vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "write_key_value".to_string(),

--- a/integration-tests/src/tests/client/features/nearvm.rs
+++ b/integration-tests/src/tests/client/features/nearvm.rs
@@ -9,6 +9,7 @@ use near_crypto::{InMemorySigner, KeyType, Signer};
 use near_primitives::hash::CryptoHash;
 use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::transaction::{Action, FunctionCallAction, Transaction};
+use near_primitives::types::AccountId;
 use nearcore::config::GenesisExt;
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
 
@@ -24,8 +25,10 @@ fn test_nearvm_upgrade() {
     // Prepare TestEnv with a contract at the old protocol version.
     let mut env = {
         let epoch_length = 5;
-        let mut genesis =
-            Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+        let mut genesis = Genesis::test(
+            vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+            1,
+        );
         genesis.config.epoch_length = epoch_length;
         genesis.config.protocol_version = old_protocol_version;
         let chain_genesis = ChainGenesis::new(&genesis);
@@ -39,7 +42,7 @@ fn test_nearvm_upgrade() {
 
         deploy_test_contract(
             &mut env,
-            "test0".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             near_test_contracts::backwards_compatible_rs_contract(),
             epoch_length,
             1,
@@ -47,10 +50,11 @@ fn test_nearvm_upgrade() {
         env
     };
 
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let tx = Transaction {
-        signer_id: "test0".parse().unwrap(),
-        receiver_id: "test0".parse().unwrap(),
+        signer_id: "test0".parse::<AccountId>().unwrap(),
+        receiver_id: "test0".parse::<AccountId>().unwrap(),
         public_key: signer.public_key(),
         actions: vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "log_something".to_string(),

--- a/integration-tests/src/tests/client/features/restore_receipts_after_fix_apply_chunks.rs
+++ b/integration-tests/src/tests/client/features/restore_receipts_after_fix_apply_chunks.rs
@@ -5,7 +5,7 @@ use near_client::test_utils::TestEnv;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::hash::CryptoHash;
 use near_primitives::runtime::migration_data::MigrationData;
-use near_primitives::types::BlockHeight;
+use near_primitives::types::{AccountId, BlockHeight};
 use near_primitives::version::ProtocolFeature;
 use nearcore::config::GenesisExt;
 use nearcore::migrations::load_migration_data;
@@ -25,7 +25,10 @@ fn run_test(
 
     let protocol_version =
         ProtocolFeature::RestoreReceiptsAfterFixApplyChunks.protocol_version() - 1;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.chain_id = String::from(chain_id);
     genesis.config.epoch_length = EPOCH_LENGTH;
     genesis.config.protocol_version = protocol_version;
@@ -68,7 +71,7 @@ fn run_test(
         }
         set_block_protocol_version(
             &mut block,
-            "test0".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             ProtocolFeature::RestoreReceiptsAfterFixApplyChunks.protocol_version(),
         );
 

--- a/integration-tests/src/tests/client/features/restrict_tla.rs
+++ b/integration-tests/src/tests/client/features/restrict_tla.rs
@@ -12,7 +12,7 @@ use nearcore::test_utils::TestEnvNightshadeSetupExt;
 #[test]
 fn test_create_top_level_accounts() {
     let epoch_length: BlockHeight = 5;
-    let account: AccountId = "test0".parse().unwrap();
+    let account: AccountId = "test0".parse::<AccountId>().unwrap();
     let mut genesis = Genesis::test(vec![account.clone()], 1);
     genesis.config.epoch_length = epoch_length;
     genesis.config.protocol_version = PROTOCOL_VERSION;
@@ -50,7 +50,7 @@ fn test_create_top_level_accounts() {
                     index: Some(0),
                     kind: ActionErrorKind::CreateAccountOnlyByRegistrar {
                         account_id: new_account_id,
-                        registrar_account_id: "registrar".parse().unwrap(),
+                        registrar_account_id: "registrar".parse::<AccountId>().unwrap(),
                         predecessor_id: account.clone()
                     }
                 }

--- a/integration-tests/src/tests/client/features/zero_balance_account.rs
+++ b/integration-tests/src/tests/client/features/zero_balance_account.rs
@@ -52,7 +52,10 @@ fn assert_zero_balance_account(env: &TestEnv, account_id: &AccountId) {
 #[test]
 fn test_zero_balance_account_creation() {
     let epoch_length = 1000;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     genesis.config.protocol_version = ProtocolFeature::ZeroBalanceAccount.protocol_version();
     let mut env = TestEnv::builder(ChainGenesis::test())
@@ -61,8 +64,9 @@ fn test_zero_balance_account_creation() {
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
-    let new_account_id: AccountId = "hello.test0".parse().unwrap();
-    let signer0 = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let new_account_id: AccountId = "hello.test0".parse::<AccountId>().unwrap();
+    let signer0 =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let new_signer =
         InMemorySigner::from_seed(new_account_id.clone(), KeyType::ED25519, "hello.test0");
 
@@ -87,7 +91,7 @@ fn test_zero_balance_account_creation() {
     assert_zero_balance_account(&mut env, &new_account_id);
 
     // create a zero balance account with contract deployed. The transaction should fail
-    let new_account_id: AccountId = "hell.test0".parse().unwrap();
+    let new_account_id: AccountId = "hell.test0".parse::<AccountId>().unwrap();
     let contract = near_test_contracts::sized_contract(ZERO_BALANCE_ACCOUNT_STORAGE_LIMIT as usize);
     let create_account_tx = SignedTransaction::create_contract(
         2,
@@ -123,7 +127,10 @@ fn test_zero_balance_account_creation() {
 #[test]
 fn test_zero_balance_account_add_key() {
     let epoch_length = 1000;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     genesis.config.protocol_version = ProtocolFeature::ZeroBalanceAccount.protocol_version();
     // create free runtime config for transaction costs to make it easier to assert
@@ -142,8 +149,9 @@ fn test_zero_balance_account_add_key() {
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
-    let new_account_id: AccountId = "hello.test0".parse().unwrap();
-    let signer0 = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let new_account_id: AccountId = "hello.test0".parse::<AccountId>().unwrap();
+    let signer0 =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let new_signer =
         InMemorySigner::from_seed(new_account_id.clone(), KeyType::ED25519, "hello.test0");
 
@@ -252,7 +260,10 @@ fn test_zero_balance_account_upgrade() {
     std::env::set_var("NEAR_TESTS_IMMEDIATE_PROTOCOL_UPGRADE", "1");
 
     let epoch_length = 5;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     genesis.config.protocol_version = ProtocolFeature::ZeroBalanceAccount.protocol_version() - 1;
     let mut env = TestEnv::builder(ChainGenesis::test())
@@ -261,8 +272,9 @@ fn test_zero_balance_account_upgrade() {
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
-    let new_account_id: AccountId = "hello.test0".parse().unwrap();
-    let signer0 = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let new_account_id: AccountId = "hello.test0".parse::<AccountId>().unwrap();
+    let signer0 =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let new_signer =
         InMemorySigner::from_seed(new_account_id.clone(), KeyType::ED25519, "hello.test0");
 

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -125,22 +125,26 @@ fn wait_for_flat_storage_creation(
 #[test]
 fn test_flat_storage_creation_sanity() {
     init_test_logger();
-    let genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
+    let genesis = Genesis::test(vec!["test0".parse::<AccountId>().unwrap()], 1);
     let shard_uid = genesis.config.shard_layout.get_shard_uids()[0];
     let store = create_test_store();
 
     // Process some blocks with flat storage. Then remove flat storage data from disk.
     {
         let mut env = setup_env(&genesis, store.clone());
-        let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+        let signer = InMemorySigner::from_seed(
+            "test0".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test0",
+        );
         let genesis_hash = *env.clients[0].chain.genesis().hash();
         for height in 1..START_HEIGHT {
             env.produce_block(0, height);
 
             let tx = SignedTransaction::send_money(
                 height,
-                "test0".parse().unwrap(),
-                "test0".parse().unwrap(),
+                "test0".parse::<AccountId>().unwrap(),
+                "test0".parse::<AccountId>().unwrap(),
                 &signer,
                 1,
                 genesis_hash,
@@ -243,23 +247,30 @@ fn test_flat_storage_creation_sanity() {
 fn test_flat_storage_creation_two_shards() {
     init_test_logger();
     let num_shards = 2;
-    let genesis =
-        Genesis::test_sharded_new_version(vec!["test0".parse().unwrap()], 1, vec![1; num_shards]);
+    let genesis = Genesis::test_sharded_new_version(
+        vec!["test0".parse::<AccountId>().unwrap()],
+        1,
+        vec![1; num_shards],
+    );
     let shard_uids = genesis.config.shard_layout.get_shard_uids();
     let store = create_test_store();
 
     // Process some blocks with flat storages for two shards. Then remove flat storage data from disk for shard 0.
     {
         let mut env = setup_env(&genesis, store.clone());
-        let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+        let signer = InMemorySigner::from_seed(
+            "test0".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test0",
+        );
         let genesis_hash = *env.clients[0].chain.genesis().hash();
         for height in 1..START_HEIGHT {
             env.produce_block(0, height);
 
             let tx = SignedTransaction::send_money(
                 height,
-                "test0".parse().unwrap(),
-                "test0".parse().unwrap(),
+                "test0".parse::<AccountId>().unwrap(),
+                "test0".parse::<AccountId>().unwrap(),
                 &signer,
                 1,
                 genesis_hash,
@@ -402,7 +413,7 @@ fn test_flat_storage_creation_start_from_state_part() {
 #[test]
 fn test_catchup_succeeds_even_if_no_new_blocks() {
     init_test_logger();
-    let genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
+    let genesis = Genesis::test(vec!["test0".parse::<AccountId>().unwrap()], 1);
     let store = create_test_store();
     let shard_uid = ShardLayout::v0_single_shard().get_shard_uids()[0];
 
@@ -437,11 +448,14 @@ fn test_catchup_succeeds_even_if_no_new_blocks() {
 fn test_flat_storage_iter() {
     init_test_logger();
     let num_shards = 3;
-    let shard_layout =
-        ShardLayout::v1(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], None, 0);
+    let shard_layout = ShardLayout::v1(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        None,
+        0,
+    );
 
     let genesis = Genesis::test_with_seeds(
-        vec!["test0".parse().unwrap()],
+        vec!["test0".parse::<AccountId>().unwrap()],
         1,
         vec![1; num_shards],
         shard_layout.clone(),
@@ -464,7 +478,7 @@ fn test_flat_storage_iter() {
                 assert_eq!(2, items.len());
                 // Two entries - one for 'near' system account, the other for the contract.
                 assert_eq!(
-                    TrieKey::Account { account_id: "near".parse().unwrap() }.to_vec(),
+                    TrieKey::Account { account_id: "near".parse::<AccountId>().unwrap() }.to_vec(),
                     items[0].as_ref().unwrap().0.to_vec()
                 );
             }
@@ -472,7 +486,7 @@ fn test_flat_storage_iter() {
                 // Two entries - one for account, the other for contract.
                 assert_eq!(2, items.len());
                 assert_eq!(
-                    TrieKey::Account { account_id: "test0".parse().unwrap() }.to_vec(),
+                    TrieKey::Account { account_id: "test0".parse::<AccountId>().unwrap() }.to_vec(),
                     items[0].as_ref().unwrap().0.to_vec()
                 );
             }
@@ -494,13 +508,14 @@ fn test_flat_storage_iter() {
 /// state of the previous flat head inaccessible.
 fn test_not_supported_block() {
     init_test_logger();
-    let genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
+    let genesis = Genesis::test(vec!["test0".parse::<AccountId>().unwrap()], 1);
     let shard_layout = ShardLayout::v0_single_shard();
     let shard_uid = shard_layout.get_shard_uids()[0];
     let store = create_test_store();
 
     let mut env = setup_env(&genesis, store);
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let genesis_hash = *env.clients[0].chain.genesis().hash();
 
     // Produce blocks up to `START_HEIGHT`.
@@ -508,8 +523,8 @@ fn test_not_supported_block() {
         env.produce_block(0, height);
         let tx = SignedTransaction::send_money(
             height,
-            "test0".parse().unwrap(),
-            "test0".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             &signer,
             1,
             genesis_hash,
@@ -519,9 +534,10 @@ fn test_not_supported_block() {
 
     let flat_head_height = START_HEIGHT - 4;
     // Trie key which must exist in the storage.
-    let trie_key_bytes =
-        near_primitives::trie_key::TrieKey::Account { account_id: "test0".parse().unwrap() }
-            .to_vec();
+    let trie_key_bytes = near_primitives::trie_key::TrieKey::Account {
+        account_id: "test0".parse::<AccountId>().unwrap(),
+    }
+    .to_vec();
     // Create trie, which includes creating chunk view, and get `ValueRef`s
     // for post state roots for blocks `START_HEIGHT - 3` and `START_HEIGHT - 2`.
     // After creating the first trie, produce block `START_HEIGHT` which moves flat storage

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -202,7 +202,10 @@ pub(crate) fn prepare_env_with_congestion(
 ) -> (TestEnv, Vec<CryptoHash>) {
     init_test_logger();
     let epoch_length = 100;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.protocol_version = protocol_version;
     genesis.config.epoch_length = epoch_length;
     genesis.config.gas_limit = 10_000_000_000_000;
@@ -215,13 +218,14 @@ pub(crate) fn prepare_env_with_congestion(
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
 
     // Deploy contract to test0.
     let tx = SignedTransaction::from_actions(
         1,
-        "test0".parse().unwrap(),
-        "test0".parse().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
         &signer,
         vec![Action::DeployContract(DeployContractAction {
             code: near_test_contracts::backwards_compatible_rs_contract().to_vec(),
@@ -251,8 +255,8 @@ pub(crate) fn prepare_env_with_congestion(
 
         let signed_transaction = SignedTransaction::from_actions(
             i + 10,
-            "test0".parse().unwrap(),
-            "test0".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             &signer,
             vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "call_promise".to_string(),
@@ -279,8 +283,8 @@ fn produce_two_blocks() {
     run_actix(async {
         let count = Arc::new(AtomicUsize::new(0));
         setup_mock(
-            vec!["test".parse().unwrap()],
-            "test".parse().unwrap(),
+            vec!["test".parse::<AccountId>().unwrap()],
+            "test".parse::<AccountId>().unwrap(),
             true,
             false,
             Box::new(move |msg, _ctx, _| {
@@ -306,8 +310,8 @@ fn produce_blocks_with_tx() {
     init_test_logger();
     run_actix(async {
         let actor_handles = setup_mock(
-            vec!["test".parse().unwrap()],
-            "test".parse().unwrap(),
+            vec!["test".parse::<AccountId>().unwrap()],
+            "test".parse::<AccountId>().unwrap(),
             true,
             false,
             Box::new(move |msg, _ctx, _| {
@@ -379,8 +383,12 @@ fn receive_network_block() {
         // it. The second header announce will happen with the endorsement a little later.
         let first_header_announce = Arc::new(RwLock::new(true));
         let actor_handles = setup_mock(
-            vec!["test2".parse().unwrap(), "test1".parse().unwrap(), "test3".parse().unwrap()],
-            "test2".parse().unwrap(),
+            vec![
+                "test2".parse::<AccountId>().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
+                "test3".parse::<AccountId>().unwrap(),
+            ],
+            "test2".parse::<AccountId>().unwrap(),
             true,
             false,
             Box::new(move |msg, _ctx, _| {
@@ -450,7 +458,7 @@ fn produce_block_with_approvals() {
     run_actix(async {
         let actor_handles = setup_mock(
             validators.clone(),
-            "test1".parse().unwrap(),
+            "test1".parse::<AccountId>().unwrap(),
             true,
             false,
             Box::new(move |msg, _ctx, _| {
@@ -551,10 +559,10 @@ fn produce_block_with_approvals() {
 fn produce_block_with_approvals_arrived_early() {
     init_test_logger();
     let vs = ValidatorSchedule::new().num_shards(4).block_producers_per_epoch(vec![vec![
-        "test1".parse().unwrap(),
-        "test2".parse().unwrap(),
-        "test3".parse().unwrap(),
-        "test4".parse().unwrap(),
+        "test1".parse::<AccountId>().unwrap(),
+        "test2".parse::<AccountId>().unwrap(),
+        "test3".parse::<AccountId>().unwrap(),
+        "test4".parse::<AccountId>().unwrap(),
     ]]);
     let archive = vec![false; vs.all_block_producers().count()];
     let epoch_sync_enabled = vec![true; vs.all_block_producers().count()];
@@ -604,7 +612,7 @@ fn produce_block_with_approvals_arrived_early() {
                             (NetworkResponses::NoResponse.into(), true)
                         }
                         NetworkRequests::Approval { approval_message } => {
-                            if approval_message.target.as_ref() == "test1"
+                            if approval_message.target.as_str() == "test1"
                                 && approval_message.approval.target_height == 4
                             {
                                 approval_counter += 1;
@@ -639,8 +647,8 @@ fn invalid_blocks_common(is_requested: bool) {
     run_actix(async move {
         let mut ban_counter = 0;
         let actor_handles = setup_mock(
-            vec!["test".parse().unwrap()],
-            "other".parse().unwrap(),
+            vec!["test".parse::<AccountId>().unwrap()],
+            "other".parse::<AccountId>().unwrap(),
             true,
             false,
             Box::new(move |msg, _ctx, _client_actor| {
@@ -832,10 +840,10 @@ enum InvalidBlockMode {
 fn ban_peer_for_invalid_block_common(mode: InvalidBlockMode) {
     init_test_logger();
     let vs = ValidatorSchedule::new().block_producers_per_epoch(vec![vec![
-        "test1".parse().unwrap(),
-        "test2".parse().unwrap(),
-        "test3".parse().unwrap(),
-        "test4".parse().unwrap(),
+        "test1".parse::<AccountId>().unwrap(),
+        "test2".parse::<AccountId>().unwrap(),
+        "test3".parse::<AccountId>().unwrap(),
+        "test4".parse::<AccountId>().unwrap(),
     ]]);
     let validators = vs.all_block_producers().cloned().collect::<Vec<_>>();
     let key_pairs =
@@ -889,7 +897,7 @@ fn ban_peer_for_invalid_block_common(mode: InvalidBlockMode) {
                                         // produce an invalid block whose invalidity cannot be verified by just
                                         // having its header.
                                         let proposals = vec![ValidatorStake::new(
-                                            "test1".parse().unwrap(),
+                                            "test1".parse::<AccountId>().unwrap(),
                                             PublicKey::empty(KeyType::ED25519),
                                             0,
                                         )];
@@ -1000,8 +1008,8 @@ fn skip_block_production() {
     init_test_logger();
     run_actix(async {
         setup_mock(
-            vec!["test1".parse().unwrap(), "test2".parse().unwrap()],
-            "test2".parse().unwrap(),
+            vec!["test1".parse::<AccountId>().unwrap(), "test2".parse::<AccountId>().unwrap()],
+            "test2".parse::<AccountId>().unwrap(),
             true,
             false,
             Box::new(move |msg, _ctx, _client_actor| {
@@ -1028,8 +1036,8 @@ fn client_sync_headers() {
         let peer_info1 = PeerInfo::random();
         let peer_info2 = peer_info1.clone();
         let actor_handles = setup_mock(
-            vec!["test".parse().unwrap()],
-            "other".parse().unwrap(),
+            vec!["test".parse::<AccountId>().unwrap()],
+            "other".parse::<AccountId>().unwrap(),
             false,
             false,
             Box::new(move |msg, _ctx, _client_actor| match msg.as_network_requests_ref() {
@@ -1090,21 +1098,22 @@ fn client_sync_headers() {
 #[test]
 fn test_process_invalid_tx() {
     init_test_logger();
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(vec!["test0".parse::<AccountId>().unwrap()], 1);
     genesis.config.transaction_validity_period = 10;
     let chain_genesis = ChainGenesis::new(&genesis);
     let mut env = TestEnv::builder(chain_genesis)
         .real_epoch_managers(&genesis.config)
         .nightshade_runtimes(&genesis)
         .build();
-    let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test1".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let tx = SignedTransaction::new(
         Signature::empty(KeyType::ED25519),
         Transaction {
-            signer_id: "test".parse().unwrap(),
+            signer_id: "test".parse::<AccountId>().unwrap(),
             public_key: signer.public_key(),
             nonce: 0,
-            receiver_id: "test".parse().unwrap(),
+            receiver_id: "test".parse::<AccountId>().unwrap(),
             block_hash: *env.clients[0].chain.genesis().hash(),
             actions: vec![],
         },
@@ -1119,10 +1128,10 @@ fn test_process_invalid_tx() {
     let tx2 = SignedTransaction::new(
         Signature::empty(KeyType::ED25519),
         Transaction {
-            signer_id: "test".parse().unwrap(),
+            signer_id: "test".parse::<AccountId>().unwrap(),
             public_key: signer.public_key(),
             nonce: 0,
-            receiver_id: "test".parse().unwrap(),
+            receiver_id: "test".parse::<AccountId>().unwrap(),
             block_hash: hash(&[1]),
             actions: vec![],
         },
@@ -1141,12 +1150,12 @@ fn test_time_attack() {
     let network_adapter = Arc::new(MockPeerManagerAdapter::default());
     let client_adapter = Arc::new(MockClientAdapterForShardsManager::default());
     let chain_genesis = ChainGenesis::test();
-    let vs =
-        ValidatorSchedule::new().block_producers_per_epoch(vec![vec!["test1".parse().unwrap()]]);
+    let vs = ValidatorSchedule::new()
+        .block_producers_per_epoch(vec![vec!["test1".parse::<AccountId>().unwrap()]]);
     let mut client = setup_client_with_synchronous_shards_manager(
         store,
         vs,
-        Some("test1".parse().unwrap()),
+        Some("test1".parse::<AccountId>().unwrap()),
         false,
         network_adapter.into(),
         client_adapter.as_sender(),
@@ -1177,12 +1186,12 @@ fn test_invalid_approvals() {
     let network_adapter = Arc::new(MockPeerManagerAdapter::default());
     let client_adapter = Arc::new(MockClientAdapterForShardsManager::default());
     let chain_genesis = ChainGenesis::test();
-    let vs =
-        ValidatorSchedule::new().block_producers_per_epoch(vec![vec!["test1".parse().unwrap()]]);
+    let vs = ValidatorSchedule::new()
+        .block_producers_per_epoch(vec![vec!["test1".parse::<AccountId>().unwrap()]]);
     let mut client = setup_client_with_synchronous_shards_manager(
         store,
         vs,
-        Some("test1".parse().unwrap()),
+        Some("test1".parse::<AccountId>().unwrap()),
         false,
         network_adapter.into(),
         client_adapter.as_sender(),
@@ -1225,12 +1234,12 @@ fn test_invalid_gas_price() {
     let client_adapter = Arc::new(MockClientAdapterForShardsManager::default());
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.min_gas_price = 100;
-    let vs =
-        ValidatorSchedule::new().block_producers_per_epoch(vec![vec!["test1".parse().unwrap()]]);
+    let vs = ValidatorSchedule::new()
+        .block_producers_per_epoch(vec![vec!["test1".parse::<AccountId>().unwrap()]]);
     let mut client = setup_client_with_synchronous_shards_manager(
         store,
         vs,
-        Some("test1".parse().unwrap()),
+        Some("test1".parse::<AccountId>().unwrap()),
         false,
         network_adapter.into(),
         client_adapter.as_sender(),
@@ -1369,7 +1378,8 @@ fn test_bad_orphan() {
 fn test_bad_chunk_mask() {
     init_test_logger();
     let chain_genesis = ChainGenesis::test();
-    let validators = vec!["test0".parse().unwrap(), "test1".parse().unwrap()];
+    let validators =
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()];
     let mut clients: Vec<Client> = validators
         .iter()
         .map(|account_id| {
@@ -1460,7 +1470,10 @@ fn test_minimum_gas_price() {
 }
 
 fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
@@ -1527,7 +1540,10 @@ fn test_gc_long_epoch() {
 fn test_archival_save_trie_changes() {
     let epoch_length = 10;
 
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
@@ -1597,7 +1613,10 @@ fn test_archival_gc_common(
     max_cold_head_height: BlockHeight,
     legacy: bool,
 ) {
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
@@ -1753,7 +1772,10 @@ fn test_gc_chunk_tail() {
 #[test]
 fn test_gc_execution_outcome() {
     let epoch_length = 5;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
@@ -1762,11 +1784,12 @@ fn test_gc_execution_outcome() {
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_hash = *env.clients[0].chain.genesis().hash();
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let tx = SignedTransaction::send_money(
         1,
-        "test0".parse().unwrap(),
-        "test1".parse().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
+        "test1".parse::<AccountId>().unwrap(),
         &signer,
         100,
         genesis_hash,
@@ -1789,7 +1812,10 @@ fn test_gc_execution_outcome() {
 #[cfg_attr(not(feature = "expensive_tests"), ignore)]
 fn test_gc_after_state_sync() {
     let epoch_length = 1024;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
@@ -1826,7 +1852,7 @@ fn test_process_block_after_state_sync() {
     let epoch_length = 1024;
     // test with shard_version > 0
     let mut genesis = Genesis::test_sharded_new_version(
-        vec!["test0".parse().unwrap(), "test1".parse().unwrap()],
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
         1,
         vec![1],
     );
@@ -1876,7 +1902,10 @@ fn test_process_block_after_state_sync() {
 #[test]
 fn test_gc_fork_tail() {
     let epoch_length = 101;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
@@ -1947,7 +1976,10 @@ fn test_tx_forwarding_no_double_forwarding() {
 #[test]
 fn test_tx_forward_around_epoch_boundary() {
     let epoch_length = 4;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.num_block_producer_seats = 2;
     genesis.config.num_block_producer_seats_per_shard = vec![2];
     genesis.config.epoch_length = epoch_length;
@@ -1961,10 +1993,11 @@ fn test_tx_forward_around_epoch_boundary() {
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_hash = *env.clients[0].chain.genesis().hash();
-    let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+    let signer =
+        InMemorySigner::from_seed("test1".parse::<AccountId>().unwrap(), KeyType::ED25519, "test1");
     let tx = SignedTransaction::stake(
         1,
-        "test1".parse().unwrap(),
+        "test1".parse::<AccountId>().unwrap(),
         &signer,
         TESTING_INIT_STAKE,
         signer.public_key.clone(),
@@ -1983,8 +2016,8 @@ fn test_tx_forward_around_epoch_boundary() {
     }
     let tx = SignedTransaction::send_money(
         1,
-        "test1".parse().unwrap(),
-        "test0".parse().unwrap(),
+        "test1".parse::<AccountId>().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
         &signer,
         1,
         genesis_hash,
@@ -2002,14 +2035,20 @@ fn test_tx_forward_around_epoch_boundary() {
     }
     assert_eq!(
         accounts_to_forward,
-        HashSet::from_iter(vec!["test0".parse().unwrap(), "test1".parse().unwrap()])
+        HashSet::from_iter(vec![
+            "test0".parse::<AccountId>().unwrap(),
+            "test1".parse::<AccountId>().unwrap()
+        ])
     );
 }
 
 /// Blocks that have already been gc'ed should not be accepted again.
 #[test]
 fn test_not_resync_old_blocks() {
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     let epoch_length = 5;
     genesis.config.epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
@@ -2035,7 +2074,10 @@ fn test_not_resync_old_blocks() {
 
 #[test]
 fn test_gc_tail_update() {
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     let epoch_length = 2;
     genesis.config.epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
@@ -2081,7 +2123,10 @@ fn test_gc_tail_update() {
 #[test]
 fn test_gas_price_change() {
     init_test_logger();
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     let target_num_tokens_left = NEAR_BASE / 10 + 1;
     let transaction_costs = RuntimeConfig::test().fees;
 
@@ -2104,11 +2149,12 @@ fn test_gas_price_change() {
 
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let genesis_hash = *genesis_block.hash();
-    let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+    let signer =
+        InMemorySigner::from_seed("test1".parse::<AccountId>().unwrap(), KeyType::ED25519, "test1");
     let tx = SignedTransaction::send_money(
         1,
-        "test1".parse().unwrap(),
-        "test0".parse().unwrap(),
+        "test1".parse::<AccountId>().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
         &signer,
         TESTING_INIT_BALANCE
             - target_num_tokens_left
@@ -2119,8 +2165,8 @@ fn test_gas_price_change() {
     env.produce_block(0, 1);
     let tx = SignedTransaction::send_money(
         2,
-        "test1".parse().unwrap(),
-        "test0".parse().unwrap(),
+        "test1".parse::<AccountId>().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
         &signer,
         1,
         genesis_hash,
@@ -2133,7 +2179,10 @@ fn test_gas_price_change() {
 
 #[test]
 fn test_gas_price_overflow() {
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     let min_gas_price = 1000000;
     let max_gas_price = 10_u128.pow(20);
     let gas_limit = 450000000000;
@@ -2152,12 +2201,13 @@ fn test_gas_price_overflow() {
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let genesis_hash = *genesis_block.hash();
-    let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+    let signer =
+        InMemorySigner::from_seed("test1".parse::<AccountId>().unwrap(), KeyType::ED25519, "test1");
     for i in 1..100 {
         let tx = SignedTransaction::send_money(
             i,
-            "test1".parse().unwrap(),
-            "test0".parse().unwrap(),
+            "test1".parse::<AccountId>().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             &signer,
             1,
             genesis_hash,
@@ -2182,7 +2232,10 @@ fn test_invalid_block_root() {
 
 #[test]
 fn test_incorrect_validator_key_produce_block() {
-    let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 2);
+    let genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        2,
+    );
     let chain_genesis = ChainGenesis::new(&genesis);
 
     let mut env = TestEnv::builder(chain_genesis)
@@ -2269,20 +2322,21 @@ fn test_block_merkle_proof_same_hash() {
 
 #[test]
 fn test_data_reset_before_state_sync() {
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(vec!["test0".parse::<AccountId>().unwrap()], 1);
     let epoch_length = 5;
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(ChainGenesis::test())
         .real_epoch_managers(&genesis.config)
         .nightshade_runtimes(&genesis)
         .build();
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let genesis_hash = *genesis_block.hash();
     let tx = SignedTransaction::create_account(
         1,
-        "test0".parse().unwrap(),
-        "test_account".parse().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
+        "test_account".parse::<AccountId>().unwrap(),
         NEAR_BASE,
         signer.public_key(),
         &signer,
@@ -2305,7 +2359,7 @@ fn test_data_reset_before_state_sync() {
             &head.prev_block_hash,
             &head.last_block_hash,
             head_block.header().epoch_id(),
-            &QueryRequest::ViewAccount { account_id: "test_account".parse().unwrap() },
+            &QueryRequest::ViewAccount { account_id: "test_account".parse::<AccountId>().unwrap() },
         )
         .unwrap();
     assert_matches!(response.kind, QueryResponseKind::ViewAccount(_));
@@ -2319,7 +2373,7 @@ fn test_data_reset_before_state_sync() {
         &head.prev_block_hash,
         &head.last_block_hash,
         head_block.header().epoch_id(),
-        &QueryRequest::ViewAccount { account_id: "test_account".parse().unwrap() },
+        &QueryRequest::ViewAccount { account_id: "test_account".parse::<AccountId>().unwrap() },
     );
     // TODO(#3742): ViewClient still has data in cache by current design.
     assert!(response.is_ok());
@@ -2328,7 +2382,10 @@ fn test_data_reset_before_state_sync() {
 #[test]
 fn test_sync_hash_validity() {
     let epoch_length = 5;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
@@ -2376,7 +2433,10 @@ fn test_validate_chunk_extra() {
     let mut capture = near_o11y::testonly::TracingCapture::enable();
 
     let epoch_length = 5;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(ChainGenesis::test())
         .real_epoch_managers(&genesis.config)
@@ -2385,11 +2445,12 @@ fn test_validate_chunk_extra() {
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let genesis_height = genesis_block.header().height();
 
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let tx = SignedTransaction::from_actions(
         1,
-        "test0".parse().unwrap(),
-        "test0".parse().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
         &signer,
         vec![Action::DeployContract(DeployContractAction {
             code: near_test_contracts::rs_contract().to_vec(),
@@ -2407,8 +2468,8 @@ fn test_validate_chunk_extra() {
     // in blocks of different heights, the state transitions are different.
     let function_call_tx = SignedTransaction::from_actions(
         2,
-        "test0".parse().unwrap(),
-        "test0".parse().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
         &signer,
         vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "write_block_height".to_string(),
@@ -2511,7 +2572,10 @@ fn test_validate_chunk_extra() {
 fn test_gas_price_change_no_chunk() {
     let epoch_length = 5;
     let min_gas_price = 5000;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     let genesis_protocol_version = PROTOCOL_VERSION - 1;
     genesis.config.epoch_length = epoch_length;
     genesis.config.protocol_version = genesis_protocol_version;
@@ -2541,7 +2605,10 @@ fn test_catchup_gas_price_change() {
     init_test_logger();
     let epoch_length = 5;
     let min_gas_price = 10000;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     genesis.config.min_gas_price = min_gas_price;
     genesis.config.gas_limit = 1000000000000;
@@ -2563,12 +2630,13 @@ fn test_catchup_gas_price_change() {
         env.process_block(0, block.clone(), Provenance::PRODUCED);
         env.process_block(1, block, Provenance::NONE);
     }
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     for i in 0..3 {
         let tx = SignedTransaction::send_money(
             i + 1,
-            "test0".parse().unwrap(),
-            "test1".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
+            "test1".parse::<AccountId>().unwrap(),
             &signer,
             1,
             *genesis_block.hash(),
@@ -2647,7 +2715,10 @@ fn test_block_execution_outcomes() {
 
     let epoch_length = 5;
     let min_gas_price = 10000;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     genesis.config.min_gas_price = min_gas_price;
     genesis.config.gas_limit = 1000000000000;
@@ -2657,14 +2728,15 @@ fn test_block_execution_outcomes() {
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let mut tx_hashes = vec![];
     for i in 0..3 {
         // send transaction to the same account to generate local receipts
         let tx = SignedTransaction::send_money(
             i + 1,
-            "test0".parse().unwrap(),
-            "test0".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             &signer,
             1,
             *genesis_block.hash(),
@@ -2734,7 +2806,7 @@ fn test_refund_receipts_processing() {
     let epoch_length = 5;
     let min_gas_price = 10000;
     let mut genesis = Genesis::test_sharded_new_version(
-        vec!["test0".parse().unwrap(), "test1".parse().unwrap()],
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
         1,
         vec![1],
     );
@@ -2749,15 +2821,16 @@ fn test_refund_receipts_processing() {
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let mut tx_hashes = vec![];
     // Send transactions to a non-existing account to generate refunds.
     for i in 0..3 {
         // Send transaction from the same account to generate local receipts.
         let tx = SignedTransaction::send_money(
             i + 1,
-            "test0".parse().unwrap(),
-            "random_account".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
+            "random_account".parse::<AccountId>().unwrap(),
             &signer,
             1,
             *genesis_block.hash(),
@@ -2812,7 +2885,8 @@ fn test_delayed_receipt_count_limit() {
 
     let epoch_length = 5;
     let min_gas_price = 10000;
-    let mut genesis = Genesis::test_sharded_new_version(vec!["test0".parse().unwrap()], 1, vec![1]);
+    let mut genesis =
+        Genesis::test_sharded_new_version(vec!["test0".parse::<AccountId>().unwrap()], 1, vec![1]);
     genesis.config.epoch_length = epoch_length;
     genesis.config.min_gas_price = min_gas_price;
     // Set gas limit to be small enough to produce some delayed receipts, but large enough for
@@ -2828,14 +2902,15 @@ fn test_delayed_receipt_count_limit() {
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     // Send enough transactions to saturate delayed receipts capacity.
     let total_tx_count = 200usize;
     for i in 0..total_tx_count {
         let tx = SignedTransaction::from_actions(
             (i + 1) as u64,
-            "test0".parse().unwrap(),
-            "test0".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             &signer,
             vec![Action::DeployContract(DeployContractAction { code: vec![92; 10000] })],
             *genesis_block.hash(),
@@ -2881,8 +2956,10 @@ fn test_execution_metadata() {
 
     let mut env = {
         let epoch_length = 5;
-        let mut genesis =
-            Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+        let mut genesis = Genesis::test(
+            vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+            1,
+        );
         genesis.config.epoch_length = epoch_length;
         let chain_genesis = ChainGenesis::new(&genesis);
         let mut env = TestEnv::builder(chain_genesis)
@@ -2890,12 +2967,18 @@ fn test_execution_metadata() {
             .nightshade_runtimes(&genesis)
             .build();
 
-        deploy_test_contract(&mut env, "test0".parse().unwrap(), &wasm_code, epoch_length, 1);
+        deploy_test_contract(
+            &mut env,
+            "test0".parse::<AccountId>().unwrap(),
+            &wasm_code,
+            epoch_length,
+            1,
+        );
         env
     };
 
     // Call the contract and get the execution outcome.
-    let execution_outcome = env.call_main(&"test0".parse().unwrap());
+    let execution_outcome = env.call_main(&"test0".parse::<AccountId>().unwrap());
 
     // Now, let's assert that we get the cost breakdown we expect.
     let config = RuntimeConfigStore::test().get_config(PROTOCOL_VERSION).clone();
@@ -2960,7 +3043,10 @@ fn test_execution_metadata() {
 fn test_epoch_protocol_version_change() {
     init_test_logger();
     let epoch_length = 5;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 2);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        2,
+    );
     genesis.config.epoch_length = epoch_length;
     genesis.config.protocol_version = PROTOCOL_VERSION - 1;
     let chain_genesis = ChainGenesis::new(&genesis);
@@ -2978,7 +3064,7 @@ fn test_epoch_protocol_version_change() {
             .unwrap();
         let chunk_producer =
             env.clients[0].epoch_manager.get_chunk_producer(&epoch_id, i, 0).unwrap();
-        let index = if chunk_producer.as_ref() == "test0" { 0 } else { 1 };
+        let index = if chunk_producer.as_str() == "test0" { 0 } else { 1 };
         let (encoded_chunk, merkle_paths, receipts) =
             create_chunk_on_height(&mut env.clients[index], i);
 
@@ -3000,7 +3086,7 @@ fn test_epoch_protocol_version_change() {
             .get_epoch_id_from_prev_block(&head.last_block_hash)
             .unwrap();
         let block_producer = env.clients[0].epoch_manager.get_block_producer(&epoch_id, i).unwrap();
-        let index = if block_producer.as_ref() == "test0" { 0 } else { 1 };
+        let index = if block_producer.as_str() == "test0" { 0 } else { 1 };
         let mut block = env.clients[index].produce_block(i).unwrap().unwrap();
         // upgrade to new protocol version but in the second epoch one node vote for the old version.
         if i != 10 {
@@ -3020,7 +3106,10 @@ fn test_epoch_protocol_version_change() {
 
 #[test]
 fn test_discard_non_finalizable_block() {
-    let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     let chain_genesis = ChainGenesis::new(&genesis);
     let mut env = TestEnv::builder(chain_genesis)
         .real_epoch_managers(&genesis.config)
@@ -3081,7 +3170,10 @@ fn test_discard_non_finalizable_block() {
 #[test]
 fn test_query_final_state() {
     let epoch_length = 10;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
 
     let chain_genesis = ChainGenesis::new(&genesis);
@@ -3091,11 +3183,12 @@ fn test_query_final_state() {
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let tx = SignedTransaction::send_money(
         1,
-        "test0".parse().unwrap(),
-        "test1".parse().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
+        "test1".parse::<AccountId>().unwrap(),
         &signer,
         100,
         *genesis_block.hash(),
@@ -3147,15 +3240,21 @@ fn test_query_final_state() {
     assert_eq!(env.clients[0].chain.head().unwrap().height, 5);
 
     let runtime = env.clients[0].runtime_adapter.clone();
-    let account_state1 =
-        query_final_state(&mut env.clients[0].chain, runtime.clone(), "test0".parse().unwrap());
+    let account_state1 = query_final_state(
+        &mut env.clients[0].chain,
+        runtime.clone(),
+        "test0".parse::<AccountId>().unwrap(),
+    );
 
     env.process_block(0, fork2_block, Provenance::NONE);
     assert_eq!(env.clients[0].chain.head().unwrap().height, 6);
 
     let runtime = env.clients[0].runtime_adapter.clone();
-    let account_state2 =
-        query_final_state(&mut env.clients[0].chain, runtime.clone(), "test0".parse().unwrap());
+    let account_state2 = query_final_state(
+        &mut env.clients[0].chain,
+        runtime.clone(),
+        "test0".parse::<AccountId>().unwrap(),
+    );
 
     assert_eq!(account_state1, account_state2);
     assert!(account_state1.amount < TESTING_INIT_BALANCE - TESTING_INIT_STAKE);
@@ -3265,7 +3364,10 @@ fn test_fork_execution_outcome() {
 
 fn prepare_env_with_transaction() -> (TestEnv, CryptoHash) {
     let epoch_length = 5;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(ChainGenesis::test())
         .real_epoch_managers(&genesis.config)
@@ -3273,11 +3375,12 @@ fn prepare_env_with_transaction() -> (TestEnv, CryptoHash) {
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let tx = SignedTransaction::send_money(
         1,
-        "test0".parse().unwrap(),
-        "test1".parse().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
+        "test1".parse::<AccountId>().unwrap(),
         &signer,
         100,
         *genesis_block.hash(),
@@ -3290,7 +3393,10 @@ fn prepare_env_with_transaction() -> (TestEnv, CryptoHash) {
 #[test]
 fn test_not_broadcast_block_on_accept() {
     let epoch_length = 5;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     let network_adapter = Arc::new(MockPeerManagerAdapter::default());
     let mut env = TestEnv::builder(ChainGenesis::test())
@@ -3313,7 +3419,10 @@ fn test_not_broadcast_block_on_accept() {
 fn test_header_version_downgrade() {
     init_test_logger();
 
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = 5;
     let chain_genesis = ChainGenesis::new(&genesis);
     let mut env = TestEnv::builder(chain_genesis)
@@ -3362,7 +3471,10 @@ fn test_header_version_downgrade() {
 )]
 fn test_node_shutdown_with_old_protocol_version() {
     let epoch_length = 5;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(ChainGenesis::test())
         .real_epoch_managers(&genesis.config)
@@ -3495,7 +3607,10 @@ fn test_congestion_receipt_execution() {
 fn test_validator_stake_host_function() {
     init_test_logger();
     let epoch_length = 5;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(ChainGenesis::test())
         .real_epoch_managers(&genesis.config)
@@ -3504,16 +3619,17 @@ fn test_validator_stake_host_function() {
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let block_height = deploy_test_contract(
         &mut env,
-        "test0".parse().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
         near_test_contracts::rs_contract(),
         epoch_length,
         1,
     );
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let signed_transaction = SignedTransaction::from_actions(
         10,
-        "test0".parse().unwrap(),
-        "test0".parse().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
+        "test0".parse::<AccountId>().unwrap(),
         &signer,
         vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "ext_validator_stake".to_string(),
@@ -3537,7 +3653,7 @@ fn test_validator_stake_host_function() {
 /// does not need to catch up.
 fn test_catchup_no_sharding_change() {
     init_integration_logger();
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(vec!["test0".parse::<AccountId>().unwrap()], 1);
     genesis.config.epoch_length = 5;
     let chain_genesis = ChainGenesis::new(&genesis);
     let mut env = TestEnv::builder(chain_genesis)
@@ -3598,8 +3714,10 @@ mod contract_precompilation_tests {
     fn test_sync_and_call_cached_contract() {
         init_integration_logger();
         let num_clients = 2;
-        let mut genesis =
-            Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+        let mut genesis = Genesis::test(
+            vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+            1,
+        );
         genesis.config.epoch_length = EPOCH_LENGTH;
 
         let mut env = TestEnv::builder(ChainGenesis::test())
@@ -3616,7 +3734,7 @@ mod contract_precompilation_tests {
         let wasm_code = near_test_contracts::rs_contract().to_vec();
         let height = deploy_test_contract(
             &mut env,
-            "test0".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             &wasm_code,
             EPOCH_LENGTH + 1,
             start_height,
@@ -3681,7 +3799,7 @@ mod contract_precompilation_tests {
             .call_function(
                 state_update,
                 view_state,
-                &"test0".parse().unwrap(),
+                &"test0".parse::<AccountId>().unwrap(),
                 "log_something",
                 &[],
                 &mut logs,
@@ -3694,8 +3812,10 @@ mod contract_precompilation_tests {
     #[cfg_attr(all(target_arch = "aarch64", target_vendor = "apple"), ignore)]
     fn test_two_deployments() {
         let num_clients = 2;
-        let mut genesis =
-            Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+        let mut genesis = Genesis::test(
+            vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+            1,
+        );
         genesis.config.epoch_length = EPOCH_LENGTH;
 
         let mut env = TestEnv::builder(ChainGenesis::test())
@@ -3712,7 +3832,7 @@ mod contract_precompilation_tests {
         let tiny_wasm_code = near_test_contracts::trivial_contract().to_vec();
         height = deploy_test_contract(
             &mut env,
-            "test0".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             &tiny_wasm_code,
             EPOCH_LENGTH,
             height,
@@ -3725,7 +3845,7 @@ mod contract_precompilation_tests {
         let wasm_code = near_test_contracts::rs_contract().to_vec();
         height = deploy_test_contract(
             &mut env,
-            "test0".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             &wasm_code,
             EPOCH_LENGTH + 1,
             height,
@@ -3771,7 +3891,11 @@ mod contract_precompilation_tests {
         init_test_logger();
         let num_clients = 3;
         let mut genesis = Genesis::test(
-            vec!["test0".parse().unwrap(), "test1".parse().unwrap(), "test2".parse().unwrap()],
+            vec![
+                "test0".parse::<AccountId>().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
+                "test2".parse::<AccountId>().unwrap(),
+            ],
             1,
         );
         genesis.config.epoch_length = EPOCH_LENGTH;
@@ -3790,7 +3914,7 @@ mod contract_precompilation_tests {
         let wasm_code = near_test_contracts::rs_contract().to_vec();
         height = deploy_test_contract(
             &mut env,
-            "test2".parse().unwrap(),
+            "test2".parse::<AccountId>().unwrap(),
             &wasm_code,
             EPOCH_LENGTH,
             height,
@@ -3798,12 +3922,16 @@ mod contract_precompilation_tests {
 
         // Delete account on which test contract is stored.
         let block = env.clients[0].chain.get_block_by_height(height - 1).unwrap();
-        let signer = InMemorySigner::from_seed("test2".parse().unwrap(), KeyType::ED25519, "test2");
+        let signer = InMemorySigner::from_seed(
+            "test2".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test2",
+        );
         let delete_account_tx = SignedTransaction::delete_account(
             2,
-            "test2".parse().unwrap(),
-            "test2".parse().unwrap(),
-            "test0".parse().unwrap(),
+            "test2".parse::<AccountId>().unwrap(),
+            "test2".parse::<AccountId>().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             &signer,
             *block.hash(),
         );

--- a/integration-tests/src/tests/client/runtimes.rs
+++ b/integration-tests/src/tests/client/runtimes.rs
@@ -11,6 +11,7 @@ use near_primitives::block_header::ApprovalType;
 use near_primitives::hash::hash;
 use near_primitives::network::PeerId;
 use near_primitives::test_utils::create_test_signer;
+use near_primitives::types::AccountId;
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use nearcore::config::GenesisExt;
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
@@ -19,7 +20,10 @@ use std::sync::Arc;
 
 #[test]
 fn test_pending_approvals() {
-    let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     let mut env = TestEnv::builder(ChainGenesis::test())
         .real_epoch_managers(&genesis.config)
         .nightshade_runtimes(&genesis)
@@ -30,16 +34,21 @@ fn test_pending_approvals() {
     let peer_id = PeerId::random();
     env.clients[0].collect_block_approval(&approval, ApprovalType::PeerApproval(peer_id.clone()));
     let approvals = env.clients[0].pending_approvals.pop(&ApprovalInner::Endorsement(parent_hash));
-    let expected =
-        vec![("test0".parse().unwrap(), (approval, ApprovalType::PeerApproval(peer_id)))]
-            .into_iter()
-            .collect::<HashMap<_, _>>();
+    let expected = vec![(
+        "test0".parse::<AccountId>().unwrap(),
+        (approval, ApprovalType::PeerApproval(peer_id)),
+    )]
+    .into_iter()
+    .collect::<HashMap<_, _>>();
     assert_eq!(approvals, Some(expected));
 }
 
 #[test]
 fn test_invalid_approvals() {
-    let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     let network_adapter = Arc::new(MockPeerManagerAdapter::default());
     let mut env = TestEnv::builder(ChainGenesis::test())
         .real_epoch_managers(&genesis.config)
@@ -54,8 +63,11 @@ fn test_invalid_approvals() {
     env.clients[0].collect_block_approval(&approval, ApprovalType::PeerApproval(peer_id.clone()));
     assert_eq!(env.clients[0].pending_approvals.len(), 0);
     // Approval with invalid signature. Should be dropped
-    let signer =
-        InMemoryValidatorSigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "random");
+    let signer = InMemoryValidatorSigner::from_seed(
+        "test0".parse::<AccountId>().unwrap(),
+        KeyType::ED25519,
+        "random",
+    );
     let genesis_hash = *env.clients[0].chain.genesis().hash();
     let approval = Approval::new(genesis_hash, 0, 1, &signer);
     env.clients[0].collect_block_approval(&approval, ApprovalType::PeerApproval(peer_id));
@@ -66,7 +78,10 @@ fn test_invalid_approvals() {
 fn test_cap_max_gas_price() {
     use near_chain::Provenance;
     use near_primitives::version::ProtocolFeature;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     let epoch_length = 5;
     genesis.config.min_gas_price = 1_000;
     genesis.config.max_gas_price = 1_000_000;

--- a/integration-tests/src/tests/client/sandbox.rs
+++ b/integration-tests/src/tests/client/sandbox.rs
@@ -15,19 +15,23 @@ use nearcore::test_utils::TestEnvNightshadeSetupExt;
 
 fn test_setup() -> (TestEnv, InMemorySigner) {
     let epoch_length = 5;
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(ChainGenesis::test())
         .real_epoch_managers(&genesis.config)
         .nightshade_runtimes(&genesis)
         .build();
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     assert_eq!(
         send_tx(
             &mut env,
             1,
-            "test0".parse().unwrap(),
-            "test0".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             &signer,
             vec![Action::DeployContract(DeployContractAction {
                 code: near_test_contracts::rs_contract().to_vec(),
@@ -41,8 +45,8 @@ fn test_setup() -> (TestEnv, InMemorySigner) {
         send_tx(
             &mut env,
             2,
-            "test0".parse().unwrap(),
-            "test0".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             &signer,
             vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "write_random_value".to_string(),
@@ -81,15 +85,15 @@ fn send_tx(
 fn test_patch_state() {
     let (mut env, _signer) = test_setup();
 
-    let state_item = env.query_state("test0".parse().unwrap()).swap_remove(0);
+    let state_item = env.query_state("test0".parse::<AccountId>().unwrap()).swap_remove(0);
     env.clients[0].chain.patch_state(SandboxStatePatch::new(vec![StateRecord::Data {
-        account_id: "test0".parse().unwrap(),
+        account_id: "test0".parse::<AccountId>().unwrap(),
         data_key: state_item.key,
         value: b"world".to_vec().into(),
     }]));
 
     do_blocks(&mut env, 9, 20);
-    let state = env.query_state("test0".parse().unwrap());
+    let state = env.query_state("test0".parse::<AccountId>().unwrap());
     assert_eq!(state.len(), 1);
     assert_eq!(state[0].value.as_slice(), b"world");
 }
@@ -97,14 +101,14 @@ fn test_patch_state() {
 #[test]
 fn test_patch_account() {
     let (mut env, _signer) = test_setup();
-    let mut test1: Account = env.query_account("test1".parse().unwrap()).into();
+    let mut test1: Account = env.query_account("test1".parse::<AccountId>().unwrap()).into();
     test1.set_amount(10);
 
     env.clients[0].chain.patch_state(SandboxStatePatch::new(vec![StateRecord::Account {
-        account_id: "test1".parse().unwrap(),
+        account_id: "test1".parse::<AccountId>().unwrap(),
         account: test1,
     }]));
     do_blocks(&mut env, 9, 20);
-    let test1_after = env.query_account("test1".parse().unwrap());
+    let test1_after = env.query_account("test1".parse::<AccountId>().unwrap());
     assert_eq!(test1_after.amount, 10);
 }

--- a/integration-tests/src/tests/client/state_dump.rs
+++ b/integration-tests/src/tests/client/state_dump.rs
@@ -16,7 +16,7 @@ use near_primitives::state::FlatStateValue;
 use near_primitives::state_part::PartId;
 use near_primitives::state_sync::StatePartKey;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::BlockHeight;
+use near_primitives::types::{AccountId, BlockHeight};
 use near_primitives::views::{QueryRequest, QueryResponseKind};
 use near_store::flat::store_helper;
 use near_store::DBCol;
@@ -35,7 +35,10 @@ use std::time::Duration;
 fn test_state_dump() {
     init_test_logger();
 
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = 25;
 
     near_actix_test_utils::run_actix(async {
@@ -67,7 +70,7 @@ fn test_state_dump() {
             epoch_manager.clone(),
             shard_tracker,
             runtime,
-            Some("test0".parse().unwrap()),
+            Some("test0".parse::<AccountId>().unwrap()),
         )
         .unwrap();
 
@@ -136,7 +139,7 @@ fn run_state_sync_with_dumped_parts(
         tracing::info!("Testing for case when head is in new epoch, but final block isn't for the dumping node...");
     }
     near_actix_test_utils::run_actix(async {
-        let mut genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
+        let mut genesis = Genesis::test(vec!["test0".parse::<AccountId>().unwrap()], 1);
         genesis.config.epoch_length = epoch_length;
         let chain_genesis = ChainGenesis::new(&genesis);
         let num_clients = 2;
@@ -148,7 +151,11 @@ fn run_state_sync_with_dumped_parts(
             .nightshade_runtimes(&genesis)
             .build();
 
-        let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+        let signer = InMemorySigner::from_seed(
+            "test0".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test0",
+        );
         let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
         let genesis_hash = *genesis_block.hash();
 
@@ -171,7 +178,7 @@ fn run_state_sync_with_dumped_parts(
             epoch_manager.clone(),
             shard_tracker,
             runtime,
-            Some("test0".parse().unwrap()),
+            Some("test0".parse::<AccountId>().unwrap()),
         )
         .unwrap();
 
@@ -187,8 +194,8 @@ fn run_state_sync_with_dumped_parts(
             if i == account_creation_at_height {
                 let tx = SignedTransaction::create_account(
                     1,
-                    "test0".parse().unwrap(),
-                    "test_account".parse().unwrap(),
+                    "test0".parse::<AccountId>().unwrap(),
+                    "test_account".parse::<AccountId>().unwrap(),
                     NEAR_BASE,
                     signer.public_key(),
                     &signer,
@@ -215,7 +222,9 @@ fn run_state_sync_with_dumped_parts(
                 &head.prev_block_hash,
                 &head.last_block_hash,
                 head_block.header().epoch_id(),
-                &QueryRequest::ViewAccount { account_id: "test_account".parse().unwrap() },
+                &QueryRequest::ViewAccount {
+                    account_id: "test_account".parse::<AccountId>().unwrap(),
+                },
             )
             .unwrap();
         assert_matches!(response.kind, QueryResponseKind::ViewAccount(_));
@@ -321,7 +330,7 @@ fn run_state_sync_with_dumped_parts(
             &synced_block_tip.prev_block_hash,
             &synced_block_tip.last_block_hash,
             synced_block_header.epoch_id(),
-            &QueryRequest::ViewAccount { account_id: "test_account".parse().unwrap() },
+            &QueryRequest::ViewAccount { account_id: "test_account".parse::<AccountId>().unwrap() },
         );
 
         if is_final_block_in_new_epoch {

--- a/integration-tests/src/tests/client/state_snapshot.rs
+++ b/integration-tests/src/tests/client/state_snapshot.rs
@@ -8,6 +8,7 @@ use near_primitives::block::Block;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::transaction::SignedTransaction;
+use near_primitives::types::AccountId;
 use near_store::config::StateSnapshotType;
 use near_store::flat::FlatStorageManager;
 use near_store::{
@@ -190,7 +191,7 @@ fn delete_content_at_path(path: &str) -> std::io::Result<()> {
 // transaction creating an account.
 fn test_make_state_snapshot() {
     init_test_logger();
-    let genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
+    let genesis = Genesis::test(vec!["test0".parse::<AccountId>().unwrap()], 1);
     let mut env = TestEnv::builder(ChainGenesis::test())
         .clients_count(1)
         .use_state_snapshots()
@@ -199,7 +200,8 @@ fn test_make_state_snapshot() {
         .nightshade_runtimes(&genesis)
         .build();
 
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let genesis_hash = *genesis_block.hash();
 
@@ -213,7 +215,7 @@ fn test_make_state_snapshot() {
         let nonce = i;
         let tx = SignedTransaction::create_account(
             nonce,
-            "test0".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             new_account_id.parse().unwrap(),
             NEAR_BASE,
             signer.public_key(),

--- a/integration-tests/src/tests/client/sync_state_nodes.rs
+++ b/integration-tests/src/tests/client/sync_state_nodes.rs
@@ -19,7 +19,7 @@ use near_primitives::shard_layout::ShardUId;
 use near_primitives::state_part::PartId;
 use near_primitives::state_sync::{CachedParts, StatePartKey};
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{BlockId, BlockReference, EpochId, EpochReference};
+use near_primitives::types::{AccountId, BlockId, BlockReference, EpochId, EpochReference};
 use near_primitives::utils::MaybeValidated;
 use near_primitives_core::types::ShardId;
 use near_store::DBCol;
@@ -36,7 +36,7 @@ fn sync_state_nodes() {
     heavy_test(|| {
         init_integration_logger();
 
-        let genesis = Genesis::test(vec!["test1".parse().unwrap()], 1);
+        let genesis = Genesis::test(vec!["test1".parse::<AccountId>().unwrap()], 1);
 
         let (port1, port2) =
             (tcp::ListenerAddr::reserve_for_test(), tcp::ListenerAddr::reserve_for_test());
@@ -137,10 +137,10 @@ fn sync_state_nodes_multishard() {
 
         let mut genesis = Genesis::test_sharded_new_version(
             vec![
-                "test1".parse().unwrap(),
-                "test2".parse().unwrap(),
-                "test3".parse().unwrap(),
-                "test4".parse().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
+                "test2".parse::<AccountId>().unwrap(),
+                "test3".parse::<AccountId>().unwrap(),
+                "test4".parse::<AccountId>().unwrap(),
             ],
             4,
             vec![2, 2],
@@ -295,7 +295,7 @@ fn sync_empty_state() {
         init_integration_logger();
 
         let mut genesis = Genesis::test_sharded_new_version(
-            vec!["test1".parse().unwrap(), "test2".parse().unwrap()],
+            vec!["test1".parse::<AccountId>().unwrap(), "test2".parse::<AccountId>().unwrap()],
             1,
             vec![1, 1, 1, 1],
         );
@@ -420,7 +420,7 @@ fn sync_state_dump() {
         init_integration_logger();
 
         let mut genesis = Genesis::test_sharded_new_version(
-            vec!["test1".parse().unwrap(), "test2".parse().unwrap()],
+            vec!["test1".parse::<AccountId>().unwrap(), "test2".parse::<AccountId>().unwrap()],
             1,
             vec![1],
         );
@@ -558,8 +558,10 @@ fn test_dump_epoch_missing_chunk_in_last_block() {
 
         for num_last_chunks_missing in 0..6 {
             assert!(num_last_chunks_missing < epoch_length);
-            let mut genesis =
-                Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+            let mut genesis = Genesis::test(
+                vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+                1,
+            );
             genesis.config.epoch_length = epoch_length;
             let mut env = TestEnv::builder(ChainGenesis::new(&genesis))
                 .clients_count(2)
@@ -571,8 +573,11 @@ fn test_dump_epoch_missing_chunk_in_last_block() {
 
             let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
             let mut blocks = vec![genesis_block.clone()];
-            let signer =
-                InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+            let signer = InMemorySigner::from_seed(
+                "test0".parse::<AccountId>().unwrap(),
+                KeyType::ED25519,
+                "test0",
+            );
             let target_height = epoch_length + 1;
             for i in 1..=target_height {
                 let block = env.clients[0].produce_block(i).unwrap().unwrap();
@@ -602,8 +607,8 @@ fn test_dump_epoch_missing_chunk_in_last_block() {
 
                 let tx = SignedTransaction::send_money(
                     i + 1,
-                    "test0".parse().unwrap(),
-                    "test1".parse().unwrap(),
+                    "test0".parse::<AccountId>().unwrap(),
+                    "test1".parse::<AccountId>().unwrap(),
                     &signer,
                     1,
                     *genesis_block.hash(),
@@ -722,7 +727,7 @@ fn test_state_sync_headers() {
         init_test_logger();
 
         run_actix(async {
-            let mut genesis = Genesis::test(vec!["test1".parse().unwrap()], 1);
+            let mut genesis = Genesis::test(vec!["test1".parse::<AccountId>().unwrap()], 1);
             // Increase epoch_length if the test is flaky.
             genesis.config.epoch_length = 50;
 
@@ -916,7 +921,7 @@ fn test_state_sync_headers_no_tracked_shards() {
         init_test_logger();
 
         run_actix(async {
-            let mut genesis = Genesis::test(vec!["test1".parse().unwrap()], 1);
+            let mut genesis = Genesis::test(vec!["test1".parse::<AccountId>().unwrap()], 1);
             // Increase epoch_length if the test is flaky.
             let epoch_length = 50;
             genesis.config.epoch_length = epoch_length;

--- a/integration-tests/src/tests/client/undo_block.rs
+++ b/integration-tests/src/tests/client/undo_block.rs
@@ -3,6 +3,7 @@ use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_epoch_manager::EpochManagerAdapter;
 use near_o11y::testonly::init_test_logger;
+use near_primitives::types::AccountId;
 use near_store::test_utils::create_test_store;
 use near_store::Store;
 use near_undo_block::undo_block;
@@ -28,7 +29,10 @@ fn test_undo_block(epoch_length: u64, stop_height: u64) {
 
     let save_trie_changes = true;
 
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = epoch_length;
 
     let store = create_test_store();

--- a/integration-tests/src/tests/nearcore/rpc_error_structs.rs
+++ b/integration-tests/src/tests/nearcore/rpc_error_structs.rs
@@ -16,7 +16,7 @@ use near_o11y::WithSpanContextExt;
 use near_primitives::hash::CryptoHash;
 use near_primitives::serialize::to_base64;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::BlockId;
+use near_primitives::types::{AccountId, BlockId};
 
 // Queries json-rpc block that doesn't exists
 // Checks if the struct is expected and contains the proper data
@@ -362,12 +362,15 @@ fn test_tx_invalid_tx_error() {
         let view_client = clients[0].1.clone();
 
         let genesis_hash = *genesis_block(&genesis).hash();
-        let signer =
-            InMemorySigner::from_seed("near.5".parse().unwrap(), KeyType::ED25519, "near.5");
+        let signer = InMemorySigner::from_seed(
+            "near.5".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "near.5",
+        );
         let transaction = SignedTransaction::send_money(
             1,
-            "near.5".parse().unwrap(),
-            "near.2".parse().unwrap(),
+            "near.5".parse::<AccountId>().unwrap(),
+            "near.2".parse::<AccountId>().unwrap(),
             &signer,
             10000,
             genesis_hash,
@@ -441,7 +444,7 @@ fn test_query_rpc_account_view_unknown_block_must_return_error() {
                     1,
                 )),
                 request: near_primitives::views::QueryRequest::ViewAccount {
-                    account_id: "near.0".parse().unwrap(),
+                    account_id: "near.0".parse::<AccountId>().unwrap(),
                 },
             })
             .await;

--- a/integration-tests/src/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/src/tests/nearcore/rpc_nodes.rs
@@ -20,7 +20,7 @@ use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::serialize::to_base64;
 use near_primitives::transaction::{PartialExecutionStatus, SignedTransaction};
 use near_primitives::types::{
-    BlockId, BlockReference, EpochId, EpochReference, Finality, TransactionOrReceiptId,
+    AccountId, BlockId, BlockReference, EpochId, EpochReference, Finality, TransactionOrReceiptId,
 };
 use near_primitives::version::ProtocolVersion;
 use near_primitives::views::{
@@ -64,7 +64,7 @@ fn test_get_validator_info_rpc() {
                         assert!(res
                             .current_validators
                             .iter()
-                            .any(|r| r.account_id.as_ref() == "near.0"));
+                            .any(|r| r.account_id.as_str() == "near.0"));
                         System::current().stop();
                     }
                 });
@@ -110,13 +110,16 @@ fn test_get_execution_outcome(is_tx_successful: bool) {
         let view_client = clients[0].1.clone();
 
         let genesis_hash = *genesis_block(&genesis).hash();
-        let signer =
-            InMemorySigner::from_seed("near.0".parse().unwrap(), KeyType::ED25519, "near.0");
+        let signer = InMemorySigner::from_seed(
+            "near.0".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "near.0",
+        );
         let transaction = if is_tx_successful {
             SignedTransaction::send_money(
                 1,
-                "near.0".parse().unwrap(),
-                "near.1".parse().unwrap(),
+                "near.0".parse::<AccountId>().unwrap(),
+                "near.1".parse::<AccountId>().unwrap(),
                 &signer,
                 10000,
                 genesis_hash,
@@ -124,8 +127,8 @@ fn test_get_execution_outcome(is_tx_successful: bool) {
         } else {
             SignedTransaction::create_account(
                 1,
-                "near.0".parse().unwrap(),
-                "near.1".parse().unwrap(),
+                "near.0".parse::<AccountId>().unwrap(),
+                "near.1".parse::<AccountId>().unwrap(),
                 10,
                 signer.public_key.clone(),
                 &signer,
@@ -148,14 +151,14 @@ fn test_get_execution_outcome(is_tx_successful: bool) {
                             let mut futures = vec![];
                             for id in vec![TransactionOrReceiptId::Transaction {
                                 transaction_hash: final_transaction_outcome.transaction_outcome.id,
-                                sender_id: "near.0".parse().unwrap(),
+                                sender_id: "near.0".parse::<AccountId>().unwrap(),
                             }]
                             .into_iter()
                             .chain(
                                 final_transaction_outcome.receipts_outcome.into_iter().map(|r| {
                                     TransactionOrReceiptId::Receipt {
                                         receipt_id: r.id,
-                                        receiver_id: "near.1".parse().unwrap(),
+                                        receiver_id: "near.1".parse::<AccountId>().unwrap(),
                                     }
                                 }),
                             ) {
@@ -282,7 +285,7 @@ fn test_query_rpc_account_view_must_succeed() {
             .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
                 block_reference: near_primitives::types::BlockReference::Finality(Finality::Final),
                 request: near_primitives::views::QueryRequest::ViewAccount {
-                    account_id: "near.0".parse().unwrap(),
+                    account_id: "near.0".parse::<AccountId>().unwrap(),
                 },
             })
             .await
@@ -322,7 +325,7 @@ fn test_query_rpc_account_view_account_doesnt_exist_must_return_error() {
                 .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
                     block_reference: near_primitives::types::BlockReference::Finality(Finality::Final),
                     request: near_primitives::views::QueryRequest::ViewAccount {
-                        account_id: "accountdoesntexist.0".parse().unwrap(),
+                        account_id: "accountdoesntexist.0".parse::<AccountId>().unwrap(),
                     },
                 })
                 .await;
@@ -369,12 +372,15 @@ fn test_tx_not_enough_balance_must_return_error() {
         let view_client = clients[0].1.clone();
 
         let genesis_hash = *genesis_block(&genesis).hash();
-        let signer =
-            InMemorySigner::from_seed("near.0".parse().unwrap(), KeyType::ED25519, "near.0");
+        let signer = InMemorySigner::from_seed(
+            "near.0".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "near.0",
+        );
         let transaction = SignedTransaction::send_money(
             1,
-            "near.0".parse().unwrap(),
-            "near.1".parse().unwrap(),
+            "near.0".parse::<AccountId>().unwrap(),
+            "near.1".parse::<AccountId>().unwrap(),
             &signer,
             1100000000000000000000000000000000,
             genesis_hash,
@@ -433,12 +439,15 @@ fn test_send_tx_sync_returns_transaction_hash() {
         let view_client = clients[0].1.clone();
 
         let genesis_hash = *genesis_block(&genesis).hash();
-        let signer =
-            InMemorySigner::from_seed("near.0".parse().unwrap(), KeyType::ED25519, "near.0");
+        let signer = InMemorySigner::from_seed(
+            "near.0".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "near.0",
+        );
         let transaction = SignedTransaction::send_money(
             1,
-            "near.0".parse().unwrap(),
-            "near.0".parse().unwrap(),
+            "near.0".parse::<AccountId>().unwrap(),
+            "near.0".parse::<AccountId>().unwrap(),
             &signer,
             10000,
             genesis_hash,
@@ -482,12 +491,15 @@ fn test_send_tx_sync_to_lightclient_must_be_routed() {
         let view_client = clients[0].1.clone();
 
         let genesis_hash = *genesis_block(&genesis).hash();
-        let signer =
-            InMemorySigner::from_seed("near.1".parse().unwrap(), KeyType::ED25519, "near.1");
+        let signer = InMemorySigner::from_seed(
+            "near.1".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "near.1",
+        );
         let transaction = SignedTransaction::send_money(
             1,
-            "near.1".parse().unwrap(),
-            "near.1".parse().unwrap(),
+            "near.1".parse::<AccountId>().unwrap(),
+            "near.1".parse::<AccountId>().unwrap(),
             &signer,
             10000,
             genesis_hash,
@@ -542,12 +554,15 @@ fn test_check_unknown_tx_must_return_error() {
         let view_client = clients[0].1.clone();
 
         let genesis_hash = *genesis_block(&genesis).hash();
-        let signer =
-            InMemorySigner::from_seed("near.0".parse().unwrap(), KeyType::ED25519, "near.0");
+        let signer = InMemorySigner::from_seed(
+            "near.0".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "near.0",
+        );
         let transaction = SignedTransaction::send_money(
             1,
-            "near.0".parse().unwrap(),
-            "near.0".parse().unwrap(),
+            "near.0".parse::<AccountId>().unwrap(),
+            "near.0".parse::<AccountId>().unwrap(),
             &signer,
             10000,
             genesis_hash,
@@ -601,11 +616,11 @@ fn test_check_tx_on_lightclient_must_return_does_not_track_shard() {
         let view_client = clients[0].1.clone();
 
         let genesis_hash = *genesis_block(&genesis).hash();
-        let signer = InMemorySigner::from_seed("near.1".parse().unwrap(), KeyType::ED25519, "near.1");
+        let signer = InMemorySigner::from_seed("near.1".parse::<AccountId>().unwrap(), KeyType::ED25519, "near.1");
         let transaction = SignedTransaction::send_money(
             1,
-            "near.1".parse().unwrap(),
-            "near.1".parse().unwrap(),
+            "near.1".parse::<AccountId>().unwrap(),
+            "near.1".parse::<AccountId>().unwrap(),
             &signer,
             10000,
             genesis_hash,

--- a/integration-tests/src/tests/nearcore/stake_nodes.rs
+++ b/integration-tests/src/tests/nearcore/stake_nodes.rs
@@ -162,11 +162,11 @@ fn test_stake_nodes() {
                         if validators
                             == vec![
                                 ValidatorInfo {
-                                    account_id: "near.0".parse().unwrap(),
+                                    account_id: "near.0".parse::<AccountId>().unwrap(),
                                     is_slashed: false,
                                 },
                                 ValidatorInfo {
-                                    account_id: "near.1".parse().unwrap(),
+                                    account_id: "near.1".parse::<AccountId>().unwrap(),
                                     is_slashed: false,
                                 },
                             ]
@@ -433,11 +433,11 @@ fn test_validator_join() {
                     let actor = actor.then(move |res| {
                         let expected = vec![
                             ValidatorInfo {
-                                account_id: "near.0".parse().unwrap(),
+                                account_id: "near.0".parse::<AccountId>().unwrap(),
                                 is_slashed: false,
                             },
                             ValidatorInfo {
-                                account_id: "near.2".parse().unwrap(),
+                                account_id: "near.2".parse::<AccountId>().unwrap(),
                                 is_slashed: false,
                             },
                         ];

--- a/integration-tests/src/tests/nearcore/sync_nodes.rs
+++ b/integration-tests/src/tests/nearcore/sync_nodes.rs
@@ -19,7 +19,7 @@ use near_primitives::num_rational::{Ratio, Rational32};
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::validator_stake::ValidatorStake;
-use near_primitives::types::{BlockHeightDelta, EpochId};
+use near_primitives::types::{AccountId, BlockHeightDelta, EpochId};
 use near_primitives::validator_signer::ValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
 use nearcore::config::{GenesisExt, TESTING_INIT_STAKE};
@@ -52,7 +52,7 @@ fn add_blocks(
             *blocks[(((prev.header().height()) / epoch_length) * epoch_length) as usize].hash(),
         );
         let next_bp_hash = CryptoHash::hash_borsh_iter([ValidatorStake::new(
-            "other".parse().unwrap(),
+            "other".parse::<AccountId>().unwrap(),
             signer.public_key(),
             TESTING_INIT_STAKE,
         )]);
@@ -102,7 +102,7 @@ fn add_blocks(
 }
 
 fn setup_configs() -> (Genesis, Block, NearConfig, NearConfig) {
-    let mut genesis = Genesis::test(vec!["other".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(vec!["other".parse::<AccountId>().unwrap()], 1);
     genesis.config.epoch_length = 5;
     // Avoid InvalidGasPrice error. Blocks must contain accurate `total_supply` value.
     // Accounting for the inflation in tests is hard.
@@ -239,7 +239,7 @@ fn sync_state_stake_change() {
     heavy_test(|| {
         init_integration_logger();
 
-        let mut genesis = Genesis::test(vec!["test1".parse().unwrap()], 1);
+        let mut genesis = Genesis::test(vec!["test1".parse::<AccountId>().unwrap()], 1);
         let epoch_length = 20;
         genesis.config.epoch_length = epoch_length;
         genesis.config.block_producer_kickout_threshold = 80;
@@ -266,13 +266,13 @@ fn sync_state_stake_change() {
 
             let genesis_hash = *genesis_block(&genesis).hash();
             let signer = Arc::new(InMemorySigner::from_seed(
-                "test1".parse().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
                 KeyType::ED25519,
                 "test1",
             ));
             let unstake_transaction = SignedTransaction::stake(
                 1,
-                "test1".parse().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
                 &*signer,
                 TESTING_INIT_STAKE / 2,
                 near1.validator_signer.as_ref().unwrap().public_key(),

--- a/integration-tests/src/tests/network/peer_handshake.rs
+++ b/integration-tests/src/tests/network/peer_handshake.rs
@@ -13,6 +13,7 @@ use near_network::PeerManagerActor;
 use near_o11y::testonly::init_test_logger;
 use near_o11y::WithSpanContextExt;
 use near_primitives::block::GenesisId;
+use near_primitives::types::AccountId;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -210,7 +211,7 @@ fn check_connection_with_new_identity() -> anyhow::Result<()> {
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
 
     runner.push(Action::Stop(1));
-    runner.push_action(change_account_id(1, "far".parse().unwrap()));
+    runner.push_action(change_account_id(1, "far".parse::<AccountId>().unwrap()));
     runner.push(Action::CheckRoutingTable(0, vec![]));
     runner.push_action(restart(1));
 

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -268,7 +268,7 @@ impl TestConfig {
     }
 
     fn peer_id(&self) -> PeerId {
-        peer_id_from_seed(&self.account_id)
+        peer_id_from_seed(&self.account_id.as_str())
     }
 
     fn peer_info(&self) -> PeerInfo {
@@ -395,7 +395,7 @@ impl Runner {
             config.whitelist.iter().map(|ix| self.test_config[*ix].peer_info()).collect();
 
         let mut network_config =
-            config::NetworkConfig::from_seed(&config.account_id, config.node_addr);
+            config::NetworkConfig::from_seed(config.account_id.as_str(), config.node_addr);
         network_config.peer_store.ban_window = config.ban_window;
         network_config.max_num_peers = config.max_num_peers;
         network_config.ttl_account_id_router = time::Duration::seconds(5);

--- a/integration-tests/src/tests/runtime/deployment.rs
+++ b/integration-tests/src/tests/runtime/deployment.rs
@@ -12,8 +12,8 @@ const ONE_NEAR: u128 = 10u128.pow(24);
 /// Tests if the maximum allowed contract can be deployed with current gas limits
 #[test]
 fn test_deploy_max_size_contract() {
-    let account_id: AccountId = "alice.near".parse().unwrap();
-    let test_contract_id: AccountId = "test_contract.alice.near".parse().unwrap();
+    let account_id: AccountId = "alice.near".parse::<AccountId>().unwrap();
+    let test_contract_id: AccountId = "test_contract.alice.near".parse::<AccountId>().unwrap();
     let runtime_config_store = RuntimeConfigStore::new(None);
     let config = runtime_config_store.get_config(PROTOCOL_VERSION);
 

--- a/integration-tests/src/tests/runtime/sanity_checks.rs
+++ b/integration-tests/src/tests/runtime/sanity_checks.rs
@@ -40,8 +40,10 @@ fn test_contract_account() -> AccountId {
 fn setup_runtime_node_with_contract(wasm_binary: &[u8]) -> RuntimeNode {
     // Create a `RuntimeNode`. Load `RuntimeConfig` from `RuntimeConfigStore`
     // to ensure we are using the latest configuration.
-    let mut genesis =
-        Genesis::test(vec![alice_account(), bob_account(), "carol.near".parse().unwrap()], 3);
+    let mut genesis = Genesis::test(
+        vec![alice_account(), bob_account(), "carol.near".parse::<AccountId>().unwrap()],
+        3,
+    );
     add_test_contract(&mut genesis, &alice_account());
     add_test_contract(&mut genesis, &bob_account());
     let runtime_config_store = RuntimeConfigStore::new(None);

--- a/integration-tests/src/tests/runtime/state_viewer.rs
+++ b/integration-tests/src/tests/runtime/state_viewer.rs
@@ -119,7 +119,7 @@ fn test_view_call() {
     let result = viewer.call_function(
         root,
         view_state,
-        &"test.contract".parse().unwrap(),
+        &"test.contract".parse::<AccountId>().unwrap(),
         "run_test",
         &[],
         &mut logs,
@@ -147,7 +147,7 @@ fn test_view_call_try_changing_storage() {
     let result = viewer.call_function(
         root,
         view_state,
-        &"test.contract".parse().unwrap(),
+        &"test.contract".parse::<AccountId>().unwrap(),
         "run_test_with_storage_change",
         &[],
         &mut logs,
@@ -179,7 +179,7 @@ fn test_view_call_with_args() {
     let view_call_result = viewer.call_function(
         root,
         view_state,
-        &"test.contract".parse().unwrap(),
+        &"test.contract".parse::<AccountId>().unwrap(),
         "sum_with_input",
         &args,
         &mut logs,
@@ -196,7 +196,7 @@ fn assert_view_state(
     want_proof: &[&'static str],
 ) -> ProofVerifier {
     let alice = alice_account();
-    let alina = "alina".parse().unwrap();
+    let alina = "alina".parse::<AccountId>().unwrap();
 
     let values = want_values
         .iter()
@@ -274,11 +274,17 @@ fn test_view_state() {
         b"321".to_vec(),
     );
     state_update.set(
-        TrieKey::ContractData { account_id: "alina".parse().unwrap(), key: b"qqq".to_vec() },
+        TrieKey::ContractData {
+            account_id: "alina".parse::<AccountId>().unwrap(),
+            key: b"qqq".to_vec(),
+        },
         b"321".to_vec(),
     );
     state_update.set(
-        TrieKey::ContractData { account_id: "alex".parse().unwrap(), key: b"qqq".to_vec() },
+        TrieKey::ContractData {
+            account_id: "alex".parse::<AccountId>().unwrap(),
+            key: b"qqq".to_vec(),
+        },
         b"321".to_vec(),
     );
     state_update.commit(StateChangeCause::InitialState);
@@ -401,7 +407,7 @@ fn test_log_when_panic() {
         .call_function(
             root,
             view_state,
-            &"test.contract".parse().unwrap(),
+            &"test.contract".parse::<AccountId>().unwrap(),
             "panic_after_logging",
             &[],
             &mut logs,

--- a/integration-tests/src/tests/runtime/test_evil_contracts.rs
+++ b/integration-tests/src/tests/runtime/test_evil_contracts.rs
@@ -1,5 +1,6 @@
 use crate::node::{Node, RuntimeNode};
 use near_primitives::errors::{ActionError, ActionErrorKind, FunctionCallError};
+use near_primitives::types::AccountId;
 use near_primitives::views::FinalExecutionStatus;
 use std::mem::size_of;
 
@@ -15,13 +16,13 @@ pub const NEAR_BASE: u128 = 1_000_000_000_000_000_000_000_000;
 const MAX_GAS: u64 = 300_000_000_000_000;
 
 fn setup_test_contract(wasm_binary: &[u8]) -> RuntimeNode {
-    let node = RuntimeNode::new(&"alice.near".parse().unwrap());
+    let node = RuntimeNode::new(&"alice.near".parse::<AccountId>().unwrap());
     let account_id = node.account_id().unwrap();
     let node_user = node.user();
     let transaction_result = node_user
         .create_account(
             account_id,
-            "test_contract".parse().unwrap(),
+            "test_contract".parse::<AccountId>().unwrap(),
             node.signer().public_key(),
             TESTING_INIT_BALANCE / 2,
         )
@@ -29,8 +30,9 @@ fn setup_test_contract(wasm_binary: &[u8]) -> RuntimeNode {
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 2);
 
-    let transaction_result =
-        node_user.deploy_contract("test_contract".parse().unwrap(), wasm_binary.to_vec()).unwrap();
+    let transaction_result = node_user
+        .deploy_contract("test_contract".parse::<AccountId>().unwrap(), wasm_binary.to_vec())
+        .unwrap();
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 1);
 
@@ -50,8 +52,8 @@ fn test_evil_deep_trie() {
         let res = node
             .user()
             .function_call(
-                "alice.near".parse().unwrap(),
-                "test_contract".parse().unwrap(),
+                "alice.near".parse::<AccountId>().unwrap(),
+                "test_contract".parse::<AccountId>().unwrap(),
                 "insert_strings",
                 input_data.to_vec(),
                 MAX_GAS,
@@ -71,8 +73,8 @@ fn test_evil_deep_trie() {
         let res = node
             .user()
             .function_call(
-                "alice.near".parse().unwrap(),
-                "test_contract".parse().unwrap(),
+                "alice.near".parse::<AccountId>().unwrap(),
+                "test_contract".parse::<AccountId>().unwrap(),
                 "delete_strings",
                 input_data.to_vec(),
                 MAX_GAS,
@@ -93,8 +95,8 @@ fn test_evil_deep_recursion() {
         let res = node
             .user()
             .function_call(
-                "alice.near".parse().unwrap(),
-                "test_contract".parse().unwrap(),
+                "alice.near".parse::<AccountId>().unwrap(),
+                "test_contract".parse::<AccountId>().unwrap(),
                 "recurse",
                 n_bytes.clone(),
                 MAX_GAS,
@@ -115,8 +117,8 @@ fn test_evil_abort() {
     let res = node
         .user()
         .function_call(
-            "alice.near".parse().unwrap(),
-            "test_contract".parse().unwrap(),
+            "alice.near".parse::<AccountId>().unwrap(),
+            "test_contract".parse::<AccountId>().unwrap(),
             "abort_with_zero",
             vec![],
             MAX_GAS,

--- a/integration-tests/src/tests/standard_cases/mod.rs
+++ b/integration-tests/src/tests/standard_cases/mod.rs
@@ -667,7 +667,8 @@ pub fn test_create_account_failure_already_exists(node: impl Node) {
 
 pub fn test_swap_key(node: impl Node) {
     let account_id = &node.account_id().unwrap();
-    let signer2 = InMemorySigner::from_random("test".parse().unwrap(), KeyType::ED25519);
+    let signer2 =
+        InMemorySigner::from_random("test".parse::<AccountId>().unwrap(), KeyType::ED25519);
     let node_user = node.user();
     let root = node_user.get_state_root();
     let money_used = TESTING_INIT_BALANCE / 2;
@@ -703,7 +704,8 @@ pub fn test_swap_key(node: impl Node) {
 
 pub fn test_add_key(node: impl Node) {
     let account_id = &node.account_id().unwrap();
-    let signer2 = InMemorySigner::from_random("test".parse().unwrap(), KeyType::ED25519);
+    let signer2 =
+        InMemorySigner::from_random("test".parse::<AccountId>().unwrap(), KeyType::ED25519);
     let node_user = node.user();
 
     add_access_key(&node, node_user.as_ref(), &AccessKey::full_access(), &signer2);
@@ -741,7 +743,8 @@ pub fn test_add_existing_key(node: impl Node) {
 
 pub fn test_delete_key(node: impl Node) {
     let account_id = &node.account_id().unwrap();
-    let signer2 = InMemorySigner::from_random("test".parse().unwrap(), KeyType::ED25519);
+    let signer2 =
+        InMemorySigner::from_random("test".parse::<AccountId>().unwrap(), KeyType::ED25519);
     let node_user = node.user();
     add_access_key(&node, node_user.as_ref(), &AccessKey::full_access(), &signer2);
 
@@ -762,7 +765,8 @@ pub fn test_delete_key(node: impl Node) {
 
 pub fn test_delete_key_not_owned(node: impl Node) {
     let account_id = &node.account_id().unwrap();
-    let signer2 = InMemorySigner::from_random("test".parse().unwrap(), KeyType::ED25519);
+    let signer2 =
+        InMemorySigner::from_random("test".parse::<AccountId>().unwrap(), KeyType::ED25519);
     let node_user = node.user();
 
     assert!(node_user.get_access_key(account_id, &node.signer().public_key()).is_ok());
@@ -856,7 +860,8 @@ pub fn test_add_access_key_function_call(node: impl Node) {
             method_names: vec![],
         }),
     };
-    let signer2 = InMemorySigner::from_random("test".parse().unwrap(), KeyType::ED25519);
+    let signer2 =
+        InMemorySigner::from_random("test".parse::<AccountId>().unwrap(), KeyType::ED25519);
     let result = add_access_key(&node, node_user.as_ref(), &access_key, &signer2);
 
     assert!(node_user.get_access_key(account_id, &node.signer().public_key()).is_ok());
@@ -876,7 +881,8 @@ pub fn test_delete_access_key(node: impl Node) {
             method_names: vec![],
         }),
     };
-    let signer2 = InMemorySigner::from_random("test".parse().unwrap(), KeyType::ED25519);
+    let signer2 =
+        InMemorySigner::from_random("test".parse::<AccountId>().unwrap(), KeyType::ED25519);
     add_access_key(&node, node_user.as_ref(), &access_key, &signer2);
 
     assert!(node_user.get_access_key(account_id, &node.signer().public_key()).is_ok());
@@ -905,7 +911,8 @@ pub fn test_add_access_key_with_allowance(node: impl Node) {
         }),
     };
     let node_user = node.user();
-    let signer2 = InMemorySigner::from_random("test".parse().unwrap(), KeyType::ED25519);
+    let signer2 =
+        InMemorySigner::from_random("test".parse::<AccountId>().unwrap(), KeyType::ED25519);
     let account = node_user.view_account(account_id).unwrap();
     let initial_balance = account.amount;
     let fee_helper = fee_helper(&node);
@@ -931,7 +938,8 @@ pub fn test_delete_access_key_with_allowance(node: impl Node) {
         }),
     };
     let node_user = node.user();
-    let signer2 = InMemorySigner::from_random("test".parse().unwrap(), KeyType::ED25519);
+    let signer2 =
+        InMemorySigner::from_random("test".parse::<AccountId>().unwrap(), KeyType::ED25519);
     let account = node_user.view_account(account_id).unwrap();
     let initial_balance = account.amount;
     let fee_helper = fee_helper(&node);
@@ -968,7 +976,10 @@ pub fn test_access_key_smart_contract(node: impl Node) {
     };
     let mut node_user = node.user();
     let account_id = &node.account_id().unwrap();
-    let signer2 = Arc::new(InMemorySigner::from_random("test".parse().unwrap(), KeyType::ED25519));
+    let signer2 = Arc::new(InMemorySigner::from_random(
+        "test".parse::<AccountId>().unwrap(),
+        KeyType::ED25519,
+    ));
     add_access_key(&node, node_user.as_ref(), &access_key, &signer2);
     node_user.set_signer(signer2.clone());
 
@@ -1020,7 +1031,8 @@ pub fn test_access_key_smart_contract_reject_method_name(node: impl Node) {
     };
     let mut node_user = node.user();
     let account_id = &node.account_id().unwrap();
-    let signer2 = InMemorySigner::from_random("test".parse().unwrap(), KeyType::ED25519);
+    let signer2 =
+        InMemorySigner::from_random("test".parse::<AccountId>().unwrap(), KeyType::ED25519);
     add_access_key(&node, node_user.as_ref(), &access_key, &signer2);
     node_user.set_signer(Arc::new(signer2));
 
@@ -1048,7 +1060,8 @@ pub fn test_access_key_smart_contract_reject_contract_id(node: impl Node) {
     };
     let mut node_user = node.user();
     let account_id = &node.account_id().unwrap();
-    let signer2 = InMemorySigner::from_random("test".parse().unwrap(), KeyType::ED25519);
+    let signer2 =
+        InMemorySigner::from_random("test".parse::<AccountId>().unwrap(), KeyType::ED25519);
     add_access_key(&node, node_user.as_ref(), &access_key, &signer2);
     node_user.set_signer(Arc::new(signer2));
 
@@ -1084,7 +1097,8 @@ pub fn test_access_key_reject_non_function_call(node: impl Node) {
         }),
     };
     let mut node_user = node.user();
-    let signer2 = InMemorySigner::from_random("test".parse().unwrap(), KeyType::ED25519);
+    let signer2 =
+        InMemorySigner::from_random("test".parse::<AccountId>().unwrap(), KeyType::ED25519);
     add_access_key(&node, node_user.as_ref(), &access_key, &signer2);
     node_user.set_signer(Arc::new(signer2));
 

--- a/integration-tests/src/tests/standard_cases/runtime.rs
+++ b/integration-tests/src/tests/standard_cases/runtime.rs
@@ -14,8 +14,10 @@ fn create_free_runtime_node() -> RuntimeNode {
 }
 
 fn create_runtime_with_expensive_storage() -> RuntimeNode {
-    let mut genesis =
-        Genesis::test(vec![alice_account(), bob_account(), "carol.near".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec![alice_account(), bob_account(), "carol.near".parse::<AccountId>().unwrap()],
+        1,
+    );
     add_test_contract(&mut genesis, &bob_account());
     // Set expensive state requirements and add alice more money.
     let mut runtime_config = RuntimeConfig::test();

--- a/integration-tests/src/tests/test_errors.rs
+++ b/integration-tests/src/tests/test_errors.rs
@@ -12,6 +12,7 @@ use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::transaction::{
     Action, AddKeyAction, CreateAccountAction, SignedTransaction, TransferAction,
 };
+use near_primitives::types::AccountId;
 use near_primitives::version::PROTOCOL_VERSION;
 use nearcore::config::{GenesisExt, TESTING_INIT_BALANCE, TESTING_INIT_STAKE};
 use nearcore::load_test_config;
@@ -39,7 +40,7 @@ fn test_check_tx_error_log() {
     let tx = SignedTransaction::from_actions(
         1,
         bob_account(),
-        "test.near".parse().unwrap(),
+        "test.near".parse::<AccountId>().unwrap(),
         &*signer,
         vec![
             Action::CreateAccount(CreateAccountAction {}),
@@ -79,7 +80,7 @@ fn test_deliver_tx_error_log() {
     let tx = SignedTransaction::from_actions(
         1,
         alice_account(),
-        "test.near".parse().unwrap(),
+        "test.near".parse::<AccountId>().unwrap(),
         &*signer,
         vec![
             Action::CreateAccount(CreateAccountAction {}),

--- a/integration-tests/src/user/mod.rs
+++ b/integration-tests/src/user/mod.rs
@@ -261,7 +261,7 @@ pub trait User {
         relayer_id: AccountId,
         actions: Vec<Action>,
     ) -> Result<FinalExecutionOutcomeView, ServerError> {
-        let inner_signer = create_user_test_signer(&signer_id);
+        let inner_signer = create_user_test_signer(signer_id.as_str());
         let user_nonce = self
             .get_access_key(&signer_id, &inner_signer.public_key)
             .expect("failed reading user's nonce for access key")

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -727,7 +727,7 @@ impl NearConfig {
         }
 
         let network_signer = InMemorySigner::from_secret_key(
-            "node".parse().unwrap(),
+            "node".parse::<AccountId>().unwrap(),
             self.network_config.node_key.clone(),
         );
         network_signer
@@ -891,7 +891,12 @@ fn generate_or_load_keys(
     account_id: Option<AccountId>,
     test_seed: Option<&str>,
 ) -> anyhow::Result<()> {
-    generate_or_load_key(dir, &config.node_key_file, Some("node".parse().unwrap()), None)?;
+    generate_or_load_key(
+        dir,
+        &config.node_key_file,
+        Some("node".parse::<AccountId>().unwrap()),
+        None,
+    )?;
     match chain_id {
         near_primitives::chains::MAINNET
         | near_primitives::chains::TESTNET
@@ -899,7 +904,8 @@ fn generate_or_load_keys(
             generate_or_load_key(dir, &config.validator_key_file, account_id, None)?;
         }
         _ => {
-            let account_id = account_id.unwrap_or_else(|| "test.near".parse().unwrap());
+            let account_id =
+                account_id.unwrap_or_else(|| "test.near".parse::<AccountId>().unwrap());
             generate_or_load_key(dir, &config.validator_key_file, Some(account_id), test_seed)?;
         }
     }
@@ -1174,7 +1180,9 @@ pub fn create_testnet_configs_from_seeds(
         seeds.iter().map(|seed| create_test_signer(seed.as_str())).collect::<Vec<_>>();
     let network_signers = seeds
         .iter()
-        .map(|seed| InMemorySigner::from_seed("node".parse().unwrap(), KeyType::ED25519, seed))
+        .map(|seed| {
+            InMemorySigner::from_seed("node".parse::<AccountId>().unwrap(), KeyType::ED25519, seed)
+        })
         .collect::<Vec<_>>();
 
     let shard_layout = ShardLayout::v0(num_shards, 0);
@@ -1477,8 +1485,10 @@ pub fn load_test_config(seed: &str, addr: tcp::ListenerAddr, genesis: Genesis) -
     config.consensus.max_block_production_delay =
         Duration::from_millis(FAST_MAX_BLOCK_PRODUCTION_DELAY);
     let (signer, validator_signer) = if seed.is_empty() {
-        let signer =
-            Arc::new(InMemorySigner::from_random("node".parse().unwrap(), KeyType::ED25519));
+        let signer = Arc::new(InMemorySigner::from_random(
+            "node".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+        ));
         (signer, None)
     } else {
         let signer =

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -1768,24 +1768,27 @@ mod test {
                 .iter()
                 .map(|x| (x.0.account_id().clone(), x.1))
                 .collect::<HashMap<_, _>>(),
-            vec![("test3".parse().unwrap(), false), ("test1".parse().unwrap(), false)]
-                .into_iter()
-                .collect::<HashMap<_, _>>()
+            vec![
+                ("test3".parse::<AccountId>().unwrap(), false),
+                ("test1".parse::<AccountId>().unwrap(), false)
+            ]
+            .into_iter()
+            .collect::<HashMap<_, _>>()
         );
 
-        let test1_acc = env.view_account(&"test1".parse().unwrap());
+        let test1_acc = env.view_account(&"test1".parse::<AccountId>().unwrap());
         // Staked 2 * X, sent 3 * X to test3.
         assert_eq!(
             (test1_acc.amount, test1_acc.locked),
             (TESTING_INIT_BALANCE - 5 * TESTING_INIT_STAKE, 2 * TESTING_INIT_STAKE)
         );
-        let test2_acc = env.view_account(&"test2".parse().unwrap());
+        let test2_acc = env.view_account(&"test2".parse::<AccountId>().unwrap());
         // Become fishermen instead
         assert_eq!(
             (test2_acc.amount, test2_acc.locked),
             (TESTING_INIT_BALANCE - test2_stake_amount, test2_stake_amount)
         );
-        let test3_acc = env.view_account(&"test3".parse().unwrap());
+        let test3_acc = env.view_account(&"test3".parse::<AccountId>().unwrap());
         // Got 3 * X, staking 2 * X of them.
         assert_eq!(
             (test3_acc.amount, test3_acc.locked),
@@ -2124,13 +2127,13 @@ mod test {
                 let bp = em.get_block_producer_info(&epoch_id, height).unwrap();
                 let cp = em.get_chunk_producer_info(&epoch_id, height, 0).unwrap();
 
-                if bp.account_id().as_ref() == "test1" {
+                if bp.account_id().as_str() == "test1" {
                     expected_blocks[0] += 1;
                 } else {
                     expected_blocks[1] += 1;
                 }
 
-                if cp.account_id().as_ref() == "test1" {
+                if cp.account_id().as_str() == "test1" {
                     expected_chunks[0] += 1;
                 } else {
                     expected_chunks[1] += 1;
@@ -2146,7 +2149,7 @@ mod test {
         update_validator_stats(&mut env, &mut expected_blocks, &mut expected_chunks);
         let mut current_epoch_validator_info = vec![
             CurrentEpochValidatorInfo {
-                account_id: "test1".parse().unwrap(),
+                account_id: "test1".parse::<AccountId>().unwrap(),
                 public_key: block_producers[0].public_key(),
                 is_slashed: false,
                 stake: TESTING_INIT_STAKE,
@@ -2159,7 +2162,7 @@ mod test {
                 num_expected_chunks_per_shard: vec![expected_chunks[0]],
             },
             CurrentEpochValidatorInfo {
-                account_id: "test2".parse().unwrap(),
+                account_id: "test2".parse::<AccountId>().unwrap(),
                 public_key: block_producers[1].public_key(),
                 is_slashed: false,
                 stake: TESTING_INIT_STAKE,
@@ -2174,13 +2177,13 @@ mod test {
         ];
         let next_epoch_validator_info = vec![
             NextEpochValidatorInfo {
-                account_id: "test1".parse().unwrap(),
+                account_id: "test1".parse::<AccountId>().unwrap(),
                 public_key: block_producers[0].public_key(),
                 stake: TESTING_INIT_STAKE,
                 shards: vec![0],
             },
             NextEpochValidatorInfo {
-                account_id: "test2".parse().unwrap(),
+                account_id: "test2".parse::<AccountId>().unwrap(),
                 public_key: block_producers[1].public_key(),
                 stake: TESTING_INIT_STAKE,
                 shards: vec![0],
@@ -2198,7 +2201,7 @@ mod test {
                 current_fishermen: vec![],
                 next_fishermen: vec![],
                 current_proposals: vec![ValidatorStake::new(
-                    "test1".parse().unwrap(),
+                    "test1".parse::<AccountId>().unwrap(),
                     block_producers[0].public_key(),
                     0,
                 )
@@ -2233,7 +2236,7 @@ mod test {
         assert_eq!(
             response.next_validators,
             vec![NextEpochValidatorInfo {
-                account_id: "test2".parse().unwrap(),
+                account_id: "test2".parse::<AccountId>().unwrap(),
                 public_key: block_producers[1].public_key(),
                 stake: TESTING_INIT_STAKE,
                 shards: vec![0],
@@ -2243,7 +2246,7 @@ mod test {
         assert_eq!(
             response.prev_epoch_kickout,
             vec![ValidatorKickoutView {
-                account_id: "test1".parse().unwrap(),
+                account_id: "test1".parse::<AccountId>().unwrap(),
                 reason: ValidatorKickoutReason::Unstaked
             }]
         );
@@ -2252,14 +2255,20 @@ mod test {
 
     #[test]
     fn test_challenges() {
-        let mut env =
-            TestEnv::new(vec![vec!["test1".parse().unwrap(), "test2".parse().unwrap()]], 2, true);
+        let mut env = TestEnv::new(
+            vec![vec![
+                "test1".parse::<AccountId>().unwrap(),
+                "test2".parse::<AccountId>().unwrap(),
+            ]],
+            2,
+            true,
+        );
         env.step(
             vec![vec![]],
             vec![true],
-            vec![SlashedValidator::new("test2".parse().unwrap(), false)],
+            vec![SlashedValidator::new("test2".parse::<AccountId>().unwrap(), false)],
         );
-        assert_eq!(env.view_account(&"test2".parse().unwrap()).locked, 0);
+        assert_eq!(env.view_account(&"test2".parse::<AccountId>().unwrap()).locked, 0);
         let mut bps = env
             .epoch_manager
             .get_epoch_block_producers_ordered(&env.head.epoch_id, &env.head.last_block_hash)
@@ -2268,16 +2277,26 @@ mod test {
             .map(|x| (x.0.account_id().clone(), x.1))
             .collect::<Vec<_>>();
         bps.sort_unstable();
-        assert_eq!(bps, vec![("test1".parse().unwrap(), false), ("test2".parse().unwrap(), true)]);
+        assert_eq!(
+            bps,
+            vec![
+                ("test1".parse::<AccountId>().unwrap(), false),
+                ("test2".parse::<AccountId>().unwrap(), true)
+            ]
+        );
         let msg = vec![0, 1, 2];
-        let signer = InMemorySigner::from_seed("test2".parse().unwrap(), KeyType::ED25519, "test2");
+        let signer = InMemorySigner::from_seed(
+            "test2".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test2",
+        );
         let signature = signer.sign(&msg);
         assert!(!env
             .epoch_manager
             .verify_validator_signature(
                 &env.head.epoch_id,
                 &env.head.last_block_hash,
-                &"test2".parse().unwrap(),
+                &"test2".parse::<AccountId>().unwrap(),
                 &msg,
                 &signature,
             )
@@ -2310,9 +2329,12 @@ mod test {
         env.step(
             vec![vec![staking_transaction]],
             vec![true],
-            vec![SlashedValidator::new("test2".parse().unwrap(), true)],
+            vec![SlashedValidator::new("test2".parse::<AccountId>().unwrap(), true)],
         );
-        assert_eq!(env.view_account(&"test2".parse().unwrap()).locked, TESTING_INIT_STAKE);
+        assert_eq!(
+            env.view_account(&"test2".parse::<AccountId>().unwrap()).locked,
+            TESTING_INIT_STAKE
+        );
         let mut bps = env
             .epoch_manager
             .get_epoch_block_producers_ordered(&env.head.epoch_id, &env.head.last_block_hash)
@@ -2324,20 +2346,24 @@ mod test {
         assert_eq!(
             bps,
             vec![
-                ("test1".parse().unwrap(), false),
-                ("test2".parse().unwrap(), true),
-                ("test3".parse().unwrap(), false)
+                ("test1".parse::<AccountId>().unwrap(), false),
+                ("test2".parse::<AccountId>().unwrap(), true),
+                ("test3".parse::<AccountId>().unwrap(), false)
             ]
         );
         let msg = vec![0, 1, 2];
-        let signer = InMemorySigner::from_seed("test2".parse().unwrap(), KeyType::ED25519, "test2");
+        let signer = InMemorySigner::from_seed(
+            "test2".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test2",
+        );
         let signature = signer.sign(&msg);
         assert!(!env
             .epoch_manager
             .verify_validator_signature(
                 &env.head.epoch_id,
                 &env.head.last_block_hash,
-                &"test2".parse().unwrap(),
+                &"test2".parse::<AccountId>().unwrap(),
                 &msg,
                 &signature,
             )
@@ -2349,16 +2375,16 @@ mod test {
         env.step(
             vec![vec![]],
             vec![true],
-            vec![SlashedValidator::new("test3".parse().unwrap(), true)],
+            vec![SlashedValidator::new("test3".parse::<AccountId>().unwrap(), true)],
         );
-        let account = env.view_account(&"test3".parse().unwrap());
+        let account = env.view_account(&"test3".parse::<AccountId>().unwrap());
         assert_eq!(account.locked, TESTING_INIT_STAKE / 3);
         assert_eq!(account.amount, TESTING_INIT_BALANCE - TESTING_INIT_STAKE / 3);
 
         for _ in 11..14 {
             env.step_default(vec![]);
         }
-        let account = env.view_account(&"test3".parse().unwrap());
+        let account = env.view_account(&"test3".parse::<AccountId>().unwrap());
         let slashed = (TESTING_INIT_STAKE / 3) * 3 / 4;
         let remaining = TESTING_INIT_STAKE / 3 - slashed;
         assert_eq!(account.locked, remaining);
@@ -2368,11 +2394,11 @@ mod test {
             env.step_default(vec![]);
         }
 
-        let account = env.view_account(&"test2".parse().unwrap());
+        let account = env.view_account(&"test2".parse::<AccountId>().unwrap());
         assert_eq!(account.locked, 0);
         assert_eq!(account.amount, TESTING_INIT_BALANCE - TESTING_INIT_STAKE);
 
-        let account = env.view_account(&"test3".parse().unwrap());
+        let account = env.view_account(&"test3".parse::<AccountId>().unwrap());
         assert_eq!(account.locked, 0);
         assert_eq!(account.amount, TESTING_INIT_BALANCE - TESTING_INIT_STAKE / 3 + remaining);
     }
@@ -2393,12 +2419,12 @@ mod test {
         env.step(
             vec![vec![]],
             vec![true],
-            vec![SlashedValidator::new("test1".parse().unwrap(), true)],
+            vec![SlashedValidator::new("test1".parse::<AccountId>().unwrap(), true)],
         );
         env.step(
             vec![vec![]],
             vec![true],
-            vec![SlashedValidator::new("test2".parse().unwrap(), true)],
+            vec![SlashedValidator::new("test2".parse::<AccountId>().unwrap(), true)],
         );
         let msg = vec![0, 1, 2];
         for i in 0..=1 {
@@ -2418,11 +2444,11 @@ mod test {
         for _ in 3..17 {
             env.step_default(vec![]);
         }
-        let account = env.view_account(&"test1".parse().unwrap());
+        let account = env.view_account(&"test1".parse::<AccountId>().unwrap());
         assert_eq!(account.locked, 0);
         assert_eq!(account.amount, TESTING_INIT_BALANCE - TESTING_INIT_STAKE);
 
-        let account = env.view_account(&"test2".parse().unwrap());
+        let account = env.view_account(&"test2".parse::<AccountId>().unwrap());
         assert_eq!(account.locked, 0);
         assert_eq!(account.amount, TESTING_INIT_BALANCE - TESTING_INIT_STAKE);
     }
@@ -2441,27 +2467,27 @@ mod test {
             vec![vec![]],
             vec![true],
             vec![
-                SlashedValidator::new("test1".parse().unwrap(), true),
-                SlashedValidator::new("test2".parse().unwrap(), false),
+                SlashedValidator::new("test1".parse::<AccountId>().unwrap(), true),
+                SlashedValidator::new("test2".parse::<AccountId>().unwrap(), false),
             ],
         );
         env.step(
             vec![vec![]],
             vec![true],
             vec![
-                SlashedValidator::new("test1".parse().unwrap(), false),
-                SlashedValidator::new("test2".parse().unwrap(), true),
+                SlashedValidator::new("test1".parse::<AccountId>().unwrap(), false),
+                SlashedValidator::new("test2".parse::<AccountId>().unwrap(), true),
             ],
         );
 
         for _ in 3..11 {
             env.step_default(vec![]);
         }
-        let account = env.view_account(&"test1".parse().unwrap());
+        let account = env.view_account(&"test1".parse::<AccountId>().unwrap());
         assert_eq!(account.locked, 0);
         assert_eq!(account.amount, TESTING_INIT_BALANCE - TESTING_INIT_STAKE);
 
-        let account = env.view_account(&"test2".parse().unwrap());
+        let account = env.view_account(&"test2".parse::<AccountId>().unwrap());
         assert_eq!(account.locked, 0);
         assert_eq!(account.amount, TESTING_INIT_BALANCE - TESTING_INIT_STAKE);
     }
@@ -2515,7 +2541,7 @@ mod test {
                 .into_iter()
                 .map(|fishermen| fishermen.take_account_id())
                 .collect::<Vec<_>>(),
-            vec!["test1".parse().unwrap(), "test2".parse().unwrap()]
+            vec!["test1".parse::<AccountId>().unwrap(), "test2".parse::<AccountId>().unwrap()]
         );
         let staking_transaction = stake(2, &signers[0], &block_producers[0], TESTING_INIT_STAKE);
         let staking_transaction2 = stake(2, &signers[1], &block_producers[1], 0);
@@ -2582,7 +2608,7 @@ mod test {
                 .into_iter()
                 .map(|fishermen| fishermen.take_account_id())
                 .collect::<Vec<_>>(),
-            vec!["test1".parse().unwrap()]
+            vec!["test1".parse::<AccountId>().unwrap()]
         );
         let staking_transaction = stake(2, &signers[0], &block_producers[0], 0);
         env.step_default(vec![staking_transaction]);
@@ -2731,7 +2757,7 @@ mod test {
     /// state optimization to view calls.
     #[test]
     fn test_flat_state_usage() {
-        let env = TestEnv::new(vec![vec!["test1".parse().unwrap()]], 4, false);
+        let env = TestEnv::new(vec![vec!["test1".parse::<AccountId>().unwrap()]], 4, false);
         let trie = env
             .runtime
             .get_trie_for_shard(0, &env.head.prev_block_hash, Trie::EMPTY_ROOT, true)

--- a/nearcore/tests/economics.rs
+++ b/nearcore/tests/economics.rs
@@ -15,11 +15,14 @@ use near_store::{genesis::initialize_genesis_state, test_utils::create_test_stor
 use nearcore::{config::GenesisExt, NightshadeRuntime};
 use testlib::fees_utils::FeeHelper;
 
-use near_primitives::types::EpochId;
+use near_primitives::types::{AccountId, EpochId};
 use primitive_types::U256;
 
 fn build_genesis() -> Genesis {
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(
+        vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+        1,
+    );
     genesis.config.epoch_length = 2;
     genesis.config.num_blocks_per_year = 2;
     genesis.config.protocol_reward_rate = Ratio::new_raw(1, 10);
@@ -70,15 +73,16 @@ fn test_burn_mint() {
         .unwrap()
         .runtime_config;
     let fee_helper = FeeHelper::new(config, genesis.config.min_gas_price);
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer =
+        InMemorySigner::from_seed("test0".parse::<AccountId>().unwrap(), KeyType::ED25519, "test0");
     let initial_total_supply = env.chain_genesis.total_supply;
     let genesis_hash = *env.clients[0].chain.genesis().hash();
     assert_eq!(
         env.clients[0].process_tx(
             SignedTransaction::send_money(
                 1,
-                "test0".parse().unwrap(),
-                "test1".parse().unwrap(),
+                "test0".parse::<AccountId>().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
                 &signer,
                 1000,
                 genesis_hash,
@@ -88,7 +92,7 @@ fn test_burn_mint() {
         ),
         ProcessTxResponse::ValidTx
     );
-    let near_balance = env.query_balance("near".parse().unwrap());
+    let near_balance = env.query_balance("near".parse::<AccountId>().unwrap());
     assert_eq!(calc_total_supply(&mut env), initial_total_supply);
     for i in 1..6 {
         env.produce_block(0, i);
@@ -123,7 +127,10 @@ fn test_burn_mint() {
     assert_eq!(block4.header().total_supply(), block3.header().total_supply() - half_transfer_cost);
     assert_eq!(block4.chunks()[0].prev_balance_burnt(), half_transfer_cost);
     // Check that Protocol Treasury account got it's 1% as well.
-    assert_eq!(env.query_balance("near".parse().unwrap()), near_balance + epoch_total_reward / 10);
+    assert_eq!(
+        env.query_balance("near".parse::<AccountId>().unwrap()),
+        near_balance + epoch_total_reward / 10
+    );
     // Block 5: reward from previous block.
     let block5 = env.clients[0].chain.get_block_by_height(5).unwrap();
     let prev_total_supply = block4.header().total_supply();

--- a/runtime/near-vm-runner/fuzz/src/lib.rs
+++ b/runtime/near-vm-runner/fuzz/src/lib.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use near_primitives::types::AccountId;
 use near_vm_runner::internal::wasmparser::{Export, ExternalKind, Parser, Payload, TypeDef};
 use near_vm_runner::logic::VMContext;
 use near_vm_runner::ContractCode;
@@ -32,10 +33,10 @@ pub fn find_entry_point(contract: &ContractCode) -> Option<String> {
 
 pub fn create_context(input: Vec<u8>) -> VMContext {
     VMContext {
-        current_account_id: "alice".parse().unwrap(),
-        signer_account_id: "bob".parse().unwrap(),
+        current_account_id: "alice".parse::<AccountId>().unwrap(),
+        signer_account_id: "bob".parse::<AccountId>().unwrap(),
         signer_account_pk: vec![0, 1, 2, 3, 4],
-        predecessor_account_id: "carol".parse().unwrap(),
+        predecessor_account_id: "carol".parse::<AccountId>().unwrap(),
         input,
         block_height: 10,
         block_timestamp: 42,

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -9,7 +9,6 @@ use super::{StorageGetMode, ValuePtr};
 use crate::config::Config;
 use crate::ProfileDataV3;
 use near_crypto::Secp256K1Signature;
-use near_primitives_core::account::id::AccountIdRef;
 use near_primitives_core::config::ExtCosts::*;
 use near_primitives_core::config::ViewConfig;
 use near_primitives_core::config::{ActionCosts, ExtCosts};

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -9,6 +9,7 @@ use super::{StorageGetMode, ValuePtr};
 use crate::config::Config;
 use crate::ProfileDataV3;
 use near_crypto::Secp256K1Signature;
+use near_primitives_core::account::id::AccountIdRef;
 use near_primitives_core::config::ExtCosts::*;
 use near_primitives_core::config::ViewConfig;
 use near_primitives_core::config::{ActionCosts, ExtCosts};
@@ -476,12 +477,12 @@ impl<'a> VMLogic<'a> {
     /// `base + write_register_base + write_register_byte * num_bytes`
     pub fn current_account_id(&mut self, register_id: u64) -> Result<()> {
         self.gas_counter.pay_base(base)?;
-
+        let account_id_ref: &AccountIdRef = self.context.current_account_id.as_ref();
         self.registers.set(
             &mut self.gas_counter,
             &self.config.limit_config,
             register_id,
-            self.context.current_account_id.as_ref().as_bytes(),
+            account_id_ref.as_bytes(),
         )
     }
 
@@ -507,11 +508,12 @@ impl<'a> VMLogic<'a> {
             }
             .into());
         }
+        let account_id_ref: &AccountIdRef = self.context.current_account_id.as_ref();
         self.registers.set(
             &mut self.gas_counter,
             &self.config.limit_config,
             register_id,
-            self.context.signer_account_id.as_ref().as_bytes(),
+            account_id_ref.as_bytes(),
         )
     }
 
@@ -565,11 +567,12 @@ impl<'a> VMLogic<'a> {
             }
             .into());
         }
+        let account_id_ref: &AccountIdRef = self.context.predecessor_account_id.as_ref();
         self.registers.set(
             &mut self.gas_counter,
             &self.config.limit_config,
             register_id,
-            self.context.predecessor_account_id.as_ref().as_bytes(),
+            account_id_ref.as_bytes(),
         )
     }
 

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -477,12 +477,11 @@ impl<'a> VMLogic<'a> {
     /// `base + write_register_base + write_register_byte * num_bytes`
     pub fn current_account_id(&mut self, register_id: u64) -> Result<()> {
         self.gas_counter.pay_base(base)?;
-        let account_id_ref: &AccountIdRef = self.context.current_account_id.as_ref();
         self.registers.set(
             &mut self.gas_counter,
             &self.config.limit_config,
             register_id,
-            account_id_ref.as_bytes(),
+            self.context.current_account_id.as_bytes(),
         )
     }
 
@@ -508,12 +507,11 @@ impl<'a> VMLogic<'a> {
             }
             .into());
         }
-        let account_id_ref: &AccountIdRef = self.context.current_account_id.as_ref();
         self.registers.set(
             &mut self.gas_counter,
             &self.config.limit_config,
             register_id,
-            account_id_ref.as_bytes(),
+            self.context.current_account_id.as_bytes(),
         )
     }
 
@@ -567,12 +565,11 @@ impl<'a> VMLogic<'a> {
             }
             .into());
         }
-        let account_id_ref: &AccountIdRef = self.context.predecessor_account_id.as_ref();
         self.registers.set(
             &mut self.gas_counter,
             &self.config.limit_config,
             register_id,
-            account_id_ref.as_bytes(),
+            self.context.predecessor_account_id.as_bytes(),
         )
     }
 

--- a/runtime/near-vm-runner/src/logic/tests/context.rs
+++ b/runtime/near-vm-runner/src/logic/tests/context.rs
@@ -50,19 +50,14 @@ decl_test_bytes!(
     test_current_account_id,
     current_account_id,
     ctx,
-    ctx.current_account_id.as_ref().as_bytes()
+    ctx.current_account_id.as_bytes()
 );
-decl_test_bytes!(
-    test_signer_account_id,
-    signer_account_id,
-    ctx,
-    ctx.signer_account_id.as_ref().as_bytes()
-);
+decl_test_bytes!(test_signer_account_id, signer_account_id, ctx, ctx.signer_account_id.as_bytes());
 decl_test_bytes!(
     test_predecessor_account_id,
     predecessor_account_id,
     ctx,
-    ctx.predecessor_account_id.as_ref().as_bytes()
+    ctx.predecessor_account_id.as_bytes()
 );
 decl_test_bytes!(test_signer_account_pk, signer_account_pk, ctx, ctx.signer_account_pk);
 

--- a/runtime/near-vm-runner/src/logic/tests/gas_counter.rs
+++ b/runtime/near-vm-runner/src/logic/tests/gas_counter.rs
@@ -7,6 +7,7 @@ use crate::logic::{HostError, VMLogicError};
 use expect_test::expect;
 use near_primitives_core::config::{ActionCosts, ExtCosts};
 use near_primitives_core::runtime::fees::Fee;
+use near_primitives_core::types::AccountId;
 
 #[test]
 fn test_dont_burn_gas_when_exceeding_attached_gas_limit() {
@@ -247,7 +248,7 @@ fn check_action_gas_exceeds_limit(
     logic_builder.config.limit_config.max_gas_burnt = gas_limit;
     logic_builder.fees_config.action_fees[cost] = fee;
     logic_builder.context.prepaid_gas = gas_attached;
-    logic_builder.context.output_data_receivers = vec!["alice.test".parse().unwrap()];
+    logic_builder.context.output_data_receivers = vec!["alice.test".parse::<AccountId>().unwrap()];
     let mut logic = logic_builder.build();
 
     let result = exercise_action(&mut logic);
@@ -299,7 +300,7 @@ fn check_action_gas_exceeds_attached(
     logic_builder.config.limit_config.max_gas_burnt = gas_limit;
     logic_builder.fees_config.action_fees[cost] = fee;
     logic_builder.context.prepaid_gas = gas_attached;
-    logic_builder.context.output_data_receivers = vec!["alice.test".parse().unwrap()];
+    logic_builder.context.output_data_receivers = vec!["alice.test".parse::<AccountId>().unwrap()];
     let mut logic = logic_builder.build();
 
     let result = exercise_action(&mut logic);

--- a/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
+++ b/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
@@ -3,6 +3,7 @@ use crate::logic::mocks::mock_memory::MockedMemory;
 use crate::logic::types::PromiseResult;
 use crate::logic::{Config, MemSlice, VMContext, VMLogic};
 use near_primitives_core::runtime::fees::RuntimeFeesConfig;
+use near_primitives_core::types::AccountId;
 
 pub(super) struct VMLogicBuilder {
     pub ext: MockedExternal,
@@ -65,10 +66,10 @@ impl VMLogicBuilder {
 
 fn get_context() -> VMContext {
     VMContext {
-        current_account_id: "alice.near".parse().unwrap(),
-        signer_account_id: "bob.near".parse().unwrap(),
+        current_account_id: "alice.near".parse::<AccountId>().unwrap(),
+        signer_account_id: "bob.near".parse::<AccountId>().unwrap(),
         signer_account_pk: vec![0, 1, 2, 3, 4],
-        predecessor_account_id: "carol.near".parse().unwrap(),
+        predecessor_account_id: "carol.near".parse::<AccountId>().unwrap(),
         input: vec![0, 1, 2, 3, 4],
         block_height: 10,
         block_timestamp: 42,

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -138,7 +138,7 @@ fn test_wasmer2_artifact_output_stability() {
 
         let mut features = CpuFeature::set();
         features.insert(CpuFeature::AVX);
-        let triple = "x86_64-unknown-linux-gnu".parse().unwrap();
+        let triple = "x86_64-unknown-linux-gnu".parse::<AccountId>().unwrap();
         let target = Target::new(triple, features);
         let vm = Wasmer2VM::new_for_target(config, target);
         let artifact = vm.compile_uncached(&contract).unwrap();
@@ -209,7 +209,7 @@ fn test_near_vm_artifact_output_stability() {
 
         let mut features = CpuFeature::set();
         features.insert(CpuFeature::AVX);
-        let triple = "x86_64-unknown-linux-gnu".parse().unwrap();
+        let triple = "x86_64-unknown-linux-gnu".parse::<AccountId>().unwrap();
         let target = Target::new(triple, features);
         let vm = NearVM::new_for_target(config, target);
         let artifact = vm.compile_uncached(&contract).unwrap();

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -138,7 +138,7 @@ fn test_wasmer2_artifact_output_stability() {
 
         let mut features = CpuFeature::set();
         features.insert(CpuFeature::AVX);
-        let triple = "x86_64-unknown-linux-gnu".parse::<AccountId>().unwrap();
+        let triple = "x86_64-unknown-linux-gnu".parse().unwrap();
         let target = Target::new(triple, features);
         let vm = Wasmer2VM::new_for_target(config, target);
         let artifact = vm.compile_uncached(&contract).unwrap();
@@ -209,7 +209,7 @@ fn test_near_vm_artifact_output_stability() {
 
         let mut features = CpuFeature::set();
         features.insert(CpuFeature::AVX);
-        let triple = "x86_64-unknown-linux-gnu".parse::<AccountId>().unwrap();
+        let triple = "x86_64-unknown-linux-gnu".parse().unwrap();
         let target = Target::new(triple, features);
         let vm = NearVM::new_for_target(config, target);
         let artifact = vm.compile_uncached(&contract).unwrap();

--- a/runtime/near-vm-runner/src/tests/fuzzers.rs
+++ b/runtime/near-vm-runner/src/tests/fuzzers.rs
@@ -8,6 +8,7 @@ use crate::VMKind;
 use arbitrary::Arbitrary;
 use bolero::check;
 use core::fmt;
+use near_primitives::types::AccountId;
 use near_primitives_core::runtime::fees::RuntimeFeesConfig;
 
 /// Finds a no-parameter exported function, something like `(func (export "entry-point"))`.
@@ -39,10 +40,10 @@ pub fn find_entry_point(contract: &ContractCode) -> Option<String> {
 
 pub fn create_context(input: Vec<u8>) -> VMContext {
     VMContext {
-        current_account_id: "alice".parse().unwrap(),
-        signer_account_id: "bob".parse().unwrap(),
+        current_account_id: "alice".parse::<AccountId>().unwrap(),
+        signer_account_id: "bob".parse::<AccountId>().unwrap(),
         signer_account_pk: vec![0, 1, 2, 3, 4],
-        predecessor_account_id: "carol".parse().unwrap(),
+        predecessor_account_id: "carol".parse::<AccountId>().unwrap(),
         input,
         block_height: 10,
         block_timestamp: 42,

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -1,6 +1,7 @@
 use near_primitives::runtime::{
     config::RuntimeConfig, config_store::RuntimeConfigStore, fees::RuntimeFeesConfig,
 };
+use near_primitives_core::types::AccountId;
 use near_primitives_core::types::Gas;
 use near_primitives_core::version::ProtocolFeature;
 use near_vm_runner::logic::{
@@ -12,10 +13,10 @@ use std::{collections::HashSet, fmt::Write, sync::Arc};
 
 pub(crate) fn test_builder() -> TestBuilder {
     let context = VMContext {
-        current_account_id: "alice".parse().unwrap(),
-        signer_account_id: "bob".parse().unwrap(),
+        current_account_id: "alice".parse::<AccountId>().unwrap(),
+        signer_account_id: "bob".parse::<AccountId>().unwrap(),
         signer_account_pk: vec![0, 1, 2],
-        predecessor_account_id: "carol".parse().unwrap(),
+        predecessor_account_id: "carol".parse::<AccountId>().unwrap(),
         input: Vec::new(),
         block_height: 10,
         block_timestamp: 42,

--- a/runtime/runtime-params-estimator/src/action_costs.rs
+++ b/runtime/runtime-params-estimator/src/action_costs.rs
@@ -694,7 +694,7 @@ fn stake_action() -> Action {
 
 fn delete_account_action() -> Action {
     Action::DeleteAccount(near_primitives::transaction::DeleteAccountAction {
-        beneficiary_id: "bob.near".parse().unwrap(),
+        beneficiary_id: "bob.near".parse::<AccountId>().unwrap(),
     })
 }
 

--- a/runtime/runtime-params-estimator/src/action_costs.rs
+++ b/runtime/runtime-params-estimator/src/action_costs.rs
@@ -254,7 +254,7 @@ impl ActionEstimation {
         let signer_id = tb.account_by_requirement(self.signer, None);
         let predecessor_id = tb.account_by_requirement(self.predecessor, Some(&signer_id));
         let receiver_id = tb.account_by_requirement(self.receiver, Some(&signer_id));
-        let signer_public_key = PublicKey::from_seed(KeyType::ED25519, &signer_id);
+        let signer_public_key = PublicKey::from_seed(KeyType::ED25519, signer_id.as_str());
 
         let action_receipt = ActionReceipt {
             signer_id,
@@ -761,7 +761,7 @@ pub(crate) fn empty_delegate_action(
     use near_primitives::signable_message::{SignableMessage, SignableMessageType};
     use near_primitives::test_utils::create_user_test_signer;
 
-    let signer = create_user_test_signer(&sender_id);
+    let signer = create_user_test_signer(sender_id.as_str());
     let delegate_action = DelegateAction {
         sender_id,
         receiver_id,

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time;
 use tracing_subscriber::Layer;
+use near_primitives::types::AccountId;
 
 mod replay;
 
@@ -165,7 +166,7 @@ fn run_estimation(cli_args: CliArgs) -> anyhow::Result<Option<CostTable>> {
         nearcore::init_configs(
             &state_dump_path,
             None,
-            Some("test.near".parse().unwrap()),
+            Some("test.near".parse::<AccountId>().unwrap()),
             Some("alice.near"),
             1,
             true,

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -3,6 +3,7 @@
 use anyhow::Context;
 use genesis_populate::GenesisBuilder;
 use near_chain_configs::GenesisValidationMode;
+use near_primitives::types::AccountId;
 use near_primitives::views::RuntimeConfigView;
 use near_vm_runner::VMKind;
 use replay::ReplayCmd;
@@ -18,7 +19,6 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time;
 use tracing_subscriber::Layer;
-use near_primitives::types::AccountId;
 
 mod replay;
 

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -26,6 +26,7 @@ use near_primitives::utils::create_random_seed;
 use near_primitives::version::{
     ProtocolFeature, ProtocolVersion, DELETE_KEY_STORAGE_USAGE_PROTOCOL_VERSION,
 };
+use near_primitives_core::account::id::AccountIdRef;
 use near_primitives_core::config::ActionCosts;
 use near_store::{
     get_access_key, get_code, remove_access_key, remove_account, set_access_key, set_code,
@@ -784,7 +785,8 @@ fn validate_delegate_action_key(
                 )
                 .into());
             }
-            if delegate_action.receiver_id.as_ref() != function_call_permission.receiver_id {
+            let account_id_ref: &AccountIdRef = delegate_action.receiver_id.as_ref();
+            if account_id_ref != function_call_permission.receiver_id {
                 result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
                     InvalidAccessKeyError::ReceiverMismatch {
                         tx_receiver: delegate_action.receiver_id.clone(),

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -785,8 +785,7 @@ fn validate_delegate_action_key(
                 )
                 .into());
             }
-            let account_id_ref: &AccountIdRef = delegate_action.receiver_id.as_ref();
-            if account_id_ref != function_call_permission.receiver_id {
+            if delegate_action.receiver_id != function_call_permission.receiver_id {
                 result.result = Err(ActionErrorKind::DelegateActionAccessKeyError(
                     InvalidAccessKeyError::ReceiverMismatch {
                         tx_receiver: delegate_action.receiver_id.clone(),

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -26,7 +26,6 @@ use near_primitives::utils::create_random_seed;
 use near_primitives::version::{
     ProtocolFeature, ProtocolVersion, DELETE_KEY_STORAGE_USAGE_PROTOCOL_VERSION,
 };
-use near_primitives_core::account::id::AccountIdRef;
 use near_primitives_core::config::ActionCosts;
 use near_store::{
     get_access_key, get_code, remove_access_key, remove_account, set_access_key, set_code,

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -995,24 +995,24 @@ mod tests {
 
     #[test]
     fn test_create_account_valid_top_level_long() {
-        let account_id = "bob_near_long_name".parse().unwrap();
-        let predecessor_id = "alice.near".parse().unwrap();
+        let account_id = "bob_near_long_name".parse::<AccountId>().unwrap();
+        let predecessor_id = "alice.near".parse::<AccountId>().unwrap();
         let action_result = test_action_create_account(account_id, predecessor_id, 11);
         assert!(action_result.result.is_ok());
     }
 
     #[test]
     fn test_create_account_valid_top_level_by_registrar() {
-        let account_id = "bob".parse().unwrap();
-        let predecessor_id = "registrar".parse().unwrap();
+        let account_id = "bob".parse::<AccountId>().unwrap();
+        let predecessor_id = "registrar".parse::<AccountId>().unwrap();
         let action_result = test_action_create_account(account_id, predecessor_id, 11);
         assert!(action_result.result.is_ok());
     }
 
     #[test]
     fn test_create_account_valid_sub_account() {
-        let account_id = "alice.near".parse().unwrap();
-        let predecessor_id = "near".parse().unwrap();
+        let account_id = "alice.near".parse::<AccountId>().unwrap();
+        let predecessor_id = "near".parse::<AccountId>().unwrap();
         let action_result = test_action_create_account(account_id, predecessor_id, 11);
         assert!(action_result.result.is_ok());
     }
@@ -1047,7 +1047,7 @@ mod tests {
                 index: None,
                 kind: ActionErrorKind::CreateAccountOnlyByRegistrar {
                     account_id: account_id,
-                    registrar_account_id: "registrar".parse().unwrap(),
+                    registrar_account_id: "registrar".parse::<AccountId>().unwrap(),
                     predecessor_id: predecessor_id,
                 },
             })
@@ -1056,8 +1056,8 @@ mod tests {
 
     #[test]
     fn test_create_account_valid_short_top_level_len_allowed() {
-        let account_id = "bob".parse().unwrap();
-        let predecessor_id = "near".parse().unwrap();
+        let account_id = "bob".parse::<AccountId>().unwrap();
+        let predecessor_id = "near".parse::<AccountId>().unwrap();
         let action_result = test_action_create_account(account_id, predecessor_id, 0);
         assert!(action_result.result.is_ok());
     }
@@ -1071,7 +1071,7 @@ mod tests {
         let mut account = Some(Account::new(100, 0, *code_hash, storage_usage));
         let mut actor_id = account_id.clone();
         let mut action_result = ActionResult::default();
-        let receipt = Receipt::new_balance_refund(&"alice.near".parse().unwrap(), 0);
+        let receipt = Receipt::new_balance_refund(&"alice.near".parse::<AccountId>().unwrap(), 0);
         let res = action_delete_account(
             state_update,
             &mut account,
@@ -1079,7 +1079,7 @@ mod tests {
             &receipt,
             &mut action_result,
             account_id,
-            &DeleteAccountAction { beneficiary_id: "bob".parse().unwrap() },
+            &DeleteAccountAction { beneficiary_id: "bob".parse::<AccountId>().unwrap() },
             ProtocolFeature::DeleteActionRestriction.protocol_version(),
         );
         assert!(res.is_ok());
@@ -1092,7 +1092,7 @@ mod tests {
         let mut state_update =
             tries.new_trie_update(ShardUId::single_shard(), CryptoHash::default());
         let action_result = test_delete_large_account(
-            &"alice".parse().unwrap(),
+            &"alice".parse::<AccountId>().unwrap(),
             &CryptoHash::default(),
             Account::MAX_ACCOUNT_DELETION_STORAGE_USAGE + 1,
             &mut state_update,
@@ -1102,7 +1102,7 @@ mod tests {
             Err(ActionError {
                 index: None,
                 kind: ActionErrorKind::DeleteAccountWithLargeState {
-                    account_id: "alice".parse().unwrap()
+                    account_id: "alice".parse::<AccountId>().unwrap()
                 }
             })
         )
@@ -1136,7 +1136,7 @@ mod tests {
             Err(ActionError {
                 index: None,
                 kind: ActionErrorKind::DeleteAccountWithLargeState {
-                    account_id: "alice".parse().unwrap()
+                    account_id: "alice".parse::<AccountId>().unwrap()
                 }
             })
         );
@@ -1145,8 +1145,8 @@ mod tests {
     fn create_delegate_action_receipt() -> (ActionReceipt, SignedDelegateAction) {
         let signed_delegate_action = SignedDelegateAction {
             delegate_action: DelegateAction {
-                sender_id: "bob.test.near".parse().unwrap(),
-                receiver_id: "token.test.near".parse().unwrap(),
+                sender_id: "bob.test.near".parse::<AccountId>().unwrap(),
+                receiver_id: "token.test.near".parse::<AccountId>().unwrap(),
                 actions: vec![
                     non_delegate_action(
                         Action::FunctionCall(
@@ -1167,7 +1167,7 @@ mod tests {
         };
 
         let action_receipt = ActionReceipt {
-            signer_id: "alice.test.near".parse().unwrap(),
+            signer_id: "alice.test.near".parse::<AccountId>().unwrap(),
             signer_public_key: PublicKey::empty(near_crypto::KeyType::ED25519),
             gas_price: 1,
             output_data_receivers: Vec::new(),
@@ -1277,7 +1277,8 @@ mod tests {
         let mut state_update = setup_account(&sender_id, &sender_pub_key, &access_key);
 
         // Corrupt receiver_id. Signature verifycation must fail.
-        signed_delegate_action.delegate_action.receiver_id = "www.test.near".parse().unwrap();
+        signed_delegate_action.delegate_action.receiver_id =
+            "www.test.near".parse::<AccountId>().unwrap();
 
         apply_delegate_action(
             &mut state_update,
@@ -1335,7 +1336,7 @@ mod tests {
             &mut state_update,
             &apply_state,
             &action_receipt,
-            &"www.test.near".parse().unwrap(),
+            &"www.test.near".parse::<AccountId>().unwrap(),
             &signed_delegate_action,
             &mut result,
         )
@@ -1345,7 +1346,7 @@ mod tests {
             result.result,
             Err(ActionErrorKind::DelegateActionSenderDoesNotMatchTxReceiver {
                 sender_id: sender_id.clone(),
-                receiver_id: "www.test.near".parse().unwrap(),
+                receiver_id: "www.test.near".parse::<AccountId>().unwrap(),
             }
             .into())
         );

--- a/runtime/runtime/src/balance_checker.rs
+++ b/runtime/runtime/src/balance_checker.rs
@@ -15,6 +15,7 @@ use near_primitives::types::{AccountId, Balance};
 use near_primitives_core::config::ActionCosts;
 use near_store::{get, get_account, get_postponed_receipt, TrieAccess, TrieUpdate};
 use std::collections::HashSet;
+use near_primitives_core::account::id::AccountIdRef;
 
 /// Returns delayed receipts with given range of indices.
 fn get_delayed_receipts(
@@ -41,7 +42,7 @@ fn receipt_cost(
     Ok(match &receipt.receipt {
         ReceiptEnum::Action(action_receipt) => {
             let mut total_cost = total_deposit(&action_receipt.actions)?;
-            if !AccountId::is_system(&receipt.predecessor_id) {
+            if !AccountIdRef::is_system(&receipt.predecessor_id) {
                 let mut total_gas = safe_add_gas(
                     config.fees.fee(ActionCosts::new_action_receipt).exec_fee(),
                     total_prepaid_exec_fees(config, &action_receipt.actions, &receipt.receiver_id)?,

--- a/runtime/runtime/src/balance_checker.rs
+++ b/runtime/runtime/src/balance_checker.rs
@@ -12,10 +12,10 @@ use near_primitives::runtime::config::RuntimeConfig;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{AccountId, Balance};
+use near_primitives_core::account::id::AccountIdRef;
 use near_primitives_core::config::ActionCosts;
 use near_store::{get, get_account, get_postponed_receipt, TrieAccess, TrieUpdate};
 use std::collections::HashSet;
-use near_primitives_core::account::id::AccountIdRef;
 
 /// Returns delayed receipts with given range of indices.
 fn get_delayed_receipts(

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -37,6 +37,7 @@ use near_primitives::utils::{
     create_action_hash, create_receipt_id_from_receipt, create_receipt_id_from_transaction,
 };
 use near_primitives::version::{ProtocolFeature, ProtocolVersion};
+use near_primitives_core::account::id::AccountIdRef;
 use near_primitives_core::config::ActionCosts;
 use near_store::{
     get, get_account, get_postponed_receipt, get_received_data, remove_postponed_receipt, set,
@@ -53,7 +54,6 @@ use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tracing::debug;
-use near_primitives_core::account::id::AccountIdRef;
 
 mod actions;
 pub mod adapter;

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -53,6 +53,7 @@ use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tracing::debug;
+use near_primitives_core::account::id::AccountIdRef;
 
 mod actions;
 pub mod adapter;
@@ -307,7 +308,7 @@ impl Runtime {
         result.compute_usage = exec_fees;
         let account_id = &receipt.receiver_id;
         let is_the_only_action = actions.len() == 1;
-        let is_refund = AccountId::is_system(&receipt.predecessor_id);
+        let is_refund = AccountIdRef::is_system(&receipt.predecessor_id);
         // Account validation
         if let Err(e) = check_account_existence(
             action,
@@ -575,7 +576,7 @@ impl Runtime {
             }
         }
 
-        let gas_deficit_amount = if AccountId::is_system(&receipt.predecessor_id) {
+        let gas_deficit_amount = if AccountIdRef::is_system(&receipt.predecessor_id) {
             // We will set gas_burnt for refund receipts to be 0 when we calculate tx_burnt_amount
             // Here we don't set result.gas_burnt to be zero if CountRefundReceiptsInGasLimit is
             // enabled because we want it to be counted in gas limit calculation later
@@ -626,7 +627,7 @@ impl Runtime {
 
         // If the receipt is a refund, then we consider it free without burnt gas.
         let gas_burnt: Gas =
-            if AccountId::is_system(&receipt.predecessor_id) { 0 } else { result.gas_burnt };
+            if AccountIdRef::is_system(&receipt.predecessor_id) { 0 } else { result.gas_burnt };
         // `gas_deficit_amount` is strictly less than `gas_price * gas_burnt`.
         let mut tx_burnt_amount =
             safe_gas_to_balance(apply_state.gas_price, gas_burnt)? - gas_deficit_amount;

--- a/runtime/runtime/src/receipt_manager.rs
+++ b/runtime/runtime/src/receipt_manager.rs
@@ -394,7 +394,7 @@ impl ReceiptManager {
 #[cfg(test)]
 mod tests {
     use near_primitives::transaction::Action;
-    use near_primitives_core::types::{Gas, GasWeight};
+    use near_primitives_core::types::{AccountId, Gas, GasWeight};
 
     #[track_caller]
     fn function_call_weight_verify(function_calls: &[(Gas, u64, Gas)], after_distribute: bool) {
@@ -404,7 +404,7 @@ mod tests {
         let mut receipt_manager = super::ReceiptManager::default();
         for &(static_gas, gas_weight, _) in function_calls {
             let index = receipt_manager
-                .create_receipt(vec![], vec![], "rick.test".parse().unwrap())
+                .create_receipt(vec![], vec![], "rick.test".parse::<AccountId>().unwrap())
                 .unwrap();
             gas_limit = gas_limit.saturating_sub(static_gas);
             receipt_manager

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -1656,7 +1656,7 @@ mod tests {
                 &limit_config,
                 &[
                     Action::DeleteAccount(DeleteAccountAction {
-                        beneficiary_id: "bob".parse().unwrap()
+                        beneficiary_id: "bob".parse::<AccountId>().unwrap()
                     }),
                     Action::CreateAccount(CreateAccountAction {}),
                 ],
@@ -1677,7 +1677,7 @@ mod tests {
                 &[
                     Action::CreateAccount(CreateAccountAction {}),
                     Action::DeleteAccount(DeleteAccountAction {
-                        beneficiary_id: "bob".parse().unwrap()
+                        beneficiary_id: "bob".parse::<AccountId>().unwrap()
                     }),
                 ],
                 PROTOCOL_VERSION,
@@ -1831,8 +1831,8 @@ mod tests {
     fn test_delegate_action_must_be_only_one() {
         let signed_delegate_action = SignedDelegateAction {
             delegate_action: DelegateAction {
-                sender_id: "bob.test.near".parse().unwrap(),
-                receiver_id: "token.test.near".parse().unwrap(),
+                sender_id: "bob.test.near".parse::<AccountId>().unwrap(),
+                receiver_id: "token.test.near".parse::<AccountId>().unwrap(),
                 actions: vec![NonDelegateAction::try_from(Action::CreateAccount(
                     CreateAccountAction {},
                 ))

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -19,6 +19,7 @@ use near_primitives::types::{AccountId, Balance};
 use near_primitives::types::{BlockHeight, StorageUsage};
 use near_primitives::version::ProtocolFeature;
 use near_primitives::version::ProtocolVersion;
+use near_primitives_core::account::id::AccountIdRef;
 use near_store::{
     get_access_key, get_account, set_access_key, set_account, StorageError, TrieUpdate,
 };
@@ -238,7 +239,8 @@ pub fn verify_and_charge_transaction(
                 )
                 .into());
             }
-            if transaction.receiver_id.as_ref() != function_call_permission.receiver_id {
+            let account_id_ref: &AccountIdRef = transaction.receiver_id.as_ref();
+            if  account_id_ref != function_call_permission.receiver_id {
                 return Err(InvalidTxError::InvalidAccessKeyError(
                     InvalidAccessKeyError::ReceiverMismatch {
                         tx_receiver: transaction.receiver_id.clone(),
@@ -517,7 +519,7 @@ fn validate_add_key_action(
 ///
 /// Checks that the `beneficiary_id` is a valid account ID.
 fn validate_delete_action(action: &DeleteAccountAction) -> Result<(), ActionsValidationError> {
-    if AccountId::validate(&action.beneficiary_id).is_err() {
+    if AccountId::validate(action.beneficiary_id.as_str()).is_err() {
         return Err(ActionsValidationError::InvalidAccountId {
             account_id: action.beneficiary_id.to_string(),
         });

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -19,7 +19,6 @@ use near_primitives::types::{AccountId, Balance};
 use near_primitives::types::{BlockHeight, StorageUsage};
 use near_primitives::version::ProtocolFeature;
 use near_primitives::version::ProtocolVersion;
-use near_primitives_core::account::id::AccountIdRef;
 use near_store::{
     get_access_key, get_account, set_access_key, set_account, StorageError, TrieUpdate,
 };

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -239,8 +239,7 @@ pub fn verify_and_charge_transaction(
                 )
                 .into());
             }
-            let account_id_ref: &AccountIdRef = transaction.receiver_id.as_ref();
-            if  account_id_ref != function_call_permission.receiver_id {
+            if transaction.receiver_id != function_call_permission.receiver_id {
                 return Err(InvalidTxError::InvalidAccessKeyError(
                     InvalidAccessKeyError::ReceiverMismatch {
                         tx_receiver: transaction.receiver_id.clone(),

--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -322,7 +322,7 @@ impl RuntimeGroup {
         self.executed_receipts
             .lock()
             .unwrap()
-            .get(executing_runtime)
+            .get(&executing_runtime.parse::<AccountId>().unwrap())
             .expect("Runtime not found")
             .iter()
             .find_map(|r| if &r.get_hash() == hash { Some(r.clone()) } else { None })
@@ -396,8 +396,8 @@ macro_rules! assert_receipts {
     $($action_name:ident, $action_pat:pat, $action_assert:block ),+
      => [ $($produced_receipt:ident),*] ) => {
         let r = $group.get_receipt($to, $receipt);
-        assert_eq!(r.predecessor_id.as_ref(), $from);
-        assert_eq!(r.receiver_id.as_ref(), $to);
+        assert_eq!(r.predecessor_id, $from);
+        assert_eq!(r.receiver_id, $to);
         match &r.receipt {
             $receipt_pat => {
                 $receipt_assert

--- a/runtime/runtime/tests/test_async_calls.rs
+++ b/runtime/runtime/tests/test_async_calls.rs
@@ -766,7 +766,7 @@ fn test_account_factory() {
                      ReceiptEnum::Action(ActionReceipt{actions, output_data_receivers, ..}), {
                         assert_eq!(output_data_receivers.len(), 1);
                         data_id = output_data_receivers[0].data_id;
-                        assert_eq!(output_data_receivers[0].receiver_id.as_ref(), "near_2");
+                        assert_eq!(output_data_receivers[0].receiver_id.as_str(), "near_2");
                      },
                      actions,
                      a0, Action::CreateAccount(CreateAccountAction{}), {},
@@ -778,7 +778,7 @@ fn test_account_factory() {
                         assert_eq!(add_key_action.access_key.nonce, 0);
                         assert_eq!(add_key_action.access_key.permission, AccessKeyPermission::FunctionCall(FunctionCallPermission {
                             allowance: Some(TESTING_INIT_BALANCE / 2),
-                            receiver_id: "near_1".parse().unwrap(),
+                            receiver_id: "near_1".to_string(),
                             method_names: vec!["call_promise".to_string(), "hello".to_string()],
                         }));
                      },
@@ -929,7 +929,7 @@ fn test_create_account_add_key_call_delete_key_delete_account() {
                         assert_eq!(delete_key_action.public_key, signer_new_account.public_key);
                      },
                      a6, Action::DeleteAccount(DeleteAccountAction{beneficiary_id}), {
-                        assert_eq!(beneficiary_id.as_ref(), "near_2");
+                        assert_eq!(beneficiary_id.as_str(), "near_2");
                      }
                      => [r2, r3, ref1] );
 
@@ -950,11 +950,19 @@ fn test_create_account_add_key_call_delete_key_delete_account() {
 
 #[test]
 fn test_transfer_64len_hex() {
-    let pk = InMemorySigner::from_seed("test_hex".parse().unwrap(), KeyType::ED25519, "test_hex");
+    let pk = InMemorySigner::from_seed(
+        "test_hex".parse::<AccountId>().unwrap(),
+        KeyType::ED25519,
+        "test_hex",
+    );
     let account_id = AccountId::try_from(hex::encode(pk.public_key.unwrap_as_ed25519().0)).unwrap();
 
     let group = RuntimeGroup::new_with_account_ids(
-        vec!["near_0".parse().unwrap(), "near_1".parse().unwrap(), account_id.clone()],
+        vec![
+            "near_0".parse::<AccountId>().unwrap(),
+            "near_1".parse::<AccountId>().unwrap(),
+            account_id.clone(),
+        ],
         2,
         near_test_contracts::rs_contract(),
     );
@@ -1000,7 +1008,7 @@ fn test_transfer_64len_hex() {
                         assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, ref0] );
-    assert_receipts!(group, "near_1" => r1 @ account_id.as_ref(),
+    assert_receipts!(group, "near_1" => r1 @ account_id.as_str(),
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
                      a0, Action::Transfer(TransferAction{deposit}), {
@@ -1013,11 +1021,19 @@ fn test_transfer_64len_hex() {
 
 #[test]
 fn test_create_transfer_64len_hex_fail() {
-    let pk = InMemorySigner::from_seed("test_hex".parse().unwrap(), KeyType::ED25519, "test_hex");
+    let pk = InMemorySigner::from_seed(
+        "test_hex".parse::<AccountId>().unwrap(),
+        KeyType::ED25519,
+        "test_hex",
+    );
     let account_id = AccountId::try_from(hex::encode(pk.public_key.unwrap_as_ed25519().0)).unwrap();
 
     let group = RuntimeGroup::new_with_account_ids(
-        vec!["near_0".parse().unwrap(), "near_1".parse().unwrap(), account_id.clone()],
+        vec![
+            "near_0".parse::<AccountId>().unwrap(),
+            "near_1".parse::<AccountId>().unwrap(),
+            account_id.clone(),
+        ],
         2,
         near_test_contracts::rs_contract(),
     );
@@ -1066,7 +1082,7 @@ fn test_create_transfer_64len_hex_fail() {
                         assert_eq!(function_call_action.deposit, 0);
                      }
                      => [r1, ref0] );
-    assert_receipts!(group, "near_1" => r1 @ account_id.as_ref(),
+    assert_receipts!(group, "near_1" => r1 @ account_id.as_str(),
                      ReceiptEnum::Action(ActionReceipt{actions, ..}), {},
                      actions,
                      a0, Action::CreateAccount(CreateAccountAction{}), {},

--- a/test-utils/runtime-tester/src/fuzzing.rs
+++ b/test-utils/runtime-tester/src/fuzzing.rs
@@ -245,7 +245,8 @@ impl TransactionConfig {
                 }
             };
 
-            let signer = scope.function_call_signer(u, &signer_account, receiver_account.id.as_str())?;
+            let signer =
+                scope.function_call_signer(u, &signer_account, receiver_account.id.as_str())?;
 
             let mut receiver_functions = vec![];
             if let Some(contract_id) = receiver_account.deployed_contract {

--- a/test-utils/runtime-tester/src/fuzzing.rs
+++ b/test-utils/runtime-tester/src/fuzzing.rs
@@ -245,7 +245,7 @@ impl TransactionConfig {
                 }
             };
 
-            let signer = scope.function_call_signer(u, &signer_account, &receiver_account.id)?;
+            let signer = scope.function_call_signer(u, &signer_account, receiver_account.id.as_str())?;
 
             let mut receiver_functions = vec![];
             if let Some(contract_id) = receiver_account.deployed_contract {

--- a/test-utils/testlib/src/runtime_utils.rs
+++ b/test-utils/testlib/src/runtime_utils.rs
@@ -6,20 +6,20 @@ use near_primitives::state_record::StateRecord;
 use near_primitives::types::{AccountId, Balance};
 
 pub fn alice_account() -> AccountId {
-    "alice.near".parse().unwrap()
+    "alice.near".parse::<AccountId>().unwrap()
 }
 pub fn bob_account() -> AccountId {
-    "bob.near".parse().unwrap()
+    "bob.near".parse::<AccountId>().unwrap()
 }
 pub fn carol_account() -> AccountId {
-    "carol.near".parse().unwrap()
+    "carol.near".parse::<AccountId>().unwrap()
 }
 pub fn eve_dot_alice_account() -> AccountId {
-    "eve.alice.near".parse().unwrap()
+    "eve.alice.near".parse::<AccountId>().unwrap()
 }
 
 pub fn x_dot_y_dot_alice_account() -> AccountId {
-    "x.y.alice.near".parse().unwrap()
+    "x.y.alice.near".parse::<AccountId>().unwrap()
 }
 
 /// Pre-deploy in genesis the standard test contract for a given account.

--- a/tools/amend-genesis/src/lib.rs
+++ b/tools/amend-genesis/src/lib.rs
@@ -601,7 +601,7 @@ mod test {
                 max_inflation_rate: nearcore::config::MAX_INFLATION_RATE,
                 total_supply: get_initial_supply(&records_in),
                 num_blocks_per_year: nearcore::config::NUM_BLOCKS_PER_YEAR,
-                protocol_treasury_account: "treasury.near".parse().unwrap(),
+                protocol_treasury_account: "treasury.near".parse::<AccountId>().unwrap(),
                 fishermen_threshold: nearcore::config::FISHERMEN_THRESHOLD,
                 shard_layout: shards,
                 min_gas_price: nearcore::config::MIN_GAS_PRICE,

--- a/tools/chainsync-loadtest/src/main.rs
+++ b/tools/chainsync-loadtest/src/main.rs
@@ -19,6 +19,7 @@ use nearcore::config::NearConfig;
 use network::Network;
 use openssl_probe;
 use std::sync::Arc;
+use near_primitives::types::AccountId;
 
 fn genesis_hash(chain_id: &str) -> CryptoHash {
     return match chain_id {
@@ -62,7 +63,7 @@ fn download_configs(chain_id: &str, dir: &std::path::Path) -> anyhow::Result<Nea
     let config = config::Config::from_file(config_path)?;
 
     // Generate node key.
-    let account_id = "node".parse().unwrap();
+    let account_id = "node".parse::<AccountId>().unwrap();
     let node_signer =
         near_crypto::InMemorySigner::from_random(account_id, near_crypto::KeyType::ED25519);
     let mut genesis = Genesis::default();

--- a/tools/chainsync-loadtest/src/main.rs
+++ b/tools/chainsync-loadtest/src/main.rs
@@ -14,12 +14,12 @@ use near_network::PeerManagerActor;
 use near_o11y::tracing::{error, info};
 use near_primitives::block::GenesisId;
 use near_primitives::hash::CryptoHash;
+use near_primitives::types::AccountId;
 use nearcore::config;
 use nearcore::config::NearConfig;
 use network::Network;
 use openssl_probe;
 use std::sync::Arc;
-use near_primitives::types::AccountId;
 
 fn genesis_hash(chain_id: &str) -> CryptoHash {
     return match chain_id {

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -461,7 +461,7 @@ mod test {
     use near_crypto::{InMemorySigner, KeyType};
     use near_epoch_manager::EpochManager;
     use near_primitives::transaction::SignedTransaction;
-    use near_primitives::types::{BlockHeight, BlockHeightDelta, NumBlocks};
+    use near_primitives::types::{AccountId, BlockHeight, BlockHeightDelta, NumBlocks};
     use near_store::genesis::initialize_genesis_state;
     use near_store::test_utils::create_test_store;
     use near_store::Store;
@@ -472,8 +472,10 @@ mod test {
     use crate::apply_chain_range::apply_chain_range;
 
     fn setup(epoch_length: NumBlocks) -> (Store, Genesis, TestEnv) {
-        let mut genesis =
-            Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+        let mut genesis = Genesis::test(
+            vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+            1,
+        );
         genesis.config.num_block_producer_seats = 2;
         genesis.config.num_block_producer_seats_per_shard = vec![2];
         genesis.config.epoch_length = epoch_length;
@@ -537,10 +539,14 @@ mod test {
         let epoch_length = 4;
         let (store, genesis, mut env) = setup(epoch_length);
         let genesis_hash = *env.clients[0].chain.genesis().hash();
-        let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+        let signer = InMemorySigner::from_seed(
+            "test1".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test1",
+        );
         let tx = SignedTransaction::stake(
             1,
-            "test1".parse().unwrap(),
+            "test1".parse::<AccountId>().unwrap(),
             &signer,
             TESTING_INIT_STAKE,
             signer.public_key.clone(),
@@ -579,10 +585,14 @@ mod test {
         let epoch_length = 4;
         let (store, genesis, mut env) = setup(epoch_length);
         let genesis_hash = *env.clients[0].chain.genesis().hash();
-        let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+        let signer = InMemorySigner::from_seed(
+            "test1".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test1",
+        );
         let tx = SignedTransaction::stake(
             1,
-            "test1".parse().unwrap(),
+            "test1".parse::<AccountId>().unwrap(),
             &signer,
             TESTING_INIT_STAKE,
             signer.public_key.clone(),

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -483,6 +483,7 @@ mod test {
     use near_primitives::hash::CryptoHash;
     use near_primitives::shard_layout;
     use near_primitives::transaction::SignedTransaction;
+    use near_primitives::types::AccountId;
     use near_primitives::utils::get_num_seats_per_shard;
     use near_store::genesis::initialize_genesis_state;
     use near_store::test_utils::create_test_store;
@@ -512,10 +513,10 @@ mod test {
     fn test_apply_chunk() {
         let genesis = Genesis::test_sharded(
             vec![
-                "test0".parse().unwrap(),
-                "test1".parse().unwrap(),
-                "test2".parse().unwrap(),
-                "test3".parse().unwrap(),
+                "test0".parse::<AccountId>().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
+                "test2".parse::<AccountId>().unwrap(),
+                "test3".parse::<AccountId>().unwrap(),
             ],
             1,
             get_num_seats_per_shard(4, 1),
@@ -597,10 +598,10 @@ mod test {
     fn test_apply_tx_apply_receipt() {
         let genesis = Genesis::test_sharded(
             vec![
-                "test0".parse().unwrap(),
-                "test1".parse().unwrap(),
-                "test2".parse().unwrap(),
-                "test3".parse().unwrap(),
+                "test0".parse::<AccountId>().unwrap(),
+                "test1".parse::<AccountId>().unwrap(),
+                "test2".parse::<AccountId>().unwrap(),
+                "test3".parse::<AccountId>().unwrap(),
             ],
             1,
             get_num_seats_per_shard(4, 1),

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -1110,7 +1110,11 @@ mod tests {
             .runtimes(runtimes)
             .build();
 
-        let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+        let signer = InMemorySigner::from_seed(
+            "test0".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test0",
+        );
         assert_eq!(env.send_money(0), near_client::ProcessTxResponse::ValidTx);
 
         // It takes 2 blocks to record a transaction on chain and apply the receipts.

--- a/tools/state-viewer/src/contract_accounts.rs
+++ b/tools/state-viewer/src/contract_accounts.rs
@@ -679,7 +679,7 @@ mod tests {
                 gas_burnt: 100,
                 compute_usage: Some(200),
                 tokens_burnt: 2000,
-                executor_id: "someone.near".parse().unwrap(),
+                executor_id: "someone.near".parse::<AccountId>().unwrap(),
                 status: ExecutionStatus::SuccessValue(vec![]),
                 metadata: ExecutionMetadata::default(),
             },

--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -325,8 +325,10 @@ mod test {
         protocol_version: ProtocolVersion,
         test_resharding: bool,
     ) -> (Store, Genesis, TestEnv, NearConfig) {
-        let mut genesis =
-            Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+        let mut genesis = Genesis::test(
+            vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+            1,
+        );
         genesis.config.num_block_producer_seats = 2;
         genesis.config.num_block_producer_seats_per_shard = vec![2];
         genesis.config.epoch_length = epoch_length;
@@ -353,12 +355,12 @@ mod test {
             Config::default(),
             genesis.clone(),
             KeyFile {
-                account_id: "test".parse().unwrap(),
+                account_id: "test".parse::<AccountId>().unwrap(),
                 public_key: PublicKey::empty(KeyType::ED25519),
                 secret_key: SecretKey::from_random(KeyType::ED25519),
             },
             Some(Arc::new(InMemoryValidatorSigner::from_random(
-                "test".parse().unwrap(),
+                "test".parse::<AccountId>().unwrap(),
                 KeyType::ED25519,
             ))),
         )
@@ -395,10 +397,14 @@ mod test {
         let epoch_length = 4;
         let (store, genesis, mut env, near_config) = setup(epoch_length, PROTOCOL_VERSION, false);
         let genesis_hash = *env.clients[0].chain.genesis().hash();
-        let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+        let signer = InMemorySigner::from_seed(
+            "test1".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test1",
+        );
         let tx = SignedTransaction::stake(
             1,
-            "test1".parse().unwrap(),
+            "test1".parse::<AccountId>().unwrap(),
             &signer,
             TESTING_INIT_STAKE,
             signer.public_key.clone(),
@@ -417,7 +423,10 @@ mod test {
             .unwrap();
         assert_eq!(
             block_producers.into_iter().map(|(r, _)| r.take_account_id()).collect::<HashSet<_>>(),
-            HashSet::from_iter(vec!["test0".parse().unwrap(), "test1".parse().unwrap()])
+            HashSet::from_iter(vec![
+                "test0".parse::<AccountId>().unwrap(),
+                "test1".parse::<AccountId>().unwrap()
+            ])
         );
         let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
         let state_roots: Vec<CryptoHash> =
@@ -448,12 +457,15 @@ mod test {
         let (store, genesis, mut env, near_config) = setup(epoch_length, PROTOCOL_VERSION, false);
         let genesis_hash = *env.clients[0].chain.genesis().hash();
 
-        let signer0 =
-            InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+        let signer0 = InMemorySigner::from_seed(
+            "test0".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test0",
+        );
         let tx00 = SignedTransaction::from_actions(
             1,
-            "test0".parse().unwrap(),
-            "test0".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             &signer0,
             vec![Action::DeployContract(DeployContractAction {
                 code: near_test_contracts::backwards_compatible_rs_contract().to_vec(),
@@ -462,7 +474,7 @@ mod test {
         );
         let tx01 = SignedTransaction::stake(
             1,
-            "test0".parse().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             &signer0,
             TESTING_INIT_STAKE,
             signer0.public_key.clone(),
@@ -471,11 +483,14 @@ mod test {
         assert_eq!(env.clients[0].process_tx(tx00, false, false), ProcessTxResponse::ValidTx);
         assert_eq!(env.clients[0].process_tx(tx01, false, false), ProcessTxResponse::ValidTx);
 
-        let signer1 =
-            InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+        let signer1 = InMemorySigner::from_seed(
+            "test1".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test1",
+        );
         let tx1 = SignedTransaction::stake(
             1,
-            "test1".parse().unwrap(),
+            "test1".parse::<AccountId>().unwrap(),
             &signer1,
             TESTING_INIT_STAKE,
             signer1.public_key.clone(),
@@ -494,7 +509,10 @@ mod test {
             .unwrap();
         assert_eq!(
             block_producers.into_iter().map(|(r, _)| r.take_account_id()).collect::<HashSet<_>>(),
-            HashSet::from_iter(vec!["test0".parse().unwrap(), "test1".parse().unwrap()]),
+            HashSet::from_iter(vec![
+                "test0".parse::<AccountId>().unwrap(),
+                "test1".parse::<AccountId>().unwrap()
+            ]),
         );
         let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
         let state_roots: Vec<CryptoHash> =
@@ -503,7 +521,7 @@ mod test {
         let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
         let runtime =
             NightshadeRuntime::test(Path::new("."), store, &genesis.config, epoch_manager.clone());
-        let select_account_ids = vec!["test0".parse().unwrap()];
+        let select_account_ids = vec!["test0".parse::<AccountId>().unwrap()];
         let new_near_config = state_dump(
             epoch_manager.as_ref(),
             runtime,
@@ -535,10 +553,14 @@ mod test {
         let epoch_length = 4;
         let (store, genesis, mut env, near_config) = setup(epoch_length, PROTOCOL_VERSION, false);
         let genesis_hash = *env.clients[0].chain.genesis().hash();
-        let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+        let signer = InMemorySigner::from_seed(
+            "test1".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test1",
+        );
         let tx = SignedTransaction::stake(
             1,
-            "test1".parse().unwrap(),
+            "test1".parse::<AccountId>().unwrap(),
             &signer,
             TESTING_INIT_STAKE,
             signer.public_key.clone(),
@@ -557,7 +579,10 @@ mod test {
             .unwrap();
         assert_eq!(
             block_producers.into_iter().map(|(r, _)| r.take_account_id()).collect::<HashSet<_>>(),
-            HashSet::from_iter(vec!["test0".parse().unwrap(), "test1".parse().unwrap()])
+            HashSet::from_iter(vec![
+                "test0".parse::<AccountId>().unwrap(),
+                "test1".parse::<AccountId>().unwrap()
+            ])
         );
         let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
         let state_roots: Vec<CryptoHash> =
@@ -586,10 +611,14 @@ mod test {
         let epoch_length = 4;
         let (store, genesis, mut env, near_config) = setup(epoch_length, PROTOCOL_VERSION, false);
         let genesis_hash = *env.clients[0].chain.genesis().hash();
-        let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+        let signer = InMemorySigner::from_seed(
+            "test1".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test1",
+        );
         let tx = SignedTransaction::stake(
             1,
-            "test1".parse().unwrap(),
+            "test1".parse::<AccountId>().unwrap(),
             &signer,
             TESTING_INIT_STAKE,
             signer.public_key.clone(),
@@ -628,7 +657,7 @@ mod test {
                 .into_iter()
                 .map(|r| r.account_id)
                 .collect::<Vec<_>>(),
-            vec!["test0".parse().unwrap()]
+            vec!["test0".parse::<AccountId>().unwrap()]
         );
         validate_genesis(&new_genesis).unwrap();
     }
@@ -683,8 +712,10 @@ mod test {
     #[should_panic(expected = "MissingTrieValue")]
     fn test_dump_state_not_track_shard() {
         let epoch_length = 4;
-        let mut genesis =
-            Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+        let mut genesis = Genesis::test(
+            vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+            1,
+        );
         genesis.config.num_block_producer_seats = 2;
         genesis.config.num_block_producer_seats_per_shard = vec![2];
         genesis.config.epoch_length = epoch_length;
@@ -716,11 +747,15 @@ mod test {
             .runtimes(vec![runtime1, runtime2.clone()])
             .build();
         let genesis_hash = *env.clients[0].chain.genesis().hash();
-        let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+        let signer = InMemorySigner::from_seed(
+            "test1".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test1",
+        );
         let tx = SignedTransaction::send_money(
             1,
-            "test1".parse().unwrap(),
-            "test0".parse().unwrap(),
+            "test1".parse::<AccountId>().unwrap(),
+            "test0".parse::<AccountId>().unwrap(),
             &signer,
             1,
             genesis_hash,
@@ -741,12 +776,12 @@ mod test {
             Config::default(),
             genesis,
             KeyFile {
-                account_id: "test".parse().unwrap(),
+                account_id: "test".parse::<AccountId>().unwrap(),
                 public_key: PublicKey::empty(KeyType::ED25519),
                 secret_key: SecretKey::from_random(KeyType::ED25519),
             },
             Some(Arc::new(InMemoryValidatorSigner::from_random(
-                "test".parse().unwrap(),
+                "test".parse::<AccountId>().unwrap(),
                 KeyType::ED25519,
             ))),
         )
@@ -771,8 +806,10 @@ mod test {
     #[test]
     fn test_dump_state_with_delayed_receipt() {
         let epoch_length = 4;
-        let mut genesis =
-            Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+        let mut genesis = Genesis::test(
+            vec!["test0".parse::<AccountId>().unwrap(), "test1".parse::<AccountId>().unwrap()],
+            1,
+        );
         genesis.config.num_block_producer_seats = 2;
         genesis.config.num_block_producer_seats_per_shard = vec![2];
         genesis.config.epoch_length = epoch_length;
@@ -794,10 +831,14 @@ mod test {
             .runtimes(vec![nightshade_runtime])
             .build();
         let genesis_hash = *env.clients[0].chain.genesis().hash();
-        let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+        let signer = InMemorySigner::from_seed(
+            "test1".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test1",
+        );
         let tx = SignedTransaction::stake(
             1,
-            "test1".parse().unwrap(),
+            "test1".parse::<AccountId>().unwrap(),
             &signer,
             TESTING_INIT_STAKE,
             signer.public_key.clone(),
@@ -811,12 +852,12 @@ mod test {
             Config::default(),
             genesis.clone(),
             KeyFile {
-                account_id: "test".parse().unwrap(),
+                account_id: "test".parse::<AccountId>().unwrap(),
                 public_key: PublicKey::empty(KeyType::ED25519),
                 secret_key: SecretKey::from_random(KeyType::ED25519),
             },
             Some(Arc::new(InMemoryValidatorSigner::from_random(
-                "test".parse().unwrap(),
+                "test".parse::<AccountId>().unwrap(),
                 KeyType::ED25519,
             ))),
         )
@@ -830,7 +871,10 @@ mod test {
             .unwrap();
         assert_eq!(
             block_producers.into_iter().map(|(r, _)| r.take_account_id()).collect::<HashSet<_>>(),
-            HashSet::from_iter(vec!["test0".parse().unwrap(), "test1".parse().unwrap()])
+            HashSet::from_iter(vec![
+                "test0".parse::<AccountId>().unwrap(),
+                "test1".parse::<AccountId>().unwrap()
+            ])
         );
         let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
         let state_roots: Vec<CryptoHash> =
@@ -861,10 +905,14 @@ mod test {
         let (store, genesis, mut env, near_config) = setup(epoch_length, PROTOCOL_VERSION, false);
 
         let genesis_hash = *env.clients[0].chain.genesis().hash();
-        let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+        let signer = InMemorySigner::from_seed(
+            "test1".parse::<AccountId>().unwrap(),
+            KeyType::ED25519,
+            "test1",
+        );
         let tx = SignedTransaction::stake(
             1,
-            "test1".parse().unwrap(),
+            "test1".parse::<AccountId>().unwrap(),
             &signer,
             TESTING_INIT_STAKE,
             signer.public_key.clone(),
@@ -883,11 +931,16 @@ mod test {
             .unwrap();
         assert_eq!(
             block_producers.into_iter().map(|(r, _)| r.take_account_id()).collect::<HashSet<_>>(),
-            HashSet::from_iter(vec!["test0".parse().unwrap(), "test1".parse().unwrap()]),
+            HashSet::from_iter(vec![
+                "test0".parse::<AccountId>().unwrap(),
+                "test1".parse::<AccountId>().unwrap()
+            ]),
         );
 
-        let whitelist_validators =
-            vec!["test1".parse().unwrap(), "non_validator_account".parse().unwrap()];
+        let whitelist_validators = vec![
+            "test1".parse::<AccountId>().unwrap(),
+            "non_validator_account".parse::<AccountId>().unwrap(),
+        ];
 
         let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
         let state_roots: Vec<CryptoHash> =
@@ -914,7 +967,7 @@ mod test {
                 .iter()
                 .map(|x| x.account_id.clone())
                 .collect::<Vec<AccountId>>(),
-            vec!["test1".parse().unwrap()]
+            vec!["test1".parse::<AccountId>().unwrap()]
         );
 
         let mut stake = HashMap::<AccountId, Balance>::new();
@@ -924,7 +977,10 @@ mod test {
             }
         });
 
-        assert_eq!(stake.get("test0").unwrap_or(&(0 as Balance)), &(0 as Balance));
+        assert_eq!(
+            stake.get(&"test0".parse::<AccountId>().unwrap()).unwrap_or(&(0 as Balance)),
+            &(0 as Balance)
+        );
 
         validate_genesis(&new_genesis).unwrap();
     }

--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -9,7 +9,6 @@ use near_primitives::block::BlockHeader;
 use near_primitives::state_record::state_record_to_account_id;
 use near_primitives::state_record::StateRecord;
 use near_primitives::types::{AccountInfo, Balance, StateRoot};
-use near_primitives_core::account::id::AccountIdRef;
 use nearcore::config::NearConfig;
 use nearcore::NightshadeRuntime;
 use redis::Commands;

--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -20,6 +20,7 @@ use std::fs;
 use std::fs::File;
 use std::path::Path;
 use std::sync::Arc;
+use near_primitives_core::account::id::AccountIdRef;
 
 /// Returns a `NearConfig` with genesis records taken from the current state.
 /// If `records_path` argument is provided, then records will be streamed into a separate file,
@@ -150,7 +151,8 @@ pub fn state_dump_redis(
             if let Some(sr) = StateRecord::from_raw_key_value(key, value) {
                 if let StateRecord::Account { account_id, account } = &sr {
                     println!("Account: {}", account_id);
-                    let redis_key = account_id.as_ref().as_bytes();
+                    let account_id_ref:&AccountIdRef = account_id.as_ref();
+                    let redis_key = account_id_ref.as_bytes();
                     redis_connection.zadd(
                         [b"account:", redis_key].concat(),
                         block_hash.as_ref(),
@@ -166,8 +168,9 @@ pub fn state_dump_redis(
 
                 if let StateRecord::Data { account_id, data_key, value } = &sr {
                     println!("Data: {}", account_id);
+                    let account_id_ref:&AccountIdRef = account_id.as_ref();
                     let redis_key =
-                        [account_id.as_ref().as_bytes(), b":", data_key.as_ref()].concat();
+                        [account_id_ref.as_bytes(), b":", data_key.as_ref()].concat();
                     redis_connection.zadd(
                         [b"data:", redis_key.as_slice()].concat(),
                         block_hash.as_ref(),
@@ -183,7 +186,8 @@ pub fn state_dump_redis(
 
                 if let StateRecord::Contract { account_id, code } = &sr {
                     println!("Contract: {}", account_id);
-                    let redis_key = [b"code:", account_id.as_ref().as_bytes()].concat();
+                    let account_id_ref:&AccountIdRef = account_id.as_ref();
+                    let redis_key = [b"code:", account_id_ref.as_bytes()].concat();
                     redis_connection.zadd(redis_key.clone(), block_hash.as_ref(), block_height)?;
                     let value_vec: &[u8] = code.as_ref();
                     redis_connection.set(

--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -9,6 +9,7 @@ use near_primitives::block::BlockHeader;
 use near_primitives::state_record::state_record_to_account_id;
 use near_primitives::state_record::StateRecord;
 use near_primitives::types::{AccountInfo, Balance, StateRoot};
+use near_primitives_core::account::id::AccountIdRef;
 use nearcore::config::NearConfig;
 use nearcore::NightshadeRuntime;
 use redis::Commands;
@@ -20,7 +21,6 @@ use std::fs;
 use std::fs::File;
 use std::path::Path;
 use std::sync::Arc;
-use near_primitives_core::account::id::AccountIdRef;
 
 /// Returns a `NearConfig` with genesis records taken from the current state.
 /// If `records_path` argument is provided, then records will be streamed into a separate file,
@@ -151,8 +151,7 @@ pub fn state_dump_redis(
             if let Some(sr) = StateRecord::from_raw_key_value(key, value) {
                 if let StateRecord::Account { account_id, account } = &sr {
                     println!("Account: {}", account_id);
-                    let account_id_ref:&AccountIdRef = account_id.as_ref();
-                    let redis_key = account_id_ref.as_bytes();
+                    let redis_key = account_id.as_bytes();
                     redis_connection.zadd(
                         [b"account:", redis_key].concat(),
                         block_hash.as_ref(),
@@ -168,9 +167,7 @@ pub fn state_dump_redis(
 
                 if let StateRecord::Data { account_id, data_key, value } = &sr {
                     println!("Data: {}", account_id);
-                    let account_id_ref:&AccountIdRef = account_id.as_ref();
-                    let redis_key =
-                        [account_id_ref.as_bytes(), b":", data_key.as_ref()].concat();
+                    let redis_key = [account_id.as_bytes(), b":", data_key.as_ref()].concat();
                     redis_connection.zadd(
                         [b"data:", redis_key.as_slice()].concat(),
                         block_hash.as_ref(),
@@ -186,8 +183,7 @@ pub fn state_dump_redis(
 
                 if let StateRecord::Contract { account_id, code } = &sr {
                     println!("Contract: {}", account_id);
-                    let account_id_ref:&AccountIdRef = account_id.as_ref();
-                    let redis_key = [b"code:", account_id_ref.as_bytes()].concat();
+                    let redis_key = [b"code:", account_id.as_bytes()].concat();
                     redis_connection.zadd(redis_key.clone(), block_hash.as_ref(), block_height)?;
                     let value_vec: &[u8] = code.as_ref();
                     redis_connection.set(


### PR DESCRIPTION
TODO: Switch near-account-id dependency to `near` repo as opposed to my personal one, once the `len` PR is merged. 