### PR TITLE
[garbage_colection] Fix crash in clear_resharding_data while fetching prev_epoch_id

### DIFF
--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -615,13 +615,6 @@ impl EpochManagerAdapter for MockEpochManager {
         }
     }
 
-    fn get_prev_epoch_id(&self, block_hash: &CryptoHash) -> Result<EpochId, EpochError> {
-        let header = self
-            .get_block_header(block_hash)?
-            .ok_or_else(|| EpochError::MissingBlock(*block_hash))?;
-        self.get_prev_epoch_id_from_prev_block(header.prev_hash())
-    }
-
     fn get_prev_epoch_id_from_prev_block(
         &self,
         prev_block_hash: &CryptoHash,

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -128,8 +128,6 @@ pub trait EpochManagerAdapter: Send + Sync {
     /// Get epoch start from a block belonging to the epoch.
     fn get_epoch_start_height(&self, block_hash: &CryptoHash) -> Result<BlockHeight, EpochError>;
 
-    fn get_prev_epoch_id(&self, block_hash: &CryptoHash) -> Result<EpochId, EpochError>;
-
     /// Get previous epoch id by hash of previous block.
     fn get_prev_epoch_id_from_prev_block(
         &self,
@@ -559,11 +557,6 @@ impl EpochManagerAdapter for EpochManagerHandle {
     fn get_epoch_start_height(&self, block_hash: &CryptoHash) -> Result<BlockHeight, EpochError> {
         let epoch_manager = self.read();
         epoch_manager.get_epoch_start_height(block_hash)
-    }
-
-    fn get_prev_epoch_id(&self, block_hash: &CryptoHash) -> Result<EpochId, EpochError> {
-        let epoch_manager = self.read();
-        epoch_manager.get_prev_epoch_id(block_hash)
     }
 
     fn get_prev_epoch_id_from_prev_block(


### PR DESCRIPTION
We had an issue in the `clear_resharding_data` while fetching the `prev_epoch_id`. The implementation of `prev_epoch_id` relied on fetching the block_info of the last block of prev_epoch to get the epoch_id. This unfortunately failed for the case of GC as the block_info was already garbage collected.

The new implementation here relies on using the block_header to get the epoch_id instead of block_info.

This was unfortunately only caught in mocknet and not integration tests as having a small enough epoch_length lead to the block_info being cached in the epoch_manager (even though it was GC'd)

Zulip post: https://near.zulipchat.com/#narrow/stream/295558-pagoda.2Fcore/topic/Master.20binary.20Can't.20clear.20old.20data/near/402240517