### PR TITLE
feat(forknet): Add targeted commands to mirror.py

### DIFF
--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -11,7 +11,6 @@ from rc import pmap
 import re
 import sys
 import time
-import cmd_utils
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 
@@ -19,6 +18,10 @@ from configured_logger import logger
 import local_test_node
 import node_config
 import remote_node
+
+
+def to_list(item):
+    return [item] if item is not None else []
 
 
 def prompt_setup_flags(args):
@@ -104,17 +107,15 @@ def init_neard_runners(args, traffic_generator, nodes, remove_home_dir=False):
             }]
         }
 
-    traffic_generator.init_neard_runner(traffic_generator_config,
-                                        remove_home_dir)
+    if traffic_generator is not None:
+        traffic_generator.init_neard_runner(traffic_generator_config,
+                                            remove_home_dir)
     pmap(lambda x: x[0].init_neard_runner(x[1], remove_home_dir),
          zip(nodes, configs))
 
 
 def init_cmd(args, traffic_generator, nodes):
-    init_neard_runners(args,
-                       traffic_generator,
-                       wanted_nodes,
-                       remove_home_dir=False)
+    init_neard_runners(args, traffic_generator, nodes, remove_home_dir=False)
 
 
 def hard_reset_cmd(args, traffic_generator, nodes):
@@ -130,15 +131,16 @@ def hard_reset_cmd(args, traffic_generator, nodes):
 
 
 def restart_cmd(args, traffic_generator, nodes):
-    all_nodes = nodes + [traffic_generator]
-    pmap(lambda node: node.stop_neard_runner(), all_nodes)
+    targeted = nodes + to_list(traffic_generator)
+    pmap(lambda node: node.stop_neard_runner(), targeted)
     if args.upload_program:
-        pmap(lambda node: node.upload_neard_runner(), all_nodes)
-    pmap(lambda node: node.start_neard_runner(), all_nodes)
+        pmap(lambda node: node.upload_neard_runner(), targeted)
+    pmap(lambda node: node.start_neard_runner(), targeted)
 
 
 def stop_runner_cmd(args, traffic_generator, nodes):
-    pmap(lambda node: node.stop_neard_runner(), nodes + [traffic_generator])
+    targeted = nodes + to_list(traffic_generator)
+    pmap(lambda node: node.stop_neard_runner(), targeted)
 
 
 # returns boot nodes and validators we want for the new test network
@@ -237,12 +239,13 @@ def new_test_cmd(args, traffic_generator, nodes):
             f'--num-validators is {args.num_validators} but only found {len(nodes)} under test'
         )
 
-    genesis_time = new_genesis_timestamp(nodes[0])
+    ref_node = traffic_generator if traffic_generator else nodes[0]
+    genesis_time = new_genesis_timestamp(ref_node)
 
-    all_nodes = nodes + [traffic_generator]
+    targeted = nodes + to_list(traffic_generator)
 
     logger.info(f'resetting/initializing home dirs')
-    test_keys = pmap(lambda node: node.neard_runner_new_test(), all_nodes)
+    test_keys = pmap(lambda node: node.neard_runner_new_test(), targeted)
 
     validators, boot_nodes = get_network_nodes(zip(nodes, test_keys),
                                                args.num_validators)
@@ -258,7 +261,7 @@ ready. After they're ready, you can run `start-traffic`""".format(validators))
             args.epoch_length,
             args.num_seats,
             args.genesis_protocol_version,
