### PR TITLE
vm: `AnyCache`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3108,11 +3108,20 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.5"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32613e41de4c47ab04970c348ca7ae7382cf116625755af070b008a15516a889"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
- "hashbrown 0.11.2",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+dependencies = [
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -3440,7 +3449,7 @@ name = "near-cache"
 version = "0.0.0"
 dependencies = [
  "bencher",
- "lru",
+ "lru 0.7.8",
  "rand",
 ]
 
@@ -3459,7 +3468,7 @@ dependencies = [
  "insta",
  "itertools",
  "itoa",
- "lru",
+ "lru 0.7.8",
  "near-async",
  "near-cache",
  "near-chain-configs",
@@ -3540,7 +3549,7 @@ dependencies = [
  "derive_more",
  "futures",
  "itertools",
- "lru",
+ "lru 0.7.8",
  "near-async",
  "near-chain",
  "near-chain-configs",
@@ -3586,7 +3595,7 @@ dependencies = [
  "derive_more",
  "futures",
  "itertools",
- "lru",
+ "lru 0.7.8",
  "near-actix-test-utils",
  "near-async",
  "near-cache",
@@ -4037,7 +4046,7 @@ dependencies = [
  "futures-util",
  "im",
  "itertools",
- "lru",
+ "lru 0.7.8",
  "near-async",
  "near-crypto",
  "near-fmt",
@@ -4361,7 +4370,7 @@ dependencies = [
  "insta",
  "itertools",
  "itoa",
- "lru",
+ "lru 0.7.8",
  "near-async",
  "near-chain",
  "near-chain-configs",
@@ -4520,7 +4529,7 @@ dependencies = [
  "expect-test",
  "finite-wasm",
  "hex",
- "lru",
+ "lru 0.12.3",
  "memoffset 0.8.0",
  "near-crypto",
  "near-parameters",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4520,6 +4520,7 @@ dependencies = [
  "expect-test",
  "finite-wasm",
  "hex",
+ "lru",
  "memoffset 0.8.0",
  "near-crypto",
  "near-parameters",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,6 +1291,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "cov-mark"
+version = "2.0.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d48d8f76bd9331f19fe2aaf3821a9f9fb32c3963e1e3d6ce82a8c09cef7444a"
+
+[[package]]
 name = "cpp_demangle"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4524,6 +4530,7 @@ dependencies = [
  "base64 0.21.0",
  "bolero",
  "borsh 1.0.0",
+ "cov-mark",
  "ed25519-dalek",
  "enum-map",
  "expect-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ borsh = { version = "1.0.0", features = ["derive", "rc"] }
 bs58 = "0.4"
 bytes = "1"
 bytesize = { version = "1.1", features = ["serde"] }
+cov-mark = "2.0.0-pre.1"
 cargo_metadata = "0.14.1"
 cc = "1.0"
 cfg-if = "1.0"

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -195,9 +195,8 @@ impl NightshadeRuntime {
         Self::test_with_runtime_config_store(
             home_dir,
             store,
-            FilesystemContractRuntimeCache::new(home_dir, None::<&str>)
+            FilesystemContractRuntimeCache::with_memory_cache(home_dir, None::<&str>, 1)
                 .expect("filesystem contract cache")
-                .with_memory_cache(1)
                 .handle(),
             genesis_config,
             epoch_manager,

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -43,7 +43,7 @@ use near_store::{
     TrieUpdate, WrappedTrieChanges, COLD_HEAD_KEY,
 };
 use near_vm_runner::ContractCode;
-use near_vm_runner::{precompile_contract, CompiledContractCache, FilesystemCompiledContractCache};
+use near_vm_runner::{precompile_contract, ContractRuntimeCache, FilesystemContractRuntimeCache};
 use node_runtime::adapter::ViewRuntimeAdapter;
 use node_runtime::state_viewer::TrieViewer;
 use node_runtime::{
@@ -68,7 +68,7 @@ pub struct NightshadeRuntime {
     runtime_config_store: RuntimeConfigStore,
 
     store: Store,
-    compiled_contract_cache: Box<dyn CompiledContractCache>,
+    compiled_contract_cache: Box<dyn ContractRuntimeCache>,
     tries: ShardTries,
     trie_viewer: TrieViewer,
     pub runtime: Runtime,
@@ -80,7 +80,7 @@ pub struct NightshadeRuntime {
 impl NightshadeRuntime {
     pub fn new(
         store: Store,
-        compiled_contract_cache: Box<dyn CompiledContractCache>,
+        compiled_contract_cache: Box<dyn ContractRuntimeCache>,
         genesis_config: &GenesisConfig,
         epoch_manager: Arc<EpochManagerHandle>,
         trie_viewer_state_size_limit: Option<u64>,
@@ -133,7 +133,7 @@ impl NightshadeRuntime {
     pub fn test_with_runtime_config_store(
         home_dir: &Path,
         store: Store,
-        compiled_contract_cache: Box<dyn CompiledContractCache>,
+        compiled_contract_cache: Box<dyn ContractRuntimeCache>,
         genesis_config: &GenesisConfig,
         epoch_manager: Arc<EpochManagerHandle>,
         runtime_config_store: RuntimeConfigStore,
@@ -161,7 +161,7 @@ impl NightshadeRuntime {
     pub fn test_with_trie_config(
         home_dir: &Path,
         store: Store,
-        compiled_contract_cache: Box<dyn CompiledContractCache>,
+        compiled_contract_cache: Box<dyn ContractRuntimeCache>,
         genesis_config: &GenesisConfig,
         epoch_manager: Arc<EpochManagerHandle>,
         trie_config: TrieConfig,
@@ -195,7 +195,7 @@ impl NightshadeRuntime {
         Self::test_with_runtime_config_store(
             home_dir,
             store,
-            FilesystemCompiledContractCache::new(home_dir, None::<&str>)
+            FilesystemContractRuntimeCache::new(home_dir, None::<&str>)
                 .expect("filesystem contract cache")
                 .handle(),
             genesis_config,
@@ -463,7 +463,7 @@ impl NightshadeRuntime {
         .entered();
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(epoch_id)?;
         let runtime_config = self.runtime_config_store.get_config(protocol_version);
-        let compiled_contract_cache: Option<Box<dyn CompiledContractCache>> =
+        let compiled_contract_cache: Option<Box<dyn ContractRuntimeCache>> =
             Some(Box::new(self.compiled_contract_cache.handle()));
         // Execute precompile_contract in parallel but prevent it from using more than half of all
         // threads so that node will still function normally.

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -197,6 +197,7 @@ impl NightshadeRuntime {
             store,
             FilesystemContractRuntimeCache::new(home_dir, None::<&str>)
                 .expect("filesystem contract cache")
+                .with_memory_cache(1)
                 .handle(),
             genesis_config,
             epoch_manager,

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -198,7 +198,7 @@ impl TestEnv {
             if config.zero_fees { RuntimeConfigStore::free() } else { RuntimeConfigStore::test() };
 
         let compiled_contract_cache =
-            FilesystemCompiledContractCache::new(&dir.as_ref(), None::<&str>).unwrap();
+            FilesystemContractRuntimeCache::new(&dir.as_ref(), None::<&str>).unwrap();
 
         initialize_genesis_state(store.clone(), &genesis, Some(dir.path()));
         let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
@@ -1461,7 +1461,7 @@ fn test_genesis_hash() {
     let runtime = NightshadeRuntime::test_with_runtime_config_store(
         tempdir.path(),
         store.clone(),
-        FilesystemCompiledContractCache::new(tempdir.path(), None::<&str>)
+        FilesystemContractRuntimeCache::new(tempdir.path(), None::<&str>)
             .expect("filesystem contract cache")
             .handle(),
         &genesis.config,

--- a/chain/client/src/test_utils/test_env_builder.rs
+++ b/chain/client/src/test_utils/test_env_builder.rs
@@ -20,7 +20,7 @@ use near_primitives::types::{AccountId, NumShards};
 use near_store::config::StateSnapshotType;
 use near_store::test_utils::create_test_store;
 use near_store::{NodeStorage, ShardUId, Store, StoreConfig, TrieConfig};
-use near_vm_runner::{CompiledContractCache, FilesystemCompiledContractCache};
+use near_vm_runner::{ContractRuntimeCache, FilesystemContractRuntimeCache};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -48,7 +48,7 @@ pub struct TestEnvBuilder {
     validators: Vec<AccountId>,
     home_dirs: Option<Vec<PathBuf>>,
     stores: Option<Vec<Store>>,
-    contract_caches: Option<Vec<Box<dyn CompiledContractCache>>>,
+    contract_caches: Option<Vec<Box<dyn ContractRuntimeCache>>>,
     epoch_managers: Option<Vec<EpochManagerKind>>,
     shard_trackers: Option<Vec<ShardTracker>>,
     runtimes: Option<Vec<Arc<dyn RuntimeAdapter>>>,
@@ -169,7 +169,7 @@ impl TestEnvBuilder {
         self
     }
 
-    pub fn contract_caches<C: CompiledContractCache>(
+    pub fn contract_caches<C: ContractRuntimeCache>(
         mut self,
         caches: impl IntoIterator<Item = C>,
     ) -> Self {
@@ -217,7 +217,7 @@ impl TestEnvBuilder {
             return self;
         }
         let count = self.clients.len();
-        self.contract_caches((0..count).map(|_| FilesystemCompiledContractCache::test().unwrap()))
+        self.contract_caches((0..count).map(|_| FilesystemContractRuntimeCache::test().unwrap()))
     }
 
     /// Specifies custom EpochManagerHandle for each client.  This allows us to
@@ -310,7 +310,7 @@ impl TestEnvBuilder {
         nightshade_runtime_creator: impl Fn(
             PathBuf,
             Store,
-            Box<dyn CompiledContractCache>,
+            Box<dyn ContractRuntimeCache>,
             Arc<EpochManagerHandle>,
             RuntimeConfigStore,
             TrieConfig,

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -98,7 +98,7 @@ pub struct ViewApplyState {
     /// Current Protocol version when we apply the state transition
     pub current_protocol_version: ProtocolVersion,
     /// Cache for compiled contracts.
-    pub cache: Option<Box<dyn near_vm_runner::CompiledContractCache>>,
+    pub cache: Option<Box<dyn near_vm_runner::ContractRuntimeCache>>,
 }
 
 impl From<&Account> for AccountView {

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -235,7 +235,7 @@ pub enum DBCol {
     /// - *Rows*: receipt (CryptoHash)
     /// - *Column type*: Receipt
     Receipts,
-    /// Precompiled machine code of the contract, used by StoreCompiledContractCache.
+    /// Precompiled machine code of the contract, used by StoreContractRuntimeCache.
     /// - *Rows*: ContractCacheKey or code hash (not sure)
     /// - *Column type*: near-vm-runner CacheRecord
     CachedContractCode,

--- a/deny.toml
+++ b/deny.toml
@@ -98,9 +98,7 @@ skip = [
     { name = "windows-targets", version = "=0.42.1" },
 
     # ed25519-dalek uses older versions of rand and rand_core
-    { name = "rand", version = "=0.7.3" },
     { name = "rand_core", version = "=0.5.1" },
-    { name = "rand_chacha", version = "=0.2.2" },
     { name = "getrandom", version = "=0.1.16" },
 
     # criterion and criterion-plot use conflicting versions
@@ -137,9 +135,6 @@ skip = [
     # rust-s3 is using an old version of smartstring
     { name = "smartstring", version = "=0.2.10" },
 
-    # validator 0.12 ~ 0.16 is still using an old version of idna
-    { name = "idna", version = "=0.2.3" },
-
     # zeropool-bn uses borsh 0.9
     { name = "borsh", version = "=0.9.3" },
     { name = "borsh-derive", version = "=0.9.3" },
@@ -159,4 +154,7 @@ skip = [
     # cloud-storage
     { name = "base64", version = "=0.12.3" },
     { name = "num-bigint", version = "=0.2.6" },
+
+    # Everything depends on this...
+    { name = "lru", version = "=0.7.8" },
 ]

--- a/integration-tests/src/tests/client/features/multinode_test_loop_example.rs
+++ b/integration-tests/src/tests/client/features/multinode_test_loop_example.rs
@@ -61,8 +61,8 @@ use near_store::config::StateSnapshotType;
 use near_store::genesis::initialize_genesis_state;
 use near_store::test_utils::create_test_store;
 use near_store::TrieConfig;
-use near_vm_runner::CompiledContractCache;
-use near_vm_runner::FilesystemCompiledContractCache;
+use near_vm_runner::ContractRuntimeCache;
+use near_vm_runner::FilesystemContractRuntimeCache;
 use nearcore::NightshadeRuntime;
 use std::collections::HashMap;
 use std::path::Path;
@@ -229,7 +229,7 @@ fn test_client_with_multi_test_loop() {
             builder.sender().for_index(idx).into_sender(),
         )));
         let home_dir = Path::new(".");
-        let contract_cache = FilesystemCompiledContractCache::new(home_dir, None::<&str>)
+        let contract_cache = FilesystemContractRuntimeCache::new(home_dir, None::<&str>)
             .expect("filesystem contract cache")
             .handle();
         let runtime_adapter = NightshadeRuntime::test_with_trie_config(

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -3381,8 +3381,9 @@ mod contract_precompilation_tests {
     use near_primitives::test_utils::MockEpochInfoProvider;
     use near_primitives::views::ViewApplyState;
     use near_store::TrieUpdate;
-    use near_vm_runner::CompiledContractCache;
-    use near_vm_runner::{get_contract_cache_key, ContractCode, FilesystemCompiledContractCache};
+    use near_vm_runner::{
+        get_contract_cache_key, ContractCode, ContractRuntimeCache, FilesystemContractRuntimeCache,
+    };
     use node_runtime::state_viewer::TrieViewer;
 
     const EPOCH_LENGTH: u64 = 25;
@@ -3416,8 +3417,8 @@ mod contract_precompilation_tests {
         let mut genesis =
             Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
         genesis.config.epoch_length = EPOCH_LENGTH;
-        let mut caches: Vec<FilesystemCompiledContractCache> =
-            (0..num_clients).map(|_| FilesystemCompiledContractCache::test().unwrap()).collect();
+        let mut caches: Vec<FilesystemContractRuntimeCache> =
+            (0..num_clients).map(|_| FilesystemContractRuntimeCache::test().unwrap()).collect();
         let mut env = TestEnv::builder(&genesis.config)
             .clients_count(num_clients)
             .use_state_snapshots()
@@ -3509,8 +3510,8 @@ mod contract_precompilation_tests {
             Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
         genesis.config.epoch_length = EPOCH_LENGTH;
 
-        let caches: Vec<FilesystemCompiledContractCache> =
-            (0..num_clients).map(|_| FilesystemCompiledContractCache::test().unwrap()).collect();
+        let caches: Vec<FilesystemContractRuntimeCache> =
+            (0..num_clients).map(|_| FilesystemContractRuntimeCache::test().unwrap()).collect();
         let mut env = TestEnv::builder(&genesis.config)
             .clients_count(num_clients)
             .use_state_snapshots()
@@ -3583,8 +3584,8 @@ mod contract_precompilation_tests {
             1,
         );
         genesis.config.epoch_length = EPOCH_LENGTH;
-        let caches: Vec<FilesystemCompiledContractCache> =
-            (0..num_clients).map(|_| FilesystemCompiledContractCache::test().unwrap()).collect();
+        let caches: Vec<FilesystemContractRuntimeCache> =
+            (0..num_clients).map(|_| FilesystemContractRuntimeCache::test().unwrap()).collect();
         let mut env = TestEnv::builder(&genesis.config)
             .clients_count(num_clients)
             .use_state_snapshots()

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -48,7 +48,7 @@ use near_rosetta_rpc::RosettaRpcConfig;
 use near_store::config::StateSnapshotType;
 use near_store::{StateSnapshotConfig, Store, TrieConfig};
 use near_telemetry::TelemetryConfig;
-use near_vm_runner::{CompiledContractCache, FilesystemCompiledContractCache};
+use near_vm_runner::{ContractRuntimeCache, FilesystemContractRuntimeCache};
 use num_rational::Rational32;
 use std::fs;
 use std::fs::File;
@@ -637,10 +637,10 @@ impl NightshadeRuntime {
         // the caller and passed into this `NightshadeRuntime::from_config` here. But that's a big
         // refactor...
         let contract_cache =
-            FilesystemCompiledContractCache::new(home_dir, config.config.store.path.as_ref())?;
+            FilesystemContractRuntimeCache::new(home_dir, config.config.store.path.as_ref())?;
         Ok(NightshadeRuntime::new(
             store,
-            CompiledContractCache::handle(&contract_cache),
+            ContractRuntimeCache::handle(&contract_cache),
             &config.genesis.config,
             epoch_manager,
             config.client_config.trie_viewer_state_size_limit,

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -637,7 +637,8 @@ impl NightshadeRuntime {
         // the caller and passed into this `NightshadeRuntime::from_config` here. But that's a big
         // refactor...
         let contract_cache =
-            FilesystemContractRuntimeCache::new(home_dir, config.config.store.path.as_ref())?;
+            FilesystemContractRuntimeCache::new(home_dir, config.config.store.path.as_ref())?
+                .with_memory_cache(128);
         Ok(NightshadeRuntime::new(
             store,
             ContractRuntimeCache::handle(&contract_cache),

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -267,6 +267,7 @@ pub struct Config {
     pub state_sync: Option<StateSyncConfig>,
     /// Limit of the size of per-shard transaction pool measured in bytes. If not set, the size
     /// will be unbounded.
+    ///
     /// New transactions that bring the size of the pool over this limit will be rejected. This
     /// guarantees that the node will use bounded resources to store incoming transactions.
     /// Setting this value too low (<1MB) on the validator might lead to production of smaller
@@ -278,12 +279,14 @@ pub struct Config {
     /// to upcoming chunk producers.
     pub tx_routing_height_horizon: BlockHeightDelta,
     /// Limit the time of adding transactions to a chunk.
+    ///
     /// A node produces a chunk by adding transactions from the transaction pool until
     /// some limit is reached. This time limit ensures that adding transactions won't take
     /// longer than the specified duration, which helps to produce the chunk quickly.
     #[serde(with = "near_async::time::serde_opt_duration_as_std")]
     pub produce_chunk_add_transactions_time_limit: Option<Duration>,
     /// Optional config for the Chunk Distribution Network feature.
+    ///
     /// If set to `None` then this node does not participate in the Chunk Distribution Network.
     /// Nodes not participating will still function fine, but possibly with higher
     /// latency due to the need of requesting chunks over the peer-to-peer network.
@@ -293,6 +296,12 @@ pub struct Config {
     /// because the previous block isn't available. The witnesses wait in the pool untl the
     /// required block appears. This variable controls how many witnesses can be stored in the pool.
     pub orphan_state_witness_pool_size: usize,
+
+    /// The number of the contracts kept loaded up for execution.
+    ///
+    /// Each loaded contract will increase the baseline memory use of the node appreciably. This
+    /// number must not exceed the excess parallelism available in the contract runtime.
+    pub max_loaded_contracts: usize,
 }
 
 fn is_false(value: &bool) -> bool {
@@ -339,6 +348,7 @@ impl Default for Config {
                 default_produce_chunk_add_transactions_time_limit(),
             chunk_distribution_network: None,
             orphan_state_witness_pool_size: default_orphan_state_witness_pool_size(),
+            max_loaded_contracts: 128,
         }
     }
 }
@@ -636,9 +646,11 @@ impl NightshadeRuntime {
         // FIXME: this (and other contract runtime resources) should probably get constructed by
         // the caller and passed into this `NightshadeRuntime::from_config` here. But that's a big
         // refactor...
-        let contract_cache =
-            FilesystemContractRuntimeCache::new(home_dir, config.config.store.path.as_ref())?
-                .with_memory_cache(128);
+        let contract_cache = FilesystemContractRuntimeCache::with_memory_cache(
+            home_dir,
+            config.config.store.path.as_ref(),
+            config.config.max_loaded_contracts,
+        )?;
         Ok(NightshadeRuntime::new(
             store,
             ContractRuntimeCache::handle(&contract_cache),

--- a/nearcore/src/test_utils.rs
+++ b/nearcore/src/test_utils.rs
@@ -5,7 +5,7 @@ use near_epoch_manager::EpochManagerHandle;
 use near_parameters::RuntimeConfigStore;
 use near_store::genesis::initialize_genesis_state;
 use near_store::{Store, TrieConfig};
-use near_vm_runner::CompiledContractCache;
+use near_vm_runner::ContractRuntimeCache;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -39,7 +39,7 @@ impl TestEnvNightshadeSetupExt for TestEnvBuilder {
         let state_snapshot_type = self.state_snapshot_type();
         let nightshade_runtime_creator = |home_dir: PathBuf,
                                           store: Store,
-                                          contract_cache: Box<dyn CompiledContractCache>,
+                                          contract_cache: Box<dyn ContractRuntimeCache>,
                                           epoch_manager: Arc<EpochManagerHandle>,
                                           runtime_config: RuntimeConfigStore,
                                           _|
@@ -75,7 +75,7 @@ impl TestEnvNightshadeSetupExt for TestEnvBuilder {
         let state_snapshot_type = self.state_snapshot_type();
         let nightshade_runtime_creator = |home_dir: PathBuf,
                                           store: Store,
-                                          contract_cache: Box<dyn CompiledContractCache>,
+                                          contract_cache: Box<dyn ContractRuntimeCache>,
                                           epoch_manager: Arc<EpochManagerHandle>,
                                           _,
                                           trie_config: TrieConfig|

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -20,7 +20,7 @@ borsh.workspace = true
 ed25519-dalek.workspace = true
 enum-map.workspace = true
 finite-wasm = { workspace = true, features = ["instrument"], optional = true }
-lru.worspace = "0.12.3"
+lru = "0.12.3"
 memoffset.workspace = true
 num-rational.workspace = true
 once_cell.workspace = true

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -20,7 +20,7 @@ borsh.workspace = true
 ed25519-dalek.workspace = true
 enum-map.workspace = true
 finite-wasm = { workspace = true, features = ["instrument"], optional = true }
-lru.worspace = true
+lru.worspace = "0.12.3"
 memoffset.workspace = true
 num-rational.workspace = true
 once_cell.workspace = true

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = { workspace = true, optional = true }
 base64.workspace = true
 bn.workspace = true
 borsh.workspace = true
+cov-mark.workspace = true
 ed25519-dalek.workspace = true
 enum-map.workspace = true
 finite-wasm = { workspace = true, features = ["instrument"], optional = true }

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -17,7 +17,6 @@ anyhow = { workspace = true, optional = true }
 base64.workspace = true
 bn.workspace = true
 borsh.workspace = true
-cov-mark.workspace = true
 ed25519-dalek.workspace = true
 enum-map.workspace = true
 finite-wasm = { workspace = true, features = ["instrument"], optional = true }
@@ -70,6 +69,7 @@ near-vm-vm = { workspace = true, optional = true }
 arbitrary.workspace = true
 assert_matches.workspace = true
 bolero.workspace = true
+cov-mark.workspace = true
 expect-test.workspace = true
 hex.workspace = true
 near-test-contracts.workspace = true

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -20,6 +20,7 @@ borsh.workspace = true
 ed25519-dalek.workspace = true
 enum-map.workspace = true
 finite-wasm = { workspace = true, features = ["instrument"], optional = true }
+lru.worspace = true
 memoffset.workspace = true
 num-rational.workspace = true
 once_cell.workspace = true

--- a/runtime/near-vm-runner/src/cache.rs
+++ b/runtime/near-vm-runner/src/cache.rs
@@ -131,6 +131,23 @@ impl<C: ContractRuntimeCache> ContractRuntimeCache for &C {
 }
 
 #[derive(Default, Clone)]
+pub struct NoContractRuntimeCache;
+
+impl ContractRuntimeCache for NoContractRuntimeCache {
+    fn handle(&self) -> Box<dyn ContractRuntimeCache> {
+        Box::new(self.clone())
+    }
+
+    fn put(&self, _: &CryptoHash, _: CompiledContract) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    fn get(&self, _: &CryptoHash) -> std::io::Result<Option<CompiledContract>> {
+        Ok(None)
+    }
+}
+
+#[derive(Default, Clone)]
 pub struct MockContractRuntimeCache {
     store: Arc<Mutex<HashMap<CryptoHash, CompiledContract>>>,
 }
@@ -228,10 +245,12 @@ impl FilesystemContractRuntimeCache {
         let state = Arc::into_inner(self.state).expect(
             "with_memory_cache may only be called on unique FilesystemContractRuntimeCaches",
         );
-        Self { state: Arc::new(FilesystemContractRuntimeCacheState {
-            any_cache: AnyCache::new(size),
-            ..state
-        }) }
+        Self {
+            state: Arc::new(FilesystemContractRuntimeCacheState {
+                any_cache: AnyCache::new(size),
+                ..state
+            }),
+        }
     }
 }
 

--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -28,8 +28,8 @@ mod wasmtime_runner;
 
 pub use crate::logic::with_ext_cost_counter;
 pub use cache::{
-    get_contract_cache_key, precompile_contract, CompiledContract, CompiledContractCache,
-    FilesystemCompiledContractCache, MockCompiledContractCache,
+    get_contract_cache_key, precompile_contract, CompiledContract, ContractRuntimeCache,
+    FilesystemContractRuntimeCache, MockContractRuntimeCache, NoContractRuntimeCache,
 };
 pub use code::ContractCode;
 pub use profile::ProfileDataV3;

--- a/runtime/near-vm-runner/src/near_vm_runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner.rs
@@ -337,7 +337,12 @@ impl NearVM {
         Ok(executable_or_error)
     }
 
-    #[tracing::instrument(level = "debug", target = "vm", "NearVM::compile_and_load", skip_all)]
+    #[tracing::instrument(
+        level = "debug",
+        target = "vm",
+        name = "NearVM::with_compiled_and_loaded",
+        skip_all
+    )]
     fn with_compiled_and_loaded<R>(
         &self,
         code: &ContractCode,
@@ -347,7 +352,7 @@ impl NearVM {
         type MemoryCacheType = Result<VMArtifact, CompilationError>;
         let to_any = |v: MemoryCacheType| -> Box<dyn std::any::Any + Send> { Box::new(v) };
         let key = get_contract_cache_key(code, &self.config);
-        cache.memory_cache().try_with_or(
+        cache.memory_cache().try_lookup(
             key,
             || {
                 // `cache` stores compiled machine code in the database

--- a/runtime/near-vm-runner/src/near_vm_runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner.rs
@@ -6,11 +6,11 @@ use crate::logic::errors::{
 use crate::logic::gas_counter::FastGasCounter;
 use crate::logic::types::PromiseResult;
 use crate::logic::{Config, External, MemSlice, MemoryLike, VMContext, VMLogic, VMOutcome};
-use crate::prepare;
 use crate::runner::VMResult;
 use crate::{
-    get_contract_cache_key, imports, CompiledContract, CompiledContractCache, ContractCode,
+    get_contract_cache_key, imports, CompiledContract, ContractCode, ContractRuntimeCache,
 };
+use crate::{prepare, NoContractRuntimeCache};
 use memoffset::offset_of;
 use near_parameters::vm::VMKind;
 use near_parameters::RuntimeFeesConfig;
@@ -319,7 +319,7 @@ impl NearVM {
     fn compile_and_cache(
         &self,
         code: &ContractCode,
-        cache: Option<&dyn CompiledContractCache>,
+        cache: Option<&dyn ContractRuntimeCache>,
     ) -> Result<Result<UniversalExecutable, CompilationError>, CacheError> {
         let executable_or_error = self.compile_uncached(code);
         let key = get_contract_cache_key(code, &self.config);
@@ -343,7 +343,7 @@ impl NearVM {
     fn compile_and_load(
         &self,
         code: &ContractCode,
-        cache: Option<&dyn CompiledContractCache>,
+        cache: Option<&dyn ContractRuntimeCache>,
     ) -> VMResult<Result<VMArtifact, CompilationError>> {
         // `cache` stores compiled machine code in the database
         //
@@ -664,7 +664,7 @@ impl crate::runner::VM for NearVM {
         context: VMContext,
         fees_config: &RuntimeFeesConfig,
         promise_results: &[PromiseResult],
-        cache: Option<&dyn CompiledContractCache>,
+        cache: Option<&dyn ContractRuntimeCache>,
     ) -> Result<VMOutcome, VMRunnerError> {
         let mut memory = NearVmMemory::new(
             self.config.limit_config.initial_memory_pages,
@@ -708,7 +708,7 @@ impl crate::runner::VM for NearVM {
     fn precompile(
         &self,
         code: &ContractCode,
-        cache: &dyn CompiledContractCache,
+        cache: &dyn ContractRuntimeCache,
     ) -> Result<
         Result<ContractPrecompilatonResult, CompilationError>,
         crate::logic::errors::CacheError,

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -2,7 +2,7 @@ use crate::errors::ContractPrecompilatonResult;
 use crate::logic::errors::{CacheError, CompilationError, VMRunnerError};
 use crate::logic::types::PromiseResult;
 use crate::logic::{External, VMContext, VMOutcome};
-use crate::{CompiledContractCache, ContractCode};
+use crate::{ContractCode, ContractRuntimeCache};
 use near_parameters::vm::{Config, VMKind};
 use near_parameters::RuntimeFeesConfig;
 
@@ -47,7 +47,7 @@ pub fn run(
     wasm_config: &Config,
     fees_config: &RuntimeFeesConfig,
     promise_results: &[PromiseResult],
-    cache: Option<&dyn CompiledContractCache>,
+    cache: Option<&dyn ContractRuntimeCache>,
 ) -> VMResult {
     let vm_kind = wasm_config.vm_kind;
     let span = tracing::debug_span!(
@@ -94,7 +94,7 @@ pub trait VM {
         context: VMContext,
         fees_config: &RuntimeFeesConfig,
         promise_results: &[PromiseResult],
-        cache: Option<&dyn CompiledContractCache>,
+        cache: Option<&dyn ContractRuntimeCache>,
     ) -> VMResult;
 
     /// Precompile a WASM contract to a VM specific format and store the result
@@ -106,7 +106,7 @@ pub trait VM {
     fn precompile(
         &self,
         code: &ContractCode,
-        cache: &dyn CompiledContractCache,
+        cache: &dyn ContractRuntimeCache,
     ) -> Result<Result<ContractPrecompilatonResult, CompilationError>, CacheError>;
 }
 

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -9,7 +9,7 @@ use crate::logic::{Config, External, MemSlice, MemoryLike, VMContext, VMLogic, V
 use crate::prepare;
 use crate::runner::VMResult;
 use crate::{
-    get_contract_cache_key, imports, CompiledContract, CompiledContractCache, ContractCode,
+    get_contract_cache_key, imports, CompiledContract, ContractCode, ContractRuntimeCache,
 };
 use memoffset::offset_of;
 use near_parameters::vm::VMKind;
@@ -292,7 +292,7 @@ impl Wasmer2VM {
     fn compile_and_cache(
         &self,
         code: &ContractCode,
-        cache: Option<&dyn CompiledContractCache>,
+        cache: Option<&dyn ContractRuntimeCache>,
     ) -> Result<Result<UniversalExecutable, CompilationError>, CacheError> {
         let executable_or_error = self.compile_uncached(code);
         let key = get_contract_cache_key(code, &self.config);
@@ -316,7 +316,7 @@ impl Wasmer2VM {
     fn compile_and_load(
         &self,
         code: &ContractCode,
-        cache: Option<&dyn CompiledContractCache>,
+        cache: Option<&dyn ContractRuntimeCache>,
     ) -> VMResult<Result<VMArtifact, CompilationError>> {
         // A bit of a tricky logic ahead! We need to deal with two levels of
         // caching:
@@ -566,7 +566,7 @@ impl crate::runner::VM for Wasmer2VM {
         context: VMContext,
         fees_config: &RuntimeFeesConfig,
         promise_results: &[PromiseResult],
-        cache: Option<&dyn CompiledContractCache>,
+        cache: Option<&dyn ContractRuntimeCache>,
     ) -> Result<VMOutcome, VMRunnerError> {
         let mut memory = Wasmer2Memory::new(
             self.config.limit_config.initial_memory_pages,
@@ -610,7 +610,7 @@ impl crate::runner::VM for Wasmer2VM {
     fn precompile(
         &self,
         code: &ContractCode,
-        cache: &dyn CompiledContractCache,
+        cache: &dyn ContractRuntimeCache,
     ) -> Result<
         Result<ContractPrecompilatonResult, CompilationError>,
         crate::logic::errors::CacheError,

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -8,7 +8,7 @@ use crate::memory::WasmerMemory;
 use crate::prepare;
 use crate::runner::VMResult;
 use crate::{
-    get_contract_cache_key, imports, CompiledContract, CompiledContractCache, ContractCode,
+    get_contract_cache_key, imports, CompiledContract, ContractCode, ContractRuntimeCache,
 };
 use near_parameters::vm::{Config, VMKind};
 use near_parameters::RuntimeFeesConfig;
@@ -260,7 +260,7 @@ impl Wasmer0VM {
     pub(crate) fn compile_and_cache(
         &self,
         code: &ContractCode,
-        cache: Option<&dyn CompiledContractCache>,
+        cache: Option<&dyn ContractRuntimeCache>,
     ) -> Result<Result<wasmer_runtime::Module, CompilationError>, CacheError> {
         let module_or_error = self.compile_uncached(code);
         let key = get_contract_cache_key(code, &self.config);
@@ -285,7 +285,7 @@ impl Wasmer0VM {
     pub(crate) fn compile_and_load(
         &self,
         code: &ContractCode,
-        cache: Option<&dyn CompiledContractCache>,
+        cache: Option<&dyn ContractRuntimeCache>,
     ) -> VMResult<Result<wasmer_runtime::Module, CompilationError>> {
         let _span = tracing::debug_span!(target: "vm", "Wasmer0VM::compile_and_load").entered();
 
@@ -348,7 +348,7 @@ impl crate::runner::VM for Wasmer0VM {
         context: VMContext,
         fees_config: &RuntimeFeesConfig,
         promise_results: &[PromiseResult],
-        cache: Option<&dyn CompiledContractCache>,
+        cache: Option<&dyn ContractRuntimeCache>,
     ) -> Result<VMOutcome, VMRunnerError> {
         if !cfg!(target_arch = "x86") && !cfg!(target_arch = "x86_64") {
             // TODO(#1940): Remove once NaN is standardized by the VM.
@@ -413,7 +413,7 @@ impl crate::runner::VM for Wasmer0VM {
     fn precompile(
         &self,
         code: &ContractCode,
-        cache: &dyn CompiledContractCache,
+        cache: &dyn ContractRuntimeCache,
     ) -> Result<
         Result<ContractPrecompilatonResult, CompilationError>,
         crate::logic::errors::CacheError,

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -6,7 +6,7 @@ use crate::logic::errors::{
 use crate::logic::types::PromiseResult;
 use crate::logic::Config;
 use crate::logic::{External, MemSlice, MemoryLike, VMContext, VMLogic, VMOutcome};
-use crate::{imports, prepare, CompiledContractCache, ContractCode};
+use crate::{imports, prepare, ContractCode, ContractRuntimeCache};
 use near_parameters::vm::VMKind;
 use near_parameters::RuntimeFeesConfig;
 use std::borrow::Cow;
@@ -158,7 +158,7 @@ impl crate::runner::VM for WasmtimeVM {
         context: VMContext,
         fees_config: &RuntimeFeesConfig,
         promise_results: &[PromiseResult],
-        _cache: Option<&dyn CompiledContractCache>,
+        _cache: Option<&dyn ContractRuntimeCache>,
     ) -> Result<VMOutcome, VMRunnerError> {
         let mut config = self.default_wasmtime_config();
         let engine = get_engine(&mut config);
@@ -242,7 +242,7 @@ impl crate::runner::VM for WasmtimeVM {
     fn precompile(
         &self,
         _code: &ContractCode,
-        _cache: &dyn CompiledContractCache,
+        _cache: &dyn ContractRuntimeCache,
     ) -> Result<
         Result<ContractPrecompilatonResult, CompilationError>,
         crate::logic::errors::CacheError,

--- a/runtime/near-vm/engine/src/universal/artifact.rs
+++ b/runtime/near-vm/engine/src/universal/artifact.rs
@@ -40,11 +40,6 @@ pub struct UniversalArtifact {
     pub(crate) local_globals: Vec<(GlobalType, GlobalInit)>,
 }
 
-/// SAFETY: err... I don't know what to say. We should refactor so this is not a thing, but
-/// hopefully this bound is actually overzealous and we don't operate on a given artifact
-/// synchronously...?
-unsafe impl Sync for UniversalArtifact {}
-
 impl UniversalArtifact {
     /// Return the extents of the specified local function.
     pub fn function_extent(&self, index: LocalFunctionIndex) -> Option<FunctionExtent> {

--- a/runtime/near-vm/engine/src/universal/artifact.rs
+++ b/runtime/near-vm/engine/src/universal/artifact.rs
@@ -40,6 +40,17 @@ pub struct UniversalArtifact {
     pub(crate) local_globals: Vec<(GlobalType, GlobalInit)>,
 }
 
+
+// FIXME SAFETY: this is probably unsound in principle -- I don't believe UniversalArtifact is
+// `Sync` necessarily. However our saving grace is that this isn't actually a bound that we need in
+// near protocol at least at the time this is implemented. The only reason this property is
+// required right now is because `Instance` stores `Arc<dyn Artifact>`. However our use of
+// `Instances` is entirely single-threaded and if we could replace that `Arc<...>` with a plain
+// `&dyn Artifact`, then all would be fine (at an expense of Instance being less convenient to use.)
+//
+// FIXME: when removing this, also remove the `trait Artifact: Sync` super trait specification.
+unsafe impl Sync for UniversalArtifact {}
+
 impl UniversalArtifact {
     /// Return the extents of the specified local function.
     pub fn function_extent(&self, index: LocalFunctionIndex) -> Option<FunctionExtent> {

--- a/runtime/near-vm/engine/src/universal/artifact.rs
+++ b/runtime/near-vm/engine/src/universal/artifact.rs
@@ -40,6 +40,11 @@ pub struct UniversalArtifact {
     pub(crate) local_globals: Vec<(GlobalType, GlobalInit)>,
 }
 
+/// SAFETY: err... I don't know what to say. We should refactor so this is not a thing, but
+/// hopefully this bound is actually overzealous and we don't operate on a given artifact
+/// synchronously...?
+unsafe impl Sync for UniversalArtifact {}
+
 impl UniversalArtifact {
     /// Return the extents of the specified local function.
     pub fn function_extent(&self, index: LocalFunctionIndex) -> Option<FunctionExtent> {

--- a/runtime/near-vm/engine/src/universal/artifact.rs
+++ b/runtime/near-vm/engine/src/universal/artifact.rs
@@ -40,7 +40,6 @@ pub struct UniversalArtifact {
     pub(crate) local_globals: Vec<(GlobalType, GlobalInit)>,
 }
 
-
 // FIXME SAFETY: this is probably unsound in principle -- I don't believe UniversalArtifact is
 // `Sync` necessarily. However our saving grace is that this isn't actually a bound that we need in
 // near protocol at least at the time this is implemented. The only reason this property is

--- a/runtime/near-vm/vm/src/artifact.rs
+++ b/runtime/near-vm/vm/src/artifact.rs
@@ -31,7 +31,7 @@ pub trait Instantiatable: Artifact {
 ///
 /// Some other operations such as linking, relocating and similar may also be performed during
 /// constructon of the Artifact, making this type particularly well suited for caching in-memory.
-pub trait Artifact: Send {
+pub trait Artifact: Send + Sync {
     /// The information about offsets into the VM context table.
     fn offsets(&self) -> &crate::VMOffsets;
 

--- a/runtime/near-vm/vm/src/artifact.rs
+++ b/runtime/near-vm/vm/src/artifact.rs
@@ -31,7 +31,7 @@ pub trait Instantiatable: Artifact {
 ///
 /// Some other operations such as linking, relocating and similar may also be performed during
 /// constructon of the Artifact, making this type particularly well suited for caching in-memory.
-pub trait Artifact: Send + Sync {
+pub trait Artifact: Send {
     /// The information about offsets into the VM context table.
     fn offsets(&self) -> &crate::VMOffsets;
 

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -19,7 +19,7 @@ use near_store::flat::{
 use near_store::{ShardTries, ShardUId, StateSnapshotConfig, TrieUpdate};
 use near_store::{TrieCache, TrieCachingStorage, TrieConfig};
 use near_vm_runner::logic::LimitConfig;
-use near_vm_runner::FilesystemCompiledContractCache;
+use near_vm_runner::FilesystemContractRuntimeCache;
 use node_runtime::{ApplyState, Runtime};
 use std::collections::HashMap;
 use std::iter;
@@ -99,7 +99,7 @@ impl<'c> EstimatorContext<'c> {
             flat_storage_manager,
             StateSnapshotConfig::default(),
         );
-        let cache = FilesystemCompiledContractCache::new(workdir.path(), None::<&str>)
+        let cache = FilesystemContractRuntimeCache::new(workdir.path(), None::<&str>)
             .expect("create contract cache");
 
         Testbed {
@@ -119,7 +119,7 @@ impl<'c> EstimatorContext<'c> {
         }
     }
 
-    fn make_apply_state(cache: FilesystemCompiledContractCache) -> ApplyState {
+    fn make_apply_state(cache: FilesystemContractRuntimeCache) -> ApplyState {
         let mut runtime_config =
             RuntimeConfigStore::new(None).get_config(PROTOCOL_VERSION).as_ref().clone();
         runtime_config.wasm_config.enable_all_features();

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -6,7 +6,7 @@ use near_parameters::RuntimeConfigStore;
 use near_primitives::types::ProtocolVersion;
 use near_vm_runner::internal::VMKindExt;
 use near_vm_runner::logic::mocks::mock_external::MockedExternal;
-use near_vm_runner::{CompiledContractCache, ContractCode, FilesystemCompiledContractCache};
+use near_vm_runner::{ContractCode, ContractRuntimeCache, FilesystemContractRuntimeCache};
 use std::fmt::Write;
 
 /// Estimates linear cost curve for a function call execution cost per byte of
@@ -62,8 +62,8 @@ fn compute_function_call_cost(
     warmup_repeats: u64,
     contract: &ContractCode,
 ) -> GasCost {
-    let cache_store = FilesystemCompiledContractCache::test().unwrap();
-    let cache: Option<&dyn CompiledContractCache> = Some(&cache_store);
+    let cache_store = FilesystemContractRuntimeCache::test().unwrap();
+    let cache: Option<&dyn ContractRuntimeCache> = Some(&cache_store);
     let protocol_version = ProtocolVersion::MAX;
     let config_store = RuntimeConfigStore::new(None);
     let runtime_config = config_store.get_config(protocol_version).as_ref();

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -5,7 +5,7 @@ use near_parameters::RuntimeConfigStore;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_vm_runner::internal::VMKindExt;
 use near_vm_runner::logic::mocks::mock_external::MockedExternal;
-use near_vm_runner::{CompiledContractCache, ContractCode, FilesystemCompiledContractCache};
+use near_vm_runner::{ContractCode, ContractRuntimeCache, FilesystemContractRuntimeCache};
 use std::fmt::Write;
 
 pub(crate) fn gas_metering_cost(config: &Config) -> (GasCost, GasCost) {
@@ -124,8 +124,8 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     let repeats = config.iter_per_block as u64;
     let vm_kind = config.vm_kind;
     let warmup_repeats = config.warmup_iters_per_block;
-    let cache_store = FilesystemCompiledContractCache::test().unwrap();
-    let cache: Option<&dyn CompiledContractCache> = Some(&cache_store);
+    let cache_store = FilesystemContractRuntimeCache::test().unwrap();
+    let cache: Option<&dyn ContractRuntimeCache> = Some(&cache_store);
     let config_store = RuntimeConfigStore::new(None);
     let runtime_config = config_store.get_config(PROTOCOL_VERSION).as_ref();
     let vm_config_gas = runtime_config.wasm_config.clone();

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -110,7 +110,7 @@ use near_primitives::version::PROTOCOL_VERSION;
 use near_vm_runner::internal::VMKindExt;
 use near_vm_runner::logic::mocks::mock_external::MockedExternal;
 use near_vm_runner::ContractCode;
-use near_vm_runner::MockCompiledContractCache;
+use near_vm_runner::MockContractRuntimeCache;
 use serde_json::json;
 use std::convert::TryFrom;
 use std::iter;
@@ -886,7 +886,7 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
     let config = config_store.get_config(PROTOCOL_VERSION).wasm_config.clone();
     let fees = RuntimeFeesConfig::test();
     let promise_results = vec![];
-    let cache = MockCompiledContractCache::default();
+    let cache = MockContractRuntimeCache::default();
 
     let mut run = || {
         let context = create_context(vec![]);

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -3,13 +3,11 @@ use crate::gas_cost::{GasCost, LeastSquaresTolerance};
 use crate::{utils::read_resource, REAL_CONTRACTS_SAMPLE};
 use near_parameters::vm::VMKind;
 use near_parameters::RuntimeConfigStore;
-use near_primitives::hash::CryptoHash;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_vm_runner::internal::VMKindExt;
 use near_vm_runner::logic::VMContext;
 use near_vm_runner::{
-    CompiledContract, ContractCode, ContractRuntimeCache, FilesystemContractRuntimeCache,
-    NoContractRuntimeCache,
+    ContractCode, ContractRuntimeCache, FilesystemContractRuntimeCache, NoContractRuntimeCache,
 };
 
 const CURRENT_ACCOUNT_ID: &str = "alice";

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -55,23 +55,6 @@ fn measure_contract(
     end
 }
 
-#[derive(Default, Clone)]
-struct MockContractRuntimeCache;
-
-impl ContractRuntimeCache for MockContractRuntimeCache {
-    fn put(&self, _key: &CryptoHash, _value: CompiledContract) -> std::io::Result<()> {
-        Ok(())
-    }
-
-    fn get(&self, _key: &CryptoHash) -> std::io::Result<Option<CompiledContract>> {
-        Ok(None)
-    }
-
-    fn handle(&self) -> Box<dyn ContractRuntimeCache> {
-        Box::new(self.clone())
-    }
-}
-
 /// Returns `(a, b)` - approximation coefficients for formula `a + b * x`
 /// where `x` is the contract size in bytes. Practically, we compute upper bound
 /// of this approximation, assuming that whole contract consists of code only.
@@ -84,7 +67,7 @@ fn precompilation_cost(
         eprintln!("WARNING: did you pass --release flag, results do not make sense otherwise")
     }
     let cache_store1 = FilesystemContractRuntimeCache::test().unwrap();
-    let cache_store2 = MockContractRuntimeCache;
+    let cache_store2 = NoContractRuntimeCache;
     let use_store = true;
     let cache: &dyn ContractRuntimeCache = if use_store { &cache_store1 } else { &cache_store2 };
     let mut xs = vec![];

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -50,8 +50,8 @@ use near_store::{set_access_key, set_code};
 use near_vm_runner::logic::types::PromiseResult;
 use near_vm_runner::logic::ReturnData;
 pub use near_vm_runner::with_ext_cost_counter;
-use near_vm_runner::CompiledContractCache;
 use near_vm_runner::ContractCode;
+use near_vm_runner::ContractRuntimeCache;
 use near_vm_runner::ProfileDataV3;
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
@@ -98,7 +98,7 @@ pub struct ApplyState {
     /// The Runtime config to use for the current transition.
     pub config: Arc<RuntimeConfig>,
     /// Cache for compiled contracts.
-    pub cache: Option<Box<dyn CompiledContractCache>>,
+    pub cache: Option<Box<dyn ContractRuntimeCache>>,
     /// Whether the chunk being applied is new.
     pub is_new_chunk: bool,
     /// Data for migrations that may need to be applied at the start of an epoch when protocol
@@ -1788,7 +1788,7 @@ mod tests {
     use near_primitives::version::PROTOCOL_VERSION;
     use near_store::test_utils::TestTriesBuilder;
     use near_store::{set_access_key, ShardTries};
-    use near_vm_runner::FilesystemCompiledContractCache;
+    use near_vm_runner::FilesystemContractRuntimeCache;
     use testlib::runtime_utils::{alice_account, bob_account};
 
     use super::*;
@@ -1886,7 +1886,7 @@ mod tests {
         let mut store_update = tries.store_update();
         let root = tries.apply_all(&trie_changes, ShardUId::single_shard(), &mut store_update);
         store_update.commit().unwrap();
-        let contract_cache = FilesystemCompiledContractCache::test().unwrap();
+        let contract_cache = FilesystemContractRuntimeCache::test().unwrap();
         let apply_state = ApplyState {
             block_height: 1,
             prev_block_hash: Default::default(),

--- a/test-utils/runtime-tester/src/run_test.rs
+++ b/test-utils/runtime-tester/src/run_test.rs
@@ -12,7 +12,7 @@ use near_primitives::types::{AccountId, BlockHeight, BlockHeightDelta, Gas, Nonc
 use near_store::config::StateSnapshotType;
 use near_store::genesis::initialize_genesis_state;
 use near_store::test_utils::create_test_store;
-use near_vm_runner::{CompiledContractCache, FilesystemCompiledContractCache};
+use near_vm_runner::{ContractRuntimeCache, FilesystemContractRuntimeCache};
 use nearcore::NightshadeRuntime;
 use std::io;
 use std::path::Path;
@@ -55,7 +55,7 @@ impl Scenario {
         initialize_genesis_state(store.clone(), &genesis, home_dir);
         let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
         let home_dir = home_dir.unwrap_or_else(|| Path::new("."));
-        let contract_cache = FilesystemCompiledContractCache::new(home_dir, None::<&str>)
+        let contract_cache = FilesystemContractRuntimeCache::new(home_dir, None::<&str>)
             .expect("filesystem contract cache")
             .handle();
         let runtime = NightshadeRuntime::test_with_runtime_config_store(


### PR DESCRIPTION
`AnyCache` is a part of the now-expanded concept of the `ContractRuntimeCache`. It allows runtimes to put anything they would like into it, so long as this cache is keyed by `CryptoKey`.

Initially I was in a lot of pain as intermediate drafts have required me to add a `unsafe impl Sync for UniversalArtifact` which I'm not sure I could possibly prove. However in the end I ended up being able to avoid it entirely by giving out `AnyCache` by reference only. Lovely! -- EDIT: crappa, looks like I did something wrong testing this locally T_T Sync appears to remain a requirement.

Note that only NearVM uses this cache currently. I don't see a good reason to port this code back to the old runtimes.

Supersedes #10787
Co-authored-by: Longarithm <the.aleksandr.logunov@gmail.com>