### PR TITLE
feat(amend-genesis): allow setting the gas price

### DIFF
--- a/tools/amend-genesis/src/cli.rs
+++ b/tools/amend-genesis/src/cli.rs
@@ -68,6 +68,12 @@ pub struct AmendGenesisCommand {
     /// on accounts in the output state
     #[clap(long)]
     num_extra_bytes_record: Option<u64>,
+    /// min_gas_price to set in the output genesis file
+    #[clap(long)]
+    min_gas_price: Option<u128>,
+    /// max_gas_price to set in the output genesis file
+    #[clap(long)]
+    max_gas_price: Option<u128>,
 }
 
 impl AmendGenesisCommand {
@@ -81,6 +87,8 @@ impl AmendGenesisCommand {
             protocol_reward_rate: self.protocol_reward_rate,
             block_producer_kickout_threshold: self.block_producer_kickout_threshold,
             chunk_producer_kickout_threshold: self.chunk_producer_kickout_threshold,
+            min_gas_price: self.min_gas_price,
+            max_gas_price: self.max_gas_price,
         };
         crate::amend_genesis(
             &self.genesis_file_in,

--- a/tools/amend-genesis/src/lib.rs
+++ b/tools/amend-genesis/src/lib.rs
@@ -254,6 +254,8 @@ pub struct GenesisChanges {
     pub protocol_reward_rate: Option<Rational32>,
     pub block_producer_kickout_threshold: Option<u8>,
     pub chunk_producer_kickout_threshold: Option<u8>,
+    pub min_gas_price: Option<Balance>,
+    pub max_gas_price: Option<Balance>,
 }
 
 /// Amend a genesis/records file created by `dump-state`.
@@ -376,6 +378,12 @@ pub fn amend_genesis(
     }
     if let Some(t) = genesis_changes.chunk_producer_kickout_threshold {
         genesis.config.chunk_producer_kickout_threshold = t;
+    }
+    if let Some(p) = genesis_changes.min_gas_price {
+        genesis.config.min_gas_price = p;
+    }
+    if let Some(p) = genesis_changes.max_gas_price {
+        genesis.config.max_gas_price = p;
     }
     genesis.to_file(genesis_file_out);
     records_seq.end()?;


### PR DESCRIPTION
After https://github.com/near/NEPs/issues/92, the min gas price was set to 100M yoctoNEAR. But the genesis file we get from the state viewer dump-state command copies the 1B min gas price from the genesis file. This results in a network with 10x the gas fees as mainnet when we launch mocknet testing networks, and many transactions sent by the mirror run command fail with too little balance. So this PR allows setting the min/max gas prices in the mocknet genesis file so we can fix that. It might also be worth changing the behavior of `view-state dump-state` to set the min gas price, but this will work for now and lets us get the right gas price in all cases