### PR TITLE
feat(mocknet): add scripts to test mocknet itself locally

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -243,7 +243,7 @@ class NeardRunner:
         args = ('tmp-near-home',) + args
         return os.path.join(self.home, *args)
 
-    def neard_init(self, rpc_port, protocol_port):
+    def neard_init(self, rpc_port, protocol_port, validator_id):
         # We make neard init save files to self.tmp_near_home_path() just to make it
         # a bit cleaner, so we can init to a non-existent directory and then move
         # the files we want to the real near home without having to remove it first
@@ -252,7 +252,14 @@ class NeardRunner:
             self.tmp_near_home_path(), 'init'
         ]
         if not self.is_traffic_generator():
-            cmd += ['--account-id', f'{socket.gethostname()}.near']
+            if validator_id is None:
+                validator_id = f'{socket.gethostname()}.near'
+            cmd += ['--account-id', validator_id]
+        else:
+            if validator_id is not None:
+                logging.warning(
+                    f'ignoring validator ID "{validator_id}" for traffic generator node'
+                )
         subprocess.check_call(cmd)
 
         with open(self.tmp_near_home_path('config.json'), 'r') as f:
@@ -298,13 +305,19 @@ class NeardRunner:
     # TODO: add a binaries argument that tells what binaries we want to use in the test. Before we do
     # this, it is pretty mandatory to implement some sort of client authentication, because without it,
     # anyone would be able to get us to download and run arbitrary code
-    def do_new_test(self, rpc_port=3030, protocol_port=24567):
+    def do_new_test(self,
+                    rpc_port=3030,
+                    protocol_port=24567,
+                    validator_id=None):
         if not isinstance(rpc_port, int):
             raise jsonrpc.exceptions.JSONRPCDispatchException(
                 code=-32600, message='rpc_port argument not an int')
         if not isinstance(protocol_port, int):
             raise jsonrpc.exceptions.JSONRPCDispatchException(
                 code=-32600, message='protocol_port argument not an int')
+        if validator_id is not None and not isinstance(validator_id, str):
+            raise jsonrpc.exceptions.JSONRPCDispatchException(
+                code=-32600, message='validator_id argument not a string')
 
         with self.lock:
             self.kill_neard()
@@ -321,7 +334,7 @@ class NeardRunner:
             except FileNotFoundError:
                 pass
 
-            self.neard_init(rpc_port, protocol_port)
+            self.neard_init(rpc_port, protocol_port, validator_id)
             self.move_init_files()
 
             with open(self.target_near_home_path('config.json'), 'r') as f:

