### PR TITLE
 cleanup(congestion_control) - resolved a few minor TODOs 

### DIFF
--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -268,7 +268,7 @@ impl<'a> ChainUpdate<'a> {
                         gas_burnt,
                         gas_limit,
                         balance_burnt,
-                        // TODO(congestion_control) integration with resharding
+                        // TODO(congestion_control) - integration with resharding
                         None,
                     );
                     sum_gas_used += gas_burnt;

--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -268,8 +268,7 @@ impl<'a> ChainUpdate<'a> {
                         gas_burnt,
                         gas_limit,
                         balance_burnt,
-                        // TODO(congestion_control) set congestion info for resharding
-                        // TODO(resharding) set congestion info for resharding
+                        // TODO(congestion_control) integration with resharding
                         None,
                     );
                     sum_gas_used += gas_burnt;

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -41,7 +41,7 @@ use near_primitives::types::{
     AccountId, ApprovalStake, Balance, BlockHeight, EpochHeight, EpochId, Nonce, NumShards,
     ShardId, StateChangesForResharding, StateRoot, StateRootNode, ValidatorInfoIdentifier,
 };
-use near_primitives::version::{ProtocolVersion, PROTOCOL_VERSION};
+use near_primitives::version::{ProtocolFeature, ProtocolVersion, PROTOCOL_VERSION};
 use near_primitives::views::{
     AccessKeyInfoView, AccessKeyList, CallResult, ContractCodeView, EpochValidatorInfo,
     QueryRequest, QueryResponse, QueryResponseKind, ViewStateResult,
@@ -391,6 +391,15 @@ impl KeyValueRuntime {
             return Ok(Some(headers_cache.get(hash).unwrap().clone()));
         }
         Ok(None)
+    }
+
+    fn get_congestion_info(protocol_version: ProtocolVersion) -> Option<CongestionInfo> {
+        if protocol_version >= ProtocolFeature::CongestionControl.protocol_version() {
+            // TODO(congestion_control) - properly initialize
+            Some(CongestionInfo::default())
+        } else {
+            None
+        }
     }
 }
 
