### PR TITLE
feat: add a time limit for processing transactions in produce_chunk

### DIFF
--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -1027,7 +1027,6 @@ impl RuntimeAdapter for KeyValueRuntime {
         while let Some(iter) = transactions.next() {
             res.push(iter.next().unwrap());
         }
-
         Ok(res)
     }
 

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -1021,19 +1021,11 @@ impl RuntimeAdapter for KeyValueRuntime {
         transactions: &mut dyn PoolIterator,
         _chain_validate: &mut dyn FnMut(&SignedTransaction) -> bool,
         _current_protocol_version: ProtocolVersion,
-        time_limit: Option<Duration>,
+        _time_limit: Option<Duration>,
     ) -> Result<Vec<SignedTransaction>, Error> {
-        let start_time = std::time::Instant::now();
-        let time_limit_reached = || match time_limit {
-            Some(limit_duration) => start_time.elapsed() >= limit_duration,
-            None => false,
-        };
         let mut res = vec![];
-        while !time_limit_reached() {
-            match transactions.next() {
-                Some(iter) => res.push(iter.next().unwrap()),
-                None => break,
-            }
+        while let Some(iter) = transactions.next() {
+            res.push(iter.next().unwrap());
         }
 
         Ok(res)

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::time::Duration;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use chrono::DateTime;
@@ -337,6 +338,7 @@ pub trait RuntimeAdapter: Send + Sync {
         pool_iterator: &mut dyn PoolIterator,
         chain_validate: &mut dyn FnMut(&SignedTransaction) -> bool,
         current_protocol_version: ProtocolVersion,
+        time_limit: Option<Duration>,
     ) -> Result<Vec<SignedTransaction>, Error>;
 
     /// Returns true if the shard layout will change in the next epoch

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -977,7 +977,7 @@ impl Client {
                         .is_ok()
                 },
                 protocol_version,
-                Some(self.config.produce_chunk_add_transactions_time_limit),
+                self.config.produce_chunk_add_transactions_time_limit,
             )?
         } else {
             vec![]

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -977,6 +977,7 @@ impl Client {
                         .is_ok()
                 },
                 protocol_version,
+                Some(std::time::Duration::from_millis(200)),
             )?
         } else {
             vec![]

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -977,7 +977,7 @@ impl Client {
                         .is_ok()
                 },
                 protocol_version,
-                Some(std::time::Duration::from_millis(200)),
+                Some(self.config.produce_chunk_add_transactions_time_limit),
             )?
         } else {
             vec![]

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -184,6 +184,9 @@ impl Client {
     pub(crate) fn update_client_config(&self, update_client_config: UpdateableClientConfig) {
         self.config.expected_shutdown.update(update_client_config.expected_shutdown);
         self.config.state_split_config.update(update_client_config.state_split_config);
+        self.config
+            .produce_chunk_add_transactions_time_limit
+            .update(update_client_config.produce_chunk_add_transactions_time_limit);
     }
 }
 
@@ -977,7 +980,7 @@ impl Client {
                         .is_ok()
                 },
                 protocol_version,
-                self.config.produce_chunk_add_transactions_time_limit,
+                self.config.produce_chunk_add_transactions_time_limit.get(),
             )?
         } else {
             vec![]

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -273,8 +273,8 @@ pub fn default_enable_multiline_logging() -> Option<bool> {
     Some(true)
 }
 
-pub fn default_produce_chunk_add_transactions_time_limit() -> Duration {
-    Duration::from_millis(200)
+pub fn default_produce_chunk_add_transactions_time_limit() -> Option<Duration> {
+    Some(Duration::from_millis(200))
 }
 
 /// ClientConfig where some fields can be updated at runtime.
@@ -394,7 +394,7 @@ pub struct ClientConfig {
     /// A node produces a chunk by adding transactions from the transaction pool until
     /// some limit is reached. This time limit ensures that adding transactions won't take
     /// longer than the specified duration, which helps to produce the chunk quickly.
-    pub produce_chunk_add_transactions_time_limit: Duration,
+    pub produce_chunk_add_transactions_time_limit: Option<Duration>,
 }
 
 impl ClientConfig {

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -394,7 +394,7 @@ pub struct ClientConfig {
     /// A node produces a chunk by adding transactions from the transaction pool until
     /// some limit is reached. This time limit ensures that adding transactions won't take
     /// longer than the specified duration, which helps to produce the chunk quickly.
-    pub produce_chunk_add_transactions_time_limit: Option<Duration>,
+    pub produce_chunk_add_transactions_time_limit: MutableConfigValue<Option<Duration>>,
 }
 
 impl ClientConfig {
@@ -474,8 +474,10 @@ impl ClientConfig {
                 "state_split_config",
             ),
             tx_routing_height_horizon: 4,
-            produce_chunk_add_transactions_time_limit:
+            produce_chunk_add_transactions_time_limit: MutableConfigValue::new(
                 default_produce_chunk_add_transactions_time_limit(),
+                "produce_chunk_add_transactions_time_limit",
+            ),
         }
     }
 }

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -305,6 +305,11 @@ pub struct ClientConfig {
     /// If the node is not a chunk producer within that many blocks, then route
     /// to upcoming chunk producers.
     pub tx_routing_height_horizon: BlockHeightDelta,
+    /// Limit the time of adding transactions to a chunk.
+    /// A node produces a chunk by adding transactions from the transaction pool until
+    /// some limit is reached. This time limit ensures that adding transactions won't take
+    /// longer than the specified duration, which helps to produce the chunk quickly.
+    pub produce_chunk_add_transactions_time_limit: Duration,
 }
 
 impl ClientConfig {
@@ -384,6 +389,7 @@ impl ClientConfig {
                 "state_split_config",
             ),
             tx_routing_height_horizon: 4,
+            produce_chunk_add_transactions_time_limit: Duration::from_millis(200),
         }
     }
 }

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -474,7 +474,8 @@ impl ClientConfig {
                 "state_split_config",
             ),
             tx_routing_height_horizon: 4,
