### PR TITLE
refactor(state-sync): Request sync block in client actor before starting state sync

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2326,12 +2326,6 @@ impl Client {
                 self.runtime_adapter.clone(),
             )? {
                 StateSyncResult::InProgress => {}
-                StateSyncResult::RequestBlock => {
-                    // here RequestBlock should not be returned, because the StateSyncInfos in
-                    // self.chain.store().iterate_state_sync_infos() should have been stored by
-                    // Chain::postprocess_block() on the block with hash sync_hash.
-                    panic!("catchup state sync indicates sync block isn't on our chain")
-                }
                 StateSyncResult::Completed => {
                     debug!(target: "catchup", "state sync completed now catch up blocks");
                     self.chain.catchup_blocks_step(

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -13,6 +13,8 @@ use crate::SyncAdapter;
 use crate::SyncMessage;
 use crate::{metrics, SyncStatus};
 use actix_rt::ArbiterHandle;
+use chrono::DateTime;
+use chrono::Utc;
 use itertools::Itertools;
 use lru::LruCache;
 use near_async::messaging::{CanSend, Sender};
@@ -178,6 +180,10 @@ pub struct Client {
     tier1_accounts_cache: Option<(EpochId, Arc<AccountKeys>)>,
     /// Used when it is needed to create flat storage in background for some shards.
     flat_storage_creator: Option<FlatStorageCreator>,
+
+    /// When the "sync block" was requested.
+    /// The "sync block" is the last block of the previous epoch, i.e. `prev_hash` of the `sync_hash` block.
+    pub last_time_sync_block_requested: Option<DateTime<Utc>>,
 }
 
 impl Client {
@@ -360,6 +366,7 @@ impl Client {
             chunk_production_info: lru::LruCache::new(PRODUCTION_TIMES_CACHE_SIZE),
             tier1_accounts_cache: None,
             flat_storage_creator,
+            last_time_sync_block_requested: None,
         })
     }
 

--- a/chain/client/src/sync/state.rs
+++ b/chain/client/src/sync/state.rs
@@ -132,13 +132,9 @@ pub struct StateSync {
     /// Is used for communication with the peers.
     network_adapter: PeerManagerAdapter,
 
-    /// When the "sync block" was requested.
-    /// The "sync block" is the last block of the previous epoch, i.e. `prev_hash` of the `sync_hash` block.
-    pub last_time_block_requested: Option<DateTime<Utc>>,
-
     /// Timeout (set in config - by default to 60 seconds) is used to figure out how long we should wait
     /// for the answer from the other node before giving up.
-    pub timeout: Duration,
+    timeout: Duration,
 
     /// Maps shard_id to result of applying downloaded state.
     state_parts_apply_results: HashMap<ShardId, Result<(), near_chain_primitives::error::Error>>,
@@ -203,7 +199,6 @@ impl StateSync {
         StateSync {
             inner,
             network_adapter,
-            last_time_block_requested: None,
             timeout,
             state_parts_apply_results: HashMap::new(),
             split_state_roots: HashMap::new(),

--- a/chain/client/src/sync/state.rs
+++ b/chain/client/src/sync/state.rs
@@ -73,8 +73,6 @@ pub const STATE_DUMP_ITERATION_TIME_LIMIT_SECS: u64 = 300;
 pub enum StateSyncResult {
     /// State sync still in progress. No action needed by the caller.
     InProgress,
-    /// The client needs to start fetching the block
-    RequestBlock,
     /// The state for all shards was downloaded.
     Completed,
 }
@@ -136,11 +134,11 @@ pub struct StateSync {
 
     /// When the "sync block" was requested.
     /// The "sync block" is the last block of the previous epoch, i.e. `prev_hash` of the `sync_hash` block.
-    last_time_block_requested: Option<DateTime<Utc>>,
+    pub last_time_block_requested: Option<DateTime<Utc>>,
 
     /// Timeout (set in config - by default to 60 seconds) is used to figure out how long we should wait
     /// for the answer from the other node before giving up.
-    timeout: Duration,
+    pub timeout: Duration,
 
     /// Maps shard_id to result of applying downloaded state.
     state_parts_apply_results: HashMap<ShardId, Result<(), near_chain_primitives::error::Error>>,
@@ -212,38 +210,6 @@ impl StateSync {
             state_parts_mpsc_rx: rx,
             state_parts_mpsc_tx: tx,
         }
-    }
-
-    fn sync_block_status(
-        &mut self,
-        prev_hash: &CryptoHash,
-        chain: &Chain,
-        now: DateTime<Utc>,
-    ) -> Result<(bool, bool), near_chain::Error> {
-        let (request_block, have_block) = if !chain.block_exists(prev_hash)? {
-            match self.last_time_block_requested {
-                None => (true, false),
-                Some(last_time) => {
-                    if now - last_time >= self.timeout {
-                        tracing::error!(
-                            target: "sync",
-                            %prev_hash,
-                            timeout_sec = self.timeout.num_seconds(),
-                            "State sync: block request timed out");
-                        (true, false)
-                    } else {
-                        (false, false)
-                    }
-                }
-            }
-        } else {
-            self.last_time_block_requested = None;
-            (false, true)
-        };
-        if request_block {
-            self.last_time_block_requested = Some(now);
-        };
-        Ok((request_block, have_block))
     }
 
     // The return value indicates whether state sync is
@@ -711,27 +677,13 @@ impl StateSync {
     ) -> Result<StateSyncResult, near_chain::Error> {
         let _span = tracing::debug_span!(target: "sync", "run", sync = "StateSync").entered();
         tracing::trace!(target: "sync", %sync_hash, ?tracking_shards, "syncing state");
-        let prev_hash = *chain.get_block_header(&sync_hash)?.prev_hash();
         let now = StaticClock::utc();
-
-        // FIXME: it checks if the block exists.. but I have no idea why..
-        // seems that we don't really use this block in case of catchup - we use it only for state sync.
-        // Seems it is related to some bug with block getting orphaned after state sync? but not sure.
-        let (request_block, have_block) = self.sync_block_status(&prev_hash, chain, now)?;
 
         if tracking_shards.is_empty() {
             // This case is possible if a validator cares about the same shards in the new epoch as
             //    in the previous (or about a subset of them), return success right away
 
-            return if !have_block {
-                if request_block {
-                    Ok(StateSyncResult::RequestBlock)
-                } else {
-                    Ok(StateSyncResult::InProgress)
-                }
-            } else {
-                Ok(StateSyncResult::Completed)
-            };
+            return Ok(StateSyncResult::Completed);
         }
         // The downloaded parts are from all shards. This function takes all downloaded parts and
         // saves them to the DB.
@@ -753,11 +705,11 @@ impl StateSync {
             runtime_adapter,
         )?;
 
-        if have_block && all_done {
-            return Ok(StateSyncResult::Completed);
+        if all_done {
+            Ok(StateSyncResult::Completed)
+        } else {
+            Ok(StateSyncResult::InProgress)
         }
-
-        Ok(if request_block { StateSyncResult::RequestBlock } else { StateSyncResult::InProgress })
     }
 
     pub fn update_download_on_state_response_message(


### PR DESCRIPTION
We only use this logic for state sync when the nodes starts with old blocks.
If the nodes has been running during the epoch change, it is supposed to have the block so it does not need it at state sync during catchup.