### PR TITLE
state parts dump to use 4040 as default prometheus port

### DIFF
--- a/tools/state-parts-dump-check/src/cli.rs
+++ b/tools/state-parts-dump-check/src/cli.rs
@@ -52,7 +52,7 @@ pub enum StatePartsDumpCheckSubCommand {
 #[derive(clap::Parser)]
 pub struct LoopCheckCommand {
     /// Listen address for prometheus metrics.
-    #[clap(long, default_value = "0.0.0.0:9090")]
+    #[clap(long, default_value = "0.0.0.0:4040")]
     prometheus_addr: String,
     // address of RPC server to retrieve latest block, epoch information
     #[clap(long)]


### PR DESCRIPTION
change default prometheus addr from 0.0.0.0:9090 to 4040