### PR TITLE
Standalone dockerfile

### DIFF
--- a/.github/workflows/neard_linux_binary.yml
+++ b/.github/workflows/neard_linux_binary.yml
@@ -16,61 +16,38 @@ on:
         required: true
 
 jobs:
-  binary-release:
-    name: "Build and publish neard binary"
-    runs-on: "ubuntu-20.04-16core"
-    environment: deploy
-    permissions:
-      id-token: write # required to use OIDC authentication
+  # binary-release:
+  #   name: "Build and publish neard binary"
+  #   runs-on: "ubuntu-20.04-16core"
+  #   environment: deploy
+  #   permissions:
+  #     id-token: write # required to use OIDC authentication
 
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::754641474505:role/GitHubActionsRunner
-          aws-region: us-west-1
+  #   steps:
+  #     - name: Configure AWS Credentials
+  #       uses: aws-actions/configure-aws-credentials@v4
+  #       with:
+  #         role-to-assume: arn:aws:iam::754641474505:role/GitHubActionsRunner
+  #         aws-region: us-west-1
 
-      - name: Checkout ${{ github.event.inputs.branch }} branch
-        if: ${{ github.event_name == 'workflow_dispatch'}}
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.branch }}
+  #     - name: Checkout ${{ github.event.inputs.branch }} branch
+  #       if: ${{ github.event_name == 'workflow_dispatch'}}
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ github.event.inputs.branch }}
 
-      - name: Checkout nearcore repository
-        if: ${{ github.event_name != 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+  #     - name: Checkout nearcore repository
+  #       if: ${{ github.event_name != 'workflow_dispatch'}}
+  #       uses: actions/checkout@v4
 
-      - name: Neard binary build and upload to S3
-        run: ./scripts/binary_release.sh
+  #     - name: Neard binary build and upload to S3
+  #       run: ./scripts/binary_release.sh
 
-      - name: Update latest version metadata in S3
-        run: |
-          echo $(git rev-parse HEAD) > latest
-          BRANCH=$(git branch --show-current)
-          aws s3 cp --acl public-read latest s3://build.nearprotocol.com/nearcore/$(uname)/${BRANCH}/latest
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKER_PAT_TOKEN }}
-  
-      - name: Build and push Docker image to nearprotocol/nearcore
-        run: |
-          COMMIT=$(git rev-parse HEAD)
-          BRANCH=${{ github.ref_name }}
-          cp target/release/neard neard
-          docker build -t nearcore -f Dockerfile  --progress=plain .
-          docker tag nearcore nearprotocol/nearcore:${BRANCH}-${COMMIT}
-          docker tag nearcore nearprotocol/nearcore:${BRANCH}
-
-          docker push nearprotocol/nearcore:${BRANCH}-${COMMIT}
-          docker push nearprotocol/nearcore:${BRANCH}
-          if [[ ${BRANCH} == "master" ]];
-          then
-            docker tag nearcore nearprotocol/nearcore:latest
-            docker push nearprotocol/nearcore:latest
-          fi
+  #     - name: Update latest version metadata in S3
+  #       run: |
+  #         echo $(git rev-parse HEAD) > latest
+  #         BRANCH=$(git branch --show-current)
+  #         aws s3 cp --acl public-read latest s3://build.nearprotocol.com/nearcore/$(uname)/${BRANCH}/latest
 
   docker-release:
     name: "Build and publish nearcore Docker image"

--- a/.github/workflows/neard_linux_binary.yml
+++ b/.github/workflows/neard_linux_binary.yml
@@ -39,8 +39,6 @@ jobs:
       - name: Checkout nearcore repository
         if: ${{ github.event_name != 'workflow_dispatch'}}
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref_name }}
 
       - name: Neard binary build and upload to S3
         run: ./scripts/binary_release.sh
@@ -63,6 +61,44 @@ jobs:
           BRANCH=${{ github.ref_name }}
           cp target/release/neard neard
           docker build -t nearcore -f Dockerfile  --progress=plain .
+          docker tag nearcore nearprotocol/nearcore:${BRANCH}-${COMMIT}
+          docker tag nearcore nearprotocol/nearcore:${BRANCH}
+
+          docker push nearprotocol/nearcore:${BRANCH}-${COMMIT}
+          docker push nearprotocol/nearcore:${BRANCH}
+          if [[ ${BRANCH} == "master" ]];
+          then
+            docker tag nearcore nearprotocol/nearcore:latest
+            docker push nearprotocol/nearcore:latest
+          fi
+
+  docker-release:
+    name: "Build and publish nearcore Docker image"
+    runs-on: "ubuntu-20.04-16core"
+    environment: deploy
+    steps:
+      - name: Checkout ${{ github.event.inputs.branch }} branch
+        if: ${{ github.event_name == 'workflow_dispatch'}}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Checkout nearcore repository
+        if: ${{ github.event_name != 'workflow_dispatch'}}
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKER_PAT_TOKEN }}
+  
+      - name: Build and push Docker image to Dockerhub
+        run: |
+          COMMIT=$(git rev-parse HEAD)
+          BRANCH=${{ github.ref_name }}
+          # docker build -t nearcore -f Dockerfile  --progress=plain .
+          make docker-nearcore
           docker tag nearcore nearprotocol/nearcore:${BRANCH}-${COMMIT}
           docker tag nearcore nearprotocol/nearcore:${BRANCH}
 

