### PR TITLE
Implement simple state witness distribution, chunk validation, and chunk approval distribution skeletons.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3642,6 +3642,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rand 0.8.5",
+ "rayon",
  "reed-solomon-erasure",
  "regex",
  "reqwest",

--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -134,6 +134,8 @@ pub enum Error {
     /// Invalid chunk state.
     #[error("Invalid Chunk State")]
     InvalidChunkState(Box<ChunkState>),
+    #[error("Invalid Chunk State Witness")]
+    InvalidChunkStateWitness,
     /// Invalid chunk mask
     #[error("Invalid Chunk Mask")]
     InvalidChunkMask,
@@ -194,6 +196,11 @@ pub enum Error {
     /// Someone is not a validator. Usually happens in signature verification
     #[error("Not A Validator")]
     NotAValidator,
+    /// Someone is not a chunk validator. Happens if we're asked to validate a chunk we're not
+    /// supposed to validate, or to verify a chunk approval signed by a validator that isn't
+    /// supposed to validate the chunk.
+    #[error("Not A Chunk Validator")]
+    NotAChunkValidator,
     /// Validator error.
     #[error("Validator Error: {0}")]
     ValidatorError(String),
@@ -263,6 +270,7 @@ impl Error {
             | Error::InvalidChunk
             | Error::InvalidChunkProofs(_)
             | Error::InvalidChunkState(_)
+            | Error::InvalidChunkStateWitness
             | Error::InvalidChunkMask
             | Error::InvalidStateRoot
             | Error::InvalidTxRoot
@@ -294,6 +302,7 @@ impl Error {
             | Error::InvalidBlockMerkleRoot
             | Error::InvalidProtocolVersion
             | Error::NotAValidator
+            | Error::NotAChunkValidator
             | Error::InvalidChallengeRoot => true,
         }
     }
@@ -334,6 +343,7 @@ impl Error {
             Error::InvalidChunk => "invalid_chunk",
             Error::InvalidChunkProofs(_) => "invalid_chunk_proofs",
             Error::InvalidChunkState(_) => "invalid_chunk_state",
+            Error::InvalidChunkStateWitness => "invalid_chunk_state_witness",
             Error::InvalidChunkMask => "invalid_chunk_mask",
             Error::InvalidStateRoot => "invalid_state_root",
             Error::InvalidTxRoot => "invalid_tx_root",
@@ -365,6 +375,7 @@ impl Error {
             Error::InvalidBlockMerkleRoot => "invalid_block_merkele_root",
             Error::InvalidProtocolVersion => "invalid_protocol_version",
             Error::NotAValidator => "not_a_validator",
+            Error::NotAChunkValidator => "not_a_chunk_validator",
             Error::InvalidChallengeRoot => "invalid_challenge_root",
         }
     }

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -34,6 +34,7 @@ use near_primitives::types::{
     AccountId, ApprovalStake, Balance, BlockHeight, EpochHeight, EpochId, Gas, Nonce, NumShards,
     ShardId, StateChangesForSplitStates, StateRoot, StateRootNode, ValidatorInfoIdentifier,
 };
+use near_primitives::validator_mandates::AssignmentWeight;
 use near_primitives::version::{ProtocolVersion, PROTOCOL_VERSION};
 use near_primitives::views::{
     AccessKeyInfoView, AccessKeyList, CallResult, ContractCodeView, EpochValidatorInfo,
@@ -702,6 +703,15 @@ impl EpochManagerAdapter for MockEpochManager {
         let chunk_producers = self.get_chunk_producers(valset, shard_id);
         let index = (shard_id + height + 1) as usize % chunk_producers.len();
         Ok(chunk_producers[index].account_id().clone())
+    }
+
+    fn get_chunk_validators(
+        &self,
+        _epoch_id: &EpochId,
+        _shard_id: ShardId,
+        _height: BlockHeight,
+    ) -> Result<HashMap<AccountId, AssignmentWeight>, EpochError> {
+        Ok(HashMap::new())
     }
 
     fn get_validator_by_account_id(

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -27,6 +27,7 @@ num-rational.workspace = true
 once_cell.workspace = true
 percent-encoding.workspace = true
 rand.workspace = true
+rayon.workspace = true
 reed-solomon-erasure.workspace = true
 regex.workspace = true
 reqwest.workspace = true

--- a/chain/client/src/chunk_validation.rs
+++ b/chain/client/src/chunk_validation.rs
@@ -1,0 +1,153 @@
+use std::sync::Arc;
+
+use near_async::messaging::{CanSend, Sender};
+use near_chain::types::RuntimeAdapter;
+use near_chain_primitives::Error;
+use near_epoch_manager::EpochManagerAdapter;
+use near_network::types::{NetworkRequests, PeerManagerMessageRequest};
+use near_primitives::checked_feature;
+use near_primitives::chunk_validation::{
+    ChunkEndorsement, ChunkEndorsementInner, ChunkEndorsementMessage, ChunkStateWitness,
+};
+use near_primitives::sharding::ShardChunkHeader;
+use near_primitives::types::EpochId;
+use near_primitives::validator_signer::ValidatorSigner;
+
+use crate::Client;
+
+/// A module that handles chunk validation logic. Chunk validation refers to a
+/// critical process of stateless validation, where chunk validators (certain
+/// validators selected to validate the chunk) verify that the chunk's state
+/// witness is correct, and then sends chunk endorsements to the block producer
+/// so that the chunk can be included in the block.
+pub struct ChunkValidator {
+    my_signer: Option<Arc<dyn ValidatorSigner>>,
+    epoch_manager: Arc<dyn EpochManagerAdapter>,
+    network_sender: Sender<PeerManagerMessageRequest>,
+    runtime_adapter: Arc<dyn RuntimeAdapter>,
+}
+
+impl ChunkValidator {
+    pub fn new(
+        my_signer: Option<Arc<dyn ValidatorSigner>>,
+        epoch_manager: Arc<dyn EpochManagerAdapter>,
+        network_sender: Sender<PeerManagerMessageRequest>,
+        runtime_adapter: Arc<dyn RuntimeAdapter>,
+    ) -> Self {
+        Self { my_signer, epoch_manager, network_sender, runtime_adapter }
+    }
+
+    /// Performs the chunk validation logic. When done, it will send the chunk
+    /// endorsement message to the block producer. The actual validation logic
+    /// happens in a separate thread.
+    pub fn start_validating_chunk(&self, state_witness: ChunkStateWitness) -> Result<(), Error> {
+        if self.my_signer.is_none() {
+            return Err(Error::NotAValidator);
+        }
+        let chunk_header = state_witness.chunk_header.clone();
+        let epoch_id =
+            self.epoch_manager.get_epoch_id_from_prev_block(chunk_header.prev_block_hash())?;
+        // We will only validate something if we are a chunk validator for this chunk.
+        // Note this also covers the case before the protocol upgrade for chunk validators,
+        // because the chunk validators will be empty.
+        let chunk_validators = self.epoch_manager.get_chunk_validators(
+            &epoch_id,
+            chunk_header.shard_id(),
+            chunk_header.height_created(),
+        )?;
+        if !chunk_validators.contains_key(self.my_signer.as_ref().unwrap().validator_id()) {
+            return Err(Error::NotAChunkValidator);
+        }
+        let block_producer =
+            self.epoch_manager.get_block_producer(&epoch_id, chunk_header.height_created())?;
+
+        let network_sender = self.network_sender.clone();
+        let signer = self.my_signer.clone().unwrap();
+        let runtime_adapter = self.runtime_adapter.clone();
+        rayon::spawn(move || match validate_chunk(&state_witness, &*runtime_adapter) {
+            Ok(()) => {
+                tracing::debug!(
+                    target: "chunk_validation",
+                    "Chunk {:?} validated successfully, sending approval to {:?}",
+                    chunk_header.chunk_hash(),
+                    block_producer,
+                );
+                let endorsement_to_sign = ChunkEndorsementInner::new(chunk_header.chunk_hash());
+                network_sender.send(PeerManagerMessageRequest::NetworkRequests(
+                    NetworkRequests::ChunkEndorsement(ChunkEndorsementMessage {
+                        approval: ChunkEndorsement {
+                            account_id: signer.validator_id().clone(),
+                            signature: signer.sign_chunk_endorsement(&endorsement_to_sign),
+                            inner: endorsement_to_sign,
+                        },
+                        target: block_producer,
+                    }),
+                ));
+            }
+            Err(err) => {
+                tracing::error!("Failed to validate chunk: {:?}", err);
+            }
+        });
+        Ok(())
+    }
+}
+
+/// The actual chunk validation logic.
+fn validate_chunk(
+    state_witness: &ChunkStateWitness,
+    runtime_adapter: &dyn RuntimeAdapter,
+) -> Result<(), Error> {
+    // TODO: Replace this with actual stateless validation logic.
+    if state_witness.state_root != state_witness.chunk_header.prev_state_root() {
+        return Err(Error::InvalidChunkStateWitness);
+    }
+    // We'll need the runtime no matter what so just leaving it here to avoid an
+    // unused variable warning.
+    runtime_adapter.get_tries();
+    Ok(())
+}
+
+impl Client {
+    /// Responds to a network request to verify a `ChunkStateWitness`, which is
+    /// sent by chunk producers after they produce a chunk.
+    pub fn process_chunk_state_witness(&mut self, witness: ChunkStateWitness) -> Result<(), Error> {
+        // TODO(#10265): We'll need to fetch some data from the chain; at the very least we need
+        // the previous block to exist, and we need the previous chunks' receipt roots.
+        // Some of this depends on delayed chunk execution. Also, if the previous block
+        // does not exist, we should queue this (similar to orphans) to retry later.
+        // For now though, we just pass it to the chunk validation logic.
+        self.chunk_validator.start_validating_chunk(witness)
+    }
+
+    /// Distributes the chunk state witness to chunk validators that are
+    /// selected to validate this chunk.
+    pub fn send_chunk_state_witness_to_chunk_validators(
+        &mut self,
+        epoch_id: &EpochId,
+        chunk_header: &ShardChunkHeader,
+    ) -> Result<(), Error> {
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(epoch_id)?;
+        if !checked_feature!("stable", ChunkValidation, protocol_version) {
+            return Ok(());
+        }
+        let chunk_validators = self.epoch_manager.get_chunk_validators(
+            epoch_id,
+            chunk_header.shard_id(),
+            chunk_header.height_created(),
+        )?;
+        let witness = ChunkStateWitness {
+            chunk_header: chunk_header.clone(),
+            state_root: chunk_header.prev_state_root(),
+        };
+        tracing::debug!(
+            target: "chunk_validation",
+            "Sending chunk state witness for chunk {:?} to chunk validators {:?}",
+            chunk_header.chunk_hash(),
+            chunk_validators.keys(),
+        );
+        self.network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
+            NetworkRequests::ChunkStateWitness(chunk_validators.into_keys().collect(), witness),
+        ));
+        Ok(())
+    }
+}

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -6,8 +6,8 @@
 //! https://github.com/near/nearcore/issues/7899
 
 use crate::adapter::{
-    BlockApproval, BlockHeadersResponse, BlockResponse, ProcessTxRequest, ProcessTxResponse,
-    RecvChallenge, SetNetworkInfo, StateResponse,
+    BlockApproval, BlockHeadersResponse, BlockResponse, ChunkStateWitnessMessage, ProcessTxRequest,
+    ProcessTxResponse, RecvChallenge, SetNetworkInfo, StateResponse,
 };
 #[cfg(feature = "test_features")]
 use crate::client::AdvProduceBlocksMode;
@@ -1918,6 +1918,22 @@ impl Handler<WithSpanContext<SyncMessage>> for ClientActor {
         tracing::debug!(target: "client", ?msg);
         // TODO
         // process messages from SyncActors
+    }
+}
+
+impl Handler<WithSpanContext<ChunkStateWitnessMessage>> for ClientActor {
+    type Result = ();
+
+    #[perf]
+    fn handle(
+        &mut self,
+        msg: WithSpanContext<ChunkStateWitnessMessage>,
+        _: &mut Context<Self>,
+    ) -> Self::Result {
+        let (_span, msg) = handler_debug_span!(target: "client", msg);
+        if let Err(err) = self.client.process_chunk_state_witness(msg.0) {
+            tracing::error!(target: "client", ?err, "Error processing chunk state witness");
+        }
     }
 }
 

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -22,6 +22,7 @@ pub use near_client_primitives::debug::DebugStatus;
 
 pub mod adapter;
 pub mod adversarial;
+mod chunk_validation;
 mod client;
 mod client_actor;
 mod config_updater;

--- a/chain/client/src/test_utils/setup.rs
+++ b/chain/client/src/test_utils/setup.rs
@@ -828,6 +828,8 @@ pub fn setup_mock_all_validators(
                         | NetworkRequests::TxStatus(_, _, _)
                         | NetworkRequests::SnapshotHostInfo { .. }
                         | NetworkRequests::Challenge(_) => {}
+                        NetworkRequests::ChunkStateWitness(_, _) => todo!(),
+                        NetworkRequests::ChunkEndorsement(_) => todo!(),
                     };
                 }
                 resp

