### PR TITLE
Revert "Deprecate AnnounceAccounts (#10024)"

### DIFF
--- a/chain/client/src/adapter.rs
+++ b/chain/client/src/adapter.rs
@@ -9,10 +9,10 @@ use near_primitives::block::{Approval, Block, BlockHeader};
 use near_primitives::challenge::Challenge;
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
-use near_primitives::network::PeerId;
+use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::sharding::PartialEncodedChunk;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{AccountId, ShardId};
+use near_primitives::types::{AccountId, EpochId, ShardId};
 use near_primitives::views::FinalExecutionOutcomeView;
 
 /// Transaction status query
@@ -77,6 +77,13 @@ pub struct StateRequestPart {
 #[derive(actix::Message, Debug)]
 #[rtype(result = "()")]
 pub struct StateResponse(pub Box<StateResponseInfo>);
+
+/// Account announcements that needs to be validated before being processed.
+/// They are paired with last epoch id known to this announcement, in order to accept only
+/// newer announcements.
+#[derive(actix::Message, Debug)]
+#[rtype(result = "Result<Vec<AnnounceAccount>,ReasonForBan>")]
+pub(crate) struct AnnounceAccountRequest(pub Vec<(AnnounceAccount, Option<EpochId>)>);
 
 #[derive(actix::Message, Debug)]
 #[rtype(result = "()")]
@@ -310,6 +317,20 @@ impl near_network::client::Client for Adapter {
         match self.client_addr.send(SetNetworkInfo(info).with_span_context()).await {
             Ok(()) => {}
             Err(err) => tracing::error!("mailbox error: {err}"),
+        }
+    }
+
+    async fn announce_account(
+        &self,
+        accounts: Vec<(AnnounceAccount, Option<EpochId>)>,
+    ) -> Result<Vec<AnnounceAccount>, ReasonForBan> {
+        match self.view_client_addr.send(AnnounceAccountRequest(accounts).with_span_context()).await
+        {
+            Ok(res) => res,
+            Err(err) => {
+                tracing::error!("mailbox error: {err}");
+                Ok(vec![])
+            }
         }
     }
 }

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -58,7 +58,7 @@ use near_primitives::block::Tip;
 use near_primitives::block_header::ApprovalType;
 use near_primitives::epoch_manager::RngSeed;
 use near_primitives::hash::CryptoHash;
-use near_primitives::network::PeerId;
+use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::static_clock::StaticClock;
 use near_primitives::types::{BlockHeight, ShardId};
 use near_primitives::unwrap_or_return;
@@ -76,7 +76,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::sync::{Arc, RwLock};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
 use tracing::{debug, error, info, trace, warn};
 
@@ -98,6 +98,8 @@ pub struct ClientActor {
     /// Identity that represents this Client at the network level.
     /// It is used as part of the messages that identify this client.
     node_id: PeerId,
+    /// Last time we announced our accounts as validators.
+    last_validator_announce_time: Option<Instant>,
     /// Info helper.
     info_helper: InfoHelper,
 
@@ -195,6 +197,7 @@ impl ClientActor {
                 tier1_accounts_keys: vec![],
                 tier1_accounts_data: vec![],
             },
+            last_validator_announce_time: None,
             info_helper,
             block_production_next_attempt: now,
             log_summary_timer_next_attempt: now,
@@ -857,6 +860,60 @@ impl fmt::Display for SyncRequirement {
 }
 
 impl ClientActor {
+    /// Check if client Account Id should be sent and send it.
+    /// Account Id is sent when is not current a validator but are becoming a validator soon.
+    fn check_send_announce_account(&mut self, prev_block_hash: CryptoHash) {
+        // If no peers, there is no one to announce to.
+        if self.network_info.num_connected_peers == 0 {
+            debug!(target: "client", "No peers: skip account announce");
+            return;
+        }
+
+        // First check that we currently have an AccountId
+        let validator_signer = match self.client.validator_signer.as_ref() {
+            None => return,
+            Some(signer) => signer,
+        };
+
+        let now = StaticClock::instant();
+        // Check that we haven't announced it too recently
+        if let Some(last_validator_announce_time) = self.last_validator_announce_time {
+            // Don't make announcement if have passed less than half of the time in which other peers
+            // should remove our Account Id from their Routing Tables.
+            if 2 * (now - last_validator_announce_time) < self.client.config.ttl_account_id_router {
+                return;
+            }
+        }
+
+        debug!(target: "client", "Check announce account for {}, last announce time {:?}", validator_signer.validator_id(), self.last_validator_announce_time);
+
+        // Announce AccountId if client is becoming a validator soon.
+        let next_epoch_id = unwrap_or_return!(self
+            .client
+            .epoch_manager
+            .get_next_epoch_id_from_prev_block(&prev_block_hash));
+
+        // Check client is part of the futures validators
+        if self.client.is_validator(&next_epoch_id, &prev_block_hash) {
+            debug!(target: "client", "Sending announce account for {}", validator_signer.validator_id());
+            self.last_validator_announce_time = Some(now);
+
+            let signature = validator_signer.sign_account_announce(
+                validator_signer.validator_id(),
+                &self.node_id,
+                &next_epoch_id,
+            );
+            self.network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
+                NetworkRequests::AnnounceAccount(AnnounceAccount {
+                    account_id: validator_signer.validator_id().clone(),
+                    peer_id: self.node_id.clone(),
+                    epoch_id: next_epoch_id,
+                    signature,
+                }),
+            ));
+        }
+    }
+
     /// Process the sandbox fast forward request. If the change in block height is past an epoch,
     /// we fast forward to just right before the epoch, produce some blocks to get past and into
     /// a new epoch, then we continue on with the residual amount to fast forward.
