### PR TITLE
fix(genesis-init): respect genesis.use_production_config when computing genesis state

### DIFF
--- a/core/store/src/genesis/initialization.rs
+++ b/core/store/src/genesis/initialization.rs
@@ -24,7 +24,12 @@ use crate::{
 const STATE_DUMP_FILE: &str = "state_dump";
 const GENESIS_ROOTS_FILE: &str = "genesis_roots";
 
-pub fn initialize_genesis_state(store: Store, genesis: &Genesis, home_dir: Option<&Path>) {
+pub fn initialize_sharded_genesis_state(
+    store: Store,
+    genesis: &Genesis,
+    genesis_epoch_config: &EpochConfig,
+    home_dir: Option<&Path>,
+) {
     // Ignore initialization if we already have genesis hash and state roots in store
     let stored_hash = get_genesis_hash(&store).expect("Store failed on genesis intialization");
     if let Some(_hash) = stored_hash {
@@ -42,7 +47,7 @@ pub fn initialize_genesis_state(store: Store, genesis: &Genesis, home_dir: Optio
             }
             genesis_state_from_dump(store.clone(), home_dir.unwrap())
         } else {
-            genesis_state_from_genesis(store.clone(), genesis)
+            genesis_state_from_genesis(store.clone(), genesis, &genesis_epoch_config.shard_layout)
         };
         let genesis_hash = genesis.json_hash();
         let mut store_update = store.store_update();
@@ -51,14 +56,18 @@ pub fn initialize_genesis_state(store: Store, genesis: &Genesis, home_dir: Optio
         store_update.commit().expect("Store failed on genesis intialization");
     }
 
-    let num_shards = genesis.config.shard_layout.shard_ids().count() as NumShards;
+    let num_shards = genesis_epoch_config.shard_layout.shard_ids().count() as NumShards;
     assert_eq!(
         num_shards,
-        genesis.config.num_block_producer_seats_per_shard.len() as NumShards,
+        genesis_epoch_config.num_block_producer_seats_per_shard.len() as NumShards,
         "genesis config shard_layout and num_block_producer_seats_per_shard indicate inconsistent number of shards {} vs {}",
         num_shards,
-        genesis.config.num_block_producer_seats_per_shard.len() as NumShards,
+        genesis_epoch_config.num_block_producer_seats_per_shard.len() as NumShards,
     );
+}
+
+pub fn initialize_genesis_state(store: Store, genesis: &Genesis, home_dir: Option<&Path>) {
+    initialize_sharded_genesis_state(store, genesis, &EpochConfig::from(&genesis.config), home_dir);
 }
 
 fn genesis_state_from_dump(store: Store, home_dir: &Path) -> Vec<StateRoot> {
@@ -74,7 +83,11 @@ fn genesis_state_from_dump(store: Store, home_dir: &Path) -> Vec<StateRoot> {
     state_roots
 }
 
-fn genesis_state_from_genesis(store: Store, genesis: &Genesis) -> Vec<StateRoot> {
+fn genesis_state_from_genesis(
+    store: Store,
+    genesis: &Genesis,
+    shard_layout: &ShardLayout,
+) -> Vec<StateRoot> {
     match &genesis.contents {
         GenesisContents::Records { records } => {
             info!(
@@ -97,11 +110,11 @@ fn genesis_state_from_genesis(store: Store, genesis: &Genesis) -> Vec<StateRoot>
     let runtime_config_store = RuntimeConfigStore::for_chain_id(&genesis.config.chain_id);
     let runtime_config = runtime_config_store.get_config(genesis.config.protocol_version);
     let storage_usage_config = &runtime_config.fees.storage_usage_config;
-    let initial_epoch_config = EpochConfig::from(&genesis.config);
-    let shard_layout = initial_epoch_config.shard_layout;
-    let shard_ids: Vec<_> = shard_layout.shard_ids().collect();
+    let shard_uids: Vec<_> = shard_layout.shard_uids().collect();
+    // note that here we are depending on the behavior that shard_layout.shard_uids() returns an iterator
+    // in order by shard id from 0 to num_shards()
     let mut shard_account_ids: Vec<HashSet<AccountId>> =
-        shard_ids.iter().map(|_| HashSet::new()).collect();
+        shard_uids.iter().map(|_| HashSet::new()).collect();
     let mut has_protocol_account = false;
     info!(target: "store","distributing records to shards");
 
@@ -118,15 +131,16 @@ fn genesis_state_from_genesis(store: Store, genesis: &Genesis) -> Vec<StateRoot>
     let tries = ShardTries::new(
         store.clone(),
         TrieConfig::default(),
-        &genesis.config.shard_layout.shard_uids().collect::<Vec<_>>(),
+        &shard_uids,
         FlatStorageManager::new(store),
         StateSnapshotConfig::default(),
     );
 
     let writers = std::sync::atomic::AtomicUsize::new(0);
-    shard_ids
+    shard_uids
         .into_par_iter()
-        .map(|shard_id| {
+        .map(|shard_uid| {
+            let shard_id = shard_uid.shard_id();
             let validators = genesis
                 .config
                 .validators
@@ -147,7 +161,7 @@ fn genesis_state_from_genesis(store: Store, genesis: &Genesis) -> Vec<StateRoot>
             GenesisStateApplier::apply(
                 &writers,
                 tries.clone(),
-                shard_id,
+                shard_uid,
                 &validators,
                 storage_usage_config,
                 genesis,

--- a/core/store/src/genesis/mod.rs
+++ b/core/store/src/genesis/mod.rs
@@ -4,7 +4,7 @@
 mod initialization;
 mod state_applier;
 
-pub use initialization::initialize_genesis_state;
+pub use initialization::{initialize_genesis_state, initialize_sharded_genesis_state};
 pub use state_applier::compute_genesis_storage_usage;
 pub use state_applier::compute_storage_usage;
 pub use state_applier::GenesisStateApplier;

--- a/core/store/src/genesis/state_applier.rs
+++ b/core/store/src/genesis/state_applier.rs
@@ -13,7 +13,7 @@ use near_primitives::receipt::{DelayedReceiptIndices, Receipt, ReceiptEnum, Rece
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::state_record::{state_record_to_account_id, StateRecord};
 use near_primitives::trie_key::TrieKey;
-use near_primitives::types::{AccountId, Balance, ShardId, StateChangeCause, StateRoot};
+use near_primitives::types::{AccountId, Balance, StateChangeCause, StateRoot};
 use near_vm_runner::ContractCode;
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic;
@@ -347,15 +347,13 @@ impl GenesisStateApplier {
     pub fn apply(
         op_limit: &atomic::AtomicUsize,
         tries: ShardTries,
-        shard_id: ShardId,
+        shard_uid: ShardUId,
         validators: &[(AccountId, PublicKey, Balance)],
         config: &StorageUsageConfig,
         genesis: &Genesis,
         shard_account_ids: HashSet<AccountId>,
     ) -> StateRoot {
         let mut delayed_receipts_indices = DelayedReceiptIndices::default();
-        let shard_uid =
-            ShardUId { version: genesis.config.shard_layout.version(), shard_id: shard_id as u32 };
         let mut storage =
             AutoFlushingTrieUpdate::new(op_limit, StateRoot::default(), &tries, shard_uid);
         Self::apply_batch(

--- a/integration-tests/src/runtime_utils.rs
+++ b/integration-tests/src/runtime_utils.rs
@@ -48,7 +48,7 @@ pub fn get_runtime_and_trie_from_genesis(genesis: &Genesis) -> (Runtime, ShardTr
     let genesis_root = GenesisStateApplier::apply(
         &writers,
         tries.clone(),
-        0,
+        ShardUId::from_shard_id_and_layout(0, shard_layout),
         &genesis
             .config
             .validators

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -26,10 +26,12 @@ use near_client::sync::adapter::SyncAdapter;
 use near_client::{start_client, start_view_client, ClientActor, ConfigUpdater, ViewClientActor};
 use near_epoch_manager::shard_tracker::{ShardTracker, TrackedConfig};
 use near_epoch_manager::EpochManager;
+use near_epoch_manager::EpochManagerAdapter;
 use near_network::PeerManagerActor;
 use near_primitives::block::GenesisId;
+use near_primitives::types::EpochId;
 use near_store::flat::FlatStateValuesInliningMigrationHandle;
-use near_store::genesis::initialize_genesis_state;
+use near_store::genesis::initialize_sharded_genesis_state;
 use near_store::metadata::DbKind;
 use near_store::metrics::spawn_db_metrics_loop;
 use near_store::{DBCol, Mode, NodeStorage, Store, StoreOpenerError};
@@ -249,13 +251,19 @@ pub fn start_with_config_and_synchronization(
         config.client_config.log_summary_period,
     )?;
 
+    let epoch_manager =
+        EpochManager::new_arc_handle(storage.get_hot_store(), &config.genesis.config);
+    let genesis_epoch_config = epoch_manager.get_epoch_config(&EpochId::default())?;
     // Initialize genesis_state in store either from genesis config or dump before other components.
     // We only initialize if the genesis state is not already initialized in store.
     // This sets up genesis_state_roots and genesis_hash in store.
-    initialize_genesis_state(storage.get_hot_store(), &config.genesis, Some(home_dir));
+    initialize_sharded_genesis_state(
+        storage.get_hot_store(),
+        &config.genesis,
+        &genesis_epoch_config,
+        Some(home_dir),
+    );
 
-    let epoch_manager =
-        EpochManager::new_arc_handle(storage.get_hot_store(), &config.genesis.config);
     let shard_tracker =
         ShardTracker::new(TrackedConfig::from_config(&config.client_config), epoch_manager.clone());
     let runtime = NightshadeRuntime::from_config(

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -742,8 +742,8 @@ class NeardRunner:
                     # protocol_versions in range [56, 63] need to have these
                     # genesis parameters, otherwise nodes get stuck because at
                     # some point it produces an incompatible EpochInfo.
-                    # TODO: Make so that the node always constructs EpochInfo
-                    #       using `AllEpochConfig::for_protocol_version()`.
+                    # TODO: remove these changes once mocknet tests will probably
+                    # only ever be run with binaries including https://github.com/near/nearcore/pull/10722
                     genesis_config['num_block_producer_seats'] = 100
                     genesis_config['num_block_producer_seats_per_shard'] = [
                         100, 100, 100, 100

--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -81,7 +81,7 @@ impl StandaloneRuntime {
         let root = GenesisStateApplier::apply(
             &writers,
             tries.clone(),
-            0,
+            ShardUId::from_shard_id_and_layout(0, &genesis.config.shard_layout),
             &[],
             &runtime_config.fees.storage_usage_config,
             &genesis,


### PR DESCRIPTION
`near_store::genesis::initialize_genesis_state()` uses the shard layout found in the genesis config when computing the initial state roots. This works fine as long as the `use_production_config` parameter is `false`. But when it's `true`, this shard layout is not necessarily the same as the one we'll get in the first epoch of the chain. So with the resharding in protocol version 64, that means that if we try to start a mocknet test forked from a 4-shard mainnet with starting protocol version 64, we hit [this assert](https://github.com/near/nearcore/blob/fb500f5b976669e2e481f1d8e3bee49dced022ec/core/primitives/src/block.rs#L102) because `initialize_genesis_state()` computed its state roots based on the 4 shards specified in the genesis config, but the `shard_ids` slice we're comparing it to is [taken from](https://github.com/near/nearcore/blob/fb500f5b976669e2e481f1d8e3bee49dced022ec/chain/chain/src/chain.rs#L398) the 5 shards we get with `use_production_config=true`

So this PR extracts an `initialize_sharded_genesis_state()` function from `initialize_genesis_state()` that takes an `EpochConfig`, which will be called with the correct config in `nearcore::start_with_config_and_synchronization()`. Then in that function, we refer to that `EpochConfig`'s shard layout and `num_block_producer_seats_per_shard` instead of the genesis config's. We do this instead of just changing `initialize_genesis_state()` because that function is called in many tests, and it would be a bit of a pain to update every caller

closes https://github.com/near/nearcore/issues/9996