### PR TITLE
feat(resharding): state-stats improvements

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -109,6 +109,7 @@ pub const EPOCH_START_INFO_BLOCKS: u64 = 500;
 
 /// Defines whether in case of adversarial block production invalid blocks can
 /// be produced.
+#[cfg(feature = "test_features")]
 #[derive(PartialEq, Eq)]
 pub enum AdvProduceBlocksMode {
     All,

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -9,7 +9,9 @@ use crate::adapter::{
     BlockApproval, BlockHeadersResponse, BlockResponse, ProcessTxRequest, ProcessTxResponse,
     RecvChallenge, SetNetworkInfo, StateResponse,
 };
-use crate::client::{AdvProduceBlocksMode, Client, EPOCH_START_INFO_BLOCKS};
+#[cfg(feature = "test_features")]
+use crate::client::AdvProduceBlocksMode;
+use crate::client::{Client, EPOCH_START_INFO_BLOCKS};
 use crate::config_updater::ConfigUpdater;
 use crate::debug::new_network_info_view;
 use crate::info::{display_sync_status, InfoHelper};

--- a/core/primitives/src/state_record.rs
+++ b/core/primitives/src/state_record.rs
@@ -17,7 +17,7 @@ use std::fmt::{Display, Formatter};
 
 /// Record in the state storage.
 #[serde_as]
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub enum StateRecord {
     /// Account information.
     Account { account_id: AccountId, account: Account },

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -8,6 +8,8 @@ use crate::tx_dump::dump_tx_from_block;
 use crate::{apply_chunk, epoch_info};
 use ansi_term::Color::Red;
 use bytesize::ByteSize;
+use itertools::GroupBy;
+use itertools::Itertools;
 use near_chain::chain::collect_receipts_from_response;
 use near_chain::migrations::check_if_block_is_first_with_chunk_of_version;
 use near_chain::types::ApplyTransactionResult;
@@ -27,9 +29,12 @@ use near_primitives::sharding::ChunkHash;
 use near_primitives::state::FlatStateValue;
 use near_primitives::state_record::state_record_to_account_id;
 use near_primitives::state_record::StateRecord;
+use near_primitives::trie_key::col::NON_DELAYED_RECEIPT_COLUMNS;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{chunk_extra::ChunkExtra, BlockHeight, ShardId, StateRoot};
 use near_primitives_core::types::Gas;
+use near_store::flat::FlatStorageChunkView;
+use near_store::flat::FlatStorageManager;
 use near_store::test_utils::create_test_store;
 use near_store::TrieStorage;
 use near_store::{DBCol, Store, Trie, TrieCache, TrieCachingStorage, TrieConfig, TrieDBStorage};
@@ -1063,39 +1068,28 @@ pub(crate) fn clear_cache(store: Store) {
 }
 
 #[derive(PartialEq, Eq)]
-pub struct StateStatsStateRecord {
-    key: Vec<u8>,
-    value: Vec<u8>,
+pub struct StateStatsAccount {
+    pub account_id: AccountId,
+    pub size: ByteSize,
 }
 
-impl StateStatsStateRecord {
-    pub fn size(&self) -> ByteSize {
-        ByteSize::b(self.key.len() as u64 + self.value.len() as u64)
-    }
-}
-
-impl Ord for StateStatsStateRecord {
+impl Ord for StateStatsAccount {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.size().cmp(&other.size()).reverse()
+        self.size.cmp(&other.size).reverse()
     }
 }
 
-impl PartialOrd for StateStatsStateRecord {
+impl PartialOrd for StateStatsAccount {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl std::fmt::Debug for StateStatsStateRecord {
+impl std::fmt::Debug for StateStatsAccount {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let state_record = StateRecord::from_raw_key_value(self.key.clone(), self.value.clone());
-
-        let Some(state_record) = state_record else { return None::<StateRecord>.fmt(f) };
-
         f.debug_struct("StateStatsStateRecord")
-            .field("account_id", &state_record_to_account_id(&state_record).as_str())
-            .field("type", &state_record.get_type_string())
-            .field("size", &self.size())
+            .field("account_id", &self.account_id.as_str())
+            .field("size", &self.size)
             .finish()
     }
 }
@@ -1105,9 +1099,8 @@ pub struct StateStats {
     pub total_size: ByteSize,
     pub total_count: usize,
 
-    pub top_state_records: BinaryHeap<StateStatsStateRecord>,
-
-    pub middle_state_record: Option<StateStatsStateRecord>,
+    pub middle_state_record: Option<StateStatsAccount>,
+    pub top_accounts: BinaryHeap<StateStatsAccount>,
 }
 
 impl core::fmt::Debug for StateStats {
@@ -1123,23 +1116,19 @@ impl core::fmt::Debug for StateStats {
             .field("total_count", &self.total_count)
             .field("average_size", &average_size)
             .field("middle_state_record", &self.middle_state_record.as_ref().unwrap())
-            .field("top_state_records", &self.top_state_records)
+            .field("top_accounts", &self.top_accounts)
             .finish()
     }
 }
 
 impl StateStats {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn push(&mut self, key: Vec<u8>, value: Vec<u8>) -> () {
-        self.total_size += key.len() as u64 + value.len() as u64;
+    pub fn push(&mut self, state_stats_account: StateStatsAccount) {
+        self.total_size += state_stats_account.size;
         self.total_count += 1;
 
-        self.top_state_records.push(StateStatsStateRecord { key, value });
-        if self.top_state_records.len() > 5 {
-            self.top_state_records.pop();
+        self.top_accounts.push(state_stats_account);
+        if self.top_accounts.len() > 5 {
+            self.top_accounts.pop();
         }
     }
 }
@@ -1161,47 +1150,129 @@ pub(crate) fn print_state_stats(home_dir: &Path, store: Store, near_config: Near
     let block_hash = *block_header.hash();
     let shard_layout = epoch_manager.get_shard_layout_from_prev_block(&block_hash).unwrap();
 
+    let flat_storage_manager = runtime.get_flat_storage_manager();
     for shard_uid in shard_layout.get_shard_uids() {
-        let flat_storage_manager = runtime.get_flat_storage_manager();
-        flat_storage_manager.create_flat_storage_for_shard(shard_uid).unwrap();
-        let trie_storage = TrieDBStorage::new(store.clone(), shard_uid);
-        let chunk_view = flat_storage_manager.chunk_view(shard_uid, block_hash).unwrap();
-
-        let mut state_stats = StateStats::new();
-
-        let iter = chunk_view.iter_flat_state_entries(None, None);
-        for item in iter {
-            let Ok((key, value)) = item else {
-                continue;
-            };
-
-            let value = read_flat_state_value(&trie_storage, value);
-
-            state_stats.push(key, value);
-        }
-
-        let middle_size = state_stats.total_size.as_u64() / 2;
-
-        let mut current_size = 0;
-        let iter = chunk_view.iter_flat_state_entries(None, None);
-        for item in iter {
-            let Ok((key, value)) = item else {
-                tracing::warn!(target: "state_viewer", ?item, "error in iter item");
-                continue;
-            };
-
-            let value = read_flat_state_value(&trie_storage, value);
-
-            current_size += key.len() + value.len();
-            if middle_size <= current_size as u64 {
-                state_stats.middle_state_record = Some(StateStatsStateRecord { key, value });
-                break;
-            }
-        }
-
-        tracing::info!(target: "state_viewer",  "{shard_uid:?}");
-        tracing::info!(target: "state_viewer",  "{state_stats:#?}");
+        print_state_stats_for_shard_uid(&store, &flat_storage_manager, block_hash, shard_uid);
     }
+}
+
+fn print_state_stats_for_shard_uid(
+    store: &Store,
+    flat_storage_manager: &FlatStorageManager,
+    block_hash: CryptoHash,
+    shard_uid: ShardUId,
+) {
+    flat_storage_manager.create_flat_storage_for_shard(shard_uid).unwrap();
+    let trie_storage = TrieDBStorage::new(store.clone(), shard_uid);
+    let chunk_view = flat_storage_manager.chunk_view(shard_uid, block_hash).unwrap();
+
+    let mut state_stats = StateStats::default();
+
+    // iteratate for the first time to get the size statistics
+    let group_by = get_state_stats_group_by(&chunk_view, &trie_storage);
+    let iter = get_state_stats_account_iter(&group_by);
+    for state_stats_account in iter {
+        state_stats.push(state_stats_account);
+    }
+
+    // iterate for the second time to find the middle account
+    let group_by = get_state_stats_group_by(&chunk_view, &trie_storage);
+    let iter = get_state_stats_account_iter(&group_by);
+    let mut current_size = ByteSize::default();
+    for state_stats_account in iter {
+        current_size += state_stats_account.size;
+        if 2 * current_size.as_u64() > state_stats.total_size.as_u64() {
+            state_stats.middle_state_record = Some(state_stats_account);
+            break;
+        }
+    }
+
+    tracing::info!(target: "state_viewer", "{shard_uid:?}");
+    tracing::info!(target: "state_viewer", "{state_stats:#?}");
+}
+
+#[derive(Eq, PartialEq)]
+struct StateStatsStateRecord {
+    account_id: AccountId,
+    state_record: StateRecord,
+    size: ByteSize,
+}
+
+impl Ord for StateStatsStateRecord {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.account_id.cmp(&other.account_id)
+    }
+}
+
+impl PartialOrd for StateStatsStateRecord {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+// Gets the flat state iterator and groups items by account id.
+fn get_state_stats_group_by<'a>(
+    chunk_view: &'a FlatStorageChunkView,
+    trie_storage: &'a TrieDBStorage,
+) -> GroupBy<
+    AccountId,
+    impl Iterator<Item = StateStatsStateRecord> + 'a,
+    impl FnMut(&StateStatsStateRecord) -> AccountId,
+> {
+    // let iter = chunk_view.iter_flat_state_entries(None, None);
+
+    let type_iters = NON_DELAYED_RECEIPT_COLUMNS
+        .iter()
+        .map(|(type_byte, _)| {
+            chunk_view.iter_flat_state_entries(Some(&[*type_byte]), Some(&[*type_byte + 1]))
+        })
+        .into_iter();
+
+    // filter out any errors
+    let type_iters = type_iters.map(|type_iter| type_iter.filter_map(|item| item.ok())).into_iter();
+
+    // convert to (StateRecord, size)
+    let type_iters = type_iters
+        .map(move |type_iter| {
+            type_iter.filter_map(move |(key, value)| {
+                let value = read_flat_state_value(&trie_storage, value);
+                let key_size = key.len() as u64;
+                let value_size = value.len() as u64;
+                let size = ByteSize::b(key_size + value_size);
+                let state_record = StateRecord::from_raw_key_value(key, value);
+                state_record.map(|state_record| StateStatsStateRecord {
+                    account_id: state_record_to_account_id(&state_record).clone(),
+                    state_record,
+                    size,
+                })
+            })
+        })
+        .into_iter();
+
+    let iter = type_iters.kmerge().into_iter();
+
+    // group by account id
+    iter.group_by(|state_record| state_record.account_id.clone())
+}
+
+fn get_state_stats_account_iter<'a>(
+    group_by: &'a GroupBy<
+        AccountId,
+        impl Iterator<Item = StateStatsStateRecord> + 'a,
+        impl FnMut(&StateStatsStateRecord) -> AccountId,
+    >,
+) -> impl Iterator<Item = StateStatsAccount> + 'a {
+    // aggregate size for each account id group
+    group_by
+        .into_iter()
+        .map(|(account_id, group)| {
+            let mut size = ByteSize::b(0);
+            for state_stats_state_record in group {
+                size += state_stats_state_record.size;
+            }
+            StateStatsAccount { account_id, size }
+        })
+        .into_iter()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- group records by account id and aggregate it to get the total size of all records belonging to each account is used
- re-arrange records to be sorted by account id, rather than type and account id

results on mainnet
```
2023-11-07T13:25:00.063905Z  INFO state_viewer: s0.v1
2023-11-07T13:25:00.063968Z  INFO state_viewer: StateStats {
    total_size: 6.5 GB,
    total_count: 18507133,
    average_size: 351 B,
    middle_state_record: StateStatsStateRecord {
        account_id: "66fde23ac459779474beb6d1f8b72164e67946de.lockup.near",
        size: 344.9 KB,
    },
    top_accounts: [
        StateStatsStateRecord {
            account_id: "athlete.promotional.basketball.playible.near",
            size: 10.0 MB,
        },
        StateStatsStateRecord {
            account_id: "amm.counselor.near",
            size: 11.7 MB,
        },
        StateStatsStateRecord {
            account_id: "asset-manager.orderly-network.near",
            size: 142.2 MB,
        },
        StateStatsStateRecord {
            account_id: "anthropocene.mintbase1.near",
            size: 18.0 MB,
        },
        StateStatsStateRecord {
            account_id: "alpha-x.raddx.near",
            size: 405.3 MB,
        },
    ],
}


2023-11-07T13:29:24.136367Z  INFO state_viewer: s1.v1
2023-11-07T13:29:24.136422Z  INFO state_viewer: StateStats {
    total_size: 5.9 GB,
    total_count: 1,
    average_size: 5.9 GB,
    middle_state_record: StateStatsStateRecord {
        account_id: "aurora",
        size: 5.9 GB,
    },
    top_accounts: [
        StateStatsStateRecord {
            account_id: "aurora",
            size: 5.9 GB,
        },
    ],
}


2023-11-07T13:32:37.941254Z  INFO state_viewer: s2.v1
2023-11-07T13:32:37.941309Z  INFO state_viewer: StateStats {
    total_size: 5.9 GB,
    total_count: 10006107,
    average_size: 587 B,
    middle_state_record: StateStatsStateRecord {
        account_id: "deadmau5.mintbase1.near",
        size: 168.2 MB,
    },
    top_accounts: [
        StateStatsStateRecord {
            account_id: "canvas-war.feiyu.near",
            size: 50.5 MB,
        },
        StateStatsStateRecord {
            account_id: "jars.sweat",
            size: 77.9 MB,
        },
        StateStatsStateRecord {
            account_id: "fusotao.octopus-registry.near",
            size: 51.8 MB,
        },
        StateStatsStateRecord {
            account_id: "deadmau5.mintbase1.near",
            size: 168.2 MB,
        },
        StateStatsStateRecord {
            account_id: "bridge-validator.sputnik-dao.near",
            size: 134.4 MB,
        },
    ],
}

2023-11-07T13:40:05.003453Z  INFO state_viewer: s3.v1
2023-11-07T13:40:05.003511Z  INFO state_viewer: StateStats {
    total_size: 11.3 GB,
    total_count: 3113322,
    average_size: 3.6 KB,
    middle_state_record: StateStatsStateRecord {
        account_id: "tge-lockup.sweat",
        size: 3.5 GB,
    },
    top_accounts: [
        StateStatsStateRecord {
            account_id: "wallet.kaiching",
            size: 158.4 MB,
        },
        StateStatsStateRecord {
            account_id: "nft.nearapps.near",
            size: 321.6 MB,
        },
        StateStatsStateRecord {
            account_id: "x.paras.near",
            size: 605.6 MB,
        },
        StateStatsStateRecord {
            account_id: "token.sweat",
            size: 1.4 GB,
        },
        StateStatsStateRecord {
            account_id: "tge-lockup.sweat",
            size: 3.5 GB,
        },
    ],
}
```