### PR TITLE
[ft-benchmark] fill actor and context db fields properly

### DIFF
--- a/scripts/ft-benchmark-data-sender.py
+++ b/scripts/ft-benchmark-data-sender.py
@@ -111,6 +111,11 @@ if __name__ == "__main__":
                         type=int,
                         required=True,
                         help='Number of users')
+    parser.add_argument('--user', type=str, default='unknown', help='User name')
+    parser.add_argument('--context',
+                        type=str,
+                        default='unknown',
+                        help='Context')
     args = parser.parse_args()
     DURATION = args.duration / 3600
 
@@ -153,7 +158,7 @@ if __name__ == "__main__":
         "size_state_bytes": state_size,
         "tps": int(average_tps),
         "total_transactions": int(processed_transactions[-1]),
-        "initiator": "crt cron job",
-        "context": "continuous benchmark run",
+        "initiator": args.user,
+        "context": args.context,
     }
     commit_to_db(response)

--- a/scripts/run-ft-benchmark.py
+++ b/scripts/run-ft-benchmark.py
@@ -24,9 +24,9 @@ def remove_lock_file() -> None:
 
 
 def run_benchmark(repo_dir: str, time: str, users: int, shards: int, nodes: int,
-                  rump_up: int) -> None:
+                  rump_up: int, user: str, context: str) -> None:
     benchmark_command = (
-        f"./scripts/start-benchmark.sh {time} {users} {shards} {nodes} {rump_up}"
+        f"./scripts/start-benchmark.sh {time} {users} {shards} {nodes} {rump_up} {user} {context}"
     )
     subprocess.run(benchmark_command, cwd=repo_dir, shell=True, check=True)
 
@@ -50,12 +50,16 @@ def main() -> None:
     parser.add_argument('--nodes', type=int, default=1, help="Number of nodes")
     parser.add_argument('--rump-up', type=int, default=10, help="Rump-up rate")
     parser.add_argument('--user', type=str, default='unknown', help="User name")
+    parser.add_argument('--context',
+                        type=str,
+                        default='unknown',
+                        help="Context")
     args = parser.parse_args()
     time_seconds = parse_timespan(args.time)
     try:
         create_lock_file(args.user)
         run_benchmark(REPO_DIR, time_seconds, args.users, args.shards,
-                      args.nodes, args.rump_up)
+                      args.nodes, args.rump_up, args.user, args.context)
     except RuntimeError as e:
         print(e)
     finally:

--- a/scripts/start-benchmark.sh
+++ b/scripts/start-benchmark.sh
@@ -6,6 +6,8 @@ USERS=$2
 SHARDS=$3
 NODES=$4
 RUMP_UP=$5
+USER=$6
+CONTEXT=$7
 
 # Stop previous experiment
 pkill -9 locust || true
@@ -33,6 +35,6 @@ sleep 30
 
 # Run data collector
 cd ~/nearcore
-python3 scripts/ft-benchmark-data-sender.py --duration $TIME --users $USERS
+python3 scripts/ft-benchmark-data-sender.py --duration $TIME --users $USERS --user $USER --context $CONTEXT
 
 echo "Benchmark completed."


### PR DESCRIPTION
Before this changes `initiator` and `context` db fields was filled by hardcoded constants. Now they switched to command line arguments. Probably it makes sense to do this arguments required and not default them to "unknown", but don't think it is very important