### PR TITLE
Disable auto-generation of wallet contract by default

### DIFF
--- a/runtime/near-wallet-contract/Cargo.toml
+++ b/runtime/near-wallet-contract/Cargo.toml
@@ -22,6 +22,7 @@ near-primitives-core.workspace = true
 anyhow.workspace = true
 
 [features]
+build_wallet_contract = []
 nightly_protocol = [
   "near-vm-runner/nightly_protocol",
 ]

--- a/runtime/near-wallet-contract/README.md
+++ b/runtime/near-wallet-contract/README.md
@@ -5,6 +5,7 @@ See https://github.com/near/NEPs/issues/518.
 Must not use in production!
 
 Currently, the contract can only be used in nightly build.
+Temporarily, we also require `build_wallet_contract` feature flag for `cargo build`.
 The `build.rs` generates WASM file and saves it to the `./res` directory.
 
 If you want to use the contract from nearcore, add this crate as a dependency

--- a/runtime/near-wallet-contract/build.rs
+++ b/runtime/near-wallet-contract/build.rs
@@ -6,7 +6,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() -> Result<()> {
-    if cfg!(not(feature = "nightly")) {
+    // TODO(eth-implicit) Remove the `build_wallet_contract` flag once we have a proper way
+    // to generate the Wallet Contract WASM file.
+    if cfg!(not(feature = "nightly")) || cfg!(not(feature = "build_wallet_contract")) {
         return Ok(());
     }
     build_contract("./wallet-contract", &[], "wallet_contract")


### PR DESCRIPTION
In some circumstances, `runtime/near-wallet-contract/build.rs` is triggered and it regenerates the Wallet Contract WASM file for unrelated PRs: https://github.com/near/nearcore/pull/10422#issuecomment-1892794073.
The `Wallet Contract` will be generated differently (https://github.com/near/nearcore/pull/10269#discussion_r1430139987), but for now I would like to include this tiny PR to stops auto-generating the WASM file by default.

To test that the WASM file is not auto-regenerated, add a space to `runtime/near-wallet-contract/wallet-contract/src/lib.rs` and run `cargo build --features nightly`.