### PR TITLE
deps: Add Locust Python deps

### DIFF
--- a/pytest/requirements.txt
+++ b/pytest/requirements.txt
@@ -3,6 +3,8 @@ base58
 cython
 deepdiff
 ed25519
+locust
+nearup
 numpy
 prometheus-client
 psutil


### PR DESCRIPTION
This should make installing all dependencies trivial with `pip install -r pytest/requirements.txt`