### PR TITLE
fix(forknet) Set snapshot on every epoch for dumper nodes

### DIFF
--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -211,13 +211,16 @@ def _apply_config_changes(node, state_sync_location):
     else:
         changes = {
             'state_sync.sync': {
-                "ExternalStorage": {
-                    "location": state_sync_location
+                'ExternalStorage': {
+                    'location': state_sync_location
                 }
             }
         }
     if node.want_state_dump:
         changes['state_sync.dump.location'] = state_sync_location
+        changes[
+            'store.state_snapshot_config.state_snapshot_type'] = 'EveryEpoch'
+        changes['store.state_snapshot_enabled'] = True
     for key, change in changes.items():
         do_update_config(node, f'{key}={json.dumps(change)}')
 


### PR DESCRIPTION
Node needs to take snapshots every epoch in order to generate state parts.