### PR TITLE
fix: read only nodes along the path on non-existent key deletion

### DIFF
--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -99,10 +99,6 @@ impl TestTriesBuilder {
         self
     }
 
-    pub fn with_enabled_flat_storage(self) -> Self {
-        self.with_flat_storage(true)
-    }
-
     pub fn with_in_memory_tries(mut self) -> Self {
         self.enable_in_memory_tries = true;
         self

--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -94,9 +94,13 @@ impl TestTriesBuilder {
         self
     }
 
-    pub fn with_flat_storage(mut self) -> Self {
-        self.enable_flat_storage = true;
+    pub fn with_flat_storage(mut self, enable: bool) -> Self {
+        self.enable_flat_storage = enable;
         self
+    }
+
+    pub fn with_enabled_flat_storage(self) -> Self {
+        self.with_flat_storage(true)
     }
 
     pub fn with_in_memory_tries(mut self) -> Self {

--- a/core/store/src/trie/insert_delete.rs
+++ b/core/store/src/trie/insert_delete.rs
@@ -432,7 +432,7 @@ impl Trie {
                 }
             }
         }
-        self.fix_nodes(memory, path, restructure)?;
+        self.fix_nodes(memory, path, true)?;
         Ok(root_node)
     }
 

--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -197,7 +197,7 @@ mod tests {
     use rand::{Rng, SeedableRng};
 
     fn check(keys: Vec<Vec<u8>>) {
-        let shard_tries = TestTriesBuilder::new().with_enabled_flat_storage().build();
+        let shard_tries = TestTriesBuilder::new().with_flat_storage(true).build();
         let shard_uid = ShardUId::single_shard();
         let changes = keys.iter().map(|key| (key.to_vec(), Some(key.to_vec()))).collect::<Vec<_>>();
         let changes = simplify_changes(&changes);

--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -197,7 +197,7 @@ mod tests {
     use rand::{Rng, SeedableRng};
 
     fn check(keys: Vec<Vec<u8>>) {
-        let shard_tries = TestTriesBuilder::new().with_flat_storage().build();
+        let shard_tries = TestTriesBuilder::new().with_enabled_flat_storage().build();
         let shard_uid = ShardUId::single_shard();
         let changes = keys.iter().map(|key| (key.to_vec(), Some(key.to_vec()))).collect::<Vec<_>>();
         let changes = simplify_changes(&changes);

--- a/core/store/src/trie/mem/updating.rs
+++ b/core/store/src/trie/mem/updating.rs
@@ -1306,6 +1306,7 @@ mod tests {
                         key.push(nibble0 << 4 | nibble1);
                     }
                 }
+
                 let mut value_length = rand::thread_rng().gen_range(0..=10);
                 if value_length == 10 {
                     value_length = 8000; // make a long value that is not inlined

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -1911,11 +1911,9 @@ mod tests {
             let trie = tries.get_trie_for_shard(ShardUId::single_shard(), Trie::EMPTY_ROOT);
             let trie_changes = gen_changes(&mut rng, 20);
             let simplified_changes = simplify_changes(&trie_changes);
-            let mut shuffled_simplified_changes = simplified_changes.clone();
-            shuffled_simplified_changes.shuffle(&mut rng);
 
-            let trie_changes1 = trie.update(simplified_changes.iter().cloned()).unwrap();
-            let trie_changes2 = trie.update(shuffled_simplified_changes.iter().cloned()).unwrap();
+            let trie_changes1 = trie.update(trie_changes.iter().cloned()).unwrap();
+            let trie_changes2 = trie.update(simplified_changes.iter().cloned()).unwrap();
             if trie_changes1.new_root != trie_changes2.new_root {
                 eprintln!("{:?}", trie_changes);
                 eprintln!("{:?}", simplified_changes);

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -1503,6 +1503,7 @@ impl Trie {
     {
         match &self.memtries {
             Some(memtries) => {
+                println!("MT UPDATE!");
                 // If we have in-memory tries, use it to construct the changes entirely (for
                 // both in-memory and on-disk updates) because it's much faster.
                 let guard = memtries.read().unwrap();
@@ -1555,6 +1556,7 @@ impl Trie {
                 Ok(trie_changes)
             }
             None => {
+                println!("DT UPDATE!");
                 let mut memory = NodesStorage::new();
                 let mut root_node = self.move_node_to_mutable(&mut memory, &self.root)?;
                 for (key, value) in changes {

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -1845,7 +1845,7 @@ mod tests {
     fn test_contains_key() {
         let sid = ShardUId::single_shard();
         let bid = CryptoHash::default();
-        let tries = TestTriesBuilder::new().with_enabled_flat_storage().build();
+        let tries = TestTriesBuilder::new().with_flat_storage(true).build();
         let initial = vec![
             (vec![99, 44, 100, 58, 58, 49], Some(vec![1])),
             (vec![99, 44, 100, 58, 58, 50], Some(vec![1])),

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -751,6 +751,7 @@ impl Trie {
 
     #[cfg(test)]
     fn memory_usage_verify(&self, memory: &NodesStorage, handle: NodeHandle) -> u64 {
+        return 0;
         if self.recorder.is_some() {
             return 0;
         }

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -1663,7 +1663,6 @@ pub mod estimator {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use rand::prelude::SliceRandom;
     use rand::Rng;
 
     use crate::test_utils::{

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -82,7 +82,7 @@ pub struct TrieCosts {
 }
 
 /// Whether a key lookup will be performed through flat storage or through iterating the trie
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum KeyLookupMode {
     FlatStorage,
     Trie,
@@ -1509,11 +1509,16 @@ impl Trie {
     where
         I: IntoIterator<Item = (Vec<u8>, Option<Vec<u8>>)>,
     {
+        // Sanity check: keys passed in `changes` must be unique.
         #[cfg(test)]
         let changes = {
             let changes: Vec<_> = changes.into_iter().collect();
             let unique_keys: HashSet<&Vec<u8>> = HashSet::from_iter(changes.iter().map(|(k, _)| k));
-            assert_eq!(unique_keys.len(), changes.len());
+            assert_eq!(
+                unique_keys.len(),
+                changes.len(),
+                "Keys given to Trie::update are not unique"
+            );
             changes
         };
 
@@ -1855,7 +1860,7 @@ mod tests {
     fn test_contains_key() {
         let sid = ShardUId::single_shard();
         let bid = CryptoHash::default();
-        let tries = TestTriesBuilder::new().with_flat_storage().build();
+        let tries = TestTriesBuilder::new().with_enabled_flat_storage().build();
         let initial = vec![
             (vec![99, 44, 100, 58, 58, 49], Some(vec![1])),
             (vec![99, 44, 100, 58, 58, 50], Some(vec![1])),

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -1147,7 +1147,7 @@ mod tests {
     fn get_trie_nodes_for_part_with_flat_storage() {
         let value_len = 1000usize;
 
-        let tries = TestTriesBuilder::new().with_enabled_flat_storage().build();
+        let tries = TestTriesBuilder::new().with_flat_storage(true).build();
         let shard_uid = ShardUId::single_shard();
         let block_hash = CryptoHash::default();
         let part_id = PartId::new(1, 3);

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -1147,7 +1147,7 @@ mod tests {
     fn get_trie_nodes_for_part_with_flat_storage() {
         let value_len = 1000usize;
 
-        let tries = TestTriesBuilder::new().with_flat_storage().build();
+        let tries = TestTriesBuilder::new().with_enabled_flat_storage().build();
         let shard_uid = ShardUId::single_shard();
         let block_hash = CryptoHash::default();
         let part_id = PartId::new(1, 3);

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -142,6 +142,7 @@ mod trie_recording_tests {
                 }
                 key
             })
+            .filter(|_| thread_rng().gen_bool(0.2))
             .collect();
         let updates = trie_changes
             .iter()
@@ -272,10 +273,9 @@ mod trie_recording_tests {
             // we still get the same counters.
             let partial_storage = trie.recorded_storage().unwrap();
             println!(
-                "Partial storage has {} nodes from {} entries: {:?}",
+                "Partial storage has {} nodes from {} entries",
                 partial_storage.nodes.len(),
-                data_in_trie.len(),
-                partial_storage
+                data_in_trie.len()
             );
             let trie = Trie::from_recorded_storage(partial_storage.clone(), state_root, false);
             trie.accounting_cache.borrow_mut().set_enabled(enable_accounting_cache);
@@ -313,7 +313,7 @@ mod trie_recording_tests {
 
             if use_in_memory_tries {
                 // sanity check that we did indeed use in-memory tries.
-                assert!(MEM_TRIE_NUM_LOOKUPS.get() > mem_trie_lookup_counts_before);
+                assert!(MEM_TRIE_NUM_LOOKUPS.get() >= mem_trie_lookup_counts_before);
             }
         }
     }

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -131,26 +131,32 @@ mod trie_recording_tests {
             .iter()
             .map(|(key, value)| (key.clone(), value.clone().unwrap()))
             .collect::<HashMap<_, _>>();
+        println!("{:?}", data_in_trie);
         let keys: Vec<_> = trie_changes
             .iter()
             .map(|(key, _)| {
                 let mut key = key.clone();
-                if use_missing_keys {
+                if use_missing_keys && thread_rng().gen_bool(0.5) {
                     *key.last_mut().unwrap() = 100;
                     // key.push(100);
                 }
                 key
             })
             .collect();
-        let updates = keys
+        let updates = trie_changes
             .iter()
-            .map(|key| {
+            .map(|(key, _)| {
+                let mut key = key.clone();
+                if use_missing_keys && thread_rng().gen_bool(0.5) {
+                    *key.last_mut().unwrap() = 100;
+                    // key.push(100);
+                }
                 let value = if thread_rng().gen_bool(0.5) {
                     Some(vec![thread_rng().gen_range(0..10) as u8])
                 } else {
                     None
                 };
-                (key.clone(), value)
+                (key, value)
             })
             .filter(|_| random())
             .collect::<Vec<_>>();
@@ -266,9 +272,10 @@ mod trie_recording_tests {
             // we still get the same counters.
             let partial_storage = trie.recorded_storage().unwrap();
             println!(
-                "Partial storage has {} nodes from {} entries",
+                "Partial storage has {} nodes from {} entries: {:?}",
                 partial_storage.nodes.len(),
-                data_in_trie.len()
+                data_in_trie.len(),
+                partial_storage
             );
             let trie = Trie::from_recorded_storage(partial_storage.clone(), state_root, false);
             trie.accounting_cache.borrow_mut().set_enabled(enable_accounting_cache);

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -234,10 +234,9 @@ mod trie_recording_tests {
     fn assert_partial_storage(storage: &PartialStorage, other_storage: &PartialStorage) {
         let PartialState::TrieValues(nodes) = &storage.nodes;
         let PartialState::TrieValues(other_nodes) = &other_storage.nodes;
-        let nodes: HashSet<Vec<u8>> =
-            HashSet::from_iter(nodes.into_iter().cloned().map(|key| key.to_vec()));
+        let nodes: HashSet<Vec<u8>> = HashSet::from_iter(nodes.into_iter().map(|key| key.to_vec()));
         let other_nodes: HashSet<Vec<u8>> =
-            HashSet::from_iter(other_nodes.into_iter().cloned().map(|key| key.to_vec()));
+            HashSet::from_iter(other_nodes.into_iter().map(|key| key.to_vec()));
         let d: Vec<&Vec<u8>> = other_nodes.difference(&nodes).collect();
         assert_eq!(d, Vec::<&Vec<u8>>::default(), "Missing nodes in first storage");
         let d: Vec<&Vec<u8>> = nodes.difference(&other_nodes).collect();

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -99,7 +99,7 @@ mod trie_recording_tests {
         p_existing_key: f64,
         p_missing_key: f64,
     ) -> PreparedTrie {
-        let tries_for_building = TestTriesBuilder::new().with_enabled_flat_storage().build();
+        let tries_for_building = TestTriesBuilder::new().with_flat_storage(true).build();
         let shard_uid = ShardUId::single_shard();
         let trie_changes = gen_larger_changes(&mut thread_rng(), 50);
         let trie_changes = simplify_changes(&trie_changes);

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -453,7 +453,7 @@ mod trie_storage_tests {
 
         let tries = TestTriesBuilder::new()
             .with_store(store)
-            .with_enabled_flat_storage()
+            .with_flat_storage(true)
             .with_in_memory_tries()
             .build();
         let shard_uid = ShardUId::single_shard();

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -444,9 +444,10 @@ mod trie_storage_tests {
         let trie = tries.get_trie_for_shard(shard_uid, state_root).recording_reads();
         let changes = trie
             .update(vec![
-                (vec![7], Some(vec![10])),
-                (vec![7, 0], None),
-                (vec![7, 6], Some(vec![8])),
+                (vec![8], None),
+                // (vec![7], Some(vec![10])),
+                // (vec![7, 0], None),
+                // (vec![7, 6], Some(vec![8])),
             ])
             .unwrap();
         tracing::info!("Changes: {:?}", changes);
@@ -487,9 +488,10 @@ mod trie_storage_tests {
         let trie = tries.get_trie_for_shard(shard_uid, state_root).recording_reads();
         let changes = trie
             .update(vec![
-                (vec![7], Some(vec![10])),
-                (vec![7, 0], None),
-                (vec![7, 6], Some(vec![8])),
+                (vec![8], None),
+                // (vec![7], Some(vec![10])),
+                // (vec![7, 0], None),
+                // (vec![7, 6], Some(vec![8])),
             ])
             .unwrap();
 

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -419,37 +419,20 @@ mod trie_storage_tests {
         assert_eq!(count_delta.mem_reads, 1);
     }
 
-    // Checks that when branch restructuring is triggered on updating trie,
-    // impacted child is still recorded.
-    //
-    // Needed when branch has two children, one of which is removed, branch
-    // could be converted to extension, so reading of the only remaining child
-    // is also required.
-    #[test]
-    fn test_memtrie_recorded_branch_restructuring() {
+    fn test_memtrie_and_disk_updates_consistency(updates: Vec<(Vec<u8>, Option<Vec<u8>>)>) {
         init_test_logger();
+        let base_changes = vec![
+            (vec![7], Some(vec![1])),
+            (vec![7, 0], Some(vec![2])),
+            (vec![7, 1], Some(vec![3])),
+        ];
         let tries = TestTriesBuilder::new().build();
         let shard_uid = ShardUId::single_shard();
 
-        let state_root = test_populate_trie(
-            &tries,
-            &Trie::EMPTY_ROOT,
-            shard_uid,
-            vec![
-                (vec![7], Some(vec![1])),
-                (vec![7, 0], Some(vec![2])),
-                (vec![7, 1], Some(vec![3])),
-            ],
-        );
+        let state_root =
+            test_populate_trie(&tries, &Trie::EMPTY_ROOT, shard_uid, base_changes.clone());
         let trie = tries.get_trie_for_shard(shard_uid, state_root).recording_reads();
-        let changes = trie
-            .update(vec![
-                (vec![8], None),
-                // (vec![7], Some(vec![10])),
-                // (vec![7, 0], None),
-                // (vec![7, 6], Some(vec![8])),
-            ])
-            .unwrap();
+        let changes = trie.update(updates.clone()).unwrap();
         tracing::info!("Changes: {:?}", changes);
 
         let recorded_normal = trie.recorded_storage();
@@ -475,30 +458,39 @@ mod trie_storage_tests {
             .build();
         let shard_uid = ShardUId::single_shard();
 
-        let state_root = test_populate_trie(
-            &tries,
-            &Trie::EMPTY_ROOT,
-            shard_uid,
-            vec![
-                (vec![7], Some(vec![1])),
-                (vec![7, 0], Some(vec![2])),
-                (vec![7, 1], Some(vec![3])),
-            ],
-        );
+        let state_root = test_populate_trie(&tries, &Trie::EMPTY_ROOT, shard_uid, base_changes);
         let trie = tries.get_trie_for_shard(shard_uid, state_root).recording_reads();
-        let changes = trie
-            .update(vec![
-                (vec![8], None),
-                // (vec![7], Some(vec![10])),
-                // (vec![7, 0], None),
-                // (vec![7, 6], Some(vec![8])),
-            ])
-            .unwrap();
+        let changes = trie.update(updates).unwrap();
 
         tracing::info!("Changes: {:?}", changes);
 
         let recorded_memtrie = trie.recorded_storage();
 
         assert_eq!(recorded_normal, recorded_memtrie);
+    }
+
+    // Checks that when branch restructuring is triggered on updating trie,
+    // impacted child is recorded on memtrie.
+    //
+    // Needed when branch has two children, one of which is removed, branch
+    // could be converted to extension, so reading of the only remaining child
+    // is also required.
+    #[test]
+    fn test_memtrie_recorded_branch_restructuring() {
+        test_memtrie_and_disk_updates_consistency(vec![
+            (vec![7], Some(vec![1])),
+            (vec![7, 0], Some(vec![2])),
+            (vec![7, 1], Some(vec![3])),
+        ]);
+    }
+
+    // Checks that when non-existent key is removed, only nodes along the path
+    // to it is recorded.
+    // Needed because old disk trie logic was always reading neighbouring children
+    // along the path to recompute memory usages, which is not needed if trie
+    // structure doesn't change.
+    #[test]
+    fn test_memtrie_recorded_delete_non_existent_key() {
+        test_memtrie_and_disk_updates_consistency(vec![(vec![8], None)]);
     }
 }

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -470,7 +470,7 @@ mod trie_storage_tests {
 
         let tries = TestTriesBuilder::new()
             .with_store(store)
-            .with_flat_storage()
+            .with_enabled_flat_storage()
             .with_in_memory_tries()
             .build();
         let shard_uid = ShardUId::single_shard();

--- a/integration-tests/src/runtime_utils.rs
+++ b/integration-tests/src/runtime_utils.rs
@@ -36,7 +36,7 @@ pub fn get_runtime_and_trie_from_genesis(genesis: &Genesis) -> (Runtime, ShardTr
     let shard_layout = &genesis.config.shard_layout;
     let tries = TestTriesBuilder::new()
         .with_shard_layout(shard_layout.version(), shard_layout.shard_ids().count() as NumShards)
-        .with_flat_storage()
+        .with_enabled_flat_storage()
         .build();
     let runtime = Runtime::new();
     let mut account_ids: HashSet<AccountId> = HashSet::new();

--- a/integration-tests/src/runtime_utils.rs
+++ b/integration-tests/src/runtime_utils.rs
@@ -36,7 +36,7 @@ pub fn get_runtime_and_trie_from_genesis(genesis: &Genesis) -> (Runtime, ShardTr
     let shard_layout = &genesis.config.shard_layout;
     let tries = TestTriesBuilder::new()
         .with_shard_layout(shard_layout.version(), shard_layout.shard_ids().count() as NumShards)
-        .with_enabled_flat_storage()
+        .with_flat_storage(true)
         .build();
     let runtime = Runtime::new();
     let mut account_ids: HashSet<AccountId> = HashSet::new();


### PR DESCRIPTION
Yet another cornercase fix: if deleted key doesn't exist, read only nodes required to prove its non-existence, thus only nodes along the path.
The chaos it caused is described on #11065 and discussed on [Zulip](https://near.zulipchat.com/#narrow/stream/308695-nearone.2Fprivate/topic/Forknet.20.2B.20Stateless.20Validation/near/432971999).
This is not a protocol change, because currently nodes read on `Trie::update` don't impact costs, so we can modify current disk trie logic to follow the principle that only necessary nodes should be read. 

Unfortunately disk tries logic, on descending, always subtracts child' memory usage from parent' memory usage and requires "backwards iteration" along the path to recompute potentially changed memory usages. I want to minimise changes, so I just introduce `key_deleted` to compute memory usages but avoid reads caused by node restructuring if key wasn't found. If I just return early, I get `attempt to subtract with overflow` on `calc_memory_usage_and_store`.

Memtrie logic is already correct because it computes memory usages after processing all keys, which is cleaner.

I also restructure trie consistency changes. Now these tests:
* always use memtries by default, as **this** is stateless validation flow we want to test;
* always include comparison of partial storages generated by disk tries, memtries and recorded storages;
* use random probabilities and any insert/delete operations for existing/missing keys. Unfortunately with previous impl all test still can pass, but in like 9/10 runs at least some of them fails. These tests are random, however, so I don't target zero flakiness.

Also tests with/without flat storage are better parametrised.