@@ -1296,6 +1353,7 @@ impl ClientActor {
             let block = self.client.chain.get_block(&accepted_block).unwrap().clone();
             self.send_chunks_metrics(&block);
             self.send_block_metrics(&block);
+            self.check_send_announce_account(*block.header().last_final_block());
         }
     }
 
@@ -1529,6 +1587,11 @@ impl ClientActor {
                 if currently_syncing {
                     info!(target: "client", "disabling sync: {}", &sync);
                     self.client.sync_status = SyncStatus::NoSync;
+
+                    // Initial transition out of "syncing" state.
+                    // Announce this client's account id if their epoch is coming up.
+                    let head = unwrap_and_report!(self.client.chain.head());
+                    self.check_send_announce_account(head.prev_block_hash);
                 }
             }
 

--- a/chain/client/src/test_utils/setup.rs
+++ b/chain/client/src/test_utils/setup.rs
@@ -5,8 +5,8 @@
 use super::block_stats::BlockStats;
 use super::peer_manager_mock::PeerManagerMock;
 use crate::adapter::{
-    BlockApproval, BlockHeadersRequest, BlockHeadersResponse, BlockRequest, BlockResponse,
-    SetNetworkInfo, StateRequestHeader, StateRequestPart,
+    AnnounceAccountRequest, BlockApproval, BlockHeadersRequest, BlockHeadersResponse, BlockRequest,
+    BlockResponse, SetNetworkInfo, StateRequestHeader, StateRequestPart,
 };
 use crate::{start_view_client, Client, ClientActor, SyncAdapter, SyncStatus, ViewClientActor};
 use actix::{Actor, Addr, AsyncContext, Context};
@@ -54,7 +54,7 @@ use num_rational::Ratio;
 use once_cell::sync::OnceCell;
 use rand::{thread_rng, Rng};
 use std::cmp::max;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::DerefMut;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
@@ -450,6 +450,7 @@ pub fn setup_mock_all_validators(
 
     let connectors: Arc<OnceCell<Vec<ActorHandlesForTesting>>> = Default::default();
 
+    let announced_accounts = Arc::new(RwLock::new(HashSet::new()));
     let genesis_block = Arc::new(RwLock::new(None));
 
     let last_height = Arc::new(RwLock::new(vec![0; key_pairs.len()]));
@@ -470,6 +471,7 @@ pub fn setup_mock_all_validators(
         let addresses = addresses.clone();
         let connectors1 = connectors.clone();
         let network_mock1 = peer_manager_mock.clone();
+        let announced_accounts1 = announced_accounts.clone();
         let last_height1 = last_height.clone();
         let last_height2 = last_height.clone();
         let largest_endorsed_height1 = largest_endorsed_height.clone();
@@ -738,6 +740,25 @@ pub fn setup_mock_all_validators(
                                             future::ready(())
                                         }),
                                 );
