### PR TITLE
rpc: ignore refunds in RPC tx methods

### DIFF
--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -62,7 +62,7 @@ use near_primitives::views::{
 use near_store::flat::{FlatStorageReadyStatus, FlatStorageStatus};
 use near_store::{DBCol, COLD_HEAD_KEY, FINAL_HEAD_KEY, HEAD_KEY};
 use std::cmp::Ordering;
-use std::collections::{BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::hash::Hash;
 use std::sync::{Arc, Mutex, RwLock};
 use tracing::{error, info, warn};
@@ -436,7 +436,29 @@ impl ViewClientActor {
             return Ok(TxExecutionStatus::None);
         }
 
-        let is_execution_finished = match execution_outcome.status {
+        // refund receipt == last receipt in outcome.receipt_ids
+        let mut awaiting_non_refund_receipt_ids: HashSet<&CryptoHash> =
+            HashSet::from_iter(&execution_outcome.transaction_outcome.outcome.receipt_ids);
+        awaiting_non_refund_receipt_ids.extend(execution_outcome.receipts_outcome.iter().flat_map(
+            |outcome| {
+                outcome.outcome.receipt_ids.split_last().map(|(_, ids)| ids).unwrap_or_else(|| &[])
+            },
+        ));
+        let executed_receipt_ids: HashSet<&CryptoHash> = execution_outcome
+            .receipts_outcome
+            .iter()
+            .filter_map(|outcome| {
+                if outcome.outcome.status == ExecutionStatusView::Unknown {
+                    None
+                } else {
+                    Some(&outcome.id)
+                }
+            })
+            .collect();
+        let executed_ignoring_refunds =
+            awaiting_non_refund_receipt_ids.is_subset(&executed_receipt_ids);
+
+        let executed_including_refunds = match execution_outcome.status {
             FinalExecutionStatus::Failure(_) | FinalExecutionStatus::SuccessValue(_) => true,
             FinalExecutionStatus::NotStarted | FinalExecutionStatus::Started => false,
         };
@@ -445,15 +467,18 @@ impl ViewClientActor {
             .chain
             .get_block_header(&execution_outcome.transaction_outcome.block_hash)?])
         {
-            return if is_execution_finished {
+            return if executed_ignoring_refunds {
                 Ok(TxExecutionStatus::ExecutedOptimistic)
             } else {
                 Ok(TxExecutionStatus::Included)
             };
         }
 
-        if !is_execution_finished {
+        if !executed_ignoring_refunds {
             return Ok(TxExecutionStatus::IncludedFinal);
+        }
+        if !executed_including_refunds {
+            return Ok(TxExecutionStatus::Executed);
         }
 
         let block_hashes: BTreeSet<CryptoHash> =

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1714,18 +1714,18 @@ pub enum TxExecutionStatus {
     /// Transaction is included into the block. The block may be not finalised yet
     Included,
     /// Transaction is included into the block +
-    /// All the transaction receipts finished their execution.
+    /// All non-refund transaction receipts finished their execution.
     /// The corresponding blocks for tx and each receipt may be not finalised yet
     #[default]
     ExecutedOptimistic,
     /// Transaction is included into finalised block
     IncludedFinal,
     /// Transaction is included into finalised block +
-    /// All the transaction receipts finished their execution.
+    /// All non-refund transaction receipts finished their execution.
     /// The corresponding blocks for each receipt may be not finalised yet
     Executed,
     /// Transaction is included into finalised block +
-    /// Execution of transaction receipts is finalised
+    /// Execution of all transaction receipts is finalised, including refund receipts
     Final,
 }
 


### PR DESCRIPTION
(drums)
Resolves https://github.com/near/nearcore/issues/6834 

This PR changes the default behaviour of `broadcast_tx_commit`, `send_tx`, `tx`, `EXPERIMENTAL_tx_status` RPC methods. We no longer wait for refund receipts by default.
If you do need to wait for refund receipts, you need ask about it explicitly by using `TxExecutionStatus::Final` option (`"wait_until": "FINAL"` in the json request).

[We had a discussion with @bowenwang1996 about the case described below, tldr: he thinks it's unreachable. I haven't reproduced it, but I still think it may be an issue. I'm investigating, leave it here for now]

Ugly side-effect:
Sometimes, the response for any of mentioned methods may look like
```json

{
  "jsonrpc": "2.0",
  "result": {
    "final_execution_status": "EXECUTED_OPTIMISTIC",
    "status": "Started",
  ...
}
```
The full response format may be found [here](https://docs.near.org/api/rpc/transactions) 

`status` field corresponds to [`FinalExecutionStatus` structure](https://github.com/near/nearcore/blob/master/core/primitives/src/views.rs#L1354-L1364):
```rust
pub enum FinalExecutionStatus {
    /// The execution has not yet started.
    #[default]
    NotStarted,
    /// The execution has started and still going.
    Started,
    /// The execution has failed with the given error.
    Failure(TxExecutionError),
    /// The execution has succeeded and returned some value or an empty vec encoded in base64.
    SuccessValue(#[serde_as(as = "Base64")] Vec<u8>),
}
```


In `status`, we store the result of all the execution process, which, strictly saying, is not finalised without refund receipts.
So, in the example above, `final_execution_status` conflicts with `status`. We say "it's executed, but not really", which may be confusing for the users.
Replacing `status` with some other value would be even a bigger problem. Current situation is a weird truth. Replaced value would be a lie, which is much worse.
Ideally, I'd prefer to drop `status` field from the response, but it's impossible because of compatibility reasons.