### PR TITLE
refactor: remove fisherman related code from epoch

### DIFF
--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -41,7 +41,6 @@ use super::*;
 
 use crate::rayon_spawner::RayonAsyncComputationSpawner;
 use near_async::time::Clock;
-use near_primitives::account::id::AccountIdRef;
 use near_primitives::trie_key::TrieKey;
 use primitive_types::U256;
 
@@ -502,10 +501,7 @@ fn test_validator_rotation() {
     );
     let test2_acc = env.view_account(&"test2".parse().unwrap());
     // Become fishermen instead
-    assert_eq!(
-        (test2_acc.amount, test2_acc.locked),
-        (TESTING_INIT_BALANCE - test2_stake_amount, test2_stake_amount)
-    );
+    assert_eq!((test2_acc.amount, test2_acc.locked), (TESTING_INIT_BALANCE, 0));
     let test3_acc = env.view_account(&"test3".parse().unwrap());
     // Got 3 * X, staking 2 * X of them.
     assert_eq!((test3_acc.amount, test3_acc.locked), (TESTING_INIT_STAKE, 2 * TESTING_INIT_STAKE));
@@ -1235,20 +1231,13 @@ fn test_fishermen_stake() {
         env.step_default(vec![]);
     }
     let account0 = env.view_account(block_producers[0].validator_id());
-    assert_eq!(account0.locked, fishermen_stake);
-    assert_eq!(account0.amount, TESTING_INIT_BALANCE - fishermen_stake);
+    assert_eq!(account0.locked, 0);
+    assert_eq!(account0.amount, TESTING_INIT_BALANCE);
     let response = env
         .epoch_manager
         .get_validator_info(ValidatorInfoIdentifier::BlockHash(env.head.last_block_hash))
         .unwrap();
-    assert_eq!(
-        response
-            .current_fishermen
-            .into_iter()
-            .map(|fishermen| fishermen.take_account_id())
-            .collect::<Vec<_>>(),
-        vec!["test1", "test2"]
-    );
+    assert!(response.current_fishermen.is_empty());
     let staking_transaction = stake(2, &signers[0], &block_producers[0], TESTING_INIT_STAKE);
     let staking_transaction2 = stake(2, &signers[1], &block_producers[1], 0);
     env.step_default(vec![staking_transaction, staking_transaction2]);
@@ -1306,20 +1295,13 @@ fn test_fishermen_unstake() {
     }
 
     let account0 = env.view_account(block_producers[0].validator_id());
-    assert_eq!(account0.locked, fishermen_stake);
-    assert_eq!(account0.amount, TESTING_INIT_BALANCE - fishermen_stake);
+    assert_eq!(account0.locked, 0);
+    assert_eq!(account0.amount, TESTING_INIT_BALANCE);
     let response = env
         .epoch_manager
         .get_validator_info(ValidatorInfoIdentifier::BlockHash(env.head.last_block_hash))
         .unwrap();
