### PR TITLE
use a larger test runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,9 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04-8core
+          - os: ubuntu-22.04-16core
             flags: ""
-          - os: ubuntu-22.04-8core
+          - os: ubuntu-22.04-16core
             flags: "--features nightly,test_features"
           - os: macos-latest-xlarge
             # FIXME: some of these tests don't work very well on MacOS at the moment. Should fix


### PR DESCRIPTION
Minute pricing scales linearly with the number of core. Considering I also expect a roughly linear scaling of test duration with the number of cores (currently ~24minutes, would hopefully get down to ~10-15 minutes with a larger runner), the total cost should not change significantly, while test latency should go significantly down.

Currently our org only supports up to 16 cores, if scaling was indeed linear I’ll see to request a 32-core runner and see whether we can still get roughly linear speedup. I don’t expect a 64-core runner to still provide significant improvements, as we definitely have minutes-long tests anyway.