### PR TITLE
feat(epoch-sync): calculate legacy epoch_sync_data_hash from EpochSyncInfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4143,6 +4143,7 @@ dependencies = [
  "insta",
  "near-crypto",
  "near-fmt",
+ "near-o11y",
  "near-primitives-core",
  "near-rpc-error-macro",
  "near-stdx",

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -6007,6 +6007,10 @@ impl<'a> ChainUpdate<'a> {
             }
         }
 
+        // We don't need to save `next_epoch_first_hash` during `EpochSyncInfo` processing.
+        // It is only needed for validation.
+        headers_to_save.remove(next_epoch_first_hash);
+
         Ok((headers, headers_to_save))
     }
 

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -60,12 +60,14 @@ nightly = [
   "protocol_feature_reject_blocks_with_outdated_protocol_version",
   "protocol_feature_simple_nightshade_v2",
   "near-fmt/nightly",
+  "near-o11y/nightly",
   "near-primitives-core/nightly",
   "near-vm-runner/nightly",
 ]
 
 nightly_protocol = [
   "near-fmt/nightly_protocol",
+  "near-o11y/nightly_protocol",
   "near-primitives-core/nightly_protocol",
   "near-vm-runner/nightly_protocol",
 ]

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -39,6 +39,7 @@ tracing.workspace = true
 
 near-crypto.workspace = true
 near-fmt.workspace = true
+near-o11y.workspace = true
 near-primitives-core.workspace = true
 near-rpc-error-macro.workspace = true
 near-vm-runner.workspace = true

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -1212,7 +1212,7 @@ pub mod epoch_sync {
     use near_primitives_core::types::EpochHeight;
     use std::fmt::{Debug, Display};
 
-    #[derive(Eq, PartialEq, Clone)]
+    #[derive(Eq, PartialEq, Clone, strum::Display)]
     pub enum EpochSyncHashType {
         LastFinalBlock,
         FirstEpochBlock,
@@ -1220,26 +1220,13 @@ pub mod epoch_sync {
         Other,
     }
 
-    impl Display for EpochSyncHashType {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            match self {
-                EpochSyncHashType::LastFinalBlock => write!(f, "Last final block ",),
-                EpochSyncHashType::FirstEpochBlock => write!(f, "First epoch block ",),
-                EpochSyncHashType::NextEpochFirstBlock => write!(f, "Next epoch first block ",),
-                EpochSyncHashType::Other => write!(f, "",),
-            }
-        }
-    }
-
-    #[derive(Eq, PartialEq, Clone)]
+    #[derive(Eq, PartialEq, Clone, thiserror::Error)]
     pub enum EpochSyncInfoError {
         HashNotFound { hash: CryptoHash, hash_type: EpochSyncHashType, epoch_height: EpochHeight },
         ShortEpoch { epoch_height: EpochHeight },
     }
 
-    impl std::error::Error for EpochSyncInfoError {}
-
-    impl Display for EpochSyncInfoError {
+    impl EpochSyncInfoError {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             match self {
                 EpochSyncInfoError::HashNotFound { hash, hash_type, epoch_height } => {
@@ -1256,20 +1243,15 @@ pub mod epoch_sync {
         }
     }
 
+    impl Display for EpochSyncInfoError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            self.fmt(f)
+        }
+    }
+
     impl Debug for EpochSyncInfoError {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            match self {
-                EpochSyncInfoError::HashNotFound { hash, hash_type, epoch_height } => {
-                    write!(
-                        f,
-                        "{} hash {:?} not a part of EpochSyncInfo for epoch {:?}",
-                        hash_type, hash, epoch_height
-                    )
-                }
-                EpochSyncInfoError::ShortEpoch { epoch_height } => {
-                    write!(f, "all_block_hashes is empty for epoch {:?}", epoch_height)
-                }
-            }
+            self.fmt(f)
         }
     }
 }

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -1205,3 +1205,71 @@ impl From<near_vm_runner::logic::errors::FunctionCallError> for FunctionCallErro
         }
     }
 }
