### PR TITLE
feat(protocol_upgrade) - implemented multiple protocol version upgrades in one release

### DIFF
--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -361,12 +361,12 @@ pub(crate) static CURRENT_PROTOCOL_VERSION: Lazy<IntGauge> = Lazy::new(|| {
         .unwrap()
 });
 
-pub(crate) static NODE_PROTOCOL_UPGRADE_VOTING_START: Lazy<IntGauge> = Lazy::new(|| {
-    try_create_int_gauge(
-        "near_node_protocol_upgrade_voting_start",
-        "Time in seconds since Unix epoch determining when node will start voting for the protocol upgrade; zero if there is no schedule for the voting")
-        .unwrap()
-});
+// pub(crate) static NODE_PROTOCOL_UPGRADE_VOTING_START: Lazy<IntGauge> = Lazy::new(|| {
+//     try_create_int_gauge(
+//         "near_node_protocol_upgrade_voting_start",
+//         "Time in seconds since Unix epoch determining when node will start voting for the protocol upgrade; zero if there is no schedule for the voting")
+//         .unwrap()
+// });
 
 pub(crate) static PRODUCE_CHUNK_TIME: Lazy<HistogramVec> = Lazy::new(|| {
     try_create_histogram_vec(
@@ -404,8 +404,9 @@ pub(crate) static PRODUCE_AND_DISTRIBUTE_CHUNK_TIME: Lazy<HistogramVec> = Lazy::
 /// `neard_version` argument.
 pub(crate) fn export_version(neard_version: &near_primitives::version::Version) {
     NODE_PROTOCOL_VERSION.set(near_primitives::version::PROTOCOL_VERSION.into());
-    NODE_PROTOCOL_UPGRADE_VOTING_START
-        .set(near_primitives::version::PROTOCOL_UPGRADE_SCHEDULE.timestamp());
+    // TODO(wacban)
+    // NODE_PROTOCOL_UPGRADE_VOTING_START
+    //     .set(near_primitives::version::PROTOCOL_UPGRADE_SCHEDULE.timestamp());
     NODE_DB_VERSION.set(near_store::metadata::DB_VERSION.into());
     NODE_BUILD_INFO.reset();
     NODE_BUILD_INFO

--- a/core/primitives/src/upgrade_schedule.rs
+++ b/core/primitives/src/upgrade_schedule.rs
@@ -12,20 +12,16 @@ pub enum ProtocolUpgradeVotingScheduleError {
     InvalidProtocolVersionOrder,
 }
 
-/// Defines the point in time after which validators are expected to vote on the
-/// new protocol version.
-#[derive(Clone, Debug, PartialEq)]
+/// Defines a schedule for validators to vote for the protocol version upgrades.
+/// Multiple protocol version upgrades can be scheduled. The default schedule is
+/// empty and in that case the node will always vote for the client protocol
+/// version.
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct ProtocolUpgradeVotingSchedule {
     /// The schedule is a sorted list of (datetime, version) tuples. The node
     /// should vote for the highest version that is less than or equal to the
     /// current time.
     schedule: Vec<(chrono::DateTime<Utc>, ProtocolVersion)>,
-}
-
-impl Default for ProtocolUpgradeVotingSchedule {
-    fn default() -> Self {
-        Self { schedule: vec![] }
-    }
 }
 
 impl ProtocolUpgradeVotingSchedule {
@@ -80,12 +76,7 @@ impl ProtocolUpgradeVotingSchedule {
         Ok(Self { schedule })
     }
 
-    pub fn parse_datetime(s: &str) -> Result<DateTime<Utc>, ParseError> {
-        let datetime = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S")?;
-        let datetime = DateTime::<Utc>::from_naive_utc_and_offset(datetime, Utc);
-        Ok(datetime)
-    }
-
+    /// This method returns the protocol version that the node should vote for.
     pub(crate) fn get_protocol_version(
         &self,
         now: DateTime<Utc>,
@@ -113,6 +104,18 @@ impl ProtocolUpgradeVotingSchedule {
         }
 
         result
+    }
+
+    /// Returns the schedule. Should only be used for exporting metrics.
+    pub fn schedule(&self) -> &Vec<(chrono::DateTime<Utc>, ProtocolVersion)> {
+        &self.schedule
+    }
+
+    /// A helper method to parse the datetime string.
+    pub fn parse_datetime(s: &str) -> Result<DateTime<Utc>, ParseError> {
+        let datetime = NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S")?;
+        let datetime = DateTime::<Utc>::from_naive_utc_and_offset(datetime, Utc);
+        Ok(datetime)
     }
 }
 

--- a/core/primitives/src/upgrade_schedule.rs
+++ b/core/primitives/src/upgrade_schedule.rs
@@ -37,7 +37,7 @@ impl ProtocolUpgradeVotingSchedule {
 
     /// This method creates an instance of the ProtocolUpgradeVotingSchedule.
     ///
-    /// It will first check if the NEAR_TESTS_IMMEDIATE_PROTOCOL_UPGRADE is set
+    /// It will first check if the NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE is set
     /// in the environment and if so return the immediate upgrade schedule. This
     /// should only be used in tests, in particular in tests that in some way
     /// test neard upgrades.
@@ -47,7 +47,7 @@ impl ProtocolUpgradeVotingSchedule {
         client_protocol_version: ProtocolVersion,
         schedule: Vec<(chrono::DateTime<Utc>, ProtocolVersion)>,
     ) -> Result<Self, ProtocolUpgradeVotingScheduleError> {
-        let immediate_upgrade = env::var("NEAR_TESTS_IMMEDIATE_PROTOCOL_UPGRADE");
+        let immediate_upgrade = env::var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE");
         if let Ok(_) = immediate_upgrade {
             tracing::warn!("Setting immediate protocol upgrade. This is fine in tests but should be avoided otherwise");
             return Ok(Self::new_immediate(client_protocol_version));
@@ -324,7 +324,7 @@ mod tests {
     fn test_env_overwrite() {
         // The immediate protocol upgrade needs to be set for this test to pass in
         // the release branch where the protocol upgrade date is set.
-        std::env::set_var("NEAR_TESTS_IMMEDIATE_PROTOCOL_UPGRADE", "1");
+        std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", "1");
 
         let client_protocol_version = 100;
         let schedule = make_simple_voting_schedule(client_protocol_version, "2999-02-03 23:59:59");

--- a/core/primitives/src/upgrade_schedule.rs
+++ b/core/primitives/src/upgrade_schedule.rs
@@ -56,8 +56,12 @@ impl ProtocolUpgradeVotingSchedule {
     ) -> Result<Self, ProtocolUpgradeVotingScheduleError> {
         let env_override = env::var(NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE);
         if let Ok(env_override) = env_override {
-            tracing::warn!("Setting protocol upgrade override. This is fine in tests but should be avoided otherwise");
             schedule = Self::parse_override(&env_override)?;
+            tracing::warn!(
+                target: "protocol_upgrade",
+                ?schedule,
+                "Setting protocol upgrade override. This is fine in tests but should be avoided otherwise"
+            );
         }
 
         // Sanity and invariant checks.
@@ -89,6 +93,8 @@ impl ProtocolUpgradeVotingSchedule {
                 return Err(ProtocolUpgradeVotingScheduleError::InvalidProtocolVersionOrder);
             }
         }
+
+        tracing::debug!(target: "protocol_upgrade", ?schedule, "created protocol upgrade schedule");
 
         Ok(Self { client_protocol_version, schedule })
     }
@@ -144,8 +150,6 @@ impl ProtocolUpgradeVotingSchedule {
         if override_str.to_lowercase() == "now" {
             return Ok(vec![]);
         }
-
-        tracing::info!(target:"protocol_upgrade", ?override_str, "parsing protocol version upgrade override");
 
         let mut result = vec![];
         let datetime_and_version_vec = override_str.split(',').collect::<Vec<_>>();

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -77,7 +77,7 @@ pub const PROTOCOL_UPGRADE_SCHEDULE: Lazy<ProtocolUpgradeVotingSchedule> = Lazy:
     // let schedule = vec![(v1_datetime, v1_protocol_version), (v2_datetime, v2_protocol_version)];
     // ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(PROTOCOL_VERSION, schedule).unwrap()
 
-    ProtocolUpgradeVotingSchedule::default()
+    ProtocolUpgradeVotingSchedule::new_immediate(PROTOCOL_VERSION)
 });
 
 /// Gives new clients an option to upgrade without announcing that they support

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -10,7 +10,7 @@ pub struct Version {
     pub rustc_version: String,
 }
 
-use crate::upgrade_schedule::{get_protocol_version_internal, ProtocolUpgradeVotingSchedule};
+use crate::upgrade_schedule::ProtocolUpgradeVotingSchedule;
 
 /// near_primitives_core re-exports
 pub use near_primitives_core::checked_feature;
@@ -59,10 +59,23 @@ pub const FIXED_MINIMUM_NEW_RECEIPT_GAS_VERSION: ProtocolVersion = 66;
 /// it’s set according to the schedule for that protocol upgrade.  Release
 /// candidates usually have separate schedule to final releases.
 pub const PROTOCOL_UPGRADE_SCHEDULE: Lazy<ProtocolUpgradeVotingSchedule> = Lazy::new(|| {
-    // Update to according to schedule when making a release.
-    // Keep in mind that the protocol upgrade will happen 1-2 epochs (15h-30h)
-    // after the set date. Ideally that should be during working hours.
-    // e.g. ProtocolUpgradeVotingSchedule::from_env_or_str("2000-01-01 15:00:00").unwrap());
+    // Update according to the schedule when making a release. Keep in mind that
+    // the protocol upgrade will happen 1-2 epochs (15h-30h) after the set date.
+    // Ideally that should be during working hours.
+    //
+    // Multiple protocol version upgrades can be scheduled. Please make sure to
+    // make sure they are ordered by datetime and version, the last one is the
+    // PROTOCOL_VERSION and that there is enough time between subsequent
+    // upgrades.
+    //
+    // e.g.
+    // let v1_protocol_version = 50;
+    // let v2_protocol_version = 51;
+    // let v1_datetime = ProtocolUpgradeVotingSchedule::parse_datetime("2000-01-01 15:00:00").unwrap();
+    // let v2_datetime = ProtocolUpgradeVotingSchedule::parse_datetime("2000-01-10 15:00:00").unwrap();
+    //
+    // let schedule = vec![(v1_datetime, v1_protocol_version), (v2_datetime, v2_protocol_version)];
+    // ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(PROTOCOL_VERSION, schedule)
 
     ProtocolUpgradeVotingSchedule::default()
 });
@@ -71,9 +84,10 @@ pub const PROTOCOL_UPGRADE_SCHEDULE: Lazy<ProtocolUpgradeVotingSchedule> = Lazy:
 /// the new version.  This gives non-validator nodes time to upgrade.  See
 /// <https://github.com/near/NEPs/issues/205>
 pub fn get_protocol_version(next_epoch_protocol_version: ProtocolVersion) -> ProtocolVersion {
-    get_protocol_version_internal(
+    let now = chrono::Utc::now();
+    PROTOCOL_UPGRADE_SCHEDULE.get_protocol_version(
+        now,
         next_epoch_protocol_version,
         PROTOCOL_VERSION,
-        *PROTOCOL_UPGRADE_SCHEDULE,
     )
 }

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -63,11 +63,11 @@ pub const PROTOCOL_UPGRADE_SCHEDULE: Lazy<ProtocolUpgradeVotingSchedule> = Lazy:
     // the protocol upgrade will happen 1-2 epochs (15h-30h) after the set date.
     // Ideally that should be during working hours.
     //
-    // Multiple protocol version upgrades can be scheduled. Please make sure to
-    // make sure they are ordered by datetime and version, the last one is the
+    // Multiple protocol version upgrades can be scheduled. Please make sure
+    // that they are ordered by datetime and version, the last one is the
     // PROTOCOL_VERSION and that there is enough time between subsequent
     // upgrades.
-    //
+
     // e.g.
     // let v1_protocol_version = 50;
     // let v2_protocol_version = 51;
@@ -77,7 +77,7 @@ pub const PROTOCOL_UPGRADE_SCHEDULE: Lazy<ProtocolUpgradeVotingSchedule> = Lazy:
     // let schedule = vec![(v1_datetime, v1_protocol_version), (v2_datetime, v2_protocol_version)];
     // ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(PROTOCOL_VERSION, schedule).unwrap()
 
-    ProtocolUpgradeVotingSchedule::new_immediate(PROTOCOL_VERSION)
+    ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(PROTOCOL_VERSION, vec![]).unwrap()
 });
 
 /// Gives new clients an option to upgrade without announcing that they support

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -75,7 +75,7 @@ pub const PROTOCOL_UPGRADE_SCHEDULE: Lazy<ProtocolUpgradeVotingSchedule> = Lazy:
     // let v2_datetime = ProtocolUpgradeVotingSchedule::parse_datetime("2000-01-10 15:00:00").unwrap();
     //
     // let schedule = vec![(v1_datetime, v1_protocol_version), (v2_datetime, v2_protocol_version)];
-    // ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(PROTOCOL_VERSION, schedule)
+    // ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(PROTOCOL_VERSION, schedule).unwrap()
 
     ProtocolUpgradeVotingSchedule::default()
 });
@@ -85,9 +85,5 @@ pub const PROTOCOL_UPGRADE_SCHEDULE: Lazy<ProtocolUpgradeVotingSchedule> = Lazy:
 /// <https://github.com/near/NEPs/issues/205>
 pub fn get_protocol_version(next_epoch_protocol_version: ProtocolVersion) -> ProtocolVersion {
     let now = chrono::Utc::now();
-    PROTOCOL_UPGRADE_SCHEDULE.get_protocol_version(
-        now,
-        next_epoch_protocol_version,
-        PROTOCOL_VERSION,
-    )
+    PROTOCOL_UPGRADE_SCHEDULE.get_protocol_version(now, next_epoch_protocol_version)
 }

--- a/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
+++ b/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
@@ -13,7 +13,7 @@ use nearcore::test_utils::TestEnvNightshadeSetupExt;
 fn test_account_id_in_function_call_permission_upgrade() {
     // The immediate protocol upgrade needs to be set for this test to pass in
     // the release branch where the protocol upgrade date is set.
-    std::env::set_var("NEAR_TESTS_IMMEDIATE_PROTOCOL_UPGRADE", "1");
+    std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", "1");
 
     let old_protocol_version =
         near_primitives::version::ProtocolFeature::AccountIdInFunctionCallPermission

--- a/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
+++ b/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
@@ -13,7 +13,7 @@ use nearcore::test_utils::TestEnvNightshadeSetupExt;
 fn test_account_id_in_function_call_permission_upgrade() {
     // The immediate protocol upgrade needs to be set for this test to pass in
     // the release branch where the protocol upgrade date is set.
-    std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", "1");
+    std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", "now");
 
     let old_protocol_version =
         near_primitives::version::ProtocolFeature::AccountIdInFunctionCallPermission

--- a/integration-tests/src/tests/client/features/flat_storage.rs
+++ b/integration-tests/src/tests/client/features/flat_storage.rs
@@ -20,7 +20,7 @@ use nearcore::test_utils::TestEnvNightshadeSetupExt;
 fn test_flat_storage_upgrade() {
     // The immediate protocol upgrade needs to be set for this test to pass in
     // the release branch where the protocol upgrade date is set.
-    std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", "1");
+    std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", "now");
 
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     let epoch_length = 12;

--- a/integration-tests/src/tests/client/features/flat_storage.rs
+++ b/integration-tests/src/tests/client/features/flat_storage.rs
@@ -20,7 +20,7 @@ use nearcore::test_utils::TestEnvNightshadeSetupExt;
 fn test_flat_storage_upgrade() {
     // The immediate protocol upgrade needs to be set for this test to pass in
     // the release branch where the protocol upgrade date is set.
-    std::env::set_var("NEAR_TESTS_IMMEDIATE_PROTOCOL_UPGRADE", "1");
+    std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", "1");
 
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     let epoch_length = 12;

--- a/integration-tests/src/tests/client/features/increase_deployment_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_deployment_cost.rs
@@ -15,7 +15,7 @@ use nearcore::test_utils::TestEnvNightshadeSetupExt;
 fn test_deploy_cost_increased() {
     // The immediate protocol upgrade needs to be set for this test to pass in
     // the release branch where the protocol upgrade date is set.
-    std::env::set_var("NEAR_TESTS_IMMEDIATE_PROTOCOL_UPGRADE", "1");
+    std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", "1");
 
     let new_protocol_version = ProtocolFeature::IncreaseDeploymentCost.protocol_version();
     let old_protocol_version = new_protocol_version - 1;

--- a/integration-tests/src/tests/client/features/increase_deployment_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_deployment_cost.rs
@@ -15,7 +15,7 @@ use nearcore::test_utils::TestEnvNightshadeSetupExt;
 fn test_deploy_cost_increased() {
     // The immediate protocol upgrade needs to be set for this test to pass in
     // the release branch where the protocol upgrade date is set.
-    std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", "1");
+    std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", "now");
 
     let new_protocol_version = ProtocolFeature::IncreaseDeploymentCost.protocol_version();
     let old_protocol_version = new_protocol_version - 1;

--- a/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
@@ -177,7 +177,7 @@ fn assert_compute_limit_reached(
 ) {
     // The immediate protocol upgrade needs to be set for this test to pass in
     // the release branch where the protocol upgrade date is set.
-    std::env::set_var("NEAR_TESTS_IMMEDIATE_PROTOCOL_UPGRADE", "1");
+    std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", "1");
     near_o11y::testonly::init_test_logger();
 
     let old_protocol_version = INCREASED_STORAGE_COSTS_PROTOCOL_VERSION - 1;

--- a/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
@@ -177,7 +177,7 @@ fn assert_compute_limit_reached(
 ) {
     // The immediate protocol upgrade needs to be set for this test to pass in
     // the release branch where the protocol upgrade date is set.
-    std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", "1");
+    std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", "now");
     near_o11y::testonly::init_test_logger();
 
     let old_protocol_version = INCREASED_STORAGE_COSTS_PROTOCOL_VERSION - 1;

--- a/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
+++ b/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
@@ -33,7 +33,7 @@ fn protocol_upgrade() {
 
     // The immediate protocol upgrade needs to be set for this test to pass in
     // the release branch where the protocol upgrade date is set.
-    std::env::set_var("NEAR_TESTS_IMMEDIATE_PROTOCOL_UPGRADE", "1");
+    std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", "1");
 
     // Prepare TestEnv with a contract at the old protocol version.
     let mut env = {

--- a/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
+++ b/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
@@ -33,7 +33,7 @@ fn protocol_upgrade() {
 
     // The immediate protocol upgrade needs to be set for this test to pass in
     // the release branch where the protocol upgrade date is set.
-    std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", "1");
+    std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", "now");
 
     // Prepare TestEnv with a contract at the old protocol version.
     let mut env = {

--- a/integration-tests/src/tests/client/features/zero_balance_account.rs
+++ b/integration-tests/src/tests/client/features/zero_balance_account.rs
@@ -242,7 +242,7 @@ fn test_zero_balance_account_add_key() {
 fn test_zero_balance_account_upgrade() {
     // The immediate protocol upgrade needs to be set for this test to pass in
     // the release branch where the protocol upgrade date is set.
-    std::env::set_var("NEAR_TESTS_IMMEDIATE_PROTOCOL_UPGRADE", "1");
+    std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", "1");
 
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);

--- a/integration-tests/src/tests/client/features/zero_balance_account.rs
+++ b/integration-tests/src/tests/client/features/zero_balance_account.rs
@@ -242,7 +242,7 @@ fn test_zero_balance_account_add_key() {
 fn test_zero_balance_account_upgrade() {
     // The immediate protocol upgrade needs to be set for this test to pass in
     // the release branch where the protocol upgrade date is set.
-    std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", "1");
+    std::env::set_var("NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE", "now");
 
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2758,28 +2758,8 @@ fn test_epoch_protocol_version_change() {
             .epoch_manager
             .get_epoch_id_from_prev_block(&head.last_block_hash)
             .unwrap();
-        let chunk_producer =
-            env.clients[0].epoch_manager.get_chunk_producer(&epoch_id, i, 0).unwrap();
-        let index = if chunk_producer == "test0" { 0 } else { 1 };
-        let ProduceChunkResult {
-            chunk: encoded_chunk,
-            encoded_chunk_parts_paths: merkle_paths,
-            receipts,
-            ..
-        } = create_chunk_on_height(&mut env.clients[index], i);
 
-        for j in 0..2 {
-            let validator_id =
-                env.clients[j].validator_signer.as_ref().unwrap().validator_id().clone();
-            env.clients[j]
-                .persist_and_distribute_encoded_chunk(
-                    encoded_chunk.clone(),
-                    merkle_paths.clone(),
-                    receipts.clone(),
-                    validator_id,
-                )
-                .unwrap();
-        }
+        produce_chunks(&mut env, &epoch_id, i);
 
         let epoch_id = env.clients[0]
             .epoch_manager

--- a/integration-tests/src/tests/client/resharding.rs
+++ b/integration-tests/src/tests/client/resharding.rs
@@ -2021,19 +2021,16 @@ fn test_shard_layout_upgrade_missing_chunks_high_missing_prob_v3() {
 
 // latest protocol
 
-#[ignore]
 #[test]
 fn test_latest_protocol_missing_chunks_low_missing_prob() {
     test_latest_protocol_missing_chunks(0.1, 25);
 }
 
-#[ignore]
 #[test]
 fn test_latest_protocol_missing_chunks_mid_missing_prob() {
     test_latest_protocol_missing_chunks(0.5, 26);
 }
 
-#[ignore]
 #[test]
 fn test_latest_protocol_missing_chunks_high_missing_prob() {
     test_latest_protocol_missing_chunks(0.9, 27);

--- a/pytest/tests/sanity/upgradable.py
+++ b/pytest/tests/sanity/upgradable.py
@@ -161,7 +161,7 @@ def test_upgrade() -> None:
         nodes[i].binary_name = executables.current.neard
         nodes[i].start(
             boot_node=nodes[0],
-            extra_env={"NEAR_TESTS_IMMEDIATE_PROTOCOL_UPGRADE": "1"},
+            extra_env={"NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE": "1"},
         )
 
     count = 0

--- a/pytest/tests/sanity/upgradable.py
+++ b/pytest/tests/sanity/upgradable.py
@@ -161,7 +161,7 @@ def test_upgrade() -> None:
         nodes[i].binary_name = executables.current.neard
         nodes[i].start(
             boot_node=nodes[0],
-            extra_env={"NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE": "1"},
+            extra_env={"NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE": "now"},
         )
 
     count = 0


### PR DESCRIPTION
Implemented the feature described in #10911. 

It may or may not be needed for the congestion control and stateless validation release but it should be useful in general and I just want to take this variable out of the equation. 