### PR TITLE
 feat(congestion_control) - handling missing chunks 

### DIFF
--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -396,7 +396,6 @@ impl<'a> ChainUpdate<'a> {
                 let old_extra = self.chain_store_update.get_chunk_extra(prev_hash, &shard_uid)?;
                 let mut new_extra = ChunkExtra::clone(&old_extra);
                 *new_extra.state_root_mut() = apply_result.new_root;
-                // TODO(congestion_control) handle missing chunks congestion info #11039
 
                 let flat_storage_manager = self.runtime_adapter.get_flat_storage_manager();
                 let store_update = flat_storage_manager.save_flat_state_changes(
@@ -906,7 +905,6 @@ impl<'a> ChainUpdate<'a> {
         // extra and apply changes to it.
         let mut new_chunk_extra = ChunkExtra::clone(&chunk_extra);
         *new_chunk_extra.state_root_mut() = apply_result.new_root;
-        // TODO(congestion_control) handle missing chunks congestion info #11039
 
         self.chain_store_update.save_chunk_extra(block_header.hash(), &shard_uid, new_chunk_extra);
         Ok(true)

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -828,10 +828,10 @@ impl RuntimeAdapter for NightshadeRuntime {
                             &tx.transaction.receiver_id,
                             &epoch_id,
                         )?;
-                        if let Some(shard_congestion) =
+                        if let Some(congestion_info) =
                             prev_block.congestion_info.get(&receiving_shard)
                         {
-                            if !shard_congestion.shard_accepts_transactions() {
+                            if !congestion_info.shard_accepts_transactions() {
                                 tracing::trace!(target: "runtime", tx=?tx.get_hash(), "discarding transaction due to congestion");
                                 continue;
                             }

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -11,6 +11,7 @@ use near_pool::{
 };
 use near_primitives::apply::ApplyChunkReason;
 use near_primitives::checked_feature;
+use near_primitives::congestion_info::ExtendedCongestionInfo;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::validator_stake::{ValidatorStake, ValidatorStakeIter};
 use near_primitives::version::PROTOCOL_VERSION;
@@ -83,14 +84,14 @@ impl NightshadeRuntime {
         let epoch_id =
             self.epoch_manager.get_epoch_id_from_prev_block(block_hash).unwrap_or_default();
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id).unwrap();
-        let congestion_info_map: HashMap<ShardId, CongestionInfo> =
+        let congestion_info_map: HashMap<ShardId, ExtendedCongestionInfo> =
             if !ProtocolFeature::CongestionControl.enabled(protocol_version) {
                 HashMap::new()
             } else {
                 let shard_ids = self.epoch_manager.shard_ids(&epoch_id).unwrap();
                 shard_ids
                     .into_iter()
-                    .map(|shard_id| (shard_id, CongestionInfo::default()))
+                    .map(|shard_id| (shard_id, ExtendedCongestionInfo::default()))
                     .collect()
             };
         let mut result = self

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -12,6 +12,7 @@ pub use near_primitives::block::{Block, BlockHeader, Tip};
 use near_primitives::challenge::{ChallengesResult, PartialState};
 use near_primitives::checked_feature;
 use near_primitives::congestion_info::CongestionInfo;
+use near_primitives::congestion_info::ExtendedCongestionInfo;
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{merklize, MerklePath};
@@ -291,14 +292,14 @@ pub struct ApplyChunkBlockContext {
     pub gas_price: Balance,
     pub challenges_result: ChallengesResult,
     pub random_seed: CryptoHash,
-    pub congestion_info: HashMap<ShardId, CongestionInfo>,
+    pub congestion_info: HashMap<ShardId, ExtendedCongestionInfo>,
 }
 
 impl ApplyChunkBlockContext {
     pub fn from_header(
         header: &BlockHeader,
         gas_price: Balance,
-        congestion_info: HashMap<ShardId, CongestionInfo>,
+        congestion_info: HashMap<ShardId, ExtendedCongestionInfo>,
     ) -> Self {
         Self {
             height: header.height(),
@@ -348,7 +349,7 @@ pub struct PrepareTransactionsBlockContext {
     pub next_gas_price: Balance,
     pub height: BlockHeight,
     pub block_hash: CryptoHash,
-    pub congestion_info: HashMap<ShardId, CongestionInfo>,
+    pub congestion_info: HashMap<ShardId, ExtendedCongestionInfo>,
 }
 
 impl From<&Block> for PrepareTransactionsBlockContext {

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -600,7 +600,9 @@ impl Block {
             let congestion_info = chunk.congestion_info().unwrap_or_default();
             let height_included = chunk.height_included();
             let height_current = self.header().height();
-            let missed_chunks_count = height_current - height_included;
+            let missed_chunks_count = height_current.checked_sub(height_included);
+            let missed_chunks_count = missed_chunks_count
+                .expect("The chunk height included must be less or equal than block height!");
 
             let extended_congestion_info =
                 ExtendedCongestionInfo::new(congestion_info, missed_chunks_count);

--- a/core/primitives/src/congestion_info.rs
+++ b/core/primitives/src/congestion_info.rs
@@ -373,12 +373,12 @@ impl CongestionInfoV1 {
         let incoming_congestion = self.incoming_congestion();
         let outgoing_congestion = self.outgoing_congestion();
         let memory_congestion = self.memory_congestion();
-        let missed_chunk_congestion = self.missed_chunks_congestion(missed_chunks_count);
+        let missed_chunks_congestion = self.missed_chunks_congestion(missed_chunks_count);
 
         incoming_congestion
             .max(outgoing_congestion)
             .max(memory_congestion)
-            .max(missed_chunk_congestion)
+            .max(missed_chunks_congestion)
     }
 
     fn incoming_congestion(&self) -> f64 {

--- a/core/primitives/src/congestion_info.rs
+++ b/core/primitives/src/congestion_info.rs
@@ -709,11 +709,11 @@ mod tests {
 
         // Test with some missed chunks congestion.
 
-        let missed_chunks_count = 7;
+        let missed_chunks_count = 8;
         let mut info = ExtendedCongestionInfo::new(congestion_info.clone(), missed_chunks_count);
         info.finalize_allowed_shard(shard, &other_shards, 3);
 
-        let expected_outgoing_limit = 0.3 * MIN_OUTGOING_GAS as f64 + 0.7 * MAX_OUTGOING_GAS as f64;
+        let expected_outgoing_limit = mix(MAX_OUTGOING_GAS, MIN_OUTGOING_GAS, 0.8) as f64;
         for other_shard in other_shards {
             assert_eq!(info.outgoing_limit(other_shard), expected_outgoing_limit as u64);
         }
@@ -724,6 +724,8 @@ mod tests {
         let mut info = ExtendedCongestionInfo::new(congestion_info.clone(), missed_chunks_count);
         info.finalize_allowed_shard(shard, &other_shards, 3);
 
+        // The allowed shard should be set to own shard. None of the other
+        // shards should be allowed to send anything.
         let expected_outgoing_limit = 0;
         for other_shard in other_shards {
             assert_eq!(info.outgoing_limit(other_shard), expected_outgoing_limit as u64);

--- a/core/primitives/src/congestion_info.rs
+++ b/core/primitives/src/congestion_info.rs
@@ -677,7 +677,7 @@ mod tests {
         // Test missed chunks congestion with outgoing congestion
         let mut congestion_info = CongestionInfo::default();
         congestion_info.add_buffered_receipt_gas(MAX_CONGESTION_OUTGOING_GAS / 2).unwrap();
-        let make = |count| ExtendedCongestionInfo::new(congestion_info.clone(), count);
+        let make = |count| ExtendedCongestionInfo::new(congestion_info, count);
 
         assert_eq!(make(0).congestion_level(), 0.5);
         assert_eq!(make(1).congestion_level(), 0.5);
@@ -699,7 +699,7 @@ mod tests {
         // Test without missed chunks congestion.
 
         let missed_chunks_count = 0;
-        let mut info = ExtendedCongestionInfo::new(congestion_info.clone(), missed_chunks_count);
+        let mut info = ExtendedCongestionInfo::new(congestion_info, missed_chunks_count);
         info.finalize_allowed_shard(shard, &other_shards, 3);
 
         let expected_outgoing_limit = 0.5 * MIN_OUTGOING_GAS as f64 + 0.5 * MAX_OUTGOING_GAS as f64;
@@ -710,7 +710,7 @@ mod tests {
         // Test with some missed chunks congestion.
 
         let missed_chunks_count = 8;
-        let mut info = ExtendedCongestionInfo::new(congestion_info.clone(), missed_chunks_count);
+        let mut info = ExtendedCongestionInfo::new(congestion_info, missed_chunks_count);
         info.finalize_allowed_shard(shard, &other_shards, 3);
 
         let expected_outgoing_limit = mix(MAX_OUTGOING_GAS, MIN_OUTGOING_GAS, 0.8) as f64;
@@ -721,7 +721,7 @@ mod tests {
         // Test with full missed chunks congestion.
 
         let missed_chunks_count = MAX_CONGESTION_MISSED_CHUNKS;
-        let mut info = ExtendedCongestionInfo::new(congestion_info.clone(), missed_chunks_count);
+        let mut info = ExtendedCongestionInfo::new(congestion_info, missed_chunks_count);
         info.finalize_allowed_shard(shard, &other_shards, 3);
 
         // The allowed shard should be set to own shard. None of the other

--- a/core/primitives/src/congestion_info.rs
+++ b/core/primitives/src/congestion_info.rs
@@ -33,6 +33,10 @@ const MAX_CONGESTION_OUTGOING_GAS: Gas = 2 * PGAS;
 /// is not a hard guarantee.
 const MAX_CONGESTION_MEMORY_CONSUMPTION: u64 = bytesize::ByteSize::mb(1000u64).0;
 
+/// How many missed chunks in a row in a shard is considered 100% congested.
+/// TODO(congestion_control) - find a good limit for missed chunks.
+const MAX_CONGESTION_MISSED_CHUNKS: u64 = 10;
+
 /// The maximum amount of gas attached to receipts a shard can forward to
 /// another shard per chunk.
 ///
@@ -102,31 +106,6 @@ pub enum CongestionInfo {
     V1(CongestionInfoV1),
 }
 
-/// Stores the congestion level of a shard.
-#[derive(
-    BorshSerialize,
-    BorshDeserialize,
-    serde::Serialize,
-    serde::Deserialize,
-    Default,
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-)]
-pub struct CongestionInfoV1 {
-    /// Sum of gas in currently delayed receipts.
-    pub delayed_receipts_gas: u128,
-    /// Sum of gas in currently buffered receipts.
-    pub buffered_receipts_gas: u128,
-    /// Size of borsh serialized receipts stored in state because they were
-    /// delayed or buffered. Postponed and yielded receipts not included.
-    pub receipt_bytes: u64,
-    /// If fully congested, only this shard can forward receipts.
-    pub allowed_shard: u16,
-}
-
 impl Default for CongestionInfo {
     fn default() -> Self {
         Self::V1(CongestionInfoV1::default())
@@ -135,9 +114,9 @@ impl Default for CongestionInfo {
 
 impl CongestionInfo {
     /// How much gas another shard can send to us in the next block.
-    pub fn outgoing_limit(&self, sender_shard: ShardId) -> Gas {
+    pub fn outgoing_limit(&self, sender_shard: ShardId, missed_chunks_count: u64) -> Gas {
         match self {
-            CongestionInfo::V1(inner) => inner.outgoing_limit(sender_shard),
+            CongestionInfo::V1(inner) => inner.outgoing_limit(sender_shard, missed_chunks_count),
         }
     }
 
@@ -150,16 +129,16 @@ impl CongestionInfo {
     }
 
     /// Whether we can accept new transaction with the receiver set to this shard.
-    pub fn shard_accepts_transactions(&self) -> bool {
+    pub fn shard_accepts_transactions(&self, missed_chunks_count: u64) -> bool {
         match self {
-            CongestionInfo::V1(inner) => inner.shard_accepts_transactions(),
+            CongestionInfo::V1(inner) => inner.shard_accepts_transactions(missed_chunks_count),
         }
     }
 
-    /// Congestion level in the range [0.0,1.0].
-    pub fn congestion_level(&self) -> f64 {
+    /// Congestion level in the range [0.0, 1.0].
+    pub fn congestion_level(&self, missed_chunks_count: u64) -> f64 {
         match self {
-            CongestionInfo::V1(inner) => inner.congestion_level(),
+            CongestionInfo::V1(inner) => inner.congestion_level(missed_chunks_count),
         }
     }
 
@@ -269,10 +248,113 @@ impl CongestionInfo {
     }
 }
 
-impl CongestionInfoV1 {
+/// The extended congestion info contains the congestion info and extra
+/// information extracted from the block that is needed for congestion control.
+///
+/// It has simpler interface and it should be used instead of using the
+/// [`CongestionInfo`] directly.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ExtendedCongestionInfo {
+    congestion_info: CongestionInfo,
+    missed_chunks_count: u64,
+}
+
+impl ExtendedCongestionInfo {
+    pub fn new(congestion_info: CongestionInfo, missed_chunks_count: u64) -> Self {
+        Self { congestion_info, missed_chunks_count }
+    }
+
+    pub fn congestion_info(self) -> CongestionInfo {
+        self.congestion_info
+    }
+
     /// How much gas another shard can send to us in the next block.
     pub fn outgoing_limit(&self, sender_shard: ShardId) -> Gas {
-        let congestion = self.congestion_level();
+        self.congestion_info.outgoing_limit(sender_shard, self.missed_chunks_count)
+    }
+
+    /// How much gas we accept for executing new transactions going to any
+    /// uncongested shards.
+    pub fn process_tx_limit(&self) -> Gas {
+        self.congestion_info.process_tx_limit()
+    }
+
+    /// Whether we can accept new transaction with the receiver set to this shard.
+    pub fn shard_accepts_transactions(&self) -> bool {
+        self.congestion_info.shard_accepts_transactions(self.missed_chunks_count)
+    }
+
+    pub fn finalize_allowed_shard(
+        &mut self,
+        own_shard: ShardId,
+        other_shards: &[ShardId],
+        congestion_seed: u64,
+    ) {
+        self.congestion_info.finalize_allowed_shard(own_shard, other_shards, congestion_seed)
+    }
+
+    pub fn add_receipt_bytes(&mut self, bytes: u64) -> Result<(), RuntimeError> {
+        self.congestion_info.add_receipt_bytes(bytes)
+    }
+
+    pub fn remove_receipt_bytes(&mut self, bytes: u64) -> Result<(), RuntimeError> {
+        self.congestion_info.remove_receipt_bytes(bytes)
+    }
+
+    pub fn add_delayed_receipt_gas(&mut self, gas: Gas) -> Result<(), RuntimeError> {
+        self.congestion_info.add_delayed_receipt_gas(gas)
+    }
+
+    pub fn remove_delayed_receipt_gas(&mut self, gas: Gas) -> Result<(), RuntimeError> {
+        self.congestion_info.remove_delayed_receipt_gas(gas)
+    }
+
+    pub fn add_buffered_receipt_gas(&mut self, gas: Gas) -> Result<(), RuntimeError> {
+        self.congestion_info.add_buffered_receipt_gas(gas)
+    }
+
+    pub fn remove_buffered_receipt_gas(&mut self, gas: Gas) -> Result<(), RuntimeError> {
+        self.congestion_info.remove_buffered_receipt_gas(gas)
+    }
+
+    #[cfg(test)]
+    /// Congestion level in the range [0.0, 1.0].
+    pub fn congestion_level(&self) -> f64 {
+        match self.congestion_info {
+            CongestionInfo::V1(inner) => inner.congestion_level(self.missed_chunks_count),
+        }
+    }
+}
+
+/// Stores the congestion level of a shard.
+#[derive(
+    BorshSerialize,
+    BorshDeserialize,
+    serde::Serialize,
+    serde::Deserialize,
+    Default,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+)]
+pub struct CongestionInfoV1 {
+    /// Sum of gas in currently delayed receipts.
+    pub delayed_receipts_gas: u128,
+    /// Sum of gas in currently buffered receipts.
+    pub buffered_receipts_gas: u128,
+    /// Size of borsh serialized receipts stored in state because they
+    /// were delayed, buffered, postponed, or yielded.
+    pub receipt_bytes: u64,
+    /// If fully congested, only this shard can forward receipts.
+    pub allowed_shard: u16,
+}
+
+impl CongestionInfoV1 {
+    /// How much gas another shard can send to us in the next block.
+    pub fn outgoing_limit(&self, sender_shard: ShardId, missed_chunks_count: u64) -> Gas {
+        let congestion = self.congestion_level(missed_chunks_count);
 
         // note: using float equality is okay here because
         // `clamped_f64_fraction` clamps to exactly 1.0.
@@ -288,12 +370,16 @@ impl CongestionInfoV1 {
         }
     }
 
-    fn congestion_level(&self) -> f64 {
+    fn congestion_level(&self, missed_chunks_count: u64) -> f64 {
         let incoming_congestion = self.incoming_congestion();
         let outgoing_congestion = self.outgoing_congestion();
         let memory_congestion = self.memory_congestion();
+        let missed_chunk_congestion = self.missed_chunks_congestion(missed_chunks_count);
 
-        incoming_congestion.max(outgoing_congestion).max(memory_congestion)
+        incoming_congestion
+            .max(outgoing_congestion)
+            .max(memory_congestion)
+            .max(missed_chunk_congestion)
     }
 
     fn incoming_congestion(&self) -> f64 {
@@ -305,6 +391,13 @@ impl CongestionInfoV1 {
     fn memory_congestion(&self) -> f64 {
         clamped_f64_fraction(self.receipt_bytes as u128, MAX_CONGESTION_MEMORY_CONSUMPTION)
     }
+    fn missed_chunks_congestion(&self, missed_chunks_count: u64) -> f64 {
+        if missed_chunks_count <= 1 {
+            return 0.0;
+        }
+
+        clamped_f64_fraction(missed_chunks_count as u128, MAX_CONGESTION_MISSED_CHUNKS)
+    }
 
     /// How much gas we accept for executing new transactions going to any
     /// uncongested shards.
@@ -313,8 +406,8 @@ impl CongestionInfoV1 {
     }
 
     /// Whether we can accept new transaction with the receiver set to this shard.
-    pub fn shard_accepts_transactions(&self) -> bool {
-        self.congestion_level() < REJECT_TX_CONGESTION_THRESHOLD
+    pub fn shard_accepts_transactions(&self, missed_chunks_count: u64) -> bool {
+        self.congestion_level(missed_chunks_count) < REJECT_TX_CONGESTION_THRESHOLD
     }
 
     /// Computes and sets the `allowed_shard` field.
@@ -326,7 +419,8 @@ impl CongestionInfoV1 {
         other_shards: &[ShardId],
         congestion_seed: u64,
     ) {
-        if self.congestion_level() < 1.0 {
+        // TODO(congestion_control) Set missed chunks count correctly.
+        if self.congestion_level(0) < 1.0 {
             self.allowed_shard = own_shard as u16;
         } else {
             if let Some(index) = congestion_seed.checked_rem(other_shards.len() as u64) {
@@ -441,12 +535,12 @@ mod tests {
         assert_eq!(0.0, inner_congestion_info.memory_congestion());
         assert_eq!(0.0, inner_congestion_info.incoming_congestion());
         assert_eq!(0.0, inner_congestion_info.outgoing_congestion());
-        assert_eq!(0.0, inner_congestion_info.congestion_level());
+        assert_eq!(0.0, inner_congestion_info.congestion_level(0));
 
         let congestion_info = CongestionInfo::V1(inner_congestion_info);
-        assert_eq!(MAX_OUTGOING_GAS, congestion_info.outgoing_limit(0));
+        assert_eq!(MAX_OUTGOING_GAS, congestion_info.outgoing_limit(0, 0));
         assert_eq!(MAX_TX_GAS, congestion_info.process_tx_limit());
-        assert!(congestion_info.shard_accepts_transactions());
+        assert!(congestion_info.shard_accepts_transactions(0));
     }
 
     #[test]
@@ -457,37 +551,37 @@ mod tests {
         congestion_info.add_receipt_bytes(500).unwrap();
         congestion_info.remove_receipt_bytes(500).unwrap();
 
-        assert_eq!(1.0, congestion_info.congestion_level());
+        assert_eq!(1.0, congestion_info.congestion_level(0));
         // fully congested, no more forwarding allowed
-        assert_eq!(0, congestion_info.outgoing_limit(1));
-        assert!(!congestion_info.shard_accepts_transactions());
+        assert_eq!(0, congestion_info.outgoing_limit(1, 0));
+        assert!(!congestion_info.shard_accepts_transactions(0));
         // processing to other shards is not restricted by memory congestion
         assert_eq!(MAX_TX_GAS, congestion_info.process_tx_limit());
 
         // remove half the congestion
         congestion_info.remove_receipt_bytes(MAX_CONGESTION_MEMORY_CONSUMPTION / 2).unwrap();
-        assert_eq!(0.5, congestion_info.congestion_level());
+        assert_eq!(0.5, congestion_info.congestion_level(0));
         assert_eq!(
             (0.5 * MIN_OUTGOING_GAS as f64 + 0.5 * MAX_OUTGOING_GAS as f64) as u64,
-            congestion_info.outgoing_limit(1)
+            congestion_info.outgoing_limit(1, 0)
         );
         // at 50%, still no new transactions are allowed
-        assert!(!congestion_info.shard_accepts_transactions());
+        assert!(!congestion_info.shard_accepts_transactions(0));
 
         // reduce congestion to 1/8
         congestion_info.remove_receipt_bytes(3 * MAX_CONGESTION_MEMORY_CONSUMPTION / 8).unwrap();
-        assert_eq!(0.125, congestion_info.congestion_level());
+        assert_eq!(0.125, congestion_info.congestion_level(0));
         assert_eq!(
             (0.125 * MIN_OUTGOING_GAS as f64 + 0.875 * MAX_OUTGOING_GAS as f64) as u64,
-            congestion_info.outgoing_limit(1)
+            congestion_info.outgoing_limit(1, 0)
         );
         // at 12.5%, new transactions are allowed (threshold is 0.25)
-        assert!(congestion_info.shard_accepts_transactions());
+        assert!(congestion_info.shard_accepts_transactions(0));
     }
 
     #[test]
     fn test_incoming_congestion() {
-        let mut congestion_info = CongestionInfo::default();
+        let mut congestion_info = ExtendedCongestionInfo::default();
 
         congestion_info.add_delayed_receipt_gas(MAX_CONGESTION_INCOMING_GAS).unwrap();
         congestion_info.add_delayed_receipt_gas(500).unwrap();
@@ -532,7 +626,7 @@ mod tests {
 
     #[test]
     fn test_outgoing_congestion() {
-        let mut congestion_info = CongestionInfo::default();
+        let mut congestion_info = ExtendedCongestionInfo::default();
 
         congestion_info.add_buffered_receipt_gas(MAX_CONGESTION_OUTGOING_GAS).unwrap();
         congestion_info.add_buffered_receipt_gas(500).unwrap();

--- a/core/store/src/trie/resharding.rs
+++ b/core/store/src/trie/resharding.rs
@@ -103,7 +103,7 @@ impl ShardTries {
                         None => trie_update.remove(trie_key),
                     }
                 }
-                // TODO(congestion_control)
+                // TODO(congestion_control) - integration with resharding
                 TrieKey::BufferedReceiptIndices => todo!(),
                 TrieKey::BufferedReceipt { .. } => todo!(),
             }

--- a/integration-tests/src/tests/client/features/congestion_control.rs
+++ b/integration-tests/src/tests/client/features/congestion_control.rs
@@ -53,8 +53,8 @@ fn test_protocol_upgrade() {
         let congestion_info = chunk_header
             .congestion_info()
             .expect("chunk header must have congestion info after upgrade");
-        assert_eq!(congestion_info.congestion_level(), 0.0);
-        assert!(congestion_info.shard_accepts_transactions());
+        assert_eq!(congestion_info.congestion_level(0), 0.0);
+        assert!(congestion_info.shard_accepts_transactions(0));
     }
 }
 

--- a/integration-tests/src/tests/client/features/stateless_validation.rs
+++ b/integration-tests/src/tests/client/features/stateless_validation.rs
@@ -234,6 +234,11 @@ fn test_chunk_validation_low_missing_chunks() {
     run_chunk_validation_test(43, 0.3);
 }
 
+// This test fails because transactions are rejected when there are too many
+// missing chunks in a row.
+// TODO(congestion_control) - make congestion control configurable,
+// disable it here and re-enable this test
+#[ignore]
 #[test]
 fn test_chunk_validation_high_missing_chunks() {
     run_chunk_validation_test(44, 0.81);

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2543,7 +2543,7 @@ fn test_refund_receipts_processing() {
     }
 
     // Make sure all transactions are processed.
-    for i in 3..16 {
+    for i in 1..16 {
         env.produce_block(0, i);
     }
 

--- a/integration-tests/src/user/runtime_user.rs
+++ b/integration-tests/src/user/runtime_user.rs
@@ -6,7 +6,7 @@ use near_chain_configs::MIN_GAS_PRICE;
 use near_crypto::{PublicKey, Signer};
 use near_jsonrpc_primitives::errors::ServerError;
 use near_parameters::RuntimeConfig;
-use near_primitives::congestion_info::CongestionInfo;
+use near_primitives::congestion_info::ExtendedCongestionInfo;
 use near_primitives::errors::{RuntimeError, TxExecutionError};
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
@@ -178,7 +178,7 @@ impl RuntimeUser {
             migration_flags: MigrationFlags::default(),
             congestion_info: all_shard_ids
                 .into_iter()
-                .map(|id| (id, CongestionInfo::default()))
+                .map(|id| (id, ExtendedCongestionInfo::default()))
                 .collect(),
         }
     }

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -4,7 +4,7 @@ use crate::gas_cost::GasCost;
 use genesis_populate::get_account_id;
 use genesis_populate::state_dump::StateDump;
 use near_parameters::{ExtCosts, RuntimeConfigStore};
-use near_primitives::congestion_info::CongestionInfo;
+use near_primitives::congestion_info::ExtendedCongestionInfo;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
 use near_primitives::runtime::migration_data::{MigrationData, MigrationFlags};
@@ -166,7 +166,7 @@ impl<'c> EstimatorContext<'c> {
             is_new_chunk: true,
             migration_data: Arc::new(MigrationData::default()),
             migration_flags: MigrationFlags::default(),
-            congestion_info: HashMap::from([(shard_id, CongestionInfo::default())]),
+            congestion_info: HashMap::from([(shard_id, ExtendedCongestionInfo::default())]),
         }
     }
 

--- a/runtime/runtime/src/congestion_control.rs
+++ b/runtime/runtime/src/congestion_control.rs
@@ -3,7 +3,7 @@ use crate::config::{
 };
 use crate::ApplyState;
 use near_parameters::{ActionCosts, RuntimeConfig};
-use near_primitives::congestion_info::{CongestionInfo, CongestionInfoV1};
+use near_primitives::congestion_info::{CongestionInfo, CongestionInfoV1, ExtendedCongestionInfo};
 use near_primitives::errors::{IntegerOverflowError, RuntimeError};
 use near_primitives::receipt::{Receipt, ReceiptEnum};
 use near_primitives::types::{EpochInfoProvider, Gas, ShardId};
@@ -36,7 +36,7 @@ pub(crate) struct ReceiptSinkV1<'a> {
 /// receiving shard and stopping us from sending more receipts to it than its
 /// nodes can keep in memory.
 pub(crate) struct ReceiptSinkV2<'a> {
-    pub(crate) congestion_info: &'a mut CongestionInfo,
+    pub(crate) congestion_info: &'a mut ExtendedCongestionInfo,
     pub(crate) outgoing_receipts: &'a mut Vec<Receipt>,
     pub(crate) outgoing_limit: HashMap<ShardId, Gas>,
     pub(crate) outgoing_buffers: ShardsOutgoingReceiptBuffer,
@@ -52,7 +52,7 @@ impl<'a> ReceiptSink<'a> {
         protocol_version: ProtocolVersion,
         trie: &dyn TrieAccess,
         apply_state: &ApplyState,
-        congestion_info: &'a mut Option<CongestionInfo>,
+        congestion_info: &'a mut Option<ExtendedCongestionInfo>,
         outgoing_receipts: &'a mut Vec<Receipt>,
     ) -> Result<Self, StorageError> {
         if let Some(ref mut congestion_info) = congestion_info {

--- a/runtime/runtime/src/metrics.rs
+++ b/runtime/runtime/src/metrics.rs
@@ -5,7 +5,7 @@ use near_o11y::metrics::{
     try_create_int_counter_vec, try_create_int_gauge_vec, CounterVec, GaugeVec, Histogram,
     HistogramVec, IntCounter, IntCounterVec, IntGaugeVec,
 };
-use near_primitives::congestion_info::CongestionInfo;
+use near_primitives::congestion_info::{CongestionInfo, ExtendedCongestionInfo};
 use near_primitives::types::ShardId;
 use once_cell::sync::Lazy;
 use std::time::Duration;
@@ -631,11 +631,11 @@ pub fn report_congestion_metrics(receipt_sink: &ReceiptSink, sender_shard_id: Sh
 }
 
 /// Report key congestion indicator levels of a shard.
-fn report_congestion_indicators(congestion_info: &CongestionInfo, shard_label: &str) {
+fn report_congestion_indicators(congestion_info: &ExtendedCongestionInfo, shard_label: &str) {
     let congestion_level = congestion_info.congestion_level();
     CONGESTION_LEVEL.with_label_values(&[shard_label]).set(congestion_level);
 
-    let CongestionInfo::V1(inner) = congestion_info;
+    let CongestionInfo::V1(inner) = congestion_info.congestion_info();
     CONGESTION_RECEIPT_BYTES
         .with_label_values(&[shard_label])
         .set(inner.receipt_bytes.try_into().unwrap_or(i64::MAX));

--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -2,7 +2,7 @@ use near_chain_configs::{get_initial_supply, Genesis, GenesisConfig, GenesisReco
 use near_crypto::{InMemorySigner, KeyType};
 use near_parameters::ActionCosts;
 use near_primitives::account::{AccessKey, Account};
-use near_primitives::congestion_info::CongestionInfo;
+use near_primitives::congestion_info::ExtendedCongestionInfo;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::receipt::Receipt;
 use near_primitives::runtime::migration_data::{MigrationData, MigrationFlags};
@@ -93,7 +93,7 @@ impl StandaloneRuntime {
             .config
             .shard_layout
             .shard_ids()
-            .map(|shard_id| (shard_id, CongestionInfo::default()))
+            .map(|shard_id| (shard_id, ExtendedCongestionInfo::default()))
             .collect();
 
         let apply_state = ApplyState {


### PR DESCRIPTION
When there are multiple missing chunks in a row in a shard we want to consider that shard as congested. That is in order to prevent outgoing receipts to that shard accumulating and then blowing up the state witness size. 

I decided to not embed the information about missing chunks in the congestion info but rather I added a new struct called ExtendedCongestionInfo. The Block now constructs congestion info, extends it with the information about missing chunks and provides this new struct to the runtime. 

Since from now the congestion level cannot be calculated without the missing chunks information I added `missing_chunks_count` argument to all methods that rely on the congestion level. That is to make sure the users of those structs do not forget about the missing chunks - compiler will warn them about it. In the runtime the ExtendedCongestionInfo struct acts as a helper to make it as convenient as it used to be. 

The congestion level itself is now a maximum of 4 values - the first three as before and a new one for missing chunks. In this PR I made it so that 10 missed chunks in a row would lead to full congestion - that number is to be adjusted based on data. Other changes can also be considered such as adding the missing chunks congestion to the max of the others. I'm open for suggestions here. 


It's in draft because I still need to add tests for this. 