### PR TITLE
ETH-implicit account support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4206,11 +4206,13 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "sha3",
  "smart-default",
  "strum",
  "thiserror",
  "time",
  "tracing",
+ "wat",
 ]
 
 [[package]]

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -48,7 +48,7 @@ fn build_chain() {
     //     cargo insta test --accept -p near-chain --features nightly -- tests::simple_chain::build_chain
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
-        insta::assert_display_snapshot!(hash, @"8WF4fG7WCM2ysZvFQAgEfTEfBovtULxnWeRpwAt3BTBJ");
+        insta::assert_display_snapshot!(hash, @"CwaiZ4AmfJSnMN9rytYwwYHCTzLioC5xcjHzNkDex1HH");
     } else {
         insta::assert_display_snapshot!(hash, @"HJmRPXT4JM9tt6mXw2gM75YaSoqeDCphhFK26uRpd1vw");
     }

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -78,7 +78,7 @@ fn build_chain() {
 
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
-        insta::assert_display_snapshot!(hash, @"3iXi6BshQaPx9TsbDt5itAXUjnTQz9AR9pg2w349TFNj");
+        insta::assert_display_snapshot!(hash, @"Dn18HUFm149fojXpwV1dYCfjdPh56S1k233kp7vmnFeE");
     } else {
         insta::assert_display_snapshot!(hash, @"HbQVGVZ3WGxsNqeM3GfSwDoxwYZ2RBP1SinAze9SYR3C");
     }

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -48,7 +48,7 @@ fn build_chain() {
     //     cargo insta test --accept -p near-chain --features nightly -- tests::simple_chain::build_chain
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
-        insta::assert_display_snapshot!(hash, @"CwaiZ4AmfJSnMN9rytYwwYHCTzLioC5xcjHzNkDex1HH");
+        insta::assert_display_snapshot!(hash, @"8WF4fG7WCM2ysZvFQAgEfTEfBovtULxnWeRpwAt3BTBJ");
     } else {
         insta::assert_display_snapshot!(hash, @"HJmRPXT4JM9tt6mXw2gM75YaSoqeDCphhFK26uRpd1vw");
     }
@@ -78,7 +78,7 @@ fn build_chain() {
 
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
-        insta::assert_display_snapshot!(hash, @"Dn18HUFm149fojXpwV1dYCfjdPh56S1k233kp7vmnFeE");
+        insta::assert_display_snapshot!(hash, @"3iXi6BshQaPx9TsbDt5itAXUjnTQz9AR9pg2w349TFNj");
     } else {
         insta::assert_display_snapshot!(hash, @"HbQVGVZ3WGxsNqeM3GfSwDoxwYZ2RBP1SinAze9SYR3C");
     }

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -156,6 +156,13 @@ impl PublicKey {
             Self::SECP256K1(_) => panic!(),
         }
     }
+
+    pub fn unwrap_as_secp256k1(&self) -> &Secp256K1PublicKey {
+        match self {
+            Self::SECP256K1(key) => key,
+            Self::ED25519(_) => panic!(),
+        }
+    }
 }
 
 // This `Hash` implementation is safe since it retains the property

--- a/core/crypto/src/test_utils.rs
+++ b/core/crypto/src/test_utils.rs
@@ -43,7 +43,7 @@ impl SecretKey {
                 let keypair = ed25519_key_pair_from_seed(seed);
                 SecretKey::ED25519(ED25519SecretKey(keypair.to_keypair_bytes()))
             }
-            _ => SecretKey::SECP256K1(secp256k1_secret_key_from_seed(seed)),
+            KeyType::SECP256K1 => SecretKey::SECP256K1(secp256k1_secret_key_from_seed(seed)),
         }
     }
 }

--- a/core/crypto/src/test_utils.rs
+++ b/core/crypto/src/test_utils.rs
@@ -28,7 +28,10 @@ impl PublicKey {
                 let keypair = ed25519_key_pair_from_seed(seed);
                 PublicKey::ED25519(ED25519PublicKey(keypair.verifying_key().to_bytes()))
             }
-            _ => unimplemented!(),
+            KeyType::SECP256K1 => {
+                let secret_key = SecretKey::SECP256K1(secp256k1_secret_key_from_seed(seed));
+                PublicKey::SECP256K1(secret_key.public_key().unwrap_as_secp256k1().clone())
+            }
         }
     }
 }

--- a/core/primitives-core/src/parameter.rs
+++ b/core/primitives-core/src/parameter.rs
@@ -157,6 +157,7 @@ pub enum Parameter {
     AltBn128,
     FunctionCallWeight,
     VmKind,
+    EthImplicitAccounts,
 }
 
 #[derive(

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -128,7 +128,7 @@ pub enum ProtocolFeature {
     /// NEP: https://github.com/near/NEPs/pull/509
     #[cfg(feature = "protocol_feature_chunk_validation")]
     ChunkValidation,
-    EthImplicit,
+    EthImplicitAccounts,
 }
 
 impl ProtocolFeature {
@@ -184,7 +184,7 @@ impl ProtocolFeature {
             ProtocolFeature::SimpleNightshadeV2 => 135,
             #[cfg(feature = "protocol_feature_chunk_validation")]
             ProtocolFeature::ChunkValidation => 137,
-            ProtocolFeature::EthImplicit => 138,
+            ProtocolFeature::EthImplicitAccounts => 138,
         }
     }
 }

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -128,6 +128,7 @@ pub enum ProtocolFeature {
     /// NEP: https://github.com/near/NEPs/pull/509
     #[cfg(feature = "protocol_feature_chunk_validation")]
     ChunkValidation,
+    EthImplicit,
 }
 
 impl ProtocolFeature {
@@ -183,6 +184,7 @@ impl ProtocolFeature {
             ProtocolFeature::SimpleNightshadeV2 => 135,
             #[cfg(feature = "protocol_feature_chunk_validation")]
             ProtocolFeature::ChunkValidation => 137,
+            ProtocolFeature::EthImplicit => 138,
         }
     }
 }
