### PR TITLE
Bump various dependency versions

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,30 @@
+[advisories]
+ignore = [
+    # DO NOT ADD ANYTHING TO THIS LIST WITHOUT CAREFUL CONSIDERATION!
+
+    # dotenv being unmaintained is ignored because it is an indirect dependency of cloud-storage, which would be hard to replace.
+    # In addition, it is most likely not ever going to be on a security-critical path, considering it only parses trusted .env files.
+    # However, we should probably replace cloud-storage with tame-gcs as soon as possible to remove this ignore.
+    "RUSTSEC-2021-0141",
+
+    # mach is unmaintained, but seems to be required by wasmtime at its latest version, which we currently cannot do without.
+    # We should replace it with mach2 in our personal code, but will need to keep it there until wasmtime switches to it.
+    # Anyway, it cannot be a security liability in production, considering it is bindings to the OS X kernel.
+    "RUSTSEC-2020-0168",
+
+    # memmap is unmaintained, but is used by wasmer0, which we need to keep alive for replayability reasons.
+    # We should remove wasmer0 and this ignore as soon as we get limited replayability.
+    "RUSTSEC-2020-0077",
+
+    # parity-wasm is deprecated, but is used by our runtimes before near-vm, which we need to keep alive for replayability reasons.
+    # We should remove them all, as well as this ignore, as soon as we get limited replayability.
+    "RUSTSEC-2022-0061",
+
+    # borsh is vulnerable, but is used by wasmer0, which we need to keep alive for replayability reasons.
+    # We should remove it, as well as this ignore, as soon as we get limited replayability.
+    "RUSTSEC-2023-0033",
+
+    # older versions of parking-lot are vulnerable, but used by wasmer0, which we need to keep alive for replayability reasons.
+    # We should remove it, as well as this ignore, as soon as we get limited replayability.
+    "RUSTSEC-2020-0070",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4828,6 +4828,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5056,6 +5066,12 @@ checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "page_size"
@@ -7401,6 +7417,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-opentelemetry"
 version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7410,7 +7437,7 @@ dependencies = [
  "opentelemetry",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.1.3",
  "tracing-subscriber",
 ]
 
@@ -7426,12 +7453,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.15"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
- "ansi_term",
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex",
  "sharded-slab",
@@ -7439,7 +7466,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,15 +340,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3477,7 +3468,6 @@ name = "near-chain"
 version = "0.0.0"
 dependencies = [
  "actix",
- "ansi_term",
  "assert_matches",
  "borsh 1.0.0",
  "bytesize",
@@ -3510,6 +3500,7 @@ dependencies = [
  "strum",
  "thiserror",
  "tracing",
+ "yansi",
 ]
 
 [[package]]
@@ -3592,7 +3583,6 @@ version = "0.0.0"
 dependencies = [
  "actix",
  "actix-rt",
- "ansi_term",
  "anyhow",
  "assert_matches",
  "async-trait",
@@ -3637,6 +3627,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "yansi",
 ]
 
 [[package]]
@@ -3644,7 +3635,6 @@ name = "near-client-primitives"
 version = "0.0.0"
 dependencies = [
  "actix",
- "ansi_term",
  "chrono",
  "near-chain-configs",
  "near-chain-primitives",
@@ -3655,6 +3645,7 @@ dependencies = [
  "serde_json",
  "strum",
  "thiserror",
+ "yansi",
 ]
 
 [[package]]
@@ -4699,7 +4690,6 @@ name = "neard"
 version = "0.0.0"
 dependencies = [
  "actix",
- "ansi_term",
  "anyhow",
  "clap 4.2.4",
  "cold-store-tool",
@@ -4739,6 +4729,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tracing",
+ "yansi",
 ]
 
 [[package]]
@@ -6736,7 +6727,6 @@ name = "state-viewer"
 version = "0.0.0"
 dependencies = [
  "actix",
- "ansi_term",
  "anyhow",
  "borsh 1.0.0",
  "bytesize",
@@ -6772,6 +6762,7 @@ dependencies = [
  "testlib",
  "thiserror",
  "tracing",
+ "yansi",
 ]
 
 [[package]]
@@ -6799,7 +6790,6 @@ dependencies = [
 name = "store-validator"
 version = "0.0.0"
 dependencies = [
- "ansi_term",
  "clap 4.2.4",
  "near-chain",
  "near-chain-configs",
@@ -6811,6 +6801,7 @@ dependencies = [
  "nearcore",
  "serde_json",
  "testlib",
+ "yansi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
- "ahash 0.8.3",
+ "ahash 0.8.6",
  "base64 0.21.0",
  "bitflags 1.3.2",
  "brotli",
@@ -290,14 +290,15 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if 1.0.0",
  "getrandom 0.2.9",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2470,7 +2471,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.6",
 ]
 
 [[package]]
@@ -2479,7 +2480,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.6",
  "allocator-api2",
 ]
 
@@ -8553,6 +8554,26 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,16 +1650,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
-dependencies = [
- "quote",
- "syn 1.0.103",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5059,15 +5049,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "output_vt100"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5384,14 +5365,12 @@ checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
 
 [[package]]
 name = "pretty_assertions"
-version = "1.2.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89f989ac94207d048d92db058e4f6ec7342b0971fc58d1271ca148b799b3563"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
 dependencies = [
- "ansi_term",
- "ctor",
  "diff",
- "output_vt100",
+ "yansi",
 ]
 
 [[package]]
@@ -8612,6 +8591,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,7 +1368,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli 0.28.0",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.2",
  "log",
  "regalloc2",
  "smallvec",
@@ -2469,11 +2475,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 dependencies = [
  "ahash 0.8.3",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -2751,7 +2758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.2",
  "serde",
 ]
 
@@ -4400,7 +4407,7 @@ version = "0.0.0"
 dependencies = [
  "enumset",
  "finite-wasm",
- "hashbrown 0.11.2",
+ "hashbrown 0.14.2",
  "near-vm-types",
  "near-vm-vm",
  "rkyv",
@@ -4419,7 +4426,7 @@ dependencies = [
  "dynasmrt 2.0.0",
  "enumset",
  "finite-wasm",
- "hashbrown 0.11.2",
+ "hashbrown 0.14.2",
  "lazy_static",
  "memoffset 0.8.0",
  "more-asserts",
@@ -4909,7 +4916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "crc32fast",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.2",
  "indexmap 2.0.0",
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,9 +2425,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.3.13"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
 dependencies = [
  "bytes",
  "fnv",
@@ -2435,7 +2435,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.2",
+ "indexmap 2.0.0",
  "slab",
  "tokio",
  "tokio-util 0.7.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8574,7 +8574,6 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e61de68ede9ffdd69c01664f65a178c5188b73f78faa21f0936016a888ff7c"
 dependencies = [
- "borsh 0.9.3",
  "byteorder",
  "crunchy",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,12 +2101,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
-dependencies = [
- "instant",
-]
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "finite-wasm"
@@ -2793,15 +2790,6 @@ dependencies = [
  "serde",
  "similar",
  "yaml-rust",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -5795,6 +5783,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5862,15 +5859,6 @@ dependencies = [
  "bitflags 1.3.2",
  "libc",
  "mach",
- "winapi",
-]
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
  "winapi",
 ]
 
@@ -6963,16 +6951,15 @@ checksum = "d7fa7e55043acb85fca6b3c01485a2eeb6b69c5d21002e273c79e465f43b7ac1"
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "libc",
- "redox_syscall 0.2.13",
- "remove_dir_all",
- "winapi",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.24",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2",
- "time 0.3.21",
+ "time",
  "url",
 ]
 
@@ -323,6 +323,12 @@ checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -554,7 +560,7 @@ dependencies = [
  "serde",
  "serde-xml-rs",
  "thiserror",
- "time 0.3.21",
+ "time",
  "url",
 ]
 
@@ -1093,18 +1099,17 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
  "serde",
- "time 0.1.44",
  "wasm-bindgen",
- "winapi",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -1287,7 +1292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05"
 dependencies = [
  "percent-encoding",
- "time 0.3.21",
+ "time",
  "version_check",
 ]
 
@@ -3464,7 +3469,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
- "time 0.3.21",
+ "time",
  "tokio",
 ]
 
@@ -3579,7 +3584,7 @@ dependencies = [
  "rand 0.8.5",
  "reed-solomon-erasure",
  "strum",
- "time 0.3.21",
+ "time",
  "tracing",
 ]
 
@@ -4051,7 +4056,7 @@ dependencies = [
  "stun",
  "tempfile",
  "thiserror",
- "time 0.3.21",
+ "time",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.2",
@@ -4183,7 +4188,7 @@ dependencies = [
  "smart-default",
  "strum",
  "thiserror",
- "time 0.3.21",
+ "time",
  "tracing",
 ]
 
@@ -6117,7 +6122,7 @@ dependencies = [
  "serde_derive",
  "sha2 0.10.6",
  "thiserror",
- "time 0.3.21",
+ "time",
  "tokio",
  "tokio-stream",
  "url",
@@ -6452,7 +6457,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.21",
+ "time",
 ]
 
 [[package]]
@@ -7067,17 +7072,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
@@ -7360,7 +7354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.21",
+ "time",
  "tracing-subscriber",
 ]
 
@@ -7667,12 +7661,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,12 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "cast"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
-dependencies = [
- "rustc_version 0.4.0",
-]
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -1070,7 +1073,7 @@ dependencies = [
  "actix",
  "anyhow",
  "async-trait",
- "clap 4.2.4",
+ "clap",
  "dirs",
  "futures",
  "log",
@@ -1104,6 +1107,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,17 +1151,6 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
-]
-
-[[package]]
-name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "bitflags 1.3.2",
- "textwrap",
- "unicode-width",
 ]
 
 [[package]]
@@ -1224,7 +1243,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
- "clap 4.2.4",
+ "clap",
  "near-chain-configs",
  "near-epoch-manager",
  "near-primitives",
@@ -1466,24 +1485,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.5"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
 dependencies = [
- "atty",
+ "anes",
  "cast",
- "clap 2.34.0",
+ "ciborium",
+ "clap",
  "criterion-plot",
- "csv",
+ "is-terminal",
  "itertools",
- "lazy_static",
  "num-traits",
+ "once_cell",
  "oorandom",
- "plotters",
- "rayon",
  "regex",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -1492,9 +1509,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
@@ -2046,7 +2063,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 4.2.4",
+ "clap",
  "insta",
  "nix 0.24.3",
  "reqwest",
@@ -2333,7 +2350,7 @@ name = "genesis-csv-to-json"
 version = "0.0.0"
 dependencies = [
  "chrono",
- "clap 4.2.4",
+ "clap",
  "csv",
  "near-chain-configs",
  "near-crypto",
@@ -2350,7 +2367,7 @@ name = "genesis-populate"
 version = "0.0.0"
 dependencies = [
  "borsh 1.0.0",
- "clap 4.2.4",
+ "clap",
  "indicatif",
  "near-chain",
  "near-chain-configs",
@@ -2718,7 +2735,7 @@ version = "0.0.0"
 dependencies = [
  "actix",
  "anyhow",
- "clap 4.2.4",
+ "clap",
  "near-indexer",
  "near-o11y",
  "openssl-probe",
@@ -2788,7 +2805,7 @@ dependencies = [
  "assert_matches",
  "borsh 1.0.0",
  "chrono",
- "clap 4.2.4",
+ "clap",
  "futures",
  "hex",
  "insta",
@@ -2926,7 +2943,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 name = "keypair-generator"
 version = "0.0.0"
 dependencies = [
- "clap 4.2.4",
+ "clap",
  "near-crypto",
  "nearcore",
 ]
@@ -3332,7 +3349,7 @@ dependencies = [
  "actix",
  "actix-rt",
  "anyhow",
- "clap 4.2.4",
+ "clap",
  "futures",
  "near-actix-test-utils",
  "near-async",
@@ -3417,7 +3434,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
- "clap 4.2.4",
+ "clap",
  "near-chain",
  "near-chain-configs",
  "near-crypto",
@@ -3692,7 +3709,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
- "clap 4.2.4",
+ "clap",
  "indicatif",
  "near-chain-configs",
  "near-epoch-manager",
@@ -3751,7 +3768,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
- "clap 4.2.4",
+ "clap",
  "near-chain",
  "near-chain-configs",
  "near-epoch-manager",
@@ -3777,7 +3794,7 @@ dependencies = [
  "actix",
  "anyhow",
  "chrono",
- "clap 4.2.4",
+ "clap",
  "hex",
  "near-chain",
  "near-chain-configs",
@@ -3957,7 +3974,7 @@ dependencies = [
  "async-trait",
  "borsh 1.0.0",
  "bs58",
- "clap 4.2.4",
+ "clap",
  "ed25519-dalek",
  "hex",
  "hkdf",
@@ -4054,7 +4071,7 @@ dependencies = [
  "atty",
  "base64 0.21.0",
  "bencher",
- "clap 4.2.4",
+ "clap",
  "itoa",
  "near-crypto",
  "near-fmt",
@@ -4108,7 +4125,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "chrono",
- "clap 4.2.4",
+ "clap",
  "near-async",
  "near-jsonrpc",
  "near-network",
@@ -4258,7 +4275,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 4.2.4",
+ "clap",
  "near-async",
  "near-jsonrpc",
  "near-network",
@@ -4279,7 +4296,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "borsh 1.0.0",
- "clap 4.2.4",
+ "clap",
  "cloud-storage",
  "near-client",
  "near-jsonrpc",
@@ -4379,7 +4396,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 4.2.4",
+ "clap",
  "near-chain",
  "near-chain-configs",
  "near-epoch-manager",
@@ -4473,7 +4490,7 @@ dependencies = [
  "base64 0.21.0",
  "bolero",
  "borsh 1.0.0",
- "clap 4.2.4",
+ "clap",
  "ed25519-dalek",
  "enum-map",
  "expect-test",
@@ -4691,7 +4708,7 @@ version = "0.0.0"
 dependencies = [
  "actix",
  "anyhow",
- "clap 4.2.4",
+ "clap",
  "cold-store-tool",
  "futures",
  "near-amend-genesis",
@@ -5309,34 +5326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
-name = "plotters"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
-dependencies = [
- "plotters-backend",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5905,7 +5894,7 @@ dependencies = [
 name = "restaked"
 version = "0.0.0"
 dependencies = [
- "clap 4.2.4",
+ "clap",
  "integration-tests",
  "near-crypto",
  "near-jsonrpc-client",
@@ -5993,7 +5982,7 @@ dependencies = [
  "bytesize",
  "cfg-if 1.0.0",
  "chrono",
- "clap 4.2.4",
+ "clap",
  "enum-map",
  "genesis-populate",
  "hex",
@@ -6366,16 +6355,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6692,7 +6671,7 @@ name = "speedy_sync"
 version = "0.0.0"
 dependencies = [
  "borsh 1.0.0",
- "clap 4.2.4",
+ "clap",
  "near-chain",
  "near-chain-configs",
  "near-chain-primitives",
@@ -6731,7 +6710,7 @@ dependencies = [
  "borsh 1.0.0",
  "bytesize",
  "chrono",
- "clap 4.2.4",
+ "clap",
  "cloud-storage",
  "insta",
  "itertools",
@@ -6790,7 +6769,7 @@ dependencies = [
 name = "store-validator"
 version = "0.0.0"
 dependencies = [
- "clap 4.2.4",
+ "clap",
  "near-chain",
  "near-chain-configs",
  "near-client",
@@ -6984,15 +6963,6 @@ dependencies = [
  "near-test-contracts",
  "node-runtime",
  "once_cell",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,9 +2531,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hex"
@@ -2866,7 +2866,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.3",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -2883,7 +2883,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.3",
  "io-lifetimes",
  "rustix 0.37.20",
  "windows-sys 0.48.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web-codegen",
- "ahash 0.7.6",
+ "ahash 0.7.7",
  "bytes",
  "bytestring",
  "cfg-if 1.0.0",
@@ -279,9 +279,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
 dependencies = [
  "getrandom 0.2.9",
  "once_cell",
@@ -518,7 +518,7 @@ dependencies = [
  "actix-service",
  "actix-tls",
  "actix-utils",
- "ahash 0.7.6",
+ "ahash 0.7.7",
  "base64 0.21.0",
  "bytes",
  "cfg-if 1.0.0",
@@ -2453,7 +2453,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.6",
+ "ahash 0.7.7",
 ]
 
 [[package]]
@@ -2462,7 +2462,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.6",
+ "ahash 0.7.7",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,17 +494,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4068,7 +4057,6 @@ name = "near-o11y"
 version = "0.0.0"
 dependencies = [
  "actix",
- "atty",
  "base64 0.21.0",
  "bencher",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ fs2 = "0.4"
 futures = "0.3.5"
 futures-util = "0.3"
 genesis-populate = { path = "genesis-tools/genesis-populate" }
-hashbrown = "0.11"
+hashbrown = "0.14.2"
 hex = { version = "0.4.2", features = ["serde"] }
 hex-literal = "0.2"
 hkdf = "0.12.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ clap = { version = "4.2.0", features = ["derive", "env", "string"] }
 cloud-storage = "0.11.1"
 conqueue = "0.4.0"
 cpu-time = "1.0"
-criterion = { version = "0.3.5", default_features = false, features = ["html_reports", "cargo_bench_support"] }
+criterion = { version = "0.5.1", default_features = false, features = ["html_reports", "cargo_bench_support"] }
 crossbeam = "0.8"
 crossbeam-channel = "0.5.8"
 crossbeam-queue = "0.3.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,6 @@ arc-swap = "1.5"
 assert_matches = "1.5.0"
 async-recursion = "1.0.4"
 async-trait = "0.1.58"
-atty = "0.2"
 awc = { version = "3", features = ["openssl"] }
 backtrace = "0.3"
 base64 = "0.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,6 @@ actix-cors = "0.6.1"
 actix-http = "3.3"
 actix-rt = "2"
 actix-web = "4.1"
-ansi_term = "0.12"
 anyhow = "1.0.62"
 arbitrary = { version = "1.2.3", features = ["derive"] }
 arc-swap = "1.5"
@@ -357,6 +356,7 @@ webrtc-util = "0.7"
 winapi = { version = "0.3", features = ["winbase", "memoryapi", "errhandlingapi", "winnt", "impl-default"] }
 xshell = "0.2.1"
 xz2 = "0.1.6"
+yansi = "0.5.1"
 
 stdx = { package = "near-stdx", path = "utils/stdx" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ base64 = "0.21"
 bencher = "0.1.5"
 bitflags = "1.2"
 blake2 = "0.9.1"
-bn = { package = "zeropool-bn", version = "0.5.11" }
+bn = { package = "zeropool-bn", version = "0.5.11", default-features = false }
 bolero = { version = "0.10.0", git = "https://github.com/Ekleog-NEAR/bolero", rev = "8f4e49d65c702a2f9858ed3c217b1cb52ce91243", features = ["arbitrary"] }
 borsh = { version = "1.0.0", features = ["derive", "rc"] }
 bs58 = "0.4"

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -10,7 +10,6 @@ workspace = true
 
 [dependencies]
 actix.workspace = true
-ansi_term.workspace = true
 assert_matches.workspace = true
 borsh.workspace = true
 bytesize.workspace = true
@@ -28,6 +27,7 @@ rayon.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+yansi.workspace = true
 
 near-async.workspace = true
 near-cache.workspace = true

--- a/chain/client-primitives/Cargo.toml
+++ b/chain/client-primitives/Cargo.toml
@@ -14,12 +14,12 @@ workspace = true
 
 [dependencies]
 actix.workspace = true
-ansi_term.workspace = true
 chrono.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 strum.workspace = true
 thiserror.workspace = true
+yansi.workspace = true
 
 near-chain-primitives.workspace = true
 near-chain-configs.workspace = true

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -21,7 +21,7 @@ pub use near_primitives::views::{StatusResponse, StatusSyncInfo};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use yansi::Color::Purple;
+use yansi::Color::Magenta;
 use yansi::Style;
 
 /// Combines errors coming from chain, tx pool and block producer.
@@ -216,7 +216,7 @@ pub fn format_shard_sync_phase(
     match &shard_sync_download.status {
         ShardSyncStatus::StateDownloadHeader => format!(
             "{} requests sent {}, last target {:?}",
-            paint("HEADER", Purple.bold(), use_colour),
+            paint("HEADER", Magenta.style().bold(), use_colour),
             shard_sync_download.downloads.get(0).map_or(0, |x| x.state_requests_count),
             shard_sync_download.downloads.get(0).map_or(None, |x| x.last_target.as_ref()),
         ),

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -1,6 +1,4 @@
 use actix::Message;
-use ansi_term::Color::Purple;
-use ansi_term::Style;
 use chrono::DateTime;
 use chrono::Utc;
 use near_chain_configs::{ClientConfig, ProtocolConfigView};
@@ -23,6 +21,8 @@ pub use near_primitives::views::{StatusResponse, StatusSyncInfo};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use yansi::Color::Purple;
+use yansi::Style;
 
 /// Combines errors coming from chain, tx pool and block producer.
 #[derive(Debug, thiserror::Error)]

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 [dependencies]
 actix-rt.workspace = true
 actix.workspace = true
-ansi_term.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 borsh.workspace = true
@@ -40,6 +39,7 @@ tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+yansi.workspace = true
 
 near-async.workspace = true
 near-chain-configs.workspace = true

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -710,7 +710,7 @@ pub(crate) fn new_network_info_view(chain: &Chain, network_info: &NetworkInfo) -
                     })
                     .collect(),
                 account_key: d.account_key.clone(),
-                timestamp: chrono::DateTime::from_utc(
+                timestamp: chrono::DateTime::from_naive_utc_and_offset(
                     chrono::NaiveDateTime::from_timestamp_opt(d.timestamp.unix_timestamp(), 0)
                         .unwrap(),
                     chrono::Utc,

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -363,11 +363,11 @@ impl InfoHelper {
         client_config: &ClientConfig,
         config_updater: &Option<ConfigUpdater>,
     ) {
-        let use_colour = matches!(self.log_summary_style, LogSummaryStyle::Colored);
-        let paint = |colour: ansi_term::Colour, text: Option<String>| match text {
-            None => ansi_term::Style::default().paint(""),
-            Some(text) if use_colour => colour.bold().paint(text),
-            Some(text) => ansi_term::Style::default().paint(text),
+        let use_color = matches!(self.log_summary_style, LogSummaryStyle::Colored);
+        let paint = |color: yansi::Color, text: Option<String>| match text {
+            None => yansi::Paint::default(""),
+            Some(text) if use_color => yansi::Paint::default(text).fg(color).bold(),
+            Some(text) => yansi::Paint::default(text),
         };
 
         let s = |num| if num == 1 { "" } else { "s" };
@@ -411,11 +411,11 @@ impl InfoHelper {
 
         info!(
             target: "stats", "{}{}{}{}{}",
-            paint(ansi_term::Colour::Yellow, sync_status_log),
-            paint(ansi_term::Colour::White, validator_info_log),
-            paint(ansi_term::Colour::Cyan, network_info_log),
-            paint(ansi_term::Colour::Green, blocks_info_log),
-            paint(ansi_term::Colour::Blue, machine_info_log),
+            paint(yansi::Color::Yellow, sync_status_log),
+            paint(yansi::Color::White, validator_info_log),
+            paint(yansi::Color::Cyan, network_info_log),
+            paint(yansi::Color::Green, blocks_info_log),
+            paint(yansi::Color::Blue, machine_info_log),
         );
         if !catchup_status_log.is_empty() {
             info!(target: "stats", "Catchups\n{}", catchup_status_log);
@@ -678,16 +678,16 @@ impl std::fmt::Display for FormatMillis {
 /// meant to be used in logging where final new line is not desired.
 struct BlocksInfo {
     blocks_info: Vec<near_primitives::views::BlockProcessingInfo>,
-    use_colour: bool,
+    use_color: bool,
 }
 
 impl std::fmt::Display for BlocksInfo {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let paint = |colour: ansi_term::Colour, text: String| {
-            if self.use_colour {
-                colour.bold().paint(text)
+        let paint = |color: yansi::Color, text: String| {
+            if self.use_color {
+                yansi::Paint::default(text).fg(color).bold()
             } else {
-                ansi_term::Style::default().paint(text)
+                yansi::Paint::default(text)
             }
         };
 
@@ -711,11 +711,8 @@ impl std::fmt::Display for BlocksInfo {
                 })
                 .collect::<String>();
 
-            let chunk_status_color = if all_chunks_received {
-                ansi_term::Colour::Green
-            } else {
-                ansi_term::Colour::White
-            };
+            let chunk_status_color =
+                if all_chunks_received { yansi::Color::Green } else { yansi::Color::White };
 
             let chunk_status = paint(chunk_status_color, chunk_status);
             let in_progress = FormatMillis("in progress", Some(block_info.in_progress_ms));

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -365,7 +365,7 @@ impl InfoHelper {
     ) {
         let use_color = matches!(self.log_summary_style, LogSummaryStyle::Colored);
         let paint = |color: yansi::Color, text: Option<String>| match text {
-            None => yansi::Paint::default(""),
+            None => yansi::Paint::default(String::new()),
             Some(text) if use_color => yansi::Paint::default(text).fg(color).bold(),
             Some(text) => yansi::Paint::default(text),
         };
@@ -538,9 +538,9 @@ impl InfoHelper {
 
     fn log_chain_processing_info(&mut self, client: &crate::Client, epoch_id: &EpochId) {
         let chain = &client.chain;
-        let use_colour = matches!(self.log_summary_style, LogSummaryStyle::Colored);
+        let use_color = matches!(self.log_summary_style, LogSummaryStyle::Colored);
         let info = chain.get_chain_processing_info();
-        let blocks_info = BlocksInfo { blocks_info: info.blocks_info, use_colour };
+        let blocks_info = BlocksInfo { blocks_info: info.blocks_info, use_color };
         tracing::debug!(
             target: "stats",
             "{:?} Orphans: {} With missing chunks: {} In processing {}{}",

--- a/core/o11y/Cargo.toml
+++ b/core/o11y/Cargo.toml
@@ -18,7 +18,6 @@ near-fmt.workspace = true
 near-primitives-core.workspace = true
 
 actix.workspace = true
-atty.workspace = true
 base64.workspace = true
 clap.workspace = true
 once_cell.workspace = true

--- a/core/o11y/src/subscriber.rs
+++ b/core/o11y/src/subscriber.rs
@@ -93,8 +93,8 @@ pub enum ColorOutput {
 }
 
 fn is_terminal() -> bool {
-    // Crate `atty` provides a platform-independent way of checking whether the output is a tty.
-    atty::is(atty::Stream::Stderr)
+    use std::io::IsTerminal;
+    std::io::stderr().is_terminal()
 }
 
 fn add_simple_log_layer<S, W>(

--- a/core/primitives/src/upgrade_schedule.rs
+++ b/core/primitives/src/upgrade_schedule.rs
@@ -11,7 +11,7 @@ pub struct ProtocolUpgradeVotingSchedule {
 
 impl Default for ProtocolUpgradeVotingSchedule {
     fn default() -> Self {
-        Self { timestamp: DateTime::<Utc>::from_utc(Default::default(), Utc) }
+        Self { timestamp: DateTime::<Utc>::from_naive_utc_and_offset(Default::default(), Utc) }
     }
 }
 
@@ -41,7 +41,7 @@ impl ProtocolUpgradeVotingSchedule {
         }
 
         Ok(Self {
-            timestamp: DateTime::<Utc>::from_utc(
+            timestamp: DateTime::<Utc>::from_naive_utc_and_offset(
                 NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S")?,
                 Utc,
             ),

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -415,12 +415,13 @@ pub fn from_timestamp(timestamp: u64) -> DateTime<chrono::Utc> {
     let secs = (timestamp / NS_IN_SECOND) as i64;
     let nsecs = (timestamp % NS_IN_SECOND) as u32;
     let naive = NaiveDateTime::from_timestamp_opt(secs, nsecs).unwrap();
-    DateTime::from_utc(naive, chrono::Utc)
+    DateTime::from_naive_utc_and_offset(naive, chrono::Utc)
 }
 
 /// Converts DateTime UTC time into timestamp in ns.
 pub fn to_timestamp(time: DateTime<chrono::Utc>) -> u64 {
-    time.timestamp_nanos() as u64
+    // The unwrap will be safe for all dates between 1678 and 2261.
+    time.timestamp_nanos_opt().unwrap() as u64
 }
 
 /// Compute number of seats per shard for given total number of seats and number of shards.

--- a/deny.toml
+++ b/deny.toml
@@ -37,6 +37,7 @@ deny = [
 ]
 
 skip = [
+    { name = "tracing-log", version = "0.1.3" },
     # wasmer 0.17 and wasmtime 0.17 uses older versions of some crates
     { name = "generic-array", version = "=0.12.4" },
 
@@ -98,9 +99,6 @@ skip = [
     { name = "windows_x86_64_msvc", version = "=0.42.2" },
     { name = "windows-targets", version = "=0.42.1" },
 
-    # chrono uses old time crate
-    { name = "time", version = "=0.1.44" },
-
     # ed25519-dalek uses older versions of rand and rand_core
     { name = "rand", version = "=0.7.3" },
     { name = "rand_core", version = "=0.5.1" },
@@ -155,7 +153,7 @@ skip = [
 
     # Various packages haven’t upgraded to 0.base64 21 yet.
     { name = "base64", version = "=0.13.0" },
-    { name = "ahash", version = "=0.7.6" },
+    { name = "ahash", version = "=0.7.7" },
 
     # actix-http hasn't upgraded iminz_oxide/flate2 yet.
     { name = "miniz_oxide", version = "=0.5.1" },

--- a/genesis-tools/genesis-csv-to-json/src/csv_parser.rs
+++ b/genesis-tools/genesis-csv-to-json/src/csv_parser.rs
@@ -230,7 +230,7 @@ fn account_records(row: &Row, gas_price: Balance) -> Vec<StateRecord> {
     if let Some(ref smart_contract) = row.smart_contract {
         let args = match smart_contract.as_str() {
             "lockup.wasm" => {
-                let lockup = row.lockup.unwrap().timestamp_nanos();
+                let lockup = row.lockup.unwrap().timestamp_nanos_opt().unwrap();
                 lockup.to_le_bytes().to_vec()
             }
             "lockup_and_vesting.wasm" => {
@@ -238,7 +238,7 @@ fn account_records(row: &Row, gas_price: Balance) -> Vec<StateRecord> {
                 // Encode four dates as timestamps as i64 with LE encoding.
                 for date in &[&row.lockup, &row.vesting_start, &row.vesting_end, &row.vesting_cliff]
                 {
-                    let date = date.unwrap().timestamp_nanos();
+                    let date = date.unwrap().timestamp_nanos_opt().unwrap();
                     res.extend_from_slice(&date.to_le_bytes());
                 }
                 res

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -17,7 +17,6 @@ name = "neard"
 
 [dependencies]
 actix.workspace = true
-ansi_term.workspace = true
 anyhow.workspace = true
 clap.workspace = true
 futures.workspace = true
@@ -33,6 +32,7 @@ thiserror.workspace = true
 tikv-jemallocator.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+yansi.workspace = true
 
 nearcore.workspace = true
 near-amend-genesis.workspace = true

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -761,11 +761,13 @@ impl VerifyProofSubCommand {
         if light_client_proof.block_header_lite.inner_lite.outcome_root != block_outcome_root {
             println!(
                 "{}",
-                ansi_term::Colour::Red.bold().paint(format!(
+                yansi::Paint::default(format!(
                     "ERROR: computed outcome root: {:?} doesn't match the block one {:?}.",
                     block_outcome_root,
                     light_client_proof.block_header_lite.inner_lite.outcome_root
                 ))
+                .fg(yansi::Color::Red)
+                .bold()
             );
             return Err(VerifyProofError::InvalidOutcomeRootProof);
         }
@@ -774,19 +776,19 @@ impl VerifyProofSubCommand {
         if light_client_proof.block_header_lite.hash()
             != light_client_proof.outcome_proof.block_hash
         {
-            println!("{}",
-            ansi_term::Colour::Red.bold().paint(format!(
-                "ERROR: block hash from header lite {:?} doesn't match the one from outcome proof {:?}",
-                light_client_proof.block_header_lite.hash(),
-                light_client_proof.outcome_proof.block_hash
-            )));
+            println!(
+                "{}",
+                yansi::Paint::default(format!(
+                    "ERROR: block hash from header lite {:?} doesn't match the one from outcome proof {:?}",
+                    light_client_proof.block_header_lite.hash(),
+                    light_client_proof.outcome_proof.block_hash
+                )).fg(yansi::Color::Red).bold()
+            );
             return Err(VerifyProofError::InvalidBlockHashProof);
         } else {
             println!(
                 "{}",
-                ansi_term::Colour::Green
-                    .bold()
-                    .paint(format!("Block hash matches {:?}", block_hash))
+                yansi::Paint::green(format!("Block hash matches {:?}", block_hash)).bold()
             );
         }
 

--- a/test-utils/store-validator/Cargo.toml
+++ b/test-utils/store-validator/Cargo.toml
@@ -12,8 +12,8 @@ publish = false
 workspace = true
 
 [dependencies]
-ansi_term.workspace = true
 clap.workspace = true
+yansi.workspace = true
 
 near-epoch-manager.workspace = true
 near-chain-configs.workspace = true

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -63,26 +63,29 @@ fn main() {
     store_validator.validate();
 
     if store_validator.tests_done() == 0 {
-        println!("{}", Red.bold().paint("No conditions has been validated"));
+        println!("{}", Red.style().bold().paint("No conditions has been validated"));
         process::exit(1);
     }
     println!(
         "{} {}",
-        White.bold().paint("Conditions validated:"),
-        Green.bold().paint(store_validator.tests_done().to_string())
+        White.style().bold().paint("Conditions validated:"),
+        Green.style().bold().paint(store_validator.tests_done().to_string())
     );
     for error in store_validator.errors.iter() {
         println!(
             "{}  {}  {}",
-            Red.bold().paint(&error.col),
-            Yellow.bold().paint(&error.key),
+            Red.style().bold().paint(&error.col),
+            Yellow.style().bold().paint(&error.key),
             error.err
         );
     }
     if store_validator.is_failed() {
-        println!("Errors found: {}", Red.bold().paint(store_validator.num_failed().to_string()));
+        println!(
+            "Errors found: {}",
+            Red.style().bold().paint(store_validator.num_failed().to_string())
+        );
         process::exit(1);
     } else {
-        println!("{}", Green.bold().paint("No errors found"));
+        println!("{}", Green.style().bold().paint("No errors found"));
     }
 }

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -1,4 +1,3 @@
-use ansi_term::Color::{Green, Red, White, Yellow};
 use clap::{Arg, Command};
 use near_chain::store_validator::StoreValidator;
 use near_chain_configs::GenesisValidationMode;
@@ -10,6 +9,7 @@ use near_o11y::testonly::init_integration_logger;
 use nearcore::{get_default_home, load_config};
 use std::path::PathBuf;
 use std::process;
+use yansi::Color::{Green, Red, White, Yellow};
 
 fn main() {
     init_integration_logger();

--- a/tools/state-viewer/Cargo.toml
+++ b/tools/state-viewer/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 
 [dependencies]
 actix.workspace = true
-ansi_term.workspace = true
 anyhow.workspace = true
 borsh.workspace = true
 bytesize.workspace = true
@@ -34,6 +33,7 @@ strum.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+yansi.workspace = true
 
 near-chain-configs.workspace = true
 near-chain.workspace = true

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -671,9 +671,14 @@ pub(crate) fn print_chain(
                 .get_block_producer(epoch_id, height)
                 .map(|account_id| account_id.to_string())
                 .unwrap_or("error".to_owned());
-            println!("{: >3} {} | {: >10}", height, Red.bold().paint("MISSING"), block_producer);
+            println!(
+                "{: >3} {} | {: >10}",
+                height,
+                Red.style().bold().paint("MISSING"),
+                block_producer
+            );
         } else {
-            println!("{: >3} {}", height, Red.bold().paint("MISSING"));
+            println!("{: >3} {}", height, Red.style().bold().paint("MISSING"));
         }
     }
 }

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -6,7 +6,6 @@ use crate::state_dump::state_dump;
 use crate::state_dump::state_dump_redis;
 use crate::tx_dump::dump_tx_from_block;
 use crate::{apply_chunk, epoch_info};
-use ansi_term::Color::Red;
 use bytesize::ByteSize;
 use itertools::GroupBy;
 use itertools::Itertools;
@@ -48,6 +47,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
+use yansi::Color::Red;
 
 pub(crate) fn apply_block(
     block_hash: CryptoHash,


### PR DESCRIPTION
In particular:
- cpufeatures
- ahash
- hashbrown
- criterion
- pretty-assertions
- tracing-subscriber
- chrono
- h2
- tempfile
- hermit-abi

Also:
- replaced ansi_term with yansi
- removed our dependency on atty altogether

All this together, alongside with https://github.com/near/nearcore/pull/10201, gets us to zero cargo-audit warnings :)

This might be best reviewed commit-by-commit, to more easily see which changes are due to which dependency (though I tried bumping chrono and replacing ansi_term at the same time, resulting in alternating commits as my test compilations made progress)