### PR TITLE
fix(snapshots): drop unwanted column families instead of deleting all keys

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -150,7 +150,6 @@ impl NightshadeRuntime {
                 home_dir: home_dir.to_path_buf(),
                 hot_store_path: PathBuf::from("data"),
                 state_snapshot_subdir: PathBuf::from("state_snapshot"),
-                compaction_enabled: false,
             },
         )
     }
@@ -177,7 +176,6 @@ impl NightshadeRuntime {
                 home_dir: home_dir.to_path_buf(),
                 hot_store_path: PathBuf::from("data"),
                 state_snapshot_subdir: PathBuf::from("state_snapshot"),
-                compaction_enabled: false,
             },
         )
     }

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -213,7 +213,6 @@ impl TestEnv {
                 home_dir: PathBuf::from(dir.path()),
                 hot_store_path: PathBuf::from("data"),
                 state_snapshot_subdir: PathBuf::from("state_snapshot"),
-                compaction_enabled: false,
             },
         );
         let state_roots = get_genesis_state_roots(&store).unwrap().unwrap();

--- a/chain/chain/src/state_snapshot_actor.rs
+++ b/chain/chain/src/state_snapshot_actor.rs
@@ -14,8 +14,7 @@ use std::sync::Arc;
 /// Runs tasks related to state snapshots.
 /// There are three main handlers in StateSnapshotActor and they are called in sequence
 /// 1. DeleteSnapshotRequest: deletes a snapshot and optionally calls CreateSnapshotRequest.
-/// 2. CreateSnapshotRequest: creates a new snapshot and optionally calls CompactSnapshotRequest based on config.
-/// 3. CompactSnapshotRequest: compacts a snapshot store.
+/// 2. CreateSnapshotRequest: creates a new snapshot.
 pub struct StateSnapshotActor {
     flat_storage_manager: FlatStorageManager,
     network_adapter: PeerManagerAdapter,
@@ -56,10 +55,6 @@ struct CreateSnapshotRequest {
     block: Block,
 }
 
-#[derive(actix::Message, Debug)]
-#[rtype(result = "()")]
-struct CompactSnapshotRequest {}
-
 impl actix::Handler<WithSpanContext<DeleteAndMaybeCreateSnapshotRequest>> for StateSnapshotActor {
     type Result = ();
 
@@ -87,7 +82,7 @@ impl actix::Handler<WithSpanContext<CreateSnapshotRequest>> for StateSnapshotAct
     type Result = ();
 
     #[perf]
-    fn handle(&mut self, msg: WithSpanContext<CreateSnapshotRequest>, context: &mut Context<Self>) {
+    fn handle(&mut self, msg: WithSpanContext<CreateSnapshotRequest>, _context: &mut Context<Self>) {
         let (_span, msg) = handler_debug_span!(target: "state_snapshot", msg);
         tracing::debug!(target: "state_snapshot", ?msg);
 
@@ -113,33 +108,10 @@ impl actix::Handler<WithSpanContext<CreateSnapshotRequest>> for StateSnapshotAct
                         },
                     ));
                 }
-
-                if self.tries.state_snapshot_config().compaction_enabled {
-                    context.address().do_send(CompactSnapshotRequest {}.with_span_context());
-                } else {
-                    tracing::info!(target: "state_snapshot", "State snapshot ready, not running compaction.");
-                }
             }
             Err(err) => {
                 tracing::error!(target: "state_snapshot", ?err, "State snapshot creation failed")
             }
-        }
-    }
-}
-
-/// Runs compaction of the snapshot store.
-impl actix::Handler<WithSpanContext<CompactSnapshotRequest>> for StateSnapshotActor {
-    type Result = ();
-
-    #[perf]
-    fn handle(&mut self, msg: WithSpanContext<CompactSnapshotRequest>, _: &mut Context<Self>) {
-        let (_span, msg) = handler_debug_span!(target: "state_snapshot", msg);
-        tracing::debug!(target: "state_snapshot", ?msg);
-
-        if let Err(err) = self.tries.compact_state_snapshot() {
-            tracing::error!(target: "state_snapshot", ?err, "State snapshot compaction failed");
-        } else {
-            tracing::info!(target: "state_snapshot", "State snapshot compaction succeeded");
         }
     }
 }

--- a/chain/chain/src/state_snapshot_actor.rs
+++ b/chain/chain/src/state_snapshot_actor.rs
@@ -82,7 +82,11 @@ impl actix::Handler<WithSpanContext<CreateSnapshotRequest>> for StateSnapshotAct
     type Result = ();
 
     #[perf]
