### PR TITLE
fix: make TestnetFewerBlockProducers only apply to testnet

### DIFF
--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -257,9 +257,8 @@ impl AllEpochConfig {
             config.validator_selection_config.num_chunk_only_producer_seats = 200;
         }
 
-        // Adjust the number of block and chunk producers for all chains except
-        // mainnet, to make it easier to test the change.
-        if chain_id != near_primitives_core::chains::MAINNET
+        // Adjust the number of block and chunk producers for testnet, to make it easier to test the change.
+        if chain_id == near_primitives_core::chains::TESTNET
             && checked_feature!("stable", TestnetFewerBlockProducers, protocol_version)
             && !checked_feature!("stable", NoChunkOnlyProducers, protocol_version)
         {


### PR DESCRIPTION
Make `TestnetFewerBlockProducers` only apply to testnet to avoid breaking other testing network due to the hardcoded change of block producers. Specifically, increasing the number of block producers will make things break due to `num_total_parts` computation that only looks at what is in genesis and if genesis protocol version is between the protocol version of `TestnetFewerBlockProducers` and `NoChunkOnlyProducers`, it will forcefully set the number of block producer seats to 20, regardless of what is set in genesis. Even worse, any attempt to increase that later in the code won't work.