### PR TITLE
Fix some typos in `docs`

### DIFF
--- a/docs/architecture/gas/README.md
+++ b/docs/architecture/gas/README.md
@@ -101,7 +101,7 @@ contract size. Today, we limit ourselves to linear-time algorithms in the
 compiler.
 
 Likewise, an action that has no scaling parameters must only use constant time
-to execute. Taking the `CreateAcccount` action as an example, with a cost of 0.1
+to execute. Taking the `CreateAccount` action as an example, with a cost of 0.1
 Tgas, it has to execute within 0.1ms. Technically, the execution time depends
 ever so slightly on the account name length. But there is a fairly low upper
 limit on that length and it makes sense to absorb all the cost in the constant

--- a/docs/architecture/how/receipt-congestion.md
+++ b/docs/architecture/how/receipt-congestion.md
@@ -41,7 +41,7 @@ sink of shard 2. This should be interpreted as if we continue sending the exact
 same workload on all shards every block. Then we reach this steady state where
 we continue to have these gas assignments per edge.
 
-Now we can do som flow analysis. It is immediately obvious that the total
+Now we can do some flow analysis. It is immediately obvious that the total
 outflow per is limited to N * 1000 Tgas but the incoming flow is unlimited.
 
 For a finite amount of time, we can accept more inflow than outflow, we just have to add buffers to store what we cannot execute, yet. But to stay within finite memory requirements, we need to fall back to a flow diagram where outflows are greater or equal to inflows within a finite time frame.

--- a/docs/architecture/how/tx_routing.md
+++ b/docs/architecture/how/tx_routing.md
@@ -85,7 +85,7 @@ it removes it from its local mempool.
 ### Can transaction get lost?
 
 Yes - they can and they do. Sometimes a node doesn’t have a path to a given
-validator or it didn’t receive an `AnnouceAccount` for it, so it doesn’t know
+validator or it didn’t receive an `AnnounceAccount` for it, so it doesn’t know
 where to forward the message. And if this happens to all 4 validators that we
 try to send to, then the message can be silently dropped.
 


### PR DESCRIPTION
Fixed some typos in `docs`.