### PR TITLE
doc: add a page on profiling

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -42,6 +42,7 @@
   - [Run Gas Estimations](./practices/workflows/gas_estimations.md)
   - [Localnet on many machines](./practices/workflows/localnet_on_many_machines.md)
   - [IO tracing](./practices/workflows/io_trace.md)
+  - [Profiling](./practices/workflows/profiling.md)
   - [Working with OpenTelemetry Traces](./practices/workflows/otel_traces.md)
 - [Code Style](./practices/style.md)
 - [Documentation](./practices/docs.md)

--- a/docs/practices/workflows/profiling.md
+++ b/docs/practices/workflows/profiling.md
@@ -101,3 +101,20 @@ and has an ability to show memory use over time from different allocation source
 
 I personally found it a bit troublesome to figure out how to open the heaptrack file from the GUI.
 However, `heaptrack myexportedfile` worked perfectly. I recommend opening the file exactly this way.
+
+### Crashes
+
+If the profiled `neard` crashes in your tests, there are a couple things you can try to get past
+it. First, is disabling `jemalloc`. Comment out this piece of code in `neard/src/main.rs`:
+
+```rust
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+```
+
+The other thing you can try is different profilers or different versions of the profilers, although
+I don't have specific recommendations here.
+
+We don't know what exactly it is about neard that leads to it crashing under the profiler as easily
+as it does. I have seen valgrind reporting that we have libraries that are deallocating with a
+wrong size class, so that might be the reason? Do definitely look into this if you have time.

--- a/docs/practices/workflows/profiling.md
+++ b/docs/practices/workflows/profiling.md
@@ -90,7 +90,7 @@ load it successfully.
 </blockquote>
 
 Once enough profiling data has been gathered, terminate the program. Use the `bytehound` CLI tool
-to operate on the profile. I recommend `bytehound serve` over directly converting to e.g. heaptrack
+to operate on the profile. I recommend `bytehound server` over directly converting to e.g. heaptrack
 format using other subcommands as each invocation will read and parse the profile data from
 scratch. This process can take quite some time. `serve` parses the inputs once and makes
 conversions and other introspection available as interactive steps.


### PR DESCRIPTION
This includes both the somewhat well known information on how to use perf as well as text on bytehound, which is the only tool that seems to work for memory profiling neard.

Fixes #11389