### PR TITLE
Increase timeout for tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,5 @@
 [profile.default]
-slow-timeout = { period = "60s", terminate-after = 2, grace-period = "0s" }
+slow-timeout = { period = "60s", terminate-after = 3, grace-period = "0s" }
 
 [[profile.default.overrides]]
 filter = 'test(test_full_estimator)'


### PR DESCRIPTION
When I run `cargo nextest run --cargo-profile dev-release` I often get timeouts because some tests can run for more than 120 seconds:
```
        PASS [  45.690s] estimator-warehouse::bin/estimator-warehouse tests::test_full_estimator
        PASS [  48.150s] integration-tests tests::client::process_blocks::contract_precompilation_tests::test_two_deployments
        PASS [  40.543s] near-client tests::query_client::test_state_request
        PASS [  68.920s] integration-tests tests::client::sync_state_nodes::test_dump_epoch_missing_chunk_in_last_block
        PASS [ 131.637s] integration-tests tests::client::state_dump::test_state_sync_w_dumped_parts
```

This is annoying, when a test timeouts the test run is considered "failed" and it spams the whole console with test logs.

Let's increase the timeout duration to 3s so that the tests don't timeout.

