### PR TITLE
network: pick STUN server to match node_addr IP version

### DIFF
--- a/chain/network/src/config_json.rs
+++ b/chain/network/src/config_json.rs
@@ -72,7 +72,7 @@ fn default_peer_expiration_duration() -> Duration {
 /// a centralized entity (and DNS used for domain resolution),
 /// prefer to set up your own STUN server, or (even better)
 /// use public_addrs instead.
-fn default_trusted_stun_servers() -> Vec<stun::ServerAddr> {
+pub(crate) fn default_trusted_stun_servers() -> Vec<stun::ServerAddr> {
     vec![
         "stun.l.google.com:19302".to_string(),
         "stun1.l.google.com:19302".to_string(),

--- a/chain/network/src/peer_manager/network_state/tier1.rs
+++ b/chain/network/src/peer_manager/network_state/tier1.rs
@@ -107,8 +107,10 @@ impl super::NetworkState {
                 // Query all the STUN servers in parallel.
                 let queries = stun_servers.iter().map(|addr| {
                     let clock = clock.clone();
+                    let want_ipv4 = node_addr.is_ipv4();
                     let addr = addr.clone();
                     self.spawn(async move {
+                        let addr = stun::lookup_host(addr, want_ipv4).await?;
                         match stun::query(&clock, &addr).await {
                             Ok(ip) => Some(ip),
                             Err(err) => {

--- a/chain/network/src/peer_manager/network_state/tier1.rs
+++ b/chain/network/src/peer_manager/network_state/tier1.rs
@@ -110,7 +110,7 @@ impl super::NetworkState {
                     let want_ipv4 = node_addr.is_ipv4();
                     let addr = addr.clone();
                     self.spawn(async move {
-                        let addr = stun::lookup_host(addr, want_ipv4).await?;
+                        let addr = stun::lookup_host(&addr, want_ipv4).await?;
                         match stun::query(&clock, &addr).await {
                             Ok(ip) => Some(ip),
                             Err(err) => {

--- a/chain/network/src/peer_manager/tests/tier1.rs
+++ b/chain/network/src/peer_manager/tests/tier1.rs
@@ -402,7 +402,10 @@ async fn stun_self_discovery() {
     let stun_server2 = stun::testonly::Server::new().await;
     let mut cfg = chain.make_config(rng);
     let vc = cfg.validator.as_mut().unwrap();
-    vc.proxies = config::ValidatorProxies::Dynamic(vec![stun_server1.addr(), stun_server2.addr()]);
+    vc.proxies = config::ValidatorProxies::Dynamic(vec![
+        stun_server1.addr().to_string(),
+        stun_server2.addr().to_string(),
+    ]);
 
     tracing::info!(target:"test", "spawn a node and advertize AccountData.");
     let pm = start_pm(clock.clock(), TestDB::new(), cfg, chain.clone()).await;

--- a/chain/network/src/stun/mod.rs
+++ b/chain/network/src/stun/mod.rs
@@ -10,14 +10,13 @@ mod tests;
 pub(crate) mod testonly;
 
 /// Address of the format "<domain/ip>:<port>" of STUN servers.
-// TODO(gprusak): turn into a proper struct implementing Display and FromStr.
 pub type ServerAddr = String;
 
 pub(crate) type Error = stun::Error;
 
 /// Convert from ServerAddr to SocketAddr via DNS resolution.
 /// Looks for IPv4 or IPv6 according to `want_ipv4`.
-pub(crate) async fn lookup_host(addr: ServerAddr, want_ipv4: bool) -> Option<SocketAddr> {
+pub(crate) async fn lookup_host(addr: &ServerAddr, want_ipv4: bool) -> Option<SocketAddr> {
     for socket_addr in tokio::net::lookup_host(addr).await.ok()? {
         if want_ipv4 == socket_addr.is_ipv4() {
             return Some(socket_addr);

--- a/chain/network/src/stun/testonly.rs
+++ b/chain/network/src/stun/testonly.rs
@@ -50,8 +50,8 @@ impl Server {
         }
     }
 
-    pub fn addr(&self) -> super::ServerAddr {
-        self.addr.to_string()
+    pub fn addr(&self) -> super::SocketAddr {
+        self.addr.clone()
     }
 
     /// Closes the STUN server. close() is async so it cannot be implemented as Drop.

--- a/chain/network/src/stun/testonly.rs
+++ b/chain/network/src/stun/testonly.rs
@@ -51,7 +51,7 @@ impl Server {
     }
 
     pub fn addr(&self) -> super::SocketAddr {
-        self.addr.clone()
+        self.addr
     }
 
     /// Closes the STUN server. close() is async so it cannot be implemented as Drop.

--- a/chain/network/src/stun/tests.rs
+++ b/chain/network/src/stun/tests.rs
@@ -1,3 +1,4 @@
+use crate::config_json::default_trusted_stun_servers;
 use crate::stun;
 use near_async::time;
 use near_o11y::testonly::init_test_logger;
@@ -10,4 +11,26 @@ async fn test_query() {
     let ip = stun::query(&clock.clock(), &server.addr()).await.unwrap();
     assert_eq!(std::net::Ipv6Addr::LOCALHOST, ip);
     server.close().await;
+}
+
+#[tokio::test]
+async fn test_lookup_host() {
+    init_test_logger();
+
+    for addr in default_trusted_stun_servers() {
+        tracing::debug!("Querying STUN server at {}", addr);
+
+        // Allow lookup to return nothing; the server may be unreachable.
+        // What we want to check here is that if an address is returned,
+        // it has the expected type (IPv4 vs IPv6).
+        if let Some(ipv4) = stun::lookup_host(&addr, true).await {
+            assert!(ipv4.is_ipv4());
+            tracing::debug!("My IPv4 addr is {}", ipv4);
+        }
+
+        if let Some(ipv6) = stun::lookup_host(&addr, false).await {
+            assert!(ipv6.is_ipv6());
+            tracing::debug!("My IPv6 addr is {}", ipv6);
+        }
+    }
 }

--- a/chain/network/src/tcp.rs
+++ b/chain/network/src/tcp.rs
@@ -234,6 +234,10 @@ impl ListenerAddr {
         socket.bind(self.0)?;
         Ok(Listener(socket.listen(LISTENER_BACKLOG)?))
     }
+
+    pub(crate) fn is_ipv4(&self) -> bool {
+        self.0.is_ipv4()
+    }
 }
 
 pub(crate) struct Listener(tokio::net::TcpListener);


### PR DESCRIPTION
When nodes query an address such as `stun.l.google.com:19302` for which there exist both IPv4 and IPv6 records, `tokio::net::UdpSocket::connect` chooses one arbitrarily.

We should make sure to query the appropriate server based on the IP version of the node's TCP listener address.