### PR TITLE
feat(mirror): add a transactions per second option

### DIFF
--- a/tools/mirror/src/chain_tracker.rs
+++ b/tools/mirror/src/chain_tracker.rs
@@ -1286,6 +1286,7 @@ impl TxTracker {
             }
         }
         assert!(info.queued_txs.remove(tx_ref));
+        info.txs_awaiting_nonce.remove(tx_ref);
         Ok(())
     }
 

--- a/tools/mirror/src/chain_tracker.rs
+++ b/tools/mirror/src/chain_tracker.rs
@@ -124,6 +124,8 @@ pub(crate) enum SentBatch {
     ExtraTxs(VecDeque<TargetChainTx>),
 }
 
+// We don't want to divide up a second into intervals that add up to us sending `tps` per second,
+// because the intervals will get too small. So sleep for at least 10 millis, and send possibly many per batch
 const MAX_BATCHES_PER_SEC: u32 = 100;
 
 struct TxBatchConfig {
@@ -133,6 +135,7 @@ struct TxBatchConfig {
     size_increase_index: u32,
 }
 
+// corresponds to the cadence set in the config, and dictates how we send transactions and how long we sleep for
 enum TrafficCadence {
     MatchBlocks,
     BlockInterval(Duration),
@@ -584,6 +587,8 @@ impl TxTracker {
         Ok(())
     }
 
+    // set the number of transactions we want in the next batch to send, either taking the whole
+    // block or just some of them, depending on whether we're targeting a specific tps number
     fn fill_tx_batch(
         &mut self,
         batch: &mut TxBatch,

--- a/tools/mirror/src/chain_tracker.rs
+++ b/tools/mirror/src/chain_tracker.rs
@@ -121,7 +121,7 @@ struct NonceInfo {
 
 pub(crate) enum SentBatch {
     MappedBlock(TxBatch),
-    ExtraTxs(Vec<TargetChainTx>),
+    ExtraTxs(VecDeque<TargetChainTx>),
 }
 
 // Keeps the queue of upcoming transactions and provides them in regular intervals via next_batch()

--- a/tools/mirror/src/chain_tracker.rs
+++ b/tools/mirror/src/chain_tracker.rs
@@ -827,7 +827,7 @@ impl TxTracker {
                     if let Some(tx) = self.get_tx(r) {
                         match tx {
                             TargetChainTx::AwaitingNonce(t) => {
-                                assert!(t.target_nonce.pending_outcomes.remove(&updater));
+                                t.target_nonce.pending_outcomes.remove(&updater);
                                 t.target_nonce.pending_outcomes.insert(new_updater.clone());
                             }
                             TargetChainTx::Ready(_) => unreachable!(),
@@ -1127,7 +1127,7 @@ impl TxTracker {
 
                         match t {
                             TargetChainTx::AwaitingNonce(t) => {
-                                assert!(t.target_nonce.pending_outcomes.remove(&updater));
+                                t.target_nonce.pending_outcomes.remove(&updater);
                                 t.target_nonce.pending_outcomes.insert(new_updater.clone());
                             }
                             TargetChainTx::Ready(_) => unreachable!(),
@@ -1248,7 +1248,7 @@ impl TxTracker {
                         };
                         match target_tx {
                             TargetChainTx::AwaitingNonce(tx) => {
-                                assert!(tx.target_nonce.pending_outcomes.remove(&updater));
+                                tx.target_nonce.pending_outcomes.remove(&updater);
                                 if tx.target_nonce.pending_outcomes.is_empty() {
                                     target_tx.try_set_nonce(None);
                                     match target_tx {

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -534,6 +534,7 @@ struct MirrorConfig {
     /// wait this long before sending each mainnet block's worth of transactions.
     /// TODO: add an option to target a specific number of transactions per second
     tx_batch_interval: Option<Duration>,
+    /// Number of transactions per second to send.
     tps: Option<u32>,
 }
 

--- a/tools/mirror/src/offline.rs
+++ b/tools/mirror/src/offline.rs
@@ -57,13 +57,13 @@ impl ChainAccess {
 impl crate::ChainAccess for ChainAccess {
     async fn init(
         &self,
-        last_height: BlockHeight,
+        next_height: BlockHeight,
         num_initial_blocks: usize,
     ) -> anyhow::Result<Vec<BlockHeight>> {
         let mut block_heights = Vec::with_capacity(num_initial_blocks);
         let head = self.head_height().await?;
 
-        let mut height = last_height + 1;
+        let mut height = next_height;
         loop {
             if height > head {
                 return Ok(block_heights);

--- a/tools/mirror/src/online.rs
+++ b/tools/mirror/src/online.rs
@@ -42,7 +42,7 @@ impl ChainAccess {
 impl crate::ChainAccess for ChainAccess {
     async fn init(
         &self,
-        last_height: BlockHeight,
+        next_height: BlockHeight,
         num_initial_blocks: usize,
     ) -> anyhow::Result<Vec<BlockHeight>> {
         // first wait until HEAD moves. We don't really need it to be fully synced.
@@ -67,7 +67,7 @@ impl crate::ChainAccess for ChainAccess {
         }
 
         let mut block_heights = Vec::with_capacity(num_initial_blocks);
-        let mut height = last_height;
+        let mut height = next_height - 1;
 
         loop {
             // note that here we are using the fact that get_next_block_height() for this struct


### PR DESCRIPTION
This adds an option to control the traffic load by specifying how many transactions per second to send. This still sends the same set of transactions, but iterates through them and selects an amount to send that will get us close to the tps number we're looking for, rather than just sending a whole block's worth at a time

This PR is complicated by the way things work in this mirror tool currently, and it would be great to find a way to simplify things and delete code in the future. But for now sadly things have to get even a little more complicated to implement this, since there's some stuff that could go wrong with the way nonces are handled