### PR TITLE
yield/resume: directly process receipts from the timeout queue

### DIFF
--- a/runtime/runtime/src/balance_checker.rs
+++ b/runtime/runtime/src/balance_checker.rs
@@ -311,6 +311,7 @@ mod tests {
             &[],
             &[],
             &[],
+            &[],
             &ApplyStats::default(),
         )
         .unwrap();
@@ -326,6 +327,7 @@ mod tests {
             &final_state,
             &None,
             &[Receipt::new_balance_refund(&alice_account(), 1000)],
+            &[],
             &[],
             &[],
             &ApplyStats::default(),
@@ -385,6 +387,7 @@ mod tests {
             &final_state,
             &None,
             &[Receipt::new_balance_refund(&account_id, refund_balance)],
+            &[],
             &[],
             &[],
             &ApplyStats::default(),
@@ -453,6 +456,7 @@ mod tests {
             &final_state,
             &None,
             &[],
+            &[],
             &[tx],
             &[receipt],
             &ApplyStats {
@@ -512,6 +516,7 @@ mod tests {
                 &initial_state,
                 &None,
                 &[receipt],
+                &[],
                 &[tx],
                 &[],
                 &ApplyStats::default(),
@@ -570,6 +575,7 @@ mod tests {
                 &initial_state,
                 &None,
                 &[receipt],
+                &[],
                 &[tx],
                 &[],
                 &ApplyStats::default(),

--- a/runtime/runtime/src/balance_checker.rs
+++ b/runtime/runtime/src/balance_checker.rs
@@ -125,6 +125,7 @@ pub(crate) fn check_balance(
     final_state: &TrieUpdate,
     validator_accounts_update: &Option<ValidatorAccountsUpdate>,
     incoming_receipts: &[Receipt],
+    yield_timeout_receipts: &[Receipt],
     transactions: &[SignedTransaction],
     outgoing_receipts: &[Receipt],
     stats: &ApplyStats,
@@ -154,6 +155,7 @@ pub(crate) fn check_balance(
         .iter()
         .map(|tx| tx.transaction.signer_id.clone())
         .chain(incoming_receipts.iter().map(|r| r.receiver_id.clone()))
+        .chain(yield_timeout_receipts.iter().map(|r| r.receiver_id.clone()))
         .chain(processed_delayed_receipts.iter().map(|r| r.receiver_id.clone()))
         .collect();
     let incoming_validator_rewards =
@@ -179,7 +181,8 @@ pub(crate) fn check_balance(
     let receipts_cost = |receipts: &[Receipt]| -> Result<Balance, IntegerOverflowError> {
         total_receipts_cost(config, receipts)
     };
-    let incoming_receipts_balance = receipts_cost(incoming_receipts)?;
+    let incoming_receipts_balance =
+        receipts_cost(incoming_receipts)? + receipts_cost(yield_timeout_receipts)?;
     let outgoing_receipts_balance = receipts_cost(outgoing_receipts)?;
     let processed_delayed_receipts_balance = receipts_cost(&processed_delayed_receipts)?;
     let new_delayed_receipts_balance = receipts_cost(&new_delayed_receipts)?;
@@ -191,6 +194,7 @@ pub(crate) fn check_balance(
     let all_potential_postponed_receipt_ids = incoming_receipts
         .iter()
         .chain(processed_delayed_receipts.iter())
+        .chain(yield_timeout_receipts.iter())
         .filter_map(|receipt| {
             let account_id = &receipt.receiver_id;
             match &receipt.receipt {

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1572,7 +1572,15 @@ impl Runtime {
         let initial_yielded_promise_indices = yielded_promise_indices.clone();
         let mut new_receipt_index: usize = 0;
 
+        let mut timeout_receipts = vec![];
         while yielded_promise_indices.first_index < yielded_promise_indices.next_available_index {
+            if total_compute_usage >= compute_limit
+                || proof_size_limit
+                    .is_some_and(|limit| state_update.trie.recorded_storage_size() > limit)
+            {
+                break;
+            }
+
             let queue_entry_key =
                 TrieKey::YieldedPromiseQueueEntry { index: yielded_promise_indices.first_index };
 
@@ -1595,12 +1603,9 @@ impl Runtime {
                 data_id: queue_entry.data_id,
             };
             if state_update.contains_key(&yielded_promise_key)? {
-                // Deliver a DataReceipt without any data to resolve the timed-out yield
-                let new_receipt = ReceiptEnum::PromiseResume(DataReceipt {
-                    data_id: queue_entry.data_id,
-                    data: None,
-                });
-
+                // Process a PromiseResume receipt to resolve the timed-out yield.
+                // Note that we don't invoke the prefetcher as it doesn't do anything
+                // for data receipts
                 let new_receipt_id = create_receipt_id_from_receipt_id(
                     protocol_version,
                     &queue_entry.data_id,
@@ -1610,12 +1615,23 @@ impl Runtime {
                 );
                 new_receipt_index += 1;
 
-                outgoing_receipts.push(Receipt {
+                let new_receipt = Receipt {
                     predecessor_id: queue_entry.account_id.clone(),
                     receiver_id: queue_entry.account_id.clone(),
                     receipt_id: new_receipt_id,
-                    receipt: new_receipt,
-                });
+                    receipt: ReceiptEnum::PromiseResume(DataReceipt {
+                        data_id: queue_entry.data_id,
+                        data: None,
+                    }),
+                };
+
+                process_receipt(
+                    &new_receipt,
+                    &mut state_update,
+                    &mut total_gas_burnt,
+                    &mut total_compute_usage,
+                )?;
+                timeout_receipts.push(new_receipt);
             }
 
             state_update.remove(queue_entry_key);
@@ -1637,6 +1653,7 @@ impl Runtime {
             &state_update,
             validator_accounts_update,
             incoming_receipts,
+            &timeout_receipts,
             transactions,
             &outgoing_receipts,
             &stats,


### PR DESCRIPTION
**What?**

Before: when a yield timed out, we would resolve it by creating a new outgoing data receipt.
After: we directly process the data receipt, which we know for a fact is destined for the local shard.

To keep the balance checker happy, these receipts are essentially interpreted as additional incoming receipts.

**Why?**

This is both an efficiency improvement and a correctness fix. We avoid the need to create an outgoing receipt. We also eliminate the following possibility:

1. User submits a transaction which creates a yielded promise.
2. After some time, the timeout triggers and the protocol delivers a new outgoing receipt. Due to congestion, the timeout receipt enters the delayed receipts queue.
3. The user submits a transaction which calls yield resume. The yield callback hasn't executed, so the user gets back a success signal indicating the yield payload was submitted successfully. When returning such a signal we guarantee that the callback will be executed with a user-submitted payload.
4. The timeout receipt is delivered and the yield callback is executed without a payload. The user is sad and confused.

After this change, the delayed receipts queue must be empty for a timeout to trigger. When the timeout triggers, the yield callback will be executed immediately. It eliminates such timing issues.