### PR TITLE
ignore warnings when building fuzzers

### DIFF
--- a/.github/workflows/master_fuzzer_binaries.yml
+++ b/.github/workflows/master_fuzzer_binaries.yml
@@ -50,5 +50,6 @@ jobs:
       - name: "Compile fuzzers and upload to GCS"
         run: |
           NAME="nearcore-${{ github.ref_name }}-$(env TZ=Etc/UTC  date +"%Y%m%d%H%M%S")"
+          sed -i 's/warnings = "deny"/warnings = "warn"/' Cargo.toml
           RUSTFLAGS="--cfg fuzz" cargo +nightly bolero build-clusterfuzz --all-features --profile fuzz
           gsutil cp -Z target/fuzz/clusterfuzz.tar "gs://fuzzer_targets/${{ github.ref_name }}/$NAME.tar.gz"

--- a/.github/workflows/ondemand_fuzzer_binaries.yml
+++ b/.github/workflows/ondemand_fuzzer_binaries.yml
@@ -86,5 +86,6 @@ jobs:
       - name: "Compile fuzzers and upload to GCS"
         run: |
           NAME="nearcore-$branch_type-$(env TZ=Etc/UTC  date +"%Y%m%d%H%M%S")"
+          sed -i 's/warnings = "deny"/warnings = "warn"/' Cargo.toml
           RUSTFLAGS="--cfg fuzz" cargo +nightly bolero build-clusterfuzz --all-features --profile fuzz
           gsutil cp -Z target/fuzz/clusterfuzz.tar "gs://fuzzer_targets/$branch_type/$NAME.tar.gz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,9 +97,6 @@ members = [
 [workspace.lints.rust]
 warnings = "deny"
 
-[workspace.profile.fuzz.lints.rust]
-warnings = { level = "allow", priority = 10 }
-
 [workspace.lints.clippy]
 all = { level = "allow", priority = -100 }
 correctness = { level = "deny", priority = -50 }


### PR DESCRIPTION
Apparently https://github.com/near/nearcore/pull/10630 was not actually enough to disable builds, as cargo does not seem to support this syntax. Instead, just remove the explicit warnings=deny setting when building fuzzers