### PR TITLE
style: check for unused dependencies using cargo-udeps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,19 @@ jobs:
           crate: just
       - run: just check-non-default
 
+  check_udeps:
+    name: "Unused dependencies"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
+        with:
+          crate: just
+      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
+        with:
+          crate: cargo-udeps
+      - run: just check-udeps
+
   cargo_audit:
     name: "Cargo Audit"
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: cargo-llvm-cov
+      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
+        with:
+          crate: cargo-udeps
 
       # Setup the dependency rust cache and llvm-cov
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,16 +971,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "c2-chacha"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27dae93fe7b1e0424dc57179ac396908c26b035a87234809f5c4dfd1b47dc80"
-dependencies = [
- "cipher",
- "ppv-lite86",
-]
-
-[[package]]
 name = "camino"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,15 +1109,6 @@ checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
  "half",
-]
-
-[[package]]
-name = "cipher"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
-dependencies = [
- "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -2706,17 +2687,6 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
@@ -3183,12 +3153,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
-
-[[package]]
 name = "maybe-async"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3417,7 +3381,6 @@ name = "near-actix-test-utils"
 version = "0.0.0"
 dependencies = [
  "actix-rt",
- "futures",
  "near-store",
  "once_cell",
 ]
@@ -3437,7 +3400,6 @@ dependencies = [
  "near-primitives",
  "near-primitives-core",
  "near-store",
- "near-test-contracts",
  "nearcore",
  "node-runtime",
  "num-rational",
@@ -3457,7 +3419,6 @@ dependencies = [
  "futures",
  "near-o11y",
  "near-performance-metrics",
- "near-primitives",
  "once_cell",
  "serde",
  "serde_json",
@@ -3681,7 +3642,6 @@ dependencies = [
  "bolero",
  "borsh 1.0.0",
  "bs58",
- "c2-chacha",
  "curve25519-dalek",
  "derive_more",
  "ed25519-dalek",
@@ -3898,7 +3858,6 @@ dependencies = [
 name = "near-jsonrpc-adversarial-primitives"
 version = "0.0.0"
 dependencies = [
- "near-network",
  "near-primitives",
  "serde",
 ]
@@ -4052,7 +4011,6 @@ dependencies = [
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-primitives",
- "near-stable-hasher",
  "near-store",
  "once_cell",
  "opentelemetry",
@@ -4139,7 +4097,6 @@ dependencies = [
  "futures",
  "libc",
  "once_cell",
- "strum",
  "tokio",
  "tokio-util 0.7.2",
  "tracing",
@@ -4244,9 +4201,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "serde_with",
  "sha2",
- "strum",
  "thiserror",
 ]
 
@@ -4280,7 +4235,6 @@ dependencies = [
  "strum",
  "thiserror",
  "tokio",
- "validator",
 ]
 
 [[package]]
@@ -4303,10 +4257,6 @@ dependencies = [
  "serde_json",
  "syn 2.0.32",
 ]
-
-[[package]]
-name = "near-stable-hasher"
-version = "0.0.0"
 
 [[package]]
 name = "near-state-parts"
@@ -4369,7 +4319,6 @@ dependencies = [
  "derive_more",
  "elastic-array",
  "enum-map",
- "fs2",
  "hex",
  "insta",
  "itertools",
@@ -4456,7 +4405,6 @@ dependencies = [
  "near-vm-types",
  "near-vm-vm",
  "rkyv",
- "smallvec",
  "target-lexicon 0.12.3",
  "thiserror",
  "tracing",
@@ -4506,7 +4454,6 @@ dependencies = [
  "enumset",
  "finite-wasm",
  "lazy_static",
- "memmap2",
  "more-asserts",
  "near-vm-compiler",
  "near-vm-types",
@@ -4557,7 +4504,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "serde_with",
  "sha2",
  "sha3",
  "strum",
@@ -4628,7 +4574,6 @@ name = "near-vm-test-generator"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "target-lexicon 0.12.3",
 ]
 
 [[package]]
@@ -4659,7 +4604,6 @@ dependencies = [
  "rkyv",
  "thiserror",
  "tracing",
- "wasmparser 0.99.0",
  "winapi",
 ]
 
@@ -4669,7 +4613,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "near-vm-test-api",
- "tempfile",
  "thiserror",
  "wast",
 ]
@@ -4789,7 +4732,6 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_json",
- "shell-escape",
  "state-viewer",
  "thiserror",
  "tikv-jemallocator",
@@ -6589,12 +6531,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-escape"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
-
-[[package]]
 name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6816,7 +6752,6 @@ dependencies = [
  "near-parameters",
  "near-primitives",
  "near-store",
- "node-runtime",
  "serde_json",
  "tokio",
  "tracing",
@@ -7580,7 +7515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
- "idna 0.3.0",
+ "idna",
  "percent-encoding",
 ]
 
@@ -7595,28 +7530,6 @@ name = "uuid"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
-
-[[package]]
-name = "validator"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d6937c33ec6039d8071bcf72933146b5bbe378d645d8fa59bdadabfc2a249"
-dependencies = [
- "idna 0.2.3",
- "lazy_static",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "url",
- "validator_types",
-]
-
-[[package]]
-name = "validator_types"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9680608df133af2c1ddd5eaf1ddce91d60d61b6bc51494ef326458365a470a"
 
 [[package]]
 name = "valuable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "sha1",
  "smallvec",
  "tokio",
@@ -534,7 +534,7 @@ dependencies = [
  "openssl",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -734,7 +734,7 @@ dependencies = [
  "bolero-kani",
  "bolero-libfuzzer",
  "cfg-if 1.0.0",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -756,7 +756,7 @@ dependencies = [
  "bolero-generator",
  "lazy_static",
  "pretty-hex",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -1065,7 +1065,7 @@ dependencies = [
  "nearcore",
  "openssl-probe",
  "parking_lot 0.12.1",
- "rand 0.8.5",
+ "rand",
  "tokio",
 ]
 
@@ -1218,7 +1218,7 @@ dependencies = [
  "near-primitives",
  "near-store",
  "nearcore",
- "rand 0.8.5",
+ "rand",
  "strum",
  "tracing",
 ]
@@ -2822,7 +2822,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "primitive-types",
- "rand 0.8.5",
+ "rand",
  "rlp",
  "serde",
  "serde_json",
@@ -3327,7 +3327,7 @@ dependencies = [
  "near-telemetry",
  "nearcore",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "rayon",
  "serde",
  "serde_json",
@@ -3432,7 +3432,7 @@ version = "0.0.0"
 dependencies = [
  "bencher",
  "lru",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -3466,8 +3466,8 @@ dependencies = [
  "near-store",
  "num-rational",
  "once_cell",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "rayon",
  "strum",
  "thiserror",
@@ -3535,7 +3535,7 @@ dependencies = [
  "near-primitives",
  "near-store",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "reed-solomon-erasure",
  "strum",
  "time",
@@ -3588,7 +3588,7 @@ dependencies = [
  "num-rational",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand",
  "rayon",
  "reed-solomon-erasure",
  "regex",
@@ -3652,7 +3652,6 @@ dependencies = [
  "near-stdx",
  "once_cell",
  "primitive-types",
- "rand 0.7.3",
  "secp256k1",
  "serde",
  "serde_json",
@@ -3676,7 +3675,7 @@ dependencies = [
  "near-primitives",
  "near-store",
  "nearcore",
- "rand 0.8.5",
+ "rand",
  "rayon",
  "rocksdb",
  "strum",
@@ -3715,8 +3714,8 @@ dependencies = [
  "near-store",
  "num-rational",
  "primitive-types",
- "rand 0.8.5",
- "rand_hc 0.3.1",
+ "rand",
+ "rand_hc",
  "serde_json",
  "smart-default",
  "tracing",
@@ -4019,7 +4018,7 @@ dependencies = [
  "pretty_assertions",
  "protobuf 3.0.2",
  "protobuf-codegen",
- "rand 0.8.5",
+ "rand",
  "rand_xorshift",
  "rayon",
  "rlimit",
@@ -4138,7 +4137,7 @@ dependencies = [
  "near-o11y",
  "near-primitives",
  "once_cell",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -4170,8 +4169,8 @@ dependencies = [
  "num-rational",
  "once_cell",
  "primitive-types",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "reed-solomon-erasure",
  "serde",
  "serde_json",
@@ -4336,7 +4335,7 @@ dependencies = [
  "near-vm-runner",
  "num_cpus",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "rayon",
  "rlimit",
  "rocksdb",
@@ -4373,7 +4372,7 @@ version = "0.0.0"
 dependencies = [
  "arbitrary",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "wasm-encoder 0.27.0",
  "wasm-smith",
  "wat",
@@ -4499,7 +4498,7 @@ dependencies = [
  "parity-wasm 0.42.2",
  "prefix-sum-vec",
  "pwasm-utils",
- "rand 0.8.5",
+ "rand",
  "ripemd",
  "serde",
  "serde_json",
@@ -4674,7 +4673,7 @@ dependencies = [
  "num-rational",
  "once_cell",
  "primitive-types",
- "rand 0.8.5",
+ "rand",
  "rayon",
  "regex",
  "reqwest",
@@ -4788,7 +4787,7 @@ dependencies = [
  "num-rational",
  "num-traits",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "rayon",
  "serde",
  "serde_json",
@@ -5006,7 +5005,7 @@ dependencies = [
  "lazy_static",
  "percent-encoding",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -5612,36 +5611,13 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -5670,15 +5646,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.9",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -6011,7 +5978,7 @@ dependencies = [
  "node-runtime",
  "num-rational",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "rand_xorshift",
  "rocksdb",
  "serde_json",
@@ -6265,7 +6232,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
- "rand 0.8.5",
+ "rand",
  "secp256k1-sys",
 ]
 
@@ -6720,7 +6687,7 @@ dependencies = [
  "nearcore",
  "node-runtime",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "rayon",
  "redis",
  "regex",
@@ -6813,7 +6780,7 @@ dependencies = [
  "crc",
  "lazy_static",
  "md-5",
- "rand 0.8.5",
+ "rand",
  "ring",
  "subtle",
  "thiserror",
@@ -7241,7 +7208,7 @@ dependencies = [
  "indexmap 1.9.2",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
  "tokio-util 0.7.2",
@@ -7422,7 +7389,7 @@ dependencies = [
  "futures",
  "log",
  "md-5",
- "rand 0.8.5",
+ "rand",
  "ring",
  "stun",
  "thiserror",
@@ -8100,7 +8067,7 @@ dependencies = [
  "memfd",
  "memoffset 0.9.0",
  "paste",
- "rand 0.8.5",
+ "rand",
  "rustix 0.38.24",
  "sptr",
  "wasm-encoder 0.35.0",
@@ -8187,7 +8154,7 @@ dependencies = [
  "libc",
  "log",
  "nix 0.24.3",
- "rand 0.8.5",
+ "rand",
  "thiserror",
  "tokio",
  "winapi",
@@ -8547,7 +8514,7 @@ dependencies = [
  "byteorder",
  "crunchy",
  "lazy_static",
- "rand 0.8.5",
+ "rand",
  "rustc-hex",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,14 +134,12 @@ borsh = { version = "1.0.0", features = ["derive", "rc"] }
 bs58 = "0.4"
 bytes = "1"
 bytesize = { version = "1.1", features = ["serde"] }
-c2-chacha = "0.3"
 cargo_metadata = "0.14.1"
 cc = "1.0"
 cfg-if = "1.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 clap = { version = "4.2.0", features = ["derive", "env", "string"] }
 cloud-storage = "0.11.1"
-conqueue = "0.4.0"
 cpu-time = "1.0"
 criterion = { version = "0.5.1", default_features = false, features = ["html_reports", "cargo_bench_support"] }
 crossbeam = "0.8"
@@ -161,7 +159,6 @@ enum-map = "2.1.0"
 enumset = "1.0"
 expect-test = "1.3.0"
 finite-wasm = "0.5.0"
-flate2 = "1.0.22"
 fs2 = "0.4"
 futures = "0.3.5"
 futures-util = "0.3"
@@ -181,13 +178,10 @@ itertools = "0.10.0"
 itoa = "1.0"
 json_comments = "0.2.1"
 lazy_static = "1.4"
-leb128 = "0.2"
 libc = "0.2.81"
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 log = "0.4"
-loupe = "0.1"
 lru = "0.7.2"
-memmap2 = "0.5"
 memoffset = "0.8"
 more-asserts = "0.2"
 near-account-id = { version = "1.0.0-alpha.4", features = ["internal_unstable", "serde", "borsh"] }
@@ -234,7 +228,6 @@ near-primitives-core = { path = "core/primitives-core" }
 near-rosetta-rpc = { path = "chain/rosetta-rpc" }
 near-rpc-error-core = { path = "tools/rpctypegen/core" }
 near-rpc-error-macro = { path = "tools/rpctypegen/macro" }
-near-stable-hasher = { path = "utils/near-stable-hasher" }
 near-state-parts = { path = "tools/state-parts" }
 near-state-parts-dump-check = { path = "tools/state-parts-dump-check" }
 near-state-viewer = { path = "tools/state-viewer", package = "state-viewer" }
@@ -247,7 +240,6 @@ near-vm-compiler = { path = "runtime/near-vm/compiler" }
 near-vm-compiler-singlepass = { path = "runtime/near-vm/compiler-singlepass" }
 near-vm-compiler-test-derive = { path = "runtime/near-vm/compiler-test-derive" }
 near-vm-engine = { path = "runtime/near-vm/engine" }
-near-vm-engine-universal = { path = "runtime/near-vm/engine-universal" }
 near-vm-runner = { path = "runtime/near-vm-runner" }
 near-vm-test-generator = { path = "runtime/near-vm/test-generator" }
 near-vm-types = { path = "runtime/near-vm/types" }
@@ -313,7 +305,6 @@ serde_yaml = "0.9"
 serial_test = "0.5"
 sha2 = "0.10"
 sha3 = "0.10"
-shell-escape = "0.1.5"
 smallvec = "1.6"
 smart-default = "0.6"
 smartstring = "1.0.1"
@@ -322,7 +313,6 @@ stun = "0.4"
 subtle = "2.2"
 syn = { version = "2.0.4", features = ["extra-traits", "full"] }
 sysinfo = "0.24.5"
-tar = "0.4.38"
 target-lexicon = { version = "0.12.2", default-features = false }
 tempfile = "3.3"
 testlib = { path = "test-utils/testlib" }
@@ -349,7 +339,6 @@ tracing-span-tree = "0.1"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter", "fmt", "registry", "std"] }
 trybuild = "1.0.11"
 turn = "0.6"
-validator = "0.12"
 wasm-encoder = "0.27.0"
 wasmer-compiler = { package = "wasmer-compiler-near", version = "=2.4.1" }
 wasmer-compiler-singlepass = { package = "wasmer-compiler-singlepass-near", version = "=2.4.1" }

--- a/Justfile
+++ b/Justfile
@@ -15,7 +15,7 @@ ci_hack_nextest_profile := if env("CI_HACKS", "0") == "1" { "--profile ci" } els
 test *FLAGS: (test-ci FLAGS) test-extra
 
 # only the tests that are exactly the same as the ones in CI
-test-ci *FLAGS: (nextest "stable" FLAGS) (nextest "nightly" FLAGS) check-non-default python-style-checks
+test-ci *FLAGS: (nextest "stable" FLAGS) (nextest "nightly" FLAGS) check-non-default check-udeps python-style-checks
 
 # tests that are as close to CI as possible, but not exactly the same code
 test-extra: check-lychee
@@ -81,6 +81,11 @@ python-style-checks:
     python3 scripts/check_pytests.py
     python3 scripts/fix_nightly_feature_flags.py
     ./scripts/formatting --check
+
+check-udeps:
+    rustup toolchain install nightly
+    rustup target add wasm32-unknown-unknown --toolchain nightly
+    env CARGO_TARGET_DIR={{justfile_directory()}}/target/udeps RUSTFLAGS='--cfg=udeps --cap-lints=allow' cargo +nightly udeps
 
 # lychee-based url validity checks
 check-lychee:

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -61,8 +61,6 @@ protocol_feature_reject_blocks_with_outdated_protocol_version = [
 ]
 
 nightly = [
-  "nightly_protocol",
-  "protocol_feature_reject_blocks_with_outdated_protocol_version",
   "near-async/nightly",
   "near-chain-configs/nightly",
   "near-client-primitives/nightly",
@@ -72,6 +70,8 @@ nightly = [
   "near-pool/nightly",
   "near-primitives/nightly",
   "near-store/nightly",
+  "nightly_protocol",
+  "protocol_feature_reject_blocks_with_outdated_protocol_version",
 ]
 nightly_protocol = [
   "near-async/nightly_protocol",

--- a/chain/chunks/Cargo.toml
+++ b/chain/chunks/Cargo.toml
@@ -16,7 +16,6 @@ actix.workspace = true
 borsh.workspace = true
 chrono.workspace = true
 derive_more.workspace = true
-derive-enum-from-into.workspace = true
 futures.workspace = true
 lru.workspace = true
 once_cell.workspace = true
@@ -44,6 +43,7 @@ near-performance-metrics-macros.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
+derive-enum-from-into.workspace = true
 
 [features]
 nightly_protocol = [

--- a/chain/chunks/Cargo.toml
+++ b/chain/chunks/Cargo.toml
@@ -58,7 +58,6 @@ nightly_protocol = [
   "near-store/nightly_protocol",
 ]
 nightly = [
-  "nightly_protocol",
   "near-async/nightly",
   "near-chain-configs/nightly",
   "near-chain/nightly",
@@ -68,6 +67,7 @@ nightly = [
   "near-pool/nightly",
   "near-primitives/nightly",
   "near-store/nightly",
+  "nightly_protocol",
 ]
 byzantine_asserts = ["near-chain/byzantine_asserts"]
 expensive_tests = []

--- a/chain/client-primitives/Cargo.toml
+++ b/chain/client-primitives/Cargo.toml
@@ -33,8 +33,8 @@ nightly_protocol = [
   "near-primitives/nightly_protocol",
 ]
 nightly = [
-  "nightly_protocol",
   "near-chain-configs/nightly",
   "near-primitives/nightly",
+  "nightly_protocol",
 ]
 sandbox = []

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -75,6 +75,7 @@ test_features = [
   "near-chunks/test_features",
 ]
 nightly_protocol = [
+  "near-actix-test-utils/nightly_protocol",
   "near-async/nightly_protocol",
   "near-chain-configs/nightly_protocol",
   "near-chain/nightly_protocol",
@@ -91,7 +92,7 @@ nightly_protocol = [
   "near-telemetry/nightly_protocol",
 ]
 nightly = [
-  "nightly_protocol",
+  "near-actix-test-utils/nightly",
   "near-async/nightly",
   "near-chain-configs/nightly",
   "near-chain/nightly",
@@ -106,6 +107,7 @@ nightly = [
   "near-primitives/nightly",
   "near-store/nightly",
   "near-telemetry/nightly",
+  "nightly_protocol",
 ]
 sandbox = [
   "near-client-primitives/sandbox",

--- a/chain/epoch-manager/Cargo.toml
+++ b/chain/epoch-manager/Cargo.toml
@@ -37,11 +37,11 @@ protocol_feature_fix_staking_threshold = [
   "near-primitives/protocol_feature_fix_staking_threshold",
 ]
 nightly = [
-  "nightly_protocol",
-  "protocol_feature_fix_staking_threshold",
   "near-chain-configs/nightly",
   "near-primitives/nightly",
   "near-store/nightly",
+  "nightly_protocol",
+  "protocol_feature_fix_staking_threshold",
 ]
 nightly_protocol = [
   "near-chain-configs/nightly_protocol",

--- a/chain/indexer-primitives/Cargo.toml
+++ b/chain/indexer-primitives/Cargo.toml
@@ -19,8 +19,8 @@ near-primitives.workspace = true
 
 [features]
 nightly = [
-  "nightly_protocol",
   "near-primitives/nightly",
+  "nightly_protocol",
 ]
 nightly_protocol = [
   "near-primitives/nightly_protocol",

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -50,7 +50,6 @@ nightly_protocol = [
 ]
 calimero_zero_storage = ["near-primitives/calimero_zero_storage"]
 nightly = [
-  "nightly_protocol",
   "near-chain-configs/nightly",
   "near-client/nightly",
   "near-dyn-configs/nightly",
@@ -60,5 +59,6 @@ nightly = [
   "near-primitives/nightly",
   "near-store/nightly",
   "nearcore/nightly",
+  "nightly_protocol",
   "node-runtime/nightly",
 ]

--- a/chain/jsonrpc-adversarial-primitives/Cargo.toml
+++ b/chain/jsonrpc-adversarial-primitives/Cargo.toml
@@ -15,16 +15,13 @@ workspace = true
 serde.workspace = true
 
 near-primitives.workspace = true
-near-network.workspace = true
 
 [features]
 nightly_protocol = [
-  "near-network/nightly_protocol",
   "near-primitives/nightly_protocol",
 ]
 nightly = [
   "nightly_protocol",
-  "near-network/nightly",
   "near-primitives/nightly",
 ]
-test_features = ["near-network/test_features"]
+test_features = []

--- a/chain/jsonrpc-adversarial-primitives/Cargo.toml
+++ b/chain/jsonrpc-adversarial-primitives/Cargo.toml
@@ -21,7 +21,7 @@ nightly_protocol = [
   "near-primitives/nightly_protocol",
 ]
 nightly = [
-  "nightly_protocol",
   "near-primitives/nightly",
+  "nightly_protocol",
 ]
 test_features = []

--- a/chain/jsonrpc-primitives/Cargo.toml
+++ b/chain/jsonrpc-primitives/Cargo.toml
@@ -30,10 +30,10 @@ nightly_protocol = [
   "near-primitives/nightly_protocol",
 ]
 nightly = [
-  "nightly_protocol",
   "near-chain-configs/nightly",
   "near-client-primitives/nightly",
   "near-primitives/nightly",
+  "nightly_protocol",
 ]
 full = ["debug_types"]
 debug_types = ["near-client-primitives"]

--- a/chain/jsonrpc/Cargo.toml
+++ b/chain/jsonrpc/Cargo.toml
@@ -47,7 +47,6 @@ test_features = [
   "near-jsonrpc-adversarial-primitives/test_features",
 ]
 nightly = [
-  "nightly_protocol",
   "near-chain-configs/nightly",
   "near-client-primitives/nightly",
   "near-client/nightly",
@@ -57,6 +56,7 @@ nightly = [
   "near-network/nightly",
   "near-o11y/nightly",
   "near-primitives/nightly",
+  "nightly_protocol",
 ]
 nightly_protocol = [
   "near-chain-configs/nightly_protocol",

--- a/chain/jsonrpc/client/Cargo.toml
+++ b/chain/jsonrpc/client/Cargo.toml
@@ -23,9 +23,9 @@ near-primitives.workspace = true
 
 [features]
 nightly = [
-  "nightly_protocol",
   "near-jsonrpc-primitives/nightly",
   "near-primitives/nightly",
+  "nightly_protocol",
 ]
 nightly_protocol = [
   "near-jsonrpc-primitives/nightly_protocol",

--- a/chain/jsonrpc/jsonrpc-tests/Cargo.toml
+++ b/chain/jsonrpc/jsonrpc-tests/Cargo.toml
@@ -36,7 +36,7 @@ near-actix-test-utils.workspace = true
 [features]
 test_features = ["near-jsonrpc/test_features"]
 nightly = [
-  "nightly_protocol",
+  "near-actix-test-utils/nightly",
   "near-chain-configs/nightly",
   "near-client/nightly",
   "near-jsonrpc-primitives/nightly",
@@ -45,8 +45,10 @@ nightly = [
   "near-o11y/nightly",
   "near-primitives/nightly",
   "near-store/nightly",
+  "nightly_protocol",
 ]
 nightly_protocol = [
+  "near-actix-test-utils/nightly_protocol",
   "near-chain-configs/nightly_protocol",
   "near-client/nightly_protocol",
   "near-jsonrpc-primitives/nightly_protocol",

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -77,12 +77,12 @@ nightly_protocol = [
   "near-store/nightly_protocol",
 ]
 nightly = [
-  "nightly_protocol",
   "near-async/nightly",
   "near-fmt/nightly",
   "near-o11y/nightly",
   "near-primitives/nightly",
   "near-store/nightly",
+  "nightly_protocol",
 ]
 performance_stats = [
     "near-performance-metrics/performance_stats",

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -20,7 +20,6 @@ async-trait.workspace = true
 actix.workspace = true
 anyhow.workspace = true
 arc-swap.workspace = true
-assert_matches.workspace = true
 borsh.workspace = true
 bytes.workspace = true
 bytesize.workspace = true
@@ -38,7 +37,6 @@ parking_lot.workspace = true
 pin-project.workspace = true
 protobuf.workspace = true
 rand.workspace = true
-rand_xorshift.workspace = true
 rayon.workspace = true
 serde.workspace = true
 smart-default.workspace = true
@@ -58,14 +56,15 @@ near-crypto.workspace = true
 near-performance-metrics.workspace = true
 near-performance-metrics-macros.workspace = true
 near-primitives.workspace = true
-near-stable-hasher.workspace = true
 near-store.workspace = true
 
 [dev-dependencies]
+assert_matches.workspace = true
 criterion.workspace = true
 pretty_assertions.workspace = true
-tempfile.workspace = true
+rand_xorshift.workspace = true
 rlimit.workspace = true
+tempfile.workspace = true
 turn.workspace = true
 webrtc-util.workspace = true
 

--- a/chain/pool/Cargo.toml
+++ b/chain/pool/Cargo.toml
@@ -22,9 +22,9 @@ near-primitives.workspace = true
 
 [features]
 nightly = [
-  "nightly_protocol",
   "near-o11y/nightly",
   "near-primitives/nightly",
+  "nightly_protocol",
 ]
 nightly_protocol = [
   "near-o11y/nightly_protocol",

--- a/chain/rosetta-rpc/Cargo.toml
+++ b/chain/rosetta-rpc/Cargo.toml
@@ -26,7 +26,6 @@ serde_json.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-validator.workspace = true
 
 near-account-id.workspace = true
 near-chain-configs.workspace = true

--- a/chain/rosetta-rpc/Cargo.toml
+++ b/chain/rosetta-rpc/Cargo.toml
@@ -44,6 +44,7 @@ near-actix-test-utils.workspace = true
 
 [features]
 nightly_protocol = [
+  "near-actix-test-utils/nightly_protocol",
   "near-chain-configs/nightly_protocol",
   "near-client-primitives/nightly_protocol",
   "near-client/nightly_protocol",
@@ -54,7 +55,7 @@ nightly_protocol = [
   "node-runtime/nightly_protocol",
 ]
 nightly = [
-  "nightly_protocol",
+  "near-actix-test-utils/nightly",
   "near-chain-configs/nightly",
   "near-client-primitives/nightly",
   "near-client/nightly",
@@ -62,5 +63,6 @@ nightly = [
   "near-o11y/nightly",
   "near-parameters/nightly",
   "near-primitives/nightly",
+  "nightly_protocol",
   "node-runtime/nightly",
 ]

--- a/chain/telemetry/Cargo.toml
+++ b/chain/telemetry/Cargo.toml
@@ -28,9 +28,9 @@ near-primitives.workspace = true
 
 [features]
 nightly = [
-  "nightly_protocol",
   "near-o11y/nightly",
   "near-primitives/nightly",
+  "nightly_protocol",
 ]
 nightly_protocol = [
   "near-o11y/nightly_protocol",

--- a/core/async/Cargo.toml
+++ b/core/async/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 
 [dependencies]
 actix.workspace = true
-derive-enum-from-into.workspace = true
 derive_more.workspace = true
 futures.workspace = true
 once_cell.workspace = true
@@ -23,17 +22,17 @@ serde_json.workspace = true
 time.workspace = true
 tokio.workspace = true
 
-near-primitives.workspace = true
 near-o11y.workspace = true
 near-performance-metrics.workspace = true
+
+[dev-dependencies]
+derive-enum-from-into.workspace = true
 
 [features]
 nightly = [
   "nightly_protocol",
   "near-o11y/nightly",
-  "near-primitives/nightly",
 ]
 nightly_protocol = [
   "near-o11y/nightly_protocol",
-  "near-primitives/nightly_protocol",
 ]

--- a/core/async/Cargo.toml
+++ b/core/async/Cargo.toml
@@ -30,8 +30,8 @@ derive-enum-from-into.workspace = true
 
 [features]
 nightly = [
-  "nightly_protocol",
   "near-o11y/nightly",
+  "nightly_protocol",
 ]
 nightly_protocol = [
   "near-o11y/nightly_protocol",

--- a/core/chain-configs/Cargo.toml
+++ b/core/chain-configs/Cargo.toml
@@ -37,10 +37,10 @@ nightly_protocol = [
   "near-primitives/nightly_protocol",
 ]
 nightly = [
-  "nightly_protocol",
   "near-o11y/nightly",
   "near-parameters/nightly",
   "near-primitives/nightly",
+  "nightly_protocol",
 ]
 default = []
 metrics = ["near-o11y"]

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 blake2.workspace = true
 borsh.workspace = true
 bs58.workspace = true
-c2-chacha.workspace = true
 curve25519-dalek.workspace = true
 derive_more.workspace = true
 ed25519-dalek.workspace = true

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -22,7 +22,6 @@ hex.workspace = true
 near-account-id.workspace = true
 once_cell.workspace = true
 primitive-types.workspace = true
-rand = "0.7" # TODO: this is probably wrong?
 secp256k1.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/core/dyn-configs/Cargo.toml
+++ b/core/dyn-configs/Cargo.toml
@@ -27,10 +27,10 @@ near-primitives.workspace = true
 
 [features]
 nightly = [
-  "nightly_protocol",
   "near-chain-configs/nightly",
   "near-o11y/nightly",
   "near-primitives/nightly",
+  "nightly_protocol",
 ]
 nightly_protocol = [
   "near-chain-configs/nightly_protocol",

--- a/core/o11y/Cargo.toml
+++ b/core/o11y/Cargo.toml
@@ -45,9 +45,9 @@ nightly_protocol = [
   "near-primitives-core/nightly_protocol",
 ]
 nightly = [
-  "nightly_protocol",
   "near-fmt/nightly",
   "near-primitives-core/nightly",
+  "nightly_protocol",
 ]
 io_trace = [ "near-fmt", "strum" ]
 

--- a/core/o11y/Cargo.toml
+++ b/core/o11y/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 near-crypto.workspace = true
-near-fmt.workspace = true
+near-fmt = { workspace = true, optional = true }
 near-primitives-core.workspace = true
 
 actix.workspace = true
@@ -26,7 +26,7 @@ opentelemetry-semantic-conventions.workspace = true
 prometheus.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-strum.workspace = true
+strum = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
@@ -49,7 +49,7 @@ nightly = [
   "near-fmt/nightly",
   "near-primitives-core/nightly",
 ]
-io_trace = []
+io_trace = [ "near-fmt", "strum" ]
 
 [[bench]]
 name = "metrics"

--- a/core/parameters/Cargo.toml
+++ b/core/parameters/Cargo.toml
@@ -33,8 +33,8 @@ insta.workspace = true
 
 [features]
 nightly = [
-  "nightly_protocol",
   "near-primitives-core/nightly",
+  "nightly_protocol",
 ]
 nightly_protocol = [
   "near-primitives-core/nightly_protocol",

--- a/core/parameters/Cargo.toml
+++ b/core/parameters/Cargo.toml
@@ -12,7 +12,6 @@ publish = true
 workspace = true
 
 [dependencies]
-assert_matches.workspace = true
 enum-map.workspace = true
 num-rational.workspace = true
 serde.workspace = true
@@ -29,6 +28,7 @@ near-primitives-core.workspace = true
 near-account-id.workspace = true
 
 [dev-dependencies]
+assert_matches.workspace = true
 insta.workspace = true
 
 [features]

--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -21,9 +21,7 @@ enum-map.workspace = true
 num-rational.workspace = true
 serde.workspace = true
 serde_repr.workspace = true
-serde_with.workspace = true
 sha2.workspace = true
-strum.workspace = true
 thiserror.workspace = true
 
 near-account-id.workspace = true

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -55,15 +55,15 @@ protocol_feature_fix_staking_threshold = ["near-primitives-core/protocol_feature
 protocol_feature_fix_contract_loading_cost = ["near-primitives-core/protocol_feature_fix_contract_loading_cost"]
 protocol_feature_reject_blocks_with_outdated_protocol_version = ["near-primitives-core/protocol_feature_reject_blocks_with_outdated_protocol_version"]
 nightly = [
-  "nightly_protocol",
-  "protocol_feature_fix_contract_loading_cost",
-  "protocol_feature_fix_staking_threshold",
-  "protocol_feature_reject_blocks_with_outdated_protocol_version",
   "near-fmt/nightly",
   "near-o11y/nightly",
   "near-parameters/nightly",
   "near-primitives-core/nightly",
   "near-vm-runner/nightly",
+  "nightly_protocol",
+  "protocol_feature_fix_contract_loading_cost",
+  "protocol_feature_fix_staking_threshold",
+  "protocol_feature_reject_blocks_with_outdated_protocol_version",
 ]
 
 nightly_protocol = [

--- a/core/primitives/src/action/mod.rs
+++ b/core/primitives/src/action/mod.rs
@@ -183,7 +183,7 @@ pub enum Action {
 // we come back up to 32 bytes later on.
 // If compiling with nightly, this check may fail due to new optimizations introduced by
 // rustc. So, cfg-them out, as our production system only runs with stable.
-#[cfg(not(fuzz))]
+#[cfg(not(any(fuzz, udeps)))]
 const _: () = assert!(
     cfg!(not(target_pointer_width = "64")) || std::mem::size_of::<Action>() == 32,
     "Action is 32 bytes for performance reasons, see #9451"

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -21,7 +21,6 @@ crossbeam.workspace = true
 derive_more.workspace = true
 elastic-array.workspace = true
 enum-map.workspace = true
-fs2.workspace = true
 hex.workspace = true
 itoa.workspace = true
 itertools.workspace = true

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -80,6 +80,8 @@ new_epoch_sync = []
 
 nightly_protocol = [
   "near-chain-configs/nightly_protocol",
+  "near-chain/nightly_protocol",
+  "near-chunks/nightly_protocol",
   "near-fmt/nightly_protocol",
   "near-o11y/nightly_protocol",
   "near-parameters/nightly_protocol",
@@ -87,11 +89,13 @@ nightly_protocol = [
   "near-vm-runner/nightly_protocol",
 ]
 nightly = [
-  "nightly_protocol",
   "near-chain-configs/nightly",
+  "near-chain/nightly",
+  "near-chunks/nightly",
   "near-fmt/nightly",
   "near-o11y/nightly",
   "near-parameters/nightly",
   "near-primitives/nightly",
   "near-vm-runner/nightly",
+  "nightly_protocol",
 ]

--- a/genesis-tools/genesis-populate/Cargo.toml
+++ b/genesis-tools/genesis-populate/Cargo.toml
@@ -38,7 +38,6 @@ nightly_protocol = [
   "nearcore/nightly_protocol",
 ]
 nightly = [
-  "nightly_protocol",
   "near-chain-configs/nightly",
   "near-chain/nightly",
   "near-epoch-manager/nightly",
@@ -46,4 +45,5 @@ nightly = [
   "near-store/nightly",
   "near-vm-runner/nightly",
   "nearcore/nightly",
+  "nightly_protocol",
 ]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -86,9 +86,6 @@ protocol_feature_reject_blocks_with_outdated_protocol_version = [
 ]
 
 nightly = [
-  "nightly_protocol",
-  "protocol_feature_fix_contract_loading_cost",
-  "protocol_feature_reject_blocks_with_outdated_protocol_version",
   "near-actix-test-utils/nightly",
   "near-async/nightly",
   "near-chain-configs/nightly",
@@ -112,7 +109,10 @@ nightly = [
   "near-vm-runner/nightly",
   "near-wallet-contract/nightly",
   "nearcore/nightly",
+  "nightly_protocol",
   "node-runtime/nightly",
+  "protocol_feature_fix_contract_loading_cost",
+  "protocol_feature_reject_blocks_with_outdated_protocol_version",
   "testlib/nightly",
 ]
 nightly_protocol = [

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -26,7 +26,6 @@ once_cell.workspace = true
 parking_lot.workspace = true
 primitive-types.workspace = true
 rand.workspace = true
-rlp.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 smart-default.workspace = true
@@ -59,7 +58,6 @@ near-o11y.workspace = true
 near-telemetry.workspace = true
 near-test-contracts.workspace = true
 near-performance-metrics.workspace = true
-near-undo-block.workspace = true
 near-vm-runner = { workspace = true, features = [ "prepare" ] }
 near-wallet-contract.workspace = true
 nearcore.workspace = true
@@ -69,6 +67,8 @@ testlib.workspace = true
 [dev-dependencies]
 assert_matches.workspace = true
 insta.workspace = true
+near-undo-block.workspace = true
+rlp.workspace = true
 
 [features]
 performance_stats = [

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -122,10 +122,7 @@ new_epoch_sync = [
 
 serialize_all_state_changes = ["near-store/serialize_all_state_changes"]
 nightly = [
-  "nightly_protocol",
-  "protocol_feature_fix_contract_loading_cost",
-  "protocol_feature_fix_staking_threshold",
-  "serialize_all_state_changes",
+  "near-actix-test-utils/nightly",
   "near-async/nightly",
   "near-chain-configs/nightly",
   "near-chain/nightly",
@@ -146,9 +143,15 @@ nightly = [
   "near-store/nightly",
   "near-telemetry/nightly",
   "near-vm-runner/nightly",
+  "nightly_protocol",
   "node-runtime/nightly",
+  "protocol_feature_fix_contract_loading_cost",
+  "protocol_feature_fix_staking_threshold",
+  "serialize_all_state_changes",
+  "testlib/nightly",
 ]
 nightly_protocol = [
+  "near-actix-test-utils/nightly_protocol",
   "near-async/nightly_protocol",
   "near-chain-configs/nightly_protocol",
   "near-chain/nightly_protocol",
@@ -170,6 +173,7 @@ nightly_protocol = [
   "near-telemetry/nightly_protocol",
   "near-vm-runner/nightly_protocol",
   "node-runtime/nightly_protocol",
+  "testlib/nightly_protocol",
 ]
 
 sandbox = [

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -27,7 +27,6 @@ rayon.workspace = true
 rlimit.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-shell-escape.workspace = true
 thiserror.workspace = true
 tikv-jemallocator.workspace = true
 tokio.workspace = true

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -77,9 +77,6 @@ serialize_all_state_changes = ["nearcore/serialize_all_state_changes"]
 new_epoch_sync = ["nearcore/new_epoch_sync", "dep:near-epoch-sync-tool"]
 
 nightly = [
-  "nightly_protocol",
-  "protocol_feature_fix_staking_threshold",
-  "serialize_all_state_changes",
   "near-chain-configs/nightly",
   "near-client/nightly",
   "near-database-tool/nightly",
@@ -96,6 +93,9 @@ nightly = [
   "near-store/nightly",
   "near-undo-block/nightly",
   "nearcore/nightly",
+  "nightly_protocol",
+  "protocol_feature_fix_staking_threshold",
+  "serialize_all_state_changes",
 ]
 nightly_protocol = [
   "near-chain-configs/nightly_protocol",

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -110,10 +110,10 @@ protocol_feature_fix_contract_loading_cost = [
 ]
 
 nightly = [
-  "nightly_protocol",
-  "protocol_feature_fix_contract_loading_cost",
   "near-parameters/nightly",
   "near-primitives-core/nightly",
+  "nightly_protocol",
+  "protocol_feature_fix_contract_loading_cost",
 ]
 sandbox = []
 io_trace = []

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -27,7 +27,6 @@ parity-wasm = { workspace = true, optional = true }
 prefix-sum-vec.workspace = true
 ripemd.workspace = true
 serde_repr.workspace = true
-serde_with.workspace = true
 serde.workspace = true
 sha2.workspace = true
 sha3.workspace = true

--- a/runtime/near-vm/compiler/Cargo.toml
+++ b/runtime/near-vm/compiler/Cargo.toml
@@ -23,7 +23,6 @@ target-lexicon.workspace = true
 enumset.workspace = true
 hashbrown = { workspace = true, optional = true }
 thiserror.workspace = true
-smallvec.workspace = true
 rkyv.workspace = true
 tracing.workspace = true
 

--- a/runtime/near-vm/engine/Cargo.toml
+++ b/runtime/near-vm/engine/Cargo.toml
@@ -19,7 +19,6 @@ backtrace.workspace = true
 enumset.workspace = true
 finite-wasm.workspace = true
 lazy_static.workspace = true
-memmap2.workspace = true
 more-asserts.workspace = true
 near-vm-compiler.workspace = true
 near-vm-types.workspace = true

--- a/runtime/near-vm/test-generator/Cargo.toml
+++ b/runtime/near-vm/test-generator/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-target-lexicon.workspace = true
 
 [features]
 test-dylib = []

--- a/runtime/near-vm/vm/Cargo.toml
+++ b/runtime/near-vm/vm/Cargo.toml
@@ -27,7 +27,6 @@ rkyv.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 near-vm-types.workspace = true
-wasmparser = "0.99.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi.workspace = true

--- a/runtime/near-vm/wast/Cargo.toml
+++ b/runtime/near-vm/wast/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 anyhow.workspace = true
 near-vm-test-api.workspace = true
 wast.workspace = true
-tempfile.workspace = true
 thiserror.workspace = true
 
 [features]

--- a/runtime/near-wallet-contract/Cargo.toml
+++ b/runtime/near-wallet-contract/Cargo.toml
@@ -23,9 +23,11 @@ anyhow.workspace = true
 
 [features]
 nightly_protocol = [
+  "near-primitives-core/nightly_protocol",
   "near-vm-runner/nightly_protocol",
 ]
 nightly = [
-  "nightly_protocol",
+  "near-primitives-core/nightly",
   "near-vm-runner/nightly",
+  "nightly_protocol",
 ]

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -69,7 +69,6 @@ no_cache = [
   "near-store/no_cache",
 ]
 nightly = [
-  "nightly_protocol",
   "genesis-populate/nightly",
   "near-chain-configs/nightly",
   "near-fmt/nightly",
@@ -79,6 +78,7 @@ nightly = [
   "near-store/nightly",
   "near-vm-runner/nightly",
   "nearcore/nightly",
+  "nightly_protocol",
   "node-runtime/nightly",
 ]
 nightly_protocol = [

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -38,7 +38,6 @@ near-wallet-contract.workspace = true
 
 [features]
 nightly = [
-  "nightly_protocol",
   "near-chain-configs/nightly",
   "near-o11y/nightly",
   "near-parameters/nightly",
@@ -47,6 +46,8 @@ nightly = [
   "near-store/nightly",
   "near-vm-runner/nightly",
   "near-wallet-contract/nightly",
+  "nightly_protocol",
+  "testlib/nightly",
 ]
 default = []
 nightly_protocol = [
@@ -58,6 +59,7 @@ nightly_protocol = [
   "near-store/nightly_protocol",
   "near-vm-runner/nightly_protocol",
   "near-wallet-contract/nightly_protocol",
+  "testlib/nightly_protocol",
 ]
 no_cpu_compatibility_checks = ["near-vm-runner/no_cpu_compatibility_checks"]
 

--- a/scripts/fix_nightly_feature_flags.py
+++ b/scripts/fix_nightly_feature_flags.py
@@ -65,7 +65,11 @@ class Crate:
     def build_deps(self, crates_by_name):
         self.deps = [
             crates_by_name[dep]
-            for dep in self.toml['dependencies'].keys()
+            for dep in self.toml.get('dependencies', {}).keys()
+            if dep in crates_by_name
+        ] + [
+            crates_by_name[dep]
+            for dep in self.toml.get('dev-dependencies', {}).keys()
             if dep in crates_by_name
         ]
 
@@ -127,13 +131,15 @@ class Crate:
         if self.has_nightly_feature:
             ensure_features()
             replace_nightly(
-                list(sorted(self.local_nightly_features)) +
-                list(sorted(self.dependency_nightly_features)))
+                sorted(
+                    set(self.local_nightly_features) |
+                    set(self.dependency_nightly_features)))
         if self.has_nightly_protocol_feature:
             ensure_features()
             replace_nightly_protocol(
-                list(sorted(self.local_nightly_protocol_features)) +
-                list(sorted(self.dependency_nightly_protocol_features)))
+                sorted(
+                    set(self.local_nightly_protocol_features) |
+                    set(self.dependency_nightly_protocol_features)))
 
         if apply_fix:
             open(toml_file_name, "w").write(new_toml_text)

--- a/test-utils/actix-test-utils/Cargo.toml
+++ b/test-utils/actix-test-utils/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 
 [dependencies]
 actix-rt.workspace = true
-futures.workspace = true
 once_cell.workspace = true
 
 near-store.workspace = true

--- a/test-utils/actix-test-utils/Cargo.toml
+++ b/test-utils/actix-test-utils/Cargo.toml
@@ -19,8 +19,8 @@ near-store.workspace = true
 
 [features]
 nightly = [
-  "nightly_protocol",
   "near-store/nightly",
+  "nightly_protocol",
 ]
 nightly_protocol = [
   "near-store/nightly_protocol",

--- a/test-utils/runtime-tester/Cargo.toml
+++ b/test-utils/runtime-tester/Cargo.toml
@@ -12,7 +12,6 @@ publish = false
 workspace = true
 
 [dependencies]
-bolero.workspace = true
 cpu-time.workspace = true
 libfuzzer-sys.workspace = true
 serde.workspace = true
@@ -35,3 +34,4 @@ near-test-contracts.workspace = true
 
 [dev-dependencies]
 testlib.workspace = true
+bolero.workspace = true

--- a/test-utils/style/src/lib.rs
+++ b/test-utils/style/src/lib.rs
@@ -77,3 +77,12 @@ fn themis() {
     cmd.args(&["run", "--locked", "-p", "themis"]);
     ensure_success(cmd);
 }
+
+#[test]
+fn udeps() {
+    let mut cmd = cargo(Some("udeps"));
+    cmd.env("RUSTUP_TOOLCHAIN", "nightly");
+    cmd.env("RUSTFLAGS", "--cfg udeps");
+    cmd.args(&["udeps"]);
+    ensure_success(cmd);
+}

--- a/test-utils/style/src/lib.rs
+++ b/test-utils/style/src/lib.rs
@@ -77,12 +77,3 @@ fn themis() {
     cmd.args(&["run", "--locked", "-p", "themis"]);
     ensure_success(cmd);
 }
-
-#[test]
-fn udeps() {
-    let mut cmd = cargo(Some("udeps"));
-    cmd.env("RUSTUP_TOOLCHAIN", "nightly");
-    cmd.env("RUSTFLAGS", "--cfg udeps");
-    cmd.args(&["udeps"]);
-    ensure_success(cmd);
-}

--- a/test-utils/testlib/Cargo.toml
+++ b/test-utils/testlib/Cargo.toml
@@ -31,11 +31,11 @@ nightly_protocol = [
   "node-runtime/nightly_protocol",
 ]
 nightly = [
-  "nightly_protocol",
   "near-chain-configs/nightly",
   "near-chain/nightly",
   "near-parameters/nightly",
   "near-primitives/nightly",
+  "nightly_protocol",
   "node-runtime/nightly",
 ]
 default = []

--- a/tools/amend-genesis/Cargo.toml
+++ b/tools/amend-genesis/Cargo.toml
@@ -29,6 +29,5 @@ near-network.workspace = true
 near-primitives.workspace = true
 near-primitives-core.workspace = true
 near-store.workspace = true
-near-test-contracts.workspace = true
 nearcore.workspace = true
 node-runtime.workspace = true

--- a/tools/database/Cargo.toml
+++ b/tools/database/Cargo.toml
@@ -31,13 +31,13 @@ near-primitives.workspace = true
 
 [features]
 nightly = [
-  "nightly_protocol",
   "near-chain-configs/nightly",
   "near-chain/nightly",
   "near-epoch-manager/nightly",
   "near-primitives/nightly",
   "near-store/nightly",
   "nearcore/nightly",
+  "nightly_protocol",
 ]
 nightly_protocol = [
   "near-chain-configs/nightly_protocol",

--- a/tools/fork-network/Cargo.toml
+++ b/tools/fork-network/Cargo.toml
@@ -36,7 +36,6 @@ nearcore.workspace = true
 
 [features]
 nightly = [
-  "nightly_protocol",
   "near-chain-configs/nightly",
   "near-chain/nightly",
   "near-epoch-manager/nightly",
@@ -46,6 +45,7 @@ nightly = [
   "near-primitives/nightly",
   "near-store/nightly",
   "nearcore/nightly",
+  "nightly_protocol",
 ]
 nightly_protocol = [
   "near-chain-configs/nightly_protocol",

--- a/tools/mirror/Cargo.toml
+++ b/tools/mirror/Cargo.toml
@@ -52,7 +52,6 @@ near-crypto.workspace = true
 
 [features]
 nightly = [
-  "nightly_protocol",
   "near-chain-configs/nightly",
   "near-chain/nightly",
   "near-client-primitives/nightly",
@@ -66,6 +65,7 @@ nightly = [
   "near-primitives/nightly",
   "near-store/nightly",
   "nearcore/nightly",
+  "nightly_protocol",
 ]
 nightly_protocol = [
   "near-chain-configs/nightly_protocol",

--- a/tools/mirror/Cargo.toml
+++ b/tools/mirror/Cargo.toml
@@ -23,7 +23,7 @@ hex.workspace = true
 hkdf.workspace = true
 once_cell.workspace = true
 openssl-probe.workspace = true
-rand_core.workspace = true
+rand_core = { workspace = true, features = ["getrandom"] }
 rocksdb.workspace = true
 secp256k1.workspace = true
 serde.workspace = true

--- a/tools/ping/Cargo.toml
+++ b/tools/ping/Cargo.toml
@@ -29,12 +29,12 @@ near-primitives.workspace = true
 
 [features]
 nightly = [
-  "nightly_protocol",
   "near-async/nightly",
   "near-jsonrpc/nightly",
   "near-network/nightly",
   "near-o11y/nightly",
   "near-primitives/nightly",
+  "nightly_protocol",
 ]
 nightly_protocol = [
   "near-async/nightly_protocol",

--- a/tools/rpctypegen/macro/Cargo.toml
+++ b/tools/rpctypegen/macro/Cargo.toml
@@ -18,10 +18,10 @@ proc-macro = true
 serde.workspace = true
 serde_json = { workspace = true, optional = true, features = ["preserve_order"] }
 syn.workspace = true
-fs2.workspace = true
+fs2 = { workspace = true, optional = true }
 
 near-rpc-error-core.workspace = true
 
 [features]
 test = []
-dump_errors_schema = ["near-rpc-error-core/dump_errors_schema", "serde_json"]
+dump_errors_schema = [ "near-rpc-error-core/dump_errors_schema", "serde_json", "fs2" ]

--- a/tools/state-parts-dump-check/Cargo.toml
+++ b/tools/state-parts-dump-check/Cargo.toml
@@ -31,7 +31,6 @@ tokio.workspace = true
 tracing.workspace = true
 [features]
 nightly = [
-  "nightly_protocol",
   "near-client/nightly",
   "near-jsonrpc/nightly",
   "near-o11y/nightly",
@@ -39,6 +38,7 @@ nightly = [
   "near-primitives/nightly",
   "near-store/nightly",
   "nearcore/nightly",
+  "nightly_protocol",
 ]
 nightly_protocol = [
   "near-client/nightly_protocol",

--- a/tools/state-parts/Cargo.toml
+++ b/tools/state-parts/Cargo.toml
@@ -29,13 +29,13 @@ near-primitives.workspace = true
 
 [features]
 nightly = [
-  "nightly_protocol",
   "near-async/nightly",
   "near-jsonrpc/nightly",
   "near-network/nightly",
   "near-o11y/nightly",
   "near-ping/nightly",
   "near-primitives/nightly",
+  "nightly_protocol",
 ]
 nightly_protocol = [
   "near-async/nightly_protocol",

--- a/tools/state-viewer/Cargo.toml
+++ b/tools/state-viewer/Cargo.toml
@@ -57,7 +57,6 @@ testlib.workspace = true
 [features]
 sandbox = ["node-runtime/sandbox", "near-chain/sandbox", "near-client/sandbox"]
 nightly = [
-  "nightly_protocol",
   "near-chain-configs/nightly",
   "near-chain/nightly",
   "near-client/nightly",
@@ -68,7 +67,9 @@ nightly = [
   "near-primitives/nightly",
   "near-store/nightly",
   "nearcore/nightly",
+  "nightly_protocol",
   "node-runtime/nightly",
+  "testlib/nightly",
 ]
 nightly_protocol = [
   "near-chain-configs/nightly_protocol",
@@ -82,4 +83,5 @@ nightly_protocol = [
   "near-store/nightly_protocol",
   "nearcore/nightly_protocol",
   "node-runtime/nightly_protocol",
+  "testlib/nightly_protocol",
 ]

--- a/tools/state-viewer/Cargo.toml
+++ b/tools/state-viewer/Cargo.toml
@@ -45,14 +45,14 @@ near-o11y.workspace = true
 near-primitives-core.workspace = true
 near-primitives.workspace = true
 near-store.workspace = true
-near-test-contracts.workspace = true
 nearcore.workspace = true
 node-runtime.workspace = true
 
 [dev-dependencies]
-near-client.workspace = true
-testlib.workspace = true
 insta.workspace = true
+near-client.workspace = true
+near-test-contracts.workspace = true
+testlib.workspace = true
 
 [features]
 sandbox = ["node-runtime/sandbox", "near-chain/sandbox", "near-client/sandbox"]

--- a/tools/storage-usage-delta-calculator/Cargo.toml
+++ b/tools/storage-usage-delta-calculator/Cargo.toml
@@ -22,4 +22,3 @@ near-o11y.workspace = true
 near-parameters.workspace = true
 near-primitives.workspace = true
 near-store.workspace = true
-node-runtime.workspace = true

--- a/tools/undo-block/Cargo.toml
+++ b/tools/undo-block/Cargo.toml
@@ -26,13 +26,13 @@ near-primitives.workspace = true
 
 [features]
 nightly = [
-  "nightly_protocol",
   "near-chain-configs/nightly",
   "near-chain/nightly",
   "near-epoch-manager/nightly",
   "near-primitives/nightly",
   "near-store/nightly",
   "nearcore/nightly",
+  "nightly_protocol",
 ]
 nightly_protocol = [
   "near-chain-configs/nightly_protocol",

--- a/utils/fmt/Cargo.toml
+++ b/utils/fmt/Cargo.toml
@@ -16,8 +16,8 @@ near-primitives-core.workspace = true
 
 [features]
 nightly = [
-  "nightly_protocol",
   "near-primitives-core/nightly",
+  "nightly_protocol",
 ]
 nightly_protocol = [
   "near-primitives-core/nightly_protocol",

--- a/utils/mainnet-res/Cargo.toml
+++ b/utils/mainnet-res/Cargo.toml
@@ -20,9 +20,9 @@ near-primitives.workspace = true
 
 [features]
 nightly = [
-  "nightly_protocol",
   "near-chain-configs/nightly",
   "near-primitives/nightly",
+  "nightly_protocol",
 ]
 nightly_protocol = [
   "near-chain-configs/nightly_protocol",

--- a/utils/near-performance-metrics/Cargo.toml
+++ b/utils/near-performance-metrics/Cargo.toml
@@ -19,7 +19,6 @@ bytesize = { workspace = true, optional = true }
 futures.workspace = true
 libc.workspace = true
 once_cell.workspace = true
-strum.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true


### PR DESCRIPTION
As evidenced by some of the changes, we have been pulling in a couple of dependencies that aren’t being used in code in any way. While that does not affect the runtime (dead crates don’t even get looked at by rustc,) it very much so does affect the compile times.

One unfortunate part of this check is that running it forces a `cargo check` of the entire worktree. That’s not ideal (and would be great if there was an easy way to combine it with some other work,) but it might do for now?