### PR TITLE
feat(resharding) - delete snapshot immediately after resharding is finished

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3486,7 +3486,7 @@ impl Chain {
         )))
     }
 
-    /// Function to create a new snapshot if needed
+    /// Function to create or delete a snapshot if necessary.
     fn process_snapshot(&mut self) -> Result<(), Error> {
         let (make_snapshot, delete_snapshot) = self.should_make_or_delete_snapshot()?;
         if !make_snapshot && !delete_snapshot {
@@ -3495,14 +3495,13 @@ impl Chain {
         let Some(snapshot_callbacks) = &self.snapshot_callbacks else { return Ok(()) };
         if make_snapshot {
             let head = self.head()?;
-            let parent_hash = head.prev_block_hash;
-            let epoch_height = self.epoch_manager.get_epoch_height_from_prev_block(&parent_hash)?;
-            let shard_layout =
-                &self.epoch_manager.get_shard_layout_from_prev_block(&parent_hash)?;
+            let prev_hash = head.prev_block_hash;
+            let epoch_height = self.epoch_manager.get_epoch_height_from_prev_block(&prev_hash)?;
+            let shard_layout = &self.epoch_manager.get_shard_layout_from_prev_block(&prev_hash)?;
             let shard_uids = shard_layout.shard_uids().collect();
             let last_block = self.get_block(&head.last_block_hash)?;
             let make_snapshot_callback = &snapshot_callbacks.make_snapshot_callback;
-            make_snapshot_callback(parent_hash, epoch_height, shard_uids, last_block);
+            make_snapshot_callback(prev_hash, epoch_height, shard_uids, last_block);
         } else if delete_snapshot {
             let delete_snapshot_callback = &snapshot_callbacks.delete_snapshot_callback;
             delete_snapshot_callback();
@@ -3510,18 +3509,20 @@ impl Chain {
         Ok(())
     }
 
+    // Similar to `process_snapshot` but only called after resharding is done.
+    // This is to speed up the snapshot removal once resharding is finished in
+    // order to minimize the storage overhead.
     pub fn process_snapshot_after_resharding(&mut self) -> Result<(), Error> {
-        tracing::debug!(target: "resharding", "boom 1");
         let Some(snapshot_callbacks) = &self.snapshot_callbacks else { return Ok(()) };
 
         let tries = self.runtime_adapter.get_tries();
         let snapshot_config = tries.state_snapshot_config();
         let delete_snapshot = match snapshot_config.state_snapshot_type {
+            // Do not delete snapshot if the node is configured to snapshot every epoch.
             StateSnapshotType::EveryEpoch => false,
+            // Delete the snapshot if it was created only for resharding.
             StateSnapshotType::ForReshardingOnly => true,
         };
-
-        tracing::debug!(target: "resharding", ?delete_snapshot, "boom 2");
 
         if delete_snapshot {
             tracing::debug!(target: "resharding", "deleting snapshot after resharding");

--- a/chain/client/src/sync/state.rs
+++ b/chain/client/src/sync/state.rs
@@ -702,6 +702,7 @@ impl StateSync {
         )?;
 
         if all_done {
+            chain.process_snapshot_after_resharding()?;
             Ok(StateSyncResult::Completed)
         } else {
             Ok(StateSyncResult::InProgress)


### PR DESCRIPTION
As long as the snapshot is present the storage overhead will keep increasing. This PR makes it so that the snapshot is deleted immediately after resharding is finished. The snapshot is only deleted if the node is not configured to take snapshots every epoch. 

Initially I wanted to put the trigger logic somewhere between sync jobs actor and chain but there it was hard to tell if resharding is finished for **all** the shards. It was made trickier by the fact that we only resharding shards that we will track next epoch and should only check those. At the end of the day I placed it in the state sync logic where it'll be triggered once all state syncs and hence all reshardings are done. 