### PR TITLE
[stateless_validation] Do not include chunk endorsement signatures for old chunks in block

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -674,11 +674,9 @@ impl Client {
         let block_ordinal: NumBlocks = block_merkle_tree.size() + 1;
         let prev_block_extra = self.chain.get_block_extra(&prev_hash)?;
         let prev_block = self.chain.get_block(&prev_hash)?;
-        let (mut chunk_headers, mut chunk_endorsements) =
-            Chain::get_prev_chunk_headers_and_chunk_endorsements(
-                self.epoch_manager.as_ref(),
-                &prev_block,
-            )?;
+        let mut chunk_headers =
+            Chain::get_prev_chunk_headers(self.epoch_manager.as_ref(), &prev_block)?;
+        let mut chunk_endorsements = vec![vec![]; chunk_headers.len()];
 
         // Add debug information about the block production (and info on when did the chunks arrive).
         self.block_production_info.record_block_production(

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -250,7 +250,7 @@ impl Block {
         height: BlockHeight,
         block_ordinal: NumBlocks,
         chunks: Vec<ShardChunkHeader>,
-        chunk_endorsements: Vec<Vec<Option<Box<Signature>>>>,
+        chunk_endorsements: Vec<ChunkEndorsementSignatures>,
         epoch_id: EpochId,
         next_epoch_id: EpochId,
         epoch_sync_data_hash: Option<CryptoHash>,

--- a/core/primitives/src/block_body.rs
+++ b/core/primitives/src/block_body.rs
@@ -62,7 +62,7 @@ impl BlockBody {
         challenges: Challenges,
         vrf_value: Value,
         vrf_proof: Proof,
-        chunk_endorsements: Vec<Vec<Option<Box<Signature>>>>,
+        chunk_endorsements: Vec<ChunkEndorsementSignatures>,
     ) -> Self {
         if !checked_feature!("stable", ChunkValidation, protocol_version) {
             BlockBody::V1(BlockBodyV1 { chunks, challenges, vrf_value, vrf_proof })


### PR DESCRIPTION
This is a follow up to comment https://github.com/near/nearcore/pull/10469#discussion_r1464954843

If we have an old chunk header present in the block, which happens in case a new chunk isn't included/is missing in the block, we don't need to include the chunk endorsement signatures in the block body.

Updated the block validation logic to reflect the same