### PR TITLE
feat: customeizable fd_limit as env var

### DIFF
--- a/.github/workflows/master_fuzzer_binaries.yml
+++ b/.github/workflows/master_fuzzer_binaries.yml
@@ -50,5 +50,6 @@ jobs:
       - name: "Compile fuzzers and upload to GCS"
         run: |
           NAME="nearcore-${{ github.ref_name }}-$(env TZ=Etc/UTC  date +"%Y%m%d%H%M%S")"
-          RUSTFLAGS="-A warnings --cfg fuzz" cargo +nightly bolero build-clusterfuzz --all-features --profile fuzz
+          # Our Clusterfuzz setup currently (2024-02) runs on Cascade Lake CPUs
+          RUSTFLAGS="--cfg fuzz -C target-cpu=cascadelake" cargo +nightly bolero build-clusterfuzz --all-features --profile fuzz
           gsutil cp -Z target/fuzz/clusterfuzz.tar "gs://fuzzer_targets/${{ github.ref_name }}/$NAME.tar.gz"

--- a/.github/workflows/neard_release.yml
+++ b/.github/workflows/neard_release.yml
@@ -47,6 +47,10 @@ jobs:
         run: |
           echo $(git rev-parse HEAD) > latest
           BRANCH=$(git branch --show-current)
+          # in case of Release triggered run, branch is empty
+          if [ -z "$BRANCH" ]; then
+            BRANCH=$(git branch -r --contains=${{ github.ref_name }} | head -n1 | cut -c3- | cut -d / -f 2)
+          fi
           aws s3 cp --acl public-read latest s3://build.nearprotocol.com/nearcore/$(uname)/${BRANCH}/latest
 
   docker-release:

--- a/.github/workflows/neard_release.yml
+++ b/.github/workflows/neard_release.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Checkout nearcore repository
         if: ${{ github.event_name != 'workflow_dispatch'}}
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Neard binary build and upload to S3
         run: ./scripts/binary_release.sh
@@ -67,6 +69,8 @@ jobs:
       - name: Checkout nearcore repository
         if: ${{ github.event_name != 'workflow_dispatch'}}
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -77,7 +81,11 @@ jobs:
       - name: Build and push Docker image to Dockerhub
         run: |
           COMMIT=$(git rev-parse HEAD)
-          BRANCH=${{ github.ref_name }}
+          BRANCH=$(git branch --show-current)
+          # in case of Release triggered run, branch is empty
+          if [ -z "$BRANCH" ]; then
+            BRANCH=$(git branch -r --contains=${{ github.ref_name }} | head -n1 | cut -c3- | cut -d / -f 2)
+          fi
           make docker-nearcore
           docker tag nearcore nearprotocol/nearcore:${BRANCH}-${COMMIT}
           docker tag nearcore nearprotocol/nearcore:${BRANCH}

--- a/.github/workflows/ondemand_fuzzer_binaries.yml
+++ b/.github/workflows/ondemand_fuzzer_binaries.yml
@@ -86,5 +86,5 @@ jobs:
       - name: "Compile fuzzers and upload to GCS"
         run: |
           NAME="nearcore-$branch_type-$(env TZ=Etc/UTC  date +"%Y%m%d%H%M%S")"
-          RUSTFLAGS="-A warnings --cfg fuzz" cargo +nightly bolero build-clusterfuzz --all-features --profile fuzz
+          RUSTFLAGS="--cfg fuzz" cargo +nightly bolero build-clusterfuzz --all-features --profile fuzz
           gsutil cp -Z target/fuzz/clusterfuzz.tar "gs://fuzzer_targets/$branch_type/$NAME.tar.gz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Protocol Changes
 
