### PR TITLE
stateless forknet: limit size of new transactions to 4MB

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -778,12 +778,20 @@ impl RuntimeAdapter for NightshadeRuntime {
         // cost of roundtripping a byte of data through disk. For today's value
         // of parameters, this corresponds to about 13megs worth of
         // transactions.
-        let size_limit = transactions_gas_limit
-            / (runtime_config.wasm_config.ext_costs.gas_cost(ExtCosts::storage_write_value_byte)
-                + runtime_config.wasm_config.ext_costs.gas_cost(ExtCosts::storage_read_value_byte));
-
-        // FORKNET: reduce size limit of new transactions to 4MB.
-        let size_limit = (size_limit as f64 / 13.0 * 4.0) as u64;
+        let size_limit = if checked_feature!("stable", StatelessValidationV0, protocol_version) {
+            // FORKNET: reduce size limit of new transactions to 4MB.
+            4_000_000
+        } else {
+            transactions_gas_limit
+                / (runtime_config
+                    .wasm_config
+                    .ext_costs
+                    .gas_cost(ExtCosts::storage_write_value_byte)
+                    + runtime_config
+                        .wasm_config
+                        .ext_costs
+                        .gas_cost(ExtCosts::storage_read_value_byte))
+        };
 
         // Add new transactions to the result until some limit is hit or the transactions run out.
         loop {

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -782,6 +782,9 @@ impl RuntimeAdapter for NightshadeRuntime {
             / (runtime_config.wasm_config.ext_costs.gas_cost(ExtCosts::storage_write_value_byte)
                 + runtime_config.wasm_config.ext_costs.gas_cost(ExtCosts::storage_read_value_byte));
 
+        // FORKNET: reduce size limit of new transactions to 4MB.
+        let size_limit = (size_limit as f64 / 13.0 * 4.0) as u64;
+
         // Add new transactions to the result until some limit is hit or the transactions run out.
         loop {
             if total_gas_burnt >= transactions_gas_limit {

--- a/chain/network/src/tcp.rs
+++ b/chain/network/src/tcp.rs
@@ -93,14 +93,14 @@ impl Stream {
             std::net::SocketAddr::V6(_) => tokio::net::TcpSocket::new_v6()?,
         };
 
-        let SO_RCVBUF = 1000000;
-        let SO_SNDBUF = 1000000;
+        let so_rcvbuf = 1000000;
+        let so_sndbuf = 1000000;
 
-        socket.set_recv_buffer_size(SO_RCVBUF)?;
-        socket.set_send_buffer_size(SO_SNDBUF)?;
+        socket.set_recv_buffer_size(so_rcvbuf)?;
+        socket.set_send_buffer_size(so_sndbuf)?;
 
-        tracing::debug!(target: "network", "SO_RCVBUF wanted {} got {:?}", SO_RCVBUF, socket.recv_buffer_size());
-        tracing::debug!(target: "network", "SO_SNDBUF wanted {} got {:?}", SO_SNDBUF, socket.send_buffer_size());
+        tracing::debug!(target: "network", "SO_RCVBUF wanted {} got {:?}", so_rcvbuf, socket.recv_buffer_size());
+        tracing::debug!(target: "network", "SO_SNDBUF wanted {} got {:?}", so_sndbuf, socket.send_buffer_size());
 
         // The `connect` may take several minutes. This happens when the
         // `SYN` packet for establishing a TCP connection gets silently


### PR DESCRIPTION
Previous limit was 13MB, let's reduce it to 4MB and see what happens.