### PR TITLE
[refactor] Add chunk_inclusion_tracker to track chunks to be included in block

### DIFF
--- a/chain/client/src/chunk_inclusion_tracker.rs
+++ b/chain/client/src/chunk_inclusion_tracker.rs
@@ -1,0 +1,100 @@
+use chrono::{DateTime, Utc};
+use itertools::Itertools;
+use lru::LruCache;
+use std::collections::HashMap;
+
+use near_primitives::hash::CryptoHash;
+use near_primitives::sharding::ShardChunkHeader;
+use near_primitives::types::{AccountId, EpochId, ShardId};
+
+use crate::metrics;
+
+const CHUNK_HEADERS_FOR_INCLUSION_CACHE_SIZE: usize = 2048;
+const NUM_EPOCH_CHUNK_PRODUCERS_TO_KEEP_IN_BLOCKLIST: usize = 1000;
+
+struct ChunkInfo {
+    pub chunk_header: ShardChunkHeader,
+    pub received_time: DateTime<Utc>,
+    pub chunk_producer: AccountId,
+}
+pub struct ChunkInclusionTracker {
+    prev_block_to_chunk_headers_ready_for_inclusion: LruCache<
+        CryptoHash,
+        HashMap<ShardId, (ShardChunkHeader, chrono::DateTime<chrono::Utc>, AccountId)>,
+    >,
+
+    banned_chunk_producers: LruCache<(EpochId, AccountId), ()>,
+}
+
+impl ChunkInclusionTracker {
+    pub fn new() -> Self {
+        Self {
+            prev_block_to_chunk_headers_ready_for_inclusion: LruCache::new(
+                CHUNK_HEADERS_FOR_INCLUSION_CACHE_SIZE,
+            ),
+            // chunk_header_info: LruCache::new(CHUNK_HEADERS_FOR_INCLUSION_CACHE_SIZE * 10),
+            banned_chunk_producers: LruCache::new(NUM_EPOCH_CHUNK_PRODUCERS_TO_KEEP_IN_BLOCKLIST),
+        }
+    }
+
+    pub fn mark_chunk_header_ready_for_inclusion(
+        &mut self,
+        chunk_header: ShardChunkHeader,
+        chunk_producer: AccountId,
+    ) {
+        let prev_block_hash = chunk_header.prev_block_hash();
+        self.prev_block_to_chunk_headers_ready_for_inclusion
+            .get_or_insert(*prev_block_hash, || HashMap::new());
+        self.prev_block_to_chunk_headers_ready_for_inclusion
+            .get_mut(prev_block_hash)
+            .unwrap()
+            .insert(chunk_header.shard_id(), (chunk_header, Utc::now(), chunk_producer));
+    }
+
+    pub fn ban_chunk_producer(&mut self, epoch_id: EpochId, account_id: AccountId) {
+        self.banned_chunk_producers.put((epoch_id, account_id), ());
+    }
+
+    pub fn get_chunk_headers_ready_for_inclusion(
+        &self,
+        epoch_id: &EpochId,
+        prev_block_hash: &CryptoHash,
+    ) -> HashMap<ShardId, (ShardChunkHeader, chrono::DateTime<chrono::Utc>, AccountId)> {
+        self.prev_block_to_chunk_headers_ready_for_inclusion
+            .peek(prev_block_hash)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|(_, (chunk_header, _, chunk_producer))| {
+                let banned = self
+                    .banned_chunk_producers
+                    .contains(&(epoch_id.clone(), chunk_producer.clone()));
+                if banned {
+                    tracing::warn!(
+                        target: "client",
+                        chunk_hash = ?chunk_header.chunk_hash(),
+                        ?chunk_producer,
+                        "Not including chunk from a banned validator");
+                    metrics::CHUNK_DROPPED_BECAUSE_OF_BANNED_CHUNK_PRODUCER.inc();
+                }
+                !banned
+            })
+            .collect()
+    }
+
+    pub fn num_chunk_headers_ready_for_inclusion(
+        &self,
+        epoch_id: &EpochId,
+        prev_block_hash: &CryptoHash,
+    ) -> usize {
+        self.get_chunk_headers_ready_for_inclusion(epoch_id, prev_block_hash).len()
+    }
+
+    pub fn get_banned_chunk_producers(&self) -> Vec<(EpochId, Vec<AccountId>)> {
+        let mut banned_chunk_producers: HashMap<EpochId, Vec<_>> = HashMap::new();
+        for ((epoch_id, account_id), _) in self.banned_chunk_producers.iter() {
+            banned_chunk_producers.entry(epoch_id.clone()).or_default().push(account_id.clone());
+        }
+        banned_chunk_producers.into_iter().collect_vec()
+    }
+}

