### PR TITLE
chore(indexer): Add feature `statelessnet_protocol` to be able to use indexer nodes in statelessnet

### DIFF
--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -62,3 +62,7 @@ nightly = [
   "nightly_protocol",
   "node-runtime/nightly",
 ]
+statelessnet_protocol = [
+  "near-primitives/statelessnet_protocol",
+  "nearcore/statelessnet_protocol",
+]


### PR DESCRIPTION
This is simply adds the `statelessnet_protocol` feature to the `chain/indexer` so we can use it during the StakeWars (statelessnet)