### PR TITLE
[state_sync] Part 3: Split make_state_snapshot into a delete_snapshot + create_snapshot

### DIFF
--- a/chain/chain/src/state_snapshot_actor.rs
+++ b/chain/chain/src/state_snapshot_actor.rs
@@ -1,4 +1,4 @@
-use actix::AsyncContext;
+use actix::{AsyncContext, Context};
 use near_o11y::{handler_debug_span, OpenTelemetrySpanExt, WithSpanContext, WithSpanContextExt};
 use near_performance_metrics_macros::perf;
 use near_primitives::block::Block;
@@ -9,6 +9,10 @@ use near_store::ShardTries;
 use std::sync::Arc;
 
 /// Runs tasks related to state snapshots.
+/// There are three main handlers in StateSnapshotActor and they are called in sequence
+/// 1. DeleteSnapshotRequest: deletes a snapshot and optionally calls CreateSnapshotRequest.
+/// 2. CreateSnapshotRequest: creates a new snapshot and optionally calls CompactSnapshotRequest based on config.
+/// 3. CompactSnapshotRequest: compacts a snapshot store.
 pub struct StateSnapshotActor {
     flat_storage_manager: FlatStorageManager,
     tries: ShardTries,
@@ -21,48 +25,70 @@ impl StateSnapshotActor {
 }
 
 impl actix::Actor for StateSnapshotActor {
-    type Context = actix::Context<Self>;
+    type Context = Context<Self>;
 }
 
 #[derive(actix::Message, Debug)]
 #[rtype(result = "()")]
-struct MakeSnapshotRequest {
+struct DeleteSnapshotRequest {
+    /// Optionally send request to create a new snapshot after deleting any existing snapshots.
+    create_snapshot_request: Option<CreateSnapshotRequest>,
+}
+
+#[derive(actix::Message, Debug)]
+#[rtype(result = "()")]
+struct CreateSnapshotRequest {
     /// prev_hash of the last processed block.
     prev_block_hash: CryptoHash,
     /// Shards that need to be present in the snapshot.
     shard_uids: Vec<ShardUId>,
     /// Last block of the prev epoch.
     block: Block,
-    /// Whether to perform compaction.
-    compaction_enabled: bool,
 }
 
 #[derive(actix::Message, Debug)]
 #[rtype(result = "()")]
 struct CompactSnapshotRequest {}
 
-/// Makes a state snapshot in the background.
-impl actix::Handler<WithSpanContext<MakeSnapshotRequest>> for StateSnapshotActor {
+impl actix::Handler<WithSpanContext<DeleteSnapshotRequest>> for StateSnapshotActor {
     type Result = ();
 
     #[perf]
-    fn handle(
-        &mut self,
-        msg: WithSpanContext<MakeSnapshotRequest>,
-        _ctx: &mut actix::Context<Self>,
-    ) -> Self::Result {
+    fn handle(&mut self, msg: WithSpanContext<DeleteSnapshotRequest>, context: &mut Context<Self>) {
         let (_span, msg) = handler_debug_span!(target: "state_snapshot", msg);
         tracing::debug!(target: "state_snapshot", ?msg);
-        let MakeSnapshotRequest { prev_block_hash, shard_uids, block, compaction_enabled } = msg;
 
-        let res = self.tries.make_state_snapshot(&prev_block_hash, &shard_uids, &block);
+        // We don't need to acquire any locks on flat storage or snapshot.
+        let DeleteSnapshotRequest { create_snapshot_request } = msg;
+        self.tries.delete_state_snapshot();
+
+        // Optionally send a create_snapshot_request after deletion
+        if let Some(create_snapshot_request) = create_snapshot_request {
+            context.address().do_send(create_snapshot_request.with_span_context());
+        }
+    }
+}
+
+impl actix::Handler<WithSpanContext<CreateSnapshotRequest>> for StateSnapshotActor {
+    type Result = ();
+
+    #[perf]
+    fn handle(&mut self, msg: WithSpanContext<CreateSnapshotRequest>, context: &mut Context<Self>) {
+        let (_span, msg) = handler_debug_span!(target: "state_snapshot", msg);
+        tracing::debug!(target: "state_snapshot", ?msg);
+
+        let CreateSnapshotRequest { prev_block_hash, shard_uids, block } = msg;
+        let res = self.tries.create_state_snapshot(prev_block_hash, &shard_uids, &block);
+
+        // Unlocking flat state head can be done asynchronously in state_snapshot_actor.
+        // The next flat storage update will bring flat storage to latest head.
         if !self.flat_storage_manager.set_flat_state_updates_mode(true) {
             tracing::error!(target: "state_snapshot", ?prev_block_hash, ?shard_uids, "Failed to unlock flat state updates");
         }
         match res {
             Ok(_) => {
-                if compaction_enabled {
-                    _ctx.address().do_send(CompactSnapshotRequest {}.with_span_context());
+                if self.tries.state_snapshot_config().compaction_enabled {
+                    context.address().do_send(CompactSnapshotRequest {}.with_span_context());
                 } else {
                     tracing::info!(target: "state_snapshot", "State snapshot ready, not running compaction.");
                 }
@@ -79,11 +105,7 @@ impl actix::Handler<WithSpanContext<CompactSnapshotRequest>> for StateSnapshotAc
     type Result = ();
 
     #[perf]
-    fn handle(
-        &mut self,
-        msg: WithSpanContext<CompactSnapshotRequest>,
-        _ctx: &mut actix::Context<Self>,
-    ) -> Self::Result {
+    fn handle(&mut self, msg: WithSpanContext<CompactSnapshotRequest>, _: &mut Context<Self>) {
         let (_span, msg) = handler_debug_span!(target: "state_snapshot", msg);
         tracing::debug!(target: "state_snapshot", ?msg);
 
@@ -102,7 +124,6 @@ pub type MakeSnapshotCallback =
 pub fn get_make_snapshot_callback(
     state_snapshot_addr: Arc<actix::Addr<StateSnapshotActor>>,
     flat_storage_manager: FlatStorageManager,
-    compaction_enabled: bool,
 ) -> MakeSnapshotCallback {
     Arc::new(move |prev_block_hash, shard_uids, block| {
         tracing::info!(
@@ -110,11 +131,16 @@ pub fn get_make_snapshot_callback(
             ?prev_block_hash,
             ?shard_uids,
             "start_snapshot_callback sends `MakeSnapshotCallback` to state_snapshot_addr");
-        if flat_storage_manager.set_flat_state_updates_mode(false) {
-            state_snapshot_addr.do_send(
-                MakeSnapshotRequest { prev_block_hash, shard_uids, block, compaction_enabled }
-                    .with_span_context(),
-            );
+        // We need to stop flat head updates synchronously in the client thread.
+        // Async update in state_snapshot_actor and potentially lead to flat head progressing beyond prev_block_hash
+        if !flat_storage_manager.set_flat_state_updates_mode(false) {
+            tracing::error!(target: "state_snapshot", ?prev_block_hash, ?shard_uids, "Failed to lock flat state updates");
+            return;
         }
+        let create_snapshot_request = CreateSnapshotRequest { prev_block_hash, shard_uids, block };
+        state_snapshot_addr.do_send(
+            DeleteSnapshotRequest { create_snapshot_request: Some(create_snapshot_request) }
+                .with_span_context(),
+        );
     })
 }

--- a/chain/client/src/test_utils/test_env_builder.rs
+++ b/chain/client/src/test_utils/test_env_builder.rs
@@ -491,7 +491,8 @@ impl TestEnvBuilder {
                     let tries = runtime.get_tries();
                     let make_state_snapshot_callback: MakeSnapshotCallback = Arc::new(move |prev_block_hash, shard_uids, block| {
                         tracing::info!(target: "state_snapshot", ?prev_block_hash, "make_snapshot_callback");
-                        tries.make_state_snapshot(&prev_block_hash, &shard_uids, &block).unwrap();
+                        tries.delete_state_snapshot();
+                        tries.create_state_snapshot(prev_block_hash, &shard_uids, &block).unwrap();
                     });
                     setup_client_with_runtime(
                         u64::try_from(num_validators).unwrap(),

--- a/core/store/src/metrics.rs
+++ b/core/store/src/metrics.rs
@@ -244,7 +244,7 @@ pub(crate) static HAS_STATE_SNAPSHOT: Lazy<IntGauge> = Lazy::new(|| {
         .unwrap()
 });
 
-pub(crate) static MAKE_STATE_SNAPSHOT_ELAPSED: Lazy<Histogram> = Lazy::new(|| {
+pub(crate) static CREATE_STATE_SNAPSHOT_ELAPSED: Lazy<Histogram> = Lazy::new(|| {
     try_create_histogram_with_buckets(
         "near_make_state_snapshot_elapsed_sec",
         "Latency of making a state snapshot, in seconds",

--- a/core/store/src/trie/state_snapshot.rs
+++ b/core/store/src/trie/state_snapshot.rs
@@ -153,52 +153,39 @@ impl ShardTries {
     }
 
     /// Makes a snapshot of the current state of the DB.
-    /// If a snapshot was previously available, it gets deleted.
-    pub fn make_state_snapshot(
+    pub fn create_state_snapshot(
         &self,
-        prev_block_hash: &CryptoHash,
+        prev_block_hash: CryptoHash,
         shard_uids: &[ShardUId],
         block: &Block,
     ) -> Result<(), anyhow::Error> {
         metrics::HAS_STATE_SNAPSHOT.set(0);
         // The function returns an `anyhow::Error`, because no special handling of errors is done yet. The errors are logged and ignored.
         let _span =
-            tracing::info_span!(target: "state_snapshot", "make_state_snapshot", ?prev_block_hash)
+            tracing::info_span!(target: "state_snapshot", "create_state_snapshot", ?prev_block_hash)
                 .entered();
-        tracing::info!(target: "state_snapshot", ?prev_block_hash, "make_state_snapshot");
+        let _timer = metrics::CREATE_STATE_SNAPSHOT_ELAPSED.start_timer();
 
-        let StateSnapshotConfig { home_dir, hot_store_path, state_snapshot_subdir, .. } =
-            self.state_snapshot_config();
-
-        let _timer = metrics::MAKE_STATE_SNAPSHOT_ELAPSED.start_timer();
         // `write()` lock is held for the whole duration of this function.
-        // Accessing the snapshot in other parts of the system will fail.
-        let mut state_snapshot_lock = self.state_snapshot().write().map_err(|err| {
-            anyhow::Error::msg(format!(
-                "error accessing write lock of state_snapshot: {}",
-                err.to_string()
-            ))
-        })?;
+        let mut state_snapshot_lock = self.state_snapshot().write().unwrap();
         let db_snapshot_hash = self.get_state_snapshot_hash();
-
         if let Some(state_snapshot) = &*state_snapshot_lock {
             // only return Ok() when the hash stored in STATE_SNAPSHOT_KEY and in state_snapshot_lock and prev_block_hash are the same
-            if db_snapshot_hash.is_ok()
-                && db_snapshot_hash.unwrap() == *prev_block_hash
-                && state_snapshot.prev_block_hash == *prev_block_hash
+            if db_snapshot_hash.is_ok_and(|hash| hash == prev_block_hash)
+                && state_snapshot.prev_block_hash == prev_block_hash
             {
                 tracing::warn!(target: "state_snapshot", ?prev_block_hash, "Requested a state snapshot but that is already available");
                 return Ok(());
             }
-            // Drop Store before deleting the underlying data.
-            *state_snapshot_lock = None;
-            self.delete_current_snapshot();
+            tracing::error!(target: "state_snapshot", ?prev_block_hash, ?state_snapshot.prev_block_hash, "Requested a state snapshot but that is already available with a different hash");
         }
 
+        let StateSnapshotConfig { home_dir, hot_store_path, state_snapshot_subdir, .. } =
+            self.state_snapshot_config();
         let storage = checkpoint_hot_storage_and_cleanup_columns(
             &self.get_store(),
             &Self::get_state_snapshot_base_dir(
-                prev_block_hash,
+                &prev_block_hash,
                 home_dir,
                 hot_store_path,
                 state_snapshot_subdir,
@@ -223,7 +210,7 @@ impl ShardTries {
         let flat_storage_manager = FlatStorageManager::new(store.clone());
         *state_snapshot_lock = Some(StateSnapshot::new(
             store,
-            *prev_block_hash,
+            prev_block_hash,
             flat_storage_manager,
             shard_uids,
             Some(block),
@@ -232,7 +219,7 @@ impl ShardTries {
         // this will set the new hash for state snapshot in rocksdb. will retry until success.
         let mut set_state_snapshot_in_db = false;
         while !set_state_snapshot_in_db {
-            set_state_snapshot_in_db = match self.set_state_snapshot_hash(Some(*prev_block_hash)) {
+            set_state_snapshot_in_db = match self.set_state_snapshot_hash(Some(prev_block_hash)) {
                 Ok(_) => true,
                 Err(err) => {
                     // This will be retried.
@@ -252,22 +239,28 @@ impl ShardTries {
         let _span =
             tracing::info_span!(target: "state_snapshot", "compact_state_snapshot").entered();
         // It's fine if the access to state snapshot blocks.
-        let state_snapshot_lock = self.state_snapshot().read().map_err(|err| {
-            anyhow::Error::msg(format!(
-                "error accessing read lock of state_snapshot: {}",
-                err.to_string()
-            ))
-        })?;
+        let state_snapshot_lock = self.state_snapshot().read().unwrap();
         if let Some(state_snapshot) = &*state_snapshot_lock {
             let _timer = metrics::COMPACT_STATE_SNAPSHOT_ELAPSED.start_timer();
-            Ok(state_snapshot.store.compact()?)
+            state_snapshot.store.compact()?;
         } else {
-            tracing::warn!(target: "state_snapshot", "Requested compaction but no state snapshot is available.");
-            Ok(())
-        }
+            tracing::error!(target: "state_snapshot", "Requested compaction but no state snapshot is available.");
+        };
+        Ok(())
     }
 
-    fn delete_current_snapshot(&self) {
+    /// Deletes all snapshots and unsets the STATE_SNAPSHOT_KEY.
+    pub fn delete_state_snapshot(&self) {
+        let _span =
+            tracing::info_span!(target: "state_snapshot", "delete_state_snapshot").entered();
+        let _timer = metrics::DELETE_STATE_SNAPSHOT_ELAPSED.start_timer();
+
+        // get snapshot_hash after acquiring write lock
+        let mut state_snapshot_lock = self.state_snapshot().write().unwrap();
+        if state_snapshot_lock.is_some() {
+            // Drop Store before deleting the underlying data.
+            *state_snapshot_lock = None;
+        }
         let StateSnapshotConfig { home_dir, hot_store_path, state_snapshot_subdir, .. } =
             self.state_snapshot_config();
 
@@ -301,9 +294,8 @@ impl ShardTries {
         hot_store_path: &Path,
         state_snapshot_subdir: &Path,
     ) -> Result<(), io::Error> {
-        let _timer = metrics::DELETE_STATE_SNAPSHOT_ELAPSED.start_timer();
         let _span =
-            tracing::info_span!(target: "state_snapshot", "delete_state_snapshot").entered();
+            tracing::info_span!(target: "state_snapshot", "delete_all_state_snapshots").entered();
         let path = home_dir.join(hot_store_path).join(state_snapshot_subdir);
         std::fs::remove_dir_all(&path)
     }
@@ -336,7 +328,7 @@ impl ShardTries {
             None => store_update.delete(DBCol::BlockMisc, key),
             Some(value) => store_update.set_ser(DBCol::BlockMisc, key, &value)?,
         }
-        store_update.commit().map_err(|err| err.into())
+        store_update.commit().into()
     }
 
     /// Read RocksDB for the latest available snapshot hash, if available, open base_path+snapshot_hash for the state snapshot
@@ -373,12 +365,7 @@ impl ShardTries {
         let flat_storage_manager = FlatStorageManager::new(store.clone());
 
         let shard_uids = get_shard_uids_fn(snapshot_hash)?;
-        let mut guard = self.state_snapshot().write().map_err(|err| {
-            anyhow::Error::msg(format!(
-                "error accessing write lock of state_snapshot: {}",
-                err.to_string()
-            ))
-        })?;
+        let mut guard = self.state_snapshot().write().unwrap();
         *guard =
             Some(StateSnapshot::new(store, snapshot_hash, flat_storage_manager, &shard_uids, None));
         metrics::HAS_STATE_SNAPSHOT.set(1);

--- a/integration-tests/src/tests/client/state_snapshot.rs
+++ b/integration-tests/src/tests/client/state_snapshot.rs
@@ -133,8 +133,9 @@ fn verify_make_snapshot(
     block_hash: CryptoHash,
     block: &Block,
 ) -> Result<(), anyhow::Error> {
-    state_snapshot_test_env.shard_tries.make_state_snapshot(
-        &block_hash,
+    state_snapshot_test_env.shard_tries.delete_state_snapshot();
+    state_snapshot_test_env.shard_tries.create_state_snapshot(
+        block_hash,
         &vec![ShardUId::single_shard()],
         block,
     )?;
@@ -243,7 +244,8 @@ fn test_make_state_snapshot() {
         )
     );
 
-    // check that if the snapshot is deleted from file system while there's entry in DBCol::STATE_SNAPSHOT_KEY and write lock is nonempty, making a snpashot of the same hash will not write to the file system
+    // check that if the snapshot is deleted from file system while there's entry in DBCol::STATE_SNAPSHOT_KEY
+    // recreating the snapshot will succeed
     let snapshot_hash = head.last_block_hash;
     let snapshot_path = ShardTries::get_state_snapshot_base_dir(
         &snapshot_hash,
@@ -252,14 +254,11 @@ fn test_make_state_snapshot() {
         &state_snapshot_test_env.state_snapshot_subdir,
     );
     delete_content_at_path(snapshot_path.to_str().unwrap()).unwrap();
-    assert_ne!(
+    assert_eq!(
         format!("{:?}", Ok::<(), anyhow::Error>(())),
         format!(
             "{:?}",
             verify_make_snapshot(&state_snapshot_test_env, head.last_block_hash, &head_block)
         )
     );
-    if let Ok(entries) = std::fs::read_dir(snapshot_path) {
-        assert_eq!(entries.count(), 0);
-    }
 }

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -321,11 +321,8 @@ pub fn start_with_config_and_synchronization(
     let state_snapshot_actor = Arc::new(
         StateSnapshotActor::new(runtime.get_flat_storage_manager(), runtime.get_tries()).start(),
     );
-    let make_state_snapshot_callback = get_make_snapshot_callback(
-        state_snapshot_actor,
-        runtime.get_flat_storage_manager(),
-        config.config.store.state_snapshot_compaction_enabled,
-    );
+    let make_state_snapshot_callback =
+        get_make_snapshot_callback(state_snapshot_actor, runtime.get_flat_storage_manager());
 
     let (client_actor, client_arbiter_handle) = start_client(
         config.client_config.clone(),


### PR DESCRIPTION
This PR splits the MakeSnapshotRequest into two parts, DeleteSnapshotRequest and CreateSnapshotRequest.

The use case here is that now we can independently call DeleteSnapshotRequest for the case where we would only need to delete a snapshot (and not create one) for the ForReshardingOnly config of state_snapshot_type. (PR https://github.com/near/nearcore/pull/10012 )

DeleteSnapshotRequest (internal to state_snapshot_actor) takes an optional CreateSnapshotRequest.

