### PR TITLE
[test] Use clock in get_protocol_version with upgrade schedule

### DIFF
--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -89,6 +89,7 @@ fn build_chain_with_orphans() {
         *last_block.header().next_bp_hash(),
         CryptoHash::default(),
         clock,
+        None,
     );
     assert_matches!(chain.process_block_test(&None, block).unwrap_err(), Error::Orphan);
     assert_matches!(

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -59,10 +59,11 @@ fn build_chain() {
 #[test]
 fn build_chain_with_orphans() {
     init_test_logger();
-    let (mut chain, _, _, signer) = setup(Clock::real());
+    let clock = Clock::real();
+    let (mut chain, _, _, signer) = setup(clock.clone());
     let mut blocks = vec![chain.get_block(&chain.genesis().hash().clone()).unwrap()];
     for i in 1..4 {
-        let block = TestBlockBuilder::new(Clock::real(), &blocks[i - 1], signer.clone()).build();
+        let block = TestBlockBuilder::new(clock.clone(), &blocks[i - 1], signer.clone()).build();
         blocks.push(block);
     }
     let last_block = &blocks[blocks.len() - 1];
@@ -87,7 +88,7 @@ fn build_chain_with_orphans() {
         &*signer,
         *last_block.header().next_bp_hash(),
         CryptoHash::default(),
-        Utc::UNIX_EPOCH,
+        clock,
     );
     assert_matches!(chain.process_block_test(&None, block).unwrap_err(), Error::Orphan);
     assert_matches!(

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -706,6 +706,11 @@ impl Client {
             prev_next_bp_hash
         };
 
+        #[cfg(feature = "sandbox")]
+        let sandbox_delta_time = Some(self.sandbox_delta_time());
+        #[cfg(not(feature = "sandbox"))]
+        let sandbox_delta_time = None;
+
         // Get block extra from previous block.
         let block_merkle_tree = self.chain.chain_store().get_block_merkle_tree(&prev_hash)?;
         let mut block_merkle_tree = PartialMerkleTree::clone(&block_merkle_tree);
@@ -798,8 +803,7 @@ impl Client {
             next_bp_hash,
             block_merkle_root,
             self.clock.clone(),
-            #[cfg(feature = "sandbox")]
-            self.sandbox_delta_time(),
+            sandbox_delta_time,
         );
 
         // Update latest known even before returning block out, to prevent race conditions.

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -706,11 +706,6 @@ impl Client {
             prev_next_bp_hash
         };
 
-        #[cfg(feature = "sandbox")]
-        let block_timestamp = self.clock.now_utc() + self.sandbox_delta_time();
-        #[cfg(not(feature = "sandbox"))]
-        let block_timestamp = self.clock.now_utc();
-
         // Get block extra from previous block.
         let block_merkle_tree = self.chain.chain_store().get_block_merkle_tree(&prev_hash)?;
         let mut block_merkle_tree = PartialMerkleTree::clone(&block_merkle_tree);
@@ -802,7 +797,9 @@ impl Client {
             &*validator_signer,
             next_bp_hash,
             block_merkle_root,
-            block_timestamp,
+            self.clock.clone(),
+            #[cfg(feature = "sandbox")]
+            self.sandbox_delta_time(),
         );
 
         // Update latest known even before returning block out, to prevent race conditions.

--- a/chain/client/src/sync/header.rs
+++ b/chain/client/src/sync/header.rs
@@ -809,6 +809,7 @@ mod test {
                 *last_block.header().next_bp_hash(),
                 block_merkle_tree.root(),
                 clock.clock(),
+                None,
             );
             block_merkle_tree.insert(*block.hash());
             chain2.process_block_header(block.header(), &mut Vec::new()).unwrap(); // just to validate

--- a/chain/client/src/sync/header.rs
+++ b/chain/client/src/sync/header.rs
@@ -808,7 +808,7 @@ mod test {
                 signer2.as_ref(),
                 *last_block.header().next_bp_hash(),
                 block_merkle_tree.root(),
-                clock.now_utc(),
+                clock.clock(),
             );
             block_merkle_tree.insert(*block.hash());
             chain2.process_block_header(block.header(), &mut Vec::new()).unwrap(); // just to validate

--- a/chain/client/src/test_utils/client.rs
+++ b/chain/client/src/test_utils/client.rs
@@ -263,6 +263,7 @@ pub fn create_chunk(
         *last_block.header().next_bp_hash(),
         block_merkle_tree.root(),
         client.clock.clone(),
+        None,
     );
     (
         ProduceChunkResult {

--- a/chain/client/src/test_utils/client.rs
+++ b/chain/client/src/test_utils/client.rs
@@ -262,7 +262,7 @@ pub fn create_chunk(
         &*client.validator_signer.get().unwrap(),
         *last_block.header().next_bp_hash(),
         block_merkle_tree.root(),
-        client.clock.now_utc(),
+        client.clock.clone(),
     );
     (
         ProduceChunkResult {

--- a/chain/client/src/tests/query_client.rs
+++ b/chain/client/src/tests/query_client.rs
@@ -99,7 +99,7 @@ fn query_status_not_crash() {
                 &signer,
                 block.header.next_bp_hash,
                 block_merkle_tree.root(),
-                Clock::real().now_utc(),
+                Clock::real(),
             );
             next_block.mut_header().get_mut().inner_lite.timestamp =
                 (next_block.header().timestamp() + Duration::seconds(60)).unix_timestamp_nanos()

--- a/chain/client/src/tests/query_client.rs
+++ b/chain/client/src/tests/query_client.rs
@@ -100,6 +100,7 @@ fn query_status_not_crash() {
                 block.header.next_bp_hash,
                 block_merkle_tree.root(),
                 Clock::real(),
+                None,
             );
             next_block.mut_header().get_mut().inner_lite.timestamp =
                 (next_block.header().timestamp() + Duration::seconds(60)).unix_timestamp_nanos()

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -68,6 +68,7 @@ pub fn make_block(
         CryptoHash::default(),
         CryptoHash::default(),
         clock,
+        None,
     )
 }
 

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -41,7 +41,7 @@ pub fn make_genesis_block(clock: &time::Clock, chunks: Vec<ShardChunk>) -> Block
 }
 
 pub fn make_block(
-    clock: &time::Clock,
+    clock: time::Clock,
     signer: &ValidatorSigner,
     prev: &Block,
     chunks: Vec<ShardChunk>,
@@ -67,7 +67,7 @@ pub fn make_block(
         signer,
         CryptoHash::default(),
         CryptoHash::default(),
-        clock.now_utc(),
+        clock,
     )
 }
 
@@ -248,7 +248,7 @@ impl Chain {
         for _ in 1..block_count {
             clock.advance(time::Duration::seconds(15));
             blocks.push(make_block(
-                &clock.clock(),
+                clock.clock(),
                 &signer.clone().into(),
                 blocks.last().unwrap(),
                 chunks.make(),

--- a/core/primitives/benches/serialization.rs
+++ b/core/primitives/benches/serialization.rs
@@ -71,7 +71,7 @@ fn create_block() -> Block {
         &signer.into(),
         CryptoHash::default(),
         CryptoHash::default(),
-        Clock::real().now_utc(),
+        Clock::real(),
     )
 }
 

--- a/core/primitives/benches/serialization.rs
+++ b/core/primitives/benches/serialization.rs
@@ -72,6 +72,7 @@ fn create_block() -> Block {
         CryptoHash::default(),
         CryptoHash::default(),
         Clock::real(),
+        None,
     )
 }
 

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -16,7 +16,7 @@ use crate::validator_signer::ValidatorSigner;
 use crate::version::{ProtocolVersion, SHARD_CHUNK_HEADER_UPGRADE_VERSION};
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_crypto::Signature;
-use near_time::{Clock, Utc};
+use near_time::{Clock, Duration, Utc};
 use primitive_types::U256;
 use std::collections::BTreeMap;
 use std::ops::Index;
@@ -267,7 +267,7 @@ impl Block {
         next_bp_hash: CryptoHash,
         block_merkle_root: CryptoHash,
         clock: Clock,
-        #[cfg(feature = "sandbox")] sandbox_delta_time: near_time::Duration,
+        sandbox_delta_time: Option<Duration>,
     ) -> Self {
         // Collect aggregate of validators and gas usage/limits from chunks.
         let mut prev_validator_proposals = vec![];
@@ -299,7 +299,9 @@ impl Block {
         let new_total_supply = prev.total_supply() + minted_amount.unwrap_or(0) - balance_burnt;
         let now = clock.now_utc().unix_timestamp_nanos() as u64;
         #[cfg(feature = "sandbox")]
-        let now = now + sandbox_delta_time;
+        let now = now + sandbox_delta_time.unwrap().whole_nanoseconds() as u64;
+        #[cfg(not(feature = "sandbox"))]
+        debug_assert!(sandbox_delta_time.is_none());
         let time = if now <= prev.raw_timestamp() { prev.raw_timestamp() + 1 } else { now };
 
         let (vrf_value, vrf_proof) = signer.compute_vrf_with_proof(prev.random_value().as_ref());

--- a/core/primitives/src/block_header.rs
+++ b/core/primitives/src/block_header.rs
@@ -8,7 +8,7 @@ use crate::validator_signer::ValidatorSigner;
 use crate::version::{get_protocol_version, ProtocolVersion, PROTOCOL_VERSION};
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_crypto::{KeyType, PublicKey, Signature};
-use near_time::Utc;
+use near_time::{Clock, Utc};
 use std::sync::Arc;
 
 #[derive(
@@ -437,6 +437,7 @@ impl BlockHeader {
         next_bp_hash: CryptoHash,
         block_merkle_root: CryptoHash,
         prev_height: BlockHeight,
+        clock: Clock,
     ) -> Self {
         let inner_lite = BlockHeaderInnerLite {
             height,
@@ -539,7 +540,7 @@ impl BlockHeader {
                 prev_height,
                 epoch_sync_data_hash,
                 approvals,
-                latest_protocol_version: get_protocol_version(next_epoch_protocol_version),
+                latest_protocol_version: get_protocol_version(next_epoch_protocol_version, clock),
             };
             let (hash, signature) = signer.sign_block_header_parts(
                 prev_hash,
@@ -572,7 +573,7 @@ impl BlockHeader {
                 prev_height,
                 epoch_sync_data_hash,
                 approvals,
-                latest_protocol_version: get_protocol_version(next_epoch_protocol_version),
+                latest_protocol_version: get_protocol_version(next_epoch_protocol_version, clock),
             };
             let (hash, signature) = signer.sign_block_header_parts(
                 prev_hash,

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -540,6 +540,7 @@ impl TestBlockBuilder {
             self.next_bp_hash,
             self.block_merkle_root,
             self.clock,
+            None,
         )
     }
 }

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -539,7 +539,7 @@ impl TestBlockBuilder {
             self.signer.as_ref(),
             self.next_bp_hash,
             self.block_merkle_root,
-            self.clock.now_utc(),
+            self.clock,
         )
     }
 }

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -1,4 +1,5 @@
 use crate::types::Balance;
+use near_time::Clock;
 use once_cell::sync::Lazy;
 
 /// Data structure for semver version and github tag or commit.
@@ -87,8 +88,11 @@ pub const PROTOCOL_UPGRADE_SCHEDULE: Lazy<ProtocolUpgradeVotingSchedule> = Lazy:
 /// Gives new clients an option to upgrade without announcing that they support
 /// the new version.  This gives non-validator nodes time to upgrade.  See
 /// <https://github.com/near/NEPs/issues/205>
-pub fn get_protocol_version(next_epoch_protocol_version: ProtocolVersion) -> ProtocolVersion {
-    let now = near_time::Utc::now_utc();
+pub fn get_protocol_version(
+    next_epoch_protocol_version: ProtocolVersion,
+    clock: Clock,
+) -> ProtocolVersion {
+    let now = clock.now_utc();
     let chrono = chrono::DateTime::from_timestamp(now.unix_timestamp(), now.nanosecond());
     PROTOCOL_UPGRADE_SCHEDULE
         .get_protocol_version(chrono.unwrap_or_default(), next_epoch_protocol_version)

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -115,7 +115,7 @@ fn test_verify_block_double_sign_challenge() {
         &signer,
         *b1.header().next_bp_hash(),
         block_merkle_tree.root(),
-        Clock::real().now_utc(),
+        Clock::real(),
     );
     let epoch_id = b1.header().epoch_id().clone();
     let valid_challenge = Challenge::produce(
@@ -437,7 +437,7 @@ fn test_verify_chunk_invalid_state_challenge() {
         &validator_signer,
         *last_block.header().next_bp_hash(),
         block_merkle_tree.root(),
-        Clock::real().now_utc(),
+        Clock::real(),
     );
 
     let challenge_body =

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -116,6 +116,7 @@ fn test_verify_block_double_sign_challenge() {
         *b1.header().next_bp_hash(),
         block_merkle_tree.root(),
         Clock::real(),
+        None,
     );
     let epoch_id = b1.header().epoch_id().clone();
     let valid_challenge = Challenge::produce(
@@ -438,6 +439,7 @@ fn test_verify_chunk_invalid_state_challenge() {
         *last_block.header().next_bp_hash(),
         block_merkle_tree.root(),
         Clock::real(),
+        None,
     );
 
     let challenge_body =

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -350,6 +350,7 @@ fn receive_network_block() {
                 last_block.header.next_bp_hash,
                 block_merkle_tree.root(),
                 Clock::real(),
+                None,
             );
             actor_handles.client_actor.do_send(
                 BlockResponse { block, peer_id: PeerInfo::random().id, was_requested: false }
@@ -436,6 +437,7 @@ fn produce_block_with_approvals() {
                 last_block.header.next_bp_hash,
                 block_merkle_tree.root(),
                 Clock::real(),
+                None,
             );
             actor_handles.client_actor.do_send(
                 BlockResponse {
@@ -652,6 +654,7 @@ fn invalid_blocks_common(is_requested: bool) {
                 last_block.header.next_bp_hash,
                 block_merkle_tree.root(),
                 Clock::real(),
+                None,
             );
             // Send block with invalid chunk mask
             let mut block = valid_block.clone();

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -349,7 +349,7 @@ fn receive_network_block() {
                 &signer,
                 last_block.header.next_bp_hash,
                 block_merkle_tree.root(),
-                Clock::real().now_utc(),
+                Clock::real(),
             );
             actor_handles.client_actor.do_send(
                 BlockResponse { block, peer_id: PeerInfo::random().id, was_requested: false }
@@ -435,7 +435,7 @@ fn produce_block_with_approvals() {
                 &signer1,
                 last_block.header.next_bp_hash,
                 block_merkle_tree.root(),
-                Clock::real().now_utc(),
+                Clock::real(),
             );
             actor_handles.client_actor.do_send(
                 BlockResponse {
@@ -651,7 +651,7 @@ fn invalid_blocks_common(is_requested: bool) {
                 &signer,
                 last_block.header.next_bp_hash,
                 block_merkle_tree.root(),
-                Clock::real().now_utc(),
+                Clock::real(),
             );
             // Send block with invalid chunk mask
             let mut block = valid_block.clone();

--- a/integration-tests/src/tests/nearcore_utils.rs
+++ b/integration-tests/src/tests/nearcore_utils.rs
@@ -85,6 +85,7 @@ pub fn add_blocks(
             next_bp_hash,
             block_merkle_tree.root(),
             clock.clone(),
+            None,
         );
         block_merkle_tree.insert(*block.hash());
         let _ = client.do_send(

--- a/integration-tests/src/tests/nearcore_utils.rs
+++ b/integration-tests/src/tests/nearcore_utils.rs
@@ -84,7 +84,7 @@ pub fn add_blocks(
             signer,
             next_bp_hash,
             block_merkle_tree.root(),
-            clock.now_utc(),
+            clock.clone(),
         );
         block_merkle_tree.insert(*block.hash());
         let _ = client.do_send(


### PR DESCRIPTION
This change is needed to make setting protocol version in block compatible with test loop that uses fake clock.