### PR TITLE
Add protocol and chain id to telemetry data

### DIFF
--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -20,7 +20,7 @@ use near_primitives::types::{
 };
 use near_primitives::unwrap_or_return;
 use near_primitives::validator_signer::ValidatorSigner;
-use near_primitives::version::Version;
+use near_primitives::version::{Version, PROTOCOL_VERSION};
 use near_primitives::views::{
     CatchupStatusView, ChunkProcessingStatus, CurrentEpochValidatorInfo, EpochValidatorInfo,
     ValidatorKickoutView,
@@ -550,6 +550,7 @@ impl InfoHelper {
                 name: "near-rs".to_string(),
                 version: self.nearcore_version.version.clone(),
                 build: self.nearcore_version.build.clone(),
+                protocol_version: PROTOCOL_VERSION,
             },
             system: TelemetrySystemInfo {
                 bandwidth_download: network_info.received_bytes_per_sec,
@@ -559,6 +560,7 @@ impl InfoHelper {
                 boot_time_seconds: self.boot_time_seconds,
             },
             chain: TelemetryChainInfo {
+                chain_id: client_config.chain_id.clone(),
                 node_id: node_id.to_string(),
                 account_id: self.validator_signer.as_ref().map(|bp| bp.validator_id().clone()),
                 is_validator,

--- a/core/primitives/src/telemetry.rs
+++ b/core/primitives/src/telemetry.rs
@@ -9,6 +9,7 @@ pub struct TelemetryAgentInfo {
     pub name: String,
     pub version: String,
     pub build: String,
+    pub protocol_version: u32,
 }
 
 #[derive(serde::Serialize, Debug)]
@@ -22,6 +23,7 @@ pub struct TelemetrySystemInfo {
 
 #[derive(serde::Serialize, Debug)]
 pub struct TelemetryChainInfo {
+    pub chain_id: String,
     pub node_id: String,
     pub account_id: Option<AccountId>,
     pub is_validator: bool,


### PR DESCRIPTION
Adding protocol version information and chain_id to telemetry data.
Chain_id is required as currently we have no way of knowing what chain telemetry data source running.

https://github.com/near/nearcore/issues/4355

Tested with a http server to make sure data is correct. From debug logs:
`2024-05-31T15:13:30.356984Z DEBUG handle{handler="TelemetryEvent" actor="TelemetryActor>"}: telemetry: msg=TelemetryEvent { content: Object({"agent": Object({"build": String("1.36.1-666-g1fec7a712"), "name": String("near-rs"), "protocol_version": Number(67), "version": String("trunk")}), "chain": Object({"account_id": String("test.near"), "block_production_tracking_delay": Number(0.1), "chain_id": String("mycustomnetwork"), "is_validator": Bool(true), "latest_block_hash": String("4LtUMDUXvgtGcGakEDgLfyhqy4HbaZ4ikKAwY4APhg7s"), "latest_block_height": Number(498), "max_block_production_delay": Number(2.0), "max_block_wait_delay": Number(6.0), "min_block_production_delay": Number(0.6), "node_id": String("ed25519:Ef5EiGH7LUQmUnKpaaUQmaV4Q9TWUsBaySjysQm7jBJm"), "num_peers": Number(0), "status": String("NoSync")}), "extra_info": String("{\"block_production_tracking_delay\":0.1,\"max_block_production_delay\":2.0,\"max_block_wait_delay\":6.0,\"min_block_production_delay\":0.6}"), "signature": String("ed25519:4jqnEmkfrbKEy2GiUL4LbYTAmVv31GfyHcbnL1TvFGmUTfXP9gLBrU9XzMCSLKhuXxnqe2e44B2TAfrEDGHyaudf"), "system": Object({"bandwidth_download": Number(0), "bandwidth_upload": Number(0), "boot_time_seconds": Number(1717168320), "cpu_usage": Number(0.0), "memory_usage": Number(118259)})}) }`

From HTTP server logs:
`{'agent': {'build': '1.36.1-666-g1fec7a712', 'name': 'near-rs', 'protocol_version': 67, 'version': 'trunk'}, 'chain': {'account_id': 'test.near', 'block_production_tracking_delay': 0.1, 'chain_id': 'mynetwork', 'is_validator': True, 'latest_block_hash': 'Hw1Z4xhSHgbp1L1HGpGGMyMTy4v68XXEAoNeydD2dYCC', 'latest_block_height': 1439, 'max_block_production_delay': 2.0, 'max_block_wait_delay': 6.0, 'min_block_production_delay': 0.6, 'node_id': 'ed25519:Ef5EiGH7LUQmUnKpaaUQmaV4Q9TWUsBaySjysQm7jBJm', 'num_peers': 0, 'status': 'NoSync'}, 'extra_info': '{"block_production_tracking_delay":0.1,"max_block_production_delay":2.0,"max_block_wait_delay":6.0,"min_block_production_delay":0.6}', 'signature': 'ed25519:3FbS722gwL18CypnysEWwBvGyhPE9mKSYRQcmn4nC2AQA4w7Wze8yF7dFoo4tPq6Ho9yvVKLNiaNLBDonSanpBKA', 'system': {'bandwidth_download': 0, 'bandwidth_upload': 0, 'boot_time_seconds': 1717168480, 'cpu_usage': 0.0, 'memory_usage': 78872}}`
