### PR TITLE
feat(resharding): setup a conservative default for resharding throttling

### DIFF
--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -176,7 +176,9 @@ pub struct StateSplitConfig {
 
 impl Default for StateSplitConfig {
     fn default() -> Self {
-        Self { batch_size: bytesize::ByteSize::mb(30), batch_delay: Duration::from_millis(100) }
+        // Conservative default for a slower resharding that puts as little
+        // extra load on the node as possible.
+        Self { batch_size: bytesize::ByteSize::kb(500), batch_delay: Duration::from_millis(100) }
     }
 }
 


### PR DESCRIPTION
Setup the throttle config to batch size = 500KB and batch delay = 100ms. 

I tested the performance on a more ambitious configuration with batch size = 1MB and batch delay = 50ms. The nodes performed well and the resharding took ~30min. The default I'm proposing shouldn't make the resharding slower by more than 4x compared to that benchmark so the total resharding time shouldn't exceed 2 hours. 