### PR TITLE
remove the currently omnipresent red mark

### DIFF
--- a/.github/workflows/nightly_nayduck.yml
+++ b/.github/workflows/nightly_nayduck.yml
@@ -1,6 +1,5 @@
 name: Nightly Nayduck tests check
 on:
-  pull_request:
   merge_group:
 
 jobs:


### PR DESCRIPTION
Considering in four weeks of always seeing red on all PRs, we still have not fixed the nayduck tests… I’m suggesting we remove it so that we get the signal again, of whether a PR passes tests or not.

Indeed, this failing means that we no longer see the actual value added by other tests, and especially the green checkmark that would otherwise be a good indicator that a PR is ready to be merged: we now need to manually check and scroll the statuses list in order to figure out whether a PR is actually ready for merge.

Currently, this is a net negative in developer experience. I’m not questioning the nayduck problem, but the solution seemed wrong to me, and time has shown it does not actually works. We need another solution, like a round-robin of everyone having to look at nayduck once a week and figure out a way to make it green, even if it is by (temporarily) disabling tests (with a plan for re-enabling them).

So, I’m petitioning to remove this check from PRs (but keep it on master CI), it would at least make the statu quo more livable for all the developers who have literally no idea how to even check which nayduck tests are failing, and whose code is unrelated to these tests anyway.