### PR TITLE
congestion: new tx prioritizing strategy

### DIFF
--- a/tools/congestion-model/src/main.rs
+++ b/tools/congestion-model/src/main.rs
@@ -1,4 +1,4 @@
-use congestion_model::strategy::{GlobalTxStopShard, NoQueueShard, SimpleBackpressure};
+use congestion_model::strategy::{GlobalTxStopShard, NewTxLast, NoQueueShard, SimpleBackpressure};
 use congestion_model::workload::{
     AllForOneProducer, BalancedProducer, LinearImbalanceProducer, Producer,
 };
@@ -71,10 +71,9 @@ fn strategy(strategy_name: &str, num_shards: usize) -> Vec<Box<dyn CongestionStr
     for _ in 0..num_shards {
         let strategy = match strategy_name {
             "No queues" => Box::new(NoQueueShard {}) as Box<dyn CongestionStrategy>,
-            "Global TX stop" => Box::<GlobalTxStopShard>::default() as Box<dyn CongestionStrategy>,
-            "Simple backpressure" => {
-                Box::<SimpleBackpressure>::default() as Box<dyn CongestionStrategy>
-            }
+            "Global TX stop" => Box::<GlobalTxStopShard>::default(),
+            "Simple backpressure" => Box::<SimpleBackpressure>::default(),
+            "New TX last" => Box::<NewTxLast>::default(),
             _ => panic!("unknown strategy: {}", strategy_name),
         };
 
@@ -104,6 +103,7 @@ fn parse_strategy_names(strategy_name: &str) -> Vec<String> {
         "No queues".to_string(),
         "Global TX stop".to_string(),
         "Simple backpressure".to_string(),
+        "New TX last".to_string(),
     ];
 
     if strategy_name == "all" {

--- a/tools/congestion-model/src/model/chunk_execution.rs
+++ b/tools/congestion-model/src/model/chunk_execution.rs
@@ -2,9 +2,7 @@ use super::queue_bundle::QueueBundle;
 use super::transaction_registry::TransactionRegistry;
 use super::BlockInfo;
 use crate::model::transaction::ExecutionResult;
-use crate::{
-    GGas, Queue, QueueId, Receipt, Round, ShardId, TransactionId, GAS_LIMIT, TX_GAS_LIMIT,
-};
+use crate::{GGas, Queue, QueueId, Receipt, Round, ShardId, TransactionId, GAS_LIMIT};
 use std::collections::{BTreeMap, VecDeque};
 
 /// Transient struct created once for each shard per model execution round,
@@ -72,9 +70,12 @@ impl<'model> ChunkExecutionContext<'model> {
 
     /// Accept a transaction and convert it to a receipt.
     pub fn accept_transaction(&mut self, tx: TransactionId) -> Receipt {
+        // note: Check the total gas limit, not the TX gas limit because we want
+        // to allow changes to how the chunk space is split between transactions
+        // and receipts.
         assert!(
-            self.gas_burnt < TX_GAS_LIMIT,
-            "trying to accept more transactions than tx gas limit allows",
+            self.gas_burnt < GAS_LIMIT,
+            "trying to accept more transactions than gas limit allows",
         );
         let ExecutionResult { gas_burnt, mut new_receipts } =
             self.transactions[tx].start(self.round);

--- a/tools/congestion-model/src/strategy/mod.rs
+++ b/tools/congestion-model/src/strategy/mod.rs
@@ -2,10 +2,12 @@ use crate::model::ChunkExecutionContext;
 use crate::{QueueId, ShardId};
 
 pub use global_tx_stop::GlobalTxStopShard;
+pub use new_tx_last::NewTxLast;
 pub use no_queues::NoQueueShard;
 pub use simple_backpressure::SimpleBackpressure;
 
 mod global_tx_stop;
+mod new_tx_last;
 mod no_queues;
 mod simple_backpressure;
 

--- a/tools/congestion-model/src/strategy/new_tx_last.rs
+++ b/tools/congestion-model/src/strategy/new_tx_last.rs
@@ -1,0 +1,44 @@
+use crate::model::ChunkExecutionContext;
+use crate::strategy::QueueFactory;
+use crate::GAS_LIMIT;
+
+#[derive(Default)]
+/// No queues, no backpressure. But always prioritize existing receipts over new
+/// transactions. This can easily starve a shard but it maximizes how many
+/// transactions get done in the global system.
+pub struct NewTxLast {}
+
+impl crate::CongestionStrategy for NewTxLast {
+    fn init(
+        &mut self,
+        _id: crate::ShardId,
+        _other_shards: &[crate::ShardId],
+        _queue_factory: &mut dyn QueueFactory,
+    ) {
+    }
+
+    fn compute_chunk(&mut self, ctx: &mut ChunkExecutionContext) {
+        // Start with receipts and reserve no chunk space to new transactions.
+        // In contrast to nearcore today, which gives new transactions priority with up to halve the chunks space.
+        while ctx.gas_burnt() < GAS_LIMIT {
+            if let Some(receipt) = ctx.incoming_receipts().pop_front() {
+                let outgoing = ctx.execute_receipt(receipt);
+                for receipt in outgoing {
+                    ctx.forward_receipt(receipt);
+                }
+            } else {
+                // no more receipts to execute
+                break;
+            }
+        }
+        while ctx.gas_burnt() < GAS_LIMIT {
+            if let Some(tx) = ctx.incoming_transactions().pop_front() {
+                let outgoing = ctx.accept_transaction(tx);
+                ctx.forward_receipt(outgoing);
+            } else {
+                // no more transaction incoming
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
The new congestion control strategy `NewTxLast` switches the order of receipt and transaction processing, giving receipt priority at all times.

In this way, we avoid wasting chunks space of congested shards on anything but making sure we resolve congestion. In some scenarios, this works really well.

However, for fairness, this is really bad. Some shards might get starved from accepting new transactions.

Note that we don't have a good metric to observe and qualify fairness, yet.