### PR TITLE
feat: limit the number of shards ids in SnapshotHostInfo

### DIFF
--- a/chain/network/src/concurrency/rayon.rs
+++ b/chain/network/src/concurrency/rayon.rs
@@ -1,4 +1,5 @@
-use rayon::iter::ParallelIterator;
+use rayon::iter::{Either, ParallelIterator};
+use std::error::Error;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// spawns a closure on a global rayon threadpool and awaits its completion.
@@ -45,4 +46,42 @@ pub fn try_map<I: ParallelIterator, T: Send>(
         })
         .collect();
     (res, ok.load(Ordering::Acquire))
+}
+
+/// Applies `func` to the iterated elements and collects the outputs. On the first `Error` the execution is stopped.
+/// Returns the outputs collected so far and a [`Result`] ([`Result::Err`] iff any `Error` was returned).
+/// Same as [`try_map`], but it operates on [`Result`] instead of [`Option`].
+pub fn try_map_result<I: ParallelIterator, T: Send, E: Error + Send>(
+    iter: I,
+    func: impl Sync + Send + Fn(I::Item) -> Result<T, E>,
+) -> (Vec<T>, Result<(), E>) {
+    // Call the function on every input value and emit some items for every result.
+    // On a successful call this iterator emits one item: `Some(Ok(output_value))`
+    // When an error occurs, the iterator emits two items: `Some(Err(the_error))` and `None``
+    // The `None` will later be used to tell rayon to stop the execution.
+    let optional_result_iter /* impl Iterator<Item = Option<Result<T, E>>> */ = iter
+        .map(|v| match func(v) {
+            Ok(val) => Either::Left(std::iter::once(Some(Ok(val)))),
+            Err(err) => Either::Right([Some(Err(err)), None].into_iter()),
+        })
+        .flatten_iter();
+
+    // `while_some()` monitors a stream of `Option` values and stops the execution when it spots a `None` value.
+    // It's used to implement the short-circuit logic - on the first error rayon will stop processing subsequent items.
+    let results_iter = optional_result_iter.while_some();
+
+    // Split the results into two groups - the left group contains the outputs resulting from a successful execution,
+    // while the right group contains errors. Collect them into twp separate Vecs.
+    let (outputs, errors): (Vec<T>, Vec<E>) = results_iter
+        .map(|res| match res {
+            Ok(value) => Either::Left(value),
+            Err(error) => Either::Right(error),
+        })
+        .collect();
+
+    // Return the output and the first error (if there was any)
+    match errors.into_iter().next() {
+        Some(first_error) => (outputs, Err(first_error)),
+        None => (outputs, Ok(())),
+    }
 }

