### PR TITLE
feat: add metric for total size of cached partial state witnesses

### DIFF
--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -828,3 +828,11 @@ pub(crate) static PARTIAL_WITNESS_PARTS_RECEIVED_RATIO: Lazy<HistogramVec> = Laz
     )
     .unwrap()
 });
+
+pub(crate) static PARTIAL_WITNESS_CACHE_SIZE: Lazy<Gauge> = Lazy::new(|| {
+    try_create_gauge(
+        "near_partial_witness_cache_size",
+        "Total size in bytes of all currently cached witness parts",
+    )
+    .unwrap()
+});


### PR DESCRIPTION
`CacheEntry` tracks its own size in `total_parts_size`, that is pretty straightforward since we can only increment it as we add more parts. The total size across all cached entries in `PartialEncodedStateWitnessTracker` is calculated by simply iterating across all entries. We can afford that performance-wise since LRU cache size is currently limited to 200 entries and we plan to reduce that before the mainnet release.