### PR TITLE
Panic in `CreateSnapshotRequest` handle if snapshot creation failed

### DIFF
--- a/chain/chain/src/state_snapshot_actor.rs
+++ b/chain/chain/src/state_snapshot_actor.rs
@@ -121,7 +121,9 @@ impl actix::Handler<WithSpanContext<CreateSnapshotRequest>> for StateSnapshotAct
                 }
             }
             Err(err) => {
-                tracing::error!(target: "state_snapshot", ?err, "State snapshot creation failed")
+                tracing::error!(target: "state_snapshot", ?err, "State snapshot creation failed.\
+                State snapshot is needed for correct node performance if it is required by config.");
+                panic!("State snapshot creation failed")
             }
         }
     }


### PR DESCRIPTION
@marcelo-gonzalez I advice to have this or a similar fix in 1.38.0.
Snapshot creation in regular neard run is handled via `StateSnapshotActor`.
In some tests and tools we call `checkpoint_hot_storage_and_cleanup_columns` directly, but right now we don't have a reason to changing those. 