### PR TITLE
fix(stateless-validation) - fix protocol version checks

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -31,7 +31,7 @@ use near_primitives::types::{
     AccountId, Balance, BlockHeight, EpochHeight, EpochId, EpochInfoProvider, Gas, MerkleHash,
     ShardId, StateChangeCause, StateChangesForResharding, StateRoot, StateRootNode,
 };
-use near_primitives::version::{ProtocolVersion, PROTOCOL_VERSION};
+use near_primitives::version::ProtocolVersion;
 use near_primitives::views::{
     AccessKeyInfoView, CallResult, ContractCodeView, QueryRequest, QueryResponse,
     QueryResponseKind, ViewApplyState, ViewStateResult,
@@ -710,7 +710,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                 storage_config.use_flat_storage,
             ),
         };
-        if checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION)
+        if checked_feature!("stable", StateWitnessSizeLimit, protocol_version)
             || cfg!(feature = "shadow_chunk_validation")
         {
             trie = trie.recording_reads();
@@ -874,7 +874,9 @@ impl RuntimeAdapter for NightshadeRuntime {
                 storage_config.use_flat_storage,
             ),
         };
-        if checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION)
+        let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(&block.prev_block_hash)?;
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
+        if checked_feature!("stable", StateWitnessSizeLimit, protocol_version)
             || cfg!(feature = "shadow_chunk_validation")
         {
             trie = trie.recording_reads();

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -692,8 +692,15 @@ impl RuntimeAdapter for NightshadeRuntime {
     ) -> Result<PreparedTransactions, Error> {
         let start_time = std::time::Instant::now();
         let PrepareTransactionsChunkContext { shard_id, gas_limit } = chunk;
+
         let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(&prev_block.block_hash)?;
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
+
+        let next_epoch_id =
+            self.epoch_manager.get_next_epoch_id_from_prev_block(&(&prev_block.block_hash))?;
+        let next_protocol_version =
+            self.epoch_manager.get_epoch_protocol_version(&next_epoch_id)?;
+
         let shard_uid = self.get_shard_uid_from_epoch_id(shard_id, &epoch_id)?;
         // While the height of the next block that includes the chunk might not be prev_height + 1,
         // using it will result in a more conservative check and will not accidentally allow
@@ -710,7 +717,11 @@ impl RuntimeAdapter for NightshadeRuntime {
                 storage_config.use_flat_storage,
             ),
         };
-        if checked_feature!("stable", StateWitnessSizeLimit, protocol_version)
+        // We need to start recording reads if the stateless validation is
+        // enabled in the next epoch. We need to save the state transition data
+        // in the current epoch to be able to produce the state witness in the
+        // next epoch.
+        if checked_feature!("stable", StateWitnessSizeLimit, next_protocol_version)
             || cfg!(feature = "shadow_chunk_validation")
         {
             trie = trie.recording_reads();
@@ -874,9 +885,16 @@ impl RuntimeAdapter for NightshadeRuntime {
                 storage_config.use_flat_storage,
             ),
         };
-        let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(&block.prev_block_hash)?;
-        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
-        if checked_feature!("stable", StateWitnessSizeLimit, protocol_version)
+        let next_epoch_id =
+            self.epoch_manager.get_next_epoch_id_from_prev_block(&block.prev_block_hash)?;
+        let next_protocol_version =
+            self.epoch_manager.get_epoch_protocol_version(&next_epoch_id)?;
+
+        // We need to start recording reads if the stateless validation is
+        // enabled in the next epoch. We need to save the state transition data
+        // in the current epoch to be able to produce the state witness in the
+        // next epoch.
+        if checked_feature!("stable", StateWitnessSizeLimit, next_protocol_version)
             || cfg!(feature = "shadow_chunk_validation")
         {
             trie = trie.recording_reads();


### PR DESCRIPTION
The checked_feature macro should always be used with the protocol version of the current block, not the binary protocol version. Otherwise the new feature would take effect during binary upgrade instead of protocol upgrade. If that happens all sorts of trouble may happen as nodes using different binaries may get diverge e.g. in state roots. 

This is a preparation for safe mainnet release.

I know it was under discussion previously but even if in this particular case it doesn't matter I would feel much safer having it done the proper way. Also it's all to easy to copy paste it elsewhere when working on the next feature so best to just stick to the rules. 

I picked the StateWitnessSizeLimit as it seemed like the proper ProtocolFeature to use for this, please correct me if I'm wrong. It doesn't really matter now though. 