### PR TITLE
feat: skip applying state witness for chunk producers

### DIFF
--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -148,7 +148,10 @@ impl ChunkValidator {
                     return Ok(());
                 }
                 Err(err) => {
-                    tracing::error!("Failed to validate chunk using existing chunk extra: {:?}", err);
+                    tracing::error!(
+                        "Failed to validate chunk using existing chunk extra: {:?}",
+                        err
+                    );
                     return Err(err);
                 }
             }

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -145,9 +145,11 @@ impl ChunkValidator {
                         &network_sender,
                         chunk_endorsement_tracker.as_ref(),
                     );
+                    return Ok(());
                 }
                 Err(err) => {
-                    tracing::error!("Failed to validate chunk: {:?}", err);
+                    tracing::error!("Failed to validate chunk using existing chunk extra: {:?}", err);
+                    return Err(err);
                 }
             }
         }


### PR DESCRIPTION
As noted in https://github.com/near/nearcore/pull/11330, we cannot skip validation of state witness altogether even if we have applied the chunk itself because chunk header still needs to be validated. Otherwise the invariant that no blocks contain invalid chunks could be broken. This PR does a much less invasive optimization and only skip apply state witness if we have the previous chunk extra locally. Other validation of state witness still remains the same.

Existing tests should suffice since we still send chunk endorsement inside the same function `start_validating_chunk`, just slightly earlier.