### PR TITLE
feat(forknet): move the traffic generator mount points for the new image type

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -151,19 +151,24 @@ class NeardRunner:
         self.lock = threading.Lock()
 
     def is_legacy(self):
-        if os.path.exists(os.path.join(self.neard_home, 'setup', 'data')):
-            if os.path.exists(
-                    os.path.join(self.neard_home, 'setup', 'records.json')):
-                logging.warning(
-                    f'found both records.json and data/ in {os.path.join(self.neard_home, "setup")}'
-                )
-            return False
         if os.path.exists(os.path.join(
                 self.neard_home, 'setup', 'records.json')) and os.path.exists(
                     os.path.join(self.neard_home, 'setup', 'genesis.json')):
+            if os.path.exists(os.path.join(self.neard_home, 'setup', 'data')):
+                logging.warning(
+                    f'found both records.json and data/ in {os.path.join(self.neard_home, "setup")}'
+                )
             return True
+        if self.is_traffic_generator():
+            target_dir = os.path.join(self.neard_home, 'target', 'setup')
+        else:
+            target_dir = os.path.join(self.neard_home, 'setup')
+        if os.path.exists(target_dir) and os.path.exists(
+                os.path.join(target_dir, 'data')) and os.path.exists(
+                    os.path.join(target_dir, 'config.json')):
+            return False
         sys.exit(
-            f'did not find either records.json and genesis.json or data/ in {os.path.join(self.neard_home, "setup")}'
+            f'did not find either records.json and genesis.json in {os.path.join(self.neard_home, "setup")} or neard home in {target_dir}'
         )
 
     def is_traffic_generator(self):
@@ -252,6 +257,16 @@ class NeardRunner:
                 self.reset_current_neard_path()
             self.save_data()
 
+    def setup_path(self, *args):
+        if not self.is_traffic_generator() or self.legacy_records:
+            args = ('setup',) + args
+        else:
+            args = (
+                'target',
+                'setup',
+            ) + args
+        return os.path.join(self.neard_home, *args)
+
     def target_near_home_path(self, *args):
         if self.is_traffic_generator():
             args = ('target',) + args
