### PR TITLE
fix: remove flakiness in the test try_map_result_stops_on_error

### DIFF
--- a/chain/network/src/concurrency/rayon.rs
+++ b/chain/network/src/concurrency/rayon.rs
@@ -143,16 +143,18 @@ mod tests {
         outputs.sort();
 
         // The error will happen on 100th input, but other threads might produce subsequent outputs in parallel,
-        // so the size of outputs could be a bit larger than 100. Compare with 10_000 as a safety margin.
-        assert!(outputs.len() > 10);
-        assert!(outputs.len() < 10_000);
-        assert_eq!(&outputs[..10], &[2, 4, 6, 8, 10, 12, 14, 16, 18, 20]);
+        // so there might be over 100 outputs. We can't really assume antything about the outputs due to the
+        // nature of multithreading, but we can check that some basic conditions hold.
 
-        for output in outputs {
+        // All outputs should be distinct
+        for two_outputs in outputs.windows(2) {
+            assert_ne!(two_outputs[0], two_outputs[1]);
+
             // All outputs should be even, func multiplies the inputs by 2.
-            assert_eq!(output % 2, 0);
-            assert!(output < 20_0000);
+            assert_eq!(two_outputs[0] % 2, 0);
+            assert_eq!(two_outputs[1] % 2, 0);
         }
+
         assert_eq!(result, Err(TestError));
     }
 


### PR DESCRIPTION
`try_map_result` is a function which takes a list of tasks and runs them on multiple threads producing task outputs until the first error occurs.

The test `try_map_result_stops_on_error` asks to execute an infinite list of tasks, but the 100th task throws an error, so the function should stop after executing ~100 tasks.

The test checked that the function produces outputs for the first 10 tasks, but this isn't always true. The first 10 tasks could end up on a thread that is preempted and the tasks aren't executed before the error is hit on the 100th task. Because of this the test is flaky.

I assumed that the first 10 tasks would be executed first, but this was wrong, we can't assume anything here. Let's remove all checks that could be broken by race conditions, no matter how unlikely. This makes the test weaker, but at least it won't be flaky.