### PR TITLE
jsonrpc: add api to get block proof

### DIFF
--- a/chain/jsonrpc-primitives/src/types/light_client.rs
+++ b/chain/jsonrpc-primitives/src/types/light_client.rs
@@ -14,6 +14,12 @@ pub struct RpcLightClientNextBlockRequest {
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct RpcLightClientBlockProofRequest {
+    pub block_hash: near_primitives::hash::CryptoHash,
+    pub light_client_head: near_primitives::hash::CryptoHash,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct RpcLightClientExecutionProofResponse {
     pub outcome_proof: near_primitives::views::ExecutionOutcomeWithIdView,
     pub outcome_root_proof: near_primitives::merkle::MerklePath,
@@ -25,6 +31,12 @@ pub struct RpcLightClientExecutionProofResponse {
 pub struct RpcLightClientNextBlockResponse {
     #[serde(flatten)]
     pub light_client_block: Option<Arc<near_primitives::views::LightClientBlockView>>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct RpcLightClientBlockProofResponse {
+    pub block_header_lite: near_primitives::views::LightClientBlockLiteView,
+    pub block_proof: near_primitives::merkle::MerklePath,
 }
 
 #[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]

--- a/chain/jsonrpc/src/api/light_client.rs
+++ b/chain/jsonrpc/src/api/light_client.rs
@@ -8,8 +8,9 @@ use near_client_primitives::types::{
 };
 use near_jsonrpc_primitives::errors::RpcParseError;
 use near_jsonrpc_primitives::types::light_client::{
-    RpcLightClientExecutionProofRequest, RpcLightClientNextBlockError,
-    RpcLightClientNextBlockRequest, RpcLightClientNextBlockResponse, RpcLightClientProofError,
+    RpcLightClientBlockProofRequest, RpcLightClientExecutionProofRequest,
+    RpcLightClientNextBlockError, RpcLightClientNextBlockRequest, RpcLightClientNextBlockResponse,
+    RpcLightClientProofError,
 };
 use near_primitives::views::LightClientBlockView;
 
@@ -26,6 +27,12 @@ impl RpcRequest for RpcLightClientNextBlockRequest {
         Params::new(value)
             .try_singleton(|last_block_hash| Ok(Self { last_block_hash }))
             .unwrap_or_parse()
+    }
+}
+
+impl RpcRequest for RpcLightClientBlockProofRequest {
+    fn parse(value: Value) -> Result<Self, RpcParseError> {
+        Params::parse(value)
     }
 }
 

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -384,9 +384,6 @@ impl JsonRpcHandler {
             "next_light_client_block" => {
                 process_method_call(request, |params| self.next_light_client_block(params)).await
             }
-            "light_client_block_proof" => {
-                process_method_call(request, |params| self.light_client_block_proof(params)).await
-            }
             "network_info" => process_method_call(request, |_params: ()| self.network_info()).await,
             "send_tx" => process_method_call(request, |params| self.send_tx(params)).await,
             "status" => process_method_call(request, |_params: ()| self.status()).await,
@@ -414,6 +411,9 @@ impl JsonRpcHandler {
                     self.light_client_execution_outcome_proof(params)
                 })
                 .await
+            }
+            "EXPERIMENTAL_light_client_block_proof" => {
+                process_method_call(request, |params| self.light_client_block_proof(params)).await
             }
             "EXPERIMENTAL_protocol_config" => {
                 process_method_call(request, |params| self.protocol_config(params)).await


### PR DESCRIPTION
Added json rpc api `light_client_block_proof` to get the block proof.
Inputs:
```
pub struct RpcLightClientBlockProofRequest {
    pub block_hash: near_primitives::hash::CryptoHash,
    pub light_client_head: near_primitives::hash::CryptoHash,
}
```
outputs:
```
pub struct RpcLightClientBlockProofResponse {
    pub block_header_lite: near_primitives::views::LightClientBlockLiteView,
    pub block_proof: near_primitives::merkle::MerklePath,
}
```
## Description
The current `light_client_proof` api returns two kinds of proofs:
1. Outcome proof: this proof is needed to prove that the outcome was included in a block.
2. Block proof: to prove the block is part of the chain.

Currently, we can use only the archival node to get proof of historical outcomes because the regular nodes store only blocks for the last five epochs.
To get rid of dependence on the archival node, we propose generating the proof for outcome in two steps:
1. Use the regular node to get the block proof.
2. Use any other sources to get blocks and outcome proofs. it could be [near-lake-framework](https://github.com/near/near-lake-framework-rs), [fastnear](https://github.com/fastnear/neardata-server), archival nodes or any other custom blocks indexer.