### PR TITLE
feat: sign chunk state witness

### DIFF
--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -13,7 +13,9 @@ use near_epoch_manager::{EpochManagerAdapter, RngSeed};
 use near_pool::types::PoolIterator;
 use near_primitives::account::{AccessKey, Account};
 use near_primitives::block_header::{Approval, ApprovalInner};
-use near_primitives::chunk_validation::{ChunkEndorsement, ChunkValidatorAssignments};
+use near_primitives::chunk_validation::{
+    ChunkEndorsement, ChunkStateWitness, ChunkValidatorAssignments,
+};
 use near_primitives::epoch_manager::block_info::BlockInfo;
 use near_primitives::epoch_manager::epoch_info::EpochInfo;
 use near_primitives::epoch_manager::EpochConfig;
@@ -922,6 +924,13 @@ impl EpochManagerAdapter for MockEpochManager {
         &self,
         _chunk_header: &ShardChunkHeader,
         _endorsement: &ChunkEndorsement,
+    ) -> Result<bool, Error> {
+        Ok(true)
+    }
+
+    fn verify_chunk_state_witness(
+        &self,
+        _state_witness: &ChunkStateWitness,
     ) -> Result<bool, Error> {
         Ok(true)
     }

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -920,7 +920,7 @@ impl EpochManagerAdapter for MockEpochManager {
         Ok(true)
     }
 
