### PR TITLE
feat: chunk producer does not need to validate witness for the same shard

### DIFF
--- a/chain/client/src/test_utils/mock_partial_witness_adapter.rs
+++ b/chain/client/src/test_utils/mock_partial_witness_adapter.rs
@@ -20,4 +20,8 @@ impl MockPartialWitnessAdapter {
     pub fn pop_distribution_request(&self) -> Option<DistributeStateWitnessRequest> {
         self.distribution_request.write().unwrap().pop_front()
     }
+
+    pub fn len(&self) -> usize {
+        self.distribution_request.read().unwrap().len()
+    }
 }

--- a/core/primitives/src/stateless_validation.rs
+++ b/core/primitives/src/stateless_validation.rs
@@ -528,6 +528,14 @@ impl ChunkValidatorAssignments {
     }
 }
 
+/// Result of initial state witness verification. There are two success cases:
+/// - `Validated` - the witness is valid and can be used for further processing.
+/// - `Skipping` - the node is a chunk producer and does not need to validate and apply the witness.
+pub enum StateWitnessVerficationResult {
+    Verified { witness: ChunkStateWitness, size: ChunkStateWitnessSize },
+    Skipping
+}
+
 #[cfg(test)]
 mod tests {
     use crate::stateless_validation::{ChunkStateWitness, EncodedChunkStateWitness};


### PR DESCRIPTION
A follow up to #11255: if a chunk producer produces chunks for a shard, then it does not need to validate state witness for that shard. In this case, we stop witness processing after decoding state witness