### PR TITLE
trie: optimize TrieRefcountDeltaMap

### DIFF
--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -1933,7 +1933,9 @@ mod tests {
             let trie = tries.get_trie_for_shard(ShardUId::single_shard(), state_root);
 
             // Those known keys.
-            for (key, value) in trie_changes.into_iter().collect::<HashMap<_, _>>() {
+            for (key, value) in
+                trie_changes.into_iter().collect::<std::collections::HashMap<_, _>>()
+            {
                 if let Some(value) = value {
                     let want = Some(Ok((key.clone(), value)));
                     let mut iterator = trie.iter().unwrap();

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -33,7 +33,7 @@ use near_primitives::types::{AccountId, StateRoot, StateRootNode};
 use near_vm_runner::ContractCode;
 pub use raw_node::{Children, RawTrieNode, RawTrieNodeWithSize};
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::hash::Hash;
 use std::rc::Rc;
@@ -449,12 +449,12 @@ impl TrieRefcountSubtraction {
 /// Helps produce a list of additions and subtractions to the trie,
 /// especially in the case where deletions don't carry the full value.
 pub struct TrieRefcountDeltaMap {
-    map: HashMap<CryptoHash, (Option<Vec<u8>>, i32)>,
+    map: BTreeMap<CryptoHash, (Option<Vec<u8>>, i32)>,
 }
 
 impl TrieRefcountDeltaMap {
     pub fn new() -> Self {
-        Self { map: HashMap::new() }
+        Self { map: BTreeMap::new() }
     }
 
     pub fn add(&mut self, hash: CryptoHash, data: Vec<u8>, refcount: u32) {
@@ -469,8 +469,9 @@ impl TrieRefcountDeltaMap {
     }
 
     pub fn into_changes(self) -> (Vec<TrieRefcountAddition>, Vec<TrieRefcountSubtraction>) {
-        let mut insertions = Vec::new();
-        let mut deletions = Vec::new();
+        let num_insertions = self.map.iter().filter(|(_h, (_v, rc))| *rc > 0).count();
+        let mut insertions = Vec::with_capacity(num_insertions);
+        let mut deletions = Vec::with_capacity(self.map.len().saturating_sub(num_insertions));
         for (hash, (value, rc)) in self.map.into_iter() {
             if rc > 0 {
                 insertions.push(TrieRefcountAddition {


### PR DESCRIPTION
This is a very initial step on optimizing parts of the storage implementation that stick out in the profiles.

Overall the `RefcountDeltaMap` operations show up as taking 400ms of wall clock time when applying 250 blocks of a single shard. With this change, the number decreases to 250ms.

One of the reasons for using BTreeMap here is the observation that inside `into_changes` we sort the changes eventually. So we might as well build up a sorted representation in the first place.

https://share.firefox.dev/3U3nF3K

---

As a side note, we seem to be storing a huge number of maps from `CryptoHash` to some value. This hash when stored in a hashmap then gets hashed again, which costs us quite some time. Once I create a `CryptoHashMap` data structure, I will re-evaluate whether it may make sense to go back to a hashmap here…