### PR TITLE
[stateless_validation] Use Balance instead of AssignmentWeight in ValidatorMandatesAssignment

### DIFF
--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -35,7 +35,6 @@ use near_primitives::types::{
     AccountId, ApprovalStake, Balance, BlockHeight, EpochHeight, EpochId, Gas, Nonce, NumShards,
     ShardId, StateChangesForResharding, StateRoot, StateRootNode, ValidatorInfoIdentifier,
 };
-use near_primitives::validator_mandates::ValidatorMandatesConfig;
 use near_primitives::version::{ProtocolVersion, PROTOCOL_VERSION};
 use near_primitives::views::{
     AccessKeyInfoView, AccessKeyList, CallResult, ContractCodeView, EpochValidatorInfo,
@@ -705,13 +704,6 @@ impl EpochManagerAdapter for MockEpochManager {
         let chunk_producers = self.get_chunk_producers(valset, shard_id);
         let index = (shard_id + height + 1) as usize % chunk_producers.len();
         Ok(chunk_producers[index].account_id().clone())
-    }
-
-    fn get_validator_mandates_config(
-        &self,
-        _epoch_id: &EpochId,
-    ) -> Result<ValidatorMandatesConfig, EpochError> {
-        Ok(Default::default())
     }
 
     fn get_chunk_validator_assignments(

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -19,7 +19,6 @@ use near_primitives::types::{
     AccountId, ApprovalStake, Balance, BlockHeight, EpochHeight, EpochId, ShardId,
     ValidatorInfoIdentifier,
 };
-use near_primitives::validator_mandates::ValidatorMandatesConfig;
 use near_primitives::version::ProtocolVersion;
 use near_primitives::views::EpochValidatorInfo;
 use near_store::{ShardUId, StoreUpdate};
@@ -188,11 +187,6 @@ pub trait EpochManagerAdapter: Send + Sync {
         height: BlockHeight,
         shard_id: ShardId,
     ) -> Result<AccountId, EpochError>;
-
-    fn get_validator_mandates_config(
-        &self,
-        epoch_id: &EpochId,
-    ) -> Result<ValidatorMandatesConfig, EpochError>;
 
     /// Gets the chunk validators for a given height and shard.
     fn get_chunk_validator_assignments(
@@ -662,14 +656,6 @@ impl EpochManagerAdapter for EpochManagerHandle {
     ) -> Result<AccountId, EpochError> {
         let epoch_manager = self.read();
         Ok(epoch_manager.get_chunk_producer_info(epoch_id, height, shard_id)?.take_account_id())
-    }
-
-    fn get_validator_mandates_config(
-        &self,
-        epoch_id: &EpochId,
-    ) -> Result<ValidatorMandatesConfig, EpochError> {
-        let epoch_manager = self.read();
-        Ok(epoch_manager.get_epoch_info(epoch_id)?.get_validator_mandates_config())
     }
 
     fn get_chunk_validator_assignments(

--- a/chain/epoch-manager/src/validator_selection.rs
+++ b/chain/epoch-manager/src/validator_selection.rs
@@ -390,8 +390,6 @@ mod tests {
     use near_primitives::epoch_manager::ValidatorSelectionConfig;
     use near_primitives::shard_layout::ShardLayout;
     use near_primitives::types::validator_stake::ValidatorStake;
-    #[cfg(feature = "nightly")]
-    use near_primitives::validator_mandates::AssignmentWeight;
     use near_primitives::version::PROTOCOL_VERSION;
     use num_rational::Ratio;
 
@@ -703,29 +701,10 @@ mod tests {
         // Given `epoch_info` and `proposals` above, the sample at a given height is deterministic.
         let height = 42;
         let expected_assignments = vec![
-            vec![
-                (1, AssignmentWeight::new(3, 0)),
-                (0, AssignmentWeight::new(3, 0)),
-                (2, AssignmentWeight::new(3, 0)),
-                (3, AssignmentWeight::new(0, 60)),
-            ],
-            vec![
-                (0, AssignmentWeight::new(6, 0)),
-                (2, AssignmentWeight::new(2, 0)),
-                (1, AssignmentWeight::new(2, 0)),
-            ],
-            vec![
-                (3, AssignmentWeight::new(2, 0)),
-                (2, AssignmentWeight::new(3, 0)),
-                (1, AssignmentWeight::new(1, 0)),
-                (0, AssignmentWeight::new(4, 0)),
-            ],
-            vec![
-                (2, AssignmentWeight::new(2, 0)),
-                (4, AssignmentWeight::new(1, 40)),
-                (1, AssignmentWeight::new(4, 0)),
-                (0, AssignmentWeight::new(2, 0)),
-            ],
+            vec![(1, 300), (0, 300), (2, 300), (3, 60)],
+            vec![(0, 600), (2, 200), (1, 200)],
+            vec![(3, 200), (2, 300), (1, 100), (0, 400)],
+            vec![(2, 200), (4, 140), (1, 400), (0, 200)],
         ];
         assert_eq!(epoch_info.sample_chunk_validators(height), expected_assignments);
     }

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -522,9 +522,7 @@ pub mod epoch_info {
     use crate::epoch_manager::ValidatorWeight;
     use crate::types::validator_stake::{ValidatorStake, ValidatorStakeIter};
     use crate::types::{BlockChunkValidatorStats, ValidatorKickoutReason};
-    use crate::validator_mandates::{
-        ValidatorMandates, ValidatorMandatesAssignment, ValidatorMandatesConfig,
-    };
+    use crate::validator_mandates::{ChunkValidatorStakeAssignment, ValidatorMandates};
     use crate::version::PROTOCOL_VERSION;
     use borsh::{BorshDeserialize, BorshSerialize};
     use near_primitives_core::hash::CryptoHash;
@@ -1092,14 +1090,10 @@ pub mod epoch_info {
             }
         }
 
-        pub fn get_validator_mandates_config(&self) -> ValidatorMandatesConfig {
-            match &self {
-                Self::V1(_) | Self::V2(_) | Self::V3(_) => Default::default(),
-                Self::V4(v4) => v4.validator_mandates.config,
-            }
-        }
-
-        pub fn sample_chunk_validators(&self, height: BlockHeight) -> ValidatorMandatesAssignment {
+        pub fn sample_chunk_validators(
+            &self,
+            height: BlockHeight,
+        ) -> ChunkValidatorStakeAssignment {
             // Chunk validator assignment was introduced with `V4`.
             match &self {
                 Self::V1(_) | Self::V2(_) | Self::V3(_) => Default::default(),


### PR DESCRIPTION
As per [this comment](https://github.com/near/nearcore/pull/10464#discussion_r1457862142) by Robin, it makes sense to abstract out the `num_mandates` and `partial_weight` and directly use stake values for chunk validator stake assignments.

This removes the necessity of expose `ValidatorMandatesConfig` outside epoch manager.