### PR TITLE
fix(loadtest): bug fix in congestion load

### DIFF
--- a/pytest/tests/loadtest/locust/common/congestion.py
+++ b/pytest/tests/loadtest/locust/common/congestion.py
@@ -48,7 +48,7 @@ class ComputeSum(base.Transaction):
         self.usage_tgas = usage_tgas
 
     def sign(self, block_hash) -> transaction.SignedTransaction:
-        return transaction.sign_function_call_tx(
+        return transaction.sign_function_call_transaction(
             self.sender.key,
             self.contract_account_id,
             "sum_n",


### PR DESCRIPTION
It looks like in the refactor #11410 the congestion load was not updated and  still returned  bytes instead of SignedTransaction. This leads to key errors during serialization when running the congestion load.