### PR TITLE
Don't run shadow chunk validation when syncing blocks

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1655,6 +1655,10 @@ impl Client {
                 info!(target: "client", "not producing a chunk");
             }
         }
+
+        // Run shadown chunk validation on the new block, unless it's coming from sync.
+        // Syncing has to be fast to catch up with the rest of the chain,
+        // applying the chunks would make the sync unworkably slow.
         if provenance != Provenance::SYNC {
             if let Err(err) = self.shadow_validate_block_chunks(&block) {
                 tracing::error!(

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1655,13 +1655,15 @@ impl Client {
                 info!(target: "client", "not producing a chunk");
             }
         }
-        if let Err(err) = self.shadow_validate_block_chunks(&block) {
-            tracing::error!(
-                target: "client",
-                ?err,
-                block_hash = ?block.hash(),
-                "block chunks shadow validation failed"
-            );
+        if provenance != Provenance::SYNC {
+            if let Err(err) = self.shadow_validate_block_chunks(&block) {
+                tracing::error!(
+                    target: "client",
+                    ?err,
+                    block_hash = ?block.hash(),
+                    "block chunks shadow validation failed"
+                );
+            }
         }
 
         self.shards_manager_adapter


### PR DESCRIPTION
Currently we run shadow validation for every new block, even if we're only syncing up to reach the current tip of the chain. This causes sync to be extremely slow, as every synced block is applied. Because of that it's often faster to setup a new node from scratch rather than wait for a node to sync.

Let's not run shadow validation when syncing, it'll make it possible to catch up with the rest of the network in a reasonable amount of time.