### PR TITLE
fix: remove direct indexing by shard id

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1204,9 +1204,12 @@ impl Chain {
                 self.chain_store.is_invalid_chunk(&chunk_header.chunk_hash())?
             {
                 let merkle_paths = Block::compute_chunk_headers_root(block.chunks().iter()).1;
+                let merkle_paths = merkle_paths
+                    .get(shard_id)
+                    .ok_or_else(|| Error::InvalidShardId(shard_id as ShardId))?;
                 let chunk_proof = ChunkProofs {
                     block_header: borsh::to_vec(&block.header()).expect("Failed to serialize"),
-                    merkle_proof: merkle_paths[shard_id].clone(),
+                    merkle_proof: merkle_paths.clone(),
                     chunk: Box::new(MaybeEncodedShardChunk::Encoded(EncodedShardChunk::clone(
                         &encoded_chunk,
                     ))),
@@ -2246,7 +2249,10 @@ impl Chain {
         }
         // Chunk header here is the same chunk header as at the `current` height.
         let sync_prev_hash = sync_prev_block.hash();
-        let chunk_header = &sync_prev_block.chunks()[shard_id as usize];
+        let chunks = sync_prev_block.chunks();
+        let chunk_header = chunks
+            .get(shard_id as usize)
+            .ok_or_else(|| Error::InvalidShardId(shard_id as ShardId))?;
         let (chunk_headers_root, chunk_proofs) = merklize(
             &sync_prev_block
                 .chunks()
@@ -2259,7 +2265,10 @@ impl Chain {
         assert_eq!(&chunk_headers_root, sync_prev_block.header().chunk_headers_root());
 
         let chunk = self.get_chunk_clone_from_header(chunk_header)?;
-        let chunk_proof = chunk_proofs[shard_id as usize].clone();
+        let chunk_proof = chunk_proofs
+            .get(shard_id as usize)
+            .ok_or_else(|| Error::InvalidShardId(shard_id as ShardId))?
+            .clone();
         let block_header =
             self.get_block_header_on_chain_by_height(&sync_hash, chunk_header.height_included())?;
 
@@ -2268,7 +2277,11 @@ impl Chain {
             .get_block(block_header.prev_hash())
         {
             Ok(prev_block) => {
-                let prev_chunk_header = prev_block.chunks()[shard_id as usize].clone();
+                let prev_chunk_header = prev_block
+                    .chunks()
+                    .get(shard_id as usize)
+                    .ok_or_else(|| Error::InvalidShardId(shard_id as ShardId))?
+                    .clone();
                 let (prev_chunk_headers_root, prev_chunk_proofs) = merklize(
                     &prev_block
                         .chunks()
@@ -2280,7 +2293,10 @@ impl Chain {
                 );
                 assert_eq!(&prev_chunk_headers_root, prev_block.header().chunk_headers_root());
 
-                let prev_chunk_proof = prev_chunk_proofs[shard_id as usize].clone();
+                let prev_chunk_proof = prev_chunk_proofs
+                    .get(shard_id as usize)
+                    .ok_or_else(|| Error::InvalidShardId(shard_id as ShardId))?
+                    .clone();
                 let prev_chunk_height_included = prev_chunk_header.height_included();
 
                 (Some(prev_chunk_header), Some(prev_chunk_proof), prev_chunk_height_included)
@@ -2437,7 +2453,11 @@ impl Chain {
         if epoch_id == prev_block.header().epoch_id() {
             return Err(sync_hash_not_first_hash(sync_hash));
         }
-        let state_root = prev_block.chunks()[shard_id as usize].prev_state_root();
+        let state_root = prev_block
+            .chunks()
+            .get(shard_id as usize)
+            .ok_or_else(|| Error::InvalidShardId(shard_id as ShardId))?
+            .prev_state_root();
         let prev_hash = *prev_block.hash();
         let prev_prev_hash = *prev_block.header().prev_hash();
         let state_root_node = self
@@ -3330,7 +3350,11 @@ impl Chain {
                 Ok(None) => {}
                 Err(err) => {
                     if err.is_bad_data() {
-                        let chunk_header = block.chunks()[shard_id].clone();
+                        let chunk_header = block
+                            .chunks()
+                            .get(shard_id)
+                            .ok_or_else(|| Error::InvalidShardId(shard_id as ShardId))?
+                            .clone();
                         invalid_chunks.push(chunk_header);
                     }
                     return Err(err);
@@ -4036,7 +4060,10 @@ impl Chain {
             let block = self.get_block(&block_hash)?;
             let chunks = block.chunks();
             for &shard_id in shard_ids.iter() {
-                if chunks[shard_id as usize].height_included() == block.header().height() {
+                let chunk_header = &chunks
+                    .get(shard_id as usize)
+                    .ok_or_else(|| Error::InvalidShardId(shard_id as ShardId))?;
+                if chunk_header.height_included() == block.header().height() {
                     return Ok(Some((block_hash, shard_id)));
                 }
             }

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1204,12 +1204,12 @@ impl Chain {
                 self.chain_store.is_invalid_chunk(&chunk_header.chunk_hash())?
             {
                 let merkle_paths = Block::compute_chunk_headers_root(block.chunks().iter()).1;
-                let merkle_paths = merkle_paths
+                let merkle_proof = merkle_paths
                     .get(shard_id)
                     .ok_or_else(|| Error::InvalidShardId(shard_id as ShardId))?;
                 let chunk_proof = ChunkProofs {
                     block_header: borsh::to_vec(&block.header()).expect("Failed to serialize"),
-                    merkle_proof: merkle_paths.clone(),
+                    merkle_proof: merkle_proof.clone(),
                     chunk: Box::new(MaybeEncodedShardChunk::Encoded(EncodedShardChunk::clone(
                         &encoded_chunk,
                     ))),

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -354,7 +354,11 @@ pub trait ChainStoreAccess {
         let mut shard_id = shard_id;
         loop {
             let block_header = self.get_block_header(&candidate_hash)?;
-            if block_header.chunk_mask()[shard_id as usize] {
+            if *block_header
+                .chunk_mask()
+                .get(shard_id as usize)
+                .ok_or_else(|| Error::InvalidShardId(shard_id as ShardId))?
+            {
                 break Ok(block_header.epoch_id().clone());
             }
             candidate_hash = *block_header.prev_hash();

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -741,8 +741,14 @@ impl Client {
             let (mut chunk_header, chunk_endorsement) =
                 self.chunk_inclusion_tracker.get_chunk_header_and_endorsements(&chunk_hash)?;
             *chunk_header.height_included_mut() = height;
-            chunk_headers[shard_id as usize] = chunk_header;
-            chunk_endorsements[shard_id as usize] = chunk_endorsement;
+            *chunk_headers
+                .get_mut(shard_id as usize)
+                .ok_or_else(|| near_chain_primitives::Error::InvalidShardId(shard_id))? =
+                chunk_header;
+            *chunk_endorsements
+                .get_mut(shard_id as usize)
+                .ok_or_else(|| near_chain_primitives::Error::InvalidShardId(shard_id))? =
+                chunk_endorsement;
         }
 
         let prev_header = &prev_block.header();

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -246,7 +246,7 @@ impl InfoHelper {
                 let chunk_producers_settlement = &epoch_info.chunk_producers_settlement();
                 let chunk_producers = chunk_producers_settlement.get(shard_id as usize);
                 let Some(chunk_producers) = chunk_producers else {
-                    tracing::warn!(target: "stats", ?shard_id, "invalid shard id");
+                    tracing::warn!(target: "stats", ?shard_id, ?chunk_producers_settlement, "invalid shard id, not found in the shard settlement");
                     continue;
                 };
                 for &id in chunk_producers {

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -243,7 +243,13 @@ impl InfoHelper {
             for shard_id in shard_ids {
                 let mut stake_per_cp = HashMap::<ValidatorId, Balance>::new();
                 stake_sum = 0;
-                for &id in &epoch_info.chunk_producers_settlement()[shard_id as usize] {
+                let chunk_producers_settlement = &epoch_info.chunk_producers_settlement();
+                let chunk_producers = chunk_producers_settlement.get(shard_id as usize);
+                let Some(chunk_producers) = chunk_producers else {
+                    tracing::warn!(target: "stats", ?shard_id, "invalid shard id");
+                    continue;
+                };
+                for &id in chunk_producers {
                     let stake = epoch_info.validator_stake(id);
                     stake_per_cp.insert(id, stake);
                     stake_sum += stake;

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -1555,8 +1555,11 @@ impl EpochManager {
         shard_id: ShardId,
     ) -> Result<bool, EpochError> {
         let epoch_info = self.get_epoch_info(&epoch_id)?;
-        let chunk_producers = epoch_info.chunk_producers_settlement();
-        for validator_id in chunk_producers[shard_id as usize].iter() {
+        let chunk_producers_settlement = epoch_info.chunk_producers_settlement();
+        let chunk_producers = chunk_producers_settlement
+            .get(shard_id as usize)
+            .ok_or_else(|| EpochError::ShardingError(format!("invalid shard id {shard_id}")))?;
+        for validator_id in chunk_producers.iter() {
             if epoch_info.validator_account_id(*validator_id) == account_id {
                 return Ok(true);
             }

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -693,6 +693,7 @@ impl<'a> ExactSizeIterator for VersionedChunksIter<'a> {
 impl<'a> Index<usize> for ChunksCollection<'a> {
     type Output = ShardChunkHeader;
 
+    /// Deprecated. Please use get instead, it's safer.
     fn index(&self, index: usize) -> &Self::Output {
         match self {
             ChunksCollection::V1(chunks) => &chunks[index],


### PR DESCRIPTION
Removed some of the usage of [shard_id] that can end up with "out of bounds" panics. This is both to better handle malicious inputs and shard layout changes during resharding. Ideally I'd like to remove the Index trait on ChunkCollection but I'm not quite there yet. Deprecating it doesn't work because it's a trait...