### PR TITLE
feat(forknet): add host env variable control to the mirror tool

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -692,12 +692,9 @@ class NeardRunner:
 
     def do_clear_env(self):
         with self.lock:
-            try:
-                env_file_path = self.home_path('.env')
-                open(env_file_path, 'w').close()
-                print(f'File {env_file_path} has been successfully cleared.')
-            except Exception as e:
-                print(f'An error occurred while clearing the env: {e}')
+            env_file_path = self.home_path('.env')
+            open(env_file_path, 'w').close()
+            print(f'File {env_file_path} has been successfully cleared.')
 
     def do_add_env(self, key_values):
         with self.lock:

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -743,9 +743,9 @@ class NeardRunner:
         assert (self.data['neard_process'] is None)
         home_path = os.path.expanduser('~')
         env = {
-            **dotenv.dotenv_values(self.home_path('.env')),  # load neard variables
-            **dotenv.dotenv_values(self.home_path(home_path, '.env.secrets')),  # load sensitive variables
             **os.environ,  # override loaded values with environment variables
+            **dotenv.dotenv_values(self.home_path(home_path, '.secrets')),  # load sensitive variables
+            **dotenv.dotenv_values(self.home_path('.env')),  # load neard variables
         }
         if 'RUST_LOG' not in env:
             env['RUST_LOG'] = 'actix_web=warn,mio=warn,tokio_util=warn,actix_server=warn,actix_http=warn,indexer=info,debug'

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -699,14 +699,15 @@ class NeardRunner:
             except Exception as e:
                 print(f'An error occurred while clearing the env: {e}')
 
-    def do_add_env(self, key_value):
+    def do_add_env(self, key_values):
         with self.lock:
             env_file_path = self.home_path('.env')
             # Create the file if it does not exit
             open(env_file_path, 'a').close()
-            logging.info(f'Updating env with {key_value}')
-            [key, value] = key_value.split("=", 1)
-            dotenv.set_key(env_file_path, key, value)
+            for key_value in key_values:
+                logging.info(f'Updating env with {key_value}')
+                [key, value] = key_value.split("=", 1)
+                dotenv.set_key(env_file_path, key, value)
 
     # check the current epoch height, and return the binary path that we should
     # be running given the epoch heights specified in config.json

--- a/pytest/tests/mocknet/helpers/requirements.txt
+++ b/pytest/tests/mocknet/helpers/requirements.txt
@@ -1,3 +1,4 @@
 json-rpc
 psutil
 requests
+python-dotenv

--- a/pytest/tests/mocknet/local_test_node.py
+++ b/pytest/tests/mocknet/local_test_node.py
@@ -100,6 +100,9 @@ class LocalTestNeardRunner:
     def init_python(self):
         return
 
+    def update_python(self):
+        return
+
     def _pid_path(self):
         return self.home / 'pid.txt'
 

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -600,7 +600,7 @@ if __name__ == '__main__':
     env_cmd_parser = subparsers.add_parser(
         'env', help='''Update the environment variable on the hosts.''')
     env_cmd_parser.add_argument('--clear-all', action='store_true')
-    env_cmd_parser.add_argument('--key-value', type=str)
+    env_cmd_parser.add_argument('--key-value', type=str, nargs='+')
     env_cmd_parser.set_defaults(func=run_env_cmd)
 
     args = parser.parse_args()

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -437,6 +437,14 @@ def run_remote_cmd(args, traffic_generator, nodes):
          on_exception="")
 
 
+def run_env_cmd(args, traffic_generator, nodes):
+    if args.clear_all:
+        func = lambda node: node.neard_clear_env()
+    else:
+        func = lambda node: node.neard_update_env(args.key_value)
+    pmap(func, nodes + [traffic_generator])
+
+
 if __name__ == '__main__':
     parser = ArgumentParser(description='Control a mocknet instance')
     parser.add_argument('--chain-id', type=str)
