### PR TITLE
fix: clippy lint in rosetta rpc

### DIFF
--- a/chain/rosetta-rpc/src/adapters/nep141.rs
+++ b/chain/rosetta-rpc/src/adapters/nep141.rs
@@ -116,13 +116,13 @@ pub(crate) async fn get_fungible_token_balance_for_account(
             contract_address.clone(),
         )));
     };
-    let serde_call_result = serde_json::from_slice(&call_result).or(Err(
-        crate::errors::ErrorKind::InternalInvariantError(format!(
+    let serde_call_result = serde_json::from_slice(&call_result).or_else(|_| {
+        Err(crate::errors::ErrorKind::InternalInvariantError(format!(
             "Couldn't read the value from the contract {:?}, for the account {:?}",
             contract_address.clone(),
             account_identifier.address.clone(),
-        )),
-    ))?;
+        )))
+    })?;
     let amount: String = match serde_json::from_value(serde_call_result) {
         Ok(amount) => amount,
         Err(err) => return Err(err.into()),


### PR DESCRIPTION
A new clippy lint has recently been activated in https://github.com/near/nearcore/pull/10654, which caused `cargo clippy` to emit a warning because the rosetta rpc code uses `.or()` instead of `.or_else()`. Fix by changing it to `or_else()`:

```console
~/nearcore$ cargo clippy
    Checking near-rosetta-rpc v0.0.0 (/home/ubuntu/nearcore/chain/rosetta-rpc)
error: use of `or` followed by a function call
   --> chain/rosetta-rpc/src/adapters/nep141.rs:119:66
    |
119 |       let serde_call_result = serde_json::from_slice(&call_result).or(Err(
    |  __________________________________________________________________^
120 | |         crate::errors::ErrorKind::InternalInvariantError(format!(
121 | |             "Couldn't read the value from the contract {:?}, for the account {:?}",
122 | |             contract_address.clone(),
123 | |             account_identifier.address.clone(),
124 | |         )),
125 | |     ))?;
    | |______^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call
    = note: requested on the command line with `-D clippy::or-fun-call`
help: try
    |
119 ~     let serde_call_result = serde_json::from_slice(&call_result).or_else(|_| Err(
120 +         crate::errors::ErrorKind::InternalInvariantError(format!(
121 +             "Couldn't read the value from the contract {:?}, for the account {:?}",
122 +             contract_address.clone(),
123 +             account_identifier.address.clone(),
124 +         )),
125 ~     ))?;
    |

error: could not compile `near-rosetta-rpc` (lib) due to 1 previous error
```

Interestingly `clippy --tests` doesn't emit the warning, only running `clippy` by itself causes this warning to appear. I guess that's why the CI in the original PR didn't catch it.