### PR TITLE
feat(mocknet): add info on local mocknet tests to the README

### DIFF
--- a/pytest/tests/mocknet/README.md
+++ b/pytest/tests/mocknet/README.md
@@ -12,3 +12,34 @@ If there's ever a problem with the neard runners on each node, for example if yo
 
 To run a locust load test on the mocknet network, run `python3 tests/mocknet/locust.py init --instance-names {}`, where
 the instance names are VMs that have been prepared for this purpose, and then run `python3 tests/mocknet/locust.py run --master {master_instance_name} --workers {worker_instance_name0,worker_instance_name1,etc...} --funding-key {key.json} --node-ip-port {mocknet_node_ip}:3030`, where `mocknet_node_ip` is an IP address of a node that's been setup by the mirror.py script, and `key.json` is an account key that contains lots of NEAR for this load test. TODO: add extra accounts for load testing purposes during the mocknet setup step
+
+# Running mocknet locally
+
+If you want to set up a mocknet instance locally, the script in local_test_node.py can set this up. First you'll need a neard home directory with some transactions in it (there's no actual requirement that it have any transactions, but it might be more interesting if it does). To get this, you can run one of the pytests that generates transactions, or you can follow the instructions in the README in `pytest/tests/loadtest/locust`.
+
+Suppose we've done that and the directory in `~/.near/localnet/node0` contains the state of one of our nodes. First, find the head of the chain:
+
+```
+neard --home ~/.near/localnet/node0 view-state view-chain
+```
+
+Then find a height of the chain that's a bit behind the head. There's no easy way to find this programatically at the timie of this writing, but you might try `neard --home ~/.near/localnet/node0 view-state view-chain --height {HEIGHT}` where `$HEIGHT` is maybe 100 blocks behind the head. For this earlier height that we choose as the fork height, there also happens to be a requirement that the first block of the epoch it belongs to should be included in the home directory as well. (This is required by the dump-state command, and maybe could be removed in the future) So if you choose some height and the below setup command fails at `view-state dump-state`, you might need to choose a later height. So, say the head of the chain is 400, and we want to fork at height 300. Then to set up a local mocknet, run:
+
+```
+python3 tests/mocknet/local_test_node.py local-test-setup --yes --num-nodes 2 --source-home-dir ~/.near/localnet/node0 --neard-binary-path ~/nearcore/target/debug/neard --fork-height 300 --legacy-records
+```
+
+Then you can run the normal `mirror.py` commands to control this mocknet instance, passing it `--local-test` instead of the usual `--start-height`, `--chain-id` and `--unique-id` flags:
+
+```
+python3 tests/mocknet/mirror.py --local-test new-test
+python3 tests/mocknet/mirror.py --local-test start-traffic
+```
+
+The above `local_test_node.py` command will set up directories in `~/.near/local-mocknet` where state has been forked from `~/.near/localnet/node0` at height 300. The `--legacy-records` argument tells us to use the older records.json method of forking state instead of the newer `neard fork-network` method. If you want to use that one, it's a bit more involved since you'll need two NEAR directories, where one has some head height, say N, and the other should have a head height M > N, *and* it should include height N as well. This will be the directory we use for the traffic generation, which is why it should include height N so that we can start sending transactions from that point. If you're using locust traffic sent to a localnet for the source chain, one way to achieve this is to start a localnet with, say, four nodes (at least that many so the chain doesn't stall when you stop one of them). Then as you're sending locust traffic, stop one of the nodes and leave the others running for a little while longer (but not so long that they end up garbage collecting the block at which the stopped node went offline). Then if `~/.near/localnet/node1` is the home directory for the node that was stopped early, and `~/.near/localnet/node0` is the home directory for one of the other nodes, you can set up the local mocknet with:
+
+```
+python3 tests/mocknet/local_test_node.py local-test-setup --yes --num-nodes 2 --source-home-dir ~/.near/localnet/node0 --neard-binary-path ~/nearcore/target/debug/neard --target-home-dir ~/.near/localnet/node1
+```
+
+And then run the mirror.py commands as explained above.

--- a/pytest/tests/mocknet/local_test_node.py
+++ b/pytest/tests/mocknet/local_test_node.py
@@ -158,7 +158,16 @@ def prompt_flags(args):
         args.neard_binary_path = sys.stdin.readline().strip()
         assert len(args.neard_binary_path) > 0
 
-    if not args.legacy_records and args.fork_height is None:
+    if args.fork_height is not None:
+        if not args.legacy_records:
+            print(
+                '--legacy-records not given. Assuming it based on --fork-height'
+            )
+            args.legacy_records = True
+    elif args.target_home_dir is not None:
+        if args.legacy_records:
+            sys.exit('cannot give --target-home-dir and --legacy-records')
+    elif not args.legacy_records:
         print(
             'prepare nodes with fork-network tool instead of genesis records JSON? [yes/no]:'
         )


### PR DESCRIPTION
This adds some instructions on how to set up a mocknet locally, plus a small fix in flag prompting in local_test_node.py.