### PR TITLE
fix(doc): fix errors encountered during cargo doc and a few warnings

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -3,7 +3,7 @@
 //! pass the control to Client. This means, any real block processing or production logic should
 //! be put in Client.
 //! Unfortunately, this is not the case today. We are in the process of refactoring ClientActor
-//! https://github.com/near/nearcore/issues/7899
+//! <https://github.com/near/nearcore/issues/7899>
 
 #[cfg(feature = "test_features")]
 use crate::client::AdvProduceBlocksMode;

--- a/chain/client/src/sync/state.rs
+++ b/chain/client/src/sync/state.rs
@@ -1,6 +1,6 @@
 //! State sync is trying to fetch the 'full state' from the peers (which can be multiple GB).
 //! It happens after HeaderSync and before BlockSync (but only if the node sees that it is 'too much behind').
-//! See https://near.github.io/nearcore/architecture/how/sync.html for more detailed information.
+//! See <https://near.github.io/nearcore/architecture/how/sync.html> for more detailed information.
 //! Such state can be downloaded only at special heights (currently - at the beginning of the current and previous
 //! epochs).
 //!

--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -478,7 +478,7 @@ impl TestEnv {
     }
 
     /// This function used to be able to upgrade to a specific protocol version
-    /// but due to https://github.com/near/nearcore/issues/8590 that
+    /// but due to <https://github.com/near/nearcore/issues/8590> that
     /// functionality does not work currently.  Hence it is renamed to upgrade
     /// to the latest version.
     pub fn upgrade_protocol_to_latest_version(&mut self) {

--- a/core/parameters/src/config.rs
+++ b/core/parameters/src/config.rs
@@ -136,16 +136,16 @@ pub struct CongestionControlConfig {
     /// another shard per chunk.
     ///
     /// The actual gas forwarding allowance is a linear interpolation between
-    /// [`CongestionControlConfig::min_outgoing_gas`] and
-    /// [`CongestionControlConfig::max_outgoing_gas`], or 0 if the receiver is
+    /// [MIN_OUTGOING_GAS](CongestionControlConfig::min_outgoing_gas) and
+    /// [MAX_OUTGOING_GAS](CongestionControlConfig::max_outgoing_gas), or 0 if the receiver is
     /// fully congested.
     pub max_outgoing_gas: Gas,
 
     /// The minimum gas each shard can send to a shard that is not fully congested.
     ///
     /// The actual gas forwarding allowance is a linear interpolation between
-    /// [`CongestionControlConfig::min_outgoing_gas`] and
-    /// [`CongestionControlConfig::max_outgoing_gas`], or 0 if the receiver is
+    /// [MIN_OUTGOING_GAS](CongestionControlConfig::min_outgoing_gas) and
+    /// [MAX_OUTGOING_GAS](CongestionControlConfig::max_outgoing_gas), or 0 if the receiver is
     /// fully congested.
     pub min_outgoing_gas: Gas,
 
@@ -162,24 +162,26 @@ pub struct CongestionControlConfig {
     /// receipts.
     ///
     /// The actual gas forwarding allowance is a linear interpolation between
-    /// [`CongestionControlConfig::min_tx_gas`] and
-    /// [`CongestionControlConfig::max_tx_gas`], based on the incoming congestion of the
-    /// local shard. Additionally, transactions can be rejected if the receiving
+    /// [MIN_OUTGOING_GAS](CongestionControlConfig::min_outgoing_gas) and
+    /// [MAX_OUTGOING_GAS](CongestionControlConfig::max_outgoing_gas),
+    /// based on the incoming congestion of the local shard.
+    /// Additionally, transactions can be rejected if the receiving
     /// remote shard is congested more than
-    /// [`CongestionControlConfig::reject_tx_congestion_threshold`] based
-    /// on their general congestion level.
+    /// [REJECT_TX_CONGESTION_THRESHOLD](CongestionControlConfig::reject_tx_congestion_threshold)
+    /// based on their general congestion level.
     pub max_tx_gas: Gas,
 
     /// The minimum amount of gas in a chunk spent on converting new transactions
     /// to receipts, as long as the receiving shard is not congested.
     ///
     /// The actual gas forwarding allowance is a linear interpolation between
-    /// [`CongestionControlConfig::min_tx_gas`] and
-    /// [`CongestionControlConfig::max_tx_gas`], based on the incoming congestion of the
-    /// local shard. Additionally, transactions can be rejected if the receiving
+    /// [MIN_OUTGOING_GAS](CongestionControlConfig::min_outgoing_gas) and
+    /// [MAX_OUTGOING_GAS](CongestionControlConfig::max_outgoing_gas),
+    /// based on the incoming congestion of the local shard.
+    /// Additionally, transactions can be rejected if the receiving
     /// remote shard is congested more than
-    /// [`CongestionControlConfig::reject_tx_congestion_threshold`] based
-    /// on their general congestion level.
+    /// [REJECT_TX_CONGESTION_THRESHOLD](CongestionControlConfig::reject_tx_congestion_threshold)
+    /// based on their general congestion level.
     pub min_tx_gas: Gas,
 
     /// How much congestion a shard can tolerate before it stops all shards from

--- a/core/parameters/src/config.rs
+++ b/core/parameters/src/config.rs
@@ -136,14 +136,16 @@ pub struct CongestionControlConfig {
     /// another shard per chunk.
     ///
     /// The actual gas forwarding allowance is a linear interpolation between
-    /// [`MIN_OUTGOING_GAS`] and [`MAX_OUTGOING_GAS`], or 0 if the receiver is
+    /// [`CongestionControlConfig::min_outgoing_gas`] and
+    /// [`CongestionControlConfig::max_outgoing_gas`], or 0 if the receiver is
     /// fully congested.
     pub max_outgoing_gas: Gas,
 
     /// The minimum gas each shard can send to a shard that is not fully congested.
     ///
     /// The actual gas forwarding allowance is a linear interpolation between
-    /// [`MIN_OUTGOING_GAS`] and [`MAX_OUTGOING_GAS`], or 0 if the receiver is
+    /// [`CongestionControlConfig::min_outgoing_gas`] and
+    /// [`CongestionControlConfig::max_outgoing_gas`], or 0 if the receiver is
     /// fully congested.
     pub min_outgoing_gas: Gas,
 
@@ -160,9 +162,11 @@ pub struct CongestionControlConfig {
     /// receipts.
     ///
     /// The actual gas forwarding allowance is a linear interpolation between
-    /// [`MIN_TX_GAS`] and [`MAX_TX_GAS`], based on the incoming congestion of the
+    /// [`CongestionControlConfig::min_tx_gas`] and
+    /// [`CongestionControlConfig::max_tx_gas`], based on the incoming congestion of the
     /// local shard. Additionally, transactions can be rejected if the receiving
-    /// remote shard is congested more than [`REJECT_TX_CONGESTION_THRESHOLD`] based
+    /// remote shard is congested more than
+    /// [`CongestionControlConfig::reject_tx_congestion_threshold`] based
     /// on their general congestion level.
     pub max_tx_gas: Gas,
 
@@ -170,9 +174,11 @@ pub struct CongestionControlConfig {
     /// to receipts, as long as the receiving shard is not congested.
     ///
     /// The actual gas forwarding allowance is a linear interpolation between
-    /// [`MIN_TX_GAS`] and [`MAX_TX_GAS`], based on the incoming congestion of the
+    /// [`CongestionControlConfig::min_tx_gas`] and
+    /// [`CongestionControlConfig::max_tx_gas`], based on the incoming congestion of the
     /// local shard. Additionally, transactions can be rejected if the receiving
-    /// remote shard is congested more than [`REJECT_TX_CONGESTION_THRESHOLD`] based
+    /// remote shard is congested more than
+    /// [`CongestionControlConfig::reject_tx_congestion_threshold`] based
     /// on their general congestion level.
     pub min_tx_gas: Gas,
 

--- a/core/parameters/src/view.rs
+++ b/core/parameters/src/view.rs
@@ -210,27 +210,27 @@ pub struct VMConfigView {
     /// Gas cost of a regular operation.
     pub regular_op_cost: u32,
 
-    /// See [`VMConfig::vm_kind`].
+    /// See [VMConfig::vm_kind](crate::vm::Config::vm_kind).
     pub vm_kind: crate::vm::VMKind,
-    /// See [`VMConfig::disable_9393_fix`].
+    /// See [VMConfig::disable_9393_fix](crate::vm::Config::disable_9393_fix).
     pub disable_9393_fix: bool,
-    /// See [`VMConfig::flat_storage_reads`].
+    /// See [VMConfig::storage_get_mode](crate::vm::Config::storage_get_mode).
     pub storage_get_mode: crate::vm::StorageGetMode,
-    /// See [`VMConfig::fix_contract_loading_cost`].
+    /// See [VMConfig::fix_contract_loading_cost](crate::vm::Config::fix_contract_loading_cost).
     pub fix_contract_loading_cost: bool,
-    /// See [`VMConfig::implicit_account_creation`].
+    /// See [VMConfig::implicit_account_creation](crate::vm::Config::implicit_account_creation).
     pub implicit_account_creation: bool,
-    /// See [`VMConfig::math_extension`].
+    /// See [VMConfig::math_extension](crate::vm::Config::math_extension).
     pub math_extension: bool,
-    /// See [`VMConfig::ed25519_verify`].
+    /// See [VMConfig::ed25519_verify](crate::vm::Config::ed25519_verify).
     pub ed25519_verify: bool,
-    /// See [`VMConfig::alt_bn128`].
+    /// See [VMConfig::alt_bn128](crate::vm::Config::alt_bn128).
     pub alt_bn128: bool,
-    /// See [`VMConfig::function_call_weight`].
+    /// See [VMConfig::function_call_weight](crate::vm::Config::function_call_weight).
     pub function_call_weight: bool,
-    /// See [`VMConfig::eth_implicit_accounts`].
+    /// See [VMConfig::eth_implicit_accounts](crate::vm::Config::eth_implicit_accounts).
     pub eth_implicit_accounts: bool,
-    /// See [`VMConfig::yield_resume_host_functions`].
+    /// See [VMConfig::yield_resume_host_functions](`crate::vm::Config::yield_resume_host_functions).
     pub yield_resume_host_functions: bool,
 
     /// Describes limits for VM and Runtime.

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -86,24 +86,24 @@ pub enum ProtocolFeature {
     MaxKickoutStake,
     /// Validate account id for function call access keys.
     AccountIdInFunctionCallPermission,
-    /// Zero Balance Account NEP 448: https://github.com/near/NEPs/pull/448
+    /// Zero Balance Account NEP 448: <https://github.com/near/NEPs/pull/448>
     ZeroBalanceAccount,
     /// Execute a set of actions on behalf of another account.
     ///
-    /// Meta Transaction NEP-366: https://github.com/near/NEPs/blob/master/neps/nep-0366.md
+    /// Meta Transaction NEP-366: <https://github.com/near/NEPs/blob/master/neps/nep-0366.md>
     DelegateAction,
     Ed25519Verify,
     /// Decouple compute and gas costs of operations to safely limit the compute time it takes to
     /// process the chunk.
     ///
-    /// Compute Costs NEP-455: https://github.com/near/NEPs/blob/master/neps/nep-0455.md
+    /// Compute Costs NEP-455: <https://github.com/near/NEPs/blob/master/neps/nep-0455.md>
     ComputeCosts,
     /// Decrease the cost of function call action. Only affects the execution cost.
     DecreaseFunctionCallBaseCost,
     /// Enable flat storage for reads, reducing number of DB accesses from `2 * key.len()` in
     /// the worst case to 2.
     ///
-    /// Flat Storage NEP-399: https://github.com/near/NEPs/blob/master/neps/nep-0399.md
+    /// Flat Storage NEP-399: <https://github.com/near/NEPs/blob/master/neps/nep-0399.md>
     FlatStorageReads,
     /// Enables preparation V2. Note that this setting is not supported in production settings
     /// without NearVmRuntime enabled alongside it, as the VM runner would be too slow.
@@ -128,16 +128,16 @@ pub enum ProtocolFeature {
     #[cfg(feature = "protocol_feature_reject_blocks_with_outdated_protocol_version")]
     RejectBlocksWithOutdatedProtocolVersions,
     /// Allows creating an account with a non refundable balance to cover storage costs.
-    /// NEP: https://github.com/near/NEPs/pull/491
+    /// NEP: <https://github.com/near/NEPs/pull/491>
     #[cfg(feature = "protocol_feature_nonrefundable_transfer_nep491")]
     NonrefundableStorage,
     RestrictTla,
     /// Increases the number of chunk producers.
     TestnetFewerBlockProducers,
-    /// Enables stateless validation which is introduced in https://github.com/near/NEPs/pull/509
+    /// Enables stateless validation which is introduced in <https://github.com/near/NEPs/pull/509>
     StatelessValidationV0,
     EthImplicitAccounts,
-    /// Enables yield execution which is introduced in https://github.com/near/NEPs/pull/519
+    /// Enables yield execution which is introduced in <https://github.com/near/NEPs/pull/519>
     YieldExecution,
 
     /// Protocol version reserved for use in resharding tests.
@@ -155,7 +155,7 @@ pub enum ProtocolFeature {
     // Receipts which generate storage proofs larger than this limit will be rejected.
     // Protocol 85 also decreased the soft per-chunk storage proof limit to 3MB.
     PerReceiptHardStorageProofLimit,
-    /// Cross-shard congestion control according to https://github.com/near/NEPs/pull/539.
+    /// Cross-shard congestion control according to <https://github.com/near/NEPs/pull/539>.
     CongestionControl,
     // Stateless validation: Distribute state witness as reed solomon encoded parts
     PartialEncodedStateWitness,

--- a/core/primitives/src/action/delegate.rs
+++ b/core/primitives/src/action/delegate.rs
@@ -1,6 +1,6 @@
 //! DelegateAction is a type of action to support meta transactions.
 //!
-//! NEP: https://github.com/near/NEPs/pull/366
+//! NEP: <https://github.com/near/NEPs/pull/366>
 //! This is the module containing the types introduced for delegate actions.
 
 pub use self::private_non_delegate_action::NonDelegateAction;

--- a/core/primitives/src/state.rs
+++ b/core/primitives/src/state.rs
@@ -74,7 +74,7 @@ impl FlatStateValue {
     /// in FlatState as `FlatStateValue::Ref`, otherwise the whole value will be
     /// stored as `FlatStateValue::Inlined`.
     /// See the following comment for reasoning behind the threshold value:
-    /// https://github.com/near/nearcore/issues/8243#issuecomment-1523049994
+    /// <https://github.com/near/nearcore/issues/8243#issuecomment-1523049994>
     pub const INLINE_DISK_VALUE_THRESHOLD: usize = 4000;
 
     pub fn on_disk(value: &[u8]) -> Self {

--- a/runtime/near-test-contracts/src/lib.rs
+++ b/runtime/near-test-contracts/src/lib.rs
@@ -90,7 +90,7 @@ pub fn fuzzing_contract() -> &'static [u8] {
 /// NEP-141 implementation (fungible token contract).
 ///
 /// The code is available here:
-/// https://github.com/near/near-sdk-rs/tree/master/examples/fungible-token
+/// <https://github.com/near/near-sdk-rs/tree/master/examples/fungible-token>
 ///
 /// We keep a static WASM of this for our integration tests. We don't have to
 /// update it with every SDK release, any contract implementing the interface

--- a/runtime/near-vm/test-generator/src/lib.rs
+++ b/runtime/near-vm/test-generator/src/lib.rs
@@ -4,7 +4,7 @@
 //! to automatically run the files in parallel.
 //!
 //! > This program is inspired/forked from:
-//! > https://github.com/bytecodealliance/wasmtime/blob/master/build.rs
+//! > <https://github.com/bytecodealliance/wasmtime/blob/master/build.rs>
 mod processors;
 
 pub use crate::processors::{emscripten_processor, wasi_processor, wast_processor};

--- a/runtime/near-vm/vm/src/vmoffsets.rs
+++ b/runtime/near-vm/vm/src/vmoffsets.rs
@@ -451,11 +451,11 @@ impl VMOffsets {
 
 /// Offsets for [`VMSharedSignatureIndex`].
 ///
-/// [`VMSharedSignatureIndex`]: crate::vmcontext::VMSharedSignatureIndex
+/// [`VMSharedSignatureIndex`]: crate::sig_registry::VMSharedSignatureIndex
 impl VMOffsets {
     /// Return the size of [`VMSharedSignatureIndex`].
     ///
-    /// [`VMSharedSignatureIndex`]: crate::vmcontext::VMSharedSignatureIndex
+    /// [`VMSharedSignatureIndex`]: crate::sig_registry::VMSharedSignatureIndex
     pub const fn size_of_vmshared_signature_index(&self) -> u8 {
         4
     }
@@ -588,7 +588,7 @@ impl VMOffsets {
 
     /// Return the offset to [`VMSharedSignatureIndex`] index `index`.
     ///
-    /// [`VMSharedSignatureIndex`]: crate::vmcontext::VMSharedSignatureIndex
+    /// [`VMSharedSignatureIndex`]: crate::sig_registry::VMSharedSignatureIndex
     // Remember updating precompute upon changes
     pub fn vmctx_vmshared_signature_id(&self, index: SignatureIndex) -> u32 {
         assert_lt!(index.as_u32(), self.num_signature_ids);

--- a/tools/congestion-model/src/lib.rs
+++ b/tools/congestion-model/src/lib.rs
@@ -32,7 +32,7 @@ pub const GAS_LIMIT: GGas = 1000 * TGAS;
 /// design of Near Protocol.
 ///
 /// The TX gas limit has been hard-coded to gas_limit / 2 for years.
-/// https://github.com/near/nearcore/blob/ac5cba2e7a7507aecce09cbd0152641e986ea381/chain/chain/src/runtime/mod.rs#L709
+/// <https://github.com/near/nearcore/blob/ac5cba2e7a7507aecce09cbd0152641e986ea381/chain/chain/src/runtime/mod.rs#L709>
 ///
 /// Changing this could be part of a congestion strategy.
 pub const TX_GAS_LIMIT: GGas = 500 * TGAS;


### PR DESCRIPTION
Fixes the errors I got while running `cargo doc`. Also fixes some (not all 😄) warnings. 
I checked that the changes look fine in the rendered documentation.