### PR TITLE
Remove rust-version.workspace = true from published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,11 @@ repository = "https://github.com/near/nearcore"
 license = "MIT OR Apache-2.0"
 
 [workspace.metadata.workspaces]
-# shared version of all public crates in the workspace
+# Shared version of all public crates in the workspace.
+# This is only used for crates that are not stable.
+# Most crates are not stable on purpose, as maintaining API compatibility is a
+# significant developer time expense. Please think thoroughly before adding
+# anything to the list of stable crates.
 version = "0.17.0"
 exclude = ["neard"]
 

--- a/chain/chain-primitives/Cargo.toml
+++ b/chain/chain-primitives/Cargo.toml
@@ -3,7 +3,6 @@ name = "near-chain-primitives"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 description = "This crate hosts NEAR chain-related error types"
 repository.workspace = true
 license.workspace = true

--- a/chain/chunks-primitives/Cargo.toml
+++ b/chain/chunks-primitives/Cargo.toml
@@ -3,7 +3,6 @@ name = "near-chunks-primitives"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 description = "This crate hosts NEAR chunks-related error types"
 repository.workspace = true
 license.workspace = true

--- a/chain/client-primitives/Cargo.toml
+++ b/chain/client-primitives/Cargo.toml
@@ -3,7 +3,6 @@ name = "near-client-primitives"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 description = "This crate hosts NEAR client-related error types"
 repository.workspace = true
 license.workspace = true

--- a/chain/indexer-primitives/Cargo.toml
+++ b/chain/indexer-primitives/Cargo.toml
@@ -3,7 +3,6 @@ name = "near-indexer-primitives"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 description = "This crate hosts structures for the NEAR Indexer Framework types"
 repository.workspace = true
 license.workspace = true

--- a/chain/jsonrpc-primitives/Cargo.toml
+++ b/chain/jsonrpc-primitives/Cargo.toml
@@ -3,7 +3,6 @@ name = "near-jsonrpc-primitives"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 description = "This crate hosts structures for the NEAR JSON RPC Requests, Responses and Error types"
 repository.workspace = true
 license.workspace = true

--- a/core/chain-configs/Cargo.toml
+++ b/core/chain-configs/Cargo.toml
@@ -3,7 +3,6 @@ name = "near-chain-configs"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 description = "This crate provides typed interfaces to the NEAR Genesis and Chain Configs"
 repository.workspace = true
 license.workspace = true

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -3,7 +3,6 @@ name = "near-crypto"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 description = "This is an internal crate for common cryptographic types"
 repository.workspace = true
 license.workspace = true

--- a/core/dyn-configs/Cargo.toml
+++ b/core/dyn-configs/Cargo.toml
@@ -3,7 +3,6 @@ name = "near-dyn-configs"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 description = "Dynamic configure helpers for the near codebase"
 repository.workspace = true
 license.workspace = true

--- a/core/o11y/Cargo.toml
+++ b/core/o11y/Cargo.toml
@@ -3,7 +3,6 @@ name = "near-o11y"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 description = "Observability helpers for the near codebase"
 repository.workspace = true
 license.workspace = true

--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -3,7 +3,6 @@ name = "near-primitives-core"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 description = "This crate provides the core set of primitives used by other nearcore crates including near-primitives"
 repository.workspace = true
 license.workspace = true

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -3,7 +3,6 @@ name = "near-primitives"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 description = "This crate provides the base set of primitives used by other nearcore crates"
 repository.workspace = true
 license.workspace = true

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -3,7 +3,6 @@ name = "near-vm-runner"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 description = "This crate implements the specification of the interface that Near blockchain exposes to the smart contracts."
 repository.workspace = true
 license.workspace = true

--- a/runtime/near-vm/compiler-singlepass/Cargo.toml
+++ b/runtime/near-vm/compiler-singlepass/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT"
 readme = "README.md"
 edition = "2021"
 publish = true
-rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/runtime/near-vm/compiler/Cargo.toml
+++ b/runtime/near-vm/compiler/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT OR Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 edition = "2021"
 publish = true
-rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/runtime/near-vm/engine/Cargo.toml
+++ b/runtime/near-vm/engine/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT OR Apache-2.0 WITH LLVM-exception "
 readme = "README.md"
 edition = "2021"
 publish = true
-rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/runtime/near-vm/types/Cargo.toml
+++ b/runtime/near-vm/types/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT OR Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 edition = "2021"
 publish = true
-rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/runtime/near-vm/vm/Cargo.toml
+++ b/runtime/near-vm/vm/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT OR Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 edition = "2021"
 publish = true
-rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/tools/rpctypegen/core/Cargo.toml
+++ b/tools/rpctypegen/core/Cargo.toml
@@ -3,7 +3,6 @@ name = "near-rpc-error-core"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 description = "This crate generates schema for Rust structs which can be used by TypeScript."
 repository.workspace = true
 license.workspace = true

--- a/tools/rpctypegen/macro/Cargo.toml
+++ b/tools/rpctypegen/macro/Cargo.toml
@@ -3,7 +3,6 @@ name = "near-rpc-error-macro"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 description = "This crate generates schema for Rust structs which can be used by TypeScript."
 repository.workspace = true
 license.workspace = true

--- a/utils/config/Cargo.toml
+++ b/utils/config/Cargo.toml
@@ -3,7 +3,6 @@ name = "near-config-utils"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 description = "This is an internal crate to provide utils for reading config files"
 repository.workspace = true
 license.workspace = true

--- a/utils/fmt/Cargo.toml
+++ b/utils/fmt/Cargo.toml
@@ -3,7 +3,6 @@ name = "near-fmt"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 description = "Helpers for pretty formatting."
 repository.workspace = true
 license.workspace = true

--- a/utils/near-cache/Cargo.toml
+++ b/utils/near-cache/Cargo.toml
@@ -3,7 +3,6 @@ name = "near-cache"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 description = "do not use this, new versions can stop being published at literally any time"
 repository.workspace = true
 license.workspace = true

--- a/utils/near-stable-hasher/Cargo.toml
+++ b/utils/near-stable-hasher/Cargo.toml
@@ -3,7 +3,6 @@ name = "near-stable-hasher"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 description = "`near-stable-hasher` is a library that is essentially a wrapper around, now deprecated, `std::hash::SipHasher`."
 repository.workspace = true
 license.workspace = true

--- a/utils/stdx/Cargo.toml
+++ b/utils/stdx/Cargo.toml
@@ -3,7 +3,6 @@ name = "near-stdx"
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 description = "This crate contains polyfills which should really be in std, but currently aren't for one reason or another."
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
This comes at the request of dev-hub, where dependencies downstream have been having issues with our aggressive rust-version policy. Supporting only the latest rust-version is not enough for them.

As a consequence, we’re removing rust-version here. This sounds like a more semantically reasonable use for rust-version anyway: a crate without rust-version set should be assumed to work with the latest stable version anyway, and maybe more without guarantees… which is exactly our guarantees.

Also update the themis tool to make sure we don’t make this mistake again.