### PR TITLE
toolchain: 1.73.0 -> 1.74.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,18 @@ members = [
     "utils/stdx",
 ]
 
+[workspace.lints.rust]
+warnings = "deny"
+
+[workspace.lints.clippy]
+all = { level = "allow", priority = -1 }
+clone_on_copy = "deny"
+correctness = "deny"
+derivable_impls = "deny"
+redundant_clone = "deny"
+suspicious = "deny"
+len_zero = "deny"
+
 [workspace.dependencies]
 actix = "0.13.0"
 actix-cors = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 version = "0.0.0" # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
-rust-version = "1.73.0"
+rust-version = "1.74.0"
 repository = "https://github.com/near/nearcore"
 license = "MIT OR Apache-2.0"
 

--- a/chain/chain-primitives/Cargo.toml
+++ b/chain/chain-primitives/Cargo.toml
@@ -9,7 +9,8 @@ repository.workspace = true
 license.workspace = true
 publish = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]
 chrono.workspace = true

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -5,6 +5,9 @@ authors.workspace = true
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix.workspace = true
 ansi_term.workspace = true

--- a/chain/chunks-primitives/Cargo.toml
+++ b/chain/chunks-primitives/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 license.workspace = true
 publish = true
 
+[lints]
+workspace = true
+
 [dependencies]
 near-chain-primitives.workspace = true
 near-primitives.workspace = true

--- a/chain/chunks/Cargo.toml
+++ b/chain/chunks/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix.workspace = true
 borsh.workspace = true

--- a/chain/client-primitives/Cargo.toml
+++ b/chain/client-primitives/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 license.workspace = true
 publish = true
 
+[lints]
+workspace = true
+
 [dependencies]
 actix.workspace = true
 ansi_term.workspace = true

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix-rt.workspace = true
 actix.workspace = true

--- a/chain/epoch-manager/Cargo.toml
+++ b/chain/epoch-manager/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 borsh.workspace = true
 chrono = { workspace = true, optional = true }

--- a/chain/indexer-primitives/Cargo.toml
+++ b/chain/indexer-primitives/Cargo.toml
@@ -9,7 +9,8 @@ repository.workspace = true
 license.workspace = true
 publish = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]
 serde.workspace = true

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix.workspace = true
 anyhow.workspace = true

--- a/chain/jsonrpc-adversarial-primitives/Cargo.toml
+++ b/chain/jsonrpc-adversarial-primitives/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 serde.workspace = true
 

--- a/chain/jsonrpc-primitives/Cargo.toml
+++ b/chain/jsonrpc-primitives/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 license.workspace = true
 publish = true
 
+[lints]
+workspace = true
+
 [dependencies]
 arbitrary.workspace = true
 serde.workspace = true

--- a/chain/jsonrpc/Cargo.toml
+++ b/chain/jsonrpc/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix-cors.workspace = true
 actix-web.workspace = true

--- a/chain/jsonrpc/client/Cargo.toml
+++ b/chain/jsonrpc/client/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix-http.workspace = true
 awc.workspace = true

--- a/chain/jsonrpc/fuzz/Cargo.toml
+++ b/chain/jsonrpc/fuzz/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [package.metadata]
 cargo-fuzz = true
 

--- a/chain/jsonrpc/jsonrpc-tests/Cargo.toml
+++ b/chain/jsonrpc/jsonrpc-tests/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix.workspace = true
 awc.workspace = true

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [build-dependencies]
 anyhow.workspace = true
 protobuf-codegen.workspace = true

--- a/chain/pool/Cargo.toml
+++ b/chain/pool/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 borsh.workspace = true
 once_cell.workspace = true

--- a/chain/rosetta-rpc/Cargo.toml
+++ b/chain/rosetta-rpc/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix-cors.workspace = true
 actix-http.workspace = true

--- a/chain/telemetry/Cargo.toml
+++ b/chain/telemetry/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix.workspace = true
 awc.workspace = true

--- a/core/async/Cargo.toml
+++ b/core/async/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix.workspace = true
 derive-enum-from-into.workspace = true

--- a/core/chain-configs/Cargo.toml
+++ b/core/chain-configs/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 license.workspace = true
 publish = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 bytesize.workspace = true

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 license.workspace = true
 publish = true
 
+[lints]
+workspace = true
+
 [dependencies]
 blake2.workspace = true
 borsh.workspace = true

--- a/core/dyn-configs/Cargo.toml
+++ b/core/dyn-configs/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 license.workspace = true
 publish = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 once_cell.workspace = true

