### PR TITLE
feat(mocknet): add a make-backup command

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -2,6 +2,7 @@
 # python script to handle neard process management.
 
 import argparse
+import datetime
 from enum import Enum
 import fcntl
 import json
@@ -9,6 +10,7 @@ import jsonrpc
 import logging
 import os
 import psutil
+import re
 import requests
 import shutil
 import signal
@@ -61,6 +63,10 @@ class JSONHandler(http.server.BaseHTTPRequestHandler):
         self.dispatcher.add_method(server.neard_runner.do_reset, name="reset")
         self.dispatcher.add_method(server.neard_runner.do_update_binaries,
                                    name="update_binaries")
+        self.dispatcher.add_method(server.neard_runner.do_make_backup,
+                                   name="make_backup")
+        self.dispatcher.add_method(server.neard_runner.do_ls_backups,
+                                   name="ls_backups")
         super().__init__(request, client_address, server)
 
     def do_GET(self):
@@ -108,6 +114,10 @@ class TestState(Enum):
     STOPPED = 6
     RESETTING = 7
     ERROR = 8
+    MAKING_BACKUP = 9
+
+
+backup_id_pattern = re.compile(r'^[0-9a-zA-Z.][0-9a-zA-Z_\-.]+$')
 
 
 class NeardRunner:
@@ -140,6 +150,8 @@ class NeardRunner:
                 'neard_process': None,
                 'current_neard_path': None,
                 'state': TestState.NONE.value,
+                'backups': {},
+                'state_data': None,
             }
         # protects self.data, and its representation on disk,
         # because both the rpc server and the main loop touch them concurrently
@@ -357,6 +369,7 @@ class NeardRunner:
                 validator_account_id = None
                 validator_public_key = None
 
+            self.data['backups'] = {}
             self.set_state(TestState.AWAITING_NETWORK_INIT)
             self.save_data()
 
@@ -463,25 +476,57 @@ class NeardRunner:
                 self.set_state(TestState.STOPPED)
                 self.save_data()
 
-    def do_reset(self):
+    def do_reset(self, backup_id=None):
         with self.lock:
             state = self.get_state()
             logging.info(f"do_reset {state}")
-            if state == TestState.RUNNING:
-                self.kill_neard()
-                self.set_state(TestState.RESETTING)
-                self.reset_current_neard_path()
-                self.save_data()
-            elif state == TestState.STOPPED:
-                self.set_state(TestState.RESETTING)
-                self.reset_current_neard_path()
-                self.save_data()
-            else:
+            if state != TestState.RUNNING and state != TestState.STOPPED:
                 raise jsonrpc.exceptions.JSONRPCDispatchException(
                     code=-32600,
-                    message=
-                    'Cannot reset node as test state has not been initialized yet'
-                )
+                    message='Cannot reset data dir as test state is not ready')
+
+            try:
+                backups = self.data['backups']
+            except KeyError:
+                backups = {}
+            if backup_id is not None and backup_id != 'start' and backup_id not in backups:
+                raise jsonrpc.exceptions.JSONRPCDispatchException(
+                    code=-32600, message=f'backup ID {backup_id} not known')
+
+            if backup_id is None or backup_id == 'start':
+                path = self.data['binaries'][0]['system_path']
+            else:
+                path = backups[backup_id]['neard_path']
+
+            if state == TestState.RUNNING:
+                self.kill_neard()
+            self.set_state(TestState.RESETTING, data=backup_id)
+            self.set_current_neard_path(path)
+            self.save_data()
+
+    def do_make_backup(self, backup_id, description=None):
+        with self.lock:
+            state = self.get_state()
+            if state != TestState.RUNNING and state != TestState.STOPPED:
+                raise jsonrpc.exceptions.JSONRPCDispatchException(
+                    code=-32600,
+                    message='Cannot make backup as test state is not ready')
+
+            if backup_id_pattern.match(backup_id) is None:
+                raise jsonrpc.exceptions.JSONRPCDispatchException(
+                    code=-32600, message=f'invalid backup ID: {backup_id}')
+
+            if backup_id in self.data.get('backups', {}):
+                raise jsonrpc.exceptions.JSONRPCDispatchException(
+                    code=-32600, message=f'backup {backup_id} already exists')
+            if state == TestState.RUNNING:
+                self.kill_neard()
+            self.making_backup(backup_id, description)
+            self.save_data()
+
+    def do_ls_backups(self):
+        with self.lock:
+            return self.data.get('backups', {})
 
     def do_update_binaries(self):
         with self.lock:
