### PR TITLE
feat(split-storage): crash on startup if the hot and cold are inconsistent

### DIFF
--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -457,9 +457,9 @@ fn test_cold_loop_on_gc_boundary() {
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
 
-    let (store, ..) = create_test_node_storage_with_cold(DB_VERSION, DbKind::Hot);
-    let hot_store = &store.get_hot_store();
-    let cold_store = &store.get_cold_store().unwrap();
+    let (storage, ..) = create_test_node_storage_with_cold(DB_VERSION, DbKind::Hot);
+    let hot_store = &storage.get_hot_store();
+    let cold_store = &storage.get_cold_store().unwrap();
     let mut env = TestEnv::builder(chain_genesis)
         .archive(true)
         .save_trie_changes(true)
@@ -486,10 +486,10 @@ fn test_cold_loop_on_gc_boundary() {
 
     let keep_going = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
 
-    copy_all_data_to_cold((*store.cold_db().unwrap()).clone(), &hot_store, 1000000, &keep_going)
+    copy_all_data_to_cold((*storage.cold_db().unwrap()).clone(), &hot_store, 1000000, &keep_going)
         .unwrap();
 
-    update_cold_head(&*store.cold_db().unwrap(), &hot_store, &(height_delta - 1)).unwrap();
+    update_cold_head(&*storage.cold_db().unwrap(), &hot_store, &(height_delta - 1)).unwrap();
 
     for height in height_delta..height_delta * 2 {
         let signer = InMemorySigner::from_seed(test0(), KeyType::ED25519, "test0");
@@ -523,8 +523,8 @@ fn test_cold_loop_on_gc_boundary() {
     near_config.client_config = env.clients[0].config.clone();
     near_config.config.save_trie_changes = Some(true);
 
-    let epoch_manager = EpochManager::new_arc_handle(store.get_hot_store(), &genesis.config);
-    spawn_cold_store_loop(&near_config, &store, epoch_manager).unwrap();
+    let epoch_manager = EpochManager::new_arc_handle(storage.get_hot_store(), &genesis.config);
+    spawn_cold_store_loop(&near_config, &storage, epoch_manager).unwrap();
     std::thread::sleep(std::time::Duration::from_secs(1));
 
     let end_cold_head =

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -486,10 +486,10 @@ fn test_cold_loop_on_gc_boundary() {
 
     let keep_going = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
 
-    copy_all_data_to_cold((*storage.cold_db().unwrap()).clone(), &hot_store, 1000000, &keep_going)
-        .unwrap();
+    let cold_db = storage.cold_db().unwrap();
+    copy_all_data_to_cold(cold_db.clone(), &hot_store, 1000000, &keep_going).unwrap();
 
-    update_cold_head(&*storage.cold_db().unwrap(), &hot_store, &(height_delta - 1)).unwrap();
+    update_cold_head(cold_db, &hot_store, &(height_delta - 1)).unwrap();
 
     for height in height_delta..height_delta * 2 {
         let signer = InMemorySigner::from_seed(test0(), KeyType::ED25519, "test0");

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -235,9 +235,9 @@ fn test_cold_db_head_update() {
     genesis.config.epoch_length = epoch_length;
     let mut chain_genesis = ChainGenesis::test();
     chain_genesis.epoch_length = epoch_length;
-    let (store, ..) = create_test_node_storage_with_cold(DB_VERSION, DbKind::Hot);
-    let hot_store = &store.get_hot_store();
-    let cold_store = &store.get_cold_store().unwrap();
+    let (storage, ..) = create_test_node_storage_with_cold(DB_VERSION, DbKind::Hot);
+    let hot_store = &storage.get_hot_store();
+    let cold_store = &storage.get_cold_store().unwrap();
     let mut env = TestEnv::builder(chain_genesis)
         .stores(vec![hot_store.clone()])
         .real_epoch_managers(&genesis.config)
@@ -247,7 +247,7 @@ fn test_cold_db_head_update() {
     for height in 1..max_height {
         env.produce_block(0, height);
         update_cold_head(
-            &*store.cold_db().unwrap(),
+            &*storage.cold_db().unwrap(),
             &env.clients[0].runtime_adapter.store(),
             &height,
         )

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -64,6 +64,24 @@ fn check_iter(
     num_checks
 }
 
+fn create_tx_deploy_contract(
+    height: u64,
+    signer: &InMemorySigner,
+    last_hash: CryptoHash,
+) -> SignedTransaction {
+    let code = near_test_contracts::rs_contract().to_vec();
+    let action = DeployContractAction { code };
+    let action = Action::DeployContract(action);
+    SignedTransaction::from_actions(
+        height,
+        "test0".parse().unwrap(),
+        "test0".parse().unwrap(),
+        signer,
+        vec![action],
+        last_hash,
+    )
+}
+
 fn create_tx_send_money(
     nonce: u64,
     signer: &InMemorySigner,
@@ -114,16 +132,7 @@ fn test_storage_after_commit_of_cold_update() {
     for height in 1..max_height {
         let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
         if height == 1 {
-            let tx = SignedTransaction::from_actions(
-                height,
-                "test0".parse().unwrap(),
-                "test0".parse().unwrap(),
-                &signer,
-                vec![Action::DeployContract(DeployContractAction {
-                    code: near_test_contracts::rs_contract().to_vec(),
-                })],
-                last_hash,
-            );
+            let tx = create_tx_deploy_contract(height, &signer, last_hash);
             assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
         }
         // Don't send transactions in last two blocks. Because on last block production a chunk from

--- a/nearcore/src/cold_storage.rs
+++ b/nearcore/src/cold_storage.rs
@@ -56,40 +56,18 @@ fn cold_store_copy(
     genesis_height: BlockHeight,
     epoch_manager: &EpochManagerHandle,
 ) -> anyhow::Result<ColdStoreCopyResult> {
-    // If COLD_HEAD is not set for hot storage we default it to genesis_height.
     let cold_head = cold_store.get_ser::<Tip>(DBCol::BlockMisc, HEAD_KEY)?;
     let cold_head_height = cold_head.map_or(genesis_height, |tip| tip.height);
 
-    // If FINAL_HEAD is not set for hot storage we default it to genesis_height.
     let hot_final_head = hot_store.get_ser::<Tip>(DBCol::BlockMisc, FINAL_HEAD_KEY)?;
     let hot_final_head_height = hot_final_head.map_or(genesis_height, |tip| tip.height);
 
-    // If TAIL is not set for hot storage we default it to genesis_height.
-    // TAIL not being set is not an error.
-    // Archive dbs don't have TAIL, that means that they have all data from genesis_height.
     let hot_tail = hot_store.get_ser::<u64>(DBCol::BlockMisc, TAIL_KEY)?;
     let hot_tail_height = hot_tail.unwrap_or(genesis_height);
 
     let _span = tracing::debug_span!(target: "cold_store", "cold_store_copy", cold_head_height, hot_final_head_height, hot_tail_height).entered();
 
-    if cold_head_height > hot_final_head_height {
-        return Err(anyhow::anyhow!(
-            "Cold head is ahead of final head. cold head height: {} final head height {}",
-            cold_head_height,
-            hot_final_head_height
-        ));
-    }
-
-    // Cold and Hot storages need to overlap.
-    // Without this check we would skip blocks from cold_head_height to hot_tail_height.
-    // This will result in corrupted cold storage.
-    if cold_head_height < hot_tail_height {
-        return Err(anyhow::anyhow!(
-            "Cold head is behind hot tail. cold head height: {} hot tail height {}",
-            cold_head_height,
-            hot_tail_height
-        ));
-    }
+    sanity_check_impl(cold_head_height, hot_final_head_height, hot_tail_height)?;
 
     if cold_head_height >= hot_final_head_height {
         return Ok(ColdStoreCopyResult::NoBlockCopied);
@@ -129,6 +107,50 @@ fn cold_store_copy(
 
     tracing::trace!(target: "cold_store", ?result, "ending");
     result
+}
+
+// Check some basic sanity conditions.
+// * cold head <= hot final head
+// * cold head >= hot tail
+fn sanity_check(
+    hot_store: &Store,
+    cold_store: &Store,
+    genesis_height: BlockHeight,
+) -> anyhow::Result<()> {
+    let cold_head = cold_store.get_ser::<Tip>(DBCol::BlockMisc, HEAD_KEY)?;
+    let cold_head_height = cold_head.map_or(genesis_height, |tip| tip.height);
+
+    let hot_final_head = hot_store.get_ser::<Tip>(DBCol::BlockMisc, FINAL_HEAD_KEY)?;
+    let hot_final_head_height = hot_final_head.map_or(genesis_height, |tip| tip.height);
+
+    let hot_tail = hot_store.get_ser::<u64>(DBCol::BlockMisc, TAIL_KEY)?;
+    let hot_tail_height = hot_tail.unwrap_or(genesis_height);
+
+    sanity_check_impl(cold_head_height, hot_final_head_height, hot_tail_height)?;
+
+    Ok(())
+}
+
+fn sanity_check_impl(
+    cold_head_height: u64,
+    hot_final_head_height: u64,
+    hot_tail_height: u64,
+) -> anyhow::Result<()> {
+    if cold_head_height > hot_final_head_height {
+        return Err(anyhow::anyhow!(
+            "Cold head is ahead of final head. cold head height: {} final head height {}",
+            cold_head_height,
+            hot_final_head_height
+        ));
+    }
+    if cold_head_height < hot_tail_height {
+        return Err(anyhow::anyhow!(
+            "Cold head is behind hot tail. cold head height: {} hot tail height {}",
+            cold_head_height,
+            hot_tail_height
+        ));
+    }
+    Ok(())
 }
 
 fn cold_store_copy_result_to_string(result: &anyhow::Result<ColdStoreCopyResult>) -> &str {
@@ -337,6 +359,11 @@ pub fn spawn_cold_store_loop(
     let genesis_height = config.genesis.config.genesis_height;
     let keep_going = Arc::new(AtomicBool::new(true));
     let keep_going_clone = keep_going.clone();
+
+    // Perform the sanity check before spawning the thread.
+    // If the check fails when the node is starting it's better to just fail
+    // fast and crash the node immediately.
+    sanity_check(&hot_store, &cold_store, genesis_height)?;
 
     let split_storage_config = config.config.split_storage.clone().unwrap_or_default();
 


### PR DESCRIPTION
In the recent split archival incident the nodes were bootstrapped with inconsistent hot and cold DBs. In such a case the node should crash immediately on startup so that the issue can be detected as early as possible. 
* Refactored the sanity check code to two new methods
* Added the sanity check before the cold loop is spawned - at this place it would crash the node if failed
* Note that once the loop is spawned the sanity check doesn't crash the node but prints an error message and bumps approproate metric - this part remained unchanged. I'm open to suggestions here. 

I'm also refactoring the cold storage tests becuase it's a pain to work with those. Dear reviewers if you prefer to review those separately I'm happy to move it to a new PR, just let me know.  
* moving create_tx_* logic to dedicated methods
* moving inlined arguments into helper variables with nice names and reducing the total line count
* renaming some variables (h->height, store -> storage)