### PR TITLE
feat: add metric for state witness validation latency

### DIFF
--- a/chain/client/src/chunk_validation.rs
+++ b/chain/client/src/chunk_validation.rs
@@ -354,7 +354,7 @@ fn validate_chunk_state_witness(
     runtime_adapter: &dyn RuntimeAdapter,
 ) -> Result<(), Error> {
     let main_transition = pre_validation_output.main_transition_params;
-    let _timer = metrics::CHUNK_STATE_WITNESS_VALIDATION_ELAPSED
+    let _timer = metrics::CHUNK_STATE_WITNESS_VALIDATION_TIME
         .with_label_values(&[&main_transition.chunk_header.shard_id().to_string()])
         .start_timer();
     let span = tracing::debug_span!(target: "chain", "validate_chunk_state_witness").entered();

--- a/chain/client/src/chunk_validation.rs
+++ b/chain/client/src/chunk_validation.rs
@@ -353,8 +353,11 @@ fn validate_chunk_state_witness(
     epoch_manager: &dyn EpochManagerAdapter,
     runtime_adapter: &dyn RuntimeAdapter,
 ) -> Result<(), Error> {
-    let span = tracing::debug_span!(target: "chain", "validate_chunk_state_witness").entered();
     let main_transition = pre_validation_output.main_transition_params;
+    let _timer = metrics::CHUNK_STATE_WITNESS_VALIDATION_ELAPSED
+        .with_label_values(&[&main_transition.chunk_header.shard_id().to_string()])
+        .start_timer();
+    let span = tracing::debug_span!(target: "chain", "validate_chunk_state_witness").entered();
     let chunk_header = main_transition.chunk_header.clone();
     let epoch_id = epoch_manager.get_epoch_id(&main_transition.block.block_hash)?;
     let shard_uid =

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -563,6 +563,16 @@ pub(crate) static SHADOW_CHUNK_VALIDATION_FAILED_TOTAL: Lazy<IntCounter> = Lazy:
     .unwrap()
 });
 
+pub(crate) static CHUNK_STATE_WITNESS_VALIDATION_ELAPSED: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "near_chunk_state_witness_validation_elapsed",
+        "State witness validation latency",
+        &["shard_id"],
+        Some(exponential_buckets(0.01, 2.0, 12).unwrap()),
+    )
+    .unwrap()
+});
+
 pub(crate) static CHUNK_STATE_WITNESS_TOTAL_SIZE: Lazy<HistogramVec> = Lazy::new(|| {
     try_create_histogram_vec(
         "near_chunk_state_witness_total_size",

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -563,10 +563,10 @@ pub(crate) static SHADOW_CHUNK_VALIDATION_FAILED_TOTAL: Lazy<IntCounter> = Lazy:
     .unwrap()
 });
 
-pub(crate) static CHUNK_STATE_WITNESS_VALIDATION_ELAPSED: Lazy<HistogramVec> = Lazy::new(|| {
+pub(crate) static CHUNK_STATE_WITNESS_VALIDATION_TIME: Lazy<HistogramVec> = Lazy::new(|| {
     try_create_histogram_vec(
-        "near_chunk_state_witness_validation_elapsed",
-        "State witness validation latency",
+        "near_chunk_state_witness_validation_time",
+        "State witness validation latency in seconds",
         &["shard_id"],
         Some(exponential_buckets(0.01, 2.0, 12).unwrap()),
     )


### PR DESCRIPTION
Measures `validate_chunk_state_witness` function execution time per `shard_id`.