### PR TITLE
Missing parentheses around url for wget for mocknet

### DIFF
--- a/pytest/lib/mocknet.py
+++ b/pytest/lib/mocknet.py
@@ -504,8 +504,8 @@ def redownload_neard(nodes, binary_url):
     pmap(
         lambda node: node.machine.
         run('sudo -u ubuntu -i',
-            input='wget -O /home/ubuntu/neard {}; chmod +x /home/ubuntu/neard'.
-            format(binary_url)), nodes)
+            input='wget -O /home/ubuntu/neard "{}"; chmod +x /home/ubuntu/neard'
+            .format(binary_url)), nodes)
 
 
 # Check /home/ubuntu/neard.upgrade to see whether the amend-genesis command is


### PR DESCRIPTION
Setting up adversenet failed when I used a neard binary url with `&` sign.
It worked so far with `s3` urls as they did not have ampersand.

Related PR: https://github.com/near/near-ops/pull/1579