### PR TITLE
runtime: temporarily workaround the LimitedMemoryPool limiting the concurrency of the contract runtime too much

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4491,7 +4491,6 @@ version = "0.0.0"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
- "crossbeam-queue",
  "enumset",
  "finite-wasm",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,6 @@ cpu-time = "1.0"
 criterion = { version = "0.5.1", default_features = false, features = ["html_reports", "cargo_bench_support"] }
 crossbeam = "0.8"
 crossbeam-channel = "0.5.8"
-crossbeam-queue = "0.3.8"
 csv = "1.2.1"
 curve25519-dalek = { version = "4.1.1", default-features = false, features = ["alloc", "precomputed-tables", "rand_core"] }
 derive-enum-from-into = "0.1.1"

--- a/runtime/near-vm-runner/src/near_vm_runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner.rs
@@ -719,7 +719,12 @@ impl crate::runner::VM for NearVM {
     }
 }
 
-#[test]
-fn test_memory_like() {
-    crate::logic::test_utils::test_memory_like(|| Box::new(NearVmMemory::new(1, 1).unwrap()));
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_memory_like() {
+        crate::logic::test_utils::test_memory_like(|| {
+            Box::new(super::NearVmMemory::new(1, 1).unwrap())
+        });
+    }
 }

--- a/runtime/near-vm-runner/src/near_vm_runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner.rs
@@ -258,7 +258,7 @@ impl NearVM {
                 // that particular function call will be slower. Not to mention there isn't a
                 // strong guarantee on the upper bound of the memory that the contract runtime may
                 // require.
-                LimitedMemoryPool::new(8, 64 * 1024 * 1024).unwrap_or_else(|e| {
+                LimitedMemoryPool::new(256, 1 * 1024 * 1024).unwrap_or_else(|e| {
                     panic!("could not pre-allocate resources for the runtime: {e}");
                 })
             })

--- a/runtime/near-vm/engine/Cargo.toml
+++ b/runtime/near-vm/engine/Cargo.toml
@@ -30,7 +30,6 @@ target-lexicon.workspace = true
 thiserror.workspace = true
 cfg-if.workspace = true
 tracing.workspace = true
-crossbeam-queue.workspace = true
 rustix = { workspace = true, features = ["param", "mm"] }
 
 [badges]


### PR DESCRIPTION
See individual commits and their descriptions for an easier review experience.

This PR is intended to be easily backportable with a minimal risk, with perhaps only the 2nd commit being superfluous in that context. There are definitely things that we can do to make the reliability and sensibility of this area much better, but they would result in a much more invasive change. My belief is that we should land both this workaround *and* fix #10732 as a follow-up.

cc #10732
cc @posvyatokum we will want this backported to 1.37.1, let me know if you'd like me to prepare a backport and/or where you want it to end up at.