### PR TITLE
[fix] Fix Linux StatelessNet Github CI

### DIFF
--- a/core/parameters/Cargo.toml
+++ b/core/parameters/Cargo.toml
@@ -39,5 +39,7 @@ nightly = [
 nightly_protocol = [
   "near-primitives-core/nightly_protocol",
 ]
-statelessnet_protocol = []
+statelessnet_protocol = [
+  "near-primitives-core/statelessnet_protocol",
+]
 calimero_zero_storage = []

--- a/core/parameters/Cargo.toml
+++ b/core/parameters/Cargo.toml
@@ -39,4 +39,5 @@ nightly = [
 nightly_protocol = [
   "near-primitives-core/nightly_protocol",
 ]
+statelessnet_protocol = []
 calimero_zero_storage = []

--- a/core/parameters/src/view.rs
+++ b/core/parameters/src/view.rs
@@ -611,12 +611,12 @@ impl From<ExtCostsConfigView> for crate::ExtCostsConfig {
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "nightly"))]
+#[cfg(not(feature = "statelessnet_protocol"))]
 mod tests {
     /// The JSON representation used in RPC responses must not remove or rename
     /// fields, only adding fields is allowed or we risk breaking clients.
     #[test]
-    #[cfg_attr(feature = "nightly", ignore)]
-    #[cfg_attr(feature = "statelessnet_protocol", ignore)]
     fn test_runtime_config_view() {
         use crate::view::RuntimeConfigView;
         use crate::RuntimeConfig;


### PR DESCRIPTION
Runtime config check related tests are not supposed to run on nightly and statelessnet.

Originally broken in https://github.com/near/nearcore/pull/10703