### PR TITLE
bug: rename function to reflect actual ability

### DIFF
--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -32,7 +32,6 @@ use near_primitives::test_utils::create_test_signer;
 use near_primitives::transaction::{Action, FunctionCallAction, SignedTransaction};
 use near_primitives::types::{AccountId, Balance, BlockHeight, EpochId, NumSeats, ShardId};
 use near_primitives::utils::MaybeValidated;
-use near_primitives::version::ProtocolVersion;
 use near_primitives::views::{
     AccountView, FinalExecutionOutcomeView, QueryRequest, QueryResponse, QueryResponseKind,
     StateItem,
@@ -433,9 +432,11 @@ impl TestEnv {
         self.clients[id].process_tx(tx, false, false)
     }
 
-    /// This function will actually bump to the latest protocol version instead of the provided one.
-    /// See https://github.com/near/nearcore/issues/8590 for details.
-    pub fn upgrade_protocol(&mut self, protocol_version: ProtocolVersion) {
+    /// This function used to be able to upgrade to a specific protocol version
+    /// but due to https://github.com/near/nearcore/issues/8590 that
+    /// functionality does not work currently.  Hence it is renamed to upgrade
+    /// to the latest version.
+    pub fn upgrade_protocol_to_latest_version(&mut self) {
         assert_eq!(self.clients.len(), 1, "at the moment, this support only a single client");
 
         let tip = self.clients[0].chain.head().unwrap();
@@ -447,8 +448,6 @@ impl TestEnv {
             self.clients[0].epoch_manager.get_block_producer(&epoch_id, tip.height).unwrap();
 
         let mut block = self.clients[0].produce_block(tip.height + 1).unwrap().unwrap();
-        eprintln!("Producing block with version {protocol_version}");
-        block.mut_header().set_latest_protocol_version(protocol_version);
         block.mut_header().resign(&create_test_signer(block_producer.as_str()));
 
         let _ = self.clients[0]

--- a/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
+++ b/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
@@ -19,7 +19,6 @@ fn test_account_id_in_function_call_permission_upgrade() {
         near_primitives::version::ProtocolFeature::AccountIdInFunctionCallPermission
             .protocol_version()
             - 1;
-    let new_protocol_version = old_protocol_version + 1;
 
     // Prepare TestEnv with a contract at the old protocol version.
     let mut env = {
@@ -70,7 +69,7 @@ fn test_account_id_in_function_call_permission_upgrade() {
         }
     };
 
-    env.upgrade_protocol(new_protocol_version);
+    env.upgrade_protocol_to_latest_version();
 
     // Re-run the transaction, now it fails due to invalid account id.
     {

--- a/integration-tests/src/tests/client/features/fix_contract_loading_cost.rs
+++ b/integration-tests/src/tests/client/features/fix_contract_loading_cost.rs
@@ -44,7 +44,7 @@ fn unchanged_gas_cost() {
     let old_gas = old_result.receipts_outcome[0].outcome.gas_burnt;
     assert_matches!(old_result.status, FinalExecutionStatus::SuccessValue(_));
 
-    env.upgrade_protocol(new_protocol_version);
+    env.upgrade_protocol_to_latest_version();
 
     let new_result = env.call_main(&account);
     let new_gas = new_result.receipts_outcome[0].outcome.gas_burnt;
@@ -77,7 +77,7 @@ fn preparation_error_gas_cost() {
     let old_gas = old_result.receipts_outcome[0].outcome.gas_burnt;
     assert_matches!(old_result.status, FinalExecutionStatus::Failure(_));
 
-    env.upgrade_protocol(new_protocol_version);
+    env.upgrade_protocol_to_latest_version();
 
     let new_result = env.call_main(&account);
     let new_gas = new_result.receipts_outcome[0].outcome.gas_burnt;

--- a/integration-tests/src/tests/client/features/flat_storage.rs
+++ b/integration-tests/src/tests/client/features/flat_storage.rs
@@ -113,7 +113,7 @@ fn test_flat_storage_upgrade() {
                 env.produce_block(0, tip.height + i + 1);
             }
             if i == 0 {
-                env.upgrade_protocol(new_protocol_version);
+                env.upgrade_protocol_to_latest_version();
             }
 
             let final_transaction_result =

--- a/integration-tests/src/tests/client/features/increase_deployment_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_deployment_cost.rs
@@ -47,7 +47,7 @@ fn test_deploy_cost_increased() {
     let tx = env.tx_from_actions(actions.clone(), &signer, signer.account_id.clone());
     let old_outcome = env.execute_tx(tx).unwrap();
 
-    env.upgrade_protocol(new_protocol_version);
+    env.upgrade_protocol_to_latest_version();
 
     let tx = env.tx_from_actions(actions, &signer, signer.account_id.clone());
     let new_outcome = env.execute_tx(tx).unwrap();

--- a/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
@@ -252,7 +252,7 @@ fn assert_compute_limit_reached(
         "should saturate gas limit, only burnt {gas_burnt} when limit was {gas_limit}"
     );
 
-    env.upgrade_protocol(new_protocol_version);
+    env.upgrade_protocol_to_latest_version();
 
     let new_chunk = produce_saturated_chunk(
         &mut env,

--- a/integration-tests/src/tests/client/features/limit_contract_functions_number.rs
+++ b/integration-tests/src/tests/client/features/limit_contract_functions_number.rs
@@ -18,7 +18,6 @@ fn verify_contract_limits_upgrade(
     expected_prepare_err: PrepareError,
 ) {
     let old_protocol_version = feature.protocol_version() - 1;
-    let new_protocol_version = feature.protocol_version();
 
     let epoch_length = 5;
     // Prepare TestEnv with a contract at the old protocol version.
@@ -52,7 +51,7 @@ fn verify_contract_limits_upgrade(
     let account = "test0".parse().unwrap();
     let old_outcome = env.call_main(&account);
 
-    env.upgrade_protocol(new_protocol_version);
+    env.upgrade_protocol_to_latest_version();
 
     let new_outcome = env.call_main(&account);
 

--- a/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
+++ b/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
@@ -24,7 +24,6 @@ fn protocol_upgrade() {
 
     let old_protocol_version =
         near_primitives::version::ProtocolFeature::LowerStorageKeyLimit.protocol_version() - 1;
-    let new_protocol_version = old_protocol_version + 1;
     let new_storage_key_limit = 2usize.pow(11); // 2 KB
     let args: Vec<u8> = vec![1u8; new_storage_key_limit + 1]
         .into_iter()
@@ -95,7 +94,7 @@ fn protocol_upgrade() {
         assert_matches!(final_result.status, FinalExecutionStatus::SuccessValue(_));
     }
 
-    env.upgrade_protocol(new_protocol_version);
+    env.upgrade_protocol_to_latest_version();
 
     // Re-run the transaction, check that execution fails.
     {

--- a/integration-tests/src/tests/client/features/nearvm.rs
+++ b/integration-tests/src/tests/client/features/nearvm.rs
@@ -17,7 +17,6 @@ fn test_nearvm_upgrade() {
 
     let old_protocol_version =
         near_primitives::version::ProtocolFeature::NearVmRuntime.protocol_version() - 1;
-    let new_protocol_version = old_protocol_version + 1;
 
     // Prepare TestEnv with a contract at the old protocol version.
     let mut env = {
@@ -74,7 +73,7 @@ fn test_nearvm_upgrade() {
         capture.drain()
     };
 
-    env.upgrade_protocol(new_protocol_version);
+    env.upgrade_protocol_to_latest_version();
 
     // Re-run the transaction.
     let logs_at_new_version = {


### PR DESCRIPTION
Renames `pub fn upgrade_protocol(&mut self, protocol_version: ProtocolVersion)` to `pub fn upgrade_protocol_to_latest_version(&mut self)`.  The function is unable to upgrade to a specific version but instead always upgrades to the latest version.

Also see https://github.com/near/nearcore/issues/8590.