### PR TITLE
Use PascalCase for parameter estimator cost parsing

### DIFF
--- a/runtime/runtime-params-estimator/src/cost.rs
+++ b/runtime/runtime-params-estimator/src/cost.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 ///
 /// TODO: Deduplicate this enum with `ExtCosts` and `ActionCosts`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, PartialOrd, Ord, clap::ValueEnum)]
+#[clap(rename_all = "PascalCase")]
 #[repr(u8)]
 pub enum Cost {
     // Every set of actions in a transaction needs to be transformed into a


### PR DESCRIPTION
According to
https://near.github.io/nearcore/practices/workflows/gas_estimations.html, this was the behavior in the past, but now it looks like the default silently changed in clap: https://docs.rs/clap/latest/clap/_derive/index.html#valueenum-attributes

So I'm adding an overwrite to revert to previous behavior.