### PR TITLE
fix: revert db version 40

### DIFF
--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -1065,8 +1065,6 @@ pub enum ValidatorKickoutReason {
     NotEnoughBlocks { produced: NumBlocks, expected: NumBlocks },
     /// Validator didn't produce enough chunks.
     NotEnoughChunks { produced: NumBlocks, expected: NumBlocks },
-    /// Validator didn't produce enough chunk endorsements.
-    NotEnoughChunkEndorsements { produced: NumBlocks, expected: NumBlocks },
     /// Validator unstaked themselves.
     Unstaked,
     /// Validator stake is now below threshold
@@ -1078,6 +1076,8 @@ pub enum ValidatorKickoutReason {
     },
     /// Enough stake but is not chosen because of seat limits.
     DidNotGetASeat,
+    /// Validator didn't produce enough chunk endorsements.
+    NotEnoughChunkEndorsements { produced: NumBlocks, expected: NumBlocks },
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]

--- a/core/store/src/metadata.rs
+++ b/core/store/src/metadata.rs
@@ -2,7 +2,7 @@
 pub type DbVersion = u32;
 
 /// Current version of the database.
-pub const DB_VERSION: DbVersion = 40;
+pub const DB_VERSION: DbVersion = 39;
 
 /// Database version at which point DbKind was introduced.
 const DB_VERSION_WITH_KIND: DbVersion = 34;

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -4,11 +4,10 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use near_primitives::epoch_manager::epoch_info::EpochSummary;
 use near_primitives::epoch_manager::AGGREGATOR_KEY;
 use near_primitives::hash::CryptoHash;
-use near_primitives::serialize::dec_format;
 use near_primitives::state::FlatStateValue;
 use near_primitives::transaction::{ExecutionOutcomeWithIdAndProof, ExecutionOutcomeWithProof};
 use near_primitives::types::{
-    validator_stake::ValidatorStake, AccountId, Balance, EpochId, NumBlocks, ShardId, ValidatorId,
+    validator_stake::ValidatorStake, AccountId, EpochId, ShardId, ValidatorId,
     ValidatorKickoutReason, ValidatorStats,
 };
 use near_primitives::types::{BlockChunkValidatorStats, ChunkStats};

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -88,7 +88,6 @@ impl<'a> near_store::StoreMigrator for Migrator<'a> {
             36 => near_store::migrations::migrate_36_to_37(store),
             37 => near_store::migrations::migrate_37_to_38(store),
             38 => near_store::migrations::migrate_38_to_39(store),
-            39 => near_store::migrations::migrate_39_to_40(store),
             DB_VERSION.. => unreachable!(),
         }
     }


### PR DESCRIPTION
I tried #11569 to solve validator kickout enum issue to get mainnet and statelessnet aligned. But because we reset statelessnet, we can get all ValidatorKickoutReasons in line. This is the easiest solution.

DB version for latest release is 38, so removing 40 is not an issue. 39 must stay.