### PR TITLE
vmlogic: maintain memory by a Box

### DIFF
--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -43,7 +43,7 @@ pub struct VMLogic<'a> {
     /// results of the methods that made the callback are stored in this collection.
     promise_results: &'a [PromiseResult],
     /// Pointer to the guest memory.
-    memory: super::vmstate::Memory<'a>,
+    memory: super::vmstate::Memory,
 
     /// Keeping track of the current account balance, which can decrease when we create promises
     /// and attach balance to them.
@@ -135,7 +135,7 @@ impl<'a> VMLogic<'a> {
         config: &'a Config,
         fees_config: &'a RuntimeFeesConfig,
         promise_results: &'a [PromiseResult],
-        memory: &'a mut dyn MemoryLike,
+        memory: impl MemoryLike + 'static,
     ) -> Self {
         // Overflow should be checked before calling VMLogic.
         let current_account_balance = context.account_balance + context.attached_deposit;
@@ -194,7 +194,7 @@ impl<'a> VMLogic<'a> {
     }
 
     #[cfg(test)]
-    pub(super) fn memory(&mut self) -> &mut super::vmstate::Memory<'a> {
+    pub(super) fn memory(&mut self) -> &mut super::vmstate::Memory {
         &mut self.memory
     }
 

--- a/runtime/near-vm-runner/src/logic/mocks/mock_memory.rs
+++ b/runtime/near-vm-runner/src/logic/mocks/mock_memory.rs
@@ -2,6 +2,7 @@ use crate::logic::{MemSlice, MemoryLike};
 
 use std::borrow::Cow;
 
+#[derive(Clone)]
 pub struct MockedMemory(Box<[u8]>);
 
 impl MockedMemory {

--- a/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
+++ b/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
@@ -43,7 +43,7 @@ impl VMLogicBuilder {
             &self.config,
             &self.fees_config,
             &self.promise_results,
-            &mut self.memory,
+            self.memory.clone(),
         ))
     }
 

--- a/runtime/near-vm-runner/src/near_vm_runner/runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner/runner.rs
@@ -304,7 +304,7 @@ impl NearVM {
 
         crate::metrics::record_compiled_contract_cache_lookup(is_cache_hit);
 
-        let mut memory = NearVmMemory::new(
+        let memory = NearVmMemory::new(
             self.config.limit_config.initial_memory_pages,
             self.config.limit_config.max_memory_pages,
         )
@@ -313,7 +313,7 @@ impl NearVM {
         // Note that we don't clone the actual backing memory, just increase the RC.
         let vmmemory = memory.vm();
         let mut logic =
-            VMLogic::new(ext, context, &self.config, fees_config, promise_results, &mut memory);
+            VMLogic::new(ext, context, &self.config, fees_config, promise_results, memory);
 
         let result = logic.before_loading_executable(method_name, wasm_bytes);
         if let Err(e) = result {

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -574,7 +574,7 @@ impl crate::runner::VM for Wasmer2VM {
         let Some(code) = ext.get_contract() else {
             return Err(VMRunnerError::ContractCodeNotPresent);
         };
-        let mut memory = Wasmer2Memory::new(
+        let memory = Wasmer2Memory::new(
             self.config.limit_config.initial_memory_pages,
             self.config.limit_config.max_memory_pages,
         )
@@ -584,7 +584,7 @@ impl crate::runner::VM for Wasmer2VM {
         // Note that we don't clone the actual backing memory, just increase the RC.
         let vmmemory = memory.vm();
         let mut logic =
-            VMLogic::new(ext, context, &self.config, fees_config, promise_results, &mut memory);
+            VMLogic::new(ext, context, &self.config, fees_config, promise_results, memory);
 
         let result = logic.before_loading_executable(method_name, code.code().len() as u64);
         if let Err(e) = result {

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -438,7 +438,7 @@ impl crate::runner::VM for Wasmer0VM {
             panic!("AVX support is required in order to run Wasmer VM Singlepass backend.");
         }
 
-        let mut memory = WasmerMemory::new(
+        let memory = WasmerMemory::new(
             self.config.limit_config.initial_memory_pages,
             self.config.limit_config.max_memory_pages,
         );
@@ -446,7 +446,7 @@ impl crate::runner::VM for Wasmer0VM {
         let memory_copy = memory.clone();
 
         let mut logic =
-            VMLogic::new(ext, context, &self.config, fees_config, promise_results, &mut memory);
+            VMLogic::new(ext, context, &self.config, fees_config, promise_results, memory);
 
         let result = logic.before_loading_executable(method_name, code.code().len() as u64);
         if let Err(e) = result {

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -250,7 +250,7 @@ impl WasmtimeVM {
         )?;
 
         let mut store = Store::new(&self.engine, ());
-        let mut memory = WasmtimeMemory::new(
+        let memory = WasmtimeMemory::new(
             &mut store,
             self.config.limit_config.initial_memory_pages,
             self.config.limit_config.max_memory_pages,
@@ -258,7 +258,7 @@ impl WasmtimeVM {
         .unwrap();
         let memory_copy = memory.0;
         let mut logic =
-            VMLogic::new(ext, context, &self.config, fees_config, promise_results, &mut memory);
+            VMLogic::new(ext, context, &self.config, fees_config, promise_results, memory);
         let result = logic.before_loading_executable(method_name, wasm_bytes);
         if let Err(e) = result {
             return Ok(VMOutcome::abort(logic, e));


### PR DESCRIPTION
This is a part of an effort to drop the lifetime from the `VMLogic` structure in order to make it more straightforward to have it live for a longer duration alongside the instance and not force our hand in pretty much "create-execute contract-drop" flow.

Part of #11319