### PR TITLE
yield/resume: improve naming consistency

### DIFF
--- a/core/primitives/src/receipt.rs
+++ b/core/primitives/src/receipt.rs
@@ -231,24 +231,24 @@ impl DelayedReceiptIndices {
     }
 }
 
-/// Stores indices for a persistent queue for yielded promises.
+/// Stores indices for a persistent queue for PromiseYield timeouts.
 #[derive(Default, BorshSerialize, BorshDeserialize, Clone, PartialEq, Debug)]
-pub struct YieldedPromiseQueueIndices {
+pub struct PromiseYieldIndices {
     // First inclusive index in the queue.
     pub first_index: u64,
     // Exclusive end index of the queue
     pub next_available_index: u64,
 }
 
-impl YieldedPromiseQueueIndices {
+impl PromiseYieldIndices {
     pub fn len(&self) -> u64 {
         self.next_available_index - self.first_index
     }
 }
 
-/// Entries in the queue of yielded promises.
+/// Entries in the queue of PromiseYield timeouts.
 #[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Debug)]
-pub struct YieldedPromiseQueueEntry {
+pub struct PromiseYieldTimeout {
     /// The account on which the yielded promise was created
     pub account_id: AccountId,
     /// The `data_id` used to identify the awaited input data

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -370,8 +370,8 @@ impl StateChanges {
                 TrieKey::PostponedReceipt { .. } => {}
                 TrieKey::DelayedReceiptIndices => {}
                 TrieKey::DelayedReceipt { .. } => {}
-                TrieKey::YieldedPromiseQueueIndices => {}
-                TrieKey::YieldedPromiseQueueEntry { .. } => {}
+                TrieKey::PromiseYieldIndices => {}
+                TrieKey::PromiseYieldTimeout { .. } => {}
                 TrieKey::PromiseYieldReceipt { .. } => {}
             }
         }

--- a/core/store/src/genesis/state_applier.rs
+++ b/core/store/src/genesis/state_applier.rs
@@ -1,8 +1,8 @@
 use crate::flat::FlatStateChanges;
 use crate::{
     get_account, has_received_data, set, set_access_key, set_account, set_code,
-    set_delayed_receipt, set_postponed_receipt, set_received_data, set_yielded_promise, ShardTries,
-    TrieUpdate,
+    set_delayed_receipt, set_postponed_receipt, set_promise_yield_receipt, set_received_data,
+    ShardTries, TrieUpdate,
 };
 
 use near_chain_configs::Genesis;
@@ -310,7 +310,7 @@ impl GenesisStateApplier {
                 }
                 ReceiptEnum::PromiseYield(ref _action_receipt) => {
                     storage.modify(|state_update| {
-                        set_yielded_promise(state_update, &receipt);
+                        set_promise_yield_receipt(state_update, &receipt);
                     });
                 }
                 ReceiptEnum::Data(_) | ReceiptEnum::PromiseResume(_) => {

--- a/core/store/src/trie/resharding.rs
+++ b/core/store/src/trie/resharding.rs
@@ -55,8 +55,8 @@ impl ShardTries {
                     }
                     None => {}
                 },
-                TrieKey::YieldedPromiseQueueIndices => {}
-                TrieKey::YieldedPromiseQueueEntry { .. } => todo!(),
+                TrieKey::PromiseYieldIndices => {}
+                TrieKey::PromiseYieldTimeout { .. } => todo!(),
                 TrieKey::PromiseYieldReceipt { .. } => todo!(),
                 TrieKey::Account { account_id }
                 | TrieKey::ContractCode { account_id }

--- a/runtime/runtime/src/balance_checker.rs
+++ b/runtime/runtime/src/balance_checker.rs
@@ -13,7 +13,7 @@ use near_primitives::transaction::SignedTransaction;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{AccountId, Balance};
 use near_store::{
-    get, get_account, get_postponed_receipt, get_yielded_promise, TrieAccess, TrieUpdate,
+    get, get_account, get_postponed_receipt, get_promise_yield_receipt, TrieAccess, TrieUpdate,
 };
 use std::collections::HashSet;
 
@@ -109,7 +109,7 @@ fn total_postponed_receipts_cost(
                 }
             }
             PostponedReceiptType::PromiseYield => {
-                match get_yielded_promise(state, account_id, *lookup_id)? {
+                match get_promise_yield_receipt(state, account_id, *lookup_id)? {
                     None => return Ok(total),
                     Some(receipt) => receipt_cost(config, &receipt)?,
                 }

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -6,7 +6,9 @@ use near_primitives::trie_key::{trie_key_parsers, TrieKey};
 use near_primitives::types::{AccountId, Balance, EpochId, EpochInfoProvider, Gas, TrieCacheMode};
 use near_primitives::utils::create_receipt_id_from_action_hash;
 use near_primitives::version::ProtocolVersion;
-use near_store::{get_code, has_yielded_promise, KeyLookupMode, TrieUpdate, TrieUpdateValuePtr};
+use near_store::{
+    get_code, has_promise_yield_receipt, KeyLookupMode, TrieUpdate, TrieUpdateValuePtr,
+};
 use near_vm_runner::logic::errors::{AnyError, VMLogicError};
 use near_vm_runner::logic::types::ReceiptIndex;
 use near_vm_runner::logic::{External, StorageGetMode, ValuePtr};
@@ -227,7 +229,7 @@ impl<'a> External for RuntimeExt<'a> {
         data: Vec<u8>,
     ) -> Result<bool, VMLogicError> {
         // If the yielded promise was created by a previous transaction, we'll find it in the trie
-        if has_yielded_promise(self.trie_update, self.account_id.clone(), data_id)
+        if has_promise_yield_receipt(self.trie_update, self.account_id.clone(), data_id)
             .map_err(wrap_storage_error)?
         {
             self.receipt_manager.create_promise_resume_receipt(data_id, data)?;

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -18,8 +18,8 @@ use near_primitives::checked_feature;
 use near_primitives::errors::{ActionError, ActionErrorKind, RuntimeError, TxExecutionError};
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{
-    ActionReceipt, DataReceipt, DelayedReceiptIndices, Receipt, ReceiptEnum, ReceivedData,
-    YieldedPromiseQueueEntry, YieldedPromiseQueueIndices,
+    ActionReceipt, DataReceipt, DelayedReceiptIndices, PromiseYieldIndices, PromiseYieldTimeout,
+    Receipt, ReceiptEnum, ReceivedData,
 };
 use near_primitives::runtime::migration_data::{MigrationData, MigrationFlags};
 use near_primitives::sandbox::state_patch::SandboxStatePatch;
@@ -41,9 +41,9 @@ use near_primitives::utils::{
 };
 use near_primitives::version::{ProtocolFeature, ProtocolVersion};
 use near_store::{
-    get, get_account, get_postponed_receipt, get_received_data, get_yielded_promise,
-    has_received_data, remove_postponed_receipt, remove_yielded_promise, set, set_account,
-    set_delayed_receipt, set_postponed_receipt, set_received_data, set_yielded_promise,
+    get, get_account, get_postponed_receipt, get_promise_yield_receipt, get_received_data,
+    has_received_data, remove_postponed_receipt, remove_promise_yield_receipt, set, set_account,
+    set_delayed_receipt, set_postponed_receipt, set_promise_yield_receipt, set_received_data,
     PartialStorage, StorageError, Trie, TrieChanges, TrieUpdate,
 };
 use near_store::{set_access_key, set_code};
@@ -1046,17 +1046,17 @@ impl Runtime {
             ReceiptEnum::PromiseYield(_) => {
                 // Received a new PromiseYield receipt. We simply store it and await
                 // the corresponding PromiseResume receipt.
-                set_yielded_promise(state_update, receipt);
+                set_promise_yield_receipt(state_update, receipt);
             }
             ReceiptEnum::PromiseResume(ref data_receipt) => {
                 // Received a new PromiseResume receipt delivering input data for a PromiseYield.
                 // It is guaranteed that the PromiseYield has exactly one input data dependency
                 // and that it arrives first, so we can simply find and execute it.
                 if let Some(yield_receipt) =
-                    get_yielded_promise(state_update, account_id, data_receipt.data_id)?
+                    get_promise_yield_receipt(state_update, account_id, data_receipt.data_id)?
                 {
                     // Remove the receipt from the state
-                    remove_yielded_promise(state_update, account_id, data_receipt.data_id);
+                    remove_promise_yield_receipt(state_update, account_id, data_receipt.data_id);
 
                     // Save the data into the state keyed by the data_id
                     set_received_data(
@@ -1566,14 +1566,14 @@ impl Runtime {
             prefetcher.clear();
         }
 
-        // Resolve timed-out yielded promises
-        let mut yielded_promise_indices: YieldedPromiseQueueIndices =
-            get(&state_update, &TrieKey::YieldedPromiseQueueIndices)?.unwrap_or_default();
-        let initial_yielded_promise_indices = yielded_promise_indices.clone();
+        // Resolve timed-out PromiseYield receipts
+        let mut promise_yield_indices: PromiseYieldIndices =
+            get(&state_update, &TrieKey::PromiseYieldIndices)?.unwrap_or_default();
+        let initial_promise_yield_indices = promise_yield_indices.clone();
         let mut new_receipt_index: usize = 0;
 
         let mut timeout_receipts = vec![];
-        while yielded_promise_indices.first_index < yielded_promise_indices.next_available_index {
+        while promise_yield_indices.first_index < promise_yield_indices.next_available_index {
             if total_compute_usage >= compute_limit
                 || proof_size_limit
                     .is_some_and(|limit| state_update.trie.recorded_storage_size() > limit)
@@ -1582,13 +1582,13 @@ impl Runtime {
             }
 
             let queue_entry_key =
-                TrieKey::YieldedPromiseQueueEntry { index: yielded_promise_indices.first_index };
+                TrieKey::PromiseYieldTimeout { index: promise_yield_indices.first_index };
 
-            let queue_entry = get::<YieldedPromiseQueueEntry>(&state_update, &queue_entry_key)?
+            let queue_entry = get::<PromiseYieldTimeout>(&state_update, &queue_entry_key)?
                 .ok_or_else(|| {
                     StorageError::StorageInconsistentState(format!(
-                        "Yielded promise queue entry #{} should be in the state",
-                        yielded_promise_indices.first_index
+                        "PromiseYield timeout queue entry #{} should be in the state",
+                        promise_yield_indices.first_index
                     ))
                 })?;
 
@@ -1640,7 +1640,7 @@ impl Runtime {
 
             state_update.remove(queue_entry_key);
             // Math checked above: first_index is less than next_available_index
-            yielded_promise_indices.first_index += 1;
+            promise_yield_indices.first_index += 1;
         }
         metrics.yield_timeouts_done(total_gas_burnt, total_compute_usage);
 
@@ -1648,8 +1648,8 @@ impl Runtime {
             set(&mut state_update, TrieKey::DelayedReceiptIndices, &delayed_receipts_indices);
         }
 
-        if yielded_promise_indices != initial_yielded_promise_indices {
-            set(&mut state_update, TrieKey::YieldedPromiseQueueIndices, &yielded_promise_indices);
+        if promise_yield_indices != initial_promise_yield_indices {
+            set(&mut state_update, TrieKey::PromiseYieldIndices, &promise_yield_indices);
         }
 
         check_balance(


### PR DESCRIPTION
Cleans up a few things across the board:
- All DB columns related to yield/resume now have a name with form `PROMISE_YIELD_???`
- Replaces instances of "yielded promise" so that we consistently use "promise yield" everywhere
- Columns and structs containing timeout information are named accordingly, replacing generic names e.g. `PromiseYieldQueueEntry` -> `PromiseYieldTimeout`
- The behavior of the get/set/remove methods in the store which specifically operate on PromiseYield _receipts_ and do not interact with the queue are clarified by including "receipt" in the name
- Queue metadata is named `PROMISE_YIELD_INDICES`, consistent with the other queue `DELAYED_RECEIPT_INDICES`

Apologies if this is a tough one to review; I tried to read over it and my brain is melting from reading the words "promise yield" 200 times in a row. Overall there are no changes beyond just renaming stuff. Fortunately we have a few unit tests for this project now. I tested things end-to-end as well in my localnet. 