--- a/chain/network/src/concurrency/rayon.rs
+++ b/chain/network/src/concurrency/rayon.rs
@@ -71,7 +71,7 @@ pub fn try_map_result<I: ParallelIterator, T: Send, E: Error + Send>(
     let results_iter = optional_result_iter.while_some();
 
     // Split the results into two groups - the left group contains the outputs resulting from a successful execution,
-    // while the right group contains errors. Collect them into twp separate Vecs.
+    // while the right group contains errors. Collect them into two separate Vecs.
     let (outputs, errors): (Vec<T>, Vec<E>) = results_iter
         .map(|res| match res {
             Ok(value) => Either::Left(value),

--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -140,6 +140,14 @@ pub struct VersionedAccountData {
 /// because it may contain many unknown fields (which are dropped during parsing).
 pub const MAX_ACCOUNT_DATA_SIZE_BYTES: usize = 10000; // 10kB
 
+/// Limit on the number of shard ids in a single [`SnapshotHostInfo`](state_sync::SnapshotHostInfo) message.
+/// The number of shards has to be limited, otherwise a malicious attack could fill the snapshot host cache
+/// with millions of shards.
+/// The assumption is that no single host is going to track state for more than 128 shards. Keeping state for
+/// a shard requires significant resources, so a single peer shouldn't be able to handle too many of them.
+/// If this assumption changes in the future, this limit will have to be revisited.
+pub const MAX_SHARDS_PER_SNAPSHOT_HOST_INFO: usize = 128;
+
 impl VersionedAccountData {
     /// Serializes AccountData to proto and signs it using `signer`.
     /// Panics if AccountData.account_id doesn't match signer.validator_id(),

--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -146,6 +146,11 @@ pub const MAX_ACCOUNT_DATA_SIZE_BYTES: usize = 10000; // 10kB
 /// The assumption is that no single host is going to track state for more than 128 shards. Keeping state for
 /// a shard requires significant resources, so a single peer shouldn't be able to handle too many of them.
 /// If this assumption changes in the future, this limit will have to be revisited.
+///
+/// Warning: adjusting this constant directly will break upgradeability. A new versioned-node would not interop
+/// correctly with an old-versioned node; it could send an excessively large message to an old node.
+/// If we ever want to change it we will need to introduce separate send and receive limits,
+/// increase the receive limit in one release then increase the send limit in the next.
 pub const MAX_SHARDS_PER_SNAPSHOT_HOST_INFO: usize = 128;
 
 impl VersionedAccountData {

--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -143,7 +143,7 @@ pub const MAX_ACCOUNT_DATA_SIZE_BYTES: usize = 10000; // 10kB
 /// Limit on the number of shard ids in a single [`SnapshotHostInfo`](state_sync::SnapshotHostInfo) message.
 /// The number of shards has to be limited, otherwise a malicious attack could fill the snapshot host cache
 /// with millions of shards.
-/// The assumption is that no single host is going to track state for more than 128 shards. Keeping state for
+/// The assumption is that no single host is going to track state for more than 512 shards. Keeping state for
 /// a shard requires significant resources, so a single peer shouldn't be able to handle too many of them.
 /// If this assumption changes in the future, this limit will have to be revisited.
 ///
@@ -151,7 +151,7 @@ pub const MAX_ACCOUNT_DATA_SIZE_BYTES: usize = 10000; // 10kB
 /// correctly with an old-versioned node; it could send an excessively large message to an old node.
 /// If we ever want to change it we will need to introduce separate send and receive limits,
 /// increase the receive limit in one release then increase the send limit in the next.
-pub const MAX_SHARDS_PER_SNAPSHOT_HOST_INFO: usize = 128;
+pub const MAX_SHARDS_PER_SNAPSHOT_HOST_INFO: usize = 512;
 
 impl VersionedAccountData {
     /// Serializes AccountData to proto and signs it using `signer`.

--- a/chain/network/src/network_protocol/state_sync.rs
+++ b/chain/network/src/network_protocol/state_sync.rs
@@ -1,9 +1,9 @@
+use super::MAX_SHARDS_PER_SNAPSHOT_HOST_INFO;
 use crate::network_protocol::Arc;
 use near_crypto::SecretKey;
 use near_crypto::Signature;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
-use near_primitives::sharding::MAX_SHARDS_PER_HOST;
 use near_primitives::types::EpochHeight;
 use near_primitives::types::ShardId;
 
@@ -58,7 +58,7 @@ impl SnapshotHostInfo {
     pub(crate) fn verify(&self) -> Result<(), SnapshotHostInfoVerificationError> {
         // Number of shards must be limited, otherwise it'd be possible to create malicious
         // messages with millions of shard ids.
-        if self.shards.len() > MAX_SHARDS_PER_HOST {
+        if self.shards.len() > MAX_SHARDS_PER_SNAPSHOT_HOST_INFO {
             return Err(SnapshotHostInfoVerificationError::TooManyShards(self.shards.len()));
         }
 
@@ -84,8 +84,8 @@ pub enum SnapshotHostInfoVerificationError {
     #[error("SnapshotHostInfo is signed with an invalid signature")]
     InvalidSignature,
     #[error(
-        "SnapshotHostInfo contains more shards than allowed: {0} > {} (MAX_SHARDS_PER_HOST)",
-        MAX_SHARDS_PER_HOST
+        "SnapshotHostInfo contains more shards than allowed: {0} > {} (MAX_SHARDS_PER_SNAPSHOT_HOST_INFO)",
+        MAX_SHARDS_PER_SNAPSHOT_HOST_INFO
     )]
     TooManyShards(usize),
 }

--- a/chain/network/src/network_protocol/state_sync.rs
+++ b/chain/network/src/network_protocol/state_sync.rs
@@ -22,7 +22,7 @@ pub struct SnapshotHostInfo {
     pub sync_hash: CryptoHash,
     /// Ordinal of the epoch of the state root
     pub epoch_height: EpochHeight,
-    /// List of shards included in the snapshot
+    /// List of shards included in the snapshot.
     pub shards: Vec<ShardId>,
     /// Signature on (sync_hash, epoch_height, shards)
     pub signature: Signature,

--- a/chain/network/src/network_protocol/state_sync.rs
+++ b/chain/network/src/network_protocol/state_sync.rs
@@ -56,14 +56,14 @@ impl SnapshotHostInfo {
     }
 
     pub(crate) fn verify(&self) -> Result<(), SnapshotHostInfoVerificationError> {
-        if !self.signature.verify(self.hash().as_ref(), self.peer_id.public_key()) {
-            return Err(SnapshotHostInfoVerificationError::InvalidSignature);
-        }
-
         // Number of shards must be limited, otherwise it'd be possible to create malicious
         // messages with millions of shard ids.
         if self.shards.len() > MAX_SHARDS_PER_HOST {
             return Err(SnapshotHostInfoVerificationError::TooManyShards(self.shards.len()));
+        }
+
+        if !self.signature.verify(self.hash().as_ref(), self.peer_id.public_key()) {
+            return Err(SnapshotHostInfoVerificationError::InvalidSignature);
         }
 
         Ok(())

--- a/chain/network/src/network_protocol/state_sync.rs
+++ b/chain/network/src/network_protocol/state_sync.rs
@@ -79,7 +79,7 @@ pub struct SyncSnapshotHosts {
     pub hosts: Vec<Arc<SnapshotHostInfo>>,
 }
 
-#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+#[derive(thiserror::Error, Debug, PartialEq, Eq, Clone)]
 pub enum SnapshotHostInfoVerificationError {
     #[error("SnapshotHostInfo is signed with an invalid signature")]
     InvalidSignature,

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -800,6 +800,8 @@ impl PeerManagerActor {
                         .copied()
                         .collect();
                 }
+                // Sort the shards to keep things tidy
+                shards.sort();
 
                 // Sign the information about the locally created snapshot using the keys in the
                 // network config before broadcasting it

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1,4 +1,3 @@
-use crate::client;
 use crate::config;
 use crate::debug::{DebugStatus, GetDebugStatus};
 use crate::network_protocol::SyncSnapshotHosts;
@@ -18,6 +17,7 @@ use crate::types::{
     NetworkResponses, PeerInfo, PeerManagerMessageRequest, PeerManagerMessageResponse, PeerType,
     SetChainInfo, SnapshotHostInfo,
 };
+use crate::{client, network_protocol};
 use actix::fut::future::wrap_future;
 use actix::{Actor as _, AsyncContext as _};
 use anyhow::Context as _;
@@ -31,7 +31,8 @@ use near_primitives::views::{
     ConnectionInfoView, EdgeView, KnownPeerStateView, NetworkGraphView, PeerStoreView,
     RecentOutboundConnectionsView, SnapshotHostInfoView, SnapshotHostsView,
 };
-use rand::seq::IteratorRandom;
+use network_protocol::MAX_SHARDS_PER_SNAPSHOT_HOST_INFO;
+use rand::seq::{IteratorRandom, SliceRandom};
 use rand::thread_rng;
 use rand::Rng;
 use std::cmp::min;
@@ -784,7 +785,22 @@ impl PeerManagerActor {
                     NetworkResponses::RouteNotFound
                 }
             }
-            NetworkRequests::SnapshotHostInfo { sync_hash, epoch_height, shards } => {
+            NetworkRequests::SnapshotHostInfo { sync_hash, epoch_height, mut shards } => {
+                if shards.len() > MAX_SHARDS_PER_SNAPSHOT_HOST_INFO {
+                    tracing::warn!("PeerManager: Sending out a SnapshotHostInfo message with {} shards, \
+                                    this is more than the allowed limit. The list of shards will be truncated. \
+                                    Please adjust the MAX_SHARDS_PER_SNAPSHOT_HOST_INFO constant ({})", shards.len(), MAX_SHARDS_PER_SNAPSHOT_HOST_INFO);
+
+                    // We can's send out more than MAX_SHARDS_PER_SNAPSHOT_HOST_INFO shards because other nodes would
+                    // ban us for abusive behavior. Let's truncate the shards vector by choosing a random subset of
+                    // MAX_SHARDS_PER_SNAPSHOT_HOST_INFO shard ids. Choosing a random subset slightly increases the chances
+                    // that other nodes will have snapshot sync information about all shards from some node.
+                    shards = shards
+                        .choose_multiple(&mut rand::thread_rng(), MAX_SHARDS_PER_SNAPSHOT_HOST_INFO)
+                        .copied()
+                        .collect();
+                }
+
                 // Sign the information about the locally created snapshot using the keys in the
                 // network config before broadcasting it
                 let snapshot_host_info = SnapshotHostInfo::new(

--- a/chain/network/src/peer_manager/tests/snapshot_hosts.rs
+++ b/chain/network/src/peer_manager/tests/snapshot_hosts.rs
@@ -165,7 +165,7 @@ async fn invalid_signature_not_broadcast() {
     let empty_sync_msg = peer3.events.recv_until(take_sync_snapshot_msg).await;
     assert_eq!(empty_sync_msg.hosts, vec![]);
 
-    tracing::info!(target:"test", "Send an invalid SyncSnapshotHosts message from from peer1. One of the host infos has too many shard ids.");
+    tracing::info!(target:"test", "Send an invalid SyncSnapshotHosts message from from peer1. One of the host infos has an invalid signature.");
     let random_secret_key = SecretKey::from_random(near_crypto::KeyType::ED25519);
     let invalid_info = make_snapshot_host_info(&peer1_config.node_id(), &random_secret_key, rng);
 

--- a/chain/network/src/peer_manager/tests/snapshot_hosts.rs
+++ b/chain/network/src/peer_manager/tests/snapshot_hosts.rs
@@ -1,6 +1,7 @@
 use crate::network_protocol::testonly as data;
 use crate::network_protocol::SnapshotHostInfo;
 use crate::network_protocol::SyncSnapshotHosts;
+use crate::network_protocol::MAX_SHARDS_PER_SNAPSHOT_HOST_INFO;
 use crate::peer;
 use crate::peer_manager;
 use crate::peer_manager::peer_manager_actor::Event as PME;
@@ -15,7 +16,6 @@ use near_o11y::testonly::init_test_logger;
 use near_o11y::WithSpanContextExt;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
-use near_primitives::sharding::MAX_SHARDS_PER_HOST;
 use near_primitives::types::EpochHeight;
 use near_primitives::types::ShardId;
 use peer_manager::testonly::FDS_PER_PEER;
@@ -229,7 +229,8 @@ async fn too_many_shards_not_broadcast() {
     assert_eq!(empty_sync_msg.hosts, vec![]);
 
     tracing::info!(target:"test", "Send an invalid SyncSnapshotHosts message from from peer1. One of the host infos has more shard ids than allowed.");
-    let too_many_shards: Vec<ShardId> = (0..(MAX_SHARDS_PER_HOST as u64 + 1)).collect();
+    let too_many_shards: Vec<ShardId> =
+        (0..(MAX_SHARDS_PER_SNAPSHOT_HOST_INFO as u64 + 1)).collect();
     let invalid_info = Arc::new(SnapshotHostInfo::new(
         peer1_config.node_id(),
         CryptoHash::hash_borsh(rng.gen::<u64>()),

--- a/chain/network/src/peer_manager/tests/snapshot_hosts.rs
+++ b/chain/network/src/peer_manager/tests/snapshot_hosts.rs
@@ -263,7 +263,7 @@ async fn too_many_shards_not_broadcast() {
                 return; // Received the expected message - end the test
             }
 
-            // Even though `ok_info_a`` and `ok_info_b`` were sent in an invalid message,
+            // Even though `ok_info_a` and `ok_info_b` were sent in an invalid message,
             // they were themselevs valid so the PeerManager can optionally accept them
             // and broadcast them to other peers. This is an expected behavior, let's filter them out here.
             if info == ok_info_a || info == ok_info_b {

--- a/chain/network/src/snapshot_hosts/mod.rs
+++ b/chain/network/src/snapshot_hosts/mod.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 #[cfg(test)]
 mod tests;
 
-#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+#[derive(thiserror::Error, Debug, PartialEq, Eq, Clone)]
 pub(crate) enum SnapshotHostInfoError {
     #[error("found multiple entries for the same peer_id")]
     DuplicatePeerId,

--- a/chain/network/src/snapshot_hosts/mod.rs
+++ b/chain/network/src/snapshot_hosts/mod.rs
@@ -6,6 +6,7 @@
 
 use crate::concurrency;
 use crate::network_protocol::SnapshotHostInfo;
+use crate::network_protocol::SnapshotHostInfoVerificationError;
 use lru::LruCache;
 use near_primitives::network::PeerId;
 use parking_lot::Mutex;
@@ -18,10 +19,10 @@ mod tests;
 
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub(crate) enum SnapshotHostInfoError {
-    #[error("found an invalid signature")]
-    InvalidSignature,
     #[error("found multiple entries for the same peer_id")]
     DuplicatePeerId,
+    #[error(transparent)]
+    VerificationError(#[from] SnapshotHostInfoVerificationError),
 }
 
 #[derive(Clone)]
@@ -93,17 +94,19 @@ impl SnapshotHostsCache {
 
         // Verify the signatures in parallel.
         // Verification will stop at the first encountered error.
-        let (data, ok) = concurrency::rayon::run(move || {
-            concurrency::rayon::try_map(new_data.into_values().par_bridge(), |d| match d.verify() {
-                true => Some(d),
-                false => None,
+        let (data, verification_result) = concurrency::rayon::run(move || {
+            concurrency::rayon::try_map_result(new_data.into_values().par_bridge(), |d| {
+                match d.verify() {
+                    Ok(()) => Ok(d),
+                    Err(err) => Err(err),
+                }
             })
         })
         .await;
-        if !ok {
-            return (data, Some(SnapshotHostInfoError::InvalidSignature));
+        match verification_result {
+            Ok(()) => (data, None),
+            Err(err) => (data, Some(SnapshotHostInfoError::VerificationError(err))),
         }
-        (data, None)
     }
 
     /// Verifies the signatures and inserts verified data to the cache.

--- a/chain/network/src/snapshot_hosts/tests.rs
+++ b/chain/network/src/snapshot_hosts/tests.rs
@@ -1,4 +1,6 @@
-use crate::network_protocol::{testonly as data, SnapshotHostInfoVerificationError};
+use crate::network_protocol::{
+    testonly as data, SnapshotHostInfoVerificationError, MAX_SHARDS_PER_SNAPSHOT_HOST_INFO,
+};
 use crate::snapshot_hosts::{Config, SnapshotHostInfoError, SnapshotHostsCache};
 use crate::testonly::assert_is_superset;
 use crate::testonly::{make_rng, AsSet as _};
@@ -7,7 +9,6 @@ use near_crypto::SecretKey;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
-use near_primitives::sharding::MAX_SHARDS_PER_HOST;
 use near_primitives::types::EpochHeight;
 use near_primitives::types::ShardId;
 use std::collections::HashSet;
@@ -120,12 +121,14 @@ async fn too_many_shards() {
     // info0 is valid
     let info0 = Arc::new(make_snapshot_host_info(&peer0, 1, vec![0, 1, 2, 3], &key0));
 
-    // info1 is invalid - it has more shard ids than MAX_SHARDS_PER_HOST
-    let too_many_shards: Vec<ShardId> = (0..(MAX_SHARDS_PER_HOST as u64 + 1)).collect();
+    // info1 is invalid - it has more shard ids than MAX_SHARDS_PER_SNAPSHOT_HOST_INFO
+    let too_many_shards: Vec<ShardId> =
+        (0..(MAX_SHARDS_PER_SNAPSHOT_HOST_INFO as u64 + 1)).collect();
     let info1 = Arc::new(make_snapshot_host_info(&peer1, 1, too_many_shards, &key1));
 
     // info1.verify() should fail
-    let expected_error = SnapshotHostInfoVerificationError::TooManyShards(MAX_SHARDS_PER_HOST + 1);
+    let expected_error =
+        SnapshotHostInfoVerificationError::TooManyShards(MAX_SHARDS_PER_SNAPSHOT_HOST_INFO + 1);
     assert_eq!(info1.verify(), Err(expected_error.clone()));
 
     // Inserting should return the expected error (TooManyShards)

--- a/chain/network/src/snapshot_hosts/tests.rs
+++ b/chain/network/src/snapshot_hosts/tests.rs
@@ -1,4 +1,4 @@
-use crate::network_protocol::testonly as data;
+use crate::network_protocol::{testonly as data, SnapshotHostInfoVerificationError};
 use crate::snapshot_hosts::{Config, SnapshotHostInfoError, SnapshotHostsCache};
 use crate::testonly::assert_is_superset;
 use crate::testonly::{make_rng, AsSet as _};
@@ -87,7 +87,12 @@ async fn invalid_signature() {
     let info1 = Arc::new(make_snapshot_host_info(&peer1, 1, vec![0, 1, 2, 3], &key1));
     let res = cache.insert(vec![info0_invalid_sig.clone(), info1.clone()]).await;
     // invalid signature => InvalidSignature
-    assert_eq!(Some(SnapshotHostInfoError::InvalidSignature), res.1);
+    assert_eq!(
+        Some(SnapshotHostInfoError::VerificationError(
+            SnapshotHostInfoVerificationError::InvalidSignature
+        )),
+        res.1
+    );
     // Partial update is allowed in case an error is encountered.
     // The valid info1 may or may not be processed before the invalid info0 is detected
     // due to parallelization, so we check for superset rather than strict equality.

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -15,6 +15,15 @@ use std::cmp::Ordering;
 use std::sync::Arc;
 use tracing::debug_span;
 
+/// Maximum number of shards that can be tracked by a single host (peer).
+/// A single host can track multiple shards, but it's unreasonable for them
+/// to handle more than MAX_SHARDS_PER_HOST. Tracking a shard requires a significant
+/// amount of resources, tracking this many would be impractical.
+/// One reason why it's useful to have a limit of shards per host is because it allows to
+/// limit the size of incoming messages that contain some kind of information for each tracked shard.
+/// Without this limit we would have to handle messages with thousands of shard ids, which could cause problems.
+pub const MAX_SHARDS_PER_HOST: usize = 128;
+
 #[derive(
     BorshSerialize,
     BorshDeserialize,

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -22,6 +22,8 @@ use tracing::debug_span;
 /// One reason why it's useful to have a limit of shards per host is because it allows to
 /// limit the size of incoming messages that contain some kind of information for each tracked shard.
 /// Without this limit we would have to handle messages with thousands of shard ids, which could cause problems.
+/// TODO(resharding): at the moment this limit isn't enforced anywhere, make sure that the limit is respected
+/// before rolling out dynamic resharding.
 pub const MAX_SHARDS_PER_HOST: usize = 128;
 
 #[derive(

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -15,17 +15,6 @@ use std::cmp::Ordering;
 use std::sync::Arc;
 use tracing::debug_span;
 
-/// Maximum number of shards that can be tracked by a single host (peer).
-/// A single host can track multiple shards, but it's unreasonable for them
-/// to handle more than MAX_SHARDS_PER_HOST. Tracking a shard requires a significant
-/// amount of resources, tracking this many would be impractical.
-/// One reason why it's useful to have a limit of shards per host is because it allows to
-/// limit the size of incoming messages that contain some kind of information for each tracked shard.
-/// Without this limit we would have to handle messages with thousands of shard ids, which could cause problems.
-/// TODO(resharding): at the moment this limit isn't enforced anywhere, make sure that the limit is respected
-/// before rolling out dynamic resharding.
-pub const MAX_SHARDS_PER_HOST: usize = 128;
-
 #[derive(
     BorshSerialize,
     BorshDeserialize,


### PR DESCRIPTION
`SnapshotHostInfo` contains a list of shard ids for which a peer has a snapshot.
Under normal circumstances this list is pretty small - the maximum size would be the total number of shards.
But a malicious peer could craft a `SnapshotHostInfo` message with very large number of shards - millions of shard ids. This could cause problems on the receiver node, so there has to be limit on the number of shard ids in a message.

Let's limit the number of shard ids in a single message to `MAX_SHARDS_PER_SNAPSHOT_HOST_INFO = 512`.
It's a constant that describes how many shards a single peer can have snapshots for.
A peer doesn't keep more state snapshots than the number of tracked shards, so this limit is reasonable. 512 shards ought to be enough for anyone.

In an ideal world we could check the current number of shards and reject messages that contain more shard ids than the current number, but sadly this can't be implemented. The problem is that the receiving node might
be behind the rest of the blockchain, and the latest information just isn't available, so it can't check what the current number of shards is.
We could reject messages in such situations, but this would lead to loss of information.

Limiting the number of shard ids to a constant number is an okay alternative.