### PR TITLE
install tools from github releases rather than building and caching them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,56 +370,67 @@ jobs:
       # codecov will send a comment only after having receidev this number of uploads.
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: unit-linux.json
           fail_ci_if_error: true
           flags: unittests,linux
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: unit-linux-nightly.json
           fail_ci_if_error: true
           flags: unittests,linux-nightly
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: unit-macos.json
           fail_ci_if_error: true
           flags: unittests,macos
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: integration-linux.json
           fail_ci_if_error: true
           flags: integration-tests,linux
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: integration-linux-nightly.json
           fail_ci_if_error: true
           flags: integration-tests,linux-nightly
       # - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
       #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
       #     files: integration-macos.json
       #     fail_ci_if_error: true
       #     flags: integration-tests,macos
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: py-backward-compat.json
           fail_ci_if_error: true
           flags: pytests,backward-compatibility,linux
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: py-db-migration.json
           fail_ci_if_error: true
           flags: pytests,db-migration,linux
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: py-sanity-checks.json
           fail_ci_if_error: true
           flags: pytests,sanity-checks,linux
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: py-genesis-check.json
           fail_ci_if_error: true
           flags: pytests,genesis-check,linux
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: py-upgradability.json
           fail_ci_if_error: true
           flags: pytests,upgradability,linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,67 +368,67 @@ jobs:
           name: coverage
       # Keep the number of uploads here in sync with codecov.yml’s after_n_build value
       # codecov will send a comment only after having receidev this number of uploads.
-      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
+      - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: unit-linux.json
           fail_ci_if_error: true
           flags: unittests,linux
-      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
+      - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: unit-linux-nightly.json
           fail_ci_if_error: true
           flags: unittests,linux-nightly
-      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
+      - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: unit-macos.json
           fail_ci_if_error: true
           flags: unittests,macos
-      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
+      - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: integration-linux.json
           fail_ci_if_error: true
           flags: integration-tests,linux
-      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
+      - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: integration-linux-nightly.json
           fail_ci_if_error: true
           flags: integration-tests,linux-nightly
-      # - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
+      # - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
       #   with:
       #     token: ${{ secrets.CODECOV_TOKEN }}
       #     files: integration-macos.json
       #     fail_ci_if_error: true
       #     flags: integration-tests,macos
-      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
+      - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: py-backward-compat.json
           fail_ci_if_error: true
           flags: pytests,backward-compatibility,linux
-      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
+      - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: py-db-migration.json
           fail_ci_if_error: true
           flags: pytests,db-migration,linux
-      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
+      - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: py-sanity-checks.json
           fail_ci_if_error: true
           flags: pytests,sanity-checks,linux
-      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
+      - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: py-genesis-check.json
           fail_ci_if_error: true
           flags: pytests,genesis-check,linux
-      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
+      - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: py-upgradability.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,21 +46,9 @@ jobs:
       - uses: actions/checkout@v4
 
       # Install all the required tools
-      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
+      - uses: taiki-e/install-action@91af8c38814c3998cb755869e5cbeffd3ab0e462
         with:
-          crate: just
-        env:
-          GITHUB_JOB: CI # share cargo-install cache across jobs here
-      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
-        with:
-          crate: cargo-nextest
-        env:
-          GITHUB_JOB: CI # share cargo-install cache across jobs here
-      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
-        with:
-          crate: cargo-llvm-cov
-        env:
-          GITHUB_JOB: CI # share cargo-install cache across jobs here
+          tool: just,cargo-nextest,cargo-llvm-cov
 
       # Setup the dependency rust cache and llvm-cov
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
@@ -104,11 +92,9 @@ jobs:
         with:
           python-version: 3.11
           cache: pip
-      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
+      - uses: taiki-e/install-action@91af8c38814c3998cb755869e5cbeffd3ab0e462
         with:
-          crate: cargo-llvm-cov
-        env:
-          GITHUB_JOB: CI # share cargo-install cache across jobs here
+          tool: cargo-llvm-cov
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
         with:
           prefix-key: "0" # change this to invalidate CI cache
@@ -135,11 +121,9 @@ jobs:
         with:
           python-version: 3.11
           cache: pip
-      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
+      - uses: taiki-e/install-action@91af8c38814c3998cb755869e5cbeffd3ab0e462
         with:
-          crate: cargo-llvm-cov
-        env:
-          GITHUB_JOB: CI # share cargo-install cache across jobs here
+          tool: cargo-llvm-cov
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
         with:
           prefix-key: "0" # change this to invalidate CI cache
@@ -170,11 +154,9 @@ jobs:
         with:
           python-version: 3.11
           cache: pip
-      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
+      - uses: taiki-e/install-action@91af8c38814c3998cb755869e5cbeffd3ab0e462
         with:
