### PR TITLE
congestion: workloads with big receipts

### DIFF
--- a/tools/congestion-model/src/main.rs
+++ b/tools/congestion-model/src/main.rs
@@ -133,6 +133,10 @@ fn workload(workload_name: &str) -> Box<dyn Producer> {
             // Transform the tx to a small local receipt which produces 3 large receipts to another shard.
             Box::new(BalancedProducer::with_sizes_and_fan_out(vec![100, 1_000_000], 3))
         }
+        "Extreme Increasing Size" => {
+            // Produce 50 big receipts instead of 3 as in "Increasing Size"
+            Box::new(BalancedProducer::with_sizes_and_fan_out(vec![100, 2_000_000], 10))
+        }
         "Shard War" => {
             // Each shard transforms one local tx into 4^3 = 64 receipts of 100kB to another shard
             Box::new(BalancedProducer::with_sizes_and_fan_out(vec![100, 100, 100, 100_000], 4))
@@ -140,6 +144,7 @@ fn workload(workload_name: &str) -> Box<dyn Producer> {
         "All To One" => Box::new(AllForOneProducer::one_hop_only()),
         "Indirect All To One" => Box::<AllForOneProducer>::default(),
         "Linear Imbalance" => Box::<LinearImbalanceProducer>::default(),
+        "Big Linear Imbalance" => Box::new(LinearImbalanceProducer::big_receipts()),
         _ => panic!("unknown workload: {}", workload_name),
     }
 }
@@ -166,10 +171,12 @@ fn parse_workload_names(workload_name: &str) -> Vec<String> {
     let available: Vec<String> = vec![
         "Balanced".to_string(),
         "Increasing Size".to_string(),
+        "Extreme Increasing Size".to_string(),
         "Shard War".to_string(),
         "All To One".to_string(),
         "Indirect All To One".to_string(),
         "Linear Imbalance".to_string(),
+        "Big Linear Imbalance".to_string(),
     ];
 
     if workload_name == "all" {

--- a/tools/congestion-model/src/workload/balanced.rs
+++ b/tools/congestion-model/src/workload/balanced.rs
@@ -74,7 +74,7 @@ impl BalancedProducer {
         let attached_gas = 300 * TGAS;
         let execution_gas = 100 * TGAS;
         let conversion_gas = 5 * TGAS;
-        let num_tx_per_shard_pair = 2;
+        let num_tx_per_shard_pair = 4;
         Self::new(
             attached_gas,
             execution_gas,
@@ -96,7 +96,10 @@ impl BalancedProducer {
         assert!(!receipt_sizes.is_empty(), "must have at least one receipt size");
         assert!(execution_gas <= attached_gas, "must attach more gas than is needed for execution");
         let depth = receipt_sizes.len();
-        let num_receipts = fan_out.pow(depth as u32 - 1);
+        let mut num_receipts = 1;
+        for d in 1..depth {
+            num_receipts += fan_out.pow(d as u32);
+        }
         let execution_gas_per_receipt = execution_gas / num_receipts as u64;
 
         let mut attached_gas_per_depth = vec![attached_gas];

--- a/tools/congestion-model/src/workload/linear_imbalance.rs
+++ b/tools/congestion-model/src/workload/linear_imbalance.rs
@@ -52,7 +52,7 @@ impl Producer for LinearImbalanceProducer {
                         receiver,
                         size: self.receipt_size,
                         attached_gas: self.attached_gas,
-                        execution_gas: self.attached_gas,
+                        execution_gas: self.execution_gas,
                     };
                     let mut tx = tx_factory(sender_id);
                     let main_receipt_id = tx.add_first_receipt(main_receipt, self.conversion_gas);
@@ -63,6 +63,17 @@ impl Producer for LinearImbalanceProducer {
             }
         }
         all_tx
+    }
+}
+
+impl LinearImbalanceProducer {
+    pub fn big_receipts() -> Self {
+        Self {
+            receipt_size: 2_000_000,
+            attached_gas: 5 * TGAS,
+            execution_gas: 5 * TGAS,
+            ..Self::default()
+        }
     }
 }
 


### PR DESCRIPTION
Two more workloads to really push the limits of large receipts with low gas.

Below are the results I'm getting for them with the current settings.
Note how the "no queue" strategy has 61 GB and 373 GB delayed receipts.
But even the traffic light strategy goes up to 1.5 GB and 2 GB.

```txt
WORKLOAD                 STRATEGY             BURNT GAS  TRANSACTIONS FINISHED MEAN TX DELAY   MAX QUEUE LEN  MAX QUEUE SIZE  MAX QUEUE PGAS
Extreme Increasing Size  No queues            4010 PGas                  34928           228           68955         61.6 GB            2161
Extreme Increasing Size  Global TX stop       4022 PGas                  37313           212           14169         13.2 GB             230
Extreme Increasing Size  Simple backpressure   264 PGas                   2350            16            8003          7.0 GB             135
Extreme Increasing Size  New TX last          4017 PGas                  37350           210            3853          3.5 GB              88
Extreme Increasing Size  Traffic Light        3861 PGas                  35920             7            1564          1.5 GB              30
Big Linear Imbalance     No queues            3850 PGas                 316472           299          211699        373.6 GB             939
Big Linear Imbalance     Global TX stop       2298 PGas                 317524           232            2063          3.2 GB               8
Big Linear Imbalance     Simple backpressure  3843 PGas                 530217           217            2646          4.7 GB              11
Big Linear Imbalance     New TX last          4001 PGas                 553279           180             490        800.0 MB               2
Big Linear Imbalance     Traffic Light        3964 PGas                 546499            10            1525          2.0 GB               4
```