### PR TITLE
feat: add gc for StateTransitionData

### DIFF
--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -586,6 +586,7 @@ impl<'a> ChainStoreUpdate<'a> {
             let block_shard_id = get_block_shard_id(&block_hash, shard_id);
             self.gc_outgoing_receipts(&block_hash, shard_id);
             self.gc_col(DBCol::IncomingReceipts, &block_shard_id);
+            self.gc_col(DBCol::StateTransitionData, &block_shard_id);
 
             // For incoming State Parts it's done in chain.clear_downloaded_parts()
             // The following code is mostly for outgoing State Parts.
@@ -686,6 +687,8 @@ impl<'a> ChainStoreUpdate<'a> {
             // delete Receipts
             self.gc_outgoing_receipts(&block_hash, shard_id);
             self.gc_col(DBCol::IncomingReceipts, &block_shard_id);
+
+            self.gc_col(DBCol::StateTransitionData, &block_shard_id);
 
             // delete DBCol::ChunkExtra based on shard_uid since it's indexed by shard_uid in the storage
             self.gc_col(DBCol::ChunkExtra, &block_shard_id);

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -456,6 +456,8 @@ impl DBCol {
             DBCol::ProcessedBlockHeights => false,
             // HeaderHashesByHeight is only needed for GC.
             DBCol::HeaderHashesByHeight => false,
+            // StateTransitionData is only needed to produce ChunkStateWitness
+            DBCol::StateTransitionData => false,
 
             // Columns that are not GC-ed need not be copied to the cold storage.
             DBCol::BlockHeader
@@ -483,8 +485,7 @@ impl DBCol {
             | DBCol::FlatState
             | DBCol::FlatStateChanges
             | DBCol::FlatStateDeltaMetadata
-            | DBCol::FlatStorageStatus
-            | DBCol::StateTransitionData => false,
+            | DBCol::FlatStorageStatus => false,
             #[cfg(feature = "new_epoch_sync")]
             DBCol::EpochSyncInfo => false
         }


### PR DESCRIPTION
My node running shadow chunk validation recently crashed with `IO error: No space left on device`.

RocksDB metrics over the last 7 days confirm that `StateTransitionData` caused that: 
<img width="749" alt="Screenshot 2024-02-01 at 15 24 06" src="https://github.com/near/nearcore/assets/3171838/242e2ea5-7dda-4658-a177-447dd291355b">

This PR makes `StateTransitionData` a part of block c collection.