### PR TITLE
fix: recompress_storage.py

### DIFF
--- a/docs/practices/workflows/io_trace.md
+++ b/docs/practices/workflows/io_trace.md
@@ -44,7 +44,7 @@ cargo build --release -p neard --features=io_trace
 target/release/neard \
     --record-io-trace=75220100-75220101.s0.io_trace \
     view-state apply-range --start-index 75220100 --end-index 75220101 \
-    --sequential --shard-id 0
+    --shard-id 0 sequential
 ```
 
 ```bash

--- a/pytest/tests/sanity/recompress_storage.py
+++ b/pytest/tests/sanity/recompress_storage.py
@@ -81,6 +81,7 @@ class RecompressStorageTestCase(unittest.TestCase):
                 'apply-range',
                 '--start-index=0',
                 '--verbose-output',
+                'sequential',
             )
 
         # Restart all nodes with the new database

--- a/runtime/runtime-params-estimator/README.md
+++ b/runtime/runtime-params-estimator/README.md
@@ -86,7 +86,7 @@ do
   target/release/neard \
     --record-io-trace=75220100-75220101.s${shard}.io_trace view-state \
     apply-range --start-index 75220100 --end-index 75220101 \
-    --sequential --shard-id ${shard}
+    --shard-id ${shard} sequential
 done
 ```
 


### PR DESCRIPTION
It was broken after #10961 because format of command changed. Fixing the format.
Note that it is not a complete solution because of #8741, but the issue may occur only if charged costs are complicated, which is unlikely the case for the test.

Nayduck https://nayduck.nearone.org/#/run/50