### PR TITLE
fix(forknet): run db migrations before snapshotting setup dir

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -314,6 +314,15 @@ class NeardRunner:
                 '--home',
                 os.path.join(self.neard_home, 'setup'),
                 'database',
+                'run-migrations',
+            ]
+            logging.info(f'running {" ".join(cmd)}')
+            subprocess.check_call(cmd)
+            cmd = [
+                self.data['binaries'][0]['system_path'],
+                '--home',
+                self.setup_path(),
+                'database',
                 'make-snapshot',
                 '--destination',
                 self.target_near_home_path(),


### PR DESCRIPTION
otherwise the new-test command of mirror.py will fail when you run it with a neard binary with a newer database version as the database in the starting image