### PR TITLE
fix(pytests): fix rpc_finality.py

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -219,9 +219,11 @@ class BaseNode(object):
         return self.json_rpc('broadcast_tx_async',
                              [base64.b64encode(signed_tx).decode('utf8')])
 
-    def send_tx_and_wait(self, signed_tx, timeout):
-        return self.json_rpc('broadcast_tx_commit',
-                             [base64.b64encode(signed_tx).decode('utf8')],
+    def send_tx_and_wait(self, signed_tx, timeout, wait_until='FINAL'):
+        return self.json_rpc('send_tx', {
+            'signed_tx_base64': base64.b64encode(signed_tx).decode('utf8'),
+            'wait_until': wait_until
+        },
                              timeout=timeout)
 
     def get_status(self,

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -219,7 +219,12 @@ class BaseNode(object):
         return self.json_rpc('broadcast_tx_async',
                              [base64.b64encode(signed_tx).decode('utf8')])
 
-    def send_tx_and_wait(self, signed_tx, timeout, wait_until='FINAL'):
+    def send_tx_and_wait(self, signed_tx, timeout):
+        return self.json_rpc('broadcast_tx_commit',
+                             [base64.b64encode(signed_tx).decode('utf8')],
+                             timeout=timeout)
+
+    def send_tx_rpc(self, signed_tx, timeout, wait_until='FINAL'):
         return self.json_rpc('send_tx', {
             'signed_tx_base64': base64.b64encode(signed_tx).decode('utf8'),
             'wait_until': wait_until

--- a/pytest/tests/sanity/rpc_finality.py
+++ b/pytest/tests/sanity/rpc_finality.py
@@ -60,9 +60,7 @@ class TestRpcFinality(unittest.TestCase):
         # this transaction will be added to the block (probably around block 5)
         # and the the receipts & transfers will happen in the next block (block 6).
         # This function should return as soon as block 6 arrives in node0.
-        logger.info(nodes[0].send_tx_and_wait(tx,
-                                              wait_until='INCLUDED',
-                                              timeout=10))
+        logger.info(nodes[0].send_tx_rpc(tx, wait_until='INCLUDED', timeout=10))
         logger.info("Done")
 
         # kill one validating node so that block cannot be finalized.

--- a/pytest/tests/sanity/rpc_finality.py
+++ b/pytest/tests/sanity/rpc_finality.py
@@ -62,7 +62,9 @@ class TestRpcFinality(unittest.TestCase):
         # this transaction will be added to the block (probably around block 5)
         # and the the receipts & transfers will happen in the next block (block 6).
         # This function should return as soon as block 6 arrives in node0.
-        logger.info(nodes[0].send_tx_and_wait(tx, timeout=10))
+        logger.info(nodes[0].send_tx_and_wait(tx,
+                                              wait_until='INCLUDED',
+                                              timeout=10))
         logger.info("Done")
 
         # kill one validating node so that block cannot be finalized.

--- a/pytest/tests/sanity/rpc_finality.py
+++ b/pytest/tests/sanity/rpc_finality.py
@@ -24,19 +24,17 @@ class TestRpcFinality(unittest.TestCase):
         min_block_delay = 3
 
         consensus = {
-            "consensus": {
-                "min_block_production_delay": {
-                    "secs": min_block_delay,
-                    "nanos": 0,
-                },
-                "max_block_production_delay": {
-                    "secs": min_block_delay * 2,
-                    "nanos": 0,
-                },
-                "max_block_wait_delay": {
-                    "secs": min_block_delay * 3,
-                    "nanos": 0,
-                }
+            "min_block_production_delay": {
+                "secs": min_block_delay,
+                "nanos": 0,
+            },
+            "max_block_production_delay": {
+                "secs": min_block_delay * 2,
+                "nanos": 0,
+            },
+            "max_block_wait_delay": {
+                "secs": min_block_delay * 3,
+                "nanos": 0,
             }
         }
 


### PR DESCRIPTION
https://github.com/near/nearcore/pull/9644 added a new RPC method for sending transactions, and added unused "wait_until" arguments to the existing ones. This change was actually not a no-op for the "broadcast_tx_commit" method, since now that method will wait until all transactions and descendant receipts are final, whereas the previous behavior was closer to the new "INCLUDED" "wait_until" parameter, and we used to just wait for the receipt outcomes to show up, but would return before they're executed and finalized.

So fix it by making send_tx_and_wait() call the send_tx method to get something closer to the old behavior.

Also, an unrelated problem with this test is that the "consensus" change to the config were put in the wrong place, so that measure to decrease the flakiness of this test wasn't actually in place