### PR TITLE
add bit flip test

### DIFF
--- a/integration-tests/src/tests/client/block_corruption.rs
+++ b/integration-tests/src/tests/client/block_corruption.rs
@@ -1,3 +1,5 @@
+use anyhow::Context;
+use borsh::BorshDeserialize;
 use near_chain::{Block, ChainGenesis, Error, Provenance};
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
@@ -98,4 +100,138 @@ fn change_shard_id_to_invalid() {
             assert!(false, "Block processing of a corrupt block succeeded.");
         }
     }
+}
+
+/// We ensure there are SOME change between these blocks.
+/// We check that they are NOT in fields that can be mutated and still pass validation by design.
+fn is_breaking_block_change(original: &Block, corrupt: &Block) -> bool {
+    original.header().latest_protocol_version() == corrupt.header().latest_protocol_version()
+        && original.header().block_ordinal() == corrupt.header().block_ordinal()
+        && original.header().timestamp() == corrupt.header().timestamp()
+        && original != corrupt
+}
+
+fn check_process_flipped_block_fails_on_bit(
+    corrupted_bit_idx: usize,
+) -> Result<anyhow::Error, anyhow::Error> {
+    let epoch_length = 5000000;
+    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    genesis.config.epoch_length = epoch_length;
+    let mut env = TestEnv::builder(ChainGenesis::new(&genesis))
+        .real_epoch_managers(&genesis.config)
+        .nightshade_runtimes(&genesis)
+        .build();
+
+    let mut last_block = env.clients[0].chain.get_block_by_height(0).unwrap();
+
+    let mid_height = 3;
+    for h in 1..=mid_height {
+        let txs = create_tx_load(h, &last_block);
+        for tx in txs {
+            assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+        }
+
+        let block = env.clients[0].produce_block(h).unwrap().unwrap();
+        env.process_block(0, block.clone(), Provenance::PRODUCED);
+        last_block = block;
+    }
+
+    let block_len = borsh::to_vec(&last_block).unwrap().len();
+    if corrupted_bit_idx >= block_len * 8 {
+        return Ok(anyhow::anyhow!("End"));
+    }
+
+    let h = mid_height + 1;
+
+    let txs = create_tx_load(h, &last_block);
+    for tx in txs {
+        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+    }
+
+    let correct_block = env.clients[0]
+        .produce_block(h)
+        .unwrap()
+        .with_context(|| format!("Failed to produce block at height {:?}", h))
+        .unwrap();
+
+    let mut block_vec = borsh::to_vec(&correct_block).unwrap();
+
+    // Technically we don't have to do first step, because of Ok("End") check.
+    // But we may change that part in the future for some reason, and I want this part to be reliable.
+
+    // get BIT index modulo BIT length of block
+    let mod_idx = corrupted_bit_idx % (block_vec.len() * 8);
+    // get index of BYTE that we are changing
+    let byte_idx = mod_idx / 8;
+    // get index of BIT in that BYTE that we are flipping
+    let bit_idx = mod_idx % 8;
+    // flip that BIT
+    block_vec[byte_idx] ^= 1 << bit_idx;
+
+    if let Ok(mut corrupt_block) = Block::try_from_slice(block_vec.as_slice()) {
+        corrupt_block.mut_header().get_mut().inner_rest.block_body_hash =
+            corrupt_block.compute_block_body_hash().unwrap();
+        corrupt_block.mut_header().resign(&InMemoryValidatorSigner::from_seed(
+            "test0".parse().unwrap(),
+            KeyType::ED25519,
+            "test0",
+        ));
+
+        if is_breaking_block_change(&correct_block, &corrupt_block) {
+            match env.clients[0].process_block_test(corrupt_block.clone().into(), Provenance::NONE)
+            {
+                Ok(_) => {
+                    return Err(anyhow::anyhow!(
+                        "Was able to process default block with {} bit switched.",
+                        corrupted_bit_idx
+                    ));
+                }
+                Err(e) => {
+                    if let Err(e) = env.clients[0]
+                        .process_block_test(correct_block.into(), Provenance::NONE)
+                    {
+                        return Err(anyhow::anyhow!("Was unable to process default block after attempting to process default block with {} bit switched. {}",
+                        corrupted_bit_idx, e)
+                        );
+                    }
+                    return Ok(e.into());
+                }
+            }
+        } else {
+            return Ok(anyhow::anyhow!("Not a breaking change"));
+        }
+    }
+    return Ok(anyhow::anyhow!("Corrupt block didn't parse"));
+}
+
+#[test]
+#[cfg_attr(not(feature = "expensive_tests"), ignore)]
+fn check_process_flipped_block_fails() {
+    init_test_logger();
+    let mut corrupted_bit_idx = 0;
+    let mut errs = vec![];
+    let mut oks = vec![];
+    loop {
+        let res = check_process_flipped_block_fails_on_bit(corrupted_bit_idx);
+        if let Ok(res) = &res {
+            if res.to_string() == "End" {
+                break;
+            }
+        }
+        match res {
+            Err(e) => errs.push(e),
+            Ok(o) => oks.push(o),
+        }
+        corrupted_bit_idx += 1;
+    }
+    tracing::info!("All of the Errors:");
+    for err in &errs {
+        tracing::info!("{:?}", err);
+    }
+    tracing::info!("{}", ["-"; 100].concat());
+    tracing::info!("All of the Oks:");
+    for ok in oks {
+        tracing::info!("{:?}", ok);
+    }
+    assert!(errs.is_empty());
 }