-    fn verify_chunk_state_witness(
+    fn verify_chunk_state_witness_signature(
         &self,
         _state_witness: &ChunkStateWitness,
     ) -> Result<bool, Error> {

--- a/chain/client/src/adapter.rs
+++ b/chain/client/src/adapter.rs
@@ -138,7 +138,10 @@ pub enum ProcessTxResponse {
 
 #[derive(actix::Message, Debug, PartialEq, Eq)]
 #[rtype(result = "()")]
-pub struct ChunkStateWitnessMessage(pub ChunkStateWitness);
+pub struct ChunkStateWitnessMessage {
+    pub witness: ChunkStateWitness,
+    pub peer_id: PeerId,
+}
 
 #[derive(actix::Message, Debug)]
 #[rtype(result = "()")]
@@ -343,8 +346,12 @@ impl near_network::client::Client for Adapter {
         }
     }
 
-    async fn chunk_state_witness(&self, witness: ChunkStateWitness) {
-        match self.client_addr.send(ChunkStateWitnessMessage(witness).with_span_context()).await {
+    async fn chunk_state_witness(&self, witness: ChunkStateWitness, peer_id: PeerId) {
+        match self
+            .client_addr
+            .send(ChunkStateWitnessMessage { witness, peer_id }.with_span_context())
+            .await
+        {
             Ok(()) => {}
             Err(err) => tracing::error!("mailbox error: {err}"),
         }

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -2005,7 +2005,7 @@ impl Handler<WithSpanContext<ChunkStateWitnessMessage>> for ClientActor {
         _: &mut Context<Self>,
     ) -> Self::Result {
         let (_span, msg) = handler_debug_span!(target: "client", msg);
-        if let Err(err) = self.client.process_chunk_state_witness(msg.0) {
+        if let Err(err) = self.client.process_chunk_state_witness(msg.witness, msg.peer_id) {
             tracing::error!(target: "client", ?err, "Error processing chunk state witness");
         }
     }

--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -22,6 +22,7 @@ use near_primitives::block::Block;
 use near_primitives::epoch_manager::RngSeed;
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
+use near_primitives::network::PeerId;
 use near_primitives::sharding::{ChunkHash, PartialEncodedChunk};
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::transaction::{Action, FunctionCallAction, SignedTransaction};
@@ -282,17 +283,31 @@ impl TestEnv {
                     NetworkRequests::ChunkStateWitness(accounts, chunk_state_witness),
                 ) = msg
                 {
-                    let mut post_state_roots =
-                        HashSet::from([chunk_state_witness.main_state_transition.post_state_root]);
+                    let chunk_state_witness_inner = &chunk_state_witness.inner;
+                    let mut post_state_roots = HashSet::from([chunk_state_witness_inner
+                        .main_state_transition
+                        .post_state_root]);
                     post_state_roots.extend(
-                        chunk_state_witness.implicit_transitions.iter().map(|t| t.post_state_root),
+                        chunk_state_witness_inner
+                            .implicit_transitions
+                            .iter()
+                            .map(|t| t.post_state_root),
                     );
                     found_differing_post_state_root_due_to_state_transitions |=
                         post_state_roots.len() >= 2;
                     for account in accounts {
+                        let sender_public_key = self.clients[idx]
+                            .validator_signer
+                            .as_ref()
+                            .unwrap()
+                            .public_key()
+                            .clone();
                         self.account_indices
                             .lookup_mut(&mut self.clients, &account)
-                            .process_chunk_state_witness(chunk_state_witness.clone())
+                            .process_chunk_state_witness(
+                                chunk_state_witness.clone(),
+                                PeerId::new(sender_public_key),
+                            )
                             .unwrap();
                     }
                     None

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -388,7 +388,10 @@ pub trait EpochManagerAdapter: Send + Sync {
         endorsement: &ChunkEndorsement,
     ) -> Result<bool, Error>;
 
-    fn verify_chunk_state_witness(&self, state_witness: &ChunkStateWitness) -> Result<bool, Error>;
+    fn verify_chunk_state_witness_signature(
+        &self,
+        state_witness: &ChunkStateWitness,
+    ) -> Result<bool, Error>;
 
     fn cares_about_shard_from_prev_block(
         &self,
@@ -993,7 +996,10 @@ impl EpochManagerAdapter for EpochManagerHandle {
         Ok(endorsement.verify(validator.public_key()))
     }
 
-    fn verify_chunk_state_witness(&self, state_witness: &ChunkStateWitness) -> Result<bool, Error> {
+    fn verify_chunk_state_witness_signature(
+        &self,
+        state_witness: &ChunkStateWitness,
+    ) -> Result<bool, Error> {
         let epoch_manager = self.read();
         let chunk_header = &state_witness.inner.chunk_header;
         let epoch_id =

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -5,7 +5,9 @@ use crate::EpochManagerHandle;
 use near_chain_primitives::Error;
 use near_crypto::Signature;
 use near_primitives::block_header::{Approval, ApprovalInner, BlockHeader};
-use near_primitives::chunk_validation::{ChunkEndorsement, ChunkValidatorAssignments};
+use near_primitives::chunk_validation::{
+    ChunkEndorsement, ChunkStateWitness, ChunkValidatorAssignments,
+};
 use near_primitives::epoch_manager::block_info::BlockInfo;
 use near_primitives::epoch_manager::epoch_info::EpochInfo;
 use near_primitives::epoch_manager::EpochConfig;
@@ -391,6 +393,8 @@ pub trait EpochManagerAdapter: Send + Sync {
         chunk_header: &ShardChunkHeader,
         endorsement: &ChunkEndorsement,
     ) -> Result<bool, Error>;
+
+    fn verify_chunk_state_witness(&self, state_witness: &ChunkStateWitness) -> Result<bool, Error>;
 
     fn cares_about_shard_from_prev_block(
         &self,
@@ -1001,6 +1005,21 @@ impl EpochManagerAdapter for EpochManagerHandle {
         let validator =
             epoch_manager.get_validator_by_account_id(&epoch_id, &endorsement.account_id)?;
         Ok(endorsement.verify(validator.public_key()))
+    }
+
+    fn verify_chunk_state_witness(&self, state_witness: &ChunkStateWitness) -> Result<bool, Error> {
+        let epoch_manager = self.read();
+        let chunk_header = &state_witness.inner.chunk_header;
+        let epoch_id =
+            epoch_manager.get_epoch_id_from_prev_block(chunk_header.prev_block_hash())?;
+        let chunk_producer = epoch_manager.get_chunk_producer_info(
+            &epoch_id,
+            chunk_header.height_created(),
+            chunk_header.shard_id(),
+        )?;
+        Ok(state_witness
+            .signature
+            .verify(&borsh::to_vec(&state_witness.inner)?, chunk_producer.public_key()))
     }
 
     fn cares_about_shard_from_prev_block(

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -11,10 +11,15 @@ use crate::test_utils::{
 };
 use near_primitives::account::id::AccountIdRef;
 use near_primitives::challenge::SlashedValidator;
+use near_primitives::chunk_validation::{
+    ChunkStateTransition, ChunkStateWitness, ChunkStateWitnessInner,
+};
 use near_primitives::epoch_manager::EpochConfig;
 use near_primitives::hash::hash;
 use near_primitives::shard_layout::ShardLayout;
+use near_primitives::sharding::{ShardChunkHeader, ShardChunkHeaderV3};
 use near_primitives::types::ValidatorKickoutReason::{NotEnoughBlocks, NotEnoughChunks};
+use near_primitives::validator_signer::ValidatorSigner;
 use near_primitives::version::ProtocolFeature::SimpleNightshade;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_store::test_utils::create_test_store;
@@ -2654,13 +2659,30 @@ fn test_max_kickout_stake_ratio() {
     );
 }
 
+fn test_chunk_header(h: &[CryptoHash], signer: &dyn ValidatorSigner) -> ShardChunkHeader {
+    ShardChunkHeader::V3(ShardChunkHeaderV3::new(
+        h[0],
+        h[2],
+        h[2],
+        h[2],
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        h[2],
+        h[2],
+        vec![],
+        signer,
+    ))
+}
+
 #[test]
-#[cfg(feature = "nightly")]
 fn test_verify_chunk_endorsements() {
     use near_chain_primitives::Error;
     use near_crypto::Signature;
     use near_primitives::chunk_validation::ChunkEndorsement;
-    use near_primitives::sharding::{ShardChunkHeader, ShardChunkHeaderV3};
     use near_primitives::test_utils::create_test_signer;
     use std::str::FromStr;
 
@@ -2690,22 +2712,7 @@ fn test_verify_chunk_endorsements() {
     assert_eq!(signer.public_key(), validator.public_key().clone());
 
     // make chunk header
-    let chunk_header = ShardChunkHeader::V3(ShardChunkHeaderV3::new(
-        h[0],
-        h[2],
-        h[2],
-        h[2],
-        0,
-        1,
-        0,
-        0,
-        0,
-        0,
-        h[2],
-        h[2],
-        vec![],
-        signer.as_ref(),
-    ));
+    let chunk_header = test_chunk_header(&h, signer.as_ref());
 
     // check chunk endorsement validity
     let mut chunk_endorsement = ChunkEndorsement::new(chunk_header.chunk_hash(), signer.clone());
@@ -2733,4 +2740,60 @@ fn test_verify_chunk_endorsements() {
         Error::NotAValidator => (),
         _ => assert!(false, "Expected NotAValidator error but got {:?}", err),
     }
+}
+
+#[test]
+fn test_verify_chunk_state_witness() {
+    use near_crypto::Signature;
+    use near_primitives::test_utils::create_test_signer;
+    use std::str::FromStr;
+
+    let amount_staked = 1_000_000;
+    let account_id = AccountId::from_str("test1").unwrap();
+    let validators = vec![(account_id.clone(), amount_staked)];
+    let h = hash_range(6);
+
+    let mut epoch_manager = setup_default_epoch_manager(validators, 5, 1, 2, 2, 90, 60);
+    record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
+    record_block(&mut epoch_manager, h[0], h[1], 1, vec![]);
+
+    let epoch_manager = epoch_manager.into_handle();
+    let epoch_id = epoch_manager.get_epoch_id(&h[1]).unwrap();
+
+    // Verify if the test signer has same public key as the chunk validator.
+    let (validator, _) =
+        epoch_manager.get_validator_by_account_id(&epoch_id, &h[0], &account_id).unwrap();
+    let signer = Arc::new(create_test_signer("test1"));
+    assert_eq!(signer.public_key(), validator.public_key().clone());
+
+    // Build a chunk state witness with arbitrary data.
+    let chunk_header = test_chunk_header(&h, signer.as_ref());
+    let witness_inner = ChunkStateWitnessInner::new(
+        chunk_header,
+        ChunkStateTransition {
+            block_hash: h[0],
+            base_state: Default::default(),
+            post_state_root: h[3],
+        },
+        Default::default(),
+        h[4],
+        vec![],
+        vec![],
+        vec![],
+        Default::default(),
+    );
+    let signature = signer.sign_chunk_state_witness(&witness_inner);
+
+    // Check chunk state witness validity.
+    let mut chunk_state_witness = ChunkStateWitness { inner: witness_inner, signature };
+    assert!(epoch_manager.verify_chunk_state_witness(&chunk_state_witness).unwrap());
+
+    // Check invalid chunk state witness signature.
+    chunk_state_witness.signature = Signature::default();
+    assert!(!epoch_manager.verify_chunk_state_witness(&chunk_state_witness).unwrap());
+
+    // Check chunk state witness invalidity when signer is not a chunk validator.
+    let bad_signer = Arc::new(create_test_signer("test2"));
+    chunk_state_witness.signature = bad_signer.sign_chunk_state_witness(&chunk_state_witness.inner);
+    assert!(!epoch_manager.verify_chunk_state_witness(&chunk_state_witness).unwrap());
 }

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -2686,6 +2686,11 @@ fn test_verify_chunk_endorsements() {
     use near_primitives::test_utils::create_test_signer;
     use std::str::FromStr;
 
+    if !checked_feature!("stable", ChunkValidation, PROTOCOL_VERSION) {
+        println!("Test not applicable without ChunkValidation enabled");
+        return;
+    }
+
     let amount_staked = 1_000_000;
     let account_id = AccountId::from_str("test1").unwrap();
     let validators = vec![(account_id.clone(), amount_staked)];
@@ -2748,6 +2753,11 @@ fn test_verify_chunk_state_witness() {
     use near_primitives::test_utils::create_test_signer;
     use std::str::FromStr;
 
+    if !checked_feature!("stable", ChunkValidation, PROTOCOL_VERSION) {
+        println!("Test not applicable without ChunkValidation enabled");
+        return;
+    }
+
     let amount_staked = 1_000_000;
     let account_id = AccountId::from_str("test1").unwrap();
     let validators = vec![(account_id.clone(), amount_staked)];
@@ -2786,14 +2796,14 @@ fn test_verify_chunk_state_witness() {
 
     // Check chunk state witness validity.
     let mut chunk_state_witness = ChunkStateWitness { inner: witness_inner, signature };
-    assert!(epoch_manager.verify_chunk_state_witness(&chunk_state_witness).unwrap());
+    assert!(epoch_manager.verify_chunk_state_witness_signature(&chunk_state_witness).unwrap());
 
     // Check invalid chunk state witness signature.
     chunk_state_witness.signature = Signature::default();
-    assert!(!epoch_manager.verify_chunk_state_witness(&chunk_state_witness).unwrap());
+    assert!(!epoch_manager.verify_chunk_state_witness_signature(&chunk_state_witness).unwrap());
 
     // Check chunk state witness invalidity when signer is not a chunk validator.
     let bad_signer = Arc::new(create_test_signer("test2"));
     chunk_state_witness.signature = bad_signer.sign_chunk_state_witness(&chunk_state_witness.inner);
-    assert!(!epoch_manager.verify_chunk_state_witness(&chunk_state_witness).unwrap());
+    assert!(!epoch_manager.verify_chunk_state_witness_signature(&chunk_state_witness).unwrap());
 }

--- a/chain/network/src/client.rs
+++ b/chain/network/src/client.rs
@@ -64,7 +64,7 @@ pub trait Client: Send + Sync + 'static {
         accounts: Vec<(AnnounceAccount, Option<EpochId>)>,
     ) -> Result<Vec<AnnounceAccount>, ReasonForBan>;
 
-    async fn chunk_state_witness(&self, witness: ChunkStateWitness);
+    async fn chunk_state_witness(&self, witness: ChunkStateWitness, peer_id: PeerId);
 
     async fn chunk_endorsement(&self, endorsement: ChunkEndorsement);
 }
@@ -135,7 +135,7 @@ impl Client for Noop {
         Ok(vec![])
     }
 
-    async fn chunk_state_witness(&self, _witness: ChunkStateWitness) {}
+    async fn chunk_state_witness(&self, _witness: ChunkStateWitness, _peer_id: PeerId) {}
 
     async fn chunk_endorsement(&self, _endorsement: ChunkEndorsement) {}
 }

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -982,7 +982,7 @@ impl PeerActor {
                 None
             }
             RoutedMessageBody::ChunkStateWitness(witness) => {
-                network_state.client.chunk_state_witness(witness).await;
+                network_state.client.chunk_state_witness(witness, peer_id).await;
                 None
             }
             RoutedMessageBody::ChunkEndorsement(endorsement) => {

--- a/chain/network/src/testonly/fake_client.rs
+++ b/chain/network/src/testonly/fake_client.rs
@@ -122,7 +122,7 @@ impl client::Client for Fake {
         Ok(accounts.into_iter().map(|a| a.0).collect())
     }
 
-    async fn chunk_state_witness(&self, witness: ChunkStateWitness) {
+    async fn chunk_state_witness(&self, witness: ChunkStateWitness, _peer_id: PeerId) {
         self.event_sink.push(Event::ChunkStateWitness(witness));
     }
 

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -69,6 +69,7 @@ pub enum ReasonForBan {
     InvalidDistanceVector = 11,
     Blacklisted = 14,
     ProvidedNotEnoughHeaders = 15,
+    BadChunkStateWitness = 16,
 }
 
 /// Banning signal sent from Peer instance to PeerManager

--- a/core/primitives/src/chunk_validation.rs
+++ b/core/primitives/src/chunk_validation.rs
@@ -11,10 +11,25 @@ use near_crypto::{PublicKey, Signature};
 use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::{AccountId, Balance};
 
+/// An arbitrary static string to make sure that this struct cannot be
+/// serialized to look identical to another serialized struct. For chunk
+/// production we are signing a chunk hash, so we need to make sure that
+/// this signature means something different.
+///
+/// This is a messy workaround until we know what to do with NEP 483.
+type SignatureDifferentiator = String;
+
+/// Signable
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct ChunkStateWitness {
+    pub inner: ChunkStateWitnessInner,
+    pub signature: Signature,
+}
+
 /// The state witness for a chunk; proves the state transition that the
 /// chunk attests to.
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
-pub struct ChunkStateWitness {
+pub struct ChunkStateWitnessInner {
     /// The chunk header that this witness is for. While this is not needed
     /// to apply the state transition, it is needed for a chunk validator to
     /// produce a chunk endorsement while knowing what they are endorsing.
@@ -77,6 +92,32 @@ pub struct ChunkStateWitness {
     /// accounts have appropriate balances, access keys, nonces, etc.
     pub new_transactions: Vec<SignedTransaction>,
     pub new_transactions_validation_state: PartialState,
+    signature_differentiator: SignatureDifferentiator,
+}
+
+impl ChunkStateWitnessInner {
+    pub fn new(
+        chunk_header: ShardChunkHeader,
+        main_state_transition: ChunkStateTransition,
+        source_receipt_proofs: HashMap<ChunkHash, ReceiptProof>,
+        applied_receipts_hash: CryptoHash,
+        transactions: Vec<SignedTransaction>,
+        implicit_transitions: Vec<ChunkStateTransition>,
+        new_transactions: Vec<SignedTransaction>,
+        new_transactions_validation_state: PartialState,
+    ) -> Self {
+        Self {
+            chunk_header,
+            main_state_transition,
+            source_receipt_proofs,
+            applied_receipts_hash,
+            transactions,
+            implicit_transitions,
+            new_transactions,
+            new_transactions_validation_state,
+            signature_differentiator: "ChunkStateWitness".to_owned(),
+        }
+    }
 }
 
 /// Represents the base state and the expected post-state-root of a chunk's state
@@ -138,13 +179,7 @@ impl ChunkEndorsement {
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ChunkEndorsementInner {
     chunk_hash: ChunkHash,
-    /// An arbitrary static string to make sure that this struct cannot be
-    /// serialized to look identical to another serialized struct. For chunk
-    /// production we are signing a chunk hash, so we need to make sure that
-    /// this signature means something different.
-    ///
-    /// This is a messy workaround until we know what to do with NEP 483.
-    signature_differentiator: String,
+    signature_differentiator: SignatureDifferentiator,
 }
 
 impl ChunkEndorsementInner {

--- a/core/primitives/src/validator_signer.rs
+++ b/core/primitives/src/validator_signer.rs
@@ -5,7 +5,7 @@ use near_crypto::{InMemorySigner, KeyType, PublicKey, Signature, Signer};
 
 use crate::block::{Approval, ApprovalInner, BlockHeader};
 use crate::challenge::ChallengeBody;
-use crate::chunk_validation::ChunkEndorsementInner;
+use crate::chunk_validation::{ChunkEndorsementInner, ChunkStateWitnessInner};
 use crate::hash::CryptoHash;
 use crate::network::{AnnounceAccount, PeerId};
 use crate::sharding::ChunkHash;
@@ -39,6 +39,9 @@ pub trait ValidatorSigner: Sync + Send {
 
     /// Signs approval of the given chunk.
     fn sign_chunk_endorsement(&self, inner: &ChunkEndorsementInner) -> Signature;
+
+    /// Signs approval of the given chunk.
+    fn sign_chunk_state_witness(&self, inner: &ChunkStateWitnessInner) -> Signature;
 
     /// Signs challenge body.
     fn sign_challenge(&self, challenge_body: &ChallengeBody) -> (CryptoHash, Signature);
@@ -113,6 +116,10 @@ impl ValidatorSigner for EmptyValidatorSigner {
     }
 
     fn sign_chunk_endorsement(&self, _inner: &ChunkEndorsementInner) -> Signature {
+        Signature::default()
+    }
+
+    fn sign_chunk_state_witness(&self, _inner: &ChunkStateWitnessInner) -> Signature {
         Signature::default()
     }
 
@@ -208,6 +215,10 @@ impl ValidatorSigner for InMemoryValidatorSigner {
     }
 
     fn sign_chunk_endorsement(&self, inner: &ChunkEndorsementInner) -> Signature {
+        self.signer.sign(&borsh::to_vec(inner).unwrap())
+    }
+
+    fn sign_chunk_state_witness(&self, inner: &ChunkStateWitnessInner) -> Signature {
         self.signer.sign(&borsh::to_vec(inner).unwrap())
     }
 

--- a/tools/chainsync-loadtest/src/network.rs
+++ b/tools/chainsync-loadtest/src/network.rs
@@ -305,7 +305,7 @@ impl near_network::client::Client for Network {
         Ok(accounts.into_iter().map(|a| a.0).collect())
     }
 
-    async fn chunk_state_witness(&self, _witness: ChunkStateWitness) {}
+    async fn chunk_state_witness(&self, _witness: ChunkStateWitness, _peer_id: PeerId) {}
 
     async fn chunk_endorsement(&self, _endorsement: ChunkEndorsement) {}
 }


### PR DESCRIPTION
It looks reasonable to have some protection against sending arbitrary data pretending to be state witness, as it is large message causing a lot of computation. Also having a message to reject of state witness is more convenient for testing.

Here I modify state witness message to include signature; construct and verify it; and also spawn message to ban peer if state witness is invalid. As chunk producer is uniquely determined by state witness data, we don't need to pass it in message. Ideally the test also should be here but it is not a trivial change so I'll send it in the next PRs.

The logic of `SignatureDifferentiator` can be done better but for now I just follow chunk endorsements pattern. Also I recognize that signing/verifying logic is quite duplicated around epoch manager, but I don't see an easy way around it.

## Testing

For now, just check that signing logic works. 