### PR TITLE
support Included transaction status

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -219,7 +219,7 @@ type BlockApplyChunksResult = (CryptoHash, Vec<(ShardId, Result<ShardUpdateResul
 /// Provides current view on the state according to the chain state.
 pub struct Chain {
     pub(crate) clock: Clock,
-    chain_store: ChainStore,
+    pub chain_store: ChainStore,
     pub epoch_manager: Arc<dyn EpochManagerAdapter>,
     pub shard_tracker: ShardTracker,
     pub runtime_adapter: Arc<dyn RuntimeAdapter>,

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -46,6 +46,7 @@ use near_primitives::sharding::ShardChunk;
 use near_primitives::state_sync::{
     ShardStateSyncResponse, ShardStateSyncResponseHeader, ShardStateSyncResponseV3,
 };
+use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockId, BlockReference, EpochReference, Finality, MaybeBlockId,
     ShardId, SyncCheckpoint, TransactionOrReceiptId, ValidatorInfoIdentifier,
@@ -53,9 +54,10 @@ use near_primitives::types::{
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
     BlockView, ChunkView, EpochValidatorInfo, ExecutionOutcomeWithIdView, ExecutionStatusView,
-    FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum, GasPriceView, LightClientBlockView,
-    MaintenanceWindowsView, QueryRequest, QueryResponse, ReceiptView, SplitStorageInfoView,
-    StateChangesKindsView, StateChangesView, TxExecutionStatus, TxStatusView,
+    FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum, FinalExecutionStatus, GasPriceView,
+    LightClientBlockView, MaintenanceWindowsView, QueryRequest, QueryResponse, ReceiptView,
+    SignedTransactionView, SplitStorageInfoView, StateChangesKindsView, StateChangesView,
+    TxExecutionStatus, TxStatusView,
 };
 use near_store::flat::{FlatStorageReadyStatus, FlatStorageStatus};
 use near_store::{DBCol, COLD_HEAD_KEY, FINAL_HEAD_KEY, HEAD_KEY};
@@ -520,11 +522,29 @@ impl ViewClientActor {
                     Ok(TxStatusView { execution_outcome: Some(res), status })
                 }
                 Err(near_chain::Error::DBNotFoundErr(_)) => {
-                    if self.chain.get_execution_outcome(&tx_hash).is_ok() {
-                        Ok(TxStatusView {
-                            execution_outcome: None,
-                            status: TxExecutionStatus::None,
-                        })
+                    if let Ok(Some(transaction)) = self.chain.chain_store.get_transaction(&tx_hash)
+                    {
+                        let transaction: SignedTransactionView =
+                            SignedTransaction::clone(&transaction).into();
+                        if let Ok(tx_outcome) = self.chain.get_execution_outcome(&tx_hash) {
+                            let outcome = FinalExecutionOutcomeViewEnum::FinalExecutionOutcome(
+                                FinalExecutionOutcomeView {
+                                    status: FinalExecutionStatus::Started,
+                                    transaction,
+                                    transaction_outcome: tx_outcome.into(),
+                                    receipts_outcome: vec![],
+                                },
+                            );
+                            Ok(TxStatusView {
+                                execution_outcome: Some(outcome),
+                                status: TxExecutionStatus::Included,
+                            })
+                        } else {
+                            Ok(TxStatusView {
+                                execution_outcome: None,
+                                status: TxExecutionStatus::Included,
+                            })
+                        }
                     } else {
                         Err(TxStatusError::MissingTransaction(tx_hash))
                     }


### PR DESCRIPTION
Ideally, we need to rewrite `chain.get_final_transaction_result` method completely.
But for now, let's start at least with supporting `TxExecutionStatus::Included` status.