### PR TITLE
fix(mocknet): clear old binaries from data.json in update-binaries

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -219,12 +219,12 @@ class NeardRunner:
             pass
 
         if force:
-            # always start from 0 and download all binaries
-            start_index = 0
-        else:
-            # start at the index of the first missing binary
-            # typically it's all or nothing
-            start_index = len(self.data['binaries'])
+            # always start from start_index = 0 and download all binaries
+            self.data['binaries'] = []
+
+        # start at the index of the first missing binary
+        # typically it's all or nothing
+        start_index = len(self.data['binaries'])
 
         # for now we assume that the binaries recorded in data.json as having been
         # dowloaded are still valid and were not touched. Also this assumes that their


### PR DESCRIPTION
When the `force` arg of download_binaries() is true, we want to redownload everything, but the way it's done before this PR is by appending info on the new binaries downloaded to the existing "binaries" field in data.json. This is not correct because it will mess up the mid-test binary upgrade logic. So just make sure to clear that field instead of appending to the existing one

Also in the future we could consider making this a bit easier to use by passing the URLs to download from in the RPC arguments, which wasn't done originally because the ports were open to the internet. Now that it's behind ssh this isn't a concern