### PR TITLE
fix(mirror): map receipts correctly in the genesis state

### DIFF
--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -14,7 +14,6 @@ use near_primitives::account::id::AccountType;
 use near_primitives::account::{AccessKey, AccessKeyPermission, Account};
 use near_primitives::borsh;
 use near_primitives::hash::CryptoHash;
-use near_primitives::receipt::Receipt;
 use near_primitives::serialize::dec_format;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::state::FlatStateValue;
@@ -480,6 +479,8 @@ impl ForkNetworkCommand {
         tracing::info!(?shard_uid);
         let mut storage_mutator: SingleShardStorageMutator = make_storage_mutator(prev_state_root)?;
 
+        // TODO: allow mutating the state with a secret, so this can be used to prepare a public test network
+        let default_key = near_mirror::key_mapping::default_extra_key(None).public_key();
         // Keeps track of accounts that have a full access key.
         let mut has_full_key = HashSet::new();
         // Lets us lookup large values in the `State` columns.
@@ -495,7 +496,6 @@ impl ForkNetworkCommand {
         let mut contract_data_updated = 0;
         let mut contract_code_updated = 0;
         let mut postponed_receipts_updated = 0;
-        let mut delayed_receipts_updated = 0;
         let mut received_data_updated = 0;
         let mut fake_block_height = block_height + 1;
         for item in store_helper::iter_flat_state_entries(shard_uid, &store, None, None) {
@@ -554,23 +554,11 @@ impl ForkNetworkCommand {
                             contract_code_updated += 1;
                         }
                     }
-                    StateRecord::PostponedReceipt(receipt) => {
-                        // TODO(eth-implicit) Change back to is_implicit() when ETH-implicit accounts are supported.
-                        if receipt.predecessor_id.get_account_type()
-                            == AccountType::NearImplicitAccount
-                            || receipt.receiver_id.get_account_type()
-                                == AccountType::NearImplicitAccount
-                        {
-                            let new_receipt = Receipt {
-                                predecessor_id: map_account(&receipt.predecessor_id, None),
-                                receiver_id: map_account(&receipt.receiver_id, None),
-                                receipt_id: receipt.receipt_id,
-                                receipt: receipt.receipt.clone(),
-                            };
-                            storage_mutator.delete_postponed_receipt(receipt)?;
-                            storage_mutator.set_postponed_receipt(&new_receipt)?;
-                            postponed_receipts_updated += 1;
-                        }
+                    StateRecord::PostponedReceipt(mut receipt) => {
+                        storage_mutator.delete_postponed_receipt(&receipt)?;
+                        near_mirror::genesis::map_receipt(&mut receipt, None, &default_key);
+                        storage_mutator.set_postponed_receipt(&receipt)?;
+                        postponed_receipts_updated += 1;
                     }
                     StateRecord::ReceivedData { account_id, data_id, data } => {
                         // TODO(eth-implicit) Change back to is_implicit() when ETH-implicit accounts are supported.
@@ -581,24 +569,10 @@ impl ForkNetworkCommand {
                             received_data_updated += 1;
                         }
                     }
-                    StateRecord::DelayedReceipt(receipt) => {
-                        // TODO(eth-implicit) Change back to is_implicit() when ETH-implicit accounts are supported.
-                        if receipt.predecessor_id.get_account_type()
-                            == AccountType::NearImplicitAccount
-                            || receipt.receiver_id.get_account_type()
-                                == AccountType::NearImplicitAccount
-                        {
-                            let new_receipt = Receipt {
-                                predecessor_id: map_account(&receipt.predecessor_id, None),
-                                receiver_id: map_account(&receipt.receiver_id, None),
-                                receipt_id: receipt.receipt_id,
-                                receipt: receipt.receipt,
-                            };
-                            storage_mutator.delete_delayed_receipt(index_delayed_receipt)?;
-                            storage_mutator
-                                .set_delayed_receipt(index_delayed_receipt, &new_receipt)?;
-                            delayed_receipts_updated += 1;
-                        }
+                    StateRecord::DelayedReceipt(mut receipt) => {
+                        storage_mutator.delete_delayed_receipt(index_delayed_receipt)?;
+                        near_mirror::genesis::map_receipt(&mut receipt, None, &default_key);
+                        storage_mutator.set_delayed_receipt(index_delayed_receipt, &receipt)?;
                         index_delayed_receipt += 1;
                     }
                 }
@@ -616,7 +590,7 @@ impl ForkNetworkCommand {
                         + contract_data_updated
                         + contract_code_updated
                         + postponed_receipts_updated
-                        + delayed_receipts_updated
+                        + index_delayed_receipt
                         + received_data_updated,
                 );
                 let state_root = storage_mutator.commit(&shard_uid, fake_block_height)?;
@@ -635,7 +609,7 @@ impl ForkNetworkCommand {
             contract_code_updated,
             contract_data_updated,
             postponed_receipts_updated,
-            delayed_receipts_updated,
+            delayed_receipts_updated = index_delayed_receipt,
             received_data_updated,
             num_has_full_key = has_full_key.len(),
             "Pass 1 done"
@@ -666,7 +640,7 @@ impl ForkNetworkCommand {
                     }
                     storage_mutator.set_access_key(
                         account_id,
-                        near_mirror::key_mapping::default_extra_key(None).public_key(),
+                        default_key.clone(),
                         AccessKey::full_access(),
                     )?;
                     num_added += 1;

--- a/tools/fork-network/src/single_shard_storage_mutator.rs
+++ b/tools/fork-network/src/single_shard_storage_mutator.rs
@@ -101,9 +101,9 @@ impl SingleShardStorageMutator {
         )
     }
 
-    pub(crate) fn delete_postponed_receipt(&mut self, receipt: Box<Receipt>) -> anyhow::Result<()> {
+    pub(crate) fn delete_postponed_receipt(&mut self, receipt: &Receipt) -> anyhow::Result<()> {
         self.remove(TrieKey::PostponedReceipt {
-            receiver_id: receipt.receiver_id,
+            receiver_id: receipt.receiver_id.clone(),
             receipt_id: receipt.receipt_id,
         })
     }

--- a/tools/mirror/src/genesis.rs
+++ b/tools/mirror/src/genesis.rs
@@ -70,7 +70,7 @@ fn map_action_receipt(
 }
 
 // map any account IDs or keys referenced in the receipt
-fn map_receipt(
+pub fn map_receipt(
     receipt: &mut Receipt,
     secret: Option<&[u8; crate::secret::SECRET_LEN]>,
     default_key: &PublicKey,
@@ -88,7 +88,7 @@ fn map_receipt(
 /// Reads records, makes changes to them and writes them to a new file.
 /// `records_file_in` must be different from `records_file_out`.
 /// Writes a secret to `secret_file_out`.
-pub fn map_records<P: AsRef<Path>>(
+pub(crate) fn map_records<P: AsRef<Path>>(
     records_file_in: P,
     records_file_out: P,
     no_secret: bool,

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -41,7 +41,7 @@ use tokio::sync::mpsc;
 
 mod chain_tracker;
 pub mod cli;
-mod genesis;
+pub mod genesis;
 pub mod key_mapping;
 mod metrics;
 mod offline;


### PR DESCRIPTION
Before this change, we are only changing the `predecessor_id` and `receiver_id` of delayed and postponed receipts in the genesis state. But there are many more references to keys and account IDs in receipts, which also need to be changed. Fix it by adding a `map_receipt()` function that goes through the receipt to map any such references, and make sure to use it in the `fork-network` command as well.