-            produce_chunk_add_transactions_time_limit: Duration::from_millis(200),
+            produce_chunk_add_transactions_time_limit:
+                default_produce_chunk_add_transactions_time_limit(),
         }
     }
 }

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -1,4 +1,5 @@
 //! Chain Client Configuration
+use crate::ExternalStorageLocation::GCS;
 use crate::MutableConfigValue;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockHeightDelta, Gas, NumBlocks, NumSeats, ShardId,
@@ -190,6 +191,90 @@ impl Default for StateSplitConfig {
             max_poll_time: Duration::from_secs(2 * 60 * 60), // 2 hours
         }
     }
+}
+
+pub fn default_header_sync_initial_timeout() -> Duration {
+    Duration::from_secs(10)
+}
+
+pub fn default_header_sync_progress_timeout() -> Duration {
+    Duration::from_secs(2)
+}
+
+pub fn default_header_sync_stall_ban_timeout() -> Duration {
+    Duration::from_secs(120)
+}
+
+pub fn default_state_sync_timeout() -> Duration {
+    Duration::from_secs(60)
+}
+
+pub fn default_header_sync_expected_height_per_second() -> u64 {
+    10
+}
+
+pub fn default_sync_check_period() -> Duration {
+    Duration::from_secs(10)
+}
+
+pub fn default_sync_step_period() -> Duration {
+    Duration::from_millis(10)
+}
+
+pub fn default_sync_height_threshold() -> u64 {
+    1
+}
+
+pub fn default_epoch_sync_enabled() -> bool {
+    false
+}
+
+pub fn default_state_sync() -> Option<StateSyncConfig> {
+    Some(StateSyncConfig {
+        dump: None,
+        sync: SyncConfig::ExternalStorage(ExternalStorageConfig {
+            location: GCS { bucket: "state-parts".to_string() },
+            num_concurrent_requests: DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_EXTERNAL,
+            num_concurrent_requests_during_catchup:
+                DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_ON_CATCHUP_EXTERNAL,
+        }),
+    })
+}
+
+pub fn default_state_sync_enabled() -> bool {
+    true
+}
+
+pub fn default_view_client_threads() -> usize {
+    4
+}
+
+pub fn default_log_summary_period() -> Duration {
+    Duration::from_secs(10)
+}
+
+pub fn default_view_client_throttle_period() -> Duration {
+    Duration::from_secs(30)
+}
+
+pub fn default_trie_viewer_state_size_limit() -> Option<u64> {
+    Some(50_000)
+}
+
+pub fn default_transaction_pool_size_limit() -> Option<u64> {
+    Some(100_000_000) // 100 MB.
+}
+
+pub fn default_tx_routing_height_horizon() -> BlockHeightDelta {
+    4
+}
+
+pub fn default_enable_multiline_logging() -> Option<bool> {
+    Some(true)
+}
+
+pub fn default_produce_chunk_add_transactions_time_limit() -> Duration {
+    Duration::from_millis(200)
 }
 
 /// ClientConfig where some fields can be updated at runtime.

