### PR TITLE
feat: add outgoing receipt buffers

### DIFF
--- a/core/primitives/src/receipt.rs
+++ b/core/primitives/src/receipt.rs
@@ -8,7 +8,7 @@ use near_fmt::AbbrBytes;
 use serde_with::base64::Base64;
 use serde_with::serde_as;
 use std::borrow::Borrow;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::io;
 use std::io::{Error, ErrorKind};
@@ -291,7 +291,7 @@ impl From<TrieQueueIndices> for DelayedReceiptIndices {
 /// column.
 #[derive(Default, BorshSerialize, BorshDeserialize, Clone, PartialEq, Debug)]
 pub struct BufferedReceiptIndices {
-    pub shard_buffers: std::collections::BTreeMap<ShardId, TrieQueueIndices>,
+    pub shard_buffers: BTreeMap<ShardId, TrieQueueIndices>,
 }
 
 /// Map of shard to list of receipts to send to it.

--- a/core/primitives/src/receipt.rs
+++ b/core/primitives/src/receipt.rs
@@ -284,5 +284,15 @@ impl From<TrieQueueIndices> for DelayedReceiptIndices {
     }
 }
 
+/// Stores indices for a persistent queue for buffered receipts that couldn't be
+/// forwarded.
+///
+/// This is the singleton value stored in the `BUFFERED_RECEIPT_INDICES` trie
+/// column.
+#[derive(Default, BorshSerialize, BorshDeserialize, Clone, PartialEq, Debug)]
+pub struct BufferedReceiptIndices {
+    pub shard_buffers: std::collections::BTreeMap<ShardId, TrieQueueIndices>,
+}
+
 /// Map of shard to list of receipts to send to it.
 pub type ReceiptResult = HashMap<ShardId, Vec<Receipt>>;

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -1,11 +1,9 @@
-use std::mem::size_of;
-
-use borsh::{BorshDeserialize, BorshSerialize};
-
-use near_crypto::PublicKey;
-
 use crate::hash::CryptoHash;
 use crate::types::AccountId;
+use borsh::{BorshDeserialize, BorshSerialize};
+use near_crypto::PublicKey;
+use near_primitives_core::types::ShardId;
+use std::mem::size_of;
 
 pub(crate) const ACCOUNT_DATA_SEPARATOR: u8 = b',';
 // The use of `ACCESS_KEY` as a separator is a historical artefact.
@@ -50,8 +48,15 @@ pub mod col {
     /// This column id is used when storing the postponed PromiseYield receipts
     /// (`primitives::receipt::Receipt`).
     pub const PROMISE_YIELD_RECEIPT: u8 = 12;
-    /// All columns except those used for the delayed receipts queue and the yielded promises
-    /// queue, which are both global state for the shard.
+    /// Indices of outgoing receipts. A singleton per shard.
+    /// (`primitives::receipt::BufferedReceiptIndices)
+    pub const BUFFERED_RECEIPT_INDICES: u8 = 13;
+    /// Outgoing receipts that need to be buffered due to congestion +
+    /// backpressure on the receiving shard.
+    /// (`primitives::receipt::Receipt`).
+    pub const BUFFERED_RECEIPT: u8 = 14;
+    /// All columns except those used for the delayed receipts queue, the yielded promises
+    /// queue, and the outgoing receipts buffer, which are global state for the shard.
     pub const COLUMNS_WITH_ACCOUNT_ID_IN_KEY: [(u8, &str); 9] = [
         (ACCOUNT, "Account"),
         (CONTRACT_CODE, "ContractCode"),
@@ -109,6 +114,14 @@ pub enum TrieKey {
     /// Used to store the postponed promise yield receipt `primitives::receipt::Receipt`
     /// for a given receiver's `AccountId` and a given `data_id`.
     PromiseYieldReceipt { receiver_id: AccountId, data_id: CryptoHash },
+    /// Used to store indices of the buffered receipts queues per shard.
+    /// NOTE: It is a singleton per shard, holding indices for all outgoing shards.
+    BufferedReceiptIndices,
+    /// Used to store a buffered receipt `primitives::receipt::Receipt` for a
+    /// given index `u64` and receiving shard. There is one unique queue
+    /// per ordered shard pair. The trie for shard X stores all queues for pairs
+    /// (X,*).
+    BufferedReceipt { receiving_shard: ShardId, index: u64 },
 }
 
 /// Provides `len` function.
@@ -177,6 +190,12 @@ impl TrieKey {
                     + account_id.len()
                     + ACCOUNT_DATA_SEPARATOR.len()
                     + key.len()
+            }
+            TrieKey::BufferedReceiptIndices => col::BUFFERED_RECEIPT_INDICES.len(),
+            TrieKey::BufferedReceipt { index, .. } => {
+                col::BUFFERED_RECEIPT.len()
+                    + std::mem::size_of::<u16>()
+                    + std::mem::size_of_val(index)
             }
         }
     }
@@ -250,6 +269,14 @@ impl TrieKey {
                 buf.push(ACCOUNT_DATA_SEPARATOR);
                 buf.extend(data_id.as_ref());
             }
