### PR TITLE
[resharding] Fix opening snapshot for split storage nodes

### DIFF
--- a/core/store/src/opener.rs
+++ b/core/store/src/opener.rs
@@ -147,7 +147,7 @@ fn is_valid_kind_archive(kind: DbKind, archive: bool) -> bool {
     match (kind, archive) {
         (DbKind::Archive, true) => true,
         (DbKind::Cold, true) => true,
-        (DbKind::Hot, true) => true,
+        (DbKind::Hot, _) => true,
         (DbKind::RPC, _) => true,
         _ => false,
     }
@@ -647,6 +647,7 @@ mod tests {
         let (home_dir, opener) = NodeStorage::test_opener();
         let node_storage = opener.open().unwrap();
         let hot_store = Store { storage: node_storage.hot_storage.clone() };
+        assert_eq!(hot_store.get_db_kind().unwrap(), Some(DbKind::RPC));
 
         let keys = vec![vec![0], vec![1], vec![2], vec![3]];
         let columns = vec![DBCol::Block, DBCol::Chunks, DBCol::BlockHeader];

--- a/integration-tests/src/tests/client/resharding.rs
+++ b/integration-tests/src/tests/client/resharding.rs
@@ -24,6 +24,7 @@ use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{ExecutionStatusView, FinalExecutionStatus, QueryRequest};
 use near_primitives_core::num_rational::Rational32;
 use near_store::flat::FlatStorageStatus;
+use near_store::metadata::DbKind;
 use near_store::test_utils::{gen_account, gen_unique_accounts};
 use near_store::trie::SnapshotError;
 use near_store::{DBCol, ShardUId};
@@ -609,18 +610,18 @@ impl TestReshardingEnv {
     }
 
     /// Check that after resharding is finished, the artifacts stored in storage is removed
-    fn check_resharding_artifacts(&mut self) {
+    fn check_resharding_artifacts(&mut self, client_id: usize) {
         tracing::debug!(target: "test", "checking resharding artifacts");
 
-        let env = &mut self.env;
-        let head = env.clients[0].chain.head().unwrap();
+        let client = &mut self.env.clients[client_id];
+        let head = client.chain.head().unwrap();
         for height in 0..head.height {
             let (block_hash, num_shards) = {
-                let block = env.clients[0].chain.get_block_by_height(height).unwrap();
+                let block = client.chain.get_block_by_height(height).unwrap();
                 (*block.hash(), block.chunks().len() as NumShards)
             };
             for shard_id in 0..num_shards {
-                let res = env.clients[0]
+                let res = client
                     .chain
                     .chain_store()
                     .get_state_changes_for_resharding(&block_hash, shard_id);
@@ -995,7 +996,7 @@ fn test_shard_layout_upgrade_simple_impl(
 
     test_env.check_tx_outcomes(false);
     test_env.check_accounts(accounts_to_check.iter().collect());
-    test_env.check_resharding_artifacts();
+    test_env.check_resharding_artifacts(0);
     test_env.check_outgoing_receipts_reassigned(&resharding_type);
     tracing::info!(target: "test", "test_shard_layout_upgrade_simple_impl finished");
 }
@@ -1023,6 +1024,41 @@ fn test_shard_layout_upgrade_simple_v2_seed_43() {
 #[test]
 fn test_shard_layout_upgrade_simple_v2_seed_44() {
     test_shard_layout_upgrade_simple_impl(ReshardingType::V2, 44, false);
+}
+
+#[test]
+fn test_resharding_with_different_db_kind() {
+    init_test_logger();
+
+    let genesis_protocol_version = get_genesis_protocol_version(&ReshardingType::V2);
+    let target_protocol_version = get_target_protocol_version(&ReshardingType::V2);
+
+    let epoch_length = 5;
+    let mut test_env = TestReshardingEnv::new(
+        epoch_length,
+        3,
+        3,
+        10,
+        None,
+        genesis_protocol_version,
+        42,
+        true,
+        Some(ReshardingType::V2),
+    );
+
+    // Set three different DbKind versions
+    test_env.env.clients[0].chain.chain_store().store().set_db_kind(DbKind::Hot).unwrap();
+    test_env.env.clients[1].chain.chain_store().store().set_db_kind(DbKind::Archive).unwrap();
+    test_env.env.clients[2].chain.chain_store().store().set_db_kind(DbKind::RPC).unwrap();
+
+    let drop_chunk_condition = DropChunkCondition::new();
+    for _ in 1..4 * epoch_length {
+        test_env.step(&drop_chunk_condition, target_protocol_version);
+    }
+
+    test_env.check_resharding_artifacts(0);
+    test_env.check_resharding_artifacts(1);
+    test_env.check_resharding_artifacts(2);
 }
 
 /// In this test we are checking whether we are properly deleting trie state and flat state
@@ -1335,7 +1371,7 @@ fn test_shard_layout_upgrade_cross_contract_calls_impl(
 
     test_env.check_accounts(new_accounts);
 
-    test_env.check_resharding_artifacts();
+    test_env.check_resharding_artifacts(0);
 }
 
 // Test cross contract calls
@@ -1409,7 +1445,7 @@ fn test_shard_layout_upgrade_incoming_receipts_impl(
         successful_txs.iter().flat_map(|tx_hash| new_accounts.get(tx_hash)).collect();
 
     test_env.check_accounts(new_accounts);
-    test_env.check_resharding_artifacts();
+    test_env.check_resharding_artifacts(0);
 }
 
 // This test doesn't make much sense for the V1 resharding. That is because in
@@ -1482,7 +1518,7 @@ fn test_missing_chunks(
         successful_txs.iter().flat_map(|tx_hash| new_accounts.get(tx_hash)).collect();
     test_env.check_accounts(new_accounts);
 
-    test_env.check_resharding_artifacts();
+    test_env.check_resharding_artifacts(0);
 }
 
 fn test_shard_layout_upgrade_missing_chunks(


### PR DESCRIPTION
In testnet we hit an issue during resharding with split storage nodes where they failed to create the snapshot required for resharding. This PR is a fix for this issue.

Link to zulip thread: https://near.zulipchat.com/#narrow/stream/308695-pagoda.2Fprivate/topic/cutting.201.2E37.2E0/near/420092380

Creation of snapshot happens via the function call `checkpoint_hot_storage_and_cleanup_columns` which takes a hot_store and creates a snapshot out of it. Later we open the snapshot `opener.open_in_mode(Mode::ReadWriteExisting)`.

The function `open_in_mode` -> `ensure_kind` -> `is_valid_kind_archive` was the point of failure. This is evident from the log line
```
Feb 06 14:19:29 testnet-rpc-archive-public-02-asia-east1-b-fc341f59 neard[1753]: 2024-02-06T14:19:29.215599Z ERROR state_snapshot: State snapshot creation failed err=Hot database kind should be RPC but got Some(Hot). Did you forget to set archive on your store opener?
```

There are three types of nodes, RPC, legacy archival and split storage nodes.

The function call to `get_default_kind` gets us the DbKind for the new snapshot hot storage while opening

To get the snapshot storage to open properly, we need to handle the three types of storages. We need to set the value of `archive` appropriately which is passed to the storage opener and ensure we set the correct storage type of the snapshot.

The table below talks about the expected values of each of these fields.

| Node type | Hot storage kind | Required snapshot storage type | archive |
| -- | -- | -- | -- |
| RPC | DbKind::RPC | RPC | false |
| Legacy Archival | DbKind::Archival | Legacy Archival | true |
| Split Storage | DbKind::Hot | RPC | false |

The place where our code went wrong with the split storage node was in function call to `is_valid_kind_archive` where the DbKind is Hot for split storage and archive is set as false.

The new relaxation in check basically states, if we are creating a snapshot of the hot storage from a split storage node, convert it into a RPC storage.

Testing: Adhoc testing where I manually set the storage DbKind as Hot and check the fix works.
Additionally added an integration test that manually sets the DbKind as Hot, Archive and RPC and checks whether resharding happens.