### PR TITLE
mocknet: lower the genesis min_gas_price config value

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -749,6 +749,11 @@ class NeardRunner:
                     genesis_config = json.load(f)
                 with open(genesis_path, 'w') as f:
                     genesis_config['use_production_config'] = True
+                    # with the normal min_gas_price (10x higher than this one)
+                    # many mirrored mainnet transactions fail with too little balance
+                    # One way to fix that would be to increase everybody's balances in
+                    # the amend-genesis command. But we can also just make this change here.
+                    genesis_config['min_gas_price'] = 10000000
                     # protocol_versions in range [56, 63] need to have these
                     # genesis parameters, otherwise nodes get stuck because at
                     # some point it produces an incompatible EpochInfo.


### PR DESCRIPTION
with the normal min_gas_price (10x higher than this one), many mirrored mainnet transactions fail with too little balance. One way to fix that would be to increase everybody's balances in the amend-genesis command. But we can also just make this change in neard_runner.py.