### PR TITLE
[stateless_validaiton] Skip validation of state witness for chunk right after genesis

### DIFF
--- a/chain/client/src/chunk_validation.rs
+++ b/chain/client/src/chunk_validation.rs
@@ -454,6 +454,7 @@ impl Client {
                 signer.as_ref(),
                 &self.chunk_validator.network_sender,
             );
+            return Ok(());
         }
         // TODO(#10265): If the previous block does not exist, we should
         // queue this (similar to orphans) to retry later.

--- a/chain/client/src/chunk_validation.rs
+++ b/chain/client/src/chunk_validation.rs
@@ -107,16 +107,8 @@ impl ChunkValidator {
             self.epoch_manager.as_ref(),
         )?;
 
-        // Send the chunk endorsement to the next NUM_NEXT_BLOCK_PRODUCERS_TO_SEND_CHUNK_ENDORSEMENT block producers.
-        // It's possible we may reach the end of the epoch, in which case, ignore the error from get_block_producer.
-        let block_height = chunk_header.height_created();
-        let block_producers = (0..NUM_NEXT_BLOCK_PRODUCERS_TO_SEND_CHUNK_ENDORSEMENT)
-            .map_while(|i| self.epoch_manager.get_block_producer(&epoch_id, block_height + i).ok())
-            .collect_vec();
-        assert!(!block_producers.is_empty());
-
         let network_sender = self.network_sender.clone();
