### PR TITLE
(quick-)fix: remove deleted test from list

### DIFF
--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -25,8 +25,6 @@ expensive --timeout=1800 near-client near_client tests::catching_up::test_all_ch
 expensive --timeout=1800 near-client near_client tests::catching_up::test_all_chunks_accepted_1000_rare_epoch_changing --features nightly
 expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_receipts_sync_hold
 expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_receipts_sync_hold --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::test_chunk_grieving
-expensive --timeout=1800 near-client near_client tests::catching_up::test_chunk_grieving --features nightly
 
 expensive integration-tests integration_tests tests::test_catchup::test_catchup
 expensive integration-tests integration_tests tests::test_catchup::test_catchup --features nightly


### PR DESCRIPTION
Test was recently deleted [here](https://github.com/near/nearcore/commit/97a284979868b195045b6b7ef78660a2e6eaab5f) but was not excluded from the list.
This result in test showing up as failed.