### PR TITLE
misc: add additional working files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,12 @@ tmp/
 # Logs
 *.log
 
+# Git mergetool leaves these sometimes.
+*.orig
+
+# May be generated if your neard panics.
+*.core
+
 # Vim tmp files
 *.swp
 rusty-tags.vi


### PR DESCRIPTION
.orig files are the "originals" that you get when doing git mergetool resolutions. We don't really want them checked in anyway.

.core files are the core dumps that you may end up with around the repository in many typical linux configurations when running neard locally and it panics for any reason.