--- a/chain/client/src/test_utils/setup.rs
+++ b/chain/client/src/test_utils/setup.rs
@@ -834,8 +834,12 @@ pub fn setup_mock_all_validators(
                         | NetworkRequests::TxStatus(_, _, _)
                         | NetworkRequests::SnapshotHostInfo { .. }
                         | NetworkRequests::Challenge(_) => {}
-                        NetworkRequests::ChunkStateWitness(_, _) => todo!(),
-                        NetworkRequests::ChunkEndorsement(_) => todo!(),
+                        NetworkRequests::ChunkStateWitness(_, _) => {
+                            // TODO(#10265): Implement for integration tests.
+                        },
+                        NetworkRequests::ChunkEndorsement(_) => {
+                            // TODO(#10265): Implement for integration tests.
+                        },
                     };
                 }
                 resp

--- a/chain/client/src/test_utils/test_env_builder.rs
+++ b/chain/client/src/test_utils/test_env_builder.rs
@@ -23,7 +23,7 @@ use near_store::{NodeStorage, ShardUId, Store, StoreConfig, TrieConfig};
 
 use super::setup::{setup_client_with_runtime, setup_synchronous_shards_manager};
 use super::test_env::TestEnv;
-use super::TEST_SEED;
+use super::{AccountIndices, TEST_SEED};
 
 #[derive(derive_more::From, Clone)]
 enum EpochManagerKind {
@@ -544,12 +544,13 @@ impl TestEnvBuilder {
             client_adapters,
             shards_manager_adapters,
             clients,
-            account_to_client_index: self
-                .clients
-                .into_iter()
-                .enumerate()
-                .map(|(index, client)| (client, index))
-                .collect(),
+            account_indices: AccountIndices(
+                self.clients
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, client)| (client, index))
+                    .collect(),
+            ),
             paused_blocks: Default::default(),
             seeds,
             archive: self.archive,

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -18,11 +18,11 @@ use near_primitives::types::{
     AccountId, ApprovalStake, Balance, BlockHeight, EpochHeight, EpochId, ShardId,
     ValidatorInfoIdentifier,
 };
