### PR TITLE
feat: add metrics around chunk endorsements

### DIFF
--- a/chain/chain/src/chunk_endorsement.rs
+++ b/chain/chain/src/chunk_endorsement.rs
@@ -95,9 +95,10 @@ impl Chain {
                 endorsed_chunk_validators.insert(account_id);
             }
 
-            if !chunk_validator_assignments.does_chunk_have_enough_stake(endorsed_chunk_validators)
-            {
-                tracing::error!(target: "chain", "Chunk does not have enough stake to be endorsed");
+            let endorsement_stats =
+                chunk_validator_assignments.compute_endorsement_stats(&endorsed_chunk_validators);
+            if !endorsement_stats.has_enough_stake() {
+                tracing::error!(target: "chain", ?endorsement_stats, "Chunk does not have enough stake to be endorsed");
                 return Err(Error::InvalidChunkEndorsement);
             }
         }

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -1,8 +1,8 @@
 use near_o11y::metrics::{
-    exponential_buckets, try_create_counter, try_create_gauge, try_create_histogram,
-    try_create_histogram_vec, try_create_int_counter, try_create_int_counter_vec,
-    try_create_int_gauge, try_create_int_gauge_vec, Counter, Gauge, Histogram, HistogramVec,
-    IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
+    exponential_buckets, linear_buckets, try_create_counter, try_create_gauge,
+    try_create_histogram, try_create_histogram_vec, try_create_int_counter,
+    try_create_int_counter_vec, try_create_int_gauge, try_create_int_gauge_vec, Counter, Gauge,
+    Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
 };
 use once_cell::sync::Lazy;
 
@@ -579,6 +579,30 @@ pub(crate) static CHUNK_STATE_WITNESS_TOTAL_SIZE: Lazy<HistogramVec> = Lazy::new
         "Stateless validation state witness size in bytes",
         &["shard_id"],
         Some(exponential_buckets(1000.0, 2.0, 20).unwrap()),
+    )
+    .unwrap()
+});
+
+pub(crate) static BLOCK_PRODUCER_ENDORSED_STAKE_RATIO: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "near_block_producer_endorsed_stake_ratio",
+        "Ratio (the value is between 0.0 and 1.0) of the endorsed stake for the produced block",
+        &["shard_id"],
+        Some(linear_buckets(0.0, 0.05, 20).unwrap()),
+    )
+    .unwrap()
+});
+
+pub(crate) static BLOCK_PRODUCER_MISSING_ENDORSEMENT_COUNT: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "near_block_producer_missing_endorsement_count",
+        "Number of validators from which the block producer has not received endorsements",
+        &["shard_id"],
+        Some({
+            let mut buckets = vec![0.0, 1.0, 2.0, 3.0, 4.0];
+            buckets.append(&mut exponential_buckets(5.0, 1.5, 10).unwrap());
+            buckets
+        }),
     )
     .unwrap()
 });

--- a/chain/client/src/stateless_validation/chunk_endorsement_tracker.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement_tracker.rs
@@ -7,10 +7,10 @@ use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::block_body::ChunkEndorsementSignatures;
 use near_primitives::checked_feature;
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
-use near_primitives::stateless_validation::{ChunkEndorsement, EndorsementStats};
-use near_primitives::types::AccountId;
+use near_primitives::stateless_validation::ChunkEndorsement;
+use near_primitives::types::{AccountId, ShardId};
 
-use crate::Client;
+use crate::{metrics, Client};
 
 // This is the number of unique chunks for which we would track the chunk endorsements.
 // Ideally, we should not be processing more than num_shards chunks at a time.
@@ -101,6 +101,11 @@ impl ChunkEndorsementTracker {
             return Ok(Some(vec![]));
         }
 
+        let chunk_validator_assignments = self.epoch_manager.get_chunk_validator_assignments(
+            &epoch_id,
+            chunk_header.shard_id(),
+            chunk_header.height_created(),
+        )?;
         // Get the chunk_endorsements for the chunk from our cache.
         // Note that these chunk endorsements are already validated as part of process_chunk_endorsement.
         // We can safely rely on the the following details
