### PR TITLE
RPC: improve supporting tx execution levels

### DIFF
--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -504,12 +504,12 @@ impl ViewClientActor {
             target_shard_id,
             true,
         ) {
-            match self.chain.get_transaction_result_for_rpc(&tx_hash) {
+            match self.chain.get_partial_transaction_result(&tx_hash) {
                 Ok(tx_result) => {
                     let status = self.get_tx_execution_status(&tx_result)?;
                     let res = if fetch_receipt {
                         let final_result =
-                            self.chain.get_final_transaction_result_with_receipt(tx_result)?;
+                            self.chain.get_transaction_result_with_receipt(tx_result)?;
                         FinalExecutionOutcomeViewEnum::FinalExecutionOutcomeWithReceipt(
                             final_result,
                         )

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -436,26 +436,23 @@ impl ViewClientActor {
             return Ok(TxExecutionStatus::None);
         }
 
+        let is_execution_finished = match execution_outcome.status {
+            FinalExecutionStatus::Failure(_) | FinalExecutionStatus::SuccessValue(_) => true,
+            FinalExecutionStatus::NotStarted | FinalExecutionStatus::Started => false,
+        };
+
         if let Err(_) = self.chain.check_blocks_final_and_canonical(&[self
             .chain
             .get_block_header(&execution_outcome.transaction_outcome.block_hash)?])
         {
-            return if execution_outcome
-                .receipts_outcome
-                .iter()
-                .all(|e| e.outcome.status != ExecutionStatusView::Unknown)
-            {
+            return if is_execution_finished {
                 Ok(TxExecutionStatus::ExecutedOptimistic)
             } else {
                 Ok(TxExecutionStatus::Included)
             };
         }
 
-        if execution_outcome
-            .receipts_outcome
-            .iter()
-            .any(|e| e.outcome.status == ExecutionStatusView::Unknown)
-        {
+        if !is_execution_finished {
             return Ok(TxExecutionStatus::IncludedFinal);
         }
 
@@ -507,7 +504,7 @@ impl ViewClientActor {
             target_shard_id,
             true,
         ) {
-            match self.chain.get_final_transaction_result(&tx_hash) {
+            match self.chain.get_transaction_result_for_rpc(&tx_hash) {
                 Ok(tx_result) => {
                     let status = self.get_tx_execution_status(&tx_result)?;
                     let res = if fetch_receipt {

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -711,8 +711,7 @@ impl JsonRpcHandler {
     > {
         self.send_tx(RpcSendTransactionRequest {
             signed_transaction: request_data.signed_transaction,
-            // Will be ignored, broadcast_tx_commit is not aligned with existing enum
-            wait_until: Default::default(),
+            wait_until: TxExecutionStatus::ExecutedOptimistic,
         })
         .await
     }

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1756,7 +1756,7 @@ impl TxStatusView {
     }
 }
 
-/// Execution outcome of the transaction and all of subsequent the receipts.
+/// Execution outcome of the transaction and all the subsequent receipts.
 /// Could be not finalised yet
 #[derive(
     BorshSerialize, BorshDeserialize, serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone,

--- a/integration-tests/src/user/runtime_user.rs
+++ b/integration-tests/src/user/runtime_user.rs
@@ -194,7 +194,7 @@ impl RuntimeUser {
         transactions
     }
 
-    // todo get rid of tons of copy pasted code, it's usually outdated comparing to the original
+    // TODO(#10942) get rid of copy pasted code, it's outdated comparing to the original
     fn get_final_transaction_result(&self, hash: &CryptoHash) -> FinalExecutionOutcomeView {
         let mut outcomes = self.get_recursive_transaction_results(hash);
         let mut looking_for_id = *hash;

--- a/integration-tests/src/user/runtime_user.rs
+++ b/integration-tests/src/user/runtime_user.rs
@@ -194,6 +194,7 @@ impl RuntimeUser {
         transactions
     }
 
+    // todo get rid of tons of copy pasted code, it's usually outdated comparing to the original
     fn get_final_transaction_result(&self, hash: &CryptoHash) -> FinalExecutionOutcomeView {
         let mut outcomes = self.get_recursive_transaction_results(hash);
         let mut looking_for_id = *hash;


### PR DESCRIPTION
More about tx execution levels: https://docs.near.org/api/rpc/transactions#tx-status-result

The levels that allow having not all the execution outcomes (Included, IncludedFinal), actually had to wait for all of the execution outcomes anyway.
[1.37.3 had a separate partial fix for supporting Included status, but let's not overcomplicate]
With the current change, we can show everything we have at the moment without extra waiting.
Also, current change helps us to be 1 step closer to resolving https://github.com/near/nearcore/issues/6834
That would be my next step after we merge this PR.

TLDR: I partially copy pasted the code.
I could have rewritten `chain:get_final_transaction_result` instead, but it has LOTS of usages everywhere. I decided it's just not safe.
I anyway changed it a little with the new function `chain:get_execution_status` (hopefully in a better way) - see the details below in the comment.
But the new logic with partial execution outcomes list is used only in view_client (aka RPC, as far as I see from the usages).
