### PR TITLE
test(congestion): integration tests for new tx limit

### DIFF
--- a/integration-tests/src/tests/client/features/congestion_control.rs
+++ b/integration-tests/src/tests/client/features/congestion_control.rs
@@ -2,23 +2,82 @@ use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_client::ProcessTxResponse;
 use near_crypto::{InMemorySigner, KeyType, PublicKey};
+use near_parameters::{RuntimeConfig, RuntimeConfigStore};
 use near_primitives::account::id::AccountId;
-use near_primitives::congestion_info::CongestionControl;
+use near_primitives::congestion_info::{CongestionControl, CongestionInfo};
 use near_primitives::errors::{ActionErrorKind, FunctionCallError, TxExecutionError};
+use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
+use near_primitives::sharding::{ShardChunk, ShardChunkHeader};
 use near_primitives::transaction::SignedTransaction;
+use near_primitives::types::ShardId;
 use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_primitives::views::FinalExecutionStatus;
+use near_vm_runner::logic::ProtocolVersion;
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
+use std::sync::Arc;
 
-fn setup_runtime(sender_id: AccountId) -> TestEnv {
-    let epoch_length = 5;
+const CONTRACT_ID: &str = "contract.test0";
+
+fn setup_runtime(sender_id: AccountId, protocol_version: ProtocolVersion) -> TestEnv {
     let mut genesis = Genesis::test_sharded_new_version(vec![sender_id], 1, vec![1, 1, 1, 1]);
-    genesis.config.epoch_length = epoch_length;
-    genesis.config.protocol_version = ProtocolFeature::CongestionControl.protocol_version() - 1;
+    genesis.config.epoch_length = 5;
+    genesis.config.protocol_version = protocol_version;
     // Chain must be sharded to test cross-shard congestion control.
     genesis.config.shard_layout = ShardLayout::v1_test();
-    TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build()
+
+    let mut config = RuntimeConfig::test();
+    // Make 1 wasm op cost ~4 GGas, to let "loop_forever" finish more quickly.
+    config.wasm_config.regular_op_cost = u32::MAX;
+    let runtime_configs = vec![RuntimeConfigStore::with_one_config(config)];
+
+    TestEnv::builder(&genesis.config)
+        .nightshade_runtimes_with_runtime_config_store(&genesis, runtime_configs)
+        .build()
+}
+
+/// Set up the RS-Contract, which includes useful functions, such as
+/// `loop_forever`.
+///
+/// This function also advances the chain to complete the deployment and checks
+/// it can be called successfully.
+fn setup_contract(env: &mut TestEnv) {
+    let block = env.clients[0].chain.get_head_block().unwrap();
+    let contract = near_test_contracts::rs_contract();
+    // the client account exists and has enough balance to create the account
+    // and deploy the contract
+    let signer_id = env.get_client_id(0);
+    let signer = InMemorySigner::from_seed(signer_id.clone(), KeyType::ED25519, signer_id.as_str());
+    let mut nonce = 1;
+    let create_contract_tx = SignedTransaction::create_contract(
+        nonce,
+        signer_id.clone(),
+        CONTRACT_ID.parse().unwrap(),
+        contract.to_vec(),
+        10 * 10u128.pow(24),
+        PublicKey::from_seed(KeyType::ED25519, CONTRACT_ID),
+        &signer,
+        *block.hash(),
+    );
+    // this adds the tx to the pool and then produces blocks until the tx result is available
+    env.execute_tx(create_contract_tx).unwrap().assert_success();
+    nonce += 1;
+
+    // Test the function call works as expected, ending in a gas exceeded error.
+    let block = env.clients[0].chain.get_head_block().unwrap();
+    let fn_tx = new_fn_call_100tgas(&mut nonce, &signer, *block.hash());
+    let FinalExecutionStatus::Failure(TxExecutionError::ActionError(action_error)) =
+        env.execute_tx(fn_tx).unwrap().status
+    else {
+        panic!("test setup error: should result in action error")
+    };
+    assert_eq!(
+        action_error.kind,
+        ActionErrorKind::FunctionCallError(FunctionCallError::ExecutionError(
+            "Exceeded the prepaid gas.".to_owned()
+        )),
+        "test setup error: should result in gas exceeded error"
+    );
 }
 
 /// Simplest possible upgrade to new protocol with congestion control enabled,
@@ -30,7 +89,10 @@ fn test_protocol_upgrade() {
         return;
     }
 
-    let mut env = setup_runtime("test0".parse().unwrap());
+    let mut env = setup_runtime(
+        "test0".parse().unwrap(),
+        ProtocolFeature::CongestionControl.protocol_version() - 1,
+    );
 
     // Produce a few blocks to get out of initial state.
     let tip = env.clients[0].chain.head().unwrap();
@@ -70,6 +132,22 @@ fn head_congestion_control_config(
     runtime_config.congestion_control_config
 }
 
+fn head_congestion_info(env: &TestEnv, shard_id: ShardId) -> CongestionInfo {
+    let chunk = head_chunk_header(env, shard_id);
+    chunk.congestion_info().unwrap()
+}
+
+fn head_chunk_header(env: &TestEnv, shard_id: u64) -> ShardChunkHeader {
+    let block = env.clients[0].chain.get_head_block().unwrap();
+    let chunks = block.chunks();
+    chunks.get(shard_id as usize).expect("chunk header must be available").clone()
+}
+
+fn head_chunk(env: &TestEnv, shard_id: u64) -> Arc<ShardChunk> {
+    let chunk_header = head_chunk_header(&env, shard_id);
+    env.clients[0].chain.get_chunk(&chunk_header.chunk_hash()).expect("chunk must be available")
+}
+
 #[test]
 fn test_protocol_upgrade_under_congestion() {
     // The following only makes sense to test if the feature is enabled in the current build.
@@ -78,53 +156,17 @@ fn test_protocol_upgrade_under_congestion() {
     }
 
     let sender_id: AccountId = "test0".parse().unwrap();
-    let contract_id: AccountId = "contract.test0".parse().unwrap();
-    let mut env = setup_runtime(sender_id.clone());
-
-    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
-    let signer = InMemorySigner::from_seed(sender_id.clone(), KeyType::ED25519, sender_id.as_str());
-    let mut nonce = 1;
+    let mut env =
+        setup_runtime(sender_id.clone(), ProtocolFeature::CongestionControl.protocol_version() - 1);
 
     // prepare a contract to call
-    let contract = near_test_contracts::rs_contract();
-    let create_contract_tx = SignedTransaction::create_contract(
-        nonce,
-        sender_id,
-        contract_id.clone(),
-        contract.to_vec(),
-        10 * 10u128.pow(24),
-        PublicKey::from_seed(KeyType::ED25519, contract_id.as_str()),
-        &signer,
-        *genesis_block.hash(),
-    );
-    // this adds the tx to the pool and then produces blocks until the tx result is available
-    env.execute_tx(create_contract_tx).unwrap().assert_success();
-    nonce += 1;
+    setup_contract(&mut env);
 
-    // Test the function call works as expected, ending in a gas exceeded error.
-    let block = env.clients[0].chain.get_head_block().unwrap();
-    let fn_tx = new_fn_call_100tgas(&mut nonce, &signer, contract_id.clone(), *block.hash());
-    let FinalExecutionStatus::Failure(TxExecutionError::ActionError(action_error)) =
-        env.execute_tx(fn_tx).unwrap().status
-    else {
-        panic!("test setup error: should result in action error")
-    };
-    assert_eq!(
-        action_error.kind,
-        ActionErrorKind::FunctionCallError(FunctionCallError::ExecutionError(
-            "Exceeded the prepaid gas.".to_owned()
-        )),
-        "test setup error: should result in gas exceeded error"
-    );
-
+    let signer = InMemorySigner::from_seed(sender_id.clone(), KeyType::ED25519, sender_id.as_str());
+    let mut nonce = 10;
     // Now, congest the network with ~1000 Pgas, enough to have some left after the protocol upgrade.
-    let block = env.clients[0].chain.get_head_block().unwrap();
-    for _ in 0..10000 {
-        let fn_tx = new_fn_call_100tgas(&mut nonce, &signer, contract_id.clone(), *block.hash());
-        // this only adds the tx to the pool, no chain progress is made
-        let response = env.clients[0].process_tx(fn_tx, false, false);
-        assert_eq!(response, ProcessTxResponse::ValidTx);
-    }
+    let n = 10000;
+    submit_n_100tgas_fns(&mut env, n, &mut nonce, &signer);
 
     // Allow transactions to enter the chain
     let tip = env.clients[0].chain.head().unwrap();
@@ -150,11 +192,12 @@ fn test_protocol_upgrade_under_congestion() {
     let tip = env.clients[0].chain.head().unwrap();
 
     // Check there is still congestion, which this test is all about.
-    let contract_shard_id =
-        env.clients[0].epoch_manager.account_id_to_shard_id(&contract_id, &tip.epoch_id).unwrap();
-    let contract_shard_chunk_header =
-        &chunks.get(contract_shard_id as usize).expect("chunk must be available");
-    let congestion_info = contract_shard_chunk_header.congestion_info().unwrap();
+    let contract_shard_id = env.clients[0]
+        .epoch_manager
+        .account_id_to_shard_id(&CONTRACT_ID.parse().unwrap(), &tip.epoch_id)
+        .unwrap();
+
+    let congestion_info = head_congestion_info(&mut env, contract_shard_id);
     let config = head_congestion_control_config(&env);
     assert_eq!(
         congestion_info.localized_congestion_level(&config),
@@ -164,10 +207,8 @@ fn test_protocol_upgrade_under_congestion() {
 
     // Also check that the congested shard is still making progress.
     env.produce_block(0, tip.height + 1);
-    let next_block = env.clients[0].chain.get_head_block().unwrap();
-    let next_chunks = next_block.chunks();
-    let next_chunk = &next_chunks.get(contract_shard_id as usize).expect("chunk must be available");
-    let next_congestion_info = next_chunk.congestion_info().unwrap();
+    let next_congestion_info = head_congestion_info(&mut env, contract_shard_id);
+
     assert!(congestion_info.delayed_receipts_gas() > next_congestion_info.delayed_receipts_gas());
     assert!(congestion_info.receipt_bytes() > next_congestion_info.receipt_bytes());
 }
@@ -195,8 +236,7 @@ fn check_old_protocol(env: &TestEnv) {
 fn new_fn_call_100tgas(
     nonce_source: &mut u64,
     signer: &InMemorySigner,
-    contract_id: AccountId,
-    block_hash: near_primitives::hash::CryptoHash,
+    block_hash: CryptoHash,
 ) -> SignedTransaction {
     let hundred_tgas = 100 * 10u64.pow(12);
     let deposit = 0;
@@ -205,7 +245,7 @@ fn new_fn_call_100tgas(
     SignedTransaction::call(
         nonce,
         signer.account_id.clone(),
-        contract_id,
+        CONTRACT_ID.parse().unwrap(),
         signer,
         deposit,
         // easy way to burn all attached gas
@@ -213,5 +253,312 @@ fn new_fn_call_100tgas(
         vec![],
         hundred_tgas,
         block_hash,
+    )
+}
+
+/// Create a dummy function call that is valid but allowed to fail when
+/// executed. It has only 1 Tgas attached.
+fn new_cheap_fn_call(
+    nonce_source: &mut u64,
+    signer: &InMemorySigner,
+    receiver: AccountId,
+    block_hash: CryptoHash,
+) -> SignedTransaction {
+    let one_tgas = 1 * 10u64.pow(12);
+    let deposit = 0;
+    let nonce = *nonce_source;
+    *nonce_source += 1;
+    SignedTransaction::call(
+        nonce,
+        signer.account_id.clone(),
+        receiver,
+        signer,
+        deposit,
+        "foo_does_not_exists".to_owned(),
+        vec![],
+        one_tgas,
+        block_hash,
+    )
+}
+
+/// Submit N transaction containing a function call action with 100 Tgas
+/// attached that will all be burned when called.
+fn submit_n_100tgas_fns(env: &mut TestEnv, n: u32, nonce: &mut u64, signer: &InMemorySigner) {
+    let block = env.clients[0].chain.get_head_block().unwrap();
+    for _ in 0..n {
+        let fn_tx = new_fn_call_100tgas(nonce, signer, *block.hash());
+        // this only adds the tx to the pool, no chain progress is made
+        let response = env.clients[0].process_tx(fn_tx, false, false);
+        assert_eq!(response, ProcessTxResponse::ValidTx);
+    }
+}
+
+/// Submit N transaction containing a cheap function call action.
+fn submit_n_cheap_fns(
+    env: &mut TestEnv,
+    n: u32,
+    nonce: &mut u64,
+    signer: &InMemorySigner,
+    receiver: &AccountId,
+) {
+    let block = env.clients[0].chain.get_head_block().unwrap();
+    for _ in 0..n {
+        let fn_tx = new_cheap_fn_call(nonce, signer, receiver.clone(), *block.hash());
+        // this only adds the tx to the pool, no chain progress is made
+        let response = env.clients[0].process_tx(fn_tx, false, false);
+        assert_eq!(response, ProcessTxResponse::ValidTx);
+    }
+}
+
+/// Test that less gas is attributed to transactions when the local shard has
+/// delayed receipts.
+///
+/// This test operates on one shard with transactions signed by the contract
+/// itself, producing only local receipts. This should be enough to trigger the
+/// linear interpolation between `max_tx_gas` and `min_tx_gas` and we want to
+/// test that indeed local traffic is enough.
+///
+/// See [`test_transaction_limit_for_remote_congestion`] for a similar test but
+/// with remote traffic.
+#[test]
+fn test_transaction_limit_for_local_congestion() {
+    if !ProtocolFeature::CongestionControl.enabled(PROTOCOL_VERSION) {
+        return;
+    }
+    let runtime_config_store = RuntimeConfigStore::new(None);
+    let config = runtime_config_store.get_config(PROTOCOL_VERSION);
+    // We don't want to go into the TX rejection limit in this test.
+    let upper_limit_congestion = config.congestion_control_config.reject_tx_congestion_threshold;
+
+    // For this test, the contract and the sender are on the same shard, even
+    // the same account.
+    let contract_id: AccountId = CONTRACT_ID.parse().unwrap();
+    let sender_id = contract_id.clone();
+    let dummy_receiver: AccountId = "a_dummy_receiver".parse().unwrap();
+    let env = setup_runtime("test0".parse().unwrap(), PROTOCOL_VERSION);
+
+    let (
+        remote_tx_included_without_congestion,
+        local_tx_included_without_congestion,
+        remote_tx_included_with_congestion,
+        local_tx_included_with_congestion,
+    ) = measure_tx_limit(env, sender_id, contract_id, dummy_receiver, upper_limit_congestion);
+
+    assert_ne!(local_tx_included_without_congestion, 0);
+    assert_ne!(remote_tx_included_with_congestion, 0);
+    // local transactions should be limited
+    assert!(
+        local_tx_included_with_congestion < local_tx_included_without_congestion,
+        "{local_tx_included_with_congestion} < {local_tx_included_without_congestion} failed"
+    );
+    // remote transactions in this case also start on the congested shard, so
+    // they should be limited, too
+    assert!(
+        remote_tx_included_with_congestion < remote_tx_included_without_congestion,
+        "{remote_tx_included_with_congestion} < {remote_tx_included_without_congestion} failed"
+    );
+}
+
+/// Test that clients adjust included transactions based on the congestion level
+/// of the local delayed receipts queue only, in this test with remote traffic.
+///
+/// We expect to see less transactions accepted on the congested shard, to give
+/// more capacity towards processing delayed receipts. But in this test we stay
+/// below `reject_tx_congestion_threshold`, meaning that the shard sending the
+/// remote traffic to the congested shard should not stop, nor should it tighten
+/// the limit on how many are accepted.
+///
+/// [`test_transaction_limit_for_local_congestion`] is a similar test but uses
+/// only local receipts. [`test_transaction_filtering`] is even closer to this
+/// test but goes beyond `reject_tx_congestion_threshold` to test the tx
+/// rejection.
+#[test]
+fn test_transaction_limit_for_remote_congestion() {
+    if !ProtocolFeature::CongestionControl.enabled(PROTOCOL_VERSION) {
+        return;
+    }
+    let runtime_config_store = RuntimeConfigStore::new(None);
+    let config = runtime_config_store.get_config(PROTOCOL_VERSION);
+    // We don't want to go into the TX rejection limit in this test.
+    let upper_limit_congestion = config.congestion_control_config.reject_tx_congestion_threshold;
+
+    let (
+        remote_tx_included_without_congestion,
+        local_tx_included_without_congestion,
+        remote_tx_included_with_congestion,
+        local_tx_included_with_congestion,
+    ) = measure_remote_tx_limit(upper_limit_congestion);
+
+    assert_ne!(remote_tx_included_without_congestion, 0);
+    assert_ne!(remote_tx_included_with_congestion, 0);
+    assert_ne!(local_tx_included_without_congestion, 0);
+    assert_ne!(local_tx_included_with_congestion, 0);
+
+    // local transactions should be limited
+    assert!(
+        local_tx_included_with_congestion < local_tx_included_without_congestion,
+        "{local_tx_included_with_congestion} < {local_tx_included_without_congestion} failed"
+    );
+    // remote transactions should be unaffected
+    assert!(
+        remote_tx_included_with_congestion == remote_tx_included_without_congestion,
+        "{remote_tx_included_with_congestion} == {remote_tx_included_without_congestion} failed"
+    );
+}
+
+/// Test that clients stop including transactions to fully congested receivers.
+///
+///
+#[test]
+fn test_transaction_filtering() {
+    if !ProtocolFeature::CongestionControl.enabled(PROTOCOL_VERSION) {
+        return;
+    }
+    let runtime_config_store = RuntimeConfigStore::new(None);
+    let config = runtime_config_store.get_config(PROTOCOL_VERSION);
+    // This test should go beyond into the TX rejection limit in this test.
+    let upper_limit_congestion =
+        3.0 * config.congestion_control_config.reject_tx_congestion_threshold;
+
+    let (
+        remote_tx_included_without_congestion,
+        local_tx_included_without_congestion,
+        remote_tx_included_with_congestion,
+        local_tx_included_with_congestion,
+    ) = measure_remote_tx_limit(upper_limit_congestion);
+
+    assert_ne!(remote_tx_included_without_congestion, 0);
+    assert_ne!(local_tx_included_without_congestion, 0);
+    assert_ne!(local_tx_included_with_congestion, 0);
+
+    // local transactions should be limited
+    assert!(
+        local_tx_included_with_congestion < local_tx_included_without_congestion,
+        "{local_tx_included_with_congestion} < {local_tx_included_without_congestion} failed"
+    );
+    // remote transactions, with congestion, should be 0
+    assert_eq!(remote_tx_included_with_congestion, 0);
+}
+
+/// Calls [`measure_tx_limit`] with accounts on three different shards.
+fn measure_remote_tx_limit(upper_limit_congestion: f64) -> (usize, usize, usize, usize) {
+    let remote_id: AccountId = "test0".parse().unwrap();
+    let contract_id: AccountId = CONTRACT_ID.parse().unwrap();
+    let dummy_id: AccountId = "a_dummy_receiver".parse().unwrap();
+    let env = setup_runtime(remote_id.clone(), PROTOCOL_VERSION);
+
+    let tip = env.clients[0].chain.head().unwrap();
+    let remote_shard_id =
+        env.clients[0].epoch_manager.account_id_to_shard_id(&remote_id, &tip.epoch_id).unwrap();
+    let contract_shard_id =
+        env.clients[0].epoch_manager.account_id_to_shard_id(&contract_id, &tip.epoch_id).unwrap();
+    let dummy_shard_id =
+        env.clients[0].epoch_manager.account_id_to_shard_id(&dummy_id, &tip.epoch_id).unwrap();
+
+    // For a clean test setup, ensure we use 3 different shards.
+    assert_ne!(remote_shard_id, contract_shard_id);
+    assert_ne!(dummy_shard_id, contract_shard_id);
+    assert_ne!(dummy_shard_id, remote_shard_id);
+
+    measure_tx_limit(env, remote_id, contract_id, dummy_id, upper_limit_congestion)
+}
+
+/// Create the target incoming congestion level and measure the difference of
+/// included transactions with and without the congestion, on the local shard
+/// and on remote shards sending to the congested shard.
+///
+/// This helper function operates on three accounts. One account has the
+/// contract that will be congested. Another account is used to send remote
+/// traffic to that shard. And lastly, we send dummy transactions from the
+/// congested account to a third account, to observe the limit applied to it.
+///
+/// The caller can choose to place the accounts on different shards or on the
+/// same shard.
+fn measure_tx_limit(
+    mut env: TestEnv,
+    remote_id: AccountId,
+    contract_id: AccountId,
+    dummy_receiver: AccountId,
+    upper_limit_congestion: f64,
+) -> (usize, usize, usize, usize) {
+    let remote_signer =
+        InMemorySigner::from_seed(remote_id.clone(), KeyType::ED25519, remote_id.as_str());
+    let local_signer =
+        InMemorySigner::from_seed(contract_id.clone(), KeyType::ED25519, contract_id.as_str());
+    let tip = env.clients[0].chain.head().unwrap();
+    let remote_shard_id =
+        env.clients[0].epoch_manager.account_id_to_shard_id(&remote_id, &tip.epoch_id).unwrap();
+    let contract_shard_id =
+        env.clients[0].epoch_manager.account_id_to_shard_id(&contract_id, &tip.epoch_id).unwrap();
+
+    setup_contract(&mut env);
+
+    // put in enough transactions to create up to
+    // `reject_tx_congestion_threshold` incoming congestion
+    let config = head_congestion_control_config(&env);
+    let num_full_congestion = config.max_congestion_incoming_gas / (100 * 10u64.pow(12));
+    let n = num_full_congestion as f64 * upper_limit_congestion;
+    // Key of new account starts at block_height * 1_000_000
+    let tip = env.clients[0].chain.head().unwrap();
+    let mut nonce = tip.height * 1_000_000 + 1;
+    submit_n_100tgas_fns(&mut env, n as u32, &mut nonce, &remote_signer);
+    let tip = env.clients[0].chain.head().unwrap();
+    // submit enough cheap transaction to at least fill the tx limit once
+    submit_n_cheap_fns(&mut env, 1000, &mut nonce, &local_signer, &dummy_receiver);
+    env.produce_block(0, tip.height + 1);
+
+    // Produce blocks until all transactions are included.
+    let timeout = 1000;
+    let mut all_included = false;
+    let mut remote_tx_included_without_congestion = 0;
+    let mut local_tx_included_without_congestion = 0;
+    for i in 2..timeout {
+        env.produce_block(0, tip.height + i);
+
+        let sender_chunk = head_chunk(&env, remote_shard_id);
+        let contract_chunk = head_chunk(&env, contract_shard_id);
+        let remote_num_tx = sender_chunk.transactions().len();
+        let local_num_tx = contract_chunk.transactions().len();
+        if i == 2 {
+            remote_tx_included_without_congestion = remote_num_tx;
+            local_tx_included_without_congestion = local_num_tx;
+        }
+        if remote_num_tx == 0 && local_num_tx == 0 {
+            all_included = true;
+            break;
+        }
+    }
+    assert!(all_included, "loop timed out before all transactions were included");
+
+    // Now we expect the contract's shard to have non-trivial incoming
+    // congestion.
+    let congestion_info = head_congestion_info(&env, contract_shard_id);
+    let incoming_congestion = congestion_info.incoming_congestion(&config);
+    let congestion_level = congestion_info.localized_congestion_level(&config);
+    // congestion should be non-trivial and below the upper limit
+    assert!(
+        incoming_congestion > upper_limit_congestion / 3.0,
+        "{incoming_congestion} > {upper_limit_congestion} / 3 failed, {congestion_info:?}"
+    );
+    assert!(
+        congestion_level < upper_limit_congestion,
+        "{congestion_level} < {upper_limit_congestion} failed, {congestion_info:?}"
+    );
+
+    // Send some more transactions to see how many will be accepted now with congestion.
+    submit_n_100tgas_fns(&mut env, n as u32, &mut nonce, &remote_signer);
+    submit_n_cheap_fns(&mut env, 1000, &mut nonce, &local_signer, &dummy_receiver);
+    let tip = env.clients[0].chain.head().unwrap();
+    env.produce_block(0, tip.height + 1);
+    env.produce_block(0, tip.height + 2);
+    let remote_chunk = head_chunk(&env, remote_shard_id);
+    let local_chunk = head_chunk(&env, contract_shard_id);
+    let remote_tx_included_with_congestion = remote_chunk.transactions().len();
+    let local_tx_included_with_congestion = local_chunk.transactions().len();
+    (
+        remote_tx_included_without_congestion,
+        local_tx_included_without_congestion,
+        remote_tx_included_with_congestion,
+        local_tx_included_with_congestion,
     )
 }


### PR DESCRIPTION
Add integration tests to check the TX processing limits are applied for congested shards, both the linearly decreasing limit and the rejection condition when the receiver shard is congested above 25%.