### PR TITLE
[cleanup] Remove ReceiptOutcomeRequest from RoutedMessageBody

### DIFF
--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -506,26 +506,13 @@ impl PeerMessage {
 pub enum RoutedMessageBody {
     BlockApproval(Approval),
     ForwardTx(SignedTransaction),
-
     TxStatusRequest(AccountId, CryptoHash),
     TxStatusResponse(FinalExecutionOutcomeView),
-
     /// Not used, but needed for borsh backward compatibility.
     _UnusedQueryRequest,
-    /// Not used, but needed for borsh backward compatibility.
     _UnusedQueryResponse,
-
-    /// Not used any longer and ignored when received.
-    ///
-    /// We’ve been still sending those messages at protocol version 56 so we
-    /// need to wait until 59 before we can remove the variant completely.
-    /// Until then we need to be able to decode those messages (even though we
-    /// will ignore them).
-    ReceiptOutcomeRequest(CryptoHash),
-
-    /// Not used, but needed to borsh backward compatibility.
+    _UnusedReceiptOutcomeRequest(CryptoHash),
     _UnusedReceiptOutcomeResponse,
-
     _UnusedStateRequestHeader,
     _UnusedStateRequestPart,
     /// StateResponse in not produced since protocol version 58.
@@ -542,7 +529,6 @@ pub enum RoutedMessageBody {
     VersionedPartialEncodedChunk(PartialEncodedChunk),
     _UnusedVersionedStateResponse,
     PartialEncodedChunkForward(PartialEncodedChunkForwardMsg),
-
     ChunkStateWitness(ChunkStateWitness),
     ChunkEndorsement(ChunkEndorsement),
 }
@@ -581,7 +567,7 @@ impl fmt::Debug for RoutedMessageBody {
             }
             RoutedMessageBody::_UnusedQueryRequest => write!(f, "QueryRequest"),
             RoutedMessageBody::_UnusedQueryResponse => write!(f, "QueryResponse"),
-            RoutedMessageBody::ReceiptOutcomeRequest(hash) => write!(f, "ReceiptRequest({})", hash),
+            RoutedMessageBody::_UnusedReceiptOutcomeRequest(_) => write!(f, "ReceiptRequest"),
             RoutedMessageBody::_UnusedReceiptOutcomeResponse => write!(f, "ReceiptResponse"),
             RoutedMessageBody::_UnusedStateRequestHeader => write!(f, "StateRequestHeader"),
             RoutedMessageBody::_UnusedStateRequestPart => write!(f, "StateRequestPart"),
@@ -695,7 +681,6 @@ impl RoutedMessage {
             RoutedMessageBody::Ping(_)
                 | RoutedMessageBody::TxStatusRequest(_, _)
                 | RoutedMessageBody::PartialEncodedChunkRequest(_)
-                | RoutedMessageBody::ReceiptOutcomeRequest(_)
         )
     }
 

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -981,13 +981,6 @@ impl PeerActor {
                     .send(ShardsManagerRequestFromNetwork::ProcessPartialEncodedChunkForward(msg));
                 None
             }
-            RoutedMessageBody::ReceiptOutcomeRequest(_) => {
-                // Silently ignore for the time being.  We’ve been still
-                // sending those messages at protocol version 56 so we
-                // need to wait until 59 before we can remove the
-                // variant completely.
-                None
-            }
             RoutedMessageBody::ChunkStateWitness(witness) => {
                 network_state.client.chunk_state_witness(witness).await;
                 None


### PR DESCRIPTION
Randomly found ReceiptOutcomeRequest which is currently unused.