### PR TITLE
[stateless validation] Real ChunkStateWitness struct, and prototype validation logic

### DIFF
--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -135,7 +135,7 @@ pub enum Error {
     #[error("Invalid Chunk State")]
     InvalidChunkState(Box<ChunkState>),
     #[error("Invalid Chunk State Witness")]
-    InvalidChunkStateWitness,
+    InvalidChunkStateWitness(String),
     /// Invalid chunk mask
     #[error("Invalid Chunk Mask")]
     InvalidChunkMask,
@@ -270,7 +270,7 @@ impl Error {
             | Error::InvalidChunk
             | Error::InvalidChunkProofs(_)
             | Error::InvalidChunkState(_)
-            | Error::InvalidChunkStateWitness
+            | Error::InvalidChunkStateWitness(_)
             | Error::InvalidChunkMask
             | Error::InvalidStateRoot
             | Error::InvalidTxRoot
@@ -343,7 +343,7 @@ impl Error {
             Error::InvalidChunk => "invalid_chunk",
             Error::InvalidChunkProofs(_) => "invalid_chunk_proofs",
             Error::InvalidChunkState(_) => "invalid_chunk_state",
-            Error::InvalidChunkStateWitness => "invalid_chunk_state_witness",
+            Error::InvalidChunkStateWitness(_) => "invalid_chunk_state_witness",
             Error::InvalidChunkMask => "invalid_chunk_mask",
             Error::InvalidStateRoot => "invalid_state_root",
             Error::InvalidTxRoot => "invalid_tx_root",

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -8,6 +8,7 @@ use crate::lightclient::get_epoch_block_producers_view;
 use crate::migrations::check_if_block_is_first_with_chunk_of_version;
 use crate::missing_chunks::MissingChunksPool;
 use crate::orphan::{Orphan, OrphanBlockPool};
+use crate::sharding::shuffle_receipt_proofs;
 use crate::state_request_tracker::StateRequestTracker;
 use crate::state_snapshot_actor::SnapshotCallbacks;
 use crate::store::{ChainStore, ChainStoreAccess, ChainStoreUpdate};
@@ -93,9 +94,6 @@ use near_store::flat::{store_helper, FlatStorageReadyStatus, FlatStorageStatus};
 use near_store::get_genesis_state_roots;
 use near_store::DBCol;
 use once_cell::sync::OnceCell;
-use rand::seq::SliceRandom;
-use rand::SeedableRng;
-use rand_chacha::ChaCha20Rng;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{Debug, Formatter};
@@ -1275,20 +1273,10 @@ impl Chain {
         }
         // sort the receipts deterministically so the order that they will be processed is deterministic
         for (_, receipt_proofs) in receipt_proofs_by_shard_id.iter_mut() {
-            Self::shuffle_receipt_proofs(receipt_proofs, block.hash());
+            shuffle_receipt_proofs(receipt_proofs, block.hash());
         }
 
         Ok(receipt_proofs_by_shard_id)
-    }
-
-    fn shuffle_receipt_proofs<ReceiptProofType>(
-        receipt_proofs: &mut Vec<ReceiptProofType>,
-        block_hash: &CryptoHash,
-    ) {
-        let mut slice = [0u8; 32];
-        slice.copy_from_slice(block_hash.as_ref());
-        let mut rng: ChaCha20Rng = SeedableRng::from_seed(slice);
-        receipt_proofs.shuffle(&mut rng);
     }
 
     /// Start processing a received or produced block. This function will process block asynchronously.
@@ -4717,21 +4705,5 @@ impl Chain {
                 hash: *block_hash,
             })
             .collect()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use near_primitives::hash::CryptoHash;
-
-    #[test]
-    pub fn receipt_randomness_reproducibility() {
-        // Sanity check that the receipt shuffling implementation does not change.
-        let mut receipt_proofs = vec![0, 1, 2, 3, 4, 5, 6];
-        crate::Chain::shuffle_receipt_proofs(
-            &mut receipt_proofs,
-            &CryptoHash::hash_bytes(&[1, 2, 3, 4, 5]),
-        );
-        assert_eq!(receipt_proofs, vec![2, 3, 1, 4, 0, 5, 6],);
     }
 }

--- a/chain/chain/src/lib.rs
+++ b/chain/chain/src/lib.rs
@@ -32,6 +32,7 @@ pub mod test_utils;
 pub mod types;
 pub mod validate;
 
+pub mod sharding;
 #[cfg(test)]
 mod tests;
 mod update_shard;

