### PR TITLE
[ft-benchmark] switch cron job to new scripts

### DIFF
--- a/scripts/ft-benchmark.sh
+++ b/scripts/ft-benchmark.sh
@@ -12,17 +12,7 @@ export PATH=$PATH:$HOME/.cargo/bin
 # Fetch the latest changes from the remote
 git fetch
 
-# Check if the local master branch is up to date with the remote master branch
-LOCAL=$(git rev-parse master)
-REMOTE=$(git rev-parse origin/master)
-
-if [ $LOCAL = $REMOTE ]; then
-    echo "The repository is up to date with the remote. No rebuilds or restarts needed."
-    exit 0
-else
-    echo "The local repository is behind the remote. Pulling changes..."
-    git pull
-fi
+git pull
 
 # some logging improvements
 NEW_COMMIT_HASH=$(git rev-parse origin/master)
@@ -30,30 +20,4 @@ LOG_DIR=scripts/ft-benchmark-logs
 MAIN_LOG_FILE=$LOG_DIR/${NEW_COMMIT_HASH}.log
 exec > >(tee -a $MAIN_LOG_FILE) 2>&1
 
-# TODO: Use ./start-benchmark.sh insread.
-
-# Stop previous experiment
-pkill -9 locust || true
-nearup stop 
-
-make neard
-
-# Start neard
-nearup run localnet --binary-path target/release/ --num-nodes 1 --num-shards 1 --override
-# Prepare python environment
-python3 -m venv .venv
-source .venv/bin/activate
-python -m pip install -r pytest/requirements.txt
-python -m pip install locust
-export KEY=~/.near/localnet/node0/validator_key.json
-
-# Run benchmark
-cd pytest/tests/loadtest/locust/
-nohup locust -H 127.0.0.1:3030  -f locustfiles/ft.py --funding-key=$KEY -t 130m -u 1000 -r 10 --processes 8 --headless &
-
-# Give locust 5 minutes to start and rump up
-sleep 300
-
-# Run data collector
-cd ~/nearcore
-python3 scripts/ft-benchmark-data-sender.py
+python3 scripts/run-ft-benchmark.py --user "scheduled_run_on_crt_ft_benchmark"


### PR DESCRIPTION
Here I switch script I'm using in cron job for regular runs to using new scripts. We can't just schedule `python3 new-script.py` on cron, because cron have a bit different environment compared to just running python file on the machine and it requires updating `PATH`. 

With current updates I agree that this script should be renamed, but soon will send PR with massive renamings and relocatings of ft-benchmark related files.