### PR TITLE
congestion: add metrics

### DIFF
--- a/core/primitives/src/congestion_info.rs
+++ b/core/primitives/src/congestion_info.rs
@@ -120,8 +120,8 @@ pub struct CongestionInfoV1 {
     pub delayed_receipts_gas: u128,
     /// Sum of gas in currently buffered receipts.
     pub buffered_receipts_gas: u128,
-    /// Size of borsh serialized receipts stored in state because they
-    /// were delayed, buffered, postponed, or yielded.
+    /// Size of borsh serialized receipts stored in state because they were
+    /// delayed or buffered. Postponed and yielded receipts not included.
     pub receipt_bytes: u64,
     /// If fully congested, only this shard can forward receipts.
     pub allowed_shard: u16,

--- a/core/store/src/trie/receipts_column_helper.rs
+++ b/core/store/src/trie/receipts_column_helper.rs
@@ -214,6 +214,10 @@ impl ShardsOutgoingReceiptBuffer {
         self.shards_indices.shard_buffers.keys().copied().collect()
     }
 
+    pub fn buffer_len(&self, shard_id: ShardId) -> Option<u64> {
+        self.shards_indices.shard_buffers.get(&shard_id).map(TrieQueueIndices::len)
+    }
+
     fn write_indices(&self, state_update: &mut TrieUpdate) {
         // A default buffer is displayed as not being there at all. This makes an
         // empty trie and one with the default `ShardsOutgoingReceiptBuffer`,

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1710,6 +1710,9 @@ impl Runtime {
             total.gas,
             total.compute,
         );
+        // After receipt processing is done, report metrics on outgoing buffers
+        // and on congestion indicators.
+        metrics::report_congestion_metrics(&receipt_sink, apply_state.shard_id);
 
         let _span = tracing::debug_span!(target: "runtime", "apply_commit").entered();
 

--- a/runtime/runtime/src/metrics.rs
+++ b/runtime/runtime/src/metrics.rs
@@ -1,8 +1,12 @@
+use crate::congestion_control::ReceiptSink;
 use near_o11y::metrics::{
-    exponential_buckets, linear_buckets, try_create_counter_vec, try_create_histogram_vec,
-    try_create_histogram_with_buckets, try_create_int_counter, try_create_int_counter_vec,
-    CounterVec, Histogram, HistogramVec, IntCounter, IntCounterVec,
+    exponential_buckets, linear_buckets, try_create_counter_vec, try_create_gauge_vec,
+    try_create_histogram_vec, try_create_histogram_with_buckets, try_create_int_counter,
+    try_create_int_counter_vec, try_create_int_gauge_vec, CounterVec, GaugeVec, Histogram,
+    HistogramVec, IntCounter, IntCounterVec, IntGaugeVec,
 };
+use near_primitives::congestion_info::CongestionInfo;
+use near_primitives::types::ShardId;
 use once_cell::sync::Lazy;
 use std::time::Duration;
 
@@ -339,6 +343,60 @@ pub static CHUNK_RECORDED_SIZE_UPPER_BOUND_RATIO: Lazy<Histogram> = Lazy::new(||
     .unwrap()
 });
 
+static RECEIPT_FORWARDING_UNUSED_CAPACITY_GAS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    try_create_int_gauge_vec(
+        "near_receipt_forwarding_unused_capacity_gas",
+        "How much additional gas could have been forwarded in the same chunk from one shard to another. An indicator for congestion backpressure.",
+        &["sender_shard_id", "receiver_shard_id"],
+    )
+    .unwrap()
+});
+
+static OUTGOING_RECEIPT_BUFFER_LEN: Lazy<IntGaugeVec> = Lazy::new(|| {
+    try_create_int_gauge_vec(
+        "near_outgoing_receipt_buffer_len",
+        "Number of receipts currently stored in the outgoing receipt buffer which were held back because the receiver is congested.",
+        &["sender_shard_id", "receiver_shard_id"],
+    )
+    .unwrap()
+});
+
+static CONGESTION_LEVEL: Lazy<GaugeVec> = Lazy::new(|| {
+    try_create_gauge_vec(
+        "near_congestion_level",
+        "Summary of congestion per shard, between 0.0 and 1.0.",
+        &["shard_id"],
+    )
+    .unwrap()
+});
+
+static CONGESTION_RECEIPT_BYTES: Lazy<IntGaugeVec> = Lazy::new(|| {
+    try_create_int_gauge_vec(
+        "near_congestion_receipt_bytes",
+        "Size of all receipts currently delayed or buffered due to congestion.",
+        &["shard_id"],
+    )
+    .unwrap()
+});
+
+static CONGESTION_INCOMING_GAS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    try_create_int_gauge_vec(
+        "near_congestion_incoming_gas",
+        "Gas of all receipts currently delayed to congestion.",
+        &["shard_id"],
+    )
+    .unwrap()
+});
+
+static CONGESTION_OUTGOING_GAS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    try_create_int_gauge_vec(
+        "near_congestion_outgoing_gas",
+        "Gas of all receipts in the outgoing receipts buffer due to congestion on other shards.",
+        &["shard_id"],
+    )
+    .unwrap()
+});
+
 /// Buckets used for burned gas in receipts.
 ///
 /// The maximum possible is 1300 Tgas for a full chunk.
