### PR TITLE
debug-ui: import directly from react-router-dom

### DIFF
--- a/tools/debug-ui/package-lock.json
+++ b/tools/debug-ui/package-lock.json
@@ -15,7 +15,6 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-query": "^4.0.0",
-        "react-router": "^6.21.3",
         "react-router-dom": "^6.21.1",
         "react-scripts": "^5.0.1",
         "react-tooltip": "^5.22.0",
@@ -15174,20 +15173,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-router": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.21.3.tgz",
-      "integrity": "sha512-a0H638ZXULv1OdkmiK6s6itNhoy33ywxmUFT/xtSoVyf9VnC7n7+VT4LjVzdIHSaF5TIh9ylUgxMXksHTgGrKg==",
-      "dependencies": {
-        "@remix-run/router": "1.14.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
     "node_modules/react-router-dom": {
       "version": "6.21.1",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.21.1.tgz",
@@ -15216,14 +15201,6 @@
       },
       "peerDependencies": {
         "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router/node_modules/@remix-run/router": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.14.2.tgz",
-      "integrity": "sha512-ACXpdMM9hmKZww21yEqWwiLws/UPLhNKvimN8RrYSqPSvB3ov7sLvAcfvaxePeLvccTQKGdkDIhLYApZVDFuKg==",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/react-scripts": {
@@ -28968,21 +28945,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
-    },
-    "react-router": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.21.3.tgz",
-      "integrity": "sha512-a0H638ZXULv1OdkmiK6s6itNhoy33ywxmUFT/xtSoVyf9VnC7n7+VT4LjVzdIHSaF5TIh9ylUgxMXksHTgGrKg==",
-      "requires": {
-        "@remix-run/router": "1.14.2"
-      },
-      "dependencies": {
-        "@remix-run/router": {
-          "version": "1.14.2",
-          "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.14.2.tgz",
-          "integrity": "sha512-ACXpdMM9hmKZww21yEqWwiLws/UPLhNKvimN8RrYSqPSvB3ov7sLvAcfvaxePeLvccTQKGdkDIhLYApZVDFuKg=="
-        }
-      }
     },
     "react-router-dom": {
       "version": "6.21.1",

--- a/tools/debug-ui/package.json
+++ b/tools/debug-ui/package.json
@@ -10,7 +10,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-query": "^4.0.0",
-    "react-router": "^6.21.3",
     "react-router-dom": "^6.21.1",
     "react-scripts": "^5.0.1",
     "react-tooltip": "^5.22.0",

--- a/tools/debug-ui/src/App.tsx
+++ b/tools/debug-ui/src/App.tsx
@@ -1,6 +1,5 @@
 import './App.scss';
-import { NavLink } from 'react-router-dom';
-import { Navigate, Route, Routes, useParams } from 'react-router';
+import { NavLink, Navigate, Route, Routes, useParams } from 'react-router-dom';
 import { ChainAndChunkInfoView } from './ChainAndChunkInfoView';
 import { ClusterView } from './ClusterView';
 import { EpochInfoView } from './EpochInfoView';

--- a/tools/debug-ui/src/EpochInfoView.tsx
+++ b/tools/debug-ui/src/EpochInfoView.tsx
@@ -1,6 +1,5 @@
 import './EpochInfoView.scss';
-import { NavLink } from 'react-router-dom';
-import { Navigate, Route, Routes } from 'react-router';
+import { NavLink, Navigate, Route, Routes } from 'react-router-dom';
 import { EpochShardsView } from './EpochShardsView';
 import { EpochValidatorsView } from './EpochValidatorsView';
 import { RecentEpochsView } from './RecentEpochsView';

--- a/tools/debug-ui/src/LandingPage.tsx
+++ b/tools/debug-ui/src/LandingPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 import './LandingPage.scss';
 import { Link } from 'react-router-dom';
 


### PR DESCRIPTION
I ran into errors trying to run the debug UI because of mismatched versions between `react-router` and `react-router-dom`. 

From [react-router documentation](https://github.com/remix-run/react-router/tree/main/packages/react-router#react-router):

> If you're using React Router, you should never `import` anything directly from the `react-router` package, but you should have everything you need in either `react-router-dom` or `react-router-native`. Both of those packages re-export everything from `react-router`.