### PR TITLE
[stateless_validation] Partial witness RATIO_DATA_PARTS under protocol config

### DIFF
--- a/chain/client/src/stateless_validation/partial_witness/encoding.rs
+++ b/chain/client/src/stateless_validation/partial_witness/encoding.rs
@@ -1,15 +1,18 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use near_primitives::checked_feature;
 use near_primitives::reed_solomon::{
     reed_solomon_decode, reed_solomon_encode, reed_solomon_part_length,
 };
 use near_primitives::stateless_validation::EncodedChunkStateWitness;
+use near_vm_runner::logic::ProtocolVersion;
 use reed_solomon_erasure::galois_8::ReedSolomon;
 
 /// Ratio of the number of data parts to total parts in the Reed Solomon encoding.
 /// The tradeoff here is having a higher ratio is better for handling missing parts and network errors
 /// but increases the size of the encoded state witness and the total network bandwidth requirements.
+const RATIO_DATA_PARTS_OLD: f32 = 0.8;
 const RATIO_DATA_PARTS: f32 = 0.6;
 
 /// Type alias around what ReedSolomon represents data part as.
@@ -25,9 +28,9 @@ pub struct WitnessEncoder {
 }
 
 impl WitnessEncoder {
-    pub fn new(total_parts: usize) -> WitnessEncoder {
+    pub fn new(total_parts: usize, protocol_version: ProtocolVersion) -> WitnessEncoder {
         let rs = if total_parts > 1 {
-            let data_parts = num_witness_data_parts(total_parts);
+            let data_parts = num_witness_data_parts(total_parts, protocol_version);
             Some(ReedSolomon::new(data_parts, total_parts - data_parts).unwrap())
         } else {
             None
@@ -74,7 +77,7 @@ impl WitnessEncoder {
 
 /// We keep one encoder for each length of chunk_validators to avoid re-creating the encoder.
 pub struct WitnessEncoderCache {
-    instances: HashMap<usize, Arc<WitnessEncoder>>,
+    instances: HashMap<(usize, ProtocolVersion), Arc<WitnessEncoder>>,
 }
 
 impl WitnessEncoderCache {
@@ -82,18 +85,35 @@ impl WitnessEncoderCache {
         Self { instances: HashMap::new() }
     }
 
-    pub fn entry(&mut self, total_parts: usize) -> Arc<WitnessEncoder> {
+    pub fn entry(
+        &mut self,
+        total_parts: usize,
+        protocol_version: ProtocolVersion,
+    ) -> Arc<WitnessEncoder> {
         self.instances
-            .entry(total_parts)
-            .or_insert_with(|| Arc::new(WitnessEncoder::new(total_parts)))
+            .entry((total_parts, protocol_version))
+            .or_insert_with(|| Arc::new(WitnessEncoder::new(total_parts, protocol_version)))
             .clone()
     }
 }
 
-pub fn witness_part_length(encoded_witness_size: usize, total_parts: usize) -> usize {
-    reed_solomon_part_length(encoded_witness_size, num_witness_data_parts(total_parts))
+pub fn witness_part_length(
+    encoded_witness_size: usize,
+    total_parts: usize,
+    protocol_version: ProtocolVersion,
+) -> usize {
+    reed_solomon_part_length(
+        encoded_witness_size,
+        num_witness_data_parts(total_parts, protocol_version),
+    )
 }
 
-fn num_witness_data_parts(total_parts: usize) -> usize {
-    std::cmp::max((total_parts as f32 * RATIO_DATA_PARTS) as usize, 1)
+fn num_witness_data_parts(total_parts: usize, protocol_version: ProtocolVersion) -> usize {
+    let ratio_data_parts =
+        if checked_feature!("stable", ChangePartialWitnessDataPartsRequired, protocol_version) {
+            RATIO_DATA_PARTS
+        } else {
+            RATIO_DATA_PARTS_OLD
+        };
+    std::cmp::max((total_parts as f32 * ratio_data_parts) as usize, 1)
 }

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
@@ -163,7 +163,8 @@ impl PartialWitnessActor {
         );
 
         // Break the state witness into parts using Reed Solomon encoding.
-        let encoder = self.encoders.entry(chunk_validators.len());
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
+        let encoder = self.encoders.entry(chunk_validators.len(), protocol_version);
         let (parts, encoded_length) = encoder.encode(&witness_bytes);
 
         Ok(chunk_validators
@@ -354,8 +355,13 @@ impl PartialWitnessActor {
             )));
         }
 
-        let max_part_len =
-            witness_part_length(MAX_COMPRESSED_STATE_WITNESS_SIZE.as_u64() as usize, num_parts);
+        let protocol_version =
+            self.epoch_manager.get_epoch_protocol_version(&partial_witness.epoch_id())?;
+        let max_part_len = witness_part_length(
+            MAX_COMPRESSED_STATE_WITNESS_SIZE.as_u64() as usize,
+            num_parts,
+            protocol_version,
+        );
         if partial_witness.part_size() > max_part_len {
             return Err(Error::InvalidPartialChunkStateWitness(format!(
                 "Part size {} exceed limit of {} (total parts: {})",

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
@@ -206,7 +206,9 @@ impl PartialEncodedStateWitnessTracker {
             return Ok(());
         }
         let num_parts = self.get_num_parts(&partial_witness)?;
-        let new_entry = CacheEntry::new(self.encoders.entry(num_parts));
+        let protocol_version =
+            self.epoch_manager.get_epoch_protocol_version(partial_witness.epoch_id())?;
+        let new_entry = CacheEntry::new(self.encoders.entry(num_parts, protocol_version));
         if let Some((evicted_key, evicted_entry)) = self.parts_cache.push(key, new_entry) {
             tracing::warn!(
                 target: "client",

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -170,6 +170,8 @@ pub enum ProtocolFeature {
     OutgoingReceiptsSizeLimit,
     /// No chunk-only producers in stateless validation
     NoChunkOnlyProducers,
+    /// Decrease the ratio of data parts in the Reed Solomon encoding for partial witness distribution.
+    ChangePartialWitnessDataPartsRequired,
 }
 
 impl ProtocolFeature {
@@ -237,6 +239,7 @@ impl ProtocolFeature {
             | ProtocolFeature::OutgoingReceiptsSizeLimit => 87,
             ProtocolFeature::CongestionControlAllowedShardValidation
             | ProtocolFeature::NoChunkOnlyProducers => 88,
+            ProtocolFeature::ChangePartialWitnessDataPartsRequired => 89,
 
             // Nightly features
             #[cfg(feature = "protocol_feature_fix_staking_threshold")]
@@ -267,7 +270,7 @@ const STABLE_PROTOCOL_VERSION: ProtocolVersion = 67;
 /// Largest protocol version supported by the current binary.
 pub const PROTOCOL_VERSION: ProtocolVersion = if cfg!(feature = "statelessnet_protocol") {
     // Current StatelessNet protocol version.
-    88
+    89
 } else if cfg!(feature = "nightly_protocol") {
     // On nightly, pick big enough version to support all features.
     143


### PR DESCRIPTION
Follow up from PR https://github.com/near/nearcore/pull/11571 where we need to have the change in ratio under a protocol upgrade.