### PR TITLE
fix(debug-ui): CryptoHash key validity

### DIFF
--- a/tools/debug-ui/src/entity_debug/keys.tsx
+++ b/tools/debug-ui/src/entity_debug/keys.tsx
@@ -1,36 +1,28 @@
 // Concrete implementations for EntityKey.
 
-import {EntityKey, EntityKeyType} from './types';
+import { EntityKey, EntityKeyType } from './types';
 
 export class StringEntityKey {
-    constructor(private _type: EntityKeyType, private value: string) {
-    }
-
+    constructor(private _type: EntityKeyType, private value: string) {}
     type(): EntityKeyType {
         return this._type;
     }
-
     toString(): string {
         return this.value;
     }
-
     toJSON(): unknown {
         return this.value;
     }
 }
 
 export class NumericEntityKey {
-    constructor(private _type: EntityKeyType, private value: number) {
-    }
-
+    constructor(private _type: EntityKeyType, private value: number) {}
     type(): EntityKeyType {
         return this._type;
     }
-
     toString(): string {
         return this.value.toString();
     }
-
     toJSON(): unknown {
         return this.value;
     }

--- a/tools/debug-ui/src/entity_debug/keys.tsx
+++ b/tools/debug-ui/src/entity_debug/keys.tsx
@@ -1,28 +1,36 @@
 // Concrete implementations for EntityKey.
 
-import { EntityKey, EntityKeyType } from './types';
+import {EntityKey, EntityKeyType} from './types';
 
 export class StringEntityKey {
-    constructor(private _type: EntityKeyType, private value: string) {}
+    constructor(private _type: EntityKeyType, private value: string) {
+    }
+
     type(): EntityKeyType {
         return this._type;
     }
+
     toString(): string {
         return this.value;
     }
+
     toJSON(): unknown {
         return this.value;
     }
 }
 
 export class NumericEntityKey {
-    constructor(private _type: EntityKeyType, private value: number) {}
+    constructor(private _type: EntityKeyType, private value: number) {
+    }
+
     type(): EntityKeyType {
         return this._type;
     }
+
     toString(): string {
         return this.value.toString();
     }
+
     toJSON(): unknown {
         return this.value;
     }
@@ -48,7 +56,13 @@ export function parseEntityKey(keyType: EntityKeyType, input: string): EntityKey
         case 'receipt_id':
         case 'transaction_hash':
         case 'state_root':
-            if (input.length != 44) {
+            // Length of 32-byte array encoded in base58 is 43 or 44 characters,
+            // depending on whether we need additional character or not.
+            // 
+            // Short explanation: 32 bytes are 256 bits, each base58 character 
+            // encodes log2(58) ≈ 5.858 bits. Then length of 32-byte array
+            // encoded in base58 is ≈ 256 / 5.858 = 43.7. 
+            if (![43, 44].includes(input.length)) {
                 return null;
             }
             return new StringEntityKey(keyType, input);

--- a/tools/debug-ui/src/entity_debug/keys.tsx
+++ b/tools/debug-ui/src/entity_debug/keys.tsx
@@ -53,7 +53,7 @@ export function parseEntityKey(keyType: EntityKeyType, input: string): EntityKey
             // 
             // Short explanation: 32 bytes are 256 bits, each base58 character 
             // encodes log2(58) ≈ 5.858 bits. Then length of 32-byte array
-            // encoded in base58 is ≈ 256 / 5.858 = 43.7. 
+            // encoded in base58 is ≈ 256 / 5.858 ≈ 43.7. 
             if (![43, 44].includes(input.length)) {
                 return null;
             }


### PR DESCRIPTION
Currently debug ui doesn't allow cryptohash-keys of length 43, though they are completely valid. For example, epoch id `nzPSmXu6KDoyamTLyK4j8s6eYw9jUfX2MVuC9zW8A6p` does exist in testnet.

This probably wasn't caught before because these keys are more rare than ones of length 43.