### PR TITLE
Ubuntu 20 distro for GHA binary builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build_binary:
     name: "Build neard"
-    runs-on: ubuntu-20.04-16core
+    runs-on: ubuntu-22.04-16core
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
@@ -36,11 +36,11 @@ jobs:
         include:
           - name: Linux
             cache_id: linux
-            os: ubuntu-20.04-16core
+            os: ubuntu-22.04-16core
             flags: ""
           - name: Linux Nightly
             cache_id: linux
-            os: ubuntu-20.04-16core
+            os: ubuntu-22.04-16core
             flags: "--features nightly,test_features"
           - name: MacOS
             cache_id: macos
@@ -126,7 +126,7 @@ jobs:
 
   py_sanity_checks:
     name: "Sanity Checks"
-    runs-on: ubuntu-20.04-16core
+    runs-on: ubuntu-22.04-16core
     strategy:
       fail-fast: false
     timeout-minutes: 90
@@ -210,7 +210,7 @@ jobs:
 
   rpc_error_schema:
     name: "RPC Schema"
-    runs-on: ubuntu-20.04-8core
+    runs-on: ubuntu-22.04-8core
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build_binary:
     name: "Build neard"
-    runs-on: ubuntu-22.04-16core
+    runs-on: ubuntu-20.04-16core
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
@@ -36,11 +36,11 @@ jobs:
         include:
           - name: Linux
             cache_id: linux
-            os: ubuntu-22.04-16core
+            os: ubuntu-20.04-16core
             flags: ""
           - name: Linux Nightly
             cache_id: linux
-            os: ubuntu-22.04-16core
+            os: ubuntu-20.04-16core
             flags: "--features nightly,test_features"
           - name: MacOS
             cache_id: macos
@@ -126,7 +126,7 @@ jobs:
 
   py_sanity_checks:
     name: "Sanity Checks"
-    runs-on: ubuntu-22.04-16core
+    runs-on: ubuntu-20.04-16core
     strategy:
       fail-fast: false
     timeout-minutes: 90
@@ -210,7 +210,7 @@ jobs:
 
   rpc_error_schema:
     name: "RPC Schema"
-    runs-on: ubuntu-22.04-8core
+    runs-on: ubuntu-20.04-8core
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43

--- a/.github/workflows/neard_assertion_binary.yml
+++ b/.github/workflows/neard_assertion_binary.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   binary-release:
     name: "Build and publish neard binary"
-    runs-on: "ubuntu-22.04-16core"
+    runs-on: "ubuntu-20.04-16core"
     environment: deploy
     permissions:
       id-token: write # required to use OIDC authentication

--- a/.github/workflows/neard_linux_binary.yml
+++ b/.github/workflows/neard_linux_binary.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   binary-release:
     name: "Build and publish neard binary"
-    runs-on: "ubuntu-22.04-16core"
+    runs-on: "ubuntu-20.04-16core"
     environment: deploy
     permissions:
       id-token: write # required to use OIDC authentication

--- a/.github/workflows/neard_nightly_binary.yml
+++ b/.github/workflows/neard_nightly_binary.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   binary-release:
     name: "Build and publish neard binary"
-    runs-on: "ubuntu-22.04-16core"
+    runs-on: "ubuntu-20.04-16core"
     environment: deploy
     permissions:
       id-token: write # required to use OIDC authentication


### PR DESCRIPTION
neard binaries built on Ubuntu 22 are no compatible with Ubuntu 20 libs:
$ ./neard --version
./neard: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./neard)
./neard: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ./neard)
./neard: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by ./neard)


