### PR TITLE
locust: Use a new session for each request

### DIFF
--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -241,10 +241,6 @@ class NearNodeProxy:
         self.request_event = environment.events.request
         [url, port] = environment.host.rsplit(":", 1)
         self.node = cluster.RpcNode(url, port)
-        self.session = Session(connection_timeout=6,
-                               network_timeout=9,
-                               max_retries=5,
-                               retry_delay=0.1)
 
     def send_tx_retry(self, tx: Transaction, locust_name) -> dict:
         """
@@ -395,8 +391,13 @@ class NearNodeProxy:
             "jsonrpc": "2.0"
         }
         try:
-            return self.session.post(url="http://%s:%s" % self.node.rpc_addr(),
-                                     json=j)
+            # Create a new session each time to allow parallel requests through the same node proxy.
+            session = Session(connection_timeout=6,
+                              network_timeout=9,
+                              max_retries=5,
+                              retry_delay=0.1)
+            return session.post(url="http://%s:%s" % self.node.rpc_addr(),
+                                json=j)
         except Exception as e:
             raise RpcError(details=e)
 


### PR DESCRIPTION
This allows parallelism across requests issued through the same NearNodeProxy. Alternative would be to use different proxies, but this can be tricky in calls like `on_locust_init` and `ft_contract.create_passive_users`.