### PR TITLE
Add Clone derive for primitive structs

### DIFF
--- a/chain/indexer-primitives/src/lib.rs
+++ b/chain/indexer-primitives/src/lib.rs
@@ -2,13 +2,13 @@ pub use near_primitives::hash::CryptoHash;
 pub use near_primitives::{self, types, views};
 
 /// Resulting struct represents block with chunks
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct StreamerMessage {
     pub block: views::BlockView,
     pub shards: Vec<IndexerShard>,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct IndexerChunkView {
     pub author: types::AccountId,
     pub header: views::ChunkHeaderView,
@@ -34,7 +34,7 @@ pub struct IndexerExecutionOutcomeWithReceipt {
     pub receipt: views::ReceiptView,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct IndexerShard {
     pub shard_id: types::ShardId,
     pub chunk: Option<IndexerChunkView>,

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1123,7 +1123,7 @@ impl From<ChunkHeaderView> for ShardChunkHeader {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 pub struct BlockView {
     pub author: AccountId,
     pub header: BlockHeaderView,
@@ -2249,7 +2249,7 @@ impl From<StateChangeKind> for StateChangeKindView {
 pub type StateChangesKindsView = Vec<StateChangeKindView>;
 
 /// See crate::types::StateChangeCause for details.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum StateChangeCauseView {
     NotWritableToDisk,
@@ -2294,7 +2294,7 @@ impl From<StateChangeCause> for StateChangeCauseView {
 }
 
 #[serde_as]
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type", content = "change")]
 pub enum StateChangeValueView {
     AccountUpdate {
@@ -2368,7 +2368,7 @@ impl From<StateChangeValue> for StateChangeValueView {
     }
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct StateChangeWithCauseView {
     pub cause: StateChangeCauseView,
     #[serde(flatten)]


### PR DESCRIPTION
This pull request adds the Clone derive for specified primitive structs, enabling easy creation of deep copies. It improves usability, consistency, and readability while adhering to Rust conventions.

**Why This Matters:**

- **Enhanced Usability:** With the `Clone` trait implemented, users can easily create copies of these structs without manually implementing the clone functionality, which improves usability and reduces boilerplate code.

- **Consistency and Readability:** By ensuring consistency in our codebase and following Rust conventions, we enhance code readability and maintainability.

- **Performance:** While cloning can incur performance overhead, it's often necessary in certain contexts, and having it readily available can streamline development processes.
