### PR TITLE
nit: upgrade react-router-dom from 6.17.0 to 6.18.0

### DIFF
--- a/tools/debug-ui/package-lock.json
+++ b/tools/debug-ui/package-lock.json
@@ -16,7 +16,7 @@
         "react-dom": "^18.2.0",
         "react-query": "^3.39.3",
         "react-router": "^6.18.0",
-        "react-router-dom": "^6.17.0",
+        "react-router-dom": "^6.18.0",
         "react-scripts": "^5.0.1",
         "react-tooltip": "^5.21.6",
         "react-xarrows": "^2.0.2"
@@ -3348,9 +3348,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.10.0.tgz",
-      "integrity": "sha512-Lm+fYpMfZoEucJ7cMxgt4dYt8jLfbpwRCzAjm9UgSLOkmlqo9gupxt6YX3DY0Fk155NT9l17d/ydi+964uS9Lw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.12.0.tgz",
+      "integrity": "sha512-2hXv036Bux90e1GXTWSMfNzfDDK8LA8JYEWfyHxzvwdp6GyoWEovKc9cotb3KCKmkdwsIBuFGX7ScTWyiHv7Eg==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -15213,11 +15213,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.18.0.tgz",
-      "integrity": "sha512-vk2y7Dsy8wI02eRRaRmOs9g2o+aE72YCx5q9VasT1N9v+lrdB79tIqrjMfByHiY5+6aYkH2rUa5X839nwWGPDg==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.19.0.tgz",
+      "integrity": "sha512-0W63PKCZ7+OuQd7Tm+RbkI8kCLmn4GPjDbX61tWljPxWgqTKlEpeQUwPkT1DRjYhF8KSihK0hQpmhU4uxVMcdw==",
       "dependencies": {
-        "@remix-run/router": "1.11.0"
+        "@remix-run/router": "1.12.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -15227,12 +15227,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.17.0.tgz",
-      "integrity": "sha512-qWHkkbXQX+6li0COUUPKAUkxjNNqPJuiBd27dVwQGDNsuFBdMbrS6UZ0CLYc4CsbdLYTckn4oB4tGDuPZpPhaQ==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.19.0.tgz",
+      "integrity": "sha512-N6dWlcgL2w0U5HZUUqU2wlmOrSb3ighJmtQ438SWbhB1yuLTXQ8yyTBMK3BSvVjp7gBtKurT554nCtMOgxCZmQ==",
       "dependencies": {
-        "@remix-run/router": "1.10.0",
-        "react-router": "6.17.0"
+        "@remix-run/router": "1.12.0",
+        "react-router": "6.19.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -15240,28 +15240,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom/node_modules/react-router": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.17.0.tgz",
-      "integrity": "sha512-YJR3OTJzi3zhqeJYADHANCGPUu9J+6fT5GLv82UWRGSxu6oJYCKVmxUcaBQuGm9udpWmPsvpme/CdHumqgsoaA==",
-      "dependencies": {
-        "@remix-run/router": "1.10.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router/node_modules/@remix-run/router": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.11.0.tgz",
-      "integrity": "sha512-BHdhcWgeiudl91HvVa2wxqZjSHbheSgIiDvxrF1VjFzBzpTtuDPkOdOi3Iqvc08kXtFkLjhbS+ML9aM8mJS+wQ==",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/react-scripts": {
@@ -20567,9 +20545,9 @@
       }
     },
     "@remix-run/router": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.10.0.tgz",
-      "integrity": "sha512-Lm+fYpMfZoEucJ7cMxgt4dYt8jLfbpwRCzAjm9UgSLOkmlqo9gupxt6YX3DY0Fk155NT9l17d/ydi+964uS9Lw=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.12.0.tgz",
+      "integrity": "sha512-2hXv036Bux90e1GXTWSMfNzfDDK8LA8JYEWfyHxzvwdp6GyoWEovKc9cotb3KCKmkdwsIBuFGX7ScTWyiHv7Eg=="
     },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -29056,37 +29034,20 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
     },
     "react-router": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.18.0.tgz",
-      "integrity": "sha512-vk2y7Dsy8wI02eRRaRmOs9g2o+aE72YCx5q9VasT1N9v+lrdB79tIqrjMfByHiY5+6aYkH2rUa5X839nwWGPDg==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.19.0.tgz",
+      "integrity": "sha512-0W63PKCZ7+OuQd7Tm+RbkI8kCLmn4GPjDbX61tWljPxWgqTKlEpeQUwPkT1DRjYhF8KSihK0hQpmhU4uxVMcdw==",
       "requires": {
-        "@remix-run/router": "1.11.0"
-      },
-      "dependencies": {
-        "@remix-run/router": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.11.0.tgz",
-          "integrity": "sha512-BHdhcWgeiudl91HvVa2wxqZjSHbheSgIiDvxrF1VjFzBzpTtuDPkOdOi3Iqvc08kXtFkLjhbS+ML9aM8mJS+wQ=="
-        }
+        "@remix-run/router": "1.12.0"
       }
     },
     "react-router-dom": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.17.0.tgz",
-      "integrity": "sha512-qWHkkbXQX+6li0COUUPKAUkxjNNqPJuiBd27dVwQGDNsuFBdMbrS6UZ0CLYc4CsbdLYTckn4oB4tGDuPZpPhaQ==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.19.0.tgz",
+      "integrity": "sha512-N6dWlcgL2w0U5HZUUqU2wlmOrSb3ighJmtQ438SWbhB1yuLTXQ8yyTBMK3BSvVjp7gBtKurT554nCtMOgxCZmQ==",
       "requires": {
-        "@remix-run/router": "1.10.0",
-        "react-router": "6.17.0"
-      },
-      "dependencies": {
-        "react-router": {
-          "version": "6.17.0",
-          "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.17.0.tgz",
-          "integrity": "sha512-YJR3OTJzi3zhqeJYADHANCGPUu9J+6fT5GLv82UWRGSxu6oJYCKVmxUcaBQuGm9udpWmPsvpme/CdHumqgsoaA==",
-          "requires": {
-            "@remix-run/router": "1.10.0"
-          }
-        }
+        "@remix-run/router": "1.12.0",
+        "react-router": "6.19.0"
       }
     },
     "react-scripts": {

--- a/tools/debug-ui/package.json
+++ b/tools/debug-ui/package.json
@@ -11,7 +11,7 @@
     "react-dom": "^18.2.0",
     "react-query": "^3.39.3",
     "react-router": "^6.18.0",
-    "react-router-dom": "^6.17.0",
+    "react-router-dom": "^6.18.0",
     "react-scripts": "^5.0.1",
     "react-tooltip": "^5.21.6",
     "react-xarrows": "^2.0.2"


### PR DESCRIPTION
Supersedes https://github.com/near/nearcore/pull/10232.  That PR had a conflict due to a recent merge and it was easier to create a new PR instead of fixing the conflict there.