### PR TITLE
fix(forknet): track all shards on dumper nodes

### DIFF
--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -197,7 +197,8 @@ def _apply_stateless_config(args, node):
     do_update_config(node, 'store.load_mem_tries_for_tracked_shards=true')
     # TODO: Enable saving witness after fixing the performance problems.
     do_update_config(node, 'save_latest_witnesses=false')
-    do_update_config(node, 'tracked_shards=[]')
+    if not node.want_state_dump:
+        do_update_config(node, 'tracked_shards=[]')
     if not args.local_test:
         node.run_cmd(
             "sudo sysctl -w net.core.rmem_max=8388608 && sudo sysctl -w net.core.wmem_max=8388608 && sudo sysctl -w net.ipv4.tcp_rmem='4096 87380 8388608' && sudo sysctl -w net.ipv4.tcp_wmem='4096 16384 8388608' && sudo sysctl -w net.ipv4.tcp_slow_start_after_idle=0"


### PR DESCRIPTION
State dumper node need to track all shards. 