### PR TITLE
 feat(congestion_control) - congestion info validation 

### DIFF
--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -179,6 +179,9 @@ pub enum Error {
     /// Invalid Balance Burnt
     #[error("Invalid Balance Burnt")]
     InvalidBalanceBurnt,
+    /// Invalid Congestion Info
+    #[error("Invalid Congestion Info")]
+    InvalidCongestionInfo,
     /// Invalid shard id
     #[error("Shard id {0} does not exist")]
     InvalidShardId(ShardId),
@@ -299,6 +302,7 @@ impl Error {
             | Error::InvalidGasPrice
             | Error::InvalidGasUsed
             | Error::InvalidBalanceBurnt
+            | Error::InvalidCongestionInfo
             | Error::InvalidShardId(_)
             | Error::InvalidStateRequest(_)
             | Error::InvalidRandomnessBeaconOutput
@@ -374,6 +378,7 @@ impl Error {
             Error::InvalidGasPrice => "invalid_gas_price",
             Error::InvalidGasUsed => "invalid_gas_used",
             Error::InvalidBalanceBurnt => "invalid_balance_burnt",
+            Error::InvalidCongestionInfo => "invalid_congestion_info",
             Error::InvalidShardId(_) => "invalid_shard_id",
             Error::InvalidStateRequest(_) => "invalid_state_request",
             Error::InvalidRandomnessBeaconOutput => "invalid_randomness_beacon_output",

--- a/chain/chain/src/validate.rs
+++ b/chain/chain/src/validate.rs
@@ -8,12 +8,14 @@ use near_primitives::block::{Block, BlockHeader};
 use near_primitives::challenge::{
     BlockDoubleSign, Challenge, ChallengeBody, ChunkProofs, ChunkState, MaybeEncodedShardChunk,
 };
+use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::merklize;
 use near_primitives::sharding::{ShardChunk, ShardChunkHeader};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{AccountId, BlockHeight, EpochId, Nonce};
+use near_primitives::version::{ProtocolFeature, ProtocolVersion};
 
 use crate::types::RuntimeAdapter;
 use crate::{byzantine_assert, Chain};
@@ -124,10 +126,14 @@ pub fn validate_chunk_with_chunk_extra(
     };
     let (outgoing_receipts_root, _) = merklize(&outgoing_receipts_hashes);
 
+    let header_epoch_id = epoch_manager.get_epoch_id_from_prev_block(prev_block_hash)?;
+    let header_protocol_version = epoch_manager.get_epoch_protocol_version(&header_epoch_id)?;
+
     validate_chunk_with_chunk_extra_and_receipts_root(
         prev_chunk_extra,
         chunk_header,
         &outgoing_receipts_root,
+        header_protocol_version,
     )
 }
 
@@ -136,6 +142,7 @@ pub fn validate_chunk_with_chunk_extra_and_receipts_root(
     prev_chunk_extra: &ChunkExtra,
     chunk_header: &ShardChunkHeader,
     outgoing_receipts_root: &CryptoHash,
+    header_protocol_version: ProtocolVersion,
 ) -> Result<(), Error> {
     if *prev_chunk_extra.state_root() != chunk_header.prev_state_root() {
         return Err(Error::InvalidStateRoot);
@@ -176,7 +183,57 @@ pub fn validate_chunk_with_chunk_extra_and_receipts_root(
         return Err(Error::InvalidGasLimit);
     }
 
+    validate_congestion_info(
+        &prev_chunk_extra.congestion_info(),
+        &chunk_header.congestion_info(),
+        header_protocol_version,
+    )?;
+
     Ok(())
+}
+
+/// Validate the congestion info propagation from the chunk extra of the previous
+/// chunk to the chunk header of the current chunk. The extra congestion info is
+/// trusted as it is the result of verified computation. The header congestion
+/// info is being validated.
+fn validate_congestion_info(
+    extra_congestion_info: &Option<CongestionInfo>,
+    header_congestion_info: &Option<CongestionInfo>,
+    header_protocol_version: ProtocolVersion,
+) -> Result<(), Error> {
+    // The congestion info should be Some iff the congestion control features is enabled.
+    let enabled = ProtocolFeature::CongestionControl.enabled(header_protocol_version);
+    if header_congestion_info.is_some() != enabled {
+        return Err(Error::InvalidCongestionInfo);
+    }
+
+    match (extra_congestion_info, header_congestion_info) {
+        // If both are none then there is no congestion info to validate.
+        (None, None) => Ok(()),
+        // If the congestion control is enabled in the previous chunk then it should
+        // also be enabled in the current chunk.
+        (Some(_), None) => Err(Error::InvalidCongestionInfo),
+        // At the epoch boundary where congestion control was enabled the chunk
+        // extra does not have the congestion control enabled and the header does
+        // have it enabled. The chunk extra of the previous chunk does not have
+        // congestion info so the congestion info in the current chunk header should
+        // be set to the default one.
+        (None, Some(_)) => {
+            if header_congestion_info == &Some(CongestionInfo::default()) {
+                Ok(())
+            } else {
+                Err(Error::InvalidCongestionInfo)
+            }
+        }
+        // Congestion Info is present in both the extra and the header. Validate it.
+        (Some(extra), Some(header)) => {
+            if !CongestionInfo::validate_extra_and_header(extra, header) {
+                Err(Error::InvalidCongestionInfo)
+            } else {
+                Ok(())
+            }
+        }
+    }
 }
 
 /// Validates a double sign challenge.

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -919,6 +919,11 @@ impl Client {
         let gas_used = chunk_extra.gas_used();
         #[cfg(feature = "test_features")]
         let gas_used = if self.produce_invalid_chunks { gas_used + 1 } else { gas_used };
+
+        // The congestion info is set to default if it is not present. If the
+        // congestion control feature is not enabled the congestion info will be
+        // stripped from the chunk header anyway. In the first chunk where
+        // feature is enabled the header will contain the default congestion info.
         let congestion_info = chunk_extra.congestion_info().unwrap_or_default();
         let (encoded_chunk, merkle_paths) = ShardsManagerActor::create_encoded_shard_chunk(
             prev_block_hash,

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -651,6 +651,7 @@ pub(crate) fn validate_chunk_state_witness(
         &chunk_extra,
         &state_witness.chunk_header,
         &outgoing_receipts_root,
+        protocol_version,
     )?;
 
     Ok(())

--- a/chain/client/src/tests/process_blocks.rs
+++ b/chain/client/src/tests/process_blocks.rs
@@ -1,5 +1,6 @@
 use crate::test_utils::TestEnv;
 use assert_matches::assert_matches;
+use near_chain::validate::validate_chunk_with_chunk_extra;
 use near_chain::{test_utils, Provenance};
 use near_crypto::vrf::Value;
 use near_crypto::{KeyType, PublicKey, Signature};
@@ -12,7 +13,8 @@ use near_primitives::sharding::ShardChunkHeaderV3;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::utils::MaybeValidated;
-use near_primitives::version::PROTOCOL_VERSION;
+use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
+use near_store::ShardUId;
 
 /// Only process one block per height
 /// Test that if a node receives two blocks at the same height, it doesn't process the second one
@@ -134,4 +136,128 @@ fn test_bad_block_signature() {
 
     let _ =
         env.clients[0].process_block_test(MaybeValidated::from(block), Provenance::NONE).unwrap();
+}
+
+enum BadCongestionInfoMode {
+    CorruptReceiptBytes,
+    CorruptDelayedReceiptsBytes,
+    CorruptBufferedReceiptsBytes,
+    CorruptAllowedShard,
+    None,
+}
+
+impl BadCongestionInfoMode {
+    fn corrupt(&self, congestion_info: &mut CongestionInfo) {
+        match self {
+            BadCongestionInfoMode::CorruptReceiptBytes => {
+                congestion_info.add_receipt_bytes(1).unwrap();
+            }
+            BadCongestionInfoMode::CorruptDelayedReceiptsBytes => {
+                congestion_info.add_delayed_receipt_gas(1).unwrap();
+            }
+            BadCongestionInfoMode::CorruptBufferedReceiptsBytes => {
+                congestion_info.add_buffered_receipt_gas(1).unwrap();
+            }
+            BadCongestionInfoMode::CorruptAllowedShard => {
+                congestion_info.set_allowed_shard(u16::MAX);
+            }
+            BadCongestionInfoMode::None => {}
+        }
+    }
+
+    fn is_ok(&self) -> bool {
+        match self {
+            BadCongestionInfoMode::CorruptReceiptBytes
+            | BadCongestionInfoMode::CorruptDelayedReceiptsBytes
+            | BadCongestionInfoMode::CorruptBufferedReceiptsBytes
+            | BadCongestionInfoMode::CorruptAllowedShard => false,
+            BadCongestionInfoMode::None => true,
+        }
+    }
+}
+
+fn test_bad_congestion_info_impl(mode: BadCongestionInfoMode) {
+    if !ProtocolFeature::CongestionControl.enabled(PROTOCOL_VERSION) {
+        return;
+    }
+
+    let mut env = TestEnv::default_builder().num_shards(4).mock_epoch_managers().build();
+    let prev_block = env.clients[0].produce_block(1).unwrap().unwrap();
+    env.process_block(0, prev_block, Provenance::PRODUCED);
+    let block = env.clients[0].produce_block(2).unwrap().unwrap();
+
+    let validator_signer = create_test_signer("test0");
+
+    let chunks: Vec<_> = block.chunks().iter().cloned().collect();
+    let chunk = chunks.get(0).unwrap();
+
+    let mut congestion_info = chunk.congestion_info().unwrap_or_default();
+    mode.corrupt(&mut congestion_info);
+
+    let mut modified_chunk_header = ShardChunkHeaderV3::new(
+        PROTOCOL_VERSION,
+        *chunk.prev_block_hash(),
+        chunk.prev_state_root(),
+        chunk.prev_outcome_root(),
+        chunk.encoded_merkle_root(),
+        chunk.encoded_length(),
+        chunk.height_created(),
+        chunk.shard_id(),
+        chunk.prev_gas_used(),
+        chunk.gas_limit(),
+        chunk.prev_balance_burnt(),
+        chunk.prev_outgoing_receipts_root(),
+        chunk.tx_root(),
+        chunk.prev_validator_proposals().collect(),
+        congestion_info,
+        &validator_signer,
+    );
+    modified_chunk_header.height_included = 2;
+
+    let modified_chunk = ShardChunkHeader::V3(modified_chunk_header);
+
+    let shard_uid = ShardUId { shard_id: 0, version: 0 };
+    let prev_block_hash = block.header().prev_hash();
+    let client = &env.clients[0];
+    let prev_chunk_extra = client.chain.get_chunk_extra(prev_block_hash, &shard_uid).unwrap();
+    let result: Result<(), near_chain::Error> = validate_chunk_with_chunk_extra(
+        &client.chain.chain_store,
+        client.epoch_manager.as_ref(),
+        prev_block_hash,
+        &prev_chunk_extra,
+        1,
+        &modified_chunk,
+    );
+
+    let expected_is_ok = mode.is_ok();
+    if expected_is_ok {
+        result.unwrap();
+    } else {
+        assert!(result.is_err());
+    }
+}
+
+#[test]
+fn test_bad_congestion_info_receipt_bytes() {
+    test_bad_congestion_info_impl(BadCongestionInfoMode::CorruptReceiptBytes);
+}
+
+#[test]
+fn test_bad_congestion_info_corrupt_delayed_receipts_bytes() {
+    test_bad_congestion_info_impl(BadCongestionInfoMode::CorruptDelayedReceiptsBytes);
+}
+
+#[test]
+fn test_bad_congestion_info_corrupt_buffered_receipts_bytes() {
+    test_bad_congestion_info_impl(BadCongestionInfoMode::CorruptBufferedReceiptsBytes);
+}
+
+#[test]
+fn test_bad_congestion_info_corrupt_allowed_shard() {
+    test_bad_congestion_info_impl(BadCongestionInfoMode::CorruptAllowedShard);
+}
+
+#[test]
+fn test_bad_congestion_info_none() {
+    test_bad_congestion_info_impl(BadCongestionInfoMode::None);
 }

--- a/core/primitives/src/congestion_info.rs
+++ b/core/primitives/src/congestion_info.rs
@@ -131,6 +131,25 @@ impl Default for CongestionInfo {
 }
 
 impl CongestionInfo {
+    // A helper method to compare the congestion info from the chunk extra of
+    // the previous chunk and the header of the current chunk. It returns true
+    // if the congestion info was correctly set in the chunk header based on the
+    // information from the chunk extra.
+    //
+    // TODO(congestion_control) validate allowed shard correctly
+    // If the shard is fully congested the any of the other shards can be the allowed shard.
+    // If the shard is not fully congested the allowed shard should be set to self.
+    pub fn validate_extra_and_header(extra: &CongestionInfo, header: &CongestionInfo) -> bool {
+        match (extra, header) {
+            (CongestionInfo::V1(extra), CongestionInfo::V1(header)) => {
+                extra.delayed_receipts_gas == header.delayed_receipts_gas
+                    && extra.buffered_receipts_gas == header.buffered_receipts_gas
+                    && extra.receipt_bytes == header.receipt_bytes
+                    && extra.allowed_shard == header.allowed_shard
+            }
+        }
+    }
+
     pub fn delayed_receipts_gas(&self) -> u128 {
         match self {
             CongestionInfo::V1(inner) => inner.delayed_receipts_gas,

--- a/integration-tests/src/tests/client/features/congestion_control.rs
+++ b/integration-tests/src/tests/client/features/congestion_control.rs
@@ -214,17 +214,6 @@ fn test_protocol_upgrade_under_congestion() {
 
     assert!(congestion_info.delayed_receipts_gas() > next_congestion_info.delayed_receipts_gas());
     assert!(congestion_info.receipt_bytes() > next_congestion_info.receipt_bytes());
-
-    let head_height = block.header().height();
-    for i in 1..head_height {
-        let block = env.clients[0].chain.get_block_by_height(i).unwrap();
-        let epoch_id = block.header().epoch_id().clone();
-        let chunks = block.chunks();
-        for chunk_header in chunks.iter() {
-            let congestion_info = chunk_header.congestion_info();
-            println!("epoch {epoch_id:?} block {i} congestion info {congestion_info:?}");
-        }
-    }
 }
 
 /// Check we are still in the old version and no congestion info is shared.


### PR DESCRIPTION
Added the validation of the congestion info fields. As far as I can tell this should cover both stateful and stateless validation transition. I added a unit test for the relevant method as well but I am not actually convinced that this is sufficient. I will see if I can add a simple nayduck end to end test as well. I also checked that the test will pass after cc stabilization. 