+use near_primitives::validator_mandates::AssignmentWeight;
 use near_primitives::version::ProtocolVersion;
 use near_primitives::views::EpochValidatorInfo;
 use near_store::{ShardUId, StoreUpdate};
 use std::cmp::Ordering;
-#[cfg(feature = "new_epoch_sync")]
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -186,6 +186,14 @@ pub trait EpochManagerAdapter: Send + Sync {
         height: BlockHeight,
         shard_id: ShardId,
     ) -> Result<AccountId, EpochError>;
+
+    /// Gets the chunk validators for a given height and shard.
+    fn get_chunk_validators(
+        &self,
+        epoch_id: &EpochId,
+        shard_id: ShardId,
+        height: BlockHeight,
+    ) -> Result<HashMap<AccountId, AssignmentWeight>, EpochError>;
 
     fn get_validator_by_account_id(
         &self,
@@ -641,6 +649,16 @@ impl EpochManagerAdapter for EpochManagerHandle {
     ) -> Result<AccountId, EpochError> {
         let epoch_manager = self.read();
         Ok(epoch_manager.get_chunk_producer_info(epoch_id, height, shard_id)?.take_account_id())
+    }
+
+    fn get_chunk_validators(
+        &self,
+        epoch_id: &EpochId,
+        shard_id: ShardId,
+        height: BlockHeight,
+    ) -> Result<HashMap<AccountId, AssignmentWeight>, EpochError> {
+        let epoch_manager = self.read();
+        epoch_manager.get_chunk_validators(epoch_id, shard_id, height)
     }
 
     fn get_validator_by_account_id(

--- a/chain/network/src/client.rs
+++ b/chain/network/src/client.rs
@@ -4,6 +4,7 @@ use crate::types::{NetworkInfo, ReasonForBan};
 
 use near_primitives::block::{Approval, Block, BlockHeader};
 use near_primitives::challenge::Challenge;
+use near_primitives::chunk_validation::ChunkStateWitness;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::transaction::SignedTransaction;
@@ -62,6 +63,8 @@ pub trait Client: Send + Sync + 'static {
         &self,
         accounts: Vec<(AnnounceAccount, Option<EpochId>)>,
     ) -> Result<Vec<AnnounceAccount>, ReasonForBan>;
+
+    async fn chunk_state_witness(&self, witness: ChunkStateWitness);
 }
 
 /// Implementation of Client which doesn't do anything and never returns errors.
