### PR TITLE
feat: add database analyse-gas-usage command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3708,6 +3708,7 @@ dependencies = [
  "borsh 1.0.0",
  "clap",
  "indicatif",
+ "near-chain",
  "near-chain-configs",
  "near-epoch-manager",
  "near-primitives",

--- a/tools/database/Cargo.toml
+++ b/tools/database/Cargo.toml
@@ -24,6 +24,7 @@ tempfile.workspace = true
 
 nearcore.workspace = true
 near-epoch-manager.workspace = true
+near-chain.workspace = true
 near-chain-configs.workspace = true
 near-store.workspace = true
 near-primitives.workspace = true

--- a/tools/database/Cargo.toml
+++ b/tools/database/Cargo.toml
@@ -33,6 +33,7 @@ near-primitives.workspace = true
 nightly = [
   "nightly_protocol",
   "near-chain-configs/nightly",
+  "near-chain/nightly",
   "near-epoch-manager/nightly",
   "near-primitives/nightly",
   "near-store/nightly",
@@ -40,6 +41,7 @@ nightly = [
 ]
 nightly_protocol = [
   "near-chain-configs/nightly_protocol",
+  "near-chain/nightly_protocol",
   "near-epoch-manager/nightly_protocol",
   "near-primitives/nightly_protocol",
   "near-store/nightly_protocol",

--- a/tools/database/src/analyse_gas_usage.rs
+++ b/tools/database/src/analyse_gas_usage.rs
@@ -392,11 +392,11 @@ fn analyse_gas_usage(
                 );
                 println!("    Left (account < split_account):");
                 let left_accounts =
-                    shard_usage.used_gas_per_account.range(..=shard_split.split_account.clone());
+                    shard_usage.used_gas_per_account.range(..shard_split.split_account.clone());
                 display_shard_split_stats(left_accounts, shard_total_gas);
                 println!("    Right (account >= split_account):");
                 let right_accounts =
-                    shard_usage.used_gas_per_account.range(shard_split.split_account..).skip(1);
+                    shard_usage.used_gas_per_account.range(shard_split.split_account..);
                 display_shard_split_stats(right_accounts, shard_total_gas);
             }
             None => println!("  No optimal split for this shard"),

--- a/tools/database/src/analyse_gas_usage.rs
+++ b/tools/database/src/analyse_gas_usage.rs
@@ -388,7 +388,10 @@ fn analyse_gas_usage(
                     "    Gas distribution (left, boundary_acc, right): ({}, {}, {})",
                     as_percentage_of(shard_split.gas_left, shard_total_gas),
                     as_percentage_of(boundary_account_gas, shard_total_gas),
-                    as_percentage_of(shard_split.gas_right.saturating_sub(boundary_account_gas), shard_total_gas)
+                    as_percentage_of(
+                        shard_split.gas_right.saturating_sub(boundary_account_gas),
+                        shard_total_gas
+                    )
                 );
                 println!("    Left (account < boundary_account):");
                 let left_accounts =
@@ -541,7 +544,8 @@ mod tests {
         // Optimal split:
         // 1 + 3 + 5 + 2 = 11
         // 8 + 1 + 2 + 8 = 19
-        let optimal_split = ShardSplit { boundary_account: account("e"), gas_left: 11, gas_right: 19 };
+        let optimal_split =
+            ShardSplit { boundary_account: account("e"), gas_left: 11, gas_right: 19 };
         assert_eq!(shard_usage.calculate_split(), Some(optimal_split));
     }
 

--- a/tools/database/src/analyse_gas_usage.rs
+++ b/tools/database/src/analyse_gas_usage.rs
@@ -88,6 +88,18 @@ struct GasUsageInShard {
     pub used_gas_total: BigGas,
 }
 
+/// A shard can be split into two halves.
+/// This struct represents the result of splitting a shard at `split_account`.
+#[derive(Debug, Clone)]
+struct ShardSplit {
+    /// Account on which the shard would be split
+    pub split_account: AccountId,
+    /// Gas used by accounts < split_account
+    pub gas_left: BigGas,
+    /// Gas used by accounts >= split_account
+    pub gas_right: BigGas,
+}
+
 impl GasUsageInShard {
     pub fn new() -> GasUsageInShard {
         GasUsageInShard { used_gas_per_account: BTreeMap::new(), used_gas_total: 0 }
@@ -106,6 +118,33 @@ impl GasUsageInShard {
             self.add_used_gas(account_id.clone(), *used_gas);
         }
         self.used_gas_total = self.used_gas_total.checked_add(other.used_gas_total).unwrap();
+    }
+
+    /// Calculate the optimal point at which this shard could be split into two halves with similar gas usage
+    pub fn calculate_split(&self) -> Option<ShardSplit> {
+        let mut split_account = match self.used_gas_per_account.keys().next() {
+            Some(account_id) => account_id,
+            None => return None,
+        };
+
+        if self.used_gas_per_account.len() < 2 {
+            return None;
+        }
+
+        let mut gas_left: BigGas = 0;
+        let mut gas_right: BigGas = self.used_gas_total;
+
+        for (account, used_gas) in self.used_gas_per_account.iter() {
+            if gas_left >= gas_right {
+                break;
+            }
+
+            split_account = &account;
+            gas_left = gas_left.checked_add(*used_gas).unwrap();
+            gas_right = gas_right.checked_sub(*used_gas).unwrap();
+        }
+
+        Some(ShardSplit { split_account: split_account.clone(), gas_left, gas_right })
     }
 }
 
@@ -245,6 +284,23 @@ fn analyse_gas_usage(
             as_percentage_of(shard_usage.used_gas_total, total_gas)
         );
         println!("  Number of accounts: {}", shard_usage.used_gas_per_account.len());
+        match shard_usage.calculate_split() {
+            Some(shard_split) => {
+                println!("  Optimal split:");
+                println!("    split_account: {}", shard_split.split_account);
+                println!(
+                    "    gas(account < split_account): {} ({} of shard)",
+                    shard_split.gas_left,
+                    as_percentage_of(shard_split.gas_left, shard_usage.used_gas_total)
+                );
+                println!(
+                    "    gas(account >= split_account): {} ({} of shard)",
+                    shard_split.gas_right,
+                    as_percentage_of(shard_split.gas_right, shard_usage.used_gas_total)
+                );
+            }
+            None => println!("  No optimal split for this shard"),
+        }
         println!("");
     }
 }

