### PR TITLE
fix: fix feature = "cargo-clippy" deprecation

### DIFF
--- a/runtime/near-vm/compiler/src/lib.rs
+++ b/runtime/near-vm/compiler/src/lib.rs
@@ -8,9 +8,9 @@
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
 #![deny(unstable_features)]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
+#![cfg_attr(clippy, allow(clippy::new_without_default))]
 #![cfg_attr(
-    feature = "cargo-clippy",
+    clippy,
     warn(
         clippy::float_arithmetic,
         clippy::mut_mut,

--- a/runtime/near-vm/engine/src/lib.rs
+++ b/runtime/near-vm/engine/src/lib.rs
@@ -2,12 +2,9 @@
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
+#![cfg_attr(clippy, allow(clippy::new_without_default, clippy::new_without_default))]
 #![cfg_attr(
-    feature = "cargo-clippy",
-    allow(clippy::new_without_default, clippy::new_without_default)
-)]
-#![cfg_attr(
-    feature = "cargo-clippy",
+    clippy,
     warn(
         clippy::float_arithmetic,
         clippy::mut_mut,

--- a/runtime/near-vm/types/src/lib.rs
+++ b/runtime/near-vm/types/src/lib.rs
@@ -7,9 +7,9 @@
 #![deny(missing_docs, unused_extern_crates)]
 #![warn(unused_import_braces)]
 #![deny(unstable_features)]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
+#![cfg_attr(clippy, allow(clippy::new_without_default))]
 #![cfg_attr(
-    feature = "cargo-clippy",
+    clippy,
     warn(
         clippy::float_arithmetic,
         clippy::mut_mut,

--- a/runtime/near-vm/vm/src/lib.rs
+++ b/runtime/near-vm/vm/src/lib.rs
@@ -3,9 +3,9 @@
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![deny(trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
+#![cfg_attr(clippy, allow(clippy::new_without_default))]
 #![cfg_attr(
-    feature = "cargo-clippy",
+    clippy,
     warn(
         clippy::float_arithmetic,
         clippy::mut_mut,

--- a/runtime/near-vm/wast/src/lib.rs
+++ b/runtime/near-vm/wast/src/lib.rs
@@ -3,9 +3,9 @@
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
 #![deny(unstable_features)]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
+#![cfg_attr(clippy, allow(clippy::new_without_default))]
 #![cfg_attr(
-    feature = "cargo-clippy",
+    clippy,
     warn(
         clippy::float_arithmetic,
         clippy::mut_mut,


### PR DESCRIPTION
https://blog.rust-lang.org/2024/02/28/Clippy-deprecating-feature-cargo-clippy.html