### PR TITLE
feat(pytest): reenable store validator

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -33,6 +33,7 @@ use std::sync::{Arc, RwLock};
 use tokio::sync::broadcast;
 
 use crate::client_actions::{ClientActionHandler, ClientActions, ClientSenderForClient};
+use crate::gc_actor::GCActor;
 use crate::start_gc_actor;
 use crate::stateless_validation::state_witness_actor::StateWitnessSenderForClient;
 use crate::sync_jobs_actions::SyncJobsActions;
@@ -181,6 +182,7 @@ fn wait_until_genesis(genesis_time: &Utc) {
 
 pub struct StartClientResult {
     pub client_actor: Addr<ClientActor>,
+    pub gc_actor: Addr<GCActor>,
     pub client_arbiter_handle: ArbiterHandle,
     pub resharding_handle: ReshardingHandle,
     pub gc_arbiter_handle: ArbiterHandle,
@@ -231,7 +233,7 @@ pub fn start_client(
     .unwrap();
     let resharding_handle = client.chain.resharding_handle.clone();
 
-    let (_, gc_arbiter_handle) = start_gc_actor(
+    let (gc_actor, gc_arbiter_handle) = start_gc_actor(
         runtime.store().clone(),
         genesis_height,
         client_config.clone(),
@@ -262,5 +264,6 @@ pub fn start_client(
         client_arbiter_handle,
         resharding_handle,
         gc_arbiter_handle,
+        gc_actor,
     }
 }

--- a/chain/jsonrpc/jsonrpc-tests/src/lib.rs
+++ b/chain/jsonrpc/jsonrpc-tests/src/lib.rs
@@ -58,6 +58,8 @@ pub fn start_all_with_validity_period_and_no_epoch_sync(
         actor_handles.client_actor.clone().with_auto_span_context().into_multi_sender(),
         actor_handles.view_client_actor.clone().with_auto_span_context().into_multi_sender(),
         noop().into_multi_sender(),
+        #[cfg(feature = "test_features")]
+        noop().into_multi_sender(),
         Arc::new(DummyEntityDebugHandler {}),
     );
     (actor_handles.view_client_actor, addr)

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1264,7 +1264,10 @@ impl JsonRpcHandler {
     /// After store validator is done, resume GC by sending another message to GC Actor.
     /// This ensures that store validator is not run concurrently with another thread that may modify storage.
     async fn adv_check_store(&self, _params: Value) -> Result<Value, RpcError> {
-        self.gc_sender.send_async(near_client::gc_actor::NetworkAdversarialMessage::StopGC).await.map_err(|_| RpcError::server_error::<String>(None))?;
+        self.gc_sender
+            .send_async(near_client::gc_actor::NetworkAdversarialMessage::StopGC)
+            .await
+            .map_err(|_| RpcError::server_error::<String>(None))?;
         let ret_val = match self
             .client_sender
             .send_async(near_client::NetworkAdversarialMessage::AdvCheckStorageConsistency)
@@ -1276,7 +1279,10 @@ impl JsonRpcHandler {
             },
             _ => Err(RpcError::server_error::<String>(None)),
         }?;
-        self.gc_sender.send_async(near_client::gc_actor::NetworkAdversarialMessage::ResumeGC).await.map_err(|_| RpcError::server_error::<String>(None))?;
+        self.gc_sender
+            .send_async(near_client::gc_actor::NetworkAdversarialMessage::ResumeGC)
+            .await
+            .map_err(|_| RpcError::server_error::<String>(None))?;
         Ok(ret_val)
     }
 }
@@ -1475,8 +1481,7 @@ pub fn start_http(
     client_sender: ClientSenderForRpc,
     view_client_sender: ViewClientSenderForRpc,
     peer_manager_sender: PeerManagerSenderForRpc,
-    #[cfg(feature = "test_features")]
-    gc_sender: GCSenderForRpc,
+    #[cfg(feature = "test_features")] gc_sender: GCSenderForRpc,
     entity_debug_handler: Arc<dyn EntityDebugHandler>,
 ) -> Vec<(&'static str, actix_web::dev::ServerHandle)> {
     let RpcConfig {

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -262,6 +262,15 @@ pub struct ViewClientSenderForRpc(
     #[cfg(feature = "test_features")] Sender<near_client::NetworkAdversarialMessage>,
 );
 
+#[cfg(feature = "test_features")]
+#[derive(Clone, near_async::MultiSend, near_async::MultiSenderFrom)]
+pub struct GCSenderForRpc(
+    AsyncSender<
+        near_client::gc_actor::NetworkAdversarialMessage,
+        ActixResult<near_client::gc_actor::NetworkAdversarialMessage>,
+    >,
+);
+
 #[derive(Clone, near_async::MultiSend, near_async::MultiSenderFrom)]
 pub struct PeerManagerSenderForRpc(AsyncSender<GetDebugStatus, ActixResult<GetDebugStatus>>);
 
@@ -269,6 +278,8 @@ struct JsonRpcHandler {
     client_sender: ClientSenderForRpc,
     view_client_sender: ViewClientSenderForRpc,
     peer_manager_sender: PeerManagerSenderForRpc,
+    #[cfg(feature = "test_features")]
+    gc_sender: GCSenderForRpc,
     polling_config: RpcPollingConfig,
     genesis_config: GenesisConfig,
     enable_debug_rpc: bool,
@@ -1249,8 +1260,12 @@ impl JsonRpcHandler {
         }
     }
 
+    /// First, stop GC by sending a message to GC Actor. Then run store validator inside Client.
+    /// After store validator is done, resume GC by sending another message to GC Actor.
+    /// This ensures that store validator is not run concurrently with another thread that may modify storage.
     async fn adv_check_store(&self, _params: Value) -> Result<Value, RpcError> {
-        match self
+        self.gc_sender.send_async(near_client::gc_actor::NetworkAdversarialMessage::StopGC).await.map_err(|_| RpcError::server_error::<String>(None))?;
+        let ret_val = match self
             .client_sender
             .send_async(near_client::NetworkAdversarialMessage::AdvCheckStorageConsistency)
             .await
@@ -1260,7 +1275,9 @@ impl JsonRpcHandler {
                 None => Err(RpcError::server_error::<String>(None)),
             },
             _ => Err(RpcError::server_error::<String>(None)),
-        }
+        }?;
+        self.gc_sender.send_async(near_client::gc_actor::NetworkAdversarialMessage::ResumeGC).await.map_err(|_| RpcError::server_error::<String>(None))?;
+        Ok(ret_val)
     }
 }
 
@@ -1458,6 +1475,8 @@ pub fn start_http(
     client_sender: ClientSenderForRpc,
     view_client_sender: ViewClientSenderForRpc,
     peer_manager_sender: PeerManagerSenderForRpc,
+    #[cfg(feature = "test_features")]
+    gc_sender: GCSenderForRpc,
     entity_debug_handler: Arc<dyn EntityDebugHandler>,
 ) -> Vec<(&'static str, actix_web::dev::ServerHandle)> {
     let RpcConfig {
@@ -1485,6 +1504,8 @@ pub fn start_http(
                 enable_debug_rpc,
                 debug_pages_src_path: debug_pages_src_path.clone().map(Into::into),
                 entity_debug_handler: entity_debug_handler.clone(),
+                #[cfg(feature = "test_features")]
+                gc_sender: gc_sender.clone(),
             }))
             .app_data(web::JsonConfig::default().limit(limits_config.json_payload_max_size))
             .wrap(middleware::Logger::default())

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -365,6 +365,10 @@ pub fn start_with_config_and_synchronization(
         client_arbiter_handle,
         resharding_handle,
         gc_arbiter_handle,
+        #[cfg(feature = "test_features")]
+        gc_actor,
+        #[cfg(not(feature = "test_features"))]
+        gc_actor: _,
     } = start_client(
         Clock::real(),
         config.client_config.clone(),
@@ -450,6 +454,8 @@ pub fn start_with_config_and_synchronization(
             client_actor.clone().with_auto_span_context().into_multi_sender(),
             view_client.clone().with_auto_span_context().into_multi_sender(),
             network_actor.into_multi_sender(),
+            #[cfg(feature = "test_features")]
+            gc_actor.into_multi_sender(),
             Arc::new(entity_debug_handler),
         ));
     }

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -368,7 +368,7 @@ pub fn start_with_config_and_synchronization(
         #[cfg(feature = "test_features")]
         gc_actor,
         #[cfg(not(feature = "test_features"))]
-        gc_actor: _,
+            gc_actor: _,
     } = start_client(
         Clock::real(),
         config.client_config.clone(),

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -144,7 +144,7 @@ class BaseNode(object):
         self._proxy_local_stopped = None
         self.proxy = None
         self.store_tests = 0
-        self.is_check_store = False
+        self.is_check_store = True
 
     def change_config(self, overrides: typing.Dict[str, typing.Any]) -> None:
         """Change client config.json of a node by applying given overrides.

--- a/pytest/tests/sanity/garbage_collection_archival.py
+++ b/pytest/tests/sanity/garbage_collection_archival.py
@@ -168,3 +168,6 @@ for key in keys:
             "block_id": block_hash
         })
     assert 'error' in res, res
+
+nodes[1].check_store()
+nodes[2].check_store()

--- a/pytest/tests/sanity/garbage_collection_intense.py
+++ b/pytest/tests/sanity/garbage_collection_intense.py
@@ -84,6 +84,8 @@ nonce += 1
 assert 'SuccessValue' in res['result']['status']
 time.sleep(1)
 
+nodes[1].stop_checking_store()
+
 while True:
     block_id = nodes[1].get_latest_block()
     if int(block_id.height) > TARGET_HEIGHT:
@@ -132,3 +134,5 @@ res = nodes[1].json_rpc(
         "block_id": deletion_finish_block_height
     })
 assert res['error']['cause']['name'] == "GARBAGE_COLLECTED_BLOCK", res
+
+nodes[1].check_store()


### PR DESCRIPTION
Re-enable store validator tests that were disabled in #11022. It works by first sending a signal to GC actor to stop garbage collection, then run the store validator, and send a signal to re-enable gc afterwards.

Nayduck run https://nayduck.nearone.org/#/run/58