### PR TITLE
network: clean up tracing error for reconnect

### DIFF
--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -445,9 +445,9 @@ impl NetworkState {
                 tracing::info!(target:"network", err = format!("{:#}", err), "Failed to connect to {peer_info}");
             }
 
-            if self.peer_store.peer_connection_attempt(&clock, &peer_info.id, result).is_err() {
-                tracing::error!(target: "network", ?peer_info, "Failed to store connection attempt.");
-            }
+            // The peer may not be in the peer store; we try to record the connection attempt but
+            // ignore any storage errors
+            let _ = self.peer_store.peer_connection_attempt(&clock, &peer_info.id, result);
 
             if succeeded {
                 return;


### PR DESCRIPTION
Re-connect attempts are triggered either by:
- A newly started node reading peers from its in-database `connection_store`
- A node losing a connection and attempting to re-establish it

In both cases the peer info isn't drawn from the peer store, so it doesn't make sense to print this storage error. It leads to a bunch of log spam when a node is started:

<img width="1128" alt="image" src="https://github.com/near/nearcore/assets/3241341/4f6fa37a-a895-4889-a521-e2877b244116">


At the same time it doesn't make sense to populate the peer store from the re-connect attempts, which may be to peers no longer present in the network.