### PR TITLE
chore: remove duplicated words in comments

### DIFF
--- a/chain/chain/src/test_utils/validator_schedule.rs
+++ b/chain/chain/src/test_utils/validator_schedule.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 /// the KeyValue runtime.
 ///
 /// In the real runtime, we use complex algorithm based on randomness and stake
-/// to select the validators. For for tests though, we just want to select them
+/// to select the validators. For tests though, we just want to select them
 /// by fiat.
 ///
 /// Conventional short name for `ValidatorSchedule` is `vs`.

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -139,7 +139,7 @@ impl InfoHelper {
         metrics::FINAL_DOOMSLUG_BLOCK_HEIGHT.set(last_final_ds_block_height as i64);
         metrics::EPOCH_HEIGHT.set(epoch_height as i64);
         if let Some(last_final_block_height_in_epoch) = last_final_block_height_in_epoch {
-            // In rare cases cases the final height isn't updated, for example right after a state sync.
+            // In rare cases the final height isn't updated, for example right after a state sync.
             // Don't update the metric in such cases.
             metrics::FINAL_BLOCK_HEIGHT_IN_EPOCH.set(last_final_block_height_in_epoch as i64);
         }

--- a/chain/client/src/sync/block.rs
+++ b/chain/client/src/sync/block.rs
@@ -444,7 +444,7 @@ mod test {
         let requested_block_hashes = collect_hashes_from_network_adapter(&network_adapter);
         assert!(requested_block_hashes.is_empty(), "{:?}", requested_block_hashes);
 
-        // Now finish paused processing processing and sanity check that we
+        // Now finish paused processing and sanity check that we
         // still are fully synced.
         env.resume_block_processing(blocks[4 * MAX_BLOCK_REQUESTS - 1].hash());
         wait_for_all_blocks_in_processing(&mut env.clients[1].chain);

--- a/chain/jsonrpc-primitives/src/errors.rs
+++ b/chain/jsonrpc-primitives/src/errors.rs
@@ -6,7 +6,7 @@ use std::fmt;
 pub struct RpcParseError(pub String);
 
 /// This struct may be returned from JSON RPC server in case of error
-/// It is expected that that this struct has impls From<_> all other RPC errors
+/// It is expected that this struct has impls From<_> all other RPC errors
 /// like [RpcBlockError](crate::types::blocks::RpcBlockError)
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq)]
 #[serde(deny_unknown_fields)]

--- a/chain/network/src/store/mod.rs
+++ b/chain/network/src/store/mod.rs
@@ -10,7 +10,7 @@ mod schema;
 
 /// Opaque error type representing storage errors.
 ///
