### PR TITLE
[important fix] DB Migration for TrieRefcountAddition/Subtraction.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,8 +725,9 @@ dependencies = [
 
 [[package]]
 name = "bolero"
-version = "0.9.0"
-source = "git+https://github.com/camshaft/bolero?rev=7d955a67fbd06f61ffaf28178e976280c33c045a#7d955a67fbd06f61ffaf28178e976280c33c045a"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9fec67acd9afcd579067cc506c537da49751b8b81c98d5a5e15ba1e853aa3c"
 dependencies = [
  "bolero-afl",
  "bolero-engine",
@@ -740,8 +741,9 @@ dependencies = [
 
 [[package]]
 name = "bolero-afl"
-version = "0.9.0"
-source = "git+https://github.com/camshaft/bolero?rev=7d955a67fbd06f61ffaf28178e976280c33c045a#7d955a67fbd06f61ffaf28178e976280c33c045a"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b34f05de1527425bb05287da09ff1ff1612538648824db49e16d9693b24065"
 dependencies = [
  "bolero-engine",
  "cc",
@@ -749,8 +751,9 @@ dependencies = [
 
 [[package]]
 name = "bolero-engine"
-version = "0.9.1"
-source = "git+https://github.com/camshaft/bolero?rev=7d955a67fbd06f61ffaf28178e976280c33c045a#7d955a67fbd06f61ffaf28178e976280c33c045a"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ddcfa4c2aa7d57b1785c6e258f612e74c96afa078300d0f811dee73592d7ca"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -762,8 +765,9 @@ dependencies = [
 
 [[package]]
 name = "bolero-generator"
-version = "0.9.1"
-source = "git+https://github.com/camshaft/bolero?rev=7d955a67fbd06f61ffaf28178e976280c33c045a#7d955a67fbd06f61ffaf28178e976280c33c045a"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8efabd99549391e8b372e8afe566e8236ca4be6be379c1b6bf81b027c472fe7"
 dependencies = [
  "arbitrary",
  "bolero-generator-derive",
@@ -773,8 +777,9 @@ dependencies = [
 
 [[package]]
 name = "bolero-generator-derive"
-version = "0.9.2"
-source = "git+https://github.com/camshaft/bolero?rev=7d955a67fbd06f61ffaf28178e976280c33c045a#7d955a67fbd06f61ffaf28178e976280c33c045a"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53397bfda19ccb48527faa14025048fc4bb76f090ccdeef1e5a355bfe4a94467"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -784,24 +789,27 @@ dependencies = [
 
 [[package]]
 name = "bolero-honggfuzz"
-version = "0.9.0"
-source = "git+https://github.com/camshaft/bolero?rev=7d955a67fbd06f61ffaf28178e976280c33c045a#7d955a67fbd06f61ffaf28178e976280c33c045a"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf78581db1a7263620a8767e645b93ad287c70122ae76f5bd67040c7f06ff8e3"
 dependencies = [
  "bolero-engine",
 ]
 
 [[package]]
 name = "bolero-kani"
-version = "0.9.0"
-source = "git+https://github.com/camshaft/bolero?rev=7d955a67fbd06f61ffaf28178e976280c33c045a#7d955a67fbd06f61ffaf28178e976280c33c045a"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e55cec272a617f5ae4ce670db035108eb97c10cd4f67de851a3c8d3f18f19cb"
 dependencies = [
  "bolero-engine",
 ]
 
 [[package]]
 name = "bolero-libfuzzer"
-version = "0.9.0"
-source = "git+https://github.com/camshaft/bolero?rev=7d955a67fbd06f61ffaf28178e976280c33c045a#7d955a67fbd06f61ffaf28178e976280c33c045a"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb42f66ee3ec89b9c411994de59d4710ced19df96fea2059feea1c2d73904c5b"
 dependencies = [
  "bolero-engine",
  "cc",

--- a/core/store/src/metadata.rs
+++ b/core/store/src/metadata.rs
@@ -2,7 +2,7 @@
 pub type DbVersion = u32;
 
 /// Current version of the database.
-pub const DB_VERSION: DbVersion = 38;
+pub const DB_VERSION: DbVersion = 39;
 
 /// Database version at which point DbKind was introduced.
 const DB_VERSION_WITH_KIND: DbVersion = 34;

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -369,12 +369,12 @@ pub trait TrieAccess {
 pub struct TrieRefcountAddition {
     /// Hash of trie_node_or_value and part of the DB key.
     /// Used for uniting with shard id to get actual DB key.
-    trie_node_or_value_hash: CryptoHash,
+    pub(crate) trie_node_or_value_hash: CryptoHash,
     /// DB value. Can be either serialized RawTrieNodeWithSize or value corresponding to
     /// some TrieKey.
-    trie_node_or_value: Vec<u8>,
+    pub(crate) trie_node_or_value: Vec<u8>,
     /// Reference count difference which will be added to the total refcount.
-    rc: std::num::NonZeroU32,
+    pub(crate) rc: std::num::NonZeroU32,
 }
 
 /// Stores reference count subtraction for some key in DB.
@@ -382,9 +382,9 @@ pub struct TrieRefcountAddition {
 pub struct TrieRefcountSubtraction {
     /// Hash of trie_node_or_value and part of the DB key.
     /// Used for uniting with shard id to get actual DB key.
-    trie_node_or_value_hash: CryptoHash,
+    pub(crate) trie_node_or_value_hash: CryptoHash,
     /// Reference count difference which will be subtracted to the total refcount.
-    rc: std::num::NonZeroU32,
+    pub(crate) rc: std::num::NonZeroU32,
 }
 
 impl TrieRefcountAddition {
@@ -477,8 +477,8 @@ impl TrieRefcountDeltaMap {
 pub struct TrieChanges {
     pub old_root: StateRoot,
     pub new_root: StateRoot,
-    insertions: Vec<TrieRefcountAddition>,
-    deletions: Vec<TrieRefcountSubtraction>,
+    pub(crate) insertions: Vec<TrieRefcountAddition>,
+    pub(crate) deletions: Vec<TrieRefcountSubtraction>,
 }
 
 impl TrieChanges {

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -115,6 +115,7 @@ impl<'a> near_store::StoreMigrator for Migrator<'a> {
             }
             36 => near_store::migrations::migrate_36_to_37(store),
             37 => near_store::migrations::migrate_37_to_38(store),
+            38 => near_store::migrations::migrate_38_to_39(store),
             DB_VERSION.. => unreachable!(),
         }
     }


### PR DESCRIPTION
Previous change, #10006 , introduced DB incompatibility because TrieChanges, which includes the changed structures, are serialized to disk. This PR implements a DB migration to fix that.