### PR TITLE
[resharding] Remove epoch_offset for resharding python test V1->V2

### DIFF
--- a/pytest/lib/resharding_lib.py
+++ b/pytest/lib/resharding_lib.py
@@ -113,12 +113,3 @@ def get_target_num_shards(binary_protocol_version):
         return 4
 
     assert False
-
-
-def get_epoch_offset(binary_protocol_version):
-    if binary_protocol_version >= V2_PROTOCOL_VERSION:
-        return 1
-    if binary_protocol_version >= V1_PROTOCOL_VERSION:
-        return 0
-
-    assert False

--- a/pytest/tests/sanity/resharding.py
+++ b/pytest/tests/sanity/resharding.py
@@ -15,7 +15,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 from configured_logger import logger
 from cluster import get_binary_protocol_version, init_cluster, load_config, spin_up_node
 from utils import MetricsTracker, poll_blocks
-from resharding_lib import append_shard_layout_config_changes, get_epoch_offset, get_genesis_num_shards, get_genesis_shard_layout_version, get_target_num_shards, get_target_shard_layout_version
+from resharding_lib import append_shard_layout_config_changes, get_genesis_num_shards, get_genesis_shard_layout_version, get_target_num_shards, get_target_shard_layout_version
 
 
 class ReshardingTest(unittest.TestCase):
@@ -35,8 +35,6 @@ class ReshardingTest(unittest.TestCase):
             self.binary_protocol_version)
         self.target_num_shards = get_target_num_shards(
             self.binary_protocol_version)
-
-        self.epoch_offset = get_epoch_offset(self.binary_protocol_version)
 
     def __get_genesis_config_changes(self):
         genesis_config_changes = [
@@ -115,9 +113,7 @@ class ReshardingTest(unittest.TestCase):
             # This may be flaky - it shouldn't - but it may. We collect metrics
             # after the block is processed. If there is some delay the shard
             # layout may change and the assertions below will fail.
-
-            # TODO(resharding) Why is epoch offset needed here?
-            if height <= 2 * self.epoch_length + self.epoch_offset:
+            if height <= 2 * self.epoch_length:
                 self.assertEqual(version, self.genesis_shard_layout_version)
                 self.assertEqual(num_shards, self.genesis_num_shards)
             else:


### PR DESCRIPTION
Locally testing revealed we don't really need the epoch_offset for V1 -> V2 resharding.

TODO: Verify on nayduck