--- a/core/o11y/Cargo.toml
+++ b/core/o11y/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 license.workspace = true
 publish = true
 
+[lints]
+workspace = true
+
 [dependencies]
 near-crypto.workspace = true
 near-fmt.workspace = true

--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 license.workspace = true
 publish = true
 
+[lints]
+workspace = true
+
 [dependencies]
 arbitrary.workspace = true
 base64.workspace = true

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 license.workspace = true
 publish = true
 
+[lints]
+workspace = true
+
 [dependencies]
 arbitrary.workspace = true
 base64.workspace = true

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix-rt.workspace = true
 actix.workspace = true

--- a/genesis-tools/genesis-csv-to-json/Cargo.toml
+++ b/genesis-tools/genesis-csv-to-json/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 chrono.workspace = true
 clap.workspace = true

--- a/genesis-tools/genesis-populate/Cargo.toml
+++ b/genesis-tools/genesis-populate/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 borsh.workspace = true
 clap.workspace = true

--- a/genesis-tools/keypair-generator/Cargo.toml
+++ b/genesis-tools/keypair-generator/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 clap.workspace = true
 

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix-rt.workspace = true
 actix.workspace = true

--- a/integration-tests/src/tests/client/sync_state_nodes.rs
+++ b/integration-tests/src/tests/client/sync_state_nodes.rs
@@ -413,6 +413,9 @@ fn sync_empty_state() {
 
 #[test]
 #[cfg_attr(not(feature = "expensive_tests"), ignore)]
+// FIXME(#9650): locks should not be held across await points, allowed currently only because the
+// lint started triggering during a toolchain bump.
+#[allow(clippy::await_holding_lock)]
 /// Runs one node for some time, which dumps state to a temp directory.
 /// Start the second node which gets state parts from that temp directory.
 fn sync_state_dump() {

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix-rt.workspace = true
 actix-web.workspace = true

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [[bin]]
 path = "src/main.rs"
 name = "neard"

--- a/pytest/tests/loadtest/contract/Cargo.toml
+++ b/pytest/tests/loadtest/contract/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Near Inc <hello@near.org>"]
 edition = "2018"
 
+[lints]
+workspace = true
+
 [workspace]
 members = []
 

--- a/runtime/near-test-contracts/Cargo.toml
+++ b/runtime/near-test-contracts/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 once_cell.workspace = true
 wat.workspace = true

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -10,6 +10,9 @@ license.workspace = true
 categories = ["wasm"]
 publish = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true, optional = true }
 base64.workspace = true

--- a/runtime/near-vm-runner/fuzz/Cargo.toml
+++ b/runtime/near-vm-runner/fuzz/Cargo.toml
@@ -11,6 +11,9 @@ publish = false
 [package.metadata]
 cargo-fuzz = true
 
+[lints]
+workspace = true
+
 [dependencies]
 arbitrary.workspace = true
 libfuzzer-sys.workspace = true

--- a/runtime/near-vm/compiler-singlepass/Cargo.toml
+++ b/runtime/near-vm/compiler-singlepass/Cargo.toml
@@ -12,6 +12,9 @@ edition = "2021"
 publish = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 finite-wasm.workspace = true
 near-vm-compiler.workspace = true

--- a/runtime/near-vm/compiler-test-derive/Cargo.toml
+++ b/runtime/near-vm/compiler-test-derive/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["unsafe", "body", "fn", "safety", "hygiene"]
 categories = ["rust-patterns"]
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 proc-macro2.workspace = true
 quote.workspace = true

--- a/runtime/near-vm/compiler/Cargo.toml
+++ b/runtime/near-vm/compiler/Cargo.toml
@@ -12,6 +12,9 @@ edition = "2021"
 publish = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 finite-wasm.workspace = true
 near-vm-vm.workspace = true

--- a/runtime/near-vm/engine/Cargo.toml
+++ b/runtime/near-vm/engine/Cargo.toml
@@ -12,6 +12,9 @@ edition = "2021"
 publish = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 backtrace.workspace = true
 enumset.workspace = true

--- a/runtime/near-vm/test-api/Cargo.toml
+++ b/runtime/near-vm/test-api/Cargo.toml
@@ -12,6 +12,9 @@ edition = "2021"
 publish = false
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 # Shared dependencies.
 [dependencies]
 # - Mandatory shared dependencies.

--- a/runtime/near-vm/test-generator/Cargo.toml
+++ b/runtime/near-vm/test-generator/Cargo.toml
@@ -6,6 +6,9 @@ authors = ["Wasmer Engineering Team <engineering@wasmer.io>", "Near Inc <hello@n
 publish = false
 license = "Apache-2.0 WITH LLVM-exception"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 target-lexicon.workspace = true

--- a/runtime/near-vm/types/Cargo.toml
+++ b/runtime/near-vm/types/Cargo.toml
@@ -12,6 +12,9 @@ edition = "2021"
 publish = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 thiserror.workspace = true
 indexmap.workspace = true

--- a/runtime/near-vm/vm/Cargo.toml
+++ b/runtime/near-vm/vm/Cargo.toml
@@ -12,6 +12,9 @@ edition = "2021"
 publish = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 backtrace.workspace = true
 cfg-if.workspace = true

--- a/runtime/near-vm/wast/Cargo.toml
+++ b/runtime/near-vm/wast/Cargo.toml
@@ -11,6 +11,9 @@ readme = "README.md"
 edition = "2021"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 near-vm-test-api.workspace = true

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "runtime-params-estimator"
 required-features = ["costs_counting"]

--- a/runtime/runtime-params-estimator/emu-cost/Dockerfile
+++ b/runtime/runtime-params-estimator/emu-cost/Dockerfile
@@ -1,5 +1,5 @@
 # our local base image
-FROM rust:1.73.0
+FROM rust:1.74.0
 
 LABEL description="Container for builds"
 

--- a/runtime/runtime-params-estimator/estimator-warehouse/Cargo.toml
+++ b/runtime/runtime-params-estimator/estimator-warehouse/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 borsh.workspace = true
 hex.workspace = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,6 +2,6 @@
 # This specifies the version of Rust we use to build.
 # Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
 # The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
-channel = "1.73.0"
+channel = "1.74.0"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]

--- a/test-utils/actix-test-utils/Cargo.toml
+++ b/test-utils/actix-test-utils/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix-rt.workspace = true
 futures.workspace = true

--- a/test-utils/runtime-tester/Cargo.toml
+++ b/test-utils/runtime-tester/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 bolero.workspace = true
 cpu-time.workspace = true

--- a/test-utils/runtime-tester/fuzz/Cargo.toml
+++ b/test-utils/runtime-tester/fuzz/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [package.metadata]
 cargo-fuzz = true
 

--- a/test-utils/store-validator/Cargo.toml
+++ b/test-utils/store-validator/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 ansi_term.workspace = true
 clap.workspace = true

--- a/test-utils/style/Cargo.toml
+++ b/test-utils/style/Cargo.toml
@@ -6,4 +6,7 @@ publish = false
 description = "An entry point for miscelaneous (stylistic) workspace-wide tests"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 
+[lints]
+workspace = true
+
 [dependencies]

--- a/test-utils/style/src/lib.rs
+++ b/test-utils/style/src/lib.rs
@@ -50,17 +50,7 @@ fn clippy() {
     let cargo = std::env::var_os("CARGO").unwrap_or(OsString::from("cargo"));
     let mut cmd = Command::new(cargo);
     cargo_env(&mut cmd);
-    cmd.args(&["clippy", "--all-targets", "--all-features", "--locked", "--"]);
-    cmd.args(&[
-        "-Aclippy::all",
-        "-Dwarnings",
-        "-Dclippy::clone_on_copy",
-        "-Dclippy::correctness",
-        "-Dclippy::derivable_impls",
-        "-Dclippy::redundant_clone",
-        "-Dclippy::suspicious",
-        "-Dclippy::len_zero",
-    ]);
+    cmd.args(&["clippy", "--all-targets", "--all-features", "--locked"]);
     ensure_success(cmd);
 }
 

--- a/test-utils/testlib/Cargo.toml
+++ b/test-utils/testlib/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 once_cell.workspace = true
 

--- a/tools/amend-genesis/Cargo.toml
+++ b/tools/amend-genesis/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 borsh.workspace = true

--- a/tools/chainsync-loadtest/Cargo.toml
+++ b/tools/chainsync-loadtest/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [[bin]]
 path = "src/main.rs"
 name = "chainsync-loadtest"

--- a/tools/cold-store/Cargo.toml
+++ b/tools/cold-store/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 borsh.workspace = true

--- a/tools/database/Cargo.toml
+++ b/tools/database/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 borsh.workspace = true

--- a/tools/flat-storage/Cargo.toml
+++ b/tools/flat-storage/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 borsh.workspace = true

--- a/tools/fork-network/Cargo.toml
+++ b/tools/fork-network/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix.workspace = true
 anyhow.workspace = true

--- a/tools/indexer/example/Cargo.toml
+++ b/tools/indexer/example/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix.workspace = true
 anyhow.workspace = true

--- a/tools/mirror/Cargo.toml
+++ b/tools/mirror/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix.workspace = true
 anyhow.workspace = true

--- a/tools/mock-node/Cargo.toml
+++ b/tools/mock-node/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix-rt.workspace = true
 actix.workspace = true

--- a/tools/ping/Cargo.toml
+++ b/tools/ping/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix-web.workspace = true
 anyhow.workspace = true

--- a/tools/restaked/Cargo.toml
+++ b/tools/restaked/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 clap.workspace = true
 tokio.workspace = true

--- a/tools/rpctypegen/core/Cargo.toml
+++ b/tools/rpctypegen/core/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 license.workspace = true
 publish = true
 
+[lints]
+workspace = true
+
 [dependencies]
 quote.workspace = true
 serde.workspace = true

--- a/tools/rpctypegen/macro/Cargo.toml
+++ b/tools/rpctypegen/macro/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 license.workspace = true
 publish = true
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/tools/speedy_sync/Cargo.toml
+++ b/tools/speedy_sync/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 near-store.workspace = true
 near-chain-primitives.workspace = true

--- a/tools/state-parts-dump-check/Cargo.toml
+++ b/tools/state-parts-dump-check/Cargo.toml
@@ -8,7 +8,8 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]
 actix-web.workspace = true

