### PR TITLE
fix(epoch_sync) - fix unintential epoch sync feature inclusion

### DIFF
--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -74,7 +74,7 @@ rosetta_rpc = ["nearcore/rosetta_rpc"]
 json_rpc = ["nearcore/json_rpc"]
 protocol_feature_fix_staking_threshold = ["nearcore/protocol_feature_fix_staking_threshold"]
 protocol_feature_nonrefundable_transfer_nep491 = ["near-state-viewer/protocol_feature_nonrefundable_transfer_nep491"]
-new_epoch_sync = ["nearcore/new_epoch_sync", "dep:near-epoch-sync-tool"]
+new_epoch_sync = ["nearcore/new_epoch_sync", "near-epoch-sync-tool/new_epoch_sync"]
 yield_resume = ["nearcore/yield_resume"]
 
 nightly = [

--- a/tools/epoch-sync/Cargo.toml
+++ b/tools/epoch-sync/Cargo.toml
@@ -11,6 +11,22 @@ publish = false
 [lints]
 workspace = true
 
+# Ignore unused dependencies. 
+# They are unused when new_epoch_sync feature is not set.
+[package.metadata.cargo-udeps.ignore]
+normal = [
+    "anyhow",
+    "clap",
+    "tracing",
+
+    "nearcore",
+    "near-chain",
+    "near-chain-configs",
+    "near-epoch-manager",
+    "near-primitives",
+    "near-store",
+]
+
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
@@ -25,4 +41,4 @@ near-store.workspace = true
 
 [features]
 default = []
-new_epoch_sync = []
+new_epoch_sync = ["nearcore/new_epoch_sync"]

--- a/tools/epoch-sync/Cargo.toml
+++ b/tools/epoch-sync/Cargo.toml
@@ -11,34 +11,34 @@ publish = false
 [lints]
 workspace = true
 
-# Ignore unused dependencies. 
-# They are unused when new_epoch_sync feature is not set.
-[package.metadata.cargo-udeps.ignore]
-normal = [
-    "anyhow",
-    "clap",
-    "tracing",
-
-    "nearcore",
-    "near-chain",
-    "near-chain-configs",
-    "near-epoch-manager",
-    "near-primitives",
-    "near-store",
-]
-
+# The dependencies are marked optional because we only need them when the
+# new_epoch_sync feature is enabled.
 [dependencies]
-anyhow.workspace = true
-clap.workspace = true
-tracing.workspace = true
+anyhow = { workspace = true, optional = true }
+clap = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
 
-nearcore.workspace = true
-near-chain.workspace = true
-near-chain-configs.workspace = true
-near-epoch-manager.workspace = true
-near-primitives.workspace = true
-near-store.workspace = true
+nearcore = { workspace = true, optional = true }
+near-chain = { workspace = true, optional = true }
+near-chain-configs = { workspace = true, optional = true }
+near-epoch-manager = { workspace = true, optional = true }
+near-primitives = { workspace = true, optional = true }
+near-store = { workspace = true, optional = true }
 
 [features]
+
 default = []
-new_epoch_sync = ["nearcore/new_epoch_sync"]
+new_epoch_sync = [
+    "nearcore/new_epoch_sync",
+
+    "dep:anyhow",
+    "dep:clap",
+    "dep:tracing",
+
+    "dep:nearcore",
+    "dep:near-chain",
+    "dep:near-chain-configs",
+    "dep:near-epoch-manager",
+    "dep:near-primitives",
+    "dep:near-store",
+]

--- a/tools/epoch-sync/Cargo.toml
+++ b/tools/epoch-sync/Cargo.toml
@@ -16,7 +16,7 @@ anyhow.workspace = true
 clap.workspace = true
 tracing.workspace = true
 
-nearcore = { workspace = true, features = ["new_epoch_sync"] }
+nearcore.workspace = true
 near-chain.workspace = true
 near-chain-configs.workspace = true
 near-epoch-manager.workspace = true

--- a/tools/epoch-sync/Cargo.toml
+++ b/tools/epoch-sync/Cargo.toml
@@ -22,3 +22,7 @@ near-chain-configs.workspace = true
 near-epoch-manager.workspace = true
 near-primitives.workspace = true
 near-store.workspace = true
+
+[features]
+default = []
+new_epoch_sync = []

--- a/tools/epoch-sync/src/cli.rs
+++ b/tools/epoch-sync/src/cli.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "new_epoch_sync")]
+
 use anyhow::Context;
 use clap;
 use near_chain::{ChainStore, ChainStoreAccess, ChainUpdate, DoomslugThresholdMode};

--- a/tools/epoch-sync/src/lib.rs
+++ b/tools/epoch-sync/src/lib.rs
@@ -1,2 +1,4 @@
+#[cfg(feature = "new_epoch_sync")]
 pub mod cli;
+#[cfg(feature = "new_epoch_sync")]
 pub use cli::EpochSyncCommand;


### PR DESCRIPTION
The epoch sync was getting enabled when using wide build commands that included the epoch sync tool. 

I'm moving the conditional enablement from Cargo.toml to the rust files. 

Additional information: https://near.zulipchat.com/#narrow/stream/300659-Rust-.F0.9F.A6.80/topic/PSA.3A.20don't.20use.20.60cargo.20build.20--bin.20neard.60