### PR TITLE
feat: adjust witness size limits

### DIFF
--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
@@ -17,7 +17,7 @@ use near_primitives::reed_solomon::reed_solomon_encode;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::stateless_validation::{
     ChunkStateWitness, ChunkStateWitnessAck, EncodedChunkStateWitness, PartialEncodedStateWitness,
-    MAX_CHUNK_STATE_WITNESS_SIZE,
+    MAX_COMPRESSED_STATE_WITNESS_SIZE,
 };
 use near_primitives::types::{AccountId, BlockHeightDelta, EpochId};
 use near_primitives::validator_signer::ValidatorSigner;
@@ -344,7 +344,7 @@ impl PartialWitnessActor {
         }
 
         let max_part_len =
-            witness_part_length(MAX_CHUNK_STATE_WITNESS_SIZE.as_u64() as usize, num_parts);
+            witness_part_length(MAX_COMPRESSED_STATE_WITNESS_SIZE.as_u64() as usize, num_parts);
         if partial_witness.part_size() > max_part_len {
             return Err(Error::InvalidPartialChunkStateWitness(format!(
                 "Part size {} exceed limit of {} (total parts: {})",

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
@@ -20,7 +20,9 @@ use crate::metrics;
 
 /// Max number of chunks to keep in the witness tracker cache. We reach here only after validation
 /// of the partial_witness so the LRU cache size need not be too large.
-const WITNESS_PARTS_CACHE_SIZE: usize = 200;
+/// This effectively limits memory usage to the size of the cache multiplied by
+/// MAX_COMPRESSED_STATE_WITNESS_SIZE, currently 40 * 32MiB = 1280MiB
+const WITNESS_PARTS_CACHE_SIZE: usize = 40;
 
 /// Number of entries to keep in LRU cache of the processed state witnesses
 /// We only store small amount of data (ChunkProductionKey) per entry there,

--- a/core/primitives/src/stateless_validation.rs
+++ b/core/primitives/src/stateless_validation.rs
@@ -22,7 +22,7 @@ pub const MAX_COMPRESSED_STATE_WITNESS_SIZE: ByteSize = ByteSize::mib(32);
 
 /// Represents max allowed size of the raw (not compressed) state witness,
 /// corresponds to the size of borsh-serialized ChunkStateWitness.
-pub const MAX_RAW_STATE_WITNESS_SIZE: ByteSize = ByteSize::mib(64);
+pub const MAX_UNCOMPRESSED_STATE_WITNESS_SIZE: ByteSize = ByteSize::mib(64);
 
 /// An arbitrary static string to make sure that this struct cannot be
 /// serialized to look identical to another serialized struct. For chunk
@@ -179,7 +179,7 @@ impl EncodedChunkStateWitness {
     /// Returns decoded witness along with the raw (uncompressed) witness size.
     pub fn decode(&self) -> std::io::Result<(ChunkStateWitness, ChunkStateWitnessSize)> {
         // We want to limit the size of decompressed data to address "Zip bomb" attack.
-        self.decode_with_limit(MAX_RAW_STATE_WITNESS_SIZE)
+        self.decode_with_limit(MAX_UNCOMPRESSED_STATE_WITNESS_SIZE)
     }
 
     /// Decompress and borsh-deserialize encoded witness bytes.

--- a/core/primitives/src/stateless_validation.rs
+++ b/core/primitives/src/stateless_validation.rs
@@ -16,8 +16,13 @@ use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::{AccountId, Balance, BlockHeight, ShardId};
 use near_primitives_core::version::PROTOCOL_VERSION;
 
-// The value here is the same as NETWORK_MESSAGE_MAX_SIZE_BYTES.
-pub const MAX_CHUNK_STATE_WITNESS_SIZE: ByteSize = ByteSize::mib(512);
+/// Represents max allowed size of the compressed state witness,
+/// corresponds to EncodedChunkStateWitness struct size.
+pub const MAX_COMPRESSED_STATE_WITNESS_SIZE: ByteSize = ByteSize::mib(32);
+
+/// Represents max allowed size of the raw (not compressed) state witness,
+/// corresponds to the size of borsh-serialized ChunkStateWitness.
+pub const MAX_RAW_STATE_WITNESS_SIZE: ByteSize = ByteSize::mib(64);
 
 /// An arbitrary static string to make sure that this struct cannot be
 /// serialized to look identical to another serialized struct. For chunk
@@ -174,7 +179,7 @@ impl EncodedChunkStateWitness {
     /// Returns decoded witness along with the raw (uncompressed) witness size.
     pub fn decode(&self) -> std::io::Result<(ChunkStateWitness, ChunkStateWitnessSize)> {
         // We want to limit the size of decompressed data to address "Zip bomb" attack.
-        self.decode_with_limit(MAX_CHUNK_STATE_WITNESS_SIZE)
+        self.decode_with_limit(MAX_RAW_STATE_WITNESS_SIZE)
     }
 
     /// Decompress and borsh-deserialize encoded witness bytes.


### PR DESCRIPTION
This PR includes the following:
* Set size limit for compressed witness to 32MiB. This is at least twice as big as the witness we expected to handle, so it give us quite some safety margin.
* Set size limit for the compressed witness to 64MiB. Same as above, this values give us pretty big margin on top of witness sizes we expect.
* Reduce partial witness cache size to 40 entries to limit memory usage at ~1.3GiB. 40 entries should be more than enough to handle all kinds of crazy chain forks 🙃 