### PR TITLE
feat: avoid processing state witness multiple times

### DIFF
--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -133,6 +133,8 @@ pub enum Error {
     InvalidChunkState(Box<ChunkState>),
     #[error("Invalid Chunk State Witness: {0}")]
     InvalidChunkStateWitness(String),
+    #[error("Duplicate Chunk State Witness: {0}")]
+    DuplicateChunkStateWitness(String),
     #[error("Invalid Chunk Endorsement")]
     InvalidChunkEndorsement,
     /// Invalid chunk mask
@@ -270,6 +272,7 @@ impl Error {
             | Error::InvalidChunkProofs(_)
             | Error::InvalidChunkState(_)
             | Error::InvalidChunkStateWitness(_)
+            | Error::DuplicateChunkStateWitness(_)
             | Error::InvalidChunkEndorsement
             | Error::InvalidChunkMask
             | Error::InvalidStateRoot
@@ -344,6 +347,7 @@ impl Error {
             Error::InvalidChunkProofs(_) => "invalid_chunk_proofs",
             Error::InvalidChunkState(_) => "invalid_chunk_state",
             Error::InvalidChunkStateWitness(_) => "invalid_chunk_state_witness",
+            Error::DuplicateChunkStateWitness(_) => "duplicate_chunk_state_witness",
             Error::InvalidChunkEndorsement => "invalid_chunk_endorsement",
             Error::InvalidChunkMask => "invalid_chunk_mask",
             Error::InvalidStateRoot => "invalid_state_root",

--- a/core/primitives/src/stateless_validation.rs
+++ b/core/primitives/src/stateless_validation.rs
@@ -376,6 +376,27 @@ impl ChunkValidatorAssignments {
     }
 }
 
+/// This struct contains combination of fields that uniquely identify chunk production.
+/// It means that for a given instance only one chunk could be produced.
+/// The main use case it to track processed state witness in order to protect stateless
+/// validator against malicious chunk producers.
+#[derive(Hash, PartialEq, Eq)]
+pub struct ChunkProductionKey {
+    pub shard_id: ShardId,
+    pub epoch_id: EpochId,
+    pub height_created: BlockHeight,
+}
+
+impl ChunkProductionKey {
+    pub fn from_witness(witness: &ChunkStateWitness) -> Self {
+        Self {
+            shard_id: witness.chunk_header.shard_id(),
+            epoch_id: witness.epoch_id.clone(),
+            height_created: witness.chunk_header.height_created(),
+        }
+    }
+}
+
 fn decompress_with_limit(data: &[u8], limit: usize) -> std::io::Result<Vec<u8>> {
     let mut buf = Vec::new().limit(limit).writer();
     match zstd::stream::copy_decode(data, &mut buf) {


### PR DESCRIPTION
This PR introduces tracking of processes state witnesses as a protection against wasting stateless validator resources.
Note that we track state witnesses for chunks built only on top of the blocks that are known to us (orphan pool takes care of the rest) and not yet final (covered by #11081). So we only need a pretty limited capacity for the LRU cache keeping track of received instances.

Part of https://github.com/near/nearcore/issues/10565.