### PR TITLE
Add EntityDebug UI entities for stateless validation

### DIFF
--- a/chain/jsonrpc-primitives/src/types/entity_debug.rs
+++ b/chain/jsonrpc-primitives/src/types/entity_debug.rs
@@ -79,6 +79,7 @@ pub enum EntityQuery {
     TrieNode { trie_path: String },
     TrieRootByChunkHash { chunk_hash: CryptoHash },
     TrieRootByStateRoot { state_root: CryptoHash, shard_uid: ShardUId },
+    ValidatorAssignmentsAtHeight { block_height: BlockHeight, epoch_id: EpochId },
 }
 
 /// We use a trait for this, because jsonrpc does not have access to low-level

--- a/chain/jsonrpc-primitives/src/types/entity_debug.rs
+++ b/chain/jsonrpc-primitives/src/types/entity_debug.rs
@@ -67,6 +67,7 @@ pub enum EntityQuery {
     ShardIdByAccountId { account_id: String, epoch_id: EpochId },
     ShardLayoutByEpochId { epoch_id: EpochId },
     ShardUIdByShardId { shard_id: ShardId, epoch_id: EpochId },
+    StateTransitionData { block_hash: CryptoHash },
     TipAtFinalHead(()),
     TipAtHead(()),
     TipAtHeaderHead(()),

--- a/chain/jsonrpc-primitives/src/types/entity_debug.rs
+++ b/chain/jsonrpc-primitives/src/types/entity_debug.rs
@@ -33,6 +33,10 @@ impl EntityDataStruct {
     pub fn new() -> EntityDataStruct {
         EntityDataStruct { entries: Vec::new() }
     }
+
+    pub fn add(&mut self, name: &str, value: EntityDataValue) {
+        self.entries.push(EntityDataEntry { name: name.to_string(), value });
+    }
 }
 
 /// All queries supported by the Entity Debug UI.

--- a/core/primitives/src/challenge.rs
+++ b/core/primitives/src/challenge.rs
@@ -9,7 +9,7 @@ use near_crypto::Signature;
 /// Serialized TrieNodeWithSize or state value.
 pub type TrieValue = std::sync::Arc<[u8]>;
 
-#[derive(BorshSerialize, BorshDeserialize, serde::Serialize, Debug, Clone, Eq, PartialEq)]
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq)]
 /// TODO (#8984): consider supporting format containing trie values only for
 /// state part boundaries and storing state items for state part range.
 pub enum PartialState {

--- a/core/primitives/src/chunk_validation.rs
+++ b/core/primitives/src/chunk_validation.rs
@@ -239,6 +239,10 @@ impl ChunkValidatorAssignments {
         self.assignments.iter().map(|(id, _)| id.clone()).collect()
     }
 
+    pub fn assignments(&self) -> &Vec<(AccountId, Balance)> {
+        &self.assignments
+    }
+
     /// Returns true if the chunk has enough stake to be considered valid.
     /// We require that at least 2/3 of the total stake of the chunk is endorsed by chunk_validators.
     pub fn does_chunk_have_enough_stake(

--- a/core/primitives/src/chunk_validation.rs
+++ b/core/primitives/src/chunk_validation.rs
@@ -206,7 +206,7 @@ impl ChunkEndorsementInner {
 
 /// Stored on disk for each chunk, including missing chunks, in order to
 /// produce a chunk state witness when needed.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, serde::Serialize)]
 pub struct StoredChunkStateTransitionData {
     /// The partial state that is needed to apply the state transition,
     /// whether it is a new chunk state transition or a implicit missing chunk

--- a/core/primitives/src/chunk_validation.rs
+++ b/core/primitives/src/chunk_validation.rs
@@ -206,7 +206,7 @@ impl ChunkEndorsementInner {
 
 /// Stored on disk for each chunk, including missing chunks, in order to
 /// produce a chunk state witness when needed.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct StoredChunkStateTransitionData {
     /// The partial state that is needed to apply the state transition,
     /// whether it is a new chunk state transition or a implicit missing chunk

--- a/nearcore/src/entity_debug_serializer.rs
+++ b/nearcore/src/entity_debug_serializer.rs
@@ -479,7 +479,7 @@ impl<'a> SerializeStructVariant for EntitySerializerStruct<'a> {
 /// that can be easily displayed by the Entity Debug UI.
 pub fn serialize_entity<T>(value: &T) -> EntityDataValue
 where
-    T: Serialize,
+    T: Serialize + ?Sized,
 {
     let mut data = EntitySerializerData::new();
     value.serialize(data.serializer(String::new())).unwrap();

--- a/tools/debug-ui/src/entity_debug/fields.tsx
+++ b/tools/debug-ui/src/entity_debug/fields.tsx
@@ -230,6 +230,7 @@ export const fieldSemantics: Record<EntityType, FieldSemantic> = {
     ShardId: shardId,
     ShardLayout: undefined,
     ShardUId: shardUId,
+    StateTransitionData: undefined,
     Tip: tip,
     Transaction: transaction,
     TrieNode: trieNode,

--- a/tools/debug-ui/src/entity_debug/fields.tsx
+++ b/tools/debug-ui/src/entity_debug/fields.tsx
@@ -243,6 +243,21 @@ const stateTransitionData = {
     array: chunkStateTransitionData,
 };
 
+const oneValidatorAssignment = {
+    struct: {
+        account_id: accountId,
+    },
+    titleKey: 'account_id',
+};
+
+const validatorAssignmentsAtHeight = {
+    struct: {
+        blockProducer: accountId,
+        chunkProducers: { array: accountId },
+        chunkValidatorAssignments: { array: { array: oneValidatorAssignment } },
+    },
+};
+
 export const fieldSemantics: Record<EntityType, FieldSemantic> = {
     AllShards: { array: shardUId },
     Block: block,
@@ -264,4 +279,5 @@ export const fieldSemantics: Record<EntityType, FieldSemantic> = {
     Transaction: transaction,
     TrieNode: trieNode,
     TrieRoot: triePath,
+    ValidatorAssignmentsAtHeight: validatorAssignmentsAtHeight,
 };

--- a/tools/debug-ui/src/entity_debug/fields.tsx
+++ b/tools/debug-ui/src/entity_debug/fields.tsx
@@ -214,6 +214,35 @@ const flatStateDeltaMetadata = {
     },
 };
 
+const partialTrieNode: any = {
+    struct: {
+        extension: nibbles,
+    },
+};
+partialTrieNode.struct.a = partialTrieNode;
+partialTrieNode.struct.b = partialTrieNode;
+partialTrieNode.struct.c = partialTrieNode;
+partialTrieNode.struct.d = partialTrieNode;
+partialTrieNode.struct.e = partialTrieNode;
+partialTrieNode.struct.f = partialTrieNode;
+partialTrieNode.array = partialTrieNode;
+
+const partialTrie = {
+    struct: {
+        root: partialTrieNode,
+    },
+};
+
+const chunkStateTransitionData = {
+    struct: {
+        base_state: partialTrie,
+    },
+};
+
+const stateTransitionData = {
+    array: chunkStateTransitionData,
+};
+
 export const fieldSemantics: Record<EntityType, FieldSemantic> = {
     AllShards: { array: shardUId },
     Block: block,
@@ -230,7 +259,7 @@ export const fieldSemantics: Record<EntityType, FieldSemantic> = {
     ShardId: shardId,
     ShardLayout: undefined,
     ShardUId: shardUId,
-    StateTransitionData: undefined,
+    StateTransitionData: stateTransitionData,
     Tip: tip,
     Transaction: transaction,
     TrieNode: trieNode,

--- a/tools/debug-ui/src/entity_debug/types.tsx
+++ b/tools/debug-ui/src/entity_debug/types.tsx
@@ -32,6 +32,7 @@ export type EntityType =
     | 'ShardId'
     | 'ShardLayout'
     | 'ShardUId'
+    | 'StateTransitionData'
     | 'Tip'
     | 'Transaction'
     | 'TrieNode'
@@ -136,6 +137,7 @@ export type EntityQuery = {
     ShardIdByAccountId?: { account_id: string };
     ShardLayoutByEpochId?: { epoch_id: string };
     ShardUIdByShardId?: { shard_id: number; epoch_id: string };
+    StateTransitionData?: { block_hash: string };
     TipAtFinalHead?: null;
     TipAtHead?: null;
     TipAtHeaderHead?: null;
@@ -170,6 +172,7 @@ export const entityQueryTypes: EntityQueryType[] = [
     'ShardIdByAccountId',
     'ShardLayoutByEpochId',
     'ShardUIdByShardId',
+    'StateTransitionData',
     'TipAtFinalHead',
     'TipAtHead',
     'TipAtHeaderHead',
@@ -231,6 +234,7 @@ export const entityQueryKeyTypes: Record<EntityQueryType, EntityQueryKeySpec[]> 
     ShardIdByAccountId: [queryKey('account_id'), implicitQueryKey('epoch_id')],
     ShardLayoutByEpochId: [queryKey('epoch_id')],
     ShardUIdByShardId: [queryKey('shard_id'), implicitQueryKey('epoch_id')],
+    StateTransitionData: [queryKey('block_hash')],
     TipAtFinalHead: [],
     TipAtHead: [],
     TipAtHeaderHead: [],
@@ -260,6 +264,7 @@ export const entityQueryOutputType: Record<EntityQueryType, EntityType> = {
     ShardIdByAccountId: 'ShardId',
     ShardLayoutByEpochId: 'ShardLayout',
     ShardUIdByShardId: 'ShardUId',
+    StateTransitionData: 'StateTransitionData',
     TipAtFinalHead: 'Tip',
     TipAtHead: 'Tip',
     TipAtHeaderHead: 'Tip',

--- a/tools/debug-ui/src/entity_debug/types.tsx
+++ b/tools/debug-ui/src/entity_debug/types.tsx
@@ -36,7 +36,8 @@ export type EntityType =
     | 'Tip'
     | 'Transaction'
     | 'TrieNode'
-    | 'TrieRoot';
+    | 'TrieRoot'
+    | 'ValidatorAssignmentsAtHeight';
 
 /// Interface for a concrete entity key.
 export interface EntityKey {
@@ -145,6 +146,7 @@ export type EntityQuery = {
     TrieNode?: { trie_path: string };
     TrieRootByChunkHash?: { chunk_hash: string };
     TrieRootByStateRoot?: { state_root: string; shard_uid: string };
+    ValidatorAssignmentsAtHeight?: { block_height: number; epoch_id: string };
 };
 
 export type EntityQueryType = keyof EntityQuery;
@@ -180,6 +182,7 @@ export const entityQueryTypes: EntityQueryType[] = [
     'TrieNode',
     'TrieRootByChunkHash',
     'TrieRootByStateRoot',
+    'ValidatorAssignmentsAtHeight',
 ];
 
 /// See entityQueryKeyTypes.
@@ -242,6 +245,7 @@ export const entityQueryKeyTypes: Record<EntityQueryType, EntityQueryKeySpec[]> 
     TrieNode: [queryKey('trie_path')],
     TrieRootByChunkHash: [queryKey('chunk_hash')],
     TrieRootByStateRoot: [queryKey('state_root'), implicitQueryKey('shard_uid')],
+    ValidatorAssignmentsAtHeight: [queryKey('block_height'), implicitQueryKey('epoch_id')],
 };
 
 /// Specifies the expected output entity type for each query.
@@ -272,4 +276,5 @@ export const entityQueryOutputType: Record<EntityQueryType, EntityType> = {
     TrieNode: 'TrieNode',
     TrieRootByChunkHash: 'TrieRoot',
     TrieRootByStateRoot: 'TrieRoot',
+    ValidatorAssignmentsAtHeight: 'ValidatorAssignmentsAtHeight',
 };


### PR DESCRIPTION
Two new queries added:
 - StateTransitionData: given block hash, query the StateTransitionData stored for each shard at that block (we don't query by chunk hash here because this data also exists for missing chunks).
 - ValidatorAssignmentsAtHeight: given block height and epoch ID, query the block producer, chunk producer for each shard, and the chunk validator assignments.

Also add the ChunkEndorsements field to the Block result. Here, adding it to the BlockView is probably better, but that is a larger change.