--- a/integration-tests/src/tests/client/block_corruption.rs
+++ b/integration-tests/src/tests/client/block_corruption.rs
@@ -187,8 +187,8 @@ fn check_process_flipped_block_fails_on_bit(
                     ));
                 }
                 Err(e) => {
-                    if let Err(e) = env.clients[0]
-                        .process_block_test(correct_block.into(), Provenance::NONE)
+                    if let Err(e) =
+                        env.clients[0].process_block_test(correct_block.into(), Provenance::NONE)
                     {
                         return Err(anyhow::anyhow!("Was unable to process default block after attempting to process default block with {} bit switched. {}",
                         corrupted_bit_idx, e)

--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -128,6 +128,8 @@ expensive --timeout=600 near-chain near_chain tests::gc::test_gc_pine --features
 expensive --timeout=700 near-chain near_chain tests::gc::test_gc_star_large
 expensive --timeout=700 near-chain near_chain tests::gc::test_gc_star_large --features nightly
 
+expensive integration-tests integration_tests tests::client::block_corruption::check_process_flipped_block_fails
+expensive integration-tests integration_tests tests::client::block_corruption::check_process_flipped_block_fails --features nightly
 expensive integration-tests integration_tests tests::client::chunks_management::chunks_recovered_from_full
 expensive integration-tests integration_tests tests::client::chunks_management::chunks_recovered_from_full --features nightly
 expensive integration-tests integration_tests tests::client::chunks_management::chunks_recovered_from_full_cop
@@ -229,6 +231,3 @@ expensive integration-tests integration_tests tests::nearcore::stake_nodes::test
 
 expensive integration-tests integration_tests tests::nearcore::track_shards::track_shards
 expensive integration-tests integration_tests tests::nearcore::track_shards::track_shards --features nightly
-
-expensive integration-tests integration_tests tests::client::block_corruption::check_process_flipped_block_fails
-expensive integration-tests integration_tests tests::client::block_corruption::check_process_flipped_block_fails --features nightly

--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -229,3 +229,6 @@ expensive integration-tests integration_tests tests::nearcore::stake_nodes::test
 
 expensive integration-tests integration_tests tests::nearcore::track_shards::track_shards
 expensive integration-tests integration_tests tests::nearcore::track_shards::track_shards --features nightly
+
+expensive integration-tests integration_tests tests::client::block_corruption::check_process_flipped_block_fails
+expensive integration-tests integration_tests tests::client::block_corruption::check_process_flipped_block_fails --features nightly


### PR DESCRIPTION
We want to make sure that every field in the block is properly validated.
One of the ways to do that is to flip random bits in the correct block and check that the resulting block is considered invalid. We can also add processing of correct blocks to the same test.

This test checks that our system is resilient to random changes in block in two ways:
- blocks with random changes are not processed
- blocks with random changes do not affect normal block production

Each block contains one 'send' transaction.
First three blocks are produced without changes.
For the fourth block we are calculating two versions – correct and corrupt.
Corrupt block is produced by
- serialising correct block
- flipping one bit
- deserialising resulting string
- resigning the resulting block

If the corrupt block can be parsed, we are trying to process it and expecting it to fail.
If it successfully fails, we are processing the correct block (and expecting it to be ok).

This test is not a panacea, and it doesn't even cover all possible block validation errors.

To run the test and check all hit validation errors I do
```
cargo test -pintegration-tests --features test_features,expensive_tests -- --nocapture check_process_flipped_block_fails > test_results.txt
sed -n '/All of the Oks:/,$p' < test_results.txt | cut -c 100- | awk '!seen[$0]++' 
```
One test run takes around 5 mins.
