### PR TITLE
[stateless_validation] Cleanup for bypass sending stateless validation messages to ourselves

### DIFF
--- a/chain/client/src/chunk_inclusion_tracker.rs
+++ b/chain/client/src/chunk_inclusion_tracker.rs
@@ -93,7 +93,7 @@ impl ChunkInclusionTracker {
     pub fn prepare_chunk_headers_ready_for_inclusion(
         &mut self,
         prev_block_hash: &CryptoHash,
-        endorsement_tracker: &mut ChunkEndorsementTracker,
+        endorsement_tracker: &ChunkEndorsementTracker,
     ) -> Result<(), Error> {
         let Some(entry) = self.prev_block_to_chunk_hash_ready.get(prev_block_hash) else {
             return Ok(());

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1065,7 +1065,7 @@ impl ClientActor {
             if me == next_block_producer_account {
                 self.client.chunk_inclusion_tracker.prepare_chunk_headers_ready_for_inclusion(
                     &head.last_block_hash,
-                    &mut self.client.chunk_endorsement_tracker,
+                    self.client.chunk_endorsement_tracker.as_ref(),
                 )?;
                 let num_chunks = self
                     .client

--- a/chain/client/src/stateless_validation/state_witness_producer.rs
+++ b/chain/client/src/stateless_validation/state_witness_producer.rs
@@ -33,7 +33,7 @@ impl Client {
         }
 
         let chunk_header = chunk.cloned_header();
-        let chunk_validators = self
+        let mut chunk_validators = self
             .epoch_manager
             .get_chunk_validator_assignments(
                 epoch_id,
@@ -48,23 +48,22 @@ impl Client {
             transactions_storage_proof,
         )?;
 
-        // TODO(#10508): Remove this block once we have better ways to handle chunk state witness and
-        // chunk endorsement related network messages.
         if let Some(my_signer) = self.validator_signer.clone() {
-            let validator_id = my_signer.validator_id();
-            if chunk_validators.contains(validator_id) {
-                // Endorse the chunk immediately, bypassing sending state witness
-                // to ourselves, because network can't send messages to ourselves.
-                // Also useful in tests where we don't have a good way to handle
-                // network messages and there's only a single client.
+            // Remove ourselves from the list of chunk validators. Network can't send messages to ourselves.
+            chunk_validators.retain(|validator| {
+                if validator != my_signer.validator_id() {
+                    return true;
+                }
+                // Bypass state witness validation if we created state witness. Endorse the chunk immediately.
                 send_chunk_endorsement_to_block_producers(
                     &chunk_header,
                     self.epoch_manager.as_ref(),
                     my_signer.as_ref(),
                     &self.network_adapter.clone().into_sender(),
-                    self.chunk_endorsement_tracker.chunk_endorsements.as_ref(),
+                    self.chunk_endorsement_tracker.as_ref(),
                 );
-            }
+                false
+            });
         };
 
         tracing::debug!(

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2407,7 +2407,7 @@ fn test_validate_chunk_extra() {
         .chunk_inclusion_tracker
         .prepare_chunk_headers_ready_for_inclusion(
             block1.hash(),
-            &mut client.chunk_endorsement_tracker,
+            client.chunk_endorsement_tracker.as_ref(),
         )
         .unwrap();
     let block = client.produce_block_on(next_height + 2, *block1.hash()).unwrap().unwrap();


### PR DESCRIPTION
I wasn't too happy exposing chunk_endorsements cache in `ChunkEndorsementTracker` that was introduced as part of this PR: https://github.com/near/nearcore/pull/10531

Hopefully this is better structured. Suggestions are welcomed!