### PR TITLE
fix: Small fix mirror script

### DIFF
--- a/pytest/tests/mocknet/README.md
+++ b/pytest/tests/mocknet/README.md
@@ -5,7 +5,7 @@ Mirror transactions from a given network into a custom mocktest network and add 
 2. Run `python3 tests/mocknet/mirror.py --chain-id {chain_id} --start-height {start_height} --unique-id {unique_id} init-neard-runner`, replacing the `{}`s with appropriate values from the `nearcore/pytest` directory. This starts a helper program on each node that will be in charge of the test state and neard process.
 3. Run `python3 tests/mocknet/mirror.py --chain-id {chain_id} --start-height {start_height} --unique-id {unique_id} new-test`. This will take a few hours.
 4. Run `python3 tests/mocknet/mirror.py --chain-id {chain_id} --start-height {start_height} --unique-id {unique_id} start-traffic` replacing the `{}`s with appropriate values
-4. Monitoring
+5. Monitoring
 - See metrics on grafana mocknet https://grafana.near.org/d/jHbiNgSnz/mocknet?orgId=1&refresh=30s&var-chain_id=All&var-node_id=.*unique_id.*&var-account_id=All replacing the "unique_id" with the value from earlier
 
 If there's ever a problem with the neard runners on each node, for example if you get a connection error running the `status` command, run the `restart-neard-runner` command to restart them, which should be safe to do.

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -322,7 +322,7 @@ def neard_runner_jsonrpc(node, method, params=[]):
     # followed by a new quote started with ' and the rest of the string, to get any single quotes
     # in method or params into the command correctly
     body = body.replace("'", "'\"'\"'")
-    r = run_cmd(node, f'curl localhost:3000 -d \'{body}\'')
+    r = cmd_utils.run_cmd(node, f'curl localhost:3000 -d \'{body}\'')
     response = json.loads(r.stdout)
     if 'error' in response:
         # TODO: errors should be handled better here in general but just exit for now


### PR DESCRIPTION
Small fix of prefix module for `run_cmd` in `mirror.py` script