### PR TITLE
Structs for contract execution error

### DIFF
--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -1,11 +1,21 @@
 use near_async::time::Utc;
 use near_primitives::block::BlockValidityError;
 use near_primitives::challenge::{ChunkProofs, ChunkState};
-use near_primitives::errors::{EpochError, StorageError};
+use near_primitives::errors::{EpochError, FunctionCallError, StorageError};
 use near_primitives::shard_layout::ShardLayoutError;
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
 use near_primitives::types::{BlockHeight, EpochId, ShardId};
 use std::io;
+
+#[derive(Debug)]
+pub enum HostError {
+    GuestPanic { panic_msg: String },
+}
+
+#[derive(Debug)]
+pub enum MyFunctionCallError {
+    HostError(HostError),
+}
 
 #[derive(thiserror::Error, Debug)]
 pub enum QueryError {
@@ -41,9 +51,9 @@ pub enum QueryError {
         block_height: near_primitives::types::BlockHeight,
         block_hash: near_primitives::hash::CryptoHash,
     },
-    #[error("Function call returned an error: {error_message}")]
+    #[error("Function call returned an error: the message haha")]
     ContractExecutionError {
-        error_message: String,
+        error_message: MyFunctionCallError,
         block_height: near_primitives::types::BlockHeight,
         block_hash: near_primitives::hash::CryptoHash,
     },

--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -15,6 +15,7 @@ pub enum HostError {
 #[derive(Debug)]
 pub enum MyFunctionCallError {
     HostError(HostError),
+    OtherError(String),
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/chain/chain/src/runtime/errors.rs
+++ b/chain/chain/src/runtime/errors.rs
@@ -1,3 +1,5 @@
+use near_chain_primitives::error::{HostError, MyFunctionCallError};
+
 use crate::near_chain_primitives::error::QueryError;
 
 #[easy_ext::ext(FromStateViewerErrors)]
@@ -18,7 +20,7 @@ impl QueryError {
                 error_message,
             } => Self::InternalError { error_message, block_height, block_hash },
             node_runtime::state_viewer::errors::CallFunctionError::VMError { error_message } => {
-                Self::ContractExecutionError { error_message, block_height, block_hash }
+                Self::ContractExecutionError { error_message: MyFunctionCallError::HostError(HostError::GuestPanic { panic_msg: "this is  my panic".to_string() }), block_height, block_hash }
             }
         }
     }

--- a/chain/chain/src/runtime/errors.rs
+++ b/chain/chain/src/runtime/errors.rs
@@ -20,7 +20,13 @@ impl QueryError {
                 error_message,
             } => Self::InternalError { error_message, block_height, block_hash },
             node_runtime::state_viewer::errors::CallFunctionError::VMError { error_message } => {
-                Self::ContractExecutionError { error_message: MyFunctionCallError::HostError(HostError::GuestPanic { panic_msg: "this is  my panic".to_string() }), block_height, block_hash }
+                let error = match error_message {
+                    node_runtime::state_viewer::errors::FunctionCallError::HostError(node_runtime::state_viewer::errors::HostError::GuestPanic { panic_msg }) => {
+                        MyFunctionCallError::HostError(HostError::GuestPanic { panic_msg })
+                    }
+                    _ => MyFunctionCallError::HostError(HostError::GuestPanic { panic_msg: "this is  my panic 2".to_string() }),
+                };
+                Self::ContractExecutionError { error_message: error, block_height, block_hash }
             }
         }
     }

--- a/chain/chain/src/runtime/errors.rs
+++ b/chain/chain/src/runtime/errors.rs
@@ -24,7 +24,7 @@ impl QueryError {
                     node_runtime::state_viewer::errors::FunctionCallError::HostError(node_runtime::state_viewer::errors::HostError::GuestPanic { panic_msg }) => {
                         MyFunctionCallError::HostError(HostError::GuestPanic { panic_msg })
                     }
-                    _ => MyFunctionCallError::HostError(HostError::GuestPanic { panic_msg: "this is  my panic 2".to_string() }),
+                    _ => MyFunctionCallError::OtherError(format!("wasm execution failed with error: {:?}", error_message)),
                 };
                 Self::ContractExecutionError { error_message: error, block_height, block_hash }
             }

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -485,6 +485,16 @@ impl From<near_chain_primitives::Error> for GetChunkError {
     }
 }
 
