### PR TITLE
feat: support partial mandates in chunk validator assignment

### DIFF
--- a/chain/epoch-manager/src/validator_selection.rs
+++ b/chain/epoch-manager/src/validator_selection.rs
@@ -384,6 +384,8 @@ mod tests {
     use near_primitives::epoch_manager::ValidatorSelectionConfig;
     use near_primitives::shard_layout::ShardLayout;
     use near_primitives::types::validator_stake::ValidatorStake;
+    #[cfg(feature = "protocol_feature_chunk_validation")]
+    use near_primitives::validator_mandates::{AssignmentWeight, ValidatorMandatesAssignment};
     use near_primitives::version::PROTOCOL_VERSION;
     use num_rational::Ratio;
 
@@ -651,13 +653,27 @@ mod tests {
             ValidatorSelectionConfig {
                 num_chunk_only_producer_seats: 0,
                 minimum_validators_per_shard: 1,
-                minimum_stake_ratio: Ratio::new(160, 1_000_000),
+                // for example purposes, we choose a higher ratio than in production
+                minimum_stake_ratio: Ratio::new(1, 10),
             },
         );
         let prev_epoch_height = 7;
         let prev_epoch_info = create_prev_epoch_info(prev_epoch_height, &["test1", "test2"], &[]);
-        let proposals =
-            create_proposals(&[("test1", 15), ("test2", 9), ("test3", 5), ("test4", 3)]);
+
+        // Choosing proposals s.t. the `threshold` (i.e. seat price) calculated in
+        // `proposals_to_epoch_info` below will be 100. For now, this `threshold` is used as the
+        // stake required for a chunk validator mandate.
+        //
+        // Note that `proposals_to_epoch_info` will not include `test6` in the set of validators,
+        // hence it will not hold a (partial) mandate
+        let proposals = create_proposals(&[
+            ("test1", 1500),
+            ("test2", 1000),
+            ("test3", 1000),
+            ("test4", 260),
+            ("test5", 140),
+            ("test6", 50),
+        ]);
 
         let epoch_info = proposals_to_epoch_info(
             &epoch_config,
@@ -674,11 +690,30 @@ mod tests {
 
         // Given `epoch_info` and `proposals` above, the sample at a given height is deterministic.
         let height = 42;
-        let expected_assignments: Vec<HashMap<ValidatorId, u16>> = vec![
-            HashMap::from([(0, 1), (1, 5), (2, 1), (3, 1)]),
-            HashMap::from([(0, 6), (1, 1), (2, 1)]),
-            HashMap::from([(0, 5), (1, 2), (2, 1)]),
-            HashMap::from([(0, 3), (1, 1), (2, 2), (3, 2)]),
+        let expected_assignments: ValidatorMandatesAssignment = vec![
+            HashMap::from([
+                (0, AssignmentWeight::new(2, 0)),
+                (1, AssignmentWeight::new(4, 0)),
+                (2, AssignmentWeight::new(2, 0)),
+                (3, AssignmentWeight::new(1, 60)),
+                (4, AssignmentWeight::new(1, 0)),
+            ]),
+            HashMap::from([
+                (0, AssignmentWeight::new(4, 0)),
+                (1, AssignmentWeight::new(2, 0)),
+                (2, AssignmentWeight::new(4, 0)),
+                (4, AssignmentWeight::new(0, 40)),
+            ]),
+            HashMap::from([
+                (0, AssignmentWeight::new(7, 0)),
+                (1, AssignmentWeight::new(1, 0)),
+                (3, AssignmentWeight::new(1, 0)),
+            ]),
+            HashMap::from([
+                (0, AssignmentWeight::new(2, 0)),
+                (1, AssignmentWeight::new(3, 0)),
+                (2, AssignmentWeight::new(4, 0)),
+            ]),
         ];
         assert_eq!(epoch_info.sample_chunk_validators(height), expected_assignments);
     }

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -522,7 +522,7 @@ pub mod epoch_info {
     use crate::epoch_manager::ValidatorWeight;
     use crate::types::validator_stake::{ValidatorStake, ValidatorStakeIter};
     use crate::types::{BlockChunkValidatorStats, ValidatorKickoutReason};
-    use crate::validator_mandates::ValidatorMandates;
+    use crate::validator_mandates::{ValidatorMandates, ValidatorMandatesAssignment};
     use crate::version::PROTOCOL_VERSION;
     use borsh::{BorshDeserialize, BorshSerialize};
     use near_primitives_core::hash::CryptoHash;
@@ -1101,10 +1101,7 @@ pub mod epoch_info {
             }
         }
 
-        pub fn sample_chunk_validators(
-            &self,
-            height: BlockHeight,
-        ) -> Vec<HashMap<ValidatorId, u16>> {
+        pub fn sample_chunk_validators(&self, height: BlockHeight) -> ValidatorMandatesAssignment {
             // Chunk validator assignment was introduced with `V4`.
             match &self {
                 Self::V1(_) => Default::default(),

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -688,6 +688,19 @@ pub mod validator_stake {
                 .expect("number of mandats should fit u16")
         }
 
+        /// Returns the weight attributed to the validator's partial mandate.
+        ///
+        /// A validator has a partial mandate if its stake cannot be divided evenly by
+        /// `stake_per_mandate`. The remainder of that division is the weight of the partial
+        /// mandate.
+        ///
+        /// Due to this definintion a validator has exactly one partial mandate with `0 <= weight <
+        /// stake_per_mandate`.
+        ///
+        /// # Example
+        ///
+        /// Let `V` be a validator with stake of 12. If `stake_per_mandate` equals 5 then the weight
+        /// of `V`'s partial mandate is `12 % 5 = 2`.
         pub fn partial_mandate_weight(&self, stake_per_mandate: Balance) -> Balance {
             self.stake() % stake_per_mandate
         }

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -687,6 +687,10 @@ pub mod validator_stake {
             u16::try_from(self.stake() / stake_per_mandate)
                 .expect("number of mandats should fit u16")
         }
+
+        pub fn partial_mandate_weight(&self, stake_per_mandate: Balance) -> Balance {
+            self.stake() % stake_per_mandate
+        }
     }
 }
 

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -1046,3 +1046,33 @@ pub struct StateChangesForShard {
     pub shard_id: ShardId,
     pub state_changes: Vec<RawStateChangesWithTrieKey>,
 }
+
+#[cfg(test)]
+mod tests {
+    use near_crypto::{KeyType, PublicKey};
+    use near_primitives_core::types::Balance;
+
+    use super::validator_stake::ValidatorStake;
+
+    fn new_validator_stake(stake: Balance) -> ValidatorStake {
+        ValidatorStake::new(
+            "test_account".parse().unwrap(),
+            PublicKey::empty(KeyType::ED25519),
+            stake,
+        )
+    }
+
+    #[test]
+    fn test_validator_stake_num_mandates() {
+        assert_eq!(new_validator_stake(0).num_mandates(5), 0);
+        assert_eq!(new_validator_stake(10).num_mandates(5), 2);
+        assert_eq!(new_validator_stake(12).num_mandates(5), 2);
+    }
+
+    #[test]
+    fn test_validator_partial_mandate_weight() {
+        assert_eq!(new_validator_stake(0).partial_mandate_weight(5), 0);
+        assert_eq!(new_validator_stake(10).partial_mandate_weight(5), 0);
+        assert_eq!(new_validator_stake(12).partial_mandate_weight(5), 2);
+    }
+}

--- a/core/primitives/src/validator_mandates.rs
+++ b/core/primitives/src/validator_mandates.rs
@@ -48,6 +48,9 @@ pub struct ValidatorMandates {
     config: ValidatorMandatesConfig,
     /// The id of a validator who holds `n >= 0` mandates occurs `n` times in the vector.
     mandates: Vec<ValidatorId>,
+    /// Contains partial mandates. Validators whose stake can be distributed across mandates without
+    /// remainder are not represented in this vector.
+    partials: Vec<(ValidatorId, Balance)>,
 }
 
 impl ValidatorMandates {
@@ -81,55 +84,107 @@ impl ValidatorMandates {
             );
         }
 
-        Self { config, mandates }
+        // TODO comment why partials aren't considered for `required_mandates`
+        // Construct vector with capacity as most likely some validators' stake will not be evenly
+        // divided by `config.stake_per_mandate`.
+        let mut partials = Vec::with_capacity(validators.len());
+        for i in 0..validators.len() {
+            let partial_weight = validators[i].partial_mandate_weight(config.stake_per_mandate);
+            if partial_weight > 0 {
+                partials.push((i as ValidatorId, partial_weight));
+            }
+        }
+
+        Self { config, mandates, partials }
     }
 
     /// Returns a validator assignment obtained by shuffling mandates.
     ///
     /// It clones mandates since [`ValidatorMandates`] is supposed to be valid for an epoch, while a
     /// new assignment is calculated at every height.
-    ///
-    /// # Interpretation of the return value
-    ///
-    /// The returned vector contains one map per shard, with the position in the vector
-    /// corresponding to `shard_id` in `0..num_shards`.
-    ///
-    /// Each `HashMap` maps `ValidatorId`s to the number of mandates they have in the corresponding
-    /// shards. A validator whose id is not in a map has not been assigned to the shard.
-    ///
-    /// ## Example
-    ///
-    /// Let `res` be the return value of this function, then `res[0][1]` maps to the number of
-    /// mandates validator with `ValidatorId` 1 holds in shard with id 0.
-    pub fn sample<R>(&self, rng: &mut R) -> Vec<HashMap<ValidatorId, u16>>
+    pub fn sample<R>(&self, rng: &mut R) -> ValidatorMandatesAssignment
     where
         R: Rng + ?Sized,
     {
-        let shuffled_mandates = self.shuffled(rng);
+        let shuffled_mandates = self.shuffled_mandates(rng);
+        let shuffled_partials = self.shuffled_partials(rng);
 
-        // Assign shuffled seat at position `i` to the shard with id `i % num_shards`.
-        let mut assignments_per_shard = Vec::with_capacity(self.config.num_shards);
+        // TODO shuffle shard ids
+        let mut mandates_per_shard = Vec::with_capacity(self.config.num_shards);
         for shard_id in 0..self.config.num_shards {
-            let mut assignments = HashMap::new();
+            let mut assignments: HashMap<ValidatorId, AssignmentWeight> = HashMap::new();
+
+            // Assign shuffled mandates at position `i` to the shard with id `i % num_shards`.
             for idx in (shard_id..shuffled_mandates.len()).step_by(self.config.num_shards) {
                 let id = shuffled_mandates[idx];
-                assignments.entry(id).and_modify(|counter| *counter += 1).or_insert(1);
+                assignments
+                    .entry(id)
+                    .and_modify(|assignment_weight| {
+                        assignment_weight.num_mandates += 1;
+                    })
+                    .or_insert(AssignmentWeight::new(1, 0));
             }
-            assignments_per_shard.push(assignments)
+
+            // Assign shuffled partials at position `i` to the shard with id `i % num_shards`.
+            for idx in (shard_id..shuffled_partials.len()).step_by(self.config.num_shards) {
+                let (id, partial_weight) = shuffled_partials[idx];
+                assignments
+                    .entry(id)
+                    .and_modify(|assignment_weight| {
+                        assignment_weight.partial_weight += partial_weight;
+                    })
+                    .or_insert(AssignmentWeight::new(0, partial_weight));
+            }
+
+            mandates_per_shard.push(assignments)
         }
 
-        assignments_per_shard
+        mandates_per_shard
     }
 
     /// Clones the contained mandates and shuffles them. Cloning is required as a shuffle happens at
     /// every height while the `ValidatorMandates` are to be valid for an epoch.
-    fn shuffled<R>(&self, rng: &mut R) -> Vec<ValidatorId>
+    fn shuffled_mandates<R>(&self, rng: &mut R) -> Vec<ValidatorId>
     where
         R: Rng + ?Sized,
     {
         let mut shuffled_mandates = self.mandates.clone();
         shuffled_mandates.shuffle(rng);
         shuffled_mandates
+    }
+
+    /// Clones the contained partials and shuffles them. Cloning is required as a shuffle happens at
+    /// every height while the `ValidatorMandates` are to be valid for an epoch.
+    fn shuffled_partials<R>(&self, rng: &mut R) -> Vec<(ValidatorId, Balance)>
+    where
+        R: Rng + ?Sized,
+    {
+        let mut shuffled_partials = self.partials.clone();
+        shuffled_partials.shuffle(rng);
+        shuffled_partials
+    }
+}
+
+/// Represents an assignment of [`ValidatorMandates`] for a specific height.
+///
+/// Contains one map per shard, with the position in the vector corresponding to `shard_id` in
+/// `0..num_shards`. Each `HashMap` maps `ValidatorId`s to the number of mandates they have in the
+/// corresponding shards. A validator whose id is not in a map has not been assigned to the shard.
+///
+/// For example, `mandates_per_shard[0][1]` maps to the [`AssignmentWeights`] validator with
+/// `ValidatorId` 1 holds in shard with id 0.
+pub type ValidatorMandatesAssignment = Vec<HashMap<ValidatorId, AssignmentWeight>>;
+
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
+pub struct AssignmentWeight {
+    pub num_mandates: u16,
+    /// Stake assigned to this partial mandate.
+    pub partial_weight: Balance,
+}
+
+impl AssignmentWeight {
+    pub fn new(num_mandates: u16, partial_weight: Balance) -> Self {
+        Self { num_mandates, partial_weight }
     }
 }
 
@@ -147,7 +202,7 @@ mod tests {
         validator_mandates::ValidatorMandatesConfig,
     };
 
-    use super::ValidatorMandates;
+    use super::{AssignmentWeight, ValidatorMandates, ValidatorMandatesAssignment};
 
     /// Returns a new, fixed RNG to be used only in tests. Using a fixed RNG facilitates testing as
     /// it makes outcomes based on that RNG deterministic.
@@ -174,8 +229,15 @@ mod tests {
     /// `vec![0, 0, 0, 1, 1, 3, 4, 4, 4]`
     ///
     /// The shuffling based on `new_fixed_rng` is (verified in
-    /// [`test_validator_mandates_shuffled`]):
+    /// [`test_validator_mandates_shuffled_mandates`]):
     /// `vec![0, 0, 0, 1, 1, 3, 4, 4, 4]`
+    ///
+    /// The partials are (verified in [`test_validator_mandates_new`]):
+    /// `vec![(1, 7), (2, 9), (3, 2), (4, 5), (5, 4), (6, 6)]`
+    ///
+    /// The shuffled partials used in tests are (verified in
+    /// [`test_validator_mandates_shuffled_partials`]):
+    /// `vec![(1, 7), (4, 5), (2, 9), (3, 2), (6, 6), (5, 4)]`
     fn new_validator_stakes() -> Vec<ValidatorStake> {
         let new_vs = |account_id: &str, balance: Balance| -> ValidatorStake {
             ValidatorStake::new(
@@ -191,6 +253,8 @@ mod tests {
             new_vs("account_2", 9),
             new_vs("account_3", 12),
             new_vs("account_4", 35),
+            new_vs("account_5", 4),
+            new_vs("account_6", 6),
         ]
     }
 
@@ -204,53 +268,116 @@ mod tests {
         // Note that "account_2" holds no mandate as its stake is below the threshold.
         let expected_mandates: Vec<ValidatorId> = vec![0, 0, 0, 1, 1, 3, 4, 4, 4];
         assert_eq!(mandates.mandates, expected_mandates);
+
+        // At 10 stake per mandate, the first validator holds no partial mandate, the second
+        // validator holds a partial mandate with weight 7, and so on.
+        let expected_partials: Vec<(ValidatorId, Balance)> =
+            vec![(1, 7), (2, 9), (3, 2), (4, 5), (5, 4), (6, 6)];
+        assert_eq!(mandates.partials, expected_partials);
     }
 
     #[test]
-    fn test_validator_mandates_shuffled() {
+    fn test_validator_mandates_shuffled_mandates() {
         let validators = new_validator_stakes();
         let config = ValidatorMandatesConfig::new(10, 1, 4);
         let mandates = ValidatorMandates::new(config, &validators);
         let mut rng = new_fixed_rng();
-        let assignment = mandates.shuffled(&mut rng);
+        let assignment = mandates.shuffled_mandates(&mut rng);
         let expected_assignment: Vec<ValidatorId> = vec![0, 1, 1, 4, 4, 4, 0, 3, 0];
         assert_eq!(assignment, expected_assignment);
     }
 
-    /// Test mandates per shard are collected correctly if `num_mandates % num_shards == 0`.
     #[test]
-    fn test_assigned_validator_mandates_get_mandates_for_shard_even() {
-        // Choosing `num_shards` such that mandates are distributed evenly.
-        let config = ValidatorMandatesConfig::new(10, 1, 3);
-        let expected_mandates_per_shards: Vec<HashMap<ValidatorId, u16>> = vec![
-            HashMap::from([(0, 2), (4, 1)]),
-            HashMap::from([(1, 1), (3, 1), (4, 1)]),
-            HashMap::from([(0, 1), (1, 1), (4, 1)]),
-        ];
-        assert_validator_mandates_sample(config, expected_mandates_per_shards);
+    fn test_validator_mandates_shuffled_partials() {
+        let validators = new_validator_stakes();
+        let config = ValidatorMandatesConfig::new(10, 1, 4);
+        let mandates = ValidatorMandates::new(config, &validators);
+        let mut rng = new_fixed_rng();
+
+        // Call `shuffled_mandates` before calling `shuffled_partials` using the same `rng` to
+        // emulate what happens in [`ValidatorMandates::sample`]. Then `expected_assignment` below
+        // equals the shuffled partial mandates assigned to shards in
+        // `test_validator_mandates_sample_*`.
+        let _ = mandates.shuffled_mandates(&mut rng);
+        let assignment = mandates.shuffled_partials(&mut rng);
+        let expected_assignment: Vec<(ValidatorId, Balance)> =
+            vec![(1, 7), (4, 5), (2, 9), (3, 2), (6, 6), (5, 4)];
+        assert_eq!(assignment, expected_assignment);
     }
 
-    /// Test mandates per shard are collected correctly if `num_mandates % num_shards != 0`.
+    /// Test mandates per shard are collected correctly for `num_mandates % num_shards == 0` and
+    /// `num_partials % num_shards == 0`.
+    #[test]
+    fn test_validator_mandates_sample_even() {
+        // Choosing `num_shards` such that mandates and partials are distributed evenly.
+        // Assignments in `test_validator_mandates_shuffled_*` can be used to construct
+        // `expected_assignment` below.
+        let config = ValidatorMandatesConfig::new(10, 1, 3);
+        let expected_assignment: ValidatorMandatesAssignment = vec![
+            HashMap::from([
+                (0, AssignmentWeight::new(2, 0)),
+                (4, AssignmentWeight::new(1, 0)),
+                (1, AssignmentWeight::new(0, 7)),
+                (3, AssignmentWeight::new(0, 2)),
+            ]),
+            HashMap::from([
+                (1, AssignmentWeight::new(1, 0)),
+                (4, AssignmentWeight::new(1, 5)),
+                (3, AssignmentWeight::new(1, 0)),
+                (6, AssignmentWeight::new(0, 6)),
+            ]),
+            HashMap::from([
+                (0, AssignmentWeight::new(1, 0)),
+                (1, AssignmentWeight::new(1, 0)),
+                (4, AssignmentWeight::new(1, 0)),
+                (2, AssignmentWeight::new(0, 9)),
+                (5, AssignmentWeight::new(0, 4)),
+            ]),
+        ];
+        assert_validator_mandates_sample(config, expected_assignment);
+    }
+
+    /// Test mandates per shard are collected correctly for `num_mandates % num_shards != 0` and
+    /// `num_partials % num_shards != 0`.
     #[test]
     fn test_assigned_validator_mandates_get_mandates_for_shard_uneven() {
-        // Choosing `num_shards` such that mandates are distributed unevenly.
-        let config = ValidatorMandatesConfig::new(10, 1, 2);
-        let expected_mandates_per_shards: Vec<HashMap<ValidatorId, u16>> =
-            vec![HashMap::from([(0, 3), (1, 1), (4, 1)]), HashMap::from([(1, 1), (4, 2), (3, 1)])];
+        // Choosing `num_shards` such that mandates and partials are distributed unevenly.
+        // Assignments in `test_validator_mandates_shuffled_*` can be used to construct
+        // `expected_assignment` below.
+        let config = ValidatorMandatesConfig::new(10, 1, 4);
+        let expected_mandates_per_shards: ValidatorMandatesAssignment = vec![
+            HashMap::from([
+                (0, AssignmentWeight::new(2, 0)),
+                (4, AssignmentWeight::new(1, 0)),
+                (1, AssignmentWeight::new(0, 7)),
+                (6, AssignmentWeight::new(0, 6)),
+            ]),
+            HashMap::from([
+                (1, AssignmentWeight::new(1, 0)),
+                (4, AssignmentWeight::new(1, 5)),
+                (5, AssignmentWeight::new(0, 4)),
+            ]),
+            HashMap::from([
+                (0, AssignmentWeight::new(1, 0)),
+                (1, AssignmentWeight::new(1, 0)),
+                (2, AssignmentWeight::new(0, 9)),
+            ]),
+            HashMap::from([(4, AssignmentWeight::new(1, 0)), (3, AssignmentWeight::new(1, 2))]),
+        ];
         assert_validator_mandates_sample(config, expected_mandates_per_shards);
     }
 
     /// Asserts mandates per shard are collected correctly.
     fn assert_validator_mandates_sample(
         config: ValidatorMandatesConfig,
-        expected_mandates_per_shards: Vec<HashMap<ValidatorId, u16>>,
+        expected_assignment: ValidatorMandatesAssignment,
     ) {
         let validators = new_validator_stakes();
         let mandates = ValidatorMandates::new(config, &validators);
 
         let mut rng = new_fixed_rng();
-        let mandates_per_shards = mandates.sample(&mut rng);
+        let assignment = mandates.sample(&mut rng);
 
-        assert_eq!(mandates_per_shards, expected_mandates_per_shards);
+        assert_eq!(assignment, expected_assignment);
     }
 }

--- a/core/primitives/src/validator_mandates.rs
+++ b/core/primitives/src/validator_mandates.rs
@@ -84,9 +84,11 @@ impl ValidatorMandates {
             );
         }
 
-        // TODO comment why partials aren't considered for `required_mandates`
+        // Not counting partials towards `required_mandates` as the weight of partials and its
+        // distribution across shards may vary widely.
+        //
         // Construct vector with capacity as most likely some validators' stake will not be evenly
-        // divided by `config.stake_per_mandate`.
+        // divided by `config.stake_per_mandate`, i.e. some validators will have partials.
         let mut partials = Vec::with_capacity(validators.len());
         for i in 0..validators.len() {
             let partial_weight = validators[i].partial_mandate_weight(config.stake_per_mandate);
@@ -109,7 +111,7 @@ impl ValidatorMandates {
         let shuffled_mandates = self.shuffled_mandates(rng);
         let shuffled_partials = self.shuffled_partials(rng);
 
-        // TODO shuffle shard ids
+        // TODO(#10014) shuffle shard ids to avoid a bias towards smaller shard ids
         let mut mandates_per_shard = Vec::with_capacity(self.config.num_shards);
         for shard_id in 0..self.config.num_shards {
             let mut assignments: HashMap<ValidatorId, AssignmentWeight> = HashMap::new();


### PR DESCRIPTION
Adds support for partial mandates in chunk validator assignment.

Currently only full mandates are considered. Assume `stake_per_mandate = 5`, then:

- Valdiator `V1` with stake 12 holds 2 full mandates corresponding to a stake of 10. The remaining stake of 2 does not participate in validation.
- Validator `V2` with stake 4 holds 0 full mandates and does not participate in validation at all.

With support for partial mandates `V1` gets a partial mandate with weight 2 and `V2` gets a partial mandate of 4. So partial mandates allow to increase the number of validators and allows them to commit their entire stake to validation.

### Probability of shard corruption

In [these simulations](https://near.zulipchat.com/#narrow/stream/407237-pagoda.2Fcore.2Fstateless-validation/topic/chunk.20validator.20assignment.20simulation.20with.20partial.20seats), the probability of shard corruption decreases as partial seats are included. In general, the effect of including partial seats depends on the distribution of (malicious) stake across validators and the stake required per mandate.

### `ValidatorMandatesAssignment`

This type is introduced to more clearly document the result of sampling chunk validators and to avoid passing around a raw `Vec<HashMap<ValidatorId, _>>`.

### Shuffling of shard ids

[This thread](https://github.com/mooori/sim-validator-assignment/pull/12#discussion_r1389895314) points out a bias towards small shard ids and brings up shard id shuffling as a way to fix it. For now shard ids are not shuffled in this PR, since I think it would make the diff harder to review. I would suggest to introduce shard id shuffling in a separate PR. This should not pose a risk as chunk validator assignment is not enabled in production.