### PR TITLE
Fix AsyncSender so that the callback does not panic when the response future is dropped.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,6 +3425,7 @@ dependencies = [
  "serde_json",
  "time",
  "tokio",
+ "tokio-util 0.7.2",
 ]
 
 [[package]]

--- a/core/async/Cargo.toml
+++ b/core/async/Cargo.toml
@@ -28,6 +28,7 @@ near-performance-metrics.workspace = true
 
 [dev-dependencies]
 derive-enum-from-into.workspace = true
+tokio-util.workspace = true
 
 [features]
 nightly = [


### PR DESCRIPTION
Also add a test for this behavior.

Closes #10660