### PR TITLE
backport: crates 0.20.1 had two important fixes that has to be in 1.37.x release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6621,9 +6621,9 @@ checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"

--- a/core/primitives/src/action/mod.rs
+++ b/core/primitives/src/action/mod.rs
@@ -178,15 +178,13 @@ pub enum Action {
     DeleteAccount(DeleteAccountAction),
     Delegate(Box<delegate::SignedDelegateAction>),
 }
-// Note: If this number ever goes down, please adjust the equality accordingly. Otherwise,
-// we would get used to better performance and would be subject to a performance loss should
-// we come back up to 32 bytes later on.
-// If compiling with nightly, this check may fail due to new optimizations introduced by
-// rustc. So, cfg-them out, as our production system only runs with stable.
-#[cfg(not(fuzz))]
+
 const _: () = assert!(
-    cfg!(not(target_pointer_width = "64")) || std::mem::size_of::<Action>() == 32,
-    "Action is 32 bytes for performance reasons, see #9451"
+    // 1 word for tag plus the largest variant `DeployContractAction` which is a 3-word `Vec`.
+    // The `<=` check covers platforms that have pointers smaller than 8 bytes as well as random
+    // freak nightlies that somehow find a way to pack everything into one less word.
+    std::mem::size_of::<Action>() <= 32,
+    "Action <= 32 bytes for performance reasons, see #9451"
 );
 
 impl Action {


### PR DESCRIPTION
* #10476
* #10481