### PR TITLE
themis: add a check for unused dependencies in root Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,6 @@ cfg-if = "1.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 clap = { version = "4.2.0", features = ["derive", "env", "string"] }
 cloud-storage = "0.11.1"
-conqueue = "0.4.0"
 cpu-time = "1.0"
 criterion = { version = "0.5.1", default_features = false, features = ["html_reports", "cargo_bench_support"] }
 crossbeam = "0.8"
@@ -161,7 +160,6 @@ enum-map = "2.1.0"
 enumset = "1.0"
 expect-test = "1.3.0"
 finite-wasm = "0.5.0"
-flate2 = "1.0.22"
 fs2 = "0.4"
 futures = "0.3.5"
 futures-util = "0.3"
@@ -181,11 +179,9 @@ itertools = "0.10.0"
 itoa = "1.0"
 json_comments = "0.2.1"
 lazy_static = "1.4"
-leb128 = "0.2"
 libc = "0.2.81"
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 log = "0.4"
-loupe = "0.1"
 lru = "0.7.2"
 memmap2 = "0.5"
 memoffset = "0.8"
@@ -247,7 +243,6 @@ near-vm-compiler = { path = "runtime/near-vm/compiler" }
 near-vm-compiler-singlepass = { path = "runtime/near-vm/compiler-singlepass" }
 near-vm-compiler-test-derive = { path = "runtime/near-vm/compiler-test-derive" }
 near-vm-engine = { path = "runtime/near-vm/engine" }
-near-vm-engine-universal = { path = "runtime/near-vm/engine-universal" }
 near-vm-runner = { path = "runtime/near-vm-runner" }
 near-vm-test-generator = { path = "runtime/near-vm/test-generator" }
 near-vm-types = { path = "runtime/near-vm/types" }
@@ -322,7 +317,6 @@ stun = "0.4"
 subtle = "2.2"
 syn = { version = "2.0.4", features = ["extra-traits", "full"] }
 sysinfo = "0.24.5"
-tar = "0.4.38"
 target-lexicon = { version = "0.12.2", default-features = false }
 tempfile = "3.3"
 testlib = { path = "test-utils/testlib" }

--- a/tools/themis/src/main.rs
+++ b/tools/themis/src/main.rs
@@ -22,6 +22,7 @@ fn main() -> anyhow::Result<()> {
         rules::publishable_has_description,
         rules::publishable_has_near_link,
         rules::recursively_publishable,
+        rules::no_superfluous_deps,
     ];
 
     let _unused_rules = [

--- a/tools/themis/src/rules.rs
+++ b/tools/themis/src/rules.rs
@@ -3,7 +3,7 @@ use super::{style, utils};
 use crate::utils::read_toml;
 use anyhow::bail;
 use cargo_metadata::DependencyKind;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 /// Ensure all crates have the `publish = <true/false>` specification
 pub fn has_publish_spec(workspace: &Workspace) -> anyhow::Result<()> {
@@ -396,6 +396,55 @@ pub fn recursively_publishable(workspace: &Workspace) -> anyhow::Result<()> {
                             + name
                             + style::reset()))
                     )),
+                })
+                .collect(),
+        });
+    }
+    Ok(())
+}
+
+/// Ensure that top-level `Cargo.toml` does not contain superfluouos dependencies.
+pub fn no_superfluous_deps(workspace: &Workspace) -> anyhow::Result<()> {
+    let mut workspace_deps = BTreeSet::<String>::new();
+    let mut read_deps = |manifest: &toml::value::Value, table_name: &'static str| {
+        let Some(deps) = manifest.get(table_name) else { return };
+        let Some(deps) = deps.as_table() else { return };
+        for (name, dep) in deps {
+            let Some(workspace_field) = dep.get("workspace") else { continue };
+            let Some(true) = workspace_field.as_bool() else { continue };
+            workspace_deps.insert(name.clone());
+        }
+    };
+    for pkg in workspace.members.iter() {
+        read_deps(&pkg.manifest.raw, "dependencies");
+        read_deps(&pkg.manifest.raw, "dev-dependencies");
+        read_deps(&pkg.manifest.raw, "build-dependencies");
+        let Some(target) = pkg.manifest.raw.get("target") else { continue };
+        let Some(target) = target.as_table() else { continue };
+        for (_, target_manifest) in target {
+            read_deps(&target_manifest, "dependencies");
+            read_deps(&target_manifest, "dev-dependencies");
+            read_deps(&target_manifest, "build-dependencies");
+        }
+    }
+    let Some(root_deps) = workspace.manifest.read(&["workspace", "dependencies"]) else {
+        panic!("Cargo.toml has no [workspace.dependencies]?");
+    };
+    let Some(root_deps) = root_deps.as_table() else {
+        panic!("workspace.dependencies is not a table?");
+    };
+    let root_deps = BTreeSet::from_iter(root_deps.keys().into_iter().cloned());
+    let diff = root_deps.difference(&workspace_deps).collect::<Vec<_>>();
+    if !diff.is_empty() {
+        bail!(ComplianceError {
+            msg: "These dependencies are not used by any workspace member".to_string(),
+            expected: None,
+            outliers: diff
+                .into_iter()
+                .map(|dep| Outlier {
+                    path: workspace.root.clone(),
+                    found: Some(dep.clone()),
+                    extra: None,
                 })
                 .collect(),
         });

--- a/tools/themis/src/types.rs
+++ b/tools/themis/src/types.rs
@@ -20,7 +20,7 @@ pub struct Workspace {
 
 #[derive(Debug)]
 pub struct Manifest {
-    raw: toml::Value,
+    pub(crate) raw: toml::Value,
     parent: Option<Rc<Manifest>>,
 }
 


### PR DESCRIPTION
It looks like we’re prone to accumulating trash in our root `Cargo.toml` file. Even dependencies that are no longer valid in any way (as evidenced by `near-vm-engine-universal`.) This themis check verifies that all deps in `Cargo.toml` are being referenced.