@@ -129,4 +132,6 @@ impl Client for Noop {
     ) -> Result<Vec<AnnounceAccount>, ReasonForBan> {
         Ok(vec![])
     }
+
+    async fn chunk_state_witness(&self, _witness: ChunkStateWitness) {}
 }

--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -7,6 +7,8 @@ mod peer;
 mod proto_conv;
 mod state_sync;
 pub use edge::*;
+use near_primitives::chunk_validation::ChunkEndorsement;
+use near_primitives::chunk_validation::ChunkStateWitness;
 pub use peer::*;
 pub use state_sync::*;
 
@@ -527,6 +529,9 @@ pub enum RoutedMessageBody {
     VersionedPartialEncodedChunk(PartialEncodedChunk),
     _UnusedVersionedStateResponse,
     PartialEncodedChunkForward(PartialEncodedChunkForwardMsg),
+
+    ChunkStateWitness(ChunkStateWitness),
+    ChunkEndorsement(ChunkEndorsement),
 }
 
 impl RoutedMessageBody {
@@ -535,10 +540,11 @@ impl RoutedMessageBody {
     // lost
     pub fn is_important(&self) -> bool {
         match self {
-            // Both BlockApproval and VersionedPartialEncodedChunk is essential for block production and
-            // are only sent by the original node and if they are lost, the receiver node doesn't
-            // know to request them.
+            // These messages are important because they are critical for block and chunk production,
+            // and lost messages cannot be requested again.
             RoutedMessageBody::BlockApproval(_)
+            | RoutedMessageBody::ChunkEndorsement(_)
+            | RoutedMessageBody::ChunkStateWitness(_)
             | RoutedMessageBody::VersionedPartialEncodedChunk(_) => true,
             _ => false,
         }
@@ -591,6 +597,8 @@ impl fmt::Debug for RoutedMessageBody {
             RoutedMessageBody::Ping(_) => write!(f, "Ping"),
             RoutedMessageBody::Pong(_) => write!(f, "Pong"),
             RoutedMessageBody::_UnusedVersionedStateResponse => write!(f, "VersionedStateResponse"),
+            RoutedMessageBody::ChunkStateWitness(_) => write!(f, "ChunkStateWitness"),
+            RoutedMessageBody::ChunkEndorsement(_) => write!(f, "ChunkEndorsement"),
         }
     }
 }

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -987,6 +987,14 @@ impl PeerActor {
                 // variant completely.
                 None
             }
+            RoutedMessageBody::ChunkStateWitness(witness) => {
+                network_state.client.chunk_state_witness(witness).await;
+                None
+            }
+            RoutedMessageBody::ChunkEndorsement(_) => {
+                // TODO(#10265): Handle chunk approvals.
+                None
+            }
             body => {
                 tracing::error!(target: "network", "Peer received unexpected message type: {:?}", body);
                 None

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -954,7 +954,7 @@ impl PeerManagerActor {
                 self.state.send_message_to_account(
                     &self.clock,
                     &approval.target,
-                    RoutedMessageBody::ChunkEndorsement(approval.approval),
+                    RoutedMessageBody::ChunkEndorsement(approval.endorsement),
                 );
                 NetworkResponses::NoResponse
             }

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -940,6 +940,24 @@ impl PeerManagerActor {
                 self.state.tier2.broadcast_message(Arc::new(PeerMessage::Challenge(challenge)));
                 NetworkResponses::NoResponse
             }
+            NetworkRequests::ChunkStateWitness(chunk_validators, state_witness) => {
+                for chunk_validator in chunk_validators {
+                    self.state.send_message_to_account(
+                        &self.clock,
+                        &chunk_validator,
+                        RoutedMessageBody::ChunkStateWitness(state_witness.clone()),
+                    );
+                }
+                NetworkResponses::NoResponse
+            }
+            NetworkRequests::ChunkEndorsement(approval) => {
+                self.state.send_message_to_account(
+                    &self.clock,
+                    &approval.target,
+                    RoutedMessageBody::ChunkEndorsement(approval.approval),
+                );
+                NetworkResponses::NoResponse
+            }
         }
     }
 

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -269,6 +269,29 @@ impl MockPeerManagerAdapter {
     pub fn put_back_most_recent(&self, request: PeerManagerMessageRequest) {
         self.requests.write().unwrap().push_back(request);
     }
+    /// Calls the handler for each message, but removing only those for which the handler returns
+    /// None (or else the returned message gets requeued; the returned message should be the same
+    /// as the one given). Returns true if any message was removed.
+    pub fn handle_filtered(
+        &self,
+        mut f: impl FnMut(PeerManagerMessageRequest) -> Option<PeerManagerMessageRequest>,
+    ) -> bool {
+        // We get the count first and then pop one by one, that way we avoid
+        // grabbing the lock for the whole duration, which might lead to a
+        // deadlock if the processing of the request results in more network
+        // messages.
+        let num_requests = self.requests.read().unwrap().len();
+        let mut handled = false;
+        for _ in 0..num_requests {
+            let request = self.requests.write().unwrap().pop_front().unwrap();
+            if let Some(request) = f(request) {
+                self.requests.write().unwrap().push_back(request);
+            } else {
+                handled = true;
+            }
+        }
+        handled
+    }
 }
 
 #[derive(actix::Message, Clone, Debug)]

