### PR TITLE
feat(forknet): add a --stateless-setup flag to new-test

### DIFF
--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -221,13 +221,20 @@ ready. After they're ready, you can run `start-traffic`""".format(validators))
 
     if args.stateless_setup:
         logger.info('enabling in-memory trie in config')
-        pmap(lambda node: do_update_config(node, 'store.load_mem_tries_for_tracked_shards=true'), all_nodes)
+        pmap(
+            lambda node: do_update_config(
+                node, 'store.load_mem_tries_for_tracked_shards=true'),
+            all_nodes)
         logger.info('enabling save_latest_witnesses in config')
         # TODO: it should be possible to update multiple keys in one RPC call so we dont have to make 2 round trips
-        pmap(lambda node: do_update_config(node, 'save_latest_witnesses=true'), all_nodes)
+        pmap(lambda node: do_update_config(node, 'save_latest_witnesses=true'),
+             all_nodes)
         if not args.local_test:
             logger.info('updating tcp sysctl values')
-            pmap(lambda node: node.run_cmd("sudo sysctl -w net.core.rmem_max=8388608 && sudo sysctl -w net.core.wmem_max=8388608 && sudo sysctl -w net.ipv4.tcp_rmem='4096 87380 8388608' && sudo sysctl -w net.ipv4.tcp_wmem='4096 16384 8388608' && sudo sysctl -w net.ipv4.tcp_slow_start_after_idle=0"), all_nodes)
+            pmap(
+                lambda node: node.run_cmd(
+                    "sudo sysctl -w net.core.rmem_max=8388608 && sudo sysctl -w net.core.wmem_max=8388608 && sudo sysctl -w net.ipv4.tcp_rmem='4096 87380 8388608' && sudo sysctl -w net.ipv4.tcp_wmem='4096 16384 8388608' && sudo sysctl -w net.ipv4.tcp_slow_start_after_idle=0"
+                ), all_nodes)
 
 
 def status_cmd(args, traffic_generator, nodes):

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -301,15 +301,19 @@ def stop_traffic_cmd(args, traffic_generator, nodes):
     traffic_generator.neard_runner_stop()
 
 
+def do_update_config(node, config_change):
+    result = node.neard_update_config(config_change)
+    if not result:
+        logger.warning(
+            f'failed updating config on {node.name()}. result: {result}')
+
+
 def update_config_cmd(args, traffic_generator, nodes):
     nodes = nodes + [traffic_generator]
-    results = pmap(
-        lambda node: node.neard_update_config(args.set),
+    pmap(
+        lambda node: do_update_config(node, args.set),
         nodes,
     )
-    if not all(results):
-        logger.warning('failed to update configs for some nodes')
-        return
 
 
 def start_nodes_cmd(args, traffic_generator, nodes):

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -222,6 +222,9 @@ ready. After they're ready, you can run `start-traffic`""".format(validators))
     if args.stateless_setup:
         logger.info('enabling in-memory trie in config')
         pmap(lambda node: do_update_config(node, 'store.load_mem_tries_for_tracked_shards=true'), all_nodes)
+        logger.info('enabling save_latest_witnesses in config')
+        # TODO: it should be possible to update multiple keys in one RPC call so we dont have to make 2 round trips
+        pmap(lambda node: do_update_config(node, 'save_latest_witnesses=true'), all_nodes)
         if not args.local_test:
             logger.info('updating tcp sysctl values')
             pmap(lambda node: node.run_cmd("sudo sysctl -w net.core.rmem_max=8388608 && sudo sysctl -w net.core.wmem_max=8388608 && sudo sysctl -w net.ipv4.tcp_rmem='4096 87380 8388608' && sudo sysctl -w net.ipv4.tcp_wmem='4096 16384 8388608' && sudo sysctl -w net.ipv4.tcp_slow_start_after_idle=0"), all_nodes)


### PR DESCRIPTION
This will automate enabling in-memory tries and changing tcp sysctl values, which is something we want to do manually anyway when starting a stateless network