### PR TITLE
[patch] Temporarily endorse all chunks in statelessnet

### DIFF
--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -72,6 +72,7 @@ near-actix-test-utils.workspace = true
 # if enabled, we assert in most situations that are impossible unless some byzantine behavior is observed.
 byzantine_asserts = ["near-chain/byzantine_asserts"]
 shadow_chunk_validation = ["near-chain/shadow_chunk_validation"]
+statelessnet_endorse_all_chunks = []
 expensive_tests = []
 test_features = [
   "near-network/test_features",

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -477,6 +477,13 @@ pub(crate) fn validate_chunk_state_witness(
         .start_timer();
     let span = tracing::debug_span!(target: "chain", "validate_chunk_state_witness").entered();
     let block_hash = pre_validation_output.main_transition_params.block_hash();
+
+    #[cfg(feature = "statelessnet_endorse_all_chunks")]
+    {
+        // Endorse all chunks assuming we are in a trusted setup
+        return Ok(());
+    }
+
     let epoch_id = epoch_manager.get_epoch_id(&block_hash)?;
     let shard_uid = epoch_manager
         .shard_id_to_uid(pre_validation_output.main_transition_params.shard_id(), &epoch_id)?;

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -124,6 +124,9 @@ statelessnet_protocol = [
 shadow_chunk_validation = [
   "near-client/shadow_chunk_validation",
 ]
+statelessnet_endorse_all_chunks = [
+  "near-client/statelessnet_endorse_all_chunks",
+]
 
 calimero_zero_storage = [
   "near-primitives/calimero_zero_storage",


### PR DESCRIPTION
As a temporary patch to recover from [StatelessNet v84 issue](https://near.zulipchat.com/#narrow/stream/422293-core.2Fstake-wars-iv/topic/StatelessNet.20v84.20issue/near/430782188) we would like validators to endorse all chunks while we are in a trusted setup.

Add `statelessnet_endorse_all_chunks` feature flag while building for statelessnet.