### PR TITLE
feat(congestion) - Initialize congestion info in the genesis-populate tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,6 +2663,7 @@ dependencies = [
  "near-test-contracts",
  "near-vm-runner",
  "nearcore",
+ "node-runtime",
  "tempfile",
 ]
 

--- a/genesis-tools/genesis-populate/Cargo.toml
+++ b/genesis-tools/genesis-populate/Cargo.toml
@@ -27,6 +27,7 @@ near-store.workspace = true
 near-chain.workspace = true
 near-test-contracts.workspace = true
 near-vm-runner.workspace = true
+node-runtime.workspace = true
 
 [features]
 nightly_protocol = [

--- a/genesis-tools/genesis-populate/Cargo.toml
+++ b/genesis-tools/genesis-populate/Cargo.toml
@@ -39,6 +39,7 @@ nightly_protocol = [
   "near-store/nightly_protocol",
   "near-vm-runner/nightly_protocol",
   "nearcore/nightly_protocol",
+  "node-runtime/nightly_protocol",
 ]
 nightly = [
   "near-async/nightly",
@@ -50,4 +51,5 @@ nightly = [
   "near-vm-runner/nightly",
   "nearcore/nightly",
   "nightly_protocol",
+  "node-runtime/nightly",
 ]

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -292,12 +292,8 @@ impl GenesisBuilder {
         if ProtocolFeature::CongestionControl.enabled(protocol_version) {
             return Ok(None);
         }
-        let trie = self.runtime.get_trie_for_shard(
-            shard_id,
-            genesis.header().prev_hash(),
-            state_root,
-            true,
-        )?;
+        let prev_hash = genesis.header().prev_hash();
+        let trie = self.runtime.get_trie_for_shard(shard_id, prev_hash, state_root, true)?;
         let protocol_config = self.runtime.get_protocol_config(genesis.header().epoch_id())?;
         let runtime_config = protocol_config.runtime_config;
         let congestion_info = bootstrap_congestion_info(&trie, &runtime_config, shard_id)?;

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -289,7 +289,7 @@ impl GenesisBuilder {
         shard_id: u64,
         state_root: CryptoHash,
     ) -> Result<Option<CongestionInfo>> {
-        if ProtocolFeature::CongestionControl.enabled(protocol_version) {
+        if !ProtocolFeature::CongestionControl.enabled(protocol_version) {
             return Ok(None);
         }
         let prev_hash = genesis.header().prev_hash();


### PR DESCRIPTION
In forknet the genesis may contains some delayed / buffered receipts. It's important to initialize the congestion info correctly otherwise integer overflow may happen when updating the congestion info. 

This is untested since I don't know how, looking for hints here :) 