### PR TITLE
fix: make new ValidatorKickoutReason backwards compatible

### DIFF
--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -110,5 +110,5 @@ nightly_protocol = [
   "near-vm-runner/nightly_protocol",
   "node-runtime/nightly_protocol",
 ]
-statelessnet_protocol = ["near-primitives/statelessnet_protocol"]
+statelessnet_protocol = ["near-store/statelessnet_protocol", "near-primitives/statelessnet_protocol"]
 sandbox = ["near-primitives/sandbox"]

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -63,6 +63,7 @@ nightly = [
   "node-runtime/nightly",
 ]
 statelessnet_protocol = [
+  "near-client/statelessnet_protocol",
   "near-primitives/statelessnet_protocol",
   "nearcore/statelessnet_protocol",
 ]

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -1066,8 +1066,6 @@ pub enum ValidatorKickoutReason {
     NotEnoughBlocks { produced: NumBlocks, expected: NumBlocks },
     /// Validator didn't produce enough chunks.
     NotEnoughChunks { produced: NumBlocks, expected: NumBlocks },
-    /// Validator didn't produce enough chunk endorsements.
-    NotEnoughChunkEndorsements { produced: NumBlocks, expected: NumBlocks },
     /// Validator unstaked themselves.
     Unstaked,
     /// Validator stake is now below threshold
@@ -1079,6 +1077,8 @@ pub enum ValidatorKickoutReason {
     },
     /// Enough stake but is not chosen because of seat limits.
     DidNotGetASeat,
+    /// Validator didn't produce enough chunk endorsements.
+    NotEnoughChunkEndorsements { produced: NumBlocks, expected: NumBlocks },
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -1066,6 +1066,8 @@ pub enum ValidatorKickoutReason {
     NotEnoughBlocks { produced: NumBlocks, expected: NumBlocks },
     /// Validator didn't produce enough chunks.
     NotEnoughChunks { produced: NumBlocks, expected: NumBlocks },
+    /// Validator didn't produce enough chunk endorsements.
+    NotEnoughChunkEndorsements { produced: NumBlocks, expected: NumBlocks },
     /// Validator unstaked themselves.
     Unstaked,
     /// Validator stake is now below threshold
@@ -1077,8 +1079,6 @@ pub enum ValidatorKickoutReason {
     },
     /// Enough stake but is not chosen because of seat limits.
     DidNotGetASeat,
-    /// Validator didn't produce enough chunk endorsements.
-    NotEnoughChunkEndorsements { produced: NumBlocks, expected: NumBlocks },
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -103,3 +103,6 @@ nightly = [
   "near-vm-runner/nightly",
   "nightly_protocol",
 ]
+statelessnet_protocol = [
+  "near-primitives/statelessnet_protocol",
+]

--- a/core/store/src/metadata.rs
+++ b/core/store/src/metadata.rs
@@ -2,7 +2,7 @@
 pub type DbVersion = u32;
 
 /// Current version of the database.
-pub const DB_VERSION: DbVersion = 39;
+pub const DB_VERSION: DbVersion = 40;
 
 /// Database version at which point DbKind was introduced.
 const DB_VERSION_WITH_KIND: DbVersion = 34;

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -348,6 +348,15 @@ pub fn migrate_38_to_39(store: &Store) -> anyhow::Result<()> {
 ///
 /// Rewrites ValidatorKickoutReason to introduce NotEnoughChunkEndorsements variant
 pub fn migrate_39_to_40(store: &Store) -> anyhow::Result<()> {
+    if cfg!(feature = "statelessnet_protocol") {
+        tracing::info!(
+            target: "migrations",
+            "For statelessnet, ValidatorKickoutReason is already at correct format. \
+            Skipping migration from 39 to 40."
+        );
+        return Ok(());
+    }
+
     use near_primitives::serialize::dec_format;
     #[derive(BorshDeserialize, serde::Deserialize)]
     pub enum LegacyValidatorKickoutReason {

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -7,7 +7,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::state::FlatStateValue;
 use near_primitives::transaction::{ExecutionOutcomeWithIdAndProof, ExecutionOutcomeWithProof};
 use near_primitives::types::{
-    validator_stake::ValidatorStake, AccountId, EpochId, ShardId, ValidatorId,
+    validator_stake::ValidatorStake, AccountId, Balance, EpochId, NumBlocks, ShardId, ValidatorId,
     ValidatorKickoutReason, ValidatorStats,
 };
 use near_primitives::types::{BlockChunkValidatorStats, ChunkStats};
@@ -335,6 +335,94 @@ pub fn migrate_38_to_39(store: &Store) -> anyhow::Result<()> {
                     (account_id, new_stats)
                 })
                 .collect(),
+            next_next_epoch_version: legacy_summary.next_version,
+        };
+        update.set(DBCol::EpochValidatorInfo, &key, &borsh::to_vec(&new_value)?);
+    }
+
+    update.commit()?;
+    Ok(())
+}
+
+/// Migrates the database from version 39 to 40.
+///
+/// Rewrites ValidatorKickoutReason to introduce NotEnoughChunkEndorsements variant
+pub fn migrate_39_to_40(store: &Store) -> anyhow::Result<()> {
+    pub enum LegacyValidatorKickoutReason {
+        /// Slashed validators are kicked out.
+        Slashed,
+        /// Validator didn't produce enough blocks.
+        NotEnoughBlocks { produced: NumBlocks, expected: NumBlocks },
+        /// Validator didn't produce enough chunks.
+        NotEnoughChunks { produced: NumBlocks, expected: NumBlocks },
+        /// Validator unstaked themselves.
+        Unstaked,
+        /// Validator stake is now below threshold
+        NotEnoughStake {
+            #[serde(with = "dec_format", rename = "stake_u128")]
+            stake: Balance,
+            #[serde(with = "dec_format", rename = "threshold_u128")]
+            threshold: Balance,
+        },
+        /// Enough stake but is not chosen because of seat limits.
+        DidNotGetASeat,
+        /// Validator didn't produce enough chunk endorsements.
+        NotEnoughChunkEndorsements { produced: NumBlocks, expected: NumBlocks },
+    }
+
+    #[derive(BorshDeserialize)]
+    struct LegacyEpochSummary {
+        pub prev_epoch_last_block_hash: CryptoHash,
+        /// Proposals from the epoch, only the latest one per account
+        pub all_proposals: Vec<ValidatorStake>,
+        /// Kickout set, includes slashed
+        pub validator_kickout: HashMap<AccountId, LegacyValidatorKickoutReason>,
+        /// Only for validators who met the threshold and didn't get slashed
+        pub validator_block_chunk_stats: HashMap<AccountId, BlockChunkValidatorStats>,
+        /// Protocol version for next epoch.
+        pub next_version: ProtocolVersion,
+    }
+
+    impl From<LegacyValidatorKickoutReason> for ValidatorKickoutReason {
+        fn from(reason: LegacyValidatorKickoutReason) -> Self {
+            match reason {
+                LegacyValidatorKickoutReason::Slashed => ValidatorKickoutReason::Slashed,
+                LegacyValidatorKickoutReason::NotEnoughBlocks { produced, expected } => {
+                    ValidatorKickoutReason::NotEnoughBlocks { produced, expected }
+                }
+                LegacyValidatorKickoutReason::NotEnoughChunks { produced, expected } => {
+                    ValidatorKickoutReason::NotEnoughChunks { produced, expected }
+                }
+                LegacyValidatorKickoutReason::Unstaked => ValidatorKickoutReason::Unstaked,
+                LegacyValidatorKickoutReason::NotEnoughStake { stake, threshold } => {
+                    ValidatorKickoutReason::NotEnoughStake { stake, threshold }
+                }
+                LegacyValidatorKickoutReason::DidNotGetASeat => {
+                    ValidatorKickoutReason::DidNotGetASeat
+                }
+                LegacyValidatorKickoutReason::NotEnoughChunkEndorsements { produced, expected } => {
+                    ValidatorKickoutReason::NotEnoughChunkEndorsements { produced, expected }
+                }
+            }
+        }
+    }
+
+    let mut update = store.store_update();
+    // Update EpochSummary
+    for result in store.iter(DBCol::EpochValidatorInfo) {
+        let (key, old_value) = result?;
+        let legacy_summary = LegacyEpochSummary::try_from_slice(&old_value)?;
+        let legacy_validator_kickout = legacy_summary.validator_kickout;
+        let validator_kickout: HashMap<AccountId, ValidatorKickoutReason> =
+            legacy_validator_kickout
+                .into_iter()
+                .map(|(account, kickout)| (account, kickout.into()))
+                .collect();
+        let new_value = EpochSummary {
+            prev_epoch_last_block_hash: legacy_summary.prev_epoch_last_block_hash,
+            all_proposals: legacy_summary.all_proposals,
+            validator_kickout,
+            validator_block_chunk_stats: legacy_summary.validator_block_chunk_stats,
             next_next_epoch_version: legacy_summary.next_version,
         };
         update.set(DBCol::EpochValidatorInfo, &key, &borsh::to_vec(&new_value)?);

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -348,6 +348,8 @@ pub fn migrate_38_to_39(store: &Store) -> anyhow::Result<()> {
 ///
 /// Rewrites ValidatorKickoutReason to introduce NotEnoughChunkEndorsements variant
 pub fn migrate_39_to_40(store: &Store) -> anyhow::Result<()> {
+    use near_primitives::serialize::dec_format;
+    #[derive(BorshDeserialize, serde::Deserialize)]
     pub enum LegacyValidatorKickoutReason {
         /// Slashed validators are kicked out.
         Slashed,

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -88,6 +88,7 @@ impl<'a> near_store::StoreMigrator for Migrator<'a> {
             36 => near_store::migrations::migrate_36_to_37(store),
             37 => near_store::migrations::migrate_37_to_38(store),
             38 => near_store::migrations::migrate_38_to_39(store),
+            39 => near_store::migrations::migrate_39_to_40(store),
             DB_VERSION.. => unreachable!(),
         }
     }


### PR DESCRIPTION
Properly migrate to new ValidatorKickoutReason enum because order of variants matter for borsh serialization.

Statelessnet was started already from new enum so migration must be skipped for it.

Needs merge to unblock testnet canaries https://near.zulipchat.com/#narrow/stream/308695-nearone.2Fprivate/topic/Testnet.20canaries.20all.20crashed/near/444467227