### PR TITLE
[Testing] Speed up multinode_test_loop_example by 20x.

### DIFF
--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -21,6 +21,7 @@ pub use self::splitdb::SplitDB;
 
 pub use self::slice::DBSlice;
 pub use self::testdb::TestDB;
+use std::sync::Arc;
 
 // `DBCol::BlockMisc` keys
 pub const HEAD_KEY: &[u8; 4] = b"HEAD";
@@ -249,6 +250,12 @@ pub trait Database: Sync + Send {
         path: &std::path::Path,
         columns_to_keep: Option<&[DBCol]>,
     ) -> anyhow::Result<()>;
+
+    /// If this is a test database, return a copy of the entire database.
+    /// Otherwise return null.
+    fn copy_if_test(&self) -> Option<Arc<dyn Database>> {
+        None
+    }
 }
 
 fn assert_no_overwrite(col: DBCol, key: &[u8], value: &[u8], old_value: &[u8]) {

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -252,7 +252,7 @@ pub trait Database: Sync + Send {
     ) -> anyhow::Result<()>;
 
     /// If this is a test database, return a copy of the entire database.
-    /// Otherwise return null.
+    /// Otherwise return None.
     fn copy_if_test(&self) -> Option<Arc<dyn Database>> {
         None
     }

--- a/core/store/src/db/testdb.rs
+++ b/core/store/src/db/testdb.rs
@@ -135,4 +135,19 @@ impl Database for TestDB {
     ) -> anyhow::Result<()> {
         Ok(())
     }
+
+    fn copy_if_test(&self) -> Option<Arc<dyn Database>> {
+        let copy = Self::default();
+        {
+            let mut db = copy.db.write().unwrap();
+            for (col, map) in self.db.read().unwrap().iter() {
+                let new_col = &mut db[col];
+                for (key, value) in map.iter() {
+                    new_col.insert(key.clone(), value.clone());
+                }
+            }
+            *copy.stats.write().unwrap() = self.stats.read().unwrap().clone();
+        }
+        Some(Arc::new(copy))
+    }
 }

--- a/core/store/src/db/testdb.rs
+++ b/core/store/src/db/testdb.rs
@@ -146,7 +146,7 @@ impl Database for TestDB {
                     new_col.insert(key.clone(), value.clone());
                 }
             }
-            *copy.stats.write().unwrap() = self.stats.read().unwrap().clone();
+            copy.stats.write().unwrap().clone_from(&self.stats.read().unwrap());
         }
         Some(Arc::new(copy))
     }

--- a/core/store/src/opener.rs
+++ b/core/store/src/opener.rs
@@ -590,6 +590,9 @@ pub fn checkpoint_hot_storage_and_cleanup_columns(
     let _span =
         tracing::info_span!(target: "state_snapshot", "checkpoint_hot_storage_and_cleanup_columns")
             .entered();
+    if let Some(storage) = hot_store.storage.copy_if_test() {
+        return Ok(NodeStorage::new(storage));
+    }
     let checkpoint_path = checkpoint_base_path.join("data");
     std::fs::create_dir_all(&checkpoint_base_path)?;
 

--- a/integration-tests/src/tests/client/features/multinode_test_loop_example.rs
+++ b/integration-tests/src/tests/client/features/multinode_test_loop_example.rs
@@ -78,7 +78,8 @@ use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::AccountId;
 use near_store::config::StateSnapshotType;
 use near_store::genesis::initialize_genesis_state;
-use near_store::{NodeStorage, StoreConfig, TrieConfig};
+use near_store::test_utils::create_test_store;
+use near_store::{StoreConfig, TrieConfig};
 use near_vm_runner::ContractRuntimeCache;
 use near_vm_runner::FilesystemContractRuntimeCache;
 use nearcore::state_sync::StateSyncDumper;
@@ -235,11 +236,9 @@ fn test_client_with_multi_test_loop() {
         let store_config = StoreConfig {
             path: Some(homedir.clone()),
             load_mem_tries_for_tracked_shards: true,
-            max_open_files: 1000,
             ..Default::default()
         };
-        let opener = NodeStorage::opener(&homedir, false, &store_config, None);
-        let store = opener.open().unwrap().get_hot_store();
+        let store = create_test_store();
         initialize_genesis_state(store.clone(), &genesis, None);
 
         let sync_jobs_actor = SyncJobsActor::new(


### PR DESCRIPTION
Somewhat hacky but very simple and very effective speedup of the multinode test. When grabbing a state snapshot, instead of having to use rocksdb, we can now use create_test_store(). The reason why it didn't work earlier was because the TestDB didn't support snapshotting. But that's just doing a copy of the data so with one conditional, we're able to make this happen.

This shortens the test from needing >100s to only 5s.