### PR TITLE
backport: optimization: do not load the wasm contract code if it is already cached

### DIFF
--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -25,7 +25,7 @@ use near_primitives::receipt::{DelayedReceiptIndices, Receipt, ReceivedData};
 pub use near_primitives::shard_layout::ShardUId;
 use near_primitives::trie_key::{trie_key_parsers, TrieKey};
 use near_primitives::types::{AccountId, StateRoot};
-use near_vm_runner::{CompiledContract, ContractCode, ContractRuntimeCache};
+use near_vm_runner::{CompiledContractInfo, ContractCode, ContractRuntimeCache};
 use once_cell::sync::Lazy;
 use std::fs::File;
 use std::path::Path;
@@ -892,9 +892,9 @@ impl ContractRuntimeCache for StoreContractRuntimeCache {
         target = "store",
         "StoreContractRuntimeCache::put",
         skip_all,
-        fields(key = key.to_string(), value.len = value.debug_len()),
+        fields(key = key.to_string(), value.len = value.compiled.debug_len()),
     )]
-    fn put(&self, key: &CryptoHash, value: CompiledContract) -> io::Result<()> {
+    fn put(&self, key: &CryptoHash, value: CompiledContractInfo) -> io::Result<()> {
         let mut update = crate::db::DBTransaction::new();
         // We intentionally use `.set` here, rather than `.insert`. We don't yet
         // guarantee deterministic compilation, so, if we happen to compile the
@@ -915,9 +915,9 @@ impl ContractRuntimeCache for StoreContractRuntimeCache {
         skip_all,
         fields(key = key.to_string()),
     )]
-    fn get(&self, key: &CryptoHash) -> io::Result<Option<CompiledContract>> {
+    fn get(&self, key: &CryptoHash) -> io::Result<Option<CompiledContractInfo>> {
         match self.db.get_raw_bytes(DBCol::CachedContractCode, key.as_ref()) {
-            Ok(Some(bytes)) => Ok(Some(CompiledContract::try_from_slice(&bytes)?)),
+            Ok(Some(bytes)) => Ok(Some(CompiledContractInfo::try_from_slice(&bytes)?)),
             Ok(None) => Ok(None),
             Err(err) => Err(err),
         }
@@ -935,6 +935,7 @@ impl ContractRuntimeCache for StoreContractRuntimeCache {
 #[cfg(test)]
 mod tests {
     use near_primitives::hash::CryptoHash;
+    use near_vm_runner::CompiledContractInfo;
 
     use super::{DBCol, NodeStorage, Store};
 
@@ -1058,7 +1059,10 @@ mod tests {
         assert_eq!(None, cache.get(&key).unwrap());
         assert_eq!(false, cache.has(&key).unwrap());
 
-        let record = CompiledContract::Code(b"foo".to_vec());
+        let record = CompiledContractInfo {
+            wasm_bytes: 3,
+            compiled: CompiledContract::Code(b"foo".to_vec()),
+        };
         cache.put(&key, record.clone()).unwrap();
         assert_eq!(Some(record), cache.get(&key).unwrap());
         assert_eq!(true, cache.has(&key).unwrap());

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -3571,7 +3571,7 @@ mod contract_precompilation_tests {
             .epoch_id()
             .clone();
         let runtime_config = env.get_runtime_config(0, epoch_id);
-        let key = get_contract_cache_key(&contract_code, &runtime_config.wasm_config);
+        let key = get_contract_cache_key(*contract_code.hash(), &runtime_config.wasm_config);
         for i in 0..num_clients {
             caches[i]
                 .get(&key)
@@ -3677,11 +3677,11 @@ mod contract_precompilation_tests {
             .clone();
         let runtime_config = env.get_runtime_config(0, epoch_id);
         let tiny_contract_key = get_contract_cache_key(
-            &ContractCode::new(tiny_wasm_code.clone(), None),
+            *ContractCode::new(tiny_wasm_code.clone(), None).hash(),
             &runtime_config.wasm_config,
         );
         let test_contract_key = get_contract_cache_key(
-            &ContractCode::new(wasm_code.clone(), None),
+            *ContractCode::new(wasm_code.clone(), None).hash(),
             &runtime_config.wasm_config,
         );
 
@@ -3757,7 +3757,7 @@ mod contract_precompilation_tests {
             .clone();
         let runtime_config = env.get_runtime_config(0, epoch_id);
         let contract_key = get_contract_cache_key(
-            &ContractCode::new(wasm_code.clone(), None),
+            *ContractCode::new(wasm_code.clone(), None).hash(),
             &runtime_config.wasm_config,
         );
 

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
@@ -32,10 +32,11 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMOutcome {
 
     let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
     let res = vm_kind.runtime(wasm_config).unwrap().run(
-        code,
+        *code.hash(),
+        Some(&code),
         &method_name,
         &mut fake_external,
-        context,
+        &context,
         fees,
         &promise_results,
         None,

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
@@ -30,6 +30,15 @@ fn run_fuzz(code: &ContractCode, config: Arc<RuntimeConfig>) -> VMOutcome {
     vm_kind
         .runtime(wasm_config)
         .unwrap()
-        .run(code, &method_name, &mut fake_external, context, fees, &promise_results, None)
+        .run(
+            *code.hash(),
+            Some(&code),
+            &method_name,
+            &mut fake_external,
+            &context,
+            fees,
+            &promise_results,
+            None,
+        )
         .unwrap_or_else(|err| panic!("fatal error: {err:?}"))
 }

--- a/runtime/near-vm-runner/src/cache.rs
+++ b/runtime/near-vm-runner/src/cache.rs
@@ -18,7 +18,8 @@ enum ContractCacheKey {
     _Version1,
     _Version2,
     _Version3,
-    Version4 {
+    _Version4,
+    Version5 {
         code_hash: CryptoHash,
         vm_config_non_crypto_hash: u64,
         vm_kind: VMKind,
@@ -47,10 +48,10 @@ fn vm_hash(vm_kind: VMKind) -> u64 {
     }
 }
 
-pub fn get_contract_cache_key(code: &ContractCode, config: &Config) -> CryptoHash {
+pub fn get_contract_cache_key(code_hash: CryptoHash, config: &Config) -> CryptoHash {
     let _span = tracing::debug_span!(target: "vm", "get_key").entered();
-    let key = ContractCacheKey::Version4 {
-        code_hash: *code.hash(),
+    let key = ContractCacheKey::Version5 {
+        code_hash,
         vm_config_non_crypto_hash: config.non_crypto_hash(),
         vm_kind: config.vm_kind,
         vm_hash: vm_hash(config.vm_kind),
@@ -76,6 +77,12 @@ impl CompiledContract {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, BorshDeserialize, BorshSerialize)]
+pub struct CompiledContractInfo {
+    pub wasm_bytes: u64,
+    pub compiled: CompiledContract,
+}
+
 /// Cache for compiled modules
 pub trait ContractRuntimeCache: Send + Sync {
     fn handle(&self) -> Box<dyn ContractRuntimeCache>;
@@ -85,8 +92,8 @@ pub trait ContractRuntimeCache: Send + Sync {
             once_cell::sync::Lazy::new(|| AnyCache::new(0));
         &ZERO_ANY_CACHE
     }
-    fn put(&self, key: &CryptoHash, value: CompiledContract) -> std::io::Result<()>;
-    fn get(&self, key: &CryptoHash) -> std::io::Result<Option<CompiledContract>>;
+    fn put(&self, key: &CryptoHash, value: CompiledContractInfo) -> std::io::Result<()>;
+    fn get(&self, key: &CryptoHash) -> std::io::Result<Option<CompiledContractInfo>>;
     fn has(&self, key: &CryptoHash) -> std::io::Result<bool> {
         self.get(key).map(|entry| entry.is_some())
     }
@@ -103,11 +110,11 @@ impl ContractRuntimeCache for Box<dyn ContractRuntimeCache> {
         <dyn ContractRuntimeCache>::handle(&**self)
     }
 
-    fn put(&self, key: &CryptoHash, value: CompiledContract) -> std::io::Result<()> {
+    fn put(&self, key: &CryptoHash, value: CompiledContractInfo) -> std::io::Result<()> {
         <dyn ContractRuntimeCache>::put(&**self, key, value)
     }
 
-    fn get(&self, key: &CryptoHash) -> std::io::Result<Option<CompiledContract>> {
+    fn get(&self, key: &CryptoHash) -> std::io::Result<Option<CompiledContractInfo>> {
         <dyn ContractRuntimeCache>::get(&**self, key)
     }
 
@@ -121,11 +128,11 @@ impl<C: ContractRuntimeCache> ContractRuntimeCache for &C {
         <C as ContractRuntimeCache>::handle(self)
     }
 
-    fn put(&self, key: &CryptoHash, value: CompiledContract) -> std::io::Result<()> {
+    fn put(&self, key: &CryptoHash, value: CompiledContractInfo) -> std::io::Result<()> {
         <C as ContractRuntimeCache>::put(self, key, value)
     }
 
-    fn get(&self, key: &CryptoHash) -> std::io::Result<Option<CompiledContract>> {
+    fn get(&self, key: &CryptoHash) -> std::io::Result<Option<CompiledContractInfo>> {
         <C as ContractRuntimeCache>::get(self, key)
     }
 
@@ -142,18 +149,18 @@ impl ContractRuntimeCache for NoContractRuntimeCache {
         Box::new(self.clone())
     }
 
-    fn put(&self, _: &CryptoHash, _: CompiledContract) -> std::io::Result<()> {
+    fn put(&self, _: &CryptoHash, _: CompiledContractInfo) -> std::io::Result<()> {
         Ok(())
     }
 
-    fn get(&self, _: &CryptoHash) -> std::io::Result<Option<CompiledContract>> {
+    fn get(&self, _: &CryptoHash) -> std::io::Result<Option<CompiledContractInfo>> {
         Ok(None)
     }
 }
 
 #[derive(Default, Clone)]
 pub struct MockContractRuntimeCache {
-    store: Arc<Mutex<HashMap<CryptoHash, CompiledContract>>>,
+    store: Arc<Mutex<HashMap<CryptoHash, CompiledContractInfo>>>,
 }
 
 impl MockContractRuntimeCache {
@@ -163,12 +170,12 @@ impl MockContractRuntimeCache {
 }
 
 impl ContractRuntimeCache for MockContractRuntimeCache {
-    fn put(&self, key: &CryptoHash, value: CompiledContract) -> std::io::Result<()> {
+    fn put(&self, key: &CryptoHash, value: CompiledContractInfo) -> std::io::Result<()> {
         self.store.lock().unwrap().insert(*key, value);
         Ok(())
     }
 
-    fn get(&self, key: &CryptoHash) -> std::io::Result<Option<CompiledContract>> {
+    fn get(&self, key: &CryptoHash) -> std::io::Result<Option<CompiledContractInfo>> {
         Ok(self.store.lock().unwrap().get(key).map(Clone::clone))
     }
 
@@ -281,9 +288,9 @@ impl ContractRuntimeCache for FilesystemContractRuntimeCache {
         target = "vm",
         "FilesystemContractRuntimeCache::put",
         skip_all,
-        fields(key = key.to_string(), value.len = value.debug_len()),
+        fields(key = key.to_string(), value.len = value.compiled.debug_len()),
     )]
-    fn put(&self, key: &CryptoHash, value: CompiledContract) -> std::io::Result<()> {
+    fn put(&self, key: &CryptoHash, value: CompiledContractInfo) -> std::io::Result<()> {
         use rustix::fs::{Mode, OFlags};
         let final_filename = key.to_string();
         let mut temp_file = tempfile::Builder::new().make_in("", |filename| {
@@ -294,7 +301,7 @@ impl ContractRuntimeCache for FilesystemContractRuntimeCache {
         // This section manually "serializes" the data. The cache is quite sensitive to
         // unnecessary overheads and in order to enable things like mmap-based file access, we want
         // to have full control of what has been written.
-        match value {
+        match value.compiled {
             CompiledContract::CompileModuleError(e) => {
                 borsh::to_writer(&mut temp_file, &e)?;
                 temp_file.write_all(&[ERROR_TAG])?;
@@ -306,6 +313,7 @@ impl ContractRuntimeCache for FilesystemContractRuntimeCache {
                 temp_file.write_all(&[CODE_TAG])?;
             }
         }
+        temp_file.write_all(&value.wasm_bytes.to_le_bytes())?;
         let temp_filename = temp_file.into_temp_path();
         // This is atomic, so there wouldn't be instances where getters see an intermediate state.
         rustix::fs::renameat(&self.state.dir, &*temp_filename, &self.state.dir, final_filename)?;
@@ -321,7 +329,7 @@ impl ContractRuntimeCache for FilesystemContractRuntimeCache {
         skip_all,
         fields(key = key.to_string()),
     )]
-    fn get(&self, key: &CryptoHash) -> std::io::Result<Option<CompiledContract>> {
+    fn get(&self, key: &CryptoHash) -> std::io::Result<Option<CompiledContractInfo>> {
         use rustix::fs::{Mode, OFlags};
         let filename = key.to_string();
         let mode = Mode::empty();
@@ -339,26 +347,34 @@ impl ContractRuntimeCache for FilesystemContractRuntimeCache {
         let mut buffer = Vec::with_capacity(stat.st_size.try_into().unwrap());
         let mut file = std::fs::File::from(file);
         file.read_to_end(&mut buffer)?;
-        match buffer.pop() {
+        if buffer.len() < 9 {
             // The file turns out to be empty/truncated? Treat as if there's no cached file.
-            None => Ok(None),
-            Some(CODE_TAG) => Ok(Some(CompiledContract::Code(buffer))),
-            Some(ERROR_TAG) => {
-                Ok(Some(CompiledContract::CompileModuleError(borsh::from_slice(&buffer)?)))
+            return Ok(None);
+        }
+        let wasm_bytes = u64::from_le_bytes(buffer[buffer.len() - 8..].try_into().unwrap());
+        let tag = buffer[buffer.len() - 9];
+        buffer.truncate(buffer.len() - 9);
+        Ok(match tag {
+            CODE_TAG => {
+                Some(CompiledContractInfo { wasm_bytes, compiled: CompiledContract::Code(buffer) })
             }
+            ERROR_TAG => Some(CompiledContractInfo {
+                wasm_bytes,
+                compiled: CompiledContract::CompileModuleError(borsh::from_slice(&buffer)?),
+            }),
             // File is malformed? For this code, since we're talking about a cache lets just treat
             // it as if there is no cached file as well. The cached file may eventually be
             // overwritten with a valid copy. And since we can compile a new copy, there doesn't
             // seem to be much reason to possibly crash the node due to this.
-            Some(_) => {
+            _ => {
                 tracing::debug!(
                     target: "vm",
                     message = "cached contract executable was found to be malformed",
                     key = %key
                 );
-                Ok(None)
+                None
             }
-        }
+        })
     }
 }
 
@@ -461,7 +477,7 @@ pub fn precompile_contract(
         Some(it) => it,
         None => return Ok(Ok(ContractPrecompilatonResult::CacheNotAvailable)),
     };
-    let key = get_contract_cache_key(code, config);
+    let key = get_contract_cache_key(*code.hash(), config);
     // Check if we already cached with such a key.
     if cache.has(&key).map_err(CacheError::ReadError)? {
         return Ok(Ok(ContractPrecompilatonResult::ContractAlreadyInCache));

--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -26,8 +26,9 @@ mod wasmtime_runner;
 
 pub use crate::logic::with_ext_cost_counter;
 pub use cache::{
-    get_contract_cache_key, precompile_contract, CompiledContract, ContractRuntimeCache,
-    FilesystemContractRuntimeCache, MockContractRuntimeCache, NoContractRuntimeCache,
+    get_contract_cache_key, precompile_contract, CompiledContract, CompiledContractInfo,
+    ContractRuntimeCache, FilesystemContractRuntimeCache, MockContractRuntimeCache,
+    NoContractRuntimeCache,
 };
 pub use code::ContractCode;
 pub use profile::ProfileDataV2;

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -32,7 +32,7 @@ pub struct VMLogic<'a> {
     /// receipts creation.
     ext: &'a mut dyn External,
     /// Part of Context API and Economics API that was extracted from the receipt.
-    context: VMContext,
+    context: &'a VMContext,
     /// All gas and economic parameters required during contract execution.
     pub(crate) config: &'a Config,
     /// Fees for creating (async) actions on runtime.
@@ -127,7 +127,7 @@ impl PublicKeyBuffer {
 impl<'a> VMLogic<'a> {
     pub fn new(
         ext: &'a mut dyn External,
-        context: VMContext,
+        context: &'a VMContext,
         config: &'a Config,
         fees_config: &'a RuntimeFeesConfig,
         promise_results: &'a [PromiseResult],
@@ -2840,7 +2840,7 @@ impl<'a> VMLogic<'a> {
     pub fn before_loading_executable(
         &mut self,
         method_name: &str,
-        wasm_code_bytes: usize,
+        wasm_code_bytes: u64,
     ) -> std::result::Result<(), super::errors::FunctionCallError> {
         if method_name.is_empty() {
             let error = super::errors::FunctionCallError::MethodResolveError(
@@ -2849,7 +2849,7 @@ impl<'a> VMLogic<'a> {
             return Err(error);
         }
         if self.config.fix_contract_loading_cost {
-            if self.add_contract_loading_fee(wasm_code_bytes as u64).is_err() {
+            if self.add_contract_loading_fee(wasm_code_bytes).is_err() {
                 let error =
                     super::errors::FunctionCallError::HostError(super::HostError::GasExceeded);
                 return Err(error);
@@ -2861,10 +2861,10 @@ impl<'a> VMLogic<'a> {
     /// Legacy code to preserve old gas charging behaviour in old protocol versions.
     pub fn after_loading_executable(
         &mut self,
-        wasm_code_bytes: usize,
+        wasm_code_bytes: u64,
     ) -> std::result::Result<(), super::errors::FunctionCallError> {
         if !self.config.fix_contract_loading_cost {
-            if self.add_contract_loading_fee(wasm_code_bytes as u64).is_err() {
+            if self.add_contract_loading_fee(wasm_code_bytes).is_err() {
                 return Err(super::errors::FunctionCallError::HostError(
                     super::HostError::GasExceeded,
                 ));

--- a/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
+++ b/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
@@ -37,10 +37,9 @@ impl VMLogicBuilder {
     }
 
     pub fn build(&mut self) -> TestVMLogic<'_> {
-        let context = self.context.clone();
         TestVMLogic::from(VMLogic::new(
             &mut self.ext,
-            context,
+            &self.context,
             &self.config,
             &self.fees_config,
             &self.promise_results,

--- a/runtime/near-vm-runner/src/near_vm_runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner.rs
@@ -1,3 +1,4 @@
+use crate::cache::CompiledContractInfo;
 use crate::errors::ContractPrecompilatonResult;
 use crate::imports::near_vm::NearVmImports;
 use crate::logic::errors::{
@@ -14,6 +15,7 @@ use crate::{prepare, NoContractRuntimeCache};
 use memoffset::offset_of;
 use near_parameters::vm::VMKind;
 use near_parameters::RuntimeFeesConfig;
+use near_primitives_core::hash::CryptoHash;
 use near_vm_compiler_singlepass::Singlepass;
 use near_vm_engine::universal::{
     MemoryPool, Universal, UniversalArtifact, UniversalEngine, UniversalExecutable,
@@ -320,15 +322,18 @@ impl NearVM {
         cache: &dyn ContractRuntimeCache,
     ) -> Result<Result<UniversalExecutable, CompilationError>, CacheError> {
         let executable_or_error = self.compile_uncached(code);
-        let key = get_contract_cache_key(code, &self.config);
-        let record = match &executable_or_error {
-            Ok(executable) => {
-                let code = executable
-                    .serialize()
-                    .map_err(|_e| CacheError::SerializationError { hash: key.0 })?;
-                CompiledContract::Code(code)
-            }
-            Err(err) => CompiledContract::CompileModuleError(err.clone()),
+        let key = get_contract_cache_key(*code.hash(), &self.config);
+        let record = CompiledContractInfo {
+            wasm_bytes: code.code().len() as u64,
+            compiled: match &executable_or_error {
+                Ok(executable) => {
+                    let code = executable
+                        .serialize()
+                        .map_err(|_e| CacheError::SerializationError { hash: key.0 })?;
+                    CompiledContract::Code(code)
+                }
+                Err(err) => CompiledContract::CompileModuleError(err.clone()),
+            },
         };
         cache.put(&key, record).map_err(CacheError::WriteError)?;
         Ok(executable_or_error)
@@ -340,79 +345,131 @@ impl NearVM {
         name = "NearVM::with_compiled_and_loaded",
         skip_all
     )]
-    fn with_compiled_and_loaded<R>(
+    fn with_compiled_and_loaded(
         &self,
-        code: &ContractCode,
+        code_hash: CryptoHash,
+        code: Option<&ContractCode>,
         cache: &dyn ContractRuntimeCache,
-        closure: impl FnOnce(&VMArtifact) -> R,
-    ) -> VMResult<Result<R, CompilationError>> {
-        type MemoryCacheType = Result<VMArtifact, CompilationError>;
+        ext: &mut dyn External,
+        context: &VMContext,
+        fees_config: &RuntimeFeesConfig,
+        promise_results: &[PromiseResult],
+        method_name: &str,
+        closure: impl FnOnce(VMMemory, VMLogic<'_>, &VMArtifact) -> Result<VMOutcome, VMRunnerError>,
+    ) -> VMResult<VMOutcome> {
+        // (wasm code size, compilation result)
+        type MemoryCacheType = (u64, Result<VMArtifact, CompilationError>);
         let to_any = |v: MemoryCacheType| -> Box<dyn std::any::Any + Send> { Box::new(v) };
-        let key = get_contract_cache_key(code, &self.config);
         cache.memory_cache().try_lookup(
-            key,
-            || {
-                // `cache` stores compiled machine code in the database
-                //
-                // Caches also cache _compilation_ errors, so that we don't have to
-                // re-parse invalid code (invalid code, in a sense, is a normal
-                // outcome). And `cache`, being a database, can fail with an `io::Error`.
-                let cache_record = {
+            code_hash,
+            || match code {
+                None => {
+                    // `cache` stores compiled machine code in the database
+                    //
+                    // Caches also cache _compilation_ errors, so that we don't have to
+                    // re-parse invalid code (invalid code, in a sense, is a normal
+                    // outcome). And `cache`, being a database, can fail with an `io::Error`.
                     let _span =
-                        tracing::debug_span!(target:"vm", "NearVM::read_cache_record").entered();
-                    cache.get(&key).map_err(CacheError::ReadError)?
-                };
+                        tracing::debug_span!(target: "vm", "NearVM::fetch_from_cache").entered();
+                    let key = get_contract_cache_key(code_hash, &self.config);
+                    let cache_record = cache.get(&key).map_err(CacheError::ReadError)?;
+                    let Some(code) = cache_record else {
+                        return Err(VMRunnerError::CacheError(CacheError::ReadError(
+                            std::io::Error::from(std::io::ErrorKind::NotFound),
+                        )));
+                    };
 
-                match cache_record {
-                    None => {}
-                    Some(CompiledContract::CompileModuleError(e)) => return Ok(to_any(Err(e))),
-                    Some(CompiledContract::Code(serialized_module)) => {
-                        let _span =
-                        tracing::debug_span!(target: "vm", "NearVM::deserialize_module_from_cache")
-                            .entered();
-                        unsafe {
-                            // (UN-)SAFETY: the `serialized_module` must have been produced by a
-                            // prior call to `serialize`.
-                            //
-                            // In practice this is not necessarily true. One could have forgotten
-                            // to change the cache key when upgrading the version of the near_vm
-                            // library or the database could have had its data corrupted while at
-                            // rest.
-                            //
-                            // There should definitely be some validation in near_vm to ensure we
-                            // load what we think we load.
-                            let executable =
-                                UniversalExecutableRef::deserialize(&serialized_module)
-                                    .map_err(|_| CacheError::DeserializationError)?;
-                            let artifact = self
-                                .engine
-                                .load_universal_executable_ref(&executable)
-                                .map(Arc::new)
-                                .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?;
-                            return Ok(to_any(Ok(artifact)));
+                    match &code.compiled {
+                        CompiledContract::CompileModuleError(err) => {
+                            Ok::<_, VMRunnerError>(to_any((code.wasm_bytes, Err(err.clone()))))
+                        }
+                        CompiledContract::Code(serialized_module) => {
+                            let _span =
+                                tracing::debug_span!(target: "vm", "NearVM::load_from_fs_cache")
+                                    .entered();
+                            unsafe {
+                                // (UN-)SAFETY: the `serialized_module` must have been produced by a prior call to
+                                // `serialize`.
+                                //
+                                // In practice this is not necessarily true. One could have forgotten to change the
+                                // cache key when upgrading the version of the near_vm library or the database could
+                                // have had its data corrupted while at rest.
+                                //
+                                // There should definitely be some validation in near_vm to ensure we load what we think
+                                // we load.
+                                let executable =
+                                    UniversalExecutableRef::deserialize(&serialized_module)
+                                        .map_err(|_| CacheError::DeserializationError)?;
+                                let artifact = self
+                                    .engine
+                                    .load_universal_executable_ref(&executable)
+                                    .map(Arc::new)
+                                    .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?;
+                                Ok(to_any((code.wasm_bytes, Ok(artifact))))
+                            }
                         }
                     }
                 }
-                let compiled = self.compile_and_cache(code, cache)?;
-                Ok(to_any(match compiled {
-                    Err(err) => Err(err),
-                    Ok(executable) => Ok(self
-                        .engine
-                        .load_universal_executable(&executable)
-                        .map(Arc::new)
-                        .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?),
-                }))
-            },
-            |value| {
-                let downcast = value
-                    .downcast_ref::<MemoryCacheType>()
-                    .expect("downcast should always succeed");
-                match &*downcast {
-                    Ok(artifact) => Ok(closure(artifact)),
-                    Err(e) => Err(CompilationError::clone(e)),
+                Some(code) => {
+                    let _span =
+                        tracing::debug_span!(target: "vm", "NearVM::build_from_source").entered();
+                    Ok(to_any((
+                        code.code().len() as u64,
+                        match self.compile_and_cache(code, cache)? {
+                            Ok(executable) => Ok(self
+                                .engine
+                                .load_universal_executable(&executable)
+                                .map(Arc::new)
+                                .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?),
+                            Err(err) => Err(err),
+                        },
+                    )))
                 }
             },
-        )
+            move |value| {
+                let _span =
+                    tracing::debug_span!(target: "vm", "NearVM::load_from_mem_cache").entered();
+                let &(wasm_bytes, ref downcast) = value
+                    .downcast_ref::<MemoryCacheType>()
+                    .expect("downcast should always succeed");
+
+                let mut memory = NearVmMemory::new(
+                    self.config.limit_config.initial_memory_pages,
+                    self.config.limit_config.max_memory_pages,
+                )
+                .expect("Cannot create memory for a contract call");
+
+                // FIXME: this mostly duplicates the `run_module` method.
+                // Note that we don't clone the actual backing memory, just increase the RC.
+                let vmmemory = memory.vm();
+                let mut logic = VMLogic::new(
+                    ext,
+                    context,
+                    &self.config,
+                    fees_config,
+                    promise_results,
+                    &mut memory,
+                );
+
+                let result = logic.before_loading_executable(method_name, wasm_bytes);
+                if let Err(e) = result {
+                    return Ok(VMOutcome::abort(logic, e));
+                }
+
+                match &*downcast {
+                    Ok(artifact) => {
+                        let result = logic.after_loading_executable(wasm_bytes);
+                        if let Err(e) = result {
+                            return Ok(VMOutcome::abort(logic, e));
+                        }
+                        closure(vmmemory, logic, artifact)
+                    }
+                    Err(e) => {
+                        Ok(VMOutcome::abort(logic, FunctionCallError::CompilationError(e.clone())))
+                    }
+                }
+            },
+        )?
     }
 
     fn run_method(
@@ -673,61 +730,36 @@ impl<'a> finite_wasm::wasmparser::VisitOperator<'a> for GasCostCfg {
 impl crate::runner::VM for NearVM {
     fn run(
         &self,
-        code: &ContractCode,
+        code_hash: CryptoHash,
+        code: Option<&ContractCode>,
         method_name: &str,
         ext: &mut dyn External,
-        context: VMContext,
+        context: &VMContext,
         fees_config: &RuntimeFeesConfig,
         promise_results: &[PromiseResult],
         cache: Option<&dyn ContractRuntimeCache>,
     ) -> Result<VMOutcome, VMRunnerError> {
-        let mut memory = NearVmMemory::new(
-            self.config.limit_config.initial_memory_pages,
-            self.config.limit_config.max_memory_pages,
-        )
-        .expect("Cannot create memory for a contract call");
-
-        // FIXME: this mostly duplicates the `run_module` method.
-        // Note that we don't clone the actual backing memory, just increase the RC.
-        let vmmemory = memory.vm();
-        let mut logic =
-            VMLogic::new(ext, context, &self.config, fees_config, promise_results, &mut memory);
-        let result = logic.before_loading_executable(method_name, code.code().len());
-        if let Err(e) = result {
-            return Ok(VMOutcome::abort(logic, e));
-        }
-
         let cache = cache.unwrap_or(&NoContractRuntimeCache);
-        enum Outcome<E> {
-            Ok,
-            Abort(E),
-            AbortButNopOutcomeInOldProtocol(E),
-        }
-        let result = self.with_compiled_and_loaded(code, cache, |artifact| {
-            let result = logic.after_loading_executable(code.code().len());
-            if let Err(e) = result {
-                return Ok(Outcome::Abort(e));
-            }
-            let import = imports::near_vm::build(vmmemory, &mut logic, artifact.engine());
-            if let Err(e) = get_entrypoint_index(&*artifact, method_name) {
-                return Ok(Outcome::AbortButNopOutcomeInOldProtocol(e));
-            }
-            match self.run_method(&artifact, import, method_name)? {
-                Ok(()) => Ok(Outcome::Ok),
-                Err(err) => Ok(Outcome::Abort(err)),
-            }
-        })?;
-        match result {
-            Ok(Ok(Outcome::Ok)) => Ok(VMOutcome::ok(logic)),
-            Ok(Ok(Outcome::Abort(e))) => Ok(VMOutcome::abort(logic, e)),
-            Ok(Ok(Outcome::AbortButNopOutcomeInOldProtocol(e))) => {
-                Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(logic, e))
-            }
-            Ok(Err(e)) => Err(e),
-            Err(err) => {
-                return Ok(VMOutcome::abort(logic, FunctionCallError::CompilationError(err)));
-            }
-        }
+        self.with_compiled_and_loaded(
+            code_hash,
+            code,
+            cache,
+            ext,
+            context,
+            fees_config,
+            promise_results,
+            method_name,
+            |vmmemory, mut logic, artifact| {
+                let import = imports::near_vm::build(vmmemory, &mut logic, artifact.engine());
+                if let Err(e) = get_entrypoint_index(&*artifact, method_name) {
+                    return Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(logic, e));
+                }
+                match self.run_method(&artifact, import, method_name)? {
+                    Ok(()) => Ok(VMOutcome::ok(logic)),
+                    Err(err) => Ok(VMOutcome::abort(logic, err)),
+                }
+            },
+        )
     }
 
     fn precompile(

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -5,6 +5,8 @@ use crate::logic::{External, VMContext, VMOutcome};
 use crate::{ContractCode, ContractRuntimeCache};
 use near_parameters::vm::{Config, VMKind};
 use near_parameters::RuntimeFeesConfig;
+use near_primitives_core::account::Account;
+use near_primitives_core::hash::CryptoHash;
 
 /// Returned by VM::run method.
 ///
@@ -40,10 +42,11 @@ pub(crate) type VMResult<T = VMOutcome> = Result<T, VMRunnerError>;
 /// The gas cost for contract preparation will be subtracted by the VM
 /// implementation.
 pub fn run(
-    code: &ContractCode,
+    account: &Account,
+    code: Option<&ContractCode>,
     method_name: &str,
     ext: &mut dyn External,
-    context: VMContext,
+    context: &VMContext,
     wasm_config: &Config,
     fees_config: &RuntimeFeesConfig,
     promise_results: &[PromiseResult],
@@ -53,7 +56,7 @@ pub fn run(
     let span = tracing::debug_span!(
         target: "vm",
         "run",
-        "code.len" = code.code().len(),
+        "code.hash" = %account.code_hash(),
         %method_name,
         ?vm_kind,
         burnt_gas = tracing::field::Empty,
@@ -64,8 +67,16 @@ pub fn run(
         .runtime(wasm_config.clone())
         .unwrap_or_else(|| panic!("the {vm_kind:?} runtime has not been enabled at compile time"));
 
-    let outcome =
-        runtime.run(code, method_name, ext, context, fees_config, promise_results, cache)?;
+    let outcome = runtime.run(
+        account.code_hash(),
+        code,
+        method_name,
+        ext,
+        context,
+        fees_config,
+        promise_results,
+        cache,
+    )?;
 
     span.record("burnt_gas", &outcome.burnt_gas);
     Ok(outcome)
@@ -88,10 +99,11 @@ pub trait VM {
     /// implementation.
     fn run(
         &self,
-        code: &ContractCode,
+        code_hash: CryptoHash,
+        code: Option<&ContractCode>,
         method_name: &str,
         ext: &mut dyn External,
-        context: VMContext,
+        context: &VMContext,
         fees_config: &RuntimeFeesConfig,
         promise_results: &[PromiseResult],
         cache: Option<&dyn ContractRuntimeCache>,

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -31,19 +31,24 @@ pub(crate) fn with_vm_variants(
     #[allow(unused)] cfg: &near_parameters::vm::Config,
     runner: impl Fn(VMKind) -> (),
 ) {
+    let run = move |kind| {
+        println!("running test with {kind:?}");
+        runner(kind)
+    };
+
     #[cfg(all(feature = "wasmer0_vm", target_arch = "x86_64"))]
-    runner(VMKind::Wasmer0);
+    run(VMKind::Wasmer0);
 
     #[cfg(feature = "wasmtime_vm")]
-    runner(VMKind::Wasmtime);
+    run(VMKind::Wasmtime);
 
     #[cfg(all(feature = "wasmer2_vm", target_arch = "x86_64"))]
-    runner(VMKind::Wasmer2);
+    run(VMKind::Wasmer2);
 
     #[cfg(all(feature = "near_vm", target_arch = "x86_64"))]
     if cfg.limit_config.contract_prepare_version == near_parameters::vm::ContractPrepareVersion::V2
     {
-        runner(VMKind::NearVm);
+        run(VMKind::NearVm);
     }
 }
 

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -2,6 +2,7 @@
 #![cfg(target_arch = "x86_64")]
 
 use super::{create_context, test_vm_config, with_vm_variants};
+use crate::cache::{CompiledContractInfo, ContractRuntimeCache};
 use crate::logic::errors::VMRunnerError;
 use crate::logic::mocks::mock_external::MockedExternal;
 use crate::logic::Config;
@@ -9,7 +10,7 @@ use crate::runner::VMKindExt;
 use crate::runner::VMResult;
 use crate::wasmer2_runner::Wasmer2VM;
 use crate::{
-    prepare, CompiledContract, ContractCode, ContractRuntimeCache, MockContractRuntimeCache,
+    prepare, ContractCode, MockContractRuntimeCache,
 };
 use assert_matches::assert_matches;
 use near_parameters::vm::VMKind;
@@ -25,22 +26,39 @@ use wasmer_engine::Executable;
 fn test_caches_compilation_error() {
     let config = test_vm_config();
     with_vm_variants(&config, |vm_kind: VMKind| {
+        // The cache is currently properly implemented only for NearVM
         match vm_kind {
-            VMKind::Wasmer0 | VMKind::Wasmer2 | VMKind::NearVm => {}
-            VMKind::Wasmtime => return,
+            VMKind::NearVm => {}
+            VMKind::Wasmer0 | VMKind::Wasmer2 | VMKind::Wasmtime => return,
         }
         let cache = MockContractRuntimeCache::default();
         let code = [42; 1000];
+        let code = ContractCode::new(code.to_vec(), None);
+        let code_hash = *code.hash();
         let terragas = 1000000000000u64;
         assert_eq!(cache.len(), 0);
-        let outcome1 =
-            make_cached_contract_call_vm(&config, &cache, &code, "method_name1", terragas, vm_kind)
-                .expect("bad failure");
+        let outcome1 = make_cached_contract_call_vm(
+            &config,
+            &cache,
+            code_hash,
+            Some(&code),
+            "method_name1",
+            terragas,
+            vm_kind,
+        )
+        .expect("bad failure");
         println!("{:?}", cache);
         assert_eq!(cache.len(), 1);
-        let outcome2 =
-            make_cached_contract_call_vm(&config, &cache, &code, "method_name2", terragas, vm_kind)
-                .expect("bad failure");
+        let outcome2 = make_cached_contract_call_vm(
+            &config,
+            &cache,
+            code_hash,
+            None,
+            "method_name2",
+            terragas,
+            vm_kind,
+        )
+        .expect("bad failure");
         assert_eq!(outcome1.aborted.as_ref(), outcome2.aborted.as_ref());
     })
 }
@@ -55,31 +73,50 @@ fn test_does_not_cache_io_error() {
         }
 
         let code = near_test_contracts::trivial_contract();
+        let code = ContractCode::new(code.to_vec(), None);
+        let code_hash = *code.hash();
         let prepaid_gas = 10u64.pow(12);
         let cache = FaultingContractRuntimeCache::default();
 
         cache.set_read_fault(true);
-        let result =
-            make_cached_contract_call_vm(&config, &cache, &code, "main", prepaid_gas, vm_kind);
+        let result = make_cached_contract_call_vm(
+            &config,
+            &cache,
+            code_hash,
+            None,
+            "main",
+            prepaid_gas,
+            vm_kind,
+        );
         assert_matches!(
             result.err(),
             Some(VMRunnerError::CacheError(crate::logic::errors::CacheError::ReadError(_)))
         );
+        cache.set_read_fault(false);
 
         cache.set_write_fault(true);
-        let result =
-            make_cached_contract_call_vm(&config, &cache, &code, "main", prepaid_gas, vm_kind);
+        let result = make_cached_contract_call_vm(
+            &config,
+            &cache,
+            code_hash,
+            Some(&code),
+            "main",
+            prepaid_gas,
+            vm_kind,
+        );
         assert_matches!(
             result.err(),
             Some(VMRunnerError::CacheError(crate::logic::errors::CacheError::WriteError(_)))
         );
+        cache.set_write_fault(false);
     })
 }
 
 fn make_cached_contract_call_vm(
     config: &Config,
     cache: &dyn ContractRuntimeCache,
-    code: &[u8],
+    code_hash: CryptoHash,
+    code: Option<&ContractCode>,
     method_name: &str,
     prepaid_gas: u64,
     vm_kind: VMKind,
@@ -89,13 +126,13 @@ fn make_cached_contract_call_vm(
     let fees = RuntimeFeesConfig::test();
     let promise_results = vec![];
     context.prepaid_gas = prepaid_gas;
-    let code = ContractCode::new(code.to_vec(), None);
     let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
     runtime.run(
-        &code,
+        code_hash,
+        code,
         method_name,
         &mut fake_external,
-        context,
+        &context,
         &fees,
         &promise_results,
         Some(cache),
@@ -262,14 +299,14 @@ impl FaultingContractRuntimeCache {
 }
 
 impl ContractRuntimeCache for FaultingContractRuntimeCache {
-    fn put(&self, key: &CryptoHash, value: CompiledContract) -> std::io::Result<()> {
+    fn put(&self, key: &CryptoHash, value: CompiledContractInfo) -> std::io::Result<()> {
         if self.write_fault.swap(false, Ordering::Relaxed) {
             return Err(io::ErrorKind::Other.into());
         }
         self.inner.put(key, value)
     }
 
-    fn get(&self, key: &CryptoHash) -> std::io::Result<Option<CompiledContract>> {
+    fn get(&self, key: &CryptoHash) -> std::io::Result<Option<CompiledContractInfo>> {
         if self.read_fault.swap(false, Ordering::Relaxed) {
             return Err(io::ErrorKind::Other.into());
         }

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -9,9 +9,7 @@ use crate::logic::Config;
 use crate::runner::VMKindExt;
 use crate::runner::VMResult;
 use crate::wasmer2_runner::Wasmer2VM;
-use crate::{
-    prepare, ContractCode, MockContractRuntimeCache,
-};
+use crate::{prepare, ContractCode, MockContractRuntimeCache};
 use assert_matches::assert_matches;
 use near_parameters::vm::VMKind;
 use near_parameters::RuntimeFeesConfig;

--- a/runtime/near-vm-runner/src/tests/fuzzers.rs
+++ b/runtime/near-vm-runner/src/tests/fuzzers.rs
@@ -121,10 +121,11 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMResult {
 
     let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
     let mut res = vm_kind.runtime(config).unwrap().run(
-        code,
+        *code.hash(),
+        Some(code),
         &method_name,
         &mut fake_external,
-        context,
+        &context,
         &fees,
         &promise_results,
         None,

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -60,10 +60,11 @@ pub fn test_read_write() {
         let promise_results = vec![];
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
         let result = runtime.run(
-            &code,
+            *code.hash(),
+            Some(&code),
             "write_key_value",
             &mut fake_external,
-            context,
+            &context,
             &fees,
             &promise_results,
             None,
@@ -72,10 +73,11 @@ pub fn test_read_write() {
 
         let context = create_context(encode(&[10u64]));
         let result = runtime.run(
-            &code,
+            *code.hash(),
+            Some(&code),
             "read_value",
             &mut fake_external,
-            context,
+            &context,
             &fees,
             &promise_results,
             None,
@@ -131,7 +133,7 @@ fn run_test_ext(
     let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
 
     let outcome = runtime
-        .run(&code, method, &mut fake_external, context, &fees, &[], None)
+        .run(*code.hash(), Some(&code), method, &mut fake_external, &context, &fees, &[], None)
         .unwrap_or_else(|err| panic!("Failed execution: {:?}", err));
 
     assert_eq!(outcome.profile.action_gas(), 0);
@@ -238,7 +240,16 @@ pub fn test_out_of_memory() {
 
         let promise_results = vec![];
         let result = runtime
-            .run(&code, "out_of_memory", &mut fake_external, context, &fees, &promise_results, None)
+            .run(
+                *code.hash(),
+                Some(&code),
+                "out_of_memory",
+                &mut fake_external,
+                &context,
+                &fees,
+                &promise_results,
+                None,
+            )
             .expect("execution failed");
         assert_eq!(
             result.aborted,
@@ -271,10 +282,11 @@ fn attach_unspent_gas_but_use_all_gas() {
 
         let outcome = runtime
             .run(
-                &code,
+                *code.hash(),
+                Some(&code),
                 "attach_unspent_gas_but_use_all_gas",
                 &mut external,
-                context.clone(),
+                &context,
                 &fees,
                 &[],
                 None,

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -223,10 +223,11 @@ impl TestBuilder {
                 println!("Running {:?} for protocol version {}", vm_kind, protocol_version);
                 let outcome = runtime
                     .run(
-                        &self.code,
+                        *self.code.hash(),
+                        Some(&self.code),
                         &self.method,
                         &mut fake_external,
-                        context,
+                        &context,
                         &fees,
                         &promise_results,
                         None,

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -14,6 +14,7 @@ pub fn test_ts_contract() {
     let config = test_vm_config();
     with_vm_variants(&config, |vm_kind: VMKind| {
         let code = ContractCode::new(near_test_contracts::ts_contract().to_vec(), None);
+        let code_hash = code.hash();
         let mut fake_external = MockedExternal::new();
 
         let context = create_context(Vec::new());
@@ -23,10 +24,11 @@ pub fn test_ts_contract() {
         let promise_results = vec![];
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
         let result = runtime.run(
-            &code,
+            *code_hash,
+            Some(&code),
             "try_panic",
             &mut fake_external,
-            context,
+            &context,
             &fees,
             &promise_results,
             None,
@@ -43,10 +45,11 @@ pub fn test_ts_contract() {
         let context = create_context(b"foo bar".to_vec());
         runtime
             .run(
-                &code,
+                *code_hash,
+                Some(&code),
                 "try_storage_write",
                 &mut fake_external,
-                context,
+                &context,
                 &fees,
                 &promise_results,
                 None,
@@ -65,10 +68,11 @@ pub fn test_ts_contract() {
         let context = create_context(b"foo".to_vec());
         let outcome = runtime
             .run(
-                &code,
+                *code_hash,
+                Some(&code),
                 "try_storage_read",
                 &mut fake_external,
-                context,
+                &context,
                 &fees,
                 &promise_results,
                 None,

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -1,3 +1,4 @@
+use crate::cache::{CompiledContract, CompiledContractInfo, ContractRuntimeCache};
 use crate::errors::{ContractPrecompilatonResult, IntoVMError};
 use crate::logic::errors::{
     CacheError, CompilationError, FunctionCallError, MethodResolveError, VMRunnerError, WasmTrap,
@@ -7,11 +8,10 @@ use crate::logic::{External, VMContext, VMLogic, VMLogicError, VMOutcome};
 use crate::memory::WasmerMemory;
 use crate::prepare;
 use crate::runner::VMResult;
-use crate::{
-    get_contract_cache_key, imports, CompiledContract, ContractCode, ContractRuntimeCache,
-};
+use crate::{get_contract_cache_key, imports, ContractCode};
 use near_parameters::vm::{Config, VMKind};
 use near_parameters::RuntimeFeesConfig;
+use near_primitives_core::hash::CryptoHash;
 use wasmer_runtime::{ImportObject, Module};
 
 fn check_method(module: &Module, method_name: &str) -> Result<(), FunctionCallError> {
@@ -264,18 +264,21 @@ impl Wasmer0VM {
         cache: Option<&dyn ContractRuntimeCache>,
     ) -> Result<Result<wasmer_runtime::Module, CompilationError>, CacheError> {
         let module_or_error = self.compile_uncached(code);
-        let key = get_contract_cache_key(code, &self.config);
+        let key = get_contract_cache_key(*code.hash(), &self.config);
 
         if let Some(cache) = cache {
-            let record = match &module_or_error {
-                Ok(module) => {
-                    let code = module
-                        .cache()
-                        .and_then(|it| it.serialize())
-                        .map_err(|_e| CacheError::SerializationError { hash: key.0 })?;
-                    CompiledContract::Code(code)
-                }
-                Err(err) => CompiledContract::CompileModuleError(err.clone()),
+            let record = CompiledContractInfo {
+                wasm_bytes: code.code().len() as u64,
+                compiled: match &module_or_error {
+                    Ok(module) => {
+                        let code = module
+                            .cache()
+                            .and_then(|it| it.serialize())
+                            .map_err(|_e| CacheError::SerializationError { hash: key.0 })?;
+                        CompiledContract::Code(code)
+                    }
+                    Err(err) => CompiledContract::CompileModuleError(err.clone()),
+                },
             };
             cache.put(&key, record).map_err(CacheError::WriteError)?;
         }
@@ -290,7 +293,7 @@ impl Wasmer0VM {
     ) -> VMResult<Result<wasmer_runtime::Module, CompilationError>> {
         let _span = tracing::debug_span!(target: "vm", "Wasmer0VM::compile_and_load").entered();
 
-        let key = get_contract_cache_key(code, &self.config);
+        let key = get_contract_cache_key(*code.hash(), &self.config);
 
         let compile_or_read_from_cache =
             || -> VMResult<Result<wasmer_runtime::Module, CompilationError>> {
@@ -306,8 +309,14 @@ impl Wasmer0VM {
 
                 let stored_module: Option<wasmer_runtime::Module> = match cache_record {
                     None => None,
-                    Some(CompiledContract::CompileModuleError(err)) => return Ok(Err(err)),
-                    Some(CompiledContract::Code(serialized_module)) => {
+                    Some(CompiledContractInfo {
+                        compiled: CompiledContract::CompileModuleError(err),
+                        ..
+                    }) => return Ok(Err(err)),
+                    Some(CompiledContractInfo {
+                        compiled: CompiledContract::Code(serialized_module),
+                        ..
+                    }) => {
                         let _span =
                             tracing::debug_span!(target: "vm", "Wasmer0VM::read_from_cache")
                                 .entered();
@@ -343,14 +352,20 @@ impl Wasmer0VM {
 impl crate::runner::VM for Wasmer0VM {
     fn run(
         &self,
-        code: &ContractCode,
+        _code_hash: CryptoHash,
+        code: Option<&ContractCode>,
         method_name: &str,
         ext: &mut dyn External,
-        context: VMContext,
+        context: &VMContext,
         fees_config: &RuntimeFeesConfig,
         promise_results: &[PromiseResult],
         cache: Option<&dyn ContractRuntimeCache>,
     ) -> Result<VMOutcome, VMRunnerError> {
+        let Some(code) = code else {
+            return Err(VMRunnerError::CacheError(CacheError::ReadError(std::io::Error::from(
+                std::io::ErrorKind::NotFound,
+            ))));
+        };
         if !cfg!(target_arch = "x86") && !cfg!(target_arch = "x86_64") {
             // TODO(#1940): Remove once NaN is standardized by the VM.
             panic!(
@@ -373,7 +388,7 @@ impl crate::runner::VM for Wasmer0VM {
         let mut logic =
             VMLogic::new(ext, context, &self.config, fees_config, promise_results, &mut memory);
 
-        let result = logic.before_loading_executable(method_name, code.code().len());
+        let result = logic.before_loading_executable(method_name, code.code().len() as u64);
         if let Err(e) = result {
             return Ok(VMOutcome::abort(logic, e));
         }
@@ -394,7 +409,7 @@ impl crate::runner::VM for Wasmer0VM {
             }
         };
 
-        let result = logic.after_loading_executable(code.code().len());
+        let result = logic.after_loading_executable(code.code().len() as u64);
         if let Err(e) = result {
             return Ok(VMOutcome::abort(logic, e));
         }

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -1,7 +1,7 @@
 use crate::errors::{ContractPrecompilatonResult, IntoVMError};
 use crate::logic::errors::{
-    CompilationError, FunctionCallError, MethodResolveError, PrepareError, VMLogicError,
-    VMRunnerError, WasmTrap,
+    CacheError, CompilationError, FunctionCallError, MethodResolveError, PrepareError,
+    VMLogicError, VMRunnerError, WasmTrap,
 };
 use crate::logic::types::PromiseResult;
 use crate::logic::Config;
@@ -9,6 +9,7 @@ use crate::logic::{External, MemSlice, MemoryLike, VMContext, VMLogic, VMOutcome
 use crate::{imports, prepare, ContractCode, ContractRuntimeCache};
 use near_parameters::vm::VMKind;
 use near_parameters::RuntimeFeesConfig;
+use near_primitives_core::hash::CryptoHash;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use wasmtime::ExternType::Func;
@@ -152,14 +153,20 @@ impl WasmtimeVM {
 impl crate::runner::VM for WasmtimeVM {
     fn run(
         &self,
-        code: &ContractCode,
+        _code_hash: CryptoHash,
+        code: Option<&ContractCode>,
         method_name: &str,
         ext: &mut dyn External,
-        context: VMContext,
+        context: &VMContext,
         fees_config: &RuntimeFeesConfig,
         promise_results: &[PromiseResult],
         _cache: Option<&dyn ContractRuntimeCache>,
     ) -> Result<VMOutcome, VMRunnerError> {
+        let Some(code) = code else {
+            return Err(VMRunnerError::CacheError(CacheError::ReadError(std::io::Error::from(
+                std::io::ErrorKind::NotFound,
+            ))));
+        };
         let mut config = self.default_wasmtime_config();
         let engine = get_engine(&mut config);
         let mut store = Store::new(&engine, ());
@@ -173,7 +180,7 @@ impl crate::runner::VM for WasmtimeVM {
         let mut logic =
             VMLogic::new(ext, context, &self.config, fees_config, promise_results, &mut memory);
 
-        let result = logic.before_loading_executable(method_name, code.code().len());
+        let result = logic.before_loading_executable(method_name, code.code().len() as u64);
         if let Err(e) = result {
             return Ok(VMOutcome::abort(logic, e));
         }
@@ -189,7 +196,7 @@ impl crate::runner::VM for WasmtimeVM {
         };
         let mut linker = Linker::new(&engine);
 
-        let result = logic.after_loading_executable(code.code().len());
+        let result = logic.after_loading_executable(code.code().len() as u64);
         if let Err(e) = result {
             return Ok(VMOutcome::abort(logic, e));
         }

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -78,10 +78,11 @@ fn compute_function_call_cost(
     for _ in 0..warmup_repeats {
         let result = runtime
             .run(
-                contract,
+                *contract.hash(),
+                Some(&contract),
                 "hello0",
                 &mut fake_external,
-                fake_context.clone(),
+                &fake_context,
                 &fees,
                 &promise_results,
                 cache,
@@ -94,10 +95,11 @@ fn compute_function_call_cost(
     for _ in 0..repeats {
         let result = runtime
             .run(
-                contract,
+                *contract.hash(),
+                Some(&contract),
                 "hello0",
                 &mut fake_external,
-                fake_context.clone(),
+                &fake_context,
                 &fees,
                 &promise_results,
                 cache,

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -145,10 +145,11 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     for _ in 0..warmup_repeats {
         let result = runtime
             .run(
-                contract,
+                *contract.hash(),
+                Some(&contract),
                 "hello",
                 &mut fake_external,
-                fake_context.clone(),
+                &fake_context,
                 &fees,
                 &promise_results,
                 cache,
@@ -165,10 +166,11 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     for _ in 0..repeats {
         let result = runtime
             .run(
-                contract,
+                *contract.hash(),
+                Some(&contract),
                 "hello",
                 &mut fake_external,
-                fake_context.clone(),
+                &fake_context,
                 &fees,
                 &promise_results,
                 cache,
@@ -182,10 +184,11 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     for _ in 0..warmup_repeats {
         let result = runtime_free_gas
             .run(
-                contract,
+                *contract.hash(),
+                Some(&contract),
                 "hello",
                 &mut fake_external,
-                fake_context.clone(),
+                &fake_context,
                 &fees,
                 &promise_results,
                 cache,
@@ -199,10 +202,11 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     for _ in 0..repeats {
         let result = runtime_free_gas
             .run(
-                contract,
+                *contract.hash(),
+                Some(&contract),
                 "hello",
                 &mut fake_external,
-                fake_context.clone(),
+                &fake_context,
                 &fees,
                 &promise_results,
                 cache,

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -882,10 +882,11 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
             .runtime(config.clone())
             .unwrap()
             .run(
-                &code,
+                *code.hash(),
+                Some(&code),
                 "cpu_ram_soak_test",
                 &mut fake_external,
-                context,
+                &context,
                 &fees,
                 &promise_results,
                 Some(&cache),

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -31,7 +31,7 @@ use near_store::{
     StorageError, TrieUpdate,
 };
 use near_vm_runner::logic::errors::{
-    CompilationError, FunctionCallError, InconsistentStateError, VMRunnerError,
+    CacheError, CompilationError, FunctionCallError, InconsistentStateError, VMRunnerError,
 };
 use near_vm_runner::logic::types::PromiseResult;
 use near_vm_runner::logic::{VMContext, VMOutcome};
@@ -76,19 +76,6 @@ pub(crate) fn execute_function_call(
 ) -> Result<VMOutcome, RuntimeError> {
     let account_id = runtime_ext.account_id();
     tracing::debug!(target: "runtime", %account_id, "Calling the contract");
-    let code = match get_contract_code(&runtime_ext, account, apply_state.current_protocol_version)
-    {
-        Ok(Some(code)) => code,
-        Ok(None) => {
-            let error = FunctionCallError::CompilationError(CompilationError::CodeDoesNotExist {
-                account_id: account_id.as_str().into(),
-            });
-            return Ok(VMOutcome::nop_outcome(error));
-        }
-        Err(e) => {
-            return Err(RuntimeError::StorageError(e));
-        }
-    };
     // Output data receipts are ignored if the function call is not the last action in the batch.
     let output_data_receivers: Vec<_> = if is_last_action {
         action_receipt.output_data_receivers.iter().map(|r| r.receiver_id.clone()).collect()
@@ -128,16 +115,58 @@ pub(crate) fn execute_function_call(
     if checked_feature!("stable", ChunkNodesCache, protocol_version) {
         runtime_ext.set_trie_cache_mode(TrieCacheMode::CachingChunk);
     }
-    let result = near_vm_runner::run(
-        &code,
+    let result_from_cache = near_vm_runner::run(
+        account,
+        None,
         &function_call.method_name,
         runtime_ext,
-        context,
+        &context,
         &config.wasm_config,
         &config.fees,
         promise_results,
         apply_state.cache.as_deref(),
     );
+    let result = match result_from_cache {
+        Err(VMRunnerError::CacheError(CacheError::ReadError(err)))
+            if err.kind() == std::io::ErrorKind::NotFound =>
+        {
+            if checked_feature!("stable", ChunkNodesCache, protocol_version) {
+                runtime_ext.set_trie_cache_mode(TrieCacheMode::CachingShard);
+            }
+            let code = match get_contract_code(
+                &runtime_ext,
+                account,
+                apply_state.current_protocol_version,
+            ) {
+                Ok(Some(code)) => code,
+                Ok(None) => {
+                    let error =
+                        FunctionCallError::CompilationError(CompilationError::CodeDoesNotExist {
+                            account_id: account_id.as_str().into(),
+                        });
+                    return Ok(VMOutcome::nop_outcome(error));
+                }
+                Err(e) => {
+                    return Err(RuntimeError::StorageError(e));
+                }
+            };
+            if checked_feature!("stable", ChunkNodesCache, protocol_version) {
+                runtime_ext.set_trie_cache_mode(TrieCacheMode::CachingChunk);
+            }
+            near_vm_runner::run(
+                account,
+                Some(&code),
+                &function_call.method_name,
+                runtime_ext,
+                &context,
+                &config.wasm_config,
+                &config.fees,
+                promise_results,
+                apply_state.cache.as_deref(),
+            )
+        }
+        res => res,
+    };
 
     if checked_feature!("stable", ChunkNodesCache, protocol_version) {
         runtime_ext.set_trie_cache_mode(TrieCacheMode::CachingShard);

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -2456,8 +2456,10 @@ mod tests {
         store_update.commit().unwrap();
 
         let contract_code = near_vm_runner::ContractCode::new(wasm_code, None);
-        let key =
-            near_vm_runner::get_contract_cache_key(&contract_code, &apply_state.config.wasm_config);
+        let key = near_vm_runner::get_contract_cache_key(
+            *contract_code.hash(),
+            &apply_state.config.wasm_config,
+        );
         apply_state
             .cache
             .unwrap()


### PR DESCRIPTION
Backport of https://github.com/near/nearcore/pull/10852 to the 1.39.0 branch (that will be released as 1.38.1)