--- a/pytest/tests/mocknet/local_test_node.py
+++ b/pytest/tests/mocknet/local_test_node.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""
+defines the LocalTestNeardRunner class meant to to test mocknet itself locally
+"""
+from argparse import ArgumentParser
+import http.server
+import json
+import os
+import pathlib
+import psutil
+import re
+import requests
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+import time
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
+
+from configured_logger import logger
+from node_handle import NodeHandle
+
+
+# return the process with pid listed in `pid_path`, if it's running
+def get_process(pid_path):
+    try:
+        with open(pid_path, 'r') as f:
+            pid = int(f.read().strip())
+    except FileNotFoundError:
+        return None
+    try:
+        return psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        return None
+
+
+# kill the process with pid listed in `pid_path`
+def kill_process(pid_path):
+    p = get_process(pid_path)
+    if p is not None:
+        logger.info(f'killing process with pid {p.pid} indicated in {pid_path}')
+        p.send_signal(signal.SIGTERM)
+        p.wait()
+    try:
+        pid_path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def http_post(addr, port, body):
+    r = requests.post(f'http://{addr}:{port}', json=body, timeout=5)
+    if r.status_code != 200:
+        logger.warning(
+            f'bad response {r.status_code} trying to post {body} to http://{addr}:{port}:\n{r.content}'
+        )
+    r.raise_for_status()
+    return r.json()
+
+
+class LocalTestNeardRunner:
+
+    def __init__(self, home, port, neard_rpc_port, neard_protocol_port):
+        # last part of the path. e.g. ~/.near/local-mocknet/traffic-generator -> traffic-generator
+        self._name = os.path.basename(os.path.normpath(home))
+        self.home = home
+        self.port = port
+        self.neard_rpc_port = neard_rpc_port
+        self.neard_protocol_port = neard_protocol_port
+
+    def name(self):
+        return self._name
+
+    def ip_addr(self):
+        return '0.0.0.0'
+
+    def neard_port(self):
+        return self.neard_rpc_port
+
+    def init(self):
+        return
+
+    def mk_neard_runner_home(self, remove_home_dir):
+        # handled by local_test_setup_cmd()
+        return
+
+    def upload_neard_runner(self):
+        return
+
+    def upload_neard_runner_config(self, config):
+        # handled by local_test_setup_cmd()
+        return
+
+    def init_python(self):
+        return
+
+    def _pid_path(self):
+        return self.home / 'pid.txt'
+
+    def stop_neard_runner(self):
+        kill_process(self._pid_path())
+
+    def start_neard_runner(self):
+        if get_process(self._pid_path()) is not None:
+            return
+
+        with open(self.home / 'stdout', 'ab') as stdout, \
+            open(self.home / 'stderr', 'ab') as stderr:
+            args = [
+                sys.executable, 'tests/mocknet/helpers/neard_runner.py',
+                '--home', self.home / 'neard-runner', '--neard-home',
+                self.home / '.near', '--neard-logs', self.home / 'neard-logs',
+                '--port',
+                str(self.port)
+            ]
+            process = subprocess.Popen(args,
+                                       stdin=subprocess.DEVNULL,
+                                       stdout=stdout,
+                                       stderr=stderr,
+                                       process_group=0)
+        with open(self._pid_path(), 'w') as f:
+            f.write(f'{process.pid}\n')
+        logger.info(
+            f'started neard runner process with pid {process.pid} listening on port {self.port}'
+        )
+
+    def neard_runner_post(self, body):
+        return http_post(self.ip_addr(), self.port, body)
+
+    def new_test_params(self):
+        return {
+            'rpc_port': self.neard_rpc_port,
+            'protocol_port': self.neard_protocol_port,
+            'validator_id': self._name,
+        }
+
+    def get_validators(self):
+        body = {
+            'method': 'validators',
+            'params': [None],
+            'id': 'dontcare',
+            'jsonrpc': '2.0'
+        }
+        return http_post(self.ip_addr(), self.neard_rpc_port, body)
+
+
+def prompt_flags(args):
+    if args.num_nodes is None:
+        print(
+            'number of validating nodes? One instance of neard_runner.py will be run for each one, plus a traffic generator: '
+        )
+        args.num_nodes = int(sys.stdin.readline().strip())
+        assert args.num_nodes > 0
+
+    if args.neard_binary_path is None:
+        print('neard binary path?: ')
+        args.neard_binary_path = sys.stdin.readline().strip()
+        assert len(args.neard_binary_path) > 0
+
+    if args.source_home_dir is None:
+        print('source home dir: ')
+        args.source_home_dir = sys.stdin.readline().strip()
+        assert len(args.source_home_dir) > 0
+
+    if args.fork_height is None:
+        print('fork height: ')
+        args.fork_height = sys.stdin.readline().strip()
+        assert len(args.fork_height) > 0
+
+
+def run_cmd(cmd):
+    try:
+        subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        sys.exit(
+            f'running `{" ".join([str(a) for a in cmd])}` returned {e.returncode}. output:\n{e.output.decode("utf-8")}'
+        )
+
+
+# dumps records from `traffic_home_dir` and prepares records with keys changed
+# for mirroring traffic
+def make_records(neard_binary_path, traffic_home_dir, start_height):
+    run_cmd([
+        neard_binary_path, '--home', traffic_home_dir, 'view-state',
+        'dump-state', '--stream', '--height',
+        str(start_height)
+    ])
+    shutil.copyfile(traffic_home_dir / 'output/genesis.json',
+                    traffic_home_dir / 'setup/genesis.json')
+    run_cmd([
+        neard_binary_path,
+        'mirror',
+        'prepare',
+        '--records-file-in',
+        traffic_home_dir / 'output/records.json',
+        '--records-file-out',
+        traffic_home_dir / 'setup/records.json',
+        '--secret-file-out',
+        '/dev/null',
+        '--no-secret',
+    ])
+
+
+def mkdirs(local_mocknet_path):
+    traffic_generator_home = local_mocknet_path / 'traffic-generator'
+    traffic_generator_home.mkdir()
+    os.mkdir(traffic_generator_home / 'neard-runner')
+    os.mkdir(traffic_generator_home / '.near')
+    os.mkdir(traffic_generator_home / '.near/setup')
+    node_homes = []
+    for i in range(args.num_nodes):
+        node_home = local_mocknet_path / f'node{i}'
+        node_home.mkdir()
+        os.mkdir(node_home / f'neard-runner')
+        os.mkdir(node_home / f'.near')
+        os.mkdir(node_home / f'.near/setup')
+        node_homes.append(node_home)
+    return traffic_generator_home, node_homes
+
+
+def copy_source_home(source_home_dir, traffic_generator_home):
+    shutil.copyfile(source_home_dir / 'config.json',
+                    traffic_generator_home / 'config.json')
+    shutil.copyfile(source_home_dir / 'node_key.json',
+                    traffic_generator_home / 'node_key.json')
+    shutil.copyfile(source_home_dir / 'genesis.json',
+                    traffic_generator_home / 'genesis.json')
+    try:
+        shutil.copyfile(source_home_dir / 'records.json',
+                        traffic_generator_home / 'records.json')
+    except FileNotFoundError:
+        pass
+    shutil.copytree(source_home_dir / 'data', traffic_generator_home / 'data')
+
+
+def make_binaries_dir(local_mocknet_path, neard_binary_path):
+    binaries_path = local_mocknet_path / 'binaries'
+    binaries_path.mkdir()
+    binary_path = binaries_path / 'neard'
+    binary_path.symlink_to(neard_binary_path)
+    return binaries_path
+
+
+class Server(http.server.HTTPServer):
+
+    def __init__(self, addr, directory):
+        self.directory = directory
+        super().__init__(addr, http.server.SimpleHTTPRequestHandler)
+
+    def finish_request(self, request, client_address):
+        self.RequestHandlerClass(request,
+                                 client_address,
+                                 self,
+                                 directory=self.directory)
+
+
+def write_config(home, config):
+    with open(home / 'neard-runner' / 'config.json', 'w') as f:
+        json.dump(config, f)
+
+
+# looks for directories called node{i} in `local_mocknet_path`
+def get_node_homes(local_mocknet_path):
+    dirents = os.listdir(local_mocknet_path)
+    node_homes = []
+    for p in dirents:
+        m = re.match(r'node(\d+)', p)
+        if m is None:
+            continue
+        node_homes.append((p, int(m.groups()[0])))
+    node_homes.sort(key=lambda x: x[1])
+    idx = -1
+    for (home, node_index) in node_homes:
+        if node_index != idx + 1:
+            raise ValueError(
+                f'some neard runner node dirs missing? found: {[n[0] for n in node_homes]}'
+            )
+        idx = node_index
+    return [local_mocknet_path / x[0] for x in node_homes]
+
+
+# return a NodeHandle for each of the neard runner directories in `local_mocknet_path`
+def get_nodes(local_mocknet_path=pathlib.Path.home() / '.near/local-mocknet'):
+    runner_port = 3000
+    neard_rpc_port = 3040
+    neard_protocol_port = 24577
+    traffic_generator = NodeHandle(
+        LocalTestNeardRunner(local_mocknet_path / 'traffic-generator',
+                             runner_port, neard_rpc_port, neard_protocol_port))
+
+    node_homes = get_node_homes(local_mocknet_path)
+    nodes = []
+    for home in node_homes:
+        runner_port += 1
+        neard_rpc_port += 1
+        neard_protocol_port += 1
+        nodes.append(
+            NodeHandle(
+                LocalTestNeardRunner(home, runner_port, neard_rpc_port,
+                                     neard_protocol_port)))
+
+    return traffic_generator, nodes
+
+
+def kill_neard_runner(home):
+    kill_process(home / 'pid.txt')
+
+
+def kill_neard_runners(local_mocknet_path):
+    kill_neard_runner(local_mocknet_path / 'traffic-generator')
+    node_homes = get_node_homes(local_mocknet_path)
+    for home in node_homes:
+        kill_neard_runner(home)
+
+
+def wait_node_serving(node):
+    while True:
+        try:
+            node.neard_runner_ready()
+            return
+        except requests.exceptions.ConnectionError:
+            pass
+        time.sleep(0.5)
+
+
+def local_test_setup_cmd(args):
+    prompt_flags(args)
+
+    local_mocknet_path = pathlib.Path.home() / '.near/local-mocknet'
+    if os.path.exists(local_mocknet_path):
+        if not args.yes:
+            print(
+                f'{local_mocknet_path} already exists. This command will delete and reinitialize it. Continue? [yes/no]:'
+            )
+            if sys.stdin.readline().strip() != 'yes':
+                return
+        kill_neard_runners(local_mocknet_path)
+        shutil.rmtree(local_mocknet_path)
+
+    neard_binary_path = pathlib.Path(args.neard_binary_path)
+    source_home_dir = pathlib.Path(args.source_home_dir)
+
+    os.mkdir(local_mocknet_path)
+    traffic_generator_home, node_homes = mkdirs(local_mocknet_path)
+
+    copy_source_home(source_home_dir, traffic_generator_home / '.near')
+    make_records(neard_binary_path, traffic_generator_home / '.near',
+                 args.fork_height)
+    for node_home in node_homes:
+        shutil.copyfile(traffic_generator_home / '.near/setup/genesis.json',
+                        node_home / '.near/setup/genesis.json')
+        shutil.copyfile(traffic_generator_home / '.near/setup/records.json',
+                        node_home / '.near/setup/records.json')
+
+    # now set up an HTTP server to serve the binary that each neard_runner.py will request
+    binaries_path = make_binaries_dir(local_mocknet_path, neard_binary_path)
+    binaries_server_addr = 'localhost'
+    binaries_server_port = 8000
+    binaries_server = Server(addr=(binaries_server_addr, binaries_server_port),
+                             directory=binaries_path)
+    server_thread = threading.Thread(
+        target=lambda: binaries_server.serve_forever(), daemon=True)
+    server_thread.start()
+
+    node_config = {
+        'is_traffic_generator':
+            False,
+        'binaries': [{
+            'url':
+                f'http://{binaries_server_addr}:{binaries_server_port}/neard',
+            'epoch_height':
+                0
+        }]
+    }
+    traffic_generator_config = {
+        'is_traffic_generator':
+            True,
+        'binaries': [{
+            'url':
+                f'http://{binaries_server_addr}:{binaries_server_port}/neard',
+            'epoch_height':
+                0
+        }]
+    }
+
+    write_config(traffic_generator_home, traffic_generator_config)
+    for node_home in node_homes:
+        write_config(node_home, node_config)
+
+    traffic_generator, nodes = get_nodes(local_mocknet_path)
+    traffic_generator.start_neard_runner()
+    for node in nodes:
+        node.start_neard_runner()
+
+    for node in [traffic_generator] + nodes:
+        wait_node_serving(node)
+
+    print(
+        f'All directories initialized. neard runners are running in dirs: {[str(traffic_generator.node.home)] + [str(n.node.home) for n in nodes]}, listening on respective ports: {[traffic_generator.node.port] + [n.node.port for n in nodes]}'
+    )
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser(description='Run a load test')
+    subparsers = parser.add_subparsers(title='subcommands',
+                                       description='valid subcommands')
+
+    local_test_setup_parser = subparsers.add_parser('local-test-setup',
+                                                    help='''
+        Setup several instances of neard-runner to run locally. Then the mirror.py --local-test
+        argument can be used to test these test scripts themselves.
+        ''')
+    local_test_setup_parser.add_argument('--num-nodes', type=int)
+    # TODO: add a --neard-upgrade-binary-path flag too
+    local_test_setup_parser.add_argument('--neard-binary-path', type=str)
+    local_test_setup_parser.add_argument('--source-home-dir',
+                                         type=str,
+                                         help='''
+    Near home directory containing some transactions that can be used to create a forked state
+    for transaction mirroring. This could be a home dir from a pytest in tests/sanity, for example.
+    ''')
+    local_test_setup_parser.add_argument('--fork-height',
+                                         type=int,
+                                         help='''
+    Height where state should be forked from in the directory indicated by --source-home-dir. Ideally this should
+    be a height close to the node's tail. This is something that could be automated if there were an easy
+    way to get machine-readable valid heights in a near data directory, but for now this flag must be given manually.
+    ''')
+    local_test_setup_parser.add_argument('--yes', action='store_true')
+    local_test_setup_parser.set_defaults(func=local_test_setup_cmd)
+
+    args = parser.parse_args()
+    args.func(args)

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -198,9 +198,6 @@ def hard_reset_cmd(args, traffic_generator, nodes):
         Continue? [yes/no]""")
     if sys.stdin.readline().strip() != 'yes':
         return
