### PR TITLE
feat(state-sync): Pass sync adapter to network

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1059,8 +1059,9 @@ impl PeerActor {
                     .await?
                     .map(PeerMessage::VersionedStateResponse),
                 PeerMessage::VersionedStateResponse(info) => {
-                        //TODO: Route to state sync actor.
-                    network_state.client.state_response(info).await;
+                    // TODO: Stop routing this message to client once state sync actor can handle it.
+                    network_state.client.state_response(info.clone()).await;
+                    network_state.state_sync.read().expect("State sync adapter lock is poisoned.").send(info);
                     None
                 }
                 msg => {

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -9,6 +9,7 @@ use crate::peer_manager::connection;
 use crate::peer_manager::network_state::{NetworkState, WhitelistNode};
 use crate::peer_manager::peer_store;
 use crate::shards_manager::ShardsManagerRequestFromNetwork;
+use crate::state_sync;
 use crate::stats::metrics;
 use crate::store;
 use crate::tcp;
@@ -37,6 +38,7 @@ use std::cmp::min;
 use std::collections::HashSet;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::sync::RwLock;
 use tracing::Instrument as _;
 
 /// Ratio between consecutive attempts to establish connection with another peer.
@@ -202,6 +204,7 @@ impl PeerManagerActor {
         store: Arc<dyn near_store::db::Database>,
         config: config::NetworkConfig,
         client: Arc<dyn client::Client>,
+        state_sync: Arc<RwLock<dyn state_sync::StateSync>>,
         shards_manager_adapter: Sender<ShardsManagerRequestFromNetwork>,
         genesis_id: GenesisId,
     ) -> anyhow::Result<actix::Addr<Self>> {
@@ -232,6 +235,7 @@ impl PeerManagerActor {
             config,
             genesis_id,
             client,
+            state_sync,
             shards_manager_adapter,
             whitelist_nodes,
         ));

--- a/chain/network/src/state_sync.rs
+++ b/chain/network/src/state_sync.rs
@@ -1,17 +1,12 @@
-use near_store::ShardUId;
+use crate::network_protocol::StateResponseInfo;
 
-/// State sync response from peers.
-#[derive(actix::Message, Debug)]
-#[rtype(result = "()")]
-pub enum StateSyncResponse {
-    HeaderResponse,
-    PartResponse,
+/// State sync interface for network.
+/// The implementation uses try_send to avoid blocking.
+pub trait StateSync: Send + Sync + 'static {
+    fn send(&self, info: StateResponseInfo);
 }
 
-/// A strongly typed asynchronous API for the State Sync logic
-/// It abstracts away the fact that it is implemented using actix
-/// actors.
-#[async_trait::async_trait]
-pub trait StateSync: Send + Sync + 'static {
-    async fn send(&self, shard_uid: ShardUId, msg: StateSyncResponse);
+pub struct Noop;
+impl StateSync for Noop {
+    fn send(&self, _info: StateResponseInfo) {}
 }

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -10,7 +10,7 @@ pub use crate::network_protocol::{
     StateResponseInfoV1, StateResponseInfoV2,
 };
 use crate::routing::routing_table_view::RoutingTableInfo;
-pub use crate::state_sync::{StateSync, StateSyncResponse};
+pub use crate::state_sync::StateSync;
 use near_async::messaging::{
     AsyncSender, CanSend, CanSendAsync, IntoAsyncSender, IntoSender, Sender,
 };

--- a/integration-tests/src/tests/network/peer_handshake.rs
+++ b/integration-tests/src/tests/network/peer_handshake.rs
@@ -23,19 +23,24 @@ fn make_peer_manager(
     boot_nodes: Vec<(&str, std::net::SocketAddr)>,
     peer_max_count: u32,
 ) -> actix::Addr<PeerManagerActor> {
+    use std::sync::RwLock;
+
     use near_async::messaging::Sender;
+    use near_network::state_sync::Noop;
 
     let mut config = config::NetworkConfig::from_seed(seed, node_addr);
     config.peer_store.boot_nodes = convert_boot_nodes(boot_nodes);
     config.max_num_peers = peer_max_count;
     config.ideal_connections_hi = peer_max_count;
     config.ideal_connections_lo = peer_max_count;
+    let state_sync = Arc::new(RwLock::new(Noop));
 
     PeerManagerActor::spawn(
         time::Clock::real(),
         near_store::db::TestDB::new(),
         config,
         Arc::new(near_network::client::Noop),
+        state_sync,
         Sender::noop(),
         GenesisId::default(),
     )

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -82,7 +82,7 @@ fn setup_network_node(
         shard_tracker.clone(),
         runtime.clone(),
         config.node_id(),
-        state_sync_adapter,
+        state_sync_adapter.clone(),
         network_adapter.clone().into(),
         shards_manager_adapter.as_sender(),
         Some(signer.clone()),
@@ -118,6 +118,7 @@ fn setup_network_node(
         db.clone(),
         config,
         Arc::new(near_client::adapter::Adapter::new(client_actor, view_client_actor)),
+        state_sync_adapter,
         shards_manager_adapter.as_sender(),
         genesis_id,
     )

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -331,7 +331,7 @@ pub fn start_with_config_and_synchronization(
         shard_tracker.clone(),
         runtime.clone(),
         node_id,
-        sync_adapter,
+        sync_adapter.clone(),
         network_adapter.clone().into(),
         shards_manager_adapter.as_sender(),
         config.validator_signer.clone(),
@@ -380,6 +380,7 @@ pub fn start_with_config_and_synchronization(
         storage.into_inner(near_store::Temperature::Hot),
         config.network_config,
         Arc::new(near_client::adapter::Adapter::new(client_actor.clone(), view_client.clone())),
+        sync_adapter,
         shards_manager_adapter.as_sender(),
         genesis_id,
     )


### PR DESCRIPTION
Pass message to state sync actor and client actor. 
Once we move the request logic to sync actor, we can stop sending the response to the client actor.