### PR TITLE
Limit ChunkStateWitness size to 16MB

### DIFF
--- a/core/primitives/src/stateless_validation.rs
+++ b/core/primitives/src/stateless_validation.rs
@@ -17,6 +17,9 @@ use near_primitives_core::types::{AccountId, Balance};
 /// This is a messy workaround until we know what to do with NEP 483.
 type SignatureDifferentiator = String;
 
+/// ChunkStateWitnesses with `inner` larger than 16MB will be rejected.
+pub const MAX_CHUNK_STATE_WITNESS_INNER_SIZE: usize = 16_000_000;
+
 /// Signable
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ChunkStateWitness {


### PR DESCRIPTION
This PR limits the size of `ChunkStateWitness` to 16MB. Witnesses larger than 16MB will be considered invalid.

It'll help to protect from abuse - huge `ChunkStateWitnesses` would require a lot of resource to process, and they would take up a lot of space in orphan witness pool, so it's good to immediately reject witnesses that are too big.

During StatelessNet loadtests by @staffik the maximum observed size of `ChunkStateWitness` was 8MB, so 16MB should be a safe limit.

There's a safeguard to make sure that a node doesn't send out a `ChunkStateWitness` which is larger than 16MB. It's good to have a safeguard there, we don't want to get all nodes banned if it turns out that the estimate was wrong and naturally produced `ChunkStateWitnesses` are sometimes larger than 16MB. 

Technically we measure the size of `ChunkStateWitnessInner`, not `ChunkStateWitness`. It was easier to do it this way because `sign_chunk_state_witness` returns the size of `ChunkStateWitnessInner`, which is also later used in the metrics.
Limiting the size of `ChunkStateWitnessInner` is enough, as `ChunkStateWitness` is made up of `ChunkStateWitnessInner` and a constant-size signature, so its size is also limited.

Refs: https://github.com/near/nearcore/issues/10259 (but not fixes, it's a primitive limit that doesn't take into account computation costs, etc)