### PR TITLE
tool(congestion) - Adding neard subcommand for debugging congestion control

### DIFF
--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -1,4 +1,5 @@
 use crate::commands::*;
+use crate::congestion_control::CongestionControlCmd;
 use crate::contract_accounts::ContractAccountFilter;
 use crate::rocksdb_stats::get_rocksdb_stats;
 use crate::trie_iteration_benchmark::TrieIterationBenchmarkCmd;
@@ -111,6 +112,10 @@ pub enum StateViewerSubCommand {
     /// `validate` command.
     #[clap(subcommand)]
     StateWitness(StateWitnessCmd),
+
+    /// Tools for printing and recalculating the congestion information.
+    #[clap(subcommand)]
+    CongestionControl(CongestionControlCmd),
 }
 
 impl StateViewerSubCommand {
@@ -170,6 +175,7 @@ impl StateViewerSubCommand {
             StateViewerSubCommand::ViewTrie(cmd) => cmd.run(store),
             StateViewerSubCommand::TrieIterationBenchmark(cmd) => cmd.run(near_config, store),
             StateViewerSubCommand::StateWitness(cmd) => cmd.run(home_dir, near_config, store),
+            StateViewerSubCommand::CongestionControl(cmd) => cmd.run(home_dir, near_config, store),
         }
     }
 }

