### PR TITLE
hardcode target cpu for clusterfuzz targets

### DIFF
--- a/.github/workflows/master_fuzzer_binaries.yml
+++ b/.github/workflows/master_fuzzer_binaries.yml
@@ -51,5 +51,6 @@ jobs:
         run: |
           NAME="nearcore-${{ github.ref_name }}-$(env TZ=Etc/UTC  date +"%Y%m%d%H%M%S")"
           sed -i 's/warnings = "deny"/warnings = "warn"/' Cargo.toml
-          RUSTFLAGS="--cfg fuzz" cargo +nightly bolero build-clusterfuzz --all-features --profile fuzz
+          # Our Clusterfuzz setup currently (2024-02) runs on Cascade Lake CPUs
+          RUSTFLAGS="--cfg fuzz -C target-cpu=cascadelake" cargo +nightly bolero build-clusterfuzz --all-features --profile fuzz
           gsutil cp -Z target/fuzz/clusterfuzz.tar "gs://fuzzer_targets/${{ github.ref_name }}/$NAME.tar.gz"


### PR DESCRIPTION
This should hopefully counter the issue that our fuzzers are currently facing, and that stem from -C target-cpu=native in bolero code: https://github.com/camshaft/bolero/blob/a9dc98616435c85daca4b1612eb4b014c757d7db/bin/cargo-bolero/src/project.rs#L143