### PR TITLE
[locust] Adjust worker and contract balances

### DIFF
--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -851,7 +851,7 @@ def do_on_locust_init(environment):
     # every worker needs a funding account to create its users, eagerly create them in the master
     if isinstance(environment.runner, runners.MasterRunner):
         num_funding_accounts = environment.parsed_options.max_workers
-        funding_balance = 1000000 * NearUser.INIT_BALANCE
+        funding_balance = 100000 * NearUser.INIT_BALANCE
 
         def create_account(id):
             account_id = f"funds_worker_{id}.{master_funding_account.key.account_id}"

--- a/pytest/tests/loadtest/locust/common/ft.py
+++ b/pytest/tests/loadtest/locust/common/ft.py
@@ -93,7 +93,7 @@ class FTContract:
         accounts = [create_account() for _ in range(num)]
         node.prepare_accounts(accounts,
                               parent,
-                              balance=7,
+                              balance=1,
                               msg="create passive user")
         with futures.ThreadPoolExecutor() as executor:
             futures.wait(


### PR DESCRIPTION
This addresses two problems:
- The initial balance of master funding account was not enough for 16 workers, so decreasing it 10x (still 10x higher than the previous value)
- Decrease the starting balance of individual user accounts - this is possible now as in FT benchmark, we disable gas price changes during congestion