--- a/chain/network/src/testonly/fake_client.rs
+++ b/chain/network/src/testonly/fake_client.rs
@@ -6,6 +6,7 @@ use crate::types::{NetworkInfo, ReasonForBan, StateResponseInfoV2};
 use near_async::messaging;
 use near_primitives::block::{Approval, Block, BlockHeader};
 use near_primitives::challenge::Challenge;
+use near_primitives::chunk_validation::ChunkStateWitness;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::sharding::{ChunkHash, PartialEncodedChunkPart};
@@ -25,6 +26,7 @@ pub enum Event {
     Challenge(Challenge),
     Chunk(Vec<PartialEncodedChunkPart>),
     ChunkRequest(ChunkHash),
+    ChunkStateWitness(ChunkStateWitness),
     Transaction(SignedTransaction),
 }
 
@@ -116,6 +118,10 @@ impl client::Client for Fake {
     ) -> Result<Vec<AnnounceAccount>, ReasonForBan> {
         self.event_sink.push(Event::AnnounceAccount(accounts.clone()));
         Ok(accounts.into_iter().map(|a| a.0).collect())
+    }
+
+    async fn chunk_state_witness(&self, witness: ChunkStateWitness) {
+        self.event_sink.push(Event::ChunkStateWitness(witness));
     }
 }
 

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -18,6 +18,7 @@ use near_async::time;
 use near_crypto::PublicKey;
 use near_primitives::block::{ApprovalMessage, Block, GenesisId};
 use near_primitives::challenge::Challenge;
