### PR TITLE
refactor: prepare shard update impl for stateless validation

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3931,7 +3931,6 @@ impl Chain {
     ) -> Result<Option<ApplyChunkJob>, Error> {
         let prev_hash = block.header().prev_hash();
         let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(prev_hash)?;
-        let shard_uid = self.epoch_manager.shard_id_to_uid(shard_id, &epoch_id)?;
         let cares_about_shard_this_epoch =
             self.shard_tracker.care_about_shard(me.as_ref(), prev_hash, shard_id, true);
         let cares_about_shard_next_epoch =
@@ -3943,7 +3942,6 @@ impl Chain {
             cares_about_shard_next_epoch,
         );
         let need_to_split_states = will_shard_layout_change && cares_about_shard_next_epoch;
-
         // We can only split states when states are ready, i.e., mode != ApplyChunksMode::NotCaughtUp
         // 1) if should_apply_transactions == true && split_state_roots.is_some(),
         //     that means split states are ready.
@@ -3965,6 +3963,7 @@ impl Chain {
             None
         };
 
+        let shard_uid = self.epoch_manager.shard_id_to_uid(shard_id, &epoch_id)?;
         let is_new_chunk = chunk_header.height_included() == block.header().height();
         let shard_update_reason = if should_apply_transactions {
             if is_new_chunk {

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3887,7 +3887,7 @@ impl Chain {
             .iter()
             .zip(prev_chunk_headers.iter())
             .enumerate()
-            .map(|(shard_id, (chunk_header, prev_chunk_header))| {
+            .filter_map(|(shard_id, (chunk_header, prev_chunk_header))| {
                 // XXX: This is a bit questionable -- sandbox state patching works
                 // only for a single shard. This so far has been enough.
                 let state_patch = state_patch.take();

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3534,9 +3534,10 @@ impl Chain {
         shard_id: ShardId,
         is_new_chunk: bool,
     ) -> Result<BlockContext, Error> {
-        // backwards compatibility
         let epoch_id = block_header.epoch_id();
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(epoch_id)?;
+        // Before `FixApplyChunks` feature, gas price was taken from current
+        // block by mistake. Preserve it for backwards compatibility.
         let gas_price = if !is_new_chunk
             && protocol_version < ProtocolFeature::FixApplyChunks.protocol_version()
         {

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3891,7 +3891,7 @@ impl Chain {
                 // XXX: This is a bit questionable -- sandbox state patching works
                 // only for a single shard. This so far has been enough.
                 let state_patch = state_patch.take();
-                let apply_chunk_job = self.get_apply_chunk_job(
+                let apply_chunk_job = self.get_update_shard_job(
                     me,
                     block,
                     prev_block,
@@ -3916,8 +3916,8 @@ impl Chain {
             .collect()
     }
 
-    /// This method returns the closure that is responsible for applying of a single chunk.
-    fn get_apply_chunk_job(
+    /// This method returns the closure that is responsible for updating a shard.
+    fn get_update_shard_job(
         &self,
         me: &Option<AccountId>,
         block: &Block,
@@ -4036,7 +4036,7 @@ impl Chain {
         let block_context = self.get_block_context_for_shard_update(
             block.header(),
             prev_block.header(),
-            shard_id as ShardId,
+            shard_id,
             is_new_chunk,
         )?;
         Ok(Some(Box::new(move |parent_span| -> Result<ApplyChunkResult, Error> {

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3930,7 +3930,6 @@ impl Chain {
         state_patch: SandboxStatePatch,
     ) -> Result<Option<ApplyChunkJob>, Error> {
         let prev_hash = block.header().prev_hash();
-        let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(prev_hash)?;
         let cares_about_shard_this_epoch =
             self.shard_tracker.care_about_shard(me.as_ref(), prev_hash, shard_id, true);
         let cares_about_shard_next_epoch =
@@ -3963,7 +3962,7 @@ impl Chain {
             None
         };
 
-        let shard_uid = self.epoch_manager.shard_id_to_uid(shard_id, &epoch_id)?;
+        let shard_uid = self.epoch_manager.shard_id_to_uid(shard_id, block.header().epoch_id())?;
         let is_new_chunk = chunk_header.height_included() == block.header().height();
         let shard_update_reason = if should_apply_transactions {
             if is_new_chunk {

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -68,7 +68,7 @@ use near_primitives::transaction::{ExecutionOutcomeWithIdAndProof, SignedTransac
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{
     AccountId, Balance, BlockExtra, BlockHeight, BlockHeightDelta, EpochId, MerkleHash, NumBlocks,
-    NumShards, ShardId, StateChangesForSplitStates, StateRoot,
+    NumShards, ShardId, StateRoot,
 };
 use near_primitives::unwrap_or_return;
 use near_primitives::utils::MaybeValidated;
@@ -3880,10 +3880,10 @@ impl Chain {
         invalid_chunks: &mut Vec<ShardChunkHeader>,
     ) -> Result<Vec<ApplyChunkJob>, Error> {
         let _span = tracing::debug_span!(target: "chain", "apply_chunks_preprocessing").entered();
-        let chunk_headers = block.chunks();
         let prev_chunk_headers =
             Chain::get_prev_chunk_headers(self.epoch_manager.as_ref(), prev_block)?;
-        chunk_headers
+        block
+            .chunks()
             .iter()
             .zip(prev_chunk_headers.iter())
             .enumerate()

--- a/chain/chain/src/lib.rs
+++ b/chain/chain/src/lib.rs
@@ -30,6 +30,7 @@ pub mod validate;
 
 #[cfg(test)]
 mod tests;
+mod update_shard;
 
 #[cfg(feature = "byzantine_asserts")]
 #[macro_export]

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -70,7 +70,7 @@ pub enum ShardUpdateReason {
     /// Instead, previous chunk header is copied.
     /// Contains result of shard update for previous block.
     OldChunk(ChunkExtra),
-    /// See comment to `split_state_roots` in `Chain::apply_chunks_preprocessing`.
+    /// See comment to `split_state_roots` in `Chain::get_apply_chunk_job`.
     /// Process only state changes caused by resharding.
     StateSplit(StateChangesForSplitStates),
 }

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -69,11 +69,11 @@ pub(crate) enum ApplyChunkResult {
 }
 
 /// State roots of split shards which are ready.
-pub type SplitStateRoots = HashMap<ShardUId, StateRoot>;
+type SplitStateRoots = HashMap<ShardUId, StateRoot>;
 
 /// Reason to update a shard when new block appears on chain.
 /// All types include state roots for split shards in case of resharding.
-pub enum ShardUpdateReason {
+pub(crate) enum ShardUpdateReason {
     /// Block has a new chunk for the shard.
     /// Contains chunk itself and all new incoming receipts to the shard.
     NewChunk(ShardChunk, Vec<Receipt>, Option<SplitStateRoots>),
@@ -95,7 +95,7 @@ pub struct ShardContext {
 
 /// Processes shard update with given block and shard.
 /// Doesn't modify chain, only produces result to be applied later.
-pub fn process_shard_update(
+pub(crate) fn process_shard_update(
     parent_span: &tracing::Span,
     runtime: &dyn RuntimeAdapter,
     epoch_manager: &dyn EpochManagerAdapter,

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -189,8 +189,8 @@ fn apply_new_chunk(
         Ok(apply_result) => {
             let apply_split_result_or_state_changes = if shard_info.will_shard_layout_change {
                 Some(apply_split_state_changes(
-                    epoch_manager.as_ref(),
-                    runtime.as_ref(),
+                    epoch_manager,
+                    runtime,
                     block_context,
                     &apply_result,
                     split_state_roots,
@@ -257,8 +257,8 @@ fn apply_old_chunk(
         Ok(apply_result) => {
             let apply_split_result_or_state_changes = if shard_info.will_shard_layout_change {
                 Some(apply_split_state_changes(
-                    epoch_manager.as_ref(),
-                    runtime.as_ref(),
+                    epoch_manager,
+                    runtime,
                     block_context,
                     &apply_result,
                     split_state_roots,

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -34,35 +34,35 @@ pub(crate) struct BlockContext {
 /// Result of updating a shard for some block when it has a new chunk for this
 /// shard.
 #[derive(Debug)]
-pub(crate) struct NewChunkResult {
-    pub shard_uid: ShardUId,
-    pub gas_limit: Gas,
-    pub apply_result: ApplyTransactionResult,
-    pub apply_split_result_or_state_changes: Option<ApplySplitStateResultOrStateChanges>,
+pub struct NewChunkResult {
+    pub(crate) shard_uid: ShardUId,
+    pub(crate) gas_limit: Gas,
+    pub(crate) apply_result: ApplyTransactionResult,
+    pub(crate) apply_split_result_or_state_changes: Option<ApplySplitStateResultOrStateChanges>,
 }
 
 /// Result of updating a shard for some block when it doesn't have a new chunk
 /// for this shard, so previous chunk header is copied.
 #[derive(Debug)]
-pub(crate) struct OldChunkResult {
-    pub shard_uid: ShardUId,
+pub struct OldChunkResult {
+    pub(crate) shard_uid: ShardUId,
     /// Note that despite the naming, no transactions are applied in this case.
     /// TODO(logunov): exclude receipts/txs context from all related types.
-    pub apply_result: ApplyTransactionResult,
-    pub apply_split_result_or_state_changes: Option<ApplySplitStateResultOrStateChanges>,
+    pub(crate) apply_result: ApplyTransactionResult,
+    pub(crate) apply_split_result_or_state_changes: Option<ApplySplitStateResultOrStateChanges>,
 }
 
 /// Result of updating a shard for some block when we apply only split state
 /// changes due to resharding.
 #[derive(Debug)]
-pub(crate) struct StateSplitResult {
+pub struct StateSplitResult {
     // parent shard of the split states
-    pub shard_uid: ShardUId,
-    pub results: Vec<ApplySplitStateResult>,
+    pub(crate) shard_uid: ShardUId,
+    pub(crate) results: Vec<ApplySplitStateResult>,
 }
 
 #[derive(Debug)]
-pub(crate) enum ApplyChunkResult {
+pub enum ApplyChunkResult {
     NewChunk(NewChunkResult),
     OldChunk(OldChunkResult),
     StateSplit(StateSplitResult),

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -87,7 +87,7 @@ pub(crate) enum ShardUpdateReason {
 }
 
 /// Information about shard to update.
-pub struct ShardContext {
+pub(crate) struct ShardContext {
     pub shard_uid: ShardUId,
     /// Whether shard layout changes in the next epoch.
     pub will_shard_layout_change: bool,

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -1,0 +1,317 @@
+use crate::crypto_hash_timer::CryptoHashTimer;
+use crate::types::{
+    ApplySplitStateResult, ApplySplitStateResultOrStateChanges, ApplyTransactionResult,
+    RuntimeAdapter, RuntimeStorageConfig,
+};
+use near_chain_primitives::Error;
+use near_epoch_manager::EpochManagerAdapter;
+use near_primitives::challenge::ChallengesResult;
+use near_primitives::hash::CryptoHash;
+use near_primitives::receipt::Receipt;
+use near_primitives::sandbox::state_patch::SandboxStatePatch;
+use near_primitives::shard_layout::ShardUId;
+use near_primitives::sharding::ShardChunk;
+use near_primitives::types::chunk_extra::ChunkExtra;
+use near_primitives::types::{Balance, BlockHeight, Gas, StateChangesForSplitStates, StateRoot};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct BlockContext {
+    pub block_hash: CryptoHash,
+    pub prev_block_hash: CryptoHash,
+    pub challenges_result: ChallengesResult,
+    pub block_timestamp: u64,
+    pub gas_price: Balance,
+    pub height: BlockHeight,
+    pub random_seed: CryptoHash,
+    pub is_first_block_with_chunk_of_version: bool,
+}
+
+#[derive(Debug)]
+pub struct SameHeightResult {
+    pub(crate) shard_uid: ShardUId,
+    pub(crate) gas_limit: Gas,
+    pub(crate) apply_result: ApplyTransactionResult,
+    pub(crate) apply_split_result_or_state_changes: Option<ApplySplitStateResultOrStateChanges>,
+}
+
+#[derive(Debug)]
+pub struct DifferentHeightResult {
+    pub(crate) shard_uid: ShardUId,
+    pub(crate) apply_result: ApplyTransactionResult,
+    pub(crate) apply_split_result_or_state_changes: Option<ApplySplitStateResultOrStateChanges>,
+}
+
+#[derive(Debug)]
+pub struct SplitStateResult {
+    // parent shard of the split states
+    pub(crate) shard_uid: ShardUId,
+    pub(crate) results: Vec<ApplySplitStateResult>,
+}
+
+#[derive(Debug)]
+pub enum ApplyChunkResult {
+    SameHeight(SameHeightResult),
+    DifferentHeight(DifferentHeightResult),
+    SplitState(SplitStateResult),
+}
+
+pub enum ShardUpdateReason {
+    NewChunk(ShardChunk, Vec<Receipt>),
+    OldChunk(ChunkExtra),
+    StateSplit(StateChangesForSplitStates),
+}
+
+pub struct ShardInfo {
+    pub shard_uid: ShardUId,
+    pub will_shard_layout_change: bool,
+}
+
+/// This method returns the closure that is responsible for applying of a single chunk.
+pub fn process_shard_update(
+    parent_span: &tracing::Span,
+    epoch_manager: Arc<dyn EpochManagerAdapter>,
+    runtime: Arc<dyn RuntimeAdapter>,
+    shard_update_reason: ShardUpdateReason,
+    block_context: BlockContext,
+    shard_info: ShardInfo,
+    split_state_roots: Option<HashMap<ShardUId, StateRoot>>,
+    state_patch: SandboxStatePatch,
+) -> Result<ApplyChunkResult, Error> {
+    match shard_update_reason {
+        ShardUpdateReason::NewChunk(chunk, receipts) => apply_new_chunk(
+            parent_span,
+            block_context,
+            chunk,
+            shard_info,
+            receipts,
+            state_patch,
+            runtime.clone(),
+            epoch_manager.clone(),
+            split_state_roots,
+        ),
+        ShardUpdateReason::OldChunk(prev_chunk_extra) => apply_old_chunk(
+            parent_span,
+            block_context,
+            &prev_chunk_extra,
+            shard_info,
+            state_patch,
+            runtime.clone(),
+            epoch_manager.clone(),
+            split_state_roots,
+        ),
+        ShardUpdateReason::StateSplit(state_changes) => apply_state_split(
+            parent_span,
+            block_context,
+            shard_info.shard_uid,
+            runtime,
+            epoch_manager,
+            split_state_roots.unwrap(),
+            state_changes,
+        ),
+    }
+}
+
+/// Returns the apply chunk job when applying a new chunk and applying transactions.
+fn apply_new_chunk(
+    parent_span: &tracing::Span,
+    block_context: BlockContext,
+    chunk: ShardChunk,
+    shard_info: ShardInfo,
+    receipts: Vec<Receipt>,
+    state_patch: SandboxStatePatch,
+    runtime: Arc<dyn RuntimeAdapter>,
+    epoch_manager: Arc<dyn EpochManagerAdapter>,
+    split_state_roots: Option<HashMap<ShardUId, CryptoHash>>,
+) -> Result<ApplyChunkResult, Error> {
+    let shard_id = shard_info.shard_uid.shard_id();
+    let _span = tracing::debug_span!(
+            target: "chain",
+            parent: parent_span,
+            "new_chunk",
+            shard_id)
+    .entered();
+    let chunk_inner = chunk.cloned_header().take_inner();
+    let gas_limit = chunk_inner.gas_limit();
+
+    let _timer = CryptoHashTimer::new(chunk.chunk_hash().0);
+    let storage_config = RuntimeStorageConfig {
+        state_root: *chunk_inner.prev_state_root(),
+        use_flat_storage: true,
+        source: crate::types::StorageDataSource::Db,
+        state_patch,
+        record_storage: false,
+    };
+    match runtime.apply_transactions(
+        shard_id,
+        storage_config,
+        block_context.height,
+        block_context.block_timestamp,
+        &block_context.prev_block_hash,
+        &block_context.block_hash,
+        &receipts,
+        chunk.transactions(),
+        chunk_inner.prev_validator_proposals(),
+        block_context.gas_price,
+        gas_limit,
+        &block_context.challenges_result,
+        block_context.random_seed,
+        true,
+        block_context.is_first_block_with_chunk_of_version,
+    ) {
+        Ok(apply_result) => {
+            let apply_split_result_or_state_changes = if shard_info.will_shard_layout_change {
+                Some(apply_split_state_changes(
+                    epoch_manager.as_ref(),
+                    runtime.as_ref(),
+                    block_context,
+                    &apply_result,
+                    split_state_roots,
+                )?)
+            } else {
+                None
+            };
+            Ok(ApplyChunkResult::SameHeight(SameHeightResult {
+                gas_limit,
+                shard_uid: shard_info.shard_uid,
+                apply_result,
+                apply_split_result_or_state_changes,
+            }))
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// Returns the apply chunk job when applying an old chunk and applying transactions.
+fn apply_old_chunk(
+    parent_span: &tracing::Span,
+    block_context: BlockContext,
+    prev_chunk_extra: &ChunkExtra,
+    shard_info: ShardInfo,
+    state_patch: SandboxStatePatch,
+    runtime: Arc<dyn RuntimeAdapter>,
+    epoch_manager: Arc<dyn EpochManagerAdapter>,
+    split_state_roots: Option<HashMap<ShardUId, CryptoHash>>,
+) -> Result<ApplyChunkResult, Error> {
+    let shard_id = shard_info.shard_uid.shard_id();
+    let _span = tracing::debug_span!(
+            target: "chain",
+            parent: parent_span,
+            "existing_chunk",
+            shard_id)
+    .entered();
+
+    let storage_config = RuntimeStorageConfig {
+        state_root: *prev_chunk_extra.state_root(),
+        use_flat_storage: true,
+        source: crate::types::StorageDataSource::Db,
+        state_patch,
+        record_storage: false,
+    };
+    match runtime.apply_transactions(
+        shard_id,
+        storage_config,
+        block_context.height,
+        block_context.block_timestamp,
+        &block_context.prev_block_hash,
+        &block_context.block_hash,
+        &[],
+        &[],
+        prev_chunk_extra.validator_proposals(),
+        block_context.gas_price,
+        prev_chunk_extra.gas_limit(),
+        &block_context.challenges_result,
+        block_context.random_seed,
+        false,
+        false,
+    ) {
+        Ok(apply_result) => {
+            let apply_split_result_or_state_changes = if shard_info.will_shard_layout_change {
+                Some(apply_split_state_changes(
+                    epoch_manager.as_ref(),
+                    runtime.as_ref(),
+                    block_context,
+                    &apply_result,
+                    split_state_roots,
+                )?)
+            } else {
+                None
+            };
+            Ok(ApplyChunkResult::DifferentHeight(DifferentHeightResult {
+                shard_uid: shard_info.shard_uid,
+                apply_result,
+                apply_split_result_or_state_changes,
+            }))
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// Returns the apply chunk job when just splitting state but not applying transactions.
+fn apply_state_split(
+    parent_span: &tracing::Span,
+    block_context: BlockContext,
+    shard_uid: ShardUId,
+    runtime: Arc<dyn RuntimeAdapter>,
+    epoch_manager: Arc<dyn EpochManagerAdapter>,
+    split_state_roots: HashMap<ShardUId, CryptoHash>,
+    state_changes: StateChangesForSplitStates,
+) -> Result<ApplyChunkResult, Error> {
+    let shard_id = shard_uid.shard_id();
+    let _span = tracing::debug_span!(
+        target: "chain",
+        parent: parent_span,
+        "split_state",
+        shard_id,
+        ?shard_uid)
+    .entered();
+    let next_epoch_id = epoch_manager.get_next_epoch_id(&block_context.block_hash)?;
+    let next_epoch_shard_layout = epoch_manager.get_shard_layout(&next_epoch_id)?;
+    let results = runtime.apply_update_to_split_states(
+        &block_context.block_hash,
+        block_context.height,
+        split_state_roots,
+        &next_epoch_shard_layout,
+        state_changes,
+    )?;
+    Ok(ApplyChunkResult::SplitState(SplitStateResult { shard_uid, results }))
+}
+
+/// Process ApplyTransactionResult to apply changes to split states
+/// When shards will change next epoch,
+///    if `split_state_roots` is not None, that means states for the split shards are ready
+///    this function updates these states and return apply results for these states
+///    otherwise, this function returns state changes needed to be applied to split
+///    states. These state changes will be stored in the database by `process_split_state`
+fn apply_split_state_changes(
+    epoch_manager: &dyn EpochManagerAdapter,
+    runtime_adapter: &dyn RuntimeAdapter,
+    block_context: BlockContext,
+    apply_result: &ApplyTransactionResult,
+    split_state_roots: Option<HashMap<ShardUId, StateRoot>>,
+) -> Result<ApplySplitStateResultOrStateChanges, Error> {
+    let state_changes = StateChangesForSplitStates::from_raw_state_changes(
+        apply_result.trie_changes.state_changes(),
+        apply_result.processed_delayed_receipts.clone(),
+    );
+    let next_epoch_shard_layout = {
+        let next_epoch_id =
+            epoch_manager.get_next_epoch_id_from_prev_block(&block_context.prev_block_hash)?;
+        epoch_manager.get_shard_layout(&next_epoch_id)?
+    };
+    // split states are ready, apply update to them now
+    if let Some(state_roots) = split_state_roots {
+        let split_state_results = runtime_adapter.apply_update_to_split_states(
+            &block_context.block_hash,
+            block_context.height,
+            state_roots,
+            &next_epoch_shard_layout,
+            state_changes,
+        )?;
+        Ok(ApplySplitStateResultOrStateChanges::ApplySplitStateResults(split_state_results))
+    } else {
+        // split states are not ready yet, store state changes in consolidated_state_changes
+        Ok(ApplySplitStateResultOrStateChanges::StateChangesForSplitStates(state_changes))
+    }
+}

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -62,7 +62,7 @@ pub(crate) struct StateSplitResult {
 }
 
 #[derive(Debug)]
-pub enum ApplyChunkResult {
+pub(crate) enum ApplyChunkResult {
     NewChunk(NewChunkResult),
     OldChunk(OldChunkResult),
     StateSplit(StateSplitResult),


### PR DESCRIPTION
This is just a refactor, which shouldn't change any behaviour of the code but prepares it for stateless validation.

We came up with idea that logic contained in `get_apply_chunk_job_*` method should not depend on Chain that heavily. Here I extract all logic where Chain is required to `get_apply_chunk_job` only. All remaining logic is moved to `update_shard.rs`. For better readability, I introduce more updates:
* "apply_chunk" is mostly replaced with "update_shard" because it is closer to what actually happens. When new chunk exists, we indeed apply it. But in two other cases listed in `ShardUpdateReason` enum we only update validator accounts or process split state info.
* excessive info about blocks and chunks is replaced with exact `BlockContext` and `ShardUpdateReason` contents which are specific for all shard updates. Now it should be much more clear which data is necessary. Note that receipts are passed only when new chunk appears.

chain.rs size is reduced by 250 lines which is good I think.

In the follow-up PRs you can see more refactoring (but less invasive) and introducing of "shadow" jobs for stateless validation on nightly, which will in fact call `apply_old_chunk` N times and then `apply_new_chunk` 1 time. It was impossible to do using previous API.

Nayduck https://nayduck.near.org/#/run/3276