### PR TITLE
fix: format tcp connection error using `Display`

### DIFF
--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -437,7 +437,7 @@ impl NetworkState {
             let succeeded = !result.is_err();
 
             if let Err(ref err) = result {
-                tracing::info!(target:"network", err = %err, "Failed to connect to {peer_info}");
+                tracing::info!(target:"network", err = format!("{:#}", err), "Failed to connect to {peer_info}");
             }
 
             if self.peer_store.peer_connection_attempt(&clock, &peer_info.id, result).is_err() {

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -436,8 +436,8 @@ impl NetworkState {
 
             let succeeded = !result.is_err();
 
-            if result.is_err() {
-                tracing::info!(target:"network", ?result, "Failed to connect to {peer_info}");
+            if let Err(ref err) = result {
+                tracing::info!(target:"network", err = %err, "Failed to connect to {peer_info}");
             }
 
             if self.peer_store.peer_connection_attempt(&clock, &peer_info.id, result).is_err() {

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -598,7 +598,7 @@ impl PeerManagerActor {
                         }.await;
 
                         if let Err(ref err) = result {
-                            tracing::info!(target: "network", err = %err, "failed to connect to {peer_info}");
+                            tracing::info!(target: "network", err = format!("{:#}", err), "failed to connect to {peer_info}");
                         }
                         if state.peer_store.peer_connection_attempt(&clock, &peer_info.id, result).is_err() {
                             tracing::error!(target: "network", ?peer_info, "Failed to store connection attempt.");

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -597,8 +597,8 @@ impl PeerManagerActor {
                             anyhow::Ok(())
                         }.await;
 
-                        if result.is_err() {
-                            tracing::info!(target:"network", ?result, "failed to connect to {peer_info}");
+                        if let Err(ref err) = result {
+                            tracing::info!(target: "network", err = %err, "failed to connect to {peer_info}");
                         }
                         if state.peer_store.peer_connection_attempt(&clock, &peer_info.id, result).is_err() {
                             tracing::error!(target: "network", ?peer_info, "Failed to store connection attempt.");


### PR DESCRIPTION
Reported by @wacban.

Debug printing results in multiline strings, which are hard to interpret. It also breaks tooling one might want to use to analyze logs.

Example:
```
2023-12-01T10:22:08.186809Z INFO network: failed to connect to ed25519:AF4j@91.226.87.212:54063 result=Err(tcp::Stream::connect()
Caused by:
deadline has elapsed)
```

I believe this is coming from the default `Debug` impl for `anyhow::Error`. Using `Display` impl should fix it as it concatenates the context via `:` instead.