### PR TITLE
congestion: balance checker changes

### DIFF
--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -629,17 +629,7 @@ impl Display for InvalidAccessKeyError {
 impl std::error::Error for InvalidAccessKeyError {}
 
 /// Happens when the input balance doesn't match the output balance in Runtime apply.
-#[derive(
-    BorshSerialize,
-    BorshDeserialize,
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    RpcError,
-    serde::Deserialize,
-    serde::Serialize,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, RpcError, serde::Deserialize, serde::Serialize)]
 pub struct BalanceMismatchError {
     // Input balances
     #[serde(with = "dec_format")]
@@ -652,6 +642,10 @@ pub struct BalanceMismatchError {
     pub processed_delayed_receipts_balance: Balance,
     #[serde(with = "dec_format")]
     pub initial_postponed_receipts_balance: Balance,
+    // TODO(congestion_control): remove cfg on stabilization
+    #[cfg(feature = "nightly")]
+    #[serde(with = "dec_format")]
+    pub forwarded_buffered_receipts_balance: Balance,
     // Output balances
     #[serde(with = "dec_format")]
     pub final_accounts_balance: Balance,
@@ -665,6 +659,10 @@ pub struct BalanceMismatchError {
     pub tx_burnt_amount: Balance,
     #[serde(with = "dec_format")]
     pub slashed_burnt_amount: Balance,
+    // TODO(congestion_control): remove cfg on stabilization
+    #[cfg(feature = "nightly")]
+    #[serde(with = "dec_format")]
+    pub new_buffered_receipts_balance: Balance,
     #[serde(with = "dec_format")]
     pub other_burnt_amount: Balance,
 }
@@ -678,6 +676,10 @@ impl Display for BalanceMismatchError {
             .saturating_add(self.incoming_receipts_balance)
             .saturating_add(self.processed_delayed_receipts_balance)
             .saturating_add(self.initial_postponed_receipts_balance);
+        // TODO(congestion_control): remove cfg on stabilization
+        #[cfg(feature = "nightly")]
+        let initial_balance =
+            initial_balance.saturating_add(self.forwarded_buffered_receipts_balance);
         let final_balance = self
             .final_accounts_balance
             .saturating_add(self.outgoing_receipts_balance)
@@ -686,7 +688,13 @@ impl Display for BalanceMismatchError {
             .saturating_add(self.tx_burnt_amount)
             .saturating_add(self.slashed_burnt_amount)
             .saturating_add(self.other_burnt_amount);
-        write!(
+        // TODO(congestion_control): remove cfg on stabilization
+        #[cfg(feature = "nightly")]
+        let final_balance = final_balance.saturating_add(self.new_buffered_receipts_balance);
+
+        // TODO(congestion_control): remove cfg on stabilization
+        #[cfg(not(feature = "nightly"))]
+        return write!(
             f,
             "Balance Mismatch Error. The input balance {} doesn't match output balance {}\n\
              Inputs:\n\
@@ -716,6 +724,43 @@ impl Display for BalanceMismatchError {
             self.final_postponed_receipts_balance,
             self.tx_burnt_amount,
             self.slashed_burnt_amount,
+            self.other_burnt_amount,
+        );
+        #[cfg(feature = "nightly")]
+        write!(
+            f,
+            "Balance Mismatch Error. The input balance {} doesn't match output balance {}\n\
+             Inputs:\n\
+             \tIncoming validator rewards sum: {}\n\
+             \tInitial accounts balance sum: {}\n\
+             \tIncoming receipts balance sum: {}\n\
+             \tProcessed delayed receipts balance sum: {}\n\
+             \tInitial postponed receipts balance sum: {}\n\
+             \tForwarded buffered receipts sum: {}\n\
+             Outputs:\n\
+             \tFinal accounts balance sum: {}\n\
+             \tOutgoing receipts balance sum: {}\n\
+             \tNew delayed receipts balance sum: {}\n\
+             \tFinal postponed receipts balance sum: {}\n\
+             \tTx fees burnt amount: {}\n\
+             \tSlashed amount: {}\n\
+             \tNew buffered receipts balance sum: {}\n\
+             \tOther burnt amount: {}",
+            initial_balance,
+            final_balance,
+            self.incoming_validator_rewards,
+            self.initial_accounts_balance,
+            self.incoming_receipts_balance,
+            self.processed_delayed_receipts_balance,
+            self.initial_postponed_receipts_balance,
+            self.forwarded_buffered_receipts_balance,
+            self.final_accounts_balance,
+            self.outgoing_receipts_balance,
+            self.new_delayed_receipts_balance,
+            self.final_postponed_receipts_balance,
+            self.tx_burnt_amount,
+            self.slashed_burnt_amount,
+            self.new_buffered_receipts_balance,
             self.other_burnt_amount,
         )
     }

--- a/core/store/src/trie/receipts_column_helper.rs
+++ b/core/store/src/trie/receipts_column_helper.rs
@@ -267,6 +267,21 @@ impl<'a> Iterator for ReceiptIterator<'a> {
     }
 }
 
+impl<'a> DoubleEndedIterator for ReceiptIterator<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let index = self.indices.next_back()?;
+        let key = self.trie_queue.trie_key(index);
+        let result = match get(self.trie, &key) {
+            Err(e) => Err(e),
+            Ok(None) => Err(StorageError::StorageInconsistentState(
+                "Receipt referenced by index should be in the state".to_owned(),
+            )),
+            Ok(Some(receipt)) => Ok(receipt),
+        };
+        Some(result)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/runtime/runtime/src/balance_checker.rs
+++ b/runtime/runtime/src/balance_checker.rs
@@ -12,10 +12,11 @@ use near_primitives::receipt::{Receipt, ReceiptEnum};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{AccountId, Balance};
+use near_store::trie::receipts_column_helper::{ShardsOutgoingReceiptBuffer, TrieQueue};
 use near_store::{
     get, get_account, get_postponed_receipt, get_promise_yield_receipt, TrieAccess, TrieUpdate,
 };
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 
 /// Returns delayed receipts with given range of indices.
 fn get_delayed_receipts(
@@ -160,6 +161,38 @@ pub(crate) fn check_balance(
             ..final_delayed_receipt_indices.next_available_index,
     )?;
 
+    // Buffered receipts
+    let mut initial_buffers = ShardsOutgoingReceiptBuffer::load(initial_state)?;
+    let mut final_buffers = ShardsOutgoingReceiptBuffer::load(final_state)?;
+    let mut forwarded_receipts: Vec<Receipt> = vec![];
+    let mut new_buffered_receipts: Vec<Receipt> = vec![];
+
+    let mut shards: BTreeSet<u64> = BTreeSet::new();
+    shards.extend(initial_buffers.shards().iter());
+    shards.extend(final_buffers.shards().iter());
+    for shard_id in shards {
+        let initial_buffer = initial_buffers.to_shard(shard_id);
+        let final_buffer = final_buffers.to_shard(shard_id);
+        let before = initial_buffer.indices();
+        let after = final_buffer.indices();
+        // Conservative math check to avoid future problems with merged shards,
+        // in which case the final index can be 0 and the initial index larger.
+        if let Some(num_forwarded) = after.first_index.checked_sub(before.first_index) {
+            // The first n receipts were forwarded.
+            for receipt in initial_buffer.iter(initial_state).take(num_forwarded as usize) {
+                forwarded_receipts.push(receipt?)
+            }
+        }
+        if let Some(num_buffered) =
+            after.next_available_index.checked_sub(before.next_available_index)
+        {
+            // The last n receipts are new. ("rev" to take from the back)
+            for receipt in final_buffer.iter(final_state).rev().take(num_buffered as usize) {
+                new_buffered_receipts.push(receipt?);
+            }
+        }
+    }
+
     // Accounts
     let mut all_accounts_ids: HashSet<AccountId> = transactions
         .iter()
@@ -196,6 +229,8 @@ pub(crate) fn check_balance(
     let outgoing_receipts_balance = receipts_cost(outgoing_receipts)?;
     let processed_delayed_receipts_balance = receipts_cost(&processed_delayed_receipts)?;
     let new_delayed_receipts_balance = receipts_cost(&new_delayed_receipts)?;
+    let forwarded_buffered_receipts_balance = receipts_cost(&forwarded_receipts)?;
+    let new_buffered_receipts_balance = receipts_cost(&new_buffered_receipts)?;
 
     // Postponed actions receipts. The receipts can be postponed and stored with the receiver's
     // account ID when the input data is not received yet.
@@ -254,7 +289,8 @@ pub(crate) fn check_balance(
         initial_accounts_balance,
         incoming_receipts_balance,
         processed_delayed_receipts_balance,
-        initial_postponed_receipts_balance
+        initial_postponed_receipts_balance,
+        forwarded_buffered_receipts_balance
     );
     let final_balance = safe_add_balance_apply!(
         final_accounts_balance,
@@ -263,6 +299,7 @@ pub(crate) fn check_balance(
         final_postponed_receipts_balance,
         stats.tx_burnt_amount,
         stats.slashed_burnt_amount,
+        new_buffered_receipts_balance,
         stats.other_burnt_amount
     );
     if initial_balance != final_balance {
@@ -273,6 +310,8 @@ pub(crate) fn check_balance(
             incoming_receipts_balance,
             processed_delayed_receipts_balance,
             initial_postponed_receipts_balance,
+            #[cfg(feature = "nightly")]
+            forwarded_buffered_receipts_balance,
             // Outputs
             final_accounts_balance,
             outgoing_receipts_balance,
@@ -280,6 +319,8 @@ pub(crate) fn check_balance(
             final_postponed_receipts_balance,
             tx_burnt_amount: stats.tx_burnt_amount,
             slashed_burnt_amount: stats.slashed_burnt_amount,
+            #[cfg(feature = "nightly")]
+            new_buffered_receipts_balance,
             other_burnt_amount: stats.other_burnt_amount,
         }
         .into())
@@ -294,12 +335,14 @@ mod tests {
     use crate::ApplyStats;
     use near_crypto::{InMemorySigner, KeyType};
     use near_primitives::hash::{hash, CryptoHash};
-    use near_primitives::receipt::{ActionReceipt, ReceiptPriority, ReceiptV0};
+    use near_primitives::receipt::{
+        ActionReceipt, BufferedReceiptIndices, ReceiptPriority, ReceiptV0, TrieQueueIndices,
+    };
     use near_primitives::test_utils::account_new;
     use near_primitives::transaction::{Action, TransferAction};
     use near_primitives::types::{MerkleHash, StateChangeCause};
     use near_store::test_utils::TestTriesBuilder;
-    use near_store::{set_account, Trie};
+    use near_store::{set, set_account, Trie};
     use testlib::runtime_utils::{alice_account, bob_account};
 
     use crate::near_primitives::shard_layout::ShardUId;
@@ -443,29 +486,8 @@ mod tests {
             },
         );
 
-        let signer =
-            InMemorySigner::from_seed(account_id.clone(), KeyType::ED25519, account_id.as_ref());
-        let tx = SignedTransaction::send_money(
-            1,
-            account_id,
-            bob_account(),
-            &signer,
-            deposit,
-            CryptoHash::default(),
-        );
-        let receipt = Receipt::V0(ReceiptV0 {
-            predecessor_id: tx.transaction.signer_id().clone(),
-            receiver_id: tx.transaction.receiver_id().clone(),
-            receipt_id: Default::default(),
-            receipt: ReceiptEnum::Action(ActionReceipt {
-                signer_id: tx.transaction.signer_id().clone(),
-                signer_public_key: tx.transaction.public_key().clone(),
-                gas_price,
-                output_data_receivers: vec![],
-                input_data_ids: vec![],
-                actions: vec![Action::Transfer(TransferAction { deposit })],
-            }),
-        });
+        let tx = transfer_tx(account_id, bob_account(), deposit);
+        let receipt = extract_transfer_receipt(&tx, gas_price, deposit);
 
         check_balance(
             &cfg,
@@ -483,6 +505,35 @@ mod tests {
             },
         )
         .unwrap();
+    }
+
+    fn transfer_tx(sender: AccountId, receiver: AccountId, deposit: u128) -> SignedTransaction {
+        let signer = InMemorySigner::from_seed(sender.clone(), KeyType::ED25519, sender.as_str());
+        let tx = SignedTransaction::send_money(
+            0,
+            sender,
+            receiver,
+            &signer,
+            deposit,
+            CryptoHash::default(),
+        );
+        tx
+    }
+
+    fn extract_transfer_receipt(tx: &SignedTransaction, gas_price: u128, deposit: u128) -> Receipt {
+        Receipt::V0(ReceiptV0 {
+            predecessor_id: tx.transaction.signer_id().clone(),
+            receiver_id: tx.transaction.receiver_id().clone(),
+            receipt_id: Default::default(),
+            receipt: ReceiptEnum::Action(ActionReceipt {
+                signer_id: tx.transaction.signer_id().clone(),
+                signer_public_key: tx.transaction.public_key().clone(),
+                gas_price,
+                output_data_receivers: vec![],
+                input_data_ids: vec![],
+                actions: vec![Action::Transfer(TransferAction { deposit })],
+            }),
+        })
     }
 
     /// This tests shows how overflow (which we do not expect) would be handled on a transfer.
@@ -505,26 +556,9 @@ mod tests {
         set_account(&mut initial_state, bob_id.clone(), &bob);
         initial_state.commit(StateChangeCause::NotWritableToDisk);
 
-        let signer =
-            InMemorySigner::from_seed(alice_id.clone(), KeyType::ED25519, alice_id.as_ref());
-
         // Sending 2 yoctoNEAR, so that we have an overflow when adding to alice's balance.
-        let tx =
-            SignedTransaction::send_money(0, alice_id, bob_id, &signer, 2, CryptoHash::default());
-
-        let receipt = Receipt::V0(ReceiptV0 {
-            predecessor_id: tx.transaction.signer_id().clone(),
-            receiver_id: tx.transaction.receiver_id().clone(),
-            receipt_id: Default::default(),
-            receipt: ReceiptEnum::Action(ActionReceipt {
-                signer_id: tx.transaction.signer_id().clone(),
-                signer_public_key: tx.transaction.public_key().clone(),
-                gas_price,
-                output_data_receivers: vec![],
-                input_data_ids: vec![],
-                actions: vec![Action::Transfer(TransferAction { deposit })],
-            }),
-        });
+        let tx = transfer_tx(alice_id, bob_id, 2);
+        let receipt = extract_transfer_receipt(&tx, gas_price, deposit);
 
         assert_eq!(
             check_balance(
@@ -561,25 +595,8 @@ mod tests {
         set_account(&mut initial_state, bob_id.clone(), &bob);
         initial_state.commit(StateChangeCause::NotWritableToDisk);
 
-        let signer =
-            InMemorySigner::from_seed(alice_id.clone(), KeyType::ED25519, alice_id.as_ref());
-
-        let tx =
-            SignedTransaction::send_money(0, alice_id, bob_id, &signer, 1, CryptoHash::default());
-
-        let receipt = Receipt::V0(ReceiptV0 {
-            predecessor_id: tx.transaction.signer_id().clone(),
-            receiver_id: tx.transaction.receiver_id().clone(),
-            receipt_id: Default::default(),
-            receipt: ReceiptEnum::Action(ActionReceipt {
-                signer_id: tx.transaction.signer_id().clone(),
-                signer_public_key: tx.transaction.public_key().clone(),
-                gas_price,
-                output_data_receivers: vec![],
-                input_data_ids: vec![],
-                actions: vec![Action::Transfer(TransferAction { deposit })],
-            }),
-        });
+        let tx = transfer_tx(alice_id, bob_id, deposit);
+        let receipt = extract_transfer_receipt(&tx, gas_price, deposit);
 
         // Alice's balance becomes u128::MAX, which causes it is interpreted as
         // the Alice's account version to be 2 or higher, instead of being interpreted
@@ -598,5 +615,146 @@ mod tests {
             ),
             Err(RuntimeError::BalanceMismatchError { .. })
         );
+    }
+
+    /// When adding a receipt to the outgoing buffer, its balance must must be
+    /// picked up by the balance checker. Test it by simulating a transfer
+    /// action removing some balance from an account and placing the receipt in
+    /// the buffer.
+    #[test]
+    fn test_add_buffered_receipt_balance() {
+        let account_id = alice_account();
+        let deposit = 100;
+        let gas_price = 10;
+        let initial_balance = TESTING_INIT_BALANCE;
+
+        let tx = transfer_tx(account_id.clone(), bob_account(), deposit);
+        let existing_receipt = extract_transfer_receipt(&tx, gas_price, deposit + 5);
+        let new_receipt = extract_transfer_receipt(&tx, gas_price, deposit);
+
+        let cfg = RuntimeConfig::test();
+        let fees = &cfg.fees;
+        let exec_gas = fees.fee(ActionCosts::new_action_receipt).exec_fee()
+            + fees.fee(ActionCosts::transfer).exec_fee();
+        let send_gas = fees.fee(ActionCosts::new_action_receipt).send_fee(false)
+            + fees.fee(ActionCosts::transfer).send_fee(false);
+
+        let final_state = prepare_state_change(
+            |trie_update| {
+                let initial_account = account_new(initial_balance, hash(&[]));
+                set_account(trie_update, account_id.clone(), &initial_account);
+
+                // create buffer with already a receipt in it, but a different balance
+                let mut indices = BufferedReceiptIndices::default();
+                indices
+                    .shard_buffers
+                    .insert(0, TrieQueueIndices { first_index: 0, next_available_index: 1 });
+
+                set(trie_update, TrieKey::BufferedReceiptIndices, &indices);
+                set(
+                    trie_update,
+                    TrieKey::BufferedReceipt { receiving_shard: 0, index: 0 },
+                    &existing_receipt,
+                );
+            },
+            |trie_update| {
+                // remove transferred deposit, plus the spent balance for gas
+                let final_account = account_new(
+                    initial_balance - (exec_gas + send_gas) as Balance * gas_price - deposit,
+                    hash(&[]),
+                );
+                set_account(trie_update, account_id.clone(), &final_account);
+
+                // store receipt with the balance in the receipt buffer
+                let mut indices = BufferedReceiptIndices::default();
+                indices
+                    .shard_buffers
+                    .insert(0, TrieQueueIndices { first_index: 0, next_available_index: 2 });
+
+                set(trie_update, TrieKey::BufferedReceiptIndices, &indices);
+                set(
+                    trie_update,
+                    TrieKey::BufferedReceipt { receiving_shard: 0, index: 1 },
+                    &new_receipt,
+                );
+            },
+        );
+
+        check_balance(
+            &RuntimeConfig::test(),
+            &final_state,
+            &None,
+            &[],
+            &[],
+            &[tx],
+            &[],
+            &ApplyStats {
+                // send gas was burnt on this shard, exec gas is part of the receipt value
+                tx_burnt_amount: send_gas as Balance * gas_price,
+                gas_deficit_amount: 0,
+                other_burnt_amount: 0,
+                slashed_burnt_amount: 0,
+            },
+        )
+        .unwrap();
+    }
+
+    /// When forwarding a receipt from the outgoing buffer, its balance must
+    /// must be picked up by the balance checker. Test it by removing a transfer
+    /// receipt from the buffer and adding it to the outgoing receipts.
+    #[test]
+    fn test_remove_buffered_receipt_balance() {
+        let account_id = alice_account();
+        let deposit = 100;
+        let gas_price = 10;
+
+        let tx = transfer_tx(account_id, bob_account(), deposit);
+        let receipt0 = extract_transfer_receipt(&tx, gas_price, deposit);
+        let receipt1 = extract_transfer_receipt(&tx, gas_price, deposit + 5);
+
+        let final_state = prepare_state_change(
+            |trie_update| {
+                // store 2 receipts with balance in the receipt buffer
+                let mut indices = BufferedReceiptIndices::default();
+                indices
+                    .shard_buffers
+                    .insert(0, TrieQueueIndices { first_index: 0, next_available_index: 2 });
+
+                set(trie_update, TrieKey::BufferedReceiptIndices, &indices);
+                set(
+                    trie_update,
+                    TrieKey::BufferedReceipt { receiving_shard: 0, index: 0 },
+                    &receipt0,
+                );
+                set(
+                    trie_update,
+                    TrieKey::BufferedReceipt { receiving_shard: 0, index: 1 },
+                    &receipt1,
+                );
+            },
+            |trie_update| {
+                // remove 1 receipt at index 0
+                let mut indices = BufferedReceiptIndices::default();
+                indices
+                    .shard_buffers
+                    .insert(0, TrieQueueIndices { first_index: 1, next_available_index: 2 });
+
+                set(trie_update, TrieKey::BufferedReceiptIndices, &indices);
+                trie_update.remove(TrieKey::BufferedReceipt { receiving_shard: 0, index: 0 });
+            },
+        );
+
+        let outgoing_receipts = [receipt0];
+        check_balance(
+            &RuntimeConfig::test(),
+            &final_state,
+            &None,
+            &[],
+            &[],
+            &[],
+            &outgoing_receipts,
+            &ApplyStats::default(),
+        )
+        .unwrap();
     }
 }


### PR DESCRIPTION
Buffered receipts need to be accounted for in the balance checker.

I decided to treat them similarly to delayed receipts, counting the balance for receipts are added and removed to the queue, not counting what is actually in the queue. This avoids reading additional buffered receipts per chunk.