--- a/tools/state-viewer/src/congestion_control.rs
+++ b/tools/state-viewer/src/congestion_control.rs
@@ -27,7 +27,7 @@ impl CongestionControlCmd {
 
     fn run_print(&self, near_config: &NearConfig, store: Store) {
         let chain_store = ChainStore::new(
-            store.clone(),
+            store,
             near_config.genesis.config.genesis_height,
             near_config.client_config.save_trie_changes,
         );

--- a/tools/state-viewer/src/congestion_control.rs
+++ b/tools/state-viewer/src/congestion_control.rs
@@ -1,0 +1,62 @@
+use std::path::Path;
+
+use near_chain::types::RuntimeAdapter;
+use near_chain::{ChainStore, ChainStoreAccess};
+use near_epoch_manager::EpochManagerAdapter;
+use near_store::Store;
+use nearcore::NearConfig;
+use node_runtime::bootstrap_congestion_info;
+
+use crate::util::load_trie;
+
+#[derive(clap::Parser)]
+pub enum CongestionControlCmd {
+    /// Print the congestion information.
+    Print,
+    /// Run the congestion info bootstrapping.
+    Bootstrap,
+}
+
+impl CongestionControlCmd {
+    pub(crate) fn run(&self, home_dir: &Path, near_config: NearConfig, store: Store) {
+        match self {
+            CongestionControlCmd::Print => self.run_print(&near_config, store),
+            CongestionControlCmd::Bootstrap => self.run_bootstrap(home_dir, &near_config, store),
+        }
+    }
+
+    fn run_print(&self, near_config: &NearConfig, store: Store) {
+        let chain_store = ChainStore::new(
+            store.clone(),
+            near_config.genesis.config.genesis_height,
+            near_config.client_config.save_trie_changes,
+        );
+        let head = chain_store.head().unwrap();
+        let block = chain_store.get_block(&head.last_block_hash).unwrap();
+
+        for chunk_header in block.chunks().iter() {
+            let congestion_info = chunk_header.congestion_info();
+            println!("{:?} - {:?}", chunk_header.shard_id(), congestion_info);
+        }
+    }
+
+    fn run_bootstrap(&self, home_dir: &Path, near_config: &NearConfig, store: Store) {
+        let (epoch_manager, runtime, state_roots, block_header) =
+            load_trie(store, home_dir, near_config);
+
+        let prev_hash = block_header.prev_hash();
+
+        for (shard_id, state_root) in state_roots.iter().enumerate() {
+            let shard_id = shard_id as u64;
+            let trie = runtime.get_trie_for_shard(shard_id, prev_hash, *state_root, true).unwrap();
+            let epoch_id = epoch_manager.get_epoch_id_from_prev_block(prev_hash).unwrap();
+            let protocol_config = runtime.get_protocol_config(&epoch_id).unwrap();
+            let runtime_config = protocol_config.runtime_config;
+
+            let congestion_info =
+                bootstrap_congestion_info(&trie, &runtime_config, shard_id).unwrap();
+
+            println!("{:?} - {:?}", shard_id, congestion_info);
+        }
+    }
+}

--- a/tools/state-viewer/src/lib.rs
+++ b/tools/state-viewer/src/lib.rs
@@ -4,6 +4,7 @@ mod apply_chain_range;
 mod apply_chunk;
 pub mod cli;
 mod commands;
+mod congestion_control;
 mod contract_accounts;
 mod epoch_info;
 mod latest_witnesses;
@@ -14,5 +15,6 @@ mod state_dump;
 mod state_parts;
 mod trie_iteration_benchmark;
 mod tx_dump;
+mod util;
 
 pub use cli::StateViewerSubCommand;

--- a/tools/state-viewer/src/util.rs
+++ b/tools/state-viewer/src/util.rs
@@ -1,0 +1,90 @@
+use std::{path::Path, sync::Arc};
+
+use near_chain::{types::Tip, Block, BlockHeader, ChainStore, ChainStoreAccess};
+use near_epoch_manager::{EpochManager, EpochManagerAdapter, EpochManagerHandle};
+use near_primitives::types::{BlockHeight, StateRoot};
+use near_store::{ShardUId, Store};
+use nearcore::{NearConfig, NightshadeRuntime, NightshadeRuntimeExt};
+
+pub enum LoadTrieMode {
+    /// Load latest state
+    Latest,
+    /// Load prev state at some height
+    Height(BlockHeight),
+    /// Load the prev state of the last final block from some height
+    LastFinalFromHeight(BlockHeight),
+}
+
+pub fn load_trie(
+    store: Store,
+    home_dir: &Path,
+    near_config: &NearConfig,
+) -> (Arc<EpochManagerHandle>, Arc<NightshadeRuntime>, Vec<StateRoot>, BlockHeader) {
+    load_trie_stop_at_height(store, home_dir, near_config, LoadTrieMode::Latest)
+}
+
+pub fn load_trie_stop_at_height(
+    store: Store,
+    home_dir: &Path,
+    near_config: &NearConfig,
+    mode: LoadTrieMode,
+) -> (Arc<EpochManagerHandle>, Arc<NightshadeRuntime>, Vec<StateRoot>, BlockHeader) {
+    let chain_store = ChainStore::new(
+        store.clone(),
+        near_config.genesis.config.genesis_height,
+        near_config.client_config.save_trie_changes,
+    );
+
+    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config);
+    let runtime =
+        NightshadeRuntime::from_config(home_dir, store, near_config, epoch_manager.clone());
+    let runtime = runtime.expect("could not create the transaction runtime");
+
+    let head = chain_store.head().unwrap();
+    let block = match mode {
+        LoadTrieMode::LastFinalFromHeight(height) => {
+            get_last_final_from_height(height, &head, &chain_store)
+        }
+        LoadTrieMode::Height(height) => {
+            let block_hash = chain_store.get_block_hash_by_height(height).unwrap();
+            chain_store.get_block(&block_hash).unwrap()
+        }
+        LoadTrieMode::Latest => chain_store.get_block(&head.last_block_hash).unwrap(),
+    };
+    let shard_layout = epoch_manager.get_shard_layout(&block.header().epoch_id()).unwrap();
+    let mut state_roots = vec![];
+    for chunk in block.chunks().iter() {
+        let shard_uid = ShardUId::from_shard_id_and_layout(chunk.shard_id(), &shard_layout);
+        let chunk_extra = chain_store.get_chunk_extra(&head.last_block_hash, &shard_uid).unwrap();
+        let state_root = *chunk_extra.state_root();
+        state_roots.push(state_root);
+    }
+
+    (epoch_manager, runtime, state_roots, block.header().clone())
+}
+
+/// find the first final block whose height is at least `height`.
+fn get_last_final_from_height(height: u64, head: &Tip, chain_store: &ChainStore) -> Block {
+    let mut cur_height = height + 1;
+    loop {
+        if cur_height >= head.height {
+            panic!("No final block with height >= {} exists", height);
+        }
+        let cur_block_hash = match chain_store.get_block_hash_by_height(cur_height) {
+            Ok(hash) => hash,
+            Err(_) => {
+                cur_height += 1;
+                continue;
+            }
+        };
+        let last_final_block_hash =
+            *chain_store.get_block_header(&cur_block_hash).unwrap().last_final_block();
+        let last_final_block = chain_store.get_block(&last_final_block_hash).unwrap();
+        if last_final_block.header().height() >= height {
+            break last_final_block;
+        } else {
+            cur_height += 1;
+            continue;
+        }
+    }
+}


### PR DESCRIPTION
Adding a tool for printing and re-calculating the congestion info. 

I also did a small refactoring - I moved some utility methods to an utils file. 

I'm going to use it to perform bootstrapping benchmarking. The plan is:
* Spin up a mainnet RPC node - this is in order to have a real-life db. 
* Load the delayed receipts queue with predefined number/ size/ gas of receipts. What receipts exactly is yet to be decided. This would likely lead to inconsistent db state but that is fine. 
* Run the `bootstrap` command introduced in this PR and measure the time it takes. 