### PR TITLE
Nayduck cli - add cancel option

### DIFF
--- a/pytest/tests/sanity/recompress_storage.py
+++ b/pytest/tests/sanity/recompress_storage.py
@@ -93,8 +93,8 @@ class RecompressStorageTestCase(unittest.TestCase):
         time.sleep(5)
         sanity.rpc_tx_status.test_tx_status(self.nodes, nonce_offset=3)
 
-    def _call(self, node: cluster.LocalNode, prefix: str,
-              *args: typing.Union[str, pathlib.Path]) -> None:
+    def _call(self, node: cluster.LocalNode, prefix: str, *args:
+              typing.Union[str, pathlib.Path]) -> None:
         """Calls node’s neard with given arguments."""
         node_dir = pathlib.Path(node.node_dir)
         cmd = [

--- a/pytest/tests/sanity/recompress_storage.py
+++ b/pytest/tests/sanity/recompress_storage.py
@@ -93,8 +93,8 @@ class RecompressStorageTestCase(unittest.TestCase):
         time.sleep(5)
         sanity.rpc_tx_status.test_tx_status(self.nodes, nonce_offset=3)
 
-    def _call(self, node: cluster.LocalNode, prefix: str, *args:
-              typing.Union[str, pathlib.Path]) -> None:
+    def _call(self, node: cluster.LocalNode, prefix: str,
+              *args: typing.Union[str, pathlib.Path]) -> None:
         """Calls node’s neard with given arguments."""
         node_dir = pathlib.Path(node.node_dir)
         cmd = [

--- a/scripts/nayduck.py
+++ b/scripts/nayduck.py
@@ -38,7 +38,10 @@ def _parse_args():
                          DEFAULT_TEST_FILE)
 
     parser = argparse.ArgumentParser(description='Run tests.')
-    parser.add_argument('--cancel', '-c', help='Cancel scheduled run. In progress tests cannot be stopped.')
+    parser.add_argument(
+        '--cancel',
+        '-c',
+        help='Cancel scheduled run. In progress tests cannot be stopped.')
     parser.add_argument('--branch',
                         '-b',
                         help='Branch to test. By default gets current one.')
@@ -319,12 +322,13 @@ def run_command(args, tests):
     while True:
         print('Sending request ...')
         if args.cancel:
-            res = requests.post(NAYDUCK_BASE_HREF + f'/api/run/{args.cancel}/cancel',
-                            cookies={'nay-code': code})
+            res = requests.post(NAYDUCK_BASE_HREF +
+                                f'/api/run/{args.cancel}/cancel',
+                                cookies={'nay-code': code})
         else:
             res = requests.post(NAYDUCK_BASE_HREF + '/api/run/new',
-                            json=post,
-                            cookies={'nay-code': code})
+                                json=post,
+                                cookies={'nay-code': code})
         if res.status_code != 401:
             break
         print(f'{styles[0]}Unauthorised.{styles[2]}\n')
@@ -333,9 +337,11 @@ def run_command(args, tests):
     if res.status_code == 200:
         json_res = json.loads(res.text)
         if args.cancel:
-            print(styles[1] + 'Cancelled ' + str(json_res) + ' test(s)' + styles[2])
+            print(styles[1] + 'Cancelled ' + str(json_res) + ' test(s)' +
+                  styles[2])
         else:
-            print(styles[json_res['code'] == 0] + json_res['response'] + styles[2])
+            print(styles[json_res['code'] == 0] + json_res['response'] +
+                  styles[2])
     else:
         print(f'{styles[0]}Got status code {res.status_code}:{styles[2]}\n')
         print(res.text)

--- a/scripts/nayduck.py
+++ b/scripts/nayduck.py
@@ -38,6 +38,7 @@ def _parse_args():
                          DEFAULT_TEST_FILE)
 
     parser = argparse.ArgumentParser(description='Run tests.')
+    parser.add_argument('--cancel','-c', help='Cancel scheduled run. In progress tests cannot be stopped.')
     parser.add_argument('--branch',
                         '-b',
                         help='Branch to test. By default gets current one.')
@@ -278,7 +279,7 @@ def run_locally(args, tests):
         subprocess.check_call(cmd, cwd=cwd, timeout=_parse_timeout(timeout))
 
 
-def run_remotely(args, tests):
+def run_command(args, tests):
     import requests
 
     try:
@@ -317,7 +318,11 @@ def run_remotely(args, tests):
 
     while True:
         print('Sending request ...')
-        res = requests.post(NAYDUCK_BASE_HREF + '/api/run/new',
+        if args.cancel:
+            res = requests.post(NAYDUCK_BASE_HREF + f'/api/run/{args.cancel}/cancel',
+                            cookies={'nay-code': code})
+        else:
+            res = requests.post(NAYDUCK_BASE_HREF + '/api/run/new',
                             json=post,
                             cookies={'nay-code': code})
         if res.status_code != 401:
@@ -327,7 +332,10 @@ def run_remotely(args, tests):
 
     if res.status_code == 200:
         json_res = json.loads(res.text)
-        print(styles[json_res['code'] == 0] + json_res['response'] + styles[2])
+        if args.cancel:
+            print(styles[1] + 'Cancelled ' + str(json_res) + ' test(s)' + styles[2])
+        else:
+            print(styles[json_res['code'] == 0] + json_res['response'] + styles[2])
     else:
         print(f'{styles[0]}Got status code {res.status_code}:{styles[2]}\n')
         print(res.text)
@@ -347,7 +355,7 @@ def main():
     if args.run_locally:
         run_locally(args, tests)
     else:
-        run_remotely(args, tests)
+        run_command(args, tests)
 
 
 if __name__ == "__main__":

--- a/scripts/nayduck.py
+++ b/scripts/nayduck.py
@@ -38,7 +38,7 @@ def _parse_args():
                          DEFAULT_TEST_FILE)
 
     parser = argparse.ArgumentParser(description='Run tests.')
-    parser.add_argument('--cancel','-c', help='Cancel scheduled run. In progress tests cannot be stopped.')
+    parser.add_argument('--cancel', '-c', help='Cancel scheduled run. In progress tests cannot be stopped.')
     parser.add_argument('--branch',
                         '-b',
                         help='Branch to test. By default gets current one.')


### PR DESCRIPTION
allows to cancel pending tests for given build ID

```
./scripts/nayduck.py --cancel 3288
Scheduling tests for: 
branch - remotes/origin/disable-store-validator-build 
commit hash - c221f8f92cb3e20767a0fa2c66a9b64c34ea3cf5
Sending request ...
Cancelled 1 tests
```