### PR TITLE
feat: check partial witness metadata

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -76,7 +76,7 @@ use near_primitives::state_sync::{
     get_num_state_parts, BitArray, CachedParts, ReceiptProofResponse, RootProof,
     ShardStateSyncResponseHeader, ShardStateSyncResponseHeaderV2, StateHeaderKey, StatePartKey,
 };
-use near_primitives::stateless_validation::EncodedChunkStateWitness;
+use near_primitives::stateless_validation::{ChunkStateWitness, ChunkStateWitnessSize};
 use near_primitives::transaction::{ExecutionOutcomeWithIdAndProof, SignedTransaction};
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{
@@ -4696,7 +4696,10 @@ pub struct BlockCatchUpResponse {
 
 #[derive(actix::Message, Debug, Clone, PartialEq, Eq)]
 #[rtype(result = "()")]
-pub struct ChunkStateWitnessMessage(pub EncodedChunkStateWitness);
+pub struct ChunkStateWitnessMessage {
+    pub witness: ChunkStateWitness,
+    pub raw_witness_size: ChunkStateWitnessSize,
+}
 
 /// Helper to track blocks catch up
 /// Lifetime of a block_hash is as follows:

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -2119,7 +2119,8 @@ impl Handler<SyncMessage> for ClientActorInner {
 impl Handler<ChunkStateWitnessMessage> for ClientActorInner {
     #[perf]
     fn handle(&mut self, msg: ChunkStateWitnessMessage) {
-        if let Err(err) = self.client.process_chunk_state_witness(msg.0, None) {
+        let ChunkStateWitnessMessage { witness, raw_witness_size } = msg;
+        if let Err(err) = self.client.process_chunk_state_witness(witness, raw_witness_size, None) {
             tracing::error!(target: "client", ?err, "Error processing chunk state witness");
         }
     }

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -32,7 +32,6 @@ use near_primitives::receipt::Receipt;
 use near_primitives::sharding::{ChunkHash, ReceiptProof, ShardChunkHeader};
 use near_primitives::stateless_validation::{
     ChunkEndorsement, ChunkStateWitness, ChunkStateWitnessAck, ChunkStateWitnessSize,
-    EncodedChunkStateWitness,
 };
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;
@@ -753,11 +752,10 @@ impl Client {
     /// you can use the `processing_done_tracker` argument (but it's optional, it's safe to pass None there).
     pub fn process_chunk_state_witness(
         &mut self,
-        encoded_witness: EncodedChunkStateWitness,
+        witness: ChunkStateWitness,
+        raw_witness_size: ChunkStateWitnessSize,
         processing_done_tracker: Option<ProcessingDoneTracker>,
     ) -> Result<(), Error> {
-        let (witness, raw_witness_size) = self.decode_state_witness(&encoded_witness)?;
-
         tracing::debug!(
             target: "client",
             chunk_hash=?witness.chunk_header.chunk_hash(),
@@ -813,22 +811,5 @@ impl Client {
         }
 
         self.chunk_validator.start_validating_chunk(witness, &self.chain, processing_done_tracker)
-    }
-
-    fn decode_state_witness(
-        &self,
-        encoded_witness: &EncodedChunkStateWitness,
-    ) -> Result<(ChunkStateWitness, ChunkStateWitnessSize), Error> {
-        let decode_start = std::time::Instant::now();
-        let (witness, raw_witness_size) = encoded_witness.decode()?;
-        let decode_elapsed_seconds = decode_start.elapsed().as_secs_f64();
-        let witness_shard = witness.chunk_header.shard_id();
-
-        // Record metrics after validating the witness
-        metrics::CHUNK_STATE_WITNESS_DECODE_TIME
-            .with_label_values(&[&witness_shard.to_string()])
-            .observe(decode_elapsed_seconds);
-
-        Ok((witness, raw_witness_size))
     }
 }

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
@@ -204,7 +204,7 @@ impl PartialEncodedStateWitnessTracker {
             let (witness, raw_witness_size) = self.decode_state_witness(&encoded_witness)?;
             if witness.chunk_production_key() != key {
                 return Err(Error::InvalidPartialChunkStateWitness(format!(
-                    "Decoded witness key {:?} doesn't match partial witness metdata {:?}",
+                    "Decoded witness key {:?} doesn't match partial witness {:?}",
                     witness.chunk_production_key(),
                     key,
                 )));

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
@@ -9,7 +9,8 @@ use near_chain::Error;
 use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::reed_solomon::reed_solomon_decode;
 use near_primitives::stateless_validation::{
-    ChunkProductionKey, EncodedChunkStateWitness, PartialEncodedStateWitness,
+    ChunkProductionKey, ChunkStateWitness, ChunkStateWitnessSize, EncodedChunkStateWitness,
+    PartialEncodedStateWitness,
 };
 use near_primitives::types::ShardId;
 use reed_solomon_erasure::galois_8::ReedSolomon;
@@ -200,7 +201,16 @@ impl PartialEncodedStateWitnessTracker {
                 .with_label_values(&[entry.shard_id.to_string().as_str()])
                 .observe(entry.duration_to_last_part.as_seconds_f64());
 
-            self.client_sender.send(ChunkStateWitnessMessage(encoded_witness));
+            let (witness, raw_witness_size) = self.decode_state_witness(&encoded_witness)?;
+            if witness.chunk_production_key() != key {
+                return Err(Error::InvalidPartialChunkStateWitness(format!(
+                    "Decoded witness key {:?} doesn't match partial witness metdata {:?}",
+                    witness.chunk_production_key(),
+                    key,
+                )));
+            }
+
+            self.client_sender.send(ChunkStateWitnessMessage { witness, raw_witness_size });
         }
         self.record_total_parts_cache_size_metric();
         Ok(())
@@ -264,5 +274,17 @@ impl PartialEncodedStateWitnessTracker {
         let total_size: usize =
             self.parts_cache.iter().map(|(_, entry)| entry.total_parts_size).sum();
         metrics::PARTIAL_WITNESS_CACHE_SIZE.set(total_size as f64);
+    }
+
+    fn decode_state_witness(
+        &self,
+        encoded_witness: &EncodedChunkStateWitness,
+    ) -> Result<(ChunkStateWitness, ChunkStateWitnessSize), Error> {
+        let decode_start = std::time::Instant::now();
+        let (witness, raw_witness_size) = encoded_witness.decode()?;
+        metrics::CHUNK_STATE_WITNESS_DECODE_TIME
+            .with_label_values(&[&witness.chunk_header.shard_id().to_string()])
+            .observe(decode_start.elapsed().as_secs_f64());
+        Ok((witness, raw_witness_size))
     }
 }

--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -360,7 +360,7 @@ impl TestEnv {
                 let DistributeStateWitnessRequest { epoch_id, chunk_header, state_witness } =
                     request;
 
-                let raw_witness_size = state_witness.borsh_size();
+                let raw_witness_size = borsh::to_vec(&state_witness).unwrap().len();
                 let chunk_validators = self.clients[client_idx]
                     .epoch_manager
                     .get_chunk_validator_assignments(

--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -27,7 +27,7 @@ use near_primitives::epoch_manager::RngSeed;
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::{ChunkHash, PartialEncodedChunk};
-use near_primitives::stateless_validation::{ChunkEndorsement, EncodedChunkStateWitness};
+use near_primitives::stateless_validation::{ChunkEndorsement, ChunkStateWitness};
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::transaction::{Action, FunctionCallAction, SignedTransaction};
 use near_primitives::types::{AccountId, Balance, BlockHeight, EpochId, NumSeats, ShardId};
@@ -329,9 +329,8 @@ impl TestEnv {
     }
 
     fn found_differing_post_state_root_due_to_state_transitions(
-        encoded_witness: &EncodedChunkStateWitness,
+        witness: &ChunkStateWitness,
     ) -> bool {
-        let witness = encoded_witness.decode().unwrap().0;
         let mut post_state_roots = HashSet::from([witness.main_state_transition.post_state_root]);
         post_state_roots.extend(witness.implicit_transitions.iter().map(|t| t.post_state_root));
         post_state_roots.len() >= 2
@@ -360,8 +359,8 @@ impl TestEnv {
             while let Some(request) = partial_witness_adapter.pop_distribution_request() {
                 let DistributeStateWitnessRequest { epoch_id, chunk_header, state_witness } =
                     request;
-                let (encoded_witness, _) =
-                    EncodedChunkStateWitness::encode(&state_witness).unwrap();
+
+                let raw_witness_size = state_witness.borsh_size();
                 let chunk_validators = self.clients[client_idx]
                     .epoch_manager
                     .get_chunk_validator_assignments(
@@ -377,7 +376,8 @@ impl TestEnv {
                     witness_processing_done_waiters.push(processing_done_tracker.make_waiter());
 
                     let processing_result = self.client(&account_id).process_chunk_state_witness(
-                        encoded_witness.clone(),
+                        state_witness.clone(),
+                        raw_witness_size,
                         Some(processing_done_tracker),
                     );
                     if !allow_errors {
@@ -387,9 +387,7 @@ impl TestEnv {
 
                 // Update output.
                 output.found_differing_post_state_root_due_to_state_transitions |=
-                    Self::found_differing_post_state_root_due_to_state_transitions(
-                        &encoded_witness,
-                    );
+                    Self::found_differing_post_state_root_due_to_state_transitions(&state_witness);
             }
         }
 

--- a/core/primitives/src/stateless_validation.rs
+++ b/core/primitives/src/stateless_validation.rs
@@ -340,6 +340,13 @@ impl ChunkStateWitness {
         }
     }
 
+    /// Returns size in bytes of borsh-serialized state witness.
+    /// NOTE: this is potentially expensive operation and should only be
+    /// used in tests.
+    pub fn borsh_size(&self) -> ChunkStateWitnessSize {
+        borsh::to_vec(&self).unwrap().len()
+    }
+
     pub fn chunk_production_key(&self) -> ChunkProductionKey {
         ChunkProductionKey {
             shard_id: self.chunk_header.shard_id(),

--- a/core/primitives/src/stateless_validation.rs
+++ b/core/primitives/src/stateless_validation.rs
@@ -340,13 +340,6 @@ impl ChunkStateWitness {
         }
     }
 
-    /// Returns size in bytes of borsh-serialized state witness.
-    /// NOTE: this is potentially expensive operation and should only be
-    /// used in tests.
-    pub fn borsh_size(&self) -> ChunkStateWitnessSize {
-        borsh::to_vec(&self).unwrap().len()
-    }
-
     pub fn chunk_production_key(&self) -> ChunkProductionKey {
         ChunkProductionKey {
             shard_id: self.chunk_header.shard_id(),

--- a/integration-tests/src/tests/client/features/stateless_validation.rs
+++ b/integration-tests/src/tests/client/features/stateless_validation.rs
@@ -1,7 +1,7 @@
 use near_client::{ProcessTxResponse, ProduceChunkResult};
 use near_epoch_manager::{EpochManager, EpochManagerAdapter};
 use near_primitives::account::id::AccountIdRef;
-use near_primitives::stateless_validation::{ChunkStateWitness, EncodedChunkStateWitness};
+use near_primitives::stateless_validation::ChunkStateWitness;
 use near_store::test_utils::create_test_store;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -339,11 +339,11 @@ fn test_chunk_state_witness_bad_shard_id() {
     let previous_block = env.clients[0].chain.head().unwrap().prev_block_hash;
     let invalid_shard_id = 1000000000;
     let witness = ChunkStateWitness::new_dummy(upper_height, invalid_shard_id, previous_block);
-    let encoded_witness = EncodedChunkStateWitness::encode(&witness).unwrap().0;
+    let witness_size = witness.borsh_size();
 
     // Client should reject this ChunkStateWitness and the error message should mention "shard"
     tracing::info!(target: "test", "Processing invalid ChunkStateWitness");
-    let res = env.clients[0].process_chunk_state_witness(encoded_witness, None);
+    let res = env.clients[0].process_chunk_state_witness(witness, witness_size, None);
     let error = res.unwrap_err();
     let error_message = format!("{}", error).to_lowercase();
     tracing::info!(target: "test", "error message: {}", error_message);

--- a/integration-tests/src/tests/client/features/stateless_validation.rs
+++ b/integration-tests/src/tests/client/features/stateless_validation.rs
@@ -339,7 +339,7 @@ fn test_chunk_state_witness_bad_shard_id() {
     let previous_block = env.clients[0].chain.head().unwrap().prev_block_hash;
     let invalid_shard_id = 1000000000;
     let witness = ChunkStateWitness::new_dummy(upper_height, invalid_shard_id, previous_block);
-    let witness_size = witness.borsh_size();
+    let witness_size = borsh::to_vec(&witness).unwrap().len();
 
     // Client should reject this ChunkStateWitness and the error message should mention "shard"
     tracing::info!(target: "test", "Processing invalid ChunkStateWitness");


### PR DESCRIPTION
This PR implements check for partial state witness metadata fields (`epoch_id`, `shard_id`, `height_created`) after decoding complete state witness. This is needed to protect against malicious chunk producer providing incorrect metadata in the partial witness.

Large part of this PR is about moving state witness decoding (decompression + borsh-deserialization) from client to partial witness actor. This is required to implement the check, but also a nice change on its own since wintess decompression can take several dozens of milliseconds, so it is better to avoid blocking client actor.

Closes #11303.