### PR TITLE
[reed_solomon] Remove ReedSolomonWrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3124,6 +3124,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "integration-tests"
 version = "0.0.0"
 dependencies = [
@@ -3176,6 +3185,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "primitive-types 0.10.1",
  "rand",
+ "reed-solomon-erasure",
  "rlp",
  "serde",
  "serde_json",
@@ -3298,7 +3308,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin",
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -3339,6 +3349,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "winapi",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "librocksdb-sys"
@@ -4465,6 +4481,7 @@ dependencies = [
  "rand",
  "rand_xorshift",
  "rayon",
+ "reed-solomon-erasure",
  "rlimit",
  "serde",
  "sha2 0.10.6",
@@ -4789,6 +4806,7 @@ dependencies = [
  "once_cell",
  "rand",
  "rayon",
+ "reed-solomon-erasure",
  "rlimit",
  "rocksdb",
  "serde",
@@ -5736,6 +5754,17 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api 0.4.7",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
@@ -5754,6 +5783,20 @@ dependencies = [
  "cloudabi",
  "libc",
  "redox_syscall 0.1.57",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.13",
  "smallvec",
  "winapi",
 ]
@@ -6307,11 +6350,15 @@ dependencies = [
 
 [[package]]
 name = "reed-solomon-erasure"
-version = "4.0.2"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a415a013dd7c5d4221382329a5a3482566da675737494935cbbbcdec04662f9d"
+checksum = "7263373d500d4d4f505d43a2a662d475a894aa94503a1ee28e9188b5f3960d4f"
 dependencies = [
+ "libm",
+ "lru 0.7.8",
+ "parking_lot 0.11.2",
  "smallvec",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -6437,7 +6484,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi",
@@ -7256,6 +7303,12 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sptr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -304,7 +304,7 @@ rand_hc = "0.3.1"
 rand_xorshift = "0.3"
 rayon = "1.5"
 redis = "0.23.0"
-reed-solomon-erasure = "4"
+reed-solomon-erasure = "6.0.0"
 regex = "1.7.1"
 region = "3.0"
 reqwest = { version = "0.11.14", features = ["blocking"] }

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -111,7 +111,7 @@ use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{verify_path, MerklePath};
 use near_primitives::receipt::Receipt;
-use near_primitives::reed_solomon::{rs_decode, rs_encode};
+use near_primitives::reed_solomon::{reed_solomon_decode, reed_solomon_encode};
 use near_primitives::sharding::{
     ChunkHash, EncodedShardChunk, EncodedShardChunkBody, PartialEncodedChunk,
     PartialEncodedChunkPart, PartialEncodedChunkV2, ReceiptProof, ShardChunk, ShardChunkHeader,
@@ -991,7 +991,7 @@ impl ShardsManager {
         // Construct EncodedShardChunk.  If we earlier determined that we will
         // need parity parts, instruct the constructor to calculate them as
         // well.  Otherwise we won’t bother.
-        let (parts, encoded_length) = rs_encode(
+        let (parts, encoded_length) = reed_solomon_encode(
             &self.rs,
             TransactionReceipt(chunk.transactions().to_vec(), outgoing_receipts.to_vec()),
         );
@@ -1053,7 +1053,7 @@ impl ShardsManager {
         }
 
         let encoded_length = chunk.encoded_length();
-        if let Err(err) = rs_decode::<TransactionReceipt>(
+        if let Err(err) = reed_solomon_decode::<TransactionReceipt>(
             &self.rs,
             chunk.content_mut().parts.as_mut_slice(),
             encoded_length as usize,

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -800,7 +800,7 @@ impl ShardsManager {
     }
 
     pub fn process_partial_encoded_chunk_request(
-        &mut self,
+        &self,
         request: PartialEncodedChunkRequestMsg,
         route_back: CryptoHash,
     ) {
@@ -836,7 +836,7 @@ impl ShardsManager {
     /// an explanation of that part of the return value.
     /// Ensures the receipts in the response are in a deterministic order.
     fn prepare_partial_encoded_chunk_response(
-        &mut self,
+        &self,
         request: PartialEncodedChunkRequestMsg,
     ) -> (PartialEncodedChunkResponseSource, PartialEncodedChunkResponseMsg) {
         let (src, mut response_msg) = self.prepare_partial_encoded_chunk_response_unsorted(request);
@@ -847,7 +847,7 @@ impl ShardsManager {
     }
 
     fn prepare_partial_encoded_chunk_response_unsorted(
-        &mut self,
+        &self,
         request: PartialEncodedChunkRequestMsg,
     ) -> (PartialEncodedChunkResponseSource, PartialEncodedChunkResponseMsg) {
         let PartialEncodedChunkRequestMsg { chunk_hash, part_ords, mut tracking_shards } = request;
@@ -962,8 +962,8 @@ impl ShardsManager {
     /// expensive operation.  If possible, the request should be served from
     /// EncodedChunksCacheEntry or PartialEncodedChunk instead.
     // pub for testing
-    pub fn lookup_partial_encoded_chunk_from_chunk_storage(
-        &mut self,
+    fn lookup_partial_encoded_chunk_from_chunk_storage(
+        &self,
         part_ords: HashSet<u64>,
         tracking_shards: HashSet<ShardId>,
         response: &mut PartialEncodedChunkResponseMsg,
@@ -1917,7 +1917,7 @@ impl ShardsManager {
         prev_outgoing_receipts_root: CryptoHash,
         tx_root: CryptoHash,
         signer: &dyn ValidatorSigner,
-        rs: &mut ReedSolomonWrapper,
+        rs: &ReedSolomonWrapper,
         protocol_version: ProtocolVersion,
     ) -> Result<(EncodedShardChunk, Vec<MerklePath>), Error> {
         EncodedShardChunk::new(
@@ -2697,7 +2697,7 @@ mod test {
     #[test]
     fn test_chunk_response_for_uncached_partial_chunk() {
         let mut fixture = ChunkTestFixture::default();
-        let mut shards_manager = ShardsManager::new(
+        let shards_manager = ShardsManager::new(
             FakeClock::default().clock(),
             Some(fixture.mock_shard_tracker.clone()),
             Arc::new(fixture.epoch_manager.clone()),
@@ -2729,7 +2729,7 @@ mod test {
     #[test]
     fn test_chunk_response_for_uncached_shard_chunk() {
         let mut fixture = ChunkTestFixture::default();
-        let mut shards_manager = ShardsManager::new(
+        let shards_manager = ShardsManager::new(
             FakeClock::default().clock(),
             Some(fixture.mock_shard_tracker.clone()),
             Arc::new(fixture.epoch_manager.clone()),
@@ -2887,7 +2887,7 @@ mod test {
     #[test]
     fn test_chunk_response_empty_request() {
         let fixture = ChunkTestFixture::default();
-        let mut shards_manager = ShardsManager::new(
+        let shards_manager = ShardsManager::new(
             FakeClock::default().clock(),
             Some(fixture.mock_shard_tracker.clone()),
             Arc::new(fixture.epoch_manager.clone()),
@@ -2911,7 +2911,7 @@ mod test {
     #[test]
     fn test_chunk_response_for_nonexistent_chunk() {
         let fixture = ChunkTestFixture::default();
-        let mut shards_manager = ShardsManager::new(
+        let shards_manager = ShardsManager::new(
             FakeClock::default().clock(),
             Some(fixture.mock_shard_tracker.clone()),
             Arc::new(fixture.epoch_manager.clone()),
@@ -2935,7 +2935,7 @@ mod test {
     #[test]
     fn test_chunk_response_for_request_including_invalid_part_ord() {
         let mut fixture = ChunkTestFixture::default();
-        let mut shards_manager = ShardsManager::new(
+        let shards_manager = ShardsManager::new(
             FakeClock::default().clock(),
             Some(fixture.mock_shard_tracker.clone()),
             Arc::new(fixture.epoch_manager.clone()),
@@ -2969,7 +2969,7 @@ mod test {
     fn test_chunk_response_for_request_with_duplicate_part_ords() {
         // We should not return any duplicates.
         let mut fixture = ChunkTestFixture::default();
-        let mut shards_manager = ShardsManager::new(
+        let shards_manager = ShardsManager::new(
             FakeClock::default().clock(),
             Some(fixture.mock_shard_tracker.clone()),
             Arc::new(fixture.epoch_manager.clone()),

--- a/chain/chunks/src/test/basic.rs
+++ b/chain/chunks/src/test/basic.rs
@@ -28,7 +28,6 @@ use near_network::{
 use near_primitives::types::{AccountId, BlockHeight};
 use near_store::test_utils::create_test_store;
 use std::collections::HashSet;
-use tracing::log::info;
 
 #[derive(derive_more::AsMut)]
 struct TestData {
@@ -203,7 +202,7 @@ fn test_chunk_forward() {
                 data.chain.record_block(*hash, i as BlockHeight + 1);
                 let next_chunk_producer = data.chain.next_chunk_producer(0);
                 if !chunk_only_producers.contains(&next_chunk_producer) {
-                    info!(target: "test", "Trying again at height {} which has chunk producer {}, we want the next chunk producer to be a chunk only producer",
+                    tracing::info!(target: "test", "Trying again at height {} which has chunk producer {}, we want the next chunk producer to be a chunk only producer",
                           i + 1, next_chunk_producer);
                     continue;
                 }

--- a/chain/chunks/src/test_loop.rs
+++ b/chain/chunks/src/test_loop.rs
@@ -25,7 +25,6 @@ use near_network::{
 use near_primitives::{
     hash::CryptoHash,
     merkle::{self, MerklePath},
-    reed_solomon::ReedSolomonWrapper,
     sharding::{
         EncodedShardChunk, PartialEncodedChunk, PartialEncodedChunkV2, ReceiptProof,
         ShardChunkHeader,
@@ -35,6 +34,7 @@ use near_primitives::{
     version::PROTOCOL_VERSION,
 };
 use near_store::Store;
+use reed_solomon_erasure::galois_8::ReedSolomon;
 use std::{collections::HashMap, sync::Arc};
 
 pub fn forward_client_request_to_shards_manager(
@@ -260,7 +260,7 @@ impl MockChainForShardsManager {
         let signer = create_test_signer(chunk_producer.as_str());
         let data_parts = self.epoch_manager.num_data_parts();
         let parity_parts = self.epoch_manager.num_total_parts() - data_parts;
-        let mut rs = ReedSolomonWrapper::new(data_parts, parity_parts);
+        let rs = ReedSolomon::new(data_parts, parity_parts).unwrap();
         let (chunk, merkle_paths) = ShardsManager::create_encoded_shard_chunk(
             self.tip.last_block_hash,
             CryptoHash::default(),
@@ -276,7 +276,7 @@ impl MockChainForShardsManager {
             receipts_root,
             MerkleHash::default(),
             &signer,
-            &mut rs,
+            &rs,
             PROTOCOL_VERSION,
         )
         .unwrap();

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -9,7 +9,6 @@ use near_network::test_utils::MockPeerManagerAdapter;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{self, MerklePath};
 use near_primitives::receipt::Receipt;
-use near_primitives::reed_solomon::ReedSolomonWrapper;
 use near_primitives::sharding::{
     EncodedShardChunk, PartialEncodedChunk, PartialEncodedChunkPart, PartialEncodedChunkV2,
     ShardChunkHeader,
@@ -20,6 +19,7 @@ use near_primitives::types::{AccountId, EpochId, ShardId};
 use near_primitives::version::PROTOCOL_VERSION;
 use near_store::test_utils::create_test_store;
 use near_store::Store;
+use reed_solomon_erasure::galois_8::ReedSolomon;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -46,7 +46,7 @@ pub struct ChunkTestFixture {
     pub mock_chunk_header: ShardChunkHeader,
     pub mock_chunk_parts: Vec<PartialEncodedChunkPart>,
     pub mock_chain_head: Tip,
-    pub rs: ReedSolomonWrapper,
+    pub rs: ReedSolomon,
 }
 
 impl Default for ChunkTestFixture {
@@ -86,7 +86,7 @@ impl ChunkTestFixture {
 
         let data_parts = epoch_manager.num_data_parts();
         let parity_parts = epoch_manager.num_total_parts() - data_parts;
-        let mut rs = ReedSolomonWrapper::new(data_parts, parity_parts);
+        let rs = ReedSolomon::new(data_parts, parity_parts).unwrap();
         let mock_ancestor_hash = CryptoHash::default();
         // generate a random block hash for the block at height 1
         let (mock_parent_hash, mock_height) =
@@ -150,7 +150,7 @@ impl ChunkTestFixture {
             receipts_root,
             MerkleHash::default(),
             &signer,
-            &mut rs,
+            &rs,
             PROTOCOL_VERSION,
         )
         .unwrap();

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -69,7 +69,6 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{merklize, MerklePath, PartialMerkleTree};
 use near_primitives::network::PeerId;
 use near_primitives::receipt::Receipt;
-use near_primitives::reed_solomon::ReedSolomonWrapper;
 use near_primitives::sharding::StateSyncInfo;
 use near_primitives::sharding::{
     ChunkHash, EncodedShardChunk, PartialEncodedChunk, ShardChunk, ShardChunkHeader, ShardInfo,
@@ -83,6 +82,7 @@ use near_primitives::validator_signer::ValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{CatchupStatusView, DroppedReason};
 use near_store::ShardUId;
+use reed_solomon_erasure::galois_8::ReedSolomon;
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -159,7 +159,7 @@ pub struct Client {
     /// List of currently accumulated challenges.
     pub challenges: HashMap<CryptoHash, Challenge>,
     /// A ReedSolomon instance to reconstruct shard.
-    pub rs_for_chunk_production: ReedSolomonWrapper,
+    pub rs_for_chunk_production: ReedSolomon,
     /// Blocks that have been re-broadcast recently. They should not be broadcast again.
     rebroadcasted_blocks: lru::LruCache<CryptoHash, ()>,
     /// Last time the head was updated, or our head was rebroadcasted. Used to re-broadcast the head
@@ -393,7 +393,7 @@ impl Client {
             block_sync,
             state_sync,
             challenges: Default::default(),
-            rs_for_chunk_production: ReedSolomonWrapper::new(data_parts, parity_parts),
+            rs_for_chunk_production: ReedSolomon::new(data_parts, parity_parts).unwrap(),
             rebroadcasted_blocks: lru::LruCache::new(NUM_REBROADCAST_BLOCKS),
             last_time_head_progress_made: clock.now(),
             block_production_info: BlockProductionTracker::new(),

--- a/chain/client/src/stateless_validation/state_witness_actions.rs
+++ b/chain/client/src/stateless_validation/state_witness_actions.rs
@@ -7,7 +7,7 @@ use near_async::time::Clock;
 use near_chain::Error;
 use near_epoch_manager::EpochManagerAdapter;
 use near_network::types::{NetworkRequests, PeerManagerAdapter, PeerManagerMessageRequest};
-use near_primitives::reed_solomon::rs_encode;
+use near_primitives::reed_solomon::reed_solomon_encode;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::stateless_validation::{
     ChunkStateWitness, ChunkStateWitnessAck, EncodedChunkStateWitness, PartialEncodedStateWitness,
@@ -128,7 +128,7 @@ impl StateWitnessActions {
             let data_parts = std::cmp::max(total_parts * 2 / 3, 1);
             ReedSolomon::new(data_parts, total_parts - data_parts).unwrap()
         });
-        let (parts, encoded_length) = rs_encode(&rs, witness_bytes);
+        let (parts, encoded_length) = reed_solomon_encode(&rs, witness_bytes);
 
         let validator_witness_tuple = chunk_validators
             .iter()

--- a/chain/client/src/test_utils/client.rs
+++ b/chain/client/src/test_utils/client.rs
@@ -188,7 +188,7 @@ pub fn create_chunk(
         let data_parts = client.chain.epoch_manager.num_data_parts();
         let decoded_chunk = chunk.decode_chunk(data_parts).unwrap();
         let parity_parts = total_parts - data_parts;
-        let mut rs = ReedSolomonWrapper::new(data_parts, parity_parts);
+        let rs = ReedSolomonWrapper::new(data_parts, parity_parts);
 
         let signer = client.validator_signer.as_ref().unwrap().clone();
         let header = chunk.cloned_header();
@@ -198,7 +198,7 @@ pub fn create_chunk(
             header.prev_outcome_root(),
             header.height_created(),
             header.shard_id(),
-            &mut rs,
+            &rs,
             header.prev_gas_used(),
             header.gas_limit(),
             header.prev_balance_burnt(),

--- a/chain/client/src/test_utils/client.rs
+++ b/chain/client/src/test_utils/client.rs
@@ -20,7 +20,6 @@ use near_network::types::HighestHeightPeerInfo;
 use near_primitives::block::Block;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{merklize, PartialMerkleTree};
-use near_primitives::reed_solomon::ReedSolomonWrapper;
 use near_primitives::sharding::{EncodedShardChunk, ShardChunk};
 use near_primitives::stateless_validation::ChunkEndorsement;
 use near_primitives::transaction::SignedTransaction;
@@ -28,6 +27,7 @@ use near_primitives::types::{BlockHeight, ShardId};
 use near_primitives::utils::MaybeValidated;
 use near_primitives::version::PROTOCOL_VERSION;
 use num_rational::Ratio;
+use reed_solomon_erasure::galois_8::ReedSolomon;
 
 impl Client {
     /// Unlike Client::start_process_block, which returns before the block finishes processing
@@ -188,7 +188,7 @@ pub fn create_chunk(
         let data_parts = client.chain.epoch_manager.num_data_parts();
         let decoded_chunk = chunk.decode_chunk(data_parts).unwrap();
         let parity_parts = total_parts - data_parts;
-        let rs = ReedSolomonWrapper::new(data_parts, parity_parts);
+        let rs = ReedSolomon::new(data_parts, parity_parts).unwrap();
 
         let signer = client.validator_signer.as_ref().unwrap().clone();
         let header = chunk.cloned_header();

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -38,6 +38,7 @@ pin-project.workspace = true
 protobuf.workspace = true
 rand.workspace = true
 rayon.workspace = true
+reed-solomon-erasure.workspace = true
 serde.workspace = true
 smart-default.workspace = true
 sha2.workspace = true

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -182,7 +182,7 @@ pub fn make_challenge<R: Rng>(rng: &mut R) -> Challenge {
 pub fn make_chunk_parts(chunk: ShardChunk) -> Vec<PartialEncodedChunkPart> {
     let total_shard_count = 10;
     let parity_shard_count = 5;
-    let mut rs = ReedSolomonWrapper::new(total_shard_count, parity_shard_count);
+    let rs = ReedSolomonWrapper::new(total_shard_count, parity_shard_count);
     let transaction_receipts =
         (chunk.transactions().to_vec(), chunk.prev_outgoing_receipts().to_vec());
     let (parts, _) = rs.encode(transaction_receipts);

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -13,7 +13,7 @@ use near_primitives::challenge::{BlockDoubleSign, Challenge, ChallengeBody};
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::num_rational::Ratio;
-use near_primitives::reed_solomon::rs_encode;
+use near_primitives::reed_solomon::reed_solomon_encode;
 use near_primitives::sharding::{
     ChunkHash, EncodedShardChunkBody, PartialEncodedChunkPart, ShardChunk,
 };
@@ -186,7 +186,7 @@ pub fn make_chunk_parts(chunk: ShardChunk) -> Vec<PartialEncodedChunkPart> {
     let rs = ReedSolomon::new(total_shard_count, parity_shard_count).unwrap();
     let transaction_receipts =
         (chunk.transactions().to_vec(), chunk.prev_outgoing_receipts().to_vec());
-    let (parts, _) = rs_encode(&rs, transaction_receipts);
+    let (parts, _) = reed_solomon_encode(&rs, transaction_receipts);
 
     let mut content = EncodedShardChunkBody { parts };
     let (_, merkle_paths) = content.get_merkle_hash_and_paths();

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -13,7 +13,7 @@ use near_primitives::challenge::{BlockDoubleSign, Challenge, ChallengeBody};
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::num_rational::Ratio;
-use near_primitives::reed_solomon::ReedSolomonWrapper;
+use near_primitives::reed_solomon::rs_encode;
 use near_primitives::sharding::{
     ChunkHash, EncodedShardChunkBody, PartialEncodedChunkPart, ShardChunk,
 };
@@ -23,6 +23,7 @@ use near_primitives::validator_signer::{InMemoryValidatorSigner, ValidatorSigner
 use near_primitives::version;
 use rand::distributions::Standard;
 use rand::Rng;
+use reed_solomon_erasure::galois_8::ReedSolomon;
 use std::collections::HashMap;
 use std::net;
 use std::sync::Arc;
@@ -182,10 +183,10 @@ pub fn make_challenge<R: Rng>(rng: &mut R) -> Challenge {
 pub fn make_chunk_parts(chunk: ShardChunk) -> Vec<PartialEncodedChunkPart> {
     let total_shard_count = 10;
     let parity_shard_count = 5;
-    let rs = ReedSolomonWrapper::new(total_shard_count, parity_shard_count);
+    let rs = ReedSolomon::new(total_shard_count, parity_shard_count).unwrap();
     let transaction_receipts =
         (chunk.transactions().to_vec(), chunk.prev_outgoing_receipts().to_vec());
-    let (parts, _) = rs.encode(transaction_receipts);
+    let (parts, _) = rs_encode(&rs, transaction_receipts);
 
     let mut content = EncodedShardChunkBody { parts };
     let (_, merkle_paths) = content.get_merkle_hash_and_paths();

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -9,7 +9,6 @@ use crate::checked_feature;
 use crate::hash::{hash, CryptoHash};
 use crate::merkle::{merklize, verify_path, MerklePath};
 use crate::num_rational::Rational32;
-use crate::reed_solomon::ReedSolomonWrapper;
 use crate::sharding::{
     ChunkHashHeight, EncodedShardChunk, ShardChunk, ShardChunkHeader, ShardChunkHeaderV1,
 };
@@ -21,6 +20,7 @@ use near_async::time::Utc;
 use near_crypto::Signature;
 use near_primitives_core::types::ShardId;
 use primitive_types::U256;
+use reed_solomon_erasure::galois_8::ReedSolomon;
 use std::ops::Index;
 use std::sync::Arc;
 
@@ -95,7 +95,7 @@ pub fn genesis_chunks(
     genesis_height: BlockHeight,
     genesis_protocol_version: ProtocolVersion,
 ) -> Vec<ShardChunk> {
-    let rs = ReedSolomonWrapper::new(1, 2);
+    let rs = ReedSolomon::new(1, 2).unwrap();
     let state_roots = if state_roots.len() == shard_ids.len() {
         state_roots
     } else {

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -95,7 +95,7 @@ pub fn genesis_chunks(
     genesis_height: BlockHeight,
     genesis_protocol_version: ProtocolVersion,
 ) -> Vec<ShardChunk> {
-    let mut rs = ReedSolomonWrapper::new(1, 2);
+    let rs = ReedSolomonWrapper::new(1, 2);
     let state_roots = if state_roots.len() == shard_ids.len() {
         state_roots
     } else {
@@ -113,7 +113,7 @@ pub fn genesis_chunks(
                 CryptoHash::default(),
                 genesis_height,
                 shard_id,
-                &mut rs,
+                &rs,
                 0,
                 initial_gas_limit,
                 0,

--- a/core/primitives/src/reed_solomon.rs
+++ b/core/primitives/src/reed_solomon.rs
@@ -4,7 +4,10 @@ use reed_solomon_erasure::galois_8::ReedSolomon;
 use std::io::Error;
 
 // Encode function takes a serializable object and returns a tuple of parts and length of encoded data
-pub fn rs_encode<T: BorshSerialize>(rs: &ReedSolomon, data: T) -> (Vec<Option<Box<[u8]>>>, usize) {
+pub fn reed_solomon_encode<T: BorshSerialize>(
+    rs: &ReedSolomon,
+    data: T,
+) -> (Vec<Option<Box<[u8]>>>, usize) {
     let mut bytes = borsh::to_vec(&data).unwrap();
     let encoded_length = bytes.len();
 
@@ -31,7 +34,7 @@ pub fn rs_encode<T: BorshSerialize>(rs: &ReedSolomon, data: T) -> (Vec<Option<Bo
 // Decode function is the reverse of encode function. It takes parts and length of encoded data
 // and returns the deserialized object.
 // Return an error if the reed solomon decoding fails or borsh deserialization fails.
-pub fn rs_decode<T: BorshDeserialize>(
+pub fn reed_solomon_decode<T: BorshDeserialize>(
     rs: &ReedSolomon,
     parts: &mut [Option<Box<[u8]>>],
     encoded_length: usize,

--- a/core/primitives/src/reed_solomon.rs
+++ b/core/primitives/src/reed_solomon.rs
@@ -2,6 +2,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use itertools::Itertools;
 use reed_solomon_erasure::galois_8::{Field, ReedSolomon};
 use reed_solomon_erasure::ReconstructShard;
+use std::cell::RefCell;
 use std::io::Error;
 
 /// The ttl for a reed solomon instance to control memory usage. This number below corresponds to
@@ -12,24 +13,32 @@ const RS_TTL: u64 = 2 * 1024;
 /// reed solomon instead to work around the memory leak in reed solomon
 /// implementation <https://github.com/darrenldl/reed-solomon-erasure/issues/74>
 pub struct ReedSolomonWrapper {
-    rs: ReedSolomon,
-    ttl: u64,
+    rs: RefCell<ReedSolomon>,
+    ttl: RefCell<u64>,
 }
 
 impl ReedSolomonWrapper {
     pub fn new(data_shards: usize, parity_shards: usize) -> Self {
         ReedSolomonWrapper {
-            rs: ReedSolomon::new(data_shards, parity_shards).unwrap(),
-            ttl: RS_TTL,
+            rs: RefCell::new(ReedSolomon::new(data_shards, parity_shards).unwrap()),
+            ttl: RefCell::new(RS_TTL),
         }
     }
 
+    pub fn total_parts(&self) -> usize {
+        self.rs.borrow().total_shard_count()
+    }
+
+    pub fn data_parts(&self) -> usize {
+        self.rs.borrow().data_shard_count()
+    }
+
     // Encode function takes a serializable object and returns a tuple of parts and length of encoded data
-    pub fn encode<T: BorshSerialize>(&mut self, data: T) -> (Vec<Option<Box<[u8]>>>, usize) {
+    pub fn encode<T: BorshSerialize>(&self, data: T) -> (Vec<Option<Box<[u8]>>>, usize) {
         let mut bytes = borsh::to_vec(&data).unwrap();
         let encoded_length = bytes.len();
 
-        let data_parts = self.rs.data_shard_count();
+        let data_parts = self.rs.borrow().data_shard_count();
         let part_length = (encoded_length + data_parts - 1) / data_parts;
 
         // Pad the bytes to be a multiple of `part_length`
@@ -40,7 +49,7 @@ impl ReedSolomonWrapper {
         let mut parts = bytes
             .chunks_exact(part_length)
             .map(|chunk| Some(chunk.to_vec().into_boxed_slice()))
-            .chain(itertools::repeat_n(None, self.rs.parity_shard_count()))
+            .chain(itertools::repeat_n(None, self.rs.borrow().parity_shard_count()))
             .collect_vec();
 
         // Fine to unwrap here as we just constructed the parts
@@ -53,7 +62,7 @@ impl ReedSolomonWrapper {
     // and returns the deserialized object.
     // Return an error if the reed solomon decoding fails or borsh deserialization fails.
     pub fn decode<T: BorshDeserialize>(
-        &mut self,
+        &self,
         parts: &mut [Option<Box<[u8]>>],
         encoded_length: usize,
     ) -> Result<T, Error> {
@@ -72,14 +81,41 @@ impl ReedSolomonWrapper {
     }
 
     fn reconstruct<T: ReconstructShard<Field>>(
-        &mut self,
+        &self,
         slices: &mut [T],
     ) -> Result<(), reed_solomon_erasure::Error> {
-        self.ttl -= 1;
-        if self.ttl == 0 {
-            *self =
-                ReedSolomonWrapper::new(self.rs.data_shard_count(), self.rs.parity_shard_count());
+        self.ttl.replace_with(|ttl| *ttl - 1);
+        if *self.ttl.borrow() == 0 {
+            let data_shards = self.rs.borrow().data_shard_count();
+            let parity_shards = self.rs.borrow().parity_shard_count();
+            self.rs.replace(ReedSolomon::new(data_shards, parity_shards).unwrap());
+            self.ttl.replace(RS_TTL);
         }
-        self.rs.reconstruct(slices)
+        self.rs.borrow().reconstruct(slices)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::Rng;
+
+    use super::{ReedSolomonWrapper, RS_TTL};
+
+    #[test]
+    pub fn test_wrapper_replace() {
+        let data_shards = 5;
+        let parity_shards = 2;
+        let rs = ReedSolomonWrapper::new(data_shards, parity_shards);
+        let mut rng = rand::thread_rng();
+        for _ in 0..RS_TTL + 5 {
+            let (mut parts, encoded_length) = rs.encode("random_data".to_string());
+            for _ in 0..parity_shards {
+                parts[rng.gen_range(0..(data_shards + parity_shards))] = None;
+            }
+            assert_eq!(
+                rs.decode::<String>(&mut parts, encoded_length).unwrap(),
+                "random_data".to_string()
+            );
+        }
     }
 }

--- a/core/primitives/src/reed_solomon.rs
+++ b/core/primitives/src/reed_solomon.rs
@@ -36,7 +36,7 @@ pub fn rs_decode<T: BorshDeserialize>(
     parts: &mut [Option<Box<[u8]>>],
     encoded_length: usize,
 ) -> Result<T, Error> {
-    if let Err(err) = rs.reconstruct(parts) {
+    if let Err(err) = rs.reconstruct_data(parts) {
         return Err(Error::other(err));
     }
 

--- a/core/primitives/src/reed_solomon.rs
+++ b/core/primitives/src/reed_solomon.rs
@@ -36,7 +36,7 @@ pub fn rs_decode<T: BorshDeserialize>(
     parts: &mut [Option<Box<[u8]>>],
     encoded_length: usize,
 ) -> Result<T, Error> {
-    if let Err(err) = rs.reconstruct_data(parts) {
+    if let Err(err) = rs.reconstruct(parts) {
         return Err(Error::other(err));
     }
 

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -980,7 +980,7 @@ impl EncodedShardChunk {
         prev_outcome_root: CryptoHash,
         height: BlockHeight,
         shard_id: ShardId,
-        rs: &mut ReedSolomonWrapper,
+        rs: &ReedSolomonWrapper,
         prev_gas_used: Gas,
         gas_limit: Gas,
         prev_balance_burnt: Balance,

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -1,7 +1,7 @@
 use crate::hash::{hash, CryptoHash};
 use crate::merkle::{combine_hash, merklize, verify_path, MerklePath};
 use crate::receipt::Receipt;
-use crate::reed_solomon::ReedSolomonWrapper;
+use crate::reed_solomon::rs_encode;
 use crate::transaction::SignedTransaction;
 use crate::types::validator_stake::{ValidatorStake, ValidatorStakeIter, ValidatorStakeV1};
 use crate::types::{Balance, BlockHeight, Gas, MerkleHash, ShardId, StateRoot};
@@ -10,6 +10,7 @@ use crate::version::{ProtocolFeature, ProtocolVersion, SHARD_CHUNK_HEADER_UPGRAD
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_crypto::Signature;
 use near_fmt::AbbrBytes;
+use reed_solomon_erasure::galois_8::ReedSolomon;
 use std::cmp::Ordering;
 use std::sync::Arc;
 use tracing::debug_span;
@@ -980,7 +981,7 @@ impl EncodedShardChunk {
         prev_outcome_root: CryptoHash,
         height: BlockHeight,
         shard_id: ShardId,
-        rs: &ReedSolomonWrapper,
+        rs: &ReedSolomon,
         prev_gas_used: Gas,
         gas_limit: Gas,
         prev_balance_burnt: Balance,
@@ -993,7 +994,7 @@ impl EncodedShardChunk {
         protocol_version: ProtocolVersion,
     ) -> Result<(Self, Vec<MerklePath>), std::io::Error> {
         let (transaction_receipts_parts, encoded_length) =
-            rs.encode(TransactionReceipt(transactions, prev_outgoing_receipts.to_vec()));
+            rs_encode(rs, TransactionReceipt(transactions, prev_outgoing_receipts.to_vec()));
         let content = EncodedShardChunkBody { parts: transaction_receipts_parts };
         let (encoded_merkle_root, merkle_paths) = content.get_merkle_hash_and_paths();
 

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -1,7 +1,7 @@
 use crate::hash::{hash, CryptoHash};
 use crate::merkle::{combine_hash, merklize, verify_path, MerklePath};
 use crate::receipt::Receipt;
-use crate::reed_solomon::rs_encode;
+use crate::reed_solomon::reed_solomon_encode;
 use crate::transaction::SignedTransaction;
 use crate::types::validator_stake::{ValidatorStake, ValidatorStakeIter, ValidatorStakeV1};
 use crate::types::{Balance, BlockHeight, Gas, MerkleHash, ShardId, StateRoot};
@@ -993,8 +993,10 @@ impl EncodedShardChunk {
         signer: &dyn ValidatorSigner,
         protocol_version: ProtocolVersion,
     ) -> Result<(Self, Vec<MerklePath>), std::io::Error> {
-        let (transaction_receipts_parts, encoded_length) =
-            rs_encode(rs, TransactionReceipt(transactions, prev_outgoing_receipts.to_vec()));
+        let (transaction_receipts_parts, encoded_length) = reed_solomon_encode(
+            rs,
+            TransactionReceipt(transactions, prev_outgoing_receipts.to_vec()),
+        );
         let content = EncodedShardChunkBody { parts: transaction_receipts_parts };
         let (encoded_merkle_root, merkle_paths) = content.get_merkle_hash_and_paths();
 

--- a/core/primitives/src/stateless_validation.rs
+++ b/core/primitives/src/stateless_validation.rs
@@ -19,6 +19,10 @@ use near_primitives_core::types::{AccountId, Balance, BlockHeight, ShardId};
 /// This is a messy workaround until we know what to do with NEP 483.
 type SignatureDifferentiator = String;
 
+/// Represents the Reed Solomon erasure encoded parts of the `EncodedChunkStateWitness`.
+/// These are created and signed by the chunk producer and sent to the chunk validators.
+/// Note that the chunk validators do not require all the parts of the state witness to
+/// reconstruct the full state witness due to the Reed Solomon erasure encoding.
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PartialEncodedStateWitness {
     inner: PartialEncodedStateWitnessInner,
@@ -64,6 +68,10 @@ impl PartialEncodedStateWitness {
 
     pub fn part(&self) -> &[u8] {
         &self.inner.part
+    }
+
+    pub fn encoded_length(&self) -> usize {
+        self.inner.encoded_length
     }
 }
 
@@ -415,6 +423,10 @@ impl ChunkValidatorAssignments {
     pub fn new(assignments: Vec<(AccountId, Balance)>) -> Self {
         let chunk_validators = assignments.iter().map(|(id, _)| id.clone()).collect();
         Self { assignments, chunk_validators }
+    }
+
+    pub fn len(&self) -> usize {
+        self.assignments.len()
     }
 
     pub fn contains(&self, account_id: &AccountId) -> bool {

--- a/core/primitives/src/stateless_validation.rs
+++ b/core/primitives/src/stateless_validation.rs
@@ -19,10 +19,6 @@ use near_primitives_core::types::{AccountId, Balance, BlockHeight, ShardId};
 /// This is a messy workaround until we know what to do with NEP 483.
 type SignatureDifferentiator = String;
 
-/// Represents the Reed Solomon erasure encoded parts of the `EncodedChunkStateWitness`.
-/// These are created and signed by the chunk producer and sent to the chunk validators.
-/// Note that the chunk validators do not require all the parts of the state witness to
-/// reconstruct the full state witness due to the Reed Solomon erasure encoding.
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct PartialEncodedStateWitness {
     inner: PartialEncodedStateWitnessInner,
@@ -68,10 +64,6 @@ impl PartialEncodedStateWitness {
 
     pub fn part(&self) -> &[u8] {
         &self.inner.part
-    }
-
-    pub fn encoded_length(&self) -> usize {
-        self.inner.encoded_length
     }
 }
 
@@ -423,10 +415,6 @@ impl ChunkValidatorAssignments {
     pub fn new(assignments: Vec<(AccountId, Balance)>) -> Self {
         let chunk_validators = assignments.iter().map(|(id, _)| id.clone()).collect();
         Self { assignments, chunk_validators }
-    }
-
-    pub fn len(&self) -> usize {
-        self.assignments.len()
     }
 
     pub fn contains(&self, account_id: &AccountId) -> bool {

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -29,6 +29,7 @@ num_cpus.workspace = true
 once_cell.workspace = true
 rand.workspace = true
 rayon.workspace = true
+reed-solomon-erasure.workspace = true
 rlimit.workspace = true
 rocksdb.workspace = true
 serde.workspace = true

--- a/core/store/benches/finalize_bench.rs
+++ b/core/store/benches/finalize_bench.rs
@@ -22,7 +22,6 @@ use near_crypto::{InMemorySigner, KeyType, Signer};
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{merklize, MerklePathItem};
 use near_primitives::receipt::{ActionReceipt, DataReceipt, Receipt, ReceiptEnum};
-use near_primitives::reed_solomon::ReedSolomonWrapper;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::{
     ChunkHash, EncodedShardChunk, PartialEncodedChunk, PartialEncodedChunkPart,
@@ -34,6 +33,7 @@ use near_primitives::types::AccountId;
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_store::DBCol;
 use rand::prelude::SliceRandom;
+use reed_solomon_erasure::galois_8::ReedSolomon;
 
 /// `ShardChunk` -> `StoreUpdate::insert_ser`.
 ///
@@ -179,7 +179,7 @@ fn create_encoded_shard_chunk(
     transactions: Vec<SignedTransaction>,
     receipts: &[Receipt],
 ) -> (EncodedShardChunk, Vec<Vec<MerklePathItem>>) {
-    let mut rs = ReedSolomonWrapper::new(33, 67);
+    let rs = ReedSolomon::new(33, 67).unwrap();
     ShardsManager::create_encoded_shard_chunk(
         Default::default(),
         Default::default(),
@@ -195,7 +195,7 @@ fn create_encoded_shard_chunk(
         Default::default(),
         Default::default(),
         &validator_signer(),
-        &mut rs,
+        &rs,
         100,
     )
     .unwrap()

--- a/deny.toml
+++ b/deny.toml
@@ -157,4 +157,9 @@ skip = [
 
     # Everything depends on this...
     { name = "lru", version = "=0.7.8" },
+
+    # reed-solomon-erasure latest version
+    { name = "parking_lot", version = "=0.11.2" },
+    { name = "parking_lot_core", version = "=0.8.6" },
+    { name = "spin", version = "=0.9.8" },
 ]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -27,6 +27,7 @@ once_cell.workspace = true
 parking_lot.workspace = true
 primitive-types.workspace = true
 rand.workspace = true
+reed-solomon-erasure.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 smart-default.workspace = true

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -15,7 +15,6 @@ use near_primitives::challenge::{
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::PartialMerkleTree;
 use near_primitives::num_rational::Ratio;
-use near_primitives::reed_solomon::ReedSolomonWrapper;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::sharding::EncodedShardChunk;
 use near_primitives::stateless_validation::ChunkEndorsement;
@@ -27,6 +26,7 @@ use near_primitives::validator_signer::ValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_store::Trie;
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
+use reed_solomon_erasure::galois_8::ReedSolomon;
 
 /// Check that block containing a challenge is rejected.
 /// TODO (#2445): Enable challenges when they are working correctly.
@@ -360,7 +360,7 @@ fn test_verify_chunk_invalid_state_challenge() {
     let total_parts = env.clients[0].epoch_manager.num_total_parts();
     let data_parts = env.clients[0].epoch_manager.num_data_parts();
     let parity_parts = total_parts - data_parts;
-    let mut rs = ReedSolomonWrapper::new(data_parts, parity_parts);
+    let rs = ReedSolomon::new(data_parts, parity_parts).unwrap();
     let (mut invalid_chunk, merkle_paths) = ShardsManager::create_encoded_shard_chunk(
         *last_block.hash(),
         Trie::EMPTY_ROOT,
@@ -376,7 +376,7 @@ fn test_verify_chunk_invalid_state_challenge() {
         last_block.chunks()[0].prev_outgoing_receipts_root(),
         CryptoHash::default(),
         &validator_signer,
-        &mut rs,
+        &rs,
         PROTOCOL_VERSION,
     )
     .unwrap();


### PR DESCRIPTION
Based on the [conversation on Zulip](https://near.zulipchat.com/#narrow/stream/300659-Rust-.F0.9F.A6.80/topic/RefCell.20usage/near/435417054), seems like the memory leak bug in reed-solomon-erasure encoding crate has been fixed with the latest version 6.0.0

This PR removes the ReedSolomonWrapper which was a workaround and upgrades the crate to version 6.0.0