### PR TITLE
fix(congestion_control) - set correct header protocol version

### DIFF
--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -488,13 +488,17 @@ pub fn validate_chunk_state_witness(
         }
     }
 
+    let parent_hash = state_witness.chunk_header.prev_block_hash();
+    let header_epoch_id = epoch_manager.get_epoch_id_from_prev_block(parent_hash)?;
+    let header_protocol_version = epoch_manager.get_epoch_protocol_version(&header_epoch_id)?;
+
     // Finally, verify that the newly proposed chunk matches everything we have computed.
     let (outgoing_receipts_root, _) = merklize(&outgoing_receipts_hashes);
     validate_chunk_with_chunk_extra_and_receipts_root(
         &chunk_extra,
         &state_witness.chunk_header,
         &outgoing_receipts_root,
-        protocol_version,
+        header_protocol_version,
     )?;
 
     Ok(())

--- a/chain/chain/src/validate.rs
+++ b/chain/chain/src/validate.rs
@@ -204,7 +204,10 @@ fn validate_congestion_info(
     // The congestion info should be Some iff the congestion control features is enabled.
     let enabled = ProtocolFeature::CongestionControl.enabled(header_protocol_version);
     if header_congestion_info.is_some() != enabled {
-        return Err(Error::InvalidCongestionInfo("Congestion Information is missing.".to_string()));
+        return Err(Error::InvalidCongestionInfo(format!(
+            "Congestion Information version mismatch. version {}, enabled: {}, info {:?}",
+            header_protocol_version, enabled, header_congestion_info
+        )));
     }
 
     match (extra_congestion_info, header_congestion_info) {


### PR DESCRIPTION
The header protocol version was not set correctly in the stateless validation context. It caused a mismatch between the congestion info in the header and congestion control not being enabled (in the wrong protocol version). 