### PR TITLE
Change apply-chunk tracker implementation

### DIFF
--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -119,3 +119,4 @@ statelessnet_protocol = [
   "near-primitives/statelessnet_protocol",
 ]
 sandbox = ["near-o11y/sandbox", "near-primitives/sandbox"]
+testloop = []

--- a/chain/chain/src/block_processing_utils.rs
+++ b/chain/chain/src/block_processing_utils.rs
@@ -236,7 +236,7 @@ mod tests {
 
         let (results_sender, results_receiver) = std::sync::mpsc::channel();
 
-        // Sawn waiter tasks
+        // Spawn waiter tasks
         for waiter in [waiter1, waiter2, waiter3] {
             let current_sender = results_sender.clone();
             let current_shared_value = shared_value.clone();

--- a/chain/chain/src/block_processing_utils.rs
+++ b/chain/chain/src/block_processing_utils.rs
@@ -148,7 +148,6 @@ impl BlocksInProcessing {
     }
 }
 
-
 /// This is used to for the thread that applies chunks to notify other waiter threads.
 /// The thread applying the chunks should call `set_done` to send the notification.
 /// The waiter threads should call `wait_until_done` to wait (blocked) for the notification.
@@ -184,7 +183,7 @@ impl ApplyChunksDoneTracker {
     pub fn wait_until_done(&self) {
         #[cfg(feature = "testloop")]
         let mut testloop_total_wait_time = Duration::from_millis(0);
-        
+
         let (lock, cvar) = &*self.0;
         match lock.lock() {
             Ok(mut guard) => loop {
@@ -196,10 +195,10 @@ impl ApplyChunksDoneTracker {
                         if done {
                             break;
                         }
-                        
+
                         // Panics during testing (eg. due to assertion failures) cause the waiter
                         // threads to miss the notification (see issue #11447). Thus, for testing only,
-                        // we limit the total wait time for waiting for the notification. 
+                        // we limit the total wait time for waiting for the notification.
                         #[cfg(feature = "testloop")]
                         if result.1.timed_out() {
                             const TESTLOOP_MAX_WAIT_TIME: Duration = Duration::from_millis(5000);

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1810,7 +1810,7 @@ impl Chain {
     }
 
     /// Applying chunks async by starting the work at the rayon thread pool
-    /// `apply_chunks_done_marker`: a marker that will be set to true once applying chunks is finished
+    /// `apply_chunks_done_tracker`: notifies the threads that wait for applying chunks is finished
     /// `apply_chunks_done_sender`: a sender to send a ApplyChunksDoneMessage message once applying chunks is finished
     fn schedule_apply_chunks(
         &self,

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1,5 +1,5 @@
 use crate::block_processing_utils::{
-    ApplyChunksDoneTracker, BlockPreprocessInfo, BlockProcessingArtifact, BlocksInProcessing
+    ApplyChunksDoneTracker, BlockPreprocessInfo, BlockProcessingArtifact, BlocksInProcessing,
 };
 use crate::blocks_delay_tracker::BlocksDelayTracker;
 use crate::chain_update::ChainUpdate;

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -99,7 +99,6 @@ use near_store::flat::{store_helper, FlatStorageReadyStatus, FlatStorageStatus};
 use near_store::get_genesis_state_roots;
 use near_store::DBCol;
 use node_runtime::bootstrap_congestion_info;
-use once_cell::sync::OnceCell;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{Debug, Formatter};

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -171,3 +171,4 @@ sandbox = [
 no_cache = ["nearcore/no_cache"]
 calimero_zero_storage = []
 new_epoch_sync = ["nearcore/new_epoch_sync"]
+testloop = ["near-chain/testloop"]

--- a/integration-tests/src/test_loop/tests/multinode_test_loop_example.rs
+++ b/integration-tests/src/test_loop/tests/multinode_test_loop_example.rs
@@ -46,7 +46,7 @@ fn test_client_with_multi_test_loop() {
     let genesis = genesis_builder.build();
 
     let TestLoopEnv { mut test_loop, datas: node_datas } =
-        builder.genesis(genesis).clients(clients).disable_gc().build();
+        builder.genesis(genesis).clients(clients).build();
 
     // Bootstrap the test by starting the components.
     for idx in 0..NUM_CLIENTS {

--- a/integration-tests/src/test_loop/tests/multinode_test_loop_example.rs
+++ b/integration-tests/src/test_loop/tests/multinode_test_loop_example.rs
@@ -46,7 +46,7 @@ fn test_client_with_multi_test_loop() {
     let genesis = genesis_builder.build();
 
     let TestLoopEnv { mut test_loop, datas: node_datas } =
-        builder.genesis(genesis).clients(clients).build();
+        builder.genesis(genesis).clients(clients).disable_gc().build();
 
     // Bootstrap the test by starting the components.
     for idx in 0..NUM_CLIENTS {


### PR DESCRIPTION
As discussed in [#11447](https://github.com/near/nearcore/issues/11447), if there is a panic (due to assertion failure) when running testloop locally, the test freezes instead of reporting the failure. This makes it difficult to run testloop in cases where we want to debug an assertion failure.

The reason for the freezing test failures is that the panic causes the objects be dropped and the drop handler for Chain blocks, waiting apply-chunks be finished: https://github.com/near/nearcore/blob/71d35d9921603d8dea60fcc41c0d5478202fc574/chain/chain/src/chain.rs#L295

However that wait does not end, since setter runs after apply-blocks is finished: https://github.com/near/nearcore/blob/71d35d9921603d8dea60fcc41c0d5478202fc574/chain/chain/src/chain.rs#L1831

And it does not get a chance to notify the waiters. For example, commenting out the drop handler for the Chain allows us to see the assertion failure, as expected. 

To handle this for testloop, we change the implementation as follows:
1. We use a condition variable to wait for apply-chunks processing and setting when it is done (condition variable naturally fits in this scenario for waiting the operation be done).
2. We introduce a feature to be enabled when running testloop. This limits the total wait time for each thread to 5 seconds. This is testing-only and not enabled in production. This is still not ideal and does not immediately unblock the waiting threads when there is a panic, but at least puts a limit on the freeze before the assertion failure is exposed.

Note: We could also use a technique such as `oneshot::Receiver`, in which case the waiter will just return whenever the sender is dropped, but it works with `async` computations only, whereas the apply-chunks is executed in a multi-threaded fashion.