### PR TITLE
refactor: clarify what is the next epoch on generation

### DIFF
--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -619,7 +619,7 @@ impl EpochManager {
         let config = self.config.for_protocol_version(protocol_version);
         // Note: non-deterministic iteration is fine here, there can be only one
         // version with large enough stake.
-        let next_next_version = if let Some((version, stake)) =
+        let next_next_epoch_version = if let Some((version, stake)) =
             versions.into_iter().max_by_key(|&(_version, stake)| stake)
         {
             let numer = *config.protocol_upgrade_stake_threshold.numer() as u128;
@@ -634,8 +634,8 @@ impl EpochManager {
             protocol_version
         };
 
-        PROTOCOL_VERSION_NEXT.set(next_next_version as i64);
-        tracing::info!(target: "epoch_manager", ?next_next_version, "Protocol version voting.");
+        PROTOCOL_VERSION_NEXT.set(next_next_epoch_version as i64);
+        tracing::info!(target: "epoch_manager", ?next_next_epoch_version, "Protocol version voting.");
 
         // Gather slashed validators and add them to kick out first.
         let slashed_validators = last_block_info.slashed();
@@ -680,7 +680,7 @@ impl EpochManager {
             all_proposals: proposals,
             validator_kickout,
             validator_block_chunk_stats,
-            next_next_epoch_version: next_next_version,
+            next_next_epoch_version,
         })
     }
 

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -680,7 +680,7 @@ impl EpochManager {
             all_proposals: proposals,
             validator_kickout,
             validator_block_chunk_stats,
-            next_version,
+            next_next_version: next_version,
         })
     }
 
@@ -705,7 +705,7 @@ impl EpochManager {
             all_proposals,
             validator_kickout,
             mut validator_block_chunk_stats,
-            next_version,
+            next_next_version,
             ..
         } = epoch_summary;
 
@@ -734,9 +734,9 @@ impl EpochManager {
                 epoch_duration,
             )
         };
-        let next_next_epoch_config = self.config.for_protocol_version(next_version);
-        let next_shard_layout =
-            self.config.for_protocol_version(epoch_protocol_version).shard_layout;
+        let next_next_epoch_config = self.config.for_protocol_version(next_next_version);
+        let next_version = next_epoch_info.protocol_version();
+        let next_shard_layout = self.config.for_protocol_version(next_version).shard_layout;
         let has_same_shard_layout = next_shard_layout == next_next_epoch_config.shard_layout;
         let next_next_epoch_info = match proposals_to_epoch_info(
             &next_next_epoch_config,
@@ -747,7 +747,7 @@ impl EpochManager {
             validator_reward,
             minted_amount,
             epoch_protocol_version,
-            next_version,
+            next_next_version,
             has_same_shard_layout,
         ) {
             Ok(next_next_epoch_info) => next_next_epoch_info,

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -619,7 +619,7 @@ impl EpochManager {
         let config = self.config.for_protocol_version(protocol_version);
         // Note: non-deterministic iteration is fine here, there can be only one
         // version with large enough stake.
-        let next_version = if let Some((version, stake)) =
+        let next_next_version = if let Some((version, stake)) =
             versions.into_iter().max_by_key(|&(_version, stake)| stake)
         {
             let numer = *config.protocol_upgrade_stake_threshold.numer() as u128;
@@ -634,8 +634,8 @@ impl EpochManager {
             protocol_version
         };
 
-        PROTOCOL_VERSION_NEXT.set(next_version as i64);
-        tracing::info!(target: "epoch_manager", ?next_version, "Protocol version voting.");
+        PROTOCOL_VERSION_NEXT.set(next_next_version as i64);
+        tracing::info!(target: "epoch_manager", ?next_next_version, "Protocol version voting.");
 
         // Gather slashed validators and add them to kick out first.
         let slashed_validators = last_block_info.slashed();
@@ -680,7 +680,7 @@ impl EpochManager {
             all_proposals: proposals,
             validator_kickout,
             validator_block_chunk_stats,
-            next_next_version: next_version,
+            next_next_version,
         })
     }
 

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -680,7 +680,7 @@ impl EpochManager {
             all_proposals: proposals,
             validator_kickout,
             validator_block_chunk_stats,
-            next_next_version,
+            next_next_epoch_version: next_next_version,
         })
     }
 
@@ -705,7 +705,7 @@ impl EpochManager {
             all_proposals,
             validator_kickout,
             mut validator_block_chunk_stats,
-            next_next_version,
+            next_next_epoch_version,
             ..
         } = epoch_summary;
 
@@ -734,9 +734,9 @@ impl EpochManager {
                 epoch_duration,
             )
         };
