### PR TITLE
refactor: Rename receipt id utils for clarity

### DIFF
--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -9,7 +9,6 @@ use rand::{thread_rng, Rng};
 use serde;
 
 use crate::hash::{hash, CryptoHash};
-use crate::receipt::Receipt;
 use crate::transaction::SignedTransaction;
 use crate::types::{NumSeats, NumShards, ShardId};
 use crate::version::{
@@ -258,9 +257,9 @@ pub fn create_receipt_id_from_receipt_id(
 
 /// Creates a new action_hash from a given receipt, a block hash and an action index.
 /// This method is backward compatible, so it takes the current protocol version.
-pub fn create_action_hash(
+pub fn create_action_hash_from_receipt_id(
     protocol_version: ProtocolVersion,
-    receipt: &Receipt,
+    receipt_id: &CryptoHash,
     prev_block_hash: &CryptoHash,
     block_hash: &CryptoHash,
     action_index: usize,
@@ -268,24 +267,24 @@ pub fn create_action_hash(
     // Action hash uses the same input as a new receipt ID, so to avoid hash conflicts we use the
     // salt starting from the `u64` going backward.
     let salt = u64::MAX.wrapping_sub(action_index as u64);
-    create_hash_upgradable(protocol_version, &receipt.receipt_id, prev_block_hash, block_hash, salt)
+    create_hash_upgradable(protocol_version, receipt_id, prev_block_hash, block_hash, salt)
 }
 
-/// Creates a new `data_id` from a given action hash, a block hash and a data index.
+/// Creates a new Receipt ID from a given action hash, a block hash and a new receipt index.
 /// This method is backward compatible, so it takes the current protocol version.
-pub fn create_data_id(
+pub fn create_receipt_id_from_action_hash(
     protocol_version: ProtocolVersion,
     action_hash: &CryptoHash,
     prev_block_hash: &CryptoHash,
     block_hash: &CryptoHash,
-    data_index: usize,
+    receipt_index: usize,
 ) -> CryptoHash {
     create_hash_upgradable(
         protocol_version,
         action_hash,
         prev_block_hash,
         block_hash,
-        data_index as u64,
+        receipt_index as u64,
     )
 }
 

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -4,7 +4,7 @@ use near_primitives::errors::{EpochError, StorageError};
 use near_primitives::hash::CryptoHash;
 use near_primitives::trie_key::{trie_key_parsers, TrieKey};
 use near_primitives::types::{AccountId, Balance, EpochId, EpochInfoProvider, Gas, TrieCacheMode};
-use near_primitives::utils::create_data_id;
+use near_primitives::utils::create_receipt_id_from_action_hash;
 use near_primitives::version::ProtocolVersion;
 use near_store::{
     get_code, get_yielded_promise, remove_yielded_promise, KeyLookupMode, TrieUpdate,
@@ -176,7 +176,7 @@ impl<'a> External for RuntimeExt<'a> {
     }
 
     fn generate_data_id(&mut self) -> CryptoHash {
-        let data_id = create_data_id(
+        let data_id = create_receipt_id_from_action_hash(
             self.current_protocol_version,
             self.action_hash,
             self.prev_block_hash,

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -36,7 +36,8 @@ use near_primitives::types::{
     EpochId, EpochInfoProvider, Gas, RawStateChangesWithTrieKey, StateChangeCause, StateRoot,
 };
 use near_primitives::utils::{
-    create_action_hash, create_receipt_id_from_receipt_id, create_receipt_id_from_transaction,
+    create_action_hash_from_receipt_id, create_receipt_id_from_receipt_id,
+    create_receipt_id_from_transaction,
 };
 use near_primitives::version::{ProtocolFeature, ProtocolVersion};
 use near_store::{
@@ -550,9 +551,9 @@ impl Runtime {
         result.compute_usage = exec_fees;
         // Executing actions one by one
         for (action_index, action) in action_receipt.actions.iter().enumerate() {
-            let action_hash = create_action_hash(
+            let action_hash = create_action_hash_from_receipt_id(
                 apply_state.current_protocol_version,
-                receipt,
+                &receipt.receipt_id,
                 &apply_state.prev_block_hash,
                 &apply_state.block_hash,
                 action_index,


### PR DESCRIPTION
This PR renames the utility function `create_data_id` to `create_receipt_id_from_action_hash`.

The receipt id is a concept which exists at the Receipt level and is not specific to a kind of Receipt (whether action or data). Each id needs to be globally unique across receipts of all kinds, and the ids used for action and data receipts share the same properties. 

There is no meaningful distinction to be made between "data ids" and other kinds of receipt ids, so I find the name of this low-level utility to be misleading.  In particular, it would not be incorrect to generate an id for an action receipt using the function in question.

Renaming the function better reflects what it actually does rather than how it happens to be used. 