### PR TITLE
fix: Deliver correct receipt type for yield timeouts

### DIFF
--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -37,6 +37,7 @@ protocol_feature_fix_staking_threshold = []
 protocol_feature_fix_contract_loading_cost = []
 protocol_feature_reject_blocks_with_outdated_protocol_version = []
 protocol_feature_nonrefundable_transfer_nep491 = []
+yield_resume = []
 
 nightly = [
   "nightly_protocol",
@@ -44,6 +45,7 @@ nightly = [
   "protocol_feature_fix_staking_threshold",
   "protocol_feature_nonrefundable_transfer_nep491",
   "protocol_feature_reject_blocks_with_outdated_protocol_version",
+  "yield_resume",
 ]
 
 nightly_protocol = [

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -54,6 +54,8 @@ protocol_feature_fix_staking_threshold = ["near-primitives-core/protocol_feature
 protocol_feature_fix_contract_loading_cost = ["near-primitives-core/protocol_feature_fix_contract_loading_cost"]
 protocol_feature_reject_blocks_with_outdated_protocol_version = ["near-primitives-core/protocol_feature_reject_blocks_with_outdated_protocol_version"]
 protocol_feature_nonrefundable_transfer_nep491 = ["near-primitives-core/protocol_feature_nonrefundable_transfer_nep491"]
+yield_resume = ["near-primitives-core/yield_resume"]
+
 nightly = [
   "near-fmt/nightly",
   "near-parameters/nightly",
@@ -64,6 +66,7 @@ nightly = [
   "protocol_feature_fix_staking_threshold",
   "protocol_feature_nonrefundable_transfer_nep491",
   "protocol_feature_reject_blocks_with_outdated_protocol_version",
+  "yield_resume",
 ]
 
 nightly_protocol = [

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -99,4 +99,5 @@ nightly = [
   "near-primitives/nightly",
   "near-vm-runner/nightly",
   "nightly_protocol",
+  "yield_resume",
 ]

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -123,7 +123,8 @@ new_epoch_sync = [
   "near-client/new_epoch_sync"
 ]
 yield_resume = [
-  "near-store/yield_resume"
+  "near-store/yield_resume",
+  "near-primitives/yield_resume",
 ]
 
 serialize_all_state_changes = ["near-store/serialize_all_state_changes"]

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1529,7 +1529,7 @@ impl Runtime {
                 get::<YieldedPromise>(&state_update, &yielded_promise_key)?
             {
                 // Deliver a DataReceipt without any data to resolve the timed-out yield
-                let new_receipt = ReceiptEnum::Data(DataReceipt { data_id, data: None });
+                let new_receipt = ReceiptEnum::PromiseResume(DataReceipt { data_id, data: None });
 
                 let new_receipt_id = create_receipt_id_from_receipt_id(
                     apply_state.current_protocol_version,


### PR DESCRIPTION
#10676 introduced receipt variant `ReceiptEnum::PromiseResume` to distinguish yield resume receipts from normal data receipts. We should use that type not just for receipts submitted via `promise_yield_resume` but also for the receipts generated by yield timeouts.

Also in that PR, deserialization for the `PromiseResume` and `PromiseYield` types is gated behind a feature flag `yield_resume`. However, the flag was not properly configured everywhere.