### PR TITLE
draft: reference implementation NEP-539

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -31,7 +31,7 @@ use near_primitives::types::{
     AccountId, Balance, BlockHeight, EpochHeight, EpochId, EpochInfoProvider, Gas, MerkleHash,
     ShardId, StateChangeCause, StateChangesForResharding, StateRoot, StateRootNode,
 };
-use near_primitives::version::ProtocolVersion;
+use near_primitives::version::{ProtocolFeature, ProtocolVersion};
 use near_primitives::views::{
     AccessKeyInfoView, CallResult, ContractCodeView, QueryRequest, QueryResponse,
     QueryResponseKind, ViewApplyState, ViewStateResult,
@@ -260,6 +260,7 @@ impl NightshadeRuntime {
             gas_price,
             challenges_result,
             random_seed,
+            congestion_info,
         } = block;
         let ApplyChunkShardContext {
             shard_id,
@@ -363,6 +364,7 @@ impl NightshadeRuntime {
             block_height,
             prev_block_hash: *prev_block_hash,
             block_hash,
+            shard_id,
             epoch_id,
             epoch_height,
             gas_price,
@@ -378,6 +380,7 @@ impl NightshadeRuntime {
                 is_first_block_of_version,
                 is_first_block_with_chunk_of_version,
             },
+            congestion_info,
         };
 
         let instant = Instant::now();
@@ -453,6 +456,7 @@ impl NightshadeRuntime {
             processed_delayed_receipts: apply_result.processed_delayed_receipts,
             processed_yield_timeouts: apply_result.processed_yield_timeouts,
             applied_receipts_hash: hash(&borsh::to_vec(receipts).unwrap()),
+            congestion_info: apply_result.congestion_info,
         };
 
         Ok(result)
@@ -1305,6 +1309,7 @@ impl node_runtime::adapter::ViewRuntimeAdapter for NightshadeRuntime {
     ) -> Result<Vec<u8>, node_runtime::state_viewer::errors::CallFunctionError> {
         let state_update = self.tries.new_trie_update_view(*shard_uid, state_root);
         let view_state = ViewApplyState {
+            shard_id: shard_uid.shard_id(),
             block_height: height,
             prev_block_hash: *prev_block_hash,
             block_hash: *block_hash,

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -87,6 +87,7 @@ impl NightshadeRuntime {
                     gas_limit,
                     is_new_chunk: true,
                     is_first_block_with_chunk_of_version: false,
+                    congestion_info: todo!("fix runtime tests"),
                 },
                 ApplyChunkBlockContext {
                     height,
@@ -96,6 +97,7 @@ impl NightshadeRuntime {
                     gas_price,
                     challenges_result: challenges_result.clone(),
                     random_seed: CryptoHash::default(),
+                    congestion_info: todo!("fix runtime tests"),
                 },
                 receipts,
                 transactions,
@@ -1585,6 +1587,7 @@ fn prepare_transactions(
             next_gas_price: env.runtime.genesis_config.min_gas_price,
             height: env.head.height,
             block_hash: env.head.last_block_hash,
+            congestion_info: todo!("fix runtime tests"),
         },
         transaction_groups,
         &mut |tx: &SignedTransaction| -> bool {

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -368,8 +368,12 @@ impl TestEnv {
     }
 
     pub fn view_account(&self, account_id: &AccountId) -> AccountView {
-        let shard_id =
-            self.epoch_manager.account_id_to_shard_id(account_id, &self.head.epoch_id).unwrap();
+        let shard_id = EpochInfoProvider::account_id_to_shard_id(
+            self.epoch_manager.as_ref(),
+            account_id,
+            &self.head.epoch_id,
+        )
+        .unwrap();
         let shard_uid = self.epoch_manager.shard_id_to_uid(shard_id, &self.head.epoch_id).unwrap();
         self.runtime
             .view_account(&shard_uid, self.state_roots[shard_id as usize], account_id)

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -1265,6 +1265,7 @@ impl RuntimeAdapter for KeyValueRuntime {
             processed_delayed_receipts: vec![],
             processed_yield_timeouts: vec![],
             applied_receipts_hash: hash(&borsh::to_vec(receipts).unwrap()),
+            congestion_info: todo!(),
         })
     }
 

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -107,6 +107,7 @@ use near_network::types::{
 };
 use near_network::types::{NetworkRequests, PeerManagerMessageRequest};
 use near_primitives::block::Tip;
+use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{verify_path, MerklePath};
@@ -1916,6 +1917,7 @@ impl ShardsManager {
         prev_outgoing_receipts: &[Receipt],
         prev_outgoing_receipts_root: CryptoHash,
         tx_root: CryptoHash,
+        congestion_info: CongestionInfo,
         signer: &dyn ValidatorSigner,
         rs: &mut ReedSolomonWrapper,
         protocol_version: ProtocolVersion,
@@ -1935,6 +1937,7 @@ impl ShardsManager {
             transactions,
             prev_outgoing_receipts,
             prev_outgoing_receipts_root,
+            congestion_info,
             signer,
             protocol_version,
         )

--- a/chain/chunks/src/test_loop.rs
+++ b/chain/chunks/src/test_loop.rs
@@ -22,6 +22,7 @@ use near_network::{
     test_loop::SupportsRoutingLookup,
     types::{NetworkRequests, PeerManagerMessageRequest},
 };
+use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::{
     hash::CryptoHash,
     merkle::{self, MerklePath},
@@ -275,6 +276,7 @@ impl MockChainForShardsManager {
             &receipts,
             receipts_root,
             MerkleHash::default(),
+            CongestionInfo::default(),
             &signer,
             &mut rs,
             PROTOCOL_VERSION,

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -6,6 +6,7 @@ use near_epoch_manager::test_utils::setup_epoch_manager_with_block_and_chunk_pro
 use near_epoch_manager::EpochManagerHandle;
 use near_network::shards_manager::ShardsManagerRequestFromNetwork;
 use near_network::test_utils::MockPeerManagerAdapter;
+use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{self, MerklePath};
 use near_primitives::receipt::Receipt;
@@ -149,6 +150,7 @@ impl ChunkTestFixture {
             &receipts,
             receipts_root,
             MerkleHash::default(),
+            CongestionInfo::default(),
             &signer,
             &mut rs,
             PROTOCOL_VERSION,

--- a/chain/client/src/test_utils/client.rs
+++ b/chain/client/src/test_utils/client.rs
@@ -207,6 +207,8 @@ pub fn create_chunk(
             transactions,
             decoded_chunk.prev_outgoing_receipts(),
             header.prev_outgoing_receipts_root(),
+            // TODO: compute if not available
+            header.congestion_info().unwrap_or_default(),
             &*signer,
             PROTOCOL_VERSION,
         )

--- a/chain/client/src/tests/process_blocks.rs
+++ b/chain/client/src/tests/process_blocks.rs
@@ -5,12 +5,15 @@ use near_crypto::vrf::Value;
 use near_crypto::{KeyType, PublicKey, Signature};
 use near_network::types::{NetworkRequests, PeerManagerMessageRequest};
 use near_primitives::block::Block;
+use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::network::PeerId;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::sharding::ShardChunkHeaderV3;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::utils::MaybeValidated;
+use near_primitives::version::PROTOCOL_VERSION;
+use std::sync::Arc;
 
 /// Only process one block per height
 /// Test that if a node receives two blocks at the same height, it doesn't process the second one
@@ -76,6 +79,8 @@ fn test_bad_shard_id() {
         chunk.tx_root(),
         chunk.prev_validator_proposals().collect(),
         &validator_signer,
+        PROTOCOL_VERSION,
+        CongestionInfo::default(),
     );
     modified_chunk.height_included = 2;
     chunks[0] = ShardChunkHeader::V3(modified_chunk);

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -116,6 +116,14 @@ impl EpochInfoProvider for EpochManagerHandle {
         let epoch_manager = self.read();
         epoch_manager.config.chain_id().into()
     }
+
+    fn account_id_to_shard_id(
+        &self,
+        account_id: &AccountId,
+        epoch_id: &EpochId,
+    ) -> Result<ShardId, EpochError> {
+        EpochManagerAdapter::account_id_to_shard_id(self, account_id, epoch_id)
+    }
 }
 
 /// Tracks epoch information across different forks, such as validators.

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -13,6 +13,7 @@ use near_o11y::testonly::init_test_logger;
 use near_primitives::account::id::AccountIdRef;
 use near_primitives::block::Tip;
 use near_primitives::challenge::SlashedValidator;
+use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::epoch_manager::EpochConfig;
 use near_primitives::hash::hash;
 use near_primitives::shard_layout::ShardLayout;
@@ -2807,6 +2808,8 @@ fn test_chunk_header(h: &[CryptoHash], signer: &dyn ValidatorSigner) -> ShardChu
         h[2],
         vec![],
         signer,
+        PROTOCOL_VERSION,
+        CongestionInfo::default(),
     ))
 }
 

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -156,6 +156,8 @@ pub enum ProtocolFeature {
     // Receipts which generate storage proofs larger than this limit will be rejected.
     // Protocol 85 also decreased the soft per-chunk storage proof limit to 3MB.
     PerReceiptHardStorageProofLimit,
+    /// Cross-shard congestion control according to NEP-539.
+    Nep539CongestionControl,
 }
 
 impl ProtocolFeature {
@@ -236,6 +238,7 @@ impl ProtocolFeature {
             ProtocolFeature::NonrefundableStorage => 140,
             #[cfg(feature = "statelessnet_protocol")]
             ProtocolFeature::SimpleNightshadeV3 => 141,
+            ProtocolFeature::Nep539CongestionControl => 142,
         }
     }
 }
@@ -251,7 +254,7 @@ pub const PROTOCOL_VERSION: ProtocolVersion = if cfg!(feature = "statelessnet_pr
     85
 } else if cfg!(feature = "nightly_protocol") {
     // On nightly, pick big enough version to support all features.
-    140
+    142
 } else {
     // Enable all stable features.
     STABLE_PROTOCOL_VERSION

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -6,6 +6,7 @@ use crate::block_body::{BlockBody, BlockBodyV1, ChunkEndorsementSignatures};
 pub use crate::block_header::*;
 use crate::challenge::{Challenges, ChallengesResult};
 use crate::checked_feature;
+use crate::congestion_info::CongestionInfo;
 use crate::hash::{hash, CryptoHash};
 use crate::merkle::{merklize, verify_path, MerklePath};
 use crate::num_rational::Rational32;
@@ -21,6 +22,7 @@ use near_async::time::Utc;
 use near_crypto::Signature;
 use near_primitives_core::types::ShardId;
 use primitive_types::U256;
+use std::collections::HashMap;
 use std::ops::Index;
 use std::sync::Arc;
 
@@ -122,6 +124,7 @@ pub fn genesis_chunks(
                 vec![],
                 &[],
                 CryptoHash::default(),
+                CongestionInfo::default(),
                 &EmptyValidatorSigner::default(),
                 genesis_protocol_version,
             )
@@ -586,6 +589,17 @@ impl Block {
             Block::BlockV1(_) | Block::BlockV2(_) | Block::BlockV3(_) => &[],
             Block::BlockV4(block) => block.body.chunk_endorsements(),
         }
+    }
+
+    pub fn shards_congestion_info(&self) -> HashMap<ShardId, CongestionInfo> {
+        self.chunks()
+            .iter()
+            .enumerate()
+            // TODO: default is not always appropriate!
+            .map(|(i, chunk_header)| {
+                (i as ShardId, chunk_header.congestion_info().unwrap_or_default())
+            })
+            .collect()
     }
 
     pub fn hash(&self) -> &CryptoHash {

--- a/core/primitives/src/congestion_info.rs
+++ b/core/primitives/src/congestion_info.rs
@@ -1,5 +1,17 @@
 use near_primitives_core::types::{Gas, ShardId};
 
+// TODO: find better home for the const?
+const MAX_CONGESTION_INCOMING_GAS: Gas = 20 * 10u64.pow(15);
+const MAX_CONGESTION_OUTGOING_GAS: Gas = 2 * 10u64.pow(15);
+const MAX_CONGESTION_MEMORY_CONSUMPTION: u64 = bytesize::ByteSize::mb(1000u64).0;
+const MIN_GAS_FORWARDING: Gas = 1 * 10u64.pow(15);
+const MAX_GAS_FORWARDING: Gas = 300 * 10u64.pow(15);
+const RED_GAS: Gas = 1 * 10u64.pow(15);
+const MIN_TX_GAS: Gas = 20 * 10u64.pow(12);
+const MAX_TX_GAS: Gas = 500 * 10u64.pow(12);
+// 0.25 * MAX_CONGESTION_INCOMING_GAS
+const REJECT_TX_CONGESTION_THRESHOLD: Gas = MAX_CONGESTION_INCOMING_GAS / 4;
+
 /// Stores the congestion level of a shard.
 ///
 /// [`CongestionInfo`] should remain an internal struct that is not borsh
@@ -19,18 +31,67 @@ pub struct CongestionInfo {
 
 impl CongestionInfo {
     /// How much gas another shard can send to us in the next block.
-    pub fn outgoing_limit(&self, _sender_shard: ShardId) -> Gas {
-        todo!()
+    pub fn outgoing_limit(&self, sender_shard: ShardId) -> Gas {
+        let incoming_congestion = self.incoming_congestion();
+        let outgoing_congestion = self.outgoing_congestion();
+        let memory_congestion = self.memory_congestion();
+
+        let congestion = incoming_congestion.max(outgoing_congestion).max(memory_congestion);
+
+        if congestion == u16::MAX {
+            // Red traffic light: reduce to minimum speed
+            if sender_shard == self.allowed_shard {
+                RED_GAS
+            } else {
+                0
+            }
+        } else {
+            mix(MAX_GAS_FORWARDING, MIN_GAS_FORWARDING, congestion)
+        }
+    }
+
+    fn incoming_congestion(&self) -> u16 {
+        u16_fraction(self.delayed_receipts_gas, MAX_CONGESTION_INCOMING_GAS)
+    }
+    fn outgoing_congestion(&self) -> u16 {
+        u16_fraction(self.buffered_receipts_gas, MAX_CONGESTION_OUTGOING_GAS)
+    }
+    fn memory_congestion(&self) -> u16 {
+        u16_fraction(self.receipt_bytes as u128, MAX_CONGESTION_MEMORY_CONSUMPTION)
     }
 
     /// How much gas we accept for executing new transactions going to any
     /// uncongested shards.
     pub fn process_tx_limit(&self) -> Gas {
-        todo!()
+        mix(MAX_TX_GAS, MIN_TX_GAS, self.incoming_congestion())
     }
 
     /// Whether we can accept new transaction with the receiver set to this shard.
     pub fn shard_accepts_transactions(&self) -> bool {
-        todo!()
+        self.delayed_receipts_gas > REJECT_TX_CONGESTION_THRESHOLD as u128
     }
+}
+
+#[inline]
+fn u16_fraction(value: u128, max: u64) -> u16 {
+    let bounded_value = std::cmp::min(value as u128, max as u128);
+    let in_u16_range = bounded_value * u16::MAX as u128 / max as u128;
+    in_u16_range as u16
+}
+
+// linearly interpolate between two values
+//
+// This method treats u16 as a fraction of u16::MAX.
+// This makes multiplication of numbers on the upper end of `u128` better behaved
+// than using f64 which lacks precision for such high numbers.
+//
+// (TODO: overkill? maybe just use f64 and hope that we never have platform incompatibilities)
+fn mix(left: u64, right: u64, ratio: u16) -> u64 {
+    let left_part = left as u128 * (u16::MAX - ratio) as u128;
+    let right_part = right as u128 * ratio as u128;
+    let total = (left_part + right_part) / u16::MAX as u128;
+
+    // conversion is save because left and right were both u64 and the result is
+    // between the two
+    return total as u64;
 }

--- a/core/primitives/src/congestion_info.rs
+++ b/core/primitives/src/congestion_info.rs
@@ -1,0 +1,36 @@
+use near_primitives_core::types::{Gas, ShardId};
+
+/// Stores the congestion level of a shard.
+///
+/// [`CongestionInfo`] should remain an internal struct that is not borsh
+/// serialized anywhere. This way we can change it more easily.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CongestionInfo {
+    /// Sum of gas in currently delayed receipts.
+    pub delayed_receipts_gas: u128,
+    /// Sum of gas in currently buffered receipts.
+    pub buffered_receipts_gas: u128,
+    /// Size of borsh serialized receipts stored in state because they
+    /// were delayed, buffered, postponed, or yielded.
+    pub receipt_bytes: u64,
+    /// If fully congested, only this shard can forward receipts.
+    pub allowed_shard: u64,
+}
+
+impl CongestionInfo {
+    /// How much gas another shard can send to us in the next block.
+    pub fn outgoing_limit(&self, _sender_shard: ShardId) -> Gas {
+        todo!()
+    }
+
+    /// How much gas we accept for executing new transactions going to any
+    /// uncongested shards.
+    pub fn process_tx_limit(&self) -> Gas {
+        todo!()
+    }
+
+    /// Whether we can accept new transaction with the receiver set to this shard.
+    pub fn shard_accepts_transactions(&self) -> bool {
+        todo!()
+    }
+}

--- a/core/primitives/src/lib.rs
+++ b/core/primitives/src/lib.rs
@@ -10,6 +10,7 @@ pub mod block;
 pub mod block_body;
 pub mod block_header;
 pub mod challenge;
+pub mod congestion_info;
 pub mod epoch_manager;
 pub mod epoch_sync;
 pub mod errors;

--- a/core/primitives/src/receipt.rs
+++ b/core/primitives/src/receipt.rs
@@ -257,5 +257,25 @@ pub struct PromiseYieldTimeout {
     pub expires_at: BlockHeight,
 }
 
+/// Stores indices for a persistent queue for buffered receipts that couldn't be forwarded.
+#[derive(Default, BorshSerialize, BorshDeserialize, Clone, PartialEq, Debug)]
+pub struct BufferedReceiptIndices {
+    pub shard_buffer_indices: std::collections::BTreeMap<ShardId, ShardBufferedReceiptIndices>,
+}
+
+#[derive(Default, BorshSerialize, BorshDeserialize, Clone, PartialEq, Debug)]
+pub struct ShardBufferedReceiptIndices {
+    // First inclusive index in the queue.
+    pub first_index: u64,
+    // Exclusive end index of the queue
+    pub next_available_index: u64,
+}
+
+impl ShardBufferedReceiptIndices {
+    pub fn len(&self) -> u64 {
+        self.next_available_index - self.first_index
+    }
+}
+
 /// Map of shard to list of receipts to send to it.
 pub type ReceiptResult = HashMap<ShardId, Vec<Receipt>>;

--- a/core/primitives/src/stateless_validation.rs
+++ b/core/primitives/src/stateless_validation.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::challenge::PartialState;
+use crate::congestion_info::CongestionInfo;
 use crate::sharding::{ChunkHash, ReceiptProof, ShardChunkHeader, ShardChunkHeaderV3};
 use crate::transaction::SignedTransaction;
 use crate::types::EpochId;
@@ -10,6 +11,7 @@ use bytes::BufMut;
 use near_crypto::{PublicKey, Signature};
 use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::{AccountId, Balance, BlockHeight, ShardId};
+use near_primitives_core::version::PROTOCOL_VERSION;
 
 /// An arbitrary static string to make sure that this struct cannot be
 /// serialized to look identical to another serialized struct. For chunk
@@ -212,6 +214,8 @@ impl ChunkStateWitness {
             Default::default(),
             Default::default(),
             &EmptyValidatorSigner::default(),
+            PROTOCOL_VERSION,
+            CongestionInfo::default(),
         ));
         Self::new(
             "alice.near".parse().unwrap(),

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -21,7 +21,7 @@ use near_async::time::Clock;
 use near_crypto::vrf::Value;
 use near_crypto::{EmptySigner, InMemorySigner, KeyType, PublicKey, SecretKey, Signature, Signer};
 use near_primitives_core::account::id::AccountIdRef;
-use near_primitives_core::types::ProtocolVersion;
+use near_primitives_core::types::{ProtocolVersion, ShardId};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -624,6 +624,14 @@ impl EpochInfoProvider for MockEpochInfoProvider {
 
     fn chain_id(&self) -> String {
         "localnet".into()
+    }
+
+    fn account_id_to_shard_id(
+        &self,
+        account_id: &AccountId,
+        epoch_id: &EpochId,
+    ) -> Result<ShardId, EpochError> {
+        todo!()
     }
 }
 

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -3,6 +3,7 @@ use std::mem::size_of;
 use borsh::{BorshDeserialize, BorshSerialize};
 
 use near_crypto::PublicKey;
+use near_primitives_core::types::ShardId;
 
 use crate::hash::CryptoHash;
 use crate::types::AccountId;
@@ -50,9 +51,14 @@ pub mod col {
     /// This column id is used when storing the postponed PromiseYield receipts
     /// (`primitives::receipt::Receipt`).
     pub const PROMISE_YIELD_RECEIPT: u8 = 12;
+    /// Indics of outgoing receipts. A singleton per shard.
+    pub const BUFFERED_RECEIPT_INDICES: u8 = 13;
+    /// Outgoing receipts that need to be buffered due to congestion +
+    /// backpressure on the receiving shard.
+    pub const BUFFERED_RECEIPT: u8 = 14;
     /// All columns except those used for the delayed receipts queue and the yielded promises
     /// queue, which are both global state for the shard.
-    pub const COLUMNS_WITH_ACCOUNT_ID_IN_KEY: [(u8, &str); 9] = [
+    pub const COLUMNS_WITH_ACCOUNT_ID_IN_KEY: [(u8, &str); 11] = [
         (ACCOUNT, "Account"),
         (CONTRACT_CODE, "ContractCode"),
         (ACCESS_KEY, "AccessKey"),
@@ -62,6 +68,8 @@ pub mod col {
         (POSTPONED_RECEIPT, "PostponedReceipt"),
         (CONTRACT_DATA, "ContractData"),
         (PROMISE_YIELD_RECEIPT, "PromiseYieldReceipt"),
+        (BUFFERED_RECEIPT_INDICES, "BufferedReceiptIndices"),
+        (BUFFERED_RECEIPT, "BufferedReceipt"),
     ];
 }
 
@@ -109,6 +117,14 @@ pub enum TrieKey {
     /// Used to store the postponed promise yield receipt `primitives::receipt::Receipt`
     /// for a given receiver's `AccountId` and a given `data_id`.
     PromiseYieldReceipt { receiver_id: AccountId, data_id: CryptoHash },
+    /// Used to store indices of the buffered receipts queues per shard.
+    /// NOTE: It is a singleton per shard, holding indices for all outgoing shards.
+    BufferedReceiptIndices,
+    /// Used to store a buffered receipt `primitives::receipt::Receipt` for a
+    /// given index `u64` and receiving shard. There is one unique queue
+    /// per ordered shard pair. The trie for shard X stores all queues for pairs
+    /// (X,*).
+    BufferedReceipt { receiving_shard: ShardId, index: u64 },
 }
 
 /// Provides `len` function.
@@ -177,6 +193,12 @@ impl TrieKey {
                     + account_id.len()
                     + ACCOUNT_DATA_SEPARATOR.len()
                     + key.len()
+            }
+            TrieKey::BufferedReceiptIndices => col::BUFFERED_RECEIPT_INDICES.len(),
+            TrieKey::BufferedReceipt { index, receiving_shard } => {
+                col::BUFFERED_RECEIPT.len()
+                    + std::mem::size_of_val(receiving_shard)
+                    + std::mem::size_of_val(index)
             }
         }
     }
@@ -250,6 +272,12 @@ impl TrieKey {
                 buf.push(ACCOUNT_DATA_SEPARATOR);
                 buf.extend(data_id.as_ref());
             }
+            TrieKey::BufferedReceiptIndices => buf.push(col::BUFFERED_RECEIPT_INDICES),
+            TrieKey::BufferedReceipt { index, receiving_shard } => {
+                buf.push(col::BUFFERED_RECEIPT);
+                buf.extend(&receiving_shard.to_le_bytes());
+                buf.extend(&index.to_le_bytes());
+            }
         };
         debug_assert_eq!(expected_len, buf.len() - start_len);
     }
@@ -276,6 +304,8 @@ impl TrieKey {
             TrieKey::PromiseYieldIndices => None,
             TrieKey::PromiseYieldTimeout { .. } => None,
             TrieKey::PromiseYieldReceipt { receiver_id, .. } => Some(receiver_id.clone()),
+            TrieKey::BufferedReceiptIndices => None,
+            TrieKey::BufferedReceipt { .. } => None,
         }
     }
 }

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -375,6 +375,8 @@ impl StateChanges {
                 TrieKey::PromiseYieldIndices => {}
                 TrieKey::PromiseYieldTimeout { .. } => {}
                 TrieKey::PromiseYieldReceipt { .. } => {}
+                TrieKey::BufferedReceiptIndices => {}
+                TrieKey::BufferedReceipt { .. } => {}
             }
         }
 

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -729,11 +729,14 @@ pub struct BlockExtra {
 }
 
 pub mod chunk_extra {
+    use crate::congestion_info::CongestionInfo;
     use crate::types::validator_stake::{ValidatorStake, ValidatorStakeIter};
     use crate::types::StateRoot;
     use borsh::{BorshDeserialize, BorshSerialize};
     use near_primitives_core::hash::CryptoHash;
     use near_primitives_core::types::{Balance, Gas};
+    use near_primitives_core::version::{ProtocolFeature, PROTOCOL_VERSION};
+    use near_vm_runner::logic::ProtocolVersion;
 
     pub use super::ChunkExtraV1;
 
@@ -742,6 +745,7 @@ pub mod chunk_extra {
     pub enum ChunkExtra {
         V1(ChunkExtraV1),
         V2(ChunkExtraV2),
+        V3(ChunkExtraV3),
     }
 
     #[derive(Debug, PartialEq, BorshSerialize, BorshDeserialize, Clone, Eq)]
@@ -760,9 +764,47 @@ pub mod chunk_extra {
         pub balance_burnt: Balance,
     }
 
+    /// V2 -> V3: add congestion info fields.
+    #[derive(Debug, PartialEq, BorshSerialize, BorshDeserialize, Clone, Eq)]
+    pub struct ChunkExtraV3 {
+        /// Post state root after applying give chunk.
+        pub state_root: StateRoot,
+        /// Root of merklizing results of receipts (transactions) execution.
+        pub outcome_root: CryptoHash,
+        /// Validator proposals produced by given chunk.
+        pub validator_proposals: Vec<ValidatorStake>,
+        /// Actually how much gas were used.
+        pub gas_used: Gas,
+        /// Gas limit, allows to increase or decrease limit based on expected time vs real time for computing the chunk.
+        pub gas_limit: Gas,
+        /// Total balance burnt after processing the current chunk.
+        pub balance_burnt: Balance,
+
+        // Fields of `CongestionInfo` inlined to avoid adding another layer of
+        // versioning.
+        /// Sum of gas in currently delayed receipts.
+        pub delayed_receipts_gas: u128,
+        /// Sum of gas in currently buffered receipts.
+        pub buffered_receipts_gas: u128,
+        /// Size of borsh serialized receipts stored in state because they
+        /// were delayed, buffered, postponed, or yielded.
+        pub receipt_bytes: u64,
+        /// If fully congested, only this shard can forward receipts.
+        pub allowed_shard: u64,
+    }
+
     impl ChunkExtra {
         pub fn new_with_only_state_root(state_root: &StateRoot) -> Self {
-            Self::new(state_root, CryptoHash::default(), vec![], 0, 0, 0)
+            Self::new(
+                state_root,
+                CryptoHash::default(),
+                vec![],
+                0,
+                0,
+                0,
+                PROTOCOL_VERSION,
+                CongestionInfo::default(),
+            )
         }
 
         pub fn new(
@@ -772,15 +814,32 @@ pub mod chunk_extra {
             gas_used: Gas,
             gas_limit: Gas,
             balance_burnt: Balance,
+            protocol_version: ProtocolVersion,
+            congestion_info: CongestionInfo,
         ) -> Self {
-            Self::V2(ChunkExtraV2 {
-                state_root: *state_root,
-                outcome_root,
-                validator_proposals,
-                gas_used,
-                gas_limit,
-                balance_burnt,
-            })
+            if ProtocolFeature::Nep539CongestionControl.protocol_version() <= protocol_version {
+                Self::V3(ChunkExtraV3 {
+                    state_root: *state_root,
+                    outcome_root,
+                    validator_proposals,
+                    gas_used,
+                    gas_limit,
+                    balance_burnt,
+                    delayed_receipts_gas: congestion_info.delayed_receipts_gas,
+                    buffered_receipts_gas: congestion_info.buffered_receipts_gas,
+                    receipt_bytes: congestion_info.receipt_bytes,
+                    allowed_shard: congestion_info.allowed_shard,
+                })
+            } else {
+                Self::V2(ChunkExtraV2 {
+                    state_root: *state_root,
+                    outcome_root,
+                    validator_proposals,
+                    gas_used,
+                    gas_limit,
+                    balance_burnt,
+                })
+            }
         }
 
         #[inline]
@@ -788,6 +847,7 @@ pub mod chunk_extra {
             match self {
                 Self::V1(v1) => &v1.outcome_root,
                 Self::V2(v2) => &v2.outcome_root,
+                Self::V3(v3) => &v3.outcome_root,
             }
         }
 
@@ -796,6 +856,7 @@ pub mod chunk_extra {
             match self {
                 Self::V1(v1) => &v1.state_root,
                 Self::V2(v2) => &v2.state_root,
+                Self::V3(v3) => &v3.state_root,
             }
         }
 
@@ -804,6 +865,7 @@ pub mod chunk_extra {
             match self {
                 Self::V1(v1) => &mut v1.state_root,
                 Self::V2(v2) => &mut v2.state_root,
+                Self::V3(v3) => &mut v3.state_root,
             }
         }
 
@@ -812,6 +874,7 @@ pub mod chunk_extra {
             match self {
                 Self::V1(v1) => ValidatorStakeIter::v1(&v1.validator_proposals),
                 Self::V2(v2) => ValidatorStakeIter::new(&v2.validator_proposals),
+                Self::V3(v3) => ValidatorStakeIter::new(&v3.validator_proposals),
             }
         }
 
@@ -820,6 +883,7 @@ pub mod chunk_extra {
             match self {
                 Self::V1(v1) => v1.gas_limit,
                 Self::V2(v2) => v2.gas_limit,
+                Self::V3(v3) => v3.gas_limit,
             }
         }
 
@@ -828,6 +892,7 @@ pub mod chunk_extra {
             match self {
                 Self::V1(v1) => v1.gas_used,
                 Self::V2(v2) => v2.gas_used,
+                Self::V3(v3) => v3.gas_used,
             }
         }
 
@@ -836,6 +901,21 @@ pub mod chunk_extra {
             match self {
                 Self::V1(v1) => v1.balance_burnt,
                 Self::V2(v2) => v2.balance_burnt,
+                Self::V3(v3) => v3.balance_burnt,
+            }
+        }
+
+        #[inline]
+        pub fn congestion_info(&self) -> Option<CongestionInfo> {
+            match self {
+                Self::V1(_) => None,
+                Self::V2(_) => None,
+                Self::V3(v3) => Some(CongestionInfo {
+                    delayed_receipts_gas: v3.delayed_receipts_gas,
+                    buffered_receipts_gas: v3.buffered_receipts_gas,
+                    receipt_bytes: v3.receipt_bytes,
+                    allowed_shard: v3.allowed_shard,
+                }),
             }
         }
     }

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -1099,6 +1099,13 @@ pub trait EpochInfoProvider {
 
     /// Get the chain_id of the chain this epoch belongs to
     fn chain_id(&self) -> String;
+
+    /// Which shard the account belongs to in the given epoch.
+    fn account_id_to_shard_id(
+        &self,
+        account_id: &AccountId,
+        epoch_id: &EpochId,
+    ) -> Result<ShardId, EpochError>;
 }
 
 /// Mode of the trie cache.

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -89,6 +89,8 @@ pub struct ViewApplyState {
     pub prev_block_hash: CryptoHash,
     /// Currently building block hash
     pub block_hash: CryptoHash,
+    /// To which shard the applied chunk belongs.
+    pub shard_id: ShardId,
     /// Current epoch id
     pub epoch_id: EpochId,
     /// Current epoch height

--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -187,12 +187,14 @@ mod tests {
     use crate::trie::mem::loading::load_trie_from_flat_state;
     use crate::trie::mem::lookup::memtrie_lookup;
     use crate::{DBCol, KeyLookupMode, NibbleSlice, ShardTries, Store, Trie, TrieUpdate};
+    use near_primitives::congestion_info::CongestionInfo;
     use near_primitives::hash::CryptoHash;
     use near_primitives::shard_layout::{get_block_shard_uid, ShardUId};
     use near_primitives::state::FlatStateValue;
     use near_primitives::trie_key::TrieKey;
     use near_primitives::types::chunk_extra::ChunkExtra;
     use near_primitives::types::StateChangeCause;
+    use near_primitives::version::PROTOCOL_VERSION;
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
 
@@ -534,7 +536,16 @@ mod tests {
         shard_uid: ShardUId,
         state_root: CryptoHash,
     ) {
-        let chunk_extra = ChunkExtra::new(&state_root, CryptoHash::default(), Vec::new(), 0, 0, 0);
+        let chunk_extra = ChunkExtra::new(
+            &state_root,
+            CryptoHash::default(),
+            Vec::new(),
+            0,
+            0,
+            0,
+            PROTOCOL_VERSION,
+            CongestionInfo::default(),
+        );
         let mut store_update = store.store_update();
         store_update
             .set_ser(DBCol::ChunkExtra, &get_block_shard_uid(&block_hash, &shard_uid), &chunk_extra)

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -49,6 +49,7 @@ pub mod mem;
 mod nibble_slice;
 mod prefetching_trie_storage;
 mod raw_node;
+pub mod receipts_column_helper;
 pub mod resharding;
 mod shard_tries;
 mod state_parts;

--- a/core/store/src/trie/receipts_column_helper.rs
+++ b/core/store/src/trie/receipts_column_helper.rs
@@ -1,0 +1,67 @@
+use near_primitives::errors::StorageError;
+use near_primitives::receipt::{Receipt, ShardBufferedReceiptIndices};
+use near_primitives::trie_key::TrieKey;
+use near_primitives::types::ShardId;
+
+use crate::{get, TrieAccess};
+
+/// Read-only iterator over receipt queues stored in the state trie.
+pub struct ReceiptIterator<'a> {
+    trie_keys: Box<dyn Iterator<Item = TrieKey>>,
+    trie: &'a dyn TrieAccess,
+}
+
+impl<'a> ReceiptIterator<'a> {
+    pub fn delayed_receipts(trie: &'a dyn TrieAccess) -> Result<Self, StorageError> {
+        let indices = crate::get_delayed_receipt_indices(trie)?;
+        Ok(Self {
+            trie_keys: Box::new(
+                (indices.first_index..indices.next_available_index)
+                    .map(move |index| TrieKey::DelayedReceipt { index }),
+            ),
+            trie,
+        })
+    }
+
+    /// Iterates over all receipts in any receipt buffer.
+    pub fn buffered_receipts(trie: &'a dyn TrieAccess) -> Result<Self, StorageError> {
+        let all_indices = crate::get_buffered_receipt_indices(trie)?;
+        let trie_keys_iter =
+            all_indices.shard_buffer_indices.into_iter().flat_map(|(shard, indices)| {
+                (indices.first_index..indices.next_available_index)
+                    .map(move |index| TrieKey::BufferedReceipt { index, receiving_shard: shard })
+            });
+        Ok(Self { trie_keys: Box::new(trie_keys_iter), trie })
+    }
+
+    /// Iterates over receipts in a receipt buffer to a specific receiver shard.
+    pub fn shard_buffered_receipts(
+        trie: &'a dyn TrieAccess,
+        receiving_shard: ShardId,
+        indices: &ShardBufferedReceiptIndices,
+    ) -> Result<Self, StorageError> {
+        Ok(Self {
+            trie_keys: Box::new(
+                (indices.first_index..indices.next_available_index)
+                    .map(move |index| TrieKey::BufferedReceipt { index, receiving_shard }),
+            ),
+            trie,
+        })
+    }
+}
+
+impl<'a> Iterator for ReceiptIterator<'a> {
+    type Item = Result<Receipt, StorageError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let key = self.trie_keys.next()?;
+        let result = match get(self.trie, &key) {
+            Err(e) => Err(e),
+            Ok(None) => Err(StorageError::StorageInconsistentState(
+                "Receipt referenced by index should be in the state".to_owned(),
+            )),
+            Ok(Some(receipt)) => Ok(receipt),
+        };
+        Some(result)
+    }
+}

--- a/core/store/src/trie/resharding.rs
+++ b/core/store/src/trie/resharding.rs
@@ -85,6 +85,9 @@ impl ShardTries {
                         // in `changes.processed_yield_timeouts`.
                     }
                 },
+                // TODO: figure out what we need to do here
+                TrieKey::BufferedReceiptIndices => todo!(),
+                TrieKey::BufferedReceipt { .. } => todo!(),
                 TrieKey::Account { account_id }
                 | TrieKey::ContractCode { account_id }
                 | TrieKey::AccessKey { account_id, .. }

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -62,11 +62,14 @@ mod trie_recording_tests {
     use crate::{DBCol, KeyLookupMode, PartialStorage, ShardTries, Store, Trie};
     use borsh::BorshDeserialize;
     use near_primitives::challenge::PartialState;
+    use near_primitives::congestion_info::CongestionInfo;
+    use near_primitives::congestion_info::StoredReceiptsInfo;
     use near_primitives::hash::{hash, CryptoHash};
     use near_primitives::shard_layout::{get_block_shard_uid, ShardUId};
     use near_primitives::state::ValueRef;
     use near_primitives::types::chunk_extra::ChunkExtra;
     use near_primitives::types::StateRoot;
+    use near_primitives::version::PROTOCOL_VERSION;
     use rand::prelude::SliceRandom;
     use rand::{random, thread_rng, Rng};
     use std::collections::{HashMap, HashSet};
@@ -122,7 +125,16 @@ mod trie_recording_tests {
         );
 
         // ChunkExtra is needed for in-memory trie loading code to query state roots.
-        let chunk_extra = ChunkExtra::new(&state_root, CryptoHash::default(), Vec::new(), 0, 0, 0);
+        let chunk_extra = ChunkExtra::new(
+            &state_root,
+            CryptoHash::default(),
+            Vec::new(),
+            0,
+            0,
+            0,
+            PROTOCOL_VERSION,
+            CongestionInfo::default(),
+        );
         let mut update_for_chunk_extra = tries_for_building.store_update();
         update_for_chunk_extra
             .set_ser(

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -211,9 +211,11 @@ mod trie_storage_tests {
     use crate::{DBCol, Store, TrieChanges, TrieConfig};
     use assert_matches::assert_matches;
     use near_o11y::testonly::init_test_logger;
+    use near_primitives::congestion_info::CongestionInfo;
     use near_primitives::hash::hash;
     use near_primitives::shard_layout::get_block_shard_uid;
     use near_primitives::types::chunk_extra::ChunkExtra;
+    use near_primitives::version::PROTOCOL_VERSION;
 
     fn create_store_with_values(values: &[Vec<u8>], shard_uid: ShardUId) -> Store {
         let tries = TestTriesBuilder::new().build();
@@ -439,8 +441,16 @@ mod trie_storage_tests {
 
         let store = create_test_store();
         // ChunkExtra is needed for in-memory trie loading code to query state roots.
-        let chunk_extra =
-            ChunkExtra::new(&Trie::EMPTY_ROOT, CryptoHash::default(), Vec::new(), 0, 0, 0);
+        let chunk_extra = ChunkExtra::new(
+            &Trie::EMPTY_ROOT,
+            CryptoHash::default(),
+            Vec::new(),
+            0,
+            0,
+            0,
+            PROTOCOL_VERSION,
+            CongestionInfo::default(),
+        );
         let mut update_for_chunk_extra = store.store_update();
         update_for_chunk_extra
             .set_ser(

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -13,6 +13,7 @@ use near_epoch_manager::types::BlockHeaderInfo;
 use near_epoch_manager::{EpochManager, EpochManagerAdapter, EpochManagerHandle};
 use near_primitives::account::{AccessKey, Account};
 use near_primitives::block::{genesis_chunks, Tip};
+use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::shard_layout::{account_id_to_shard_id, ShardUId};
 use near_primitives::state_record::StateRecord;
@@ -259,6 +260,8 @@ impl GenesisBuilder {
                     0,
                     self.genesis.config.gas_limit,
                     0,
+                    self.genesis.config.protocol_version,
+                    CongestionInfo::default(),
                 ),
             );
         }

--- a/integration-tests/src/tests/client/block_corruption.rs
+++ b/integration-tests/src/tests/client/block_corruption.rs
@@ -70,6 +70,7 @@ fn change_shard_id_to_invalid() {
             ShardChunkHeader::V3(new_chunk) => match &mut new_chunk.inner {
                 ShardChunkHeaderInner::V1(inner) => inner.shard_id = 100,
                 ShardChunkHeaderInner::V2(inner) => inner.shard_id = 100,
+                ShardChunkHeaderInner::V3(inner) => inner.shard_id = 100,
             },
         };
         new_chunks.push(new_chunk);

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -12,6 +12,7 @@ use near_primitives::challenge::{
     BlockDoubleSign, Challenge, ChallengeBody, ChunkProofs, MaybeEncodedShardChunk, PartialState,
     TrieValue,
 };
+use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::PartialMerkleTree;
 use near_primitives::num_rational::Ratio;
@@ -375,6 +376,7 @@ fn test_verify_chunk_invalid_state_challenge() {
         &[],
         last_block.chunks()[0].prev_outgoing_receipts_root(),
         CryptoHash::default(),
+        CongestionInfo::default(),
         &validator_signer,
         &mut rs,
         PROTOCOL_VERSION,

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -1169,6 +1169,7 @@ fn test_bad_orphan() {
             match &mut chunk.inner {
                 ShardChunkHeaderInner::V1(inner) => inner.prev_outcome_root = CryptoHash([1; 32]),
                 ShardChunkHeaderInner::V2(inner) => inner.prev_outcome_root = CryptoHash([1; 32]),
+                ShardChunkHeaderInner::V3(inner) => inner.prev_outcome_root = CryptoHash([1; 32]),
             }
             chunk.hash = ShardChunkHeaderV3::compute_hash(&chunk.inner);
         }
@@ -3482,6 +3483,7 @@ mod contract_precompilation_tests {
             block_height: EPOCH_LENGTH,
             prev_block_hash: *block.header().prev_hash(),
             block_hash: *block.hash(),
+            shard_id: ShardUId::single_shard().shard_id(),
             epoch_id: block.header().epoch_id().clone(),
             epoch_height: 1,
             block_timestamp: block.header().raw_timestamp(),

--- a/integration-tests/src/tests/runtime/state_viewer.rs
+++ b/integration-tests/src/tests/runtime/state_viewer.rs
@@ -18,7 +18,7 @@ use near_primitives::{
     types::{EpochId, StateChangeCause},
     version::PROTOCOL_VERSION,
 };
-use near_store::{set_account, NibbleSlice, RawTrieNode, RawTrieNodeWithSize};
+use near_store::{set_account, NibbleSlice, RawTrieNode, RawTrieNodeWithSize, ShardUId};
 use node_runtime::state_viewer::errors;
 use node_runtime::state_viewer::*;
 use testlib::runtime_utils::alice_account;
@@ -110,6 +110,7 @@ fn test_view_call() {
         block_height: 1,
         prev_block_hash: CryptoHash::default(),
         block_hash: CryptoHash::default(),
+        shard_id: ShardUId::single_shard().shard_id(),
         epoch_id: EpochId::default(),
         epoch_height: 0,
         block_timestamp: 1,
@@ -138,6 +139,7 @@ fn test_view_call_try_changing_storage() {
         block_height: 1,
         prev_block_hash: CryptoHash::default(),
         block_hash: CryptoHash::default(),
+        shard_id: ShardUId::single_shard().shard_id(),
         epoch_id: EpochId::default(),
         epoch_height: 0,
         block_timestamp: 1,
@@ -170,6 +172,7 @@ fn test_view_call_with_args() {
         block_height: 1,
         prev_block_hash: CryptoHash::default(),
         block_hash: CryptoHash::default(),
+        shard_id: ShardUId::single_shard().shard_id(),
         epoch_id: EpochId::default(),
         epoch_height: 0,
         block_timestamp: 1,
@@ -390,6 +393,7 @@ fn test_log_when_panic() {
         block_height: 1,
         prev_block_hash: CryptoHash::default(),
         block_hash: CryptoHash::default(),
+        shard_id: ShardUId::single_shard().shard_id(),
         epoch_id: EpochId::default(),
         epoch_height: 0,
         block_timestamp: 1,

--- a/integration-tests/src/user/runtime_user.rs
+++ b/integration-tests/src/user/runtime_user.rs
@@ -6,7 +6,6 @@ use near_chain_configs::MIN_GAS_PRICE;
 use near_crypto::{PublicKey, Signer};
 use near_jsonrpc_primitives::errors::ServerError;
 use near_parameters::RuntimeConfig;
-use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::errors::{RuntimeError, TxExecutionError};
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;

--- a/integration-tests/src/user/runtime_user.rs
+++ b/integration-tests/src/user/runtime_user.rs
@@ -6,6 +6,7 @@ use near_chain_configs::MIN_GAS_PRICE;
 use near_crypto::{PublicKey, Signer};
 use near_jsonrpc_primitives::errors::ServerError;
 use near_parameters::RuntimeConfig;
+use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::errors::{RuntimeError, TxExecutionError};
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
@@ -156,6 +157,7 @@ impl RuntimeUser {
             prev_block_hash: Default::default(),
             block_hash: Default::default(),
             block_timestamp: 0,
+            shard_id: todo!("fix integration tests"),
             epoch_height: 0,
             gas_price: MIN_GAS_PRICE,
             gas_limit: None,
@@ -167,6 +169,8 @@ impl RuntimeUser {
             is_new_chunk: true,
             migration_data: Arc::new(MigrationData::default()),
             migration_flags: MigrationFlags::default(),
+            // TODO: Probably should create a hashmap per shard and fill a default congestion info for each
+            congestion_info: HashMap::default(),
         }
     }
 
@@ -284,6 +288,7 @@ impl User for RuntimeUser {
             block_height: apply_state.block_height,
             prev_block_hash: apply_state.prev_block_hash,
             block_hash: apply_state.block_hash,
+            shard_id: todo!("fix integration tests"),
             epoch_id: apply_state.epoch_id,
             epoch_height: apply_state.epoch_height,
             block_timestamp: apply_state.block_timestamp,

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -4,6 +4,7 @@ use crate::gas_cost::GasCost;
 use genesis_populate::get_account_id;
 use genesis_populate::state_dump::StateDump;
 use near_parameters::{ExtCosts, RuntimeConfigStore};
+use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
 use near_primitives::runtime::migration_data::{MigrationData, MigrationFlags};
@@ -144,12 +145,14 @@ impl<'c> EstimatorContext<'c> {
         };
         runtime_config.account_creation_config.min_allowed_top_level_account_length = 0;
 
+        let shard_id = ShardUId::single_shard().shard_id();
         ApplyState {
             // Put each runtime into a separate shard.
             block_height: 1,
             // Epoch length is long enough to avoid corner cases.
             prev_block_hash: Default::default(),
             block_hash: Default::default(),
+            shard_id,
             epoch_id: Default::default(),
             epoch_height: 0,
             gas_price: 0,
@@ -162,6 +165,7 @@ impl<'c> EstimatorContext<'c> {
             is_new_chunk: true,
             migration_data: Arc::new(MigrationData::default()),
             migration_flags: MigrationFlags::default(),
+            congestion_info: HashMap::from([(shard_id, CongestionInfo::default())]),
         }
     }
 

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -1175,6 +1175,7 @@ mod tests {
     use crate::near_primitives::shard_layout::ShardUId;
     use near_primitives::account::FunctionCallPermission;
     use near_primitives::action::delegate::NonDelegateAction;
+    use near_primitives::congestion_info::CongestionInfo;
     use near_primitives::errors::InvalidAccessKeyError;
     use near_primitives::hash::hash;
     use near_primitives::runtime::migration_data::MigrationFlags;
@@ -1184,6 +1185,7 @@ mod tests {
     use near_primitives_core::version::PROTOCOL_VERSION;
     use near_store::set_account;
     use near_store::test_utils::TestTriesBuilder;
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     fn test_action_create_account(
@@ -1407,6 +1409,7 @@ mod tests {
             block_height,
             prev_block_hash: CryptoHash::default(),
             block_hash: CryptoHash::default(),
+            shard_id: ShardUId::single_shard().shard_id(),
             epoch_id: EpochId::default(),
             epoch_height: 3,
             gas_price: 2,
@@ -1419,6 +1422,7 @@ mod tests {
             is_new_chunk: false,
             migration_data: Arc::default(),
             migration_flags: MigrationFlags::default(),
+            congestion_info: HashMap::new(),
         }
     }
 

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -15,6 +15,7 @@ use near_parameters::{ActionCosts, RuntimeConfig};
 pub use near_primitives;
 use near_primitives::account::Account;
 use near_primitives::checked_feature;
+use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::errors::{
     ActionError, ActionErrorKind, IntegerOverflowError, RuntimeError, TxExecutionError,
 };
@@ -33,6 +34,7 @@ use near_primitives::transaction::{
     SignedTransaction, TransferAction,
 };
 use near_primitives::trie_key::TrieKey;
+use near_primitives::types::ShardId;
 use near_primitives::types::{
     validator_stake::ValidatorStake, AccountId, Balance, BlockHeight, Compute, EpochHeight,
     EpochId, EpochInfoProvider, Gas, RawStateChangesWithTrieKey, StateChangeCause, StateRoot,
@@ -82,6 +84,8 @@ pub struct ApplyState {
     pub prev_block_hash: CryptoHash,
     /// Current block hash
     pub block_hash: CryptoHash,
+    /// To which shard the applied chunk belongs.
+    pub shard_id: ShardId,
     /// Current epoch id
     pub epoch_id: EpochId,
     /// Current epoch height
@@ -108,6 +112,8 @@ pub struct ApplyState {
     pub migration_data: Arc<MigrationData>,
     /// Flags for migrations indicating whether they can be applied at this block
     pub migration_flags: MigrationFlags,
+    /// Congestion level on each shard based on the latest known chunk header of each shard.
+    pub congestion_info: HashMap<ShardId, CongestionInfo>,
 }
 
 /// Contains information to update validators accounts at the first block of a new epoch.
@@ -161,6 +167,7 @@ pub struct ApplyResult {
     pub proof: Option<PartialStorage>,
     pub delayed_receipts_count: u64,
     pub metrics: Option<metrics::ApplyMetrics>,
+    pub congestion_info: CongestionInfo,
 }
 
 #[derive(Debug)]
@@ -1371,6 +1378,7 @@ impl Runtime {
                 proof,
                 delayed_receipts_count: delayed_receipts_indices.len(),
                 metrics: None,
+                congestion_info: todo!(),
             });
         }
 
@@ -1751,6 +1759,7 @@ impl Runtime {
             proof,
             delayed_receipts_count: delayed_receipts_indices.len(),
             metrics: Some(metrics),
+            congestion_info: todo!(),
         })
     }
 
@@ -1834,6 +1843,19 @@ fn action_transfer_or_implicit_account_creation(
             epoch_info_provider,
         );
     })
+}
+
+/// Iterate all columns in the trie holding unprocessed receipts and
+/// computes the storage consumption as well as attached gas.
+///
+/// This is an IO intensive operation! Only do it to bootstrap the
+/// `CongestionInfo`. In normal operation, this information is kept up
+/// to date and passed from chunk to chunk through chunk extra fields.
+pub fn compute_congestion_info(
+    trie: &dyn near_store::TrieAccess,
+    config: &RuntimeConfig,
+) -> Result<CongestionInfo, StorageError> {
+    todo!()
 }
 
 struct TotalResourceGuard {
@@ -1976,6 +1998,7 @@ mod tests {
             block_height: 1,
             prev_block_hash: Default::default(),
             block_hash: Default::default(),
+            shard_id: ShardUId::single_shard().shard_id(),
             epoch_id: Default::default(),
             epoch_height: 0,
             gas_price: GAS_PRICE,
@@ -1988,6 +2011,7 @@ mod tests {
             is_new_chunk: true,
             migration_data: Arc::new(MigrationData::default()),
             migration_flags: MigrationFlags::default(),
+            congestion_info: HashMap::new(),
         };
 
         (runtime, tries, root, apply_state, signer, MockEpochInfoProvider::default())

--- a/runtime/runtime/src/receipt_sink.rs
+++ b/runtime/runtime/src/receipt_sink.rs
@@ -1,0 +1,179 @@
+use super::{receipt_congestion_gas, receipt_size};
+use crate::ApplyState;
+use near_parameters::RuntimeConfig;
+use near_primitives::congestion_info::CongestionInfo;
+use near_primitives::errors::RuntimeError;
+use near_primitives::receipt::{BufferedReceiptIndices, Receipt};
+use near_primitives::types::{EpochInfoProvider, Gas, ShardId};
+use near_store::remove_buffered_receipt;
+use near_store::{
+    push_buffered_receipt, trie::receipts_column_helper::ReceiptIterator, TrieUpdate,
+};
+use std::collections::HashMap;
+
+/// A helper struct to buffer or forward receipts.
+///
+/// When the runtime produces receipts for other shards, a `ReceiptSink` accept
+/// them and either puts them in the outgoing receipts list, or puts them in a
+/// buffer which is stored in the trie.
+///
+/// This is for congestion control, allowing to apply backpressure from the
+/// receiving shard and stopping us from sending more receipts to it than its
+/// nodes can keep in memory.
+pub(crate) struct ReceiptSink<'a> {
+    pub(crate) congestion_info: &'a mut CongestionInfo,
+    pub(crate) outgoing_limit: &'a mut HashMap<ShardId, Gas>,
+    pub(crate) buffered_receipts_indices: &'a mut BufferedReceiptIndices,
+    pub(crate) outgoing_receipts: &'a mut Vec<Receipt>,
+}
+
+enum ReceiptForwarding {
+    Forwarded,
+    NotForwarded(Receipt),
+}
+
+impl ReceiptSink<'_> {
+    /// Forward receipts already in the buffer to the outgoing receipts vector, as
+    /// much as the gas limits allow.
+    pub(crate) fn forward_from_buffer(
+        &mut self,
+        state_update: &mut TrieUpdate,
+        apply_state: &ApplyState,
+    ) -> Result<(), RuntimeError> {
+        for (&shard, buffer_indices) in &mut self.buffered_receipts_indices.shard_buffer_indices {
+            let index_before = buffer_indices.first_index;
+            for receipt_result in
+                ReceiptIterator::shard_buffered_receipts(&state_update.trie, shard, buffer_indices)?
+            {
+                let receipt = receipt_result?;
+                let bytes = receipt_size(&receipt)?;
+                let gas = receipt_congestion_gas(&receipt, &apply_state.config)?;
+                match Self::try_forward(
+                    receipt,
+                    shard,
+                    self.outgoing_limit,
+                    self.outgoing_receipts,
+                    apply_state,
+                )? {
+                    ReceiptForwarding::Forwarded => {
+                        self.congestion_info.receipt_bytes = self
+                            .congestion_info
+                            .receipt_bytes
+                            .checked_sub(bytes as u64)
+                            .ok_or_else(|| RuntimeError::UnexpectedIntegerOverflow)?;
+                        self.congestion_info.buffered_receipts_gas = self
+                            .congestion_info
+                            .buffered_receipts_gas
+                            .checked_sub(gas as u128)
+                            .ok_or_else(|| RuntimeError::UnexpectedIntegerOverflow)?;
+                        buffer_indices.first_index = buffer_indices
+                            .first_index
+                            .checked_add(1)
+                            .ok_or_else(|| RuntimeError::UnexpectedIntegerOverflow)?;
+                    }
+                    ReceiptForwarding::NotForwarded(_) => {
+                        break;
+                    }
+                }
+            }
+            // removing receipts from state here to avoid double borrow of `state_update`
+            for index in index_before..buffer_indices.first_index {
+                remove_buffered_receipt(state_update, index, shard);
+            }
+        }
+        Ok(())
+    }
+
+    /// Put a receipt in the outgoing receipts vector (=forward) if the
+    /// congestion preventing limits allow it. Put it in the buffered receipts
+    /// queue otherwise.
+    pub(crate) fn forward_or_buffer_receipt(
+        &mut self,
+        receipt: Receipt,
+        apply_state: &ApplyState,
+        state_update: &mut TrieUpdate,
+        epoch_info_provider: &dyn EpochInfoProvider,
+    ) -> Result<(), RuntimeError> {
+        let shard = epoch_info_provider
+            .account_id_to_shard_id(&receipt.receiver_id, &apply_state.epoch_id)?;
+        if shard == apply_state.shard_id {
+            // No limits on receipts that stay on the same shard. Backpressure
+            // wouldn't help, the receipt takes the same memory if buffered or
+            // in the delayed receipts queue.
+            self.outgoing_receipts.push(receipt);
+            return Ok(());
+        }
+        match Self::try_forward(
+            receipt,
+            shard,
+            self.outgoing_limit,
+            self.outgoing_receipts,
+            apply_state,
+        )? {
+            ReceiptForwarding::Forwarded => (),
+            ReceiptForwarding::NotForwarded(receipt) => {
+                self.buffer_receipt(&receipt, state_update, shard, &apply_state.config)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Forward a receipt if possible and return whether it was forwarded or
+    /// not.
+    ///
+    /// This does not take `&mut self` as first argument to make lifetime
+    /// management easier. Instead it takes exactly the fields it requires,
+    /// namely `outgoing_limit` and `outgoing_receipt`.
+    fn try_forward(
+        receipt: Receipt,
+        shard: ShardId,
+        outgoing_limit: &mut HashMap<ShardId, Gas>,
+        outgoing_receipts: &mut Vec<Receipt>,
+        apply_state: &ApplyState,
+    ) -> Result<ReceiptForwarding, RuntimeError> {
+        // Default case set to `Gas::MAX`: If no outgoing limit was defined for the receiving
+        // shard, this usually just means the feature is not enabled. Or, it
+        // could be a special case during resharding events. Or even a bug. In
+        // any case, if we cannot know a limit, treating it as literally "no
+        // limit" is the safest approach to ensure availability.
+        let forward_limit = outgoing_limit.entry(shard).or_insert(Gas::MAX);
+        let gas_to_forward = receipt_congestion_gas(&receipt, &apply_state.config)?;
+        if *forward_limit > gas_to_forward {
+            outgoing_receipts.push(receipt);
+            // underflow impossible: checked forward_limit > gas_to_forward above
+            *forward_limit -= gas_to_forward;
+            Ok(ReceiptForwarding::Forwarded)
+        } else {
+            Ok(ReceiptForwarding::NotForwarded(receipt))
+        }
+    }
+
+    /// Put a receipt in the outgoing receipt buffer of a shard.
+    fn buffer_receipt(
+        &mut self,
+        receipt: &Receipt,
+        state_update: &mut TrieUpdate,
+        shard: u64,
+        config: &RuntimeConfig,
+    ) -> Result<(), RuntimeError> {
+        let bytes = receipt_size(&receipt)?;
+        let gas = receipt_congestion_gas(&receipt, config)?;
+        self.congestion_info.receipt_bytes = self
+            .congestion_info
+            .receipt_bytes
+            .checked_add(bytes as u64)
+            .ok_or_else(|| RuntimeError::UnexpectedIntegerOverflow)?;
+        self.congestion_info.buffered_receipts_gas = self
+            .congestion_info
+            .buffered_receipts_gas
+            .checked_add(gas as u128)
+            .ok_or_else(|| RuntimeError::UnexpectedIntegerOverflow)?;
+        push_buffered_receipt(
+            state_update,
+            self.buffered_receipts_indices.shard_buffer_indices.entry(shard).or_default(),
+            &receipt,
+            shard,
+        )?;
+        Ok(())
+    }
+}

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -193,6 +193,7 @@ impl TrieViewer {
             // Used for legacy reasons
             prev_block_hash: view_state.prev_block_hash,
             block_hash: view_state.block_hash,
+            shard_id: view_state.shard_id,
             epoch_id: view_state.epoch_id.clone(),
             epoch_height: view_state.epoch_height,
             gas_price: 0,
@@ -205,6 +206,7 @@ impl TrieViewer {
             is_new_chunk: false,
             migration_data: Arc::new(MigrationData::default()),
             migration_flags: MigrationFlags::default(),
+            congestion_info: Default::default(),
         };
         let action_receipt = ActionReceipt {
             signer_id: originator_id.clone(),

--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -2,6 +2,7 @@ use near_chain_configs::{get_initial_supply, Genesis, GenesisConfig, GenesisReco
 use near_crypto::{InMemorySigner, KeyType};
 use near_parameters::ActionCosts;
 use near_primitives::account::{AccessKey, Account};
+use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::receipt::Receipt;
 use near_primitives::runtime::migration_data::{MigrationData, MigrationFlags};
@@ -78,20 +79,28 @@ impl StandaloneRuntime {
             account_ids.insert(state_record_to_account_id(record).clone());
         });
         let writers = std::sync::atomic::AtomicUsize::new(0);
+        let shard_uid = ShardUId::from_shard_id_and_layout(0, &genesis.config.shard_layout);
         let root = GenesisStateApplier::apply(
             &writers,
             tries.clone(),
-            ShardUId::from_shard_id_and_layout(0, &genesis.config.shard_layout),
+            shard_uid,
             &[],
             &runtime_config.fees.storage_usage_config,
             &genesis,
             account_ids,
         );
+        let congestion_info: HashMap<_, _> = genesis
+            .config
+            .shard_layout
+            .shard_ids()
+            .map(|shard_id| (shard_id, CongestionInfo::default()))
+            .collect();
 
         let apply_state = ApplyState {
             block_height: 1,
             prev_block_hash: Default::default(),
             block_hash: Default::default(),
+            shard_id: shard_uid.shard_id(),
             epoch_id: Default::default(),
             epoch_height: 0,
             gas_price: 100,
@@ -104,6 +113,7 @@ impl StandaloneRuntime {
             is_new_chunk: true,
             migration_data: Arc::new(MigrationData::default()),
             migration_flags: MigrationFlags::default(),
+            congestion_info,
         };
 
         Self {

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -151,6 +151,7 @@ pub(crate) fn apply_chunk(
                 ),
                 gas_price,
                 random_seed: hash("random seed".as_ref()),
+                congestion_info: prev_block.shards_congestion_info(),
             },
             &receipts,
             transactions,

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -699,6 +699,8 @@ pub enum RecordType {
     DelayedReceiptOrIndices = col::DELAYED_RECEIPT_OR_INDICES,
     ContractData = col::CONTRACT_DATA,
     PromiseYieldReceipt = col::PROMISE_YIELD_RECEIPT,
+    BufferedReceiptIndices = col::BUFFERED_RECEIPT_INDICES,
+    BufferedReceipt = col::BUFFERED_RECEIPT,
 }
 
 impl clap::ValueEnum for RecordType {
@@ -734,6 +736,10 @@ impl clap::ValueEnum for RecordType {
             Self::ContractData => Some(clap::builder::PossibleValue::new("contract-data")),
             Self::PromiseYieldReceipt => {
                 Some(clap::builder::PossibleValue::new("promise-yield-receipt"))
+            }
+            Self::BufferedReceipt => Some(clap::builder::PossibleValue::new("buffered-receipt")),
+            Self::BufferedReceiptIndices => {
+                Some(clap::builder::PossibleValue::new("buffered-receipt-indices"))
             }
         }
     }

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -35,6 +35,7 @@ use near_primitives::state_record::StateRecord;
 use near_primitives::trie_key::col::COLUMNS_WITH_ACCOUNT_ID_IN_KEY;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{chunk_extra::ChunkExtra, BlockHeight, ShardId, StateRoot};
+use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives_core::types::Gas;
 use near_store::flat::FlatStorageChunkView;
 use near_store::flat::FlatStorageManager;
@@ -104,6 +105,7 @@ pub(crate) fn apply_block(
                 ApplyChunkBlockContext::from_header(
                     block.header(),
                     prev_block.header().next_gas_price(),
+                    prev_block.shards_congestion_info(),
                 ),
                 &receipts,
                 chunk.transactions(),
@@ -112,6 +114,7 @@ pub(crate) fn apply_block(
     } else {
         let chunk_extra =
             chain_store.get_chunk_extra(block.header().prev_hash(), &shard_uid).unwrap();
+        let prev_block = chain_store.get_block(block.header().prev_hash()).unwrap();
 
         runtime
             .apply_chunk(
@@ -126,6 +129,7 @@ pub(crate) fn apply_block(
                 ApplyChunkBlockContext::from_header(
                     block.header(),
                     block.header().next_gas_price(),
+                    prev_block.shards_congestion_info(),
                 ),
                 &[],
                 &[],
@@ -506,10 +510,18 @@ pub(crate) fn get_receipt(receipt_id: CryptoHash, near_config: NearConfig, store
 fn chunk_extras_equal(l: &ChunkExtra, r: &ChunkExtra) -> bool {
     // explicitly enumerate the versions in a match here first so that if a new version is
     // added, we'll get a compile error here and be reminded to update it correctly.
+    //
+    // edit with v3: To avoid too many explicit combinations, use wildcards for
+    // versions >= 3. The compiler will still notice the missing `(v1, new_v)`
+    // combinations.
     match (l, r) {
         (ChunkExtra::V1(l), ChunkExtra::V1(r)) => return l == r,
         (ChunkExtra::V2(l), ChunkExtra::V2(r)) => return l == r,
-        (ChunkExtra::V1(_), ChunkExtra::V2(_)) | (ChunkExtra::V2(_), ChunkExtra::V1(_)) => {}
+        (ChunkExtra::V3(l), ChunkExtra::V3(r)) => return l == r,
+        (ChunkExtra::V1(_), ChunkExtra::V2(_))
+        | (ChunkExtra::V2(_), ChunkExtra::V1(_))
+        | (_, ChunkExtra::V3(_))
+        | (ChunkExtra::V3(_), _) => {}
     };
     if l.state_root() != r.state_root() {
         return false;
@@ -524,6 +536,9 @@ fn chunk_extras_equal(l: &ChunkExtra, r: &ChunkExtra) -> bool {
         return false;
     }
     if l.balance_burnt() != r.balance_burnt() {
+        return false;
+    }
+    if l.congestion_info() != r.congestion_info() {
         return false;
     }
     l.validator_proposals().collect::<Vec<_>>() == r.validator_proposals().collect::<Vec<_>>()
@@ -721,6 +736,8 @@ pub(crate) fn replay_chain(
 }
 
 pub(crate) fn resulting_chunk_extra(result: &ApplyChunkResult, gas_limit: Gas) -> ChunkExtra {
+    // TODO: is it okay to use latest protocol version hre for the chunk extra?
+    let protocol_version = PROTOCOL_VERSION;
     let (outcome_root, _) = ApplyChunkResult::compute_outcomes_proof(&result.outcomes);
     ChunkExtra::new(
         &result.new_root,
@@ -729,6 +746,8 @@ pub(crate) fn resulting_chunk_extra(result: &ApplyChunkResult, gas_limit: Gas) -
         result.total_gas_burnt,
         gas_limit,
         result.total_balance_burnt,
+        protocol_version,
+        result.congestion_info.clone(),
     )
 }
 


### PR DESCRIPTION
Reference implementation of [NEP-539](https://github.com/near/NEPs/pull/539).

Advice: It is best to review per commit.

The reference implementation is without tests and certain features might not be working properly. But it should show how all the relevant parts are handled.

While the most relevant parts will be patched here as well, most of the further development to make this ready for nearcore  will happen on separate branches that build on this.

- Part 1, congestion info in the chunk header, chunk extra, and passed in-and-out of the runtime
  - branch: [nep539-part1-congestion-info](https://github.com/near/nearcore/tree/nep539-part1-congestion-info)
  - PR: https://github.com/near/nearcore/pull/11128
- Part 2, outgoing receipt buffer in trie
  - branch: [nep539-part2-receipts-buffer](https://github.com/near/nearcore/tree/nep539-part2-receipts-buffer)
  - PR: https://github.com/near/nearcore/pull/11129
- Part 3, runtime changes to actually do congestion control
  - branch: [nep539-part3-runtime-changes](https://github.com/near/nearcore/tree/nep539-part3-runtime-changes)
  - PR: https://github.com/near/nearcore/pull/11130