-    all_nodes = nodes + [traffic_generator]
-    pmap(stop_neard_runner, all_nodes)
-    mocknet.stop_nodes(all_nodes)
     init_neard_runners(args, traffic_generator, nodes, remove_home_dir=True)
 
 

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -116,8 +116,9 @@ def init_neard_runner(node, config, remove_home_dir=False):
 
 
 def stop_neard_runner(node):
-    # it's probably fine for now, but this is very heavy handed/not precise
-    node.machine.run('kill $(ps -C python -o pid=)')
+    # this looks for python processes with neard_runner.py in the command line. the first word will
+    # be the pid, which we extract with the last awk command
+    node.machine.run('kill $(ps -C python -o pid=,cmd= | grep neard_runner.py | awk \'{print $1};\')')
 
 
 def prompt_init_flags(args):

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -130,6 +130,10 @@ def restart_cmd(args, traffic_generator, nodes):
     pmap(lambda node: node.start_neard_runner(), all_nodes)
 
 
+def stop_runner_cmd(args, traffic_generator, nodes):
+    pmap(lambda node: node.stop_neard_runner(), nodes + [traffic_generator])
+
+
 # returns boot nodes and validators we want for the new test network
 def get_network_nodes(new_test_rpc_responses, num_validators):
     validators = []
