### PR TITLE
feat: rate limit for network messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Non-protocol Changes
 
+* Enforce rate limits to received network messages [#11617](https://github.com/near/nearcore/issues/11617). Rate limits are configured by default, but they can be overridden through the experimental configuration option `received_messages_rate_limits`.
+
 ## 1.40.0
 
 ### Protocol Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4472,6 +4472,7 @@ dependencies = [
  "reed-solomon-erasure",
  "rlimit",
  "serde",
+ "serde_json",
  "sha2 0.10.6",
  "smart-default",
  "strum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4444,6 +4444,7 @@ dependencies = [
  "criterion",
  "crossbeam-channel",
  "derive_more",
+ "enum-map",
  "futures",
  "futures-util",
  "im",

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -72,6 +72,7 @@ rlimit.workspace = true
 tempfile.workspace = true
 turn.workspace = true
 webrtc-util.workspace = true
+serde_json.workspace = true
 
 [features]
 nightly_protocol = [

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -26,6 +26,7 @@ bytesize.workspace = true
 chrono.workspace = true
 crossbeam-channel.workspace = true
 derive_more.workspace = true
+enum-map.workspace = true
 futures-util.workspace = true
 futures.workspace = true
 im.workspace = true

--- a/chain/network/src/config.rs
+++ b/chain/network/src/config.rs
@@ -3,6 +3,7 @@ use crate::concurrency::rate;
 use crate::network_protocol::PeerAddr;
 use crate::network_protocol::PeerInfo;
 use crate::peer_manager::peer_store;
+use crate::rate_limits::messages_limits;
 use crate::snapshot_hosts;
 use crate::stun;
 use crate::tcp;
@@ -191,6 +192,9 @@ pub struct NetworkConfig {
     //   * ignoring received deleted edges as well
     pub skip_tombstones: Option<time::Duration>,
 
+    /// Configuration of rate limits for incoming messages.
+    pub received_messages_rate_limits: messages_limits::Config,
+
     #[cfg(test)]
     pub(crate) event_sink:
         near_async::messaging::Sender<crate::peer_manager::peer_manager_actor::Event>,
@@ -370,6 +374,8 @@ impl NetworkConfig {
             } else {
                 None
             },
+            // TODO(trisfald): set config properly
+            received_messages_rate_limits: messages_limits::Config::default(),
             #[cfg(test)]
             event_sink: near_async::messaging::IntoSender::into_sender(
                 near_async::messaging::noop(),
@@ -447,6 +453,7 @@ impl NetworkConfig {
                 enable_outbound: true,
             }),
             skip_tombstones: None,
+            received_messages_rate_limits: messages_limits::Config::default(),
             #[cfg(test)]
             event_sink: near_async::messaging::IntoSender::into_sender(
                 near_async::messaging::noop(),

--- a/chain/network/src/config.rs
+++ b/chain/network/src/config.rs
@@ -694,21 +694,15 @@ mod test {
     #[test]
     fn received_messages_rate_limits_error() {
         let mut nc = config::NetworkConfig::from_seed("123", tcp::ListenerAddr::reserve_for_test());
-        nc.received_messages_rate_limits.rate_limits.push(SingleMessageConfig::new(
-            BlockHeaders,
-            1,
-            -4.0,
-            None,
-        ));
+        nc.received_messages_rate_limits
+            .rate_limits
+            .insert(BlockHeaders, SingleMessageConfig::new(1, -4.0, None));
         assert!(nc.verify().is_err());
 
         let mut nc = config::NetworkConfig::from_seed("123", tcp::ListenerAddr::reserve_for_test());
-        nc.received_messages_rate_limits.rate_limits.push(SingleMessageConfig::new(
-            BlockHeaders,
-            1,
-            4.0,
-            None,
-        ));
+        nc.received_messages_rate_limits
+            .rate_limits
+            .insert(BlockHeaders, SingleMessageConfig::new(1, 4.0, None));
         assert!(nc.verify().is_ok());
     }
 }

--- a/chain/network/src/config.rs
+++ b/chain/network/src/config.rs
@@ -240,6 +240,9 @@ impl NetworkConfig {
         ) {
             self.routing_table_update_rate_limit = rate::Limit { qps, burst }
         }
+        if let Some(rate_limits) = overrides.received_messages_rate_limits {
+            self.received_messages_rate_limits.apply_overrides(rate_limits);
+        }
     }
 
     pub fn new(
@@ -374,8 +377,8 @@ impl NetworkConfig {
             } else {
                 None
             },
-            // TODO(trisfald): set config properly
-            received_messages_rate_limits: messages_limits::Config::default(),
+            // Use a preset to configure rate limits and override entries with user defined values later.
+            received_messages_rate_limits: messages_limits::Config::standard_preset(),
             #[cfg(test)]
             event_sink: near_async::messaging::IntoSender::into_sender(
                 near_async::messaging::noop(),

--- a/chain/network/src/config_json.rs
+++ b/chain/network/src/config_json.rs
@@ -1,4 +1,5 @@
 use crate::network_protocol::PeerAddr;
+use crate::rate_limits::messages_limits;
 use crate::stun;
 use near_async::time::Duration;
 
@@ -285,6 +286,7 @@ pub struct NetworkConfigOverrides {
     pub accounts_data_broadcast_rate_limit_qps: Option<f64>,
     pub routing_table_update_rate_limit_burst: Option<u64>,
     pub routing_table_update_rate_limit_qps: Option<f64>,
+    pub received_messages_rate_limits: Option<messages_limits::OverrideConfig>,
 }
 
 impl Default for ExperimentalConfig {

--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -1,4 +1,5 @@
 pub use crate::peer_manager::peer_manager_actor::{Event, PeerManagerActor};
+pub use crate::rate_limits::messages_limits::OverrideConfig as MessagesLimitsOverrideConfig;
 
 mod accounts_data;
 mod announce_accounts;

--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -6,6 +6,7 @@ mod network_protocol;
 mod peer;
 mod peer_manager;
 mod private_actix;
+mod rate_limits;
 mod snapshot_hosts;
 mod stats;
 mod store;

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -317,7 +317,7 @@ impl PeerActor {
         };
         let received_messages_rate_limits = messages_limits::RateLimits::from_config(
             &network_state.config.received_messages_rate_limits,
-            Some(clock.now()),
+            clock.now(),
         );
         // recv is the HandshakeSignal returned by this spawn_inner() call.
         let (send, recv): (HandshakeSignalSender, HandshakeSignal) =

--- a/chain/network/src/peer/tests/mod.rs
+++ b/chain/network/src/peer/tests/mod.rs
@@ -1,2 +1,3 @@
 mod communication;
+mod rate_limits;
 mod stream;

--- a/chain/network/src/peer/tests/rate_limits.rs
+++ b/chain/network/src/peer/tests/rate_limits.rs
@@ -1,15 +1,19 @@
 use crate::broadcast::Receiver;
+use crate::config::NetworkConfig;
 use crate::network_protocol::{testonly as data, PartialEncodedChunkRequestMsg, RoutedMessageBody};
 use crate::network_protocol::{Encoding, PeerMessage};
 use crate::peer::testonly::{Event, PeerConfig, PeerHandle};
 use crate::peer_manager::peer_manager_actor::Event as PME;
+use crate::rate_limits::messages_limits;
 use crate::tcp;
 use crate::testonly::{make_rng, Rng};
 use near_async::time::FakeClock;
 use near_o11y::testonly::init_test_logger;
+use near_primitives::hash::CryptoHash;
+use rand::Rng as _;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::time::{sleep_until, Instant};
+use tokio::time::{sleep, sleep_until, Instant};
 
 #[tokio::test]
 // Verifies that peer traffic is rate limited per message type. Not all messages are rate limited.
@@ -19,19 +23,20 @@ async fn test_message_rate_limits() -> anyhow::Result<()> {
     init_test_logger();
     tracing::info!("test_message_rate_limits");
 
+    let mut clock = FakeClock::default();
     let mut rng = make_rng(89028037453);
-    let (outbound, inbound) = setup_test_peers(&mut rng).await;
+    let (outbound, inbound) = setup_test_peers(&mut clock, &mut rng).await;
 
     const MESSAGES: u32 = 7;
     // Let's gather all events received from now on. We'll check them later, after producing messages.
     let mut events = inbound.events.from_now();
-    let messages_samples = send_messages(&inbound, &outbound, &mut rng, 0, MESSAGES).await;
+    let messages_samples = send_messages(&inbound, &outbound, &mut rng, MESSAGES).await;
 
     // Check how many messages of each type have been received.
     let messages_received =
-        wait_for_messages(&messages_samples, &mut events, Duration::from_secs(3)).await;
+        wait_for_similar_messages(&messages_samples, &mut events, Duration::from_secs(3)).await;
     tracing::debug!(target:"test","received {messages_received:?} messages");
-    // SyncRoutingTable gets rate limited (7 sent vs 5 bucket_start).
+    // BlockRequest gets rate limited (7 sent vs 5 bucket_start).
     assert!(messages_received[0] < MESSAGES);
     // PartialEncodedChunkRequest gets rate limited (7 sent vs 5 bucket_start).
     assert!(messages_received[1] < MESSAGES);
@@ -42,16 +47,16 @@ async fn test_message_rate_limits() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-// Verifies that peer traffic is not rate limited when messages are sent at regular intevals,
+// Verifies that peer traffic is not rate limited when messages are sent at regular intervals,
 // and the total number of messages is below the limit.
 async fn test_message_rate_limits_over_time() -> anyhow::Result<()> {
     init_test_logger();
     tracing::info!("test_message_rate_limits_over_time");
 
+    let mut clock = FakeClock::default();
     let mut rng = make_rng(89028037453);
-    let (outbound, inbound) = setup_test_peers(&mut rng).await;
+    let (outbound, inbound) = setup_test_peers(&mut clock, &mut rng).await;
 
-    const SEED: u64 = 89028037453;
     const MESSAGES: u32 = 4;
     const INTERVAL: Duration = Duration::from_secs(2);
     // Let's gather all events received from now on. We'll check them later, after producing messages.
@@ -59,18 +64,19 @@ async fn test_message_rate_limits_over_time() -> anyhow::Result<()> {
 
     // Send 4 messages of each type every 2 seconds, three times.
     let mut messages_samples = Vec::new();
-    let now = Instant::now();
+    let now = clock.now();
     for i in 0..3 {
-        let mut rng = make_rng(SEED);
-        messages_samples =
-            send_messages(&inbound, &outbound, &mut rng, MESSAGES * i, MESSAGES).await;
-        sleep_until(now + INTERVAL * (i + 1)).await;
+        messages_samples = send_messages(&inbound, &outbound, &mut rng, MESSAGES).await;
+        // Advance the fake clock to refresh rate limits.
+        clock.advance_until(now + INTERVAL * (i + 1));
+        // Give some time to peer actors to process messages.
+        sleep(Duration::from_secs(1)).await;
     }
 
     let messages_received =
-        wait_for_messages(&messages_samples, &mut events, Duration::from_secs(3)).await;
+        wait_for_similar_messages(&messages_samples, &mut events, Duration::from_secs(3)).await;
     tracing::debug!(target:"test","received {messages_received:?} messages");
-    // SyncRoutingTable and PartialEncodedChunkRequest doesn't get rate limited
+    // BlockRequest and PartialEncodedChunkRequest don't get rate limited
     // 12 sent vs 5 bucket_start + 2.5 refilled * 4s
     assert_eq!(messages_received[0], MESSAGES * 3);
     assert_eq!(messages_received[1], MESSAGES * 3);
@@ -80,9 +86,11 @@ async fn test_message_rate_limits_over_time() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Waits up to `duration` and then checks how many events equal to each one of `samples` have been received.
+/// Waits up to `duration` and then checks how many events equal (in type only) to each one of `samples`
+/// have been received.
+///
 /// Returns a vector of the same size of `samples`.
-async fn wait_for_messages(
+async fn wait_for_similar_messages(
     samples: &[PeerMessage],
     events: &mut Receiver<Event>,
     duration: Duration,
@@ -91,20 +99,9 @@ async fn wait_for_messages(
     sleep_until(Instant::now() + duration).await;
     while let Some(event) = events.try_recv() {
         match event {
-            // Routed messages aren't exactly the same, just look at the type.
-            Event::Network(PME::MessageProcessed(_, got))
-                if matches!(got, PeerMessage::Routed(_)) =>
-            {
-                for (i, sample) in samples.iter().enumerate() {
-                    if sample.msg_variant() == got.msg_variant() {
-                        messages_received[i] += 1;
-                    }
-                }
-            }
-            // For all other message check equality.
             Event::Network(PME::MessageProcessed(_, got)) => {
                 for (i, sample) in samples.iter().enumerate() {
-                    if *sample == got {
+                    if sample.msg_variant() == got.msg_variant() {
                         messages_received[i] += 1;
                     }
                 }
@@ -118,23 +115,34 @@ async fn wait_for_messages(
 /// Setup two connected peers.
 ///
 /// Rate limits configuration:
-/// - `SyncRoutingTable`, `PartialEncodedChunkRequest`: bucket_start = 5, bucket_max = 10, refill_rate = 2.5/s
+/// - `BlockRequest`, `PartialEncodedChunkRequest`: bucket_start = 5, bucket_max = 10, refill_rate = 2.5/s
 /// - `Transaction`: bucket_start = bucket_max = 50, refill_rate = 5/s
-async fn setup_test_peers(mut rng: &mut Rng) -> (PeerHandle, PeerHandle) {
-    let mut clock = FakeClock::default();
+async fn setup_test_peers(clock: &mut FakeClock, mut rng: &mut Rng) -> (PeerHandle, PeerHandle) {
+    let chain = Arc::new(data::Chain::make(clock, &mut rng, 12));
 
-    let chain = Arc::new(data::Chain::make(&mut clock, &mut rng, 12));
+    // Customize the network configuration to set some arbitrary rate limits.
+    let add_rate_limits = |mut network_config: NetworkConfig| {
+        let rate_limits = &mut network_config.received_messages_rate_limits.rate_limits;
+        use messages_limits::RateLimitedPeerMessageKey::*;
+        rate_limits.push(messages_limits::SingleMessageConfig::new(BlockRequest, 10, 2.5, Some(5)));
+        rate_limits.push(messages_limits::SingleMessageConfig::new(
+            PartialEncodedChunkRequest,
+            10,
+            2.5,
+            Some(5),
+        ));
+        rate_limits.push(messages_limits::SingleMessageConfig::new(Transaction, 50, 5.0, None));
+        network_config
+    };
 
-    // TODO(trisfald): change config and set rate limit for SyncRoutingTable and PartialEncodedChunkRequest
-    // but no limit for Transaction.
     let inbound_cfg = PeerConfig {
         chain: chain.clone(),
-        network: chain.make_config(&mut rng),
+        network: add_rate_limits(chain.make_config(&mut rng)),
         force_encoding: Some(Encoding::Proto),
     };
     let outbound_cfg = PeerConfig {
         chain: chain.clone(),
-        network: chain.make_config(&mut rng),
+        network: add_rate_limits(chain.make_config(&mut rng)),
         force_encoding: Some(Encoding::Proto),
     };
     let (outbound_stream, inbound_stream) =
@@ -148,25 +156,24 @@ async fn setup_test_peers(mut rng: &mut Rng) -> (PeerHandle, PeerHandle) {
     (outbound, inbound)
 }
 
-/// Sends samplea of various messages:
-/// - `SyncRoutingTable`
+/// Sends samples of various messages:
+/// - `BlockRequest`
 /// - `PartialEncodedChunkRequest`
 /// - `Transaction`
 ///
-/// Messages are sent `count` times each. An `offset` is needed to make routed messages unique.
+/// Messages are sent `count` times each.
 ///
 /// Returns a vector with an example of one of each message above (useful for comparisons.)
 async fn send_messages(
     inbound: &PeerHandle,
     outbound: &PeerHandle,
     rng: &mut Rng,
-    offset: u32,
     count: u32,
 ) -> Vec<PeerMessage> {
     let mut messages_samples = Vec::new();
 
-    tracing::info!(target:"test","send SyncRoutingTable");
-    let message = PeerMessage::SyncRoutingTable(data::make_routing_table(rng));
+    tracing::info!(target:"test","send BlockRequest");
+    let message = PeerMessage::BlockRequest(CryptoHash::default());
     for _ in 0..count {
         outbound.send(message.clone()).await;
     }
@@ -174,11 +181,12 @@ async fn send_messages(
 
     tracing::info!(target:"test","send PartialEncodedChunkRequest");
     // Duplicated routed messages are filtered out so we must tweak each message to make it unique.
+
     for i in 0..count {
         let message = PeerMessage::Routed(Box::new(outbound.routed_message(
             RoutedMessageBody::PartialEncodedChunkRequest(PartialEncodedChunkRequestMsg {
                 chunk_hash: outbound.cfg.chain.blocks[5].chunks()[2].chunk_hash(),
-                part_ords: vec![(i + offset).into()],
+                part_ords: vec![rng.gen()],
                 tracking_shards: Default::default(),
             }),
             inbound.cfg.id(),

--- a/chain/network/src/peer/tests/rate_limits.rs
+++ b/chain/network/src/peer/tests/rate_limits.rs
@@ -1,0 +1,202 @@
+use crate::broadcast::Receiver;
+use crate::network_protocol::{testonly as data, PartialEncodedChunkRequestMsg, RoutedMessageBody};
+use crate::network_protocol::{Encoding, PeerMessage};
+use crate::peer::testonly::{Event, PeerConfig, PeerHandle};
+use crate::peer_manager::peer_manager_actor::Event as PME;
+use crate::tcp;
+use crate::testonly::{make_rng, Rng};
+use near_async::time::FakeClock;
+use near_o11y::testonly::init_test_logger;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::{sleep_until, Instant};
+
+#[tokio::test]
+// Verifies that peer traffic is rate limited per message type. Not all messages are rate limited.
+// This test works by sending many messages very quickly and then check how many of them
+// were effectively processed by the receiver.
+async fn test_message_rate_limits() -> anyhow::Result<()> {
+    init_test_logger();
+    tracing::info!("test_message_rate_limits");
+
+    let mut rng = make_rng(89028037453);
+    let (outbound, inbound) = setup_test_peers(&mut rng).await;
+
+    const MESSAGES: u32 = 7;
+    // Let's gather all events received from now on. We'll check them later, after producing messages.
+    let mut events = inbound.events.from_now();
+    let messages_samples = send_messages(&inbound, &outbound, &mut rng, 0, MESSAGES).await;
+
+    // Check how many messages of each type have been received.
+    let messages_received =
+        wait_for_messages(&messages_samples, &mut events, Duration::from_secs(3)).await;
+    tracing::debug!(target:"test","received {messages_received:?} messages");
+    // SyncRoutingTable gets rate limited (7 sent vs 5 bucket_start).
+    assert!(messages_received[0] < MESSAGES);
+    // PartialEncodedChunkRequest gets rate limited (7 sent vs 5 bucket_start).
+    assert!(messages_received[1] < MESSAGES);
+    // Transaction doesn't get rate limited (7 sent vs 50 bucket_start).
+    assert_eq!(messages_received[2], MESSAGES);
+
+    Ok(())
+}
+
+#[tokio::test]
+// Verifies that peer traffic is not rate limited when messages are sent at regular intevals,
+// and the total number of messages is below the limit.
+async fn test_message_rate_limits_over_time() -> anyhow::Result<()> {
+    init_test_logger();
+    tracing::info!("test_message_rate_limits_over_time");
+
+    let mut rng = make_rng(89028037453);
+    let (outbound, inbound) = setup_test_peers(&mut rng).await;
+
+    const SEED: u64 = 89028037453;
+    const MESSAGES: u32 = 4;
+    const INTERVAL: Duration = Duration::from_secs(2);
+    // Let's gather all events received from now on. We'll check them later, after producing messages.
+    let mut events = inbound.events.from_now();
+
+    // Send 4 messages of each type every 2 seconds, three times.
+    let mut messages_samples = Vec::new();
+    let now = Instant::now();
+    for i in 0..3 {
+        let mut rng = make_rng(SEED);
+        messages_samples =
+            send_messages(&inbound, &outbound, &mut rng, MESSAGES * i, MESSAGES).await;
+        sleep_until(now + INTERVAL * (i + 1)).await;
+    }
+
+    let messages_received =
+        wait_for_messages(&messages_samples, &mut events, Duration::from_secs(3)).await;
+    tracing::debug!(target:"test","received {messages_received:?} messages");
+    // SyncRoutingTable and PartialEncodedChunkRequest doesn't get rate limited
+    // 12 sent vs 5 bucket_start + 2.5 refilled * 4s
+    assert_eq!(messages_received[0], MESSAGES * 3);
+    assert_eq!(messages_received[1], MESSAGES * 3);
+    // Transaction doesn't get rate limited (12 sent vs 50 bucket_start).
+    assert_eq!(messages_received[2], MESSAGES * 3);
+
+    Ok(())
+}
+
+/// Waits up to `duration` and then checks how many events equal to each one of `samples` have been received.
+/// Returns a vector of the same size of `samples`.
+async fn wait_for_messages(
+    samples: &[PeerMessage],
+    events: &mut Receiver<Event>,
+    duration: Duration,
+) -> Vec<u32> {
+    let mut messages_received = vec![0; 3];
+    sleep_until(Instant::now() + duration).await;
+    while let Some(event) = events.try_recv() {
+        match event {
+            // Routed messages aren't exactly the same, just look at the type.
+            Event::Network(PME::MessageProcessed(_, got))
+                if matches!(got, PeerMessage::Routed(_)) =>
+            {
+                for (i, sample) in samples.iter().enumerate() {
+                    if sample.msg_variant() == got.msg_variant() {
+                        messages_received[i] += 1;
+                    }
+                }
+            }
+            // For all other message check equality.
+            Event::Network(PME::MessageProcessed(_, got)) => {
+                for (i, sample) in samples.iter().enumerate() {
+                    if *sample == got {
+                        messages_received[i] += 1;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    messages_received
+}
+
+/// Setup two connected peers.
+///
+/// Rate limits configuration:
+/// - `SyncRoutingTable`, `PartialEncodedChunkRequest`: bucket_start = 5, bucket_max = 10, refill_rate = 2.5/s
+/// - `Transaction`: bucket_start = bucket_max = 50, refill_rate = 5/s
+async fn setup_test_peers(mut rng: &mut Rng) -> (PeerHandle, PeerHandle) {
+    let mut clock = FakeClock::default();
+
+    let chain = Arc::new(data::Chain::make(&mut clock, &mut rng, 12));
+
+    // TODO(trisfald): change config and set rate limit for SyncRoutingTable and PartialEncodedChunkRequest
+    // but no limit for Transaction.
+    let inbound_cfg = PeerConfig {
+        chain: chain.clone(),
+        network: chain.make_config(&mut rng),
+        force_encoding: Some(Encoding::Proto),
+    };
+    let outbound_cfg = PeerConfig {
+        chain: chain.clone(),
+        network: chain.make_config(&mut rng),
+        force_encoding: Some(Encoding::Proto),
+    };
+    let (outbound_stream, inbound_stream) =
+        tcp::Stream::loopback(inbound_cfg.id(), tcp::Tier::T2).await;
+    let mut inbound = PeerHandle::start_endpoint(clock.clock(), inbound_cfg, inbound_stream).await;
+    let mut outbound =
+        PeerHandle::start_endpoint(clock.clock(), outbound_cfg, outbound_stream).await;
+
+    outbound.complete_handshake().await;
+    inbound.complete_handshake().await;
+    (outbound, inbound)
+}
+
+/// Sends samplea of various messages:
+/// - `SyncRoutingTable`
+/// - `PartialEncodedChunkRequest`
+/// - `Transaction`
+///
+/// Messages are sent `count` times each. An `offset` is needed to make routed messages unique.
+///
+/// Returns a vector with an example of one of each message above (useful for comparisons.)
+async fn send_messages(
+    inbound: &PeerHandle,
+    outbound: &PeerHandle,
+    rng: &mut Rng,
+    offset: u32,
+    count: u32,
+) -> Vec<PeerMessage> {
+    let mut messages_samples = Vec::new();
+
+    tracing::info!(target:"test","send SyncRoutingTable");
+    let message = PeerMessage::SyncRoutingTable(data::make_routing_table(rng));
+    for _ in 0..count {
+        outbound.send(message.clone()).await;
+    }
+    messages_samples.push(message);
+
+    tracing::info!(target:"test","send PartialEncodedChunkRequest");
+    // Duplicated routed messages are filtered out so we must tweak each message to make it unique.
+    for i in 0..count {
+        let message = PeerMessage::Routed(Box::new(outbound.routed_message(
+            RoutedMessageBody::PartialEncodedChunkRequest(PartialEncodedChunkRequestMsg {
+                chunk_hash: outbound.cfg.chain.blocks[5].chunks()[2].chunk_hash(),
+                part_ords: vec![(i + offset).into()],
+                tracking_shards: Default::default(),
+            }),
+            inbound.cfg.id(),
+            1,
+            None,
+        )));
+        outbound.send(message.clone()).await;
+        if i == count - 1 {
+            messages_samples.push(message);
+        }
+    }
+
+    tracing::info!(target:"test","send Transaction");
+    let message = PeerMessage::Transaction(data::make_signed_transaction(rng));
+    for _ in 0..count {
+        outbound.send(message.clone()).await;
+    }
+    messages_samples.push(message);
+
+    messages_samples
+}

--- a/chain/network/src/peer/tests/rate_limits.rs
+++ b/chain/network/src/peer/tests/rate_limits.rs
@@ -124,14 +124,13 @@ async fn setup_test_peers(clock: &mut FakeClock, mut rng: &mut Rng) -> (PeerHand
     let add_rate_limits = |mut network_config: NetworkConfig| {
         let rate_limits = &mut network_config.received_messages_rate_limits.rate_limits;
         use messages_limits::RateLimitedPeerMessageKey::*;
-        rate_limits.push(messages_limits::SingleMessageConfig::new(BlockRequest, 10, 2.5, Some(5)));
-        rate_limits.push(messages_limits::SingleMessageConfig::new(
+        rate_limits
+            .insert(BlockRequest, messages_limits::SingleMessageConfig::new(10, 2.5, Some(5)));
+        rate_limits.insert(
             PartialEncodedChunkRequest,
-            10,
-            2.5,
-            Some(5),
-        ));
-        rate_limits.push(messages_limits::SingleMessageConfig::new(Transaction, 50, 5.0, None));
+            messages_limits::SingleMessageConfig::new(10, 2.5, Some(5)),
+        );
+        rate_limits.insert(Transaction, messages_limits::SingleMessageConfig::new(50, 5.0, None));
         network_config
     };
 

--- a/chain/network/src/rate_limits/messages_limits.rs
+++ b/chain/network/src/rate_limits/messages_limits.rs
@@ -1,0 +1,349 @@
+//! This module facilitates the initialization and the storage
+//! of rate limits per message.
+
+use enum_map::{enum_map, EnumMap};
+use near_async::time::Duration;
+
+use crate::network_protocol::{PeerMessage, RoutedMessageBody};
+
+use super::token_bucket::{TokenBucket, TokenBucketError};
+
+/// Object responsible to manage the rate limits of all network messages
+/// for a single connection/peer.
+#[derive(Default)]
+pub struct RateLimits {
+    buckets: EnumMap<RateLimitedPeerMessageKey, Option<TokenBucket>>,
+}
+
+impl RateLimits {
+    pub fn from_config(config: &Config) -> Self {
+        let mut buckets = enum_map! { _ => None };
+        // Configuration is assumed to be correct. Any failure to build a bucket is ignored.
+        for message_config in &config.rate_limits {
+            let key = message_config.message_key;
+            let initial_size = message_config.initial_size.unwrap_or(message_config.maximum_size);
+            match TokenBucket::new(
+                initial_size,
+                message_config.maximum_size,
+                message_config.refill_rate,
+            ) {
+                Ok(bucket) => buckets[key] = Some(bucket),
+                Err(err) => {
+                    tracing::warn!(target: "network", "ignoring rate limit for {key} due to an error ({err})")
+                }
+            }
+        }
+        Self { buckets }
+    }
+
+    /// Checks if the given message is under the rate limits.
+    ///
+    /// Returns `true` if the message should be allowed to continue. Otherwise,
+    /// if it should be rate limited, returns `false`.
+    pub fn is_allowed(&self, message: &PeerMessage) -> bool {
+        if let Some((key, cost)) = get_key_and_token_cost(message) {
+            if let Some(bucket) = &self.buckets[key] {
+                return bucket.acquire(cost);
+            }
+        }
+        true
+    }
+
+    /// Updates all rate limits according to their own refresh rate, using `duration` as
+    /// the time elapsed since the previous update.
+    pub fn update(&self, duration: Duration) {
+        for (_, maybe_bucket) in &self.buckets {
+            maybe_bucket.as_ref().map(|bucket| bucket.refill(duration));
+        }
+    }
+}
+
+/// Rate limit configuration for a single network message.
+#[derive(Clone)]
+struct SingleMessageConfig {
+    message_key: RateLimitedPeerMessageKey,
+    maximum_size: u32,
+    refill_rate: f32,
+    /// Optional initial size. Defaults to `maximum_size` if absent.
+    initial_size: Option<u32>,
+}
+
+/// Network messages rate limits configuration.
+#[derive(Default, Clone)]
+pub struct Config {
+    rate_limits: Vec<SingleMessageConfig>,
+}
+
+impl Config {
+    /// Validates this configuration object.
+    ///
+    /// # Errors
+    ///
+    /// If at least one error is present, returns the list of all configuration errors.  
+    pub fn validate(&self) -> Result<(), Vec<(RateLimitedPeerMessageKey, TokenBucketError)>> {
+        let mut errors = Vec::new();
+        for message_config in &self.rate_limits {
+            if let Err(err) = TokenBucket::validate_refill_rate(message_config.refill_rate) {
+                errors.push((message_config.message_key, err));
+            }
+        }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+}
+
+/// This enum represents the variants of [PeerMessage] that can be rate limited.
+/// It is meant to be used as an index for mapping peer messages to a value.
+#[derive(Clone, Copy, enum_map::Enum, strum::Display, Debug, PartialEq, Eq)]
+#[allow(clippy::large_enum_variant)]
+pub enum RateLimitedPeerMessageKey {
+    SyncRoutingTable,
+    DistanceVector,
+    RequestUpdateNonce,
+    SyncAccountsData,
+    PeersRequest,
+    PeersResponse,
+    BlockHeadersRequest,
+    BlockHeaders,
+    BlockRequest,
+    Block,
+    Transaction,
+    SyncSnapshotHosts,
+    StateRequestHeader,
+    StateRequestPart,
+    VersionedStateResponse,
+    BlockApproval,
+    ForwardTx,
+    TxStatusRequest,
+    TxStatusResponse,
+    StateResponse,
+    PartialEncodedChunkRequest,
+    PartialEncodedChunkResponse,
+    VersionedPartialEncodedChunk,
+    PartialEncodedChunkForward,
+    ChunkEndorsement,
+    ChunkStateWitnessAck,
+    PartialEncodedStateWitness,
+    PartialEncodedStateWitnessForward,
+}
+
+/// Given a `PeerMessage` returns a tuple containing the `RateLimitedPeerMessageKey`
+/// corresponding to the message's type and its the cost (in tokens) for rate limiting
+/// purposes.
+///
+/// Returns `Some` if the message has the potential to be rate limited (through the correct configuration).
+/// Returns `None` if the message is not meant to be rate limited in any scenario.
+fn get_key_and_token_cost(message: &PeerMessage) -> Option<(RateLimitedPeerMessageKey, u32)> {
+    use RateLimitedPeerMessageKey::*;
+    match message {
+        PeerMessage::SyncRoutingTable(_) => Some((SyncRoutingTable, 1)),
+        PeerMessage::DistanceVector(_) => Some((DistanceVector, 1)),
+        PeerMessage::RequestUpdateNonce(_) => Some((RequestUpdateNonce, 1)),
+        PeerMessage::SyncAccountsData(_) => Some((SyncAccountsData, 1)),
+        PeerMessage::PeersRequest(_) => Some((PeersRequest, 1)),
+        PeerMessage::PeersResponse(_) => Some((PeersResponse, 1)),
+        PeerMessage::BlockHeadersRequest(_) => Some((BlockHeadersRequest, 1)),
+        PeerMessage::BlockHeaders(_) => Some((BlockHeaders, 1)),
+        PeerMessage::BlockRequest(_) => Some((BlockRequest, 1)),
+        PeerMessage::Block(_) => Some((Block, 1)),
+        PeerMessage::Transaction(_) => Some((Transaction, 1)),
+        PeerMessage::Routed(msg) => match msg.body {
+            RoutedMessageBody::BlockApproval(_) => Some((BlockApproval, 1)),
+            RoutedMessageBody::ForwardTx(_) => Some((ForwardTx, 1)),
+            RoutedMessageBody::TxStatusRequest(_, _) => Some((TxStatusRequest, 1)),
+            RoutedMessageBody::TxStatusResponse(_) => Some((TxStatusResponse, 1)),
+            RoutedMessageBody::StateResponse(_) => Some((StateResponse, 1)),
+            RoutedMessageBody::PartialEncodedChunkRequest(_) => {
+                Some((PartialEncodedChunkRequest, 1))
+            }
+            RoutedMessageBody::PartialEncodedChunkResponse(_) => {
+                Some((PartialEncodedChunkResponse, 1))
+            }
+            RoutedMessageBody::VersionedPartialEncodedChunk(_) => {
+                Some((VersionedPartialEncodedChunk, 1))
+            }
+            RoutedMessageBody::PartialEncodedChunkForward(_) => {
+                Some((PartialEncodedChunkForward, 1))
+            }
+            RoutedMessageBody::ChunkEndorsement(_) => Some((ChunkEndorsement, 1)),
+            RoutedMessageBody::ChunkStateWitnessAck(_) => Some((ChunkStateWitnessAck, 1)),
+            RoutedMessageBody::PartialEncodedStateWitness(_) => {
+                Some((PartialEncodedStateWitness, 1))
+            }
+            RoutedMessageBody::PartialEncodedStateWitnessForward(_) => {
+                Some((PartialEncodedStateWitnessForward, 1))
+            }
+            RoutedMessageBody::Ping(_)
+            | RoutedMessageBody::Pong(_)
+            | RoutedMessageBody::_UnusedChunkStateWitness
+            | RoutedMessageBody::_UnusedVersionedStateResponse
+            | RoutedMessageBody::_UnusedPartialEncodedChunk
+            | RoutedMessageBody::_UnusedQueryRequest
+            | RoutedMessageBody::_UnusedQueryResponse
+            | RoutedMessageBody::_UnusedReceiptOutcomeRequest(_)
+            | RoutedMessageBody::_UnusedReceiptOutcomeResponse
+            | RoutedMessageBody::_UnusedStateRequestHeader
+            | RoutedMessageBody::_UnusedStateRequestPart => None,
+        },
+        PeerMessage::SyncSnapshotHosts(_) => Some((SyncSnapshotHosts, 1)),
+        PeerMessage::StateRequestHeader(_, _) => Some((StateRequestHeader, 1)),
+        PeerMessage::StateRequestPart(_, _, _) => Some((StateRequestPart, 1)),
+        PeerMessage::VersionedStateResponse(_) => Some((VersionedStateResponse, 1)),
+        PeerMessage::Tier1Handshake(_)
+        | PeerMessage::Tier2Handshake(_)
+        | PeerMessage::HandshakeFailure(_, _)
+        | PeerMessage::LastEdge(_)
+        | PeerMessage::Disconnect(_)
+        | PeerMessage::Challenge(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use near_primitives::hash::CryptoHash;
+
+    use crate::network_protocol::{Disconnect, PeerMessage};
+
+    use super::*;
+
+    #[test]
+    fn is_allowed() {
+        let disconnect =
+            PeerMessage::Disconnect(Disconnect { remove_from_connection_store: false });
+        let block_request = PeerMessage::BlockRequest(CryptoHash::default());
+
+        // Test message that can't be rate limited.
+        {
+            let limits = RateLimits::default();
+            assert!(limits.is_allowed(&disconnect));
+        }
+
+        // Test message that might be rate limited, but the system is not configured to do so.
+        {
+            let limits = RateLimits::default();
+            assert!(limits.is_allowed(&block_request));
+        }
+
+        // Test rate limited message with enough tokens.
+        {
+            let mut limits = RateLimits::default();
+            limits.buckets[RateLimitedPeerMessageKey::BlockRequest] =
+                Some(TokenBucket::new(1, 1, 0.0).unwrap());
+            assert!(limits.is_allowed(&block_request));
+        }
+
+        // Test rate limited message without enough tokens.
+        {
+            let mut limits = RateLimits::default();
+            limits.buckets[RateLimitedPeerMessageKey::BlockRequest] =
+                Some(TokenBucket::new(0, 1, 0.0).unwrap());
+            assert!(!limits.is_allowed(&block_request));
+        }
+    }
+
+    #[test]
+    fn configuration() {
+        use RateLimitedPeerMessageKey::*;
+        let mut config = Config::default();
+
+        config.rate_limits.push(SingleMessageConfig {
+            message_key: Block,
+            maximum_size: 5,
+            refill_rate: 1.0,
+            initial_size: Some(1),
+        });
+        config.rate_limits.push(SingleMessageConfig {
+            message_key: BlockApproval,
+            maximum_size: 5,
+            refill_rate: 1.0,
+            initial_size: None,
+        });
+        config.rate_limits.push(SingleMessageConfig {
+            message_key: BlockHeaders,
+            maximum_size: 1,
+            refill_rate: -4.0,
+            initial_size: None,
+        });
+
+        let limits = RateLimits::from_config(&config);
+
+        // Bucket should exist with capacity = 1.
+        assert!(!limits.buckets[Block].as_ref().unwrap().acquire(2));
+        // Bucket should exist with capacity = 5.
+        assert!(limits.buckets[BlockApproval].as_ref().unwrap().acquire(2));
+        // Bucket should not exist due to a config error.
+        assert!(limits.buckets[BlockHeaders].is_none());
+    }
+
+    #[test]
+    fn configuration_errors() {
+        use RateLimitedPeerMessageKey::*;
+        let mut config = Config::default();
+        assert!(config.validate().is_ok());
+
+        config.rate_limits.push(SingleMessageConfig {
+            message_key: Block,
+            maximum_size: 0,
+            refill_rate: 1.0,
+            initial_size: None,
+        });
+        assert!(config.validate().is_ok());
+
+        config.rate_limits.push(SingleMessageConfig {
+            message_key: BlockApproval,
+            maximum_size: 0,
+            refill_rate: -1.0,
+            initial_size: None,
+        });
+        assert_eq!(
+            config.validate(),
+            Err(vec![(BlockApproval, TokenBucketError::InvalidRefillRate(-1.0))])
+        );
+
+        config.rate_limits.push(SingleMessageConfig {
+            message_key: BlockHeaders,
+            maximum_size: 0,
+            refill_rate: -2.0,
+            initial_size: None,
+        });
+        assert_eq!(
+            config.validate(),
+            Err(vec![
+                (BlockApproval, TokenBucketError::InvalidRefillRate(-1.0)),
+                (BlockHeaders, TokenBucketError::InvalidRefillRate(-2.0))
+            ])
+        );
+    }
+
+    #[test]
+    fn update() {
+        use RateLimitedPeerMessageKey::*;
+        let mut config = Config::default();
+
+        config.rate_limits.push(SingleMessageConfig {
+            message_key: Block,
+            maximum_size: 5,
+            refill_rate: 1.0,
+            initial_size: Some(0),
+        });
+        config.rate_limits.push(SingleMessageConfig {
+            message_key: BlockApproval,
+            maximum_size: 5,
+            refill_rate: 1.0,
+            initial_size: Some(0),
+        });
+
+        let limits = RateLimits::from_config(&config);
+
+        assert!(!limits.buckets[Block].as_ref().unwrap().acquire(1));
+        assert!(!limits.buckets[BlockApproval].as_ref().unwrap().acquire(1));
+
+        limits.update(Duration::seconds(1));
+
+        assert!(limits.buckets[Block].as_ref().unwrap().acquire(1));
+        assert!(limits.buckets[BlockApproval].as_ref().unwrap().acquire(1));
+    }
+}

--- a/chain/network/src/rate_limits/messages_limits.rs
+++ b/chain/network/src/rate_limits/messages_limits.rs
@@ -272,6 +272,8 @@ mod tests {
         assert!(limits.buckets[BlockApproval].as_ref().unwrap().acquire(2));
         // Bucket should not exist due to a config error.
         assert!(limits.buckets[BlockHeaders].is_none());
+        // Buckets are not instantiated for message types not present in the config.
+        assert!(limits.buckets[RequestUpdateNonce].is_none());
     }
 
     #[test]

--- a/chain/network/src/rate_limits/messages_limits.rs
+++ b/chain/network/src/rate_limits/messages_limits.rs
@@ -60,18 +60,29 @@ impl RateLimits {
 
 /// Rate limit configuration for a single network message.
 #[derive(Clone)]
-struct SingleMessageConfig {
-    message_key: RateLimitedPeerMessageKey,
-    maximum_size: u32,
-    refill_rate: f32,
+pub struct SingleMessageConfig {
+    pub message_key: RateLimitedPeerMessageKey,
+    pub maximum_size: u32,
+    pub refill_rate: f32,
     /// Optional initial size. Defaults to `maximum_size` if absent.
-    initial_size: Option<u32>,
+    pub initial_size: Option<u32>,
+}
+
+impl SingleMessageConfig {
+    pub fn new(
+        message_key: RateLimitedPeerMessageKey,
+        maximum_size: u32,
+        refill_rate: f32,
+        initial_size: Option<u32>,
+    ) -> Self {
+        Self { message_key, maximum_size, refill_rate, initial_size }
+    }
 }
 
 /// Network messages rate limits configuration.
 #[derive(Default, Clone)]
 pub struct Config {
-    rate_limits: Vec<SingleMessageConfig>,
+    pub rate_limits: Vec<SingleMessageConfig>,
 }
 
 impl Config {
@@ -249,24 +260,9 @@ mod tests {
         use RateLimitedPeerMessageKey::*;
         let mut config = Config::default();
 
-        config.rate_limits.push(SingleMessageConfig {
-            message_key: Block,
-            maximum_size: 5,
-            refill_rate: 1.0,
-            initial_size: Some(1),
-        });
-        config.rate_limits.push(SingleMessageConfig {
-            message_key: BlockApproval,
-            maximum_size: 5,
-            refill_rate: 1.0,
-            initial_size: None,
-        });
-        config.rate_limits.push(SingleMessageConfig {
-            message_key: BlockHeaders,
-            maximum_size: 1,
-            refill_rate: -4.0,
-            initial_size: None,
-        });
+        config.rate_limits.push(SingleMessageConfig::new(Block, 5, 1.0, Some(1)));
+        config.rate_limits.push(SingleMessageConfig::new(BlockApproval, 5, 1.0, None));
+        config.rate_limits.push(SingleMessageConfig::new(BlockHeaders, 1, -4.0, None));
 
         let limits = RateLimits::from_config(&config);
 
@@ -284,31 +280,16 @@ mod tests {
         let mut config = Config::default();
         assert!(config.validate().is_ok());
 
-        config.rate_limits.push(SingleMessageConfig {
-            message_key: Block,
-            maximum_size: 0,
-            refill_rate: 1.0,
-            initial_size: None,
-        });
+        config.rate_limits.push(SingleMessageConfig::new(Block, 0, 1.0, None));
         assert!(config.validate().is_ok());
 
-        config.rate_limits.push(SingleMessageConfig {
-            message_key: BlockApproval,
-            maximum_size: 0,
-            refill_rate: -1.0,
-            initial_size: None,
-        });
+        config.rate_limits.push(SingleMessageConfig::new(BlockApproval, 0, -1.0, None));
         assert_eq!(
             config.validate(),
             Err(vec![(BlockApproval, TokenBucketError::InvalidRefillRate(-1.0))])
         );
 
-        config.rate_limits.push(SingleMessageConfig {
-            message_key: BlockHeaders,
-            maximum_size: 0,
-            refill_rate: -2.0,
-            initial_size: None,
-        });
+        config.rate_limits.push(SingleMessageConfig::new(BlockHeaders, 0, -2.0, None));
         assert_eq!(
             config.validate(),
             Err(vec![
@@ -323,18 +304,8 @@ mod tests {
         use RateLimitedPeerMessageKey::*;
         let mut config = Config::default();
 
-        config.rate_limits.push(SingleMessageConfig {
-            message_key: Block,
-            maximum_size: 5,
-            refill_rate: 1.0,
-            initial_size: Some(0),
-        });
-        config.rate_limits.push(SingleMessageConfig {
-            message_key: BlockApproval,
-            maximum_size: 5,
-            refill_rate: 1.0,
-            initial_size: Some(0),
-        });
+        config.rate_limits.push(SingleMessageConfig::new(Block, 5, 1.0, Some(0)));
+        config.rate_limits.push(SingleMessageConfig::new(BlockApproval, 5, 1.0, Some(0)));
 
         let limits = RateLimits::from_config(&config);
 

--- a/chain/network/src/rate_limits/mod.rs
+++ b/chain/network/src/rate_limits/mod.rs
@@ -1,1 +1,2 @@
-mod token_bucket;
+pub mod messages_limits;
+pub mod token_bucket;

--- a/chain/network/src/rate_limits/mod.rs
+++ b/chain/network/src/rate_limits/mod.rs
@@ -1,0 +1,1 @@
+mod token_bucket;

--- a/chain/network/src/rate_limits/token_bucket.rs
+++ b/chain/network/src/rate_limits/token_bucket.rs
@@ -10,9 +10,7 @@
 //! or delayed. However, this module responsibility stops at telling
 //! whether or not the incoming messages are allowed.
 
-use std::sync::atomic::{AtomicU64, Ordering};
-
-use near_async::time::Duration;
+use near_async::time::Instant;
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum TokenBucketError {
@@ -23,17 +21,20 @@ pub enum TokenBucketError {
 /// Into how many parts a token can be divided.
 const TOKEN_PARTS_NUMBER: u64 = 1 << 31;
 
-/// Struct to hold the state for the token bucket algorithm. Thread-safe.
+/// Struct to hold the state for the token bucket algorithm.
 ///
 /// The precision guarantee is, at least, such that a bucket having `refill_rate` = 0.001s
 /// update at regular intervals every 10ms will successfully generate a token after 1000±1s.
 pub struct TokenBucket {
+    /// Maximum number of tokens the bucket can hold.
     maximum_size: u32,
     /// Tokens in the bucket. They are stored as `tokens * TOKEN_PARTS_NUMBER`.
     /// In this way we can refill the bucket at shorter intervals.  
-    size: AtomicU64,
+    size: u64,
     /// Refill rate in token per second.
     refill_rate: f32,
+    /// Last time the bucket was refreshed.
+    last_refill: Option<Instant>,
 }
 
 impl TokenBucket {
@@ -44,6 +45,8 @@ impl TokenBucket {
     /// * `initial_size` - Initial amount of tokens in the bucket
     /// * `maximum_size` - Maximum amount of tokens the bucket can hold
     /// * `refill_rate` - Bucket refill rate in token per second
+    /// * `start_time` - Point in time used as a start to calculate the bucket refill.
+    /// Set it to `None` to start counting the first time [TokenBucket::acquire] is called.
     ///
     /// # Errors
     ///
@@ -52,50 +55,62 @@ impl TokenBucket {
         initial_size: u32,
         maximum_size: u32,
         refill_rate: f32,
+        start_time: Option<Instant>,
     ) -> Result<Self, TokenBucketError> {
         let size = to_tokens_with_parts(maximum_size.min(initial_size));
-        let size = AtomicU64::new(size);
         TokenBucket::validate_refill_rate(refill_rate)?;
-        Ok(Self { maximum_size, size, refill_rate })
+        Ok(Self { maximum_size, size, refill_rate, last_refill: start_time })
     }
 
     /// Makes an attempt to acquire `token` tokens.
     ///
+    /// This method takes a parameter called `now` which should be equivalent to the current time.
+    /// The latter is used to refill the bucket before subtracting tokens.
+    ///
     /// If the tokens are available they are subtracted from the current `size` and
     /// the method returns `true`. Otherwise, `size` is not changed and the method
     /// returns `false`.
-    pub fn acquire(&self, tokens: u32) -> bool {
+    pub fn acquire(&mut self, tokens: u32, now: Instant) -> bool {
+        self.refill(now);
         let tokens = to_tokens_with_parts(tokens);
-        self.size
-            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |size| {
-                if size >= tokens {
-                    Some(size - tokens)
-                } else {
-                    None
-                }
-            })
-            .is_ok()
+        if self.size >= tokens {
+            self.size -= tokens;
+            true
+        } else {
+            false
+        }
     }
 
     /// Refills the bucket with the right number of tokens according to
-    /// the `refill_rate`, assuming an interval of time equal to `duration`
-    /// has passed. Negative durations are ignored.
+    /// the `refill_rate` and the new current time `now`.
     ///
-    /// For example: if `refill_rate` == 1 and `duration` == 1s then exactly 1 token
+    /// For example: if `refill_rate` == 1 and `now - last_refill` == 1s then exactly 1 token
     /// will be added.
-    pub fn refill(&self, duration: Duration) {
-        if duration.is_negative() || duration.is_zero() {
+    fn refill(&mut self, now: Instant) {
+        let last_refill = if let Some(val) = self.last_refill {
+            val
+        } else {
+            // Simply set `last_refill` if this's the first refill.
+            self.last_refill = Some(now);
+            return;
+        };
+        // Sanity check: now should be bigger than the last refill time.
+        if now <= last_refill {
             return;
         }
-        let tokens_to_add = duration.as_seconds_f64() * self.refill_rate as f64;
-        let tokens_to_add = tokens_to_add * TOKEN_PARTS_NUMBER as f64;
-        // Always returns `Some`.
-        let _ = self.size.fetch_update(Ordering::AcqRel, Ordering::Acquire, |size| {
-            let new_size = size
-                .saturating_add(tokens_to_add as u64)
+        // Compute how many tokens should be added to the current size.
+        let duration = now - last_refill;
+        let tokens_to_add = duration.as_secs_f64() * self.refill_rate as f64;
+        let tokens_to_add = (tokens_to_add * TOKEN_PARTS_NUMBER as f64) as u64;
+        // Update `last_refill` and `size` only if there's a change. This is done to prevent
+        // losing token parts to clamping if the duration is too small.
+        if tokens_to_add > 0 {
+            self.size = self
+                .size
+                .saturating_add(tokens_to_add)
                 .min(to_tokens_with_parts(self.maximum_size));
-            Some(new_size)
-        });
+            self.last_refill = Some(now);
+        }
     }
 
     /// Returns an error if the value provided is not in the correct range for
@@ -109,30 +124,19 @@ impl TokenBucket {
         }
         Ok(())
     }
-
-    #[cfg(test)]
-    fn size(&self) -> u64 {
-        self.size.load(Ordering::Acquire)
-    }
 }
 
 /// Transforms a value of `tokens` without a fractional part into a representation
 /// having a fractional part.
 fn to_tokens_with_parts(tokens: u32) -> u64 {
+    // Safe (check the test `token_fractional_representation_cant_overflow`).
     tokens as u64 * TOKEN_PARTS_NUMBER
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        sync::Arc,
-        thread::{self, sleep},
-    };
-
-    use near_async::time::Instant;
-    use pretty_assertions::assert_eq;
-
     use super::*;
+    use near_async::time::{Duration, Instant};
 
     #[test]
     fn token_fractional_representation_cant_overflow() {
@@ -141,172 +145,173 @@ mod tests {
 
     #[test]
     fn initial_more_than_max() {
-        let bucket = TokenBucket::new(5, 2, 1.0).expect("bucket should be well formed");
-        assert_eq!(bucket.size(), to_tokens_with_parts(2));
+        let bucket = TokenBucket::new(5, 2, 1.0, None).expect("bucket should be well formed");
+        assert_eq!(bucket.size, to_tokens_with_parts(2));
         assert_eq!(bucket.maximum_size, 2);
     }
 
     #[test]
     fn invalid_refill_rate() {
-        assert!(TokenBucket::new(2, 2, f32::NAN).is_err());
-        assert!(TokenBucket::new(2, 2, f32::INFINITY).is_err());
-        assert!(TokenBucket::new(2, 2, f32::NEG_INFINITY).is_err());
-        assert!(TokenBucket::new(2, 2, -1.0).is_err());
+        assert!(TokenBucket::new(2, 2, f32::NAN, None).is_err());
+        assert!(TokenBucket::new(2, 2, f32::INFINITY, None).is_err());
+        assert!(TokenBucket::new(2, 2, f32::NEG_INFINITY, None).is_err());
+        assert!(TokenBucket::new(2, 2, -1.0, None).is_err());
     }
 
     #[test]
     fn valid_refill_rate() {
-        assert!(TokenBucket::new(2, 2, 0.0).is_ok());
-        assert!(TokenBucket::new(2, 2, 0.3).is_ok());
+        assert!(TokenBucket::new(2, 2, 0.0, None).is_ok());
+        assert!(TokenBucket::new(2, 2, 0.3, None).is_ok());
     }
 
     #[test]
     fn acquire() {
-        let bucket = TokenBucket::new(5, 10, 1.0).expect("bucket should be well formed");
+        let mut bucket = TokenBucket::new(5, 10, 1.0, None).expect("bucket should be well formed");
+        let now = Instant::now();
 
-        assert!(bucket.acquire(0));
-        assert_eq!(bucket.size(), to_tokens_with_parts(5));
+        assert!(bucket.acquire(0, now));
+        assert_eq!(bucket.size, to_tokens_with_parts(5));
 
-        assert!(bucket.acquire(1));
-        assert_eq!(bucket.size(), to_tokens_with_parts(4));
+        assert!(bucket.acquire(1, now));
+        assert_eq!(bucket.size, to_tokens_with_parts(4));
 
-        assert!(!bucket.acquire(10));
-        assert_eq!(bucket.size(), to_tokens_with_parts(4));
+        assert!(!bucket.acquire(10, now));
+        assert_eq!(bucket.size, to_tokens_with_parts(4));
 
-        assert!(bucket.acquire(4));
-        assert_eq!(bucket.size(), to_tokens_with_parts(0));
+        assert!(bucket.acquire(4, now));
+        assert_eq!(bucket.size, to_tokens_with_parts(0));
 
-        assert!(!bucket.acquire(1));
-        assert_eq!(bucket.size(), to_tokens_with_parts(0));
+        assert!(!bucket.acquire(1, now));
+        assert_eq!(bucket.size, to_tokens_with_parts(0));
     }
 
     #[test]
     fn max_is_zero() {
-        let bucket = TokenBucket::new(0, 0, 0.0).expect("bucket should be well formed");
-        assert!(bucket.acquire(0));
-        assert!(!bucket.acquire(1));
+        let mut bucket = TokenBucket::new(0, 0, 0.0, None).expect("bucket should be well formed");
+        let now = Instant::now();
+        assert!(bucket.acquire(0, now));
+        assert!(!bucket.acquire(1, now));
     }
 
     #[test]
-    fn refill() {
-        let bucket = TokenBucket::new(0, 1000, 10.0).expect("bucket should be well formed");
-        bucket.refill(Duration::seconds(2));
-        assert_eq!(bucket.size(), to_tokens_with_parts(20));
-        bucket.refill(Duration::milliseconds(500));
-        assert_eq!(bucket.size(), to_tokens_with_parts(20 + 5));
+    fn buckets_get_refilled() {
+        let now = Instant::now();
+        let mut bucket =
+            TokenBucket::new(0, 1000, 10.0, Some(now)).expect("bucket should be well formed");
+        assert!(!bucket.acquire(1, now));
+        assert!(bucket.acquire(1, now + Duration::milliseconds(500)));
     }
 
     #[test]
-    fn refill_zero_rate() {
-        let bucket = TokenBucket::new(10, 10, 0.0).expect("bucket should be well formed");
-        assert!(bucket.acquire(10));
-        assert!(!bucket.acquire(1));
-        bucket.refill(Duration::seconds(100));
-        assert!(!bucket.acquire(1));
+    fn time_is_initialized_correctly() {
+        let now = Instant::now();
+
+        let mut bucket = TokenBucket::new(0, 5, 1.0, None).expect("bucket should be well formed");
+        assert!(bucket.last_refill.is_none());
+        let size = bucket.size;
+        bucket.refill(now);
+        assert_eq!(bucket.last_refill, Some(now));
+        assert_eq!(bucket.size, size);
+
+        let mut bucket =
+            TokenBucket::new(0, 5, 1.0, Some(now)).expect("bucket should be well formed");
+        assert!(bucket.last_refill.is_some());
+        assert!(bucket.acquire(1, now + Duration::seconds(1)));
     }
 
     #[test]
-    fn refill_non_positive_duration() {
-        let bucket = TokenBucket::new(10, 10, 1.0).expect("bucket should be well formed");
-        let size = bucket.size();
-        bucket.refill(Duration::seconds(0));
-        bucket.refill(Duration::seconds(-1));
-        assert_eq!(bucket.size(), size);
+    fn zero_refill_rate() {
+        let mut bucket = TokenBucket::new(10, 10, 0.0, None).expect("bucket should be well formed");
+        let now = Instant::now();
+        assert!(bucket.acquire(10, now));
+        assert!(!bucket.acquire(1, now));
+        assert!(!bucket.acquire(1, now + Duration::seconds(100)));
+    }
+
+    #[test]
+    fn refill_no_time_elapsed() {
+        let now = Instant::now();
+        let mut bucket =
+            TokenBucket::new(10, 10, 1.0, Some(now)).expect("bucket should be well formed");
+        let size = bucket.size;
+        bucket.refill(now);
+        assert_eq!(bucket.size, size);
+    }
+
+    #[test]
+    fn check_non_monotonic_clocks_safety() {
+        let now = Instant::now();
+        let mut bucket =
+            TokenBucket::new(10, 10, 1.0, Some(now)).expect("bucket should be well formed");
+        let size = bucket.size;
+        bucket.refill(now - Duration::seconds(100));
+        assert_eq!(bucket.size, size);
     }
 
     #[test]
     fn refill_partial_token() {
-        let bucket = TokenBucket::new(0, 5, 0.4).expect("bucket should be well formed");
-        assert!(!bucket.acquire(1));
-        bucket.refill(Duration::seconds(1));
-        assert!(!bucket.acquire(1));
-        bucket.refill(Duration::seconds(1));
-        assert!(!bucket.acquire(1));
-        bucket.refill(Duration::seconds(1));
-        assert!(bucket.acquire(1));
+        let now = Instant::now();
+        let mut bucket =
+            TokenBucket::new(0, 5, 0.4, Some(now)).expect("bucket should be well formed");
+        assert!(!bucket.acquire(1, now));
+        assert!(!bucket.acquire(1, now + Duration::seconds(1)));
+        assert!(!bucket.acquire(1, now + Duration::seconds(2)));
+        assert!(bucket.acquire(1, now + Duration::seconds(3)));
     }
 
     #[test]
     fn refill_overflow_bucket_max_size() {
-        let bucket = TokenBucket::new(2, 5, 1.0).expect("bucket should be well formed");
-        bucket.refill(Duration::seconds(2));
-        assert_eq!(bucket.size(), to_tokens_with_parts(4));
-        bucket.refill(Duration::seconds(2));
-        assert_eq!(bucket.size(), to_tokens_with_parts(5));
-        assert!(bucket.acquire(5));
-        bucket.refill(Duration::seconds(10));
-        assert_eq!(bucket.size(), to_tokens_with_parts(5));
+        let now = Instant::now();
+        let mut bucket =
+            TokenBucket::new(2, 5, 1.0, Some(now)).expect("bucket should be well formed");
+
+        bucket.refill(now + Duration::seconds(2));
+        assert_eq!(bucket.size, to_tokens_with_parts(4));
+
+        bucket.refill(now + Duration::seconds(4));
+        assert_eq!(bucket.size, to_tokens_with_parts(5));
+
+        assert!(bucket.acquire(5, now + Duration::seconds(4)));
+        assert_eq!(bucket.size, to_tokens_with_parts(0));
+
+        assert!(bucket.acquire(5, now + Duration::seconds(10)));
+        assert_eq!(bucket.size, to_tokens_with_parts(0));
     }
 
     #[test]
     fn check_with_numeric_limits() {
-        let bucket =
-            TokenBucket::new(u32::MAX, u32::MAX, 1000.0).expect("bucket should be well formed");
-        assert!(bucket.acquire(u32::MAX));
-        assert!(!bucket.acquire(1));
-        bucket.refill(Duration::seconds(i64::MAX));
-        assert!(bucket.acquire(u32::MAX));
-        assert!(!bucket.acquire(1));
+        let now = Instant::now();
+        let mut bucket = TokenBucket::new(u32::MAX, u32::MAX, 1_000_000.0, Some(now))
+            .expect("bucket should be well formed");
+
+        assert!(bucket.acquire(u32::MAX, now));
+        assert!(!bucket.acquire(1, now));
+
+        let now = now + Duration::days(100);
+        assert!(bucket.acquire(u32::MAX, now));
+        assert!(!bucket.acquire(1, now));
     }
 
     #[test]
     /// Validate if `TokenBucket` meets the requirement of being able to refresh tokens successfully
     /// when both the refill rate and the elapsed time are very low.
     fn validate_guaranteed_resolution() {
-        let bucket = TokenBucket::new(0, 10, 0.001).expect("bucket should be well formed");
+        let mut now = Instant::now();
+        let mut bucket =
+            TokenBucket::new(0, 10, 0.001, Some(now)).expect("bucket should be well formed");
         // Up to 999s: no new token added.
         for _ in 0..99_900 {
-            bucket.refill(Duration::milliseconds(10));
+            now += Duration::milliseconds(10);
+            assert!(!bucket.acquire(1, now));
         }
-        assert!(!bucket.acquire(1));
         // From 999s to 1001s: the new token should get added.
         let mut tokens_added = 0;
         for _ in 99_900..100_100 {
-            bucket.refill(Duration::milliseconds(10));
-            if bucket.acquire(1) {
+            now += Duration::milliseconds(10);
+            if bucket.acquire(1, now) {
                 tokens_added += 1;
             }
         }
         assert_eq!(tokens_added, 1);
-    }
-
-    #[test]
-    fn parallelism_happy_path() {
-        // Start two thread.
-        // Thread A refills tokens.
-        // Thread B consumes tokens.
-        // Thread B should successfully consume tokens as they get in.
-        let bucket = TokenBucket::new(0, 10000, 100.0).expect("bucket should be well formed");
-        let bucket = Arc::new(bucket);
-
-        let bucket_clone = bucket.clone();
-        let thread_a = thread::spawn(move || {
-            for _ in 0..10 {
-                // Sleep 10 times x 100ms => produce 100 tokens
-                const PERIOD: Duration = Duration::milliseconds(100);
-                sleep(PERIOD.try_into().unwrap());
-                bucket_clone.refill(PERIOD);
-            }
-        });
-
-        let thread_b = thread::spawn(move || {
-            // Must get 100 tokens.
-            let mut acquired = 0;
-            let shutdown_time = Instant::now() + Duration::seconds(3);
-            loop {
-                if bucket.acquire(1) {
-                    acquired += 1;
-                }
-                if acquired >= 100 || Instant::now() >= shutdown_time {
-                    break;
-                }
-                sleep(std::time::Duration::from_millis(1));
-            }
-            acquired
-        });
-
-        thread_a.join().unwrap();
-        let acquired = thread_b.join().unwrap();
-        assert_eq!(acquired, 100);
     }
 }

--- a/chain/network/src/rate_limits/token_bucket.rs
+++ b/chain/network/src/rate_limits/token_bucket.rs
@@ -1,0 +1,242 @@
+//! Implementation of the token bucket algorithm, used to put limits on
+//! bandwidth and burstiness of network traffic.
+//!
+//! The algorithm depicts an imaginary bucket into which tokens are added
+//! at regular intervals of time. The bucket has a well defined maximum size
+//! and overflowing tokens are simply discarded.
+//! Network traffic (packets, messages, etc) 'consume' a given amount of tokens
+//! in order to be allowed to pass.
+//! If there aren't enough tokens in the bucket, the traffic might be stopped
+//! or delayed. However, this module responsibility stops at telling
+//! whether or not the incoming messages are allowed.
+
+use near_async::time::Duration;
+
+#[derive(thiserror::Error, Debug, PartialEq)]
+pub(crate) enum TokenBucketError {
+    #[error("invalid value for refill rate ({0})")]
+    InvalidRefillRate(f32),
+}
+
+/// Into how many parts a token can be divided.
+const TOKEN_PARTS_NUMBER: u64 = 1 << 31;
+
+/// Struct to hold the state for the token bucket algorithm.
+///
+/// The precision guarantee is, at least, such that a bucket having `refill_rate` = 0.001s
+/// update at regular intervals every 10ms will successfully generate a token after 1000±1s.
+pub struct TokenBucket {
+    maximum_size: u32,
+    /// Tokens in the bucket. They are stored as `tokens * TOKEN_PARTS_NUMBER`.
+    /// In this way we can refill the bucket at shorter intervals.  
+    size: u64,
+    /// Refill rate in token per second.
+    refill_rate: f32,
+}
+
+impl TokenBucket {
+    /// Creates a new token bucket.
+    ///
+    /// # Arguments
+    ///
+    /// * `initial_size` - Initial amount of tokens in the bucket
+    /// * `maximum_size` - Maximum amount of tokens the bucket can hold
+    /// * `refill_rate` - Bucket refill rate in token per second
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any of the arguments has in invalid value.
+    pub fn new(
+        initial_size: u32,
+        maximum_size: u32,
+        refill_rate: f32,
+    ) -> Result<Self, TokenBucketError> {
+        let size = to_tokens_with_parts(maximum_size.min(initial_size));
+        if refill_rate < 0.0 {
+            return Err(TokenBucketError::InvalidRefillRate(refill_rate));
+        }
+        if !refill_rate.is_normal() && refill_rate != 0.0 {
+            return Err(TokenBucketError::InvalidRefillRate(refill_rate));
+        }
+        Ok(Self { maximum_size, size, refill_rate })
+    }
+
+    /// Makes an attempt to acquire `token` tokens.
+    ///
+    /// If the tokens are available they are subtracted from the current `size` and
+    /// the method returns `true`. Otherwise, `size` is not changed and the method
+    /// returns `false`.
+    pub fn acquire(&mut self, tokens: u32) -> bool {
+        let tokens = to_tokens_with_parts(tokens);
+        if self.size >= tokens {
+            self.size -= tokens;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Refills the bucket with the right number of tokens according to
+    /// the `refill_rate`, assuming an interval of time equal to `duration`
+    /// has passed. Negative durations are ignored.
+    ///
+    /// For example: if `refill_rate` == 1 and `duration` == 1s then exactly 1 token
+    /// will be added.
+    pub fn refill(&mut self, duration: Duration) {
+        if duration.is_negative() || duration.is_zero() {
+            return;
+        }
+        let tokens_to_add = duration.as_seconds_f64() * self.refill_rate as f64;
+        let tokens_to_add = tokens_to_add * TOKEN_PARTS_NUMBER as f64;
+        let new_size = self
+            .size
+            .saturating_add(tokens_to_add as u64)
+            .min(to_tokens_with_parts(self.maximum_size));
+        self.size = new_size;
+    }
+}
+
+/// Transforms a value of `tokens` without a fractional part into a representation
+/// having a fractional part.
+fn to_tokens_with_parts(tokens: u32) -> u64 {
+    tokens as u64 * TOKEN_PARTS_NUMBER
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_fractional_representation_cant_overflow() {
+        assert!(TOKEN_PARTS_NUMBER.saturating_mul(u32::MAX as u64) < u64::MAX);
+    }
+
+    #[test]
+    fn initial_more_than_max() {
+        let bucket = TokenBucket::new(5, 2, 1.0).expect("bucket should be well formed");
+        assert_eq!(bucket.size, to_tokens_with_parts(2));
+        assert_eq!(bucket.maximum_size, 2);
+    }
+
+    #[test]
+    fn invalid_refill_rate() {
+        assert!(TokenBucket::new(2, 2, f32::NAN).is_err());
+        assert!(TokenBucket::new(2, 2, f32::INFINITY).is_err());
+        assert!(TokenBucket::new(2, 2, f32::NEG_INFINITY).is_err());
+        assert!(TokenBucket::new(2, 2, -1.0).is_err());
+    }
+
+    #[test]
+    fn valid_refill_rate() {
+        assert!(TokenBucket::new(2, 2, 0.0).is_ok());
+        assert!(TokenBucket::new(2, 2, 0.3).is_ok());
+    }
+
+    #[test]
+    fn acquire() {
+        let mut bucket = TokenBucket::new(5, 10, 1.0).expect("bucket should be well formed");
+
+        assert!(bucket.acquire(0));
+        assert_eq!(bucket.size, to_tokens_with_parts(5));
+
+        assert!(bucket.acquire(1));
+        assert_eq!(bucket.size, to_tokens_with_parts(4));
+
+        assert!(!bucket.acquire(10));
+        assert_eq!(bucket.size, to_tokens_with_parts(4));
+
+        assert!(bucket.acquire(4));
+        assert_eq!(bucket.size, to_tokens_with_parts(0));
+
+        assert!(!bucket.acquire(1));
+        assert_eq!(bucket.size, to_tokens_with_parts(0));
+    }
+
+    #[test]
+    fn max_is_zero() {
+        let mut bucket = TokenBucket::new(0, 0, 0.0).expect("bucket should be well formed");
+        assert!(bucket.acquire(0));
+        assert!(!bucket.acquire(1));
+    }
+
+    #[test]
+    fn refill() {
+        let mut bucket = TokenBucket::new(0, 1000, 10.0).expect("bucket should be well formed");
+        bucket.refill(Duration::seconds(2));
+        assert_eq!(bucket.size, to_tokens_with_parts(20));
+        bucket.refill(Duration::milliseconds(500));
+        assert_eq!(bucket.size, to_tokens_with_parts(20 + 5));
+    }
+
+    #[test]
+    fn refill_zero_rate() {
+        let mut bucket = TokenBucket::new(10, 10, 0.0).expect("bucket should be well formed");
+        assert!(bucket.acquire(10));
+        assert!(!bucket.acquire(1));
+        bucket.refill(Duration::seconds(100));
+        assert!(!bucket.acquire(1));
+    }
+
+    #[test]
+    fn refill_non_positive_duration() {
+        let mut bucket = TokenBucket::new(10, 10, 1.0).expect("bucket should be well formed");
+        let size = bucket.size;
+        bucket.refill(Duration::seconds(0));
+        bucket.refill(Duration::seconds(-1));
+        assert_eq!(bucket.size, size);
+    }
+
+    #[test]
+    fn refill_partial_token() {
+        let mut bucket = TokenBucket::new(0, 5, 0.4).expect("bucket should be well formed");
+        assert!(!bucket.acquire(1));
+        bucket.refill(Duration::seconds(1));
+        assert!(!bucket.acquire(1));
+        bucket.refill(Duration::seconds(1));
+        assert!(!bucket.acquire(1));
+        bucket.refill(Duration::seconds(1));
+        assert!(bucket.acquire(1));
+    }
+
+    #[test]
+    fn refill_overflow_bucket_max_size() {
+        let mut bucket = TokenBucket::new(2, 5, 1.0).expect("bucket should be well formed");
+        bucket.refill(Duration::seconds(2));
+        assert_eq!(bucket.size, to_tokens_with_parts(4));
+        bucket.refill(Duration::seconds(2));
+        assert_eq!(bucket.size, to_tokens_with_parts(5));
+        assert!(bucket.acquire(5));
+        bucket.refill(Duration::seconds(10));
+        assert_eq!(bucket.size, to_tokens_with_parts(5));
+    }
+
+    #[test]
+    fn check_with_numeric_limits() {
+        let mut bucket =
+            TokenBucket::new(u32::MAX, u32::MAX, 1000.0).expect("bucket should be well formed");
+        assert!(bucket.acquire(u32::MAX));
+        assert!(!bucket.acquire(1));
+        bucket.refill(Duration::seconds(i64::MAX));
+        assert!(bucket.acquire(u32::MAX));
+        assert!(!bucket.acquire(1));
+    }
+
+    #[test]
+    fn validate_guaranteed_resolution() {
+        let mut bucket = TokenBucket::new(0, 10, 0.001).expect("bucket should be well formed");
+        // Up to 999s: no new token added.
+        for _ in 0..99_900 {
+            bucket.refill(Duration::milliseconds(10));
+        }
+        assert!(!bucket.acquire(1));
+        // From 999s to 1001s: the new token should get added.
+        let mut tokens_added = 0;
+        for _ in 99_900..100_100 {
+            bucket.refill(Duration::milliseconds(10));
+            if bucket.acquire(1) {
+                tokens_added += 1;
+            }
+        }
+        assert_eq!(tokens_added, 1);
+    }
+}

--- a/chain/network/src/rate_limits/token_bucket.rs
+++ b/chain/network/src/rate_limits/token_bucket.rs
@@ -55,12 +55,7 @@ impl TokenBucket {
     ) -> Result<Self, TokenBucketError> {
         let size = to_tokens_with_parts(maximum_size.min(initial_size));
         let size = AtomicU64::new(size);
-        if refill_rate < 0.0 {
-            return Err(TokenBucketError::InvalidRefillRate(refill_rate));
-        }
-        if !refill_rate.is_normal() && refill_rate != 0.0 {
-            return Err(TokenBucketError::InvalidRefillRate(refill_rate));
-        }
+        TokenBucket::validate_refill_rate(refill_rate)?;
         Ok(Self { maximum_size, size, refill_rate })
     }
 
@@ -101,6 +96,18 @@ impl TokenBucket {
                 .min(to_tokens_with_parts(self.maximum_size));
             Some(new_size)
         });
+    }
+
+    /// Returns an error if the value provided is not in the correct range for
+    /// `refill_rate`.
+    pub(crate) fn validate_refill_rate(refill_rate: f32) -> Result<(), TokenBucketError> {
+        if refill_rate < 0.0 {
+            return Err(TokenBucketError::InvalidRefillRate(refill_rate));
+        }
+        if !refill_rate.is_normal() && refill_rate != 0.0 {
+            return Err(TokenBucketError::InvalidRefillRate(refill_rate));
+        }
+        Ok(())
     }
 
     #[cfg(test)]

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -192,6 +192,14 @@ pub(crate) static PEER_MESSAGE_SENT_BY_TYPE_TOTAL: Lazy<IntCounterVec> = Lazy::n
     )
     .unwrap()
 });
+pub(crate) static PEER_MESSAGE_RATE_LIMITED_BY_TYPE_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    try_create_int_counter_vec(
+        "near_peer_message_rate_limited_by_type_total",
+        "Number of messages dropped because rate limited by message types",
+        &["type"],
+    )
+    .unwrap()
+});
 pub(crate) static SYNC_ACCOUNTS_DATA: Lazy<IntCounterVec> = Lazy::new(|| {
     try_create_int_counter_vec(
         "near_sync_accounts_data",

--- a/nearcore/src/config_duration_test.rs
+++ b/nearcore/src/config_duration_test.rs
@@ -58,6 +58,9 @@ fn test_config_duration_all_std() {
                     routed_message_ttl: Some(0),
                     routing_table_update_rate_limit_burst: Some(0),
                     routing_table_update_rate_limit_qps: Some(0.0),
+                    received_messages_rate_limits: Some(
+                        near_network::MessagesLimitsOverrideConfig::default(),
+                    ),
                 },
                 ..Default::default()
             },


### PR DESCRIPTION
Implementation for rate limits of incoming network messages. 
Original issue: #11617. Also supersedes #11618.

**Note:** rate limits are implemented but not defined with this PR; in practice, nothing should change  for a node.

## PR summary
This PR adds:
- A module to arbitrate rate limits using a token bucket algorithm (see `token_bucket.rs`)
- Convenience class to handle all rate limits of a network connection (see `messages_limits.rs`)
- Changes to `peer_actor.rs` to implement the rate limits on received messages
- Changes to the network configuration
- A new metric to count messages dropped due to rate limits
- Unit tests

## Leftovers
- ~Make rate limits configurable, likely through config files with overrides~ _done_
- ~Use more accurate token allocation for some network messages, in particular the ones containing a dynamic number of elements. For reference: [analysis](https://docs.google.com/document/d/1Uo4211zkjgU7lHEnrEBBqD997Tn19eIh67P6Czl4JUg/edit#heading=h.711dlbykkndl)~ _to be done in a another PR_