### PR TITLE
refactor: extract `transaction_validity_check` function

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2873,6 +2873,21 @@ impl Chain {
         Ok(())
     }
 
+    pub fn transaction_validity_check<'a>(
+        &'a self,
+        prev_block_header: BlockHeader,
+    ) -> impl FnMut(&SignedTransaction) -> bool + 'a {
+        move |tx: &SignedTransaction| -> bool {
+            self.chain_store()
+                .check_transaction_validity_period(
+                    &prev_block_header,
+                    &tx.transaction.block_hash,
+                    self.transaction_validity_period,
+                )
+                .is_ok()
+        }
+    }
+
     /// For given pair of block headers and shard id, return information about
     /// block necessary for processing shard update.
     pub fn get_apply_chunk_block_context(

--- a/chain/client/src/chunk_validation.rs
+++ b/chain/client/src/chunk_validation.rs
@@ -225,23 +225,15 @@ fn validate_prepared_transactions(
     storage_config: RuntimeStorageConfig,
     transactions: &[SignedTransaction],
 ) -> Result<PreparedTransactions, Error> {
-    let store = chain.chain_store();
-    let parent_block_header = store.get_block_header(chunk_header.prev_block_hash())?;
+    let parent_block_header =
+        chain.chain_store().get_block_header(chunk_header.prev_block_hash())?;
 
     runtime_adapter.prepare_transactions(
         storage_config,
         chunk_header.into(),
         (&parent_block_header).into(),
         &mut TransactionGroupIteratorWrapper::new(transactions),
-        &mut |tx: &SignedTransaction| -> bool {
-            store
-                .check_transaction_validity_period(
-                    &parent_block_header,
-                    &tx.transaction.block_hash,
-                    chain.transaction_validity_period,
-                )
-                .is_ok()
-        },
+        &mut chain.transaction_validity_check(parent_block_header),
         None,
     )
 }


### PR DESCRIPTION
Runtime `prepare_transactions` accepts `chain_validate` callback to perform additional transaction validation using data from chain. This PR extract common code into a separate function as part of `Chain`.