--- a/tools/database/src/analyse_gas_usage.rs
+++ b/tools/database/src/analyse_gas_usage.rs
@@ -2,13 +2,19 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 use clap::Parser;
-use near_chain::{ChainStore, ChainStoreAccess};
+use near_chain::{Block, ChainStore};
 use near_epoch_manager::EpochManager;
 use near_store::{NodeStorage, Store};
 use nearcore::open_storage;
 
+use crate::block_iterators::LastNBlocksIterator;
+
 #[derive(Parser)]
-pub(crate) struct AnalyseGasUsageCommand;
+pub(crate) struct AnalyseGasUsageCommand {
+    /// Analyse the last N blocks in the blockchain
+    #[arg(long)]
+    last_blocks: Option<u64>,
+}
 
 impl AnalyseGasUsageCommand {
     pub(crate) fn run(&self, home: &PathBuf) -> anyhow::Result<()> {
@@ -24,16 +30,27 @@ impl AnalyseGasUsageCommand {
             near_config.genesis.config.genesis_height,
             false,
         ));
-        let _epoch_manager =
+        let epoch_manager =
             EpochManager::new_from_genesis_config(store, &near_config.genesis.config).unwrap();
 
-        println!(
-            "Analysing gas usage, the tip of the blockchain is: {:#?}",
-            chain_store.head().unwrap()
-        );
+        // Create an iterator over the blocks that should be analysed
+        let last_blocks_to_analyse: u64 = self.last_blocks.unwrap_or(100);
+        let blocks_iter = LastNBlocksIterator::new(last_blocks_to_analyse, chain_store.clone());
 
-        // TODO: Implement the analysis
+        // Analyse
+        analyse_gas_usage(blocks_iter, &chain_store, &epoch_manager);
 
         Ok(())
+    }
+}
+
+fn analyse_gas_usage(
+    blocks_iter: impl Iterator<Item = Block>,
+    _chain_store: &ChainStore,
+    _epoch_manager: &EpochManager,
+) {
+    for block in blocks_iter {
+        println!("Analysing block with height: {}", block.header().height());
+        // TODO: Analyse
     }
 }

--- a/tools/database/src/analyse_gas_usage.rs
+++ b/tools/database/src/analyse_gas_usage.rs
@@ -291,31 +291,31 @@ fn display_shard_split_stats<'a>(
     total_shard_gas: BigGas,
 ) {
     let mut accounts_num: u64 = 0;
-    let mut total_gas: BigGas = 0;
+    let mut total_split_half_gas: BigGas = 0;
     let mut top_3_finder = BiggestAccountsFinder::new(3);
 
     for (account, used_gas) in accounts {
         accounts_num += 1;
-        total_gas = total_gas.checked_add(*used_gas).unwrap();
+        total_split_half_gas = total_split_half_gas.checked_add(*used_gas).unwrap();
         top_3_finder.add_account_stats(account.clone(), *used_gas);
     }
 
     let indent = "      ";
     println!(
-        "{}Gas: {} ({} of shard total)",
+        "{}Gas: {} ({} of shard)",
         indent,
-        display_gas(total_gas),
-        as_percentage_of(total_gas, total_shard_gas)
+        display_gas(total_split_half_gas),
+        as_percentage_of(total_split_half_gas, total_shard_gas)
     );
     println!("{}Accounts: {}", indent, accounts_num);
     println!("{}Top 3 accounts:", indent);
     for (i, (account, used_gas)) in top_3_finder.get_biggest_accounts().enumerate() {
         println!("{}  #{}: {}", indent, i + 1, account);
         println!(
-            "{}      Used gas: {} ({} of shard split half)",
+            "{}      Used gas: {} ({} of shard)",
             indent,
             display_gas(used_gas),
-            as_percentage_of(used_gas, total_gas)
+            as_percentage_of(used_gas, total_shard_gas)
         )
     }
 }
