### PR TITLE
[stateless_validation] Change ratio of data parts needed for partial witness distribution from 0.8 to 0.6

### DIFF
--- a/chain/client/src/stateless_validation/partial_witness/encoding.rs
+++ b/chain/client/src/stateless_validation/partial_witness/encoding.rs
@@ -10,7 +10,7 @@ use reed_solomon_erasure::galois_8::ReedSolomon;
 /// Ratio of the number of data parts to total parts in the Reed Solomon encoding.
 /// The tradeoff here is having a higher ratio is better for handling missing parts and network errors
 /// but increases the size of the encoded state witness and the total network bandwidth requirements.
-const RATIO_DATA_PARTS: f32 = 0.8;
+const RATIO_DATA_PARTS: f32 = 0.6;
 
 /// Type alias around what ReedSolomon represents data part as.
 /// This should help with making the code a bit more understandable.


### PR DESCRIPTION
Short term fix for the current stuck statelessnet.

We have a bunch of validator nodes offline due to which we are not able to gather the 80% parts required for reconstructing the state witness.

This PR changes this to 60% as a short term fix. We would have to reason about a more long term solution for partial witness distribution.