### PR TITLE
fix(mirror): bump the gas for create_account function calls in the test

### DIFF
--- a/pytest/tools/mirror/mirror_utils.py
+++ b/pytest/tools/mirror/mirror_utils.py
@@ -369,7 +369,7 @@ def call_create_account(node, signer_key, account_id, public_key, nonce,
     args = bytearray(args, encoding='utf-8')
 
     actions = [
-        transaction.create_function_call_action('create_account', args, 10**13,
+        transaction.create_function_call_action('create_account', args, 10**14,
                                                 10**24),
         transaction.create_payment_action(123)
     ]


### PR DESCRIPTION
protocol version 66 causes these contract calls to fail now with prepaid gas exceeded errors. Bumping the gas to 10**14 like the other calls fixes this.