### PR TITLE
refactor: Simplify retrieval of transaction id

### DIFF
--- a/pytest/tests/loadtest/locust/common/congestion.py
+++ b/pytest/tests/loadtest/locust/common/congestion.py
@@ -47,7 +47,7 @@ class ComputeSum(base.Transaction):
         self.sender = sender
         self.usage_tgas = usage_tgas
 
-    def sign_and_serialize(self, block_hash) -> bytes:
+    def sign(self, block_hash) -> transaction.SignedTransaction:
         return transaction.sign_function_call_tx(
             self.sender.key,
             self.contract_account_id,

--- a/pytest/tests/loadtest/locust/common/social.py
+++ b/pytest/tests/loadtest/locust/common/social.py
@@ -57,7 +57,7 @@ class InitSocialDB(Transaction):
         super().__init__()
         self.contract = contract
 
-    def sign_and_serialize(self, block_hash) -> bytes:
+    def sign(self, block_hash) -> transaction.SignedTransaction:
         # Call the #[init] function, no arguments
         call_new_action = create_function_call_action("new", "", 100 * TGAS, 0)
 
@@ -69,7 +69,7 @@ class InitSocialDB(Transaction):
         # Batch the two actions above into one transaction
         nonce = self.contract.use_nonce()
         key = self.contract.key
-        return transaction.sign_and_serialize_transaction(
+        return transaction.sign_transaction(
             key.account_id, nonce, [call_new_action, call_set_status_action],
             block_hash, key.account_id, key.decoded_pk(), key.decoded_sk())
 


### PR DESCRIPTION
The transaction id is available after its creation, which we want to use in https://github.com/near/nearcore/pull/11364. It was tricky to extract it because we were receiving a serialized transaction from this API, so I refactored the code to return SignedTransaction instead which also now contains transaction_id.