+                            }
+                        }
+                        NetworkRequests::AnnounceAccount(announce_account) => {
+                            let mut aa = announced_accounts1.write().unwrap();
+                            let key = (
+                                announce_account.account_id.clone(),
+                                announce_account.epoch_id.clone(),
+                            );
+                            if aa.get(&key).is_none() {
+                                aa.insert(key);
+                                for actor_handles in connectors1 {
+                                    actor_handles.view_client_actor.do_send(
+                                        AnnounceAccountRequest(vec![(
+                                            announce_account.clone(),
+                                            None,
+                                        )])
+                                            .with_span_context(),
+                                    )
+                                }
                             }
                         }
                         NetworkRequests::Approval { approval_message } => {

--- a/chain/jsonrpc/res/last_blocks.js
+++ b/chain/jsonrpc/res/last_blocks.js
@@ -304,7 +304,7 @@ function Page() {
         <div className="explanation">Skipped chunks have grey background.</div>
         <div className="explanation">
             Red text means that we don't know this producer
-            (we haven't received the account data).
+            (it's not present in our announce account list).
         </div>
         {error && <div className="error">{error.stack}</div>}
         <div className="missed-blocks">

--- a/chain/jsonrpc/res/network_info.html
+++ b/chain/jsonrpc/res/network_info.html
@@ -258,8 +258,9 @@ Unknown: <span class="js-unknown-chunk-producers"></span>
 Unreachable: <span class="js-unreachable-chunk-producers"></span>
     </pre>
 
-    <b>Unknown</b> means that we didn't receive account data for this validator (so we don't know on which
-    peer it is). This usually means that the validator didn't connect to the network
+    <b>Unknown</b> means that we didn't receive 'announce' information about this validator (so we don't know on which
+    peer it
+    is). This usually means that the validator didn't connect to the network
     during current epoch.
 
     <br>

--- a/chain/network/src/announce_accounts/mod.rs
+++ b/chain/network/src/announce_accounts/mod.rs
@@ -1,0 +1,117 @@
+use crate::store;
+use lru::LruCache;
+use near_primitives::network::{AnnounceAccount, PeerId};
+use near_primitives::types::AccountId;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+
+#[cfg(test)]
+mod tests;
+
+const ANNOUNCE_ACCOUNT_CACHE_SIZE: usize = 10_000;
+
+struct Inner {
+    /// Maps an account_id to a peer owning it.
+    account_peers: LruCache<AccountId, AnnounceAccount>,
+    /// Subset of account_peers, which we have broadcasted to the peers.
+    /// It is used to skip rebroadcasting the same data multiple times.
+    /// It contains less entries than account_peers in case some AnnounceAccounts
+    /// have been loaded from storage without broadcasting.
+    account_peers_broadcasted: LruCache<AccountId, AnnounceAccount>,
+    /// Access to store on disk
+    store: store::Store,
+}
+
+impl Inner {
+    /// Get AnnounceAccount for the given AccountId.
+    fn get_announce(&mut self, account_id: &AccountId) -> Option<AnnounceAccount> {
+        if let Some(announce_account) = self.account_peers.get(account_id) {
+            return Some(announce_account.clone());
+        }
+
+        match self.store.get_account_announcement(&account_id) {
+            Err(err) => {
+                tracing::warn!(target: "network", "Error loading announce account from store: {:?}", err);
+                None
+            }
+            Ok(None) => None,
+            Ok(Some(stored_announce_account)) => {
+                self.account_peers.put(account_id.clone(), stored_announce_account.clone());
+                Some(stored_announce_account)
+            }
+        }
+    }
+}
+
+pub(crate) struct AnnounceAccountCache(Mutex<Inner>);
+
+impl AnnounceAccountCache {
+    pub fn new(store: store::Store) -> Self {
+        Self(Mutex::new(Inner {
+            account_peers: LruCache::new(ANNOUNCE_ACCOUNT_CACHE_SIZE),
+            account_peers_broadcasted: LruCache::new(ANNOUNCE_ACCOUNT_CACHE_SIZE),
+            store,
+        }))
+    }
+
+    /// Adds accounts to the cache.
+    /// Returns the diff: new values that should be broadcasted.
+    /// Note: There is at most one peer id per account id.
+    pub(crate) fn add_accounts(
+        &self,
+        account_announcements: Vec<AnnounceAccount>,
+    ) -> Vec<AnnounceAccount> {
+        let mut inner = self.0.lock();
+        let mut res = vec![];
+        for announcement in account_announcements {
+            let account_id = &announcement.account_id;
+            let epoch_id = &announcement.epoch_id;
+
+            // We skip broadcasting stuff that is already broadcasted.
+            if inner.account_peers_broadcasted.get(account_id).map(|x| &x.epoch_id)
+                == Some(epoch_id)
+            {
+                continue;
+            }
+
+            inner.account_peers.put(account_id.clone(), announcement.clone());
+            inner.account_peers_broadcasted.put(account_id.clone(), announcement.clone());
+
+            // Add account to store. Best effort
+            if let Err(e) = inner.store.set_account_announcement(account_id, &announcement) {
+                tracing::warn!(target: "network", "Error saving announce account to store: {:?}", e);
+            }
+            res.push(announcement);
+        }
+        res
+    }
+
+    /// Find peer that owns this AccountId.
+    pub(crate) fn get_account_owner(&self, account_id: &AccountId) -> Option<PeerId> {
+        self.0.lock().get_announce(account_id).map(|announce_account| announce_account.peer_id)
+    }
+
+    /// Public interface for `account_peers`.
+    /// Get keys currently on cache.
+    pub(crate) fn get_accounts_keys(&self) -> Vec<AccountId> {
+        self.0.lock().account_peers.iter().map(|(k, _)| k).cloned().collect()
+    }
+
+    /// Get announce accounts on cache.
+    pub(crate) fn get_announcements(&self) -> Vec<AnnounceAccount> {
+        self.0.lock().account_peers.iter().map(|(_, v)| v.clone()).collect()
+    }
+
+    /// Get AnnounceAccount for the given AccountIds, that we already broadcasted.
+    pub(crate) fn get_broadcasted_announcements<'a>(
+        &'a self,
+        account_ids: impl Iterator<Item = &'a AccountId>,
+    ) -> HashMap<AccountId, AnnounceAccount> {
+        let mut inner = self.0.lock();
+        account_ids
+            .filter_map(|id| {
+                inner.account_peers_broadcasted.get(id).map(|a| (id.clone(), a.clone()))
+            })
+            .collect()
+    }
+}

--- a/chain/network/src/announce_accounts/tests.rs
+++ b/chain/network/src/announce_accounts/tests.rs
@@ -1,0 +1,108 @@
+use crate::announce_accounts::*;
+use crate::test_utils::{random_epoch_id, random_peer_id};
+use near_crypto::Signature;
+use near_primitives::network::AnnounceAccount;
+
+#[test]
+fn announcement_same_epoch() {
+    let store = crate::store::Store::from(near_store::db::TestDB::new());
+
+    let peer_id0 = random_peer_id();
+    let peer_id1 = random_peer_id();
+    let epoch_id0 = random_epoch_id();
+
+    let announcements_cache = AnnounceAccountCache::new(store);
+
+    let announce0 = AnnounceAccount {
+        account_id: "near0".parse().unwrap(),
+        peer_id: peer_id0.clone(),
+        epoch_id: epoch_id0.clone(),
+        signature: Signature::default(),
+    };
+
+    // Same as announce1 but with different peer id
+    let announce1 = AnnounceAccount {
+        account_id: "near0".parse().unwrap(),
+        peer_id: peer_id1,
+        epoch_id: epoch_id0,
+        signature: Signature::default(),
+    };
+
+    // Adding multiple announcements for the same account_id and epoch_id.
+    // The first one should win.
+    assert_eq!(
+        announcements_cache.add_accounts(vec![announce0.clone(), announce1.clone()]),
+        vec![announce0.clone()]
+    );
+    assert_eq!(announcements_cache.get_announcements(), vec![announce0.clone()]);
+    assert_eq!(announcements_cache.get_account_owner(&announce0.account_id).unwrap(), peer_id0);
+
+    // Adding a conflicting announcement later. Should be a noop.
+    assert_eq!(announcements_cache.add_accounts(vec![announce1]), vec![]);
+    assert_eq!(announcements_cache.get_announcements(), vec![announce0.clone()]);
+    assert_eq!(announcements_cache.get_account_owner(&announce0.account_id).unwrap(), peer_id0);
+}
+
+#[test]
+fn dont_load_on_build() {
+    let store = crate::store::Store::from(near_store::db::TestDB::new());
+
+    let peer_id0 = random_peer_id();
+    let peer_id1 = random_peer_id();
+    let epoch_id0 = random_epoch_id();
+    let epoch_id1 = random_epoch_id();
+
+    let announcements_cache = AnnounceAccountCache::new(store.clone());
+
+    let announce0 = AnnounceAccount {
+        account_id: "near0".parse().unwrap(),
+        peer_id: peer_id0,
+        epoch_id: epoch_id0,
+        signature: Signature::default(),
+    };
+
+    // Same as announce1 but with different peer id
+    let announce1 = AnnounceAccount {
+        account_id: "near1".parse().unwrap(),
+        peer_id: peer_id1,
+        epoch_id: epoch_id1,
+        signature: Signature::default(),
+    };
+
+    announcements_cache.add_accounts(vec![announce0.clone()]);
+    announcements_cache.add_accounts(vec![announce1.clone()]);
+    let accounts: Vec<AnnounceAccount> = announcements_cache.get_announcements();
+    assert!(vec![announce0, announce1].iter().all(|announce| { accounts.contains(&announce) }));
+    assert_eq!(accounts.len(), 2);
+
+    let announcements_cache1 = AnnounceAccountCache::new(store);
+    assert_eq!(announcements_cache1.get_announcements().len(), 0);
+}
+
+#[test]
+fn load_from_disk() {
+    let store = crate::store::Store::from(near_store::db::TestDB::new());
+
+    let peer_id0 = random_peer_id();
+    let epoch_id0 = random_epoch_id();
+
+    let announcements_cache = AnnounceAccountCache::new(store.clone());
+    let announcements_cache1 = AnnounceAccountCache::new(store);
+
+    let announce0 = AnnounceAccount {
+        account_id: "near0".parse().unwrap(),
+        peer_id: peer_id0.clone(),
+        epoch_id: epoch_id0,
+        signature: Signature::default(),
+    };
+
+    // Announcement is added to first cache and to disk
+    announcements_cache.add_accounts(vec![announce0.clone()]);
+    assert_eq!(announcements_cache.get_announcements().len(), 1);
+    // Second cache is empty
+    assert_eq!(announcements_cache1.get_announcements().len(), 0);
+    // Try to find this peer and load it from disk
+    assert_eq!(announcements_cache1.get_account_owner(&announce0.account_id).unwrap(), peer_id0);
+    // Second cache should contain account loaded from disk
+    assert_eq!(announcements_cache1.get_announcements().len(), 1);
+}

--- a/chain/network/src/client.rs
+++ b/chain/network/src/client.rs
@@ -5,9 +5,9 @@ use crate::types::{NetworkInfo, ReasonForBan};
 use near_primitives::block::{Approval, Block, BlockHeader};
 use near_primitives::challenge::Challenge;
 use near_primitives::hash::CryptoHash;
-use near_primitives::network::PeerId;
+use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{AccountId, ShardId};
+use near_primitives::types::{AccountId, EpochId, ShardId};
 use near_primitives::views::FinalExecutionOutcomeView;
 
 /// A strongly typed asynchronous API for the Client logic.
@@ -57,6 +57,11 @@ pub trait Client: Send + Sync + 'static {
     async fn challenge(&self, challenge: Challenge);
 
     async fn network_info(&self, info: NetworkInfo);
+
+    async fn announce_account(
+        &self,
+        accounts: Vec<(AnnounceAccount, Option<EpochId>)>,
+    ) -> Result<Vec<AnnounceAccount>, ReasonForBan>;
 }
 
 /// Implementation of Client which doesn't do anything and never returns errors.
