### PR TITLE
fix(integration-tests): fix protocol version in test_protocol_config_rpc

### DIFF
--- a/integration-tests/src/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/src/tests/nearcore/rpc_nodes.rs
@@ -247,7 +247,8 @@ fn test_protocol_config_rpc() {
 
         let runtime_config_store = RuntimeConfigStore::new(None);
         let intial_runtime_config = runtime_config_store.get_config(ProtocolVersion::MIN);
-        let latest_runtime_config = runtime_config_store.get_config(near_primitives::version::PROTOCOL_VERSION);
+        let latest_runtime_config =
+            runtime_config_store.get_config(near_primitives::version::PROTOCOL_VERSION);
         assert_ne!(
             config_response.config_view.runtime_config.storage_amount_per_byte,
             intial_runtime_config.storage_amount_per_byte()

--- a/integration-tests/src/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/src/tests/nearcore/rpc_nodes.rs
@@ -247,7 +247,7 @@ fn test_protocol_config_rpc() {
 
         let runtime_config_store = RuntimeConfigStore::new(None);
         let intial_runtime_config = runtime_config_store.get_config(ProtocolVersion::MIN);
-        let latest_runtime_config = runtime_config_store.get_config(ProtocolVersion::MAX);
+        let latest_runtime_config = runtime_config_store.get_config(near_primitives::version::PROTOCOL_VERSION);
         assert_ne!(
             config_response.config_view.runtime_config.storage_amount_per_byte,
             intial_runtime_config.storage_amount_per_byte()


### PR DESCRIPTION
this test checks that the result of the EXPERIMENTAL_protocol_config rpc matches the stored protocol config, but the rpc response will give the latest stable protocol version's config, and the protocol config returned when asking for ProtocolVersion::MAX is going to be the nightly one, which might not match the stable protocol config