### PR TITLE
fix(snapshots): spawn a new Arbiter for the StateSnapshotActor 

### DIFF
--- a/chain/chain/src/state_snapshot_actor.rs
+++ b/chain/chain/src/state_snapshot_actor.rs
@@ -134,7 +134,7 @@ pub struct SnapshotCallbacks {
 
 /// Sends a request to make a state snapshot.
 pub fn get_make_snapshot_callback(
-    state_snapshot_addr: Arc<actix::Addr<StateSnapshotActor>>,
+    state_snapshot_addr: actix::Addr<StateSnapshotActor>,
     flat_storage_manager: FlatStorageManager,
 ) -> MakeSnapshotCallback {
     Arc::new(move |prev_block_hash, epoch_height, shard_uids, block| {
@@ -162,7 +162,7 @@ pub fn get_make_snapshot_callback(
 
 /// Sends a request to delete a state snapshot.
 pub fn get_delete_snapshot_callback(
-    state_snapshot_addr: Arc<actix::Addr<StateSnapshotActor>>,
+    state_snapshot_addr: actix::Addr<StateSnapshotActor>,
 ) -> DeleteSnapshotCallback {
     Arc::new(move || {
         tracing::info!(

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -334,14 +334,12 @@ pub fn start_with_config_and_synchronization(
         adv.clone(),
     );
 
-    let state_snapshot_actor = Arc::new(
-        StateSnapshotActor::new(
-            runtime.get_flat_storage_manager(),
-            network_adapter.as_multi_sender(),
-            runtime.get_tries(),
-        )
-        .start(),
-    );
+    let state_snapshot_actor = StateSnapshotActor::new(
+        runtime.get_flat_storage_manager(),
+        network_adapter.as_multi_sender(),
+        runtime.get_tries(),
+    )
+    .start();
     let delete_snapshot_callback = get_delete_snapshot_callback(state_snapshot_actor.clone());
     let make_snapshot_callback =
         get_make_snapshot_callback(state_snapshot_actor, runtime.get_flat_storage_manager());

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -334,12 +334,11 @@ pub fn start_with_config_and_synchronization(
         adv.clone(),
     );
 
-    let state_snapshot_actor = StateSnapshotActor::new(
+    let (state_snapshot_actor, state_snapshot_arbiter) = StateSnapshotActor::spawn(
         runtime.get_flat_storage_manager(),
         network_adapter.as_multi_sender(),
         runtime.get_tries(),
-    )
-    .start();
+    );
     let delete_snapshot_callback = get_delete_snapshot_callback(state_snapshot_actor.clone());
     let make_snapshot_callback =
         get_make_snapshot_callback(state_snapshot_actor, runtime.get_flat_storage_manager());
@@ -445,8 +444,12 @@ pub fn start_with_config_and_synchronization(
 
     tracing::trace!(target: "diagnostic", key = "log", "Starting NEAR node with diagnostic activated");
 
-    let mut arbiters =
-        vec![client_arbiter_handle, shards_manager_arbiter_handle, trie_metrics_arbiter];
+    let mut arbiters = vec![
+        client_arbiter_handle,
+        shards_manager_arbiter_handle,
+        trie_metrics_arbiter,
+        state_snapshot_arbiter,
+    ];
     if let Some(db_metrics_arbiter) = db_metrics_arbiter {
         arbiters.push(db_metrics_arbiter);
     }


### PR DESCRIPTION
Before this change the `StateSnapshotActor` is started in the `Arbiter` corresponding to the thread running `nearcore::start_with_config_and_synchronization()`. This is the same thread that receives requests destined for the `ViewClientActor`, before [handing them off](https://github.com/actix/actix/blob/c954c1827fd51111b77b1ebca6a86413004a5d3c/actix/src/sync.rs#L161) to one of those threads. So when a checkpoint is being created, all messages to the `ViewClientActor` will be blocked, which is made worse by https://github.com/near/nearcore/pull/10803/ since checkpoints now take a bit longer to create (at least on a localnet).

This is currently causing the [failures in skip_epoch.py](https://nayduck.near.org/#/test/595132), and we can fix it by just starting this actor in a new thread