@@ -195,7 +197,7 @@ const STABLE_PROTOCOL_VERSION: ProtocolVersion = 64;
 /// Largest protocol version supported by the current binary.
 pub const PROTOCOL_VERSION: ProtocolVersion = if cfg!(feature = "nightly_protocol") {
     // On nightly, pick big enough version to support all features.
-    139
+    140
 } else {
     // Enable all stable features.
     STABLE_PROTOCOL_VERSION

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -197,7 +197,7 @@ const STABLE_PROTOCOL_VERSION: ProtocolVersion = 64;
 /// Largest protocol version supported by the current binary.
 pub const PROTOCOL_VERSION: ProtocolVersion = if cfg!(feature = "nightly_protocol") {
     // On nightly, pick big enough version to support all features.
-    140
+    139
 } else {
     // Enable all stable features.
     STABLE_PROTOCOL_VERSION

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -33,12 +33,14 @@ serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
 serde_yaml.workspace = true
+sha3.workspace = true
 smart-default.workspace = true
 stdx.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tracing.workspace = true
+wat.workspace = true
 
 near-crypto.workspace = true
 near-fmt.workspace = true

--- a/core/primitives/res/runtime_configs/138.yaml
+++ b/core/primitives/res/runtime_configs/138.yaml
@@ -1,0 +1,1 @@
+eth_implicit_accounts: { old: false, new: true }

--- a/core/primitives/res/runtime_configs/parameters.snap
+++ b/core/primitives/res/runtime_configs/parameters.snap
@@ -172,4 +172,5 @@ ed25519_verify                          true
 alt_bn128                               true
 function_call_weight                    true
 vm_kind                                 NearVm
+eth_implicit_accounts                   false
 

--- a/core/primitives/res/runtime_configs/parameters.yaml
+++ b/core/primitives/res/runtime_configs/parameters.yaml
@@ -207,3 +207,4 @@ ed25519_verify: false
 alt_bn128: false
 function_call_weight: false
 vm_kind: Wasmer0
+eth_implicit_accounts: false

--- a/core/primitives/res/runtime_configs/parameters_testnet.yaml
+++ b/core/primitives/res/runtime_configs/parameters_testnet.yaml
@@ -202,3 +202,4 @@ ed25519_verify: false
 alt_bn128: false
 function_call_weight: false
 vm_kind: Wasmer0
+eth_implicit_accounts: false

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -486,9 +486,9 @@ pub enum ActionErrorKind {
     /// Error occurs when a new `ActionReceipt` created by the `FunctionCall` action fails
     /// receipt validation.
     NewReceiptValidationError(ReceiptValidationError),
-    /// Error occurs when a `CreateAccount` action is called on hex-characters
-    /// account of length 64.  See implicit account creation NEP:
-    /// <https://github.com/nearprotocol/NEPs/pull/71>.
+    /// Error occurs when a `CreateAccount` action is called on a NEAR-implicit or ETH-implicit account.
+    /// See NEAR-implicit account creation NEP: <https://github.com/nearprotocol/NEPs/pull/71>.
+    /// Also, see ETH-implicit account creation NEP: <https://github.com/near/NEPs/issues/518>.
     ///
     /// TODO(#8598): This error is named very poorly. A better name would be
     /// `OnlyNamedAccountCreationAllowed`.

--- a/core/primitives/src/runtime/config_store.rs
+++ b/core/primitives/src/runtime/config_store.rs
@@ -38,6 +38,8 @@ static CONFIG_DIFFS: &[(ProtocolVersion, &str)] = &[
     (63, include_config!("63.yaml")),
     (64, include_config!("64.yaml")),
     (129, include_config!("129.yaml")),
+    // Introduce ETH-implicit accounts.
+    (138, include_config!("138.yaml")),
 ];
 
 /// Testnet parameters for versions <= 29, which (incorrectly) differed from mainnet parameters

--- a/core/primitives/src/runtime/parameter_table.rs
+++ b/core/primitives/src/runtime/parameter_table.rs
@@ -323,6 +323,7 @@ impl TryFrom<&ParameterTable> for RuntimeConfig {
                 ed25519_verify: params.get(Parameter::Ed25519Verify)?,
                 alt_bn128: params.get(Parameter::AltBn128)?,
                 function_call_weight: params.get(Parameter::FunctionCallWeight)?,
+                eth_implicit_accounts: params.get(Parameter::EthImplicitAccounts)?,
             },
             account_creation_config: AccountCreationConfig {
                 min_allowed_top_level_account_length: params

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__0.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__0.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": false,
     "function_call_weight": false,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__129.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__129.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": true,
     "alt_bn128": true,
     "function_call_weight": true,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__138.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__138.json.snap
@@ -24,9 +24,9 @@ expression: config_view
     },
     "action_creation_config": {
       "create_account_cost": {
-        "send_sir": 99607375000,
-        "send_not_sir": 99607375000,
-        "execution": 99607375000
+        "send_sir": 3850000000000,
+        "send_not_sir": 3850000000000,
+        "execution": 3850000000000
       },
       "deploy_contract_cost": {
         "send_sir": 184765750000,
@@ -36,7 +36,7 @@ expression: config_view
       "deploy_contract_cost_per_byte": {
         "send_sir": 6812999,
         "send_not_sir": 6812999,
-        "execution": 6812999
+        "execution": 64572944
       },
       "function_call_cost": {
         "send_sir": 2319861500000,
@@ -174,18 +174,18 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
-    "storage_get_mode": "Trie",
-    "fix_contract_loading_cost": false,
+    "storage_get_mode": "FlatStorage",
+    "fix_contract_loading_cost": true,
     "implicit_account_creation": true,
     "math_extension": true,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
-    "eth_implicit_accounts": false,
+    "ed25519_verify": true,
+    "alt_bn128": true,
+    "function_call_weight": true,
+    "eth_implicit_accounts": true,
     "limit_config": {
-      "max_gas_burnt": 200000000000000,
-      "max_stack_height": 16384,
-      "contract_prepare_version": 1,
+      "max_gas_burnt": 300000000000000,
+      "max_stack_height": 262144,
+      "contract_prepare_version": 2,
       "initial_memory_pages": 1024,
       "max_memory_pages": 2048,
       "registers_memory_limit": 1073741824,
@@ -201,17 +201,18 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_length_storage_key": 4194304,
+      "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
       "max_number_input_data_dependencies": 128,
       "max_functions_number_per_contract": 10000,
-      "wasmer2_stack_limit": 102400,
-      "account_id_validity_rules_version": 0
+      "wasmer2_stack_limit": 204800,
+      "max_locals_per_contract": 1000000,
+      "account_id_validity_rules_version": 1
     }
   },
   "account_creation_config": {
-    "min_allowed_top_level_account_length": 32,
+    "min_allowed_top_level_account_length": 65,
     "registrar_account_id": "registrar"
   }
 }

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__35.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__35.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": false,
     "function_call_weight": false,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__42.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__42.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": false,
     "function_call_weight": false,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__46.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__46.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": false,
     "function_call_weight": false,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__48.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__48.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": false,
     "function_call_weight": false,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__49.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__49.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": false,
     "function_call_weight": false,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__52.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__52.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": false,
     "function_call_weight": false,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__53.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__53.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": false,
     "function_call_weight": true,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__55.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__55.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": true,
     "function_call_weight": true,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__57.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__57.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": true,
     "function_call_weight": true,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__59.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__59.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": true,
     "alt_bn128": true,
     "function_call_weight": true,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__61.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__61.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": true,
     "alt_bn128": true,
     "function_call_weight": true,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__62.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__62.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": true,
     "alt_bn128": true,
     "function_call_weight": true,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__63.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__63.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": true,
     "alt_bn128": true,
     "function_call_weight": true,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__64.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__64.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": true,
     "alt_bn128": true,
     "function_call_weight": true,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_0.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_0.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": false,
     "function_call_weight": false,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_129.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_129.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": true,
     "alt_bn128": true,
     "function_call_weight": true,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_138.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_138.json.snap
@@ -24,9 +24,9 @@ expression: config_view
     },
     "action_creation_config": {
       "create_account_cost": {
-        "send_sir": 99607375000,
-        "send_not_sir": 99607375000,
-        "execution": 99607375000
+        "send_sir": 3850000000000,
+        "send_not_sir": 3850000000000,
+        "execution": 3850000000000
       },
       "deploy_contract_cost": {
         "send_sir": 184765750000,
@@ -36,7 +36,7 @@ expression: config_view
       "deploy_contract_cost_per_byte": {
         "send_sir": 6812999,
         "send_not_sir": 6812999,
-        "execution": 6812999
+        "execution": 64572944
       },
       "function_call_cost": {
         "send_sir": 2319861500000,
@@ -174,18 +174,18 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
-    "storage_get_mode": "Trie",
-    "fix_contract_loading_cost": false,
+    "storage_get_mode": "FlatStorage",
+    "fix_contract_loading_cost": true,
     "implicit_account_creation": true,
     "math_extension": true,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
-    "eth_implicit_accounts": false,
+    "ed25519_verify": true,
+    "alt_bn128": true,
+    "function_call_weight": true,
+    "eth_implicit_accounts": true,
     "limit_config": {
-      "max_gas_burnt": 200000000000000,
-      "max_stack_height": 16384,
-      "contract_prepare_version": 1,
+      "max_gas_burnt": 300000000000000,
+      "max_stack_height": 262144,
+      "contract_prepare_version": 2,
       "initial_memory_pages": 1024,
       "max_memory_pages": 2048,
       "registers_memory_limit": 1073741824,
@@ -201,17 +201,18 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_length_storage_key": 4194304,
+      "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
       "max_number_input_data_dependencies": 128,
       "max_functions_number_per_contract": 10000,
-      "wasmer2_stack_limit": 102400,
-      "account_id_validity_rules_version": 0
+      "wasmer2_stack_limit": 204800,
+      "max_locals_per_contract": 1000000,
+      "account_id_validity_rules_version": 1
     }
   },
   "account_creation_config": {
-    "min_allowed_top_level_account_length": 32,
+    "min_allowed_top_level_account_length": 65,
     "registrar_account_id": "registrar"
   }
 }

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_35.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_35.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": false,
     "function_call_weight": false,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_42.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_42.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": false,
     "function_call_weight": false,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_46.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_46.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": false,
     "function_call_weight": false,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_48.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_48.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": false,
     "function_call_weight": false,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_49.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_49.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": false,
     "function_call_weight": false,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_50.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_50.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": false,
     "function_call_weight": false,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_52.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_52.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": false,
     "function_call_weight": false,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_53.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_53.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": false,
     "function_call_weight": true,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_55.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_55.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": true,
     "function_call_weight": true,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_57.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_57.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": false,
     "alt_bn128": true,
     "function_call_weight": true,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_59.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_59.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": true,
     "alt_bn128": true,
     "function_call_weight": true,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_61.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_61.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": true,
     "alt_bn128": true,
     "function_call_weight": true,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_62.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_62.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": true,
     "alt_bn128": true,
     "function_call_weight": true,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_63.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_63.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": true,
     "alt_bn128": true,
     "function_call_weight": true,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_64.json.snap
+++ b/core/primitives/src/runtime/snapshots/near_primitives__runtime__config_store__tests__testnet_64.json.snap
@@ -181,6 +181,7 @@ expression: config_view
     "ed25519_verify": true,
     "alt_bn128": true,
     "function_call_weight": true,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
+++ b/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
@@ -181,6 +181,7 @@ expression: "&view"
     "ed25519_verify": true,
     "alt_bn128": true,
     "function_call_weight": true,
+    "eth_implicit_accounts": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
+++ b/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
@@ -181,7 +181,7 @@ expression: "&view"
     "ed25519_verify": true,
     "alt_bn128": true,
     "function_call_weight": true,
-    "eth_implicit_accounts": true,
+    "eth_implicit_accounts": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -561,6 +561,11 @@ pub fn near_implicit_test_account_secret() -> SecretKey {
     "ed25519:5roj6k68kvZu3UEJFyXSfjdKGrodgZUfFLZFpzYXWtESNsLWhYrq3JGi4YpqeVKuw1m9R2TEHjfgWT1fjUqB1DNy".parse().unwrap()
 }
 
+/// A fixed ETH-implicit account.
+pub fn eth_implicit_test_account() -> AccountId {
+    "0x96791e923f8cf697ad9c3290f2c9059f0231b24c".parse().unwrap()
+}
+
 impl FinalExecutionOutcomeView {
     #[track_caller]
     /// Check transaction and all transitive receipts for success status.

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -8,7 +8,6 @@ use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use serde;
 
-use crate::checked_feature;
 use crate::hash::{hash, CryptoHash};
 use crate::receipt::Receipt;
 use crate::transaction::SignedTransaction;
@@ -472,7 +471,7 @@ where
     Serializable(object)
 }
 
-// TODO(eth-implicit) Replace this function (and wat dependency) with real Wallet Contract implementation.
+// TODO(eth-implicit) Replace this function (and wat dependency) with a real Wallet Contract implementation.
 pub fn wallet_contract_placeholder() -> ContractCode {
     let code = wat::parse_str(r#"(module (func (export "main")))"#);
     ContractCode::new(code.unwrap().to_vec(), None)
@@ -480,9 +479,9 @@ pub fn wallet_contract_placeholder() -> ContractCode {
 
 /// From `near-account-id` version `1.0.0-alpha.2`, `is_implicit` returns true for ETH-implicit accounts.
 /// This function is a wrapper for `is_implicit` method so that we can easily differentiate its behavior
-/// based on the protocol version.
-pub fn account_is_implicit(account_id: &AccountId, protocol_version: ProtocolVersion) -> bool {
-    if checked_feature!("stable", EthImplicit, protocol_version) {
+/// based on whether ETH-implicit accounts are enabled.
+pub fn account_is_implicit(account_id: &AccountId, eth_implicit_accounts_enabled: bool) -> bool {
+    if eth_implicit_accounts_enabled {
         account_id.get_account_type().is_implicit()
     } else {
         account_id.get_account_type() == AccountType::NearImplicitAccount

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -490,6 +490,7 @@ pub fn account_is_implicit(account_id: &AccountId, protocol_version: ProtocolVer
 }
 
 /// Derives `AccountId` from `PublicKey`.
+/// If the key type is ED25519, returns hex-encoded copy of the key.
 /// If the key type is SECP256K1, returns '0x' + keccak256(public_key)[12:32].hex().
 pub fn derive_account_id_from_public_key(public_key: &PublicKey) -> AccountId {
     match public_key.key_type() {

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -18,7 +18,7 @@ use crate::version::{
     CREATE_RECEIPT_ID_SWITCH_TO_CURRENT_BLOCK_VERSION,
 };
 
-use near_crypto::{KeyType, PublicKey};
+use near_crypto::{ED25519PublicKey, Secp256K1PublicKey};
 use near_primitives_core::account::id::{AccountId, AccountType};
 use near_vm_runner::ContractCode;
 
@@ -489,38 +489,39 @@ pub fn account_is_implicit(account_id: &AccountId, protocol_version: ProtocolVer
     }
 }
 
-/// Derives `AccountId` from `PublicKey`.
-/// If the key type is ED25519, returns hex-encoded copy of the key.
-/// If the key type is SECP256K1, returns '0x' + keccak256(public_key)[12:32].hex().
-pub fn derive_account_id_from_public_key(public_key: &PublicKey) -> AccountId {
-    match public_key.key_type() {
-        KeyType::ED25519 => hex::encode(public_key.key_data()).parse().unwrap(),
-        KeyType::SECP256K1 => {
-            use sha3::Digest;
-            let pk_hash = sha3::Keccak256::digest(&public_key.key_data());
-            format!("0x{}", hex::encode(&pk_hash[12..32])).parse().unwrap()
-        }
-    }
+/// Returns hex-encoded copy of the public key.
+/// This is a NEAR-implicit account ID which can be controlled by the corresponding ED25519 private key.
+pub fn derive_near_implicit_account_id(public_key: &ED25519PublicKey) -> AccountId {
+    hex::encode(public_key).parse().unwrap()
+}
+
+/// Returns '0x' + keccak256(public_key)[12:32].hex().
+/// This is an ETH-implicit account ID which can be controlled by the corresponding Secp256K1 private key.
+pub fn derive_eth_implicit_account_id(public_key: &Secp256K1PublicKey) -> AccountId {
+    use sha3::Digest;
+    let pk_hash = sha3::Keccak256::digest(&public_key);
+    format!("0x{}", hex::encode(&pk_hash[12..32])).parse().unwrap()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use near_crypto::{KeyType, PublicKey};
 
     #[test]
-    fn test_derive_account_id_from_ed25519_public_key() {
+    fn test_derive_near_implicit_account_id() {
         let public_key = PublicKey::from_seed(KeyType::ED25519, "test");
         let expected: AccountId =
             "bb4dc639b212e075a751685b26bdcea5920a504181ff2910e8549742127092a0".parse().unwrap();
-        let account_id = derive_account_id_from_public_key(&public_key);
+        let account_id = derive_near_implicit_account_id(public_key.unwrap_as_ed25519());
         assert_eq!(account_id, expected);
     }
 
     #[test]
-    fn test_derive_account_id_from_secp256k1_public_key() {
+    fn test_derive_eth_implicit_account_id() {
         let public_key = PublicKey::from_seed(KeyType::SECP256K1, "test");
         let expected: AccountId = "0x96791e923f8cf697ad9c3290f2c9059f0231b24c".parse().unwrap();
-        let account_id = derive_account_id_from_public_key(&public_key);
+        let account_id = derive_eth_implicit_account_id(public_key.unwrap_as_secp256k1());
         assert_eq!(account_id, expected);
     }
 

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -2561,6 +2561,8 @@ pub struct VMConfigView {
     pub alt_bn128: bool,
     /// See [`VMConfig::function_call_weight`].
     pub function_call_weight: bool,
+    /// See [`VMConfig::eth_implicit_accounts`].
+    pub eth_implicit_accounts: bool,
 
     /// Describes limits for VM and Runtime.
     ///
@@ -2585,6 +2587,7 @@ impl From<near_vm_runner::logic::Config> for VMConfigView {
             alt_bn128: config.alt_bn128,
             function_call_weight: config.function_call_weight,
             vm_kind: config.vm_kind,
+            eth_implicit_accounts: config.eth_implicit_accounts,
         }
     }
 }
@@ -2605,6 +2608,7 @@ impl From<VMConfigView> for near_vm_runner::logic::Config {
             alt_bn128: view.alt_bn128,
             function_call_weight: view.function_call_weight,
             vm_kind: view.vm_kind,
+            eth_implicit_accounts: view.eth_implicit_accounts,
         }
     }
 }

--- a/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
@@ -12,14 +12,15 @@ use near_network::shards_manager::ShardsManagerRequestFromNetwork;
 use near_network::types::{NetworkRequests, PeerManagerMessageRequest};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::account::AccessKey;
-use near_primitives::errors::InvalidTxError;
+use near_primitives::checked_feature;
+use near_primitives::errors::{InvalidAccessKeyError, InvalidTxError};
 use near_primitives::runtime::config_store::RuntimeConfigStore;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::ChunkHash;
-use near_primitives::transaction::SignedTransaction;
+use near_primitives::transaction::{Action, AddKeyAction, DeployContractAction, SignedTransaction};
 use near_primitives::types::{AccountId, BlockHeight};
-use near_primitives::utils::derive_account_id_from_public_key;
-use near_primitives::version::{ProtocolFeature, ProtocolVersion};
+use near_primitives::utils::{derive_account_id_from_public_key, wallet_contract_placeholder};
+use near_primitives::version::{ProtocolFeature, ProtocolVersion, PROTOCOL_VERSION};
 use near_primitives::views::FinalExecutionStatus;
 use nearcore::config::GenesisExt;
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
@@ -200,7 +201,7 @@ fn get_status_of_tx_hash_collision_for_implicit_account(
 
 /// Test that duplicate transactions from NEAR-implicit accounts are properly rejected.
 #[test]
-fn test_transaction_hash_collision_for_implicit_account_fail() {
+fn test_transaction_hash_collision_for_near_implicit_account_fail() {
     let protocol_version = ProtocolFeature::AccessKeyNonceForImplicitAccounts.protocol_version();
     let secret_key = SecretKey::from_seed(KeyType::ED25519, "test");
     let implicit_account_id = derive_account_id_from_public_key(&secret_key.public_key());
@@ -216,7 +217,7 @@ fn test_transaction_hash_collision_for_implicit_account_fail() {
 
 /// Test that duplicate transactions from NEAR-implicit accounts are not rejected until protocol upgrade.
 #[test]
-fn test_transaction_hash_collision_for_implicit_account_ok() {
+fn test_transaction_hash_collision_for_near_implicit_account_ok() {
     let protocol_version =
         ProtocolFeature::AccessKeyNonceForImplicitAccounts.protocol_version() - 1;
     let secret_key = SecretKey::from_seed(KeyType::ED25519, "test");
@@ -229,6 +230,103 @@ fn test_transaction_hash_collision_for_implicit_account_ok() {
         ),
         ProcessTxResponse::ValidTx
     );
+}
+
+/// Test that transactions from ETH-implicit accounts are rejected.
+#[test]
+fn test_transaction_from_eth_implicit_account_fail() {
+    if !checked_feature!("stable", EthImplicit, PROTOCOL_VERSION) {
+        return;
+    }
+    let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut env = TestEnv::builder(ChainGenesis::test())
+        .real_epoch_managers(&genesis.config)
+        .nightshade_runtimes(&genesis)
+        .build();
+    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
+    let deposit_for_account_creation = 10u128.pow(23);
+    let mut height = 1;
+    let blocks_number = 5;
+    let signer1 = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+
+    let secret_key = SecretKey::from_seed(KeyType::SECP256K1, "test");
+    let public_key = secret_key.public_key();
+    let implicit_account_id = derive_account_id_from_public_key(&public_key);
+    let implicit_account_signer =
+        InMemorySigner::from_secret_key(implicit_account_id.clone(), secret_key);
+
+    // Send money to ETH-implicit account, invoking its creation.
+    let send_money_tx = SignedTransaction::send_money(
+        1,
+        "test1".parse().unwrap(),
+        implicit_account_id.clone(),
+        &signer1,
+        deposit_for_account_creation,
+        *genesis_block.hash(),
+    );
+    // Check for tx success status and get new block height.
+    height = check_tx_processing(&mut env, send_money_tx, height, blocks_number);
+    let block = env.clients[0].chain.get_block_by_height(height - 1).unwrap();
+
+    // Try to send money from ETH-implicit account using `(block_height - 1) * 1e6` as a nonce.
+    // That would be a good nonce for any access key, but the transaction should fail nonetheless because there is no access key.
+    let nonce = (height - 1) * AccessKey::ACCESS_KEY_NONCE_RANGE_MULTIPLIER;
+    let send_money_from_implicit_account_tx = SignedTransaction::send_money(
+        nonce,
+        implicit_account_id.clone(),
+        "test0".parse().unwrap(),
+        &implicit_account_signer,
+        100,
+        *block.hash(),
+    );
+    let response = env.clients[0].process_tx(send_money_from_implicit_account_tx, false, false);
+    let expected_tx_error = ProcessTxResponse::InvalidTx(InvalidTxError::InvalidAccessKeyError(
+        InvalidAccessKeyError::AccessKeyNotFound {
+            account_id: implicit_account_id.clone(),
+            public_key: public_key.clone(),
+        },
+    ));
+    assert_eq!(response, expected_tx_error);
+
+    // Try to delete ETH-implicit account.
+    let delete_implicit_account_tx = SignedTransaction::delete_account(
+        nonce,
+        implicit_account_id.clone(),
+        implicit_account_id.clone(),
+        "test0".parse().unwrap(),
+        &implicit_account_signer,
+        *block.hash(),
+    );
+    let response = env.clients[0].process_tx(delete_implicit_account_tx, false, false);
+    assert_eq!(response, expected_tx_error);
+
+    // Try to add an access key to the ETH-implicit account.
+    let add_access_key_to_implicit_account_tx = SignedTransaction::from_actions(
+        nonce,
+        implicit_account_id.clone(),
+        implicit_account_id.clone(),
+        &implicit_account_signer,
+        vec![Action::AddKey(Box::new(AddKeyAction {
+            public_key,
+            access_key: AccessKey::full_access(),
+        }))],
+        *block.hash(),
+    );
+    let response = env.clients[0].process_tx(add_access_key_to_implicit_account_tx, false, false);
+    assert_eq!(response, expected_tx_error);
+
+    // Try to deploy the Wallet Contract again to the ETH-implicit account.
+    let wallet_contract_code = wallet_contract_placeholder().code().to_vec();
+    let add_access_key_to_implicit_account_tx = SignedTransaction::from_actions(
+        nonce,
+        implicit_account_id.clone(),
+        implicit_account_id,
+        &implicit_account_signer,
+        vec![Action::DeployContract(DeployContractAction { code: wallet_contract_code })],
+        *block.hash(),
+    );
+    let response = env.clients[0].process_tx(add_access_key_to_implicit_account_tx, false, false);
+    assert_eq!(response, expected_tx_error);
 }
 
 /// Test that chunks with transactions that have expired are considered invalid.

--- a/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
@@ -18,7 +18,7 @@ use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockHeight};
-use near_primitives::utils::derive_near_implicit_account_id;
+use near_primitives::utils::derive_account_id_from_public_key;
 use near_primitives::version::{ProtocolFeature, ProtocolVersion};
 use near_primitives::views::FinalExecutionStatus;
 use nearcore::config::GenesisExt;
@@ -203,8 +203,7 @@ fn get_status_of_tx_hash_collision_for_implicit_account(
 fn test_transaction_hash_collision_for_implicit_account_fail() {
     let protocol_version = ProtocolFeature::AccessKeyNonceForImplicitAccounts.protocol_version();
     let secret_key = SecretKey::from_seed(KeyType::ED25519, "test");
-    let implicit_account_id =
-        derive_near_implicit_account_id(secret_key.public_key().unwrap_as_ed25519());
+    let implicit_account_id = derive_account_id_from_public_key(&secret_key.public_key());
     let implicit_account_signer = InMemorySigner::from_secret_key(implicit_account_id, secret_key);
     assert_matches!(
         get_status_of_tx_hash_collision_for_implicit_account(
@@ -221,8 +220,7 @@ fn test_transaction_hash_collision_for_implicit_account_ok() {
     let protocol_version =
         ProtocolFeature::AccessKeyNonceForImplicitAccounts.protocol_version() - 1;
     let secret_key = SecretKey::from_seed(KeyType::ED25519, "test");
-    let implicit_account_id =
-        derive_near_implicit_account_id(secret_key.public_key().unwrap_as_ed25519());
+    let implicit_account_id = derive_account_id_from_public_key(&secret_key.public_key());
     let implicit_account_signer = InMemorySigner::from_secret_key(implicit_account_id, secret_key);
     assert_matches!(
         get_status_of_tx_hash_collision_for_implicit_account(

--- a/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
@@ -19,7 +19,9 @@ use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::transaction::{Action, AddKeyAction, DeployContractAction, SignedTransaction};
 use near_primitives::types::{AccountId, BlockHeight};
-use near_primitives::utils::{derive_account_id_from_public_key, wallet_contract_placeholder};
+use near_primitives::utils::{
+    derive_eth_implicit_account_id, derive_near_implicit_account_id, wallet_contract_placeholder,
+};
 use near_primitives::version::{ProtocolFeature, ProtocolVersion, PROTOCOL_VERSION};
 use near_primitives::views::FinalExecutionStatus;
 use nearcore::config::GenesisExt;
@@ -205,7 +207,8 @@ fn get_status_of_tx_hash_collision_for_near_implicit_account(
 fn test_transaction_hash_collision_for_near_implicit_account_fail() {
     let protocol_version = ProtocolFeature::AccessKeyNonceForImplicitAccounts.protocol_version();
     let secret_key = SecretKey::from_seed(KeyType::ED25519, "test");
-    let near_implicit_account_id = derive_account_id_from_public_key(&secret_key.public_key());
+    let public_key = secret_key.public_key();
+    let near_implicit_account_id = derive_near_implicit_account_id(public_key.unwrap_as_ed25519());
     let near_implicit_account_signer =
         InMemorySigner::from_secret_key(near_implicit_account_id, secret_key);
     assert_matches!(
@@ -223,7 +226,8 @@ fn test_transaction_hash_collision_for_near_implicit_account_ok() {
     let protocol_version =
         ProtocolFeature::AccessKeyNonceForImplicitAccounts.protocol_version() - 1;
     let secret_key = SecretKey::from_seed(KeyType::ED25519, "test");
-    let near_implicit_account_id = derive_account_id_from_public_key(&secret_key.public_key());
+    let public_key = secret_key.public_key();
+    let near_implicit_account_id = derive_near_implicit_account_id(public_key.unwrap_as_ed25519());
     let near_implicit_account_signer =
         InMemorySigner::from_secret_key(near_implicit_account_id, secret_key);
     assert_matches!(
@@ -254,7 +258,7 @@ fn test_transaction_from_eth_implicit_account_fail() {
 
     let secret_key = SecretKey::from_seed(KeyType::SECP256K1, "test");
     let public_key = secret_key.public_key();
-    let eth_implicit_account_id = derive_account_id_from_public_key(&public_key);
+    let eth_implicit_account_id = derive_eth_implicit_account_id(public_key.unwrap_as_secp256k1());
     let eth_implicit_account_signer =
         InMemorySigner::from_secret_key(eth_implicit_account_id.clone(), secret_key);
 

--- a/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
@@ -242,7 +242,7 @@ fn test_transaction_hash_collision_for_near_implicit_account_ok() {
 /// Test that transactions from ETH-implicit accounts are rejected.
 #[test]
 fn test_transaction_from_eth_implicit_account_fail() {
-    if !checked_feature!("stable", EthImplicit, PROTOCOL_VERSION) {
+    if !checked_feature!("stable", EthImplicitAccounts, PROTOCOL_VERSION) {
         return;
     }
     let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);

--- a/integration-tests/src/tests/client/features/delegate_action.rs
+++ b/integration-tests/src/tests/client/features/delegate_action.rs
@@ -142,7 +142,7 @@ fn check_meta_tx_execution(
     let user_pubk = match sender.get_account_type() {
         AccountType::NearImplicitAccount => PublicKey::from_near_implicit_account(&sender).unwrap(),
         AccountType::EthImplicitAccount => {
-            if checked_feature!("stable", EthImplicit, protocol_version) {
+            if checked_feature!("stable", EthImplicitAccounts, protocol_version) {
                 // ETH-implicit accounts must not have access key.
                 panic!("No access keys");
             } else {
@@ -816,7 +816,7 @@ fn meta_tx_create_near_implicit_account_fails() {
 
 #[test]
 fn meta_tx_create_eth_implicit_account_fails() {
-    if !checked_feature!("stable", EthImplicit, PROTOCOL_VERSION) {
+    if !checked_feature!("stable", EthImplicitAccounts, PROTOCOL_VERSION) {
         return;
     }
     meta_tx_create_implicit_account_fails(eth_implicit_test_account());
@@ -863,7 +863,7 @@ fn meta_tx_create_and_use_near_implicit_account() {
 
 #[test]
 fn meta_tx_create_and_use_eth_implicit_account() {
-    if !checked_feature!("stable", EthImplicit, PROTOCOL_VERSION) {
+    if !checked_feature!("stable", EthImplicitAccounts, PROTOCOL_VERSION) {
         return;
     }
     meta_tx_create_and_use_implicit_account(eth_implicit_test_account());
@@ -941,7 +941,7 @@ fn meta_tx_create_near_implicit_account() {
 
 #[test]
 fn meta_tx_create_eth_implicit_account() {
-    if !checked_feature!("stable", EthImplicit, PROTOCOL_VERSION) {
+    if !checked_feature!("stable", EthImplicitAccounts, PROTOCOL_VERSION) {
         return;
     }
     meta_tx_create_implicit_account(eth_implicit_test_account());

--- a/integration-tests/src/tests/client/features/delegate_action.rs
+++ b/integration-tests/src/tests/client/features/delegate_action.rs
@@ -12,18 +12,21 @@ use near_crypto::{KeyType, PublicKey, Signer};
 use near_primitives::account::{
     id::AccountType, AccessKey, AccessKeyPermission, FunctionCallPermission,
 };
+use near_primitives::checked_feature;
 use near_primitives::config::ActionCosts;
 use near_primitives::errors::{
     ActionError, ActionErrorKind, ActionsValidationError, InvalidAccessKeyError, InvalidTxError,
     TxExecutionError,
 };
-use near_primitives::test_utils::{create_user_test_signer, near_implicit_test_account};
+use near_primitives::test_utils::{
+    create_user_test_signer, eth_implicit_test_account, near_implicit_test_account,
+};
 use near_primitives::transaction::{
     Action, AddKeyAction, CreateAccountAction, DeleteAccountAction, DeleteKeyAction,
     DeployContractAction, FunctionCallAction, StakeAction, TransferAction,
 };
 use near_primitives::types::{AccountId, Balance};
-use near_primitives::version::{ProtocolFeature, ProtocolVersion};
+use near_primitives::version::{ProtocolFeature, ProtocolVersion, PROTOCOL_VERSION};
 use near_primitives::views::{
     AccessKeyPermissionView, ExecutionStatusView, FinalExecutionOutcomeView, FinalExecutionStatus,
 };
@@ -121,6 +124,7 @@ fn check_meta_tx_execution(
     receiver: AccountId,
 ) -> (FinalExecutionOutcomeView, i128, i128, i128) {
     let node_user = node.user();
+    let protocol_version = node.genesis().config.protocol_version;
 
     assert_eq!(
         relayer,
@@ -137,7 +141,14 @@ fn check_meta_tx_execution(
         .nonce;
     let user_pubk = match sender.get_account_type() {
         AccountType::NearImplicitAccount => PublicKey::from_near_implicit_account(&sender).unwrap(),
-        AccountType::EthImplicitAccount => PublicKey::from_seed(KeyType::ED25519, sender.as_ref()),
+        AccountType::EthImplicitAccount => {
+            if checked_feature!("stable", EthImplicit, protocol_version) {
+                // Eth-implicit accounts must not have access key.
+                panic!("No access keys");
+            } else {
+                PublicKey::from_seed(KeyType::ED25519, sender.as_ref())
+            }
+        }
         AccountType::NamedAccount => PublicKey::from_seed(KeyType::ED25519, sender.as_ref()),
     };
     let user_nonce_before = node_user.get_access_key(&sender, &user_pubk).unwrap().nonce;
@@ -803,12 +814,22 @@ fn meta_tx_create_near_implicit_account_fails() {
     meta_tx_create_implicit_account_fails(near_implicit_test_account());
 }
 
+#[test]
+fn meta_tx_create_eth_implicit_account_fails() {
+    if !checked_feature!("stable", EthImplicit, PROTOCOL_VERSION) {
+        return;
+    }
+    meta_tx_create_implicit_account_fails(eth_implicit_test_account());
+}
+
 /// Try creating an implicit account with a meta tx transfer and use the account
 /// in the same meta transaction.
 ///
 /// This is expected to fail with `AccountDoesNotExist`, known limitation of NEP-366.
-/// It only works with accounts that already exists because it needs to do a
-/// nonce check against the access key, which can only exist if the account exists.
+/// In case of Near-implicit accounts it only works with accounts that already exist
+/// because it needs to do a nonce check against the access key,
+/// which can only exist if the account exists.
+/// In case of Eth-implicit accounts the access key does not exist anyway.
 fn meta_tx_create_and_use_implicit_account(new_account: AccountId) {
     let relayer = bob_account();
     let sender = alice_account();
@@ -840,12 +861,24 @@ fn meta_tx_create_and_use_near_implicit_account() {
     meta_tx_create_and_use_implicit_account(near_implicit_test_account());
 }
 
-/// Creating an implicit account with a meta tx transfer and use the account in
+#[test]
+fn meta_tx_create_and_use_eth_implicit_account() {
+    if !checked_feature!("stable", EthImplicit, PROTOCOL_VERSION) {
+        return;
+    }
+    meta_tx_create_and_use_implicit_account(eth_implicit_test_account());
+}
+
+/// Creating an implicit account with a meta tx transfer and try using the account in
 /// a second meta transaction.
 ///
 /// Creation through a meta tx should work as normal, it's just that the relayer
 /// pays for the storage and the user could delete the account and cash in,
 /// hence this workflow is not ideal from all circumstances.
+///
+/// Using the account should only work for Near-implicit accounts,
+/// as Eth-implicit accounts do not have access keys
+/// and they can only be used by calling associated smart contract.
 fn meta_tx_create_implicit_account(new_account: AccountId) {
     let relayer = bob_account();
     let sender = alice_account();
@@ -860,8 +893,8 @@ fn meta_tx_create_implicit_account(new_account: AccountId) {
 
     let tx_cost = match new_account.get_account_type() {
         AccountType::NearImplicitAccount => fee_helper.create_account_transfer_full_key_cost(),
-        AccountType::EthImplicitAccount => panic!("must be near-implicit"),
-        AccountType::NamedAccount => panic!("must be near-implicit"),
+        AccountType::EthImplicitAccount => fee_helper.create_account_transfer_cost(),
+        AccountType::NamedAccount => panic!("must be implicit"),
     };
     check_meta_tx_no_fn_call(
         &node,
@@ -878,6 +911,13 @@ fn meta_tx_create_implicit_account(new_account: AccountId) {
     let balance = node.view_balance(&new_account).expect("failed looking up balance");
     assert_eq!(balance, initial_amount);
 
+    if new_account.get_account_type() == AccountType::EthImplicitAccount {
+        // ETH-implicit account must not have access key added.
+        assert!(node.user().is_locked(&new_account).unwrap());
+        // We will not attempt to make a transfer from this account.
+        return;
+    }
+
     // Now test we can use this account in a meta transaction that sends back half the tokens to alice.
     let transfer_amount = initial_amount / 2;
     let actions = vec![Action::Transfer(TransferAction { deposit: transfer_amount })];
@@ -887,19 +927,22 @@ fn meta_tx_create_implicit_account(new_account: AccountId) {
         actions,
         tx_cost,
         transfer_amount,
-        new_account.clone(),
+        new_account,
         relayer,
         sender,
     )
     .assert_success();
-
-    // balance of the new account should NOT change, the relayer pays for it!
-    // (note: relayer balance checks etc are done in the shared checker function)
-    let balance = node.view_balance(&new_account).expect("failed looking up balance");
-    assert_eq!(balance, initial_amount);
 }
 
 #[test]
 fn meta_tx_create_near_implicit_account() {
     meta_tx_create_implicit_account(near_implicit_test_account());
+}
+
+#[test]
+fn meta_tx_create_eth_implicit_account() {
+    if !checked_feature!("stable", EthImplicit, PROTOCOL_VERSION) {
+        return;
+    }
+    meta_tx_create_implicit_account(eth_implicit_test_account());
 }

--- a/integration-tests/src/tests/client/features/delegate_action.rs
+++ b/integration-tests/src/tests/client/features/delegate_action.rs
@@ -143,8 +143,7 @@ fn check_meta_tx_execution(
         AccountType::NearImplicitAccount => PublicKey::from_near_implicit_account(&sender).unwrap(),
         AccountType::EthImplicitAccount => {
             if checked_feature!("stable", EthImplicitAccounts, protocol_version) {
-                // ETH-implicit accounts must not have access key.
-                panic!("No access keys");
+                panic!("ETH-implicit accounts must not have access key");
             } else {
                 PublicKey::from_seed(KeyType::ED25519, sender.as_ref())
             }

--- a/integration-tests/src/tests/client/features/delegate_action.rs
+++ b/integration-tests/src/tests/client/features/delegate_action.rs
@@ -143,7 +143,7 @@ fn check_meta_tx_execution(
         AccountType::NearImplicitAccount => PublicKey::from_near_implicit_account(&sender).unwrap(),
         AccountType::EthImplicitAccount => {
             if checked_feature!("stable", EthImplicit, protocol_version) {
-                // Eth-implicit accounts must not have access key.
+                // ETH-implicit accounts must not have access key.
                 panic!("No access keys");
             } else {
                 PublicKey::from_seed(KeyType::ED25519, sender.as_ref())
@@ -826,10 +826,10 @@ fn meta_tx_create_eth_implicit_account_fails() {
 /// in the same meta transaction.
 ///
 /// This is expected to fail with `AccountDoesNotExist`, known limitation of NEP-366.
-/// In case of Near-implicit accounts it only works with accounts that already exist
+/// In case of NEAR-implicit accounts it only works with accounts that already exist
 /// because it needs to do a nonce check against the access key,
 /// which can only exist if the account exists.
-/// In case of Eth-implicit accounts the access key does not exist anyway.
+/// In case of ETH-implicit accounts the access key does not exist anyway.
 fn meta_tx_create_and_use_implicit_account(new_account: AccountId) {
     let relayer = bob_account();
     let sender = alice_account();
@@ -876,8 +876,8 @@ fn meta_tx_create_and_use_eth_implicit_account() {
 /// pays for the storage and the user could delete the account and cash in,
 /// hence this workflow is not ideal from all circumstances.
 ///
-/// Using the account should only work for Near-implicit accounts,
-/// as Eth-implicit accounts do not have access keys
+/// Using the account should only work for NEAR-implicit accounts,
+/// as ETH-implicit accounts do not have access keys
 /// and they can only be used by calling associated smart contract.
 fn meta_tx_create_implicit_account(new_account: AccountId) {
     let relayer = bob_account();

--- a/integration-tests/src/tests/client/features/restrict_tla.rs
+++ b/integration-tests/src/tests/client/features/restrict_tla.rs
@@ -23,11 +23,11 @@ fn test_create_top_level_accounts() {
         .build();
 
     // These accounts cannot be created because they are top level accounts that are not implicit.
-    // Note that implicit accounts have to be 64 characters long.
+    // Note that implicit accounts have to be 64 or 42 (if starts with '0x') characters long.
     let top_level_accounts = [
-        "0x06012c8cf97bead5deae237070f9587f8e7a266d",
-        "0x5e97870f263700f46aa00d967821199b9bc5a120",
-        "0x0000000000000000000000000000000000000000",
+        "0x06012c8cf97bead5deae237070f9587f8e7a266da",
+        "0a5e97870f263700f46aa00d967821199b9bc5a120",
+        "0x000000000000000000000000000000000000000",
         "alice",
         "thisisaveryverylongtoplevelaccount",
     ];

--- a/integration-tests/src/tests/standard_cases/mod.rs
+++ b/integration-tests/src/tests/standard_cases/mod.rs
@@ -371,7 +371,7 @@ pub fn transfer_tokens_implicit_account(node: impl Node, public_key: PublicKey) 
         }
         AccountType::EthImplicitAccount => {
             // A transfer to ETH-implicit address does not create access key.
-            assert!(node_user.get_access_key(&receiver_id, &public_key).is_err());
+            assert!(view_access_key.is_err());
         }
         AccountType::NamedAccount => std::panic!("must be implicit"),
     }

--- a/integration-tests/src/tests/standard_cases/mod.rs
+++ b/integration-tests/src/tests/standard_cases/mod.rs
@@ -16,7 +16,7 @@ use near_primitives::errors::{
 };
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::types::{AccountId, Balance, TrieNodesCount};
-use near_primitives::utils::derive_account_id_from_public_key;
+use near_primitives::utils::{derive_eth_implicit_account_id, derive_near_implicit_account_id};
 use near_primitives::views::{
     AccessKeyView, AccountView, ExecutionMetadataView, FinalExecutionOutcomeView,
     FinalExecutionStatus,
@@ -336,7 +336,11 @@ pub fn transfer_tokens_implicit_account(node: impl Node, public_key: PublicKey) 
     let root = node_user.get_state_root();
     let tokens_used = 10u128.pow(25);
     let fee_helper = fee_helper(&node);
-    let receiver_id = derive_account_id_from_public_key(&public_key);
+
+    let receiver_id = match public_key.key_type() {
+        KeyType::ED25519 => derive_near_implicit_account_id(public_key.unwrap_as_ed25519()),
+        KeyType::SECP256K1 => derive_eth_implicit_account_id(public_key.unwrap_as_secp256k1()),
+    };
 
     let transfer_cost = match receiver_id.get_account_type() {
         AccountType::NearImplicitAccount => fee_helper.create_account_transfer_full_key_cost(),
@@ -404,7 +408,11 @@ pub fn trying_to_create_implicit_account(node: impl Node, public_key: PublicKey)
     let root = node_user.get_state_root();
     let tokens_used = 10u128.pow(25);
     let fee_helper = fee_helper(&node);
-    let receiver_id = derive_account_id_from_public_key(&public_key);
+
+    let receiver_id = match public_key.key_type() {
+        KeyType::ED25519 => derive_near_implicit_account_id(public_key.unwrap_as_ed25519()),
+        KeyType::SECP256K1 => derive_eth_implicit_account_id(public_key.unwrap_as_secp256k1()),
+    };
 
     let transaction_result = node_user
         .create_account(account_id.clone(), receiver_id.clone(), public_key, tokens_used)

--- a/integration-tests/src/tests/standard_cases/mod.rs
+++ b/integration-tests/src/tests/standard_cases/mod.rs
@@ -16,7 +16,7 @@ use near_primitives::errors::{
 };
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::types::{AccountId, Balance, TrieNodesCount};
-use near_primitives::utils::derive_near_implicit_account_id;
+use near_primitives::utils::derive_account_id_from_public_key;
 use near_primitives::views::{
     AccessKeyView, AccountView, ExecutionMetadataView, FinalExecutionOutcomeView,
     FinalExecutionStatus,
@@ -336,12 +336,12 @@ pub fn transfer_tokens_implicit_account(node: impl Node, public_key: PublicKey) 
     let root = node_user.get_state_root();
     let tokens_used = 10u128.pow(25);
     let fee_helper = fee_helper(&node);
-    let receiver_id = derive_near_implicit_account_id(public_key.unwrap_as_ed25519());
+    let receiver_id = derive_account_id_from_public_key(&public_key);
 
     let transfer_cost = match receiver_id.get_account_type() {
         AccountType::NearImplicitAccount => fee_helper.create_account_transfer_full_key_cost(),
-        AccountType::EthImplicitAccount => std::panic!("must be near-implicit"),
-        AccountType::NamedAccount => std::panic!("must be near-implicit"),
+        AccountType::EthImplicitAccount => fee_helper.create_account_transfer_cost(),
+        AccountType::NamedAccount => std::panic!("must be implicit"),
     };
 
     let transaction_result =
@@ -369,8 +369,11 @@ pub fn transfer_tokens_implicit_account(node: impl Node, public_key: PublicKey) 
         AccountType::NearImplicitAccount => {
             assert_eq!(view_access_key.unwrap(), AccessKey::full_access().into());
         }
-        AccountType::EthImplicitAccount => std::panic!("must be near-implicit"),
-        AccountType::NamedAccount => std::panic!("must be near-implicit"),
+        AccountType::EthImplicitAccount => {
+            // A transfer to ETH-implicit address does not create access key.
+            assert!(node_user.get_access_key(&receiver_id, &public_key).is_err());
+        }
+        AccountType::NamedAccount => std::panic!("must be implicit"),
     }
 
     let transaction_result =
@@ -401,31 +404,30 @@ pub fn trying_to_create_implicit_account(node: impl Node, public_key: PublicKey)
     let root = node_user.get_state_root();
     let tokens_used = 10u128.pow(25);
     let fee_helper = fee_helper(&node);
-    let receiver_id = derive_near_implicit_account_id(public_key.unwrap_as_ed25519());
+    let receiver_id = derive_account_id_from_public_key(&public_key);
 
     let transaction_result = node_user
-        .create_account(
-            account_id.clone(),
-            receiver_id.clone(),
-            node.signer().public_key(),
-            tokens_used,
-        )
+        .create_account(account_id.clone(), receiver_id.clone(), public_key, tokens_used)
         .unwrap();
+
+    let create_account_fee = fee_helper.cfg().fee(ActionCosts::create_account).send_fee(false);
+    let add_access_key_fee = fee_helper
+        .cfg()
+        .fee(near_primitives::config::ActionCosts::add_full_access_key)
+        .send_fee(false);
 
     let cost = match receiver_id.get_account_type() {
         AccountType::NearImplicitAccount => {
-            let fail_cost =
-                fee_helper.create_account_transfer_full_key_cost_fail_on_create_account();
-            let create_account_fee =
-                fee_helper.cfg().fee(ActionCosts::create_account).send_fee(false);
-            let add_access_key_fee = fee_helper
-                .cfg()
-                .fee(near_primitives::config::ActionCosts::add_full_access_key)
-                .send_fee(false);
-            fail_cost + fee_helper.gas_to_balance(create_account_fee + add_access_key_fee)
+            fee_helper.create_account_transfer_full_key_cost_fail_on_create_account()
+                + fee_helper.gas_to_balance(create_account_fee + add_access_key_fee)
         }
-        AccountType::EthImplicitAccount => std::panic!("must be near-implicit"),
-        AccountType::NamedAccount => std::panic!("must be near-implicit"),
+        AccountType::EthImplicitAccount => {
+            // This test uses `node_user.create_account` method that is normally used for NamedAccounts and should fail here.
+            fee_helper.create_account_transfer_full_key_cost_fail_on_create_account()
+                // We add this fee analogously to the NEAR-implicit match arm above (without `add_access_key_fee`).
+                + fee_helper.gas_to_balance(create_account_fee)
+        }
+        AccountType::NamedAccount => std::panic!("must be implicit"),
     };
 
     assert_eq!(

--- a/integration-tests/src/tests/standard_cases/runtime.rs
+++ b/integration-tests/src/tests/standard_cases/runtime.rs
@@ -125,7 +125,7 @@ fn test_transfer_tokens_near_implicit_account_runtime() {
 
 #[test]
 fn test_transfer_tokens_eth_implicit_account_runtime() {
-    if !checked_feature!("stable", EthImplicit, PROTOCOL_VERSION) {
+    if !checked_feature!("stable", EthImplicitAccounts, PROTOCOL_VERSION) {
         return;
     }
     let node = create_runtime_node();
@@ -142,7 +142,7 @@ fn test_trying_to_create_near_implicit_account_runtime() {
 
 #[test]
 fn test_trying_to_create_eth_implicit_account_runtime() {
-    if !checked_feature!("stable", EthImplicit, PROTOCOL_VERSION) {
+    if !checked_feature!("stable", EthImplicitAccounts, PROTOCOL_VERSION) {
         return;
     }
     let node = create_runtime_node();

--- a/integration-tests/src/tests/standard_cases/runtime.rs
+++ b/integration-tests/src/tests/standard_cases/runtime.rs
@@ -1,7 +1,10 @@
 use crate::node::RuntimeNode;
 use crate::tests::standard_cases::*;
 use near_chain_configs::Genesis;
+use near_crypto::SecretKey;
+use near_primitives::checked_feature;
 use near_primitives::state_record::StateRecord;
+use near_primitives::version::PROTOCOL_VERSION;
 use nearcore::config::{GenesisExt, TESTING_INIT_BALANCE};
 use testlib::runtime_utils::{add_test_contract, alice_account, bob_account};
 
@@ -121,10 +124,30 @@ fn test_transfer_tokens_near_implicit_account_runtime() {
 }
 
 #[test]
+fn test_transfer_tokens_eth_implicit_account_runtime() {
+    if !checked_feature!("stable", EthImplicit, PROTOCOL_VERSION) {
+        return;
+    }
+    let node = create_runtime_node();
+    let secret_key = SecretKey::from_seed(KeyType::SECP256K1, "test");
+    transfer_tokens_implicit_account(node, secret_key.public_key());
+}
+
+#[test]
 fn test_trying_to_create_near_implicit_account_runtime() {
     let node = create_runtime_node();
     let public_key = node.user().signer().public_key();
     trying_to_create_implicit_account(node, public_key);
+}
+
+#[test]
+fn test_trying_to_create_eth_implicit_account_runtime() {
+    if !checked_feature!("stable", EthImplicit, PROTOCOL_VERSION) {
+        return;
+    }
+    let node = create_runtime_node();
+    let secret_key = SecretKey::from_seed(KeyType::SECP256K1, "test");
+    trying_to_create_implicit_account(node, secret_key.public_key());
 }
 
 #[test]

--- a/integration-tests/src/user/mod.rs
+++ b/integration-tests/src/user/mod.rs
@@ -38,6 +38,9 @@ pub trait User {
 
     fn view_state(&self, account_id: &AccountId, prefix: &[u8]) -> Result<ViewStateResult, String>;
 
+    /// Returns whether the account is locked (has no access keys).
+    fn is_locked(&self, account_id: &AccountId) -> Result<bool, String>;
+
     fn view_call(
         &self,
         account_id: &AccountId,

--- a/integration-tests/src/user/rpc_user.rs
+++ b/integration-tests/src/user/rpc_user.rs
@@ -9,7 +9,7 @@ use near_crypto::{PublicKey, Signer};
 use near_jsonrpc::client::{new_client, JsonRpcClient};
 use near_jsonrpc_client::ChunkId;
 use near_jsonrpc_primitives::errors::ServerError;
-use near_jsonrpc_primitives::types::query::{RpcQueryRequest, RpcQueryResponse};
+use near_jsonrpc_primitives::types::query::{QueryResponseKind, RpcQueryRequest, RpcQueryResponse};
 use near_jsonrpc_primitives::types::transactions::{RpcTransactionStatusRequest, TransactionInfo};
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
@@ -70,9 +70,7 @@ impl User for RpcUser {
     fn view_account(&self, account_id: &AccountId) -> Result<AccountView, String> {
         let query = QueryRequest::ViewAccount { account_id: account_id.clone() };
         match self.query(query)?.kind {
-            near_jsonrpc_primitives::types::query::QueryResponseKind::ViewAccount(account_view) => {
-                Ok(account_view)
-            }
+            QueryResponseKind::ViewAccount(account_view) => Ok(account_view),
             _ => Err("Invalid type of response".into()),
         }
     }
@@ -84,9 +82,7 @@ impl User for RpcUser {
             include_proof: false,
         };
         match self.query(query)?.kind {
-            near_jsonrpc_primitives::types::query::QueryResponseKind::ViewState(
-                view_state_result,
-            ) => Ok(view_state_result),
+            QueryResponseKind::ViewState(view_state_result) => Ok(view_state_result),
             _ => Err("Invalid type of response".into()),
         }
     }
@@ -94,9 +90,7 @@ impl User for RpcUser {
     fn is_locked(&self, account_id: &AccountId) -> Result<bool, String> {
         let query = QueryRequest::ViewAccessKeyList { account_id: account_id.clone() };
         match self.query(query)?.kind {
-            near_jsonrpc_primitives::types::query::QueryResponseKind::AccessKeyList(
-                access_keys,
-            ) => Ok(access_keys.keys.is_empty()),
+            QueryResponseKind::AccessKeyList(access_keys) => Ok(access_keys.keys.is_empty()),
             _ => Err("Invalid type of response".into()),
         }
     }
@@ -104,9 +98,7 @@ impl User for RpcUser {
     fn view_contract_code(&self, account_id: &AccountId) -> Result<ContractCodeView, String> {
         let query = QueryRequest::ViewCode { account_id: account_id.clone() };
         match self.query(query)?.kind {
-            near_jsonrpc_primitives::types::query::QueryResponseKind::ViewCode(
-                contract_code_view,
-            ) => Ok(contract_code_view),
+            QueryResponseKind::ViewCode(contract_code_view) => Ok(contract_code_view),
             _ => Err("Invalid type of response".into()),
         }
     }
@@ -123,9 +115,7 @@ impl User for RpcUser {
             args: args.to_vec().into(),
         };
         match self.query(query)?.kind {
-            near_jsonrpc_primitives::types::query::QueryResponseKind::CallResult(call_result) => {
-                Ok(call_result)
-            }
+            QueryResponseKind::CallResult(call_result) => Ok(call_result),
             _ => Err("Invalid type of response".into()),
         }
     }
@@ -227,9 +217,7 @@ impl User for RpcUser {
             public_key: public_key.clone(),
         };
         match self.query(query)?.kind {
-            near_jsonrpc_primitives::types::query::QueryResponseKind::AccessKey(access_key) => {
-                Ok(access_key)
-            }
+            QueryResponseKind::AccessKey(access_key) => Ok(access_key),
             _ => Err("Invalid type of response".into()),
         }
     }

--- a/integration-tests/src/user/rpc_user.rs
+++ b/integration-tests/src/user/rpc_user.rs
@@ -91,6 +91,16 @@ impl User for RpcUser {
         }
     }
 
+    fn is_locked(&self, account_id: &AccountId) -> Result<bool, String> {
+        let query = QueryRequest::ViewAccessKeyList { account_id: account_id.clone() };
+        match self.query(query)?.kind {
+            near_jsonrpc_primitives::types::query::QueryResponseKind::AccessKeyList(
+                access_keys,
+            ) => Ok(access_keys.keys.is_empty()),
+            _ => Err("Invalid type of response".into()),
+        }
+    }
+
     fn view_contract_code(&self, account_id: &AccountId) -> Result<ContractCodeView, String> {
         let query = QueryRequest::ViewCode { account_id: account_id.clone() };
         match self.query(query)?.kind {

--- a/integration-tests/src/user/runtime_user.rs
+++ b/integration-tests/src/user/runtime_user.rs
@@ -252,6 +252,14 @@ impl User for RuntimeUser {
             .map_err(|err| err.to_string())
     }
 
+    fn is_locked(&self, account_id: &AccountId) -> Result<bool, String> {
+        let state_update = self.client.read().expect(POISONED_LOCK_ERR).get_state_update();
+        self.trie_viewer
+            .view_access_keys(&state_update, account_id)
+            .map(|access_keys| access_keys.is_empty())
+            .map_err(|err| err.to_string())
+    }
+
     fn view_call(
         &self,
         account_id: &AccountId,

--- a/runtime/near-vm-runner/src/config.rs
+++ b/runtime/near-vm-runner/src/config.rs
@@ -51,6 +51,9 @@ pub struct Config {
     /// Enable the `FunctionCallWeight` protocol feature.
     pub function_call_weight: bool,
 
+    /// Enable the `EthImplicitAccounts` protocol feature.
+    pub eth_implicit_accounts: bool,
+
     /// Describes limits for VM and Runtime.
     pub limit_config: LimitConfig,
 }

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -17,6 +17,7 @@ use near_primitives_core::runtime::fees::{transfer_exec_fee, transfer_send_fee};
 use near_primitives_core::types::{
     AccountId, Balance, Compute, EpochHeight, Gas, GasWeight, StorageUsage,
 };
+use near_primitives_core::version::PROTOCOL_VERSION;
 use std::mem::size_of;
 
 pub type Result<T, E = VMLogicError> = ::std::result::Result<T, E>;
@@ -1781,11 +1782,15 @@ impl<'a> VMLogic<'a> {
             sir,
             self.config.implicit_account_creation,
             receiver_id.get_account_type(),
+            // TODO(eth-implicit) What protocol version to use?
+            PROTOCOL_VERSION,
         );
         let exec_fee = transfer_exec_fee(
             self.fees_config,
             self.config.implicit_account_creation,
             receiver_id.get_account_type(),
+            // TODO(eth-implicit) What protocol version to use?
+            PROTOCOL_VERSION,
         );
         let burn_gas = send_fee;
         let use_gas = burn_gas.checked_add(exec_fee).ok_or(HostError::IntegerOverflow)?;

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -17,7 +17,6 @@ use near_primitives_core::runtime::fees::{transfer_exec_fee, transfer_send_fee};
 use near_primitives_core::types::{
     AccountId, Balance, Compute, EpochHeight, Gas, GasWeight, StorageUsage,
 };
-use near_primitives_core::version::PROTOCOL_VERSION;
 use std::mem::size_of;
 
 pub type Result<T, E = VMLogicError> = ::std::result::Result<T, E>;
@@ -1781,16 +1780,14 @@ impl<'a> VMLogic<'a> {
             self.fees_config,
             sir,
             self.config.implicit_account_creation,
+            self.config.eth_implicit_accounts,
             receiver_id.get_account_type(),
-            // TODO(eth-implicit) What protocol version to use?
-            PROTOCOL_VERSION,
         );
         let exec_fee = transfer_exec_fee(
             self.fees_config,
             self.config.implicit_account_creation,
+            self.config.eth_implicit_accounts,
             receiver_id.get_account_type(),
-            // TODO(eth-implicit) What protocol version to use?
-            PROTOCOL_VERSION,
         );
         let burn_gas = send_fee;
         let use_gas = burn_gas.checked_add(exec_fee).ok_or(HostError::IntegerOverflow)?;

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -48,6 +48,7 @@ impl crate::logic::Config {
             ed25519_verify: config.ed25519_verify,
             alt_bn128: config.alt_bn128,
             function_call_weight: config.function_call_weight,
+            eth_implicit_accounts: config.eth_implicit_accounts,
             limit_config: crate::config::LimitConfig {
                 max_gas_burnt: config.limit_config.max_gas_burnt,
                 max_stack_height: config.limit_config.max_stack_height,

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -477,7 +477,7 @@ pub(crate) fn action_implicit_account_creation_transfer(
         // Invariant: The `account_id` is implicit.
         // It holds because in the only calling site, we've checked the permissions before.
         AccountType::EthImplicitAccount => {
-            if checked_feature!("stable", EthImplicit, current_protocol_version) {
+            if checked_feature!("stable", EthImplicitAccounts, current_protocol_version) {
                 // TODO(eth-implicit) Use real Wallet Contract.
                 let wallet_contract = wallet_contract_placeholder();
                 let storage_usage = fee_config.storage_usage_config.num_bytes_account
@@ -918,7 +918,6 @@ pub(crate) fn check_account_existence(
     config: &RuntimeConfig,
     is_the_only_action: bool,
     is_refund: bool,
-    current_protocol_version: ProtocolVersion,
 ) -> Result<(), ActionError> {
     match action {
         Action::CreateAccount(_) => {
@@ -930,7 +929,7 @@ pub(crate) fn check_account_existence(
             } else {
                 // TODO: this should be `config.implicit_account_creation`.
                 if config.wasm_config.implicit_account_creation
-                    && account_is_implicit(account_id, current_protocol_version)
+                    && account_is_implicit(account_id, config.wasm_config.eth_implicit_accounts)
                 {
                     // If the account doesn't exist and it's implicit, then you
                     // should only be able to create it using single transfer action.
@@ -952,7 +951,7 @@ pub(crate) fn check_account_existence(
             if account.is_none() {
                 return if config.wasm_config.implicit_account_creation
                     && is_the_only_action
-                    && account_is_implicit(account_id, current_protocol_version)
+                    && account_is_implicit(account_id, config.wasm_config.eth_implicit_accounts)
                     && !is_refund
                 {
                     // OK. It's implicit account creation.
@@ -1407,7 +1406,6 @@ mod tests {
                 &RuntimeConfig::test(),
                 false,
                 false,
-                apply_state.current_protocol_version,
             ),
             Err(ActionErrorKind::AccountDoesNotExist { account_id: sender_id.clone() }.into())
         );

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -431,7 +431,7 @@ pub(crate) fn action_create_account(
     ));
 }
 
-/// Can only be used for NEAR-implicit accounts.
+/// Can only be used for implicit accounts.
 pub(crate) fn action_implicit_account_creation_transfer(
     state_update: &mut TrieUpdate,
     apply_state: &ApplyState,
@@ -487,6 +487,7 @@ pub(crate) fn action_implicit_account_creation_transfer(
                 *account =
                     Some(Account::new(transfer.deposit, 0, *wallet_contract.hash(), storage_usage));
 
+                // TODO(eth-implicit) Store a reference to the `Wallet Contract` instead of literally deploying it.
                 set_code(state_update, account_id.clone(), &wallet_contract);
                 // Precompile the contract and store result (compiled code or error) in the database.
                 // Note, that contract compilation costs are already accounted in deploy cost using
@@ -498,9 +499,14 @@ pub(crate) fn action_implicit_account_creation_transfer(
                 )
                 .ok();
             } else {
+                // This panic is unreachable as this is an implicit account creation transfer.
+                // `check_account_existence` would fail because in this protocol version `account_is_implicit`
+                // would return false for an account that is of the ETH-implicit type.
                 panic!("must be near-implicit");
             }
         }
+        // This panic is unreachable as this is an implicit account creation transfer.
+        // `check_account_existence` would fail because `account_is_implicit` would return false for a Named account.
         AccountType::NamedAccount => panic!("must be implicit"),
     }
 }

--- a/runtime/runtime/src/config.rs
+++ b/runtime/runtime/src/config.rs
@@ -3,7 +3,6 @@
 use near_primitives::account::AccessKeyPermission;
 use near_primitives::errors::IntegerOverflowError;
 use near_primitives_core::config::ActionCosts;
-use near_primitives_core::version::PROTOCOL_VERSION;
 use num_bigint::BigUint;
 use num_traits::cast::ToPrimitive;
 use num_traits::pow::Pow;
@@ -101,9 +100,8 @@ pub fn total_send_fees(
                     fees,
                     sender_is_receiver,
                     config.wasm_config.implicit_account_creation,
+                    config.wasm_config.eth_implicit_accounts,
                     receiver_id.get_account_type(),
-                    // TODO(eth-implicit) What protocol version to use?
-                    PROTOCOL_VERSION,
                 )
             }
             Stake(_) => fees.fee(ActionCosts::stake).send_fee(sender_is_receiver),
@@ -197,9 +195,8 @@ pub fn exec_fee(config: &RuntimeConfig, action: &Action, receiver_id: &AccountId
             transfer_exec_fee(
                 fees,
                 config.wasm_config.implicit_account_creation,
+                config.wasm_config.eth_implicit_accounts,
                 receiver_id.get_account_type(),
-                // TODO(eth-implicit) What protocol version to use?
-                PROTOCOL_VERSION,
             )
         }
         Stake(_) => fees.fee(ActionCosts::stake).exec_fee(),

--- a/runtime/runtime/src/config.rs
+++ b/runtime/runtime/src/config.rs
@@ -3,6 +3,7 @@
 use near_primitives::account::AccessKeyPermission;
 use near_primitives::errors::IntegerOverflowError;
 use near_primitives_core::config::ActionCosts;
+use near_primitives_core::version::PROTOCOL_VERSION;
 use num_bigint::BigUint;
 use num_traits::cast::ToPrimitive;
 use num_traits::pow::Pow;
@@ -101,6 +102,8 @@ pub fn total_send_fees(
                     sender_is_receiver,
                     config.wasm_config.implicit_account_creation,
                     receiver_id.get_account_type(),
+                    // TODO(eth-implicit) What protocol version to use?
+                    PROTOCOL_VERSION,
                 )
             }
             Stake(_) => fees.fee(ActionCosts::stake).send_fee(sender_is_receiver),
@@ -195,6 +198,8 @@ pub fn exec_fee(config: &RuntimeConfig, action: &Action, receiver_id: &AccountId
                 fees,
                 config.wasm_config.implicit_account_creation,
                 receiver_id.get_account_type(),
+                // TODO(eth-implicit) What protocol version to use?
+                PROTOCOL_VERSION,
             )
         }
         Stake(_) => fees.fee(ActionCosts::stake).exec_fee(),

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -316,6 +316,7 @@ impl Runtime {
             &apply_state.config,
             is_the_only_action,
             is_refund,
+            apply_state.current_protocol_version,
         ) {
             result.result = Err(e);
             return Ok(result);
@@ -382,6 +383,7 @@ impl Runtime {
                     debug_assert!(!is_refund);
                     action_implicit_account_creation_transfer(
                         state_update,
+                        apply_state,
                         &apply_state.config.fees,
                         account,
                         actor_id,

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -316,7 +316,6 @@ impl Runtime {
             &apply_state.config,
             is_the_only_action,
             is_refund,
-            apply_state.current_protocol_version,
         ) {
             result.result = Err(e);
             return Ok(result);

--- a/test-utils/testlib/src/fees_utils.rs
+++ b/test-utils/testlib/src/fees_utils.rs
@@ -56,8 +56,22 @@ impl FeeHelper {
         exec_gas + send_gas
     }
 
+    pub fn create_account_transfer_fee(&self) -> Gas {
+        let exec_gas = self.cfg().fee(ActionCosts::new_action_receipt).exec_fee()
+            + self.cfg().fee(ActionCosts::create_account).exec_fee()
+            + self.cfg().fee(ActionCosts::transfer).exec_fee();
+        let send_gas = self.cfg().fee(ActionCosts::new_action_receipt).send_fee(false)
+            + self.cfg().fee(ActionCosts::create_account).send_fee(false)
+            + self.cfg().fee(ActionCosts::transfer).send_fee(false);
+        exec_gas + send_gas
+    }
+
     pub fn create_account_transfer_full_key_cost(&self) -> Balance {
         self.gas_to_balance(self.create_account_transfer_full_key_fee())
+    }
+
+    pub fn create_account_transfer_cost(&self) -> Balance {
+        self.gas_to_balance(self.create_account_transfer_fee())
     }
 
     pub fn create_account_transfer_full_key_cost_no_reward(&self) -> Balance {
@@ -116,10 +130,6 @@ impl FeeHelper {
 
     pub fn transfer_cost(&self) -> Balance {
         self.gas_to_balance(self.transfer_fee())
-    }
-
-    pub fn transfer_cost_64len_hex(&self) -> Balance {
-        self.create_account_transfer_full_key_cost()
     }
 
     pub fn stake_cost(&self) -> Balance {

--- a/tools/mirror/src/key_mapping.rs
+++ b/tools/mirror/src/key_mapping.rs
@@ -1,7 +1,7 @@
 use hkdf::Hkdf;
 use near_crypto::{ED25519PublicKey, ED25519SecretKey, PublicKey, Secp256K1PublicKey, SecretKey};
 use near_primitives::types::AccountId;
-use near_primitives::utils::derive_near_implicit_account_id;
+use near_primitives::utils::derive_account_id_from_public_key;
 use near_primitives_core::account::id::AccountType;
 use sha2::Sha256;
 
@@ -107,10 +107,11 @@ pub fn map_account(
     match account_id.get_account_type() {
         AccountType::NearImplicitAccount => {
             let public_key =
-                PublicKey::from_near_implicit_account(account_id).expect("must be near-implicit");
+                PublicKey::from_near_implicit_account(account_id).expect("must be implicit");
             let mapped_key = map_key(&public_key, secret);
-            derive_near_implicit_account_id(mapped_key.public_key().unwrap_as_ed25519())
+            derive_account_id_from_public_key(&mapped_key.public_key())
         }
+        // TODO(eth-implicit) map to a new ETH address
         AccountType::EthImplicitAccount => account_id.clone(),
         AccountType::NamedAccount => account_id.clone(),
     }

--- a/tools/mirror/src/key_mapping.rs
+++ b/tools/mirror/src/key_mapping.rs
@@ -1,7 +1,7 @@
 use hkdf::Hkdf;
 use near_crypto::{ED25519PublicKey, ED25519SecretKey, PublicKey, Secp256K1PublicKey, SecretKey};
 use near_primitives::types::AccountId;
-use near_primitives::utils::derive_account_id_from_public_key;
+use near_primitives::utils::derive_near_implicit_account_id;
 use near_primitives_core::account::id::AccountType;
 use sha2::Sha256;
 
@@ -109,7 +109,7 @@ pub fn map_account(
             let public_key =
                 PublicKey::from_near_implicit_account(account_id).expect("must be implicit");
             let mapped_key = map_key(&public_key, secret);
-            derive_account_id_from_public_key(&mapped_key.public_key())
+            derive_near_implicit_account_id(&mapped_key.public_key().unwrap_as_ed25519())
         }
         // TODO(eth-implicit) map to a new ETH address
         AccountType::EthImplicitAccount => account_id.clone(),


### PR DESCRIPTION
## Context
Tracking issue: https://github.com/near/nearcore/issues/10018.
Design: https://github.com/near/NEPs/issues/518#issue-1996465013.

### Goal
We want the NEAR Protocol's ecosystem to be closer with Ethereum by integrating Web3 wallet support.
To accomplish that, some changes on the protocol level are needed with an emphasis on user experience continuity.
Following the design, the main change on the protocol level would be to have ETH-style addresses managed by a new `Wallet Contract` integrated into the protocol.
For seamless onboarding of EVM users, the contract will be free of charge.

### Previous work
This PR is built on top of a [preparatory PR](https://github.com/near/nearcore/pull/10020).
It reintroduces some changes from a [closed PR](https://github.com/near/nearcore/pull/10056) that follows an old design.

## Summary
On a transfer to an ETH-implicit address:
1. An account is created at this address.
2. The account does not have any access key added. Thus, it is not possible to make a transaction from this account directly.
3. The Wallet Contract (as a part of the protocol) is deployed to the account. For this PR, an empty smart contract is used as a placeholder.

### Changes
- On a transfer to an ETH-implicit address, if an account does not exist yet at this address:
   - Create account at this address.
   - Deploy a `Wallet Contract` placeholder (empty contract now) to this account.
- Update fee for a transfer to an ETH-implicit address to include account creation cost. `Wallet Contract` deployment is free of charge (user only pays for an increased storage).
- Tests:
   - Test whether it is possible to create an ETH-implicit account by making a transfer to that address, and whether further funds can be sent to this account.
   - Test that no access key is added to an ETH-implicit account (the account is locked) and in consequence no transactions are possible from this account.
- Guard the changes with `EthImplicitAccounts` protocol feature and `eth_implicit_accounts` runtime config flag.

## Next work
- Discuss how the `Wallet Contract` should be integrated into the protocol for efficiency.
- Use the `Wallet Contract` placeholder implementation that allows to transfer funds only.