### PR TITLE
chore: resolve a warning from cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ chrono = { version = "0.4.19", features = ["serde"] }
 clap = { version = "4.2.0", features = ["derive", "env", "string"] }
 cloud-storage = "0.11.1"
 cpu-time = "1.0"
-criterion = { version = "0.5.1", default_features = false, features = [
+criterion = { version = "0.5.1", default-features = false, features = [
     "html_reports",
     "cargo_bench_support",
 ] }


### PR DESCRIPTION
Something about this spelling no longer working starting with 2024 edition.