### PR TITLE
chore: use the master link of NEP-0508

### DIFF
--- a/docs/architecture/how/resharding.md
+++ b/docs/architecture/how/resharding.md
@@ -11,7 +11,7 @@ number of shards.
 
 The resharding is described in more detail in the following NEPs:
 * [NEP-0040](https://github.com/near/NEPs/blob/master/specs/Proposals/0040-split-states.md)
-* [NEP-0508](https://github.com/near/NEPs/pull/508) - TODO - once merged use the master link
+* [NEP-0508](https://github.com/near/NEPs/blob/master/neps/nep-0508.md)
 
 ## Shard layout
 


### PR DESCRIPTION
remove TODO to use the master link of NEP-0508