### PR TITLE
fix(mocknet): return HTTP 200 on error in neard_runner.py

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -34,19 +34,6 @@ def get_lock(home):
     return fd
 
 
-def http_code(jsonrpc_error):
-    if jsonrpc_error is None:
-        return http.HTTPStatus.OK
-
-    if jsonrpc_error['code'] == -32700 or jsonrpc_error[
-            'code'] == -32600 or jsonrpc_error['code'] == -32602:
-        return http.HTTPStatus.BAD_REQUEST
-    elif jsonrpc_error['code'] == -32601:
-        return http.HTTPStatus.NOT_FOUND
-    else:
-        return http.HTTPStatus.INTERNAL_SERVER_ERROR
-
-
 class JSONHandler(http.server.BaseHTTPRequestHandler):
 
     def __init__(self, request, client_address, server):
@@ -91,7 +78,7 @@ class JSONHandler(http.server.BaseHTTPRequestHandler):
         response = jsonrpc.JSONRPCResponseManager.handle(body, self.dispatcher)
         response_body = response.json.encode('UTF-8')
 
-        self.send_response(http_code(response.error))
+        self.send_response(http.HTTPStatus.OK)
         self.send_header("Content-Type", 'application/json')
         self.send_header("Content-Length", str(len(response_body)))
         self.end_headers()


### PR DESCRIPTION
JSON RPC errors should return 200 on error, since there's nothing wrong with the HTTP layer. This simplifies error handling in general, and makes it more straightforward to see that the error was at the JSON RPC level instead of HTTP, and to inspect the type of error returned in that case

This will be useful when we add support for fork-network in mocknet, because then we'll want to add a new RPC method that tells what type of mocknet we're running (legacy records.json vs fork-network), and we'll want to more granularly tell whether that RPC call fails because the neard runner doesn't recognize the method name, which will tell us that it's an older neard_runner.py and that we can assume it's using the legacy records