### PR TITLE
fix: Disable generation of WASM file for Wallet Contract

### DIFF
--- a/runtime/near-wallet-contract/Cargo.toml
+++ b/runtime/near-wallet-contract/Cargo.toml
@@ -22,7 +22,6 @@ near-primitives-core.workspace = true
 anyhow.workspace = true
 
 [features]
-build_wallet_contract = []
 nightly_protocol = [
   "near-primitives-core/nightly_protocol",
   "near-vm-runner/nightly_protocol",

--- a/runtime/near-wallet-contract/README.md
+++ b/runtime/near-wallet-contract/README.md
@@ -4,8 +4,8 @@ See https://github.com/near/NEPs/issues/518.
 
 Must not use in production!
 
-Currently, the contract can only be used in nightly build.
-Temporarily, we also require `build_wallet_contract` feature flag for `cargo build`.
+Currently, the contract build is disabled!
+
 The `build.rs` generates WASM file and saves it to the `./res` directory.
 
 If you want to use the contract from nearcore, add this crate as a dependency

--- a/runtime/near-wallet-contract/build.rs
+++ b/runtime/near-wallet-contract/build.rs
@@ -5,12 +5,10 @@ use anyhow::{anyhow, Context, Ok, Result};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+#[allow(unreachable_code)]
 fn main() -> Result<()> {
-    // TODO(eth-implicit) Remove the `build_wallet_contract` flag once we have a proper way
-    // to generate the Wallet Contract WASM file.
-    if cfg!(not(feature = "nightly")) || cfg!(not(feature = "build_wallet_contract")) {
-        return Ok(());
-    }
+    // TODO(eth-implicit) Remove this once we have a proper way to generate the Wallet Contract WASM file.
+    return Ok(());
     build_contract("./wallet-contract", &[], "wallet_contract")
 }
 


### PR DESCRIPTION
Looks like https://github.com/near/nearcore/pull/10436 is not enough, because the WASM file is still generated if someone manually run tests with `--all-features` flag, which triggers `build_wallet_contract` too.
To make sure it does not happen at all, I would disable the Wallect Contract build completely. We currently do not use it anyway.