### PR TITLE
feat: support IPv6 node address in locust loadtests

### DIFF
--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -232,7 +232,7 @@ class NearNodeProxy:
 
     def __init__(self, environment):
         self.request_event = environment.events.request
-        url, port = environment.host.split(":")
+        [url, port] = environment.host.rsplit(":", 1)
         self.node = cluster.RpcNode(url, port)
         self.session = requests.Session()
 


### PR DESCRIPTION
To run a locust loadtest the user has to pass an URL to the RPC node. This is done using the `-H` flag:
```bash
locust -H 127.0.0.1:3030 ...
```

This works with IPv4 addresses, but breaks with IPv6, because the code splits the host address by `:` to find the hostname and port. Ipv6 addresses can contain colons, which breaks this logic.

This command didn't work before this change:
```bash
locust -H "[::1]:3030" ...
```

Let's fix it by splitting on the last colon in the string. This makes it possible to use IPv6 addresses with locust loadtests.