### PR TITLE
Enable some integration tests that were disabled because of stateless validation

### DIFF
--- a/integration-tests/src/tests/client/chunks_management.rs
+++ b/integration-tests/src/tests/client/chunks_management.rs
@@ -17,8 +17,6 @@ use near_o11y::WithSpanContextExt;
 use near_primitives::hash::CryptoHash;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::AccountId;
-use near_primitives_core::checked_feature;
-use near_primitives_core::version::PROTOCOL_VERSION;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
@@ -34,10 +32,6 @@ struct Test {
 
 impl Test {
     fn run(self) {
-        // TODO(#10506): Fix test to handle stateless validation
-        if checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION) {
-            return;
-        }
         heavy_test(move || run_actix(async move { self.run_impl() }))
     }
 

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -66,7 +66,6 @@ use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{
     BlockHeaderView, FinalExecutionStatus, QueryRequest, QueryResponseKind,
 };
-use near_primitives_core::checked_feature;
 use near_primitives_core::num_rational::{Ratio, Rational32};
 use near_primitives_core::types::ShardId;
 use near_store::cold_storage::{update_cold_db, update_cold_head};
@@ -2270,11 +2269,6 @@ fn test_block_height_processed_orphan() {
 
 #[test]
 fn test_validate_chunk_extra() {
-    // TODO(#10506): Fix test to handle stateless validation
-    if checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION) {
-        return;
-    }
-
     let mut capture = near_o11y::testonly::TracingCapture::enable();
 
     let epoch_length = 5;

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -1256,11 +1256,6 @@ fn test_bad_orphan() {
 
 #[test]
 fn test_bad_chunk_mask() {
-    // TODO(#10506): Fix test to handle stateless validation
-    if checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION) {
-        return;
-    }
-
     init_test_logger();
     let chain_genesis = ChainGenesis::test();
     let validators = vec!["test0".parse().unwrap(), "test1".parse().unwrap()];


### PR DESCRIPTION
A few tests were disabled because they broke when stateless validation was enabled.
It turns out that some of them are passing now, so we can enable them again.

I didn't need to make any changes to these tests, they seem to work fine as is.

Refs: https://github.com/near/nearcore/issues/10506