### PR TITLE
test(stateless_validation) - Implemented a protocol upgrade integration test

### DIFF
--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -781,6 +781,37 @@ impl TestEnv {
         let tx = self.tx_from_actions(actions, &signer, signer.account_id.clone());
         self.execute_tx(tx).unwrap()
     }
+
+    /// Print a short summary of all the blocks from genesis to head.
+    pub fn print_summary(&self) {
+        let client = &self.clients[0];
+
+        let genesis_height = client.chain.genesis().height();
+        let head_height = client.chain.head().unwrap().height;
+
+        tracing::info!(target: "test", genesis_height, head_height, "printing summary");
+        for height in genesis_height..head_height + 1 {
+            self.print_block_summary(height);
+        }
+    }
+
+    pub fn print_block_summary(&self, height: u64) {
+        let client = &self.clients[0];
+        let block = client.chain.get_block_by_height(height);
+        let Ok(block) = block else {
+            tracing::info!(target: "test", "Block {}: missing", height);
+            return;
+        };
+        let prev_hash = block.header().prev_hash();
+        let epoch_id = client.epoch_manager.get_epoch_id_from_prev_block(prev_hash).unwrap();
+        let protocol_version = client.epoch_manager.get_epoch_protocol_version(&epoch_id).unwrap();
+        let latest_protocol_version = block.header().latest_protocol_version();
+
+        let block_hash = block.hash();
+        let chunk_mask = block.header().chunk_mask();
+
+        tracing::info!(target: "test", height, ?block_hash, ?chunk_mask, protocol_version, latest_protocol_version, "block");
+    }
 }
 
 impl Drop for TestEnv {

--- a/integration-tests/src/tests/client/features/stateless_validation.rs
+++ b/integration-tests/src/tests/client/features/stateless_validation.rs
@@ -2,6 +2,7 @@ use near_client::{ProcessTxResponse, ProduceChunkResult};
 use near_epoch_manager::{EpochManager, EpochManagerAdapter};
 use near_primitives::account::id::AccountIdRef;
 use near_primitives::stateless_validation::ChunkStateWitness;
+use near_primitives::version::ProtocolFeature;
 use near_store::test_utils::create_test_store;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -19,17 +20,21 @@ use near_primitives::state_record::StateRecord;
 use near_primitives::test_utils::{create_test_signer, create_user_test_signer};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountInfo, EpochId};
+use near_primitives::version::{ProtocolVersion, PROTOCOL_VERSION};
 use near_primitives::views::FinalExecutionStatus;
 use near_primitives_core::account::{AccessKey, Account};
 use near_primitives_core::checked_feature;
 use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::{AccountId, NumSeats};
-use near_primitives_core::version::PROTOCOL_VERSION;
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
 
 const ONE_NEAR: u128 = 1_000_000_000_000_000_000_000_000;
 
-fn run_chunk_validation_test(seed: u64, prob_missing_chunk: f64) {
+fn run_chunk_validation_test(
+    seed: u64,
+    prob_missing_chunk: f64,
+    genesis_protocol_version: ProtocolVersion,
+) {
     init_integration_logger();
 
     if !checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION) {
@@ -56,7 +61,7 @@ fn run_chunk_validation_test(seed: u64, prob_missing_chunk: f64) {
     let mut genesis_config = GenesisConfig {
         // Use the latest protocol version. Otherwise, the version may be too
         // old that e.g. blocks don't even store previous heights.
-        protocol_version: PROTOCOL_VERSION,
+        protocol_version: genesis_protocol_version,
         // Some arbitrary starting height. Doesn't matter.
         genesis_height: 10000,
         shard_layout,
@@ -116,7 +121,7 @@ fn run_chunk_validation_test(seed: u64, prob_missing_chunk: f64) {
                 0,
                 CryptoHash::default(),
                 0,
-                PROTOCOL_VERSION,
+                genesis_protocol_version,
             ),
         });
         records.push(StateRecord::AccessKey {
@@ -225,25 +230,46 @@ fn run_chunk_validation_test(seed: u64, prob_missing_chunk: f64) {
     if prob_missing_chunk >= 0.8 {
         assert!(found_differing_post_state_root_due_to_state_transitions);
     }
+
+    // print some extra info to easy debugging
+    let genesis_height = genesis.config.genesis_height;
+    for i in 0..blocks_to_produce {
+        let client = &env.clients[0];
+        let height = genesis_height + i as u64;
+        let block = client.chain.get_block_by_height(height);
+        let Ok(block) = block else {
+            tracing::info!(target: "test", "Block {}: missing", height);
+            continue;
+        };
+        let prev_hash = block.header().prev_hash();
+        let epoch_id = client.epoch_manager.get_epoch_id_from_prev_block(prev_hash).unwrap();
+        let protocol_version = client.epoch_manager.get_epoch_protocol_version(&epoch_id).unwrap();
+
+        tracing::info!(target: "test", "Block {}-{}: {} -> {}", height, block.hash(), protocol_version, block.header().latest_protocol_version());
+    }
 }
 
 #[test]
 fn test_chunk_validation_no_missing_chunks() {
-    run_chunk_validation_test(42, 0.0);
+    run_chunk_validation_test(42, 0.0, PROTOCOL_VERSION);
 }
 
 #[test]
 fn test_chunk_validation_low_missing_chunks() {
-    run_chunk_validation_test(43, 0.3);
+    run_chunk_validation_test(43, 0.3, PROTOCOL_VERSION);
 }
 
-// This test fails because transactions are rejected when there are too many
-// missing chunks in a row.
-// TODO(congestion_control) - make congestion control configurable,
-// disable it here and re-enable this test
 #[test]
 fn test_chunk_validation_high_missing_chunks() {
-    run_chunk_validation_test(44, 0.81);
+    run_chunk_validation_test(44, 0.81, PROTOCOL_VERSION);
+}
+#[test]
+fn test_chunk_validation_protocol_upgrade() {
+    run_chunk_validation_test(
+        42,
+        0.0,
+        ProtocolFeature::StatelessValidationV0.protocol_version() - 1,
+    );
 }
 
 #[test]


### PR DESCRIPTION
This test performs a protocol upgrade from the version before StatelessValidationV0 to the binary's PROTOCOL_VERSION. This test would have caught the issue fixed in #11469. As is, in nightly, the test checks protocol upgrade from 79 to 143. 

Note that we also have protocol upgrade tests for congestion control. I think this test didn't catch the mentioned issue because it's configured with only one client and (I think) it automatically accepts its own chunks. It was much easier to reuse the stateless validation test configuration than to reimplement it in congestion control tests. Also this test seems generally useful. 