### PR TITLE
fix(nayduck): State sync skip state dump

### DIFF
--- a/core/primitives/src/state_sync.rs
+++ b/core/primitives/src/state_sync.rs
@@ -261,6 +261,7 @@ pub fn get_num_state_parts(memory_usage: u64) -> u64 {
 pub enum StateSyncDumpProgress {
     /// Represents two cases:
     /// * An epoch dump is complete
+    /// * An epoch dump is skipped in the epoch where shard layout changes
     /// * The node is running its first epoch and there is nothing to dump.
     AllDumped {
         /// The dumped state corresponds to the state at the beginning of the specified epoch.

--- a/core/primitives/src/state_sync.rs
+++ b/core/primitives/src/state_sync.rs
@@ -261,13 +261,14 @@ pub fn get_num_state_parts(memory_usage: u64) -> u64 {
 pub enum StateSyncDumpProgress {
     /// Represents two cases:
     /// * An epoch dump is complete
-    /// * An epoch dump is skipped in the epoch where shard layout changes
     /// * The node is running its first epoch and there is nothing to dump.
     AllDumped {
         /// The dumped state corresponds to the state at the beginning of the specified epoch.
         epoch_id: EpochId,
         epoch_height: EpochHeight,
     },
+    /// * An epoch dump is skipped in the epoch where shard layout changes
+    Skipped { epoch_id: EpochId, epoch_height: EpochHeight },
     /// Represents the case of an epoch being partially dumped.
     InProgress {
         /// The dumped state corresponds to the state at the beginning of the specified epoch.

--- a/nearcore/src/state_sync.rs
+++ b/nearcore/src/state_sync.rs
@@ -202,15 +202,22 @@ fn select_random_part_id_with_index(parts_to_be_dumped: &Vec<u64>) -> (u64, usiz
     (selected_element, selected_idx)
 }
 
+struct StateDumpShardInfo {
+    epoch_id: EpochId,
+    epoch_height: EpochHeight,
+    sync_hash: CryptoHash,
+}
+
 fn get_current_state(
     chain: &Chain,
     shard_id: &ShardId,
     shard_tracker: &ShardTracker,
     account_id: &Option<AccountId>,
     epoch_manager: Arc<dyn EpochManagerAdapter>,
-) -> Result<Option<(EpochId, EpochHeight, CryptoHash)>, Error> {
+) -> Result<Option<StateDumpShardInfo>, Error> {
     let was_last_epoch_done = match chain.chain_store().get_state_sync_dump_progress(*shard_id) {
         Ok(StateSyncDumpProgress::AllDumped { epoch_id, .. }) => Some(epoch_id),
+        Ok(StateSyncDumpProgress::Skipped { epoch_id, .. }) => Some(epoch_id),
         _ => None,
     };
 
@@ -219,17 +226,22 @@ fn get_current_state(
             tracing::debug!(target: "state_sync_dump", shard_id, ?err, "check_latest_epoch failed. Will retry.");
             Err(err)
         }
-        Ok((prev_epoch_id, new_epoch_id, new_epoch_height, new_sync_hash)) => {
+        Ok(LatestEpochInfo {
+            prev_epoch_id,
+            epoch_id: new_epoch_id,
+            epoch_height: new_epoch_height,
+            sync_hash: new_sync_hash,
+        }) => {
             if Some(&new_epoch_id) == was_last_epoch_done.as_ref() {
-                tracing::debug!(target: "state_sync_dump", shard_id, ?was_last_epoch_done, ?new_epoch_id, new_epoch_height, ?new_sync_hash, "latest epoch is all dumped. No new epoch to dump. Idle");
+                tracing::debug!(target: "state_sync_dump", shard_id, ?was_last_epoch_done, ?new_epoch_id, new_epoch_height, ?new_sync_hash, "latest epoch is done. No new epoch to dump. Idle");
                 Ok(None)
             } else if epoch_manager.get_shard_layout(&prev_epoch_id)
                 != epoch_manager.get_shard_layout(&new_epoch_id)
             {
-                tracing::debug!(target: "state_sync_dump", shard_id, ?was_last_epoch_done, ?new_epoch_id, new_epoch_height, ?new_sync_hash, "latest epoch is skipped due to shard layout change. Idle");
+                tracing::debug!(target: "state_sync_dump", shard_id, ?was_last_epoch_done, ?new_epoch_id, new_epoch_height, ?new_sync_hash, "Shard layout change detected, will skip dumping for this epoch. Idle");
                 chain.chain_store().set_state_sync_dump_progress(
                     *shard_id,
-                    Some(StateSyncDumpProgress::AllDumped {
+                    Some(StateSyncDumpProgress::Skipped {
                         epoch_id: new_epoch_id,
                         epoch_height: new_epoch_height,
                     }),
@@ -242,7 +254,11 @@ fn get_current_state(
                 &shard_tracker,
                 &account_id,
             )? {
-                Ok(Some((new_epoch_id, new_epoch_height, new_sync_hash)))
+                Ok(Some(StateDumpShardInfo {
+                    epoch_id: new_epoch_id,
+                    epoch_height: new_epoch_height,
+                    sync_hash: new_sync_hash,
+                }))
             } else {
                 tracing::debug!(target: "state_sync_dump", shard_id, ?new_epoch_id, new_epoch_height, ?new_sync_hash, "Doesn't care about the shard in the current epoch. Idle");
                 Ok(None)
@@ -323,7 +339,7 @@ async fn state_sync_dump(
                 None
             }
             Ok(None) => None,
-            Ok(Some((epoch_id, epoch_height, sync_hash))) => {
+            Ok(Some(StateDumpShardInfo { epoch_id, epoch_height, sync_hash })) => {
                 let in_progress_data = get_in_progress_data(shard_id, sync_hash, &chain);
                 match in_progress_data {
                     Err(err) => {
@@ -601,12 +617,19 @@ fn cares_about_shard(
     Ok(shard_tracker.care_about_shard(account_id.as_ref(), sync_prev_hash, *shard_id, true))
 }
 
+struct LatestEpochInfo {
+    prev_epoch_id: EpochId,
+    epoch_id: EpochId,
+    epoch_height: EpochHeight,
+    sync_hash: CryptoHash,
+}
+
 /// return epoch_id and sync_hash of the latest complete epoch available locally.
 fn get_latest_epoch(
     shard_id: &ShardId,
     chain: &Chain,
     epoch_manager: Arc<dyn EpochManagerAdapter>,
-) -> Result<(EpochId, EpochId, EpochHeight, CryptoHash), Error> {
+) -> Result<LatestEpochInfo, Error> {
     let head = chain.head()?;
     tracing::debug!(target: "state_sync_dump", shard_id, "Check if a new complete epoch is available");
     let hash = head.last_block_hash;
@@ -620,5 +643,5 @@ fn get_latest_epoch(
     let epoch_height = epoch_info.epoch_height();
     tracing::debug!(target: "state_sync_dump", ?final_hash, ?sync_hash, ?epoch_id, epoch_height, "get_latest_epoch");
 
-    Ok((prev_epoch_id, epoch_id, epoch_height, sync_hash))
+    Ok(LatestEpochInfo { prev_epoch_id, epoch_id, epoch_height, sync_hash })
 }

--- a/pytest/tests/sanity/gc_after_sync.py
+++ b/pytest/tests/sanity/gc_after_sync.py
@@ -13,7 +13,7 @@ from configured_logger import logger
 import state_sync_lib
 import utils
 
-EPOCH_LENGTH = 20
+EPOCH_LENGTH = 50
 TARGET_HEIGHT = int(EPOCH_LENGTH * 2.5)
 AFTER_SYNC_HEIGHT = EPOCH_LENGTH * 10
 TIMEOUT = 300

--- a/pytest/tests/sanity/gc_after_sync1.py
+++ b/pytest/tests/sanity/gc_after_sync1.py
@@ -11,24 +11,27 @@ import pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 
 from cluster import start_cluster
+import state_sync_lib
 from configured_logger import logger
 import utils
 
-EPOCH_LENGTH = 20
+EPOCH_LENGTH = 30
 TARGET_HEIGHT1 = EPOCH_LENGTH + (EPOCH_LENGTH // 2)
 TARGET_HEIGHT2 = EPOCH_LENGTH * 3 + (EPOCH_LENGTH // 2)
 TARGET_HEIGHT3 = EPOCH_LENGTH * 10 + (EPOCH_LENGTH // 2)
 
-node0_config = {"gc_blocks_limit": 10}
+node0_config, node1_config = state_sync_lib.get_state_sync_configs_pair()
 
-node1_config = {
+node0_config.update({"gc_blocks_limit": 10})
+
+node1_config.update({
     "consensus": {
         "block_fetch_horizon": 10,
         "block_header_fetch_horizon": 10,
     },
     "tracked_shards": [0],
     "gc_blocks_limit": 10,
-}
+})
 
 nodes = start_cluster(
     1, 1, 1, None,


### PR DESCRIPTION
This addresses `sanity/state_sync_fail.py` and `sanity/gc_after_sync.py`.

`sanity/state_sync_fail.py`- the node was trying to dump after the shard layout change.
`sanity/gc_after_sync.py` did not have state sync configured and the epoch was to short for the node to sync to the right epoch. 