### PR TITLE
fix(nightly): Remove deleted test from list

### DIFF
--- a/integration-tests/src/tests/nearcore/rpc_error_structs.rs
+++ b/integration-tests/src/tests/nearcore/rpc_error_structs.rs
@@ -347,7 +347,8 @@ fn test_receipt_id_unknown_receipt_error() {
 /// Sends tx to first light client through `broadcast_tx_commit` and checks that the transaction has failed.
 /// Checks if the struct is expected and contains the proper data
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
+#[ignore = "Invalid test setup. broadcast_tx_commit times out. Fix and reenable."]
+// #[cfg_attr(not(feature = "expensive_tests"), ignore)]
 fn test_tx_invalid_tx_error() {
     init_integration_logger();
 

--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -201,10 +201,6 @@ expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_q
 expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_query_rpc_account_view_account_doesnt_exist_must_return_error --features nightly
 expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_query_rpc_account_view_must_succeed
 expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_query_rpc_account_view_must_succeed --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_send_tx_sync_returns_transaction_hash
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_send_tx_sync_returns_transaction_hash --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_send_tx_sync_to_lightclient_must_be_routed
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_send_tx_sync_to_lightclient_must_be_routed --features nightly
 expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_tx_not_enough_balance_must_return_error
 expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_tx_not_enough_balance_must_return_error --features nightly
 expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_validators_by_epoch_id_current_epoch_not_fails


### PR DESCRIPTION
Tests were removed so I am excluding them from nightly nayduck run.
One test was changed [here](https://github.com/near/nearcore/pull/9596/files#r1386748297). 