### PR TITLE
Enable in-memory trie when state sync

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -521,7 +521,7 @@ impl Chain {
             })
             .cloned()
             .collect();
-        runtime_adapter.load_mem_tries_on_startup(&shard_uids, &tracked_shards)?;
+        runtime_adapter.load_mem_tries_on_startup(&tracked_shards)?;
 
         info!(target: "chain", "Init: header head @ #{} {}; block head @ #{} {}",
               header_head.height, header_head.last_block_hash,

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2771,19 +2771,7 @@ impl Chain {
             store_update.commit()?;
             flat_storage_manager.create_flat_storage_for_shard(shard_uid).unwrap();
             // Flat storage is ready, load memtrie if it is enabled.
-            let memtrie_loaded = self
-                .runtime_adapter
-                .load_mem_trie_on_catchup(&shard_uid, &chunk.prev_state_root())?;
-            // If memtrie is enabled but it was not loaded now, it would mean it was already loaded.
-            // It should never happen during state sync.
-            debug_assert!(
-                memtrie_loaded
-                    || !self
-                        .runtime_adapter
-                        .get_tries()
-                        .trie_config()
-                        .enable_mem_trie_for_tracked_shards
-            );
+            self.runtime_adapter.load_mem_trie_on_catchup(&shard_uid, &chunk.prev_state_root())?;
         }
 
         let mut height = shard_state_header.chunk_height_included();

--- a/chain/chain/src/resharding.rs
+++ b/chain/chain/src/resharding.rs
@@ -434,6 +434,7 @@ impl Chain {
 
         let child_shard_uids = state_roots.keys().cloned().collect_vec();
         self.initialize_flat_storage(&prev_hash, &child_shard_uids)?;
+        // TODO(#10844) Load in-memory trie if needed.
 
         let mut chain_store_update = self.mut_chain_store().store_update();
         for (shard_uid, state_root) in state_roots {

--- a/chain/chain/src/resharding.rs
+++ b/chain/chain/src/resharding.rs
@@ -434,7 +434,7 @@ impl Chain {
 
         let child_shard_uids = state_roots.keys().cloned().collect_vec();
         self.initialize_flat_storage(&prev_hash, &child_shard_uids)?;
-        // TODO(#10844) Load in-memory trie if needed.
+        // TODO(resharding) #10844 Load in-memory trie if needed.
 
         let mut chain_store_update = self.mut_chain_store().store_update();
         for (shard_uid, state_root) in state_roots {

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -1246,7 +1246,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         shard_uid: &ShardUId,
         state_root: &StateRoot,
     ) -> Result<(), StorageError> {
-        if !self.get_tries().trie_config().load_mem_trie_for_tracked_shards {
+        if !self.get_tries().trie_config().load_mem_tries_for_tracked_shards {
             return Ok(());
         }
         // It should not happen that memtrie is already loaded for a shard

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -1237,12 +1237,8 @@ impl RuntimeAdapter for NightshadeRuntime {
         Ok(epoch_manager.will_shard_layout_change(parent_hash)?)
     }
 
-    fn load_mem_tries_on_startup(
-        &self,
-        all_shards: &[ShardUId],
-        tracked_shards: &[ShardUId],
-    ) -> Result<(), StorageError> {
-        self.tries.load_mem_tries_for_enabled_shards(all_shards, tracked_shards)
+    fn load_mem_tries_on_startup(&self, tracked_shards: &[ShardUId]) -> Result<(), StorageError> {
+        self.tries.load_mem_tries_for_enabled_shards(tracked_shards)
     }
 
     fn load_mem_trie_on_catchup(

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -1237,8 +1237,12 @@ impl RuntimeAdapter for NightshadeRuntime {
         Ok(epoch_manager.will_shard_layout_change(parent_hash)?)
     }
 
-    fn load_mem_tries_on_startup(&self, shard_uids: &[ShardUId]) -> Result<(), StorageError> {
-        self.tries.load_mem_tries_for_enabled_shards(shard_uids)
+    fn load_mem_tries_on_startup(
+        &self,
+        all_shards: &[ShardUId],
+        tracked_shards: &[ShardUId],
+    ) -> Result<(), StorageError> {
+        self.tries.load_mem_tries_for_enabled_shards(all_shards, tracked_shards)
     }
 
     fn load_mem_trie_on_catchup(

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -1240,6 +1240,26 @@ impl RuntimeAdapter for NightshadeRuntime {
     fn load_mem_tries_on_startup(&self, shard_uids: &[ShardUId]) -> Result<(), StorageError> {
         self.tries.load_mem_tries_for_enabled_shards(shard_uids)
     }
+
+    fn load_mem_trie_on_catchup(
+        &self,
+        shard_uid: &ShardUId,
+        state_root: &StateRoot,
+    ) -> Result<bool, StorageError> {
+        if !self.tries.should_load_mem_trie_on_catchup(shard_uid) {
+            return Ok(false);
+        }
+        self.tries.load_mem_trie(shard_uid, Some(*state_root))?;
+        Ok(true)
+    }
+
+    fn retain_mem_tries(&self, shard_uids: &[ShardUId]) {
+        self.tries.retain_mem_tries(shard_uids)
+    }
+
+    fn unload_mem_trie(&self, shard_uid: &ShardUId) {
+        self.tries.unload_mem_trie(shard_uid)
+    }
 }
 
 impl node_runtime::adapter::ViewRuntimeAdapter for NightshadeRuntime {

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -1551,6 +1551,7 @@ fn get_test_env_with_chain_and_pool() -> (TestEnv, Chain, TransactionPool) {
         ChainConfig::test(),
         None,
         Arc::new(RayonAsyncComputationSpawner),
+        None,
     )
     .unwrap();
 

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -418,6 +418,7 @@ mod tests {
             ChainConfig::test(),
             None,
             Arc::new(RayonAsyncComputationSpawner),
+            None,
         )
         .unwrap();
         (

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -75,6 +75,7 @@ pub fn get_chain_with_epoch_length_and_num_shards(
         ChainConfig::test(),
         None,
         Arc::new(RayonAsyncComputationSpawner),
+        None,
     )
     .unwrap()
 }
@@ -164,6 +165,7 @@ pub fn setup_with_tx_validity_period(
         ChainConfig::test(),
         None,
         Arc::new(RayonAsyncComputationSpawner),
+        None,
     )
     .unwrap();
 

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -462,14 +462,6 @@ impl EpochManagerAdapter for MockEpochManager {
         Ok(ShardUId { version: 0, shard_id: shard_id as u32 })
     }
 
-    fn shard_ids_to_uids(
-        &self,
-        shard_ids: &[ShardId],
-        _epoch_id: &EpochId,
-    ) -> Result<Vec<ShardUId>, EpochError> {
-        Ok(shard_ids.iter().map(|id| ShardUId { version: 0, shard_id: *id as u32 }).collect())
-    }
-
     fn get_block_info(&self, _hash: &CryptoHash) -> Result<Arc<BlockInfo>, EpochError> {
         Ok(Default::default())
     }
@@ -1478,8 +1470,8 @@ impl RuntimeAdapter for KeyValueRuntime {
         &self,
         _shard_uid: &ShardUId,
         _state_root: &StateRoot,
-    ) -> Result<bool, StorageError> {
-        Ok(false)
+    ) -> Result<(), StorageError> {
+        Ok(())
     }
 
     fn retain_mem_tries(&self, _shard_uids: &[ShardUId]) {}

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -1462,11 +1462,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         Ok(vec![])
     }
 
-    fn load_mem_tries_on_startup(
-        &self,
-        _all_shards: &[ShardUId],
-        _tracked_shards: &[ShardUId],
-    ) -> Result<(), StorageError> {
+    fn load_mem_tries_on_startup(&self, _tracked_shards: &[ShardUId]) -> Result<(), StorageError> {
         Ok(())
     }
 

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -462,6 +462,14 @@ impl EpochManagerAdapter for MockEpochManager {
         Ok(ShardUId { version: 0, shard_id: shard_id as u32 })
     }
 
+    fn shard_ids_to_uids(
+        &self,
+        shard_ids: &[ShardId],
+        _epoch_id: &EpochId,
+    ) -> Result<Vec<ShardUId>, EpochError> {
+        Ok(shard_ids.iter().map(|id| ShardUId { version: 0, shard_id: *id as u32 }).collect())
+    }
+
     fn get_block_info(&self, _hash: &CryptoHash) -> Result<Arc<BlockInfo>, EpochError> {
         Ok(Default::default())
     }
@@ -1465,4 +1473,16 @@ impl RuntimeAdapter for KeyValueRuntime {
     fn load_mem_tries_on_startup(&self, _shard_uids: &[ShardUId]) -> Result<(), StorageError> {
         Ok(())
     }
+
+    fn load_mem_trie_on_catchup(
+        &self,
+        _shard_uid: &ShardUId,
+        _state_root: &StateRoot,
+    ) -> Result<bool, StorageError> {
+        Ok(false)
+    }
+
+    fn retain_mem_tries(&self, _shard_uids: &[ShardUId]) {}
+
+    fn unload_mem_trie(&self, _shard_uid: &ShardUId) {}
 }

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -1462,7 +1462,11 @@ impl RuntimeAdapter for KeyValueRuntime {
         Ok(vec![])
     }
 
-    fn load_mem_tries_on_startup(&self, _shard_uids: &[ShardUId]) -> Result<(), StorageError> {
+    fn load_mem_tries_on_startup(
+        &self,
+        _all_shards: &[ShardUId],
+        _tracked_shards: &[ShardUId],
+    ) -> Result<(), StorageError> {
         Ok(())
     }
 

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -512,7 +512,11 @@ pub trait RuntimeAdapter: Send + Sync {
     /// Loads in-memory tries upon startup. The given shard_uids are possible candidates to load,
     /// but which exact shards to load depends on configuration. This may only be called when flat
     /// storage is ready.
-    fn load_mem_tries_on_startup(&self, shard_uids: &[ShardUId]) -> Result<(), StorageError>;
+    fn load_mem_tries_on_startup(
+        &self,
+        all_shards: &[ShardUId],
+        tracked_shards: &[ShardUId],
+    ) -> Result<(), StorageError>;
 
     /// Loads in-memory trie upon catchup, if it is enabled.
     /// Requires state root because `ChunkExtra` is not available at the time mem-trie is being loaded.

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -514,13 +514,13 @@ pub trait RuntimeAdapter: Send + Sync {
     /// storage is ready.
     fn load_mem_tries_on_startup(&self, shard_uids: &[ShardUId]) -> Result<(), StorageError>;
 
-    /// Loads in-memory trie upon catchup. On success, returns whether mem-trie was loaded.
+    /// Loads in-memory trie upon catchup, if it is enabled.
     /// Requires state root because `ChunkExtra` is not available at the time mem-trie is being loaded.
     fn load_mem_trie_on_catchup(
         &self,
         shard_uid: &ShardUId,
         state_root: &StateRoot,
-    ) -> Result<bool, StorageError>;
+    ) -> Result<(), StorageError>;
 
     /// Retains in-memory tries for given shards, i.e. unload tries from memory for shards that are NOT
     /// in the given list. Should be called to unload obsolete tries from memory.

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -513,6 +513,21 @@ pub trait RuntimeAdapter: Send + Sync {
     /// but which exact shards to load depends on configuration. This may only be called when flat
     /// storage is ready.
     fn load_mem_tries_on_startup(&self, shard_uids: &[ShardUId]) -> Result<(), StorageError>;
+
+    /// Loads in-memory trie upon catchup. On success, returns whether mem-trie was loaded.
+    /// Requires state root because `ChunkExtra` is not available at the time mem-trie is being loaded.
+    fn load_mem_trie_on_catchup(
+        &self,
+        shard_uid: &ShardUId,
+        state_root: &StateRoot,
+    ) -> Result<bool, StorageError>;
+
+    /// Retains in-memory tries for given shards, i.e. unload tries from memory for shards that are NOT
+    /// in the given list. Should be called to unload obsolete tries from memory.
+    fn retain_mem_tries(&self, shard_uids: &[ShardUId]);
+
+    /// Unload trie from memory for given shard.
+    fn unload_mem_trie(&self, shard_uid: &ShardUId);
 }
 
 /// The last known / checked height and time when we have processed it.

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -512,11 +512,7 @@ pub trait RuntimeAdapter: Send + Sync {
     /// Loads in-memory tries upon startup. The given shard_uids are possible candidates to load,
     /// but which exact shards to load depends on configuration. This may only be called when flat
     /// storage is ready.
-    fn load_mem_tries_on_startup(
-        &self,
-        all_shards: &[ShardUId],
-        tracked_shards: &[ShardUId],
-    ) -> Result<(), StorageError>;
+    fn load_mem_tries_on_startup(&self, tracked_shards: &[ShardUId]) -> Result<(), StorageError>;
 
     /// Loads in-memory trie upon catchup, if it is enabled.
     /// Requires state root because `ChunkExtra` is not available at the time mem-trie is being loaded.

--- a/chain/chunks/src/logic.rs
+++ b/chain/chunks/src/logic.rs
@@ -1,6 +1,4 @@
-use near_chain::{
-    types::EpochManagerAdapter, validate::validate_chunk_proofs, BlockHeader, Chain, ChainStore,
-};
+use near_chain::{types::EpochManagerAdapter, validate::validate_chunk_proofs, Chain, ChainStore};
 use near_chunks_primitives::Error;
 use near_epoch_manager::shard_tracker::ShardTracker;
 use near_primitives::{
@@ -46,31 +44,6 @@ pub fn cares_about_shard_this_or_next_epoch(
     // TODO(robin-near): I think we only need the shard_tracker if is_me is false.
     shard_tracker.care_about_shard(account_id, parent_hash, shard_id, is_me)
         || shard_tracker.will_care_about_shard(account_id, parent_hash, shard_id, is_me)
-}
-
-pub fn get_shards_cares_about_this_or_next_epoch(
-    account_id: Option<&AccountId>,
-    is_me: bool,
-    block_header: &BlockHeader,
-    shard_tracker: &ShardTracker,
-    epoch_manager: &dyn EpochManagerAdapter,
-) -> Vec<ShardId> {
-    let parent_hash = *block_header.prev_hash();
-    let epoch_id = block_header.epoch_id().clone();
-    epoch_manager
-        .shard_ids(&epoch_id)
-        .unwrap()
-        .into_iter()
-        .filter(|&shard_id| {
-            cares_about_shard_this_or_next_epoch(
-                account_id,
-                &parent_hash,
-                shard_id,
-                is_me,
-                shard_tracker,
-            )
-        })
-        .collect()
 }
 
 pub fn chunk_needs_to_be_fetched_from_archival(

--- a/chain/chunks/src/logic.rs
+++ b/chain/chunks/src/logic.rs
@@ -1,4 +1,6 @@
-use near_chain::{types::EpochManagerAdapter, validate::validate_chunk_proofs, Chain, ChainStore};
+use near_chain::{
+    types::EpochManagerAdapter, validate::validate_chunk_proofs, BlockHeader, Chain, ChainStore,
+};
 use near_chunks_primitives::Error;
 use near_epoch_manager::shard_tracker::ShardTracker;
 use near_primitives::{
@@ -44,6 +46,31 @@ pub fn cares_about_shard_this_or_next_epoch(
     // TODO(robin-near): I think we only need the shard_tracker if is_me is false.
     shard_tracker.care_about_shard(account_id, parent_hash, shard_id, is_me)
         || shard_tracker.will_care_about_shard(account_id, parent_hash, shard_id, is_me)
+}
+
+pub fn get_shards_cares_about_this_or_next_epoch(
+    account_id: Option<&AccountId>,
+    is_me: bool,
+    block_header: &BlockHeader,
+    shard_tracker: &ShardTracker,
+    epoch_manager: &dyn EpochManagerAdapter,
+) -> Vec<ShardId> {
+    let parent_hash = *block_header.prev_hash();
+    let epoch_id = block_header.epoch_id().clone();
+    epoch_manager
+        .shard_ids(&epoch_id)
+        .unwrap()
+        .into_iter()
+        .filter(|&shard_id| {
+            cares_about_shard_this_or_next_epoch(
+                account_id,
+                &parent_hash,
+                shard_id,
+                is_me,
+                shard_tracker,
+            )
+        })
+        .collect()
 }
 
 pub fn chunk_needs_to_be_fetched_from_archival(

--- a/chain/chunks/src/logic.rs
+++ b/chain/chunks/src/logic.rs
@@ -55,16 +55,14 @@ pub fn get_shards_cares_about_this_or_next_epoch(
     shard_tracker: &ShardTracker,
     epoch_manager: &dyn EpochManagerAdapter,
 ) -> Vec<ShardId> {
-    let parent_hash = *block_header.prev_hash();
-    let epoch_id = block_header.epoch_id().clone();
     epoch_manager
-        .shard_ids(&epoch_id)
+        .shard_ids(&block_header.epoch_id())
         .unwrap()
         .into_iter()
         .filter(|&shard_id| {
             cares_about_shard_this_or_next_epoch(
                 account_id,
-                &parent_hash,
+                block_header.prev_hash(),
                 shard_id,
                 is_me,
                 shard_tracker,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -43,7 +43,8 @@ use near_chain_configs::{ClientConfig, LogSummaryStyle, UpdateableClientConfig};
 use near_chunks::adapter::ShardsManagerRequestFromClient;
 use near_chunks::client::ShardedTransactionPool;
 use near_chunks::logic::{
-    cares_about_shard_this_or_next_epoch, decode_encoded_chunk, persist_chunk,
+    cares_about_shard_this_or_next_epoch, decode_encoded_chunk,
+    get_shards_cares_about_this_or_next_epoch, persist_chunk,
 };
 use near_chunks::ShardsManager;
 use near_client_primitives::debug::ChunkProduction;
@@ -2333,13 +2334,15 @@ impl Client {
         let _span = debug_span!(target: "sync", "run_catchup").entered();
         let mut notify_state_sync = false;
         let me = &self.validator_signer.as_ref().map(|x| x.validator_id().clone());
+
         for (sync_hash, state_sync_info) in self.chain.chain_store().iterate_state_sync_infos()? {
             assert_eq!(sync_hash, state_sync_info.epoch_tail_hash);
             let network_adapter = self.network_adapter.clone();
 
             let shards_to_split = self.get_shards_to_split(sync_hash, &state_sync_info, me)?;
             let state_sync_timeout = self.config.state_sync_timeout;
-            let epoch_id = self.chain.get_block(&sync_hash)?.header().epoch_id().clone();
+            let block_header = self.chain.get_block(&sync_hash)?.header().clone();
+            let epoch_id = block_header.epoch_id();
 
             let (state_sync, shards_to_split, blocks_catch_up_state) =
                 self.catchup_state_syncs.entry(sync_hash).or_insert_with(|| {
@@ -2367,9 +2370,27 @@ impl Client {
                 state_sync_info.shards.iter().map(|tuple| tuple.0).collect();
             // Notify each shard to sync.
             if notify_state_sync {
-                for shard_id in &tracking_shards {
-                    let shard_uid =
-                        self.epoch_manager.shard_id_to_uid(*shard_id, &epoch_id).unwrap();
+                let shard_layout = self
+                    .epoch_manager
+                    .get_shard_layout(&epoch_id)
+                    .expect("Cannot get shard layout");
+
+                // Make sure mem-tries for shards we do not care about are unloaded before we start a new state sync.
+                let shards_cares_this_or_next_epoch = get_shards_cares_about_this_or_next_epoch(
+                    me.as_ref(),
+                    true,
+                    &block_header,
+                    &self.shard_tracker,
+                    self.epoch_manager.as_ref(),
+                );
+                let shard_uids: Vec<_> = shards_cares_this_or_next_epoch
+                    .iter()
+                    .map(|id| self.epoch_manager.shard_id_to_uid(*id, &epoch_id).unwrap())
+                    .collect();
+                self.runtime_adapter.retain_mem_tries(&shard_uids);
+
+                for &shard_id in &tracking_shards {
+                    let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
                     match self.state_sync_adapter.clone().read() {
                         Ok(sync_adapter) => sync_adapter.send(
                             shard_uid,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2367,12 +2367,11 @@ impl Client {
                 state_sync_info.shards.iter().map(|tuple| tuple.0).collect();
             // Notify each shard to sync.
             if notify_state_sync {
-                let shard_layout = self
-                    .epoch_manager
-                    .get_shard_layout(&epoch_id)
-                    .expect("Cannot get shard layout");
-                for &shard_id in &tracking_shards {
-                    let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
+                for shard_uid in
+                    self.epoch_manager.shard_ids_to_uids(&tracking_shards, &epoch_id).unwrap()
+                {
+                    // Explicitly unload mem-trie for shard that we start state sync, even if the shard was tracked in the same epoch.
+                    self.runtime_adapter.unload_mem_trie(&shard_uid);
                     match self.state_sync_adapter.clone().read() {
                         Ok(sync_adapter) => sync_adapter.send(
                             shard_uid,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -276,6 +276,7 @@ impl Client {
             chain_config.clone(),
             snapshot_callbacks,
             async_computation_spawner.clone(),
+            validator_signer.as_ref().map(|x| x.validator_id()),
         )?;
         // Create flat storage or initiate migration to flat storage.
         let flat_storage_creator = FlatStorageCreator::new(

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2370,8 +2370,6 @@ impl Client {
                 for shard_id in &tracking_shards {
                     let shard_uid =
                         self.epoch_manager.shard_id_to_uid(*shard_id, &epoch_id).unwrap();
-                    // Explicitly unload mem-trie for shard that we start state sync, even if the shard was tracked in the same epoch.
-                    self.runtime_adapter.unload_mem_trie(&shard_uid);
                     match self.state_sync_adapter.clone().read() {
                         Ok(sync_adapter) => sync_adapter.send(
                             shard_uid,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2367,9 +2367,9 @@ impl Client {
                 state_sync_info.shards.iter().map(|tuple| tuple.0).collect();
             // Notify each shard to sync.
             if notify_state_sync {
-                for shard_uid in
-                    self.epoch_manager.shard_ids_to_uids(&tracking_shards, &epoch_id).unwrap()
-                {
+                for shard_id in &tracking_shards {
+                    let shard_uid =
+                        self.epoch_manager.shard_id_to_uid(*shard_id, &epoch_id).unwrap();
                     // Explicitly unload mem-trie for shard that we start state sync, even if the shard was tracked in the same epoch.
                     self.runtime_adapter.unload_mem_trie(&shard_uid);
                     match self.state_sync_adapter.clone().read() {

--- a/chain/client/src/client_actions.rs
+++ b/chain/client/src/client_actions.rs
@@ -33,7 +33,7 @@ use near_chain::{
 use near_chain_configs::{ClientConfig, LogSummaryStyle};
 use near_chain_primitives::error::EpochErrorResultToChainError;
 use near_chunks::client::ShardsManagerResponse;
-use near_chunks::logic::get_shards_cares_about_this_or_next_epoch;
+use near_chunks::logic::cares_about_shard_this_or_next_epoch;
 use near_client_primitives::types::{
     Error, GetClientConfig, GetClientConfigError, GetNetworkInfo, NetworkInfoResponse,
     StateSyncStatus, Status, StatusError, StatusSyncInfo, SyncStatus,
@@ -1543,20 +1543,30 @@ impl ClientActions {
                         unwrap_and_report!(self.client.chain.get_block_header(&sync_hash));
                     let prev_hash = *block_header.prev_hash();
                     let epoch_id = block_header.epoch_id().clone();
-                    let shards_to_sync = get_shards_cares_about_this_or_next_epoch(
-                        me.as_ref(),
-                        true,
-                        &block_header,
-                        &self.client.shard_tracker,
-                        self.client.epoch_manager.as_ref(),
-                    );
-                    let shard_uids = self
+                    let shards_to_sync: Vec<_> = self
                         .client
                         .epoch_manager
-                        .shard_ids_to_uids(shards_to_sync.as_slice(), &epoch_id)
-                        .unwrap();
+                        .shard_ids(&epoch_id)
+                        .unwrap()
+                        .into_iter()
+                        .filter(|&shard_id| {
+                            cares_about_shard_this_or_next_epoch(
+                                me.as_ref(),
+                                &prev_hash,
+                                shard_id,
+                                true,
+                                &self.client.shard_tracker,
+                            )
+                        })
+                        .collect();
+                    let shard_uids: Vec<_> = shards_to_sync
+                        .iter()
+                        .map(|id| {
+                            self.client.epoch_manager.shard_id_to_uid(*id, &epoch_id).unwrap()
+                        })
+                        .collect();
                     // Make sure mem-tries can be loaded only for shards we care about this or next epoch.
-                    self.client.runtime_adapter.retain_mem_tries(shard_uids.as_slice());
+                    self.client.runtime_adapter.retain_mem_tries(&shard_uids);
 
                     let use_colour =
                         matches!(self.client.config.log_summary_style, LogSummaryStyle::Colored);

--- a/chain/client/src/client_actions.rs
+++ b/chain/client/src/client_actions.rs
@@ -33,7 +33,7 @@ use near_chain::{
 use near_chain_configs::{ClientConfig, LogSummaryStyle};
 use near_chain_primitives::error::EpochErrorResultToChainError;
 use near_chunks::client::ShardsManagerResponse;
-use near_chunks::logic::cares_about_shard_this_or_next_epoch;
+use near_chunks::logic::get_shards_cares_about_this_or_next_epoch;
 use near_client_primitives::types::{
     Error, GetClientConfig, GetClientConfigError, GetNetworkInfo, NetworkInfoResponse,
     StateSyncStatus, Status, StatusError, StatusSyncInfo, SyncStatus,
@@ -1543,22 +1543,20 @@ impl ClientActions {
                         unwrap_and_report!(self.client.chain.get_block_header(&sync_hash));
                     let prev_hash = *block_header.prev_hash();
                     let epoch_id = block_header.epoch_id().clone();
-                    let shards_to_sync: Vec<_> = self
+                    let shards_to_sync = get_shards_cares_about_this_or_next_epoch(
+                        me.as_ref(),
+                        true,
+                        &block_header,
+                        &self.client.shard_tracker,
+                        self.client.epoch_manager.as_ref(),
+                    );
+                    let shard_uids = self
                         .client
                         .epoch_manager
-                        .shard_ids(&epoch_id)
-                        .unwrap()
-                        .into_iter()
-                        .filter(|&shard_id| {
-                            cares_about_shard_this_or_next_epoch(
-                                me.as_ref(),
-                                &prev_hash,
-                                shard_id,
-                                true,
-                                &self.client.shard_tracker,
-                            )
-                        })
-                        .collect();
+                        .shard_ids_to_uids(shards_to_sync.as_slice(), &epoch_id)
+                        .unwrap();
+                    // Make sure mem-tries can be loaded only for shards we care about this or next epoch.
+                    self.client.runtime_adapter.retain_mem_tries(shard_uids.as_slice());
 
                     let use_colour =
                         matches!(self.client.config.log_summary_style, LogSummaryStyle::Colored);

--- a/chain/client/src/client_actions.rs
+++ b/chain/client/src/client_actions.rs
@@ -33,7 +33,7 @@ use near_chain::{
 use near_chain_configs::{ClientConfig, LogSummaryStyle};
 use near_chain_primitives::error::EpochErrorResultToChainError;
 use near_chunks::client::ShardsManagerResponse;
-use near_chunks::logic::cares_about_shard_this_or_next_epoch;
+use near_chunks::logic::get_shards_cares_about_this_or_next_epoch;
 use near_client_primitives::types::{
     Error, GetClientConfig, GetClientConfigError, GetNetworkInfo, NetworkInfoResponse,
     StateSyncStatus, Status, StatusError, StatusSyncInfo, SyncStatus,
@@ -1543,30 +1543,13 @@ impl ClientActions {
                         unwrap_and_report!(self.client.chain.get_block_header(&sync_hash));
                     let prev_hash = *block_header.prev_hash();
                     let epoch_id = block_header.epoch_id().clone();
-                    let shards_to_sync: Vec<_> = self
-                        .client
-                        .epoch_manager
-                        .shard_ids(&epoch_id)
-                        .unwrap()
-                        .into_iter()
-                        .filter(|&shard_id| {
-                            cares_about_shard_this_or_next_epoch(
-                                me.as_ref(),
-                                &prev_hash,
-                                shard_id,
-                                true,
-                                &self.client.shard_tracker,
-                            )
-                        })
-                        .collect();
-                    let shard_uids: Vec<_> = shards_to_sync
-                        .iter()
-                        .map(|id| {
-                            self.client.epoch_manager.shard_id_to_uid(*id, &epoch_id).unwrap()
-                        })
-                        .collect();
-                    // Make sure mem-tries can be loaded only for shards we care about this or next epoch.
-                    self.client.runtime_adapter.retain_mem_tries(&shard_uids);
+                    let shards_to_sync = get_shards_cares_about_this_or_next_epoch(
+                        me.as_ref(),
+                        true,
+                        &block_header,
+                        &self.client.shard_tracker,
+                        self.client.epoch_manager.as_ref(),
+                    );
 
                     let use_colour =
                         matches!(self.client.config.log_summary_style, LogSummaryStyle::Colored);

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -924,6 +924,7 @@ mod tests {
             ChainConfig::test(),
             None,
             Arc::new(RayonAsyncComputationSpawner),
+            None,
         )
         .unwrap();
 

--- a/chain/client/src/sync_jobs_actions.rs
+++ b/chain/client/src/sync_jobs_actions.rs
@@ -81,6 +81,9 @@ impl SyncJobsActions {
     }
 
     pub fn handle_apply_state_parts_request(&mut self, msg: ApplyStatePartsRequest) {
+        // Unload mem-trie (in case it is still loaded) before we apply state parts.
+        msg.runtime_adapter.unload_mem_trie(&msg.shard_uid);
+
         let shard_id = msg.shard_uid.shard_id as ShardId;
         match self.clear_flat_state(&msg) {
             Err(err) => {

--- a/chain/client/src/test_utils/setup.rs
+++ b/chain/client/src/test_utils/setup.rs
@@ -121,6 +121,7 @@ pub fn setup(
         },
         None,
         Arc::new(RayonAsyncComputationSpawner),
+        None,
     )
     .unwrap();
     let genesis_block = chain.get_block(&chain.genesis().hash().clone()).unwrap();
@@ -259,6 +260,7 @@ pub fn setup_only_view(
         },
         None,
         Arc::new(RayonAsyncComputationSpawner),
+        None,
     )
     .unwrap();
 
@@ -1030,6 +1032,7 @@ pub fn setup_synchronous_shards_manager(
         }, // irrelevant
         None,
         Arc::new(RayonAsyncComputationSpawner),
+        None,
     )
     .unwrap();
     let chain_head = chain.head().unwrap();

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -71,13 +71,6 @@ pub trait EpochManagerAdapter: Send + Sync {
         epoch_id: &EpochId,
     ) -> Result<ShardUId, EpochError>;
 
-    /// Converts list of `ShardId` to a list of `ShardUId`.`
-    fn shard_ids_to_uids(
-        &self,
-        shard_ids: &[ShardId],
-        epoch_id: &EpochId,
-    ) -> Result<Vec<ShardUId>, EpochError>;
-
     fn get_block_info(&self, hash: &CryptoHash) -> Result<Arc<BlockInfo>, EpochError>;
 
     fn get_epoch_config(&self, epoch_id: &EpochId) -> Result<EpochConfig, EpochError>;
@@ -528,19 +521,6 @@ impl EpochManagerAdapter for EpochManagerHandle {
         let epoch_manager = self.read();
         let shard_layout = epoch_manager.get_shard_layout(epoch_id)?;
         Ok(ShardUId::from_shard_id_and_layout(shard_id, &shard_layout))
-    }
-
-    fn shard_ids_to_uids(
-        &self,
-        shard_ids: &[ShardId],
-        epoch_id: &EpochId,
-    ) -> Result<Vec<ShardUId>, EpochError> {
-        let epoch_manager = self.read();
-        let shard_layout = epoch_manager.get_shard_layout(epoch_id)?;
-        Ok(shard_ids
-            .iter()
-            .map(|id| ShardUId::from_shard_id_and_layout(*id, &shard_layout))
-            .collect())
     }
 
     fn get_block_info(&self, hash: &CryptoHash) -> Result<Arc<BlockInfo>, EpochError> {

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -71,6 +71,13 @@ pub trait EpochManagerAdapter: Send + Sync {
         epoch_id: &EpochId,
     ) -> Result<ShardUId, EpochError>;
 
+    /// Converts list of `ShardId` to a list of `ShardUId`.`
+    fn shard_ids_to_uids(
+        &self,
+        shard_ids: &[ShardId],
+        epoch_id: &EpochId,
+    ) -> Result<Vec<ShardUId>, EpochError>;
+
     fn get_block_info(&self, hash: &CryptoHash) -> Result<Arc<BlockInfo>, EpochError>;
 
     fn get_epoch_config(&self, epoch_id: &EpochId) -> Result<EpochConfig, EpochError>;
@@ -521,6 +528,19 @@ impl EpochManagerAdapter for EpochManagerHandle {
         let epoch_manager = self.read();
         let shard_layout = epoch_manager.get_shard_layout(epoch_id)?;
         Ok(ShardUId::from_shard_id_and_layout(shard_id, &shard_layout))
+    }
+
+    fn shard_ids_to_uids(
+        &self,
+        shard_ids: &[ShardId],
+        epoch_id: &EpochId,
+    ) -> Result<Vec<ShardUId>, EpochError> {
+        let epoch_manager = self.read();
+        let shard_layout = epoch_manager.get_shard_layout(epoch_id)?;
+        Ok(shard_ids
+            .iter()
+            .map(|id| ShardUId::from_shard_id_and_layout(*id, &shard_layout))
+            .collect())
     }
 
     fn get_block_info(&self, hash: &CryptoHash) -> Result<Arc<BlockInfo>, EpochError> {

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -65,6 +65,8 @@ pub struct StoreConfig {
     pub load_mem_tries_for_shards: Vec<ShardUId>,
     /// If true, load mem tries for all shards; this has priority over `load_mem_tries_for_shards`.
     pub load_mem_tries_for_all_shards: bool,
+    /// If true, load mem trie for each shard being tracked.
+    pub enable_mem_trie_for_tracked_shards: bool,
 
     /// Path where to create RocksDB checkpoints during database migrations or
     /// `false` to disable that feature.
@@ -259,6 +261,7 @@ impl Default for StoreConfig {
             // requires more RAM and takes several minutes on startup.
             load_mem_tries_for_shards: Default::default(),
             load_mem_tries_for_all_shards: false,
+            enable_mem_trie_for_tracked_shards: false,
 
             migration_snapshot: Default::default(),
 

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -66,7 +66,7 @@ pub struct StoreConfig {
     /// If true, load mem tries for all shards; this has priority over `load_mem_tries_for_shards`.
     pub load_mem_tries_for_all_shards: bool,
     /// If true, load mem trie for each shard being tracked.
-    pub enable_mem_trie_for_tracked_shards: bool,
+    pub load_mem_trie_for_tracked_shards: bool,
 
     /// Path where to create RocksDB checkpoints during database migrations or
     /// `false` to disable that feature.
@@ -261,7 +261,7 @@ impl Default for StoreConfig {
             // requires more RAM and takes several minutes on startup.
             load_mem_tries_for_shards: Default::default(),
             load_mem_tries_for_all_shards: false,
-            enable_mem_trie_for_tracked_shards: false,
+            load_mem_trie_for_tracked_shards: false,
 
             migration_snapshot: Default::default(),
 

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -66,7 +66,7 @@ pub struct StoreConfig {
     /// If true, load mem tries for all shards; this has priority over `load_mem_tries_for_shards`.
     pub load_mem_tries_for_all_shards: bool,
     /// If true, load mem trie for each shard being tracked.
-    pub load_mem_trie_for_tracked_shards: bool,
+    pub load_mem_tries_for_tracked_shards: bool,
 
     /// Path where to create RocksDB checkpoints during database migrations or
     /// `false` to disable that feature.
@@ -261,7 +261,7 @@ impl Default for StoreConfig {
             // requires more RAM and takes several minutes on startup.
             load_mem_tries_for_shards: Default::default(),
             load_mem_tries_for_all_shards: false,
-            load_mem_trie_for_tracked_shards: false,
+            load_mem_tries_for_tracked_shards: false,
 
             migration_snapshot: Default::default(),
 

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -63,9 +63,7 @@ pub struct StoreConfig {
     /// TODO(#9511): This does not automatically survive resharding. We may need to figure out a
     /// strategy for that.
     pub load_mem_tries_for_shards: Vec<ShardUId>,
-    /// If true, load mem tries for all shards; this has priority over `load_mem_tries_for_shards`.
-    pub load_mem_tries_for_all_shards: bool,
-    /// If true, load mem trie for each shard being tracked.
+    /// If true, load mem trie for each shard being tracked; this has priority over `load_mem_tries_for_shards`.
     pub load_mem_tries_for_tracked_shards: bool,
 
     /// Path where to create RocksDB checkpoints during database migrations or
@@ -260,7 +258,6 @@ impl Default for StoreConfig {
             // It will speed up processing of shards where it is enabled, but
             // requires more RAM and takes several minutes on startup.
             load_mem_tries_for_shards: Default::default(),
-            load_mem_tries_for_all_shards: false,
             load_mem_tries_for_tracked_shards: false,
 
             migration_snapshot: Default::default(),

--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -147,7 +147,7 @@ impl TestTriesBuilder {
             }
         }
         if self.enable_in_memory_tries {
-            tries.load_mem_tries_for_enabled_shards(&shard_uids).unwrap();
+            tries.load_mem_tries_for_enabled_shards(&shard_uids, Default::default()).unwrap();
         }
         tries
     }

--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -113,7 +113,7 @@ impl TestTriesBuilder {
         let tries = ShardTries::new(
             store,
             TrieConfig {
-                load_mem_tries_for_all_shards: self.enable_in_memory_tries,
+                load_mem_tries_for_tracked_shards: self.enable_in_memory_tries,
                 ..Default::default()
             },
             &shard_uids,
@@ -147,7 +147,7 @@ impl TestTriesBuilder {
             }
         }
         if self.enable_in_memory_tries {
-            tries.load_mem_tries_for_enabled_shards(&shard_uids, Default::default()).unwrap();
+            tries.load_mem_tries_for_enabled_shards(&shard_uids).unwrap();
         }
         tries
     }

--- a/core/store/src/trie/config.rs
+++ b/core/store/src/trie/config.rs
@@ -35,7 +35,7 @@ pub struct TrieConfig {
     pub load_mem_tries_for_shards: Vec<ShardUId>,
     pub load_mem_tries_for_all_shards: bool,
     /// Whether mem-trie should be loaded for each tracked shard.
-    pub load_mem_trie_for_tracked_shards: bool,
+    pub load_mem_tries_for_tracked_shards: bool,
 }
 
 impl TrieConfig {
@@ -61,7 +61,7 @@ impl TrieConfig {
         }
         this.load_mem_tries_for_shards = config.load_mem_tries_for_shards.clone();
         this.load_mem_tries_for_all_shards = config.load_mem_tries_for_all_shards;
-        this.load_mem_trie_for_tracked_shards = config.load_mem_trie_for_tracked_shards;
+        this.load_mem_tries_for_tracked_shards = config.load_mem_tries_for_tracked_shards;
 
         this
     }

--- a/core/store/src/trie/config.rs
+++ b/core/store/src/trie/config.rs
@@ -34,6 +34,8 @@ pub struct TrieConfig {
     /// List of shards we will load into memory.
     pub load_mem_tries_for_shards: Vec<ShardUId>,
     pub load_mem_tries_for_all_shards: bool,
+    /// Whether mem-trie should be loaded for each tracked shard.
+    pub enable_mem_trie_for_tracked_shards: bool,
 }
 
 impl TrieConfig {
@@ -59,6 +61,7 @@ impl TrieConfig {
         }
         this.load_mem_tries_for_shards = config.load_mem_tries_for_shards.clone();
         this.load_mem_tries_for_all_shards = config.load_mem_tries_for_all_shards;
+        this.enable_mem_trie_for_tracked_shards = config.enable_mem_trie_for_tracked_shards;
 
         this
     }

--- a/core/store/src/trie/config.rs
+++ b/core/store/src/trie/config.rs
@@ -35,7 +35,7 @@ pub struct TrieConfig {
     pub load_mem_tries_for_shards: Vec<ShardUId>,
     pub load_mem_tries_for_all_shards: bool,
     /// Whether mem-trie should be loaded for each tracked shard.
-    pub enable_mem_trie_for_tracked_shards: bool,
+    pub load_mem_trie_for_tracked_shards: bool,
 }
 
 impl TrieConfig {
@@ -61,7 +61,7 @@ impl TrieConfig {
         }
         this.load_mem_tries_for_shards = config.load_mem_tries_for_shards.clone();
         this.load_mem_tries_for_all_shards = config.load_mem_tries_for_all_shards;
-        this.enable_mem_trie_for_tracked_shards = config.enable_mem_trie_for_tracked_shards;
+        this.load_mem_trie_for_tracked_shards = config.load_mem_trie_for_tracked_shards;
 
         this
     }

--- a/core/store/src/trie/config.rs
+++ b/core/store/src/trie/config.rs
@@ -33,7 +33,6 @@ pub struct TrieConfig {
     pub sweat_prefetch_senders: Vec<AccountId>,
     /// List of shards we will load into memory.
     pub load_mem_tries_for_shards: Vec<ShardUId>,
-    pub load_mem_tries_for_all_shards: bool,
     /// Whether mem-trie should be loaded for each tracked shard.
     pub load_mem_tries_for_tracked_shards: bool,
 }
@@ -60,7 +59,6 @@ impl TrieConfig {
             }
         }
         this.load_mem_tries_for_shards = config.load_mem_tries_for_shards.clone();
-        this.load_mem_tries_for_all_shards = config.load_mem_tries_for_all_shards;
         this.load_mem_tries_for_tracked_shards = config.load_mem_tries_for_tracked_shards;
 
         this

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -385,12 +385,17 @@ impl ShardTries {
 
     /// Remove trie from memory for shards not included in the given list.
     pub fn retain_mem_tries(&self, shard_uids: &[ShardUId]) {
+        info!(target: "memtrie", "Current memtries: {:?}. Keeping memtries for shards {:?}...",
+            self.0.mem_tries.read().unwrap().keys(), shard_uids);
         self.0.mem_tries.write().unwrap().retain(|shard_uid, _| shard_uids.contains(shard_uid));
+        info!(target: "memtrie", "Memtries retaining complete for shards {:?}", shard_uids);
     }
 
     /// Remove trie from memory for given shard.
     pub fn unload_mem_trie(&self, shard_uid: &ShardUId) {
+        info!(target: "memtrie", "Unloading trie from memory for shard {:?}...", shard_uid);
         self.0.mem_tries.write().unwrap().remove(shard_uid);
+        info!(target: "memtrie", "Memtrie unloading complete for shard {:?}", shard_uid);
     }
 
     /// Loads in-memory-trie for given shard and state root (if given).
@@ -399,8 +404,10 @@ impl ShardTries {
         shard_uid: &ShardUId,
         state_root: Option<StateRoot>,
     ) -> Result<(), StorageError> {
+        info!(target: "memtrie", "Loading trie to memory for shard {:?}...", shard_uid);
         let mem_tries = load_trie_from_flat_state_and_delta(&self.0.store, *shard_uid, state_root)?;
         self.0.mem_tries.write().unwrap().insert(*shard_uid, Arc::new(RwLock::new(mem_tries)));
+        info!(target: "memtrie", "Memtrie loading complete for shard {:?}", shard_uid);
         Ok(())
     }
 
@@ -725,7 +732,7 @@ mod test {
             sweat_prefetch_senders: Vec::new(),
             load_mem_tries_for_shards: Vec::new(),
             load_mem_tries_for_all_shards: false,
-            load_mem_trie_for_tracked_shards: false,
+            load_mem_tries_for_tracked_shards: false,
         };
         let shard_uids = Vec::from([ShardUId::single_shard()]);
         ShardTries::new(
@@ -846,7 +853,7 @@ mod test {
             sweat_prefetch_senders: Vec::new(),
             load_mem_tries_for_shards: Vec::new(),
             load_mem_tries_for_all_shards: false,
-            load_mem_trie_for_tracked_shards: false,
+            load_mem_tries_for_tracked_shards: false,
         };
         let shard_uids = Vec::from([ShardUId { shard_id: 0, version: 0 }]);
         let shard_uid = *shard_uids.first().unwrap();

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -404,12 +404,9 @@ impl ShardTries {
         Ok(())
     }
 
-    /// Should be called on upon catchup to decide whether to load mem-trie for the shard.
-    pub fn should_load_mem_trie_on_catchup(&self, shard_uid: &ShardUId) -> bool {
-        if !self.0.trie_config.enable_mem_trie_for_tracked_shards {
-            return false;
-        }
-        !self.0.mem_tries.read().unwrap().contains_key(shard_uid)
+    /// Returns whether mem-trie is loaded for the given shard.
+    pub fn is_mem_trie_loaded(&self, shard_uid: &ShardUId) -> bool {
+        self.0.mem_tries.read().unwrap().contains_key(shard_uid)
     }
 
     /// Should be called upon startup to load in-memory tries for enabled shards.
@@ -728,7 +725,7 @@ mod test {
             sweat_prefetch_senders: Vec::new(),
             load_mem_tries_for_shards: Vec::new(),
             load_mem_tries_for_all_shards: false,
-            enable_mem_trie_for_tracked_shards: false,
+            load_mem_trie_for_tracked_shards: false,
         };
         let shard_uids = Vec::from([ShardUId::single_shard()]);
         ShardTries::new(
@@ -849,7 +846,7 @@ mod test {
             sweat_prefetch_senders: Vec::new(),
             load_mem_tries_for_shards: Vec::new(),
             load_mem_tries_for_all_shards: false,
-            enable_mem_trie_for_tracked_shards: false,
+            load_mem_trie_for_tracked_shards: false,
         };
         let shard_uids = Vec::from([ShardUId { shard_id: 0, version: 0 }]);
         let shard_uid = *shard_uids.first().unwrap();

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -419,15 +419,18 @@ impl ShardTries {
     /// Should be called upon startup to load in-memory tries for enabled shards.
     pub fn load_mem_tries_for_enabled_shards(
         &self,
-        shard_uids: &[ShardUId],
+        all_shards: &[ShardUId],
+        tracked_shards: &[ShardUId],
     ) -> Result<(), StorageError> {
         let trie_config = &self.0.trie_config;
-        let shard_uids_to_load = shard_uids
+        let shard_uids_to_load = all_shards
             .iter()
             .copied()
             .filter(|shard_uid| {
                 trie_config.load_mem_tries_for_all_shards
                     || trie_config.load_mem_tries_for_shards.contains(shard_uid)
+                    || (trie_config.load_mem_tries_for_tracked_shards
+                        && tracked_shards.contains(shard_uid))
             })
             .collect::<Vec<_>>();
 

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -419,18 +419,15 @@ impl ShardTries {
     /// Should be called upon startup to load in-memory tries for enabled shards.
     pub fn load_mem_tries_for_enabled_shards(
         &self,
-        all_shards: &[ShardUId],
         tracked_shards: &[ShardUId],
     ) -> Result<(), StorageError> {
         let trie_config = &self.0.trie_config;
-        let shard_uids_to_load = all_shards
+        let shard_uids_to_load = tracked_shards
             .iter()
             .copied()
             .filter(|shard_uid| {
-                trie_config.load_mem_tries_for_all_shards
+                trie_config.load_mem_tries_for_tracked_shards
                     || trie_config.load_mem_tries_for_shards.contains(shard_uid)
-                    || (trie_config.load_mem_tries_for_tracked_shards
-                        && tracked_shards.contains(shard_uid))
             })
             .collect::<Vec<_>>();
 
@@ -734,7 +731,6 @@ mod test {
             sweat_prefetch_receivers: Vec::new(),
             sweat_prefetch_senders: Vec::new(),
             load_mem_tries_for_shards: Vec::new(),
-            load_mem_tries_for_all_shards: false,
             load_mem_tries_for_tracked_shards: false,
         };
         let shard_uids = Vec::from([ShardUId::single_shard()]);
@@ -855,7 +851,6 @@ mod test {
             sweat_prefetch_receivers: Vec::new(),
             sweat_prefetch_senders: Vec::new(),
             load_mem_tries_for_shards: Vec::new(),
-            load_mem_tries_for_all_shards: false,
             load_mem_tries_for_tracked_shards: false,
         };
         let shard_uids = Vec::from([ShardUId { shard_id: 0, version: 0 }]);

--- a/integration-tests/src/genesis_helpers.rs
+++ b/integration-tests/src/genesis_helpers.rs
@@ -38,6 +38,7 @@ pub fn genesis_header(genesis: &Genesis) -> BlockHeader {
         ChainConfig::test(),
         None,
         Arc::new(RayonAsyncComputationSpawner),
+        None,
     )
     .unwrap();
     chain.genesis().clone()
@@ -63,6 +64,7 @@ pub fn genesis_block(genesis: &Genesis) -> Block {
         ChainConfig::test(),
         None,
         Arc::new(RayonAsyncComputationSpawner),
+        None,
     )
     .unwrap();
     chain.get_block(&chain.genesis().hash().clone()).unwrap()

--- a/integration-tests/src/tests/client/features/multinode_test_loop_example.rs
+++ b/integration-tests/src/tests/client/features/multinode_test_loop_example.rs
@@ -239,7 +239,7 @@ fn test_client_with_multi_test_loop() {
             contract_cache,
             &genesis.config,
             epoch_manager.clone(),
-            TrieConfig { load_mem_tries_for_all_shards: true, ..Default::default() },
+            TrieConfig { load_mem_tries_for_tracked_shards: true, ..Default::default() },
             StateSnapshotType::ForReshardingOnly,
         );
 

--- a/integration-tests/src/tests/client/state_snapshot.rs
+++ b/integration-tests/src/tests/client/state_snapshot.rs
@@ -45,7 +45,7 @@ impl StateSnaptshotTestEnv {
             sweat_prefetch_senders: Vec::new(),
             load_mem_tries_for_shards: Vec::new(),
             load_mem_tries_for_all_shards: false,
-            load_mem_trie_for_tracked_shards: false,
+            load_mem_tries_for_tracked_shards: false,
         };
         let flat_storage_manager = FlatStorageManager::new(store.clone());
         let shard_uids = [ShardUId::single_shard()];

--- a/integration-tests/src/tests/client/state_snapshot.rs
+++ b/integration-tests/src/tests/client/state_snapshot.rs
@@ -45,7 +45,7 @@ impl StateSnaptshotTestEnv {
             sweat_prefetch_senders: Vec::new(),
             load_mem_tries_for_shards: Vec::new(),
             load_mem_tries_for_all_shards: false,
-            enable_mem_trie_for_tracked_shards: false,
+            load_mem_trie_for_tracked_shards: false,
         };
         let flat_storage_manager = FlatStorageManager::new(store.clone());
         let shard_uids = [ShardUId::single_shard()];

--- a/integration-tests/src/tests/client/state_snapshot.rs
+++ b/integration-tests/src/tests/client/state_snapshot.rs
@@ -45,6 +45,7 @@ impl StateSnaptshotTestEnv {
             sweat_prefetch_senders: Vec::new(),
             load_mem_tries_for_shards: Vec::new(),
             load_mem_tries_for_all_shards: false,
+            enable_mem_trie_for_tracked_shards: false,
         };
         let flat_storage_manager = FlatStorageManager::new(store.clone());
         let shard_uids = [ShardUId::single_shard()];

--- a/integration-tests/src/tests/client/state_snapshot.rs
+++ b/integration-tests/src/tests/client/state_snapshot.rs
@@ -44,7 +44,6 @@ impl StateSnaptshotTestEnv {
             sweat_prefetch_receivers: Vec::new(),
             sweat_prefetch_senders: Vec::new(),
             load_mem_tries_for_shards: Vec::new(),
-            load_mem_tries_for_all_shards: false,
             load_mem_tries_for_tracked_shards: false,
         };
         let flat_storage_manager = FlatStorageManager::new(store.clone());

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -320,7 +320,7 @@ impl ForkNetworkCommand {
         let runtime =
             NightshadeRuntime::from_config(home_dir, store.clone(), &near_config, epoch_manager)
                 .context("could not create the transaction runtime")?;
-        runtime.load_mem_tries_on_startup(&all_shard_uids).unwrap();
+        runtime.load_mem_tries_on_startup(&all_shard_uids, Default::default()).unwrap();
 
         let make_storage_mutator: MakeSingleShardStorageMutatorFn =
             Arc::new(move |prev_state_root| {

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -303,7 +303,7 @@ impl ForkNetworkCommand {
         home_dir: &Path,
     ) -> anyhow::Result<Vec<StateRoot>> {
         // Open storage with migration
-        near_config.config.store.load_mem_tries_for_all_shards = true;
+        near_config.config.store.load_mem_tries_for_tracked_shards = true;
         let storage = open_storage(&home_dir, near_config).unwrap();
         let store = storage.get_hot_store();
 
@@ -320,7 +320,7 @@ impl ForkNetworkCommand {
         let runtime =
             NightshadeRuntime::from_config(home_dir, store.clone(), &near_config, epoch_manager)
                 .context("could not create the transaction runtime")?;
-        runtime.load_mem_tries_on_startup(&all_shard_uids, Default::default()).unwrap();
+        runtime.load_mem_tries_on_startup(&all_shard_uids).unwrap();
 
         let make_storage_mutator: MakeSingleShardStorageMutatorFn =
             Arc::new(move |prev_state_root| {

--- a/tools/speedy_sync/src/main.rs
+++ b/tools/speedy_sync/src/main.rs
@@ -255,6 +255,7 @@ fn load_snapshot(load_cmd: LoadCmd) {
         },
         None,
         Arc::new(RayonAsyncComputationSpawner),
+        None,
     )
     .unwrap();
 


### PR DESCRIPTION
**Issue**: https://github.com/near/nearcore/issues/10564

**Summary**
Adds logic to load / unload in-memory tries that works with state sync. Enables in-memory trie with single shard tracking.

**Changes**
- Add optional `state_root` parameter for memtrie loading logic - it's needed when we cannot read the state root from chunk extra.
- Add `load_mem_tries_for_tracked_shards` config parameter.
- Add methods for loading / unloading in-memory tries.
- Remove obsolete tries from memory before each new state sync.

**Follow up tasks**
- Add shard assignment shuffling every epoch for StatelessNet: https://github.com/near/nearcore/issues/10845.
- Make sure the logic works well with resharding, and state is fully GC-ed, add integration tests: https://github.com/near/nearcore/issues/10844.