### PR TITLE
fix(minor): more aggressive state witness orphan pool final block height check

### DIFF
--- a/chain/client/src/stateless_validation/chunk_validator/orphan_witness_pool.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/orphan_witness_pool.rs
@@ -89,7 +89,7 @@ impl OrphanStateWitnessPool {
     pub fn remove_witnesses_below_final_height(&mut self, final_height: BlockHeight) {
         let mut to_remove: Vec<(ShardId, BlockHeight)> = Vec::new();
         for ((witness_shard, witness_height), cache_entry) in self.witness_cache.iter() {
-            if *witness_height < final_height {
+            if *witness_height <= final_height {
                 to_remove.push((*witness_shard, *witness_height));
                 let header = &cache_entry.witness.chunk_header;
                 tracing::debug!(
@@ -358,7 +358,7 @@ mod tests {
         let waiting_for_100 = pool.take_state_witnesses_waiting_for_block(&block(100));
         assert_contents(waiting_for_100, vec![witness2]);
 
-        pool.remove_witnesses_below_final_height(103);
+        pool.remove_witnesses_below_final_height(102);
 
         let waiting_for_99 = pool.take_state_witnesses_waiting_for_block(&block(99));
         assert_contents(waiting_for_99, vec![]);


### PR DESCRIPTION
It is safe to also drop state witness with `height_created` equal to the height of the last final block.
This is mostly to stay consistent with the check introduced in #11081.