### PR TITLE
Upgrade the 'insta' dependency to version 1.37.0 to fix cargo audit warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2767,9 +2767,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.34.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d64600be34b2fcfc267740a243fa7744441bb4947a619ac4e5bb6507f35fbfc"
+checksum = "1718b3f2b85bb5054baf8ce406e36401f27c3169205f4175504c4b1d98252d3f"
 dependencies = [
  "console",
  "lazy_static",
@@ -2778,7 +2778,6 @@ dependencies = [
  "pest_derive",
  "serde",
  "similar",
- "yaml-rust",
 ]
 
 [[package]]
@@ -8519,15 +8518,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c179869f34fc7c01830d3ce7ea2086bc3a07e0d35289b667d0a8bf910258926c"
 dependencies = [
  "lzma-sys",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,7 @@ hyper-tls = "0.5.0"
 im = "15"
 indexmap = "1.6"
 indicatif = { version = "0.15.0", features = ["with_rayon"] }
-insta = { version = "1.34.0", features = ["json", "yaml", "redactions"] }
+insta = { version = "1.37.0", features = ["json", "yaml", "redactions"] }
 integration-tests = { path = "integration-tests" }
 itertools = "0.10.0"
 itoa = "1.0"

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -33,9 +33,9 @@ fn build_chain() {
     //     cargo insta test --accept -p near-chain --features nightly -- tests::simple_chain::build_chain
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
-        insta::assert_display_snapshot!(hash, @"Dnn7UkUiRfMu13jheAbcoJvQ66gKBgAoynRdEkMTkX58");
+        insta::assert_snapshot!(hash, @"Dnn7UkUiRfMu13jheAbcoJvQ66gKBgAoynRdEkMTkX58");
     } else {
-        insta::assert_display_snapshot!(hash, @"EsUNazp4zR2XgiwZSuQnX9dsaFk1VDhdRwGYt1YHpu5b");
+        insta::assert_snapshot!(hash, @"EsUNazp4zR2XgiwZSuQnX9dsaFk1VDhdRwGYt1YHpu5b");
     }
 
     for i in 1..5 {
@@ -51,9 +51,9 @@ fn build_chain() {
 
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
-        insta::assert_display_snapshot!(hash, @"8xU6fbbdGeYmQRaAbsszMHDM88KSAaniHykowTUDYXpm");
+        insta::assert_snapshot!(hash, @"8xU6fbbdGeYmQRaAbsszMHDM88KSAaniHykowTUDYXpm");
     } else {
-        insta::assert_display_snapshot!(hash, @"CJ5p62dVTMVgRADQrWPkFLrozDN8KxbKMGqjVkPXBD7W");
+        insta::assert_snapshot!(hash, @"CJ5p62dVTMVgRADQrWPkFLrozDN8KxbKMGqjVkPXBD7W");
     }
 }
 

--- a/core/parameters/src/config_store.rs
+++ b/core/parameters/src/config_store.rs
@@ -351,7 +351,7 @@ mod tests {
                 omit_expression => true,
             }, {
                 any_failure |= std::panic::catch_unwind(|| {
-                    insta::assert_display_snapshot!("parameters", params);
+                    insta::assert_snapshot!("parameters", params);
                 }).is_err();
             });
         }

--- a/core/store/src/db/colddb.rs
+++ b/core/store/src/db/colddb.rs
@@ -272,7 +272,7 @@ mod test {
         // Check expected value.  Use cargo-insta to update the expected value:
         //     cargo install cargo-insta
         //     cargo insta test --accept -p near-store  -- db::colddb
-        insta::assert_display_snapshot!(result.join("\n"), @r###"
+        insta::assert_snapshot!(result.join("\n"), @r###"
         State `ShardUId || 11111111111111111111111111111111`
             [cold] get_raw_bytes        → FooBar; rc: 1
             [cold] get_with_rc_stripped → FooBar
@@ -318,7 +318,7 @@ mod test {
         // Check expected value.  Use cargo-insta to update the expected value:
         //     cargo install cargo-insta
         //     cargo insta test --accept -p near-store  -- db::colddb
-        insta::assert_display_snapshot!(result.join("\n"), @r###"
+        insta::assert_snapshot!(result.join("\n"), @r###"
         State
         [cold] (`ShardUId || 11111111111111111111111111111111`, FooBar)
         [raw ] (`ShardUId || 11111111111111111111111111111111`, FooBar)


### PR DESCRIPTION
Recently `cargo audit` started complaining that the `yaml-rust` dependency is unmaintained (https://github.com/near/nearcore/issues/10876). `yaml-rust` is an indirect dependency that comes from the `insta` crate, so to fix the warning we must upgrade `insta` to a version that doesn't have this problem.
The `insta` crate just had a new release which fixes the problem detected by `cargo audit` (they pasted the whole `yaml-rust` crate into their tree x.x (https://github.com/mitsuhiko/insta/pull/465)). We can upgrade to the latest version to get rid of the warning.

Upgrading to the latest version is relatively painless, I just had to replace `assert_display_snapshot` with `assert_snapshot` because `assert_display_snapshot` is now deprecated (see https://github.com/mitsuhiko/insta/blob/8379841b8fde1cbd2fee019a9207ebea3619658f/src/macros.rs#L372)

Fixes: https://github.com/near/nearcore/issues/10876