### PR TITLE
fix(resharding) - fixing the resharding.py nayduck test

### DIFF
--- a/pytest/tests/sanity/resharding.py
+++ b/pytest/tests/sanity/resharding.py
@@ -23,7 +23,7 @@ from resharding_lib import ReshardingTestBase, get_genesis_config_changes, get_c
 class ReshardingTest(ReshardingTestBase):
 
     def setUp(self) -> None:
-        super().setUp(epoch_length=5)
+        super().setUp(epoch_length=20)
 
     def test_resharding(self):
         logger.info("The resharding test is starting.")


### PR DESCRIPTION
The resharding nayduck test is [flaky](https://nayduck.near.org/#/test_history/593017). I believe that is because every now and then taking the state snapshot takes a long time and the test breaks before snapshot is ready for resharding. 

I went all the way to the following line and it seems like most of the slowness is there. It's down to rocksdb at this point and I don't feel like debugging it further so I'm just going to increase the epoch length to give the test enough time to take the snapshot and finish resharding. 
https://github.com/near/nearcore/blob/d4d1b82f39a57932eff0a7a28c5745b72915f848/core/store/src/db/rocksdb/snapshot.rs#L98 