### PR TITLE
fix: sanity/restart.py: don't kick out validators

### DIFF
--- a/pytest/tests/sanity/restart.py
+++ b/pytest/tests/sanity/restart.py
@@ -15,6 +15,9 @@ TIMEOUT = 150
 BLOCKS1 = 20
 BLOCKS2 = 40
 
+# The epoch size is 10 and the validators will miss a few blocks during restarts, so the kickout threshold has to be adjusted.
+# Otherwise validators will get kicked out and the blockchain will grind to a halt. The threshold is set to 0 to avoid any such problems.
+# On production network this isn't a problem because the epoch size is a few orders of magnitude larger.
 nodes = start_cluster(
     2, 0, 2, None,
     [["epoch_length", 10], ["block_producer_kickout_threshold", 0]], {})

--- a/pytest/tests/sanity/restart.py
+++ b/pytest/tests/sanity/restart.py
@@ -17,7 +17,7 @@ BLOCKS2 = 40
 
 nodes = start_cluster(
     2, 0, 2, None,
-    [["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {})
+    [["epoch_length", 10], ["block_producer_kickout_threshold", 0]], {})
 
 started = time.time()
 


### PR DESCRIPTION
The test [`tests/sanity/restart.py`](https://github.com/jancionear/nearcore/blob/7c0b58fd02a7ecc401736628cc977f6c8cff5fbf/pytest/tests/sanity/restart.py)  is failing because one of the validators gets kicked out. Let's disable kickout to make the test pass again.

The test sets up a network with two validator nodes and epoch size equal to 10 blocks. It lets the network run for 20 blocks, then stops both nodes and starts them again. After the restart it checks that the blockchain still produces blocks.

The problem is that validators might miss some blocks due to the restart, and then they're kicked out for it. Once one of the two validators gets kicked out, the blockchain stops producing blocks. The kickout threshold was set at 80%, so if a validator misses even one block out of four, that will fall under the threshold (3/4 = 75%) and it'll get kicked out. Epoch size is 10, so 4 is a typical number of blocks that a validator is asked to produce.

Missing a single block shouldn't cause kickout. Usually this isn't a problem as the epoch size is 43200, not 10, so a few seconds of downtime don't cause any issues. Here a few seconds of downtime are equal to half of the epoch.

To fix the issue let's disable kickout in this test. By setting the kickout thershold to 0 we can ensure that no validator will get kicked out during the test.

Here are logs from an example failed test run. I cleaned them up a bit by removing spammy messages:
[test.log](https://github.com/near/nearcore/files/13320226/test.log)
[node0.log](https://github.com/near/nearcore/files/13320231/node0.log)
[node1.log](https://github.com/near/nearcore/files/13320233/node1.log)

In this run the validator `test0` gets kicked out at height 24 because it produced 3 blocks out of 4:
```
handle{handler="ApplyChunksDoneMessage" actor="ClientActor"}:postprocess_block{height=24}: epoch_manager: All proposals: [], Kickouts: {AccountId("test0"): NotEnoughBlocks { produced: 3, expected: 4 }}, Block Tracker: {1: ValidatorStats { produced: 9, expected: 9 }, 0: ValidatorStats { produced: 3, expected: 4 }}, Shard Tracker: {1: {1: ValidatorStats { produced: 11, expected: 12 }}, 0: {0: ValidatorStats { produced: 11, expected: 12 }}}
```

Then in the next epoch the blockchain is unable to produce the block at height 34 and the test fails:
```
check_triggers:handle_block_production: client: Cannot produce any block: not enough approvals beyond 34
```

Setting the kickout threshold to 0 makes the test pass.

