### PR TITLE
feat(mocknet): change HTTP request logic

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -828,7 +828,7 @@ class NeardRunner:
         # something so lightweight
         main_loop = threading.Thread(target=self.main_loop)
         main_loop.start()
-        s = RpcServer(('0.0.0.0', port), self)
+        s = RpcServer(('localhost', port), self)
         s.serve_forever()
 
 

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -828,6 +828,9 @@ class NeardRunner:
         # something so lightweight
         main_loop = threading.Thread(target=self.main_loop)
         main_loop.start()
+        # this will listen only on the loopback interface and won't be accessible
+        # over the internet. If connecting to another machine, we can SSH and then make
+        # the request locally
         s = RpcServer(('localhost', port), self)
         s.serve_forever()
 

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -336,6 +336,10 @@ def neard_runner_jsonrpc(node, method, params=[]):
         'jsonrpc': '2.0'
     }
     body = json.dumps(body)
+    # '"'"' will be interpreted as ending the first quote and then concatenating it with "'",
+    # followed by a new quote started with ' and the rest of the string, to get any single quotes
+    # in method or params into the command correctly
+    body = body.replace("'", "'\"'\"'")
     r = run_cmd(node, f'curl localhost:3000 -d \'{body}\'')
     response = json.loads(r.stdout)
     if 'error' in response:


### PR DESCRIPTION
We'll change things to bind to "localhost" instead of "0.0.0.0", and make HTTP requests by SSH + curl on the remote server. It's also possible to set up an explicit SSH/SOCKS proxy, but that would require one for each server and would be long-lived, which might be a bit annoying for people running the test scripts