--- a/core/chain-configs/src/lib.rs
+++ b/core/chain-configs/src/lib.rs
@@ -6,9 +6,17 @@ mod metrics;
 mod updateable_config;
 
 pub use client_config::{
-    ClientConfig, DumpConfig, ExternalStorageConfig, ExternalStorageLocation, GCConfig,
-    LogSummaryStyle, StateSplitConfig, StateSyncConfig, SyncConfig, DEFAULT_GC_NUM_EPOCHS_TO_KEEP,
-    DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_EXTERNAL,
+    default_enable_multiline_logging, default_epoch_sync_enabled,
+    default_header_sync_expected_height_per_second, default_header_sync_initial_timeout,
+    default_header_sync_progress_timeout, default_header_sync_stall_ban_timeout,
+    default_log_summary_period, default_produce_chunk_add_transactions_time_limit,
+    default_state_sync, default_state_sync_enabled, default_state_sync_timeout,
+    default_sync_check_period, default_sync_height_threshold, default_sync_step_period,
+    default_transaction_pool_size_limit, default_trie_viewer_state_size_limit,
+    default_tx_routing_height_horizon, default_view_client_threads,
+    default_view_client_throttle_period, ClientConfig, DumpConfig, ExternalStorageConfig,
+    ExternalStorageLocation, GCConfig, LogSummaryStyle, StateSplitConfig, StateSyncConfig,
+    SyncConfig, DEFAULT_GC_NUM_EPOCHS_TO_KEEP, DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_EXTERNAL,
     DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_ON_CATCHUP_EXTERNAL, MIN_GC_NUM_EPOCHS_TO_KEEP,
     TEST_STATE_SYNC_TIMEOUT,
 };

--- a/core/chain-configs/src/updateable_config.rs
+++ b/core/chain-configs/src/updateable_config.rs
@@ -1,7 +1,7 @@
 use near_primitives::types::BlockHeight;
 use serde::{Deserialize, Serialize, Serializer};
-use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
+use std::{fmt::Debug, time::Duration};
 
 use crate::StateSplitConfig;
 
