### PR TITLE
refactor: group runtime apply_transactions block/chunk-related arguments

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -11,13 +11,14 @@ use crate::state_request_tracker::StateRequestTracker;
 use crate::state_snapshot_actor::SnapshotCallbacks;
 use crate::store::{ChainStore, ChainStoreAccess, ChainStoreUpdate, GCMode};
 use crate::types::{
-    AcceptedBlock, ApplySplitStateResultOrStateChanges, ApplyTransactionResult, Block,
-    BlockEconomicsConfig, BlockHeader, BlockStatus, ChainConfig, ChainGenesis, Provenance,
-    RuntimeAdapter, RuntimeStorageConfig,
+    AcceptedBlock, ApplySplitStateResultOrStateChanges, ApplyTransactionResult,
+    ApplyTransactionsBlockContext, ApplyTransactionsChunkContext, Block, BlockEconomicsConfig,
+    BlockHeader, BlockStatus, ChainConfig, ChainGenesis, Provenance, RuntimeAdapter,
+    RuntimeStorageConfig,
 };
 use crate::update_shard::{
-    process_shard_update, ApplyChunkResult, BlockContext, NewChunkResult, OldChunkResult,
-    ShardContext, ShardUpdateReason, StateSplitResult,
+    process_shard_update, ApplyChunkResult, NewChunkData, NewChunkResult, OldChunkData,
+    OldChunkResult, ShardContext, ShardUpdateReason, StateSplitData, StateSplitResult,
 };
 use crate::validate::{
     validate_challenge, validate_chunk_proofs, validate_chunk_with_chunk_extra,
@@ -3557,13 +3558,12 @@ impl Chain {
 
     /// For given pair of block headers and shard id, return information about
     /// block necessary for processing shard update.
-    fn get_block_context_for_shard_update(
+    fn get_apply_transactions_block_context(
         &self,
         block_header: &BlockHeader,
         prev_block_header: &BlockHeader,
-        shard_id: ShardId,
         is_new_chunk: bool,
-    ) -> Result<BlockContext, Error> {
+    ) -> Result<ApplyTransactionsBlockContext, Error> {
         let epoch_id = block_header.epoch_id();
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(epoch_id)?;
         // Before `FixApplyChunks` feature, gas price was taken from current
@@ -3576,28 +3576,7 @@ impl Chain {
             prev_block_header.next_gas_price()
         };
 
-        // This variable is responsible for checking to which block we can apply receipts previously lost in apply_chunks
-        // (see https://github.com/near/nearcore/pull/4248/)
-        // We take the first block with existing chunk in the first epoch in which protocol feature
-        // RestoreReceiptsAfterFixApplyChunks was enabled, and put the restored receipts there.
-        let is_first_block_with_chunk_of_version = is_new_chunk
-            && check_if_block_is_first_with_chunk_of_version(
-                self.store(),
-                self.epoch_manager.as_ref(),
-                block_header.prev_hash(),
-                shard_id,
-            )?;
-
-        Ok(BlockContext {
-            block_hash: *block_header.hash(),
-            prev_block_hash: *block_header.prev_hash(),
-            challenges_result: block_header.challenges_result().clone(),
-            block_timestamp: block_header.raw_timestamp(),
-            gas_price,
-            height: block_header.height(),
-            random_seed: *block_header.random_value(),
-            is_first_block_with_chunk_of_version,
-        })
+        Ok(ApplyTransactionsBlockContext::from_header(block_header, gas_price))
     }
 
     fn block_catch_up_postprocess(
@@ -3977,6 +3956,11 @@ impl Chain {
         let shard_uid = self.epoch_manager.shard_id_to_uid(shard_id, block.header().epoch_id())?;
         let is_new_chunk = chunk_header.height_included() == block.header().height();
         let shard_update_reason = if should_apply_transactions {
+            let block_context = self.get_apply_transactions_block_context(
+                block.header(),
+                prev_block.header(),
+                is_new_chunk,
+            )?;
             if is_new_chunk {
                 // Validate new chunk and collect incoming receipts for it.
 
@@ -4028,38 +4012,56 @@ impl Chain {
                 let old_receipts = collect_receipts_from_response(old_receipts);
                 let receipts = [new_receipts, old_receipts].concat();
 
-                ShardUpdateReason::NewChunk(chunk, receipts, split_state_roots)
-            } else {
-                ShardUpdateReason::OldChunk(
-                    ChunkExtra::clone(self.get_chunk_extra(prev_hash, &shard_uid)?.as_ref()),
+                // This variable is responsible for checking to which block we can apply receipts previously lost in apply_chunks
+                // (see https://github.com/near/nearcore/pull/4248/)
+                // We take the first block with existing chunk in the first epoch in which protocol feature
+                // RestoreReceiptsAfterFixApplyChunks was enabled, and put the restored receipts there.
+                let is_first_block_with_chunk_of_version =
+                    check_if_block_is_first_with_chunk_of_version(
+                        self.store(),
+                        self.epoch_manager.as_ref(),
+                        block.header().prev_hash(),
+                        shard_id,
+                    )?;
+
+                ShardUpdateReason::NewChunk(NewChunkData {
+                    block: block_context,
+                    is_first_block_with_chunk_of_version,
+                    chunk,
+                    receipts,
                     split_state_roots,
-                )
+                })
+            } else {
+                ShardUpdateReason::OldChunk(OldChunkData {
+                    block: block_context,
+                    prev_chunk_extra: ChunkExtra::clone(
+                        self.get_chunk_extra(prev_hash, &shard_uid)?.as_ref(),
+                    ),
+                    split_state_roots,
+                })
             }
         } else if let Some(split_state_roots) = split_state_roots {
             assert!(mode == ApplyChunksMode::CatchingUp && cares_about_shard_this_epoch);
-            ShardUpdateReason::StateSplit(
+            let state_changes =
+                self.store().get_state_changes_for_split_states(block.hash(), shard_id)?;
+            ShardUpdateReason::StateSplit(StateSplitData {
+                block_hash: *block.hash(),
+                block_height: block.header().height(),
+                state_changes,
                 split_state_roots,
-                self.store().get_state_changes_for_split_states(block.hash(), shard_id)?,
-            )
+            })
         } else {
             return Ok(None);
         };
 
         let runtime = self.runtime_adapter.clone();
         let epoch_manager = self.epoch_manager.clone();
-        let block_context = self.get_block_context_for_shard_update(
-            block.header(),
-            prev_block.header(),
-            shard_id,
-            is_new_chunk,
-        )?;
         Ok(Some(Box::new(move |parent_span| -> Result<ApplyChunkResult, Error> {
             Ok(process_shard_update(
                 parent_span,
                 runtime.as_ref(),
                 epoch_manager.as_ref(),
                 shard_update_reason,
-                block_context,
                 ShardContext { shard_uid, will_shard_layout_change },
                 state_patch,
             )?)
@@ -5570,21 +5572,25 @@ impl<'a> ChainUpdate<'a> {
         let is_first_block_with_chunk_of_version = false;
 
         let apply_result = self.runtime_adapter.apply_transactions(
-            shard_id,
             RuntimeStorageConfig::new(chunk_header.prev_state_root(), true),
-            chunk_header.height_included(),
-            block_header.raw_timestamp(),
-            &chunk_header.prev_block_hash(),
-            block_header.hash(),
+            ApplyTransactionsChunkContext {
+                shard_id,
+                gas_limit,
+                last_validator_proposals: chunk_header.prev_validator_proposals(),
+                is_first_block_with_chunk_of_version,
+                is_new_chunk: true,
+            },
+            ApplyTransactionsBlockContext {
+                height: chunk_header.height_included(),
+                block_hash: *block_header.hash(),
+                prev_block_hash: *chunk_header.prev_block_hash(),
+                block_timestamp: block_header.raw_timestamp(),
+                gas_price,
+                challenges_result: block_header.challenges_result().clone(),
+                random_seed: *block_header.random_value(),
+            },
             &receipts,
             chunk.transactions(),
-            chunk_header.prev_validator_proposals(),
-            gas_price,
-            gas_limit,
-            block_header.challenges_result(),
-            *block_header.random_value(),
-            true,
-            is_first_block_with_chunk_of_version,
         )?;
 
         let (outcome_root, outcome_proofs) =
@@ -5663,21 +5669,20 @@ impl<'a> ChainUpdate<'a> {
             self.chain_store_update.get_chunk_extra(prev_block_header.hash(), &shard_uid)?;
 
         let apply_result = self.runtime_adapter.apply_transactions(
-            shard_id,
             RuntimeStorageConfig::new(*chunk_extra.state_root(), true),
-            block_header.height(),
-            block_header.raw_timestamp(),
-            prev_block_header.hash(),
-            block_header.hash(),
+            ApplyTransactionsChunkContext {
+                shard_id,
+                last_validator_proposals: chunk_extra.validator_proposals(),
+                gas_limit: chunk_extra.gas_limit(),
+                is_new_chunk: false,
+                is_first_block_with_chunk_of_version: false,
+            },
+            ApplyTransactionsBlockContext::from_header(
+                &block_header,
+                prev_block_header.next_gas_price(),
+            ),
             &[],
             &[],
-            chunk_extra.validator_proposals(),
-            prev_block_header.next_gas_price(),
-            chunk_extra.gas_limit(),
-            block_header.challenges_result(),
-            *block_header.random_value(),
-            false,
-            false,
         )?;
         let flat_storage_manager = self.runtime_adapter.get_flat_storage_manager();
         let store_update = flat_storage_manager.save_flat_state_changes(

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -1,6 +1,7 @@
 use super::ValidatorSchedule;
 use crate::types::{
-    ApplySplitStateResult, ApplyTransactionResult, RuntimeAdapter, RuntimeStorageConfig,
+    ApplySplitStateResult, ApplyTransactionResult, ApplyTransactionsBlockContext,
+    ApplyTransactionsChunkContext, RuntimeAdapter, RuntimeStorageConfig,
 };
 use crate::BlockHeader;
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -12,7 +13,6 @@ use near_epoch_manager::{EpochManagerAdapter, RngSeed};
 use near_pool::types::PoolIterator;
 use near_primitives::account::{AccessKey, Account};
 use near_primitives::block_header::{Approval, ApprovalInner};
-use near_primitives::challenge::ChallengesResult;
 use near_primitives::epoch_manager::block_info::BlockInfo;
 use near_primitives::epoch_manager::epoch_info::EpochInfo;
 use near_primitives::epoch_manager::EpochConfig;
@@ -29,7 +29,7 @@ use near_primitives::transaction::{
     Action, ExecutionMetadata, ExecutionOutcome, ExecutionOutcomeWithId, ExecutionStatus,
     SignedTransaction, TransferAction,
 };
-use near_primitives::types::validator_stake::{ValidatorStake, ValidatorStakeIter};
+use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
     AccountId, ApprovalStake, Balance, BlockHeight, EpochHeight, EpochId, Gas, Nonce, NumShards,
     ShardId, StateChangesForSplitStates, StateRoot, StateRootNode, ValidatorInfoIdentifier,
@@ -1031,24 +1031,15 @@ impl RuntimeAdapter for KeyValueRuntime {
 
     fn apply_transactions(
         &self,
-        shard_id: ShardId,
         storage_config: RuntimeStorageConfig,
-        height: BlockHeight,
-        _block_timestamp: u64,
-        _prev_block_hash: &CryptoHash,
-        block_hash: &CryptoHash,
+        chunk: ApplyTransactionsChunkContext,
+        block: ApplyTransactionsBlockContext,
         receipts: &[Receipt],
         transactions: &[SignedTransaction],
-        _last_validator_proposals: ValidatorStakeIter,
-        gas_price: Balance,
-        _gas_limit: Gas,
-        _challenges: &ChallengesResult,
-        _random_seed: CryptoHash,
-        _is_new_chunk: bool,
-        _is_first_block_with_chunk_of_version: bool,
     ) -> Result<ApplyTransactionResult, Error> {
         assert!(!storage_config.record_storage);
         let mut tx_results = vec![];
+        let shard_id = chunk.shard_id;
 
         let mut state =
             self.state.read().unwrap().get(&storage_config.state_root).cloned().unwrap();
@@ -1146,7 +1137,7 @@ impl RuntimeAdapter for KeyValueRuntime {
                         receipt: ReceiptEnum::Action(ActionReceipt {
                             signer_id: from.clone(),
                             signer_public_key: PublicKey::empty(KeyType::ED25519),
-                            gas_price,
+                            gas_price: block.gas_price,
                             output_data_receivers: vec![],
                             input_data_ids: vec![],
                             actions: vec![Action::Transfer(TransferAction { deposit: amount })],
@@ -1185,8 +1176,8 @@ impl RuntimeAdapter for KeyValueRuntime {
                 ShardUId { version: 0, shard_id: shard_id as u32 },
                 TrieChanges::empty(state_root),
                 Default::default(),
-                *block_hash,
-                height,
+                block.block_hash,
+                block.height,
             ),
             new_root: state_root,
             outcomes: tx_results,

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -266,6 +266,39 @@ impl RuntimeStorageConfig {
     }
 }
 
+#[derive(Clone)]
+pub struct ApplyTransactionsBlockContext {
+    pub height: BlockHeight,
+    pub block_hash: CryptoHash,
+    pub prev_block_hash: CryptoHash,
+    pub block_timestamp: u64,
+    pub gas_price: Balance,
+    pub challenges_result: ChallengesResult,
+    pub random_seed: CryptoHash,
+}
+
+impl ApplyTransactionsBlockContext {
+    pub fn from_header(header: &BlockHeader, gas_price: Balance) -> Self {
+        Self {
+            height: header.height(),
+            block_hash: *header.hash(),
+            prev_block_hash: *header.prev_hash(),
+            block_timestamp: header.raw_timestamp(),
+            gas_price,
+            challenges_result: header.challenges_result().clone(),
+            random_seed: *header.random_value(),
+        }
+    }
+}
+
+pub struct ApplyTransactionsChunkContext<'a> {
+    pub shard_id: ShardId,
+    pub last_validator_proposals: ValidatorStakeIter<'a>,
+    pub gas_limit: Gas,
+    pub is_new_chunk: bool,
+    pub is_first_block_with_chunk_of_version: bool,
+}
+
 /// Bridge between the chain and the runtime.
 /// Main function is to update state given transactions.
 /// Additionally handles validators.
@@ -345,21 +378,11 @@ pub trait RuntimeAdapter: Send + Sync {
     /// Also returns transaction result for each transaction and new receipts.
     fn apply_transactions(
         &self,
-        shard_id: ShardId,
         storage: RuntimeStorageConfig,
-        height: BlockHeight,
-        block_timestamp: u64,
-        prev_block_hash: &CryptoHash,
-        block_hash: &CryptoHash,
+        chunk: ApplyTransactionsChunkContext,
+        block: ApplyTransactionsBlockContext,
         receipts: &[Receipt],
         transactions: &[SignedTransaction],
-        last_validator_proposals: ValidatorStakeIter,
-        gas_price: Balance,
-        gas_limit: Gas,
-        challenges_result: &ChallengesResult,
-        random_seed: CryptoHash,
-        is_new_chunk: bool,
-        is_first_block_with_chunk_of_version: bool,
     ) -> Result<ApplyTransactionResult, Error>;
 
     /// Query runtime with given `path` and `data`.

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -5,8 +5,8 @@ use crate::NearConfig;
 use borsh::BorshDeserialize;
 use errors::FromStateViewerErrors;
 use near_chain::types::{
-    ApplySplitStateResult, ApplyTransactionResult, RuntimeAdapter, RuntimeStorageConfig,
-    StorageDataSource, Tip,
+    ApplySplitStateResult, ApplyTransactionResult, ApplyTransactionsBlockContext,
+    ApplyTransactionsChunkContext, RuntimeAdapter, RuntimeStorageConfig, StorageDataSource, Tip,
 };
 use near_chain::Error;
 use near_chain_configs::{
@@ -16,7 +16,6 @@ use near_crypto::PublicKey;
 use near_epoch_manager::{EpochManagerAdapter, EpochManagerHandle};
 use near_pool::types::PoolIterator;
 use near_primitives::account::{AccessKey, Account};
-use near_primitives::challenge::ChallengesResult;
 use near_primitives::config::ActionCosts;
 use near_primitives::config::ExtCosts;
 use near_primitives::errors::{InvalidTxError, RuntimeError, StorageError};
@@ -31,7 +30,6 @@ use near_primitives::shard_layout::{
 use near_primitives::state_part::PartId;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::trie_key::TrieKey;
-use near_primitives::types::validator_stake::ValidatorStakeIter;
 use near_primitives::types::{
     AccountId, Balance, BlockHeight, EpochHeight, EpochId, EpochInfoProvider, Gas, MerkleHash,
     ShardId, StateChangeCause, StateChangesForSplitStates, StateRoot, StateRootNode,
@@ -276,23 +274,29 @@ impl NightshadeRuntime {
     fn process_state_update(
         &self,
         trie: Trie,
-        shard_id: ShardId,
-        block_height: BlockHeight,
-        block_hash: &CryptoHash,
-        block_timestamp: u64,
-        prev_block_hash: &CryptoHash,
+        chunk: ApplyTransactionsChunkContext,
+        block: ApplyTransactionsBlockContext,
         receipts: &[Receipt],
         transactions: &[SignedTransaction],
-        last_validator_proposals: ValidatorStakeIter,
-        gas_price: Balance,
-        gas_limit: Gas,
-        challenges_result: &ChallengesResult,
-        random_seed: CryptoHash,
-        is_new_chunk: bool,
-        is_first_block_with_chunk_of_version: bool,
         state_patch: SandboxStatePatch,
     ) -> Result<ApplyTransactionResult, Error> {
         let _span = tracing::debug_span!(target: "runtime", "process_state_update").entered();
+        let ApplyTransactionsBlockContext {
+            height: block_height,
+            block_hash,
+            ref prev_block_hash,
+            block_timestamp,
+            gas_price,
+            challenges_result,
+            random_seed,
+        } = block;
+        let ApplyTransactionsChunkContext {
+            shard_id,
+            last_validator_proposals,
+            gas_limit,
+            is_new_chunk,
+            is_first_block_with_chunk_of_version,
+        } = chunk;
         let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(prev_block_hash)?;
         let validator_accounts_update = {
             let epoch_manager = self.epoch_manager.read();
@@ -382,7 +386,7 @@ impl NightshadeRuntime {
         let apply_state = ApplyState {
             block_height,
             prev_block_hash: *prev_block_hash,
-            block_hash: *block_hash,
+            block_hash,
             epoch_id,
             epoch_height,
             gas_price,
@@ -460,7 +464,7 @@ impl NightshadeRuntime {
                 shard_uid,
                 apply_result.trie_changes,
                 apply_result.state_changes,
-                *block_hash,
+                block_hash,
                 apply_state.block_height,
             ),
             new_root: apply_result.state_root,
@@ -826,29 +830,20 @@ impl RuntimeAdapter for NightshadeRuntime {
 
     fn apply_transactions(
         &self,
-        shard_id: ShardId,
         storage_config: RuntimeStorageConfig,
-        height: BlockHeight,
-        block_timestamp: u64,
-        prev_block_hash: &CryptoHash,
-        block_hash: &CryptoHash,
+        chunk: ApplyTransactionsChunkContext,
+        block: ApplyTransactionsBlockContext,
         receipts: &[Receipt],
         transactions: &[SignedTransaction],
-        last_validator_proposals: ValidatorStakeIter,
-        gas_price: Balance,
-        gas_limit: Gas,
-        challenges: &ChallengesResult,
-        random_seed: CryptoHash,
-        is_new_chunk: bool,
-        is_first_block_with_chunk_of_version: bool,
     ) -> Result<ApplyTransactionResult, Error> {
+        let shard_id = chunk.shard_id;
         let _timer =
             metrics::APPLYING_CHUNKS_TIME.with_label_values(&[&shard_id.to_string()]).start_timer();
 
         let mut trie = match storage_config.source {
             StorageDataSource::Db => self.get_trie_for_shard(
                 shard_id,
-                prev_block_hash,
+                &block.prev_block_hash,
                 storage_config.state_root,
                 storage_config.use_flat_storage,
             )?,
@@ -864,20 +859,10 @@ impl RuntimeAdapter for NightshadeRuntime {
 
         match self.process_state_update(
             trie,
-            shard_id,
-            height,
-            block_hash,
-            block_timestamp,
-            prev_block_hash,
+            chunk,
+            block,
             receipts,
             transactions,
-            last_validator_proposals,
-            gas_price,
-            gas_limit,
-            challenges,
-            random_seed,
-            is_new_chunk,
-            is_first_block_with_chunk_of_version,
             storage_config.state_patch,
         ) {
             Ok(result) => Ok(result),

--- a/nearcore/src/runtime/tests.rs
+++ b/nearcore/src/runtime/tests.rs
@@ -5,7 +5,7 @@ use near_chain::{Chain, ChainGenesis};
 use near_epoch_manager::types::BlockHeaderInfo;
 use near_epoch_manager::EpochManager;
 use near_primitives::test_utils::create_test_signer;
-use near_primitives::types::validator_stake::ValidatorStake;
+use near_primitives::types::validator_stake::{ValidatorStake, ValidatorStakeIter};
 use near_store::flat::{FlatStateChanges, FlatStateDelta, FlatStateDeltaMetadata};
 use near_store::genesis::initialize_genesis_state;
 use num_rational::Ratio;
@@ -15,7 +15,7 @@ use near_chain_configs::{Genesis, DEFAULT_GC_NUM_EPOCHS_TO_KEEP};
 use near_crypto::{InMemorySigner, KeyType, Signer};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::block::Tip;
-use near_primitives::challenge::SlashedValidator;
+use near_primitives::challenge::{ChallengesResult, SlashedValidator};
 use near_primitives::transaction::{Action, DeleteAccountAction, StakeAction, TransferAction};
 use near_primitives::types::{
     BlockHeightDelta, Nonce, ValidatorId, ValidatorInfoIdentifier, ValidatorKickoutReason,
@@ -61,28 +61,32 @@ impl NightshadeRuntime {
         block_hash: &CryptoHash,
         receipts: &[Receipt],
         transactions: &[SignedTransaction],
-        last_proposals: ValidatorStakeIter,
+        last_validator_proposals: ValidatorStakeIter,
         gas_price: Balance,
         gas_limit: Gas,
-        challenges: &ChallengesResult,
+        challenges_result: &ChallengesResult,
     ) -> (StateRoot, Vec<ValidatorStake>, Vec<Receipt>) {
         let mut result = self
             .apply_transactions(
-                shard_id,
                 RuntimeStorageConfig::new(*state_root, true),
-                height,
-                block_timestamp,
-                prev_block_hash,
-                block_hash,
+                ApplyTransactionsChunkContext {
+                    shard_id,
+                    last_validator_proposals,
+                    gas_limit,
+                    is_new_chunk: true,
+                    is_first_block_with_chunk_of_version: false,
+                },
+                ApplyTransactionsBlockContext {
+                    height,
+                    block_hash: *block_hash,
+                    prev_block_hash: *prev_block_hash,
+                    block_timestamp,
+                    gas_price,
+                    challenges_result: challenges_result.clone(),
+                    random_seed: CryptoHash::default(),
+                },
                 receipts,
                 transactions,
-                last_proposals,
-                gas_price,
-                gas_limit,
-                challenges,
-                CryptoHash::default(),
-                true,
-                false,
             )
             .unwrap();
         let mut store_update = self.store.store_update();

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -1,6 +1,9 @@
 use near_chain::chain::collect_receipts_from_response;
 use near_chain::migrations::check_if_block_is_first_with_chunk_of_version;
-use near_chain::types::{ApplyTransactionResult, RuntimeAdapter, RuntimeStorageConfig};
+use near_chain::types::{
+    ApplyTransactionResult, ApplyTransactionsBlockContext, ApplyTransactionsChunkContext,
+    RuntimeAdapter, RuntimeStorageConfig,
+};
 use near_chain::{ChainStore, ChainStoreAccess, ChainStoreUpdate};
 use near_chain_configs::Genesis;
 use near_epoch_manager::{EpochManagerAdapter, EpochManagerHandle};
@@ -228,21 +231,20 @@ fn apply_block_from_range(
         }
         runtime_adapter
             .apply_transactions(
-                shard_id,
                 RuntimeStorageConfig::new(*chunk_inner.prev_state_root(), use_flat_storage),
-                height,
-                block.header().raw_timestamp(),
-                block.header().prev_hash(),
-                block.hash(),
+                ApplyTransactionsChunkContext {
+                    shard_id,
+                    last_validator_proposals: chunk_inner.prev_validator_proposals(),
+                    gas_limit: chunk_inner.gas_limit(),
+                    is_new_chunk: true,
+                    is_first_block_with_chunk_of_version,
+                },
+                ApplyTransactionsBlockContext::from_header(
+                    block.header(),
+                    prev_block.header().next_gas_price(),
+                ),
                 &receipts,
                 chunk.transactions(),
-                chunk_inner.prev_validator_proposals(),
-                prev_block.header().next_gas_price(),
-                chunk_inner.gas_limit(),
-                block.header().challenges_result(),
-                *block.header().random_value(),
-                true,
-                is_first_block_with_chunk_of_version,
             )
             .unwrap()
     } else {
@@ -253,21 +255,20 @@ fn apply_block_from_range(
 
         runtime_adapter
             .apply_transactions(
-                shard_id,
                 RuntimeStorageConfig::new(*chunk_extra.state_root(), use_flat_storage),
-                block.header().height(),
-                block.header().raw_timestamp(),
-                block.header().prev_hash(),
-                block.hash(),
+                ApplyTransactionsChunkContext {
+                    shard_id,
+                    last_validator_proposals: chunk_extra.validator_proposals(),
+                    gas_limit: chunk_extra.gas_limit(),
+                    is_new_chunk: false,
+                    is_first_block_with_chunk_of_version: false,
+                },
+                ApplyTransactionsBlockContext::from_header(
+                    block.header(),
+                    block.header().next_gas_price(),
+                ),
                 &[],
                 &[],
-                chunk_extra.validator_proposals(),
-                block.header().next_gas_price(),
-                chunk_extra.gas_limit(),
-                block.header().challenges_result(),
-                *block.header().random_value(),
-                false,
-                false,
             )
             .unwrap()
     };


### PR DESCRIPTION
This PR groups block- and chunk-related `RuntimeAdapter::apply_transactions` arguments into a separate structs. It also replaces usage `update_shard::BlockContext` with `ApplyTransactionsBlockContext` as well as a bit of refactoring around `ShardUpdateReason` to only require data which is actually used.

Implements the first idea from https://github.com/near/nearcore/issues/10261.