### PR TITLE
Add metric for recorded storage proof size, also calculate adjusted size based on number of trie removals

### DIFF
--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -683,6 +683,14 @@ impl Trie {
             .unwrap_or_default()
     }
 
+    /// Size of the recorded state proof plus some additional size added to cover removals.
+    pub fn adjusted_recorded_storage_size(&self) -> usize {
+        self.recorder
+            .as_ref()
+            .map(|recorder| recorder.borrow().adjusted_recorded_storage_size())
+            .unwrap_or_default()
+    }
+
     /// Constructs a Trie from the partial storage (i.e. state proof) that
     /// was returned from recorded_storage(). If used to access the same trie
     /// nodes as when the partial storage was generated, this trie will behave

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -684,10 +684,11 @@ impl Trie {
     }
 
     /// Size of the recorded state proof plus some additional size added to cover removals.
-    pub fn adjusted_recorded_storage_size(&self) -> usize {
+    /// An upper-bound estimation of the true recorded size after finalization.
+    pub fn recorded_storage_size_upper_bound(&self) -> usize {
         self.recorder
             .as_ref()
-            .map(|recorder| recorder.borrow().adjusted_recorded_storage_size())
+            .map(|recorder| recorder.borrow().recorded_storage_size_upper_bound())
             .unwrap_or_default()
     }
 

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -9,7 +9,7 @@ pub struct TrieRecorder {
     recorded: HashMap<CryptoHash, Arc<[u8]>>,
     size: usize,
     /// Counts removals performed while recording.
-    /// adjusted_recorded_storage_size takes it into account when calculating the total size.
+    /// recorded_storage_size_upper_bound takes it into account when calculating the total size.
     removal_counter: usize,
 }
 
@@ -41,8 +41,9 @@ impl TrieRecorder {
     }
 
     /// Size of the recorded state proof plus some additional size added to cover removals.
+    /// An upper-bound estimation of the true recorded size after finalization.
     /// See https://github.com/near/nearcore/issues/10890 and https://github.com/near/nearcore/pull/11000 for details.
-    pub fn adjusted_recorded_storage_size(&self) -> usize {
+    pub fn recorded_storage_size_upper_bound(&self) -> usize {
         // Charge 2000 bytes for every removal
         let removals_size = self.removal_counter.saturating_mul(2000);
         self.recorded_storage_size().saturating_add(removals_size)

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -41,7 +41,7 @@ impl TrieRecorder {
     }
 
     /// Size of the recorded state proof plus some additional size added to cover removals.
-    /// See https://github.com/near/nearcore/issues/10890 for details.
+    /// See https://github.com/near/nearcore/issues/10890 and https://github.com/near/nearcore/pull/11000 for details.
     pub fn adjusted_recorded_storage_size(&self) -> usize {
         // Charge 2000 bytes for every removal
         let removals_size = self.removal_counter.saturating_mul(2000);

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -115,6 +115,9 @@ impl TrieUpdate {
 
     pub fn remove(&mut self, trie_key: TrieKey) {
         self.prospective.insert(trie_key.to_vec(), TrieKeyValueUpdate { trie_key, value: None });
+        if let Some(recorder) = &self.trie.recorder {
+            recorder.borrow_mut().record_removal();
+        }
     }
 
     pub fn commit(&mut self, event: StateChangeCause) {

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1425,8 +1425,8 @@ impl Runtime {
             .entered();
             let node_counter_before = state_update.trie().get_trie_nodes_count();
             let recorded_storage_size_before = state_update.trie().recorded_storage_size();
-            let adjusted_recorded_storage_size_before =
-                state_update.trie().adjusted_recorded_storage_size();
+            let storage_proof_size_upper_bound_before =
+                state_update.trie().recorded_storage_size_upper_bound();
             let result = self.process_receipt(
                 state_update,
                 apply_state,
@@ -1444,16 +1444,16 @@ impl Runtime {
                 .recorded_storage_size()
                 .saturating_sub(recorded_storage_size_before)
                 as f64;
-            let adjusted_recorded_storage_diff = state_update
+            let recorded_storage_upper_bound_diff = state_update
                 .trie()
-                .adjusted_recorded_storage_size()
-                .saturating_sub(adjusted_recorded_storage_size_before)
+                .recorded_storage_size_upper_bound()
+                .saturating_sub(storage_proof_size_upper_bound_before)
                 as f64;
             metrics::RECEIPT_RECORDED_SIZE.observe(recorded_storage_diff);
-            metrics::RECEIPT_ADJUSTED_RECORDED_SIZE.observe(adjusted_recorded_storage_diff);
+            metrics::RECEIPT_RECORDED_SIZE_UPPER_BOUND.observe(recorded_storage_upper_bound_diff);
             let recorded_storage_proof_ratio =
-                adjusted_recorded_storage_diff / f64::max(1.0, recorded_storage_diff);
-            metrics::RECEIPT_ADJUSTED_RECORDED_SIZE_RATIO.observe(recorded_storage_proof_ratio);
+                recorded_storage_upper_bound_diff / f64::max(1.0, recorded_storage_diff);
+            metrics::RECEIPT_RECORDED_SIZE_UPPER_BOUND_RATIO.observe(recorded_storage_proof_ratio);
             if let Some(outcome_with_id) = result? {
                 let gas_burnt = outcome_with_id.outcome.gas_burnt;
                 let compute_usage = outcome_with_id

--- a/runtime/runtime/src/metrics.rs
+++ b/runtime/runtime/src/metrics.rs
@@ -1,7 +1,7 @@
 use near_o11y::metrics::{
-    try_create_counter_vec, try_create_histogram_vec, try_create_histogram_with_buckets,
-    try_create_int_counter, try_create_int_counter_vec, CounterVec, Histogram, HistogramVec,
-    IntCounter, IntCounterVec,
+    exponential_buckets, try_create_counter_vec, try_create_histogram_vec,
+    try_create_histogram_with_buckets, try_create_int_counter, try_create_int_counter_vec,
+    CounterVec, Histogram, HistogramVec, IntCounter, IntCounterVec,
 };
 use once_cell::sync::Lazy;
 use std::time::Duration;
@@ -338,38 +338,16 @@ fn buckets_for_compute() -> Option<Vec<f64>> {
     ])
 }
 
+// Buckets from 0 to 100 MB
 fn buckets_for_storage_proof_size() -> Vec<f64> {
-    vec![
-        0.,
-        100.,
-        200.,
-        400.,
-        800.,
-        2_000.,
-        4_000.,
-        8_000.,
-        16_000.,
-        32_000.,
-        64_000.,
-        128_000.,
-        256_000.,
-        512_000.,
-        1_000_000.,
-        2_000_000.,
-        4_000_000.,
-        6_000_000.,
-        8_000_000.,
-        16_000_000.,
-        32_000_000.,
-        64_000_000.,
-    ]
+    // 100 * 2**20 = 100 MB
+    exponential_buckets(100., 2., 20).unwrap()
 }
 
+// Buckets from 1 to 1.46
 fn buckets_for_storage_proof_size_ratio() -> Vec<f64> {
-    vec![
-        1., 1.03, 1.05, 1.07, 1.10, 1.15, 1.20, 1.30, 1.40, 1.50, 1.70, 1.90, 2.1, 2.5, 3., 4., 5.,
-        7., 8., 10.,
-    ]
+    // 1.02 ** 20 = 1.46
+    exponential_buckets(1., 1.02, 20).unwrap()
 }
 
 /// Helper struct to collect partial costs of `Runtime::apply` and reporting it

--- a/runtime/runtime/src/metrics.rs
+++ b/runtime/runtime/src/metrics.rs
@@ -294,7 +294,7 @@ pub static RECEIPT_RECORDED_SIZE: Lazy<Histogram> = Lazy::new(|| {
     try_create_histogram_with_buckets(
         "near_receipt_recorded_size",
         "Size of storage proof recorded when executing a receipt",
-        buckets_for_storage_proof_size(),
+        buckets_for_receipt_storage_proof_size(),
     )
     .unwrap()
 });
@@ -302,7 +302,7 @@ pub static RECEIPT_RECORDED_SIZE_UPPER_BOUND: Lazy<Histogram> = Lazy::new(|| {
     try_create_histogram_with_buckets(
         "near_receipt_recorded_size_upper_bound",
         "Upper bound estimation (e.g with extra size added for deletes) of storage proof size recorded when executing a receipt",
-        buckets_for_storage_proof_size(),
+        buckets_for_receipt_storage_proof_size(),
     )
     .unwrap()
 });
@@ -363,9 +363,15 @@ fn buckets_for_compute() -> Option<Vec<f64>> {
 }
 
 // Buckets from 0 to 100 MB
-fn buckets_for_storage_proof_size() -> Vec<f64> {
+fn buckets_for_receipt_storage_proof_size() -> Vec<f64> {
     // 100 * 2**20 = 100 MB
     exponential_buckets(100., 2., 20).unwrap()
+}
+
+// Buckets from 100KB to 100MB
+fn buckets_for_storage_proof_size() -> Vec<f64> {
+    // 100KB * 2**10 = 100 MB
+    exponential_buckets(100_000., 2., 10).unwrap()
 }
 
 // Buckets from 1 to 1.46

--- a/runtime/runtime/src/metrics.rs
+++ b/runtime/runtime/src/metrics.rs
@@ -314,6 +314,30 @@ pub static RECEIPT_RECORDED_SIZE_UPPER_BOUND_RATIO: Lazy<Histogram> = Lazy::new(
     )
     .unwrap()
 });
+pub static CHUNK_RECORDED_SIZE: Lazy<Histogram> = Lazy::new(|| {
+    try_create_histogram_with_buckets(
+        "near_chunk_recorded_size",
+        "Total size of storage proof (recorded trie nodes for state witness, post-finalization) for a single chunk",
+        buckets_for_storage_proof_size(),
+    )
+    .unwrap()
+});
+pub static CHUNK_RECORDED_SIZE_UPPER_BOUND: Lazy<Histogram> = Lazy::new(|| {
+    try_create_histogram_with_buckets(
+        "near_chunk_recorded_size_upper_bound",
+        "Upper bound of storage proof size (recorded trie nodes size + estimated charges, pre-finalization) for a single chunk",
+        buckets_for_storage_proof_size(),
+    )
+    .unwrap()
+});
+pub static CHUNK_RECORDED_SIZE_UPPER_BOUND_RATIO: Lazy<Histogram> = Lazy::new(|| {
+    try_create_histogram_with_buckets(
+        "near_chunk_recorded_size_upper_bound_ratio",
+        "Ratio of upper bound to true storage proof size, equal to (near_chunk_recorded_size_upper_bound / near_chunk_recorded_size)",
+        buckets_for_storage_proof_size_ratio(),
+    )
+    .unwrap()
+});
 
 /// Buckets used for burned gas in receipts.
 ///

--- a/runtime/runtime/src/metrics.rs
+++ b/runtime/runtime/src/metrics.rs
@@ -298,18 +298,18 @@ pub static RECEIPT_RECORDED_SIZE: Lazy<Histogram> = Lazy::new(|| {
     )
     .unwrap()
 });
-pub static RECEIPT_ADJUSTED_RECORDED_SIZE: Lazy<Histogram> = Lazy::new(|| {
+pub static RECEIPT_RECORDED_SIZE_UPPER_BOUND: Lazy<Histogram> = Lazy::new(|| {
     try_create_histogram_with_buckets(
-        "near_receipt_adjusted_recorded_size",
-        "Adjusted size (e.g with extra size added for deletes) of storage proof recorded when executing a receipt",
+        "near_receipt_recorded_size_upper_bound",
+        "Upper bound estimation (e.g with extra size added for deletes) of storage proof size recorded when executing a receipt",
         buckets_for_storage_proof_size(),
     )
     .unwrap()
 });
-pub static RECEIPT_ADJUSTED_RECORDED_SIZE_RATIO: Lazy<Histogram> = Lazy::new(|| {
+pub static RECEIPT_RECORDED_SIZE_UPPER_BOUND_RATIO: Lazy<Histogram> = Lazy::new(|| {
     try_create_histogram_with_buckets(
-        "near_receipt_adjusted_recorded_size_ratio",
-        "Ratio of adjusted to nonadjusted, equal to (near_receipt_adjusted_recorded_size / near_receipt_recorded_size)",
+        "near_receipt_recorded_size_upper_bound_ratio",
+        "Ratio of upper bound to true recorded size, equal to (near_receipt_recorded_size_upper_bound / near_receipt_recorded_size)",
         buckets_for_storage_proof_size_ratio(),
     )
     .unwrap()


### PR DESCRIPTION
In https://github.com/near/nearcore/issues/10890 we considered adding extra 2000 bytes to the storage proof size for every removal operation on the trie (Idea 1). This PR implements the logic of recording the number of removals and calculating the adjusted storage proof size. It's not used in the soft witness size limit for now, as we have to evaluate how viable of a solution it is. There are concerns that charging 2000 bytes extra would cause the throughput to drop.

To evaluate the impact of adjusting the size calculation like this, the PR adds three new metrics.
* `near_receipt_recorded_size` - a histogram of how much storage proof is recorded when processing a receipt. Apart from https://github.com/near/nearcore/issues/10890, it'll help us estimate what the hard per-receipt storage proof size limit should be. 
* `near_receipt_adjusted_recorded_size` - a histogram of adjusted storage proof size calculated when processing a receipt
* `near_receipt_adjusted_recorded_size_ratio` - ratio of adjusted size to non-adjusted size. It'll allow us to evaluate how much the adjustment affects the final size. The hope is that contracts rarely delete things, so the effect will be small (a few percent), but it might turn out that this assumption is false and the adjusted size is e.g 2x higher that the non-adjusted one. In that case we'd have to reevaluate whether it's a viable solution.

I'd like to run code from this branch on shadow validation nodes to gather data from mainnet traffic.