### PR TITLE
feat(resharding): label metrics with the parent shard uid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,8 +725,9 @@ dependencies = [
 
 [[package]]
 name = "bolero"
-version = "0.9.0"
-source = "git+https://github.com/camshaft/bolero?rev=7d955a67fbd06f61ffaf28178e976280c33c045a#7d955a67fbd06f61ffaf28178e976280c33c045a"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9fec67acd9afcd579067cc506c537da49751b8b81c98d5a5e15ba1e853aa3c"
 dependencies = [
  "bolero-afl",
  "bolero-engine",
@@ -740,8 +741,9 @@ dependencies = [
 
 [[package]]
 name = "bolero-afl"
-version = "0.9.0"
-source = "git+https://github.com/camshaft/bolero?rev=7d955a67fbd06f61ffaf28178e976280c33c045a#7d955a67fbd06f61ffaf28178e976280c33c045a"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b34f05de1527425bb05287da09ff1ff1612538648824db49e16d9693b24065"
 dependencies = [
  "bolero-engine",
  "cc",
@@ -749,8 +751,9 @@ dependencies = [
 
 [[package]]
 name = "bolero-engine"
-version = "0.9.1"
-source = "git+https://github.com/camshaft/bolero?rev=7d955a67fbd06f61ffaf28178e976280c33c045a#7d955a67fbd06f61ffaf28178e976280c33c045a"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ddcfa4c2aa7d57b1785c6e258f612e74c96afa078300d0f811dee73592d7ca"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -762,8 +765,9 @@ dependencies = [
 
 [[package]]
 name = "bolero-generator"
-version = "0.9.1"
-source = "git+https://github.com/camshaft/bolero?rev=7d955a67fbd06f61ffaf28178e976280c33c045a#7d955a67fbd06f61ffaf28178e976280c33c045a"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8efabd99549391e8b372e8afe566e8236ca4be6be379c1b6bf81b027c472fe7"
 dependencies = [
  "arbitrary",
  "bolero-generator-derive",
@@ -773,8 +777,9 @@ dependencies = [
 
 [[package]]
 name = "bolero-generator-derive"
-version = "0.9.2"
-source = "git+https://github.com/camshaft/bolero?rev=7d955a67fbd06f61ffaf28178e976280c33c045a#7d955a67fbd06f61ffaf28178e976280c33c045a"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53397bfda19ccb48527faa14025048fc4bb76f090ccdeef1e5a355bfe4a94467"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -784,24 +789,27 @@ dependencies = [
 
 [[package]]
 name = "bolero-honggfuzz"
-version = "0.9.0"
-source = "git+https://github.com/camshaft/bolero?rev=7d955a67fbd06f61ffaf28178e976280c33c045a#7d955a67fbd06f61ffaf28178e976280c33c045a"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf78581db1a7263620a8767e645b93ad287c70122ae76f5bd67040c7f06ff8e3"
 dependencies = [
  "bolero-engine",
 ]
 
 [[package]]
 name = "bolero-kani"
-version = "0.9.0"
-source = "git+https://github.com/camshaft/bolero?rev=7d955a67fbd06f61ffaf28178e976280c33c045a#7d955a67fbd06f61ffaf28178e976280c33c045a"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e55cec272a617f5ae4ce670db035108eb97c10cd4f67de851a3c8d3f18f19cb"
 dependencies = [
  "bolero-engine",
 ]
 
 [[package]]
 name = "bolero-libfuzzer"
-version = "0.9.0"
-source = "git+https://github.com/camshaft/bolero?rev=7d955a67fbd06f61ffaf28178e976280c33c045a#7d955a67fbd06f61ffaf28178e976280c33c045a"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb42f66ee3ec89b9c411994de59d4710ced19df96fea2059feea1c2d73904c5b"
 dependencies = [
  "bolero-engine",
  "cc",

--- a/chain/chain/src/resharding.rs
+++ b/chain/chain/src/resharding.rs
@@ -396,7 +396,6 @@ impl Chain {
         }
         chain_store_update.commit()?;
 
-        tracing::info!(?shard_uid, ?child_shard_uids, "boom");
         RESHARDING_STATUS
             .with_label_values(&[&shard_uid.to_string()])
             .set(ReshardingStatus::Finished.into());

--- a/chain/chain/src/resharding.rs
+++ b/chain/chain/src/resharding.rs
@@ -197,7 +197,6 @@ impl Chain {
         let prev_block_header = self.get_block_header(prev_hash)?;
         let prev_prev_hash = prev_block_header.prev_hash();
         let state_root = *self.get_chunk_extra(&prev_hash, &shard_uid)?.state_root();
-        let child_shard_uids = next_epoch_shard_layout.get_split_shard_uids(shard_id);
 
         state_split_scheduler(StateSplitRequest {
             tries: Arc::new(self.runtime_adapter.get_tries()),
@@ -211,11 +210,9 @@ impl Chain {
             config: self.state_split_config,
         });
 
-        for shard_uid in child_shard_uids.unwrap_or_default() {
-            RESHARDING_STATUS
-                .with_label_values(&[&shard_uid.to_string()])
-                .set(ReshardingStatus::Scheduled.into());
-        }
+        RESHARDING_STATUS
+            .with_label_values(&[&shard_uid.to_string()])
+            .set(ReshardingStatus::Scheduled.into());
         Ok(())
     }
 
@@ -268,11 +265,9 @@ impl Chain {
         let mut state_roots: HashMap<_, _> =
             new_shards.iter().map(|shard_uid| (*shard_uid, Trie::EMPTY_ROOT)).collect();
 
-        for shard_uid in &new_shards {
-            RESHARDING_STATUS
-                .with_label_values(&[&shard_uid.to_string()])
-                .set(ReshardingStatus::BuildingState.into());
-        }
+        RESHARDING_STATUS
+            .with_label_values(&[&shard_uid.to_string()])
+            .set(ReshardingStatus::BuildingState.into());
 
         // Build the required iterator from flat storage and delta changes. Note that we are
         // working with iterators as we don't want to have all the state in memory at once.
@@ -382,6 +377,7 @@ impl Chain {
 
     pub fn build_state_for_split_shards_postprocessing(
         &mut self,
+        shard_uid: ShardUId,
         sync_hash: &CryptoHash,
         state_roots: HashMap<ShardUId, StateRoot>,
     ) -> Result<(), Error> {
@@ -400,11 +396,10 @@ impl Chain {
         }
         chain_store_update.commit()?;
 
-        for shard_uid in child_shard_uids {
-            RESHARDING_STATUS
-                .with_label_values(&[&shard_uid.to_string()])
-                .set(ReshardingStatus::Finished.into());
-        }
+        tracing::info!(?shard_uid, ?child_shard_uids, "boom");
+        RESHARDING_STATUS
+            .with_label_values(&[&shard_uid.to_string()])
+            .set(ReshardingStatus::Finished.into());
 
         Ok(())
     }


### PR DESCRIPTION
It actually makes sense to label metrics by parent shard uid. Otherwise the same metric value is duplicated for the children. It's because the processing also happens per parent. 