### PR TITLE
feat(forknet): make backups using RockDB snapshots

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -1013,10 +1013,8 @@ class NeardRunner:
             '--destination',
             backup_dir
         ]
-        self.run_neard(cmd)
-        running = True
-        while running:
-            _, running, exit_code = self.poll_neard()
+        logging.info(f'running {" ".join(cmd)}')
+        exit_code = subprocess.check_call(cmd)
         logging.info(f'copying data dir to {backup_dir} finished with code {exit_code}')
         # Copy config, genesis and node_key to the backup folder to use them to restore the db.
         for file in ["config.json", "genesis.json", "node_key.json"]:
@@ -1072,8 +1070,9 @@ class NeardRunner:
         # Before using snapshots for backup we used to copy the 'data' folder.
         # This is useful to be able to restore from backups done the old way.
         if not os.path.exists(os.path.join(backup_path, 'data')):
+            # TODO: Remove this branch once we no longer support old backups
             shutil.copytree(backup_path, self.target_near_home_path('data'))
-            exit_code = 0
+            logging.info(f'data dir restored by copying files from {backup_path}')
         else:
             cmd = [
                 self.data['current_neard_path'], '--home',
@@ -1084,11 +1083,9 @@ class NeardRunner:
                 '--destination',
                 self.target_near_home_path()
             ]
-            self.run_neard(cmd)
-            running = True
-            while running:
-                _, running, exit_code = self.poll_neard()
-        logging.info(f'data dir restoration terminated with code {exit_code}')
+            logging.info(f'running {" ".join(cmd)}')
+            exit_code = subprocess.check_call(cmd)
+            logging.info(f'snapshot restoration of {backup_path} terminated with code {exit_code}')
 
     def reset_near_home(self):
         backup_id = self.data['state_data']

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -1006,19 +1006,17 @@ class NeardRunner:
         logging.info(f'copying data dir to {backup_dir}')
         cmd = [
             self.data['current_neard_path'], '--home',
-            self.target_near_home_path(),
-            '--unsafe-fast-startup',
-            'database',
-            'make-snapshot',
-            '--destination',
-            backup_dir
+            self.target_near_home_path(), '--unsafe-fast-startup', 'database',
+            'make-snapshot', '--destination', backup_dir
         ]
         logging.info(f'running {" ".join(cmd)}')
         exit_code = subprocess.check_call(cmd)
-        logging.info(f'copying data dir to {backup_dir} finished with code {exit_code}')
+        logging.info(
+            f'copying data dir to {backup_dir} finished with code {exit_code}')
         # Copy config, genesis and node_key to the backup folder to use them to restore the db.
         for file in ["config.json", "genesis.json", "node_key.json"]:
-            shutil.copyfile(self.target_near_home_path(file), os.path.join(backup_dir, file))
+            shutil.copyfile(self.target_near_home_path(file),
+                            os.path.join(backup_dir, file))
         backups = self.data.get('backups', {})
         if name in backups:
             # shouldn't happen if we check this in do_make_backups(), but fine to be paranoid and at least warn here
@@ -1072,20 +1070,20 @@ class NeardRunner:
         if not os.path.exists(os.path.join(backup_path, 'data')):
             # TODO: Remove this branch once we no longer support old backups
             shutil.copytree(backup_path, self.target_near_home_path('data'))
-            logging.info(f'data dir restored by copying files from {backup_path}')
+            logging.info(
+                f'data dir restored by copying files from {backup_path}')
         else:
             cmd = [
-                self.data['current_neard_path'], '--home',
-                backup_path,
-                '--unsafe-fast-startup',
-                'database',
-                'make-snapshot',
+                self.data['current_neard_path'], '--home', backup_path,
+                '--unsafe-fast-startup', 'database', 'make-snapshot',
                 '--destination',
                 self.target_near_home_path()
             ]
             logging.info(f'running {" ".join(cmd)}')
             exit_code = subprocess.check_call(cmd)
-            logging.info(f'snapshot restoration of {backup_path} terminated with code {exit_code}')
+            logging.info(
+                f'snapshot restoration of {backup_path} terminated with code {exit_code}'
+            )
 
     def reset_near_home(self):
         backup_id = self.data['state_data']


### PR DESCRIPTION
We currently copy the `data` folder of a node to a separate folder. 
in this PR we are introducing backups using RocksDB snapshots.
This will take advantage of RocksDB property that `.sst` files are immutable and we are just linking them instead of making a copy.

This will allow us to take subsequent backups by using less space. The network downtime is also reduced to ~10 seconds.

`neard_runner.py` logs when restoring old backup took 5 minutes
```
[2024-04-25 00:01:57,606] INFO: do_reset TestState.STOPPED
127.0.0.1 - - [25/Apr/2024 00:01:57] "POST / HTTP/1.1" 200 -
[2024-04-25 00:01:58,431] INFO: removing the old directory
[2024-04-25 00:02:02,545] INFO: restoring data dir from backup at /home/ubuntu/.near/neard-runner/backups/start
[2024-04-25 00:07:07,751] INFO: data dir restoration terminated with code 0
```


`neard_runner.py` logs when restoring new backup took 10 seconds. Including the event loop timeout (max 10 seconds).
```
127.0.0.1 - - [25/Apr/2024 00:09:13] "POST / HTTP/1.1" 200 -
[2024-04-25 00:09:23,479] INFO: removing the old directory
[2024-04-25 00:09:23,495] INFO: restoring data dir from backup at /home/ubuntu/.near/neard-runner/backups/tst3
[2024-04-25 00:09:23,495] INFO: running /home/ubuntu/.near/neard-runner/binaries/neard0 --home /home/ubuntu/.near/neard-runner/backups/tst3 --unsafe-fast-startup database make-snapshot --destination /home/ubuntu/.near
...neard logs...
[2024-04-25 00:09:24,138] INFO: data dir restoration terminated with code 0
```