### PR TITLE
rust: 1.76.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 version = "0.0.0" # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
-rust-version = "1.75.0"
+rust-version = "1.76.0"
 repository = "https://github.com/near/nearcore"
 license = "MIT OR Apache-2.0"
 

--- a/chain/client/src/adapter.rs
+++ b/chain/client/src/adapter.rs
@@ -1,8 +1,8 @@
 use crate::client_actor::ClientActor;
 use crate::view_client::ViewClientActor;
 use near_network::types::{
-    NetworkInfo, PartialEncodedChunkForwardMsg, PartialEncodedChunkRequestMsg,
-    PartialEncodedChunkResponseMsg, ReasonForBan, StateResponseInfo,
+    NetworkInfo,
+    ReasonForBan, StateResponseInfo,
 };
 use near_o11y::WithSpanContextExt;
 use near_primitives::block::{Approval, Block, BlockHeader};
@@ -10,7 +10,6 @@ use near_primitives::challenge::Challenge;
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
-use near_primitives::sharding::PartialEncodedChunk;
 use near_primitives::stateless_validation::{ChunkEndorsement, ChunkStateWitness};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, EpochId, ShardId};
@@ -96,22 +95,19 @@ pub(crate) struct RecvChallenge(pub Challenge);
 
 #[derive(actix::Message, Debug)]
 #[rtype(result = "()")]
-pub(crate) struct RecvPartialEncodedChunkForward(pub PartialEncodedChunkForwardMsg);
+pub(crate) struct RecvPartialEncodedChunkForward;
 
 #[derive(actix::Message, Debug)]
 #[rtype(result = "()")]
-pub(crate) struct RecvPartialEncodedChunk(pub PartialEncodedChunk);
+pub(crate) struct RecvPartialEncodedChunk;
 
 #[derive(actix::Message, Debug)]
 #[rtype(result = "()")]
-pub(crate) struct RecvPartialEncodedChunkResponse(
-    pub PartialEncodedChunkResponseMsg,
-    pub std::time::Instant,
-);
+pub(crate) struct RecvPartialEncodedChunkResponse;
 
 #[derive(actix::Message, Debug)]
 #[rtype(result = "()")]
