### PR TITLE
build fuzzers on ubuntu-20.04

### DIFF
--- a/.github/workflows/master_fuzzer_binaries.yml
+++ b/.github/workflows/master_fuzzer_binaries.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build_fuzzers:
     name: Build Fuzzers
-    runs-on: "ubuntu-22.04-32core"
+    runs-on: "ubuntu-20.04-32core"
 
     permissions:
       contents: "read"

--- a/.github/workflows/ondemand_fuzzer_binaries.yml
+++ b/.github/workflows/ondemand_fuzzer_binaries.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   build_fuzzers:
     name: Build Fuzzers
-    runs-on: "ubuntu-22.04-32core"
+    runs-on: "ubuntu-20.04-32core"
 
     permissions:
       contents: "read"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "bolero"
 version = "0.10.0"
-source = "git+https://github.com/Ekleog-NEAR/bolero?rev=8f4e49d65c702a2f9858ed3c217b1cb52ce91243#8f4e49d65c702a2f9858ed3c217b1cb52ce91243"
+source = "git+https://github.com/Ekleog-NEAR/bolero?rev=56da8e6d1d018519a30b36d85d3a53fe35a42eaf#56da8e6d1d018519a30b36d85d3a53fe35a42eaf"
 dependencies = [
  "bolero-afl",
  "bolero-engine",
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "bolero-afl"
 version = "0.10.0"
-source = "git+https://github.com/Ekleog-NEAR/bolero?rev=8f4e49d65c702a2f9858ed3c217b1cb52ce91243#8f4e49d65c702a2f9858ed3c217b1cb52ce91243"
+source = "git+https://github.com/Ekleog-NEAR/bolero?rev=56da8e6d1d018519a30b36d85d3a53fe35a42eaf#56da8e6d1d018519a30b36d85d3a53fe35a42eaf"
 dependencies = [
  "bolero-engine",
  "cc",
@@ -749,7 +749,7 @@ dependencies = [
 [[package]]
 name = "bolero-engine"
 version = "0.10.0"
-source = "git+https://github.com/Ekleog-NEAR/bolero?rev=8f4e49d65c702a2f9858ed3c217b1cb52ce91243#8f4e49d65c702a2f9858ed3c217b1cb52ce91243"
+source = "git+https://github.com/Ekleog-NEAR/bolero?rev=56da8e6d1d018519a30b36d85d3a53fe35a42eaf#56da8e6d1d018519a30b36d85d3a53fe35a42eaf"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -762,7 +762,7 @@ dependencies = [
 [[package]]
 name = "bolero-generator"
 version = "0.10.0"
-source = "git+https://github.com/Ekleog-NEAR/bolero?rev=8f4e49d65c702a2f9858ed3c217b1cb52ce91243#8f4e49d65c702a2f9858ed3c217b1cb52ce91243"
+source = "git+https://github.com/Ekleog-NEAR/bolero?rev=56da8e6d1d018519a30b36d85d3a53fe35a42eaf#56da8e6d1d018519a30b36d85d3a53fe35a42eaf"
 dependencies = [
  "arbitrary",
  "bolero-generator-derive",
@@ -773,7 +773,7 @@ dependencies = [
 [[package]]
 name = "bolero-generator-derive"
 version = "0.10.0"
-source = "git+https://github.com/Ekleog-NEAR/bolero?rev=8f4e49d65c702a2f9858ed3c217b1cb52ce91243#8f4e49d65c702a2f9858ed3c217b1cb52ce91243"
+source = "git+https://github.com/Ekleog-NEAR/bolero?rev=56da8e6d1d018519a30b36d85d3a53fe35a42eaf#56da8e6d1d018519a30b36d85d3a53fe35a42eaf"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -784,7 +784,7 @@ dependencies = [
 [[package]]
 name = "bolero-honggfuzz"
 version = "0.10.0"
-source = "git+https://github.com/Ekleog-NEAR/bolero?rev=8f4e49d65c702a2f9858ed3c217b1cb52ce91243#8f4e49d65c702a2f9858ed3c217b1cb52ce91243"
+source = "git+https://github.com/Ekleog-NEAR/bolero?rev=56da8e6d1d018519a30b36d85d3a53fe35a42eaf#56da8e6d1d018519a30b36d85d3a53fe35a42eaf"
 dependencies = [
  "bolero-engine",
 ]
@@ -792,7 +792,7 @@ dependencies = [
 [[package]]
 name = "bolero-kani"
 version = "0.10.0"
-source = "git+https://github.com/Ekleog-NEAR/bolero?rev=8f4e49d65c702a2f9858ed3c217b1cb52ce91243#8f4e49d65c702a2f9858ed3c217b1cb52ce91243"
+source = "git+https://github.com/Ekleog-NEAR/bolero?rev=56da8e6d1d018519a30b36d85d3a53fe35a42eaf#56da8e6d1d018519a30b36d85d3a53fe35a42eaf"
 dependencies = [
  "bolero-engine",
 ]
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "bolero-libfuzzer"
 version = "0.10.0"
-source = "git+https://github.com/Ekleog-NEAR/bolero?rev=8f4e49d65c702a2f9858ed3c217b1cb52ce91243#8f4e49d65c702a2f9858ed3c217b1cb52ce91243"
+source = "git+https://github.com/Ekleog-NEAR/bolero?rev=56da8e6d1d018519a30b36d85d3a53fe35a42eaf#56da8e6d1d018519a30b36d85d3a53fe35a42eaf"
 dependencies = [
  "bolero-engine",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ bencher = "0.1.5"
 bitflags = "1.2"
 blake2 = "0.9.1"
 bn = { package = "zeropool-bn", version = "0.5.11", default-features = false }
-bolero = { version = "0.10.0", git = "https://github.com/Ekleog-NEAR/bolero", rev = "8f4e49d65c702a2f9858ed3c217b1cb52ce91243", features = ["arbitrary"] }
+bolero = { version = "0.10.0", git = "https://github.com/Ekleog-NEAR/bolero", rev = "56da8e6d1d018519a30b36d85d3a53fe35a42eaf", features = ["arbitrary"] }
 borsh = { version = "1.0.0", features = ["derive", "rc"] }
 bs58 = "0.4"
 bytes = "1"


### PR DESCRIPTION
Currently, our clusterfuzz runners do not have the glibc version required to run builds made on ubuntu-22.04.

Building fuzzers on ubuntu-20.04 should fix the issue (that is only apparent in fuzzer logs); hopefully once we upgrade our clusterfuzz runners we’ll be able to bump to a newer ubuntu LTS.