### PR TITLE
refactor(congestion): Clearer protocol version checks

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -624,7 +624,7 @@ impl Chain {
     }
 
     fn get_genesis_congestion_info(protocol_version: ProtocolVersion) -> Option<CongestionInfo> {
-        if protocol_version >= ProtocolFeature::CongestionControl.protocol_version() {
+        if ProtocolFeature::CongestionControl.enabled(protocol_version) {
             // TODO(congestion_control) - properly initialize
             Some(CongestionInfo::default())
         } else {

--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -254,7 +254,7 @@ impl<'a> ChainUpdate<'a> {
                         balance_split
                     };
 
-                    if protocol_version >= ProtocolFeature::CongestionControl.protocol_version() {
+                    if ProtocolFeature::CongestionControl.enabled(protocol_version) {
                         // This will likely break resharding integration tests
                         // when congestion control is enabled. Let's mark them
                         // ignore when that happens.

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -797,7 +797,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                 result.limited_by = Some(PrepareTransactionsLimit::Size);
                 break;
             }
-            if protocol_version < ProtocolFeature::CongestionControl.protocol_version() {
+            if !ProtocolFeature::CongestionControl.enabled(protocol_version) {
                 // Keep this for the upgrade phase, afterwards it can be
                 // removed. It does not need to be kept because it does not
                 // affect replayability.
@@ -819,7 +819,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                 while let Some(tx) = iter.next() {
                     num_checked_transactions += 1;
 
-                    if ProtocolFeature::CongestionControl.protocol_version() <= protocol_version {
+                    if ProtocolFeature::CongestionControl.enabled(protocol_version) {
                         let receiving_shard = EpochManagerAdapter::account_id_to_shard_id(
                             self.epoch_manager.as_ref(),
                             &tx.transaction.receiver_id,
@@ -1306,7 +1306,7 @@ fn chunk_tx_gas_limit(
     shard_id: u64,
     gas_limit: u64,
 ) -> u64 {
-    if ProtocolFeature::CongestionControl.protocol_version() <= protocol_version {
+    if ProtocolFeature::CongestionControl.enabled(protocol_version) {
         if let Some(own_congestion) = prev_block.congestion_info.get(&shard_id) {
             own_congestion.process_tx_limit()
         } else {

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -83,14 +83,16 @@ impl NightshadeRuntime {
         let epoch_id =
             self.epoch_manager.get_epoch_id_from_prev_block(block_hash).unwrap_or_default();
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id).unwrap();
-        let congestion_info_map: HashMap<ShardId, CongestionInfo> = if protocol_version
-            < ProtocolFeature::CongestionControl.protocol_version()
-        {
-            HashMap::new()
-        } else {
-            let shard_ids = self.epoch_manager.shard_ids(&epoch_id).unwrap();
-            shard_ids.into_iter().map(|shard_id| (shard_id, CongestionInfo::default())).collect()
-        };
+        let congestion_info_map: HashMap<ShardId, CongestionInfo> =
+            if !ProtocolFeature::CongestionControl.enabled(protocol_version) {
+                HashMap::new()
+            } else {
+                let shard_ids = self.epoch_manager.shard_ids(&epoch_id).unwrap();
+                shard_ids
+                    .into_iter()
+                    .map(|shard_id| (shard_id, CongestionInfo::default()))
+                    .collect()
+            };
         let mut result = self
             .apply_chunk(
                 RuntimeStorageConfig::new(*state_root, true),

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -394,7 +394,7 @@ impl KeyValueRuntime {
     }
 
     fn get_congestion_info(protocol_version: ProtocolVersion) -> Option<CongestionInfo> {
-        if protocol_version >= ProtocolFeature::CongestionControl.protocol_version() {
+        if ProtocolFeature::CongestionControl.enabled(protocol_version) {
             // TODO(congestion_control) - properly initialize
             Some(CongestionInfo::default())
         } else {

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -239,6 +239,10 @@ impl ProtocolFeature {
             ProtocolFeature::CongestionControl => 142,
         }
     }
+
+    pub fn enabled(&self, protocol_version: ProtocolVersion) -> bool {
+        protocol_version <= self.protocol_version()
+    }
 }
 
 /// Current protocol version used on the mainnet.

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -241,7 +241,7 @@ impl ProtocolFeature {
     }
 
     pub fn enabled(&self, protocol_version: ProtocolVersion) -> bool {
-        protocol_version <= self.protocol_version()
+        protocol_version >= self.protocol_version()
     }
 }
 

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -196,7 +196,7 @@ impl ShardChunkHeaderV3 {
         congestion_info: CongestionInfo,
         signer: &dyn ValidatorSigner,
     ) -> Self {
-        let inner = if protocol_version >= ProtocolFeature::CongestionControl.protocol_version() {
+        let inner = if ProtocolFeature::CongestionControl.enabled(protocol_version) {
             ShardChunkHeaderInner::V3(ShardChunkHeaderInnerV3 {
                 prev_block_hash,
                 prev_state_root,

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -818,7 +818,7 @@ pub mod chunk_extra {
             balance_burnt: Balance,
             congestion_info: Option<CongestionInfo>,
         ) -> Self {
-            if protocol_version >= ProtocolFeature::CongestionControl.protocol_version() {
+            if ProtocolFeature::CongestionControl.enabled(protocol_version) {
                 assert!(congestion_info.is_some());
                 Self::V3(ChunkExtraV3 {
                     state_root: *state_root,

--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -536,12 +536,9 @@ mod tests {
         shard_uid: ShardUId,
         state_root: CryptoHash,
     ) {
-        let congestion_info =
-            if PROTOCOL_VERSION >= ProtocolFeature::CongestionControl.protocol_version() {
-                Some(CongestionInfo::default())
-            } else {
-                None
-            };
+        let congestion_info = ProtocolFeature::CongestionControl
+            .enabled(PROTOCOL_VERSION)
+            .then(CongestionInfo::default);
 
         let chunk_extra = ChunkExtra::new(
             PROTOCOL_VERSION,

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -141,12 +141,9 @@ mod trie_recording_tests {
             &trie_changes,
         );
 
-        let congestion_info =
-            if PROTOCOL_VERSION >= ProtocolFeature::CongestionControl.protocol_version() {
-                Some(CongestionInfo::default())
-            } else {
-                None
-            };
+        let congestion_info = ProtocolFeature::CongestionControl
+            .enabled(PROTOCOL_VERSION)
+            .then(CongestionInfo::default);
 
         // ChunkExtra is needed for in-memory trie loading code to query state roots.
         let chunk_extra = ChunkExtra::new(

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -440,12 +440,9 @@ mod trie_storage_tests {
         let recorded_normal = trie.recorded_storage();
 
         let store = create_test_store();
-        let congestion_info =
-            if PROTOCOL_VERSION >= ProtocolFeature::CongestionControl.protocol_version() {
-                Some(CongestionInfo::default())
-            } else {
-                None
-            };
+        let congestion_info = ProtocolFeature::CongestionControl
+            .enabled(PROTOCOL_VERSION)
+            .then(CongestionInfo::default);
         // ChunkExtra is needed for in-memory trie loading code to query state roots.
         let chunk_extra = ChunkExtra::new(
             PROTOCOL_VERSION,

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -279,7 +279,7 @@ impl GenesisBuilder {
     }
 
     fn get_congestion_control(protocol_version: ProtocolVersion) -> Option<CongestionInfo> {
-        if protocol_version >= ProtocolFeature::CongestionControl.protocol_version() {
+        if ProtocolFeature::CongestionControl.enabled(protocol_version) {
             // TODO(congestion_control) - properly initialize
             Some(CongestionInfo::default())
         } else {

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2591,7 +2591,7 @@ fn test_refund_receipts_processing() {
 fn test_delayed_receipt_count_limit() {
     init_test_logger();
 
-    if ProtocolFeature::CongestionControl.protocol_version() >= PROTOCOL_VERSION {
+    if ProtocolFeature::CongestionControl.enabled(PROTOCOL_VERSION) {
         // congestion control replaces the delayed receipt count limit, making this test irrelevant
         return;
     }

--- a/runtime/runtime/src/congestion_control.rs
+++ b/runtime/runtime/src/congestion_control.rs
@@ -56,9 +56,7 @@ impl<'a> ReceiptSink<'a> {
         outgoing_receipts: &'a mut Vec<Receipt>,
     ) -> Result<Self, StorageError> {
         if let Some(ref mut congestion_info) = congestion_info {
-            debug_assert!(
-                protocol_version >= ProtocolFeature::CongestionControl.protocol_version()
-            );
+            debug_assert!(ProtocolFeature::CongestionControl.enabled(protocol_version));
             let outgoing_buffers = ShardsOutgoingReceiptBuffer::load(trie)?;
 
             let outgoing_limit: HashMap<ShardId, Gas> = apply_state
@@ -76,7 +74,7 @@ impl<'a> ReceiptSink<'a> {
                 outgoing_buffers,
             }))
         } else {
-            debug_assert!(protocol_version < ProtocolFeature::CongestionControl.protocol_version());
+            debug_assert!(!ProtocolFeature::CongestionControl.enabled(protocol_version));
             Ok(ReceiptSink::V1(ReceiptSinkV1 { outgoing_receipts: outgoing_receipts }))
         }
     }

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1829,7 +1829,7 @@ impl ApplyState {
         &self,
         protocol_version: ProtocolVersion,
     ) -> Result<Option<CongestionInfo>, RuntimeError> {
-        if protocol_version >= ProtocolFeature::CongestionControl.protocol_version() {
+        if ProtocolFeature::CongestionControl.enabled(protocol_version) {
             let congestion_info = self
                 .congestion_info
                 .get(&self.shard_id)


### PR DESCRIPTION
Add `fn ProtocolVersion::enabled` to avoid making direct comparisons all over the code.

`checked_feature!` used to be the right choice.
But without cfg, a complex macro is overkill.

This PR only uses the new fn for `ProtocolFeature::CongestionControl` checks. We can consider replacing the checks for other features, too.