### PR TITLE
lychee: only check checked-in files

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -80,7 +80,7 @@ python-style-checks:
 check-lychee:
     # This is not actually run in CI. GITHUB_TOKEN can still be set locally by people who want
     # to reproduce CI behavior in a better way.
-    lychee . {{ if env("GITHUB_TOKEN", "") != "" { "" } else { "-a 429" } }}
+    git ls-files | grep 'md$\|mkd$\|html\?$' | xargs lychee {{ if env("GITHUB_TOKEN", "") != "" { "" } else { "-a 429" } }}
     @echo {{ if env("GITHUB_TOKEN", "") != "" { "" } \
              else { "Note: 'Too Many Requests' errors are allowed here but not in CI, set GITHUB_TOKEN to check them" } }}
 


### PR DESCRIPTION
In my local environment lychee was crawling through the `target/` directory, which contained a link to a PDF at `dl.acm.org`. Running the test suite one too many times has got me a ban(ana)d off their site.

Conversely having checked lychee's code, it only ever checks links in markdown and html files. So for instance whatever links we might have in our code or docstrings can easily remain broken and we’d be none-the-wiser.

For what it is worth at least for the time being the number of links checked remains the same as before.