### PR TITLE
chore: Bump near-account-id version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3419,9 +3419,9 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df682a64c06590d210725268a738a88321536d76beb02f0465bfbdc379f0cbf"
+checksum = "d10d45a9c49c3e975c362cf4d1dc1d7b72a716b30394bea56ee2a8fb225f50b7"
 dependencies = [
  "borsh 1.0.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,7 +180,7 @@ lru = "0.7.2"
 memmap2 = "0.5"
 memoffset = "0.8"
 more-asserts = "0.2"
-near-account-id = { version = "1.0.0-alpha.2", features = ["internal_unstable", "serde", "borsh"] }
+near-account-id = { version = "1.0.0-alpha.4", features = ["internal_unstable", "serde", "borsh"] }
 near-actix-test-utils = { path = "test-utils/actix-test-utils" }
 near-amend-genesis = { path = "tools/amend-genesis" }
 near-database-tool= { path = "tools/database" }


### PR DESCRIPTION
Contains https://github.com/near/near-account-id-rs/pull/20