### PR TITLE
fix: use header_head to determine validators for forwarding transactions

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3776,25 +3776,6 @@ impl Chain {
         Ok(FinalExecutionOutcomeWithReceiptView { final_outcome, receipts })
     }
 
-    /// Find a validator to forward transactions to
-    pub fn find_chunk_producer_for_forwarding(
-        &self,
-        epoch_id: &EpochId,
-        shard_id: ShardId,
-        horizon: BlockHeight,
-    ) -> Result<AccountId, Error> {
-        let head = self.head()?;
-        let target_height = head.height + horizon - 1;
-        Ok(self.epoch_manager.get_chunk_producer(epoch_id, target_height, shard_id)?)
-    }
-
-    /// Find a validator that is responsible for a given shard to forward requests to
-    pub fn find_validator_for_forwarding(&self, shard_id: ShardId) -> Result<AccountId, Error> {
-        let head = self.head()?;
-        let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(&head.last_block_hash)?;
-        self.find_chunk_producer_for_forwarding(&epoch_id, shard_id, TX_ROUTING_HEIGHT_HORIZON)
-    }
-
     pub fn check_blocks_final_and_canonical(
         &self,
         block_headers: &[BlockHeader],


### PR DESCRIPTION
Functions `find_chunk_producer_for_forwarding()`, `find_validator_for_forwarding()` are not used much, one calls another, and they both call `chain.head()`.

That seems unnecessary. Refactored to call `get_chunk_producer()` directly, and not worry about 3 layers of functions using different types of heads.

See https://github.com/near/nearcore/pull/10251 for context