### PR TITLE
fix: Pass release type to binary_release.sh in custom-release GitHub action

### DIFF
--- a/.github/workflows/neard_custom_release.yml
+++ b/.github/workflows/neard_custom_release.yml
@@ -44,7 +44,9 @@ jobs:
           fetch-depth: 0
 
       - name: Neard binary build and upload to S3
-        run: ./scripts/binary_release.sh
+        env:
+          release_type: ${{ github.event.inputs.release }}
+        run: ./scripts/binary_release.sh $release_type   
 
       - name: Update latest version metadata in S3
         run: |

--- a/.github/workflows/neard_custom_release.yml
+++ b/.github/workflows/neard_custom_release.yml
@@ -44,9 +44,7 @@ jobs:
           fetch-depth: 0
 
       - name: Neard binary build and upload to S3
-        env:
-          release_type: ${{ github.event.inputs.release }}
-        run: ./scripts/binary_release.sh $release_type   
+        run: ./scripts/binary_release.sh ${{ github.event.inputs.release }}
 
       - name: Update latest version metadata in S3
         run: |


### PR DESCRIPTION
We added a [new GitHub action](https://github.com/near/nearcore/actions/workflows/neard_custom_release.yml) to pass a release type param to the binary_release.sh script, so that we can compile neard with different features (eg. with stateless validation). But missed passing the parameter to the script. This change passes the param value to the script.