### PR TITLE
fix(configs): print out underlying deserialization errors

### DIFF
--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -525,29 +525,32 @@ impl Genesis {
         path: P,
         genesis_validation: GenesisValidationMode,
     ) -> Result<Self, ValidationError> {
-        let mut file = File::open(&path).map_err(|_| ValidationError::GenesisFileError {
+        let mut file = File::open(&path).map_err(|e| ValidationError::GenesisFileError {
             error_message: format!(
-                "Could not open genesis config file at path {}.",
-                &path.as_ref().display()
+                "Could not open genesis config file at path {}: {:?}",
+                &path.as_ref().display(),
+                e,
             ),
         })?;
 
         let mut json_str = String::new();
-        file.read_to_string(&mut json_str).map_err(|_| ValidationError::GenesisFileError {
-            error_message: format!("Failed to read genesis config file to string. "),
+        file.read_to_string(&mut json_str).map_err(|e| ValidationError::GenesisFileError {
+            error_message: format!("Failed to read genesis config file to string: {:?}", e),
         })?;
 
         let json_str_without_comments = near_config_utils::strip_comments_from_json_str(&json_str)
-            .map_err(|_| ValidationError::GenesisFileError {
-                error_message: format!("Failed to strip comments from genesis config file"),
+            .map_err(|e| ValidationError::GenesisFileError {
+                error_message: format!(
+                    "Failed to strip comments from genesis config file: {:?}",
+                    e
+                ),
             })?;
 
-        let genesis =
-            serde_json::from_str::<Genesis>(&json_str_without_comments).map_err(|_| {
-                ValidationError::GenesisFileError {
-                    error_message: format!("Failed to deserialize the genesis records."),
-                }
-            })?;
+        let genesis = serde_json::from_str::<Genesis>(&json_str_without_comments).map_err(|e| {
+            ValidationError::GenesisFileError {
+                error_message: format!("Failed to deserialize the genesis records: {:?}", e),
+            }
+        })?;
 
         genesis.validate(genesis_validation)?;
         Ok(genesis)

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -435,8 +435,8 @@ impl Config {
             &mut serde_json::Deserializer::from_str(&json_str_without_comments),
             |field| unrecognised_fields.push(field.to_string()),
         )
-        .map_err(|_| ValidationError::ConfigFileError {
-            error_message: format!("Failed to deserialize config from {}", path.display()),
+        .map_err(|e| ValidationError::ConfigFileError {
+            error_message: format!("Failed to deserialize config from {}: {:?}", path.display(), e),
         })?;
 
         if !unrecognised_fields.is_empty() {


### PR DESCRIPTION
It's a bit sad to throw away the original error messages, because then it becomes a lot harder to see what the problem is when all you see is "Failed to deserialize config from ~/.near/config.json"