### PR TITLE
[store] Add functionality to delete trie from store

### DIFF
--- a/chain/client/src/sync_jobs_actor.rs
+++ b/chain/client/src/sync_jobs_actor.rs
@@ -75,10 +75,13 @@ impl SyncJobsActor {
         msg: &ApplyStatePartsRequest,
     ) -> Result<bool, near_chain_primitives::error::Error> {
         let _span = tracing::debug_span!(target: "client", "clear_flat_state").entered();
-        Ok(msg
+        let mut store_update = msg.runtime_adapter.store().store_update();
+        let success = msg
             .runtime_adapter
             .get_flat_storage_manager()
-            .remove_flat_storage_for_shard(msg.shard_uid)?)
+            .remove_flat_storage_for_shard(msg.shard_uid, &mut store_update)?;
+        store_update.commit()?;
+        Ok(success)
     }
 }
 

--- a/core/store/src/flat/manager.rs
+++ b/core/store/src/flat/manager.rs
@@ -218,11 +218,14 @@ impl FlatStorageManager {
     /// Removes FlatStorage object from FlatStorageManager.
     /// If FlatStorageManager did have that object, then removes all information about Flat State and returns Ok(true).
     /// Otherwise does nothing and returns Ok(false).
-    pub fn remove_flat_storage_for_shard(&self, shard_uid: ShardUId) -> Result<bool, StorageError> {
+    pub fn remove_flat_storage_for_shard(
+        &self,
+        shard_uid: ShardUId,
+        store_update: &mut StoreUpdate,
+    ) -> Result<bool, StorageError> {
         let mut flat_storages = self.0.flat_storages.lock().expect(POISONED_LOCK_ERR);
-
         if let Some(flat_store) = flat_storages.remove(&shard_uid) {
-            flat_store.clear_state()?;
+            flat_store.clear_state(store_update)?;
             Ok(true)
         } else {
             Ok(false)

--- a/core/store/src/flat/storage.rs
+++ b/core/store/src/flat/storage.rs
@@ -436,21 +436,13 @@ impl FlatStorage {
     }
 
     /// Clears all State key-value pairs from flat storage.
-    pub fn clear_state(&self) -> Result<(), StorageError> {
+    pub fn clear_state(&self, store_update: &mut StoreUpdate) -> Result<(), StorageError> {
         let guard = self.0.write().expect(super::POISONED_LOCK_ERR);
-
-        let mut store_update = guard.store.store_update();
-        store_helper::remove_all_flat_state_values(&mut store_update, guard.shard_uid);
-        store_helper::remove_all_deltas(&mut store_update, guard.shard_uid);
-
-        store_helper::set_flat_storage_status(
-            &mut store_update,
-            guard.shard_uid,
-            FlatStorageStatus::Empty,
-        );
-        store_update.commit().map_err(|_| StorageError::StorageInternalError)?;
+        let shard_uid = guard.shard_uid;
+        store_helper::remove_all_flat_state_values(store_update, shard_uid);
+        store_helper::remove_all_deltas(store_update, shard_uid);
+        store_helper::set_flat_storage_status(store_update, shard_uid, FlatStorageStatus::Empty);
         guard.update_delta_metrics();
-
         Ok(())
     }
 

--- a/core/store/src/flat/store_helper.rs
+++ b/core/store/src/flat/store_helper.rs
@@ -126,6 +126,10 @@ pub fn remove_all_flat_state_values(store_update: &mut StoreUpdate, shard_uid: S
     remove_range_by_shard_uid(store_update, shard_uid, DBCol::FlatState);
 }
 
+pub fn remove_all_state_values(store_update: &mut StoreUpdate, shard_uid: ShardUId) {
+    remove_range_by_shard_uid(store_update, shard_uid, DBCol::State);
+}
+
 pub fn encode_flat_state_db_key(shard_uid: ShardUId, key: &[u8]) -> Vec<u8> {
     let mut buffer = vec![];
     buffer.extend_from_slice(&shard_uid.to_bytes());

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -177,7 +177,11 @@ fn test_flat_storage_creation_sanity() {
             );
         }
 
-        get_flat_storage_manager(&env).remove_flat_storage_for_shard(shard_uid).unwrap();
+        let mut store_update = store.store_update();
+        get_flat_storage_manager(&env)
+            .remove_flat_storage_for_shard(shard_uid, &mut store_update)
+            .unwrap();
+        store_update.commit().unwrap();
     }
 
     // Create new chain and runtime using the same store. It should produce next blocks normally, but now it should
@@ -274,7 +278,11 @@ fn test_flat_storage_creation_two_shards() {
             );
         }
 
-        get_flat_storage_manager(&env).remove_flat_storage_for_shard(shard_uids[0]).unwrap();
+        let mut store_update = store.store_update();
+        get_flat_storage_manager(&env)
+            .remove_flat_storage_for_shard(shard_uids[0], &mut store_update)
+            .unwrap();
+        store_update.commit().unwrap();
     }
 
     // Check that flat storage is not ready for shard 0 but ready for shard 1.
@@ -416,7 +424,11 @@ fn test_catchup_succeeds_even_if_no_new_blocks() {
             env.produce_block(0, height);
         }
         // Remove flat storage.
-        get_flat_storage_manager(&env).remove_flat_storage_for_shard(shard_uid).unwrap();
+        let mut store_update = store.store_update();
+        get_flat_storage_manager(&env)
+            .remove_flat_storage_for_shard(shard_uid, &mut store_update)
+            .unwrap();
+        store_update.commit().unwrap();
     }
     let mut env = setup_env(&genesis, store.clone());
     assert!(get_flat_storage_manager(&env).get_flat_storage_for_shard(shard_uid).is_none());

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2466,10 +2466,12 @@ fn test_catchup_gas_price_change() {
         let store = rt.store();
 
         let shard_id = msg.shard_uid.shard_id as ShardId;
+        let mut store_update = store.store_update();
         assert!(rt
             .get_flat_storage_manager()
-            .remove_flat_storage_for_shard(msg.shard_uid)
+            .remove_flat_storage_for_shard(msg.shard_uid, &mut store_update)
             .unwrap());
+        store_update.commit().unwrap();
         for part_id in 0..msg.num_parts {
             let key = borsh::to_vec(&StatePartKey(msg.sync_hash, shard_id, part_id)).unwrap();
             let part = store.get(DBCol::StateParts, &key).unwrap().unwrap();

--- a/integration-tests/src/tests/client/state_dump.rs
+++ b/integration-tests/src/tests/client/state_dump.rs
@@ -294,10 +294,12 @@ fn run_state_sync_with_dumped_parts(
         let runtime_client_1 = Arc::clone(&env.clients[1].runtime_adapter);
         let runtime_client_0 = Arc::clone(&env.clients[0].runtime_adapter);
         let client_0_store = runtime_client_0.store();
+        let mut store_update = runtime_client_1.store().store_update();
         assert!(runtime_client_1
             .get_flat_storage_manager()
-            .remove_flat_storage_for_shard(ShardUId::single_shard())
+            .remove_flat_storage_for_shard(ShardUId::single_shard(), &mut store_update)
             .unwrap());
+        store_update.commit().unwrap();
 
         for part_id in 0..num_parts {
             let key = borsh::to_vec(&StatePartKey(sync_hash, 0, part_id)).unwrap();

--- a/integration-tests/src/tests/client/sync_state_nodes.rs
+++ b/integration-tests/src/tests/client/sync_state_nodes.rs
@@ -665,11 +665,12 @@ fn test_dump_epoch_missing_chunk_in_last_block() {
                 let store = rt.store();
 
                 let shard_id = msg.shard_uid.shard_id as ShardId;
-
+                let mut store_update = store.store_update();
                 assert!(rt
                     .get_flat_storage_manager()
-                    .remove_flat_storage_for_shard(msg.shard_uid)
+                    .remove_flat_storage_for_shard(msg.shard_uid, &mut store_update)
                     .unwrap());
+                store_update.commit().unwrap();
 
                 for part_id in 0..msg.num_parts {
                     let key =

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -217,7 +217,7 @@ impl FlatStorageCommand {
         near_config: &NearConfig,
         opener: StoreOpener,
     ) -> anyhow::Result<()> {
-        let (_, epoch_manager, rw_hot_runtime, rw_chain_store, _) =
+        let (_, epoch_manager, rw_hot_runtime, rw_chain_store, store) =
             Self::get_db(&opener, home_dir, &near_config, near_store::Mode::ReadWriteExisting);
         let tip = rw_chain_store.final_head()?;
 
@@ -225,7 +225,9 @@ impl FlatStorageCommand {
         let shard_uid = epoch_manager.shard_id_to_uid(cmd.shard_id, &tip.epoch_id)?;
         let flat_storage_manager = rw_hot_runtime.get_flat_storage_manager();
         flat_storage_manager.create_flat_storage_for_shard(shard_uid)?;
-        flat_storage_manager.remove_flat_storage_for_shard(shard_uid)?;
+        let mut store_update = store.store_update();
+        flat_storage_manager.remove_flat_storage_for_shard(shard_uid, &mut store_update)?;
+        store_update.commit()?;
         Ok(())
     }
 


### PR DESCRIPTION
This PR has two main changes

1. It adds a function to remove data associated with a trie from store `remove_flat_storage_for_shard`. We clear the cache and view cache and remove all data associated with the shard_uid from RocksDB
2. Change the flat storage `clear_state` and `remove_flat_storage_for_shard` to accept a `store_update` instead of directly committing the changes to store. This is helpful to club a set of RocksDB changes from other store_update.