### PR TITLE
Print error description in InvalidChunkStateWitness error

### DIFF
--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -134,7 +134,7 @@ pub enum Error {
     /// Invalid chunk state.
     #[error("Invalid Chunk State")]
     InvalidChunkState(Box<ChunkState>),
-    #[error("Invalid Chunk State Witness")]
+    #[error("Invalid Chunk State Witness: {0}")]
     InvalidChunkStateWitness(String),
     #[error("Invalid Chunk Endorsement")]
     InvalidChunkEndorsement,


### PR DESCRIPTION
This error variant contains a String with additional description, but it isn't printed when the error is displayed.
Let's print the description to make errors clearer, it'll make debugging things easier.