### PR TITLE
refactor: remove StorageDataSource::DbTrieOnly

### DIFF
--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -254,10 +254,6 @@ impl ChainGenesis {
 pub enum StorageDataSource {
     /// Full state data is present in DB.
     Db,
-    /// Trie is present in DB and flat storage is not.
-    /// Used for testing stateless validation jobs, should be removed after
-    /// stateless validation release.
-    DbTrieOnly,
     /// State data is supplied from state witness, there is no state data
     /// stored on disk.
     Recorded(PartialStorage),

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -648,11 +648,6 @@ impl Trie {
         }
     }
 
-    /// Temporary helper, must be removed after stateless validation release.
-    pub fn dont_charge_gas_for_trie_node_access(&mut self) {
-        self.charge_gas_for_trie_node_access = false;
-    }
-
     /// Makes a new trie that has everything the same except that access
     /// through that trie accumulates a state proof for all nodes accessed.
     pub fn recording_reads(&self) -> Self {

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -868,18 +868,6 @@ impl RuntimeAdapter for NightshadeRuntime {
                 storage_config.state_root,
                 storage_config.use_flat_storage,
             )?,
-            StorageDataSource::DbTrieOnly => {
-                // If there is no flat storage on disk, use trie but simulate costs with enabled
-                // flat storage by not charging gas for trie nodes.
-                let mut trie = self.get_trie_for_shard(
-                    shard_id,
-                    &block.prev_block_hash,
-                    storage_config.state_root,
-                    false,
-                )?;
-                trie.dont_charge_gas_for_trie_node_access();
-                trie
-            }
             StorageDataSource::Recorded(storage) => Trie::from_recorded_storage(
                 storage,
                 storage_config.state_root,


### PR DESCRIPTION
It was introduced as a temporary measure which is no longer required.