### PR TITLE
refactor: add prev_ prefix to receipts in PartialEncodedChunk

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1265,7 +1265,7 @@ impl Chain {
             }
             let partial_encoded_chunk =
                 self.chain_store.get_partial_chunk(&chunk_header.chunk_hash()).unwrap();
-            for receipt in partial_encoded_chunk.receipts().iter() {
+            for receipt in partial_encoded_chunk.prev_outgoing_receipts().iter() {
                 let ReceiptProof(_, shard_proof) = receipt;
                 let ShardProof { to_shard_id, .. } = shard_proof;
                 receipt_proofs_by_shard_id

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -307,7 +307,7 @@ pub fn display_chain(me: &Option<AccountId>, chain: &mut Chain, tail: bool) {
                             chunk_producer,
                             partial_chunk.parts().iter().map(|x| x.part_ord).collect::<Vec<_>>(),
                             partial_chunk
-                                .receipts()
+                                .prev_outgoing_receipts()
                                 .iter()
                                 .map(|x| format!("{} => {}", x.0.len(), x.1.to_shard_id))
                                 .collect::<Vec<_>>(),

--- a/chain/chunks/src/chunk_cache.rs
+++ b/chain/chunks/src/chunk_cache.rs
@@ -94,7 +94,7 @@ impl EncodedChunksCacheEntry {
             });
         }
 
-        for receipt in partial_encoded_chunk.receipts.iter() {
+        for receipt in partial_encoded_chunk.prev_outgoing_receipts.iter() {
             let shard_id = receipt.1.to_shard_id;
             self.receipts.entry(shard_id).or_insert_with(|| receipt.clone());
         }
@@ -309,7 +309,7 @@ mod tests {
         cache.merge_in_partial_encoded_chunk(&PartialEncodedChunkV2 {
             header: header1.clone(),
             parts: vec![],
-            receipts: vec![],
+            prev_outgoing_receipts: vec![],
         });
         assert_eq!(
             cache.get_incomplete_chunks(&CryptoHash::default()).unwrap(),
@@ -329,7 +329,7 @@ mod tests {
         let mut cache = EncodedChunksCache::new();
         let header = create_chunk_header(1, 0);
         let partial_encoded_chunk =
-            PartialEncodedChunkV2 { header: header, parts: vec![], receipts: vec![] };
+            PartialEncodedChunkV2 { header: header, parts: vec![], prev_outgoing_receipts: vec![] };
         cache.merge_in_partial_encoded_chunk(&partial_encoded_chunk);
         assert!(!cache.height_map.is_empty());
 

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -930,7 +930,7 @@ impl ShardsManager {
                 response.parts.push(part.clone());
             }
         }
-        for receipt in partial_chunk.receipts() {
+        for receipt in partial_chunk.prev_outgoing_receipts() {
             if tracking_shards.contains(&receipt.1.to_shard_id) {
                 response.receipts.push(receipt.clone());
             }
@@ -1241,7 +1241,7 @@ impl ShardsManager {
         let partial_chunk = PartialEncodedChunk::V2(PartialEncodedChunkV2 {
             header,
             parts: forward.parts,
-            receipts: Vec::new(),
+            prev_outgoing_receipts: Vec::new(),
         });
         self.process_partial_encoded_chunk(MaybeValidated::from_validated(partial_chunk))?;
         Ok(())
@@ -1358,7 +1358,7 @@ impl ShardsManager {
             self.encoded_chunks.merge_in_partial_encoded_chunk(&PartialEncodedChunkV2 {
                 header: header.clone(),
                 parts: parts.into_values().collect(),
-                receipts: vec![],
+                prev_outgoing_receipts: vec![],
             });
             return true;
         }
@@ -1464,7 +1464,7 @@ impl ShardsManager {
         }
 
         // 1.e Checking receipts validity
-        for proof in partial_encoded_chunk.receipts.iter() {
+        for proof in partial_encoded_chunk.prev_outgoing_receipts.iter() {
             // TODO: only validate receipts we care about
             // https://github.com/near/nearcore/issues/5885
             // we can't simply use prev_block_hash to check if the node tracks this shard or not
@@ -2466,7 +2466,7 @@ mod test {
         let partial_encoded_chunk = PartialEncodedChunk::V2(PartialEncodedChunkV2 {
             header: fixture.mock_chunk_header.clone(),
             parts: other_parts,
-            receipts: Vec::new(),
+            prev_outgoing_receipts: Vec::new(),
         });
         // The validator receives a chunk header with the rest of the parts it needed
         let result = shards_manager

--- a/chain/chunks/src/logic.rs
+++ b/chain/chunks/src/logic.rs
@@ -118,7 +118,7 @@ pub fn make_partial_encoded_chunk_from_owned_parts_and_needed_receipts<'a>(
         })
         .cloned()
         .collect();
-    let mut receipts: Vec<_> = receipts
+    let mut prev_outgoing_receipts: Vec<_> = receipts
         .filter(|receipt| {
             cares_about_shard
                 || need_receipt(prev_block_hash, receipt.1.to_shard_id, me, shard_tracker)
@@ -126,18 +126,14 @@ pub fn make_partial_encoded_chunk_from_owned_parts_and_needed_receipts<'a>(
         .cloned()
         .collect();
     // Make sure the receipts are in a deterministic order.
-    receipts.sort();
+    prev_outgoing_receipts.sort();
     match header.clone() {
-        ShardChunkHeader::V1(header) => PartialEncodedChunk::V1(PartialEncodedChunkV1 {
-            header,
-            parts,
-            prev_outgoing_receipts: receipts,
-        }),
-        header => PartialEncodedChunk::V2(PartialEncodedChunkV2 {
-            header,
-            parts,
-            prev_outgoing_receipts: receipts,
-        }),
+        ShardChunkHeader::V1(header) => {
+            PartialEncodedChunk::V1(PartialEncodedChunkV1 { header, parts, prev_outgoing_receipts })
+        }
+        header => {
+            PartialEncodedChunk::V2(PartialEncodedChunkV2 { header, parts, prev_outgoing_receipts })
+        }
     }
 }
 
@@ -201,7 +197,7 @@ fn create_partial_chunk(
     shard_tracker: &ShardTracker,
 ) -> Result<PartialEncodedChunk, EpochError> {
     let header = encoded_chunk.cloned_header();
-    let receipts =
+    let prev_outgoing_receipts =
         make_outgoing_receipts_proofs(&header, &outgoing_receipts, epoch_manager)?.collect();
     let partial_chunk = PartialEncodedChunkV2 {
         header,
@@ -218,7 +214,7 @@ fn create_partial_chunk(
                 PartialEncodedChunkPart { part_ord, part, merkle_proof }
             })
             .collect(),
-        prev_outgoing_receipts: receipts,
+        prev_outgoing_receipts,
     };
 
     Ok(make_partial_encoded_chunk_from_owned_parts_and_needed_receipts(

--- a/chain/chunks/src/logic.rs
+++ b/chain/chunks/src/logic.rs
@@ -128,10 +128,16 @@ pub fn make_partial_encoded_chunk_from_owned_parts_and_needed_receipts<'a>(
     // Make sure the receipts are in a deterministic order.
     receipts.sort();
     match header.clone() {
-        ShardChunkHeader::V1(header) => {
-            PartialEncodedChunk::V1(PartialEncodedChunkV1 { header, parts, receipts })
-        }
-        header => PartialEncodedChunk::V2(PartialEncodedChunkV2 { header, parts, receipts }),
+        ShardChunkHeader::V1(header) => PartialEncodedChunk::V1(PartialEncodedChunkV1 {
+            header,
+            parts,
+            prev_outgoing_receipts: receipts,
+        }),
+        header => PartialEncodedChunk::V2(PartialEncodedChunkV2 {
+            header,
+            parts,
+            prev_outgoing_receipts: receipts,
+        }),
     }
 }
 
@@ -212,13 +218,13 @@ fn create_partial_chunk(
                 PartialEncodedChunkPart { part_ord, part, merkle_proof }
             })
             .collect(),
-        receipts,
+        prev_outgoing_receipts: receipts,
     };
 
     Ok(make_partial_encoded_chunk_from_owned_parts_and_needed_receipts(
         &partial_chunk.header,
         partial_chunk.parts.iter(),
-        partial_chunk.receipts.iter(),
+        partial_chunk.prev_outgoing_receipts.iter(),
         me,
         epoch_manager,
         shard_tracker,

--- a/chain/chunks/src/test/multi.rs
+++ b/chain/chunks/src/test/multi.rs
@@ -309,12 +309,15 @@ fn test_distribute_chunk_with_chunk_only_producers() {
                             if data.chain.cares_about_shard_this_or_next_epoch(1) {
                                 // If we track shard 1, we should have the full chunk
                                 // and thus have every receipt proof.
-                                assert_eq!(partial_chunk.receipts().len(), 3);
+                                assert_eq!(partial_chunk.prev_outgoing_receipts().len(), 3);
                             } else {
                                 // Otherwise, we should only have the receipt proof for the
                                 // shard we care about.
-                                assert_eq!(partial_chunk.receipts().len(), 1);
-                                assert_eq!(partial_chunk.receipts()[0].1.to_shard_id, shard);
+                                assert_eq!(partial_chunk.prev_outgoing_receipts().len(), 1);
+                                assert_eq!(
+                                    partial_chunk.prev_outgoing_receipts()[0].1.to_shard_id,
+                                    shard
+                                );
                             }
                         }
                     }

--- a/chain/chunks/src/test_loop.rs
+++ b/chain/chunks/src/test_loop.rs
@@ -366,9 +366,9 @@ impl TestChunkEncoder {
         PartialEncodedChunk::V2(PartialEncodedChunkV2 {
             header: self.encoded_chunk.cloned_header(),
             parts,
-            receipts: self
+            prev_outgoing_receipts: self
                 .full_partial_chunk
-                .receipts()
+                .prev_outgoing_receipts()
                 .iter()
                 .enumerate()
                 .filter(|(i, _)| receipt_shards.contains(&(*i as ShardId)))

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -206,7 +206,7 @@ impl ChunkTestFixture {
         PartialEncodedChunk::V2(PartialEncodedChunkV2 {
             header: self.mock_chunk_header.clone(),
             parts,
-            receipts: Vec::new(),
+            prev_outgoing_receipts: Vec::new(),
         })
     }
 

--- a/chain/client/src/tests/catching_up.rs
+++ b/chain/client/src/tests/catching_up.rs
@@ -230,7 +230,7 @@ fn test_catchup_receipts_sync_common(wait_till: u64, send: u64, sync_hold: bool)
                             //     include the receipt. The `distant` epoch is the first one that
                             //     will get the receipt through the state sync.
                             let receipts: Vec<Receipt> = partial_encoded_chunk
-                                .receipts
+                                .prev_outgoing_receipts
                                 .iter()
                                 .map(|x| x.0.clone())
                                 .flatten()

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -488,15 +488,13 @@ impl PartialEncodedChunk {
     pub fn new(
         header: ShardChunkHeader,
         parts: Vec<PartialEncodedChunkPart>,
-        receipts: Vec<ReceiptProof>,
+        prev_outgoing_receipts: Vec<ReceiptProof>,
     ) -> Self {
         match header {
             ShardChunkHeader::V1(header) => {
-                Self::V1(PartialEncodedChunkV1 { header, parts, prev_outgoing_receipts: receipts })
+                Self::V1(PartialEncodedChunkV1 { header, parts, prev_outgoing_receipts })
             }
-            header => {
-                Self::V2(PartialEncodedChunkV2 { header, parts, prev_outgoing_receipts: receipts })
-            }
+            header => Self::V2(PartialEncodedChunkV2 { header, parts, prev_outgoing_receipts }),
         }
     }
 
@@ -1153,7 +1151,7 @@ impl EncodedShardChunk {
     pub fn create_partial_encoded_chunk(
         &self,
         part_ords: Vec<u64>,
-        receipts: Vec<ReceiptProof>,
+        prev_outgoing_receipts: Vec<ReceiptProof>,
         merkle_paths: &[MerklePath],
     ) -> PartialEncodedChunk {
         let parts = self.part_ords_to_parts(part_ords, merkle_paths);
@@ -1162,7 +1160,7 @@ impl EncodedShardChunk {
                 let chunk = PartialEncodedChunkV1 {
                     header: chunk.header.clone(),
                     parts,
-                    prev_outgoing_receipts: receipts,
+                    prev_outgoing_receipts,
                 };
                 PartialEncodedChunk::V1(chunk)
             }
@@ -1170,7 +1168,7 @@ impl EncodedShardChunk {
                 let chunk = PartialEncodedChunkV2 {
                     header: chunk.header.clone(),
                     parts,
-                    prev_outgoing_receipts: receipts,
+                    prev_outgoing_receipts,
                 };
                 PartialEncodedChunk::V2(chunk)
             }

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -1178,7 +1178,7 @@ impl EncodedShardChunk {
     pub fn create_partial_encoded_chunk_with_arc_receipts(
         &self,
         part_ords: Vec<u64>,
-        receipts: Vec<Arc<ReceiptProof>>,
+        prev_outgoing_receipts: Vec<Arc<ReceiptProof>>,
         merkle_paths: &[MerklePath],
     ) -> PartialEncodedChunkWithArcReceipts {
         let parts = self.part_ords_to_parts(part_ords, merkle_paths);
@@ -1186,7 +1186,7 @@ impl EncodedShardChunk {
             Self::V1(chunk) => ShardChunkHeader::V1(chunk.header.clone()),
             Self::V2(chunk) => chunk.header.clone(),
         };
-        PartialEncodedChunkWithArcReceipts { header, parts, prev_outgoing_receipts: receipts }
+        PartialEncodedChunkWithArcReceipts { header, parts, prev_outgoing_receipts }
     }
 
     pub fn decode_chunk(&self, data_parts: usize) -> Result<ShardChunk, std::io::Error> {

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -492,9 +492,11 @@ impl PartialEncodedChunk {
     ) -> Self {
         match header {
             ShardChunkHeader::V1(header) => {
-                Self::V1(PartialEncodedChunkV1 { header, parts, receipts })
+                Self::V1(PartialEncodedChunkV1 { header, parts, prev_outgoing_receipts: receipts })
             }
-            header => Self::V2(PartialEncodedChunkV2 { header, parts, receipts }),
+            header => {
+                Self::V2(PartialEncodedChunkV2 { header, parts, prev_outgoing_receipts: receipts })
+            }
         }
     }
 
@@ -528,10 +530,10 @@ impl PartialEncodedChunk {
     }
 
     #[inline]
-    pub fn receipts(&self) -> &[ReceiptProof] {
+    pub fn prev_outgoing_receipts(&self) -> &[ReceiptProof] {
         match self {
-            Self::V1(chunk) => &chunk.receipts,
-            Self::V2(chunk) => &chunk.receipts,
+            Self::V1(chunk) => &chunk.prev_outgoing_receipts,
+            Self::V2(chunk) => &chunk.prev_outgoing_receipts,
         }
     }
 
@@ -569,7 +571,7 @@ impl PartialEncodedChunk {
 pub struct PartialEncodedChunkV2 {
     pub header: ShardChunkHeader,
     pub parts: Vec<PartialEncodedChunkPart>,
-    pub receipts: Vec<ReceiptProof>,
+    pub prev_outgoing_receipts: Vec<ReceiptProof>,
 }
 
 impl From<PartialEncodedChunk> for PartialEncodedChunkV2 {
@@ -578,7 +580,7 @@ impl From<PartialEncodedChunk> for PartialEncodedChunkV2 {
             PartialEncodedChunk::V1(chunk) => PartialEncodedChunkV2 {
                 header: ShardChunkHeader::V1(chunk.header),
                 parts: chunk.parts,
-                receipts: chunk.receipts,
+                prev_outgoing_receipts: chunk.prev_outgoing_receipts,
             },
             PartialEncodedChunk::V2(chunk) => chunk,
         }
@@ -589,14 +591,14 @@ impl From<PartialEncodedChunk> for PartialEncodedChunkV2 {
 pub struct PartialEncodedChunkV1 {
     pub header: ShardChunkHeaderV1,
     pub parts: Vec<PartialEncodedChunkPart>,
-    pub receipts: Vec<ReceiptProof>,
+    pub prev_outgoing_receipts: Vec<ReceiptProof>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PartialEncodedChunkWithArcReceipts {
     pub header: ShardChunkHeader,
     pub parts: Vec<PartialEncodedChunkPart>,
-    pub receipts: Vec<Arc<ReceiptProof>>,
+    pub prev_outgoing_receipts: Vec<Arc<ReceiptProof>>,
 }
 
 impl From<PartialEncodedChunkWithArcReceipts> for PartialEncodedChunk {
@@ -604,7 +606,11 @@ impl From<PartialEncodedChunkWithArcReceipts> for PartialEncodedChunk {
         Self::V2(PartialEncodedChunkV2 {
             header: pec.header,
             parts: pec.parts,
-            receipts: pec.receipts.into_iter().map(|r| ReceiptProof::clone(&r)).collect(),
+            prev_outgoing_receipts: pec
+                .prev_outgoing_receipts
+                .into_iter()
+                .map(|r| ReceiptProof::clone(&r))
+                .collect(),
         })
     }
 }
@@ -1153,11 +1159,19 @@ impl EncodedShardChunk {
         let parts = self.part_ords_to_parts(part_ords, merkle_paths);
         match self {
             Self::V1(chunk) => {
-                let chunk = PartialEncodedChunkV1 { header: chunk.header.clone(), parts, receipts };
+                let chunk = PartialEncodedChunkV1 {
+                    header: chunk.header.clone(),
+                    parts,
+                    prev_outgoing_receipts: receipts,
+                };
                 PartialEncodedChunk::V1(chunk)
             }
             Self::V2(chunk) => {
-                let chunk = PartialEncodedChunkV2 { header: chunk.header.clone(), parts, receipts };
+                let chunk = PartialEncodedChunkV2 {
+                    header: chunk.header.clone(),
+                    parts,
+                    prev_outgoing_receipts: receipts,
+                };
                 PartialEncodedChunk::V2(chunk)
             }
         }
@@ -1174,7 +1188,7 @@ impl EncodedShardChunk {
             Self::V1(chunk) => ShardChunkHeader::V1(chunk.header.clone()),
             Self::V2(chunk) => chunk.header.clone(),
         };
-        PartialEncodedChunkWithArcReceipts { header, parts, receipts }
+        PartialEncodedChunkWithArcReceipts { header, parts, prev_outgoing_receipts: receipts }
     }
 
     pub fn decode_chunk(&self, data_parts: usize) -> Result<ShardChunk, std::io::Error> {

--- a/core/store/benches/finalize_bench.rs
+++ b/core/store/benches/finalize_bench.rs
@@ -240,7 +240,7 @@ fn encoded_chunk_to_partial_encoded_chunk(
                 PartialEncodedChunkPart { part_ord, part, merkle_proof }
             })
             .collect(),
-        receipts: receipt_proofs,
+        prev_outgoing_receipts: receipt_proofs,
     });
     partial_chunk
 }

--- a/tools/mock-node/src/lib.rs
+++ b/tools/mock-node/src/lib.rs
@@ -478,8 +478,11 @@ fn retrieve_partial_encoded_chunk(
         .collect();
 
     // Same process for receipts as above for parts.
-    let present_receipts: HashMap<ShardId, _> =
-        partial_chunk.receipts().iter().map(|receipt| (receipt.1.to_shard_id, receipt)).collect();
+    let present_receipts: HashMap<ShardId, _> = partial_chunk
+        .prev_outgoing_receipts()
+        .iter()
+        .map(|receipt| (receipt.1.to_shard_id, receipt))
+        .collect();
     let receipts: Vec<_> = request
         .tracking_shards
         .iter()

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -52,7 +52,7 @@ fn get_incoming_receipts(
 
     for chunk in chunks {
         if let Ok(partial_encoded_chunk) = chain_store.get_partial_chunk(&chunk.chunk_hash()) {
-            for receipt in partial_encoded_chunk.receipts().iter() {
+            for receipt in partial_encoded_chunk.prev_outgoing_receipts().iter() {
                 let ReceiptProof(_, shard_proof) = receipt;
                 if shard_proof.to_shard_id == shard_id {
                     receipt_proofs.push(receipt.clone());


### PR DESCRIPTION
The `receipts` field in `PartialEncodedChunk` represents the outgoing receipts of the previous chunk. Let's modify the name to make it more descriptive: `prev_outgoing_receipts` is much clearer than just `receipts`. The same name is already used in `ShardChunk`, so it'll make the code more consistent and readable.

The change shouldn't break anything, the reasoning is the same as in https://github.com/near/nearcore/pull/9500:

> This change is safe since field names are not used for serialisation because those structs only support Borsh serialization.

This PR doesn't make any changes to the logic, it just renames `receipts` to `prev_outgoing_receipts`.