### PR TITLE
[stateless_validation] Add helper functions for chunk endorsement validation

### DIFF
--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -35,6 +35,7 @@ use near_primitives::types::{
     AccountId, ApprovalStake, Balance, BlockHeight, EpochHeight, EpochId, Gas, Nonce, NumShards,
     ShardId, StateChangesForResharding, StateRoot, StateRootNode, ValidatorInfoIdentifier,
 };
+use near_primitives::validator_mandates::ValidatorMandatesConfig;
 use near_primitives::version::{ProtocolVersion, PROTOCOL_VERSION};
 use near_primitives::views::{
     AccessKeyInfoView, AccessKeyList, CallResult, ContractCodeView, EpochValidatorInfo,
@@ -704,6 +705,13 @@ impl EpochManagerAdapter for MockEpochManager {
         let chunk_producers = self.get_chunk_producers(valset, shard_id);
         let index = (shard_id + height + 1) as usize % chunk_producers.len();
         Ok(chunk_producers[index].account_id().clone())
+    }
+
+    fn get_validator_mandates_config(
+        &self,
+        _epoch_id: &EpochId,
+    ) -> Result<ValidatorMandatesConfig, EpochError> {
+        Ok(Default::default())
     }
 
     fn get_chunk_validator_assignments(

--- a/chain/client/src/chunk_validation.rs
+++ b/chain/client/src/chunk_validation.rs
@@ -96,7 +96,7 @@ impl ChunkValidator {
             chunk_header.shard_id(),
             chunk_header.height_created(),
         )?;
-        if !chunk_validator_assignments.chunk_validators.contains(my_signer.validator_id()) {
+        if !chunk_validator_assignments.contains(my_signer.validator_id()) {
             return Err(Error::NotAChunkValidator);
         }
 
@@ -517,8 +517,7 @@ impl Client {
                 chunk_header.shard_id(),
                 chunk_header.height_created(),
             )?
-            .chunk_validators
-            .clone();
+            .ordered_chunk_validators();
         let prev_chunk = self.chain.get_chunk(&prev_chunk_header.chunk_hash())?;
         let (main_state_transition, implicit_transitions, applied_receipts_hash) =
             self.collect_state_transition_data(&chunk_header, prev_chunk_header)?;

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -2678,10 +2678,10 @@ fn test_verify_chunk_endorsements() {
     let epoch_id = epoch_manager.get_epoch_id(&h[1]).unwrap();
 
     // verify if we have one chunk validator
-    let chunk_validators =
-        &epoch_manager.get_chunk_validator_assignments(&epoch_id, 0, 1).unwrap().chunk_validators;
-    assert_eq!(chunk_validators.len(), 1);
-    assert!(chunk_validators.contains(&account_id));
+    let chunk_validator_assignments =
+        &epoch_manager.get_chunk_validator_assignments(&epoch_id, 0, 1).unwrap();
+    assert_eq!(chunk_validator_assignments.ordered_chunk_validators().len(), 1);
+    assert!(chunk_validator_assignments.contains(&account_id));
 
     // verify if the test signer has same public key as the chunk validator
     let (validator, _) =

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -258,7 +258,7 @@ pub enum NetworkRequests {
     /// A challenge to invalidate a block.
     Challenge(Challenge),
     /// A chunk's state witness.
-    ChunkStateWitness(HashSet<AccountId>, ChunkStateWitness),
+    ChunkStateWitness(Vec<AccountId>, ChunkStateWitness),
     /// Message for a chunk endorsement, sent by a chunk validator to the block producer.
     ChunkEndorsement(AccountId, ChunkEndorsement),
 }

--- a/core/primitives/src/block_body.rs
+++ b/core/primitives/src/block_body.rs
@@ -42,8 +42,10 @@ pub struct BlockBodyV2 {
     // If the chunk_validator did not endorse the chunk, the signature is None.
     // For cases of missing chunk, we include the chunk endorsements from the previous
     // block just like we do for chunks.
-    pub chunk_endorsements: Vec<Vec<Option<Box<Signature>>>>,
+    pub chunk_endorsements: Vec<ChunkEndorsementSignatures>,
 }
+
+pub type ChunkEndorsementSignatures = Vec<Option<Box<Signature>>>;
 
 // For now, we only have one version of block body.
 // Eventually with ChunkValidation, we would include ChunkEndorsement in BlockBodyV2

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -522,7 +522,9 @@ pub mod epoch_info {
     use crate::epoch_manager::ValidatorWeight;
     use crate::types::validator_stake::{ValidatorStake, ValidatorStakeIter};
     use crate::types::{BlockChunkValidatorStats, ValidatorKickoutReason};
-    use crate::validator_mandates::{ValidatorMandates, ValidatorMandatesAssignment};
+    use crate::validator_mandates::{
+        ValidatorMandates, ValidatorMandatesAssignment, ValidatorMandatesConfig,
+    };
     use crate::version::PROTOCOL_VERSION;
     use borsh::{BorshDeserialize, BorshSerialize};
     use near_primitives_core::hash::CryptoHash;
@@ -1090,12 +1092,17 @@ pub mod epoch_info {
             }
         }
 
+        pub fn get_validator_mandates_config(&self) -> ValidatorMandatesConfig {
+            match &self {
+                Self::V1(_) | Self::V2(_) | Self::V3(_) => Default::default(),
+                Self::V4(v4) => v4.validator_mandates.config.clone(),
+            }
+        }
+
         pub fn sample_chunk_validators(&self, height: BlockHeight) -> ValidatorMandatesAssignment {
             // Chunk validator assignment was introduced with `V4`.
             match &self {
-                Self::V1(_) => Default::default(),
-                Self::V2(_) => Default::default(),
-                Self::V3(_) => Default::default(),
+                Self::V1(_) | Self::V2(_) | Self::V3(_) => Default::default(),
                 Self::V4(v4) => {
                     let mut rng = Self::chunk_validate_rng(&v4.rng_seed, height);
                     v4.validator_mandates.sample(&mut rng)

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -1095,7 +1095,7 @@ pub mod epoch_info {
         pub fn get_validator_mandates_config(&self) -> ValidatorMandatesConfig {
             match &self {
                 Self::V1(_) | Self::V2(_) | Self::V3(_) => Default::default(),
-                Self::V4(v4) => v4.validator_mandates.config.clone(),
+                Self::V4(v4) => v4.validator_mandates.config,
             }
         }
 

--- a/core/primitives/src/validator_mandates.rs
+++ b/core/primitives/src/validator_mandates.rs
@@ -13,7 +13,7 @@ use rand::{seq::SliceRandom, Rng};
 )]
 pub struct ValidatorMandatesConfig {
     /// The amount of stake that corresponds to one mandate.
-    stake_per_mandate: Balance,
+    pub stake_per_mandate: Balance,
     /// The minimum number of mandates required per shard.
     min_mandates_per_shard: usize,
     /// The number of shards for the referenced epoch.
@@ -53,7 +53,7 @@ impl ValidatorMandatesConfig {
 )]
 pub struct ValidatorMandates {
     /// The configuration applied to the mandates.
-    config: ValidatorMandatesConfig,
+    pub config: ValidatorMandatesConfig,
     /// Each element represents a validator mandate held by the validator with the given id.
     ///
     /// The id of a validator who holds `n >= 0` mandates occurs `n` times in the vector.


### PR DESCRIPTION
Couple of awesome changes here...
- Expose validator_mandates_config as we need this to calculating total stake. See function `does_chunk_have_enough_stake`
- `Vec<Option<Box<Signature>>>`??? Wth is this??? Type aliased it to `ChunkEndorsementSignatures`
- Added `validate_signature` function to `ChunkEndorsement` that checks whether a signature + public key is valid or not. This is used for verifying chunk endorsement signature in header.
- `ChunkValidatorAssignments` just got coooooler!! Now we have a `does_chunk_have_enough_stake` function that calculates whether we have 2/3rd stake and we are good to go?
- Some other minor improvements to `ChunkValidatorAssignments` like adding `ordered_chunk_validators` function and `contains` function