### PR TITLE
refactor: generalize state trie queue

### DIFF
--- a/core/primitives/src/receipt.rs
+++ b/core/primitives/src/receipt.rs
@@ -257,5 +257,32 @@ pub struct PromiseYieldTimeout {
     pub expires_at: BlockHeight,
 }
 
+/// Stores indices for a persistent queue in the state trie.
+#[derive(Default, BorshSerialize, BorshDeserialize, Clone, PartialEq, Debug)]
+pub struct TrieQueueIndices {
+    // First inclusive index in the queue.
+    pub first_index: u64,
+    // Exclusive end index of the queue
+    pub next_available_index: u64,
+}
+
+impl TrieQueueIndices {
+    pub fn len(&self) -> u64 {
+        self.next_available_index - self.first_index
+    }
+}
+
+impl From<DelayedReceiptIndices> for TrieQueueIndices {
+    fn from(other: DelayedReceiptIndices) -> Self {
+        Self { first_index: other.first_index, next_available_index: other.next_available_index }
+    }
+}
+
+impl From<TrieQueueIndices> for DelayedReceiptIndices {
+    fn from(other: TrieQueueIndices) -> Self {
+        Self { first_index: other.first_index, next_available_index: other.next_available_index }
+    }
+}
+
 /// Map of shard to list of receipts to send to it.
 pub type ReceiptResult = HashMap<ShardId, Vec<Receipt>>;

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -42,7 +42,7 @@ use near_primitives::utils::{
     create_receipt_id_from_transaction,
 };
 use near_primitives::version::{ProtocolFeature, ProtocolVersion};
-use near_store::trie::receipts_column_helper::DelayedReceiptQueue;
+use near_store::trie::receipts_column_helper::{DelayedReceiptQueue, TrieQueue};
 use near_store::{
     get, get_account, get_postponed_receipt, get_promise_yield_receipt, get_received_data,
     has_received_data, remove_postponed_receipt, remove_promise_yield_receipt, set, set_account,


### PR DESCRIPTION
In #11159 we added a helper for the delayed receipts queue. To add more queues as simply as possible, we need to generalize the implementation a bit more.

First: Move code that is independent of the queue content to a new trait `TrieQueue`. Trie keys and access to fields is done through trait methods that each specific queue impl needs to define.

Second: Introduce `struct TrieQueueIndices` for a general way of storing queue indices. We keep the type `DelayedReceiptIndices` for backwards compatibility of dependencies to the primitives crate but provide conversion from and to it.

Third: Change the internals of `ReceiptIterator` to make use of these generalizations. We can avoid boxing a weird closure this way and make the addition of new queue implementations much easier.