### PR TITLE
[Memtrie] Implement trie iterator based on memtrie.

### DIFF
--- a/chain/chain/src/flat_storage_creator.rs
+++ b/chain/chain/src/flat_storage_creator.rs
@@ -102,7 +102,7 @@ impl FlatStorageShardCreator {
         let path_end = trie.find_state_part_boundary(part_id.idx + 1, part_id.total).unwrap();
         let hex_path_begin = Self::nibbles_to_hex(&path_begin);
         debug!(target: "store", "Preload state part from {hex_path_begin}");
-        let mut trie_iter = trie.iter().unwrap();
+        let mut trie_iter = trie.disk_iter().unwrap();
 
         let mut store_update = store.store_update();
         let mut num_items = 0;

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -557,7 +557,7 @@ pub(crate) fn trie_changes_chunk_extra_exists(
     // 4) Trie should exist for `shard_uid` and the root
     let trie = sv.runtime.get_tries().get_trie_for_shard(*shard_uid, new_root);
     let trie_iterator = unwrap_or_err!(
-        trie.iter(),
+        trie.disk_iter(),
         "Trie Node Missing for shard {:?} root {:?}",
         shard_uid,
         new_root

--- a/chain/chain/src/tests/garbage_collection.rs
+++ b/chain/chain/src/tests/garbage_collection.rs
@@ -221,7 +221,7 @@ fn gc_fork_common(simple_chains: Vec<SimpleChain>, max_changes: usize) {
 
         let mut state_root2 = state_roots2[simple_chain.from as usize];
         let state_root1 = states1[simple_chain.from as usize].1[shard_to_check_trie as usize];
-        tries1.get_trie_for_shard(shard_uid, state_root1).iter().unwrap();
+        tries1.get_trie_for_shard(shard_uid, state_root1).disk_iter().unwrap();
         assert_eq!(state_root1, state_root2);
 
         for i in start_index..start_index + simple_chain.length {
@@ -277,13 +277,13 @@ fn gc_fork_common(simple_chains: Vec<SimpleChain>, max_changes: usize) {
                 );
                 let a = tries1
                     .get_trie_for_shard(shard_uid, state_root1)
-                    .iter()
+                    .disk_iter()
                     .unwrap()
                     .map(|item| item.unwrap().0)
                     .collect::<Vec<_>>();
                 let b = tries2
                     .get_trie_for_shard(shard_uid, state_root1)
-                    .iter()
+                    .disk_iter()
                     .unwrap()
                     .map(|item| item.unwrap().0)
                     .collect::<Vec<_>>();

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -966,8 +966,9 @@ pub fn remove_account(
     state_update.remove(TrieKey::ContractCode { account_id: account_id.clone() });
 
     // Removing access keys
+    let lock = state_update.trie().lock_for_iter();
     let public_keys = state_update
-        .iter(&trie_key_parsers::get_raw_prefix_for_access_keys(account_id))?
+        .locked_iter(&trie_key_parsers::get_raw_prefix_for_access_keys(account_id), &lock)?
         .map(|raw_key| {
             trie_key_parsers::parse_public_key_from_access_key_key(&raw_key?, account_id).map_err(
                 |_e| {
@@ -978,13 +979,16 @@ pub fn remove_account(
             )
         })
         .collect::<Result<Vec<_>, _>>()?;
+    drop(lock);
+
     for public_key in public_keys {
         state_update.remove(TrieKey::AccessKey { account_id: account_id.clone(), public_key });
     }
 
     // Removing contract data
+    let lock = state_update.trie().lock_for_iter();
     let data_keys = state_update
-        .iter(&trie_key_parsers::get_raw_prefix_for_contract_data(account_id, &[]))?
+        .locked_iter(&trie_key_parsers::get_raw_prefix_for_contract_data(account_id, &[]), &lock)?
         .map(|raw_key| {
             trie_key_parsers::parse_data_key_from_contract_data_key(&raw_key?, account_id)
                 .map_err(|_e| {
@@ -995,6 +999,8 @@ pub fn remove_account(
                 .map(Vec::from)
         })
         .collect::<Result<Vec<_>, _>>()?;
+    drop(lock);
+
     for key in data_keys {
         state_update.remove(TrieKey::ContractData { account_id: account_id.clone(), key });
     }

--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -5,16 +5,19 @@ use crate::flat::{
 use crate::metadata::{DbKind, DbVersion, DB_VERSION};
 use crate::{
     get, get_delayed_receipt_indices, get_promise_yield_indices, DBCol, NodeStorage, ShardTries,
-    StateSnapshotConfig, Store, TrieConfig,
+    StateSnapshotConfig, Store, Trie, TrieConfig,
 };
 use itertools::Itertools;
 use near_primitives::account::id::AccountId;
+use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{DataReceipt, PromiseYieldTimeout, Receipt, ReceiptEnum};
-use near_primitives::shard_layout::{ShardUId, ShardVersion};
+use near_primitives::shard_layout::{get_block_shard_uid, ShardUId, ShardVersion};
 use near_primitives::state::FlatStateValue;
 use near_primitives::trie_key::TrieKey;
+use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{NumShards, StateRoot};
+use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use rand::seq::SliceRandom;
 use rand::Rng;
 use std::collections::HashMap;
@@ -99,19 +102,22 @@ impl TestTriesBuilder {
         self
     }
 
-    pub fn with_in_memory_tries(mut self) -> Self {
-        self.enable_in_memory_tries = true;
+    pub fn with_in_memory_tries(mut self, enable: bool) -> Self {
+        self.enable_in_memory_tries = enable;
         self
     }
 
     pub fn build(self) -> ShardTries {
+        if self.enable_in_memory_tries && !self.enable_flat_storage {
+            panic!("In-memory tries require flat storage");
+        }
         let store = self.store.unwrap_or_else(create_test_store);
         let shard_uids = (0..self.num_shards)
             .map(|shard_id| ShardUId { shard_id: shard_id as u32, version: self.shard_version })
             .collect::<Vec<_>>();
         let flat_storage_manager = FlatStorageManager::new(store.clone());
         let tries = ShardTries::new(
-            store,
+            store.clone(),
             TrieConfig {
                 load_mem_tries_for_tracked_shards: self.enable_in_memory_tries,
                 ..Default::default()
@@ -147,6 +153,32 @@ impl TestTriesBuilder {
             }
         }
         if self.enable_in_memory_tries {
+            // ChunkExtra is needed for in-memory trie loading code to query state roots.
+            let congestion_info = ProtocolFeature::CongestionControl
+                .enabled(PROTOCOL_VERSION)
+                .then(CongestionInfo::default);
+            let chunk_extra = ChunkExtra::new(
+                PROTOCOL_VERSION,
+                &Trie::EMPTY_ROOT,
+                CryptoHash::default(),
+                Vec::new(),
+                0,
+                0,
+                0,
+                congestion_info,
+            );
+            let mut update_for_chunk_extra = store.store_update();
+            for shard_uid in &shard_uids {
+                update_for_chunk_extra
+                    .set_ser(
+                        DBCol::ChunkExtra,
+                        &get_block_shard_uid(&CryptoHash::default(), shard_uid),
+                        &chunk_extra,
+                    )
+                    .unwrap();
+            }
+            update_for_chunk_extra.commit().unwrap();
+
             tries.load_mem_tries_for_enabled_shards(&shard_uids).unwrap();
         }
         tries

--- a/core/store/src/trie/iterator.rs
+++ b/core/store/src/trie/iterator.rs
@@ -4,6 +4,8 @@ use crate::trie::nibble_slice::NibbleSlice;
 use crate::trie::{TrieNode, TrieNodeWithSize, ValueHandle};
 use crate::{MissingTrieValueContext, StorageError, Trie};
 
+use super::mem::iter::MemTrieIterator;
+
 /// Crumb is a piece of trie iteration state. It describes a node on the trail and processing status of that node.
 #[derive(Debug)]
 struct Crumb {
@@ -49,7 +51,7 @@ impl Crumb {
 /// currently being processed.
 /// The trail and the key_nibbles may have different lengths e.g. an extension trie node
 /// will add only a single item to the trail but may add multiple nibbles to the key_nibbles.
-pub struct TrieIterator<'a> {
+pub struct DiskTrieIterator<'a> {
     trie: &'a Trie,
     trail: Vec<Crumb>,
     pub(crate) key_nibbles: Vec<u8>,
@@ -82,14 +84,14 @@ pub struct TrieTraversalItem {
     pub key: Option<Vec<u8>>,
 }
 
-impl<'a> TrieIterator<'a> {
+impl<'a> DiskTrieIterator<'a> {
     #![allow(clippy::new_ret_no_self)]
     /// Create a new iterator.
     pub(super) fn new(
         trie: &'a Trie,
         prune_condition: Option<Box<dyn Fn(&Vec<u8>) -> bool>>,
     ) -> Result<Self, StorageError> {
-        let mut r = TrieIterator {
+        let mut r = DiskTrieIterator {
             trie,
             trail: Vec::with_capacity(8),
             key_nibbles: Vec::with_capacity(64),
@@ -391,7 +393,7 @@ enum IterStep {
     Value(CryptoHash),
 }
 
-impl<'a> Iterator for TrieIterator<'a> {
+impl<'a> Iterator for DiskTrieIterator<'a> {
     type Item = Result<TrieItem, StorageError>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -424,19 +426,42 @@ impl<'a> Iterator for TrieIterator<'a> {
     }
 }
 
+pub enum TrieIterator<'a> {
+    Disk(DiskTrieIterator<'a>),
+    Memtrie(MemTrieIterator<'a>),
+}
+
+impl<'a> Iterator for TrieIterator<'a> {
+    type Item = Result<TrieItem, StorageError>;
+
+    fn next(&mut self) -> Option<Result<TrieItem, StorageError>> {
+        match self {
+            TrieIterator::Disk(iter) => iter.next(),
+            TrieIterator::Memtrie(iter) => iter.next(),
+        }
+    }
+}
+
+impl<'a> TrieIterator<'a> {
+    pub fn seek_prefix<K: AsRef<[u8]>>(&mut self, key: K) -> Result<(), StorageError> {
+        match self {
+            TrieIterator::Disk(iter) => iter.seek_prefix(key),
+            TrieIterator::Memtrie(iter) => Ok(iter.seek_prefix(key)),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-
-    use itertools::Itertools;
-    use rand::seq::SliceRandom;
-    use rand::Rng;
-
     use crate::test_utils::{gen_changes, simplify_changes, test_populate_trie, TestTriesBuilder};
     use crate::trie::iterator::IterStep;
     use crate::trie::nibble_slice::NibbleSlice;
     use crate::Trie;
+    use itertools::Itertools;
     use near_primitives::shard_layout::ShardUId;
+    use rand::seq::SliceRandom;
+    use rand::Rng;
+    use std::collections::BTreeMap;
 
     fn value() -> Option<Vec<u8>> {
         Some(vec![0])
@@ -453,43 +478,59 @@ mod tests {
         let trie = tries.get_trie_for_shard(ShardUId::single_shard(), state_root);
         let path_begin: Vec<_> = NibbleSlice::new(b"aa").iter().collect();
         let path_end: Vec<_> = NibbleSlice::new(b"abb").iter().collect();
-        let mut trie_iter = trie.iter().unwrap();
+        let mut trie_iter = trie.disk_iter().unwrap();
         let items = trie_iter.visit_nodes_interval(&path_begin, &path_end).unwrap();
         let trie_items: Vec<_> = items.into_iter().map(|item| item.key).flatten().collect();
         assert_eq!(trie_items, vec![b"aa"]);
     }
 
-    #[test]
-    fn test_iterator() {
+    fn test_iterator(use_memtries: bool) {
         let mut rng = rand::thread_rng();
         for _ in 0..100 {
-            let (trie_changes, map, trie) = gen_random_trie(&mut rng);
+            let (trie_changes, map, trie) = gen_random_trie(&mut rng, use_memtries);
 
             {
-                let result1: Vec<_> = trie.iter().unwrap().map(Result::unwrap).collect();
+                let lock = trie.lock_for_iter();
+                let iter = lock.iter().unwrap();
+                if use_memtries {
+                    assert!(matches!(iter, crate::trie::iterator::TrieIterator::Memtrie(_)));
+                } else {
+                    assert!(matches!(iter, crate::trie::iterator::TrieIterator::Disk(_)));
+                }
+                let result1: Vec<_> = iter.map(Result::unwrap).collect();
                 let result2: Vec<_> = map.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
                 assert_eq!(result1, result2);
             }
-            test_seek_prefix(&trie, &map, &[]);
+            test_seek_prefix(&trie, &map, &[], use_memtries);
 
             for (seek_key, _) in trie_changes.iter() {
-                test_seek_prefix(&trie, &map, seek_key);
+                test_seek_prefix(&trie, &map, seek_key, use_memtries);
             }
             for _ in 0..20 {
                 let alphabet = &b"abcdefgh"[0..rng.gen_range(2..8)];
                 let key_length = rng.gen_range(1..8);
                 let seek_key: Vec<u8> =
                     (0..key_length).map(|_| *alphabet.choose(&mut rng).unwrap()).collect();
-                test_seek_prefix(&trie, &map, &seek_key);
+                test_seek_prefix(&trie, &map, &seek_key, use_memtries);
             }
         }
+    }
+
+    #[test]
+    fn test_disk_iterator() {
+        test_iterator(false);
+    }
+
+    #[test]
+    fn test_memtrie_iterator() {
+        test_iterator(true);
     }
 
     #[test]
     fn test_iterator_with_prune_condition_base() {
         let mut rng = rand::thread_rng();
         for _ in 0..100 {
-            let (trie_changes, map, trie) = gen_random_trie(&mut rng);
+            let (trie_changes, map, trie) = gen_random_trie(&mut rng, false);
 
             // Check that pruning just one key (and it's subtree) works as expected.
             for (prune_key, _) in &trie_changes {
@@ -499,7 +540,7 @@ mod tests {
                     move |key_nibbles: &Vec<u8>| key_nibbles.starts_with(&prune_key_nibbles);
 
                 let result1 = trie
-                    .iter_with_prune_condition(Some(Box::new(prune_condition.clone())))
+                    .disk_iter_with_prune_condition(Some(Box::new(prune_condition.clone())))
                     .unwrap()
                     .map(Result::unwrap)
                     .collect_vec();
@@ -525,7 +566,7 @@ mod tests {
     fn test_iterator_with_prune_condition_subtree() {
         let mut rng = rand::thread_rng();
         for _ in 0..100 {
-            let (trie_changes, map, trie) = gen_random_trie(&mut rng);
+            let (trie_changes, map, trie) = gen_random_trie(&mut rng, false);
 
             // Test pruning by all keys that are present in the trie.
             for (prune_key, _) in &trie_changes {
@@ -542,7 +583,7 @@ mod tests {
                     move |key_nibbles: &Vec<u8>| key_nibbles.starts_with(&prune_key_nibbles);
 
                 let result1 = trie
-                    .iter_with_prune_condition(Some(Box::new(prune_condition.clone())))
+                    .disk_iter_with_prune_condition(Some(Box::new(prune_condition.clone())))
                     .unwrap()
                     .map(Result::unwrap)
                     .collect_vec();
@@ -572,7 +613,7 @@ mod tests {
         let trie_changes = keys.iter().map(|key| (key.clone(), value())).collect();
         let state_root = test_populate_trie(&tries, &Trie::EMPTY_ROOT, shard_uid, trie_changes);
         let trie = tries.get_trie_for_shard(shard_uid, state_root);
-        let iter = trie.iter_with_max_depth(max_depth).unwrap();
+        let iter = trie.disk_iter_with_max_depth(max_depth).unwrap();
         let keys: Vec<_> = iter.map(|item| item.unwrap().0).collect();
 
         assert_eq!(&keys, pruned_keys);
@@ -610,8 +651,13 @@ mod tests {
 
     fn gen_random_trie(
         rng: &mut rand::rngs::ThreadRng,
+        use_memtries: bool,
     ) -> (Vec<(Vec<u8>, Option<Vec<u8>>)>, BTreeMap<Vec<u8>, Vec<u8>>, Trie) {
-        let tries = TestTriesBuilder::new().with_shard_layout(1, 2).build();
+        let tries = TestTriesBuilder::new()
+            .with_shard_layout(1, 2)
+            .with_flat_storage(use_memtries)
+            .with_in_memory_tries(use_memtries)
+            .build();
         let shard_uid = ShardUId { version: 1, shard_id: 0 };
         let trie_changes = gen_changes(rng, 10);
         let trie_changes = simplify_changes(&trie_changes);
@@ -628,8 +674,19 @@ mod tests {
         (trie_changes, map, trie)
     }
 
-    fn test_seek_prefix(trie: &Trie, map: &BTreeMap<Vec<u8>, Vec<u8>>, seek_key: &[u8]) {
-        let mut iterator = trie.iter().unwrap();
+    fn test_seek_prefix(
+        trie: &Trie,
+        map: &BTreeMap<Vec<u8>, Vec<u8>>,
+        seek_key: &[u8],
+        is_memtrie: bool,
+    ) {
+        let lock = trie.lock_for_iter();
+        let mut iterator = lock.iter().unwrap();
+        if is_memtrie {
+            assert!(matches!(iterator, crate::trie::iterator::TrieIterator::Memtrie(_)));
+        } else {
+            assert!(matches!(iterator, crate::trie::iterator::TrieIterator::Disk(_)));
+        }
         iterator.seek_prefix(&seek_key).unwrap();
         let mut got = Vec::with_capacity(5);
         for item in iterator {
@@ -662,7 +719,7 @@ mod tests {
                 trie_changes.clone(),
             );
             let trie = tries.get_trie_for_shard(ShardUId::single_shard(), state_root);
-            let mut iterator = trie.iter().unwrap();
+            let mut iterator = trie.disk_iter().unwrap();
             loop {
                 let iter_step = match iterator.iter_step() {
                     Some(iter_step) => iter_step,

--- a/core/store/src/trie/mem/iter.rs
+++ b/core/store/src/trie/mem/iter.rs
@@ -1,3 +1,15 @@
+//! Iterator that traverses a memtrie in key order.
+//!
+//! This is essentially a copy of the `DiskTrieIterator`, with the following notable differences:
+//!  - It doesn't support extra options like remembering nodes or puning;
+//!  - It uses None to represent an "empty" placeholder node rather than `TrieNode::Empty`;
+//!  - MemTrieNodeView splits Branch and BranchWithValue into separate variants, whereas TrieNode
+//!    handles them in a single variant with an optional value field, but the iteration logic
+//!    remains the same.
+//!  - Memtrie code paths don't return any errors, except when looking up the value from the State
+//!    column.
+//!
+//! Testing of the `MemTrieIterator` is done together by tests of `DiskTrieIterator`.
 use super::node::{MemTrieNodePtr, MemTrieNodeView};
 use crate::{
     trie::{iterator::TrieItem, OptimizedValueRef},

--- a/core/store/src/trie/mem/iter.rs
+++ b/core/store/src/trie/mem/iter.rs
@@ -1,0 +1,261 @@
+use super::node::{MemTrieNodePtr, MemTrieNodeView};
+use crate::{
+    trie::{iterator::TrieItem, OptimizedValueRef},
+    NibbleSlice,
+};
+use near_primitives::errors::StorageError;
+
+/// Crumb is a piece of trie iteration state. It describes a node on the trail and processing status of that node.
+#[derive(Debug)]
+struct Crumb<'a> {
+    node: Option<MemTrieNodeView<'a>>,
+    status: CrumbStatus,
+    prefix_boundary: bool,
+}
+
+/// The status of processing of a node during trie iteration.
+/// Each node is processed in the following order:
+/// Entering -> At -> AtChild(0) -> ... -> AtChild(15) -> Exiting
+#[derive(Debug, Clone, Copy)]
+enum CrumbStatus {
+    Entering,
+    At,
+    AtChild(u8),
+    Exiting,
+}
+
+impl<'a> Crumb<'a> {
+    fn increment(&mut self) {
+        if self.prefix_boundary {
+            self.status = CrumbStatus::Exiting;
+            return;
+        }
+        self.status = match (&self.status, &self.node) {
+            (_, None) => CrumbStatus::Exiting,
+            (&CrumbStatus::Entering, _) => CrumbStatus::At,
+            (&CrumbStatus::At, Some(MemTrieNodeView::Branch { .. })) => CrumbStatus::AtChild(0),
+            (&CrumbStatus::At, Some(MemTrieNodeView::BranchWithValue { .. })) => {
+                CrumbStatus::AtChild(0)
+            }
+            (&CrumbStatus::AtChild(x), Some(MemTrieNodeView::Branch { .. })) if x < 15 => {
+                CrumbStatus::AtChild(x + 1)
+            }
+            (&CrumbStatus::AtChild(x), Some(MemTrieNodeView::BranchWithValue { .. })) if x < 15 => {
+                CrumbStatus::AtChild(x + 1)
+            }
+            _ => CrumbStatus::Exiting,
+        }
+    }
+}
+
+/// Trie iteration is done using a stack based approach.
+/// There are two stacks that we track while iterating: the trail and the key_nibbles.
+/// The trail is a vector of trie nodes on the path from root node to the node that is
+/// currently being processed together with processing status - the Crumb.
+/// The key_nibbles is a vector of nibbles from the state root node to the node that is
+/// currently being processed.
+/// The trail and the key_nibbles may have different lengths e.g. an extension trie node
+/// will add only a single item to the trail but may add multiple nibbles to the key_nibbles.
+
+pub struct MemTrieIterator<'a> {
+    root: Option<MemTrieNodePtr<'a>>,
+    trail: Vec<Crumb<'a>>,
+    key_nibbles: Vec<u8>,
+
+    /// Memtrie does not store large values, so we need to fetch them from the State column.
+    /// This function allows us to do that.
+    value_getter: Box<dyn Fn(OptimizedValueRef) -> Result<Vec<u8>, StorageError> + 'a>,
+}
+
+impl<'a> MemTrieIterator<'a> {
+    /// Create a new iterator.
+    pub fn new(
+        root: Option<MemTrieNodePtr<'a>>,
+        value_getter: Box<dyn Fn(OptimizedValueRef) -> Result<Vec<u8>, StorageError> + 'a>,
+    ) -> Self {
+        let mut r =
+            MemTrieIterator { root, trail: Vec::new(), key_nibbles: Vec::new(), value_getter };
+        r.descend_into_node(root);
+        r
+    }
+
+    /// Position the iterator on the first element with key >= `key`.
+    pub fn seek_prefix<K: AsRef<[u8]>>(&mut self, key: K) {
+        self.seek_nibble_slice(NibbleSlice::new(key.as_ref()), true);
+    }
+
+    /// Returns the hash of the last node.
+    pub(crate) fn seek_nibble_slice(
+        &mut self,
+        mut key: NibbleSlice<'_>,
+        is_prefix_seek: bool,
+    ) -> Option<MemTrieNodePtr<'a>> {
+        self.trail.clear();
+        self.key_nibbles.clear();
+        // Checks if a key in an extension or leaf matches our search query.
+        //
+        // When doing prefix seek, this checks whether `key` is a prefix of
+        // `ext_key`.  When doing regular range seek, this checks whether `key`
+        // is no greater than `ext_key`.  If those conditions aren’t met, the
+        // node with `ext_key` should not match our query.
+        let check_ext_key = |key: &NibbleSlice, ext_key: &NibbleSlice| {
+            if is_prefix_seek {
+                ext_key.starts_with(key)
+            } else {
+                ext_key >= key
+            }
+        };
+
+        let mut ptr = self.root;
+        let mut prev_prefix_boundary = &mut false;
+        loop {
+            *prev_prefix_boundary = is_prefix_seek;
+            self.descend_into_node(ptr);
+            let Crumb { status, node, prefix_boundary } = self.trail.last_mut().unwrap();
+            prev_prefix_boundary = prefix_boundary;
+            match &node {
+                None => break,
+                Some(MemTrieNodeView::Leaf { extension, .. }) => {
+                    let existing_key = NibbleSlice::from_encoded(extension.raw_slice()).0;
+                    if !check_ext_key(&key, &existing_key) {
+                        self.key_nibbles.extend(existing_key.iter());
+                        *status = CrumbStatus::Exiting;
+                    }
+                    break;
+                }
+                Some(MemTrieNodeView::Branch { children, .. })
+                | Some(MemTrieNodeView::BranchWithValue { children, .. }) => {
+                    if key.is_empty() {
+                        break;
+                    }
+                    let idx = key.at(0);
+                    self.key_nibbles.push(idx);
+                    *status = CrumbStatus::AtChild(idx);
+                    if let Some(child) = children.get(idx as usize) {
+                        ptr = Some(child);
+                        key = key.mid(1);
+                    } else {
+                        *prefix_boundary = is_prefix_seek;
+                        break;
+                    }
+                }
+                Some(MemTrieNodeView::Extension { extension, child, .. }) => {
+                    let existing_key = NibbleSlice::from_encoded(extension.raw_slice()).0;
+                    if key.starts_with(&existing_key) {
+                        key = key.mid(existing_key.len());
+                        ptr = Some(*child);
+                        *status = CrumbStatus::At;
+                        self.key_nibbles.extend(existing_key.iter());
+                    } else {
+                        if !check_ext_key(&key, &existing_key) {
+                            *status = CrumbStatus::Exiting;
+                            self.key_nibbles.extend(existing_key.iter());
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        ptr
+    }
+
+    /// Fetches node by its ptr and adds it to the trail.
+    ///
+    /// The node is stored as the last [`Crumb`] in the trail.
+    fn descend_into_node(&mut self, ptr: Option<MemTrieNodePtr<'a>>) {
+        let node = ptr.map(|ptr| ptr.view());
+        self.trail.push(Crumb { status: CrumbStatus::Entering, node, prefix_boundary: false });
+    }
+
+    fn key(&self) -> Vec<u8> {
+        let mut result = <Vec<u8>>::with_capacity(self.key_nibbles.len() / 2);
+        for i in (1..self.key_nibbles.len()).step_by(2) {
+            result.push(self.key_nibbles[i - 1] * 16 + self.key_nibbles[i]);
+        }
+        result
+    }
+
+    /// Calculates the next step of the iteration.
+    fn iter_step(&mut self) -> Option<IterStep<'a>> {
+        let last = self.trail.last_mut()?;
+        last.increment();
+        Some(match (last.status, &last.node) {
+            (CrumbStatus::Exiting, n) => {
+                match n {
+                    Some(MemTrieNodeView::Leaf { extension, .. })
+                    | Some(MemTrieNodeView::Extension { extension, .. }) => {
+                        let existing_key = NibbleSlice::from_encoded(extension.raw_slice()).0;
+                        let l = self.key_nibbles.len();
+                        self.key_nibbles.truncate(l - existing_key.len());
+                    }
+                    Some(MemTrieNodeView::Branch { .. })
+                    | Some(MemTrieNodeView::BranchWithValue { .. }) => {
+                        self.key_nibbles.pop();
+                    }
+                    _ => {}
+                }
+                IterStep::PopTrail
+            }
+            (CrumbStatus::At, Some(MemTrieNodeView::BranchWithValue { value, .. })) => {
+                IterStep::Value(value.to_optimized_value_ref())
+            }
+            (CrumbStatus::At, Some(MemTrieNodeView::Branch { .. })) => IterStep::Continue,
+            (CrumbStatus::At, Some(MemTrieNodeView::Leaf { extension, value })) => {
+                let key = NibbleSlice::from_encoded(extension.raw_slice()).0;
+                self.key_nibbles.extend(key.iter());
+                IterStep::Value(value.to_optimized_value_ref())
+            }
+            (CrumbStatus::At, Some(MemTrieNodeView::Extension { extension, child, .. })) => {
+                let key = NibbleSlice::from_encoded(extension.raw_slice()).0;
+                self.key_nibbles.extend(key.iter());
+                IterStep::Descend(*child)
+            }
+            (CrumbStatus::AtChild(i), Some(MemTrieNodeView::Branch { children, .. }))
+            | (CrumbStatus::AtChild(i), Some(MemTrieNodeView::BranchWithValue { children, .. })) => {
+                if i == 0 {
+                    self.key_nibbles.push(0);
+                }
+                if let Some(ref child) = children.get(i as usize) {
+                    if i != 0 {
+                        *self.key_nibbles.last_mut().expect("Pushed child value before") = i;
+                    }
+                    IterStep::Descend(*child)
+                } else {
+                    IterStep::Continue
+                }
+            }
+            _ => panic!("Should never see Entering or AtChild without a Branch here."),
+        })
+    }
+}
+
+#[derive(Debug)]
+enum IterStep<'a> {
+    Continue,
+    PopTrail,
+    Descend(MemTrieNodePtr<'a>),
+    Value(OptimizedValueRef),
+}
+
+impl<'a> Iterator for MemTrieIterator<'a> {
+    type Item = Result<TrieItem, StorageError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let iter_step = self.iter_step()?;
+
+            match iter_step {
+                IterStep::Continue => {}
+                IterStep::PopTrail => {
+                    self.trail.pop();
+                }
+                IterStep::Descend(ptr) => {
+                    self.descend_into_node(Some(ptr));
+                }
+                IterStep::Value(value_ref) => {
+                    return Some((self.value_getter)(value_ref).map(|value| (self.key(), value)))
+                }
+            }
+        }
+    }
+}

--- a/core/store/src/trie/mem/mod.rs
+++ b/core/store/src/trie/mem/mod.rs
@@ -11,6 +11,7 @@ use std::collections::{BTreeMap, HashMap};
 mod arena;
 mod construction;
 pub(crate) mod flexible_data;
+pub mod iter;
 pub mod loading;
 pub mod lookup;
 pub mod metrics;

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -1,5 +1,7 @@
 use self::accounting_cache::TrieAccountingCache;
+use self::iterator::DiskTrieIterator;
 use self::mem::flexible_data::value::ValueView;
+use self::mem::iter::MemTrieIterator;
 use self::mem::lookup::memtrie_lookup;
 use self::mem::updating::{UpdatedMemTrieNode, UpdatedMemTrieNodeId};
 use self::mem::MemTries;
@@ -38,7 +40,7 @@ use std::fmt::Write;
 use std::hash::Hash;
 use std::rc::Rc;
 use std::str;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, RwLock, RwLockReadGuard};
 
 pub mod accounting_cache;
 mod config;
@@ -912,7 +914,7 @@ impl Trie {
             Self::should_prune_view_trie(&partial_key, record_type, &from.as_ref(), &to.as_ref())
         };
 
-        let iter = match self.iter_with_prune_condition(Some(Box::new(prune_condition))) {
+        let iter = match self.disk_iter_with_prune_condition(Some(Box::new(prune_condition))) {
             Ok(iter) => iter,
             Err(err) => {
                 writeln!(f, "Error when getting the trie iterator: {}", err).expect("write failed");
@@ -1610,29 +1612,73 @@ impl Trie {
         }
     }
 
-    pub fn iter<'a>(&'a self) -> Result<TrieIterator<'a>, StorageError> {
-        TrieIterator::new(self, None)
+    /// Returns an iterator that can be used to traverse any range in the trie.
+    /// This only uses the on-disk trie. If memtrie iteration is desired, see
+    /// `lock_for_iter`.
+    pub fn disk_iter(&self) -> Result<DiskTrieIterator<'_>, StorageError> {
+        DiskTrieIterator::new(self, None)
     }
 
-    pub fn iter_with_max_depth<'a>(
+    pub fn disk_iter_with_max_depth<'a>(
         &'a self,
         max_depth: usize,
-    ) -> Result<TrieIterator<'a>, StorageError> {
-        TrieIterator::new(
+    ) -> Result<DiskTrieIterator<'a>, StorageError> {
+        DiskTrieIterator::new(
             self,
             Some(Box::new(move |key_nibbles: &Vec<u8>| key_nibbles.len() > max_depth)),
         )
     }
 
-    pub fn iter_with_prune_condition<'a>(
+    pub fn disk_iter_with_prune_condition<'a>(
         &'a self,
         prune_condition: Option<Box<dyn Fn(&Vec<u8>) -> bool>>,
-    ) -> Result<TrieIterator<'a>, StorageError> {
-        TrieIterator::new(self, prune_condition)
+    ) -> Result<DiskTrieIterator<'a>, StorageError> {
+        DiskTrieIterator::new(self, prune_condition)
+    }
+
+    /// Grabs a read lock on the trie, so that a memtrie iterator can be
+    /// constructed afterward. This is needed because memtries are not
+    /// thread-safe.
+    pub fn lock_for_iter(&self) -> TrieWithReadLock<'_> {
+        TrieWithReadLock { trie: self, memtries: self.memtries.as_ref().map(|m| m.read().unwrap()) }
     }
 
     pub fn get_trie_nodes_count(&self) -> TrieNodesCount {
         self.accounting_cache.borrow().get_trie_nodes_count()
+    }
+}
+
+/// A wrapper around `Trie`, but holding a read lock on memtries if they are present.
+/// This is needed to construct an memtrie iterator, as memtries are not thread-safe.
+pub struct TrieWithReadLock<'a> {
+    trie: &'a Trie,
+    memtries: Option<RwLockReadGuard<'a, MemTries>>,
+}
+
+impl<'a> TrieWithReadLock<'a> {
+    /// Obtains an iterator that can be used to traverse any range in the trie.
+    /// If memtries are present, returns an iterator that traverses the memtrie.
+    /// Otherwise, it falls back to an iterator that traverses the on-disk trie.
+    pub fn iter(&self) -> Result<TrieIterator<'_>, StorageError> {
+        match &self.memtries {
+            Some(memtries) => {
+                let root = if self.trie.root == CryptoHash::default() {
+                    None
+                } else {
+                    Some(memtries.get_root(&self.trie.root).ok_or_else(|| {
+                        StorageError::StorageInconsistentState(format!(
+                            "Failed to find root node {} in memtrie",
+                            self.trie.root
+                        ))
+                    })?)
+                };
+                Ok(TrieIterator::Memtrie(MemTrieIterator::new(
+                    root,
+                    Box::new(|value_ref| self.trie.deref_optimized(&value_ref)),
+                )))
+            }
+            None => Ok(TrieIterator::Disk(DiskTrieIterator::new(self.trie, None)?)),
+        }
     }
 }
 
@@ -1744,7 +1790,7 @@ mod tests {
         let root = test_populate_trie(&tries, &Trie::EMPTY_ROOT, shard_uid, changes.clone());
         let new_root = test_clear_trie(&tries, &root, shard_uid, changes);
         assert_eq!(new_root, Trie::EMPTY_ROOT);
-        assert_eq!(trie.iter().unwrap().fold(0, |acc, _| acc + 1), 0);
+        assert_eq!(trie.disk_iter().unwrap().fold(0, |acc, _| acc + 1), 0);
     }
 
     #[test]
@@ -1760,17 +1806,17 @@ mod tests {
         let root = test_populate_trie(&tries, &Trie::EMPTY_ROOT, shard_uid, pairs.clone());
         let trie = tries.get_trie_for_shard(shard_uid, root);
         let mut iter_pairs = vec![];
-        for pair in trie.iter().unwrap() {
+        for pair in trie.disk_iter().unwrap() {
             let (key, value) = pair.unwrap();
             iter_pairs.push((key, Some(value.to_vec())));
         }
         assert_eq!(pairs, iter_pairs);
 
-        let assert_has_next = |want, other_iter: &mut TrieIterator| {
+        let assert_has_next = |want, other_iter: &mut DiskTrieIterator| {
             assert_eq!(Some(want), other_iter.next().map(|item| item.unwrap().0).as_deref());
         };
 
-        let mut other_iter = trie.iter().unwrap();
+        let mut other_iter = trie.disk_iter().unwrap();
         other_iter.seek_prefix(b"r").unwrap();
         assert_eq!(other_iter.next(), None);
         other_iter.seek_prefix(b"x").unwrap();
@@ -1829,7 +1875,7 @@ mod tests {
         ];
         let root = test_populate_trie(&tries, &Trie::EMPTY_ROOT, ShardUId::single_shard(), changes);
         let trie = tries.get_trie_for_shard(ShardUId::single_shard(), root);
-        let mut iter = trie.iter().unwrap();
+        let mut iter = trie.disk_iter().unwrap();
         iter.seek_prefix(&[0, 116, 101, 115, 116, 44]).unwrap();
         let mut pairs = vec![];
         for pair in iter {
@@ -1866,7 +1912,7 @@ mod tests {
         ];
         let root = test_populate_trie(&tries, &root, ShardUId::single_shard(), changes);
         let trie = tries.get_trie_for_shard(ShardUId::single_shard(), root);
-        for r in trie.iter().unwrap() {
+        for r in trie.disk_iter().unwrap() {
             r.unwrap();
         }
     }
@@ -1917,7 +1963,7 @@ mod tests {
         ];
         let tries = TestTriesBuilder::new().build();
         let root = test_populate_trie(&tries, &Trie::EMPTY_ROOT, ShardUId::single_shard(), initial);
-        tries.get_trie_for_shard(ShardUId::single_shard(), root).iter().unwrap().for_each(
+        tries.get_trie_for_shard(ShardUId::single_shard(), root).disk_iter().unwrap().for_each(
             |result| {
                 result.unwrap();
             },
@@ -1925,7 +1971,7 @@ mod tests {
 
         let changes = vec![(vec![1, 2, 3], None)];
         let root = test_populate_trie(&tries, &root, ShardUId::single_shard(), changes);
-        tries.get_trie_for_shard(ShardUId::single_shard(), root).iter().unwrap().for_each(
+        tries.get_trie_for_shard(ShardUId::single_shard(), root).disk_iter().unwrap().for_each(
             |result| {
                 result.unwrap();
             },
@@ -1974,7 +2020,7 @@ mod tests {
             {
                 if let Some(value) = value {
                     let want = Some(Ok((key.clone(), value)));
-                    let mut iterator = trie.iter().unwrap();
+                    let mut iterator = trie.disk_iter().unwrap();
                     iterator.seek_prefix(&key).unwrap();
                     assert_eq!(want, iterator.next(), "key: {key:x?}");
                 }
@@ -1983,7 +2029,7 @@ mod tests {
             // Test some more random keys.
             let queries = gen_changes(&mut rng, 500).into_iter().map(|(key, _)| key);
             for query in queries {
-                let mut iterator = trie.iter().unwrap();
+                let mut iterator = trie.disk_iter().unwrap();
                 iterator.seek_prefix(&query).unwrap();
                 if let Some(Ok((key, _))) = iterator.next() {
                     assert!(key.starts_with(&query), "‘{key:x?}’ does not start with ‘{query:x?}’");
@@ -2014,7 +2060,7 @@ mod tests {
 
             let trie = tries.get_trie_for_shard(ShardUId::single_shard(), state_root);
             let trie_changes = trie
-                .iter()
+                .disk_iter()
                 .unwrap()
                 .map(|item| {
                     let (key, _) = item.unwrap();

--- a/core/store/src/trie/resharding.rs
+++ b/core/store/src/trie/resharding.rs
@@ -24,7 +24,7 @@ impl Trie {
     pub fn get_trie_items_for_part(&self, part_id: PartId) -> Result<Vec<TrieItem>, StorageError> {
         let path_begin = self.find_state_part_boundary(part_id.idx, part_id.total)?;
         let path_end = self.find_state_part_boundary(part_id.idx + 1, part_id.total)?;
-        self.iter()?.get_trie_items(&path_begin, &path_end)
+        self.disk_iter()?.get_trie_items(&path_begin, &path_end)
     }
 }
 
@@ -554,11 +554,12 @@ mod tests {
 
                 // check that the 4 tries combined to the orig trie
                 let trie = tries.get_trie_for_shard(ShardUId::single_shard(), state_root);
-                let trie_items: HashMap<_, _> = trie.iter().unwrap().map(Result::unwrap).collect();
+                let trie_items: HashMap<_, _> =
+                    trie.disk_iter().unwrap().map(Result::unwrap).collect();
                 let mut combined_trie_items: HashMap<Vec<u8>, Vec<u8>> = HashMap::new();
                 for (shard_uid, state_root) in state_roots.iter() {
                     let trie = tries.get_view_trie_for_shard(*shard_uid, *state_root);
-                    combined_trie_items.extend(trie.iter().unwrap().map(Result::unwrap));
+                    combined_trie_items.extend(trie.disk_iter().unwrap().map(Result::unwrap));
                 }
                 assert_eq!(trie_items, combined_trie_items);
             }

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -320,7 +320,7 @@ impl Trie {
         let path_begin = self.find_state_part_boundary(part_id.idx, part_id.total)?;
         let path_end = self.find_state_part_boundary(part_id.idx + 1, part_id.total)?;
 
-        let mut iterator = self.iter()?;
+        let mut iterator = self.disk_iter()?;
         let nodes_list = iterator.visit_nodes_interval(&path_begin, &path_end)?;
         tracing::debug!(
             target: "state-parts",
@@ -457,7 +457,7 @@ impl Trie {
         let trie = Trie::from_recorded_storage(PartialStorage { nodes: part }, *state_root, false);
         let path_begin = trie.find_state_part_boundary(part_id.idx, part_id.total)?;
         let path_end = trie.find_state_part_boundary(part_id.idx + 1, part_id.total)?;
-        let mut iterator = trie.iter()?;
+        let mut iterator = trie.disk_iter()?;
         let trie_traversal_items = iterator.visit_nodes_interval(&path_begin, &path_end)?;
         let mut refcount_changes = TrieRefcountDeltaMap::new();
         let mut flat_state_delta = FlatStateChanges::default();

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -1,5 +1,5 @@
 pub use self::iterator::TrieUpdateIterator;
-use super::{OptimizedValueRef, Trie};
+use super::{OptimizedValueRef, Trie, TrieWithReadLock};
 use crate::trie::{KeyLookupMode, TrieChanges};
 use crate::{StorageError, TrieStorage};
 use near_primitives::hash::CryptoHash;
@@ -238,7 +238,15 @@ impl TrieUpdate {
 
     /// Returns Error if the underlying storage fails
     pub fn iter(&self, key_prefix: &[u8]) -> Result<TrieUpdateIterator<'_>, StorageError> {
-        TrieUpdateIterator::new(self, key_prefix)
+        TrieUpdateIterator::new(self, key_prefix, None)
+    }
+
+    pub fn locked_iter<'a>(
+        &'a self,
+        key_prefix: &[u8],
+        lock: &'a TrieWithReadLock<'_>,
+    ) -> Result<TrieUpdateIterator<'a>, StorageError> {
+        TrieUpdateIterator::new(self, key_prefix, Some(lock))
     }
 
     pub fn get_root(&self) -> &StateRoot {

--- a/core/store/src/trie/update/iterator.rs
+++ b/core/store/src/trie/update/iterator.rs
@@ -1,7 +1,7 @@
 use std::iter::Peekable;
 use std::ops::Bound;
 
-use crate::trie::update::*;
+use crate::trie::{update::*, TrieWithReadLock};
 use crate::StorageError;
 
 use crate::trie::TrieIterator;
@@ -39,8 +39,15 @@ pub struct TrieUpdateIterator<'a>(Option<(Peekable<TrieIterator<'a>>, Peekable<M
 
 impl<'a> TrieUpdateIterator<'a> {
     #![allow(clippy::new_ret_no_self)]
-    pub fn new(state_update: &'a TrieUpdate, prefix: &[u8]) -> Result<Self, StorageError> {
-        let mut trie_iter = state_update.trie.iter()?;
+    pub fn new(
+        state_update: &'a TrieUpdate,
+        prefix: &[u8],
+        lock: Option<&'a TrieWithReadLock<'_>>,
+    ) -> Result<Self, StorageError> {
+        let mut trie_iter = match lock {
+            Some(lock) => lock.iter()?,
+            None => TrieIterator::Disk(state_update.trie.disk_iter()?),
+        };
         trie_iter.seek_prefix(prefix)?;
 
         let end_bound = make_prefix_range_end_bound(prefix);

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -334,7 +334,7 @@ fn test_flat_storage_creation_start_from_state_part() {
             .map(|part_id| {
                 let path_begin = trie.find_state_part_boundary(part_id, NUM_PARTS).unwrap();
                 let path_end = trie.find_state_part_boundary(part_id + 1, NUM_PARTS).unwrap();
-                let mut trie_iter = trie.iter().unwrap();
+                let mut trie_iter = trie.disk_iter().unwrap();
                 let mut keys = vec![];
                 for item in trie_iter.visit_nodes_interval(&path_begin, &path_end).unwrap() {
                     if let TrieTraversalItem { key: Some(trie_key), .. } = item {

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -57,7 +57,7 @@ fn read_trie_items(bench: &mut Bencher, shard_id: usize, mode: Mode) {
             .unwrap();
         let start = Instant::now();
         let num_items_read = trie
-            .iter()
+            .disk_iter()
             .unwrap()
             .enumerate()
             .map(|(i, _)| {

--- a/nearcore/src/metrics.rs
+++ b/nearcore/src/metrics.rs
@@ -167,7 +167,7 @@ fn get_postponed_receipt_count_for_shard(
 }
 
 fn get_postponed_receipt_count_for_trie(trie: Trie) -> Result<i64, anyhow::Error> {
-    let mut iter = trie.iter()?;
+    let mut iter = trie.disk_iter()?;
     iter.seek_prefix([trie_key::col::POSTPONED_RECEIPT])?;
     let mut count = 0;
     for item in iter {

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -142,7 +142,7 @@ impl TrieViewer {
         let mut values = vec![];
         let query = trie_key_parsers::get_raw_prefix_for_contract_data(account_id, prefix);
         let acc_sep_len = query.len() - prefix.len();
-        let mut iter = state_update.trie().iter()?;
+        let mut iter = state_update.trie().disk_iter()?;
         iter.remember_visited_nodes(include_proof);
         iter.seek_prefix(&query)?;
         for item in &mut iter {

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -329,7 +329,7 @@ impl FlatStorageCommand {
         let flat_state_entries_iter =
             store_helper::iter_flat_state_entries(shard_uid, &hot_store, None, None);
 
-        let trie_iter = trie.iter()?;
+        let trie_iter = trie.disk_iter()?;
         let mut verified = 0;
         let mut success = true;
         for (item_trie, item_flat) in tqdm(std::iter::zip(trie_iter, flat_state_entries_iter)) {
@@ -433,7 +433,7 @@ impl FlatStorageCommand {
         let missing_keys_right_boundary =
             &[near_primitives::trie_key::col::DELAYED_RECEIPT_OR_INDICES + 1];
 
-        let mut prev_iter = trie.iter()?;
+        let mut prev_iter = trie.disk_iter()?;
         let nibbles_left_boundary: Vec<_> =
             near_store::NibbleSlice::new(missing_keys_left_boundary).iter().collect();
         let nibbles_right_boundary: Vec<_> =

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -760,7 +760,7 @@ pub(crate) fn state(home_dir: &Path, near_config: NearConfig, store: Store) {
         let trie = runtime
             .get_trie_for_shard(shard_id as u64, header.prev_hash(), *state_root, false)
             .unwrap();
-        for item in trie.iter().unwrap() {
+        for item in trie.disk_iter().unwrap() {
             let (key, value) = item.unwrap();
             if let Some(state_record) = StateRecord::from_raw_key_value(key, value) {
                 println!("{}", state_record);

--- a/tools/state-viewer/src/contract_accounts.rs
+++ b/tools/state-viewer/src/contract_accounts.rs
@@ -191,7 +191,7 @@ impl ContractAccount {
 
 impl ContractAccountIterator {
     pub(crate) fn new(trie: Trie, filter: ContractAccountFilter) -> anyhow::Result<Self> {
-        let mut trie_iter = trie.iter()?;
+        let mut trie_iter = trie.disk_iter()?;
         // TODO(#8376): Consider changing the interface to TrieKey to make this easier.
         // `TrieKey::ContractCode` requires a valid `AccountId`, we use "xx"
         let key = TrieKey::ContractCode { account_id: "xx".parse()? }.to_vec();
@@ -208,6 +208,7 @@ impl ContractAccountIterator {
 
         // finally, use trie iterator to find all contract nodes
         let vec_of_nodes = trie_iter.visit_nodes_interval(&nibbles_before, &nibbles_after)?;
+        drop(trie_iter);
         let contract_nodes = VecDeque::from(vec_of_nodes);
         Ok(Self { contract_nodes, filter, trie })
     }

--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -146,7 +146,7 @@ pub fn state_dump_redis(
         let trie = runtime
             .get_trie_for_shard(shard_id as u64, last_block_header.prev_hash(), *state_root, false)
             .unwrap();
-        for item in trie.iter().unwrap() {
+        for item in trie.disk_iter().unwrap() {
             let (key, value) = item.unwrap();
             if let Some(sr) = StateRecord::from_raw_key_value(key, value) {
                 if let StateRecord::Account { account_id, account } = &sr {
@@ -236,7 +236,7 @@ fn iterate_over_records(
         let trie = runtime
             .get_trie_for_shard(shard_id as u64, last_block_header.prev_hash(), *state_root, false)
             .unwrap();
-        for item in trie.iter().unwrap() {
+        for item in trie.disk_iter().unwrap() {
             let (key, value) = item.unwrap();
             if let Some(mut sr) = StateRecord::from_raw_key_value(key, value) {
                 if !should_include_record(&sr, &account_allowlist) {

--- a/tools/state-viewer/src/state_parts.rs
+++ b/tools/state-viewer/src/state_parts.rs
@@ -523,7 +523,7 @@ fn get_first_state_record(state_root: &StateRoot, data: &[u8]) -> Option<StateRe
     let trie =
         Trie::from_recorded_storage(PartialStorage { nodes: trie_nodes }, *state_root, false);
 
-    for (key, value) in trie.iter().unwrap().flatten() {
+    for (key, value) in trie.disk_iter().unwrap().flatten() {
         if let Some(sr) = StateRecord::from_raw_key_value(key, value) {
             return Some(sr);
         }

--- a/tools/state-viewer/src/trie_iteration_benchmark.rs
+++ b/tools/state-viewer/src/trie_iteration_benchmark.rs
@@ -164,7 +164,7 @@ impl TrieIterationBenchmarkCmd {
         let start = Instant::now();
         let mut node_count = 0;
         let mut error_count = 0;
-        let iter = trie.iter_with_prune_condition(prune_condition);
+        let iter = trie.disk_iter_with_prune_condition(prune_condition);
         let iter = match iter {
             Ok(iter) => iter,
             Err(err) => {


### PR DESCRIPTION
Closes https://github.com/near/nearcore/issues/11278

This mostly copies from the on-disk trie implementation except adapting it to memtrie data structures. This eliminates the sole remaining disk-trie use during normal validator node operation (when memtrie is enabled), remove_account.

The memtrie implementation requires a different API because there's no way to grab a read lock and construct an iterator at the same time, due to there necessarily being two layers of lifetimes. So whereas we used to have Trie::iter(), we now must have Trie::lock_for_iter() and then use the result to .iter().