### PR TITLE
fix(test) - fix flaky test 

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -167,6 +167,7 @@ impl NightshadeRuntime {
         compiled_contract_cache: Box<dyn ContractRuntimeCache>,
         genesis_config: &GenesisConfig,
         epoch_manager: Arc<EpochManagerHandle>,
+        runtime_config_store: Option<RuntimeConfigStore>,
         trie_config: TrieConfig,
         state_snapshot_type: StateSnapshotType,
     ) -> Arc<Self> {
@@ -177,7 +178,7 @@ impl NightshadeRuntime {
             epoch_manager,
             None,
             None,
-            None,
+            runtime_config_store,
             DEFAULT_GC_NUM_EPOCHS_TO_KEEP,
             trie_config,
             StateSnapshotConfig {

--- a/core/parameters/src/config.rs
+++ b/core/parameters/src/config.rs
@@ -203,7 +203,7 @@ impl CongestionControlConfig {
             allowed_shard_outgoing_gas: max_value,
             max_tx_gas: max_value,
             min_tx_gas: max_value,
-            reject_tx_congestion_threshold: 1.0,
+            reject_tx_congestion_threshold: 2.0,
         }
     }
 }

--- a/integration-tests/src/tests/client/features/multinode_stateless_validators.rs
+++ b/integration-tests/src/tests/client/features/multinode_stateless_validators.rs
@@ -288,6 +288,7 @@ fn test_stateless_validators_with_multi_test_loop() {
             contract_cache,
             &genesis.config,
             epoch_manager.clone(),
+            None,
             TrieConfig::from_store_config(&store_config),
             StateSnapshotType::EveryEpoch,
         );

--- a/integration-tests/src/tests/client/features/multinode_test_loop_example.rs
+++ b/integration-tests/src/tests/client/features/multinode_test_loop_example.rs
@@ -267,6 +267,7 @@ fn test_client_with_multi_test_loop() {
             contract_cache,
             &genesis.config,
             epoch_manager.clone(),
+            None,
             TrieConfig::from_store_config(&store_config),
             StateSnapshotType::EveryEpoch,
         );

--- a/nearcore/src/test_utils.rs
+++ b/nearcore/src/test_utils.rs
@@ -84,7 +84,7 @@ impl TestEnvNightshadeSetupExt for TestEnvBuilder {
                                           store: Store,
                                           contract_cache: Box<dyn ContractRuntimeCache>,
                                           epoch_manager: Arc<EpochManagerHandle>,
-                                          _,
+                                          runtime_config_store: RuntimeConfigStore,
                                           trie_config: TrieConfig|
          -> Arc<dyn RuntimeAdapter> {
             // TODO: It's not ideal to initialize genesis state with the nightshade runtime here for tests
@@ -98,6 +98,7 @@ impl TestEnvNightshadeSetupExt for TestEnvBuilder {
                 contract_cache,
                 &genesis.config,
                 epoch_manager,
+                Some(runtime_config_store),
                 trie_config,
                 state_snapshot_type.clone(),
             )


### PR DESCRIPTION
The `test_in_memory_trie_node_consistency` was failing occasionally because the config with disabled congestion control wasn't properly passed into the nightshade runtime. Also setting the threshold for rejecting transactions from 1 to 2 because otherwise some could still get rejected under full congestion. 