### PR TITLE
[network] Do not resend successful Tier 1 network messages over Tier 2 network

### DIFF
--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -582,7 +582,7 @@ impl NetworkState {
                     clock,
                     RawRoutedMessage {
                         target: PeerIdOrHash::PeerId(data.peer_id.clone()),
-                        body: msg.clone(),
+                        body: msg,
                     },
                 ))));
                 return true;


### PR DESCRIPTION
The current default behavior was to send Tier 1 network messages over both Tier 1 and Tier 2.

This PR changes that behavior to not send message over Tier 2 in case it was successfully sent over Tier 1