### PR TITLE
refactor: improve runtime `prepare_transactions` api

### DIFF
--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -1,7 +1,8 @@
 use super::ValidatorSchedule;
 use crate::types::{
     ApplyChunkBlockContext, ApplyChunkResult, ApplyChunkShardContext, ApplyResultForResharding,
-    PreparedTransactions, RuntimeAdapter, RuntimeStorageConfig,
+    PrepareTransactionsBlockContext, PrepareTransactionsChunkContext, PreparedTransactions,
+    RuntimeAdapter, RuntimeStorageConfig,
 };
 use crate::BlockHeader;
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -34,7 +35,7 @@ use near_primitives::transaction::{
 };
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
-    AccountId, ApprovalStake, Balance, BlockHeight, EpochHeight, EpochId, Gas, Nonce, NumShards,
+    AccountId, ApprovalStake, Balance, BlockHeight, EpochHeight, EpochId, Nonce, NumShards,
     ShardId, StateChangesForResharding, StateRoot, StateRootNode, ValidatorInfoIdentifier,
 };
 use near_primitives::version::{ProtocolVersion, PROTOCOL_VERSION};
@@ -1045,15 +1046,11 @@ impl RuntimeAdapter for KeyValueRuntime {
 
     fn prepare_transactions(
         &self,
-        _gas_price: Balance,
-        _gas_limit: Gas,
-        _epoch_id: &EpochId,
-        _shard_id: ShardId,
-        _storage_config: RuntimeStorageConfig,
-        _next_block_height: BlockHeight,
+        _storage: RuntimeStorageConfig,
+        _chunk: PrepareTransactionsChunkContext,
+        _prev_block: PrepareTransactionsBlockContext,
         transaction_groups: &mut dyn TransactionGroupIterator,
         _chain_validate: &mut dyn FnMut(&SignedTransaction) -> bool,
-        _current_protocol_version: ProtocolVersion,
         _time_limit: Option<Duration>,
     ) -> Result<PreparedTransactions, Error> {
         let mut res = vec![];

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -335,6 +335,27 @@ pub enum PrepareTransactionsLimit {
     ReceiptCount,
 }
 
+pub struct PrepareTransactionsBlockContext {
+    pub next_gas_price: Balance,
+    pub height: BlockHeight,
+    pub block_hash: CryptoHash,
+}
+
+impl PrepareTransactionsBlockContext {
+    pub fn from_header(header: &BlockHeader) -> Self {
+        Self {
+            next_gas_price: header.next_gas_price(),
+            height: header.height(),
+            block_hash: *header.hash(),
+        }
+    }
+}
+
+pub struct PrepareTransactionsChunkContext {
+    pub shard_id: ShardId,
+    pub gas_limit: Gas,
+}
+
 /// Bridge between the chain and the runtime.
 /// Main function is to update state given transactions.
 /// Additionally handles validators.
@@ -392,15 +413,11 @@ pub trait RuntimeAdapter: Send + Sync {
     /// `RuntimeError::StorageError`.
     fn prepare_transactions(
         &self,
-        gas_price: Balance,
-        gas_limit: Gas,
-        epoch_id: &EpochId,
-        shard_id: ShardId,
         storage: RuntimeStorageConfig,
-        next_block_height: BlockHeight,
+        chunk: PrepareTransactionsChunkContext,
+        prev_block: PrepareTransactionsBlockContext,
         transaction_groups: &mut dyn TransactionGroupIterator,
         chain_validate: &mut dyn FnMut(&SignedTransaction) -> bool,
-        current_protocol_version: ProtocolVersion,
         time_limit: Option<Duration>,
     ) -> Result<PreparedTransactions, Error>;
 

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -8,6 +8,7 @@ use near_chain_configs::MutableConfigValue;
 use near_chain_configs::ReshardingConfig;
 use near_pool::types::TransactionGroupIterator;
 use near_primitives::sandbox::state_patch::SandboxStatePatch;
+use near_primitives::sharding::ShardChunkHeader;
 use near_store::flat::FlatStorageManager;
 use near_store::StorageError;
 use num_rational::Rational32;
@@ -341,8 +342,8 @@ pub struct PrepareTransactionsBlockContext {
     pub block_hash: CryptoHash,
 }
 
-impl PrepareTransactionsBlockContext {
-    pub fn from_header(header: &BlockHeader) -> Self {
+impl From<&BlockHeader> for PrepareTransactionsBlockContext {
+    fn from(header: &BlockHeader) -> Self {
         Self {
             next_gas_price: header.next_gas_price(),
             height: header.height(),
@@ -350,10 +351,15 @@ impl PrepareTransactionsBlockContext {
         }
     }
 }
-
 pub struct PrepareTransactionsChunkContext {
     pub shard_id: ShardId,
     pub gas_limit: Gas,
+}
+
+impl From<&ShardChunkHeader> for PrepareTransactionsChunkContext {
+    fn from(header: &ShardChunkHeader) -> Self {
+        Self { shard_id: header.shard_id(), gas_limit: header.gas_limit() }
+    }
 }
 
 /// Bridge between the chain and the runtime.

--- a/chain/client/src/chunk_validation.rs
+++ b/chain/client/src/chunk_validation.rs
@@ -6,9 +6,8 @@ use near_chain::chain::{
 };
 use near_chain::sharding::shuffle_receipt_proofs;
 use near_chain::types::{
-    ApplyChunkBlockContext, ApplyChunkResult, PrepareTransactionsBlockContext,
-    PrepareTransactionsChunkContext, PreparedTransactions, RuntimeAdapter, RuntimeStorageConfig,
-    StorageDataSource,
+    ApplyChunkBlockContext, ApplyChunkResult, PreparedTransactions, RuntimeAdapter,
+    RuntimeStorageConfig, StorageDataSource,
 };
 use near_chain::validate::validate_chunk_with_chunk_extra_and_receipts_root;
 use near_chain::{Block, BlockHeader, Chain, ChainStoreAccess};
@@ -231,11 +230,8 @@ fn validate_prepared_transactions(
 
     runtime_adapter.prepare_transactions(
         storage_config,
-        PrepareTransactionsChunkContext {
-            shard_id: chunk_header.shard_id(),
-            gas_limit: chunk_header.gas_limit(),
-        },
-        PrepareTransactionsBlockContext::from_header(&parent_block_header),
+        chunk_header.into(),
+        (&parent_block_header).into(),
         &mut TransactionGroupIteratorWrapper::new(transactions),
         &mut |tx: &SignedTransaction| -> bool {
             store

--- a/chain/client/src/chunk_validation.rs
+++ b/chain/client/src/chunk_validation.rs
@@ -6,8 +6,9 @@ use near_chain::chain::{
 };
 use near_chain::sharding::shuffle_receipt_proofs;
 use near_chain::types::{
-    ApplyChunkBlockContext, ApplyChunkResult, PreparedTransactions, RuntimeAdapter,
-    RuntimeStorageConfig, StorageDataSource,
+    ApplyChunkBlockContext, ApplyChunkResult, PrepareTransactionsBlockContext,
+    PrepareTransactionsChunkContext, PreparedTransactions, RuntimeAdapter, RuntimeStorageConfig,
+    StorageDataSource,
 };
 use near_chain::validate::validate_chunk_with_chunk_extra_and_receipts_root;
 use near_chain::{Block, BlockHeader, Chain, ChainStoreAccess};
@@ -220,35 +221,31 @@ impl ChunkValidator {
 /// Uses `storage_config` to possibly record reads or use recorded storage.
 fn validate_prepared_transactions(
     chain: &Chain,
-    epoch_manager: &dyn EpochManagerAdapter,
     runtime_adapter: &dyn RuntimeAdapter,
     chunk_header: &ShardChunkHeader,
     storage_config: RuntimeStorageConfig,
     transactions: &[SignedTransaction],
 ) -> Result<PreparedTransactions, Error> {
     let store = chain.chain_store();
-    let epoch_id = epoch_manager.get_epoch_id_from_prev_block(chunk_header.prev_block_hash())?;
-    let parent_block = store.get_block(chunk_header.prev_block_hash())?;
-    let parent_block_header = parent_block.header();
+    let parent_block_header = store.get_block_header(chunk_header.prev_block_hash())?;
 
     runtime_adapter.prepare_transactions(
-        parent_block_header.next_gas_price(),
-        chunk_header.gas_limit(),
-        &epoch_id,
-        chunk_header.shard_id(),
         storage_config,
-        parent_block_header.height() + 1,
+        PrepareTransactionsChunkContext {
+            shard_id: chunk_header.shard_id(),
+            gas_limit: chunk_header.gas_limit(),
+        },
+        PrepareTransactionsBlockContext::from_header(&parent_block_header),
         &mut TransactionGroupIteratorWrapper::new(transactions),
         &mut |tx: &SignedTransaction| -> bool {
             store
                 .check_transaction_validity_period(
-                    parent_block_header,
+                    &parent_block_header,
                     &tx.transaction.block_hash,
                     chain.transaction_validity_period,
                 )
                 .is_ok()
         },
-        epoch_manager.get_epoch_protocol_version(&epoch_id)?,
         None,
     )
 }
@@ -341,7 +338,6 @@ fn pre_validate_chunk_state_witness(
 
         match validate_prepared_transactions(
             chain,
-            epoch_manager,
             runtime_adapter,
             &state_witness.chunk_header,
             transactions_validation_storage_config,
@@ -856,7 +852,6 @@ impl Client {
         // Normally it is provided by chunk producer, but for shadow validation we need to generate it ourselves.
         let Ok(validated_transactions) = validate_prepared_transactions(
             &self.chain,
-            self.epoch_manager.as_ref(),
             self.runtime_adapter.as_ref(),
             &chunk_header,
             transactions_validation_storage_config,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -29,7 +29,6 @@ use near_chain::orphan::OrphanMissingChunks;
 use near_chain::resharding::ReshardingRequest;
 use near_chain::state_snapshot_actor::SnapshotCallbacks;
 use near_chain::test_utils::format_hash;
-use near_chain::types::PrepareTransactionsBlockContext;
 use near_chain::types::PrepareTransactionsChunkContext;
 use near_chain::types::{
     ChainConfig, LatestKnown, PreparedTransactions, RuntimeAdapter, RuntimeStorageConfig,
@@ -75,8 +74,7 @@ use near_primitives::sharding::{
 };
 use near_primitives::static_clock::StaticClock;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::Gas;
-use near_primitives::types::StateRoot;
+use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{AccountId, ApprovalStake, BlockHeight, EpochId, NumBlocks, ShardId};
 use near_primitives::unwrap_or_return;
 use near_primitives::utils::MaybeValidated;
@@ -823,12 +821,8 @@ impl Client {
             .map_err(|err| Error::ChunkProducer(format!("No chunk extra available: {}", err)))?;
 
         let prev_block_header = self.chain.get_block_header(&prev_block_hash)?;
-        let prepared_transactions = self.prepare_transactions(
-            shard_uid,
-            chunk_extra.gas_limit(),
-            *chunk_extra.state_root(),
-            &prev_block_header,
-        )?;
+        let prepared_transactions =
+            self.prepare_transactions(shard_uid, chunk_extra.as_ref(), &prev_block_header)?;
         #[cfg(feature = "test_features")]
         let prepared_transactions = PreparedTransactions {
             transactions: Self::maybe_insert_invalid_transaction(
@@ -949,8 +943,7 @@ impl Client {
     fn prepare_transactions(
         &mut self,
         shard_uid: ShardUId,
-        gas_limit: Gas,
-        state_root: StateRoot,
+        chunk_extra: &ChunkExtra,
         prev_block_header: &BlockHeader,
     ) -> Result<PreparedTransactions, Error> {
         let Self { chain, sharded_tx_pool, runtime_adapter: runtime, .. } = self;
@@ -967,7 +960,7 @@ impl Client {
             let record_storage = chain
                 .should_produce_state_witness_for_this_or_next_epoch(&me, prev_block_header)?;
             let storage_config = RuntimeStorageConfig {
-                state_root,
+                state_root: *chunk_extra.state_root(),
                 use_flat_storage: true,
                 source: StorageDataSource::Db,
                 state_patch: Default::default(),
@@ -975,8 +968,8 @@ impl Client {
             };
             runtime.prepare_transactions(
                 storage_config,
-                PrepareTransactionsChunkContext { shard_id, gas_limit },
-                PrepareTransactionsBlockContext::from_header(prev_block_header),
+                PrepareTransactionsChunkContext { shard_id, gas_limit: chunk_extra.gas_limit() },
+                prev_block_header.into(),
                 &mut iter,
                 &mut |tx: &SignedTransaction| -> bool {
                     chain

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -720,8 +720,8 @@ impl RuntimeAdapter for NightshadeRuntime {
         let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(&prev_block.block_hash)?;
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
         let shard_uid = self.get_shard_uid_from_epoch_id(shard_id, &epoch_id)?;
-        // while the height of the next block that includes the chunk might not be prev_height + 1,
-        // passing it will result in a more conservative check and will not accidentally allow
+        // While the height of the next block that includes the chunk might not be prev_height + 1,
+        // using it will result in a more conservative check and will not accidentally allow
         // invalid transactions to be included.
         let next_block_height = prev_block.height + 1;
 

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -6,8 +6,8 @@ use borsh::BorshDeserialize;
 use errors::FromStateViewerErrors;
 use near_chain::types::{
     ApplyChunkBlockContext, ApplyChunkResult, ApplyChunkShardContext, ApplyResultForResharding,
-    PrepareTransactionsLimit, PreparedTransactions, RuntimeAdapter, RuntimeStorageConfig,
-    StorageDataSource, Tip,
+    PrepareTransactionsBlockContext, PrepareTransactionsChunkContext, PrepareTransactionsLimit,
+    PreparedTransactions, RuntimeAdapter, RuntimeStorageConfig, StorageDataSource, Tip,
 };
 use near_chain::Error;
 use near_chain_configs::{
@@ -708,19 +708,22 @@ impl RuntimeAdapter for NightshadeRuntime {
 
     fn prepare_transactions(
         &self,
-        gas_price: Balance,
-        gas_limit: Gas,
-        epoch_id: &EpochId,
-        shard_id: ShardId,
         storage_config: RuntimeStorageConfig,
-        next_block_height: BlockHeight,
+        chunk: PrepareTransactionsChunkContext,
+        prev_block: PrepareTransactionsBlockContext,
         transaction_groups: &mut dyn TransactionGroupIterator,
         chain_validate: &mut dyn FnMut(&SignedTransaction) -> bool,
-        current_protocol_version: ProtocolVersion,
         time_limit: Option<Duration>,
     ) -> Result<PreparedTransactions, Error> {
         let start_time = std::time::Instant::now();
-        let shard_uid = self.get_shard_uid_from_epoch_id(shard_id, epoch_id)?;
+        let PrepareTransactionsChunkContext { shard_id, gas_limit } = chunk;
+        let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(&prev_block.block_hash)?;
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
+        let shard_uid = self.get_shard_uid_from_epoch_id(shard_id, &epoch_id)?;
+        // while the height of the next block that includes the chunk might not be prev_height + 1,
+        // passing it will result in a more conservative check and will not accidentally allow
+        // invalid transactions to be included.
+        let next_block_height = prev_block.height + 1;
 
         let mut trie = match storage_config.source {
             StorageDataSource::Db => {
@@ -749,7 +752,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         };
         let mut num_checked_transactions = 0;
 
-        let runtime_config = self.runtime_config_store.get_config(current_protocol_version);
+        let runtime_config = self.runtime_config_store.get_config(protocol_version);
 
         // To avoid limiting the throughput of the network, we want to include enough receipts to
         // saturate the capacity of the chunk even in case when all of these receipts end up using
@@ -820,11 +823,11 @@ impl RuntimeAdapter for NightshadeRuntime {
                     match verify_and_charge_transaction(
                         runtime_config,
                         &mut state_update,
-                        gas_price,
+                        prev_block.next_gas_price,
                         &tx,
                         false,
                         Some(next_block_height),
-                        current_protocol_version,
+                        protocol_version,
                     ) {
                         Ok(verification_result) => {
                             tracing::trace!(target: "runtime", tx=?tx.get_hash(), "including transaction that passed validation");


### PR DESCRIPTION
* Wrap block/chunk-related arguments into separate struct, consistent with `apply_chunk`
* Get rid of arguments that can be derived by runtime using its `epoch_manager`
* Move some of the logic (such as `next_block_height = prev_block.height + 1`, determining `epoch_id` and `protocol_version`, etc.) inside since it is part of the implementation and should not be decided by clients