### PR TITLE
increase crate publisher runner’s disk space

### DIFF
--- a/.github/workflows/near_crates_publish.yml
+++ b/.github/workflows/near_crates_publish.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   publish-cargo-crates:
     name: "Publish near-workspaces on crates.io https://crates.io/crates/near-workspaces"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04-16core"
     environment: deploy
     permissions:
       contents: write # required for crates push

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 # Most crates are not stable on purpose, as maintaining API compatibility is a
 # significant developer time expense. Please think thoroughly before adding
 # anything to the list of stable crates.
-version = "0.19.0-pre.1"
+version = "0.19.0-pre.2"
 exclude = ["neard"]
 
 [workspace]


### PR DESCRIPTION
Considering rust compilation is heavily parallelized, increasing the number of cores also means that compilation will go faster by basically this amount, which means no additional charge compared to a smaller large runner.

This should fix [the last crate publishing failure](https://github.com/near/nearcore/actions/runs/7278852375).

Also bump the prerelease version number to be able to attempt a second crate publishing with the new runner straight away.