### PR TITLE
refactor(state-sync): apply state parts for different shards in parallel

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2348,10 +2348,11 @@ impl Client {
         Ok(false)
     }
 
+    /// Returns the shard IDs of shards that the client needs to run catchup for
     pub fn catchup_shards(&self) -> Result<Vec<ShardId>, Error> {
         let mut shards = HashSet::new();
         for (_sync_hash, state_sync_info) in self.chain.store().iterate_state_sync_infos()? {
-            shards.extend(state_sync_info.shards.iter().map(|tuple| tuple.0));
+            shards.extend(state_sync_info.shards.iter().map(|shard_info| shard_info.0));
         }
         Ok(shards.into_iter().collect())
     }

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2348,6 +2348,14 @@ impl Client {
         Ok(false)
     }
 
+    pub fn catchup_shards(&self) -> Result<Vec<ShardId>, Error> {
+        let mut shards = HashSet::new();
+        for (_sync_hash, state_sync_info) in self.chain.store().iterate_state_sync_infos()? {
+            shards.extend(state_sync_info.shards.iter().map(|tuple| tuple.0));
+        }
+        Ok(shards.into_iter().collect())
+    }
+
     /// Walks through all the ongoing state syncs for future epochs and processes them
     pub fn run_catchup(
         &mut self,

--- a/chain/client/src/sync/sync_actor.rs
+++ b/chain/client/src/sync/sync_actor.rs
@@ -4,14 +4,19 @@ use near_network::types::{PeerManagerMessageRequest, StateSyncResponse};
 use near_o11y::{handler_debug_span, OpenTelemetrySpanExt, WithSpanContext};
 use near_performance_metrics_macros::perf;
 use near_primitives::hash::CryptoHash;
-use near_store::ShardUId;
+use near_primitives::state_part::PartId;
+use near_primitives::state_sync::StatePartKey;
+use near_primitives::types::ShardId;
+use near_store::DBCol;
+
+use near_chain::chain::{ApplyStatePartsRequest, ApplyStatePartsResponse};
 use tracing::{debug, info, warn};
 
 /// Message channels
 #[allow(dead_code)]
 struct MessageSenders {
     /// Used to send messages to client
-    client_adapter: Sender<ClientSyncMessage>,
+    client_adapter: Sender<ApplyStatePartsResponse>,
     /// Used to send messages to peer manager
     network_adapter: Sender<PeerManagerMessageRequest>,
 }
@@ -20,7 +25,7 @@ struct MessageSenders {
 #[allow(dead_code)]
 pub struct SyncActor {
     /// Shard being synced
-    shard_uid: ShardUId,
+    shard_id: ShardId,
     /// Hash of the state that is downloaded
     sync_hash: CryptoHash,
     /// Channels used to communicate with other actors
@@ -29,12 +34,12 @@ pub struct SyncActor {
 
 impl SyncActor {
     pub fn new(
-        shard_uid: ShardUId,
-        client_adapter: Sender<ClientSyncMessage>,
+        shard_id: ShardId,
+        client_adapter: Sender<ApplyStatePartsResponse>,
         network_adapter: Sender<PeerManagerMessageRequest>,
     ) -> Self {
         Self {
-            shard_uid,
+            shard_id,
             sync_hash: CryptoHash::new(),
             senders: MessageSenders { client_adapter, network_adapter },
         }
@@ -42,10 +47,10 @@ impl SyncActor {
 
     fn handle_client_sync_message(&mut self, msg: ClientSyncMessage) {
         match msg {
-            ClientSyncMessage::StartSync(SyncShardInfo { sync_hash, shard_uid }) => {
-                assert_eq!(shard_uid, self.shard_uid, "Message is not for this shard SyncActor");
+            ClientSyncMessage::StartSync(SyncShardInfo { sync_hash, shard_id }) => {
+                assert_eq!(shard_id, self.shard_id, "Message is not for this shard SyncActor");
                 // Start syncing the shard.
-                info!(target: "sync", shard_id = ?self.shard_uid.shard_id, "Startgin sync on shard");
+                info!(target: "sync", shard_id = ?self.shard_id, "Startgin sync on shard");
                 // TODO: Add logic to commence state sync.
                 self.sync_hash = sync_hash;
             }
@@ -58,12 +63,49 @@ impl SyncActor {
     fn handle_network_sync_message(&mut self, msg: StateSyncResponse) {
         match msg {
             StateSyncResponse::HeaderResponse => {
-                debug!(target: "sync", shard_id = ?self.shard_uid.shard_id, "Got header response");
+                debug!(target: "sync", shard_id = ?self.shard_id, "Got header response");
             }
             StateSyncResponse::PartResponse => {
                 warn!(target: "sync", "Unsupported message received by SyncActor: SyncDone.");
             }
         }
+    }
+
+    /// Clears flat storage before applying state parts.
+    /// Returns whether the flat storage state was cleared.
+    fn clear_flat_state(
+        &mut self,
+        msg: &ApplyStatePartsRequest,
+    ) -> Result<bool, near_chain_primitives::error::Error> {
+        let _span = tracing::debug_span!(target: "client", "clear_flat_state").entered();
+        Ok(msg
+            .runtime_adapter
+            .get_flat_storage_manager()
+            .remove_flat_storage_for_shard(msg.shard_uid)?)
+    }
+
+    fn apply_parts(
+        &mut self,
+        msg: &ApplyStatePartsRequest,
+    ) -> Result<(), near_chain_primitives::error::Error> {
+        let _span = tracing::debug_span!(target: "client", "apply_parts").entered();
+        let store = msg.runtime_adapter.store();
+
+        let shard_id = msg.shard_uid.shard_id as ShardId;
+        for part_id in 0..msg.num_parts {
+            let key = borsh::to_vec(&StatePartKey(msg.sync_hash, shard_id, part_id))?;
+            let part = store.get(DBCol::StateParts, &key)?.unwrap();
+
+            msg.runtime_adapter.apply_state_part(
+                shard_id,
+                &msg.state_root,
+                PartId::new(part_id, msg.num_parts),
+                &part,
+                &msg.epoch_id,
+            )?;
+        }
+
+        Ok(())
     }
 }
 
@@ -72,11 +114,11 @@ impl actix::Actor for SyncActor {
     type Context = actix::Context<Self>;
 
     fn started(&mut self, _ctx: &mut Self::Context) {
-        info!(target: "sync", shard_id = ?self.shard_uid.shard_id, "Sync actor started.");
+        info!(target: "sync", shard_id = ?self.shard_id, "Sync actor started.");
     }
 
     fn stopped(&mut self, _ctx: &mut Self::Context) {
-        info!(target: "sync", shard_id = ?self.shard_uid.shard_id, "Sync actor stopped.");
+        info!(target: "sync", shard_id = ?self.shard_id, "Sync actor stopped.");
     }
 }
 
@@ -105,5 +147,41 @@ impl actix::Handler<WithSpanContext<StateSyncResponse>> for SyncActor {
     ) -> Self::Result {
         let (_span, msg) = handler_debug_span!(target: "sync", msg);
         self.handle_network_sync_message(msg);
+    }
+}
+
+impl actix::Handler<WithSpanContext<ApplyStatePartsRequest>> for SyncActor {
+    type Result = ();
+    #[perf]
+    fn handle(
+        &mut self,
+        msg: WithSpanContext<ApplyStatePartsRequest>,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        let (_span, msg) = handler_debug_span!(target: "sync", msg);
+        let shard_id = msg.shard_uid.shard_id as ShardId;
+        match self.clear_flat_state(&msg) {
+            Err(err) => {
+                self.senders.client_adapter.send(ApplyStatePartsResponse {
+                    apply_result: Err(err),
+                    shard_id,
+                    sync_hash: msg.sync_hash,
+                });
+                return;
+            }
+            Ok(false) => {
+                // Can't panic here, because that breaks many KvRuntime tests.
+                tracing::error!(target: "client", shard_uid = ?msg.shard_uid, "Failed to delete Flat State, but proceeding with applying state parts.");
+            }
+            Ok(true) => {
+                tracing::debug!(target: "client", shard_uid = ?msg.shard_uid, "Deleted all Flat State");
+            }
+        }
+        let result = self.apply_parts(&msg);
+        self.senders.client_adapter.send(ApplyStatePartsResponse {
+            apply_result: result,
+            shard_id,
+            sync_hash: msg.sync_hash,
+        });
     }
 }

--- a/chain/client/src/sync/sync_actor.rs
+++ b/chain/client/src/sync/sync_actor.rs
@@ -1,5 +1,6 @@
 use super::adapter::{SyncMessage as ClientSyncMessage, SyncShardInfo};
 use near_async::messaging::Sender;
+use near_chain::chain::{ApplyStatePartsRequest, ApplyStatePartsResponse};
 use near_network::types::{PeerManagerMessageRequest, StateSyncResponse};
 use near_o11y::{handler_debug_span, OpenTelemetrySpanExt, WithSpanContext};
 use near_performance_metrics_macros::perf;
@@ -8,8 +9,6 @@ use near_primitives::state_part::PartId;
 use near_primitives::state_sync::StatePartKey;
 use near_primitives::types::ShardId;
 use near_store::DBCol;
-
-use near_chain::chain::{ApplyStatePartsRequest, ApplyStatePartsResponse};
 use tracing::{debug, info, warn};
 
 /// Message channels
@@ -171,6 +170,7 @@ impl actix::Handler<WithSpanContext<ApplyStatePartsRequest>> for SyncActor {
             }
             Ok(false) => {
                 // Can't panic here, because that breaks many KvRuntime tests.
+                // TODO: figure out how to fix things so that we can panic here
                 tracing::error!(target: "client", shard_uid = ?msg.shard_uid, "Failed to delete Flat State, but proceeding with applying state parts.");
             }
             Ok(true) => {

--- a/chain/client/src/sync_jobs_actor.rs
+++ b/chain/client/src/sync_jobs_actor.rs
@@ -1,18 +1,11 @@
 use crate::ClientActor;
 use actix::AsyncContext;
 
-use near_chain::chain::{
-    do_apply_chunks, ApplyStatePartsRequest, ApplyStatePartsResponse, BlockCatchUpRequest,
-    BlockCatchUpResponse,
-};
+use near_chain::chain::{do_apply_chunks, BlockCatchUpRequest, BlockCatchUpResponse};
 use near_chain::resharding::StateSplitRequest;
 use near_chain::Chain;
 use near_o11y::{handler_debug_span, OpenTelemetrySpanExt, WithSpanContext, WithSpanContextExt};
 use near_performance_metrics_macros::perf;
-use near_primitives::state_part::PartId;
-use near_primitives::state_sync::StatePartKey;
-use near_primitives::types::ShardId;
-use near_store::DBCol;
 use std::time::Duration;
 
 const RESHARDING_RETRY_TIME: Duration = Duration::from_secs(30);
@@ -43,87 +36,10 @@ where
 
 impl SyncJobsActor {
     pub(crate) const MAILBOX_CAPACITY: usize = 100;
-
-    fn apply_parts(
-        &mut self,
-        msg: &ApplyStatePartsRequest,
-    ) -> Result<(), near_chain_primitives::error::Error> {
-        let _span = tracing::debug_span!(target: "client", "apply_parts").entered();
-        let store = msg.runtime_adapter.store();
-
-        let shard_id = msg.shard_uid.shard_id as ShardId;
-        for part_id in 0..msg.num_parts {
-            let key = borsh::to_vec(&StatePartKey(msg.sync_hash, shard_id, part_id))?;
-            let part = store.get(DBCol::StateParts, &key)?.unwrap();
-
-            msg.runtime_adapter.apply_state_part(
-                shard_id,
-                &msg.state_root,
-                PartId::new(part_id, msg.num_parts),
-                &part,
-                &msg.epoch_id,
-            )?;
-        }
-
-        Ok(())
-    }
-
-    /// Clears flat storage before applying state parts.
-    /// Returns whether the flat storage state was cleared.
-    fn clear_flat_state(
-        &mut self,
-        msg: &ApplyStatePartsRequest,
-    ) -> Result<bool, near_chain_primitives::error::Error> {
-        let _span = tracing::debug_span!(target: "client", "clear_flat_state").entered();
-        Ok(msg
-            .runtime_adapter
-            .get_flat_storage_manager()
-            .remove_flat_storage_for_shard(msg.shard_uid)?)
-    }
 }
 
 impl actix::Actor for SyncJobsActor {
     type Context = actix::Context<Self>;
-}
-
-impl actix::Handler<WithSpanContext<ApplyStatePartsRequest>> for SyncJobsActor {
-    type Result = ();
-
-    #[perf]
-    fn handle(
-        &mut self,
-        msg: WithSpanContext<ApplyStatePartsRequest>,
-        _: &mut Self::Context,
-    ) -> Self::Result {
-        let (_span, msg) = handler_debug_span!(target: "client", msg);
-        let shard_id = msg.shard_uid.shard_id as ShardId;
-        match self.clear_flat_state(&msg) {
-            Err(err) => {
-                self.client_addr.do_send(
-                    ApplyStatePartsResponse {
-                        apply_result: Err(err),
-                        shard_id,
-                        sync_hash: msg.sync_hash,
-                    }
-                    .with_span_context(),
-                );
-                return;
-            }
-            Ok(false) => {
-                // Can't panic here, because that breaks many KvRuntime tests.
-                tracing::error!(target: "client", shard_uid = ?msg.shard_uid, "Failed to delete Flat State, but proceeding with applying state parts.");
-            }
-            Ok(true) => {
-                tracing::debug!(target: "client", shard_uid = ?msg.shard_uid, "Deleted all Flat State");
-            }
-        }
-
-        let result = self.apply_parts(&msg);
-        self.client_addr.do_send(
-            ApplyStatePartsResponse { apply_result: result, shard_id, sync_hash: msg.sync_hash }
-                .with_span_context(),
-        );
-    }
 }
 
 impl actix::Handler<WithSpanContext<BlockCatchUpRequest>> for SyncJobsActor {

--- a/chain/network/src/state_sync.rs
+++ b/chain/network/src/state_sync.rs
@@ -1,4 +1,4 @@
-use near_store::ShardUId;
+use near_primitives::types::ShardId;
 
 /// State sync response from peers.
 #[derive(actix::Message, Debug)]
@@ -13,5 +13,5 @@ pub enum StateSyncResponse {
 /// actors.
 #[async_trait::async_trait]
 pub trait StateSync: Send + Sync + 'static {
-    async fn send(&mut self, shard_uid: ShardUId, msg: StateSyncResponse);
+    async fn send(&mut self, shard_uid: ShardId, msg: StateSyncResponse);
 }

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -15,9 +15,7 @@ use near_async::time;
 use near_chain::state_snapshot_actor::{get_make_snapshot_callback, StateSnapshotActor};
 use near_chain::types::RuntimeAdapter;
 use near_chain::{Chain, ChainGenesis};
-use near_chain_configs::SyncConfig;
 use near_chunks::shards_manager_actor::start_shards_manager;
-use near_client::sync::adapter::SyncAdapter;
 use near_client::{start_client, start_view_client, ClientActor, ConfigUpdater, ViewClientActor};
 use near_epoch_manager::shard_tracker::{ShardTracker, TrackedConfig};
 use near_epoch_manager::EpochManager;
@@ -289,18 +287,6 @@ pub fn start_with_config_and_synchronization(
         hash: *genesis_block.header().hash(),
     };
 
-    // State Sync actors
-    let client_adapter_for_sync = Arc::new(LateBoundSender::default());
-    let network_adapter_for_sync = Arc::new(LateBoundSender::default());
-    let _sync_adapter = Arc::new(if let SyncConfig::Peers = config.client_config.state_sync.sync {
-        Some(SyncAdapter::new(
-            client_adapter_for_sync.as_sender(),
-            network_adapter_for_sync.as_sender(),
-        ))
-    } else {
-        None
-    });
-
     let node_id = config.network_config.node_id();
     let network_adapter = Arc::new(LateBoundSender::default());
     let shards_manager_adapter = Arc::new(LateBoundSender::default());
@@ -343,9 +329,6 @@ pub fn start_with_config_and_synchronization(
         adv,
         config_updater,
     );
-    if let SyncConfig::Peers = config.client_config.state_sync.sync {
-        client_adapter_for_sync.bind(client_actor.clone().with_auto_span_context())
-    };
     client_adapter_for_shards_manager.bind(client_actor.clone().with_auto_span_context());
     let (shards_manager_actor, shards_manager_arbiter_handle) = start_shards_manager(
         epoch_manager.clone(),
@@ -387,9 +370,6 @@ pub fn start_with_config_and_synchronization(
     )
     .context("PeerManager::spawn()")?;
     network_adapter.bind(network_actor.clone().with_auto_span_context());
-    if let SyncConfig::Peers = config.client_config.state_sync.sync {
-        network_adapter_for_sync.bind(network_actor.clone().with_auto_span_context())
-    }
     #[cfg(feature = "json_rpc")]
     if let Some(rpc_config) = config.rpc_config {
         let entity_debug_handler = EntityDebugHandlerImpl {


### PR DESCRIPTION
This is the first step in moving the state sync logic to model where one thread per shard will be started. Here we move the part application logic from `SyncJobsActor` to the `SyncActor` added in https://github.com/near/nearcore/pull/9669. This means that the core of the logic is still in the client actor, but the requests to apply parts will be sent to different threads running these `SyncActor`s.

In an ideal world, we'll be able to separate out more of the logic so that each of these actors can interact with the network layer, taking responsibility for downloading/requesting the parts themselves, but for now this PR will just take the first step towards that and set things up.

Also we make a few changes to the scaffolding added in https://github.com/near/nearcore/pull/9669 to make things easier/more direct.
 * don't initialize the `SyncArbiter` in `nearcore::start_with_config()` like all the others, but instead just make it a field in the `ClientActor`, since its logic has no need to run separately in another thread or something. It's just managing the threads that the `ClientActor` knows how to start (how many, when to start them, etc). that means we don't need to store the client and network actors in that struct.

 * change `ShardUId` to `ShardId` throughout just to make things a little easier, since it shouldn't be incorrect. If there's a change in shard layout version, we can still just send requests to actors by shard ID