### PR TITLE
[Chunk Endorsement] Use partial chunk to get header instead of full chunk

### DIFF
--- a/chain/client/src/stateless_validation/chunk_endorsement_tracker.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement_tracker.rs
@@ -35,9 +35,11 @@ impl Client {
         &mut self,
         endorsement: ChunkEndorsement,
     ) -> Result<(), Error> {
-        // We should not need whole chunk ready here, we only need chunk header.
-        match
-            self.chain.chain_store().get_partial_chunk(endorsement.chunk_hash()) {
+        // We need the chunk header in order to process the chunk endorsement.
+        // If we don't have the header, then queue it up for when we do have the header.
+        // We must use the partial chunk (as opposed to the full chunk) in order to get
+        // the chunk header, because we may not be tracking that shard.
+        match self.chain.chain_store().get_partial_chunk(endorsement.chunk_hash()) {
             Ok(chunk) => self
                 .chunk_endorsement_tracker
                 .process_chunk_endorsement(&chunk.cloned_header(), endorsement),

--- a/chain/client/src/stateless_validation/chunk_endorsement_tracker.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement_tracker.rs
@@ -1,4 +1,5 @@
 use near_cache::SyncLruCache;
+use near_chain::ChainStoreAccess;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -35,7 +36,8 @@ impl Client {
         endorsement: ChunkEndorsement,
     ) -> Result<(), Error> {
         // We should not need whole chunk ready here, we only need chunk header.
-        match self.chain.get_chunk(endorsement.chunk_hash()) {
+        match
+            self.chain.chain_store().get_partial_chunk(endorsement.chunk_hash()) {
             Ok(chunk) => self
                 .chunk_endorsement_tracker
                 .process_chunk_endorsement(&chunk.cloned_header(), endorsement),


### PR DESCRIPTION
Testing is pending. It's not very easy because ShardsManager right now still forwards all parts to all block producers.