### PR TITLE
enable resharding v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@
 
 ### Protocol Changes
 
-* Resharding v2 - new implementation for resharding and a new shard layout for production networks
-  * [#10303](https://github.com/near/nearcore/pull/10303)
-  * [NEP-0508](https://github.com/near/NEPs/pull/508)
+* Resharding v2 - new implementation for resharding and a new shard layout for production networks. [#10303](https://github.com/near/nearcore/pull/10303), [NEP-0508](https://github.com/near/NEPs/pull/508)
 * Restrict the creation of non-implicit top-level account that are longer than 32 bytes. Only the registrar account can create them. [#9589](https://github.com/near/nearcore/pull/9589)
 * Adjust the number of block producers and chunk producers on testnet to facilitate testing of chunk-only producers [#9563](https://github.com/near/nearcore/pull/9563)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Protocol Changes
 
 * Resharding v2 - new implementation for resharding and a new shard layout for production networks
-  * TODO PR link
+  * [#10303](https://github.com/near/nearcore/pull/10303)
   * [NEP-0508](https://github.com/near/NEPs/pull/508)
 * Restrict the creation of non-implicit top-level account that are longer than 32 bytes. Only the registrar account can create them. [#9589](https://github.com/near/nearcore/pull/9589)
 * Adjust the number of block producers and chunk producers on testnet to facilitate testing of chunk-only producers [#9563](https://github.com/near/nearcore/pull/9563)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Protocol Changes
 
+* Resharding v2 - new implementation for resharding and a new shard layout for production networks
+  * TODO PR link
+  * [NEP-0508](https://github.com/near/NEPs/pull/508)
 * Restrict the creation of non-implicit top-level account that are longer than 32 bytes. Only the registrar account can create them. [#9589](https://github.com/near/nearcore/pull/9589)
 * Adjust the number of block producers and chunk producers on testnet to facilitate testing of chunk-only producers [#9563](https://github.com/near/nearcore/pull/9563)
 

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -110,6 +110,7 @@ pub enum ProtocolFeature {
     /// as it hardcodes preparation v2 code into the generated assembly.
     NearVmRuntime,
     BlockHeaderV4,
+    SimpleNightshadeV2,
     /// In case not all validator seats are occupied our algorithm provide incorrect minimal seat
     /// price - it reports as alpha * sum_stake instead of alpha * sum_stake / (1 - alpha), where
     /// alpha is min stake ratio
@@ -120,7 +121,6 @@ pub enum ProtocolFeature {
     FixContractLoadingCost,
     #[cfg(feature = "protocol_feature_reject_blocks_with_outdated_protocol_version")]
     RejectBlocksWithOutdatedProtocolVersions,
-    SimpleNightshadeV2,
     RestrictTla,
     /// Increases the number of chunk producers.
     TestnetFewerBlockProducers,
@@ -172,6 +172,7 @@ impl ProtocolFeature {
             ProtocolFeature::PreparationV2 | ProtocolFeature::NearVmRuntime => 62,
             ProtocolFeature::BlockHeaderV4 => 63,
             ProtocolFeature::RestrictTla | ProtocolFeature::TestnetFewerBlockProducers => 64,
+            ProtocolFeature::SimpleNightshadeV2 => 64,
 
             // Nightly features
             #[cfg(feature = "protocol_feature_fix_staking_threshold")]
@@ -180,7 +181,6 @@ impl ProtocolFeature {
             ProtocolFeature::FixContractLoadingCost => 129,
             #[cfg(feature = "protocol_feature_reject_blocks_with_outdated_protocol_version")]
             ProtocolFeature::RejectBlocksWithOutdatedProtocolVersions => 132,
-            ProtocolFeature::SimpleNightshadeV2 => 135,
             ProtocolFeature::ChunkValidation => 137,
             ProtocolFeature::EthImplicitAccounts => 138,
         }

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -110,6 +110,8 @@ pub enum ProtocolFeature {
     /// as it hardcodes preparation v2 code into the generated assembly.
     NearVmRuntime,
     BlockHeaderV4,
+    /// Resharding V2. A new implementation for resharding and a new shard
+    /// layout for the production networks.
     SimpleNightshadeV2,
     /// In case not all validator seats are occupied our algorithm provide incorrect minimal seat
     /// price - it reports as alpha * sum_stake instead of alpha * sum_stake / (1 - alpha), where
@@ -171,8 +173,9 @@ impl ProtocolFeature {
             ProtocolFeature::ComputeCosts | ProtocolFeature::FlatStorageReads => 61,
             ProtocolFeature::PreparationV2 | ProtocolFeature::NearVmRuntime => 62,
             ProtocolFeature::BlockHeaderV4 => 63,
-            ProtocolFeature::RestrictTla | ProtocolFeature::TestnetFewerBlockProducers => 64,
-            ProtocolFeature::SimpleNightshadeV2 => 64,
+            ProtocolFeature::RestrictTla
+            | ProtocolFeature::TestnetFewerBlockProducers
+            | ProtocolFeature::SimpleNightshadeV2 => 64,
 
             // Nightly features
             #[cfg(feature = "protocol_feature_fix_staking_threshold")]


### PR DESCRIPTION
# Feature to stabilize
This PR stabilizes the Resharding V2 protocol feature. It introduces a new implementation for resharding and a new shard layout for the production networks - mainnet and testnet. The resharding process from the current shard layout to the new shard layout will be triggered automatically an epoch before the switch to the new protocol version. 

# Context

- https://github.com/near/NEPs/pull/508
- https://github.com/near/nearcore/issues/8992

# Testing and QA

This feature was extensively tested in unit tests, integration tests, nayduck tests, mocknet, testnet and mainnet. 

# Checklist
- [ ] nayduck - https://nayduck.near.org/#/run/3308 
- [x] Update CHANGELOG.md to include this protocol feature in the `Unreleased` section.