### PR TITLE
Fix update cache

### DIFF
--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -210,12 +210,27 @@ impl ShardTries {
     }
 
     pub fn update_cache(&self, ops: Vec<(&CryptoHash, Option<&[u8]>)>, shard_uid: ShardUId) {
-        let mut caches = self.0.caches.write().expect(POISONED_LOCK_ERR);
-        let cache = caches
-            .entry(shard_uid)
-            .or_insert_with(|| TrieCache::new(&self.0.trie_config, shard_uid, false))
-            .clone();
-        cache.update_cache(ops);
+        // First acquire a read lock to see if the shard uid exists. The shard uid may not exist due to resharding
+        let shard_uid_exists = {
+            let caches = self.0.caches.read().expect(POISONED_LOCK_ERR);
+            caches.contains_key(&shard_uid)
+        };
+        // If the shard uid exists, we acquire a read lock to update the trie cache for the corresponding shard.
+        // If the shard uid does not exist, then we acquire a write lock to expand the cache with the new shard uid as a key.
+        if shard_uid_exists {
+            let caches = self.0.caches.read().expect(POISONED_LOCK_ERR);
+            match caches.get(&shard_uid) {
+                Some(cache) => cache.update_cache(ops),
+                None => debug_assert!(false, "key existence has been checked"),
+            }
+        } else{
+            let mut caches = self.0.caches.write().expect(POISONED_LOCK_ERR);
+            let cache = caches
+                .entry(shard_uid)
+                .or_insert_with(|| TrieCache::new(&self.0.trie_config, shard_uid, false))
+                .clone();
+            cache.update_cache(ops);
+        }
     }
 
     fn apply_deletions_inner(


### PR DESCRIPTION
There is a lock contention issue on `caches` in `ShardTries`. We always acquire the write lock for the `Rwlock` but that is only needed when there is a change in the number of shards, which happens extremely rarely. This lock contention partially leads to #10970. The fix here works by always checking whether the shard already exists and only acquire a write lock if the shard does not exist and the outer hash map needs to be modified.