### PR TITLE
fix(forknet): ignore tracing server and set up state dumper node properly

### DIFF
--- a/pytest/tests/mocknet/local_test_node.py
+++ b/pytest/tests/mocknet/local_test_node.py
@@ -358,14 +358,16 @@ def get_node_homes(local_mocknet_path):
 
 DEFAULT_LOCAL_MOCKNET_DIR = pathlib.Path.home() / '.near/local-mocknet'
 
+
 # return a NodeHandle for each of the neard runner directories in `local_mocknet_path`
 def get_nodes(local_mocknet_path=DEFAULT_LOCAL_MOCKNET_DIR):
     runner_port = 3000
     neard_rpc_port = 3040
     neard_protocol_port = 24577
-    traffic_generator = NodeHandle(
-        LocalTestNeardRunner(local_mocknet_path / 'traffic-generator',
-                             runner_port, neard_rpc_port, neard_protocol_port), can_validate=False)
+    traffic_generator = NodeHandle(LocalTestNeardRunner(
+        local_mocknet_path / 'traffic-generator', runner_port, neard_rpc_port,
+        neard_protocol_port),
+                                   can_validate=False)
 
     node_homes = get_node_homes(local_mocknet_path)
     nodes = []

--- a/pytest/tests/mocknet/local_test_node.py
+++ b/pytest/tests/mocknet/local_test_node.py
@@ -356,14 +356,16 @@ def get_node_homes(local_mocknet_path):
     return [local_mocknet_path / x[0] for x in node_homes]
 
 
+DEFAULT_LOCAL_MOCKNET_DIR = pathlib.Path.home() / '.near/local-mocknet'
+
 # return a NodeHandle for each of the neard runner directories in `local_mocknet_path`
-def get_nodes(local_mocknet_path=pathlib.Path.home() / '.near/local-mocknet'):
+def get_nodes(local_mocknet_path=DEFAULT_LOCAL_MOCKNET_DIR):
     runner_port = 3000
     neard_rpc_port = 3040
     neard_protocol_port = 24577
     traffic_generator = NodeHandle(
         LocalTestNeardRunner(local_mocknet_path / 'traffic-generator',
-                             runner_port, neard_rpc_port, neard_protocol_port))
+                             runner_port, neard_rpc_port, neard_protocol_port), can_validate=False)
 
     node_homes = get_node_homes(local_mocknet_path)
     nodes = []
@@ -415,7 +417,7 @@ def local_test_setup_cmd(args):
         if args.fork_height is not None:
             sys.exit('cannot give --fork-height without --legacy-records')
 
