### PR TITLE
allow warnings for fuzzer building

### DIFF
--- a/.github/workflows/master_fuzzer_binaries.yml
+++ b/.github/workflows/master_fuzzer_binaries.yml
@@ -45,5 +45,5 @@ jobs:
       - name: "Compile fuzzers and upload to GCS"
         run: |
           NAME="nearcore-${{ github.ref_name }}-$(env TZ=Etc/UTC  date +"%Y%m%d%H%M%S")"
-          cargo +nightly bolero build-clusterfuzz --all-features --profile fuzz
+          RUSTFLAGS="-A warnings" cargo +nightly bolero build-clusterfuzz --all-features --profile fuzz
           gsutil cp -Z target/fuzz/clusterfuzz.tar "gs://fuzzer_targets/${{ github.ref_name }}/$NAME.tar.gz"


### PR DESCRIPTION
Fuzzer building runs on rustc nightly, which can have a different set of warnings than rustc stable. Rather than introduce a new compilation step for all the PRs, just compile fuzzers without caring about warnings.

Fixes a recent fuzzer building issue, probably caused by a nightly upgrade: https://github.com/near/nearcore/actions/runs/6929988512/job/18848791016