### PR TITLE
fix(fork-network): allow hyphen values for chain_id_suffix

### DIFF
--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -104,7 +104,7 @@ struct SetValidatorsCmd {
     pub validators: PathBuf,
     #[arg(short, long, default_value = "1000")]
     pub epoch_length: NumBlocks,
-    #[arg(long, default_value = "-fork")]
+    #[arg(long, default_value = "-fork", allow_hyphen_values = true)]
     pub chain_id_suffix: String,
 }
 


### PR DESCRIPTION
Fix for #10034

`chain_id_suffix` can now start with however many hyphens we want