### PR TITLE
[stateless_validation] Process and store incoming chunk endorsements to block produce

### DIFF
--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -5,6 +5,7 @@ use chrono::Utc;
 
 use near_primitives::block::BlockValidityError;
 use near_primitives::challenge::{ChunkProofs, ChunkState};
+use near_primitives::chunk_validation::ChunkEndorsement;
 use near_primitives::errors::{EpochError, StorageError};
 use near_primitives::shard_layout::ShardLayoutError;
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
@@ -136,6 +137,8 @@ pub enum Error {
     InvalidChunkState(Box<ChunkState>),
     #[error("Invalid Chunk State Witness")]
     InvalidChunkStateWitness(String),
+    #[error("Invalid Chunk Endorsement")]
+    InvalidChunkEndorsement(ChunkEndorsement),
     /// Invalid chunk mask
     #[error("Invalid Chunk Mask")]
     InvalidChunkMask,
@@ -271,6 +274,7 @@ impl Error {
             | Error::InvalidChunkProofs(_)
             | Error::InvalidChunkState(_)
             | Error::InvalidChunkStateWitness(_)
+            | Error::InvalidChunkEndorsement(_)
             | Error::InvalidChunkMask
             | Error::InvalidStateRoot
             | Error::InvalidTxRoot
@@ -344,6 +348,7 @@ impl Error {
             Error::InvalidChunkProofs(_) => "invalid_chunk_proofs",
             Error::InvalidChunkState(_) => "invalid_chunk_state",
             Error::InvalidChunkStateWitness(_) => "invalid_chunk_state_witness",
+            Error::InvalidChunkEndorsement(_) => "invalid_chunk_endorsement",
             Error::InvalidChunkMask => "invalid_chunk_mask",
             Error::InvalidStateRoot => "invalid_state_root",
             Error::InvalidTxRoot => "invalid_tx_root",

--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -5,7 +5,6 @@ use chrono::Utc;
 
 use near_primitives::block::BlockValidityError;
 use near_primitives::challenge::{ChunkProofs, ChunkState};
-use near_primitives::chunk_validation::ChunkEndorsement;
 use near_primitives::errors::{EpochError, StorageError};
 use near_primitives::shard_layout::ShardLayoutError;
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
@@ -138,7 +137,7 @@ pub enum Error {
     #[error("Invalid Chunk State Witness")]
     InvalidChunkStateWitness(String),
     #[error("Invalid Chunk Endorsement")]
-    InvalidChunkEndorsement(ChunkEndorsement),
+    InvalidChunkEndorsement,
     /// Invalid chunk mask
     #[error("Invalid Chunk Mask")]
     InvalidChunkMask,
@@ -274,7 +273,7 @@ impl Error {
             | Error::InvalidChunkProofs(_)
             | Error::InvalidChunkState(_)
             | Error::InvalidChunkStateWitness(_)
-            | Error::InvalidChunkEndorsement(_)
+            | Error::InvalidChunkEndorsement
             | Error::InvalidChunkMask
             | Error::InvalidStateRoot
             | Error::InvalidTxRoot
@@ -348,7 +347,7 @@ impl Error {
             Error::InvalidChunkProofs(_) => "invalid_chunk_proofs",
             Error::InvalidChunkState(_) => "invalid_chunk_state",
             Error::InvalidChunkStateWitness(_) => "invalid_chunk_state_witness",
-            Error::InvalidChunkEndorsement(_) => "invalid_chunk_endorsement",
+            Error::InvalidChunkEndorsement => "invalid_chunk_endorsement",
             Error::InvalidChunkMask => "invalid_chunk_mask",
             Error::InvalidStateRoot => "invalid_state_root",
             Error::InvalidTxRoot => "invalid_tx_root",

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -13,6 +13,7 @@ use near_epoch_manager::{EpochManagerAdapter, RngSeed};
 use near_pool::types::PoolIterator;
 use near_primitives::account::{AccessKey, Account};
 use near_primitives::block_header::{Approval, ApprovalInner};
+use near_primitives::chunk_validation::ChunkEndorsement;
 use near_primitives::epoch_manager::block_info::BlockInfo;
 use near_primitives::epoch_manager::epoch_info::EpochInfo;
 use near_primitives::epoch_manager::EpochConfig;
@@ -23,7 +24,7 @@ use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::receipt::{ActionReceipt, Receipt, ReceiptEnum};
 use near_primitives::shard_layout;
 use near_primitives::shard_layout::{ShardLayout, ShardUId};
-use near_primitives::sharding::ChunkHash;
+use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
 use near_primitives::state_part::PartId;
 use near_primitives::transaction::{
     Action, ExecutionMetadata, ExecutionOutcome, ExecutionOutcomeWithId, ExecutionStatus,
@@ -908,6 +909,14 @@ impl EpochManagerAdapter for MockEpochManager {
         } else {
             Ok(())
         }
+    }
+
+    fn verify_chunk_endorsement(
+        &self,
+        _chunk_header: &ShardChunkHeader,
+        _endorsement: &ChunkEndorsement,
+    ) -> Result<bool, Error> {
+        Ok(true)
     }
 
     fn cares_about_shard_from_prev_block(

--- a/chain/client/src/chunk_validation.rs
+++ b/chain/client/src/chunk_validation.rs
@@ -502,7 +502,8 @@ impl Client {
 
         let chunk_header = self.chain.get_chunk(chunk_hash)?.cloned_header();
         if !self.epoch_manager.verify_chunk_endorsement(&chunk_header, &endorsement)? {
-            return Err(Error::InvalidChunkEndorsement(endorsement));
+            tracing::error!(target: "chunk_validation", ?endorsement, "Invalid chunk endorsement.");
+            return Err(Error::InvalidChunkEndorsement);
         }
 
         // If we are the current block producer, we store the chunk endorsement for each chunk which

--- a/chain/client/src/chunk_validation.rs
+++ b/chain/client/src/chunk_validation.rs
@@ -13,20 +13,24 @@ use near_network::types::{NetworkRequests, PeerManagerMessageRequest};
 use near_primitives::challenge::PartialState;
 use near_primitives::checked_feature;
 use near_primitives::chunk_validation::{
-    ChunkEndorsement, ChunkEndorsementInner, ChunkStateTransition, ChunkStateWitness,
+    ChunkEndorsement, ChunkStateTransition, ChunkStateWitness,
 };
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::merkle::merklize;
 use near_primitives::receipt::Receipt;
-use near_primitives::sharding::{ShardChunk, ShardChunkHeader};
+use near_primitives::sharding::{ChunkHash, ShardChunk, ShardChunkHeader};
 use near_primitives::types::chunk_extra::ChunkExtra;
-use near_primitives::types::{EpochId, ShardId};
+use near_primitives::types::{AccountId, EpochId, ShardId};
 use near_primitives::validator_signer::ValidatorSigner;
 use near_store::PartialStorage;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::Client;
+
+// This is the number of unique chunks for which we would track the chunk endorsements.
+// Ideally, we should not be processing more than num_shards chunks at a time.
+const NUM_CHUNK_ENDORSEMENTS_CACHE_COUNT: usize = 100;
 
 /// A module that handles chunk validation logic. Chunk validation refers to a
 /// critical process of stateless validation, where chunk validators (certain
@@ -39,6 +43,11 @@ pub struct ChunkValidator {
     epoch_manager: Arc<dyn EpochManagerAdapter>,
     network_sender: Sender<PeerManagerMessageRequest>,
     runtime_adapter: Arc<dyn RuntimeAdapter>,
+
+    /// We store the validated chunk endorsements received from chunk validators
+    /// This is keyed on chunk_hash and account_id of validator to avoid duplicates.
+    /// Chunk endorsements would later be used as a part of block production.
+    chunk_endorsements: lru::LruCache<ChunkHash, HashMap<AccountId, ChunkEndorsement>>,
 }
 
 impl ChunkValidator {
@@ -48,7 +57,13 @@ impl ChunkValidator {
         network_sender: Sender<PeerManagerMessageRequest>,
         runtime_adapter: Arc<dyn RuntimeAdapter>,
     ) -> Self {
-        Self { my_signer, epoch_manager, network_sender, runtime_adapter }
+        Self {
+            my_signer,
+            epoch_manager,
+            network_sender,
+            runtime_adapter,
+            chunk_endorsements: lru::LruCache::new(NUM_CHUNK_ENDORSEMENTS_CACHE_COUNT),
+        }
     }
 
     /// Performs the chunk validation logic. When done, it will send the chunk
@@ -104,12 +119,7 @@ impl ChunkValidator {
                         block_producer=%block_producer,
                         "Chunk validated successfully, sending endorsement",
                     );
-                    let endorsement_to_sign = ChunkEndorsementInner::new(chunk_header.chunk_hash());
-                    let endorsement = ChunkEndorsement {
-                        account_id: signer.validator_id().clone(),
-                        signature: signer.sign_chunk_endorsement(&endorsement_to_sign),
-                        inner: endorsement_to_sign,
-                    };
+                    let endorsement = ChunkEndorsement::new(chunk_header.chunk_hash(), signer);
                     network_sender.send(PeerManagerMessageRequest::NetworkRequests(
                         NetworkRequests::ChunkEndorsement(block_producer, endorsement),
                     ));
@@ -470,13 +480,41 @@ impl Client {
     }
 
     /// Function to process an incoming chunk endorsement from chunk validators.
+    /// We first verify the chunk endorsement and then store it in a cache.
+    /// We would later include the endorsements in the block production.
     pub fn process_chunk_endorsement(
         &mut self,
-        _endorsement: ChunkEndorsement,
+        endorsement: ChunkEndorsement,
     ) -> Result<(), Error> {
-        // TODO(10265): Here if we are the current block producer, we would store the chunk endorsement
-        // for each chunk which would later be used during block production to check whether to include the
-        // chunk or not.
+        let chunk_hash = endorsement.chunk_hash();
+        let account_id = &endorsement.account_id;
+
+        // If we have already processed this chunk endorsement, return early.
+        if self
+            .chunk_validator
+            .chunk_endorsements
+            .get(chunk_hash)
+            .is_some_and(|existing_endorsements| existing_endorsements.get(account_id).is_some())
+        {
+            tracing::debug!(target: "chunk_validation", ?endorsement, "Already received chunk endorsement.");
+            return Ok(());
+        }
+
+        let chunk_header = self.chain.get_chunk(chunk_hash)?.cloned_header();
+        if !self.epoch_manager.verify_chunk_endorsement(&chunk_header, &endorsement)? {
+            return Err(Error::InvalidChunkEndorsement(endorsement));
+        }
+
+        // If we are the current block producer, we store the chunk endorsement for each chunk which
+        // would later be used during block production to check whether to include the chunk or not.
+        tracing::debug!(target: "chunk_validation", ?endorsement, "Received and saved chunk endorsement.");
+        self.chunk_validator
+            .chunk_endorsements
+            .get_or_insert(chunk_hash.clone(), || HashMap::new());
+        let chunk_endorsements =
+            self.chunk_validator.chunk_endorsements.get_mut(chunk_hash).unwrap();
+        chunk_endorsements.insert(account_id.clone(), endorsement);
+
         Ok(())
     }
 }

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -2668,7 +2668,7 @@ fn test_verify_chunk_endorsements() {
     let validators = vec![(account_id.clone(), amount_staked)];
     let h = hash_range(6);
 
-    let mut epoch_manager = setup_default_epoch_manager(validators.clone(), 5, 1, 2, 2, 90, 60);
+    let mut epoch_manager = setup_default_epoch_manager(validators, 5, 1, 2, 2, 90, 60);
     record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
     record_block(&mut epoch_manager, h[0], h[1], 1, vec![]);
 

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -1,7 +1,5 @@
 mod random_epochs;
 
-use std::str::FromStr;
-
 use super::*;
 use crate::reward_calculator::NUM_NS_IN_SECOND;
 use crate::test_utils::{
@@ -11,16 +9,11 @@ use crate::test_utils::{
     record_with_block_info, reward, setup_default_epoch_manager, setup_epoch_manager, stake,
     DEFAULT_TOTAL_SUPPLY,
 };
-use near_chain_primitives::Error;
-use near_crypto::Signature;
 use near_primitives::account::id::AccountIdRef;
 use near_primitives::challenge::SlashedValidator;
-use near_primitives::chunk_validation::ChunkEndorsement;
 use near_primitives::epoch_manager::EpochConfig;
 use near_primitives::hash::hash;
 use near_primitives::shard_layout::ShardLayout;
-use near_primitives::sharding::{ShardChunkHeader, ShardChunkHeaderV3};
-use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::ValidatorKickoutReason::{NotEnoughBlocks, NotEnoughChunks};
 use near_primitives::version::ProtocolFeature::SimpleNightshade;
 use near_primitives::version::PROTOCOL_VERSION;
@@ -2664,6 +2657,13 @@ fn test_max_kickout_stake_ratio() {
 #[test]
 #[cfg(feature = "nightly")]
 fn test_verify_chunk_endorsements() {
+    use near_chain_primitives::Error;
+    use near_crypto::Signature;
+    use near_primitives::chunk_validation::ChunkEndorsement;
+    use near_primitives::sharding::{ShardChunkHeader, ShardChunkHeaderV3};
+    use near_primitives::test_utils::create_test_signer;
+    use std::str::FromStr;
+
     let amount_staked = 1_000_000;
     let account_id = AccountId::from_str("test1").unwrap();
     let validators = vec![(account_id.clone(), amount_staked)];

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -2662,6 +2662,7 @@ fn test_max_kickout_stake_ratio() {
 }
 
 #[test]
+#[cfg(feature = "nightly")]
 fn test_verify_chunk_endorsements() {
     let amount_staked = 1_000_000;
     let account_id = AccountId::from_str("test1").unwrap();

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -1,5 +1,7 @@
 mod random_epochs;
 
+use std::str::FromStr;
+
 use super::*;
 use crate::reward_calculator::NUM_NS_IN_SECOND;
 use crate::test_utils::{
@@ -9,11 +11,16 @@ use crate::test_utils::{
     record_with_block_info, reward, setup_default_epoch_manager, setup_epoch_manager, stake,
     DEFAULT_TOTAL_SUPPLY,
 };
+use near_chain_primitives::Error;
+use near_crypto::Signature;
 use near_primitives::account::id::AccountIdRef;
 use near_primitives::challenge::SlashedValidator;
+use near_primitives::chunk_validation::ChunkEndorsement;
 use near_primitives::epoch_manager::EpochConfig;
 use near_primitives::hash::hash;
 use near_primitives::shard_layout::ShardLayout;
+use near_primitives::sharding::{ShardChunkHeader, ShardChunkHeaderV3};
+use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::ValidatorKickoutReason::{NotEnoughBlocks, NotEnoughChunks};
 use near_primitives::version::ProtocolFeature::SimpleNightshade;
 use near_primitives::version::PROTOCOL_VERSION;
@@ -2652,4 +2659,76 @@ fn test_max_kickout_stake_ratio() {
             ),
         ])
     );
+}
+
+#[test]
+fn test_verify_chunk_endorsements() {
+    let amount_staked = 1_000_000;
+    let account_id = AccountId::from_str("test1").unwrap();
+    let validators = vec![(account_id.clone(), amount_staked)];
+    let h = hash_range(6);
+
+    let mut epoch_manager = setup_default_epoch_manager(validators.clone(), 5, 1, 2, 2, 90, 60);
+    record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
+    record_block(&mut epoch_manager, h[0], h[1], 1, vec![]);
+
+    // build a chunk endorsement and chunk header
+    let epoch_manager = epoch_manager.into_handle();
+    let epoch_id = epoch_manager.get_epoch_id(&h[1]).unwrap();
+
+    // verify if we have one chunk validator
+    let chunk_validators = epoch_manager.get_chunk_validators(&epoch_id, 0, 1).unwrap();
+    assert_eq!(chunk_validators.len(), 1);
+    assert!(chunk_validators.contains_key(&account_id));
+
+    // verify if the test signer has same public key as the chunk validator
+    let (validator, _) =
+        epoch_manager.get_validator_by_account_id(&epoch_id, &h[0], &account_id).unwrap();
+    let signer = Arc::new(create_test_signer("test1"));
+    assert_eq!(signer.public_key(), validator.public_key().clone());
+
+    // make chunk header
+    let chunk_header = ShardChunkHeader::V3(ShardChunkHeaderV3::new(
+        h[0],
+        h[2],
+        h[2],
+        h[2],
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        h[2],
+        h[2],
+        vec![],
+        signer.as_ref(),
+    ));
+
+    // check chunk endorsement validity
+    let mut chunk_endorsement = ChunkEndorsement::new(chunk_header.chunk_hash(), signer.clone());
+    assert!(epoch_manager.verify_chunk_endorsement(&chunk_header, &chunk_endorsement).unwrap());
+
+    // check invalid chunk endorsement signature
+    chunk_endorsement.signature = Signature::default();
+    assert!(!epoch_manager.verify_chunk_endorsement(&chunk_header, &chunk_endorsement).unwrap());
+
+    // check chunk endorsement invalidity when chunk header and chunk endorsement don't match
+    let chunk_endorsement = ChunkEndorsement::new(h[3].into(), signer);
+    let err =
+        epoch_manager.verify_chunk_endorsement(&chunk_header, &chunk_endorsement).unwrap_err();
+    match err {
+        Error::InvalidChunkEndorsement => (),
+        _ => assert!(false, "Expected InvalidChunkEndorsement error but got {:?}", err),
+    }
+
+    // check chunk endorsement invalidity when signer is not chunk validator
+    let bad_signer = Arc::new(create_test_signer("test2"));
+    let chunk_endorsement = ChunkEndorsement::new(chunk_header.chunk_hash(), bad_signer);
+    let err =
+        epoch_manager.verify_chunk_endorsement(&chunk_header, &chunk_endorsement).unwrap_err();
+    match err {
+        Error::NotAValidator => (),
+        _ => assert!(false, "Expected NotAValidator error but got {:?}", err),
+    }
 }

--- a/core/primitives/src/chunk_validation.rs
+++ b/core/primitives/src/chunk_validation.rs
@@ -100,9 +100,9 @@ pub struct ChunkStateTransition {
 /// chunk validator has verified that the chunk state witness is correct.
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ChunkEndorsement {
-    pub account_id: AccountId,
     inner: ChunkEndorsementInner,
-    signature: Signature,
+    pub account_id: AccountId,
+    pub signature: Signature,
 }
 
 impl ChunkEndorsement {

--- a/core/primitives/src/chunk_validation.rs
+++ b/core/primitives/src/chunk_validation.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::challenge::PartialState;
 use crate::sharding::{ChunkHash, ReceiptProof, ShardChunkHeader};
 use crate::transaction::SignedTransaction;
+use crate::validator_signer::ValidatorSigner;
 use borsh::{BorshDeserialize, BorshSerialize};
-use near_crypto::Signature;
+use near_crypto::{PublicKey, Signature};
 use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::AccountId;
 
@@ -98,15 +100,33 @@ pub struct ChunkStateTransition {
 /// chunk validator has verified that the chunk state witness is correct.
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ChunkEndorsement {
-    pub inner: ChunkEndorsementInner,
     pub account_id: AccountId,
-    pub signature: Signature,
+    inner: ChunkEndorsementInner,
+    signature: Signature,
+}
+
+impl ChunkEndorsement {
+    pub fn new(chunk_hash: ChunkHash, signer: Arc<dyn ValidatorSigner>) -> ChunkEndorsement {
+        let inner = ChunkEndorsementInner::new(chunk_hash);
+        let account_id = signer.validator_id().clone();
+        let signature = signer.sign_chunk_endorsement(&inner);
+        Self { inner, account_id, signature }
+    }
+
+    pub fn verify(&self, public_key: &PublicKey) -> bool {
+        let data = borsh::to_vec(&self.inner).unwrap();
+        self.signature.verify(&data, public_key)
+    }
+
+    pub fn chunk_hash(&self) -> &ChunkHash {
+        &self.inner.chunk_hash
+    }
 }
 
 /// This is the part of the chunk endorsement that is actually being signed.
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ChunkEndorsementInner {
-    pub chunk_hash: ChunkHash,
+    chunk_hash: ChunkHash,
     /// An arbitrary static string to make sure that this struct cannot be
     /// serialized to look identical to another serialized struct. For chunk
     /// production we are signing a chunk hash, so we need to make sure that
@@ -117,7 +137,7 @@ pub struct ChunkEndorsementInner {
 }
 
 impl ChunkEndorsementInner {
-    pub fn new(chunk_hash: ChunkHash) -> Self {
+    fn new(chunk_hash: ChunkHash) -> Self {
         Self { chunk_hash, signature_differentiator: "ChunkEndorsement".to_owned() }
     }
 }


### PR DESCRIPTION
This PR adds the implementation for `process_chunk_endorsement` function in client.

When a client gets a new chunk endorsement, we do the following
- Verify if the chunk endorsement is from a valid chunk validator
- Verify if the signature is correct
- Store the chunk endorsement in-memory in a LRU cache `LruCache<ChunkHash, HashMap<AccountId, ChunkEndorsement>>`

The ChunkEndorsements would later be included in the block body during block production.

Minor cleanup to the ChunkEndorsement struct as well.