### PR TITLE
fix: record chunk endorsement metrics only when the block is actually produced

### DIFF
--- a/chain/client/src/chunk_inclusion_tracker.rs
+++ b/chain/client/src/chunk_inclusion_tracker.rs
@@ -2,6 +2,7 @@ use itertools::Itertools;
 use lru::LruCache;
 use near_async::time::Utc;
 use near_chain_primitives::Error;
+use near_o11y::log_assert_fail;
 use near_primitives::block_body::ChunkEndorsementSignatures;
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
@@ -9,18 +10,28 @@ use near_primitives::types::{AccountId, EpochId, ShardId};
 use std::collections::HashMap;
 
 use crate::metrics;
-use crate::stateless_validation::chunk_endorsement_tracker::ChunkEndorsementTracker;
+use crate::stateless_validation::chunk_endorsement_tracker::{
+    ChunkEndorsementTracker, ChunkEndorsementsState,
+};
 
 const CHUNK_HEADERS_FOR_INCLUSION_CACHE_SIZE: usize = 2048;
 const NUM_EPOCH_CHUNK_PRODUCERS_TO_KEEP_IN_BLOCKLIST: usize = 1000;
 
 // chunk_header, received_time and chunk_producer are populated when we call mark_chunk_header_ready_for_inclusion
-// signatures is populated later during call to prepare_chunk_headers_ready_for_inclusion
+// endorsements is populated later during call to prepare_chunk_headers_ready_for_inclusion
 struct ChunkInfo {
     pub chunk_header: ShardChunkHeader,
     pub received_time: Utc,
     pub chunk_producer: AccountId,
-    pub signatures: Option<ChunkEndorsementSignatures>,
+    pub endorsements: Option<ChunkEndorsementsState>,
+}
+
+impl ChunkInfo {
+    fn has_chunk_endorsements(&self) -> bool {
+        self.endorsements
+            .as_ref()
+            .is_some_and(|state| matches!(state, ChunkEndorsementsState::Endorsed(_, _)))
+    }
 }
 
 pub struct ChunkInclusionTracker {
@@ -74,7 +85,7 @@ impl ChunkInclusionTracker {
             chunk_header,
             received_time: Utc::now_utc(),
             chunk_producer,
-            signatures: None,
+            endorsements: None,
         };
         self.chunk_hash_to_chunk_info.insert(chunk_hash, chunk_info);
     }
@@ -104,8 +115,8 @@ impl ChunkInclusionTracker {
 
         for chunk_hash in entry.values() {
             let chunk_info = self.chunk_hash_to_chunk_info.get_mut(chunk_hash).unwrap();
-            chunk_info.signatures =
-                endorsement_tracker.get_chunk_endorsement_signatures(&chunk_info.chunk_header)?;
+            chunk_info.endorsements =
+                Some(endorsement_tracker.compute_chunk_endorsements(&chunk_info.chunk_header)?);
         }
         Ok(())
     }
@@ -125,18 +136,6 @@ impl ChunkInclusionTracker {
         banned
     }
 
-    fn has_chunk_endorsements(&self, chunk_info: &ChunkInfo) -> bool {
-        let has_chunk_endorsements = chunk_info.signatures.is_some();
-        if !has_chunk_endorsements {
-            tracing::warn!(
-                target: "client",
-                chunk_hash = ?chunk_info.chunk_header.chunk_hash(),
-                chunk_producer = ?chunk_info.chunk_producer,
-                "Not including chunk because of insufficient chunk endorsements");
-        }
-        has_chunk_endorsements
-    }
-
     /// Function to return the chunks that are ready to be included in a block.
     /// We filter out the chunks that are produced by banned chunk producers or have insufficient
     /// chunk validator endorsements.
