### PR TITLE
Fix: neard-release pipeline

### DIFF
--- a/.github/workflows/neard_release.yml
+++ b/.github/workflows/neard_release.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Checkout nearcore repository
         if: ${{ github.event_name != 'workflow_dispatch'}}
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Neard binary build and upload to S3
         run: ./scripts/binary_release.sh
@@ -67,6 +69,8 @@ jobs:
       - name: Checkout nearcore repository
         if: ${{ github.event_name != 'workflow_dispatch'}}
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -77,7 +81,11 @@ jobs:
       - name: Build and push Docker image to Dockerhub
         run: |
           COMMIT=$(git rev-parse HEAD)
-          BRANCH=${{ github.ref_name }}
+          BRANCH=$(git branch --show-current)
+          # in case of Release triggered run, branch is empty
+          if [ -z "$BRANCH" ]; then
+            BRANCH=$(git branch -r --contains=${{ github.ref_name }} | head -n1 | cut -c3- | cut -d / -f 2)
+          fi
           make docker-nearcore
           docker tag nearcore nearprotocol/nearcore:${BRANCH}-${COMMIT}
           docker tag nearcore nearprotocol/nearcore:${BRANCH}


### PR DESCRIPTION
https://github.com/near/nearcore/pull/10495 was meant to fix the builds triggered by release events.
With actions/checkout GHA action only a single commit is fetched by default and thus missing branch match.
To fetch all history for all branches and tags, setting fetch-depth to 0 for both binary and docker image release jobs.

This was [tested](https://github.com/near/andrei-playground/actions/runs/7696882172/job/20972653224) on a private repo.
<img width="676" alt="Screenshot 2024-01-29 at 13 42 09" src="https://github.com/near/nearcore/assets/122784628/941c1cd8-285e-4853-a9e7-a6ea6885c838">
