### PR TITLE
fix: make adversarial_behaviors tests pass with stateless validation

### DIFF
--- a/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
@@ -768,7 +768,7 @@ fn test_chunk_forwarding_optimization() {
         test.env.process_shards_manager_responses(0);
 
         // Propagating state witnesses and chunk endorsements is required for block production
-        test.env.propagate_chunk_state_witnesses_and_endorsements();
+        test.env.propagate_chunk_state_witnesses_and_endorsements(false);
     }
 
     // With very high probability we should've encountered some cases where forwarded parts

--- a/integration-tests/src/tests/client/features/adversarial_behaviors.rs
+++ b/integration-tests/src/tests/client/features/adversarial_behaviors.rs
@@ -119,11 +119,6 @@ impl AdversarialBehaviorTestData {
 
 #[test]
 fn test_non_adversarial_case() {
-    // TODO(#10506): Fix test to handle stateless validation
-    if checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION) {
-        return;
-    }
-
     init_test_logger();
     let mut test = AdversarialBehaviorTestData::new();
     let epoch_manager = test.env.clients[0].epoch_manager.clone();
@@ -180,6 +175,9 @@ fn test_non_adversarial_case() {
             assert_eq!(&accepted_blocks[0], block.header().hash());
             assert_eq!(test.env.clients[i].chain.head().unwrap().height, height);
         }
+
+        test.process_all_actor_messages();
+        test.env.propagate_chunk_state_witnesses_and_endorsements(false);
     }
 
     // Sanity check that the final chain head is what we expect

--- a/integration-tests/src/tests/client/features/adversarial_behaviors.rs
+++ b/integration-tests/src/tests/client/features/adversarial_behaviors.rs
@@ -249,8 +249,11 @@ fn test_banning_chunk_producer_when_seeing_invalid_chunk_base(
                         if uses_stateless_validation {
                             // With stateless validation the block usually isn't skipped. Chunk validators
                             // won't send chunk endorsements for this chunk, which means that it won't be
-                            // included in the block at all. The only exception is the first few blocks,
-                            // which still use the old protocol. In this test the block with height 2 is skipped.
+                            // included in the block at all. The only exception is the first few blocks after
+                            // genesis, which are currently handled in a special way.
+                            // In this test the block with height 2 is skipped.
+                            // TODO(#10502): Properly handle blocks right after genesis, ideally no blocks
+                            // would be skipped when using stateless validation.
                             this_block_should_be_skipped = height < 3;
                         } else {
                             // In the old protocol, chunks are first included in the block and then the block

--- a/integration-tests/src/tests/client/features/in_memory_tries.rs
+++ b/integration-tests/src/tests/client/features/in_memory_tries.rs
@@ -363,7 +363,7 @@ fn run_chain_for_some_blocks_while_sending_money_around(
         for j in 0..env.clients.len() {
             env.process_shards_manager_responses_and_finish_processing_blocks(j);
         }
-        env.propagate_chunk_state_witnesses_and_endorsements();
+        env.propagate_chunk_state_witnesses_and_endorsements(false);
     }
 
     for (account, balance) in balances {

--- a/integration-tests/src/tests/client/features/stateless_validation.rs
+++ b/integration-tests/src/tests/client/features/stateless_validation.rs
@@ -188,8 +188,8 @@ fn run_chunk_validation_test(seed: u64, prob_missing_chunk: f64) {
             env.process_shards_manager_responses_and_finish_processing_blocks(j);
         }
 
-        let output = env.propagate_chunk_state_witnesses();
-        env.propagate_chunk_endorsements();
+        let output = env.propagate_chunk_state_witnesses(false);
+        env.propagate_chunk_endorsements(false);
 
         found_differing_post_state_root_due_to_state_transitions |=
             output.found_differing_post_state_root_due_to_state_transitions;


### PR DESCRIPTION
## Description
The tests in `adversarial_behaviors.rs` didn't work with stateless validation, let's make them pass again.
To achieve this we first need to propagate chunk state witnesses and endorsements, and then adjust the expected behavior to match the one exhibited by stateless validation. 

The most complex part of this PR is modifying which blocks should be skipped in `test_banning_chunk_producer_when_seeing_invalid_chunk_base()`.
This function creates a blockchain with one malicious chunk producer and runs it for a few epochs. 
Which blocks will be skipped depends on whether we are using stateless validation or not.

### Without stateless validation
In the old version of the protocol the invalid chunk is included in a block and then the whole block is validated. The chunk is invalid, so the whole block is also invalid and the block should be skipped. After that the malicious chunk producer is banned for the rest of the epoch, which means that block producers will reject chunks sent by this chunk producer, so the subsequent blocks won't contain any invalid chunks and won't be skipped.
Only the first block with invalid chunks in an epoch should be skipped. 

### With stateless validation
With stateless validation the situation is entirely different. When the malicious chunk producer produces an invalid chunk, chunk validators will refuse to send out endorsements for this chunk, so the chunk won't be included in any block. This means that no blocks should be skipped.

There is one exception - in the test the block produced at height 2 is invalid and gets skipped. I suspect that this is because the first few blocks after genesis don't use stateless validation, and they are still handled by old protocol. I'm not 100% sure if that's the case, @Longarithm could you confirm that this explanation makes sense?
Something is definitely different  for the first few blocks, in the logs I can see `client: Banning chunk producer for producing invalid` at height 2, which seems to belong to the old protocol. In the new version malicious chunk producers are banned using `BanPeer`, without any log messages.

Refs: https://github.com/near/nearcore/issues/10506, [zulip discussion](https://near.zulipchat.com/#narrow/stream/295558-pagoda.2Fcore/topic/Skipping.20the.20first.20block.20with.20missing.20chunks.20in.20an.20epoch.3F/near/419838610)