### PR TITLE
[network] Changes to StatelessValidation related network messages

### DIFF
--- a/chain/network/src/peer_manager/connection/mod.rs
+++ b/chain/network/src/peer_manager/connection/mod.rs
@@ -45,8 +45,10 @@ impl tcp::Tier {
 
     pub(crate) fn is_allowed_routed(self, body: &RoutedMessageBody) -> bool {
         match body {
-            RoutedMessageBody::BlockApproval(..) => true,
-            RoutedMessageBody::VersionedPartialEncodedChunk(..) => true,
+            RoutedMessageBody::BlockApproval(..)
+            | RoutedMessageBody::ChunkStateWitness(..)
+            | RoutedMessageBody::ChunkEndorsement(..)
+            | RoutedMessageBody::VersionedPartialEncodedChunk(..) => true,
             _ => self == tcp::Tier::T2,
         }
     }

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -42,10 +42,6 @@ mod tier1;
 /// Limit number of pending Peer actors to avoid OOM.
 pub(crate) const LIMIT_PENDING_PEERS: usize = 60;
 
-/// Send important messages three times.
-/// We send these messages multiple times to reduce the chance that they are lost
-const IMPORTANT_MESSAGE_RESENT_COUNT: usize = 3;
-
 /// Size of LRU cache size of recent routed messages.
 /// It should be large enough to detect duplicates (i.e. all messages received during
 /// production of 1 block should fit).
@@ -626,12 +622,8 @@ impl NetworkState {
 
         let msg = RawRoutedMessage { target: PeerIdOrHash::PeerId(target), body: msg };
         let msg = self.sign_message(clock, msg);
-        if msg.body.is_important() {
-            for _ in 0..IMPORTANT_MESSAGE_RESENT_COUNT {
-                success |= self.send_message_to_peer(clock, tcp::Tier::T2, msg.clone());
-            }
-        } else {
-            success |= self.send_message_to_peer(clock, tcp::Tier::T2, msg)
+        for _ in 0..msg.body.message_resend_count() {
+            success |= self.send_message_to_peer(clock, tcp::Tier::T2, msg.clone());
         }
         success
     }


### PR DESCRIPTION
Two main changes
- ChunkStateWitness and ChunkEndorsement are not sent multiple times over network.
- Change preference of ChunkStateWitness and ChunkEndorsement to send over Tier 1 connection

ChunkStateWitness are heavy and we do not want to send them over the network multiple times.
ChunkEndorsement do not need to be sent multiple times either as they are mainly over tier 1 network.

Minor cleanup and renaming functions.