### PR TITLE
rpc: partial revert of #10792

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3083,32 +3083,35 @@ impl Chain {
     fn get_execution_status(
         &self,
         outcomes: &[ExecutionOutcomeWithIdView],
+        transaction_hash: &CryptoHash,
     ) -> FinalExecutionStatus {
-        let mut awaiting_receipt_ids = HashSet::new();
-        let mut seen_receipt_ids = HashSet::new();
-        let mut result: FinalExecutionStatus = FinalExecutionStatus::NotStarted;
-        for outcome in outcomes {
-            seen_receipt_ids.insert(&outcome.id);
-            match &outcome.outcome.status {
-                ExecutionStatusView::Unknown => return FinalExecutionStatus::Started,
-                ExecutionStatusView::Failure(e) => return FinalExecutionStatus::Failure(e.clone()),
-                ExecutionStatusView::SuccessValue(v) => {
-                    if result == FinalExecutionStatus::NotStarted {
-                        // historically, we used the first SuccessValue we have seen
-                        // let's continue sticking to it
-                        result = FinalExecutionStatus::SuccessValue(v.clone());
+        let mut looking_for_id = *transaction_hash;
+        let num_outcomes = outcomes.len();
+        outcomes
+            .iter()
+            .find_map(|outcome_with_id| {
+                if outcome_with_id.id == looking_for_id {
+                    match &outcome_with_id.outcome.status {
+                        ExecutionStatusView::Unknown if num_outcomes == 1 => {
+                            Some(FinalExecutionStatus::NotStarted)
+                        }
+                        ExecutionStatusView::Unknown => Some(FinalExecutionStatus::Started),
+                        ExecutionStatusView::Failure(e) => {
+                            Some(FinalExecutionStatus::Failure(e.clone()))
+                        }
+                        ExecutionStatusView::SuccessValue(v) => {
+                            Some(FinalExecutionStatus::SuccessValue(v.clone()))
+                        }
+                        ExecutionStatusView::SuccessReceiptId(id) => {
+                            looking_for_id = *id;
+                            None
+                        }
                     }
+                } else {
+                    None
                 }
-                ExecutionStatusView::SuccessReceiptId(_) => {
-                    awaiting_receipt_ids.extend(&outcome.outcome.receipt_ids);
-                }
-            }
-        }
-        return if awaiting_receipt_ids.is_subset(&seen_receipt_ids) {
-            result
-        } else {
-            FinalExecutionStatus::Started
-        };
+            })
+            .expect("results should resolve to a final outcome")
     }
 
     /// Collect all the execution outcomes existing at the current moment
@@ -3140,7 +3143,7 @@ impl Chain {
     ) -> Result<FinalExecutionOutcomeView, Error> {
         let mut outcomes = Vec::new();
         self.get_recursive_transaction_results(&mut outcomes, transaction_hash, true)?;
-        let status = self.get_execution_status(&outcomes);
+        let status = self.get_execution_status(&outcomes, transaction_hash);
         let receipts_outcome = outcomes.split_off(1);
         let transaction = self.chain_store.get_transaction(transaction_hash)?.ok_or_else(|| {
             Error::DBNotFoundErr(format!("Transaction {} is not found", transaction_hash))
@@ -3172,7 +3175,7 @@ impl Chain {
             )));
         }
 
-        let status = self.get_execution_status(&outcomes);
+        let status = self.get_execution_status(&outcomes, transaction_hash);
         let receipts_outcome = outcomes.split_off(1);
         let transaction_outcome = outcomes.pop().unwrap();
         Ok(FinalExecutionOutcomeView { status, transaction, transaction_outcome, receipts_outcome })

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3085,6 +3085,9 @@ impl Chain {
         outcomes: &[ExecutionOutcomeWithIdView],
         transaction_hash: &CryptoHash,
     ) -> FinalExecutionStatus {
+        if outcomes.is_empty() {
+            return FinalExecutionStatus::NotStarted;
+        }
         let mut looking_for_id = *transaction_hash;
         let num_outcomes = outcomes.len();
         outcomes
@@ -3111,7 +3114,7 @@ impl Chain {
                     None
                 }
             })
-            .expect("results should resolve to a final outcome")
+            .unwrap_or_else(|| FinalExecutionStatus::Started)
     }
 
     /// Collect all the execution outcomes existing at the current moment

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -436,6 +436,15 @@ impl ViewClientActor {
             return Ok(TxExecutionStatus::None);
         }
 
+        let mut awaiting_receipt_ids: HashSet<&CryptoHash> =
+            HashSet::from_iter(&execution_outcome.transaction_outcome.outcome.receipt_ids);
+        awaiting_receipt_ids.extend(
+            execution_outcome
+                .receipts_outcome
+                .iter()
+                .flat_map(|outcome| &outcome.outcome.receipt_ids),
+        );
+
         // refund receipt == last receipt in outcome.receipt_ids
         let mut awaiting_non_refund_receipt_ids: HashSet<&CryptoHash> =
             HashSet::from_iter(&execution_outcome.transaction_outcome.outcome.receipt_ids);
@@ -444,6 +453,7 @@ impl ViewClientActor {
                 outcome.outcome.receipt_ids.split_last().map(|(_, ids)| ids).unwrap_or_else(|| &[])
             },
         ));
+
         let executed_receipt_ids: HashSet<&CryptoHash> = execution_outcome
             .receipts_outcome
             .iter()
@@ -455,13 +465,10 @@ impl ViewClientActor {
                 }
             })
             .collect();
+
         let executed_ignoring_refunds =
             awaiting_non_refund_receipt_ids.is_subset(&executed_receipt_ids);
-
-        let executed_including_refunds = match execution_outcome.status {
-            FinalExecutionStatus::Failure(_) | FinalExecutionStatus::SuccessValue(_) => true,
-            FinalExecutionStatus::NotStarted | FinalExecutionStatus::Started => false,
-        };
+        let executed_including_refunds = awaiting_receipt_ids.is_subset(&executed_receipt_ids);
 
         if let Err(_) = self.chain.check_blocks_final_and_canonical(&[self
             .chain


### PR DESCRIPTION
This PR is based on https://github.com/near/nearcore/pull/10948 because it touches the same places
It's better to look at the separate commits

So first commit can be reviewed separately in https://github.com/near/nearcore/pull/10948

Second commit is a partial revert of https://github.com/near/nearcore/pull/10792
I just returned this piece back, no changes is made
https://github.com/near/nearcore/pull/10792/files#diff-ef9c6aaa80a330e446c5365f42be9bff37ba4f898cf519dadd7e17545783c77cL3099-L3126 

Third commit is the meaningful part. We need to adjust the logic with the old implementation.
1. We now treat incomplete list of the receipts as a valid state. It means no `expect` usage, handle empty list of outcomes
2. We no longer can use `status` field for `finalExecutionStatus`