### PR TITLE
routing: finish deprecation of old-style nonces

### DIFF
--- a/chain/jsonrpc/res/network_info.html
+++ b/chain/jsonrpc/res/network_info.html
@@ -132,8 +132,7 @@
                                 .append($('<td>').append(JSON.stringify(peer.tracked_shards)))
                                 .append($('<td>').append(JSON.stringify(peer.archival)))
                                 .append($('<td>').append(((peer.is_outbound_peer) ? 'OUT' : 'IN')))
-                                // If this is a new style nonce - show the approx time since it was created.
-                                .append($('<td>').append(peer.nonce + " <br> " + ((peer.nonce > 1660000000) ? convertTime(Date.now() - peer.nonce * 1000) : "old style nonce")))
+                                .append($('<td>').append(peer.nonce + " <br> " + convertTime(Date.now() - peer.nonce * 1000)))
                                 .append($('<td>').append(convertTime(peer.connection_established_time_millis)))
                                 .append($('<td>').append(computeTraffic(peer.received_bytes_per_sec, peer.sent_bytes_per_sec)))
                                 .append($('<td>').append(routedValidator.join(",")))

--- a/chain/network/src/peer/tests/communication.rs
+++ b/chain/network/src/peer/tests/communication.rs
@@ -8,7 +8,7 @@ use crate::peer_manager::peer_manager_actor::Event as PME;
 use crate::tcp;
 use crate::testonly::make_rng;
 use crate::testonly::stream::Stream;
-use crate::types::{PartialEncodedChunkRequestMsg, PartialEncodedChunkResponseMsg};
+use crate::types::{Edge, PartialEncodedChunkRequestMsg, PartialEncodedChunkResponseMsg};
 use anyhow::Context as _;
 use assert_matches::assert_matches;
 use near_async::time;
@@ -208,7 +208,8 @@ async fn test_handshake(outbound_encoding: Option<Encoding>, inbound_encoding: O
         target_peer_id: inbound.cfg.id(),
         sender_listen_port: Some(outbound_port),
         sender_chain_info: outbound_cfg.chain.get_peer_chain_info(),
-        partial_edge_info: outbound_cfg.partial_edge_info(&inbound.cfg.id(), 1),
+        partial_edge_info: outbound_cfg
+            .partial_edge_info(&inbound.cfg.id(), Edge::create_fresh_nonce(&clock.clock())),
         owned_account: None,
     };
     // We will also introduce chain_id mismatch, but ProtocolVersionMismatch is expected to take priority.

--- a/chain/network/src/peer_manager/tests/connection_pool.rs
+++ b/chain/network/src/peer_manager/tests/connection_pool.rs
@@ -11,6 +11,7 @@ use crate::private_actix::RegisterPeerError;
 use crate::tcp;
 use crate::testonly::make_rng;
 use crate::testonly::stream::Stream;
+use crate::types::Edge;
 use near_async::time;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::version::PROTOCOL_VERSION;
