### PR TITLE
congestion: decrease backpressure sensibility

### DIFF
--- a/core/parameters/res/runtime_configs/82.yaml
+++ b/core/parameters/res/runtime_configs/82.yaml
@@ -1,0 +1,14 @@
+# Congestion control adjustment to avoid oversensitive backpressure on large
+# receipt stalls.
+
+# 2 PGAS -> 10 PGAS
+max_congestion_outgoing_gas: { 
+  old : 2_000_000_000_000_000,
+  new : 10_000_000_000_000_000,
+}
+
+# 0.25 -> 0.5
+reject_tx_congestion_threshold: { 
+  old : { numerator: 25, denominator: 100 },
+  new : { numerator: 50, denominator: 100 },
+}

--- a/core/parameters/src/config_store.rs
+++ b/core/parameters/src/config_store.rs
@@ -43,6 +43,7 @@ static CONFIG_DIFFS: &[(ProtocolVersion, &str)] = &[
     (80, include_config!("80.yaml")),
     // Stateless Validation.
     (81, include_config!("81.yaml")),
+    (82, include_config!("82.yaml")),
     (129, include_config!("129.yaml")),
     // Introduce ETH-implicit accounts.
     (138, include_config!("138.yaml")),

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__138.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__138.json.snap
@@ -226,7 +226,7 @@ expression: config_view
   },
   "congestion_control_config": {
     "max_congestion_incoming_gas": 20000000000000000,
-    "max_congestion_outgoing_gas": 2000000000000000,
+    "max_congestion_outgoing_gas": 10000000000000000,
     "max_congestion_memory_consumption": 1000000000,
     "max_congestion_missed_chunks": 5,
     "max_outgoing_gas": 300000000000000000,
@@ -234,7 +234,7 @@ expression: config_view
     "allowed_shard_outgoing_gas": 1000000000000000,
     "max_tx_gas": 500000000000000,
     "min_tx_gas": 20000000000000,
-    "reject_tx_congestion_threshold": 0.25,
+    "reject_tx_congestion_threshold": 0.5,
     "outgoing_receipts_usual_size_limit": 102400,
     "outgoing_receipts_big_size_limit": 4718592
   },

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__82.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__82.json.snap
@@ -179,7 +179,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
     "storage_get_mode": "FlatStorage",
-    "fix_contract_loading_cost": true,
+    "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "math_extension": true,
     "ed25519_verify": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
@@ -226,7 +226,7 @@ expression: config_view
   },
   "congestion_control_config": {
     "max_congestion_incoming_gas": 20000000000000000,
-    "max_congestion_outgoing_gas": 2000000000000000,
+    "max_congestion_outgoing_gas": 10000000000000000,
     "max_congestion_memory_consumption": 1000000000,
     "max_congestion_missed_chunks": 5,
     "max_outgoing_gas": 300000000000000000,
@@ -234,7 +234,7 @@ expression: config_view
     "allowed_shard_outgoing_gas": 1000000000000000,
     "max_tx_gas": 500000000000000,
     "min_tx_gas": 20000000000000,
-    "reject_tx_congestion_threshold": 0.25,
+    "reject_tx_congestion_threshold": 0.5,
     "outgoing_receipts_usual_size_limit": 102400,
     "outgoing_receipts_big_size_limit": 4718592
   },

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_138.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_138.json.snap
@@ -226,7 +226,7 @@ expression: config_view
   },
   "congestion_control_config": {
     "max_congestion_incoming_gas": 20000000000000000,
-    "max_congestion_outgoing_gas": 2000000000000000,
+    "max_congestion_outgoing_gas": 10000000000000000,
     "max_congestion_memory_consumption": 1000000000,
     "max_congestion_missed_chunks": 5,
     "max_outgoing_gas": 300000000000000000,
@@ -234,7 +234,7 @@ expression: config_view
     "allowed_shard_outgoing_gas": 1000000000000000,
     "max_tx_gas": 500000000000000,
     "min_tx_gas": 20000000000000,
-    "reject_tx_congestion_threshold": 0.25,
+    "reject_tx_congestion_threshold": 0.5,
     "outgoing_receipts_usual_size_limit": 102400,
     "outgoing_receipts_big_size_limit": 4718592
   },

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_82.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_82.json.snap
@@ -179,7 +179,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
     "storage_get_mode": "FlatStorage",
-    "fix_contract_loading_cost": true,
+    "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "math_extension": true,
     "ed25519_verify": true,

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -269,7 +269,7 @@ const STABLE_PROTOCOL_VERSION: ProtocolVersion = 67;
 /// Largest protocol version supported by the current binary.
 pub const PROTOCOL_VERSION: ProtocolVersion = if cfg!(feature = "statelessnet_protocol") {
     // Current StatelessNet protocol version.
-    81
+    82
 } else if cfg!(feature = "nightly_protocol") {
     // On nightly, pick big enough version to support all features.
     143


### PR DESCRIPTION
With new limits on outgoing receipts, based on their size, the original parameters for backpressure on outgoing congestion are no longer ideal. Small numbers of receipts in the outgoing buffer will be a common case and should not cause backpressure.