### PR TITLE
Revert "feat: count block approval towards chunk endorsement (#11255)"

### DIFF
--- a/chain/chain/src/stateless_validation/chunk_endorsement.rs
+++ b/chain/chain/src/stateless_validation/chunk_endorsement.rs
@@ -30,23 +30,6 @@ impl Chain {
             return Err(Error::InvalidChunkEndorsement);
         }
 
-        // Get the block producers who have sent approvals for the block. They should be counted towards chunk endorsements.
-        let block_producers =
-            self.epoch_manager.get_epoch_block_approvers_ordered(block.header().prev_hash())?;
-        let chunk_endorsement_from_approvals = block_producers
-            .into_iter()
-            .zip(block.header().approvals())
-            .filter_map(
-                |((approval, _), signature)| {
-                    if signature.is_some() {
-                        Some(approval.account_id)
-                    } else {
-                        None
-                    }
-                },
-            )
-            .collect::<HashSet<_>>();
-
         let epoch_id =
             self.epoch_manager.get_epoch_id_from_prev_block(block.header().prev_hash())?;
         for (chunk_header, signatures) in block.chunks().iter().zip(block.chunk_endorsements()) {
@@ -84,7 +67,6 @@ impl Chain {
             // Verify that the signature in block body are valid for given chunk_validator.
             // Signature can be either None, or Some(signature).
             // We calculate the stake of the chunk_validators for who we have the signature present.
-            // We always include block producers who have sent approvals, since that indicate they have applied the corresponding chunk
             let mut endorsed_chunk_validators = HashSet::new();
             for (account_id, signature) in ordered_chunk_validators.iter().zip(signatures) {
                 let Some(signature) = signature else { continue };
@@ -110,16 +92,7 @@ impl Chain {
                 }
 
                 // Add validators with signature in endorsed_chunk_validators. We later use this to check stake.
-                endorsed_chunk_validators.insert(account_id.clone());
-            }
-
-            for chunk_producer in self
-                .epoch_manager
-                .get_epoch_chunk_producers_for_shard(&epoch_id, chunk_header.shard_id())?
-            {
-                if chunk_endorsement_from_approvals.contains(chunk_producer.account_id()) {
-                    endorsed_chunk_validators.insert(chunk_producer.account_id().clone());
-                }
+                endorsed_chunk_validators.insert(account_id);
             }
 
             let endorsement_stats =

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -742,15 +742,6 @@ impl EpochManagerAdapter for MockEpochManager {
         Ok(chunk_producers[index].account_id().clone())
     }
 
-    fn get_epoch_chunk_producers_for_shard(
-        &self,
-        epoch_id: &EpochId,
-        shard_id: ShardId,
-    ) -> Result<Vec<ValidatorStake>, EpochError> {
-        let valset = self.get_valset_for_epoch(epoch_id)?;
-        Ok(self.get_chunk_producers(valset, shard_id))
-    }
-
     fn get_chunk_validator_assignments(
         &self,
         epoch_id: &EpochId,

--- a/chain/client/src/chunk_inclusion_tracker.rs
+++ b/chain/client/src/chunk_inclusion_tracker.rs
@@ -7,7 +7,7 @@ use near_primitives::block_body::ChunkEndorsementSignatures;
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
 use near_primitives::types::{AccountId, EpochId, ShardId};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use crate::metrics;
 use crate::stateless_validation::chunk_endorsement_tracker::{
@@ -106,18 +106,15 @@ impl ChunkInclusionTracker {
         &mut self,
         prev_block_hash: &CryptoHash,
         endorsement_tracker: &ChunkEndorsementTracker,
-        mut chunk_producers_with_approvals: HashMap<ShardId, HashSet<AccountId>>,
     ) -> Result<(), Error> {
         let Some(entry) = self.prev_block_to_chunk_hash_ready.get(prev_block_hash) else {
             return Ok(());
         };
 
-        for (shard_id, chunk_hash) in entry.iter() {
+        for chunk_hash in entry.values() {
             let chunk_info = self.chunk_hash_to_chunk_info.get_mut(chunk_hash).unwrap();
-            chunk_info.endorsements = endorsement_tracker.compute_chunk_endorsements(
-                &chunk_info.chunk_header,
-                chunk_producers_with_approvals.remove(shard_id).unwrap_or_default(),
-            )?;
+            chunk_info.endorsements =
+                endorsement_tracker.compute_chunk_endorsements(&chunk_info.chunk_header)?;
         }
         Ok(())
     }

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -557,38 +557,6 @@ impl Client {
         self.produce_block_on_head(height, true)
     }
 
-    /// Wrapper on top of `self.chunk_inclusion_tracker.prepare_chunk_headers_ready_for_inclusion`
-    /// and uses block approvals for chunk endorsements
-    pub fn prepare_chunk_headers_ready_for_inclusion(
-        &mut self,
-        prev_block_hash: &CryptoHash,
-        height: BlockHeight,
-    ) -> Result<(), Error> {
-        let prev = self.chain.get_block_header(prev_block_hash)?;
-        // Compute a map of shard id -> chunk producers who already sent approvals. For those chunk producers, if they also
-        // act as a chunk validator, they don't need to send chunk endorsements.
-        let witness = self.doomslug.get_witness(prev.hash(), prev.height(), height);
-        let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(prev_block_hash)?;
-        let mut chunk_producers_with_approvals = HashMap::new();
-        for shard_id in self.epoch_manager.shard_ids(&epoch_id)? {
-            let chunk_producers =
-                self.epoch_manager.get_epoch_chunk_producers_for_shard(&epoch_id, shard_id)?;
-            for chunk_producer in chunk_producers {
-                if witness.contains_key(chunk_producer.account_id()) {
-                    chunk_producers_with_approvals
-                        .entry(shard_id)
-                        .or_insert_with(HashSet::new)
-                        .insert(chunk_producer.account_id().clone());
-                }
-            }
-        }
-        Ok(self.chunk_inclusion_tracker.prepare_chunk_headers_ready_for_inclusion(
-            prev_block_hash,
-            self.chunk_endorsement_tracker.as_ref(),
-            chunk_producers_with_approvals,
-        )?)
-    }
-
     /// Produce block for given `height` on top of chain head.
     /// Either returns produced block (not applied) or error.
     pub fn produce_block_on_head(
@@ -606,7 +574,10 @@ impl Client {
         );
 
         if prepare_chunk_headers {
-            self.prepare_chunk_headers_ready_for_inclusion(&head.last_block_hash, height)?;
+            self.chunk_inclusion_tracker.prepare_chunk_headers_ready_for_inclusion(
+                &head.last_block_hash,
+                self.chunk_endorsement_tracker.as_ref(),
+            )?;
         }
 
         self.produce_block_on(height, head.last_block_hash)

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1106,8 +1106,10 @@ impl ClientActorInner {
                 self.client.epoch_manager.get_block_producer(&epoch_id, height)?;
 
             if me == next_block_producer_account {
-                self.client
-                    .prepare_chunk_headers_ready_for_inclusion(&head.last_block_hash, height)?;
+                self.client.chunk_inclusion_tracker.prepare_chunk_headers_ready_for_inclusion(
+                    &head.last_block_hash,
+                    self.client.chunk_endorsement_tracker.as_ref(),
+                )?;
                 let num_chunks = self
                     .client
                     .chunk_inclusion_tracker

--- a/chain/client/src/stateless_validation/chunk_endorsement_tracker.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement_tracker.rs
@@ -1,6 +1,6 @@
 use near_cache::SyncLruCache;
 use near_chain::ChainStoreAccess;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use near_chain_primitives::Error;
@@ -171,7 +171,6 @@ impl ChunkEndorsementTracker {
     pub fn compute_chunk_endorsements(
         &self,
         chunk_header: &ShardChunkHeader,
-        chunk_producers_with_approvals: HashSet<AccountId>,
     ) -> Result<ChunkEndorsementsState, Error> {
         let epoch_id =
             self.epoch_manager.get_epoch_id_from_prev_block(chunk_header.prev_block_hash())?;
@@ -186,28 +185,19 @@ impl ChunkEndorsementTracker {
             chunk_header.shard_id(),
             chunk_header.height_created(),
         )?;
-
-        let mut all_endorsers = chunk_producers_with_approvals;
-
         // Get the chunk_endorsements for the chunk from our cache.
         // Note that these chunk endorsements are already validated as part of process_chunk_endorsement.
         // We can safely rely on the following details
         //    1. The chunk endorsements are from valid chunk_validator for this chunk.
         //    2. The chunk endorsements signatures are valid.
-
-        let chunk_endorsements = {
-            if let Some(chunk_endorsements) =
-                self.chunk_endorsements.get(&chunk_header.chunk_hash())
-            {
-                all_endorsers.extend(chunk_endorsements.keys().cloned());
-                chunk_endorsements
-            } else {
-                HashMap::new()
-            }
+        let Some(chunk_endorsements) = self.chunk_endorsements.get(&chunk_header.chunk_hash())
+        else {
+            // Early return if no chunk_endorsements found in our cache.
+            return Ok(ChunkEndorsementsState::NotEnoughStake(None));
         };
 
-        let endorsement_stats =
-            chunk_validator_assignments.compute_endorsement_stats(&all_endorsers);
+        let endorsement_stats = chunk_validator_assignments
+            .compute_endorsement_stats(&chunk_endorsements.keys().collect());
 
         // Check whether the current set of chunk_validators have enough stake to include chunk in block.
         if !endorsement_stats.has_enough_stake() {

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -191,12 +191,6 @@ pub trait EpochManagerAdapter: Send + Sync {
         epoch_id: &EpochId,
     ) -> Result<Vec<ValidatorStake>, EpochError>;
 
-    fn get_epoch_chunk_producers_for_shard(
-        &self,
-        epoch_id: &EpochId,
-        shard_id: ShardId,
-    ) -> Result<Vec<ValidatorStake>, EpochError>;
-
     /// Block producers for given height for the main block. Return EpochError if outside of known boundaries.
     fn get_block_producer(
         &self,
@@ -718,15 +712,6 @@ impl EpochManagerAdapter for EpochManagerHandle {
     ) -> Result<Vec<ValidatorStake>, EpochError> {
         let epoch_manager = self.read();
         Ok(epoch_manager.get_all_chunk_producers(epoch_id)?.to_vec())
-    }
-
-    fn get_epoch_chunk_producers_for_shard(
-        &self,
-        epoch_id: &EpochId,
-        shard_id: ShardId,
-    ) -> Result<Vec<ValidatorStake>, EpochError> {
-        let epoch_manager = self.read();
-        Ok(epoch_manager.get_chunk_producers_for_shard(epoch_id, shard_id)?)
     }
 
     fn get_block_producer(

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -955,24 +955,6 @@ impl EpochManager {
         })
     }
 
-    pub fn get_chunk_producers_for_shard(
-        &self,
-        epoch_id: &EpochId,
-        shard_id: ShardId,
-    ) -> Result<Vec<ValidatorStake>, EpochError> {
-        let epoch_info = self.get_epoch_info(epoch_id)?;
-        let chunk_producers = epoch_info.chunk_producers_settlement();
-        let chunk_producers = chunk_producers
-            .get(shard_id as usize)
-            .ok_or_else(|| {
-                EpochError::ShardingError(format!("{} is not a valid shard id", shard_id))
-            })?
-            .iter()
-            .map(|i| epoch_info.get_validator(*i))
-            .collect();
-        Ok(chunk_producers)
-    }
-
     /// Returns the list of chunk_validators for the given shard_id and height and set of account ids.
     /// Generation of chunk_validators and their order is deterministic for given shard_id and height.
     /// We cache the generated chunk_validators.

--- a/core/primitives/src/stateless_validation.rs
+++ b/core/primitives/src/stateless_validation.rs
@@ -507,7 +507,7 @@ impl ChunkValidatorAssignments {
 
     pub fn compute_endorsement_stats(
         &self,
-        endorsed_chunk_validators: &HashSet<AccountId>,
+        endorsed_chunk_validators: &HashSet<&AccountId>,
     ) -> EndorsementStats {
         let mut total_stake = 0;
         let mut endorsed_stake = 0;

--- a/integration-tests/src/tests/client/features/stateless_validation.rs
+++ b/integration-tests/src/tests/client/features/stateless_validation.rs
@@ -1,5 +1,4 @@
 use near_epoch_manager::{EpochManager, EpochManagerAdapter};
-use near_primitives::block::{Approval, ApprovalType};
 use near_primitives::stateless_validation::{ChunkStateWitness, EncodedChunkStateWitness};
 use near_store::test_utils::create_test_store;
 use rand::rngs::StdRng;
@@ -10,7 +9,7 @@ use near_chain::Provenance;
 use near_chain_configs::{Genesis, GenesisConfig, GenesisRecords};
 use near_client::test_utils::TestEnv;
 use near_crypto::{InMemorySigner, KeyType};
-use near_o11y::testonly::{init_integration_logger, init_test_logger};
+use near_o11y::testonly::init_integration_logger;
 use near_primitives::epoch_manager::AllEpochConfigTestOverrides;
 use near_primitives::num_rational::Rational32;
 use near_primitives::shard_layout::ShardLayout;
@@ -346,71 +345,4 @@ fn test_chunk_state_witness_bad_shard_id() {
     let error_message = format!("{}", error).to_lowercase();
     tracing::info!(target: "test", "error message: {}", error_message);
     assert!(error_message.contains("shard"));
-}
-
-/// Test that block approvals can serve as chunk endorsements by not sending chunk endorsements from block producers
-#[test]
-fn test_implicit_chunk_endorsements() {
-    init_test_logger();
-
-    if !checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION) {
-        println!("Test not applicable without StatelessValidation enabled");
-        return;
-    }
-
-    let accounts =
-        vec!["test0".parse().unwrap(), "test1".parse().unwrap(), "test2".parse().unwrap()];
-    let signers: Vec<near_primitives::validator_signer::InMemoryValidatorSigner> = accounts
-        .iter()
-        .map(|account_id: &AccountId| create_test_signer(account_id.as_str()))
-        .collect();
-    let genesis = Genesis::test(accounts.clone(), 2);
-    let mut env = TestEnv::builder(&genesis.config)
-        .validators(accounts.clone())
-        .clients(accounts)
-        .nightshade_runtimes(&genesis)
-        .build();
-
-    // Run the client for a few blocks
-    let target_height = 6;
-    for _ in 1..target_height {
-        let tip = env.clients[0].chain.head().unwrap();
-        let block_producer = env.get_block_producer_at_offset(&tip, 1);
-        tracing::info!(
-            target: "stateless_validation",
-            "Producing block at height {} by {}", tip.height + 1, block_producer
-        );
-        let block = env.client(&block_producer).produce_block(tip.height + 1).unwrap().unwrap();
-        let approvals: Vec<_> = signers
-            .iter()
-            .map(|signer| {
-                Approval::new(
-                    *block.hash(),
-                    block.header().height(),
-                    block.header().height() + 1,
-                    signer,
-                )
-            })
-            .collect();
-        for i in 0..env.clients.len() {
-            let blocks_processed =
-                env.clients[i].process_block_test(block.clone().into(), Provenance::NONE).unwrap();
-            assert_eq!(blocks_processed, vec![*block.hash()]);
-            if block.header().height() > 1 {
-                // Check that chunks are included in the block. This is only possible if we have block approvals working
-                // as chunk endorsements since chunk endorsements are not sent in this test.
-                assert!(block.header().chunk_mask().iter().all(|&b| b));
-            }
-            for approval in &approvals {
-                env.clients[i].collect_block_approval(approval, ApprovalType::SelfApproval);
-            }
-        }
-
-        env.process_partial_encoded_chunks();
-        for j in 0..env.clients.len() {
-            env.process_shards_manager_responses_and_finish_processing_blocks(j);
-        }
-        // Do not propagate chunk state witnesses and endorsements
-        // Block producers should be able to endorse through approvals and process chunks without state witness
-    }
 }

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2301,9 +2301,14 @@ fn test_validate_chunk_extra() {
 
     // Produce a block on top of block1.
     // Validate that result of chunk execution in `block1` is legit.
-    let height = next_height + 2;
-    client.prepare_chunk_headers_ready_for_inclusion(block1.hash(), height).unwrap();
-    let block = client.produce_block_on(height, *block1.hash()).unwrap().unwrap();
+    client
+        .chunk_inclusion_tracker
+        .prepare_chunk_headers_ready_for_inclusion(
+            block1.hash(),
+            client.chunk_endorsement_tracker.as_ref(),
+        )
+        .unwrap();
+    let block = client.produce_block_on(next_height + 2, *block1.hash()).unwrap().unwrap();
     client.process_block_test(block.into(), Provenance::PRODUCED).unwrap();
     let chunks = client
         .chunk_inclusion_tracker


### PR DESCRIPTION
The logic in #11255 is not correct because chunk endorsement is dependent on the chunk header included in the current block and endorses that chunk header is valid. Block approvals cannot replace chunk endorsements because when a block approval is sent, there is no guarantee that the chunk producer has seen the new chunk header and therefore a malicious attacker can still produce an invalid chunk with correct block approvals. Thanks @pugachAG for catching this!