### PR TITLE
feat: add size check for state witness part

### DIFF
--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
@@ -345,10 +345,10 @@ impl PartialWitnessActor {
 
         let max_part_len =
             witness_part_length(MAX_CHUNK_STATE_WITNESS_SIZE.as_u64() as usize, num_parts);
-        if partial_witness.part_len() > max_part_len {
+        if partial_witness.part_size() > max_part_len {
             return Err(Error::InvalidPartialChunkStateWitness(format!(
                 "Part size {} exceed limit of {} (total parts: {})",
-                partial_witness.part_len(),
+                partial_witness.part_size(),
                 max_part_len,
                 num_parts
             )));

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
@@ -17,6 +17,7 @@ use near_primitives::reed_solomon::reed_solomon_encode;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::stateless_validation::{
     ChunkStateWitness, ChunkStateWitnessAck, EncodedChunkStateWitness, PartialEncodedStateWitness,
+    MAX_CHUNK_STATE_WITNESS_SIZE,
 };
 use near_primitives::types::{AccountId, BlockHeightDelta, EpochId};
 use near_primitives::validator_signer::ValidatorSigner;
@@ -26,7 +27,9 @@ use crate::client_actor::ClientSenderForPartialWitness;
 use crate::metrics;
 use crate::stateless_validation::state_witness_tracker::ChunkStateWitnessTracker;
 
-use super::partial_witness_tracker::{PartialEncodedStateWitnessTracker, RsMap};
+use super::partial_witness_tracker::{
+    witness_part_length, PartialEncodedStateWitnessTracker, RsMap,
+};
 
 pub struct PartialWitnessActor {
     /// Adapter to send messages to the network.
@@ -337,6 +340,17 @@ impl PartialWitnessActor {
             return Err(Error::InvalidPartialChunkStateWitness(format!(
                 "Invalid part_ord in PartialEncodedStateWitness: {}",
                 partial_witness.part_ord()
+            )));
+        }
+
+        let max_part_len =
+            witness_part_length(MAX_CHUNK_STATE_WITNESS_SIZE.as_u64() as usize, num_parts);
+        if partial_witness.part_len() > max_part_len {
+            return Err(Error::InvalidPartialChunkStateWitness(format!(
+                "Part size {} exceed limit of {} (total parts: {})",
+                partial_witness.part_len(),
+                max_part_len,
+                num_parts
             )));
         }
 

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
@@ -48,7 +48,7 @@ impl RsMap {
         self.rs_map
             .entry(total_parts)
             .or_insert_with(|| {
-                let data_parts = witness_data_parts(total_parts);
+                let data_parts = num_witness_data_parts(total_parts);
                 Arc::new(Some(ReedSolomon::new(data_parts, total_parts - data_parts).unwrap()))
             })
             .clone()
@@ -56,10 +56,10 @@ impl RsMap {
 }
 
 pub fn witness_part_length(encoded_witness_size: usize, total_parts: usize) -> usize {
-    reed_solomon_part_length(encoded_witness_size, witness_data_parts(total_parts))
+    reed_solomon_part_length(encoded_witness_size, num_witness_data_parts(total_parts))
 }
 
-fn witness_data_parts(total_parts: usize) -> usize {
+fn num_witness_data_parts(total_parts: usize) -> usize {
     std::cmp::max((total_parts as f32 * RATIO_DATA_PARTS) as usize, 1)
 }
 

--- a/core/primitives/src/reed_solomon.rs
+++ b/core/primitives/src/reed_solomon.rs
@@ -12,7 +12,7 @@ pub fn reed_solomon_encode<T: BorshSerialize>(
     let encoded_length = bytes.len();
 
     let data_parts = rs.data_shard_count();
-    let part_length = (encoded_length + data_parts - 1) / data_parts;
+    let part_length = reed_solomon_part_length(encoded_length, data_parts);
 
     // Pad the bytes to be a multiple of `part_length`
     // Convert encoded data into `data_shard_count` number of parts and pad with `parity_shard_count` None values
@@ -51,4 +51,8 @@ pub fn reed_solomon_decode<T: BorshDeserialize>(
         .collect_vec();
 
     T::try_from_slice(&encoded_data)
+}
+
+pub fn reed_solomon_part_length(encoded_length: usize, data_parts: usize) -> usize {
+    (encoded_length + data_parts - 1) / data_parts
 }

--- a/core/primitives/src/stateless_validation.rs
+++ b/core/primitives/src/stateless_validation.rs
@@ -97,7 +97,7 @@ impl PartialEncodedStateWitness {
         self.inner.part_ord
     }
 
-    pub fn part_len(&self) -> usize {
+    pub fn part_size(&self) -> usize {
         self.inner.part.len()
     }
 

--- a/core/primitives/src/stateless_validation.rs
+++ b/core/primitives/src/stateless_validation.rs
@@ -16,6 +16,9 @@ use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::{AccountId, Balance, BlockHeight, ShardId};
 use near_primitives_core::version::PROTOCOL_VERSION;
 
+// The value here is the same as NETWORK_MESSAGE_MAX_SIZE_BYTES.
+pub const MAX_CHUNK_STATE_WITNESS_SIZE: ByteSize = ByteSize::mib(512);
+
 /// An arbitrary static string to make sure that this struct cannot be
 /// serialized to look identical to another serialized struct. For chunk
 /// production we are signing a chunk hash, so we need to make sure that
@@ -94,6 +97,10 @@ impl PartialEncodedStateWitness {
         self.inner.part_ord
     }
 
+    pub fn part_len(&self) -> usize {
+        self.inner.part.len()
+    }
+
     /// Decomposes the partial witness to return (part_ord, part, encoded_length)
     pub fn decompose(self) -> (usize, Box<[u8]>, usize) {
         (self.inner.part_ord, self.inner.part, self.inner.encoded_length)
@@ -167,10 +174,7 @@ impl EncodedChunkStateWitness {
     /// Returns decoded witness along with the raw (uncompressed) witness size.
     pub fn decode(&self) -> std::io::Result<(ChunkStateWitness, ChunkStateWitnessSize)> {
         // We want to limit the size of decompressed data to address "Zip bomb" attack.
-        // The value here is the same as NETWORK_MESSAGE_MAX_SIZE_BYTES.
-        const MAX_WITNESS_SIZE: ByteSize = ByteSize::mib(512);
-
-        self.decode_with_limit(MAX_WITNESS_SIZE)
+        self.decode_with_limit(MAX_CHUNK_STATE_WITNESS_SIZE)
     }
 
     /// Decompress and borsh-deserialize encoded witness bytes.


### PR DESCRIPTION
This PR adds check a single witness part size based on max witness size. For now the limit is the same as max network message size, that will be adjusted in a separate PR.

Closes #11304.