### PR TITLE
[Trie] Optimize runtime trie access by avoiding wasted lookups of inlined values.

### DIFF
--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -82,6 +82,7 @@ mod tests {
     };
     use crate::trie::mem::loading::load_trie_from_flat_state;
     use crate::trie::mem::lookup::memtrie_lookup;
+    use crate::trie::OptimizedValueRef;
     use crate::{KeyLookupMode, NibbleSlice, Trie, TrieUpdate};
     use near_primitives::hash::CryptoHash;
     use near_primitives::shard_layout::ShardUId;
@@ -128,8 +129,8 @@ mod tests {
         let mut nodes_count = TrieNodesCount { db_reads: 0, mem_reads: 0 };
         for key in keys.iter() {
             let actual_value_ref = memtrie_lookup(root, key, Some(&mut cache), &mut nodes_count)
-                .map(|v| v.to_value_ref());
-            let expected_value_ref = trie.get_ref(key, KeyLookupMode::Trie).unwrap();
+                .map(OptimizedValueRef::from_flat_value);
+            let expected_value_ref = trie.get_optimized_ref(key, KeyLookupMode::Trie).unwrap();
             assert_eq!(actual_value_ref, expected_value_ref, "{:?}", NibbleSlice::new(key));
             assert_eq!(&nodes_count, &trie.get_trie_nodes_count());
         }

--- a/core/store/src/trie/mem/updating.rs
+++ b/core/store/src/trie/mem/updating.rs
@@ -996,15 +996,17 @@ mod tests {
                         &mut TrieNodesCount { db_reads: 0, mem_reads: 0 },
                     )
                 });
