### PR TITLE
fix(resharding) - disable nightly nayduck tests

### DIFF
--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -147,12 +147,15 @@ pytest sanity/meta_tx.py --features nightly
 pytest --timeout=600 sanity/split_storage.py
 pytest --timeout=600 sanity/split_storage.py --features nightly
 
-# Test for resharding
+# Tests for resharding
 pytest --timeout=120 sanity/resharding.py
-pytest --timeout=120 sanity/resharding.py --features nightly
-pytest --timeout=120 sanity/resharding_error_handling.py
-pytest --timeout=120 sanity/resharding_error_handling.py --features nightly
 pytest --timeout=120 sanity/resharding_rpc_tx.py
-pytest --timeout=120 sanity/resharding_rpc_tx.py --features nightly
 pytest --timeout=120 sanity/resharding_restart.py
-pytest --timeout=120 sanity/resharding_restart.py --features nightly
+pytest --timeout=120 sanity/resharding_error_handling.py
+
+# Tests for resharding in nightly are disabled because resharding is not
+# compatible with stateless validation. 
+# pytest --timeout=120 sanity/resharding.py --features nightly
+# pytest --timeout=120 sanity/resharding_rpc_tx.py --features nightly
+# pytest --timeout=120 sanity/resharding_restart.py --features nightly
+# pytest --timeout=120 sanity/resharding_error_handling.py --features nightly


### PR DESCRIPTION
Stateless Validation is enabled in nightly and it breaks the resharding tests. This PR disabled those tests in nightly. 

sample output:
```
2024-02-07T13:49:51.368919Z  INFO network: ed25519:FXXrTXiKWpXj1R6r5fBvMLpstd8gPyrBq3qMByqKVzKF: Peer Some(ed25519:He7QeRuwizNEhBioYG3u4DZ8jWXyETiyNzFD3MkTjDMf@127.0.0.1:24577) disconnected, reason: peer banned: BadChunkStateWitness
```
Then the validators refuse to talk to each other stop producing blocks and the tests timeouts. 