### PR TITLE
fix(mocknet): ignore ReadTimeout errors from neard status page

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -499,7 +499,8 @@ class NeardRunner:
                 else:
                     break
             return path
-        except (requests.exceptions.ConnectionError, KeyError):
+        except (requests.exceptions.ConnectionError,
+                requests.exceptions.ReadTimeout, KeyError):
             return self.data['current_neard_path']
 
     def run_neard(self, cmd, out_file=None):


### PR DESCRIPTION
if the neard runner gets a ReadTimeout error from neard when trying to check the epoch height, this isn't a reason to crash, since it can just be retried later