@@ -588,6 +596,12 @@ if __name__ == '__main__':
         type=str,
         help='Filter through the selected nodes using regex.')
     run_cmd_parser.set_defaults(func=run_remote_cmd)
+
+    env_cmd_parser = subparsers.add_parser(
+        'env', help='''Update the environment variable on the hosts.''')
+    env_cmd_parser.add_argument('--clear-all', action='store_true')
+    env_cmd_parser.add_argument('--key-value', type=str)
+    env_cmd_parser.set_defaults(func=run_env_cmd)
 
     args = parser.parse_args()
 

--- a/pytest/tests/mocknet/node_handle.py
+++ b/pytest/tests/mocknet/node_handle.py
@@ -33,6 +33,7 @@ class NodeHandle:
 
     def upload_neard_runner(self):
         self.node.upload_neard_runner()
+        self.node.update_python()
 
     def run_cmd(self, cmd, raise_on_fail=False, return_on_fail=False):
         return self.node.run_cmd(cmd, raise_on_fail, return_on_fail)
@@ -149,3 +150,14 @@ class NodeHandle:
                 "key_value": key_value,
             },
         )
+
+    def neard_update_env(self, key_value):
+        return self.neard_runner_jsonrpc(
+            'add_env',
+            params={
+                "key_value": key_value,
+            },
+        )
+
+    def neard_clear_env(self):
+        return self.neard_runner_jsonrpc('clear_env')

--- a/pytest/tests/mocknet/node_handle.py
+++ b/pytest/tests/mocknet/node_handle.py
@@ -155,7 +155,7 @@ class NodeHandle:
         return self.neard_runner_jsonrpc(
             'add_env',
             params={
-                "key_value": key_value,
+                "key_values": key_value,
             },
         )
 

--- a/pytest/tests/mocknet/remote_node.py
+++ b/pytest/tests/mocknet/remote_node.py
@@ -63,6 +63,10 @@ class RemoteNeardRunner:
         ' && ./venv/bin/pip install -r requirements.txt'
         cmd_utils.run_cmd(self.node, cmd)
 
+    def update_python(self):
+        cmd = f'cd {self.neard_runner_home} && ./venv/bin/pip install -r requirements.txt'
+        cmd_utils.run_cmd(self.node, cmd)
+
     def stop_neard_runner(self):
         # this looks for python processes with neard_runner.py in the command line. the first word will
         # be the pid, which we extract with the last awk command


### PR DESCRIPTION
This PR changes the way we load the env variables on the host.
The neard_runner.py will now load ~/.env.secret and $NEARD_RUNNER_HOME/.env when it starts `neard`.

This PR also introduces new mirror commands to modify the env variables on the forknet hosts.

This feature will enable the configuration of state dumper and the tracing server.

tested on a host:
```
ubuntu@mocknet--t4dm:~$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "method": "clear_env", "params": {}, "id": 1}' 127.0.0.1:3000
{"result": null, "id": 1, "jsonrpc": "2.0"}
ubuntu@mocknet--t4dm:~$ cat ~/.near/neard-runner/.env
ubuntu@mocknet--t4dm:~$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "method": "add_env", "params": {"key_value": "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://xxxxxxx"}, "id": 1}' 127.0.0.1:3000
ubuntu@mocknet~$ cat ~/.near/neard-runner/.env
OTEL_EXPORTER_OTLP_TRACES_ENDPOINT='http://xxxxxxx’
ubuntu@mocknet--t4dm:~$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "method": "add_env", "params": {"key_value": "TEST=test"}, "id": 1}' 127.0.0.1:3000
{"result": null, "id": 1, "jsonrpc": "2.0"}
ubuntu@mocknet--t4dm:~$ cat ~/.near/neard-runner/.env
OTEL_EXPORTER_OTLP_TRACES_ENDPOINT='http://xxxxxxxx:xxxx’
TEST='test'
```