@@ -312,7 +327,7 @@ class NeardRunner:
             cmd = [
                 self.data['binaries'][0]['system_path'],
                 '--home',
-                os.path.join(self.neard_home, 'setup'),
+                self.setup_path(),
                 'database',
                 'make-snapshot',
                 '--destination',
@@ -339,9 +354,8 @@ class NeardRunner:
             shutil.move(self.tmp_near_home_path(path),
                         self.target_near_home_path(path))
         if not self.legacy_records:
-            shutil.copyfile(
-                os.path.join(self.neard_home, 'setup', 'genesis.json'),
-                self.target_near_home_path('genesis.json'))
+            shutil.copyfile(self.setup_path('genesis.json'),
+                            self.target_near_home_path('genesis.json'))
 
     # This RPC method tells to stop neard and re-initialize its home dir. This returns the
     # validator and node key that resulted from the initialization. We can't yet call amend-genesis
@@ -703,6 +717,16 @@ class NeardRunner:
         self.data['neard_process'] = None
         self.save_data()
 
+    def source_near_home_path(self):
+        if not self.is_traffic_generator():
+            logging.warn(
+                'source_near_home_path() called on non-traffic-generator node')
+            return self.neard_home
+        if self.legacy_records:
+            return self.neard_home
+        else:
+            return os.path.join(self.neard_home, 'source')
+
     # If this is a regular node, starts neard run. If it's a traffic generator, starts neard mirror run
     def start_neard(self):
         for i in range(20, -1, -1):
@@ -720,7 +744,7 @@ class NeardRunner:
                     'mirror',
                     'run',
                     '--source-home',
-                    self.neard_home,
+                    self.source_near_home_path(),
                     '--target-home',
                     self.target_near_home_path(),
                     '--no-secret',
@@ -817,9 +841,9 @@ class NeardRunner:
                 self.data['binaries'][0]['system_path'],
                 'amend-genesis',
                 '--genesis-file-in',
-                os.path.join(self.neard_home, 'setup', 'genesis.json'),
+                self.setup_path('genesis.json'),
                 '--records-file-in',
-                os.path.join(self.neard_home, 'setup', 'records.json'),
+                self.setup_path('records.json'),
                 '--genesis-file-out',
                 self.target_near_home_path('genesis.json'),
                 '--records-file-out',

--- a/pytest/tests/mocknet/local_test_node.py
+++ b/pytest/tests/mocknet/local_test_node.py
@@ -247,7 +247,7 @@ def make_legacy_records(neard_binary_path, traffic_generator_home, node_homes,
                         node_home / '.near/setup/records.json')
 
 
-def fork_db(neard_binary_path, target_home_dir, home_dir, setup_dir):
+def fork_db(neard_binary_path, target_home_dir, setup_dir):
     copy_source_home(target_home_dir, setup_dir)
 
     run_cmd([
@@ -269,11 +269,9 @@ def fork_db(neard_binary_path, target_home_dir, home_dir, setup_dir):
 
 def make_forked_network(neard_binary_path, traffic_generator_home, node_homes,
                         source_home_dir, target_home_dir):
-    for (home_dir, setup_dir) in [
-        (h / '.near', h / '.near/setup') for h in node_homes
-    ] + [(traffic_generator_home / '.near/target',
-          traffic_generator_home / '.near/setup')]:
-        fork_db(neard_binary_path, target_home_dir, home_dir, setup_dir)
+    for setup_dir in [h / '.near/setup' for h in node_homes
+                     ] + [traffic_generator_home / '.near/setup']:
+        fork_db(neard_binary_path, target_home_dir, setup_dir)
 
 
 def mkdirs(local_mocknet_path):

--- a/pytest/tests/mocknet/remote_node.py
+++ b/pytest/tests/mocknet/remote_node.py
@@ -4,6 +4,7 @@ defines the RemoteNeardRunner class meant to be interacted with over ssh
 """
 import pathlib
 import json
+import os
 import sys
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
@@ -15,8 +16,9 @@ import mocknet
 
 class RemoteNeardRunner:
 
-    def __init__(self, node):
+    def __init__(self, node, neard_runner_home):
         self.node = node
+        self.neard_runner_home = neard_runner_home
 
     def name(self):
         return self.node.instance_name
@@ -34,27 +36,26 @@ class RemoteNeardRunner:
         if remove_home_dir:
             cmd_utils.run_cmd(
                 self.node,
-                'rm -rf /home/ubuntu/.near/neard-runner && mkdir -p /home/ubuntu/.near/neard-runner'
+                f'rm -rf {self.neard_runner_home} && mkdir -p {self.neard_runner_home}'
             )
         else:
-            cmd_utils.run_cmd(self.node,
-                              'mkdir -p /home/ubuntu/.near/neard-runner')
+            cmd_utils.run_cmd(self.node, f'mkdir -p {self.neard_runner_home}')
 
     def upload_neard_runner(self):
         self.node.machine.upload('tests/mocknet/helpers/neard_runner.py',
-                                 '/home/ubuntu/.near/neard-runner',
+                                 self.neard_runner_home,
                                  switch_user='ubuntu')
         self.node.machine.upload('tests/mocknet/helpers/requirements.txt',
-                                 '/home/ubuntu/.near/neard-runner',
+                                 self.neard_runner_home,
                                  switch_user='ubuntu')
 
     def upload_neard_runner_config(self, config):
         mocknet.upload_json(self.node,
-                            '/home/ubuntu/.near/neard-runner/config.json',
+                            os.path.join(self.neard_runner_home, 'config.json'),
                             config)
 
     def init_python(self):
-        cmd = 'cd /home/ubuntu/.near/neard-runner && python3 -m virtualenv venv -p $(which python3)' \
+        cmd = f'cd {self.neard_runner_home} && python3 -m virtualenv venv -p $(which python3)' \
         ' && ./venv/bin/pip install -r requirements.txt'
         cmd_utils.run_cmd(self.node, cmd)
 
@@ -66,8 +67,8 @@ class RemoteNeardRunner:
         )
 
     def start_neard_runner(self):
-        cmd_utils.run_in_background(self.node, f'/home/ubuntu/.near/neard-runner/venv/bin/python /home/ubuntu/.near/neard-runner/neard_runner.py ' \
-            '--home /home/ubuntu/.near/neard-runner --neard-home /home/ubuntu/.near ' \
+        cmd_utils.run_in_background(self.node, f'{os.path.join(self.neard_runner_home, "venv/bin/python")} {os.path.join(self.neard_runner_home, "neard_runner.py")} ' \
+            f'--home {self.neard_runner_home} --neard-home /home/ubuntu/.near ' \
             '--neard-logs /home/ubuntu/neard-logs --port 3000', 'neard-runner.txt')
 
     def neard_runner_post(self, body):
@@ -106,6 +107,20 @@ def get_nodes(chain_id, start_height, unique_id):
 
     if traffic_generator is None:
         sys.exit(f'no traffic generator instance found')
-    return NodeHandle(RemoteNeardRunner(traffic_generator)), [
-        NodeHandle(RemoteNeardRunner(node)) for node in nodes
-    ]
+    # here we want the neard-runner home dir to be on the same disk as the target data dir since we'll be making backups
+    # on that disk
+    traffic_target_home = cmd_utils.run_cmd(
+        traffic_generator,
+        'cat /proc/mounts | grep "/home/ubuntu/.near" | grep -v "source" | head -n 1 | awk \'{print $2};\''
+    ).stdout.strip()
+    if len(traffic_target_home) < 1:
+        sys.exit(
+            f'could not find any mounts in /home/ubuntu/.near on {traffic_generator.instance_name}'
+        )
+    traffic_runner_home = os.path.join(traffic_target_home, 'neard-runner')
+    return NodeHandle(RemoteNeardRunner(
+        traffic_generator, traffic_runner_home)), [
+            NodeHandle(
+                RemoteNeardRunner(node, '/home/ubuntu/.near/neard-runner'))
+            for node in nodes
+        ]


### PR DESCRIPTION
The old version of forknet/mocknet has one disk for each node, where there are the starting genesis and records files in `~/.near/setup/`, and the traffic generator includes those plus a full NEAR home dir in `~/.near/`. With the new faster `fork-network` based mocknet setup, we need a full home dir for both the source chain and the target chain setup directory. So it's not economical to include the target setup directory in both images (validator node and traffic generator). Instead we'll want to have two images, and mount two disks on the traffic generator. This PR implements the logic necessary to have `neard_runner.py` keep the old mountpoints when the legacy records.json method is being used, and to assume that with the new version, the source home directory will be mounted at `~/.near/source`, and the target home directory will be mounted at `~/.near/target`, with the setup home dir in `~/.near/target/setup`.