@@ -154,7 +153,15 @@ impl ChunkInclusionTracker {
         for (shard_id, chunk_hash) in entry {
             let chunk_info = self.chunk_hash_to_chunk_info.get(chunk_hash).unwrap();
             let banned = self.is_banned(epoch_id, &chunk_info);
-            let has_chunk_endorsements = self.has_chunk_endorsements(&chunk_info);
+            let has_chunk_endorsements = chunk_info.has_chunk_endorsements();
+            if !has_chunk_endorsements {
+                tracing::debug!(
+                    target: "client",
+                    chunk_hash = ?chunk_info.chunk_header.chunk_hash(),
+                    chunk_producer = ?chunk_info.chunk_producer,
+                    "Not including chunk because of insufficient chunk endorsements"
+                );
+            }
             if !banned && has_chunk_endorsements {
                 // only add to chunk_headers_ready_for_inclusion if chunk is not from a banned chunk producer
                 // and chunk has sufficient chunk endorsements.
@@ -194,7 +201,14 @@ impl ChunkInclusionTracker {
     ) -> Result<(ShardChunkHeader, ChunkEndorsementSignatures), Error> {
         let chunk_info = self.get_chunk_info(chunk_hash)?;
         let chunk_header = chunk_info.chunk_header.clone();
-        let signatures = chunk_info.signatures.clone().unwrap_or_default();
+        let signatures = chunk_info
+            .endorsements
+            .as_ref()
+            .and_then(|state| match state {
+                ChunkEndorsementsState::Endorsed(_, signatures) => Some(signatures.clone()),
+                ChunkEndorsementsState::NotEnoughStake(_) => None,
+            })
+            .unwrap_or_default();
         Ok((chunk_header, signatures))
     }
 
@@ -204,5 +218,40 @@ impl ChunkInclusionTracker {
     ) -> Result<(AccountId, Utc), Error> {
         let chunk_info = self.get_chunk_info(chunk_hash)?;
         Ok((chunk_info.chunk_producer.clone(), chunk_info.received_time))
+    }
+
+    pub fn record_endorsement_metrics(&self, prev_block_hash: &CryptoHash) {
+        let Some(entry) = self.prev_block_to_chunk_hash_ready.peek(prev_block_hash) else {
+            return;
+        };
+
+        for (shard_id, chunk_hash) in entry {
+            let Some(chunk_info) = self.chunk_hash_to_chunk_info.get(chunk_hash) else {
+                log_assert_fail!("Chunk info is missing for shard {shard_id} chunk {chunk_hash:?}");
+                continue;
+            };
+            let Some(ref endorsements_state) = chunk_info.endorsements else {
+                log_assert_fail!(
+                    "Endorsements state is missing for shard {shard_id} chunk {chunk_hash:?}"
+                );
+                continue;
+            };
+            let stats = endorsements_state.stats();
+            let shard_label = shard_id.to_string();
+            let label_values = &[shard_label.as_ref()];
+            metrics::BLOCK_PRODUCER_ENDORSED_STAKE_RATIO.with_label_values(label_values).observe(
+                if stats.total_stake > 0 {
+                    stats.endorsed_stake as f64 / stats.total_stake as f64
+                } else {
+                    0.0
+                },
+            );
+            metrics::BLOCK_PRODUCER_MISSING_ENDORSEMENT_COUNT
+                .with_label_values(label_values)
+                .observe(
+                    (stats.total_validators_count.saturating_sub(stats.endorsed_validators_count))
+                        as f64,
+                );
+        }
     }
 }

--- a/chain/client/src/client_actions.rs
+++ b/chain/client/src/client_actions.rs
@@ -972,6 +972,9 @@ impl ClientActions {
                     have_all_chunks,
                     log_block_production_info,
                 ) {
+                    self.client
+                        .chunk_inclusion_tracker
+                        .record_endorsement_metrics(&head.last_block_hash);
                     if let Err(err) = self.produce_block(height) {
                         // If there is an error, report it and let it retry on the next loop step.
                         error!(target: "client", height, "Block production failed: {}", err);

--- a/chain/client/src/stateless_validation/chunk_endorsement_tracker.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement_tracker.rs
@@ -193,7 +193,7 @@ impl ChunkEndorsementTracker {
         let Some(chunk_endorsements) = self.chunk_endorsements.get(&chunk_header.chunk_hash())
         else {
             // Early return if no chunk_endorsements found in our cache.
-            return Ok(ChunkEndorsementsState::NotEnoughStake(Default::default()));
+            return Ok(ChunkEndorsementsState::NotEnoughStake(None));
         };
 
         let endorsement_stats = chunk_validator_assignments

--- a/chain/client/src/stateless_validation/chunk_endorsement_tracker.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement_tracker.rs
@@ -8,14 +8,28 @@ use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::block_body::ChunkEndorsementSignatures;
 use near_primitives::checked_feature;
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
-use near_primitives::stateless_validation::ChunkEndorsement;
-use near_primitives::types::{AccountId, ShardId};
+use near_primitives::stateless_validation::{ChunkEndorsement, EndorsementStats};
+use near_primitives::types::AccountId;
 
-use crate::{metrics, Client};
+use crate::Client;
 
 // This is the number of unique chunks for which we would track the chunk endorsements.
 // Ideally, we should not be processing more than num_shards chunks at a time.
 const NUM_CHUNKS_IN_CHUNK_ENDORSEMENTS_CACHE: usize = 100;
+
+pub enum ChunkEndorsementsState {
+    Endorsed(EndorsementStats, ChunkEndorsementSignatures),
+    NotEnoughStake(EndorsementStats),
+}
+
+impl ChunkEndorsementsState {
+    pub fn stats(&self) -> &EndorsementStats {
+        match self {
+            Self::Endorsed(stats, _) => stats,
+            Self::NotEnoughStake(stats) => stats,
+        }
+    }
+}
 
 /// Module to track chunk endorsements received from chunk validators.
 pub struct ChunkEndorsementTracker {
@@ -152,16 +166,16 @@ impl ChunkEndorsementTracker {
     /// Signatures have the same order as ordered_chunk_validators, thus ready to be included in a block as is.
     /// Returns None if chunk doesn't have enough stake.
     /// For older protocol version, we return an empty array of chunk endorsements.
-    pub fn get_chunk_endorsement_signatures(
+    pub fn compute_chunk_endorsements(
         &self,
         chunk_header: &ShardChunkHeader,
-    ) -> Result<Option<ChunkEndorsementSignatures>, Error> {
+    ) -> Result<ChunkEndorsementsState, Error> {
         let epoch_id =
             self.epoch_manager.get_epoch_id_from_prev_block(chunk_header.prev_block_hash())?;
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
         if !checked_feature!("stable", StatelessValidationV0, protocol_version) {
             // Return an empty array of chunk endorsements for older protocol versions.
-            return Ok(Some(vec![]));
+            return Ok(ChunkEndorsementsState::Endorsed(Default::default(), vec![]));
         }
 
         let chunk_validator_assignments = self.epoch_manager.get_chunk_validator_assignments(
@@ -177,27 +191,15 @@ impl ChunkEndorsementTracker {
         let Some(chunk_endorsements) = self.chunk_endorsements.get(&chunk_header.chunk_hash())
         else {
             // Early return if no chunk_enforsements found in our cache.
-            record_endorsement_metrics(
-                chunk_header.shard_id(),
-                0.0,
-                chunk_validator_assignments.assignments().len(),
-            );
-            return Ok(None);
+            return Ok(ChunkEndorsementsState::NotEnoughStake(Default::default()));
         };
 
         let endorsement_stats = chunk_validator_assignments
             .compute_endorsement_stats(&chunk_endorsements.keys().collect());
-        record_endorsement_metrics(
-            chunk_header.shard_id(),
-            endorsement_stats.endorsed_stake as f64 / endorsement_stats.total_stake as f64,
-            endorsement_stats
-                .total_validators_count
-                .saturating_sub(endorsement_stats.endorsed_validators_count),
-        );
 
         // Check whether the current set of chunk_validators have enough stake to include chunk in block.
         if !endorsement_stats.has_enough_stake() {
-            return Ok(None);
+            return Ok(ChunkEndorsementsState::NotEnoughStake(endorsement_stats));
         }
 
         // We've already verified the chunk_endorsements are valid, collect signatures.
@@ -212,21 +214,6 @@ impl ChunkEndorsementTracker {
             })
             .collect();
 
-        Ok(Some(signatures))
+        Ok(ChunkEndorsementsState::Endorsed(endorsement_stats, signatures))
     }
-}
-
-fn record_endorsement_metrics(
-    shard_id: ShardId,
-    endorsed_stake_ratio: f64,
-    missing_endorsement_count: usize,
-) {
-    let shard_label = shard_id.to_string();
-    let label_values = &[shard_label.as_ref()];
-    metrics::BLOCK_PRODUCER_ENDORSED_STAKE_RATIO
-        .with_label_values(label_values)
-        .observe(endorsed_stake_ratio);
-    metrics::BLOCK_PRODUCER_MISSING_ENDORSEMENT_COUNT
-        .with_label_values(label_values)
-        .observe(missing_endorsement_count as f64);
 }

--- a/core/primitives/src/stateless_validation.rs
+++ b/core/primitives/src/stateless_validation.rs
@@ -238,7 +238,7 @@ pub struct StoredChunkStateTransitionData {
     pub receipts_hash: CryptoHash,
 }
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct EndorsementStats {
     pub total_stake: Balance,
     pub endorsed_stake: Balance,

--- a/core/primitives/src/stateless_validation.rs
+++ b/core/primitives/src/stateless_validation.rs
@@ -238,7 +238,7 @@ pub struct StoredChunkStateTransitionData {
     pub receipts_hash: CryptoHash,
 }
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct EndorsementStats {
     pub total_stake: Balance,
     pub endorsed_stake: Balance,


### PR DESCRIPTION
@Longarithm mentioned that chunk endorsement metrics (added in #10533) are recorded every time we check if the chunk is ready for inclusion. The intent was to only emit those when the block is actually produced which is implemented in this PR.

I've also noticed that we emit a warning log in a similar fashion, that is also fixed in this PR.