### PR TITLE
use a hack to make fuzzer building actually work

### DIFF
--- a/.github/workflows/master_fuzzer_binaries.yml
+++ b/.github/workflows/master_fuzzer_binaries.yml
@@ -29,8 +29,9 @@ jobs:
         with:
           crate: cargo-bolero
           # TODO: remove the below once https://github.com/camshaft/bolero/pull/195 is released on crates.io
-          git: https://github.com/camshaft/bolero
-          rev: 8c5a50a57b0e4c4cc8111cfd95670dc75cd2dea7
+          # and https://github.com/camshaft/bolero/pull/196 has a proper fix
+          git: https://github.com/Ekleog-NEAR/bolero
+          rev: 8f4e49d65c702a2f9858ed3c217b1cb52ce91243
 
       - run: rustup target add --toolchain nightly wasm32-unknown-unknown
 

--- a/.github/workflows/ondemand_fuzzer_binaries.yml
+++ b/.github/workflows/ondemand_fuzzer_binaries.yml
@@ -44,9 +44,10 @@ jobs:
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: cargo-bolero
-          # TODO: remove the below once https://github.com/camshaft/bolero/pull/195 lands
-          git: https://github.com/camshaft/bolero
-          rev: 8c5a50a57b0e4c4cc8111cfd95670dc75cd2dea7
+          # TODO: remove the below once https://github.com/camshaft/bolero/pull/195 is released on crates.io
+          # and https://github.com/camshaft/bolero/pull/196 has a proper fix
+          git: https://github.com/Ekleog-NEAR/bolero
+          rev: 8f4e49d65c702a2f9858ed3c217b1cb52ce91243
 
       - run: rustup target add --toolchain nightly wasm32-unknown-unknown
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,8 +726,7 @@ dependencies = [
 [[package]]
 name = "bolero"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9fec67acd9afcd579067cc506c537da49751b8b81c98d5a5e15ba1e853aa3c"
+source = "git+https://github.com/Ekleog-NEAR/bolero?rev=8f4e49d65c702a2f9858ed3c217b1cb52ce91243#8f4e49d65c702a2f9858ed3c217b1cb52ce91243"
 dependencies = [
  "bolero-afl",
  "bolero-engine",
@@ -742,8 +741,7 @@ dependencies = [
 [[package]]
 name = "bolero-afl"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b34f05de1527425bb05287da09ff1ff1612538648824db49e16d9693b24065"
+source = "git+https://github.com/Ekleog-NEAR/bolero?rev=8f4e49d65c702a2f9858ed3c217b1cb52ce91243#8f4e49d65c702a2f9858ed3c217b1cb52ce91243"
 dependencies = [
  "bolero-engine",
  "cc",
@@ -752,8 +750,7 @@ dependencies = [
 [[package]]
 name = "bolero-engine"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ddcfa4c2aa7d57b1785c6e258f612e74c96afa078300d0f811dee73592d7ca"
+source = "git+https://github.com/Ekleog-NEAR/bolero?rev=8f4e49d65c702a2f9858ed3c217b1cb52ce91243#8f4e49d65c702a2f9858ed3c217b1cb52ce91243"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -766,8 +763,7 @@ dependencies = [
 [[package]]
 name = "bolero-generator"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8efabd99549391e8b372e8afe566e8236ca4be6be379c1b6bf81b027c472fe7"
+source = "git+https://github.com/Ekleog-NEAR/bolero?rev=8f4e49d65c702a2f9858ed3c217b1cb52ce91243#8f4e49d65c702a2f9858ed3c217b1cb52ce91243"
 dependencies = [
  "arbitrary",
  "bolero-generator-derive",
@@ -778,8 +774,7 @@ dependencies = [
 [[package]]
 name = "bolero-generator-derive"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53397bfda19ccb48527faa14025048fc4bb76f090ccdeef1e5a355bfe4a94467"
+source = "git+https://github.com/Ekleog-NEAR/bolero?rev=8f4e49d65c702a2f9858ed3c217b1cb52ce91243#8f4e49d65c702a2f9858ed3c217b1cb52ce91243"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -790,8 +785,7 @@ dependencies = [
 [[package]]
 name = "bolero-honggfuzz"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf78581db1a7263620a8767e645b93ad287c70122ae76f5bd67040c7f06ff8e3"
+source = "git+https://github.com/Ekleog-NEAR/bolero?rev=8f4e49d65c702a2f9858ed3c217b1cb52ce91243#8f4e49d65c702a2f9858ed3c217b1cb52ce91243"
 dependencies = [
  "bolero-engine",
 ]
@@ -799,8 +793,7 @@ dependencies = [
 [[package]]
 name = "bolero-kani"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e55cec272a617f5ae4ce670db035108eb97c10cd4f67de851a3c8d3f18f19cb"
+source = "git+https://github.com/Ekleog-NEAR/bolero?rev=8f4e49d65c702a2f9858ed3c217b1cb52ce91243#8f4e49d65c702a2f9858ed3c217b1cb52ce91243"
 dependencies = [
  "bolero-engine",
 ]
@@ -808,8 +801,7 @@ dependencies = [
 [[package]]
 name = "bolero-libfuzzer"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb42f66ee3ec89b9c411994de59d4710ced19df96fea2059feea1c2d73904c5b"
+source = "git+https://github.com/Ekleog-NEAR/bolero?rev=8f4e49d65c702a2f9858ed3c217b1cb52ce91243#8f4e49d65c702a2f9858ed3c217b1cb52ce91243"
 dependencies = [
  "bolero-engine",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ bencher = "0.1.5"
 bitflags = "1.2"
 blake2 = "0.9.1"
 bn = { package = "zeropool-bn", version = "0.5.11" }
-bolero = { version = "0.10.0", features = ["arbitrary"] }
+bolero = { version = "0.10.0", git = "https://github.com/Ekleog-NEAR/bolero", rev = "8f4e49d65c702a2f9858ed3c217b1cb52ce91243", features = ["arbitrary"] }
 borsh = { version = "1.0.0", features = ["derive", "rc"] }
 bs58 = "0.4"
 bytes = "1"

--- a/runtime/near-vm-runner/src/prepare/prepare_v1.rs
+++ b/runtime/near-vm-runner/src/prepare/prepare_v1.rs
@@ -237,7 +237,7 @@ mod test {
     use crate::logic::{Config, ContractPrepareVersion};
 
     #[test]
-    fn v1_preparation_generates_valid_contract() {
+    fn v1_preparation_generates_valid_contract_fuzzer() {
         let mut config = Config::test();
         let prepare_version = ContractPrepareVersion::V1;
         config.limit_config.contract_prepare_version = prepare_version;

--- a/runtime/near-vm-runner/src/prepare/prepare_v2.rs
+++ b/runtime/near-vm-runner/src/prepare/prepare_v2.rs
@@ -366,7 +366,7 @@ mod test {
     use crate::VMKind;
 
     #[test]
-    fn v2_preparation_wasmtime_generates_valid_contract() {
+    fn v2_preparation_wasmtime_generates_valid_contract_fuzzer() {
         let mut config = Config::test();
         let prepare_version = ContractPrepareVersion::V2;
         config.limit_config.contract_prepare_version = prepare_version;
@@ -393,7 +393,7 @@ mod test {
     }
 
     #[test]
-    fn v2_preparation_near_vm_generates_valid_contract() {
+    fn v2_preparation_near_vm_generates_valid_contract_fuzzer() {
         let mut config = Config::test();
         let prepare_version = ContractPrepareVersion::V2;
         config.limit_config.contract_prepare_version = prepare_version;

--- a/runtime/near-vm-runner/src/tests/fuzzers.rs
+++ b/runtime/near-vm-runner/src/tests/fuzzers.rs
@@ -6,7 +6,6 @@ use crate::runner::VMResult;
 use crate::ContractCode;
 use crate::VMKind;
 use arbitrary::Arbitrary;
-use bolero::check;
 use core::fmt;
 use near_primitives_core::runtime::fees::RuntimeFeesConfig;
 
@@ -145,8 +144,8 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMResult {
 }
 
 #[test]
-fn current_vm_does_not_crash() {
-    check!().with_arbitrary::<ArbitraryModule>().for_each(|module: &ArbitraryModule| {
+fn current_vm_does_not_crash_fuzzer() {
+    bolero::check!().with_arbitrary::<ArbitraryModule>().for_each(|module: &ArbitraryModule| {
         let code = ContractCode::new(module.0.module.to_bytes(), None);
         let config = Config::test();
         let _result = run_fuzz(&code, config.vm_kind);
@@ -155,8 +154,8 @@ fn current_vm_does_not_crash() {
 
 #[test]
 #[cfg_attr(not(all(feature = "near_vm", target_arch = "x86_64")), ignore)]
-fn near_vm_and_wasmtime_agree() {
-    check!().with_arbitrary::<ArbitraryModule>().for_each(|module: &ArbitraryModule| {
+fn near_vm_and_wasmtime_agree_fuzzer() {
+    bolero::check!().with_arbitrary::<ArbitraryModule>().for_each(|module: &ArbitraryModule| {
         let code = ContractCode::new(module.0.module.to_bytes(), None);
         let near_vm = run_fuzz(&code, VMKind::NearVm).expect("fatal failure");
         let wasmtime = run_fuzz(&code, VMKind::Wasmtime).expect("fatal failure");
@@ -166,7 +165,7 @@ fn near_vm_and_wasmtime_agree() {
 
 #[test]
 #[cfg(all(feature = "near_vm", target_arch = "x86_64"))]
-fn near_vm_is_reproducible() {
+fn near_vm_is_reproducible_fuzzer() {
     use crate::near_vm_runner::NearVM;
     use near_primitives::hash::CryptoHash;
 

--- a/runtime/near-vm/types/Cargo.toml
+++ b/runtime/near-vm/types/Cargo.toml
@@ -23,4 +23,3 @@ bolero.workspace = true
 
 [[test]]
 name = "partial-sum-map"
-harness = false

--- a/runtime/near-vm/types/tests/partial-sum-map/main.rs
+++ b/runtime/near-vm/types/tests/partial-sum-map/main.rs
@@ -1,6 +1,7 @@
 use near_vm_types::partial_sum_map::{Error, PartialSumMap};
 
-fn main() {
+#[test]
+fn partial_sum_map_fuzzer() {
     bolero::check!().with_type::<(Vec<(u32, u32)>, Vec<u32>)>().for_each(|input| {
         let adds = &input.0;
         let tests = &input.1;

--- a/test-utils/runtime-tester/src/fuzzing.rs
+++ b/test-utils/runtime-tester/src/fuzzing.rs
@@ -789,7 +789,7 @@ mod tests {
     }
 
     #[test]
-    fn fuzz_scenario() {
+    fn scenario_fuzzer() {
         bolero::check!()
             .with_iterations(100) // Limit to 100 iterations, the default of 1000 would be too slow
             .with_arbitrary::<Scenario>()


### PR DESCRIPTION
See discussion at [1]. Here, the solution is what would be a bad solution for bolero upstream (because it no longer works with un-harnessed fuzzers), but is fine enough for our use case.

[1] https://github.com/camshaft/bolero/issues/196