### PR TITLE
fix(congestion): correct trie key for buffered receipts

### DIFF
--- a/core/store/src/trie/receipts_column_helper.rs
+++ b/core/store/src/trie/receipts_column_helper.rs
@@ -246,7 +246,7 @@ impl TrieQueue for OutgoingReceiptBuffer<'_> {
     }
 
     fn trie_key(&self, index: u64) -> TrieKey {
-        TrieKey::DelayedReceipt { index }
+        TrieKey::BufferedReceipt { index, receiving_shard: self.shard_id }
     }
 }
 


### PR DESCRIPTION
Somehow this got in wrong, using delayed receipts instead of buffered receipts. Perhaps a rebasing error, perhaps just wrong copy-paste from the beginning...

Anyway, the new tests I'm adding right now are exposing this. But the error is big enough that I think it should be fixed explicitly, not as a drive-by in a number of general tests.