### PR TITLE
[ft transfer benchmark] Add nearup to PATH

### DIFF
--- a/scripts/ft-benchmark.sh
+++ b/scripts/ft-benchmark.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -xeo pipefail
 
+# For debugging purposes
+whoami
+date
+
+# Otherwise nearup and cargo don't work even if installed properly
+PATH=/home/ubuntu/.local/bin/:$PATH
+export PATH=$PATH:$HOME/.cargo/bin
+
 # Fetch the latest changes from the remote
 git fetch
 


### PR DESCRIPTION
Description of the script I changed: #11391.

I need to add this to `$PATH`, otherwise job inside `cron` don't see `nearup` and `cargo`. Probably it could be done in some more generic way, but I think since we want MVP asap this is fine.

Also added some lines to enrich logs and make debugging easier.