### PR TITLE
rust: 1.79.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 version = "0.0.0"                               # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
-rust-version = "1.78.0"
+rust-version = "1.79.0"
 repository = "https://github.com/near/nearcore"
 license = "MIT OR Apache-2.0"
 

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -111,4 +111,4 @@ nightly_protocol = [
   "node-runtime/nightly_protocol",
 ]
 statelessnet_protocol = ["near-primitives/statelessnet_protocol"]
-sandbox = ["near-primitives/sandbox"]
+sandbox = ["near-o11y/sandbox", "near-primitives/sandbox"]

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -121,6 +121,7 @@ nightly = [
 sandbox = [
   "near-client-primitives/sandbox",
   "near-chain/sandbox",
+  "near-o11y/sandbox",
 ]
 new_epoch_sync = [
   "near-chain/new_epoch_sync"

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -73,7 +73,7 @@ use near_primitives::network::PeerId;
 use near_primitives::receipt::Receipt;
 use near_primitives::sharding::StateSyncInfo;
 use near_primitives::sharding::{
-    ChunkHash, EncodedShardChunk, PartialEncodedChunk, ShardChunk, ShardChunkHeader, ShardInfo,
+    EncodedShardChunk, PartialEncodedChunk, ShardChunk, ShardChunkHeader, ShardInfo,
 };
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;
@@ -214,30 +214,6 @@ impl Client {
             .produce_chunk_add_transactions_time_limit
             .update(update_client_config.produce_chunk_add_transactions_time_limit);
     }
-}
-
-// Debug information about the upcoming block.
-#[derive(Default)]
-pub struct BlockDebugStatus {
-    // How long is this block 'in progress' (time since we first saw it).
-    pub in_progress_for: Option<Duration>,
-    // How long is this block in orphan pool.
-    pub in_orphan_for: Option<Duration>,
-    // List of chunk hashes that belong to this block.
-    pub chunk_hashes: Vec<ChunkHash>,
-
-    // Chunk statuses are below:
-    // We first sent the request to fetch the chunk
-    // Later we get the response from the peer and we try to reconstruct it.
-    // If reconstructions succeeds, the chunk will be marked as complete.
-    // If it fails (or fragments are missing) - we're going to re-request the chunk again.
-
-    // Chunks that we reqeusted (sent the request to peers).
-    pub chunks_requested: HashSet<ChunkHash>,
-    // Chunks for which we've received the response.
-    pub chunks_received: HashSet<ChunkHash>,
-    // Chunks completed - fully rebuild and present in database.
-    pub chunks_completed: HashSet<ChunkHash>,
 }
 
 pub struct ProduceChunkResult {

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -81,12 +81,6 @@ pub struct ViewClientRequestManager {
     pub tx_status_requests: lru::LruCache<CryptoHash, Instant>,
     /// Transaction status response
     pub tx_status_response: lru::LruCache<CryptoHash, FinalExecutionOutcomeView>,
-    /// Query requests that need to be forwarded to other shards
-    pub query_requests: lru::LruCache<String, Instant>,
-    /// Query responses from other nodes (can be errors)
-    pub query_responses: lru::LruCache<String, Result<QueryResponse, String>>,
-    /// Receipt outcome requests
-    pub receipt_outcome_requests: lru::LruCache<CryptoHash, Instant>,
 }
 
 pub type ViewClientActor = SyncActixWrapper<ViewClientActorInner>;
@@ -113,11 +107,6 @@ impl ViewClientRequestManager {
         Self {
             tx_status_requests: lru::LruCache::new(NonZeroUsize::new(QUERY_REQUEST_LIMIT).unwrap()),
             tx_status_response: lru::LruCache::new(NonZeroUsize::new(QUERY_REQUEST_LIMIT).unwrap()),
-            query_requests: lru::LruCache::new(NonZeroUsize::new(QUERY_REQUEST_LIMIT).unwrap()),
-            query_responses: lru::LruCache::new(NonZeroUsize::new(QUERY_REQUEST_LIMIT).unwrap()),
-            receipt_outcome_requests: lru::LruCache::new(
-                NonZeroUsize::new(QUERY_REQUEST_LIMIT).unwrap(),
-            ),
         }
     }
 }

--- a/chain/jsonrpc/Cargo.toml
+++ b/chain/jsonrpc/Cargo.toml
@@ -76,4 +76,5 @@ nightly_protocol = [
 ]
 sandbox = [
   "near-client/sandbox",
+  "near-o11y/sandbox",
 ]

--- a/chain/jsonrpc/jsonrpc-tests/Cargo.toml
+++ b/chain/jsonrpc/jsonrpc-tests/Cargo.toml
@@ -64,4 +64,4 @@ nightly_protocol = [
 statelessnet_protocol = [
   "near-primitives/statelessnet_protocol",
 ]
-sandbox = ["near-jsonrpc/sandbox"]
+sandbox = ["near-jsonrpc/sandbox", "near-o11y/sandbox"]

--- a/core/o11y/Cargo.toml
+++ b/core/o11y/Cargo.toml
@@ -51,6 +51,7 @@ nightly = [
   "nightly_protocol",
 ]
 io_trace = [ "near-fmt", "strum" ]
+sandbox = []
 
 [[bench]]
 name = "metrics"

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -161,7 +161,12 @@ statelessnet_protocol = [
   "near-chain/statelessnet_protocol",
   "near-primitives/statelessnet_protocol",
 ]
-sandbox = ["near-chain/sandbox", "node-runtime/sandbox", "near-client/sandbox"]
+sandbox = [
+  "near-chain/sandbox",
+  "near-client/sandbox",
+  "near-o11y/sandbox",
+  "node-runtime/sandbox",
+]
 no_cache = ["nearcore/no_cache"]
 calimero_zero_storage = []
 new_epoch_sync = ["nearcore/new_epoch_sync"]

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -185,8 +185,9 @@ statelessnet_protocol = [
 ]
 sandbox = [
   "near-client/sandbox",
-  "node-runtime/sandbox",
   "near-jsonrpc/sandbox",
+  "near-o11y/sandbox",
+  "node-runtime/sandbox",
 ]
 io_trace = ["near-vm-runner/io_trace"]
 

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -132,7 +132,7 @@ calimero_zero_storage = [
 # with this flag and then enable it at runtime with `--record-io-trace=path` option.
 io_trace = ["near-store/io_trace", "near-o11y/io_trace", "nearcore/io_trace"]
 
-sandbox = ["nearcore/sandbox"]
+sandbox = ["near-o11y/sandbox", "nearcore/sandbox"]
 
 [package.metadata.workspaces]
 independent = true

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -137,7 +137,7 @@ nightly = [
   "nightly_protocol",
   "protocol_feature_fix_contract_loading_cost",
 ]
-sandbox = []
+sandbox = ["near-o11y/sandbox"]
 io_trace = ["base64"]
 test_features = []
 

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -314,6 +314,7 @@ fn link<'a, 'b>(
                 });
                 unsafe {
                     // Transmute the lifetime of caller so it's possible to put it in a thread-local.
+                    #[allow(clippy::missing_transmute_annotations)]
                     crate::wasmtime_runner::CALLER.with(|runner_caller| *runner_caller.borrow_mut() = std::mem::transmute(caller));
                 }
                 let logic: &mut VMLogic<'_> = unsafe { &mut *(data as *mut VMLogic<'_>) };

