### PR TITLE
feat: Change default shard trie cache size to 500MB

### DIFF
--- a/core/store/src/trie/config.rs
+++ b/core/store/src/trie/config.rs
@@ -7,9 +7,9 @@ use tracing::error;
 
 /// Default memory limit, if nothing else is configured.
 /// It is chosen to correspond roughly to the old limit, which was
-/// 50k entries * TRIE_LIMIT_CACHED_VALUE_SIZE.
+/// 500k entries * TRIE_LIMIT_CACHED_VALUE_SIZE.
 pub(crate) const DEFAULT_SHARD_CACHE_TOTAL_SIZE_LIMIT: u64 =
-    if cfg!(feature = "no_cache") { 1 } else { 50_000_000 };
+    if cfg!(feature = "no_cache") { 1 } else { 500_000_000 };
 
 /// Capacity for the deletions queue.
 /// It is chosen to fit all hashes of deleted nodes for 3 completely full blocks.


### PR DESCRIPTION
Current value is 50MB which might not be enough when the shard is overloaded. One example when this can be an issue is when delayed receipts queue grows to 20k+ items, which already happened during NEAT inscription load. Insufficient cache size results in increased number of disk reads to State rocksdb column. That increases chunk application time which results in more missed chunks.
This only applies to shards 0,1,2 since we have an overwrite for shard 3. So overall expected RAM increase is 3 * (500 - 50) = 1350MB. 