### PR TITLE
Add a way to wait until a state witness is fully processed, which makes writing integration tests easier

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -2011,7 +2011,7 @@ impl Handler<WithSpanContext<ChunkStateWitnessMessage>> for ClientActor {
         let (_span, msg) = handler_debug_span!(target: "client", msg);
         let peer_id = msg.peer_id.clone();
         let attempts_remaining = msg.attempts_remaining;
-        match self.client.process_chunk_state_witness(msg.witness, msg.peer_id) {
+        match self.client.process_chunk_state_witness(msg.witness, msg.peer_id, None) {
             Err(err) => {
                 tracing::error!(target: "client", ?err, "Error processing chunk state witness");
             }

--- a/chain/client/src/stateless_validation/mod.rs
+++ b/chain/client/src/stateless_validation/mod.rs
@@ -1,4 +1,5 @@
 pub mod chunk_endorsement_tracker;
 pub mod chunk_validator;
+pub mod processing_tracker;
 mod shadow_validate;
 mod state_witness_producer;

--- a/chain/client/src/stateless_validation/processing_tracker.rs
+++ b/chain/client/src/stateless_validation/processing_tracker.rs
@@ -42,7 +42,7 @@ pub struct ProcessingDoneWaiter(Arc<OnceCell<()>>);
 impl ProcessingDoneWaiter {
     /// Wait until the processing is finished.
     pub fn wait(self) {
-        let _wait_res: &() = self.0.wait();
+        self.0.wait();
     }
 }
 

--- a/chain/client/src/stateless_validation/processing_tracker.rs
+++ b/chain/client/src/stateless_validation/processing_tracker.rs
@@ -1,0 +1,112 @@
+use std::sync::Arc;
+
+use once_cell::sync::OnceCell;
+
+/// `ProcessingDoneTracker` can be used in conjuction with a `ProcessingDoneWaiter`
+/// to wait until some processing is finished. `ProcessingDoneTracker` should be
+/// kept alive as long as the processing is ongoing, then once it's dropped,
+/// the paired `ProcessingDoneWaiter` will be notified that the processing has finished.\
+/// Does NOT implement `Clone`, if you want to clone it, wrap it in an `Arc`.
+pub struct ProcessingDoneTracker(Arc<OnceCell<()>>);
+
+impl ProcessingDoneTracker {
+    /// Create a new `ProcessingDoneTracker`
+    pub fn new() -> ProcessingDoneTracker {
+        ProcessingDoneTracker(Arc::new(OnceCell::new()))
+    }
+
+    /// Create a `ProcessingDoneWaiter` paired to this `ProcessingDoneTracker`.\
+    /// When this `ProcessingDoneTracker` is dropped, the paired waiter will be notified.
+    pub fn make_waiter(&self) -> ProcessingDoneWaiter {
+        ProcessingDoneWaiter(self.0.clone())
+    }
+}
+
+impl Drop for ProcessingDoneTracker {
+    fn drop(&mut self) {
+        // Set a value to notify waiters that the processing has finished.
+        //
+        // OnceCell::set() returns an Err when the cell already has a value.
+        // This should be impossible, as there's only one ProcessingDoneTracker
+        // that will set this value when dropped, so it's safe to unwrap() it.
+        self.0.set(()).unwrap();
+    }
+}
+
+/// `ProcessingDoneWaiter` is used to wait until the processing has finished.\
+/// The `wait()` method will block until the paired `ProcessingDoneTracker` is dropped.\
+/// A new instance of `ProcessingDoneWaiter` can be created by calling `ProcessingDoneTracker::make_waiter`.
+#[derive(Clone)]
+pub struct ProcessingDoneWaiter(Arc<OnceCell<()>>);
+
+impl ProcessingDoneWaiter {
+    /// Wait until the processing is finished.
+    pub fn wait(self) {
+        let _wait_res: &() = self.0.wait();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use super::ProcessingDoneTracker;
+
+    /// Basic test for `ProcessingDoneTracker` and `ProcessingDoneWaiter`.
+    /// Spawns a task on a separate thread and waits for it to finish
+    /// using a tracker and a waiter.
+    #[test]
+    fn test_processing_done() {
+        let shared_value: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+
+        let tracker = ProcessingDoneTracker::new();
+        let waiter = tracker.make_waiter();
+
+        let captured_shared_value = shared_value.clone();
+        std::thread::spawn(move || {
+            let _captured_tracker = tracker;
+            std::thread::sleep(Duration::from_millis(32));
+            captured_shared_value.store(true, Ordering::Relaxed);
+        });
+
+        waiter.wait();
+        assert_eq!(shared_value.load(Ordering::Relaxed), true);
+    }
+
+    /// Test that there can be multiple instances of `ProcessingDoneWaiter`.
+    #[test]
+    fn test_multiple_waiters() {
+        let shared_value: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+
+        let tracker = ProcessingDoneTracker::new();
+        let waiter1 = tracker.make_waiter();
+        let waiter2 = waiter1.clone();
+        let waiter3 = tracker.make_waiter();
+
+        let (results_sender, results_receiver) = std::sync::mpsc::channel();
+
+        // Sawn waiter tasks
+        for waiter in [waiter1, waiter2, waiter3] {
+            let cur_sender = results_sender.clone();
+            let cur_shared_value = shared_value.clone();
+            std::thread::spawn(move || {
+                waiter.wait();
+                let read_value = cur_shared_value.load(Ordering::Relaxed);
+                cur_sender.send(read_value).unwrap();
+            });
+        }
+
+        // Wait 32ms then set the shared_value to true
+        std::thread::sleep(Duration::from_millis(32));
+        shared_value.store(true, Ordering::Relaxed);
+        std::mem::drop(tracker);
+
+        // Check values that waiters read
+        for _ in 0..3 {
+            let waiter_value = results_receiver.recv().unwrap();
+            assert_eq!(waiter_value, true);
+        }
+    }
+}

--- a/chain/client/src/stateless_validation/processing_tracker.rs
+++ b/chain/client/src/stateless_validation/processing_tracker.rs
@@ -5,7 +5,7 @@ use once_cell::sync::OnceCell;
 /// `ProcessingDoneTracker` can be used in conjuction with a `ProcessingDoneWaiter`
 /// to wait until some processing is finished. `ProcessingDoneTracker` should be
 /// kept alive as long as the processing is ongoing, then once it's dropped,
-/// the paired `ProcessingDoneWaiter` will be notified that the processing has finished.\
+/// the paired `ProcessingDoneWaiter` will be notified that the processing has finished.
 /// Does NOT implement `Clone`, if you want to clone it, wrap it in an `Arc`.
 pub struct ProcessingDoneTracker(Arc<OnceCell<()>>);
 
@@ -15,7 +15,7 @@ impl ProcessingDoneTracker {
         ProcessingDoneTracker(Arc::new(OnceCell::new()))
     }
 
-    /// Create a `ProcessingDoneWaiter` paired to this `ProcessingDoneTracker`.\
+    /// Create a `ProcessingDoneWaiter` paired to this `ProcessingDoneTracker`.
     /// When this `ProcessingDoneTracker` is dropped, the paired waiter will be notified.
     pub fn make_waiter(&self) -> ProcessingDoneWaiter {
         ProcessingDoneWaiter(self.0.clone())
@@ -33,8 +33,8 @@ impl Drop for ProcessingDoneTracker {
     }
 }
 
-/// `ProcessingDoneWaiter` is used to wait until the processing has finished.\
-/// The `wait()` method will block until the paired `ProcessingDoneTracker` is dropped.\
+/// `ProcessingDoneWaiter` is used to wait until the processing has finished.
+/// The `wait()` method will block until the paired `ProcessingDoneTracker` is dropped.
 /// A new instance of `ProcessingDoneWaiter` can be created by calling `ProcessingDoneTracker::make_waiter`.
 #[derive(Clone)]
 pub struct ProcessingDoneWaiter(Arc<OnceCell<()>>);

--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -1,8 +1,11 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use crate::adapter::ProcessTxResponse;
+use crate::stateless_validation::processing_tracker::{
+    ProcessingDoneTracker, ProcessingDoneWaiter,
+};
 use crate::Client;
 use near_async::messaging::CanSend;
 use near_chain::test_utils::ValidatorSchedule;
@@ -23,7 +26,7 @@ use near_primitives::epoch_manager::RngSeed;
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
-use near_primitives::sharding::{ChunkHash, PartialEncodedChunk};
+use near_primitives::sharding::PartialEncodedChunk;
 use near_primitives::stateless_validation::ChunkStateWitness;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::transaction::{Action, FunctionCallAction, SignedTransaction};
@@ -38,8 +41,6 @@ use once_cell::sync::OnceCell;
 use super::setup::{setup_client_with_runtime, ShardsManagerAdapterForTest};
 use super::test_env_builder::TestEnvBuilder;
 use super::TEST_SEED;
-
-const CHUNK_ENDORSEMENTS_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// An environment for writing integration tests with multiple clients.
 /// This environment can simulate near nodes without network and it can be configured to use different runtimes.
@@ -63,9 +64,6 @@ pub struct StateWitnessPropagationOutput {
     /// Whether some propagated state witness includes two different post state
     /// roots.
     pub found_differing_post_state_root_due_to_state_transitions: bool,
-
-    /// All the account_ids that we've sent the chunk witness to.
-    pub chunk_hash_to_account_ids: HashMap<ChunkHash, HashSet<AccountId>>,
 }
 
 impl TestEnv {
@@ -286,12 +284,14 @@ impl TestEnv {
         post_state_roots.len() >= 2
     }
 
-    /// Triggers processing of all chunk state witnesses received by network.
+    /// Processes all state witnesses sent over the network. The function waits for the processing to finish,
+    /// so chunk endorsements are available immediately after this function returns.
     pub fn propagate_chunk_state_witnesses(&mut self) -> StateWitnessPropagationOutput {
         let mut output = StateWitnessPropagationOutput {
             found_differing_post_state_root_due_to_state_transitions: false,
-            chunk_hash_to_account_ids: HashMap::new(),
         };
+        let mut witness_processing_done_waiters: Vec<ProcessingDoneWaiter> = Vec::new();
+
         let network_adapters = self.network_adapters.clone();
         for network_adapter in network_adapters {
             network_adapter.handle_filtered(|request| match request {
@@ -301,11 +301,14 @@ impl TestEnv {
                 )) => {
                     // Process chunk state witness for each client.
                     for account_id in account_ids.iter() {
+                        let processing_done_tracker = ProcessingDoneTracker::new();
+                        witness_processing_done_waiters.push(processing_done_tracker.make_waiter());
+
                         self.client(account_id)
                             .process_chunk_state_witness(
                                 state_witness.clone(),
                                 PeerId::random(),
-                                None,
+                                Some(processing_done_tracker),
                             )
                             .unwrap();
                     }
@@ -316,66 +319,42 @@ impl TestEnv {
                             &state_witness,
                         );
 
-                    output.chunk_hash_to_account_ids.insert(
-                        state_witness.inner.chunk_header.chunk_hash(),
-                        account_ids.into_iter().collect(),
-                    );
                     None
                 }
                 _ => Some(request),
             });
         }
+
+        // Wait for all state witnesses to be processed before returning.
+        for processing_done_waiter in witness_processing_done_waiters {
+            processing_done_waiter.wait();
+        }
+
         output
     }
 
-    /// Waits for `CHUNK_ENDORSEMENTS_TIMEOUT` to receive chunk endorsement for the given chunk hashes.
-    /// Panics if it doesn't happen.
-    /// `chunk_hash_to_account_ids` maps hashes to the set of account ids that are expected to endorse the chunk.
-    /// Note that we need to wait here as the chunk state witness is processed asynchronously.
-    /// Block producers don't send endorsements to themselves, so we don't wait for endorsements
-    /// sent by `excluded_block_producer`.
-    pub fn wait_to_propagate_chunk_endorsements(
-        &mut self,
-        mut chunk_hash_to_account_ids: HashMap<ChunkHash, HashSet<AccountId>>,
-        excluded_block_producer: &AccountId,
-    ) {
+    pub fn propagate_chunk_endorsements(&mut self) {
+        // Clone the Vec to satisfy the borrow checker.
         let network_adapters = self.network_adapters.clone();
-        let timer = Instant::now();
+        for network_adapter in network_adapters {
+            network_adapter.handle_filtered(|request| match request {
+                PeerManagerMessageRequest::NetworkRequests(NetworkRequests::ChunkEndorsement(
+                    account_id,
+                    endorsement,
+                )) => {
+                    // Remove endorsement.account_id on receiving endorsement.
+                    self.client(&account_id).process_chunk_endorsement(endorsement).unwrap();
 
-        // Remove the account_id of excluded_block_producer, block producers don't send endorsements to themselves
-        for account_ids in chunk_hash_to_account_ids.values_mut() {
-            account_ids.remove(excluded_block_producer);
+                    None
+                }
+                _ => Some(request),
+            });
         }
+    }
 
-        loop {
-            for network_adapter in &network_adapters {
-                network_adapter.handle_filtered(|request| match request {
-                    PeerManagerMessageRequest::NetworkRequests(
-                        NetworkRequests::ChunkEndorsement(account_id, endorsement),
-                    ) => {
-                        // Remove endorsement.account_id on receiving endorsement.
-                        chunk_hash_to_account_ids
-                            .get_mut(endorsement.chunk_hash())
-                            .map(|entry| entry.remove(&endorsement.account_id));
-
-                        self.client(&account_id).process_chunk_endorsement(endorsement).unwrap();
-
-                        None
-                    }
-                    _ => Some(request),
-                });
-            }
-
-            // Check if we received all endorsements.
-            chunk_hash_to_account_ids.retain(|_, v| !v.is_empty());
-            if chunk_hash_to_account_ids.is_empty() {
-                return;
-            }
-            if timer.elapsed() > CHUNK_ENDORSEMENTS_TIMEOUT {
-                panic!("Missing chunk endorsements: {:?}", chunk_hash_to_account_ids);
-            }
-            std::thread::sleep(Duration::from_micros(100));
-        }
+    pub fn propagate_chunk_state_witnesses_and_endorsements(&mut self) {
+        self.propagate_chunk_state_witnesses();
+        self.propagate_chunk_endorsements();
     }
 
     pub fn send_money(&mut self, id: usize) -> ProcessTxResponse {

--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -342,7 +342,6 @@ impl TestEnv {
                     account_id,
                     endorsement,
                 )) => {
-                    // Remove endorsement.account_id on receiving endorsement.
                     self.client(&account_id).process_chunk_endorsement(endorsement).unwrap();
 
                     None

--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -302,7 +302,11 @@ impl TestEnv {
                     // Process chunk state witness for each client.
                     for account_id in account_ids.iter() {
                         self.client(account_id)
-                            .process_chunk_state_witness(state_witness.clone(), PeerId::random())
+                            .process_chunk_state_witness(
+                                state_witness.clone(),
+                                PeerId::random(),
+                                None,
+                            )
                             .unwrap();
                     }
 

--- a/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
@@ -768,13 +768,7 @@ fn test_chunk_forwarding_optimization() {
         test.env.process_shards_manager_responses(0);
 
         // Propagating state witnesses and chunk endorsements is required for block production
-        let output = test.env.propagate_chunk_state_witnesses();
-        let next_block_producer =
-            test.env.clients[0].validator_signer.as_ref().unwrap().validator_id().clone();
-        test.env.wait_to_propagate_chunk_endorsements(
-            output.chunk_hash_to_account_ids,
-            &next_block_producer,
-        );
+        test.env.propagate_chunk_state_witnesses_and_endorsements();
     }
 
     // With very high probability we should've encountered some cases where forwarded parts

--- a/integration-tests/src/tests/client/features/in_memory_tries.rs
+++ b/integration-tests/src/tests/client/features/in_memory_tries.rs
@@ -12,7 +12,6 @@ use near_primitives::test_utils::{create_test_signer, create_user_test_signer};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountInfo, EpochId};
 use near_primitives_core::account::{AccessKey, Account};
-use near_primitives_core::checked_feature;
 use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::AccountId;
 use near_primitives_core::version::PROTOCOL_VERSION;
@@ -26,11 +25,6 @@ const ONE_NEAR: u128 = 1_000_000_000_000_000_000_000_000;
 
 #[test]
 fn test_in_memory_trie_node_consistency() {
-    // TODO(#10506): Fix test to handle stateless validation
-    if checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION) {
-        return;
-    }
-
     // Recommended to run with RUST_LOG=memtrie=debug,chunks=error,info
     init_test_logger();
     let validator_stake = 1000000 * ONE_NEAR;
@@ -369,6 +363,7 @@ fn run_chain_for_some_blocks_while_sending_money_around(
         for j in 0..env.clients.len() {
             env.process_shards_manager_responses_and_finish_processing_blocks(j);
         }
+        env.propagate_chunk_state_witnesses_and_endorsements();
     }
 
     for (account, balance) in balances {

--- a/integration-tests/src/tests/client/features/stateless_validation.rs
+++ b/integration-tests/src/tests/client/features/stateless_validation.rs
@@ -188,17 +188,8 @@ fn run_chunk_validation_test(seed: u64, prob_missing_chunk: f64) {
             env.process_shards_manager_responses_and_finish_processing_blocks(j);
         }
 
-        // First propagate chunk state witnesses, then chunk endorsements.
-        // Note that validation of chunk state witness is done asynchonously
-        // which is why it's important to pass the expected set of chunk endorsements to wait for.
-        // We don't wait for endorsements from the next block producer, as block producers don't
-        // send endorsements to themselves.
         let output = env.propagate_chunk_state_witnesses();
-        let next_block_producer = get_block_producer(&env, &tip, 2);
-        env.wait_to_propagate_chunk_endorsements(
-            output.chunk_hash_to_account_ids,
-            &next_block_producer,
-        );
+        env.propagate_chunk_endorsements();
 
         found_differing_post_state_root_due_to_state_transitions |=
             output.found_differing_post_state_root_due_to_state_transitions;


### PR DESCRIPTION
State witnesses are processed asynchronously - a task is spawned on a separate thread, which validates the state witness and then sends out chunk endorsements. Currently there's no way to directly wait for this processing to finish, one can only wait for the chunk endorsements to appear. This makes writing integration tests difficult. Let's add a way to wait for the processing to finish, which will make writing the tests easier.

Details:
There's no network stack in integration tests, all messages are passed around manually. We first propagate all state witness messages, which starts their processing in the background, but then we have to wait for this processing to finish before propagating chunk endorsements. As there's no way to wait for it, we have to do tricky things. The current approach is to
define the set of expected chunk endorsements that should appear, and then wait for the right endorsement messages to be sent out. This approach has some limitations - it's often hard to figure out which endorsements should be sent out exactly, as the tests create various strange scenarios - missing chunks, blocks, forks, etc... It requires a lot of manual work to fully understand the test and prepare the right set. It's also quite fragile, any change in chunk endorsements (e.g not sending them to ourselves) will break all the tests.
Adding the ability to wait for witness processing to finish greatly simplifies things. We can just pass around witnesses, wait for them to finish, and then propagate the generated endorsements. Without defining any expected sets to wait for.
As an example of the benefits offered by this solution, compare the fix in https://github.com/near/nearcore/pull/10537 to the one added in this PR. The one in https://github.com/near/nearcore/pull/10537 is much more complex and fragile.

I saw that there is also a thing called `ChunkEndorsementTracker`, which tracks what chunk endorsements were sent out, but IMO it's a different thing from `ProcessingDoneTracker`. We were already able to track which endorsements are sent out in the tests, but that didn't make writing tests easier. Additionally, in some tests we send out  invalid chunks, which wouldn't produce any endorsements at all, so we couldn't wait for them.

Refs: https://github.com/near/nearcore/issues/10506, https://github.com/near/nearcore/pull/10537, [zulip conversation](https://near.zulipchat.com/#narrow/stream/407237-pagoda.2Fcore.2Fstateless-validation/topic/A.20way.20to.20wait.20for.20state.20witness.20processing.20to.20finish/near/419062119)