### PR TITLE
fix(nayduck) - Recompile the test contracts when test_features is enabled. 

### DIFF
--- a/runtime/near-test-contracts/build.rs
+++ b/runtime/near-test-contracts/build.rs
@@ -54,6 +54,7 @@ fn build_contract(dir: &str, args: &[&str], output: &str) -> Result<(), Error> {
         .map_err(|err| format!("failed to copy `{}`: {}", src.display(), err))?;
     println!("cargo:rerun-if-changed=./{}/src/lib.rs", dir);
     println!("cargo:rerun-if-changed=./{}/Cargo.toml", dir);
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_TEST_FEATURES");
     Ok(())
 }
 

--- a/runtime/near-test-contracts/build.rs
+++ b/runtime/near-test-contracts/build.rs
@@ -9,9 +9,10 @@ fn main() {
         std::process::exit(1);
     }
 }
-
 fn try_main() -> Result<(), Error> {
     let mut test_contract_features = vec!["latest_protocol"];
+
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_TEST_FEATURES");
     if env::var("CARGO_FEATURE_TEST_FEATURES").is_ok() {
         test_contract_features.push("test_features");
     }
@@ -54,7 +55,6 @@ fn build_contract(dir: &str, args: &[&str], output: &str) -> Result<(), Error> {
         .map_err(|err| format!("failed to copy `{}`: {}", src.display(), err))?;
     println!("cargo:rerun-if-changed=./{}/src/lib.rs", dir);
     println!("cargo:rerun-if-changed=./{}/Cargo.toml", dir);
-    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_TEST_FEATURES");
     Ok(())
 }
 


### PR DESCRIPTION
Another attempt at fixing slow_chunk and congestion_control nayduck tests. Those were failing because the test contract was not being built correctly with the test_features enabled. Here I'm making the build script rerun the build if the relevant feature is changed. 

The first attempt and some relevant discussion is here - #11619. I know this new approach is not the best way to fix this issue but it is much quicker and seems to be getting the job done. 

https://nayduck.nearone.org/#/run/160