### PR TITLE
fix(mirror): wait 15 seconds before sending transactions

### DIFF
--- a/tools/mirror/src/chain_tracker.rs
+++ b/tools/mirror/src/chain_tracker.rs
@@ -129,7 +129,6 @@ pub(crate) enum SentBatch {
 
 // TODO: the separation between what's in here and what's in the main file with struct TxMirror is not
 // that clear and doesn't make that much sense. Should refactor
-#[derive(Default)]
 pub(crate) struct TxTracker {
     sent_txs: HashMap<CryptoHash, TxSendInfo>,
     txs_by_signer: HashMap<(AccountId, PublicKey), BTreeSet<TxId>>,
@@ -169,7 +168,22 @@ impl TxTracker {
         I: IntoIterator<Item = &'a BlockHeight>,
     {
         let next_heights = next_heights.into_iter().map(Clone::clone).collect();
-        Self { min_block_production_delay, next_heights, stop_height, ..Default::default() }
+        Self {
+            min_block_production_delay,
+            next_heights,
+            stop_height,
+            send_time: None,
+            sent_txs: HashMap::new(),
+            txs_by_signer: HashMap::new(),
+            queued_blocks: VecDeque::new(),
+            updater_to_keys: HashMap::new(),
+            nonces: HashMap::new(),
+            height_queued: None,
+            nonempty_height_queued: None,
+            height_popped: None,
+            height_seen: None,
+            recent_block_timestamps: VecDeque::new(),
+        }
     }
 
     pub(crate) async fn next_heights<T: ChainAccess>(


### PR DESCRIPTION
The test pytest/tools/mirror/offline_test.py often fails with many fewer transactions observed than wanted, and the logs reveal that many transactions are invalid because the access keys used do not exist in the target chain. This happens because some early transactions that should have added those keys never make it on chain. These transactions are sent successfully from the perspective of the ClientActor, but the logs show that they're dropped by the peer manager:

```
DEBUG handle{handler="PeerManagerMessageRequest" actor="PeerManagerActor" msg_type="NetworkRequests"}: network: Failed sending message: peer not connected to=ed25519:Fz7d1xkkt3XsvTPiwk4JRhMuPru4Ss7cLS8fdhshDRj3 num_connected_peers=1 msg=Routed(RoutedMessageV2 { msg: RoutedMessage { ... body: tx GFW8HgTndXVKdcLHdsCXxURjHxDnnEqHadrbxvsLKVQb ...
```

So, the peer manager is dropping the transaction instead of routing it, and the test fails because many subsequent transactions depended on that one. A git bisect shows that this behavior starts after https://github.com/near/nearcore/pull/9651. It seems that this failure to route messages happens for a bit longer after startup after that PR.  The proper way to handle this might be to implement a mechanism whereby these messages won't just silently be dropped, and the ClientActor can receive a notification that it wasn't successful so that we can retry it later. But for now a workaround is to just wait a little bit before sending transactions. So we'll set a 15 second timer for the first batch of transactions, and then proceed normally with the others 