### PR TITLE
feat: add a debug page with basic information about split store

### DIFF
--- a/chain/jsonrpc-primitives/src/types/split_storage.rs
+++ b/chain/jsonrpc-primitives/src/types/split_storage.rs
@@ -2,6 +2,8 @@ use near_primitives::views::SplitStorageInfoView;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::types::status::RpcStatusError;
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RpcSplitStorageInfoRequest {}
 
@@ -37,5 +39,18 @@ impl From<RpcSplitStorageInfoError> for crate::errors::RpcError {
         };
 
         Self::new_internal_or_handler_error(error_data, error_data_value)
+    }
+}
+
+impl RpcSplitStorageInfoError {
+    // Implementing From<RpcSplitStorageInfoError> for RpcStatusError causes cargo to spit out hundreds
+    // of lines of compilation errors. I don't want to spend time debugging this, so let's use this function instead.
+    // It's good enough.
+    pub fn into_rpc_status_error(self) -> RpcStatusError {
+        match self {
+            RpcSplitStorageInfoError::InternalError { error_message } => {
+                RpcStatusError::InternalError { error_message }
+            }
+        }
     }
 }

--- a/chain/jsonrpc-primitives/src/types/status.rs
+++ b/chain/jsonrpc-primitives/src/types/status.rs
@@ -5,7 +5,8 @@ use near_client_primitives::debug::{
 #[cfg(feature = "debug_types")]
 use near_primitives::views::{
     CatchupStatusView, ChainProcessingInfo, NetworkGraphView, NetworkRoutesView, PeerStoreView,
-    RecentOutboundConnectionsView, RequestedStatePartsView, SnapshotHostsView, SyncStatusView,
+    RecentOutboundConnectionsView, RequestedStatePartsView, SnapshotHostsView,
+    SplitStorageInfoView, SyncStatusView,
 };
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -34,6 +35,7 @@ pub enum DebugStatusResponse {
     RecentOutboundConnections(RecentOutboundConnectionsView),
     Routes(NetworkRoutesView),
     SnapshotHosts(SnapshotHostsView),
+    SplitStoreStatus(SplitStorageInfoView),
 }
 
 #[cfg(feature = "debug_types")]

--- a/chain/jsonrpc/res/debug.html
+++ b/chain/jsonrpc/res/debug.html
@@ -67,6 +67,7 @@
     <h1><a href="debug/pages/sync">Sync info</a></h1>
     <h1><a href="debug/pages/validator">Validator info</a></h1>
     <h1><a href="debug/client_config">Client Config</a></h1>
+    <h1><a href="debug/pages/split_store">Split Store</a></h1>
 </body>
 
 </html>

--- a/chain/jsonrpc/res/split_store.html
+++ b/chain/jsonrpc/res/split_store.html
@@ -1,0 +1,33 @@
+<html>
+
+<head>
+    <title> Split Store </title>
+</head>
+
+<body>
+    <h1>
+        Split Store
+    </h1>
+
+    <ul>
+        <li> Head height: <span id="head-height"></span></li>
+        <li> Cold head height: <span id="cold-head-height"></span></li>
+        <li> Final head height: <span id="final-head-height"></span></li>
+        <li> Hot db kind: <span id="hot-db-kind"></span></li>
+    </ul>
+
+    <script>
+        document.body.onload = async () => {
+            response = await fetch("../api/split_store_info")
+            response_json = await response.json()
+            info = response_json['status_response']['SplitStoreStatus']
+
+            document.getElementById("head-height").textContent = String(info["head_height"])
+            document.getElementById("cold-head-height").textContent = String(info["cold_head_height"])
+            document.getElementById("final-head-height").textContent = String(info["final_head_height"])
+            document.getElementById("hot-db-kind").textContent = String(info["hot_db_kind"])
+        }
+    </script>
+</body>
+
+</html>

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1453,6 +1453,7 @@ async fn display_debug_html(
         "sync.css" => Some(debug_page_string!("sync.css", handler)),
         "validator" => Some(debug_page_string!("validator.html", handler)),
         "validator.css" => Some(debug_page_string!("validator.css", handler)),
+        "split_store" => Some(debug_page_string!("split_store.html", handler)),
         _ => None,
     };
 

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -24,7 +24,9 @@ use near_jsonrpc_primitives::message::{Message, Request};
 use near_jsonrpc_primitives::types::config::RpcProtocolConfigResponse;
 use near_jsonrpc_primitives::types::entity_debug::{EntityDebugHandler, EntityQuery};
 use near_jsonrpc_primitives::types::query::RpcQueryRequest;
-use near_jsonrpc_primitives::types::split_storage::RpcSplitStorageInfoResponse;
+use near_jsonrpc_primitives::types::split_storage::{
+    RpcSplitStorageInfoRequest, RpcSplitStorageInfoResponse,
+};
 use near_jsonrpc_primitives::types::transactions::{
     RpcSendTransactionRequest, RpcTransactionResponse,
 };
@@ -771,6 +773,13 @@ impl JsonRpcHandler {
                         .peer_manager_send(near_network::debug::GetDebugStatus::SnapshotHosts)
                         .await?
                         .rpc_into(),
+                    "/debug/api/split_store_info" => {
+                        let split_storage_info: RpcSplitStorageInfoResponse = self
+                            .split_storage_info(RpcSplitStorageInfoRequest {})
+                            .await
+                            .map_err(|e| e.into_rpc_status_error())?;
+                        near_jsonrpc_primitives::types::status::DebugStatusResponse::SplitStoreStatus(split_storage_info.result)
+                    }
                     _ => return Ok(None),
                 };
             Ok(Some(near_jsonrpc_primitives::types::status::RpcDebugStatusResponse {


### PR DESCRIPTION
Add a new debug page: `/debug/pages/split_store`
This page provides basic information about the state of split store.
An example report looks like this:

![image](https://github.com/near/nearcore/assets/149345204/2ec1cfc1-7e31-4a1d-a37c-e843fbf89c81)

Fixes: https://github.com/near/nearcore/issues/9549
