### PR TITLE
fix codecov intermittent failure on PRs from forked repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,67 +382,56 @@ jobs:
       # codecov will send a comment only after having receidev this number of uploads.
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: unit-linux.json
           fail_ci_if_error: true
           flags: unittests,linux
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: unit-linux-nightly.json
           fail_ci_if_error: true
           flags: unittests,linux-nightly
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: unit-macos.json
           fail_ci_if_error: true
           flags: unittests,macos
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: integration-linux.json
           fail_ci_if_error: true
           flags: integration-tests,linux
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: integration-linux-nightly.json
           fail_ci_if_error: true
           flags: integration-tests,linux-nightly
       # - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
       #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
       #     files: integration-macos.json
       #     fail_ci_if_error: true
       #     flags: integration-tests,macos
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: py-backward-compat.json
           fail_ci_if_error: true
           flags: pytests,backward-compatibility,linux
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: py-db-migration.json
           fail_ci_if_error: true
           flags: pytests,db-migration,linux
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: py-sanity-checks.json
           fail_ci_if_error: true
           flags: pytests,sanity-checks,linux
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: py-genesis-check.json
           fail_ci_if_error: true
           flags: pytests,genesis-check,linux
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: py-upgradability.json
           fail_ci_if_error: true
           flags: pytests,upgradability,linux

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,11 @@
 codecov:
   notify:
     after_n_builds: 10 # Keep in sync with .github/workflows/ci.yml
+  # Dear h4xx0rz reading this,
+  # Feel free to use this token to upload arbitrary coverage information to codecov.
+  # We do not care. The best you can do is make us facepalm.
+  # Best,
+  token: 1d44b2e4-764d-4336-b989-d3c620176bd2
 
 coverage:
   status:


### PR DESCRIPTION
Forked repos do not actually have access to the codecov token, and codecov is subject to rate-limiting which leads to intermittent failures.

Making the token public is not a big deal, because we really treat all information on codecov as informational only, and do not publicize it as an important part of our system.

However, it’s likely that someone will report a bug bounty about it, so I also added a quite descriptive explanation of the fact we do not care.