### PR TITLE
[cleanup] Minor cleanup in serde default

### DIFF
--- a/chain/network/src/config_json.rs
+++ b/chain/network/src/config_json.rs
@@ -60,11 +60,6 @@ fn default_peer_expiration_duration() -> Duration {
     Duration::from_secs(7 * 24 * 60 * 60)
 }
 
-/// If non-zero - we'll skip sending tombstones during initial sync and for that many seconds after start.
-fn default_skip_tombstones() -> i64 {
-    0
-}
-
 /// This is a list of public STUN servers provided by Google,
 /// which are known to have good availability. To avoid trusting
 /// a centralized entity (and DNS used for domain resolution),
@@ -201,28 +196,11 @@ pub struct Config {
     pub experimental: ExperimentalConfig,
 }
 
-fn default_tier1_enable_inbound() -> bool {
-    true
-}
-fn default_tier1_enable_outbound() -> bool {
-    true
-}
-
-fn default_tier1_connect_interval() -> Duration {
-    Duration::from_secs(60)
-}
-
-fn default_tier1_new_connections_per_attempt() -> u64 {
-    50
-}
-
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct ExperimentalConfig {
     // If true - don't allow any inbound connections.
-    #[serde(default)]
     pub inbound_disabled: bool,
     // If true - connect only to the boot nodes.
-    #[serde(default)]
     pub connect_only_to_boot_nodes: bool,
 
     // If greater than 0, then system will no longer send or receive tombstones
@@ -230,28 +208,22 @@ pub struct ExperimentalConfig {
     //
     // The better name is `skip_tombstones_seconds`, but we keep send for
     // compatibility.
-    #[serde(default = "default_skip_tombstones")]
     pub skip_sending_tombstones_seconds: i64,
 
     /// See `near_network::config::Tier1::enable_inbound`.
-    #[serde(default = "default_tier1_enable_inbound")]
     pub tier1_enable_inbound: bool,
 
     /// See `near_network::config::Tier1::enable_outbound`.
-    #[serde(default = "default_tier1_enable_outbound")]
     pub tier1_enable_outbound: bool,
 
     /// See `near_network::config::Tier1::connect_interval`.
-    #[serde(default = "default_tier1_connect_interval")]
     pub tier1_connect_interval: Duration,
 
     /// See `near_network::config::Tier1::new_connections_per_attempt`.
-    #[serde(default = "default_tier1_new_connections_per_attempt")]
     pub tier1_new_connections_per_attempt: u64,
 
     /// See `NetworkConfig`.
     /// Fields set here will override the NetworkConfig fields.
-    #[serde(default)]
     pub network_config_overrides: NetworkConfigOverrides,
 }
 
@@ -277,11 +249,11 @@ impl Default for ExperimentalConfig {
         ExperimentalConfig {
             inbound_disabled: false,
             connect_only_to_boot_nodes: false,
-            skip_sending_tombstones_seconds: default_skip_tombstones(),
-            tier1_enable_inbound: default_tier1_enable_inbound(),
-            tier1_enable_outbound: default_tier1_enable_outbound(),
-            tier1_connect_interval: default_tier1_connect_interval(),
-            tier1_new_connections_per_attempt: default_tier1_new_connections_per_attempt(),
+            skip_sending_tombstones_seconds: 0,
+            tier1_enable_inbound: true,
+            tier1_enable_outbound: true,
+            tier1_connect_interval: Duration::from_secs(60),
+            tier1_new_connections_per_attempt: 50,
             network_config_overrides: Default::default(),
         }
     }

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -30,19 +30,17 @@ pub const DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_ON_CATCHUP_EXTERNAL: u32 = 
 
 /// Configuration for garbage collection.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
+#[serde(default)]
 pub struct GCConfig {
     /// Maximum number of blocks to garbage collect at every garbage collection
     /// call.
-    #[serde(default = "default_gc_blocks_limit")]
     pub gc_blocks_limit: NumBlocks,
 
     /// Maximum number of height to go through at each garbage collection step
     /// when cleaning forks during garbage collection.
-    #[serde(default = "default_gc_fork_clean_step")]
     pub gc_fork_clean_step: u64,
 
     /// Number of epochs for which we keep store data.
-    #[serde(default = "default_gc_num_epochs_to_keep")]
     pub gc_num_epochs_to_keep: u64,
 }
 
@@ -54,18 +52,6 @@ impl Default for GCConfig {
             gc_num_epochs_to_keep: DEFAULT_GC_NUM_EPOCHS_TO_KEEP,
         }
     }
