### PR TITLE
feat(forknet): allow running traffic generator with a key map secret

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -850,8 +850,12 @@ class NeardRunner:
                     self.source_near_home_path(),
                     '--target-home',
                     self.target_near_home_path(),
-                    '--no-secret',
                 ]
+                if os.path.exists(self.setup_path('mirror-secret.json')):
+                    cmd.append('--secret-file')
+                    cmd.append(self.setup_path('mirror-secret.json'))
+                else:
+                    cmd.append('--no-secret')
                 if batch_interval_millis is not None:
                     with open(self.target_near_home_path('mirror-config.json'),
                               'w') as f:


### PR DESCRIPTION
we've been using the mirror tool without a secret used to map keys, which is fine when we're running internal tests. but if we want to start a forknet instance that will later be opened up to the public, we'll want to use a mix the mapped keys with a secret. so here we will assume that it will be placed in ~/.near/setup/mirror-secret.json (or ~/.near/target/setup/mirror-secret.json for V2 setups) and we'll use it if so