### PR TITLE
emergency fix and tooling to save split archival nodes in testnet resharding 

### DIFF
--- a/core/store/src/opener.rs
+++ b/core/store/src/opener.rs
@@ -39,8 +39,8 @@ pub enum StoreOpenerError {
     /// Specifically, this happens if node is running with a single database and
     /// its kind is not RPC or Archive; or it’s running with two databases and
     /// their types aren’t Hot and Cold respectively.
-    #[error("{which} database kind should be {want} but got {got:?}. Did you forget to set archive on your store opener?")]
-    DbKindMismatch { which: &'static str, got: Option<DbKind>, want: DbKind },
+    // #[error("{which} database kind should be {want} but got {got:?}. Did you forget to set archive on your store opener?")]
+    // DbKindMismatch { which: &'static str, got: Option<DbKind>, want: DbKind },
 
     /// Unable to create a migration snapshot because one already exists.
     #[error(
@@ -364,16 +364,20 @@ impl<'a> StoreOpener<'a> {
 
         let current_kind = store.get_db_kind()?;
         let default_kind = get_default_kind(archive, temp);
-        let err =
-            Err(StoreOpenerError::DbKindMismatch { which, got: current_kind, want: default_kind });
+        // let err =
+        //     Err(StoreOpenerError::DbKindMismatch { which, got: current_kind, want: default_kind });
 
         // If kind is set check if it's the expected one.
         if let Some(current_kind) = current_kind {
             if !is_valid_kind_temp(current_kind, temp) {
-                return err;
+                tracing::info!(target: "db_opener", "ignoring mismatching kind temperature");
+                return Ok(());
+                // return err;
             }
             if !is_valid_kind_archive(current_kind, archive) {
-                return err;
+                tracing::info!(target: "db_opener", "ignoring mismatching kind archive");
+                return Ok(());
+                // return err;
             }
             return Ok(());
         }
@@ -386,7 +390,8 @@ impl<'a> StoreOpener<'a> {
             return Ok(());
         }
 
-        return err;
+        Ok(())
+        // return err;
     }
 
     /// Ensures that the db has the correct - most recent - version. If the

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -104,13 +104,13 @@ pub fn open_storage(home_dir: &Path, near_config: &mut NearConfig) -> anyhow::Re
         Err(err @ StoreOpenerError::HotColdVersionMismatch { .. }) => {
             Err(anyhow::anyhow!("{err}"))
         },
-        Err(StoreOpenerError::DbKindMismatch { which, got, want }) => {
-            Err(if let Some(got) = got {
-                anyhow::anyhow!("{which} database kind should be {want} but got {got}")
-            } else {
-                anyhow::anyhow!("{which} database kind should be {want} but none was set")
-            })
-        }
+        // Err(StoreOpenerError::DbKindMismatch { which, got, want }) => {
+        //     Err(if let Some(got) = got {
+        //         anyhow::anyhow!("{which} database kind should be {want} but got {got}")
+        //     } else {
+        //         anyhow::anyhow!("{which} database kind should be {want} but none was set")
+        //     })
+        // }
         Err(StoreOpenerError::SnapshotAlreadyExists(snap_path)) => {
             Err(anyhow::anyhow!(
                 "Detected an existing database migration snapshot at ‘{}’.\n\

--- a/tools/database/src/commands.rs
+++ b/tools/database/src/commands.rs
@@ -7,6 +7,7 @@ use crate::make_snapshot::MakeSnapshotCommand;
 use crate::memtrie::LoadMemTrieCommand;
 use crate::run_migrations::RunMigrationsCommand;
 use crate::state_perf::StatePerfCommand;
+use crate::write_to_db::WriteCryptoHashCommand;
 use clap::Parser;
 use std::path::PathBuf;
 
@@ -46,6 +47,9 @@ enum SubCommand {
 
     /// Loads an in-memory trie for research purposes.
     LoadMemTrie(LoadMemTrieCommand),
+
+    /// Write CryptoHash to DB
+    WriteCryptoHash(WriteCryptoHashCommand),
 }
 
 impl DatabaseCommand {
@@ -74,6 +78,7 @@ impl DatabaseCommand {
                 .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
                 cmd.run(near_config, home)
             }
+            SubCommand::WriteCryptoHash(cmd) => cmd.run(home),
         }
     }
 }

--- a/tools/database/src/lib.rs
+++ b/tools/database/src/lib.rs
@@ -10,3 +10,4 @@ mod memtrie;
 mod run_migrations;
 mod state_perf;
 mod utils;
+mod write_to_db;

--- a/tools/database/src/write_to_db.rs
+++ b/tools/database/src/write_to_db.rs
@@ -1,0 +1,29 @@
+use near_store::{DBCol, NodeStorage};
+use std::path::Path;
+
+#[derive(clap::Args)]
+pub(crate) struct WriteCryptoHashCommand {
+    #[clap(long)]
+    hash: near_primitives::hash::CryptoHash,
+}
+
+impl WriteCryptoHashCommand {
+    pub(crate) fn run(&self, home_dir: &Path) -> anyhow::Result<()> {
+        let near_config = nearcore::config::load_config(
+            &home_dir,
+            near_chain_configs::GenesisValidationMode::UnsafeFast,
+        )?;
+        let opener = NodeStorage::opener(
+            home_dir,
+            near_config.config.archive,
+            &near_config.config.store,
+            near_config.config.cold_store.as_ref(),
+        );
+
+        let storage = opener.open()?;
+        let store = storage.get_hot_store();
+        let mut store_update = store.store_update();
+        store_update.set_ser(DBCol::BlockMisc, near_store::STATE_SNAPSHOT_KEY, &self.hash)?;
+        Ok(store_update.commit()?)
+    }
+}


### PR DESCRIPTION
* disable the db opener check
* subcommand to set the snapshot manually