### PR TITLE
Bump protocol version for 1.40.0

### DIFF
--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -35,7 +35,7 @@ fn build_chain() {
     if cfg!(feature = "nightly") {
         insta::assert_snapshot!(hash, @"CyVdmcpdfz8VAqZFN4zbZLTRcbcnAUzRJwNgxbgeEUMU");
     } else {
-        insta::assert_snapshot!(hash, @"CxmRfDBCbukRuksZMKEwHe6o8zqc2eZFsXmbQvPygwYi");
+        insta::assert_snapshot!(hash, @"2WHohfYksQnwKwSEoTKpkseu2RWthbGf9kmGetgHgfQQ");
     }
 
     for i in 1..5 {
@@ -53,7 +53,7 @@ fn build_chain() {
     if cfg!(feature = "nightly") {
         insta::assert_snapshot!(hash, @"72j1xRcBZpPtyo2rpPBPRspL6Q9LCju2Doa8KFhYPNJt");
     } else {
-        insta::assert_snapshot!(hash, @"6tqFaqvsAjrtkuPfnuXz2pJ1VPt1kvF95hVJR7x9JhXG");
+        insta::assert_snapshot!(hash, @"HJuuENeSwwikoR9BZA7cSonxAPZgY5mKQWL2pSXwjAwZ");
     }
 }
 

--- a/chain/jsonrpc/jsonrpc-tests/res/genesis_config.json
+++ b/chain/jsonrpc/jsonrpc-tests/res/genesis_config.json
@@ -1,5 +1,5 @@
 {
-  "protocol_version": 66,
+  "protocol_version": 67,
   "genesis_time": "1970-01-01T00:00:00.000000000Z",
   "chain_id": "sample",
   "genesis_height": 0,

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -238,7 +238,7 @@ impl ProtocolFeature {
 /// Current protocol version used on the mainnet.
 /// Some features (e. g. FixStorageUsage) require that there is at least one epoch with exactly
 /// the corresponding version
-const STABLE_PROTOCOL_VERSION: ProtocolVersion = 66;
+const STABLE_PROTOCOL_VERSION: ProtocolVersion = 67;
 
 /// Largest protocol version supported by the current binary.
 pub const PROTOCOL_VERSION: ProtocolVersion = if cfg!(feature = "statelessnet_protocol") {


### PR DESCRIPTION
1.39.0 release has protocol version 66 https://github.com/near/nearcore/blob/1.39.0/core/primitives-core/src/version.rs#L202

This means that 1.40 should have protocol version 67. As no new protocol features were stabilised since the last release, making an empty protocol upgrade