### PR TITLE
fix(mirror): queue fake blocks for initial create account txs

### DIFF
--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -1815,17 +1815,24 @@ impl<T: ChainAccess> TxMirror<T> {
             // send any extra function call-initiated create accounts for the first few blocks right now
             // we set source_hash to 0 because we don't actually care about it here, and it doesn't even exist since these are
             // not transactions corresponding to some actual block, but just extra txs create account actions in the first few blocks.
-            let mut txs = Vec::new();
+            let mut block = MappedBlock {
+                source_hash: CryptoHash::default(),
+                source_height: last_height,
+                chunks: vec![MappedChunk { shard_id: 0, txs: Vec::new() }],
+            };
             for h in next_heights {
-                self.add_create_account_txs(h, target_head, &mut tracker, &mut txs).await?;
+                self.add_create_account_txs(h, target_head, &mut tracker, &mut block.chunks[0].txs)
+                    .await?;
             }
-            if !txs.is_empty() {
+            if block.chunks.iter().any(|c| !c.txs.is_empty()) {
                 tracing::debug!(target: "mirror", "sending extra create account transactions for the first {} blocks", CREATE_ACCOUNT_DELTA);
-                self.send_transactions(txs.iter_mut()).await?;
+                tracker.queue_block(block, &self.target_view_client, &self.db).await?;
+                let mut b = tracker.next_batch(&self.target_view_client, &self.db).await?;
+                self.send_transactions(b.txs.iter_mut().map(|(_tx_ref, tx)| tx)).await?;
                 tracker
                     .on_txs_sent(
                         &self.db,
-                        crate::chain_tracker::SentBatch::ExtraTxs(txs),
+                        crate::chain_tracker::SentBatch::MappedBlock(b),
                         target_height,
                     )
                     .await?;


### PR DESCRIPTION
This reverts commit e301c09e5acf75a4e1603c8ae3904f24eef9962f from https://github.com/near/nearcore/pull/11325. This small commit was not necessary, and actually incorrect, because there's an assumption that changed access keys will only appear in SentBatch::MappedBlock(). Otherwise we hit an assertion here: https://github.com/near/nearcore/blob/510948178c5920c614448dc7bcce72873a1655fd/tools/mirror/src/chain_tracker.rs#L1026