### PR TITLE
feat(mocknet): add subcommand to mirror.py to run commands on all mocknet hosts

### DIFF
--- a/pytest/tests/mocknet/cmd_utils.py
+++ b/pytest/tests/mocknet/cmd_utils.py
@@ -4,12 +4,15 @@ LOG_DIR = '/home/ubuntu/logs'
 STATUS_DIR = '/home/ubuntu/logs/status'
 
 
-def run_cmd(node, cmd):
+def run_cmd(node, cmd, raise_on_fail=False, return_on_fail=False):
     r = node.machine.run(cmd)
     if r.exitcode != 0:
-        sys.exit(
-            f'failed running {cmd} on {node.instance_name}:\nstdout: {r.stdout}\nstderr: {r.stderr}'
-        )
+        msg = f'failed running {cmd} on {node.instance_name}:\nstdout: {r.stdout}\nstderr: {r.stderr}'
+        if return_on_fail:
+            return r
+        if raise_on_fail:
+            raise msg
+        sys.exit(msg)
     return r
 
 

--- a/pytest/tests/mocknet/local_test_node.py
+++ b/pytest/tests/mocknet/local_test_node.py
@@ -93,7 +93,9 @@ class LocalTestNeardRunner:
         return
 
     def run_cmd(self, cmd, raise_on_fail=False, return_on_fail=False):
-        logger.error("Does not make sense to run command on local host. The behaviour may not be the desired one.")
+        logger.error(
+            "Does not make sense to run command on local host. The behaviour may not be the desired one."
+        )
 
     def init_python(self):
         return

--- a/pytest/tests/mocknet/local_test_node.py
+++ b/pytest/tests/mocknet/local_test_node.py
@@ -92,6 +92,9 @@ class LocalTestNeardRunner:
         # handled by local_test_setup_cmd()
         return
 
+    def run_cmd(self, cmd):
+        logger.error("Does not make sense to run command on local test.")
+
     def init_python(self):
         return
 

--- a/pytest/tests/mocknet/local_test_node.py
+++ b/pytest/tests/mocknet/local_test_node.py
@@ -92,8 +92,8 @@ class LocalTestNeardRunner:
         # handled by local_test_setup_cmd()
         return
 
-    def run_cmd(self, cmd):
-        logger.error("Does not make sense to run command on local test.")
+    def run_cmd(self, cmd, raise_on_fail=False, return_on_fail=False):
+        logger.error("Does not make sense to run command on local host. The behaviour may not be the desired one.")
 
     def init_python(self):
         return

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -360,7 +360,7 @@ def run_remote_cmd(args, traffic_generator, nodes):
         logger.error(f'No hosts selected. Change filters and try again.')
         return
     logger.info(f'Running cmd on {"".join([h.name() for h in targeted ])}')
-    pmap(lambda node: cmd_utils.run_cmd(node.node.node, args.cmd), targeted)
+    pmap(lambda node: node.run_cmd(args.cmd), targeted)
 
 
 if __name__ == '__main__':

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -360,7 +360,7 @@ def run_remote_cmd(args, traffic_generator, nodes):
         logger.error(f'No hosts selected. Change filters and try again.')
         return
     logger.info(f'Running cmd on {"".join([h.name() for h in targeted ])}')
-    pmap(lambda node: node.run_cmd(args.cmd), targeted)
+    pmap(lambda node: logger.info('{0}:\nstdout:\n{1.stdout}\nstderr:\n{1.stderr}'.format(node.name(), node.run_cmd(args.cmd, return_on_fail=True))), targeted, on_exception="")
 
 
 if __name__ == '__main__':

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -11,6 +11,7 @@ from rc import pmap
 import re
 import sys
 import time
+import cmd_utils
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 
@@ -347,6 +348,13 @@ def update_binaries_cmd(args, traffic_generator, nodes):
          nodes + [traffic_generator])
 
 
+def run_remote_cmd(args, traffic_generator, nodes):
+    if args.all or args.traffic:
+        cmd_utils.run_cmd(traffic_generator.node.node, args.cmd)
+    if args.all or args.nodes:
+        pmap(lambda node: cmd_utils.run_cmd(node.node.node, args.cmd), nodes)
+
+
 if __name__ == '__main__':
     parser = ArgumentParser(description='Control a mocknet instance')
     parser.add_argument('--chain-id', type=str)
@@ -478,6 +486,20 @@ if __name__ == '__main__':
         'Update the neard binaries by re-downloading them. The same urls are used.'
     )
     update_binaries_parser.set_defaults(func=update_binaries_cmd)