@@ -698,8 +743,16 @@ class NeardRunner:
     def get_state(self):
         return TestState(self.data['state'])
 
-    def set_state(self, state):
+    def set_state(self, state, data=None):
         self.data['state'] = state.value
+        self.data['state_data'] = data
+
+    def making_backup(self, backup_id, description=None):
+        self.set_state(TestState.MAKING_BACKUP,
+                       data={
+                           'backup_id': backup_id,
+                           'description': description
+                       })
 
     def network_init(self):
         # wait til we get a network_init RPC
@@ -824,6 +877,37 @@ class NeardRunner:
                 self.set_state(TestState.STATE_ROOTS)
                 self.save_data()
 
+    def make_backup(self):
+        now = str(datetime.datetime.now())
+        backup_data = self.data['state_data']
+        name = backup_data['backup_id']
+        description = backup_data.get('description', None)
+
+        backup_dir = self.home_path('backups', name)
+        if os.path.exists(backup_dir):
+            logging.warn(f'{backup_dir} already exists, copying files anyway')
+            return
+        logging.info(f'copying data dir to {backup_dir}')
+        shutil.copytree(self.target_near_home_path('data'),
+                        backup_dir,
+                        dirs_exist_ok=True)
+        logging.info(f'copied data dir to {backup_dir}')
+
+        backups = self.data.get('backups', {})
+        if name in backups:
+            # shouldn't happen if we check this in do_make_backups(), but fine to be paranoid and at least warn here
+            logging.warn(
+                f'backup {name} already existed in data.json, but it was not present before'
+            )
+        backups[name] = {
+            'time': now,
+            'description': description,
+            'neard_path': self.data['current_neard_path']
+        }
+        self.data['backups'] = backups
+        self.set_state(TestState.STOPPED)
+        self.save_data()
+
     def check_genesis_state(self):
         path, running, exit_code = self.poll_neard()
         if not running:
@@ -845,26 +929,31 @@ class NeardRunner:
                 except FileNotFoundError:
                     pass
                 os.mkdir(self.home_path('backups'))
-                # Right now we save the backup to backups/start and in the future
-                # it would be nice to support a feature that lets you stop all the nodes and
-                # make another backup to restore to
-                backup_dir = self.home_path('backups', 'start')
-                logging.info(f'copying data dir to {backup_dir}')
-                shutil.copytree(self.target_near_home_path('data'), backup_dir)
-                self.set_state(TestState.STOPPED)
+                self.making_backup(
+                    'start',
+                    description='initial test state after state root computation'
+                )
                 self.save_data()
+                self.make_backup()
         except requests.exceptions.ConnectionError:
             pass
 
     def reset_near_home(self):
+        backup_id = self.data['state_data']
+        if backup_id is None:
+            backup_id = 'start'
+        backup_path = self.home_path('backups', backup_id)
+        if not os.path.exists(backup_path):
+            logging.error(f'backup dir {backup_path} does not exist')
+            self.set_state(TestState.ERROR)
+            self.save_data()
         try:
             logging.info("removing the old directory")
             shutil.rmtree(self.target_near_home_path('data'))
         except FileNotFoundError:
             pass
-        logging.info('restoring data dir from backup')
-        shutil.copytree(self.home_path('backups', 'start'),
-                        self.target_near_home_path('data'))
+        logging.info(f'restoring data dir from backup at {backup_path}')
+        shutil.copytree(backup_path, self.target_near_home_path('data'))
         logging.info('data dir restored')
         self.set_state(TestState.STOPPED)
         self.save_data()
