### PR TITLE
fix(db): Consider hot and cold dbs archivals

### DIFF
--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -251,7 +251,7 @@ impl NodeStorage {
         Ok(match metadata::DbMetadata::read(self.hot_storage.as_ref())?.kind.unwrap() {
             metadata::DbKind::RPC => false,
             metadata::DbKind::Archive => true,
-            metadata::DbKind::Hot | metadata::DbKind::Cold => todo!(),
+            metadata::DbKind::Hot | metadata::DbKind::Cold => true,
         })
     }
 


### PR DESCRIPTION
This reflect my understanding of DBKinds. `Archive`, `Hot`, and `Cold` dbs are only present in archival nodes. `RPC` is the only non-archival db kind.
This change will make it harder for people to open `Hot` storage as a single DB in non-archival mode. They will first have to change DBKind of hot db to `RPC` using the `database` tool of neard. Then, if they want to open this db as part of split storage again, they will need to change DBKind back using the same tool.

This whole part of code is due to a refactoring. I will think about the best project for this tasks on Monday.