### PR TITLE
fix(mirror): send V0 transactions

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -978,7 +978,7 @@ impl Client {
         if insert {
             txs.transactions.push(SignedTransaction::new(
                 near_crypto::Signature::empty(near_crypto::KeyType::ED25519),
-                near_primitives::transaction::Transaction::new(
+                near_primitives::transaction::Transaction::new_v1(
                     "test".parse().unwrap(),
                     near_crypto::PublicKey::empty(near_crypto::KeyType::SECP256K1),
                     "other".parse().unwrap(),

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -30,33 +30,21 @@ pub fn account_new(amount: Balance, code_hash: CryptoHash) -> Account {
 }
 
 impl Transaction {
-    pub fn new(
+    pub fn new_v0(
         signer_id: AccountId,
         public_key: PublicKey,
         receiver_id: AccountId,
         nonce: Nonce,
         block_hash: CryptoHash,
-        priority_fee: Option<u64>,
     ) -> Self {
-        match priority_fee {
-            Some(priority_fee) => Transaction::V1(TransactionV1 {
-                signer_id,
-                public_key,
-                nonce,
-                receiver_id,
-                block_hash,
-                actions: vec![],
-                priority_fee,
-            }),
-            None => Transaction::V0(TransactionV0 {
-                signer_id,
-                public_key,
-                nonce,
-                receiver_id,
-                block_hash,
-                actions: vec![],
-            }),
-        }
+        Transaction::V0(TransactionV0 {
+            signer_id,
+            public_key,
+            nonce,
+            receiver_id,
+            block_hash,
+            actions: vec![],
+        })
     }
 
     pub fn actions_mut(&mut self) -> &mut Vec<Action> {

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -47,6 +47,25 @@ impl Transaction {
         })
     }
 
+    pub fn new_v1(
+        signer_id: AccountId,
+        public_key: PublicKey,
+        receiver_id: AccountId,
+        nonce: Nonce,
+        block_hash: CryptoHash,
+        priority_fee: u64,
+    ) -> Self {
+        Transaction::V1(TransactionV1 {
+            signer_id,
+            public_key,
+            nonce,
+            receiver_id,
+            block_hash,
+            actions: vec![],
+            priority_fee,
+        })
+    }
+
     pub fn actions_mut(&mut self) -> &mut Vec<Action> {
         match self {
             Transaction::V0(tx) => &mut tx.actions,

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -36,17 +36,27 @@ impl Transaction {
         receiver_id: AccountId,
         nonce: Nonce,
         block_hash: CryptoHash,
-        priority_fee: u64,
+        priority_fee: Option<u64>,
     ) -> Self {
-        Transaction::V1(TransactionV1 {
-            signer_id,
-            public_key,
-            nonce,
-            receiver_id,
-            block_hash,
-            actions: vec![],
-            priority_fee,
-        })
+        match priority_fee {
+            Some(priority_fee) => Transaction::V1(TransactionV1 {
+                signer_id,
+                public_key,
+                nonce,
+                receiver_id,
+                block_hash,
+                actions: vec![],
+                priority_fee,
+            }),
+            None => Transaction::V0(TransactionV0 {
+                signer_id,
+                public_key,
+                nonce,
+                receiver_id,
+                block_hash,
+                actions: vec![],
+            }),
+        }
     }
 
     pub fn actions_mut(&mut self) -> &mut Vec<Action> {

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -597,13 +597,12 @@ impl TxAwaitingNonce {
         provenance: MappedTxProvenance,
         nonce_updates: HashSet<(AccountId, PublicKey)>,
     ) -> Self {
-        let mut target_tx = Transaction::new(
+        let mut target_tx = Transaction::new_v0(
             target_signer_id,
             target_public_key,
             target_receiver_id,
             0,
             *ref_hash,
-            None,
         );
         *target_tx.actions_mut() = actions;
         Self {
@@ -645,13 +644,12 @@ impl MappedTx {
         provenance: MappedTxProvenance,
         nonce_updates: HashSet<(AccountId, PublicKey)>,
     ) -> Self {
-        let mut target_tx = Transaction::new(
+        let mut target_tx = Transaction::new_v0(
             target_signer_id,
             target_public_key,
             target_receiver_id,
             nonce,
             *ref_hash,
-            None,
         );
         *target_tx.actions_mut() = actions;
         let target_tx = SignedTransaction::new(

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -603,7 +603,7 @@ impl TxAwaitingNonce {
             target_receiver_id,
             0,
             *ref_hash,
-            0,
+            None,
         );
         *target_tx.actions_mut() = actions;
         Self {
@@ -651,7 +651,7 @@ impl MappedTx {
             target_receiver_id,
             nonce,
             *ref_hash,
-            0,
+            None,
         );
         *target_tx.actions_mut() = actions;
         let target_tx = SignedTransaction::new(


### PR DESCRIPTION
The Transaction::new() function was changed to create V1 transactions, but we want only V0 transactions in the mirror tool for now, because otherwise all our transactions will be rejected. So we can fix this by making the priority_fee field an Option, and having it return a V0 transaction if it's None