### PR TITLE
[Test] Refactor create_*_tries() and ShardTries::test_*() into TestTriesBuilder.

### DIFF
--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -7,6 +7,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use near_epoch_manager::types::BlockHeaderInfo;
 use near_epoch_manager::{EpochManagerAdapter, RngSeed};
 use near_primitives::state_part::PartId;
+use near_store::test_utils::TestTriesBuilder;
 use num_rational::Ratio;
 
 use near_chain_configs::{ProtocolConfig, DEFAULT_GC_NUM_EPOCHS_TO_KEEP};
@@ -334,7 +335,10 @@ impl KeyValueRuntime {
         let num_shards = epoch_manager.num_shards(&EpochId::default()).unwrap();
         let epoch_length =
             epoch_manager.get_epoch_config(&EpochId::default()).unwrap().epoch_length;
-        let tries = ShardTries::test(store.clone(), num_shards);
+        let tries = TestTriesBuilder::new()
+            .with_store(store.clone())
+            .with_shard_layout(0, num_shards)
+            .build();
         let mut initial_amounts = HashMap::new();
         for (i, validator_stake) in epoch_manager
             .validators_by_valset

--- a/core/store/benches/trie_bench.rs
+++ b/core/store/benches/trie_bench.rs
@@ -5,7 +5,7 @@ use bencher::Bencher;
 use rand::random;
 
 use near_primitives::shard_layout::ShardUId;
-use near_store::test_utils::create_tries;
+use near_store::test_utils::TestTriesBuilder;
 use near_store::Trie;
 
 fn rand_bytes() -> Vec<u8> {
@@ -14,7 +14,7 @@ fn rand_bytes() -> Vec<u8> {
 
 fn trie_lookup(bench: &mut Bencher) {
     let (changed_keys, trie) = {
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
 
         let trie = tries.get_trie_for_shard(ShardUId::single_shard(), Trie::EMPTY_ROOT);
         let mut changes = vec![];
@@ -42,7 +42,7 @@ fn trie_lookup(bench: &mut Bencher) {
 }
 
 fn trie_update(bench: &mut Bencher) {
-    let tries = create_tries();
+    let tries = TestTriesBuilder::new().build();
     let trie = tries.get_trie_for_shard(ShardUId::single_shard(), Trie::EMPTY_ROOT);
     let mut changes = vec![];
     for _ in 0..100 {

--- a/core/store/src/trie/iterator.rs
+++ b/core/store/src/trie/iterator.rs
@@ -432,9 +432,7 @@ mod tests {
     use rand::seq::SliceRandom;
     use rand::Rng;
 
-    use crate::test_utils::{
-        create_tries, create_tries_complex, gen_changes, simplify_changes, test_populate_trie,
-    };
+    use crate::test_utils::{gen_changes, simplify_changes, test_populate_trie, TestTriesBuilder};
     use crate::trie::iterator::IterStep;
     use crate::trie::nibble_slice::NibbleSlice;
     use crate::Trie;
@@ -449,7 +447,7 @@ mod tests {
     #[test]
     fn test_visit_interval() {
         let trie_changes = vec![(b"aa".to_vec(), Some(vec![1])), (b"abb".to_vec(), Some(vec![2]))];
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let state_root =
             test_populate_trie(&tries, &Trie::EMPTY_ROOT, ShardUId::single_shard(), trie_changes);
         let trie = tries.get_trie_for_shard(ShardUId::single_shard(), state_root);
@@ -570,7 +568,7 @@ mod tests {
         max_depth: usize,
     ) {
         let shard_uid = ShardUId::single_shard();
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let trie_changes = keys.iter().map(|key| (key.clone(), value())).collect();
         let state_root = test_populate_trie(&tries, &Trie::EMPTY_ROOT, shard_uid, trie_changes);
         let trie = tries.get_trie_for_shard(shard_uid, state_root);
@@ -613,7 +611,7 @@ mod tests {
     fn gen_random_trie(
         rng: &mut rand::rngs::ThreadRng,
     ) -> (Vec<(Vec<u8>, Option<Vec<u8>>)>, BTreeMap<Vec<u8>, Vec<u8>>, Trie) {
-        let tries = create_tries_complex(1, 2);
+        let tries = TestTriesBuilder::new().with_shard_layout(1, 2).build();
         let shard_uid = ShardUId { version: 1, shard_id: 0 };
         let trie_changes = gen_changes(rng, 10);
         let trie_changes = simplify_changes(&trie_changes);
@@ -654,7 +652,7 @@ mod tests {
     fn test_has_value() {
         let mut rng = rand::thread_rng();
         for _ in 0..100 {
-            let tries = create_tries();
+            let tries = TestTriesBuilder::new().build();
             let trie_changes = gen_changes(&mut rng, 10);
             let trie_changes = simplify_changes(&trie_changes);
             let state_root = test_populate_trie(

--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -78,7 +78,7 @@ pub fn load_trie_from_flat_state(
 #[cfg(test)]
 mod tests {
     use crate::test_utils::{
-        create_tries, simplify_changes, test_populate_flat_storage, test_populate_trie,
+        simplify_changes, test_populate_flat_storage, test_populate_trie, TestTriesBuilder,
     };
     use crate::trie::mem::loading::load_trie_from_flat_state;
     use crate::trie::mem::lookup::memtrie_lookup;
@@ -91,7 +91,7 @@ mod tests {
     use std::collections::HashSet;
 
     fn check(keys: Vec<Vec<u8>>) {
-        let shard_tries = create_tries();
+        let shard_tries = TestTriesBuilder::new().build();
         let shard_uid = ShardUId::single_shard();
         let changes = keys.iter().map(|key| (key.to_vec(), Some(key.to_vec()))).collect::<Vec<_>>();
         let changes = simplify_changes(&changes);

--- a/core/store/src/trie/mem/metrics.rs
+++ b/core/store/src/trie/mem/metrics.rs
@@ -1,5 +1,6 @@
 use near_o11y::metrics::{
-    try_create_int_counter_vec, try_create_int_gauge_vec, IntCounterVec, IntGaugeVec,
+    try_create_int_counter, try_create_int_counter_vec, try_create_int_gauge_vec, IntCounter,
+    IntCounterVec, IntGaugeVec,
 };
 use once_cell::sync::Lazy;
 
@@ -17,6 +18,14 @@ pub static MEM_TRIE_NUM_NODES_CREATED_FROM_UPDATES: Lazy<IntCounterVec> = Lazy::
         "near_mem_trie_num_nodes_created_from_updates",
         "Number of trie nodes created by applying updates",
         &["shard_uid"],
+    )
+    .unwrap()
+});
+
+pub static MEM_TRIE_NUM_LOOKUPS: Lazy<IntCounter> = Lazy::new(|| {
+    try_create_int_counter(
+        "near_mem_trie_num_lookups",
+        "Number of in-memory trie lookups (number of keys looked up)",
     )
     .unwrap()
 });

--- a/core/store/src/trie/mem/mod.rs
+++ b/core/store/src/trie/mem/mod.rs
@@ -13,7 +13,7 @@ mod construction;
 mod flexible_data;
 pub mod loading;
 pub mod lookup;
-mod metrics;
+pub mod metrics;
 pub mod node;
 pub mod updating;
 
@@ -86,7 +86,7 @@ impl MemTries {
             self.roots.entry(state_root).or_default().push(mem_root);
         }
         MEM_TRIE_NUM_ROOTS
-            .with_label_values(&[&self.shard_uid.shard_id.to_string()])
+            .with_label_values(&[&self.shard_uid.to_string()])
             .set(self.roots.len() as i64);
     }
 
@@ -131,7 +131,7 @@ impl MemTries {
             debug_assert!(false, "Deleting non-existent root: {}", state_root);
         }
         MEM_TRIE_NUM_ROOTS
-            .with_label_values(&[&self.shard_uid.shard_id.to_string()])
+            .with_label_values(&[&self.shard_uid.to_string()])
             .set(self.roots.len() as i64);
     }
 

--- a/core/store/src/trie/mem/updating.rs
+++ b/core/store/src/trie/mem/updating.rs
@@ -869,7 +869,7 @@ pub fn apply_memtrie_changes(memtries: &mut MemTries, changes: &MemTrieChanges) 
 
 #[cfg(test)]
 mod tests {
-    use crate::test_utils::create_test_store;
+    use crate::test_utils::TestTriesBuilder;
     use crate::trie::mem::lookup::memtrie_lookup;
     use crate::trie::mem::updating::apply_memtrie_changes;
     use crate::trie::mem::MemTries;
@@ -893,8 +893,7 @@ mod tests {
     impl TestTries {
         fn new(check_deleted_keys: bool) -> Self {
             let mem = MemTries::new(100 * 1024 * 1024, ShardUId::single_shard());
-            let store = create_test_store();
-            let disk = ShardTries::test(store, 1);
+            let disk = TestTriesBuilder::new().build();
             Self {
                 mem,
                 disk,

--- a/core/store/src/trie/split_state.rs
+++ b/core/store/src/trie/split_state.rs
@@ -319,7 +319,7 @@ pub fn get_delayed_receipts(
 mod tests {
     use crate::split_state::{apply_delayed_receipts_to_split_states_impl, get_delayed_receipts};
     use crate::test_utils::{
-        create_tries, gen_changes, gen_receipts, get_all_delayed_receipts, test_populate_trie,
+        gen_changes, gen_receipts, get_all_delayed_receipts, test_populate_trie, TestTriesBuilder,
     };
 
     use crate::{set, ShardTries, ShardUId, Trie};
@@ -337,7 +337,7 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         for _ in 0..20 {
-            let tries = create_tries();
+            let tries = TestTriesBuilder::new().build();
             // add 4 new shards for version 1
             let num_shards = 4;
             let mut state_root = Trie::EMPTY_ROOT;
@@ -385,7 +385,7 @@ mod tests {
             let all_receipts = gen_receipts(&mut rng, 200);
 
             // push receipt to trie
-            let tries = create_tries();
+            let tries = TestTriesBuilder::new().build();
             let mut trie_update = tries.new_trie_update(ShardUId::single_shard(), Trie::EMPTY_ROOT);
             let mut delayed_receipt_indices = DelayedReceiptIndices::default();
 
@@ -475,7 +475,7 @@ mod tests {
     fn test_apply_delayed_receipts_to_new_states() {
         let mut rng = rand::thread_rng();
 
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let num_shards = 4;
 
         for _ in 0..10 {

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -519,9 +519,7 @@ mod tests {
 
     use near_primitives::hash::{hash, CryptoHash};
 
-    use crate::test_utils::{
-        create_tries, create_tries_with_flat_storage, gen_changes, test_populate_trie,
-    };
+    use crate::test_utils::{gen_changes, test_populate_trie, TestTriesBuilder};
     use crate::trie::iterator::CrumbStatus;
     use crate::trie::{
         TrieRefcountAddition, TrieRefcountDeltaMap, TrieRefcountSubtraction, ValueHandle,
@@ -548,7 +546,7 @@ mod tests {
         // that boundaries are nontrivial.
         let num_parts = 10u64;
 
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let state_root =
             test_populate_trie(&tries, &Trie::EMPTY_ROOT, ShardUId::single_shard(), trie_changes);
         let trie = tries.get_trie_for_shard(ShardUId::single_shard(), state_root);
@@ -587,7 +585,7 @@ mod tests {
         // empty and other parts contain exactly one key.
         let num_parts = trie_changes.len() + 1;
 
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let state_root = test_populate_trie(
             &tries,
             &Trie::EMPTY_ROOT,
@@ -823,7 +821,7 @@ mod tests {
         let max_part_overhead =
             big_value_length.max(max_key_length_in_nibbles * max_node_serialized_size * 2);
         let trie_changes = gen_trie_changes(&mut rng, max_key_length, big_value_length);
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let state_root =
             test_populate_trie(&tries, &Trie::EMPTY_ROOT, ShardUId::single_shard(), trie_changes);
         let trie = tries.get_trie_for_shard(ShardUId::single_shard(), state_root);
@@ -916,7 +914,7 @@ mod tests {
     fn test_combine_state_parts() {
         let mut rng = rand::thread_rng();
         for _ in 0..2000 {
-            let tries = create_tries();
+            let tries = TestTriesBuilder::new().build();
             let trie_changes = gen_changes(&mut rng, 20);
             let state_root = test_populate_trie(
                 &tries,
@@ -1039,7 +1037,7 @@ mod tests {
     /// Doesn't use FlatStorage.
     #[test]
     fn invalid_state_parts() {
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let shard_uid = ShardUId::single_shard();
         let part_id = PartId::new(1, 2);
         let trie = tries.get_trie_for_shard(shard_uid, Trie::EMPTY_ROOT);
@@ -1114,7 +1112,7 @@ mod tests {
     fn test_get_trie_nodes_for_part() {
         let mut rng = rand::thread_rng();
         for _ in 0..20 {
-            let tries = create_tries();
+            let tries = TestTriesBuilder::new().build();
             let trie_changes = gen_changes(&mut rng, 10);
 
             let state_root = test_populate_trie(
@@ -1149,7 +1147,7 @@ mod tests {
     fn get_trie_nodes_for_part_with_flat_storage() {
         let value_len = 1000usize;
 
-        let tries = create_tries_with_flat_storage();
+        let tries = TestTriesBuilder::new().with_flat_storage().build();
         let shard_uid = ShardUId::single_shard();
         let block_hash = CryptoHash::default();
         let part_id = PartId::new(1, 3);

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -28,8 +28,8 @@ impl TrieRecorder {
 #[cfg(test)]
 mod trie_recording_tests {
     use crate::test_utils::{
-        create_tries_complex_with_flat_storage, gen_larger_changes, simplify_changes,
-        test_populate_flat_storage, test_populate_trie,
+        gen_larger_changes, simplify_changes, test_populate_flat_storage, test_populate_trie,
+        TestTriesBuilder,
     };
     use crate::Trie;
     use near_primitives::hash::CryptoHash;
@@ -45,7 +45,7 @@ mod trie_recording_tests {
     fn test_trie_recording_consistency(enable_accounting_cache: bool, use_missing_keys: bool) {
         let mut rng = rand::thread_rng();
         for _ in 0..NUM_ITERATIONS_PER_TEST {
-            let tries = create_tries_complex_with_flat_storage(1, 2);
+            let tries = TestTriesBuilder::new().with_shard_layout(1, 2).with_flat_storage().build();
 
             let shard_uid = ShardUId { version: 1, shard_id: 0 };
             let trie_changes = gen_larger_changes(&mut rng, 50);
@@ -136,7 +136,7 @@ mod trie_recording_tests {
     ) {
         let mut rng = rand::thread_rng();
         for _ in 0..NUM_ITERATIONS_PER_TEST {
-            let tries = create_tries_complex_with_flat_storage(1, 2);
+            let tries = TestTriesBuilder::new().with_shard_layout(1, 2).with_flat_storage().build();
 
             let shard_uid = ShardUId { version: 1, shard_id: 0 };
             let trie_changes = gen_larger_changes(&mut rng, 50);

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -1,4 +1,4 @@
-use crate::test_utils::{create_tries_complex, gen_changes, simplify_changes, test_populate_trie};
+use crate::test_utils::{gen_changes, simplify_changes, test_populate_trie, TestTriesBuilder};
 use crate::trie::trie_storage::{TrieMemoryPartialStorage, TrieStorage};
 use crate::{PartialStorage, Trie, TrieUpdate};
 use assert_matches::assert_matches;
@@ -101,7 +101,7 @@ where
 fn test_reads_with_incomplete_storage() {
     let mut rng = rand::thread_rng();
     for _ in 0..50 {
-        let tries = create_tries_complex(1, 2);
+        let tries = TestTriesBuilder::new().with_shard_layout(1, 2).build();
         let shard_uid = ShardUId { version: 1, shard_id: 0 };
         let trie_changes = gen_changes(&mut rng, 20);
         let trie_changes = simplify_changes(&trie_changes);
@@ -144,7 +144,6 @@ fn test_reads_with_incomplete_storage() {
 #[cfg(test)]
 mod nodes_counter_tests {
     use super::*;
-    use crate::test_utils::create_tries;
     use crate::trie::nibble_slice::NibbleSlice;
 
     fn create_trie_key(nibbles: &[u8]) -> Vec<u8> {
@@ -152,7 +151,7 @@ mod nodes_counter_tests {
     }
 
     fn create_trie(items: &[(Vec<u8>, Option<Vec<u8>>)]) -> Rc<Trie> {
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let shard_uid = ShardUId { version: 1, shard_id: 0 };
         let trie_changes = simplify_changes(&items);
         let state_root = test_populate_trie(&tries, &Trie::EMPTY_ROOT, shard_uid, trie_changes);
@@ -205,7 +204,7 @@ mod nodes_counter_tests {
 #[cfg(test)]
 mod trie_storage_tests {
     use super::*;
-    use crate::test_utils::{create_test_store, create_tries};
+    use crate::test_utils::create_test_store;
     use crate::trie::accounting_cache::TrieAccountingCache;
     use crate::trie::trie_storage::{TrieCache, TrieCachingStorage, TrieDBStorage};
     use crate::trie::TrieRefcountAddition;
@@ -214,7 +213,7 @@ mod trie_storage_tests {
     use near_primitives::hash::hash;
 
     fn create_store_with_values(values: &[Vec<u8>], shard_uid: ShardUId) -> Store {
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let mut trie_changes = TrieChanges::empty(Trie::EMPTY_ROOT);
         trie_changes.insertions = values
             .iter()

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -169,7 +169,7 @@ impl crate::TrieAccess for TrieUpdate {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_utils::{create_tries, create_tries_complex};
+    use crate::test_utils::TestTriesBuilder;
 
     use super::*;
     use crate::ShardUId;
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn trie() {
-        let tries = create_tries_complex(SHARD_VERSION, 2);
+        let tries = TestTriesBuilder::new().with_shard_layout(SHARD_VERSION, 2).build();
         let root = Trie::EMPTY_ROOT;
         let mut trie_update = tries.new_trie_update(COMPLEX_SHARD_UID, root);
         trie_update.set(test_key(b"dog".to_vec()), b"puppy".to_vec());
@@ -209,7 +209,7 @@ mod tests {
 
     #[test]
     fn trie_remove() {
-        let tries = create_tries_complex(SHARD_VERSION, 2);
+        let tries = TestTriesBuilder::new().with_shard_layout(SHARD_VERSION, 2).build();
 
         // Delete non-existing element.
         let mut trie_update = tries.new_trie_update(COMPLEX_SHARD_UID, Trie::EMPTY_ROOT);
@@ -256,7 +256,7 @@ mod tests {
 
     #[test]
     fn trie_iter() {
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let mut trie_update = tries.new_trie_update(ShardUId::single_shard(), Trie::EMPTY_ROOT);
         trie_update.set(test_key(b"dog".to_vec()), b"puppy".to_vec());
         trie_update.set(test_key(b"aaa".to_vec()), b"puppy".to_vec());

--- a/integration-tests/src/runtime_utils.rs
+++ b/integration-tests/src/runtime_utils.rs
@@ -6,7 +6,7 @@ use near_primitives::state_record::{state_record_to_account_id, StateRecord};
 use near_primitives::types::AccountId;
 use near_primitives::types::StateRoot;
 use near_store::genesis::GenesisStateApplier;
-use near_store::test_utils::create_tries_complex_with_flat_storage;
+use near_store::test_utils::TestTriesBuilder;
 use near_store::{ShardTries, TrieUpdate};
 use nearcore::config::GenesisExt;
 use node_runtime::config::RuntimeConfig;
@@ -34,8 +34,10 @@ pub fn get_test_trie_viewer() -> (TrieViewer, TrieUpdate) {
 
 pub fn get_runtime_and_trie_from_genesis(genesis: &Genesis) -> (Runtime, ShardTries, StateRoot) {
     let shard_layout = &genesis.config.shard_layout;
-    let tries =
-        create_tries_complex_with_flat_storage(shard_layout.version(), shard_layout.num_shards());
+    let tries = TestTriesBuilder::new()
+        .with_shard_layout(shard_layout.version(), shard_layout.num_shards())
+        .with_flat_storage()
+        .build();
     let runtime = Runtime::new();
     let mut account_ids: HashSet<AccountId> = HashSet::new();
     genesis.for_each_record(|record: &StateRecord| {

--- a/nearcore/src/metrics.rs
+++ b/nearcore/src/metrics.rs
@@ -284,16 +284,16 @@ pub fn spawn_trie_metrics_loop(
 mod tests {
     use super::*;
     use near_primitives::trie_key::col;
-    use near_store::test_utils::create_tries;
     use near_store::test_utils::simplify_changes;
     use near_store::test_utils::test_populate_trie;
+    use near_store::test_utils::TestTriesBuilder;
 
     fn create_item(key: &[u8]) -> (Vec<u8>, Option<Vec<u8>>) {
         (key.to_vec(), Some(vec![]))
     }
 
     fn create_trie(items: &[(Vec<u8>, Option<Vec<u8>>)]) -> Trie {
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let shard_uid = ShardUId { version: 1, shard_id: 0 };
         let trie_changes = simplify_changes(&items);
         let state_root = test_populate_trie(&tries, &Trie::EMPTY_ROOT, shard_uid, trie_changes);

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -961,7 +961,7 @@ mod tests {
     use near_primitives::trie_key::TrieKey;
     use near_primitives::types::{EpochId, StateChangeCause};
     use near_store::set_account;
-    use near_store::test_utils::create_tries;
+    use near_store::test_utils::TestTriesBuilder;
     use std::sync::Arc;
 
     fn test_action_create_account(
@@ -1088,7 +1088,7 @@ mod tests {
 
     #[test]
     fn test_delete_account_too_large() {
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let mut state_update =
             tries.new_trie_update(ShardUId::single_shard(), CryptoHash::default());
         let action_result = test_delete_large_account(
@@ -1109,7 +1109,7 @@ mod tests {
     }
 
     fn test_delete_account_with_contract(storage_usage: u64) -> ActionResult {
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let mut state_update =
             tries.new_trie_update(ShardUId::single_shard(), CryptoHash::default());
         let account_id = "alice".parse::<AccountId>().unwrap();
@@ -1203,7 +1203,7 @@ mod tests {
         public_key: &PublicKey,
         access_key: &AccessKey,
     ) -> TrieUpdate {
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let mut state_update =
             tries.new_trie_update(ShardUId::single_shard(), CryptoHash::default());
         let account = Account::new(100, 0, CryptoHash::default(), 100);

--- a/runtime/runtime/src/balance_checker.rs
+++ b/runtime/runtime/src/balance_checker.rs
@@ -248,7 +248,7 @@ mod tests {
     use near_primitives::test_utils::account_new;
     use near_primitives::transaction::{Action, TransferAction};
     use near_primitives::types::{MerkleHash, StateChangeCause};
-    use near_store::test_utils::create_tries;
+    use near_store::test_utils::TestTriesBuilder;
     use near_store::{set_account, Trie};
     use testlib::runtime_utils::{alice_account, bob_account};
 
@@ -263,7 +263,7 @@ mod tests {
 
     #[test]
     fn test_check_balance_no_op() {
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let root = MerkleHash::default();
         let final_state = tries.new_trie_update(ShardUId::single_shard(), root);
         check_balance(
@@ -280,7 +280,7 @@ mod tests {
 
     #[test]
     fn test_check_balance_unaccounted_refund() {
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let root = MerkleHash::default();
         let final_state = tries.new_trie_update(ShardUId::single_shard(), root);
         let err = check_balance(
@@ -300,7 +300,7 @@ mod tests {
         set_initial_state: impl FnOnce(&mut TrieUpdate),
         set_final_state: impl FnOnce(&mut TrieUpdate),
     ) -> TrieUpdate {
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let shard_uid = ShardUId::single_shard();
 
         // Commit initial state
@@ -429,7 +429,7 @@ mod tests {
 
     #[test]
     fn test_total_balance_overflow_returns_unexpected_overflow() {
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let root = MerkleHash::default();
         let alice_id = alice_account();
         let bob_id = bob_account();

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1529,7 +1529,7 @@ mod tests {
     use near_primitives::types::MerkleHash;
     use near_primitives::version::PROTOCOL_VERSION;
     use near_primitives_core::config::{ExtCosts, ParameterCost};
-    use near_store::test_utils::create_tries;
+    use near_store::test_utils::TestTriesBuilder;
     use near_store::{set_access_key, ShardTries, StoreCompiledContractCache};
     use testlib::runtime_utils::{alice_account, bob_account};
 
@@ -1563,7 +1563,7 @@ mod tests {
 
     #[test]
     fn test_get_and_set_accounts() {
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let mut state_update =
             tries.new_trie_update(ShardUId::single_shard(), MerkleHash::default());
         let test_account = account_new(to_yocto(10), hash(&[]));
@@ -1575,7 +1575,7 @@ mod tests {
 
     #[test]
     fn test_get_account_from_trie() {
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let root = MerkleHash::default();
         let mut state_update = tries.new_trie_update(ShardUId::single_shard(), root);
         let test_account = account_new(to_yocto(10), hash(&[]));
@@ -1601,7 +1601,7 @@ mod tests {
         gas_limit: Gas,
     ) -> (Runtime, ShardTries, CryptoHash, ApplyState, Arc<InMemorySigner>, impl EpochInfoProvider)
     {
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let root = MerkleHash::default();
         let runtime = Runtime::new();
         let account_id = alice_account();

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -549,7 +549,7 @@ mod tests {
     };
     use near_primitives::types::{AccountId, Balance, MerkleHash, StateChangeCause};
     use near_primitives::version::PROTOCOL_VERSION;
-    use near_store::test_utils::create_tries;
+    use near_store::test_utils::TestTriesBuilder;
     use testlib::runtime_utils::{alice_account, bob_account, eve_dot_alice_account};
 
     use crate::near_primitives::shard_layout::ShardUId;
@@ -591,7 +591,7 @@ mod tests {
         // account has data
         accounts: Vec<(AccountId, Balance, Balance, Vec<AccessKey>, bool, bool)>,
     ) -> (Arc<InMemorySigner>, TrieUpdate, Balance) {
-        let tries = create_tries();
+        let tries = TestTriesBuilder::new().build();
         let root = MerkleHash::default();
 
         let account_id = alice_account();

--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -13,7 +13,7 @@ use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives_core::account::id::AccountIdRef;
 use near_primitives_core::config::ActionCosts;
 use near_store::genesis::GenesisStateApplier;
-use near_store::test_utils::create_tries;
+use near_store::test_utils::TestTriesBuilder;
 use near_store::ShardTries;
 use node_runtime::{ApplyState, Runtime};
 use random_config::random_config;
@@ -261,8 +261,14 @@ impl RuntimeGroup {
             let signer = signer.clone();
             let state_records = Arc::clone(&group.state_records);
             let validators = group.validators.clone();
-            let runtime_factory =
-                move || StandaloneRuntime::new(signer, &state_records, create_tries(), validators);
+            let runtime_factory = move || {
+                StandaloneRuntime::new(
+                    signer,
+                    &state_records,
+                    TestTriesBuilder::new().build(),
+                    validators,
+                )
+            };
             handles.push(Self::start_runtime_in_thread(group.clone(), runtime_factory));
         }
         handles

--- a/tools/state-viewer/src/contract_accounts.rs
+++ b/tools/state-viewer/src/contract_accounts.rs
@@ -493,8 +493,9 @@ mod tests {
     use near_primitives::types::AccountId;
     use near_store::test_utils::{
         create_test_store, test_populate_store, test_populate_store_rc, test_populate_trie,
+        TestTriesBuilder,
     };
-    use near_store::{DBCol, ShardTries, ShardUId, Store, Trie};
+    use near_store::{DBCol, ShardUId, Store, Trie};
     use std::fmt::Write;
 
     #[test]
@@ -635,7 +636,7 @@ mod tests {
         let store = create_test_store();
         test_populate_store(&store, store_data);
         test_populate_store_rc(&store, store_data_rc);
-        let tries = ShardTries::test_shard_version(store.clone(), 0, 1);
+        let tries = TestTriesBuilder::new().with_store(store.clone()).build();
         let root =
             test_populate_trie(&tries, &Trie::EMPTY_ROOT, ShardUId::single_shard(), trie_data);
         let trie = tries.get_trie_for_shard(ShardUId::single_shard(), root);


### PR DESCRIPTION
so that we stop the proliferation of various test trie creation methods - or else, there will be even more when I add ability to construct tries with memtries.