### PR TITLE
[cleanup] Use `is_genesis` function where ever possible

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2291,7 +2291,7 @@ impl Chain {
             }
             Err(e) => match e {
                 Error::DBNotFoundErr(_) => {
-                    if block_header.prev_hash() == &CryptoHash::default() {
+                    if block_header.is_genesis() {
                         (None, None, 0)
                     } else {
                         return Err(e);

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -1992,13 +1992,13 @@ impl<'a> ChainStoreUpdate<'a> {
     }
 
     fn update_and_save_block_merkle_tree(&mut self, header: &BlockHeader) -> Result<(), Error> {
-        let prev_hash = *header.prev_hash();
-        if prev_hash == CryptoHash::default() {
+        if header.is_genesis() {
             self.save_block_merkle_tree(*header.hash(), PartialMerkleTree::default());
         } else {
-            let old_merkle_tree = self.get_block_merkle_tree(&prev_hash)?;
+            let prev_hash = header.prev_hash();
+            let old_merkle_tree = self.get_block_merkle_tree(prev_hash)?;
             let mut new_merkle_tree = PartialMerkleTree::clone(&old_merkle_tree);
-            new_merkle_tree.insert(prev_hash);
+            new_merkle_tree.insert(*prev_hash);
             self.save_block_merkle_tree(*header.hash(), new_merkle_tree);
         }
         Ok(())

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -256,7 +256,7 @@ pub fn display_chain(me: &Option<AccountId>, chain: &mut Chain, tail: bool) {
         }
     });
     for header in headers {
-        if header.prev_hash() == &CryptoHash::default() {
+        if header.is_genesis() {
             // Genesis block.
             debug!("{: >3} {}", header.height(), format_hash(*header.hash()));
         } else {

--- a/chain/client/src/sync/header.rs
+++ b/chain/client/src/sync/header.rs
@@ -749,7 +749,7 @@ mod test {
             let last_block = chain2.get_block(&chain2.head().unwrap().last_block_hash).unwrap();
             let this_height = last_block.header().height() + 1;
             let (epoch_id, next_epoch_id) =
-                if last_block.header().prev_hash() == &CryptoHash::default() {
+                if last_block.header().is_genesis() {
                     (last_block.header().next_epoch_id().clone(), EpochId(*last_block.hash()))
                 } else {
                     (

--- a/chain/client/src/sync/header.rs
+++ b/chain/client/src/sync/header.rs
@@ -748,15 +748,14 @@ mod test {
         for _ in 0..(4 * MAX_BLOCK_HEADERS + 10) {
             let last_block = chain2.get_block(&chain2.head().unwrap().last_block_hash).unwrap();
             let this_height = last_block.header().height() + 1;
-            let (epoch_id, next_epoch_id) =
-                if last_block.header().is_genesis() {
-                    (last_block.header().next_epoch_id().clone(), EpochId(*last_block.hash()))
-                } else {
-                    (
-                        last_block.header().epoch_id().clone(),
-                        last_block.header().next_epoch_id().clone(),
-                    )
-                };
+            let (epoch_id, next_epoch_id) = if last_block.header().is_genesis() {
+                (last_block.header().next_epoch_id().clone(), EpochId(*last_block.hash()))
+            } else {
+                (
+                    last_block.header().epoch_id().clone(),
+                    last_block.header().next_epoch_id().clone(),
+                )
+            };
             let block = Block::produce(
                 PROTOCOL_VERSION,
                 PROTOCOL_VERSION,

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -369,6 +369,11 @@ pub mod block_info {
         }
 
         #[inline]
+        pub fn is_genesis(&self) -> bool {
+            self.prev_hash() == &CryptoHash::default()
+        }
+
+        #[inline]
         pub fn epoch_first_block(&self) -> &CryptoHash {
             match self {
                 Self::V1(v1) => &v1.epoch_first_block,

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -402,7 +402,7 @@ impl TestBlockBuilder {
             signer: signer.clone(),
             height: prev.header().height() + 1,
             epoch_id: prev.header().epoch_id().clone(),
-            next_epoch_id: if prev.header().prev_hash() == &CryptoHash::default() {
+            next_epoch_id: if prev.header().is_genesis() {
                 EpochId(*prev.hash())
             } else {
                 prev.header().next_epoch_id().clone()

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -7,7 +7,6 @@ use near_chain::types::{
 use near_chain::{ChainStore, ChainStoreAccess, ChainStoreUpdate};
 use near_chain_configs::Genesis;
 use near_epoch_manager::{EpochManagerAdapter, EpochManagerHandle};
-use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::DelayedReceiptIndices;
 use near_primitives::transaction::{Action, ExecutionOutcomeWithId, ExecutionOutcomeWithProof};
 use near_primitives::trie_key::TrieKey;
@@ -149,7 +148,7 @@ fn apply_block_from_range(
         .get_block_producer(block.header().epoch_id(), block.header().height())
         .unwrap();
 
-    let apply_result = if *block.header().is_genesis() {
+    let apply_result = if block.header().is_genesis() {
         if verbose_output {
             println!("Skipping the genesis block #{}.", height);
         }

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -149,7 +149,7 @@ fn apply_block_from_range(
         .get_block_producer(block.header().epoch_id(), block.header().height())
         .unwrap();
 
-    let apply_result = if *block.header().prev_hash() == CryptoHash::default() {
+    let apply_result = if *block.header().is_genesis() {
         if verbose_output {
             println!("Skipping the genesis block #{}.", height);
         }


### PR DESCRIPTION
Noticed the introduction of `is_genesis` function in https://github.com/near/nearcore/pull/10633

This PR tries to use the `is_genesis` function in place of comparing prev_hash with CryptoHash::default()