### PR TITLE
[cleanup] Remove memtrie related function from Runtime interface

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -521,7 +521,7 @@ impl Chain {
             })
             .cloned()
             .collect();
-        runtime_adapter.load_mem_tries_on_startup(&tracked_shards)?;
+        runtime_adapter.get_tries().load_mem_tries_for_enabled_shards(&tracked_shards)?;
 
         info!(target: "chain", "Init: header head @ #{} {}; block head @ #{} {}",
               header_head.height, header_head.last_block_hash,
@@ -2784,7 +2784,9 @@ impl Chain {
             store_update.commit()?;
             flat_storage_manager.create_flat_storage_for_shard(shard_uid).unwrap();
             // Flat storage is ready, load memtrie if it is enabled.
-            self.runtime_adapter.load_mem_trie_on_catchup(&shard_uid, &chunk.prev_state_root())?;
+            self.runtime_adapter
+                .get_tries()
+                .load_mem_trie_on_catchup(&shard_uid, &chunk.prev_state_root())?;
         }
 
         let mut height = shard_state_header.chunk_height_included();

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -1243,32 +1243,6 @@ impl RuntimeAdapter for NightshadeRuntime {
         let epoch_manager = self.epoch_manager.read();
         Ok(epoch_manager.will_shard_layout_change(parent_hash)?)
     }
-
-    fn load_mem_tries_on_startup(&self, tracked_shards: &[ShardUId]) -> Result<(), StorageError> {
-        self.tries.load_mem_tries_for_enabled_shards(tracked_shards)
-    }
-
-    fn load_mem_trie_on_catchup(
-        &self,
-        shard_uid: &ShardUId,
-        state_root: &StateRoot,
-    ) -> Result<(), StorageError> {
-        if !self.get_tries().trie_config().load_mem_tries_for_tracked_shards {
-            return Ok(());
-        }
-        // It should not happen that memtrie is already loaded for a shard
-        // for which we just did state sync.
-        debug_assert!(!self.tries.is_mem_trie_loaded(shard_uid));
-        self.tries.load_mem_trie(shard_uid, Some(*state_root))
-    }
-
-    fn retain_mem_tries(&self, shard_uids: &[ShardUId]) {
-        self.tries.retain_mem_tries(shard_uids)
-    }
-
-    fn unload_mem_trie(&self, shard_uid: &ShardUId) {
-        self.tries.unload_mem_trie(shard_uid)
-    }
 }
 
 impl node_runtime::adapter::ViewRuntimeAdapter for NightshadeRuntime {

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -47,8 +47,8 @@ use near_primitives::views::{
 use near_primitives::{checked_feature, shard_layout};
 use near_store::test_utils::TestTriesBuilder;
 use near_store::{
-    set_genesis_hash, set_genesis_state_roots, DBCol, ShardTries, StorageError, Store, StoreUpdate,
-    Trie, TrieChanges, WrappedTrieChanges,
+    set_genesis_hash, set_genesis_state_roots, DBCol, ShardTries, Store, StoreUpdate, Trie,
+    TrieChanges, WrappedTrieChanges,
 };
 use num_rational::Ratio;
 use std::cmp::Ordering;
@@ -1462,20 +1462,4 @@ impl RuntimeAdapter for KeyValueRuntime {
     ) -> Result<Vec<ApplyResultForResharding>, Error> {
         Ok(vec![])
     }
-
-    fn load_mem_tries_on_startup(&self, _tracked_shards: &[ShardUId]) -> Result<(), StorageError> {
-        Ok(())
-    }
-
-    fn load_mem_trie_on_catchup(
-        &self,
-        _shard_uid: &ShardUId,
-        _state_root: &StateRoot,
-    ) -> Result<(), StorageError> {
-        Ok(())
-    }
-
-    fn retain_mem_tries(&self, _shard_uids: &[ShardUId]) {}
-
-    fn unload_mem_trie(&self, _shard_uid: &ShardUId) {}
 }

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -31,7 +31,6 @@ use near_primitives::version::{
 };
 use near_primitives::views::{QueryRequest, QueryResponse};
 use near_store::flat::FlatStorageManager;
-use near_store::StorageError;
 use near_store::{PartialStorage, ShardTries, Store, Trie, WrappedTrieChanges};
 use num_rational::Rational32;
 use std::collections::HashMap;
@@ -509,26 +508,6 @@ pub trait RuntimeAdapter: Send + Sync {
     ) -> bool;
 
     fn get_protocol_config(&self, epoch_id: &EpochId) -> Result<ProtocolConfig, Error>;
-
-    /// Loads in-memory tries upon startup. The given shard_uids are possible candidates to load,
-    /// but which exact shards to load depends on configuration. This may only be called when flat
-    /// storage is ready.
-    fn load_mem_tries_on_startup(&self, tracked_shards: &[ShardUId]) -> Result<(), StorageError>;
-
-    /// Loads in-memory trie upon catchup, if it is enabled.
-    /// Requires state root because `ChunkExtra` is not available at the time mem-trie is being loaded.
-    fn load_mem_trie_on_catchup(
-        &self,
-        shard_uid: &ShardUId,
-        state_root: &StateRoot,
-    ) -> Result<(), StorageError>;
-
-    /// Retains in-memory tries for given shards, i.e. unload tries from memory for shards that are NOT
-    /// in the given list. Should be called to unload obsolete tries from memory.
-    fn retain_mem_tries(&self, shard_uids: &[ShardUId]);
-
-    /// Unload trie from memory for given shard.
-    fn unload_mem_trie(&self, shard_uid: &ShardUId);
 }
 
 /// The last known / checked height and time when we have processed it.

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2388,7 +2388,7 @@ impl Client {
                     .iter()
                     .map(|id| self.epoch_manager.shard_id_to_uid(*id, &epoch_id).unwrap())
                     .collect();
-                self.runtime_adapter.retain_mem_tries(&shard_uids);
+                self.runtime_adapter.get_tries().retain_mem_tries(&shard_uids);
 
                 for &shard_id in &tracking_shards {
                     let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);

--- a/chain/client/src/sync_jobs_actions.rs
+++ b/chain/client/src/sync_jobs_actions.rs
@@ -82,7 +82,7 @@ impl SyncJobsActions {
 
     pub fn handle_apply_state_parts_request(&mut self, msg: ApplyStatePartsRequest) {
         // Unload mem-trie (in case it is still loaded) before we apply state parts.
-        msg.runtime_adapter.unload_mem_trie(&msg.shard_uid);
+        msg.runtime_adapter.get_tries().unload_mem_trie(&msg.shard_uid);
 
         let shard_id = msg.shard_uid.shard_id as ShardId;
         match self.clear_flat_state(&msg) {

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -319,7 +319,7 @@ impl ForkNetworkCommand {
         let runtime =
             NightshadeRuntime::from_config(home_dir, store.clone(), &near_config, epoch_manager)
                 .context("could not create the transaction runtime")?;
-        runtime.load_mem_tries_on_startup(&all_shard_uids).unwrap();
+        runtime.get_tries().load_mem_tries_for_enabled_shards(&all_shard_uids).unwrap();
 
         let make_storage_mutator: MakeSingleShardStorageMutatorFn =
             Arc::new(move |prev_state_root| {


### PR DESCRIPTION
Cleanup the Runtime interface a bit. There's no reason to have memtrie related functions in the runtime interface.

FIxed this: https://github.com/near/nearcore/issues/10872