### PR TITLE
fix(config): disable epoch sync, enable state sync

### DIFF
--- a/core/chain-configs/src/lib.rs
+++ b/core/chain-configs/src/lib.rs
@@ -8,7 +8,9 @@ mod updateable_config;
 pub use client_config::{
     ClientConfig, DumpConfig, ExternalStorageConfig, ExternalStorageLocation, GCConfig,
     LogSummaryStyle, StateSplitConfig, StateSyncConfig, SyncConfig, DEFAULT_GC_NUM_EPOCHS_TO_KEEP,
-    MIN_GC_NUM_EPOCHS_TO_KEEP, TEST_STATE_SYNC_TIMEOUT,
+    DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_EXTERNAL,
+    DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_ON_CATCHUP_EXTERNAL, MIN_GC_NUM_EPOCHS_TO_KEEP,
+    TEST_STATE_SYNC_TIMEOUT,
 };
 pub use genesis_config::{
     get_initial_supply, stream_records_from_file, Genesis, GenesisChangeConfig, GenesisConfig,

--- a/core/primitives/src/chains.rs
+++ b/core/primitives/src/chains.rs
@@ -5,9 +5,3 @@ pub const MAINNET: &str = "mainnet";
 
 /// Primary testing environment.
 pub const TESTNET: &str = "testnet";
-
-/// Used for testing certain new protocol features.
-pub const STAKEWARS: &str = "stakewars";
-
-/// Nightly testing.
-pub const BETANET: &str = "betanet";

--- a/genesis-tools/genesis-csv-to-json/src/csv_to_json_configs.rs
+++ b/genesis-tools/genesis-csv-to-json/src/csv_to_json_configs.rs
@@ -25,8 +25,7 @@ fn verify_total_supply(total_supply: Balance, chain_id: &str) {
             "Total supply should be exactly 1 billion"
         );
     } else if total_supply > 10_000_000_000 * NEAR_BASE
-        && (chain_id == near_primitives::chains::TESTNET
-            || chain_id == near_primitives::chains::STAKEWARS)
+        && chain_id == near_primitives::chains::TESTNET
     {
         panic!("Total supply should not be more than 10 billion");
     }

--- a/integration-tests/src/tests/client/sync_state_nodes.rs
+++ b/integration-tests/src/tests/client/sync_state_nodes.rs
@@ -936,7 +936,7 @@ fn test_state_sync_headers_no_tracked_shards() {
                 .unwrap();
             near1.config.store.state_snapshot_enabled = false;
             near1.config.store.state_snapshot_compaction_enabled = false;
-            near1.config.state_sync_enabled = Some(false);
+            near1.config.state_sync_enabled = false;
             near1.client_config.state_sync_enabled = false;
 
             let _node1 = start_with_config(dir1.path(), near1).expect("start_with_config");
@@ -954,7 +954,7 @@ fn test_state_sync_headers_no_tracked_shards() {
                 .unwrap();
             near2.config.store.state_snapshot_enabled = true;
             near2.config.store.state_snapshot_compaction_enabled = false;
-            near2.config.state_sync_enabled = Some(false);
+            near2.config.state_sync_enabled = false;
             near2.client_config.state_sync_enabled = false;
 
             let nearcore::NearNode { view_client: view_client2, .. } =

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -943,7 +943,7 @@ fn generate_or_load_keys(
     Ok(())
 }
 
-fn set_block_production_delay(fast: bool, chain_id: &str, config: &mut Config) {
+fn set_block_production_delay(chain_id: &str, fast: bool, config: &mut Config) {
     match chain_id {
         near_primitives::chains::MAINNET => {
             config.consensus.min_block_production_delay =
@@ -1023,7 +1023,7 @@ pub fn init_configs(
     // https://github.com/near/nearcore/issues/7388
     config.tracked_shards = vec![0];
     // If a config gets generated, block production times may need to be updated.
-    set_block_production_delay(&chain_id, &mut config);
+    set_block_production_delay(&chain_id, fast, &mut config);
 
     if let Some(url) = download_config_url {
         download_config(url, &dir.join(CONFIG_FILENAME))

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -516,7 +516,6 @@ impl RunCmd {
         {
             if near_config.client_config.chain_id == near_primitives::chains::MAINNET
                 || near_config.client_config.chain_id == near_primitives::chains::TESTNET
-                || near_config.client_config.chain_id == near_primitives::chains::BETANET
             {
                 eprintln!(
                     "Sandbox node can only run dedicate localnet, cannot connect to a network"

--- a/tools/chainsync-loadtest/src/main.rs
+++ b/tools/chainsync-loadtest/src/main.rs
@@ -24,7 +24,6 @@ fn genesis_hash(chain_id: &str) -> CryptoHash {
     return match chain_id {
         near_primitives::chains::MAINNET => "EPnLgE7iEq9s7yTkos96M3cWymH5avBAPm3qx3NXqR8H",
         near_primitives::chains::TESTNET => "FWJ9kR6KFWoyMoNjpLXXGHeuiy7tEY6GmoFeCA5yuc6b",
-        near_primitives::chains::BETANET => "6hy7VoEJhPEUaJr1d5ePBhKdgeDWKCjLoUAn7XS9YPj",
         _ => {
             return Default::default();
         }


### PR DESCRIPTION
* Simplifies `state_sync_enabled` and `enable_multiline_logging`.
* Adjusts {min,max}_block_production_delay config options when generating configs for testnet and mainnet.
* Simplifies config initialization logic.
* Deletes betanet and stakewars