### PR TITLE
fix(configs): fill in missing values in ExperimentalConfig with defaults

### DIFF
--- a/chain/network/src/config_json.rs
+++ b/chain/network/src/config_json.rs
@@ -197,6 +197,7 @@ pub struct Config {
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+#[serde(default)]
 pub struct ExperimentalConfig {
     // If true - don't allow any inbound connections.
     pub inbound_disabled: bool,

--- a/chain/network/src/config_json.rs
+++ b/chain/network/src/config_json.rs
@@ -196,12 +196,29 @@ pub struct Config {
     pub experimental: ExperimentalConfig,
 }
 
+fn default_tier1_enable_inbound() -> bool {
+    true
+}
+
+fn default_tier1_enable_outbound() -> bool {
+    true
+}
+
+fn default_tier1_connect_interval() -> Duration {
+    Duration::from_secs(60)
+}
+
+fn default_tier1_new_connections_per_attempt() -> u64 {
+    50
+}
+
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
-#[serde(default)]
 pub struct ExperimentalConfig {
     // If true - don't allow any inbound connections.
+    #[serde(default)]
     pub inbound_disabled: bool,
     // If true - connect only to the boot nodes.
+    #[serde(default)]
     pub connect_only_to_boot_nodes: bool,
 
     // If greater than 0, then system will no longer send or receive tombstones
@@ -209,22 +226,28 @@ pub struct ExperimentalConfig {
     //
     // The better name is `skip_tombstones_seconds`, but we keep send for
     // compatibility.
+    #[serde(default)]
     pub skip_sending_tombstones_seconds: i64,
 
     /// See `near_network::config::Tier1::enable_inbound`.
+    #[serde(default = "default_tier1_enable_inbound")]
     pub tier1_enable_inbound: bool,
 
     /// See `near_network::config::Tier1::enable_outbound`.
+    #[serde(default = "default_tier1_enable_outbound")]
     pub tier1_enable_outbound: bool,
 
     /// See `near_network::config::Tier1::connect_interval`.
+    #[serde(default = "default_tier1_connect_interval")]
     pub tier1_connect_interval: Duration,
 
     /// See `near_network::config::Tier1::new_connections_per_attempt`.
+    #[serde(default = "default_tier1_new_connections_per_attempt")]
     pub tier1_new_connections_per_attempt: u64,
 
     /// See `NetworkConfig`.
     /// Fields set here will override the NetworkConfig fields.
+    #[serde(default)]
     pub network_config_overrides: NetworkConfigOverrides,
 }
 
@@ -251,10 +274,10 @@ impl Default for ExperimentalConfig {
             inbound_disabled: false,
             connect_only_to_boot_nodes: false,
             skip_sending_tombstones_seconds: 0,
-            tier1_enable_inbound: true,
-            tier1_enable_outbound: true,
-            tier1_connect_interval: Duration::from_secs(60),
-            tier1_new_connections_per_attempt: 50,
+            tier1_enable_inbound: default_tier1_enable_inbound(),
+            tier1_enable_outbound: default_tier1_enable_outbound(),
+            tier1_connect_interval: default_tier1_connect_interval(),
+            tier1_new_connections_per_attempt: default_tier1_new_connections_per_attempt(),
             network_config_overrides: Default::default(),
         }
     }


### PR DESCRIPTION
the command `neard --home {home_dir} init --chain-id mainnet --download-config` downloads the config at
https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/mainnet/config.json and then saves a config file built from that one to {home_dir}/config.json. This is expected to work even when particular fields are missing by filling them in with defaults, which is why many config fields are marked with some sort of `#[serde(default)]` or `#[serde(default = default_fn)]`. But the `ExperimentalConfig` doesn't fill in these defaults. The existing `#[serde(default)]` over that field in `near_network::config_json::Config` will have us fill it in if it's totally missing, but we get an error if it's present with some fields missing, which is the case today:

```
Error: Failed to initialize configs

Caused by:
    config.json file issue: Failed to deserialize config from /tmp/n/config.json: Error("missing field `network_config_overrides`", line: 98, column: 5)
```

Fix it by adding a `#[serde(default)]` to each of the fields in `ExperimentalConfig` 