### PR TITLE
fix: spammy log - not a validator

### DIFF
--- a/chain/client/src/stateless_validation/chunk_validator/orphan_witness_handling.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/orphan_witness_handling.rs
@@ -110,8 +110,6 @@ impl Client {
     ) {
         if let Some(signer) = signer {
             self.process_ready_orphan_witnesses(new_block, signer);
-        } else {
-            tracing::error!(target: "client", new_block=?new_block.hash(), "Cannot process ready orphan witnesses - not a validator");
         }
 
         // Remove all orphan witnesses that are below the last final block of the new block.


### PR DESCRIPTION
See https://github.com/near/nearcore/pull/11400#issuecomment-2182650051

It seems non-validator nodes still call `process_ready_orphan_witnesses_and_clean_old` and logging an error in such case is spammy.