### PR TITLE
[resharding] Shard layout V3 for statelessnet_protocol

### DIFF
--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -202,9 +202,6 @@ impl ProtocolFeature {
             ProtocolFeature::RestrictTla
             | ProtocolFeature::TestnetFewerBlockProducers
             | ProtocolFeature::SimpleNightshadeV2 => 64,
-            // The SimpleNightshadeV3 should not be enabled in statelessnet.
-            // TODO(resharding) clean up after stake wars is over.
-            #[cfg(not(feature = "statelessnet_protocol"))]
             ProtocolFeature::SimpleNightshadeV3 => 65,
             ProtocolFeature::DecreaseFunctionCallBaseCost => 66,
 
@@ -234,8 +231,6 @@ impl ProtocolFeature {
             ProtocolFeature::EthImplicitAccounts => 138,
             #[cfg(feature = "protocol_feature_nonrefundable_transfer_nep491")]
             ProtocolFeature::NonrefundableStorage => 140,
-            #[cfg(feature = "statelessnet_protocol")]
-            ProtocolFeature::SimpleNightshadeV3 => 141,
         }
     }
 }

--- a/integration-tests/src/tests/client/resharding.rs
+++ b/integration-tests/src/tests/client/resharding.rs
@@ -46,7 +46,6 @@ const SIMPLE_NIGHTSHADE_PROTOCOL_VERSION: ProtocolVersion =
 const SIMPLE_NIGHTSHADE_V2_PROTOCOL_VERSION: ProtocolVersion =
     ProtocolFeature::SimpleNightshadeV2.protocol_version();
 
-#[cfg(not(feature = "statelessnet_protocol"))]
 const SIMPLE_NIGHTSHADE_V3_PROTOCOL_VERSION: ProtocolVersion =
     ProtocolFeature::SimpleNightshadeV3.protocol_version();
 
