### PR TITLE
config: default `max_loaded_contracts` to 256

### DIFF
--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -348,7 +348,7 @@ impl Default for Config {
                 default_produce_chunk_add_transactions_time_limit(),
             chunk_distribution_network: None,
             orphan_state_witness_pool_size: default_orphan_state_witness_pool_size(),
-            max_loaded_contracts: 128,
+            max_loaded_contracts: 256,
         }
     }
 }


### PR DESCRIPTION
As per https://near.zulipchat.com/#narrow/stream/295306-contract-runtime/topic/bottleneck.20on.20compile_and_load/near/427771708

This should be 2GB of RAM at most.