### PR TITLE
yield/resume: separate timeout receipts in balance checker

### DIFF
--- a/chain/jsonrpc/res/rpc_errors_schema.json
+++ b/chain/jsonrpc/res/rpc_errors_schema.json
@@ -141,6 +141,7 @@
         "other_burnt_amount": "",
         "outgoing_receipts_balance": "",
         "processed_delayed_receipts_balance": "",
+        "processed_yield_timeout_receipts_balance": "",
         "slashed_burnt_amount": "",
         "tx_burnt_amount": ""
       }

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -644,6 +644,8 @@ pub struct BalanceMismatchError {
     #[serde(with = "dec_format")]
     pub processed_delayed_receipts_balance: Balance,
     #[serde(with = "dec_format")]
+    pub processed_yield_timeout_receipts_balance: Balance,
+    #[serde(with = "dec_format")]
     pub initial_postponed_receipts_balance: Balance,
     // Output balances
     #[serde(with = "dec_format")]
@@ -670,6 +672,7 @@ impl Display for BalanceMismatchError {
             .saturating_add(self.initial_accounts_balance)
             .saturating_add(self.incoming_receipts_balance)
             .saturating_add(self.processed_delayed_receipts_balance)
+            .saturating_add(self.processed_yield_timeout_receipts_balance)
             .saturating_add(self.initial_postponed_receipts_balance);
         let final_balance = self
             .final_accounts_balance
@@ -687,6 +690,7 @@ impl Display for BalanceMismatchError {
              \tInitial accounts balance sum: {}\n\
              \tIncoming receipts balance sum: {}\n\
              \tProcessed delayed receipts balance sum: {}\n\
+             \tProcessed yield timeout receipts balance sum: {}\n\
              \tInitial postponed receipts balance sum: {}\n\
              Outputs:\n\
              \tFinal accounts balance sum: {}\n\
@@ -702,6 +706,7 @@ impl Display for BalanceMismatchError {
             self.initial_accounts_balance,
             self.incoming_receipts_balance,
             self.processed_delayed_receipts_balance,
+            self.processed_yield_timeout_receipts_balance,
             self.initial_postponed_receipts_balance,
             self.final_accounts_balance,
             self.outgoing_receipts_balance,

--- a/runtime/runtime/src/balance_checker.rs
+++ b/runtime/runtime/src/balance_checker.rs
@@ -181,10 +181,10 @@ pub(crate) fn check_balance(
     let receipts_cost = |receipts: &[Receipt]| -> Result<Balance, IntegerOverflowError> {
         total_receipts_cost(config, receipts)
     };
-    let incoming_receipts_balance =
-        receipts_cost(incoming_receipts)? + receipts_cost(yield_timeout_receipts)?;
+    let incoming_receipts_balance = receipts_cost(incoming_receipts)?;
     let outgoing_receipts_balance = receipts_cost(outgoing_receipts)?;
     let processed_delayed_receipts_balance = receipts_cost(&processed_delayed_receipts)?;
+    let processed_yield_timeout_receipts_balance = receipts_cost(yield_timeout_receipts)?;
     let new_delayed_receipts_balance = receipts_cost(&new_delayed_receipts)?;
 
     // Postponed actions receipts. The receipts can be postponed and stored with the receiver's
@@ -242,6 +242,7 @@ pub(crate) fn check_balance(
         initial_accounts_balance,
         incoming_receipts_balance,
         processed_delayed_receipts_balance,
+        processed_yield_timeout_receipts_balance,
         initial_postponed_receipts_balance
     );
     let final_balance = safe_add_balance_apply!(
@@ -260,6 +261,7 @@ pub(crate) fn check_balance(
             initial_accounts_balance,
             incoming_receipts_balance,
             processed_delayed_receipts_balance,
+            processed_yield_timeout_receipts_balance,
             initial_postponed_receipts_balance,
             // Outputs
             final_accounts_balance,


### PR DESCRIPTION
Instead of lumping in yield timeouts with incoming receipts, gives them their own field in BalanceMismatchError. 