### PR TITLE
feat(db): Adding MixedDB

### DIFF
--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -5,6 +5,7 @@ use std::io;
 pub(crate) mod rocksdb;
 
 mod colddb;
+mod mixeddb;
 mod splitdb;
 
 pub mod refcount;
@@ -14,6 +15,7 @@ mod testdb;
 mod database_tests;
 
 pub use self::colddb::ColdDB;
+pub use self::mixeddb::{MixedDB, ReadOrder};
 pub use self::rocksdb::RocksDB;
 pub use self::splitdb::SplitDB;
 

--- a/core/store/src/db/mixeddb.rs
+++ b/core/store/src/db/mixeddb.rs
@@ -1,0 +1,141 @@
+use std::io;
+use std::sync::Arc;
+
+use crate::db::{DBIterator, DBSlice, DBTransaction, Database, StoreStatistics};
+use crate::DBCol;
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug)]
+pub enum ReadOrder {
+    ReadDBFirst,
+    WriteDBFirst,
+}
+
+/// MixedDB allows to have dedicated read-only db, and specify the order of data retrieval.
+/// With `ReadOrder::ReadDBFirst` you can overwrite some information in DB, without actually modifying it.
+/// With `ReadOrder::WriteDBFirst` you can record results of any operations only in a separate DB.
+/// This way you can conduct several experiments on data, without having to create checkpoints or restoring data.
+/// And you can compare data from different experiments faster, as your write DB will be smaller.
+///
+/// SplitDB can be considered a `MixedDB { read_db: cold_db, write_db: hot_db, read_order: ReadOrder::WriteDBFirst }`
+/// But it also has several assertions about types of columns we can retrieve from `read_db`,
+/// And it is suitable for production,
+///
+/// MixedDB is designed to be used with neard tools, and is not planned for integration into production.
+pub struct MixedDB {
+    /// Read-only DB.
+    read_db: Arc<dyn Database>,
+    /// DB for writes.
+    write_db: Arc<dyn Database>,
+    /// order of data lookup.
+    read_order: ReadOrder,
+}
+
+impl MixedDB {
+    #[allow(dead_code)]
+    pub fn new(
+        read_db: Arc<dyn Database>,
+        write_db: Arc<dyn Database>,
+        read_order: ReadOrder,
+    ) -> Arc<Self> {
+        return Arc::new(MixedDB { read_db, write_db, read_order });
+    }
+
+    /// Return the first DB in the order of data lookup
+    fn first_db(&self) -> &Arc<dyn Database> {
+        match self.read_order {
+            ReadOrder::ReadDBFirst => &self.read_db,
+            ReadOrder::WriteDBFirst => &self.write_db,
+        }
+    }
+
+    /// Return the second DB in the order of data lookup
+    fn second_db(&self) -> &Arc<dyn Database> {
+        match self.read_order {
+            ReadOrder::ReadDBFirst => &self.write_db,
+            ReadOrder::WriteDBFirst => &self.read_db,
+        }
+    }
+
+    /// This function is imported from SplitDB, but we may want to refactor them later.
+    fn merge_iter<'a>(a: DBIterator<'a>, b: DBIterator<'a>) -> DBIterator<'a> {
+        crate::db::SplitDB::merge_iter(a, b)
+    }
+}
+
+impl Database for MixedDB {
+    fn get_raw_bytes(&self, col: DBCol, key: &[u8]) -> io::Result<Option<DBSlice<'_>>> {
+        if let Some(first_result) = self.first_db().get_raw_bytes(col, key)? {
+            return Ok(Some(first_result));
+        }
+        self.second_db().get_raw_bytes(col, key)
+    }
+
+    fn get_with_rc_stripped(&self, col: DBCol, key: &[u8]) -> io::Result<Option<DBSlice<'_>>> {
+        assert!(col.is_rc());
+
+        if let Some(first_result) = self.first_db().get_with_rc_stripped(col, key)? {
+            return Ok(Some(first_result));
+        }
+        self.second_db().get_with_rc_stripped(col, key)
+    }
+
+    fn iter<'a>(&'a self, col: DBCol) -> DBIterator<'a> {
+        Self::merge_iter(self.read_db.iter(col), self.write_db.iter(col))
+    }
+
+    fn iter_prefix<'a>(&'a self, col: DBCol, key_prefix: &'a [u8]) -> DBIterator<'a> {
+        return Self::merge_iter(
+            self.first_db().iter_prefix(col, key_prefix),
+            self.second_db().iter_prefix(col, key_prefix),
+        );
+    }
+
+    fn iter_range<'a>(
+        &'a self,
+        col: DBCol,
+        lower_bound: Option<&[u8]>,
+        upper_bound: Option<&[u8]>,
+    ) -> DBIterator<'a> {
+        return Self::merge_iter(
+            self.first_db().iter_range(col, lower_bound, upper_bound),
+            self.second_db().iter_range(col, lower_bound, upper_bound),
+        );
+    }
+
+    fn iter_raw_bytes<'a>(&'a self, col: DBCol) -> DBIterator<'a> {
+        return Self::merge_iter(
+            self.first_db().iter_raw_bytes(col),
+            self.second_db().iter_raw_bytes(col),
+        );
+    }
+
+    fn write(&self, batch: DBTransaction) -> io::Result<()> {
+        self.write_db.write(batch)
+    }
+
+    /// There is no need to flush a read-only DB.
+    fn flush(&self) -> io::Result<()> {
+        self.write_db.flush()
+    }
+
+    /// There is no need to compact an immutable DB.
+    fn compact(&self) -> io::Result<()> {
+        self.write_db.compact()
+    }
+
+    /// Write DB actually has real changes,
+    /// so exporting it's statistics is a reasonable request.
+    fn get_store_statistics(&self) -> Option<StoreStatistics> {
+        self.write_db.get_store_statistics()
+    }
+
+    /// There is no need to create checkpoint of an immutable DB.
+    fn create_checkpoint(
+        &self,
+        path: &std::path::Path,
+        columns_to_keep: Option<&[DBCol]>,
+    ) -> anyhow::Result<()> {
+        self.write_db.create_checkpoint(path, columns_to_keep)
+    }
+}

