### PR TITLE
feat: use the < operator instead of cmp method to improve readability

### DIFF
--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -2,7 +2,6 @@ use crate::hash::CryptoHash;
 use crate::types::{AccountId, NumShards};
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_primitives_core::types::ShardId;
-use std::cmp::Ordering::Greater;
 use std::collections::HashMap;
 use std::{fmt, str};
 
@@ -251,7 +250,7 @@ pub fn account_id_to_shard_id(account_id: &AccountId, shard_layout: &ShardLayout
             // scan. For the time being, with only 4 shards, this is perfectly fine.
             let mut shard_id: ShardId = 0;
             for boundary_account in boundary_accounts {
-                if boundary_account.cmp(account_id) == Greater {
+                if account_id < boundary_account {
                     break;
                 }
                 shard_id += 1;


### PR DESCRIPTION
The following code is currently used for comparing `boundary_account` and `account_id`:
```rust
if boundary_account.cmp(account_id) == Greater {
    ...
}
```

IMO it's a bit confusing - it isn't immediately obvious whether this means `boundary_account` > `account_id` or `account_id` > `boundary_account`. I misread this line and because of that I made a mistake in #10240.

Let's change it to something that is easier to read:
```rust
if account_id < boundary_account {
    ...
}
```