### PR TITLE
congestion: genesis congestion info

### DIFF
--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -325,15 +325,9 @@ pub(crate) fn pre_validate_chunk_state_witness(
             .get(&shard_id)
             .map(|info| info.congestion_info);
         let genesis_protocol_version = epoch_manager.get_epoch_protocol_version(&epoch_id)?;
-        MainTransition::Genesis {
-            chunk_extra: chain.genesis_chunk_extra(
-                shard_id,
-                genesis_protocol_version,
-                congestion_info,
-            )?,
-            block_hash: *last_chunk_block.hash(),
-            shard_id,
-        }
+        let chunk_extra =
+            chain.genesis_chunk_extra(shard_id, genesis_protocol_version, congestion_info)?;
+        MainTransition::Genesis { chunk_extra, block_hash: *last_chunk_block.hash(), shard_id }
     } else {
         MainTransition::NewChunk(NewChunkData {
             chunk_header: last_chunk_block.chunks().get(shard_id as usize).unwrap().clone(),

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -320,9 +320,17 @@ pub(crate) fn pre_validate_chunk_state_witness(
 
     let main_transition_params = if last_chunk_block.header().is_genesis() {
         let epoch_id = last_chunk_block.header().epoch_id();
+        let congestion_info = last_chunk_block
+            .shards_congestion_info()
+            .get(&shard_id)
+            .map(|info| info.congestion_info);
         let genesis_protocol_version = epoch_manager.get_epoch_protocol_version(&epoch_id)?;
         MainTransition::Genesis {
-            chunk_extra: chain.genesis_chunk_extra(shard_id, genesis_protocol_version)?,
+            chunk_extra: chain.genesis_chunk_extra(
+                shard_id,
+                genesis_protocol_version,
+                congestion_info,
+            )?,
             block_hash: *last_chunk_block.hash(),
             shard_id,
         }


### PR DESCRIPTION
A small PR to initialize the congestion info for genesis.

Please check if this is correct. But I think we can just take the genesis block and read the congestion info from there. I assume it's usually empty, but if genesis somehow contains delayed or buffered receipts, I assume it should be included in the chunk header.