### PR TITLE
[stateless_validation] Adding some much useful metrics to partial witness

### DIFF
--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -788,3 +788,43 @@ pub(crate) static BLOCK_PRODUCER_MISSING_ENDORSEMENT_COUNT: Lazy<HistogramVec> =
     )
     .unwrap()
 });
+
+pub(crate) static PARTIAL_WITNESS_ENCODE_TIME: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "near_partial_witness_encode_time",
+        "Partial state witness generation from encoded state witness time in seconds",
+        &["shard_id"],
+        Some(linear_buckets(0.0, 0.005, 20).unwrap()),
+    )
+    .unwrap()
+});
+
+pub(crate) static PARTIAL_WITNESS_DECODE_TIME: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "near_partial_witness_decode_time",
+        "Time taken from receiving first partial witness part to receiving enough parts to decode the state witness",
+        &["shard_id"],
+        Some(exponential_buckets(0.001, 2.0, 13).unwrap()),
+    )
+    .unwrap()
+});
+
+pub(crate) static PARTIAL_WITNESS_TOTAL_TIME: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "near_partial_witness_total_time",
+        "Time taken from receiving first partial witness part to receiving last partial witness part",
+        &["shard_id"],
+        Some(exponential_buckets(0.001, 2.0, 13).unwrap()),
+    )
+    .unwrap()
+});
+
+pub(crate) static PARTIAL_WITNESS_PARTS_RECEIVED_RATIO: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "near_partial_witness_parts_received_ratio",
+        "Ratio (the value is between 0.0 and 1.0) of the number of parts received for the partial state witness",
+        &["shard_id"],
+        Some(linear_buckets(0.0, 0.05, 20).unwrap()),
+    )
+    .unwrap()
+});

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
@@ -176,7 +176,7 @@ impl PartialWitnessActor {
 
     // Function to generate the parts of the state witness and return them as a tuple of chunk_validator and part.
     fn generate_state_witness_parts(
-        &self,
+        &mut self,
         epoch_id: EpochId,
         chunk_header: ShardChunkHeader,
         witness_bytes: EncodedChunkStateWitness,
@@ -230,9 +230,9 @@ impl PartialWitnessActor {
             .with_label_values(&[shard_id_label.as_str()])
             .start_timer();
         let validator_witness_tuple = self.generate_state_witness_parts(
-            epoch_id.clone(),
-            chunk_header.clone(),
-            witness_bytes.clone(),
+            epoch_id,
+            chunk_header,
+            witness_bytes,
             chunk_validators.clone(),
         );
         encode_timer.observe_duration();

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
@@ -174,16 +174,14 @@ impl PartialWitnessActor {
         ));
     }
 
-    // Break the state witness into parts and send each part to the corresponding chunk validator owner.
-    // The chunk validator owner will then forward the part to all other chunk validators.
-    // Each chunk validator would collect the parts and reconstruct the state witness.
-    fn send_state_witness_parts(
-        &mut self,
+    // Function to generate the parts of the state witness and return them as a tuple of chunk_validator and part.
+    fn generate_state_witness_parts(
+        &self,
         epoch_id: EpochId,
         chunk_header: ShardChunkHeader,
         witness_bytes: EncodedChunkStateWitness,
         chunk_validators: Vec<AccountId>,
-    ) -> Result<(), Error> {
+    ) -> Vec<(AccountId, PartialEncodedStateWitness)> {
         // Break the state witness into parts using Reed Solomon encoding.
         let rs = self.rs_map.entry(chunk_validators.len());
 
@@ -196,7 +194,7 @@ impl PartialWitnessActor {
             ),
         };
 
-        let validator_witness_tuple = chunk_validators
+        chunk_validators
             .iter()
             .zip_eq(parts)
             .enumerate()
@@ -213,7 +211,31 @@ impl PartialWitnessActor {
                 );
                 (chunk_validator.clone(), partial_witness)
             })
