### PR TITLE
Flat storage tool

### DIFF
--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -11,10 +11,11 @@ pub mod refcount;
 mod slice;
 mod testdb;
 
-mod amendeddb;
 mod database_tests;
+mod mixeddb;
 
 pub use self::colddb::ColdDB;
+pub use self::mixeddb::{MixedDB, ReadOrder};
 pub use self::rocksdb::RocksDB;
 pub use self::splitdb::SplitDB;
 

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -11,6 +11,7 @@ pub mod refcount;
 mod slice;
 mod testdb;
 
+mod amendeddb;
 mod database_tests;
 
 pub use self::colddb::ColdDB;

--- a/core/store/src/db/amendeddb.rs
+++ b/core/store/src/db/amendeddb.rs
@@ -1,0 +1,93 @@
+use std::io;
+use std::sync::Arc;
+
+use crate::db::{DBIterator, DBSlice, DBTransaction, Database, StoreStatistics};
+use crate::DBCol;
+
+pub struct AmendedDB {
+    /// Read-only db that is read before main.
+    amendments: Arc<dyn Database>,
+    /// DB for writes and info missing from amendments.
+    main: Arc<dyn Database>,
+}
+
+impl AmendedDB {
+    #[allow(dead_code)]
+    pub fn new(amendments: Arc<dyn Database>, main: Arc<dyn Database>) -> Arc<Self> {
+        return Arc::new(AmendedDB { amendments, main });
+    }
+}
+
+impl Database for AmendedDB {
+    fn get_raw_bytes(&self, col: DBCol, key: &[u8]) -> io::Result<Option<DBSlice<'_>>> {
+        if let Some(amendments_result) = self.amendments.get_raw_bytes(col, key)? {
+            return Ok(Some(amendments_result));
+        }
+        self.main.get_raw_bytes(col, key)
+    }
+
+    fn get_with_rc_stripped(&self, col: DBCol, key: &[u8]) -> io::Result<Option<DBSlice<'_>>> {
+        assert!(col.is_rc());
+
+        if let Some(amendments_result) = self.amendments.get_with_rc_stripped(col, key)? {
+            return Ok(Some(amendments_result));
+        }
+        self.main.get_with_rc_stripped(col, key)
+    }
+
+    /// TODO(posvyatokum): None of the iteration works for this DB
+    fn iter<'a>(&'a self, col: DBCol) -> DBIterator<'a> {
+        tracing::warn!(target: "store", "Iteration is not properly implemented for AmendedDB");
+        self.main.iter(col)
+    }
+
+    /// TODO(posvyatokum): None of the iteration works for this DB
+    fn iter_prefix<'a>(&'a self, col: DBCol, key_prefix: &'a [u8]) -> DBIterator<'a> {
+        tracing::warn!(target: "store", "Iteration is not properly implemented for AmendedDB");
+        self.main.iter_prefix(col, key_prefix)
+    }
+
+    /// TODO(posvyatokum): None of the iteration works for this DB
+    fn iter_range<'a>(
+        &'a self,
+        col: DBCol,
+        lower_bound: Option<&[u8]>,
+        upper_bound: Option<&[u8]>,
+    ) -> DBIterator<'a> {
+        tracing::warn!(target: "store", "Iteration is not properly implemented for AmendedDB");
+        self.main.iter_range(col, lower_bound, upper_bound)
+    }
+
+    /// TODO(posvyatokum): None of the iteration works for this DB
+    fn iter_raw_bytes<'a>(&'a self, col: DBCol) -> DBIterator<'a> {
+        tracing::warn!(target: "store", "Iteration is not properly implemented for AmendedDB");
+        self.main.iter_raw_bytes(col)
+    }
+
+    /// The split db, in principle, should be read only and only used in view client.
+    /// However the view client *does* write to the db in order to update cache.
+    /// Hence we need to allow writing to the split db but only write to the hot db.
+    fn write(&self, batch: DBTransaction) -> io::Result<()> {
+        self.main.write(batch)
+    }
+
+    fn flush(&self) -> io::Result<()> {
+        self.main.flush()
+    }
+
+    fn compact(&self) -> io::Result<()> {
+        self.main.compact()
+    }
+
+    fn get_store_statistics(&self) -> Option<StoreStatistics> {
+        self.main.get_store_statistics()
+    }
+
+    fn create_checkpoint(
+        &self,
+        path: &std::path::Path,
+        columns_to_keep: Option<&[DBCol]>,
+    ) -> anyhow::Result<()> {
+        self.main.create_checkpoint(path, columns_to_keep)
+    }
+}

