### PR TITLE
[Memtrie] No longer use mmap for memtrie arena.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4311,7 +4311,6 @@ dependencies = [
  "itertools",
  "itoa",
  "lru",
- "memmap2",
  "near-chain",
  "near-chain-configs",
  "near-chunks",

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -23,7 +23,6 @@ hex.workspace = true
 itoa.workspace = true
 itertools.workspace = true
 lru.workspace = true
-memmap2.workspace = true
 num_cpus.workspace = true
 once_cell.workspace = true
 rand.workspace = true

--- a/core/store/src/trie/mem/arena/alloc.rs
+++ b/core/store/src/trie/mem/arena/alloc.rs
@@ -1,17 +1,18 @@
 use near_o11y::metrics::IntGauge;
 
 use super::metrics::MEM_TRIE_ARENA_ACTIVE_ALLOCS_COUNT;
-use super::{ArenaMemory, ArenaSliceMut};
+use super::{ArenaMemory, ArenaPos, ArenaSliceMut};
 use crate::trie::mem::arena::metrics::{
     MEM_TRIE_ARENA_ACTIVE_ALLOCS_BYTES, MEM_TRIE_ARENA_MEMORY_USAGE_BYTES,
 };
+use crate::trie::mem::flexible_data::encoding::BorshFixedSize;
 
 /// Simple bump allocator with freelists. Allocations are rounded up to its
 /// allocation class, so that deallocated memory can be reused by a similarly
 /// sized allocation.
 pub struct Allocator {
-    freelists: [usize; NUM_ALLOCATION_CLASSES],
-    next_ptr: usize,
+    freelists: [ArenaPos; NUM_ALLOCATION_CLASSES],
+    next_ptr: ArenaPos,
 
     // Stats. Note that keep the bytes and count locally too because the
     // gauges are process-wide, so stats-keeping directly with those may not be
@@ -26,6 +27,7 @@ pub struct Allocator {
 const MAX_ALLOC_SIZE: usize = 16 * 1024;
 const ROUND_UP_TO_8_BYTES_UNDER: usize = 256;
 const ROUND_UP_TO_64_BYTES_UNDER: usize = 1024;
+const CHUNK_SIZE: usize = 4 * 1024 * 1024;
 
 /// Calculates the allocation class (an index from 0 to NUM_ALLOCATION_CLASSES)
 /// for the given size that we wish to allocate.
@@ -56,8 +58,8 @@ const NUM_ALLOCATION_CLASSES: usize = allocation_class(MAX_ALLOC_SIZE) + 1;
 impl Allocator {
     pub fn new(name: String) -> Self {
         Self {
-            freelists: [usize::MAX; NUM_ALLOCATION_CLASSES],
-            next_ptr: 0,
+            freelists: [ArenaPos::invalid(); NUM_ALLOCATION_CLASSES],
+            next_ptr: ArenaPos::invalid(),
             active_allocs_bytes: 0,
             active_allocs_count: 0,
             active_allocs_bytes_gauge: MEM_TRIE_ARENA_ACTIVE_ALLOCS_BYTES
@@ -66,6 +68,14 @@ impl Allocator {
                 .with_label_values(&[&name]),
             memory_usage_gauge: MEM_TRIE_ARENA_MEMORY_USAGE_BYTES.with_label_values(&[&name]),
         }
+    }
+
+    /// Adds a new page to the arena, and updates the next_ptr to the beginning of
+    /// the new page.
+    fn new_page(&mut self, arena: &mut ArenaMemory) {
+        arena.chunks.push(vec![0; CHUNK_SIZE]);
+        self.next_ptr = ArenaPos { chunk: (arena.chunks.len() - 1) as u32, pos: 0 };
+        self.memory_usage_gauge.set(arena.chunks.len() as i64 * CHUNK_SIZE as i64);
     }
 
     /// Allocates a slice of the given size in the arena.
@@ -77,38 +87,32 @@ impl Allocator {
         self.active_allocs_count_gauge.set(self.active_allocs_count as i64);
         let size_class = allocation_class(size);
         let allocation_size = allocation_size(size_class);
-        if self.freelists[size_class] == usize::MAX {
-            if arena.mmap.len() < self.next_ptr + allocation_size {
-                panic!(
-                    "In-memory trie Arena out of memory; configured as {} bytes maximum,
-                    tried to allocate {} when {} bytes already used",
-                    arena.mmap.len(),
-                    allocation_size,
-                    self.next_ptr
-                );
+        if self.freelists[size_class].is_invalid() {
+            if self.next_ptr.is_invalid()
+                || arena.chunks[self.next_ptr.chunk as usize].len()
+                    <= self.next_ptr.pos as usize + allocation_size
+            {
+                self.new_page(arena);
             }
             let ptr = self.next_ptr;
-            self.next_ptr += allocation_size;
-            self.memory_usage_gauge.set(self.next_ptr as i64);
+            self.next_ptr = self.next_ptr.offset(allocation_size);
             arena.slice_mut(ptr, size)
         } else {
             let pos = self.freelists[size_class];
-            self.freelists[size_class] = arena.ptr(pos).read_usize();
+            self.freelists[size_class] = arena.ptr(pos).read_pos();
             arena.slice_mut(pos, size)
         }
     }
 
     /// Deallocates the given slice from the arena; the slice's `pos` and `len`
     /// must be the same as an allocation that was returned earlier.
-    pub fn deallocate(&mut self, arena: &mut ArenaMemory, pos: usize, len: usize) {
+    pub fn deallocate(&mut self, arena: &mut ArenaMemory, pos: ArenaPos, len: usize) {
         self.active_allocs_bytes -= len;
         self.active_allocs_count -= 1;
         self.active_allocs_bytes_gauge.set(self.active_allocs_bytes as i64);
         self.active_allocs_count_gauge.set(self.active_allocs_count as i64);
         let size_class = allocation_class(len);
-        arena
-            .slice_mut(pos, allocation_size(size_class))
-            .write_usize_at(0, self.freelists[size_class]);
+        arena.slice_mut(pos, ArenaPos::SERIALIZED_SIZE).write_pos_at(0, self.freelists[size_class]);
         self.freelists[size_class] = pos;
     }
 
@@ -126,11 +130,11 @@ mod test {
 
     #[test]
     fn test_allocate_deallocate() {
-        let mut arena = Arena::new(10000, "".to_owned());
-        // Repeatedly allocate and deallocate; we should not run out of memory.
-        for i in 0..1000 {
+        let mut arena = Arena::new("".to_owned());
+        // Repeatedly allocate and deallocate.
+        for i in 0..10 {
             let mut slices = Vec::new();
-            for size in 1..=100 {
+            for size in (1..=16384).step_by(3) {
                 let mut alloc = arena.alloc(size);
                 // Check that the allocated length is large enough.
                 assert!(alloc.len >= size);
@@ -144,12 +148,32 @@ mod test {
             slices.sort_by_key(|(pos, _)| *pos);
             // Check that the allocated intervals don't overlap.
             for i in 1..slices.len() {
-                assert!(slices[i - 1].0 + slices[i - 1].1 <= slices[i].0);
+                assert!(slices[i - 1].0.offset(slices[i - 1].1) <= slices[i].0);
             }
             for (pos, len) in slices {
                 arena.dealloc(pos, len);
             }
         }
+    }
+
+    #[test]
+    fn test_allocation_reuse() {
+        let mut arena = Arena::new("".to_owned());
+        // Repeatedly allocate and deallocate. New allocations should reuse
+        // old deallocated memory.
+        for _ in 0..10 {
+            let mut slices = Vec::new();
+            for _ in 0..2000 {
+                let alloc = arena.alloc(8192);
+                slices.push((alloc.pos, alloc.len));
+            }
+            for (pos, len) in slices {
+                arena.dealloc(pos, len);
+            }
+        }
+        assert_eq!(arena.num_active_allocs(), 0);
+        // 8192 * 2000 <= 16MB, so we should have allocated only 4 chunks.
+        assert_eq!(arena.memory.chunks.len(), 4);
     }
 
     #[test]

--- a/core/store/src/trie/mem/arena/mod.rs
+++ b/core/store/src/trie/mem/arena/mod.rs
@@ -2,10 +2,11 @@ mod alloc;
 mod metrics;
 use self::alloc::Allocator;
 use borsh::{BorshDeserialize, BorshSerialize};
-use memmap2::{MmapMut, MmapOptions};
-use std::fmt::{Debug, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
 use std::mem::size_of;
+
+use super::flexible_data::encoding::BorshFixedSize;
 
 /// Arena to store in-memory trie nodes.
 /// Includes a bump allocator that can free nodes.
@@ -25,40 +26,81 @@ pub struct Arena {
 /// or `ArenaSlice` (range of bytes) to read the actual memory, and the
 /// mutable versions `ArenaPtrMut` and `ArenaSliceMut` to write memory.
 pub struct ArenaMemory {
-    mmap: MmapMut,
+    chunks: Vec<Vec<u8>>,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Hash,
+    PartialEq,
+    Eq,
+    Default,
+    PartialOrd,
+    Ord,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+pub struct ArenaPos {
+    chunk: u32,
+    pos: u32,
+}
+
+impl BorshFixedSize for ArenaPos {
+    const SERIALIZED_SIZE: usize = 8;
+}
+
+impl Display for ArenaPos {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "c{:x}:p{:x}", self.chunk, self.pos)
+    }
+}
+
+impl ArenaPos {
+    pub fn offset(self, offset: usize) -> Self {
+        Self { chunk: self.chunk, pos: self.pos + offset as u32 }
+    }
+
+    pub(crate) const fn invalid() -> Self {
+        Self { chunk: u32::MAX, pos: u32::MAX }
+    }
+
+    pub(crate) const fn is_invalid(&self) -> bool {
+        self.chunk == u32::MAX && self.pos == u32::MAX
+    }
 }
 
 impl ArenaMemory {
-    fn new(max_size_in_bytes: usize) -> Self {
-        let mmap = MmapOptions::new().len(max_size_in_bytes).map_anon().expect("mmap failed");
-        Self { mmap }
+    fn new() -> Self {
+        Self { chunks: Vec::new() }
     }
 
-    fn raw_slice(&self, pos: usize, len: usize) -> &[u8] {
-        &self.mmap[pos..pos + len]
+    fn raw_slice(&self, pos: ArenaPos, len: usize) -> &[u8] {
+        &self.chunks[pos.chunk as usize][pos.pos as usize..pos.pos as usize + len]
     }
 
-    fn raw_slice_mut(&mut self, pos: usize, len: usize) -> &mut [u8] {
-        &mut self.mmap[pos..pos + len]
+    fn raw_slice_mut(&mut self, pos: ArenaPos, len: usize) -> &mut [u8] {
+        &mut self.chunks[pos.chunk as usize][pos.pos as usize..pos.pos as usize + len]
     }
 
     /// Provides read access to a region of memory in the arena.
-    pub fn slice<'a>(&'a self, pos: usize, len: usize) -> ArenaSlice<'a> {
+    pub fn slice<'a>(&'a self, pos: ArenaPos, len: usize) -> ArenaSlice<'a> {
         ArenaSlice { arena: self, pos, len }
     }
 
     /// Provides write access to a region of memory in the arena.
-    pub fn slice_mut<'a>(&'a mut self, pos: usize, len: usize) -> ArenaSliceMut<'a> {
+    pub fn slice_mut<'a>(&'a mut self, pos: ArenaPos, len: usize) -> ArenaSliceMut<'a> {
         ArenaSliceMut { arena: self, pos, len }
     }
 
     /// Represents some position in the arena but without a known length.
-    pub fn ptr<'a>(self: &'a Self, pos: usize) -> ArenaPtr<'a> {
+    pub fn ptr<'a>(self: &'a Self, pos: ArenaPos) -> ArenaPtr<'a> {
         ArenaPtr { arena: self, pos }
     }
 
     /// Like `ptr` but with write access.
-    pub fn ptr_mut<'a>(self: &'a mut Self, pos: usize) -> ArenaPtrMut<'a> {
+    pub fn ptr_mut<'a>(self: &'a mut Self, pos: ArenaPos) -> ArenaPtrMut<'a> {
         ArenaPtrMut { arena: self, pos }
     }
 }
@@ -68,8 +110,8 @@ impl Arena {
     /// The `max_size_in_bytes` can be conservatively large as long as it
     /// can fit into virtual memory (which there are terabytes of). The actual
     /// memory usage will only be as much as is needed.
-    pub fn new(max_size_in_bytes: usize, name: String) -> Self {
-        Self { memory: ArenaMemory::new(max_size_in_bytes), allocator: Allocator::new(name) }
+    pub fn new(name: String) -> Self {
+        Self { memory: ArenaMemory::new(), allocator: Allocator::new(name) }
     }
 
     /// Allocates a slice of the given size in the arena.
@@ -79,7 +121,7 @@ impl Arena {
 
     /// Deallocates the given slice from the arena; the slice's `pos` and `len`
     /// must be the same as an allocation that was returned earlier.
-    pub fn dealloc(&mut self, pos: usize, len: usize) {
+    pub fn dealloc(&mut self, pos: ArenaPos, len: usize) {
         self.allocator.deallocate(&mut self.memory, pos, len);
     }
 
@@ -102,12 +144,12 @@ impl Arena {
 #[derive(Clone, Copy)]
 pub struct ArenaPtr<'a> {
     arena: &'a ArenaMemory,
-    pos: usize,
+    pos: ArenaPos,
 }
 
 impl<'a> Debug for ArenaPtr<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "arena[{:x}]", self.pos)
+        write!(f, "arena[{}]", self.pos)
     }
 }
 
@@ -129,11 +171,11 @@ impl<'a> Eq for ArenaPtr<'a> {}
 impl<'a> ArenaPtr<'a> {
     /// Returns a slice relative to this pointer.
     pub fn slice(&self, offset: usize, len: usize) -> ArenaSlice<'a> {
-        ArenaSlice { arena: self.arena, pos: self.pos + offset, len }
+        ArenaSlice { arena: self.arena, pos: self.pos.offset(offset), len }
     }
 
-    /// Returns the offset to the beginning of the arena.
-    pub fn raw_offset(&self) -> usize {
+    /// Returns the raw position in the arena.
+    pub fn raw_pos(&self) -> ArenaPos {
         self.pos
     }
 
@@ -141,9 +183,9 @@ impl<'a> ArenaPtr<'a> {
         self.arena
     }
 
-    /// Reads a usize at the memory pointed to by this pointer.
-    pub fn read_usize(&self) -> usize {
-        usize::try_from_slice(&self.arena.raw_slice(self.pos, size_of::<usize>())).unwrap()
+    /// Reads an ArenaPos at the memory pointed to by this pointer.
+    pub fn read_pos(&self) -> ArenaPos {
+        ArenaPos::try_from_slice(&self.arena.raw_slice(self.pos, size_of::<usize>())).unwrap()
     }
 }
 
@@ -151,13 +193,13 @@ impl<'a> ArenaPtr<'a> {
 #[derive(Clone)]
 pub struct ArenaSlice<'a> {
     arena: &'a ArenaMemory,
-    pos: usize,
+    pos: ArenaPos,
     len: usize,
 }
 
 impl<'a> Debug for ArenaSlice<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "arena[{:x}..{:x}]", self.pos, self.pos + self.len)
+        write!(f, "arena[{}..{:x}]", self.pos, self.pos.pos as usize + self.len)
     }
 }
 
@@ -172,28 +214,28 @@ impl<'a> ArenaSlice<'a> {
     }
 
     /// Provides direct access to the memory.
-    pub fn raw_slice(&self) -> &'a [u8] {
+    pub fn raw_slice(&self) -> &[u8] {
         &self.arena.raw_slice(self.pos, self.len)
     }
 
     /// Reads a usize at the given offset in the slice (bounds checked),
     /// and returns it as a pointer.
     pub fn read_ptr_at(&self, pos: usize) -> ArenaPtr<'a> {
-        let pos = usize::try_from_slice(&self.raw_slice()[pos..][..size_of::<usize>()]).unwrap();
+        let pos = ArenaPos::try_from_slice(&self.raw_slice()[pos..][..size_of::<usize>()]).unwrap();
         ArenaPtr { arena: self.arena, pos }
     }
 
     /// Returns a slice within this slice. This checks bounds.
     pub fn subslice(&self, start: usize, len: usize) -> ArenaSlice<'a> {
         assert!(start + len <= self.len);
-        ArenaSlice { arena: self.arena, pos: self.pos + start, len }
+        ArenaSlice { arena: self.arena, pos: self.pos.offset(start), len }
     }
 }
 
 /// Like `ArenaPtr` but allows writing to the memory.
 pub struct ArenaPtrMut<'a> {
     arena: &'a mut ArenaMemory,
-    pos: usize,
+    pos: ArenaPos,
 }
 
 impl<'a> ArenaPtrMut<'a> {
@@ -212,12 +254,12 @@ impl<'a> ArenaPtrMut<'a> {
     /// Makes a slice relative to the pointer, which can only be used while
     /// also holding a mutable reference to the original pointer.
     pub fn slice<'b>(&'b self, offset: usize, len: usize) -> ArenaSlice<'b> {
-        ArenaSlice { arena: self.arena, pos: self.pos + offset, len }
+        ArenaSlice { arena: self.arena, pos: self.pos.offset(offset), len }
     }
 
     /// Like `slice` but makes a mutable slice.
     pub fn slice_mut<'b>(&'b mut self, offset: usize, len: usize) -> ArenaSliceMut<'b> {
-        ArenaSliceMut { arena: self.arena, pos: self.pos + offset, len }
+        ArenaSliceMut { arena: self.arena, pos: self.pos.offset(offset), len }
     }
 
     /// Provides mutable access to the whole memory, while holding a mutable