--- a/core/store/src/db/splitdb.rs
+++ b/core/store/src/db/splitdb.rs
@@ -35,7 +35,7 @@ impl SplitDB {
     /// implements total order on values but always compares the error on the
     /// left as lesser. This isn't even partial order. It is fine for merging
     /// lists but should not be used for anything more complex like sorting.
-    fn db_iter_item_cmp(a: &DBIteratorItem, b: &DBIteratorItem) -> Ordering {
+    pub(crate) fn db_iter_item_cmp(a: &DBIteratorItem, b: &DBIteratorItem) -> Ordering {
         match (a, b) {
             // Always put errors first.
             (Err(_), _) => Ordering::Less,
@@ -52,7 +52,7 @@ impl SplitDB {
     /// iterator will contain unique and sorted items from both input iterators.
     ///
     /// All errors from both inputs will be returned.
-    fn merge_iter<'a>(a: DBIterator<'a>, b: DBIterator<'a>) -> DBIterator<'a> {
+    pub(crate) fn merge_iter<'a>(a: DBIterator<'a>, b: DBIterator<'a>) -> DBIterator<'a> {
         // Merge the two iterators using the cmp function. The result will be an
         // iter of EitherOrBoth.
         let iter = itertools::merge_join_by(a, b, Self::db_iter_item_cmp);


### PR DESCRIPTION
MixedDB allows to have dedicated read-only db, and specify the order of data retrieval.
With `ReadOrder::ReadDBFirst` you can overwrite some information in DB, without actually modifying it.
With `ReadOrder::WriteDBFirst` you can record results of any operations only in a separate DB.
This way you can conduct several experiments on data, without having to create checkpoints or restoring data.
And you can compare data from different experiments faster, as your write DB will be smaller.

SplitDB can be considered a `MixedDB { read_db: cold_db, write_db: hot_db, read_order: ReadOrder::WriteDBFirst }`
But it also has several assertions about types of columns we can retrieve from `read_db`,
And it is suitable for production.
MixedDB is designed to be used with neard tools, and is not planned for integration into production.

@wacban  I want to use this new DB type in #11026.
Suggestion is to have `MixedDB { read_db: split_db, write_db: new_db, ReadOrder::WriteDBFirst }`

Some code to help you integrate `MixedDB` into your work
This code is lifted from some unfinished project I have:
```
   fn open_rocksdb(path: &Path, home_dir: &Path, mode: Mode) -> anyhow::Result<Arc<dyn Database>> {
        let path = if path.is_absolute() { PathBuf::from(path) } else { home_dir.join(&path) };
        Ok(Arc::new(near_store::db::RocksDB::open(
            &path,
            &StoreConfig::default(),
            mode,
            near_store::Temperature::Hot,
        )?))
    }

    fn add_read_only_source(
        base_db: Arc<dyn Database>,
        new_source_path: &Path,
        home_dir: &Path,
        order: &ReadOrder,
    ) -> anyhow::Result<Arc<dyn Database>> {
        let source = Self::open_rocksdb(new_source_path, home_dir, Mode::ReadOnly)?;
        Ok(MixedDB::new(source, base_db, *order))
    }

    fn add_read_write_db(
        base_db: Arc<dyn Database>,
        new_write_path: &Path,
        home_dir: &Path,
        order: &ReadOrder,
    ) -> anyhow::Result<Arc<dyn Database>> {
        let write_db = Self::open_rocksdb(new_write_path, home_dir, Mode::ReadWrite)?;
        Ok(MixedDB::new(base_db, write_db, *order))
    }
```

Also, be sure to set DB version and kind
Plus maybe some BlockMisc data (although I am not sure that it is needed to open DB)
```
fn set_block_misc(height: BlockHeight, source_store: &Store, target_store: &Store) {
        let mut db_update = target_store.store_update();

        let header = Self::get_header(height, source_store);
        let tip = Tip::from_header(&header);

        let col = DBCol::BlockMisc;
        db_update.set_ser(col, near_store::HEAD_KEY, &tip).expect("Unable to write HEAD_KEY");
        db_update
            .set_ser(col, near_store::HEADER_HEAD_KEY, &tip)
            .expect("Unable to write HEADER_HEAD_KEY");
        db_update
            .set_ser(col, near_store::FINAL_HEAD_KEY, &tip)
            .expect("Unable to write FINAL_HEAD_KEY");
        db_update.commit().expect("Unable to commit to TestDB");
    }
```