### PR TITLE
fix: use cargo-bolero with a fix for `cargo bolero list` with failing tests

### DIFF
--- a/.github/workflows/master_fuzzer_binaries.yml
+++ b/.github/workflows/master_fuzzer_binaries.yml
@@ -28,6 +28,9 @@ jobs:
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: cargo-bolero
+          # TODO: remove the below once https://github.com/camshaft/bolero/pull/195 lands
+          git: https://github.com/camshaft/bolero
+          rev: 8c5a50a57b0e4c4cc8111cfd95670dc75cd2dea7
 
       - run: rustup target add --toolchain nightly wasm32-unknown-unknown
 

--- a/.github/workflows/master_fuzzer_binaries.yml
+++ b/.github/workflows/master_fuzzer_binaries.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: cargo-bolero
-          # TODO: remove the below once https://github.com/camshaft/bolero/pull/195 lands
+          # TODO: remove the below once https://github.com/camshaft/bolero/pull/195 is released on crates.io
           git: https://github.com/camshaft/bolero
           rev: 8c5a50a57b0e4c4cc8111cfd95670dc75cd2dea7
 

--- a/.github/workflows/ondemand_fuzzer_binaries.yml
+++ b/.github/workflows/ondemand_fuzzer_binaries.yml
@@ -54,6 +54,9 @@ jobs:
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: cargo-bolero
+          # TODO: remove the below once https://github.com/camshaft/bolero/pull/195 lands
+          git: https://github.com/camshaft/bolero
+          rev: 8c5a50a57b0e4c4cc8111cfd95670dc75cd2dea7
 
       - run: rustup target add --toolchain nightly wasm32-unknown-unknown
 


### PR DESCRIPTION
We have tests that fail with `cargo test`, and this throws off `cargo bolero list`, that runs `cargo test` to list the fuzzers.

With this change, we add camshaft/bolero#195, that ignores such failures and actually lists all fuzzers.

This should fix the issue, that all the latest uploads to the fuzzers bucket actually were empty tarballs.