--- a/core/store/src/db/amendeddb.rs
+++ b/core/store/src/db/amendeddb.rs
@@ -1,50 +1,120 @@
+use itertools::EitherOrBoth;
+use std::cmp::Ordering;
 use std::io;
 use std::sync::Arc;
 
-use crate::db::{DBIterator, DBSlice, DBTransaction, Database, StoreStatistics};
+use crate::db::{DBIterator, DBIteratorItem, DBSlice, DBTransaction, Database, StoreStatistics};
 use crate::DBCol;
 
-pub struct AmendedDB {
-    /// Read-only db that is read before main.
-    amendments: Arc<dyn Database>,
-    /// DB for writes and info missing from amendments.
-    main: Arc<dyn Database>,
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug)]
+pub enum ReadOrder {
+    ReadDBFirst,
+    WriteDBFirst,
 }
 
-impl AmendedDB {
+pub struct MixedDB {
+    /// Read-only DB.
+    read_db: Arc<dyn Database>,
+    /// DB for writes.
+    write_db: Arc<dyn Database>,
+    /// order of data lookup.
+    read_order: ReadOrder,
+}
+
+impl MixedDB {
     #[allow(dead_code)]
-    pub fn new(amendments: Arc<dyn Database>, main: Arc<dyn Database>) -> Arc<Self> {
-        return Arc::new(AmendedDB { amendments, main });
+    pub fn new(
+        read_db: Arc<dyn Database>,
+        write_db: Arc<dyn Database>,
+        read_order: ReadOrder,
+    ) -> Arc<Self> {
+        return Arc::new(MixedDB { read_db, write_db, read_order });
+    }
+
+    fn first_db(&self) -> &Arc<dyn Database> {
+        match self.read_order {
+            ReadOrder::ReadDBFirst => &self.read_db,
+            ReadOrder::WriteDBFirst => &self.write_db,
+        }
+    }
+
+    fn second_db(&self) -> &Arc<dyn Database> {
+        match self.read_order {
+            ReadOrder::ReadDBFirst => &self.write_db,
+            ReadOrder::WriteDBFirst => &self.read_db,
+        }
+    }
+
+    /// The cmp function for the DBIteratorItems.
+    ///
+    /// Note that this does not implement total ordering because there isn't a
+    /// clear way to compare errors to errors or errors to values. Instead it
+    /// implements total order on values but always compares the error on the
+    /// left as lesser. This isn't even partial order. It is fine for merging
+    /// lists but should not be used for anything more complex like sorting.
+    fn db_iter_item_cmp(a: &DBIteratorItem, b: &DBIteratorItem) -> Ordering {
+        match (a, b) {
+            // Always put errors first.
+            (Err(_), _) => Ordering::Less,
+            (_, Err(_)) => Ordering::Greater,
+            // When comparing two (key, value) paris only compare the keys.
+            // - values in hot and cold may differ in rc but they are still the same
+            // - values written to cold should be immutable anyway
+            // - values writted to cold should be final
+            (Ok((a_key, _)), Ok((b_key, _))) => Ord::cmp(a_key, b_key),
+        }
+    }
+
+    /// Returns merge iterator for the given two DBIterators. The returned
+    /// iterator will contain unique and sorted items from both input iterators.
+    ///
+    /// All errors from both inputs will be returned.
+    fn merge_iter<'a>(a: DBIterator<'a>, b: DBIterator<'a>) -> DBIterator<'a> {
+        // Merge the two iterators using the cmp function. The result will be an
+        // iter of EitherOrBoth.
+        let iter = itertools::merge_join_by(a, b, Self::db_iter_item_cmp);
+        // Flatten the EitherOrBoth while discarding duplicates. Each input
+        // iterator should only contain unique and sorted items. If any item is
+        // present in both iterors before the merge, it will get mapped to a
+        // EitherOrBoth::Both in the merged iter. Pick either and discard the
+        // other - this will guarantee uniqueness of the resulting iterator.
+        let iter = iter.map(|item| match item {
+            EitherOrBoth::Both(item, _) => item,
+            EitherOrBoth::Left(item) => item,
+            EitherOrBoth::Right(item) => item,
+        });
+        Box::new(iter)
     }
 }
 
-impl Database for AmendedDB {
+impl Database for MixedDB {
     fn get_raw_bytes(&self, col: DBCol, key: &[u8]) -> io::Result<Option<DBSlice<'_>>> {
-        if let Some(amendments_result) = self.amendments.get_raw_bytes(col, key)? {
-            return Ok(Some(amendments_result));
+        if let Some(first_result) = self.first_db().get_raw_bytes(col, key)? {
+            return Ok(Some(first_result));
         }
-        self.main.get_raw_bytes(col, key)
+        self.second_db().get_raw_bytes(col, key)
     }
 
     fn get_with_rc_stripped(&self, col: DBCol, key: &[u8]) -> io::Result<Option<DBSlice<'_>>> {
         assert!(col.is_rc());
 
-        if let Some(amendments_result) = self.amendments.get_with_rc_stripped(col, key)? {
-            return Ok(Some(amendments_result));
+        if let Some(first_result) = self.first_db().get_with_rc_stripped(col, key)? {
+            return Ok(Some(first_result));
         }
-        self.main.get_with_rc_stripped(col, key)
+        self.second_db().get_with_rc_stripped(col, key)
     }
 
-    /// TODO(posvyatokum): None of the iteration works for this DB
     fn iter<'a>(&'a self, col: DBCol) -> DBIterator<'a> {
-        tracing::warn!(target: "store", "Iteration is not properly implemented for AmendedDB");
-        self.main.iter(col)
+        Self::merge_iter(self.read_db.iter(col), self.write_db.iter(col))
     }
 
     /// TODO(posvyatokum): None of the iteration works for this DB
     fn iter_prefix<'a>(&'a self, col: DBCol, key_prefix: &'a [u8]) -> DBIterator<'a> {
-        tracing::warn!(target: "store", "Iteration is not properly implemented for AmendedDB");
-        self.main.iter_prefix(col, key_prefix)
+        return Self::merge_iter(
+            self.read_db.iter_prefix(col, key_prefix),
+            self.write_db.iter_prefix(col, key_prefix),
+        );
     }
 
     /// TODO(posvyatokum): None of the iteration works for this DB
@@ -54,33 +124,37 @@ impl Database for AmendedDB {
         lower_bound: Option<&[u8]>,
         upper_bound: Option<&[u8]>,
     ) -> DBIterator<'a> {
-        tracing::warn!(target: "store", "Iteration is not properly implemented for AmendedDB");
-        self.main.iter_range(col, lower_bound, upper_bound)
+        return Self::merge_iter(
+            self.read_db.iter_range(col, lower_bound, upper_bound),
+            self.write_db.iter_range(col, lower_bound, upper_bound),
+        );
     }
 
     /// TODO(posvyatokum): None of the iteration works for this DB
     fn iter_raw_bytes<'a>(&'a self, col: DBCol) -> DBIterator<'a> {
