### PR TITLE
rust: 1.75.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 version = "0.0.0" # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
-rust-version = "1.74.0"
+rust-version = "1.75.0"
 repository = "https://github.com/near/nearcore"
 license = "MIT OR Apache-2.0"
 

--- a/runtime/near-vm/test-api/src/sys/externals/mod.rs
+++ b/runtime/near-vm/test-api/src/sys/externals/mod.rs
@@ -3,9 +3,7 @@ mod global;
 mod memory;
 mod table;
 
-pub use self::function::{
-    FromToNativeWasmType, Function, HostFunction, WasmTypeList, WithEnv, WithoutEnv,
-};
+pub use self::function::{FromToNativeWasmType, Function, WasmTypeList};
 
 pub use self::global::Global;
 pub use self::memory::Memory;

--- a/runtime/near-vm/test-api/src/sys/types.rs
+++ b/runtime/near-vm/test-api/src/sys/types.rs
@@ -3,8 +3,7 @@ use super::store::{Store, StoreObject};
 use near_vm_engine::RuntimeError;
 use near_vm_types::Value;
 pub use near_vm_types::{
-    ExportType, ExternType, FunctionType, GlobalType, MemoryType, Mutability, TableType,
-    Type as ValType,
+    FunctionType, GlobalType, MemoryType, Mutability, TableType, Type as ValType,
 };
 use near_vm_vm::VMFuncRef;
 

--- a/runtime/near-vm/vm/src/mmap.rs
+++ b/runtime/near-vm/vm/src/mmap.rs
@@ -175,8 +175,7 @@ impl Mmap {
         assert_lt!(start, self.len - len);
 
         // Commit the accessible size.
-        let ptr = self.ptr as *const u8;
-        unsafe { region::protect(ptr.add(start), len, region::Protection::READ_WRITE) }
+        unsafe { region::protect(self.as_ptr().add(start), len, region::Protection::READ_WRITE) }
             .map_err(|e| e.to_string())
     }
 
@@ -195,9 +194,10 @@ impl Mmap {
         assert_lt!(start, self.len - len);
 
         // Commit the accessible size.
-        let ptr = self.ptr as *const u8;
-        if unsafe { VirtualAlloc(ptr.add(start) as *mut c_void, len, MEM_COMMIT, PAGE_READWRITE) }
-            .is_null()
+        if unsafe {
+            VirtualAlloc(self.as_ptr().add(start) as *mut c_void, len, MEM_COMMIT, PAGE_READWRITE)
+        }
+        .is_null()
         {
             return Err(io::Error::last_os_error().to_string());
         }
@@ -207,12 +207,12 @@ impl Mmap {
 
     /// Return the allocated memory as a slice of u8.
     pub fn as_slice(&self) -> &[u8] {
-        unsafe { slice::from_raw_parts(self.ptr as *const u8, self.len) }
+        unsafe { slice::from_raw_parts(self.as_ptr(), self.len) }
     }
 
     /// Return the allocated memory as a mutable slice of u8.
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
-        unsafe { slice::from_raw_parts_mut(self.ptr as *mut u8, self.len) }
+        unsafe { slice::from_raw_parts_mut(self.as_mut_ptr(), self.len) }
     }
 
     /// Return the allocated memory as a pointer to u8.

--- a/runtime/runtime-params-estimator/emu-cost/Dockerfile
+++ b/runtime/runtime-params-estimator/emu-cost/Dockerfile
@@ -1,5 +1,5 @@
 # our local base image
-FROM rust:1.74.0
+FROM rust:1.75.0
 
 LABEL description="Container for builds"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,6 +2,6 @@
 # This specifies the version of Rust we use to build.
 # Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
 # The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
-channel = "1.74.0"
+channel = "1.75.0"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
Release notes: https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html

I briefly looked for instances where we could replace our code with the newly added `pointer::byte_` methods, but found nothing of note.