### PR TITLE
parameters: move out test strings to a separate file

### DIFF
--- a/core/parameters/src/fixture_base_0.yml
+++ b/core/parameters/src/fixture_base_0.yml
@@ -1,0 +1,11 @@
+# Comment line
+registrar_account_id: registrar
+min_allowed_top_level_account_length: 32
+storage_amount_per_byte: 100_000_000_000_000_000_000
+storage_num_bytes_account: 100
+storage_num_extra_bytes_record: 40
+burnt_gas_reward: {
+  numerator: 1_000_000,
+  denominator: 300,
+}
+wasm_storage_read_base: { gas: 50_000_000_000, compute: 100_000_000_000 }

--- a/core/parameters/src/fixture_base_1.yml
+++ b/core/parameters/src/fixture_base_1.yml
@@ -1,0 +1,12 @@
+registrar_account_id: registrar
+# Comment line
+min_allowed_top_level_account_length: 32
+
+# Comment line with trailing whitespace # 
+
+# Note the quotes here, they are necessary as otherwise the value can't be parsed by `serde_yaml`
+# due to not fitting into u64 type.
+storage_amount_per_byte: "100000000000000000000"
+storage_num_bytes_account: 100
+storage_num_extra_bytes_record   :   40  
+

--- a/core/parameters/src/fixture_diff_0.yml
+++ b/core/parameters/src/fixture_diff_0.yml
@@ -1,0 +1,12 @@
+# Comment line
+registrar_account_id: { old: "registrar", new: "near" }
+min_allowed_top_level_account_length: { old: 32, new: 32_000 }
+wasm_regular_op_cost: { new: 3_856_371 }
+burnt_gas_reward: {
+    old: { numerator: 1_000_000, denominator: 300 },
+    new: { numerator: 2_000_000, denominator: 500 },
+}
+wasm_storage_read_base: {
+    old: { gas: 50_000_000_000, compute: 100_000_000_000 },
+    new: { gas: 50_000_000_000, compute: 200_000_000_000 },
+}

--- a/core/parameters/src/fixture_diff_1.yml
+++ b/core/parameters/src/fixture_diff_1.yml
@@ -1,0 +1,9 @@
+# Comment line
+registrar_account_id: { old: "near", new: "registrar" }
+storage_num_extra_bytes_record: { old: 40, new: 77 }
+wasm_regular_op_cost: { old: 3_856_371, new: 0 }
+max_memory_pages: { new: 512 }
+burnt_gas_reward: {
+    old: { numerator: 2_000_000, denominator: 500 },
+    new: { numerator: 3_000_000, denominator: 800 },
+}

--- a/core/parameters/src/parameter_table.rs
+++ b/core/parameters/src/parameter_table.rs
@@ -531,61 +531,10 @@ mod tests {
         }
     }
 
-    static BASE_0: &str = r#"
-# Comment line
-registrar_account_id: registrar
-min_allowed_top_level_account_length: 32
-storage_amount_per_byte: 100_000_000_000_000_000_000
-storage_num_bytes_account: 100
-storage_num_extra_bytes_record: 40
-burnt_gas_reward: {
-  numerator: 1_000_000,
-  denominator: 300,
-}
-wasm_storage_read_base: { gas: 50_000_000_000, compute: 100_000_000_000 }
-"#;
-
-    static BASE_1: &str = r#"
-registrar_account_id: registrar
-# Comment line
-min_allowed_top_level_account_length: 32
-
-# Comment line with trailing whitespace # 
-
-# Note the quotes here, they are necessary as otherwise the value can't be parsed by `serde_yaml`
-# due to not fitting into u64 type.
-storage_amount_per_byte: "100000000000000000000"
-storage_num_bytes_account: 100
-storage_num_extra_bytes_record   :   40  
-
-"#;
-
-    static DIFF_0: &str = r#"
-# Comment line
-registrar_account_id: { old: "registrar", new: "near" }
-min_allowed_top_level_account_length: { old: 32, new: 32_000 }
-wasm_regular_op_cost: { new: 3_856_371 }
-burnt_gas_reward: {
-    old: { numerator: 1_000_000, denominator: 300 },
-    new: { numerator: 2_000_000, denominator: 500 },
-}
-wasm_storage_read_base: {
-    old: { gas: 50_000_000_000, compute: 100_000_000_000 },
-    new: { gas: 50_000_000_000, compute: 200_000_000_000 },
-}
-"#;
-
-    static DIFF_1: &str = r#"
-# Comment line
-registrar_account_id: { old: "near", new: "registrar" }
-storage_num_extra_bytes_record: { old: 40, new: 77 }
-wasm_regular_op_cost: { old: 3_856_371, new: 0 }
-max_memory_pages: { new: 512 }
-burnt_gas_reward: {
-    old: { numerator: 2_000_000, denominator: 500 },
-    new: { numerator: 3_000_000, denominator: 800 },
-}
-"#;
+    static BASE_0: &str = include_str!("fixture_base_0.yml");
+    static BASE_1: &str = include_str!("fixture_base_1.yml");
+    static DIFF_0: &str = include_str!("fixture_diff_0.yml");
+    static DIFF_1: &str = include_str!("fixture_diff_1.yml");
 
     // Tests synthetic small example configurations. For tests with "real"
     // input data, we already have


### PR DESCRIPTION
One of these strings intentionally has some trailing space at the end of the line. This is pretty hard to work with when the editor is set up to strip these off, as in my case, making modifying those files a chore.

Moving them into files that’ll never get touched as a common case solves this problem altogether.