@@ -117,4 +122,11 @@ impl Client for Noop {
     async fn challenge(&self, _challenge: Challenge) {}
 
     async fn network_info(&self, _info: NetworkInfo) {}
+
+    async fn announce_account(
+        &self,
+        _accounts: Vec<(AnnounceAccount, Option<EpochId>)>,
+    ) -> Result<Vec<AnnounceAccount>, ReasonForBan> {
+        Ok(vec![])
+    }
 }

--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -1,6 +1,7 @@
 pub use crate::peer_manager::peer_manager_actor::{Event, PeerManagerActor};
 
 mod accounts_data;
+mod announce_accounts;
 mod network_protocol;
 mod peer;
 mod peer_manager;

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -32,7 +32,8 @@ use near_crypto::Signature;
 use near_o11y::{handler_debug_span, log_assert, OpenTelemetrySpanExt, WithSpanContext};
 use near_performance_metrics_macros::perf;
 use near_primitives::hash::CryptoHash;
-use near_primitives::network::PeerId;
+use near_primitives::network::{AnnounceAccount, PeerId};
+use near_primitives::types::EpochId;
 use near_primitives::utils::DisplayOption;
 use near_primitives::version::{
     ProtocolVersion, PEER_MIN_ALLOWED_PROTOCOL_VERSION, PROTOCOL_VERSION,
@@ -812,9 +813,10 @@ impl PeerActor {
             known_edges.retain(|edge| edge.removal_info().is_none());
             metrics::EDGE_TOMBSTONE_SENDING_SKIPPED.inc();
         }
+        let known_accounts = self.network_state.account_announcements.get_announcements();
         self.send_message_or_log(&PeerMessage::SyncRoutingTable(RoutingTableUpdate::new(
             known_edges,
-            vec![],
+            known_accounts,
         )));
     }
 
