### PR TITLE
doc: adjust the style guide on `#[instrument]`

### DIFF
--- a/docs/practices/style.md
+++ b/docs/practices/style.md
@@ -407,16 +407,15 @@ find a particular span in logs or other tools ingesting the span data. If a
 span begins at the top of a function, prefer giving it a name of that function,
 otherwise prefer a `snake_case` name.
 
-Default to the [`#[tracing::instrument]`](instrument) macro. When instrumenting asynchronous
-functions either this or the `Future::instrument` is **required**. The spans produced in these
-contexts will be wrong if the span is held across an await point. Correct handling of this is
-handled for you via either of the suggested methods. If instrumentation of async functions is not
-done according to this guidance it can lead to difficult to troubleshoot issues such as stack
-overflows.
+When instrumenting asynchronous functions the [`#[tracing::instrument]`](instrument) macro or the
+`Future::instrument` is **required**. Using `Span::entered` or a similar method that is not aware
+of yield points will result in incorrect span data and could lead to difficult to troubleshoot
+issues such as stack overflows.
 
-Always use `level`, `target` and `skip_all` to avoid implicit defaults for the level, target or
-adding all function arguments as the span fields (this can get really expensive quite fast). After
-careful consideration specify the fields you want to record through `fields()` option:
+Always explicitly specify the `level`, `target`, and `skip_all` options and do not rely on the
+default values. `skip_all` avoids adding all function arguments as span fields which can lead
+recording potentially unnecessary and expensive information. Carefully consider which information
+needs recording and the cost of recording the information when using the `fields` option.
 
 [instrument]: https://docs.rs/tracing-attributes/latest/tracing_attributes/attr.instrument.html
 

--- a/docs/practices/style.md
+++ b/docs/practices/style.md
@@ -407,16 +407,45 @@ find a particular span in logs or other tools ingesting the span data. If a
 span begins at the top of a function, prefer giving it a name of that function,
 otherwise prefer a `snake_case` name.
 
-Use the regular span API over convenience macros such as `#[instrument]`, as
-this allows instrumenting portions of a function without affecting the code
-structure:
+Use the regular span API if you need to instrument portions of a function without affecting the
+code structure:
 
 ```rust
 fn compile_and_serialize_wasmer(code: &[u8]) -> Result<wasmer::Module> {
-    let _span = tracing::debug_span!(target: "vm", "compile_and_serialize_wasmer").entered();
-    // ...
-    // _span will be dropped when this scope ends, terminating the span created above.
-    // You can also `drop` it manually, to end the span early with `drop(_span)`.
+    // Some code...
+    {
+        let _span = tracing::debug_span!(target: "vm", "compile_wasmer").entered();
+        // ...
+        // _span will be dropped when this scope ends, terminating the span created above.
+        // You can also `drop` it manually, to end the span early with `drop(_span)`.
+    }
+    // Some more code...
+}
+```
+
+Use the [`#[tracing::instrument]`](instrument) macro to instrument asynchronous functions. The
+spans produced in these contexts will be wrong if the span is held across an await point, and it
+can lead to difficult to troubleshoot issues such as stack overflows. Always use `level`, `target`
+and `skip_all` to avoid implicit defaults for the level, target or adding all function arguments as
+the span fields (this can get really expensive quite fast). After careful consideration specify the
+fields you want to have through `fields()` option:
+
+[instrument]: https://docs.rs/tracing-attributes/latest/tracing_attributes/attr.instrument.html
+
+```rust
+#[tracing::instrument(
+    level = "trace",
+    target = "network",
+    "handle_sync_routing_table",
+    skip_all
+)]
+async fn handle_sync_routing_table(
+    clock: &time::Clock,
+    network_state: &Arc<NetworkState>,
+    conn: Arc<connection::Connection>,
+    rtu: RoutingTableUpdate,
+) {
+    ...
 }
 ```
 

--- a/docs/practices/style.md
+++ b/docs/practices/style.md
@@ -410,8 +410,9 @@ otherwise prefer a `snake_case` name.
 Default to the [`#[tracing::instrument]`](instrument) macro. When instrumenting asynchronous
 functions either this or the `Future::instrument` is **required**. The spans produced in these
 contexts will be wrong if the span is held across an await point. Correct handling of this is
-handled for you via either of these methods. If instrumentation of async functions is not done
-according to this guidance it can lead to difficult to troubleshoot issues such as stack overflows.
+handled for you via either of the suggested methods. If instrumentation of async functions is not
+done according to this guidance it can lead to difficult to troubleshoot issues such as stack
+overflows.
 
 Always use `level`, `target` and `skip_all` to avoid implicit defaults for the level, target or
 adding all function arguments as the span fields (this can get really expensive quite fast). After


### PR DESCRIPTION
Pushing people towards the `tracing::*_span!` has caused us some significant grief, especially in https://github.com/near/nearcore/pull/10663 so we better allow and encourage `#[instrument]`.