### PR TITLE
debug-ui: show epoch heights and sort snapshot hosts

### DIFF
--- a/chain/client-primitives/src/debug.rs
+++ b/chain/client-primitives/src/debug.rs
@@ -25,6 +25,7 @@ pub struct TrackedShardsView {
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct EpochInfoView {
+    pub epoch_height: u64,
     pub epoch_id: CryptoHash,
     pub height: BlockHeight,
     pub first_block: Option<(CryptoHash, Utc)>,

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -286,6 +286,11 @@ impl ClientActorInner {
         };
         return Ok((
             EpochInfoView {
+                epoch_height: self
+                    .client
+                    .epoch_manager
+                    .get_epoch_info(&epoch_id)
+                    .map(|info| info.epoch_height())?,
                 epoch_id: epoch_id.0,
                 height: block.header().height(),
                 first_block: Some((*block.header().hash(), block.header().timestamp())),
@@ -312,6 +317,11 @@ impl ClientActorInner {
             self.get_producers_for_epoch(&head.next_epoch_id, &head.last_block_hash)?;
 
         Ok(EpochInfoView {
+            epoch_height: self
+                .client
+                .epoch_manager
+                .get_epoch_info(&head.next_epoch_id)
+                .map(|info| info.epoch_height())?,
             epoch_id: head.next_epoch_id.0,
             // Expected height of the next epoch.
             height: epoch_start_height + self.client.config.epoch_length,

--- a/tools/debug-ui/src/RecentEpochsView.tsx
+++ b/tools/debug-ui/src/RecentEpochsView.tsx
@@ -33,6 +33,7 @@ export const RecentEpochsView = ({ addr }: RecentEpochsViewProps) => {
             <thead>
                 <tr>
                     <th></th>
+                    <th>Epoch Height</th>
                     <th>Epoch ID</th>
                     <th>Start Height</th>
                     <th>Protocol Version</th>
@@ -77,6 +78,7 @@ export const RecentEpochsView = ({ addr }: RecentEpochsViewProps) => {
                     return (
                         <tr className={rowClassName} key={epochInfo.epoch_id}>
                             <td>{firstColumnText}</td>
+                            <td>{epochInfo.epoch_height}</td>
                             <td>{epochInfo.epoch_id}</td>
                             <td>{epochInfo.height}</td>
                             <td>{epochInfo.protocol_version}</td>

--- a/tools/debug-ui/src/SnapshotHostsView.tsx
+++ b/tools/debug-ui/src/SnapshotHostsView.tsx
@@ -20,7 +20,12 @@ export const SnapshotHostsView = ({ addr }: SnapshotHostsViewProps) => {
     }
 
     let snapshot_hosts = snapshotHosts!.status_response.SnapshotHosts.hosts;
-    snapshot_hosts.sort((a, b) => b.epoch_height - a.epoch_height);
+    snapshot_hosts.sort((a, b) => {
+        if (a.epoch_height != b.epoch_height) {
+            return b.epoch_height - a.epoch_height;
+        }
+        return a.peer_id.localeCompare(b.peer_id);
+    });
 
     return (
         <div className="snapshot-hosts-view">

--- a/tools/debug-ui/src/SnapshotHostsView.tsx
+++ b/tools/debug-ui/src/SnapshotHostsView.tsx
@@ -19,7 +19,8 @@ export const SnapshotHostsView = ({ addr }: SnapshotHostsViewProps) => {
         return <div className="error">{(error as Error).stack}</div>;
     }
 
-    const snapshot_hosts = snapshotHosts!.status_response.SnapshotHosts;
+    let snapshot_hosts = snapshotHosts!.status_response.SnapshotHosts.hosts;
+    snapshot_hosts.sort((a, b) => b.epoch_height - a.epoch_height);
 
     return (
         <div className="snapshot-hosts-view">
@@ -31,7 +32,7 @@ export const SnapshotHostsView = ({ addr }: SnapshotHostsViewProps) => {
                     <th>Sync Hash</th>
                 </thead>
                 <tbody>
-                    {snapshot_hosts.hosts.map((host) => {
+                    {snapshot_hosts.map((host) => {
                         return (
                             <tr key={host.peer_id}>
                                 <td>{host.peer_id}</td>

--- a/tools/debug-ui/src/api.tsx
+++ b/tools/debug-ui/src/api.tsx
@@ -172,6 +172,7 @@ export interface DebugChunkStatus {
 }
 
 export interface EpochInfoView {
+    epoch_height: number;
     epoch_id: string;
     height: number;
     first_block: null | [string, string];


### PR DESCRIPTION
Couple of minor improvements which help to understand the state of decentralized state sync.

![image](https://github.com/near/nearcore/assets/3241341/a3066017-3ad8-4d29-affb-bf8fabfee435)