--- a/chain/client/src/chunk_inclusion_tracker.rs
+++ b/chain/client/src/chunk_inclusion_tracker.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use lru::LruCache;
 use std::collections::HashMap;
@@ -12,11 +11,6 @@ use crate::metrics;
 const CHUNK_HEADERS_FOR_INCLUSION_CACHE_SIZE: usize = 2048;
 const NUM_EPOCH_CHUNK_PRODUCERS_TO_KEEP_IN_BLOCKLIST: usize = 1000;
 
-struct ChunkInfo {
-    pub chunk_header: ShardChunkHeader,
-    pub received_time: DateTime<Utc>,
-    pub chunk_producer: AccountId,
-}
 pub struct ChunkInclusionTracker {
     prev_block_to_chunk_headers_ready_for_inclusion: LruCache<
         CryptoHash,
@@ -48,7 +42,7 @@ impl ChunkInclusionTracker {
         self.prev_block_to_chunk_headers_ready_for_inclusion
             .get_mut(prev_block_hash)
             .unwrap()
-            .insert(chunk_header.shard_id(), (chunk_header, Utc::now(), chunk_producer));
+            .insert(chunk_header.shard_id(), (chunk_header, chrono::Utc::now(), chunk_producer));
     }
 
     pub fn ban_chunk_producer(&mut self, epoch_id: EpochId, account_id: AccountId) {

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2,10 +2,10 @@
 //! This client works completely synchronously and must be operated by some async actor outside.
 
 use crate::adapter::ProcessTxResponse;
+use crate::chunk_inclusion_tracker::ChunkInclusionTracker;
 use crate::chunk_validation::ChunkValidator;
 use crate::debug::BlockProductionTracker;
 use crate::debug::PRODUCTION_TIMES_CACHE_SIZE;
-use crate::chunk_inclusion_tracker::ChunkInclusionTracker;
 use crate::sync::adapter::SyncShardInfo;
 use crate::sync::block::BlockSync;
 use crate::sync::epoch::EpochSync;

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -582,14 +582,6 @@ impl Client {
             }
         }
 
-        // Gets chunk headers here
-        // Filter out the chunks that have 2/3 (stake) of chunk endorsements from the chunk validators (some criterial)
-        // Additional field in the block to include the chunk endorsements
-        // Validation logic would change appropriately to check chunk endorsements
-        // Need a timer mechanism to wait for endorsements till timeout and produce whatever we have after timeout
-        // see ready_to_produce_block() in doomslug.rs and handle_block_production() fn in client.rs
-        // have_all_chunks function in handle_block_production
-        // have_all_chunks bool change to also have_all_chunk_endorsements
         let new_chunks = self
             .chunk_inclusion_tracker
             .get_chunk_headers_ready_for_inclusion(&epoch_id, &prev_hash);

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -183,7 +183,7 @@ pub struct Client {
     /// chunk endorsements tracking etc.
     pub chunk_validator: ChunkValidator,
     /// Tracks current chunks that are ready to be included in block
-    /// Manages filtering out chunks that maybe from banned chunk_producers or similar reasons
+    /// Also tracks banned chunk producers and filters out chunks produced by them
     pub chunk_inclusion_tracker: ChunkInclusionTracker,
 }
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -5,6 +5,7 @@ use crate::adapter::ProcessTxResponse;
 use crate::chunk_validation::ChunkValidator;
 use crate::debug::BlockProductionTracker;
 use crate::debug::PRODUCTION_TIMES_CACHE_SIZE;
+use crate::chunk_inclusion_tracker::ChunkInclusionTracker;
 use crate::sync::adapter::SyncShardInfo;
 use crate::sync::block::BlockSync;
 use crate::sync::epoch::EpochSync;
@@ -17,7 +18,6 @@ use actix_rt::ArbiterHandle;
 use chrono::DateTime;
 use chrono::Utc;
 use itertools::Itertools;
-use lru::LruCache;
 use near_async::messaging::IntoSender;
 use near_async::messaging::{CanSend, Sender};
 use near_chain::chain::VerifyBlockHashAndSignatureResult;
@@ -89,8 +89,6 @@ use std::time::{Duration, Instant};
 use tracing::{debug, debug_span, error, info, trace, warn};
 
 const NUM_REBROADCAST_BLOCKS: usize = 30;
-const CHUNK_HEADERS_FOR_INCLUSION_CACHE_SIZE: usize = 2048;
-const NUM_EPOCH_CHUNK_PRODUCERS_TO_KEEP_IN_BLOCKLIST: usize = 1000;
 
 /// The time we wait for the response to a Epoch Sync request before retrying
 // TODO #3488 set 30_000
@@ -137,11 +135,6 @@ pub struct Client {
     pub runtime_adapter: Arc<dyn RuntimeAdapter>,
     pub shards_manager_adapter: Sender<ShardsManagerRequestFromClient>,
     pub sharded_tx_pool: ShardedTransactionPool,
-    prev_block_to_chunk_headers_ready_for_inclusion: LruCache<
-        CryptoHash,
-        HashMap<ShardId, (ShardChunkHeader, chrono::DateTime<chrono::Utc>, AccountId)>,
-    >,
-    pub do_not_include_chunks_from: LruCache<(EpochId, AccountId), ()>,
     /// Network adapter.
     pub network_adapter: PeerManagerAdapter,
     /// Signer for block producer (if present).
@@ -186,8 +179,12 @@ pub struct Client {
     /// When the "sync block" was requested.
     /// The "sync block" is the last block of the previous epoch, i.e. `prev_hash` of the `sync_hash` block.
     pub last_time_sync_block_requested: Option<DateTime<Utc>>,
-
+    /// Helper module for stateless validation functionality like chunk witness production, validation
+    /// chunk endorsements tracking etc.
     pub chunk_validator: ChunkValidator,
+    /// Tracks current chunks that are ready to be included in block
+    /// Manages filtering out chunks that maybe from banned chunk_producers or similar reasons
+    pub chunk_inclusion_tracker: ChunkInclusionTracker,
 }
 
 impl Client {
@@ -357,12 +354,6 @@ impl Client {
             runtime_adapter,
             shards_manager_adapter,
             sharded_tx_pool,
-            prev_block_to_chunk_headers_ready_for_inclusion: LruCache::new(
-                CHUNK_HEADERS_FOR_INCLUSION_CACHE_SIZE,
-            ),
-            do_not_include_chunks_from: LruCache::new(
-                NUM_EPOCH_CHUNK_PRODUCERS_TO_KEEP_IN_BLOCKLIST,
-            ),
             network_adapter,
             validator_signer,
             pending_approvals: lru::LruCache::new(num_block_producer_seats),
@@ -381,6 +372,7 @@ impl Client {
             flat_storage_creator,
             last_time_sync_block_requested: None,
             chunk_validator,
+            chunk_inclusion_tracker: ChunkInclusionTracker::new(),
         })
     }
 
@@ -520,53 +512,6 @@ impl Client {
         Ok(true)
     }
 
-    pub fn get_chunk_headers_ready_for_inclusion(
-        &self,
-        epoch_id: &EpochId,
-        prev_block_hash: &CryptoHash,
-    ) -> HashMap<ShardId, (ShardChunkHeader, chrono::DateTime<chrono::Utc>, AccountId)> {
-        self.prev_block_to_chunk_headers_ready_for_inclusion
-            .peek(prev_block_hash)
-            .cloned()
-            .unwrap_or_default()
-            .into_iter()
-            .filter(|(_, (chunk_header, _, chunk_producer))| {
-                let banned = self
-                    .do_not_include_chunks_from
-                    .contains(&(epoch_id.clone(), chunk_producer.clone()));
-                if banned {
-                    warn!(
-                        target: "client",
-                        chunk_hash = ?chunk_header.chunk_hash(),
-                        ?chunk_producer,
-                        "Not including chunk from a banned validator");
-                    metrics::CHUNK_DROPPED_BECAUSE_OF_BANNED_CHUNK_PRODUCER.inc();
-                }
-                !banned
-            })
-            .collect()
-    }
-
-    pub fn num_chunk_headers_ready_for_inclusion(
-        &self,
-        epoch_id: &EpochId,
-        prev_block_hash: &CryptoHash,
-    ) -> usize {
-        let entries =
-            match self.prev_block_to_chunk_headers_ready_for_inclusion.peek(prev_block_hash) {
-                Some(entries) => entries,
-                None => return 0,
-            };
-        entries
-            .values()
-            .filter(|(_, _, chunk_producer)| {
-                !self
-                    .do_not_include_chunks_from
-                    .contains(&(epoch_id.clone(), chunk_producer.clone()))
-            })
-            .count()
-    }
-
     /// Produce block if we are block producer for given block `height`.
     /// Either returns produced block (not applied) or error.
     pub fn produce_block(&mut self, height: BlockHeight) -> Result<Option<Block>, Error> {
@@ -637,7 +582,17 @@ impl Client {
             }
         }
 
-        let new_chunks = self.get_chunk_headers_ready_for_inclusion(&epoch_id, &prev_hash);
+        // Gets chunk headers here
+        // Filter out the chunks that have 2/3 (stake) of chunk endorsements from the chunk validators (some criterial)
+        // Additional field in the block to include the chunk endorsements
+        // Validation logic would change appropriately to check chunk endorsements
+        // Need a timer mechanism to wait for endorsements till timeout and produce whatever we have after timeout
+        // see ready_to_produce_block() in doomslug.rs and handle_block_production() fn in client.rs
+        // have_all_chunks function in handle_block_production
+        // have_all_chunks bool change to also have_all_chunk_endorsements
+        let new_chunks = self
+            .chunk_inclusion_tracker
+            .get_chunk_headers_ready_for_inclusion(&epoch_id, &prev_hash);
         debug!(
             target: "client",
             validator=?validator_signer.validator_id(),
@@ -1380,7 +1335,7 @@ impl Client {
             chunk_hash = ?chunk_header.chunk_hash(),
             "Banning chunk producer for producing invalid chunk");
         metrics::CHUNK_PRODUCER_BANNED_FOR_EPOCH.inc();
-        self.do_not_include_chunks_from.put((epoch_id, chunk_producer), ());
+        self.chunk_inclusion_tracker.ban_chunk_producer(epoch_id, chunk_producer);
         Ok(())
     }
 
@@ -1420,20 +1375,6 @@ impl Client {
         if let Err(err) = update.commit() {
             error!(target: "client", ?err, "Error saving invalid chunk");
         }
-    }
-
-    pub fn on_chunk_header_ready_for_inclusion(
-        &mut self,
-        chunk_header: ShardChunkHeader,
-        chunk_producer: AccountId,
-    ) {
-        let prev_block_hash = chunk_header.prev_block_hash();
-        self.prev_block_to_chunk_headers_ready_for_inclusion
-            .get_or_insert(*prev_block_hash, || HashMap::new());
-        self.prev_block_to_chunk_headers_ready_for_inclusion
-            .get_mut(prev_block_hash)
-            .unwrap()
-            .insert(chunk_header.shard_id(), (chunk_header, chrono::Utc::now(), chunk_producer));
     }
 
     pub fn sync_block_headers(
@@ -1807,7 +1748,8 @@ impl Client {
             Some(shard_chunk.clone()),
             self.chain.mut_chain_store(),
         )?;
-        self.on_chunk_header_ready_for_inclusion(encoded_chunk.cloned_header(), validator_id);
+        self.chunk_inclusion_tracker
+            .mark_chunk_header_ready_for_inclusion(encoded_chunk.cloned_header(), validator_id);
         self.shards_manager_adapter.send(ShardsManagerRequestFromClient::DistributeEncodedChunk {
             partial_chunk,
             encoded_chunk,

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1065,6 +1065,7 @@ impl ClientActor {
             if me == next_block_producer_account {
                 let num_chunks = self
                     .client
+                    .chunk_inclusion_tracker
                     .num_chunk_headers_ready_for_inclusion(&epoch_id, &head.last_block_hash);
                 let have_all_chunks = head.height == 0
                     || num_chunks == self.client.epoch_manager.shard_ids(&epoch_id).unwrap().len();
@@ -1958,7 +1959,9 @@ impl Handler<WithSpanContext<ShardsManagerResponse>> for ClientActor {
                 chunk_header,
                 chunk_producer,
             } => {
-                self.client.on_chunk_header_ready_for_inclusion(chunk_header, chunk_producer);
+                self.client
+                    .chunk_inclusion_tracker
+                    .mark_chunk_header_ready_for_inclusion(chunk_header, chunk_producer);
             }
         }
     }

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -3,7 +3,6 @@
 use crate::ClientActor;
 use actix::{Context, Handler};
 
-use itertools::Itertools;
 use near_chain::crypto_hash_timer::CryptoHashTimer;
 use near_chain::{near_chain_primitives, Chain, ChainStoreAccess};
 use near_client_primitives::debug::{
@@ -624,14 +623,8 @@ impl ClientActor {
             production: productions,
             banned_chunk_producers: self
                 .client
-                .do_not_include_chunks_from
-                .iter()
-                .map(|(k, _)| k.clone())
-                .sorted()
-                .group_by(|(k, _)| k.clone())
-                .into_iter()
-                .map(|(k, vs)| (k, vs.map(|(_, v)| v).collect()))
-                .collect(),
+                .chunk_inclusion_tracker
+                .get_banned_chunk_producers(),
         })
     }
 }

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -29,6 +29,7 @@ mod config_updater;
 pub mod debug;
 mod info;
 mod metrics;
+mod chunk_inclusion_tracker;
 pub mod sync;
 mod sync_jobs_actor;
 pub mod test_utils;

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -22,6 +22,7 @@ pub use near_client_primitives::debug::DebugStatus;
 
 pub mod adapter;
 pub mod adversarial;
+mod chunk_inclusion_tracker;
 mod chunk_validation;
 mod client;
 mod client_actor;
@@ -29,7 +30,6 @@ mod config_updater;
 pub mod debug;
 mod info;
 mod metrics;
-mod chunk_inclusion_tracker;
 pub mod sync;
 mod sync_jobs_actor;
 pub mod test_utils;

--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -243,7 +243,8 @@ impl TestEnv {
                     chunk_producer,
                 } => {
                     self.clients[id]
-                        .on_chunk_header_ready_for_inclusion(chunk_header, chunk_producer);
+                        .chunk_inclusion_tracker
+                        .mark_chunk_header_ready_for_inclusion(chunk_header, chunk_producer);
                 }
             }
             any_processed = true;

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2385,6 +2385,7 @@ fn test_validate_chunk_extra() {
     let b = env.clients[0].produce_block_on(next_height + 2, *block1.hash()).unwrap().unwrap();
     env.clients[0].process_block_test(b.into(), Provenance::PRODUCED).unwrap();
     let chunks = env.clients[0]
+        .chunk_inclusion_tracker
         .get_chunk_headers_ready_for_inclusion(block1.header().epoch_id(), &block1.hash());
     let chunk_extra =
         env.clients[0].chain.get_chunk_extra(block1.hash(), &ShardUId::single_shard()).unwrap();


### PR DESCRIPTION
Refactoring effort needed for adding in future functionality related to stateless validation where we filter out chunks based on whether they have enough chunk_endorsement or not.