### PR TITLE
always set cfg(fuzz) when building for fuzzers

### DIFF
--- a/.github/workflows/master_fuzzer_binaries.yml
+++ b/.github/workflows/master_fuzzer_binaries.yml
@@ -45,5 +45,5 @@ jobs:
       - name: "Compile fuzzers and upload to GCS"
         run: |
           NAME="nearcore-${{ github.ref_name }}-$(env TZ=Etc/UTC  date +"%Y%m%d%H%M%S")"
-          RUSTFLAGS="-A warnings" cargo +nightly bolero build-clusterfuzz --all-features --profile fuzz
+          RUSTFLAGS="-A warnings --cfg fuzz" cargo +nightly bolero build-clusterfuzz --all-features --profile fuzz
           gsutil cp -Z target/fuzz/clusterfuzz.tar "gs://fuzzer_targets/${{ github.ref_name }}/$NAME.tar.gz"

--- a/.github/workflows/ondemand_fuzzer_binaries.yml
+++ b/.github/workflows/ondemand_fuzzer_binaries.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: "Set up GCP SDK"
         uses: "google-github-actions/setup-gcloud@v1"
+        with:
+          version: ">= 416.0.0"
 
       - name: Checkout Release/RC branch
         if: contains(fromJSON('["released", "prereleased"]'), github.event.action)
@@ -79,5 +81,5 @@ jobs:
       - name: "Compile fuzzers and upload to GCS"
         run: |
           NAME="nearcore-$branch_type-$(env TZ=Etc/UTC  date +"%Y%m%d%H%M%S")"
-          cargo +nightly bolero build-clusterfuzz --all-features --profile fuzz
+          RUSTFLAGS="-A warnings --cfg fuzz" cargo +nightly bolero build-clusterfuzz --all-features --profile fuzz
           gsutil cp -Z target/fuzz/clusterfuzz.tar "gs://fuzzer_targets/$branch_type/$NAME.tar.gz"


### PR DESCRIPTION
Due to cargo-bolero first compiling in test mode and then in fuzz mode, #10364 was not actually enough to fix the issues.

With this change, cargo-bolero will always set `--cfg fuzz`, even when compiling in test mode, so that all builds performed with nightly do see the assertion skipped.

Part of https://github.com/near/near-one-project-tracking/issues/9