### PR TITLE
fix(metrics): changed shard id to shard uid in flat storage metrics

### DIFF
--- a/chain/chain/src/flat_storage_creator.rs
+++ b/chain/chain/src/flat_storage_creator.rs
@@ -70,7 +70,7 @@ impl FlatStorageShardCreator {
             remaining_state_parts: None,
             fetched_parts_sender,
             fetched_parts_receiver,
-            metrics: FlatStorageCreationMetrics::new(shard_uid.shard_id()),
+            metrics: FlatStorageCreationMetrics::new(shard_uid),
         }
     }
 

--- a/core/store/src/flat/metrics.rs
+++ b/core/store/src/flat/metrics.rs
@@ -1,6 +1,6 @@
 use crate::metrics::flat_state_metrics;
 use near_o11y::metrics::{IntCounter, IntGauge};
-use near_primitives::types::{BlockHeight, ShardId};
+use near_primitives::{shard_layout::ShardUId, types::BlockHeight};
 
 use super::FlatStorageStatus;
 
@@ -14,21 +14,21 @@ pub(crate) struct FlatStorageMetrics {
 }
 
 impl FlatStorageMetrics {
-    pub(crate) fn new(shard_id: ShardId) -> Self {
-        let shard_id_label = shard_id.to_string();
+    pub(crate) fn new(shard_uid: ShardUId) -> Self {
+        let shard_uid_label = shard_uid.to_string();
         Self {
             flat_head_height: flat_state_metrics::FLAT_STORAGE_HEAD_HEIGHT
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
             distance_to_head: flat_state_metrics::FLAT_STORAGE_DISTANCE_TO_HEAD
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
             hops_to_head: flat_state_metrics::FLAT_STORAGE_HOPS_TO_HEAD
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
             cached_deltas: flat_state_metrics::FLAT_STORAGE_CACHED_DELTAS
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
             cached_changes_num_items: flat_state_metrics::FLAT_STORAGE_CACHED_CHANGES_NUM_ITEMS
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
             cached_changes_size: flat_state_metrics::FLAT_STORAGE_CACHED_CHANGES_SIZE
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
         }
     }
 
@@ -64,21 +64,21 @@ pub struct FlatStorageCreationMetrics {
 }
 
 impl FlatStorageCreationMetrics {
-    pub fn new(shard_id: ShardId) -> Self {
-        let shard_id_label = shard_id.to_string();
+    pub fn new(shard_uid: ShardUId) -> Self {
+        let shard_uid_label = shard_uid.to_string();
         Self {
             status: flat_state_metrics::FLAT_STORAGE_CREATION_STATUS
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
             flat_head_height: flat_state_metrics::FLAT_STORAGE_HEAD_HEIGHT
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
             remaining_state_parts: flat_state_metrics::FLAT_STORAGE_CREATION_REMAINING_STATE_PARTS
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
             fetched_state_parts: flat_state_metrics::FLAT_STORAGE_CREATION_FETCHED_STATE_PARTS
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
             fetched_state_items: flat_state_metrics::FLAT_STORAGE_CREATION_FETCHED_STATE_ITEMS
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
             threads_used: flat_state_metrics::FLAT_STORAGE_CREATION_THREADS_USED
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
         }
     }
 

--- a/core/store/src/flat/storage.rs
+++ b/core/store/src/flat/storage.rs
@@ -245,7 +245,7 @@ impl FlatStorage {
                 )));
             }
         };
-        let metrics = FlatStorageMetrics::new(shard_id);
+        let metrics = FlatStorageMetrics::new(shard_uid);
         metrics.set_flat_head_height(flat_head.height);
 
         let deltas_metadata = store_helper::get_all_deltas_metadata(&store, shard_uid)

--- a/core/store/src/metrics.rs
+++ b/core/store/src/metrics.rs
@@ -393,7 +393,7 @@ pub mod flat_state_metrics {
         try_create_int_gauge_vec(
             "flat_storage_creation_status",
             "Integer representing status of flat storage creation",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });
@@ -401,7 +401,7 @@ pub mod flat_state_metrics {
         try_create_int_gauge_vec(
             "flat_storage_creation_remaining_state_parts",
             "Number of remaining state parts to fetch to fill flat storage in bytes",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });
@@ -409,7 +409,7 @@ pub mod flat_state_metrics {
         try_create_int_counter_vec(
             "flat_storage_creation_fetched_state_parts",
             "Number of fetched state parts to fill flat storage in bytes",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });
@@ -417,7 +417,7 @@ pub mod flat_state_metrics {
         try_create_int_counter_vec(
             "flat_storage_creation_fetched_state_items",
             "Number of fetched items to fill flat storage",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });
@@ -425,7 +425,7 @@ pub mod flat_state_metrics {
         try_create_int_gauge_vec(
             "flat_storage_creation_threads_used",
             "Number of currently used threads to fetch state",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });
@@ -433,7 +433,7 @@ pub mod flat_state_metrics {
         try_create_int_gauge_vec(
             "flat_storage_head_height",
             "Height of flat storage head",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });
@@ -441,7 +441,7 @@ pub mod flat_state_metrics {
         try_create_int_gauge_vec(
             "flat_storage_cached_deltas",
             "Number of cached deltas in flat storage",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });
@@ -449,7 +449,7 @@ pub mod flat_state_metrics {
         try_create_int_gauge_vec(
             "flat_storage_cached_changes_num_items",
             "Number of items in all cached changes in flat storage",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });
@@ -457,7 +457,7 @@ pub mod flat_state_metrics {
         try_create_int_gauge_vec(
             "flat_storage_cached_changes_size",
             "Total size of cached changes in flat storage",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });
@@ -465,7 +465,7 @@ pub mod flat_state_metrics {
         try_create_int_gauge_vec(
             "flat_storage_distance_to_head",
             "Height distance between processed block and flat storage head",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });
@@ -473,7 +473,7 @@ pub mod flat_state_metrics {
         try_create_int_gauge_vec(
             "flat_storage_hops_to_head",
             "Number of blocks visited to flat storage head",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });


### PR DESCRIPTION
During resharding we maintain flat storage for both the parent and children shards. In order to disambiguate and not mix the metrics for shards with the same ids we should use shard_uid instead of shard_id. 