-          crate: cargo-llvm-cov
-        env:
-          GITHUB_JOB: CI # share cargo-install cache across jobs here
+          tool: cargo-llvm-cov
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
         with:
           prefix-key: "0" # change this to invalidate CI cache
@@ -207,11 +189,9 @@ jobs:
         with:
           python-version: 3.11
           cache: pip
-      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
+      - uses: taiki-e/install-action@91af8c38814c3998cb755869e5cbeffd3ab0e462
         with:
-          crate: cargo-llvm-cov
-        env:
-          GITHUB_JOB: CI # share cargo-install cache across jobs here
+          tool: cargo-llvm-cov
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
         with:
           prefix-key: "0" # change this to invalidate CI cache
@@ -234,11 +214,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
+      - uses: taiki-e/install-action@91af8c38814c3998cb755869e5cbeffd3ab0e462
         with:
-          crate: just
-        env:
-          GITHUB_JOB: CI # share cargo-install cache across jobs here
+          tool: just
       - uses: actions/setup-python@v4
         with:
           python-version: 3.11
@@ -255,11 +233,9 @@ jobs:
         with:
           python-version: 3.11
           cache: pip
-      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
+      - uses: taiki-e/install-action@91af8c38814c3998cb755869e5cbeffd3ab0e462
         with:
-          crate: cargo-llvm-cov
-        env:
-          GITHUB_JOB: CI # share cargo-install cache across jobs here
+          tool: cargo-llvm-cov
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
         with:
           prefix-key: "0" # change this to invalidate CI cache
@@ -285,11 +261,9 @@ jobs:
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
         with:
           save-if: "${{ github.event_name == 'merge_group' }}" # save the cache only from master CI
-      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
+      - uses: taiki-e/install-action@91af8c38814c3998cb755869e5cbeffd3ab0e462
         with:
-          crate: just
-        env:
-          GITHUB_JOB: CI # share cargo-install cache across jobs here
+          tool: just
       - run: just check-rpc-errors-schema
 
   lychee_checks:
@@ -306,11 +280,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
+      - uses: taiki-e/install-action@91af8c38814c3998cb755869e5cbeffd3ab0e462
         with:
-          crate: just
-        env:
-          GITHUB_JOB: CI # share cargo-install cache across jobs here
+          tool: just
       - run: just check-cargo-fmt
 
   check_clippy:
@@ -318,11 +290,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
+      - uses: taiki-e/install-action@91af8c38814c3998cb755869e5cbeffd3ab0e462
         with:
-          crate: just
-        env:
-          GITHUB_JOB: CI # share cargo-install cache across jobs here
+          tool: just
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
         with:
           save-if: "${{ github.event_name == 'merge_group' }}" # save the cache only from master CI
@@ -333,16 +303,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
+      - uses: taiki-e/install-action@91af8c38814c3998cb755869e5cbeffd3ab0e462
         with:
-          crate: just
-        env:
-          GITHUB_JOB: CI # share cargo-install cache across jobs here
-      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
-        with:
-          crate: cargo-deny
-        env:
-          GITHUB_JOB: CI # share cargo-install cache across jobs here
+          tool: just,cargo-deny
       - run: just check-cargo-deny
 
   check_themis:
@@ -350,11 +313,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
+      - uses: taiki-e/install-action@91af8c38814c3998cb755869e5cbeffd3ab0e462
         with:
-          crate: just
-        env:
-          GITHUB_JOB: CI # share cargo-install cache across jobs here
+          tool: just
       - run: just check-themis
 
   check_non_default:
@@ -362,11 +323,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
+      - uses: taiki-e/install-action@91af8c38814c3998cb755869e5cbeffd3ab0e462
         with:
-          crate: just
-        env:
-          GITHUB_JOB: CI # share cargo-install cache across jobs here
+          tool: just
       - run: just check-non-default
 
   check_udeps:
@@ -374,16 +333,9 @@ jobs:
     runs-on: ubuntu-22.04-8core
     steps:
       - uses: actions/checkout@v4
-      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
+      - uses: taiki-e/install-action@91af8c38814c3998cb755869e5cbeffd3ab0e462
         with:
-          crate: just
-        env:
-          GITHUB_JOB: CI # share cargo-install cache across jobs here
-      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
-        with:
-          crate: cargo-udeps
-        env:
-          GITHUB_JOB: CI # share cargo-install cache across jobs here
+          tool: just,cargo-udeps
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
         with:
           save-if: "${{ github.event_name == 'merge_group' }}" # save the cache only from master CI
@@ -394,11 +346,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
+      - uses: taiki-e/install-action@91af8c38814c3998cb755869e5cbeffd3ab0e462
         with:
