### PR TITLE
fix: enable test_function_limit_change

### DIFF
--- a/integration-tests/src/tests/client/features/limit_contract_functions_number.rs
+++ b/integration-tests/src/tests/client/features/limit_contract_functions_number.rs
@@ -9,8 +9,6 @@ use near_primitives::errors::{
 };
 use near_primitives::version::ProtocolFeature;
 use near_primitives::views::FinalExecutionStatus;
-use near_primitives_core::checked_feature;
-use near_primitives_core::version::PROTOCOL_VERSION;
 use nearcore::config::GenesisExt;
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
 
@@ -77,11 +75,6 @@ fn verify_contract_limits_upgrade(
 // Check that we can't call a contract exceeding functions number limit after upgrade.
 #[test]
 fn test_function_limit_change() {
-    // TODO(#10506): Fix test to handle stateless validation
-    if checked_feature!("stable", ChunkValidation, PROTOCOL_VERSION) {
-        return;
-    }
-
     verify_contract_limits_upgrade(
         ProtocolFeature::LimitContractFunctionsNumber,
         100_000,


### PR DESCRIPTION
It looks like this test now works with stateless validation, so let's enable it again.
I didn't need to make any changes to the test, maybe something was fixed in the meantime.

Refs: https://github.com/near/nearcore/issues/10506