### PR TITLE
fix: timeout in skip_epoch pytest

### DIFF
--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -51,8 +51,8 @@ pytest sanity/sync_chunks_from_archival.py
 pytest sanity/sync_chunks_from_archival.py --features nightly
 pytest sanity/rpc_tx_forwarding.py
 pytest sanity/rpc_tx_forwarding.py --features nightly
-pytest --timeout=240 sanity/skip_epoch.py
-pytest --timeout=240 sanity/skip_epoch.py --features nightly
+pytest --timeout=480 sanity/skip_epoch.py
+pytest --timeout=480 sanity/skip_epoch.py --features nightly
 pytest --timeout=240 sanity/one_val.py
 pytest --timeout=240 sanity/one_val.py nightly --features nightly
 pytest --timeout=240 sanity/lightclnt.py


### PR DESCRIPTION
In some previous PR #9503 epoch length was increased, but timeout wasn't updated proportionally.
8 minutes look more than enough: https://nayduck.near.org/#/test/576088