### PR TITLE
[stateless_validation][fix] Hack sending state witness for chunk after genesis

### DIFF
--- a/core/primitives/src/chunk_validation.rs
+++ b/core/primitives/src/chunk_validation.rs
@@ -118,9 +118,27 @@ impl ChunkStateWitnessInner {
     }
 }
 
+impl ChunkStateWitness {
+    // TODO(#10502): To be used only for creating state witness when previous chunk is genesis.
+    // Clean this up once we can properly handle creating state witness for genesis chunk.
+    pub fn empty(chunk_header: ShardChunkHeader) -> Self {
+        let inner = ChunkStateWitnessInner::new(
+            chunk_header,
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        );
+        ChunkStateWitness { inner, signature: Signature::default() }
+    }
+}
+
 /// Represents the base state and the expected post-state-root of a chunk's state
 /// transition. The actual state transition itself is not included here.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ChunkStateTransition {
     /// The block that contains the chunk; this identifies which part of the
     /// state transition we're talking about.


### PR DESCRIPTION
This is mainly to solve issues related to testing where we were initially not getting the chunk endorsements.

I've created an issue for this here: https://github.com/near/nearcore/issues/10502

Fixes issue in PR https://github.com/near/nearcore/pull/10487