### PR TITLE
fix(resharding): delay deleting the snapshot until after catchup

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2990,6 +2990,10 @@ impl Chain {
             );
         }
 
+        // Nit: it would be more elegant to only call this after resharding, not
+        // after every state sync but it doesn't hurt.
+        self.process_snapshot_after_resharding()?;
+
         Ok(())
     }
 
@@ -3532,10 +3536,10 @@ impl Chain {
         Ok(())
     }
 
-    // Similar to `process_snapshot` but only called after resharding is done.
-    // This is to speed up the snapshot removal once resharding is finished in
-    // order to minimize the storage overhead.
-    pub fn process_snapshot_after_resharding(&mut self) -> Result<(), Error> {
+    // Similar to `process_snapshot` but only called after resharding and
+    // catchup is done. This is to speed up the snapshot removal once resharding
+    // is finished in order to minimize the storage overhead.
+    fn process_snapshot_after_resharding(&mut self) -> Result<(), Error> {
         let Some(snapshot_callbacks) = &self.snapshot_callbacks else { return Ok(()) };
 
         let tries = self.runtime_adapter.get_tries();

--- a/chain/client/src/sync/state.rs
+++ b/chain/client/src/sync/state.rs
@@ -768,7 +768,6 @@ impl StateSync {
         )?;
 
         if all_done {
-            chain.process_snapshot_after_resharding()?;
             Ok(StateSyncResult::Completed)
         } else {
             Ok(StateSyncResult::InProgress)


### PR DESCRIPTION
I haven't verified it but it seem that restarting the node during catchup does not resume the catchup but rather it restarts the whole resharding from scratch. While suboptimal I'm not aiming to fix that now. This PR merely moves the deletion of state snapshot to after catchup is finished. This way the restarted resharding can succeed. 