### PR TITLE
test(resharding) - test for getting the shard layout info by rpc

### DIFF
--- a/pytest/lib/utils.py
+++ b/pytest/lib/utils.py
@@ -1,4 +1,3 @@
-import atexit
 import base58
 import hashlib
 import json
@@ -7,7 +6,6 @@ import pathlib
 import random
 import re
 import shutil
-import subprocess
 import sys
 import tempfile
 import time


### PR DESCRIPTION
We need a way for near ecosystem developers to query the current shard layout. The EXPERIMENTAL_protocol_config allows that although with some extra steps. It should be good enough until we have time to implement a dedicated endpoint just for the shard layout. In this PR I extended the resharding nayduck test to check that the mentioned rpc endpoint works as expected and that changes in the shard layout are reflected in the rpc. 