+### Non-protocol Changes
+
+## 1.37.0
+
+### Protocol Changes
+
 * Resharding v2 - new implementation for resharding and a new shard layout for production networks. [#10303](https://github.com/near/nearcore/pull/10303), [NEP-0508](https://github.com/near/NEPs/pull/508)
 * Restrict the creation of non-implicit top-level account that are longer than 32 bytes. Only the registrar account can create them. [#9589](https://github.com/near/nearcore/pull/9589)
 * Adjust the number of block producers and chunk producers on testnet to facilitate testing of chunk-only producers [#9563](https://github.com/near/nearcore/pull/9563)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5584,11 +5584,10 @@ checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
 [[package]]
 name = "protobuf"
 version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a74937d52a466a535fda2e83f0e575f3ef1b34e4a84545b4a9e418fad32a3b1c"
+source = "git+https://github.com/near/rust-protobuf.git?branch=3.0.2-patch#86cdbf1ce1f085486b15ec94af1954c55c1e2862"
 dependencies = [
  "once_cell",
- "protobuf-support",
+ "protobuf-support 3.0.2 (git+https://github.com/near/rust-protobuf.git?branch=3.0.2-patch)",
  "thiserror",
 ]
 
@@ -5617,7 +5616,7 @@ dependencies = [
  "indexmap 1.9.2",
  "log",
  "protobuf 3.0.2",
- "protobuf-support",
+ "protobuf-support 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile",
  "thiserror",
  "which",
@@ -5628,6 +5627,14 @@ name = "protobuf-support"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebf34636d66670da249c3b6589142e7f0b4918a015ec72fa32102fd43e023b0e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.0.2"
+source = "git+https://github.com/near/rust-protobuf.git?branch=3.0.2-patch#86cdbf1ce1f085486b15ec94af1954c55c1e2862"
 dependencies = [
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4520,7 +4520,6 @@ version = "1.37.0"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
- "crossbeam-queue",
  "enumset",
  "finite-wasm",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chainsync-loadtest"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "cold-store-tool"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "estimator-warehouse"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2356,7 +2356,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-csv-to-json"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-populate"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "borsh 1.0.0",
  "clap",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-example"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2954,7 +2954,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "keypair-generator"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "clap",
  "near-crypto",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "mock-node"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "near-actix-test-utils"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix-rt",
  "futures",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "near-amend-genesis"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3468,7 +3468,7 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "derive-enum-from-into",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "bencher",
  "lru",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -3557,7 +3557,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "chrono",
  "near-crypto",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "near-client"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3665,7 +3665,7 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "chrono",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "blake2",
  "bolero",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "near-database-tool"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3744,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "borsh 1.0.0",
  "chrono",
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-sync-tool"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "near-flat-storage"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3816,14 +3816,14 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "near-primitives-core",
 ]
 
 [[package]]
 name = "near-fork-network"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "near-primitives",
  "serde",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-adversarial-primitives"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "near-network",
  "near-primitives",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix-http",
  "awc",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-fuzz"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "arbitrary",
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-tests"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "awc",
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "near-mirror"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -4101,7 +4101,7 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "base64 0.21.0",
@@ -4130,7 +4130,7 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "assert_matches",
  "borsh 1.0.0",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "quote",
  "syn 2.0.32",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "near-ping"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -4193,7 +4193,7 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "borsh 1.0.0",
  "near-crypto",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "arbitrary",
  "base64 0.21.0",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4303,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-core"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "quote",
  "serde",
@@ -4313,7 +4313,7 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "fs2",
  "near-rpc-error-core",
@@ -4324,11 +4324,11 @@ dependencies = [
 
 [[package]]
 name = "near-stable-hasher"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 
 [[package]]
 name = "near-state-parts"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4347,7 +4347,7 @@ dependencies = [
 
 [[package]]
 name = "near-state-parts-dump-check"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "actix-web",
@@ -4370,11 +4370,11 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 
 [[package]]
 name = "near-store"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "awc",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "near-test-contracts"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "arbitrary",
  "once_cell",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "near-undo-block"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4466,7 +4466,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-test-derive"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -4538,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4600,7 +4600,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner-fuzz"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -4614,7 +4614,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-api"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -4643,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-generator"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "target-lexicon 0.12.3",
@@ -4651,7 +4651,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "bolero",
  "indexmap 1.9.2",
@@ -4662,7 +4662,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "backtrace",
  "cc",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-wast"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "near-vm-test-api",
@@ -4694,7 +4694,7 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "near-primitives-core",
@@ -4703,7 +4703,7 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "neard"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -4843,7 +4843,7 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "assert_matches",
  "borsh 1.0.0",
@@ -5974,7 +5974,7 @@ dependencies = [
 
 [[package]]
 name = "restaked"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "clap",
  "integration-tests",
@@ -6066,7 +6066,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-params-estimator"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -6107,7 +6107,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "bolero",
  "cpu-time",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester-fuzz"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "libfuzzer-sys",
  "runtime-tester",
@@ -6749,7 +6749,7 @@ dependencies = [
 
 [[package]]
 name = "speedy_sync"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "borsh 1.0.0",
  "clap",
@@ -6784,7 +6784,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-viewer"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -6833,7 +6833,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-usage-delta-calculator"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -6849,7 +6849,7 @@ dependencies = [
 
 [[package]]
 name = "store-validator"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "clap",
  "near-chain",
@@ -7024,7 +7024,7 @@ dependencies = [
 
 [[package]]
 name = "testlib"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "near-chain",
  "near-chain-configs",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "themis"
-version = "1.38.0-rc.2"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chainsync-loadtest"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "cold-store-tool"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "estimator-warehouse"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2356,7 +2356,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-csv-to-json"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "chrono",
  "clap",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-populate"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "borsh 1.0.0",
  "clap",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-example"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2954,7 +2954,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "keypair-generator"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "clap",
  "near-crypto",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "mock-node"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "near-actix-test-utils"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix-rt",
  "futures",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "near-amend-genesis"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3468,7 +3468,7 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "derive-enum-from-into",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "bencher",
  "lru",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -3557,7 +3557,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "chrono",
  "near-crypto",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "near-client"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3665,7 +3665,7 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "chrono",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "blake2",
  "bolero",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "near-database-tool"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3744,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "borsh 1.0.0",
  "chrono",
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-sync-tool"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "near-flat-storage"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3816,14 +3816,14 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "near-primitives-core",
 ]
 
 [[package]]
 name = "near-fork-network"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "near-primitives",
  "serde",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-adversarial-primitives"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "near-network",
  "near-primitives",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix-http",
  "awc",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-fuzz"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "arbitrary",
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-tests"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "awc",
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "near-mirror"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -4101,7 +4101,7 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "base64 0.21.0",
@@ -4130,7 +4130,7 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "assert_matches",
  "borsh 1.0.0",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "quote",
  "syn 2.0.32",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "near-ping"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -4193,7 +4193,7 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "borsh 1.0.0",
  "near-crypto",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "arbitrary",
  "base64 0.21.0",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4303,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-core"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "quote",
  "serde",
@@ -4313,7 +4313,7 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "fs2",
  "near-rpc-error-core",
@@ -4324,11 +4324,11 @@ dependencies = [
 
 [[package]]
 name = "near-stable-hasher"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 
 [[package]]
 name = "near-state-parts"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4347,7 +4347,7 @@ dependencies = [
 
 [[package]]
 name = "near-state-parts-dump-check"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "actix-web",
@@ -4370,11 +4370,11 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 
 [[package]]
 name = "near-store"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "awc",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "near-test-contracts"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "arbitrary",
  "once_cell",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "near-undo-block"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4466,7 +4466,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-test-derive"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4600,7 +4600,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner-fuzz"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -4614,7 +4614,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-api"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -4643,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-generator"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "anyhow",
  "target-lexicon 0.12.3",
@@ -4651,7 +4651,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "bolero",
  "indexmap 1.9.2",
@@ -4662,7 +4662,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "backtrace",
  "cc",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-wast"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "anyhow",
  "near-vm-test-api",
@@ -4694,7 +4694,7 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "anyhow",
  "near-primitives-core",
@@ -4703,7 +4703,7 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "neard"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -4843,7 +4843,7 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "assert_matches",
  "borsh 1.0.0",
@@ -5974,7 +5974,7 @@ dependencies = [
 
 [[package]]
 name = "restaked"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "clap",
  "integration-tests",
@@ -6066,7 +6066,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-params-estimator"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -6107,7 +6107,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "bolero",
  "cpu-time",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester-fuzz"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "libfuzzer-sys",
  "runtime-tester",
@@ -6749,7 +6749,7 @@ dependencies = [
 
 [[package]]
 name = "speedy_sync"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "borsh 1.0.0",
  "clap",
@@ -6784,7 +6784,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-viewer"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -6833,7 +6833,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-usage-delta-calculator"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -6849,7 +6849,7 @@ dependencies = [
 
 [[package]]
 name = "store-validator"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "clap",
  "near-chain",
@@ -7024,7 +7024,7 @@ dependencies = [
 
 [[package]]
 name = "testlib"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "near-chain",
  "near-chain-configs",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "themis"
-version = "1.38.0-rc.1"
+version = "1.38.0-rc.2"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chainsync-loadtest"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "cold-store-tool"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "estimator-warehouse"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2356,7 +2356,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-csv-to-json"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "chrono",
  "clap",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-populate"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "borsh 1.0.0",
  "clap",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-example"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2954,7 +2954,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "keypair-generator"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "clap",
  "near-crypto",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "mock-node"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "near-actix-test-utils"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix-rt",
  "futures",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "near-amend-genesis"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3468,7 +3468,7 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "derive-enum-from-into",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "bencher",
  "lru",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -3557,7 +3557,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "chrono",
  "near-crypto",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "near-client"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3665,7 +3665,7 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "chrono",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "blake2",
  "bolero",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "near-database-tool"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3744,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "borsh 1.0.0",
  "chrono",
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-sync-tool"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "near-flat-storage"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3816,14 +3816,14 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "near-primitives-core",
 ]
 
 [[package]]
 name = "near-fork-network"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "near-primitives",
  "serde",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-adversarial-primitives"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "near-network",
  "near-primitives",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix-http",
  "awc",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-fuzz"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "arbitrary",
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-tests"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "awc",
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "near-mirror"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -4101,7 +4101,7 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "base64 0.21.0",
@@ -4130,7 +4130,7 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "assert_matches",
  "borsh 1.0.0",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "quote",
  "syn 2.0.32",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "near-ping"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -4193,7 +4193,7 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "borsh 1.0.0",
  "near-crypto",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "arbitrary",
  "base64 0.21.0",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4303,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-core"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "quote",
  "serde",
@@ -4313,7 +4313,7 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "fs2",
  "near-rpc-error-core",
@@ -4324,11 +4324,11 @@ dependencies = [
 
 [[package]]
 name = "near-stable-hasher"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 
 [[package]]
 name = "near-state-parts"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4347,7 +4347,7 @@ dependencies = [
 
 [[package]]
 name = "near-state-parts-dump-check"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "actix-web",
@@ -4370,11 +4370,11 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 
 [[package]]
 name = "near-store"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "awc",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "near-test-contracts"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "arbitrary",
  "once_cell",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "near-undo-block"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4466,7 +4466,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-test-derive"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -4540,7 +4540,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4601,7 +4601,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner-fuzz"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-api"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -4644,7 +4644,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-generator"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "anyhow",
  "target-lexicon 0.12.3",
@@ -4652,7 +4652,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "bolero",
  "indexmap 1.9.2",
@@ -4663,7 +4663,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "backtrace",
  "cc",
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-wast"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "anyhow",
  "near-vm-test-api",
@@ -4695,7 +4695,7 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "anyhow",
  "near-primitives-core",
@@ -4704,7 +4704,7 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "neard"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -4844,7 +4844,7 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "assert_matches",
  "borsh 1.0.0",
@@ -5975,7 +5975,7 @@ dependencies = [
 
 [[package]]
 name = "restaked"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "clap",
  "integration-tests",
@@ -6067,7 +6067,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-params-estimator"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -6108,7 +6108,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "bolero",
  "cpu-time",
@@ -6134,7 +6134,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester-fuzz"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "libfuzzer-sys",
  "runtime-tester",
@@ -6750,7 +6750,7 @@ dependencies = [
 
 [[package]]
 name = "speedy_sync"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "borsh 1.0.0",
  "clap",
@@ -6785,7 +6785,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-viewer"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -6834,7 +6834,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-usage-delta-calculator"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -6850,7 +6850,7 @@ dependencies = [
 
 [[package]]
 name = "store-validator"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "clap",
  "near-chain",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "testlib"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "near-chain",
  "near-chain-configs",
@@ -7039,7 +7039,7 @@ dependencies = [
 
 [[package]]
 name = "themis"
-version = "1.37.0-rc.1"
+version = "1.37.0-rc.2"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chainsync-loadtest"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "cold-store-tool"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "estimator-warehouse"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2356,7 +2356,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-csv-to-json"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-populate"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "borsh 1.0.0",
  "clap",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-example"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2954,7 +2954,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "keypair-generator"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "clap",
  "near-crypto",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "mock-node"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "near-actix-test-utils"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix-rt",
  "futures",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "near-amend-genesis"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3468,7 +3468,7 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "derive-enum-from-into",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "bencher",
  "lru",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -3557,7 +3557,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "chrono",
  "near-crypto",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "near-client"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3665,7 +3665,7 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "chrono",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "blake2",
  "bolero",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "near-database-tool"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3744,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "borsh 1.0.0",
  "chrono",
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-sync-tool"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "near-flat-storage"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3816,14 +3816,14 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "near-primitives-core",
 ]
 
 [[package]]
 name = "near-fork-network"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "near-primitives",
  "serde",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-adversarial-primitives"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "near-network",
  "near-primitives",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix-http",
  "awc",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-fuzz"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "arbitrary",
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-tests"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "awc",
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "near-mirror"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -4101,7 +4101,7 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "base64 0.21.0",
@@ -4130,7 +4130,7 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "assert_matches",
  "borsh 1.0.0",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "quote",
  "syn 2.0.32",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "near-ping"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -4193,7 +4193,7 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "borsh 1.0.0",
  "near-crypto",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "arbitrary",
  "base64 0.21.0",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4303,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-core"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "quote",
  "serde",
@@ -4313,7 +4313,7 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "fs2",
  "near-rpc-error-core",
@@ -4324,11 +4324,11 @@ dependencies = [
 
 [[package]]
 name = "near-stable-hasher"
-version = "1.37.0"
+version = "1.37.1"
 
 [[package]]
 name = "near-state-parts"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4347,7 +4347,7 @@ dependencies = [
 
 [[package]]
 name = "near-state-parts-dump-check"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "actix-web",
@@ -4370,11 +4370,11 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "1.37.0"
+version = "1.37.1"
 
 [[package]]
 name = "near-store"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "awc",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "near-test-contracts"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "arbitrary",
  "once_cell",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "near-undo-block"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4466,7 +4466,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-test-derive"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4600,7 +4600,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner-fuzz"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -4614,7 +4614,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-api"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -4643,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-generator"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "anyhow",
  "target-lexicon 0.12.3",
@@ -4651,7 +4651,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "bolero",
  "indexmap 1.9.2",
@@ -4662,7 +4662,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "backtrace",
  "cc",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-wast"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "anyhow",
  "near-vm-test-api",
@@ -4694,7 +4694,7 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "anyhow",
  "near-primitives-core",
@@ -4703,7 +4703,7 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "neard"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -4843,7 +4843,7 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "assert_matches",
  "borsh 1.0.0",
@@ -5974,7 +5974,7 @@ dependencies = [
 
 [[package]]
 name = "restaked"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "clap",
  "integration-tests",
@@ -6066,7 +6066,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-params-estimator"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -6107,7 +6107,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "bolero",
  "cpu-time",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester-fuzz"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "libfuzzer-sys",
  "runtime-tester",
@@ -6749,7 +6749,7 @@ dependencies = [
 
 [[package]]
 name = "speedy_sync"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "borsh 1.0.0",
  "clap",
@@ -6784,7 +6784,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-viewer"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -6833,7 +6833,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-usage-delta-calculator"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -6849,7 +6849,7 @@ dependencies = [
 
 [[package]]
 name = "store-validator"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "clap",
  "near-chain",
@@ -7024,7 +7024,7 @@ dependencies = [
 
 [[package]]
 name = "testlib"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "near-chain",
  "near-chain-configs",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "themis"
-version = "1.37.0"
+version = "1.37.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chainsync-loadtest"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "cold-store-tool"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "estimator-warehouse"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2356,7 +2356,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-csv-to-json"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-populate"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "borsh 1.0.0",
  "clap",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-example"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2954,7 +2954,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "keypair-generator"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "clap",
  "near-crypto",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "mock-node"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "near-actix-test-utils"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix-rt",
  "futures",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "near-amend-genesis"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3468,7 +3468,7 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "derive-enum-from-into",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "bencher",
  "lru",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -3557,7 +3557,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "chrono",
  "near-crypto",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "near-client"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3665,7 +3665,7 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "chrono",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "blake2",
  "bolero",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "near-database-tool"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3744,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "borsh 1.0.0",
  "chrono",
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-sync-tool"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "near-flat-storage"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3816,14 +3816,14 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "near-primitives-core",
 ]
 
 [[package]]
 name = "near-fork-network"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "near-primitives",
  "serde",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-adversarial-primitives"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "near-network",
  "near-primitives",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix-http",
  "awc",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-fuzz"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "arbitrary",
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-tests"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "awc",
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "near-mirror"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -4101,7 +4101,7 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "base64 0.21.0",
@@ -4130,7 +4130,7 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "assert_matches",
  "borsh 1.0.0",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "quote",
  "syn 2.0.32",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "near-ping"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -4193,7 +4193,7 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "borsh 1.0.0",
  "near-crypto",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "arbitrary",
  "base64 0.21.0",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4303,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-core"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "quote",
  "serde",
@@ -4313,7 +4313,7 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "fs2",
  "near-rpc-error-core",
@@ -4324,11 +4324,11 @@ dependencies = [
 
 [[package]]
 name = "near-stable-hasher"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 
 [[package]]
 name = "near-state-parts"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4347,7 +4347,7 @@ dependencies = [
 
 [[package]]
 name = "near-state-parts-dump-check"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "actix-web",
@@ -4370,11 +4370,11 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 
 [[package]]
 name = "near-store"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "awc",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "near-test-contracts"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "arbitrary",
  "once_cell",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "near-undo-block"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4466,7 +4466,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-test-derive"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -4540,7 +4540,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4601,7 +4601,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner-fuzz"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-api"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -4644,7 +4644,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-generator"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "anyhow",
  "target-lexicon 0.12.3",
@@ -4652,7 +4652,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "bolero",
  "indexmap 1.9.2",
@@ -4663,7 +4663,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "backtrace",
  "cc",
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-wast"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "anyhow",
  "near-vm-test-api",
@@ -4695,7 +4695,7 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "anyhow",
  "near-primitives-core",
@@ -4704,7 +4704,7 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "neard"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -4844,7 +4844,7 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "assert_matches",
  "borsh 1.0.0",
@@ -5975,7 +5975,7 @@ dependencies = [
 
 [[package]]
 name = "restaked"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "clap",
  "integration-tests",
@@ -6067,7 +6067,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-params-estimator"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -6108,7 +6108,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "bolero",
  "cpu-time",
@@ -6134,7 +6134,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester-fuzz"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "libfuzzer-sys",
  "runtime-tester",
@@ -6750,7 +6750,7 @@ dependencies = [
 
 [[package]]
 name = "speedy_sync"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "borsh 1.0.0",
  "clap",
@@ -6785,7 +6785,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-viewer"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -6834,7 +6834,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-usage-delta-calculator"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -6850,7 +6850,7 @@ dependencies = [
 
 [[package]]
 name = "store-validator"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "clap",
  "near-chain",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "testlib"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "near-chain",
  "near-chain-configs",
@@ -7039,7 +7039,7 @@ dependencies = [
 
 [[package]]
 name = "themis"
-version = "1.37.0-rc.3"
+version = "1.37.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2437,9 +2437,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6621,9 +6621,9 @@ checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chainsync-loadtest"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "anyhow",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "cold-store-tool"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "estimator-warehouse"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2356,7 +2356,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-csv-to-json"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "chrono",
  "clap",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-populate"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "borsh 1.0.0",
  "clap",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-example"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "anyhow",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2954,7 +2954,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "keypair-generator"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "clap",
  "near-crypto",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "mock-node"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "near-actix-test-utils"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix-rt",
  "futures",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "near-amend-genesis"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3468,7 +3468,7 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "derive-enum-from-into",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "bencher",
  "lru",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -3557,7 +3557,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "chrono",
  "near-crypto",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "near-client"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3665,7 +3665,7 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "chrono",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "blake2",
  "bolero",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "near-database-tool"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3744,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "borsh 1.0.0",
  "chrono",
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-sync-tool"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "near-flat-storage"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3816,14 +3816,14 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "near-primitives-core",
 ]
 
 [[package]]
 name = "near-fork-network"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "anyhow",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "anyhow",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "near-primitives",
  "serde",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-adversarial-primitives"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "near-network",
  "near-primitives",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix-http",
  "awc",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-fuzz"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "arbitrary",
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-tests"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "awc",
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "near-mirror"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "anyhow",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "anyhow",
@@ -4101,7 +4101,7 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "base64 0.21.0",
@@ -4130,7 +4130,7 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "assert_matches",
  "borsh 1.0.0",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "quote",
  "syn 2.0.32",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "near-ping"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -4193,7 +4193,7 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "borsh 1.0.0",
  "near-crypto",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "arbitrary",
  "base64 0.21.0",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4303,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-core"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "quote",
  "serde",
@@ -4313,7 +4313,7 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "fs2",
  "near-rpc-error-core",
@@ -4324,11 +4324,11 @@ dependencies = [
 
 [[package]]
 name = "near-stable-hasher"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 
 [[package]]
 name = "near-state-parts"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4347,7 +4347,7 @@ dependencies = [
 
 [[package]]
 name = "near-state-parts-dump-check"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "actix-web",
@@ -4370,11 +4370,11 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 
 [[package]]
 name = "near-store"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "awc",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "near-test-contracts"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "arbitrary",
  "once_cell",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "near-undo-block"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4466,7 +4466,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-test-derive"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -4540,7 +4540,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4601,7 +4601,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner-fuzz"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-api"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -4644,7 +4644,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-generator"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "anyhow",
  "target-lexicon 0.12.3",
@@ -4652,7 +4652,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "bolero",
  "indexmap 1.9.2",
@@ -4663,7 +4663,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "backtrace",
  "cc",
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-wast"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "anyhow",
  "near-vm-test-api",
@@ -4695,7 +4695,7 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "anyhow",
  "near-primitives-core",
@@ -4704,7 +4704,7 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "neard"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "anyhow",
@@ -4844,7 +4844,7 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "assert_matches",
  "borsh 1.0.0",
@@ -5975,7 +5975,7 @@ dependencies = [
 
 [[package]]
 name = "restaked"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "clap",
  "integration-tests",
@@ -6067,7 +6067,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-params-estimator"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -6108,7 +6108,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "bolero",
  "cpu-time",
@@ -6134,7 +6134,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester-fuzz"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "libfuzzer-sys",
  "runtime-tester",
@@ -6750,7 +6750,7 @@ dependencies = [
 
 [[package]]
 name = "speedy_sync"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "borsh 1.0.0",
  "clap",
@@ -6785,7 +6785,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-viewer"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "actix",
  "anyhow",
@@ -6834,7 +6834,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-usage-delta-calculator"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -6850,7 +6850,7 @@ dependencies = [
 
 [[package]]
 name = "store-validator"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "clap",
  "near-chain",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "testlib"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "near-chain",
  "near-chain-configs",
@@ -7039,7 +7039,7 @@ dependencies = [
 
 [[package]]
 name = "themis"
-version = "1.37.0-rc.2"
+version = "1.37.0-rc.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chainsync-loadtest"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "cold-store-tool"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "estimator-warehouse"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2356,7 +2356,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-csv-to-json"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-populate"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "borsh 1.0.0",
  "clap",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-example"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2954,7 +2954,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "keypair-generator"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "clap",
  "near-crypto",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "mock-node"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "near-actix-test-utils"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix-rt",
  "futures",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "near-amend-genesis"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3468,7 +3468,7 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "derive-enum-from-into",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "bencher",
  "lru",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -3557,7 +3557,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "chrono",
  "near-crypto",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "near-client"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3665,7 +3665,7 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "chrono",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "blake2",
  "bolero",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "near-database-tool"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3744,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "borsh 1.0.0",
  "chrono",
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-sync-tool"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "near-flat-storage"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3816,14 +3816,14 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "near-primitives-core",
 ]
 
 [[package]]
 name = "near-fork-network"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "near-primitives",
  "serde",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-adversarial-primitives"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "near-network",
  "near-primitives",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix-http",
  "awc",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-fuzz"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "arbitrary",
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-tests"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "awc",
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "near-mirror"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -4101,7 +4101,7 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "base64 0.21.0",
@@ -4130,7 +4130,7 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "assert_matches",
  "borsh 1.0.0",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "quote",
  "syn 2.0.32",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "near-ping"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -4193,7 +4193,7 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "borsh 1.0.0",
  "near-crypto",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "arbitrary",
  "base64 0.21.0",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4303,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-core"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "quote",
  "serde",
@@ -4313,7 +4313,7 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "fs2",
  "near-rpc-error-core",
@@ -4324,11 +4324,11 @@ dependencies = [
 
 [[package]]
 name = "near-stable-hasher"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 
 [[package]]
 name = "near-state-parts"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4347,7 +4347,7 @@ dependencies = [
 
 [[package]]
 name = "near-state-parts-dump-check"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "actix-web",
@@ -4370,11 +4370,11 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 
 [[package]]
 name = "near-store"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "awc",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "near-test-contracts"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "arbitrary",
  "once_cell",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "near-undo-block"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4466,7 +4466,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-test-derive"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -4540,7 +4540,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4601,7 +4601,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner-fuzz"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-api"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -4644,7 +4644,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-generator"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "target-lexicon 0.12.3",
@@ -4652,7 +4652,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "bolero",
  "indexmap 1.9.2",
@@ -4663,7 +4663,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "backtrace",
  "cc",
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-wast"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "near-vm-test-api",
@@ -4695,7 +4695,7 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "near-primitives-core",
@@ -4704,7 +4704,7 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "neard"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -4844,7 +4844,7 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "assert_matches",
  "borsh 1.0.0",
@@ -5968,7 +5968,7 @@ dependencies = [
 
 [[package]]
 name = "restaked"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "clap",
  "integration-tests",
@@ -6060,7 +6060,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-params-estimator"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -6101,7 +6101,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "bolero",
  "cpu-time",
@@ -6127,7 +6127,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester-fuzz"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "libfuzzer-sys",
  "runtime-tester",
@@ -6743,7 +6743,7 @@ dependencies = [
 
 [[package]]
 name = "speedy_sync"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "borsh 1.0.0",
  "clap",
@@ -6778,7 +6778,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-viewer"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -6827,7 +6827,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-usage-delta-calculator"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -6843,7 +6843,7 @@ dependencies = [
 
 [[package]]
 name = "store-validator"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "clap",
  "near-chain",
@@ -7018,7 +7018,7 @@ dependencies = [
 
 [[package]]
 name = "testlib"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "near-chain",
  "near-chain-configs",
@@ -7032,7 +7032,7 @@ dependencies = [
 
 [[package]]
 name = "themis"
-version = "0.0.0"
+version = "1.37.0-rc.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chainsync-loadtest"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "cold-store-tool"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "estimator-warehouse"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2356,7 +2356,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-csv-to-json"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-populate"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "borsh 1.0.0",
  "clap",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-example"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2954,7 +2954,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "keypair-generator"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "clap",
  "near-crypto",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "mock-node"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "near-actix-test-utils"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix-rt",
  "futures",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "near-amend-genesis"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3468,7 +3468,7 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "derive-enum-from-into",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "bencher",
  "lru",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -3557,7 +3557,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "chrono",
  "near-crypto",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "near-client"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3665,7 +3665,7 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "chrono",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "blake2",
  "bolero",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "near-database-tool"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3744,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -3761,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "borsh 1.0.0",
  "chrono",
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-sync-tool"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "near-flat-storage"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -3816,14 +3816,14 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "near-primitives-core",
 ]
 
 [[package]]
 name = "near-fork-network"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "near-primitives",
  "serde",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3915,7 +3915,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-adversarial-primitives"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "near-network",
  "near-primitives",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix-http",
  "awc",
@@ -3937,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-fuzz"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "arbitrary",
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-tests"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "awc",
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "near-mirror"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -4101,7 +4101,7 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "base64 0.21.0",
@@ -4130,7 +4130,7 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "assert_matches",
  "borsh 1.0.0",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "quote",
  "syn 2.0.32",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "near-ping"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -4193,7 +4193,7 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "borsh 1.0.0",
  "near-crypto",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "arbitrary",
  "base64 0.21.0",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4303,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-core"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "quote",
  "serde",
@@ -4313,7 +4313,7 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "fs2",
  "near-rpc-error-core",
@@ -4324,11 +4324,11 @@ dependencies = [
 
 [[package]]
 name = "near-stable-hasher"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 
 [[package]]
 name = "near-state-parts"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4347,7 +4347,7 @@ dependencies = [
 
 [[package]]
 name = "near-state-parts-dump-check"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "actix-web",
@@ -4370,11 +4370,11 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 
 [[package]]
 name = "near-store"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "awc",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "near-test-contracts"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "arbitrary",
  "once_cell",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "near-undo-block"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4466,7 +4466,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-test-derive"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4600,7 +4600,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner-fuzz"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -4614,7 +4614,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-api"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -4643,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-generator"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "anyhow",
  "target-lexicon 0.12.3",
@@ -4651,7 +4651,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "bolero",
  "indexmap 1.9.2",
@@ -4662,7 +4662,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "backtrace",
  "cc",
@@ -4683,7 +4683,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-wast"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "anyhow",
  "near-vm-test-api",
@@ -4694,7 +4694,7 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "anyhow",
  "near-primitives-core",
@@ -4703,7 +4703,7 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "neard"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -4843,7 +4843,7 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "assert_matches",
  "borsh 1.0.0",
@@ -5974,7 +5974,7 @@ dependencies = [
 
 [[package]]
 name = "restaked"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "clap",
  "integration-tests",
@@ -6066,7 +6066,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-params-estimator"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh 1.0.0",
@@ -6107,7 +6107,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "bolero",
  "cpu-time",
@@ -6133,7 +6133,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester-fuzz"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "libfuzzer-sys",
  "runtime-tester",
@@ -6749,7 +6749,7 @@ dependencies = [
 
 [[package]]
 name = "speedy_sync"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "borsh 1.0.0",
  "clap",
@@ -6784,7 +6784,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-viewer"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -6833,7 +6833,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-usage-delta-calculator"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -6849,7 +6849,7 @@ dependencies = [
 
 [[package]]
 name = "store-validator"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "clap",
  "near-chain",
@@ -7024,7 +7024,7 @@ dependencies = [
 
 [[package]]
 name = "testlib"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "near-chain",
  "near-chain-configs",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "themis"
-version = "1.37.1"
+version = "1.38.0-rc.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1555,9 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.8"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -4531,7 +4531,6 @@ dependencies = [
  "region",
  "rkyv",
  "rustc-demangle",
- "rustix 0.37.20",
  "target-lexicon 0.12.3",
  "thiserror",
  "tracing",
@@ -4554,6 +4553,7 @@ dependencies = [
  "hex",
  "loupe",
  "memoffset 0.8.0",
+ "near-cache",
  "near-crypto",
  "near-parameters",
  "near-primitives-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -370,6 +370,7 @@ yansi = "0.5.1"
 stdx = { package = "near-stdx", path = "utils/stdx" }
 
 [patch.crates-io]
+protobuf = { git = "https://github.com/near/rust-protobuf.git", branch = "3.0.2-patch" }
 
 # Note that "bench" profile inherits from "release" profile and
 # "test" profile inherits from "dev" profile.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.37.0-rc.1" # managed by cargo-workspaces, see below
+version = "1.37.0-rc.2" # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,6 @@ cpu-time = "1.0"
 criterion = { version = "0.5.1", default_features = false, features = ["html_reports", "cargo_bench_support"] }
 crossbeam = "0.8"
 crossbeam-channel = "0.5.8"
-crossbeam-queue = "0.3.8"
 csv = "1.2.1"
 curve25519-dalek = { version = "4.1.1", default-features = false, features = ["alloc", "precomputed-tables", "rand_core"] }
 derive-enum-from-into = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.37.0-rc.3" # managed by cargo-workspaces, see below
+version = "1.37.0" # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.38.0-rc.1" # managed by cargo-workspaces, see below
+version = "1.38.0-rc.2" # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.37.0-rc.2" # managed by cargo-workspaces, see below
+version = "1.37.0-rc.3" # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.37.1" # managed by cargo-workspaces, see below
+version = "1.38.0-rc.1" # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.0.0" # managed by cargo-workspaces, see below
+version = "1.37.0-rc.1" # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.38.0-rc.2" # managed by cargo-workspaces, see below
+version = "1.38.0" # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.75.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,9 +94,6 @@ members = [
     "utils/stdx",
 ]
 
-[workspace.lints.rust]
-warnings = "deny"
-
 [workspace.lints.clippy]
 all = { level = "allow", priority = -1 }
 clone_on_copy = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -293,7 +293,6 @@ runtime-tester = { path = "test-utils/runtime-tester" }
 rusqlite = { version = "0.29.0", features = ["bundled", "chrono", "functions"] }
 rustc-demangle = "0.1"
 rust-s3 = { version = "0.32.3", features = ["blocking"] }
-rustix = "0.37"
 secp256k1 = { version = "0.27.0", features = ["recovery", "rand-std"] }
 semver = "1.0.4"
 serde = { version = "1.0.136", features = ["alloc", "derive", "rc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.37.0" # managed by cargo-workspaces, see below
+version = "1.37.1" # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.75.0"
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 # Most crates are not stable on purpose, as maintaining API compatibility is a
 # significant developer time expense. Please think thoroughly before adding
 # anything to the list of stable crates.
-version = "0.21.0"
+version = "0.21.1"
 exclude = ["neard"]
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 # Most crates are not stable on purpose, as maintaining API compatibility is a
 # significant developer time expense. Please think thoroughly before adding
 # anything to the list of stable crates.
-version = "0.19.0"
+version = "0.21.0"
 exclude = ["neard"]
 
 [workspace]

--- a/Justfile
+++ b/Justfile
@@ -56,8 +56,6 @@ nextest-integration TYPE *FLAGS:
 nextest-integration TYPE *FLAGS:
     @echo "Nextest integration tests are currently disabled on macos!"
 
-<<<<<<< HEAD
-=======
 # check various build configurations compile as anticipated
 check-non-default:
     # Ensure that near-vm-runner always builds without default features enabled
@@ -82,7 +80,6 @@ check-cargo-deny:
 check-themis:
     env CARGO_TARGET_DIR="target/themis" cargo run --locked -p themis
 
->>>>>>> b03bfffa4 (do not have a globally-set warnings=deny, but set it locally in CI only (#10738))
 # generate a codecov report for RULE
 codecov RULE:
     #!/usr/bin/env bash

--- a/Justfile
+++ b/Justfile
@@ -25,6 +25,7 @@ nextest TYPE *FLAGS: (nextest-unit TYPE FLAGS) (nextest-integration TYPE FLAGS)
 
 # cargo unit tests, TYPE is "stable" or "nightly"
 nextest-unit TYPE *FLAGS:
+    RUSTFLAGS="-D warnings" \
     cargo nextest run \
         --locked \
         --workspace \
@@ -40,6 +41,7 @@ nextest-unit TYPE *FLAGS:
 # cargo integration tests, TYPE is "stable" or "nightly"
 [linux]
 nextest-integration TYPE *FLAGS:
+    RUSTFLAGS="-D warnings" \
     cargo nextest run \
         --locked \
         --package integration-tests \
@@ -54,6 +56,33 @@ nextest-integration TYPE *FLAGS:
 nextest-integration TYPE *FLAGS:
     @echo "Nextest integration tests are currently disabled on macos!"
 
+<<<<<<< HEAD
+=======
+# check various build configurations compile as anticipated
+check-non-default:
+    # Ensure that near-vm-runner always builds without default features enabled
+    RUSTFLAGS="-D warnings" \
+    cargo check -p near-vm-runner --no-default-features
+
+# check rust formatting
+check-cargo-fmt:
+    cargo fmt -- --check
+
+# check clippy lints
+check-cargo-clippy:
+    CARGO_TARGET_DIR="target/clippy" \
+    RUSTFLAGS="-D warnings" \
+    cargo clippy --all-features --all-targets --locked
+
+# check cargo deny lints
+check-cargo-deny:
+    cargo deny --all-features --locked check bans
+
+# themis-based checks
+check-themis:
+    env CARGO_TARGET_DIR="target/themis" cargo run --locked -p themis
+
+>>>>>>> b03bfffa4 (do not have a globally-set warnings=deny, but set it locally in CI only (#10738))
 # generate a codecov report for RULE
 codecov RULE:
     #!/usr/bin/env bash

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -635,13 +635,13 @@ impl Chain {
     }
 
     fn maybe_mark_block_invalid(&mut self, block_hash: CryptoHash, error: &Error) {
-        metrics::NUM_INVALID_BLOCKS.with_label_values(&[error.prometheus_label_value()]).inc();
         // We only mark the block as invalid if the block has bad data (not for other errors that would
         // not be the fault of the block itself), except when the block has a bad signature which means
         // the block might not have been what the block producer originally produced. Either way, it's
         // OK if we miss some cases here because this is just an optimization to avoid reprocessing
         // known invalid blocks so the network recovers faster in case of any issues.
         if error.is_bad_data() && !matches!(error, Error::InvalidSignature) {
+            metrics::NUM_INVALID_BLOCKS.with_label_values(&[error.prometheus_label_value()]).inc();
             self.invalid_blocks.put(block_hash, ());
         }
     }

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2955,6 +2955,11 @@ impl Chain {
         }
         chain_store_update.remove_state_sync_info(*epoch_first_block);
 
+        // Remove all stored split state changes for resharding once catchup is completed.
+        // We only remove these after the catchup is completed to ensure that restarting the node
+        // in the middle of the catchup does not lead to the split state already being deleted from prior run
+        chain_store_update.remove_all_state_changes_for_resharding();
+
         chain_store_update.commit()?;
 
         for hash in affected_blocks.iter() {

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2966,6 +2966,10 @@ impl Chain {
             );
         }
 
+        // Nit: it would be more elegant to only call this after resharding, not
+        // after every state sync but it doesn't hurt.
+        self.process_snapshot_after_resharding()?;
+
         Ok(())
     }
 
@@ -3763,10 +3767,10 @@ impl Chain {
         Ok(())
     }
 
-    // Similar to `process_snapshot` but only called after resharding is done.
-    // This is to speed up the snapshot removal once resharding is finished in
-    // order to minimize the storage overhead.
-    pub fn process_snapshot_after_resharding(&mut self) -> Result<(), Error> {
+    // Similar to `process_snapshot` but only called after resharding and
+    // catchup is done. This is to speed up the snapshot removal once resharding
+    // is finished in order to minimize the storage overhead.
+    fn process_snapshot_after_resharding(&mut self) -> Result<(), Error> {
         let Some(snapshot_callbacks) = &self.snapshot_callbacks else { return Ok(()) };
 
         let tries = self.runtime_adapter.get_tries();

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3461,6 +3461,7 @@ impl Chain {
         )))
     }
 
+<<<<<<< HEAD
     /// Gets range of block and shard contexts for blocks between two
     /// consecutive chunks for given `shard_id`.
     /// One chunk is represented by `chunk_prev_hash`.
@@ -3740,30 +3741,50 @@ impl Chain {
         )))
     }
 
-    /// Function to create a new snapshot if needed
+    /// Function to create or delete a snapshot if necessary.
     fn process_snapshot(&mut self) -> Result<(), Error> {
         let (make_snapshot, delete_snapshot) = self.should_make_or_delete_snapshot()?;
         if !make_snapshot && !delete_snapshot {
             return Ok(());
         }
-        if let Some(snapshot_callbacks) = &self.snapshot_callbacks {
-            if make_snapshot {
-                let head = self.head()?;
-                let epoch_height =
-                    self.epoch_manager.get_epoch_height_from_prev_block(&head.prev_block_hash)?;
-                let shard_uids = self
-                    .epoch_manager
-                    .get_shard_layout_from_prev_block(&head.prev_block_hash)?
-                    .shard_uids()
-                    .collect();
-                let last_block = self.get_block(&head.last_block_hash)?;
-                let make_snapshot_callback = &snapshot_callbacks.make_snapshot_callback;
-                make_snapshot_callback(head.prev_block_hash, epoch_height, shard_uids, last_block);
-            } else if delete_snapshot {
-                let delete_snapshot_callback = &snapshot_callbacks.delete_snapshot_callback;
-                delete_snapshot_callback();
-            }
+        let Some(snapshot_callbacks) = &self.snapshot_callbacks else { return Ok(()) };
+        if make_snapshot {
+            let head = self.head()?;
+            let prev_hash = head.prev_block_hash;
+            let epoch_height = self.epoch_manager.get_epoch_height_from_prev_block(&prev_hash)?;
+            let shard_layout = &self.epoch_manager.get_shard_layout_from_prev_block(&prev_hash)?;
+            let shard_uids = shard_layout.shard_uids().collect();
+            let last_block = self.get_block(&head.last_block_hash)?;
+            let make_snapshot_callback = &snapshot_callbacks.make_snapshot_callback;
+            make_snapshot_callback(prev_hash, epoch_height, shard_uids, last_block);
+        } else if delete_snapshot {
+            let delete_snapshot_callback = &snapshot_callbacks.delete_snapshot_callback;
+            delete_snapshot_callback();
         }
+        Ok(())
+    }
+
+    // Similar to `process_snapshot` but only called after resharding is done.
+    // This is to speed up the snapshot removal once resharding is finished in
+    // order to minimize the storage overhead.
+    pub fn process_snapshot_after_resharding(&mut self) -> Result<(), Error> {
+        let Some(snapshot_callbacks) = &self.snapshot_callbacks else { return Ok(()) };
+
+        let tries = self.runtime_adapter.get_tries();
+        let snapshot_config = tries.state_snapshot_config();
+        let delete_snapshot = match snapshot_config.state_snapshot_type {
+            // Do not delete snapshot if the node is configured to snapshot every epoch.
+            StateSnapshotType::EveryEpoch => false,
+            // Delete the snapshot if it was created only for resharding.
+            StateSnapshotType::ForReshardingOnly => true,
+        };
+
+        if delete_snapshot {
+            tracing::debug!(target: "resharding", "deleting snapshot after resharding");
+            let delete_snapshot_callback = &snapshot_callbacks.delete_snapshot_callback;
+            delete_snapshot_callback();
+        }
+
         Ok(())
     }
 

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -216,7 +216,7 @@ type BlockApplyChunksResult = (CryptoHash, Vec<(ShardId, Result<ShardUpdateResul
 /// Facade to the blockchain block processing and storage.
 /// Provides current view on the state according to the chain state.
 pub struct Chain {
-    chain_store: ChainStore,
+    pub chain_store: ChainStore,
     pub epoch_manager: Arc<dyn EpochManagerAdapter>,
     pub shard_tracker: ShardTracker,
     pub runtime_adapter: Arc<dyn RuntimeAdapter>,

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3461,7 +3461,6 @@ impl Chain {
         )))
     }
 
-<<<<<<< HEAD
     /// Gets range of block and shard contexts for blocks between two
     /// consecutive chunks for given `shard_id`.
     /// One chunk is represented by `chunk_prev_hash`.

--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -402,8 +402,6 @@ impl<'a> ChainUpdate<'a> {
                 }
             }
             ShardBlockUpdateResult::Resharding(ReshardingResult { shard_uid, results }) => {
-                self.chain_store_update
-                    .remove_state_changes_for_resharding(*block.hash(), shard_uid.shard_id());
                 self.process_resharding_results(
                     block,
                     &shard_uid,

--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -288,7 +288,7 @@ impl<'a> ChainUpdate<'a> {
                         result.shard_uid,
                         result.trie_changes.state_changes(),
                     )?;
-                    flat_storage_manager.update_flat_storage_for_shard(*shard_uid, block)?;
+                    flat_storage_manager.update_flat_storage_for_shard(result.shard_uid, block)?;
                     self.chain_store_update.merge(store_update);
 
                     self.chain_store_update.save_chunk_extra(

--- a/chain/chain/src/flat_storage_creator.rs
+++ b/chain/chain/src/flat_storage_creator.rs
@@ -71,7 +71,7 @@ impl FlatStorageShardCreator {
             remaining_state_parts: None,
             fetched_parts_sender,
             fetched_parts_receiver,
-            metrics: FlatStorageCreationMetrics::new(shard_uid.shard_id()),
+            metrics: FlatStorageCreationMetrics::new(shard_uid),
         }
     }
 

--- a/chain/chain/src/flat_storage_creator.rs
+++ b/chain/chain/src/flat_storage_creator.rs
@@ -15,14 +15,15 @@ use assert_matches::assert_matches;
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use near_chain_primitives::Error;
 use near_epoch_manager::EpochManagerAdapter;
+use near_primitives::block::Tip;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::state::FlatStateValue;
 use near_primitives::state_part::PartId;
 use near_primitives::types::{BlockHeight, StateRoot};
 use near_store::flat::{
     store_helper, BlockInfo, FetchingStateStatus, FlatStateChanges, FlatStorageCreationMetrics,
-    FlatStorageCreationStatus, FlatStorageReadyStatus, FlatStorageStatus, NUM_PARTS_IN_ONE_STEP,
-    STATE_PART_MEMORY_LIMIT,
+    FlatStorageCreationStatus, FlatStorageManager, FlatStorageReadyStatus, FlatStorageStatus,
+    NUM_PARTS_IN_ONE_STEP, STATE_PART_MEMORY_LIMIT,
 };
 use near_store::Store;
 use near_store::{Trie, TrieDBStorage, TrieTraversalItem};
@@ -434,15 +435,51 @@ impl FlatStorageCreator {
         chain_store: &ChainStore,
         num_threads: usize,
     ) -> Result<Option<Self>, Error> {
-        let chain_head = chain_store.head()?;
-        let shard_ids = epoch_manager.shard_ids(&chain_head.epoch_id)?;
-        let mut shard_creators: HashMap<ShardUId, FlatStorageShardCreator> = HashMap::new();
-        let mut creation_needed = false;
         let flat_storage_manager = runtime.get_flat_storage_manager();
         // Create flat storage for all shards.
         // TODO(nikurt): Choose which shards need to open the flat storage.
+
+        // Create flat storage for the shards in the current epoch.
+        let chain_head = chain_store.head()?;
+        let shard_creators = Self::create_flat_storage_for_current_epoch(
+            &chain_head,
+            &epoch_manager,
+            &flat_storage_manager,
+            &runtime,
+        )?;
+
+        // Create flat storage for the shards in the next epoch. This only
+        // matters during resharding where the shards in the next epoch are
+        // different than in the current epoch. The flat storage for the
+        // children shards is initially created at the end of the resharding.
+        // This method here is only needed when the node is restared after
+        // resharding is finished but before switching to the new shard layout.
+        Self::create_flat_storage_for_next_epoch(
+            &chain_head,
+            &epoch_manager,
+            &flat_storage_manager,
+        )?;
+
+        if shard_creators.is_empty() {
+            return Ok(None);
+        }
+        let pool = rayon::ThreadPoolBuilder::new().num_threads(num_threads).build().unwrap();
+        let flat_storage_creator = Self { shard_creators, pool };
+        Ok(Some(flat_storage_creator))
+    }
+
+    fn create_flat_storage_for_current_epoch(
+        chain_head: &Tip,
+        epoch_manager: &Arc<dyn EpochManagerAdapter>,
+        flat_storage_manager: &FlatStorageManager,
+        runtime: &Arc<dyn RuntimeAdapter>,
+    ) -> Result<HashMap<ShardUId, FlatStorageShardCreator>, Error> {
+        let epoch_id = &chain_head.epoch_id;
+        tracing::debug!(target: "store", ?epoch_id, "creating flat storage for the current epoch");
+
+        let mut shard_creators: HashMap<ShardUId, FlatStorageShardCreator> = HashMap::new();
+        let shard_ids = epoch_manager.shard_ids(epoch_id)?;
         for shard_id in shard_ids {
-            // The node applies transactions from the shards it cares about this and the next epoch.
             let shard_uid = epoch_manager.shard_id_to_uid(shard_id, &chain_head.epoch_id)?;
             let status = flat_storage_manager.get_flat_storage_status(shard_uid);
 
@@ -451,7 +488,6 @@ impl FlatStorageCreator {
                     flat_storage_manager.create_flat_storage_for_shard(shard_uid).unwrap();
                 }
                 FlatStorageStatus::Empty | FlatStorageStatus::Creation(_) => {
-                    creation_needed = true;
                     shard_creators.insert(
                         shard_uid,
                         FlatStorageShardCreator::new(
@@ -466,15 +502,39 @@ impl FlatStorageCreator {
             }
         }
 
-        let flat_storage_creator = if creation_needed {
-            Some(Self {
-                shard_creators,
-                pool: rayon::ThreadPoolBuilder::new().num_threads(num_threads).build().unwrap(),
-            })
-        } else {
-            None
-        };
-        Ok(flat_storage_creator)
+        Ok(shard_creators)
+    }
+
+    fn create_flat_storage_for_next_epoch(
+        chain_head: &Tip,
+        epoch_manager: &Arc<dyn EpochManagerAdapter>,
+        flat_storage_manager: &FlatStorageManager,
+    ) -> Result<(), Error> {
+        if !epoch_manager.will_shard_layout_change(&chain_head.last_block_hash)? {
+            return Ok(());
+        }
+
+        let next_epoch_id = &chain_head.next_epoch_id;
+        tracing::debug!(target: "store", ?next_epoch_id, "creating flat storage for the next epoch");
+
+        let shard_ids = epoch_manager.shard_ids(next_epoch_id)?;
+        for shard_id in shard_ids {
+            let shard_uid = epoch_manager.shard_id_to_uid(shard_id, next_epoch_id)?;
+            let status = flat_storage_manager.get_flat_storage_status(shard_uid);
+
+            match status {
+                FlatStorageStatus::Ready(_) => {
+                    flat_storage_manager.create_flat_storage_for_shard(shard_uid).unwrap();
+                }
+                FlatStorageStatus::Empty
+                | FlatStorageStatus::Creation(_)
+                | FlatStorageStatus::Disabled => {
+                    // The flat storage for children shards will be created
+                    // separately in the resharding process.
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Updates statuses of underlying flat storage creation processes. Returns boolean

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -525,7 +525,7 @@ impl<'a> ChainStoreUpdate<'a> {
     ) -> Result<(), Error> {
         let mut store_update = self.store().store_update();
 
-        tracing::info!(target: "garbage_collection", ?gc_mode, ?block_hash, "GC block_hash");
+        tracing::debug!(target: "garbage_collection", ?gc_mode, ?block_hash, "GC block_hash");
 
         // 1. Apply revert insertions or deletions from DBCol::TrieChanges for Trie
         {

--- a/chain/chain/src/state_snapshot_actor.rs
+++ b/chain/chain/src/state_snapshot_actor.rs
@@ -114,7 +114,9 @@ impl actix::Handler<WithSpanContext<CreateSnapshotRequest>> for StateSnapshotAct
                 }
             }
             Err(err) => {
-                tracing::error!(target: "state_snapshot", ?err, "State snapshot creation failed")
+                tracing::error!(target: "state_snapshot", ?err, "State snapshot creation failed.\
+                State snapshot is needed for correct node performance if it is required by config.");
+                panic!("State snapshot creation failed")
             }
         }
     }

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -1441,8 +1441,7 @@ pub struct ChainStoreUpdate<'a> {
 
     // All state changes made by a chunk, this is only used for resharding.
     add_state_changes_for_resharding: HashMap<(CryptoHash, ShardId), StateChangesForResharding>,
-    remove_state_changes_for_resharding: HashSet<(CryptoHash, ShardId)>,
-
+    remove_all_state_changes_for_resharding: bool,
     add_blocks_to_catchup: Vec<(CryptoHash, CryptoHash)>,
     // A pair (prev_hash, hash) to be removed from blocks to catchup
     remove_blocks_to_catchup: Vec<(CryptoHash, CryptoHash)>,
@@ -1468,7 +1467,7 @@ impl<'a> ChainStoreUpdate<'a> {
             largest_target_height: None,
             trie_changes: vec![],
             add_state_changes_for_resharding: HashMap::new(),
-            remove_state_changes_for_resharding: HashSet::new(),
+            remove_all_state_changes_for_resharding: false,
             add_blocks_to_catchup: vec![],
             remove_blocks_to_catchup: vec![],
             remove_prev_blocks_to_catchup: vec![],
@@ -2089,15 +2088,8 @@ impl<'a> ChainStoreUpdate<'a> {
         assert!(prev.is_none());
     }
 
-    pub fn remove_state_changes_for_resharding(
-        &mut self,
-        block_hash: CryptoHash,
-        shard_id: ShardId,
-    ) {
-        // We should not remove state changes for the same chunk twice
-        let value_not_present =
-            self.remove_state_changes_for_resharding.insert((block_hash, shard_id));
-        assert!(value_not_present);
+    pub fn remove_all_state_changes_for_resharding(&mut self) {
+        self.remove_all_state_changes_for_resharding = true;
     }
 
     pub fn add_block_to_catchup(&mut self, prev_hash: CryptoHash, block_hash: CryptoHash) {
@@ -2534,11 +2526,9 @@ impl<'a> ChainStoreUpdate<'a> {
                 &state_changes,
             )?;
         }
-        for (block_hash, shard_id) in self.remove_state_changes_for_resharding.drain() {
-            store_update.delete(
-                DBCol::StateChangesForSplitStates,
-                &get_block_shard_id(&block_hash, shard_id),
-            );
+
+        if self.remove_all_state_changes_for_resharding {
+            store_update.delete_all(DBCol::StateChangesForSplitStates);
         }
 
         let mut affected_catchup_blocks = HashSet::new();

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -606,6 +606,7 @@ impl ChainStore {
     ) -> Result<(), Error> {
         tracing::trace!(target: "resharding", ?protocol_version, shard_id, receipts_shard_id, "reassign_outgoing_receipts_for_resharding");
         // If simple nightshade v2 is enabled and stable use that.
+        // Same reassignment of outgoing receipts works for simple nightshade v3
         if checked_feature!("stable", SimpleNightshadeV2, protocol_version) {
             Self::reassign_outgoing_receipts_for_resharding_v2(
                 receipts,

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -54,7 +54,7 @@ fn build_chain() {
     if cfg!(feature = "nightly") {
         insta::assert_display_snapshot!(hash, @"CwaiZ4AmfJSnMN9rytYwwYHCTzLioC5xcjHzNkDex1HH");
     } else {
-        insta::assert_display_snapshot!(hash, @"HJmRPXT4JM9tt6mXw2gM75YaSoqeDCphhFK26uRpd1vw");
+        insta::assert_display_snapshot!(hash, @"387773cK74c4cHxNWnrTgoZ2dkEhVjtFjJNpSxeWohPx");
     }
 
     for i in 1..5 {
@@ -84,7 +84,7 @@ fn build_chain() {
     if cfg!(feature = "nightly") {
         insta::assert_display_snapshot!(hash, @"Dn18HUFm149fojXpwV1dYCfjdPh56S1k233kp7vmnFeE");
     } else {
-        insta::assert_display_snapshot!(hash, @"HbQVGVZ3WGxsNqeM3GfSwDoxwYZ2RBP1SinAze9SYR3C");
+        insta::assert_display_snapshot!(hash, @"6QpFm2bFYyfBjrk1KACMLr4dsezfZNYWGFnsbuD7gssH");
     }
 }
 

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -423,7 +423,7 @@ impl Handler<WithSpanContext<BlockResponse>> for ClientActor {
     fn handle(&mut self, msg: WithSpanContext<BlockResponse>, ctx: &mut Context<Self>) {
         self.wrap(msg, ctx, "BlockResponse", |this: &mut Self, msg|{
             let BlockResponse{ block, peer_id, was_requested } = msg;
-            info!(target: "client", block_height = block.header().height(), block_hash = ?block.header().hash(), "BlockResponse");
+            debug!(target: "client", block_height = block.header().height(), block_hash = ?block.header().hash(), "BlockResponse");
             let blocks_at_height = this
                 .client
                 .chain

--- a/chain/client/src/sync/state.rs
+++ b/chain/client/src/sync/state.rs
@@ -702,6 +702,7 @@ impl StateSync {
         )?;
 
         if all_done {
+            chain.process_snapshot_after_resharding()?;
             Ok(StateSyncResult::Completed)
         } else {
             Ok(StateSyncResult::InProgress)

--- a/chain/client/src/sync/state.rs
+++ b/chain/client/src/sync/state.rs
@@ -702,7 +702,6 @@ impl StateSync {
         )?;
 
         if all_done {
-            chain.process_snapshot_after_resharding()?;
             Ok(StateSyncResult::Completed)
         } else {
             Ok(StateSyncResult::InProgress)

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -277,14 +277,14 @@ impl ViewClientActor {
         for block_height in head.height..next_epoch_start_height {
             let bp = epoch_info.sample_block_producer(block_height);
             let bp = epoch_info.get_validator(bp).account_id().clone();
-            let cps: Vec<AccountId> = shard_ids
+            let cps = shard_ids
                 .iter()
                 .map(|&shard_id| {
-                    let cp = epoch_info.sample_chunk_producer(block_height, shard_id);
+                    let cp = epoch_info.sample_chunk_producer(block_height, shard_id)?;
                     let cp = epoch_info.get_validator(cp).account_id().clone();
-                    cp
+                    Ok(cp)
                 })
-                .collect();
+                .collect::<Result<Vec<AccountId>, near_chain::Error>>()?;
             if account_id != bp && !cps.iter().any(|a| *a == account_id) {
                 if let Some(start) = start_block_of_window {
                     if block_height == last_block_of_epoch {

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -46,6 +46,7 @@ use near_primitives::state_sync::{
     ShardStateSyncResponse, ShardStateSyncResponseHeader, ShardStateSyncResponseV3,
 };
 use near_primitives::static_clock::StaticClock;
+use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockId, BlockReference, EpochReference, Finality, MaybeBlockId,
     ShardId, SyncCheckpoint, TransactionOrReceiptId, ValidatorInfoIdentifier,
@@ -53,9 +54,10 @@ use near_primitives::types::{
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{
     BlockView, ChunkView, EpochValidatorInfo, ExecutionOutcomeWithIdView, ExecutionStatusView,
-    FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum, GasPriceView, LightClientBlockView,
-    MaintenanceWindowsView, QueryRequest, QueryResponse, ReceiptView, SplitStorageInfoView,
-    StateChangesKindsView, StateChangesView, TxExecutionStatus, TxStatusView,
+    FinalExecutionOutcomeView, FinalExecutionOutcomeViewEnum, FinalExecutionStatus, GasPriceView,
+    LightClientBlockView, MaintenanceWindowsView, QueryRequest, QueryResponse, ReceiptView,
+    SignedTransactionView, SplitStorageInfoView, StateChangesKindsView, StateChangesView,
+    TxExecutionStatus, TxStatusView,
 };
 use near_store::flat::{FlatStorageReadyStatus, FlatStorageStatus};
 use near_store::{DBCol, COLD_HEAD_KEY, FINAL_HEAD_KEY, HEAD_KEY};
@@ -513,11 +515,29 @@ impl ViewClientActor {
                     Ok(TxStatusView { execution_outcome: Some(res), status })
                 }
                 Err(near_chain::Error::DBNotFoundErr(_)) => {
-                    if self.chain.get_execution_outcome(&tx_hash).is_ok() {
-                        Ok(TxStatusView {
-                            execution_outcome: None,
-                            status: TxExecutionStatus::None,
-                        })
+                    if let Ok(Some(transaction)) = self.chain.chain_store.get_transaction(&tx_hash)
+                    {
+                        let transaction: SignedTransactionView =
+                            SignedTransaction::clone(&transaction).into();
+                        if let Ok(tx_outcome) = self.chain.get_execution_outcome(&tx_hash) {
+                            let outcome = FinalExecutionOutcomeViewEnum::FinalExecutionOutcome(
+                                FinalExecutionOutcomeView {
+                                    status: FinalExecutionStatus::Started,
+                                    transaction,
+                                    transaction_outcome: tx_outcome.into(),
+                                    receipts_outcome: vec![],
+                                },
+                            );
+                            Ok(TxStatusView {
+                                execution_outcome: Some(outcome),
+                                status: TxExecutionStatus::Included,
+                            })
+                        } else {
+                            Ok(TxStatusView {
+                                execution_outcome: None,
+                                status: TxExecutionStatus::Included,
+                            })
+                        }
                     } else {
                         Err(TxStatusError::MissingTransaction(tx_hash))
                     }

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -431,7 +431,15 @@ impl ViewClientActor {
             .chain
             .get_block_header(&execution_outcome.transaction_outcome.block_hash)?])
         {
-            return Ok(TxExecutionStatus::Included);
+            return if execution_outcome
+                .receipts_outcome
+                .iter()
+                .all(|e| e.outcome.status != ExecutionStatusView::Unknown)
+            {
+                Ok(TxExecutionStatus::ExecutedOptimistic)
+            } else {
+                Ok(TxExecutionStatus::Included)
+            };
         }
 
         if execution_outcome

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -1117,6 +1117,7 @@ impl EpochManager {
         match self.get_epoch_info(&EpochId(*hash)) {
             Ok(_) => Ok(true),
             Err(EpochError::IOErr(msg)) => Err(EpochError::IOErr(msg)),
+            Err(EpochError::EpochOutOfBounds(_)) => Ok(false),
             Err(EpochError::MissingBlock(_)) => Ok(false),
             Err(err) => {
                 warn!(target: "epoch_manager", ?err, "Unexpected error in is_last_block_in_finished_epoch");

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -1013,7 +1013,7 @@ impl EpochManager {
         shard_id: ShardId,
     ) -> Result<ValidatorStake, EpochError> {
         let epoch_info = self.get_epoch_info(epoch_id)?;
-        let validator_id = Self::chunk_producer_from_info(&epoch_info, height, shard_id);
+        let validator_id = Self::chunk_producer_from_info(&epoch_info, height, shard_id)?;
         Ok(epoch_info.get_validator(validator_id))
     }
 
@@ -1540,7 +1540,7 @@ impl EpochManager {
         epoch_info: &EpochInfo,
         height: BlockHeight,
         shard_id: ShardId,
-    ) -> ValidatorId {
+    ) -> Result<ValidatorId, EpochError> {
         epoch_info.sample_chunk_producer(height, shard_id)
     }
 
@@ -1851,7 +1851,7 @@ impl EpochManager {
             let prev_epoch = prev_info.epoch_id().clone();
 
             let block_info = self.get_block_info(&cur_hash)?;
-            aggregator.update_tail(&block_info, &epoch_info, prev_height);
+            aggregator.update_tail(&block_info, &epoch_info, prev_height)?;
 
             if prev_hash == self.epoch_info_aggregator.last_block_hash {
                 // We’ve reached sync point of the old aggregator.  If old

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -1126,7 +1126,7 @@ fn test_expected_chunks_prev_block_not_produced() {
         let prev_block_info = epoch_manager.get_block_info(&prev_block).unwrap();
         let prev_height = prev_block_info.height();
         let expected_chunk_producer =
-            EpochManager::chunk_producer_from_info(&epoch_info, prev_height + 1, 0);
+            EpochManager::chunk_producer_from_info(&epoch_info, prev_height + 1, 0).unwrap();
         // test1 does not produce blocks during first epoch
         if block_producer == 0 && epoch_id == initial_epoch_id {
             expected += 1;
@@ -1468,7 +1468,8 @@ fn test_chunk_validator_kickout() {
                         &epoch_info,
                         height,
                         shard_id as u64,
-                    );
+                    )
+                    .unwrap();
                     // test1 skips chunks
                     if chunk_producer == 0 {
                         expected += 1;

--- a/chain/epoch-manager/src/types.rs
+++ b/chain/epoch-manager/src/types.rs
@@ -3,6 +3,7 @@ use near_primitives::block_header::BlockHeader;
 use near_primitives::challenge::SlashedValidator;
 use near_primitives::epoch_manager::block_info::BlockInfo;
 use near_primitives::epoch_manager::epoch_info::EpochInfo;
+use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
@@ -104,7 +105,7 @@ impl EpochInfoAggregator {
         block_info: &BlockInfo,
         epoch_info: &EpochInfo,
         prev_block_height: BlockHeight,
-    ) {
+    ) -> Result<(), EpochError> {
         let _span =
             debug_span!(target: "epoch_tracker", "update_tail", prev_block_height).entered();
         // Step 1: update block tracer
@@ -138,7 +139,7 @@ impl EpochInfoAggregator {
                 epoch_info,
                 prev_block_height + 1,
                 i as ShardId,
-            );
+            )?;
             let tracker = self.shard_tracker.entry(i as ShardId).or_insert_with(HashMap::new);
             tracker
                 .entry(chunk_validator_id)
@@ -169,6 +170,8 @@ impl EpochInfoAggregator {
         for proposal in block_info.proposals_iter() {
             self.all_proposals.entry(proposal.account_id().clone()).or_insert(proposal);
         }
+
+        Ok(())
     }
 
     /// Merges information from `other` aggregator into `self`.

--- a/chain/epoch-manager/src/validator_selection.rs
+++ b/chain/epoch-manager/src/validator_selection.rs
@@ -605,7 +605,7 @@ mod tests {
 
         for shard_id in 0..num_shards {
             for h in 0..100_000 {
-                let cp = epoch_info.sample_chunk_producer(h, shard_id);
+                let cp = epoch_info.sample_chunk_producer(h, shard_id).unwrap();
                 // Don't read too much into this. The reason the ValidatorId always
                 // equals the ShardId is because the validators are assigned to shards in order.
                 assert_eq!(cp, shard_id)
@@ -634,7 +634,7 @@ mod tests {
         for shard_id in 0..num_shards {
             let mut counts: [i32; 2] = [0, 0];
             for h in 0..100_000 {
-                let cp = epoch_info.sample_chunk_producer(h, shard_id);
+                let cp = epoch_info.sample_chunk_producer(h, shard_id).unwrap();
                 // if ValidatorId is in the second half then it is the lower
                 // stake validator (because they are sorted by decreasing stake).
                 let index = if cp >= num_shards { 1 } else { 0 };

--- a/chain/jsonrpc/jsonrpc-tests/res/genesis_config.json
+++ b/chain/jsonrpc/jsonrpc-tests/res/genesis_config.json
@@ -1,5 +1,5 @@
 {
-  "protocol_version": 64,
+  "protocol_version": 65,
   "genesis_time": "1970-01-01T00:00:00.000000000Z",
   "chain_id": "sample",
   "genesis_height": 0,

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -339,7 +339,7 @@ impl JsonRpcHandler {
                 process_method_call(request, |params| self.next_light_client_block(params)).await
             }
             "network_info" => process_method_call(request, |_params: ()| self.network_info()).await,
-            "send_tx" => process_method_call(request, |params| self.send_tx(params, false)).await,
+            "send_tx" => process_method_call(request, |params| self.send_tx(params)).await,
             "status" => process_method_call(request, |_params: ()| self.status()).await,
             "tx" => {
                 process_method_call(request, |params| self.tx_status_common(params, false)).await
@@ -539,7 +539,6 @@ impl JsonRpcHandler {
         tx_info: near_jsonrpc_primitives::types::transactions::TransactionInfo,
         finality: near_primitives::views::TxExecutionStatus,
         fetch_receipt: bool,
-        is_legacy_broadcast_tx_commit: bool,
     ) -> Result<
         near_jsonrpc_primitives::types::transactions::RpcTransactionResponse,
         near_jsonrpc_primitives::types::transactions::RpcTransactionError,
@@ -557,16 +556,7 @@ impl JsonRpcHandler {
                 .await;
                 match tx_status_result.clone() {
                     Ok(result) => {
-                        let ready_to_return = if is_legacy_broadcast_tx_commit {
-                            // `broadcast_tx_commit` does not have an option in TxExecutionStatus enum.
-                            // We need to provide the transaction with all the corresponding receipts,
-                            // but we don't want to wait until all of them will be in the canonical chain.
-                            result.execution_outcome.is_some()
-                        } else {
-                            result.status >= finality
-                        };
-
-                        if ready_to_return {
+                        if tx_execution_status_meets_expectations(&finality, &result.status) {
                             break Ok(result.into())
                         }
                         // else: No such transaction recorded on chain yet
@@ -648,7 +638,6 @@ impl JsonRpcHandler {
     async fn send_tx(
         &self,
         request_data: near_jsonrpc_primitives::types::transactions::RpcSendTransactionRequest,
-        is_legacy_broadcast_tx_commit: bool,
     ) -> Result<
         near_jsonrpc_primitives::types::transactions::RpcTransactionResponse,
         near_jsonrpc_primitives::types::transactions::RpcTransactionError,
@@ -667,7 +656,6 @@ impl JsonRpcHandler {
                     near_jsonrpc_primitives::types::transactions::TransactionInfo::from_signed_tx(tx.clone()),
                     request_data.wait_until,
                     false,
-                    is_legacy_broadcast_tx_commit,
                 ).await
             }
             network_client_response=> {
@@ -687,14 +675,11 @@ impl JsonRpcHandler {
         near_jsonrpc_primitives::types::transactions::RpcTransactionResponse,
         near_jsonrpc_primitives::types::transactions::RpcTransactionError,
     > {
-        self.send_tx(
-            RpcSendTransactionRequest {
-                signed_transaction: request_data.signed_transaction,
-                // Will be ignored, broadcast_tx_commit is not aligned with existing enum
-                wait_until: Default::default(),
-            },
-            true,
-        )
+        self.send_tx(RpcSendTransactionRequest {
+            signed_transaction: request_data.signed_transaction,
+            // Will be ignored, broadcast_tx_commit is not aligned with existing enum
+            wait_until: Default::default(),
+        })
         .await
     }
 
@@ -858,12 +843,7 @@ impl JsonRpcHandler {
         near_jsonrpc_primitives::types::transactions::RpcTransactionError,
     > {
         let tx_status = self
-            .tx_status_fetch(
-                request_data.transaction_info,
-                request_data.wait_until,
-                fetch_receipt,
-                false,
-            )
+            .tx_status_fetch(request_data.transaction_info, request_data.wait_until, fetch_receipt)
             .await?;
         Ok(tx_status.rpc_into())
     }
@@ -1600,4 +1580,30 @@ pub fn start_http(
     }
 
     servers
+}
+
+fn tx_execution_status_meets_expectations(
+    expected: &TxExecutionStatus,
+    actual: &TxExecutionStatus,
+) -> bool {
+    match expected {
+        TxExecutionStatus::None => true,
+        TxExecutionStatus::Included => actual != &TxExecutionStatus::None,
+        TxExecutionStatus::ExecutedOptimistic => [
+            TxExecutionStatus::ExecutedOptimistic,
+            TxExecutionStatus::Executed,
+            TxExecutionStatus::Final,
+        ]
+        .contains(actual),
+        TxExecutionStatus::IncludedFinal => [
+            TxExecutionStatus::IncludedFinal,
+            TxExecutionStatus::Executed,
+            TxExecutionStatus::Final,
+        ]
+        .contains(actual),
+        TxExecutionStatus::Executed => {
+            [TxExecutionStatus::Executed, TxExecutionStatus::Final].contains(actual)
+        }
+        TxExecutionStatus::Final => actual == &TxExecutionStatus::Final,
+    }
 }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -588,15 +588,12 @@ impl JsonRpcHandler {
         .map_err(|_| {
             metrics::RPC_TIMEOUT_TOTAL.inc();
             tracing::warn!(
-                target: "jsonrpc", "Timeout: tx_status_fetch method. tx_info {:?} fetch_receipt {:?}",
+                target: "jsonrpc", "Timeout: tx_status_fetch method. tx_info {:?} fetch_receipt {:?} result {:?}",
                 tx_info,
                 fetch_receipt,
+                tx_status_result
             );
-            if let Err(error) = tx_status_result {
-                error
-            } else {
-                near_jsonrpc_primitives::types::transactions::RpcTransactionError::TimeoutError
-            }
+            near_jsonrpc_primitives::types::transactions::RpcTransactionError::TimeoutError
         })?
     }
 

--- a/chain/network/src/config_json.rs
+++ b/chain/network/src/config_json.rs
@@ -196,11 +196,29 @@ pub struct Config {
     pub experimental: ExperimentalConfig,
 }
 
+fn default_tier1_enable_inbound() -> bool {
+    true
+}
+
+fn default_tier1_enable_outbound() -> bool {
+    true
+}
+
+fn default_tier1_connect_interval() -> Duration {
+    Duration::from_secs(60)
+}
+
+fn default_tier1_new_connections_per_attempt() -> u64 {
+    50
+}
+
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct ExperimentalConfig {
     // If true - don't allow any inbound connections.
+    #[serde(default)]
     pub inbound_disabled: bool,
     // If true - connect only to the boot nodes.
+    #[serde(default)]
     pub connect_only_to_boot_nodes: bool,
 
     // If greater than 0, then system will no longer send or receive tombstones
@@ -208,22 +226,28 @@ pub struct ExperimentalConfig {
     //
     // The better name is `skip_tombstones_seconds`, but we keep send for
     // compatibility.
+    #[serde(default)]
     pub skip_sending_tombstones_seconds: i64,
 
     /// See `near_network::config::Tier1::enable_inbound`.
+    #[serde(default = "default_tier1_enable_inbound")]
     pub tier1_enable_inbound: bool,
 
     /// See `near_network::config::Tier1::enable_outbound`.
+    #[serde(default = "default_tier1_enable_outbound")]
     pub tier1_enable_outbound: bool,
 
     /// See `near_network::config::Tier1::connect_interval`.
+    #[serde(default = "default_tier1_connect_interval")]
     pub tier1_connect_interval: Duration,
 
     /// See `near_network::config::Tier1::new_connections_per_attempt`.
+    #[serde(default = "default_tier1_new_connections_per_attempt")]
     pub tier1_new_connections_per_attempt: u64,
 
     /// See `NetworkConfig`.
     /// Fields set here will override the NetworkConfig fields.
+    #[serde(default)]
     pub network_config_overrides: NetworkConfigOverrides,
 }
 
@@ -250,10 +274,10 @@ impl Default for ExperimentalConfig {
             inbound_disabled: false,
             connect_only_to_boot_nodes: false,
             skip_sending_tombstones_seconds: 0,
-            tier1_enable_inbound: true,
-            tier1_enable_outbound: true,
-            tier1_connect_interval: Duration::from_secs(60),
-            tier1_new_connections_per_attempt: 50,
+            tier1_enable_inbound: default_tier1_enable_inbound(),
+            tier1_enable_outbound: default_tier1_enable_outbound(),
+            tier1_connect_interval: default_tier1_connect_interval(),
+            tier1_new_connections_per_attempt: default_tier1_new_connections_per_attempt(),
             network_config_overrides: Default::default(),
         }
     }

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -562,7 +562,6 @@ impl PeerManagerActor {
         mut interval: time::Duration,
         (default_interval, max_interval): (time::Duration, time::Duration),
     ) {
-        let _span = tracing::trace_span!(target: "network", "monitor_peers_trigger").entered();
         let _timer =
             metrics::PEER_MANAGER_TRIGGER_TIME.with_label_values(&["monitor_peers"]).start_timer();
 
@@ -700,7 +699,6 @@ impl PeerManagerActor {
     }
 
     fn push_network_info_trigger(&self, ctx: &mut actix::Context<Self>, interval: time::Duration) {
-        let _span = tracing::trace_span!(target: "network", "push_network_info_trigger").entered();
         let network_info = self.get_network_info();
         let _timer = metrics::PEER_MANAGER_TRIGGER_TIME
             .with_label_values(&["push_network_info"])
@@ -728,10 +726,6 @@ impl PeerManagerActor {
         msg: NetworkRequests,
         ctx: &mut actix::Context<Self>,
     ) -> NetworkResponses {
-        let msg_type: &str = msg.as_ref();
-        let _span =
-            tracing::trace_span!(target: "network", "handle_msg_network_requests", msg_type)
-                .entered();
         metrics::REQUEST_COUNT_BY_TYPE_TOTAL.with_label_values(&[msg.as_ref()]).inc();
         match msg {
             NetworkRequests::Block { block } => {

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -196,7 +196,7 @@ impl ProtocolFeature {
 /// Current protocol version used on the mainnet.
 /// Some features (e. g. FixStorageUsage) require that there is at least one epoch with exactly
 /// the corresponding version
-const STABLE_PROTOCOL_VERSION: ProtocolVersion = 64;
+const STABLE_PROTOCOL_VERSION: ProtocolVersion = 65;
 
 /// Largest protocol version supported by the current binary.
 pub const PROTOCOL_VERSION: ProtocolVersion = if cfg!(feature = "nightly_protocol") {

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -113,6 +113,8 @@ pub enum ProtocolFeature {
     /// Resharding V2. A new implementation for resharding and a new shard
     /// layout for the production networks.
     SimpleNightshadeV2,
+    /// Built on top of Resharding V2. Changes shard layout to V3 to split shard 2 into two parts.
+    SimpleNightshadeV3,
     /// In case not all validator seats are occupied our algorithm provide incorrect minimal seat
     /// price - it reports as alpha * sum_stake instead of alpha * sum_stake / (1 - alpha), where
     /// alpha is min stake ratio
@@ -176,6 +178,7 @@ impl ProtocolFeature {
             ProtocolFeature::RestrictTla
             | ProtocolFeature::TestnetFewerBlockProducers
             | ProtocolFeature::SimpleNightshadeV2 => 64,
+            ProtocolFeature::SimpleNightshadeV3 => 65,
 
             // Nightly features
             #[cfg(feature = "protocol_feature_fix_staking_threshold")]

--- a/core/primitives/src/action/mod.rs
+++ b/core/primitives/src/action/mod.rs
@@ -178,15 +178,13 @@ pub enum Action {
     DeleteAccount(DeleteAccountAction),
     Delegate(Box<delegate::SignedDelegateAction>),
 }
-// Note: If this number ever goes down, please adjust the equality accordingly. Otherwise,
-// we would get used to better performance and would be subject to a performance loss should
-// we come back up to 32 bytes later on.
-// If compiling with nightly, this check may fail due to new optimizations introduced by
-// rustc. So, cfg-them out, as our production system only runs with stable.
-#[cfg(not(fuzz))]
+
 const _: () = assert!(
-    cfg!(not(target_pointer_width = "64")) || std::mem::size_of::<Action>() == 32,
-    "Action is 32 bytes for performance reasons, see #9451"
+    // 1 word for tag plus the largest variant `DeployContractAction` which is a 3-word `Vec`.
+    // The `<=` check covers platforms that have pointers smaller than 8 bytes as well as random
+    // freak nightlies that somehow find a way to pack everything into one less word.
+    std::mem::size_of::<Action>() <= 32,
+    "Action <= 32 bytes for performance reasons, see #9451"
 );
 
 impl Action {

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -144,6 +144,11 @@ impl AllEpochConfig {
     }
 
     fn config_nightshade(config: &mut EpochConfig, protocol_version: ProtocolVersion) {
+        if checked_feature!("stable", SimpleNightshadeV3, protocol_version) {
+            Self::config_nightshade_impl(config, ShardLayout::get_simple_nightshade_layout_v3());
+            return;
+        }
+
         if checked_feature!("stable", SimpleNightshadeV2, protocol_version) {
             Self::config_nightshade_impl(config, ShardLayout::get_simple_nightshade_layout_v2());
             return;

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -861,6 +861,18 @@ pub enum EpochError {
     ChunkValidatorSelectionError(String),
 }
 
+impl EpochError {
+    pub fn new_sharding_error(shard_id: usize, epoch_height: u64) -> Self {
+        EpochError::ShardingError(format!("{shard_id} is out of bound for epoch {epoch_height}"))
+    }
+
+    pub fn new_sampling_error(sample: usize, shard_id: usize, epoch_height: u64) -> Self {
+        EpochError::ShardingError(format!(
+            "Sample {sample} is out of bound for shard {shard_id} in epoch {epoch_height}"
+        ))
+    }
+}
+
 impl std::error::Error for EpochError {}
 
 impl Display for EpochError {

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -167,6 +167,24 @@ impl ShardLayout {
         )
     }
 
+    /// Returns the simple nightshade layout, version 3, that will be used in production.
+    pub fn get_simple_nightshade_layout_v3() -> ShardLayout {
+        ShardLayout::v1(
+            vec![
+                "aurora",
+                "aurora-0",
+                "game.hot.tg",
+                "kkuuue2akv_1630967379.near",
+                "tge-lockup.sweat",
+            ]
+            .into_iter()
+            .map(|s| s.parse().unwrap())
+            .collect(),
+            Some(vec![vec![0], vec![1], vec![2, 3], vec![4], vec![5]]),
+            3,
+        )
+    }
+
     /// Given a parent shard id, return the shard uids for the shards in the current shard layout that
     /// are split from this parent shard. If this shard layout has no parent shard layout, return None
     pub fn get_children_shards_uids(&self, parent_shard_id: ShardId) -> Option<Vec<ShardUId>> {
@@ -568,6 +586,7 @@ mod tests {
         let v0 = ShardLayout::v0(1, 0);
         let v1 = ShardLayout::get_simple_nightshade_layout();
         let v2 = ShardLayout::get_simple_nightshade_layout_v2();
+        let v3 = ShardLayout::get_simple_nightshade_layout_v3();
 
         insta::assert_snapshot!(serde_json::to_string_pretty(&v0).unwrap(), @r###"
         {
@@ -635,6 +654,46 @@ mod tests {
               3
             ],
             "version": 2
+          }
+        }
+        "###);
+        insta::assert_snapshot!(serde_json::to_string_pretty(&v3).unwrap(), @r###"
+        {
+          "V1": {
+            "boundary_accounts": [
+              "aurora",
+              "aurora-0",
+              "game.hot.tg",
+              "kkuuue2akv_1630967379.near",
+              "tge-lockup.sweat"
+            ],
+            "shards_split_map": [
+              [
+                0
+              ],
+              [
+                1
+              ],
+              [
+                2,
+                3
+              ],
+              [
+                4
+              ],
+              [
+                5
+              ]
+            ],
+            "to_parent_shard_map": [
+              0,
+              1,
+              2,
+              2,
+              3,
+              4
+            ],
+            "version": 3
           }
         }
         "###);

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -60,8 +60,8 @@ pub const PROTOCOL_UPGRADE_SCHEDULE: Lazy<ProtocolUpgradeVotingSchedule> = Lazy:
     // after the set date. Ideally that should be during working hours.
     // e.g. ProtocolUpgradeVotingSchedule::from_env_or_str("2000-01-01 15:00:00").unwrap());
 
-    // Monday
-    ProtocolUpgradeVotingSchedule::from_env_or_str("2024-03-12 18:00:00").unwrap()
+    // Wednesday
+    ProtocolUpgradeVotingSchedule::from_env_or_str("2024-03-20 14:00:00").unwrap()
 });
 
 /// Gives new clients an option to upgrade without announcing that they support

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -61,7 +61,7 @@ pub const PROTOCOL_UPGRADE_SCHEDULE: Lazy<ProtocolUpgradeVotingSchedule> = Lazy:
     // e.g. ProtocolUpgradeVotingSchedule::from_env_or_str("2000-01-01 15:00:00").unwrap());
 
     // Monday
-    ProtocolUpgradeVotingSchedule::from_env_or_str("2024-03-11 18:00:00").unwrap()
+    ProtocolUpgradeVotingSchedule::from_env_or_str("2024-03-12 18:00:00").unwrap()
 });
 
 /// Gives new clients an option to upgrade without announcing that they support

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -60,8 +60,8 @@ pub const PROTOCOL_UPGRADE_SCHEDULE: Lazy<ProtocolUpgradeVotingSchedule> = Lazy:
     // after the set date. Ideally that should be during working hours.
     // e.g. ProtocolUpgradeVotingSchedule::from_env_or_str("2000-01-01 15:00:00").unwrap());
 
-    // Tuesday
-    ProtocolUpgradeVotingSchedule::from_env_or_str("2024-02-06 12:00:00").unwrap()
+    // Monday
+    ProtocolUpgradeVotingSchedule::from_env_or_str("2024-03-11 18:00:00").unwrap()
 });
 
 /// Gives new clients an option to upgrade without announcing that they support

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -60,8 +60,8 @@ pub const PROTOCOL_UPGRADE_SCHEDULE: Lazy<ProtocolUpgradeVotingSchedule> = Lazy:
     // after the set date. Ideally that should be during working hours.
     // e.g. ProtocolUpgradeVotingSchedule::from_env_or_str("2000-01-01 15:00:00").unwrap());
 
-    // Monday
-    ProtocolUpgradeVotingSchedule::from_env_or_str("2024-01-29 15:00:00").unwrap()
+    // Tuesday
+    ProtocolUpgradeVotingSchedule::from_env_or_str("2024-01-30 15:00:00").unwrap()
 });
 
 /// Gives new clients an option to upgrade without announcing that they support

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -60,7 +60,8 @@ pub const PROTOCOL_UPGRADE_SCHEDULE: Lazy<ProtocolUpgradeVotingSchedule> = Lazy:
     // after the set date. Ideally that should be during working hours.
     // e.g. ProtocolUpgradeVotingSchedule::from_env_or_str("2000-01-01 15:00:00").unwrap());
 
-    ProtocolUpgradeVotingSchedule::default()
+    // Monday
+    ProtocolUpgradeVotingSchedule::from_env_or_str("2024-01-29 15:00:00").unwrap()
 });
 
 /// Gives new clients an option to upgrade without announcing that they support

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -60,8 +60,8 @@ pub const PROTOCOL_UPGRADE_SCHEDULE: Lazy<ProtocolUpgradeVotingSchedule> = Lazy:
     // after the set date. Ideally that should be during working hours.
     // e.g. ProtocolUpgradeVotingSchedule::from_env_or_str("2000-01-01 15:00:00").unwrap());
 
-    // Tuesday
-    ProtocolUpgradeVotingSchedule::from_env_or_str("2024-01-30 15:00:00").unwrap()
+    // Monday
+    ProtocolUpgradeVotingSchedule::from_env_or_str("2024-02-05 15:00:00").unwrap()
 });
 
 /// Gives new clients an option to upgrade without announcing that they support

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -60,8 +60,8 @@ pub const PROTOCOL_UPGRADE_SCHEDULE: Lazy<ProtocolUpgradeVotingSchedule> = Lazy:
     // after the set date. Ideally that should be during working hours.
     // e.g. ProtocolUpgradeVotingSchedule::from_env_or_str("2000-01-01 15:00:00").unwrap());
 
-    // Monday
-    ProtocolUpgradeVotingSchedule::from_env_or_str("2024-02-05 15:00:00").unwrap()
+    // Tuesday
+    ProtocolUpgradeVotingSchedule::from_env_or_str("2024-02-06 12:00:00").unwrap()
 });
 
 /// Gives new clients an option to upgrade without announcing that they support

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1683,8 +1683,6 @@ pub struct TxStatusView {
     Default,
     Eq,
     PartialEq,
-    Ord,
-    PartialOrd,
 )]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum TxExecutionStatus {
@@ -1692,6 +1690,11 @@ pub enum TxExecutionStatus {
     None,
     /// Transaction is included into the block. The block may be not finalised yet
     Included,
+    /// Transaction is included into the block +
+    /// All the transaction receipts finished their execution.
+    /// The corresponding blocks for tx and each receipt may be not finalised yet
+    #[default]
+    ExecutedOptimistic,
     /// Transaction is included into finalised block
     IncludedFinal,
     /// Transaction is included into finalised block +
@@ -1700,7 +1703,6 @@ pub enum TxExecutionStatus {
     Executed,
     /// Transaction is included into finalised block +
     /// Execution of transaction receipts is finalised
-    #[default]
     Final,
 }
 

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1667,7 +1667,7 @@ impl ExecutionOutcomeWithIdView {
         self.outcome.to_hashes(self.id)
     }
 }
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TxStatusView {
     pub execution_outcome: Option<FinalExecutionOutcomeViewEnum>,
     pub status: TxExecutionStatus,

--- a/core/store/src/cold_storage.rs
+++ b/core/store/src/cold_storage.rs
@@ -1,6 +1,5 @@
 use crate::columns::DBKeyType;
 use crate::db::{ColdDB, COLD_HEAD_KEY, HEAD_KEY};
-use crate::trie::TrieRefcountAddition;
 use crate::{metrics, DBCol, DBTransaction, Database, Store, TrieChanges};
 
 use borsh::BorshDeserialize;
@@ -9,17 +8,39 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::ShardChunk;
 use near_primitives::types::BlockHeight;
+use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use std::collections::HashMap;
 use std::io;
 use strum::IntoEnumIterator;
 
 type StoreKey = Vec<u8>;
 type StoreValue = Option<Vec<u8>>;
-type StoreCache = HashMap<(DBCol, StoreKey), StoreValue>;
 
-struct StoreWithCache<'a> {
-    store: &'a Store,
-    cache: StoreCache,
+/// This trait is used on top of Store to calculate cold loop specific metrics,
+/// and implement conversion to errors for absent data.
+pub trait ColdMigrationStore {
+    fn iter_prefix_with_callback_for_cold(
+        &self,
+        col: DBCol,
+        key_prefix: &[u8],
+        callback: impl FnMut(Box<[u8]>),
+    ) -> io::Result<()>;
+
+    fn get_for_cold(&self, column: DBCol, key: &[u8]) -> io::Result<StoreValue>;
+
+    fn get_ser_for_cold<T: BorshDeserialize>(
+        &self,
+        column: DBCol,
+        key: &[u8],
+    ) -> io::Result<Option<T>>;
+
+    fn get_or_err_for_cold(&self, column: DBCol, key: &[u8]) -> io::Result<Vec<u8>>;
+
+    fn get_ser_or_err_for_cold<T: BorshDeserialize>(
+        &self,
+        column: DBCol,
+        key: &[u8],
+    ) -> io::Result<T>;
 }
 
 /// The BatchTransaction can be used to write multiple set operations to the cold db in batches.
@@ -37,7 +58,6 @@ struct BatchTransaction {
 /// Updates provided cold database from provided hot store with information about block at `height`.
 /// Returns if the block was copied (false only if height is not present in `hot_store`).
 /// Block as `height` has to be final.
-/// Wraps hot store in `StoreWithCache` for optimizing reads.
 ///
 /// First, we read from hot store information necessary
 /// to determine all the keys that need to be updated in cold db.
@@ -59,35 +79,53 @@ pub fn update_cold_db(
     hot_store: &Store,
     shard_layout: &ShardLayout,
     height: &BlockHeight,
+    num_threads: usize,
 ) -> io::Result<bool> {
     let _span = tracing::debug_span!(target: "cold_store", "update cold db", height = height);
     let _timer = metrics::COLD_COPY_DURATION.start_timer();
 
-    let mut store_with_cache = StoreWithCache { store: hot_store, cache: StoreCache::new() };
-
-    if store_with_cache.get(DBCol::BlockHeight, &height.to_le_bytes())?.is_none() {
+    if hot_store.get_for_cold(DBCol::BlockHeight, &height.to_le_bytes())?.is_none() {
         return Ok(false);
     }
 
     let height_key = height.to_le_bytes();
-    let block_hash_vec = store_with_cache.get_or_err(DBCol::BlockHeight, &height_key)?;
+    let block_hash_vec = hot_store.get_or_err_for_cold(DBCol::BlockHeight, &height_key)?;
     let block_hash_key = block_hash_vec.as_slice();
 
     let key_type_to_keys =
-        get_keys_from_store(&mut store_with_cache, shard_layout, &height_key, block_hash_key)?;
-    for col in DBCol::iter() {
-        if !col.is_cold() {
-            continue;
-        }
+        get_keys_from_store(&hot_store, shard_layout, &height_key, block_hash_key)?;
+    let cold_columns = DBCol::iter().filter(|col| col.is_cold()).collect::<Vec<DBCol>>();
 
-        if col == DBCol::State {
-            copy_state_from_store(shard_layout, block_hash_key, cold_db, &mut store_with_cache)?;
-            continue;
-        }
-
-        let keys = combine_keys(&key_type_to_keys, &col.key_type());
-        copy_from_store(cold_db, &mut store_with_cache, col, keys)?;
-    }
+    // Create new thread pool with `num_threads`.
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(num_threads)
+        .build()
+        .map_err(|_| io::Error::new(io::ErrorKind::Other, "Failed to create rayon pool"))?
+        .install(|| {
+            cold_columns
+                .into_par_iter() // Process every cold column as a separate task in thread pool in parallel.
+                // Copy column to cold db.
+                .map(|col: DBCol| -> io::Result<()> {
+                    if col == DBCol::State {
+                        copy_state_from_store(shard_layout, block_hash_key, cold_db, &hot_store)
+                    } else {
+                        let keys = combine_keys(&key_type_to_keys, &col.key_type());
+                        copy_from_store(cold_db, &hot_store, col, keys)
+                    }
+                })
+                // Return first found error, or Ok(())
+                .reduce(
+                    || Ok(()), // Ok(()) by default
+                    // First found Err, or Ok(())g
+                    |left, right| -> io::Result<()> {
+                        vec![left, right]
+                            .into_iter()
+                            .filter(|res| res.is_err())
+                            .next()
+                            .unwrap_or(Ok(()))
+                    },
+                )
+        })?;
 
     Ok(true)
 }
@@ -128,7 +166,7 @@ fn copy_state_from_store(
     shard_layout: &ShardLayout,
     block_hash_key: &[u8],
     cold_db: &ColdDB,
-    hot_store: &mut StoreWithCache,
+    hot_store: &Store,
 ) -> io::Result<()> {
     let col = DBCol::State;
     let _span = tracing::debug_span!(target: "cold_store", "copy_state_from_store", %col);
@@ -148,12 +186,8 @@ fn copy_state_from_store(
 
         let Some(trie_changes) = trie_changes else { continue };
         for op in trie_changes.insertions() {
-            hot_store.insert_state_to_cache_from_op(op, &shard_uid_key);
-
             let key = join_two_keys(&shard_uid_key, op.hash().as_bytes());
-            let value = hot_store.get(DBCol::State, &key)?;
-            let value =
-                value.ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, hex::encode(&key)))?;
+            let value = op.payload().to_vec();
 
             tracing::trace!(target: "cold_store", pretty_key=?near_fmt::StorageKey(&key), "copying state node to colddb");
             rc_aware_set(&mut transaction, DBCol::State, key, value);
@@ -176,7 +210,7 @@ fn copy_state_from_store(
 /// Writes that transaction to cold_db.
 fn copy_from_store(
     cold_db: &ColdDB,
-    hot_store: &mut StoreWithCache,
+    hot_store: &Store,
     col: DBCol,
     keys: Vec<StoreKey>,
 ) -> io::Result<()> {
@@ -196,7 +230,7 @@ fn copy_from_store(
         // might speed things up.  Currently our Database abstraction
         // doesn’t offer interface for it so that would need to be
         // added.
-        let data = hot_store.get(col, &key)?;
+        let data = hot_store.get_for_cold(col, &key)?;
         if let Some(value) = data {
             // TODO: As an optimisation, we might consider breaking the
             // abstraction layer.  Since we’re always writing to cold database,
@@ -236,11 +270,11 @@ pub fn update_cold_head(
 ) -> io::Result<()> {
     tracing::debug!(target: "cold_store", "update HEAD of cold db to {}", height);
 
-    let mut store = StoreWithCache { store: hot_store, cache: StoreCache::new() };
-
     let height_key = height.to_le_bytes();
-    let block_hash_key = store.get_or_err(DBCol::BlockHeight, &height_key)?.as_slice().to_vec();
-    let tip_header = &store.get_ser_or_err::<BlockHeader>(DBCol::BlockHeader, &block_hash_key)?;
+    let block_hash_key =
+        hot_store.get_or_err_for_cold(DBCol::BlockHeight, &height_key)?.as_slice().to_vec();
+    let tip_header =
+        &hot_store.get_ser_or_err_for_cold::<BlockHeader>(DBCol::BlockHeader, &block_hash_key)?;
     let tip = Tip::from_header(tip_header);
 
     // Write HEAD to the cold db.
@@ -306,7 +340,6 @@ pub fn copy_all_data_to_cold(
 // can be used to copy the genesis records from hot to cold.
 // TODO - How did copying from genesis worked in the prod migration to split storage?
 pub fn test_cold_genesis_update(cold_db: &ColdDB, hot_store: &Store) -> io::Result<()> {
-    let mut store_with_cache = StoreWithCache { store: hot_store, cache: StoreCache::new() };
     for col in DBCol::iter() {
         if !col.is_cold() {
             continue;
@@ -317,7 +350,7 @@ pub fn test_cold_genesis_update(cold_db: &ColdDB, hot_store: &Store) -> io::Resu
         // specialized `copy_state_from_store`.
         copy_from_store(
             cold_db,
-            &mut store_with_cache,
+            &hot_store,
             col,
             hot_store.iter(col).map(|x| x.unwrap().0.to_vec()).collect(),
         )?;
@@ -342,19 +375,19 @@ pub fn test_get_store_initial_writes(column: DBCol) -> u64 {
 /// For BlockHash it is just one key -- block hash of that height.
 /// But for TransactionHash, for example, it is all of the tx hashes in that block.
 fn get_keys_from_store(
-    store: &mut StoreWithCache,
+    store: &Store,
     shard_layout: &ShardLayout,
     height_key: &[u8],
     block_hash_key: &[u8],
 ) -> io::Result<HashMap<DBKeyType, Vec<StoreKey>>> {
     let mut key_type_to_keys = HashMap::new();
 
-    let block: Block = store.get_ser_or_err(DBCol::Block, &block_hash_key)?;
+    let block: Block = store.get_ser_or_err_for_cold(DBCol::Block, &block_hash_key)?;
     let chunks = block
         .chunks()
         .iter()
         .map(|chunk_header| {
-            store.get_ser_or_err(DBCol::Chunks, chunk_header.chunk_hash().as_bytes())
+            store.get_ser_or_err_for_cold(DBCol::Chunks, chunk_header.chunk_hash().as_bytes())
         })
         .collect::<io::Result<Vec<ShardChunk>>>()?;
 
@@ -386,7 +419,7 @@ fn get_keys_from_store(
                 // TODO: write StateChanges values to colddb directly, not to cache.
                 DBKeyType::TrieKey => {
                     let mut keys = vec![];
-                    store.iter_prefix_with_callback(
+                    store.iter_prefix_with_callback_for_cold(
                         DBCol::StateChanges,
                         &block_hash_key,
                         |full_key| {
@@ -497,68 +530,50 @@ where
     }
 }
 
-impl StoreWithCache<'_> {
-    pub fn iter_prefix_with_callback(
-        &mut self,
+impl ColdMigrationStore for Store {
+    fn iter_prefix_with_callback_for_cold(
+        &self,
         col: DBCol,
         key_prefix: &[u8],
         mut callback: impl FnMut(Box<[u8]>),
     ) -> io::Result<()> {
-        for iter_result in self.store.iter_prefix(col, key_prefix) {
-            let (key, value) = iter_result?;
-            self.cache.insert((col, key.to_vec()), Some(value.into()));
+        for iter_result in self.iter_prefix(col, key_prefix) {
+            crate::metrics::COLD_MIGRATION_READS.with_label_values(&[<&str>::from(col)]).inc();
+            let (key, _) = iter_result?;
             callback(key);
         }
         Ok(())
     }
 
-    pub fn get(&mut self, column: DBCol, key: &[u8]) -> io::Result<StoreValue> {
-        if !self.cache.contains_key(&(column, key.to_vec())) {
-            crate::metrics::COLD_MIGRATION_READS.with_label_values(&[<&str>::from(column)]).inc();
-            self.cache.insert(
-                (column, key.to_vec()),
-                self.store.get(column, key)?.map(|x| x.as_slice().to_vec()),
-            );
-        }
-        Ok(self.cache[&(column, key.to_vec())].clone())
+    fn get_for_cold(&self, column: DBCol, key: &[u8]) -> io::Result<StoreValue> {
+        crate::metrics::COLD_MIGRATION_READS.with_label_values(&[<&str>::from(column)]).inc();
+        Ok(self.get(column, key)?.map(|x| x.as_slice().to_vec()))
     }
 
-    pub fn get_ser<T: BorshDeserialize>(
-        &mut self,
+    fn get_ser_for_cold<T: BorshDeserialize>(
+        &self,
         column: DBCol,
         key: &[u8],
     ) -> io::Result<Option<T>> {
-        match self.get(column, key)? {
+        match self.get_for_cold(column, key)? {
             Some(bytes) => Ok(Some(T::try_from_slice(&bytes)?)),
             None => Ok(None),
         }
     }
 
-    pub fn get_or_err(&mut self, column: DBCol, key: &[u8]) -> io::Result<Vec<u8>> {
-        option_to_not_found(self.get(column, key), format_args!("{:?}: {:?}", column, key))
+    fn get_or_err_for_cold(&self, column: DBCol, key: &[u8]) -> io::Result<Vec<u8>> {
+        option_to_not_found(self.get_for_cold(column, key), format_args!("{:?}: {:?}", column, key))
     }
 
-    pub fn get_ser_or_err<T: BorshDeserialize>(
-        &mut self,
+    fn get_ser_or_err_for_cold<T: BorshDeserialize>(
+        &self,
         column: DBCol,
         key: &[u8],
     ) -> io::Result<T> {
-        option_to_not_found(self.get_ser(column, key), format_args!("{:?}: {:?}", column, key))
-    }
-
-    pub fn insert_state_to_cache_from_op(
-        &mut self,
-        op: &TrieRefcountAddition,
-        shard_uid_key: &[u8],
-    ) {
-        debug_assert_eq!(
-            DBCol::State.key_type(),
-            &[DBKeyType::ShardUId, DBKeyType::TrieNodeOrValueHash]
-        );
-        self.cache.insert(
-            (DBCol::State, join_two_keys(shard_uid_key, op.hash().as_bytes())),
-            Some(op.payload().to_vec()),
-        );
+        option_to_not_found(
+            self.get_ser_for_cold(column, key),
+            format_args!("{:?}: {:?}", column, key),
+        )
     }
 }
 

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -112,9 +112,6 @@ pub struct StoreConfig {
 
     // TODO (#9989): To be phased out in favor of state_snapshot_config
     pub state_snapshot_enabled: bool,
-
-    // TODO (#9989): To be phased out in favor of state_snapshot_config
-    pub state_snapshot_compaction_enabled: bool,
 }
 
 /// Config used to control state snapshot creation. This is used for state sync and resharding.
@@ -122,11 +119,6 @@ pub struct StoreConfig {
 #[serde(default)]
 pub struct StateSnapshotConfig {
     pub state_snapshot_type: StateSnapshotType,
-    /// State Snapshot compaction usually is a good thing but is heavy on IO and can take considerable
-    /// amount of time.
-    /// It makes state snapshots tiny (10GB) over the course of an epoch.
-    /// We may want to disable it for archival nodes during resharding
-    pub compaction_enabled: bool,
 }
 
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
@@ -304,9 +296,6 @@ impl Default for StoreConfig {
 
             // TODO: To be phased out in favor of state_snapshot_config
             state_snapshot_enabled: false,
-
-            // TODO: To be phased out in favor of state_snapshot_config
-            state_snapshot_compaction_enabled: false,
         }
     }
 }

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -240,17 +240,24 @@ impl Default for StoreConfig {
             block_size: bytesize::ByteSize::kib(16),
 
             trie_cache: TrieCacheConfig {
-                default_max_bytes: DEFAULT_SHARD_CACHE_TOTAL_SIZE_LIMIT,
-                // Temporary solution to make contracts with heavy trie access
-                // patterns on shard 3 more stable. It was chosen by the estimation
-                // of the largest contract storage size we are aware as of 23/08/2022.
-                // Consider removing after implementing flat storage. (#7327)
-                // Note: on >= 1.34 nearcore version use 1_000_000_000 if you have
-                // minimal hardware.
-                per_shard_max_bytes: HashMap::from_iter([(
-                    ShardUId { version: 1, shard_id: 3 },
-                    3_000_000_000,
-                )]),
+                default_max_bytes: 500_000_000,
+                // TODO(resharding) The cache size needs to adjusted for every resharding.
+                // Make that automatic e.g. by defining the minimum cache size per account rather than shard.
+                per_shard_max_bytes: HashMap::from_iter([
+                    // Temporary solution to make contracts with heavy trie access
+                    // patterns on shard 3 more stable. It was chosen by the estimation
+                    // of the largest contract storage size we are aware as of 23/08/2022.
+                    // Note: on >= 1.34 nearcore version use 1_000_000_000 if you have
+                    // minimal hardware.
+                    // In simple nightshade the heavy contract "token.sweat" is in shard 3
+                    (ShardUId { version: 1, shard_id: 3 }, 3_000_000_000),
+                    // In simple nightshade v2 the heavy contract "token.sweat" is in shard 4
+                    (ShardUId { version: 2, shard_id: 4 }, 3_000_000_000),
+                    // Shard 1 is dedicated to aurora and it had very few cache
+                    // misses even with cache size of only 50MB
+                    (ShardUId { version: 1, shard_id: 1 }, 50_000_000),
+                    (ShardUId { version: 2, shard_id: 1 }, 50_000_000),
+                ]),
                 shard_cache_deletions_queue_capacity: DEFAULT_SHARD_CACHE_DELETIONS_QUEUE_CAPACITY,
             },
 

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -253,10 +253,13 @@ impl Default for StoreConfig {
                     (ShardUId { version: 1, shard_id: 3 }, 3_000_000_000),
                     // In simple nightshade v2 the heavy contract "token.sweat" is in shard 4
                     (ShardUId { version: 2, shard_id: 4 }, 3_000_000_000),
+                    // In simple nightshade v3 the heavy contract "token.sweat" is in shard 5
+                    (ShardUId { version: 3, shard_id: 5 }, 3_000_000_000),
                     // Shard 1 is dedicated to aurora and it had very few cache
                     // misses even with cache size of only 50MB
                     (ShardUId { version: 1, shard_id: 1 }, 50_000_000),
                     (ShardUId { version: 2, shard_id: 1 }, 50_000_000),
+                    (ShardUId { version: 3, shard_id: 1 }, 50_000_000),
                 ]),
                 shard_cache_deletions_queue_capacity: DEFAULT_SHARD_CACHE_DELETIONS_QUEUE_CAPACITY,
             },

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -229,7 +229,11 @@ pub trait Database: Sync + Send {
     fn get_store_statistics(&self) -> Option<StoreStatistics>;
 
     /// Create checkpoint in provided path
-    fn create_checkpoint(&self, path: &std::path::Path) -> anyhow::Result<()>;
+    fn create_checkpoint(
+        &self,
+        path: &std::path::Path,
+        columns_to_keep: Option<&[DBCol]>,
+    ) -> anyhow::Result<()>;
 }
 
 fn assert_no_overwrite(col: DBCol, key: &[u8], value: &[u8], old_value: &[u8]) {

--- a/core/store/src/db/colddb.rs
+++ b/core/store/src/db/colddb.rs
@@ -111,8 +111,12 @@ impl Database for ColdDB {
         self.cold.get_store_statistics()
     }
 
-    fn create_checkpoint(&self, path: &std::path::Path) -> anyhow::Result<()> {
-        self.cold.create_checkpoint(path)
+    fn create_checkpoint(
+        &self,
+        path: &std::path::Path,
+        columns_to_keep: Option<&[DBCol]>,
+    ) -> anyhow::Result<()> {
+        self.cold.create_checkpoint(path, columns_to_keep)
     }
 }
 

--- a/core/store/src/db/splitdb.rs
+++ b/core/store/src/db/splitdb.rs
@@ -198,7 +198,11 @@ impl Database for SplitDB {
         None
     }
 
-    fn create_checkpoint(&self, _path: &std::path::Path) -> anyhow::Result<()> {
+    fn create_checkpoint(
+        &self,
+        _path: &std::path::Path,
+        _columns_to_keep: Option<&[DBCol]>,
+    ) -> anyhow::Result<()> {
         log_assert_fail!("create_checkpoint is not allowed - the split storage has two stores");
         Ok(())
     }

--- a/core/store/src/db/testdb.rs
+++ b/core/store/src/db/testdb.rs
@@ -128,7 +128,11 @@ impl Database for TestDB {
         self.stats.read().unwrap().clone()
     }
 
-    fn create_checkpoint(&self, _path: &std::path::Path) -> anyhow::Result<()> {
+    fn create_checkpoint(
+        &self,
+        _path: &std::path::Path,
+        _columns_to_keep: Option<&[DBCol]>,
+    ) -> anyhow::Result<()> {
         Ok(())
     }
 }

--- a/core/store/src/flat/manager.rs
+++ b/core/store/src/flat/manager.rs
@@ -64,19 +64,25 @@ impl FlatStorageManager {
         );
     }
 
-    /// Creates flat storage instance for shard `shard_uid`. The function also checks that
-    /// the shard's flat storage state hasn't been set before, otherwise it panics.
+    /// Creates flat storage instance for shard `shard_uid`. This function
+    /// allows creating flat storage if it already exists even though it's not
+    /// desired. It needs to allow that to cover a resharding restart case.
     /// TODO (#7327): this behavior may change when we implement support for state sync
     /// and resharding.
     pub fn create_flat_storage_for_shard(&self, shard_uid: ShardUId) -> Result<(), StorageError> {
         tracing::debug!(target: "store", ?shard_uid, "Creating flat storage for shard");
         let mut flat_storages = self.0.flat_storages.lock().expect(POISONED_LOCK_ERR);
-        let original_value =
-            flat_storages.insert(shard_uid, FlatStorage::new(self.0.store.clone(), shard_uid)?);
-        // TODO (#7327): maybe we should propagate the error instead of assert here
-        // assert is fine now because this function is only called at construction time, but we
-        // will need to be more careful when we want to implement flat storage for resharding
-        assert!(original_value.is_none());
+        let flat_storage = FlatStorage::new(self.0.store.clone(), shard_uid)?;
+        let original_value = flat_storages.insert(shard_uid, flat_storage);
+        if original_value.is_some() {
+            // Generally speaking this shouldn't happen. It may only happen when
+            // the node is restarted in the middle of resharding.
+            //
+            // TODO(resharding) It would be better to detect when building state
+            // is finished for a shard and skip doing it again after restart. We
+            // can then assert that the flat storage is only created once.
+            tracing::warn!(target: "store", ?shard_uid, "Creating flat storage for shard that already has flat storage.");
+        }
         Ok(())
     }
 

--- a/core/store/src/flat/metrics.rs
+++ b/core/store/src/flat/metrics.rs
@@ -1,6 +1,6 @@
 use crate::metrics::flat_state_metrics;
 use near_o11y::metrics::{IntCounter, IntGauge};
-use near_primitives::types::{BlockHeight, ShardId};
+use near_primitives::{shard_layout::ShardUId, types::BlockHeight};
 
 use super::FlatStorageStatus;
 
@@ -14,21 +14,21 @@ pub(crate) struct FlatStorageMetrics {
 }
 
 impl FlatStorageMetrics {
-    pub(crate) fn new(shard_id: ShardId) -> Self {
-        let shard_id_label = shard_id.to_string();
+    pub(crate) fn new(shard_uid: ShardUId) -> Self {
+        let shard_uid_label = shard_uid.to_string();
         Self {
             flat_head_height: flat_state_metrics::FLAT_STORAGE_HEAD_HEIGHT
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
             distance_to_head: flat_state_metrics::FLAT_STORAGE_DISTANCE_TO_HEAD
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
             hops_to_head: flat_state_metrics::FLAT_STORAGE_HOPS_TO_HEAD
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
             cached_deltas: flat_state_metrics::FLAT_STORAGE_CACHED_DELTAS
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
             cached_changes_num_items: flat_state_metrics::FLAT_STORAGE_CACHED_CHANGES_NUM_ITEMS
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
             cached_changes_size: flat_state_metrics::FLAT_STORAGE_CACHED_CHANGES_SIZE
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
         }
     }
 
@@ -64,21 +64,21 @@ pub struct FlatStorageCreationMetrics {
 }
 
 impl FlatStorageCreationMetrics {
-    pub fn new(shard_id: ShardId) -> Self {
-        let shard_id_label = shard_id.to_string();
+    pub fn new(shard_uid: ShardUId) -> Self {
+        let shard_uid_label = shard_uid.to_string();
         Self {
             status: flat_state_metrics::FLAT_STORAGE_CREATION_STATUS
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
             flat_head_height: flat_state_metrics::FLAT_STORAGE_HEAD_HEIGHT
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
             remaining_state_parts: flat_state_metrics::FLAT_STORAGE_CREATION_REMAINING_STATE_PARTS
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
             fetched_state_parts: flat_state_metrics::FLAT_STORAGE_CREATION_FETCHED_STATE_PARTS
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
             fetched_state_items: flat_state_metrics::FLAT_STORAGE_CREATION_FETCHED_STATE_ITEMS
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
             threads_used: flat_state_metrics::FLAT_STORAGE_CREATION_THREADS_USED
-                .with_label_values(&[&shard_id_label]),
+                .with_label_values(&[&shard_uid_label]),
         }
     }
 

--- a/core/store/src/flat/storage.rs
+++ b/core/store/src/flat/storage.rs
@@ -415,11 +415,10 @@ impl FlatStorage {
     pub fn add_delta(&self, delta: FlatStateDelta) -> Result<StoreUpdate, FlatStorageError> {
         let mut guard = self.0.write().expect(super::POISONED_LOCK_ERR);
         let shard_uid = guard.shard_uid;
-        let shard_id = shard_uid.shard_id();
         let block = &delta.metadata.block;
         let block_hash = block.hash;
         let block_height = block.height;
-        debug!(target: "store", %shard_id, %block_hash, %block_height, "Adding block to flat storage");
+        debug!(target: "store", %shard_uid, %block_hash, %block_height, "Adding block to flat storage");
         if block.prev_hash != guard.flat_head.hash && !guard.deltas.contains_key(&block.prev_hash) {
             return Err(guard.create_block_not_supported_error(&block_hash));
         }

--- a/core/store/src/flat/storage.rs
+++ b/core/store/src/flat/storage.rs
@@ -245,7 +245,7 @@ impl FlatStorage {
                 )));
             }
         };
-        let metrics = FlatStorageMetrics::new(shard_id);
+        let metrics = FlatStorageMetrics::new(shard_uid);
         metrics.set_flat_head_height(flat_head.height);
 
         let deltas_metadata = store_helper::get_all_deltas_metadata(&store, shard_uid)

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -37,6 +37,7 @@ pub use crate::trie::{
     PartialStorage, PrefetchApi, PrefetchError, RawTrieNode, RawTrieNodeWithSize, ShardTries,
     StateSnapshot, StateSnapshotConfig, Trie, TrieAccess, TrieCache, TrieCachingStorage,
     TrieChanges, TrieConfig, TrieDBStorage, TrieStorage, WrappedTrieChanges,
+    STATE_SNAPSHOT_COLUMNS,
 };
 
 pub mod cold_storage;

--- a/core/store/src/metrics.rs
+++ b/core/store/src/metrics.rs
@@ -393,7 +393,7 @@ pub mod flat_state_metrics {
         try_create_int_gauge_vec(
             "flat_storage_creation_status",
             "Integer representing status of flat storage creation",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });
@@ -401,7 +401,7 @@ pub mod flat_state_metrics {
         try_create_int_gauge_vec(
             "flat_storage_creation_remaining_state_parts",
             "Number of remaining state parts to fetch to fill flat storage in bytes",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });
@@ -409,7 +409,7 @@ pub mod flat_state_metrics {
         try_create_int_counter_vec(
             "flat_storage_creation_fetched_state_parts",
             "Number of fetched state parts to fill flat storage in bytes",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });
@@ -417,7 +417,7 @@ pub mod flat_state_metrics {
         try_create_int_counter_vec(
             "flat_storage_creation_fetched_state_items",
             "Number of fetched items to fill flat storage",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });
@@ -425,7 +425,7 @@ pub mod flat_state_metrics {
         try_create_int_gauge_vec(
             "flat_storage_creation_threads_used",
             "Number of currently used threads to fetch state",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });
@@ -433,7 +433,7 @@ pub mod flat_state_metrics {
         try_create_int_gauge_vec(
             "flat_storage_head_height",
             "Height of flat storage head",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });
@@ -441,7 +441,7 @@ pub mod flat_state_metrics {
         try_create_int_gauge_vec(
             "flat_storage_cached_deltas",
             "Number of cached deltas in flat storage",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });
@@ -449,7 +449,7 @@ pub mod flat_state_metrics {
         try_create_int_gauge_vec(
             "flat_storage_cached_changes_num_items",
             "Number of items in all cached changes in flat storage",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });
@@ -457,7 +457,7 @@ pub mod flat_state_metrics {
         try_create_int_gauge_vec(
             "flat_storage_cached_changes_size",
             "Total size of cached changes in flat storage",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });
@@ -465,7 +465,7 @@ pub mod flat_state_metrics {
         try_create_int_gauge_vec(
             "flat_storage_distance_to_head",
             "Height distance between processed block and flat storage head",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });
@@ -473,7 +473,7 @@ pub mod flat_state_metrics {
         try_create_int_gauge_vec(
             "flat_storage_hops_to_head",
             "Number of blocks visited to flat storage head",
-            &["shard_id"],
+            &["shard_uid"],
         )
         .unwrap()
     });

--- a/core/store/src/metrics.rs
+++ b/core/store/src/metrics.rs
@@ -262,15 +262,6 @@ pub(crate) static DELETE_STATE_SNAPSHOT_ELAPSED: Lazy<Histogram> = Lazy::new(|| 
     .unwrap()
 });
 
-pub(crate) static COMPACT_STATE_SNAPSHOT_ELAPSED: Lazy<Histogram> = Lazy::new(|| {
-    try_create_histogram_with_buckets(
-        "near_compact_state_snapshot_elapsed_sec",
-        "Latency of compaction of a state snapshot, in seconds",
-        exponential_buckets(0.001, 1.6, 40).unwrap(),
-    )
-    .unwrap()
-});
-
 pub(crate) static MOVE_STATE_SNAPSHOT_FLAT_HEAD_ELAPSED: Lazy<HistogramVec> = Lazy::new(|| {
     try_create_histogram_vec(
         "near_move_state_snapshot_flat_head_elapsed_sec",

--- a/core/store/src/metrics.rs
+++ b/core/store/src/metrics.rs
@@ -391,7 +391,7 @@ pub mod flat_state_metrics {
 
     pub static FLAT_STORAGE_CREATION_STATUS: Lazy<IntGaugeVec> = Lazy::new(|| {
         try_create_int_gauge_vec(
-            "flat_storage_creation_status",
+            "near_flat_storage_creation_status",
             "Integer representing status of flat storage creation",
             &["shard_uid"],
         )
@@ -399,7 +399,7 @@ pub mod flat_state_metrics {
     });
     pub static FLAT_STORAGE_CREATION_REMAINING_STATE_PARTS: Lazy<IntGaugeVec> = Lazy::new(|| {
         try_create_int_gauge_vec(
-            "flat_storage_creation_remaining_state_parts",
+            "near_flat_storage_creation_remaining_state_parts",
             "Number of remaining state parts to fetch to fill flat storage in bytes",
             &["shard_uid"],
         )
@@ -407,7 +407,7 @@ pub mod flat_state_metrics {
     });
     pub static FLAT_STORAGE_CREATION_FETCHED_STATE_PARTS: Lazy<IntCounterVec> = Lazy::new(|| {
         try_create_int_counter_vec(
-            "flat_storage_creation_fetched_state_parts",
+            "near_flat_storage_creation_fetched_state_parts",
             "Number of fetched state parts to fill flat storage in bytes",
             &["shard_uid"],
         )
@@ -415,7 +415,7 @@ pub mod flat_state_metrics {
     });
     pub static FLAT_STORAGE_CREATION_FETCHED_STATE_ITEMS: Lazy<IntCounterVec> = Lazy::new(|| {
         try_create_int_counter_vec(
-            "flat_storage_creation_fetched_state_items",
+            "near_flat_storage_creation_fetched_state_items",
             "Number of fetched items to fill flat storage",
             &["shard_uid"],
         )
@@ -423,7 +423,7 @@ pub mod flat_state_metrics {
     });
     pub static FLAT_STORAGE_CREATION_THREADS_USED: Lazy<IntGaugeVec> = Lazy::new(|| {
         try_create_int_gauge_vec(
-            "flat_storage_creation_threads_used",
+            "near_flat_storage_creation_threads_used",
             "Number of currently used threads to fetch state",
             &["shard_uid"],
         )
@@ -431,7 +431,7 @@ pub mod flat_state_metrics {
     });
     pub static FLAT_STORAGE_HEAD_HEIGHT: Lazy<IntGaugeVec> = Lazy::new(|| {
         try_create_int_gauge_vec(
-            "flat_storage_head_height",
+            "near_flat_storage_head_height",
             "Height of flat storage head",
             &["shard_uid"],
         )
@@ -439,7 +439,7 @@ pub mod flat_state_metrics {
     });
     pub static FLAT_STORAGE_CACHED_DELTAS: Lazy<IntGaugeVec> = Lazy::new(|| {
         try_create_int_gauge_vec(
-            "flat_storage_cached_deltas",
+            "near_flat_storage_cached_deltas",
             "Number of cached deltas in flat storage",
             &["shard_uid"],
         )
@@ -447,7 +447,7 @@ pub mod flat_state_metrics {
     });
     pub static FLAT_STORAGE_CACHED_CHANGES_NUM_ITEMS: Lazy<IntGaugeVec> = Lazy::new(|| {
         try_create_int_gauge_vec(
-            "flat_storage_cached_changes_num_items",
+            "near_flat_storage_cached_changes_num_items",
             "Number of items in all cached changes in flat storage",
             &["shard_uid"],
         )
@@ -455,7 +455,7 @@ pub mod flat_state_metrics {
     });
     pub static FLAT_STORAGE_CACHED_CHANGES_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
         try_create_int_gauge_vec(
-            "flat_storage_cached_changes_size",
+            "near_flat_storage_cached_changes_size",
             "Total size of cached changes in flat storage",
             &["shard_uid"],
         )
@@ -463,7 +463,7 @@ pub mod flat_state_metrics {
     });
     pub static FLAT_STORAGE_DISTANCE_TO_HEAD: Lazy<IntGaugeVec> = Lazy::new(|| {
         try_create_int_gauge_vec(
-            "flat_storage_distance_to_head",
+            "near_flat_storage_distance_to_head",
             "Height distance between processed block and flat storage head",
             &["shard_uid"],
         )
@@ -471,7 +471,7 @@ pub mod flat_state_metrics {
     });
     pub static FLAT_STORAGE_HOPS_TO_HEAD: Lazy<IntGaugeVec> = Lazy::new(|| {
         try_create_int_gauge_vec(
-            "flat_storage_hops_to_head",
+            "near_flat_storage_hops_to_head",
             "Number of blocks visited to flat storage head",
             &["shard_uid"],
         )

--- a/core/store/src/opener.rs
+++ b/core/store/src/opener.rs
@@ -3,7 +3,6 @@ use crate::db::rocksdb::RocksDB;
 use crate::metadata::{DbKind, DbMetadata, DbVersion, DB_VERSION};
 use crate::{DBCol, DBTransaction, Mode, NodeStorage, Store, StoreConfig, Temperature};
 use std::sync::Arc;
-use strum::IntoEnumIterator;
 
 #[derive(Debug, thiserror::Error)]
 pub enum StoreOpenerError {
@@ -586,7 +585,7 @@ pub trait StoreMigrator {
 pub fn checkpoint_hot_storage_and_cleanup_columns(
     hot_store: &Store,
     checkpoint_base_path: &std::path::Path,
-    columns_to_keep: Option<Vec<DBCol>>,
+    columns_to_keep: Option<&[DBCol]>,
 ) -> Result<NodeStorage, StoreOpenerError> {
     let _span =
         tracing::info_span!(target: "state_snapshot", "checkpoint_hot_storage_and_cleanup_columns")
@@ -596,7 +595,7 @@ pub fn checkpoint_hot_storage_and_cleanup_columns(
 
     hot_store
         .storage
-        .create_checkpoint(&checkpoint_path)
+        .create_checkpoint(&checkpoint_path, columns_to_keep)
         .map_err(StoreOpenerError::CheckpointError)?;
 
     // As only path from config is used in StoreOpener, default config with custom path will do.
@@ -604,11 +603,11 @@ pub fn checkpoint_hot_storage_and_cleanup_columns(
     config.path = Some(checkpoint_path);
     let archive = hot_store.get_db_kind()? == Some(DbKind::Archive);
     let opener = StoreOpener::new(checkpoint_base_path, archive, &config, None);
+    // This will create all the column families that were dropped by create_checkpoint(),
+    // but all the data and associated files that were in them previously should be gone.
     let node_storage = opener.open_in_mode(Mode::ReadWriteExisting)?;
 
-    if let Some(columns_to_keep) = columns_to_keep {
-        let columns_to_keep_set: std::collections::HashSet<DBCol> =
-            std::collections::HashSet::from_iter(columns_to_keep.into_iter());
+    if columns_to_keep.is_some() {
         let mut transaction = DBTransaction::new();
         // Force the checkpoint to be a Hot DB kind to simplify opening the snapshots later.
         transaction.set(
@@ -617,15 +616,7 @@ pub fn checkpoint_hot_storage_and_cleanup_columns(
             <&str>::from(DbKind::RPC).as_bytes().to_vec(),
         );
 
-        for col in DBCol::iter() {
-            if !columns_to_keep_set.contains(&col) {
-                transaction.delete_all(col);
-            }
-        }
-
-        tracing::debug!(target: "state_snapshot", ?transaction, "Transaction ready");
         node_storage.hot_storage.write(transaction)?;
-        tracing::debug!(target: "state_snapshot", "Transaction written");
     }
 
     Ok(node_storage)
@@ -673,7 +664,7 @@ mod tests {
         let store = checkpoint_hot_storage_and_cleanup_columns(
             &hot_store,
             &home_dir.path().join(PathBuf::from("checkpoint_some")),
-            Some(vec![DBCol::Block]),
+            Some(&[DBCol::Block]),
         )
         .unwrap();
         check_keys_existence(&store.get_hot_store(), &DBCol::Block, &keys, true);
@@ -683,7 +674,7 @@ mod tests {
         let store = checkpoint_hot_storage_and_cleanup_columns(
             &hot_store,
             &home_dir.path().join(PathBuf::from("checkpoint_all")),
-            Some(vec![DBCol::Block, DBCol::Chunks, DBCol::BlockHeader]),
+            Some(&[DBCol::Block, DBCol::Chunks, DBCol::BlockHeader]),
         )
         .unwrap();
         check_keys_existence(&store.get_hot_store(), &DBCol::Block, &keys, true);
@@ -693,7 +684,7 @@ mod tests {
         let store = checkpoint_hot_storage_and_cleanup_columns(
             &hot_store,
             &home_dir.path().join(PathBuf::from("checkpoint_empty")),
-            Some(vec![]),
+            Some(&[]),
         )
         .unwrap();
         check_keys_existence(&store.get_hot_store(), &DBCol::Block, &keys, false);

--- a/core/store/src/opener.rs
+++ b/core/store/src/opener.rs
@@ -147,7 +147,7 @@ fn is_valid_kind_archive(kind: DbKind, archive: bool) -> bool {
     match (kind, archive) {
         (DbKind::Archive, true) => true,
         (DbKind::Cold, true) => true,
-        (DbKind::Hot, true) => true,
+        (DbKind::Hot, _) => true,
         (DbKind::RPC, _) => true,
         _ => false,
     }
@@ -647,6 +647,7 @@ mod tests {
         let (home_dir, opener) = NodeStorage::test_opener();
         let node_storage = opener.open().unwrap();
         let hot_store = Store { storage: node_storage.hot_storage.clone() };
+        assert_eq!(hot_store.get_db_kind().unwrap(), Some(DbKind::RPC));
 
         let keys = vec![vec![0], vec![1], vec![2], vec![3]];
         let columns = vec![DBCol::Block, DBCol::Chunks, DBCol::BlockHeader];

--- a/core/store/src/trie/config.rs
+++ b/core/store/src/trie/config.rs
@@ -7,9 +7,9 @@ use tracing::error;
 
 /// Default memory limit, if nothing else is configured.
 /// It is chosen to correspond roughly to the old limit, which was
-/// 500k entries * TRIE_LIMIT_CACHED_VALUE_SIZE.
+/// 50k entries * TRIE_LIMIT_CACHED_VALUE_SIZE.
 pub(crate) const DEFAULT_SHARD_CACHE_TOTAL_SIZE_LIMIT: u64 =
-    if cfg!(feature = "no_cache") { 1 } else { 500_000_000 };
+    if cfg!(feature = "no_cache") { 1 } else { 50_000_000 };
 
 /// Capacity for the deletions queue.
 /// It is chosen to fit all hashes of deleted nodes for 3 completely full blocks.

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -14,7 +14,9 @@ use crate::trie::iterator::TrieIterator;
 pub use crate::trie::nibble_slice::NibbleSlice;
 pub use crate::trie::prefetching_trie_storage::{PrefetchApi, PrefetchError};
 pub use crate::trie::shard_tries::{KeyForStateChanges, ShardTries, WrappedTrieChanges};
-pub use crate::trie::state_snapshot::{SnapshotError, StateSnapshot, StateSnapshotConfig};
+pub use crate::trie::state_snapshot::{
+    SnapshotError, StateSnapshot, StateSnapshotConfig, STATE_SNAPSHOT_COLUMNS,
+};
 pub use crate::trie::trie_storage::{TrieCache, TrieCachingStorage, TrieDBStorage, TrieStorage};
 use crate::StorageError;
 use borsh::{BorshDeserialize, BorshSerialize};

--- a/core/store/src/trie/state_snapshot.rs
+++ b/core/store/src/trie/state_snapshot.rs
@@ -137,8 +137,18 @@ pub struct StateSnapshotConfig {
     pub home_dir: PathBuf,
     pub hot_store_path: PathBuf,
     pub state_snapshot_subdir: PathBuf,
-    pub compaction_enabled: bool,
 }
+
+pub const STATE_SNAPSHOT_COLUMNS: &[DBCol] = &[
+    // Keep DbVersion and BlockMisc, otherwise you'll not be able to open the state snapshot as a Store.
+    DBCol::DbVersion,
+    DBCol::BlockMisc,
+    // Flat storage columns.
+    DBCol::FlatState,
+    DBCol::FlatStateChanges,
+    DBCol::FlatStateDeltaMetadata,
+    DBCol::FlatStorageStatus,
+];
 
 impl ShardTries {
     pub fn get_state_snapshot(
@@ -198,16 +208,7 @@ impl ShardTries {
             ),
             // TODO: Cleanup Changes and DeltaMetadata to avoid extra memory usage.
             // Can't be cleaned up now because these columns are needed to `update_flat_head()`.
-            Some(vec![
-                // Keep DbVersion and BlockMisc, otherwise you'll not be able to open the state snapshot as a Store.
-                DBCol::DbVersion,
-                DBCol::BlockMisc,
-                // Flat storage columns.
-                DBCol::FlatState,
-                DBCol::FlatStateChanges,
-                DBCol::FlatStateDeltaMetadata,
-                DBCol::FlatStorageStatus,
-            ]),
+            Some(STATE_SNAPSHOT_COLUMNS),
         )?;
         let store = storage.get_hot_store();
         // It is fine to create a separate FlatStorageManager, because
@@ -238,21 +239,6 @@ impl ShardTries {
         metrics::HAS_STATE_SNAPSHOT.set(1);
         tracing::info!(target: "state_snapshot", ?prev_block_hash, "Made a checkpoint");
         Ok(Some(state_snapshot_lock.as_ref().unwrap().get_shard_uids()))
-    }
-
-    /// Runs compaction on the snapshot.
-    pub fn compact_state_snapshot(&self) -> Result<(), anyhow::Error> {
-        let _span =
-            tracing::info_span!(target: "state_snapshot", "compact_state_snapshot").entered();
-        // It's fine if the access to state snapshot blocks.
-        let state_snapshot_lock = self.state_snapshot().read().unwrap();
-        if let Some(state_snapshot) = &*state_snapshot_lock {
-            let _timer = metrics::COMPACT_STATE_SNAPSHOT_ELAPSED.start_timer();
-            state_snapshot.store.compact()?;
-        } else {
-            tracing::error!(target: "state_snapshot", "Requested compaction but no state snapshot is available.");
-        };
-        Ok(())
     }
 
     /// Deletes all snapshots and unsets the STATE_SNAPSHOT_KEY.

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -94,7 +94,6 @@ fn test_storage_after_commit_of_cold_update() {
         .unwrap();
 
     let state_reads = test_get_store_reads(DBCol::State);
-    let state_changes_reads = test_get_store_reads(DBCol::StateChanges);
 
     for h in 1..max_height {
         let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
@@ -147,26 +146,17 @@ fn test_storage_after_commit_of_cold_update() {
         let block = env.clients[0].produce_block(h).unwrap().unwrap();
         env.process_block(0, block.clone(), Provenance::PRODUCED);
 
-        update_cold_db(
-            &*storage.cold_db().unwrap(),
-            &env.clients[0].runtime_adapter.store(),
-            &env.clients[0]
-                .epoch_manager
-                .get_shard_layout(
-                    &env.clients[0].epoch_manager.get_epoch_id_from_prev_block(&last_hash).unwrap(),
-                )
-                .unwrap(),
-            &h,
-        )
-        .unwrap();
+        let client = &env.clients[0];
+        let client_store = client.runtime_adapter.store();
+        let epoch_id = client.epoch_manager.get_epoch_id_from_prev_block(&last_hash).unwrap();
+        let shard_layout = client.epoch_manager.get_shard_layout(&epoch_id).unwrap();
+        update_cold_db(cold_db, &client_store, &shard_layout, &height, 4).unwrap();
 
         last_hash = *block.hash();
     }
 
     // assert that we don't read State from db, but from TrieChanges
     assert_eq!(state_reads, test_get_store_reads(DBCol::State));
-    // assert that we don't read StateChanges from db again after iter_prefix
-    assert_eq!(state_changes_reads, test_get_store_reads(DBCol::StateChanges));
 
     // We still need to filter out one chunk
     let mut no_check_rules: Vec<Box<dyn Fn(DBCol, &Box<[u8]>, &Box<[u8]>) -> bool>> = vec![];
@@ -319,18 +309,11 @@ fn test_cold_db_copy_with_height_skips() {
             }
         };
 
-        update_cold_db(
-            &*storage.cold_db().unwrap(),
-            &env.clients[0].runtime_adapter.store(),
-            &env.clients[0]
-                .epoch_manager
-                .get_shard_layout(
-                    &env.clients[0].epoch_manager.get_epoch_id_from_prev_block(&last_hash).unwrap(),
-                )
-                .unwrap(),
-            &h,
-        )
-        .unwrap();
+        let client = &env.clients[0];
+        let epoch_id = client.epoch_manager.get_epoch_id_from_prev_block(&last_hash).unwrap();
+        let shard_layout = client.epoch_manager.get_shard_layout(&epoch_id).unwrap();
+        update_cold_db(&cold_db, &client.runtime_adapter.store(), &shard_layout, &height, 1)
+            .unwrap();
 
         if block.is_some() {
             last_hash = *block.unwrap().hash();

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -1510,7 +1510,7 @@ fn test_archival_gc_common(
         blocks.push(block);
 
         if i <= max_cold_head_height {
-            update_cold_db(storage.cold_db().unwrap(), hot_store, &shard_layout, &i).unwrap();
+            update_cold_db(storage.cold_db().unwrap(), hot_store, &shard_layout, &i, 1).unwrap();
             update_cold_head(storage.cold_db().unwrap(), &hot_store, &i).unwrap();
         }
     }

--- a/integration-tests/src/tests/client/state_snapshot.rs
+++ b/integration-tests/src/tests/client/state_snapshot.rs
@@ -55,7 +55,6 @@ impl StateSnaptshotTestEnv {
             home_dir: home_dir.clone(),
             hot_store_path: hot_store_path.clone(),
             state_snapshot_subdir: state_snapshot_subdir.clone(),
-            compaction_enabled: true,
         };
         let shard_tries = ShardTries::new(
             store.clone(),

--- a/integration-tests/src/tests/client/sync_state_nodes.rs
+++ b/integration-tests/src/tests/client/sync_state_nodes.rs
@@ -454,7 +454,6 @@ fn sync_state_dump() {
                 credentials_file: None,
             });
             near1.config.store.state_snapshot_enabled = true;
-            near1.config.store.state_snapshot_compaction_enabled = false;
 
             let dir1 = tempfile::Builder::new().prefix("sync_nodes_1").tempdir().unwrap();
             let nearcore::NearNode {
@@ -738,7 +737,6 @@ fn test_state_sync_headers() {
             let dir1 =
                 tempfile::Builder::new().prefix("test_state_sync_headers").tempdir().unwrap();
             near1.config.store.state_snapshot_enabled = true;
-            near1.config.store.state_snapshot_compaction_enabled = false;
 
             let nearcore::NearNode { view_client: view_client1, .. } =
                 start_with_config(dir1.path(), near1).expect("start_with_config");
@@ -935,7 +933,6 @@ fn test_state_sync_headers_no_tracked_shards() {
                 .tempdir()
                 .unwrap();
             near1.config.store.state_snapshot_enabled = false;
-            near1.config.store.state_snapshot_compaction_enabled = false;
             near1.config.state_sync_enabled = false;
             near1.client_config.state_sync_enabled = false;
 
@@ -953,7 +950,6 @@ fn test_state_sync_headers_no_tracked_shards() {
                 .tempdir()
                 .unwrap();
             near2.config.store.state_snapshot_enabled = true;
-            near2.config.store.state_snapshot_compaction_enabled = false;
             near2.config.state_sync_enabled = false;
             near2.client_config.state_sync_enabled = false;
 

--- a/nearcore/src/cold_storage.rs
+++ b/nearcore/src/cold_storage.rs
@@ -55,6 +55,7 @@ fn cold_store_copy(
     cold_db: &Arc<ColdDB>,
     genesis_height: BlockHeight,
     epoch_manager: &EpochManagerHandle,
+    num_threads: usize,
 ) -> anyhow::Result<ColdStoreCopyResult> {
     // If COLD_HEAD is not set for hot storage we default it to genesis_height.
     let cold_head = cold_store.get_ser::<Tip>(DBCol::BlockMisc, HEAD_KEY)?;
@@ -107,7 +108,7 @@ fn cold_store_copy(
     let shard_layout = epoch_manager.get_shard_layout(&epoch_id)?;
 
     let mut next_height = cold_head_height + 1;
-    while !update_cold_db(cold_db, hot_store, &shard_layout, &next_height)? {
+    while !update_cold_db(cold_db, hot_store, &shard_layout, &next_height, num_threads)? {
         next_height += 1;
         if next_height > hot_final_head_height {
             return Err(anyhow::anyhow!(
@@ -266,8 +267,14 @@ fn cold_store_loop(
         }
 
         let instant = std::time::Instant::now();
-        let result =
-            cold_store_copy(&hot_store, &cold_store, &cold_db, genesis_height, epoch_manager);
+        let result = cold_store_copy(
+            &hot_store,
+            &cold_store,
+            &cold_db,
+            genesis_height,
+            epoch_manager,
+            split_storage_config.num_cold_store_read_threads,
+        );
         let duration = instant.elapsed();
 
         let result_string = cold_store_copy_result_to_string(&result);

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -376,6 +376,10 @@ fn default_cold_store_initial_migration_loop_sleep_duration() -> Duration {
     Duration::from_secs(30)
 }
 
+fn default_num_cold_store_read_threads() -> usize {
+    4
+}
+
 fn default_cold_store_loop_sleep_duration() -> Duration {
     Duration::from_secs(1)
 }
@@ -392,6 +396,9 @@ pub struct SplitStorageConfig {
 
     #[serde(default = "default_cold_store_loop_sleep_duration")]
     pub cold_store_loop_sleep_duration: Duration,
+
+    #[serde(default = "default_num_cold_store_read_threads")]
+    pub num_cold_store_read_threads: usize,
 }
 
 impl Default for SplitStorageConfig {
@@ -403,6 +410,7 @@ impl Default for SplitStorageConfig {
             cold_store_initial_migration_loop_sleep_duration:
                 default_cold_store_initial_migration_loop_sleep_duration(),
             cold_store_loop_sleep_duration: default_cold_store_loop_sleep_duration(),
+            num_cold_store_read_threads: default_num_cold_store_read_threads(),
         }
     }
 }

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -72,7 +72,7 @@ pub const MIN_BLOCK_PRODUCTION_DELAY: u64 = 600;
 /// Mainnet and testnet validators are configured with a different value due to
 /// performance values.
 pub const MAINNET_MIN_BLOCK_PRODUCTION_DELAY: u64 = 1_300;
-pub const TESTNET_MIN_BLOCK_PRODUCTION_DELAY: u64 = 1_000;
+pub const TESTNET_MIN_BLOCK_PRODUCTION_DELAY: u64 = 1_300;
 
 /// Maximum time to delay block production without approvals is ms.
 pub const MAX_BLOCK_PRODUCTION_DELAY: u64 = 2_000;
@@ -80,7 +80,7 @@ pub const MAX_BLOCK_PRODUCTION_DELAY: u64 = 2_000;
 /// Mainnet and testnet validators are configured with a different value due to
 /// performance values.
 pub const MAINNET_MAX_BLOCK_PRODUCTION_DELAY: u64 = 3_000;
-pub const TESTNET_MAX_BLOCK_PRODUCTION_DELAY: u64 = 2_500;
+pub const TESTNET_MAX_BLOCK_PRODUCTION_DELAY: u64 = 3_000;
 
 /// Maximum time until skipping the previous block is ms.
 pub const MAX_BLOCK_WAIT_DELAY: u64 = 6_000;

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -92,15 +92,11 @@ impl NightshadeRuntime {
         if config.config.store.state_snapshot_enabled {
             state_snapshot_type = StateSnapshotType::EveryEpoch;
         }
-        // TODO (#9989): directly use the new state snapshot config once the migration is done.
-        let compaction_enabled = config.config.store.state_snapshot_compaction_enabled
-            || config.config.store.state_snapshot_config.compaction_enabled;
         let state_snapshot_config = StateSnapshotConfig {
             state_snapshot_type,
             home_dir: home_dir.to_path_buf(),
             hot_store_path: config.config.store.path.clone().unwrap_or(PathBuf::from("data")),
             state_snapshot_subdir: PathBuf::from("state_snapshot"),
-            compaction_enabled,
         };
         Self::new(
             store,
@@ -187,7 +183,6 @@ impl NightshadeRuntime {
                 home_dir: home_dir.to_path_buf(),
                 hot_store_path: PathBuf::from("data"),
                 state_snapshot_subdir: PathBuf::from("state_snapshot"),
-                compaction_enabled: false,
             },
         )
     }
@@ -214,7 +209,6 @@ impl NightshadeRuntime {
                 home_dir: home_dir.to_path_buf(),
                 hot_store_path: PathBuf::from("data"),
                 state_snapshot_subdir: PathBuf::from("state_snapshot"),
-                compaction_enabled: false,
             },
         )
     }

--- a/nearcore/src/runtime/tests.rs
+++ b/nearcore/src/runtime/tests.rs
@@ -188,7 +188,6 @@ impl TestEnv {
                 home_dir: PathBuf::from(dir.path()),
                 hot_store_path: PathBuf::from("data"),
                 state_snapshot_subdir: PathBuf::from("state_snapshot"),
-                compaction_enabled: false,
             },
         );
         let state_roots = get_genesis_state_roots(&store).unwrap().unwrap();

--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -50,20 +50,6 @@ fn main() -> anyhow::Result<()> {
     openssl_probe::init_ssl_cert_env_vars();
     near_performance_metrics::process::schedule_printing_performance_stats(Duration::from_secs(60));
 
-    // The default FD soft limit in linux is 1024.
-    // We use more than that, for example we support up to 1000 TCP
-    // connections, using 5 FDs per each connection.
-    // We consider 65535 to be a reasonable limit for this binary,
-    // and we enforce it here. We also set the hard limit to the same value
-    // to prevent the inner logic from trying to bump it further:
-    // FD limit is a global variable, so it shouldn't be modified in an
-    // uncoordinated way.
-    //const FD_LIMIT: u64 = 65535;
-    //let (_, hard) = rlimit::Resource::NOFILE.get().context("rlimit::Resource::NOFILE::get()")?;
-    //rlimit::Resource::NOFILE.set(FD_LIMIT, FD_LIMIT).context(format!(
-    //    "couldn't set the file descriptor limit to {FD_LIMIT}, hard limit = {hard}"
-    //))?;
-
     // Retrieve FD_LIMIT from an environment variable with a default value of 65535.
     let fd_limit_default = 65535; // Default value
     let fd_limit_str = env::var("FD_LIMIT").unwrap_or_else(|_| fd_limit_default.to_string());

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -40,6 +40,7 @@ wasm-encoder.workspace = true
 wasmparser.workspace = true
 wasmtime = { workspace = true, optional = true }
 
+near-cache.workspace = true
 near-crypto.workspace = true
 near-primitives-core.workspace = true
 near-parameters.workspace = true

--- a/runtime/near-vm-runner/src/near_vm_runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner.rs
@@ -258,7 +258,7 @@ impl NearVM {
                 // that particular function call will be slower. Not to mention there isn't a
                 // strong guarantee on the upper bound of the memory that the contract runtime may
                 // require.
-                LimitedMemoryPool::new(8, 64 * 1024 * 1024).unwrap_or_else(|e| {
+                LimitedMemoryPool::new(256, 1 * 1024 * 1024).unwrap_or_else(|e| {
                     panic!("could not pre-allocate resources for the runtime: {e}");
                 })
             })
@@ -719,7 +719,12 @@ impl crate::runner::VM for NearVM {
     }
 }
 
-#[test]
-fn test_memory_like() {
-    crate::logic::test_utils::test_memory_like(|| Box::new(NearVmMemory::new(1, 1).unwrap()));
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_memory_like() {
+        crate::logic::test_utils::test_memory_like(|| {
+            Box::new(super::NearVmMemory::new(1, 1).unwrap())
+        });
+    }
 }

--- a/runtime/near-vm-runner/src/near_vm_runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner.rs
@@ -17,7 +17,7 @@ use near_parameters::vm::VMKind;
 use near_parameters::RuntimeFeesConfig;
 use near_vm_compiler_singlepass::Singlepass;
 use near_vm_engine::universal::{
-    LimitedMemoryPool, Universal, UniversalEngine, UniversalExecutable, UniversalExecutableRef,
+    Universal, UniversalEngine, UniversalExecutable, UniversalExecutableRef,
 };
 use near_vm_types::{FunctionIndex, InstanceConfig, MemoryType, Pages, WASM_PAGE_SIZE};
 use near_vm_vm::{
@@ -26,7 +26,7 @@ use near_vm_vm::{
 use std::borrow::Cow;
 use std::hash::Hash;
 use std::mem::size_of;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct NearVmMemory(Arc<LinearMemory>);
@@ -241,38 +241,11 @@ impl NearVM {
         compiler.set_9393_fix(!config.disable_9393_fix);
         // We only support universal engine at the moment.
         assert_eq!(VM_CONFIG.engine, NearVmEngine::Universal);
-
-        static CODE_MEMORY_POOL_CELL: OnceLock<LimitedMemoryPool> = OnceLock::new();
-        let code_memory_pool = CODE_MEMORY_POOL_CELL
-            .get_or_init(|| {
-                // FIXME: should have as many code memories as there are possible parallel
-                // invocations of the runtime… How do we determine that? Should we make it
-                // configurable for the node operators, perhaps, so that they can make an informed
-                // choice based on the amount of memory they have and shards they track? Should we
-                // actually use some sort of semaphore to enforce a parallelism limit?
-                //
-                // NB: 64MiB is a best guess as to what the maximum size a loaded artifact can
-                // plausibly be. This is not necessarily true – there may be WebAssembly
-                // instructions that expand by more than 4 times in terms of instruction size after
-                // a conversion to x86_64, In that case a re-allocation will occur and executing
-                // that particular function call will be slower. Not to mention there isn't a
-                // strong guarantee on the upper bound of the memory that the contract runtime may
-                // require.
-                LimitedMemoryPool::new(256, 1 * 1024 * 1024).unwrap_or_else(|e| {
-                    panic!("could not pre-allocate resources for the runtime: {e}");
-                })
-            })
-            .clone();
-
         let features =
             crate::features::WasmFeatures::from(config.limit_config.contract_prepare_version);
         Self {
             config,
-            engine: Universal::new(compiler)
-                .target(target)
-                .features(features.into())
-                .code_memory_pool(code_memory_pool)
-                .engine(),
+            engine: Universal::new(compiler).target(target).features(features.into()).engine(),
         }
     }
 
@@ -346,58 +319,83 @@ impl NearVM {
         code: &ContractCode,
         cache: Option<&dyn CompiledContractCache>,
     ) -> VMResult<Result<VMArtifact, CompilationError>> {
-        // `cache` stores compiled machine code in the database
+        // A bit of a tricky logic ahead! We need to deal with two levels of
+        // caching:
+        //   * `cache` stores compiled machine code in the database
+        //   * `MEM_CACHE` below holds in-memory cache of loaded contracts
         //
         // Caches also cache _compilation_ errors, so that we don't have to
         // re-parse invalid code (invalid code, in a sense, is a normal
         // outcome). And `cache`, being a database, can fail with an `io::Error`.
         let _span = tracing::debug_span!(target: "vm", "NearVM::compile_and_load").entered();
         let key = get_contract_cache_key(code, &self.config);
-        let cache_record = cache
-            .map(|cache| cache.get(&key))
-            .transpose()
-            .map_err(CacheError::ReadError)?
-            .flatten();
 
-        let stored_artifact: Option<VMArtifact> = match cache_record {
-            None => None,
-            Some(CompiledContract::CompileModuleError(err)) => return Ok(Err(err)),
-            Some(CompiledContract::Code(serialized_module)) => {
-                let _span = tracing::debug_span!(target: "vm", "NearVM::read_from_cache").entered();
-                unsafe {
-                    // (UN-)SAFETY: the `serialized_module` must have been produced by a prior call to
-                    // `serialize`.
-                    //
-                    // In practice this is not necessarily true. One could have forgotten to change the
-                    // cache key when upgrading the version of the near_vm library or the database could
-                    // have had its data corrupted while at rest.
-                    //
-                    // There should definitely be some validation in near_vm to ensure we load what we think
-                    // we load.
-                    let executable = UniversalExecutableRef::deserialize(&serialized_module)
-                        .map_err(|_| CacheError::DeserializationError)?;
-                    let artifact = self
-                        .engine
-                        .load_universal_executable_ref(&executable)
-                        .map(Arc::new)
-                        .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?;
-                    Some(artifact)
+        let compile_or_read_from_cache = || -> VMResult<Result<VMArtifact, CompilationError>> {
+            let _span =
+                tracing::debug_span!(target: "vm", "NearVM::compile_or_read_from_cache").entered();
+            let cache_record = cache
+                .map(|cache| cache.get(&key))
+                .transpose()
+                .map_err(CacheError::ReadError)?
+                .flatten();
+
+            let stored_artifact: Option<VMArtifact> = match cache_record {
+                None => None,
+                Some(CompiledContract::CompileModuleError(err)) => return Ok(Err(err)),
+                Some(CompiledContract::Code(serialized_module)) => {
+                    let _span =
+                        tracing::debug_span!(target: "vm", "NearVM::read_from_cache").entered();
+                    unsafe {
+                        // (UN-)SAFETY: the `serialized_module` must have been produced by a prior call to
+                        // `serialize`.
+                        //
+                        // In practice this is not necessarily true. One could have forgotten to change the
+                        // cache key when upgrading the version of the near_vm library or the database could
+                        // have had its data corrupted while at rest.
+                        //
+                        // There should definitely be some validation in near_vm to ensure we load what we think
+                        // we load.
+                        let executable = UniversalExecutableRef::deserialize(&serialized_module)
+                            .map_err(|_| CacheError::DeserializationError)?;
+                        let artifact = self
+                            .engine
+                            .load_universal_executable_ref(&executable)
+                            .map(Arc::new)
+                            .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?;
+                        Some(artifact)
+                    }
                 }
-            }
+            };
+
+            Ok(if let Some(it) = stored_artifact {
+                Ok(it)
+            } else {
+                match self.compile_and_cache(code, cache)? {
+                    Ok(executable) => Ok(self
+                        .engine
+                        .load_universal_executable(&executable)
+                        .map(Arc::new)
+                        .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?),
+                    Err(err) => Err(err),
+                }
+            })
         };
 
-        Ok(if let Some(it) = stored_artifact {
-            Ok(it)
-        } else {
-            match self.compile_and_cache(code, cache)? {
-                Ok(executable) => Ok(self
-                    .engine
-                    .load_universal_executable(&executable)
-                    .map(Arc::new)
-                    .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?),
-                Err(err) => Err(err),
-            }
-        })
+        #[cfg(feature = "no_cache")]
+        return compile_or_read_from_cache();
+
+        #[cfg(not(feature = "no_cache"))]
+        return {
+            static MEM_CACHE: once_cell::sync::Lazy<
+                near_cache::SyncLruCache<
+                    near_primitives_core::hash::CryptoHash,
+                    Result<VMArtifact, CompilationError>,
+                >,
+            > = once_cell::sync::Lazy::new(|| {
+                near_cache::SyncLruCache::new(128)
+            });
+            MEM_CACHE.get_or_try_put(key, |_key| compile_or_read_from_cache())
+        };
     }
 
     fn run_method(

--- a/runtime/near-vm/compiler/src/error.rs
+++ b/runtime/near-vm/compiler/src/error.rs
@@ -40,8 +40,8 @@ pub enum CompileError {
     Resource(String),
 
     /// Cannot downcast the engine to a specific type.
-    #[error("data offset is out of bounds")]
-    InvalidOffset,
+    #[error("cannot downcast the engine to a specific type")]
+    EngineDowncast,
 }
 
 impl From<WasmError> for CompileError {

--- a/runtime/near-vm/engine/Cargo.toml
+++ b/runtime/near-vm/engine/Cargo.toml
@@ -31,7 +31,6 @@ target-lexicon.workspace = true
 thiserror.workspace = true
 cfg-if.workspace = true
 tracing.workspace = true
-crossbeam-queue.workspace = true
 rustix = { workspace = true, features = ["param", "mm"] }
 
 [badges]

--- a/runtime/near-vm/engine/Cargo.toml
+++ b/runtime/near-vm/engine/Cargo.toml
@@ -31,7 +31,6 @@ target-lexicon.workspace = true
 thiserror.workspace = true
 cfg-if.workspace = true
 tracing.workspace = true
-rustix = { workspace = true, features = ["param", "mm"] }
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/runtime/near-vm/engine/src/universal/artifact.rs
+++ b/runtime/near-vm/engine/src/universal/artifact.rs
@@ -20,8 +20,7 @@ use std::sync::Arc;
 /// A compiled wasm module, containing everything necessary for instantiation.
 pub struct UniversalArtifact {
     // TODO: figure out how to allocate fewer distinct structures onto heap. Maybe have an arena…?
-    pub(crate) engine: super::UniversalEngine,
-    pub(crate) _code_memory: super::CodeMemory,
+    pub(crate) engine: crate::universal::UniversalEngine,
     pub(crate) import_counts: ImportCounts,
     pub(crate) start_function: Option<FunctionIndex>,
     pub(crate) vmoffsets: VMOffsets,
@@ -48,7 +47,7 @@ impl UniversalArtifact {
     }
 
     /// Return the engine instance this artifact is loaded into.
-    pub fn engine(&self) -> &super::UniversalEngine {
+    pub fn engine(&self) -> &crate::universal::UniversalEngine {
         &self.engine
     }
 }

--- a/runtime/near-vm/engine/src/universal/builder.rs
+++ b/runtime/near-vm/engine/src/universal/builder.rs
@@ -7,7 +7,6 @@ pub struct Universal {
     compiler_config: Option<Box<dyn CompilerConfig>>,
     target: Option<Target>,
     features: Option<Features>,
-    pool: Option<super::LimitedMemoryPool>,
 }
 
 impl Universal {
@@ -16,17 +15,12 @@ impl Universal {
     where
         T: Into<Box<dyn CompilerConfig>>,
     {
-        Self {
-            compiler_config: Some(compiler_config.into()),
-            target: None,
-            features: None,
-            pool: None,
-        }
+        Self { compiler_config: Some(compiler_config.into()), target: None, features: None }
     }
 
     /// Create a new headless Universal
     pub fn headless() -> Self {
-        Self { compiler_config: None, target: None, features: None, pool: None }
+        Self { compiler_config: None, target: None, features: None }
     }
 
     /// Set the target
@@ -41,25 +35,17 @@ impl Universal {
         self
     }
 
-    /// Set the pool of reusable code memory
-    pub fn code_memory_pool(mut self, pool: super::LimitedMemoryPool) -> Self {
-        self.pool = Some(pool);
-        self
-    }
-
     /// Build the `UniversalEngine` for this configuration
     pub fn engine(self) -> UniversalEngine {
         let target = self.target.unwrap_or_default();
-        let pool =
-            self.pool.unwrap_or_else(|| panic!("Universal::code_memory_pool was not set up!"));
         if let Some(compiler_config) = self.compiler_config {
             let features = self
                 .features
                 .unwrap_or_else(|| compiler_config.default_features_for_target(&target));
             let compiler = compiler_config.compiler();
-            UniversalEngine::new(compiler, target, features, pool)
+            UniversalEngine::new(compiler, target, features)
         } else {
-            UniversalEngine::headless(pool)
+            UniversalEngine::headless()
         }
     }
 }

--- a/runtime/near-vm/engine/src/universal/code_memory.rs
+++ b/runtime/near-vm/engine/src/universal/code_memory.rs
@@ -2,279 +2,170 @@
 // Attributions: https://github.com/wasmerio/wasmer/blob/master/ATTRIBUTIONS.md
 
 //! Memory management for executable code.
-use near_vm_compiler::CompileError;
-use rustix::mm::{self, MapFlags, MprotectFlags, ProtFlags};
-use std::sync::Arc;
+use near_vm_compiler::{CustomSectionRef, FunctionBodyRef};
+use near_vm_vm::{Mmap, VMFunctionBody};
 
 /// The optimal alignment for functions.
 ///
 /// On x86-64, this is 16 since it's what the optimizations assume.
 /// When we add support for other architectures, we should also figure out their
 /// optimal alignment values.
-pub(crate) const ARCH_FUNCTION_ALIGNMENT: u16 = 16;
+const ARCH_FUNCTION_ALIGNMENT: usize = 16;
 
 /// The optimal alignment for data.
 ///
-pub(crate) const DATA_SECTION_ALIGNMENT: u16 = 64;
+const DATA_SECTION_ALIGNMENT: usize = 64;
+
+/// Memory manager for executable code.
+pub struct CodeMemory {
+    mmap: Mmap,
+    start_of_nonexecutable_pages: usize,
+}
+
+impl CodeMemory {
+    /// Create a new `CodeMemory` instance.
+    pub fn new() -> Self {
+        Self { mmap: Mmap::new(), start_of_nonexecutable_pages: 0 }
+    }
+
+    /// Allocate a single contiguous block of memory for the functions and custom sections, and copy the data in place.
+    pub fn allocate(
+        &mut self,
+        functions: &[FunctionBodyRef<'_>],
+        executable_sections: &[CustomSectionRef<'_>],
+        data_sections: &[CustomSectionRef<'_>],
+    ) -> Result<(Vec<&mut [VMFunctionBody]>, Vec<&mut [u8]>, Vec<&mut [u8]>), String> {
+        let mut function_result = vec![];
+        let mut data_section_result = vec![];
+        let mut executable_section_result = vec![];
+
+        let page_size = region::page::size();
+
+        // 1. Calculate the total size, that is:
+        // - function body size, including all trampolines
+        // -- windows unwind info
+        // -- padding between functions
+        // - executable section body
+        // -- padding between executable sections
+        // - padding until a new page to change page permissions
+        // - data section body size
+        // -- padding between data sections
+
+        let total_len = round_up(
+            functions.iter().fold(0, |acc, func| {
+                round_up(acc + Self::function_allocation_size(*func), ARCH_FUNCTION_ALIGNMENT)
+            }) + executable_sections
+                .iter()
+                .fold(0, |acc, exec| round_up(acc + exec.bytes.len(), ARCH_FUNCTION_ALIGNMENT)),
+            page_size,
+        ) + data_sections
+            .iter()
+            .fold(0, |acc, data| round_up(acc + data.bytes.len(), DATA_SECTION_ALIGNMENT));
+
+        // 2. Allocate the pages. Mark them all read-write.
+
+        self.mmap = Mmap::with_at_least(total_len)?;
+
+        // 3. Determine where the pointers to each function, executable section
+        // or data section are. Copy the functions. Collect the addresses of each and return them.
+
+        let mut bytes = 0;
+        let mut buf = self.mmap.as_mut_slice();
+        for func in functions {
+            let len = round_up(Self::function_allocation_size(*func), ARCH_FUNCTION_ALIGNMENT);
+            let (func_buf, next_buf) = buf.split_at_mut(len);
+            buf = next_buf;
+            bytes += len;
+
+            let vmfunc = Self::copy_function(*func, func_buf);
+            assert_eq!(vmfunc.as_ptr() as usize % ARCH_FUNCTION_ALIGNMENT, 0);
+            function_result.push(vmfunc);
+        }
+        for section in executable_sections {
+            let section = &section.bytes;
+            assert_eq!(buf.as_mut_ptr() as usize % ARCH_FUNCTION_ALIGNMENT, 0);
+            let len = round_up(section.len(), ARCH_FUNCTION_ALIGNMENT);
+            let (s, next_buf) = buf.split_at_mut(len);
+            buf = next_buf;
+            bytes += len;
+            s[..section.len()].copy_from_slice(*section);
+            executable_section_result.push(s);
+        }
+
+        self.start_of_nonexecutable_pages = bytes;
+
+        if !data_sections.is_empty() {
+            // Data sections have different page permissions from the executable
+            // code that came before it, so they need to be on different pages.
+            let padding = round_up(bytes, page_size) - bytes;
+            buf = buf.split_at_mut(padding).1;
+
+            for section in data_sections {
+                let section = &section.bytes;
+                assert_eq!(buf.as_mut_ptr() as usize % DATA_SECTION_ALIGNMENT, 0);
+                let len = round_up(section.len(), DATA_SECTION_ALIGNMENT);
+                let (s, next_buf) = buf.split_at_mut(len);
+                buf = next_buf;
+                s[..section.len()].copy_from_slice(*section);
+                data_section_result.push(s);
+            }
+        }
+
+        Ok((function_result, executable_section_result, data_section_result))
+    }
+
+    /// Apply the page permissions.
+    pub fn publish(&mut self) {
+        if self.mmap.is_empty() || self.start_of_nonexecutable_pages == 0 {
+            return;
+        }
+        assert!(self.mmap.len() >= self.start_of_nonexecutable_pages);
+        unsafe {
+            region::protect(
+                self.mmap.as_mut_ptr(),
+                self.start_of_nonexecutable_pages,
+                region::Protection::READ_EXECUTE,
+            )
+        }
+        .expect("unable to make memory readonly and executable");
+    }
+
+    /// Calculates the allocation size of the given compiled function.
+    fn function_allocation_size(func: FunctionBodyRef<'_>) -> usize {
+        func.body.len()
+    }
+
+    /// Copies the data of the compiled function to the given buffer.
+    ///
+    /// This will also add the function to the current function table.
+    fn copy_function<'a>(func: FunctionBodyRef<'_>, buf: &'a mut [u8]) -> &'a mut [VMFunctionBody] {
+        assert_eq!(buf.as_ptr() as usize % ARCH_FUNCTION_ALIGNMENT, 0);
+
+        let func_len = func.body.len();
+
+        let (body, _remainder) = buf.split_at_mut(func_len);
+        body.copy_from_slice(&func.body);
+        Self::view_as_mut_vmfunc_slice(body)
+    }
+
+    /// Convert mut a slice from u8 to VMFunctionBody.
+    fn view_as_mut_vmfunc_slice(slice: &mut [u8]) -> &mut [VMFunctionBody] {
+        let byte_ptr: *mut [u8] = slice;
+        let body_ptr = byte_ptr as *mut [VMFunctionBody];
+        unsafe { &mut *body_ptr }
+    }
+}
 
 fn round_up(size: usize, multiple: usize) -> usize {
     debug_assert!(multiple.is_power_of_two());
     (size + (multiple - 1)) & !(multiple - 1)
 }
 
-pub struct CodeMemoryWriter<'a> {
-    memory: &'a mut CodeMemory,
-    offset: usize,
-}
-
-impl<'a> CodeMemoryWriter<'a> {
-    /// Write the contents from the provided buffer into the location of `self.memory` aligned to
-    /// provided `alignment`.
-    ///
-    /// The `alignment` actually used may be greater than the spepcified value. This is relevant,
-    /// for example, when calling this function after a sequence of [`Self::write_executable`]
-    /// calls.
-    ///
-    /// Returns the position within the mapping at which the buffer was written.
-    pub fn write_data(&mut self, mut alignment: u16, input: &[u8]) -> Result<usize, CompileError> {
-        if self.offset == self.memory.executable_end {
-            alignment = u16::try_from(rustix::param::page_size()).expect("page size > u16::MAX");
-        }
-        self.write_inner(alignment, input)
-    }
-
-    /// Write the executable code from the provided buffer into the executable portion of
-    /// `self.memory`.
-    ///
-    /// All executable parts must be written out before `self.write_data` is called for the first
-    /// time.
-    ///
-    /// Returns the position within the mapping at which the buffer was written.
-    pub fn write_executable(
-        &mut self,
-        alignment: u16,
-        input: &[u8],
-    ) -> Result<usize, CompileError> {
-        assert_eq!(
-            self.memory.executable_end, self.offset,
-            "may not interleave executable and data in the same map"
-        );
-        let result = self.write_inner(alignment, input);
-        self.memory.executable_end = self.offset;
-        result
-    }
-
-    fn write_inner(&mut self, alignment: u16, input: &[u8]) -> Result<usize, CompileError> {
-        let entry_offset = self.offset;
-        let aligned_offset = round_up(entry_offset, usize::from(alignment));
-        let final_offset = aligned_offset + input.len();
-        let out_buffer = self.memory.as_slice_mut();
-        // Fill out the padding with zeroes, if only to make sure there are no gadgets in there.
-        out_buffer
-            .get_mut(entry_offset..aligned_offset)
-            .ok_or_else(|| CompileError::Resource("out of code memory space".into()))?
-            .fill(0);
-        out_buffer
-            .get_mut(aligned_offset..final_offset)
-            .ok_or_else(|| CompileError::Resource("out of code memory space".into()))?
-            .copy_from_slice(input);
-        self.offset = final_offset;
-        Ok(aligned_offset)
-    }
-
-    /// The current position of the writer.
-    pub fn position(&self) -> usize {
-        self.offset
-    }
-}
-
-/// Mappings to regions of memory storing the executable JIT code.
-pub struct CodeMemory {
-    /// Where to return this memory to when dropped.
-    source_pool: Option<Arc<std::sync::Mutex<Vec<Self>>>>,
-
-    /// The mapping
-    map: *mut u8,
-
-    /// Mapping size
-    size: usize,
-
-    /// Addresses `0..executable_end` contain executable memory.
-    ///
-    /// In a populated buffer rounding this up to the next page will give the address of the
-    /// read-write data portion of this memory.
-    executable_end: usize,
-}
-
-impl CodeMemory {
-    fn create(size: usize) -> rustix::io::Result<Self> {
-        // Make sure callers don’t pass in a 0-sized map request. That is most likely a bug.
-        assert!(size != 0);
-        let size = round_up(size, rustix::param::page_size());
-        let map = unsafe {
-            mm::mmap_anonymous(
-                std::ptr::null_mut(),
-                size,
-                ProtFlags::WRITE | ProtFlags::READ,
-                MapFlags::SHARED,
-            )?
-        };
-        Ok(Self { source_pool: None, map: map.cast(), executable_end: 0, size })
-    }
-
-    fn as_slice_mut(&mut self) -> &mut [u8] {
-        unsafe {
-            // SAFETY: We have made sure that this is the only reference to the memory region by
-            // requiring a mutable self reference.
-            std::slice::from_raw_parts_mut(self.map, self.size)
-        }
-    }
-
-    /// Ensure this CodeMemory is at least of the requested size.
-    ///
-    /// This will invalidate any data previously written into the mapping if the mapping needs to
-    /// be resized.
-    pub fn resize(mut self, size: usize) -> rustix::io::Result<Self> {
-        if self.size < size {
-            // Ideally we would use mremap, but see
-            // https://bugzilla.kernel.org/show_bug.cgi?id=8691
-            let mut result = Self::create(size)?;
-            result.source_pool = self.source_pool.take();
-            drop(self);
-            Ok(result)
-        } else {
-            self.executable_end = 0;
-            Ok(self)
-        }
-    }
-
-    /// Write to this code memory from the beginning of the mapping.
-    ///
-    /// # Safety
-    ///
-    /// At the time this method is called, there should remain no dangling readable/executable
-    /// references to this `CodeMemory`, for the original code memory that those references point
-    /// to are invalidated as soon as this method is invoked.
-    pub unsafe fn writer(&mut self) -> CodeMemoryWriter<'_> {
-        self.executable_end = 0;
-        CodeMemoryWriter { memory: self, offset: 0 }
-    }
-
-    /// Publish the specified number of bytes as executable code.
-    ///
-    /// # Safety
-    ///
-    /// Calling this requires that no mutable references to the code memory remain.
-    pub unsafe fn publish(&mut self) -> Result<(), CompileError> {
-        mm::mprotect(
-            self.map.cast(),
-            self.executable_end,
-            MprotectFlags::EXEC | MprotectFlags::READ,
-        )
-        .map_err(|e| {
-            CompileError::Resource(format!("could not make code memory executable: {}", e))
-        })
-    }
-
-    /// Remap the offset into an absolute address within a read-execute mapping.
-    ///
-    /// Offset must not exceed `isize::MAX`.
-    pub unsafe fn executable_address(&self, offset: usize) -> *const u8 {
-        // TODO: encapsulate offsets so that this `offset` is guaranteed to be sound.
-        debug_assert!(offset <= isize::MAX as usize);
-        self.map.offset(offset as isize)
-    }
-
-    /// Remap the offset into an absolute address within a read-write mapping.
-    ///
-    /// Offset must not exceed `isize::MAX`.
-    pub unsafe fn writable_address(&self, offset: usize) -> *mut u8 {
-        // TODO: encapsulate offsets so that this `offset` is guaranteed to be sound.
-        debug_assert!(offset <= isize::MAX as usize);
-        self.map.offset(offset as isize)
-    }
-}
-
-impl Drop for CodeMemory {
-    fn drop(&mut self) {
-        if let Some(source_pool) = self.source_pool.take() {
-            unsafe {
-                let result = mm::mprotect(
-                    self.map.cast(),
-                    self.size,
-                    MprotectFlags::WRITE | MprotectFlags::READ,
-                );
-                if let Err(e) = result {
-                    panic!(
-                        "could not mprotect mapping before returning it to the memory pool: \
-                         map={:?}, size={:?}, error={}",
-                        self.map, self.size, e
-                    );
-                }
-            }
-            let mut guard = source_pool.lock().expect("unreachable due to panic=abort");
-            guard.push(Self {
-                source_pool: None,
-                map: self.map,
-                size: self.size,
-                executable_end: 0,
-            });
-        } else {
-            unsafe {
-                if let Err(e) = mm::munmap(self.map.cast(), self.size) {
-                    tracing::error!(
-                        target: "near_vm",
-                        message="could not unmap mapping",
-                        map=?self.map, size=self.size, error=%e
-                    );
-                }
-            }
-        }
-    }
-}
-
-unsafe impl Send for CodeMemory {}
-
-/// The pool of preallocated memory maps for storing the code.
-///
-/// This pool cannot grow and will only allow up to a number of code mappings that were specified
-/// at construction time.
-///
-/// However it is possible for the mappings inside to grow to accomodate larger code.
-#[derive(Clone)]
-pub struct LimitedMemoryPool {
-    pool: Arc<std::sync::Mutex<Vec<CodeMemory>>>,
-}
-
-impl LimitedMemoryPool {
-    /// Create a new pool with `count` mappings initialized to `default_memory_size` each.
-    pub fn new(count: usize, default_memory_size: usize) -> rustix::io::Result<Self> {
-        let mut pool = Vec::with_capacity(count);
-        for _ in 0..count {
-            pool.push(CodeMemory::create(default_memory_size)?);
-        }
-        let pool = Arc::new(std::sync::Mutex::new(pool));
-        Ok(Self { pool })
-    }
-
-    /// Get a memory mapping, at least `size` bytes large.
-    pub fn get(&self, size: usize) -> rustix::io::Result<CodeMemory> {
-        let mut guard = self.pool.lock().expect("unreachable due to panic=abort");
-        let mut memory = guard.pop().ok_or(rustix::io::Errno::NOMEM)?;
-        memory.source_pool = Some(Arc::clone(&self.pool));
-        if memory.size < size {
-            Ok(memory.resize(size)?)
-        } else {
-            Ok(memory)
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::CodeMemory;
     fn _assert() {
-        fn _assert_send<T: Send>() {}
-        _assert_send::<CodeMemory>();
+        fn _assert_send_sync<T: Send + Sync>() {}
+        _assert_send_sync::<CodeMemory>();
     }
 }

--- a/runtime/near-vm/engine/src/universal/engine.rs
+++ b/runtime/near-vm/engine/src/universal/engine.rs
@@ -1,8 +1,7 @@
 //! Universal compilation.
 
-use super::code_memory::{ARCH_FUNCTION_ALIGNMENT, DATA_SECTION_ALIGNMENT};
-use super::executable::{unrkyv, UniversalExecutableRef};
-use super::{CodeMemory, UniversalArtifact, UniversalExecutable};
+use crate::universal::executable::{unrkyv, UniversalExecutableRef};
+use crate::universal::{CodeMemory, UniversalArtifact, UniversalExecutable};
 use crate::EngineId;
 use near_vm_compiler::Compiler;
 use near_vm_compiler::{
@@ -17,7 +16,7 @@ use near_vm_types::{
 };
 use near_vm_vm::{
     FuncDataRegistry, FunctionBodyPtr, SectionBodyPtr, SignatureRegistry, Tunables,
-    VMCallerCheckedAnyfunc, VMFuncRef, VMImportType, VMLocalFunction, VMOffsets,
+    VMCallerCheckedAnyfunc, VMFuncRef, VMFunctionBody, VMImportType, VMLocalFunction, VMOffsets,
     VMSharedSignatureIndex, VMTrampoline,
 };
 use rkyv::de::deserializers::SharedDeserializeMap;
@@ -36,16 +35,11 @@ pub struct UniversalEngine {
 
 impl UniversalEngine {
     /// Create a new `UniversalEngine` with the given config
-    pub fn new(
-        compiler: Box<dyn Compiler>,
-        target: Target,
-        features: Features,
-        memory_allocator: super::LimitedMemoryPool,
-    ) -> Self {
+    pub fn new(compiler: Box<dyn Compiler>, target: Target, features: Features) -> Self {
         Self {
             inner: Arc::new(Mutex::new(UniversalEngineInner {
                 compiler: Some(compiler),
-                code_memory_pool: memory_allocator,
+                code_memory: vec![],
                 signatures: SignatureRegistry::new(),
                 func_data: Arc::new(FuncDataRegistry::new()),
                 features,
@@ -68,11 +62,11 @@ impl UniversalEngine {
     ///
     /// Headless engines can't compile or validate any modules,
     /// they just take already processed Modules (via `Module::serialize`).
-    pub fn headless(memory_allocator: super::LimitedMemoryPool) -> Self {
+    pub fn headless() -> Self {
         Self {
             inner: Arc::new(Mutex::new(UniversalEngineInner {
                 compiler: None,
-                code_memory_pool: memory_allocator,
+                code_memory: vec![],
                 signatures: SignatureRegistry::new(),
                 func_data: Arc::new(FuncDataRegistry::new()),
                 features: Features::default(),
@@ -221,8 +215,8 @@ impl UniversalEngine {
             .map(|(_, sig)| inner_engine.signatures.register(sig.clone()))
             .collect::<PrimaryMap<SignatureIndex, _>>()
             .into_boxed_slice();
-        let (functions, trampolines, dynamic_trampolines, custom_sections, mut code_memory) =
-            inner_engine.allocate(
+        let (functions, trampolines, dynamic_trampolines, custom_sections) = inner_engine
+            .allocate(
                 local_functions,
                 function_call_trampolines.iter().map(|(_, b)| b.into()),
                 dynamic_function_trampolines.iter().map(|(_, b)| b.into()),
@@ -270,12 +264,7 @@ impl UniversalEngine {
         );
 
         // Make all code loaded executable.
-        unsafe {
-            // SAFETY: We finished relocation and linking just above. There should be no write
-            // access past this point, though I don’t think we have a good mechanism to ensure this
-            // statically at this point..
-            code_memory.publish()?;
-        }
+        inner_engine.publish_compiled_code();
         let exports = module
             .exports
             .iter()
@@ -284,7 +273,6 @@ impl UniversalEngine {
 
         Ok(UniversalArtifact {
             engine: self.clone(),
-            _code_memory: code_memory,
             import_counts: module.import_counts,
             start_function: module.start_function,
             vmoffsets: VMOffsets::for_host().with_module_info(&*module),
@@ -362,8 +350,8 @@ impl UniversalEngine {
             })
             .collect::<PrimaryMap<SignatureIndex, _>>()
             .into_boxed_slice();
-        let (functions, trampolines, dynamic_trampolines, custom_sections, mut code_memory) =
-            inner_engine.allocate(
+        let (functions, trampolines, dynamic_trampolines, custom_sections) = inner_engine
+            .allocate(
                 local_functions,
                 call_trampolines.map(|(_, b)| b.into()),
                 dynamic_trampolines.map(|(_, b)| b.into()),
@@ -417,12 +405,7 @@ impl UniversalEngine {
         );
 
         // Make all code compiled thus far executable.
-        unsafe {
-            // SAFETY: We finished relocation and linking just above. There should be no write
-            // access past this point, though I don’t think we have a good mechanism to ensure this
-            // statically at this point..
-            code_memory.publish()?;
-        }
+        inner_engine.publish_compiled_code();
         let exports = module
             .exports
             .iter()
@@ -430,7 +413,6 @@ impl UniversalEngine {
             .collect::<BTreeMap<String, ExportIndex>>();
         Ok(UniversalArtifact {
             engine: self.clone(),
-            _code_memory: code_memory,
             import_counts,
             start_function: unrkyv(&module.start_function),
             vmoffsets: VMOffsets::for_host().with_archived_module_info(&*module),
@@ -485,10 +467,11 @@ impl UniversalEngine {
 pub struct UniversalEngineInner {
     /// The compiler
     compiler: Option<Box<dyn Compiler>>,
-    /// Pool from which code memory can be allocated.
-    code_memory_pool: super::LimitedMemoryPool,
     /// The features to compile the Wasm module with
     features: Features,
+    /// The code memory is responsible of publishing the compiled
+    /// functions to memory.
+    code_memory: Vec<CodeMemory>,
     /// The signature registry is used mainly to operate with trampolines
     /// performantly.
     pub(crate) signatures: SignatureRegistry,
@@ -532,11 +515,10 @@ impl UniversalEngineInner {
             PrimaryMap<SignatureIndex, VMTrampoline>,
             PrimaryMap<FunctionIndex, FunctionBodyPtr>,
             PrimaryMap<SectionIndex, SectionBodyPtr>,
-            CodeMemory,
         ),
         CompileError,
     > {
-        let code_memory_pool = &mut self.code_memory_pool;
+        let code_memory = &mut self.code_memory;
         let function_count = local_functions.len();
         let call_trampoline_count = call_trampolines.len();
         let function_bodies =
@@ -554,88 +536,50 @@ impl UniversalEngineInner {
             }
             section_types.push(section.protection);
         }
+        code_memory.push(CodeMemory::new());
+        let code_memory = self.code_memory.last_mut().expect("infallible");
 
-        // 1. Calculate the total size, that is:
-        // - function body size, including all trampolines
-        // -- windows unwind info
-        // -- padding between functions
-        // - executable section body
-        // -- padding between executable sections
-        // - padding until a new page to change page permissions
-        // - data section body size
-        // -- padding between data sections
-        let page_size = rustix::param::page_size();
-        let total_len = 0;
-        let total_len = function_bodies.iter().fold(total_len, |acc, func| {
-            round_up(acc, ARCH_FUNCTION_ALIGNMENT.into()) + function_allocation_size(*func)
-        });
-        let total_len = executable_sections.iter().fold(total_len, |acc, exec| {
-            round_up(acc, ARCH_FUNCTION_ALIGNMENT.into()) + exec.bytes.len()
-        });
-        let total_len = round_up(total_len, page_size);
-        let total_len = data_sections.iter().fold(total_len, |acc, data| {
-            round_up(acc, DATA_SECTION_ALIGNMENT.into()) + data.bytes.len()
-        });
-
-        let mut code_memory = code_memory_pool.get(total_len).map_err(|e| {
-            CompileError::Resource(format!("could not allocate code memory: {}", e))
-        })?;
-        let mut code_writer = unsafe {
-            // SAFETY: We just popped out an unused code memory from an allocator pool.
-            code_memory.writer()
-        };
-
-        let mut allocated_functions = vec![];
-        let mut allocated_data_sections = vec![];
-        let mut allocated_executable_sections = vec![];
-        for func in function_bodies {
-            let offset = code_writer
-                .write_executable(ARCH_FUNCTION_ALIGNMENT, func.body)
-                .expect("incorrectly computed code memory size");
-            allocated_functions.push((offset, func.body.len()));
-        }
-        for section in executable_sections {
-            let offset = code_writer.write_executable(ARCH_FUNCTION_ALIGNMENT, section.bytes)?;
-            allocated_executable_sections.push(offset);
-        }
-        if !data_sections.is_empty() {
-            for section in data_sections {
-                let offset = code_writer
-                    .write_data(DATA_SECTION_ALIGNMENT, section.bytes)
-                    .expect("incorrectly computed code memory size");
-                allocated_data_sections.push(offset);
-            }
-        }
+        let (mut allocated_functions, allocated_executable_sections, allocated_data_sections) =
+            code_memory
+                .allocate(
+                    function_bodies.as_slice(),
+                    executable_sections.as_slice(),
+                    data_sections.as_slice(),
+                )
+                .map_err(|message| {
+                    CompileError::Resource(format!(
+                        "failed to allocate memory for functions: {}",
+                        message
+                    ))
+                })?;
 
         let mut allocated_function_call_trampolines: PrimaryMap<SignatureIndex, VMTrampoline> =
             PrimaryMap::new();
-
-        for (offset, _) in allocated_functions.drain(0..call_trampoline_count) {
-            let trampoline = unsafe {
-                // SAFETY: The executable code was written at the specified offset just above.
-                // TODO: Somewhat concerning is that the `VMTrampoline` does not ensure that the
-                // lifetime of the function pointer is a subset of the lifetime of the
-                // `code_memory`. Quite conversely, this `transmute` asserts that `VMTrampoline:
-                // 'static` and thus that this function pointer is callable even after
-                // `code_memory` is freed.
-                //
-                // As lifetime annotations in Rust cannot influence the codegen, this is not a
-                // source of undefined behaviour but we do lose static lifetime checks that Rust
-                // enforces.
-                std::mem::transmute::<_, VMTrampoline>(code_memory.executable_address(offset))
-            };
+        for ptr in allocated_functions.drain(0..call_trampoline_count).map(|slice| slice.as_ptr()) {
+            // SAFETY: The executable code was written at the specified offset just above.
+            // TODO: Somewhat concerning is that the `VMTrampoline` does not ensure that the
+            // lifetime of the function pointer is a subset of the lifetime of the
+            // `code_memory`. Quite conversely, this `transmute` asserts that `VMTrampoline:
+            // 'static` and thus that this function pointer is callable even after
+            // `code_memory` is freed.
+            //
+            // As lifetime annotations in Rust cannot influence the codegen, this is not a
+            // source of undefined behaviour but we do lose static lifetime checks that Rust
+            // enforces.
+            let trampoline =
+                unsafe { std::mem::transmute::<*const VMFunctionBody, VMTrampoline>(ptr) };
             allocated_function_call_trampolines.push(trampoline);
         }
 
         let allocated_functions_result = allocated_functions
             .drain(0..function_count)
             .enumerate()
-            .map(|(index, (offset, length))| -> Result<_, CompileError> {
+            .map(|(index, slice)| -> Result<_, CompileError> {
                 let index = LocalFunctionIndex::new(index);
                 let (sig_idx, sig) = function_signature(index);
                 Ok(VMLocalFunction {
-                    body: FunctionBodyPtr(unsafe { code_memory.executable_address(offset).cast() }),
-                    length: u32::try_from(length).map_err(|_| {
+                    body: FunctionBodyPtr(slice.as_ptr()),
+                    length: u32::try_from(slice.len()).map_err(|_| {
                         CompileError::Codegen("function body length exceeds 4GiB".into())
                     })?,
                     signature: sig,
@@ -646,9 +590,7 @@ impl UniversalEngineInner {
 
         let allocated_dynamic_function_trampolines = allocated_functions
             .drain(..)
-            .map(|(offset, _)| {
-                FunctionBodyPtr(unsafe { code_memory.executable_address(offset).cast() })
-            })
+            .map(|slice| FunctionBodyPtr(slice.as_ptr()))
             .collect::<PrimaryMap<FunctionIndex, _>>();
 
         let mut exec_iter = allocated_executable_sections.iter();
@@ -656,11 +598,15 @@ impl UniversalEngineInner {
         let allocated_custom_sections = section_types
             .into_iter()
             .map(|protection| {
-                SectionBodyPtr(if protection == CustomSectionProtection::ReadExecute {
-                    unsafe { code_memory.executable_address(*exec_iter.next().unwrap()).cast() }
-                } else {
-                    unsafe { code_memory.writable_address(*data_iter.next().unwrap()).cast() }
-                })
+                SectionBodyPtr(
+                    if protection == CustomSectionProtection::ReadExecute {
+                        exec_iter.next()
+                    } else {
+                        data_iter.next()
+                    }
+                    .unwrap()
+                    .as_ptr(),
+                )
             })
             .collect::<PrimaryMap<SectionIndex, _>>();
 
@@ -669,21 +615,16 @@ impl UniversalEngineInner {
             allocated_function_call_trampolines,
             allocated_dynamic_function_trampolines,
             allocated_custom_sections,
-            code_memory,
         ))
+    }
+
+    /// Make memory containing compiled code executable.
+    pub(crate) fn publish_compiled_code(&mut self) {
+        self.code_memory.last_mut().unwrap().publish();
     }
 
     /// Shared func metadata registry.
     pub(crate) fn func_data(&self) -> &Arc<FuncDataRegistry> {
         &self.func_data
     }
-}
-
-fn round_up(size: usize, multiple: usize) -> usize {
-    debug_assert!(multiple.is_power_of_two());
-    (size + (multiple - 1)) & !(multiple - 1)
-}
-
-fn function_allocation_size(func: FunctionBodyRef<'_>) -> usize {
-    func.body.len()
 }

--- a/runtime/near-vm/engine/src/universal/mod.rs
+++ b/runtime/near-vm/engine/src/universal/mod.rs
@@ -7,7 +7,7 @@ mod link;
 
 pub use self::artifact::UniversalArtifact;
 pub use self::builder::Universal;
-pub use self::code_memory::{CodeMemory, LimitedMemoryPool};
+pub use self::code_memory::CodeMemory;
 pub use self::engine::UniversalEngine;
 pub use self::executable::{UniversalExecutable, UniversalExecutableRef};
 pub use self::link::link_module;

--- a/runtime/near-vm/test-api/src/sys/instance.rs
+++ b/runtime/near-vm/test-api/src/sys/instance.rs
@@ -24,6 +24,20 @@ pub struct Instance {
     module: Module,
 }
 
+#[cfg(test)]
+mod send_test {
+    use super::*;
+
+    fn is_send<T: Send>() -> bool {
+        true
+    }
+
+    #[test]
+    fn instance_is_send() {
+        assert!(is_send::<Instance>());
+    }
+}
+
 /// An error while instantiating a module.
 ///
 /// This is not a common WebAssembly error, however

--- a/runtime/near-vm/test-api/src/sys/store.rs
+++ b/runtime/near-vm/test-api/src/sys/store.rs
@@ -84,9 +84,7 @@ impl Default for Store {
         fn get_engine(mut config: impl CompilerConfig + 'static) -> UniversalEngine {
             cfg_if::cfg_if! {
                 if #[cfg(feature = "default-universal")] {
-                    let pool = near_vm_engine::universal::LimitedMemoryPool::new(1, 0x10000).unwrap();
                     near_vm_engine::universal::Universal::new(config)
-                        .code_memory_pool(pool)
                         .engine()
                 } else if #[cfg(feature = "default-dylib")] {
                     near_vm_engine_dylib::Dylib::new(config)

--- a/runtime/near-vm/tests/compilers/compilation.rs
+++ b/runtime/near-vm/tests/compilers/compilation.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use near_vm_compiler::CompileError;
-use near_vm_engine::universal::{LimitedMemoryPool, Universal};
+use near_vm_engine::universal::Universal;
 use near_vm_test_api::*;
 use near_vm_vm::Artifact;
 
@@ -75,8 +75,7 @@ fn profiling() {
     "#;
     let wasm = wat2wasm(wat.as_bytes()).unwrap();
     let compiler = Singlepass::default();
-    let pool = LimitedMemoryPool::new(1, 0x10000).unwrap();
-    let engine = Arc::new(Universal::new(compiler).code_memory_pool(pool).engine());
+    let engine = Arc::new(Universal::new(compiler).engine());
     let store = Store::new(Arc::clone(&engine));
     match compile_uncached(&store, &engine, &wasm, false) {
         Ok(art) => unsafe {

--- a/runtime/near-vm/tests/compilers/config.rs
+++ b/runtime/near-vm/tests/compilers/config.rs
@@ -45,10 +45,7 @@ impl Config {
     }
 
     pub fn engine(&self, compiler_config: Box<dyn CompilerConfig>) -> UniversalEngine {
-        let mut engine = near_vm_engine::universal::Universal::new(compiler_config)
-            .code_memory_pool(
-                near_vm_engine::universal::LimitedMemoryPool::new(128, 16 * 4096).unwrap(),
-            );
+        let mut engine = near_vm_engine::universal::Universal::new(compiler_config);
         if let Some(ref features) = self.features {
             engine = engine.features(features.clone())
         }

--- a/runtime/near-vm/tests/compilers/deterministic.rs
+++ b/runtime/near-vm/tests/compilers/deterministic.rs
@@ -1,12 +1,11 @@
 use anyhow::Result;
 use near_vm_compiler_singlepass::Singlepass;
-use near_vm_engine::universal::{LimitedMemoryPool, Universal};
+use near_vm_engine::universal::Universal;
 use near_vm_test_api::{wat2wasm, BaseTunables};
 
 fn compile_and_compare(wasm: &[u8]) -> Result<()> {
     let compiler = Singlepass::default();
-    let pool = LimitedMemoryPool::new(1, 0x10000).unwrap();
-    let engine = Universal::new(compiler).code_memory_pool(pool).engine();
+    let engine = Universal::new(compiler).engine();
     let tunables = BaseTunables::for_target(engine.target());
 
     // compile for first time

--- a/runtime/near-vm/tests/compilers/stack_limiter.rs
+++ b/runtime/near-vm/tests/compilers/stack_limiter.rs
@@ -1,13 +1,12 @@
 use near_vm_compiler_singlepass::Singlepass;
-use near_vm_engine::universal::{LimitedMemoryPool, Universal};
+use near_vm_engine::universal::Universal;
 use near_vm_test_api::*;
 use near_vm_types::InstanceConfig;
 use near_vm_vm::TrapCode;
 
 fn get_store() -> Store {
     let compiler = Singlepass::default();
-    let pool = LimitedMemoryPool::new(6, 0x100000).expect("foo");
-    let store = Store::new(Universal::new(compiler).code_memory_pool(pool).engine().into());
+    let store = Store::new(Universal::new(compiler).engine().into());
     store
 }
 

--- a/runtime/near-vm/vm/src/artifact.rs
+++ b/runtime/near-vm/vm/src/artifact.rs
@@ -8,7 +8,7 @@ use std::{any::Any, collections::BTreeMap, sync::Arc};
 /// [`Artifact`]s that can be instantiated.
 pub trait Instantiatable: Artifact {
     /// The errors that can occur when instantiating.
-    type Error: std::error::Error + Send;
+    type Error: std::error::Error + Send + Sync;
 
     /// Crate an `Instance` from this `Artifact`.
     ///
@@ -31,7 +31,7 @@ pub trait Instantiatable: Artifact {
 ///
 /// Some other operations such as linking, relocating and similar may also be performed during
 /// constructon of the Artifact, making this type particularly well suited for caching in-memory.
-pub trait Artifact: Send {
+pub trait Artifact: Send + Sync {
     /// The information about offsets into the VM context table.
     fn offsets(&self) -> &crate::VMOffsets;
 

--- a/scripts/binary_release.sh
+++ b/scripts/binary_release.sh
@@ -13,6 +13,13 @@ case "$release" in
 esac
 
 BRANCH=$(git branch --show-current)
+
+# in case of Release triggered run, branch is empty
+if [ -z "$BRANCH" ]; then
+  REF=$(git describe --tags | head -n1)
+  BRANCH=$(git branch -r --contains=$REF | head -n1 | cut -c3- | cut -d / -f 2)
+fi
+
 COMMIT=$(git rev-parse HEAD)
 
 os=$(uname)

--- a/tools/cold-store/src/cli.rs
+++ b/tools/cold-store/src/cli.rs
@@ -226,6 +226,7 @@ fn copy_next_block(store: &NodeStorage, config: &NearConfig, epoch_manager: &Epo
             .get_shard_layout(&epoch_manager.get_epoch_id_from_prev_block(&cold_head_hash).unwrap())
             .unwrap(),
         &next_height,
+        1,
     )
     .expect(&std::format!("Failed to copy block at height {} to cold db", next_height));
 

--- a/tools/database/src/commands.rs
+++ b/tools/database/src/commands.rs
@@ -7,6 +7,7 @@ use crate::make_snapshot::MakeSnapshotCommand;
 use crate::memtrie::LoadMemTrieCommand;
 use crate::run_migrations::RunMigrationsCommand;
 use crate::state_perf::StatePerfCommand;
+use crate::write_to_db::WriteCryptoHashCommand;
 use clap::Parser;
 use std::path::PathBuf;
 
@@ -46,6 +47,9 @@ enum SubCommand {
 
     /// Loads an in-memory trie for research purposes.
     LoadMemTrie(LoadMemTrieCommand),
+
+    /// Write CryptoHash to DB
+    WriteCryptoHash(WriteCryptoHashCommand),
 }
 
 impl DatabaseCommand {
@@ -74,6 +78,7 @@ impl DatabaseCommand {
                 .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
                 cmd.run(near_config, home)
             }
+            SubCommand::WriteCryptoHash(cmd) => cmd.run(home),
         }
     }
 }

--- a/tools/database/src/lib.rs
+++ b/tools/database/src/lib.rs
@@ -10,3 +10,4 @@ mod memtrie;
 mod run_migrations;
 mod state_perf;
 mod utils;
+mod write_to_db;

--- a/tools/database/src/write_to_db.rs
+++ b/tools/database/src/write_to_db.rs
@@ -1,0 +1,29 @@
+use near_store::{DBCol, NodeStorage};
+use std::path::Path;
+
+#[derive(clap::Args)]
+pub(crate) struct WriteCryptoHashCommand {
+    #[clap(long)]
+    hash: near_primitives::hash::CryptoHash,
+}
+
+impl WriteCryptoHashCommand {
+    pub(crate) fn run(&self, home_dir: &Path) -> anyhow::Result<()> {
+        let near_config = nearcore::config::load_config(
+            &home_dir,
+            near_chain_configs::GenesisValidationMode::UnsafeFast,
+        )?;
+        let opener = NodeStorage::opener(
+            home_dir,
+            near_config.config.archive,
+            &near_config.config.store,
+            near_config.config.cold_store.as_ref(),
+        );
+
+        let storage = opener.open()?;
+        let store = storage.get_hot_store();
+        let mut store_update = store.store_update();
+        store_update.set_ser(DBCol::BlockMisc, near_store::STATE_SNAPSHOT_KEY, &self.hash)?;
+        Ok(store_update.commit()?)
+    }
+}

--- a/tools/database/src/write_to_db.rs
+++ b/tools/database/src/write_to_db.rs
@@ -1,10 +1,25 @@
 use near_store::{DBCol, NodeStorage};
 use std::path::Path;
 
+#[derive(clap::Subcommand)]
+enum BlockMiscKeySelector {
+    StateSnapshot,
+}
+
+#[derive(clap::Subcommand)]
+enum ColumnSelector {
+    BlockMisc {
+        #[clap(subcommand)]
+        key: BlockMiscKeySelector,
+    },
+}
+
 #[derive(clap::Args)]
 pub(crate) struct WriteCryptoHashCommand {
     #[clap(long)]
     hash: near_primitives::hash::CryptoHash,
+    #[clap(subcommand)]
+    column: ColumnSelector,
 }
 
 impl WriteCryptoHashCommand {
@@ -23,7 +38,19 @@ impl WriteCryptoHashCommand {
         let storage = opener.open()?;
         let store = storage.get_hot_store();
         let mut store_update = store.store_update();
-        store_update.set_ser(DBCol::BlockMisc, near_store::STATE_SNAPSHOT_KEY, &self.hash)?;
+
+        match &self.column {
+            ColumnSelector::BlockMisc { key } => match key {
+                BlockMiscKeySelector::StateSnapshot => {
+                    store_update.set_ser(
+                        DBCol::BlockMisc,
+                        near_store::STATE_SNAPSHOT_KEY,
+                        &self.hash,
+                    )?;
+                }
+            },
+        }
+
         Ok(store_update.commit()?)
     }
 }

--- a/tools/state-viewer/src/epoch_info.rs
+++ b/tools/state-viewer/src/epoch_info.rs
@@ -96,7 +96,7 @@ fn display_block_and_chunk_producers(
         let cps: Vec<String> = shard_ids
             .iter()
             .map(|&shard_id| {
-                let cp = epoch_info.sample_chunk_producer(block_height, shard_id);
+                let cp = epoch_info.sample_chunk_producer(block_height, shard_id).unwrap();
                 let cp = epoch_info.get_validator(cp).account_id().clone();
                 cp.as_str().to_string()
             })
@@ -280,7 +280,8 @@ fn display_validator_info(
                     .iter()
                     .map(|&shard_id| (block_height, shard_id))
                     .filter(|&(block_height, shard_id)| {
-                        epoch_info.sample_chunk_producer(block_height, shard_id) == *validator_id
+                        epoch_info.sample_chunk_producer(block_height, shard_id).unwrap()
+                            == *validator_id
                     })
                     .collect::<Vec<(BlockHeight, ShardId)>>()
             })

--- a/tools/state-viewer/src/scan_db.rs
+++ b/tools/state-viewer/src/scan_db.rs
@@ -238,7 +238,7 @@ fn format_block_misc_value<'a>(key: &'a [u8], value: &'a [u8]) -> Box<dyn Debug 
         Box::new(BlockHeight::try_from_slice(value).unwrap())
     } else if key == near_store::LATEST_KNOWN_KEY {
         Box::new(LatestKnown::try_from_slice(value).unwrap())
-    } else if key == near_store::GENESIS_JSON_HASH_KEY {
+    } else if key == near_store::GENESIS_JSON_HASH_KEY || key == near_store::STATE_SNAPSHOT_KEY {
         Box::new(CryptoHash::try_from(value).unwrap())
     } else if key == near_store::GENESIS_STATE_ROOTS_KEY {
         Box::new(Vec::<StateRoot>::try_from_slice(value).unwrap())


### PR DESCRIPTION
This PR introduces the ability to customize the file descriptor (FD) limit for the neard process through an environment variable. Currently, neard has a hardcoded file descriptor hard limit of 65,000. While this default setting accommodates typical operation, edge cases such as the resharding event have demonstrated that archival nodes can exhaust this limit due to the opening of multiple RocksDB instances, leading to errors from too many open files.

Motivation
During intensive operations like resharding, archival nodes encounter the FD hard limit, resulting in failure due to "too many open files" errors. Providing operators with the flexibility to adjust the FD limit as needed based on their configuration and operational demands will enhance the stability and adaptability of neard.

Changes
Environment Variable FD_LIMIT: Operators can now specify an FD_LIMIT environment variable to set the file descriptor limit, offering a way to increase it beyond the default 65,000 when necessary.
Default Behavior: In the absence of this environment variable, the file descriptor limit will remain at the default setting of 65,000. This ensures backward compatibility and maintains current performance expectations under standard operational conditions.