### PR TITLE
[cleanup] Remove references of `setup_client_with_synchronous_shards_manager`

### DIFF
--- a/chain/client/src/test_utils/setup.rs
+++ b/chain/client/src/test_utils/setup.rs
@@ -10,7 +10,6 @@ use crate::adapter::{
 };
 use crate::{start_view_client, Client, ClientActor, SyncAdapter, SyncStatus, ViewClientActor};
 use actix::{Actor, Addr, AsyncContext, Context};
-use actix_rt::System;
 use chrono::DateTime;
 use chrono::Utc;
 use futures::{future, FutureExt};
@@ -1045,52 +1044,6 @@ pub fn setup_synchronous_shards_manager(
         chain_header_head,
     );
     Arc::new(SynchronousShardsManagerAdapter::new(shards_manager)).into()
-}
-
-pub fn setup_client_with_synchronous_shards_manager(
-    store: Store,
-    vs: ValidatorSchedule,
-    account_id: Option<AccountId>,
-    enable_doomslug: bool,
-    network_adapter: PeerManagerAdapter,
-    client_adapter: Sender<ShardsManagerResponse>,
-    chain_genesis: ChainGenesis,
-    rng_seed: RngSeed,
-    archive: bool,
-    save_trie_changes: bool,
-) -> Client {
-    if let None = System::try_current() {
-        let _ = System::new();
-    }
-    let num_validator_seats = vs.all_block_producers().count() as NumSeats;
-    let epoch_manager =
-        MockEpochManager::new_with_validators(store.clone(), vs, chain_genesis.epoch_length);
-    let shard_tracker = ShardTracker::new_empty(epoch_manager.clone());
-    let runtime = KeyValueRuntime::new(store, epoch_manager.as_ref());
-    let shards_manager_adapter = setup_synchronous_shards_manager(
-        account_id.clone(),
-        client_adapter,
-        network_adapter.clone(),
-        epoch_manager.clone(),
-        shard_tracker.clone(),
-        runtime.clone(),
-        &chain_genesis,
-    );
-    setup_client_with_runtime(
-        num_validator_seats,
-        account_id,
-        enable_doomslug,
-        network_adapter,
-        shards_manager_adapter,
-        chain_genesis,
-        epoch_manager,
-        shard_tracker,
-        runtime,
-        rng_seed,
-        archive,
-        save_trie_changes,
-        None,
-    )
 }
 
 /// A combined trait bound for both the client side and network side of the ShardsManager API.

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -8,7 +8,6 @@ use assert_matches::assert_matches;
 use futures::{future, FutureExt};
 use itertools::Itertools;
 use near_actix_test_utils::run_actix;
-use near_async::messaging::IntoSender;
 use near_chain::chain::ApplyStatePartsRequest;
 use near_chain::test_utils::ValidatorSchedule;
 use near_chain::types::{LatestKnown, RuntimeAdapter};
@@ -18,7 +17,6 @@ use near_chain::{
     Block, BlockProcessingArtifact, ChainGenesis, ChainStoreAccess, Error, Provenance,
 };
 use near_chain_configs::{Genesis, DEFAULT_GC_NUM_EPOCHS_TO_KEEP};
-use near_chunks::test_utils::MockClientAdapterForShardsManager;
 use near_client::test_utils::{
     create_chunk_on_height, setup_mock, setup_mock_all_validators, TestEnv,
 };
@@ -40,7 +38,6 @@ use near_parameters::{ActionCosts, ExtCosts};
 use near_parameters::{RuntimeConfig, RuntimeConfigStore};
 use near_primitives::block::Approval;
 use near_primitives::block_header::BlockHeader;
-use near_primitives::epoch_manager::RngSeed;
 use near_primitives::errors::TxExecutionError;
 use near_primitives::errors::{ActionError, ActionErrorKind, InvalidTxError};
 use near_primitives::hash::{hash, CryptoHash};
@@ -72,7 +69,6 @@ use near_store::cold_storage::{update_cold_db, update_cold_head};
 use near_store::metadata::DbKind;
 use near_store::metadata::DB_VERSION;
 use near_store::test_utils::create_test_node_storage_with_cold;
-use near_store::test_utils::create_test_store;
 use near_store::NodeStorage;
 use near_store::{get, DBCol, TrieChanges};
 use nearcore::config::{GenesisExt, TESTING_INIT_BALANCE, TESTING_INIT_STAKE};
@@ -738,8 +734,6 @@ fn invalid_blocks_common(is_requested: bool) {
         near_network::test_utils::wait_or_panic(5000);
     });
 }
-
-const TEST_SEED: RngSeed = [3; 32];
 
 #[test]
 fn test_invalid_blocks_not_requested() {


### PR DESCRIPTION
Cleanup of tests. One more reference of MockEpochManager and KeyValueRuntime removed! 🎉 

Waiting for PR https://github.com/near/nearcore/pull/10583 to be merged in 