-            .collect_vec();
+            .collect_vec()
+    }
+
+    // Break the state witness into parts and send each part to the corresponding chunk validator owner.
+    // The chunk validator owner will then forward the part to all other chunk validators.
+    // Each chunk validator would collect the parts and reconstruct the state witness.
+    fn send_state_witness_parts(
+        &mut self,
+        epoch_id: EpochId,
+        chunk_header: ShardChunkHeader,
+        witness_bytes: EncodedChunkStateWitness,
+        chunk_validators: Vec<AccountId>,
+    ) -> Result<(), Error> {
+        // Record time taken to encode the state witness parts.
+        let shard_id_label = chunk_header.shard_id().to_string();
+        let encode_timer = metrics::PARTIAL_WITNESS_ENCODE_TIME
+            .with_label_values(&[shard_id_label.as_str()])
+            .start_timer();
+        let validator_witness_tuple = self.generate_state_witness_parts(
+            epoch_id.clone(),
+            chunk_header.clone(),
+            witness_bytes.clone(),
+            chunk_validators.clone(),
+        );
+        encode_timer.observe_duration();
 
         // Since we can't send network message to ourselves, we need to send the PartialEncodedStateWitnessForward
         // message for our part.

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use lru::LruCache;
 use near_async::messaging::CanSend;
+use near_async::time::{Duration, Instant};
 use near_chain::chain::ProcessChunkStateWitnessMessage;
 use near_chain::Error;
 use near_epoch_manager::EpochManagerAdapter;
@@ -12,6 +13,7 @@ use near_primitives::types::{BlockHeight, ShardId};
 use reed_solomon_erasure::galois_8::ReedSolomon;
 
 use crate::client_actions::ClientSenderForPartialWitness;
+use crate::metrics;
 
 /// Max number of chunks to keep in the witness tracker cache. We reach here only after validation
 /// of the partial_witness so the LRU cache size need not be too large.
@@ -51,6 +53,9 @@ impl RsMap {
 
 struct CacheEntry {
     pub is_decoded: bool,
+    pub shard_id: ShardId,
+    pub timer: Instant,
+    pub duration_to_last_part: Duration,
     pub data_parts_present: usize,
     pub data_parts_required: usize,
     pub parts: Vec<Option<Box<[u8]>>>,
@@ -65,6 +70,9 @@ impl CacheEntry {
         };
         Self {
             is_decoded: false,
+            shard_id: 0, // Dummy value
+            timer: Instant::now(),
+            duration_to_last_part: Duration::seconds(0),
             data_parts_present: 0,
             data_parts_required: data_parts,
             parts: vec![None; total_parts],
@@ -94,14 +102,17 @@ impl CacheEntry {
             return None;
         }
 
+        // Increment the count of data parts present even if the part has been decoded before.
+        // We use this in metrics to track the number of parts received. Insert the part into the cache entry.
+        self.data_parts_present += 1;
+        self.parts[part_ord] = Some(part);
+        self.shard_id = shard_id;
+        self.duration_to_last_part = self.timer.elapsed();
+
         // Check if we have already decoded the state witness.
         if self.is_decoded {
             return None;
         }
-
-        // Insert the part into the cache entry.
-        self.parts[part_ord] = Some(part);
-        self.data_parts_present += 1;
 
         // If we have enough parts, try to decode the state witness.
         if self.data_parts_present < self.data_parts_required {
@@ -177,6 +188,12 @@ impl PartialEncodedStateWitnessTracker {
 
         if let Some(encoded_witness) = entry.insert_in_cache_entry(partial_witness) {
             tracing::debug!(target: "stateless_validation", ?key, "Sending encoded witness to client.");
+
+            // Record the time taken from receiving first part to decoding partial witness.
+            metrics::PARTIAL_WITNESS_DECODE_TIME
+                .with_label_values(&[entry.shard_id.to_string().as_str()])
+                .observe(entry.duration_to_last_part.as_seconds_f64());
+
             self.client_sender.send(ProcessChunkStateWitnessMessage(encoded_witness));
         }
         Ok(())
@@ -209,6 +226,19 @@ impl PartialEncodedStateWitnessTracker {
         let rs = self.rs_map.entry(num_parts);
         let new_entry = CacheEntry::new(rs);
         if let Some((evicted_chunk_hash, evicted_entry)) = self.parts_cache.push(key, new_entry) {
+            // Record the ratio of parts received to parts required for the evicted entry.
+            // Note that this includes the parts received after decoding the state witness.
+            let parts_received_ratio =
+                evicted_entry.data_parts_present as f64 / evicted_entry.data_parts_required as f64;
+            metrics::PARTIAL_WITNESS_PARTS_RECEIVED_RATIO
+                .with_label_values(&[evicted_entry.shard_id.to_string().as_str()])
+                .observe(parts_received_ratio);
+
+            // Record the time taken from receiving first part to receiving the last part.
+            metrics::PARTIAL_WITNESS_TOTAL_TIME
+                .with_label_values(&[evicted_entry.shard_id.to_string().as_str()])
+                .observe(evicted_entry.duration_to_last_part.as_seconds_f64());
+
             // Check if the evicted entry has been fully decoded and processed.
             if !evicted_entry.is_decoded {
                 tracing::warn!(


### PR DESCRIPTION
Added 4 set of metrics
- PARTIAL_WITNESS_ENCODE_TIME: Time taken to encode state witness to parts. This should ideally be super tiny
- PARTIAL_WITNESS_DECODE_TIME: Time taken from receiving the first part of the partial witness to when the state witness is decoded. Note that if we are one of the validators, this time would be longer as we auto-add our own part to the cache.
- PARTIAL_WITNESS_TOTAL_TIME: Time taken from receiving the first part to the last part
- PARTIAL_WITNESS_PARTS_RECEIVED_RATIO: Ratio of parts received to total parts. Note that we capture this during cache entry eviction so we should have enough time to receive all parts (even if we have decoded the state witness)

Biggest gotcha I can think of is when the chunk producer is the validation, then the first network delay gets included in the PARTIAL_WITNESS_DECODE_TIME and PARTIAL_WITNESS_TOTAL_TIME metrics which might inflate the values. But nevertheless this metric might be useful. Let's see...