### PR TITLE
[resharding] Nightshade V3 shard layout for protocol version 65

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -607,6 +607,7 @@ impl ChainStore {
     ) -> Result<(), Error> {
         tracing::trace!(target: "resharding", ?protocol_version, shard_id, receipts_shard_id, "reassign_outgoing_receipts_for_resharding");
         // If simple nightshade v2 is enabled and stable use that.
+        // Same reassignment of outgoing receipts works for simple nightshade v3
         if checked_feature!("stable", SimpleNightshadeV2, protocol_version) {
             Self::reassign_outgoing_receipts_for_resharding_v2(
                 receipts,

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -113,6 +113,7 @@ pub enum ProtocolFeature {
     /// Resharding V2. A new implementation for resharding and a new shard
     /// layout for the production networks.
     SimpleNightshadeV2,
+    /// Built on top of Resharding V2. Changes shard layout to V3 to split shard 2 into two parts.
     SimpleNightshadeV3,
     /// In case not all validator seats are occupied our algorithm provide incorrect minimal seat
     /// price - it reports as alpha * sum_stake instead of alpha * sum_stake / (1 - alpha), where

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -113,6 +113,7 @@ pub enum ProtocolFeature {
     /// Resharding V2. A new implementation for resharding and a new shard
     /// layout for the production networks.
     SimpleNightshadeV2,
+    SimpleNightshadeV3,
     /// In case not all validator seats are occupied our algorithm provide incorrect minimal seat
     /// price - it reports as alpha * sum_stake instead of alpha * sum_stake / (1 - alpha), where
     /// alpha is min stake ratio
@@ -184,6 +185,7 @@ impl ProtocolFeature {
             ProtocolFeature::RestrictTla
             | ProtocolFeature::TestnetFewerBlockProducers
             | ProtocolFeature::SimpleNightshadeV2 => 64,
+            ProtocolFeature::SimpleNightshadeV3 => 65,
 
             // StatelessNet features
             ProtocolFeature::StatelessValidationV0 => 80,

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -166,6 +166,11 @@ impl AllEpochConfig {
     }
 
     fn config_nightshade(config: &mut EpochConfig, protocol_version: ProtocolVersion) {
+        if checked_feature!("stable", SimpleNightshadeV3, protocol_version) {
+            Self::config_nightshade_impl(config, ShardLayout::get_simple_nightshade_layout_v3());
+            return;
+        }
+
         if checked_feature!("stable", SimpleNightshadeV2, protocol_version) {
             Self::config_nightshade_impl(config, ShardLayout::get_simple_nightshade_layout_v2());
             return;

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -663,7 +663,7 @@ mod tests {
             "boundary_accounts": [
               "aurora",
               "aurora-0",
-              "g-to-be-determined",
+              "game.hot.tg",
               "kkuuue2akv_1630967379.near",
               "tge-lockup.sweat"
             ],

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -586,6 +586,7 @@ mod tests {
         let v0 = ShardLayout::v0(1, 0);
         let v1 = ShardLayout::get_simple_nightshade_layout();
         let v2 = ShardLayout::get_simple_nightshade_layout_v2();
+        let v3 = ShardLayout::get_simple_nightshade_layout_v3();
 
         insta::assert_snapshot!(serde_json::to_string_pretty(&v0).unwrap(), @r###"
         {
@@ -653,6 +654,46 @@ mod tests {
               3
             ],
             "version": 2
+          }
+        }
+        "###);
+        insta::assert_snapshot!(serde_json::to_string_pretty(&v3).unwrap(), @r###"
+        {
+          "V1": {
+            "boundary_accounts": [
+              "aurora",
+              "aurora-0",
+              "g-to-be-determined",
+              "kkuuue2akv_1630967379.near",
+              "tge-lockup.sweat"
+            ],
+            "shards_split_map": [
+              [
+                0
+              ],
+              [
+                1,
+                2
+              ],
+              [
+                3
+              ],
+              [
+                4
+              ],
+              [
+                5
+              ]
+            ],
+            "to_parent_shard_map": [
+              0,
+              1,
+              1,
+              2,
+              3,
+              4
+            ],
+            "version": 3
           }
         }
         "###);

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -180,7 +180,7 @@ impl ShardLayout {
             .into_iter()
             .map(|s| s.parse().unwrap())
             .collect(),
-            Some(vec![vec![0], vec![1, 2], vec![3], vec![4], vec![5]]),
+            Some(vec![vec![0], vec![1], vec![2, 3], vec![4], vec![5]]),
             3,
         )
     }
@@ -672,10 +672,10 @@ mod tests {
                 0
               ],
               [
-                1,
-                2
+                1
               ],
               [
+                2,
                 3
               ],
               [
@@ -688,7 +688,7 @@ mod tests {
             "to_parent_shard_map": [
               0,
               1,
-              1,
+              2,
               2,
               3,
               4

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -173,7 +173,7 @@ impl ShardLayout {
             vec![
                 "aurora",
                 "aurora-0",
-                "g-to-be-determined", // TODO: Figure out the split point
+                "game.hot.tg",
                 "kkuuue2akv_1630967379.near",
                 "tge-lockup.sweat",
             ]

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -167,6 +167,25 @@ impl ShardLayout {
         )
     }
 
+    /// Returns the simple nightshade layout, version 3, that will be used in production.
+    /// This would split shard 2 into two parts
+    pub fn get_simple_nightshade_layout_v3() -> ShardLayout {
+        ShardLayout::v1(
+            vec![
+                "aurora",
+                "aurora-0",
+                "g-to-be-determined", // TODO: Figure out the split point
+                "kkuuue2akv_1630967379.near",
+                "tge-lockup.sweat",
+            ]
+            .into_iter()
+            .map(|s| s.parse().unwrap())
+            .collect(),
+            Some(vec![vec![0], vec![1], vec![2], vec![3, 4]]),
+            3,
+        )
+    }
+
     /// Given a parent shard id, return the shard uids for the shards in the current shard layout that
     /// are split from this parent shard. If this shard layout has no parent shard layout, return None
     pub fn get_children_shards_uids(&self, parent_shard_id: ShardId) -> Option<Vec<ShardUId>> {

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -168,7 +168,6 @@ impl ShardLayout {
     }
 
     /// Returns the simple nightshade layout, version 3, that will be used in production.
-    /// This would split shard 2 into two parts
     pub fn get_simple_nightshade_layout_v3() -> ShardLayout {
         ShardLayout::v1(
             vec![
@@ -181,7 +180,7 @@ impl ShardLayout {
             .into_iter()
             .map(|s| s.parse().unwrap())
             .collect(),
-            Some(vec![vec![0], vec![1], vec![2], vec![3, 4]]),
+            Some(vec![vec![0], vec![1, 2], vec![3], vec![4], vec![5]]),
             3,
         )
     }

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -235,10 +235,13 @@ impl Default for StoreConfig {
                     (ShardUId { version: 1, shard_id: 3 }, bytesize::ByteSize::gb(3)),
                     // In simple nightshade v2 the heavy contract "token.sweat" is in shard 4
                     (ShardUId { version: 2, shard_id: 4 }, bytesize::ByteSize::gb(3)),
+                    // In simple nightshade v3 the heavy contract "token.sweat" is in shard 5
+                    (ShardUId { version: 3, shard_id: 5 }, bytesize::ByteSize::gb(3)),
                     // Shard 1 is dedicated to aurora and it had very few cache
                     // misses even with cache size of only 50MB
                     (ShardUId { version: 1, shard_id: 1 }, bytesize::ByteSize::mb(50)),
                     (ShardUId { version: 2, shard_id: 1 }, bytesize::ByteSize::mb(50)),
+                    (ShardUId { version: 3, shard_id: 1 }, bytesize::ByteSize::mb(50)),
                 ]),
                 shard_cache_deletions_queue_capacity: DEFAULT_SHARD_CACHE_DELETIONS_QUEUE_CAPACITY,
             },


### PR DESCRIPTION
This PR is to be cherry-picked into release 1.38.0 for splitting shard 2 into two parts.

Hot and kai-ching both fall on shard 2 which has been causing a lot of congestion.

Zulip thread: https://near.zulipchat.com/#narrow/stream/308695-nearone.2Fprivate/topic/constant.20congestion.20on.20shard.202/near/425367222