### PR TITLE
fix flaky test snapshot_hosts::invalid_signature

### DIFF
--- a/chain/network/src/snapshot_hosts/tests.rs
+++ b/chain/network/src/snapshot_hosts/tests.rs
@@ -93,7 +93,7 @@ async fn invalid_signature() {
     // due to parallelization, so we check for superset rather than strict equality.
     assert_is_superset(&[&info1].as_set(), &res.0.as_set());
     // Partial update should match the state.
-    assert_eq!([&info1].as_set(), cache.get_hosts().iter().collect::<HashSet<_>>());
+    assert_eq!(res.0.as_set(), cache.get_hosts().iter().collect::<HashSet<_>>());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Follow up to #10123, which fixed the previous line in this test:

https://github.com/near/nearcore/blob/5b3e69aef58cf0274c080264a60692d889089aaa/chain/network/src/snapshot_hosts/tests.rs#L91-L94

The test was still flaky because the line modified in this PR needs to be fixed as well.