+
+    run_cmd_parser = subparsers.add_parser('run-cmd',
+                                           help='''Run the cmd on the hosts.''')
+    run_cmd_parser.add_argument('--cmd', type=str)
+    run_cmd_parser.add_argument('--all',
+                                action='store_true',
+                                help='Run on all hosts')
+    run_cmd_parser.add_argument('--nodes',
+                                action='store_true',
+                                help='Run on nodes')
+    run_cmd_parser.add_argument('--traffic',
+                                action='store_true',
+                                help='Run on traffic host')
+    run_cmd_parser.set_defaults(func=run_remote_cmd)
 
     args = parser.parse_args()
 

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -360,7 +360,11 @@ def run_remote_cmd(args, traffic_generator, nodes):
         logger.error(f'No hosts selected. Change filters and try again.')
         return
     logger.info(f'Running cmd on {"".join([h.name() for h in targeted ])}')
-    pmap(lambda node: logger.info('{0}:\nstdout:\n{1.stdout}\nstderr:\n{1.stderr}'.format(node.name(), node.run_cmd(args.cmd, return_on_fail=True))), targeted, on_exception="")
+    pmap(lambda node: logger.info(
+        '{0}:\nstdout:\n{1.stdout}\nstderr:\n{1.stderr}'.format(
+            node.name(), node.run_cmd(args.cmd, return_on_fail=True))),
+         targeted,
+         on_exception="")
 
 
 if __name__ == '__main__':

--- a/pytest/tests/mocknet/node_handle.py
+++ b/pytest/tests/mocknet/node_handle.py
@@ -31,8 +31,8 @@ class NodeHandle:
     def upload_neard_runner(self):
         self.node.upload_neard_runner()
 
-    def run_cmd(self, cmd):
-        return self.node.run_cmd(cmd)
+    def run_cmd(self, cmd, raise_on_fail=False, return_on_fail=False):
+        return self.node.run_cmd(cmd, raise_on_fail, return_on_fail)
 
     def init_neard_runner(self, config, remove_home_dir=False):
         self.node.stop_neard_runner()

--- a/pytest/tests/mocknet/node_handle.py
+++ b/pytest/tests/mocknet/node_handle.py
@@ -31,6 +31,9 @@ class NodeHandle:
     def upload_neard_runner(self):
         self.node.upload_neard_runner()
 
+    def run_cmd(self, cmd):
+        return self.node.run_cmd(cmd)
+
     def init_neard_runner(self, config, remove_home_dir=False):
         self.node.stop_neard_runner()
         self.node.init()

--- a/pytest/tests/mocknet/remote_node.py
+++ b/pytest/tests/mocknet/remote_node.py
@@ -55,7 +55,7 @@ class RemoteNeardRunner:
                             config)
 
     def run_cmd(self, cmd, raise_on_fail=False, return_on_fail=False):
-        r = cmd_utils.run_cmd(self.node,cmd, raise_on_fail, return_on_fail)
+        r = cmd_utils.run_cmd(self.node, cmd, raise_on_fail, return_on_fail)
         return r
 
     def init_python(self):

--- a/pytest/tests/mocknet/remote_node.py
+++ b/pytest/tests/mocknet/remote_node.py
@@ -54,9 +54,9 @@ class RemoteNeardRunner:
                             os.path.join(self.neard_runner_home, 'config.json'),
                             config)
 
-    def run_cmd(self, cmd):
-        r = cmd_utils.run_cmd(self.node,cmd)
-        return r.stdout
+    def run_cmd(self, cmd, raise_on_fail=False, return_on_fail=False):
+        r = cmd_utils.run_cmd(self.node,cmd, raise_on_fail, return_on_fail)
+        return r
 
     def init_python(self):
         cmd = f'cd {self.neard_runner_home} && python3 -m virtualenv venv -p $(which python3)' \

--- a/pytest/tests/mocknet/remote_node.py
+++ b/pytest/tests/mocknet/remote_node.py
@@ -54,6 +54,10 @@ class RemoteNeardRunner:
                             os.path.join(self.neard_runner_home, 'config.json'),
                             config)
 
+    def run_cmd(self, cmd):
+        r = cmd_utils.run_cmd(self.node,cmd)
+        return r.stdout
+
     def init_python(self):
         cmd = f'cd {self.neard_runner_home} && python3 -m virtualenv venv -p $(which python3)' \
         ' && ./venv/bin/pip install -r requirements.txt'


### PR DESCRIPTION
This PR introduces `run-cmd` subcommand that allow the user to issue commands to all the mocknet hosts.

It can target `--all` the host, only `--nodes` or only `--traffic` hosts.
It can also `--filter` the selected nodes with a regex.
It prints out the output of the command on every host. ` > /dev/null` if you don't want it.