### PR TITLE
fix: a slow chunk should not lead to chain getting stuck

### DIFF
--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -152,10 +152,7 @@ impl ChunkValidator {
         // Case 1: We have the chunk extra and outgoing receipts cached.
         let cached_result = {
             let mut shard_cache = self.validation_result_cache.write().unwrap();
-            let cache = shard_cache
-                .entry(shard_uid)
-                .or_insert_with(|| LruCache::new(NUM_WITNESS_RESULT_CACHE_ENTRIES));
-            cache.get(&prev_chunk_hash).cloned()
+            shard_cache.get_mut(&shard_uid).and_then(|cache| cache.get(&prev_chunk_hash)).cloned()
         };
 
         if let Some(ChunkStateWitnessValidationResult { chunk_extra, outgoing_receipts }) =

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -75,8 +75,11 @@ pub struct ChunkValidator {
     chunk_endorsement_tracker: Arc<ChunkEndorsementTracker>,
     orphan_witness_pool: OrphanStateWitnessPool,
     validation_spawner: Arc<dyn AsyncComputationSpawner>,
-    validation_result_cache:
-        Arc<RwLock<HashMap<ShardUId, LruCache<(EpochId, BlockHeight), ChunkStateWitnessValidationResult>>>>,
+    validation_result_cache: Arc<
+        RwLock<
+            HashMap<ShardUId, LruCache<(EpochId, BlockHeight), ChunkStateWitnessValidationResult>>,
+        >,
+    >,
 }
 
 impl ChunkValidator {
@@ -155,7 +158,10 @@ impl ChunkValidator {
             let mut shard_cache = self.validation_result_cache.write().unwrap();
             shard_cache
                 .get_mut(&shard_uid)
-                .and_then(|cache| cache.get(&(prev_block.header().epoch_id().clone(), last_header_height_included)))
+                .and_then(|cache| {
+                    cache
+                        .get(&(prev_block.header().epoch_id().clone(), last_header_height_included))
+                })
                 .cloned()
         };
 
@@ -265,7 +271,10 @@ impl ChunkValidator {
                     // cached result from applying state witness for H, which results in an incorrect state transition.
                     // NOTE: we rely on the assumption that the last chunk included is in the same epoch as the previous block, i.e., there is at least one
                     // chunk in every epoch.
-                    cache.put((prev_block.header().epoch_id().clone(), last_header_height_included), validation_result);
+                    cache.put(
+                        (prev_block.header().epoch_id().clone(), last_header_height_included),
+                        validation_result,
+                    );
                     send_chunk_endorsement_to_block_producers(
                         &chunk_header,
                         epoch_manager.as_ref(),

--- a/chain/client/src/stateless_validation/shadow_validate.rs
+++ b/chain/client/src/stateless_validation/shadow_validate.rs
@@ -8,6 +8,7 @@ use near_primitives::stateless_validation::EncodedChunkStateWitness;
 
 use crate::stateless_validation::chunk_validator::{
     pre_validate_chunk_state_witness, validate_chunk_state_witness, validate_prepared_transactions,
+    MainStateTransitionCache,
 };
 use crate::{metrics, Client};
 
@@ -126,8 +127,9 @@ impl Client {
                 pre_validation_result,
                 epoch_manager.as_ref(),
                 runtime_adapter.as_ref(),
+                &MainStateTransitionCache::default(),
             ) {
-                Ok(_) => {
+                Ok(()) => {
                     tracing::debug!(
                         target: "client",
                         shard_id,

--- a/chain/client/src/stateless_validation/shadow_validate.rs
+++ b/chain/client/src/stateless_validation/shadow_validate.rs
@@ -127,7 +127,7 @@ impl Client {
                 epoch_manager.as_ref(),
                 runtime_adapter.as_ref(),
             ) {
-                Ok(()) => {
+                Ok(_) => {
                     tracing::debug!(
                         target: "client",
                         shard_id,


### PR DESCRIPTION
This is a suboptimal fix to #11339 that is easy to implement. The core of the problem is as follows: if a chunk is slow to apply for chunk validators, then their chunk endorsements will not get included in the following block. However, the next block could still be produced, at which point it becomes impossible to include that chunk because when a block producer produces a block, it only includes chunks whose prev block hash is the same as its tip. Now, when a new block is a produced, a chunk producer, after processing that block, will produce a new chunk, which again will cause chunk validators to take a long time to apply and therefore not able to send endorsement before the next block is produced.

This fix works by caching the state validation result so that if there are multiple chunks with the same previous chunk (not previous block), then validators don't need to apply the same (expensive) state transition again. Therefore they can send an endorsement very quickly when the next chunk is produced. `slow_chunk.py` passes with this change.

However, this fix is not optimal because for each block, the set of validators assigned to a shard changes and it may take a while before there is an assignment in which 2/3 of the validators have applied the expensive state transition and can quickly send an endorsement. It is also not clear what the optimal fix is. One idea is to remove the invariant that blocks can only include chunks with the same prev block hash, so that old chunks can be included if enough endorsements are received at some point. That, however, is a nontrivial change and can potentially break a lot of things.
