### PR TITLE
fix(custom-build) Add the build target to the url

### DIFF
--- a/.github/workflows/neard_custom_release.yml
+++ b/.github/workflows/neard_custom_release.yml
@@ -54,7 +54,7 @@ jobs:
           if [ -z "$BRANCH" ]; then
             BRANCH=$(git branch -r --contains=${{ github.ref_name }} | head -n1 | cut -c3- | cut -d / -f 2)
           fi
-          aws s3 cp --acl public-read latest s3://build.nearprotocol.com/nearcore/$(uname)/${BRANCH}/latest
+          aws s3 cp --acl public-read latest s3://build.nearprotocol.com/nearcore/$(uname)/${BRANCH}/${{ github.event.inputs.release }}/latest
 
   docker-release:
     name: "Build and publish nearcore Docker image"

--- a/scripts/binary_release.sh
+++ b/scripts/binary_release.sh
@@ -53,6 +53,7 @@ function upload_binary {
 
   else
     folder="${release%-release}"
+    aws s3 cp --acl public-read target/release/$1 s3://build.nearprotocol.com/nearcore/${os}/${BRANCH}/${folder}/$1
     aws s3 cp --acl public-read target/release/$1 s3://build.nearprotocol.com/nearcore/${os}/${BRANCH}/${COMMIT}/${folder}/$1
     aws s3 cp --acl public-read target/release/$1 s3://build.nearprotocol.com/nearcore/${os_and_arch}/${BRANCH}/${COMMIT}/${folder}/$1
   fi


### PR DESCRIPTION
The current custom release logic will upload to a url that changes every time based on commit. 
This PR introduces the option to have the same url for subsequent builds of the same branch: `/${os}/${BRANCH}/${target}/neard`