@@ -99,7 +100,7 @@ async fn loop_connection() {
             partial_edge_info: PartialEdgeInfo::new(
                 &pm.cfg.node_id(),
                 &pm.cfg.node_id(),
-                1,
+                Edge::create_fresh_nonce(&clock.clock()),
                 &pm.cfg.node_key,
             ),
             owned_account: None,
@@ -159,7 +160,7 @@ async fn owned_account_mismatch() {
             partial_edge_info: PartialEdgeInfo::new(
                 &cfg.node_id(),
                 &pm.cfg.node_id(),
-                1,
+                Edge::create_fresh_nonce(&clock.clock()),
                 &cfg.node_key,
             ),
             owned_account: Some(
@@ -244,18 +245,25 @@ async fn invalid_edge() {
     let chain_info = peer_manager::testonly::make_chain_info(&chain, &[&cfg]);
     pm.set_chain_info(chain_info).await;
 
+    let nonce = Edge::create_fresh_nonce(&clock.clock());
+
     let testcases = [
         (
             "wrong key",
-            PartialEdgeInfo::new(&cfg.node_id(), &pm.cfg.node_id(), 1, &data::make_secret_key(rng)),
+            PartialEdgeInfo::new(
+                &cfg.node_id(),
+                &pm.cfg.node_id(),
+                nonce,
+                &data::make_secret_key(rng),
+            ),
         ),
         (
             "wrong source",
-            PartialEdgeInfo::new(&data::make_peer_id(rng), &pm.cfg.node_id(), 1, &cfg.node_key),
+            PartialEdgeInfo::new(&data::make_peer_id(rng), &pm.cfg.node_id(), nonce, &cfg.node_key),
         ),
         (
             "wrong target",
-            PartialEdgeInfo::new(&cfg.node_id(), &data::make_peer_id(rng), 1, &cfg.node_key),
+            PartialEdgeInfo::new(&cfg.node_id(), &data::make_peer_id(rng), nonce, &cfg.node_key),
         ),
     ];
 

--- a/chain/network/src/peer_manager/tests/nonce.rs
+++ b/chain/network/src/peer_manager/tests/nonce.rs
@@ -28,7 +28,7 @@ async fn test_nonces() {
     init_test_logger();
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
-    let mut clock = time::FakeClock::new(time::Utc::UNIX_EPOCH);
+    let mut clock = time::FakeClock::new(time::Utc::UNIX_EPOCH + time::Duration::days(2));
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let test_cases = [
@@ -107,7 +107,7 @@ async fn test_nonce_refresh() {
     init_test_logger();
     let mut rng = make_rng(921853255);
     let rng = &mut rng;
-    let mut clock = time::FakeClock::new(time::Utc::UNIX_EPOCH);
+    let mut clock = time::FakeClock::new(time::Utc::UNIX_EPOCH + time::Duration::days(2));
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     // Start a PeerManager.

--- a/chain/network/src/peer_manager/tests/nonce.rs
+++ b/chain/network/src/peer_manager/tests/nonce.rs
@@ -1,7 +1,5 @@
 use crate::network_protocol::testonly as data;
-use crate::network_protocol::{
-    Encoding, Handshake, PartialEdgeInfo, PeerMessage, EDGE_MIN_TIMESTAMP_NONCE,
-};
+use crate::network_protocol::{Encoding, Handshake, PartialEdgeInfo, PeerMessage};
 use crate::peer_manager::testonly::{ActorHandler, Event};
 use crate::peer_manager::{self, peer_manager_actor};
 use crate::tcp;
@@ -30,7 +28,7 @@ async fn test_nonces() {
     init_test_logger();
     let mut rng = make_rng(921853233);
     let rng = &mut rng;
-    let mut clock = time::FakeClock::new(*EDGE_MIN_TIMESTAMP_NONCE + time::Duration::days(2));
+    let mut clock = time::FakeClock::new(time::Utc::UNIX_EPOCH);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     let test_cases = [
@@ -109,7 +107,7 @@ async fn test_nonce_refresh() {
     init_test_logger();
     let mut rng = make_rng(921853255);
     let rng = &mut rng;
-    let mut clock = time::FakeClock::new(*EDGE_MIN_TIMESTAMP_NONCE + time::Duration::days(2));
+    let mut clock = time::FakeClock::new(time::Utc::UNIX_EPOCH);
     let chain = Arc::new(data::Chain::make(&mut clock, rng, 10));
 
     // Start a PeerManager.
@@ -135,7 +133,7 @@ async fn test_nonce_refresh() {
     let edge = wait_for_edge(&mut pm2).await;
     let start_time = clock.now_utc();
     // First edge between them should have the nonce equal to the current time.
-    assert_eq!(Edge::nonce_to_utc(edge.nonce()).unwrap().unwrap(), start_time);
+    assert_eq!(Edge::nonce_to_utc(edge.nonce()).unwrap(), start_time);
 
     // Advance a clock by 1 hour.
     clock.advance(time::Duration::HOUR);
@@ -144,10 +142,10 @@ async fn test_nonce_refresh() {
 
     loop {
         let edge = wait_for_edge(&mut pm2).await;
-        if Edge::nonce_to_utc(edge.nonce()).unwrap().unwrap() == start_time {
+        if Edge::nonce_to_utc(edge.nonce()).unwrap() == start_time {
             tracing::debug!("Still seeing old edge..");
         } else {
-            assert_eq!(Edge::nonce_to_utc(edge.nonce()).unwrap().unwrap(), new_nonce_utc);
+            assert_eq!(Edge::nonce_to_utc(edge.nonce()).unwrap(), new_nonce_utc);
             break;
         }
     }
@@ -160,7 +158,7 @@ async fn test_nonce_refresh() {
         )
         .await;
 
-    assert_eq!(Edge::nonce_to_utc(pm2_nonce).unwrap().unwrap(), new_nonce_utc);
+    assert_eq!(Edge::nonce_to_utc(pm2_nonce).unwrap(), new_nonce_utc);
 
     let pm_nonce = pm
         .with_state(|s| async move {
@@ -168,5 +166,5 @@ async fn test_nonce_refresh() {
         })
         .await;
 
-    assert_eq!(Edge::nonce_to_utc(pm_nonce).unwrap().unwrap(), new_nonce_utc);
+    assert_eq!(Edge::nonce_to_utc(pm_nonce).unwrap(), new_nonce_utc);
 }

--- a/chain/network/src/peer_manager/tests/nonce.rs
+++ b/chain/network/src/peer_manager/tests/nonce.rs
@@ -43,8 +43,6 @@ async fn test_nonces() {
         ((i64::MAX - 1) as u64, false, "i64 max - 1"),
         (253402300799, false, "Max time"),
         (253402300799 + 2, false, "Over max time"),
-        //(Some(0), false, "Nonce 0"),
-        (1, true, "Nonce 1"),
     ];
 
     for test in test_cases {

--- a/chain/network/src/peer_manager/tests/routing.rs
+++ b/chain/network/src/peer_manager/tests/routing.rs
@@ -14,7 +14,7 @@ use crate::peer_manager::testonly::Event;
 use crate::private_actix::RegisterPeerError;
 use crate::tcp;
 use crate::testonly::{abort_on_panic, make_rng, Rng};
-use crate::types::PeerMessage;
+use crate::types::{Edge, PeerMessage};
 use crate::types::{PeerInfo, ReasonForBan};
 use near_async::time;
 use near_primitives::network::PeerId;
@@ -1001,7 +1001,11 @@ async fn repeated_data_in_sync_routing_table() {
         }
         // Add more data.
         let key = data::make_secret_key(rng);
-        edges_want.insert(data::make_edge(&peer.cfg.network.node_key, &key, 1));
+        edges_want.insert(data::make_edge(
+            &peer.cfg.network.node_key,
+            &key,
+            Edge::create_fresh_nonce(&clock.clock()),
+        ));
         accounts_want.insert(data::make_announce_account(rng));
         // Send all the data created so far. PeerManager is expected to discard the duplicates.
         peer.send(PeerMessage::SyncRoutingTable(RoutingTableUpdate {
@@ -1081,7 +1085,11 @@ async fn fix_local_edges() {
         .await;
     // TODO(gprusak): the case when the edge is updated via UpdateNondeRequest is not covered yet,
     // as it requires awaiting for the RPC roundtrip which is not implemented yet.
-    let edge1 = data::make_edge(&pm.cfg.node_key, &data::make_secret_key(rng), 1);
+    let edge1 = data::make_edge(
+        &pm.cfg.node_key,
+        &data::make_secret_key(rng),
+        Edge::create_fresh_nonce(&clock.clock()),
+    );
     let edge2 = conn
         .edge
         .as_ref()

--- a/chain/network/src/raw/tests.rs
+++ b/chain/network/src/raw/tests.rs
@@ -31,6 +31,7 @@ async fn test_raw_conn_pings() {
     .await;
 
     let mut conn = raw::Connection::connect(
+        &clock.clock(),
         addr,
         peer_id.clone(),
         None,
@@ -91,6 +92,7 @@ async fn test_raw_conn_state_parts() {
     .await;
 
     let mut conn = raw::Connection::connect(
+        &clock.clock(),
         addr,
         peer_id.clone(),
         None,

--- a/chain/network/src/routing/graph/tests.rs
+++ b/chain/network/src/routing/graph/tests.rs
@@ -100,7 +100,7 @@ fn to_active_nonce(t: time::Utc) -> u64 {
 async fn expired_edges() {
     init_test_logger();
     let clock = time::FakeClock::default();
-    clock.set_utc(time::Utc::UNIX_EPOCH);
+    clock.set_utc(time::Utc::UNIX_EPOCH + time::Duration::days(2));
     let mut rng = make_rng(87927345);
     let rng = &mut rng;
     let node_key = data::make_secret_key(rng);

--- a/chain/network/src/routing/graph/tests.rs
+++ b/chain/network/src/routing/graph/tests.rs
@@ -1,7 +1,6 @@
 use super::{Graph, GraphConfig};
 use crate::network_protocol::testonly as data;
 use crate::network_protocol::Edge;
-use crate::network_protocol::EDGE_MIN_TIMESTAMP_NONCE;
 use crate::testonly::make_rng;
 use near_async::time;
 use near_crypto::SecretKey;
@@ -101,7 +100,7 @@ fn to_active_nonce(t: time::Utc) -> u64 {
 async fn expired_edges() {
     init_test_logger();
     let clock = time::FakeClock::default();
-    clock.set_utc(*EDGE_MIN_TIMESTAMP_NONCE + time::Duration::days(2));
+    clock.set_utc(time::Utc::UNIX_EPOCH);
     let mut rng = make_rng(87927345);
     let rng = &mut rng;
     let node_key = data::make_secret_key(rng);

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -235,9 +235,6 @@ pub(crate) static ROUTING_TABLE_RECALCULATION_HISTOGRAM: Lazy<Histogram> = Lazy:
 });
 pub(crate) static EDGE_UPDATES: Lazy<IntCounter> =
     Lazy::new(|| try_create_int_counter("near_edge_updates", "Unique edge updates").unwrap());
-pub(crate) static EDGE_NONCE: Lazy<IntCounterVec> = Lazy::new(|| {
-    try_create_int_counter_vec("near_edge_nonce", "Edge nonce types", &["type"]).unwrap()
-});
 pub(crate) static EDGE_ACTIVE: Lazy<IntGauge> = Lazy::new(|| {
     try_create_int_gauge("near_edge_active", "Total edges active between peers").unwrap()
 });

--- a/tools/debug-ui/src/CurrentPeersView.tsx
+++ b/tools/debug-ui/src/CurrentPeersView.tsx
@@ -272,9 +272,9 @@ export const CurrentPeersView = ({ addr }: NetworkInfoViewProps) => {
                                 <td>
                                     {peer.nonce}
                                     <br />
-                                    {peer.nonce > 1660000000
-                                        ? formatDurationInMillis(Date.now() - peer.nonce * 1000)
-                                        : 'old style nonce'}
+                                    {formatDurationInMillis(
+                                        Date.now() - peer.nonce * 1000
+                                    )}
                                 </td>
                                 <td>
                                     {formatDurationInMillis(

--- a/tools/ping/src/lib.rs
+++ b/tools/ping/src/lib.rs
@@ -390,7 +390,10 @@ async fn ping_via_node(
 
     app_info.add_peer(peer_id.clone(), None);
 
+    let clock = time::Clock::real();
+
     let mut peer = match Connection::connect(
+        &clock,
         peer_addr,
         peer_id,
         protocol_version,

--- a/tools/state-parts/src/lib.rs
+++ b/tools/state-parts/src/lib.rs
@@ -88,7 +88,10 @@ async fn state_parts_from_node(
     assert!(start_part_id < num_parts && num_parts > 0, "{}/{}", start_part_id, num_parts);
     let mut app_info = AppInfo::new();
 
+    let clock = time::Clock::real();
+
     let mut peer = match Connection::connect(
+        &clock,
         peer_addr,
         peer_id.clone(),
         protocol_version,


### PR DESCRIPTION
This PR completes the planned deprecation of old-style nonces:

https://github.com/near/nearcore/blob/1479c9084dcfa7480add2ff69a499596a237df55/chain/network/src/network_protocol/edge.rs#L9-L14

It will also address an increase in network traffic seen after #11018 due to transmission of ancient tombstone edges which lingered in the DB storage. After we remove this special logic preventing them from expiring they will simply be discarded.

---

A few tests had to be updated because they were using hardcoded nonce 1 and relying on the fact that it never expires.

Similarly raw connection was (ab)using the fact that a handshake containing a partial edge with nonce 1 will always be accepted. Now it generates a proper timestamp when initiating a handshake. It means that the users of raw connection (ping tool and state part request/response) will need to have a clock which is reasonably in sync (within 30 min) with the clock on the node which which they are trying to communicate.