-        let signer = self.my_signer.clone().unwrap();
+        let signer = my_signer.clone();
         let epoch_manager = self.epoch_manager.clone();
         let runtime_adapter = self.runtime_adapter.clone();
         rayon::spawn(move || {
@@ -127,18 +119,12 @@ impl ChunkValidator {
                 runtime_adapter.as_ref(),
             ) {
                 Ok(()) => {
-                    tracing::debug!(
-                        target: "chunk_validation",
-                        chunk_hash=?chunk_header.chunk_hash(),
-                        ?block_producers,
-                        "Chunk validated successfully, sending endorsement",
+                    send_chunk_endorsement_to_block_producers(
+                        &chunk_header,
+                        epoch_manager.as_ref(),
+                        signer.as_ref(),
+                        &network_sender,
                     );
-                    let endorsement = ChunkEndorsement::new(chunk_header.chunk_hash(), signer);
-                    for block_producer in block_producers {
-                        network_sender.send(PeerManagerMessageRequest::NetworkRequests(
-                            NetworkRequests::ChunkEndorsement(block_producer, endorsement.clone()),
-                        ));
-                    }
                 }
                 Err(err) => {
                     tracing::error!("Failed to validate chunk: {:?}", err);
@@ -421,10 +407,54 @@ fn apply_result_to_chunk_extra(
     )
 }
 
+fn send_chunk_endorsement_to_block_producers(
+    chunk_header: &ShardChunkHeader,
+    epoch_manager: &dyn EpochManagerAdapter,
+    signer: &dyn ValidatorSigner,
+    network_sender: &Sender<PeerManagerMessageRequest>,
+) {
+    let epoch_id =
+        epoch_manager.get_epoch_id_from_prev_block(chunk_header.prev_block_hash()).unwrap();
+
+    // Send the chunk endorsement to the next NUM_NEXT_BLOCK_PRODUCERS_TO_SEND_CHUNK_ENDORSEMENT block producers.
+    // It's possible we may reach the end of the epoch, in which case, ignore the error from get_block_producer.
+    let block_height = chunk_header.height_created();
+    let block_producers = (0..NUM_NEXT_BLOCK_PRODUCERS_TO_SEND_CHUNK_ENDORSEMENT)
+        .map_while(|i| epoch_manager.get_block_producer(&epoch_id, block_height + i).ok())
+        .collect_vec();
+    assert!(!block_producers.is_empty());
+
+    tracing::debug!(
+        target: "chunk_validation",
+        chunk_hash=?chunk_header.chunk_hash(),
+        ?block_producers,
+        "Chunk validated successfully, sending endorsement",
+    );
+
+    let endorsement = ChunkEndorsement::new(chunk_header.chunk_hash(), signer);
+    for block_producer in block_producers {
+        network_sender.send(PeerManagerMessageRequest::NetworkRequests(
+            NetworkRequests::ChunkEndorsement(block_producer, endorsement.clone()),
+        ));
+    }
+}
+
 impl Client {
     /// Responds to a network request to verify a `ChunkStateWitness`, which is
     /// sent by chunk producers after they produce a chunk.
     pub fn process_chunk_state_witness(&mut self, witness: ChunkStateWitness) -> Result<(), Error> {
+        // First chunk after genesis doesn't have to be endorsed.
+        if witness.chunk_header.prev_block_hash() == self.chain.genesis().hash() {
+            let Some(signer) = self.validator_signer.as_ref() else {
+                return Err(Error::NotAChunkValidator);
+            };
+            send_chunk_endorsement_to_block_producers(
+                &witness.chunk_header,
+                self.epoch_manager.as_ref(),
+                signer.as_ref(),
+                &self.chunk_validator.network_sender,
+            );
+        }
         // TODO(#10265): If the previous block does not exist, we should
         // queue this (similar to orphans) to retry later.
         self.chunk_validator.start_validating_chunk(witness, self.chain.chain_store())
@@ -497,10 +527,6 @@ impl Client {
     ) -> Result<(), Error> {
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(epoch_id)?;
         if !checked_feature!("stable", ChunkValidation, protocol_version) {
-            return Ok(());
-        }
-        // First chunk after genesis doesn't have to be endorsed.
-        if prev_chunk_header.prev_block_hash() == &CryptoHash::default() {
             return Ok(());
         }
 

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -2708,7 +2708,7 @@ fn test_verify_chunk_endorsements() {
     ));
 
     // check chunk endorsement validity
-    let mut chunk_endorsement = ChunkEndorsement::new(chunk_header.chunk_hash(), signer.clone());
+    let mut chunk_endorsement = ChunkEndorsement::new(chunk_header.chunk_hash(), signer.as_ref());
     assert!(epoch_manager.verify_chunk_endorsement(&chunk_header, &chunk_endorsement).unwrap());
 
     // check invalid chunk endorsement signature
@@ -2716,7 +2716,7 @@ fn test_verify_chunk_endorsements() {
     assert!(!epoch_manager.verify_chunk_endorsement(&chunk_header, &chunk_endorsement).unwrap());
 
     // check chunk endorsement invalidity when chunk header and chunk endorsement don't match
-    let chunk_endorsement = ChunkEndorsement::new(h[3].into(), signer);
+    let chunk_endorsement = ChunkEndorsement::new(h[3].into(), signer.as_ref());
     let err =
         epoch_manager.verify_chunk_endorsement(&chunk_header, &chunk_endorsement).unwrap_err();
     match err {
@@ -2726,7 +2726,7 @@ fn test_verify_chunk_endorsements() {
 
     // check chunk endorsement invalidity when signer is not chunk validator
     let bad_signer = Arc::new(create_test_signer("test2"));
-    let chunk_endorsement = ChunkEndorsement::new(chunk_header.chunk_hash(), bad_signer);
+    let chunk_endorsement = ChunkEndorsement::new(chunk_header.chunk_hash(), bad_signer.as_ref());
     let err =
         epoch_manager.verify_chunk_endorsement(&chunk_header, &chunk_endorsement).unwrap_err();
     match err {

--- a/core/primitives/src/chunk_validation.rs
+++ b/core/primitives/src/chunk_validation.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
 
 use crate::challenge::PartialState;
 use crate::sharding::{ChunkHash, ReceiptProof, ShardChunkHeader};
@@ -106,7 +105,7 @@ pub struct ChunkEndorsement {
 }
 
 impl ChunkEndorsement {
-    pub fn new(chunk_hash: ChunkHash, signer: Arc<dyn ValidatorSigner>) -> ChunkEndorsement {
+    pub fn new(chunk_hash: ChunkHash, signer: &dyn ValidatorSigner) -> ChunkEndorsement {
         let inner = ChunkEndorsementInner::new(chunk_hash);
         let account_id = signer.validator_id().clone();
         let signature = signer.sign_chunk_endorsement(&inner);


### PR DESCRIPTION
We are skipping state witness validation for the chunk right after genesis chunk due to some complications of trying to run the genesis chunk in runtime (it's not possible to do so).

Initially this edge case check was a part of `send_chunk_state_witness_to_chunk_validators` and we didn't send state witness at all.

This has an issue that we do not process and send chunk endorsements either due to this. Instead pushed this check into `process_chunk_state_witness` and we send chunk endorsements for this special case.