### PR TITLE
crates: Release 0.20.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 # Most crates are not stable on purpose, as maintaining API compatibility is a
 # significant developer time expense. Please think thoroughly before adding
 # anything to the list of stable crates.
-version = "0.20.0"
+version = "0.20.1"
 exclude = ["neard"]
 
 [workspace]


### PR DESCRIPTION
Merges the version bump commit from https://github.com/near/nearcore/tree/crates-0.20.x