### PR TITLE
refactor: introduce partial witness encoding mod

### DIFF
--- a/chain/client/src/stateless_validation/partial_witness/encoding.rs
+++ b/chain/client/src/stateless_validation/partial_witness/encoding.rs
@@ -1,0 +1,99 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use near_primitives::reed_solomon::{
+    reed_solomon_decode, reed_solomon_encode, reed_solomon_part_length,
+};
+use near_primitives::stateless_validation::EncodedChunkStateWitness;
+use reed_solomon_erasure::galois_8::ReedSolomon;
+
+/// Ratio of the number of data parts to total parts in the Reed Solomon encoding.
+/// The tradeoff here is having a higher ratio is better for handling missing parts and network errors
+/// but increases the size of the encoded state witness and the total network bandwidth requirements.
+const RATIO_DATA_PARTS: f32 = 0.8;
+
+/// Type alias around what ReedSolomon represents data part as.
+/// This should help with making the code a bit more understandable.
+pub type WitnessPart = Option<Box<[u8]>>;
+
+/// Reed Solomon encoder wrapper for encoding and decoding state witness parts.
+pub struct WitnessEncoder {
+    /// None corresponds to the case when we are the only validator for the chunk
+    /// since ReedSolomon does not support having exactly 1 total part count and
+    /// no parity parts.
+    rs: Option<ReedSolomon>,
+}
+
+impl WitnessEncoder {
+    pub fn new(total_parts: usize) -> WitnessEncoder {
+        let rs = if total_parts > 1 {
+            let data_parts = num_witness_data_parts(total_parts);
+            Some(ReedSolomon::new(data_parts, total_parts - data_parts).unwrap())
+        } else {
+            None
+        };
+        Self { rs }
+    }
+
+    pub fn total_parts(&self) -> usize {
+        match self.rs {
+            Some(ref rs) => rs.total_shard_count(),
+            None => 1,
+        }
+    }
+
+    pub fn data_parts(&self) -> usize {
+        match self.rs {
+            Some(ref rs) => rs.data_shard_count(),
+            None => 1,
+        }
+    }
+
+    pub fn encode(&self, witness: &EncodedChunkStateWitness) -> (Vec<WitnessPart>, usize) {
+        match self.rs {
+            Some(ref rs) => reed_solomon_encode(rs, witness),
+            None => {
+                (vec![Some(witness.as_slice().to_vec().into_boxed_slice())], witness.size_bytes())
+            }
+        }
+    }
+
+    pub fn decode(
+        &self,
+        parts: &mut [WitnessPart],
+        encoded_length: usize,
+    ) -> Result<EncodedChunkStateWitness, std::io::Error> {
+        match self.rs {
+            Some(ref rs) => reed_solomon_decode(rs, parts, encoded_length),
+            None => {
+                Ok(EncodedChunkStateWitness::from_boxed_slice(parts[0].as_ref().unwrap().clone()))
+            }
+        }
+    }
+}
+
+/// We keep one encoder for each length of chunk_validators to avoid re-creating the encoder.
+pub struct WitnessEncoderCache {
+    instances: HashMap<usize, Arc<WitnessEncoder>>,
+}
+
+impl WitnessEncoderCache {
+    pub fn new() -> Self {
+        Self { instances: HashMap::new() }
+    }
+
+    pub fn entry(&mut self, total_parts: usize) -> Arc<WitnessEncoder> {
+        self.instances
+            .entry(total_parts)
+            .or_insert_with(|| Arc::new(WitnessEncoder::new(total_parts)))
+            .clone()
+    }
+}
+
+pub fn witness_part_length(encoded_witness_size: usize, total_parts: usize) -> usize {
+    reed_solomon_part_length(encoded_witness_size, num_witness_data_parts(total_parts))
+}
+
+fn num_witness_data_parts(total_parts: usize) -> usize {
+    std::cmp::max((total_parts as f32 * RATIO_DATA_PARTS) as usize, 1)
+}

--- a/chain/client/src/stateless_validation/partial_witness/mod.rs
+++ b/chain/client/src/stateless_validation/partial_witness/mod.rs
@@ -1,2 +1,3 @@
+mod encoding;
 pub mod partial_witness_actor;
 mod partial_witness_tracker;

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
@@ -13,7 +13,6 @@ use near_network::state_witness::{
 use near_network::types::{NetworkRequests, PeerManagerAdapter, PeerManagerMessageRequest};
 use near_performance_metrics_macros::perf;
 use near_primitives::block::Tip;
-use near_primitives::reed_solomon::reed_solomon_encode;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::stateless_validation::{
     ChunkStateWitness, ChunkStateWitnessAck, EncodedChunkStateWitness, PartialEncodedStateWitness,
@@ -27,9 +26,8 @@ use crate::client_actor::ClientSenderForPartialWitness;
 use crate::metrics;
 use crate::stateless_validation::state_witness_tracker::ChunkStateWitnessTracker;
 
-use super::partial_witness_tracker::{
-    witness_part_length, PartialEncodedStateWitnessTracker, RsMap,
-};
+use super::encoding::{witness_part_length, WitnessEncoderCache};
+use super::partial_witness_tracker::PartialEncodedStateWitnessTracker;
 
 pub struct PartialWitnessActor {
     /// Adapter to send messages to the network.
@@ -44,7 +42,7 @@ pub struct PartialWitnessActor {
     state_witness_tracker: ChunkStateWitnessTracker,
     /// Reed Solomon encoder for encoding state witness parts.
     /// We keep one wrapper for each length of chunk_validators to avoid re-creating the encoder.
-    rs_map: RsMap,
+    encoders: WitnessEncoderCache,
     /// Currently used to find the chain HEAD when validating partial witnesses,
     /// but should be removed if we implement retrieving this info from the client
     store: Store,
@@ -118,7 +116,7 @@ impl PartialWitnessActor {
             epoch_manager,
             partial_witness_tracker,
             state_witness_tracker: ChunkStateWitnessTracker::new(clock),
-            rs_map: RsMap::new(),
+            encoders: WitnessEncoderCache::new(),
             store,
         }
     }
@@ -169,16 +167,8 @@ impl PartialWitnessActor {
         chunk_validators: Vec<AccountId>,
     ) -> Vec<(AccountId, PartialEncodedStateWitness)> {
         // Break the state witness into parts using Reed Solomon encoding.
-        let rs = self.rs_map.entry(chunk_validators.len());
-
-        // For the case when we are the only validator for the chunk, we don't need to do Reed Solomon encoding.
-        let (parts, encoded_length) = match rs.as_ref() {
-            Some(rs) => reed_solomon_encode(&rs, witness_bytes),
-            None => (
-                vec![Some(witness_bytes.as_slice().to_vec().into_boxed_slice())],
-                witness_bytes.size_bytes(),
-            ),
-        };
+        let encoder = self.encoders.entry(chunk_validators.len());
+        let (parts, encoded_length) = encoder.encode(&witness_bytes);
 
         chunk_validators
             .iter()


### PR DESCRIPTION
This PR includes the following:
* Move everything related to partial witness reed solomon encoding to a separate module
* Introduce wrapper around `Option<ReedSolomon>` to encapsulate logic around handling a single part which is currently spread around the codebase.  