@@ -1399,6 +1401,26 @@ impl PeerActor {
             .await
         {
             conn.stop(Some(ban_reason));
+        }
+
+        // For every announce we received, we fetch the last announce with the same account_id
+        // that we already broadcasted. Client actor will both verify signatures of the received announces
+        // as well as filter out those which are older than the fetched ones (to avoid overriding
+        // a newer announce with an older one).
+        let old = network_state
+            .account_announcements
+            .get_broadcasted_announcements(rtu.accounts.iter().map(|a| &a.account_id));
+        let accounts: Vec<(AnnounceAccount, Option<EpochId>)> = rtu
+            .accounts
+            .into_iter()
+            .map(|aa| {
+                let id = aa.account_id.clone();
+                (aa, old.get(&id).map(|old| old.epoch_id.clone()))
+            })
+            .collect();
+        match network_state.client.announce_account(accounts).await {
+            Err(ban_reason) => conn.stop(Some(ban_reason)),
+            Ok(accounts) => network_state.add_accounts(accounts).await,
         }
     }
 

--- a/chain/network/src/peer_manager/network_state/routing.rs
+++ b/chain/network/src/peer_manager/network_state/routing.rs
@@ -13,7 +13,7 @@ use crate::tcp;
 use crate::types::ReasonForBan;
 use near_async::time;
 use near_primitives::hash::CryptoHash;
