### PR TITLE
Near one nayduck

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/feature_stabilization.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature_stabilization.md
@@ -11,5 +11,5 @@ Feel free to link other pull requests or issues here.
 Describe the testing plan for this protocol and why you are confident that it is ready to be stabilized.
 
 # Checklist
-- [ ] Link to nightly nayduck run (`./scripts/nayduck.py`, [docs](https://github.com/near/nearcore/blob/master/nightly/README.md#scheduling-a-run)):  https://nayduck.near.org/
+- [ ] Link to nightly nayduck run (`./scripts/nayduck.py`, [docs](https://github.com/near/nearcore/blob/master/nightly/README.md#scheduling-a-run)):  https://nayduck.nearone.org/
 - [ ] Update CHANGELOG.md to include this protocol feature in the `Unreleased` section.

--- a/.github/workflows/nightly_nayduck.yml
+++ b/.github/workflows/nightly_nayduck.yml
@@ -15,7 +15,7 @@ jobs:
       # and check if there are any non-passing tests
       - name: Check if there are any non-passing tests
         run: |
-          NIGHTLY_RESULTS=$(curl -s https://nayduck.near.org/api/nightly-events)
+          NIGHTLY_RESULTS=$(curl -s https://nayduck.nearone.org/api/nightly-events)
           UNSUCCESSFUL_TESTS=$(jq -e '.tests | .[][] | select(.[2] != "PASSED" ) ' <<< ${NIGHTLY_RESULTS} )
           if [ -z "$UNSUCCESSFUL_TESTS" ] ; then echo "Nightly Nayduck tests OK"; \
           else echo "Nightly Nayduck tests are failing" && exit 1; fi

--- a/docs/practices/testing/README.md
+++ b/docs/practices/testing/README.md
@@ -47,7 +47,7 @@ It requires nextest harness which can be installed by running `cargo install car
 
 Expensive and python tests are not part of CI, and are run by a custom nightly
 runner. The results of the latest runs are available
-[here](https://nayduck.near.org/#/). Today, test runs launch approximately
+[here](https://nayduck.nearone.org/#/). Today, test runs launch approximately
 every 5-6 hours. For the latest results look at the **second** run, since the
 first one has some tests still scheduled to run.
 

--- a/nightly/README.md
+++ b/nightly/README.md
@@ -5,7 +5,7 @@ request a run of the tests.  Most notably, `nightly.txt` file contains
 all the tests that NayDuck runs once a day on the head of the master
 branch of the repository.
 
-Nightly build results are available on [NayDuck](https://nayduck.near.org/).
+Nightly build results are available on [NayDuck](https://nayduck.nearone.org/).
 
 ## List file format
 

--- a/scripts/nayduck.py
+++ b/scripts/nayduck.py
@@ -7,7 +7,7 @@ To request a new run, use the following command:
        --branch    <your_branch>   \
        --test-file <test_file>.txt
 
-Scheduled runs can be seen at <https://nayduck.near.org/>.
+Scheduled runs can be seen at <https://nayduck.nearone.org/>.
 
 See README.md in nightly directory for documentation of the test suite file
 format.  Note that you must be a member of the Near or Near Protocol
@@ -28,7 +28,7 @@ import typing
 REPO_DIR = pathlib.Path(__file__).resolve().parents[1]
 
 DEFAULT_TEST_FILE = 'nightly/nightly.txt'
-NAYDUCK_BASE_HREF = 'https://nayduck.near.org'
+NAYDUCK_BASE_HREF = 'https://nayduck.nearone.org'
 
 
 def _parse_args():

--- a/scripts/nayduck.py
+++ b/scripts/nayduck.py
@@ -13,7 +13,7 @@ See README.md in nightly directory for documentation of the test suite file
 format.  Note that you must be a member of the Near or Near Protocol
 organisation on GitHub to authenticate (<https://github.com/orgs/near/people>).
 
-The source code for NayDuck itself is at <https://github.com/near/nayduck>.
+The source code for NayDuck itself is at <https://github.com/Near-One/nayduck>.
 """
 
 import getpass
@@ -231,7 +231,7 @@ def _parse_timeout(timeout: typing.Optional[str]) -> typing.Optional[int]:
 
 def run_locally(args, tests):
     for test in tests:
-        # See nayduck specs at https://github.com/near/nayduck/blob/master/lib/testspec.py
+        # See nayduck specs at https://github.com/Near-One/nayduck/blob/master/lib/testspec.py
         fields = test.split()
 
         timeout = None


### PR DESCRIPTION
Nayduck testing infrastructure was moved from Pagoda to NearOne:
https://nayduck.near.org -> https://nayduck.nearone.org
