### PR TITLE
Better buckets for storage proof size metrics

### DIFF
--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1453,7 +1453,12 @@ impl Runtime {
             metrics::RECEIPT_RECORDED_SIZE_UPPER_BOUND.observe(recorded_storage_upper_bound_diff);
             let recorded_storage_proof_ratio =
                 recorded_storage_upper_bound_diff / f64::max(1.0, recorded_storage_diff);
-            metrics::RECEIPT_RECORDED_SIZE_UPPER_BOUND_RATIO.observe(recorded_storage_proof_ratio);
+            // Record the ratio only for large receipts, small receipts can have a very high ratio,
+            // but the ratio is not that important for them.
+            if recorded_storage_upper_bound_diff > 100_000. {
+                metrics::RECEIPT_RECORDED_SIZE_UPPER_BOUND_RATIO
+                    .observe(recorded_storage_proof_ratio);
+            }
             if let Some(outcome_with_id) = result? {
                 let gas_burnt = outcome_with_id.outcome.gas_burnt;
                 let compute_usage = outcome_with_id

--- a/runtime/runtime/src/metrics.rs
+++ b/runtime/runtime/src/metrics.rs
@@ -309,7 +309,7 @@ pub static RECEIPT_RECORDED_SIZE_UPPER_BOUND: Lazy<Histogram> = Lazy::new(|| {
 pub static RECEIPT_RECORDED_SIZE_UPPER_BOUND_RATIO: Lazy<Histogram> = Lazy::new(|| {
     try_create_histogram_with_buckets(
         "near_receipt_recorded_size_upper_bound_ratio",
-        "Ratio of upper bound to true recorded size, equal to (near_receipt_recorded_size_upper_bound / near_receipt_recorded_size)",
+        "Ratio of upper bound to true recorded size, calculated only for sizes larger than 100KB, equal to (near_receipt_recorded_size_upper_bound / near_receipt_recorded_size)",
         buckets_for_storage_proof_size_ratio(),
     )
     .unwrap()


### PR DESCRIPTION
In #11000 I added some metrics for the size of receipt/chunk storage proofs, along with upper bound estimation of those sizes. The buckets chosen in the PR weren't that good, as I didn't know what sort of values to expect.
I have spent some time looking at the data and I'd like to adjust the buckets to better fit the data distribution.

* Most receipts generate < 100KB of storage proof, so for receipt-level sizes I'd like to use  a few small buckets and then some more big buckets to catch the big outliers.
* Chunk level proofs are usually within 2-6MB, so I changed the metric to use buckets between 0 and 15MB with 500KB increases
* The ratio for receipts was sometimes extremely high. I think it was due to small receipts (a receipt which writes little, but removes two nodes could easily shoot up to 50x ratio). Small receipts don't matter for the hard per receipt limit, so I excluded them from the metric to keep the values reasonable.

You can see how the new metrics look like here: https://nearinc.grafana.net/d/edbl9ztm5h1q8b/stateless-validation?orgId=1&var-chain_id=mainnet&var-shard_id=All&var-node_id=ci-b20a9aef-mainnet-rpc-europe-west4-01-84346caf&from=now-15m&to=now