### PR TITLE
bench: simplify db permissions

### DIFF
--- a/benchmarks/continous/db/README.md
+++ b/benchmarks/continous/db/README.md
@@ -29,10 +29,8 @@ A role with read-only permissions is created for Grafana:
 create role grafana_reader login password 'store_it_in_1password';
 grant connect on database benchmarks to grafana_reader;
 
--- Execute these statements when connected to the benchmarks db.
-grant usage on schema public to grafana_reader;
--- Repeat this when creating a new db that should be available in Grafana.
-grant select on ft_transfer to grafana_reader;
+-- Execute this statement when connected to the benchmarks db.
+grant pg_read_all_data to grafana_reader;
 ```
 
 The `grafana_reader` may use up to 20 connections. To verify that the PostgreSQL instance allows a sufficient number of connections you can run:

--- a/benchmarks/continous/db/tool/orm/migrations/2024-06-12-094545_simplify_permissions/down.sql
+++ b/benchmarks/continous/db/tool/orm/migrations/2024-06-12-094545_simplify_permissions/down.sql
@@ -1,0 +1,7 @@
+grant select on ft_transfers to grafana_reader;
+grant select on ft_transfers to benchmark_runner;
+grant insert on ft_transfers to benchmark_runner;
+
+revoke pg_read_all_data from grafana_reader;
+revoke pg_read_all_data from benchmark_runner;
+revoke pg_write_all_data from benchmark_runner;

--- a/benchmarks/continous/db/tool/orm/migrations/2024-06-12-094545_simplify_permissions/up.sql
+++ b/benchmarks/continous/db/tool/orm/migrations/2024-06-12-094545_simplify_permissions/up.sql
@@ -1,0 +1,13 @@
+-- Cleanup permissions granted previously. See comment below for motivation.
+revoke select on ft_transfers from grafana_reader;
+revoke select on ft_transfers from benchmark_runner;
+revoke insert on ft_transfers from benchmar_runner;
+
+-- Granting individual permissions like done previously is tedious and error
+-- prone. In addition it must be repeated for all new tables.
+-- The benchmarks db contains no sensitive data, so we can use
+-- `pg_read_all_data` and `pg_write_all_data` to simplify things. These
+-- permissions automatically apply to new tables added in the future.
+grant pg_read_all_data to grafana_reader;
+grant pg_read_all_data to benchmark_runner;
+grant pg_write_all_data to benchmark_runner;


### PR DESCRIPTION
As the db does not contain sensitive data, permission management can be simplified by granting `pg_read_all_data` and `pg_write_all_data` instead of more fine grained permissions.