### PR TITLE
fix(resharding): fixed the resharding_rpc_tx nayduck test

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -485,7 +485,7 @@ class LocalNode(BaseNode):
             self.wait_for_rpc(10)
         except:
             logger.error(
-                '=== failed to start node, rpc does not ready in 10 seconds')
+                '=== failed to start node, rpc is not ready in 10 seconds')
 
     def run_cmd(self, *, cmd: tuple, extra_env: typing.Dict[str, str] = dict()):
 

--- a/pytest/tests/sanity/resharding_rpc_tx.py
+++ b/pytest/tests/sanity/resharding_rpc_tx.py
@@ -8,6 +8,7 @@ We submit a transfer transaction between the accounts and verify the transaction
 import sys
 import unittest
 import pathlib
+import copy
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 
@@ -51,6 +52,20 @@ class ReshardingRpcTx(ReshardingTestBase):
     def __verify_tx_status(self, transfer_response, sender_account_id):
         tx_hash = transfer_response['result']['transaction']['hash']
         response = self.node.get_tx(tx_hash, sender_account_id)
+
+        self.assertEqual(
+            transfer_response['result']['final_execution_status'],
+            'EXECUTED',
+        )
+        self.assertEqual(
+            response['result']['final_execution_status'],
+            'FINAL',
+        )
+
+        transfer_response = copy.deepcopy(transfer_response)
+        transfer_response['result']['final_execution_status'] = "IGNORE_ME"
+        response['result']['final_execution_status'] = "IGNORE_ME"
+
         assert response == transfer_response, response
         pass
 


### PR DESCRIPTION
Something's changed and now when submitting the transaction the result has status "EXECUTED" and when getting the status later via RPC the result has status "FINAL". Previously the test was asserting equality of those, now adjusted to accomodate the different statuses. 

First commit is just a minor refactor and the second one is the actual fix. Best reviewed separately. 