### PR TITLE
test: statelessnet ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,13 @@ jobs:
             type: stable
             runs_integ_tests: true
             upload_profraws: true
+          - name: Linux StatelessNet
+            id: linux-statelessnet
+            cache_id: linux
+            os: ubuntu-22.04-16core
+            type: statelessnet
+            runs_integ_tests: true
+            upload_profraws: true
           - name: Linux Nightly
             id: linux-nightly
             cache_id: linux

--- a/Justfile
+++ b/Justfile
@@ -7,6 +7,7 @@ with_macos_excludes := if os() == "macos" {
     ""
 }
 nightly_flags := "--features nightly,test_features"
+statelessnet_flags := "--features statelessnet_protocol"
 
 export RUST_BACKTRACE := env("RUST_BACKTRACE", "short")
 ci_hack_nextest_profile := if env("CI_HACKS", "0") == "1" { "--profile ci" } else { "" }
@@ -23,6 +24,7 @@ test-ci *FLAGS: check-cargo-fmt \
                 check-non-default \
                 check-cargo-udeps \
                 (nextest "nightly" FLAGS) \
+                (nextest "statelessnet" FLAGS) \
                 (nextest "stable" FLAGS)
 # order them with the fastest / most likely to fail checks first
 # when changing this, remember to adjust the CI workflow in parallel, as CI runs each of these in a separate job
@@ -43,6 +45,7 @@ nextest-unit TYPE *FLAGS:
         {{ ci_hack_nextest_profile }} \
         {{ with_macos_excludes }} \
         {{ if TYPE == "nightly" { nightly_flags } \
+           else if TYPE == "statelessnet" { statelessnet_flags } \
            else if TYPE == "stable" { "" } \
            else { error("TYPE is neighter 'nightly' nor 'stable'") } }} \
         {{ FLAGS }}
@@ -56,6 +59,7 @@ nextest-integration TYPE *FLAGS:
         --cargo-profile dev-release \
         {{ ci_hack_nextest_profile }} \
         {{ if TYPE == "nightly" { nightly_flags } \
+           else if TYPE == "statelessnet" { statelessnet_flags } \
            else if TYPE == "stable" { "" } \
            else { error("TYPE is neither 'nightly' nor 'stable'") } }} \
         {{ FLAGS }}

--- a/Justfile
+++ b/Justfile
@@ -28,6 +28,8 @@ test-ci *FLAGS: check-cargo-fmt \
                 (nextest "stable" FLAGS)
 # order them with the fastest / most likely to fail checks first
 # when changing this, remember to adjust the CI workflow in parallel, as CI runs each of these in a separate job
+# remove statelessnet everywhere once the program is finished, see
+# https://github.com/near/near-one-project-tracking/issues/20
 
 # tests that are as close to CI as possible, but not exactly the same code
 test-extra: check-lychee

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -85,4 +85,7 @@ nightly_protocol = [
   "near-primitives/nightly_protocol",
   "near-store/nightly_protocol",
 ]
+statelessnet_protocol = [
+  "near-primitives/statelessnet_protocol",
+]
 sandbox = ["near-primitives/sandbox"]

--- a/chain/chain/src/tests/mod.rs
+++ b/chain/chain/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod challenges;
 mod doomslug;
 mod garbage_collection;
+#[cfg(not(feature = "statelessnet_protocol"))]
 mod simple_chain;
 mod sync_chain;
 

--- a/chain/chain/src/tests/mod.rs
+++ b/chain/chain/src/tests/mod.rs
@@ -1,6 +1,8 @@
 mod challenges;
 mod doomslug;
 mod garbage_collection;
+// Checks consistency of chain block hashes for stable and nightly chains.
+// Disable for custom chains.
 #[cfg(not(feature = "statelessnet_protocol"))]
 mod simple_chain;
 mod sync_chain;

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -143,6 +143,7 @@ nightly_protocol = [
   "testlib/nightly_protocol",
 ]
 statelessnet_protocol = [
+  "near-chain/statelessnet_protocol",
   "near-primitives/statelessnet_protocol",
 ]
 sandbox = ["near-chain/sandbox", "node-runtime/sandbox", "near-client/sandbox"]

--- a/integration-tests/src/tests/client/features/limit_contract_functions_number.rs
+++ b/integration-tests/src/tests/client/features/limit_contract_functions_number.rs
@@ -75,7 +75,7 @@ fn verify_contract_limits_upgrade(
 
 // Check that we can't call a contract exceeding functions number limit after upgrade.
 // Disabled in nightly due to https://github.com/near/nearcore/issues/8590
-#[cfg(not(feature = "nightly"))]
+#[cfg(all(not(feature = "nightly"), not(feature = "statelessnet_protocol")))]
 #[test]
 fn test_function_limit_change() {
     verify_contract_limits_upgrade(
@@ -88,7 +88,7 @@ fn test_function_limit_change() {
 
 // Check that we can't call a contract exceeding functions number limit after upgrade.
 // Disabled in nightly due to https://github.com/near/nearcore/issues/8590
-#[cfg(not(feature = "nightly"))]
+#[cfg(all(not(feature = "nightly"), not(feature = "statelessnet_protocol")))]
 #[test]
 fn test_local_limit_change() {
     verify_contract_limits_upgrade(

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -175,7 +175,9 @@ nightly_protocol = [
   "node-runtime/nightly_protocol",
   "testlib/nightly_protocol",
 ]
-
+statelessnet_protocol = [
+  "near-chain/statelessnet_protocol"
+]
 sandbox = [
   "near-client/sandbox",
   "node-runtime/sandbox",

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -116,6 +116,7 @@ nightly_protocol = [
   "nearcore/nightly_protocol",
 ]
 statelessnet_protocol = [
+  "nearcore/statelessnet_protocol",
   "near-primitives/statelessnet_protocol",
 ]
 


### PR DESCRIPTION
Introduce automatic CI checks for latest statelessnet binary used for https://github.com/near/near-one-project-tracking/issues/20. This PR adopts new check automatically.
The check is not required, in order not to block main development flow.
Wanted to make this trigger only on demand, but there is no simple way to do it.