### PR TITLE
implement custom coverage generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,14 @@ jobs:
           shared-key: "cargo_nextest-${{ matrix.cache_id }}"
           save-if: "${{ github.event_name == 'merge_group' }}" # save the cache only from master CI
 
-      # Run the tests
+      # Run the tests:
+      - run: mkdir -p coverage/profraw/{unit,integration,binaries}
+      # - Run the unit tests, retrieving the coverage information
       - run: just codecov "nextest-unit ${{ matrix.type }}"
       - run: mv coverage/codecov/{new,unit-${{matrix.id}}}.json
-      - run: mkdir -p coverage/profraw/{unit,integration,binaries}
       - run: cd coverage/profraw/new && tar -c --zstd -f ../unit/${{matrix.id}}.tar.zst *
       - run: rm -rf coverage/profraw/new
+      # - Run the integration tests, retrieving the coverage information
       - run: just codecov "nextest-integration ${{ matrix.type }}"
         if: matrix.runs_integ_tests
       - run: mv coverage/codecov/{new,integration-${{matrix.id}}}.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       # Run the tests
       - run: just codecov "nextest-unit ${{ matrix.type }}"
       - run: mv coverage/codecov/{new,unit-${{matrix.id}}}.json
-      - run: mkdir -p coverage/profraw/{unit,integration}
+      - run: mkdir -p coverage/profraw/{unit,integration,binaries}
       - run: cd coverage/profraw/new && tar -c --zstd -f ../unit/${{matrix.id}}.tar.zst *
       - run: rm -rf coverage/profraw/new
       - run: just codecov "nextest-integration ${{ matrix.type }}"
@@ -71,6 +71,12 @@ jobs:
         if: matrix.runs_integ_tests
       - run: rm -rf coverage/profraw/new
         if: matrix.runs_integ_tests
+
+      # Cleanup the target directory, leaving only stuff interesting to llvm-cov, and tarball it
+      - run: find target/dev-release/ \( -name incremental -or -name .fingerprint -or -name out \) -exec rm -rf '{}' \;
+      - run: find target/dev-release/ -not -executable -delete
+      - run: find target/dev-release/ -name 'build*script*build*' -delete
+      - run: tar -c --zstd -f coverage/profraw/binaries/${{matrix.id}}.tar.zst target/dev-release/
 
       # Upload the coverage
       - uses: actions/upload-artifact@v3
@@ -391,7 +397,7 @@ jobs:
           python-version: 3.11
           cache: pip
       - run: pip3 install --user diff-cover
