### PR TITLE
coverage: apply `-Cinstrument-coverage` to workspace crates only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,8 @@ jobs:
         with:
           prefix-key: "0" # change this to invalidate CI cache
           shared-key: "cargo_nextest-${{ matrix.cache_id }}"
-      - run: cargo llvm-cov show-env | tr -d "'" >> "$GITHUB_ENV"
-
+      - run: cargo llvm-cov show-env | grep -v RUSTFLAGS | tr -d "'" >> "$GITHUB_ENV"
+      - run: echo "RUSTC_WORKSPACE_WRAPPER=$PWD/scripts/rustc-coverage-wrapper.sh" >> "$GITHUB_ENV"
       # Run unit tests
       - run: cargo nextest run --locked --workspace --exclude integration-tests --cargo-profile dev-release --profile ci ${{ matrix.flags }}
         env:
@@ -115,7 +115,8 @@ jobs:
           shared-key: "cargo_nextest-linux"
           save-if: "false" # use the cache from nextest, but don’t double-save
       - run: pip3 install --user -r pytest/requirements.txt
-      - run: cargo llvm-cov show-env | tr -d "'" >> "$GITHUB_ENV"
+      - run: cargo llvm-cov show-env | grep -v RUSTFLAGS | tr -d "'" >> "$GITHUB_ENV"
+      - run: echo "RUSTC_WORKSPACE_WRAPPER=$PWD/scripts/rustc-coverage-wrapper.sh" >> "$GITHUB_ENV"
       - run: cargo build --locked --profile dev-release -p neard --bin neard
       - run: echo "CURRENT_NEARD=$PWD/target/dev-release/neard" >> "$GITHUB_ENV"
       - run: cd pytest && python3 tests/sanity/backward_compatible.py
@@ -145,7 +146,8 @@ jobs:
           shared-key: "cargo_nextest-linux"
           save-if: "false" # use the cache from nextest, but don’t double-save
       - run: pip3 install --user -r pytest/requirements.txt
-      - run: cargo llvm-cov show-env | tr -d "'" >> "$GITHUB_ENV"
+      - run: cargo llvm-cov show-env | grep -v RUSTFLAGS | tr -d "'" >> "$GITHUB_ENV"
+      - run: echo "RUSTC_WORKSPACE_WRAPPER=$PWD/scripts/rustc-coverage-wrapper.sh" >> "$GITHUB_ENV"
       - run: cargo build --locked --profile dev-release -p neard --bin neard
       - run: echo "CURRENT_NEARD=$PWD/target/dev-release/neard" >> "$GITHUB_ENV"
       - run: echo "NEAR_ROOT=$PWD" >> "$GITHUB_ENV"
@@ -181,7 +183,8 @@ jobs:
       - run: pip3 install --user -r pytest/requirements.txt
       # This is the only job that uses `--features nightly` so we build this in-line instead of a
       # separate job like done with the regular neard.
-      - run: cargo llvm-cov show-env | tr -d "'" >> "$GITHUB_ENV"
+      - run: cargo llvm-cov show-env | grep -v RUSTFLAGS | tr -d "'" >> "$GITHUB_ENV"
+      - run: echo "RUSTC_WORKSPACE_WRAPPER=$PWD/scripts/rustc-coverage-wrapper.sh" >> "$GITHUB_ENV"
       - run: cargo build --profile dev-release -p neard --bin neard --features nightly
       # Note: We're not running spin_up_cluster.py for non-nightly
       # because spinning up non-nightly clusters is already covered
@@ -215,7 +218,8 @@ jobs:
           shared-key: "cargo_nextest-linux"
           save-if: "false" # use the cache from nextest, but don’t double-save
       - run: pip3 install --user -r pytest/requirements.txt
-      - run: cargo llvm-cov show-env | tr -d "'" >> "$GITHUB_ENV"
+      - run: cargo llvm-cov show-env | grep -v RUSTFLAGS | tr -d "'" >> "$GITHUB_ENV"
+      - run: echo "RUSTC_WORKSPACE_WRAPPER=$PWD/scripts/rustc-coverage-wrapper.sh" >> "$GITHUB_ENV"
       - run: cargo build --locked --profile dev-release -p neard --bin neard
       - run: echo "CURRENT_NEARD=$PWD/target/dev-release/neard" >> "$GITHUB_ENV"
       - run: python3 scripts/state/update_res.py check
@@ -260,7 +264,8 @@ jobs:
           shared-key: "cargo_nextest-linux"
           save-if: "false" # use the cache from nextest, but don’t double-save
       - run: pip3 install --user -r pytest/requirements.txt
-      - run: cargo llvm-cov show-env | tr -d "'" >> "$GITHUB_ENV"
+      - run: cargo llvm-cov show-env | grep -v RUSTFLAGS | tr -d "'" >> "$GITHUB_ENV"
+      - run: echo "RUSTC_WORKSPACE_WRAPPER=$PWD/scripts/rustc-coverage-wrapper.sh" >> "$GITHUB_ENV"
       - run: cargo build --locked --profile dev-release -p neard --bin neard
       - run: echo "CURRENT_NEARD=$PWD/target/dev-release/neard" >> "$GITHUB_ENV"
       - run: cd pytest && python3 tests/sanity/upgradable.py

--- a/runtime/near-test-contracts/build.rs
+++ b/runtime/near-test-contracts/build.rs
@@ -48,6 +48,7 @@ fn cargo_build_cmd(target_dir: &std::path::Path) -> Command {
 
     res.env_remove("CARGO_BUILD_RUSTFLAGS");
     res.env_remove("CARGO_ENCODED_RUSTFLAGS");
+    res.env_remove("RUSTC_WORKSPACE_WRAPPER");
 
     res.env("RUSTFLAGS", "-Dwarnings");
     res.env("CARGO_TARGET_DIR", target_dir);

--- a/scripts/rustc-coverage-wrapper.sh
+++ b/scripts/rustc-coverage-wrapper.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+## When collecting coverage we want to instrument only the crates in our workspace, and not the
+## external dependencies (there is no value in doing so – we don’t run tests for our dependencies
+## anyway.) Furthermore, instrumenting the crates like these run a risk of significant performance
+## regressions, such as seen in #10201
+
+RUSTC="$1"; shift
+exec "$RUSTC" -Cinstrument-coverage --cfg=coverage "$@"


### PR DESCRIPTION
When collecting coverage we want to instrument only the crates in our workspace, and not the external dependencies. There is no value in doing otherwise – we don’t run tests for our dependencies anyway. Furthermore, instrumenting the external dependencies runs a risk of significant performance regressions, such as seen in #10201.