### PR TITLE
test: add a test for self-call delay via x-contract calls

### DIFF
--- a/integration-tests/src/tests/runtime/test_evil_contracts.rs
+++ b/integration-tests/src/tests/runtime/test_evil_contracts.rs
@@ -85,6 +85,23 @@ fn test_evil_deep_trie() {
 }
 
 #[test]
+fn test_self_delay() {
+    let node = setup_test_contract(near_test_contracts::nightly_rs_contract());
+    let res = node
+        .user()
+        .function_call(
+            "alice.near".parse().unwrap(),
+            "test_contract".parse().unwrap(),
+            "max_self_recursion_delay",
+            vec![0; 4],
+            MAX_GAS,
+            0,
+        )
+        .unwrap();
+    assert_eq!(res.status, FinalExecutionStatus::SuccessValue(vec![0, 0, 0, 61]), "{:?}", res);
+}
+
+#[test]
 fn test_evil_deep_recursion() {
     let node = setup_test_contract(near_test_contracts::rs_contract());
     for n in [100u64, 1000, 10000, 100000, 1000000] {

--- a/integration-tests/src/tests/runtime/test_evil_contracts.rs
+++ b/integration-tests/src/tests/runtime/test_evil_contracts.rs
@@ -84,6 +84,12 @@ fn test_evil_deep_trie() {
     }
 }
 
+/// Test delaying the conclusion of a receipt for as long as possible through the use of self
+/// cross-contract calls.
+///
+/// I hear that the protocol-level limit on the depth here is 64, so given the current fee
+/// structure this limit cannot be reached by this contract, but once they decrease it might very
+/// well be necessary to adjust the `expected_max_depth` to at most that limit.
 #[test]
 fn test_self_delay() {
     let node = setup_test_contract(near_test_contracts::nightly_rs_contract());
@@ -98,7 +104,12 @@ fn test_self_delay() {
             0,
         )
         .unwrap();
-    assert_eq!(res.status, FinalExecutionStatus::SuccessValue(vec![0, 0, 0, 61]), "{:?}", res);
+    let expected_max_depth = 61u32;
+    assert_eq!(
+        res.status,
+        FinalExecutionStatus::SuccessValue(expected_max_depth.to_be_bytes().to_vec()),
+        "{res:?} has not recursed the expected number of times",
+    );
 }
 
 #[test]

--- a/runtime/near-test-contracts/test-contract-rs/src/lib.rs
+++ b/runtime/near-test-contracts/test-contract-rs/src/lib.rs
@@ -613,6 +613,12 @@ pub fn from_base64(s: &str) -> Vec<u8> {
     base64::Engine::decode(engine, s).unwrap()
 }
 
+/// Delay completion of the receipt for as long as possible through self cross-contract calls.
+///
+/// This contract keeps the recursion depth and returns it when less than 5Tgas remains, which is
+/// most likely is no longer sufficient for another cross-contract call.
+///
+/// This is a stable alternative to yield/resume proposal at the time of writing.
 #[no_mangle]
 pub unsafe fn max_self_recursion_delay() {
     input(0);

--- a/runtime/near-test-contracts/test-contract-rs/src/lib.rs
+++ b/runtime/near-test-contracts/test-contract-rs/src/lib.rs
@@ -614,6 +614,36 @@ pub fn from_base64(s: &str) -> Vec<u8> {
 }
 
 #[no_mangle]
+pub unsafe fn max_self_recursion_delay() {
+    input(0);
+    let bytes = [0u8; 4];
+    read_register(0, bytes.as_ptr() as *const u64 as u64);
+    let recursion = u32::from_be_bytes(bytes);
+    let available_gas = prepaid_gas() - used_gas();
+    if available_gas < 5_000_000_000_000 {
+        return value_return(4, bytes.as_ptr() as u64);
+    }
+    current_account_id(1);
+    let method_name = "max_self_recursion_delay";
+    let promise_idx = promise_batch_create(u64::MAX, 1);
+    let amount = 1u128;
+    let gas_fixed = 0;
+    let gas_weight = 1;
+    let argument_bytes = recursion.saturating_add(1).to_be_bytes();
+    promise_batch_action_function_call_weight(
+        promise_idx,
+        method_name.len() as u64,
+        method_name.as_ptr() as u64,
+        argument_bytes.len() as u64,
+        argument_bytes.as_ptr() as u64,
+        &amount as *const u128 as u64,
+        gas_fixed,
+        gas_weight,
+    );
+    promise_return(promise_idx);
+}
+
+#[no_mangle]
 fn call_promise() {
     unsafe {
         input(0);


### PR DESCRIPTION
A very minimal test I wrote to check just how deep can we go with calling self to delay completion of a receipt.