@@ -317,6 +321,10 @@ if __name__ == '__main__':
         help='''Restarts the neard runner on all nodes.''')
     restart_parser.add_argument('--upload-program', action='store_true')
     restart_parser.set_defaults(func=restart_cmd, upload_program=False)
+
+    stop_runner_parser = subparsers.add_parser(
+        'stop-neard-runner', help='''Stops the neard runner on all nodes.''')
+    stop_runner_parser.set_defaults(func=stop_runner_cmd)
 
     hard_reset_parser = subparsers.add_parser(
         'hard-reset',

--- a/pytest/tests/mocknet/node_handle.py
+++ b/pytest/tests/mocknet/node_handle.py
@@ -1,0 +1,111 @@
+import pathlib
+import requests
+import sys
+import time
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
+
+from configured_logger import logger
+
+
+class NodeHandle:
+
+    def __init__(self, node):
+        self.node = node
+
+    def name(self):
+        return self.node.name()
+
+    def ip_addr(self):
+        return self.node.ip_addr()
+
+    def stop_neard_runner(self):
+        self.node.stop_neard_runner()
+
+    def start_neard_runner(self):
+        self.node.start_neard_runner()
+
+    def upload_neard_runner(self):
+        self.node.upload_neard_runner()
+
+    def init_neard_runner(self, config, remove_home_dir=False):
+        self.node.stop_neard_runner()
+        self.node.init()
+        self.node.mk_neard_runner_home(remove_home_dir)
+        self.node.upload_neard_runner()
+        # TODO: this config file should just be replaced by parameters to the new-test
+        # rpc method. This was originally made a config file instead because the rpc port
+        # was open to the internet, but now that we call it via ssh instead (which we should
+        # have done from the beginning), it's not really necessary and just an arbitrary difference
+        self.node.upload_neard_runner_config(config)
+        self.node.init_python()
+        self.node.start_neard_runner()
+
+    # TODO: is the validators RPC the best way to do this? What are we trying to
+    # test for exactly? The use of this is basically just cargo culted from a while ago,
+    # but maybe we should consider something else
+    def wait_node_up(self):
+        while True:
+            try:
+                res = self.node.get_validators()
+                if 'error' not in res:
+                    assert 'result' in res
+                    logger.info(f'Node {self.node.name()} is up')
+                    return
+            except (ConnectionRefusedError,
+                    requests.exceptions.ConnectionError) as e:
+                pass
+            time.sleep(10)
+
+    def neard_runner_jsonrpc(self, method, params=[]):
+        body = {
+            'method': method,
+            'params': params,
+            'id': 'dontcare',
+            'jsonrpc': '2.0'
+        }
+        response = self.node.neard_runner_post(body)
+        if 'error' in response:
+            # TODO: errors should be handled better here in general but just exit for now
+            sys.exit(
+                f'bad response trying to send {method} JSON RPC to neard runner on {self.node.name()}:\n{response}'
+            )
+        return response['result']
+
+    def neard_runner_start(self):
+        return self.neard_runner_jsonrpc('start')
+
+    def neard_runner_stop(self):
+        return self.neard_runner_jsonrpc('stop')
+
+    def neard_runner_new_test(self):
+        return self.neard_runner_jsonrpc('new_test')
+
+    def neard_runner_network_init(self, validators, boot_nodes, epoch_length,
+                                  num_seats, protocol_version):
+        return self.neard_runner_jsonrpc(
+            'network_init',
+            params={
+                'validators': validators,
+                'boot_nodes': boot_nodes,
+                'epoch_length': epoch_length,
+                'num_seats': num_seats,
+                'protocol_version': protocol_version,
+            })
+
+    def neard_runner_ready(self):
+        return self.neard_runner_jsonrpc('ready')
+
+    def neard_runner_reset(self):
+        return self.neard_runner_jsonrpc('reset')
+
+    def neard_runner_update_binaries(self):
+        return self.neard_runner_jsonrpc('update_binaries')
+
+    def neard_update_config(self, key_value):
+        return self.neard_runner_jsonrpc(
+            'update_config',
+            params={
+                "key_value": key_value,
+            },
+        )

--- a/pytest/tests/mocknet/node_handle.py
+++ b/pytest/tests/mocknet/node_handle.py
@@ -19,6 +19,9 @@ class NodeHandle:
     def ip_addr(self):
         return self.node.ip_addr()
 
+    def neard_port(self):
+        return self.node.neard_port()
+
     def stop_neard_runner(self):
         self.node.stop_neard_runner()
 
@@ -79,7 +82,8 @@ class NodeHandle:
         return self.neard_runner_jsonrpc('stop')
 
     def neard_runner_new_test(self):
-        return self.neard_runner_jsonrpc('new_test')
+        params = self.node.new_test_params()
+        return self.neard_runner_jsonrpc('new_test', params)
 
     def neard_runner_network_init(self, validators, boot_nodes, epoch_length,
                                   num_seats, protocol_version):

--- a/pytest/tests/mocknet/remote_node.py
+++ b/pytest/tests/mocknet/remote_node.py
@@ -24,6 +24,9 @@ class RemoteNeardRunner:
     def ip_addr(self):
         return self.node.machine.ip
 
+    def neard_port(self):
+        return 3030
+
     def init(self):
         cmd_utils.init_node(self.node)
 
@@ -73,6 +76,9 @@ class RemoteNeardRunner:
         body = body.replace("'", "'\"'\"'")
         r = cmd_utils.run_cmd(self.node, f'curl localhost:3000 -d \'{body}\'')
         return json.loads(r.stdout)
+
+    def new_test_params(self):
+        return []
 
     def get_validators(self):
         return self.node.get_validators()

--- a/pytest/tests/mocknet/remote_node.py
+++ b/pytest/tests/mocknet/remote_node.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+defines the RemoteNeardRunner class meant to be interacted with over ssh
+"""
+import pathlib
+import json
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
+
+import cmd_utils
+from node_handle import NodeHandle
+import mocknet
+
+
+class RemoteNeardRunner:
+
+    def __init__(self, node):
+        self.node = node
+
+    def name(self):
+        return self.node.instance_name
+
+    def ip_addr(self):
+        return self.node.machine.ip
+
+    def init(self):
+        cmd_utils.init_node(self.node)
+
+    def mk_neard_runner_home(self, remove_home_dir):
+        if remove_home_dir:
+            cmd_utils.run_cmd(
+                self.node,
+                'rm -rf /home/ubuntu/neard-runner && mkdir -p /home/ubuntu/neard-runner'
+            )
+        else:
+            cmd_utils.run_cmd(self.node, 'mkdir -p /home/ubuntu/neard-runner')
+
+    def upload_neard_runner(self):
+        self.node.machine.upload('tests/mocknet/helpers/neard_runner.py',
+                                 '/home/ubuntu/neard-runner',
+                                 switch_user='ubuntu')
+        self.node.machine.upload('tests/mocknet/helpers/requirements.txt',
+                                 '/home/ubuntu/neard-runner',
+                                 switch_user='ubuntu')
+
+    def upload_neard_runner_config(self, config):
+        mocknet.upload_json(self.node, '/home/ubuntu/neard-runner/config.json',
+                            config)
+
+    def init_python(self):
+        cmd = 'cd /home/ubuntu/neard-runner && python3 -m virtualenv venv -p $(which python3)' \
+        ' && ./venv/bin/pip install -r requirements.txt'
+        cmd_utils.run_cmd(self.node, cmd)
+
+    def stop_neard_runner(self):
+        # this looks for python processes with neard_runner.py in the command line. the first word will
+        # be the pid, which we extract with the last awk command
+        self.node.machine.run(
+            'kill $(ps -C python -o pid=,cmd= | grep neard_runner.py | awk \'{print $1};\')'
+        )
+
+    def start_neard_runner(self):
+        cmd_utils.run_in_background(self.node, f'/home/ubuntu/neard-runner/venv/bin/python /home/ubuntu/neard-runner/neard_runner.py ' \
+            '--home /home/ubuntu/neard-runner --neard-home /home/ubuntu/.near ' \
+            '--neard-logs /home/ubuntu/neard-logs --port 3000', 'neard-runner.txt')
+
+    def neard_runner_post(self, body):
+        body = json.dumps(body)
+        # '"'"' will be interpreted as ending the first quote and then concatenating it with "'",
+        # followed by a new quote started with ' and the rest of the string, to get any single quotes
+        # in method or params into the command correctly
+        body = body.replace("'", "'\"'\"'")
+        r = cmd_utils.run_cmd(self.node, f'curl localhost:3000 -d \'{body}\'')
+        return json.loads(r.stdout)
+
+    def get_validators(self):
+        return self.node.get_validators()
+
+
+def get_nodes(chain_id, start_height, unique_id):
+    pattern = chain_id + '-' + str(start_height) + '-' + unique_id
+    all_nodes = mocknet.get_nodes(pattern=pattern)
+    if len(all_nodes) < 1:
+        sys.exit(f'no known nodes matching {pattern}')
+
+    traffic_generator = None
+    nodes = []
+    for n in all_nodes:
+        if n.instance_name.endswith('traffic'):
+            if traffic_generator is not None:
+                sys.exit(
+                    f'more than one traffic generator instance found. {traffic_generator.instance_name} and {n.instance_name}'
+                )
+            traffic_generator = n
+        else:
+            nodes.append(n)
+
+    if traffic_generator is None:
+        sys.exit(f'no traffic generator instance found')
+    return NodeHandle(RemoteNeardRunner(traffic_generator)), [
+        NodeHandle(RemoteNeardRunner(node)) for node in nodes
+    ]


### PR DESCRIPTION
This splits out common functionality previously written out in mirror.py into a `NodeHandle` class, and then provides two implementations, one for real mocknet tests over SSH, and one for local testing that starts neard runner processes locally. This is helpful because without this, it can be very difficult to test changes to the mocknet scripts themselves, as starting a real mocknet test can be expensive and time consuming

The `local_test_node.py` file added here includes a command that can be used to set up a local test with state taken from a local near home directory. An example of how to use it is:

```
$ cd pytest/
$ python3 tests/sanity/{your_favorite_test}
$ # find a height close to tail, trying different values until you get a DBNotFound error. Use a height close to the tail as the --fork-height argument in the next command
$ ~/nearcore/target/debug/neard --home ~/.near/test0_finished view-state view-chain --height {some_height}
$ python3 tests/mocknet/local_test_node.py local-test-setup --num-nodes 3 --source-home-dir ~/.near/test0_finished --neard-binary-path ~/nearcore/target/debug/neard --fork-height {some_height}
[2024-03-19 15:26:48] INFO: started neard runner process with pid 1489770 listening on port 3000
[2024-03-19 15:26:48] INFO: started neard runner process with pid 1489771 listening on port 3001
[2024-03-19 15:26:48] INFO: started neard runner process with pid 1489772 listening on port 3002
[2024-03-19 15:26:48] INFO: started neard runner process with pid 1489773 listening on port 3003
127.0.0.1 - - [19/Mar/2024 15:26:48] "GET /neard HTTP/1.1" 200 -
127.0.0.1 - - [19/Mar/2024 15:26:51] "GET /neard HTTP/1.1" 200 -
127.0.0.1 - - [19/Mar/2024 15:26:55] "GET /neard HTTP/1.1" 200 -
127.0.0.1 - - [19/Mar/2024 15:27:17] "GET /neard HTTP/1.1" 200 -
All directories initialized. neard runners are running in dirs: ['~/.near/local-mocknet/traffic-generator', '~/.near/local-mocknet/node0', '~/.near/local-mocknet/node1', '~/.near/local-mocknet/node2'], listening on respective ports: [3000, 3001, 3002, 3003]
$ # now use the normal mirror.py script with the --local-test flag instead of the usual --chain-id, --unique-id and --start-height
$ python3 tests/mocknet/mirror.py --local-test new-test
$ python3 tests/mocknet/mirror.py --local-test start-traffic
```