-      - run: mkdir target
+      - run: for f in coverage/profraw/binaries/*.tar.zst; do tar -x --zstd -f $f; done
       - run: find coverage/profraw
       - run: for f in coverage/profraw/${{matrix.type}}/*.tar.zst; do tar -x --zstd -C target/ -f $f; done
       - run: find target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,13 @@ jobs:
       # Run the tests
       - run: just codecov "nextest-unit ${{ matrix.type }}"
       - run: mv coverage/codecov/{new,unit-${{matrix.id}}}.json
-      - run: mv coverage/profraw/{new,unit}
+      - run: ZSTD_CLEVEL=19 tar -c --zstd coverage/profraw/new/* -f coverage/profraw/unit/${{matrix.id}}.tar.zst
+      - run: rm -rf coverage/profraw/new
       - run: just codecov "nextest-integration ${{ matrix.type }}"
         if: matrix.runs_integ_tests
       - run: mv coverage/codecov/{new,integration-${{matrix.id}}}.json
         if: matrix.runs_integ_tests
-      - run: mv coverage/profraw/{new,integration}
+      - run: ZSTD_CLEVEL=19 tar -c --zstd coverage/profraw/new/* -f coverage/profraw/integration/${{matrix.id}}.tar.zst
         if: matrix.runs_integ_tests
 
       # Upload the coverage
@@ -379,6 +380,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: coverage-profraw
+          path: coverage/profraw
       - uses: taiki-e/install-action@91af8c38814c3998cb755869e5cbeffd3ab0e462
         with:
           tool: cargo-llvm-cov
@@ -387,7 +389,7 @@ jobs:
           python-version: 3.11
           cache: pip
       - run: pip3 install --user diff-cover
-      - run: mv coverage-profraw/${{matrix.type}}/*.profraw target/
+      - run: for f in coverage/profraw/${{matrix.type}}/*.tar.zst; do tar -x --zstd -C target/ -f $f; done
       - run: cargo llvm-cov show-env | grep -v RUSTFLAGS | tr -d "'" >> "$GITHUB_ENV"
       - run: mkdir -p coverage/lcov coverage/html
       - run: cargo llvm-cov report --profile dev-release --lcov --output-path coverage/lcov/${{matrix.type}}.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,13 +76,12 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: coverage-profraw
-          path: |
-            coverage/profraw
+          path: coverage/profraw
+          retention-days: 7
       - uses: actions/upload-artifact@v3
         with:
           name: coverage-codecov
-          path: |
-            coverage/codecov
+          path: coverage/codecov
 
   protobuf_backward_compat:
     name: "Protobuf Backward Compatibility"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,13 @@ jobs:
       # Run the tests
       - run: just codecov "nextest-unit ${{ matrix.type }}"
       - run: mv coverage/codecov/{new,unit-${{matrix.id}}}.json
-      - run: ZSTD_CLEVEL=19 tar -c --zstd coverage/profraw/new/* -f coverage/profraw/unit/${{matrix.id}}.tar.zst
+      - run: ZSTD_CLEVEL=19 tar -c --zstd -f coverage/profraw/unit/${{matrix.id}}.tar.zst coverage/profraw/new/*
       - run: rm -rf coverage/profraw/new
       - run: just codecov "nextest-integration ${{ matrix.type }}"
         if: matrix.runs_integ_tests
       - run: mv coverage/codecov/{new,integration-${{matrix.id}}}.json
         if: matrix.runs_integ_tests
-      - run: ZSTD_CLEVEL=19 tar -c --zstd coverage/profraw/new/* -f coverage/profraw/integration/${{matrix.id}}.tar.zst
+      - run: ZSTD_CLEVEL=19 tar -c --zstd -f coverage/profraw/integration/${{matrix.id}}.tar.zst coverage/profraw/new/*
         if: matrix.runs_integ_tests
 
       # Upload the coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,6 +390,7 @@ jobs:
           python-version: 3.11
           cache: pip
       - run: pip3 install --user diff-cover
+      - run: mkdir target
       - run: for f in coverage/profraw/${{matrix.type}}/*.tar.zst; do tar -x --zstd -C target/ -f $f; done
       - run: cargo llvm-cov show-env | grep -v RUSTFLAGS | tr -d "'" >> "$GITHUB_ENV"
       - run: mkdir -p coverage/lcov coverage/html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: coverage-codecov
-          path: coverage/cordecov
+          path: coverage/codecov
 
   py_sanity_checks:
     name: "Sanity Checks"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         with:
           name: coverage-profraw
           path: coverage/profraw
-          retention-days: 7
+          retention-days: 2
       - uses: actions/upload-artifact@v3
         with:
           name: coverage-codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,7 +404,7 @@ jobs:
       - run: cargo llvm-cov show-env | grep -v RUSTFLAGS | tr -d "'" >> "$GITHUB_ENV"
       - run: mkdir -p coverage/lcov coverage/html
       - run: cargo llvm-cov report --profile dev-release --lcov --output-path coverage/lcov/${{matrix.type}}.lcov
-      - run: cargo llvm-cov report --profile dev-release --html --hide-instantiations --output-dir coverage/html/${{matrix.type}}
+      - run: cargo llvm-cov report --profile dev-release --html --hide-instantiations --output-dir coverage/html/${{matrix.type}}-full
       - run: git fetch origin master
       - run: diff-cover --compare-branch=origin/master --html-report coverage/html/${{matrix.type}}-diff.html coverage/lcov/${{matrix.type}}.lcov
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,19 +59,26 @@ jobs:
 
       # Run the tests
       - run: just codecov "nextest-unit ${{ matrix.type }}"
-      - run: mv codecov.json unit-${{ matrix.id }}.json
+      - run: mv coverage/codecov/{new,unit-${{matrix.id}}}.json
+      - run: mv coverage/profraw/{new,unit}
       - run: just codecov "nextest-integration ${{ matrix.type }}"
         if: matrix.runs_integ_tests
-      - run: mv codecov.json integration-${{ matrix.id }}.json
+      - run: mv coverage/codecov/{new,integration-${{matrix.id}}}.json
+        if: matrix.runs_integ_tests
+      - run: mv coverage/profraw/{new,integration}
         if: matrix.runs_integ_tests
 
       # Upload the coverage
       - uses: actions/upload-artifact@v3
         with:
-          name: coverage
+          name: coverage-profraw
           path: |
-            unit-${{ matrix.id }}.json
-            integration-${{ matrix.id }}.json
+            coverage/profraw
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coverage-codecov
+          path: |
+            coverage/codecov
 
   protobuf_backward_compat:
     name: "Protobuf Backward Compatibility"
@@ -106,11 +113,11 @@ jobs:
       - run: cargo build --locked --profile dev-release -p neard --bin neard
       - run: echo "CURRENT_NEARD=$PWD/target/dev-release/neard" >> "$GITHUB_ENV"
       - run: cd pytest && python3 tests/sanity/backward_compatible.py
-      - run: cargo llvm-cov report --profile dev-release --codecov --output-path py-backward-compat.json
+      - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-backward-compat.json
       - uses: actions/upload-artifact@v3
         with:
-          name: coverage
-          path: py-backward-compat.json
+          name: coverage-codecov
+          path: coverage/codecov
 
   py_db_migration:
     name: "Database Migration"
@@ -136,11 +143,11 @@ jobs:
       - run: echo "CURRENT_NEARD=$PWD/target/dev-release/neard" >> "$GITHUB_ENV"
       - run: echo "NEAR_ROOT=$PWD" >> "$GITHUB_ENV"
       - run: cd pytest && python3 tests/sanity/db_migration.py
-      - run: cargo llvm-cov report --profile dev-release --codecov --output-path py-db-migration.json
+      - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-db-migration.json
       - uses: actions/upload-artifact@v3
         with:
-          name: coverage
-          path: py-db-migration.json
+          name: coverage-codecov
+          path: coverage/cordecov
 
   py_sanity_checks:
     name: "Sanity Checks"
@@ -174,11 +181,11 @@ jobs:
       - run: python3 pytest/tests/sanity/spin_up_cluster.py
         env:
           NEAR_ROOT: "target/dev-release"
-      - run: cargo llvm-cov report --profile dev-release --codecov --output-path py-sanity-checks.json
+      - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-sanity-checks.json
       - uses: actions/upload-artifact@v3
         with:
-          name: coverage
-          path: py-sanity-checks.json
+          name: coverage-codecov
+          path: coverage/codecov
 
   py_genesis_check:
     name: "Genesis Changes"
@@ -203,11 +210,11 @@ jobs:
       - run: cargo build --locked --profile dev-release -p neard --bin neard
       - run: echo "CURRENT_NEARD=$PWD/target/dev-release/neard" >> "$GITHUB_ENV"
       - run: python3 scripts/state/update_res.py check
-      - run: cargo llvm-cov report --profile dev-release --codecov --output-path py-genesis-check.json
+      - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-genesis-check.json
       - uses: actions/upload-artifact@v3
         with:
-          name: coverage
-          path: py-genesis-check.json
+          name: coverage-codecov
+          path: coverage/codecov
 
   py_style_check:
     name: "Style"
@@ -247,11 +254,11 @@ jobs:
       - run: cargo build --locked --profile dev-release -p neard --bin neard
       - run: echo "CURRENT_NEARD=$PWD/target/dev-release/neard" >> "$GITHUB_ENV"
       - run: cd pytest && python3 tests/sanity/upgradable.py
-      - run: cargo llvm-cov report --profile dev-release --codecov --output-path py-upgradability.json
+      - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-upgradability.json
       - uses: actions/upload-artifact@v3
         with:
-          name: coverage
-          path: py-upgradability.json
+          name: coverage-codecov
+          path: coverage/codecov
 
   rpc_error_schema:
     name: "RPC Schema"
@@ -351,6 +358,43 @@ jobs:
           tool: cargo-audit
       - run: cargo audit -D warnings
 
+  generate_coverage:
+    name: "Generate Coverage Artifact"
+    runs-on: ubuntu-latest
+    needs:
+      - cargo_nextest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - type: unit
+          - type: integration
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v3
+        with:
+          name: coverage-profraw
+      - uses: taiki-e/install-action@91af8c38814c3998cb755869e5cbeffd3ab0e462
+        with:
+          tool: cargo-llvm-cov
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+          cache: pip
+      - run: pip3 install --user diff-cover
+      - run: cargo llvm-cov show-env | grep -v RUSTFLAGS | tr -d "'" >> "$GITHUB_ENV"
+      - run: cargo llvm-cov report --profile dev-release --lcov --output-path coverage/lcov/${{matrix.type}}.lcov
+      - run: cargo llvm-cov report --profile dev-release --html --hide-instantiations --output-dir coverage/html/${{matrix.type}}
+      - run: diff-cover --html-report coverage/html/${{matrix.type}}-diff.html coverage/lcov/${{matrix.type}}.lcov
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coverage-lcov
+          path: coverage/lcov
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coverage-html
+          path: coverage/html
+
   upload_coverage:
     name: "Upload Coverage"
     runs-on: ubuntu-latest
@@ -365,7 +409,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v3
         with:
-          name: coverage
+          name: coverage-codecov
       # Keep the number of uploads here in sync with codecov.yml’s after_n_build value
       # codecov will send a comment only after having receidev this number of uploads.
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,7 +382,7 @@ jobs:
           python-version: 3.11
           cache: pip
       - run: pip3 install --user diff-cover
-      - run: mv coverage-profraw/${{matrix.type}} target/profraw
+      - run: mv coverage-profraw/${{matrix.type}}/*.profraw target/
       - run: cargo llvm-cov show-env | grep -v RUSTFLAGS | tr -d "'" >> "$GITHUB_ENV"
       - run: cargo llvm-cov report --profile dev-release --lcov --output-path coverage/lcov/${{matrix.type}}.lcov
       - run: cargo llvm-cov report --profile dev-release --html --hide-instantiations --output-dir coverage/html/${{matrix.type}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,8 +403,7 @@ jobs:
       - run: mkdir -p coverage/lcov coverage/html
       - run: cargo llvm-cov report --profile dev-release --lcov --output-path coverage/lcov/${{matrix.type}}.lcov
       - run: cargo llvm-cov report --profile dev-release --html --hide-instantiations --output-dir coverage/html/${{matrix.type}}
-      - run: git remote -v
-      - run: git fetch origin/master
+      - run: git fetch origin master
       - run: diff-cover --compare-branch=origin/master --html-report coverage/html/${{matrix.type}}-diff.html coverage/lcov/${{matrix.type}}.lcov
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,13 @@ jobs:
       - run: just codecov "nextest-unit ${{ matrix.type }}"
       - run: mv coverage/codecov/{new,unit-${{matrix.id}}}.json
       - run: mkdir -p coverage/profraw/{unit,integration}
-      - run: tar -c --zstd -f coverage/profraw/unit/${{matrix.id}}.tar.zst coverage/profraw/new/*
+      - run: cd coverage/profraw/new && tar -c --zstd -f ../unit/${{matrix.id}}.tar.zst *
       - run: rm -rf coverage/profraw/new
       - run: just codecov "nextest-integration ${{ matrix.type }}"
         if: matrix.runs_integ_tests
       - run: mv coverage/codecov/{new,integration-${{matrix.id}}}.json
         if: matrix.runs_integ_tests
-      - run: tar -c --zstd -f coverage/profraw/integration/${{matrix.id}}.tar.zst coverage/profraw/new/*
+      - run: cd coverage/profraw/new && tar -c --zstd -f ../integration/${{matrix.id}}.tar.zst *
         if: matrix.runs_integ_tests
       - run: rm -rf coverage/profraw/new
         if: matrix.runs_integ_tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,7 +393,9 @@ jobs:
           cache: pip
       - run: pip3 install --user diff-cover
       - run: mkdir target
+      - run: find coverage/profraw
       - run: for f in coverage/profraw/${{matrix.type}}/*.tar.zst; do tar -x --zstd -C target/ -f $f; done
+      - run: ls target
       - run: cargo llvm-cov show-env | grep -v RUSTFLAGS | tr -d "'" >> "$GITHUB_ENV"
       - run: mkdir -p coverage/lcov coverage/html
       - run: cargo llvm-cov report --profile dev-release --lcov --output-path coverage/lcov/${{matrix.type}}.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
       - run: echo "CURRENT_NEARD=$PWD/target/dev-release/neard" >> "$GITHUB_ENV"
       - run: echo "NEAR_ROOT=$PWD" >> "$GITHUB_ENV"
       - run: cd pytest && python3 tests/sanity/db_migration.py
+      - run: mkdir -p coverage/codecov
       - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-db-migration.json
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,7 @@ jobs:
           python-version: 3.11
           cache: pip
       - run: pip3 install --user diff-cover
+      - run: mv coverage-profraw/${{matrix.type}} target/profraw
       - run: cargo llvm-cov show-env | grep -v RUSTFLAGS | tr -d "'" >> "$GITHUB_ENV"
       - run: cargo llvm-cov report --profile dev-release --lcov --output-path coverage/lcov/${{matrix.type}}.lcov
       - run: cargo llvm-cov report --profile dev-release --html --hide-instantiations --output-dir coverage/html/${{matrix.type}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,18 +60,15 @@ jobs:
       # Run the tests:
       - run: mkdir -p coverage/profraw/{unit,integration,binaries}
       # - Run the unit tests, retrieving the coverage information
-      - run: just codecov "nextest-unit ${{ matrix.type }}"
+      - run: just codecov-ci "nextest-unit ${{ matrix.type }}"
       - run: mv coverage/codecov/{new,unit-${{matrix.id}}}.json
-      - run: cd coverage/profraw/new && tar -c --zstd -f ../unit/${{matrix.id}}.tar.zst *
-      - run: rm -rf coverage/profraw/new
+      - run: mv coverage/profraw/{new,unit/${{matrix.id}}}.tar.zst
       # - Run the integration tests, retrieving the coverage information
-      - run: just codecov "nextest-integration ${{ matrix.type }}"
+      - run: just codecov-ci "nextest-integration ${{ matrix.type }}"
         if: matrix.runs_integ_tests
       - run: mv coverage/codecov/{new,integration-${{matrix.id}}}.json
         if: matrix.runs_integ_tests
-      - run: cd coverage/profraw/new && tar -c --zstd -f ../integration/${{matrix.id}}.tar.zst *
-        if: matrix.runs_integ_tests
-      - run: rm -rf coverage/profraw/new
+      - run: mv coverage/profraw/{new,integration/${{matrix.id}}}.tar.zst
         if: matrix.runs_integ_tests
 
       # Cleanup the target directory, leaving only stuff interesting to llvm-cov, and tarball it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,18 +29,23 @@ jobs:
             os: ubuntu-22.04-16core
             type: stable
             runs_integ_tests: true
+            upload_profraws: true
           - name: Linux Nightly
             id: linux-nightly
             cache_id: linux
             os: ubuntu-22.04-16core
             type: nightly
             runs_integ_tests: true
+            upload_profraws: true
           - name: MacOS
             id: macos
             cache_id: macos
             os: macos-latest-xlarge
             type: stable
             runs_integ_tests: false
+            # TODO: Currently only computing linux coverage, because the MacOS runners
+            # have files at a different path and thus comes out duplicated.
+            upload_profraws: false
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
@@ -72,13 +77,12 @@ jobs:
         if: matrix.runs_integ_tests
 
       # Cleanup the target directory, leaving only stuff interesting to llvm-cov, and tarball it
-      - run: find target/dev-release/ \( -name incremental -or -name .fingerprint -or -name out \) -exec rm -rf '{}' \; || true
-      - run: find target/dev-release/ -not -executable -delete || true
-      - run: find target/dev-release/ -name 'build*script*build*' -delete || true
-      - run: tar -c --zstd -f coverage/profraw/binaries/${{matrix.id}}.tar.zst target/dev-release/
+      - run: just tar-bins-for-coverage-ci
+      - run: mv coverage/profraw/binaries/{new,${{matrix.id}}}.tar.zst
 
       # Upload the coverage
       - uses: actions/upload-artifact@v3
+        if: matrix.upload_profraws
         with:
           name: coverage-profraw
           path: coverage/profraw

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,6 +403,8 @@ jobs:
       - run: mkdir -p coverage/lcov coverage/html
       - run: cargo llvm-cov report --profile dev-release --lcov --output-path coverage/lcov/${{matrix.type}}.lcov
       - run: cargo llvm-cov report --profile dev-release --html --hide-instantiations --output-dir coverage/html/${{matrix.type}}
+      - run: git remote -v
+      - run: git fetch origin/master
       - run: diff-cover --compare-branch=origin/master --html-report coverage/html/${{matrix.type}}-diff.html coverage/lcov/${{matrix.type}}.lcov
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
         if: matrix.runs_integ_tests
       - run: tar -c --zstd -f coverage/profraw/integration/${{matrix.id}}.tar.zst coverage/profraw/new/*
         if: matrix.runs_integ_tests
+      - run: rm -rf coverage/profraw/new
+        if: matrix.runs_integ_tests
 
       # Upload the coverage
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,7 @@ jobs:
       - run: cargo build --locked --profile dev-release -p neard --bin neard
       - run: echo "CURRENT_NEARD=$PWD/target/dev-release/neard" >> "$GITHUB_ENV"
       - run: cd pytest && python3 tests/sanity/backward_compatible.py
+      - run: mkdir -p coverage/codecov
       - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-backward-compat.json
       - uses: actions/upload-artifact@v3
         with:
@@ -181,6 +182,7 @@ jobs:
       - run: python3 pytest/tests/sanity/spin_up_cluster.py
         env:
           NEAR_ROOT: "target/dev-release"
+      - run: mkdir -p coverage/codecov
       - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-sanity-checks.json
       - uses: actions/upload-artifact@v3
         with:
@@ -210,6 +212,7 @@ jobs:
       - run: cargo build --locked --profile dev-release -p neard --bin neard
       - run: echo "CURRENT_NEARD=$PWD/target/dev-release/neard" >> "$GITHUB_ENV"
       - run: python3 scripts/state/update_res.py check
+      - run: mkdir -p coverage/codecov
       - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-genesis-check.json
       - uses: actions/upload-artifact@v3
         with:
@@ -254,6 +257,7 @@ jobs:
       - run: cargo build --locked --profile dev-release -p neard --bin neard
       - run: echo "CURRENT_NEARD=$PWD/target/dev-release/neard" >> "$GITHUB_ENV"
       - run: cd pytest && python3 tests/sanity/upgradable.py
+      - run: mkdir -p coverage/codecov
       - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-upgradability.json
       - uses: actions/upload-artifact@v3
         with:
@@ -384,6 +388,7 @@ jobs:
       - run: pip3 install --user diff-cover
       - run: mv coverage-profraw/${{matrix.type}}/*.profraw target/
       - run: cargo llvm-cov show-env | grep -v RUSTFLAGS | tr -d "'" >> "$GITHUB_ENV"
+      - run: mkdir -p coverage/lcov coverage/html
       - run: cargo llvm-cov report --profile dev-release --lcov --output-path coverage/lcov/${{matrix.type}}.lcov
       - run: cargo llvm-cov report --profile dev-release --html --hide-instantiations --output-dir coverage/html/${{matrix.type}}
       - run: diff-cover --html-report coverage/html/${{matrix.type}}-diff.html coverage/lcov/${{matrix.type}}.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,6 +385,8 @@ jobs:
           - type: integration
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1000 # have enough history to find the merge-base between PR and master
       - uses: actions/download-artifact@v3
         with:
           name: coverage-profraw

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,7 +395,8 @@ jobs:
       - run: mkdir target
       - run: find coverage/profraw
       - run: for f in coverage/profraw/${{matrix.type}}/*.tar.zst; do tar -x --zstd -C target/ -f $f; done
-      - run: ls target
+      - run: find target
+      - run: for f in coverage/profraw/${{matrix.type}}/*.tar.zst; do tar -t --zstd -f $f; done
       - run: cargo llvm-cov show-env | grep -v RUSTFLAGS | tr -d "'" >> "$GITHUB_ENV"
       - run: mkdir -p coverage/lcov coverage/html
       - run: cargo llvm-cov report --profile dev-release --lcov --output-path coverage/lcov/${{matrix.type}}.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,7 +406,7 @@ jobs:
       - run: mkdir -p coverage/lcov coverage/html
       - run: cargo llvm-cov report --profile dev-release --lcov --output-path coverage/lcov/${{matrix.type}}.lcov
       - run: cargo llvm-cov report --profile dev-release --html --hide-instantiations --output-dir coverage/html/${{matrix.type}}
-      - run: diff-cover --html-report coverage/html/${{matrix.type}}-diff.html coverage/lcov/${{matrix.type}}.lcov
+      - run: diff-cover --compare-branch=origin/master --html-report coverage/html/${{matrix.type}}-diff.html coverage/lcov/${{matrix.type}}.lcov
       - uses: actions/upload-artifact@v3
         with:
           name: coverage-lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,13 @@ jobs:
       - run: just codecov "nextest-unit ${{ matrix.type }}"
       - run: mv coverage/codecov/{new,unit-${{matrix.id}}}.json
       - run: mkdir -p coverage/profraw/{unit,integration}
-      - run: ZSTD_CLEVEL=19 tar -c --zstd -f coverage/profraw/unit/${{matrix.id}}.tar.zst coverage/profraw/new/*
+      - run: tar -c --zstd -f coverage/profraw/unit/${{matrix.id}}.tar.zst coverage/profraw/new/*
       - run: rm -rf coverage/profraw/new
       - run: just codecov "nextest-integration ${{ matrix.type }}"
         if: matrix.runs_integ_tests
       - run: mv coverage/codecov/{new,integration-${{matrix.id}}}.json
         if: matrix.runs_integ_tests
-      - run: ZSTD_CLEVEL=19 tar -c --zstd -f coverage/profraw/integration/${{matrix.id}}.tar.zst coverage/profraw/new/*
+      - run: tar -c --zstd -f coverage/profraw/integration/${{matrix.id}}.tar.zst coverage/profraw/new/*
         if: matrix.runs_integ_tests
 
       # Upload the coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,10 +398,7 @@ jobs:
           cache: pip
       - run: pip3 install --user diff-cover
       - run: for f in coverage/profraw/binaries/*.tar.zst; do tar -x --zstd -f $f; done
-      - run: find coverage/profraw
       - run: for f in coverage/profraw/${{matrix.type}}/*.tar.zst; do tar -x --zstd -C target/ -f $f; done
-      - run: find target
-      - run: for f in coverage/profraw/${{matrix.type}}/*.tar.zst; do tar -t --zstd -f $f; done
       - run: cargo llvm-cov show-env | grep -v RUSTFLAGS | tr -d "'" >> "$GITHUB_ENV"
       - run: mkdir -p coverage/lcov coverage/html
       - run: cargo llvm-cov report --profile dev-release --lcov --output-path coverage/lcov/${{matrix.type}}.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,9 @@ jobs:
         if: matrix.runs_integ_tests
 
       # Cleanup the target directory, leaving only stuff interesting to llvm-cov, and tarball it
-      - run: find target/dev-release/ \( -name incremental -or -name .fingerprint -or -name out \) -exec rm -rf '{}' \;
-      - run: find target/dev-release/ -not -executable -delete
-      - run: find target/dev-release/ -name 'build*script*build*' -delete
+      - run: find target/dev-release/ \( -name incremental -or -name .fingerprint -or -name out \) -exec rm -rf '{}' \; || true
+      - run: find target/dev-release/ -not -executable -delete || true
+      - run: find target/dev-release/ -name 'build*script*build*' -delete || true
       - run: tar -c --zstd -f coverage/profraw/binaries/${{matrix.id}}.tar.zst target/dev-release/
 
       # Upload the coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
       # Run the tests
       - run: just codecov "nextest-unit ${{ matrix.type }}"
       - run: mv coverage/codecov/{new,unit-${{matrix.id}}}.json
+      - run: mkdir -p coverage/profraw/{unit,integration}
       - run: ZSTD_CLEVEL=19 tar -c --zstd -f coverage/profraw/unit/${{matrix.id}}.tar.zst coverage/profraw/new/*
       - run: rm -rf coverage/profraw/new
       - run: just codecov "nextest-integration ${{ matrix.type }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,7 +382,9 @@ jobs:
       matrix:
         include:
           - type: unit
+            profraws: unit
           - type: integration
+            profraws: unit integration
     steps:
       - uses: actions/checkout@v4
         with:
@@ -400,7 +402,13 @@ jobs:
           cache: pip
       - run: pip3 install --user diff-cover
       - run: for f in coverage/profraw/binaries/*.tar.zst; do tar -x --zstd -f $f; done
-      - run: for f in coverage/profraw/${{matrix.type}}/*.tar.zst; do tar -x --zstd -C target/ -f $f; done
+      - name: Retrieve the profraws used to generate this coverage (${{matrix.profraws}})
+        run: |
+          for profile in ${{matrix.profraws}}; do
+            for f in coverage/profraw/$profile/*.tar.zst; do
+              tar -x --zstd -C target/ -f $f
+            done
+          done
       - run: cargo llvm-cov show-env | grep -v RUSTFLAGS | tr -d "'" >> "$GITHUB_ENV"
       - run: mkdir -p coverage/lcov coverage/html
       - run: cargo llvm-cov report --profile dev-release --lcov --output-path coverage/lcov/${{matrix.type}}.lcov

--- a/Justfile
+++ b/Justfile
@@ -92,13 +92,13 @@ codecov RULE:
     # Note: macos seems to not support `source <()` as a way to set environment variables, but
     # this variant seems to work on both linux and macos.
     # TODO: remove the RUSTFLAGS hack, see also https://github.com/rust-lang/cargo/issues/13040
-    cargo llvm-cov show-env --export-prefix | grep -v RUSTFLAGS= | grep -v LLVM_PROFILE_FILE= > env
+    cargo llvm-cov show-env --export-prefix | grep -v RUSTFLAGS= > env
     source ./env
     export RUSTC_WORKSPACE_WRAPPER="{{ absolute_path("scripts/rustc-coverage-wrapper.sh") }}"
-    export LLVM_PROFILE_FILE="{{ absolute_path("target/profraw") }}"
     {{ just_executable() }} {{ RULE }}
     cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/new.json
-    mv target/profraw coverage/profraw/new
+    mkdir coverage/profraw/new
+    mv target/*.profraw coverage/profraw/new
 
 # style checks from python scripts
 python-style-checks:

--- a/Justfile
+++ b/Justfile
@@ -109,6 +109,14 @@ codecov-ci RULE:
     popd
     rm -rf target/*.profraw
 
+# generate a tarball with all the binaries for coverage CI
+tar-bins-for-coverage-ci:
+    #!/usr/bin/env bash
+    find target/dev-release/ \( -name incremental -or -name .fingerprint -or -name out \) -exec rm -rf '{}' \; || true
+    find target/dev-release/ -not -executable -delete || true
+    find target/dev-release/ -name 'build*script*build*' -delete || true
+    tar -c --zstd -f coverage/profraw/binaries/new.tar.zst target/dev-release/
+
 # style checks from python scripts
 python-style-checks:
     python3 scripts/check_nightly.py

--- a/Justfile
+++ b/Justfile
@@ -96,6 +96,7 @@ codecov RULE:
     source ./env
     export RUSTC_WORKSPACE_WRAPPER="{{ absolute_path("scripts/rustc-coverage-wrapper.sh") }}"
     {{ just_executable() }} {{ RULE }}
+    mkdir -p coverage/codecov
     cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/new.json
     mkdir coverage/profraw/new
     mv target/*.profraw coverage/profraw/new

--- a/Justfile
+++ b/Justfile
@@ -98,8 +98,16 @@ codecov RULE:
     {{ just_executable() }} {{ RULE }}
     mkdir -p coverage/codecov
     cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/new.json
-    mkdir -p coverage/profraw/new
-    mv target/*.profraw coverage/profraw/new
+
+# generate a codecov report for RULE, CI version
+codecov-ci RULE:
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    {{ just_executable() }} codecov "{{ RULE }}"
+    pushd target
+    tar -c --zstd -f ../coverage/profraw/new.tar.zst *.profraw
+    popd
+    rm -rf target/*.profraw
 
 # style checks from python scripts
 python-style-checks:

--- a/Justfile
+++ b/Justfile
@@ -98,7 +98,7 @@ codecov RULE:
     {{ just_executable() }} {{ RULE }}
     mkdir -p coverage/codecov
     cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/new.json
-    mkdir coverage/profraw/new
+    mkdir -p coverage/profraw/new
     mv target/*.profraw coverage/profraw/new
 
 # style checks from python scripts

--- a/Justfile
+++ b/Justfile
@@ -92,13 +92,12 @@ codecov RULE:
     # Note: macos seems to not support `source <()` as a way to set environment variables, but
     # this variant seems to work on both linux and macos.
     # TODO: remove the RUSTFLAGS hack, see also https://github.com/rust-lang/cargo/issues/13040
-    cargo llvm-cov show-env --export-prefix | grep -v RUSTFLAGS > env
+    cargo llvm-cov show-env --export-prefix | grep -v RUSTFLAGS= | grep -v LLVM_PROFILE_FILE= > env
     source ./env
     export RUSTC_WORKSPACE_WRAPPER="{{ absolute_path("scripts/rustc-coverage-wrapper.sh") }}"
+    export LLVM_PROFILE_FILE="{{ absolute_path("coverage/profraw/new") }}"
     {{ just_executable() }} {{ RULE }}
-    cargo llvm-cov report --profile dev-release --codecov --output-path codecov.json
-    # See https://github.com/taiki-e/cargo-llvm-cov/issues/292
-    find target -name '*.profraw' -delete
+    cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/new.json
 
 # style checks from python scripts
 python-style-checks:

--- a/Justfile
+++ b/Justfile
@@ -95,9 +95,10 @@ codecov RULE:
     cargo llvm-cov show-env --export-prefix | grep -v RUSTFLAGS= | grep -v LLVM_PROFILE_FILE= > env
     source ./env
     export RUSTC_WORKSPACE_WRAPPER="{{ absolute_path("scripts/rustc-coverage-wrapper.sh") }}"
-    export LLVM_PROFILE_FILE="{{ absolute_path("coverage/profraw/new") }}"
+    export LLVM_PROFILE_FILE="{{ absolute_path("target/profraw") }}"
     {{ just_executable() }} {{ RULE }}
     cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/new.json
+    mv target/profraw coverage/profraw/new
 
 # style checks from python scripts
 python-style-checks:


### PR DESCRIPTION
This adds a `coverage-html` as well as a `coverage-lcov` artifact. They can be used for easier access to the coverage data than codecov.

In particular:
- `coverage-lcov` can be loaded into vscode with eg. [the coverage gutters extensions](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters), allowing for easily looking into which code is currently not covered by unit/integration tests
- `coverage-html` contains:
  - One `unit` and one `integration` folder, respectively showing the full coverage report for just unit tests and for integration tests
  - One `unit-diff.html` and one `integration-diff.html` file, respectively showing how well-covered the diff is under just the unit tests and under integration tests