-}
-
-fn default_gc_blocks_limit() -> NumBlocks {
-    GCConfig::default().gc_blocks_limit
-}
-
-fn default_gc_fork_clean_step() -> u64 {
-    GCConfig::default().gc_fork_clean_step
-}
-
-fn default_gc_num_epochs_to_keep() -> u64 {
-    GCConfig::default().gc_num_epochs_to_keep()
 }
 
 impl GCConfig {

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -302,19 +302,15 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub save_trie_changes: Option<bool>,
     pub log_summary_style: LogSummaryStyle,
-    #[serde(default = "default_log_summary_period")]
     pub log_summary_period: Duration,
     // Allows more detailed logging, for example a list of orphaned blocks.
     pub enable_multiline_logging: Option<bool>,
     /// Garbage collection configuration.
-    #[serde(default, flatten)]
+    #[serde(flatten)]
     pub gc: GCConfig,
-    #[serde(default = "default_view_client_threads")]
     pub view_client_threads: usize,
     pub epoch_sync_enabled: bool,
-    #[serde(default = "default_view_client_throttle_period")]
     pub view_client_throttle_period: Duration,
-    #[serde(default = "default_trie_viewer_state_size_limit")]
     pub trie_viewer_state_size_limit: Option<u64>,
     /// If set, overrides value in genesis configuration.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -323,14 +319,14 @@ pub struct Config {
     pub store: near_store::StoreConfig,
     /// Different parameters to configure underlying cold storage.
     /// This feature is under development, do not use in production.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cold_store: Option<near_store::StoreConfig>,
     /// Configuration for the split storage.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub split_storage: Option<SplitStorageConfig>,
     /// The node will stop after the head exceeds this height.
     /// The node usually stops within several seconds after reaching the target height.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub expected_shutdown: Option<BlockHeight>,
     /// Whether to use state sync (unreliable and corrupts the DB if fails) or do a block sync instead.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -344,7 +340,6 @@ pub struct Config {
     /// guarantees that the node will use bounded resources to store incoming transactions.
     /// Setting this value too low (<1MB) on the validator might lead to production of smaller
     /// chunks and underutilizing the capacity of the network.
-    #[serde(default = "default_transaction_pool_size_limit")]
     pub transaction_pool_size_limit: Option<u64>,
     pub state_split_config: StateSplitConfig,
 }


### PR DESCRIPTION
Discovered simplified way to have default values in serde for structs only when ALL fields have a default.

We can have a #[serde(default)] attribute for the whole struct and any missing fields are picked up from the Default::default() implementation of the struct.

Playground example
```
#[derive(Serialize, Deserialize, Debug)]
#[serde(default)]
struct Point {
    x: i32,
    y: i32,
}

impl Default for Point {
    fn default() -> Self {
        Self { x: 1, y: 2 }
    }
}

#[test]
fn serde() {
    let point = Point { x: 10, y: 20 };
    let serialized = serde_json::to_string(&point).unwrap();
    println!("serialized = {}", serialized);
    let deserialized: Point = serde_json::from_str(&serialized).unwrap();
    println!("deserialized = {:?}", deserialized); // I get Point { x: 10, y: 20 }
    let serialized = "{\"x\":15}";
    let deserialized: Point = serde_json::from_str(&serialized).unwrap();
    println!("deserialized = {:?}", deserialized); // I get Point { x: 15, y: 2 }
}
```

Bit more context here: https://github.com/near/nearcore/pull/10202