### PR TITLE
Don't charge extra for trie deletions outside of contract execution

### DIFF
--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -178,7 +178,7 @@ impl TrieUpdate {
         // This only applies to removals performed by the contracts. Removals performed
         // by the runtime are assumed to be non-malicious and we don't charge extra for them.
         if let Some(recorder) = &self.trie.recorder {
-            if matches!(trie_key, TrieKey::ContractCode { .. }) {
+            if matches!(trie_key, TrieKey::ContractData { .. }) {
                 recorder.borrow_mut().record_removal();
             }
         }


### PR DESCRIPTION
To limit the amount of storage proof generated during chunk application we calculate the upper bound estimation of how big the storage proof will be, and stop executing receipts when this estimated size gets to big. When estimating we assume that every trie removals generates 2000 bytes of storage proof, because this is the maximum size that a malicious attacker could generate (#11069, #10890).

This estimation was meant to limit the size of proof generated while executing receipts, but currently it also applies to other trie removals performed by the runtime, for example when removing receipts from the delayed receipt queue. This is really wasteful - removing 1000 receipts would cause the estimation to jump by 2MB, hitting the soft limit. We don't really need to charge this much for internal operations performed by the runtime, they aren't malicious. Let's change is so that only contracts are charged extra for removals. This will avoid the extra big estimation caused by normal queue manipulation.

Refs: https://near.zulipchat.com/#narrow/stream/308695-nearone.2Fprivate/topic/Large.20number.20of.20delayed.20receipts.20in.20statelessnet/near/442878068