### PR TITLE
feat(chunk-validator-assignment): shuffle shard ids

### DIFF
--- a/chain/epoch-manager/src/validator_selection.rs
+++ b/chain/epoch-manager/src/validator_selection.rs
@@ -698,27 +698,26 @@ mod tests {
         let height = 42;
         let expected_assignments: ValidatorMandatesAssignment = vec![
             HashMap::from([
-                (0, AssignmentWeight::new(2, 0)),
-                (1, AssignmentWeight::new(4, 0)),
+                (0, AssignmentWeight::new(6, 0)),
                 (2, AssignmentWeight::new(2, 0)),
-                (3, AssignmentWeight::new(1, 60)),
                 (4, AssignmentWeight::new(1, 0)),
             ]),
             HashMap::from([
                 (0, AssignmentWeight::new(4, 0)),
-                (1, AssignmentWeight::new(2, 0)),
+                (1, AssignmentWeight::new(1, 0)),
+                (2, AssignmentWeight::new(3, 0)),
+                (3, AssignmentWeight::new(2, 60)),
+            ]),
+            HashMap::from([
+                (0, AssignmentWeight::new(2, 0)),
+                (1, AssignmentWeight::new(4, 0)),
                 (2, AssignmentWeight::new(4, 0)),
                 (4, AssignmentWeight::new(0, 40)),
             ]),
             HashMap::from([
-                (0, AssignmentWeight::new(7, 0)),
-                (1, AssignmentWeight::new(1, 0)),
-                (3, AssignmentWeight::new(1, 0)),
-            ]),
-            HashMap::from([
-                (0, AssignmentWeight::new(2, 0)),
-                (1, AssignmentWeight::new(3, 0)),
-                (2, AssignmentWeight::new(4, 0)),
+                (0, AssignmentWeight::new(3, 0)),
+                (1, AssignmentWeight::new(5, 0)),
+                (2, AssignmentWeight::new(1, 0)),
             ]),
         ];
         assert_eq!(epoch_info.sample_chunk_validators(height), expected_assignments);

--- a/chain/epoch-manager/src/validator_selection.rs
+++ b/chain/epoch-manager/src/validator_selection.rs
@@ -698,26 +698,27 @@ mod tests {
         let height = 42;
         let expected_assignments: ValidatorMandatesAssignment = vec![
             HashMap::from([
+                (0, AssignmentWeight::new(3, 0)),
+                (1, AssignmentWeight::new(3, 0)),
+                (2, AssignmentWeight::new(3, 0)),
+                (3, AssignmentWeight::new(0, 60)),
+            ]),
+            HashMap::from([
                 (0, AssignmentWeight::new(6, 0)),
+                (1, AssignmentWeight::new(2, 0)),
                 (2, AssignmentWeight::new(2, 0)),
-                (4, AssignmentWeight::new(1, 0)),
             ]),
             HashMap::from([
                 (0, AssignmentWeight::new(4, 0)),
                 (1, AssignmentWeight::new(1, 0)),
                 (2, AssignmentWeight::new(3, 0)),
-                (3, AssignmentWeight::new(2, 60)),
+                (3, AssignmentWeight::new(2, 0)),
             ]),
             HashMap::from([
                 (0, AssignmentWeight::new(2, 0)),
                 (1, AssignmentWeight::new(4, 0)),
-                (2, AssignmentWeight::new(4, 0)),
-                (4, AssignmentWeight::new(0, 40)),
-            ]),
-            HashMap::from([
-                (0, AssignmentWeight::new(3, 0)),
-                (1, AssignmentWeight::new(5, 0)),
-                (2, AssignmentWeight::new(1, 0)),
+                (2, AssignmentWeight::new(2, 0)),
+                (4, AssignmentWeight::new(1, 40)),
             ]),
         ];
         assert_eq!(epoch_info.sample_chunk_validators(height), expected_assignments);

--- a/core/primitives/src/validator_mandates.rs
+++ b/core/primitives/src/validator_mandates.rs
@@ -450,7 +450,7 @@ mod tests {
         let expected_mandates_per_shards: ValidatorMandatesAssignment = vec![
             HashMap::from([
                 (0, AssignmentWeight::new(2, 0)),
-                (4, AssignmentWeight::new(1,0 )),
+                (4, AssignmentWeight::new(1, 0)),
                 (1, AssignmentWeight::new(0, 7)),
             ]),
             HashMap::from([

--- a/core/primitives/src/validator_mandates.rs
+++ b/core/primitives/src/validator_mandates.rs
@@ -444,20 +444,22 @@ mod tests {
         assert_eq!(assignment, expected_assignment);
     }
 
-    /// Testing with `num_shards = 4` to know the shard id shufflings for tests above.
     #[test]
-    fn test_shuffled_shard_ids_new_4_shards() {
-        let mut rng = new_fixed_rng();
-        let shuffled_shard_ids = ShuffledShardIds::new(&mut rng, 4);
-        assert_eq!(shuffled_shard_ids, ShuffledShardIds { shuffled_ids: vec![0, 2, 1, 3] });
+    fn test_shuffled_shards_new() {
+        // Testing with different `num_shards` values to verify the shufflings used in other tests.
+        assert_shuffled_shard_ids(4, vec![0, 2, 1, 3]);
+        assert_shuffled_shard_ids(3, vec![2, 1, 0]);
     }
 
-    /// Testing with `num_shards = 3` to know the shard id shufflings for tests above.
-    #[test]
-    fn test_shuffled_shard_ids_new_3_shards() {
+    /// Testing with `num_shards = 3` to know the shuffling for tests with that config.
+    fn assert_shuffled_shard_ids(num_shards: usize, expected_shuffling: Vec<usize>) {
         let mut rng = new_fixed_rng();
-        let shuffled_ids_full_mandates = ShuffledShardIds::new(&mut rng, 3);
-        assert_eq!(shuffled_ids_full_mandates, ShuffledShardIds { shuffled_ids: vec![2, 1, 0] });
+        let shuffled_ids_full_mandates = ShuffledShardIds::new(&mut rng, num_shards);
+        assert_eq!(
+            shuffled_ids_full_mandates,
+            ShuffledShardIds { shuffled_ids: expected_shuffling },
+            "Unexpected shuffling for num_shards = {num_shards}"
+        );
     }
 
     #[test]

--- a/core/primitives/src/validator_mandates.rs
+++ b/core/primitives/src/validator_mandates.rs
@@ -40,6 +40,13 @@ impl ValidatorMandatesConfig {
 }
 
 /// The mandates for a set of validators given a [`ValidatorMandatesConfig`].
+///
+/// A mandate is a liability for a validator to validate a shard. Depending on its stake and the
+/// `stake_per_mandate` specified in `ValidatorMandatesConfig`, a validator may hold multiple
+/// mandates. Each mandate may be assigned to a different shard. The assignment of mandates to
+/// shards is calculated with [`Self::sample`], typically at every height.
+///
+/// See #9983 for context and links to resources that introduce mandates.
 #[derive(
     BorshSerialize, BorshDeserialize, Default, Clone, Debug, PartialEq, Eq, serde::Serialize,
 )]

--- a/core/primitives/src/validator_mandates.rs
+++ b/core/primitives/src/validator_mandates.rs
@@ -242,10 +242,7 @@ impl ShuffledShardIds {
     where
         R: Rng + ?Sized,
     {
-        let mut shuffled_ids = Vec::with_capacity(num_shards);
-        for shard_id in 0..num_shards {
-            shuffled_ids.push(shard_id);
-        }
+        let mut shuffled_ids = (0..num_shards).collect::<Vec<_>>();
         shuffled_ids.shuffle(rng);
         Self { shuffled_ids }
     }

--- a/core/primitives/src/validator_mandates.rs
+++ b/core/primitives/src/validator_mandates.rs
@@ -134,7 +134,10 @@ impl ValidatorMandates {
         let mut mandates_per_shard: ValidatorMandatesAssignment =
             vec![HashMap::new(); self.config.num_shards];
         for shard_id in 0..self.config.num_shards {
-            let mut assignments: HashMap<ValidatorId, AssignmentWeight> = HashMap::new();
+            // Achieve shard id shuffling by writing to the position of the alias of `shard_id`.
+            // The unwrap is safe as above we constructed the vector with `num_shards` elements.
+            let assignments =
+                mandates_per_shard.get_mut(shuffled_shard_ids.get_alias(shard_id)).unwrap();
 
             // For the current `shard_id`, collect mandates with index `i` such that
             // `i % num_shards == shard_id`.
@@ -159,9 +162,6 @@ impl ValidatorMandates {
                     })
                     .or_insert(AssignmentWeight::new(0, partial_weight));
             }
-
-            // Achieve shard id shuffling by writing to the position of the alias of `shard_id`.
-            mandates_per_shard[shuffled_shard_ids.get_alias(shard_id)] = assignments;
         }
 
         mandates_per_shard

--- a/core/primitives/src/validator_mandates.rs
+++ b/core/primitives/src/validator_mandates.rs
@@ -115,7 +115,7 @@ impl ValidatorMandates {
         R: Rng + ?Sized,
     {
         // Shuffling shard ids to avoid a bias towards lower ids, see [`ShuffledShardIds`]. We
-        // do two separate shufflings for full and partial mandates to reduce the likelihood of
+        // do two separate shuffes for full and partial mandates to reduce the likelihood of
         // assigning fewer full _and_ partial mandates to the _same_ shard.
         let shard_ids_for_mandates = ShuffledShardIds::new(rng, self.config.num_shards);
         let shard_ids_for_partials = ShuffledShardIds::new(rng, self.config.num_shards);
@@ -129,8 +129,6 @@ impl ValidatorMandates {
         //
         // Assume, for example, there are 10 mandates and 4 shards. Then the shard with id 1 gets
         // assigned the mandates with indices 1, 5, and 9.
-        //
-        // TODO(#10014) shuffle shard ids to avoid a bias towards smaller shard ids
         let mut mandates_per_shard: ValidatorMandatesAssignment =
             vec![HashMap::new(); self.config.num_shards];
         for shard_id in 0..self.config.num_shards {
@@ -341,7 +339,7 @@ mod tests {
 
     #[test]
     fn test_validator_mandates_shuffled_mandates() {
-        // Testing with different `num_shards` values to verify the shufflings used in other tests.
+        // Testing with different `num_shards` values to verify the shuffles used in other tests.
         assert_validator_mandates_shuffled_mandates(3, vec![0, 1, 4, 4, 3, 1, 4, 0, 0]);
         assert_validator_mandates_shuffled_mandates(4, vec![0, 4, 1, 1, 0, 0, 4, 3, 4]);
     }
@@ -369,7 +367,7 @@ mod tests {
 
     #[test]
     fn test_validator_mandates_shuffled_partials() {
-        // Testing with different `num_shards` values to verify the shufflings used in other tests.
+        // Testing with different `num_shards` values to verify the shuffles used in other tests.
         assert_validator_mandates_shuffled_partials(
             3,
             vec![(3, 2), (4, 5), (1, 7), (2, 9), (5, 4), (6, 6)],
@@ -486,8 +484,8 @@ mod tests {
 
     #[test]
     fn test_shuffled_shard_ids_new() {
-        // Testing with different `num_shards` values to verify the shufflings used in other tests.
-        // Doing two shufflings for each `num_shards` with the same RNG since shard ids are shuffled
+        // Testing with different `num_shards` values to verify the shuffles used in other tests.
+        // Doing two shuffles for each `num_shards` with the same RNG since shard ids are shuffled
         // twice (once for full and once for partial mandates).
         let mut rng_3_shards = new_fixed_rng();
         assert_shuffled_shard_ids(&mut rng_3_shards, 3, vec![2, 1, 0], "3 shards, 1st shuffle");


### PR DESCRIPTION
Introduces a shuffling of shard ids when assigning chunk validators to shards. Without that shuffling it is predictable which shards receive fewer (partial) mandates when they cannot be distributed evenly across shards. See this [comment](https://github.com/mooori/sim-validator-assignment/pull/12#discussion_r1389895314) which also brings up the idea of shard id shuffling.

### Separate shuffles for full and partial mandate assignment

If there was only one shuffling for both full and partial mandates, then the shard(s) that get a full mandate less may also get a partial mandate less. Separate shufflings counter that and ideally (depending on randomness) stake is distributed more evenly as shards that receive a full mandate less may still get the maximum amount of partial mandates.

### Related issue

#10014