@@ -372,7 +372,7 @@ fn analyse_gas_usage(
         if let Some((biggest_account, biggest_account_gas)) = shard_usage.biggest_account() {
             println!("  Biggest account: {}", biggest_account);
             println!(
-                "  Biggest account gas: {} ({} of shard total)",
+                "  Biggest account gas: {} ({} of shard)",
                 display_gas(biggest_account_gas),
                 as_percentage_of(biggest_account_gas, shard_total_gas)
             );

--- a/tools/database/src/analyse_gas_usage.rs
+++ b/tools/database/src/analyse_gas_usage.rs
@@ -256,6 +256,16 @@ impl BiggestAccountsFinder {
     }
 }
 
+// Calculates how much percent of `big` is `small` and returns it as a string.
+// Example: as_percentage_of(10, 100) == "10.0%"
+fn as_percentage_of(small: BigGas, big: BigGas) -> String {
+    if big > 0 {
+        format!("{:.1}%", small as f64 / big as f64 * 100.0)
+    } else {
+        format!("-")
+    }
+}
+
 fn analyse_gas_usage(
     blocks_iter: impl Iterator<Item = Block>,
     chain_store: &ChainStore,
@@ -279,16 +289,6 @@ fn analyse_gas_usage(
             get_gas_usage_in_block(&block, chain_store, epoch_manager);
         gas_usage_stats.merge(gas_usage_in_block);
     }
-
-    // Calculates how much percent of `big` is `small` and returns it as a string.
-    // Example: as_percentage_of(10, 100) == "10.0%"
-    let as_percentage_of = |small: BigGas, big: BigGas| {
-        if big > 0 {
-            format!("{:.1}%", small as f64 / big as f64 * 100.0)
-        } else {
-            format!("-")
-        }
-    };
 
     // Print out the analysis
     if blocks_count == 0 {

--- a/tools/database/src/analyse_gas_usage.rs
+++ b/tools/database/src/analyse_gas_usage.rs
@@ -123,7 +123,6 @@ impl GasUsageInShard {
         for (account_id, used_gas) in &other.used_gas_per_account {
             self.add_used_gas(account_id.clone(), *used_gas);
         }
-        self.used_gas_total = self.used_gas_total.checked_add(other.used_gas_total).unwrap();
     }
 
     /// Calculate the optimal point at which this shard could be split into two halves with similar gas usage

--- a/tools/database/src/analyse_gas_usage.rs
+++ b/tools/database/src/analyse_gas_usage.rs
@@ -381,11 +381,14 @@ fn analyse_gas_usage(
             Some(shard_split) => {
                 println!("  Optimal split:");
                 println!("    split_account: {}", shard_split.split_account);
+                let split_account_gas =
+                    *shard_usage.used_gas_per_account.get(&shard_split.split_account).unwrap();
+                println!("    gas(split_account): {}", display_gas(split_account_gas));
                 println!(
-                    "    gas(split_account): {}",
-                    display_gas(
-                        *shard_usage.used_gas_per_account.get(&shard_split.split_account).unwrap()
-                    )
+                    "    Gas distribution (left, split_acc, right): ({}, {}, {})",
+                    as_percentage_of(shard_split.gas_left, shard_total_gas),
+                    as_percentage_of(split_account_gas, shard_total_gas),
+                    as_percentage_of(shard_split.gas_right.saturating_sub(split_account_gas), shard_total_gas)
                 );
                 println!("    Left (account < split_account):");
                 let left_accounts =

--- a/tools/database/src/analyse_gas_usage.rs
+++ b/tools/database/src/analyse_gas_usage.rs
@@ -1,13 +1,29 @@
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use clap::Parser;
 use near_chain::{Block, ChainStore};
 use near_epoch_manager::EpochManager;
-use near_store::{NodeStorage, Store};
+
+use near_primitives::epoch_manager::block_info::BlockInfo;
+use near_primitives::hash::CryptoHash;
+use near_primitives::shard_layout::{account_id_to_shard_id, ShardLayout};
+use near_primitives::transaction::ExecutionOutcome;
+use near_primitives::types::{AccountId, BlockHeight, EpochId, ShardId};
+
+use near_store::{NodeStorage, ShardUId, Store};
 use nearcore::open_storage;
 
 use crate::block_iterators::LastNBlocksIterator;
+
+/// `Gas` is an u64, but it stil might overflow when analysing a large amount of blocks.
+/// 1ms of compute is about 1TGas = 10^12 gas. One epoch takes 43200 seconds (43200000ms).
+/// This means that the amount of gas consumed during a single epoch can reach 43200000 * 10^12 = 4.32 * 10^19
+/// 10^19 doesn't fit in u64, so we need to use u128
+/// To avoid overflows, let's use `BigGas` for storing gas amounts in the code.
+type BigGas = u128;
 
 #[derive(Parser)]
 pub(crate) struct AnalyseGasUsageCommand {
@@ -44,13 +60,169 @@ impl AnalyseGasUsageCommand {
     }
 }
 
+#[derive(Clone, Debug, Default)]
+struct GasUsageInShard {
+    pub used_gas_per_account: BTreeMap<AccountId, BigGas>,
+    pub used_gas_total: BigGas,
+}
+
+impl GasUsageInShard {
+    pub fn new() -> GasUsageInShard {
+        GasUsageInShard { used_gas_per_account: BTreeMap::new(), used_gas_total: 0 }
+    }
+
+    pub fn add_used_gas(&mut self, account: AccountId, used_gas: BigGas) {
+        let old_used_gas: &BigGas = self.used_gas_per_account.get(&account).unwrap_or(&0);
+        let new_used_gas: BigGas = old_used_gas.checked_add(used_gas).unwrap();
+        self.used_gas_per_account.insert(account, new_used_gas);
+
+        self.used_gas_total = self.used_gas_total.checked_add(used_gas).unwrap();
+    }
+
+    pub fn merge(&mut self, other: &GasUsageInShard) {
+        for (account_id, used_gas) in &other.used_gas_per_account {
+            self.add_used_gas(account_id.clone(), *used_gas);
+        }
+        self.used_gas_total = self.used_gas_total.checked_add(other.used_gas_total).unwrap();
+    }
+}
+
+#[derive(Clone, Debug)]
+struct GasUsageStats {
+    pub shards: BTreeMap<ShardUId, GasUsageInShard>,
+}
+
+impl GasUsageStats {
+    pub fn new() -> GasUsageStats {
+        GasUsageStats { shards: BTreeMap::new() }
+    }
+
+    pub fn add_gas_usage_in_shard(&mut self, shard_uid: ShardUId, shard_usage: GasUsageInShard) {
+        match self.shards.get_mut(&shard_uid) {
+            Some(existing_shard_usage) => existing_shard_usage.merge(&shard_usage),
+            None => {
+                let _ = self.shards.insert(shard_uid, shard_usage);
+            }
+        }
+    }
+
+    pub fn used_gas_total(&self) -> BigGas {
+        let mut result: BigGas = 0;
+        for shard_usage in self.shards.values() {
+            result = result.checked_add(shard_usage.used_gas_total).unwrap();
+        }
+        result
+    }
+
+    pub fn merge(&mut self, other: GasUsageStats) {
+        for (shard_uid, shard_usage) in other.shards {
+            self.add_gas_usage_in_shard(shard_uid, shard_usage);
+        }
+    }
+}
+
+fn get_gas_usage_in_block(
+    block: &Block,
+    chain_store: &ChainStore,
+    epoch_manager: &EpochManager,
+) -> GasUsageStats {
+    let block_info: Arc<BlockInfo> = epoch_manager.get_block_info(block.hash()).unwrap();
+    let epoch_id: &EpochId = block_info.epoch_id();
+    let shard_layout: ShardLayout = epoch_manager.get_shard_layout(epoch_id).unwrap();
+
+    let mut result = GasUsageStats::new();
+
+    // Go over every chunk in this block and gather data
+    for chunk_header in block.chunks().iter() {
+        let shard_id: ShardId = chunk_header.shard_id();
+        let shard_uid: ShardUId = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
+
+        let mut gas_usage_in_shard = GasUsageInShard::new();
+
+        // The outcome of each transaction and receipt executed in this chunk is saved in the database as an ExecutionOutcome.
+        // Go through all ExecutionOutcomes from this chunk and record the gas usage.
+        let outcome_ids: Vec<CryptoHash> =
+            chain_store.get_outcomes_by_block_hash_and_shard_id(block.hash(), shard_id).unwrap();
+        for outcome_id in outcome_ids {
+            let outcome: ExecutionOutcome = chain_store
+                .get_outcome_by_id_and_block_hash(&outcome_id, block.hash())
+                .unwrap()
+                .unwrap()
+                .outcome;
+
+            // Sanity check - make sure that the executor of this outcome belongs to this shard
+            let account_shard: ShardId =
+                account_id_to_shard_id(&outcome.executor_id, &shard_layout);
+            assert_eq!(account_shard, shard_id);
+
+            gas_usage_in_shard.add_used_gas(outcome.executor_id, outcome.gas_burnt.into());
+        }
+
+        result.add_gas_usage_in_shard(shard_uid, gas_usage_in_shard);
+    }
+
+    result
+}
+
 fn analyse_gas_usage(
     blocks_iter: impl Iterator<Item = Block>,
-    _chain_store: &ChainStore,
-    _epoch_manager: &EpochManager,
+    chain_store: &ChainStore,
+    epoch_manager: &EpochManager,
 ) {
+    // Gather statistics about gas usage in all of the blocks
+    let mut blocks_count: usize = 0;
+    let mut first_analysed_block: Option<(BlockHeight, CryptoHash)> = None;
+    let mut last_analysed_block: Option<(BlockHeight, CryptoHash)> = None;
+
+    let mut gas_usage_stats = GasUsageStats::new();
+
     for block in blocks_iter {
-        println!("Analysing block with height: {}", block.header().height());
-        // TODO: Analyse
+        blocks_count += 1;
+        if first_analysed_block.is_none() {
+            first_analysed_block = Some((block.header().height(), *block.hash()));
+        }
+        last_analysed_block = Some((block.header().height(), *block.hash()));
+
+        let gas_usage_in_block: GasUsageStats =
+            get_gas_usage_in_block(&block, chain_store, epoch_manager);
+        gas_usage_stats.merge(gas_usage_in_block);
+    }
+
+    // Calculates how much percent of `big` is `small` and returns it as a string.
+    // Example: as_percentage_of(10, 100) == "10.0%"
+    let as_percentage_of = |small: BigGas, big: BigGas| {
+        if big > 0 {
+            format!("{:.1}%", small as f64 / big as f64 * 100.0)
+        } else {
+            format!("-")
+        }
+    };
+
+    // Print out the analysis
+    if blocks_count == 0 {
+        println!("No blocks to analyse!");
+        return;
+    }
+    println!("");
+    println!("Analysed {} blocks between:", blocks_count);
+    if let Some((block_height, block_hash)) = first_analysed_block {
+        println!("Block: height = {block_height}, hash = {block_hash}");
+    }
+    if let Some((block_height, block_hash)) = last_analysed_block {
+        println!("Block: height = {block_height}, hash = {block_hash}");
+    }
+    let total_gas: BigGas = gas_usage_stats.used_gas_total();
+    println!("");
+    println!("Total gas used: {}", total_gas);
+    println!("");
+    for (shard_uid, shard_usage) in &gas_usage_stats.shards {
+        println!("Shard: {}", shard_uid);
+        println!(
+            "  Gas usage: {} ({} of total)",
+            shard_usage.used_gas_total,
+            as_percentage_of(shard_usage.used_gas_total, total_gas)
+        );
+        println!("  Number of accounts: {}", shard_usage.used_gas_per_account.len());
+        println!("");
     }
 }

--- a/tools/database/src/analyse_gas_usage.rs
+++ b/tools/database/src/analyse_gas_usage.rs
@@ -1,0 +1,39 @@
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use clap::Parser;
+use near_chain::{ChainStore, ChainStoreAccess};
+use near_epoch_manager::EpochManager;
+use near_store::{NodeStorage, Store};
+use nearcore::open_storage;
+
+#[derive(Parser)]
+pub(crate) struct AnalyseGasUsageCommand;
+
+impl AnalyseGasUsageCommand {
+    pub(crate) fn run(&self, home: &PathBuf) -> anyhow::Result<()> {
+        // Create a ChainStore and EpochManager that will be used to read blockchain data.
+        let mut near_config =
+            nearcore::config::load_config(home, near_chain_configs::GenesisValidationMode::Full)
+                .unwrap();
+        let node_storage: NodeStorage = open_storage(&home, &mut near_config).unwrap();
+        let store: Store =
+            node_storage.get_split_store().unwrap_or_else(|| node_storage.get_hot_store());
+        let chain_store = Rc::new(ChainStore::new(
+            store.clone(),
+            near_config.genesis.config.genesis_height,
+            false,
+        ));
+        let _epoch_manager =
+            EpochManager::new_from_genesis_config(store, &near_config.genesis.config).unwrap();
+
+        println!(
+            "Analysing gas usage, the tip of the blockchain is: {:#?}",
+            chain_store.head().unwrap()
+        );
+
+        // TODO: Implement the analysis
+
+        Ok(())
+    }
+}

--- a/tools/database/src/analyse_gas_usage.rs
+++ b/tools/database/src/analyse_gas_usage.rs
@@ -25,6 +25,12 @@ use crate::block_iterators::{CommandArgs, LastNBlocksIterator};
 /// To avoid overflows, let's use `BigGas` for storing gas amounts in the code.
 type BigGas = u128;
 
+/// Display gas amount in a human-friendly way
+fn display_gas(gas: BigGas) -> String {
+    let tera_gas = gas as f64 / 1e12;
+    format!("{:.2} TGas", tera_gas)
+}
+
 #[derive(Parser)]
 pub(crate) struct AnalyseGasUsageCommand {
     /// Analyse the last N blocks in the blockchain
@@ -299,13 +305,13 @@ fn analyse_gas_usage(
     }
     let total_gas: BigGas = gas_usage_stats.used_gas_total();
     println!("");
-    println!("Total gas used: {}", total_gas);
+    println!("Total gas used: {}", display_gas(total_gas));
     println!("");
     for (shard_uid, shard_usage) in &gas_usage_stats.shards {
         println!("Shard: {}", shard_uid);
         println!(
             "  Gas usage: {} ({} of total)",
-            shard_usage.used_gas_total,
+            display_gas(shard_usage.used_gas_total),
             as_percentage_of(shard_usage.used_gas_total, total_gas)
         );
         println!("  Number of accounts: {}", shard_usage.used_gas_per_account.len());
@@ -315,12 +321,12 @@ fn analyse_gas_usage(
                 println!("    split_account: {}", shard_split.split_account);
                 println!(
                     "    gas(account < split_account): {} ({} of shard)",
-                    shard_split.gas_left,
+                    display_gas(shard_split.gas_left),
                     as_percentage_of(shard_split.gas_left, shard_usage.used_gas_total)
                 );
                 println!(
                     "    gas(account >= split_account): {} ({} of shard)",
-                    shard_split.gas_right,
+                    display_gas(shard_split.gas_right),
                     as_percentage_of(shard_split.gas_right, shard_usage.used_gas_total)
                 );
             }
@@ -341,7 +347,7 @@ fn analyse_gas_usage(
         println!("#{}: {}", i + 1, account);
         println!(
             "    Used gas: {} ({} of total)",
-            gas_usage,
+            display_gas(gas_usage),
             as_percentage_of(gas_usage, total_gas)
         )
     }

--- a/tools/database/src/analyse_gas_usage.rs
+++ b/tools/database/src/analyse_gas_usage.rs
@@ -113,9 +113,8 @@ impl GasUsageInShard {
     }
 
     pub fn add_used_gas(&mut self, account: AccountId, used_gas: BigGas) {
-        let old_used_gas: &BigGas = self.used_gas_per_account.get(&account).unwrap_or(&0);
-        let new_used_gas: BigGas = old_used_gas.checked_add(used_gas).unwrap();
-        self.used_gas_per_account.insert(account, new_used_gas);
+        let account_gas = self.used_gas_per_account.entry(account).or_insert(0);
+        *account_gas = account_gas.checked_add(used_gas).unwrap();
     }
 
     pub fn used_gas_total(&self) -> BigGas {

--- a/tools/database/src/block_iterators/height_range.rs
+++ b/tools/database/src/block_iterators/height_range.rs
@@ -1,0 +1,83 @@
+use std::rc::Rc;
+
+use near_chain::{Block, ChainStore, ChainStoreAccess, Error};
+use near_primitives::{hash::CryptoHash, types::BlockHeight};
+
+/// Iterate over blocks between two block heights.
+/// `from_height` and `to_height` are inclusive
+pub struct BlockHeightRangeIterator {
+    chain_store: Rc<ChainStore>,
+    from_block_height: BlockHeight,
+    /// Hash of the block that will be returned when next() is called
+    current_block_hash: Option<CryptoHash>,
+}
+
+impl BlockHeightRangeIterator {
+    /// Create an iterator which iterates over blocks between from_height and to_height.
+    /// `from_height` and `to_height` are inclusive.
+    /// Both arguments are optional, passing `None`` means that the limit is +- infinity.
+    pub fn new(
+        from_height_opt: Option<BlockHeight>,
+        to_height_opt: Option<BlockHeight>,
+        chain_store: Rc<ChainStore>,
+    ) -> BlockHeightRangeIterator {
+        if let (Some(from), Some(to)) = (&from_height_opt, &to_height_opt) {
+            if *from > *to {
+                // Empty iterator
+                return BlockHeightRangeIterator {
+                    chain_store,
+                    from_block_height: 0,
+                    current_block_hash: None,
+                };
+            }
+        }
+
+        let min_height: BlockHeight = chain_store.get_genesis_height();
+        let max_height: BlockHeight = chain_store.head().unwrap().height;
+
+        let from_height: BlockHeight = from_height_opt.unwrap_or(min_height);
+        let mut to_height: BlockHeight = to_height_opt.unwrap_or(max_height);
+
+        // There is no point in going over nonexisting blocks past the highest height
+        if to_height > max_height {
+            to_height = max_height;
+        }
+
+        // A block with height `to_height` might not exist.
+        // Go over the range in reverse and find the highest block that exists.
+        let mut current_block_hash: Option<CryptoHash> = None;
+        for height in (from_height..=to_height).rev() {
+            match chain_store.get_block_hash_by_height(height) {
+                Ok(hash) => {
+                    current_block_hash = Some(hash);
+                    break;
+                }
+                Err(Error::DBNotFoundErr(_)) => continue,
+                err => err.unwrap(),
+            };
+        }
+
+        BlockHeightRangeIterator { chain_store, from_block_height: from_height, current_block_hash }
+    }
+}
+
+impl Iterator for BlockHeightRangeIterator {
+    type Item = Block;
+
+    fn next(&mut self) -> Option<Block> {
+        if let Some(hash) = self.current_block_hash.take() {
+            let current_block = self.chain_store.get_block(&hash).unwrap();
+            // Make sure that the block is within the from..=to range, stop iterating if it isn't
+            if current_block.header().height() >= self.from_block_height {
+                // Set the previous block as "current" one, as long as the current one isn't the genesis block
+                if current_block.header().height() != self.chain_store.get_genesis_height() {
+                    self.current_block_hash = Some(*current_block.header().prev_hash());
+                }
+
+                return Some(current_block);
+            }
+        }
+
+        None
+    }
+}

--- a/tools/database/src/block_iterators/height_range.rs
+++ b/tools/database/src/block_iterators/height_range.rs
@@ -32,11 +32,11 @@ impl BlockHeightRangeIterator {
             }
         }
 
-        let min_height: BlockHeight = chain_store.get_genesis_height();
-        let max_height: BlockHeight = chain_store.head().unwrap().height;
+        let min_height = chain_store.get_genesis_height();
+        let max_height = chain_store.head().unwrap().height;
 
-        let from_height: BlockHeight = from_height_opt.unwrap_or(min_height);
-        let mut to_height: BlockHeight = to_height_opt.unwrap_or(max_height);
+        let from_height = from_height_opt.unwrap_or(min_height);
+        let mut to_height = to_height_opt.unwrap_or(max_height);
 
         // There is no point in going over nonexisting blocks past the highest height
         if to_height > max_height {
@@ -65,7 +65,7 @@ impl Iterator for BlockHeightRangeIterator {
     type Item = Block;
 
     fn next(&mut self) -> Option<Block> {
-        let current_block_hash: CryptoHash = match self.current_block_hash.take() {
+        let current_block_hash = match self.current_block_hash.take() {
             Some(hash) => hash,
             None => return None,
         };

--- a/tools/database/src/block_iterators/last_blocks.rs
+++ b/tools/database/src/block_iterators/last_blocks.rs
@@ -29,7 +29,7 @@ impl Iterator for LastNBlocksIterator {
         };
 
         if let Some(current_block_hash) = self.current_block_hash.take() {
-            let current_block: Block = self.chain_store.get_block(&current_block_hash).unwrap();
+            let current_block = self.chain_store.get_block(&current_block_hash).unwrap();
 
             // Set the previous block as "current" one, as long as the current one isn't the genesis block
             if current_block.header().height() != self.chain_store.get_genesis_height() {

--- a/tools/database/src/block_iterators/last_blocks.rs
+++ b/tools/database/src/block_iterators/last_blocks.rs
@@ -1,0 +1,43 @@
+use std::rc::Rc;
+
+use near_chain::{Block, ChainStore, ChainStoreAccess};
+use near_primitives::hash::CryptoHash;
+
+/// Iterate over the last N blocks in the blockchain
+pub struct LastNBlocksIterator {
+    chain_store: Rc<ChainStore>,
+    blocks_left: u64,
+    /// Hash of the block that will be returned when next() is called
+    current_block_hash: Option<CryptoHash>,
+}
+
+impl LastNBlocksIterator {
+    pub fn new(blocks_num: u64, chain_store: Rc<ChainStore>) -> LastNBlocksIterator {
+        let current_block_hash = Some(chain_store.head().unwrap().last_block_hash);
+        LastNBlocksIterator { chain_store, blocks_left: blocks_num, current_block_hash }
+    }
+}
+
+impl Iterator for LastNBlocksIterator {
+    type Item = Block;
+
+    fn next(&mut self) -> Option<Block> {
+        // Decrease the amount of blocks left to produce
+        match self.blocks_left.checked_sub(1) {
+            Some(new_blocks_left) => self.blocks_left = new_blocks_left,
+            None => return None,
+        };
+
+        if let Some(current_block_hash) = self.current_block_hash.take() {
+            let current_block: Block = self.chain_store.get_block(&current_block_hash).unwrap();
+
+            // Set the previous block as "current" one, as long as the current one isn't the genesis block
+            if current_block.header().height() != self.chain_store.get_genesis_height() {
+                self.current_block_hash = Some(*current_block.header().prev_hash());
+            }
+            return Some(current_block);
+        }
+
+        None
+    }
+}

--- a/tools/database/src/block_iterators/mod.rs
+++ b/tools/database/src/block_iterators/mod.rs
@@ -1,0 +1,6 @@
+//! This module contains iterators that can be used to iterate over blocks in the database
+
+pub mod last_blocks;
+
+/// Iterate over the last N blocks in the blockchain
+pub use last_blocks::LastNBlocksIterator;

--- a/tools/database/src/block_iterators/mod.rs
+++ b/tools/database/src/block_iterators/mod.rs
@@ -1,6 +1,61 @@
 //! This module contains iterators that can be used to iterate over blocks in the database
 
-pub mod last_blocks;
+mod height_range;
+mod last_blocks;
+
+use std::rc::Rc;
+
+use near_chain::{Block, ChainStore};
+use near_primitives::types::BlockHeight;
+
+/// Iterate over blocks between two block heights.
+/// `from_height` and `to_height` are inclusive
+pub use height_range::BlockHeightRangeIterator;
 
 /// Iterate over the last N blocks in the blockchain
 pub use last_blocks::LastNBlocksIterator;
+
+/// Arguments that user can pass to a command to choose some subset of blocks
+pub struct CommandArgs {
+    /// Analyse the last N blocks
+    pub last_blocks: Option<u64>,
+
+    /// Analyse blocks from the given block height, inclusive
+    pub from_block_height: Option<BlockHeight>,
+
+    /// Analyse blocks up to the given block height, inclusive
+    pub to_block_height: Option<BlockHeight>,
+}
+
+/// Produce to right iterator for a given set of command line arguments
+pub fn make_block_iterator_from_command_args(
+    command_args: CommandArgs,
+    chain_store: Rc<ChainStore>,
+) -> Option<Box<dyn Iterator<Item = Block>>> {
+    // Make sure that only one type of argument is used (there is no mixing of last_blocks and from_block_height)
+    let mut arg_types_used: u64 = 0;
+    if command_args.last_blocks.is_some() {
+        arg_types_used += 1;
+    }
+    if command_args.from_block_height.is_some() || command_args.from_block_height.is_some() {
+        arg_types_used += 1;
+    }
+
+    if arg_types_used > 1 {
+        panic!("It is illegal to mix multiple types of arguments specifying a subset of blocks");
+    }
+
+    if let Some(last_blocks) = command_args.last_blocks {
+        return Some(Box::new(LastNBlocksIterator::new(last_blocks, chain_store)));
+    }
+
+    if command_args.from_block_height.is_some() || command_args.to_block_height.is_some() {
+        return Some(Box::new(BlockHeightRangeIterator::new(
+            command_args.from_block_height,
+            command_args.to_block_height,
+            chain_store,
+        )));
+    }
+
+    None
+}

--- a/tools/database/src/commands.rs
+++ b/tools/database/src/commands.rs
@@ -1,5 +1,6 @@
 use crate::adjust_database::ChangeDbKindCommand;
 use crate::analyse_data_size_distribution::AnalyseDataSizeDistributionCommand;
+use crate::analyse_gas_usage::AnalyseGasUsageCommand;
 use crate::compact::RunCompactionCommand;
 use crate::corrupt::CorruptStateSnapshotCommand;
 use crate::make_snapshot::MakeSnapshotCommand;
@@ -20,6 +21,9 @@ pub struct DatabaseCommand {
 enum SubCommand {
     /// Analyse data size distribution in RocksDB
     AnalyseDataSizeDistribution(AnalyseDataSizeDistributionCommand),
+
+    /// Analyse gas usage in a chosen sequnce of blocks
+    AnalyseGasUsage(AnalyseGasUsageCommand),
 
     /// Change DbKind of hot or cold db.
     ChangeDbKind(ChangeDbKindCommand),
@@ -48,6 +52,7 @@ impl DatabaseCommand {
     pub fn run(&self, home: &PathBuf) -> anyhow::Result<()> {
         match &self.subcmd {
             SubCommand::AnalyseDataSizeDistribution(cmd) => cmd.run(home),
+            SubCommand::AnalyseGasUsage(cmd) => cmd.run(home),
             SubCommand::ChangeDbKind(cmd) => cmd.run(home),
             SubCommand::CompactDatabase(cmd) => cmd.run(home),
             SubCommand::CorruptStateSnapshot(cmd) => cmd.run(home),

--- a/tools/database/src/lib.rs
+++ b/tools/database/src/lib.rs
@@ -1,5 +1,6 @@
 mod adjust_database;
 mod analyse_data_size_distribution;
+mod analyse_gas_usage;
 pub mod commands;
 mod compact;
 mod corrupt;

--- a/tools/database/src/lib.rs
+++ b/tools/database/src/lib.rs
@@ -1,6 +1,7 @@
 mod adjust_database;
 mod analyse_data_size_distribution;
 mod analyse_gas_usage;
+mod block_iterators;
 pub mod commands;
 mod compact;
 mod corrupt;


### PR DESCRIPTION
Add a command which allows to analyse gas usage on some part of the blockchain.
The command goes over the specified blocks and gathers information about how much
gas was used by each block, shard and account.
Then it displays an analysis of all the data.

The analysis contains:
* Total gas used
* Gas used on each shard
* Top 10 accounts by gas usage
* The optimal account by which a shard could be split into two halves with similar gas usage

Help page:
```bash
$ ./neard database analyse-gas-usage --help
Analyse gas usage in a chosen sequnce of blocks

Usage: neard database analyse-gas-usage [OPTIONS]

Options:
      --last-blocks <LAST_BLOCKS>
          Analyse the last N blocks in the blockchain
      --from-block-height <FROM_BLOCK_HEIGHT>
          Analyse blocks from the given block height, inclusive
      --to-block-height <TO_BLOCK_HEIGHT>
          Analyse blocks up to the given block height, inclusive
  -h, --help
          Print help
```

Example usage:
```bash
# Analyse gas usage in the last 1000 blocks
cargo run --bin neard -- database analyse-gas-usage --last-blocks 1000

# Analyse gas usage in blocks with heights between 200 and 300 (inclusive)
./neard database analyse-gas-usage --from-block-height 200 --to-block-height 300
```