### PR TITLE
congestion: more context info for strategies

### DIFF
--- a/tools/congestion-model/src/model/chunk_execution.rs
+++ b/tools/congestion-model/src/model/chunk_execution.rs
@@ -111,4 +111,27 @@ impl<'model> ChunkExecutionContext<'model> {
     pub(crate) fn finish(self) -> (Vec<Receipt>, BlockInfo) {
         (self.outgoing_receipts, self.block_info_output)
     }
+
+    /// A sequence of increasing numbers.
+    pub fn block_height(&self) -> Round {
+        self.round
+    }
+
+    /// Gas cost to convert the transaction to a receipt.
+    pub fn tx_conversion_gas(&self, id: TransactionId) -> GGas {
+        self.transactions[id].tx_conversion_cost
+    }
+
+    /// Gas attached to the transaction after conversion.
+    ///
+    /// Like in real nearcore, this does not include the conversion cost. Unlike
+    /// real nearcore, we are not splitting between action execution gas and
+    /// attached gas.
+    pub fn tx_attached_gas(&self, id: TransactionId) -> GGas {
+        self.transactions[id].initial_receipt_gas()
+    }
+
+    pub fn tx_receiver(&self, id: TransactionId) -> ShardId {
+        self.transactions[id].receiver()
+    }
 }

--- a/tools/congestion-model/src/model/chunk_execution.rs
+++ b/tools/congestion-model/src/model/chunk_execution.rs
@@ -132,6 +132,6 @@ impl<'model> ChunkExecutionContext<'model> {
     }
 
     pub fn tx_receiver(&self, id: TransactionId) -> ShardId {
-        self.transactions[id].receiver()
+        self.transactions[id].initial_receipt_receiver()
     }
 }

--- a/tools/congestion-model/src/model/transaction.rs
+++ b/tools/congestion-model/src/model/transaction.rs
@@ -12,7 +12,7 @@ pub(crate) struct Transaction {
     /// Where the transaction is converted to the first receipt.
     pub(crate) sender_shard: ShardId,
     /// Where the transaction's first receipt is sent to.
-    pub(crate) receiver_shard: ShardId,
+    pub(crate) initial_receipt_receiver: ShardId,
 
     /// The receipt created when converting the transaction to a receipt.
     pub(crate) initial_receipt: ReceiptId,
@@ -113,7 +113,7 @@ impl Transaction {
     }
 
     pub(crate) fn receiver(&self) -> ShardId {
-        self.receiver_shard
+        self.initial_receipt_receiver
     }
 
     pub(crate) fn initial_receipt_gas(&self) -> GGas {

--- a/tools/congestion-model/src/model/transaction.rs
+++ b/tools/congestion-model/src/model/transaction.rs
@@ -112,7 +112,7 @@ impl Transaction {
         Some(receipt)
     }
 
-    pub(crate) fn receiver(&self) -> ShardId {
+    pub(crate) fn initial_receipt_receiver(&self) -> ShardId {
         self.initial_receipt_receiver
     }
 

--- a/tools/congestion-model/src/model/transaction.rs
+++ b/tools/congestion-model/src/model/transaction.rs
@@ -11,11 +11,15 @@ pub(crate) struct Transaction {
 
     /// Where the transaction is converted to the first receipt.
     pub(crate) sender_shard: ShardId,
+    /// Where the transaction's first receipt is sent to.
+    pub(crate) receiver_shard: ShardId,
 
     /// The receipt created when converting the transaction to a receipt.
     pub(crate) initial_receipt: ReceiptId,
     /// Gas burnt for converting the transaction to the first receipt.
     pub(crate) tx_conversion_cost: GGas,
+    /// Gas attached to the first receipt.
+    pub(crate) initial_receipt_gas: GGas,
 
     /// Definition of directed edges of the DAG.
     pub(crate) outgoing: HashMap<ReceiptId, Vec<ReceiptId>>,
@@ -106,6 +110,14 @@ impl Transaction {
         receipt.created_at = Some(round);
         self.pending_receipts.insert(receipt.id);
         Some(receipt)
+    }
+
+    pub(crate) fn receiver(&self) -> ShardId {
+        self.receiver_shard
+    }
+
+    pub(crate) fn initial_receipt_gas(&self) -> GGas {
+        self.initial_receipt_gas
     }
 }
 

--- a/tools/congestion-model/src/workload/transaction_builder.rs
+++ b/tools/congestion-model/src/workload/transaction_builder.rs
@@ -170,7 +170,7 @@ impl TransactionBuilder {
         Transaction {
             id: self.id,
             sender_shard: self.sender_shard,
-            receiver_shard: receipts[&initial_receipt].receiver,
+            initial_receipt_receiver: receipts[&initial_receipt].receiver,
             initial_receipt_gas: receipts[&initial_receipt].attached_gas,
             initial_receipt,
             tx_conversion_cost: self.tx_conversion_cost,

--- a/tools/congestion-model/src/workload/transaction_builder.rs
+++ b/tools/congestion-model/src/workload/transaction_builder.rs
@@ -170,6 +170,8 @@ impl TransactionBuilder {
         Transaction {
             id: self.id,
             sender_shard: self.sender_shard,
+            receiver_shard: receipts[&initial_receipt].receiver,
+            initial_receipt_gas: receipts[&initial_receipt].attached_gas,
             initial_receipt,
             tx_conversion_cost: self.tx_conversion_cost,
             outgoing,


### PR DESCRIPTION
Adding several reader methods on the chunk execution context to allow strategies to depend on transaction details and block height.