### PR TITLE
fix: no chunk-only producer in stateless validation

### DIFF
--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -168,6 +168,8 @@ pub enum ProtocolFeature {
     WitnessTransactionLimits,
     /// Size limit on outgoing receipts.
     OutgoingReceiptsSizeLimit,
+    /// No chunk-only producers in stateless validation
+    NoChunkOnlyProducers,
 }
 
 impl ProtocolFeature {
@@ -233,7 +235,8 @@ impl ProtocolFeature {
             ProtocolFeature::WitnessTransactionLimits
             | ProtocolFeature::CongestionControl
             | ProtocolFeature::OutgoingReceiptsSizeLimit => 87,
-            ProtocolFeature::CongestionControlAllowedShardValidation => 88,
+            ProtocolFeature::CongestionControlAllowedShardValidation
+            | ProtocolFeature::NoChunkOnlyProducers => 88,
 
             // Nightly features
             #[cfg(feature = "protocol_feature_fix_staking_threshold")]

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -261,6 +261,7 @@ impl AllEpochConfig {
         // mainnet, to make it easier to test the change.
         if chain_id != near_primitives_core::chains::MAINNET
             && checked_feature!("stable", TestnetFewerBlockProducers, protocol_version)
+            && !checked_feature!("stable", NoChunkOnlyProducers, protocol_version)
         {
             let shard_ids = config.shard_layout.shard_ids();
             // Decrease the number of block producers from 100 to 20.
@@ -269,6 +270,11 @@ impl AllEpochConfig {
                 shard_ids.map(|_| config.num_block_producer_seats).collect();
             // Decrease the number of chunk producers.
             config.validator_selection_config.num_chunk_only_producer_seats = 100;
+        }
+
+        if checked_feature!("stable", NoChunkOnlyProducers, protocol_version) {
+            // Make sure there is no chunk only producer in stateless validation
+            config.validator_selection_config.num_chunk_only_producer_seats = 0;
         }
     }
 


### PR DESCRIPTION
We had this code change that forced 20 block producers on chain ids that are not mainnet. However, it makes no sense in stateless validation where there is no chunk-only producers. Fixed this by introducing a new protocol version.