### PR TITLE
congestion: glue together congestion info bootstrapping

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -414,8 +414,6 @@ impl NightshadeRuntime {
                 // TODO(#2152): process gracefully
                 RuntimeError::ReceiptValidationError(e) => panic!("{}", e),
                 RuntimeError::ValidatorError(e) => e.into(),
-                // TODO(#2152): process gracefully
-                RuntimeError::ContextError(e) => panic!("{}", e),
             })?;
         let elapsed = instant.elapsed();
 

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -596,17 +596,18 @@ impl Block {
 
         for chunk in self.chunks().iter() {
             let shard_id = chunk.shard_id();
-            // TODO(congestion_control): default is not always appropriate!
-            let congestion_info = chunk.congestion_info().unwrap_or_default();
-            let height_included = chunk.height_included();
-            let height_current = self.header().height();
-            let missed_chunks_count = height_current.checked_sub(height_included);
-            let missed_chunks_count = missed_chunks_count
-                .expect("The chunk height included must be less or equal than block height!");
 
-            let extended_congestion_info =
-                ExtendedCongestionInfo::new(congestion_info, missed_chunks_count);
-            result.insert(shard_id, extended_congestion_info);
+            if let Some(congestion_info) = chunk.congestion_info() {
+                let height_included = chunk.height_included();
+                let height_current = self.header().height();
+                let missed_chunks_count = height_current.checked_sub(height_included);
+                let missed_chunks_count = missed_chunks_count
+                    .expect("The chunk height included must be less or equal than block height!");
+
+                let extended_congestion_info =
+                    ExtendedCongestionInfo::new(congestion_info, missed_chunks_count);
+                result.insert(shard_id, extended_congestion_info);
+            }
         }
         result
     }

