### PR TITLE
fix(nayduck) - update test names after refactoring

### DIFF
--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -113,18 +113,18 @@ expensive integration-tests integration_tests tests::standard_cases::rpc::test_u
 expensive integration-tests integration_tests tests::standard_cases::rpc::test_upload_contract_testnet --features nightly
 
 # GC tests
-expensive --timeout=900 near-chain near_chain tests::gc::test_gc_remove_fork_large
-expensive --timeout=900 near-chain near_chain tests::gc::test_gc_remove_fork_large --features nightly
-expensive --timeout=1200 near-chain near_chain tests::gc::test_gc_not_remove_fork_large
-expensive --timeout=1200 near-chain near_chain tests::gc::test_gc_not_remove_fork_large --features nightly
-expensive --timeout=1200 near-chain near_chain tests::gc::test_gc_boundaries_large
-expensive --timeout=1200 near-chain near_chain tests::gc::test_gc_boundaries_large --features nightly
-expensive --timeout=900 near-chain near_chain tests::gc::test_gc_random_large
-expensive --timeout=900 near-chain near_chain tests::gc::test_gc_random_large --features nightly
-expensive --timeout=600 near-chain near_chain tests::gc::test_gc_pine
-expensive --timeout=600 near-chain near_chain tests::gc::test_gc_pine --features nightly
-expensive --timeout=700 near-chain near_chain tests::gc::test_gc_star_large
-expensive --timeout=700 near-chain near_chain tests::gc::test_gc_star_large --features nightly
+expensive --timeout=900 near-chain near_chain tests::garbage_collection::test_gc_remove_fork_large
+expensive --timeout=900 near-chain near_chain tests::garbage_collection::test_gc_remove_fork_large --features nightly
+expensive --timeout=1200 near-chain near_chain tests::garbage_collection::test_gc_not_remove_fork_large
+expensive --timeout=1200 near-chain near_chain tests::garbage_collection::test_gc_not_remove_fork_large --features nightly
+expensive --timeout=1200 near-chain near_chain tests::garbage_collection::test_gc_boundaries_large
+expensive --timeout=1200 near-chain near_chain tests::garbage_collection::test_gc_boundaries_large --features nightly
+expensive --timeout=900 near-chain near_chain tests::garbage_collection::test_gc_random_large
+expensive --timeout=900 near-chain near_chain tests::garbage_collection::test_gc_random_large --features nightly
+expensive --timeout=600 near-chain near_chain tests::garbage_collection::test_gc_pine
+expensive --timeout=600 near-chain near_chain tests::garbage_collection::test_gc_pine --features nightly
+expensive --timeout=700 near-chain near_chain tests::garbage_collection::test_gc_star_large
+expensive --timeout=700 near-chain near_chain tests::garbage_collection::test_gc_star_large --features nightly
 
 expensive --timeout=1200 integration-tests integration_tests tests::client::block_corruption::check_process_flipped_block_fails
 expensive --timeout=1200 integration-tests integration_tests tests::client::block_corruption::check_process_flipped_block_fails --features nightly


### PR DESCRIPTION
The tests were failing in nayduck because the name of the test was wrong and no tests were actually executed. 
e.g.
```
https://nayduck.near.org/#/test/571329
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 57 filtered out; finished in 0.00s
```

I'm hoping this should help. I tried one of the tests and it passed.