### PR TITLE
fix: make validators() rust api compatible with RPC servers 

### DIFF
--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -187,7 +187,6 @@ jsonrpc_client!(pub struct JsonRpcClient {
     pub fn EXPERIMENTAL_tx_status(&self, tx: String) -> RpcRequest<RpcTransactionResponse>;
     pub fn health(&self) -> RpcRequest<()>;
     pub fn chunk(&self, id: ChunkId) -> RpcRequest<ChunkView>;
-    pub fn validators(&self, epoch_id_or_block_id: Option<EpochReference>) -> RpcRequest<EpochValidatorInfo>;
     pub fn gas_price(&self, block_id: MaybeBlockId) -> RpcRequest<GasPriceView>;
 });
 
@@ -260,6 +259,14 @@ impl JsonRpcClient {
     ) -> RpcRequest<near_jsonrpc_primitives::types::split_storage::RpcSplitStorageInfoResponse>
     {
         call_method(&self.client, &self.server_addr, "EXPERIMENTAL_split_storage_info", request)
+    }
+
+    pub fn validators(&self, epoch_id_or_block_id: Option<EpochReference>)  -> RpcRequest<EpochValidatorInfo> {
+        let epoch_reference = match epoch_id_or_block_id {
+            Some(epoch_reference) => epoch_reference,
+            _ => EpochReference::Latest
+        };
+        call_method(&self.client, &self.server_addr, "validators", epoch_reference)
     }
 }
 

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -261,10 +261,13 @@ impl JsonRpcClient {
         call_method(&self.client, &self.server_addr, "EXPERIMENTAL_split_storage_info", request)
     }
 
-    pub fn validators(&self, epoch_id_or_block_id: Option<EpochReference>)  -> RpcRequest<EpochValidatorInfo> {
+    pub fn validators(
+        &self,
+        epoch_id_or_block_id: Option<EpochReference>,
+    ) -> RpcRequest<EpochValidatorInfo> {
         let epoch_reference = match epoch_id_or_block_id {
             Some(epoch_reference) => epoch_reference,
-            _ => EpochReference::Latest
+            _ => EpochReference::Latest,
         };
         call_method(&self.client, &self.server_addr, "validators", epoch_reference)
     }

--- a/chain/jsonrpc/src/api/validator.rs
+++ b/chain/jsonrpc/src/api/validator.rs
@@ -88,14 +88,12 @@ mod tests {
         let block_height: u64 = 12345;
         let params = serde_json::json!({"block_id": block_height});
         let result = RpcValidatorRequest::parse(params);
-        assert!(result.is_ok());
-        let result_unwrap = result.unwrap();
-        let res_serialized = format!("{result_unwrap:?}");
-        let expected = RpcValidatorRequest {
-            epoch_reference: EpochReference::BlockId(BlockId::Height(block_height)),
-        };
-        let expected_serialized = format!("{expected:?}");
-        assert_eq!(res_serialized, expected_serialized);
+        assert_eq!(
+            result.unwrap(),
+            RpcValidatorRequest {
+                epoch_reference: EpochReference::BlockId(BlockId::Height(block_height)),
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
Problem:
I have a piece of code in my monitoring tool:
```
let latest_epoch_response = rpc_client
            .validators(Some(EpochReference::EpochId(EpochId(latest_epoch_id))))
            .await.unwrap()
```
And on latest master, this is failing with
```
RpcError { error_struct: Some(RequestValidationError(ParseError { error_message: "Failed parsing args: data did not match any variant of untagged enum BlockId" })), code: -32700, message: "Parse error", data: Some(String("Failed parsing args: data did not match any variant of untagged enum BlockId")) }
```

Solution: 
change validators() rust api by letting it directly call the "validators" method. 