### PR TITLE
bump unsafe-libyaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7581,9 +7581,9 @@ checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.5"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
+checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
 
 [[package]]
 name = "untrusted"


### PR DESCRIPTION
Fixes https://rustsec.org/advisories/RUSTSEC-2023-0075