### PR TITLE
fix: test_chunk_forwarding_optimization with statelessnet_protocol feature

### DIFF
--- a/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
@@ -775,7 +775,7 @@ fn test_chunk_forwarding_optimization() {
     // Note: For nightly, which includes SingleShardTracking, this check is disabled because
     // we're so efficient with part forwarding now that we don't seem to be forwarding more
     // than it is necessary.
-    if !cfg!(feature = "nightly") {
+    if !cfg!(feature = "nightly") && !cfg!(feature = "statelessnet_protocol") {
         assert!(PARTIAL_ENCODED_CHUNK_FORWARD_CACHED_WITHOUT_HEADER.get() > 0.0);
     }
     debug!(target: "test",


### PR DESCRIPTION
The main assertion in the integration test `test_chunk_forwarding_optimization` is disabled on `--features nightly`, which is a recent change that was introduced due to single shard tracking in https://github.com/near/nearcore/pull/10582.

Let's also disable it on `--features statelessnet_protocol`, the reasoning is similar.

Fixes: https://github.com/near/nearcore/issues/10600