@@ -556,5 +614,56 @@ impl ApplyMetrics {
         CHUNK_COMPUTE
             .with_label_values(&[shard_id])
             .observe(self.accumulated_compute as f64 / TERA);
+    }
+}
+
+pub fn report_congestion_metrics(receipt_sink: &ReceiptSink, sender_shard_id: ShardId) {
+    match receipt_sink {
+        ReceiptSink::V1(_) => {
+            // no metrics to report
+        }
+        ReceiptSink::V2(inner) => {
+            let sender_shard_label = sender_shard_id.to_string();
+            report_congestion_indicators(&inner.congestion_info, &sender_shard_label);
+            report_outgoing_buffers(inner, sender_shard_label);
+        }
+    }
+}
+
+/// Report key congestion indicator levels of a shard.
+fn report_congestion_indicators(congestion_info: &CongestionInfo, shard_label: &str) {
+    let congestion_level = congestion_info.congestion_level();
+    CONGESTION_LEVEL.with_label_values(&[shard_label]).set(congestion_level);
+
+    let CongestionInfo::V1(inner) = congestion_info;
+    CONGESTION_RECEIPT_BYTES
+        .with_label_values(&[shard_label])
+        .set(inner.receipt_bytes.try_into().unwrap_or(i64::MAX));
+    CONGESTION_INCOMING_GAS
+        .with_label_values(&[shard_label])
+        .set(inner.delayed_receipts_gas.try_into().unwrap_or(i64::MAX));
+    CONGESTION_OUTGOING_GAS
+        .with_label_values(&[shard_label])
+        .set(inner.buffered_receipts_gas.try_into().unwrap_or(i64::MAX));
+}
+
+/// From `sender_shard` to all other shards, reports how many receipts are
+/// currently buffered and how much forwarding capacity was left.
+fn report_outgoing_buffers(
+    inner: &crate::congestion_control::ReceiptSinkV2,
+    sender_shard_label: String,
+) {
+    for (&receiver_shard_id, &unused_capacity) in inner.outgoing_limit.iter() {
+        let receiver_shard_label = receiver_shard_id.to_string();
+
+        RECEIPT_FORWARDING_UNUSED_CAPACITY_GAS
+            .with_label_values(&[&sender_shard_label, &receiver_shard_label])
+            .set(i64::try_from(unused_capacity).unwrap_or(i64::MAX));
+
+        if let Some(len) = inner.outgoing_buffers.buffer_len(receiver_shard_id) {
+            OUTGOING_RECEIPT_BUFFER_LEN
+                .with_label_values(&[&sender_shard_label, &receiver_shard_label])
+                .set(i64::try_from(len).unwrap_or(i64::MAX));
+        }
     }
 }


### PR DESCRIPTION
To observe how congested a shard is and why,
add a gauge per shard for the following values.

- congestion level (f64 between 0 and 1)
- congestion_info.receipt_bytes (i64)
- congestion_info.delayed_receipts_gas (i64)
- congestion_info.buffered_receipts_gas (i64)

Plus, to observe if a shard is subject to backpressure from a different shard, or how close it is from experiencing it, add two gauges  for each (sender,receiver) shard pair:

- currently buffered receipt (count)
- unused gas forwarding capacity (gas)