### PR TITLE
[stateless_validation] Add testing for handling state witness and chunk endorsements

### DIFF
--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -19,6 +19,7 @@ use near_o11y::testonly::TracingCapture;
 use near_parameters::RuntimeConfig;
 use near_primitives::action::delegate::{DelegateAction, NonDelegateAction, SignedDelegateAction};
 use near_primitives::block::Block;
+use near_primitives::chunk_validation::ChunkStateWitness;
 use near_primitives::epoch_manager::RngSeed;
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
@@ -26,7 +27,7 @@ use near_primitives::network::PeerId;
 use near_primitives::sharding::{ChunkHash, PartialEncodedChunk};
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::transaction::{Action, FunctionCallAction, SignedTransaction};
-use near_primitives::types::{AccountId, Balance, BlockHeight, EpochId, NumSeats, ShardId};
+use near_primitives::types::{AccountId, Balance, BlockHeight, EpochId, NumSeats};
 use near_primitives::utils::MaybeValidated;
 use near_primitives::version::ProtocolVersion;
 use near_primitives::views::{
@@ -38,7 +39,7 @@ use super::setup::{setup_client_with_runtime, ShardsManagerAdapterForTest};
 use super::test_env_builder::TestEnvBuilder;
 use super::TEST_SEED;
 
-const CHUNK_ENDORSEMENTS_TIMEOUT: Duration = Duration::from_secs(60);
+const CHUNK_ENDORSEMENTS_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// An environment for writing integration tests with multiple clients.
 /// This environment can simulate near nodes without network and it can be configured to use different runtimes.
@@ -62,6 +63,9 @@ pub struct StateWitnessPropagationOutput {
     /// Whether some propagated state witness includes two different post state
     /// roots.
     pub found_differing_post_state_root_due_to_state_transitions: bool,
+
+    /// All the account_ids that we've sent the chunk witness to.
+    pub chunk_hash_to_account_ids: HashMap<ChunkHash, HashSet<AccountId>>,
 }
 
 impl TestEnv {
@@ -270,87 +274,92 @@ impl TestEnv {
         }
     }
 
-    /// Triggers processing of all chunk state witnesses received by network.
-    pub fn propagate_chunk_state_witnesses(&mut self) -> StateWitnessPropagationOutput {
-        let mut found_differing_post_state_root_due_to_state_transitions = false;
-        for idx in 0..self.clients.len() {
-            let _span =
-                tracing::debug_span!(target: "test", "propagate_chunk_state_witnesses", client=idx)
-                    .entered();
-
-            self.network_adapters[idx].handle_filtered(|msg| {
-                if let PeerManagerMessageRequest::NetworkRequests(
-                    NetworkRequests::ChunkStateWitness(accounts, chunk_state_witness),
-                ) = msg
-                {
-                    let chunk_state_witness_inner = &chunk_state_witness.inner;
-                    let mut post_state_roots = HashSet::from([chunk_state_witness_inner
-                        .main_state_transition
-                        .post_state_root]);
-                    post_state_roots.extend(
-                        chunk_state_witness_inner
-                            .implicit_transitions
-                            .iter()
-                            .map(|t| t.post_state_root),
-                    );
-                    found_differing_post_state_root_due_to_state_transitions |=
-                        post_state_roots.len() >= 2;
-                    for account in accounts {
-                        let sender_public_key = self.clients[idx]
-                            .validator_signer
-                            .as_ref()
-                            .unwrap()
-                            .public_key()
-                            .clone();
-                        self.account_indices
-                            .lookup_mut(&mut self.clients, &account)
-                            .process_chunk_state_witness(
-                                chunk_state_witness.clone(),
-                                PeerId::new(sender_public_key),
-                            )
-                            .unwrap();
-                    }
-                    None
-                } else {
-                    Some(msg)
-                }
-            });
-        }
-        StateWitnessPropagationOutput { found_differing_post_state_root_due_to_state_transitions }
+    fn found_differing_post_state_root_due_to_state_transitions(
+        chunk_state_witness: &ChunkStateWitness,
+    ) -> bool {
+        let chunk_state_witness_inner = &chunk_state_witness.inner;
+        let mut post_state_roots =
+            HashSet::from([chunk_state_witness_inner.main_state_transition.post_state_root]);
+        post_state_roots.extend(
+            chunk_state_witness_inner.implicit_transitions.iter().map(|t| t.post_state_root),
+        );
+        post_state_roots.len() >= 2
     }
 
-    /// Waits for `CHUNK_ENDORSEMENTS_TIMEOUT` to receive at least one chunk
-    /// endorsement for the given chunk hashes.
+    /// Triggers processing of all chunk state witnesses received by network.
+    pub fn propagate_chunk_state_witnesses(&mut self) -> StateWitnessPropagationOutput {
+        let mut output = StateWitnessPropagationOutput {
+            found_differing_post_state_root_due_to_state_transitions: false,
+            chunk_hash_to_account_ids: HashMap::new(),
+        };
+        let network_adapters = self.network_adapters.clone();
+        for network_adapter in network_adapters {
+            network_adapter.handle_filtered(|request| match request {
+                PeerManagerMessageRequest::NetworkRequests(NetworkRequests::ChunkStateWitness(
+                    account_ids,
+                    state_witness,
+                )) => {
+                    // Process chunk state witness for each client.
+                    for account_id in account_ids.iter() {
+                        self.client(account_id)
+                            .process_chunk_state_witness(state_witness.clone(), PeerId::random())
+                            .unwrap();
+                    }
+
+                    // Update output.
+                    output.found_differing_post_state_root_due_to_state_transitions |=
+                        Self::found_differing_post_state_root_due_to_state_transitions(
+                            &state_witness,
+                        );
+
+                    output.chunk_hash_to_account_ids.insert(
+                        state_witness.inner.chunk_header.chunk_hash(),
+                        account_ids.into_iter().collect(),
+                    );
+                    None
+                }
+                _ => Some(request),
+            });
+        }
+        output
+    }
+
+    /// Waits for `CHUNK_ENDORSEMENTS_TIMEOUT` to receive chunk endorsement for the given chunk hashes.
     /// Panics if it doesn't happen.
-    /// `chunk_hashes` maps hashes to pair of height at which chunk is included
-    /// and shard id for better debugging.
-    pub fn wait_for_chunk_endorsements(
+    /// `chunk_hash_to_account_ids` maps hashes to the set of account ids that are expected to endorse the chunk.
+    /// Note that we need to wait here as the chunk state witness is processed asynchronously.
+    pub fn wait_to_propagate_chunk_endorsements(
         &mut self,
-        mut chunk_hashes: HashMap<ChunkHash, (BlockHeight, ShardId)>,
+        chunk_hash_to_account_ids: &mut HashMap<ChunkHash, HashSet<AccountId>>,
     ) {
-        let _span = tracing::debug_span!(target: "test", "get_all_chunk_endorsements").entered();
+        let network_adapters = self.network_adapters.clone();
         let timer = Instant::now();
         loop {
-            tracing::debug!(target: "test", "remaining endorsements: {:?}", chunk_hashes);
-            for idx in 0..self.clients.len() {
-                self.network_adapters[idx].handle_filtered(|msg| {
-                    if let PeerManagerMessageRequest::NetworkRequests(
-                        NetworkRequests::ChunkEndorsement(_, endorsement),
-                    ) = msg
-                    {
-                        chunk_hashes.remove(endorsement.chunk_hash());
+            for network_adapter in network_adapters.iter() {
+                network_adapter.handle_filtered(|request| match request {
+                    PeerManagerMessageRequest::NetworkRequests(
+                        NetworkRequests::ChunkEndorsement(account_id, endorsement),
+                    ) => {
+                        // Remove endorsement.account_id on receiving endorsement.
+                        chunk_hash_to_account_ids
+                            .get_mut(endorsement.chunk_hash())
+                            .map(|entry| entry.remove(&endorsement.account_id));
+
+                        self.client(&account_id).process_chunk_endorsement(endorsement).unwrap();
+
                         None
-                    } else {
-                        Some(msg)
                     }
+                    _ => Some(request),
                 });
             }
 
-            if chunk_hashes.is_empty() {
-                break;
+            // Check if we received all endorsements.
+            chunk_hash_to_account_ids.retain(|_, v| !v.is_empty());
+            if chunk_hash_to_account_ids.is_empty() {
+                return;
             }
             if timer.elapsed() > CHUNK_ENDORSEMENTS_TIMEOUT {
-                panic!("Missing chunk endorsements: {:?}", chunk_hashes);
+                panic!("Missing chunk endorsements: {:?}", chunk_hash_to_account_ids);
             }
             std::thread::sleep(Duration::from_micros(100));
         }

--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -330,12 +330,12 @@ impl TestEnv {
     /// Note that we need to wait here as the chunk state witness is processed asynchronously.
     pub fn wait_to_propagate_chunk_endorsements(
         &mut self,
-        chunk_hash_to_account_ids: &mut HashMap<ChunkHash, HashSet<AccountId>>,
+        mut chunk_hash_to_account_ids: HashMap<ChunkHash, HashSet<AccountId>>,
     ) {
         let network_adapters = self.network_adapters.clone();
         let timer = Instant::now();
         loop {
-            for network_adapter in network_adapters.iter() {
+            for network_adapter in &network_adapters {
                 network_adapter.handle_filtered(|request| match request {
                     PeerManagerMessageRequest::NetworkRequests(
                         NetworkRequests::ChunkEndorsement(account_id, endorsement),

--- a/integration-tests/src/tests/client/features/chunk_validation.rs
+++ b/integration-tests/src/tests/client/features/chunk_validation.rs
@@ -1,3 +1,7 @@
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use std::collections::HashSet;
+
 use near_chain::{ChainGenesis, Provenance};
 use near_chain_configs::{Genesis, GenesisConfig, GenesisRecords};
 use near_client::test_utils::TestEnv;
@@ -18,9 +22,6 @@ use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::{AccountId, NumSeats};
 use near_primitives_core::version::PROTOCOL_VERSION;
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
-use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
-use std::collections::{HashMap, HashSet};
 
 const ONE_NEAR: u128 = 1_000_000_000_000_000_000_000_000;
 
@@ -126,7 +127,6 @@ fn run_chunk_validation_test(seed: u64, prob_missing_chunk: f64) {
     let mut tx_hashes = vec![];
 
     let mut rng: StdRng = SeedableRng::seed_from_u64(seed);
-    let mut expected_chunks = HashMap::new();
     let mut found_differing_post_state_root_due_to_state_transitions = false;
     for round in 0..blocks_to_produce {
         let heads = env
@@ -185,9 +185,15 @@ fn run_chunk_validation_test(seed: u64, prob_missing_chunk: f64) {
         for j in 0..env.clients.len() {
             env.process_shards_manager_responses_and_finish_processing_blocks(j);
         }
-        let result = env.propagate_chunk_state_witnesses();
+
+        // First propagate chunk state witnesses, then chunk endorsements.
+        // Note that validation of chunk state witness is done asynchonously
+        // which is why it's important to pass the expected set of chunk endorsements to wait for.
+        let mut output = env.propagate_chunk_state_witnesses();
+        env.wait_to_propagate_chunk_endorsements(&mut output.chunk_hash_to_account_ids);
+
         found_differing_post_state_root_due_to_state_transitions |=
-            result.found_differing_post_state_root_due_to_state_transitions;
+            output.found_differing_post_state_root_due_to_state_transitions;
     }
 
     // Check that at least one tx was fully executed, ensuring that executing
@@ -211,32 +217,6 @@ fn run_chunk_validation_test(seed: u64, prob_missing_chunk: f64) {
     if prob_missing_chunk >= 0.8 {
         assert!(found_differing_post_state_root_due_to_state_transitions);
     }
-
-    // Collect chunk hashes which have to be endorsed and check that it indeed
-    // happens.
-    let mut block = env.clients[0]
-        .chain
-        .get_block(&env.clients[0].chain.head().unwrap().last_block_hash)
-        .unwrap();
-    loop {
-        let prev_hash = *block.header().prev_hash();
-        if prev_hash == CryptoHash::default() {
-            break;
-        }
-        let prev_block = env.clients[0].chain.get_block(&prev_hash).unwrap();
-        for (chunk, prev_chunk) in block.chunks().iter().zip(prev_block.chunks().iter()) {
-            if chunk.is_new_chunk(block.header().height()) {
-                // First chunk after genesis doesn't have to be endorsed.
-                if prev_chunk.prev_block_hash() != &CryptoHash::default() {
-                    expected_chunks
-                        .insert(chunk.chunk_hash(), (block.header().height(), chunk.shard_id()));
-                }
-            }
-        }
-        block = prev_block;
-    }
-
-    env.wait_for_chunk_endorsements(expected_chunks);
 }
 
 #[test]

--- a/integration-tests/src/tests/client/features/chunk_validation.rs
+++ b/integration-tests/src/tests/client/features/chunk_validation.rs
@@ -189,8 +189,8 @@ fn run_chunk_validation_test(seed: u64, prob_missing_chunk: f64) {
         // First propagate chunk state witnesses, then chunk endorsements.
         // Note that validation of chunk state witness is done asynchonously
         // which is why it's important to pass the expected set of chunk endorsements to wait for.
-        let mut output = env.propagate_chunk_state_witnesses();
-        env.wait_to_propagate_chunk_endorsements(&mut output.chunk_hash_to_account_ids);
+        let output = env.propagate_chunk_state_witnesses();
+        env.wait_to_propagate_chunk_endorsements(output.chunk_hash_to_account_ids);
 
         found_differing_post_state_root_due_to_state_transitions |=
             output.found_differing_post_state_root_due_to_state_transitions;


### PR DESCRIPTION
This PR improves the testing infrastructure for stateless validation to handle cases of network message propagation of `ChunkStateWitness` and `ChunkEndorsement`.

With the changes in validation of signature in chunk header, we need to handle `ChunkEndorsement` messages at the time of block production.