### PR TITLE
neard: don't fiddle with file limits unnecessarily

### DIFF
--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -59,11 +59,16 @@ fn main() -> anyhow::Result<()> {
     // to prevent the inner logic from trying to bump it further:
     // FD limit is a global variable, so it shouldn't be modified in an
     // uncoordinated way.
-    const FD_LIMIT: u64 = 65535;
-    let (_, hard) = rlimit::Resource::NOFILE.get().context("rlimit::Resource::NOFILE::get()")?;
-    rlimit::Resource::NOFILE.set(FD_LIMIT, FD_LIMIT).context(format!(
-        "couldn't set the file descriptor limit to {FD_LIMIT}, hard limit = {hard}"
-    ))?;
+    const REQUIRED_NOFILE: u64 = 65535;
+    let (soft, hard) = rlimit::Resource::NOFILE.get().context("rlimit::Resource::NOFILE::get()")?;
+    if soft < REQUIRED_NOFILE || hard < REQUIRED_NOFILE {
+        let new_soft = soft.max(REQUIRED_NOFILE);
+        let new_hard = hard.max(REQUIRED_NOFILE);
+        rlimit::Resource::NOFILE.set(new_soft, new_hard).context(format!(
+            "couldn't set the file descriptor limit to ({new_soft}, {new_hard}), \
+             current limit = ({soft}, {hard})"
+        ))?;
+    }
 
     NeardCmd::parse_and_run()
 }


### PR DESCRIPTION
This causes a few problems:

1. rlimit is a privileged call requiring certain capabilities, which the user might not have, making them unable to run the node even *if* their current limits are high enough;
2. historically operators have attempted to set a higher limit but neard would override it to a smaller one and still run into problems that the operators were attempting to workaround by setting limit higher in the first place;
3. arguably this is not the responsibility of neard to set up limits like these for itself, and systemd gives plenty of good tools to fiddle with these...