-          crate: cargo-audit
-        env:
-          GITHUB_JOB: CI # share cargo-install cache across jobs here
+          tool: cargo-audit
       - run: cargo audit -D warnings
 
   upload_coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,7 +354,6 @@ jobs:
   upload_coverage:
     name: "Upload Coverage"
     runs-on: ubuntu-latest
-    environment: codecov
     needs:
       - cargo_nextest
       - py_backward_compat
@@ -369,79 +368,58 @@ jobs:
           name: coverage
       # Keep the number of uploads here in sync with codecov.yml’s after_n_build value
       # codecov will send a comment only after having receidev this number of uploads.
-      - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
+      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
           files: unit-linux.json
           fail_ci_if_error: true
           flags: unittests,linux
-          token: ${{ secrets.CODECOV_TOKEN }}
-      - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
+      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
           files: unit-linux-nightly.json
           fail_ci_if_error: true
           flags: unittests,linux-nightly
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
+      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
           files: unit-macos.json
           fail_ci_if_error: true
           flags: unittests,macos
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
+      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
           files: integration-linux.json
           fail_ci_if_error: true
           flags: integration-tests,linux
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
+      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
           files: integration-linux-nightly.json
           fail_ci_if_error: true
           flags: integration-tests,linux-nightly
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      # - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
+      # - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
       #   with:
       #     files: integration-macos.json
       #     fail_ci_if_error: true
       #     flags: integration-tests,macos
-      #   env:
-      #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
+      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
           files: py-backward-compat.json
           fail_ci_if_error: true
           flags: pytests,backward-compatibility,linux
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
+      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
           files: py-db-migration.json
           fail_ci_if_error: true
           flags: pytests,db-migration,linux
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
+      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
           files: py-sanity-checks.json
           fail_ci_if_error: true
           flags: pytests,sanity-checks,linux
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
+      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
           files: py-genesis-check.json
           fail_ci_if_error: true
           flags: pytests,genesis-check,linux
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
+      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
           files: py-upgradability.json
           fail_ci_if_error: true
           flags: pytests,upgradability,linux
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,8 +374,7 @@ jobs:
           files: unit-linux.json
           fail_ci_if_error: true
           flags: unittests,linux
-        env:
-          CODECOV_TOKEN: ee0ab430-8754-47a8-818c-bb6254fc3012
+          token: ${{ secrets.CODECOV_TOKEN }}
       - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
           files: unit-linux-nightly.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,7 +375,7 @@ jobs:
           fail_ci_if_error: true
           flags: unittests,linux
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          CODECOV_TOKEN: ee0ab430-8754-47a8-818c-bb6254fc3012
       - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
           files: unit-linux-nightly.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,7 +354,7 @@ jobs:
   upload_coverage:
     name: "Upload Coverage"
     runs-on: ubuntu-latest
-    environment: ci
+    environment: codecov
     needs:
       - cargo_nextest
       - py_backward_compat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,7 @@ jobs:
   upload_coverage:
     name: "Upload Coverage"
     runs-on: ubuntu-latest
+    environment: ci
     needs:
       - cargo_nextest
       - py_backward_compat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,18 @@ jobs:
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: just
+        env:
+          GITHUB_JOB: CI # share cargo-install cache across jobs here
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: cargo-nextest
+        env:
+          GITHUB_JOB: CI # share cargo-install cache across jobs here
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: cargo-llvm-cov
+        env:
+          GITHUB_JOB: CI # share cargo-install cache across jobs here
 
       # Setup the dependency rust cache and llvm-cov
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
@@ -101,6 +107,8 @@ jobs:
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: cargo-llvm-cov
+        env:
+          GITHUB_JOB: CI # share cargo-install cache across jobs here
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
         with:
           prefix-key: "0" # change this to invalidate CI cache
@@ -130,6 +138,8 @@ jobs:
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: cargo-llvm-cov
+        env:
+          GITHUB_JOB: CI # share cargo-install cache across jobs here
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
         with:
           prefix-key: "0" # change this to invalidate CI cache
@@ -163,6 +173,8 @@ jobs:
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: cargo-llvm-cov
+        env:
+          GITHUB_JOB: CI # share cargo-install cache across jobs here
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
         with:
           prefix-key: "0" # change this to invalidate CI cache
@@ -198,6 +210,8 @@ jobs:
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: cargo-llvm-cov
+        env:
+          GITHUB_JOB: CI # share cargo-install cache across jobs here
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
         with:
           prefix-key: "0" # change this to invalidate CI cache
@@ -223,6 +237,8 @@ jobs:
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: just
+        env:
+          GITHUB_JOB: CI # share cargo-install cache across jobs here
       - uses: actions/setup-python@v4
         with:
           python-version: 3.11
@@ -242,6 +258,8 @@ jobs:
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: cargo-llvm-cov
+        env:
+          GITHUB_JOB: CI # share cargo-install cache across jobs here
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
         with:
           prefix-key: "0" # change this to invalidate CI cache
