### PR TITLE
fix: compute chunk signatures once

### DIFF
--- a/chain/client/src/chunk_inclusion_tracker.rs
+++ b/chain/client/src/chunk_inclusion_tracker.rs
@@ -21,20 +21,7 @@ struct ChunkInfo {
     pub chunk_header: ShardChunkHeader,
     pub received_time: DateTime<Utc>,
     pub chunk_producer: AccountId,
-    pub signatures: ChunkInfoSignaturesState,
-}
-
-impl ChunkInfo {
-    fn has_chunk_endorsements(&self) -> bool {
-        matches!(self.signatures, ChunkInfoSignaturesState::Some(_))
-    }
-}
-
-#[derive(Clone)]
-enum ChunkInfoSignaturesState {
-    NotComputed,
-    None,
-    Some(ChunkEndorsementSignatures),
+    pub signatures: Option<ChunkEndorsementSignatures>,
 }
 
 pub struct ChunkInclusionTracker {
@@ -84,12 +71,8 @@ impl ChunkInclusionTracker {
         }
         // Insert chunk info in chunk_hash_to_chunk_info. This would be cleaned up later during eviction
         let chunk_hash = chunk_header.chunk_hash();
-        let chunk_info = ChunkInfo {
-            chunk_header,
-            received_time: Utc::now(),
-            chunk_producer,
-            signatures: ChunkInfoSignaturesState::NotComputed,
-        };
+        let chunk_info =
+            ChunkInfo { chunk_header, received_time: Utc::now(), chunk_producer, signatures: None };
         self.chunk_hash_to_chunk_info.insert(chunk_hash, chunk_info);
     }
 
@@ -118,14 +101,8 @@ impl ChunkInclusionTracker {
 
         for chunk_hash in entry.values() {
             let chunk_info = self.chunk_hash_to_chunk_info.get_mut(chunk_hash).unwrap();
-            if matches!(chunk_info.signatures, ChunkInfoSignaturesState::NotComputed) {
-                chunk_info.signatures = match endorsement_tracker
-                    .get_chunk_endorsement_signatures(&chunk_info.chunk_header)?
-                {
-                    Some(signatures) => ChunkInfoSignaturesState::Some(signatures),
-                    None => ChunkInfoSignaturesState::None,
-                };
-            }
+            chunk_info.signatures =
+                endorsement_tracker.get_chunk_endorsement_signatures(&chunk_info.chunk_header)?;
         }
         Ok(())
     }
@@ -145,6 +122,18 @@ impl ChunkInclusionTracker {
         banned
     }
 
+    fn has_chunk_endorsements(&self, chunk_info: &ChunkInfo) -> bool {
+        let has_chunk_endorsements = chunk_info.signatures.is_some();
+        if !has_chunk_endorsements {
+            tracing::warn!(
+                target: "client",
+                chunk_hash = ?chunk_info.chunk_header.chunk_hash(),
+                chunk_producer = ?chunk_info.chunk_producer,
+                "Not including chunk because of insufficient chunk endorsements");
+        }
+        has_chunk_endorsements
+    }
+
     /// Function to return the chunks that are ready to be included in a block.
     /// We filter out the chunks that are produced by banned chunk producers or have insufficient
     /// chunk validator endorsements.
@@ -162,14 +151,7 @@ impl ChunkInclusionTracker {
         for (shard_id, chunk_hash) in entry {
             let chunk_info = self.chunk_hash_to_chunk_info.get(chunk_hash).unwrap();
             let banned = self.is_banned(epoch_id, &chunk_info);
-            let has_chunk_endorsements = chunk_info.has_chunk_endorsements();
-            if !has_chunk_endorsements {
-                tracing::warn!(
-                    target: "client",
-                    chunk_hash = ?chunk_info.chunk_header.chunk_hash(),
-                    chunk_producer = ?chunk_info.chunk_producer,
-                    "Not including chunk because of insufficient chunk endorsements");
-            }
+            let has_chunk_endorsements = self.has_chunk_endorsements(&chunk_info);
             if !banned && has_chunk_endorsements {
                 // only add to chunk_headers_ready_for_inclusion if chunk is not from a banned chunk producer
                 // and chunk has sufficient chunk endorsements.
@@ -209,10 +191,7 @@ impl ChunkInclusionTracker {
     ) -> Result<(ShardChunkHeader, ChunkEndorsementSignatures), Error> {
         let chunk_info = self.get_chunk_info(chunk_hash)?;
         let chunk_header = chunk_info.chunk_header.clone();
-        let signatures = match chunk_info.signatures {
-            ChunkInfoSignaturesState::NotComputed | ChunkInfoSignaturesState::None => vec![],
-            ChunkInfoSignaturesState::Some(ref signatures) => signatures.clone(),
-        };
+        let signatures = chunk_info.signatures.clone().unwrap_or_default();
         Ok((chunk_header, signatures))
     }
 

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1269,7 +1269,7 @@ impl ClientActor {
     /// Can return error, should be called with `produce_block` to handle errors and reschedule.
     fn produce_block(&mut self, next_height: BlockHeight) -> Result<(), Error> {
         let _span = tracing::debug_span!(target: "client", "produce_block", next_height).entered();
-        if let Some(block) = self.client.produce_block(next_height)? {
+        if let Some(block) = self.client.produce_block_on_head(next_height, false)? {
             // If we produced the block, send it out before we apply the block.
             self.network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
                 NetworkRequests::Block { block: block.clone() },


### PR DESCRIPTION
Currently `prepare_chunk_headers_ready_for_inclusion` is called twice when producing a block:
* directly as part of `ClientActor::handle_block_production` 
* `ClientActor::handle_block_production`  -> `ClientActor::produce_block` -> `Client::produce_block`

This results in endorsement metrics (see #10533) emitted twice.
This PR fixes it by adding `produce_block_on_head` with `prepare_chunk_headers` argument to avoid calling `prepare_chunk_headers_ready_for_inclusion` from `ClientActor` while still calling it from the tests.