### PR TITLE
fix(nayduck) - fixing the resharding_rpc_tx nayduck test

### DIFF
--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -795,6 +795,13 @@ pub mod chunk_extra {
         /// for resharding where we only need the state root. This should not be
         /// used as part of regular processing.
         pub fn new_with_only_state_root(state_root: &StateRoot) -> Self {
+            // TODO(congestion_control) - integration with resharding
+            let congestion_control = if ProtocolFeature::CongestionControl.enabled(PROTOCOL_VERSION)
+            {
+                Some(CongestionInfo::default())
+            } else {
+                None
+            };
             Self::new(
                 PROTOCOL_VERSION,
                 state_root,
@@ -803,8 +810,7 @@ pub mod chunk_extra {
                 0,
                 0,
                 0,
-                // TODO(congestion_control) - integration with resharding
-                None,
+                congestion_control,
             )
         }
 

--- a/pytest/tests/sanity/resharding_rpc_tx.py
+++ b/pytest/tests/sanity/resharding_rpc_tx.py
@@ -31,6 +31,10 @@ class ReshardingRpcTx(ReshardingTestBase):
         # test checks the right things.
         super().setUp(epoch_length=20)
 
+        # Print full diff in case of assertion failure. It's handy when the
+        # responses from submit and get transaction differ.
+        self.maxDiff = None
+
     def __setup_account(self, account_id, nonce):
         """ Create an account with full access key and balance. """
         encoded_block_hash = self.node.get_latest_block().hash_bytes
@@ -69,8 +73,13 @@ class ReshardingRpcTx(ReshardingTestBase):
         transfer_response['result']['final_execution_status'] = "IGNORE_ME"
         response['result']['final_execution_status'] = "IGNORE_ME"
 
-        assert response == transfer_response, response
-        pass
+        response = response['result']
+        transfer_response = transfer_response['result']
+
+        # Do not compare receipts_outcome field it may have more values in the
+        # latter response.
+        for key in ['status', 'transaction', 'transaction_outcome']:
+            self.assertEqual(response[key], transfer_response[key])
 
     def test_resharding_rpc_tx(self):
         num_nodes = 2


### PR DESCRIPTION
There were two new issues in this test, fixing both. 
- congestion control was not properly initialized for some feature configuration
- the response had more values in the receipt outcomes