### PR TITLE
congestion: report gas per chunk in the summary

### DIFF
--- a/tools/congestion-model/src/evaluation/mod.rs
+++ b/tools/congestion-model/src/evaluation/mod.rs
@@ -133,3 +133,11 @@ impl std::ops::Sub for GasThroughput {
         Self { total: self.total - rhs.total }
     }
 }
+
+impl std::ops::Div<usize> for GasThroughput {
+    type Output = GasThroughput;
+
+    fn div(self, rhs: usize) -> Self::Output {
+        Self { total: self.total / rhs as u64 }
+    }
+}

--- a/tools/congestion-model/src/evaluation/summary_table.rs
+++ b/tools/congestion-model/src/evaluation/summary_table.rs
@@ -1,12 +1,12 @@
 use super::{GasThroughput, Progress, ShardQueueLengths, UserExperience};
-use crate::PGAS;
+use crate::{PGAS, TGAS};
 
 pub fn print_summary_header() {
     println!(
         "{:<25}{:<25}{:>25}{:>25}{:>16}{:>16}{:>16}{:>16}{:>16}",
         "WORKLOAD",
         "STRATEGY",
-        "BURNT GAS",
+        "BURNT GAS PER CHUNK",
         "TRANSACTIONS FINISHED",
         "MEDIAN TX DELAY",
         "90p TX DELAY",
@@ -25,8 +25,8 @@ pub fn print_summary_row(
     user_experience: &UserExperience,
 ) {
     println!(
-        "{workload:<25}{strategy:<25}{:>20} PGas{:>25}{:>16}{:>16}{:>16}{:>16}{:>16}",
-        throughput.total / PGAS,
+        "{workload:<25}{strategy:<25}{:>20} TGas{:>25}{:>16}{:>16}{:>16}{:>16}{:>16}",
+        throughput.total / TGAS,
         progress.finished_transactions,
         user_experience.successful_tx_delay_median,
         user_experience.successful_tx_delay_90th_percentile,

--- a/tools/congestion-model/src/main.rs
+++ b/tools/congestion-model/src/main.rs
@@ -143,7 +143,9 @@ fn run_model(
         workload_name,
         strategy_name,
         &model.progress(),
-        &(model.gas_throughput() - warmup_gas_usage),
+        &((model.gas_throughput() - warmup_gas_usage)
+            / (num_rounds - num_warmup_rounds)
+            / num_shards),
         &max_queues,
         &model.user_experience(),
     );


### PR DESCRIPTION
This is better for comparing different strategies under different configurations.
It is easier to interpret how much gas has been burnt per chunk, rather than in total.