### PR TITLE
fix: test_check_unknown_tx_must_return_error nayduck test

### DIFF
--- a/chain/jsonrpc-primitives/src/types/transactions.rs
+++ b/chain/jsonrpc-primitives/src/types/transactions.rs
@@ -31,7 +31,7 @@ pub enum SignedTransaction {
     SignedTransaction(near_primitives::transaction::SignedTransaction),
 }
 
-#[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize, Clone)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcTransactionError {
     #[error("An error happened during transaction execution: {context:?}")]

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -542,15 +542,17 @@ impl JsonRpcHandler {
         near_jsonrpc_primitives::types::transactions::RpcTransactionError,
     > {
         let (tx_hash, account_id) = tx_info.to_tx_hash_and_account();
+        let mut tx_status_result =
+            Err(near_jsonrpc_primitives::types::transactions::RpcTransactionError::TimeoutError);
         timeout(self.polling_config.polling_timeout, async {
             loop {
-                let tx_status_result = self.view_client_send( TxStatus {
-                        tx_hash,
-                        signer_account_id: account_id.clone(),
-                        fetch_receipt,
-                    })
-                    .await;
-                match tx_status_result {
+                tx_status_result = self.view_client_send( TxStatus {
+                    tx_hash,
+                    signer_account_id: account_id.clone(),
+                    fetch_receipt,
+                })
+                .await;
+                match tx_status_result.clone() {
                     Ok(result) => {
                         if result.status >= finality {
                             break Ok(result.into())
@@ -588,7 +590,7 @@ impl JsonRpcHandler {
                 tx_info,
                 fetch_receipt,
             );
-            near_jsonrpc_primitives::types::transactions::RpcTransactionError::TimeoutError
+            tx_status_result.err().unwrap()
         })?
     }
 

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -590,7 +590,11 @@ impl JsonRpcHandler {
                 tx_info,
                 fetch_receipt,
             );
-            tx_status_result.err().unwrap()
+            if let Err(error) = tx_status_result {
+                error
+            } else {
+                near_jsonrpc_primitives::types::transactions::RpcTransactionError::TimeoutError
+            }
         })?
     }
 

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1673,7 +1673,7 @@ impl ExecutionOutcomeWithIdView {
         self.outcome.to_hashes(self.id)
     }
 }
-
+#[derive(Clone)]
 pub struct TxStatusView {
     pub execution_outcome: Option<FinalExecutionOutcomeViewEnum>,
     pub status: TxExecutionStatus,
@@ -1710,7 +1710,7 @@ pub enum TxExecutionStatus {
     Final,
 }
 
-#[derive(BorshSerialize, BorshDeserialize, serde::Serialize, serde::Deserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, serde::Serialize, serde::Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum FinalExecutionOutcomeViewEnum {
     FinalExecutionOutcome(FinalExecutionOutcomeView),


### PR DESCRIPTION
This PR tries to fix [test_check_unknown_tx_must_return_error](https://github.com/near/nearcore/blob/0e0f191ea31c173e266530505cf7147b14f509ab/integration-tests/src/tests/nearcore/rpc_nodes.rs#L420)
Master code: 
The timeout() returns Elapsed if after polling there are no result, and if this happens, we return a TIMEOUT error instead of the specific error that we got that was not returned as a result. For example, when polled result matched `Err(err @ near_jsonrpc_primitives::types::transactions::RpcTransactionError::UnknownTransaction {
                        ..
                    })`, there are some edge cases that will always be TIMEOUT; and if the transaction never got finalized within timeout, then the error returned will always be TIMEOUT too.

The change:
use a mutable variable to represent the result we got inside the timeout loop. If this was indeed an error after timeout has passed, we return this error; if it is not, that means finality is not reached, we return TIMEOUT error.