-        let next_next_epoch_config = self.config.for_protocol_version(next_next_version);
-        let next_version = next_epoch_info.protocol_version();
-        let next_shard_layout = self.config.for_protocol_version(next_version).shard_layout;
+        let next_next_epoch_config = self.config.for_protocol_version(next_next_epoch_version);
+        let next_epoch_version = next_epoch_info.protocol_version();
+        let next_shard_layout = self.config.for_protocol_version(next_epoch_version).shard_layout;
         let has_same_shard_layout = next_shard_layout == next_next_epoch_config.shard_layout;
         let next_next_epoch_info = match proposals_to_epoch_info(
             &next_next_epoch_config,
@@ -747,7 +747,7 @@ impl EpochManager {
             validator_reward,
             minted_amount,
             epoch_protocol_version,
-            next_next_version,
+            next_next_epoch_version,
             has_same_shard_layout,
         ) {
             Ok(next_next_epoch_info) => next_next_epoch_info,

--- a/chain/epoch-manager/src/proposals.rs
+++ b/chain/epoch-manager/src/proposals.rs
@@ -45,11 +45,13 @@ pub fn proposals_to_epoch_info(
     validator_kickout: HashMap<AccountId, ValidatorKickoutReason>,
     validator_reward: HashMap<AccountId, Balance>,
     minted_amount: Balance,
-    current_version: ProtocolVersion,
-    next_version: ProtocolVersion,
+    prev_prev_protocol_version: ProtocolVersion,
+    protocol_version: ProtocolVersion,
     use_stable_shard_assignment: bool,
 ) -> Result<EpochInfo, EpochError> {
-    if checked_feature!("stable", AliasValidatorSelectionAlgorithm, current_version) {
+    // For this protocol feature, switch happened two epochs after protocol upgrade.
+    // Keeping it this way for replayability.
+    if checked_feature!("stable", AliasValidatorSelectionAlgorithm, prev_prev_protocol_version) {
         return crate::validator_selection::proposals_to_epoch_info(
             epoch_config,
             rng_seed,
@@ -58,7 +60,7 @@ pub fn proposals_to_epoch_info(
             validator_kickout,
             validator_reward,
             minted_amount,
-            next_version,
+            protocol_version,
             use_stable_shard_assignment,
         );
     } else {
@@ -70,7 +72,7 @@ pub fn proposals_to_epoch_info(
             validator_kickout,
             validator_reward,
             minted_amount,
-            next_version,
+            protocol_version,
         );
     }
 }

--- a/chain/epoch-manager/src/proposals.rs
+++ b/chain/epoch-manager/src/proposals.rs
@@ -45,13 +45,17 @@ pub fn proposals_to_epoch_info(
     validator_kickout: HashMap<AccountId, ValidatorKickoutReason>,
     validator_reward: HashMap<AccountId, Balance>,
     minted_amount: Balance,
-    prev_prev_protocol_version: ProtocolVersion,
+    prev_prev_epoch_protocol_version: ProtocolVersion,
     protocol_version: ProtocolVersion,
     use_stable_shard_assignment: bool,
 ) -> Result<EpochInfo, EpochError> {
     // For this protocol feature, switch happened two epochs after protocol upgrade.
     // Keeping it this way for replayability.
-    if checked_feature!("stable", AliasValidatorSelectionAlgorithm, prev_prev_protocol_version) {
+    if checked_feature!(
+        "stable",
+        AliasValidatorSelectionAlgorithm,
+        prev_prev_epoch_protocol_version
+    ) {
         return crate::validator_selection::proposals_to_epoch_info(
             epoch_config,
             rng_seed,

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -1268,8 +1268,9 @@ pub mod epoch_info {
         pub validator_kickout: HashMap<AccountId, ValidatorKickoutReason>,
         /// Only for validators who met the threshold and didn't get slashed
         pub validator_block_chunk_stats: HashMap<AccountId, BlockChunkValidatorStats>,
-        /// Protocol version for next epoch.
-        pub next_version: ProtocolVersion,
+        /// Protocol version for next next epoch, as summary of epoch T defines
+        /// epoch T+2.
+        pub next_next_version: ProtocolVersion,
     }
 }
 

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -1270,7 +1270,7 @@ pub mod epoch_info {
         pub validator_block_chunk_stats: HashMap<AccountId, BlockChunkValidatorStats>,
         /// Protocol version for next next epoch, as summary of epoch T defines
         /// epoch T+2.
-        pub next_next_version: ProtocolVersion,
+        pub next_next_epoch_version: ProtocolVersion,
     }
 }
 

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -338,7 +338,7 @@ pub fn migrate_38_to_39(store: &Store) -> anyhow::Result<()> {
                     (account_id, new_stats)
                 })
                 .collect(),
-            next_version: legacy_summary.next_version,
+            next_next_version: legacy_summary.next_version,
         };
         update.set(DBCol::EpochValidatorInfo, &key, &borsh::to_vec(&new_value)?);
     }

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -338,7 +338,7 @@ pub fn migrate_38_to_39(store: &Store) -> anyhow::Result<()> {
                     (account_id, new_stats)
                 })
                 .collect(),
-            next_next_version: legacy_summary.next_version,
+            next_next_epoch_version: legacy_summary.next_version,
         };
         update.set(DBCol::EpochValidatorInfo, &key, &borsh::to_vec(&new_value)?);
     }


### PR DESCRIPTION
On #11322 there was a fair suggestion to clarify what is "next" and "next next" epoch, and in fact, there was some inaccuracy there, which I want to resolve.
With the fixed definitions,

* As epoch T defines epoch T+2, EpochSummary field for epoch T must be called `next_next_version`, not `next_version`. Self-check: on epoch T validators voted for new protocol version; however, on epoch T+1 upgrade doesn't happen because validators need to already sync at some state, which corresponds to old protocol version; protocol version of T+2 is defined by epoch_summary(T).next_next_version.
* `proposals_to_epoch_info` arguments are aligned with what is "prev" and "next". `prev_prev_protocol_version` is kept for legacy reasons, `prev_epoch_info` is indeed info of the epoch before, `protocol_version` is the one which we use to generate current info.

Moreover, previous shard layout comparison was incorrect and now it is fixed as well.