### PR TITLE
[resharding] Add pytest for checking RPC calls after resharding

### DIFF
--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -144,7 +144,7 @@ pytest sanity/recompress_storage.py --features nightly
 pytest sanity/meta_tx.py --features nightly
 
 # Tests for split storage and split storage migration
-pFytest --timeout=600 sanity/split_storage.py
+pytest --timeout=600 sanity/split_storage.py
 pytest --timeout=600 sanity/split_storage.py --features nightly
 
 # Test for resharding

--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -152,5 +152,5 @@ pytest --timeout=120 sanity/resharding.py
 pytest --timeout=120 sanity/resharding.py --features nightly
 pytest --timeout=120 sanity/resharding_error_handling.py
 pytest --timeout=120 sanity/resharding_error_handling.py --features nightly
-pytest --timeout=120 sanity/rpc_tx_resharding.py
-pytest --timeout=120 sanity/rpc_tx_resharding.py --features nightly
+pytest --timeout=120 sanity/resharding_rpc_tx.py
+pytest --timeout=120 sanity/resharding_rpc_tx.py --features nightly

--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -144,13 +144,13 @@ pytest sanity/recompress_storage.py --features nightly
 pytest sanity/meta_tx.py --features nightly
 
 # Tests for split storage and split storage migration
-pytest --timeout=600 sanity/split_storage.py
+pFytest --timeout=600 sanity/split_storage.py
 pytest --timeout=600 sanity/split_storage.py --features nightly
 
 # Test for resharding
 pytest --timeout=120 sanity/resharding.py
 pytest --timeout=120 sanity/resharding.py --features nightly
-
-# Test for resharding error handling
 pytest --timeout=120 sanity/resharding_error_handling.py
 pytest --timeout=120 sanity/resharding_error_handling.py --features nightly
+pytest --timeout=120 sanity/rpc_tx_resharding.py
+pytest --timeout=120 sanity/rpc_tx_resharding.py --features nightly

--- a/pytest/lib/resharding_lib.py
+++ b/pytest/lib/resharding_lib.py
@@ -21,6 +21,20 @@ V1_SHARD_LAYOUT = {
 }
 
 
+def get_genesis_config_changes(epoch_length,
+                               binary_protocol_version,
+                               logger=None):
+    genesis_config_changes = [
+        ["epoch_length", epoch_length],
+    ]
+    append_shard_layout_config_changes(
+        genesis_config_changes,
+        binary_protocol_version,
+        logger,
+    )
+    return genesis_config_changes
+
+
 # Append the genesis config changes that are required for testing resharding.
 # This method will set the protocol version, shard layout and a few other
 # configs so that it matches the protocol configuration as of right before the
@@ -122,3 +136,28 @@ def get_epoch_offset(binary_protocol_version):
         return 0
 
     assert False
+
+
+def get_client_config_changes(num_nodes, initial_delay=None):
+    single = {
+        "tracked_shards": [0],
+        "state_split_config": {
+            "batch_size": 1000000,
+            # don't throttle resharding
+            "batch_delay": {
+                "secs": 0,
+                "nanos": 0,
+            },
+            # retry often to start resharding as fast as possible
+            "retry_delay": {
+                "secs": 0,
+                "nanos": 100_000_000
+            }
+        }
+    }
+    if initial_delay is not None:
+        single["state_split_config"]["initial_delay"] = {
+            "secs": initial_delay,
+            "nanos": 0
+        }
+    return {i: single for i in range(num_nodes)}

--- a/pytest/tests/sanity/resharding.py
+++ b/pytest/tests/sanity/resharding.py
@@ -15,7 +15,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 from configured_logger import logger
 from cluster import get_binary_protocol_version, init_cluster, load_config, spin_up_node
 from utils import MetricsTracker, poll_blocks
-from resharding_lib import append_shard_layout_config_changes, get_epoch_offset, get_genesis_num_shards, get_genesis_shard_layout_version, get_target_num_shards, get_target_shard_layout_version
+import resharding_lib
 
 
 class ReshardingTest(unittest.TestCase):
@@ -26,56 +26,27 @@ class ReshardingTest(unittest.TestCase):
         self.binary_protocol_version = get_binary_protocol_version(self.config)
         assert self.binary_protocol_version is not None
 
