### PR TITLE
locust: Send FT transfers asynchronously

### DIFF
--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -301,7 +301,7 @@ class NearNodeProxy:
                             "NONE"
                     })
                 meta["response_length"] = len(submit_raw_response.text)
-                submit_response = submit_raw_response.json()
+                submit_response = json.loads(submit_raw_response.text)
                 if not "result" in submit_response:
                     meta["exception"] = RpcError(
                         message="Failed to submit transaction",
@@ -342,7 +342,7 @@ class NearNodeProxy:
                         "NONE"
                 })
             meta["response_length"] = len(submit_raw_response.text)
-            submit_response = submit_raw_response.json()
+            submit_response = json.loads(submit_raw_response.text)
             if not "result" in submit_response:
                 meta["exception"] = RpcError(
                     message="Failed to submit transaction",
@@ -398,11 +398,12 @@ class NearNodeProxy:
         result_response = self.post_json("EXPERIMENTAL_tx_status", params)
         # very verbose, but very useful to see what's happening when things are stuck
         logger.debug(
-            f"polling, got: {result_response.status_code} {result_response.json()}"
+            f"polling, got: {result_response.status_code} {json.loads(result_response.text)}"
         )
 
         try:
-            meta["response"] = evaluate_rpc_result(result_response.json())
+            meta["response"] = evaluate_rpc_result(
+                json.loads(result_response.text))
         except:
             # Store raw response to improve error-reporting.
             meta["response"] = result_response.content
@@ -488,7 +489,7 @@ class NearNodeProxy:
                             "NONE"
                     })
                 meta["response_length"] = len(submit_raw_response.text)
-                submit_response = submit_raw_response.json()
+                submit_response = json.loads(submit_raw_response.text)
                 if not "result" in submit_response:
                     # something failed, let's not block, just try again later
                     logger.debug(

--- a/pytest/tests/loadtest/locust/locustfiles/ft.py
+++ b/pytest/tests/loadtest/locust/locustfiles/ft.py
@@ -10,7 +10,7 @@ import sys
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[4] / 'lib'))
 
 from configured_logger import new_logger
-from locust import between, task
+from locust import constant_throughput, task
 from common.base import NearUser
 from common.ft import TransferFT
 
@@ -22,13 +22,15 @@ class FTTransferUser(NearUser):
     Registers itself on an FT contract in the setup phase, then just sends FTs to
     random users.
     """
-    wait_time = between(1, 3)  # random pause between transactions
+    # Each Locust user will try to send one transaction per second.
+    # See https://docs.locust.io/en/stable/api.html#locust.wait_time.constant_throughput.
+    wait_time = constant_throughput(1.0)
 
     @task
     def ft_transfer(self):
         receiver = self.ft.random_receiver(self.account_id)
         tx = TransferFT(self.ft.account, self.account, receiver, how_much=1)
-        self.send_tx(tx, locust_name="FT transfer")
+        self.send_tx_async(tx, locust_name="FT transfer")
 
     def on_start(self):
         super().on_start()


### PR DESCRIPTION
This PR aims to make it easier to achieve a constant TPS load with FT transfer workload.
We achieve this with two changes:
1. Transactions are now sent without waiting for their completion
2. We use `constant_throughput(1.0)` which means that each Locust user tries to send one transaction per second.