### PR TITLE
Add a metric showing what limited number of processed receipts in a chunk

### DIFF
--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1823,6 +1823,23 @@ impl Runtime {
             proof_size_limit,
         )?;
 
+        let shard_id_str = processing_state.apply_state.shard_id.to_string();
+        if processing_state.total.compute >= compute_limit {
+            metrics::CHUNK_RECEIPTS_LIMITED_BY
+                .with_label_values(&[shard_id_str.as_str(), "compute_limit"])
+                .inc();
+        } else if proof_size_limit.is_some_and(|limit| {
+            processing_state.state_update.trie.recorded_storage_size_upper_bound() > limit
+        }) {
+            metrics::CHUNK_RECEIPTS_LIMITED_BY
+                .with_label_values(&[shard_id_str.as_str(), "storage_proof_size_limit"])
+                .inc();
+        } else {
+            metrics::CHUNK_RECEIPTS_LIMITED_BY
+                .with_label_values(&[shard_id_str.as_str(), "unlimited"])
+                .inc();
+        }
+
         Ok(ProcessReceiptsResult {
             promise_yield_result,
             validator_proposals,

--- a/runtime/runtime/src/metrics.rs
+++ b/runtime/runtime/src/metrics.rs
@@ -398,6 +398,15 @@ static CONGESTION_OUTGOING_GAS: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub(crate) static CHUNK_RECEIPTS_LIMITED_BY: Lazy<IntCounterVec> = Lazy::new(|| {
+    try_create_int_counter_vec(
+        "near_chunk_receipts_limited_by",
+        "Number of chunks where the number of processed receipts was limited by a certain factor.",
+        &["shard_id", "limited_by"],
+    )
+    .unwrap()
+});
+
 /// Buckets used for burned gas in receipts.
 ///
 /// The maximum possible is 1300 Tgas for a full chunk.


### PR DESCRIPTION
The metric counts the number of chunks where the number of processed receipts was limited by a certain factor.

Here's an example visualisation from a localnet node with ft.py loadtest at ~500 TPS:

![image](https://github.com/near/nearcore/assets/149345204/b2cdcd51-e620-49e3-9507-6282a36144a7)

We can see that for ~20% of chunks on shard 0 the number of processed receipts was limited by the `compute_limit`.

This will allow us to see what's the bottleneck for receipt processing - is it the compute limit, storage proof limit, or something else.