### PR TITLE
[ft-benchmark] run locust in nohup

### DIFF
--- a/scripts/ft-benchmark.sh
+++ b/scripts/ft-benchmark.sh
@@ -41,7 +41,7 @@ export KEY=~/.near/localnet/node0/validator_key.json
 
 # Run benchmark
 cd pytest/tests/loadtest/locust/
-locust -H 127.0.0.1:3030  -f locustfiles/ft.py --funding-key=$KEY -u 1000 -r 10 --processes 8 --headless
+nohup locust -H 127.0.0.1:3030  -f locustfiles/ft.py --funding-key=$KEY -u 1000 -r 10 --processes 8 --headless &
 
 # Give locust 5 minutes to start and rump up
 sleep 300


### PR DESCRIPTION
Without running locust in nohup, shell script waits until locust finish and only after this run data sender