### PR TITLE
fix build on nightly

### DIFF
--- a/core/primitives/src/action/mod.rs
+++ b/core/primitives/src/action/mod.rs
@@ -178,9 +178,15 @@ pub enum Action {
     DeleteAccount(DeleteAccountAction),
     Delegate(Box<delegate::SignedDelegateAction>),
 }
+// Note: If this number ever goes down, please adjust the equality accordingly. Otherwise,
+// we would get used to better performance and would be subject to a performance loss should
+// we come back up to 32 bytes later on.
+// If compiling with nightly, this check may fail due to new optimizations introduced by
+// rustc. So, cfg-them out, as our production system only runs with stable.
+#[cfg(not(fuzz))]
 const _: () = assert!(
-    cfg!(not(target_pointer_width = "64")) || std::mem::size_of::<Action>() <= 32,
-    "Action is less than 32 bytes for performance reasons, see #9451"
+    cfg!(not(target_pointer_width = "64")) || std::mem::size_of::<Action>() == 32,
+    "Action is 32 bytes for performance reasons, see #9451"
 );
 
 impl Action {

--- a/core/primitives/src/action/mod.rs
+++ b/core/primitives/src/action/mod.rs
@@ -179,7 +179,7 @@ pub enum Action {
     Delegate(Box<delegate::SignedDelegateAction>),
 }
 const _: () = assert!(
-    cfg!(not(target_pointer_width = "64")) || std::mem::size_of::<Action>() == 32,
+    cfg!(not(target_pointer_width = "64")) || std::mem::size_of::<Action>() <= 32,
     "Action is less than 32 bytes for performance reasons, see #9451"
 );
 


### PR DESCRIPTION
Nightly probably introduced an optimization that further reduces the size of `Action`.

This change should fix [our fuzzer builds](https://github.com/near/nearcore/actions/runs/7287168944/job/19857279411), as well as get us ready for when said nightly optimization will land on master

cc https://github.com/near/near-one-project-tracking/issues/9