### PR TITLE
config(congestion_control) - set max_congestion_missed_chunks to 2

### DIFF
--- a/core/parameters/res/runtime_configs/87.yaml
+++ b/core/parameters/res/runtime_configs/87.yaml
@@ -31,10 +31,10 @@ max_congestion_memory_consumption: {
   old : 9_223_372_036_854_775_807,
   new : 1_000_000_000,
 }
-# 10 missed chunks
+# 2 missed chunks
 max_congestion_missed_chunks: { 
   old : 9_223_372_036_854_775_807,
-  new : 10,
+  new : 2,
 }
 
 # 300 PGAS

--- a/core/parameters/src/config.rs
+++ b/core/parameters/src/config.rs
@@ -130,7 +130,6 @@ pub struct CongestionControlConfig {
     pub max_congestion_memory_consumption: u64,
 
     /// How many missed chunks in a row in a shard is considered 100% congested.
-    /// TODO(congestion_control) - find a good limit for missed chunks.
     pub max_congestion_missed_chunks: u64,
 
     /// The maximum amount of gas attached to receipts a shard can forward to

--- a/core/primitives/src/congestion_info.rs
+++ b/core/primitives/src/congestion_info.rs
@@ -641,7 +641,11 @@ mod tests {
             return;
         }
 
-        let config = get_config();
+        // The default config is quite restricting, allow more missed chunks for
+        // this test to check the middle cases.
+        let mut config = get_config();
+        config.max_congestion_missed_chunks = 10;
+
         let info = CongestionInfo::default();
 
         // Test missed chunks congestion without any other congestion
@@ -684,7 +688,10 @@ mod tests {
             return;
         }
 
-        let config = get_config();
+        // The default config is quite restricting, allow more missed chunks for
+        // this test to check the middle cases.
+        let mut config = get_config();
+        config.max_congestion_missed_chunks = 10;
 
         // Setup half congested congestion info.
         let mut info = CongestionInfo::default();

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -262,7 +262,9 @@ fn test_cold_db_copy_with_height_skips() {
     let mut genesis = Genesis::test(vec![test0(), test1()], 1);
     genesis.config.epoch_length = epoch_length;
     genesis.config.min_gas_price = 0;
-    let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
+    let mut env = TestEnv::builder(&genesis.config)
+        .nightshade_runtimes_congestion_control_disabled(&genesis)
+        .build();
 
     let (storage, ..) = create_test_node_storage_with_cold(DB_VERSION, DbKind::Hot);
     let cold_db = storage.cold_db().unwrap();

--- a/nearcore/src/test_utils.rs
+++ b/nearcore/src/test_utils.rs
@@ -102,7 +102,8 @@ impl TestEnvNightshadeSetupExt for TestEnvBuilder {
                 state_snapshot_type.clone(),
             )
         };
-        let dummy_runtime_configs = vec![RuntimeConfigStore::test(); self.num_clients()];
+        let dummy_runtime_configs =
+            vec![RuntimeConfigStore::test_congestion_control_disabled(); self.num_clients()];
         self.internal_initialize_nightshade_runtimes(
             dummy_runtime_configs,
             trie_configs,


### PR DESCRIPTION
Setting the max_congestion_missed_chunks to 2. This means that at most 2 (+/-1) chunks worth of outgoing receipts can accumulate before all shards will stop forwarding any receipts to the shard with missing chunks. This is a relatively conservative limit to minimize the impact of incoming receipts on source_receipt_proofs size in the state witness. I expect it to have minimal impact on the total throughput of the chain since it's quite rare to see more than one missed chunk in a row. 

It's also worth noting that just having one missed chunk is a special case that will not increase the congestion level:
https://github.com/near/nearcore/blob/dd1e2786bac3622020f6e684e986eb426751600a/core/primitives/src/congestion_info.rs#L65-L68 