### PR TITLE
Fix `deploy_call_smart_contract`

### DIFF
--- a/pytest/tests/contracts/deploy_call_smart_contract.py
+++ b/pytest/tests/contracts/deploy_call_smart_contract.py
@@ -11,6 +11,8 @@ from cluster import start_cluster
 from transaction import sign_deploy_contract_tx, sign_function_call_tx
 from utils import load_test_contract
 
+GGAS = 10**9
+
 
 def test_deploy_contract():
     nodes = start_cluster(
@@ -26,8 +28,7 @@ def test_deploy_contract():
     last_block_hash = nodes[1].get_latest_block().hash_bytes
     tx = sign_function_call_tx(nodes[0].signer_key,
                                nodes[0].signer_key.account_id, 'log_something',
-                               [], 100000000000, 100000000000, 20,
-                               last_block_hash)
+                               [], 150 * GGAS, 1, 20, last_block_hash)
     res = nodes[1].send_tx_and_wait(tx, 20)
     import json
     print(json.dumps(res, indent=2))


### PR DESCRIPTION
This is resolving one of the items from https://github.com/near/nearcore/issues/11031

It is quite bizarre that this test is failing in the first place, as the change in the gas costs should be strictly beneficial to the users.
Here is an example failure: https://nayduck.nearone.org/#/test/12357

@Ekleog-NEAR , any ideas?