@@ -1274,7 +1283,7 @@ impl RuntimeAdapter for KeyValueRuntime {
             processed_delayed_receipts: vec![],
             processed_yield_timeouts: vec![],
             applied_receipts_hash: hash(&borsh::to_vec(receipts).unwrap()),
-            congestion_info: Some(CongestionInfo::default()),
+            congestion_info: Self::get_congestion_info(PROTOCOL_VERSION),
         })
     }
 

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -154,7 +154,6 @@ pub(crate) fn validate_prepared_transactions(
     storage_config: RuntimeStorageConfig,
     transactions: &[SignedTransaction],
 ) -> Result<PreparedTransactions, Error> {
-    // TODO(congestion_control): Is it okay to read full block here?
     let parent_block = chain.chain_store().get_block(chunk_header.prev_block_hash())?;
 
     runtime_adapter.prepare_transactions(

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -278,14 +278,10 @@ pub(crate) fn pre_validate_chunk_state_witness(
     }
 
     let main_transition_params = if last_chunk_block.header().is_genesis() {
-        // TODO(congestion_control): check if this epoch_id / protocol version is right for genesis
-        let epoch_id = epoch_manager
-            .get_next_epoch_id_from_prev_block(last_chunk_block.header().prev_hash())?;
+        let epoch_id = last_chunk_block.header().epoch_id();
+        let genesis_protocol_version = epoch_manager.get_epoch_protocol_version(&epoch_id)?;
         MainTransition::Genesis {
-            chunk_extra: chain.genesis_chunk_extra(
-                shard_id,
-                epoch_manager.get_epoch_protocol_version(&epoch_id)?,
-            )?,
+            chunk_extra: chain.genesis_chunk_extra(shard_id, genesis_protocol_version)?,
             block_hash: *last_chunk_block.hash(),
             shard_id,
         }

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -791,6 +791,9 @@ pub mod chunk_extra {
     }
 
     impl ChunkExtra {
+        /// This method creates a slimmed down and invalid ChunkExtra. It's used
+        /// for resharding where we only need the state root. This should not be
+        /// used as part of regular processing.
         pub fn new_with_only_state_root(state_root: &StateRoot) -> Self {
             Self::new(
                 PROTOCOL_VERSION,
@@ -800,9 +803,7 @@ pub mod chunk_extra {
                 0,
                 0,
                 0,
-                // TODO(congestion_control) - this breaks the invariant that
-                // congestion info is set when protocol version is greater equal
-                // to the congestion control protocol version.
+                // TODO(congestion_control) - integration with resharding
                 None,
             )
         }
@@ -818,7 +819,6 @@ pub mod chunk_extra {
             congestion_info: Option<CongestionInfo>,
         ) -> Self {
             if protocol_version >= ProtocolFeature::CongestionControl.protocol_version() {
-                // TODO(congestion_control)
                 assert!(congestion_info.is_some());
                 Self::V3(ChunkExtraV3 {
                     state_root: *state_root,
@@ -830,8 +830,7 @@ pub mod chunk_extra {
                     congestion_info: congestion_info.unwrap(),
                 })
             } else {
-                // TODO(congestion_control)
-                // assert!(congestion_info.is_none());
+                assert!(congestion_info.is_none());
                 Self::V2(ChunkExtraV2 {
                     state_root: *state_root,
                     outcome_root,

--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -194,7 +194,7 @@ mod tests {
     use near_primitives::trie_key::TrieKey;
     use near_primitives::types::chunk_extra::ChunkExtra;
     use near_primitives::types::StateChangeCause;
-    use near_primitives::version::PROTOCOL_VERSION;
+    use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
 
@@ -536,6 +536,13 @@ mod tests {
         shard_uid: ShardUId,
         state_root: CryptoHash,
     ) {
+        let congestion_info =
+            if PROTOCOL_VERSION >= ProtocolFeature::CongestionControl.protocol_version() {
+                Some(CongestionInfo::default())
+            } else {
+                None
+            };
+
         let chunk_extra = ChunkExtra::new(
             PROTOCOL_VERSION,
             &state_root,
@@ -544,7 +551,7 @@ mod tests {
             0,
             0,
             0,
-            Some(CongestionInfo::default()),
+            congestion_info,
         );
         let mut store_update = store.store_update();
         store_update

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -86,7 +86,7 @@ mod trie_recording_tests {
     use near_primitives::state::ValueRef;
     use near_primitives::types::chunk_extra::ChunkExtra;
     use near_primitives::types::StateRoot;
-    use near_primitives::version::PROTOCOL_VERSION;
+    use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
     use rand::prelude::SliceRandom;
     use rand::{random, thread_rng, Rng};
     use std::collections::{HashMap, HashSet};
@@ -141,6 +141,13 @@ mod trie_recording_tests {
             &trie_changes,
         );
 
+        let congestion_info =
+            if PROTOCOL_VERSION >= ProtocolFeature::CongestionControl.protocol_version() {
+                Some(CongestionInfo::default())
+            } else {
+                None
+            };
+
         // ChunkExtra is needed for in-memory trie loading code to query state roots.
         let chunk_extra = ChunkExtra::new(
             PROTOCOL_VERSION,
@@ -150,7 +157,7 @@ mod trie_recording_tests {
             0,
             0,
             0,
-            Some(CongestionInfo::default()),
+            congestion_info,
         );
         let mut update_for_chunk_extra = tries_for_building.store_update();
         update_for_chunk_extra

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -215,7 +215,7 @@ mod trie_storage_tests {
     use near_primitives::hash::hash;
     use near_primitives::shard_layout::get_block_shard_uid;
     use near_primitives::types::chunk_extra::ChunkExtra;
-    use near_primitives::version::PROTOCOL_VERSION;
+    use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 
     fn create_store_with_values(values: &[Vec<u8>], shard_uid: ShardUId) -> Store {
         let tries = TestTriesBuilder::new().build();
@@ -440,6 +440,12 @@ mod trie_storage_tests {
         let recorded_normal = trie.recorded_storage();
 
         let store = create_test_store();
+        let congestion_info =
+            if PROTOCOL_VERSION >= ProtocolFeature::CongestionControl.protocol_version() {
+                Some(CongestionInfo::default())
+            } else {
+                None
+            };
         // ChunkExtra is needed for in-memory trie loading code to query state roots.
         let chunk_extra = ChunkExtra::new(
             PROTOCOL_VERSION,
@@ -449,7 +455,7 @@ mod trie_storage_tests {
             0,
             0,
             0,
-            Some(CongestionInfo::default()),
+            congestion_info,
         );
         let mut update_for_chunk_extra = store.store_update();
         update_for_chunk_extra

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -20,10 +20,12 @@ use near_primitives::state_record::StateRecord;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{AccountId, Balance, EpochId, ShardId, StateChangeCause, StateRoot};
 use near_primitives::utils::to_timestamp;
+use near_primitives::version::ProtocolFeature;
 use near_store::genesis::{compute_storage_usage, initialize_genesis_state};
 use near_store::{
     get_account, get_genesis_state_roots, set_access_key, set_account, set_code, Store, TrieUpdate,
 };
+use near_vm_runner::logic::ProtocolVersion;
 use near_vm_runner::ContractCode;
 use nearcore::{NearConfig, NightshadeRuntime, NightshadeRuntimeExt};
 use std::collections::BTreeMap;
@@ -246,6 +248,8 @@ impl GenesisBuilder {
             .expect("save genesis block header shouldn't fail");
         store_update.save_block(genesis.clone());
 
+        let protocol_version = self.genesis.config.protocol_version;
+        let congestion_info = Self::get_congestion_control(protocol_version);
         for (chunk_header, state_root) in genesis.chunks().iter().zip(self.roots.values()) {
             store_update.save_chunk_extra(
                 genesis.hash(),
@@ -261,7 +265,7 @@ impl GenesisBuilder {
                     0,
                     self.genesis.config.gas_limit,
                     0,
-                    Some(CongestionInfo::default()),
+                    congestion_info,
                 ),
             );
         }
@@ -272,6 +276,15 @@ impl GenesisBuilder {
         store_update.commit().unwrap();
 
         Ok(())
+    }
+
+    fn get_congestion_control(protocol_version: ProtocolVersion) -> Option<CongestionInfo> {
+        if protocol_version >= ProtocolFeature::CongestionControl.protocol_version() {
+            // TODO(congestion_control) - properly initialize
+            Some(CongestionInfo::default())
+        } else {
+            None
+        }
     }
 
     fn add_additional_account(&mut self, account_id: AccountId) -> Result<()> {

--- a/integration-tests/src/tests/client/resharding.rs
+++ b/integration-tests/src/tests/client/resharding.rs
@@ -1050,8 +1050,8 @@ fn test_shard_layout_upgrade_simple_impl(
     tracing::info!(target: "test", "test_shard_layout_upgrade_simple_impl finished");
 }
 
-// TODO(congestion_control) - set congestion control for resharding and
-// un-ignore all integration tests
+// TODO(congestion_control) - integration with resharding
+// set congestion control for resharding and un-ignore all integration tests
 
 #[ignore]
 #[test]

--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -131,8 +131,8 @@ pytest sanity/rpc_tx_submission.py --features nightly
 # The state sync fail test checks that state sync fails during or after
 # resharding. Currently it's disabled because resharding and congestion control
 # are not fully integrated. There are two steps to be taken:
-# TODO(congestion_control) - fix integration with resharding and enable fail test
-# TODO(resharding) - fix integration with state sync and adjust fail test
+# TODO(congestion_control) - integration with resharding and enable fail_test
+# TODO(resharding) - integration with state sync and adjust fail_test
 # TODO(#9519)
 # pytest sanity/state_sync_fail.py
 # pytest sanity/state_sync_fail.py --features nightly

--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -632,7 +632,7 @@ mod test {
         validate_genesis(&new_genesis).unwrap();
     }
 
-    // TODO(congestion_control) - fix and re-enable this test
+    // TODO(congestion_control) - integration with resharding
     #[ignore]
     #[test]
     fn test_dump_state_shard_upgrade() {


### PR DESCRIPTION
Removing a few TODOs and updating some others.

* Renamed all TODOs related to resharding to "integration with resharding" so that it's easier to filter those out. 
* Resolved TODO in chunk validation when getting genesis transition params - reading epoch id directly from header
* Resolved TODOs in ChunkExtra::new - uncommented the asserts. 
* Resolved TODO is validate_prepared_transactions - I checked that the method that calls this function reads multiple blocks including this one. It's not convenient to pass the block as an argument but it should be in the db cache so fetching it again should be really cheap.