### PR TITLE
fix(mocknet): avoid calling sys.exit() in neard runner

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -180,7 +180,8 @@ class NeardRunner:
                         f'config should contain one binary with epoch_height 0')
             else:
                 if epoch_height == last_epoch_height:
-                    raise ValueError(f'repeated epoch height in config: {epoch_height}')
+                    raise ValueError(
+                        f'repeated epoch height in config: {epoch_height}')
             last_epoch_height = epoch_height
             binaries.append({
                 'url': b['url'],
@@ -462,9 +463,7 @@ class NeardRunner:
             except ValueError as e:
                 raise jsonrpc.exceptions.JSONRPCDispatchException(
                     code=-32603,
-                    message=
-                    f'Internal error downloading binaries: {e}'
-                )
+                    message=f'Internal error downloading binaries: {e}')
                 self.set_state(TestState.ERROR)
                 self.save_data()
             logging.info('update binaries finished')


### PR DESCRIPTION
sys.exit() doesn't do what you'd think in python threading.Threads. If it's called in an RPC handler, it just causes that handler to exit, and when it's called in main_loop(), it just causes that function to exit, but the program is still running and accepting connections, which can be quite confusing when main_loop() was expected to do some work after an RPC call returns OK. 

So instead of calling sys.exit(), we can add a TestState.ERROR variant and set the state to that when something bad seems to have happened, and then the test operator can take a look and hopefully fix it.