### PR TITLE
introduce all the necessary features for reusing contract data memories

### DIFF
--- a/runtime/near-vm-runner/src/near_vm_runner/runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner/runner.rs
@@ -304,6 +304,7 @@ impl NearVM {
         let mut memory = NearVmMemory::new(
             self.config.limit_config.initial_memory_pages,
             self.config.limit_config.max_memory_pages,
+            None, // TODO: this should actually reuse the memories
         )
         .expect("Cannot create memory for a contract call");
         // FIXME: this mostly duplicates the `run_module` method.
@@ -637,7 +638,7 @@ mod tests {
     #[test]
     fn test_memory_like() {
         crate::logic::test_utils::test_memory_like(|| {
-            Box::new(super::NearVmMemory::new(1, 1).unwrap())
+            Box::new(super::NearVmMemory::new(1, 1, None).unwrap())
         });
     }
 }

--- a/runtime/near-vm/test-api/src/sys/tunables.rs
+++ b/runtime/near-vm/test-api/src/sys/tunables.rs
@@ -106,7 +106,7 @@ impl Tunables for BaseTunables {
         ty: &MemoryType,
         style: &MemoryStyle,
     ) -> Result<Arc<LinearMemory>, MemoryError> {
-        Ok(Arc::new(LinearMemory::new(&ty, &style)?))
+        Ok(Arc::new(LinearMemory::new(&ty, &style, None)?))
     }
 
     /// Create a memory owned by the VM given a [`MemoryType`] and a [`MemoryStyle`].


### PR DESCRIPTION
With this, all that’s missing should be the contract data memory queue, and checking that the `Arc::into_inner` actually works properly at least most of the time. I’m… not that hopeful about this second precondition, but let’s see what happens with a bit of testing.

Part of #11033 