### PR TITLE
congestion: multi-hop transactions in all-for-one workload

### DIFF
--- a/tools/congestion-model/src/main.rs
+++ b/tools/congestion-model/src/main.rs
@@ -120,7 +120,8 @@ fn normalize_cmdline_arg(value: &str) -> String {
 fn workload(workload_name: &str) -> Box<dyn Producer> {
     match workload_name {
         "Balanced" => Box::<BalancedProducer>::default(),
-        "All To One" => Box::<AllForOneProducer>::default(),
+        "All To One" => Box::new(AllForOneProducer::one_hop_only()),
+        "Indirect All To One" => Box::<AllForOneProducer>::default(),
         "Linear Imbalance" => Box::<LinearImbalanceProducer>::default(),
         _ => panic!("unknown workload: {}", workload_name),
     }
@@ -145,8 +146,12 @@ fn strategy(strategy_name: &str, num_shards: usize) -> Vec<Box<dyn CongestionStr
 }
 
 fn parse_workload_names(workload_name: &str) -> Vec<String> {
-    let available: Vec<String> =
-        vec!["Balanced".to_string(), "All To One".to_string(), "Linear Imbalance".to_string()];
+    let available: Vec<String> = vec![
+        "Balanced".to_string(),
+        "All To One".to_string(),
+        "Indirect All To One".to_string(),
+        "Linear Imbalance".to_string(),
+    ];
 
     if workload_name == "all" {
         return available;

--- a/tools/congestion-model/src/workload/all_for_one.rs
+++ b/tools/congestion-model/src/workload/all_for_one.rs
@@ -2,14 +2,36 @@ use crate::{GGas, ReceiptDefinition, ShardId, TransactionBuilder, TGAS};
 
 use super::{utils, Producer};
 
-/// Simple transaction producer that sends receipts from all shards to shard 0.
+/// Transaction producer that sends receipts from all shards to shard 0.
+///
+/// A third of the transactions contain a single receipt, going directly to
+/// shard 0. Those are easy to manage by congestion control strategies, as the
+/// receiver is known up front and therefore it can easily be dropped when that
+/// shard is congested.
+///
+/// Another third of transactions contains two receipts, with most of the gas
+/// spent on the second receipt. The first receipt executes locally, the second
+/// receipt is in shard 0 where the congestion should happen.
+///
+/// The last third of transactions has three receipts. The first two receipts
+/// execute at shard + 1 and shard + 2 (mod N). The third receipt again executes
+/// at shard 0.
+///
+/// Each of the three types of receipts can also be disabled individually. But
+/// by default, all three are produced.
+///
+/// All receipts have the same size, to keep the workload relatively simple.
 pub struct AllForOneProducer {
     // config options
     pub receipt_size: u64,
     pub attached_gas: GGas,
-    pub execution_gas: GGas,
+    pub light_execution_gas: GGas,
+    pub last_execution_gas: GGas,
     pub conversion_gas: GGas,
     pub messages_per_round: usize,
+    pub enable_one_hop: bool,
+    pub enable_two_hops: bool,
+    pub enable_three_hops: bool,
 
     // state
     pub round_robin_shards: Box<dyn Iterator<Item = ShardId>>,
@@ -29,11 +51,28 @@ impl Producer for AllForOneProducer {
         shards: &[ShardId],
         tx_factory: &mut dyn FnMut(ShardId) -> TransactionBuilder,
     ) -> Vec<TransactionBuilder> {
+        let mut hops_enabled = vec![];
+        if self.enable_one_hop {
+            hops_enabled.push(1);
+        }
+        if self.enable_two_hops {
+            hops_enabled.push(2);
+        }
+        if self.enable_three_hops {
+            hops_enabled.push(3);
+        }
+
         (0..self.messages_per_round)
-            .map(|_| {
+            .zip(hops_enabled.iter().cycle())
+            .map(|(_, hops)| {
                 let shard = self.round_robin_shards.next().unwrap();
                 let mut tx = tx_factory(shard);
-                self.produce_one_tx(shards, &mut tx);
+                match hops {
+                    1 => self.produce_one_hop_tx(shards, &mut tx),
+                    2 => self.produce_two_hops_tx(shards, &mut tx),
+                    3 => self.produce_three_hops_tx(shards, &mut tx),
+                    _ => unreachable!(),
+                }
                 tx
             })
             .collect()
@@ -41,17 +80,72 @@ impl Producer for AllForOneProducer {
 }
 
 impl AllForOneProducer {
-    fn produce_one_tx(&self, shards: &[ShardId], tx: &mut TransactionBuilder) {
-        let first = tx.add_first_receipt(self.receipt_to_shard_0(shards), self.conversion_gas);
+    /// Transaction with a single receipt, going directly to shard 0.
+    fn produce_one_hop_tx(&self, shards: &[ShardId], tx: &mut TransactionBuilder) {
+        let heavy_receipt = self.receipt_to_shard_0(shards, 1);
+        let first = tx.add_first_receipt(heavy_receipt, self.conversion_gas);
         tx.new_outgoing_receipt(first, utils::refund_receipt(tx.sender_shard()));
     }
 
-    fn receipt_to_shard_0(&self, shards: &[ShardId]) -> ReceiptDefinition {
+    /// Transaction with two receipts, a one executing locally with small
+    /// execution gas, followed by one going to shard 0 spending more gas.
+    fn produce_two_hops_tx(&self, shards: &[ShardId], tx: &mut TransactionBuilder) {
+        let light_receipt = self.light_receipt(tx.sender_shard(), 0);
+        let heavy_receipt = self.receipt_to_shard_0(shards, 1);
+        let first = tx.add_first_receipt(light_receipt, self.conversion_gas);
+        let second = tx.new_outgoing_receipt(first, heavy_receipt);
+
+        tx.new_outgoing_receipt(first, utils::refund_receipt(tx.sender_shard()));
+        tx.new_outgoing_receipt(second, utils::refund_receipt(tx.sender_shard()));
+    }
+
+    /// Transaction with a chain of three receipts, the last one spending the
+    /// most gas. The last receipt always has shard 0 as receiver.
+    fn produce_three_hops_tx(&self, shards: &[ShardId], tx: &mut TransactionBuilder) {
+        let my_index = shards
+            .iter()
+            .position(|&id| id == tx.sender_shard())
+            .expect("sender must be in shards");
+        let hop_1 = shards[(my_index + 1) % shards.len()];
+        let hop_2 = shards[(my_index + 2) % shards.len()];
+
+        let light_receipt_1 = self.light_receipt(hop_1, 0);
+        let light_receipt_2 = self.light_receipt(hop_2, 1);
+        let heavy_receipt = self.receipt_to_shard_0(shards, 2);
+
+        let first = tx.add_first_receipt(light_receipt_1, self.conversion_gas);
+        let second = tx.new_outgoing_receipt(first, light_receipt_2);
+        let third = tx.new_outgoing_receipt(second, heavy_receipt);
+
+        tx.new_outgoing_receipt(first, utils::refund_receipt(tx.sender_shard()));
+        tx.new_outgoing_receipt(second, utils::refund_receipt(tx.sender_shard()));
+        tx.new_outgoing_receipt(third, utils::refund_receipt(tx.sender_shard()));
+    }
+
+    fn receipt_to_shard_0(&self, shards: &[ShardId], prior_hops: u64) -> ReceiptDefinition {
         ReceiptDefinition {
             receiver: shards[0],
             size: self.receipt_size,
-            attached_gas: self.attached_gas,
-            execution_gas: self.attached_gas,
+            attached_gas: self.attached_gas - self.last_execution_gas * prior_hops,
+            execution_gas: self.last_execution_gas,
+        }
+    }
+
+    fn light_receipt(&self, shard: ShardId, prior_hops: u64) -> ReceiptDefinition {
+        ReceiptDefinition {
+            receiver: shard,
+            size: self.receipt_size,
+            attached_gas: self.attached_gas - self.last_execution_gas * prior_hops,
+            execution_gas: self.light_execution_gas,
+        }
+    }
+
+    pub fn one_hop_only() -> Self {
+        Self {
+            enable_one_hop: true,
+            enable_two_hops: false,
+            enable_three_hops: false,
+            ..Default::default()
         }
     }
 }
@@ -59,15 +153,20 @@ impl AllForOneProducer {
 impl Default for AllForOneProducer {
     fn default() -> Self {
         // for this simple scenario, as a default, use 1kb sized receipts with 300 Tgas attached that
-        // end up actually executing 5 TGas + 100 TGas.
+        // end up actually executing 5 TGas + 100 TGas (+ optionally 2x 10 Tgas).
         Self {
             receipt_size: 1024,
             attached_gas: 300 * TGAS,
-            execution_gas: 100 * TGAS,
+            light_execution_gas: 10 * TGAS,
+            last_execution_gas: 100 * TGAS,
             conversion_gas: 5 * TGAS,
-            messages_per_round: 20,
+            // ideally a number divisible by 3
+            messages_per_round: 42,
             // empty iterator overwritten in init
             round_robin_shards: Box::new(std::iter::empty()),
+            enable_one_hop: true,
+            enable_two_hops: true,
+            enable_three_hops: true,
         }
     }
 }


### PR DESCRIPTION
Rather than just sending single-receipt actions, we want transactions that touch multiple shards. Specifically, we want workloads that are not very predictable with regards to which shard will be burning most of the gas.

With  this commit, we have an "All To One" and an "Indirect All To One" strategy. The first is what we had before, depth 1 transactions only. The second is with transaction of up to depth 3.