### PR TITLE
use larger runner for fuzzer binary builder

### DIFF
--- a/.github/workflows/master_fuzzer_binaries.yml
+++ b/.github/workflows/master_fuzzer_binaries.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build_fuzzers:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04-16core"
 
     permissions:
       contents: "read"


### PR DESCRIPTION
This should fix eg. https://github.com/near/nearcore/actions/runs/6723034524/job/18272218040, that failed due, AFAICT, to out of disk space. Hopefully with this bigger builder, we should not run out of disk space any longer. And rust compilation is pretty well-parallelized anyway, so the cost should not be significantly higher.