### PR TITLE
[Memtrie] Optimize NibbleSlice during the memtrie construction code path

### DIFF
--- a/core/store/src/trie/mem/flexible_data/children.rs
+++ b/core/store/src/trie/mem/flexible_data/children.rs
@@ -40,11 +40,11 @@ impl FlexibleDataHeader for EncodedChildrenHeader {
 
     fn encode_flexible_data(
         &self,
-        children: [Option<MemTrieNodeId>; 16],
+        children: &[Option<MemTrieNodeId>; 16],
         target: &mut ArenaSliceMut<'_>,
     ) {
         let mut j = 0;
-        for (i, child) in children.into_iter().enumerate() {
+        for (i, child) in children.iter().enumerate() {
             if self.mask & (1 << i) != 0 {
                 target.write_pos_at(j, child.unwrap().pos);
                 j += size_of::<usize>();

--- a/core/store/src/trie/mem/flexible_data/encoding.rs
+++ b/core/store/src/trie/mem/flexible_data/encoding.rs
@@ -51,7 +51,7 @@ impl<'a> RawEncoder<'a> {
     /// flexibly-sized part, as returned by `header.flexible_data_length()`.
     /// Note that the header itself is NOT encoded; only the flexible part is.
     /// The header is expected to have been encoded earlier.
-    pub fn encode_flexible<T: FlexibleDataHeader>(&mut self, header: &T, data: T::InputData) {
+    pub fn encode_flexible<T: FlexibleDataHeader>(&mut self, header: &T, data: &T::InputData) {
         let length = header.flexible_data_length();
         header.encode_flexible_data(data, &mut self.data.subslice_mut(self.pos, length));
         self.pos += length;

--- a/core/store/src/trie/mem/flexible_data/extension.rs
+++ b/core/store/src/trie/mem/flexible_data/extension.rs
@@ -16,9 +16,9 @@ impl BorshFixedSize for EncodedExtensionHeader {
 }
 
 impl FlexibleDataHeader for EncodedExtensionHeader {
-    type InputData = Box<[u8]>;
+    type InputData = [u8];
     type View<'a> = ArenaSlice<'a>;
-    fn from_input(extension: &Box<[u8]>) -> EncodedExtensionHeader {
+    fn from_input(extension: &[u8]) -> EncodedExtensionHeader {
         EncodedExtensionHeader { length: extension.len() as u16 }
     }
 
@@ -26,7 +26,7 @@ impl FlexibleDataHeader for EncodedExtensionHeader {
         self.length as usize
     }
 
-    fn encode_flexible_data(&self, extension: Box<[u8]>, target: &mut ArenaSliceMut<'_>) {
+    fn encode_flexible_data(&self, extension: &[u8], target: &mut ArenaSliceMut<'_>) {
         target.raw_slice_mut().copy_from_slice(&extension);
     }
 

--- a/core/store/src/trie/mem/flexible_data/mod.rs
+++ b/core/store/src/trie/mem/flexible_data/mod.rs
@@ -28,7 +28,7 @@ pub mod value;
 /// with multiple flexibly-sized parts with relative ease.
 pub trait FlexibleDataHeader {
     /// The type of the original form of data to be used for encoding.
-    type InputData;
+    type InputData: ?Sized;
     /// The type of a view of the decoded data, which may reference the memory
     /// that we are decoding from, and therefore having a lifetime.
     type View<'a>;
@@ -45,7 +45,7 @@ pub trait FlexibleDataHeader {
     /// slice. This function must be implemented in a way that writes
     /// exactly `self.flexible_data_length()` bytes to the given memory
     /// slice. The caller must ensure that the memory slice is large enough.
-    fn encode_flexible_data(&self, data: Self::InputData, target: &mut ArenaSliceMut<'_>);
+    fn encode_flexible_data(&self, data: &Self::InputData, target: &mut ArenaSliceMut<'_>);
 
     /// Decodes the flexibly-sized part of the data from the given memory
     /// slice. This function must be implemented in a consistent manner

--- a/core/store/src/trie/mem/flexible_data/value.rs
+++ b/core/store/src/trie/mem/flexible_data/value.rs
@@ -60,7 +60,7 @@ impl FlexibleDataHeader for EncodedValueHeader {
         }
     }
 
-    fn encode_flexible_data(&self, value: FlatStateValue, target: &mut ArenaSliceMut<'_>) {
+    fn encode_flexible_data(&self, value: &FlatStateValue, target: &mut ArenaSliceMut<'_>) {
         let (length, inlined) = self.decode();
         match value {
             FlatStateValue::Ref(value_ref) => {
@@ -71,7 +71,7 @@ impl FlexibleDataHeader for EncodedValueHeader {
             FlatStateValue::Inlined(v) => {
                 assert!(inlined);
                 assert_eq!(length, v.len() as u32);
-                target.raw_slice_mut().copy_from_slice(&v);
+                target.raw_slice_mut().copy_from_slice(v);
             }
         }
     }

--- a/core/store/src/trie/mem/freelist.rs
+++ b/core/store/src/trie/mem/freelist.rs
@@ -1,0 +1,90 @@
+use std::ops::Deref;
+
+/// A simple freelist for `Vec<u8>` that is used to avoid unnecessary
+/// re-allocations.
+pub struct VecU8Freelist {
+    free: Vec<ReusableVecU8>,
+
+    // There are two ways we detect that the freelist is not being used properly:
+    //  1. If a ReusableVecU8 is dropped before being returned to the freelist,
+    //     it will panic in debug.
+    //  2. If the number of allocations exceeds the expected number of allocations,
+    //     it will panic in debug and log an error in production the first time
+    //     it happens.
+    num_allocs: usize,
+    expected_allocs: usize,
+}
+
+/// A wrapper around `Vec<u8>` that makes it harder to accidentally drop it
+/// without returning it to the freelist.
+pub struct ReusableVecU8 {
+    vec: Vec<u8>,
+}
+
+impl Deref for ReusableVecU8 {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.vec
+    }
+}
+
+impl ReusableVecU8 {
+    /// Used to actually free the vector in the end.
+    fn internal_free(&mut self) {
+        std::mem::take(&mut self.vec);
+    }
+
+    pub fn vec_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.vec
+    }
+}
+
+impl Drop for ReusableVecU8 {
+    fn drop(&mut self) {
+        // Do not drop without returning it to the freelist.
+        debug_assert_eq!(self.vec.capacity(), 0);
+    }
+}
+
+impl VecU8Freelist {
+    /// Create a new freelist with an expected number of non-reused allocations.
+    /// The expected number is used to detect incorrect usage of the freelist.
+    pub fn new(expected_allocs: usize) -> Self {
+        Self { free: Vec::with_capacity(expected_allocs), num_allocs: 0, expected_allocs }
+    }
+
+    /// Returns a byte array, by either reusing one or allocating a new one
+    /// if there's none to reuse.
+    pub fn alloc(&mut self) -> ReusableVecU8 {
+        if let Some(vec) = self.free.pop() {
+            vec
+        } else {
+            self.num_allocs += 1;
+            if self.num_allocs == self.expected_allocs {
+                // If this triggers, it means that we're not using the freelist properly.
+                if cfg!(debug_assertions) {
+                    panic!("Too many freelist allocations; expected {}", self.expected_allocs);
+                } else {
+                    tracing::error!(target: "memtrie", "Too many freelist allocations; expected {}", self.expected_allocs);
+                }
+            }
+            ReusableVecU8 { vec: Vec::new() }
+        }
+    }
+
+    /// Returns a byte array to the freelist.
+    pub fn free(&mut self, mut vec: ReusableVecU8) {
+        vec.vec.clear();
+        self.free.push(vec);
+    }
+}
+
+impl Drop for VecU8Freelist {
+    fn drop(&mut self) {
+        // This is where the returned byte arrays are actually freed.
+        for mut vec in self.free.drain(..) {
+            vec.internal_free();
+        }
+    }
+}

--- a/core/store/src/trie/mem/mod.rs
+++ b/core/store/src/trie/mem/mod.rs
@@ -11,6 +11,7 @@ use std::collections::{BTreeMap, HashMap};
 mod arena;
 mod construction;
 pub(crate) mod flexible_data;
+mod freelist;
 pub mod iter;
 pub mod loading;
 pub mod lookup;
@@ -224,13 +225,10 @@ mod tests {
                                 let root = MemTrieNodeId::new(
                                     arena,
                                     InputMemTrieNode::Leaf {
-                                        value: FlatStateValue::Inlined(
+                                        value: &FlatStateValue::Inlined(
                                             format!("{}", height).into_bytes(),
                                         ),
-                                        extension: NibbleSlice::new(&[])
-                                            .encoded(true)
-                                            .to_vec()
-                                            .into_boxed_slice(),
+                                        extension: &NibbleSlice::new(&[]).encoded(true),
                                     },
                                 );
                                 root.as_ptr_mut(arena.memory_mut()).compute_hash_recursively();

--- a/core/store/src/trie/mem/node/encoding.rs
+++ b/core/store/src/trie/mem/node/encoding.rs
@@ -180,7 +180,7 @@ impl MemTrieNodeId {
                     value: value_header,
                 });
                 data.encode_flexible(&extension_header, extension);
-                data.encode_flexible(&value_header, value);
+                data.encode_flexible(&value_header, &value);
                 data.finish()
             }
             InputMemTrieNode::Extension { extension, child } => {
@@ -209,7 +209,7 @@ impl MemTrieNodeId {
                     nonleaf: NonLeafHeader::new(memory_usage, node_hash),
                     children: children_header,
                 });
-                data.encode_flexible(&children_header, children);
+                data.encode_flexible(&children_header, &children);
                 data.finish()
             }
             InputMemTrieNode::BranchWithValue { children, value } => {
@@ -227,8 +227,8 @@ impl MemTrieNodeId {
                     children: children_header,
                     value: value_header,
                 });
-                data.encode_flexible(&children_header, children);
-                data.encode_flexible(&value_header, value);
+                data.encode_flexible(&children_header, &children);
+                data.encode_flexible(&value_header, &value);
                 data.finish()
             }
         };

--- a/core/store/src/trie/mem/node/mod.rs
+++ b/core/store/src/trie/mem/node/mod.rs
@@ -43,6 +43,14 @@ impl MemTrieNodeId {
     }
 }
 
+/// This is for internal use only, so that we can put `MemTrieNodeId` in an
+/// ElasticArray.
+impl Default for MemTrieNodeId {
+    fn default() -> Self {
+        Self { pos: ArenaPos::invalid() }
+    }
+}
+
 /// Pointer to an in-memory trie node that allows read-only access to the node
 /// and all its descendants.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -79,11 +87,11 @@ impl<'a> MemTrieNodePtr<'a> {
 
 /// Used to construct a new in-memory trie node.
 #[derive(PartialEq, Eq, Debug, Clone)]
-pub enum InputMemTrieNode {
-    Leaf { value: FlatStateValue, extension: Box<[u8]> },
-    Extension { extension: Box<[u8]>, child: MemTrieNodeId },
+pub enum InputMemTrieNode<'a> {
+    Leaf { value: &'a FlatStateValue, extension: &'a [u8] },
+    Extension { extension: &'a [u8], child: MemTrieNodeId },
     Branch { children: [Option<MemTrieNodeId>; 16] },
-    BranchWithValue { children: [Option<MemTrieNodeId>; 16], value: FlatStateValue },
+    BranchWithValue { children: [Option<MemTrieNodeId>; 16], value: &'a FlatStateValue },
 }
 
 /// A view of the encoded data of `MemTrieNode`, obtainable via

--- a/core/store/src/trie/mem/node/tests.rs
+++ b/core/store/src/trie/mem/node/tests.rs
@@ -11,8 +11,8 @@ fn test_basic_leaf_node_inlined() {
     let node = MemTrieNodeId::new(
         &mut arena,
         InputMemTrieNode::Leaf {
-            extension: vec![0, 1, 2, 3, 4].into_boxed_slice(),
-            value: FlatStateValue::Inlined(vec![5, 6, 7, 8, 9]),
+            extension: &[0, 1, 2, 3, 4],
+            value: &FlatStateValue::Inlined(vec![5, 6, 7, 8, 9]),
         },
     );
     let view = node.as_ptr(arena.memory()).view();
@@ -44,8 +44,8 @@ fn test_basic_leaf_node_ref() {
     let node = MemTrieNodeId::new(
         &mut arena,
         InputMemTrieNode::Leaf {
-            extension: vec![0, 1, 2, 3, 4].into_boxed_slice(),
-            value: FlatStateValue::Ref(ValueRef { hash: test_hash, length: 5 }),
+            extension: &[0, 1, 2, 3, 4],
+            value: &FlatStateValue::Ref(ValueRef { hash: test_hash, length: 5 }),
         },
     );
     let view = node.as_ptr(arena.memory()).view();
@@ -75,10 +75,7 @@ fn test_basic_leaf_node_empty_extension_empty_value() {
     let mut arena = Arena::new("".to_owned());
     let node = MemTrieNodeId::new(
         &mut arena,
-        InputMemTrieNode::Leaf {
-            extension: vec![].into_boxed_slice(),
-            value: FlatStateValue::Inlined(vec![]),
-        },
+        InputMemTrieNode::Leaf { extension: &[], value: &FlatStateValue::Inlined(vec![]) },
     );
     let view = node.as_ptr(arena.memory()).view();
     assert_eq!(
@@ -105,13 +102,13 @@ fn test_basic_extension_node() {
     let child = MemTrieNodeId::new(
         &mut arena,
         InputMemTrieNode::Leaf {
-            extension: vec![0, 1, 2, 3, 4].into_boxed_slice(),
-            value: FlatStateValue::Inlined(vec![5, 6, 7, 8, 9]),
+            extension: &[0, 1, 2, 3, 4],
+            value: &FlatStateValue::Inlined(vec![5, 6, 7, 8, 9]),
         },
     );
     let node = MemTrieNodeId::new(
         &mut arena,
-        InputMemTrieNode::Extension { extension: vec![5, 6, 7, 8, 9].into_boxed_slice(), child },
+        InputMemTrieNode::Extension { extension: &[5, 6, 7, 8, 9], child },
     );
     node.as_ptr_mut(arena.memory_mut()).compute_hash_recursively();
     let child_ptr = child.as_ptr(arena.memory());
@@ -152,17 +149,11 @@ fn test_basic_branch_node() {
     let mut arena = Arena::new("".to_owned());
     let child1 = MemTrieNodeId::new(
         &mut arena,
-        InputMemTrieNode::Leaf {
-            extension: vec![].into_boxed_slice(),
-            value: FlatStateValue::Inlined(vec![1]),
-        },
+        InputMemTrieNode::Leaf { extension: &[], value: &FlatStateValue::Inlined(vec![1]) },
     );
     let child2 = MemTrieNodeId::new(
         &mut arena,
-        InputMemTrieNode::Leaf {
-            extension: vec![1].into_boxed_slice(),
-            value: FlatStateValue::Inlined(vec![2]),
-        },
+        InputMemTrieNode::Leaf { extension: &[1], value: &FlatStateValue::Inlined(vec![2]) },
     );
     let node = MemTrieNodeId::new(
         &mut arena,
@@ -222,23 +213,17 @@ fn test_basic_branch_with_value_node() {
     let mut arena = Arena::new("".to_owned());
     let child1 = MemTrieNodeId::new(
         &mut arena,
-        InputMemTrieNode::Leaf {
-            extension: vec![].into_boxed_slice(),
-            value: FlatStateValue::Inlined(vec![1]),
-        },
+        InputMemTrieNode::Leaf { extension: &[], value: &FlatStateValue::Inlined(vec![1]) },
     );
     let child2 = MemTrieNodeId::new(
         &mut arena,
-        InputMemTrieNode::Leaf {
-            extension: vec![1].into_boxed_slice(),
-            value: FlatStateValue::Inlined(vec![2]),
-        },
+        InputMemTrieNode::Leaf { extension: &[1], value: &FlatStateValue::Inlined(vec![2]) },
     );
     let node = MemTrieNodeId::new(
         &mut arena,
         InputMemTrieNode::BranchWithValue {
             children: branch_array(vec![(0, child1), (15, child2)]),
-            value: FlatStateValue::Inlined(vec![3, 4, 5]),
+            value: &FlatStateValue::Inlined(vec![3, 4, 5]),
         },
     );
 

--- a/core/store/src/trie/mem/updating.rs
+++ b/core/store/src/trie/mem/updating.rs
@@ -876,7 +876,7 @@ pub fn apply_memtrie_changes(
             let node_ids_with_hashes = &changes.node_ids_with_hashes;
             for (node_id, node_hash) in node_ids_with_hashes.iter() {
                 let node = updated_nodes.get(*node_id).unwrap().clone().unwrap();
-                let node = match node {
+                let node = match &node {
                     UpdatedMemTrieNode::Empty => unreachable!(),
                     UpdatedMemTrieNode::Branch { children, value } => {
                         let mut new_children = [None; 16];
@@ -896,7 +896,7 @@ pub fn apply_memtrie_changes(
                     UpdatedMemTrieNode::Extension { extension, child } => {
                         InputMemTrieNode::Extension {
                             extension,
-                            child: map_to_new_node_id(child, &updated_to_new_map),
+                            child: map_to_new_node_id(*child, &updated_to_new_map),
                         }
                     }
                     UpdatedMemTrieNode::Leaf { extension, value } => {

--- a/core/store/src/trie/nibble_slice.rs
+++ b/core/store/src/trie/nibble_slice.rs
@@ -102,11 +102,8 @@ impl<'a> NibbleSlice<'a> {
     /// Get the nibble at position `i`.
     #[inline(always)]
     pub fn at(&self, i: usize) -> u8 {
-        if (self.offset + i) & 1 == 1 {
-            self.data[(self.offset + i) / 2] & 15u8
-        } else {
-            self.data[(self.offset + i) / 2] >> 4
-        }
+        let shift = if (self.offset + i) & 1 == 1 { 0 } else { 4 };
+        (self.data[(self.offset + i) / 2] >> shift) & 0xf
     }
 
     /// Return object which represents a view on to this slice (further) offset by `i` nibbles.
@@ -147,15 +144,38 @@ impl<'a> NibbleSlice<'a> {
     /// Encode while nibble slice in prefixed hex notation, noting whether it `is_leaf`.
     #[inline]
     pub fn encoded(&self, is_leaf: bool) -> ElasticArray36<u8> {
+        let mut to = ElasticArray36::new();
         let l = self.len();
-        let mut r = ElasticArray36::new();
-        let mut i = l % 2;
-        r.push(if i == 1 { 0x10 + self.at(0) } else { 0 } + if is_leaf { 0x20 } else { 0 });
-        while i < l {
-            r.push(self.at(i) * 16 + self.at(i + 1));
-            i += 2;
+        let parity = l % 2;
+        let mut first_byte: u8 = 0;
+        if parity == 1 {
+            first_byte = 0x10 + self.at(0);
         }
-        r
+        if is_leaf {
+            first_byte |= 0x20;
+        }
+        to.push(first_byte);
+        let from_byte = (self.offset + parity) / 2;
+        to.append_slice(&self.data[from_byte..]);
+        to
+    }
+
+    /// Same as `encoded`, but writes the result to the given vector.
+    #[inline]
+    pub fn encode_to(&self, is_leaf: bool, to: &mut Vec<u8>) {
+        let l = self.len();
+        let parity = l % 2;
+        let mut first_byte: u8 = 0;
+        if parity == 1 {
+            first_byte = 0x10 + self.at(0);
+        }
+        if is_leaf {
+            first_byte |= 0x20;
+        }
+        to.clear();
+        to.push(first_byte);
+        let from_byte = (self.offset + parity) / 2;
+        to.extend_from_slice(&self.data[from_byte..]);
     }
 
     pub fn merge_encoded(&self, other: &Self, is_leaf: bool) -> ElasticArray36<u8> {
@@ -193,6 +213,18 @@ impl<'a> NibbleSlice<'a> {
             i += 2;
         }
         r
+    }
+
+    /// Same as `encoded_leftmost`, but writes the result to the given vector.
+    pub fn encode_leftmost_to(&self, n: usize, is_leaf: bool, to: &mut Vec<u8>) {
+        let l = min(self.len(), n);
+        to.resize(1 + l / 2, 0);
+        let mut i = l % 2;
+        to[0] = if i == 1 { 0x10 + self.at(0) } else { 0 } + if is_leaf { 0x20 } else { 0 };
+        while i < l {
+            to[i / 2 + 1] = self.at(i) * 16 + self.at(i + 1);
+            i += 2;
+        }
     }
 
     // Helper to convert nibbles to bytes.
@@ -294,6 +326,11 @@ mod tests {
         let n = NibbleSlice::new(D);
         assert_eq!(n.encoded(false), ElasticArray36::from_slice(&[0x00, 0x01, 0x23, 0x45]));
         assert_eq!(n.encoded(true), ElasticArray36::from_slice(&[0x20, 0x01, 0x23, 0x45]));
+        let mut v = vec![];
+        n.encode_to(false, &mut v);
+        assert_eq!(v, vec![0x00, 0x01, 0x23, 0x45]);
+        n.encode_to(true, &mut v);
+        assert_eq!(v, vec![0x20, 0x01, 0x23, 0x45]);
         assert_eq!(n.mid(1).encoded(false), ElasticArray36::from_slice(&[0x11, 0x23, 0x45]));
         assert_eq!(n.mid(1).encoded(true), ElasticArray36::from_slice(&[0x31, 0x23, 0x45]));
     }
@@ -308,10 +345,24 @@ mod tests {
     }
 
     fn encode_decode(nibbles: &[u8], is_leaf: bool) {
-        let n = NibbleSlice::encode_nibbles(nibbles, is_leaf);
-        let (n, is_leaf_decoded) = NibbleSlice::from_encoded(&n);
+        let encoded = NibbleSlice::encode_nibbles(nibbles, is_leaf);
+        let (n, is_leaf_decoded) = NibbleSlice::from_encoded(&encoded);
         assert_eq!(&n.iter().collect::<Vec<_>>(), nibbles);
-        assert_eq!(is_leaf_decoded, is_leaf)
+        assert_eq!(is_leaf_decoded, is_leaf);
+        let reencoded = n.encoded(is_leaf);
+        assert_eq!(&reencoded, &encoded);
+        let mut reencoded2 = vec![];
+        n.encode_to(is_leaf, &mut reencoded2);
+        assert_eq!(&reencoded2, &encoded.to_vec());
+
+        for i in 0..nibbles.len() {
+            let encoded = NibbleSlice::encode_nibbles(&nibbles[..i], is_leaf);
+            let leftmost_encoded = n.encoded_leftmost(i, is_leaf);
+            assert_eq!(&leftmost_encoded, &encoded);
+            let mut leftmost_encoded2 = vec![];
+            n.encode_leftmost_to(i, is_leaf, &mut leftmost_encoded2);
+            assert_eq!(&leftmost_encoded2, &encoded.to_vec());
+        }
     }
 
     #[test]


### PR DESCRIPTION
This contains two top optimizations that speed up the memtrie construction code:

* Rather than allocating a new Vec<u8> every time we encode nibbles, we use a freelist so that previously allocated Vec<u8> can be reused. This reduces allocations from O(millions) to O(tens).
  * As a side effect, InputMemTrieNode has to be changed to contain borrowed slices, as we can no longer give owned Box<[u8]> to it. This is totally fine though because anyway the InputMemTrieNode's data needs to be copied into the constructed memtrie nodes in the arena.
* Optimize the nibble slice encoding function so that rather than encoding nibble by nibble, we encode the first nibble and then just copy the remaining bytes directly. Also optimize the at(i) function, removing branching entirely (this code now gets compiled to a bunch of arithmetic operations).

On shard 5 these optimizations reduce load time from 146s to 122s.