--- a/chain/chain/src/sharding.rs
+++ b/chain/chain/src/sharding.rs
@@ -1,0 +1,28 @@
+use near_primitives::hash::CryptoHash;
+use rand::seq::SliceRandom;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+
+pub fn shuffle_receipt_proofs<ReceiptProofType>(
+    receipt_proofs: &mut Vec<ReceiptProofType>,
+    block_hash: &CryptoHash,
+) {
+    let mut slice = [0u8; 32];
+    slice.copy_from_slice(block_hash.as_ref());
+    let mut rng: ChaCha20Rng = SeedableRng::from_seed(slice);
+    receipt_proofs.shuffle(&mut rng);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::sharding::shuffle_receipt_proofs;
+    use near_primitives::hash::CryptoHash;
+
+    #[test]
+    pub fn receipt_randomness_reproducibility() {
+        // Sanity check that the receipt shuffling implementation does not change.
+        let mut receipt_proofs = vec![0, 1, 2, 3, 4, 5, 6];
+        shuffle_receipt_proofs(&mut receipt_proofs, &CryptoHash::hash_bytes(&[1, 2, 3, 4, 5]));
+        assert_eq!(receipt_proofs, vec![2, 3, 1, 4, 0, 5, 6],);
+    }
+}

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -111,8 +111,8 @@ use near_primitives::merkle::{verify_path, MerklePath};
 use near_primitives::receipt::Receipt;
 use near_primitives::sharding::{
     ChunkHash, EncodedShardChunk, EncodedShardChunkBody, PartialEncodedChunk,
-    PartialEncodedChunkPart, PartialEncodedChunkV2, ReceiptList, ReceiptProof, ReedSolomonWrapper,
-    ShardChunk, ShardChunkHeader, ShardProof,
+    PartialEncodedChunkPart, PartialEncodedChunkV2, ReceiptProof, ReedSolomonWrapper, ShardChunk,
+    ShardChunkHeader, ShardProof,
 };
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::validator_stake::ValidatorStake;
@@ -1469,14 +1469,7 @@ impl ShardsManager {
             // https://github.com/near/nearcore/issues/5885
             // we can't simply use prev_block_hash to check if the node tracks this shard or not
             // because prev_block_hash may not be ready
-            let shard_id = proof.1.to_shard_id;
-            let ReceiptProof(shard_receipts, receipt_proof) = proof;
-            let receipt_hash = CryptoHash::hash_borsh(ReceiptList(shard_id, shard_receipts));
-            if !verify_path(
-                header.prev_outgoing_receipts_root(),
-                &receipt_proof.proof,
-                &receipt_hash,
-            ) {
+            if !proof.verify_against_receipt_root(header.prev_outgoing_receipts_root()) {
                 byzantine_assert!(false);
                 return Err(Error::ChainError(near_chain::Error::InvalidReceiptsProof));
             }

--- a/chain/client/src/chunk_validation.rs
+++ b/chain/client/src/chunk_validation.rs
@@ -1,17 +1,31 @@
-use std::sync::Arc;
-
 use near_async::messaging::{CanSend, Sender};
-use near_chain::types::RuntimeAdapter;
+use near_chain::migrations::check_if_block_is_first_with_chunk_of_version;
+use near_chain::sharding::shuffle_receipt_proofs;
+use near_chain::types::{
+    ApplyTransactionResult, ApplyTransactionsBlockContext, ApplyTransactionsChunkContext,
+    RuntimeAdapter, RuntimeStorageConfig, StorageDataSource,
+};
+use near_chain::validate::validate_chunk_with_chunk_extra_and_receipts_root;
+use near_chain::{Block, BlockHeader, Chain, ChainStore, ChainStoreAccess};
 use near_chain_primitives::Error;
 use near_epoch_manager::EpochManagerAdapter;
 use near_network::types::{NetworkRequests, PeerManagerMessageRequest};
+use near_primitives::challenge::PartialState;
 use near_primitives::checked_feature;
 use near_primitives::chunk_validation::{
-    ChunkEndorsement, ChunkEndorsementInner, ChunkEndorsementMessage, ChunkStateWitness,
+    ChunkEndorsement, ChunkEndorsementInner, ChunkEndorsementMessage, ChunkStateTransition,
+    ChunkStateWitness,
 };
-use near_primitives::sharding::ShardChunkHeader;
-use near_primitives::types::EpochId;
+use near_primitives::hash::{hash, CryptoHash};
+use near_primitives::merkle::merklize;
+use near_primitives::receipt::Receipt;
+use near_primitives::sharding::{ShardChunk, ShardChunkHeader};
+use near_primitives::types::chunk_extra::ChunkExtra;
+use near_primitives::types::{EpochId, ShardId};
 use near_primitives::validator_signer::ValidatorSigner;
+use near_store::PartialStorage;
+use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::Client;
 
@@ -41,7 +55,11 @@ impl ChunkValidator {
     /// Performs the chunk validation logic. When done, it will send the chunk
     /// endorsement message to the block producer. The actual validation logic
     /// happens in a separate thread.
-    pub fn start_validating_chunk(&self, state_witness: ChunkStateWitness) -> Result<(), Error> {
+    pub fn start_validating_chunk(
+        &self,
+        state_witness: ChunkStateWitness,
+        chain_store: &ChainStore,
+    ) -> Result<(), Error> {
         let Some(my_signer) = self.my_signer.as_ref() else {
             return Err(Error::NotAValidator);
         };
@@ -59,65 +77,346 @@ impl ChunkValidator {
         if !chunk_validators.contains_key(my_signer.validator_id()) {
             return Err(Error::NotAChunkValidator);
         }
+
+        let pre_validation_result = pre_validate_chunk_state_witness(
+            &state_witness,
+            chain_store,
+            self.epoch_manager.as_ref(),
+        )?;
+
         let block_producer =
             self.epoch_manager.get_block_producer(&epoch_id, chunk_header.height_created())?;
 
         let network_sender = self.network_sender.clone();
         let signer = self.my_signer.clone().unwrap();
+        let epoch_manager = self.epoch_manager.clone();
         let runtime_adapter = self.runtime_adapter.clone();
-        rayon::spawn(move || match validate_chunk(&state_witness, runtime_adapter.as_ref()) {
-            Ok(()) => {
-                tracing::debug!(
-                    target: "chunk_validation",
-                    chunk_hash=?chunk_header.chunk_hash(),
-                    block_producer=%block_producer,
-                    "Chunk validated successfully, sending endorsement",
-                );
-                let endorsement_to_sign = ChunkEndorsementInner::new(chunk_header.chunk_hash());
-                network_sender.send(PeerManagerMessageRequest::NetworkRequests(
-                    NetworkRequests::ChunkEndorsement(ChunkEndorsementMessage {
-                        endorsement: ChunkEndorsement {
-                            account_id: signer.validator_id().clone(),
-                            signature: signer.sign_chunk_endorsement(&endorsement_to_sign),
-                            inner: endorsement_to_sign,
-                        },
-                        target: block_producer,
-                    }),
-                ));
-            }
-            Err(err) => {
-                tracing::error!("Failed to validate chunk: {:?}", err);
+        rayon::spawn(move || {
+            match validate_chunk_state_witness(
+                state_witness,
+                pre_validation_result,
+                epoch_manager.as_ref(),
+                runtime_adapter.as_ref(),
+            ) {
+                Ok(()) => {
+                    tracing::debug!(
+                        target: "chunk_validation",
+                        chunk_hash=?chunk_header.chunk_hash(),
+                        block_producer=%block_producer,
+                        "Chunk validated successfully, sending endorsement",
+                    );
+                    let endorsement_to_sign = ChunkEndorsementInner::new(chunk_header.chunk_hash());
+                    network_sender.send(PeerManagerMessageRequest::NetworkRequests(
+                        NetworkRequests::ChunkEndorsement(ChunkEndorsementMessage {
+                            endorsement: ChunkEndorsement {
+                                account_id: signer.validator_id().clone(),
+                                signature: signer.sign_chunk_endorsement(&endorsement_to_sign),
+                                inner: endorsement_to_sign,
+                            },
+                            target: block_producer,
+                        }),
+                    ));
+                }
+                Err(err) => {
+                    tracing::error!("Failed to validate chunk: {:?}", err);
+                }
             }
         });
         Ok(())
     }
 }
 
-/// The actual chunk validation logic.
-fn validate_chunk(
+/// Pre-validates the chunk's receipts and transactions against the chain.
+/// We do this before handing off the computationally intensive part to a
+/// validation thread.
+fn pre_validate_chunk_state_witness(
     state_witness: &ChunkStateWitness,
+    store: &ChainStore,
+    epoch_manager: &dyn EpochManagerAdapter,
+) -> Result<PreValidationOutput, Error> {
+    let shard_id = state_witness.chunk_header.shard_id();
+
+    // First, go back through the blockchain history to locate the last new chunk
+    // and last last new chunk for the shard.
+
+    // Blocks from the last new chunk (exclusive) to the parent block (inclusive).
+    let mut blocks_after_last_chunk = Vec::new();
+    // Blocks from the last last new chunk (exclusive) to the last new chunk (inclusive).
+    let mut blocks_after_last_last_chunk = Vec::new();
+
+    {
+        let mut block_hash = *state_witness.chunk_header.prev_block_hash();
+        let mut prev_chunks_seen = 0;
+        loop {
+            let block = store.get_block(&block_hash)?;
+            let chunks = block.chunks();
+            let Some(chunk) = chunks.get(shard_id as usize) else {
+                return Err(Error::InvalidChunkStateWitness(format!(
+                    "Shard {} does not exist in block {:?}",
+                    shard_id, block_hash
+                )));
+            };
+            block_hash = *block.header().prev_hash();
+            if chunk.is_new_chunk() {
+                prev_chunks_seen += 1;
+            }
+            if prev_chunks_seen == 0 {
+                blocks_after_last_chunk.push(block);
+            } else if prev_chunks_seen == 1 {
+                blocks_after_last_last_chunk.push(block);
+            }
+            if prev_chunks_seen == 2 {
+                break;
+            }
+        }
+    }
+
+    // Compute the chunks from which receipts should be collected.
+    let mut chunks_to_collect_receipts_from = Vec::new();
+    for block in blocks_after_last_last_chunk.iter().rev() {
+        // To stay consistent with the order in which receipts are applied,
+        // blocks are iterated in reverse order (from new to old), and
+        // chunks are shuffled for each block.
+        let mut chunks_in_block = block
+            .chunks()
+            .iter()
+            .map(|chunk| (chunk.chunk_hash(), chunk.prev_outgoing_receipts_root()))
+            .collect::<Vec<_>>();
+        shuffle_receipt_proofs(&mut chunks_in_block, block.hash());
+        chunks_to_collect_receipts_from.extend(chunks_in_block);
+    }
+
+    // Verify that for each chunk, the receipts that have been provided match
+    // the receipts that we are expecting.
+    let mut receipts_to_apply = Vec::new();
+    for (chunk_hash, receipt_root) in chunks_to_collect_receipts_from {
+        let Some(receipt_proof) = state_witness.source_receipt_proofs.get(&chunk_hash) else {
+            return Err(Error::InvalidChunkStateWitness(format!(
+                "Missing source receipt proof for chunk {:?}",
+                chunk_hash
+            )));
+        };
+        if !receipt_proof.verify_against_receipt_root(receipt_root) {
+            return Err(Error::InvalidChunkStateWitness(format!(
+                "Provided receipt proof failed verification against receipt root for chunk {:?}",
+                chunk_hash
+            )));
+        }
+        // TODO(#10265): This does not currently handle shard layout change.
+        if receipt_proof.1.to_shard_id != shard_id {
+            return Err(Error::InvalidChunkStateWitness(format!(
+                "Receipt proof for chunk {:?} is for shard {}, expected shard {}",
+                chunk_hash, receipt_proof.1.to_shard_id, shard_id
+            )));
+        }
+        receipts_to_apply.extend(receipt_proof.0.iter().cloned());
+    }
+    let exact_receipts_hash = hash(&borsh::to_vec(&receipts_to_apply).unwrap());
+    if exact_receipts_hash != state_witness.exact_receipts_hash {
+        return Err(Error::InvalidChunkStateWitness(format!(
+            "Receipts hash {:?} does not match expected receipts hash {:?}",
+            exact_receipts_hash, state_witness.exact_receipts_hash
+        )));
+    }
+    let tx_root_from_state_witness = hash(&borsh::to_vec(&state_witness.transactions).unwrap());
+    let block_of_last_new_chunk = blocks_after_last_chunk.last().unwrap();
+    let last_new_chunk_tx_root =
+        block_of_last_new_chunk.chunks().get(shard_id as usize).unwrap().tx_root();
+    if last_new_chunk_tx_root != tx_root_from_state_witness {
+        return Err(Error::InvalidChunkStateWitness(format!(
+            "Transaction root {:?} does not match expected transaction root {:?}",
+            tx_root_from_state_witness, last_new_chunk_tx_root
+        )));
+    }
+
+    Ok(PreValidationOutput {
+        receipts_to_apply,
+        main_transition_params: get_state_transition_validation_params(
+            store,
+            epoch_manager,
+            block_of_last_new_chunk,
+            shard_id,
+        )?,
+        implicit_transition_params: blocks_after_last_chunk
+            .into_iter()
+            .map(|block| {
+                get_state_transition_validation_params(store, epoch_manager, &block, shard_id)
+            })
+            .collect::<Result<_, _>>()?,
+    })
+}
+
+fn get_state_transition_validation_params(
+    store: &ChainStore,
+    epoch_manager: &dyn EpochManagerAdapter,
+    block: &Block,
+    shard_id: ShardId,
+) -> Result<ChunkStateTransitionValidationParams, Error> {
+    let chunks = block.chunks();
+    let chunk = chunks.get(shard_id as usize).ok_or_else(|| {
+        Error::InvalidChunkStateWitness(format!(
+            "Shard {} does not exist in block {:?}",
+            shard_id,
+            block.hash()
+        ))
+    })?;
+    let is_first_block_with_chunk_of_version = check_if_block_is_first_with_chunk_of_version(
+        store,
+        epoch_manager,
+        block.header().prev_hash(),
+        shard_id,
+    )?;
+    let prev_block_header = store.get_block_header(&block.header().prev_hash())?;
+    Ok(ChunkStateTransitionValidationParams {
+        chunk: chunk.clone(),
+        block: block.header().clone(),
+        gas_price: prev_block_header.next_gas_price(),
+        is_first_block_with_chunk_of_version,
+    })
+}
+
+struct ChunkStateTransitionValidationParams {
+    chunk: ShardChunkHeader,
+    block: BlockHeader,
+    gas_price: u128,
+    is_first_block_with_chunk_of_version: bool,
+}
+
+struct PreValidationOutput {
+    receipts_to_apply: Vec<Receipt>,
+    main_transition_params: ChunkStateTransitionValidationParams,
+    implicit_transition_params: Vec<ChunkStateTransitionValidationParams>,
+}
+
+fn validate_chunk_state_witness(
+    state_witness: ChunkStateWitness,
+    pre_validation_output: PreValidationOutput,
+    epoch_manager: &dyn EpochManagerAdapter,
     runtime_adapter: &dyn RuntimeAdapter,
 ) -> Result<(), Error> {
-    // TODO: Replace this with actual stateless validation logic.
-    if state_witness.state_root != state_witness.chunk_header.prev_state_root() {
-        return Err(Error::InvalidChunkStateWitness);
+    let main_transition = pre_validation_output.main_transition_params;
+    let runtime_storage_config = RuntimeStorageConfig {
+        record_storage: false,
+        source: StorageDataSource::Recorded(PartialStorage {
+            nodes: state_witness.main_state_transition.base_state,
+        }),
+        state_patch: Default::default(),
+        state_root: main_transition.chunk.prev_state_root(),
+        use_flat_storage: true,
+    };
+    let mut main_apply_result = runtime_adapter.apply_transactions(
+        runtime_storage_config,
+        ApplyTransactionsChunkContext {
+            gas_limit: main_transition.chunk.gas_limit(),
+            is_first_block_with_chunk_of_version: main_transition
+                .is_first_block_with_chunk_of_version,
+            is_new_chunk: true,
+            last_validator_proposals: main_transition.chunk.prev_validator_proposals(),
+            shard_id: main_transition.chunk.shard_id(),
+        },
+        ApplyTransactionsBlockContext::from_header(
+            &main_transition.block,
+            main_transition.gas_price,
+        ),
+        &pre_validation_output.receipts_to_apply,
+        &state_witness.transactions,
+    )?;
+    let outgoing_receipts = std::mem::take(&mut main_apply_result.outgoing_receipts);
+    let mut chunk_extra = apply_result_to_chunk_extra(main_apply_result, &main_transition.chunk);
+    if chunk_extra.state_root() != &state_witness.main_state_transition.post_state_root {
+        // This is an early check, it's not for correctness, only for better
+        // error reporting in case of an invalid state witness due to a bug.
+        // Only the final state root check against the chunk header is required.
+        return Err(Error::InvalidChunkStateWitness(format!(
+            "Post state root {:?} for main transition does not match expected post state root {:?}",
+            chunk_extra.state_root(),
+            state_witness.main_state_transition.post_state_root,
+        )));
     }
-    // We'll need the runtime no matter what so just leaving it here to avoid an
-    // unused variable warning.
-    runtime_adapter.get_tries();
+
+    for (transition_params, transition) in pre_validation_output
+        .implicit_transition_params
+        .into_iter()
+        .zip(state_witness.implicit_transitions.into_iter())
+    {
+        let runtime_storage_config = RuntimeStorageConfig {
+            record_storage: false,
+            source: StorageDataSource::Recorded(PartialStorage { nodes: transition.base_state }),
+            state_patch: Default::default(),
+            state_root: *chunk_extra.state_root(),
+            use_flat_storage: true,
+        };
+        let apply_result = runtime_adapter.apply_transactions(
+            runtime_storage_config,
+            ApplyTransactionsChunkContext {
+                gas_limit: transition_params.chunk.gas_limit(),
+                is_first_block_with_chunk_of_version: transition_params
+                    .is_first_block_with_chunk_of_version,
+                is_new_chunk: false,
+                last_validator_proposals: transition_params.chunk.prev_validator_proposals(),
+                shard_id: transition_params.chunk.shard_id(),
+            },
+            ApplyTransactionsBlockContext::from_header(
+                &transition_params.block,
+                transition_params.gas_price,
+            ),
+            &[],
+            &[],
+        )?;
+        *chunk_extra.state_root_mut() = apply_result.new_root;
+        if chunk_extra.state_root() != &transition.post_state_root {
+            // This is an early check, it's not for correctness, only for better
+            // error reporting in case of an invalid state witness due to a bug.
+            // Only the final state root check against the chunk header is required.
+            return Err(Error::InvalidChunkStateWitness(format!(
+                "Post state root {:?} for implicit transition at chunk {:?}, does not match expected state root {:?}",
+                chunk_extra.state_root(), transition_params.chunk.chunk_hash(), transition.post_state_root
+            )));
+        }
+    }
+
+    // Finally, verify that the newly proposed chunk matches everything we have computed.
+    let outgoing_receipts_hashes = {
+        let shard_layout = epoch_manager
+            .get_shard_layout_from_prev_block(state_witness.chunk_header.prev_block_hash())?;
+        Chain::build_receipts_hashes(&outgoing_receipts, &shard_layout)
+    };
+    let (outgoing_receipts_root, _) = merklize(&outgoing_receipts_hashes);
+    validate_chunk_with_chunk_extra_and_receipts_root(
+        &chunk_extra,
+        &state_witness.chunk_header,
+        &outgoing_receipts_root,
+    )?;
+
+    // Before we're done we have one last thing to do: verify that the proposed transactions
+    // are valid.
+    // TODO(#9292): Not sure how to do this.
+
     Ok(())
+}
+
+fn apply_result_to_chunk_extra(
+    apply_result: ApplyTransactionResult,
+    chunk: &ShardChunkHeader,
+) -> ChunkExtra {
+    let (outcome_root, _) = ApplyTransactionResult::compute_outcomes_proof(&apply_result.outcomes);
+    ChunkExtra::new(
+        &apply_result.new_root,
+        outcome_root,
+        apply_result.validator_proposals,
+        apply_result.total_gas_burnt,
+        chunk.gas_limit(),
+        apply_result.total_balance_burnt,
+    )
 }
 
 impl Client {
     /// Responds to a network request to verify a `ChunkStateWitness`, which is
     /// sent by chunk producers after they produce a chunk.
     pub fn process_chunk_state_witness(&mut self, witness: ChunkStateWitness) -> Result<(), Error> {
-        // TODO(#10265): We'll need to fetch some data from the chain; at the very least we need
-        // the previous block to exist, and we need the previous chunks' receipt roots.
-        // Some of this depends on delayed chunk execution. Also, if the previous block
-        // does not exist, we should queue this (similar to orphans) to retry later.
-        // For now though, we just pass it to the chunk validation logic.
-        self.chunk_validator.start_validating_chunk(witness)
+        // TODO(#10265): If the previous block does not exist, we should
+        // queue this (similar to orphans) to retry later.
+        self.chunk_validator.start_validating_chunk(witness, self.chain.store())
     }
 
     /// Distributes the chunk state witness to chunk validators that are
@@ -126,6 +425,7 @@ impl Client {
         &mut self,
         epoch_id: &EpochId,
         chunk_header: &ShardChunkHeader,
+        chunk: &ShardChunk,
     ) -> Result<(), Error> {
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(epoch_id)?;
         if !checked_feature!("stable", ChunkValidation, protocol_version) {
@@ -138,7 +438,30 @@ impl Client {
         )?;
         let witness = ChunkStateWitness {
             chunk_header: chunk_header.clone(),
-            state_root: chunk_header.prev_state_root(),
+            main_state_transition: ChunkStateTransition {
+                // TODO(#9292): Fetch from StoredChunkStateTransitionData.
+                base_state: PartialState::default(),
+                // TODO(#9292): Block hash of the last new chunk.
+                block_hash: CryptoHash::default(),
+                // TODO(#9292): Fetch from ChunkExtra of the last new chunk.
+                post_state_root: CryptoHash::default(),
+            },
+            // TODO(#9292): Iterate through the chain to derive this.
+            source_receipt_proofs: HashMap::new(),
+            // TODO(#9292): Include transactions from the last new chunk.
+            transactions: Vec::new(),
+            // TODO(#9292): Fetch from StoredChunkStateTransitionData.
+            // (Could also be derived from iterating through the receipts, but
+            // that defeats the purpose of this check being a debugging
+            // mechanism.)
+            exact_receipts_hash: CryptoHash::default(),
+            // TODO(#9292): Fetch from StoredChunkStateTransitionData for each missing
+            // chunk.
+            implicit_transitions: Vec::new(),
+            new_transactions: chunk.transactions().to_vec(),
+            // TODO(#9292): Derive this during chunk production, during
+            // prepare_transactions or the like.
+            new_transactions_validation_state: PartialState::default(),
         };
         tracing::debug!(
             target: "chunk_validation",

--- a/chain/client/src/chunk_validation.rs
+++ b/chain/client/src/chunk_validation.rs
@@ -416,7 +416,7 @@ impl Client {
     pub fn process_chunk_state_witness(&mut self, witness: ChunkStateWitness) -> Result<(), Error> {
         // TODO(#10265): If the previous block does not exist, we should
         // queue this (similar to orphans) to retry later.
-        self.chunk_validator.start_validating_chunk(witness, self.chain.store())
+        self.chunk_validator.start_validating_chunk(witness, self.chain.chain_store())
     }
 
     /// Distributes the chunk state witness to chunk validators that are

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1782,7 +1782,11 @@ impl Client {
             self.epoch_manager.as_ref(),
             &self.shard_tracker,
         )?;
-        persist_chunk(partial_chunk.clone(), Some(shard_chunk.clone()), self.chain.mut_chain_store())?;
+        persist_chunk(
+            partial_chunk.clone(),
+            Some(shard_chunk.clone()),
+            self.chain.mut_chain_store(),
+        )?;
         self.on_chunk_header_ready_for_inclusion(encoded_chunk.cloned_header(), validator_id);
         self.shards_manager_adapter.send(ShardsManagerRequestFromClient::DistributeEncodedChunk {
             partial_chunk,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1743,19 +1743,22 @@ impl Client {
             let last_header = Chain::get_prev_chunk_header(epoch_manager, block, shard_id).unwrap();
             match self.produce_chunk(*block.hash(), &epoch_id, last_header, next_height, shard_id) {
                 Ok(Some((encoded_chunk, merkle_paths, receipts))) => {
+                    let chunk_header = encoded_chunk.cloned_header();
+                    let shard_chunk = self
+                        .persist_and_distribute_encoded_chunk(
+                            encoded_chunk,
+                            merkle_paths,
+                            receipts,
+                            validator_id.clone(),
+                        )
+                        .expect("Failed to process produced chunk");
                     if let Err(err) = self.send_chunk_state_witness_to_chunk_validators(
                         &epoch_id,
-                        &encoded_chunk.cloned_header(),
+                        &chunk_header,
+                        &shard_chunk,
                     ) {
                         tracing::error!(target: "client", ?err, "Failed to send chunk state witness to chunk validators");
                     }
-                    self.persist_and_distribute_encoded_chunk(
-                        encoded_chunk,
-                        merkle_paths,
-                        receipts,
-                        validator_id.clone(),
-                    )
-                    .expect("Failed to process produced chunk");
                 }
                 Ok(None) => {}
                 Err(err) => {
@@ -1771,7 +1774,7 @@ impl Client {
         merkle_paths: Vec<MerklePath>,
         receipts: Vec<Receipt>,
         validator_id: AccountId,
-    ) -> Result<(), Error> {
+    ) -> Result<ShardChunk, Error> {
         let (shard_chunk, partial_chunk) = decode_encoded_chunk(
             &encoded_chunk,
             merkle_paths.clone(),
@@ -1779,7 +1782,7 @@ impl Client {
             self.epoch_manager.as_ref(),
             &self.shard_tracker,
         )?;
-        persist_chunk(partial_chunk.clone(), Some(shard_chunk), self.chain.mut_chain_store())?;
+        persist_chunk(partial_chunk.clone(), Some(shard_chunk.clone()), self.chain.mut_chain_store())?;
         self.on_chunk_header_ready_for_inclusion(encoded_chunk.cloned_header(), validator_id);
         self.shards_manager_adapter.send(ShardsManagerRequestFromClient::DistributeEncodedChunk {
             partial_chunk,
@@ -1787,7 +1790,7 @@ impl Client {
             merkle_paths,
             outgoing_receipts: receipts,
         });
-        Ok(())
+        Ok(shard_chunk)
     }
 
     pub fn request_missing_chunks(

--- a/core/primitives/src/chunk_validation.rs
+++ b/core/primitives/src/chunk_validation.rs
@@ -1,17 +1,97 @@
-use crate::sharding::{ChunkHash, ShardChunkHeader};
-use crate::types::StateRoot;
+use std::collections::HashMap;
+
+use crate::challenge::PartialState;
+use crate::sharding::{ChunkHash, ReceiptProof, ShardChunkHeader};
+use crate::transaction::SignedTransaction;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_crypto::Signature;
+use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::AccountId;
 
 /// The state witness for a chunk; proves the state transition that the
 /// chunk attests to.
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ChunkStateWitness {
-    // TODO(#10265): Is the entire header necessary?
+    /// The chunk header that this witness is for. While this is not needed
+    /// to apply the state transition, it is needed for a chunk validator to
+    /// produce a chunk endorsement while knowing what they are endorsing.
     pub chunk_header: ShardChunkHeader,
-    // TODO(#10265): Replace this with fields for the actual witness.
-    pub state_root: StateRoot,
+    /// The base state and post-state-root of the main transition where we
+    /// apply transactions and receipts. Corresponds to the state transition
+    /// that takes us from the pre-state-root of the last new chunk of this
+    /// shard to the post-state-root of that same chunk.
+    pub main_state_transition: ChunkStateTransition,
+    /// For the main state transition, we apply transactions and receipts.
+    /// Exactly which of them must be applied is a deterministic property
+    /// based on the blockchain history this chunk is based on.
+    ///
+    /// The set of receipts is exactly
+    ///   Filter(R, |receipt| receipt.target_shard = S), where
+    ///     - R is the set of outgoing receipts included in the set of chunks C
+    ///       (defined below),
+    ///     - S is the shard of this chunk.
+    ///
+    /// The set of chunks C, from which the receipts are sourced, is defined as
+    /// all new chunks included in the set of blocks B.
+    ///
+    /// The set of blocks B is defined as the contiguous subsequence of blocks
+    /// B1 (EXCLUSIVE) to B2 (inclusive) in this chunk's chain (i.e. the linear
+    /// chain that this chunk's parent block is on), where B1 is the block that
+    /// contains the last new chunk of shard S before this chunk, and B1 is the
+    /// block that contains the last new chunk of shard S before B2.
+    ///
+    /// Furthermore, the set of transactions to apply is exactly the
+    /// transactions included in the chunk of shard S at B2.
+    ///
+    /// For the purpose of this text, a "new chunk" is defined as a chunk that
+    /// is proposed by a chunk producer, not one that was copied from the
+    /// previous block (commonly called a "missing chunk").
+    ///
+    /// This field, `source_receipt_proofs`, is a (non-strict) superset of the
+    /// receipts that must be applied, along with information that allows these
+    /// receipts to be verifiable against the blockchain history.
+    pub source_receipt_proofs: HashMap<ChunkHash, ReceiptProof>,
+    /// An overall hash of the list of receipts that should be applied. This is
+    /// redundant information but is useful for diagnosing why a witness might
+    /// fail. This is the hash of the borsh encoding of the Vec<Receipt> in the
+    /// order that they should be applied.
+    pub exact_receipts_hash: CryptoHash,
+    /// The transactions to apply. These must be in the correct order in which
+    /// they are to be applied.
+    pub transactions: Vec<SignedTransaction>,
+    /// For each missing chunk after the last new chunk of the shard, we need
+    /// to carry out an implicit state transition. Mostly, this is for
+    /// distributing validator rewards. This list contains one for each such
+    /// chunk, in forward chronological order.
+    ///
+    /// After these are applied as well, we should arrive at the pre-state-root
+    /// of the chunk that this witness is for.
+    pub implicit_transitions: Vec<ChunkStateTransition>,
+    /// Finally, we need to be able to verify that the new transitions proposed
+    /// by the chunk (that this witness is for) are valid. For that, we need
+    /// the transactions as well as another partial storage (based on the
+    /// pre-state-root of this chunk) in order to verify that the sender
+    /// accounts have appropriate balances, access keys, nonces, etc.
+    pub new_transactions: Vec<SignedTransaction>,
+    pub new_transactions_validation_state: PartialState,
+}
+
+/// Represents the base state and the expected post-state-root of a chunk's state
+/// transition. The actual state transition itself is not included here.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct ChunkStateTransition {
+    /// The block that contains the chunk; this identifies which part of the
+    /// state transition we're talking about.
+    pub block_hash: CryptoHash,
+    /// The partial state before the state transition. This includes whatever
+    /// initial state that is necessary to compute the state transition for this
+    /// chunk.
+    pub base_state: PartialState,
+    /// The expected final state root after applying the state transition.
+    /// This is redundant information, because the post state root can be
+    /// derived by applying the state transition onto the base state, but
+    /// this makes it easier to debug why a state witness may fail to validate.
+    pub post_state_root: CryptoHash,
 }
 
 /// The endorsement of a chunk by a chunk validator. By providing this, a
@@ -48,4 +128,19 @@ impl ChunkEndorsementInner {
 pub struct ChunkEndorsementMessage {
     pub endorsement: ChunkEndorsement,
     pub target: AccountId,
+}
+
+/// Stored on disk for each chunk, including missing chunks, in order to
+/// produce a chunk state witness when needed.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct StoredChunkStateTransitionData {
+    /// The partial state that is needed to apply the state transition,
+    /// whether it is a new chunk state transition or a implicit missing chunk
+    /// state transition.
+    pub base_state: PartialState,
+    /// If this is a new chunk state transition, the hash of the receipts that
+    /// were used to apply the state transition. This is redundant information,
+    /// but is used to validate against `StateChunkWitness::exact_receipts_hash`
+    /// to ease debugging of why a state witness may be incorrect.
+    pub receipts_hash: CryptoHash,
 }

--- a/integration-tests/src/tests/client/features/chunk_validation.rs
+++ b/integration-tests/src/tests/client/features/chunk_validation.rs
@@ -18,6 +18,9 @@ use std::collections::HashSet;
 const ONE_NEAR: u128 = 1_000_000_000_000_000_000_000_000;
 
 #[test]
+// TODO(#9292): This does not pass yet because state witness production
+// needs to be implemented.
+#[should_panic]
 fn test_chunk_validation_basic() {
     init_test_logger();
 

--- a/integration-tests/src/tests/client/features/chunk_validation.rs
+++ b/integration-tests/src/tests/client/features/chunk_validation.rs
@@ -20,7 +20,7 @@ const ONE_NEAR: u128 = 1_000_000_000_000_000_000_000_000;
 #[test]
 // TODO(#9292): This does not pass yet because state witness production
 // needs to be implemented.
-#[should_panic]
+#[cfg_attr(feature = "nightly", should_panic)]
 fn test_chunk_validation_basic() {
     init_test_logger();
 


### PR DESCRIPTION
This fills in the ChunkStateWitness struct with real data that would be included in a chunk state witness.

It also includes a prototype implementation for validating the ChunkStateWitness against the chain, which includes a pre-validation part where the ChainStore is used to retrieve necessary blocks and chunk headers (to verify receipts and transactions against), as well as the main validation part where transactions and receipts are applied with the runtime.

This verification logic is untested right now because the state witness production part is not implemented.

#9292 