### PR TITLE
fix: pytest staking tests and tracking shards

### DIFF
--- a/pytest/tests/sanity/staking2.py
+++ b/pytest/tests/sanity/staking2.py
@@ -95,6 +95,7 @@ def doit(seq=[]):
                           ["block_producer_kickout_threshold", 40],
                           ["chunk_producer_kickout_threshold", 40]], {
                               0: {
+                                  "tracked_shards": [0],
                                   "view_client_throttle_period": {
                                       "secs": 0,
                                       "nanos": 0
@@ -107,6 +108,7 @@ def doit(seq=[]):
                                   }
                               },
                               1: {
+                                  "tracked_shards": [0],
                                   "view_client_throttle_period": {
                                       "secs": 0,
                                       "nanos": 0


### PR DESCRIPTION
Force tracking shard 0 for all nodes in staking-related pytests.

Current failures are caused by stake of some nodes going to 0, which causes node to fall out of validator set and stop tracking shard 0. When it gets back, state sync is triggered, which is (currently?) supported only in state-sync related tests.

With that simple change, all staking tests pass now: https://nayduck.near.org/#/run/3398.