### PR TITLE
bench/ft_transfer: add db table

### DIFF
--- a/benchmarks/continous/db/ft_transfer_schema.sql
+++ b/benchmarks/continous/db/ft_transfer_schema.sql
@@ -1,0 +1,33 @@
+create table ft_transfer (
+    id serial primary key,
+
+    -- Metada related to the execution of the benchmark.
+
+    -- Timestamp of benchmark execution start.
+    -- Enables Grafana time series queries.
+    -- https://grafana.com/docs/grafana/latest/datasources/postgres
+    -- /#time-series-queries
+    time timestamp not null,
+    -- Hash of the git commit off which the run's neard was compiled.
+    git_commit_hash varchar(40) not null,
+    -- Time when the commit was made. Store it in the db to easily check how
+    --  recent the commit is.
+    git_commit_time timestamp not null,
+    -- Number of shards where users sending ft transfers are located.
+    num_shards integer not null,
+    -- Number of unique users that sent ft transfers.
+    num_unique_users integer not null,
+    -- Size of the synthetic state at the beginning of the run in bytes.
+    size_state_bytes integer not null,
+    -- Whether the set of machines running nodes and generating transactions
+    -- was disjoint.
+    disjoint_workloads boolean not null,
+
+    -- Bencmark results.
+
+    -- FT transfer transactions per second aggregated over the run of the
+    -- benchmark.
+    tps integer not null,
+    -- Total number of ft transfer transactions executed during the run.
+    total_transactions integer not null
+);

--- a/benchmarks/continous/db/ft_transfer_schema.sql
+++ b/benchmarks/continous/db/ft_transfer_schema.sql
@@ -1,7 +1,7 @@
 create table ft_transfer (
     id serial primary key,
 
-    -- Metada related to the execution of the benchmark.
+    -- Metadata related to the execution of the benchmark.
 
     -- Timestamp of benchmark execution start.
     -- Enables Grafana time series queries.
@@ -9,19 +9,25 @@ create table ft_transfer (
     -- /#time-series-queries
     time timestamp not null,
     -- Hash of the git commit off which the run's neard was compiled.
-    git_commit_hash varchar(40) not null,
+    git_commit_hash text not null,
     -- Time when the commit was made. Store it in the db to easily check how
     --  recent the commit is.
     git_commit_time timestamp not null,
+    -- Number of (physically separate) NEAR nodes participating in the run.
+    num_nodes integer not null,
+    -- Descriptors of NEAR nodes' hardware, e.g. GCP machine types.
+    node_hardware text [] not null,
+    -- Number of machines used for traffic generation.
+    num_traffic_gen_machines integer not null,
+    -- Whether the set of machines running nodes and generating transactions
+    -- was disjoint.
+    disjoint_workloads boolean not null,
     -- Number of shards where users sending ft transfers are located.
     num_shards integer not null,
     -- Number of unique users that sent ft transfers.
     num_unique_users integer not null,
     -- Size of the synthetic state at the beginning of the run in bytes.
     size_state_bytes integer not null,
-    -- Whether the set of machines running nodes and generating transactions
-    -- was disjoint.
-    disjoint_workloads boolean not null,
 
     -- Bencmark results.
 


### PR DESCRIPTION
Related to #11405.

Not sure if this directory makes sense, but I couldn't find another place where this should obviously be. I'd like to push more files with code/commands related to db setup and admin, so I think having a dedicated directory can be useful.

Proposing this table as a starting point, probably we'll have multiple iterations anyway as benchmarks are fleshed out.