### PR TITLE
congestion: fix nep strategy filtering

### DIFF
--- a/tools/congestion-model/src/strategy/nep.rs
+++ b/tools/congestion-model/src/strategy/nep.rs
@@ -147,7 +147,8 @@ impl NepStrategy {
             }
 
             if self.get_filter_stop(ctx, tx) {
-                break;
+                // reject receipt
+                continue;
             }
 
             let outgoing = ctx.accept_transaction(tx);


### PR DESCRIPTION
The filter is per outgoing shard, we should keep
working on new transactions for other shards even
after hitting the limit for one shard.