### PR TITLE
feat(neard): print all enabled features in `neard --version`

### DIFF
--- a/neard/build.rs
+++ b/neard/build.rs
@@ -92,6 +92,27 @@ fn get_git_version() -> Result<String> {
     }
 }
 
+/// Get features enabled using the --features flag.
+fn get_enabled_features() -> String {
+    let mut features: Vec<String> = Vec::new();
+
+    // Every enabled feature has a corresponding environment variable that is set to 1
+    // For example:
+    // CARGO_FEATURE_JSON_RPC=1
+    // CARGO_FEATURE_ROSETTA_RPC=1
+    // ..
+
+    let feature_start = "CARGO_FEATURE_";
+    for (variable, value) in std::env::vars() {
+        if variable.starts_with(feature_start) && value == "1" {
+            features.push(variable[feature_start.len()..].to_string().to_lowercase());
+        }
+    }
+    features.sort();
+
+    features.join(", ")
+}
+
 fn main() {
     if let Err(err) = try_main() {
         eprintln!("{}", err);
@@ -113,6 +134,8 @@ fn try_main() -> Result<()> {
     println!("cargo:rustc-env=NEARD_BUILD={}", get_git_version()?);
 
     println!("cargo:rustc-env=NEARD_RUSTC_VERSION={}", rustc_version::version()?);
+
+    println!("cargo:rustc-env=NEARD_FEATURES={}", get_enabled_features());
 
     Ok(())
 }

--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -13,11 +13,12 @@ use std::time::Duration;
 static NEARD_VERSION: &str = env!("NEARD_VERSION");
 static NEARD_BUILD: &str = env!("NEARD_BUILD");
 static RUSTC_VERSION: &str = env!("NEARD_RUSTC_VERSION");
+static NEARD_FEATURES: &str = env!("NEARD_FEATURES");
 
 static NEARD_VERSION_STRING: Lazy<String> = Lazy::new(|| {
     format!(
-        "(release {}) (build {}) (rustc {}) (protocol {}) (db {})",
-        NEARD_VERSION, NEARD_BUILD, RUSTC_VERSION, PROTOCOL_VERSION, DB_VERSION
+        "(release {}) (build {}) (rustc {}) (protocol {}) (db {})\nfeatures: [{}]",
+        NEARD_VERSION, NEARD_BUILD, RUSTC_VERSION, PROTOCOL_VERSION, DB_VERSION, NEARD_FEATURES
     )
 });
 


### PR DESCRIPTION
Print all of the build time features enabled using the `--features` flag in the output of `neard --version`

Examples:
```
$ cargo run -p neard -- --version
...
neard (release trunk) (build 1.36.1-489-gdf22f90b9) (rustc 1.77.0) (protocol 67) (db 39)
features: [default, json_rpc, rosetta_rpc]
```

```
$ cargo run -p neard --features statelessnet_protocol,new_epoch_sync -- --version
...
neard (release trunk) (build 1.36.1-489-gdf22f90b9) (rustc 1.77.0) (protocol 85) (db 39)
features: [default, json_rpc, near_epoch_sync_tool, new_epoch_sync, rosetta_rpc, statelessnet_protocol]
```

```
$ cargo run -p neard --features nightly -- --version
...
neard (release trunk) (build 1.36.1-489-gdf22f90b9) (rustc 1.77.0) (protocol 140) (db 39)
features: [default, json_rpc, nightly, nightly_protocol, protocol_feature_fix_staking_threshold, protocol_feature_nonrefundable_transfer_nep491, rosetta_rpc, yield_resume]
```
```
$ ./neard --version
neard (release trunk) (build 1.36.1-489-gdf22f90b9) (rustc 1.77.0) (protocol 67) (db 39)
features: [default, json_rpc, rosetta_rpc]
```

Sometimes I have a `neard` binary, but I'm not sure which features were enabled during the build. It would be nice to be able to get this information somehow.
I can get the git commit from `--version`, but it didn't print the features, so now I added the feature of printing features.

We can can get the features from environment variables available to the `build.rs` script  (e.g [build-rs-env.txt](https://github.com/near/nearcore/files/15132189/build-rs-env.txt)). Then `build.rs` exposes an environment variable in a way that's visible from the `neard` crate (e.g. [cargo-run-env.txt](https://github.com/near/nearcore/files/15132195/cargo-run-env.txt))