### PR TITLE
Add metrics comparing the V1 and V2 routing protocols

### DIFF
--- a/chain/network/src/routing/graph_v2/mod.rs
+++ b/chain/network/src/routing/graph_v2/mod.rs
@@ -723,7 +723,7 @@ impl GraphV2 {
                 let (next_hops, to_broadcast) =
                     inner.compute_routes(&clock, &this.unreliable_peers.load());
 
-                this.routing_table.update(next_hops.into());
+                this.routing_table.update(next_hops.into(), Arc::new(inner.my_distances.clone()));
 
                 inner.log_state();
 

--- a/chain/network/src/routing/mod.rs
+++ b/chain/network/src/routing/mod.rs
@@ -6,5 +6,5 @@ mod graph_v2;
 pub(crate) mod route_back_cache;
 pub mod routing_table_view;
 
-pub(crate) use graph::{Graph, GraphConfig, NextHopTable};
+pub(crate) use graph::{DistanceTable, Graph, GraphConfig, NextHopTable};
 pub(crate) use graph_v2::{GraphConfigV2, GraphV2, NetworkTopologyChange};

--- a/chain/network/src/routing/routing_table_view/tests.rs
+++ b/chain/network/src/routing/routing_table_view/tests.rs
@@ -20,7 +20,7 @@ fn find_route() {
 
     // Check that RoutingTableView always selects a valid next hop.
     let rtv = RoutingTableView::new();
-    rtv.update(next_hops.clone());
+    rtv.update(next_hops.clone(), Default::default());
     for _ in 0..1000 {
         let p = peers.choose(rng).unwrap();
         let got = rtv.find_next_hop_for_target(&p).unwrap();

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -363,6 +363,18 @@ pub(crate) static ACCOUNT_TO_PEER_LOOKUPS: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub(crate) static NETWORK_ROUTED_MSG_DISTANCES: Lazy<IntCounterVec> = Lazy::new(|| {
+    try_create_int_counter_vec(
+        "near_network_routed_msg_distances",
+        "compares routing distance by protocol (V1 vs V2)",
+        // Compares the routing distances for the V1 and V2 routing protocols.
+        // We are currently running both while validating performance of V2.
+        // Eventually we want to deprecate V1 and run only V2.
+        &["cmp"],
+    )
+    .unwrap()
+});
+
 /// Updated the prometheus metrics about the received routed message `msg`.
 /// `tier` indicates the network over which the message was transmitted.
 /// `fastest` indicates whether this message is the first copy of `msg` received -


### PR DESCRIPTION
Generally, we expect both routing protocols to achieve the exact same distances. Collecting these metrics will help us further validate the performance of the V2 protocol as we prepare to deprecate V1.