### PR TITLE
Add test_long_chain_with_restart_from_snapshot

### DIFF
--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -3431,29 +3431,46 @@ fn test_catchup_no_sharding_change() {
     }
 }
 
-/// To optimise this test, set `epoch_length` to 5 and enable `no_cache` feature.
+/// Run `gc_num_epochs_to_keep` epochs + several blocks.
+/// Start a second env from the "snapshot" of the first.
+/// Run one more epoch.
+/// "Restart from the snapshot" is to ensure that we can continue producing blocks without relying on caches.
 #[test]
-fn test_long_chain() {
+fn test_long_chain_with_restart_from_snapshot() {
     init_test_logger();
 
-    let epoch_length = 1000;
+    let epoch_length = 25;
 
-    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
 
     genesis.config.epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
-    let mut env = TestEnv::builder(chain_genesis)
+    let mut env1 = TestEnv::builder(chain_genesis.clone())
         .real_epoch_managers(&genesis.config)
         .nightshade_runtimes(&genesis)
         .archive(false)
         .build();
 
-    let max_height = epoch_length * 2 * env.clients[0].config.gc.gc_num_epochs_to_keep;
+    env1.clients[0].config.gc.gc_blocks_limit = 2;
+
+    let max_height = epoch_length * env1.clients[0].config.gc.gc_num_epochs_to_keep + 3;
 
     for h in 1..max_height {
-        let block = env.clients[0].produce_block(h).unwrap().unwrap();
-        env.process_block(0, block.clone(), Provenance::PRODUCED);
+        let block = env1.clients[0].produce_block(h).unwrap().unwrap();
+        env1.process_block(0, block.clone(), Provenance::PRODUCED);
+    }
+
+    let mut env2 = TestEnv::builder(chain_genesis)
+        .stores(vec![env1.clients[0].chain.store().store().clone()])
+        .real_epoch_managers(&genesis.config)
+        .nightshade_runtimes(&genesis)
+        .archive(false)
+        .build();
+
+    for h in max_height..(max_height + epoch_length) {
+        let block = env2.clients[0].produce_block(h).unwrap().unwrap();
+        env2.process_block(0, block.clone(), Provenance::PRODUCED);
     }
 }
 

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -3452,6 +3452,11 @@ fn test_long_chain_with_restart_from_snapshot() {
         .archive(false)
         .build();
 
+    // In TestEnv `gc_blocks_limit` defaults to 100.
+    // That means that whole epoch will be garbage collected in one block.
+    // We want this test to have "more realistic" snapshot setup, where last kept epoch is only partially garbage collected.
+    //
+    // `gc_blocks_limit = 2` is the default setup in production.
     env1.clients[0].config.gc.gc_blocks_limit = 2;
 
     let max_height = epoch_length * env1.clients[0].config.gc.gc_num_epochs_to_keep + 3;


### PR DESCRIPTION
The main motivation for the test is to see how garbage collection will behave without caches if we restart from the middle of an epoch.