### PR TITLE
[test] real_epoch_managers doesn't need `genesis.config`

### DIFF
--- a/chain/client/src/test_utils/test_env_builder.rs
+++ b/chain/client/src/test_utils/test_env_builder.rs
@@ -245,14 +245,13 @@ impl TestEnvBuilder {
         self
     }
 
-    pub fn real_epoch_managers(self, genesis_config: &GenesisConfig) -> Self {
-        self.real_epoch_managers_with_test_overrides(genesis_config, None)
+    pub fn real_epoch_managers(self) -> Self {
+        self.real_epoch_managers_with_test_overrides(None)
     }
 
     /// Constructs real EpochManager implementations for each instance.
     pub fn real_epoch_managers_with_test_overrides(
         self,
-        genesis_config: &GenesisConfig,
         test_overrides: Option<AllEpochConfigTestOverrides>,
     ) -> Self {
         assert!(
@@ -264,7 +263,7 @@ impl TestEnvBuilder {
             .map(|i| {
                 EpochManager::new_arc_handle_with_test_overrides(
                     ret.stores.as_ref().unwrap()[i].clone(),
-                    genesis_config,
+                    &ret.genesis_config,
                     test_overrides.clone(),
                 )
             })

--- a/integration-tests/src/tests/client/benchmarks.rs
+++ b/integration-tests/src/tests/client/benchmarks.rs
@@ -29,7 +29,7 @@ fn benchmark_large_chunk_production_time() {
 
     let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
 

--- a/integration-tests/src/tests/client/block_corruption.rs
+++ b/integration-tests/src/tests/client/block_corruption.rs
@@ -37,8 +37,8 @@ fn change_shard_id_to_invalid() {
     let epoch_length = 5000000;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
 
@@ -180,7 +180,7 @@ fn check_process_flipped_block_fails_on_bit(
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
 

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -60,8 +60,8 @@ fn test_block_with_challenges() {
 #[test]
 fn test_invalid_chunk_state() {
     let genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     env.produce_block(0, 1);
@@ -333,8 +333,8 @@ fn challenge(
 #[test]
 fn test_verify_chunk_invalid_state_challenge() {
     let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -332,7 +332,8 @@ fn challenge(
 
 #[test]
 fn test_verify_chunk_invalid_state_challenge() {
-    let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    genesis.config.min_gas_price = 0;
     let mut env = TestEnv::builder(&genesis.config)
         .real_epoch_managers()
         .nightshade_runtimes(&genesis)

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -122,7 +122,7 @@ fn test_storage_after_commit_of_cold_update() {
     genesis.config.epoch_length = epoch_length;
     genesis.config.min_gas_price = 0;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
 
@@ -233,7 +233,7 @@ fn test_cold_db_head_update() {
     let cold_db = storage.cold_db().unwrap();
     let mut env = TestEnv::builder(&genesis.config)
         .stores(vec![hot_store.clone()])
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
 
@@ -268,7 +268,7 @@ fn test_cold_db_copy_with_height_skips() {
     genesis.config.epoch_length = epoch_length;
     genesis.config.min_gas_price = 0;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
 
@@ -365,7 +365,7 @@ fn test_initial_copy_to_cold(batch_size: usize) {
     let mut genesis = Genesis::test(vec![test0(), test1()], 1);
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
 
@@ -449,7 +449,7 @@ fn test_cold_loop_on_gc_boundary() {
         .archive(true)
         .save_trie_changes(true)
         .stores(vec![hot_store.clone()])
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
 

--- a/integration-tests/src/tests/client/epoch_sync.rs
+++ b/integration-tests/src/tests/client/epoch_sync.rs
@@ -92,7 +92,7 @@ fn test_continuous_epoch_sync_info_population() {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
 
@@ -247,7 +247,7 @@ fn test_epoch_sync_data_hash_from_epoch_sync_info() {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
 
@@ -327,11 +327,11 @@ fn test_node_after_simulated_sync() {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
 
-    let mut env = TestEnv::default_builder()
+    let mut env = TestEnv::builder(&genesis.config)
         .clients_count(num_clients)
         .real_stores()
         .use_state_snapshots()
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
 

--- a/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
@@ -242,6 +242,7 @@ fn test_chunk_transaction_validity() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
+    genesis.config.min_gas_price = 0;
     let mut env = TestEnv::builder(&genesis.config)
         .real_epoch_managers()
         .nightshade_runtimes(&genesis)

--- a/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
@@ -52,8 +52,8 @@ fn test_transaction_hash_collision() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
@@ -125,8 +125,8 @@ fn get_status_of_tx_hash_collision_for_near_implicit_account(
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
     genesis.config.protocol_version = protocol_version;
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
@@ -242,8 +242,8 @@ fn test_chunk_transaction_validity() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
@@ -276,8 +276,8 @@ fn test_transaction_nonce_too_large() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
@@ -344,7 +344,7 @@ fn test_request_chunks_for_orphan() {
     let mut env = TestEnv::builder(&genesis.config)
         .clients_count(num_clients)
         .validator_seats(num_validators as usize)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .track_all_shards()
         .nightshade_runtimes_with_runtime_config_store(
             &genesis,
@@ -484,7 +484,7 @@ fn test_processing_chunks_sanity() {
     let mut env = TestEnv::builder(&genesis.config)
         .clients_count(num_clients)
         .validator_seats(num_validators as usize)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .track_all_shards()
         .nightshade_runtimes(&genesis)
         .build();
@@ -583,7 +583,7 @@ impl ChunkForwardingOptimizationTestData {
         let env = TestEnv::builder(&genesis.config)
             .clients_count(num_clients)
             .validator_seats(num_validators as usize)
-            .real_epoch_managers(&genesis.config)
+            .real_epoch_managers()
             .track_all_shards()
             .nightshade_runtimes(&genesis)
             .build();
@@ -812,7 +812,7 @@ fn test_processing_blocks_async() {
     let mut env = TestEnv::builder(&genesis.config)
         .clients_count(num_clients)
         .validator_seats(num_validators as usize)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .track_all_shards()
         .nightshade_runtimes(&genesis)
         .build();

--- a/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
+++ b/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
@@ -30,7 +30,7 @@ fn test_account_id_in_function_call_permission_upgrade() {
         genesis.config.epoch_length = epoch_length;
         genesis.config.protocol_version = old_protocol_version;
         TestEnv::builder(&genesis.config)
-            .real_epoch_managers(&genesis.config)
+            .real_epoch_managers()
             .nightshade_runtimes_with_runtime_config_store(
                 &genesis,
                 vec![RuntimeConfigStore::new(None)],
@@ -93,7 +93,7 @@ fn test_very_long_account_id() {
     let mut env = {
         let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
         TestEnv::builder(&genesis.config)
-            .real_epoch_managers(&genesis.config)
+            .real_epoch_managers()
             .nightshade_runtimes_with_runtime_config_store(
                 &genesis,
                 vec![RuntimeConfigStore::new(None)],

--- a/integration-tests/src/tests/client/features/adversarial_behaviors.rs
+++ b/integration-tests/src/tests/client/features/adversarial_behaviors.rs
@@ -62,7 +62,7 @@ impl AdversarialBehaviorTestData {
             .clock(clock.clock())
             .clients_count(num_clients)
             .validator_seats(num_validators as usize)
-            .real_epoch_managers(&genesis.config)
+            .real_epoch_managers()
             .track_all_shards()
             .nightshade_runtimes(&genesis)
             .build();

--- a/integration-tests/src/tests/client/features/chunk_nodes_cache.rs
+++ b/integration-tests/src/tests/client/features/chunk_nodes_cache.rs
@@ -91,7 +91,7 @@ fn compare_node_counts() {
     genesis.config.epoch_length = epoch_length;
     genesis.config.protocol_version = old_protocol_version;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes_with_runtime_config_store(
             &genesis,
             vec![RuntimeConfigStore::new(None)],

--- a/integration-tests/src/tests/client/features/delegate_action.rs
+++ b/integration-tests/src/tests/client/features/delegate_action.rs
@@ -57,8 +57,8 @@ fn exec_meta_transaction(
         Genesis::test(vec![validator, user.clone(), receiver.clone(), relayer.clone()], 1);
     genesis.config.epoch_length = 1000;
     genesis.config.protocol_version = protocol_version;
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
 

--- a/integration-tests/src/tests/client/features/fix_contract_loading_cost.rs
+++ b/integration-tests/src/tests/client/features/fix_contract_loading_cost.rs
@@ -19,7 +19,7 @@ fn prepare_env_with_contract(
     genesis.config.protocol_version = protocol_version;
     let runtime_config = near_parameters::RuntimeConfigStore::new(None);
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes_with_runtime_config_store(&genesis, vec![runtime_config])
         .build();
     deploy_test_contract(&mut env, account, &contract, epoch_length, 1);

--- a/integration-tests/src/tests/client/features/fix_storage_usage.rs
+++ b/integration-tests/src/tests/client/features/fix_storage_usage.rs
@@ -21,7 +21,7 @@ fn process_blocks_with_storage_usage_fix(
     genesis.config.epoch_length = epoch_length;
     genesis.config.protocol_version = ProtocolFeature::FixStorageUsage.protocol_version() - 1;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     for i in 1..=16 {

--- a/integration-tests/src/tests/client/features/flat_storage.rs
+++ b/integration-tests/src/tests/client/features/flat_storage.rs
@@ -29,7 +29,7 @@ fn test_flat_storage_upgrade() {
     genesis.config.protocol_version = old_protocol_version;
     let runtime_config = near_parameters::RuntimeConfigStore::new(None);
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes_with_runtime_config_store(&genesis, vec![runtime_config])
         .build();
 

--- a/integration-tests/src/tests/client/features/in_memory_tries.rs
+++ b/integration-tests/src/tests/client/features/in_memory_tries.rs
@@ -120,7 +120,7 @@ fn test_in_memory_trie_node_consistency() {
     let mut env = TestEnv::builder(&genesis.config)
         .clients(vec!["account0".parse().unwrap(), "account1".parse().unwrap()])
         .stores(stores.clone())
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .track_all_shards()
         .nightshade_runtimes_with_trie_config(
             &genesis,
@@ -179,7 +179,7 @@ fn test_in_memory_trie_node_consistency() {
     let mut env = TestEnv::builder(&genesis.config)
         .clients(vec!["account0".parse().unwrap(), "account1".parse().unwrap()])
         .stores(stores.clone())
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .track_all_shards()
         .nightshade_runtimes_with_trie_config(
             &genesis,
@@ -210,7 +210,7 @@ fn test_in_memory_trie_node_consistency() {
     let mut env = TestEnv::builder(&genesis.config)
         .clients(vec!["account0".parse().unwrap(), "account1".parse().unwrap()])
         .stores(stores)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .track_all_shards()
         .nightshade_runtimes_with_trie_config(
             &genesis,

--- a/integration-tests/src/tests/client/features/increase_deployment_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_deployment_cost.rs
@@ -35,7 +35,7 @@ fn test_deploy_cost_increased() {
         genesis.config.epoch_length = epoch_length;
         genesis.config.protocol_version = old_protocol_version;
         TestEnv::builder(&genesis.config)
-            .real_epoch_managers(&genesis.config)
+            .real_epoch_managers()
             .nightshade_runtimes_with_runtime_config_store(
                 &genesis,
                 vec![RuntimeConfigStore::new(None)],

--- a/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
@@ -195,7 +195,7 @@ fn assert_compute_limit_reached(
         genesis.config.protocol_version = old_protocol_version;
         genesis.config.gas_limit = genesis.config.gas_limit / gas_divider;
         TestEnv::builder(&genesis.config)
-            .real_epoch_managers(&genesis.config)
+            .real_epoch_managers()
             .nightshade_runtimes_with_runtime_config_store(&genesis, vec![runtime_config_store])
             .build()
     };

--- a/integration-tests/src/tests/client/features/limit_contract_functions_number.rs
+++ b/integration-tests/src/tests/client/features/limit_contract_functions_number.rs
@@ -29,7 +29,7 @@ fn verify_contract_limits_upgrade(
         genesis.config.epoch_length = epoch_length;
         genesis.config.protocol_version = old_protocol_version;
         let mut env = TestEnv::builder(&genesis.config)
-            .real_epoch_managers(&genesis.config)
+            .real_epoch_managers()
             .nightshade_runtimes_with_runtime_config_store(
                 &genesis,
                 vec![RuntimeConfigStore::new(None)],

--- a/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
+++ b/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
@@ -44,7 +44,7 @@ fn protocol_upgrade() {
         genesis.config.epoch_length = epoch_length;
         genesis.config.protocol_version = old_protocol_version;
         let mut env = TestEnv::builder(&genesis.config)
-            .real_epoch_managers(&genesis.config)
+            .real_epoch_managers()
             .track_all_shards()
             .nightshade_runtimes_with_runtime_config_store(
                 &genesis,

--- a/integration-tests/src/tests/client/features/nearvm.rs
+++ b/integration-tests/src/tests/client/features/nearvm.rs
@@ -28,7 +28,7 @@ fn test_nearvm_upgrade() {
         genesis.config.epoch_length = epoch_length;
         genesis.config.protocol_version = old_protocol_version;
         let mut env = TestEnv::builder(&genesis.config)
-            .real_epoch_managers(&genesis.config)
+            .real_epoch_managers()
             .nightshade_runtimes_with_runtime_config_store(
                 &genesis,
                 vec![RuntimeConfigStore::new(None)],

--- a/integration-tests/src/tests/client/features/restore_receipts_after_fix_apply_chunks.rs
+++ b/integration-tests/src/tests/client/features/restore_receipts_after_fix_apply_chunks.rs
@@ -33,7 +33,7 @@ fn run_test(
     let migration_data = load_migration_data(&genesis.config.chain_id);
 
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
 

--- a/integration-tests/src/tests/client/features/restrict_tla.rs
+++ b/integration-tests/src/tests/client/features/restrict_tla.rs
@@ -17,7 +17,7 @@ fn test_create_top_level_accounts() {
     genesis.config.protocol_version = PROTOCOL_VERSION;
     let runtime_config = near_parameters::RuntimeConfigStore::new(None);
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes_with_runtime_config_store(&genesis, vec![runtime_config])
         .build();
 

--- a/integration-tests/src/tests/client/features/stateless_validation.rs
+++ b/integration-tests/src/tests/client/features/stateless_validation.rs
@@ -121,7 +121,7 @@ fn run_chunk_validation_test(seed: u64, prob_missing_chunk: f64) {
     let genesis = Genesis::new(genesis_config, GenesisRecords(records)).unwrap();
     let mut env = TestEnv::builder(&genesis.config)
         .clients(accounts.iter().take(8).cloned().collect())
-        .real_epoch_managers_with_test_overrides(&genesis.config, epoch_config_test_overrides)
+        .real_epoch_managers_with_test_overrides(epoch_config_test_overrides)
         .nightshade_runtimes(&genesis)
         .build();
     let mut tx_hashes = vec![];

--- a/integration-tests/src/tests/client/features/wallet_contract.rs
+++ b/integration-tests/src/tests/client/features/wallet_contract.rs
@@ -72,8 +72,8 @@ fn test_eth_implicit_account_creation() {
         return;
     }
     let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
@@ -128,8 +128,8 @@ fn test_transaction_from_eth_implicit_account_fail() {
         return;
     }
     let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();

--- a/integration-tests/src/tests/client/features/zero_balance_account.rs
+++ b/integration-tests/src/tests/client/features/zero_balance_account.rs
@@ -51,8 +51,8 @@ fn test_zero_balance_account_creation() {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
     genesis.config.protocol_version = ProtocolFeature::ZeroBalanceAccount.protocol_version();
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
@@ -132,8 +132,8 @@ fn test_zero_balance_account_add_key() {
     };
     runtime_config.wasm_config.ext_costs = ExtCostsConfig::test();
     let runtime_config_store = RuntimeConfigStore::with_one_config(runtime_config);
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes_with_runtime_config_store(&genesis, vec![runtime_config_store])
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
@@ -251,8 +251,8 @@ fn test_zero_balance_account_upgrade() {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
     genesis.config.protocol_version = ProtocolFeature::ZeroBalanceAccount.protocol_version() - 1;
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -35,7 +35,7 @@ const CREATION_TIMEOUT: BlockHeight = 30;
 fn setup_env(genesis: &Genesis, store: Store) -> TestEnv {
     TestEnv::builder(&genesis.config)
         .stores(vec![store])
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(genesis)
         .build()
 }

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -201,7 +201,7 @@ pub(crate) fn prepare_env_with_congestion(
         genesis.config.gas_price_adjustment_rate = gas_price_adjustment_rate;
     }
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
@@ -1015,7 +1015,7 @@ fn test_process_invalid_tx() {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
     genesis.config.transaction_validity_period = 10;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test0");
@@ -1221,7 +1221,7 @@ fn test_bad_chunk_mask() {
     let genesis = Genesis::test_sharded(accounts.clone(), num_validators, vec![num_validators; 2]);
     let mut env = TestEnv::builder(&genesis.config)
         .clients(accounts)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .track_all_shards()
         .build();
@@ -1305,7 +1305,7 @@ fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let mut blocks = vec![];
@@ -1371,7 +1371,7 @@ fn test_archival_save_trie_changes() {
     genesis.config.epoch_length = epoch_length;
     genesis.config.total_supply = 1_000_000_000;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .archive(true)
         .save_trie_changes(true)
@@ -1442,7 +1442,7 @@ fn test_archival_gc_common(
     let hot_store = &storage.get_hot_store();
     let mut env = TestEnv::builder(&genesis.config)
         .stores(vec![hot_store.clone()])
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .archive(true)
         .save_trie_changes(true)
@@ -1592,7 +1592,7 @@ fn test_gc_execution_outcome() {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_hash = *env.clients[0].chain.genesis().hash();
@@ -1627,7 +1627,7 @@ fn test_gc_after_state_sync() {
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(&genesis.config)
         .clients_count(2)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     for i in 1..epoch_length * 4 + 2 {
@@ -1668,7 +1668,7 @@ fn test_process_block_after_state_sync() {
         .clients_count(1)
         .use_state_snapshots()
         .real_stores()
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
 
@@ -1710,7 +1710,7 @@ fn test_gc_fork_tail() {
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(&genesis.config)
         .clients_count(2)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let b1 = env.clients[0].produce_block(1).unwrap().unwrap();
@@ -1782,7 +1782,7 @@ fn test_tx_forward_around_epoch_boundary() {
     let mut env = TestEnv::builder(&genesis.config)
         .clients_count(3)
         .validator_seats(2)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_hash = *env.clients[0].chain.genesis().hash();
@@ -1838,7 +1838,7 @@ fn test_not_resync_old_blocks() {
     let epoch_length = 5;
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let mut blocks = vec![];
@@ -1863,7 +1863,7 @@ fn test_gc_tail_update() {
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(&genesis.config)
         .clients_count(2)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let mut blocks = vec![];
@@ -1918,7 +1918,7 @@ fn test_gas_price_change() {
     genesis.config.gas_limit = gas_limit;
     genesis.config.gas_price_adjustment_rate = gas_price_adjustment_rate;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
 
@@ -1966,7 +1966,7 @@ fn test_gas_price_overflow() {
     genesis.config.max_gas_price = max_gas_price;
 
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
@@ -2004,7 +2004,7 @@ fn test_incorrect_validator_key_produce_block() {
     let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 2);
     let mut env = TestEnv::builder(&genesis.config)
         .clients_count(1)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .track_all_shards()
         .build();
@@ -2093,10 +2093,8 @@ fn test_data_reset_before_state_sync() {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
     let epoch_length = 5;
     genesis.config.epoch_length = epoch_length;
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
-        .nightshade_runtimes(&genesis)
-        .build();
+    let mut env =
+        TestEnv::default_builder().real_epoch_managers().nightshade_runtimes(&genesis).build();
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let genesis_hash = *genesis_block.hash();
@@ -2152,7 +2150,7 @@ fn test_sync_hash_validity() {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     for i in 1..19 {
@@ -2202,10 +2200,8 @@ fn test_validate_chunk_extra() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
-        .nightshade_runtimes(&genesis)
-        .build();
+    let mut env =
+        TestEnv::default_builder().real_epoch_managers().nightshade_runtimes(&genesis).build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let genesis_height = genesis_block.header().height();
 
@@ -2363,7 +2359,7 @@ fn test_catchup_gas_price_change() {
         .clients_count(2)
         .use_state_snapshots()
         .real_stores()
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
 
@@ -2466,7 +2462,7 @@ fn test_block_execution_outcomes() {
     genesis.config.min_gas_price = min_gas_price;
     genesis.config.gas_limit = 1000000000000;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
@@ -2557,7 +2553,7 @@ fn test_refund_receipts_processing() {
     // transactions to get through.
     genesis.config.gas_limit = 100_000_000;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
@@ -2634,7 +2630,7 @@ fn test_delayed_receipt_count_limit() {
     let chunk_gas_limit = 10 * transaction_costs.fee(ActionCosts::new_action_receipt).exec_fee();
     genesis.config.gas_limit = chunk_gas_limit;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
@@ -2696,7 +2692,7 @@ fn test_execution_metadata() {
             Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
         genesis.config.epoch_length = epoch_length;
         let mut env = TestEnv::builder(&genesis.config)
-            .real_epoch_managers(&genesis.config)
+            .real_epoch_managers()
             .nightshade_runtimes(&genesis)
             .build();
 
@@ -2776,7 +2772,7 @@ fn test_epoch_protocol_version_change() {
     let mut env = TestEnv::builder(&genesis.config)
         .clients_count(2)
         .validator_seats(2)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     for i in 1..=16 {
@@ -2835,7 +2831,7 @@ fn test_epoch_protocol_version_change() {
 fn test_discard_non_finalizable_block() {
     let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
 
@@ -2896,7 +2892,7 @@ fn test_query_final_state() {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
@@ -3096,10 +3092,8 @@ fn prepare_env_with_transaction() -> (TestEnv, CryptoHash) {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
-        .nightshade_runtimes(&genesis)
-        .build();
+    let mut env =
+        TestEnv::default_builder().real_epoch_managers().nightshade_runtimes(&genesis).build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
@@ -3124,7 +3118,7 @@ fn test_not_broadcast_block_on_accept() {
     let network_adapter = Arc::new(MockPeerManagerAdapter::default());
     let mut env = TestEnv::default_builder()
         .clients_count(2)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .network_adapters(vec![
             Arc::new(MockPeerManagerAdapter::default()),
@@ -3145,7 +3139,7 @@ fn test_header_version_downgrade() {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = 5;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let validator_signer = create_test_signer("test0");
@@ -3192,10 +3186,8 @@ fn test_node_shutdown_with_old_protocol_version() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
-        .nightshade_runtimes(&genesis)
-        .build();
+    let mut env =
+        TestEnv::default_builder().real_epoch_managers().nightshade_runtimes(&genesis).build();
     let validator_signer = create_test_signer("test0");
     for i in 1..=5 {
         let mut block = env.clients[0].produce_block(i).unwrap().unwrap();
@@ -3325,10 +3317,8 @@ fn test_validator_stake_host_function() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
-        .nightshade_runtimes(&genesis)
-        .build();
+    let mut env =
+        TestEnv::default_builder().real_epoch_managers().nightshade_runtimes(&genesis).build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let block_height = deploy_test_contract(
         &mut env,
@@ -3370,7 +3360,7 @@ fn test_catchup_no_sharding_change() {
     let mut env = TestEnv::builder(&genesis.config)
         .clients_count(1)
         .validator_seats(1)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     // run the chain to a few epochs and make sure no catch up is triggered and the chain still
@@ -3405,7 +3395,7 @@ fn test_long_chain_with_restart_from_snapshot() {
 
     genesis.config.epoch_length = epoch_length;
     let mut env1 = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .archive(false)
         .build();
@@ -3426,7 +3416,7 @@ fn test_long_chain_with_restart_from_snapshot() {
 
     let mut env2 = TestEnv::builder(&genesis.config)
         .stores(vec![env1.clients[0].chain.chain_store().store().clone()])
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .archive(false)
         .build();
@@ -3483,7 +3473,7 @@ mod contract_precompilation_tests {
             .clients_count(num_clients)
             .use_state_snapshots()
             .real_stores()
-            .real_epoch_managers(&genesis.config)
+            .real_epoch_managers()
             .nightshade_runtimes(&genesis)
             .build();
 
@@ -3579,7 +3569,7 @@ mod contract_precompilation_tests {
             .clients_count(num_clients)
             .use_state_snapshots()
             .real_stores()
-            .real_epoch_managers(&genesis.config)
+            .real_epoch_managers()
             .nightshade_runtimes(&genesis)
             .build();
 
@@ -3657,7 +3647,7 @@ mod contract_precompilation_tests {
             .clients_count(num_clients)
             .use_state_snapshots()
             .real_stores()
-            .real_epoch_managers(&genesis.config)
+            .real_epoch_managers()
             .nightshade_runtimes(&genesis)
             .build();
 

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2202,6 +2202,7 @@ fn test_validate_chunk_extra() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
+    genesis.config.min_gas_price = 0;
     let mut env = TestEnv::builder(&genesis.config)
         .real_epoch_managers()
         .nightshade_runtimes(&genesis)
@@ -3478,9 +3479,8 @@ mod contract_precompilation_tests {
         let mut genesis =
             Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
         genesis.config.epoch_length = EPOCH_LENGTH;
-        genesis.config.min_gas_price = 0;
 
-        let mut env = TestEnv::default_builder()
+        let mut env = TestEnv::builder(&genesis.config)
             .clients_count(num_clients)
             .use_state_snapshots()
             .real_stores()
@@ -3575,9 +3575,8 @@ mod contract_precompilation_tests {
         let mut genesis =
             Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
         genesis.config.epoch_length = EPOCH_LENGTH;
-        genesis.config.min_gas_price = 0;
 
-        let mut env = TestEnv::default_builder()
+        let mut env = TestEnv::builder(&genesis.config)
             .clients_count(num_clients)
             .use_state_snapshots()
             .real_stores()
@@ -3654,9 +3653,8 @@ mod contract_precompilation_tests {
             1,
         );
         genesis.config.epoch_length = EPOCH_LENGTH;
-        genesis.config.min_gas_price = 0;
 
-        let mut env = TestEnv::default_builder()
+        let mut env = TestEnv::builder(&genesis.config)
             .clients_count(num_clients)
             .use_state_snapshots()
             .real_stores()

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2093,8 +2093,10 @@ fn test_data_reset_before_state_sync() {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
     let epoch_length = 5;
     genesis.config.epoch_length = epoch_length;
-    let mut env =
-        TestEnv::default_builder().real_epoch_managers().nightshade_runtimes(&genesis).build();
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
+        .nightshade_runtimes(&genesis)
+        .build();
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let genesis_hash = *genesis_block.hash();
@@ -2200,8 +2202,10 @@ fn test_validate_chunk_extra() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
-    let mut env =
-        TestEnv::default_builder().real_epoch_managers().nightshade_runtimes(&genesis).build();
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
+        .nightshade_runtimes(&genesis)
+        .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let genesis_height = genesis_block.header().height();
 
@@ -3092,8 +3096,10 @@ fn prepare_env_with_transaction() -> (TestEnv, CryptoHash) {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
-    let mut env =
-        TestEnv::default_builder().real_epoch_managers().nightshade_runtimes(&genesis).build();
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
+        .nightshade_runtimes(&genesis)
+        .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
@@ -3116,7 +3122,7 @@ fn test_not_broadcast_block_on_accept() {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
     let network_adapter = Arc::new(MockPeerManagerAdapter::default());
-    let mut env = TestEnv::default_builder()
+    let mut env = TestEnv::builder(&genesis.config)
         .clients_count(2)
         .real_epoch_managers()
         .nightshade_runtimes(&genesis)
@@ -3186,8 +3192,10 @@ fn test_node_shutdown_with_old_protocol_version() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
-    let mut env =
-        TestEnv::default_builder().real_epoch_managers().nightshade_runtimes(&genesis).build();
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
+        .nightshade_runtimes(&genesis)
+        .build();
     let validator_signer = create_test_signer("test0");
     for i in 1..=5 {
         let mut block = env.clients[0].produce_block(i).unwrap().unwrap();
@@ -3317,8 +3325,10 @@ fn test_validator_stake_host_function() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
-    let mut env =
-        TestEnv::default_builder().real_epoch_managers().nightshade_runtimes(&genesis).build();
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
+        .nightshade_runtimes(&genesis)
+        .build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let block_height = deploy_test_contract(
         &mut env,
@@ -3468,6 +3478,7 @@ mod contract_precompilation_tests {
         let mut genesis =
             Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
         genesis.config.epoch_length = EPOCH_LENGTH;
+        genesis.config.min_gas_price = 0;
 
         let mut env = TestEnv::default_builder()
             .clients_count(num_clients)
@@ -3564,6 +3575,7 @@ mod contract_precompilation_tests {
         let mut genesis =
             Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
         genesis.config.epoch_length = EPOCH_LENGTH;
+        genesis.config.min_gas_price = 0;
 
         let mut env = TestEnv::default_builder()
             .clients_count(num_clients)
@@ -3642,6 +3654,7 @@ mod contract_precompilation_tests {
             1,
         );
         genesis.config.epoch_length = EPOCH_LENGTH;
+        genesis.config.min_gas_price = 0;
 
         let mut env = TestEnv::default_builder()
             .clients_count(num_clients)

--- a/integration-tests/src/tests/client/resharding.rs
+++ b/integration-tests/src/tests/client/resharding.rs
@@ -218,7 +218,7 @@ impl TestReshardingEnv {
             .clients_count(num_clients)
             .validator_seats(num_validators)
             .real_stores()
-            .real_epoch_managers_with_test_overrides(&genesis.config, epoch_config_test_overrides)
+            .real_epoch_managers_with_test_overrides(epoch_config_test_overrides)
             .nightshade_runtimes(&genesis)
             .track_all_shards()
             .build();

--- a/integration-tests/src/tests/client/runtimes.rs
+++ b/integration-tests/src/tests/client/runtimes.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 #[test]
 fn test_pending_approvals() {
     let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let signer = create_test_signer("test0");
@@ -40,8 +40,8 @@ fn test_pending_approvals() {
 fn test_invalid_approvals() {
     let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     let network_adapter = Arc::new(MockPeerManagerAdapter::default());
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .network_adapters(vec![network_adapter])
         .build();
@@ -72,7 +72,7 @@ fn test_cap_max_gas_price() {
     genesis.config.protocol_version = ProtocolFeature::CapMaxGasPrice.protocol_version();
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(&genesis.config)
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
 

--- a/integration-tests/src/tests/client/sandbox.rs
+++ b/integration-tests/src/tests/client/sandbox.rs
@@ -17,8 +17,8 @@ fn test_setup() -> (TestEnv, InMemorySigner) {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
-    let mut env = TestEnv::default_builder()
-        .real_epoch_managers(&genesis.config)
+    let mut env = TestEnv::builder(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
     let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");

--- a/integration-tests/src/tests/client/state_dump.rs
+++ b/integration-tests/src/tests/client/state_dump.rs
@@ -43,7 +43,7 @@ fn test_state_dump() {
             .clients_count(1)
             .use_state_snapshots()
             .real_stores()
-            .real_epoch_managers(&genesis.config)
+            .real_epoch_managers()
             .nightshade_runtimes(&genesis)
             .build();
 
@@ -141,7 +141,7 @@ fn run_state_sync_with_dumped_parts(
             .clients_count(num_clients)
             .use_state_snapshots()
             .real_stores()
-            .real_epoch_managers(&genesis.config)
+            .real_epoch_managers()
             .nightshade_runtimes(&genesis)
             .build();
 

--- a/integration-tests/src/tests/client/state_snapshot.rs
+++ b/integration-tests/src/tests/client/state_snapshot.rs
@@ -194,11 +194,11 @@ fn delete_content_at_path(path: &str) -> std::io::Result<()> {
 fn test_make_state_snapshot() {
     init_test_logger();
     let genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
-    let mut env = TestEnv::default_builder()
+    let mut env = TestEnv::builder(&genesis.config)
         .clients_count(1)
         .use_state_snapshots()
         .real_stores()
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(&genesis)
         .build();
 

--- a/integration-tests/src/tests/client/sync_state_nodes.rs
+++ b/integration-tests/src/tests/client/sync_state_nodes.rs
@@ -568,7 +568,7 @@ fn test_dump_epoch_missing_chunk_in_last_block() {
                 .clients_count(2)
                 .use_state_snapshots()
                 .real_stores()
-                .real_epoch_managers(&genesis.config)
+                .real_epoch_managers()
                 .nightshade_runtimes(&genesis)
                 .build();
 

--- a/integration-tests/src/tests/client/undo_block.rs
+++ b/integration-tests/src/tests/client/undo_block.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 fn setup_env(genesis: &Genesis, store: Store) -> (TestEnv, Arc<dyn EpochManagerAdapter>) {
     let env = TestEnv::builder(&genesis.config)
         .stores(vec![store])
-        .real_epoch_managers(&genesis.config)
+        .real_epoch_managers()
         .nightshade_runtimes(genesis)
         .build();
     let epoch_manager = env.clients[0].epoch_manager.clone();

--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -339,13 +339,13 @@ mod test {
                 .validator_seats(2)
                 .use_state_snapshots()
                 .real_stores()
-                .real_epoch_managers(&genesis.config)
+                .real_epoch_managers()
                 .nightshade_runtimes(&genesis)
                 .build()
         } else {
             TestEnv::builder(&genesis.config)
                 .validator_seats(2)
-                .real_epoch_managers(&genesis.config)
+                .real_epoch_managers()
                 .nightshade_runtimes(&genesis)
                 .build()
         };


### PR DESCRIPTION
Buildup PRs

https://github.com/near/nearcore/pull/10590
https://github.com/near/nearcore/pull/10591
https://github.com/near/nearcore/pull/10594

Next PR I'll try using the real epoch manager as default and let's see what happens...