-            genesis_time=genesis_time), all_nodes)
+            genesis_time=genesis_time), targeted)
 
     if args.local_test:
         location = {
@@ -279,7 +282,7 @@ ready. After they're ready, you can run `start-traffic`""".format(validators))
         else:
             location = None
     logger.info('Applying default config changes')
-    pmap(lambda node: _apply_config_changes(node, location), all_nodes)
+    pmap(lambda node: _apply_config_changes(node, location), targeted)
 
     if args.stateless_setup:
         logger.info('Configuring nodes for stateless protocol')
@@ -287,19 +290,19 @@ ready. After they're ready, you can run `start-traffic`""".format(validators))
 
 
 def status_cmd(args, traffic_generator, nodes):
-    all_nodes = nodes + [traffic_generator]
-    statuses = pmap(lambda node: node.neard_runner_ready(), all_nodes)
-    num_ready = 0
+    targeted = nodes + to_list(traffic_generator)
+    statuses = pmap(lambda node: node.neard_runner_ready(), targeted)
+
     not_ready = []
-    for ready, node in zip(statuses, all_nodes):
+    for ready, node in zip(statuses, targeted):
         if not ready:
             not_ready.append(node.name())
 
     if len(not_ready) == 0:
-        print(f'all {len(all_nodes)} nodes ready')
+        print(f'all {len(targeted)} nodes ready')
     else:
         print(
-            f'{len(all_nodes)-len(not_ready)}/{len(all_nodes)} ready. Nodes not ready: {not_ready[:3]}'
+            f'{len(targeted)-len(not_ready)}/{len(targeted)} ready. Nodes not ready: {not_ready[:3]}'
         )
 
 
@@ -311,14 +314,15 @@ def reset_cmd(args, traffic_generator, nodes):
         if sys.stdin.readline().strip() != 'yes':
             sys.exit()
     if args.backup_id is None:
-        backups = nodes[0].neard_runner_ls_backups()
+        ref_node = traffic_generator if traffic_generator else nodes[0]
+        backups = ref_node.neard_runner_ls_backups()
         backups_msg = 'ID |  Time  | Description\n'
         if 'start' not in backups:
             backups_msg += 'start | None | initial test state after state root computation\n'
         for backup_id, backup_data in backups.items():
             backups_msg += f'{backup_id} | {backup_data.get("time")} | {backup_data.get("description")}\n'
 
-        print(f'Backups as reported by {nodes[0].name()}):\n\n{backups_msg}')
+        print(f'Backups as reported by {ref_node.name()}):\n\n{backups_msg}')
         print('please enter a backup ID here:')
         args.backup_id = sys.stdin.readline().strip()
         if args.backup_id != 'start' and args.backup_id not in backups:
@@ -326,9 +330,9 @@ def reset_cmd(args, traffic_generator, nodes):
                 f'Given backup ID ({args.backup_id}) was not in the list given')
             sys.exit()
 
-    all_nodes = nodes + [traffic_generator]
+    targeted = nodes + to_list(traffic_generator)
     pmap(lambda node: node.neard_runner_reset(backup_id=args.backup_id),
-         all_nodes)
+         targeted)
     logger.info(
         'Data dir reset in progress. Run the `status` command to see when this is finished. Until it is finished, neard runners may not respond to HTTP requests.'
     )
@@ -353,14 +357,15 @@ def make_backup_cmd(args, traffic_generator, nodes):
             if len(description) > 0:
                 args.description = description
 
-    all_nodes = nodes + [traffic_generator]
+    targeted = nodes + to_list(traffic_generator)
     pmap(
         lambda node: node.neard_runner_make_backup(
-            backup_id=args.backup_id, description=args.description), all_nodes)
+            backup_id=args.backup_id, description=args.description), targeted)
 
 
 def stop_nodes_cmd(args, traffic_generator, nodes):
-    pmap(lambda node: node.neard_runner_stop(), nodes + [traffic_generator])
+    targeted = nodes + to_list(traffic_generator)
+    pmap(lambda node: node.neard_runner_stop(), targeted)
 
 
 def stop_traffic_cmd(args, traffic_generator, nodes):
@@ -375,7 +380,7 @@ def do_update_config(node, config_change):
 
 
 def update_config_cmd(args, traffic_generator, nodes):
-    nodes = nodes + [traffic_generator]
+    nodes = nodes + to_list(traffic_generator)
     pmap(
         lambda node: do_update_config(node, args.set),
         nodes,
@@ -393,6 +398,9 @@ def start_nodes_cmd(args, traffic_generator, nodes):
 
 
 def start_traffic_cmd(args, traffic_generator, nodes):
+    if traffic_generator is None:
+        logger.warning('No traffic node selected. Change filters.')
+        return
     if not all(
             pmap(lambda node: node.neard_runner_ready(),
                  nodes + [traffic_generator])):
@@ -415,20 +423,11 @@ def start_traffic_cmd(args, traffic_generator, nodes):
 
 def update_binaries_cmd(args, traffic_generator, nodes):
     pmap(lambda node: node.neard_runner_update_binaries(),
-         nodes + [traffic_generator])
+         nodes + to_list(traffic_generator))
 
 
 def run_remote_cmd(args, traffic_generator, nodes):
