### PR TITLE
tracing: instrument contract cache operations

### DIFF
--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -970,6 +970,13 @@ impl StoreCompiledContractCache {
 /// Key must take into account VM being used and its configuration, so that
 /// we don't cache non-gas metered binaries, for example.
 impl CompiledContractCache for StoreCompiledContractCache {
+    #[tracing::instrument(
+        level = "trace",
+        target = "store",
+        "StoreCompiledContractCache::put",
+        skip_all,
+        fields(key = key.to_string(), value.len = value.debug_len()),
+    )]
     fn put(&self, key: &CryptoHash, value: CompiledContract) -> io::Result<()> {
         let mut update = crate::db::DBTransaction::new();
         // We intentionally use `.set` here, rather than `.insert`. We don't yet
@@ -984,6 +991,13 @@ impl CompiledContractCache for StoreCompiledContractCache {
         self.db.write(update)
     }
 
+    #[tracing::instrument(
+        level = "trace",
+        target = "store",
+        "StoreCompiledContractCache::get",
+        skip_all,
+        fields(key = key.to_string()),
+    )]
     fn get(&self, key: &CryptoHash) -> io::Result<Option<CompiledContract>> {
         match self.db.get_raw_bytes(DBCol::CachedContractCode, key.as_ref()) {
             Ok(Some(bytes)) => Ok(Some(CompiledContract::try_from_slice(&bytes)?)),

--- a/runtime/near-vm-runner/src/logic/mod.rs
+++ b/runtime/near-vm-runner/src/logic/mod.rs
@@ -31,6 +31,18 @@ pub enum CompiledContract {
     Code(Vec<u8>),
 }
 
+impl CompiledContract {
+    /// Return the length of the compiled contract data.
+    ///
+    /// If the `CompiledContract` represents a compilation failure, returns `0`.
+    pub fn debug_len(&self) -> usize {
+        match self {
+            CompiledContract::CompileModuleError(_) => 0,
+            CompiledContract::Code(c) => c.len(),
+        }
+    }
+}
+
 /// Cache for compiled modules
 pub trait CompiledContractCache: Send + Sync {
     fn put(&self, key: &CryptoHash, value: CompiledContract) -> std::io::Result<()>;


### PR DESCRIPTION
This instruments the `StoreCompiledContractCache` to show an overall cost of these operations whenever they are used. The level I've chosen here is `trace` to avoid polluting the traces too much in default operation. #10774 has a targeted instrumentation at a higher level.