### PR TITLE
fix(pytest): fix rpc_tx_submission.py

### DIFF
--- a/pytest/tests/sanity/rpc_tx_submission.py
+++ b/pytest/tests/sanity/rpc_tx_submission.py
@@ -45,8 +45,8 @@ new_balances = [
     int(nodes[0].get_account("test%s" % x)['result']['amount']) for x in [0, 1]
 ]
 logger.info(f"BALANCES AFTER {new_balances}")
-assert new_balances[0] == old_balances[0] - 303
-assert new_balances[1] == old_balances[1] + 303
+assert new_balances[0] == old_balances[0] - 201
+assert new_balances[1] == old_balances[1] + 201
 
 status = nodes[0].get_status()
 hash_ = status['sync_info']['latest_block_hash']


### PR DESCRIPTION
https://github.com/near/nearcore/pull/9596 removed an RPC Method and altered this test, but the previous version of the test sends 3 transfer txs with amounts 100, 101 and 102, and now the test only sends 2 transfer txs with amounts 100 and 101. So update the expected balance changes to reflect that