### PR TITLE
fix: Don't ban peers for invalid ChunkStateWitness messages

### DIFF
--- a/chain/client/src/client_actions.rs
+++ b/chain/client/src/client_actions.rs
@@ -1829,7 +1829,7 @@ impl ClientActionHandler<ChunkStateWitnessMessage> for ClientActions {
 
     #[perf]
     fn handle(&mut self, msg: ChunkStateWitnessMessage) -> Self::Result {
-        if let Err(err) = self.client.process_chunk_state_witness(msg.witness, msg.peer_id, None) {
+        if let Err(err) = self.client.process_chunk_state_witness(msg.0, None) {
             tracing::error!(target: "client", ?err, "Error processing chunk state witness");
         }
     }

--- a/chain/client/src/stateless_validation/chunk_validator/orphan_witness_handling.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/orphan_witness_handling.rs
@@ -10,7 +10,6 @@ use bytesize::ByteSize;
 use itertools::Itertools;
 use near_chain::Block;
 use near_chain_primitives::Error;
-use near_primitives::network::PeerId;
 use near_primitives::stateless_validation::ChunkStateWitness;
 use near_primitives::types::{BlockHeight, EpochId};
 use std::ops::Range;
@@ -173,12 +172,9 @@ impl Client {
                 witness_prev_block = ?header.prev_block_hash(),
                 "Processing an orphaned ChunkStateWitness, its previous block has arrived."
             );
-            if let Err(err) = self.process_chunk_state_witness_with_prev_block(
-                witness,
-                PeerId::random(), // TODO: Should peer_id even be here? https://github.com/near/stakewars-iv/issues/17
-                new_block,
-                None,
-            ) {
+            if let Err(err) =
+                self.process_chunk_state_witness_with_prev_block(witness, new_block, None)
+            {
                 tracing::error!(target: "client", ?err, "Error processing orphan chunk state witness");
             }
         }

--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -29,7 +29,6 @@ use near_primitives::block::Block;
 use near_primitives::epoch_manager::RngSeed;
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
-use near_primitives::network::PeerId;
 use near_primitives::sharding::{ChunkHash, PartialEncodedChunk};
 use near_primitives::stateless_validation::{ChunkEndorsement, ChunkStateWitness};
 use near_primitives::test_utils::create_test_signer;
@@ -331,7 +330,6 @@ impl TestEnv {
                         let processing_result =
                             self.client(account_id).process_chunk_state_witness(
                                 state_witness.clone(),
-                                PeerId::random(),
                                 Some(processing_done_tracker),
                             );
                         if !allow_errors {

--- a/chain/network/src/client.rs
+++ b/chain/network/src/client.rs
@@ -114,10 +114,7 @@ pub struct AnnounceAccountRequest(pub Vec<(AnnounceAccount, Option<EpochId>)>);
 
 #[derive(actix::Message, Debug, Clone, PartialEq, Eq)]
 #[rtype(result = "()")]
-pub struct ChunkStateWitnessMessage {
-    pub witness: ChunkStateWitness,
-    pub peer_id: PeerId,
-}
+pub struct ChunkStateWitnessMessage(pub ChunkStateWitness);
 
 #[derive(actix::Message, Debug, Clone, PartialEq, Eq)]
 #[rtype(result = "()")]

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1010,11 +1010,7 @@ impl PeerActor {
                 None
             }
             RoutedMessageBody::ChunkStateWitness(witness) => {
-                network_state
-                    .client
-                    .send_async(ChunkStateWitnessMessage { witness, peer_id })
-                    .await
-                    .ok();
+                network_state.client.send_async(ChunkStateWitnessMessage(witness)).await.ok();
                 None
             }
             RoutedMessageBody::ChunkEndorsement(endorsement) => {

--- a/integration-tests/src/tests/client/features/stateless_validation.rs
+++ b/integration-tests/src/tests/client/features/stateless_validation.rs
@@ -1,5 +1,4 @@
 use near_epoch_manager::{EpochManager, EpochManagerAdapter};
-use near_primitives::network::PeerId;
 use near_primitives::stateless_validation::ChunkStateWitness;
 use near_store::test_utils::create_test_store;
 use nearcore::config::GenesisExt;
@@ -336,7 +335,7 @@ fn test_chunk_state_witness_bad_shard_id() {
 
     // Client should reject this ChunkStateWitness and the error message should mention "shard"
     tracing::info!(target: "test", "Processing invalid ChunkStateWitness");
-    let res = env.clients[0].process_chunk_state_witness(witness, PeerId::random(), None);
+    let res = env.clients[0].process_chunk_state_witness(witness, None);
     let error = res.unwrap_err();
     let error_message = format!("{}", error).to_lowercase();
     tracing::info!(target: "test", "error message: {}", error_message);


### PR DESCRIPTION
The current logic of banning peers that sent a message with invalid ChunkStateWitness is flawed - it bans the peer that forwarded the message instead of the one that produced it, which means that innocent peers could be banned for forwarding a bad message.

Let's remove the existing banning logic because it's invalid. Later it can be properly reimplemented in another PR.

Fixes: https://github.com/near/stakewars-iv/issues/17
Refs: [zulip conversation](https://near.zulipchat.com/#narrow/stream/407237-pagoda.2Fcore.2Fstateless-validation/topic/StatelessNet.20monitoring/near/423565210)