### PR TITLE
refactor: downgrade `vm::get_key` span to the trace level

### DIFF
--- a/runtime/near-vm-runner/src/cache.rs
+++ b/runtime/near-vm-runner/src/cache.rs
@@ -44,8 +44,8 @@ fn vm_hash(vm_kind: VMKind) -> u64 {
     }
 }
 
+#[tracing::instrument(level = "trace", target = "vm", "get_key", skip_all)]
 pub fn get_contract_cache_key(code: &ContractCode, config: &Config) -> CryptoHash {
-    let _span = tracing::debug_span!(target: "vm", "get_key").entered();
     let key = ContractCacheKey::Version4 {
         code_hash: *code.hash(),
         vm_config_non_crypto_hash: config.non_crypto_hash(),


### PR DESCRIPTION
While this span is not very frequent, it does not provide particularly much information to trace it, so lets redelegate it to a more verbose level.