### PR TITLE
feat: stabilize serialize_all_state_changes

### DIFF
--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -76,7 +76,6 @@ io_trace = []
 no_cache = []
 single_thread_rocksdb = [] # Deactivate RocksDB IO background threads
 test_features = []
-serialize_all_state_changes = []
 new_epoch_sync = []
 yield_resume = []
 

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -541,40 +541,18 @@ impl WrappedTrieChanges {
                 continue;
             }
 
-            let storage_key = if cfg!(feature = "serialize_all_state_changes") {
-                // Serialize all kinds of state changes without any filtering.
-                // Without this it's not possible to replay state changes to get an identical state root.
-
-                // This branch will become the default in the near future.
-
-                match change_with_trie_key.trie_key.get_account_id() {
-                    // If a TrieKey itself doesn't identify the Shard, then we need to add shard id to the row key.
-                    None => KeyForStateChanges::delayed_receipt_key_from_trie_key(
-                        &self.block_hash,
-                        &change_with_trie_key.trie_key,
-                        &self.shard_uid,
-                    ),
-                    // TrieKey has enough information to identify the shard it comes from.
-                    _ => KeyForStateChanges::from_trie_key(
-                        &self.block_hash,
-                        &change_with_trie_key.trie_key,
-                    ),
-                }
-            } else {
-                // This branch is the current neard behavior.
-                // Only a subset of state changes get serialized.
-
-                // Filtering trie keys for user facing RPC reporting.
-                // NOTE: If the trie key is not one of the account specific, it may cause key conflict
-                // when the node tracks multiple shards. See #2563.
-                match &change_with_trie_key.trie_key {
-                    TrieKey::Account { .. }
-                    | TrieKey::ContractCode { .. }
-                    | TrieKey::AccessKey { .. }
-                    | TrieKey::ContractData { .. } => {}
-                    _ => continue,
-                };
-                KeyForStateChanges::from_trie_key(&self.block_hash, &change_with_trie_key.trie_key)
+            let storage_key = match change_with_trie_key.trie_key.get_account_id() {
+                // If a TrieKey itself doesn't identify the Shard, then we need to add shard id to the row key.
+                None => KeyForStateChanges::delayed_receipt_key_from_trie_key(
+                    &self.block_hash,
+                    &change_with_trie_key.trie_key,
+                    &self.shard_uid,
+                ),
+                // TrieKey has enough information to identify the shard it comes from.
+                _ => KeyForStateChanges::from_trie_key(
+                    &self.block_hash,
+                    &change_with_trie_key.trie_key,
+                ),
             };
 
             store_update.set(

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -128,7 +128,6 @@ yield_resume = [
   "near-primitives/yield_resume",
 ]
 
-serialize_all_state_changes = ["near-store/serialize_all_state_changes"]
 nightly = [
   "near-actix-test-utils/nightly",
   "near-async/nightly",
@@ -156,7 +155,6 @@ nightly = [
   "protocol_feature_fix_contract_loading_cost",
   "protocol_feature_fix_staking_threshold",
   "protocol_feature_nonrefundable_transfer_nep491",
-  "serialize_all_state_changes",
   "testlib/nightly",
   "yield_resume",
 ]

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -74,7 +74,6 @@ rosetta_rpc = ["nearcore/rosetta_rpc"]
 json_rpc = ["nearcore/json_rpc"]
 protocol_feature_fix_staking_threshold = ["nearcore/protocol_feature_fix_staking_threshold"]
 protocol_feature_nonrefundable_transfer_nep491 = ["near-state-viewer/protocol_feature_nonrefundable_transfer_nep491"]
-serialize_all_state_changes = ["nearcore/serialize_all_state_changes"]
 new_epoch_sync = ["nearcore/new_epoch_sync", "dep:near-epoch-sync-tool"]
 yield_resume = ["nearcore/yield_resume"]
 
@@ -98,7 +97,6 @@ nightly = [
   "nightly_protocol",
   "protocol_feature_fix_staking_threshold",
   "protocol_feature_nonrefundable_transfer_nep491",
-  "serialize_all_state_changes",
   "yield_resume",
 ]
 nightly_protocol = [


### PR DESCRIPTION
This feature was introduced long time ago but never stabilized. I believe we had canary nodes running with this feature enabled, so I think it's time.

Goal is to always save all state changes to disk. This allows to rollback flat storage without replaying previous chunk.

There is always a concern with disk usage increase. If this happens even after canary node testing, we can always roll it back. However, the proper reduction of DBCol::StateChanges should be done via replacing all values with ValueRefs, as the values are always stored in DBCol::State.