### PR TITLE
modify existing validators() rust api to take both epoch_id and block_id

### DIFF
--- a/chain/jsonrpc-primitives/src/types/validator.rs
+++ b/chain/jsonrpc-primitives/src/types/validator.rs
@@ -14,7 +14,7 @@ pub enum RpcValidatorError {
     InternalError { error_message: String },
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, arbitrary::Arbitrary)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, arbitrary::Arbitrary, PartialEq, Eq)]
 pub struct RpcValidatorRequest {
     #[serde(flatten)]
     pub epoch_reference: near_primitives::types::EpochReference,

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -11,7 +11,7 @@ use near_jsonrpc_primitives::types::transactions::{
 use near_jsonrpc_primitives::types::validator::RpcValidatorsOrderedRequest;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::{
-    BlockId, BlockReference, EpochId, EpochReference, MaybeBlockId, ShardId,
+    BlockId, BlockReference, MaybeEpochReference, MaybeBlockId, ShardId,
 };
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
@@ -189,7 +189,7 @@ jsonrpc_client!(pub struct JsonRpcClient {
     pub fn EXPERIMENTAL_tx_status(&self, tx: String) -> RpcRequest<RpcTransactionResponse>;
     pub fn health(&self) -> RpcRequest<()>;
     pub fn chunk(&self, id: ChunkId) -> RpcRequest<ChunkView>;
-    pub fn validators(&self, block_id: MaybeBlockId) -> RpcRequest<EpochValidatorInfo>;
+    pub fn validators(&self, epoch_id_or_block_id: MaybeEpochReference) -> RpcRequest<EpochValidatorInfo>;
     pub fn gas_price(&self, block_id: MaybeBlockId) -> RpcRequest<GasPriceView>;
 });
 
@@ -221,15 +221,6 @@ impl JsonRpcClient {
 
     pub fn tx(&self, request: RpcTransactionStatusRequest) -> RpcRequest<RpcTransactionResponse> {
         call_method(&self.client, &self.server_addr, "tx", request)
-    }
-
-    pub fn validators_by_epoch_id(&self, epoch_id: EpochId) -> RpcRequest<EpochValidatorInfo> {
-        call_method(
-            &self.client,
-            &self.server_addr,
-            "validators",
-            EpochReference::EpochId(epoch_id),
-        )
     }
 
     #[allow(non_snake_case)]

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -10,7 +10,7 @@ use near_jsonrpc_primitives::types::transactions::{
 };
 use near_jsonrpc_primitives::types::validator::RpcValidatorsOrderedRequest;
 use near_primitives::hash::CryptoHash;
-use near_primitives::types::{BlockId, BlockReference, MaybeBlockId, MaybeEpochReference, ShardId};
+use near_primitives::types::{BlockId, BlockReference, EpochReference, MaybeBlockId, ShardId};
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
     BlockView, ChunkView, EpochValidatorInfo, GasPriceView, StatusResponse,
@@ -187,7 +187,7 @@ jsonrpc_client!(pub struct JsonRpcClient {
     pub fn EXPERIMENTAL_tx_status(&self, tx: String) -> RpcRequest<RpcTransactionResponse>;
     pub fn health(&self) -> RpcRequest<()>;
     pub fn chunk(&self, id: ChunkId) -> RpcRequest<ChunkView>;
-    pub fn validators(&self, epoch_id_or_block_id: MaybeEpochReference) -> RpcRequest<EpochValidatorInfo>;
+    pub fn validators(&self, epoch_id_or_block_id: Option<EpochReference>) -> RpcRequest<EpochValidatorInfo>;
     pub fn gas_price(&self, block_id: MaybeBlockId) -> RpcRequest<GasPriceView>;
 });
 

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -10,9 +10,7 @@ use near_jsonrpc_primitives::types::transactions::{
 };
 use near_jsonrpc_primitives::types::validator::RpcValidatorsOrderedRequest;
 use near_primitives::hash::CryptoHash;
-use near_primitives::types::{
-    BlockId, BlockReference, MaybeEpochReference, MaybeBlockId, ShardId,
-};
+use near_primitives::types::{BlockId, BlockReference, MaybeBlockId, MaybeEpochReference, ShardId};
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
     BlockView, ChunkView, EpochValidatorInfo, GasPriceView, StatusResponse,

--- a/chain/jsonrpc/src/api/validator.rs
+++ b/chain/jsonrpc/src/api/validator.rs
@@ -11,13 +11,17 @@ use super::{Params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcValidatorRequest {
     fn parse(value: Value) -> Result<Self, RpcParseError> {
+        // this takes care of the legacy input format [block_id]
         if let Ok(epoch_reference) = Params::new(value.clone())
             .try_singleton(|block_id| match block_id {
                 Some(id) => Ok(EpochReference::BlockId(id)),
                 None => Ok(EpochReference::Latest),
-            }).unwrap_or_parse() {
-                Ok(Self {epoch_reference})
+            })
+            .unwrap_or_parse()
+        {
+            Ok(Self { epoch_reference })
         } else {
+            // this takes care of the map format input, e.g. {"epoch_id": "5Yheiw"} or {"block_id": 12345}
             Params::parse(value).map(|epoch_reference| Self { epoch_reference })
         }
     }
@@ -76,7 +80,6 @@ mod tests {
     fn test_serialize_validators_params_as_object_input_block_height() {
         let block_height: u64 = 12345;
         let params = serde_json::json!({"block_id": block_height});
-        println!("result is: {:?}", RpcValidatorRequest::parse(params.clone()));
         assert!(RpcValidatorRequest::parse(params).is_ok());
     }
 
@@ -84,8 +87,6 @@ mod tests {
     fn test_serialize_validators_params_as_object_input_epoch_id() {
         let epoch_id = CryptoHash::new().to_string();
         let params = serde_json::json!({"epoch_id": epoch_id});
-        println!("result is: {:?}", RpcValidatorRequest::parse(params.clone()));
         assert!(RpcValidatorRequest::parse(params).is_ok());
     }
-
 }

--- a/chain/jsonrpc/src/api/validator.rs
+++ b/chain/jsonrpc/src/api/validator.rs
@@ -61,32 +61,67 @@ mod tests {
     use crate::api::RpcRequest;
     use near_jsonrpc_primitives::types::validator::RpcValidatorRequest;
     use near_primitives::hash::CryptoHash;
+    use near_primitives::types::{BlockId, EpochId, EpochReference};
 
     #[test]
     fn test_serialize_validators_params_as_vec() {
-        let block_hash = CryptoHash::new().to_string();
-        let params = serde_json::json!([block_hash]);
-        assert!(RpcValidatorRequest::parse(params).is_ok());
+        let block_hash = CryptoHash::new();
+        let block_hash_string = CryptoHash::new().to_string();
+        let params = serde_json::json!([block_hash_string]);
+        let result = RpcValidatorRequest::parse(params);
+        assert!(result.is_ok());
+        let result_unwrap = result.unwrap();
+        let res_serialized = format!("{result_unwrap:?}");
+        let expected = RpcValidatorRequest {
+            epoch_reference: EpochReference::BlockId(BlockId::Hash(block_hash)),
+        };
+        let expected_serialized = format!("{expected:?}");
+        assert_eq!(res_serialized, expected_serialized);
     }
 
     #[test]
     fn test_serialize_validators_params_as_object_input_block_hash() {
-        let block_hash = CryptoHash::new().to_string();
-        let params = serde_json::json!({"block_id": block_hash});
-        assert!(RpcValidatorRequest::parse(params).is_ok());
+        let block_hash = CryptoHash::new();
+        let block_hash_string = CryptoHash::new().to_string();
+        let params = serde_json::json!({"block_id": block_hash_string});
+        let result = RpcValidatorRequest::parse(params);
+        assert!(result.is_ok());
+        let result_unwrap = result.unwrap();
+        let res_serialized = format!("{result_unwrap:?}");
+        let expected = RpcValidatorRequest {
+            epoch_reference: EpochReference::BlockId(BlockId::Hash(block_hash)),
+        };
+        let expected_serialized = format!("{expected:?}");
+        assert_eq!(res_serialized, expected_serialized);
     }
 
     #[test]
     fn test_serialize_validators_params_as_object_input_block_height() {
         let block_height: u64 = 12345;
         let params = serde_json::json!({"block_id": block_height});
-        assert!(RpcValidatorRequest::parse(params).is_ok());
+        let result = RpcValidatorRequest::parse(params);
+        assert!(result.is_ok());
+        let result_unwrap = result.unwrap();
+        let res_serialized = format!("{result_unwrap:?}");
+        let expected = RpcValidatorRequest {
+            epoch_reference: EpochReference::BlockId(BlockId::Height(block_height)),
+        };
+        let expected_serialized = format!("{expected:?}");
+        assert_eq!(res_serialized, expected_serialized);
     }
 
     #[test]
     fn test_serialize_validators_params_as_object_input_epoch_id() {
-        let epoch_id = CryptoHash::new().to_string();
-        let params = serde_json::json!({"epoch_id": epoch_id});
-        assert!(RpcValidatorRequest::parse(params).is_ok());
+        let epoch_id = CryptoHash::new();
+        let epoch_id_string = epoch_id.to_string();
+        let params = serde_json::json!({"epoch_id": epoch_id_string});
+        let result = RpcValidatorRequest::parse(params);
+        assert!(result.is_ok());
+        let result_unwrap = result.unwrap();
+        let res_serialized = format!("{result_unwrap:?}");
+        let expected =
+            RpcValidatorRequest { epoch_reference: EpochReference::EpochId(EpochId(epoch_id)) };
+        let expected_serialized = format!("{expected:?}");
+        assert_eq!(res_serialized, expected_serialized);
     }
 }

--- a/chain/jsonrpc/src/api/validator.rs
+++ b/chain/jsonrpc/src/api/validator.rs
@@ -11,19 +11,13 @@ use super::{Params, RpcFrom, RpcRequest};
 
 impl RpcRequest for RpcValidatorRequest {
     fn parse(value: Value) -> Result<Self, RpcParseError> {
-        // this takes care of the legacy input format [block_id]
-        if let Ok(epoch_reference) = Params::new(value.clone())
+        let epoch_reference = Params::new(value)
             .try_singleton(|block_id| match block_id {
                 Some(id) => Ok(EpochReference::BlockId(id)),
                 None => Ok(EpochReference::Latest),
             })
-            .unwrap_or_parse()
-        {
-            Ok(Self { epoch_reference })
-        } else {
-            // this takes care of the map format input, e.g. {"epoch_id": "5Yheiw"} or {"block_id": 12345}
-            Params::parse(value).map(|epoch_reference| Self { epoch_reference })
-        }
+            .unwrap_or_parse()?;
+        Ok(Self { epoch_reference: epoch_reference })
     }
 }
 
@@ -66,33 +60,27 @@ mod tests {
     #[test]
     fn test_serialize_validators_params_as_vec() {
         let block_hash = CryptoHash::new();
-        let block_hash_string = CryptoHash::new().to_string();
-        let params = serde_json::json!([block_hash_string]);
+        let params = serde_json::json!([block_hash.to_string()]);
         let result = RpcValidatorRequest::parse(params);
-        assert!(result.is_ok());
-        let result_unwrap = result.unwrap();
-        let res_serialized = format!("{result_unwrap:?}");
-        let expected = RpcValidatorRequest {
-            epoch_reference: EpochReference::BlockId(BlockId::Hash(block_hash)),
-        };
-        let expected_serialized = format!("{expected:?}");
-        assert_eq!(res_serialized, expected_serialized);
+        assert_eq!(
+            result.unwrap(),
+            RpcValidatorRequest {
+                epoch_reference: EpochReference::BlockId(BlockId::Hash(block_hash)),
+            }
+        );
     }
 
     #[test]
     fn test_serialize_validators_params_as_object_input_block_hash() {
         let block_hash = CryptoHash::new();
-        let block_hash_string = CryptoHash::new().to_string();
-        let params = serde_json::json!({"block_id": block_hash_string});
+        let params = serde_json::json!({"block_id": block_hash.to_string()});
         let result = RpcValidatorRequest::parse(params);
-        assert!(result.is_ok());
-        let result_unwrap = result.unwrap();
-        let res_serialized = format!("{result_unwrap:?}");
-        let expected = RpcValidatorRequest {
-            epoch_reference: EpochReference::BlockId(BlockId::Hash(block_hash)),
-        };
-        let expected_serialized = format!("{expected:?}");
-        assert_eq!(res_serialized, expected_serialized);
+        assert_eq!(
+            result.unwrap(),
+            RpcValidatorRequest {
+                epoch_reference: EpochReference::BlockId(BlockId::Hash(block_hash)),
+            }
+        );
     }
 
     #[test]
@@ -113,15 +101,11 @@ mod tests {
     #[test]
     fn test_serialize_validators_params_as_object_input_epoch_id() {
         let epoch_id = CryptoHash::new();
-        let epoch_id_string = epoch_id.to_string();
-        let params = serde_json::json!({"epoch_id": epoch_id_string});
+        let params = serde_json::json!({"epoch_id": epoch_id.to_string()});
         let result = RpcValidatorRequest::parse(params);
-        assert!(result.is_ok());
-        let result_unwrap = result.unwrap();
-        let res_serialized = format!("{result_unwrap:?}");
-        let expected =
-            RpcValidatorRequest { epoch_reference: EpochReference::EpochId(EpochId(epoch_id)) };
-        let expected_serialized = format!("{expected:?}");
-        assert_eq!(res_serialized, expected_serialized);
+        assert_eq!(
+            result.unwrap(),
+            RpcValidatorRequest { epoch_reference: EpochReference::EpochId(EpochId(epoch_id)) }
+        );
     }
 }

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -897,7 +897,7 @@ pub struct BlockChunkValidatorStats {
     pub chunk_stats: ValidatorStats,
 }
 
-#[derive(serde::Deserialize, Debug, arbitrary::Arbitrary)]
+#[derive(serde::Deserialize, Debug, arbitrary::Arbitrary, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum EpochReference {
     EpochId(EpochId),

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -905,6 +905,8 @@ pub enum EpochReference {
     Latest,
 }
 
+pub type MaybeEpochReference = Option<EpochReference>;
+
 impl serde::Serialize for EpochReference {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -905,8 +905,6 @@ pub enum EpochReference {
     Latest,
 }
 
-pub type MaybeEpochReference = Option<EpochReference>;
-
 impl serde::Serialize for EpochReference {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where

--- a/integration-tests/src/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/src/tests/nearcore/rpc_nodes.rs
@@ -56,7 +56,9 @@ fn test_get_validator_info_rpc() {
                     if block_view.header.height > 1 {
                         let client = new_client(&format!("http://{}", rpc_addrs_copy[0]));
                         let block_hash = block_view.header.hash;
-                        let invalid_res = client.validators(Some(EpochReference::BlockId(BlockId::Hash(block_hash)))).await;
+                        let invalid_res = client
+                            .validators(Some(EpochReference::BlockId(BlockId::Hash(block_hash))))
+                            .await;
                         assert!(invalid_res.is_err());
                         let res = client.validators(None).await.unwrap();
                         assert_eq!(res.current_validators.len(), 1);

--- a/integration-tests/src/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/src/tests/nearcore/rpc_nodes.rs
@@ -56,10 +56,9 @@ fn test_get_validator_info_rpc() {
                     if block_view.header.height > 1 {
                         let client = new_client(&format!("http://{}", rpc_addrs_copy[0]));
                         let block_hash = block_view.header.hash;
-                        let invalid_res = client.validators(Some(BlockId::Hash(block_hash))).await;
+                        let invalid_res = client.validators(Some(EpochReference::BlockId(BlockId::Hash(block_hash)))).await;
                         assert!(invalid_res.is_err());
                         let res = client.validators(None).await.unwrap();
-
                         assert_eq!(res.current_validators.len(), 1);
                         assert!(res.current_validators.iter().any(|r| r.account_id == "near.0"));
                         System::current().stop();

--- a/integration-tests/src/user/rpc_user.rs
+++ b/integration-tests/src/user/rpc_user.rs
@@ -16,7 +16,7 @@ use near_primitives::receipt::Receipt;
 use near_primitives::serialize::to_base64;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{
-    AccountId, BlockHeight, BlockId, BlockReference, ShardId, MaybeEpochReference,
+    AccountId, BlockHeight, BlockId, BlockReference, MaybeEpochReference, ShardId,
 };
 use near_primitives::views::{
     AccessKeyView, AccountView, BlockView, CallResult, ChunkView, ContractCodeView,
@@ -56,8 +56,13 @@ impl RpcUser {
         self.actix(move |client| client.query(request).map_err(|err| err.to_string()))
     }
 
-    pub fn validators(&self, epoch_id_or_block_id: MaybeEpochReference) -> Result<EpochValidatorInfo, String> {
-        self.actix(move |client| client.validators(epoch_id_or_block_id).map_err(|err| err.to_string()))
+    pub fn validators(
+        &self,
+        epoch_id_or_block_id: MaybeEpochReference,
+    ) -> Result<EpochValidatorInfo, String> {
+        self.actix(move |client| {
+            client.validators(epoch_id_or_block_id).map_err(|err| err.to_string())
+        })
     }
 }
 

--- a/integration-tests/src/user/rpc_user.rs
+++ b/integration-tests/src/user/rpc_user.rs
@@ -16,7 +16,7 @@ use near_primitives::receipt::Receipt;
 use near_primitives::serialize::to_base64;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{
-    AccountId, BlockHeight, BlockId, BlockReference, MaybeBlockId, ShardId,
+    AccountId, BlockHeight, BlockId, BlockReference, ShardId, MaybeEpochReference,
 };
 use near_primitives::views::{
     AccessKeyView, AccountView, BlockView, CallResult, ChunkView, ContractCodeView,
@@ -56,8 +56,8 @@ impl RpcUser {
         self.actix(move |client| client.query(request).map_err(|err| err.to_string()))
     }
 
-    pub fn validators(&self, block_id: MaybeBlockId) -> Result<EpochValidatorInfo, String> {
-        self.actix(move |client| client.validators(block_id).map_err(|err| err.to_string()))
+    pub fn validators(&self, epoch_id_or_block_id: MaybeEpochReference) -> Result<EpochValidatorInfo, String> {
+        self.actix(move |client| client.validators(epoch_id_or_block_id).map_err(|err| err.to_string()))
     }
 }
 

--- a/integration-tests/src/user/rpc_user.rs
+++ b/integration-tests/src/user/rpc_user.rs
@@ -16,7 +16,7 @@ use near_primitives::receipt::Receipt;
 use near_primitives::serialize::to_base64;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{
-    AccountId, BlockHeight, BlockId, BlockReference, MaybeEpochReference, ShardId,
+    AccountId, BlockHeight, BlockId, BlockReference, EpochReference, ShardId,
 };
 use near_primitives::views::{
     AccessKeyView, AccountView, BlockView, CallResult, ChunkView, ContractCodeView,
@@ -58,7 +58,7 @@ impl RpcUser {
 
     pub fn validators(
         &self,
-        epoch_id_or_block_id: MaybeEpochReference,
+        epoch_id_or_block_id: Option<EpochReference>,
     ) -> Result<EpochValidatorInfo, String> {
         self.actix(move |client| {
             client.validators(epoch_id_or_block_id).map_err(|err| err.to_string())

--- a/tools/state-parts-dump-check/src/cli.rs
+++ b/tools/state-parts-dump-check/src/cli.rs
@@ -8,7 +8,9 @@ use near_client::sync::external::{
 use near_jsonrpc::client::{new_client, JsonRpcClient};
 use near_primitives::hash::CryptoHash;
 use near_primitives::state_part::PartId;
-use near_primitives::types::{BlockId, BlockReference, EpochId, EpochReference, Finality, ShardId, StateRoot};
+use near_primitives::types::{
+    BlockId, BlockReference, EpochId, EpochReference, Finality, ShardId, StateRoot,
+};
 use near_primitives::views::BlockView;
 use near_store::Trie;
 use nearcore::state_sync::extract_part_id_from_part_file_name;

--- a/tools/state-parts-dump-check/src/cli.rs
+++ b/tools/state-parts-dump-check/src/cli.rs
@@ -8,7 +8,7 @@ use near_client::sync::external::{
 use near_jsonrpc::client::{new_client, JsonRpcClient};
 use near_primitives::hash::CryptoHash;
 use near_primitives::state_part::PartId;
-use near_primitives::types::{BlockId, BlockReference, EpochId, Finality, ShardId, StateRoot};
+use near_primitives::types::{BlockId, BlockReference, EpochId, EpochReference, Finality, ShardId, StateRoot};
 use near_primitives::views::BlockView;
 use near_store::Trie;
 use nearcore::state_sync::extract_part_id_from_part_file_name;
@@ -639,7 +639,7 @@ async fn get_processing_epoch_information(
     let latest_epoch_id = latest_block_response.header.epoch_id;
     let latest_epoch_response =
         rpc_client
-            .validators_by_epoch_id(EpochId(latest_epoch_id))
+            .validators(Some(EpochReference::EpochId(EpochId(latest_epoch_id))))
             .await
             .or_else(|_| Err(anyhow!("validators_by_epoch_id for latest_epoch_id failed")))?;
     let latest_epoch_height = latest_epoch_response.epoch_height;
@@ -664,7 +664,7 @@ async fn get_previous_epoch_last_block_response(
     current_epoch_id: CryptoHash,
 ) -> anyhow::Result<BlockView> {
     let current_epoch_response = rpc_client
-        .validators_by_epoch_id(EpochId(current_epoch_id))
+        .validators(Some(EpochReference::EpochId(EpochId(current_epoch_id))))
         .await
         .or_else(|_| Err(anyhow!("validators_by_epoch_id for current_epoch_id failed")))?;
     let current_epoch_first_block_height = current_epoch_response.epoch_start_height;

--- a/tools/state-parts-dump-check/src/cli.rs
+++ b/tools/state-parts-dump-check/src/cli.rs
@@ -639,11 +639,10 @@ async fn get_processing_epoch_information(
         .await
         .or_else(|_| Err(anyhow!("get final block failed")))?;
     let latest_epoch_id = latest_block_response.header.epoch_id;
-    let latest_epoch_response =
-        rpc_client
-            .validators(Some(EpochReference::EpochId(EpochId(latest_epoch_id))))
-            .await
-            .or_else(|_| Err(anyhow!("validators_by_epoch_id for latest_epoch_id failed")))?;
+    let latest_epoch_response = rpc_client
+        .validators(Some(EpochReference::EpochId(EpochId(latest_epoch_id))))
+        .await
+        .or_else(|_| Err(anyhow!("validators_by_epoch_id for latest_epoch_id failed")))?;
     let latest_epoch_height = latest_epoch_response.epoch_height;
     let prev_epoch_last_block_response =
         get_previous_epoch_last_block_response(rpc_client, latest_epoch_id).await?;


### PR DESCRIPTION
1. removed the previously added `validator_by_epoch_id()` api
2. modified the pre-existing `validators(maybe_block_id)` api to be `validators(maybe_epoch_reference)`. Basically now within rust, we can input `None`, or `Some(EpochReference::EpochId(epoch_id))` or `Some(EpochReference::BlockId(block_id))`. 
3. added some unit tests to test all currently supported json inputs to the `validators` RPC endpoint are working. When users send requests to the near rpc validators endpoint, they could use as input the legacy format `[block_id]` or the map format `{"epoch_id": epoch_hash}` or `{"block_id": block hash/height}`