### PR TITLE
[stateless_validation] Include chunk_endorsement signatures in block body

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1030,14 +1030,6 @@ impl Chain {
             }
         }
 
-        // Check that block has chunk endorsements.
-        if checked_feature!("stable", ChunkValidation, epoch_protocol_version) {
-            if block.chunk_endorsements().is_empty() {
-                tracing::warn!("Block has no chunk endorsements: {:?}", block.hash());
-                return Ok(VerifyBlockHashAndSignatureResult::Incorrect);
-            }
-        }
-
         // Verify the signature. Since the signature is signed on the hash of block header, this check
         // makes sure the block header content is not tampered
         if !self.epoch_manager.verify_header_signature(block.header())? {
@@ -1889,7 +1881,7 @@ impl Chain {
     /// Preprocess a block before applying chunks, verify that we have the necessary information
     /// to process the block an the block is valid.
     /// Note that this function does NOT introduce any changes to chain state.
-    pub(crate) fn preprocess_block(
+    fn preprocess_block(
         &self,
         me: &Option<AccountId>,
         block: &MaybeValidated<Block>,

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -47,6 +47,7 @@ use near_epoch_manager::types::BlockHeaderInfo;
 use near_epoch_manager::EpochManagerAdapter;
 use near_o11y::log_assert;
 use near_primitives::block::{genesis_chunks, Block, BlockValidityError, Tip};
+use near_primitives::block_body::ChunkEndorsementSignatures;
 use near_primitives::block_header::BlockHeader;
 use near_primitives::challenge::{
     BlockDoubleSign, Challenge, ChallengeBody, ChallengesResult, ChunkProofs, ChunkState,
@@ -1031,11 +1032,10 @@ impl Chain {
 
         // Check that block has chunk endorsements.
         if checked_feature!("stable", ChunkValidation, epoch_protocol_version) {
-            // TODO(shreyan): Enable this in next PR once we start adding chunk endorsements.
-            // if block.chunk_endorsements().is_empty() {
-            //     tracing::warn!("Block has no chunk endorsements: {:?}", block.hash());
-            //     return Ok(VerifyBlockHashAndSignatureResult::Incorrect);
-            // }
+            if block.chunk_endorsements().is_empty() {
+                tracing::warn!("Block has no chunk endorsements: {:?}", block.hash());
+                return Ok(VerifyBlockHashAndSignatureResult::Incorrect);
+            }
         }
 
         // Verify the signature. Since the signature is signed on the hash of block header, this check
@@ -1101,8 +1101,10 @@ impl Chain {
 
     /// Do basic validation of the information that we can get from the chunk headers in `block`
     fn validate_chunk_headers(&self, block: &Block, prev_block: &Block) -> Result<(), Error> {
-        let prev_chunk_headers =
-            Chain::get_prev_chunk_headers(self.epoch_manager.as_ref(), prev_block)?;
+        let (prev_chunk_headers, _) = Chain::get_prev_chunk_headers_and_chunk_endorsements(
+            self.epoch_manager.as_ref(),
+            prev_block,
+        )?;
         for (chunk_header, prev_chunk_header) in
             block.chunks().iter().zip(prev_chunk_headers.iter())
         {
@@ -3256,8 +3258,10 @@ impl Chain {
         invalid_chunks: &mut Vec<ShardChunkHeader>,
     ) -> Result<Vec<UpdateShardJob>, Error> {
         let _span = tracing::debug_span!(target: "chain", "apply_chunks_preprocessing").entered();
-        let prev_chunk_headers =
-            Chain::get_prev_chunk_headers(self.epoch_manager.as_ref(), prev_block)?;
+        let (prev_chunk_headers, _) = Chain::get_prev_chunk_headers_and_chunk_endorsements(
+            self.epoch_manager.as_ref(),
+            prev_block,
+        )?;
 
         let mut maybe_jobs = vec![];
         for (shard_id, (chunk_header, prev_chunk_header)) in
@@ -4132,29 +4136,37 @@ impl Chain {
         Ok(headers)
     }
 
-    /// Returns a vector of chunk headers, each of which corresponds to the previous chunk of
-    /// a chunk in the block after `prev_block`
+    /// Returns a vector of chunk headers, and vector of chunk endorsement signatures each of which corresponds
+    /// to the chunk in the `prev_block`
     /// This function is important when the block after `prev_block` has different number of chunks
-    /// from `prev_block`.
+    /// from `prev_block` in cases of resharding.
     /// In block production and processing, often we need to get the previous chunks of chunks
     /// in the current block, this function provides a way to do so while handling sharding changes
     /// correctly.
     /// For example, if `prev_block` has two shards 0, 1 and the block after `prev_block` will have
     /// 4 shards 0, 1, 2, 3, 0 and 1 split from shard 0 and 2 and 3 split from shard 1.
-    /// `get_prev_chunks(runtime_adapter, prev_block)` will return
+    /// `get_prev_chunk_headers_and_chunk_endorsements(epoch_manager, prev_block)` will return
     /// `[prev_block.chunks()[0], prev_block.chunks()[0], prev_block.chunks()[1], prev_block.chunks()[1]]`
-    pub fn get_prev_chunk_headers(
+    /// and the corresponding chunk endorsements.
+    pub fn get_prev_chunk_headers_and_chunk_endorsements(
         epoch_manager: &dyn EpochManagerAdapter,
         prev_block: &Block,
-    ) -> Result<Vec<ShardChunkHeader>, Error> {
+    ) -> Result<(Vec<ShardChunkHeader>, Vec<ChunkEndorsementSignatures>), Error> {
         let epoch_id = epoch_manager.get_epoch_id_from_prev_block(prev_block.hash())?;
         let shard_ids = epoch_manager.shard_ids(&epoch_id)?;
         let prev_shard_ids = epoch_manager.get_prev_shard_ids(prev_block.hash(), shard_ids)?;
         let chunks = prev_block.chunks();
-        Ok(prev_shard_ids
-            .into_iter()
-            .map(|shard_id| chunks.get(shard_id as usize).unwrap().clone())
-            .collect())
+        let chunk_endorsements = prev_block.chunk_endorsements();
+
+        let chunk_headers = prev_shard_ids
+            .iter()
+            .map(|shard_id| chunks.get(*shard_id as usize).cloned().unwrap())
+            .collect();
+        let chunk_endorsement = prev_shard_ids
+            .iter()
+            .map(|shard_id| chunk_endorsements.get(*shard_id as usize).cloned().unwrap_or_default())
+            .collect();
+        Ok((chunk_headers, chunk_endorsement))
     }
 
     pub fn get_prev_chunk_header(

--- a/chain/client/src/chunk_inclusion_tracker.rs
+++ b/chain/client/src/chunk_inclusion_tracker.rs
@@ -73,7 +73,7 @@ impl ChunkInclusionTracker {
             // Call to prev_block_to_chunk_hash_ready.push might evict an entry from LRU cache.
             // In case of an eviction, cleanup entries in chunk_hash_to_chunk_info
             let maybe_evicted_entry =
-                self.prev_block_to_chunk_hash_ready.push(prev_block_hash.clone(), new_entry);
+                self.prev_block_to_chunk_hash_ready.push(*prev_block_hash, new_entry);
             if let Some((_, evicted_entry)) = maybe_evicted_entry {
                 self.process_evicted_entry(evicted_entry);
             }

--- a/chain/client/src/chunk_inclusion_tracker.rs
+++ b/chain/client/src/chunk_inclusion_tracker.rs
@@ -1,37 +1,60 @@
+use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use lru::LruCache;
+use near_primitives::checked_feature;
+use near_primitives::version::ProtocolVersion;
 use std::collections::HashMap;
+use std::sync::Arc;
 
+use near_chain_primitives::Error;
+use near_epoch_manager::EpochManagerAdapter;
+use near_primitives::block_body::ChunkEndorsementSignatures;
 use near_primitives::hash::CryptoHash;
-use near_primitives::sharding::ShardChunkHeader;
+use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
 use near_primitives::types::{AccountId, EpochId, ShardId};
 
+use crate::chunk_validation::ChunkValidator;
 use crate::metrics;
 
 const CHUNK_HEADERS_FOR_INCLUSION_CACHE_SIZE: usize = 2048;
 const NUM_EPOCH_CHUNK_PRODUCERS_TO_KEEP_IN_BLOCKLIST: usize = 1000;
 
+struct ChunkInfo {
+    // chunk_header, received_time and chunk_producer are populated when we call mark_chunk_header_ready_for_inclusion
+    pub chunk_header: ShardChunkHeader,
+    pub received_time: DateTime<Utc>,
+    pub chunk_producer: AccountId,
+    // The signatures are populated later during call to chunk_validator.get_chunk_endorsement_signature
+    // This is a sort of cache to store previously fetched signatures.
+    pub signatures: Option<ChunkEndorsementSignatures>,
+}
+
 pub struct ChunkInclusionTracker {
     // Track chunks that are ready to be included in a block.
     // Key is the previous_block_hash as the chunk is created based on this block. It's possible that
     // the block included isn't of height previous_block_height + 1 in cases of skipped blocks etc.
-    // We store the map of chunks from [shard_id] to (chunk_header, chunk received_time, chunk_producer account_id)
-    prev_block_to_chunk_headers_ready_for_inclusion: LruCache<
-        CryptoHash,
-        HashMap<ShardId, (ShardChunkHeader, chrono::DateTime<chrono::Utc>, AccountId)>,
-    >,
+    // We store the map of chunks from [shard_id] to chunk_hash
+    prev_block_to_chunk_hash_ready: LruCache<CryptoHash, HashMap<ShardId, ChunkHash>>,
+
+    // Map from chunk_hash to chunk_info.
+    // ChunkInfo stores the chunk_header, received_time, chunk_producer and chunk endorsements.
+    // Cleaning up of chunk_hash_to_chunk_info is handled during cache eviction from prev_block_to_chunk_hash_ready.
+    chunk_hash_to_chunk_info: HashMap<ChunkHash, ChunkInfo>,
 
     // Track banned chunk producers for a given epoch. We filter out chunks produced by them.
     banned_chunk_producers: LruCache<(EpochId, AccountId), ()>,
+
+    // Epoch manager to get the protocol version for a given epoch.
+    epoch_manager: Arc<dyn EpochManagerAdapter>,
 }
 
 impl ChunkInclusionTracker {
-    pub fn new() -> Self {
+    pub fn new(epoch_manager: Arc<dyn EpochManagerAdapter>) -> Self {
         Self {
-            prev_block_to_chunk_headers_ready_for_inclusion: LruCache::new(
-                CHUNK_HEADERS_FOR_INCLUSION_CACHE_SIZE,
-            ),
+            prev_block_to_chunk_hash_ready: LruCache::new(CHUNK_HEADERS_FOR_INCLUSION_CACHE_SIZE),
+            chunk_hash_to_chunk_info: HashMap::new(),
             banned_chunk_producers: LruCache::new(NUM_EPOCH_CHUNK_PRODUCERS_TO_KEEP_IN_BLOCKLIST),
+            epoch_manager,
         }
     }
 
@@ -42,12 +65,31 @@ impl ChunkInclusionTracker {
         chunk_producer: AccountId,
     ) {
         let prev_block_hash = chunk_header.prev_block_hash();
-        self.prev_block_to_chunk_headers_ready_for_inclusion
-            .get_or_insert(*prev_block_hash, || HashMap::new());
-        self.prev_block_to_chunk_headers_ready_for_inclusion
-            .get_mut(prev_block_hash)
-            .unwrap()
-            .insert(chunk_header.shard_id(), (chunk_header, chrono::Utc::now(), chunk_producer));
+        if let Some(entry) = self.prev_block_to_chunk_hash_ready.get_mut(prev_block_hash) {
+            // If prev_block_hash entry exists, add the new chunk to the entry.
+            entry.insert(chunk_header.shard_id(), chunk_header.chunk_hash());
+        } else {
+            let new_entry = HashMap::from([(chunk_header.shard_id(), chunk_header.chunk_hash())]);
+            // Call to prev_block_to_chunk_hash_ready.push might evict an entry from LRU cache.
+            // In case of an eviction, cleanup entries in chunk_hash_to_chunk_info
+            let maybe_evicted_entry =
+                self.prev_block_to_chunk_hash_ready.push(prev_block_hash.clone(), new_entry);
+            if let Some((_, evicted_entry)) = maybe_evicted_entry {
+                self.process_evicted_entry(evicted_entry);
+            }
+        }
+        // Insert chunk info in chunk_hash_to_chunk_info. This would be cleaned up later during eviction
+        let chunk_hash = chunk_header.chunk_hash();
+        let chunk_info =
+            ChunkInfo { chunk_header, received_time: Utc::now(), chunk_producer, signatures: None };
+        self.chunk_hash_to_chunk_info.insert(chunk_hash, chunk_info);
+    }
+
+    // once a set of ChunkHash is evicted from prev_block_to_chunk_hash_ready, cleanup chunk_hash_to_chunk_info
+    fn process_evicted_entry(&mut self, evicted_entry: HashMap<ShardId, ChunkHash>) {
+        for (_, chunk_hash) in evicted_entry.into_iter() {
+            self.chunk_hash_to_chunk_info.remove(&chunk_hash);
+        }
     }
 
     /// Add account_id to the list of banned chunk producers for the given epoch.
@@ -57,42 +99,47 @@ impl ChunkInclusionTracker {
     }
 
     /// Function to return the chunks that are ready to be included in a block.
-    /// We filter out the chunks that are produced by banned chunk producers.
-    /// Return type contains some extra information needed for debug logs and metrics.
-    ///     HashMap from [shard_id] to (chunk_header, chunk received_time, chunk_producer account_id)
+    /// We filter out the chunks that are produced by banned chunk producers or have insufficient
+    /// chunk validator endorsements.
+    /// Return HashMap from [shard_id] -> chunk_hash
+    /// We can later use the chunk_hash to fetch chunk_header, chunk_endorsements, chunk_producer_and_received_time
     pub fn get_chunk_headers_ready_for_inclusion(
-        &self,
+        &mut self,
         epoch_id: &EpochId,
         prev_block_hash: &CryptoHash,
-    ) -> HashMap<ShardId, (ShardChunkHeader, chrono::DateTime<chrono::Utc>, AccountId)> {
-        self.prev_block_to_chunk_headers_ready_for_inclusion
-            .peek(prev_block_hash)
-            .cloned()
-            .unwrap_or_default()
-            .into_iter()
-            .filter(|(_, (chunk_header, _, chunk_producer))| {
-                let banned = self
-                    .banned_chunk_producers
-                    .contains(&(epoch_id.clone(), chunk_producer.clone()));
-                if banned {
-                    tracing::warn!(
-                        target: "client",
-                        chunk_hash = ?chunk_header.chunk_hash(),
-                        ?chunk_producer,
-                        "Not including chunk from a banned validator");
-                    metrics::CHUNK_DROPPED_BECAUSE_OF_BANNED_CHUNK_PRODUCER.inc();
+        chunk_validator: &mut ChunkValidator,
+    ) -> Result<HashMap<ShardId, ChunkHash>, Error> {
+        let mut chunk_headers_ready_for_inclusion = HashMap::new();
+        if let Some(entry) = self.prev_block_to_chunk_hash_ready.get_mut(prev_block_hash) {
+            let protocol_version = self.epoch_manager.get_epoch_protocol_version(epoch_id)?;
+            for (shard_id, chunk_hash) in entry.iter_mut() {
+                let chunk_info = self.chunk_hash_to_chunk_info.get_mut(chunk_hash).unwrap();
+                if filter_banned_chunk_producers(
+                    &self.banned_chunk_producers,
+                    epoch_id,
+                    &chunk_info,
+                ) && filter_insufficient_chunk_endorsements(
+                    chunk_info,
+                    chunk_validator,
+                    protocol_version,
+                )? {
+                    // only add to chunk_headers_ready_for_inclusion if chunk passes the banned_chunk_producers and
+                    // insufficient_chunk_endorsements checks
+                    chunk_headers_ready_for_inclusion.insert(*shard_id, chunk_hash.clone());
                 }
-                !banned
-            })
-            .collect()
+            }
+        }
+        Ok(chunk_headers_ready_for_inclusion)
     }
 
     pub fn num_chunk_headers_ready_for_inclusion(
-        &self,
+        &mut self,
         epoch_id: &EpochId,
         prev_block_hash: &CryptoHash,
+        chunk_validator: &mut ChunkValidator,
     ) -> usize {
-        self.get_chunk_headers_ready_for_inclusion(epoch_id, prev_block_hash).len()
+        self.get_chunk_headers_ready_for_inclusion(epoch_id, prev_block_hash, chunk_validator)
+            .map_or(0, |chunks| chunks.len())
     }
 
     pub fn get_banned_chunk_producers(&self) -> Vec<(EpochId, Vec<AccountId>)> {
@@ -102,4 +149,69 @@ impl ChunkInclusionTracker {
         }
         banned_chunk_producers.into_iter().collect_vec()
     }
+
+    fn get_chunk_info(&self, chunk_hash: &ChunkHash) -> Result<&ChunkInfo, Error> {
+        // It should never happen that we are missing the key in chunk_hash_to_chunk_info
+        self.chunk_hash_to_chunk_info
+            .get(chunk_hash)
+            .ok_or(Error::Other(format!("missing key {:?} in ChunkInclusionTracker", chunk_hash)))
+    }
+
+    pub fn chunk_header(&self, chunk_hash: &ChunkHash) -> Result<&ShardChunkHeader, Error> {
+        Ok(&self.get_chunk_info(chunk_hash)?.chunk_header)
+    }
+
+    pub fn chunk_endorsements(
+        &self,
+        chunk_hash: &ChunkHash,
+    ) -> Result<ChunkEndorsementSignatures, Error> {
+        Ok(self.get_chunk_info(chunk_hash)?.signatures.clone().unwrap_or_default())
+    }
+
+    pub fn chunk_producer_and_received_time(
+        &self,
+        chunk_hash: &ChunkHash,
+    ) -> Result<(AccountId, DateTime<Utc>), Error> {
+        let chunk_info = self.get_chunk_info(chunk_hash)?;
+        Ok((chunk_info.chunk_producer.clone(), chunk_info.received_time))
+    }
+}
+
+fn filter_banned_chunk_producers(
+    banned_chunk_producers: &LruCache<(EpochId, AccountId), ()>,
+    epoch_id: &EpochId,
+    chunk_info: &ChunkInfo,
+) -> bool {
+    let banned =
+        banned_chunk_producers.contains(&(epoch_id.clone(), chunk_info.chunk_producer.clone()));
+    if banned {
+        tracing::warn!(
+            target: "client",
+            chunk_hash = ?chunk_info.chunk_header.chunk_hash(),
+            chunk_producer = ?chunk_info.chunk_producer,
+            "Not including chunk from a banned validator");
+        metrics::CHUNK_DROPPED_BECAUSE_OF_BANNED_CHUNK_PRODUCER.inc();
+    }
+    !banned
+}
+
+fn filter_insufficient_chunk_endorsements(
+    chunk_info: &mut ChunkInfo,
+    chunk_validator: &mut ChunkValidator,
+    protocol_version: ProtocolVersion,
+) -> Result<bool, Error> {
+    if !checked_feature!("stable", ChunkValidation, protocol_version) {
+        return Ok(true);
+    }
+
+    // We cache the signatures in chunk_info.signatures. If it's None, we need to fetch it from chunk_validator.
+    if chunk_info.signatures.is_some() {
+        return Ok(true);
+    }
+
+    // Update chunk_info.signatures with the new signatures and return.
+    Ok(chunk_validator
+        .get_chunk_endorsement_signature(&chunk_info.chunk_header)?
+        .map(|signatures| chunk_info.signatures = Some(signatures))
+        .is_some())
 }

--- a/chain/client/src/chunk_inclusion_tracker.rs
+++ b/chain/client/src/chunk_inclusion_tracker.rs
@@ -143,9 +143,9 @@ impl ChunkInclusionTracker {
         &self,
         epoch_id: &EpochId,
         prev_block_hash: &CryptoHash,
-    ) -> Result<HashMap<ShardId, ChunkHash>, Error> {
+    ) -> HashMap<ShardId, ChunkHash> {
         let Some(entry) = self.prev_block_to_chunk_hash_ready.peek(prev_block_hash) else {
-            return Ok(HashMap::new());
+            return HashMap::new();
         };
 
         let mut chunk_headers_ready_for_inclusion = HashMap::new();
@@ -160,7 +160,7 @@ impl ChunkInclusionTracker {
                 chunk_headers_ready_for_inclusion.insert(*shard_id, chunk_hash.clone());
             }
         }
-        Ok(chunk_headers_ready_for_inclusion)
+        chunk_headers_ready_for_inclusion
     }
 
     pub fn num_chunk_headers_ready_for_inclusion(
@@ -168,8 +168,7 @@ impl ChunkInclusionTracker {
         epoch_id: &EpochId,
         prev_block_hash: &CryptoHash,
     ) -> usize {
-        self.get_chunk_headers_ready_for_inclusion(epoch_id, prev_block_hash)
-            .map_or(0, |chunks| chunks.len())
+        self.get_chunk_headers_ready_for_inclusion(epoch_id, prev_block_hash).len()
     }
 
     pub fn get_banned_chunk_producers(&self) -> Vec<(EpochId, Vec<AccountId>)> {

--- a/chain/client/src/chunk_validation.rs
+++ b/chain/client/src/chunk_validation.rs
@@ -12,6 +12,7 @@ use near_chain::{Chain, ChainStore, ChainStoreAccess};
 use near_chain_primitives::Error;
 use near_epoch_manager::EpochManagerAdapter;
 use near_network::types::{NetworkRequests, PeerManagerMessageRequest};
+use near_primitives::block_body::ChunkEndorsementSignatures;
 use near_primitives::challenge::PartialState;
 use near_primitives::checked_feature;
 use near_primitives::chunk_validation::{
@@ -145,6 +146,62 @@ impl ChunkValidator {
             }
         });
         Ok(())
+    }
+
+    /// This function does two things
+    ///     1. Verifies if the chunk_endorsements have enough stake for chunk to be included in block.
+    ///     2. Collects the chunk_endorsement signatures from chunk_validators to include in block body.
+    /// We return an optional signature.
+    ///     None specifies we didn't have enough stake to include chunk in block.
+    ///     Some(signature) gives us the ordered chunk_endorsement signatures to include in block.
+    pub fn get_chunk_endorsement_signature(
+        &mut self,
+        chunk_header: &ShardChunkHeader,
+    ) -> Result<Option<ChunkEndorsementSignatures>, Error> {
+        // Get the chunk_endorsements for the chunk from our cache.
+        // Note that these chunk endorsements are already validated as part of process_chunk_endorsement.
+        // We can safely rely on the the following details
+        //    1. The chunk endorsements are from valid chunk_validator for this chunk.
+        //    2. The chunk endorsements signatures are valid.
+        let chunk_endorsements = self
+            .chunk_endorsements
+            .get_or_insert(chunk_header.chunk_hash(), || HashMap::new())
+            .unwrap();
+
+        // Early return for empty chunk_endorsements.
+        if chunk_endorsements.is_empty() {
+            return Ok(None);
+        }
+
+        let epoch_id =
+            self.epoch_manager.get_epoch_id_from_prev_block(chunk_header.prev_block_hash())?;
+        let chunk_validator_assignments = self.epoch_manager.get_chunk_validator_assignments(
+            &epoch_id,
+            chunk_header.shard_id(),
+            chunk_header.height_created(),
+        )?;
+
+        // Check whether the current set of chunk_validators have enough stake to include chunk in block.
+        // TODO: Second argument `0` in `does_chunk_have_enough_stake` will go away with PR #10467
+        if !chunk_validator_assignments
+            .does_chunk_have_enough_stake(&chunk_endorsements.keys().cloned().collect(), 0)
+        {
+            return Ok(None);
+        }
+
+        // We've already verified the chunk_endorsements are valid, collect signatures.
+        let signatures = chunk_validator_assignments
+            .ordered_chunk_validators()
+            .iter()
+            .map(|account_id| {
+                // map Option<ChunkEndorsement> to Option<Box<Signature>>
+                chunk_endorsements
+                    .get(account_id)
+                    .map(|endorsement| Box::new(endorsement.signature.clone()))
+            })
+            .collect();
+
+        Ok(Some(signatures))
     }
 }
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -589,7 +589,7 @@ impl Client {
 
         let new_chunks = self
             .chunk_inclusion_tracker
-            .get_chunk_headers_ready_for_inclusion(&epoch_id, &prev_hash)?;
+            .get_chunk_headers_ready_for_inclusion(&epoch_id, &prev_hash);
         debug!(
             target: "client",
             validator=?validator_signer.validator_id(),

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1063,10 +1063,12 @@ impl ClientActor {
                 self.client.epoch_manager.get_block_producer(&epoch_id, height)?;
 
             if me == next_block_producer_account {
-                let num_chunks = self
-                    .client
-                    .chunk_inclusion_tracker
-                    .num_chunk_headers_ready_for_inclusion(&epoch_id, &head.last_block_hash);
+                let num_chunks =
+                    self.client.chunk_inclusion_tracker.num_chunk_headers_ready_for_inclusion(
+                        &epoch_id,
+                        &head.last_block_hash,
+                        &mut self.client.chunk_validator,
+                    );
                 let have_all_chunks = head.height == 0
                     || num_chunks == self.client.epoch_manager.shard_ids(&epoch_id).unwrap().len();
 

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1063,12 +1063,14 @@ impl ClientActor {
                 self.client.epoch_manager.get_block_producer(&epoch_id, height)?;
 
             if me == next_block_producer_account {
-                let num_chunks =
-                    self.client.chunk_inclusion_tracker.num_chunk_headers_ready_for_inclusion(
-                        &epoch_id,
-                        &head.last_block_hash,
-                        &mut self.client.chunk_validator,
-                    );
+                self.client.chunk_inclusion_tracker.prepare_chunk_headers_ready_for_inclusion(
+                    &head.last_block_hash,
+                    &mut self.client.chunk_validator,
+                )?;
+                let num_chunks = self
+                    .client
+                    .chunk_inclusion_tracker
+                    .num_chunk_headers_ready_for_inclusion(&epoch_id, &head.last_block_hash);
                 let have_all_chunks = head.height == 0
                     || num_chunks == self.client.epoch_manager.shard_ids(&epoch_id).unwrap().len();
 

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -1,5 +1,6 @@
 //! Structs in this file are used for debug purposes, and might change at any time
 //! without backwards compatibility.
+use crate::chunk_inclusion_tracker::ChunkInclusionTracker;
 use crate::ClientActor;
 use actix::{Context, Handler};
 
@@ -31,7 +32,7 @@ use std::collections::{HashMap, HashSet};
 
 use near_client_primitives::debug::{DebugBlockStatus, DebugChunkStatus};
 use near_network::types::{ConnectedPeerInfo, NetworkInfo, PeerType};
-use near_primitives::sharding::ShardChunkHeader;
+use near_primitives::sharding::ChunkHash;
 use near_primitives::static_clock::StaticClock;
 use near_primitives::views::{
     AccountDataView, KnownProducerView, NetworkInfoView, PeerInfoView, Tier1ProxyView,
@@ -118,15 +119,18 @@ impl BlockProductionTracker {
         block_height: BlockHeight,
         epoch_id: &EpochId,
         num_shards: ShardId,
-        new_chunks: &HashMap<ShardId, (ShardChunkHeader, chrono::DateTime<chrono::Utc>, AccountId)>,
+        new_chunks: &HashMap<ShardId, ChunkHash>,
         epoch_manager: &dyn EpochManagerAdapter,
+        chunk_inclusion_tracker: &ChunkInclusionTracker,
     ) -> Result<Vec<ChunkCollection>, Error> {
         let mut chunk_collection_info = vec![];
         for shard_id in 0..num_shards {
-            if let Some((_, chunk_time, chunk_producer)) = new_chunks.get(&shard_id) {
+            if let Some(chunk_hash) = new_chunks.get(&shard_id) {
+                let (chunk_producer, received_time) =
+                    chunk_inclusion_tracker.chunk_producer_and_received_time(chunk_hash)?;
                 chunk_collection_info.push(ChunkCollection {
-                    chunk_producer: chunk_producer.clone(),
-                    received_time: Some(*chunk_time),
+                    chunk_producer,
+                    received_time: Some(received_time),
                     chunk_included: true,
                 });
             } else {

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -127,7 +127,7 @@ impl BlockProductionTracker {
         for shard_id in 0..num_shards {
             if let Some(chunk_hash) = new_chunks.get(&shard_id) {
                 let (chunk_producer, received_time) =
-                    chunk_inclusion_tracker.chunk_producer_and_received_time(chunk_hash)?;
+                    chunk_inclusion_tracker.get_chunk_producer_and_received_time(chunk_hash)?;
                 chunk_collection_info.push(ChunkCollection {
                     chunk_producer,
                     received_time: Some(received_time),

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -2,7 +2,7 @@ use crate::block::BlockValidityError::{
     InvalidChallengeRoot, InvalidChunkHeaderRoot, InvalidChunkMask, InvalidReceiptRoot,
     InvalidStateRoot, InvalidTransactionRoot,
 };
-use crate::block_body::{BlockBody, BlockBodyV1};
+use crate::block_body::{BlockBody, BlockBodyV1, ChunkEndorsementSignatures};
 pub use crate::block_header::*;
 use crate::challenge::{Challenges, ChallengesResult};
 use crate::checked_feature;
@@ -583,7 +583,7 @@ impl Block {
     }
 
     #[inline]
-    pub fn chunk_endorsements(&self) -> &[Vec<Option<Box<Signature>>>] {
+    pub fn chunk_endorsements(&self) -> &[ChunkEndorsementSignatures] {
         match self {
             Block::BlockV1(_) | Block::BlockV2(_) | Block::BlockV3(_) => &[],
             Block::BlockV4(block) => block.body.chunk_endorsements(),

--- a/core/primitives/src/block_body.rs
+++ b/core/primitives/src/block_body.rs
@@ -110,7 +110,7 @@ impl BlockBody {
     }
 
     #[inline]
-    pub fn chunk_endorsements(&self) -> &[Vec<Option<Box<Signature>>>] {
+    pub fn chunk_endorsements(&self) -> &[ChunkEndorsementSignatures] {
         match self {
             BlockBody::V1(_) => &[],
             BlockBody::V2(body) => &body.chunk_endorsements,

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2386,14 +2386,14 @@ fn test_validate_chunk_extra() {
     env.clients[0].process_block_test(b.into(), Provenance::PRODUCED).unwrap();
     let chunks = {
         let client = &mut env.clients[0];
-        client.chunk_inclusion_tracker.get_chunk_headers_ready_for_inclusion(
-            block1.header().epoch_id(),
-            &block1.hash(),
-            &mut client.chunk_validator,
-        )
+        client
+            .chunk_inclusion_tracker
+            .get_chunk_headers_ready_for_inclusion(block1.header().epoch_id(), &block1.hash())
     };
-    let chunk_header =
-        env.clients[0].chunk_inclusion_tracker.chunk_header(chunks.get(&0).unwrap()).unwrap();
+    let (chunk_header, _) = env.clients[0]
+        .chunk_inclusion_tracker
+        .get_chunk_header_and_endorsements(chunks.get(&0).unwrap())
+        .unwrap();
     let chunk_extra =
         env.clients[0].chain.get_chunk_extra(block1.hash(), &ShardUId::single_shard()).unwrap();
     assert!(validate_chunk_with_chunk_extra(
@@ -2402,7 +2402,7 @@ fn test_validate_chunk_extra() {
         block1.hash(),
         &chunk_extra,
         block1.chunks()[0].height_included(),
-        chunk_header,
+        &chunk_header,
     )
     .is_ok());
 }

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2386,14 +2386,11 @@ fn test_validate_chunk_extra() {
     env.clients[0].process_block_test(b.into(), Provenance::PRODUCED).unwrap();
     let chunks = {
         let client = &mut env.clients[0];
-        client
-            .chunk_inclusion_tracker
-            .get_chunk_headers_ready_for_inclusion(
-                block1.header().epoch_id(),
-                &block1.hash(),
-                &mut client.chunk_validator,
-            )
-            .unwrap()
+        client.chunk_inclusion_tracker.get_chunk_headers_ready_for_inclusion(
+            block1.header().epoch_id(),
+            &block1.hash(),
+            &mut client.chunk_validator,
+        )
     };
     let chunk_header =
         env.clients[0].chunk_inclusion_tracker.chunk_header(chunks.get(&0).unwrap()).unwrap();

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2384,9 +2384,19 @@ fn test_validate_chunk_extra() {
     // Validate that result of chunk execution in `block1` is legit.
     let b = env.clients[0].produce_block_on(next_height + 2, *block1.hash()).unwrap().unwrap();
     env.clients[0].process_block_test(b.into(), Provenance::PRODUCED).unwrap();
-    let chunks = env.clients[0]
-        .chunk_inclusion_tracker
-        .get_chunk_headers_ready_for_inclusion(block1.header().epoch_id(), &block1.hash());
+    let chunks = {
+        let client = &mut env.clients[0];
+        client
+            .chunk_inclusion_tracker
+            .get_chunk_headers_ready_for_inclusion(
+                block1.header().epoch_id(),
+                &block1.hash(),
+                &mut client.chunk_validator,
+            )
+            .unwrap()
+    };
+    let chunk_header =
+        env.clients[0].chunk_inclusion_tracker.chunk_header(chunks.get(&0).unwrap()).unwrap();
     let chunk_extra =
         env.clients[0].chain.get_chunk_extra(block1.hash(), &ShardUId::single_shard()).unwrap();
     assert!(validate_chunk_with_chunk_extra(
@@ -2395,7 +2405,7 @@ fn test_validate_chunk_extra() {
         block1.hash(),
         &chunk_extra,
         block1.chunks()[0].height_included(),
-        &chunks.get(&0).cloned().unwrap().0,
+        chunk_header,
     )
     .is_ok());
 }


### PR DESCRIPTION
## Chunk endorsements signatures in block

This PR writes the logic to include chunk endorsement signatures in block. We tap into the logic in chunk_inclusion_tracker to filter out chunks that don't have enough endorsed signatures.

In case of missing chunk, just like we borrow chunk headers from previous block, we also borrow the chunk endorsement signatures corresponding to the chunk from the previous block.

## Changes to ChunkInclusionTracker

Updated the ChunkInclusionTracker module to have an LRU cache for `prev_block_to_chunk_headers_ready_for_inclusion` + HashMap for chunk hash to random info associated with the chunk.

This is a two step indirection, and we handle cleaning up the `chunk_hash_to_chunk_info` during cache eviction.

Additionally, call to `get_chunk_headers_ready_for_inclusion` now returns just the chunk hash instead of all the random details for the chunk and we can make subsequent calls to chunk_inclusion_tracker to get the other chunk related info like header, signatures, time included etc.

Added filter `chunk_validator.get_chunk_endorsement_signature(&chunk_info.chunk_header)` to reject chunks that don't have enough chunk endorsements. Note that this is behind a feature flag.

## Getting chunk endorsement signatures

Added `get_chunk_endorsement_signature` function to chunk validator module. We use the cached chunk endorsements stored in calls to `process_chunk_endorsement` to get the set of signatures. If we don't have enough stake endorsed, we return None, else we return the signature array.

TODO: Update/fix tests.