--- a/runtime/near-vm/compiler/src/translator/environ.rs
+++ b/runtime/near-vm/compiler/src/translator/environ.rs
@@ -60,7 +60,7 @@ impl<'data> ModuleEnvironment<'data> {
     /// Translate a wasm module using this environment. This consumes the
     /// `ModuleEnvironment` and produces a `ModuleInfoTranslation`.
     #[tracing::instrument(target = "near_vm", level = "trace", skip_all)]
-    pub fn translate(mut self, data: &'data [u8]) -> WasmResult<ModuleEnvironment<'data>> {
+    pub fn translate(mut self, data: &'data [u8]) -> WasmResult<Self> {
         assert!(self.module_translation_state.is_none());
         let module_translation_state = translate_module(data, &mut self)?;
         self.module_translation_state = Some(module_translation_state);

--- a/runtime/near-vm/engine/src/universal/engine.rs
+++ b/runtime/near-vm/engine/src/universal/engine.rs
@@ -622,7 +622,9 @@ impl UniversalEngineInner {
                 // As lifetime annotations in Rust cannot influence the codegen, this is not a
                 // source of undefined behaviour but we do lose static lifetime checks that Rust
                 // enforces.
-                std::mem::transmute::<_, VMTrampoline>(code_memory.executable_address(offset))
+                std::mem::transmute::<*const u8, VMTrampoline>(
+                    code_memory.executable_address(offset),
+                )
             };
             allocated_function_call_trampolines.push(trampoline);
         }

--- a/runtime/near-vm/engine/src/universal/executable.rs
+++ b/runtime/near-vm/engine/src/universal/executable.rs
@@ -58,9 +58,7 @@ impl<'a> UniversalExecutableRef<'a> {
     /// Right now we are not doing any extra work for validation, but
     /// `rkyv` has an option to do bytecheck on the serialized data before
     /// serializing (via `rkyv::check_archived_value`).
-    pub unsafe fn deserialize(
-        data: &'a [u8],
-    ) -> Result<UniversalExecutableRef<'a>, DeserializeError> {
+    pub unsafe fn deserialize(data: &'a [u8]) -> Result<Self, DeserializeError> {
         Self::verify_serialized(data).map_err(|e| DeserializeError::Incompatible(e.to_string()))?;
         let (archive, position) = data.split_at(data.len() - 8);
         let mut position_value = [0u8; 8];

--- a/runtime/near-vm/test-api/src/sys/externals/function.rs
+++ b/runtime/near-vm/test-api/src/sys/externals/function.rs
@@ -116,6 +116,7 @@ fn build_export_function_metadata<Env>(
 where
     Env: Clone + Sized + 'static + Send + Sync,
 {
+    #[allow(clippy::missing_transmute_annotations)]
     let import_init_function_ptr = Some(unsafe {
         std::mem::transmute::<_, ImportInitializerFuncPtr>(import_init_function_ptr)
     });
@@ -1556,7 +1557,11 @@ mod inner {
         #[test]
         fn test_function_pointer() {
             let f = Function::new(func_i32__i32);
-            let function = unsafe { std::mem::transmute::<_, fn(usize, i32) -> i32>(f.address) };
+            let function = unsafe {
+                std::mem::transmute::<*const near_vm_vm::VMFunctionBody, fn(usize, i32) -> i32>(
+                    f.address,
+                )
+            };
             assert_eq!(function(0, 3), 6);
         }
     }

--- a/runtime/near-vm/test-api/src/sys/native.rs
+++ b/runtime/near-vm/test-api/src/sys/native.rs
@@ -171,6 +171,7 @@ macro_rules! impl_native_traits {
                     match self.arg_kind() {
                         VMFunctionKind::Static => {
                             let results = catch_unwind(AssertUnwindSafe(|| unsafe {
+                                #[allow(clippy::missing_transmute_annotations)]
                                 let f = std::mem::transmute::<_, unsafe extern "C" fn( VMFunctionEnvironment, $( $x, )*) -> Rets::CStruct>(self.address());
                                 // We always pass the vmctx
                                 f( self.vmctx(), $( $x, )* )

--- a/runtime/near-vm/vm/src/lib.rs
+++ b/runtime/near-vm/vm/src/lib.rs
@@ -1,7 +1,6 @@
 //! Runtime library support for Wasmer.
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
-#![deny(trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
 #![allow(clippy::new_without_default)]
 #![warn(

--- a/runtime/near-vm/vm/src/trap/traphandlers.rs
+++ b/runtime/near-vm/vm/src/trap/traphandlers.rs
@@ -150,9 +150,10 @@ pub unsafe fn near_vm_call_trampoline(
     values_vec: *mut u8,
 ) -> Result<(), Trap> {
     catch_traps(|| {
-        mem::transmute::<_, extern "C" fn(VMFunctionEnvironment, *const VMFunctionBody, *mut u8)>(
-            trampoline,
-        )(callee_env, callee, values_vec);
+        mem::transmute::<
+            VMTrampoline,
+            extern "C" fn(VMFunctionEnvironment, *const VMFunctionBody, *mut u8),
+        >(trampoline)(callee_env, callee, values_vec);
     })
 }
 

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -93,5 +93,5 @@ nightly_protocol = [
   "nearcore/nightly_protocol",
   "node-runtime/nightly_protocol",
 ]
-sandbox = ["node-runtime/sandbox"]
+sandbox = ["near-o11y/sandbox", "node-runtime/sandbox"]
 io_trace = ["near-store/io_trace", "near-o11y/io_trace", "near-vm-runner/io_trace"]

--- a/runtime/runtime-params-estimator/emu-cost/Dockerfile
+++ b/runtime/runtime-params-estimator/emu-cost/Dockerfile
@@ -1,5 +1,5 @@
 # our local base image
-FROM docker.io/rust:1.78.0
+FROM docker.io/rust:1.79.0
 
 LABEL description="Container for builds"
 

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -66,7 +66,7 @@ no_cache = [
   "near-store/no_cache",
 ]
 
-sandbox = ["near-vm-runner/sandbox"]
+sandbox = ["near-o11y/sandbox", "near-vm-runner/sandbox"]
 test_features = [
   "near-primitives/test_features",
   "near-vm-runner/test_features",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,6 +2,6 @@
 # This specifies the version of Rust we use to build.
 # Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
 # The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
-channel = "1.78.0"
+channel = "1.79.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 targets = ["wasm32-unknown-unknown"]

--- a/tools/epoch-sync/src/cli.rs
+++ b/tools/epoch-sync/src/cli.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "new_epoch_sync")]
-
 use anyhow::Context;
 use clap;
 use near_chain::{ChainStore, ChainStoreAccess, ChainUpdate, DoomslugThresholdMode};

--- a/tools/state-viewer/Cargo.toml
+++ b/tools/state-viewer/Cargo.toml
@@ -56,7 +56,12 @@ near-test-contracts.workspace = true
 testlib.workspace = true
 
 [features]
-sandbox = ["node-runtime/sandbox", "near-chain/sandbox", "near-client/sandbox"]
+sandbox = [
+  "near-chain/sandbox",
+  "near-client/sandbox",
+  "near-o11y/sandbox",
+  "node-runtime/sandbox",
+]
 protocol_feature_nonrefundable_transfer_nep491 = [
   "near-primitives/protocol_feature_nonrefundable_transfer_nep491",
 ]

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -3,7 +3,7 @@ name = "near-tracing"
 version = "0.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
-rust-version = "1.78.0"
+rust-version = "1.79.0"
 repository = "https://github.com/near/nearcore"
 license = "MIT OR Apache-2.0"
 

--- a/tracing/Dockerfile
+++ b/tracing/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.78-buster as builder
+FROM rust:1.79-buster as builder
 
 ADD Cargo.toml /build/Cargo.toml
 ADD Cargo.lock /build/Cargo.lock

--- a/utils/stdx/src/lib.rs
+++ b/utils/stdx/src/lib.rs
@@ -9,9 +9,11 @@
 pub fn split_array<const N: usize, const L: usize, const R: usize>(
     xs: &[u8; N],
 ) -> (&[u8; L], &[u8; R]) {
-    #[allow(clippy::let_unit_value)]
-    let () = AssertEqSum::<N, L, R>::OK;
-
+    const {
+        if N != L + R {
+            panic!()
+        }
+    };
     let (left, right) = xs.split_at(L);
     (left.try_into().unwrap(), right.try_into().unwrap())
 }
@@ -20,8 +22,11 @@ pub fn split_array<const N: usize, const L: usize, const R: usize>(
 pub fn split_array_mut<const N: usize, const L: usize, const R: usize>(
     xs: &mut [u8; N],
 ) -> (&mut [u8; L], &mut [u8; R]) {
-    #[allow(clippy::let_unit_value)]
-    let () = AssertEqSum::<N, L, R>::OK;
+    const {
+        if N != L + R {
+            panic!()
+        }
+    };
 
     let (left, right) = xs.split_at_mut(L);
     (left.try_into().unwrap(), right.try_into().unwrap())
@@ -38,8 +43,11 @@ pub fn join_array<const N: usize, const L: usize, const R: usize>(
     left: [u8; L],
     right: [u8; R],
 ) -> [u8; N] {
-    #[allow(clippy::let_unit_value)]
-    let () = AssertEqSum::<N, L, R>::OK;
+    const {
+        if N != L + R {
+            panic!()
+        }
+    };
 
     let mut res = [0; N];
     let (l, r) = res.split_at_mut(L);
@@ -56,8 +64,11 @@ fn test_join() {
 /// Splits a slice into a slice of N-element arrays.
 // TODO(mina86): Replace with [T]::as_chunks once that’s stabilised.
 pub fn as_chunks<const N: usize, T>(slice: &[T]) -> (&[[T; N]], &[T]) {
-    #[allow(clippy::let_unit_value)]
-    let () = AssertNonZero::<N>::OK;
+    const {
+        if N == 0 {
+            panic!()
+        }
+    };
 
     let len = slice.len().checked_div(N).expect("static assert above ensures N ≠ 0");
     let (head, tail) = slice
@@ -103,16 +114,4 @@ fn test_as_chunks() {
         Err(InexactChunkingError { slice_len: 5, chunk_size: 2 }),
         as_chunks_exact::<2, _>(&[0, 1, 2, 3, 4])
     );
-}
-
-/// Asserts, at compile time, that `S == A + B`.
-struct AssertEqSum<const S: usize, const A: usize, const B: usize>;
-impl<const S: usize, const A: usize, const B: usize> AssertEqSum<S, A, B> {
-    const OK: () = assert!(S == A + B);
-}
-
-/// Asserts, at compile time, that `N` is non-zero.
-struct AssertNonZero<const N: usize>;
-impl<const N: usize> AssertNonZero<N> {
-    const OK: () = assert!(N != 0);
 }


### PR DESCRIPTION
Release notes: https://blog.rust-lang.org/2024/06/13/Rust-1.79.0.html

Compiler found some dead code.  Clippy complained about bunch of new
stuff¹.  Inline const expressions got stabilised which allowed to
simplify static checks in stdx.

Apart from that I’ve not found any other code that could be improved
though places where the new stabilised features could be used are
non-trivial to look for.

¹ I’m not sure if I like the new clippy::missing_transmute_annotations
  check.  At least in nearcore it feels very noisy without actually
  doing anything good.  I’ve added annotation in a few places but
  where the annotation would be too long I just disabled that check.
  Perhaps it should be disabled globally?