@@ -93,4 +93,7 @@ pub struct UpdateableClientConfig {
 
     // Configuration for resharding.
     pub state_split_config: StateSplitConfig,
+
+    /// Time limit for adding transactions in produce_chunk()
+    pub produce_chunk_add_transactions_time_limit: Option<Duration>,
 }

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -315,7 +315,7 @@ pub struct Config {
     /// A node produces a chunk by adding transactions from the transaction pool until
     /// some limit is reached. This time limit ensures that adding transactions won't take
     /// longer than the specified duration, which helps to produce the chunk quickly.
-    pub produce_chunk_add_transactions_time_limit: Duration,
+    pub produce_chunk_add_transactions_time_limit: Option<Duration>,
 }
 
 fn is_false(value: &bool) -> bool {

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -661,8 +661,10 @@ impl NearConfig {
                     "state_split_config",
                 ),
                 tx_routing_height_horizon: config.tx_routing_height_horizon,
-                produce_chunk_add_transactions_time_limit: config
-                    .produce_chunk_add_transactions_time_limit,
+                produce_chunk_add_transactions_time_limit: MutableConfigValue::new(
+                    config.produce_chunk_add_transactions_time_limit,
+                    "produce_chunk_add_transactions_time_limit",
+                ),
             },
             network_config: NetworkConfig::new(
                 config.network,

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -1,12 +1,18 @@
 use crate::download_file::{run_download_file, FileDownloadError};
 use crate::dyn_config::LOG_CONFIG_FILENAME;
 use anyhow::{anyhow, bail, Context};
-use near_chain_configs::ExternalStorageLocation::GCS;
 use near_chain_configs::{
-    get_initial_supply, ClientConfig, ExternalStorageConfig, GCConfig, Genesis, GenesisConfig,
-    GenesisValidationMode, LogSummaryStyle, MutableConfigValue, StateSplitConfig, StateSyncConfig,
-    SyncConfig, DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_EXTERNAL,
-    DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_ON_CATCHUP_EXTERNAL,
+    default_enable_multiline_logging, default_epoch_sync_enabled,
+    default_header_sync_expected_height_per_second, default_header_sync_initial_timeout,
+    default_header_sync_progress_timeout, default_header_sync_stall_ban_timeout,
+    default_log_summary_period, default_produce_chunk_add_transactions_time_limit,
+    default_state_sync, default_state_sync_enabled, default_state_sync_timeout,
+    default_sync_check_period, default_sync_height_threshold, default_sync_step_period,
+    default_transaction_pool_size_limit, default_trie_viewer_state_size_limit,
+    default_tx_routing_height_horizon, default_view_client_threads,
+    default_view_client_throttle_period, get_initial_supply, ClientConfig, GCConfig, Genesis,
+    GenesisConfig, GenesisValidationMode, LogSummaryStyle, MutableConfigValue, StateSplitConfig,
+    StateSyncConfig,
 };
 use near_config_utils::{ValidationError, ValidationErrors};
 use near_crypto::{InMemorySigner, KeyFile, KeyType, PublicKey, Signer};
@@ -150,92 +156,8 @@ pub const MAX_INFLATION_RATE: Rational32 = Rational32::new_raw(1, 20);
 /// Protocol upgrade stake threshold.
 pub const PROTOCOL_UPGRADE_STAKE_THRESHOLD: Rational32 = Rational32::new_raw(4, 5);
 
-fn default_header_sync_initial_timeout() -> Duration {
-    Duration::from_secs(10)
-}
-
-fn default_header_sync_progress_timeout() -> Duration {
-    Duration::from_secs(2)
-}
-
-fn default_header_sync_stall_ban_timeout() -> Duration {
-    Duration::from_secs(120)
-}
-
-fn default_state_sync_timeout() -> Duration {
-    Duration::from_secs(60)
-}
-
-fn default_header_sync_expected_height_per_second() -> u64 {
-    10
-}
-
-fn default_sync_check_period() -> Duration {
-    Duration::from_secs(10)
-}
-
-fn default_sync_step_period() -> Duration {
-    Duration::from_millis(10)
-}
-
-fn default_sync_height_threshold() -> u64 {
-    1
-}
-
-fn default_epoch_sync_enabled() -> bool {
-    false
-}
-
-fn default_state_sync() -> Option<StateSyncConfig> {
-    Some(StateSyncConfig {
-        dump: None,
-        sync: SyncConfig::ExternalStorage(ExternalStorageConfig {
-            location: GCS { bucket: "state-parts".to_string() },
-            num_concurrent_requests: DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_EXTERNAL,
-            num_concurrent_requests_during_catchup:
-                DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_ON_CATCHUP_EXTERNAL,
-        }),
-    })
-}
-
-fn default_state_sync_enabled() -> bool {
-    true
-}
-
-fn default_view_client_threads() -> usize {
-    4
-}
-
-fn default_log_summary_period() -> Duration {
-    Duration::from_secs(10)
-}
-
 fn default_doomslug_step_period() -> Duration {
     Duration::from_millis(100)
-}
-
-fn default_view_client_throttle_period() -> Duration {
-    Duration::from_secs(30)
-}
-
-fn default_trie_viewer_state_size_limit() -> Option<u64> {
-    Some(50_000)
-}
-
-fn default_transaction_pool_size_limit() -> Option<u64> {
-    Some(100_000_000) // 100 MB.
-}
-
-fn default_tx_routing_height_horizon() -> BlockHeightDelta {
-    4
-}
-
-fn default_enable_multiline_logging() -> Option<bool> {
-    Some(true)
-}
-
-fn default_produce_chunk_add_transactions_time_limit() -> Duration {
-    Duration::from_millis(200)
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -234,6 +234,10 @@ fn default_enable_multiline_logging() -> Option<bool> {
     Some(true)
 }
 
+fn default_produce_chunk_add_transactions_time_limit() -> Duration {
+    Duration::from_millis(200)
+}
+
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct Consensus {
     /// Minimum number of peers to start syncing.
@@ -385,6 +389,11 @@ pub struct Config {
     /// If the node is not a chunk producer within that many blocks, then route
     /// to upcoming chunk producers.
     pub tx_routing_height_horizon: BlockHeightDelta,
+    /// Limit the time of adding transactions to a chunk.
+    /// A node produces a chunk by adding transactions from the transaction pool until
+    /// some limit is reached. This time limit ensures that adding transactions won't take
+    /// longer than the specified duration, which helps to produce the chunk quickly.
+    pub produce_chunk_add_transactions_time_limit: Duration,
 }
 
 fn is_false(value: &bool) -> bool {
@@ -427,6 +436,8 @@ impl Default for Config {
             enable_multiline_logging: default_enable_multiline_logging(),
             state_split_config: StateSplitConfig::default(),
             tx_routing_height_horizon: default_tx_routing_height_horizon(),
+            produce_chunk_add_transactions_time_limit:
+                default_produce_chunk_add_transactions_time_limit(),
         }
     }
 }
@@ -728,6 +739,8 @@ impl NearConfig {
                     "state_split_config",
                 ),
                 tx_routing_height_horizon: config.tx_routing_height_horizon,
+                produce_chunk_add_transactions_time_limit: config
+                    .produce_chunk_add_transactions_time_limit,
             },
             network_config: NetworkConfig::new(
                 config.network,

--- a/nearcore/src/dyn_config.rs
+++ b/nearcore/src/dyn_config.rs
@@ -48,6 +48,7 @@ pub fn get_updateable_client_config(config: Config) -> UpdateableClientConfig {
     UpdateableClientConfig {
         expected_shutdown: config.expected_shutdown,
         state_split_config: config.state_split_config,
+        produce_chunk_add_transactions_time_limit: config.produce_chunk_add_transactions_time_limit,
     }
 }
 

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -60,6 +60,7 @@ use node_runtime::{
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 use std::time::Instant;
 use tracing::{debug, error, info};
 
@@ -711,7 +712,13 @@ impl RuntimeAdapter for NightshadeRuntime {
         pool_iterator: &mut dyn PoolIterator,
         chain_validate: &mut dyn FnMut(&SignedTransaction) -> bool,
         current_protocol_version: ProtocolVersion,
+        time_limit: Option<Duration>,
     ) -> Result<Vec<SignedTransaction>, Error> {
+        let start_time = std::time::Instant::now();
+        let time_limit_reached = || match time_limit {
+            Some(limit_duration) => start_time.elapsed() >= limit_duration,
+            None => false,
+        };
         let shard_uid = self.get_shard_uid_from_epoch_id(shard_id, epoch_id)?;
         let mut state_update = self.tries.new_trie_update(shard_uid, state_root);
 
@@ -763,6 +770,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         while total_gas_burnt < transactions_gas_limit
             && total_size < size_limit
             && transactions.len() < new_receipt_count_limit
+            && !time_limit_reached()
         {
             if let Some(iter) = pool_iterator.next() {
                 while let Some(tx) = iter.next() {


### PR DESCRIPTION
To produce a chunk the node fetches transactions from the transaction pool and adds them to the chunk. Adding a transaction to the chunk can be computationally expensive - the transaction is converted to receipt, which burns gas. Because of that the number of transactions has to be limited. The node will fetch transactions until some kind of limit is reached, and then decide that the chunk is ready and publish it.

Currently we have a limit of gas that can be used for preparing transactions, but there is a big problem with it - it doesn't take into account discarding invalid transactions from the pool. Processing an invalid transaction doesn't burn gas, so the node could spend a lot of time discarding invalid transactions without ever reaching the limit. This would make chunk production very slow and the others might decide to just skip the chunk instead of waiting for it.

Let's add another limit to `prepare_transactions`: a time limit. When producing a chunk the node will be allowed to add new transactions to the chunk for up to X milliseconds. This will ensure that a chunk is produced quickly, even when there are many invalid transactions.

Choosing a good value for the limit is difficult, so a new config option is added to allow changing it on the fly: `produce_chunk_add_transactions_time_limit`.

The default value for the time limit is 200ms. The reasoning for choosing this value is as follows:
* Assuming that we want to produce ~1 block per second, 200ms is the largest value that would support that. If my understanding of the flow is correct, a 200ms chunk production would look like this:
  * Chunk producer produces a chunk (200ms)
  * Chunk producer publishes the chunk (50ms (?))
  * Validator receives the chunk
  * Validator validates the transactions, redoing chunk producer's work (200ms)
  * Validator runs receipts (500ms)
  
  This gives us a 1s time to produce a block.
* Looking at the metrics from mainnet, the P99 time to produce a chunk is ~60ms (and maximum is similar). 200ms is more than three times that, so it shouldn't break anything on the chain: https://nearinc.grafana.net/d/cd668436-f19a-4f3d-b4a5-a35ebd3701b0/chunk-production-stats?from=now-12h&to=now&refresh=1h&orgId=1
* During the minting of NEAT, the P99 time to produce a chunk jumped to ~860ms. This is unacceptable, as this will cause the chain to produce less than one block per second. This limit would prevent that. https://nearinc.grafana.net/d/cd668436-f19a-4f3d-b4a5-a35ebd3701b0/chunk-production-stats?from=1701298800000&to=1701342000000&orgId=1

For a more detailed discussion, see the comments in https://github.com/near/nearcore/issues/10278

Fixes: #10278