### PR TITLE
congestion: transaction pool trimming

### DIFF
--- a/tools/congestion-model/src/model/mod.rs
+++ b/tools/congestion-model/src/model/mod.rs
@@ -126,10 +126,9 @@ impl Model {
 
     pub fn trim_transaction_pools(&mut self, max_len: usize) {
         for &shard_id in &self.shard_ids {
-            if self.queues.incoming_transactions(shard_id).len() > max_len {
-                self.queues
-                    .incoming_transactions_mut(shard_id)
-                    .resize_with(max_len, || unreachable!());
+            let len = self.queues.incoming_transactions(shard_id).len();
+            if len > max_len {
+                self.queues.incoming_transactions_mut(shard_id).drain(0..len - max_len);
             }
         }
     }

--- a/tools/congestion-model/src/model/mod.rs
+++ b/tools/congestion-model/src/model/mod.rs
@@ -124,6 +124,16 @@ impl Model {
             .collect()
     }
 
+    pub fn trim_transaction_pools(&mut self, max_len: usize) {
+        for &shard_id in &self.shard_ids {
+            if self.queues.incoming_transactions(shard_id).len() > max_len {
+                self.queues
+                    .incoming_transactions_mut(shard_id)
+                    .resize_with(max_len, || unreachable!());
+            }
+        }
+    }
+
     pub fn shard(&mut self, id: ShardId) -> &mut dyn CongestionStrategy {
         self.shards[id.0].as_mut()
     }


### PR DESCRIPTION
If we run with infinite transaction pools, some workloads report really long transaction delays. This reflects reality in some sense. But is not really useful for comparison.

The CLI flag `tx_pool_size` allows to trim the pool, possibly even empty it completely. Then, the reported delays are shorter because started transactions are fresher.