### PR TITLE
config: adjust shard cache sizes

### DIFF
--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -241,15 +241,17 @@ impl Default for StoreConfig {
 
             trie_cache: TrieCacheConfig {
                 default_max_bytes: 500_000_000,
-                // Temporary solution to make contracts with heavy trie access
-                // patterns on shard 3 more stable. It was chosen by the estimation
-                // of the largest contract storage size we are aware as of 23/08/2022.
-                // Consider removing after implementing flat storage. (#7327)
-                // Note: on >= 1.34 nearcore version use 1_000_000_000 if you have
-                // minimal hardware.
+                // TODO(resharding) The cache size needs to adjusted for every resharding.
+                // Make that automatic e.g. by defining the minimum cache size per account rather than shard.
                 per_shard_max_bytes: HashMap::from_iter([
+                    // Temporary solution to make contracts with heavy trie access
+                    // patterns on shard 3 more stable. It was chosen by the estimation
+                    // of the largest contract storage size we are aware as of 23/08/2022.
+                    // Note: on >= 1.34 nearcore version use 1_000_000_000 if you have
+                    // minimal hardware.
+                    // In simple nightshade the heavy contract "token.sweat" is in shard 3
                     (ShardUId { version: 1, shard_id: 3 }, 3_000_000_000),
-                    // After resharding "token.sweat" account moves to shard 4
+                    // In simple nightshade v2 the heavy contract "token.sweat" is in shard 4
                     (ShardUId { version: 2, shard_id: 4 }, 3_000_000_000),
                     // Shard 1 is dedicated to aurora and it had very few cache
                     // misses even with cache size of only 50MB

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -240,17 +240,22 @@ impl Default for StoreConfig {
             block_size: bytesize::ByteSize::kib(16),
 
             trie_cache: TrieCacheConfig {
-                default_max_bytes: DEFAULT_SHARD_CACHE_TOTAL_SIZE_LIMIT,
+                default_max_bytes: 500_000_000,
                 // Temporary solution to make contracts with heavy trie access
                 // patterns on shard 3 more stable. It was chosen by the estimation
                 // of the largest contract storage size we are aware as of 23/08/2022.
                 // Consider removing after implementing flat storage. (#7327)
                 // Note: on >= 1.34 nearcore version use 1_000_000_000 if you have
                 // minimal hardware.
-                per_shard_max_bytes: HashMap::from_iter([(
-                    ShardUId { version: 1, shard_id: 3 },
-                    3_000_000_000,
-                )]),
+                per_shard_max_bytes: HashMap::from_iter([
+                    (ShardUId { version: 1, shard_id: 3 }, 3_000_000_000),
+                    // After resharding "token.sweat" account moves to shard 4
+                    (ShardUId { version: 2, shard_id: 4 }, 3_000_000_000),
+                    // Shard 1 is dedicated to aurora and it had very few cache
+                    // misses even with cache size of only 50MB
+                    (ShardUId { version: 1, shard_id: 1 }, 50_000_000),
+                    (ShardUId { version: 2, shard_id: 1 }, 50_000_000),
+                ]),
                 shard_cache_deletions_queue_capacity: DEFAULT_SHARD_CACHE_DELETIONS_QUEUE_CAPACITY,
             },
 

--- a/core/store/src/trie/config.rs
+++ b/core/store/src/trie/config.rs
@@ -7,9 +7,9 @@ use tracing::error;
 
 /// Default memory limit, if nothing else is configured.
 /// It is chosen to correspond roughly to the old limit, which was
-/// 500k entries * TRIE_LIMIT_CACHED_VALUE_SIZE.
+/// 50k entries * TRIE_LIMIT_CACHED_VALUE_SIZE.
 pub(crate) const DEFAULT_SHARD_CACHE_TOTAL_SIZE_LIMIT: u64 =
-    if cfg!(feature = "no_cache") { 1 } else { 500_000_000 };
+    if cfg!(feature = "no_cache") { 1 } else { 50_000_000 };
 
 /// Capacity for the deletions queue.
 /// It is chosen to fit all hashes of deleted nodes for 3 completely full blocks.


### PR DESCRIPTION
* Do not apply default size increase introduced in #10373 to `view_trie_cache` since view calls are not latency-sensitive
* Opt out shard 1 from the increase since it only contains aurora account and based on the current metrics has very low cache miss rate even with a size of 50MB
* Configure shard 3 override of 3GB to also apply after resharding