### PR TITLE
Use constant minimum_new_receipt_gas

### DIFF
--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -136,6 +136,7 @@ pub async fn build_streamer_message(
                 .filter(|tx| tx.transaction.signer_id == tx.transaction.receiver_id)
                 .collect::<Vec<&IndexerTransactionWithOutcome>>(),
             &block,
+            protocol_config_view.protocol_version,
         )
         .await?;
 
@@ -322,6 +323,7 @@ async fn find_local_receipt_by_id_in_block(
 ) -> Result<Option<views::ReceiptView>, FailedToFetchData> {
     let chunks = fetch_block_chunks(&client, &block).await?;
 
+    let protocol_config_view = fetch_protocol_config(&client, block.header.hash).await?;
     let mut shards_outcomes = fetch_outcomes(&client, block.header.hash).await?;
 
     for chunk in chunks {
@@ -348,6 +350,7 @@ async fn find_local_receipt_by_id_in_block(
                 &runtime_config,
                 vec![&indexer_transaction],
                 &block,
+                protocol_config_view.protocol_version,
             )
             .await?;
 

--- a/chain/indexer/src/streamer/utils.rs
+++ b/chain/indexer/src/streamer/utils.rs
@@ -2,6 +2,7 @@ use actix::Addr;
 
 use near_indexer_primitives::IndexerTransactionWithOutcome;
 use near_parameters::RuntimeConfig;
+use near_primitives::version::ProtocolVersion;
 use near_primitives::views;
 use node_runtime::config::tx_cost;
 
@@ -13,6 +14,7 @@ pub(crate) async fn convert_transactions_sir_into_local_receipts(
     runtime_config: &RuntimeConfig,
     txs: Vec<&IndexerTransactionWithOutcome>,
     block: &views::BlockView,
+    protocol_version: ProtocolVersion,
 ) -> Result<Vec<views::ReceiptView>, FailedToFetchData> {
     if txs.is_empty() {
         return Ok(vec![]);
@@ -43,6 +45,7 @@ pub(crate) async fn convert_transactions_sir_into_local_receipts(
                     },
                     prev_block_gas_price,
                     true,
+                    protocol_version,
                 );
                 views::ReceiptView {
                     predecessor_id: tx.transaction.signer_id.clone(),

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -44,8 +44,12 @@ pub const DELETE_KEY_STORAGE_USAGE_PROTOCOL_VERSION: ProtocolVersion = 40;
 
 pub const SHARD_CHUNK_HEADER_UPGRADE_VERSION: ProtocolVersion = 41;
 
-/// Updates the way receipt ID is constructed to use current block hash instead of last block hash
+/// Updates the way receipt ID is constructed to use current block hash instead of last block hash.
 pub const CREATE_RECEIPT_ID_SWITCH_TO_CURRENT_BLOCK_VERSION: ProtocolVersion = 42;
+
+/// Pessimistic gas price estimation uses a fixed value of `minimum_new_receipt_gas` to stop being
+/// tied to the function call base cost.
+pub const FIXED_MINIMUM_NEW_RECEIPT_GAS_VERSION: ProtocolVersion = 66;
 
 /// The points in time after which the voting for the latest protocol version
 /// should start.

--- a/runtime/runtime/src/config.rs
+++ b/runtime/runtime/src/config.rs
@@ -2,6 +2,8 @@
 
 use near_primitives::account::AccessKeyPermission;
 use near_primitives::errors::IntegerOverflowError;
+use near_primitives::version::FIXED_MINIMUM_NEW_RECEIPT_GAS_VERSION;
+use near_primitives_core::types::ProtocolVersion;
 use num_bigint::BigUint;
 use num_traits::cast::ToPrimitive;
 use num_traits::pow::Pow;
@@ -248,6 +250,7 @@ pub fn tx_cost(
     transaction: &Transaction,
     gas_price: Balance,
     sender_is_receiver: bool,
+    protocol_version: ProtocolVersion,
 ) -> Result<TransactionCost, IntegerOverflowError> {
     let fees = &config.fees;
     let mut gas_burnt: Gas = fees.fee(ActionCosts::new_action_receipt).send_fee(sender_is_receiver);
@@ -267,7 +270,15 @@ pub fn tx_cost(
     // If signer is equals to receiver the receipt will be processed at the same block as this
     // transaction. Otherwise it will processed in the next block and the gas might be inflated.
     let initial_receipt_hop = if transaction.signer_id == transaction.receiver_id { 0 } else { 1 };
-    let minimum_new_receipt_gas = fees.min_receipt_with_function_call_gas();
+    let minimum_new_receipt_gas = if protocol_version < FIXED_MINIMUM_NEW_RECEIPT_GAS_VERSION {
+        fees.min_receipt_with_function_call_gas()
+    } else {
+        // The pessimistic gas pricing is a best-effort limit which can be breached in case of
+        // congestion when receipts are delayed before they execute. Hence there is not much
+        // value to tie this limit to the function call base cost. Making it constant limits
+        // overcharging to 6x, which was the value before the cost increase.
+        4_855_842_000_000 // 4.855TGas.
+    };
     // In case the config is free, we don't care about the maximum depth.
     let receipt_gas_price = if gas_price == 0 {
         0

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -128,7 +128,7 @@ pub fn validate_transaction(
 
     let sender_is_receiver = &transaction.receiver_id == signer_id;
 
-    tx_cost(&config, transaction, gas_price, sender_is_receiver)
+    tx_cost(&config, transaction, gas_price, sender_is_receiver, current_protocol_version)
         .map_err(|_| InvalidTxError::CostOverflow.into())
 }
 


### PR DESCRIPTION
This addresses the issue from https://github.com/near/nearcore/issues/10829.

Because we plan to decrease the function call cost, we need to modify the refund estimation logic that [relies](https://near.zulipchat.com/#narrow/stream/295306-contract-runtime/topic/major.20function.20call.20fees.20today/near/427527995) on function call base cost.
This PR sets [minimum_new_receipt_gas](https://github.com/near/nearcore/blob/32ef06752f3702e22bd69542df07a4e6e123477e/runtime/runtime/src/config.rs#L270) to 108_059_500_000 + 2_319_861_500_000 + 2_319_861_500_000 ~= 4.7TGas which would limit the overcharging to 6x which is the current level.