### PR TITLE
feat(voting): added logs and metrics for the protocol version voting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3749,6 +3749,7 @@ dependencies = [
  "near-primitives",
  "near-store",
  "num-rational",
+ "once_cell",
  "primitive-types",
  "rand",
  "rand_hc",

--- a/chain/epoch-manager/Cargo.toml
+++ b/chain/epoch-manager/Cargo.toml
@@ -23,6 +23,7 @@ smart-default.workspace = true
 tracing.workspace = true
 # itertools has collect_vec which is useful in quick debugging prints
 itertools.workspace = true
+once_cell.workspace = true
 
 near-o11y.workspace = true
 near-crypto.workspace = true

--- a/chain/epoch-manager/src/metrics.rs
+++ b/chain/epoch-manager/src/metrics.rs
@@ -1,0 +1,16 @@
+use near_o11y::metrics::{try_create_int_gauge, try_create_int_gauge_vec, IntGauge, IntGaugeVec};
+use once_cell::sync::Lazy;
+
+pub(crate) static PROTOCOL_VERSION_VOTES: Lazy<IntGaugeVec> = Lazy::new(|| {
+    try_create_int_gauge_vec(
+        "near_protocol_version_votes",
+        "The percentage of stake voting for each protocol version",
+        &["protocol_version"],
+    )
+    .unwrap()
+});
+
+pub(crate) static PROTOCOL_VERSION_NEXT: Lazy<IntGauge> = Lazy::new(|| {
+    try_create_int_gauge("near_protocol_version_next", "The protocol version for the next epoch.")
+        .unwrap()
+});

--- a/pytest/tests/sanity/upgradable.py
+++ b/pytest/tests/sanity/upgradable.py
@@ -139,7 +139,20 @@ def test_upgrade() -> None:
     assert 'error' not in res, res
     assert 'Failure' not in res['result']['status'], res
 
-    utils.wait_for_blocks(nodes[0], count=20)
+    metrics_tracker = utils.MetricsTracker(nodes[3])
+
+    count = 0
+    for height, _ in utils.poll_blocks(nodes[0]):
+        votes = metrics_tracker.get_metric_all_values(
+            "near_protocol_version_votes")
+        next = metrics_tracker.get_int_metric_value(
+            "near_protocol_version_next")
+
+        print(f"#{height}: {votes} -> {next}")
+
+        count += 1
+        if count > 20:
+            break
 
     # Restart stable nodes into new version.
     for i in range(3):
@@ -151,7 +164,19 @@ def test_upgrade() -> None:
             extra_env={"NEAR_TESTS_IMMEDIATE_PROTOCOL_UPGRADE": "1"},
         )
 
-    utils.wait_for_blocks(nodes[3], count=60)
+    count = 0
+    for height, _ in utils.poll_blocks(nodes[3]):
+        votes = metrics_tracker.get_metric_all_values(
+            "near_protocol_version_votes")
+        next = metrics_tracker.get_int_metric_value(
+            "near_protocol_version_next")
+
+        print(f"#{height}: {votes} -> {next}")
+
+        count += 1
+        if count > 60:
+            break
+
     status0 = nodes[0].get_status()
     status3 = nodes[3].get_status()
     protocol_version = status0['protocol_version']


### PR DESCRIPTION
* Added logs about the protocol voting. Please note those are INFO level logs. I allowed myself to make it INFO because it only happens at the epoch boundary. This adds 2-3 log lines every 16 hours. 
* Added metrics about the protocol voting. This can be used for grafana and monitoring. Again, the metrics are populated only at the epoch boundary so a bit too late but it's better than nothing. It should be enough to tell why the voting didn't happen when expected. 

neard logs from the upgradable test:
```
2024-03-15T14:11:58.469094Z  INFO {height=21}: epoch_manager: Protocol version voting. version=64 stake_percent=75
2024-03-15T14:11:58.469120Z  INFO {height=21}: epoch_manager: Protocol version voting. version=65 stake_percent=25
2024-03-15T14:11:58.469143Z  INFO {height=21}: epoch_manager: Protocol version voting. next_version=64
2024-03-15T14:12:10.956314Z  INFO {height=41}: epoch_manager: Protocol version voting. version=64 stake_percent=50
2024-03-15T14:12:10.956332Z  INFO {height=41}: epoch_manager: Protocol version voting. version=65 stake_percent=50
2024-03-15T14:12:10.956343Z  INFO {height=41}: epoch_manager: Protocol version voting. next_version=64
2024-03-15T14:12:23.186205Z  INFO {height=61}: epoch_manager: Protocol version voting. version=65 stake_percent=100
2024-03-15T14:12:23.186226Z  INFO {height=61}: epoch_manager: Protocol version voting. next_version=65
2024-03-15T14:12:35.231042Z  INFO {height=81}: epoch_manager: Protocol version voting. version=65 stake_percent=100
2024-03-15T14:12:35.231062Z  INFO {height=81}: epoch_manager: Protocol version voting. next_version=65
2024-03-15T14:12:47.425518Z  INFO {height=101}: epoch_manager: Protocol version voting. version=65 stake_percent=100
2024-03-15T14:12:47.425538Z  INFO {height=101}: epoch_manager: Protocol version voting. next_version=65
```

nayduck logs from the upgradable test, read from the metrics:
```
// a few of those till end of first epoch
#19: [] -> None
...
// plenty of those while only one node is upgraded
#25: [({'protocol_version': '64'}, 75.0), ({'protocol_version': '65'}, 25.0)] -> 64
...
// plenty of those after all the nodes are upgraded
#68: [({'protocol_version': '65'}, 100.0)] -> 65
```