### PR TITLE
fix: bypass sending stateless validation messages to ourselves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3568,6 +3568,7 @@ dependencies = [
  "lru",
  "near-actix-test-utils",
  "near-async",
+ "near-cache",
  "near-chain",
  "near-chain-configs",
  "near-chain-primitives",

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -43,6 +43,7 @@ tracing.workspace = true
 yansi.workspace = true
 
 near-async.workspace = true
+near-cache.workspace = true
 near-chain-configs.workspace = true
 near-chain-primitives.workspace = true
 near-chain.workspace = true

--- a/chain/client/src/stateless_validation/chunk_endorsement_tracker.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement_tracker.rs
@@ -22,7 +22,7 @@ pub struct ChunkEndorsementTracker {
     /// We store the validated chunk endorsements received from chunk validators
     /// This is keyed on chunk_hash and account_id of validator to avoid duplicates.
     /// Chunk endorsements would later be used as a part of block production.
-    chunk_endorsements: Arc<SyncLruCache<ChunkHash, HashMap<AccountId, ChunkEndorsement>>>,
+    pub chunk_endorsements: Arc<SyncLruCache<ChunkHash, HashMap<AccountId, ChunkEndorsement>>>,
 }
 
 impl Client {
@@ -46,7 +46,7 @@ impl ChunkEndorsementTracker {
     /// Function to process an incoming chunk endorsement from chunk validators.
     /// We first verify the chunk endorsement and then store it in a cache.
     /// We would later include the endorsements in the block production.
-    pub fn process_chunk_endorsement(
+    fn process_chunk_endorsement(
         &self,
         chunk_header: ShardChunkHeader,
         endorsement: ChunkEndorsement,
@@ -106,7 +106,7 @@ impl ChunkEndorsementTracker {
         // We can safely rely on the the following details
         //    1. The chunk endorsements are from valid chunk_validator for this chunk.
         //    2. The chunk endorsements signatures are valid.
-        let Some(chunk_endorsements) = self.chunk_endorsements.peek(&chunk_header.chunk_hash())
+        let Some(chunk_endorsements) = self.chunk_endorsements.get(&chunk_header.chunk_hash())
         else {
             // Early return if no chunk_enforsements found in our cache.
             return Ok(None);

--- a/chain/client/src/stateless_validation/chunk_endorsement_tracker.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement_tracker.rs
@@ -1,3 +1,4 @@
+use near_cache::SyncLruCache;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -21,7 +22,7 @@ pub struct ChunkEndorsementTracker {
     /// We store the validated chunk endorsements received from chunk validators
     /// This is keyed on chunk_hash and account_id of validator to avoid duplicates.
     /// Chunk endorsements would later be used as a part of block production.
-    chunk_endorsements: lru::LruCache<ChunkHash, HashMap<AccountId, ChunkEndorsement>>,
+    chunk_endorsements: Arc<SyncLruCache<ChunkHash, HashMap<AccountId, ChunkEndorsement>>>,
 }
 
 impl Client {
@@ -38,15 +39,15 @@ impl ChunkEndorsementTracker {
     pub fn new(epoch_manager: Arc<dyn EpochManagerAdapter>) -> Self {
         Self {
             epoch_manager,
-            chunk_endorsements: lru::LruCache::new(NUM_CHUNKS_IN_CHUNK_ENDORSEMENTS_CACHE),
+            chunk_endorsements: Arc::new(SyncLruCache::new(NUM_CHUNKS_IN_CHUNK_ENDORSEMENTS_CACHE)),
         }
     }
 
     /// Function to process an incoming chunk endorsement from chunk validators.
     /// We first verify the chunk endorsement and then store it in a cache.
     /// We would later include the endorsements in the block production.
-    fn process_chunk_endorsement(
-        &mut self,
+    pub fn process_chunk_endorsement(
+        &self,
         chunk_header: ShardChunkHeader,
         endorsement: ChunkEndorsement,
     ) -> Result<(), Error> {
@@ -75,8 +76,9 @@ impl ChunkEndorsementTracker {
         // Maybe add check to ensure we don't accept endorsements from chunks already included in some block?
         // Maybe add check to ensure we don't accept endorsements from chunks that have too old height_created?
         tracing::debug!(target: "stateless_validation", ?endorsement, "Received and saved chunk endorsement.");
-        self.chunk_endorsements.get_or_insert(chunk_hash.clone(), || HashMap::new());
-        let chunk_endorsements = self.chunk_endorsements.get_mut(chunk_hash).unwrap();
+        let mut guard = self.chunk_endorsements.as_ref().lock();
+        guard.get_or_insert(chunk_hash.clone(), || HashMap::new());
+        let chunk_endorsements = guard.get_mut(chunk_hash).unwrap();
         chunk_endorsements.insert(account_id.clone(), endorsement);
 
         Ok(())

--- a/chain/client/src/stateless_validation/chunk_validator.rs
+++ b/chain/client/src/stateless_validation/chunk_validator.rs
@@ -544,7 +544,7 @@ pub fn send_chunk_endorsement_to_block_producers(
 
     let chunk_hash = chunk_header.chunk_hash();
     tracing::debug!(
-        target: "chunk_validation",
+        target: "stateless_validation",
         chunk_hash=?chunk_hash,
         ?block_producers,
         "Chunk validated successfully, sending endorsement",

--- a/chain/client/src/stateless_validation/chunk_validator.rs
+++ b/chain/client/src/stateless_validation/chunk_validator.rs
@@ -524,7 +524,7 @@ fn apply_result_to_chunk_extra(
     )
 }
 
-fn send_chunk_endorsement_to_block_producers(
+pub fn send_chunk_endorsement_to_block_producers(
     chunk_header: &ShardChunkHeader,
     epoch_manager: &dyn EpochManagerAdapter,
     signer: &dyn ValidatorSigner,

--- a/chain/client/src/stateless_validation/chunk_validator.rs
+++ b/chain/client/src/stateless_validation/chunk_validator.rs
@@ -553,6 +553,8 @@ pub fn send_chunk_endorsement_to_block_producers(
     let endorsement = ChunkEndorsement::new(chunk_header.chunk_hash(), signer);
     for block_producer in block_producers {
         if signer.validator_id() == &block_producer {
+            // Add endorsement to the cache of our chunk endorsements
+            // immediately, because network won't handle message to ourselves.
             let mut guard = my_chunk_endorsements.lock();
             guard.get_or_insert(chunk_hash.clone(), || HashMap::new());
             let chunk_endorsements = guard.get_mut(&chunk_hash).unwrap();

--- a/chain/client/src/stateless_validation/state_witness_producer.rs
+++ b/chain/client/src/stateless_validation/state_witness_producer.rs
@@ -53,7 +53,7 @@ impl Client {
         if let Some(my_signer) = self.validator_signer.clone() {
             let validator_id = my_signer.validator_id();
             if chunk_validators.contains(validator_id) {
-                // Endorse the chunk automatically, bypassing sending state witness
+                // Endorse the chunk immediately, bypassing sending state witness
                 // to ourselves, because network can't send messages to ourselves.
                 // Also useful in tests where we don't have a good way to handle
                 // network messages and there's only a single client.

--- a/chain/client/src/stateless_validation/state_witness_producer.rs
+++ b/chain/client/src/stateless_validation/state_witness_producer.rs
@@ -1,4 +1,4 @@
-use near_async::messaging::CanSend;
+use near_async::messaging::{CanSend, IntoSender};
 
 use near_chain::{BlockHeader, Chain, ChainStoreAccess};
 use near_chain_primitives::Error;
@@ -14,6 +14,7 @@ use near_primitives::stateless_validation::{
 use near_primitives::types::EpochId;
 use std::collections::HashMap;
 
+use crate::stateless_validation::chunk_validator::send_chunk_endorsement_to_block_producers;
 use crate::Client;
 
 impl Client {
@@ -51,15 +52,19 @@ impl Client {
         // TODO(#10508): Remove this block once we have better ways to handle chunk state witness and
         // chunk endorsement related network messages.
         if let Some(my_signer) = self.validator_signer.clone() {
-            let block_producer =
-                self.epoch_manager.get_block_producer(&epoch_id, chunk_header.height_created())?;
-            if my_signer.validator_id() == &block_producer {
-                // Send a copy of the chunk endorsement to ourselves.
-                // Mainly useful in tests where we don't have a good way to handle network messages and there's
-                // only a single client.
-                let endorsement =
-                    ChunkEndorsement::new(chunk_header.chunk_hash(), my_signer.as_ref());
-                self.process_chunk_endorsement(endorsement)?;
+            let validator_id = my_signer.validator_id();
+            if chunk_validators.contains(validator_id) {
+                // Endorse the chunk automatically, bypassing sending state witness
+                // to ourselves, because network can't send messages to ourselves.
+                // Also useful in tests where we don't have a good way to handle
+                // network messages and there's only a single client.
+                send_chunk_endorsement_to_block_producers(
+                    &chunk_header,
+                    self.epoch_manager.as_ref(),
+                    my_signer.as_ref(),
+                    &self.network_adapter.clone().into_sender(),
+                    self.chunk_endorsement_tracker.chunk_endorsements.as_ref(),
+                );
             }
         };
 

--- a/chain/client/src/stateless_validation/state_witness_producer.rs
+++ b/chain/client/src/stateless_validation/state_witness_producer.rs
@@ -8,8 +8,7 @@ use near_primitives::checked_feature;
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::{ChunkHash, ReceiptProof, ShardChunk, ShardChunkHeader};
 use near_primitives::stateless_validation::{
-    ChunkEndorsement, ChunkStateTransition, ChunkStateWitness, ChunkStateWitnessInner,
-    StoredChunkStateTransitionData,
+    ChunkStateTransition, ChunkStateWitness, ChunkStateWitnessInner, StoredChunkStateTransitionData,
 };
 use near_primitives::types::EpochId;
 use std::collections::HashMap;

--- a/utils/near-cache/src/sync.rs
+++ b/utils/near-cache/src/sync.rs
@@ -73,6 +73,10 @@ where
     pub fn get(&self, key: &K) -> Option<V> {
         self.inner.lock().unwrap().get(key).cloned()
     }
+
+    pub fn lock(&self) -> std::sync::MutexGuard<LruCache<K, V>> {
+        self.inner.lock().unwrap()
+    }
 }
 
 #[cfg(test)]

--- a/utils/near-cache/src/sync.rs
+++ b/utils/near-cache/src/sync.rs
@@ -74,6 +74,7 @@ where
         self.inner.lock().unwrap().get(key).cloned()
     }
 
+    /// Returns the lock over underlying LRU cache.
     pub fn lock(&self) -> std::sync::MutexGuard<LruCache<K, V>> {
         self.inner.lock().unwrap()
     }


### PR DESCRIPTION
Internal testing revealed that our network doesn't send messages to ourselves, so if we try sending state witness or endorsement to ourselves, this message gets dropped: https://near.zulipchat.com/#narrow/stream/407237-pagoda.2Fcore.2Fstateless-validation/topic/Internal.20testnet.20findings/near/418348484

Making the quick fix for it to unblock stateless net. Because there are two messages - witness/endorsement, there are two patches:
1. if we are chunk producer and chunk validator, we immediately send endorsement to block producer, bypassing sending state witness to ourselves;
2. if we are block producer and chunk validator, we immediately add endorsement to chunk endorsement cache, bypassing sending endorsement to ourselves.

Note that when node operates in all three roles, it happily does both.
To do so, I hide chunk endorsement cache behind the mutex, as now it can be modified inside a thread where state witness is validated.