### PR TITLE
[testloop] Convert TestLoopAsyncComputationSpawner to use CallbackEvent

### DIFF
--- a/core/async/src/test_loop/delay_sender.rs
+++ b/core/async/src/test_loop/delay_sender.rs
@@ -1,16 +1,15 @@
 use crate::break_apart::BreakApart;
 use crate::messaging;
 use crate::messaging::{IntoMultiSender, IntoSender};
-use crate::test_loop::futures::{
-    TestLoopAsyncComputationEvent, TestLoopAsyncComputationSpawner, TestLoopDelayedActionEvent,
-    TestLoopDelayedActionRunner,
-};
 use crate::time;
 use crate::time::Duration;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-use super::futures::{TestLoopFutureSpawner, TestLoopTask};
+use super::futures::{
+    TestLoopDelayedActionEvent, TestLoopDelayedActionRunner, TestLoopFutureSpawner, TestLoopTask,
+};
+use super::test_loop_sender::{CallbackEvent, TestLoopAsyncComputationSpawner};
 
 /// Interface to send an event with a delay (in virtual time). It can be
 /// converted to a Sender for any message type that can be converted into
@@ -97,10 +96,10 @@ impl<Event> DelaySender<Event> {
         artificial_delay: impl Fn(&str) -> Duration + Send + Sync + 'static,
     ) -> TestLoopAsyncComputationSpawner
     where
-        Event: From<TestLoopAsyncComputationEvent> + 'static,
+        Event: From<CallbackEvent> + 'static,
     {
         TestLoopAsyncComputationSpawner {
-            sender: self.narrow(),
+            pending_events_sender: self.narrow(),
             artificial_delay: Box::new(artificial_delay),
         }
     }

--- a/integration-tests/src/tests/client/features/simple_test_loop_example.rs
+++ b/integration-tests/src/tests/client/features/simple_test_loop_example.rs
@@ -1,8 +1,6 @@
 use derive_enum_from_into::{EnumFrom, EnumTryInto};
 use near_async::messaging::{noop, IntoMultiSender, IntoSender, LateBoundSender};
-use near_async::test_loop::futures::{
-    drive_async_computations, drive_futures, TestLoopAsyncComputationEvent, TestLoopTask,
-};
+use near_async::test_loop::futures::{drive_futures, TestLoopTask};
 use near_async::test_loop::test_loop_sender::{callback_event_handler, CallbackEvent};
 use near_async::test_loop::TestLoopBuilder;
 use near_async::time::Duration;
@@ -43,7 +41,6 @@ impl AsMut<TestData> for TestData {
 enum TestEvent {
     Callback(CallbackEvent),
     Task(Arc<TestLoopTask>),
-    AsyncComputation(TestLoopAsyncComputationEvent),
 }
 
 const ONE_NEAR: u128 = 1_000_000_000_000_000_000_000_000;
@@ -175,7 +172,6 @@ fn test_client_with_simple_test_loop() {
     let mut test = builder.build(data);
     test.register_handler(callback_event_handler().widen());
     test.register_handler(drive_futures().widen());
-    test.register_handler(drive_async_computations().widen());
 
     test.run_for(Duration::seconds(10));
     test.shutdown_and_drain_remaining_events(Duration::seconds(1));


### PR DESCRIPTION
Move towards shifting everything to using the CallbackEvent