### PR TITLE
fix: release prefetch slot if there is storage error

### DIFF
--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -429,67 +429,69 @@ impl TrieCachingStorage {
 
     /// Reads value if it is not in shard cache. Handles dropping the cache
     /// lock. Either waits for prefetcher to fetch it or reads it from DB.
+    /// It is responsibility of caller to release the prefetch slot later.
     fn read_for_shard_cache_miss(
         &self,
         guard: std::sync::MutexGuard<TrieCacheInner>,
         hash: &CryptoHash,
     ) -> Result<Arc<[u8]>, StorageError> {
-        let val = if let Some(prefetcher) = &self.prefetch_api {
-            let prefetch_state = prefetcher.prefetching.get_or_set_fetching(*hash);
-            // Keep lock until here to avoid race condition between shard cache lookup and reserving prefetch slot.
+        let Some(prefetcher) = &self.prefetch_api else {
             std::mem::drop(guard);
+            return self.read_from_db(hash);
+        };
 
-            match prefetch_state {
-                // Slot reserved for us, the main thread.
-                // `SlotReserved` for the main thread means, either we have not submitted a prefetch request for
-                // this value, or maybe it is just still queued up. Either way, prefetching is not going to help
-                // so the main thread should fetch data from DB on its own.
-                PrefetcherResult::SlotReserved => {
-                    self.metrics.prefetch_not_requested.inc();
-                    self.read_from_db(hash)?
-                }
-                // `MemoryLimitReached` is not really relevant for the main thread,
-                // we always have to go to DB even if we could not stage a new prefetch.
-                // It only means we were not able to mark it as already being fetched, which in turn could lead to
-                // a prefetcher trying to fetch the same value before we can put it in the shard cache.
-                PrefetcherResult::MemoryLimitReached => {
-                    self.metrics.prefetch_memory_limit_reached.inc();
-                    self.read_from_db(hash)?
-                }
-                PrefetcherResult::Prefetched(value) => {
-                    near_o11y::io_trace!(count: "prefetch_hit");
-                    self.metrics.prefetch_hits.inc();
-                    value
-                }
-                PrefetcherResult::Pending => {
-                    near_o11y::io_trace!(count: "prefetch_pending");
-                    self.metrics.prefetch_pending.inc();
-                    std::thread::yield_now();
-                    // If data is already being prefetched, wait for that instead of sending a new request.
-                    match prefetcher.prefetching.blocking_get(*hash) {
-                        Some(value) => value,
-                        // Only main thread (this one) removes values from staging area,
-                        // therefore blocking read will usually not return empty unless there
-                        // was a storage error. Or in the case of forks and parallel chunk
-                        // processing where one chunk cleans up prefetched data from the other.
-                        // So first we need to check if the data was inserted to shard_cache
-                        // by the main thread from another fork and only if that fails then
-                        // fetch the data from the DB.
-                        None => {
-                            if let Some(value) = self.shard_cache.get(hash) {
-                                self.metrics.prefetch_conflict.inc();
-                                value
-                            } else {
-                                self.metrics.prefetch_retry.inc();
-                                self.read_from_db(hash)?
-                            }
+        let prefetch_state = prefetcher.prefetching.get_or_set_fetching(*hash);
+        // Drop lock only here to avoid race condition between shard cache
+        // lookup and reserving prefetch slot.
+        std::mem::drop(guard);
+
+        let val = match prefetch_state {
+            // Slot reserved for us, the main thread.
+            // `SlotReserved` for the main thread means, either we have not submitted a prefetch request for
+            // this value, or maybe it is just still queued up. Either way, prefetching is not going to help
+            // so the main thread should fetch data from DB on its own.
+            PrefetcherResult::SlotReserved => {
+                self.metrics.prefetch_not_requested.inc();
+                self.read_from_db(hash)?
+            }
+            // `MemoryLimitReached` is not really relevant for the main thread,
+            // we always have to go to DB even if we could not stage a new prefetch.
+            // It only means we were not able to mark it as already being fetched, which in turn could lead to
+            // a prefetcher trying to fetch the same value before we can put it in the shard cache.
+            PrefetcherResult::MemoryLimitReached => {
+                self.metrics.prefetch_memory_limit_reached.inc();
+                self.read_from_db(hash)?
+            }
+            PrefetcherResult::Prefetched(value) => {
+                near_o11y::io_trace!(count: "prefetch_hit");
+                self.metrics.prefetch_hits.inc();
+                value
+            }
+            PrefetcherResult::Pending => {
+                near_o11y::io_trace!(count: "prefetch_pending");
+                self.metrics.prefetch_pending.inc();
+                std::thread::yield_now();
+                // If data is already being prefetched, wait for that instead of sending a new request.
+                match prefetcher.prefetching.blocking_get(*hash) {
+                    Some(value) => value,
+                    // Only main thread (this one) removes values from staging area,
+                    // therefore blocking read will usually not return empty unless there
+                    // was a storage error. Or in the case of forks and parallel chunk
+                    // processing where one chunk cleans up prefetched data from the other.
+                    // So first we need to check if the data was inserted to shard_cache
+                    // by the main thread from another fork and only if that fails then
+                    // fetch the data from the DB.
+                    None => {
+                        if let Some(value) = self.shard_cache.get(hash) {
+                            self.metrics.prefetch_conflict.inc();
+                            value
+                        } else {
+                            self.metrics.prefetch_retry.inc();
+                            self.read_from_db(hash)?
                         }
                     }
                 }
             }
-        } else {
-            std::mem::drop(guard);
-            self.read_from_db(hash)?
         };
         Ok(val)
     }
@@ -501,45 +503,41 @@ impl TrieStorage for TrieCachingStorage {
         let mut guard = self.shard_cache.lock();
         self.metrics.shard_cache_size.set(guard.len() as i64);
         self.metrics.shard_cache_current_total_size.set(guard.current_total_size() as i64);
-        let val = match guard.get(hash) {
-            Some(val) => {
-                self.metrics.shard_cache_hits.inc();
-                near_o11y::io_trace!(count: "shard_cache_hit");
-                val
-            }
-            None => {
-                self.metrics.shard_cache_misses.inc();
-                near_o11y::io_trace!(count: "shard_cache_miss");
-                let val = match self.read_for_shard_cache_miss(guard, hash) {
-                    Ok(val) => val,
-                    Err(e) => {
-                        if let Some(prefetcher) = &self.prefetch_api {
-                            prefetcher.prefetching.release(hash);
-                        }
-                        return Err(e);
-                    }
-                };
+        if let Some(val) = guard.get(hash) {
+            self.metrics.shard_cache_hits.inc();
+            near_o11y::io_trace!(count: "shard_cache_hit");
+            return Ok(val);
+        }
 
-                // Insert value to shard cache, if its size is small enough.
-                // It is fine to have a size limit for shard cache and **not** have a limit for accounting cache, because key
-                // is always a value hash, so for each key there could be only one value, and it is impossible to have
-                // **different** values for the given key in shard and accounting caches.
-                if val.len() < TrieConfig::max_cached_value_size() {
-                    let mut guard = self.shard_cache.lock();
-                    guard.put(*hash, val.clone());
-                } else {
-                    self.metrics.shard_cache_too_large.inc();
-                    near_o11y::io_trace!(count: "shard_cache_too_large");
-                }
-
+        self.metrics.shard_cache_misses.inc();
+        near_o11y::io_trace!(count: "shard_cache_miss");
+        let val = match self.read_for_shard_cache_miss(guard, hash) {
+            Ok(val) => val,
+            Err(e) => {
+                // Only release after attempt to read the value. See comment on fn release.
                 if let Some(prefetcher) = &self.prefetch_api {
-                    // Only release after insertion in shard cache. See comment on fn release.
                     prefetcher.prefetching.release(hash);
                 }
-
-                val
+                return Err(e);
             }
         };
+
+        // Insert value to shard cache, if its size is small enough.
+        // It is fine to have a size limit for shard cache and **not** have a limit for accounting cache, because key
+        // is always a value hash, so for each key there could be only one value, and it is impossible to have
+        // **different** values for the given key in shard and accounting caches.
+        if val.len() < TrieConfig::max_cached_value_size() {
+            let mut guard = self.shard_cache.lock();
+            guard.put(*hash, val.clone());
+        } else {
+            self.metrics.shard_cache_too_large.inc();
+            near_o11y::io_trace!(count: "shard_cache_too_large");
+        }
+
+        if let Some(prefetcher) = &self.prefetch_api {
+            // Only release after insertion in shard cache. See comment on fn release.
+            prefetcher.prefetching.release(hash);
+        }
 
         Ok(val)
     }

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -426,6 +426,73 @@ impl TrieCachingStorage {
         key[8..].copy_from_slice(hash.as_ref());
         key
     }
+
+    /// Reads value if it is not in shard cache. Handles dropping the cache
+    /// lock. Either waits for prefetcher to fetch it or reads it from DB.
+    fn read_for_shard_cache_miss(
+        &self,
+        guard: std::sync::MutexGuard<TrieCacheInner>,
+        hash: &CryptoHash,
+    ) -> Result<Arc<[u8]>, StorageError> {
+        let val = if let Some(prefetcher) = &self.prefetch_api {
+            let prefetch_state = prefetcher.prefetching.get_or_set_fetching(*hash);
+            // Keep lock until here to avoid race condition between shard cache lookup and reserving prefetch slot.
+            std::mem::drop(guard);
+
+            match prefetch_state {
+                // Slot reserved for us, the main thread.
+                // `SlotReserved` for the main thread means, either we have not submitted a prefetch request for
+                // this value, or maybe it is just still queued up. Either way, prefetching is not going to help
+                // so the main thread should fetch data from DB on its own.
+                PrefetcherResult::SlotReserved => {
+                    self.metrics.prefetch_not_requested.inc();
+                    self.read_from_db(hash)?
+                }
+                // `MemoryLimitReached` is not really relevant for the main thread,
+                // we always have to go to DB even if we could not stage a new prefetch.
+                // It only means we were not able to mark it as already being fetched, which in turn could lead to
+                // a prefetcher trying to fetch the same value before we can put it in the shard cache.
+                PrefetcherResult::MemoryLimitReached => {
+                    self.metrics.prefetch_memory_limit_reached.inc();
+                    self.read_from_db(hash)?
+                }
+                PrefetcherResult::Prefetched(value) => {
+                    near_o11y::io_trace!(count: "prefetch_hit");
+                    self.metrics.prefetch_hits.inc();
+                    value
+                }
+                PrefetcherResult::Pending => {
+                    near_o11y::io_trace!(count: "prefetch_pending");
+                    self.metrics.prefetch_pending.inc();
+                    std::thread::yield_now();
+                    // If data is already being prefetched, wait for that instead of sending a new request.
+                    match prefetcher.prefetching.blocking_get(*hash) {
+                        Some(value) => value,
+                        // Only main thread (this one) removes values from staging area,
+                        // therefore blocking read will usually not return empty unless there
+                        // was a storage error. Or in the case of forks and parallel chunk
+                        // processing where one chunk cleans up prefetched data from the other.
+                        // So first we need to check if the data was inserted to shard_cache
+                        // by the main thread from another fork and only if that fails then
+                        // fetch the data from the DB.
+                        None => {
+                            if let Some(value) = self.shard_cache.get(hash) {
+                                self.metrics.prefetch_conflict.inc();
+                                value
+                            } else {
+                                self.metrics.prefetch_retry.inc();
+                                self.read_from_db(hash)?
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            std::mem::drop(guard);
+            self.read_from_db(hash)?
+        };
+        Ok(val)
+    }
 }
 
 impl TrieStorage for TrieCachingStorage {
@@ -443,64 +510,15 @@ impl TrieStorage for TrieCachingStorage {
             None => {
                 self.metrics.shard_cache_misses.inc();
                 near_o11y::io_trace!(count: "shard_cache_miss");
-                let val;
-                if let Some(prefetcher) = &self.prefetch_api {
-                    let prefetch_state = prefetcher.prefetching.get_or_set_fetching(*hash);
-                    // Keep lock until here to avoid race condition between shard cache lookup and reserving prefetch slot.
-                    std::mem::drop(guard);
-
-                    val = match prefetch_state {
-                        // Slot reserved for us, the main thread.
-                        // `SlotReserved` for the main thread means, either we have not submitted a prefetch request for
-                        // this value, or maybe it is just still queued up. Either way, prefetching is not going to help
-                        // so the main thread should fetch data from DB on its own.
-                        PrefetcherResult::SlotReserved => {
-                            self.metrics.prefetch_not_requested.inc();
-                            self.read_from_db(hash)?
+                let val = match self.read_for_shard_cache_miss(guard, hash) {
+                    Ok(val) => val,
+                    Err(e) => {
+                        if let Some(prefetcher) = &self.prefetch_api {
+                            prefetcher.prefetching.release(hash);
                         }
-                        // `MemoryLimitReached` is not really relevant for the main thread,
-                        // we always have to go to DB even if we could not stage a new prefetch.
-                        // It only means we were not able to mark it as already being fetched, which in turn could lead to
-                        // a prefetcher trying to fetch the same value before we can put it in the shard cache.
-                        PrefetcherResult::MemoryLimitReached => {
-                            self.metrics.prefetch_memory_limit_reached.inc();
-                            self.read_from_db(hash)?
-                        }
-                        PrefetcherResult::Prefetched(value) => {
-                            near_o11y::io_trace!(count: "prefetch_hit");
-                            self.metrics.prefetch_hits.inc();
-                            value
-                        }
-                        PrefetcherResult::Pending => {
-                            near_o11y::io_trace!(count: "prefetch_pending");
-                            self.metrics.prefetch_pending.inc();
-                            std::thread::yield_now();
-                            // If data is already being prefetched, wait for that instead of sending a new request.
-                            match prefetcher.prefetching.blocking_get(*hash) {
-                                Some(value) => value,
-                                // Only main thread (this one) removes values from staging area,
-                                // therefore blocking read will usually not return empty unless there
-                                // was a storage error. Or in the case of forks and parallel chunk
-                                // processing where one chunk cleans up prefetched data from the other.
-                                // So first we need to check if the data was inserted to shard_cache
-                                // by the main thread from another fork and only if that fails then
-                                // fetch the data from the DB.
-                                None => {
-                                    if let Some(value) = self.shard_cache.get(hash) {
-                                        self.metrics.prefetch_conflict.inc();
-                                        value
-                                    } else {
-                                        self.metrics.prefetch_retry.inc();
-                                        self.read_from_db(hash)?
-                                    }
-                                }
-                            }
-                        }
-                    };
-                } else {
-                    std::mem::drop(guard);
-                    val = self.read_from_db(hash)?;
-                }
+                        return Err(e);
+                    }
+                };
 
                 // Insert value to shard cache, if its size is small enough.
                 // It is fine to have a size limit for shard cache and **not** have a limit for accounting cache, because key


### PR DESCRIPTION
This just moves some code from `retrieve_raw_bytes` into separate method `read_for_shard_cache_miss`.
But additionally, if that read results in storage error, we release prefetcher staging area.
If we don't do this, additional read of non-existing value will observe prefetch pending slot and hang on it.