### PR TITLE
fix(split-storage) - optimize copying of state

### DIFF
--- a/core/store/src/cold_storage.rs
+++ b/core/store/src/cold_storage.rs
@@ -184,8 +184,6 @@ fn copy_from_store(
 
     // note this function should only be used for state in tests where it's
     // needed to copy state records from genesis
-    #[cfg(not(test))]
-    debug_assert!(col != DBCol::State);
 
     let _span = tracing::debug_span!(target: "cold_store", "copy_from_store", col = %col);
     let instant = std::time::Instant::now();

--- a/nearcore/src/cold_storage.rs
+++ b/nearcore/src/cold_storage.rs
@@ -34,6 +34,7 @@ impl ColdStoreLoopHandle {
 }
 
 /// The ColdStoreCopyResult indicates if and what block was copied.
+#[derive(Debug)]
 enum ColdStoreCopyResult {
     // No block was copied. The cold head is up to date with the final head.
     NoBlockCopied,
@@ -69,7 +70,9 @@ fn cold_store_copy(
     let hot_tail = hot_store.get_ser::<u64>(DBCol::BlockMisc, TAIL_KEY)?;
     let hot_tail_height = hot_tail.unwrap_or(genesis_height);
 
-    tracing::debug!(target: "cold_store", "cold store loop, cold_head {}, hot_final_head {}, hot_tail {}", cold_head_height, hot_final_head_height, hot_tail_height);
+    let _span = tracing::debug_span!(target: "cold_store", "cold_store_copy", cold_head_height, hot_final_head_height, hot_tail_height).entered();
+
+    tracing::debug!(target: "cold_store", "starting");
 
     if cold_head_height > hot_final_head_height {
         return Err(anyhow::anyhow!(
@@ -120,11 +123,14 @@ fn cold_store_copy(
 
     update_cold_head(cold_db, hot_store, &next_height)?;
 
-    if next_height >= hot_final_head_height {
+    let result = if next_height >= hot_final_head_height {
         Ok(ColdStoreCopyResult::LatestBlockCopied)
     } else {
         Ok(ColdStoreCopyResult::OtherBlockCopied)
-    }
+    };
+
+    tracing::debug!(target: "cold_store", ?result, "ending");
+    result
 }
 
 fn cold_store_copy_result_to_string(result: &anyhow::Result<ColdStoreCopyResult>) -> &str {
@@ -260,12 +266,18 @@ fn cold_store_loop(
             tracing::debug!(target : "cold_store", "Stopping the cold store loop");
             break;
         }
+
+        let start_time = std::time::Instant::now();
         let result =
             cold_store_copy(&hot_store, &cold_store, &cold_db, genesis_height, epoch_manager);
+        let duration = start_time.elapsed();
 
-        metrics::COLD_STORE_COPY_RESULT
-            .with_label_values(&[cold_store_copy_result_to_string(&result)])
-            .inc();
+        let result_string = cold_store_copy_result_to_string(&result);
+        metrics::COLD_STORE_COPY_RESULT.with_label_values(&[result_string]).inc();
+        metrics::COLD_STORE_COPY_TIME.observe(duration.as_secs_f64());
+        if duration > std::time::Duration::from_secs(1) {
+            tracing::warn!(target : "cold_store", "cold_store_copy took {}s", duration.as_secs_f64());
+        }
 
         let sleep_duration = split_storage_config.cold_store_loop_sleep_duration;
         match result {

--- a/nearcore/src/metrics.rs
+++ b/nearcore/src/metrics.rs
@@ -4,9 +4,9 @@ use actix_rt::ArbiterHandle;
 use near_chain::{Block, ChainStore, ChainStoreAccess};
 use near_epoch_manager::EpochManager;
 use near_o11y::metrics::{
-    exponential_buckets, linear_buckets, processing_time_buckets, try_create_histogram,
-    try_create_histogram_vec, try_create_int_counter_vec, try_create_int_gauge,
-    try_create_int_gauge_vec, Histogram, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec,
+    exponential_buckets, linear_buckets, processing_time_buckets, try_create_histogram_vec,
+    try_create_int_counter_vec, try_create_int_gauge, try_create_int_gauge_vec, HistogramVec,
+    IntCounterVec, IntGauge, IntGaugeVec,
 };
 
 use near_primitives::{shard_layout::ShardLayout, state_record::StateRecord, trie_key};
@@ -78,14 +78,6 @@ pub(crate) static COLD_STORE_COPY_RESULT: Lazy<IntCounterVec> = Lazy::new(|| {
         "near_cold_store_copy_result",
         "The result of a cold store copy iteration in the cold store loop.",
         &["copy_result"],
-    )
-    .unwrap()
-});
-
-pub(crate) static COLD_STORE_COPY_TIME: Lazy<Histogram> = Lazy::new(|| {
-    try_create_histogram(
-        "near_cold_store_copy_time",
-        "Time taken to copy a block from the hot store to the cold store",
     )
     .unwrap()
 });

--- a/nearcore/src/metrics.rs
+++ b/nearcore/src/metrics.rs
@@ -4,9 +4,9 @@ use actix_rt::ArbiterHandle;
 use near_chain::{Block, ChainStore, ChainStoreAccess};
 use near_epoch_manager::EpochManager;
 use near_o11y::metrics::{
-    exponential_buckets, linear_buckets, processing_time_buckets, try_create_histogram_vec,
-    try_create_int_counter_vec, try_create_int_gauge, try_create_int_gauge_vec, HistogramVec,
-    IntCounterVec, IntGauge, IntGaugeVec,
+    exponential_buckets, linear_buckets, processing_time_buckets, try_create_histogram,
+    try_create_histogram_vec, try_create_int_counter_vec, try_create_int_gauge,
+    try_create_int_gauge_vec, Histogram, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec,
 };
 
 use near_primitives::{shard_layout::ShardLayout, state_record::StateRecord, trie_key};
@@ -78,6 +78,14 @@ pub(crate) static COLD_STORE_COPY_RESULT: Lazy<IntCounterVec> = Lazy::new(|| {
         "near_cold_store_copy_result",
         "The result of a cold store copy iteration in the cold store loop.",
         &["copy_result"],
+    )
+    .unwrap()
+});
+
+pub(crate) static COLD_STORE_COPY_TIME: Lazy<Histogram> = Lazy::new(|| {
+    try_create_histogram(
+        "near_cold_store_copy_time",
+        "Time taken to copy a block from the hot store to the cold store",
     )
     .unwrap()
 });


### PR DESCRIPTION
The current approach means that when looking for a trie node in the db we need to check all shards. In practice most nodes are only ever present in one shard so the current implementation is ~4x slower when it comes to reading trie nodes than it could be. The state reads also happen to account for majority of time spent in copying heights from hot to cold. 

This fix should resolve the ever growing cold head lag that is described in more detail on [zulip](https://near.zulipchat.com/#narrow/stream/308695-pagoda.2Fprivate/topic/Split.20storage.20nodes.20increasing.20cold.20head.20lag) which is a major issue for our archival nodes. 