### PR TITLE
wasmtime: remove lightbeam support code

### DIFF
--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -120,15 +120,9 @@ impl IntoVMError for anyhow::Error {
     }
 }
 
-#[cfg(not(feature = "lightbeam"))]
 #[allow(clippy::needless_pass_by_ref_mut)]
 pub fn get_engine(config: &mut wasmtime::Config) -> Engine {
     Engine::new(config).unwrap()
-}
-
-#[cfg(feature = "lightbeam")]
-pub fn get_engine(config: &mut wasmtime::Config) -> Engine {
-    Engine::new(config.strategy(wasmtime::Strategy::Lightbeam).unwrap()).unwrap()
 }
 
 pub(crate) fn wasmtime_vm_hash() -> u64 {

--- a/runtime/runtime-params-estimator/compiler.sh
+++ b/runtime/runtime-params-estimator/compiler.sh
@@ -9,12 +9,6 @@ if [ "$1" == "wasmtime" ]; then
   VMKIND="$1";
   features="$features"
 fi
-if [ "$1" == "lightbeam" ]; then
-  VMKIND="wasmtime"
-  features="$features,lightbeam"
-fi
-
-
 
 set -ex
 

--- a/runtime/runtime-params-estimator/estimate.sh
+++ b/runtime/runtime-params-estimator/estimate.sh
@@ -7,7 +7,7 @@ features="required"
 
 if [[ ! -z "$1" ]]; then
   features="$features,$1"
-  if [[ "$1" == *"wasmtime"* || "$1" == *"lightbeam"* ]]; then
+  if [[ "$1" == *"wasmtime"* ]]; then
     vmkind="wasmtime";
   fi
 fi


### PR DESCRIPTION
Lightbeam backend has been removed from wasmtime all the way back in 2021. The supporting code we have here won't build, and we don't test it either.

https://github.com/bytecodealliance/wasmtime/pull/3390