-use near_primitives::network::PeerId;
+use near_primitives::network::{AnnounceAccount, PeerId};
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -38,6 +38,20 @@ impl NetworkState {
         for conn in self.tier2.load().ready.values() {
             conn.send_message(msg.clone());
         }
+    }
+
+    /// Adds AnnounceAccounts (without validating them) to the routing table.
+    /// Then it broadcasts all the AnnounceAccounts that haven't been seen before.
+    pub async fn add_accounts(self: &Arc<NetworkState>, accounts: Vec<AnnounceAccount>) {
+        let this = self.clone();
+        self.spawn(async move {
+            let new_accounts = this.account_announcements.add_accounts(accounts);
+            tracing::debug!(target: "network", account_id = ?this.config.validator.as_ref().map(|v|v.account_id()), ?new_accounts, "Received new accounts");
+            this.broadcast_routing_table_update(RoutingTableUpdate::from_accounts(
+                new_accounts.clone(),
+            ));
+            this.config.event_sink.push(Event::AccountsAdded(new_accounts));
+        }).await.unwrap()
     }
 
     /// Constructs a partial edge to the given peer with the nonce specified.

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -26,7 +26,7 @@ use near_async::time;
 use near_o11y::{handler_debug_span, handler_trace_span, OpenTelemetrySpanExt, WithSpanContext};
 use near_performance_metrics_macros::perf;
 use near_primitives::block::GenesisId;
