### PR TITLE
refactor: rename runtime apply_transactions -> apply_chunk

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -13,8 +13,8 @@ use crate::state_snapshot_actor::SnapshotCallbacks;
 use crate::store::{ChainStore, ChainStoreAccess, ChainStoreUpdate};
 
 use crate::types::{
-    AcceptedBlock, ApplyTransactionResult, ApplyTransactionsBlockContext, BlockEconomicsConfig,
-    ChainConfig, RuntimeAdapter, StorageDataSource,
+    AcceptedBlock, ApplyChunkBlockContext, ApplyChunkResult, BlockEconomicsConfig, ChainConfig,
+    RuntimeAdapter, StorageDataSource,
 };
 use crate::update_shard::{
     apply_new_chunk, process_missing_chunks_range, process_shard_update, NewChunkData,
@@ -2878,12 +2878,12 @@ impl Chain {
 
     /// For given pair of block headers and shard id, return information about
     /// block necessary for processing shard update.
-    fn get_apply_transactions_block_context(
+    fn get_apply_chunk_block_context(
         &self,
         block_header: &BlockHeader,
         prev_block_header: &BlockHeader,
         is_new_chunk: bool,
-    ) -> Result<ApplyTransactionsBlockContext, Error> {
+    ) -> Result<ApplyChunkBlockContext, Error> {
         let epoch_id = block_header.epoch_id();
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(epoch_id)?;
         // Before `FixApplyChunks` feature, gas price was taken from current
@@ -2896,7 +2896,7 @@ impl Chain {
             prev_block_header.next_gas_price()
         };
 
-        Ok(ApplyTransactionsBlockContext::from_header(block_header, gas_price))
+        Ok(ApplyChunkBlockContext::from_header(block_header, gas_price))
     }
 
     fn block_catch_up_postprocess(
@@ -3296,7 +3296,7 @@ impl Chain {
         let cares_about_shard_next_epoch =
             self.shard_tracker.will_care_about_shard(me.as_ref(), prev_hash, shard_id, true);
         let will_shard_layout_change = self.epoch_manager.will_shard_layout_change(prev_hash)?;
-        let should_apply_transactions = get_should_apply_transactions(
+        let should_apply_chunk = get_should_apply_chunk(
             mode,
             cares_about_shard_this_epoch,
             cares_about_shard_next_epoch,
@@ -3307,7 +3307,7 @@ impl Chain {
             shard_uid,
             cares_about_shard_this_epoch,
             will_shard_layout_change,
-            should_apply_transactions,
+            should_apply_chunk,
             need_to_reshard,
         })
     }
@@ -3330,16 +3330,16 @@ impl Chain {
         let shard_context = self.get_shard_context(me, block.header(), shard_id, mode)?;
 
         // We can only perform resharding when states are ready, i.e., mode != ApplyChunksMode::NotCaughtUp
-        // 1) if should_apply_transactions == true && resharding_state_roots.is_some(),
+        // 1) if should_apply_chunk == true && resharding_state_roots.is_some(),
         //     that means children shards are ready.
         //    `apply_resharding_state_changes` will apply updates to the children shards
-        // 2) if should_apply_transactions == true && resharding_state_roots.is_none(),
+        // 2) if should_apply_chunk == true && resharding_state_roots.is_none(),
         //     that means children shards are not ready yet.
         //    `apply_resharding_state_changes` will return `state_changes_for_resharding`,
         //     which will be stored to the database in `process_apply_chunks`
-        // 3) if should_apply_transactions == false && resharding_state_roots.is_some()
+        // 3) if should_apply_chunk == false && resharding_state_roots.is_some()
         //    This implies mode == CatchingUp and cares_about_shard_this_epoch == true,
-        //    otherwise should_apply_transactions will be true
+        //    otherwise should_apply_chunk will be true
         //    That means transactions have already been applied last time when apply_chunks are
         //    called with mode NotCaughtUp, therefore `state_changes_for_resharding` have been
         //    stored in the database. Then we can safely read that and apply that to the split
@@ -3352,8 +3352,8 @@ impl Chain {
             };
 
         let is_new_chunk = chunk_header.height_included() == block.header().height();
-        let shard_update_reason = if shard_context.should_apply_transactions {
-            let block_context = self.get_apply_transactions_block_context(
+        let shard_update_reason = if shard_context.should_apply_chunk {
+            let block_context = self.get_apply_chunk_block_context(
                 block.header(),
                 prev_block.header(),
                 is_new_chunk,
@@ -3490,11 +3490,10 @@ impl Chain {
         shard_id: ShardId,
         mode: ApplyChunksMode,
         return_chunk_extra: bool,
-    ) -> Result<(Vec<(ApplyTransactionsBlockContext, ShardContext)>, Option<ChunkExtra>), Error>
-    {
+    ) -> Result<(Vec<(ApplyChunkBlockContext, ShardContext)>, Option<ChunkExtra>), Error> {
         let blocks_to_execute =
             self.get_blocks_until_height(chunk_prev_hash, prev_chunk_height_included, false)?;
-        let mut execution_contexts: Vec<(ApplyTransactionsBlockContext, ShardContext)> = vec![];
+        let mut execution_contexts: Vec<(ApplyChunkBlockContext, ShardContext)> = vec![];
         for block_hash in blocks_to_execute {
             let block_header = self.get_block_header(&block_hash)?;
             let prev_block_header = self.get_previous_header(&block_header)?;
@@ -3505,11 +3504,7 @@ impl Chain {
                 )));
             }
             execution_contexts.push((
-                self.get_apply_transactions_block_context(
-                    &block_header,
-                    &prev_block_header,
-                    false,
-                )?,
+                self.get_apply_chunk_block_context(&block_header, &prev_block_header, false)?,
                 shard_context,
             ));
         }
@@ -3565,7 +3560,7 @@ impl Chain {
         let is_new_chunk = chunk_header.height_included() == block.header().height();
 
         // If we don't track a shard or there is no chunk, there is nothing to validate.
-        if !last_shard_context.should_apply_transactions || !is_new_chunk {
+        if !last_shard_context.should_apply_chunk || !is_new_chunk {
             return Ok(None);
         }
 
@@ -3667,7 +3662,7 @@ impl Chain {
                 return Ok(None);
             }
             (
-                self.get_apply_transactions_block_context(&block_header, &prev_block_header, true)?,
+                self.get_apply_chunk_block_context(&block_header, &prev_block_header, true)?,
                 shard_context,
             )
         };
@@ -3729,7 +3724,7 @@ impl Chain {
                         epoch_manager.as_ref(),
                     )?;
                 let (outcome_root, _) =
-                    ApplyTransactionResult::compute_outcomes_proof(&apply_result.outcomes);
+                    ApplyChunkResult::compute_outcomes_proof(&apply_result.outcomes);
                 current_chunk_extra = ChunkExtra::new(
                     &apply_result.new_root,
                     outcome_root,
@@ -3865,7 +3860,7 @@ fn sync_hash_not_first_hash(sync_hash: CryptoHash) -> Error {
 /// ApplyChunksMode::NotCaughtUp once with ApplyChunksMode::CatchingUp. Note
 /// that it does not guard whether the children shards are ready or not, see the
 /// comments before `need_to_reshard`
-fn get_should_apply_transactions(
+fn get_should_apply_chunk(
     mode: ApplyChunksMode,
     cares_about_shard_this_epoch: bool,
     cares_about_shard_next_epoch: bool,

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -1,7 +1,7 @@
 use super::ValidatorSchedule;
 use crate::types::{
-    ApplyResultForResharding, ApplyTransactionResult, ApplyTransactionsBlockContext,
-    ApplyTransactionsChunkContext, RuntimeAdapter, RuntimeStorageConfig,
+    ApplyChunkBlockContext, ApplyChunkResult, ApplyChunkShardContext, ApplyResultForResharding,
+    RuntimeAdapter, RuntimeStorageConfig,
 };
 use crate::BlockHeader;
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -1040,14 +1040,14 @@ impl RuntimeAdapter for KeyValueRuntime {
         Ok(res)
     }
 
-    fn apply_transactions(
+    fn apply_chunk(
         &self,
         storage_config: RuntimeStorageConfig,
-        chunk: ApplyTransactionsChunkContext,
-        block: ApplyTransactionsBlockContext,
+        chunk: ApplyChunkShardContext,
+        block: ApplyChunkBlockContext,
         receipts: &[Receipt],
         transactions: &[SignedTransaction],
-    ) -> Result<ApplyTransactionResult, Error> {
+    ) -> Result<ApplyChunkResult, Error> {
         assert!(!storage_config.record_storage);
         let mut tx_results = vec![];
         let shard_id = chunk.shard_id;
@@ -1181,7 +1181,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         self.state.write().unwrap().insert(state_root, state);
         self.state_size.write().unwrap().insert(state_root, state_size);
 
-        Ok(ApplyTransactionResult {
+        Ok(ApplyChunkResult {
             trie_changes: WrappedTrieChanges::new(
                 self.get_tries(),
                 ShardUId { version: 0, shard_id: shard_id as u32 },

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -100,7 +100,7 @@ pub enum ReshardingResults {
 }
 
 #[derive(Debug)]
-pub struct ApplyTransactionResult {
+pub struct ApplyChunkResult {
     pub trie_changes: WrappedTrieChanges,
     pub new_root: StateRoot,
     pub outcomes: Vec<ExecutionOutcomeWithId>,
@@ -112,7 +112,7 @@ pub struct ApplyTransactionResult {
     pub processed_delayed_receipts: Vec<Receipt>,
 }
 
-impl ApplyTransactionResult {
+impl ApplyChunkResult {
     /// Returns root and paths for all the outcomes in the result.
     pub fn compute_outcomes_proof(
         outcomes: &[ExecutionOutcomeWithId],
@@ -279,7 +279,7 @@ impl RuntimeStorageConfig {
 }
 
 #[derive(Clone)]
-pub struct ApplyTransactionsBlockContext {
+pub struct ApplyChunkBlockContext {
     pub height: BlockHeight,
     pub block_hash: CryptoHash,
     pub prev_block_hash: CryptoHash,
@@ -289,7 +289,7 @@ pub struct ApplyTransactionsBlockContext {
     pub random_seed: CryptoHash,
 }
 
-impl ApplyTransactionsBlockContext {
+impl ApplyChunkBlockContext {
     pub fn from_header(header: &BlockHeader, gas_price: Balance) -> Self {
         Self {
             height: header.height(),
@@ -303,7 +303,7 @@ impl ApplyTransactionsBlockContext {
     }
 }
 
-pub struct ApplyTransactionsChunkContext<'a> {
+pub struct ApplyChunkShardContext<'a> {
     pub shard_id: ShardId,
     pub last_validator_proposals: ValidatorStakeIter<'a>,
     pub gas_limit: Gas,
@@ -387,16 +387,17 @@ pub trait RuntimeAdapter: Send + Sync {
     /// Get the block height for which garbage collection should not go over
     fn get_gc_stop_height(&self, block_hash: &CryptoHash) -> BlockHeight;
 
-    /// Apply transactions to given state root and return store update and new state root.
+    /// Apply transactions and receipts to given state root and return store update
+    /// and new state root.
     /// Also returns transaction result for each transaction and new receipts.
-    fn apply_transactions(
+    fn apply_chunk(
         &self,
         storage: RuntimeStorageConfig,
-        chunk: ApplyTransactionsChunkContext,
-        block: ApplyTransactionsBlockContext,
+        chunk: ApplyChunkShardContext,
+        block: ApplyChunkBlockContext,
         receipts: &[Receipt],
         transactions: &[SignedTransaction],
-    ) -> Result<ApplyTransactionResult, Error>;
+    ) -> Result<ApplyChunkResult, Error>;
 
     /// Query runtime with given `path` and `data`.
     fn query(
@@ -548,7 +549,7 @@ mod tests {
             },
         };
         let outcomes = vec![outcome1, outcome2];
-        let (outcome_root, paths) = ApplyTransactionResult::compute_outcomes_proof(&outcomes);
+        let (outcome_root, paths) = ApplyChunkResult::compute_outcomes_proof(&outcomes);
         for (outcome_with_id, path) in outcomes.into_iter().zip(paths.into_iter()) {
             assert!(verify_path(outcome_root, &path, &outcome_with_id.to_hashes()));
         }

--- a/nearcore/src/runtime/tests.rs
+++ b/nearcore/src/runtime/tests.rs
@@ -67,16 +67,16 @@ impl NightshadeRuntime {
         challenges_result: &ChallengesResult,
     ) -> (StateRoot, Vec<ValidatorStake>, Vec<Receipt>) {
         let mut result = self
-            .apply_transactions(
+            .apply_chunk(
                 RuntimeStorageConfig::new(*state_root, true),
-                ApplyTransactionsChunkContext {
+                ApplyChunkShardContext {
                     shard_id,
                     last_validator_proposals,
                     gas_limit,
                     is_new_chunk: true,
                     is_first_block_with_chunk_of_version: false,
                 },
-                ApplyTransactionsBlockContext {
+                ApplyChunkBlockContext {
                     height,
                     block_hash: *block_hash,
                     prev_block_hash: *prev_block_hash,

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -1,8 +1,8 @@
 use near_chain::chain::collect_receipts_from_response;
 use near_chain::migrations::check_if_block_is_first_with_chunk_of_version;
 use near_chain::types::{
-    ApplyTransactionResult, ApplyTransactionsBlockContext, ApplyTransactionsChunkContext,
-    RuntimeAdapter, RuntimeStorageConfig,
+    ApplyChunkBlockContext, ApplyChunkResult, ApplyChunkShardContext, RuntimeAdapter,
+    RuntimeStorageConfig,
 };
 use near_chain::{ChainStore, ChainStoreAccess, ChainStoreUpdate};
 use near_chain_configs::Genesis;
@@ -230,16 +230,16 @@ fn apply_block_from_range(
             }
         }
         runtime_adapter
-            .apply_transactions(
+            .apply_chunk(
                 RuntimeStorageConfig::new(*chunk_inner.prev_state_root(), use_flat_storage),
-                ApplyTransactionsChunkContext {
+                ApplyChunkShardContext {
                     shard_id,
                     last_validator_proposals: chunk_inner.prev_validator_proposals(),
                     gas_limit: chunk_inner.gas_limit(),
                     is_new_chunk: true,
                     is_first_block_with_chunk_of_version,
                 },
-                ApplyTransactionsBlockContext::from_header(
+                ApplyChunkBlockContext::from_header(
                     block.header(),
                     prev_block.header().next_gas_price(),
                 ),
@@ -254,16 +254,16 @@ fn apply_block_from_range(
         prev_chunk_extra = Some(chunk_extra.clone());
 
         runtime_adapter
-            .apply_transactions(
+            .apply_chunk(
                 RuntimeStorageConfig::new(*chunk_extra.state_root(), use_flat_storage),
-                ApplyTransactionsChunkContext {
+                ApplyChunkShardContext {
                     shard_id,
                     last_validator_proposals: chunk_extra.validator_proposals(),
                     gas_limit: chunk_extra.gas_limit(),
                     is_new_chunk: false,
                     is_first_block_with_chunk_of_version: false,
                 },
-                ApplyTransactionsBlockContext::from_header(
+                ApplyChunkBlockContext::from_header(
                     block.header(),
                     block.header().next_gas_price(),
                 ),
@@ -273,7 +273,7 @@ fn apply_block_from_range(
             .unwrap()
     };
 
-    let (outcome_root, _) = ApplyTransactionResult::compute_outcomes_proof(&apply_result.outcomes);
+    let (outcome_root, _) = ApplyChunkResult::compute_outcomes_proof(&apply_result.outcomes);
     let chunk_extra = ChunkExtra::new(
         &apply_result.new_root,
         outcome_root,


### PR DESCRIPTION
`apply_transactions` is confusing for multiple reasons:
- this function processes not only transactions but also receipts
- transactions are not directly applied, but converted to receipts