### PR TITLE
[resharding] Handle case of restarting node during resharding catchup

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2983,6 +2983,11 @@ impl Chain {
         }
         chain_store_update.remove_state_sync_info(*epoch_first_block);
 
+        // Remove all stored split state changes for resharding once catchup is completed.
+        // We only remove these after the catchup is completed to ensure that restarting the node
+        // in the middle of the catchup does not lead to the split state already being deleted from prior run
+        chain_store_update.remove_all_state_changes_for_resharding();
+
         chain_store_update.commit()?;
 
         for hash in affected_blocks.iter() {

--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -395,8 +395,6 @@ impl<'a> ChainUpdate<'a> {
                 }
             }
             ShardUpdateResult::Resharding(ReshardingResult { shard_uid, results }) => {
-                self.chain_store_update
-                    .remove_state_changes_for_resharding(*block.hash(), shard_uid.shard_id());
                 self.process_resharding_results(
                     block,
                     &shard_uid,

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -1442,7 +1442,7 @@ pub struct ChainStoreUpdate<'a> {
     state_transition_data: HashMap<(CryptoHash, ShardId), StoredChunkStateTransitionData>,
     // All state changes made by a chunk, this is only used for resharding.
     add_state_changes_for_resharding: HashMap<(CryptoHash, ShardId), StateChangesForResharding>,
-    remove_state_changes_for_resharding: HashSet<(CryptoHash, ShardId)>,
+    remove_all_state_changes_for_resharding: bool,
     add_blocks_to_catchup: Vec<(CryptoHash, CryptoHash)>,
     // A pair (prev_hash, hash) to be removed from blocks to catchup
     remove_blocks_to_catchup: Vec<(CryptoHash, CryptoHash)>,
@@ -1469,7 +1469,7 @@ impl<'a> ChainStoreUpdate<'a> {
             trie_changes: vec![],
             state_transition_data: Default::default(),
             add_state_changes_for_resharding: HashMap::new(),
-            remove_state_changes_for_resharding: HashSet::new(),
+            remove_all_state_changes_for_resharding: false,
             add_blocks_to_catchup: vec![],
             remove_blocks_to_catchup: vec![],
             remove_prev_blocks_to_catchup: vec![],
@@ -2108,15 +2108,8 @@ impl<'a> ChainStoreUpdate<'a> {
         assert!(prev.is_none());
     }
 
-    pub fn remove_state_changes_for_resharding(
-        &mut self,
-        block_hash: CryptoHash,
-        shard_id: ShardId,
-    ) {
-        // We should not remove state changes for the same chunk twice
-        let value_not_present =
-            self.remove_state_changes_for_resharding.insert((block_hash, shard_id));
-        assert!(value_not_present);
+    pub fn remove_all_state_changes_for_resharding(&mut self) {
+        self.remove_all_state_changes_for_resharding = true;
     }
 
     pub fn add_block_to_catchup(&mut self, prev_hash: CryptoHash, block_hash: CryptoHash) {
@@ -2560,11 +2553,9 @@ impl<'a> ChainStoreUpdate<'a> {
                 &state_changes,
             )?;
         }
-        for (block_hash, shard_id) in self.remove_state_changes_for_resharding.drain() {
-            store_update.delete(
-                DBCol::StateChangesForSplitStates,
-                &get_block_shard_id(&block_hash, shard_id),
-            );
+
+        if self.remove_all_state_changes_for_resharding {
+            store_update.delete_all(DBCol::StateChangesForSplitStates);
         }
 
         let mut affected_catchup_blocks = HashSet::new();


### PR DESCRIPTION
This PR is a fix for the issue where when we restart a node doing resharding and in the catchup phase.

High level issue: When we restart a node in the epoch when resharding in happening, what happens is we go through the whole state_sync process from the beginning which includes resharding. Once building of the child trie is completed, we then do a catchup, apply the split state to the child tried and delete the split state changes for resharding [here](https://github.com/near/nearcore/blob/e00dcaa72cfed35831b1e72760d21bb8152f1049/chain/chain/src/chain_update.rs#L399).

Zulip thread link: https://near.zulipchat.com/#narrow/stream/308695-pagoda.2Fprivate/topic/Problems.20after.20resharding.20restart/near/421312417

This is the implementation of Option 1 in the thread.

The key idea here is to not delete the `DBCol::StateChangesForSplitStates` during catchup of individual blocks but rather at the end of the catchup phase. This implies, in case we restart the node in the middle the catchup, we would still have all the split state information in `DBCol::StateChangesForSplitStates` and it wouldn't have been deleted.

TODO: Testing on mocknet.