### PR TITLE
Panic in debug mode or non-prod chain when there is a chunk-witness validation error

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -362,8 +362,7 @@ impl Client {
             Arc::new(ChunkEndorsementTracker::new(epoch_manager.clone()));
         // Chunk validator should panic if there is a validator error in non-production chains (eg. mocket and localnet).
         let panic_on_validation_error = config.chain_id != near_primitives::chains::MAINNET
-            && config.chain_id != near_primitives::chains::TESTNET
-            && config.chain_id != near_primitives::chains::STATELESSNET;
+            && config.chain_id != near_primitives::chains::TESTNET;
         let chunk_validator = ChunkValidator::new(
             validator_signer.clone(),
             epoch_manager.clone(),

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -360,6 +360,10 @@ impl Client {
         );
         let chunk_endorsement_tracker =
             Arc::new(ChunkEndorsementTracker::new(epoch_manager.clone()));
+        /// Chunk validator should panic if there is a validator error in non-production chains (eg. mocket and localnet).
+        let panic_on_validation_error = self.config.chain_id != near_primitives::chains::MAINNET
+            && self.config.chain_id != near_primitives::chains::TESTNET
+            && self.config.chain_id != near_primitives::chains::STATELESSNET;
         let chunk_validator = ChunkValidator::new(
             validator_signer.clone(),
             epoch_manager.clone(),
@@ -368,6 +372,7 @@ impl Client {
             chunk_endorsement_tracker.clone(),
             config.orphan_state_witness_pool_size,
             async_computation_spawner,
+            panic_on_validation_error,
         );
         let chunk_distribution_network = ChunkDistributionNetwork::from_config(&config);
         Ok(Self {

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -360,10 +360,10 @@ impl Client {
         );
         let chunk_endorsement_tracker =
             Arc::new(ChunkEndorsementTracker::new(epoch_manager.clone()));
-        /// Chunk validator should panic if there is a validator error in non-production chains (eg. mocket and localnet).
-        let panic_on_validation_error = self.config.chain_id != near_primitives::chains::MAINNET
-            && self.config.chain_id != near_primitives::chains::TESTNET
-            && self.config.chain_id != near_primitives::chains::STATELESSNET;
+        // Chunk validator should panic if there is a validator error in non-production chains (eg. mocket and localnet).
+        let panic_on_validation_error = config.chain_id != near_primitives::chains::MAINNET
+            && config.chain_id != near_primitives::chains::TESTNET
+            && config.chain_id != near_primitives::chains::STATELESSNET;
         let chunk_validator = ChunkValidator::new(
             validator_signer.clone(),
             epoch_manager.clone(),

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -38,6 +38,7 @@ use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::ShardId;
 use near_primitives::validator_signer::ValidatorSigner;
+use near_o11y::log_assert_fail;
 use near_store::{PartialStorage, ShardUId};
 use near_vm_runner::logic::ProtocolVersion;
 use orphan_witness_pool::OrphanStateWitnessPool;
@@ -153,7 +154,8 @@ impl ChunkValidator {
             chunk_header.shard_id(),
         )?;
         let shard_uid = epoch_manager.shard_id_to_uid(last_header.shard_id(), &epoch_id)?;
-
+        let panic_on_validation_error = self.panic_on_validation_error;
+        
         if let Ok(prev_chunk_extra) = chain.get_chunk_extra(prev_block_hash, &shard_uid) {
             match validate_chunk_with_chunk_extra(
                 chain.chain_store(),
@@ -174,7 +176,7 @@ impl ChunkValidator {
                     return Ok(());
                 }
                 Err(err) => {
-                    if self.panic_on_validation_error {
+                    if panic_on_validation_error {
                         panic!("Failed to validate chunk using existing chunk extra: {:?}", err);
                     } else {
                         log_assert_fail!("Failed to validate chunk using existing chunk extra: {:?}", err);
@@ -208,7 +210,7 @@ impl ChunkValidator {
                     );
                 }
                 Err(err) => {
-                    if self.panic_on_validation_error {
+                    if panic_on_validation_error {
                         panic!("Failed to validate chunk: {:?}", err);
                     } else {
                         log_assert_fail!("Failed to validate chunk: {:?}", err);

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -24,7 +24,6 @@ use near_chain::{Block, Chain, ChainStoreAccess};
 use near_chain_primitives::Error;
 use near_epoch_manager::EpochManagerAdapter;
 use near_network::types::{NetworkRequests, PeerManagerMessageRequest};
-use near_o11y::log_assert_fail;
 use near_pool::TransactionGroupIteratorWrapper;
 use near_primitives::apply::ApplyChunkReason;
 use near_primitives::hash::{hash, CryptoHash};
@@ -179,7 +178,7 @@ impl ChunkValidator {
                     if panic_on_validation_error {
                         panic!("Failed to validate chunk using existing chunk extra: {:?}", err);
                     } else {
-                        log_assert_fail!(
+                        tracing::error!(
                             "Failed to validate chunk using existing chunk extra: {:?}",
                             err
                         );
@@ -216,7 +215,7 @@ impl ChunkValidator {
                     if panic_on_validation_error {
                         panic!("Failed to validate chunk: {:?}", err);
                     } else {
-                        log_assert_fail!("Failed to validate chunk: {:?}", err);
+                        tracing::error!("Failed to validate chunk: {:?}", err);
                     }
                 }
             }

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -24,6 +24,7 @@ use near_chain::{Block, Chain, ChainStoreAccess};
 use near_chain_primitives::Error;
 use near_epoch_manager::EpochManagerAdapter;
 use near_network::types::{NetworkRequests, PeerManagerMessageRequest};
+use near_o11y::log_assert_fail;
 use near_pool::TransactionGroupIteratorWrapper;
 use near_primitives::apply::ApplyChunkReason;
 use near_primitives::hash::{hash, CryptoHash};
@@ -38,7 +39,6 @@ use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::ShardId;
 use near_primitives::validator_signer::ValidatorSigner;
-use near_o11y::log_assert_fail;
 use near_store::{PartialStorage, ShardUId};
 use near_vm_runner::logic::ProtocolVersion;
 use orphan_witness_pool::OrphanStateWitnessPool;
@@ -155,7 +155,7 @@ impl ChunkValidator {
         )?;
         let shard_uid = epoch_manager.shard_id_to_uid(last_header.shard_id(), &epoch_id)?;
         let panic_on_validation_error = self.panic_on_validation_error;
-        
+
         if let Ok(prev_chunk_extra) = chain.get_chunk_extra(prev_block_hash, &shard_uid) {
             match validate_chunk_with_chunk_extra(
                 chain.chain_store(),
@@ -179,7 +179,10 @@ impl ChunkValidator {
                     if panic_on_validation_error {
                         panic!("Failed to validate chunk using existing chunk extra: {:?}", err);
                     } else {
-                        log_assert_fail!("Failed to validate chunk using existing chunk extra: {:?}", err);
+                        log_assert_fail!(
+                            "Failed to validate chunk using existing chunk extra: {:?}",
+                            err
+                        );
                     }
                     return Err(err);
                 }

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -223,6 +223,14 @@ impl ChunkValidator {
         });
         Ok(())
     }
+
+    /// TESTING ONLY: Used to override the value of panic_on_validation_error, for example,
+    /// when the chunks validation errors are expected when testing adversarial behavior and
+    /// the test should not panic for the invalid chunks witnesses.
+    #[cfg(feature = "test_features")]
+    pub fn set_should_panic_on_validation_error(&mut self, value: bool) {
+        self.panic_on_validation_error = value;
+    }
 }
 
 /// Checks that proposed `transactions` are valid for a chunk with `chunk_header`.

--- a/integration-tests/src/tests/client/features/adversarial_behaviors.rs
+++ b/integration-tests/src/tests/client/features/adversarial_behaviors.rs
@@ -362,7 +362,9 @@ fn test_banning_chunk_producer_when_seeing_invalid_chunk() {
     init_test_logger();
     let mut test = AdversarialBehaviorTestData::new();
     test.env.clients[7].produce_invalid_chunks = true;
-    test.env.clients[7].chunk_validator.set_should_panic_on_validation_error(false);
+    for client in test.env.clients.iter_mut() {
+        client.chunk_validator.set_should_panic_on_validation_error(false);
+    }
     test_banning_chunk_producer_when_seeing_invalid_chunk_base(test);
 }
 
@@ -372,6 +374,8 @@ fn test_banning_chunk_producer_when_seeing_invalid_tx_in_chunk() {
     init_test_logger();
     let mut test = AdversarialBehaviorTestData::new();
     test.env.clients[7].produce_invalid_tx_in_chunks = true;
-    test.env.clients[7].chunk_validator.set_should_panic_on_validation_error(false);
+    for client in test.env.clients.iter_mut() {
+        client.chunk_validator.set_should_panic_on_validation_error(false);
+    }
     test_banning_chunk_producer_when_seeing_invalid_chunk_base(test);
 }

--- a/integration-tests/src/tests/client/features/adversarial_behaviors.rs
+++ b/integration-tests/src/tests/client/features/adversarial_behaviors.rs
@@ -362,6 +362,7 @@ fn test_banning_chunk_producer_when_seeing_invalid_chunk() {
     init_test_logger();
     let mut test = AdversarialBehaviorTestData::new();
     test.env.clients[7].produce_invalid_chunks = true;
+    test.env.clients[7].chunk_validator.set_should_panic_on_validation_error(false);
     test_banning_chunk_producer_when_seeing_invalid_chunk_base(test);
 }
 
@@ -371,5 +372,6 @@ fn test_banning_chunk_producer_when_seeing_invalid_tx_in_chunk() {
     init_test_logger();
     let mut test = AdversarialBehaviorTestData::new();
     test.env.clients[7].produce_invalid_tx_in_chunks = true;
+    test.env.clients[7].chunk_validator.set_should_panic_on_validation_error(false);
     test_banning_chunk_producer_when_seeing_invalid_chunk_base(test);
 }


### PR DESCRIPTION
This is an attempt to create a submittable version of [this commit](https://github.com/near/nearcore/commit/0c6c82266302c3b115d73c4df66cdc545ba37d37).

After this change chunk-witness validation errors will lead to panic for non-production chains (eg. mocknet and localnet). mainnet and testnet will continue to log error and continue on validation errors.
We also add a method to enable/disable this for tests, especially for adversarial behavior where the chunk validation errors are intended as part of the test scenario.