### PR TITLE
[actor] Introduce Actor and HandlerWithContext trait

### DIFF
--- a/chain/chain/src/state_snapshot_actor.rs
+++ b/chain/chain/src/state_snapshot_actor.rs
@@ -1,4 +1,4 @@
-use near_async::messaging::{CanSend, Handler, Sender};
+use near_async::messaging::{Actor, CanSend, Handler, Sender};
 use near_async::{MultiSend, MultiSendMessage, MultiSenderFrom};
 use near_network::types::{NetworkRequests, PeerManagerAdapter, PeerManagerMessageRequest};
 use near_performance_metrics_macros::perf;
@@ -20,6 +20,8 @@ pub struct StateSnapshotActor {
     tries: ShardTries,
     self_sender: StateSnapshotSenderForStateSnapshot,
 }
+
+impl Actor for StateSnapshotActor {}
 
 impl StateSnapshotActor {
     pub fn new(

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use itertools::Itertools;
-use near_async::messaging::{CanSend, Handler, Sender};
+use near_async::messaging::{Actor, CanSend, Handler, Sender};
 use near_async::time::Clock;
 use near_async::{MultiSend, MultiSendMessage, MultiSenderFrom};
 use near_chain::Error;
@@ -43,6 +43,8 @@ pub struct PartialWitnessActor {
     /// We keep one wrapper for each length of chunk_validators to avoid re-creating the encoder.
     rs_map: RsMap,
 }
+
+impl Actor for PartialWitnessActor {}
 
 #[derive(actix::Message, Debug)]
 #[rtype(result = "()")]

--- a/chain/client/src/sync_jobs_actor.rs
+++ b/chain/client/src/sync_jobs_actor.rs
@@ -1,7 +1,7 @@
 use actix::Actor;
 use near_async::actix_wrapper::ActixWrapper;
 use near_async::futures::{ActixFutureSpawner, FutureSpawner, FutureSpawnerExt};
-use near_async::messaging::{self, CanSend, Handler, HandlerWithContext, Sender};
+use near_async::messaging::{self, CanSend, Handler, Sender};
 use near_async::time::Duration;
 use near_async::{MultiSend, MultiSendMessage, MultiSenderFrom};
 use near_chain::chain::{

--- a/chain/client/src/sync_jobs_actor.rs
+++ b/chain/client/src/sync_jobs_actor.rs
@@ -1,7 +1,7 @@
 use actix::Actor;
 use near_async::actix_wrapper::ActixWrapper;
 use near_async::futures::{ActixFutureSpawner, FutureSpawner, FutureSpawnerExt};
-use near_async::messaging::{CanSend, Handler, Sender};
+use near_async::messaging::{self, CanSend, Handler, HandlerWithContext, Sender};
 use near_async::time::Duration;
 use near_async::{MultiSend, MultiSendMessage, MultiSenderFrom};
 use near_chain::chain::{
@@ -38,6 +38,8 @@ pub struct SyncJobsActor {
     client_sender: ClientSenderForSyncJobs,
     sync_jobs_sender: SyncJobsSenderForSyncJobs,
 }
+
+impl messaging::Actor for SyncJobsActor {}
 
 impl Handler<LoadMemtrieRequest> for SyncJobsActor {
     #[perf]

--- a/chain/telemetry/src/lib.rs
+++ b/chain/telemetry/src/lib.rs
@@ -2,7 +2,7 @@ mod metrics;
 
 use awc::{Client, Connector};
 use futures::FutureExt;
-use near_async::messaging::Handler;
+use near_async::messaging::{Actor, Handler};
 use near_async::time::{Duration, Instant};
 use near_performance_metrics_macros::perf;
 use std::ops::Sub;
@@ -47,6 +47,8 @@ impl Default for TelemetryActor {
         Self::new(TelemetryConfig::default())
     }
 }
+
+impl Actor for TelemetryActor {}
 
 impl TelemetryActor {
     pub fn new(config: TelemetryConfig) -> Self {

--- a/core/async/src/actix_wrapper.rs
+++ b/core/async/src/actix_wrapper.rs
@@ -1,7 +1,10 @@
+use std::ops::{Deref, DerefMut};
+
 use actix::Actor;
 use near_o11y::{handler_debug_span, WithSpanContext};
 
-use crate::messaging::Handler;
+use crate::futures::DelayedActionRunner;
+use crate::messaging::{Handler, HandlerWithContext};
 
 /// Wrapper on top of a generic actor to make it implement actix::Actor trait. The wrapped actor
 /// should implement the Handler trait for all the messages it would like to handle.
@@ -23,17 +26,33 @@ where
     type Context = actix::Context<Self>;
 }
 
+// Implementing Deref and DerefMut for the wrapped actor to allow access to the inner struct
+// This is required for implementing DelayedActionRunner<T> for actix::Context<Outer>
+impl<T> Deref for ActixWrapper<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.actor
+    }
+}
+
+impl<T> DerefMut for ActixWrapper<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.actor
+    }
+}
+
 impl<M, T> actix::Handler<WithSpanContext<M>> for ActixWrapper<T>
 where
     Self: actix::Actor,
-    T: Handler<M>,
+    Self::Context: DelayedActionRunner<T>,
+    T: HandlerWithContext<T, M>,
     M: actix::Message,
     <M as actix::Message>::Result: actix::dev::MessageResponse<ActixWrapper<T>, WithSpanContext<M>>,
 {
     type Result = M::Result;
-    fn handle(&mut self, msg: WithSpanContext<M>, _ctx: &mut Self::Context) -> Self::Result {
+    fn handle(&mut self, msg: WithSpanContext<M>, ctx: &mut Self::Context) -> Self::Result {
         let (_span, msg) = handler_debug_span!(target: "actix_message_handler", msg);
-        self.actor.handle(msg)
+        self.actor.handle(msg, ctx)
     }
 }
 

--- a/core/async/src/actix_wrapper.rs
+++ b/core/async/src/actix_wrapper.rs
@@ -45,7 +45,7 @@ impl<M, T> actix::Handler<WithSpanContext<M>> for ActixWrapper<T>
 where
     Self: actix::Actor,
     Self::Context: DelayedActionRunner<T>,
-    T: HandlerWithContext<T, M>,
+    T: HandlerWithContext<M>,
     M: actix::Message,
     <M as actix::Message>::Result: actix::dev::MessageResponse<ActixWrapper<T>, WithSpanContext<M>>,
 {

--- a/core/async/src/messaging.rs
+++ b/core/async/src/messaging.rs
@@ -8,6 +8,10 @@ use std::fmt::{Debug, Display};
 use std::sync::Arc;
 use tokio::sync::oneshot;
 
+pub trait Actor {
+    fn start_actor(&mut self, _ctx: &mut dyn DelayedActionRunner<Self>) {}
+}
+
 /// Trait for handling a message.
 /// This works in unison with the [`CanSend`] trait. An actor implements the Handler trait for all
 /// messages it would like to handle, while the CanSend trait implements the logic to send the

--- a/core/async/src/messaging.rs
+++ b/core/async/src/messaging.rs
@@ -8,6 +8,10 @@ use std::fmt::{Debug, Display};
 use std::sync::Arc;
 use tokio::sync::oneshot;
 
+/// Trait for an actor. An actor is a struct that can handle messages and implementes the Handler or
+/// HandlerWithContext trait. We can optionally implement the start_actor trait which is executed in
+/// the beginning of the actor's lifecycle.
+/// This corresponds to the actix::Actor trait `started` function.
 pub trait Actor {
     fn start_actor(&mut self, _ctx: &mut dyn DelayedActionRunner<Self>) {}
 }

--- a/core/async/src/messaging.rs
+++ b/core/async/src/messaging.rs
@@ -17,6 +17,12 @@ pub trait Handler<M: actix::Message> {
     fn handle(&mut self, msg: M) -> M::Result;
 }
 
+/// Trait for handling a message with context.
+/// This is similar to the [`Handler`] trait, but it allows the handler to access the delayed action
+/// runner that is used to schedule actions to be run in the future. For actix::Actor, the context
+/// defined as actix::Context<Self> implements DelayedActionRunner<T>.
+/// Note that the implementer for hander of a message only needs to implement either of Handler or
+/// HandlerWithContext, not both.
 pub trait HandlerWithContext<T, M: actix::Message> {
     fn handle(&mut self, msg: M, ctx: &mut dyn DelayedActionRunner<T>) -> M::Result;
 }

--- a/core/async/src/messaging.rs
+++ b/core/async/src/messaging.rs
@@ -23,16 +23,16 @@ pub trait Handler<M: actix::Message> {
 /// defined as actix::Context<Self> implements DelayedActionRunner<T>.
 /// Note that the implementer for hander of a message only needs to implement either of Handler or
 /// HandlerWithContext, not both.
-pub trait HandlerWithContext<T, M: actix::Message> {
-    fn handle(&mut self, msg: M, ctx: &mut dyn DelayedActionRunner<T>) -> M::Result;
+pub trait HandlerWithContext<M: actix::Message> {
+    fn handle(&mut self, msg: M, ctx: &mut dyn DelayedActionRunner<Self>) -> M::Result;
 }
 
-impl<A, T, M> HandlerWithContext<T, M> for A
+impl<A, M> HandlerWithContext<M> for A
 where
     M: actix::Message,
     A: Handler<M>,
 {
-    fn handle(&mut self, msg: M, _ctx: &mut dyn DelayedActionRunner<T>) -> M::Result {
+    fn handle(&mut self, msg: M, _ctx: &mut dyn DelayedActionRunner<Self>) -> M::Result {
         Handler::handle(self, msg)
     }
 }


### PR DESCRIPTION
This PR introduces a generic trait `Actor` to handle actix::Actor started function calls.

This PR introduces a new type of handler, `HandlerWithContext` that takes in a context object as input to the handle function.

This is to mimic the actix::Context<Self> that's usually passed to the handler. We require the `DelayedActionRunner` capability of the context and hence, that's the only thing we are exposing for now.

Note that the old `Handler` still stays in place and we have a default implementation for the extension `HandlerWithContext` trait.
 
Follow up of PR https://github.com/near/nearcore/pull/11214