+            TrieKey::BufferedReceiptIndices => buf.push(col::BUFFERED_RECEIPT_INDICES),
+            TrieKey::BufferedReceipt { index, receiving_shard } => {
+                buf.push(col::BUFFERED_RECEIPT);
+                // Use  u16 for shard id to reduce depth in trie.
+                assert!(*receiving_shard <= u16::MAX as u64, "Shard ID too big.");
+                buf.extend(&(*receiving_shard as u16).to_le_bytes());
+                buf.extend(&index.to_le_bytes());
+            }
         };
         debug_assert_eq!(expected_len, buf.len() - start_len);
     }
@@ -276,6 +303,8 @@ impl TrieKey {
             TrieKey::PromiseYieldIndices => None,
             TrieKey::PromiseYieldTimeout { .. } => None,
             TrieKey::PromiseYieldReceipt { receiver_id, .. } => Some(receiver_id.clone()),
+            TrieKey::BufferedReceiptIndices => None,
+            TrieKey::BufferedReceipt { .. } => None,
         }
     }
 }

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -49,7 +49,7 @@ pub mod col {
     /// (`primitives::receipt::Receipt`).
     pub const PROMISE_YIELD_RECEIPT: u8 = 12;
     /// Indices of outgoing receipts. A singleton per shard.
-    /// (`primitives::receipt::BufferedReceiptIndices)
+    /// (`primitives::receipt::BufferedReceiptIndices`)
     pub const BUFFERED_RECEIPT_INDICES: u8 = 13;
     /// Outgoing receipts that need to be buffered due to congestion +
     /// backpressure on the receiving shard.
@@ -57,6 +57,9 @@ pub mod col {
     pub const BUFFERED_RECEIPT: u8 = 14;
     /// All columns except those used for the delayed receipts queue, the yielded promises
     /// queue, and the outgoing receipts buffer, which are global state for the shard.
+
+    // NOTE: NEW_COLUMN = 15 will be the last unique nibble in the trie!
+    // Consider demultiplexing on 15 and using 2-nibble prefixes.
     pub const COLUMNS_WITH_ACCOUNT_ID_IN_KEY: [(u8, &str); 9] = [
         (ACCOUNT, "Account"),
         (CONTRACT_CODE, "ContractCode"),
@@ -120,7 +123,7 @@ pub enum TrieKey {
     /// Used to store a buffered receipt `primitives::receipt::Receipt` for a
     /// given index `u64` and receiving shard. There is one unique queue
     /// per ordered shard pair. The trie for shard X stores all queues for pairs
-    /// (X,*).
+    /// (X,*) without (X,X).
     BufferedReceipt { receiving_shard: ShardId, index: u64 },
 }
 

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -379,6 +379,8 @@ impl StateChanges {
                 TrieKey::PromiseYieldIndices => {}
                 TrieKey::PromiseYieldTimeout { .. } => {}
                 TrieKey::PromiseYieldReceipt { .. } => {}
+                TrieKey::BufferedReceiptIndices => {}
+                TrieKey::BufferedReceipt { .. } => {}
             }
         }
 

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -24,8 +24,8 @@ use near_primitives::account::{AccessKey, Account};
 pub use near_primitives::errors::{MissingTrieValueContext, StorageError};
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{
-    DelayedReceiptIndices, PromiseYieldIndices, PromiseYieldTimeout, Receipt, ReceiptEnum,
-    ReceivedData,
+    BufferedReceiptIndices, DelayedReceiptIndices, PromiseYieldIndices, PromiseYieldTimeout,
+    Receipt, ReceiptEnum, ReceivedData,
 };
 pub use near_primitives::shard_layout::ShardUId;
 use near_primitives::trie_key::{trie_key_parsers, TrieKey};
@@ -900,6 +900,12 @@ pub fn has_promise_yield_receipt(
     data_id: CryptoHash,
 ) -> Result<bool, StorageError> {
     trie.contains_key(&TrieKey::PromiseYieldReceipt { receiver_id, data_id })
+}
+
+pub fn get_buffered_receipt_indices(
+    trie: &dyn TrieAccess,
+) -> Result<BufferedReceiptIndices, StorageError> {
+    Ok(get(trie, &TrieKey::BufferedReceiptIndices)?.unwrap_or_default())
 }
 
 pub fn set_access_key(

--- a/core/store/src/trie/resharding.rs
+++ b/core/store/src/trie/resharding.rs
@@ -103,6 +103,9 @@ impl ShardTries {
                         None => trie_update.remove(trie_key),
                     }
                 }
+                // TODO(congestion_control)
+                TrieKey::BufferedReceiptIndices => todo!(),
+                TrieKey::BufferedReceipt { .. } => todo!(),
             }
         }
         for (_, update) in trie_updates.iter_mut() {


### PR DESCRIPTION
Add an outgoing receipt buffer for each other shard to the state trie.

This is part of congestion control (NEP-539).

This PR only adds the new buffers and unit tests for it, without actually using them. Future PRs will use it.