### PR TITLE
store: return borrow to memtrie data on lookups

### DIFF
--- a/core/store/src/trie/mem/flexible_data/value.rs
+++ b/core/store/src/trie/mem/flexible_data/value.rs
@@ -1,4 +1,5 @@
 use crate::trie::mem::arena::{ArenaSlice, ArenaSliceMut};
+use crate::trie::OptimizedValueRef;
 
 use super::encoding::BorshFixedSize;
 use super::FlexibleDataHeader;
@@ -100,6 +101,10 @@ impl<'a> ValueView<'a> {
             }
             Self::Inlined(data) => FlatStateValue::Inlined(data.raw_slice().to_vec()),
         }
+    }
+
+    pub(crate) fn to_optimized_value_ref(&self) -> OptimizedValueRef {
+        OptimizedValueRef::from_flat_value(self.to_flat_value())
     }
 
     pub fn len(&self) -> usize {

--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -184,7 +184,6 @@ mod tests {
     };
     use crate::trie::mem::loading::load_trie_from_flat_state;
     use crate::trie::mem::lookup::memtrie_lookup;
-    use crate::trie::OptimizedValueRef;
     use crate::{DBCol, KeyLookupMode, NibbleSlice, ShardTries, Store, Trie, TrieUpdate};
     use near_primitives::hash::CryptoHash;
     use near_primitives::shard_layout::{get_block_shard_uid, ShardUId};
@@ -235,7 +234,7 @@ mod tests {
         for key in keys.iter().chain([b"not in trie".to_vec()].iter()) {
             let mut nodes_accessed = Vec::new();
             let actual_value_ref = memtrie_lookup(root, key, Some(&mut nodes_accessed))
-                .map(OptimizedValueRef::from_flat_value);
+                .map(|v| v.to_optimized_value_ref());
             let expected_value_ref =
                 trie.get_optimized_ref(key, KeyLookupMode::FlatStorage).unwrap();
             assert_eq!(actual_value_ref, expected_value_ref, "{:?}", NibbleSlice::new(key));
@@ -465,23 +464,28 @@ mod tests {
         let mem_tries = load_trie_from_flat_state_and_delta(&store, shard_uid).unwrap();
 
         assert_eq!(
-            memtrie_lookup(mem_tries.get_root(&state_root_0).unwrap(), &test_key.to_vec(), None),
+            memtrie_lookup(mem_tries.get_root(&state_root_0).unwrap(), &test_key.to_vec(), None)
+                .map(|v| v.to_flat_value()),
             Some(FlatStateValue::inlined(&test_val0))
         );
         assert_eq!(
-            memtrie_lookup(mem_tries.get_root(&state_root_1).unwrap(), &test_key.to_vec(), None),
+            memtrie_lookup(mem_tries.get_root(&state_root_1).unwrap(), &test_key.to_vec(), None)
+                .map(|v| v.to_flat_value()),
             Some(FlatStateValue::inlined(&test_val1))
         );
         assert_eq!(
-            memtrie_lookup(mem_tries.get_root(&state_root_2).unwrap(), &test_key.to_vec(), None),
+            memtrie_lookup(mem_tries.get_root(&state_root_2).unwrap(), &test_key.to_vec(), None)
+                .map(|v| v.to_flat_value()),
             Some(FlatStateValue::inlined(&test_val2))
         );
         assert_eq!(
-            memtrie_lookup(mem_tries.get_root(&state_root_3).unwrap(), &test_key.to_vec(), None),
+            memtrie_lookup(mem_tries.get_root(&state_root_3).unwrap(), &test_key.to_vec(), None)
+                .map(|v| v.to_flat_value()),
             Some(FlatStateValue::inlined(&test_val3))
         );
         assert_eq!(
-            memtrie_lookup(mem_tries.get_root(&state_root_4).unwrap(), &test_key.to_vec(), None),
+            memtrie_lookup(mem_tries.get_root(&state_root_4).unwrap(), &test_key.to_vec(), None)
+                .map(|v| v.to_flat_value()),
             Some(FlatStateValue::inlined(&test_val4))
         );
     }

--- a/core/store/src/trie/mem/mod.rs
+++ b/core/store/src/trie/mem/mod.rs
@@ -10,7 +10,7 @@ use std::collections::{BTreeMap, HashMap};
 
 mod arena;
 mod construction;
-mod flexible_data;
+pub(crate) mod flexible_data;
 pub mod loading;
 pub mod lookup;
 pub mod metrics;

--- a/core/store/src/trie/mem/updating.rs
+++ b/core/store/src/trie/mem/updating.rs
@@ -998,6 +998,7 @@ mod tests {
                         .unwrap_or_else(|| {
                             panic!("Key {} is in truth but not in memtrie", hex::encode(key))
                         })
+                        .to_flat_value()
                         .to_value_ref();
                     let disk_value_ref = disk_result
                         .unwrap_or_else(|| {

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -1253,6 +1253,10 @@ impl Trie {
     /// `charge_gas_for_trie_node_access` is used to control whether Trie node
     /// accesses incur any gas. Note that access to values is never charged here;
     /// it is only charged when the returned ref is dereferenced.
+    ///
+    /// The storage of memtries and the data therein are behind a lock, as thus unlike many other
+    /// functions here, the access to the value reference is provided as an argument to the
+    /// `map_result` closure.
     fn lookup_from_memory<R: 'static>(
         &self,
         key: &[u8],

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -1282,7 +1282,7 @@ impl Trie {
                 recorder.borrow_mut().record(&node_hash, serialized_node);
             }
         }
-        Ok(flat_value.map(OptimizedValueRef::from_flat_value))
+        Ok(flat_value.map(|v| v.to_optimized_value_ref()))
     }
 
     /// For debugging only. Returns the raw node at the given path starting from the root.


### PR DESCRIPTION
This is primarily intended to enable cheap existence lookups eventually but stylistically it seems quite awkward to force a conversion on the users of the API when a choice can be given at low-to-no cost.