@@ -230,12 +272,12 @@ impl<'a> ArenaPtrMut<'a> {
 /// Represents a mutable slice of memory in the arena.
 pub struct ArenaSliceMut<'a> {
     arena: &'a mut ArenaMemory,
-    pos: usize,
+    pos: ArenaPos,
     len: usize,
 }
 
 impl<'a> ArenaSliceMut<'a> {
-    pub fn raw_offset(&self) -> usize {
+    pub fn raw_pos(&self) -> ArenaPos {
         self.pos
     }
 
@@ -243,16 +285,18 @@ impl<'a> ArenaSliceMut<'a> {
         self.len
     }
 
-    /// Writes a usize at the given offset in the slice (bounds checked).
-    pub fn write_usize_at(&mut self, pos: usize, ptr: usize) {
-        assert!(pos + size_of::<usize>() <= self.len);
-        ptr.serialize(&mut &mut self.arena.raw_slice_mut(self.pos + pos, size_of::<usize>()))
+    /// Writes a ArenaPos at the given offset in the slice (bounds checked).
+    pub fn write_pos_at(&mut self, offset: usize, to_write: ArenaPos) {
+        assert!(offset + size_of::<ArenaPos>() <= self.len);
+        to_write
+            .serialize(
+                &mut &mut self.arena.raw_slice_mut(self.pos.offset(offset), size_of::<usize>()),
+            )
             .unwrap();
     }
 
-    /// Provides mutable raw memory access. It is only possible while holding
-    /// a mutable reference to the original slice.
-    pub fn raw_slice_mut<'b>(&'b mut self) -> &'b mut [u8] {
+    /// Provides mutable raw memory access.
+    pub fn raw_slice_mut(&mut self) -> &mut [u8] {
         self.arena.raw_slice_mut(self.pos, self.len)
     }
 
@@ -260,43 +304,37 @@ impl<'a> ArenaSliceMut<'a> {
     /// holding a mutable reference to the original slice.
     pub fn subslice_mut<'b>(&'b mut self, start: usize, len: usize) -> ArenaSliceMut<'b> {
         assert!(start + len <= self.len);
-        ArenaSliceMut { arena: self.arena, pos: self.pos + start, len }
+        ArenaSliceMut { arena: self.arena, pos: self.pos.offset(start), len }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    #[test]
-    fn test_arena_mmap() {
-        let mut arena1 = super::ArenaMemory::new(1);
-        let mut arena2 = super::ArenaMemory::new(1000);
-        let mut arena3 = super::ArenaMemory::new(10000);
-        let mut arena4 = super::ArenaMemory::new(100000);
-        let size_100gb = 100 * 1024 * 1024 * 1024;
-        // 100GB is a lot, but it's all virtual memory so it's fine in 64-bit.
-        let mut arena5 = super::ArenaMemory::new(size_100gb);
-        arena1.raw_slice_mut(0, 1).fill(1);
-        arena2.raw_slice_mut(0, 1000).fill(2);
-        arena3.raw_slice_mut(0, 10000).fill(3);
-        arena4.raw_slice_mut(0, 100000).fill(4);
-        arena5.raw_slice_mut(size_100gb - 100, 100).fill(5);
-        assert!(arena1.raw_slice(0, 1).iter().all(|x| *x == 1));
-        assert!(arena2.raw_slice(0, 1000).iter().all(|x| *x == 2));
-        assert!(arena3.raw_slice(0, 10000).iter().all(|x| *x == 3));
-        assert!(arena4.raw_slice(0, 100000).iter().all(|x| *x == 4));
-        assert!(arena5.raw_slice(size_100gb - 100, 100).iter().all(|x| *x == 5));
-    }
+    use crate::trie::mem::arena::ArenaPos;
 
     #[test]
     fn test_arena_ptr_and_slice() {
-        let mut arena = super::ArenaMemory::new(10 * 4096);
+        let mut arena = super::ArenaMemory::new();
+        arena.chunks.push(vec![0; 1000]);
+        arena.chunks.push(vec![0; 1000]);
 
-        arena.ptr_mut(8).slice_mut(4, 16).write_usize_at(6, 123456);
-        assert_eq!(arena.ptr(8).slice(4, 16).read_ptr_at(6).raw_offset(), 123456);
-        assert_eq!(arena.slice(18, 8).read_ptr_at(0).raw_offset(), 123456);
+        let chunk1 = ArenaPos { chunk: 1, pos: 0 };
 
-        arena.slice_mut(10, 20).subslice_mut(1, 8).write_usize_at(0, 234567);
-        assert_eq!(arena.slice(10, 20).subslice(1, 8).read_ptr_at(0).raw_offset(), 234567);
-        assert_eq!(arena.slice(11, 8).read_ptr_at(0).raw_offset(), 234567);
+        arena.ptr_mut(chunk1.offset(8)).slice_mut(4, 16).write_pos_at(6, chunk1.offset(123));
+        assert_eq!(
+            arena.ptr(chunk1.offset(8)).slice(4, 16).read_ptr_at(6).raw_pos(),
+            chunk1.offset(123)
+        );
+        assert_eq!(arena.slice(chunk1.offset(18), 8).read_ptr_at(0).raw_pos(), chunk1.offset(123));
+
+        arena
+            .slice_mut(chunk1.offset(10), 20)
+            .subslice_mut(1, 8)
+            .write_pos_at(0, chunk1.offset(234));
+        assert_eq!(
+            arena.slice(chunk1.offset(10), 20).subslice(1, 8).read_ptr_at(0).raw_pos(),
+            chunk1.offset(234)
+        );
+        assert_eq!(arena.slice(chunk1.offset(11), 8).read_ptr_at(0).raw_pos(), chunk1.offset(234));
     }
 }

--- a/core/store/src/trie/mem/flexible_data/children.rs
+++ b/core/store/src/trie/mem/flexible_data/children.rs
@@ -46,7 +46,7 @@ impl FlexibleDataHeader for EncodedChildrenHeader {
         let mut j = 0;
         for (i, child) in children.into_iter().enumerate() {
             if self.mask & (1 << i) != 0 {
-                target.write_usize_at(j, child.unwrap().pos);
+                target.write_pos_at(j, child.unwrap().pos);
                 j += size_of::<usize>();
             } else {
                 debug_assert!(child.is_none());

--- a/core/store/src/trie/mem/mod.rs
+++ b/core/store/src/trie/mem/mod.rs
@@ -45,9 +45,9 @@ pub struct MemTries {
 }
 
 impl MemTries {
-    pub fn new(arena_size_in_bytes: usize, shard_uid: ShardUId) -> Self {
+    pub fn new(shard_uid: ShardUId) -> Self {
         Self {
-            arena: Arena::new(arena_size_in_bytes, shard_uid.to_string()),
+            arena: Arena::new(shard_uid.to_string()),
             roots: HashMap::new(),
             heights: Default::default(),
             shard_uid,
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn test_construct_empty_trie() {
-        let mut tries = MemTries::new(1024 * 1024, ShardUId::single_shard());
+        let mut tries = MemTries::new(ShardUId::single_shard());
         let state_root =
             tries.construct_root(123, |_| -> Result<Option<MemTrieNodeId>, ()> { Ok(None) });
         assert_eq!(state_root, Ok(CryptoHash::default()));
@@ -200,7 +200,7 @@ mod tests {
         //    height.
         //
         // And we make sure that the GC refcounting works correctly.
-        let mut tries = MemTries::new(1024 * 1024 * 1024, ShardUId::single_shard());
+        let mut tries = MemTries::new(ShardUId::single_shard());
         let mut available_hashes: Vec<(BlockHeight, CryptoHash)> = Vec::new();
         for height in 100..=200 {
             let num_roots_at_height = rand::thread_rng().gen_range(1..=4);

--- a/core/store/src/trie/mem/node/encoding.rs
+++ b/core/store/src/trie/mem/node/encoding.rs
@@ -1,5 +1,5 @@
 use super::{InputMemTrieNode, MemTrieNodeId, MemTrieNodePtr, MemTrieNodeView};
-use crate::trie::mem::arena::Arena;
+use crate::trie::mem::arena::{Arena, ArenaPos};
 use crate::trie::mem::flexible_data::children::EncodedChildrenHeader;
 use crate::trie::mem::flexible_data::encoding::{BorshFixedSize, RawDecoder, RawEncoder};
 use crate::trie::mem::flexible_data::extension::EncodedExtensionHeader;
@@ -62,14 +62,14 @@ impl BorshFixedSize for LeafHeader {
 pub(crate) struct ExtensionHeader {
     common: CommonHeader,
     nonleaf: NonLeafHeader,
-    child: usize,
+    child: ArenaPos,
     extension: EncodedExtensionHeader,
 }
 
 impl BorshFixedSize for ExtensionHeader {
     const SERIALIZED_SIZE: usize = CommonHeader::SERIALIZED_SIZE
         + NonLeafHeader::SERIALIZED_SIZE
-        + std::mem::size_of::<usize>()
+        + ArenaPos::SERIALIZED_SIZE
         + EncodedExtensionHeader::SERIALIZED_SIZE;
 }
 
@@ -232,7 +232,7 @@ impl MemTrieNodeId {
                 data.finish()
             }
         };
-        Self { pos: data.raw_offset() }
+        Self { pos: data.raw_pos() }
     }
 
     /// Increments the refcount, returning the new refcount.

--- a/core/store/src/trie/mem/node/mod.rs
+++ b/core/store/src/trie/mem/node/mod.rs
@@ -4,7 +4,7 @@ mod mutation;
 mod tests;
 mod view;
 
-use super::arena::{Arena, ArenaMemory, ArenaPtr, ArenaPtrMut, ArenaSlice};
+use super::arena::{Arena, ArenaMemory, ArenaPos, ArenaPtr, ArenaPtrMut, ArenaSlice};
 use super::flexible_data::children::ChildrenView;
 use super::flexible_data::value::ValueView;
 use near_primitives::hash::CryptoHash;
@@ -22,7 +22,7 @@ use std::fmt::{Debug, Formatter};
 /// of trie nodes.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub struct MemTrieNodeId {
-    pub(crate) pos: usize,
+    pub(crate) pos: ArenaPos,
 }
 
 impl MemTrieNodeId {
@@ -73,7 +73,7 @@ impl<'a> MemTrieNodePtr<'a> {
     }
 
     pub fn id(&self) -> MemTrieNodeId {
-        MemTrieNodeId { pos: self.ptr.raw_offset() }
+        MemTrieNodeId { pos: self.ptr.raw_pos() }
     }
 }
 

--- a/core/store/src/trie/mem/node/tests.rs
+++ b/core/store/src/trie/mem/node/tests.rs
@@ -7,7 +7,7 @@ use near_primitives::state::{FlatStateValue, ValueRef};
 
 #[test]
 fn test_basic_leaf_node_inlined() {
-    let mut arena = Arena::new(1024, "".to_owned());
+    let mut arena = Arena::new("".to_owned());
     let node = MemTrieNodeId::new(
         &mut arena,
         InputMemTrieNode::Leaf {
@@ -39,7 +39,7 @@ fn test_basic_leaf_node_inlined() {
 
 #[test]
 fn test_basic_leaf_node_ref() {
-    let mut arena = Arena::new(1024, "".to_owned());
+    let mut arena = Arena::new("".to_owned());
     let test_hash = hash(&[5, 6, 7, 8, 9]);
     let node = MemTrieNodeId::new(
         &mut arena,
@@ -72,7 +72,7 @@ fn test_basic_leaf_node_ref() {
 
 #[test]
 fn test_basic_leaf_node_empty_extension_empty_value() {
-    let mut arena = Arena::new(1024, "".to_owned());
+    let mut arena = Arena::new("".to_owned());
     let node = MemTrieNodeId::new(
         &mut arena,
         InputMemTrieNode::Leaf {
@@ -101,7 +101,7 @@ fn test_basic_leaf_node_empty_extension_empty_value() {
 
 #[test]
 fn test_basic_extension_node() {
-    let mut arena = Arena::new(1024, "".to_owned());
+    let mut arena = Arena::new("".to_owned());
     let child = MemTrieNodeId::new(
         &mut arena,
         InputMemTrieNode::Leaf {
@@ -149,7 +149,7 @@ fn branch_array(children: Vec<(usize, MemTrieNodeId)>) -> [Option<MemTrieNodeId>
 
 #[test]
 fn test_basic_branch_node() {
-    let mut arena = Arena::new(1024, "".to_owned());
+    let mut arena = Arena::new("".to_owned());
     let child1 = MemTrieNodeId::new(
         &mut arena,
         InputMemTrieNode::Leaf {
@@ -219,7 +219,7 @@ fn test_basic_branch_node() {
 
 #[test]
 fn test_basic_branch_with_value_node() {
-    let mut arena = Arena::new(1024, "".to_owned());
+    let mut arena = Arena::new("".to_owned());
     let child1 = MemTrieNodeId::new(
         &mut arena,
         InputMemTrieNode::Leaf {

--- a/core/store/src/trie/mem/updating.rs
+++ b/core/store/src/trie/mem/updating.rs
@@ -894,7 +894,7 @@ mod tests {
 
     impl TestTries {
         fn new(check_deleted_keys: bool) -> Self {
-            let mem = MemTries::new(100 * 1024 * 1024, ShardUId::single_shard());
+            let mem = MemTries::new(ShardUId::single_shard());
             let disk = TestTriesBuilder::new().build();
             Self {
                 mem,

--- a/tools/database/src/memtrie.rs
+++ b/tools/database/src/memtrie.rs
@@ -37,13 +37,7 @@ impl LoadMemTrieCommand {
         let state_root = flat_head_state_root(&store, &shard_uid);
         let flat_head_height = flat_head(&store, &shard_uid).height;
 
-        let _trie = load_trie_from_flat_state(
-            &store,
-            shard_uid,
-            state_root,
-            flat_head_height,
-            64 * 1024 * 1024 * 1024,
-        )?;
+        let _trie = load_trie_from_flat_state(&store, shard_uid, state_root, flat_head_height)?;
         println!(
             "Loaded trie for shard {} at height {}, press Ctrl-C to exit.",
             self.shard_id, flat_head_height


### PR DESCRIPTION
This solves an issue with the current memtrie implementation that mmap requires either NO_RESERVE or overcommit enabled, by avoiding mmap altogether.

It's not actually necessary to have contiguous memory. We'll instead have chunks of contiguous memory. Individual allocations will be entirely within a chunk anyway.

Instead of using `usize` to represent a position in the arena, we now use `ArenaPos`, which simply is just the chunk index and position within chunk. We just needed some simple tweaks to use ArenaPos everywhere and there are no big changes.

I've picked 4MB as the chunk size, so that the memory overhead for not being able to allocate a big value is at most 8KB (I think in practice it's at most key size (2k?) + value size (4k?)) per chunk. So with 16GB of total size the overhead here is worst-case 32MB; on the other hand the overhead from having a last chunk is at most 4MB. So, that seems like a reasonable chunk size value to pick.

@Ekleog I haven't forgotten about your comments on the original PR (#9541 ) . I'm just tackling the more blocker items first. I'll come back to address these comments before the whole thing is considered complete.