### PR TITLE
chore(congestion_control) - Added a dedicated protocol feature for allowed shard validation

### DIFF
--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -492,6 +492,7 @@ pub fn validate_chunk_state_witness(
     // Finally, verify that the newly proposed chunk matches everything we have computed.
     let (outgoing_receipts_root, _) = merklize(&outgoing_receipts_hashes);
     validate_chunk_with_chunk_extra_and_receipts_root(
+        protocol_version,
         &chunk_extra,
         &state_witness.chunk_header,
         &outgoing_receipts_root,

--- a/chain/chain/src/validate.rs
+++ b/chain/chain/src/validate.rs
@@ -14,6 +14,7 @@ use near_primitives::merkle::merklize;
 use near_primitives::sharding::{ShardChunk, ShardChunkHeader};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;
+use near_primitives::types::ProtocolVersion;
 use near_primitives::types::{AccountId, BlockHeight, EpochId, Nonce};
 
 use crate::types::RuntimeAdapter;
@@ -125,7 +126,11 @@ pub fn validate_chunk_with_chunk_extra(
     };
     let (outgoing_receipts_root, _) = merklize(&outgoing_receipts_hashes);
 
+    let prev_epoch_id = epoch_manager.get_epoch_id(prev_block_hash)?;
+    let prev_protocol_version = epoch_manager.get_epoch_protocol_version(&prev_epoch_id)?;
+
     validate_chunk_with_chunk_extra_and_receipts_root(
+        prev_protocol_version,
         prev_chunk_extra,
         chunk_header,
         &outgoing_receipts_root,
@@ -134,6 +139,7 @@ pub fn validate_chunk_with_chunk_extra(
 
 /// Validate that all next chunk information matches previous chunk extra.
 pub fn validate_chunk_with_chunk_extra_and_receipts_root(
+    prev_protocol_version: ProtocolVersion,
     prev_chunk_extra: &ChunkExtra,
     chunk_header: &ShardChunkHeader,
     outgoing_receipts_root: &CryptoHash,
@@ -177,7 +183,11 @@ pub fn validate_chunk_with_chunk_extra_and_receipts_root(
         return Err(Error::InvalidGasLimit);
     }
 
-    validate_congestion_info(&prev_chunk_extra.congestion_info(), &chunk_header.congestion_info())?;
+    validate_congestion_info(
+        prev_protocol_version,
+        &prev_chunk_extra.congestion_info(),
+        &chunk_header.congestion_info(),
+    )?;
 
     Ok(())
 }
@@ -187,6 +197,7 @@ pub fn validate_chunk_with_chunk_extra_and_receipts_root(
 /// trusted as it is the result of verified computation. The header congestion
 /// info is being validated.
 fn validate_congestion_info(
+    extra_protocol_version: ProtocolVersion,
     extra_congestion_info: &Option<CongestionInfo>,
     header_congestion_info: &Option<CongestionInfo>,
 ) -> Result<(), Error> {
@@ -200,14 +211,16 @@ fn validate_congestion_info(
             extra_congestion_info, header_congestion_info
         ))),
         // Congestion Info is present in both the extra and the header. Validate it.
-        (Some(extra), Some(header)) => CongestionInfo::validate_extra_and_header(extra, header)
-            .then_some(())
-            .ok_or_else(|| {
-                Error::InvalidCongestionInfo(format!(
-                    "Congestion Information validate error. extra: {:?}, header: {:?}",
-                    extra, header
-                ))
-            }),
+        (Some(extra), Some(header)) => {
+            CongestionInfo::validate_extra_and_header(extra_protocol_version, extra, header)
+                .then_some(())
+                .ok_or_else(|| {
+                    Error::InvalidCongestionInfo(format!(
+                        "Congestion Information validate error. extra: {:?}, header: {:?}",
+                        extra, header
+                    ))
+                })
+        }
     }
 }
 

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -157,6 +157,11 @@ pub enum ProtocolFeature {
     PerReceiptHardStorageProofLimit,
     /// Cross-shard congestion control according to <https://github.com/near/NEPs/pull/539>.
     CongestionControl,
+    /// The allowed shard validation for congestion control. This is only needed
+    /// for statelessnet where it's released separately from the main
+    /// CongestionControl feature.
+    /// TODO(congestion_control) - remove it on stabilization
+    CongestionControlAllowedShardValidation,
     // Stateless validation: Distribute state witness as reed solomon encoded parts
     PartialEncodedStateWitness,
     /// Size limits for transactions included in a ChunkStateWitness.
@@ -228,6 +233,7 @@ impl ProtocolFeature {
             ProtocolFeature::WitnessTransactionLimits
             | ProtocolFeature::CongestionControl
             | ProtocolFeature::OutgoingReceiptsSizeLimit => 87,
+            ProtocolFeature::CongestionControlAllowedShardValidation => 88,
 
             // Nightly features
             #[cfg(feature = "protocol_feature_fix_staking_threshold")]
@@ -258,7 +264,7 @@ const STABLE_PROTOCOL_VERSION: ProtocolVersion = 67;
 /// Largest protocol version supported by the current binary.
 pub const PROTOCOL_VERSION: ProtocolVersion = if cfg!(feature = "statelessnet_protocol") {
     // Current StatelessNet protocol version.
-    87
+    88
 } else if cfg!(feature = "nightly_protocol") {
     // On nightly, pick big enough version to support all features.
     143

--- a/core/primitives/src/congestion_info.rs
+++ b/core/primitives/src/congestion_info.rs
@@ -3,7 +3,10 @@ use std::collections::BTreeMap;
 use crate::errors::RuntimeError;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_parameters::config::CongestionControlConfig;
-use near_primitives_core::types::{Gas, ShardId};
+use near_primitives_core::{
+    types::{Gas, ProtocolVersion, ShardId},
+    version::ProtocolFeature,
+};
 
 /// This class combines the congestion control config, congestion info and
 /// missed chunks count. It contains the main congestion control logic and
@@ -150,13 +153,23 @@ impl CongestionInfo {
     // information from the chunk extra.
     //
     // TODO(congestion_control) validate allowed shard
-    pub fn validate_extra_and_header(extra: &CongestionInfo, header: &CongestionInfo) -> bool {
+    pub fn validate_extra_and_header(
+        extra_protocol_version: ProtocolVersion,
+        extra: &CongestionInfo,
+        header: &CongestionInfo,
+    ) -> bool {
         match (extra, header) {
             (CongestionInfo::V1(extra), CongestionInfo::V1(header)) => {
+                let correct_allowed_shard =
+                    if ProtocolFeature::CongestionControl.enabled(extra_protocol_version) {
+                        extra.allowed_shard == header.allowed_shard
+                    } else {
+                        true
+                    };
                 extra.delayed_receipts_gas == header.delayed_receipts_gas
                     && extra.buffered_receipts_gas == header.buffered_receipts_gas
                     && extra.receipt_bytes == header.receipt_bytes
-                    && extra.allowed_shard == header.allowed_shard
+                    && correct_allowed_shard
             }
         }
     }


### PR DESCRIPTION
The stateless validation was released without the allowed shard validation. Now that I want to add it back by adding #11526 it's going to be a protocol upgrade and should be handled as such. When stabilizing we can remove it to keep the code cleaner. 