### PR TITLE
feat(congestion-model): simple warmup

### DIFF
--- a/tools/congestion-model/src/evaluation/mod.rs
+++ b/tools/congestion-model/src/evaluation/mod.rs
@@ -125,3 +125,11 @@ impl Model {
         stats_writer.write_record(None::<&[u8]>).unwrap();
     }
 }
+
+impl std::ops::Sub for GasThroughput {
+    type Output = GasThroughput;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self { total: self.total - rhs.total }
+    }
+}


### PR DESCRIPTION
To report utilization in terms of burnt gas, it can be useful to disregard the first N rounds.