@@ -884,6 +973,8 @@ class NeardRunner:
                     self.check_upgrade_neard()
                 elif state == TestState.RESETTING:
                     self.reset_near_home()
+                elif state == TestState.MAKING_BACKUP:
+                    self.make_backup()
             time.sleep(10)
 
     def serve(self, port):

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -190,9 +190,11 @@ class NeardRunner:
             })
         return binaries
 
+    def set_current_neard_path(self, path):
+        self.data['current_neard_path'] = path
+
     def reset_current_neard_path(self):
-        self.data['current_neard_path'] = self.data['binaries'][0][
-            'system_path']
+        self.set_current_neard_path(self.data['binaries'][0]['system_path'])
 
     # tries to download the binaries specified in config.json, saving them in $home/binaries/
     # if force is set to true all binaries will be downloaded, otherwise only the missing ones
@@ -690,7 +692,7 @@ class NeardRunner:
                 start_neard = True
 
         if start_neard:
-            self.data['current_neard_path'] = neard_path
+            self.set_current_neard_path(neard_path)
             self.start_neard()
 
     def get_state(self):

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -485,10 +485,7 @@ class NeardRunner:
                     code=-32600,
                     message='Cannot reset data dir as test state is not ready')
 
-            try:
-                backups = self.data['backups']
-            except KeyError:
-                backups = {}
+            backups = self.data.get('backups', {})
             if backup_id is not None and backup_id != 'start' and backup_id not in backups:
                 raise jsonrpc.exceptions.JSONRPCDispatchException(
                     code=-32600, message=f'backup ID {backup_id} not known')
@@ -748,11 +745,8 @@ class NeardRunner:
         self.data['state_data'] = data
 
     def making_backup(self, backup_id, description=None):
-        self.set_state(TestState.MAKING_BACKUP,
-                       data={
-                           'backup_id': backup_id,
-                           'description': description
-                       })
+        backup_data = {'backup_id': backup_id, 'description': description}
+        self.set_state(TestState.MAKING_BACKUP, data=backup_data)
 
     def network_init(self):
         # wait til we get a network_init RPC

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -885,7 +885,11 @@ class NeardRunner:
 
         backup_dir = self.home_path('backups', name)
         if os.path.exists(backup_dir):
