### PR TITLE
GHA workflow: Master build neard version

### DIFF
--- a/.github/workflows/neard_release.yml
+++ b/.github/workflows/neard_release.yml
@@ -3,7 +3,7 @@ name: Neard binary and Docker image release
 on:
   # Run when a new release or rc is created
   release:
-    types: [released, prereleased]
+    types: [published]
   push:
     branches: master
 

--- a/.github/workflows/neard_release.yml
+++ b/.github/workflows/neard_release.yml
@@ -36,11 +36,18 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch }}
 
-      - name: Checkout nearcore repository
-        if: ${{ github.event_name != 'workflow_dispatch'}}
+      - name: Checkout nearcore release
+        # for release events we need to checkout all branches to be able to determine
+        # later branch name
+        if: ${{ github.event_name != 'workflow_dispatch' && github.event_name == 'release'}}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Checkout  repository for master branch
+        # In case of master branch we want to checkout with depth 1
+        if: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'release'}}
+        uses: actions/checkout@v4
 
       - name: Neard binary build and upload to S3
         run: ./scripts/binary_release.sh
@@ -66,11 +73,18 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch }}
 
-      - name: Checkout nearcore repository
-        if: ${{ github.event_name != 'workflow_dispatch'}}
+      - name: Checkout nearcore release
+        # for release events we need to checkout all branches to be able to determine
+        # later branch name
+        if: ${{ github.event_name != 'workflow_dispatch' && github.event_name == 'release'}}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Checkout  repository for master branch
+        # In case of master branch we want to checkout with depth 1
+        if: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'release'}}
+        uses: actions/checkout@v4
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
In https://github.com/near/nearcore/pull/10521 I made checkout process to fetch all nearcore branches.
This instead messed with master branch builds version because these are fetching latest annotated tag:
```
➜  nearcore git:(master) git "describe" "--always" "--dirty=-modified" "--tags" "--match=[0-9]*"  
1.36.1-653-g2b01868d4
```

To avoid this, we will be fetching with depth 1(default fetch-depth) when workflow is triggered by master branch push events.
```
➜  nearcore git:(master) git "describe" "--always" "--dirty=-modified" "--tags" "--match=[0-9]*"  
dfa392b
```