### PR TITLE
Remove tracing from `move_node_to_mutable`

### DIFF
--- a/core/store/src/trie/insert_delete.rs
+++ b/core/store/src/trie/insert_delete.rs
@@ -563,16 +563,16 @@ impl Trie {
                             new_children[i - 1] = Some(last_hash);
                         }
                         while i < 16 {
-                            match children[i].clone() {
+                            match &children[i] {
                                 Some(NodeHandle::InMemory(handle)) => {
                                     stack.push((
                                         node,
                                         FlattenNodesCrumb::AtChild(new_children, i + 1),
                                     ));
-                                    stack.push((handle, FlattenNodesCrumb::Entering));
+                                    stack.push((*handle, FlattenNodesCrumb::Entering));
                                     continue 'outer;
                                 }
-                                Some(NodeHandle::Hash(hash)) => new_children[i] = Some(hash),
+                                Some(NodeHandle::Hash(hash)) => new_children[i] = Some(*hash),
                                 None => {}
                             }
                             i += 1;

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -1130,12 +1130,6 @@ impl Trie {
         }
     }
 
-    #[tracing::instrument(
-        level = "trace",
-        target = "store::trie",
-        "Trie::move_node_to_mutable",
-        skip_all
-    )]
     fn move_node_to_mutable(
         &self,
         memory: &mut NodesStorage,


### PR DESCRIPTION
This is a particularly frequently invoked function, and the overhead of tracing is becomes somewhat notable with the frequent invocations, even when the span is disabled.