-/// Invariant: any store error is a critical operational operational error
+/// Invariant: any store error is a critical operational error
 /// which signals about data corruption. It wouldn't be wrong to replace all places /// where the error originates with outright panics.
 ///
 /// If you have an error condition which needs to be handled somehow, it should be

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -35,7 +35,7 @@ pub mod col {
     /// This column id is used when storing:
     /// * the indices of the delayed receipts queue (a singleton per shard)
     /// * the delayed receipts themselves
-    /// The identifier is shared between two different key types for for historical reasons. It
+    /// The identifier is shared between two different key types for historical reasons. It
     /// is valid because the length of `TrieKey::DelayedReceipt` is always greater than
     /// `TrieKey::DelayedReceiptIndices` when serialized to bytes.
     pub const DELAYED_RECEIPT_OR_INDICES: u8 = 7;

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -183,7 +183,7 @@ pub enum StateChangeCause {
     /// Updated delayed receipts queue in the state.
     /// We either processed previously delayed receipts or added more receipts to the delayed queue.
     UpdatedDelayedReceipts,
-    /// State change that happens when we update validator accounts. Not associated with with any
+    /// State change that happens when we update validator accounts. Not associated with any
     /// specific transaction or receipt.
     ValidatorAccountsUpdate,
     /// State change that is happens due to migration that happens in first block of an epoch

--- a/pytest/lib/utils.py
+++ b/pytest/lib/utils.py
@@ -418,7 +418,7 @@ def poll_blocks(node: cluster.LocalNode,
             sent to the node.
         kw: Keyword arguments passed to `BaseDone.get_latest_block` method.
     Yields:
-        A `cluster.BlockId` object for each each time node’s latest block
+        A `cluster.BlockId` object for each time node’s latest block
         changes including the first block when function starts.  Note that there
         is no guarantee that there will be no skipped blocks.
     Raises:

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -1248,8 +1248,8 @@ impl<'a> VMLogic<'a> {
     /// # Cost
     ///
     /// This is a convenience function that encapsulates several costs:
-    /// `burnt_gas := dispatch cost of the receipt + base dispatch cost  cost of the data receipt`
-    /// `used_gas := burnt_gas + exec cost of the receipt + base exec cost  cost of the data receipt`
+    /// `burnt_gas := dispatch cost of the receipt + base dispatch cost of the data receipt`
+    /// `used_gas := burnt_gas + exec cost of the receipt + base exec cost of the data receipt`
     /// Notice that we prepay all base cost upon the creation of the data dependency, we are going to
     /// pay for the content transmitted through the dependency upon the actual creation of the
     /// DataReceipt.
@@ -2914,7 +2914,7 @@ impl<'a> VMLogic<'a> {
     /// * If `iterator_id` does not correspond to an existing iterator returns `InvalidIteratorId`;
     /// * If between the creation of the iterator and calling `storage_iter_next` the range over
     ///   which it iterates was modified returns `IteratorWasInvalidated`. Specifically, if
-    ///   `storage_write` or `storage_remove` was invoked on the key key such that:
+    ///   `storage_write` or `storage_remove` was invoked on the key such that:
     ///   * in case of `storage_iter_prefix`. `key` has the given prefix and:
     ///     * Iterator was not called next yet.
     ///     * `next` was already called on the iterator and it is currently pointing at the `key`

--- a/runtime/near-vm-runner/src/logic/tests/gas_counter.rs
+++ b/runtime/near-vm-runner/src/logic/tests/gas_counter.rs
@@ -274,7 +274,7 @@ fn check_action_gas_exceeds_limit(
 /// the arguments.
 ///
 /// This case is more interesting because the burnt gas can be below used gas,
-/// when the prepaid gas was exceeded by burnt burnt + promised gas but not by
+/// when the prepaid gas was exceeded by burnt + promised gas but not by
 /// burnt gas alone.
 ///
 /// Consequently, `num_action_paid` here is even more important to calculate

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -40,7 +40,7 @@
 //!
 //! To run estimations on a non-empty DB with standardised content, we first
 //! dump all records to a `StateDump` written to a file. Then for each
-//! iteration of a an estimation, we first load the records from this dump into
+//! iteration of an estimation, we first load the records from this dump into
 //! a fresh database. Afterwards, it is crucial to run compaction on RocksDB
 //! before starting measurements. Otherwise, the SST file layout can be very
 //! inefficient, as there was no time to restructure them. We assume that in

--- a/runtime/runtime/src/balance_checker.rs
+++ b/runtime/runtime/src/balance_checker.rs
@@ -671,7 +671,7 @@ mod tests {
         );
     }
 
-    /// When adding a receipt to the outgoing buffer, its balance must must be
+    /// When adding a receipt to the outgoing buffer, its balance must be
     /// picked up by the balance checker. Test it by simulating a transfer
     /// action removing some balance from an account and placing the receipt in
     /// the buffer.

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -26,7 +26,7 @@ pub mod errors;
 pub struct TrieViewer {
     /// Upper bound of the byte size of contract state that is still viewable. None is no limit
     state_size_limit: Option<u64>,
-    /// Gas limit used when when handling call_function queries.
+    /// Gas limit used when handling call_function queries.
     max_gas_burnt_view: Gas,
 }
 

--- a/utils/near-cache/src/cell.rs
+++ b/utils/near-cache/src/cell.rs
@@ -30,7 +30,7 @@ where
     }
 
     /// Return the value of they key in the cache otherwise computes the value and inserts it into
-    /// the cache. If the key is already in the cache, they gets moved to the head of
+    /// the cache. If the key is already in the cache, they get moved to the head of
     /// the LRU list.
     pub fn get_or_put<F>(&self, key: K, f: F) -> V
     where

--- a/utils/near-cache/src/cell.rs
+++ b/utils/near-cache/src/cell.rs
@@ -30,7 +30,7 @@ where
     }
 
     /// Return the value of they key in the cache otherwise computes the value and inserts it into
-    /// the cache. If the key is already in the cache, they gets gets moved to the head of
+    /// the cache. If the key is already in the cache, they gets moved to the head of
     /// the LRU list.
     pub fn get_or_put<F>(&self, key: K, f: F) -> V
     where

--- a/utils/near-cache/src/sync.rs
+++ b/utils/near-cache/src/sync.rs
@@ -30,7 +30,7 @@ where
     }
 
     /// Return the value of they key in the cache otherwise computes the value and inserts it into
-    /// the cache. If the key is already in the cache, they gets moved to the head of
+    /// the cache. If the key is already in the cache, they get moved to the head of
     /// the LRU list.
     pub fn get_or_put<F>(&self, key: K, f: F) -> V
     where

--- a/utils/near-cache/src/sync.rs
+++ b/utils/near-cache/src/sync.rs
@@ -30,7 +30,7 @@ where
     }
 
     /// Return the value of they key in the cache otherwise computes the value and inserts it into
-    /// the cache. If the key is already in the cache, they gets gets moved to the head of
+    /// the cache. If the key is already in the cache, they gets moved to the head of
     /// the LRU list.
     pub fn get_or_put<F>(&self, key: K, f: F) -> V
     where


### PR DESCRIPTION
remove duplicated words in comments to improve readability.