### PR TITLE
fix(ci): bump actions workflow versions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -27,6 +27,7 @@ jobs:
       with:
         name: book
         path: target/book
+        overwrite: true
 
   deploy:
     name: Deploy

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Build
       run: mdbook build
       working-directory: docs
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: book
         path: target/book
@@ -36,7 +36,7 @@ jobs:
     needs: book
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
         name: book
     - uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,7 @@ jobs:
           fetch-depth: 1000 # have enough history to find the merge-base between PR and master
       - uses: actions/download-artifact@v4
         with:
-          name: coverage-profraw-*
+          pattern: coverage-profraw-*
           path: coverage/profraw
           merge-multiple: true
       - uses: taiki-e/install-action@9b5b983efc779f85e5e5d11539f005e85ccb27ff
@@ -419,7 +419,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
-          name: coverage-codecov-*
+          pattern: coverage-codecov-*
           merge-multiple: true
       # Keep the number of uploads here in sync with codecov.yml’s after_n_build value
       # codecov will send a comment only after having receidev this number of uploads.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: matrix.upload_profraws
         with:
-          name: coverage-profraw-${{ github.sha }}
+          name: coverage-profraw-${{ github.sha }}-${{ matrix.name }}
           path: coverage/profraw
           retention-days: 2
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: matrix.upload_profraws
         with:
-          name: coverage-profraw
+          name: coverage-profraw-${{ github.sha }}
           path: coverage/profraw
           retention-days: 2
       - uses: actions/upload-artifact@v4
@@ -371,8 +371,9 @@ jobs:
           fetch-depth: 1000 # have enough history to find the merge-base between PR and master
       - uses: actions/download-artifact@v4
         with:
-          name: coverage-profraw
+          name: coverage-profraw-*
           path: coverage/profraw
+          merge-multiple: true
       - uses: taiki-e/install-action@9b5b983efc779f85e5e5d11539f005e85ccb27ff
         with:
           tool: cargo-llvm-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           retention-days: 2
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-codecov
+          name: coverage-codecov-${{ github.ref }}-cargo_nextest-${{ matrix.name }}
           path: coverage/codecov
 
   protobuf_backward_compat:
@@ -121,7 +121,7 @@ jobs:
       - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-backward-compat.json
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-codecov
+          name: coverage-codecov-${{ github.ref }}-py_backward_compat
           path: coverage/codecov
 
   py_db_migration:
@@ -148,7 +148,7 @@ jobs:
       - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-db-migration.json
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-codecov
+          name: coverage-codecov-${{ github.ref }}-py_db_migration
           path: coverage/codecov
 
   py_sanity_checks:
@@ -183,7 +183,7 @@ jobs:
       - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-sanity-checks.json
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-codecov
+          name: coverage-codecov-${{ github.ref }}-py_sanity_checks
           path: coverage/codecov
 
   py_genesis_check:
@@ -209,7 +209,7 @@ jobs:
       - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-genesis-check.json
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-codecov
+          name: coverage-codecov-${{ github.ref }}-py_genesis_check
           path: coverage/codecov
 
   py_style_check:
@@ -250,7 +250,7 @@ jobs:
       - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-upgradability.json
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-codecov
+          name: coverage-codecov-${{ github.ref }}-py_upgradability
           path: coverage/codecov
 
   rpc_error_schema:
@@ -418,7 +418,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
-          name: coverage-codecov
+          name: coverage-codecov-*
+          merge-multiple: true
       # Keep the number of uploads here in sync with codecov.yml’s after_n_build value
       # codecov will send a comment only after having receidev this number of uploads.
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,11 +398,11 @@ jobs:
       - run: diff-cover --compare-branch=origin/master --html-report coverage/html/${{matrix.type}}-diff.html coverage/lcov/${{matrix.type}}.lcov
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-lcov-${{ matrix.name }}
+          name: coverage-lcov-${{ matrix.type }}
           path: coverage/lcov
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-html-${{ matrix.name }}
+          name: coverage-html-${{ matrix.type }}
           path: coverage/html
 
   upload_coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,11 +398,11 @@ jobs:
       - run: diff-cover --compare-branch=origin/master --html-report coverage/html/${{matrix.type}}-diff.html coverage/lcov/${{matrix.type}}.lcov
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-lcov
+          name: coverage-lcov-${{ matrix.name }}
           path: coverage/lcov
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-html
+          name: coverage-html-${{ matrix.name }}
           path: coverage/html
 
   upload_coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           retention-days: 2
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-codecov-${{ github.ref }}-cargo_nextest-${{ matrix.name }}
+          name: coverage-codecov-${{ github.sha }}-cargo_nextest-${{ matrix.name }}
           path: coverage/codecov
 
   protobuf_backward_compat:
@@ -121,7 +121,7 @@ jobs:
       - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-backward-compat.json
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-codecov-${{ github.ref }}-py_backward_compat
+          name: coverage-codecov-${{ github.sha }}-py_backward_compat
           path: coverage/codecov
 
   py_db_migration:
