### PR TITLE
introduce hack for fuzzers building

### DIFF
--- a/.github/workflows/master_fuzzer_binaries.yml
+++ b/.github/workflows/master_fuzzer_binaries.yml
@@ -31,7 +31,7 @@ jobs:
           # TODO: remove the below once https://github.com/camshaft/bolero/pull/195 is released on crates.io
           # and https://github.com/camshaft/bolero/pull/196 has a proper fix
           git: https://github.com/Ekleog-NEAR/bolero
-          rev: 8f4e49d65c702a2f9858ed3c217b1cb52ce91243
+          rev: 56da8e6d1d018519a30b36d85d3a53fe35a42eaf
 
       - run: rustup target add --toolchain nightly wasm32-unknown-unknown
 

--- a/.github/workflows/ondemand_fuzzer_binaries.yml
+++ b/.github/workflows/ondemand_fuzzer_binaries.yml
@@ -47,7 +47,7 @@ jobs:
           # TODO: remove the below once https://github.com/camshaft/bolero/pull/195 is released on crates.io
           # and https://github.com/camshaft/bolero/pull/196 has a proper fix
           git: https://github.com/Ekleog-NEAR/bolero
-          rev: 8f4e49d65c702a2f9858ed3c217b1cb52ce91243
+          rev: 56da8e6d1d018519a30b36d85d3a53fe35a42eaf
 
       - run: rustup target add --toolchain nightly wasm32-unknown-unknown
 


### PR DESCRIPTION
This introduces a hack in our fork of cargo-bolero, needed for proper fuzzer building. The reason is still the same as the patch previously applied: the current bolero way of auto-detecting fuzzers is suboptimal.

All these patches should be able to go away with some work on cargo-bolero, but we have other priorities, and this hack seems to make the tarball builds work locally at least.

With this, we run with two patches:
- https://github.com/Ekleog-NEAR/bolero/commit/877f19959e708f288e2e3c814768743f86f69c80, which is a bit hacky but might deserve being included upstream were it not for backward compatibility reasons
- https://github.com/Ekleog-NEAR/bolero/commit/56da8e6d1d018519a30b36d85d3a53fe35a42eaf, which is a real, bad hack, but seems to be enough to stop having to care about it for now, until we can go back to it and fix the underlying issue that fuzzer listing is currently not well-implemented