### PR TITLE
fix: bump statelessnet to 82

### DIFF
--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -206,7 +206,7 @@ const STABLE_PROTOCOL_VERSION: ProtocolVersion = 64;
 /// Largest protocol version supported by the current binary.
 pub const PROTOCOL_VERSION: ProtocolVersion = if cfg!(feature = "statelessnet_protocol") {
     // Current StatelessNet protocol version.
-    81
+    82
 } else if cfg!(feature = "nightly_protocol") {
     // On nightly, pick big enough version to support all features.
     139


### PR DESCRIPTION
Setting protocol version to use `ProtocolFeature::SingleShardTracking` introduced in https://github.com/near/nearcore/pull/10582.