@@ -148,7 +148,7 @@ jobs:
       - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-db-migration.json
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-codecov-${{ github.ref }}-py_db_migration
+          name: coverage-codecov-${{ github.sha }}-py_db_migration
           path: coverage/codecov
 
   py_sanity_checks:
@@ -183,7 +183,7 @@ jobs:
       - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-sanity-checks.json
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-codecov-${{ github.ref }}-py_sanity_checks
+          name: coverage-codecov-${{ github.sha }}-py_sanity_checks
           path: coverage/codecov
 
   py_genesis_check:
@@ -209,7 +209,7 @@ jobs:
       - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-genesis-check.json
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-codecov-${{ github.ref }}-py_genesis_check
+          name: coverage-codecov-${{ github.sha }}-py_genesis_check
           path: coverage/codecov
 
   py_style_check:
@@ -250,7 +250,7 @@ jobs:
       - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-upgradability.json
       - uses: actions/upload-artifact@v4
         with:
-          name: coverage-codecov-${{ github.ref }}-py_upgradability
+          name: coverage-codecov-${{ github.sha }}-py_upgradability
           path: coverage/codecov
 
   rpc_error_schema:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,13 +77,13 @@ jobs:
       - run: mv coverage/profraw/binaries/{new,${{matrix.id}}}.tar.zst
 
       # Upload the coverage
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: matrix.upload_profraws
         with:
           name: coverage-profraw
           path: coverage/profraw
           retention-days: 2
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: coverage-codecov
           path: coverage/codecov
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-22.04-8core
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.11
           cache: pip
@@ -119,7 +119,7 @@ jobs:
       - run: cd pytest && python3 tests/sanity/backward_compatible.py
       - run: mkdir -p coverage/codecov
       - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-backward-compat.json
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: coverage-codecov
           path: coverage/codecov
@@ -129,7 +129,7 @@ jobs:
     runs-on: ubuntu-22.04-8core
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.11
           cache: pip
@@ -146,7 +146,7 @@ jobs:
       - run: cd pytest && python3 tests/sanity/db_migration.py
       - run: mkdir -p coverage/codecov
       - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-db-migration.json
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: coverage-codecov
           path: coverage/codecov
@@ -159,7 +159,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.11
           cache: pip
@@ -181,7 +181,7 @@ jobs:
           NEAR_ROOT: "target/dev-release"
       - run: mkdir -p coverage/codecov
       - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-sanity-checks.json
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: coverage-codecov
           path: coverage/codecov
@@ -191,7 +191,7 @@ jobs:
     runs-on: ubuntu-22.04-8core
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.11
           cache: pip
@@ -207,7 +207,7 @@ jobs:
       - run: python3 scripts/state/update_res.py check
       - run: mkdir -p coverage/codecov
       - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-genesis-check.json
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: coverage-codecov
           path: coverage/codecov
@@ -220,7 +220,7 @@ jobs:
       - uses: taiki-e/install-action@9b5b983efc779f85e5e5d11539f005e85ccb27ff
         with:
           tool: just
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.11
           cache: pip
@@ -232,7 +232,7 @@ jobs:
     runs-on: ubuntu-22.04-8core
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.11
           cache: pip
@@ -248,7 +248,7 @@ jobs:
       - run: cd pytest && python3 tests/sanity/upgradable.py
       - run: mkdir -p coverage/codecov
       - run: cargo llvm-cov report --profile dev-release --codecov --output-path coverage/codecov/py-upgradability.json
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: coverage-codecov
           path: coverage/codecov
@@ -369,14 +369,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1000 # have enough history to find the merge-base between PR and master
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: coverage-profraw
           path: coverage/profraw
       - uses: taiki-e/install-action@9b5b983efc779f85e5e5d11539f005e85ccb27ff
         with:
           tool: cargo-llvm-cov
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.11
           cache: pip
@@ -395,11 +395,11 @@ jobs:
       - run: cargo llvm-cov report --profile dev-release --html --hide-instantiations --output-dir coverage/html/${{matrix.type}}-full
       - run: git fetch origin master
       - run: diff-cover --compare-branch=origin/master --html-report coverage/html/${{matrix.type}}-diff.html coverage/lcov/${{matrix.type}}.lcov
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: coverage-lcov
           path: coverage/lcov
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: coverage-html
           path: coverage/html
@@ -416,7 +416,7 @@ jobs:
       - py_upgradability
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: coverage-codecov
       # Keep the number of uploads here in sync with codecov.yml’s after_n_build value


### PR DESCRIPTION
Currently there are tons of warnings on Actions:
![](https://github.com/near/nearcore/assets/168894316/d4b54dec-3d81-4290-8feb-ff70b89ea080)

As some actions are relying on Node16 which is going to EOL(https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/), and some workflows are being deprecated.

For example https://github.com/actions/download-artifact
> actions/download-artifact@v3 is scheduled for deprecation on November 30, 2024. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) Similarly, v1/v2 are scheduled for deprecation on June 30, 2024.

https://github.com/actions/upload-artifact
> actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) Similarly, v1/v2 are scheduled for deprecation on June 30, 2024.

This PR bumps those workflows to avoid future breaking on CI flow when those actions are deprecated.