### PR TITLE
yield/resume: gas fee estimations

### DIFF
--- a/core/parameters/res/runtime_configs/139.yaml
+++ b/core/parameters/res/runtime_configs/139.yaml
@@ -1,6 +1,5 @@
 yield_resume: { old: false, new: true }
-# FIXME(yield_resume): These fees are placeholders.
-wasm_yield_create_base: { old: 300_000_000_000_000, new: 10_000_000_000_000 }
-wasm_yield_create_byte: { old: 300_000_000_000_000, new: 10_000_000 }
-wasm_yield_resume_base: { old: 300_000_000_000_000, new: 10_000_000_000_000 }
-wasm_yield_resume_byte: { old: 300_000_000_000_000, new: 100_000_000 }
+wasm_yield_create_base: { old: 300_000_000_000_000, new: 153_411_779_276 }
+wasm_yield_create_byte: { old: 300_000_000_000_000, new: 15_643_988 }
+wasm_yield_resume_base: { old: 300_000_000_000_000, new: 1_195_627_285_210 }
+wasm_yield_resume_byte: { old: 300_000_000_000_000, new: 17_212_011 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__139.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__139.json.snap
@@ -170,10 +170,10 @@ expression: config_view
       "alt_bn128_g1_sum_element": 5000000000,
       "alt_bn128_pairing_check_base": 9686000000000,
       "alt_bn128_pairing_check_element": 5102000000000,
-      "yield_create_base": 10000000000000,
-      "yield_create_byte": 10000000,
-      "yield_resume_base": 10000000000000,
-      "yield_resume_byte": 10000000000000
+      "yield_create_base": 153411779276,
+      "yield_create_byte": 15643988,
+      "yield_resume_base": 1195627285210,
+      "yield_resume_byte": 1195627285210
     },
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_139.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_139.json.snap
@@ -170,10 +170,10 @@ expression: config_view
       "alt_bn128_g1_sum_element": 5000000000,
       "alt_bn128_pairing_check_base": 9686000000000,
       "alt_bn128_pairing_check_element": 5102000000000,
-      "yield_create_base": 10000000000000,
-      "yield_create_byte": 10000000,
-      "yield_resume_base": 10000000000000,
-      "yield_resume_byte": 10000000000000
+      "yield_create_base": 153411779276,
+      "yield_create_byte": 15643988,
+      "yield_resume_base": 1195627285210,
+      "yield_resume_byte": 1195627285210
     },
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,

--- a/runtime/near-test-contracts/estimator-contract/src/lib.rs
+++ b/runtime/near-test-contracts/estimator-contract/src/lib.rs
@@ -110,7 +110,7 @@ extern "C" {
         data_id_ptr: u64,
         payload_len: u64,
         payload_ptr: u64,
-    ) -> u64;
+    ) -> u32;
     // #######################
     // # Promise API actions #
     // #######################
@@ -1051,6 +1051,38 @@ pub unsafe fn yield_create_byte_1000b_argument_length() {
             1,
             0,
         );