--- a/.github/workflows/neard_release.yml
+++ b/.github/workflows/neard_release.yml
@@ -1,4 +1,4 @@
-name: Neard Linux binary and Docker image release
+name: Neard binary and Docker image release
 
 on:
   # Run when a new release or rc is created
@@ -16,38 +16,38 @@ on:
         required: true
 
 jobs:
-  # binary-release:
-  #   name: "Build and publish neard binary"
-  #   runs-on: "ubuntu-20.04-16core"
-  #   environment: deploy
-  #   permissions:
-  #     id-token: write # required to use OIDC authentication
+  binary-release:
+    name: "Build and publish neard binary"
+    runs-on: "ubuntu-20.04-16core"
+    environment: deploy
+    permissions:
+      id-token: write # required to use OIDC authentication
 
-  #   steps:
-  #     - name: Configure AWS Credentials
-  #       uses: aws-actions/configure-aws-credentials@v4
-  #       with:
-  #         role-to-assume: arn:aws:iam::754641474505:role/GitHubActionsRunner
-  #         aws-region: us-west-1
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::754641474505:role/GitHubActionsRunner
+          aws-region: us-west-1
 
-  #     - name: Checkout ${{ github.event.inputs.branch }} branch
-  #       if: ${{ github.event_name == 'workflow_dispatch'}}
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ github.event.inputs.branch }}
+      - name: Checkout ${{ github.event.inputs.branch }} branch
+        if: ${{ github.event_name == 'workflow_dispatch'}}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
 
-  #     - name: Checkout nearcore repository
-  #       if: ${{ github.event_name != 'workflow_dispatch'}}
-  #       uses: actions/checkout@v4
+      - name: Checkout nearcore repository
+        if: ${{ github.event_name != 'workflow_dispatch'}}
+        uses: actions/checkout@v4
 
-  #     - name: Neard binary build and upload to S3
-  #       run: ./scripts/binary_release.sh
+      - name: Neard binary build and upload to S3
+        run: ./scripts/binary_release.sh
 
-  #     - name: Update latest version metadata in S3
-  #       run: |
-  #         echo $(git rev-parse HEAD) > latest
-  #         BRANCH=$(git branch --show-current)
-  #         aws s3 cp --acl public-read latest s3://build.nearprotocol.com/nearcore/$(uname)/${BRANCH}/latest
+      - name: Update latest version metadata in S3
+        run: |
+          echo $(git rev-parse HEAD) > latest
+          BRANCH=$(git branch --show-current)
+          aws s3 cp --acl public-read latest s3://build.nearprotocol.com/nearcore/$(uname)/${BRANCH}/latest
 
   docker-release:
     name: "Build and publish nearcore Docker image"
@@ -74,13 +74,13 @@ jobs:
         run: |
           COMMIT=$(git rev-parse HEAD)
           BRANCH=${{ github.ref_name }}
-          # docker build -t nearcore -f Dockerfile  --progress=plain .
           make docker-nearcore
           docker tag nearcore nearprotocol/nearcore:${BRANCH}-${COMMIT}
           docker tag nearcore nearprotocol/nearcore:${BRANCH}
 
           docker push nearprotocol/nearcore:${BRANCH}-${COMMIT}
           docker push nearprotocol/nearcore:${BRANCH}
+          
           if [[ ${BRANCH} == "master" ]];
           then
             docker tag nearcore nearprotocol/nearcore:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,36 @@
+# syntax=docker/dockerfile-upstream:experimental
+
+FROM ubuntu:22.04 as build
+
+RUN apt-get update -qq && apt-get install -y \
+    git \
+    cmake \
+    g++ \
+    pkg-config \
+    libssl-dev \
+    curl \
+    llvm \
+    clang \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY ./rust-toolchain.toml /tmp/rust-toolchain.toml
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN curl https://sh.rustup.rs -sSf | \
+    sh -s -- -y --no-modify-path --default-toolchain none
+
+VOLUME [ /near ]
+WORKDIR /near
+COPY . .
+
+ENV PORTABLE=ON
+ARG make_target=
+RUN make CARGO_TARGET_DIR=/tmp/target \
+    "${make_target:?make_target not set}"
+
 # Docker image
 FROM ubuntu:22.04
 
@@ -8,6 +41,6 @@ RUN apt-get update -qq && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY scripts/run_docker.sh /usr/local/bin/run.sh
-COPY neard /usr/local/bin/
+COPY --from=build /tmp/target/release/neard /usr/local/bin/
 
 CMD ["/usr/local/bin/run.sh"]


### PR DESCRIPTION
In this PR I split the neard release WF into 2 jobs: 1 for binary and second for docker image.
In addition, I make the Dockerfile standalone so it can function independent of the binary build job.

test run [here](https://github.com/near/nearcore/actions/runs/6889456250/job/18740477267)