### PR TITLE
fix: near_ prefix to flat storage metrics

### DIFF
--- a/core/store/src/metrics.rs
+++ b/core/store/src/metrics.rs
@@ -392,7 +392,7 @@ pub mod flat_state_metrics {
 
     pub static FLAT_STORAGE_CREATION_STATUS: Lazy<IntGaugeVec> = Lazy::new(|| {
         try_create_int_gauge_vec(
-            "flat_storage_creation_status",
+            "near_flat_storage_creation_status",
             "Integer representing status of flat storage creation",
             &["shard_uid"],
         )
@@ -400,7 +400,7 @@ pub mod flat_state_metrics {
     });
     pub static FLAT_STORAGE_CREATION_REMAINING_STATE_PARTS: Lazy<IntGaugeVec> = Lazy::new(|| {
         try_create_int_gauge_vec(
-            "flat_storage_creation_remaining_state_parts",
+            "near_flat_storage_creation_remaining_state_parts",
             "Number of remaining state parts to fetch to fill flat storage in bytes",
             &["shard_uid"],
         )
@@ -408,7 +408,7 @@ pub mod flat_state_metrics {
     });
     pub static FLAT_STORAGE_CREATION_FETCHED_STATE_PARTS: Lazy<IntCounterVec> = Lazy::new(|| {
         try_create_int_counter_vec(
-            "flat_storage_creation_fetched_state_parts",
+            "near_flat_storage_creation_fetched_state_parts",
             "Number of fetched state parts to fill flat storage in bytes",
             &["shard_uid"],
         )
@@ -416,7 +416,7 @@ pub mod flat_state_metrics {
     });
     pub static FLAT_STORAGE_CREATION_FETCHED_STATE_ITEMS: Lazy<IntCounterVec> = Lazy::new(|| {
         try_create_int_counter_vec(
-            "flat_storage_creation_fetched_state_items",
+            "near_flat_storage_creation_fetched_state_items",
             "Number of fetched items to fill flat storage",
             &["shard_uid"],
         )
@@ -424,7 +424,7 @@ pub mod flat_state_metrics {
     });
     pub static FLAT_STORAGE_CREATION_THREADS_USED: Lazy<IntGaugeVec> = Lazy::new(|| {
         try_create_int_gauge_vec(
-            "flat_storage_creation_threads_used",
+            "near_flat_storage_creation_threads_used",
             "Number of currently used threads to fetch state",
             &["shard_uid"],
         )
@@ -432,7 +432,7 @@ pub mod flat_state_metrics {
     });
     pub static FLAT_STORAGE_HEAD_HEIGHT: Lazy<IntGaugeVec> = Lazy::new(|| {
         try_create_int_gauge_vec(
-            "flat_storage_head_height",
+            "near_flat_storage_head_height",
             "Height of flat storage head",
             &["shard_uid"],
         )
@@ -440,7 +440,7 @@ pub mod flat_state_metrics {
     });
     pub static FLAT_STORAGE_CACHED_DELTAS: Lazy<IntGaugeVec> = Lazy::new(|| {
         try_create_int_gauge_vec(
-            "flat_storage_cached_deltas",
+            "near_flat_storage_cached_deltas",
             "Number of cached deltas in flat storage",
             &["shard_uid"],
         )
@@ -448,7 +448,7 @@ pub mod flat_state_metrics {
     });
     pub static FLAT_STORAGE_CACHED_CHANGES_NUM_ITEMS: Lazy<IntGaugeVec> = Lazy::new(|| {
         try_create_int_gauge_vec(
-            "flat_storage_cached_changes_num_items",
+            "near_flat_storage_cached_changes_num_items",
             "Number of items in all cached changes in flat storage",
             &["shard_uid"],
         )
@@ -456,7 +456,7 @@ pub mod flat_state_metrics {
     });
     pub static FLAT_STORAGE_CACHED_CHANGES_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
         try_create_int_gauge_vec(
-            "flat_storage_cached_changes_size",
+            "near_flat_storage_cached_changes_size",
             "Total size of cached changes in flat storage",
             &["shard_uid"],
         )
@@ -464,7 +464,7 @@ pub mod flat_state_metrics {
     });
     pub static FLAT_STORAGE_DISTANCE_TO_HEAD: Lazy<IntGaugeVec> = Lazy::new(|| {
         try_create_int_gauge_vec(
-            "flat_storage_distance_to_head",
+            "near_flat_storage_distance_to_head",
             "Height distance between processed block and flat storage head",
             &["shard_uid"],
         )
@@ -472,7 +472,7 @@ pub mod flat_state_metrics {
     });
     pub static FLAT_STORAGE_HOPS_TO_HEAD: Lazy<IntGaugeVec> = Lazy::new(|| {
         try_create_int_gauge_vec(
-            "flat_storage_hops_to_head",
+            "near_flat_storage_hops_to_head",
             "Number of blocks visited to flat storage head",
             &["shard_uid"],
         )


### PR DESCRIPTION
As these metrics were recently changed and continuity of data is broken, we can add "near_" prefix to prometheus metrics which was missing all the time. 

@wacban I wonder how painful is it to add this to 1.38 for convenience?