--- a/core/primitives/src/congestion_info.rs
+++ b/core/primitives/src/congestion_info.rs
@@ -258,8 +258,8 @@ impl CongestionInfo {
     /// If in a fully congested state, decide which shard of `other_shards` is
     /// allowed to forward to `own_shard` this round. In this case, we stop all
     /// of `other_shards` from sending anything to `own_shard`. But to guarantee
-    /// progress, we allow one shard of `other_shards` to send `RED_GAS` in the
-    /// next chunk.
+    /// progress, we allow one shard of `other_shards` to send
+    /// `allowed_shard_outgoing_gas` in the next chunk.
     ///
     /// Otherwise, when the congestion level is < 1.0, set `allowed_shard` to
     /// `own_shard`. The field is ignored in this case but we still want a

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -66,8 +66,6 @@ pub enum RuntimeError {
     ReceiptValidationError(ReceiptValidationError),
     /// Error when accessing validator information. Happens inside epoch manager.
     ValidatorError(EpochError),
-    /// The context provided  to the runtime is inconsistent.
-    ContextError(ContextError),
 }
 
 impl std::fmt::Display for RuntimeError {
@@ -982,19 +980,6 @@ impl Debug for EpochError {
 impl From<std::io::Error> for EpochError {
     fn from(error: std::io::Error) -> Self {
         EpochError::IOErr(error.to_string())
-    }
-}
-
-#[derive(Eq, PartialEq, Clone, thiserror::Error, Debug)]
-
-pub enum ContextError {
-    #[error("No congestion info for shard {shard_id} in the runtime context")]
-    MissingCongestionInfo { shard_id: u64 },
-}
-
-impl From<ContextError> for RuntimeError {
-    fn from(other: ContextError) -> Self {
-        RuntimeError::ContextError(other)
     }
 }
 

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -428,6 +428,7 @@ impl ShardChunkHeader {
         }
     }
 
+    /// Congestion info, if the feature is enabled on the chunk, `None` otherwise.
     #[inline]
     pub fn congestion_info(&self) -> Option<CongestionInfo> {
         match self {

--- a/core/primitives/src/sharding/shard_chunk_header_inner.rs
+++ b/core/primitives/src/sharding/shard_chunk_header_inner.rs
@@ -130,12 +130,13 @@ impl ShardChunkHeaderInner {
         }
     }
 
+    /// Congestion info, if the feature is enabled on the chunk, `None`` otherwise.
     #[inline]
     pub fn congestion_info(&self) -> Option<CongestionInfo> {
         match self {
             Self::V1(_) => None,
             Self::V2(_) => None,
-            Self::V3(v3) => v3.congestion_info.into(),
+            Self::V3(v3) => Some(v3.congestion_info),
         }
     }
 }
@@ -218,6 +219,6 @@ pub struct ShardChunkHeaderInnerV3 {
     pub tx_root: CryptoHash,
     /// Validator proposals from the previous chunk.
     pub prev_validator_proposals: Vec<ValidatorStake>,
-    /// Congestion info.
+    /// Congestion info about this shard after the previous chunk was applied.
     pub congestion_info: CongestionInfo,
 }

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -785,8 +785,7 @@ pub mod chunk_extra {
         pub gas_limit: Gas,
         /// Total balance burnt after processing the current chunk.
         pub balance_burnt: Balance,
-        /// Congestion info. This field should be set to None for chunks before
-        /// the congestion control protocol version and Some otherwise.
+        /// Congestion info about this shard after the chunk was applied.
         congestion_info: CongestionInfo,
     }
 

--- a/integration-tests/src/tests/client/features/congestion_control.rs
+++ b/integration-tests/src/tests/client/features/congestion_control.rs
@@ -13,7 +13,7 @@ use near_primitives::views::FinalExecutionStatus;
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
 
 fn setup_runtime(sender_id: AccountId) -> TestEnv {
-    let epoch_length = 10;
+    let epoch_length = 5;
     let mut genesis = Genesis::test_sharded_new_version(vec![sender_id], 1, vec![1, 1, 1, 1]);
     genesis.config.epoch_length = epoch_length;
     genesis.config.protocol_version = ProtocolFeature::CongestionControl.protocol_version() - 1;
@@ -64,7 +64,7 @@ fn test_protocol_upgrade() {
             .expect("chunk header must have congestion info after upgrade");
         let congestion_control =
             CongestionControl::new(runtime_config.congestion_control_config, congestion_info, 0);
-        assert_eq!(congestion_control.congestion_level(true), 0.0);
+        assert_eq!(congestion_control.congestion_level(), 0.0);
         assert!(congestion_control.shard_accepts_transactions());
     }
 }
@@ -127,7 +127,7 @@ fn test_protocol_upgrade_under_congestion() {
 
     // Allow transactions to enter the chain
     let tip = env.clients[0].chain.head().unwrap();
-    for i in 1..6 {
+    for i in 1..3 {
         env.produce_block(0, tip.height + i);
     }
 
@@ -174,7 +174,7 @@ fn test_protocol_upgrade_under_congestion() {
     let contract_shard_chunk_header =
         &chunks.get(contract_shard_id as usize).expect("chunk must be available");
     let _congestion_info = contract_shard_chunk_header.congestion_info().unwrap();
-    // TODO(congestion_control) - properly initialize
+    // TODO(congestion_control) - delayed receipts accounting
     // assert_eq!(
     //     congestion_info.congestion_level(),
     //     1.0,

--- a/integration-tests/src/user/runtime_user.rs
+++ b/integration-tests/src/user/runtime_user.rs
@@ -14,7 +14,7 @@ use near_primitives::runtime::migration_data::{MigrationData, MigrationFlags};
 use near_primitives::test_utils::MockEpochInfoProvider;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockHeightDelta, MerkleHash};
-use near_primitives::version::PROTOCOL_VERSION;
+use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_primitives::views::{
     AccessKeyView, AccountView, BlockView, CallResult, ChunkView, ContractCodeView,
     ExecutionOutcomeView, ExecutionOutcomeWithIdView, ExecutionStatusView,
@@ -156,6 +156,11 @@ impl RuntimeUser {
         let shard_id = 0;
         // TODO(congestion_control) - Set other shard ids somehow.
         let all_shard_ids = [0, 1, 2, 3, 4, 5];
+        let congestion_info = if ProtocolFeature::CongestionControl.enabled(PROTOCOL_VERSION) {
+            all_shard_ids.into_iter().map(|id| (id, ExtendedCongestionInfo::default())).collect()
+        } else {
+            HashMap::new()
+        };
 
         ApplyState {
             apply_reason: None,
@@ -175,10 +180,7 @@ impl RuntimeUser {
             is_new_chunk: true,
             migration_data: Arc::new(MigrationData::default()),
             migration_flags: MigrationFlags::default(),
-            congestion_info: all_shard_ids
-                .into_iter()
-                .map(|id| (id, ExtendedCongestionInfo::default()))
-                .collect(),
+            congestion_info,
         }
     }
 

--- a/integration-tests/src/user/runtime_user.rs
+++ b/integration-tests/src/user/runtime_user.rs
@@ -122,7 +122,6 @@ impl RuntimeUser {
                     }
                     RuntimeError::ReceiptValidationError(e) => panic!("{}", e),
                     RuntimeError::ValidatorError(e) => panic!("{}", e),
-                    RuntimeError::ContextError(e) => panic!("{}", e),
                 })?;
             for outcome_with_id in apply_result.outcomes {
                 self.transaction_results

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -12,7 +12,7 @@ use near_primitives::state::FlatStateValue;
 use near_primitives::test_utils::MockEpochInfoProvider;
 use near_primitives::transaction::{ExecutionStatus, SignedTransaction};
 use near_primitives::types::{Gas, MerkleHash};
-use near_primitives::version::PROTOCOL_VERSION;
+use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_store::flat::{
     store_helper, BlockInfo, FlatStateChanges, FlatStateDelta, FlatStateDeltaMetadata, FlatStorage,
     FlatStorageManager, FlatStorageReadyStatus, FlatStorageStatus,
@@ -166,7 +166,11 @@ impl<'c> EstimatorContext<'c> {
             is_new_chunk: true,
             migration_data: Arc::new(MigrationData::default()),
             migration_flags: MigrationFlags::default(),
-            congestion_info: HashMap::from([(shard_id, ExtendedCongestionInfo::default())]),
+            congestion_info: if ProtocolFeature::CongestionControl.enabled(PROTOCOL_VERSION) {
+                HashMap::from([(shard_id, ExtendedCongestionInfo::default())])
+            } else {
+                HashMap::new()
+            },
         }
     }
 

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1963,6 +1963,7 @@ mod tests {
     use near_primitives::action::delegate::{
         DelegateAction, NonDelegateAction, SignedDelegateAction,
     };
+    use near_primitives::congestion_info::CongestionControl;
     use near_primitives::hash::hash;
     use near_primitives::receipt::ReceiptPriority;
     use near_primitives::shard_layout::ShardUId;
@@ -3358,7 +3359,7 @@ mod tests {
         // Check congestion is 1.0
         if ProtocolFeature::CongestionControl.enabled(PROTOCOL_VERSION) {
             let congestion = apply_state.congestion_control(receiver_shard, 0);
-            assert_eq!(congestion.congestion_level(true), 1.0);
+            assert_eq!(congestion.congestion_level(), 1.0);
             assert_eq!(congestion.outgoing_limit(local_shard), 0);
         }
 
@@ -3376,7 +3377,7 @@ mod tests {
         // Check congestion is less than 1.0
         if ProtocolFeature::CongestionControl.enabled(PROTOCOL_VERSION) {
             let congestion = apply_state.congestion_control(receiver_shard, 0);
-            assert!(congestion.congestion_level(true) < 1.0);
+            assert!(congestion.congestion_level() < 1.0);
             // this exact number does not matter but if it changes the test setup
             // needs to adapt to ensure the number of forwarded receipts is as expected
             assert!(

--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -11,7 +11,7 @@ use near_primitives::state_record::{state_record_to_account_id, StateRecord};
 use near_primitives::test_utils::MockEpochInfoProvider;
 use near_primitives::transaction::{ExecutionOutcomeWithId, SignedTransaction};
 use near_primitives::types::{AccountId, AccountInfo, Balance};
-use near_primitives::version::PROTOCOL_VERSION;
+use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_primitives_core::account::id::AccountIdRef;
 use near_store::genesis::GenesisStateApplier;
 use near_store::test_utils::TestTriesBuilder;
@@ -89,12 +89,17 @@ impl StandaloneRuntime {
             &genesis,
             account_ids,
         );
-        let congestion_info: HashMap<_, _> = genesis
-            .config
-            .shard_layout
-            .shard_ids()
-            .map(|shard_id| (shard_id, ExtendedCongestionInfo::default()))
-            .collect();
+        let congestion_info: HashMap<_, _> =
+            if ProtocolFeature::CongestionControl.enabled(PROTOCOL_VERSION) {
+                genesis
+                    .config
+                    .shard_layout
+                    .shard_ids()
+                    .map(|shard_id| (shard_id, ExtendedCongestionInfo::default()))
+                    .collect()
+            } else {
+                Default::default()
+            };
 
         let apply_state = ApplyState {
             apply_reason: None,


### PR DESCRIPTION
We still had an unresolved issue: Where in the code will the first congestion info be computed? This is referred to as bootstrapping the congestion info.

In this PR, I suggest we let the runtime compute it inside `apply`, which means it is done on the shard level, rather than the chain level. I believe this makes sense, since we don't need anything other than the state trie to make this computation. And I'd rather not dig into the trie from the chain level.

As a side-effect of this, the `ContextError` introduced for congestion control is no longer possible. Implementation errors, which would have previously caused this error followed by a crash, would now cause an expensive recomputation of the congestion info and print a warning.

This PR also suggest a semantic change to how CongestionControl and CongestionInfo are used. I think we should clearly distinguish between:

1) Read-only usage of congestion info (through CongestionControl) when making congestion control decisions. 2) A congestion info we are still building.

Thus, I changed the semantic of `CongestionControl` to only make sense for looking at previous chunks' congestion info. Consequently, ReceiptSink now only holds an instance of `CongestionInfo`.

With this semantic change, the `CongestionControl` no longer has a need for add/remove function to modify internals. And the finalization of the allowed shard no longer makes sense on that struct, this should happen on the CongestionInfo only.

But now we need a way to compute the congestion level on the `CongestionInfo` struct (without missed chunks) and one on `CongestionControl` (with missed chunks). At this point, the somewhat object-oriented approach to store the config inside `CongestionControl` no longer works as smoothly. Thus, a few more function need the config object injected at the parameter level. I have to admit, it's a bit more clutter. But I think it makes sense to use apply_state.config as source of truth rather than a copy of the config.

I even tried to add another struct (e.g. CongestionInfoBuilder) to further make the distinction between mutable and read-only congestion info. But for my taste, it adds more clutter than justified. We already have too many different types.

With all this justification for the semantic changes, I want to stress that I am still open to different semantics and code structures. Getting this right is important to me, to not make the runtime code a bigger mess than it has to be. This is just one proposal how it could be done.