### PR TITLE
[Single Shard] Introduce SingleShardTracking, and fix partial chunk forwarding logic for single shard tracking.

### DIFF
--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -538,11 +538,6 @@ impl ShardsManager {
             Some(it) => it,
         };
         let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(prev_hash)?;
-        if self.epoch_manager.is_next_block_epoch_start(prev_hash)? {
-            // Chunk forwarding is likely incorrect when the previous block is
-            // in a different epoch. So just don't wait.
-            return Ok(false);
-        }
         let block_producers =
             self.epoch_manager.get_epoch_block_producers_ordered(&epoch_id, prev_hash)?;
         for (bp, _) in block_producers {

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -538,6 +538,11 @@ impl ShardsManager {
             Some(it) => it,
         };
         let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(prev_hash)?;
+        if self.epoch_manager.is_next_block_epoch_start(prev_hash)? {
+            // Chunk forwarding is likely incorrect when the previous block is
+            // in a different epoch. So just don't wait.
+            return Ok(false);
+        }
         let block_producers =
             self.epoch_manager.get_epoch_block_producers_ordered(&epoch_id, prev_hash)?;
         for (bp, _) in block_producers {

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1810,7 +1810,7 @@ impl ShardsManager {
                 self.peer_manager_adapter.send(PeerManagerMessageRequest::NetworkRequests(
                     NetworkRequests::PartialEncodedChunkForward {
                         account_id: next_chunk_producer,
-                        forward: forward.clone(),
+                        forward,
                     },
                 ));
             }

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1743,7 +1743,7 @@ impl ShardsManager {
         partial_encoded_chunk: &PartialEncodedChunkV2,
         part_ords: HashSet<u64>,
         epoch_id: &EpochId,
-        lastest_block_hash: &CryptoHash,
+        latest_block_hash: &CryptoHash,
     ) -> Result<(), Error> {
         let me = match self.me.as_ref() {
             Some(me) => me,
@@ -1773,7 +1773,7 @@ impl ShardsManager {
 
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(epoch_id)?;
         let block_producers =
-            self.epoch_manager.get_epoch_block_producers_ordered(&epoch_id, lastest_block_hash)?;
+            self.epoch_manager.get_epoch_block_producers_ordered(&epoch_id, latest_block_hash)?;
         let current_chunk_height = partial_encoded_chunk.header.height_created();
 
         if checked_feature!("stable", SingleShardTracking, protocol_version) {
@@ -1790,7 +1790,7 @@ impl ShardsManager {
 
                 if cares_about_shard_this_or_next_epoch(
                     Some(&bp_account_id),
-                    lastest_block_hash,
+                    latest_block_hash,
                     shard_id,
                     false,
                     &self.shard_tracker,

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -119,10 +119,10 @@ use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
     AccountId, Balance, BlockHeight, BlockHeightDelta, EpochId, Gas, MerkleHash, ShardId, StateRoot,
 };
-use near_primitives::unwrap_or_return;
 use near_primitives::utils::MaybeValidated;
 use near_primitives::validator_signer::ValidatorSigner;
 use near_primitives::version::ProtocolVersion;
+use near_primitives::{checked_feature, unwrap_or_return};
 use rand::seq::IteratorRandom;
 use rand::Rng;
 use std::collections::{HashMap, HashSet};
@@ -1771,50 +1771,95 @@ impl ShardsManager {
             owned_parts,
         );
 
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(epoch_id)?;
         let block_producers =
             self.epoch_manager.get_epoch_block_producers_ordered(&epoch_id, lastest_block_hash)?;
         let current_chunk_height = partial_encoded_chunk.header.height_created();
-        let mut next_chunk_producers = self
-            .epoch_manager
-            .shard_ids(&epoch_id)?
-            .into_iter()
-            .map(|shard_id| {
-                self.epoch_manager.get_chunk_producer(&epoch_id, current_chunk_height + 1, shard_id)
-            })
-            .collect::<Result<HashSet<_>, _>>()?;
-        next_chunk_producers.remove(me);
-        for (bp, _) in block_producers {
-            let bp_account_id = bp.take_account_id();
-            // no need to send anything to myself
-            if me == &bp_account_id {
-                continue;
+
+        if checked_feature!("stable", SingleShardTracking, protocol_version) {
+            let shard_id = partial_encoded_chunk.header.shard_id();
+            let mut accounts_forwarded_to = HashSet::new();
+            accounts_forwarded_to.insert(me.clone());
+            let next_chunk_producer = self.epoch_manager.get_chunk_producer(
+                &epoch_id,
+                current_chunk_height + 1,
+                shard_id,
+            )?;
+            for (bp, _) in block_producers {
+                let bp_account_id = bp.take_account_id();
+
+                if cares_about_shard_this_or_next_epoch(
+                    Some(&bp_account_id),
+                    lastest_block_hash,
+                    shard_id,
+                    false,
+                    &self.shard_tracker,
+                ) {
+                    if accounts_forwarded_to.insert(bp_account_id.clone()) {
+                        self.peer_manager_adapter.send(PeerManagerMessageRequest::NetworkRequests(
+                            NetworkRequests::PartialEncodedChunkForward {
+                                account_id: bp_account_id,
+                                forward: forward.clone(),
+                            },
+                        ));
+                    }
+                }
             }
-            next_chunk_producers.remove(&bp_account_id);
 
-            // Technically, here we should check if the block producer actually cares about the shard.
-            // We don't because with the current implementation, we force all validators to track all
-            // shards by making their config tracking all shards.
-            // See https://github.com/near/nearcore/issues/7388
-            self.peer_manager_adapter.send(PeerManagerMessageRequest::NetworkRequests(
-                NetworkRequests::PartialEncodedChunkForward {
-                    account_id: bp_account_id,
-                    forward: forward.clone(),
-                },
-            ));
+            if accounts_forwarded_to.insert(next_chunk_producer.clone()) {
+                self.peer_manager_adapter.send(PeerManagerMessageRequest::NetworkRequests(
+                    NetworkRequests::PartialEncodedChunkForward {
+                        account_id: next_chunk_producer,
+                        forward: forward.clone(),
+                    },
+                ));
+            }
+        } else {
+            let mut next_chunk_producers = self
+                .epoch_manager
+                .shard_ids(&epoch_id)?
+                .into_iter()
+                .map(|shard_id| {
+                    self.epoch_manager.get_chunk_producer(
+                        &epoch_id,
+                        current_chunk_height + 1,
+                        shard_id,
+                    )
+                })
+                .collect::<Result<HashSet<_>, _>>()?;
+            next_chunk_producers.remove(me);
+            for (bp, _) in block_producers {
+                let bp_account_id = bp.take_account_id();
+                // no need to send anything to myself
+                if me == &bp_account_id {
+                    continue;
+                }
+                next_chunk_producers.remove(&bp_account_id);
+
+                // Technically, here we should check if the block producer actually cares about the shard.
+                // We don't because with the current implementation, we force all validators to track all
+                // shards by making their config tracking all shards.
+                // See https://github.com/near/nearcore/issues/7388
+                self.peer_manager_adapter.send(PeerManagerMessageRequest::NetworkRequests(
+                    NetworkRequests::PartialEncodedChunkForward {
+                        account_id: bp_account_id,
+                        forward: forward.clone(),
+                    },
+                ));
+            }
+
+            // We also forward chunk parts to incoming chunk producers because we want them to be able
+            // to produce the next chunk without delays. For the same reason as above, we don't check if they
+            // actually track this shard.
+            for next_chunk_producer in next_chunk_producers {
+                self.peer_manager_adapter.send(PeerManagerMessageRequest::NetworkRequests(
+                    NetworkRequests::PartialEncodedChunkForward {
+                        account_id: next_chunk_producer,
+                        forward: forward.clone(),
+                    },
+                ));
+            }
         }
-
-        // We also forward chunk parts to incoming chunk producers because we want them to be able
-        // to produce the next chunk without delays. For the same reason as above, we don't check if they
-        // actually track this shard.
-        for next_chunk_producer in next_chunk_producers {
-            self.peer_manager_adapter.send(PeerManagerMessageRequest::NetworkRequests(
-                NetworkRequests::PartialEncodedChunkForward {
-                    account_id: next_chunk_producer,
-                    forward: forward.clone(),
-                },
-            ));
-        }
-
         Ok(())
     }
 

--- a/chain/chunks/src/test/multi.rs
+++ b/chain/chunks/src/test/multi.rs
@@ -26,7 +26,7 @@ use crate::{
         ShardsManagerResendChunkRequests,
     },
     test_utils::default_tip,
-    ShardsManager,
+    ShardsManager, CHUNK_REQUEST_RETRY,
 };
 
 #[derive(derive_more::AsMut, derive_more::AsRef)]
@@ -101,9 +101,7 @@ fn basic_setup(config: BasicSetupConfig) -> ShardsManagerTestLoop {
         test.register_handler(capture_events::<ShardsManagerResponse>().widen().for_index(idx));
         test.register_handler(route_shards_manager_network_messages(NETWORK_DELAY));
         test.register_handler(
-            periodically_resend_chunk_requests(time::Duration::milliseconds(400))
-                .widen()
-                .for_index(idx),
+            periodically_resend_chunk_requests(CHUNK_REQUEST_RETRY).widen().for_index(idx),
         );
     }
     test

--- a/chain/chunks/src/test/multi.rs
+++ b/chain/chunks/src/test/multi.rs
@@ -21,8 +21,9 @@ use crate::{
     client::ShardsManagerResponse,
     test_loop::{
         forward_client_request_to_shards_manager, forward_network_request_to_shards_manager,
-        route_shards_manager_network_messages, MockChainForShardsManager,
-        MockChainForShardsManagerConfig,
+        periodically_resend_chunk_requests, route_shards_manager_network_messages,
+        MockChainForShardsManager, MockChainForShardsManagerConfig,
+        ShardsManagerResendChunkRequests,
     },
     test_utils::default_tip,
     ShardsManager,
@@ -43,6 +44,7 @@ enum TestEvent {
     NetworkToShardsManager(ShardsManagerRequestFromNetwork),
     ShardsManagerToClient(ShardsManagerResponse),
     OutboundNetwork(PeerManagerMessageRequest),
+    ShardsManagerResendChunkRequests(ShardsManagerResendChunkRequests),
 }
 
 type ShardsManagerTestLoop = near_async::test_loop::TestLoop<Vec<TestData>, (usize, TestEvent)>;
@@ -98,9 +100,11 @@ fn basic_setup(config: BasicSetupConfig) -> ShardsManagerTestLoop {
         test.register_handler(forward_network_request_to_shards_manager().widen().for_index(idx));
         test.register_handler(capture_events::<ShardsManagerResponse>().widen().for_index(idx));
         test.register_handler(route_shards_manager_network_messages(NETWORK_DELAY));
-        // Note that we don't have the periodically resending requests handler, because
-        // our forwarding logic means that we don't need to resend requests, unless
-        // there is unreliable network, which is tested separately.
+        test.register_handler(
+            periodically_resend_chunk_requests(time::Duration::milliseconds(400))
+                .widen()
+                .for_index(idx),
+        );
     }
     test
 }
@@ -187,10 +191,14 @@ fn test_distribute_chunk_track_all_shards() {
     });
     // Two network rounds is enough because each node should have
     // forwarded the parts to those block producers that need them.
-    // TODO: after phase 2, we will need a longer delay because validators
-    // that don't track the shard will not get forwards. We may also need
-    // to add the periodic resending handler.
-    test.run_for(NETWORK_DELAY * 2);
+    // However, after SingleShardTracking protocol upgrade, we need a longer
+    // delay because validators that don't track the shard will not get
+    // parts forwarded to them.
+    if cfg!(feature = "nightly") {
+        test.run_for(NETWORK_DELAY * 4 + time::Duration::milliseconds(400));
+    } else {
+        test.run_for(NETWORK_DELAY * 2);
+    }
 
     // All other nodes should have received the complete chunk.
     for idx in 0..test.data.len() {

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -24,6 +24,7 @@ use std::sync::{Arc, Mutex, RwLock};
 
 use crate::adapter::ShardsManagerRequestFromClient;
 use crate::client::ShardsManagerResponse;
+use crate::test_loop::ShardsManagerResendChunkRequests;
 use crate::ShardsManager;
 
 /// Deprecated. Use `MockChainForShardsManager`.
@@ -299,6 +300,13 @@ impl CanSend<ShardsManagerRequestFromNetwork> for SynchronousShardsManagerAdapte
     fn send(&self, msg: ShardsManagerRequestFromNetwork) {
         let mut shards_manager = self.shards_manager.lock().unwrap();
         shards_manager.handle_network_request(msg);
+    }
+}
+
+impl CanSend<ShardsManagerResendChunkRequests> for SynchronousShardsManagerAdapter {
+    fn send(&self, _: ShardsManagerResendChunkRequests) {
+        let mut shards_manager = self.shards_manager.lock().unwrap();
+        shards_manager.resend_chunk_requests();
     }
 }
 

--- a/chain/client/src/test_utils/setup.rs
+++ b/chain/client/src/test_utils/setup.rs
@@ -16,7 +16,7 @@ use chrono::Utc;
 use futures::{future, FutureExt};
 use near_async::actix::AddrWithAutoSpanContextExt;
 use near_async::messaging::{CanSend, IntoSender, LateBoundSender, Sender};
-use near_async::time;
+use near_async::time::Clock;
 use near_chain::state_snapshot_actor::SnapshotCallbacks;
 use near_chain::test_utils::{KeyValueRuntime, MockEpochManager, ValidatorSchedule};
 use near_chain::types::{ChainConfig, RuntimeAdapter};
@@ -922,7 +922,7 @@ pub fn setup_client_with_runtime(
     account_id: Option<AccountId>,
     enable_doomslug: bool,
     network_adapter: PeerManagerAdapter,
-    shards_manager_adapter: ShardsManagerAdapterForTest,
+    shards_manager_adapter: SynchronousShardsManagerAdapter,
     chain_genesis: ChainGenesis,
     epoch_manager: Arc<dyn EpochManagerAdapter>,
     shard_tracker: ShardTracker,
@@ -955,7 +955,7 @@ pub fn setup_client_with_runtime(
         state_sync_adapter,
         runtime,
         network_adapter,
-        shards_manager_adapter.client.into(),
+        shards_manager_adapter.into_sender(),
         validator_signer,
         enable_doomslug,
         rng_seed,
@@ -972,7 +972,7 @@ pub fn setup_client(
     account_id: Option<AccountId>,
     enable_doomslug: bool,
     network_adapter: PeerManagerAdapter,
-    shards_manager_adapter: ShardsManagerAdapterForTest,
+    shards_manager_adapter: SynchronousShardsManagerAdapter,
     chain_genesis: ChainGenesis,
     rng_seed: RngSeed,
     archive: bool,
@@ -1001,6 +1001,7 @@ pub fn setup_client(
 }
 
 pub fn setup_synchronous_shards_manager(
+    clock: Clock,
     account_id: Option<AccountId>,
     client_adapter: Sender<ShardsManagerResponse>,
     network_adapter: PeerManagerAdapter,
@@ -1008,7 +1009,7 @@ pub fn setup_synchronous_shards_manager(
     shard_tracker: ShardTracker,
     runtime: Arc<dyn RuntimeAdapter>,
     chain_genesis: &ChainGenesis,
-) -> ShardsManagerAdapterForTest {
+) -> SynchronousShardsManagerAdapter {
     // Initialize the chain, to make sure that if the store is empty, we write the genesis
     // into the store, and as a short cut to get the parameters needed to instantiate
     // ShardsManager. This way we don't have to wait to construct the Client first.
@@ -1034,7 +1035,7 @@ pub fn setup_synchronous_shards_manager(
     let chain_head = chain.head().unwrap();
     let chain_header_head = chain.header_head().unwrap();
     let shards_manager = ShardsManager::new(
-        time::Clock::real(),
+        clock,
         account_id,
         epoch_manager,
         shard_tracker,
@@ -1044,7 +1045,7 @@ pub fn setup_synchronous_shards_manager(
         chain_head,
         chain_header_head,
     );
-    Arc::new(SynchronousShardsManagerAdapter::new(shards_manager)).into()
+    SynchronousShardsManagerAdapter::new(shards_manager)
 }
 
 pub fn setup_client_with_synchronous_shards_manager(
@@ -1068,6 +1069,7 @@ pub fn setup_client_with_synchronous_shards_manager(
     let shard_tracker = ShardTracker::new_empty(epoch_manager.clone());
     let runtime = KeyValueRuntime::new(store, epoch_manager.as_ref());
     let shards_manager_adapter = setup_synchronous_shards_manager(
+        Clock::real(),
         account_id.clone(),
         client_adapter,
         network_adapter.clone(),

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -132,6 +132,8 @@ pub enum ProtocolFeature {
 
     // Stateless validation: lower block and chunk validator kickout percent from 90 to 50.
     LowerValidatorKickoutPercentForDebugging,
+    // Stateless validation: single shard tracking.
+    SingleShardTracking,
 }
 
 impl ProtocolFeature {
@@ -182,6 +184,7 @@ impl ProtocolFeature {
             // StatelessNet features
             ProtocolFeature::StatelessValidationV0 => 80,
             ProtocolFeature::LowerValidatorKickoutPercentForDebugging => 81,
+            ProtocolFeature::SingleShardTracking => 82,
 
             // Nightly features
             #[cfg(feature = "protocol_feature_fix_staking_threshold")]

--- a/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
@@ -774,7 +774,12 @@ fn test_chunk_forwarding_optimization() {
     // With very high probability we should've encountered some cases where forwarded parts
     // could not be applied because the chunk header is not available. Assert this did indeed
     // happen.
-    assert!(PARTIAL_ENCODED_CHUNK_FORWARD_CACHED_WITHOUT_HEADER.get() > 0.0);
+    // Note: For nightly, which includes SingleShardTracking, this check is disabled because
+    // we're so efficient with part forwarding now that we don't seem to be forwarding more
+    // than it is necessary.
+    if !cfg!(feature = "nightly") {
+        assert!(PARTIAL_ENCODED_CHUNK_FORWARD_CACHED_WITHOUT_HEADER.get() > 0.0);
+    }
     debug!(target: "test",
         "Counters for debugging:
                 num_part_ords_requested: {}

--- a/integration-tests/src/tests/client/features/adversarial_behaviors.rs
+++ b/integration-tests/src/tests/client/features/adversarial_behaviors.rs
@@ -181,9 +181,6 @@ fn test_non_adversarial_case() {
             // process other network messages (such as production of the next chunk) which is OK.
             test.process_all_actor_messages();
             accepted_blocks.extend(test.env.clients[i].finish_blocks_in_processing());
-            // Give one more chance, in case there are any parts that needed to be requested.
-            test.process_all_actor_messages();
-            accepted_blocks.extend(test.env.clients[i].finish_blocks_in_processing());
 
             assert_eq!(
                 accepted_blocks.len(),

--- a/integration-tests/src/tests/client/features/stateless_validation.rs
+++ b/integration-tests/src/tests/client/features/stateless_validation.rs
@@ -73,8 +73,8 @@ fn run_chunk_validation_test(seed: u64, prob_missing_chunk: f64) {
         protocol_treasury_account: accounts[num_validators].clone(),
         // Simply make all validators block producers.
         num_block_producer_seats: num_validators as NumSeats,
-        // Make all validators produce chunks for all shards.
-        minimum_validators_per_shard: num_validators as NumSeats,
+        // Each shard has 2 chunk prducers, so 4 shards, 8 chunk producers total.
+        minimum_validators_per_shard: 2,
         // Even though not used for the most recent protocol version,
         // this must still have the same length as the number of shards,
         // or else the genesis fails validation.


### PR DESCRIPTION
This properly tests the changes introduced in #10575 ; I've verified that without 10575, the stateless validation integration now fails.

This also properly implements chunk forwarding for the single shard (or rather, any number of shards) tracking case. Previously we were forwarding all parts to all block producers and all incoming chunk producers, but now we're forwarding to only those who track the corresponding shard. The TestLoop-based integration test in multi.rs have been modified to test the behavior of this new logic, too.