### PR TITLE
yield/resume: add test create_then_resume

### DIFF
--- a/integration-tests/src/tests/runtime/test_yield_resume.rs
+++ b/integration-tests/src/tests/runtime/test_yield_resume.rs
@@ -34,6 +34,88 @@ fn setup_test_contract(wasm_binary: &[u8]) -> RuntimeNode {
 }
 
 #[test]
+fn create_then_resume() {
+    let node = setup_test_contract(near_test_contracts::nightly_rs_contract());
+
+    let yield_payload = vec![6u8; 16];
+
+    // Hardcoded key under which the yield callback will write data.
+    // We use this to observe whether the callback has been executed.
+    let key = 123u64.to_le_bytes().to_vec();
+
+    // Set up the yield execution
+    let res = node
+        .user()
+        .function_call(
+            "alice.near".parse().unwrap(),
+            "test_contract".parse().unwrap(),
+            "call_yield_create",
+            yield_payload.clone(),
+            MAX_GAS,
+            0,
+        )
+        .unwrap();
+
+    let data_id = match res.status {
+        FinalExecutionStatus::SuccessValue(data_id) => data_id,
+        _ => {
+            panic!("{res:?} unexpected result; expected some data id");
+        }
+    };
+
+    // Confirm that the yield callback hasn't been executed yet
+    let res = node
+        .user()
+        .function_call(
+            "alice.near".parse().unwrap(),
+            "test_contract".parse().unwrap(),
+            "read_value",
+            key.clone(),
+            MAX_GAS,
+            0,
+        )
+        .unwrap();
+    assert_eq!(res.status, FinalExecutionStatus::SuccessValue(vec![]), "{res:?} unexpected result",);
+
+    // Call yield resume with the payload followed by the data id
+    let args: Vec<u8> = yield_payload.into_iter().chain(data_id.into_iter()).collect();
+    let res = node
+        .user()
+        .function_call(
+            "alice.near".parse().unwrap(),
+            "test_contract".parse().unwrap(),
+            "call_yield_resume",
+            args,
+            MAX_GAS,
+            0,
+        )
+        .unwrap();
+    assert_eq!(
+        res.status,
+        FinalExecutionStatus::SuccessValue(vec![1u8]),
+        "{res:?} unexpected result; expected 1",
+    );
+
+    // Confirm that the yield callback was executed
+    let res = node
+        .user()
+        .function_call(
+            "alice.near".parse().unwrap(),
+            "test_contract".parse().unwrap(),
+            "read_value",
+            key,
+            MAX_GAS,
+            0,
+        )
+        .unwrap();
+    assert_eq!(
+        res.status,
+        FinalExecutionStatus::SuccessValue("Resumed ".as_bytes().to_vec()),
+        "{res:?} unexpected result",
+    );
+}
+
+#[test]
 fn create_and_resume_in_one_call() {
     let node = setup_test_contract(near_test_contracts::nightly_rs_contract());
 

--- a/integration-tests/src/tests/standard_cases/mod.rs
+++ b/integration-tests/src/tests/standard_cases/mod.rs
@@ -1461,7 +1461,7 @@ fn check_trie_nodes_count(
             node_touches = receipt_hashes
                 .iter()
                 .map(|receipt_hash| {
-                    let result = node_user.get_transaction_result(receipt_hash);
+                    let result = node_user.get_transaction_result(receipt_hash).unwrap();
                     get_trie_nodes_count(&result.metadata, runtime_config)
                 })
                 .collect();

--- a/integration-tests/src/user/mod.rs
+++ b/integration-tests/src/user/mod.rs
@@ -76,7 +76,7 @@ pub trait User {
 
     fn get_chunk_by_height(&self, height: BlockHeight, shard_id: ShardId) -> Option<ChunkView>;
 
-    fn get_transaction_result(&self, hash: &CryptoHash) -> ExecutionOutcomeView;
+    fn get_transaction_result(&self, hash: &CryptoHash) -> Option<ExecutionOutcomeView>;
 
     fn get_transaction_final_result(&self, hash: &CryptoHash) -> FinalExecutionOutcomeView;
 

--- a/integration-tests/src/user/rpc_user.rs
+++ b/integration-tests/src/user/rpc_user.rs
@@ -184,7 +184,7 @@ impl User for RpcUser {
         .ok()
     }
 
-    fn get_transaction_result(&self, _hash: &CryptoHash) -> ExecutionOutcomeView {
+    fn get_transaction_result(&self, _hash: &CryptoHash) -> Option<ExecutionOutcomeView> {
         unimplemented!()
     }
 

--- a/integration-tests/src/user/runtime_user.rs
+++ b/integration-tests/src/user/runtime_user.rs
@@ -174,7 +174,13 @@ impl RuntimeUser {
         &self,
         hash: &CryptoHash,
     ) -> Vec<ExecutionOutcomeWithIdView> {
-        let outcome = self.get_transaction_result(hash);
+        let outcome = match self.get_transaction_result(hash) {
+            Some(outcome) => outcome,
+            None => {
+                return vec![];
+            }
+        };
+
         let receipt_ids = outcome.receipt_ids.clone();
         let mut transactions = vec![ExecutionOutcomeWithIdView {
             id: *hash,
@@ -341,8 +347,8 @@ impl User for RuntimeUser {
         unimplemented!("get_chunk should not be implemented for RuntimeUser");
     }
 
-    fn get_transaction_result(&self, hash: &CryptoHash) -> ExecutionOutcomeView {
-        self.transaction_results.borrow().get(hash).cloned().unwrap()
+    fn get_transaction_result(&self, hash: &CryptoHash) -> Option<ExecutionOutcomeView> {
+        self.transaction_results.borrow().get(hash).cloned()
     }
 
     fn get_transaction_final_result(&self, hash: &CryptoHash) -> FinalExecutionOutcomeView {


### PR DESCRIPTION
Follow up to #10746. Adds a test with separate transactions creating a yield and then resuming it.