### PR TITLE
congestion: only init outgoing buffers when used

### DIFF
--- a/core/store/src/trie/receipts_column_helper.rs
+++ b/core/store/src/trie/receipts_column_helper.rs
@@ -130,11 +130,13 @@ pub trait TrieQueue {
             state_update.remove(key);
         }
 
-        self.indices_mut().first_index = indices
-            .first_index
-            .checked_add(to_remove)
-            .expect("first_index + to_remove should be < next_available_index");
-        self.write_indices(state_update);
+        if to_remove > 0 {
+            self.indices_mut().first_index = indices
+                .first_index
+                .checked_add(to_remove)
+                .expect("first_index + to_remove should be < next_available_index");
+            self.write_indices(state_update);
+        }
         Ok(to_remove)
     }
 
@@ -215,18 +217,7 @@ impl ShardsOutgoingReceiptBuffer {
     }
 
     fn write_indices(&self, state_update: &mut TrieUpdate) {
-        // A default buffer is displayed as not being there at all. This makes an
-        // empty trie and one with the default `ShardsOutgoingReceiptBuffer`,
-        // which are loaded as equivalent, produce the same trie root hash.
-        // TODO(congestion_control) - Figure out if we need this. It's tricky,
-        // if we write back an empty map as a value, many tests fail because the
-        // trie root changes unexpectedly. But if we store it as empty, we have
-        // to be careful to no re-compute it unnecessarily.
-        if self.shards_indices.shard_buffers.values().all(TrieQueueIndices::is_default) {
-            state_update.remove(TrieKey::BufferedReceiptIndices);
-        } else {
-            set(state_update, TrieKey::BufferedReceiptIndices, &self.shards_indices);
-        }
+        set(state_update, TrieKey::BufferedReceiptIndices, &self.shards_indices);
     }
 }
 

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -3104,7 +3104,7 @@ mod tests {
     }
 
     /// Check that applying nothing does not change the state trie.
-    /// 
+    ///
     /// This test is useful to check that trie columns are not accidentally
     /// initialized. Many integration tests will fail as well if this fails, but
     /// those are harder to root cause.

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -3102,6 +3102,42 @@ mod tests {
         let code_key = TrieKey::ContractCode { account_id: bob_account() };
         assert_matches!(storage.get(&code_key.to_vec()), Err(_) | Ok(None));
     }
+
+    /// Check that applying nothing does not change the state trie.
+    /// 
+    /// This test is useful to check that trie columns are not accidentally
+    /// initialized. Many integration tests will fail as well if this fails, but
+    /// those are harder to root cause.
+    #[test]
+    fn test_empty_apply() {
+        let initial_balance = to_yocto(1_000_000);
+        let initial_locked = to_yocto(500_000);
+        let gas_limit = 10u64.pow(15);
+        let (runtime, tries, root_before, apply_state, _signer, epoch_info_provider) =
+            setup_runtime(initial_balance, initial_locked, gas_limit);
+
+        let receipts = [];
+        let transactions = [];
+
+        let apply_result = runtime
+            .apply(
+                tries.get_trie_for_shard(ShardUId::single_shard(), root_before),
+                &None,
+                &apply_state,
+                &receipts,
+                &transactions,
+                &epoch_info_provider,
+                Default::default(),
+            )
+            .unwrap();
+        let mut store_update = tries.store_update();
+        let root_after = tries.apply_all(
+            &apply_result.trie_changes,
+            ShardUId::single_shard(),
+            &mut store_update,
+        );
+        assert_eq!(root_before, root_after, "state root changed for applying empty receipts");
+    }
 }
 
 /// Interface provided for gas cost estimations.


### PR DESCRIPTION
The previous implementation wrote the outgoing buffer indices to the trie in `pop_n` even if the buffer was still empty. To prevent this as showing up as a trie change, I added logic that checks specifically for empty values.

As it turns out, it is much easier to prevent writing indices back in the first place, which is also how it's done for the existing delayed receipts queue to avoid the same issue.