+    }
+}
+
+#[no_mangle]
+pub unsafe fn yield_resume_base_prepare() {
+    const METHOD_NAME: &str = "n";
+    for i in 0..255u8 {
+        promise_yield_create(METHOD_NAME.len() as u64, METHOD_NAME.as_ptr() as u64, 0, 0, 0, 1, 2);
+        storage_write(1, core::ptr::addr_of!(i) as u64, u64::MAX, 2, 3);
+    }
+}
+
+#[no_mangle]
+pub unsafe fn yield_resume_base() {
+    for i in 0..255u8 {
+        match storage_read(1, core::ptr::addr_of!(i) as u64, 0) {
+            0 => panic!("storage_read did not produce data_id"),
+            1 => assert_eq!(promise_yield_resume(u64::MAX, 0, 0, 0), 1),
+            _ => panic!("unexpected storage_read return"),
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe fn yield_resume_payload() {
+    const ARGUMENTS: [u8; 1000] = [b'a'; 1000];
+    for i in 0..255u8 {
+        match storage_read(1, core::ptr::addr_of!(i) as u64, 0) {
+            0 => panic!("storage_read did not produce data_id"),
+            1 => assert_eq!(promise_yield_resume(u64::MAX, 0, 1000, ARGUMENTS.as_ptr() as u64), 1),
+            _ => panic!("unexpected storage_read return"),
+        }
     }
 }
 

--- a/runtime/runtime-params-estimator/src/cost.rs
+++ b/runtime/runtime-params-estimator/src/cost.rs
@@ -702,7 +702,6 @@ pub enum Cost {
     ///
     /// Estimation: We run a very tight loop of 1000 calls to this host function. Then we subtract
     /// all other known costs from the estimated number.
-    ///
     YieldCreateBase,
     /// Estimates `yield_create_byte`, the cost charged per method and argument byte in calls to the
     /// `promise_yield_create` host function.
@@ -711,6 +710,19 @@ pub enum Cost {
     /// with additional method bytes, and another time with some significant number of bytes in
     /// arguments.
     YieldCreateByte,
+
+    /// Estimates `yield_resume_base`, which covers the base cost of the host function
+    /// `promise_yield_resume`.
+    ///
+    /// Estimation: Execution of this host function depends on a prior successful call to the
+    /// `promise_yield_create`. Furthermore, we want `promise_yield_resume` to be invoked in a
+    /// separate block, so we prepare the state and write the data IDs into the storage. Then
+    /// measure a contract that reads the 255 data IDs from the storage and resumes them.
+    YieldResumeBase,
+
+    /// Estimates `yield_resume_byte`, which covers the per-byte cost of the parameters of the
+    /// `promise_yield_resume` host function.
+    YieldResumeByte,
 
     __Count,
 }

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -46,6 +46,9 @@ pub(crate) struct CachedCosts {
     pub(crate) apply_block: Option<GasCost>,
     pub(crate) touching_trie_node_write: Option<GasCost>,
     pub(crate) ed25519_verify_base: Option<GasCost>,
+    pub(crate) function_call_base: Option<GasCost>,
+    #[cfg(feature = "nightly")]
+    pub(crate) yield_create_base: Option<GasCost>,
 }
 
 impl<'c> EstimatorContext<'c> {

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -254,10 +254,14 @@ static ALL_COSTS: &[(Cost, fn(&mut EstimatorContext) -> GasCost)] = &[
     (Cost::GasMeteringOp, gas_metering_op),
     (Cost::RocksDbInsertValueByte, rocks_db_insert_value_byte),
     (Cost::RocksDbReadValueByte, rocks_db_read_value_byte),
-    #[cfg(feature = "yield_create")]
+    #[cfg(feature = "nightly")]
     (Cost::YieldCreateBase, yield_create_base),
-    #[cfg(feature = "yield_create")]
+    #[cfg(feature = "nightly")]
     (Cost::YieldCreateByte, yield_create_byte),
+    #[cfg(feature = "nightly")]
+    (Cost::YieldResumeBase, yield_resume_base),
+    #[cfg(feature = "nightly")]
+    (Cost::YieldResumeByte, yield_resume_byte),
     (Cost::CpuBenchmarkSha256, cpu_benchmark_sha256),
     (Cost::OneCPUInstruction, one_cpu_instruction),
     (Cost::OneNanosecond, one_nanosecond),
@@ -726,6 +730,9 @@ fn pure_deploy_bytes(ctx: &mut EstimatorContext) -> GasCost {
 
 /// Base cost for a fn call action, without receipt creation or contract loading.
 fn action_function_call_base(ctx: &mut EstimatorContext) -> GasCost {
+    if let Some(cost) = &ctx.cached.function_call_base {
+        return cost.clone();
+    }
     let config_store = RuntimeConfigStore::new(None);
     let vm_config = config_store.get_config(PROTOCOL_VERSION).wasm_config.clone();
     let n_actions = 100;
@@ -734,7 +741,8 @@ fn action_function_call_base(ctx: &mut EstimatorContext) -> GasCost {
     let base_cost = fn_cost_in_contract(ctx, "main", &code, n_actions);
     // Executable loading is a separately charged step, so it must be subtracted on the action cost.
     let executable_loading_cost = contract_loading_base(ctx);
-    base_cost.saturating_sub(&executable_loading_cost, &NonNegativeTolerance::PER_MILLE)
+    let cost = base_cost.saturating_sub(&executable_loading_cost, &NonNegativeTolerance::PER_MILLE);
+    ctx.cached.function_call_base.insert(cost).clone()
 }
 
 fn action_function_call_per_byte(ctx: &mut EstimatorContext) -> GasCost {
@@ -1016,11 +1024,11 @@ fn ecrecover_base(ctx: &mut EstimatorContext) -> GasCost {
 }
 
 fn ed25519_verify_base(ctx: &mut EstimatorContext) -> GasCost {
-    if ctx.cached.ed25519_verify_base.is_none() {
-        let cost = fn_cost(ctx, "ed25519_verify_32b_500", ExtCosts::ed25519_verify_base, 500);
-        ctx.cached.ed25519_verify_base = Some(cost);
+    if let Some(cost) = &ctx.cached.ed25519_verify_base {
+        return cost.clone();
     }
-    ctx.cached.ed25519_verify_base.clone().unwrap()
+    let cost = fn_cost(ctx, "ed25519_verify_32b_500", ExtCosts::ed25519_verify_base, 500);
+    ctx.cached.ed25519_verify_base.insert(cost).clone()
 }
 
 fn ed25519_verify_byte(ctx: &mut EstimatorContext) -> GasCost {
@@ -1068,6 +1076,7 @@ fn storage_has_key_base(ctx: &mut EstimatorContext) -> GasCost {
         "storage_has_key_10b_key_10b_value_1k",
         ExtCosts::storage_has_key_base,
         1000,
+        0,
     )
 }
 fn storage_has_key_byte(ctx: &mut EstimatorContext) -> GasCost {
@@ -1077,24 +1086,23 @@ fn storage_has_key_byte(ctx: &mut EstimatorContext) -> GasCost {
         "storage_has_key_10kib_key_10b_value_1k",
         ExtCosts::storage_has_key_byte,
         10 * 1024 * 1000,
+        0,
     )
 }
 
 fn storage_read_base(ctx: &mut EstimatorContext) -> GasCost {
-    if let Some(cost) = ctx.cached.storage_read_base.clone() {
-        return cost;
+    if let Some(cost) = &ctx.cached.storage_read_base {
+        return cost.clone();
     }
-
     let cost = fn_cost_with_setup(
         ctx,
         "storage_write_10b_key_10b_value_1k",
         "storage_read_10b_key_10b_value_1k",
         ExtCosts::storage_read_base,
         1000,
+        0,
     );
-
-    ctx.cached.storage_read_base = Some(cost.clone());
-    cost
+    ctx.cached.storage_read_base.insert(cost).clone()
 }
 fn storage_read_key_byte(ctx: &mut EstimatorContext) -> GasCost {
     fn_cost_with_setup(
@@ -1103,6 +1111,7 @@ fn storage_read_key_byte(ctx: &mut EstimatorContext) -> GasCost {
         "storage_read_10kib_key_10b_value_1k",
         ExtCosts::storage_read_key_byte,
         10 * 1024 * 1000,
+        0,
     )
 }
 fn storage_read_value_byte(ctx: &mut EstimatorContext) -> GasCost {
@@ -1112,6 +1121,7 @@ fn storage_read_value_byte(ctx: &mut EstimatorContext) -> GasCost {
         "storage_read_10b_key_10kib_value_1k",
         ExtCosts::storage_read_value_byte,
         10 * 1024 * 1000,
+        0,
     )
 }
 
@@ -1141,6 +1151,7 @@ fn storage_write_evicted_byte(ctx: &mut EstimatorContext) -> GasCost {
         "storage_write_10b_key_10kib_value_1k",
         ExtCosts::storage_write_evicted_byte,
         10 * 1024 * 1000,
+        0,
     )
 }
 
@@ -1151,6 +1162,7 @@ fn storage_remove_base(ctx: &mut EstimatorContext) -> GasCost {
         "storage_remove_10b_key_10b_value_1k",
         ExtCosts::storage_remove_base,
         1000,
+        0,
     )
 }
 fn storage_remove_key_byte(ctx: &mut EstimatorContext) -> GasCost {
@@ -1160,6 +1172,7 @@ fn storage_remove_key_byte(ctx: &mut EstimatorContext) -> GasCost {
         "storage_remove_10kib_key_10b_value_1k",
         ExtCosts::storage_remove_key_byte,
         10 * 1024 * 1000,
+        0,
     )
 }
 fn storage_remove_ret_value_byte(ctx: &mut EstimatorContext) -> GasCost {
@@ -1169,6 +1182,7 @@ fn storage_remove_ret_value_byte(ctx: &mut EstimatorContext) -> GasCost {
         "storage_remove_10b_key_10kib_value_1k",
         ExtCosts::storage_remove_ret_value_byte,
         10 * 1024 * 1000,
+        0,
     )
 }
 
@@ -1261,18 +1275,71 @@ fn rocks_db_read_value_byte(ctx: &mut EstimatorContext) -> GasCost {
     rocks_db_read_cost(&ctx.config) / total_bytes
 }
 
-#[cfg(feature = "yield_create")]
+#[cfg(feature = "nightly")]
 fn yield_create_base(ctx: &mut EstimatorContext) -> GasCost {
-    let result = fn_cost_count(ctx, "yield_create_base", ExtCosts::yield_create_base, 1);
-    dbg!(result).0
+    let base_cost = noop_function_call_cost(ctx);
+    let result = if let Some(cost) = &ctx.cached.yield_create_base {
+        cost.clone()
+    } else {
+        let (result, count) =
+            fn_cost_count(ctx, "yield_create_base", ExtCosts::yield_create_base, 1);
+        assert_eq!(count, 1000);
+        let result = result / count;
+        ctx.cached.yield_create_base.insert(result).clone()
+    };
+    result.saturating_sub(&(base_cost / 1000), &NonNegativeTolerance::PER_MILLE)
 }
 
-#[cfg(feature = "yield_create")]
+#[cfg(feature = "nightly")]
 fn yield_create_byte(ctx: &mut EstimatorContext) -> GasCost {
-    let base_cost = fn_cost_count(ctx, "yield_create_base", ExtCosts::yield_create_base, 1);
-    let total_cost =
+    let noop_function_call = noop_function_call_cost(ctx);
+    let base_cost = yield_create_base(ctx);
+    let method_cost =
         fn_cost_count(ctx, "yield_create_byte_100b_method_length", ExtCosts::yield_create_base, 1);
-    total_cost.0.saturating_sub(&base_cost.0, &NonNegativeTolerance::PER_MILLE)
+    let argument_cost = fn_cost_count(
+        ctx,
+        "yield_create_byte_1000b_argument_length",
+        ExtCosts::yield_create_base,
+        1,
+    );
+    let compute = |(cost, count): (GasCost, u64), bytes: u64| -> GasCost {
+        let it = cost.saturating_sub(&noop_function_call, &NonNegativeTolerance::PER_MILLE) / count;
+        it.saturating_sub(&base_cost, &NonNegativeTolerance::PER_MILLE) / bytes
+    };
+    std::cmp::max(compute(method_cost, 100), compute(argument_cost, 1001))
+}
+
+#[cfg(feature = "nightly")]
+fn yield_resume_base(ctx: &mut EstimatorContext) -> GasCost {
+    fn_cost_with_setup(
+        ctx,
+        "yield_resume_base_prepare",
+        "yield_resume_base",
+        ExtCosts::yield_resume_base,
+        255,
+        1,
+    )
+}
+
+#[cfg(feature = "nightly")]
+fn yield_resume_byte(ctx: &mut EstimatorContext) -> GasCost {
+    let baseline = fn_cost_with_setup(
+        ctx,
+        "yield_resume_base_prepare",
+        "yield_resume_base",
+        ExtCosts::yield_resume_base,
+        255,
+        1,
+    );
+    let with_payload = fn_cost_with_setup(
+        ctx,
+        "yield_resume_base_prepare",
+        "yield_resume_payload",
+        ExtCosts::yield_resume_base,
+        255,
+        1,
+    );
+    with_payload.saturating_sub(&baseline, &NonNegativeTolerance::PER_MILLE) / 1000
 }
 
 fn gas_metering(ctx: &mut EstimatorContext) -> (GasCost, GasCost) {

--- a/runtime/runtime-params-estimator/src/utils.rs
+++ b/runtime/runtime-params-estimator/src/utils.rs
@@ -168,9 +168,9 @@ pub(crate) fn fn_cost_with_setup(
     method: &str,
     ext_cost: ExtCosts,
     count: u64,
+    block_latency: usize,
 ) -> GasCost {
     let (total_cost, measured_count) = {
-        let block_latency = 0;
         let overhead = overhead_per_measured_block(ctx, block_latency);
         let block_size = 2usize;
         let n_blocks = ctx.config.warmup_iters_per_block + ctx.config.iter_per_block;
@@ -198,7 +198,7 @@ pub(crate) fn fn_cost_with_setup(
             blocks
         };
 
-        let measurements = testbed.measure_blocks(blocks, 0);
+        let measurements = testbed.measure_blocks(blocks, block_latency);
         // Filter out setup blocks.
         let measurements: Vec<_> = measurements
             .into_iter()


### PR DESCRIPTION
Somewhat surprising to me is that estimations for the resume are much more high than for create. I suspect that the estimation is covering a significant part of the transaction runtime that is not really related to the resumes, but I'm struggling to isolate the interesting parts well.

So for the time being I'm submitting the baseline safe estimates. In practice the time will be (likely, much) lower than the fees charged for the operations, but the fees are still low enough that these host functions are very usable still.

We can explore dedicating additional engineering time to isolating the regions of interest better if these turn out to be a pain point. But in the meantime lets land these.