### PR TITLE
chore: make target_validator_mandates_per_shard configurable

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -1316,6 +1316,8 @@ impl RuntimeAdapter for NightshadeRuntime {
             epoch_config.chunk_producer_kickout_threshold;
         genesis_config.chunk_validator_only_kickout_threshold =
             epoch_config.chunk_validator_only_kickout_threshold;
+        genesis_config.target_validator_mandates_per_shard =
+            epoch_config.target_validator_mandates_per_shard;
         genesis_config.max_kickout_stake_perc = epoch_config.validator_max_kickout_stake_perc;
         genesis_config.online_min_threshold = epoch_config.online_min_threshold;
         genesis_config.online_max_threshold = epoch_config.online_max_threshold;

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -487,6 +487,7 @@ impl EpochManagerAdapter for MockEpochManager {
             block_producer_kickout_threshold: 0,
             chunk_producer_kickout_threshold: 0,
             chunk_validator_only_kickout_threshold: 0,
+            target_validator_mandates_per_shard: 1,
             validator_max_kickout_stake_perc: 0,
             online_min_threshold: Ratio::new(1i32, 4i32),
             online_max_threshold: Ratio::new(3i32, 4i32),

--- a/chain/epoch-manager/src/shard_tracker.rs
+++ b/chain/epoch-manager/src/shard_tracker.rs
@@ -230,6 +230,7 @@ mod tests {
             block_producer_kickout_threshold: 90,
             chunk_producer_kickout_threshold: 60,
             chunk_validator_only_kickout_threshold: 60,
+            target_validator_mandates_per_shard: 1,
             fishermen_threshold: 0,
             online_max_threshold: Ratio::from_integer(1),
             online_min_threshold: Ratio::new(90, 100),

--- a/chain/epoch-manager/src/test_utils.rs
+++ b/chain/epoch-manager/src/test_utils.rs
@@ -141,7 +141,7 @@ pub fn epoch_config_with_production_config(
         block_producer_kickout_threshold,
         chunk_producer_kickout_threshold,
         chunk_validator_only_kickout_threshold,
-        target_validator_mandates_per_shard: 1,
+        target_validator_mandates_per_shard: 68,
         fishermen_threshold: 0,
         online_min_threshold: Ratio::new(90, 100),
         online_max_threshold: Ratio::new(99, 100),

--- a/chain/epoch-manager/src/test_utils.rs
+++ b/chain/epoch-manager/src/test_utils.rs
@@ -141,6 +141,7 @@ pub fn epoch_config_with_production_config(
         block_producer_kickout_threshold,
         chunk_producer_kickout_threshold,
         chunk_validator_only_kickout_threshold,
+        target_validator_mandates_per_shard: 1,
         fishermen_threshold: 0,
         online_min_threshold: Ratio::new(90, 100),
         online_max_threshold: Ratio::new(99, 100),

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -2206,6 +2206,7 @@ fn test_protocol_version_switch_with_many_seats() {
         block_producer_kickout_threshold: 90,
         chunk_producer_kickout_threshold: 60,
         chunk_validator_only_kickout_threshold: 60,
+        target_validator_mandates_per_shard: 10,
         fishermen_threshold: 0,
         online_min_threshold: Ratio::new(90, 100),
         online_max_threshold: Ratio::new(99, 100),

--- a/chain/epoch-manager/src/validator_selection.rs
+++ b/chain/epoch-manager/src/validator_selection.rs
@@ -275,10 +275,11 @@ pub fn proposals_to_epoch_info(
     // Assign chunk validators to shards using validator mandates abstraction.
     let validator_mandates = if checked_feature!("stable", StatelessValidationV0, protocol_version)
     {
-        // Value chosen based on calculations for the security of the protocol.
+        // Default production value chosen to 68 based on calculations for the
+        // security of the mainnet protocol.
         // With this number of mandates per shard and 6 shards, the theory calculations predict the
         // protocol is secure for 40 years (at 90% confidence).
-        let target_mandates_per_shard = 68;
+        let target_mandates_per_shard = epoch_config.target_validator_mandates_per_shard as usize;
         let num_shards = shard_ids.len();
         let validator_mandates_config =
             ValidatorMandatesConfig::new(target_mandates_per_shard, num_shards);

--- a/chain/epoch-manager/src/validator_selection.rs
+++ b/chain/epoch-manager/src/validator_selection.rs
@@ -1277,6 +1277,7 @@ mod tests {
             block_producer_kickout_threshold: 0,
             chunk_producer_kickout_threshold: 0,
             chunk_validator_only_kickout_threshold: 0,
+            target_validator_mandates_per_shard: 1,
             validator_max_kickout_stake_perc: 100,
             online_min_threshold: 0.into(),
             online_max_threshold: 0.into(),

--- a/chain/epoch-manager/src/validator_selection.rs
+++ b/chain/epoch-manager/src/validator_selection.rs
@@ -1278,7 +1278,7 @@ mod tests {
             block_producer_kickout_threshold: 0,
             chunk_producer_kickout_threshold: 0,
             chunk_validator_only_kickout_threshold: 0,
-            target_validator_mandates_per_shard: 1,
+            target_validator_mandates_per_shard: 68,
             validator_max_kickout_stake_perc: 100,
             online_min_threshold: 0.into(),
             online_max_threshold: 0.into(),

--- a/chain/jsonrpc/jsonrpc-tests/res/genesis_config.json
+++ b/chain/jsonrpc/jsonrpc-tests/res/genesis_config.json
@@ -22,6 +22,7 @@
   "block_producer_kickout_threshold": 90,
   "chunk_producer_kickout_threshold": 90,
   "chunk_validator_only_kickout_threshold": 80,
+  "target_validator_mandates_per_shard": 0,
   "online_min_threshold": [
     9,
     10

--- a/chain/jsonrpc/jsonrpc-tests/res/genesis_config.json
+++ b/chain/jsonrpc/jsonrpc-tests/res/genesis_config.json
@@ -22,7 +22,7 @@
   "block_producer_kickout_threshold": 90,
   "chunk_producer_kickout_threshold": 90,
   "chunk_validator_only_kickout_threshold": 80,
-  "target_validator_mandates_per_shard": 0,
+  "target_validator_mandates_per_shard": 68,
   "online_min_threshold": [
     9,
     10

--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -48,6 +48,10 @@ fn default_chunk_validator_only_kickout_threshold() -> u8 {
     80
 }
 
+fn default_target_validator_mandates_per_shard() -> NumSeats {
+    68
+}
+
 fn default_minimum_stake_divisor() -> u64 {
     10
 }
@@ -139,6 +143,8 @@ pub struct GenesisConfig {
     /// Threshold for kicking out nodes which are only chunk validators, between 0 and 100.
     #[serde(default = "default_chunk_validator_only_kickout_threshold")]
     pub chunk_validator_only_kickout_threshold: u8,
+    #[serde(default = "default_target_validator_mandates_per_shard")]
+    pub target_validator_mandates_per_shard: NumSeats,
     /// Online minimum threshold below which validator doesn't receive reward.
     #[serde(default = "default_online_min_threshold")]
     #[default(Rational32::new(90, 100))]
@@ -245,6 +251,7 @@ impl From<&GenesisConfig> for EpochConfig {
             block_producer_kickout_threshold: config.block_producer_kickout_threshold,
             chunk_producer_kickout_threshold: config.chunk_producer_kickout_threshold,
             chunk_validator_only_kickout_threshold: config.chunk_validator_only_kickout_threshold,
+            target_validator_mandates_per_shard: config.target_validator_mandates_per_shard,
             fishermen_threshold: config.fishermen_threshold,
             online_min_threshold: config.online_min_threshold,
             online_max_threshold: config.online_max_threshold,
@@ -805,6 +812,7 @@ pub struct ProtocolConfigView {
     pub chunk_producer_kickout_threshold: u8,
     /// Threshold for kicking out nodes which are only chunk validators, between 0 and 100.
     pub chunk_validator_only_kickout_threshold: u8,
+    pub target_validator_mandates_per_shard: NumSeats,
     /// Online minimum threshold below which validator doesn't receive reward.
     pub online_min_threshold: Rational32,
     /// Online maximum threshold above which validator gets full reward.
@@ -874,6 +882,7 @@ impl From<ProtocolConfig> for ProtocolConfigView {
             chunk_producer_kickout_threshold: genesis_config.chunk_producer_kickout_threshold,
             chunk_validator_only_kickout_threshold: genesis_config
                 .chunk_validator_only_kickout_threshold,
+            target_validator_mandates_per_shard: genesis_config.target_validator_mandates_per_shard,
             online_min_threshold: genesis_config.online_min_threshold,
             online_max_threshold: genesis_config.online_max_threshold,
             gas_price_adjustment_rate: genesis_config.gas_price_adjustment_rate,

--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -143,7 +143,9 @@ pub struct GenesisConfig {
     /// Threshold for kicking out nodes which are only chunk validators, between 0 and 100.
     #[serde(default = "default_chunk_validator_only_kickout_threshold")]
     pub chunk_validator_only_kickout_threshold: u8,
+    /// Number of chunk validator mandates for each shard.
     #[serde(default = "default_target_validator_mandates_per_shard")]
+    #[default(68)]
     pub target_validator_mandates_per_shard: NumSeats,
     /// Online minimum threshold below which validator doesn't receive reward.
     #[serde(default = "default_online_min_threshold")]
@@ -812,6 +814,7 @@ pub struct ProtocolConfigView {
     pub chunk_producer_kickout_threshold: u8,
     /// Threshold for kicking out nodes which are only chunk validators, between 0 and 100.
     pub chunk_validator_only_kickout_threshold: u8,
+    /// Number of chunk validator mandates for each shard.
     pub target_validator_mandates_per_shard: NumSeats,
     /// Online minimum threshold below which validator doesn't receive reward.
     pub online_min_threshold: Rational32,
@@ -1096,6 +1099,7 @@ mod test {
               "block_producer_kickout_threshold": 90,
               "chunk_producer_kickout_threshold": 90,
               "chunk_validator_only_kickout_threshold": 80,
+              "target_validator_mandates_per_shard": 68,
               "online_min_threshold": [
                 9,
                 10
@@ -1222,6 +1226,7 @@ mod test {
               "block_producer_kickout_threshold": 90,
               "chunk_producer_kickout_threshold": 90,
               "chunk_validator_only_kickout_threshold": 80,
+              "target_validator_mandates_per_shard": 68,
               "online_min_threshold": [
                 9,
                 10

--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -143,7 +143,7 @@ pub struct GenesisConfig {
     /// Threshold for kicking out nodes which are only chunk validators, between 0 and 100.
     #[serde(default = "default_chunk_validator_only_kickout_threshold")]
     pub chunk_validator_only_kickout_threshold: u8,
-    /// Number of chunk validator mandates for each shard.
+    /// Number of target chunk validator mandates for each shard.
     #[serde(default = "default_target_validator_mandates_per_shard")]
     #[default(68)]
     pub target_validator_mandates_per_shard: NumSeats,
@@ -814,7 +814,7 @@ pub struct ProtocolConfigView {
     pub chunk_producer_kickout_threshold: u8,
     /// Threshold for kicking out nodes which are only chunk validators, between 0 and 100.
     pub chunk_validator_only_kickout_threshold: u8,
-    /// Number of chunk validator mandates for each shard.
+    /// Number of target chunk validator mandates for each shard.
     pub target_validator_mandates_per_shard: NumSeats,
     /// Online minimum threshold below which validator doesn't receive reward.
     pub online_min_threshold: Rational32,

--- a/core/chain-configs/src/test_genesis.rs
+++ b/core/chain-configs/src/test_genesis.rs
@@ -41,6 +41,7 @@ pub struct TestGenesisBuilder {
     transaction_validity_period: Option<NumBlocks>,
     validators: Option<ValidatorsSpec>,
     minimum_validators_per_shard: Option<NumSeats>,
+    target_validator_mandates_per_shard: Option<NumSeats>,
     protocol_treasury_account: Option<String>,
     shuffle_shard_assignment_for_chunk_producers: Option<bool>,
     kickouts_config: Option<KickoutsConfig>,
@@ -205,6 +206,14 @@ impl TestGenesisBuilder {
         self
     }
 
+    pub fn target_validator_mandates_per_shard(
+        &mut self,
+        target_validator_mandates_per_shard: NumSeats,
+    ) -> &mut Self {
+        self.target_validator_mandates_per_shard = Some(target_validator_mandates_per_shard);
+        self
+    }
+
     /// Specifies the protocol treasury account. If not specified, this will
     /// pick an arbitrary account name and ensure that it is included in the
     /// genesis records.
@@ -325,6 +334,15 @@ impl TestGenesisBuilder {
             );
             default
         });
+        let target_validator_mandates_per_shard =
+            self.target_validator_mandates_per_shard.unwrap_or_else(|| {
+                let default = 68;
+                tracing::warn!(
+                    "Genesis minimum_validators_per_shard not explicitly set, defaulting to {:?}.",
+                    default
+                );
+                default
+            });
         let protocol_treasury_account: AccountId = self
             .protocol_treasury_account
             .clone()
@@ -446,6 +464,7 @@ impl TestGenesisBuilder {
             chunk_producer_kickout_threshold: kickouts_config.chunk_producer_kickout_threshold,
             chunk_validator_only_kickout_threshold: kickouts_config
                 .chunk_validator_only_kickout_threshold,
+            target_validator_mandates_per_shard,
             transaction_validity_period,
             protocol_version,
             protocol_treasury_account,

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -39,7 +39,7 @@ pub struct EpochConfig {
     pub chunk_producer_kickout_threshold: u8,
     /// Threshold for kicking out nodes which are only chunk validators.
     pub chunk_validator_only_kickout_threshold: u8,
-    /// Number of chunk validator mandates for each shard.
+    /// Number of target chunk validator mandates for each shard.
     pub target_validator_mandates_per_shard: NumSeats,
     /// Max ratio of validators that we can kick out in an epoch
     pub validator_max_kickout_stake_perc: u8,

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -39,6 +39,8 @@ pub struct EpochConfig {
     pub chunk_producer_kickout_threshold: u8,
     /// Threshold for kicking out nodes which are only chunk validators.
     pub chunk_validator_only_kickout_threshold: u8,
+    /// Number of chunk validator mandates per each shard.
+    pub target_validator_mandates_per_shard: NumSeats,
     /// Max ratio of validators that we can kick out in an epoch
     pub validator_max_kickout_stake_perc: u8,
     /// Online minimum threshold below which validator doesn't receive reward.

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -39,7 +39,7 @@ pub struct EpochConfig {
     pub chunk_producer_kickout_threshold: u8,
     /// Threshold for kicking out nodes which are only chunk validators.
     pub chunk_validator_only_kickout_threshold: u8,
-    /// Number of chunk validator mandates per each shard.
+    /// Number of chunk validator mandates for each shard.
     pub target_validator_mandates_per_shard: NumSeats,
     /// Max ratio of validators that we can kick out in an epoch
     pub validator_max_kickout_stake_perc: u8,

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -533,6 +533,7 @@ mod tests {
                 block_producer_kickout_threshold: 0,
                 chunk_producer_kickout_threshold: 0,
                 chunk_validator_only_kickout_threshold: 0,
+                target_validator_mandates_per_shard: 0,
                 validator_max_kickout_stake_perc: 0,
                 online_min_threshold: 0.into(),
                 online_max_threshold: 0.into(),

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -792,6 +792,7 @@ impl ForkNetworkCommand {
             block_producer_kickout_threshold: 0,
             chunk_producer_kickout_threshold: 0,
             chunk_validator_only_kickout_threshold: 0,
+            target_validator_mandates_per_shard: epoch_config.target_validator_mandates_per_shard,
             max_kickout_stake_perc: 0,
             online_min_threshold: epoch_config.online_min_threshold,
             online_max_threshold: epoch_config.online_max_threshold,

--- a/utils/mainnet-res/res/mainnet_genesis.json
+++ b/utils/mainnet-res/res/mainnet_genesis.json
@@ -17,6 +17,7 @@
   "block_producer_kickout_threshold": 90,
   "chunk_producer_kickout_threshold": 90,
   "chunk_validator_only_kickout_threshold": 80,
+  "target_validator_mandates_per_shard": 68,
   "online_min_threshold": [
     90,
     100


### PR DESCRIPTION
It would be very convenient to set this value to 1 in tests to ensure that most of validators are assigned to validate only one chunk, so we have better control to test rewards and kickouts. Adding this field to genesis until it's not too late.