### PR TITLE
Fix: get branch on RELEASE event triggered workflow

### DIFF
--- a/.github/workflows/neard_release.yml
+++ b/.github/workflows/neard_release.yml
@@ -47,6 +47,10 @@ jobs:
         run: |
           echo $(git rev-parse HEAD) > latest
           BRANCH=$(git branch --show-current)
+          # in case of Release triggered run, branch is empty
+          if [ -z "$BRANCH" ]; then
+            BRANCH=$(git branch -r --contains=${{ github.ref_name }} | head -n1 | cut -c3- | cut -d / -f 2)
+          fi
           aws s3 cp --acl public-read latest s3://build.nearprotocol.com/nearcore/$(uname)/${BRANCH}/latest
 
   docker-release:

--- a/scripts/binary_release.sh
+++ b/scripts/binary_release.sh
@@ -13,6 +13,13 @@ case "$release" in
 esac
 
 BRANCH=$(git branch --show-current)
+
+# in case of Release triggered run, branch is empty
+if [ -z "$BRANCH" ]; then
+  REF=$(git describe --tags | head -n1)
+  BRANCH=$(git branch -r --contains=$REF | head -n1 | cut -c3- | cut -d / -f 2)
+fi
+
 COMMIT=$(git rev-parse HEAD)
 
 os=$(uname)


### PR DESCRIPTION
On release triggered workflow runs, the HEAD is detached and no local branch is present.
Due to this, BRANCH var ends up as an empty string and this causes failures to publish artifacts:
https://github.com/near/nearcore/actions/runs/7640475082/job/20815674136
++ git branch --show-current
+ BRANCH=
++ git rev-parse HEAD
+ COMMIT=c869dd6c1e942f21e27a74c7e47a698de
++ uname


this leads to incorrect S3 paths:
`s3://build.nearprotocol.com/nearcore/$(uname)/${BRANCH}/latest` -> `s3://build.nearprotocol.com/nearcore/Linux//latest`