### PR TITLE
feat: clean orphaned witnesses below the last final height

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1642,7 +1642,7 @@ impl Client {
         self.shards_manager_adapter
             .send(ShardsManagerRequestFromClient::CheckIncompleteChunks(*block.hash()));
 
-        self.process_ready_orphan_chunk_state_witnesses(&block);
+        self.process_ready_orphan_witnesses_and_clean_old(&block);
     }
 
     /// Reconcile the transaction pool after processing a block.

--- a/chain/client/src/stateless_validation/chunk_validator/orphan_witness_handling.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/orphan_witness_handling.rs
@@ -158,7 +158,7 @@ impl Client {
 
     /// Once a new block arrives, we can process the orphaned chunk state witnesses that were waiting
     // for this block. This function takes the ready witnesses out of the orhan pool and process them.
-    pub fn process_ready_orphan_chunk_state_witnesses(&mut self, new_block: &Block) {
+    pub fn process_ready_orphan_witnesses_and_clean_old(&mut self, new_block: &Block) {
         let ready_witnesses = self
             .chunk_validator
             .orphan_witness_pool

--- a/chain/client/src/stateless_validation/chunk_validator/orphan_witness_handling.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/orphan_witness_handling.rs
@@ -157,8 +157,8 @@ impl Client {
     }
 
     /// Once a new block arrives, we can process the orphaned chunk state witnesses that were waiting
-    // for this block. This function takes the ready witnesses out of the orhan pool and process them.
-    // It also removes old witnesses (below final height) from the orphan pool to save memory.
+    /// for this block. This function takes the ready witnesses out of the orhan pool and process them.
+    /// It also removes old witnesses (below final height) from the orphan pool to save memory.
     pub fn process_ready_orphan_witnesses_and_clean_old(&mut self, new_block: &Block) {
         let ready_witnesses = self
             .chunk_validator

--- a/chain/client/src/stateless_validation/chunk_validator/orphan_witness_handling.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/orphan_witness_handling.rs
@@ -158,6 +158,7 @@ impl Client {
 
     /// Once a new block arrives, we can process the orphaned chunk state witnesses that were waiting
     // for this block. This function takes the ready witnesses out of the orhan pool and process them.
+    // It also removes old witnesses (below final height) from the orphan pool to save memory.
     pub fn process_ready_orphan_witnesses_and_clean_old(&mut self, new_block: &Block) {
         let ready_witnesses = self
             .chunk_validator


### PR DESCRIPTION
Orphaned witnesses which are below the final height of the chain will never be processed, so let's remove them from the orphan pool to free up memory.

Fixes: https://github.com/near/nearcore/issues/10649