### PR TITLE
fix: avoid unnecessary string interpolation

### DIFF
--- a/chain/client/src/stateless_validation/state_witness_producer.rs
+++ b/chain/client/src/stateless_validation/state_witness_producer.rs
@@ -150,7 +150,7 @@ impl Client {
                     near_store::DBCol::StateTransitionData,
                     &near_primitives::utils::get_block_shard_id(main_block, shard_id),
                 )?
-                .ok_or(Error::Other(format!(
+                .ok_or_else(|| Error::Other(format!(
                     "Missing main transition state proof for block {main_block} and shard {shard_id}"
                 )))?;
             (base_state, receipts_hash)
@@ -168,7 +168,7 @@ impl Client {
                     near_store::DBCol::StateTransitionData,
                     &near_primitives::utils::get_block_shard_id(block_hash, shard_id),
                 )?
-                .ok_or(Error::Other(format!(
+                .ok_or_else(|| Error::Other(format!(
                     "Missing implicit transition state proof for block {block_hash} and shard {shard_id}"
                 )))?;
             implicit_transitions.push(ChunkStateTransition {


### PR DESCRIPTION
With `ok_or` string interpolation is executed even when there is no error which is the prevalent case. 