### PR TITLE
rpc: return timeout error from tx_status_fetch

### DIFF
--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -628,15 +628,12 @@ impl JsonRpcHandler {
         .map_err(|_| {
             metrics::RPC_TIMEOUT_TOTAL.inc();
             tracing::warn!(
-                target: "jsonrpc", "Timeout: tx_status_fetch method. tx_info {:?} fetch_receipt {:?}",
+                target: "jsonrpc", "Timeout: tx_status_fetch method. tx_info {:?} fetch_receipt {:?} result {:?}",
                 tx_info,
                 fetch_receipt,
+                tx_status_result
             );
-            if let Err(error) = tx_status_result {
-                error
-            } else {
-                near_jsonrpc_primitives::types::transactions::RpcTransactionError::TimeoutError
-            }
+            near_jsonrpc_primitives::types::transactions::RpcTransactionError::TimeoutError
         })?
     }
 

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1690,7 +1690,7 @@ impl ExecutionOutcomeWithIdView {
         self.outcome.to_hashes(self.id)
     }
 }
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TxStatusView {
     pub execution_outcome: Option<FinalExecutionOutcomeViewEnum>,
     pub status: TxExecutionStatus,


### PR DESCRIPTION
All the logic of `tx_status_fetch` function is: we poll tx_status method and wait for the desired level of tx finality.
`tx_status_fetch` is used in several places including `broadcast_tx_commit` RPC method.

With the chunk congestions we have right now, we return `UNKNOWN_TRANSACTION` error to `broadcast_tx_commit` after 20 seconds of waiting, which is both sad and weird.

The error we store in `tx_status_result` is not good enough to show it to the user, otherwise we would break from the loop with it immediately.
If we reach the timeout boundary, I suggest always to return timeout error.