### PR TITLE
test(stateless_validation) - Fixed and enabled chunk validation test

### DIFF
--- a/core/parameters/src/config.rs
+++ b/core/parameters/src/config.rs
@@ -187,3 +187,24 @@ pub struct CongestionControlConfig {
 // that NaN != NaN. In the CongestionControlConfig the field should never be NaN
 // so it is okay for us to add the Eq trait to it manually.
 impl Eq for CongestionControlConfig {}
+
+impl CongestionControlConfig {
+    /// Creates a config where congestion control is disabled. This config can
+    /// be used for tests. It can be useful e.g. in tests with missing chunks
+    /// where we still want to process all transactions.
+    pub fn test_disabled() -> Self {
+        let max_value = u64::MAX;
+        Self {
+            max_congestion_incoming_gas: max_value,
+            max_congestion_outgoing_gas: max_value,
+            max_congestion_memory_consumption: max_value,
+            max_congestion_missed_chunks: max_value,
+            max_outgoing_gas: max_value,
+            min_outgoing_gas: max_value,
+            allowed_shard_outgoing_gas: max_value,
+            max_tx_gas: max_value,
+            min_tx_gas: max_value,
+            reject_tx_congestion_threshold: 1.0,
+        }
+    }
+}

--- a/core/parameters/src/config_store.rs
+++ b/core/parameters/src/config_store.rs
@@ -1,4 +1,4 @@
-use crate::config::RuntimeConfig;
+use crate::config::{CongestionControlConfig, RuntimeConfig};
 use crate::parameter_table::{ParameterTable, ParameterTableDiff};
 use near_primitives_core::types::ProtocolVersion;
 use std::collections::BTreeMap;
@@ -137,6 +137,14 @@ impl RuntimeConfigStore {
     /// Constructs test store.
     pub fn test() -> Self {
         Self::with_one_config(RuntimeConfig::test())
+    }
+
+    /// Constructs test store.
+    pub fn test_congestion_control_disabled() -> Self {
+        let mut config = RuntimeConfig::test();
+        config.congestion_control_config = CongestionControlConfig::test_disabled();
+
+        Self::with_one_config(config)
     }
 
     /// Constructs store with a single config with zero costs.

--- a/integration-tests/src/tests/client/features/stateless_validation.rs
+++ b/integration-tests/src/tests/client/features/stateless_validation.rs
@@ -129,7 +129,9 @@ fn run_chunk_validation_test(seed: u64, prob_missing_chunk: f64) {
     let mut env = TestEnv::builder(&genesis.config)
         .clients(accounts.iter().take(8).cloned().collect())
         .epoch_managers_with_test_overrides(epoch_config_test_overrides)
-        .nightshade_runtimes(&genesis)
+        // Disable congestion control in order to avoid rejecting transactions
+        // in tests with missing chunks.
+        .nightshade_runtimes_congestion_control_disabled(&genesis)
         .build();
     let mut tx_hashes = vec![];
 
@@ -237,7 +239,6 @@ fn test_chunk_validation_low_missing_chunks() {
 // missing chunks in a row.
 // TODO(congestion_control) - make congestion control configurable,
 // disable it here and re-enable this test
-#[ignore]
 #[test]
 fn test_chunk_validation_high_missing_chunks() {
     run_chunk_validation_test(44, 0.81);

--- a/nearcore/src/test_utils.rs
+++ b/nearcore/src/test_utils.rs
@@ -13,6 +13,7 @@ use crate::NightshadeRuntime;
 
 pub trait TestEnvNightshadeSetupExt {
     fn nightshade_runtimes(self, genesis: &Genesis) -> Self;
+    fn nightshade_runtimes_congestion_control_disabled(self, genesis: &Genesis) -> Self;
     fn nightshade_runtimes_with_runtime_config_store(
         self,
         genesis: &Genesis,
@@ -28,6 +29,12 @@ pub trait TestEnvNightshadeSetupExt {
 impl TestEnvNightshadeSetupExt for TestEnvBuilder {
     fn nightshade_runtimes(self, genesis: &Genesis) -> Self {
         let runtime_configs = vec![RuntimeConfigStore::test(); self.num_clients()];
+        self.nightshade_runtimes_with_runtime_config_store(genesis, runtime_configs)
+    }
+
+    fn nightshade_runtimes_congestion_control_disabled(self, genesis: &Genesis) -> Self {
+        let runtime_config_store = RuntimeConfigStore::test_congestion_control_disabled();
+        let runtime_configs = vec![runtime_config_store; self.num_clients()];
         self.nightshade_runtimes_with_runtime_config_store(genesis, runtime_configs)
     }
 


### PR DESCRIPTION
The test was broken in nightly because with congestion control enabled some transactions were being rejected due to missing chunks congestion. I implemented a test configuration that disables congestion control, used it in the broken test and enabled it. 