-    assert_eq!(
-        response
-            .current_fishermen
-            .into_iter()
-            .map(|fishermen| fishermen.take_account_id())
-            .collect::<Vec<_>>(),
-        vec![AccountIdRef::new_or_panic("test1")]
-    );
+    assert!(response.current_fishermen.is_empty());
     let staking_transaction = stake(2, &signers[0], &block_producers[0], 0);
     env.step_default(vec![staking_transaction]);
     for _ in 10..17 {

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -742,8 +742,8 @@ impl EpochManager {
             validator_kickout,
             validator_reward,
             minted_amount,
-            next_version,
             epoch_protocol_version,
+            next_version,
         ) {
             Ok(next_next_epoch_info) => next_next_epoch_info,
             Err(EpochError::ThresholdError { stake_sum, num_seats }) => {

--- a/chain/epoch-manager/src/proposals.rs
+++ b/chain/epoch-manager/src/proposals.rs
@@ -83,7 +83,7 @@ mod old_validator_selection {
     use near_primitives::errors::EpochError;
     use near_primitives::types::validator_stake::ValidatorStake;
     use near_primitives::types::{
-        AccountId, Balance, NumSeats, ValidatorId, ValidatorKickoutReason,
+        AccountId, Balance, NumSeats, NumShards, ValidatorId, ValidatorKickoutReason,
     };
     use near_primitives::validator_mandates::ValidatorMandates;
     use near_primitives::version::ProtocolVersion;

--- a/chain/epoch-manager/src/proposals.rs
+++ b/chain/epoch-manager/src/proposals.rs
@@ -83,7 +83,7 @@ mod old_validator_selection {
     use near_primitives::errors::EpochError;
     use near_primitives::types::validator_stake::ValidatorStake;
     use near_primitives::types::{
-        AccountId, Balance, NumSeats, NumShards, ValidatorId, ValidatorKickoutReason,
+        AccountId, Balance, NumSeats, ValidatorId, ValidatorKickoutReason,
     };
     use near_primitives::validator_mandates::ValidatorMandates;
     use near_primitives::version::ProtocolVersion;

--- a/chain/epoch-manager/src/proposals.rs
+++ b/chain/epoch-manager/src/proposals.rs
@@ -45,10 +45,10 @@ pub fn proposals_to_epoch_info(
     validator_kickout: HashMap<AccountId, ValidatorKickoutReason>,
     validator_reward: HashMap<AccountId, Balance>,
     minted_amount: Balance,
+    current_version: ProtocolVersion,
     next_version: ProtocolVersion,
-    last_epoch_version: ProtocolVersion,
 ) -> Result<EpochInfo, EpochError> {
-    if checked_feature!("stable", AliasValidatorSelectionAlgorithm, last_epoch_version) {
+    if checked_feature!("stable", AliasValidatorSelectionAlgorithm, current_version) {
         return crate::validator_selection::proposals_to_epoch_info(
             epoch_config,
             rng_seed,
@@ -57,8 +57,8 @@ pub fn proposals_to_epoch_info(
             validator_kickout,
             validator_reward,
             minted_amount,
+            current_version,
             next_version,
-            last_epoch_version,
         );
     } else {
         return old_validator_selection::proposals_to_epoch_info(

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -22,9 +22,7 @@ use near_primitives::stateless_validation::{
     ChunkStateTransition, ChunkStateWitness, EncodedChunkStateWitness,
     SignedEncodedChunkStateWitness,
 };
-use near_primitives::types::ValidatorKickoutReason::{
-    NotEnoughBlocks, NotEnoughChunks, NotEnoughStake,
-};
+use near_primitives::types::ValidatorKickoutReason::{NotEnoughBlocks, NotEnoughChunks};
 use near_primitives::validator_signer::ValidatorSigner;
 use near_primitives::version::ProtocolFeature::SimpleNightshade;
 use near_primitives::version::PROTOCOL_VERSION;

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -748,14 +748,8 @@ fn test_validator_reward_one_validator() {
 
     let epoch_info = epoch_manager.get_epoch_info(&EpochId(h[2])).unwrap();
     check_validators(&epoch_info, &[("test2", stake_amount + test2_reward)]);
-    check_fishermen(&epoch_info, &[("test1", test1_stake_amount)]);
-    check_stake_change(
-        &epoch_info,
-        vec![
-            ("test1".parse().unwrap(), test1_stake_amount),
-            ("test2".parse().unwrap(), stake_amount + test2_reward),
-        ],
-    );
+    check_fishermen(&epoch_info, &[]);
+    check_stake_change(&epoch_info, vec![("test2".parse().unwrap(), stake_amount + test2_reward)]);
     check_kickout(&epoch_info, &[]);
     check_reward(
         &epoch_info,
@@ -1705,7 +1699,7 @@ fn test_fishermen() {
     );
     let epoch_info = em.get_epoch_info(&EpochId::default()).unwrap();
     check_validators(&epoch_info, &[("test1", stake_amount), ("test2", stake_amount)]);
-    check_fishermen(&epoch_info, &[("test3", fishermen_threshold)]);
+    check_fishermen(&epoch_info, &[]);
     check_stake_change(
         &epoch_info,
         vec![
@@ -1867,7 +1861,7 @@ fn test_kickout_set() {
     record_block(&mut epoch_manager, h[3], h[4], 4, vec![]);
     let epoch_info = epoch_manager.get_epoch_info(&EpochId(h[4])).unwrap();
     check_validators(&epoch_info, &[("test1", stake_amount), ("test2", stake_amount)]);
-    check_fishermen(&epoch_info, &[("test3", 10)]);
+    check_fishermen(&epoch_info, &[]);
     check_kickout(&epoch_info, &[]);
     check_stake_change(
         &epoch_info,
@@ -2159,6 +2153,7 @@ fn check_validators(epoch_info: &EpochInfo, expected_validators: &[(&str, u128)]
 }
 
 fn check_fishermen(epoch_info: &EpochInfo, expected_fishermen: &[(&str, u128)]) {
+    assert_eq!(epoch_info.fishermen_iter().len(), expected_fishermen.len());
     for (v, (account_id, stake)) in epoch_info.fishermen_iter().zip(expected_fishermen.into_iter())
     {
         assert_eq!(v.account_id(), *account_id);
@@ -2202,7 +2197,7 @@ fn test_fisherman_kickout() {
 
     let epoch_info2 = epoch_manager.get_epoch_info(&EpochId(h[1])).unwrap();
     check_validators(&epoch_info2, &[("test2", stake_amount), ("test3", stake_amount)]);
-    check_fishermen(&epoch_info2, &[("test1", 148)]);
+    check_fishermen(&epoch_info2, &[]);
     check_stake_change(
         &epoch_info2,
         vec![

--- a/chain/epoch-manager/src/validator_selection.rs
+++ b/chain/epoch-manager/src/validator_selection.rs
@@ -23,8 +23,8 @@ pub fn proposals_to_epoch_info(
     mut validator_kickout: HashMap<AccountId, ValidatorKickoutReason>,
     validator_reward: HashMap<AccountId, Balance>,
     minted_amount: Balance,
+    current_version: ProtocolVersion,
     next_version: ProtocolVersion,
-    last_version: ProtocolVersion,
 ) -> Result<EpochInfo, EpochError> {
     debug_assert!(
         proposals.iter().map(|stake| stake.account_id()).collect::<HashSet<_>>().len()
@@ -51,7 +51,7 @@ pub fn proposals_to_epoch_info(
         &mut block_producer_proposals,
         max_bp_selected,
         min_stake_ratio,
-        last_version,
+        current_version,
     );
     let (chunk_producer_proposals, chunk_producers, cp_stake_threshold) =
         if checked_feature!("stable", ChunkOnlyProducers, next_version) {
@@ -63,7 +63,7 @@ pub fn proposals_to_epoch_info(
                 max_cp_selected,
                 min_stake_ratio,
                 shard_ids.len() as NumShards,
-                last_version,
+                current_version,
             );
             (chunk_producer_proposals, chunk_producers, cp_stake_treshold)
         } else {

--- a/chain/epoch-manager/src/validator_selection.rs
+++ b/chain/epoch-manager/src/validator_selection.rs
@@ -868,9 +868,9 @@ mod tests {
         )
         .unwrap();
 
-        // stake below validator threshold, but above fishermen threshold become fishermen
-        let fishermen: Vec<_> = epoch_info.fishermen_iter().map(|v| v.take_account_id()).collect();
-        assert_eq!(fishermen, vec!["test4"]);
+        let fishermen: Vec<AccountId> =
+            epoch_info.fishermen_iter().map(|v| v.take_account_id()).collect();
+        assert!(fishermen.is_empty());
 
         // too low stakes are kicked out
         let kickout = epoch_info.validator_kickout();

--- a/chain/epoch-manager/src/validator_selection.rs
+++ b/chain/epoch-manager/src/validator_selection.rs
@@ -58,14 +58,14 @@ pub fn proposals_to_epoch_info(
             let mut chunk_producer_proposals = order_proposals(proposals.into_values());
             let max_cp_selected = max_bp_selected
                 + (epoch_config.validator_selection_config.num_chunk_only_producer_seats as usize);
-            let (chunk_producers, cp_stake_treshold) = select_chunk_producers(
+            let (chunk_producers, cp_stake_threshold) = select_chunk_producers(
                 &mut chunk_producer_proposals,
                 max_cp_selected,
                 min_stake_ratio,
                 shard_ids.len() as NumShards,
                 current_version,
             );
-            (chunk_producer_proposals, chunk_producers, cp_stake_treshold)
+            (chunk_producer_proposals, chunk_producers, cp_stake_threshold)
         } else {
             (block_producer_proposals, block_producers.clone(), bp_stake_threshold)
         };


### PR DESCRIPTION
Remove fishermen-related code from epoch info generation and tests, because it is unlikely to be used but is distracting.
Also fix some typos and names.

Fields will be marked as deprecated in future PRs, I'd like to continue removing code later.