+#[derive(Debug)]
+pub enum HostError3 {
+    GuestPanic3 { panic_msg: String },
+}
+
+#[derive(Debug)]
+pub enum MyFunctionCallError3 {
+    HostError3(HostError3),
+}
+
 /// Queries client for given path / data.
 #[derive(Clone, Debug)]
 pub struct Query {
@@ -544,7 +554,7 @@ pub enum QueryError {
     },
     #[error("Function call returned an error: vm error haha")]
     ContractExecutionError {
-        vm_error: MyFunctionCallError,
+        vm_error: MyFunctionCallError3,
         block_height: near_primitives::types::BlockHeight,
         block_hash: near_primitives::hash::CryptoHash,
     },

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -1,5 +1,6 @@
 use actix::Message;
 use near_chain_configs::{ClientConfig, ProtocolConfigView};
+use near_chain_primitives::error::MyFunctionCallError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{MerklePath, PartialMerkleTree};
 use near_primitives::network::PeerId;
@@ -541,9 +542,9 @@ pub enum QueryError {
         block_height: near_primitives::types::BlockHeight,
         block_hash: near_primitives::hash::CryptoHash,
     },
-    #[error("Function call returned an error: {vm_error}")]
+    #[error("Function call returned an error: vm error haha")]
     ContractExecutionError {
-        vm_error: String,
+        vm_error: MyFunctionCallError,
         block_height: near_primitives::types::BlockHeight,
         block_hash: near_primitives::hash::CryptoHash,
     },

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -493,6 +493,7 @@ pub enum HostError3 {
 #[derive(Debug)]
 pub enum MyFunctionCallError3 {
     HostError3(HostError3),
+    OtherError(String),
 }
 
 /// Queries client for given path / data.

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -413,6 +413,9 @@ impl ViewClientActorInner {
                         MyFunctionCallError::HostError(HostError::GuestPanic { panic_msg }) => {
                             MyFunctionCallError3::HostError3(HostError3::GuestPanic3 { panic_msg })
                         },
+                        MyFunctionCallError::OtherError(error) => {
+                            MyFunctionCallError3::OtherError(error)
+                        }
                     };
                     QueryError::ContractExecutionError {
                         vm_error: error,

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -14,16 +14,9 @@ use near_chain::{
     get_epoch_block_producers_view, Chain, ChainGenesis, ChainStoreAccess, DoomslugThresholdMode,
 };
 use near_chain_configs::{ClientConfig, ProtocolConfigView};
-use near_chain_primitives::error::EpochErrorResultToChainError;
+use near_chain_primitives::error::{EpochErrorResultToChainError, HostError, MyFunctionCallError};
 use near_client_primitives::types::{
-    Error, GetBlock, GetBlockError, GetBlockProof, GetBlockProofError, GetBlockProofResponse,
-    GetBlockWithMerkleTree, GetChunkError, GetExecutionOutcome, GetExecutionOutcomeError,
-    GetExecutionOutcomesForBlock, GetGasPrice, GetGasPriceError, GetMaintenanceWindows,
-    GetMaintenanceWindowsError, GetNextLightClientBlockError, GetProtocolConfig,
-    GetProtocolConfigError, GetReceipt, GetReceiptError, GetSplitStorageInfo,
-    GetSplitStorageInfoError, GetStateChangesError, GetStateChangesWithCauseInBlock,
-    GetStateChangesWithCauseInBlockForTrackedShards, GetValidatorInfoError, Query, QueryError,
-    TxStatus, TxStatusError,
+    Error, GetBlock, GetBlockError, GetBlockProof, GetBlockProofError, GetBlockProofResponse, GetBlockWithMerkleTree, GetChunkError, GetExecutionOutcome, GetExecutionOutcomeError, GetExecutionOutcomesForBlock, GetGasPrice, GetGasPriceError, GetMaintenanceWindows, GetMaintenanceWindowsError, GetNextLightClientBlockError, GetProtocolConfig, GetProtocolConfigError, GetReceipt, GetReceiptError, GetSplitStorageInfo, GetSplitStorageInfoError, GetStateChangesError, GetStateChangesWithCauseInBlock, GetStateChangesWithCauseInBlockForTrackedShards, GetValidatorInfoError, HostError3, MyFunctionCallError3, Query, QueryError, TxStatus, TxStatusError
 };
 use near_epoch_manager::shard_tracker::ShardTracker;
 use near_epoch_manager::EpochManagerAdapter;
@@ -415,10 +408,17 @@ impl ViewClientActorInner {
                     error_message,
                     block_hash,
                     block_height,
-                } => QueryError::ContractExecutionError {
-                    vm_error: error_message,
-                    block_height,
-                    block_hash,
+                } => {
+                    let error = match error_message {
+                        MyFunctionCallError::HostError(HostError::GuestPanic { panic_msg }) => {
+                            MyFunctionCallError3::HostError3(HostError3::GuestPanic3 { panic_msg })
+                        },
+                    };
+                    QueryError::ContractExecutionError {
+                        vm_error: error,
+                        block_height,
+                        block_hash,
+                    }
                 },
                 near_chain::near_chain_primitives::error::QueryError::TooLargeContractState {
                     requested_account_id,

--- a/chain/jsonrpc-primitives/src/types/query.rs
+++ b/chain/jsonrpc-primitives/src/types/query.rs
@@ -6,6 +6,17 @@ pub struct RpcQueryRequest {
     pub request: near_primitives::views::QueryRequest,
 }
 
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub enum HostError2 {
+    GuestPanic2 { panic_msg: String },
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub enum MyFunctionCallError2 {
+    HostError2(HostError2),
+}
+
 #[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcQueryError {
@@ -28,7 +39,7 @@ pub enum RpcQueryError {
         block_height: near_primitives::types::BlockHeight,
         block_hash: near_primitives::hash::CryptoHash,
     },
-    #[error("account {requested_account_id} does not exist while viewing")]
+    #[error("account {requested_account_id} does not exist while viewing hehey")]
     UnknownAccount {
         requested_account_id: near_primitives::types::AccountId,
         block_height: near_primitives::types::BlockHeight,
@@ -54,9 +65,9 @@ pub enum RpcQueryError {
         block_height: near_primitives::types::BlockHeight,
         block_hash: near_primitives::hash::CryptoHash,
     },
-    #[error("Function call returned an error: {vm_error}")]
+    #[error("Function call returned an error: vm errorlol hehey")]
     ContractExecutionError {
-        vm_error: String,
+        vm_error: MyFunctionCallError2,
         block_height: near_primitives::types::BlockHeight,
         block_hash: near_primitives::hash::CryptoHash,
     },

--- a/chain/jsonrpc-primitives/src/types/query.rs
+++ b/chain/jsonrpc-primitives/src/types/query.rs
@@ -7,14 +7,15 @@ pub struct RpcQueryRequest {
 }
 
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 pub enum HostError2 {
     GuestPanic2 { panic_msg: String },
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 pub enum MyFunctionCallError2 {
     HostError2(HostError2),
+    OtherError(String),
 }
 
 #[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]

--- a/chain/jsonrpc/src/api/query.rs
+++ b/chain/jsonrpc/src/api/query.rs
@@ -125,9 +125,10 @@ impl RpcFrom<QueryError> for RpcQueryError {
                     MyFunctionCallError3::HostError3(HostError3::GuestPanic3 { panic_msg }) => {
                         return Self::ContractExecutionError { vm_error: MyFunctionCallError2::HostError2(HostError2::GuestPanic2 { panic_msg: panic_msg }), block_height, block_hash };
                     }
-                    _ => {}
+                    MyFunctionCallError3::OtherError(error) => {
+                        return Self::ContractExecutionError { vm_error: MyFunctionCallError2::OtherError(error), block_height, block_hash }
+                    }
                 }
-                Self::ContractExecutionError { vm_error: MyFunctionCallError2::HostError2(HostError2::GuestPanic2 { panic_msg: "this is  my panic 2".to_string() }), block_height, block_hash }
             }
             QueryError::Unreachable { ref error_message } => {
                 tracing::warn!(target: "jsonrpc", "Unreachable error occurred: {}", error_message);

--- a/chain/jsonrpc/src/api/query.rs
+++ b/chain/jsonrpc/src/api/query.rs
@@ -1,4 +1,6 @@
 use near_async::messaging::AsyncSendError;
+use near_client_primitives::types::HostError3;
+use near_client_primitives::types::MyFunctionCallError3;
 use serde_json::Value;
 
 use near_client_primitives::types::QueryError;
@@ -119,6 +121,12 @@ impl RpcFrom<QueryError> for RpcQueryError {
                 Self::UnknownAccessKey { public_key, block_height, block_hash }
             }
             QueryError::ContractExecutionError { vm_error, block_height, block_hash } => {
+                match vm_error {
+                    MyFunctionCallError3::HostError3(HostError3::GuestPanic3 { panic_msg }) => {
+                        return Self::ContractExecutionError { vm_error: MyFunctionCallError2::HostError2(HostError2::GuestPanic2 { panic_msg: panic_msg }), block_height, block_hash };
+                    }
+                    _ => {}
+                }
                 Self::ContractExecutionError { vm_error: MyFunctionCallError2::HostError2(HostError2::GuestPanic2 { panic_msg: "this is  my panic 2".to_string() }), block_height, block_hash }
             }
             QueryError::Unreachable { ref error_message } => {

--- a/chain/jsonrpc/src/api/query.rs
+++ b/chain/jsonrpc/src/api/query.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 
 use near_client_primitives::types::QueryError;
 use near_jsonrpc_primitives::errors::RpcParseError;
-use near_jsonrpc_primitives::types::query::{RpcQueryError, RpcQueryRequest, RpcQueryResponse};
+use near_jsonrpc_primitives::types::query::{HostError2, MyFunctionCallError2, RpcQueryError, RpcQueryRequest, RpcQueryResponse};
 use near_primitives::types::BlockReference;
 use near_primitives::views::{QueryRequest, QueryResponse};
 
@@ -109,6 +109,7 @@ impl RpcFrom<QueryError> for RpcQueryError {
                 Self::InvalidAccount { requested_account_id, block_height, block_hash }
             }
             QueryError::UnknownAccount { requested_account_id, block_height, block_hash } => {
+                println!("here got it");
                 Self::UnknownAccount { requested_account_id, block_height, block_hash }
             }
             QueryError::NoContractCode { contract_account_id, block_height, block_hash } => {
@@ -118,7 +119,7 @@ impl RpcFrom<QueryError> for RpcQueryError {
                 Self::UnknownAccessKey { public_key, block_height, block_hash }
             }
             QueryError::ContractExecutionError { vm_error, block_height, block_hash } => {
-                Self::ContractExecutionError { vm_error, block_height, block_hash }
+                Self::ContractExecutionError { vm_error: MyFunctionCallError2::HostError2(HostError2::GuestPanic2 { panic_msg: "this is  my panic 2".to_string() }), block_height, block_hash }
             }
             QueryError::Unreachable { ref error_message } => {
                 tracing::warn!(target: "jsonrpc", "Unreachable error occurred: {}", error_message);

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -172,16 +172,16 @@ fn process_query_response(
     match query_response {
         Ok(rpc_query_response) => serialize_response(rpc_query_response),
         Err(err) => match err {
-            near_jsonrpc_primitives::types::query::RpcQueryError::ContractExecutionError {
-                vm_error,
-                block_height,
-                block_hash,
-            } => Ok(json!({
-                "error": vm_error,
-                "logs": json!([]),
-                "block_height": block_height,
-                "block_hash": block_hash,
-            })),
+            // near_jsonrpc_primitives::types::query::RpcQueryError::ContractExecutionError {
+            //     vm_error,
+            //     block_height,
+            //     block_hash,
+            // } => Ok(json!({
+            //     "error": vm_error,
+            //     "logs": json!([]),
+            //     "block_height": block_height,
+            //     "block_hash": block_hash,
+            // })),
             near_jsonrpc_primitives::types::query::RpcQueryError::UnknownAccessKey {
                 public_key,
                 block_height,

--- a/runtime/runtime/src/state_viewer/errors.rs
+++ b/runtime/runtime/src/state_viewer/errors.rs
@@ -1,3 +1,5 @@
+use near_vm_runner::logic::errors::FunctionCallError;
+
 #[derive(thiserror::Error, Debug)]
 pub enum ViewAccountError {
     #[error("Account ID \"{requested_account_id}\" is invalid")]
@@ -51,7 +53,7 @@ pub enum CallFunctionError {
     #[error("Internal error: #{error_message}")]
     InternalError { error_message: String },
     #[error("VM error occurred: #{error_message}")]
-    VMError { error_message: String },
+    VMError { error_message: FunctionCallError },
 }
 
 impl From<ViewAccountError> for ViewContractCodeError {

--- a/runtime/runtime/src/state_viewer/errors.rs
+++ b/runtime/runtime/src/state_viewer/errors.rs
@@ -1,4 +1,5 @@
-use near_vm_runner::logic::errors::FunctionCallError;
+pub use near_vm_runner::logic::errors::FunctionCallError;
+pub use near_vm_runner::logic::errors::HostError;
 
 #[derive(thiserror::Error, Debug)]
 pub enum ViewAccountError {

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -244,9 +244,9 @@ impl TrieViewer {
 
         if let Some(err) = outcome.aborted {
             logs.extend(outcome.logs);
-            let message = format!("wasm execution failed with error: {:?}", err);
+            let message = format!("wasm execution failed with error: hehey {:?}", err);
             debug!(target: "runtime", "(exec time {}) {}", time_str, message);
-            Err(errors::CallFunctionError::VMError { error_message: message })
+            Err(errors::CallFunctionError::VMError { error_message: err })
         } else {
             debug!(target: "runtime", "(exec time {}) result of execution: {:?}", time_str, outcome);
             logs.extend(outcome.logs);


### PR DESCRIPTION
This PR attempts to align view-function call error messages with transaction function call error messages.

Here is the error message when you call it with a transaction:

```sh
near --teach-me contract call-function as-transaction frol22.testnet qwe json-args {} prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR'
```

```json
"status": {
  "Failure": {
    "ActionError": {
      "index": 0,
      "kind": {
        "FunctionCallError": {
          "MethodResolveError": "MethodNotFound"
        }
      }
    }
  }
}
```

Here is the error message when you call it with a RPC view-function (read-only):

```sh
curl -X POST https://rpc.testnet.near.org \
              -H "Content-Type: application/json" \
              -d '{"jsonrpc":"2.0", "method":"query", "params":{"request_type": "call_function", "finality": "final", "account_id": "frol22.testnet", "method_name": "asd", "args_base64": "e30="}, "id":"dontcare"}'
```

```json
{
  "jsonrpc":"2.0",
  "result": {
    "block_hash":"BEkfWU8Qe7xstTEfeaSM7vn69dj9FjEqxP5WmzhoqiJc",
    "block_height":170835830,
    "error":"wasm execution failed with error: MethodResolveError(MethodNotFound)",
    "logs":[]
  },
  "id":"dontcare"
}
```

Notice that the VM error message is not structured, and as such, it is hard to properly handle the errors.

The considerations to take:

1. We cannot break the existing structure of the reported errors as that may potentially break apps that rely on parsing the `["result"]["error"]` text
2. We don't want to introduce two ways to represent errors, so we'd better reuse existing types
3. Wasm execution error should not be an RPC error, it is a valid response from the app

This PR was just an experiment and won't be completed any time soon. Please, feel free to take it from here or start from scratch.