@@ -109,16 +114,23 @@ impl ChunkEndorsementTracker {
         let Some(chunk_endorsements) = self.chunk_endorsements.get(&chunk_header.chunk_hash())
         else {
             // Early return if no chunk_enforsements found in our cache.
+            record_endorsement_metrics(
+                chunk_header.shard_id(),
+                0.0,
+                chunk_validator_assignments.assignments().len(),
+            );
             return Ok(None);
         };
 
-        let chunk_validator_assignments = self.epoch_manager.get_chunk_validator_assignments(
-            &epoch_id,
-            chunk_header.shard_id(),
-            chunk_header.height_created(),
-        )?;
         let endorsement_stats = chunk_validator_assignments
             .compute_endorsement_stats(&chunk_endorsements.keys().collect());
+        record_endorsement_metrics(
+            chunk_header.shard_id(),
+            endorsement_stats.endorsed_stake as f64 / endorsement_stats.total_stake as f64,
+            endorsement_stats
+                .total_validators_count
+                .saturating_sub(endorsement_stats.endorsed_validators_count),
+        );
 
         // Check whether the current set of chunk_validators have enough stake to include chunk in block.
         if !endorsement_stats.has_enough_stake() {
@@ -139,4 +151,19 @@ impl ChunkEndorsementTracker {
 
         Ok(Some(signatures))
     }
+}
+
+fn record_endorsement_metrics(
+    shard_id: ShardId,
+    endorsed_stake_ratio: f64,
+    missing_endorsement_count: usize,
+) {
+    let shard_label = shard_id.to_string();
+    let label_values = &[shard_label.as_ref()];
+    metrics::BLOCK_PRODUCER_ENDORSED_STAKE_RATIO
+        .with_label_values(label_values)
+        .observe(endorsed_stake_ratio);
+    metrics::BLOCK_PRODUCER_MISSING_ENDORSEMENT_COUNT
+        .with_label_values(label_values)
+        .observe(missing_endorsement_count as f64);
 }

--- a/chain/client/src/stateless_validation/chunk_endorsement_tracker.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement_tracker.rs
@@ -7,7 +7,7 @@ use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::block_body::ChunkEndorsementSignatures;
 use near_primitives::checked_feature;
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
-use near_primitives::stateless_validation::ChunkEndorsement;
+use near_primitives::stateless_validation::{ChunkEndorsement, EndorsementStats};
 use near_primitives::types::AccountId;
 
 use crate::Client;
@@ -117,11 +117,11 @@ impl ChunkEndorsementTracker {
             chunk_header.shard_id(),
             chunk_header.height_created(),
         )?;
+        let endorsement_stats = chunk_validator_assignments
+            .compute_endorsement_stats(&chunk_endorsements.keys().collect());
 
         // Check whether the current set of chunk_validators have enough stake to include chunk in block.
-        if !chunk_validator_assignments
-            .does_chunk_have_enough_stake(chunk_endorsements.keys().collect())
-        {
+        if !endorsement_stats.has_enough_stake() {
             return Ok(None);
         }
 

--- a/core/primitives/src/stateless_validation.rs
+++ b/core/primitives/src/stateless_validation.rs
@@ -219,6 +219,24 @@ pub struct StoredChunkStateTransitionData {
     pub receipts_hash: CryptoHash,
 }
 
+#[derive(Debug)]
+pub struct EndorsementStats {
+    pub total_stake: Balance,
+    pub endorsed_stake: Balance,
+    pub total_validators_count: usize,
+    pub endorced_validators_count: usize,
+}
+
+impl EndorsementStats {
+    pub fn has_enough_stake(&self) -> bool {
+        self.endorsed_stake > self.required_stake()
+    }
+
+    pub fn required_stake(&self) -> Balance {
+        self.total_stake * 2 / 3
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct ChunkValidatorAssignments {
     assignments: Vec<(AccountId, Balance)>,
@@ -243,20 +261,25 @@ impl ChunkValidatorAssignments {
         &self.assignments
     }
 
-    /// Returns true if the chunk has enough stake to be considered valid.
-    /// We require that at least 2/3 of the total stake of the chunk is endorsed by chunk_validators.
-    pub fn does_chunk_have_enough_stake(
+    pub fn compute_endorsement_stats(
         &self,
-        endorsed_chunk_validators: HashSet<&AccountId>,
-    ) -> bool {
+        endorsed_chunk_validators: &HashSet<&AccountId>,
+    ) -> EndorsementStats {
         let mut total_stake = 0;
         let mut endorsed_stake = 0;
+        let mut endorced_validators_count = 0;
         for (account_id, stake) in &self.assignments {
             total_stake += stake;
             if endorsed_chunk_validators.contains(account_id) {
                 endorsed_stake += stake;
+                endorced_validators_count += 1;
             }
         }
-        endorsed_stake > total_stake * 2 / 3
+        EndorsementStats {
+            total_stake,
+            endorsed_stake,
+            endorced_validators_count,
+            total_validators_count: self.assignments.len(),
+        }
     }
 }

--- a/core/primitives/src/stateless_validation.rs
+++ b/core/primitives/src/stateless_validation.rs
@@ -229,11 +229,11 @@ pub struct EndorsementStats {
 
 impl EndorsementStats {
     pub fn has_enough_stake(&self) -> bool {
-        self.endorsed_stake > self.required_stake()
+        self.endorsed_stake >= self.required_stake()
     }
 
     pub fn required_stake(&self) -> Balance {
-        self.total_stake * 2 / 3
+        self.total_stake * 2 / 3 + 1
     }
 }
 

--- a/core/primitives/src/stateless_validation.rs
+++ b/core/primitives/src/stateless_validation.rs
@@ -224,7 +224,7 @@ pub struct EndorsementStats {
     pub total_stake: Balance,
     pub endorsed_stake: Balance,
     pub total_validators_count: usize,
-    pub endorced_validators_count: usize,
+    pub endorsed_validators_count: usize,
 }
 
 impl EndorsementStats {
@@ -267,18 +267,18 @@ impl ChunkValidatorAssignments {
     ) -> EndorsementStats {
         let mut total_stake = 0;
         let mut endorsed_stake = 0;
-        let mut endorced_validators_count = 0;
+        let mut endorsed_validators_count = 0;
         for (account_id, stake) in &self.assignments {
             total_stake += stake;
             if endorsed_chunk_validators.contains(account_id) {
                 endorsed_stake += stake;
-                endorced_validators_count += 1;
+                endorsed_validators_count += 1;
             }
         }
         EndorsementStats {
             total_stake,
             endorsed_stake,
-            endorced_validators_count,
+            endorsed_validators_count,
             total_validators_count: self.assignments.len(),
         }
     }

--- a/integration-tests/src/tests/client/features/limit_contract_functions_number.rs
+++ b/integration-tests/src/tests/client/features/limit_contract_functions_number.rs
@@ -12,6 +12,7 @@ use near_primitives::views::FinalExecutionStatus;
 use nearcore::config::GenesisExt;
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
 
+#[allow(dead_code)]
 fn verify_contract_limits_upgrade(
     feature: ProtocolFeature,
     function_limit: u32,
@@ -73,6 +74,8 @@ fn verify_contract_limits_upgrade(
 }
 
 // Check that we can't call a contract exceeding functions number limit after upgrade.
+// Disabled in nightly due to https://github.com/near/nearcore/issues/8590
+#[cfg(not(feature = "nightly"))]
 #[test]
 fn test_function_limit_change() {
     verify_contract_limits_upgrade(
@@ -84,6 +87,8 @@ fn test_function_limit_change() {
 }
 
 // Check that we can't call a contract exceeding functions number limit after upgrade.
+// Disabled in nightly due to https://github.com/near/nearcore/issues/8590
+#[cfg(not(feature = "nightly"))]
 #[test]
 fn test_local_limit_change() {
     verify_contract_limits_upgrade(


### PR DESCRIPTION
This PR adds the following metrics emitted by the block producer:
* Histogram for the endorsed stake ratio. This could help us to identify if chunks are missed because of insufficient endorsement stake.
* Histogram for the number of missing endorsement signatures, so we can track how many validators failed to send the endorsement in time. 