-    local_mocknet_path = pathlib.Path.home() / '.near/local-mocknet'
+    local_mocknet_path = DEFAULT_LOCAL_MOCKNET_DIR
     if os.path.exists(local_mocknet_path):
         if not args.yes:
             print(

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -221,7 +221,7 @@ def _apply_config_changes(node, state_sync_location):
         do_update_config(node, f'{key}={json.dumps(change)}')
 
 
-def new_test(args, traffic_generator, nodes):
+def new_test_cmd(args, traffic_generator, nodes):
     prompt_setup_flags(args)
 
     if args.epoch_length <= 0:
@@ -500,7 +500,7 @@ if __name__ == '__main__':
     new_test_parser.add_argument('--stateless-setup', action='store_true')
     new_test_parser.add_argument('--gcs-state-sync', action='store_true')
     new_test_parser.add_argument('--yes', action='store_true')
-    new_test_parser.set_defaults(func=new_test)
+    new_test_parser.set_defaults(func=new_test_cmd)
 
     status_parser = subparsers.add_parser(
         'status',

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -218,7 +218,7 @@ def new_test(args, traffic_generator, nodes):
     test_keys = pmap(lambda node: node.neard_runner_new_test(), all_nodes)
 
     validators, boot_nodes = get_network_nodes(
-        zip([n.ip_addr() for n in all_nodes], test_keys), args.num_validators)
+        zip([n.ip_addr() for n in nodes], test_keys), args.num_validators)
 
     logger.info("""setting validators: {0}
 Then running neard amend-genesis on all nodes, and starting neard to compute genesis \

--- a/pytest/tests/mocknet/node_config.py
+++ b/pytest/tests/mocknet/node_config.py
@@ -28,18 +28,18 @@ def _is_three(node):
     return node.name() == 'node3'
 
 TEST_CONFIG = [
-    {
-        'node_matches': _is_two,
-        'can_validate': False,
-        'want_state_dump': True,
-        'want_neard_runner': True,
-    },
-    {
-        'node_matches': _is_three,
-        'can_validate': False,
-        'want_state_dump': False,
-        'want_neard_runner': False,
-    },
+    # {
+    #     'node_matches': _is_two,
+    #     'can_validate': False,
+    #     'want_state_dump': True,
+    #     'want_neard_runner': True,
+    # },
+    # {
+    #     'node_matches': _is_three,
+    #     'can_validate': False,
+    #     'want_state_dump': False,
+    #     'want_neard_runner': False,
+    # },
 ]
 
 # set attributes (e.g. do we want this node to possibly validate?) on this particular node

--- a/pytest/tests/mocknet/node_config.py
+++ b/pytest/tests/mocknet/node_config.py
@@ -1,0 +1,60 @@
+
+# TODO: these should be identified by tags
+def _is_tracing_server(node):
+    return node.name().endswith('tracing-server')
+
+def _is_dumper(node):
+    return node.name().endswith('dumper')
+
+REMOTE_CONFIG = [
+    {
+        'node_matches': _is_dumper,
+        'can_validate': False,
+        'want_state_dump': True,
+        'want_neard_runner': True,
+    },
+    {
+        'node_matches': _is_tracing_server,
+        'can_validate': False,
+        'want_state_dump': False,
+        'want_neard_runner': False,
+    },
+]
+
+def _is_two(node):
+    return node.name() == 'node2'
+
+def _is_three(node):
+    return node.name() == 'node3'
+
+TEST_CONFIG = [
+    {
+        'node_matches': _is_two,
+        'can_validate': False,
+        'want_state_dump': True,
+        'want_neard_runner': True,
+    },
+    {
+        'node_matches': _is_three,
+        'can_validate': False,
+        'want_state_dump': False,
+        'want_neard_runner': False,
+    },
+]
+
+# set attributes (e.g. do we want this node to possibly validate?) on this particular node
+def configure_nodes(nodes, node_setup_config):
+    for node in nodes:
+        node_config = None
+        for c in node_setup_config:
+            if c['node_matches'](node):
+                if node_config is not None:
+                    sys.exit(f'multiple node configuration matches for {f.node()}')
+                node_config = c
+        if node_config is None:
+            continue
+        node.can_validate = node_config['can_validate']
+        node.want_neard_runner = node_config['want_neard_runner']
+        node.want_state_dump = node_config['want_state_dump']
+
+

--- a/pytest/tests/mocknet/node_config.py
+++ b/pytest/tests/mocknet/node_config.py
@@ -1,10 +1,11 @@
-
 # TODO: these should be identified by tags
 def _is_tracing_server(node):
     return node.name().endswith('tracing-server')
 
+
 def _is_dumper(node):
     return node.name().endswith('dumper')
+
 
 REMOTE_CONFIG = [
     {
@@ -21,11 +22,14 @@ REMOTE_CONFIG = [
     },
 ]
 
+
 def _is_two(node):
     return node.name() == 'node2'
 
+
 def _is_three(node):
     return node.name() == 'node3'
+
 
 TEST_CONFIG = [
     # {
@@ -42,6 +46,7 @@ TEST_CONFIG = [
     # },
 ]
 
+
 # set attributes (e.g. do we want this node to possibly validate?) on this particular node
 def configure_nodes(nodes, node_setup_config):
     for node in nodes:
@@ -49,12 +54,11 @@ def configure_nodes(nodes, node_setup_config):
         for c in node_setup_config:
             if c['node_matches'](node):
                 if node_config is not None:
-                    sys.exit(f'multiple node configuration matches for {f.node()}')
+                    sys.exit(
+                        f'multiple node configuration matches for {f.node()}')
                 node_config = c
         if node_config is None:
             continue
         node.can_validate = node_config['can_validate']
         node.want_neard_runner = node_config['want_neard_runner']
         node.want_state_dump = node_config['want_state_dump']
-
-

--- a/pytest/tests/mocknet/node_handle.py
+++ b/pytest/tests/mocknet/node_handle.py
@@ -10,8 +10,11 @@ from configured_logger import logger
 
 class NodeHandle:
 
-    def __init__(self, node):
+    def __init__(self, node, can_validate=True, want_state_dump=False):
         self.node = node
+        self.can_validate = can_validate
+        self.want_state_dump = want_state_dump
+        self.want_neard_runner = True
 
     def name(self):
         return self.node.name()

--- a/pytest/tests/mocknet/remote_node.py
+++ b/pytest/tests/mocknet/remote_node.py
@@ -122,9 +122,10 @@ def get_nodes(chain_id, start_height, unique_id):
             f'could not find any mounts in /home/ubuntu/.near on {traffic_generator.instance_name}'
         )
     traffic_runner_home = os.path.join(traffic_target_home, 'neard-runner')
-    return NodeHandle(RemoteNeardRunner(
-        traffic_generator, traffic_runner_home), can_validate=False), [
-            NodeHandle(
-                RemoteNeardRunner(node, '/home/ubuntu/.near/neard-runner'))
-            for node in nodes
-        ]
+    return NodeHandle(RemoteNeardRunner(traffic_generator, traffic_runner_home),
+                      can_validate=False), [
+                          NodeHandle(
+                              RemoteNeardRunner(
+                                  node, '/home/ubuntu/.near/neard-runner'))
+                          for node in nodes
+                      ]

--- a/pytest/tests/mocknet/remote_node.py
+++ b/pytest/tests/mocknet/remote_node.py
@@ -123,7 +123,7 @@ def get_nodes(chain_id, start_height, unique_id):
         )
     traffic_runner_home = os.path.join(traffic_target_home, 'neard-runner')
     return NodeHandle(RemoteNeardRunner(
-        traffic_generator, traffic_runner_home)), [
+        traffic_generator, traffic_runner_home), can_validate=False), [
             NodeHandle(
                 RemoteNeardRunner(node, '/home/ubuntu/.near/neard-runner'))
             for node in nodes


### PR DESCRIPTION
This adds some fields (`can_validate`, `want_state_dump`, `want_neard_runner`) to `NodeHandle`. If `want_neard_runner` is false, then we ignore it when running all commands. If `want_state_dump` is true, we configure its state sync dump config, along with configuring it and the rest of the nodes with a correct `state_sync.sync` config. If `can_validate` is false, we ignore it when building the list of validator nodes.

The nodes will be configured in `node_config.py`, where for now we match on the names of instances