### PR TITLE
clear reserved listener addresses after each fuzzer run

### DIFF
--- a/chain/network/src/peer_manager/tests/fuzzers.rs
+++ b/chain/network/src/peer_manager/tests/fuzzers.rs
@@ -41,6 +41,7 @@ async fn random_handshake_connect(input: &[u8]) {
         })
         .await;
     pm.check_consistency().await;
+    crate::tcp::RESERVED_LISTENER_ADDRS.lock().unwrap().clear();
 }
 
 #[test]

--- a/chain/network/src/tcp.rs
+++ b/chain/network/src/tcp.rs
@@ -10,8 +10,9 @@ const LISTENER_BACKLOG: u32 = 128;
 
 /// TEST-ONLY: guards ensuring that OS considers the given TCP listener port to be in use until
 /// this OS process is terminated.
-static RESERVED_LISTENER_ADDRS: Lazy<Mutex<HashMap<std::net::SocketAddr, tokio::net::TcpSocket>>> =
-    Lazy::new(|| Mutex::new(HashMap::new()));
+pub(crate) static RESERVED_LISTENER_ADDRS: Lazy<
+    Mutex<HashMap<std::net::SocketAddr, tokio::net::TcpSocket>>,
+> = Lazy::new(|| Mutex::new(HashMap::new()));
 
 /// TCP connections established by a node belong to different logical networks (aka tiers),
 /// which serve different purpose.


### PR DESCRIPTION
This should avoid the issue listed at https://github.com/near/nearcore/issues/10784.

It should be fine because we always run with `cargo nextest` anyway, meaning that only the fuzzer’s own sockets will be cleared by the change.