### PR TITLE
[resharding] GC trie state and flat state after resharding

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -729,7 +729,7 @@ impl Chain {
             epoch_length: chain_genesis.epoch_length,
             block_economics_config: BlockEconomicsConfig::from(chain_genesis),
             doomslug_threshold_mode,
-            blocks_delay_tracker: BlocksDelayTracker::default(),
+            blocks_delay_tracker: Default::default(),
             apply_chunks_sender: sc,
             apply_chunks_receiver: rc,
             last_time_head_updated: StaticClock::instant(),
@@ -1060,6 +1060,11 @@ impl Chain {
                         self.epoch_manager.as_ref(),
                         *block_hash,
                         GCMode::Canonical(tries.clone()),
+                    )?;
+                    chain_store_update.clear_resharding_data(
+                        self.runtime_adapter.as_ref(),
+                        self.epoch_manager.as_ref(),
+                        *block_hash,
                     )?;
                     gc_blocks_remaining -= 1;
                 } else {

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -52,7 +52,7 @@ use near_store::{
 
 use crate::byzantine_assert;
 use crate::chunks_store::ReadOnlyChunksStore;
-use crate::types::{Block, BlockHeader, LatestKnown};
+use crate::types::{Block, BlockHeader, LatestKnown, RuntimeAdapter};
 use near_store::db::{StoreStatistics, STATE_SYNC_DUMP_KEY};
 use near_store::flat::store_helper;
 use std::sync::Arc;
@@ -2318,6 +2318,42 @@ impl<'a> ChainStoreUpdate<'a> {
             shard_uids_to_gc.extend(next_shard_layout.get_shard_uids());
         }
         shard_uids_to_gc
+    }
+
+    /// GC trie state and flat state data after a resharding event
+    /// Most of the work happens on the last block of the epoch when resharding is COMPLETED
+    /// During GC, when we detect a change in shard layout, we can clear off all entries from
+    /// the parent shards
+    pub fn clear_resharding_data(
+        &mut self,
+        runtime: &dyn RuntimeAdapter,
+        epoch_manager: &dyn EpochManagerAdapter,
+        block_hash: CryptoHash,
+    ) -> Result<(), Error> {
+        // Need to check if this is the last block of the epoch where resharding is completed
+        // which means shard layout changed in the previous epoch
+        if !epoch_manager.is_next_block_epoch_start(&block_hash)? {
+            return Ok(());
+        }
+        let epoch_id = epoch_manager.get_epoch_id(&block_hash)?;
+        let shard_layout = epoch_manager.get_shard_layout(&epoch_id)?;
+        let prev_epoch_id = epoch_manager.get_prev_epoch_id(&block_hash)?;
+        let prev_shard_layout = epoch_manager.get_shard_layout(&prev_epoch_id)?;
+        if shard_layout == prev_shard_layout {
+            return Ok(());
+        }
+
+        // Now we can proceed to removing the trie state and flat state
+        let mut store_update = self.store().store_update();
+        for shard_uid in prev_shard_layout.get_shard_uids() {
+            runtime.get_tries().delete_trie_for_shard(shard_uid, &mut store_update);
+            runtime
+                .get_flat_storage_manager()
+                .remove_flat_storage_for_shard(shard_uid, &mut store_update)?;
+        }
+
+        self.merge(store_update);
+        Ok(())
     }
 
     // Clearing block data of `block_hash`, if on a fork.

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -621,6 +621,13 @@ impl EpochManagerAdapter for MockEpochManager {
         }
     }
 
+    fn get_prev_epoch_id(&self, block_hash: &CryptoHash) -> Result<EpochId, EpochError> {
+        let header = self
+            .get_block_header(block_hash)?
+            .ok_or_else(|| EpochError::MissingBlock(*block_hash))?;
+        self.get_prev_epoch_id_from_prev_block(header.prev_hash())
+    }
+
     fn get_prev_epoch_id_from_prev_block(
         &self,
         prev_block_hash: &CryptoHash,

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -128,6 +128,8 @@ pub trait EpochManagerAdapter: Send + Sync {
     /// Get epoch start from a block belonging to the epoch.
     fn get_epoch_start_height(&self, block_hash: &CryptoHash) -> Result<BlockHeight, EpochError>;
 
+    fn get_prev_epoch_id(&self, block_hash: &CryptoHash) -> Result<EpochId, EpochError>;
+
     /// Get previous epoch id by hash of previous block.
     fn get_prev_epoch_id_from_prev_block(
         &self,
@@ -560,6 +562,11 @@ impl EpochManagerAdapter for EpochManagerHandle {
     fn get_epoch_start_height(&self, block_hash: &CryptoHash) -> Result<BlockHeight, EpochError> {
         let epoch_manager = self.read();
         epoch_manager.get_epoch_start_height(block_hash).map_err(EpochError::from)
+    }
+
+    fn get_prev_epoch_id(&self, block_hash: &CryptoHash) -> Result<EpochId, EpochError> {
+        let epoch_manager = self.read();
+        epoch_manager.get_prev_epoch_id(block_hash)
     }
 
     fn get_prev_epoch_id_from_prev_block(


### PR DESCRIPTION
This PR plugs into the Garbage Collection (GC) code to cleanup trie state and flat state after a resharding event.

During GC, when we are clearing the last block of the epoch when resharding happens, we can also go ahead and clean up state from the parent shards.

More context on GC: https://near.github.io/nearcore/architecture/how/gc.html

We use the functions introduced in PR https://github.com/near/nearcore/pull/10136 to clear the trie cache as well as delete the flat storage and set flat storage status as empty.