-    fn handle(&mut self, msg: WithSpanContext<CreateSnapshotRequest>, _context: &mut Context<Self>) {
+    fn handle(
+        &mut self,
+        msg: WithSpanContext<CreateSnapshotRequest>,
+        _context: &mut Context<Self>,
+    ) {
         let (_span, msg) = handler_debug_span!(target: "state_snapshot", msg);
         tracing::debug!(target: "state_snapshot", ?msg);
 

--- a/chain/chain/src/state_snapshot_actor.rs
+++ b/chain/chain/src/state_snapshot_actor.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 
 /// Runs tasks related to state snapshots.
 /// There are three main handlers in StateSnapshotActor and they are called in sequence
-/// 1. DeleteSnapshotRequest: deletes a snapshot and optionally calls CreateSnapshotRequest.
-/// 2. CreateSnapshotRequest: creates a new snapshot.
+/// 1. [`DeleteAndMaybeCreateSnapshotRequest`]: deletes a snapshot and optionally calls CreateSnapshotRequest.
+/// 2. [`CreateSnapshotRequest`]: creates a new snapshot.
 pub struct StateSnapshotActor {
     flat_storage_manager: FlatStorageManager,
     network_adapter: PeerManagerAdapter,

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -95,9 +95,6 @@ pub struct StoreConfig {
 
     // TODO (#9989): To be phased out in favor of state_snapshot_config
     pub state_snapshot_enabled: bool,
-
-    // TODO (#9989): To be phased out in favor of state_snapshot_config
-    pub state_snapshot_compaction_enabled: bool,
 }
 
 /// Config used to control state snapshot creation. This is used for state sync and resharding.
@@ -105,11 +102,6 @@ pub struct StoreConfig {
 #[serde(default)]
 pub struct StateSnapshotConfig {
     pub state_snapshot_type: StateSnapshotType,
-    /// State Snapshot compaction usually is a good thing but is heavy on IO and can take considerable
-    /// amount of time.
-    /// It makes state snapshots tiny (10GB) over the course of an epoch.
-    /// We may want to disable it for archival nodes during resharding
-    pub compaction_enabled: bool,
 }
 
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
@@ -274,9 +266,6 @@ impl Default for StoreConfig {
 
             // TODO: To be phased out in favor of state_snapshot_config
             state_snapshot_enabled: false,
-
-            // TODO: To be phased out in favor of state_snapshot_config
-            state_snapshot_compaction_enabled: false,
         }
     }
 }

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -230,7 +230,11 @@ pub trait Database: Sync + Send {
     fn get_store_statistics(&self) -> Option<StoreStatistics>;
 
     /// Create checkpoint in provided path
-    fn create_checkpoint(&self, path: &std::path::Path) -> anyhow::Result<()>;
+    fn create_checkpoint(
+        &self,
+        path: &std::path::Path,
+        columns_to_keep: Option<&[DBCol]>,
+    ) -> anyhow::Result<()>;
 }
 
 fn assert_no_overwrite(col: DBCol, key: &[u8], value: &[u8], old_value: &[u8]) {

--- a/core/store/src/db/colddb.rs
+++ b/core/store/src/db/colddb.rs
@@ -111,8 +111,12 @@ impl Database for ColdDB {
         self.cold.get_store_statistics()
     }
 
-    fn create_checkpoint(&self, path: &std::path::Path) -> anyhow::Result<()> {
-        self.cold.create_checkpoint(path)
+    fn create_checkpoint(
+        &self,
+        path: &std::path::Path,
+        columns_to_keep: Option<&[DBCol]>,
+    ) -> anyhow::Result<()> {
+        self.cold.create_checkpoint(path, columns_to_keep)
     }
 }
 

--- a/core/store/src/db/splitdb.rs
+++ b/core/store/src/db/splitdb.rs
@@ -198,7 +198,11 @@ impl Database for SplitDB {
         None
     }
 
-    fn create_checkpoint(&self, _path: &std::path::Path) -> anyhow::Result<()> {
+    fn create_checkpoint(
+        &self,
+        _path: &std::path::Path,
+        _columns_to_keep: Option<&[DBCol]>,
+    ) -> anyhow::Result<()> {
         log_assert_fail!("create_checkpoint is not allowed - the split storage has two stores");
         Ok(())
     }

--- a/core/store/src/db/testdb.rs
+++ b/core/store/src/db/testdb.rs
@@ -128,7 +128,11 @@ impl Database for TestDB {
         self.stats.read().unwrap().clone()
     }
 
-    fn create_checkpoint(&self, _path: &std::path::Path) -> anyhow::Result<()> {
+    fn create_checkpoint(
+        &self,
+        _path: &std::path::Path,
+        _columns_to_keep: Option<&[DBCol]>,
+    ) -> anyhow::Result<()> {
         Ok(())
     }
 }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -40,6 +40,7 @@ pub use crate::trie::{
     PartialStorage, PrefetchApi, PrefetchError, RawTrieNode, RawTrieNodeWithSize, ShardTries,
     StateSnapshot, StateSnapshotConfig, Trie, TrieAccess, TrieCache, TrieCachingStorage,
     TrieChanges, TrieConfig, TrieDBStorage, TrieStorage, WrappedTrieChanges,
+    STATE_SNAPSHOT_COLUMNS,
 };
 
 pub mod cold_storage;

--- a/core/store/src/metrics.rs
+++ b/core/store/src/metrics.rs
@@ -263,15 +263,6 @@ pub(crate) static DELETE_STATE_SNAPSHOT_ELAPSED: Lazy<Histogram> = Lazy::new(|| 
     .unwrap()
 });
 
-pub(crate) static COMPACT_STATE_SNAPSHOT_ELAPSED: Lazy<Histogram> = Lazy::new(|| {
-    try_create_histogram_with_buckets(
-        "near_compact_state_snapshot_elapsed_sec",
-        "Latency of compaction of a state snapshot, in seconds",
-        exponential_buckets(0.001, 1.6, 40).unwrap(),
-    )
-    .unwrap()
-});
-
 pub(crate) static MOVE_STATE_SNAPSHOT_FLAT_HEAD_ELAPSED: Lazy<HistogramVec> = Lazy::new(|| {
     try_create_histogram_vec(
         "near_move_state_snapshot_flat_head_elapsed_sec",

--- a/core/store/src/opener.rs
+++ b/core/store/src/opener.rs
@@ -616,9 +616,7 @@ pub fn checkpoint_hot_storage_and_cleanup_columns(
             <&str>::from(DbKind::RPC).as_bytes().to_vec(),
         );
 
-        tracing::debug!(target: "state_snapshot", ?transaction, "Transaction ready");
         node_storage.hot_storage.write(transaction)?;
-        tracing::debug!(target: "state_snapshot", "Transaction written");
     }
 
     Ok(node_storage)

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -15,7 +15,9 @@ use crate::trie::iterator::TrieIterator;
 pub use crate::trie::nibble_slice::NibbleSlice;
 pub use crate::trie::prefetching_trie_storage::{PrefetchApi, PrefetchError};
 pub use crate::trie::shard_tries::{KeyForStateChanges, ShardTries, WrappedTrieChanges};
-pub use crate::trie::state_snapshot::{SnapshotError, StateSnapshot, StateSnapshotConfig};
+pub use crate::trie::state_snapshot::{
+    SnapshotError, StateSnapshot, StateSnapshotConfig, STATE_SNAPSHOT_COLUMNS,
+};
 pub use crate::trie::trie_storage::{TrieCache, TrieCachingStorage, TrieDBStorage, TrieStorage};
 use crate::StorageError;
 use borsh::{BorshDeserialize, BorshSerialize};

--- a/core/store/src/trie/state_snapshot.rs
+++ b/core/store/src/trie/state_snapshot.rs
@@ -198,7 +198,7 @@ impl ShardTries {
             ),
             // TODO: Cleanup Changes and DeltaMetadata to avoid extra memory usage.
             // Can't be cleaned up now because these columns are needed to `update_flat_head()`.
-            Some(vec![
+            Some(&[
                 // Keep DbVersion and BlockMisc, otherwise you'll not be able to open the state snapshot as a Store.
                 DBCol::DbVersion,
                 DBCol::BlockMisc,

--- a/core/store/src/trie/state_snapshot.rs
+++ b/core/store/src/trie/state_snapshot.rs
@@ -139,6 +139,17 @@ pub struct StateSnapshotConfig {
     pub state_snapshot_subdir: PathBuf,
 }
 
+pub const STATE_SNAPSHOT_COLUMNS: &[DBCol] = &[
+    // Keep DbVersion and BlockMisc, otherwise you'll not be able to open the state snapshot as a Store.
+    DBCol::DbVersion,
+    DBCol::BlockMisc,
+    // Flat storage columns.
+    DBCol::FlatState,
+    DBCol::FlatStateChanges,
+    DBCol::FlatStateDeltaMetadata,
+    DBCol::FlatStorageStatus,
+];
+
 impl ShardTries {
     pub fn get_state_snapshot(
         &self,
@@ -197,16 +208,7 @@ impl ShardTries {
             ),
             // TODO: Cleanup Changes and DeltaMetadata to avoid extra memory usage.
             // Can't be cleaned up now because these columns are needed to `update_flat_head()`.
-            Some(&[
-                // Keep DbVersion and BlockMisc, otherwise you'll not be able to open the state snapshot as a Store.
-                DBCol::DbVersion,
-                DBCol::BlockMisc,
-                // Flat storage columns.
-                DBCol::FlatState,
-                DBCol::FlatStateChanges,
-                DBCol::FlatStateDeltaMetadata,
-                DBCol::FlatStorageStatus,
-            ]),
+            Some(STATE_SNAPSHOT_COLUMNS),
         )?;
         let store = storage.get_hot_store();
         // It is fine to create a separate FlatStorageManager, because

--- a/integration-tests/src/tests/client/state_snapshot.rs
+++ b/integration-tests/src/tests/client/state_snapshot.rs
@@ -53,7 +53,6 @@ impl StateSnaptshotTestEnv {
             home_dir: home_dir.clone(),
             hot_store_path: hot_store_path.clone(),
             state_snapshot_subdir: state_snapshot_subdir.clone(),
-            compaction_enabled: true,
         };
         let shard_tries = ShardTries::new(
             store.clone(),

--- a/integration-tests/src/tests/client/sync_state_nodes.rs
+++ b/integration-tests/src/tests/client/sync_state_nodes.rs
@@ -455,7 +455,6 @@ fn sync_state_dump() {
                 credentials_file: None,
             });
             near1.config.store.state_snapshot_enabled = true;
-            near1.config.store.state_snapshot_compaction_enabled = false;
 
             let dir1 = tempfile::Builder::new().prefix("sync_nodes_1").tempdir().unwrap();
             let nearcore::NearNode {
@@ -738,7 +737,6 @@ fn test_state_sync_headers() {
             let dir1 =
                 tempfile::Builder::new().prefix("test_state_sync_headers").tempdir().unwrap();
             near1.config.store.state_snapshot_enabled = true;
-            near1.config.store.state_snapshot_compaction_enabled = false;
 
             let nearcore::NearNode { view_client: view_client1, .. } =
                 start_with_config(dir1.path(), near1).expect("start_with_config");
@@ -935,7 +933,6 @@ fn test_state_sync_headers_no_tracked_shards() {
                 .tempdir()
                 .unwrap();
             near1.config.store.state_snapshot_enabled = false;
-            near1.config.store.state_snapshot_compaction_enabled = false;
             near1.config.state_sync_enabled = false;
             near1.client_config.state_sync_enabled = false;
 
@@ -953,7 +950,6 @@ fn test_state_sync_headers_no_tracked_shards() {
                 .tempdir()
                 .unwrap();
             near2.config.store.state_snapshot_enabled = true;
-            near2.config.store.state_snapshot_compaction_enabled = false;
             near2.config.state_sync_enabled = false;
             near2.client_config.state_sync_enabled = false;
 

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -621,9 +621,6 @@ impl NightshadeRuntime {
         if config.config.store.state_snapshot_enabled {
             state_snapshot_type = StateSnapshotType::EveryEpoch;
         }
-        // TODO (#9989): directly use the new state snapshot config once the migration is done.
-        let compaction_enabled = config.config.store.state_snapshot_compaction_enabled
-            || config.config.store.state_snapshot_config.compaction_enabled;
         let state_snapshot_config = StateSnapshotConfig {
             state_snapshot_type,
             home_dir: home_dir.to_path_buf(),
@@ -634,7 +631,6 @@ impl NightshadeRuntime {
                 .clone()
                 .unwrap_or_else(|| PathBuf::from("data")),
             state_snapshot_subdir: PathBuf::from("state_snapshot"),
-            compaction_enabled,
         };
         NightshadeRuntime::new(
             store,

--- a/tools/database/src/make_snapshot.rs
+++ b/tools/database/src/make_snapshot.rs
@@ -70,7 +70,7 @@ mod tests {
         }
 
         let destination = home_dir.path().join("data").join("snapshot");
-        let cmd = MakeSnapshotCommand { destination: destination.clone() };
+        let cmd = MakeSnapshotCommand { destination: destination.clone(), flat_state_only: false };
         cmd.run(home_dir.path(), false, &store_config).unwrap();
         println!("Made a checkpoint");
 


### PR DESCRIPTION
If the `columns_to_keep` arg of `checkpoint_hot_storage_and_cleanup_columns()` is `Some`, then we delete all the data in every other column. Then if snapshot compaction is enabled in the configs, we rely on that to clean up the files on disk. Instead of doing that, we can just call `drop_cf()` on every unwanted column family, and the associated sst files will be removed without the need for any compactions.

So this moves the `columns_to_keep` arg to `near_store::db::Database::create_checkpoint()`, and has the rocksdb implementation of that trait call `drop_cf()` on unwanted column families. These column families are then immediately recreated in  `checkpoint_hot_storage_and_cleanup_columns()` by the call to `StoreOpener::open_in_mode()`, but the data on disk is gone.

This also means we can get rid of the state snapshot options in the config, since they were only ever intended to clean up the unwanted files, which aren't there anymore.