### PR TITLE
feat: add shadow stateless validation

### DIFF
--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -53,6 +53,7 @@ assert_matches.workspace = true
 byzantine_asserts = []
 expensive_tests = []
 test_features = []
+shadow_chunk_validation = []
 no_cache = ["near-store/no_cache"]
 new_epoch_sync = ["near-store/new_epoch_sync", "near-primitives/new_epoch_sync", "near-epoch-manager/new_epoch_sync", "near-chain-primitives/new_epoch_sync"]
 

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3226,6 +3226,9 @@ impl Chain {
         me: &Option<AccountId>,
         block_header: &BlockHeader,
     ) -> Result<bool, Error> {
+        if cfg!(feature = "shadow_chunk_validation") {
+            return Ok(true);
+        }
         let epoch_id = block_header.epoch_id();
         // Use epoch manager because block is not in DB yet.
         let next_epoch_id =

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -68,6 +68,7 @@ near-actix-test-utils.workspace = true
 [features]
 # if enabled, we assert in most situations that are impossible unless some byzantine behavior is observed.
 byzantine_asserts = ["near-chain/byzantine_asserts"]
+shadow_chunk_validation = ["near-chain/shadow_chunk_validation"]
 expensive_tests = []
 test_features = [
   "near-network/test_features",

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1587,6 +1587,14 @@ impl Client {
                 info!(target: "client", "not producing a chunk");
             }
         }
+        if let Err(err) = self.shadow_validate_block_chunks(&block) {
+            tracing::error!(
+                target: "client",
+                ?err,
+                block_hash = ?block.hash(),
+                "block chunks shadow validation failed"
+            );
+        }
 
         self.shards_manager_adapter
             .send(ShardsManagerRequestFromClient::CheckIncompleteChunks(*block.hash()));
@@ -1707,7 +1715,7 @@ impl Client {
                         .expect("Failed to process produced chunk");
                     if let Err(err) = self.send_chunk_state_witness_to_chunk_validators(
                         &epoch_id,
-                        last_header,
+                        &last_header,
                         &shard_chunk,
                     ) {
                         tracing::error!(target: "client", ?err, "Failed to send chunk state witness to chunk validators");

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -554,3 +554,21 @@ pub(crate) static SYNC_REQUIREMENT_CURRENT: Lazy<IntGaugeVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub(crate) static SHADOW_CHUNK_VALIDATION_FAILED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
+    try_create_int_counter(
+        "near_shadow_chunk_validation_failed_total",
+        "Shadow chunk validation failures count",
+    )
+    .unwrap()
+});
+
+pub(crate) static CHUNK_STATE_WITNESS_TOTAL_SIZE: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "near_chunk_state_witness_total_size",
+        "Stateless validation state witness size in bytes",
+        &["shard_id"],
+        Some(exponential_buckets(1000.0, 2.0, 20).unwrap()),
+    )
+    .unwrap()
+});


### PR DESCRIPTION
This is the first PR for #10440.

New feature `shadow_chunk_validation` is introduced. When enabled it makes the node produce state witness for every chunk in every processed block and then self-validate it. New metrics are introduced for validation failures and state witness size.

Detailed state witness size breakdown metrics from [robin/witness-size](https://github.com/near/nearcore/compare/robin/witness-size) will be added in a separate PR.