### PR TITLE
Enhancements for Read RPC: Compatibility with near-indexer and Handling Optimistic Blocks

### DIFF
--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -15,6 +15,7 @@ pub use near_indexer_primitives::{
 };
 
 mod streamer;
+pub use streamer::build_streamer_message;
 
 pub const INDEXER: &str = "indexer";
 

--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -64,7 +64,7 @@ fn test_problematic_blocks_hash() {
 /// It fetches the block and all related parts (chunks, outcomes, state changes etc.)
 /// and returns everything together in one struct
 #[async_recursion]
-async fn build_streamer_message(
+pub async fn build_streamer_message(
     client: &Addr<near_client::ViewClientActor>,
     block: views::BlockView,
 ) -> Result<StreamerMessage, FailedToFetchData> {


### PR DESCRIPTION
Hello everyone!

This pull request addresses two urgent tasks related to our project's [Read RPC](https://github.com/near/read-rpc) functionality.

[Issue 1](https://github.com/near/read-rpc/issues/188): 
Making our state-indexer compatible with the near-indexer to eliminate the 3-second delay caused by [Lake-framework](https://github.com/near/near-lake-framework-rs). This compatibility enhancement ensures smoother and more efficient operation of our system by removing unnecessary delays.

[Issue 2](https://github.com/near/read-rpc/issues/186): 
Enhancing our service to handle requests for optimistic blocks directly, without proxying to nodes. This optimization streamlines the process, improving response times and overall system performance.

To achieve these tasks, modifications have been made to the near-indexer. Specifically, the `build_streamer_message` method has been made public to facilitate the creation of `StreamerMessage` for optimistic blocks.

This pull request aims to enhance the reliability, efficiency, and performance of our Read RPC functionality, addressing critical needs within our project.

