### PR TITLE
make fd_limit an env var to let operater increase beyond 65k default

### DIFF
--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -50,19 +50,19 @@ fn main() -> anyhow::Result<()> {
     openssl_probe::init_ssl_cert_env_vars();
     near_performance_metrics::process::schedule_printing_performance_stats(Duration::from_secs(60));
 
-    // The default FD soft limit in linux is 1024.
-    // We use more than that, for example we support up to 1000 TCP
-    // connections, using 5 FDs per each connection.
-    // We consider 65535 to be a reasonable limit for this binary,
-    // and we enforce it here. We also set the hard limit to the same value
-    // to prevent the inner logic from trying to bump it further:
-    // FD limit is a global variable, so it shouldn't be modified in an
-    // uncoordinated way.
-    const FD_LIMIT: u64 = 65535;
+    // Retrieve FD_LIMIT from an environment variable with a default value of 65535.
+    let fd_limit_default = 65535; // Default value
+    let fd_limit_str = env::var("FD_LIMIT").unwrap_or_else(|_| fd_limit_default.to_string());
+    let fd_limit = fd_limit_str.parse::<u64>().context("Failed to parse FD_LIMIT from environment variable")?;
+
+    // Retrieve the current hard limit
     let (_, hard) = rlimit::Resource::NOFILE.get().context("rlimit::Resource::NOFILE::get()")?;
-    rlimit::Resource::NOFILE.set(FD_LIMIT, FD_LIMIT).context(format!(
-        "couldn't set the file descriptor limit to {FD_LIMIT}, hard limit = {hard}"
+    // Attempt to set both the soft and hard limits to fd_limit
+    rlimit::Resource::NOFILE.set(fd_limit, fd_limit).context(format!(
+        "couldn't set the file descriptor limit to {}, hard limit = {}",
+        fd_limit, hard
     ))?;
+
 
     NeardCmd::parse_and_run()
 }


### PR DESCRIPTION
This PR introduces the ability to customize the file descriptor (FD) limit for the neard process through an environment variable. Currently, neard has a hardcoded file descriptor hard limit of 65,000. While this default setting accommodates typical operation, edge cases such as the resharding event have demonstrated that archival nodes can exhaust this limit due to the opening of multiple RocksDB instances, leading to errors from too many open files.

Motivation
During intensive operations like resharding, archival nodes encounter the FD hard limit, resulting in failure due to "too many open files" errors. Providing operators with the flexibility to adjust the FD limit as needed based on their configuration and operational demands will enhance the stability and adaptability of neard.

Changes
Environment Variable FD_LIMIT: Operators can now specify an FD_LIMIT environment variable to set the file descriptor limit, offering a way to increase it beyond the default 65,000 when necessary.
Default Behavior: In the absence of this environment variable, the file descriptor limit will remain at the default setting of 65,000. This ensures backward compatibility and maintains current performance expectations under standard operational conditions.