### PR TITLE
fix(nayduck) - propagate test features to test contracts

### DIFF
--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -60,7 +60,7 @@ near-o11y.workspace = true
 near-telemetry.workspace = true
 near-test-contracts.workspace = true
 near-performance-metrics.workspace = true
-near-vm-runner = { workspace = true, features = [ "prepare" ] }
+near-vm-runner = { workspace = true, features = ["prepare"] }
 near-wallet-contract.workspace = true
 nearcore.workspace = true
 node-runtime.workspace = true
@@ -87,6 +87,7 @@ test_features = [
   "nearcore/test_features",
   "near-store/test_features",
   "near-vm-runner/test_features",
+  "near-test-contracts/test_features",
 ]
 protocol_feature_fix_contract_loading_cost = [
   "nearcore/protocol_feature_fix_contract_loading_cost",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -60,7 +60,7 @@ near-o11y.workspace = true
 near-telemetry.workspace = true
 near-test-contracts.workspace = true
 near-performance-metrics.workspace = true
-near-vm-runner = { workspace = true, features = ["prepare"] }
+near-vm-runner = { workspace = true, features = [ "prepare" ] }
 near-wallet-contract.workspace = true
 nearcore.workspace = true
 node-runtime.workspace = true

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -139,7 +139,7 @@ nightly = [
 ]
 sandbox = ["near-o11y/sandbox"]
 io_trace = ["base64"]
-test_features = []
+test_features = ["near-test-contracts/test_features"]
 
 # Use this feature to enable counting of fees and costs applied.
 costs_counting = []

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -29,12 +29,7 @@ near-parameters.workspace = true
 near-primitives.workspace = true
 near-primitives-core.workspace = true
 near-store.workspace = true
-near-vm-runner = { workspace = true, features = [
-  "wasmer0_vm",
-  "wasmer2_vm",
-  "near_vm",
-  "wasmtime_vm",
-] }
+near-vm-runner = { workspace = true, features = [ "wasmer0_vm", "wasmer2_vm", "near_vm", "wasmtime_vm" ] }
 near-wallet-contract.workspace = true
 
 [features]
@@ -66,7 +61,10 @@ nightly_protocol = [
 protocol_feature_nonrefundable_transfer_nep491 = []
 no_cpu_compatibility_checks = ["near-vm-runner/no_cpu_compatibility_checks"]
 
-no_cache = ["near-vm-runner/no_cache", "near-store/no_cache"]
+no_cache = [
+  "near-vm-runner/no_cache",
+  "near-store/no_cache",
+]
 
 sandbox = ["near-o11y/sandbox", "near-vm-runner/sandbox"]
 test_features = [

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -29,7 +29,12 @@ near-parameters.workspace = true
 near-primitives.workspace = true
 near-primitives-core.workspace = true
 near-store.workspace = true
-near-vm-runner = { workspace = true, features = [ "wasmer0_vm", "wasmer2_vm", "near_vm", "wasmtime_vm" ] }
+near-vm-runner = { workspace = true, features = [
+  "wasmer0_vm",
+  "wasmer2_vm",
+  "near_vm",
+  "wasmtime_vm",
+] }
 near-wallet-contract.workspace = true
 
 [features]
@@ -61,15 +66,13 @@ nightly_protocol = [
 protocol_feature_nonrefundable_transfer_nep491 = []
 no_cpu_compatibility_checks = ["near-vm-runner/no_cpu_compatibility_checks"]
 
-no_cache = [
-  "near-vm-runner/no_cache",
-  "near-store/no_cache",
-]
+no_cache = ["near-vm-runner/no_cache", "near-store/no_cache"]
 
 sandbox = ["near-o11y/sandbox", "near-vm-runner/sandbox"]
 test_features = [
   "near-primitives/test_features",
   "near-vm-runner/test_features",
+  "near-test-contracts/test_features",
 ]
 
 [dev-dependencies]


### PR DESCRIPTION
The test fails in nayduck with "MethodNotFound" when trying to call the sleep method. This should only happen if the test contract is built without the test_features rust feature enabled. 

I was able to reproduce it **once** locally. As soon as I added debug logs to the `build.rs` file in the near-test-contracts directory the test started passing. I suspect there is some race condition when building that causes the test_features to not be enabled. This is a lousy attempt to fix that issue by setting test_features wherever possible. I'm looking for hints on how to properly debug this. 