@@ -270,6 +288,8 @@ jobs:
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: just
+        env:
+          GITHUB_JOB: CI # share cargo-install cache across jobs here
       - run: just check-rpc-errors-schema
 
   lychee_checks:
@@ -289,6 +309,8 @@ jobs:
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: just
+        env:
+          GITHUB_JOB: CI # share cargo-install cache across jobs here
       - run: just check-cargo-fmt
 
   check_clippy:
@@ -299,6 +321,8 @@ jobs:
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: just
+        env:
+          GITHUB_JOB: CI # share cargo-install cache across jobs here
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
         with:
           save-if: "${{ github.event_name == 'merge_group' }}" # save the cache only from master CI
@@ -312,9 +336,13 @@ jobs:
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: just
+        env:
+          GITHUB_JOB: CI # share cargo-install cache across jobs here
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: cargo-deny
+        env:
+          GITHUB_JOB: CI # share cargo-install cache across jobs here
       - run: just check-cargo-deny
 
   check_themis:
@@ -325,6 +353,8 @@ jobs:
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: just
+        env:
+          GITHUB_JOB: CI # share cargo-install cache across jobs here
       - run: just check-themis
 
   check_non_default:
@@ -335,6 +365,8 @@ jobs:
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: just
+        env:
+          GITHUB_JOB: CI # share cargo-install cache across jobs here
       - run: just check-non-default
 
   check_udeps:
@@ -345,9 +377,13 @@ jobs:
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: just
+        env:
+          GITHUB_JOB: CI # share cargo-install cache across jobs here
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: cargo-udeps
+        env:
+          GITHUB_JOB: CI # share cargo-install cache across jobs here
       - uses: Swatinem/rust-cache@a95ba195448af2da9b00fb742d14ffaaf3c21f43
         with:
           save-if: "${{ github.event_name == 'merge_group' }}" # save the cache only from master CI
@@ -361,6 +397,8 @@ jobs:
       - uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941
         with:
           crate: cargo-audit
+        env:
+          GITHUB_JOB: CI # share cargo-install cache across jobs here
       - run: cargo audit -D warnings
 
   upload_coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,67 +370,78 @@ jobs:
       # codecov will send a comment only after having receidev this number of uploads.
       - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: unit-linux.json
           fail_ci_if_error: true
           flags: unittests,linux
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: unit-linux-nightly.json
           fail_ci_if_error: true
           flags: unittests,linux-nightly
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: unit-macos.json
           fail_ci_if_error: true
           flags: unittests,macos
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: integration-linux.json
           fail_ci_if_error: true
           flags: integration-tests,linux
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: integration-linux-nightly.json
           fail_ci_if_error: true
           flags: integration-tests,linux-nightly
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       # - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
       #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
       #     files: integration-macos.json
       #     fail_ci_if_error: true
       #     flags: integration-tests,macos
+      #   env:
+      #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: py-backward-compat.json
           fail_ci_if_error: true
           flags: pytests,backward-compatibility,linux
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: py-db-migration.json
           fail_ci_if_error: true
           flags: pytests,db-migration,linux
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: py-sanity-checks.json
           fail_ci_if_error: true
           flags: pytests,sanity-checks,linux
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: py-genesis-check.json
           fail_ci_if_error: true
           flags: pytests,genesis-check,linux
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - uses: codecov/codecov-action@428cda1b1c731be3e8bfa389049c3f276d572ffb
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: py-upgradability.json
           fail_ci_if_error: true
           flags: pytests,upgradability,linux
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,11 @@
 codecov:
   notify:
     after_n_builds: 10 # Keep in sync with .github/workflows/ci.yml
+  # Dear h4xx0rz reading this,
+  # Feel free to use this token to upload arbitrary coverage information to codecov.
+  # We do not care.
+  # Best,
+  token: 1d44b2e4-764d-4336-b989-d3c620176bd2
 
 coverage:
   status:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,6 @@
 codecov:
   notify:
     after_n_builds: 10 # Keep in sync with .github/workflows/ci.yml
-  # Dear h4xx0rz reading this,
-  # Feel free to use this token to upload arbitrary coverage information to codecov.
-  # We do not care.
-  # Best,
-  token: 1d44b2e4-764d-4336-b989-d3c620176bd2
 
 coverage:
   status:


### PR DESCRIPTION
This should help us with the number of caches for the tools we use. Each one is lightweight, but they are a lot.

Currently, 23 of the 25 caches on the github first page are `cargo-install` caches, and that just continues in the next pages. My guess is the action doesn’t deal with the cache properly and has the same cache uploaded multiple times, because we don’t even have that many cargo-install calls. Unfortunately, reading the code of the cargo-install action, I was not able to see an obvious reason why it resulted in this.