### PR TITLE
cleanup(congestion_control) - remove CongestionControlAllowedShardValidation

### DIFF
--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -492,7 +492,6 @@ pub fn validate_chunk_state_witness(
     // Finally, verify that the newly proposed chunk matches everything we have computed.
     let (outgoing_receipts_root, _) = merklize(&outgoing_receipts_hashes);
     validate_chunk_with_chunk_extra_and_receipts_root(
-        protocol_version,
         &chunk_extra,
         &state_witness.chunk_header,
         &outgoing_receipts_root,

--- a/chain/chain/src/validate.rs
+++ b/chain/chain/src/validate.rs
@@ -14,7 +14,6 @@ use near_primitives::merkle::merklize;
 use near_primitives::sharding::{ShardChunk, ShardChunkHeader};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;
-use near_primitives::types::ProtocolVersion;
 use near_primitives::types::{AccountId, BlockHeight, EpochId, Nonce};
 
 use crate::types::RuntimeAdapter;
@@ -126,11 +125,7 @@ pub fn validate_chunk_with_chunk_extra(
     };
     let (outgoing_receipts_root, _) = merklize(&outgoing_receipts_hashes);
 
-    let prev_epoch_id = epoch_manager.get_epoch_id(prev_block_hash)?;
-    let prev_protocol_version = epoch_manager.get_epoch_protocol_version(&prev_epoch_id)?;
-
     validate_chunk_with_chunk_extra_and_receipts_root(
-        prev_protocol_version,
         prev_chunk_extra,
         chunk_header,
         &outgoing_receipts_root,
@@ -139,7 +134,6 @@ pub fn validate_chunk_with_chunk_extra(
 
 /// Validate that all next chunk information matches previous chunk extra.
 pub fn validate_chunk_with_chunk_extra_and_receipts_root(
-    prev_protocol_version: ProtocolVersion,
     prev_chunk_extra: &ChunkExtra,
     chunk_header: &ShardChunkHeader,
     outgoing_receipts_root: &CryptoHash,
@@ -183,11 +177,7 @@ pub fn validate_chunk_with_chunk_extra_and_receipts_root(
         return Err(Error::InvalidGasLimit);
     }
 
-    validate_congestion_info(
-        prev_protocol_version,
-        &prev_chunk_extra.congestion_info(),
-        &chunk_header.congestion_info(),
-    )?;
+    validate_congestion_info(&prev_chunk_extra.congestion_info(), &chunk_header.congestion_info())?;
 
     Ok(())
 }
@@ -197,7 +187,6 @@ pub fn validate_chunk_with_chunk_extra_and_receipts_root(
 /// trusted as it is the result of verified computation. The header congestion
 /// info is being validated.
 fn validate_congestion_info(
-    extra_protocol_version: ProtocolVersion,
     extra_congestion_info: &Option<CongestionInfo>,
     header_congestion_info: &Option<CongestionInfo>,
 ) -> Result<(), Error> {
@@ -211,16 +200,14 @@ fn validate_congestion_info(
             extra_congestion_info, header_congestion_info
         ))),
         // Congestion Info is present in both the extra and the header. Validate it.
-        (Some(extra), Some(header)) => {
-            CongestionInfo::validate_extra_and_header(extra_protocol_version, extra, header)
-                .then_some(())
-                .ok_or_else(|| {
-                    Error::InvalidCongestionInfo(format!(
-                        "Congestion Information validate error. extra: {:?}, header: {:?}",
-                        extra, header
-                    ))
-                })
-        }
+        (Some(extra), Some(header)) => CongestionInfo::validate_extra_and_header(extra, header)
+            .then_some(())
+            .ok_or_else(|| {
+                Error::InvalidCongestionInfo(format!(
+                    "Congestion Information validate error. extra: {:?}, header: {:?}",
+                    extra, header
+                ))
+            }),
     }
 }
 

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -157,11 +157,6 @@ pub enum ProtocolFeature {
     PerReceiptHardStorageProofLimit,
     /// Cross-shard congestion control according to <https://github.com/near/NEPs/pull/539>.
     CongestionControl,
-    /// The allowed shard validation for congestion control. This is only needed
-    /// for statelessnet where it's released separately from the main
-    /// CongestionControl feature.
-    /// TODO(congestion_control) - remove it on stabilization
-    CongestionControlAllowedShardValidation,
     // Stateless validation: Distribute state witness as reed solomon encoded parts
     PartialEncodedStateWitness,
     /// Size limits for transactions included in a ChunkStateWitness.
@@ -230,8 +225,7 @@ impl ProtocolFeature {
             ProtocolFeature::SimpleNightshadeTestonly => 79,
 
             // StatelessNet features
-            ProtocolFeature::CongestionControl
-            | ProtocolFeature::CongestionControlAllowedShardValidation => 80,
+            ProtocolFeature::CongestionControl => 80,
             ProtocolFeature::StatelessValidationV0
             | ProtocolFeature::LowerValidatorKickoutPercentForDebugging => 81,
             ProtocolFeature::SingleShardTracking => 82,

--- a/core/primitives/src/congestion_info.rs
+++ b/core/primitives/src/congestion_info.rs
@@ -3,10 +3,7 @@ use std::collections::BTreeMap;
 use crate::errors::RuntimeError;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_parameters::config::CongestionControlConfig;
-use near_primitives_core::{
-    types::{Gas, ProtocolVersion, ShardId},
-    version::ProtocolFeature,
-};
+use near_primitives_core::types::{Gas, ShardId};
 
 /// This class combines the congestion control config, congestion info and
 /// missed chunks count. It contains the main congestion control logic and
@@ -153,25 +150,13 @@ impl CongestionInfo {
     // information from the chunk extra.
     //
     // TODO(congestion_control) validate allowed shard
-    pub fn validate_extra_and_header(
-        extra_protocol_version: ProtocolVersion,
-        extra: &CongestionInfo,
-        header: &CongestionInfo,
-    ) -> bool {
+    pub fn validate_extra_and_header(extra: &CongestionInfo, header: &CongestionInfo) -> bool {
         match (extra, header) {
             (CongestionInfo::V1(extra), CongestionInfo::V1(header)) => {
-                let correct_allowed_shard =
-                    if ProtocolFeature::CongestionControlAllowedShardValidation
-                        .enabled(extra_protocol_version)
-                    {
-                        extra.allowed_shard == header.allowed_shard
-                    } else {
-                        true
-                    };
                 extra.delayed_receipts_gas == header.delayed_receipts_gas
                     && extra.buffered_receipts_gas == header.buffered_receipts_gas
                     && extra.receipt_bytes == header.receipt_bytes
-                    && correct_allowed_shard
+                    && extra.allowed_shard == header.allowed_shard
             }
         }
     }


### PR DESCRIPTION
This feature was only needed for the protocol upgrade in statelessnet. Now that statelessnet is past this feature we can get rid of it and simplify the code. The simplification is not needing to pass the protocol version around. 