### PR TITLE
feat(forknet): allow url update when using update-binaries cmd

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -677,8 +677,10 @@ class NeardRunner:
                 f'Updating binary list for height:{epoch_height} or idx:{binary_idx} with '
                 f'url: {neard_binary_url}')
         else:
-            logging.error(f'wrong arguments provided')
-            return
+            logging.error(
+                f'Update binaries failed. Wrong params: url: {neard_binary_url}, height:{epoch_height}, idx:{binary_idx}'
+            )
+            raise jsonrpc.exceptions.JSONRPCInvalidParams()
 
         if 'binaries' not in self.config:
             self.config['binaries'] = []
@@ -704,7 +706,10 @@ class NeardRunner:
                 logging.error(
                     f'idx {binary_idx} is out of bounds for the binary list of length {binaries_number}'
                 )
-                return
+                raise jsonrpc.exceptions.JSONRPCInvalidParams(
+                    message=
+                    f'Invalid binary idx. Out of bounds for list of length {binaries_number}'
+                )
             self.config['binaries'][binary_idx]['url'] = neard_binary_url
 
     def do_update_binaries(self, neard_binary_url, epoch_height, binary_idx):

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -429,8 +429,14 @@ def start_traffic_cmd(args, traffic_generator, nodes):
 
 
 def update_binaries_cmd(args, traffic_generator, nodes):
-    pmap(lambda node: node.neard_runner_update_binaries(),
-         nodes + to_list(traffic_generator))
+    if (args.neard_binary_url is not None or args.update_epoch_height is not None
+       ) and (args.neard_binary_url is None or args.update_epoch_height is None):
+        logger.warning(f'specify both neard_binary_url and update_epoch_height')
+        return
+    pmap(
+        lambda node: node.neard_runner_update_binaries(
+            args.neard_binary_url, args.update_epoch_height),
+        nodes + to_list(traffic_generator))
 
 
 def run_remote_cmd(args, traffic_generator, nodes):
@@ -608,7 +614,9 @@ if __name__ == '__main__':
         'update-binaries',
         help=
         'Update the neard binaries by re-downloading them. The same urls are used.'
-    )
+        + ' Add or override the URLs with --neard-binary-url.')
+    update_binaries_parser.add_argument('--neard-binary-url', type=str)
+    update_binaries_parser.add_argument('--update-epoch-height', type=int)
     update_binaries_parser.set_defaults(func=update_binaries_cmd)
 
     run_cmd_parser = subparsers.add_parser('run-cmd',

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -639,7 +639,7 @@ if __name__ == '__main__':
         If a binary already exists on the host for this epoch height, the old one will be replaced.
         Otherwise a new binary will be added with this epoch height.
         ''')
-    group.add_argument('--binary_idx',
+    group.add_argument('--binary-idx',
                        type=int,
                        help='''
         0 based indexing.

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -610,13 +610,27 @@ if __name__ == '__main__':
     # nearcore-release buildkite and urls in the following format without commit
     # but only with the branch name:
     # https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Linux/<branch-name>/neard"
-    update_binaries_parser = subparsers.add_parser(
-        'update-binaries',
-        help=
-        'Update the neard binaries by re-downloading them. The same urls are used.'
-        + ' Add or override the URLs with --neard-binary-url.')
-    update_binaries_parser.add_argument('--neard-binary-url', type=str)
-    update_binaries_parser.add_argument('--update-epoch-height', type=int)
+    update_binaries_parser = subparsers.add_parser('update-binaries',
+                                                   help='''
+        Update the neard binaries by re-downloading them. The same urls are used.
+        Add or override the URLs with --neard-binary-url by specifying the epoch height.
+        If the network was started with 2 urls, the upgrade epoch height can be randomly assigned
+        on each host. Use caution when specifying --update-epoch-height so that it will not interlace
+        with the random upgrade window for neard1.
+        ''')
+    update_binaries_parser.add_argument('--neard-binary-url',
+                                        type=str,
+                                        help='''
+        If you plan to restart the network multiple times, it is recommended to use
+        URLs that only depend on the branch name. This way, every time you build,
+        you will not need to update the URL but just run update-binaries.
+        ''')
+    update_binaries_parser.add_argument('--update-epoch-height',
+                                        type=int,
+                                        help='''
+        The epoch height where this binary will begin to run.
+        If a binary already exists on the host for this epoch height, the old one will be replaced.
+        ''')
     update_binaries_parser.set_defaults(func=update_binaries_cmd)
 
     run_cmd_parser = subparsers.add_parser('run-cmd',

--- a/pytest/tests/mocknet/node_handle.py
+++ b/pytest/tests/mocknet/node_handle.py
@@ -140,8 +140,15 @@ class NodeHandle:
         return self.neard_runner_jsonrpc('reset',
                                          params={'backup_id': backup_id})
 
-    def neard_runner_update_binaries(self):
-        return self.neard_runner_jsonrpc('update_binaries')
+    def neard_runner_update_binaries(self,
+                                     neard_binary_url=None,
+                                     update_epoch_height=None):
+        return self.neard_runner_jsonrpc(
+            'update_binaries',
+            params={
+                'neard_binary_url': neard_binary_url,
+                'update_epoch_height': update_epoch_height,
+            })
 
     def neard_update_config(self, key_value):
         return self.neard_runner_jsonrpc(

--- a/pytest/tests/mocknet/node_handle.py
+++ b/pytest/tests/mocknet/node_handle.py
@@ -142,12 +142,14 @@ class NodeHandle:
 
     def neard_runner_update_binaries(self,
                                      neard_binary_url=None,
-                                     update_epoch_height=None):
+                                     epoch_height=None,
+                                     binary_idx=None):
         return self.neard_runner_jsonrpc(
             'update_binaries',
             params={
                 'neard_binary_url': neard_binary_url,
-                'update_epoch_height': update_epoch_height,
+                'epoch_height': epoch_height,
+                'binary_idx': binary_idx,
             })
 
     def neard_update_config(self, key_value):


### PR DESCRIPTION
Add two parameters to update-binaries to allow url update for an epoch.

Usage:
`mirror update-binaries ` # will redownload all binaries in `config.json`
`mirror amend-binaries --neard-binary-url <some url> --epoch-height 0` # will update the url for epoch height 0 in `config.json` and then download all binaries. 
`mirror amend-binaries --neard-binary-url <some url> --binary-idx 0` # will update the url for the first binary which is at epoch height 0 in `config.json` and then download all binaries. 

`mirror amend-binaries --neard-binary-url <some url> --epoch-height 10` # will insert the url for epoch height 10 in `config.json` and then download all binaries. 

`mirror amend-binaries --neard-binary-url <some url> --binary-idx 1` # will update the url for the second binary which is at epoch height 10 in `config.json` and then download all binaries. 

