### PR TITLE
congestion: print queue size in bytes and gas

### DIFF
--- a/tools/congestion-model/src/evaluation/mod.rs
+++ b/tools/congestion-model/src/evaluation/mod.rs
@@ -91,7 +91,9 @@ impl Model {
         for shard_id in self.shard_ids.clone() {
             for queue in self.queues.shard_queues(shard_id) {
                 let field_name = format!("shard_{}_queue_{}", shard_id, queue.name());
-                stats_writer.write_field(field_name).unwrap();
+                stats_writer.write_field(format!("{field_name}_len")).unwrap();
+                stats_writer.write_field(format!("{field_name}_bytes")).unwrap();
+                stats_writer.write_field(format!("{field_name}_gas")).unwrap();
             }
         }
         stats_writer.write_record(None::<&[u8]>).unwrap();
@@ -120,6 +122,8 @@ impl Model {
         for shard_id in self.shard_ids.clone() {
             for queue in self.queues.shard_queues(shard_id) {
                 stats_writer.write_field(format!("{}", queue.len())).unwrap();
+                stats_writer.write_field(format!("{}", queue.size())).unwrap();
+                stats_writer.write_field(format!("{}", queue.attached_gas())).unwrap();
             }
         }
 

--- a/tools/congestion-model/src/model/queue.rs
+++ b/tools/congestion-model/src/model/queue.rs
@@ -17,6 +17,10 @@ impl Queue {
         self.messages.iter().map(|receipt| receipt.size).sum()
     }
 
+    pub fn attached_gas(&self) -> u64 {
+        self.messages.iter().map(|receipt| receipt.attached_gas).sum()
+    }
+
     pub fn shard(&self) -> ShardId {
         self.shard
     }


### PR DESCRIPTION
So far, we only printed the queue length, as in "number of elements". But we are much more interested in the size in bytes, as this is the real constraint. Also add the same for attached gas, as this can be interesting, too.

The way this is computed, it's rather inefficient. We might want to compute the sums more efficiently.
But running

`time cargo run --release -- --write-stats`

still finishes in
`real    0m18.183s`

on my machine, so I guess it's still tolerable, for now...