-        tracing::warn!(target: "store", "Iteration is not properly implemented for AmendedDB");
-        self.main.iter_raw_bytes(col)
+        return Self::merge_iter(
+            self.read_db.iter_raw_bytes(col),
+            self.write_db.iter_raw_bytes(col),
+        );
     }
 
     /// The split db, in principle, should be read only and only used in view client.
     /// However the view client *does* write to the db in order to update cache.
     /// Hence we need to allow writing to the split db but only write to the hot db.
     fn write(&self, batch: DBTransaction) -> io::Result<()> {
-        self.main.write(batch)
+        self.write_db.write(batch)
     }
 
     fn flush(&self) -> io::Result<()> {
-        self.main.flush()
+        self.write_db.flush()
     }
 
     fn compact(&self) -> io::Result<()> {
-        self.main.compact()
+        self.write_db.compact()
     }
 
     fn get_store_statistics(&self) -> Option<StoreStatistics> {
-        self.main.get_store_statistics()
+        self.write_db.get_store_statistics()
     }
 
     fn create_checkpoint(
@@ -88,6 +162,6 @@ impl Database for AmendedDB {
         path: &std::path::Path,
         columns_to_keep: Option<&[DBCol]>,
     ) -> anyhow::Result<()> {
-        self.main.create_checkpoint(path, columns_to_keep)
+        self.write_db.create_checkpoint(path, columns_to_keep)
     }
 }

