### PR TITLE
fix: adversenet speedups and fixes

### DIFF
--- a/pytest/lib/mocknet.py
+++ b/pytest/lib/mocknet.py
@@ -1090,7 +1090,6 @@ def neard_start_script(node, upgrade_schedule=None, epoch_height=None):
     return '''
         sudo mv /home/ubuntu/near.log /home/ubuntu/near.log.1 2>/dev/null
         sudo mv /home/ubuntu/near.upgrade.log /home/ubuntu/near.upgrade.log.1 2>/dev/null
-        sudo rm -rf /home/ubuntu/.near/data
         tmux new -s near -d bash
         sudo rm -rf /home/ubuntu/neard.log
         tmux send-keys -t near 'RUST_BACKTRACE=full RUST_LOG=debug,actix_web=info {neard_binary} run 2>&1 | tee -a {neard_binary}.log' C-m

--- a/pytest/lib/mocknet.py
+++ b/pytest/lib/mocknet.py
@@ -1056,15 +1056,20 @@ def create_and_upload_config_file_from_default(nodes, chain_id, overrider=None):
     pmap(lambda node: upload_config(node, config_json, overrider), nodes)
 
 
-def update_existing_config_file(nodes, overrider=None):
-    for node in nodes:
-        config_json = download_and_read_json(
-            nodes[0],
-            '/home/ubuntu/.near/config.json',
-        )
-        overrider(node, config_json)
-        upload_json(node, '/home/ubuntu/.near/config.json', config_json)
+def update_existing_config_file(node, overrider=None):
+    config_json = download_and_read_json(
+        node,
+        '/home/ubuntu/.near/config.json',
+    )
+    overrider(node, config_json)
+    upload_json(node, '/home/ubuntu/.near/config.json', config_json)
 
+
+def update_existing_config_files(nodes, overrider=None):
+    pmap(
+        lambda node: start_node(node, overrider=overrider),
+        nodes,
+    )
 
 def start_nodes(nodes, upgrade_schedule=None):
     pmap(

--- a/pytest/lib/mocknet.py
+++ b/pytest/lib/mocknet.py
@@ -1067,7 +1067,7 @@ def update_existing_config_file(node, overrider=None):
 
 def update_existing_config_files(nodes, overrider=None):
     pmap(
-        lambda node: start_node(node, overrider=overrider),
+        lambda node: update_existing_config_file(node, overrider=overrider),
         nodes,
     )
 

--- a/pytest/lib/mocknet.py
+++ b/pytest/lib/mocknet.py
@@ -932,8 +932,10 @@ def create_and_upload_genesis_file_from_empty_genesis(
     genesis_config['num_block_producer_seats_per_shard'] = [int(num_seats)] * 4
 
     genesis_config['records'] = records
-    pmap(lambda node: upload_json(node, '/home/ubuntu/.near/genesis.json', genesis_config),
-         [node for (node, _) in validator_node_and_stakes] + rpc_nodes)
+    pmap(
+        lambda node: upload_json(node, '/home/ubuntu/.near/genesis.json',
+                                 genesis_config),
+        [node for (node, _) in validator_node_and_stakes] + rpc_nodes)
 
 
 def download_and_read_json(node, filename):
@@ -1070,6 +1072,7 @@ def update_existing_config_files(nodes, overrider=None):
         lambda node: update_existing_config_file(node, overrider=overrider),
         nodes,
     )
+
 
 def start_nodes(nodes, upgrade_schedule=None):
     pmap(

--- a/pytest/lib/mocknet.py
+++ b/pytest/lib/mocknet.py
@@ -932,8 +932,8 @@ def create_and_upload_genesis_file_from_empty_genesis(
     genesis_config['num_block_producer_seats_per_shard'] = [int(num_seats)] * 4
 
     genesis_config['records'] = records
-    for node in [node for (node, _) in validator_node_and_stakes] + rpc_nodes:
-        upload_json(node, '/home/ubuntu/.near/genesis.json', genesis_config)
+    pmap(lambda node: upload_json(node, '/home/ubuntu/.near/genesis.json', genesis_config),
+         [node for (node, _) in validator_node_and_stakes] + rpc_nodes)
 
 
 def download_and_read_json(node, filename):
@@ -1027,6 +1027,13 @@ def update_config_file(
         json.dump(config_json, f, indent=2)
 
 
+def upload_config(node, config_json, overrider):
+    copied_config = json.loads(json.dumps(config_json))
+    if overrider:
+        overrider(node, copied_config)
+    upload_json(node, '/home/ubuntu/.near/config.json', copied_config)
+
+
 def create_and_upload_config_file_from_default(nodes, chain_id, overrider=None):
     nodes[0].machine.run(
         'rm -rf /home/ubuntu/.near-tmp && mkdir /home/ubuntu/.near-tmp && /home/ubuntu/neard --home /home/ubuntu/.near-tmp init --chain-id {}'
@@ -1046,11 +1053,7 @@ def create_and_upload_config_file_from_default(nodes, chain_id, overrider=None):
     if 'telemetry' in config_json:
         config_json['telemetry']['endpoints'] = []
 
-    for node in nodes:
-        copied_config = json.loads(json.dumps(config_json))
-        if overrider:
-            overrider(node, copied_config)
-        upload_json(node, '/home/ubuntu/.near/config.json', copied_config)
+    pmap(lambda node: upload_config(node, config_json, overrider), nodes)
 
 
 def update_existing_config_file(nodes, overrider=None):
@@ -1089,6 +1092,7 @@ def neard_start_script(node, upgrade_schedule=None, epoch_height=None):
         sudo mv /home/ubuntu/near.upgrade.log /home/ubuntu/near.upgrade.log.1 2>/dev/null
         sudo rm -rf /home/ubuntu/.near/data
         tmux new -s near -d bash
+        sudo rm -rf /home/ubuntu/neard.log
         tmux send-keys -t near 'RUST_BACKTRACE=full RUST_LOG=debug,actix_web=info {neard_binary} run 2>&1 | tee -a {neard_binary}.log' C-m
     '''.format(neard_binary=shlex.quote(neard_binary))
 

--- a/pytest/tests/mocknet/load_test_spoon.py
+++ b/pytest/tests/mocknet/load_test_spoon.py
@@ -274,6 +274,7 @@ class LoadTestSpoon:
             all_node_pks=all_node_pks,
             node_ips=node_ips,
         )
+        mocknet.clear_data(self.all_nodes)
         mocknet.start_nodes(self.all_nodes, self.upgrade_schedule)
         time.sleep(60)
 

--- a/pytest/tests/mocknet/run_adversenet.py
+++ b/pytest/tests/mocknet/run_adversenet.py
@@ -196,6 +196,6 @@ if __name__ == '__main__':
         mocknet.create_and_upload_config_file_from_default(
             all_nodes, chain_id, override_config)
     else:
-        mocknet.update_existing_config_file(all_nodes, override_config)
+        mocknet.update_existing_config_files(all_nodes, override_config)
     mocknet.start_nodes(all_nodes)
     mocknet.wait_all_nodes_up(all_nodes)


### PR DESCRIPTION
1. It is quite annoying to wait for sequential JSON uploading, especially for many nodes, so I parallelize this.
2. Not sure why neard init script always clears data if there is a specific function for it. Removing it from neard init - now it makes `update` command in adversenet actually working.
3. Removing neard logs on each restart because this file grows extremely quickly.

@robin-near why each "Adding account..." execution takes 5 seconds?