-    targeted = []
-    if args.all or args.traffic:
-        targeted.append(traffic_generator)
-    if args.all or args.nodes:
-        targeted.extend(nodes)
-    if args.filter is not None:
-        targeted = [h for h in targeted if re.search(args.filter, h.name())]
-    if len(targeted) == 0:
-        logger.error(f'No hosts selected. Change filters and try again.')
-        return
+    targeted = nodes + to_list(traffic_generator)
     logger.info(f'Running cmd on {"".join([h.name() for h in targeted ])}')
     pmap(lambda node: logger.info(
         '{0}:\nstdout:\n{1.stdout}\nstderr:\n{1.stderr}'.format(
@@ -442,7 +441,25 @@ def run_env_cmd(args, traffic_generator, nodes):
         func = lambda node: node.neard_clear_env()
     else:
         func = lambda node: node.neard_update_env(args.key_value)
-    pmap(func, nodes + [traffic_generator])
+    targeted = nodes + to_list(traffic_generator)
+    pmap(func, targeted)
+
+
+def filter_hosts(args, traffic_generator, nodes):
+    if args.filter is not None:
+        if not re.search(args.filter, traffic_generator.name()):
+            traffic_generator = None
+        nodes = [h for h in nodes if re.search(args.filter, h.name())]
+    if args.type not in ['all', 'traffic']:
+        traffic_generator = None
+    if args.type not in ['all', 'nodes']:
+        nodes = []
+
+    if len(nodes) == 0 and traffic_generator == None:
+        logger.error(f'No hosts selected. Change filters and try again.')
+        exit(1)
+
+    return traffic_generator, nodes
 
 
 if __name__ == '__main__':
@@ -451,6 +468,14 @@ if __name__ == '__main__':
     parser.add_argument('--start-height', type=int)
     parser.add_argument('--unique-id', type=str)
     parser.add_argument('--local-test', action='store_true')
+    parser.add_argument('--type',
+                        type=str,
+                        choices=['all', 'nodes', 'traffic'],
+                        default='all',
+                        help='Type of hosts to select')
+    parser.add_argument('--filter',
+                        type=str,
+                        help='Filter through the selected nodes using regex.')
 
     subparsers = parser.add_subparsers(title='subcommands',
                                        description='valid subcommands',
@@ -582,19 +607,6 @@ if __name__ == '__main__':
     run_cmd_parser = subparsers.add_parser('run-cmd',
                                            help='''Run the cmd on the hosts.''')
     run_cmd_parser.add_argument('--cmd', type=str)
-    run_cmd_parser.add_argument('--all',
-                                action='store_true',
-                                help='Run on all hosts')
-    run_cmd_parser.add_argument('--nodes',
-                                action='store_true',
-                                help='Run on nodes')
-    run_cmd_parser.add_argument('--traffic',
-                                action='store_true',
-                                help='Run on traffic host')
-    run_cmd_parser.add_argument(
-        '--filter',
-        type=str,
-        help='Filter through the selected nodes using regex.')
     run_cmd_parser.set_defaults(func=run_remote_cmd)
 
     env_cmd_parser = subparsers.add_parser(
@@ -622,6 +634,10 @@ if __name__ == '__main__':
         node_config.configure_nodes(nodes + [traffic_generator],
                                     node_config.REMOTE_CONFIG)
 
+    # Select the affected hosts.
+    # traffic_generator can become None,
+    # nodes list can become empty
+    traffic_generator, nodes = filter_hosts(args, traffic_generator, nodes)
     wanted_nodes = []
     for node in nodes:
         if node.want_neard_runner:

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -446,13 +446,13 @@ def run_env_cmd(args, traffic_generator, nodes):
 
 
 def filter_hosts(args, traffic_generator, nodes):
-    if args.filter is not None:
+    if args.host_filter is not None:
         if not re.search(args.filter, traffic_generator.name()):
             traffic_generator = None
         nodes = [h for h in nodes if re.search(args.filter, h.name())]
-    if args.type not in ['all', 'traffic']:
+    if args.host_type not in ['all', 'traffic']:
         traffic_generator = None
-    if args.type not in ['all', 'nodes']:
+    if args.host_type not in ['all', 'nodes']:
         nodes = []
 
     if len(nodes) == 0 and traffic_generator == None:
@@ -468,12 +468,12 @@ if __name__ == '__main__':
     parser.add_argument('--start-height', type=int)
     parser.add_argument('--unique-id', type=str)
     parser.add_argument('--local-test', action='store_true')
-    parser.add_argument('--type',
+    parser.add_argument('--host-type',
                         type=str,
                         choices=['all', 'nodes', 'traffic'],
                         default='all',
                         help='Type of hosts to select')
-    parser.add_argument('--filter',
+    parser.add_argument('--host-filter',
                         type=str,
                         help='Filter through the selected nodes using regex.')
 


### PR DESCRIPTION
Allow targeted commands from mirror.py. Every command can be issued only for a subset of nodes by using the following filters:
`mirror --help`
```
Control a mocknet instance

options:
...
  --type {all,nodes,traffic}
                        Type of hosts to select
  --filter FILTER       Filter through the selected nodes using regex.
...
```

`mirror --filter="-dumper" run-cmd --cmd "ls" `
```
[2024-05-29 11:43:25] INFO: created configured logger, name test, level 20
[2024-05-29 11:43:26] INFO: created configured logger, name serializer, level 20
[2024-05-29 11:43:32] INFO: Running cmd on mocknet-*******-dumper
[2024-05-29 11:43:33] INFO: mocknet-*******-dumper:
stdout:
data
logs
neard-logs

stderr:
```

`mirror --type="nodes" run-cmd --cmd "ls" ` # will target all nodes

`mirror --type="traffic" run-cmd --cmd "ls" ` # will target the traffic node
```
...
INFO: Running cmd on mocknet-*******-traffic
...
```