### PR TITLE
Unload obsolete memtries post block processing

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1956,8 +1956,10 @@ impl Chain {
             }
         }
 
-        // Garbage collect memtries that we do not care about this or next epoch.
-        self.runtime_adapter.get_tries().retain_mem_tries(&shards_cares_this_or_next_epoch);
+        if self.epoch_manager.is_next_block_epoch_start(block.header().prev_hash())? {
+            // Keep in memory only these tries that we care about this or next epoch.
+            self.runtime_adapter.get_tries().retain_mem_tries(&shards_cares_this_or_next_epoch);
+        }
 
         if let Err(err) = self.garbage_collect_state_transition_data(&block) {
             tracing::error!(target: "chain", ?err, "failed to garbage collect state transition data");

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1943,7 +1943,7 @@ impl Chain {
             let need_flat_storage_update = if is_caught_up {
                 // If we already caught up this epoch, then flat storage exists for both shards which we already track
                 // and shards which will be tracked in next epoch, so we can update them.
-                care_about_shard_this_or_next_epoch 
+                care_about_shard_this_or_next_epoch
             } else {
                 // If we didn't catch up, we can update only shards tracked right now. Remaining shards will be updated
                 // during catchup of this block.

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -45,8 +45,7 @@ use near_chain_configs::{
 use near_chunks::adapter::ShardsManagerRequestFromClient;
 use near_chunks::client::ShardedTransactionPool;
 use near_chunks::logic::{
-    cares_about_shard_this_or_next_epoch, decode_encoded_chunk,
-    get_shards_cares_about_this_or_next_epoch, persist_chunk,
+    cares_about_shard_this_or_next_epoch, decode_encoded_chunk, persist_chunk,
 };
 use near_chunks::shards_manager_actor::ShardsManagerActor;
 use near_client_primitives::debug::ChunkProduction;
@@ -2503,20 +2502,6 @@ impl Client {
                     .epoch_manager
                     .get_shard_layout(&epoch_id)
                     .expect("Cannot get shard layout");
-
-                // Make sure mem-tries for shards we do not care about are unloaded before we start a new state sync.
-                let shards_cares_this_or_next_epoch = get_shards_cares_about_this_or_next_epoch(
-                    me.as_ref(),
-                    true,
-                    &block_header,
-                    &self.shard_tracker,
-                    self.epoch_manager.as_ref(),
-                );
-                let shard_uids: Vec<_> = shards_cares_this_or_next_epoch
-                    .iter()
-                    .map(|id| self.epoch_manager.shard_id_to_uid(*id, &epoch_id).unwrap())
-                    .collect();
-                self.runtime_adapter.get_tries().retain_mem_tries(&shard_uids);
 
                 for &shard_id in &tracking_shards {
                     let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);


### PR DESCRIPTION
Currently we remove obsolete memtries only when we start state sync for a new shard: https://github.com/near/nearcore/blob/master/chain/client/src/client.rs#L2507-L2519
However, it does not unload obsolete memtries in all cases.
For example, if we tracked shards [0, 1, 2], and then we track shards [0, 1] only, shard 2 won't be unloaded, because we did not start a new state sync.
Although it is not critical, trie for shard 2 could occupy memory forever.

This PR calls the routine to unload obsolete memtries as a block post-processing step too.