### PR TITLE
feat: emit state witness size metric as part of `send_chunk_state_witness_to_chunk_validators`

### DIFF
--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -2792,7 +2792,7 @@ fn test_verify_chunk_state_witness() {
         vec![],
         Default::default(),
     );
-    let signature = signer.sign_chunk_state_witness(&witness_inner);
+    let signature = signer.sign_chunk_state_witness(&witness_inner).0;
 
     // Check chunk state witness validity.
     let mut chunk_state_witness = ChunkStateWitness { inner: witness_inner, signature };
@@ -2804,6 +2804,7 @@ fn test_verify_chunk_state_witness() {
 
     // Check chunk state witness invalidity when signer is not a chunk validator.
     let bad_signer = Arc::new(create_test_signer("test2"));
-    chunk_state_witness.signature = bad_signer.sign_chunk_state_witness(&chunk_state_witness.inner);
+    chunk_state_witness.signature =
+        bad_signer.sign_chunk_state_witness(&chunk_state_witness.inner).0;
     assert!(!epoch_manager.verify_chunk_state_witness_signature(&chunk_state_witness).unwrap());
 }

--- a/core/primitives/src/validator_signer.rs
+++ b/core/primitives/src/validator_signer.rs
@@ -41,7 +41,8 @@ pub trait ValidatorSigner: Sync + Send {
     fn sign_chunk_endorsement(&self, inner: &ChunkEndorsementInner) -> Signature;
 
     /// Signs approval of the given chunk.
-    fn sign_chunk_state_witness(&self, inner: &ChunkStateWitnessInner) -> Signature;
+    /// Returns signature and a signed payload size in bytes
+    fn sign_chunk_state_witness(&self, inner: &ChunkStateWitnessInner) -> (Signature, usize);
 
     /// Signs challenge body.
     fn sign_challenge(&self, challenge_body: &ChallengeBody) -> (CryptoHash, Signature);
@@ -119,8 +120,8 @@ impl ValidatorSigner for EmptyValidatorSigner {
         Signature::default()
     }
 
-    fn sign_chunk_state_witness(&self, _inner: &ChunkStateWitnessInner) -> Signature {
-        Signature::default()
+    fn sign_chunk_state_witness(&self, _inner: &ChunkStateWitnessInner) -> (Signature, usize) {
+        (Signature::default(), 0)
     }
 
     fn sign_challenge(&self, challenge_body: &ChallengeBody) -> (CryptoHash, Signature) {
@@ -218,8 +219,9 @@ impl ValidatorSigner for InMemoryValidatorSigner {
         self.signer.sign(&borsh::to_vec(inner).unwrap())
     }
 
-    fn sign_chunk_state_witness(&self, inner: &ChunkStateWitnessInner) -> Signature {
-        self.signer.sign(&borsh::to_vec(inner).unwrap())
+    fn sign_chunk_state_witness(&self, inner: &ChunkStateWitnessInner) -> (Signature, usize) {
+        let data = borsh::to_vec(inner).unwrap();
+        (self.signer.sign(&data), data.len())
     }
 
     fn sign_challenge(&self, challenge_body: &ChallengeBody) -> (CryptoHash, Signature) {


### PR DESCRIPTION
We already serialise state witness in order to sign it, so this PR extends `sign_chunk_state_witness` to also return serialised data size and emits as `near_chunk_state_witness_total_size` metric (was added as part of shadow chunk validation in #10478).