### PR TITLE
[ft-benchmark] manual benchmark triggering

### DIFF
--- a/scripts/ft-benchmark.sh
+++ b/scripts/ft-benchmark.sh
@@ -30,6 +30,8 @@ LOG_DIR=scripts/ft-benchmark-logs
 MAIN_LOG_FILE=$LOG_DIR/${NEW_COMMIT_HASH}.log
 exec > >(tee -a $MAIN_LOG_FILE) 2>&1
 
+# TODO: Use ./start-benchmark.sh insread.
+
 # Stop previous experiment
 pkill -9 locust || true
 nearup stop 

--- a/scripts/run-ft-benchmark.py
+++ b/scripts/run-ft-benchmark.py
@@ -1,0 +1,66 @@
+import argparse
+import os
+import subprocess
+
+LOCK_FILE = "/tmp/run-ft-benchmark.lock"
+REPO_DIR = "~/nearcore"
+
+
+def create_lock_file(user: str) -> None:
+    if os.path.exists(LOCK_FILE):
+        with open(LOCK_FILE, 'r') as f:
+            running_user = f.read().strip()
+        raise RuntimeError(f"{running_user} already running benchmark")
+    with open(LOCK_FILE, 'w+') as f:
+        f.write(user)
+
+
+def remove_lock_file() -> None:
+    if os.path.exists(LOCK_FILE):
+        os.remove(LOCK_FILE)
+    else:
+        raise RuntimeError("Somebody already removed the lock file!!!")
+
+
+def run_benchmark(repo_dir: str, time: str, users: int, shards: int, nodes: int,
+                  rump_up: int) -> None:
+    benchmark_command = (
+        f"./scripts/start_benchmark.sh {time} {users} {shards} {nodes} {rump_up}"
+    )
+    subprocess.run(benchmark_command, cwd=repo_dir, shell=True, check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run FT benchmark",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--time',
+                        type=str,
+                        default='1h',
+                        help="Time duration (e.g., 2h, 30m, 45s)")
+    parser.add_argument('--users',
+                        type=int,
+                        default=1000,
+                        help="Number of users")
+    parser.add_argument('--shards',
+                        type=int,
+                        default=1,
+                        help="Number of shards")
+    parser.add_argument('--nodes', type=int, default=1, help="Number of nodes")
+    parser.add_argument('--rump-up', type=int, default=10, help="Rump-up rate")
+    parser.add_argument('--user', type=str, default='unknown', help="User name")
+
+    args = parser.parse_args()
+
+    try:
+        create_lock_file(args.user)
+        run_benchmark(REPO_DIR, args.time, args.users, args.shards, args.nodes,
+                      args.rump_up)
+    except RuntimeError as e:
+        print(e)
+    finally:
+        remove_lock_file()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/start-benchmark.sh
+++ b/scripts/start-benchmark.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Get arguments from the command line
+TIME=$1
+USERS=$2
+SHARDS=$3
+NODES=$4
+RUMP_UP=$5
+
+# Stop previous experiment
+pkill -9 locust || true
+nearup stop
+
+# Build the project
+make neard
+
+# Start neard
+nearup run localnet --binary-path target/release/ --num-nodes $NODES --num-shards $SHARDS --override
+
+# Prepare python environment
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -r pytest/requirements.txt
+python -m pip install locust
+export KEY=~/.near/localnet/node0/validator_key.json
+
+# Run benchmark
+cd pytest/tests/loadtest/locust/
+nohup locust -H 127.0.0.1:3030 -f locustfiles/ft.py --funding-key=$KEY -t $TIME -u $USERS -r $RUMP_UP --processes 8 --headless &
+
+# Give locust 5 minutes to start and rump up
+sleep 300
+
+# Run data collector
+cd ~/nearcore
+python3 scripts/ft-benchmark-data-sender.py
+
+echo "Benchmark completed."


### PR DESCRIPTION
This is a step to manual triggering of `ft-benchmark`.

Note: I think this lock file don't provide 100% protection, but IMO probability of two actors triggering this script within time of creating lock file is small enough.