### PR TITLE
runtime: implement loading the contract through Externals

### DIFF
--- a/core/store/src/trie/accounting_cache.rs
+++ b/core/store/src/trie/accounting_cache.rs
@@ -10,18 +10,15 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 /// Switch that controls whether the `TrieAccountingCache` is enabled.
-#[derive(Clone)]
-// The atomic bool here is used entirely for interior mutability. This is still entirely a
-// single-threaded structure.
-pub struct TrieAccountingCacheSwitch(Rc<std::sync::atomic::AtomicBool>);
+pub struct TrieAccountingCacheSwitch(Rc<std::cell::Cell<bool>>);
 
 impl TrieAccountingCacheSwitch {
     pub fn set(&self, enabled: bool) {
-        self.0.store(enabled, std::sync::atomic::Ordering::Relaxed);
+        self.0.set(enabled);
     }
 
     pub fn enabled(&self) -> bool {
-        self.0.load(std::sync::atomic::Ordering::Relaxed)
+        self.0.get()
     }
 }
 

--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -257,7 +257,8 @@ mod tests {
             &CryptoHash::default(),
             false,
         ));
-        trie_update.set_trie_cache_mode(near_primitives::types::TrieCacheMode::CachingChunk);
+        let _mode_guard = trie_update
+            .with_trie_cache_mode(Some(near_primitives::types::TrieCacheMode::CachingChunk));
         let trie = trie_update.trie();
         let root = in_memory_trie.get_root(&state_root).unwrap();
 

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -321,7 +321,7 @@ mod trie_recording_tests {
             // Let's capture the baseline node counts - this is what will happen
             // in production.
             let trie = get_trie_for_shard(&tries, shard_uid, state_root, use_flat_storage);
-            trie.accounting_cache.borrow_mut().set_enabled(enable_accounting_cache);
+            trie.accounting_cache.borrow().enable_switch().set(enable_accounting_cache);
             for key in &keys_to_get {
                 assert_eq!(trie.get(key).unwrap(), data_in_trie.get(key).cloned());
             }
@@ -341,7 +341,7 @@ mod trie_recording_tests {
             // we get are exactly the same.
             let trie = get_trie_for_shard(&tries, shard_uid, state_root, use_flat_storage)
                 .recording_reads();
-            trie.accounting_cache.borrow_mut().set_enabled(enable_accounting_cache);
+            trie.accounting_cache.borrow().enable_switch().set(enable_accounting_cache);
             for key in &keys_to_get {
                 assert_eq!(trie.get(key).unwrap(), data_in_trie.get(key).cloned());
             }
@@ -366,7 +366,7 @@ mod trie_recording_tests {
             destructively_delete_in_memory_state_from_disk(&store, &data_in_trie);
             let trie = get_trie_for_shard(&tries, shard_uid, state_root, use_flat_storage)
                 .recording_reads();
-            trie.accounting_cache.borrow_mut().set_enabled(enable_accounting_cache);
+            trie.accounting_cache.borrow().enable_switch().set(enable_accounting_cache);
             for key in &keys_to_get {
                 assert_eq!(trie.get(key).unwrap(), data_in_trie.get(key).cloned());
             }
@@ -392,7 +392,7 @@ mod trie_recording_tests {
             );
             let trie =
                 Trie::from_recorded_storage(partial_storage.clone(), state_root, use_flat_storage);
-            trie.accounting_cache.borrow_mut().set_enabled(enable_accounting_cache);
+            trie.accounting_cache.borrow().enable_switch().set(enable_accounting_cache);
             for key in &keys_to_get {
                 assert_eq!(trie.get(key).unwrap(), data_in_trie.get(key).cloned());
             }
@@ -410,7 +410,7 @@ mod trie_recording_tests {
             // Build a Trie using recorded storage and enable recording_reads on this Trie
             let trie = Trie::from_recorded_storage(partial_storage, state_root, use_flat_storage)
                 .recording_reads();
-            trie.accounting_cache.borrow_mut().set_enabled(enable_accounting_cache);
+            trie.accounting_cache.borrow().enable_switch().set(enable_accounting_cache);
             for key in &keys_to_get {
                 assert_eq!(trie.get(key).unwrap(), data_in_trie.get(key).cloned());
             }

--- a/core/store/src/trie/trie_tests.rs
+++ b/core/store/src/trie/trie_tests.rs
@@ -303,7 +303,7 @@ mod trie_storage_tests {
         let mut accounting_cache = TrieAccountingCache::new(None);
         let key = hash(&value);
 
-        accounting_cache.set_enabled(true);
+        accounting_cache.enable_switch().set(true);
         let _ = accounting_cache.retrieve_raw_bytes_with_accounting(&key, &trie_caching_storage);
 
         let count_before: TrieNodesCount = accounting_cache.get_trie_nodes_count();
@@ -339,7 +339,7 @@ mod trie_storage_tests {
 
         // Move to CachingChunk mode. Retrieval should increment the counter, because it is the first time we accessed
         // item while caching chunk.
-        accounting_cache.set_enabled(true);
+        accounting_cache.enable_switch().set(true);
         let count_before = accounting_cache.get_trie_nodes_count();
         let result =
             accounting_cache.retrieve_raw_bytes_with_accounting(&key, &trie_caching_storage);
@@ -361,7 +361,7 @@ mod trie_storage_tests {
 
         // Even if we switch to caching shard, retrieval shouldn't increment the counter. Accounting cache only grows and is
         // dropped only when trie caching storage is dropped.
-        accounting_cache.set_enabled(true);
+        accounting_cache.enable_switch().set(true);
         let count_before = accounting_cache.get_trie_nodes_count();
         let result =
             accounting_cache.retrieve_raw_bytes_with_accounting(&key, &trie_caching_storage);
@@ -393,12 +393,12 @@ mod trie_storage_tests {
         let value = &values[0];
         let key = hash(&value);
 
-        accounting_cache.set_enabled(true);
+        accounting_cache.enable_switch().set(true);
         let result =
             accounting_cache.retrieve_raw_bytes_with_accounting(&key, &trie_caching_storage);
         assert_eq!(result.unwrap().as_ref(), value);
 
-        accounting_cache.set_enabled(true);
+        accounting_cache.enable_switch().set(true);
         for value in values[1..].iter() {
             let result = accounting_cache
                 .retrieve_raw_bytes_with_accounting(&hash(value), &trie_caching_storage);

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
@@ -18,7 +18,7 @@ libfuzzer_sys::fuzz_target!(|module: ArbitraryModule| {
 });
 
 fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMOutcome {
-    let mut fake_external = MockedExternal::with_code(code.clone());
+    let mut fake_external = MockedExternal::with_code(code.clone_for_tests());
     let mut context = create_context(vec![]);
     context.prepaid_gas = 10u64.pow(14);
     let config_store = RuntimeConfigStore::new(None);
@@ -32,7 +32,6 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMOutcome {
 
     let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
     let res = vm_kind.runtime(wasm_config).unwrap().run(
-        Some(&code),
         &method_name,
         &mut fake_external,
         &context,

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
@@ -18,7 +18,7 @@ libfuzzer_sys::fuzz_target!(|module: ArbitraryModule| {
 });
 
 fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMOutcome {
-    let mut fake_external = MockedExternal::with_code_hash(*code.hash());
+    let mut fake_external = MockedExternal::with_code(code.clone());
     let mut context = create_context(vec![]);
     context.prepaid_gas = 10u64.pow(14);
     let config_store = RuntimeConfigStore::new(None);

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
@@ -18,7 +18,7 @@ libfuzzer_sys::fuzz_target!(|module: ArbitraryModule| {
 });
 
 fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMOutcome {
-    let mut fake_external = MockedExternal::new();
+    let mut fake_external = MockedExternal::with_code_hash(*code.hash());
     let mut context = create_context(vec![]);
     context.prepaid_gas = 10u64.pow(14);
     let config_store = RuntimeConfigStore::new(None);
@@ -32,7 +32,6 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMOutcome {
 
     let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
     let res = vm_kind.runtime(wasm_config).unwrap().run(
-        *code.hash(),
         Some(&code),
         &method_name,
         &mut fake_external,

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
@@ -17,7 +17,7 @@ libfuzzer_sys::fuzz_target!(|module: ArbitraryModule| {
 });
 
 fn run_fuzz(code: &ContractCode, config: Arc<RuntimeConfig>) -> VMOutcome {
-    let mut fake_external = MockedExternal::with_code_hash(*code.hash());
+    let mut fake_external = MockedExternal::with_code(code.clone());
     let mut context = create_context(vec![]);
     context.prepaid_gas = 10u64.pow(14);
     let mut wasm_config = config.wasm_config.clone();

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
@@ -17,7 +17,7 @@ libfuzzer_sys::fuzz_target!(|module: ArbitraryModule| {
 });
 
 fn run_fuzz(code: &ContractCode, config: Arc<RuntimeConfig>) -> VMOutcome {
-    let mut fake_external = MockedExternal::new();
+    let mut fake_external = MockedExternal::with_code_hash(*code.hash());
     let mut context = create_context(vec![]);
     context.prepaid_gas = 10u64.pow(14);
     let mut wasm_config = config.wasm_config.clone();
@@ -30,15 +30,6 @@ fn run_fuzz(code: &ContractCode, config: Arc<RuntimeConfig>) -> VMOutcome {
     vm_kind
         .runtime(wasm_config)
         .unwrap()
-        .run(
-            *code.hash(),
-            Some(&code),
-            &method_name,
-            &mut fake_external,
-            &context,
-            fees,
-            &promise_results,
-            None,
-        )
+        .run(Some(&code), &method_name, &mut fake_external, &context, fees, &promise_results, None)
         .unwrap_or_else(|err| panic!("fatal error: {err:?}"))
 }

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
@@ -17,7 +17,7 @@ libfuzzer_sys::fuzz_target!(|module: ArbitraryModule| {
 });
 
 fn run_fuzz(code: &ContractCode, config: Arc<RuntimeConfig>) -> VMOutcome {
-    let mut fake_external = MockedExternal::with_code(code.clone());
+    let mut fake_external = MockedExternal::with_code(code.clone_for_tests());
     let mut context = create_context(vec![]);
     context.prepaid_gas = 10u64.pow(14);
     let mut wasm_config = config.wasm_config.clone();
@@ -30,6 +30,6 @@ fn run_fuzz(code: &ContractCode, config: Arc<RuntimeConfig>) -> VMOutcome {
     vm_kind
         .runtime(wasm_config)
         .unwrap()
-        .run(Some(&code), &method_name, &mut fake_external, &context, fees, &promise_results, None)
+        .run(&method_name, &mut fake_external, &context, fees, &promise_results, None)
         .unwrap_or_else(|err| panic!("fatal error: {err:?}"))
 }

--- a/runtime/near-vm-runner/src/code.rs
+++ b/runtime/near-vm-runner/src/code.rs
@@ -26,9 +26,6 @@ impl ContractCode {
     }
 
     pub fn clone_for_tests(&self) -> Self {
-        Self {
-            code: self.code.clone(),
-            hash: self.hash,
-        }
+        Self { code: self.code.clone(), hash: self.hash }
     }
 }

--- a/runtime/near-vm-runner/src/code.rs
+++ b/runtime/near-vm-runner/src/code.rs
@@ -1,5 +1,6 @@
 use near_primitives_core::hash::{hash as sha256, CryptoHash};
 
+#[derive(Clone)]
 pub struct ContractCode {
     code: Vec<u8>,
     hash: CryptoHash,

--- a/runtime/near-vm-runner/src/code.rs
+++ b/runtime/near-vm-runner/src/code.rs
@@ -1,6 +1,5 @@
 use near_primitives_core::hash::{hash as sha256, CryptoHash};
 
-#[derive(Clone)]
 pub struct ContractCode {
     code: Vec<u8>,
     hash: CryptoHash,
@@ -24,5 +23,12 @@ impl ContractCode {
 
     pub fn hash(&self) -> &CryptoHash {
         &self.hash
+    }
+
+    pub fn clone_for_tests(&self) -> Self {
+        Self {
+            code: self.code.clone(),
+            hash: self.hash,
+        }
     }
 }

--- a/runtime/near-vm-runner/src/logic/dependencies.rs
+++ b/runtime/near-vm-runner/src/logic/dependencies.rs
@@ -488,4 +488,7 @@ pub trait External {
     ///
     /// Panics if `ReceiptIndex` is invalid.
     fn get_receipt_receiver(&self, receipt_index: ReceiptIndex) -> &AccountId;
+
+    /// Hash of the contract for the current account.
+    fn code_hash(&self) -> CryptoHash;
 }

--- a/runtime/near-vm-runner/src/logic/dependencies.rs
+++ b/runtime/near-vm-runner/src/logic/dependencies.rs
@@ -6,7 +6,6 @@ use near_parameters::vm::StorageGetMode;
 use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::{AccountId, Balance, Gas, GasWeight, Nonce};
 use std::borrow::Cow;
-use std::error::Error;
 
 /// Representation of the address slice of guest memory.
 #[derive(Clone, Copy)]
@@ -132,12 +131,6 @@ impl TrieNodesCount {
             mem_reads: self.mem_reads.checked_sub(other.mem_reads)?,
         })
     }
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum GetContractError {
-    #[error("storage error has occurred")]
-    StorageError(Box<dyn Error + Send + Sync>),
 }
 
 /// An external blockchain interface for the Runtime logic
@@ -500,5 +493,5 @@ pub trait External {
     fn code_hash(&self) -> CryptoHash;
 
     /// Get the contract code
-    fn get_contract(&self) -> Result<Option<std::sync::Arc<crate::ContractCode>>, GetContractError>;
+    fn get_contract(&self) -> Option<std::sync::Arc<crate::ContractCode>>;
 }

--- a/runtime/near-vm-runner/src/logic/dependencies.rs
+++ b/runtime/near-vm-runner/src/logic/dependencies.rs
@@ -6,6 +6,7 @@ use near_parameters::vm::StorageGetMode;
 use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::{AccountId, Balance, Gas, GasWeight, Nonce};
 use std::borrow::Cow;
+use std::error::Error;
 
 /// Representation of the address slice of guest memory.
 #[derive(Clone, Copy)]
@@ -131,6 +132,10 @@ impl TrieNodesCount {
             mem_reads: self.mem_reads.checked_sub(other.mem_reads)?,
         })
     }
+}
+
+pub enum GetContractError {
+    StorageError(Box<dyn Error + Send + Sync>),
 }
 
 /// An external blockchain interface for the Runtime logic
@@ -491,4 +496,7 @@ pub trait External {
 
     /// Hash of the contract for the current account.
     fn code_hash(&self) -> CryptoHash;
+
+    /// Get the contract code
+    fn get_contract(&self) -> Result<Option<std::sync::Arc<crate::ContractCode>>, GetContractError>;
 }

--- a/runtime/near-vm-runner/src/logic/dependencies.rs
+++ b/runtime/near-vm-runner/src/logic/dependencies.rs
@@ -134,7 +134,9 @@ impl TrieNodesCount {
     }
 }
 
+#[derive(thiserror::Error, Debug)]
 pub enum GetContractError {
+    #[error("storage error has occurred")]
     StorageError(Box<dyn Error + Send + Sync>),
 }
 

--- a/runtime/near-vm-runner/src/logic/errors.rs
+++ b/runtime/near-vm-runner/src/logic/errors.rs
@@ -29,6 +29,10 @@ pub enum VMRunnerError {
     Nondeterministic(String),
     #[error("unknown error during contract execution: {debug_message}")]
     WasmUnknownError { debug_message: String },
+    #[error("could not load the contract from the storage")]
+    GetContract(#[source] super::GetContractError),
+    #[error("account has no associated contract code")]
+    ContractCodeNotPresent,
 }
 
 /// Permitted errors that cause a function call to fail gracefully.
@@ -65,6 +69,7 @@ pub enum CacheError {
     #[error("cache serialization error")]
     SerializationError { hash: [u8; 32] },
 }
+
 /// A kind of a trap happened during execution of a binary
 #[derive(Debug, Clone, PartialEq, Eq, strum::IntoStaticStr)]
 pub enum WasmTrap {

--- a/runtime/near-vm-runner/src/logic/errors.rs
+++ b/runtime/near-vm-runner/src/logic/errors.rs
@@ -29,8 +29,6 @@ pub enum VMRunnerError {
     Nondeterministic(String),
     #[error("unknown error during contract execution: {debug_message}")]
     WasmUnknownError { debug_message: String },
-    #[error("could not load the contract from the storage")]
-    GetContract(#[source] super::GetContractError),
     #[error("account has no associated contract code")]
     ContractCodeNotPresent,
 }

--- a/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
+++ b/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
@@ -77,6 +77,7 @@ pub struct MockedExternal {
     pub fake_trie: HashMap<Vec<u8>, Vec<u8>>,
     pub validators: HashMap<AccountId, Balance>,
     pub action_log: Vec<MockAction>,
+    pub code_hash: CryptoHash,
     data_count: u64,
 }
 
@@ -106,6 +107,10 @@ impl ValuePtr for MockedValuePtr {
 impl MockedExternal {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn with_code_hash(code_hash: CryptoHash) -> Self {
+        Self { code_hash, ..Self::default() }
     }
 }
 
@@ -308,5 +313,9 @@ impl External for MockedExternal {
             MockAction::CreateReceipt { receiver_id, .. } => receiver_id,
             _ => panic!("not a valid receipt index!"),
         }
+    }
+
+    fn code_hash(&self) -> CryptoHash {
+        self.code_hash
     }
 }

--- a/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
+++ b/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
@@ -1,4 +1,4 @@
-use crate::logic::dependencies::{GetContractError, Result, TrieNodesCount};
+use crate::logic::dependencies::{Result, TrieNodesCount};
 use crate::logic::types::ReceiptIndex;
 use crate::logic::{External, StorageGetMode, ValuePtr};
 use crate::ContractCode;
@@ -325,7 +325,7 @@ impl External for MockedExternal {
         self.code_hash
     }
 
-    fn get_contract(&self) -> Result<Option<Arc<ContractCode>>, GetContractError> {
-        Ok(self.code.clone())
+    fn get_contract(&self) -> Option<Arc<ContractCode>> {
+        self.code.clone()
     }
 }

--- a/runtime/near-vm-runner/src/logic/mod.rs
+++ b/runtime/near-vm-runner/src/logic/mod.rs
@@ -14,7 +14,7 @@ mod utils;
 mod vmstate;
 
 pub use context::VMContext;
-pub use dependencies::{External, MemSlice, MemoryLike, TrieNodesCount, ValuePtr, GetContractError};
+pub use dependencies::{External, MemSlice, MemoryLike, TrieNodesCount, ValuePtr};
 pub use errors::{HostError, VMLogicError};
 pub use gas_counter::with_ext_cost_counter;
 pub use logic::{VMLogic, VMOutcome};

--- a/runtime/near-vm-runner/src/logic/mod.rs
+++ b/runtime/near-vm-runner/src/logic/mod.rs
@@ -14,7 +14,7 @@ mod utils;
 mod vmstate;
 
 pub use context::VMContext;
-pub use dependencies::{External, MemSlice, MemoryLike, TrieNodesCount, ValuePtr};
+pub use dependencies::{External, MemSlice, MemoryLike, TrieNodesCount, ValuePtr, GetContractError};
 pub use errors::{HostError, VMLogicError};
 pub use gas_counter::with_ext_cost_counter;
 pub use logic::{VMLogic, VMOutcome};

--- a/runtime/near-vm-runner/src/near_vm_runner/runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner/runner.rs
@@ -239,9 +239,7 @@ impl NearVM {
                 let key = get_contract_cache_key(code_hash, &self.config);
                 let cache_record = cache.get(&key).map_err(CacheError::ReadError)?;
                 let Some(compiled_contract_info) = cache_record else {
-                    let Some(code) =
-                        ext.get_contract().map_err(|err| VMRunnerError::GetContract(err))?
-                    else {
+                    let Some(code) = ext.get_contract() else {
                         return Err(VMRunnerError::ContractCodeNotPresent);
                     };
                     let _span =

--- a/runtime/near-vm-runner/src/near_vm_runner/runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner/runner.rs
@@ -590,7 +590,6 @@ impl<'a> finite_wasm::wasmparser::VisitOperator<'a> for GasCostCfg {
 impl crate::runner::VM for NearVM {
     fn run(
         &self,
-        code_hash: CryptoHash,
         code: Option<&ContractCode>,
         method_name: &str,
         ext: &mut dyn External,
@@ -601,7 +600,7 @@ impl crate::runner::VM for NearVM {
     ) -> Result<VMOutcome, VMRunnerError> {
         let cache = cache.unwrap_or(&NoContractRuntimeCache);
         self.with_compiled_and_loaded(
-            code_hash,
+            ext.code_hash(),
             code,
             cache,
             ext,

--- a/runtime/near-vm-runner/src/near_vm_runner/runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner/runner.rs
@@ -16,7 +16,6 @@ use crate::{prepare, NoContractRuntimeCache};
 use memoffset::offset_of;
 use near_parameters::vm::VMKind;
 use near_parameters::RuntimeFeesConfig;
-use near_primitives_core::hash::CryptoHash;
 use near_vm_compiler_singlepass::Singlepass;
 use near_vm_engine::universal::{
     MemoryPool, Universal, UniversalArtifact, UniversalEngine, UniversalExecutable,
@@ -212,8 +211,6 @@ impl NearVM {
     )]
     fn with_compiled_and_loaded(
         &self,
-        code_hash: CryptoHash,
-        code: Option<&ContractCode>,
         cache: &dyn ContractRuntimeCache,
         ext: &mut dyn External,
         context: &VMContext,
@@ -228,64 +225,31 @@ impl NearVM {
         // To identify a cache hit from either in-memory and on-disk cache correctly, we first assume that we have a cache hit here,
         // and then we set it to false when we fail to find any entry and decide to compile (by calling compile_and_cache below).
         let mut is_cache_hit = true;
+        let code_hash = ext.code_hash();
         let (wasm_bytes, artifact_result) = cache.memory_cache().try_lookup(
             code_hash,
-            || match code {
-                None => {
-                    // `cache` stores compiled machine code in the database
-                    //
-                    // Caches also cache _compilation_ errors, so that we don't have to
-                    // re-parse invalid code (invalid code, in a sense, is a normal
-                    // outcome). And `cache`, being a database, can fail with an `io::Error`.
-                    let _span =
-                        tracing::debug_span!(target: "vm", "NearVM::fetch_from_cache").entered();
-                    let key = get_contract_cache_key(code_hash, &self.config);
-                    let cache_record = cache.get(&key).map_err(CacheError::ReadError)?;
-                    let Some(code) = cache_record else {
-                        return Err(VMRunnerError::CacheError(CacheError::ReadError(
-                            std::io::Error::from(std::io::ErrorKind::NotFound),
-                        )));
+            || {
+                // `cache` stores compiled machine code in the database
+                //
+                // Caches also cache _compilation_ errors, so that we don't have to
+                // re-parse invalid code (invalid code, in a sense, is a normal
+                // outcome). And `cache`, being a database, can fail with an `io::Error`.
+                let _span =
+                    tracing::debug_span!(target: "vm", "NearVM::fetch_from_cache").entered();
+                let key = get_contract_cache_key(code_hash, &self.config);
+                let cache_record = cache.get(&key).map_err(CacheError::ReadError)?;
+                let Some(compiled_contract_info) = cache_record else {
+                    let Some(code) =
+                        ext.get_contract().map_err(|err| VMRunnerError::GetContract(err))?
+                    else {
+                        return Err(VMRunnerError::ContractCodeNotPresent);
                     };
-
-                    match &code.compiled {
-                        CompiledContract::CompileModuleError(err) => {
-                            Ok::<_, VMRunnerError>(to_any((code.wasm_bytes, Err(err.clone()))))
-                        }
-                        CompiledContract::Code(serialized_module) => {
-                            let _span =
-                                tracing::debug_span!(target: "vm", "NearVM::load_from_fs_cache")
-                                    .entered();
-                            unsafe {
-                                // (UN-)SAFETY: the `serialized_module` must have been produced by
-                                // a prior call to `serialize`.
-                                //
-                                // In practice this is not necessarily true. One could have
-                                // forgotten to change the cache key when upgrading the version of
-                                // the near_vm library or the database could have had its data
-                                // corrupted while at rest.
-                                //
-                                // There should definitely be some validation in near_vm to ensure
-                                // we load what we think we load.
-                                let executable =
-                                    UniversalExecutableRef::deserialize(&serialized_module)
-                                        .map_err(|_| CacheError::DeserializationError)?;
-                                let artifact = self
-                                    .engine
-                                    .load_universal_executable_ref(&executable)
-                                    .map(Arc::new)
-                                    .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?;
-                                Ok(to_any((code.wasm_bytes, Ok(artifact))))
-                            }
-                        }
-                    }
-                }
-                Some(code) => {
                     let _span =
                         tracing::debug_span!(target: "vm", "NearVM::build_from_source").entered();
                     is_cache_hit = false;
-                    Ok(to_any((
+                    return Ok(to_any((
                         code.code().len() as u64,
-                        match self.compile_and_cache(code, cache)? {
+                        match self.compile_and_cache(&code, cache)? {
                             Ok(executable) => Ok(self
                                 .engine
                                 .load_universal_executable(&executable)
@@ -293,7 +257,40 @@ impl NearVM {
                                 .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?),
                             Err(err) => Err(err),
                         },
-                    )))
+                    )));
+                };
+
+                match &compiled_contract_info.compiled {
+                    CompiledContract::CompileModuleError(err) => Ok::<_, VMRunnerError>(to_any((
+                        compiled_contract_info.wasm_bytes,
+                        Err(err.clone()),
+                    ))),
+                    CompiledContract::Code(serialized_module) => {
+                        let _span =
+                            tracing::debug_span!(target: "vm", "NearVM::load_from_fs_cache")
+                                .entered();
+                        unsafe {
+                            // (UN-)SAFETY: the `serialized_module` must have been produced by
+                            // a prior call to `serialize`.
+                            //
+                            // In practice this is not necessarily true. One could have
+                            // forgotten to change the cache key when upgrading the version of
+                            // the near_vm library or the database could have had its data
+                            // corrupted while at rest.
+                            //
+                            // There should definitely be some validation in near_vm to ensure
+                            // we load what we think we load.
+                            let executable =
+                                UniversalExecutableRef::deserialize(&serialized_module)
+                                    .map_err(|_| CacheError::DeserializationError)?;
+                            let artifact = self
+                                .engine
+                                .load_universal_executable_ref(&executable)
+                                .map(Arc::new)
+                                .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?;
+                            Ok(to_any((compiled_contract_info.wasm_bytes, Ok(artifact))))
+                        }
+                    }
                 }
             },
             move |value| {
@@ -590,7 +587,6 @@ impl<'a> finite_wasm::wasmparser::VisitOperator<'a> for GasCostCfg {
 impl crate::runner::VM for NearVM {
     fn run(
         &self,
-        code: Option<&ContractCode>,
         method_name: &str,
         ext: &mut dyn External,
         context: &VMContext,
@@ -600,8 +596,6 @@ impl crate::runner::VM for NearVM {
     ) -> Result<VMOutcome, VMRunnerError> {
         let cache = cache.unwrap_or(&NoContractRuntimeCache);
         self.with_compiled_and_loaded(
-            ext.code_hash(),
-            code,
             cache,
             ext,
             context,

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -5,8 +5,6 @@ use crate::logic::{External, VMContext, VMOutcome};
 use crate::{ContractCode, ContractRuntimeCache};
 use near_parameters::vm::{Config, VMKind};
 use near_parameters::RuntimeFeesConfig;
-use near_primitives_core::account::Account;
-use near_primitives_core::hash::CryptoHash;
 
 /// Returned by VM::run method.
 ///
@@ -42,14 +40,13 @@ pub(crate) type VMResult<T = VMOutcome> = Result<T, VMRunnerError>;
 /// The gas cost for contract preparation will be subtracted by the VM
 /// implementation.
 #[tracing::instrument(target = "vm", level = "debug", "run", skip_all, fields(
-    code.hash = %account.code_hash(),
+    code.hash = %ext.code_hash(),
     method_name,
     vm_kind = ?wasm_config.vm_kind,
     burnt_gas = tracing::field::Empty,
     compute_usage = tracing::field::Empty,
 ))]
 pub fn run(
-    account: &Account,
     code: Option<&ContractCode>,
     method_name: &str,
     ext: &mut dyn External,
@@ -65,7 +62,6 @@ pub fn run(
         .runtime(wasm_config.clone())
         .unwrap_or_else(|| panic!("the {vm_kind:?} runtime has not been enabled at compile time"));
     let outcome = runtime.run(
-        account.code_hash(),
         code,
         method_name,
         ext,
@@ -101,7 +97,6 @@ pub trait VM {
     /// implementation.
     fn run(
         &self,
-        code_hash: CryptoHash,
         code: Option<&ContractCode>,
         method_name: &str,
         ext: &mut dyn External,

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -47,7 +47,6 @@ pub(crate) type VMResult<T = VMOutcome> = Result<T, VMRunnerError>;
     compute_usage = tracing::field::Empty,
 ))]
 pub fn run(
-    code: Option<&ContractCode>,
     method_name: &str,
     ext: &mut dyn External,
     context: &VMContext,
@@ -61,15 +60,7 @@ pub fn run(
     let runtime = vm_kind
         .runtime(wasm_config.clone())
         .unwrap_or_else(|| panic!("the {vm_kind:?} runtime has not been enabled at compile time"));
-    let outcome = runtime.run(
-        code,
-        method_name,
-        ext,
-        context,
-        fees_config,
-        promise_results,
-        cache,
-    );
+    let outcome = runtime.run(method_name, ext, context, fees_config, promise_results, cache);
     let outcome = match outcome {
         Ok(o) => o,
         e @ Err(_) => return e,
@@ -97,7 +88,6 @@ pub trait VM {
     /// implementation.
     fn run(
         &self,
-        code: Option<&ContractCode>,
         method_name: &str,
         ext: &mut dyn External,
         context: &VMContext,

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -116,7 +116,12 @@ fn make_cached_contract_call_vm(
     prepaid_gas: u64,
     vm_kind: VMKind,
 ) -> VMResult {
-    let mut fake_external = MockedExternal::with_code_hash(code_hash);
+    let mut fake_external = if let Some(code) = code {
+        MockedExternal::with_code_and_hash(code_hash, code.clone())
+    } else {
+        MockedExternal::new()
+    };
+    fake_external.code_hash = code_hash;
     let mut context = create_context(vec![]);
     let fees = RuntimeFeesConfig::test();
     let promise_results = vec![];

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -116,14 +116,13 @@ fn make_cached_contract_call_vm(
     prepaid_gas: u64,
     vm_kind: VMKind,
 ) -> VMResult {
-    let mut fake_external = MockedExternal::new();
+    let mut fake_external = MockedExternal::with_code_hash(code_hash);
     let mut context = create_context(vec![]);
     let fees = RuntimeFeesConfig::test();
     let promise_results = vec![];
     context.prepaid_gas = prepaid_gas;
     let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
     runtime.run(
-        code_hash,
         code,
         method_name,
         &mut fake_external,

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -127,14 +127,7 @@ fn make_cached_contract_call_vm(
     let promise_results = vec![];
     context.prepaid_gas = prepaid_gas;
     let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
-    runtime.run(
-        method_name,
-        &mut fake_external,
-        &context,
-        &fees,
-        &promise_results,
-        Some(cache),
-    )
+    runtime.run(method_name, &mut fake_external, &context, &fees, &promise_results, Some(cache))
 }
 
 #[test]

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -63,8 +63,8 @@ fn test_does_not_cache_io_error() {
     let config = test_vm_config();
     with_vm_variants(&config, |vm_kind: VMKind| {
         match vm_kind {
-            VMKind::Wasmer0 | VMKind::Wasmer2 | VMKind::NearVm => {}
-            VMKind::Wasmtime => return,
+            VMKind::NearVm => {}
+            VMKind::Wasmer0 | VMKind::Wasmer2 | VMKind::Wasmtime => return,
         }
 
         let code = near_test_contracts::trivial_contract();
@@ -128,7 +128,6 @@ fn make_cached_contract_call_vm(
     context.prepaid_gas = prepaid_gas;
     let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
     runtime.run(
-        code,
         method_name,
         &mut fake_external,
         &context,

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -117,7 +117,7 @@ fn make_cached_contract_call_vm(
     vm_kind: VMKind,
 ) -> VMResult {
     let mut fake_external = if let Some(code) = code {
-        MockedExternal::with_code_and_hash(code_hash, code.clone())
+        MockedExternal::with_code_and_hash(code_hash, code.clone_for_tests())
     } else {
         MockedExternal::new()
     };

--- a/runtime/near-vm-runner/src/tests/fuzzers.rs
+++ b/runtime/near-vm-runner/src/tests/fuzzers.rs
@@ -106,8 +106,7 @@ impl fmt::Debug for ArbitraryModule {
 }
 
 fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMResult {
-    let mut fake_external = MockedExternal::with_code_hash(*code.hash());
-
+    let mut fake_external = MockedExternal::with_code(code.clone());
     let mut context = create_context(vec![]);
     context.prepaid_gas = 10u64.pow(14);
 

--- a/runtime/near-vm-runner/src/tests/fuzzers.rs
+++ b/runtime/near-vm-runner/src/tests/fuzzers.rs
@@ -106,7 +106,7 @@ impl fmt::Debug for ArbitraryModule {
 }
 
 fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMResult {
-    let mut fake_external = MockedExternal::new();
+    let mut fake_external = MockedExternal::with_code_hash(*code.hash());
 
     let mut context = create_context(vec![]);
     context.prepaid_gas = 10u64.pow(14);
@@ -121,7 +121,6 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMResult {
 
     let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
     let mut res = vm_kind.runtime(config).unwrap().run(
-        *code.hash(),
         Some(code),
         &method_name,
         &mut fake_external,

--- a/runtime/near-vm-runner/src/tests/fuzzers.rs
+++ b/runtime/near-vm-runner/src/tests/fuzzers.rs
@@ -120,7 +120,6 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMResult {
 
     let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
     let mut res = vm_kind.runtime(config).unwrap().run(
-        Some(code),
         &method_name,
         &mut fake_external,
         &context,

--- a/runtime/near-vm-runner/src/tests/fuzzers.rs
+++ b/runtime/near-vm-runner/src/tests/fuzzers.rs
@@ -106,7 +106,7 @@ impl fmt::Debug for ArbitraryModule {
 }
 
 fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMResult {
-    let mut fake_external = MockedExternal::with_code(code.clone());
+    let mut fake_external = MockedExternal::with_code(code.clone_for_tests());
     let mut context = create_context(vec![]);
     context.prepaid_gas = 10u64.pow(14);
 

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -53,15 +53,12 @@ pub fn test_read_write() {
     with_vm_variants(&config, |vm_kind: VMKind| {
         let code = test_contract(vm_kind);
         let mut fake_external = MockedExternal::with_code(code);
-        let code = test_contract(vm_kind);
-
         let context = create_context(encode(&[10u64, 20u64]));
         let fees = RuntimeFeesConfig::test();
 
         let promise_results = vec![];
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
         let result = runtime.run(
-            Some(&code),
             "write_key_value",
             &mut fake_external,
             &context,
@@ -72,15 +69,8 @@ pub fn test_read_write() {
         assert_run_result(result, 0);
 
         let context = create_context(encode(&[10u64]));
-        let result = runtime.run(
-            Some(&code),
-            "read_value",
-            &mut fake_external,
-            &context,
-            &fees,
-            &promise_results,
-            None,
-        );
+        let result =
+            runtime.run("read_value", &mut fake_external, &context, &fees, &promise_results, None);
         assert_run_result(result, 20);
     });
 }
@@ -125,7 +115,6 @@ fn run_test_ext(
 ) {
     let code = test_contract(vm_kind);
     let mut fake_external = MockedExternal::with_code(code);
-    let code = test_contract(vm_kind);
     fake_external.validators =
         validators.into_iter().map(|(s, b)| (s.parse().unwrap(), b)).collect();
     let fees = RuntimeFeesConfig::test();
@@ -133,7 +122,7 @@ fn run_test_ext(
     let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
 
     let outcome = runtime
-        .run(Some(&code), method, &mut fake_external, &context, &fees, &[], None)
+        .run(method, &mut fake_external, &context, &fees, &[], None)
         .unwrap_or_else(|err| panic!("Failed execution: {:?}", err));
 
     assert_eq!(outcome.profile.action_gas(), 0);
@@ -233,23 +222,13 @@ pub fn test_out_of_memory() {
 
         let code = test_contract(vm_kind);
         let mut fake_external = MockedExternal::with_code(code);
-        let code = test_contract(vm_kind);
-
         let context = create_context(Vec::new());
         let fees = RuntimeFeesConfig::free();
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
 
         let promise_results = vec![];
         let result = runtime
-            .run(
-                Some(&code),
-                "out_of_memory",
-                &mut fake_external,
-                &context,
-                &fees,
-                &promise_results,
-                None,
-            )
+            .run("out_of_memory", &mut fake_external, &context, &fees, &promise_results, None)
             .expect("execution failed");
         assert_eq!(
             result.aborted,
@@ -277,20 +256,11 @@ fn attach_unspent_gas_but_use_all_gas() {
     with_vm_variants(&config, |vm_kind: VMKind| {
         let code = function_call_weight_contract();
         let mut external = MockedExternal::with_code(code);
-        let code = function_call_weight_contract();
         let fees = RuntimeFeesConfig::test();
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
 
         let outcome = runtime
-            .run(
-                Some(&code),
-                "attach_unspent_gas_but_use_all_gas",
-                &mut external,
-                &context,
-                &fees,
-                &[],
-                None,
-            )
+            .run("attach_unspent_gas_but_use_all_gas", &mut external, &context, &fees, &[], None)
             .unwrap_or_else(|err| panic!("Failed execution: {:?}", err));
 
         let err = outcome.aborted.as_ref().unwrap();

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -52,7 +52,8 @@ pub fn test_read_write() {
     let config = test_vm_config();
     with_vm_variants(&config, |vm_kind: VMKind| {
         let code = test_contract(vm_kind);
-        let mut fake_external = MockedExternal::with_code_hash(*code.hash());
+        let mut fake_external = MockedExternal::with_code(code);
+        let code = test_contract(vm_kind);
 
         let context = create_context(encode(&[10u64, 20u64]));
         let fees = RuntimeFeesConfig::test();
@@ -123,7 +124,8 @@ fn run_test_ext(
     vm_kind: VMKind,
 ) {
     let code = test_contract(vm_kind);
-    let mut fake_external = MockedExternal::with_code_hash(*code.hash());
+    let mut fake_external = MockedExternal::with_code(code);
+    let code = test_contract(vm_kind);
     fake_external.validators =
         validators.into_iter().map(|(s, b)| (s.parse().unwrap(), b)).collect();
     let fees = RuntimeFeesConfig::test();
@@ -230,7 +232,8 @@ pub fn test_out_of_memory() {
         }
 
         let code = test_contract(vm_kind);
-        let mut fake_external = MockedExternal::with_code_hash(*code.hash());
+        let mut fake_external = MockedExternal::with_code(code);
+        let code = test_contract(vm_kind);
 
         let context = create_context(Vec::new());
         let fees = RuntimeFeesConfig::free();
@@ -273,7 +276,8 @@ fn attach_unspent_gas_but_use_all_gas() {
 
     with_vm_variants(&config, |vm_kind: VMKind| {
         let code = function_call_weight_contract();
-        let mut external = MockedExternal::with_code_hash(*code.hash());
+        let mut external = MockedExternal::with_code(code);
+        let code = function_call_weight_contract();
         let fees = RuntimeFeesConfig::test();
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
 

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -225,7 +225,6 @@ impl TestBuilder {
                 println!("Running {:?} for protocol version {}", vm_kind, protocol_version);
                 let outcome = runtime
                     .run(
-                        Some(&self.code),
                         &self.method,
                         &mut fake_external,
                         &context,

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -212,7 +212,7 @@ impl TestBuilder {
                     continue;
                 }
 
-                let mut fake_external = MockedExternal::with_code(self.code.clone());
+                let mut fake_external = MockedExternal::with_code(self.code.clone_for_tests());
                 let config = runtime_config.wasm_config.clone();
                 let fees = RuntimeFeesConfig::test();
                 let context = self.context.clone();

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -212,7 +212,7 @@ impl TestBuilder {
                     continue;
                 }
 
-                let mut fake_external = MockedExternal::new();
+                let mut fake_external = MockedExternal::with_code_hash(*self.code.hash());
                 let config = runtime_config.wasm_config.clone();
                 let fees = RuntimeFeesConfig::test();
                 let context = self.context.clone();
@@ -225,7 +225,6 @@ impl TestBuilder {
                 println!("Running {:?} for protocol version {}", vm_kind, protocol_version);
                 let outcome = runtime
                     .run(
-                        *self.code.hash(),
                         Some(&self.code),
                         &self.method,
                         &mut fake_external,

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -212,7 +212,7 @@ impl TestBuilder {
                     continue;
                 }
 
-                let mut fake_external = MockedExternal::with_code_hash(*self.code.hash());
+                let mut fake_external = MockedExternal::with_code(self.code.clone());
                 let config = runtime_config.wasm_config.clone();
                 let fees = RuntimeFeesConfig::test();
                 let context = self.context.clone();

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -224,14 +224,7 @@ impl TestBuilder {
                 };
                 println!("Running {:?} for protocol version {}", vm_kind, protocol_version);
                 let outcome = runtime
-                    .run(
-                        &self.method,
-                        &mut fake_external,
-                        &context,
-                        &fees,
-                        &promise_results,
-                        None,
-                    )
+                    .run(&self.method, &mut fake_external, &context, &fees, &promise_results, None)
                     .expect("execution failed");
 
                 let mut got = String::new();

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -15,23 +15,14 @@ pub fn test_ts_contract() {
     with_vm_variants(&config, |vm_kind: VMKind| {
         let code = ContractCode::new(near_test_contracts::ts_contract().to_vec(), None);
         let mut fake_external = MockedExternal::with_code(code);
-        let code = ContractCode::new(near_test_contracts::ts_contract().to_vec(), None);
-
         let context = create_context(Vec::new());
         let fees = RuntimeFeesConfig::test();
 
         // Call method that panics.
         let promise_results = vec![];
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
-        let result = runtime.run(
-            Some(&code),
-            "try_panic",
-            &mut fake_external,
-            &context,
-            &fees,
-            &promise_results,
-            None,
-        );
+        let result =
+            runtime.run("try_panic", &mut fake_external, &context, &fees, &promise_results, None);
         let outcome = result.expect("execution failed");
         assert_eq!(
             outcome.aborted,
@@ -43,15 +34,7 @@ pub fn test_ts_contract() {
         // Call method that writes something into storage.
         let context = create_context(b"foo bar".to_vec());
         runtime
-            .run(
-                Some(&code),
-                "try_storage_write",
-                &mut fake_external,
-                &context,
-                &fees,
-                &promise_results,
-                None,
-            )
+            .run("try_storage_write", &mut fake_external, &context, &fees, &promise_results, None)
             .expect("bad failure");
         // Verify by looking directly into the storage of the host.
         {
@@ -65,15 +48,7 @@ pub fn test_ts_contract() {
         // Call method that reads the value from storage using registers.
         let context = create_context(b"foo".to_vec());
         let outcome = runtime
-            .run(
-                Some(&code),
-                "try_storage_read",
-                &mut fake_external,
-                &context,
-                &fees,
-                &promise_results,
-                None,
-            )
+            .run("try_storage_read", &mut fake_external, &context, &fees, &promise_results, None)
             .expect("execution failed");
 
         if let ReturnData::Value(value) = outcome.return_data {

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -14,8 +14,8 @@ pub fn test_ts_contract() {
     let config = test_vm_config();
     with_vm_variants(&config, |vm_kind: VMKind| {
         let code = ContractCode::new(near_test_contracts::ts_contract().to_vec(), None);
-        let code_hash = code.hash();
-        let mut fake_external = MockedExternal::with_code_hash(*code_hash);
+        let mut fake_external = MockedExternal::with_code(code);
+        let code = ContractCode::new(near_test_contracts::ts_contract().to_vec(), None);
 
         let context = create_context(Vec::new());
         let fees = RuntimeFeesConfig::test();

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -15,7 +15,7 @@ pub fn test_ts_contract() {
     with_vm_variants(&config, |vm_kind: VMKind| {
         let code = ContractCode::new(near_test_contracts::ts_contract().to_vec(), None);
         let code_hash = code.hash();
-        let mut fake_external = MockedExternal::new();
+        let mut fake_external = MockedExternal::with_code_hash(*code_hash);
 
         let context = create_context(Vec::new());
         let fees = RuntimeFeesConfig::test();
@@ -24,7 +24,6 @@ pub fn test_ts_contract() {
         let promise_results = vec![];
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
         let result = runtime.run(
-            *code_hash,
             Some(&code),
             "try_panic",
             &mut fake_external,
@@ -45,7 +44,6 @@ pub fn test_ts_contract() {
         let context = create_context(b"foo bar".to_vec());
         runtime
             .run(
-                *code_hash,
                 Some(&code),
                 "try_storage_write",
                 &mut fake_external,
@@ -68,7 +66,6 @@ pub fn test_ts_contract() {
         let context = create_context(b"foo".to_vec());
         let outcome = runtime
             .run(
-                *code_hash,
                 Some(&code),
                 "try_storage_read",
                 &mut fake_external,

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -12,7 +12,6 @@ use crate::{get_contract_cache_key, imports, ContractCode};
 use memoffset::offset_of;
 use near_parameters::vm::VMKind;
 use near_parameters::RuntimeFeesConfig;
-use near_primitives_core::hash::CryptoHash;
 use std::borrow::Cow;
 use std::hash::Hash;
 use std::mem::size_of;
@@ -565,7 +564,6 @@ impl wasmer_vm::Tunables for &Wasmer2VM {
 impl crate::runner::VM for Wasmer2VM {
     fn run(
         &self,
-        _code_hash: CryptoHash,
         code: Option<&ContractCode>,
         method_name: &str,
         ext: &mut dyn External,

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -571,7 +571,7 @@ impl crate::runner::VM for Wasmer2VM {
         promise_results: &[PromiseResult],
         cache: Option<&dyn ContractRuntimeCache>,
     ) -> Result<VMOutcome, VMRunnerError> {
-        let Some(code) = ext.get_contract().map_err(|err| VMRunnerError::GetContract(err))? else {
+        let Some(code) = ext.get_contract() else {
             return Err(VMRunnerError::ContractCodeNotPresent);
         };
         let mut memory = Wasmer2Memory::new(

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -11,7 +11,6 @@ use crate::runner::VMResult;
 use crate::{get_contract_cache_key, imports, ContractCode};
 use near_parameters::vm::{Config, VMKind};
 use near_parameters::RuntimeFeesConfig;
-use near_primitives_core::hash::CryptoHash;
 use std::borrow::Cow;
 use std::ffi::c_void;
 use wasmer_runtime::units::Pages;
@@ -417,7 +416,6 @@ impl Wasmer0VM {
 impl crate::runner::VM for Wasmer0VM {
     fn run(
         &self,
-        _code_hash: CryptoHash,
         code: Option<&ContractCode>,
         method_name: &str,
         ext: &mut dyn External,

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -416,7 +416,6 @@ impl Wasmer0VM {
 impl crate::runner::VM for Wasmer0VM {
     fn run(
         &self,
-        code: Option<&ContractCode>,
         method_name: &str,
         ext: &mut dyn External,
         context: &VMContext,
@@ -424,10 +423,8 @@ impl crate::runner::VM for Wasmer0VM {
         promise_results: &[PromiseResult],
         cache: Option<&dyn ContractRuntimeCache>,
     ) -> Result<VMOutcome, VMRunnerError> {
-        let Some(code) = code else {
-            return Err(VMRunnerError::CacheError(CacheError::ReadError(std::io::Error::from(
-                std::io::ErrorKind::NotFound,
-            ))));
+        let Some(code) = ext.get_contract().map_err(|err| VMRunnerError::GetContract(err))? else {
+            return Err(VMRunnerError::ContractCodeNotPresent);
         };
         if !cfg!(target_arch = "x86") && !cfg!(target_arch = "x86_64") {
             // TODO(#1940): Remove once NaN is standardized by the VM.
@@ -457,7 +454,7 @@ impl crate::runner::VM for Wasmer0VM {
         }
 
         // TODO: consider using get_module() here, once we'll go via deployment path.
-        let module = self.compile_and_load(code, cache)?;
+        let module = self.compile_and_load(&code, cache)?;
         let module = match module {
             Ok(x) => x,
             // Note on backwards-compatibility: This error used to be an error

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -423,7 +423,7 @@ impl crate::runner::VM for Wasmer0VM {
         promise_results: &[PromiseResult],
         cache: Option<&dyn ContractRuntimeCache>,
     ) -> Result<VMOutcome, VMRunnerError> {
-        let Some(code) = ext.get_contract().map_err(|err| VMRunnerError::GetContract(err))? else {
+        let Some(code) = ext.get_contract() else {
             return Err(VMRunnerError::ContractCodeNotPresent);
         };
         if !cfg!(target_arch = "x86") && !cfg!(target_arch = "x86_64") {

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -9,7 +9,6 @@ use crate::logic::{External, MemSlice, MemoryLike, VMContext, VMLogic, VMOutcome
 use crate::{imports, prepare, ContractCode, ContractRuntimeCache};
 use near_parameters::vm::VMKind;
 use near_parameters::RuntimeFeesConfig;
-use near_primitives_core::hash::CryptoHash;
 use std::borrow::Cow;
 use std::cell::{RefCell, UnsafeCell};
 use std::ffi::c_void;
@@ -152,7 +151,6 @@ impl WasmtimeVM {
 impl crate::runner::VM for WasmtimeVM {
     fn run(
         &self,
-        _code_hash: CryptoHash,
         code: Option<&ContractCode>,
         method_name: &str,
         ext: &mut dyn External,

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -158,7 +158,7 @@ impl crate::runner::VM for WasmtimeVM {
         promise_results: &[PromiseResult],
         _cache: Option<&dyn ContractRuntimeCache>,
     ) -> Result<VMOutcome, VMRunnerError> {
-        let Some(code) = ext.get_contract().map_err(|err| VMRunnerError::GetContract(err))? else {
+        let Some(code) = ext.get_contract() else {
             return Err(VMRunnerError::ContractCodeNotPresent);
         };
         let mut config = self.default_wasmtime_config();

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -78,7 +78,6 @@ fn compute_function_call_cost(
     for _ in 0..warmup_repeats {
         let result = runtime
             .run(
-                Some(&contract),
                 "hello0",
                 &mut fake_external,
                 &fake_context,
@@ -94,7 +93,6 @@ fn compute_function_call_cost(
     for _ in 0..repeats {
         let result = runtime
             .run(
-                Some(&contract),
                 "hello0",
                 &mut fake_external,
                 &fake_context,

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -77,14 +77,7 @@ fn compute_function_call_cost(
     // Warmup.
     for _ in 0..warmup_repeats {
         let result = runtime
-            .run(
-                "hello0",
-                &mut fake_external,
-                &fake_context,
-                &fees,
-                &promise_results,
-                cache,
-            )
+            .run("hello0", &mut fake_external, &fake_context, &fees, &promise_results, cache)
             .expect("fatal error");
         assert!(result.aborted.is_none());
     }
@@ -92,14 +85,7 @@ fn compute_function_call_cost(
     let start = GasCost::measure(gas_metric);
     for _ in 0..repeats {
         let result = runtime
-            .run(
-                "hello0",
-                &mut fake_external,
-                &fake_context,
-                &fees,
-                &promise_results,
-                cache,
-            )
+            .run("hello0", &mut fake_external, &fake_context, &fees, &promise_results, cache)
             .expect("fatal_error");
         assert!(result.aborted.is_none());
     }

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -70,7 +70,7 @@ fn compute_function_call_cost(
     let vm_config = runtime_config.wasm_config.clone();
     let runtime = vm_kind.runtime(vm_config).expect("runtime has not been enabled");
     let fees = runtime_config.fees.clone();
-    let mut fake_external = MockedExternal::new();
+    let mut fake_external = MockedExternal::with_code_hash(*contract.hash());
     let fake_context = create_context(vec![]);
     let promise_results = vec![];
 
@@ -78,7 +78,6 @@ fn compute_function_call_cost(
     for _ in 0..warmup_repeats {
         let result = runtime
             .run(
-                *contract.hash(),
                 Some(&contract),
                 "hello0",
                 &mut fake_external,
@@ -95,7 +94,6 @@ fn compute_function_call_cost(
     for _ in 0..repeats {
         let result = runtime
             .run(
-                *contract.hash(),
                 Some(&contract),
                 "hello0",
                 &mut fake_external,

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -70,7 +70,7 @@ fn compute_function_call_cost(
     let vm_config = runtime_config.wasm_config.clone();
     let runtime = vm_kind.runtime(vm_config).expect("runtime has not been enabled");
     let fees = runtime_config.fees.clone();
-    let mut fake_external = MockedExternal::with_code(contract.clone());
+    let mut fake_external = MockedExternal::with_code(contract.clone_for_tests());
     let fake_context = create_context(vec![]);
     let promise_results = vec![];
 

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -70,7 +70,7 @@ fn compute_function_call_cost(
     let vm_config = runtime_config.wasm_config.clone();
     let runtime = vm_kind.runtime(vm_config).expect("runtime has not been enabled");
     let fees = runtime_config.fees.clone();
-    let mut fake_external = MockedExternal::with_code_hash(*contract.hash());
+    let mut fake_external = MockedExternal::with_code(contract.clone());
     let fake_context = create_context(vec![]);
     let promise_results = vec![];
 

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -138,7 +138,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     let runtime = vm_kind.runtime(vm_config_gas).expect("runtime has not been enabled");
     let runtime_free_gas = vm_kind.runtime(vm_config_free).expect("runtime has not been enabled");
     let fees = runtime_config.fees.clone();
-    let mut fake_external = MockedExternal::with_code(contract.clone());
+    let mut fake_external = MockedExternal::with_code(contract.clone_for_tests());
     let fake_context = create_context(vec![]);
     let promise_results = vec![];
 

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -146,7 +146,6 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     for _ in 0..warmup_repeats {
         let result = runtime
             .run(
-                Some(&contract),
                 "hello",
                 &mut fake_external,
                 &fake_context,
@@ -166,7 +165,6 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     for _ in 0..repeats {
         let result = runtime
             .run(
-                Some(&contract),
                 "hello",
                 &mut fake_external,
                 &fake_context,
@@ -183,7 +181,6 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     for _ in 0..warmup_repeats {
         let result = runtime_free_gas
             .run(
-                Some(&contract),
                 "hello",
                 &mut fake_external,
                 &fake_context,
@@ -200,7 +197,6 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     for _ in 0..repeats {
         let result = runtime_free_gas
             .run(
-                Some(&contract),
                 "hello",
                 &mut fake_external,
                 &fake_context,

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -145,14 +145,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     // Warmup with gas metering
     for _ in 0..warmup_repeats {
         let result = runtime
-            .run(
-                "hello",
-                &mut fake_external,
-                &fake_context,
-                &fees,
-                &promise_results,
-                cache,
-            )
+            .run("hello", &mut fake_external, &fake_context, &fees, &promise_results, cache)
             .expect("fatal_error");
         if let Some(err) = &result.aborted {
             eprintln!("error: {}", err);
@@ -164,14 +157,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     let start = GasCost::measure(gas_metric);
     for _ in 0..repeats {
         let result = runtime
-            .run(
-                "hello",
-                &mut fake_external,
-                &fake_context,
-                &fees,
-                &promise_results,
-                cache,
-            )
+            .run("hello", &mut fake_external, &fake_context, &fees, &promise_results, cache)
             .expect("fatal_error");
         assert!(result.aborted.is_none());
     }
@@ -180,14 +166,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     // Warmup without gas metering
     for _ in 0..warmup_repeats {
         let result = runtime_free_gas
-            .run(
-                "hello",
-                &mut fake_external,
-                &fake_context,
-                &fees,
-                &promise_results,
-                cache,
-            )
+            .run("hello", &mut fake_external, &fake_context, &fees, &promise_results, cache)
             .expect("fatal_error");
         assert!(result.aborted.is_none());
     }
@@ -196,14 +175,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     let start = GasCost::measure(gas_metric);
     for _ in 0..repeats {
         let result = runtime_free_gas
-            .run(
-                "hello",
-                &mut fake_external,
-                &fake_context,
-                &fees,
-                &promise_results,
-                cache,
-            )
+            .run("hello", &mut fake_external, &fake_context, &fees, &promise_results, cache)
             .expect("fatal_error");
         assert!(result.aborted.is_none());
     }

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -138,7 +138,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     let runtime = vm_kind.runtime(vm_config_gas).expect("runtime has not been enabled");
     let runtime_free_gas = vm_kind.runtime(vm_config_free).expect("runtime has not been enabled");
     let fees = runtime_config.fees.clone();
-    let mut fake_external = MockedExternal::new();
+    let mut fake_external = MockedExternal::with_code_hash(*contract.hash());
     let fake_context = create_context(vec![]);
     let promise_results = vec![];
 
@@ -146,7 +146,6 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     for _ in 0..warmup_repeats {
         let result = runtime
             .run(
-                *contract.hash(),
                 Some(&contract),
                 "hello",
                 &mut fake_external,
@@ -167,7 +166,6 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     for _ in 0..repeats {
         let result = runtime
             .run(
-                *contract.hash(),
                 Some(&contract),
                 "hello",
                 &mut fake_external,
@@ -185,7 +183,6 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     for _ in 0..warmup_repeats {
         let result = runtime_free_gas
             .run(
-                *contract.hash(),
                 Some(&contract),
                 "hello",
                 &mut fake_external,
@@ -203,7 +200,6 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     for _ in 0..repeats {
         let result = runtime_free_gas
             .run(
-                *contract.hash(),
                 Some(&contract),
                 "hello",
                 &mut fake_external,

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -138,7 +138,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     let runtime = vm_kind.runtime(vm_config_gas).expect("runtime has not been enabled");
     let runtime_free_gas = vm_kind.runtime(vm_config_free).expect("runtime has not been enabled");
     let fees = runtime_config.fees.clone();
-    let mut fake_external = MockedExternal::with_code_hash(*contract.hash());
+    let mut fake_external = MockedExternal::with_code(contract.clone());
     let fake_context = create_context(vec![]);
     let promise_results = vec![];
 

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -884,8 +884,7 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
     let n_iters = 10;
 
     let code = ContractCode::new(code.to_vec(), None);
-    let mut fake_external = MockedExternal::with_code_hash(*code.hash());
-
+    let mut fake_external = MockedExternal::with_code(code.clone());
     let config_store = RuntimeConfigStore::new(None);
     let config = config_store.get_config(PROTOCOL_VERSION).wasm_config.clone();
     let fees = RuntimeFeesConfig::test();

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -884,7 +884,8 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
     let n_iters = 10;
 
     let code = ContractCode::new(code.to_vec(), None);
-    let mut fake_external = MockedExternal::new();
+    let mut fake_external = MockedExternal::with_code_hash(*code.hash());
+
     let config_store = RuntimeConfigStore::new(None);
     let config = config_store.get_config(PROTOCOL_VERSION).wasm_config.clone();
     let fees = RuntimeFeesConfig::test();
@@ -897,7 +898,6 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
             .runtime(config.clone())
             .unwrap()
             .run(
-                *code.hash(),
                 Some(&code),
                 "cpu_ram_soak_test",
                 &mut fake_external,

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -884,7 +884,7 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
     let n_iters = 10;
 
     let code = ContractCode::new(code.to_vec(), None);
-    let mut fake_external = MockedExternal::with_code(code.clone());
+    let mut fake_external = MockedExternal::with_code(code.clone_for_tests());
     let config_store = RuntimeConfigStore::new(None);
     let config = config_store.get_config(PROTOCOL_VERSION).wasm_config.clone();
     let fees = RuntimeFeesConfig::test();

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -897,7 +897,6 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
             .runtime(config.clone())
             .unwrap()
             .run(
-                Some(&code),
                 "cpu_ram_soak_test",
                 &mut fake_external,
                 &context,

--- a/runtime/runtime-params-estimator/src/trie.rs
+++ b/runtime/runtime-params-estimator/src/trie.rs
@@ -249,7 +249,7 @@ fn read_node_from_accounting_cache_ext(
             // Create a new cache and load nodes into it as preparation.
             let caching_storage = testbed.trie_caching_storage();
             let mut accounting_cache = TrieAccountingCache::new(None);
-            accounting_cache.set_enabled(true);
+            accounting_cache.enable_switch().set(true);
             let _dummy_sum = read_raw_nodes_from_storage(
                 &caching_storage,
                 &mut accounting_cache,

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -39,7 +39,7 @@ use near_vm_runner::logic::errors::{
     CacheError, CompilationError, FunctionCallError, InconsistentStateError, VMRunnerError,
 };
 use near_vm_runner::logic::types::PromiseResult;
-use near_vm_runner::logic::{VMContext, VMOutcome};
+use near_vm_runner::logic::{External as _, VMContext, VMOutcome};
 use near_vm_runner::precompile_contract;
 use near_vm_runner::ContractCode;
 use near_wallet_contract::{wallet_contract, wallet_contract_magic_bytes};
@@ -125,8 +125,9 @@ pub(crate) fn execute_function_call(
                         });
                     return Ok(VMOutcome::nop_outcome(error));
                 }
-                Err(e) => {
-                    return Err(RuntimeError::StorageError(e));
+                Err(near_vm_runner::logic::GetContractError::StorageError(e)) => {
+                    let error = e.downcast().expect("downcast to a storage error");
+                    return Err(RuntimeError::StorageError(*error));
                 }
             };
             let r = near_vm_runner::run(

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -136,7 +136,7 @@ pub(crate) fn execute_function_call(
             return Ok(VMOutcome::nop_outcome(error));
         }
         Err(VMRunnerError::GetContract(GetContractError::StorageError(e))) => {
-            let error = e.downcast().expect("downcast to a storage error");
+            let error = e.downcast::<StorageError>().expect("downcast to a storage error");
             return Err(RuntimeError::StorageError(*error));
         }
         Err(VMRunnerError::ExternalError(any_err)) => {

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -21,6 +21,7 @@ pub struct RuntimeExt<'a> {
     trie_update: &'a mut TrieUpdate,
     pub(crate) receipt_manager: &'a mut ReceiptManager,
     account_id: &'a AccountId,
+    account: &'a Account,
     action_hash: &'a CryptoHash,
     data_count: u64,
     epoch_id: &'a EpochId,
@@ -63,6 +64,7 @@ impl<'a> RuntimeExt<'a> {
         trie_update: &'a mut TrieUpdate,
         receipt_manager: &'a mut ReceiptManager,
         account_id: &'a AccountId,
+        account: &'a Account,
         action_hash: &'a CryptoHash,
         epoch_id: &'a EpochId,
         prev_block_hash: &'a CryptoHash,
@@ -74,6 +76,7 @@ impl<'a> RuntimeExt<'a> {
             trie_update,
             receipt_manager,
             account_id,
+            account,
             action_hash,
             data_count: 0,
             epoch_id,
@@ -89,12 +92,14 @@ impl<'a> RuntimeExt<'a> {
         self.account_id
     }
 
-    pub fn get_contract(
-        &self,
-        account: &Account,
-    ) -> Result<Option<Arc<ContractCode>>, StorageError> {
+    #[inline]
+    pub fn account(&self) -> &'a Account {
+        self.account
+    }
+
+    pub fn get_contract(&self) -> Result<Option<Arc<ContractCode>>, StorageError> {
         let account_id = self.account_id();
-        let code_hash = account.code_hash();
+        let code_hash = self.code_hash();
         if checked_feature!("stable", EthImplicitAccounts, self.current_protocol_version)
             && account_id.get_account_type() == AccountType::EthImplicitAccount
         {
@@ -379,5 +384,9 @@ impl<'a> External for RuntimeExt<'a> {
 
     fn get_receipt_receiver(&self, receipt_index: ReceiptIndex) -> &AccountId {
         self.receipt_manager.get_receipt_receiver(receipt_index)
+    }
+
+    fn code_hash(&self) -> CryptoHash {
+        self.account.code_hash()
     }
 }

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -12,7 +12,7 @@ use near_primitives::version::ProtocolVersion;
 use near_store::{has_promise_yield_receipt, KeyLookupMode, TrieUpdate, TrieUpdateValuePtr};
 use near_vm_runner::logic::errors::{AnyError, VMLogicError};
 use near_vm_runner::logic::types::ReceiptIndex;
-use near_vm_runner::logic::{External, StorageGetMode, ValuePtr, GetContractError};
+use near_vm_runner::logic::{External, StorageGetMode, ValuePtr};
 use near_vm_runner::ContractCode;
 use near_wallet_contract::{wallet_contract, wallet_contract_magic_bytes};
 use std::sync::Arc;
@@ -368,7 +368,7 @@ impl<'a> External for RuntimeExt<'a> {
         self.account.code_hash()
     }
 
-    fn get_contract(&self) -> Result<Option<Arc<ContractCode>>, GetContractError> {
+    fn get_contract(&self) -> Option<Arc<ContractCode>> {
         let account_id = self.account_id();
         let code_hash = self.code_hash();
         if checked_feature!("stable", EthImplicitAccounts, self.current_protocol_version)
@@ -376,7 +376,7 @@ impl<'a> External for RuntimeExt<'a> {
         {
             let chain_id = self.chain_id();
             assert!(&code_hash == wallet_contract_magic_bytes(&chain_id).hash());
-            return Ok(Some(wallet_contract(&chain_id)));
+            return Some(wallet_contract(&chain_id));
         }
         if checked_feature!("stable", ChunkNodesCache, self.current_protocol_version) {
             self.trie_update.set_trie_cache_mode(TrieCacheMode::CachingShard);
@@ -387,6 +387,6 @@ impl<'a> External for RuntimeExt<'a> {
         if checked_feature!("stable", ChunkNodesCache, self.current_protocol_version) {
             self.trie_update.set_trie_cache_mode(TrieCacheMode::CachingChunk);
         }
-        Ok(contract)
+        contract
     }
 }

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -190,7 +190,7 @@ impl TrieViewer {
     ) -> Result<Vec<u8>, errors::CallFunctionError> {
         let now = Instant::now();
         let root = *state_update.get_root();
-        let mut account = get_account(&state_update, contract_id)?.ok_or_else(|| {
+        let account = get_account(&state_update, contract_id)?.ok_or_else(|| {
             errors::CallFunctionError::AccountDoesNotExist {
                 requested_account_id: contract_id.clone(),
             }
@@ -204,6 +204,7 @@ impl TrieViewer {
             &mut state_update,
             &mut receipt_manager,
             contract_id,
+            &account,
             &empty_hash,
             &view_state.epoch_id,
             &view_state.prev_block_hash,
@@ -251,7 +252,6 @@ impl TrieViewer {
         let outcome = execute_function_call(
             &apply_state,
             &mut runtime_ext,
-            &mut account,
             originator_id,
             &action_receipt,
             &[],


### PR DESCRIPTION
This simplifies the interface to the contract runtime and makes it
easier to split up the loading vs. instantiation vs. execution as it
gets exposed as an API from the contract runtime.

Thematically `VMContext` is probably more appropriate place for storing
some of this functionality, however Externals is quite a bit more of a
straightforward home for this functionality by the virtue of it already
having access to the storage where the contracts live in.

The downside of this being stored in `Externals` is precisely that until
this point `Externals` has been entirely focused on providing an interface
for host functions to interact with. And now the trait is gaining methods
that are slightly outside of that area of responsibility.