### PR TITLE
fix: use `log_assert_fail` when creating state witness with missing proof

### DIFF
--- a/chain/client/src/stateless_validation/state_witness_producer.rs
+++ b/chain/client/src/stateless_validation/state_witness_producer.rs
@@ -3,6 +3,7 @@ use near_async::messaging::{CanSend, IntoSender};
 use near_chain::{BlockHeader, Chain, ChainStoreAccess};
 use near_chain_primitives::Error;
 use near_network::types::{NetworkRequests, PeerManagerMessageRequest};
+use near_o11y::log_assert_fail;
 use near_primitives::challenge::PartialState;
 use near_primitives::checked_feature;
 use near_primitives::hash::{hash, CryptoHash};
@@ -102,7 +103,9 @@ impl Client {
             // With stateless validation chunk producer uses recording reads when validating transactions.
             // The storage proof must be available here.
             transactions_storage_proof.ok_or_else(|| {
-                Error::Other("Missing storage proof for transactions validation".to_owned())
+                let message = "Missing storage proof for transactions validation";
+                log_assert_fail!("{message}");
+                Error::Other(message.to_owned())
             })?
         };
 
@@ -153,9 +156,13 @@ impl Client {
                     near_store::DBCol::StateTransitionData,
                     &near_primitives::utils::get_block_shard_id(main_block, shard_id),
                 )?
-                .ok_or_else(|| Error::Other(format!(
-                    "Missing main transition state proof for block {main_block} and shard {shard_id}"
-                )))?;
+                .ok_or_else(|| {
+                    let message = format!(
+                        "Missing main transition state proof for block {main_block} and shard {shard_id}"
+                    );
+                    log_assert_fail!("{message}");
+                    Error::Other(message)
+                })?;
             (base_state, receipts_hash)
         };
         let main_transition = ChunkStateTransition {
@@ -171,9 +178,13 @@ impl Client {
                     near_store::DBCol::StateTransitionData,
                     &near_primitives::utils::get_block_shard_id(block_hash, shard_id),
                 )?
-                .ok_or_else(|| Error::Other(format!(
-                    "Missing implicit transition state proof for block {block_hash} and shard {shard_id}"
-                )))?;
+                .ok_or_else(|| {
+                    let message = format!(
+                        "Missing implicit transition state proof for block {block_hash} and shard {shard_id}"
+                    );
+                    log_assert_fail!("{message}");
+                    Error::Other(message)
+                })?;
             implicit_transitions.push(ChunkStateTransition {
                 block_hash: *block_hash,
                 base_state,


### PR DESCRIPTION
Such situations indicate illegal state/programmatic error that will result in missing chunk. It is still better to avoid panic in such case, so we return `Err` instead. This PR adds `log_assert_fail` which was introduced specifically for such cases.