### PR TITLE
fix(nayduck) - fix slow_chunk test - bypass congestion control

### DIFF
--- a/pytest/tests/sanity/slow_chunk.py
+++ b/pytest/tests/sanity/slow_chunk.py
@@ -50,6 +50,10 @@ class SlowChunkTest(unittest.TestCase):
             client_config_changes,
         )
 
+        # The chain is slow to warm up. Wait until the chain is ready otherwise
+        # the missing chunks congestion will kick in due to missing blocks.
+        list(poll_blocks(rpc, __target=10))
+
         self.__deploy_contract(rpc)
 
         self.__call_contract(rpc)


### PR DESCRIPTION
At the beginning of the test there are a few missing blocks leading to congestion control kicking in and rejecting the transactions. I added a few blocks wait to allow the chain to warm up before starting the actual test. 