### PR TITLE
refactor: erase ReceiptEnum::is_action and ::action

### DIFF
--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -1118,7 +1118,9 @@ impl RuntimeAdapter for KeyValueRuntime {
         let mut balance_transfers = vec![];
 
         for receipt in receipts.iter() {
-            if let Some(action) = &receipt.receipt.action() {
+            if let ReceiptEnum::Action(action) | ReceiptEnum::PromiseYield(action) =
+                &receipt.receipt
+            {
                 assert_eq!(account_id_to_shard_id(&receipt.receiver_id, self.num_shards), shard_id);
                 if !state.receipt_nonces.contains(&receipt.receipt_id) {
                     state.receipt_nonces.insert(receipt.receipt_id);

--- a/core/primitives/src/receipt.rs
+++ b/core/primitives/src/receipt.rs
@@ -124,24 +124,6 @@ pub enum ReceiptEnum {
     PromiseResume(DataReceipt),
 }
 
-impl ReceiptEnum {
-    pub fn is_action(&self) -> bool {
-        match self {
-            ReceiptEnum::Action(_) | ReceiptEnum::PromiseYield(_) => true,
-            _ => false,
-        }
-    }
-
-    pub fn action(&self) -> Option<&ActionReceipt> {
-        match self {
-            ReceiptEnum::Action(action_receipt) | ReceiptEnum::PromiseYield(action_receipt) => {
-                Some(action_receipt)
-            }
-            _ => None,
-        }
-    }
-}
-
 impl BorshDeserialize for ReceiptEnum {
     fn deserialize_reader<R: io::Read>(rd: &mut R) -> io::Result<Self> {
         // after we stabilize yield_resume we can simply derive BorshDeserialize trait again

--- a/runtime/runtime/src/prefetch.rs
+++ b/runtime/runtime/src/prefetch.rs
@@ -43,7 +43,7 @@
 
 use near_o11y::metrics::prometheus;
 use near_o11y::metrics::prometheus::core::GenericCounter;
-use near_primitives::receipt::Receipt;
+use near_primitives::receipt::{Receipt, ReceiptEnum};
 use near_primitives::transaction::{Action, SignedTransaction};
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::AccountId;
@@ -91,30 +91,36 @@ impl TriePrefetcher {
         receipts: &[Receipt],
     ) -> Result<(), PrefetchError> {
         for receipt in receipts.iter() {
-            if let Some(action_receipt) = &receipt.receipt.action() {
-                let account_id = receipt.receiver_id.clone();
+            match &receipt.receipt {
+                ReceiptEnum::Action(action_receipt) | ReceiptEnum::PromiseYield(action_receipt) => {
+                    let account_id = receipt.receiver_id.clone();
 
-                // general-purpose account prefetching
-                if self.prefetch_api.enable_receipt_prefetching {
-                    let trie_key = TrieKey::Account { account_id: account_id.clone() };
-                    self.prefetch_trie_key(trie_key)?;
-                }
+                    // general-purpose account prefetching
+                    if self.prefetch_api.enable_receipt_prefetching {
+                        let trie_key = TrieKey::Account { account_id: account_id.clone() };
+                        self.prefetch_trie_key(trie_key)?;
+                    }
 
-                // SWEAT specific argument prefetcher
-                if self.prefetch_api.sweat_prefetch_receivers.contains(&account_id)
-                    && self.prefetch_api.sweat_prefetch_senders.contains(&receipt.predecessor_id)
-                {
-                    for action in &action_receipt.actions {
-                        if let Action::FunctionCall(fn_call) = action {
-                            if fn_call.method_name == "record_batch" {
-                                self.prefetch_sweat_record_batch(
-                                    account_id.clone(),
-                                    &fn_call.args,
-                                )?;
+                    // SWEAT specific argument prefetcher
+                    if self.prefetch_api.sweat_prefetch_receivers.contains(&account_id)
+                        && self
+                            .prefetch_api
+                            .sweat_prefetch_senders
+                            .contains(&receipt.predecessor_id)
+                    {
+                        for action in &action_receipt.actions {
+                            if let Action::FunctionCall(fn_call) = action {
+                                if fn_call.method_name == "record_batch" {
+                                    self.prefetch_sweat_record_batch(
+                                        account_id.clone(),
+                                        &fn_call.args,
+                                    )?;
+                                }
                             }
                         }
                     }
                 }
+                ReceiptEnum::Data(_) | ReceiptEnum::PromiseResume(_) => {}
             }
         }
         Ok(())

--- a/tools/mirror/src/chain_tracker.rs
+++ b/tools/mirror/src/chain_tracker.rs
@@ -853,7 +853,7 @@ impl TxTracker {
                     }
                 }
             }
-            _ => {}
+            ReceiptEnumView::Data { .. } => {}
         };
         Ok(())
     }

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -1295,7 +1295,7 @@ impl<T: ChainAccess> TxMirror<T> {
                 Err(ChainError::Other(e)) => return Err(e),
             };
 
-            if let ReceiptEnum::Action(r) = &receipt.receipt {
+            if let ReceiptEnum::Action(r) | ReceiptEnum::PromiseYield(r) = &receipt.receipt {
                 if (provenance.is_create_account() && receipt.predecessor_id == receipt.receiver_id)
                     || (!provenance.is_create_account()
                         && receipt.predecessor_id != receipt.receiver_id)
@@ -1409,7 +1409,7 @@ impl<T: ChainAccess> TxMirror<T> {
         tracker: &mut crate::chain_tracker::TxTracker,
         txs: &mut Vec<TargetChainTx>,
     ) -> anyhow::Result<()> {
-        if let ReceiptEnum::Action(r) = &receipt.receipt {
+        if let ReceiptEnum::Action(r) | ReceiptEnum::PromiseYield(r) = &receipt.receipt {
             if r.actions.iter().any(|a| matches!(a, Action::FunctionCall(_))) {
                 self.add_function_call_keys(
                     tracker,


### PR DESCRIPTION
In #10676 we introduced ReceiptEnum variants `PromiseYield` and `PromiseResume`.

At the time `Action` and `PromiseYield` receipts were treated identically through the protocol, so it was reasonable to have unified helpers `is_action` and `action`.

After #10689 there are fundamental  and subtle differences between `Action` receipts and`PromiseYield` receipts (for example how they are handled in [apply_receipt](https://github.com/near/nearcore/blob/6a68a2b18a8e17c9f1946d5ccd49742e7e14b587/runtime/runtime/src/lib.rs#L1039)). It seems safer now to explicitly specify behavior everywhere.