### PR TITLE
[stateless_validation] Rename feature `ChunkValidation` to `StatelessValidationV0`

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2014,7 +2014,7 @@ impl Chain {
 
         self.validate_chunk_headers(&block, &prev_block)?;
 
-        if checked_feature!("stable", ChunkValidation, protocol_version) {
+        if checked_feature!("stable", StatelessValidationV0, protocol_version) {
             self.validate_chunk_endorsements_in_block(&block)?;
         }
 
@@ -3245,7 +3245,7 @@ impl Chain {
             self.epoch_manager.get_next_epoch_id_from_prev_block(block_header.prev_hash())?;
         let next_protocol_version =
             self.epoch_manager.get_epoch_protocol_version(&next_epoch_id)?;
-        if !checked_feature!("stable", ChunkValidation, next_protocol_version) {
+        if !checked_feature!("stable", StatelessValidationV0, next_protocol_version) {
             // Chunk validation not enabled yet.
             return Ok(false);
         }

--- a/chain/client/src/stateless_validation/chunk_endorsement_tracker.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement_tracker.rs
@@ -96,7 +96,7 @@ impl ChunkEndorsementTracker {
         let epoch_id =
             self.epoch_manager.get_epoch_id_from_prev_block(chunk_header.prev_block_hash())?;
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
-        if !checked_feature!("stable", ChunkValidation, protocol_version) {
+        if !checked_feature!("stable", StatelessValidationV0, protocol_version) {
             // Return an empty array of chunk endorsements for older protocol versions.
             return Ok(Some(vec![]));
         }

--- a/chain/client/src/stateless_validation/state_witness_producer.rs
+++ b/chain/client/src/stateless_validation/state_witness_producer.rs
@@ -28,7 +28,7 @@ impl Client {
         transactions_storage_proof: Option<PartialState>,
     ) -> Result<(), Error> {
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(epoch_id)?;
-        if !checked_feature!("stable", ChunkValidation, protocol_version) {
+        if !checked_feature!("stable", StatelessValidationV0, protocol_version) {
             return Ok(());
         }
 

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -2686,7 +2686,7 @@ fn test_verify_chunk_endorsements() {
     use near_primitives::test_utils::create_test_signer;
     use std::str::FromStr;
 
-    if !checked_feature!("stable", ChunkValidation, PROTOCOL_VERSION) {
+    if !checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION) {
         println!("Test not applicable without ChunkValidation enabled");
         return;
     }
@@ -2753,7 +2753,7 @@ fn test_verify_chunk_state_witness() {
     use near_primitives::test_utils::create_test_signer;
     use std::str::FromStr;
 
-    if !checked_feature!("stable", ChunkValidation, PROTOCOL_VERSION) {
+    if !checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION) {
         println!("Test not applicable without ChunkValidation enabled");
         return;
     }

--- a/chain/epoch-manager/src/validator_selection.rs
+++ b/chain/epoch-manager/src/validator_selection.rs
@@ -179,7 +179,7 @@ pub fn proposals_to_epoch_info(
             .collect()
     };
 
-    let validator_mandates = if checked_feature!("stable", ChunkValidation, next_version) {
+    let validator_mandates = if checked_feature!("stable", StatelessValidationV0, next_version) {
         // TODO(#10014) determine required stake per mandate instead of reusing seat price.
         // TODO(#10014) determine `min_mandates_per_shard`
         let min_mandates_per_shard = 0;

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -126,9 +126,8 @@ pub enum ProtocolFeature {
     RestrictTla,
     /// Increases the number of chunk producers.
     TestnetFewerBlockProducers,
-    /// Enables chunk validation which is introduced with stateless validation.
-    /// NEP: https://github.com/near/NEPs/pull/509
-    ChunkValidation,
+    /// Enables stateless validation which is introduced in https://github.com/near/NEPs/pull/509
+    StatelessValidationV0,
     EthImplicitAccounts,
 }
 
@@ -178,7 +177,7 @@ impl ProtocolFeature {
             | ProtocolFeature::SimpleNightshadeV2 => 64,
 
             // StatelessNet features
-            ProtocolFeature::ChunkValidation => 80,
+            ProtocolFeature::StatelessValidationV0 => 80,
 
             // Nightly features
             #[cfg(feature = "protocol_feature_fix_staking_threshold")]

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -173,7 +173,7 @@ impl Block {
                 vrf_value: *body.vrf_value(),
                 vrf_proof: *body.vrf_proof(),
             }))
-        } else if !checked_feature!("stable", ChunkValidation, this_epoch_protocol_version) {
+        } else if !checked_feature!("stable", StatelessValidationV0, this_epoch_protocol_version) {
             // BlockV3 should only have BlockBodyV1
             match body {
                 BlockBody::V1(body) => Block::BlockV3(Arc::new(BlockV3 { header, body })),

--- a/core/primitives/src/block_body.rs
+++ b/core/primitives/src/block_body.rs
@@ -64,7 +64,7 @@ impl BlockBody {
         vrf_proof: Proof,
         chunk_endorsements: Vec<ChunkEndorsementSignatures>,
     ) -> Self {
-        if !checked_feature!("stable", ChunkValidation, protocol_version) {
+        if !checked_feature!("stable", StatelessValidationV0, protocol_version) {
             BlockBody::V1(BlockBodyV1 { chunks, challenges, vrf_value, vrf_proof })
         } else {
             BlockBody::V2(BlockBodyV2 {

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -703,7 +703,7 @@ pub mod epoch_info {
                 let block_producers_sampler = stake_weights(&block_producers_settlement);
                 let chunk_producers_sampler =
                     chunk_producers_settlement.iter().map(|vs| stake_weights(vs)).collect();
-                if checked_feature!("stable", ChunkValidation, protocol_version) {
+                if checked_feature!("stable", StatelessValidationV0, protocol_version) {
                     Self::V4(EpochInfoV4 {
                         epoch_height,
                         validators,

--- a/integration-tests/src/tests/client/chunks_management.rs
+++ b/integration-tests/src/tests/client/chunks_management.rs
@@ -35,7 +35,7 @@ struct Test {
 impl Test {
     fn run(self) {
         // TODO(#10506): Fix test to handle stateless validation
-        if checked_feature!("stable", ChunkValidation, PROTOCOL_VERSION) {
+        if checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION) {
             return;
         }
         heavy_test(move || run_actix(async move { self.run_impl() }))

--- a/integration-tests/src/tests/client/features/adversarial_behaviors.rs
+++ b/integration-tests/src/tests/client/features/adversarial_behaviors.rs
@@ -126,7 +126,7 @@ impl AdversarialBehaviorTestData {
 #[test]
 fn test_non_adversarial_case() {
     // TODO(#10506): Fix test to handle stateless validation
-    if checked_feature!("stable", ChunkValidation, PROTOCOL_VERSION) {
+    if checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION) {
         return;
     }
 
@@ -333,7 +333,7 @@ fn test_banning_chunk_producer_when_seeing_invalid_chunk_base(
 #[cfg(feature = "test_features")]
 fn test_banning_chunk_producer_when_seeing_invalid_chunk() {
     // TODO(#10506): Fix test to handle stateless validation
-    if checked_feature!("stable", ChunkValidation, PROTOCOL_VERSION) {
+    if checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION) {
         return;
     }
 
@@ -347,7 +347,7 @@ fn test_banning_chunk_producer_when_seeing_invalid_chunk() {
 #[cfg(feature = "test_features")]
 fn test_banning_chunk_producer_when_seeing_invalid_tx_in_chunk() {
     // TODO(#10506): Fix test to handle stateless validation
-    if checked_feature!("stable", ChunkValidation, PROTOCOL_VERSION) {
+    if checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION) {
         return;
     }
 

--- a/integration-tests/src/tests/client/features/in_memory_tries.rs
+++ b/integration-tests/src/tests/client/features/in_memory_tries.rs
@@ -27,7 +27,7 @@ const ONE_NEAR: u128 = 1_000_000_000_000_000_000_000_000;
 #[test]
 fn test_in_memory_trie_node_consistency() {
     // TODO(#10506): Fix test to handle stateless validation
-    if checked_feature!("stable", ChunkValidation, PROTOCOL_VERSION) {
+    if checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION) {
         return;
     }
 

--- a/integration-tests/src/tests/client/features/limit_contract_functions_number.rs
+++ b/integration-tests/src/tests/client/features/limit_contract_functions_number.rs
@@ -78,7 +78,7 @@ fn verify_contract_limits_upgrade(
 #[test]
 fn test_function_limit_change() {
     // TODO(#10506): Fix test to handle stateless validation
-    if checked_feature!("stable", ChunkValidation, PROTOCOL_VERSION) {
+    if checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION) {
         return;
     }
 

--- a/integration-tests/src/tests/client/features/stateless_validation.rs
+++ b/integration-tests/src/tests/client/features/stateless_validation.rs
@@ -28,8 +28,8 @@ const ONE_NEAR: u128 = 1_000_000_000_000_000_000_000_000;
 fn run_chunk_validation_test(seed: u64, prob_missing_chunk: f64) {
     init_integration_logger();
 
-    if !checked_feature!("stable", ChunkValidation, PROTOCOL_VERSION) {
-        println!("Test not applicable without ChunkValidation enabled");
+    if !checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION) {
+        println!("Test not applicable without StatelessValidation enabled");
         return;
     }
 

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -1257,7 +1257,7 @@ fn test_bad_orphan() {
 #[test]
 fn test_bad_chunk_mask() {
     // TODO(#10506): Fix test to handle stateless validation
-    if checked_feature!("stable", ChunkValidation, PROTOCOL_VERSION) {
+    if checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION) {
         return;
     }
 
@@ -2276,7 +2276,7 @@ fn test_block_height_processed_orphan() {
 #[test]
 fn test_validate_chunk_extra() {
     // TODO(#10506): Fix test to handle stateless validation
-    if checked_feature!("stable", ChunkValidation, PROTOCOL_VERSION) {
+    if checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION) {
         return;
     }
 


### PR DESCRIPTION
Originally discussed in [this comment](https://github.com/near/nearcore/pull/10522#discussion_r1469792827), I feel like renaming feature `ChunkValidation` to `StatelessValidationV0` makes sense. With subsequent releases, we can have `StatelessValidationV1` etc.

@wacban @robin-near, thoughts?