### PR TITLE
fix: typo in ChunkStateWitness comment

### DIFF
--- a/core/primitives/src/chunk_validation.rs
+++ b/core/primitives/src/chunk_validation.rs
@@ -38,7 +38,7 @@ pub struct ChunkStateWitness {
     ///
     /// The set of blocks B is defined as the contiguous subsequence of blocks
     /// B1 (EXCLUSIVE) to B2 (inclusive) in this chunk's chain (i.e. the linear
-    /// chain that this chunk's parent block is on), where B1 is the block that
+    /// chain that this chunk's parent block is on), where B2 is the block that
     /// contains the last new chunk of shard S before this chunk, and B1 is the
     /// block that contains the last new chunk of shard S before B2.
     ///


### PR DESCRIPTION
The comment on the `source_receipt_proofs` field in `ChunkStateWitness` mentions `B1` twice, which looks like a typo:
```rust
/// where B1 is the block that contains the last new chunk of shard S before this chunk,
/// and B1 is the block that contains the last new chunk of shard S before B2.
```
It doesn't make much sense to mention `B1` twice there, IIUC the first `B1` was supposed to be `B2`.