+use near_primitives::chunk_validation::{ChunkEndorsementMessage, ChunkStateWitness};
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::sharding::PartialEncodedChunkWithArcReceipts;
@@ -256,6 +257,11 @@ pub enum NetworkRequests {
     TxStatus(AccountId, AccountId, CryptoHash),
     /// A challenge to invalidate a block.
     Challenge(Challenge),
+    /// A chunk's state witness.
+    ChunkStateWitness(Vec<AccountId>, ChunkStateWitness),
+    /// Message for a chunk endorsement, sent by a chunk validator to
+    /// the block producer.
+    ChunkEndorsement(ChunkEndorsementMessage),
 }
 
 /// Combines peer address info, chain.

--- a/core/primitives/src/chunk_validation.rs
+++ b/core/primitives/src/chunk_validation.rs
@@ -1,0 +1,51 @@
+use crate::sharding::{ChunkHash, ShardChunkHeader};
+use crate::types::StateRoot;
+use borsh::{BorshDeserialize, BorshSerialize};
+use near_crypto::Signature;
+use near_primitives_core::types::AccountId;
+
+/// The state witness for a chunk; proves the state transition that the
+/// chunk attests to.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct ChunkStateWitness {
+    // TODO(#10265): Is the entire header necessary?
+    pub chunk_header: ShardChunkHeader,
+    // TODO(#10265): Replace this with fields for the actual witness.
+    pub state_root: StateRoot,
+}
+
+/// The endorsement of a chunk by a chunk validator. By providing this, a
+/// chunk validator has verified that the chunk state witness is correct.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct ChunkEndorsement {
+    pub inner: ChunkEndorsementInner,
+    pub account_id: AccountId,
+    pub signature: Signature,
+}
+
+/// This is the part of the chunk endorsement that is actually being signed.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct ChunkEndorsementInner {
+    pub chunk_hash: ChunkHash,
+    /// An arbitrary static string to make sure that this struct cannot be
+    /// serialized to look identical to another serialized struct. For chunk
+    /// production we are signing a chunk hash, so we need to make sure that
+    /// this signature means something different.
+    ///
+    /// This is a messy workaround until we know what to do with NEP 483.
+    signature_differentiator: String,
+}
+
+impl ChunkEndorsementInner {
+    pub fn new(chunk_hash: ChunkHash) -> Self {
+        Self { chunk_hash, signature_differentiator: "ChunkEndorsement".to_owned() }
+    }
+}
+
+/// Message intended for the network layer to send a chunk endorsement.
+/// It just includes an additional target account ID to send it to.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct ChunkEndorsementMessage {
+    pub approval: ChunkEndorsement,
+    pub target: AccountId,
+}

--- a/core/primitives/src/chunk_validation.rs
+++ b/core/primitives/src/chunk_validation.rs
@@ -46,6 +46,6 @@ impl ChunkEndorsementInner {
 /// It just includes an additional target account ID to send it to.
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ChunkEndorsementMessage {
-    pub approval: ChunkEndorsement,
+    pub endorsement: ChunkEndorsement,
     pub target: AccountId,
 }

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -857,6 +857,8 @@ pub enum EpochError {
         num_validators: u64,
         num_shards: u64,
     },
+    /// Error selecting validators for a chunk.
+    ChunkValidatorSelectionError(String),
 }
 
 impl std::error::Error for EpochError {}
@@ -881,6 +883,9 @@ impl Display for EpochError {
             EpochError::NotEnoughValidators { num_shards, num_validators } => {
                 write!(f, "There were not enough validator proposals to fill all shards. num_proposals: {}, num_shards: {}", num_validators, num_shards)
             }
+            EpochError::ChunkValidatorSelectionError(err) => {
+                write!(f, "Error selecting validators for a chunk: {}", err)
+            }
         }
     }
 }