@@ -63,7 +62,6 @@ enum ReshardingType {
     // In the V1->V2 resharding outgoing receipts are reassigned to lowest index child.
     V2,
     // In the V2->V3 resharding outgoing receipts are reassigned to lowest index child.
-    #[cfg(not(feature = "statelessnet_protocol"))]
     V3,
     // In V3->TESTONLY resharding outgoing receipts are reassigned to lowest index child.
     #[cfg(feature = "nightly")]
@@ -74,7 +72,6 @@ fn get_target_protocol_version(resharding_type: &ReshardingType) -> ProtocolVers
     match resharding_type {
         ReshardingType::V1 => SIMPLE_NIGHTSHADE_PROTOCOL_VERSION,
         ReshardingType::V2 => SIMPLE_NIGHTSHADE_V2_PROTOCOL_VERSION,
-        #[cfg(not(feature = "statelessnet_protocol"))]
         ReshardingType::V3 => SIMPLE_NIGHTSHADE_V3_PROTOCOL_VERSION,
         #[cfg(feature = "nightly")]
         ReshardingType::TESTONLY => SIMPLE_NIGHTSHADE_TESTONLY_PROTOCOL_VERSION,
@@ -89,7 +86,6 @@ fn get_parent_shard_uids(resharding_type: &ReshardingType) -> Vec<ShardUId> {
     let shard_layout = match resharding_type {
         ReshardingType::V1 => ShardLayout::v0_single_shard(),
         ReshardingType::V2 => ShardLayout::get_simple_nightshade_layout(),
-        #[cfg(not(feature = "statelessnet_protocol"))]
         ReshardingType::V3 => ShardLayout::get_simple_nightshade_layout_v2(),
         #[cfg(feature = "nightly")]
         ReshardingType::TESTONLY => ShardLayout::get_simple_nightshade_layout_v3(),
@@ -107,7 +103,6 @@ fn get_expected_shards_num(
         match resharding_type {
             ReshardingType::V1 => 1,
             ReshardingType::V2 => 4,
-            #[cfg(not(feature = "statelessnet_protocol"))]
             ReshardingType::V3 => 5,
             #[cfg(feature = "nightly")]
             ReshardingType::TESTONLY => 6,
@@ -116,7 +111,6 @@ fn get_expected_shards_num(
         match resharding_type {
             ReshardingType::V1 => 4,
             ReshardingType::V2 => 5,
-            #[cfg(not(feature = "statelessnet_protocol"))]
             ReshardingType::V3 => 6,
             #[cfg(feature = "nightly")]
             ReshardingType::TESTONLY => 7,
@@ -831,7 +825,6 @@ fn check_outgoing_receipts_reassigned_impl(
                 assert!(outgoing_receipts.is_empty());
             }
         }
-        #[cfg(not(feature = "statelessnet_protocol"))]
         ReshardingType::V3 => {
             // In V2->V3 resharding the outgoing receipts should be reassigned
             // to the lowest index child of the parent shard.
@@ -1082,19 +1075,16 @@ fn test_shard_layout_upgrade_simple_v2_seed_44() {
     test_shard_layout_upgrade_simple_impl(ReshardingType::V2, 44, false);
 }
 
-#[cfg(not(feature = "statelessnet_protocol"))]
 #[test]
 fn test_shard_layout_upgrade_simple_v3_seed_42() {
     test_shard_layout_upgrade_simple_impl(ReshardingType::V3, 42, false);
 }
 
-#[cfg(not(feature = "statelessnet_protocol"))]
 #[test]
 fn test_shard_layout_upgrade_simple_v3_seed_43() {
     test_shard_layout_upgrade_simple_impl(ReshardingType::V3, 43, false);
 }
 
-#[cfg(not(feature = "statelessnet_protocol"))]
 #[test]
 fn test_shard_layout_upgrade_simple_v3_seed_44() {
     test_shard_layout_upgrade_simple_impl(ReshardingType::V3, 44, false);
@@ -1157,7 +1147,6 @@ fn test_resharding_with_different_db_kind_v2() {
     test_resharding_with_different_db_kind_impl(ReshardingType::V2);
 }
 
-#[cfg(not(feature = "statelessnet_protocol"))]
 #[test]
 fn test_resharding_with_different_db_kind_v3() {
     test_resharding_with_different_db_kind_impl(ReshardingType::V3);
@@ -1217,7 +1206,6 @@ fn test_shard_layout_upgrade_gc_v2() {
     test_shard_layout_upgrade_gc_impl(ReshardingType::V2, 44);
 }
 
-#[cfg(not(feature = "statelessnet_protocol"))]
 #[test]
 fn test_shard_layout_upgrade_gc_v3() {
     test_shard_layout_upgrade_gc_impl(ReshardingType::V3, 44);
@@ -1520,7 +1508,6 @@ fn test_shard_layout_upgrade_cross_contract_calls_v2_seed_44() {
 // Test cross contract calls
 // This test case tests postponed receipts and delayed receipts
 #[test]
-#[cfg(not(feature = "statelessnet_protocol"))]
 fn test_shard_layout_upgrade_cross_contract_calls_v3_seed_42() {
     test_shard_layout_upgrade_cross_contract_calls_impl(ReshardingType::V3, 42);
 }
@@ -1528,7 +1515,6 @@ fn test_shard_layout_upgrade_cross_contract_calls_v3_seed_42() {
 // Test cross contract calls
 // This test case tests postponed receipts and delayed receipts
 #[test]
-#[cfg(not(feature = "statelessnet_protocol"))]
 fn test_shard_layout_upgrade_cross_contract_calls_v3_seed_43() {
     test_shard_layout_upgrade_cross_contract_calls_impl(ReshardingType::V3, 43);
 }
@@ -1536,7 +1522,6 @@ fn test_shard_layout_upgrade_cross_contract_calls_v3_seed_43() {
 // Test cross contract calls
 // This test case tests postponed receipts and delayed receipts
 #[test]
-#[cfg(not(feature = "statelessnet_protocol"))]
 fn test_shard_layout_upgrade_cross_contract_calls_v3_seed_44() {
     test_shard_layout_upgrade_cross_contract_calls_impl(ReshardingType::V3, 44);
 }
@@ -1776,19 +1761,16 @@ fn test_shard_layout_upgrade_incoming_receipts_v2_seed_44() {
     test_shard_layout_upgrade_incoming_receipts_impl(ReshardingType::V2, 44);
 }
 
-#[cfg(not(feature = "statelessnet_protocol"))]
 #[test]
 fn test_shard_layout_upgrade_incoming_receipts_v3_seed_42() {
     test_shard_layout_upgrade_incoming_receipts_impl(ReshardingType::V3, 42);
 }
 
-#[cfg(not(feature = "statelessnet_protocol"))]
 #[test]
 fn test_shard_layout_upgrade_incoming_receipts_v3_seed_43() {
     test_shard_layout_upgrade_incoming_receipts_impl(ReshardingType::V3, 43);
 }
 
-#[cfg(not(feature = "statelessnet_protocol"))]
 #[test]
 fn test_shard_layout_upgrade_incoming_receipts_v3_seed_44() {
     test_shard_layout_upgrade_incoming_receipts_impl(ReshardingType::V3, 44);
@@ -1961,19 +1943,16 @@ fn test_shard_layout_upgrade_missing_chunks_high_missing_prob_v2_seed_44() {
 
 // V3 tests
 
-#[cfg(not(feature = "statelessnet_protocol"))]
 #[test]
 fn test_shard_layout_upgrade_missing_chunks_low_missing_prob_v3() {
     test_shard_layout_upgrade_missing_chunks(ReshardingType::V3, 0.1, 42);
 }
 
-#[cfg(not(feature = "statelessnet_protocol"))]
 #[test]
 fn test_shard_layout_upgrade_missing_chunks_mid_missing_prob_v3() {
     test_shard_layout_upgrade_missing_chunks(ReshardingType::V3, 0.5, 42);
 }
 
-#[cfg(not(feature = "statelessnet_protocol"))]
 #[test]
 fn test_shard_layout_upgrade_missing_chunks_high_missing_prob_v3() {
     test_shard_layout_upgrade_missing_chunks(ReshardingType::V3, 0.9, 42);
@@ -2081,7 +2060,6 @@ fn test_shard_layout_upgrade_error_handling_v2() {
     test_shard_layout_upgrade_error_handling_impl(ReshardingType::V2, 42, false);
 }
 
-#[cfg(not(feature = "statelessnet_protocol"))]
 #[test]
 fn test_shard_layout_upgrade_error_handling_v3() {
     test_shard_layout_upgrade_error_handling_impl(ReshardingType::V3, 42, false);


### PR DESCRIPTION
Originally we had disabled V3 layout (6 shards) for stateless_net as we do not support resharding with stateless net.

This more recently has been causing some problems with forknet + stateless validation where all the traffic from mainnet shards 2 and 3 is hitting shard 2 on forknet.

Since we have the capability to redeploy and restart forknet nodes at will, we can remove this shard layout constraint.