### PR TITLE
perf: Migrate to pynacl.SigningKey

### DIFF
--- a/pytest/lib/key.py
+++ b/pytest/lib/key.py
@@ -4,6 +4,7 @@ import os
 import typing
 
 import ed25519
+from nacl.signing import SigningKey
 
 
 class Key:
@@ -75,4 +76,5 @@ class Key:
 
     def sign_bytes(self, data: typing.Union[bytes, bytearray]) -> bytes:
         sk = self.decoded_sk()
-        return ed25519.SigningKey(sk).sign(bytes(data))
+        seed = sk[:32]
+        return SigningKey(seed).sign(bytes(data)).signature

--- a/pytest/lib/transaction.py
+++ b/pytest/lib/transaction.py
@@ -1,6 +1,6 @@
 from serializer import BinarySerializer
 import hashlib
-from ed25519 import SigningKey
+from nacl.signing import SigningKey
 import base58
 
 from messages.tx import *
@@ -36,7 +36,8 @@ def sign_transaction(receiverId, nonce, actions, blockHash, accountId, pk,
 
     signature = Signature()
     signature.keyType = 0
-    signature.data = SigningKey(sk).sign(hash_bytes)
+    seed = sk[:32]
+    signature.data = SigningKey(seed).sign(hash_bytes).signature
 
     signedTx = SignedTransaction()
     signedTx.transaction = tx
@@ -85,7 +86,8 @@ def create_signed_delegated_action(senderId, receiverId, actions, nonce,
 
     signature = Signature()
     signature.keyType = 0
-    signature.data = SigningKey(sk).sign(hash_)
+    seed = sk[:32]
+    signature.data = SigningKey(seed).sign(hash_).signature
 
     signedDA = SignedDelegate()
     signedDA.delegateAction = delegated_action

--- a/pytest/tests/sanity/rosetta.py
+++ b/pytest/tests/sanity/rosetta.py
@@ -9,9 +9,7 @@ import time
 import typing
 import unittest
 
-import base64
 import base58
-import ed25519
 import requests
 import requests.exceptions
 


### PR DESCRIPTION
We use it extensively in Locust benchmarks and it shows as a hotspot. A single signature takes around 1-2ms on my machine. PyNacl is a recommended replacement for python-ed25519 that is supposed to be 10-20 times faster for signatures.

This is a part of https://github.com/near/nearcore/issues/11352

I've followed this guide: https://github.com/warner/python-ed25519?tab=readme-ov-file#migrating-to-pynacl