+
+#[cfg(feature = "new_epoch_sync")]
+pub mod epoch_sync {
+    use near_primitives_core::hash::CryptoHash;
+    use near_primitives_core::types::EpochHeight;
+    use std::fmt::{Debug, Display};
+
+    #[derive(Eq, PartialEq, Clone)]
+    pub enum EpochSyncHashType {
+        LastFinalBlock,
+        FirstEpochBlock,
+        NextEpochFirstBlock,
+        Other,
+    }
+
+    impl Display for EpochSyncHashType {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                EpochSyncHashType::LastFinalBlock => write!(f, "Last final block ",),
+                EpochSyncHashType::FirstEpochBlock => write!(f, "First epoch block ",),
+                EpochSyncHashType::NextEpochFirstBlock => write!(f, "Next epoch first block ",),
+                EpochSyncHashType::Other => write!(f, "",),
+            }
+        }
+    }
+
+    #[derive(Eq, PartialEq, Clone)]
+    pub enum EpochSyncInfoError {
+        HashNotFound { hash: CryptoHash, hash_type: EpochSyncHashType, epoch_height: EpochHeight },
+        ShortEpoch { epoch_height: EpochHeight },
+    }
+
+    impl std::error::Error for EpochSyncInfoError {}
+
+    impl Display for EpochSyncInfoError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                EpochSyncInfoError::HashNotFound { hash, hash_type, epoch_height } => {
+                    write!(
+                        f,
+                        "{} hash {:?} not a part of EpochSyncInfo for epoch {:?}",
+                        hash_type, hash, epoch_height
+                    )
+                }
+                EpochSyncInfoError::ShortEpoch { epoch_height } => {
+                    write!(f, "all_block_hashes.len() < 2 for epoch {:?}", epoch_height)
+                }
+            }
+        }
+    }
+
+    impl Debug for EpochSyncInfoError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                EpochSyncInfoError::HashNotFound { hash, hash_type, epoch_height } => {
+                    write!(
+                        f,
+                        "{} hash {:?} not a part of EpochSyncInfo for epoch {:?}",
+                        hash_type, hash, epoch_height
+                    )
+                }
+                EpochSyncInfoError::ShortEpoch { epoch_height } => {
+                    write!(f, "all_block_hashes is empty for epoch {:?}", epoch_height)
+                }
+            }
+        }
+    }
+}

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -1210,9 +1210,9 @@ impl From<near_vm_runner::logic::errors::FunctionCallError> for FunctionCallErro
 pub mod epoch_sync {
     use near_primitives_core::hash::CryptoHash;
     use near_primitives_core::types::EpochHeight;
-    use std::fmt::{Debug, Display};
+    use std::fmt::Debug;
 
-    #[derive(Eq, PartialEq, Clone, strum::Display)]
+    #[derive(Eq, PartialEq, Clone, strum::Display, Debug)]
     pub enum EpochSyncHashType {
         LastFinalBlock,
         FirstEpochBlock,
@@ -1220,38 +1220,11 @@ pub mod epoch_sync {
         Other,
     }
 
-    #[derive(Eq, PartialEq, Clone, thiserror::Error)]
+    #[derive(Eq, PartialEq, Clone, thiserror::Error, Debug)]
     pub enum EpochSyncInfoError {
+        #[error("{hash_type} hash {hash:?} not a part of EpochSyncInfo for epoch {epoch_height}")]
         HashNotFound { hash: CryptoHash, hash_type: EpochSyncHashType, epoch_height: EpochHeight },
+        #[error("all_block_hashes.len() < 2 for epoch {epoch_height}")]
         ShortEpoch { epoch_height: EpochHeight },
-    }
-
-    impl EpochSyncInfoError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            match self {
-                EpochSyncInfoError::HashNotFound { hash, hash_type, epoch_height } => {
-                    write!(
-                        f,
-                        "{} hash {:?} not a part of EpochSyncInfo for epoch {:?}",
-                        hash_type, hash, epoch_height
-                    )
-                }
-                EpochSyncInfoError::ShortEpoch { epoch_height } => {
-                    write!(f, "all_block_hashes.len() < 2 for epoch {:?}", epoch_height)
-                }
-            }
-        }
-    }
-
-    impl Display for EpochSyncInfoError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            self.fmt(f)
-        }
-    }
-
-    impl Debug for EpochSyncInfoError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            self.fmt(f)
-        }
     }
 }


### PR DESCRIPTION
First part of #10031
Adding support for `EpochInfo` validation through `epoch_sync_data_hash` in new epoch sync.

Included in PR:
- reconstruction of `BlockInfo` headers
- calculation of `epoch_sync_data_hash` from `EpochSyncInfo`
- bad attempt at good errors in all of that
- test for both `BlockInfo` and `epoch_sync_data_hash` reconstruction

Coming next: epoch sync testing tool, specifically command to test that reconstructed `epoch_sync_data_hash` matches recorded `epoch_sync_data_hash` on all real data in testnet/mainnet.