--- a/tools/state-parts/Cargo.toml
+++ b/tools/state-parts/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true

--- a/tools/state-viewer/Cargo.toml
+++ b/tools/state-viewer/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix.workspace = true
 ansi_term.workspace = true

--- a/tools/storage-usage-delta-calculator/Cargo.toml
+++ b/tools/storage-usage-delta-calculator/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 serde_json.workspace = true

--- a/tools/themis/Cargo.toml
+++ b/tools/themis/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 toml.workspace = true
 serde.workspace = true

--- a/tools/themis/src/main.rs
+++ b/tools/themis/src/main.rs
@@ -12,6 +12,7 @@ fn main() -> anyhow::Result<()> {
         rules::is_unversioned,
         rules::has_publish_spec,
         rules::has_rust_version,
+        rules::has_lint_inheritance,
         rules::rust_version_matches_toolchain,
         rules::has_unified_rust_edition,
         rules::author_is_near,

--- a/tools/undo-block/Cargo.toml
+++ b/tools/undo-block/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true

--- a/utils/config/Cargo.toml
+++ b/utils/config/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 license.workspace = true
 publish = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 json_comments.workspace = true

--- a/utils/fmt/Cargo.toml
+++ b/utils/fmt/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 license.workspace = true
 publish = true
 
+[lints]
+workspace = true
+
 [dependencies]
 near-primitives-core.workspace = true
 

--- a/utils/mainnet-res/Cargo.toml
+++ b/utils/mainnet-res/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 serde_json.workspace = true
 

--- a/utils/near-cache/Cargo.toml
+++ b/utils/near-cache/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 license.workspace = true
 publish = true
 
+[lints]
+workspace = true
+
 [dependencies]
 lru.workspace = true
 

--- a/utils/near-performance-metrics-macros/Cargo.toml
+++ b/utils/near-performance-metrics-macros/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 quote.workspace = true
 syn.workspace = true

--- a/utils/near-performance-metrics/Cargo.toml
+++ b/utils/near-performance-metrics/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 actix.workspace = true
 bitflags.workspace = true

--- a/utils/near-stable-hasher/Cargo.toml
+++ b/utils/near-stable-hasher/Cargo.toml
@@ -8,3 +8,6 @@ description = "`near-stable-hasher` is a library that is essentially a wrapper a
 repository.workspace = true
 license.workspace = true
 publish = true
+
+[lints]
+workspace = true

--- a/utils/stdx/Cargo.toml
+++ b/utils/stdx/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 license.workspace = true
 publish = true
 
+[lints]
+workspace = true
+
 [dependencies]
 # Absolutely must not depend on any crates from nearcore workspace,
 # and should have as few dependencies as possible otherwise.


### PR DESCRIPTION
I think discussion is warranted on whether we want to use the lint inheritance. The previous way was definitely quite a bit more terse, but it was also much less composable (e.g. it was less straightforward to exclude or include a specific crate from a specific lint)