### PR TITLE
fix: test_access_key_smart_contract_testnet test

### DIFF
--- a/core/parameters/src/cost.rs
+++ b/core/parameters/src/cost.rs
@@ -406,9 +406,9 @@ impl RuntimeFeesConfig {
                     execution: 6812999,
                 },
                 ActionCosts::function_call_base => Fee {
-                    send_sir: 2319861500000,
-                    send_not_sir: 2319861500000,
-                    execution: 2319861500000,
+                    send_sir: 200_000_000_000,
+                    send_not_sir: 200_000_000_000,
+                    execution: 780_000_000_000,
                 },
                 ActionCosts::function_call_byte => Fee {
                     send_sir: 2235934,

--- a/runtime/near-vm-runner/src/logic/tests/gas_counter.rs
+++ b/runtime/near-vm-runner/src/logic/tests/gas_counter.rs
@@ -518,13 +518,13 @@ fn out_of_gas_function_call_byte() {
     check_action_gas_exceeds_attached(
         ActionCosts::function_call_byte,
         40,
-        expect!["2444873079439 burnt 10000000000000 used"],
+        expect!["325011579439 burnt 10000000000000 used"],
         cross_contract_call,
     );
     check_action_gas_exceeds_attached(
         ActionCosts::function_call_byte,
         40,
-        expect!["2444873079439 burnt 10000000000000 used"],
+        expect!["325011579439 burnt 10000000000000 used"],
         cross_contract_call_gas_weight,
     );
 }

--- a/runtime/near-vm-runner/src/logic/tests/promises.rs
+++ b/runtime/near-vm-runner/src/logic/tests/promises.rs
@@ -164,7 +164,7 @@ fn test_promise_batch_action_create_account() {
     logic
         .promise_batch_action_create_account(index)
         .expect("should add an action to create account");
-    assert_eq!(logic.used_gas().unwrap(), 12578263688564);
+    assert_eq!(logic.used_gas().unwrap(), 8918540688564);
     expect_test::expect![[r#"
         [
           {
@@ -233,7 +233,7 @@ fn test_promise_batch_action_deploy_contract() {
     logic
         .promise_batch_action_deploy_contract(index, code.len, code.ptr)
         .expect("should add an action to deploy contract");
-    assert_eq!(logic.used_gas().unwrap(), 5255774958146);
+    assert_eq!(logic.used_gas().unwrap(), 1596051958146);
     expect_test::expect![[r#"
         [
           {
@@ -312,7 +312,7 @@ fn test_promise_batch_action_transfer() {
         .promise_batch_action_transfer(index, num_110u128.ptr)
         .expect("should add an action to transfer money");
     logic.promise_batch_action_transfer(index, num_1u128.ptr).expect_err("not enough money");
-    assert_eq!(logic.used_gas().unwrap(), 5349703444787);
+    assert_eq!(logic.used_gas().unwrap(), 1689980444787);
     expect_test::expect![[r#"
         [
           {
@@ -387,7 +387,7 @@ fn test_promise_batch_action_stake() {
     logic
         .promise_batch_action_stake(index, num_110u128.ptr, key.len, key.ptr)
         .expect("should add an action to stake");
-    assert_eq!(logic.used_gas().unwrap(), 5138414976215);
+    assert_eq!(logic.used_gas().unwrap(), 1478691976215);
     expect_test::expect![[r#"
         [
           {
@@ -485,7 +485,7 @@ fn test_promise_batch_action_add_key_with_function_call() {
         method_names,
     )
     .expect("should add allowance");
-    assert_eq!(logic.used_gas().unwrap(), 5126680499695);
+    assert_eq!(logic.used_gas().unwrap(), 1466957499695);
     expect_test::expect![[r#"
         [
           {
@@ -572,7 +572,7 @@ fn test_promise_batch_then() {
     logic
         .promise_batch_then(index, account_id.len, account_id.ptr)
         .expect("promise batch should run ok");
-    assert_eq!(logic.used_gas().unwrap(), 24124999601771);
+    assert_eq!(logic.used_gas().unwrap(), 20465276601771);
     expect_test::expect![[r#"
         [
           {


### PR DESCRIPTION
The test was broken as a result of #10943.

This PR adjusts `RuntimeFeesConfig::test()` to match the updated costs.

In the long term the proper solution looks like #11082, but it breaks the hardcoded assumption about gas costs that other tests have.

The fix was tested locally with `cargo test -pintegration-tests --features test_features,expensive_tests -- --exact --nocapture tests::standard_cases::rpc::test_access_key_smart_contract_testnet`

Part of #11031.