### PR TITLE
fix: adjust comments in `pre_validate_chunk_witness` to match the code

### DIFF
--- a/chain/client/src/chunk_validation.rs
+++ b/chain/client/src/chunk_validation.rs
@@ -161,9 +161,9 @@ fn pre_validate_chunk_state_witness(
     // First, go back through the blockchain history to locate the last new chunk
     // and last last new chunk for the shard.
 
-    // Blocks from the last new chunk (exclusive) to the parent block (inclusive).
+    // Blocks from the last new chunk (inclusive) to the parent block (inclusive).
     let mut blocks_after_last_chunk = Vec::new();
-    // Blocks from the last last new chunk (exclusive) to the last new chunk (inclusive).
+    // Blocks from the last last new chunk (inclusive) to the last new chunk (exclusive).
     let mut blocks_after_last_last_chunk = Vec::new();
 
     {


### PR DESCRIPTION
The comments on these two variables don't match the code:
```rust
// Blocks from the last new chunk (exclusive) to the parent block (inclusive).
let mut blocks_after_last_chunk = Vec::new();
// Blocks from the last last new chunk (exclusive) to the last new chunk (inclusive).
let mut blocks_after_last_last_chunk = Vec::new();
````

It seems that instead of `(last_last_chunk, last_chunk]` `(last_chunk, parent_block]`, in reality it's `[last_last_chunk, last_chunk)`, `[last_chunk, parent_block]`.
The rest of the code follows this convention, so the code itself does the correct thing, but it doesn't match what was said in the comment, which makes it much harder to read.

Let's adjust the comments to match what's in the code.

Refs: https://github.com/near/nearcore/pull/10413#discussion_r1451291298