### PR TITLE
 fix(nayduck) - fix congestion control test - configure timeouts 

### DIFF
--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -643,10 +643,11 @@ impl JsonRpcHandler {
         .map_err(|_| {
             metrics::RPC_TIMEOUT_TOTAL.inc();
             tracing::warn!(
-                target: "jsonrpc", "Timeout: tx_status_fetch method. tx_info {:?} fetch_receipt {:?} result {:?}",
+                target: "jsonrpc", "Timeout: tx_status_fetch method. tx_info {:?} fetch_receipt {:?} result {:?} timeout {:?}",
                 tx_info,
                 fetch_receipt,
-                tx_status_result
+                tx_status_result,
+                self.polling_config.polling_timeout,
             );
             near_jsonrpc_primitives::types::transactions::RpcTransactionError::TimeoutError
         })?


### PR DESCRIPTION
The default timeouts introduced in #11397 mean that a failing requests will take about 1 minute to complete including the timeouts. In the congestion control test we intentionally overload the chain and expect that some transactions will be rejected. Combined this means that the test would take 20 minutes to complete. The fix is to better configure the timeouts and retries in the nayduck infra. 