### PR TITLE
fix(resharding) - fixed resharding rpc tx test

### DIFF
--- a/pytest/tests/sanity/resharding_rpc_tx.py
+++ b/pytest/tests/sanity/resharding_rpc_tx.py
@@ -16,7 +16,7 @@ from configured_logger import logger
 import cluster
 from resharding_lib import ReshardingTestBase, get_genesis_config_changes, get_client_config_changes
 import transaction
-from utils import MetricsTracker, poll_blocks
+from utils import MetricsTracker, poll_blocks, wait_for_blocks
 import key
 
 STARTING_AMOUNT = 123 * (10**24)
@@ -25,7 +25,11 @@ STARTING_AMOUNT = 123 * (10**24)
 class ReshardingRpcTx(ReshardingTestBase):
 
     def setUp(self) -> None:
-        super().setUp(epoch_length=5)
+        # The epoch needs to be quite long because we submit transactions and
+        # wait for the response which takes some blocks. We need to make sure
+        # that transactions are fully processed before resharding so that the
+        # test checks the right things.
+        super().setUp(epoch_length=20)
 
     def __setup_account(self, account_id, nonce):
         """ Create an account with full access key and balance. """
@@ -40,6 +44,7 @@ class ReshardingRpcTx(ReshardingTestBase):
         return account
 
     def __submit_transfer_tx(self, from_key, to_account_id, nonce):
+        logger.info(f"submit transfer tx from {from_key} to {to_account_id}")
         """ Submit a transfer transaction and wait for the response. """
         encoded_block_hash = self.node.get_latest_block().hash_bytes
         payment_tx = transaction.sign_payment_tx(from_key, to_account_id, 100,
@@ -89,8 +94,9 @@ class ReshardingRpcTx(ReshardingTestBase):
         account0 = self.__setup_account('setup_test_account.test0', 1)
         account1 = self.__setup_account('z_setup_test_account.test0', 2)
 
+        logger.info("wait for one block to create the accounts")
         # Poll one block to create the accounts
-        poll_blocks(self.node)
+        wait_for_blocks(self.node, count=1)
 
         # Submit a transfer transaction between the accounts, we would verify the transaction status later
         response0 = self.__submit_transfer_tx(
@@ -107,7 +113,7 @@ class ReshardingRpcTx(ReshardingTestBase):
         metrics_tracker = MetricsTracker(self.node)
         for height, _ in poll_blocks(self.node):
             # wait for resharding to complete
-            if height < 2 * self.epoch_length:
+            if height <= 2 * self.epoch_length + self.epoch_offset:
                 continue
 
             # Quick check whether resharding is completed


### PR DESCRIPTION
The test waits for transactions to get fully processed which slows it down. I extended the epoch lenght so that we can comfortably prepare and send transactions before resharding and check the status after. 

There was a small bug in the epoch boundary calculation that wasn't exposed until now because we would always enter the loop late. 