### PR TITLE
fix: don't read empty flat storage deltas

### DIFF
--- a/core/store/src/flat/delta.rs
+++ b/core/store/src/flat/delta.rs
@@ -128,7 +128,7 @@ impl FlatStateChanges {
 
 /// `FlatStateChanges` which uses hash of raw `TrieKey`s instead of keys themselves.
 /// Used to reduce memory used by deltas and serves read queries.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct CachedFlatStateChanges(HashMap<CryptoHash, Option<ValueRef>>);
 
 #[derive(Debug)]

--- a/core/store/src/flat/storage.rs
+++ b/core/store/src/flat/storage.rs
@@ -255,13 +255,20 @@ impl FlatStorage {
         let mut deltas = HashMap::new();
         for delta_metadata in deltas_metadata {
             let block_hash = delta_metadata.block.hash;
-            let changes: CachedFlatStateChanges =
+            let changes: CachedFlatStateChanges = if delta_metadata
+                .prev_block_with_changes
+                .is_none()
+            {
                 store_helper::get_delta_changes(&store, shard_uid, block_hash)
                     .expect("failed to read flat state delta changes")
                     .unwrap_or_else(|| {
                         panic!("cannot find block delta for block {block_hash:?} shard {shard_id}")
                     })
-                    .into();
+                    .into()
+            } else {
+                // Don't read delta if we know that it is empty.
+                Default::default()
+            };
             deltas.insert(
                 block_hash,
                 CachedFlatStateDelta { metadata: delta_metadata, changes: Arc::new(changes) },


### PR DESCRIPTION
Temporary optimization for cases when there are no state changes for a while and deltas are not removed from storage.
If we know from metadata that delta is empty, set it to empty without reading it.