--- a/core/store/src/db/mixeddb.rs
+++ b/core/store/src/db/mixeddb.rs
@@ -91,8 +91,10 @@ impl MixedDB {
 impl Database for MixedDB {
     fn get_raw_bytes(&self, col: DBCol, key: &[u8]) -> io::Result<Option<DBSlice<'_>>> {
         if let Some(first_result) = self.first_db().get_raw_bytes(col, key)? {
+            tracing::trace!(target: "mixeddb", ?col, "Returning from first DB");
             return Ok(Some(first_result));
         }
+        tracing::trace!(target: "mixeddb", ?col, "Returning from second DB");
         self.second_db().get_raw_bytes(col, key)
     }
 
@@ -100,8 +102,10 @@ impl Database for MixedDB {
         assert!(col.is_rc());
 
         if let Some(first_result) = self.first_db().get_with_rc_stripped(col, key)? {
+            tracing::trace!(target: "mixeddb", ?col, "Returning from first DB");
             return Ok(Some(first_result));
         }
+        tracing::trace!(target: "mixeddb", ?col, "Returning from second DB");
         self.second_db().get_with_rc_stripped(col, key)
     }
 
@@ -142,6 +146,7 @@ impl Database for MixedDB {
     /// However the view client *does* write to the db in order to update cache.
     /// Hence we need to allow writing to the split db but only write to the hot db.
     fn write(&self, batch: DBTransaction) -> io::Result<()> {
+        tracing::trace!(target: "mixeddb", "Writing to writeDB");
         self.write_db.write(batch)
     }
 

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -761,7 +761,7 @@ impl FlatStorageCommand {
             home_dir,
             near_config.config.archive,
             &near_config.config.store,
-            None,
+            near_config.config.cold_store.as_ref(),
         );
 
         match &self.subcmd {


### PR DESCRIPTION
This PR is for demonstration purposes only, and should not be merged as is.

I plan to use `flat-storage init` tool to recreate a flat storage from a historical height. But this tool uses final height right now.
Finding and changing every usage of `BlockMisc` in flat storage initialisation seemed like too much. So before init I "overwrite" BlockMisc column.
This is done through `MixedDB`. This struct is also used to write all the changes in the separate db.
`MixedDB` has read-only database, and read-write database. All writes go to the read-write db, but reading is done sequentially. Read priority is decided during db creation.
So, to "overwrite" base db, I need to combine it with read-only db that contains amendments, and choose read priority as `ReadDBFirst`.
To write something to another db, I need to use it as a read-write db, and choose read priority as `WriteDBFirst` (as i assume that we should give priority to a fresher data).

I have some questions still:
- For which height should we create FlatStorage? And should we call init tool for `height + 1` or `height`?
- Should we add parallel init of all shards? Or there is no profit over calling this tool sequentially?
- Should I replace the db in the same way in the `verify` command and run it after the FlatStorage creation? Will it help us to find any bugs?  