@@ -900,6 +905,9 @@ impl Debug for EpochError {
             EpochError::ShardingError(err) => write!(f, "ShardingError({})", err),
             EpochError::NotEnoughValidators { num_shards, num_validators } => {
                 write!(f, "NotEnoughValidators({}, {})", num_validators, num_shards)
+            }
+            EpochError::ChunkValidatorSelectionError(err) => {
+                write!(f, "ChunkValidatorSelectionError({})", err)
             }
         }
     }

--- a/core/primitives/src/lib.rs
+++ b/core/primitives/src/lib.rs
@@ -10,6 +10,7 @@ pub mod block;
 pub mod block_header;
 pub mod chains;
 pub mod challenge;
+pub mod chunk_validation;
 pub mod epoch_manager;
 pub mod epoch_sync;
 pub mod errors;

--- a/integration-tests/src/tests/client/features.rs
+++ b/integration-tests/src/tests/client/features.rs
@@ -5,6 +5,7 @@ mod account_id_in_function_call_permission;
 mod adversarial_behaviors;
 mod cap_max_gas_price;
 mod chunk_nodes_cache;
+mod chunk_validation;
 mod delegate_action;
 #[cfg(feature = "protocol_feature_fix_contract_loading_cost")]
 mod fix_contract_loading_cost;

--- a/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
@@ -784,6 +784,8 @@ impl ChunkForwardingOptimizationTestData {
                     ShardsManagerRequestFromNetwork::ProcessPartialEncodedChunkForward(forward),
                 );
             }
+            NetworkRequests::ChunkStateWitness(_, _) => {}
+            NetworkRequests::ChunkEndorsement(_) => {}
             _ => {
                 panic!("Unexpected network request: {:?}", requests);
             }

