### PR TITLE
fix(mirror): change the default extra key when running with a key mapping secret

### DIFF
--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -666,7 +666,7 @@ impl ForkNetworkCommand {
                     }
                     storage_mutator.set_access_key(
                         account_id,
-                        near_mirror::key_mapping::EXTRA_KEY.public_key(),
+                        near_mirror::key_mapping::default_extra_key(None).public_key(),
                         AccessKey::full_access(),
                     )?;
                     num_added += 1;

--- a/tools/mirror/src/genesis.rs
+++ b/tools/mirror/src/genesis.rs
@@ -105,11 +105,12 @@ pub fn map_records<P: AsRef<Path>>(
             }
         };
     })?;
+    let default_key = crate::key_mapping::default_extra_key(secret.as_ref());
     for account_id in accounts {
         if !has_full_key.contains(&account_id) {
             records_seq.serialize_element(&StateRecord::AccessKey {
                 account_id,
-                public_key: crate::key_mapping::EXTRA_KEY.public_key(),
+                public_key: default_key.public_key(),
                 access_key: AccessKey::full_access(),
             })?;
         }

--- a/tools/mirror/src/key_mapping.rs
+++ b/tools/mirror/src/key_mapping.rs
@@ -9,12 +9,19 @@ use sha2::Sha256;
 // We will ensure that every account in the target chain has at least one full access
 // key by adding this one (when preparing the records file, or when sending a create account tx)
 // if one doesn't exist
-pub const EXTRA_KEY: SecretKey = SecretKey::ED25519(ED25519SecretKey([
+const DEFAULT_EXTRA_KEY: SecretKey = SecretKey::ED25519(ED25519SecretKey([
     213, 175, 27, 65, 239, 63, 64, 126, 187, 96, 90, 207, 42, 75, 1, 199, 109, 5, 0, 67, 207, 80,
     147, 19, 53, 126, 142, 30, 162, 168, 97, 155, 119, 161, 145, 134, 247, 30, 152, 37, 178, 129,
     174, 62, 225, 47, 43, 131, 212, 59, 200, 4, 158, 143, 3, 235, 237, 190, 51, 82, 253, 38, 36,
     145,
 ]));
+
+pub fn default_extra_key(secret: Option<&[u8; crate::secret::SECRET_LEN]>) -> SecretKey {
+    match secret {
+        Some(s) => map_key(&DEFAULT_EXTRA_KEY.public_key(), Some(s)),
+        None => DEFAULT_EXTRA_KEY,
+    }
+}
 
 fn ed25519_map_secret(
     buf: &mut [u8],

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -162,7 +162,7 @@ fn put_target_nonce(
     public_key: &PublicKey,
     nonce: &LatestTargetNonce,
 ) -> anyhow::Result<()> {
-    tracing::debug!(target: "mirror", "storing {:?} in DB for ({}, {:?})", &nonce, account_id, public_key);
+    tracing::trace!(target: "mirror", "storing {:?} in DB for ({}, {:?})", &nonce, account_id, public_key);
     let db_key = nonce_col_key(account_id, public_key);
     db.put_cf(
         db.cf_handle(DBCol::Nonces.name()).unwrap(),
@@ -196,7 +196,7 @@ fn put_pending_outcome(
     id: CryptoHash,
     access_keys: HashSet<(AccountId, PublicKey)>,
 ) -> anyhow::Result<()> {
-    tracing::debug!(target: "mirror", "storing {:?} in DB for {:?}", &access_keys, &id);
+    tracing::trace!(target: "mirror", "storing {:?} in DB for {:?}", &access_keys, &id);
     Ok(db.put_cf(
         db.cf_handle(DBCol::AccessKeyOutcomes.name()).unwrap(),
         &borsh::to_vec(&id).unwrap(),
@@ -205,7 +205,7 @@ fn put_pending_outcome(
 }
 
 fn delete_pending_outcome(db: &DB, id: &CryptoHash) -> anyhow::Result<()> {
-    tracing::debug!(target: "mirror", "deleting {:?} from DB", &id);
+    tracing::trace!(target: "mirror", "deleting {:?} from DB", &id);
     Ok(db.delete_cf(
         db.cf_handle(DBCol::AccessKeyOutcomes.name()).unwrap(),
         &borsh::to_vec(&id).unwrap(),

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -479,6 +479,7 @@ struct TxMirror<T: ChainAccess> {
     target_min_block_production_delay: Duration,
     tracked_shards: Vec<ShardId>,
     secret: Option<[u8; crate::secret::SECRET_LEN]>,
+    default_extra_key: SecretKey,
 }
 
 fn open_db<P: AsRef<Path>>(home: P, config: &NearConfig) -> anyhow::Result<DB> {
@@ -882,6 +883,7 @@ impl<T: ChainAccess> TxMirror<T> {
         .context("failed to start target chain indexer")?;
         let (target_view_client, target_client) = target_indexer.client_actors();
         let target_stream = target_indexer.streamer();
+        let default_extra_key = crate::key_mapping::default_extra_key(secret.as_ref());
 
         Ok(Self {
             source_chain_access,
@@ -895,6 +897,7 @@ impl<T: ChainAccess> TxMirror<T> {
                 .min_block_production_delay,
             tracked_shards: target_config.config.tracked_shards,
             secret,
+            default_extra_key,
         })
     }
 
@@ -1034,7 +1037,7 @@ impl<T: ChainAccess> TxMirror<T> {
         }
         if account_created && !full_key_added {
             actions.push(Action::AddKey(Box::new(AddKeyAction {
-                public_key: crate::key_mapping::EXTRA_KEY.public_key(),
+                public_key: self.default_extra_key.public_key(),
                 access_key: AccessKey::full_access(),
             })));
         }
@@ -1176,7 +1179,7 @@ impl<T: ChainAccess> TxMirror<T> {
                             target: "mirror", "trying to prepare a transaction with the default extra key for {} because no full access key for {} in the source chain is known at block {}",
                             &provenance, &target_signer_id, &block_hash,
                         );
-                        crate::key_mapping::EXTRA_KEY
+                        self.default_extra_key.clone()
                     }
                 }
             }
@@ -1229,7 +1232,7 @@ impl<T: ChainAccess> TxMirror<T> {
         }
         if account_created && !full_key_added {
             target_actions.push(Action::AddKey(Box::new(AddKeyAction {
-                public_key: crate::key_mapping::EXTRA_KEY.public_key(),
+                public_key: self.default_extra_key.public_key(),
                 access_key: AccessKey::full_access(),
             })));
         }


### PR DESCRIPTION
When records are prepared for a forked network to work with the mirror tool, there is an option to include a secret that will be used to map keys so that only someone with the secret can generate the keys in the forked chain. There is also a default key that is added to any account that doesn't have a full access key in the source chain so that we can send transactions on its behalf in the forked chain. But there was an oversight where this default extra key is not mixed with the secret, which means that anyone can control any account that doesn't have any full access key in the source chain. So fix it by mapping the key with the secret, and leaving it as-is when there's no secret, which should be backward compatible with old setups with no secret.

This hasn't been an issue, but the records prepared for the statelessnet program were prepared with a secret so that only the test operator can control the accounts coming from mainnet, and these accounts were therefore exposed on statelessnet. They have since all been updated manually to use the default key defined in this PR