### PR TITLE
mocknet: Add ability to customize project

### DIFF
--- a/pytest/lib/mocknet.py
+++ b/pytest/lib/mocknet.py
@@ -89,21 +89,21 @@ ACCOUNTS = {
 }
 
 
-def get_node(hostname):
+def get_node(hostname, project=PROJECT):
     instance_name = hostname
     n = GCloudNode(
         instance_name,
         username=NODE_USERNAME,
-        project=PROJECT,
+        project=project,
         ssh_key_path=NODE_SSH_KEY_PATH,
     )
     return n
 
 
-def get_nodes(pattern=None):
+def get_nodes(pattern=None, project=PROJECT):
     machines = gcloud.list(
         pattern=pattern,
-        project=PROJECT,
+        project=project,
         username=NODE_USERNAME,
         ssh_key_path=NODE_SSH_KEY_PATH,
     )
@@ -111,7 +111,7 @@ def get_nodes(pattern=None):
         lambda machine: GCloudNode(
             machine.name,
             username=NODE_USERNAME,
-            project=PROJECT,
+            project=project,
             ssh_key_path=NODE_SSH_KEY_PATH,
         ),
         machines,


### PR DESCRIPTION
This allows scripts that use this file to specify which project they want to use without forcing the user to set environment variable.