-            logging.warn(f'{backup_dir} already exists, copying files anyway')
+            # we already checked that this backup ID didn't already exist, so if this path
+            # exists, someone probably manually added it. for now just set the state to ERROR
+            # and make the human intervene, but it shouldn't happen in practice
+            logging.warn(f'{backup_dir} already exists')
+            self.set_state(TestState.ERROR)
             return
         logging.info(f'copying data dir to {backup_dir}')
         shutil.copytree(self.target_near_home_path('data'),

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -257,11 +257,11 @@ def make_backup_cmd(args, traffic_generator, nodes):
         args.backup_id = sys.stdin.readline().strip()
         if re.match(r'^[0-9a-zA-Z.][0-9a-zA-Z_\-.]+$', args.backup_id) is None:
             sys.exit('invalid backup ID')
-    if args.description is None:
-        print('please enter a description (enter nothing to skip):')
-        description = sys.stdin.readline().strip()
-        if len(description) > 0:
-            args.description = description
+        if args.description is None:
+            print('please enter a description (enter nothing to skip):')
+            description = sys.stdin.readline().strip()
+            if len(description) > 0:
+                args.description = description
 
     all_nodes = nodes + [traffic_generator]
     pmap(

--- a/pytest/tests/mocknet/node_handle.py
+++ b/pytest/tests/mocknet/node_handle.py
@@ -100,8 +100,19 @@ class NodeHandle:
     def neard_runner_ready(self):
         return self.neard_runner_jsonrpc('ready')
 
-    def neard_runner_reset(self):
-        return self.neard_runner_jsonrpc('reset')
+    def neard_runner_make_backup(self, backup_id, description=None):
+        return self.neard_runner_jsonrpc('make_backup',
+                                         params={
+                                             'backup_id': backup_id,
+                                             'description': description
+                                         })
+
+    def neard_runner_ls_backups(self):
+        return self.neard_runner_jsonrpc('ls_backups')
+
+    def neard_runner_reset(self, backup_id=None):
+        return self.neard_runner_jsonrpc('reset',
+                                         params={'backup_id': backup_id})
 
     def neard_runner_update_binaries(self):
         return self.neard_runner_jsonrpc('update_binaries')

--- a/pytest/tests/mocknet/remote_node.py
+++ b/pytest/tests/mocknet/remote_node.py
@@ -34,25 +34,27 @@ class RemoteNeardRunner:
         if remove_home_dir:
             cmd_utils.run_cmd(
                 self.node,
-                'rm -rf /home/ubuntu/neard-runner && mkdir -p /home/ubuntu/neard-runner'
+                'rm -rf /home/ubuntu/.near/neard-runner && mkdir -p /home/ubuntu/.near/neard-runner'
             )
         else:
-            cmd_utils.run_cmd(self.node, 'mkdir -p /home/ubuntu/neard-runner')
+            cmd_utils.run_cmd(self.node,
+                              'mkdir -p /home/ubuntu/.near/neard-runner')
 
     def upload_neard_runner(self):
         self.node.machine.upload('tests/mocknet/helpers/neard_runner.py',
-                                 '/home/ubuntu/neard-runner',
+                                 '/home/ubuntu/.near/neard-runner',
                                  switch_user='ubuntu')
         self.node.machine.upload('tests/mocknet/helpers/requirements.txt',
-                                 '/home/ubuntu/neard-runner',
+                                 '/home/ubuntu/.near/neard-runner',
                                  switch_user='ubuntu')
 
     def upload_neard_runner_config(self, config):
-        mocknet.upload_json(self.node, '/home/ubuntu/neard-runner/config.json',
+        mocknet.upload_json(self.node,
+                            '/home/ubuntu/.near/neard-runner/config.json',
                             config)
 
     def init_python(self):
-        cmd = 'cd /home/ubuntu/neard-runner && python3 -m virtualenv venv -p $(which python3)' \
+        cmd = 'cd /home/ubuntu/.near/neard-runner && python3 -m virtualenv venv -p $(which python3)' \
         ' && ./venv/bin/pip install -r requirements.txt'
         cmd_utils.run_cmd(self.node, cmd)
 
@@ -64,8 +66,8 @@ class RemoteNeardRunner:
         )
 
     def start_neard_runner(self):
-        cmd_utils.run_in_background(self.node, f'/home/ubuntu/neard-runner/venv/bin/python /home/ubuntu/neard-runner/neard_runner.py ' \
-            '--home /home/ubuntu/neard-runner --neard-home /home/ubuntu/.near ' \
+        cmd_utils.run_in_background(self.node, f'/home/ubuntu/.near/neard-runner/venv/bin/python /home/ubuntu/.near/neard-runner/neard_runner.py ' \
+            '--home /home/ubuntu/.near/neard-runner --neard-home /home/ubuntu/.near ' \
             '--neard-logs /home/ubuntu/neard-logs --port 3000', 'neard-runner.txt')
 
     def neard_runner_post(self, body):


### PR DESCRIPTION
It is often useful to stop all the nodes and make backups of their data dirs so that we can reset to that point later. For example, when testing resharding it's nice to have a backup at a point right before the resharding epoch starts so that we can test the resharding part over and over without having to start from the beginning. So this PR adds a `make_backup` RPC method to `neard_runner.py` that stops neard and copies its data dir, remembering the `backup_id` parameter associated with it. Then in the `reset` command, the same `backup_id` can be referenced to restore to a previous backup.