### PR TITLE
Split TrieRefcountChange to TrieRefcountAddition/Subtraction.

### DIFF
--- a/core/store/src/cold_storage.rs
+++ b/core/store/src/cold_storage.rs
@@ -1,6 +1,6 @@
 use crate::columns::DBKeyType;
 use crate::db::{ColdDB, COLD_HEAD_KEY, HEAD_KEY};
-use crate::trie::TrieRefcountChange;
+use crate::trie::TrieRefcountAddition;
 use crate::{metrics, DBCol, DBTransaction, Database, Store, TrieChanges};
 
 use borsh::BorshDeserialize;
@@ -475,7 +475,11 @@ impl StoreWithCache<'_> {
         option_to_not_found(self.get_ser(column, key), format_args!("{:?}: {:?}", column, key))
     }
 
-    pub fn insert_state_to_cache_from_op(&mut self, op: &TrieRefcountChange, shard_uid_key: &[u8]) {
+    pub fn insert_state_to_cache_from_op(
+        &mut self,
+        op: &TrieRefcountAddition,
+        shard_uid_key: &[u8],
+    ) {
         debug_assert_eq!(
             DBCol::State.key_type(),
             &[DBKeyType::ShardUId, DBKeyType::TrieNodeOrValueHash]

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -26,7 +26,7 @@ pub use raw_node::{Children, RawTrieNode, RawTrieNodeWithSize};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt::Write;
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 use std::rc::Rc;
 use std::str;
 use std::sync::Arc;
@@ -366,21 +366,30 @@ pub trait TrieAccess {
     fn get(&self, key: &TrieKey) -> Result<Option<Vec<u8>>, StorageError>;
 }
 
-/// Stores reference count change for some key-value pair in DB.
-#[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
-pub struct TrieRefcountChange {
+/// Stores reference count addition for some key-value pair in DB.
+#[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub struct TrieRefcountAddition {
     /// Hash of trie_node_or_value and part of the DB key.
     /// Used for uniting with shard id to get actual DB key.
     trie_node_or_value_hash: CryptoHash,
     /// DB value. Can be either serialized RawTrieNodeWithSize or value corresponding to
     /// some TrieKey.
     trie_node_or_value: Vec<u8>,
-    /// Reference count difference which will be added to the total refcount if it corresponds to
-    /// insertion and subtracted from it in the case of deletion.
+    /// Reference count difference which will be added to the total refcount.
     rc: std::num::NonZeroU32,
 }
 
-impl TrieRefcountChange {
+/// Stores reference count subtraction for some key in DB.
+#[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub struct TrieRefcountSubtraction {
+    /// Hash of trie_node_or_value and part of the DB key.
+    /// Used for uniting with shard id to get actual DB key.
+    trie_node_or_value_hash: CryptoHash,
+    /// Reference count difference which will be subtracted to the total refcount.
+    rc: std::num::NonZeroU32,
+}
+
+impl TrieRefcountAddition {
     pub fn hash(&self) -> &CryptoHash {
         &self.trie_node_or_value_hash
     }
@@ -388,14 +397,67 @@ impl TrieRefcountChange {
     pub fn payload(&self) -> &[u8] {
         self.trie_node_or_value.as_slice()
     }
-}
 
-impl Hash for TrieRefcountChange {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write(&self.trie_node_or_value_hash.0);
-        state.write_u32(self.rc.into());
+    pub fn revert(&self) -> TrieRefcountSubtraction {
+        TrieRefcountSubtraction {
+            trie_node_or_value_hash: self.trie_node_or_value_hash,
+            rc: self.rc,
+        }
     }
 }
+
+impl TrieRefcountSubtraction {
+    pub fn hash(&self) -> &CryptoHash {
+        &self.trie_node_or_value_hash
+    }
+}
+
+/// Helps produce a list of additions and subtractions to the trie,
+/// especially in the case where deletions don't carry the full value.
+pub struct TrieRefcountDeltaMap {
+    map: HashMap<CryptoHash, (Option<Vec<u8>>, i32)>,
+}
+
+impl TrieRefcountDeltaMap {
+    pub fn new() -> Self {
+        Self { map: HashMap::new() }
+    }
+
+    pub fn add(&mut self, hash: CryptoHash, data: Vec<u8>, refcount: u32) {
+        let (old_value, old_rc) = self.map.entry(hash).or_insert((None, 0));
+        *old_value = Some(data);
+        *old_rc += refcount as i32;
+    }
+
+    pub fn subtract(&mut self, hash: CryptoHash, refcount: u32) {
+        let (_, old_rc) = self.map.entry(hash).or_insert((None, 0));
+        *old_rc -= refcount as i32;
+    }
+
+    pub fn into_changes(self) -> (Vec<TrieRefcountAddition>, Vec<TrieRefcountSubtraction>) {
+        let mut insertions = Vec::new();
+        let mut deletions = Vec::new();
+        for (hash, (value, rc)) in self.map.into_iter() {
+            if rc > 0 {
+                insertions.push(TrieRefcountAddition {
+                    trie_node_or_value_hash: hash,
+                    trie_node_or_value: value.expect("value must be present"),
+                    rc: std::num::NonZeroU32::new(rc as u32).unwrap(),
+                });
+            } else if rc < 0 {
+                deletions.push(TrieRefcountSubtraction {
+                    trie_node_or_value_hash: hash,
+                    rc: std::num::NonZeroU32::new((-rc) as u32).unwrap(),
+                });
+            }
+        }
+        // Sort so that trie changes have unique representation.
+        insertions.sort();
+        deletions.sort();
+        (insertions, deletions)
+    }
+}
+
 ///
 /// TrieChanges stores delta for refcount.
 /// Multiple versions of the state work the following way:
@@ -423,8 +485,8 @@ impl Hash for TrieRefcountChange {
 pub struct TrieChanges {
     pub old_root: StateRoot,
     pub new_root: StateRoot,
-    insertions: Vec<TrieRefcountChange>,
-    deletions: Vec<TrieRefcountChange>,
+    insertions: Vec<TrieRefcountAddition>,
+    deletions: Vec<TrieRefcountSubtraction>,
 }
 
 impl TrieChanges {
@@ -432,7 +494,7 @@ impl TrieChanges {
         TrieChanges { old_root, new_root: old_root, insertions: vec![], deletions: vec![] }
     }
 
-    pub fn insertions(&self) -> &[TrieRefcountChange] {
+    pub fn insertions(&self) -> &[TrieRefcountAddition] {
         self.insertions.as_slice()
     }
 }
@@ -600,12 +662,8 @@ impl Trie {
     ) -> Result<(), StorageError> {
         match value {
             ValueHandle::HashAndSize(value) => {
-                let bytes = self.internal_retrieve_trie_node(&value.hash, true)?;
-                memory
-                    .refcount_changes
-                    .entry(value.hash)
-                    .or_insert_with(|| (bytes.to_vec(), 0))
-                    .1 -= 1;
+                self.internal_retrieve_trie_node(&value.hash, true)?;
+                memory.refcount_changes.subtract(value.hash, 1);
             }
             ValueHandle::InMemory(_) => {
                 // do nothing
@@ -943,9 +1001,9 @@ impl Trie {
     ) -> Result<StorageHandle, StorageError> {
         match self.retrieve_raw_node(hash, true)? {
             None => Ok(memory.store(TrieNodeWithSize::empty())),
-            Some((bytes, node)) => {
+            Some((_, node)) => {
                 let result = memory.store(TrieNodeWithSize::from_raw(node));
-                memory.refcount_changes.entry(*hash).or_insert_with(|| (bytes.to_vec(), 0)).1 -= 1;
+                memory.refcount_changes.subtract(*hash, 1);
                 Ok(result)
             }
         }
@@ -1150,32 +1208,6 @@ impl Trie {
             }
             None => Ok(None),
         }
-    }
-
-    pub(crate) fn convert_to_insertions_and_deletions(
-        changes: HashMap<CryptoHash, (Vec<u8>, i32)>,
-    ) -> (Vec<TrieRefcountChange>, Vec<TrieRefcountChange>) {
-        let mut deletions = Vec::new();
-        let mut insertions = Vec::new();
-        for (trie_node_or_value_hash, (trie_node_or_value, rc)) in changes.into_iter() {
-            if rc > 0 {
-                insertions.push(TrieRefcountChange {
-                    trie_node_or_value_hash,
-                    trie_node_or_value,
-                    rc: std::num::NonZeroU32::new(rc as u32).unwrap(),
-                });
-            } else if rc < 0 {
-                deletions.push(TrieRefcountChange {
-                    trie_node_or_value_hash,
-                    trie_node_or_value,
-                    rc: std::num::NonZeroU32::new((-rc) as u32).unwrap(),
-                });
-            }
-        }
-        // Sort so that trie changes have unique representation
-        insertions.sort();
-        deletions.sort();
-        (insertions, deletions)
     }
 
     pub fn update<I>(&self, changes: I) -> Result<TrieChanges, StorageError>

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -406,12 +406,6 @@ impl TrieRefcountAddition {
     }
 }
 
-impl TrieRefcountSubtraction {
-    pub fn hash(&self) -> &CryptoHash {
-        &self.trie_node_or_value_hash
-    }
-}
-
 /// Helps produce a list of additions and subtractions to the trie,
 /// especially in the case where deletions don't carry the full value.
 pub struct TrieRefcountDeltaMap {

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -36,6 +36,8 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::Arc;
 
+use super::TrieRefcountDeltaMap;
+
 /// Trie key in nibbles corresponding to the right boundary for the last state part.
 /// Guaranteed to be bigger than any existing trie key.
 const LAST_STATE_PART_BOUNDARY: &[u8; 1] = &[16];
@@ -457,12 +459,12 @@ impl Trie {
         let path_end = trie.find_state_part_boundary(part_id.idx + 1, part_id.total)?;
         let mut iterator = trie.iter()?;
         let trie_traversal_items = iterator.visit_nodes_interval(&path_begin, &path_end)?;
-        let mut map = HashMap::new();
+        let mut refcount_changes = TrieRefcountDeltaMap::new();
         let mut flat_state_delta = FlatStateChanges::default();
         let mut contract_codes = Vec::new();
         for TrieTraversalItem { hash, key } in trie_traversal_items {
             let value = trie.retrieve_value(&hash)?;
-            map.entry(hash).or_insert_with(|| (value.to_vec(), 0)).1 += 1;
+            refcount_changes.add(hash, value.to_vec(), 1);
             if let Some(trie_key) = key {
                 let flat_state_value = FlatStateValue::on_disk(&value);
                 flat_state_delta.insert(trie_key.clone(), Some(flat_state_value));
@@ -471,7 +473,7 @@ impl Trie {
                 }
             }
         }
-        let (insertions, deletions) = Trie::convert_to_insertions_and_deletions(map);
+        let (insertions, deletions) = refcount_changes.into_changes();
         Ok(ApplyStatePartResult {
             trie_changes: TrieChanges {
                 old_root: Trie::EMPTY_ROOT,
@@ -506,6 +508,8 @@ impl Trie {
 mod tests {
     use assert_matches::assert_matches;
     use std::collections::{HashMap, HashSet};
+    use std::fmt::Debug;
+    use std::hash::Hash;
     use std::sync::Arc;
 
     use rand::prelude::ThreadRng;
@@ -518,7 +522,9 @@ mod tests {
         create_tries, create_tries_with_flat_storage, gen_changes, test_populate_trie,
     };
     use crate::trie::iterator::CrumbStatus;
-    use crate::trie::{TrieRefcountChange, ValueHandle};
+    use crate::trie::{
+        TrieRefcountAddition, TrieRefcountDeltaMap, TrieRefcountSubtraction, ValueHandle,
+    };
 
     use super::*;
     use crate::{DBCol, MissingTrieValueContext, TrieCachingStorage};
@@ -629,7 +635,7 @@ mod tests {
             })?;
             let mut insertions = insertions
                 .into_iter()
-                .map(|(k, (v, rc))| TrieRefcountChange {
+                .map(|(k, (v, rc))| TrieRefcountAddition {
                     trie_node_or_value_hash: k,
                     trie_node_or_value: v,
                     rc: std::num::NonZeroU32::new(rc).unwrap(),
@@ -881,23 +887,19 @@ mod tests {
             return TrieChanges::empty(Trie::EMPTY_ROOT);
         }
         let new_root = changes[0].new_root;
-        let mut map = HashMap::new();
+        let mut map = TrieRefcountDeltaMap::new();
         for changes_set in changes {
             assert!(changes_set.deletions.is_empty(), "state parts only have insertions");
-            for TrieRefcountChange { trie_node_or_value_hash, trie_node_or_value, rc } in
+            for TrieRefcountAddition { trie_node_or_value_hash, trie_node_or_value, rc } in
                 changes_set.insertions
             {
-                map.entry(trie_node_or_value_hash).or_insert_with(|| (trie_node_or_value, 0)).1 +=
-                    rc.get() as i32;
+                map.add(trie_node_or_value_hash, trie_node_or_value, rc.get());
             }
-            for TrieRefcountChange { trie_node_or_value_hash, trie_node_or_value, rc } in
-                changes_set.deletions
-            {
-                map.entry(trie_node_or_value_hash).or_insert_with(|| (trie_node_or_value, 0)).1 -=
-                    rc.get() as i32;
+            for TrieRefcountSubtraction { trie_node_or_value_hash, rc } in changes_set.deletions {
+                map.subtract(trie_node_or_value_hash, rc.get());
             }
         }
-        let (insertions, deletions) = Trie::convert_to_insertions_and_deletions(map);
+        let (insertions, deletions) = map.into_changes();
         TrieChanges { old_root: Default::default(), new_root, insertions, deletions }
     }
 
@@ -971,10 +973,7 @@ mod tests {
         }
     }
 
-    fn format_simple_trie_refcount_diff(
-        left: &[TrieRefcountChange],
-        right: &[TrieRefcountChange],
-    ) -> String {
+    fn format_simple_trie_refcount_diff<T: Hash + Debug + Eq>(left: &[T], right: &[T]) -> String {
         let left_set: HashSet<_> = HashSet::from_iter(left.iter());
         let right_set: HashSet<_> = HashSet::from_iter(right.iter());
         format!(

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -208,7 +208,7 @@ mod trie_storage_tests {
     use crate::test_utils::{create_test_store, create_tries};
     use crate::trie::accounting_cache::TrieAccountingCache;
     use crate::trie::trie_storage::{TrieCache, TrieCachingStorage, TrieDBStorage};
-    use crate::trie::TrieRefcountChange;
+    use crate::trie::TrieRefcountAddition;
     use crate::{Store, TrieChanges, TrieConfig};
     use assert_matches::assert_matches;
     use near_primitives::hash::hash;
@@ -218,7 +218,7 @@ mod trie_storage_tests {
         let mut trie_changes = TrieChanges::empty(Trie::EMPTY_ROOT);
         trie_changes.insertions = values
             .iter()
-            .map(|value| TrieRefcountChange {
+            .map(|value| TrieRefcountAddition {
                 trie_node_or_value_hash: hash(value),
                 trie_node_or_value: value.clone(),
                 rc: std::num::NonZeroU32::new(1).unwrap(),


### PR DESCRIPTION
This is because for subtraction we don't need the value, and currently that value is just being passed around and eventually dropped. This refactoring is also useful for in-memory trie operations, because otherwise, deleting a node would require fetching the node's value (from on-disk trie) unnecessarily.