-        self.genesis_shard_layout_version = get_genesis_shard_layout_version(
+        self.genesis_shard_layout_version = resharding_lib.get_genesis_shard_layout_version(
             self.binary_protocol_version)
-        self.target_shard_layout_version = get_target_shard_layout_version(
-            self.binary_protocol_version)
-
-        self.genesis_num_shards = get_genesis_num_shards(
-            self.binary_protocol_version)
-        self.target_num_shards = get_target_num_shards(
+        self.target_shard_layout_version = resharding_lib.get_target_shard_layout_version(
             self.binary_protocol_version)
 
-        self.epoch_offset = get_epoch_offset(self.binary_protocol_version)
+        self.genesis_num_shards = resharding_lib.get_genesis_num_shards(
+            self.binary_protocol_version)
+        self.target_num_shards = resharding_lib.get_target_num_shards(
+            self.binary_protocol_version)
 
-    def __get_genesis_config_changes(self):
-        genesis_config_changes = [
-            ["epoch_length", self.epoch_length],
-        ]
-
-        append_shard_layout_config_changes(
-            genesis_config_changes,
-            self.binary_protocol_version,
-            logger,
-        )
-
-        return genesis_config_changes
-
-    def __get_client_config_changes(self, num_nodes):
-        single = {
-            "tracked_shards": [0],
-            "state_split_config": {
-                "batch_size": 1000000,
-                # don't throttle resharding
-                "batch_delay": {
-                    "secs": 0,
-                    "nanos": 0,
-                },
-                # retry often to start resharding as fast as possible
-                "retry_delay": {
-                    "secs": 0,
-                    "nanos": 100_000_000
-                }
-            }
-        }
-        return {i: single for i in range(num_nodes)}
+        self.epoch_offset = resharding_lib.get_epoch_offset(
+            self.binary_protocol_version)
 
     def test_resharding(self):
         logger.info("The resharding test is starting.")
         num_nodes = 2
 
-        genesis_config_changes = self.__get_genesis_config_changes()
-        client_config_changes = self.__get_client_config_changes(num_nodes)
+        genesis_config_changes = resharding_lib.get_genesis_config_changes(
+            self.epoch_length, self.binary_protocol_version, logger)
+        client_config_changes = resharding_lib.get_client_config_changes(
+            num_nodes)
 
         near_root, [node0_dir, node1_dir] = init_cluster(
             num_nodes=num_nodes,

--- a/pytest/tests/sanity/resharding.py
+++ b/pytest/tests/sanity/resharding.py
@@ -15,7 +15,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 from configured_logger import logger
 from cluster import get_binary_protocol_version, init_cluster, load_config, spin_up_node
 from utils import MetricsTracker, poll_blocks
-import resharding_lib
+from resharding_lib import get_genesis_shard_layout_version, get_target_shard_layout_version, get_genesis_num_shards, get_target_num_shards, get_epoch_offset, get_genesis_config_changes, get_client_config_changes
 
 
 class ReshardingTest(unittest.TestCase):
@@ -26,27 +26,25 @@ class ReshardingTest(unittest.TestCase):
         self.binary_protocol_version = get_binary_protocol_version(self.config)
         assert self.binary_protocol_version is not None
 
-        self.genesis_shard_layout_version = resharding_lib.get_genesis_shard_layout_version(
+        self.genesis_shard_layout_version = get_genesis_shard_layout_version(
             self.binary_protocol_version)
-        self.target_shard_layout_version = resharding_lib.get_target_shard_layout_version(
-            self.binary_protocol_version)
-
-        self.genesis_num_shards = resharding_lib.get_genesis_num_shards(
-            self.binary_protocol_version)
-        self.target_num_shards = resharding_lib.get_target_num_shards(
+        self.target_shard_layout_version = get_target_shard_layout_version(
             self.binary_protocol_version)
 
-        self.epoch_offset = resharding_lib.get_epoch_offset(
+        self.genesis_num_shards = get_genesis_num_shards(
             self.binary_protocol_version)
+        self.target_num_shards = get_target_num_shards(
+            self.binary_protocol_version)
+
+        self.epoch_offset = get_epoch_offset(self.binary_protocol_version)
 
     def test_resharding(self):
         logger.info("The resharding test is starting.")
         num_nodes = 2
 
-        genesis_config_changes = resharding_lib.get_genesis_config_changes(
+        genesis_config_changes = get_genesis_config_changes(
             self.epoch_length, self.binary_protocol_version, logger)
-        client_config_changes = resharding_lib.get_client_config_changes(
-            num_nodes)
+        client_config_changes = get_client_config_changes(num_nodes)
 
         near_root, [node0_dir, node1_dir] = init_cluster(
             num_nodes=num_nodes,

--- a/pytest/tests/sanity/resharding_error_handling.py
+++ b/pytest/tests/sanity/resharding_error_handling.py
@@ -17,7 +17,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 from configured_logger import logger
 from cluster import corrupt_state_snapshot, get_binary_protocol_version, init_cluster, load_config, spin_up_node
 from utils import MetricsTracker, poll_blocks, wait_for_blocks
-from resharding_lib import append_shard_layout_config_changes, get_genesis_num_shards, get_genesis_shard_layout_version, get_target_num_shards, get_target_shard_layout_version
+import resharding_lib
 
 
 # TODO(resharding): refactor the resharding tests to re-use the common logic
@@ -29,56 +29,15 @@ class ReshardingErrorHandlingTest(unittest.TestCase):
         self.binary_protocol_version = get_binary_protocol_version(self.config)
         assert self.binary_protocol_version is not None
 
-        self.genesis_shard_layout_version = get_genesis_shard_layout_version(
+        self.genesis_shard_layout_version = resharding_lib.get_genesis_shard_layout_version(
             self.binary_protocol_version)
-        self.target_shard_layout_version = get_target_shard_layout_version(
-            self.binary_protocol_version)
-
-        self.genesis_num_shards = get_genesis_num_shards(
-            self.binary_protocol_version)
-        self.target_num_shards = get_target_num_shards(
+        self.target_shard_layout_version = resharding_lib.get_target_shard_layout_version(
             self.binary_protocol_version)
 
-    def __get_genesis_config_changes(self):
-        genesis_config_changes = [
-            ["epoch_length", self.epoch_length],
-        ]
-
-        append_shard_layout_config_changes(
-            genesis_config_changes,
-            self.binary_protocol_version,
-            logger,
-        )
-
-        return genesis_config_changes
-
-    def __get_client_config_changes(self, num_nodes):
-        single = {
-            "tracked_shards": [0],
-            # arbitrary long initial delay to not trigger resharding
-            # will get overwritten before restarting the node
-            "state_split_config": self.__get_state_split_config(10)
-        }
-        return {i: single for i in range(num_nodes)}
-
-    def __get_state_split_config(self, initial_delay):
-        return {
-            "batch_size": 1000000,
-            # don't throttle resharding
-            "batch_delay": {
-                "secs": 0,
-                "nanos": 0,
-            },
-            # retry often to start resharding as fast as possible
-            "retry_delay": {
-                "secs": 0,
-                "nanos": 100_000_000
-            },
-            "initial_delay": {
-                "secs": initial_delay,
-                "nanos": 0
-            },
-        }
+        self.genesis_num_shards = resharding_lib.get_genesis_num_shards(
+            self.binary_protocol_version)
+        self.target_num_shards = resharding_lib.get_target_num_shards(
+            self.binary_protocol_version)
 
     # timeline by block number
     # epoch_length + 2 - snapshot is requested
@@ -91,8 +50,10 @@ class ReshardingErrorHandlingTest(unittest.TestCase):
         logger.info("The resharding test is starting.")
         num_nodes = 2
 
-        genesis_config_changes = self.__get_genesis_config_changes()
-        client_config_changes = self.__get_client_config_changes(num_nodes)
+        genesis_config_changes = resharding_lib.get_genesis_config_changes(
+            self.epoch_length, self.binary_protocol_version, logger)
+        client_config_changes = resharding_lib.get_client_config_changes(
+            num_nodes, 10)
 
         near_root, [node0_dir, node1_dir] = init_cluster(
             num_nodes=num_nodes,

--- a/pytest/tests/sanity/resharding_error_handling.py
+++ b/pytest/tests/sanity/resharding_error_handling.py
@@ -95,9 +95,9 @@ class ReshardingErrorHandlingTest(unittest.TestCase):
         logger.info(f"corrupted state snapshot\n{output}")
 
         # Update the initial delay to start resharding as soon as possible.
-        client_config_changes = resharding_lib.get_client_config_changes(1, 0)[0]
-        node0.change_config(client_config_changes)
-        node1.change_config(client_config_changes)
+        config_changes = resharding_lib.get_client_config_changes(1, 0)[0]
+        node0.change_config(config_changes)
+        node1.change_config(config_changes)
 
         logger.info("restarting nodes")
         node0.start()

--- a/pytest/tests/sanity/resharding_error_handling.py
+++ b/pytest/tests/sanity/resharding_error_handling.py
@@ -95,9 +95,7 @@ class ReshardingErrorHandlingTest(unittest.TestCase):
         logger.info(f"corrupted state snapshot\n{output}")
 
         # Update the initial delay to start resharding as soon as possible.
-        client_config_changes = {
-            "state_split_config": self.__get_state_split_config(initial_delay=0)
-        }
+        client_config_changes = resharding_lib.get_client_config_changes(1, 0)[0]
         node0.change_config(client_config_changes)
         node1.change_config(client_config_changes)
 

--- a/pytest/tests/sanity/rpc_tx_resharding.py
+++ b/pytest/tests/sanity/rpc_tx_resharding.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Testing RPC call to transaction status after a resharding event.
+We create two account that we know would fall into different shards after resharding.
+We submit a transfer transaction between the accounts and verify the transaction status after resharding.
+"""
+
+import sys
+import unittest
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
+
+from configured_logger import logger
+import cluster
+import resharding_lib
+import transaction
+from utils import MetricsTracker, poll_blocks
+import key
+
+STARTING_AMOUNT = 123 * (10**24)
+
+
+class ReshardingTest2(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.epoch_length = 5
+        self.config = cluster.load_config()
+        self.binary_protocol_version = cluster.get_binary_protocol_version(
+            self.config)
+        assert self.binary_protocol_version is not None
+
+        self.target_shard_layout_version = resharding_lib.get_target_shard_layout_version(
+            self.binary_protocol_version)
+        self.target_num_shards = resharding_lib.get_target_num_shards(
+            self.binary_protocol_version)
+
+    def __setup_account(self, account_id, nonce):
+        encoded_block_hash = self.node.get_latest_block().hash_bytes
+        account = key.Key.from_random(account_id)
+        account_tx = transaction.sign_create_account_with_full_access_key_and_balance_tx(
+            self.node.signer_key, account.account_id, account, STARTING_AMOUNT,
+            nonce, encoded_block_hash)
+        response = self.node.send_tx_and_wait(account_tx, timeout=20)
+        assert 'error' not in response, response
+        assert 'Failure' not in response['result']['status'], response
+        return account
+
+    def __submit_transfer_tx(self, from_key, to_account_id, nonce):
+        encoded_block_hash = self.node.get_latest_block().hash_bytes
+        payment_tx = transaction.sign_payment_tx(from_key, to_account_id, 100,
+                                                 nonce, encoded_block_hash)
+        response = self.node.send_tx_and_wait(payment_tx, timeout=20)
+        assert 'error' not in response, response
+        assert 'Failure' not in response['result']['status'], response
+        return response
+
+    def __verify_tx_status(self, transfer_response, sender_account_id):
+        tx_hash = transfer_response['result']['transaction']['hash']
+        response = self.node.get_tx(tx_hash, sender_account_id)
+        assert response == transfer_response, response
+        pass
+
+    def test_rcp_tx_resharding(self):
+        num_nodes = 2
+        genesis_config_changes = resharding_lib.get_genesis_config_changes(
+            self.epoch_length, self.binary_protocol_version, logger)
+        client_config_changes = resharding_lib.get_client_config_changes(
+            num_nodes)
+        nodes = cluster.start_cluster(
+            num_nodes=num_nodes,
+            num_observers=0,
+            num_shards=1,
+            config=self.config,
+            genesis_config_changes=genesis_config_changes,
+            client_config_changes=client_config_changes)
+        self.node = nodes[0]
+
+        # The shard boundries are at "kkuuue2akv_1630967379.near" and "tge-lockup.sweat" for shard 4 and 5
+        # We would like to create accounts that are in different shards
+        # The first account before and after resharding is in shard 4
+        # The second account after resharding is in shard 5
+        account0 = self.__setup_account('setup_test_account.test0', 1)
+        account1 = self.__setup_account('z_setup_test_account.test0', 2)
+
+        # Poll one block to create the accounts
+        poll_blocks(self.node)
+
+        # Submit a transfer transaction between the accounts, we would verify the transaction status later
+        response0 = self.__submit_transfer_tx(account0, account1.account_id,
+                                              6000001)
+        response1 = self.__submit_transfer_tx(account1, account0.account_id,
+                                              12000001)
+
+        metrics_tracker = MetricsTracker(self.node)
+        for height, _ in poll_blocks(self.node):
+            # wait for resharding to complete
+            if height < 2 * self.epoch_length:
+                continue
+
+            # Quick check whether resharding is completed
+            version = metrics_tracker.get_int_metric_value(
+                "near_shard_layout_version")
+            num_shards = metrics_tracker.get_int_metric_value(
+                "near_shard_layout_num_shards")
+            self.assertEqual(version, self.target_shard_layout_version)
+            self.assertEqual(num_shards, self.target_num_shards)
+
+            # Verify the transaction status after resharding
+            self.__verify_tx_status(response0, account0.account_id)
+            self.__verify_tx_status(response0, account1.account_id)
+            self.__verify_tx_status(response1, account0.account_id)
+            self.__verify_tx_status(response1, account1.account_id)
+            break
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds a basic pytest to check if the RPC calls to tx endpoint work after a resharding event.

Note that this test currently works under the assumption that the node is tracking all shards and future improvements to the tests where we may need to redirect the request to a node tracking the specific shard we are interested in, would come later.

Resolving https://github.com/near/nearcore/issues/5047