### PR TITLE
Fix `Option<Duration>` deserialization when None.

### DIFF
--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -113,6 +113,7 @@ pub struct DumpConfig {
     /// How often to check if a new epoch has started.
     /// Feel free to set to `None`, defaults are sensible.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     #[serde(with = "near_async::time::serde_opt_duration_as_std")]
     pub iteration_delay: Option<Duration>,
     /// Location of a json file with credentials allowing write access to the bucket.

--- a/core/chain-configs/src/updateable_config.rs
+++ b/core/chain-configs/src/updateable_config.rs
@@ -98,6 +98,7 @@ pub struct UpdateableClientConfig {
     pub resharding_config: ReshardingConfig,
 
     /// Time limit for adding transactions in produce_chunk()
+    #[serde(default)]
     #[serde(with = "near_async::time::serde_opt_duration_as_std")]
     pub produce_chunk_add_transactions_time_limit: Option<Duration>,
 }

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -280,6 +280,7 @@ pub struct Config {
     /// A node produces a chunk by adding transactions from the transaction pool until
     /// some limit is reached. This time limit ensures that adding transactions won't take
     /// longer than the specified duration, which helps to produce the chunk quickly.
+    #[serde(default)]
     #[serde(with = "near_async::time::serde_opt_duration_as_std")]
     pub produce_chunk_add_transactions_time_limit: Option<Duration>,
     /// Optional config for the Chunk Distribution Network feature.


### PR DESCRIPTION
Apparently by default Option is deserialized to None when the field is missing, but if you use `serde(with = ...)`, that behavior is gone. So add `serde(default)` to bring that behavior back.