-                let disk_result = disk_trie.get_ref(key, KeyLookupMode::Trie).unwrap();
+                let disk_result = disk_trie.get_optimized_ref(key, KeyLookupMode::Trie).unwrap();
                 if let Some(value_ref) = value_ref {
                     let memtrie_value_ref = memtrie_result
                         .expect(&format!("Key {} is in truth but not in memtrie", hex::encode(key)))
                         .to_value_ref();
-                    let disk_value_ref = disk_result.expect(&format!(
-                        "Key {} is in truth but not in disk trie",
-                        hex::encode(key)
-                    ));
+                    let disk_value_ref = disk_result
+                        .expect(&format!(
+                            "Key {} is in truth but not in disk trie",
+                            hex::encode(key)
+                        ))
+                        .into_value_ref();
                     assert_eq!(
                         memtrie_value_ref,
                         *value_ref,

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -170,7 +170,7 @@ mod trie_recording_tests {
                 .collect::<Vec<_>>();
 
             // First, check that the trie is using flat storage, so that counters are all zero.
-            // Only use get_ref(), because get() will actually dereference values which can
+            // Only use get_optimized_ref(), because get() will actually dereference values which can
             // cause trie reads.
             let trie = tries.get_trie_with_block_hash_for_shard(
                 shard_uid,
@@ -179,7 +179,7 @@ mod trie_recording_tests {
                 false,
             );
             for key in &keys_to_test_with {
-                trie.get_ref(&key, crate::KeyLookupMode::FlatStorage).unwrap();
+                trie.get_optimized_ref(&key, crate::KeyLookupMode::FlatStorage).unwrap();
             }
             assert_eq!(trie.get_trie_nodes_count(), TrieNodesCount { db_reads: 0, mem_reads: 0 });
 

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -72,10 +72,10 @@ impl TrieUpdate {
             }
         }
 
-        let result = 
-            self.trie
-                .get_optimized_ref(&key, mode)?
-                .map(|optimized_value_ref| TrieUpdateValuePtr::Ref(&self.trie, optimized_value_ref));
+        let result = self
+            .trie
+            .get_optimized_ref(&key, mode)?
+            .map(|optimized_value_ref| TrieUpdateValuePtr::Ref(&self.trie, optimized_value_ref));
 
         Ok(result)
     }

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -1,15 +1,14 @@
 pub use self::iterator::TrieUpdateIterator;
-use super::Trie;
+use super::{OptimizedValueRef, Trie};
 use crate::trie::{KeyLookupMode, TrieChanges};
 use crate::StorageError;
-use near_primitives::hash::CryptoHash;
-use near_primitives::state::ValueRef;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{
     RawStateChange, RawStateChanges, RawStateChangesWithTrieKey, StateChangeCause, StateRoot,
     TrieCacheMode,
 };
 use std::collections::BTreeMap;
+
 mod iterator;
 
 /// Key-value update. Contains a TrieKey and a value.
@@ -30,7 +29,7 @@ pub struct TrieUpdate {
 }
 
 pub enum TrieUpdateValuePtr<'a> {
-    HashAndSize(&'a Trie, u32, CryptoHash),
+    Ref(&'a Trie, OptimizedValueRef),
     MemoryRef(&'a [u8]),
 }
 
@@ -38,16 +37,14 @@ impl<'a> TrieUpdateValuePtr<'a> {
     pub fn len(&self) -> u32 {
         match self {
             TrieUpdateValuePtr::MemoryRef(value) => value.len() as u32,
-            TrieUpdateValuePtr::HashAndSize(_, length, _) => *length,
+            TrieUpdateValuePtr::Ref(_, value_ref) => value_ref.len() as u32,
         }
     }
 
     pub fn deref_value(&self) -> Result<Vec<u8>, StorageError> {
         match self {
             TrieUpdateValuePtr::MemoryRef(value) => Ok(value.to_vec()),
-            TrieUpdateValuePtr::HashAndSize(trie, _, hash) => {
-                trie.internal_retrieve_trie_node(hash, true).map(|bytes| bytes.to_vec())
-            }
+            TrieUpdateValuePtr::Ref(trie, value_ref) => Ok(trie.deref_optimized(value_ref)?),
         }
     }
 }
@@ -75,11 +72,12 @@ impl TrieUpdate {
             }
         }
 
-        self.trie.get_ref(&key, mode).map(|option| {
-            option.map(|ValueRef { length, hash }| {
-                TrieUpdateValuePtr::HashAndSize(&self.trie, length, hash)
-            })
-        })
+        let result = 
+            self.trie
+                .get_optimized_ref(&key, mode)?
+                .map(|optimized_value_ref| TrieUpdateValuePtr::Ref(&self.trie, optimized_value_ref));
+
+        Ok(result)
     }
 
     pub fn get(&self, key: &TrieKey) -> Result<Option<Vec<u8>>, StorageError> {
@@ -169,10 +167,10 @@ impl crate::TrieAccess for TrieUpdate {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_utils::TestTriesBuilder;
-
     use super::*;
+    use crate::test_utils::TestTriesBuilder;
     use crate::ShardUId;
+    use near_primitives::hash::CryptoHash;
     const SHARD_VERSION: u32 = 1;
     const COMPLEX_SHARD_UID: ShardUId = ShardUId { version: SHARD_VERSION, shard_id: 0 };
 

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -390,7 +390,10 @@ fn test_flat_storage_creation_start_from_state_part() {
             .unwrap();
         for part_trie_keys in trie_keys.iter() {
             for trie_key in part_trie_keys.iter() {
-                assert_matches!(trie.get_ref(&trie_key, KeyLookupMode::FlatStorage), Ok(Some(_)));
+                assert_matches!(
+                    trie.get_optimized_ref(&trie_key, KeyLookupMode::FlatStorage),
+                    Ok(Some(_))
+                );
             }
         }
         assert_eq!(trie.get_trie_nodes_count(), TrieNodesCount { db_reads: 0, mem_reads: 0 });
@@ -542,7 +545,7 @@ fn test_not_supported_block() {
         if height == flat_head_height {
             env.produce_block(0, START_HEIGHT);
         }
-        get_ref_results.push(trie.get_ref(&trie_key_bytes, KeyLookupMode::FlatStorage));
+        get_ref_results.push(trie.get_optimized_ref(&trie_key_bytes, KeyLookupMode::FlatStorage));
     }
 
     // The first result should be FlatStorageError, because we can't read from first chunk view anymore.


### PR DESCRIPTION
Previously in #9991 , `Trie::get` was improved so that it would not issue an on-disk lookup of a value if the value was fetched from flat storage and was already inlined in flat storage. However, during contract execution, the `Trie::get` code path is never executed; instead we still always go through `Trie::get_ref`.  The problem is that `Trie::get_ref` always throws away the value even if it's already available via `FlatStateValue::Inlined`, so that means during contract execution, the flat state inlined value is useless.

This PR applies the same optimization for contract executions. In fact, it cleans up the code so that it's less confusing than the state that the previous PR left it in. We're pretty much back to `get_ref` and `get`, except that `get_ref` is now changed to `get_optimized_ref`, and returns a reference that can be dereferenced efficiently if the value was already available. Gas accounting is now simpler too, because the value is considered accessed when and only when dereferencing it.