-use near_primitives::network::PeerId;
+use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::views::{
     ConnectionInfoView, EdgeView, KnownPeerStateView, NetworkGraphView, PeerStoreView,
     RecentOutboundConnectionsView, SnapshotHostInfoView, SnapshotHostsView,
@@ -104,6 +104,7 @@ pub enum Event {
     PeerManagerStarted,
     ServerStarted,
     RoutedMessageDropped,
+    AccountsAdded(Vec<AnnounceAccount>),
     EdgesAdded(Vec<Edge>),
     Ping(Ping),
     Pong(Pong),
@@ -650,7 +651,6 @@ impl PeerManagerActor {
         let tier2 = self.state.tier2.load();
         let now = self.clock.now();
         let graph = self.state.graph.load();
-        let accounts_data = self.state.accounts_data.load();
         let connected_peer = |cp: &Arc<connection::Connection>| ConnectedPeerInfo {
             full_peer_info: cp.full_peer_info(),
             received_bytes_per_sec: cp.stats.received_bytes_per_sec.load(Ordering::Relaxed),
@@ -680,27 +680,21 @@ impl PeerManagerActor {
                 .values()
                 .map(|x| x.stats.received_bytes_per_sec.load(Ordering::Relaxed))
                 .sum(),
-            known_producers: accounts_data
-                .keys_by_id
-                .iter()
-                .filter_map(|(account_id, account_keys)| {
-                    let peer_id = account_keys
-                        .iter()
-                        .flat_map(|key| accounts_data.data.get(key))
-                        .next()
-                        .map(|data| data.peer_id.clone())?;
-                    let next_hops = self.state.graph.routing_table.view_route(&peer_id);
-                    Some(KnownProducer {
-                        account_id: account_id.clone(),
-                        peer_id,
-                        // TODO: fill in the address.
-                        addr: None,
-                        next_hops,
-                    })
+            known_producers: self
+                .state
+                .account_announcements
+                .get_announcements()
+                .into_iter()
+                .map(|announce_account| KnownProducer {
+                    account_id: announce_account.account_id,
+                    peer_id: announce_account.peer_id.clone(),
+                    // TODO: fill in the address.
+                    addr: None,
+                    next_hops: self.state.graph.routing_table.view_route(&announce_account.peer_id),
                 })
                 .collect(),
-            tier1_accounts_keys: accounts_data.keys.iter().cloned().collect(),
-            tier1_accounts_data: accounts_data.data.values().cloned().collect(),
+            tier1_accounts_keys: self.state.accounts_data.load().keys.iter().cloned().collect(),
+            tier1_accounts_data: self.state.accounts_data.load().data.values().cloned().collect(),
         }
     }
 
@@ -731,7 +725,7 @@ impl PeerManagerActor {
     fn handle_msg_network_requests(
         &mut self,
         msg: NetworkRequests,
-        _ctx: &mut actix::Context<Self>,
+        ctx: &mut actix::Context<Self>,
     ) -> NetworkResponses {
         let msg_type: &str = msg.as_ref();
         let _span =
@@ -808,6 +802,13 @@ impl PeerManagerActor {
             }
             NetworkRequests::BanPeer { peer_id, ban_reason } => {
                 self.state.disconnect_and_ban(&self.clock, &peer_id, ban_reason);
+                NetworkResponses::NoResponse
+            }
+            NetworkRequests::AnnounceAccount(announce_account) => {
+                let state = self.state.clone();
+                ctx.spawn(wrap_future(async move {
+                    state.add_accounts(vec![announce_account]).await;
+                }));
                 NetworkResponses::NoResponse
             }
             NetworkRequests::PartialEncodedChunkRequest { target, request, create_time } => {

--- a/chain/network/src/peer_manager/testonly.rs
+++ b/chain/network/src/peer_manager/testonly.rs
@@ -14,13 +14,15 @@ use crate::test_utils;
 use crate::testonly::actix::ActixSystem;
 use crate::testonly::fake_client;
 use crate::types::{
-    AccountKeys, ChainInfo, KnownPeerStatus, PeerManagerMessageRequest, ReasonForBan,
+    AccountKeys, ChainInfo, KnownPeerStatus, NetworkRequests, PeerManagerMessageRequest,
+    ReasonForBan,
 };
 use crate::PeerManagerActor;
 use near_async::messaging::IntoSender;
 use near_async::time;
 use near_o11y::WithSpanContextExt;
-use near_primitives::network::PeerId;
+use near_primitives::network::{AnnounceAccount, PeerId};
+use near_primitives::types::AccountId;
 use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
@@ -371,6 +373,17 @@ impl ActorHandler {
         .await;
     }
 
+    pub async fn announce_account(&self, aa: AnnounceAccount) {
+        self.actix
+            .addr
+            .send(
+                PeerManagerMessageRequest::NetworkRequests(NetworkRequests::AnnounceAccount(aa))
+                    .with_span_context(),
+            )
+            .await
+            .unwrap();
+    }
+
     // Awaits until the accounts_data state satisfies predicate `pred`.
     pub async fn wait_for_accounts_data_pred(
         &self,
@@ -427,6 +440,25 @@ impl ActorHandler {
             events
                 .recv_until(|ev| match ev {
                     Event::PeerManager(PME::EdgesAdded { .. }) => Some(()),
+                    _ => None,
+                })
+                .await;
+        }
+    }
+
+    pub async fn wait_for_account_owner(&self, account: &AccountId) -> PeerId {
+        let mut events = self.events.from_now();
+        loop {
+            let account = account.clone();
+            let got = self
+                .with_state(|s| async move { s.account_announcements.get_account_owner(&account) })
+                .await;
+            if let Some(got) = got {
+                return got;
+            }
+            events
+                .recv_until(|ev| match ev {
+                    Event::PeerManager(PME::AccountsAdded(_)) => Some(()),
                     _ => None,
                 })
                 .await;

--- a/chain/network/src/peer_manager/tests/tier1.rs
+++ b/chain/network/src/peer_manager/tests/tier1.rs
@@ -371,7 +371,7 @@ async fn tier2_routing_using_accounts_data() {
     pm0.connect_to(&pm1.peer_info(), tcp::Tier::T2).await;
 
     tracing::info!(target:"test", "Try to send a routed message pm0 -> pm1 over TIER2");
-    // It should fail due to missing routing information: AccountData is not
+    // It should fail due to missing routing information: neither AccountData or AnnounceAccount is
     // broadcasted by default in tests.
     // TODO(gprusak): send_tier1_message sends an Approval message, which is not a valid message to
     // be sent from a non-TIER1 node. Make it more realistic by sending a Transaction message.

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -358,6 +358,19 @@ pub(crate) static ALREADY_CONNECTED_ACCOUNT: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
+pub(crate) static ACCOUNT_TO_PEER_LOOKUPS: Lazy<IntCounterVec> = Lazy::new(|| {
+    try_create_int_counter_vec(
+        "near_account_to_peer_lookups",
+        "number of lookups of peer_id by account_id (for routed messages)",
+        // Source is either "AnnounceAccount" or "AccountData".
+        // We want to deprecate AnnounceAccount, so eventually we want all
+        // lookups to be done via AccountData. For now AnnounceAccount is
+        // used as a fallback.
+        &["source"],
+    )
+    .unwrap()
+});
+
 pub(crate) static NETWORK_ROUTED_MSG_DISTANCES: Lazy<IntCounterVec> = Lazy::new(|| {
     try_create_int_counter_vec(
         "near_network_routed_msg_distances",

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -19,7 +19,7 @@ use near_crypto::PublicKey;
 use near_primitives::block::{ApprovalMessage, Block, GenesisId};
 use near_primitives::challenge::Challenge;
 use near_primitives::hash::CryptoHash;
-use near_primitives::network::PeerId;
+use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::sharding::PartialEncodedChunkWithArcReceipts;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockHeight, EpochHeight, ShardId};
@@ -229,6 +229,8 @@ pub enum NetworkRequests {
     StateRequestPart { shard_id: ShardId, sync_hash: CryptoHash, part_id: u64, peer_id: PeerId },
     /// Ban given peer.
     BanPeer { peer_id: PeerId, ban_reason: ReasonForBan },
+    /// Announce account
+    AnnounceAccount(AnnounceAccount),
     /// Broadcast information about a hosted snapshot.
     SnapshotHostInfo { sync_hash: CryptoHash, epoch_height: EpochHeight, shards: Vec<ShardId> },
 
@@ -435,6 +437,7 @@ mod tests {
     #[test]
     fn test_struct_size() {
         assert_size!(PeerInfo);
+        assert_size!(AnnounceAccount);
         assert_size!(RawRoutedMessage);
         assert_size!(RoutedMessage);
         assert_size!(KnownPeerState);

--- a/tools/chainsync-loadtest/src/network.rs
+++ b/tools/chainsync-loadtest/src/network.rs
@@ -14,11 +14,11 @@ use near_network::types::{
 use near_primitives::block::{Approval, Block, BlockHeader};
 use near_primitives::challenge::Challenge;
 use near_primitives::hash::CryptoHash;
-use near_primitives::network::PeerId;
+use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::sharding::ChunkHash;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{AccountId, ShardId};
+use near_primitives::types::{AccountId, EpochId, ShardId};
 use near_primitives::views::FinalExecutionOutcomeView;
 use nearcore::config::NearConfig;
 use rand::seq::SliceRandom;
@@ -294,5 +294,12 @@ impl near_network::client::Client for Network {
         for s in n.info_futures.split_off(0) {
             s.send(n.info_.clone()).unwrap();
         }
+    }
+
+    async fn announce_account(
+        &self,
+        accounts: Vec<(AnnounceAccount, Option<EpochId>)>,
+    ) -> Result<Vec<AnnounceAccount>, ReasonForBan> {
+        Ok(accounts.into_iter().map(|a| a.0).collect())
     }
 }


### PR DESCRIPTION
This reverts commit 5f942be30fa0aeab3ddf97e2fb289e6835370dc7 in order to fix some integration tests.
 x "pytest sanity/network_drop_package.py --features nightly",
  "pytest sanity/network_drop_package.py",
 x "pytest sanity/proxy_restart.py --features nightly",
  "pytest sanity/proxy_restart.py",
x  "pytest sanity/proxy_simple.py --features nightly",
  "pytest sanity/proxy_simple.py",
x  "pytest sanity/restart.py --features nightly",---Jan
  "pytest sanity/restart.py",---Jan
 x "pytest sanity/sync_ban.py false --features nightly",
  "pytest sanity/sync_ban.py false",
 "expensive integration-tests integration_tests tests::client::block_corruption::check_process_flipped_block_fails --features nightly",
  "expensive integration-tests integration_tests tests::client::block_corruption::check_process_flipped_block_fails"
  "expensive integration-tests integration_tests 