-pub(crate) struct RecvPartialEncodedChunkRequest(pub PartialEncodedChunkRequestMsg, pub CryptoHash);
+pub(crate) struct RecvPartialEncodedChunkRequest;
 
 #[derive(actix::Message, Debug)]
 #[rtype(result = "ProcessTxResponse")]

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -244,13 +244,14 @@ impl PeerActor {
         network_state: Arc<NetworkState>,
     ) -> Result<(actix::Addr<Self>, HandshakeSignal), ClosingReason> {
         let connecting_status = match &stream.type_ {
-            tcp::StreamType::Inbound => ConnectingStatus::Inbound(
-                network_state
+            tcp::StreamType::Inbound => {
+                let _ = network_state
                     .inbound_handshake_permits
                     .clone()
                     .try_acquire_owned()
-                    .map_err(|_| ClosingReason::TooManyInbound)?,
-            ),
+                    .map_err(|_| ClosingReason::TooManyInbound)?;
+                ConnectingStatus::Inbound
+            },
             tcp::StreamType::Outbound { tier, peer_id } => ConnectingStatus::Outbound {
                 _permit: match tier {
                     tcp::Tier::T1 => network_state
@@ -294,7 +295,7 @@ impl PeerActor {
             account_id: network_state.config.validator.as_ref().map(|v| v.account_id()),
         };
         // recv is the HandshakeSignal returned by this spawn_inner() call.
-        let (send, recv): (HandshakeSignalSender, HandshakeSignal) =
+        let (_send, recv): (HandshakeSignalSender, HandshakeSignal) =
             tokio::sync::oneshot::channel();
         // Start PeerActor on separate thread.
         Ok((
@@ -314,7 +315,7 @@ impl PeerActor {
                         tcp::StreamType::Inbound => PeerType::Inbound,
                         tcp::StreamType::Outbound { .. } => PeerType::Outbound,
                     },
-                    peer_status: PeerStatus::Connecting(send, connecting_status),
+                    peer_status: PeerStatus::Connecting(connecting_status),
                     framed,
                     tracker: Default::default(),
                     stats,
@@ -483,7 +484,7 @@ impl PeerActor {
     ) {
         tracing::debug!(target: "network", "{:?}: Received handshake {:?}", self.my_node_info.id, handshake);
         let cs = match &self.peer_status {
-            PeerStatus::Connecting(_, it) => it,
+            PeerStatus::Connecting(it) => it,
             _ => panic!("process_handshake called in non-connecting state"),
         };
         match cs {
@@ -517,7 +518,7 @@ impl PeerActor {
                     return;
                 }
             }
-            ConnectingStatus::Inbound { .. } => {
+            ConnectingStatus::Inbound => {
                 if PEER_MIN_ALLOWED_PROTOCOL_VERSION > handshake.protocol_version
                     || handshake.protocol_version > PROTOCOL_VERSION
                 {
@@ -594,7 +595,7 @@ impl PeerActor {
             ConnectingStatus::Outbound { handshake_spec, .. } => {
                 handshake_spec.partial_edge_info.clone()
             }
-            ConnectingStatus::Inbound { .. } => {
+            ConnectingStatus::Inbound => {
                 self.network_state.propose_edge(&self.clock, &handshake.sender_peer_id, Some(nonce))
             }
         };
@@ -830,7 +831,7 @@ impl PeerActor {
     fn handle_msg_connecting(&mut self, ctx: &mut actix::Context<Self>, msg: PeerMessage) {
         match (&mut self.peer_status, msg) {
             (
-                PeerStatus::Connecting(_, ConnectingStatus::Outbound { handshake_spec, .. }),
+                PeerStatus::Connecting(ConnectingStatus::Outbound { handshake_spec, .. }),
                 PeerMessage::HandshakeFailure(peer_info, reason),
             ) => {
                 match reason {
@@ -868,7 +869,7 @@ impl PeerActor {
             // TODO(gprusak): LastEdge should rather be a variant of HandshakeFailure.
             // Clean this up (you don't have to modify the proto, just the translation layer).
             (
-                PeerStatus::Connecting(_, ConnectingStatus::Outbound { handshake_spec, .. }),
+                PeerStatus::Connecting(ConnectingStatus::Outbound { handshake_spec, .. }),
                 PeerMessage::LastEdge(edge),
             ) => {
                 // Check that the edge provided:
@@ -1472,7 +1473,7 @@ impl actix::Actor for PeerActor {
         );
 
         // If outbound peer, initiate handshake.
-        if let PeerStatus::Connecting(_, ConnectingStatus::Outbound { handshake_spec, .. }) =
+        if let PeerStatus::Connecting(ConnectingStatus::Outbound { handshake_spec, .. }) =
             &self.peer_status
         {
             self.send_handshake(handshake_spec.clone());
@@ -1691,11 +1692,9 @@ impl actix::Handler<WithSpanContext<Stop>> for PeerActor {
     }
 }
 
-type InboundHandshakePermit = tokio::sync::OwnedSemaphorePermit;
-
 #[derive(Debug)]
 enum ConnectingStatus {
-    Inbound(InboundHandshakePermit),
+    Inbound,
     Outbound { _permit: connection::OutboundHandshakePermit, handshake_spec: HandshakeSpec },
 }
 
@@ -1714,7 +1713,7 @@ enum ConnectingStatus {
 #[derive(Debug)]
 enum PeerStatus {
     /// Handshake in progress.
-    Connecting(HandshakeSignalSender, ConnectingStatus),
+    Connecting(ConnectingStatus),
     /// Ready to go.
     Ready(Arc<connection::Connection>),
 }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -570,7 +570,7 @@ impl StoreUpdate {
     ///
     /// Panics if `self`’s and `other`’s storage are incompatible.
     pub fn merge(&mut self, other: StoreUpdate) {
-        assert!(same_db(&self.storage, &other.storage));
+        assert!(core::ptr::addr_eq(Arc::as_ptr(&self.storage), Arc::as_ptr(&other.storage)));
         self.transaction.merge(other.transaction)
     }
 
@@ -621,13 +621,6 @@ impl StoreUpdate {
         }
         self.storage.write(self.transaction)
     }
-}
-
-fn same_db(lhs: &Arc<dyn Database>, rhs: &Arc<dyn Database>) -> bool {
-    // Note: avoid comparing wide pointers here to work-around
-    // https://github.com/rust-lang/rust/issues/69757
-    let addr = |arc| Arc::as_ptr(arc) as *const u8;
-    return addr(lhs) == addr(rhs);
 }
 
 impl fmt::Debug for StoreUpdate {

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -561,7 +561,7 @@ pub struct ApplyStatePartResult {
 }
 
 enum NodeOrValue {
-    Node(Box<RawTrieNodeWithSize>),
+    Node,
     Value(std::sync::Arc<[u8]>),
 }
 
@@ -802,7 +802,7 @@ impl Trie {
         to: &Option<&AccountId>,
     ) {
         match self.debug_retrieve_raw_node_or_value(hash) {
-            Ok(NodeOrValue::Node(_)) => {
+            Ok(NodeOrValue::Node) => {
                 let mut prefix: Vec<u8> = Vec::new();
                 let mut limit = limit.unwrap_or(u32::MAX);
                 self.print_recursive_internal(
@@ -1105,7 +1105,7 @@ impl Trie {
     ) -> Result<NodeOrValue, StorageError> {
         let bytes = self.internal_retrieve_trie_node(hash, true)?;
         match RawTrieNodeWithSize::try_from_slice(&bytes) {
-            Ok(node) => Ok(NodeOrValue::Node(Box::new(node))),
+            Ok(_) => Ok(NodeOrValue::Node),
             Err(_) => Ok(NodeOrValue::Value(bytes)),
         }
     }

--- a/runtime/near-vm-runner/src/imports.rs
+++ b/runtime/near-vm-runner/src/imports.rs
@@ -658,7 +658,7 @@ pub(crate) mod wasmtime {
     }
 
     thread_local! {
-        static CALLER_CONTEXT: UnsafeCell<*mut c_void> = UnsafeCell::new(0 as *mut c_void);
+        static CALLER_CONTEXT: UnsafeCell<*mut c_void> = const { UnsafeCell::new(core::ptr::null_mut()) };
     }
 
     pub(crate) fn link<'a, 'b>(

--- a/runtime/near-vm-runner/src/instrument/stack_height/mod.rs
+++ b/runtime/near-vm-runner/src/instrument/stack_height/mod.rs
@@ -90,6 +90,9 @@ mod thunk;
 ///
 /// This means that the module is invalid.
 #[derive(Debug)]
+// TODO: Use the error message somewhere.  Currently it’s set but never actually
+// used.
+#[allow(dead_code)]
 pub struct Error(String);
 
 pub(crate) struct Context {

--- a/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
+++ b/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 
 #[derive(serde::Serialize)]
 #[serde(remote = "GasWeight")]
+#[allow(dead_code)]  // The value is never read because this is a mock.
 struct GasWeightSer(u64);
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -18,7 +18,7 @@ use wasmtime::{Engine, Linker, Memory, MemoryType, Module, Store};
 
 type Caller = wasmtime::Caller<'static, ()>;
 thread_local! {
-    pub(crate) static CALLER: RefCell<Option<Caller>> = RefCell::new(None);
+    pub(crate) static CALLER: RefCell<Option<Caller>> = const { RefCell::new(None) };
 }
 pub struct WasmtimeMemory(Memory);
 

--- a/runtime/near-vm/test-api/src/sys/externals/table.rs
+++ b/runtime/near-vm/test-api/src/sys/externals/table.rs
@@ -1,6 +1,3 @@
-// This is test code...
-#![allow(clippy::vtable_address_comparisons)]
-
 use super::super::exports::Exportable;
 use super::super::store::Store;
 use super::super::types::TableType;

--- a/runtime/near-vm/vm/src/lib.rs
+++ b/runtime/near-vm/vm/src/lib.rs
@@ -5,7 +5,7 @@
 #![warn(unused_import_braces)]
 #![cfg_attr(
     feature = "cargo-clippy",
-    allow(clippy::new_without_default, clippy::vtable_address_comparisons)
+    allow(clippy::new_without_default)
 )]
 #![cfg_attr(
     feature = "cargo-clippy",

--- a/runtime/near-vm/vm/src/trap/traphandlers.rs
+++ b/runtime/near-vm/vm/src/trap/traphandlers.rs
@@ -295,7 +295,7 @@ mod tls {
         // allows the runtime to perform per-thread initialization if necessary
         // for handling traps (e.g. setting up ports on macOS and sigaltstack on
         // Unix).
-        thread_local!(static PTR: Cell<Ptr> = Cell::new(ptr::null()));
+        thread_local!(static PTR: Cell<Ptr> = const { Cell::new(ptr::null()) });
 
         #[inline(never)] // see module docs for why this is here
         pub fn replace(val: Ptr) -> Result<Ptr, Trap> {

--- a/runtime/runtime-params-estimator/emu-cost/Dockerfile
+++ b/runtime/runtime-params-estimator/emu-cost/Dockerfile
@@ -1,5 +1,5 @@
 # our local base image
-FROM rust:1.75.0
+FROM rust:1.76.0
 
 LABEL description="Container for builds"
 

--- a/runtime/runtime-params-estimator/src/rocksdb.rs
+++ b/runtime/runtime-params-estimator/src/rocksdb.rs
@@ -242,7 +242,6 @@ fn input_data(db_config: &RocksDBTestConfig, data_size: usize) -> Vec<u8> {
 fn backup_input_data(data: &[u8]) {
     let mut stats_file = std::fs::OpenOptions::new()
         .read(true)
-        .write(true)
         .append(true)
         .create(true)
         .open("names-to-stats.txt")

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,6 +2,6 @@
 # This specifies the version of Rust we use to build.
 # Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
 # The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
-channel = "1.75.0"
+channel = "1.76.0"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
Release notes: https://blog.rust-lang.org/2024/02/08/Rust-1.76.0.html

ptr::addr_eq immediately jumped at me as replacement for same_db the
moment I saw it and now it’s finally stabilised.  The rest of the
changes don’t seem relevant (though admittedly I haven’t really
looked).
