### PR TITLE
feat(test_infra) - added adversarial controls for chunk production

### DIFF
--- a/chain/client/src/client_actions.rs
+++ b/chain/client/src/client_actions.rs
@@ -214,10 +214,20 @@ impl ClientActions {
 }
 
 #[cfg(feature = "test_features")]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub enum AdvProduceChunksMode {
+    // Produce chunks as usual.
+    Valid,
+    // Stop producing chunks.
+    StopProduce,
+}
+
+#[cfg(feature = "test_features")]
 #[derive(actix::Message, Debug)]
 #[rtype(result = "Option<u64>")]
 pub enum NetworkAdversarialMessage {
     AdvProduceBlocks(u64, bool),
+    AdvProduceChunks(AdvProduceChunksMode),
     AdvSwitchToHeight(u64),
     AdvDisableHeaderSync,
     AdvDisableDoomslug,
@@ -323,6 +333,10 @@ impl ClientActionHandler<NetworkAdversarialMessage> for ClientActions {
                 } else {
                     Some(store_validator.tests_done())
                 }
+            }
+            NetworkAdversarialMessage::AdvProduceChunks(adv_produce_chunks) => {
+                self.client.adv_produce_chunks = Some(adv_produce_chunks);
+                None
             }
         }
     }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -480,6 +480,7 @@ impl JsonRpcHandler {
             "adv_disable_header_sync" => self.adv_disable_header_sync(request.params).await,
             "adv_disable_doomslug" => self.adv_disable_doomslug(request.params).await,
             "adv_produce_blocks" => self.adv_produce_blocks(request.params).await,
+            "adv_produce_chunks" => self.adv_produce_chunks(request.params).await,
             "adv_switch_to_height" => self.adv_switch_to_height(request.params).await,
             "adv_get_saved_blocks" => self.adv_get_saved_blocks(request.params).await,
             "adv_check_store" => self.adv_check_store(request.params).await,
@@ -1257,6 +1258,12 @@ impl JsonRpcHandler {
         let (num_blocks, only_valid) = crate::api::Params::parse(params)?;
         self.client_sender
             .send(near_client::NetworkAdversarialMessage::AdvProduceBlocks(num_blocks, only_valid));
+        Ok(Value::String(String::new()))
+    }
+
+    async fn adv_produce_chunks(&self, params: Value) -> Result<Value, RpcError> {
+        let mode = crate::api::Params::parse(params)?;
+        self.client_sender.send(near_client::NetworkAdversarialMessage::AdvProduceChunks(mode));
         Ok(Value::String(String::new()))
     }
 

--- a/nightly/pytest-adversarial.txt
+++ b/nightly/pytest-adversarial.txt
@@ -18,3 +18,6 @@ pytest adversarial/start_from_genesis.py doomslug_off --features nightly
 # working on a fix.
 #pytest adversarial/gc_rollback.py
 #pytest adversarial/gc_rollback.py --features nightly
+
+pytest adversarial/chunk_missing.py
+pytest adversarial/chunk_missing.py --features nightly

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -399,20 +399,24 @@ class RpcNode(BaseNode):
 
 class LocalNode(BaseNode):
 
-    def __init__(self,
-                 port,
-                 rpc_port,
-                 near_root,
-                 node_dir,
-                 blacklist,
-                 binary_name=None,
-                 single_node=False):
+    def __init__(
+        self,
+        port,
+        rpc_port,
+        near_root,
+        node_dir,
+        blacklist,
+        binary_name=None,
+        single_node=False,
+        ordinal=None,
+    ):
         super(LocalNode, self).__init__()
         self.port = port
         self.rpc_port = rpc_port
         self.near_root = str(near_root)
         self.node_dir = node_dir
         self.binary_name = binary_name or 'neard'
+        self.ordinal = ordinal
         self.cleaned = False
         self.validator_key = Key.from_json_file(
             os.path.join(node_dir, "validator_key.json"))
@@ -462,11 +466,14 @@ class LocalNode(BaseNode):
             logger.info(f'=== stdout: available at {stdout}')
             logger.info(f'=== stderr: available at {stderr}')
 
-    def start(self,
-              *,
-              boot_node: BootNode = None,
-              skip_starting_proxy=False,
-              extra_env: typing.Dict[str, str] = dict()):
+    def start(
+            self,
+            *,
+            boot_node: BootNode = None,
+            skip_starting_proxy=False,
+            extra_env: typing.Dict[str, str] = dict(),
+    ):
+        logger.info(f"Starting node {self.ordinal}.")
         cmd = self._get_command_line(
             self.near_root,
             self.node_dir,
@@ -510,6 +517,7 @@ class LocalNode(BaseNode):
         self._pid = self._process.pid
 
     def kill(self, *, gentle=False):
+        logger.info(f"Killing node {self.ordinal}.")
         """Kills the process.  If `gentle` sends SIGINT before killing."""
         if self._proxy_local_stopped is not None:
             self._proxy_local_stopped.value = 1

--- a/pytest/lib/utils.py
+++ b/pytest/lib/utils.py
@@ -444,7 +444,7 @@ def poll_blocks(node: cluster.LocalNode,
                 start_height = latest.height
             count += 1
 
-        if latest.height >= __target:
+        if __target and latest.height >= __target:
             return
 
         time.sleep(poll_interval)

--- a/pytest/lib/utils.py
+++ b/pytest/lib/utils.py
@@ -443,6 +443,10 @@ def poll_blocks(node: cluster.LocalNode,
             if start_height == -1:
                 start_height = latest.height
             count += 1
+
+        if latest.height >= __target:
+            return
+
         time.sleep(poll_interval)
 
     msg = 'Timed out polling blocks from a node\n'

--- a/pytest/tests/adversarial/adv_chunk_missing.py
+++ b/pytest/tests/adversarial/adv_chunk_missing.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# A small test that disables chunk production for a few blocks and then
+# re-enables it. This is more of an example how to disable chunk production than
+# an actual test.
+# Usage:
+# python3 pytest/tests/adversarial/adv_chunk_missing.py
+
+import unittest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
+
+from cluster import start_cluster
+from configured_logger import logger
+from utils import poll_blocks, wait_for_blocks
+
+
+class AdvChunkMissingTest(unittest.TestCase):
+
+    def test(self):
+        logger.info("starting adv chunk missing test")
+
+        [node] = start_cluster(
+            num_nodes=1,
+            num_observers=0,
+            num_shards=1,
+            config=None,
+            genesis_config_changes=[],
+            client_config_changes={},
+            message_handler=None,
+        )
+
+        for _, hash in poll_blocks(node, __target=10):
+            self.__check_new_chunks(node, hash)
+
+        self.__stop_chunk_produce(node)
+
+        for height, hash in poll_blocks(node, __target=20):
+            # Do not check the first two blocks. Block #10 was produced in the
+            # old loop and has all chunks. Block #11 contains chunks produced on
+            # top of block #10 when chunk production wasn't stopped yet.
+            if height <= 11:
+                continue
+            self.__check_old_chunks(node, hash)
+
+        self.__start_chunk_produce(node)
+
+        for _, hash in poll_blocks(node, __target=30):
+            # Do not check the first two blocks. Block #20 was produced in the
+            # old loop and has no chunks. Block #21 chunks should have been
+            # produced on top of ten but chunk production was still disabled
+            # then.
+            if height <= 21:
+                continue
+            self.__check_new_chunks(node, hash)
+
+    def __stop_chunk_produce(self, node):
+        res = node.json_rpc('adv_produce_chunks', "StopProduce")
+        self.assertIn('result', res, res)
+
+    def __start_chunk_produce(self, node):
+        res = node.json_rpc('adv_produce_chunks', "Valid")
+        self.assertIn('result', res, res)
+
+    def __check_new_chunks(self, node, block_hash):
+        block = node.json_rpc("block", {"block_id": block_hash})
+
+        height_included = self.__get_height_included(block)
+        height = self.__get_height(block)
+
+        # A chunk that was correctly produced should have height_included equal
+        # to the block height.
+        self.assertEqual(height_included, height)
+
+    def __check_old_chunks(self, node, block_hash):
+        block = node.json_rpc("block", {"block_id": block_hash})
+
+        height_included = self.__get_height_included(block)
+        height = self.__get_height(block)
+
+        # A missing chunk is a copy of the previous chunk. In this case the
+        # height included should not be equal to the block height.
+        self.assertNotEqual(height_included, height)
+
+    def __get_height_included(self, block):
+        self.assertIn('result', block, block)
+        block = block['result']
+
+        self.assertIn('chunks', block, block)
+        chunks = block['chunks']
+
+        self.assertEqual(len(chunks), 1)
+        [chunk] = chunks
+
+        self.assertIn('height_included', chunk, chunk)
+        height_included = chunk['height_included']
+
+        return height_included
+
+    def __get_height(self, block):
+        self.assertIn('result', block, block)
+        block = block['result']
+
+        self.assertIn('header', block, block)
+        header = block['header']
+
+        self.assertIn('height', header, header)
+        height = header['height']
+
+        return height
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pytest/tests/adversarial/chunk_missing.py
+++ b/pytest/tests/adversarial/chunk_missing.py
@@ -3,7 +3,7 @@
 # re-enables it. This is more of an example how to disable chunk production than
 # an actual test.
 # Usage:
-# python3 pytest/tests/adversarial/adv_chunk_missing.py
+# python3 pytest/tests/adversarial/chunk_missing.py
 
 import unittest
 import sys

--- a/pytest/tests/adversarial/fork_sync.py
+++ b/pytest/tests/adversarial/fork_sync.py
@@ -34,17 +34,17 @@ for i in range(0, 4):
 # step 1, let nodes run for some time
 utils.wait_for_blocks(nodes[0], target=FIRST_STEP_WAIT)
 
+logger.info("killing node 0 and 1")
 for i in range(2):
     nodes[i].kill()
 
-logger.info("killing node 0 and 1")
 utils.wait_for_blocks(nodes[2], target=FIRST_STEP_WAIT + SECOND_STEP_WAIT)
 
+logger.info("killing node 2 and 3")
 for i in range(2, 4):
     nodes[i].kill()
 
-logger.info("killing node 2 and 3")
-
+logger.info("starting node 0 and 1 with doomslug disabled")
 for i in range(2):
     nodes[i].start(boot_node=nodes[0])
     res = nodes[i].json_rpc('adv_disable_doomslug', [])
@@ -54,6 +54,7 @@ time.sleep(1)
 
 utils.wait_for_blocks(nodes[0], target=FIRST_STEP_WAIT + SECOND_STEP_WAIT)
 
+logger.info("starting node 2 and 3 with doomslug disabled")
 for i in range(2, 4):
     nodes[i].start(boot_node=nodes[0])
     res = nodes[i].json_rpc('adv_disable_doomslug', [])

--- a/pytest/tests/adversarial/fork_sync.py
+++ b/pytest/tests/adversarial/fork_sync.py
@@ -34,13 +34,11 @@ for i in range(0, 4):
 # step 1, let nodes run for some time
 utils.wait_for_blocks(nodes[0], target=FIRST_STEP_WAIT)
 
-logger.info("killing node 0 and 1")
 for i in range(2):
     nodes[i].kill()
 
 utils.wait_for_blocks(nodes[2], target=FIRST_STEP_WAIT + SECOND_STEP_WAIT)
 
-logger.info("killing node 2 and 3")
 for i in range(2, 4):
     nodes[i].kill()
 


### PR DESCRIPTION
* Added a new adversarial control that disables/enables chunk production.
* Added a new rpc endpoint to control the above. 
* Added an example python test using the controls. 

I need to test the scenario where a range of blocks is missing chunks at the end of epoch. This is needed to test the state sync and congestion control integration. I'll do that in a follow up PR. 