### PR TITLE
introduce an always-failing fuzzer, to sanity-check our clusterfuzz setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4190,6 +4190,7 @@ dependencies = [
  "assert_matches",
  "base64 0.21.0",
  "bencher",
+ "bolero",
  "borsh 1.0.0",
  "bytesize",
  "cfg-if 1.0.0",

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -91,6 +91,7 @@ calimero_zero_storage = []
 [dev-dependencies]
 assert_matches.workspace = true
 bencher.workspace = true
+bolero.workspace = true
 insta.workspace = true
 expect-test.workspace = true
 

--- a/core/primitives/src/lib.rs
+++ b/core/primitives/src/lib.rs
@@ -42,3 +42,11 @@ pub mod views;
 
 pub use crate::version::checked_feature;
 pub use near_primitives_core::chains;
+
+#[cfg(fuzz)]
+#[test]
+fn failing_fuzzer() {
+    // This fuzzer always fails. It is used as a sanity-check that our clusterfuzz instance
+    // is working properly, as it has silently stopped working quite a few times already.
+    bolero::check!().for_each(|_| panic!("The expected-to-fail fuzzer actually failed"))
+}


### PR DESCRIPTION
Based on the clusterfuzz web UI I cannot confirm whether it is actually working properly, and I’m under the impression that it is actually not running the fuzzers we’re asking it to.

This fuzzer should make it obvious: if clusterfuzz does not report a fuzzer failure on it, then it is broken.

There is no good place for it, so I just put it in our current "everything else" near-primitives crate, as it has basically no internal dependencies on anything it’ll be very easy to move it out whenever we actually get close to getting rid of near-primitives.