### PR TITLE
fix(nightly): disable broken test

### DIFF
--- a/integration-tests/src/tests/nearcore/rpc_error_structs.rs
+++ b/integration-tests/src/tests/nearcore/rpc_error_structs.rs
@@ -347,7 +347,7 @@ fn test_receipt_id_unknown_receipt_error() {
 /// Sends tx to first light client through `broadcast_tx_commit` and checks that the transaction has failed.
 /// Checks if the struct is expected and contains the proper data
 #[test]
-#[ignore = "Invalid test setup. broadcast_tx_commit times out. Fix and reenable."]
+#[ignore = "Invalid test setup. broadcast_tx_commit times out because we haven't implemented forwarding logic. Fix and reenable."]
 // #[cfg_attr(not(feature = "expensive_tests"), ignore)]
 fn test_tx_invalid_tx_error() {
     init_integration_logger();

--- a/integration-tests/src/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/src/tests/nearcore/rpc_nodes.rs
@@ -476,8 +476,9 @@ fn test_check_unknown_tx_must_return_error() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_check_tx_on_lightclient_must_return_does_not_track_shard() {
+#[ignore = "Need to implement forwarding and fix the test"]
+// #[cfg_attr(not(feature = "expensive_tests"), ignore)]
+fn test_tx_status_on_lightclient_must_return_does_not_track_shard() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()

--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -185,8 +185,8 @@ expensive integration-tests integration_tests tests::nearcore::rpc_error_structs
 expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::test_tx_invalid_tx_error
 expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::test_tx_invalid_tx_error --features nightly
 
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_check_tx_on_lightclient_must_return_does_not_track_shard
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_check_tx_on_lightclient_must_return_does_not_track_shard --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_tx_status_on_lightclient_must_return_does_not_track_shard
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_tx_status_on_lightclient_must_return_does_not_track_shard --features nightly
 expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_check_unknown_tx_must_return_error
 expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_check_unknown_tx_must_return_error --features nightly
 expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_get_execution_outcome_tx_failure


### PR DESCRIPTION
I dropped check_tx method https://github.com/near/nearcore/pull/9601
But I decided to leave this test and I replaced `check_tx` with `tx_status`. `tx_status` returns timeout instead of `does_not_track_shard`. Instead of fixing this, I suggest to wait until we implement forwarding logic, I planned to work on forwarding anyways.

Let's disable the test for now, and hopefully, in one day, we will return the real status to the user.