--- a/integration-tests/src/tests/client/features/adversarial_behaviors.rs
+++ b/integration-tests/src/tests/client/features/adversarial_behaviors.rs
@@ -84,6 +84,12 @@ impl AdversarialBehaviorTestData {
             NetworkRequests::Challenge(_) => {
                 // challenges not enabled.
             }
+            NetworkRequests::ChunkEndorsement(_) => {
+                // TODO(#10265).
+            }
+            NetworkRequests::ChunkStateWitness(_, _) => {
+                // TODO(#10265).
+            }
             _ => {
                 panic!("Unexpected network request: {:?}", requests);
             }

--- a/integration-tests/src/tests/client/features/chunk_validation.rs
+++ b/integration-tests/src/tests/client/features/chunk_validation.rs
@@ -1,0 +1,143 @@
+use near_chain::{ChainGenesis, Provenance};
+use near_chain_configs::{Genesis, GenesisConfig, GenesisRecords};
+use near_client::test_utils::TestEnv;
+use near_o11y::testonly::init_test_logger;
+use near_primitives::block::Tip;
+use near_primitives::shard_layout::ShardLayout;
+use near_primitives::state_record::StateRecord;
+use near_primitives::test_utils::create_test_signer;
+use near_primitives::types::AccountInfo;
+use near_primitives_core::account::Account;
+use near_primitives_core::checked_feature;
+use near_primitives_core::hash::CryptoHash;
+use near_primitives_core::types::AccountId;
+use near_primitives_core::version::PROTOCOL_VERSION;
+use nearcore::test_utils::TestEnvNightshadeSetupExt;
+use std::collections::HashSet;
+
+const ONE_NEAR: u128 = 1_000_000_000_000_000_000_000_000;
+
+#[test]
+fn test_chunk_validation_basic() {
+    init_test_logger();
+
+    if !checked_feature!("stable", ChunkValidation, PROTOCOL_VERSION) {
+        println!("Test not applicable without ChunkValidation enabled");
+        return;
+    }
+
+    let validator_stake = 1000000 * ONE_NEAR;
+    let accounts =
+        (0..9).map(|i| format!("account{}", i).parse().unwrap()).collect::<Vec<AccountId>>();
+    let mut genesis_config = GenesisConfig {
+        // Use the latest protocol version. Otherwise, the version may be too
+        // old that e.g. blocks don't even store previous heights.
+        protocol_version: PROTOCOL_VERSION,
+        // Some arbitrary starting height. Doesn't matter.
+        genesis_height: 10000,
+        // We'll use four shards for this test.
+        shard_layout: ShardLayout::get_simple_nightshade_layout(),
+        // Make 8 validators, which means 2 will be assigned as chunk validators
+        // for each chunk.
+        validators: accounts
+            .iter()
+            .take(8)
+            .map(|account_id| AccountInfo {
+                account_id: account_id.clone(),
+                public_key: create_test_signer(account_id.as_str()).public_key(),
+                amount: validator_stake,
+            })
+            .collect(),
+        // We don't care about epoch transitions in this test.
+        epoch_length: 10000,
+        // The genesis requires this, so set it to something arbitrary.
+        protocol_treasury_account: accounts[8].clone(),
+        // Simply make all validators block producers.
+        num_block_producer_seats: 8,
+        // Make all validators produce chunks for all shards.
+        minimum_validators_per_shard: 8,
+        // Even though not used for the most recent protocol version,
+        // this must still have the same length as the number of shards,
+        // or else the genesis fails validation.
+        num_block_producer_seats_per_shard: vec![8, 8, 8, 8],
+        ..Default::default()
+    };
+
+    // Set up the records corresponding to the validator accounts.
+    let mut records = Vec::new();
+    for (i, account) in accounts.iter().enumerate() {
+        // The staked amount must be consistent with validators from genesis.
+        let staked = if i < 8 { validator_stake } else { 0 };
+        records.push(StateRecord::Account {
+            account_id: account.clone(),
+            account: Account::new(0, staked, CryptoHash::default(), 0),
+        });
+        // The total supply must be correct to pass validation.
+        genesis_config.total_supply += staked;
+    }
+    let genesis = Genesis::new(genesis_config, GenesisRecords(records)).unwrap();
+    let chain_genesis = ChainGenesis::new(&genesis);
+
+    let mut env = TestEnv::builder(chain_genesis)
+        .clients(accounts.iter().take(8).cloned().collect())
+        .real_epoch_managers(&genesis.config)
+        .nightshade_runtimes(&genesis)
+        .build();
+
+    for round in 0..10 {
+        let heads = env
+            .clients
+            .iter()
+            .map(|client| client.chain.head().unwrap().last_block_hash)
+            .collect::<HashSet<_>>();
+        assert_eq!(heads.len(), 1, "All clients should have the same head");
+        let tip = env.clients[0].chain.head().unwrap();
+
+        let block_producer = get_block_producer(&env, &tip, 1);
+        println!("Producing block at height {} by {}", tip.height + 1, block_producer);
+        let block = env.client(&block_producer).produce_block(tip.height + 1).unwrap().unwrap();
+        if round > 1 {
+            for i in 0..4 {
+                let chunks = block.chunks();
+                let chunk = chunks.get(i).unwrap();
+                assert_eq!(chunk.height_created(), chunk.height_included());
+            }
+        }
+
+        // Apply the block.
+        for i in 0..env.clients.len() {
+            println!(
+                "  Applying block at height {} at {}",
+                block.header().height(),
+                env.get_client_id(i)
+            );
+            let blocks_processed =
+                env.clients[i].process_block_test(block.clone().into(), Provenance::NONE).unwrap();
+            assert_eq!(blocks_processed, vec![*block.hash()]);
+        }
+
+        env.process_partial_encoded_chunks();
+        for j in 0..env.clients.len() {
+            env.process_shards_manager_responses_and_finish_processing_blocks(j);
+        }
+        env.propagate_chunk_state_witnesses();
+    }
+
+    // Wait a bit and check that we've received at least some chunk approvals.
+    // TODO(#10265): We need to make this not time-based, and we need to assert
+    // exactly how many approvals (or total stake) we have.
+    std::thread::sleep(std::time::Duration::from_secs(1));
+    let approvals = env.get_all_chunk_endorsements();
+    assert!(!approvals.is_empty());
+}
+
+// Returns the block producer for the height of head + height_offset.
+fn get_block_producer(env: &TestEnv, head: &Tip, height_offset: u64) -> AccountId {
+    let client = &env.clients[0];
+    let epoch_manager = &client.epoch_manager;
+    let parent_hash = &head.last_block_hash;
+    let epoch_id = epoch_manager.get_epoch_id_from_prev_block(parent_hash).unwrap();
+    let height = head.height + height_offset;
+    let block_producer = epoch_manager.get_block_producer(&epoch_id, height).unwrap();
+    block_producer
+}

--- a/tools/chainsync-loadtest/src/network.rs
+++ b/tools/chainsync-loadtest/src/network.rs
@@ -13,6 +13,7 @@ use near_network::types::{
 };
 use near_primitives::block::{Approval, Block, BlockHeader};
 use near_primitives::challenge::Challenge;
+use near_primitives::chunk_validation::ChunkStateWitness;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::sharding::ChunkHash;
@@ -302,4 +303,6 @@ impl near_network::client::Client for Network {
     ) -> Result<Vec<AnnounceAccount>, ReasonForBan> {
         Ok(accounts.into_iter().map(|a| a.0).collect())
     }
+
+    async fn chunk_state_witness(&self, _witness: ChunkStateWitness) {}
 }


### PR DESCRIPTION
This is a pretty rough PR, but I'm making an attempt to concretely implement the flow from distributing the state witness to sending the chunk endorsement. The following is left out: (1) production of the state witness; (2) actual validation logic; (3) receiving the chunk endorsement. However, the skeleton of the flow is there, including multithreading of the validation logic.

Very open to comments.