### PR TITLE
[TestLoop Refactoring] Introduce AsyncComputationSpawner, and make the multi-node test work.

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -13,6 +13,7 @@ use crate::state_request_tracker::StateRequestTracker;
 use crate::state_snapshot_actor::SnapshotCallbacks;
 use crate::store::{ChainStore, ChainStoreAccess, ChainStoreUpdate};
 
+use crate::rayon_spawner::RayonAsyncComputationSpawner;
 use crate::types::{
     AcceptedBlock, ApplyChunkBlockContext, BlockEconomicsConfig, ChainConfig, RuntimeAdapter,
     StorageDataSource,
@@ -37,6 +38,7 @@ use borsh::BorshDeserialize;
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use itertools::Itertools;
 use lru::LruCache;
+use near_async::futures::{AsyncComputationSpawner, AsyncComputationSpawnerExt};
 use near_async::time::{Clock, Duration, Instant};
 use near_chain_configs::{MutableConfigValue, ReshardingConfig, ReshardingHandle};
 #[cfg(feature = "new_epoch_sync")]
@@ -239,6 +241,8 @@ pub struct Chain {
     apply_chunks_sender: Sender<BlockApplyChunksResult>,
     /// Used to receive apply chunks results
     apply_chunks_receiver: Receiver<BlockApplyChunksResult>,
+    /// Used to spawn the apply chunks jobs.
+    apply_chunks_spawner: Box<dyn AsyncComputationSpawner>,
     /// Time when head was updated most recently.
     last_time_head_updated: Instant,
     /// Prevents re-application of known-to-be-invalid blocks, so that in case of a
@@ -362,6 +366,7 @@ impl Chain {
             blocks_delay_tracker: BlocksDelayTracker::new(clock.clone()),
             apply_chunks_sender: sc,
             apply_chunks_receiver: rc,
+            apply_chunks_spawner: Box::new(RayonAsyncComputationSpawner),
             last_time_head_updated: clock.now(),
             invalid_blocks: LruCache::new(INVALID_CHUNKS_POOL_SIZE),
             pending_state_patch: Default::default(),
@@ -384,6 +389,7 @@ impl Chain {
         doomslug_threshold_mode: DoomslugThresholdMode,
         chain_config: ChainConfig,
         snapshot_callbacks: Option<SnapshotCallbacks>,
+        apply_chunks_spawner: Box<dyn AsyncComputationSpawner>,
     ) -> Result<Chain, Error> {
         // Get runtime initial state and create genesis block out of it.
         let state_roots = get_genesis_state_roots(runtime_adapter.store())?
@@ -538,6 +544,7 @@ impl Chain {
             blocks_delay_tracker: BlocksDelayTracker::new(clock.clone()),
             apply_chunks_sender: sc,
             apply_chunks_receiver: rc,
+            apply_chunks_spawner,
             last_time_head_updated: clock.now(),
             pending_state_patch: Default::default(),
             requested_state_parts: StateRequestTracker::new(),
@@ -1707,7 +1714,7 @@ impl Chain {
         apply_chunks_done_callback: DoneApplyChunkCallback,
     ) {
         let sc = self.apply_chunks_sender.clone();
-        spawn(move || {
+        self.apply_chunks_spawner.spawn("apply_chunks", move || {
             // do_apply_chunks runs `work` in parallel, but still waits for all of them to finish
             let res = do_apply_chunks(block_hash, block_height, work);
             // If we encounter error here, that means the receiver is deallocated and the client
@@ -1719,13 +1726,6 @@ impl Chain {
             }
             apply_chunks_done_callback(block_hash);
         });
-
-        /// `rayon::spawn` decorated to propagate `tracing` context across
-        /// threads.
-        fn spawn(f: impl FnOnce() + Send + 'static) {
-            let dispatcher = tracing::dispatcher::get_default(|it| it.clone());
-            rayon::spawn(move || tracing::dispatcher::with_default(&dispatcher, f))
-        }
     }
 
     fn postprocess_block_only(

--- a/chain/chain/src/lib.rs
+++ b/chain/chain/src/lib.rs
@@ -34,6 +34,7 @@ pub mod test_utils;
 pub mod types;
 pub mod validate;
 
+pub mod rayon_spawner;
 pub mod sharding;
 #[cfg(test)]
 mod tests;

--- a/chain/chain/src/rayon_spawner.rs
+++ b/chain/chain/src/rayon_spawner.rs
@@ -1,0 +1,10 @@
+use near_async::futures::AsyncComputationSpawner;
+
+pub struct RayonAsyncComputationSpawner;
+
+impl AsyncComputationSpawner for RayonAsyncComputationSpawner {
+    fn spawn_boxed(&self, _name: &str, f: Box<dyn FnOnce() + Send>) {
+        let dispatcher = tracing::dispatcher::get_default(|it| it.clone());
+        rayon::spawn(move || tracing::dispatcher::with_default(&dispatcher, f))
+    }
+}

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -37,6 +37,7 @@ use near_store::{get_genesis_state_roots, NodeStorage, PartialStorage};
 
 use super::*;
 
+use crate::rayon_spawner::RayonAsyncComputationSpawner;
 use near_async::time::Clock;
 use near_primitives::account::id::AccountIdRef;
 use near_primitives::trie_key::TrieKey;
@@ -1541,6 +1542,7 @@ fn get_test_env_with_chain_and_pool() -> (TestEnv, Chain, TransactionPool) {
         DoomslugThresholdMode::NoApprovals,
         ChainConfig::test(),
         None,
+        Box::new(RayonAsyncComputationSpawner),
     )
     .unwrap();
 

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -387,6 +387,7 @@ mod tests {
     use near_store::genesis::initialize_genesis_state;
     use near_store::test_utils::create_test_store;
 
+    use crate::rayon_spawner::RayonAsyncComputationSpawner;
     use crate::runtime::NightshadeRuntime;
     use crate::types::ChainConfig;
     use crate::{Chain, ChainGenesis, ChainStoreAccess, DoomslugThresholdMode};
@@ -416,6 +417,7 @@ mod tests {
             DoomslugThresholdMode::NoApprovals,
             ChainConfig::test(),
             None,
+            Box::new(RayonAsyncComputationSpawner),
         )
         .unwrap();
         (

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use crate::block_processing_utils::BlockNotInPoolError;
 use crate::chain::Chain;
+use crate::rayon_spawner::RayonAsyncComputationSpawner;
 use crate::runtime::NightshadeRuntime;
 use crate::store::ChainStoreAccess;
 use crate::types::{AcceptedBlock, ChainConfig, ChainGenesis};
@@ -73,6 +74,7 @@ pub fn get_chain_with_epoch_length_and_num_shards(
         DoomslugThresholdMode::NoApprovals,
         ChainConfig::test(),
         None,
+        Box::new(RayonAsyncComputationSpawner),
     )
     .unwrap()
 }
@@ -155,6 +157,7 @@ fn setup_with_tx_validity_period(
         DoomslugThresholdMode::NoApprovals,
         ChainConfig::test(),
         None,
+        Box::new(RayonAsyncComputationSpawner),
     )
     .unwrap();
 
@@ -194,6 +197,7 @@ pub fn setup_with_validators(
         DoomslugThresholdMode::NoApprovals,
         ChainConfig::test(),
         None,
+        Box::new(RayonAsyncComputationSpawner),
     )
     .unwrap();
     (chain, epoch_manager, runtime, signers)
@@ -231,6 +235,7 @@ pub fn setup_with_validators_and_start_time(
         DoomslugThresholdMode::NoApprovals,
         ChainConfig::test(),
         None,
+        Box::new(RayonAsyncComputationSpawner),
     )
     .unwrap();
     (chain, epoch_manager, runtime, signers)

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -16,7 +16,7 @@ use crate::SyncAdapter;
 use crate::SyncMessage;
 use crate::{metrics, SyncStatus};
 use itertools::Itertools;
-use near_async::futures::FutureSpawner;
+use near_async::futures::{AsyncComputationSpawner, FutureSpawner};
 use near_async::messaging::IntoSender;
 use near_async::messaging::{CanSend, Sender};
 use near_async::time::{Clock, Duration, Instant};
@@ -250,6 +250,7 @@ impl Client {
         enable_doomslug: bool,
         rng_seed: RngSeed,
         snapshot_callbacks: Option<SnapshotCallbacks>,
+        apply_chunks_spawner: Box<dyn AsyncComputationSpawner>,
     ) -> Result<Self, Error> {
         let doomslug_threshold_mode = if enable_doomslug {
             DoomslugThresholdMode::TwoThirds
@@ -270,6 +271,7 @@ impl Client {
             doomslug_threshold_mode,
             chain_config.clone(),
             snapshot_callbacks,
+            apply_chunks_spawner,
         )?;
         // Create flat storage or initiate migration to flat storage.
         let flat_storage_creator = FlatStorageCreator::new(

--- a/chain/client/src/client_actions.rs
+++ b/chain/client/src/client_actions.rs
@@ -101,7 +101,7 @@ pub struct ClientActions {
 
     // Sender to be able to send a message to myself.
     myself_sender: ClientSenderForClient,
-    pub(crate) client: Client,
+    pub client: Client,
     network_adapter: PeerManagerAdapter,
     network_info: NetworkInfo,
     /// Identity that represents this Client at the network level.

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -12,6 +12,7 @@ use near_async::futures::ActixArbiterHandleFutureSpawner;
 use near_async::messaging::{IntoMultiSender, IntoSender, Sender};
 use near_async::time::Utc;
 use near_async::time::{Clock, Duration};
+use near_chain::rayon_spawner::RayonAsyncComputationSpawner;
 use near_chain::state_snapshot_actor::SnapshotCallbacks;
 use near_chain::types::RuntimeAdapter;
 use near_chain::ChainGenesis;
@@ -213,6 +214,7 @@ pub fn start_client(
         true,
         random_seed_from_thread(),
         snapshot_callbacks,
+        Box::new(RayonAsyncComputationSpawner),
     )
     .unwrap();
     let resharding_handle = client.chain.resharding_handle.clone();

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -862,6 +862,7 @@ mod tests {
     use assert_matches::assert_matches;
     use near_async::messaging::{noop, IntoSender};
     use near_async::time::Clock;
+    use near_chain::rayon_spawner::RayonAsyncComputationSpawner;
     use near_chain::test_utils::{KeyValueRuntime, MockEpochManager, ValidatorSchedule};
     use near_chain::types::ChainConfig;
     use near_chain::{Chain, ChainGenesis, DoomslugThresholdMode};
@@ -923,6 +924,7 @@ mod tests {
             doomslug_threshold_mode,
             ChainConfig::test(),
             None,
+            Box::new(RayonAsyncComputationSpawner),
         )
         .unwrap();
 

--- a/chain/client/src/test_utils/setup.rs
+++ b/chain/client/src/test_utils/setup.rs
@@ -10,6 +10,7 @@ use futures::{future, FutureExt};
 use near_async::actix::AddrWithAutoSpanContextExt;
 use near_async::messaging::{noop, CanSend, IntoMultiSender, IntoSender, LateBoundSender, Sender};
 use near_async::time::{Clock, Duration, Instant, Utc};
+use near_chain::rayon_spawner::RayonAsyncComputationSpawner;
 use near_chain::state_snapshot_actor::SnapshotCallbacks;
 use near_chain::test_utils::{KeyValueRuntime, MockEpochManager, ValidatorSchedule};
 use near_chain::types::{ChainConfig, RuntimeAdapter};
@@ -119,6 +120,7 @@ pub fn setup(
             ),
         },
         None,
+        Box::new(RayonAsyncComputationSpawner),
     )
     .unwrap();
     let genesis_block = chain.get_block(&chain.genesis().hash().clone()).unwrap();
@@ -181,6 +183,7 @@ pub fn setup(
         enable_doomslug,
         TEST_SEED,
         None,
+        Box::new(RayonAsyncComputationSpawner),
     )
     .unwrap();
     let client_actor = ClientActor::new(
@@ -255,6 +258,7 @@ pub fn setup_only_view(
             ),
         },
         None,
+        Box::new(RayonAsyncComputationSpawner),
     )
     .unwrap();
 
@@ -984,6 +988,7 @@ pub fn setup_client_with_runtime(
         enable_doomslug,
         rng_seed,
         snapshot_callbacks,
+        Box::new(RayonAsyncComputationSpawner),
     )
     .unwrap();
     client.sync_status = SyncStatus::NoSync;
@@ -1021,6 +1026,7 @@ pub fn setup_synchronous_shards_manager(
             ),
         }, // irrelevant
         None,
+        Box::new(RayonAsyncComputationSpawner),
     )
     .unwrap();
     let chain_head = chain.head().unwrap();

--- a/core/async/src/test_loop/futures.rs
+++ b/core/async/src/test_loop/futures.rs
@@ -1,5 +1,5 @@
 use super::{delay_sender::DelaySender, event_handler::LoopEventHandler};
-use crate::futures::DelayedActionRunner;
+use crate::futures::{AsyncComputationSpawner, DelayedActionRunner};
 use crate::time::Duration;
 use crate::{futures::FutureSpawner, messaging::CanSend};
 use futures::future::BoxFuture;
@@ -148,4 +148,37 @@ impl<T> DelayedActionRunner<T> for TestLoopDelayedActionRunner<T> {
             dur.try_into().unwrap(),
         );
     }
+}
+
+/// An event that represents async computation. See async_computation_spawner() in DelaySender.
+pub struct TestLoopAsyncComputationEvent {
+    name: String,
+    f: Box<dyn FnOnce() + Send>,
+}
+
+impl Debug for TestLoopAsyncComputationEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("AsyncComputation").field(&self.name).finish()
+    }
+}
+
+/// AsyncComputationSpawner that spawns the computation in the TestLoop.
+pub struct TestLoopAsyncComputationSpawner {
+    pub(crate) sender: DelaySender<TestLoopAsyncComputationEvent>,
+    pub(crate) artificial_delay: Box<dyn Fn(&str) -> Duration + Send + Sync>,
+}
+
+impl AsyncComputationSpawner for TestLoopAsyncComputationSpawner {
+    fn spawn_boxed(&self, name: &str, f: Box<dyn FnOnce() + Send>) {
+        self.sender.send_with_delay(
+            TestLoopAsyncComputationEvent { name: name.to_string(), f },
+            (self.artificial_delay)(name),
+        );
+    }
+}
+
+pub fn drive_async_computations() -> LoopEventHandler<(), TestLoopAsyncComputationEvent> {
+    LoopEventHandler::new_simple(|event: TestLoopAsyncComputationEvent, _data: &mut ()| {
+        (event.f)();
+    })
 }

--- a/integration-tests/src/genesis_helpers.rs
+++ b/integration-tests/src/genesis_helpers.rs
@@ -4,6 +4,7 @@ use near_epoch_manager::EpochManager;
 use near_store::genesis::initialize_genesis_state;
 use tempfile::tempdir;
 
+use near_chain::rayon_spawner::RayonAsyncComputationSpawner;
 use near_chain::types::ChainConfig;
 use near_chain::{Chain, ChainGenesis, DoomslugThresholdMode};
 use near_chain_configs::Genesis;
@@ -36,6 +37,7 @@ pub fn genesis_header(genesis: &Genesis) -> BlockHeader {
         DoomslugThresholdMode::TwoThirds,
         ChainConfig::test(),
         None,
+        Box::new(RayonAsyncComputationSpawner),
     )
     .unwrap();
     chain.genesis().clone()
@@ -60,6 +62,7 @@ pub fn genesis_block(genesis: &Genesis) -> Block {
         DoomslugThresholdMode::TwoThirds,
         ChainConfig::test(),
         None,
+        Box::new(RayonAsyncComputationSpawner),
     )
     .unwrap();
     chain.get_block(&chain.genesis().hash().clone()).unwrap()

--- a/integration-tests/src/tests/client/features/simple_test_loop_example.rs
+++ b/integration-tests/src/tests/client/features/simple_test_loop_example.rs
@@ -2,7 +2,8 @@ use derive_enum_from_into::{EnumFrom, EnumTryInto};
 use near_async::futures::DelayedActionRunnerExt;
 use near_async::messaging::{noop, IntoMultiSender, IntoSender};
 use near_async::test_loop::futures::{
-    drive_delayed_action_runners, drive_futures, TestLoopDelayedActionEvent, TestLoopTask,
+    drive_async_computations, drive_delayed_action_runners, drive_futures,
+    TestLoopAsyncComputationEvent, TestLoopDelayedActionEvent, TestLoopTask,
 };
 use near_async::test_loop::TestLoopBuilder;
 use near_async::time::Duration;
@@ -35,6 +36,7 @@ use near_primitives::shard_layout::ShardLayout;
 use near_primitives::state_record::StateRecord;
 use near_primitives::test_utils::{create_test_signer, create_user_test_signer};
 use near_primitives::types::{AccountId, AccountInfo};
+use near_primitives::utils::from_timestamp;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives_core::account::{AccessKey, Account};
 use near_primitives_core::hash::CryptoHash;
@@ -56,6 +58,7 @@ struct TestData {
 #[allow(clippy::large_enum_variant)]
 enum TestEvent {
     Task(Arc<TestLoopTask>),
+    AsyncComputation(TestLoopAsyncComputationEvent),
     ClientDelayedActions(TestLoopDelayedActionEvent<ClientActions>),
     ClientEventFromNetwork(ClientSenderForNetworkMessage),
     ClientEventFromClient(ClientSenderForClientMessage),
@@ -69,9 +72,6 @@ enum TestEvent {
 
 const ONE_NEAR: u128 = 1_000_000_000_000_000_000_000_000;
 
-// TODO(robin-near): Complete this test so that it will actually run a chain.
-// TODO(robin-near): Make this a multi-node test.
-// TODO(robin-near): Make the network layer send messages.
 #[test]
 fn test_client_with_simple_test_loop() {
     let builder = TestLoopBuilder::<TestEvent>::new();
@@ -96,6 +96,7 @@ fn test_client_with_simple_test_loop() {
 
     // TODO: Make some builder for genesis.
     let mut genesis_config = GenesisConfig {
+        genesis_time: from_timestamp(builder.clock().now_utc().unix_timestamp_nanos() as u64),
         protocol_version: PROTOCOL_VERSION,
         genesis_height: 10000,
         shard_layout: ShardLayout::v1(
@@ -178,6 +179,7 @@ fn test_client_with_simple_test_loop() {
         true,
         [0; 32],
         None,
+        Box::new(builder.sender().into_async_computation_spawner(|_| Duration::milliseconds(80))),
     )
     .unwrap();
 
@@ -228,6 +230,7 @@ fn test_client_with_simple_test_loop() {
         .widen(),
     );
     test.register_handler(drive_futures().widen());
+    test.register_handler(drive_async_computations().widen());
     test.register_handler(drive_delayed_action_runners::<ClientActions>().widen());
     test.register_handler(forward_client_request_to_shards_manager().widen());
     // TODO: handle additional events.

--- a/tools/debug-ui/src/log_visualizer/events.ts
+++ b/tools/debug-ui/src/log_visualizer/events.ts
@@ -57,7 +57,9 @@ export class EventItem {
             const secondBracket = /[({]/.exec(afterFirstParens);
             if (secondBracket !== null) {
                 this.subtitle = afterFirstParens.substring(0, secondBracket.index);
-                if (this.subtitle === "DelayedAction" || this.subtitle === "Task") {
+                if (this.subtitle === "DelayedAction"
+                    || this.subtitle === "Task"
+                    || this.subtitle === "AsyncComputation") {
                     // Special logic for DelayedAction and Task, where we're more interested
                     // in the name, which is printed in the parens.
                     this.subtitle = afterFirstParens.substring(secondBracket.index + 1, afterFirstParens.length - 1);

--- a/tools/speedy_sync/src/main.rs
+++ b/tools/speedy_sync/src/main.rs
@@ -1,5 +1,6 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_async::time::Clock;
+use near_chain::rayon_spawner::RayonAsyncComputationSpawner;
 use near_chain::types::{ChainConfig, Tip};
 use near_chain::{Chain, ChainGenesis, DoomslugThresholdMode};
 use near_chain_configs::{GenesisValidationMode, MutableConfigValue, ReshardingConfig};
@@ -251,6 +252,7 @@ fn load_snapshot(load_cmd: LoadCmd) {
             ),
         },
         None,
+        Box::new(RayonAsyncComputationSpawner),
     )
     .unwrap();
 


### PR DESCRIPTION
* Introduce `AsyncComputationSpawner`, which is an abstraction of the mechanism to spawn async computation. We have two cases of async computation right now that I know of: chunk application, and stateless validation. The production implementation is rayon::spawn, and the test loop implementation posts it onto the event loop, with an optional delay that the test writer can inject (by providing a function from name to Duration).
* Improve the TestLoop API so that we now have `run_for(duration)`, `run_until(condition_fn, duration)`, and `finish_remaining_events(duration)`. Previously, `run_for` was enough because the tests we wrote using TestLoop were more like one-shot tests, where something happens and then if you run it longer nothing would happen except timers. But now, we're writing continuously-running tests, where if we keep running the test we would get more things happening (blocks keep being produced). So, run_until becomes useful to run the test until some condition becomes true. See the comments for finish_remaining_events.
* Add a panic hook to TestLoop initialization, so that if the test panics, we abort the process - otherwise some stuff like Chain destructor can hang forever and it's confusing. Also, when panicking we print a nice message like this:

```
 0.099s DEBUG catchup:run_catchup: sync: close time.busy=4.21µs time.idle=542ns
 0.099s DEBUG catchup: client: close time.busy=10.2µs time.idle=624ns
 0.099s  INFO test_loop: TEST_LOOP_EVENT_START {"current_index":11,"total_events":26,"current_event":"(0, ShardsManagerDelayedActions(DelayedAction(\"resend_chunk_requests\")))","current_time_ms":100}

================== ❗❗❗ P A N I C ❗❗❗ ===================

thread 'tests::client::features::multinode_test_loop_example::test_client_with_multi_test_loop' panicked at /<redacted>/nearcore/core/async/src/test_loop.rs:332:9:
Unhandled event: (0, ShardsManagerDelayedActions(DelayedAction("resend_chunk_requests")))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

💡💡💡 Tip: This is a TestLoop test. Pipe the output of this test to a file, and then use the visualizer from tools/debug-ui/README.md to see a detailed breakdown of what happened in the test.
error: test failed, to rerun pass `-p integration-tests --lib`

Caused by:
  process didn't exit successfully: `/<redacted>/nearcore/target/debug/deps/integration_tests-d66cae6d43167a50 test_client_with_multi_test_loop --nocapture` (signal: 6, SIGABRT: process abort signal)
```

* The multi-node client test now works properly (well, I believe; I need to add more assertions). It's doing all the chunk distributions now:
<img width="1166" alt="image" src="https://github.com/near/nearcore/assets/111538878/5504bbd2-7775-48c2-8361-aab4545454c9">
