### PR TITLE
Lower transaction size limit to 1.5MiB

### DIFF
--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -34,7 +34,7 @@ fn build_chain() {
     if cfg!(feature = "nightly") {
         insta::assert_snapshot!(hash, @"C3zeKRZubVungxfrSdq379TSCYnuz2YzjEkcJTdm3pU4");
     } else {
-        insta::assert_snapshot!(hash, @"2WHohfYksQnwKwSEoTKpkseu2RWthbGf9kmGetgHgfQQ");
+        insta::assert_snapshot!(hash, @"Gy5ScP5b8NmHSFvdRHWmdvfRwLfx3gs5GoasiXXtmNmv");
     }
 
     for i in 1..5 {
@@ -52,7 +52,7 @@ fn build_chain() {
     if cfg!(feature = "nightly") {
         insta::assert_snapshot!(hash, @"EjLaoHRiAdRp2NcDqwbMcAYYxGfcv5R7GuYUNfRpaJvB");
     } else {
-        insta::assert_snapshot!(hash, @"HJuuENeSwwikoR9BZA7cSonxAPZgY5mKQWL2pSXwjAwZ");
+        insta::assert_snapshot!(hash, @"HoBdHTTC2QSkQfsmBerpTJnBVyfMDBzjBA9DwM4wnpMC");
     }
 }
 

--- a/chain/jsonrpc/jsonrpc-tests/res/genesis_config.json
+++ b/chain/jsonrpc/jsonrpc-tests/res/genesis_config.json
@@ -1,5 +1,5 @@
 {
-  "protocol_version": 67,
+  "protocol_version": 68,
   "genesis_time": "1970-01-01T00:00:00.000000000Z",
   "chain_id": "sample",
   "genesis_height": 0,

--- a/core/parameters/res/runtime_configs/68.yaml
+++ b/core/parameters/res/runtime_configs/68.yaml
@@ -1,0 +1,1 @@
+max_transaction_size: {old: 4_194_304, new: 1_572_864}

--- a/core/parameters/res/runtime_configs/parameters.snap
+++ b/core/parameters/res/runtime_configs/parameters.snap
@@ -160,7 +160,7 @@ max_length_method_name                                   256
 max_arguments_length                               4_194_304
 max_length_returned_data                           4_194_304
 max_contract_size                                  4_194_304
-max_transaction_size                               4_194_304
+max_transaction_size                               1_572_864
 max_length_storage_key                                 2_048
 max_length_storage_value                           4_194_304
 max_promises_per_function_call_action                  1_024

--- a/core/parameters/src/config_store.rs
+++ b/core/parameters/src/config_store.rs
@@ -39,6 +39,7 @@ static CONFIG_DIFFS: &[(ProtocolVersion, &str)] = &[
     (64, include_config!("64.yaml")),
     (66, include_config!("66.yaml")),
     (67, include_config!("67.yaml")),
+    (68, include_config!("68.yaml")),
     (83, include_config!("83.yaml")),
     (85, include_config!("85.yaml")),
     (129, include_config!("129.yaml")),

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__129.json.snap
@@ -206,7 +206,7 @@ expression: config_view
       "max_arguments_length": 4194304,
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
-      "max_transaction_size": 4194304,
+      "max_transaction_size": 1572864,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__138.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__138.json.snap
@@ -206,7 +206,7 @@ expression: config_view
       "max_arguments_length": 4194304,
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
-      "max_transaction_size": 4194304,
+      "max_transaction_size": 1572864,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__139.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__139.json.snap
@@ -206,7 +206,7 @@ expression: config_view
       "max_arguments_length": 4194304,
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
-      "max_transaction_size": 4194304,
+      "max_transaction_size": 1572864,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__142.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__142.json.snap
@@ -206,7 +206,7 @@ expression: config_view
       "max_arguments_length": 4194304,
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
-      "max_transaction_size": 4194304,
+      "max_transaction_size": 1572864,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__68.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__68.json.snap
@@ -1,6 +1,6 @@
 ---
-source: core/primitives/src/views.rs
-expression: "&view"
+source: core/parameters/src/config_store.rs
+expression: config_view
 ---
 {
   "storage_amount_per_byte": "10000000000000000000",

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__83.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__83.json.snap
@@ -206,7 +206,7 @@ expression: config_view
       "max_arguments_length": 4194304,
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
-      "max_transaction_size": 4194304,
+      "max_transaction_size": 1572864,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__85.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__85.json.snap
@@ -206,7 +206,7 @@ expression: config_view
       "max_arguments_length": 4194304,
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
-      "max_transaction_size": 4194304,
+      "max_transaction_size": 1572864,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
@@ -206,7 +206,7 @@ expression: config_view
       "max_arguments_length": 4194304,
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
-      "max_transaction_size": 4194304,
+      "max_transaction_size": 1572864,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_138.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_138.json.snap
@@ -206,7 +206,7 @@ expression: config_view
       "max_arguments_length": 4194304,
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
-      "max_transaction_size": 4194304,
+      "max_transaction_size": 1572864,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_139.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_139.json.snap
@@ -206,7 +206,7 @@ expression: config_view
       "max_arguments_length": 4194304,
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
-      "max_transaction_size": 4194304,
+      "max_transaction_size": 1572864,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_142.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_142.json.snap
@@ -206,7 +206,7 @@ expression: config_view
       "max_arguments_length": 4194304,
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
-      "max_transaction_size": 4194304,
+      "max_transaction_size": 1572864,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_68.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_68.json.snap
@@ -1,6 +1,6 @@
 ---
-source: core/primitives/src/views.rs
-expression: "&view"
+source: core/parameters/src/config_store.rs
+expression: config_view
 ---
 {
   "storage_amount_per_byte": "10000000000000000000",

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_83.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_83.json.snap
@@ -206,7 +206,7 @@ expression: config_view
       "max_arguments_length": 4194304,
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
-      "max_transaction_size": 4194304,
+      "max_transaction_size": 1572864,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_85.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_85.json.snap
@@ -206,7 +206,7 @@ expression: config_view
       "max_arguments_length": 4194304,
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
-      "max_transaction_size": 4194304,
+      "max_transaction_size": 1572864,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,

--- a/core/parameters/src/snapshots/near_parameters__view__tests__runtime_config_view.snap
+++ b/core/parameters/src/snapshots/near_parameters__view__tests__runtime_config_view.snap
@@ -206,7 +206,7 @@ expression: "&view"
       "max_arguments_length": 4194304,
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
-      "max_transaction_size": 4194304,
+      "max_transaction_size": 1572864,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -247,7 +247,7 @@ impl ProtocolFeature {
 /// Current protocol version used on the mainnet.
 /// Some features (e. g. FixStorageUsage) require that there is at least one epoch with exactly
 /// the corresponding version
-const STABLE_PROTOCOL_VERSION: ProtocolVersion = 67;
+const STABLE_PROTOCOL_VERSION: ProtocolVersion = 68;
 
 /// Largest protocol version supported by the current binary.
 pub const PROTOCOL_VERSION: ProtocolVersion = if cfg!(feature = "statelessnet_protocol") {

--- a/integration-tests/src/tests/client/benchmarks.rs
+++ b/integration-tests/src/tests/client/benchmarks.rs
@@ -23,8 +23,8 @@ use nearcore::test_utils::TestEnvNightshadeSetupExt;
 fn benchmark_large_chunk_production_time() {
     let mb = 1024usize.pow(2);
 
-    let n_txes = 20;
-    let tx_size = 3 * mb;
+    let n_txes = 60;
+    let tx_size = 1 * mb;
 
     let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
@@ -56,5 +56,5 @@ fn benchmark_large_chunk_production_time() {
 
     // Check that we limit the size of the chunk and not include all `n_txes`
     // transactions in the chunk.
-    assert!(30 * mb < size && size < 40 * mb, "{size}");
+    assert!(25 * mb < size && size < 40 * mb, "{size}");
 }

--- a/runtime/runtime-params-estimator/src/action_costs.rs
+++ b/runtime/runtime-params-estimator/src/action_costs.rs
@@ -791,8 +791,8 @@ impl ActionSize {
             // calling "noop" requires 4 bytes
             ActionSize::Min => 4,
             // max_arguments_length: 4_194_304
-            // max_transaction_size: 4_194_304
-            ActionSize::Max => (4_194_304 / 100) - 35,
+            // max_transaction_size: 1_572_864
+            ActionSize::Max => (1_572_864 / 100) - 35,
         }
     }
 
@@ -813,7 +813,7 @@ impl ActionSize {
             // fails with `InvalidTxError(TransactionSizeExceeded`, it could be a
             // protocol change due to the TX limit computation changing.
             // The test `test_deploy_contract_tx_max_size` checks this.
-            ActionSize::Max => 4 * 1024 * 1024 - 182,
+            ActionSize::Max => 1_572_864 - 182,
         }
     }
 }
@@ -827,7 +827,7 @@ mod tests {
     fn test_deploy_contract_tx_max_size() {
         // The size of a transaction constructed from this must be exactly at the limit.
         let deploy_action = deploy_action(ActionSize::Max);
-        let limit = 4_194_304;
+        let limit = 1_572_864;
 
         // We also need some account IDs constructed the same way as in the estimator.
         // Let's try multiple index sizes to ensure this does not affect the length.

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -719,13 +719,13 @@ fn pure_deploy_bytes(ctx: &mut EstimatorContext) -> GasCost {
     let config_store = RuntimeConfigStore::new(None);
     let vm_config = config_store.get_config(PROTOCOL_VERSION).wasm_config.clone();
     let small_code = generate_data_only_contract(0, &vm_config);
-    let large_code = generate_data_only_contract(bytesize::mb(4u64) as usize, &vm_config);
+    let large_code = generate_data_only_contract(bytesize::kb(1500u64) as usize, &vm_config);
     let small_code_len = small_code.len();
     let large_code_len = large_code.len();
     let cost_empty = deploy_contract_cost(ctx, small_code, Some(b"main"));
-    let cost_4mb = deploy_contract_cost(ctx, large_code, Some(b"main"));
+    let cost_15mb = deploy_contract_cost(ctx, large_code, Some(b"main"));
 
-    (cost_4mb - cost_empty) / (large_code_len - small_code_len) as u64
+    (cost_15mb - cost_empty) / (large_code_len - small_code_len) as u64
 }
 
 /// Base cost for a fn call action, without receipt creation or contract loading.
@@ -749,7 +749,7 @@ fn action_function_call_per_byte(ctx: &mut EstimatorContext) -> GasCost {
     // X values below 1M have a rather high variance. Therefore, use one small X
     // value and two larger values to fit a curve that gets the slope about
     // right.
-    let xs = [1, 1_000_000, 4_000_000];
+    let xs = [1, 1_000_000, 1_500_000];
     let ys: Vec<GasCost> = xs
         .iter()
         .map(|&arg_len| inner_action_function_call_per_byte(ctx, arg_len as usize))
@@ -800,7 +800,7 @@ fn function_call_per_storage_byte(ctx: &mut EstimatorContext) -> GasCost {
     let small_code = generate_data_only_contract(0, &vm_config);
     let small_cost = fn_cost_in_contract(ctx, "main", &small_code, n_actions);
 
-    let large_code = generate_data_only_contract(4_000_000, &vm_config);
+    let large_code = generate_data_only_contract(1_500_000, &vm_config);
     let large_cost = fn_cost_in_contract(ctx, "main", &large_code, n_actions);
 
     large_cost.saturating_sub(&small_cost, &NonNegativeTolerance::PER_MILLE)


### PR DESCRIPTION
Lower transaction size limit to 1.5MiB

The size limit for a single transaction used to be 4MiB, this PR reduces it to 1.5MiB. Transactions larger than 1.5MiB will be rejected.

This is done to help with https://github.com/near/nearcore/issues/11103. It's hard to limit the size of `ChunkStateWitness` when a single transaction can be as large as 4MiB. Having 1.5MiB transactions makes things much more manageable.

This will break some transactions.
On current mainnet there is approximately one transaction larger than 1.5MiB per day (~420 large txs per year).
We've decided that it's okay to break those transactions.
List of transactions larger than 1.5MiB from the last year of mainnet traffic: [broken-transactions.txt](https://github.com/near/nearcore/files/15407751/broken-transactions.txt)

The new limit is introduced in protocol version `68`.
This protocol version could be released before the full stateless validation launch, to see if anyone complains.

Note that this change doesn't limit the size of receipts, only transactions. It's still possible to create a receipt with a 4MiB contract or function call, but that's out of scope for the transaction size limit.

Zulip discussion about lowering the limit: https://near.zulipchat.com/#narrow/stream/295306-contract-runtime/topic/.E2.9C.94.20Lowering.20the.20limit.20for.20contract.20code.20size

