### PR TITLE
fix: prevent num parts configuration error by enforcing panic

### DIFF
--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -2017,7 +2017,7 @@ impl ShardsManagerActor {
         let _timer = metrics::DISTRIBUTE_ENCODED_CHUNK_TIME
             .with_label_values(&[&shard_id.to_string()])
             .start_timer();
-        // TODO: if the number of validators exceeds the number of parts, this logic must be changed
+        // It is guaranteed that the number of parts will be no smaller than the number of block producers
         let chunk_header = encoded_chunk.cloned_header();
         let prev_block_hash = chunk_header.prev_block_hash();
         let _span = tracing::debug_span!(

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -20,7 +20,9 @@ use near_primitives::types::{
     EpochInfoProvider, NumSeats, ShardId, ValidatorId, ValidatorInfoIdentifier,
     ValidatorKickoutReason, ValidatorStats,
 };
-use near_primitives::version::{ProtocolVersion, UPGRADABILITY_FIX_PROTOCOL_VERSION};
+use near_primitives::version::{
+    ProtocolVersion, PROTOCOL_VERSION, UPGRADABILITY_FIX_PROTOCOL_VERSION,
+};
 use near_primitives::views::{
     CurrentEpochValidatorInfo, EpochValidatorInfo, NextEpochValidatorInfo, ValidatorKickoutView,
 };
@@ -242,6 +244,11 @@ impl EpochManager {
             .unwrap_or_default();
         let genesis_num_block_producer_seats =
             config.for_protocol_version(genesis_protocol_version).num_block_producer_seats;
+        if config.for_protocol_version(PROTOCOL_VERSION).num_block_producer_seats
+            > genesis_num_block_producer_seats
+        {
+            panic!("Increasing the number of block producer seat is not supported due to chunk part computation");
+        }
         let mut epoch_manager = EpochManager {
             store,
             config,

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -3242,3 +3242,35 @@ fn test_possible_epochs_of_height_around_tip() {
         }
     }
 }
+
+#[cfg(feature = "nightly")]
+#[test]
+#[should_panic(expected = "Increasing the number of block producer seat is not supported")]
+fn test_increase_block_producer_seats() {
+    let store = create_test_store();
+    let config = epoch_config_with_production_config(
+        5,
+        1,
+        20,
+        20,
+        90,
+        90,
+        90,
+        true
+    );
+    let reward_calculator = default_reward_calculator();
+    let validators: Vec<(AccountId, u128)> = vec![("test0".parse().unwrap(), 1_000_000)];
+    // use a small number so that any protocol version is higher
+    let genesis_protocol_version = 0;
+    EpochManager::new(
+        store,
+        config,
+        genesis_protocol_version,
+        reward_calculator,
+        validators
+            .iter()
+            .map(|(account_id, balance)| stake(account_id.clone(), *balance))
+            .collect(),
+    )
+    .unwrap();
+}


### PR DESCRIPTION
On statelessnet we observed that a configuration issue caused a hard-to-debug problem with chunk misses that is caused by `num_total_parts` being smaller than the number of block producers. This change prevents this configuration error from happening by panicking the node if the local client's protocol version would cause such a violation of invariant. We do need to change this behavior in the future in case we plan to change `num_total_parts`.