### PR TITLE
feat: add `shadow_chunk_validation` feature to neard

### DIFF
--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -123,6 +123,9 @@ statelessnet_protocol = [
   "nearcore/statelessnet_protocol",
   "near-primitives/statelessnet_protocol",
 ]
+shadow_chunk_validation = [
+  "near-client/shadow_chunk_validation",
+]
 
 calimero_zero_storage = [
   "near-primitives/calimero_zero_storage",


### PR DESCRIPTION
This allows building only `neard` binary for testing with `cargo build -p neard --features shadow_chunk_validation`.