### PR TITLE
add some swap to avoid memory fragmentation

### DIFF
--- a/.github/workflows/master_fuzzer_binaries.yml
+++ b/.github/workflows/master_fuzzer_binaries.yml
@@ -14,6 +14,11 @@ jobs:
       id-token: "write"
 
     steps:
+      - run: sudo fallocate -l 128G /swap-file
+      - run: sudo chmod 600 /swap-file
+      - run: sudo mkswap /swap-file
+      - run: sudo swapon /swap-file
+
       - id: "auth"
         uses: "google-github-actions/auth@v1"
         with:

--- a/.github/workflows/ondemand_fuzzer_binaries.yml
+++ b/.github/workflows/ondemand_fuzzer_binaries.yml
@@ -30,6 +30,11 @@ jobs:
       id-token: "write"
 
     steps:
+      - run: sudo fallocate -l 128G /swap-file
+      - run: sudo chmod 600 /swap-file
+      - run: sudo mkswap /swap-file
+      - run: sudo swapon /swap-file
+
       - id: "auth"
         uses: "google-github-actions/auth@v1"
         with:


### PR DESCRIPTION
This should hopefully fail failing builds like https://github.com/near/nearcore/actions/runs/7410527434/job/20163048488

My guess is this issue is not actually OOM, but memory fragmentation, because AFAIR larger github runners don’t have any swap.

Adding just a bit of swap would thus likely solve the issue, but we have 1.2T of disk space, so we may as well add quite a bit so that linux can do whatever it wants to be faster.

Part of https://github.com/near/near-one-project-tracking/issues/9