### PR TITLE
vm: split preparation and running of a contract

### DIFF
--- a/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
@@ -30,13 +30,8 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMOutcome {
     wasm_config.limit_config.contract_prepare_version =
         near_vm_runner::logic::ContractPrepareVersion::V2;
 
-    let res = vm_kind.runtime(wasm_config.into()).unwrap().run(
-        &mut fake_external,
-        &context,
-        fees,
-        [].into(),
-        None,
-    );
+    let res =
+        vm_kind.runtime(wasm_config.into()).unwrap().run(&mut fake_external, &context, fees, None);
 
     // Remove the VMError message details as they can differ between runtimes
     // TODO: maybe there's actually things we could check for equality here too?

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
@@ -20,7 +20,8 @@ libfuzzer_sys::fuzz_target!(|module: ArbitraryModule| {
 
 fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMOutcome {
     let mut fake_external = MockedExternal::with_code(code.clone_for_tests());
-    let mut context = create_context(vec![]);
+    let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
+    let mut context = create_context(&method_name, vec![]);
     context.prepaid_gas = 10u64.pow(14);
     let config_store = RuntimeConfigStore::new(None);
     let config = config_store.get_config(PROTOCOL_VERSION);
@@ -29,9 +30,7 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMOutcome {
     wasm_config.limit_config.contract_prepare_version =
         near_vm_runner::logic::ContractPrepareVersion::V2;
 
-    let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
     let res = vm_kind.runtime(wasm_config.into()).unwrap().run(
-        &method_name,
         &mut fake_external,
         &context,
         fees,

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
@@ -30,8 +30,11 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMOutcome {
     wasm_config.limit_config.contract_prepare_version =
         near_vm_runner::logic::ContractPrepareVersion::V2;
 
-    let res =
-        vm_kind.runtime(wasm_config.into()).unwrap().run(&mut fake_external, &context, fees, None);
+    let res = vm_kind
+        .runtime(wasm_config.into())
+        .unwrap()
+        .prepare(&fake_external, &context, None)
+        .run(&mut fake_external, &context, fees);
 
     // Remove the VMError message details as they can differ between runtimes
     // TODO: maybe there's actually things we could check for equality here too?

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
@@ -28,6 +28,6 @@ fn run_fuzz(code: &ContractCode, config: Arc<RuntimeConfig>) -> VMOutcome {
     vm_kind
         .runtime(wasm_config.into())
         .unwrap()
-        .run(&mut fake_external, &context, fees, [].into(), None)
+        .run(&mut fake_external, &context, fees, None)
         .unwrap_or_else(|err| panic!("fatal error: {err:?}"))
 }

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
@@ -28,6 +28,7 @@ fn run_fuzz(code: &ContractCode, config: Arc<RuntimeConfig>) -> VMOutcome {
     vm_kind
         .runtime(wasm_config.into())
         .unwrap()
-        .run(&mut fake_external, &context, fees, None)
+        .prepare(&fake_external, &context, None)
+        .run(&mut fake_external, &context, fees)
         .unwrap_or_else(|err| panic!("fatal error: {err:?}"))
 }

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
@@ -18,16 +18,16 @@ libfuzzer_sys::fuzz_target!(|module: ArbitraryModule| {
 
 fn run_fuzz(code: &ContractCode, config: Arc<RuntimeConfig>) -> VMOutcome {
     let mut fake_external = MockedExternal::with_code(code.clone_for_tests());
-    let mut context = create_context(vec![]);
+    let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
+    let mut context = create_context(&method_name, vec![]);
     context.prepaid_gas = 10u64.pow(14);
     let mut wasm_config = near_parameters::vm::Config::clone(&config.wasm_config);
     wasm_config.limit_config.wasmer2_stack_limit = i32::MAX; // If we can crash wasmer2 even without the secondary stack limit it's still good to know
     let vm_kind = config.wasm_config.vm_kind;
     let fees = Arc::clone(&config.fees);
-    let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
     vm_kind
         .runtime(wasm_config.into())
         .unwrap()
-        .run(&method_name, &mut fake_external, &context, fees, [].into(), None)
+        .run(&mut fake_external, &context, fees, [].into(), None)
         .unwrap_or_else(|err| panic!("fatal error: {err:?}"))
 }

--- a/runtime/near-vm-runner/fuzz/src/lib.rs
+++ b/runtime/near-vm-runner/fuzz/src/lib.rs
@@ -38,6 +38,7 @@ pub fn create_context(method: &str, input: Vec<u8>) -> VMContext {
         predecessor_account_id: "carol".parse().unwrap(),
         method: method.into(),
         input,
+        promise_results: Vec::new().into(),
         block_height: 10,
         block_timestamp: 42,
         epoch_height: 1,

--- a/runtime/near-vm-runner/fuzz/src/lib.rs
+++ b/runtime/near-vm-runner/fuzz/src/lib.rs
@@ -30,12 +30,13 @@ pub fn find_entry_point(contract: &ContractCode) -> Option<String> {
     None
 }
 
-pub fn create_context(input: Vec<u8>) -> VMContext {
+pub fn create_context(method: &str, input: Vec<u8>) -> VMContext {
     VMContext {
         current_account_id: "alice".parse().unwrap(),
         signer_account_id: "bob".parse().unwrap(),
         signer_account_pk: vec![0, 1, 2, 3, 4],
         predecessor_account_id: "carol".parse().unwrap(),
+        method: method.into(),
         input,
         block_height: 10,
         block_timestamp: 42,

--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -36,7 +36,7 @@ pub use code::ContractCode;
 #[cfg(feature = "metrics")]
 pub use metrics::{report_metrics, reset_metrics};
 pub use profile::ProfileDataV3;
-pub use runner::{run, VM, PreparedContract};
+pub use runner::{run, PreparedContract, VM};
 
 /// This is public for internal experimentation use only, and should otherwise be considered an
 /// implementation detail of `near-vm-runner`.

--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -36,7 +36,7 @@ pub use code::ContractCode;
 #[cfg(feature = "metrics")]
 pub use metrics::{report_metrics, reset_metrics};
 pub use profile::ProfileDataV3;
-pub use runner::{run, VM};
+pub use runner::{run, VM, PreparedContract};
 
 /// This is public for internal experimentation use only, and should otherwise be considered an
 /// implementation detail of `near-vm-runner`.

--- a/runtime/near-vm-runner/src/logic/context.rs
+++ b/runtime/near-vm-runner/src/logic/context.rs
@@ -1,4 +1,4 @@
-use super::types::PublicKey;
+use super::types::{PromiseResult, PublicKey};
 use near_primitives_core::config::ViewConfig;
 use near_primitives_core::types::{
     AccountId, Balance, BlockHeight, EpochHeight, Gas, StorageUsage,
@@ -25,6 +25,9 @@ pub struct VMContext {
     /// The input to the contract call.
     /// Encoded as base64 string to be able to pass input in borsh binary format.
     pub input: Vec<u8>,
+    /// If this method execution is invoked directly as a callback by one or more contract calls
+    /// the results of the methods that made the callback are stored in this collection.
+    pub promise_results: std::sync::Arc<[PromiseResult]>,
     /// The current block height.
     pub block_height: BlockHeight,
     /// The current block timestamp (number of non-leap-nanoseconds since January 1, 1970 0:00:00 UTC).

--- a/runtime/near-vm-runner/src/logic/context.rs
+++ b/runtime/near-vm-runner/src/logic/context.rs
@@ -20,6 +20,8 @@ pub struct VMContext {
     /// If this execution is the result of direct execution of transaction then it
     /// is equal to `signer_account_id`.
     pub predecessor_account_id: AccountId,
+    /// The name of the method to invoke.
+    pub method: String,
     /// The input to the contract call.
     /// Encoded as base64 string to be able to pass input in borsh binary format.
     pub input: Vec<u8>,

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -35,7 +35,7 @@ fn base64(s: &[u8]) -> String {
 /// This is a subset of [`VMLogic`] that's strictly necessary to produce `VMOutcome`s.
 pub struct ExecutionResultState {
     /// All gas and economic parameters required during contract execution.
-    config: Arc<Config>,
+    pub(crate) config: Arc<Config>,
     /// Gas tracking for the current contract execution.
     gas_counter: GasCounter,
     /// Logs written by the runtime.

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -219,9 +219,6 @@ pub struct VMLogic<'a> {
     config: Arc<Config>,
     /// Fees charged for various operations that contract may execute.
     fees_config: Arc<RuntimeFeesConfig>,
-    /// If this method execution is invoked directly as a callback by one or more contract calls the
-    /// results of the methods that made the callback are stored in this collection.
-    promise_results: Arc<[PromiseResult]>,
     /// Pointer to the guest memory.
     memory: super::vmstate::Memory,
 
@@ -303,7 +300,6 @@ impl<'a> VMLogic<'a> {
         ext: &'a mut dyn External,
         context: &'a VMContext,
         fees_config: Arc<RuntimeFeesConfig>,
-        promise_results: Arc<[PromiseResult]>,
         result_state: ExecutionResultState,
         memory: impl MemoryLike + 'static,
     ) -> Self {
@@ -319,7 +315,6 @@ impl<'a> VMLogic<'a> {
             context,
             config,
             fees_config,
-            promise_results,
             memory: super::vmstate::Memory::new(memory),
             current_account_locked_balance,
             recorded_storage_counter,
@@ -2381,7 +2376,7 @@ impl<'a> VMLogic<'a> {
             }
             .into());
         }
-        Ok(self.promise_results.len() as _)
+        Ok(self.context.promise_results.len() as _)
     }
 
     /// If the current function is invoked by a callback we can access the execution results of the
@@ -2414,6 +2409,7 @@ impl<'a> VMLogic<'a> {
             );
         }
         match self
+            .context
             .promise_results
             .get(result_idx as usize)
             .ok_or(HostError::InvalidPromiseResultIndex { result_idx })?

--- a/runtime/near-vm-runner/src/logic/tests/promises.rs
+++ b/runtime/near-vm-runner/src/logic/tests/promises.rs
@@ -19,7 +19,7 @@ fn test_promise_results() {
     ];
 
     let mut logic_builder = VMLogicBuilder::default();
-    logic_builder.promise_results = promise_results.into();
+    logic_builder.context.promise_results = promise_results.into();
     let mut logic = logic_builder.build();
 
     assert_eq!(logic.promise_results_count(), Ok(3), "Total count of registers must be 3");

--- a/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
+++ b/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
@@ -71,6 +71,7 @@ fn get_context() -> VMContext {
         signer_account_id: "bob.near".parse().unwrap(),
         signer_account_pk: vec![0, 1, 2, 3, 4],
         predecessor_account_id: "carol.near".parse().unwrap(),
+        method: "VMLogicBuilder::method_not_specified".into(),
         input: vec![0, 1, 2, 3, 4],
         block_height: 10,
         block_timestamp: 42,

--- a/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
+++ b/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
@@ -1,6 +1,5 @@
 use crate::logic::mocks::mock_external::MockedExternal;
 use crate::logic::mocks::mock_memory::MockedMemory;
-use crate::logic::types::PromiseResult;
 use crate::logic::{Config, ExecutionResultState, MemSlice, VMContext, VMLogic};
 use crate::tests::test_vm_config;
 use near_parameters::RuntimeFeesConfig;
@@ -10,7 +9,6 @@ pub(super) struct VMLogicBuilder {
     pub ext: MockedExternal,
     pub config: Config,
     pub fees_config: RuntimeFeesConfig,
-    pub promise_results: Arc<[PromiseResult]>,
     pub memory: MockedMemory,
     pub context: VMContext,
 }
@@ -22,7 +20,6 @@ impl Default for VMLogicBuilder {
             fees_config: RuntimeFeesConfig::test(),
             ext: MockedExternal::default(),
             memory: MockedMemory::default(),
-            promise_results: [].into(),
             context: get_context(),
         }
     }
@@ -43,7 +40,6 @@ impl VMLogicBuilder {
             &mut self.ext,
             &self.context,
             Arc::new(self.fees_config.clone()),
-            Arc::clone(&self.promise_results),
             result_state,
             self.memory.clone(),
         ))
@@ -59,7 +55,6 @@ impl VMLogicBuilder {
             fees_config: RuntimeFeesConfig::free(),
             ext: MockedExternal::default(),
             memory: MockedMemory::default(),
-            promise_results: [].into(),
             context: get_context(),
         }
     }
@@ -73,6 +68,7 @@ fn get_context() -> VMContext {
         predecessor_account_id: "carol.near".parse().unwrap(),
         method: "VMLogicBuilder::method_not_specified".into(),
         input: vec![0, 1, 2, 3, 4],
+        promise_results: vec![].into(),
         block_height: 10,
         block_timestamp: 42,
         epoch_height: 1,

--- a/runtime/near-vm-runner/src/near_vm_runner/runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner/runner.rs
@@ -5,7 +5,6 @@ use crate::logic::errors::{
     CacheError, CompilationError, FunctionCallError, MethodResolveError, VMRunnerError, WasmTrap,
 };
 use crate::logic::gas_counter::FastGasCounter;
-use crate::logic::types::PromiseResult;
 use crate::logic::{Config, ExecutionResultState, External, VMContext, VMLogic, VMOutcome};
 use crate::near_vm_runner::{NearVmCompiler, NearVmEngine};
 use crate::runner::VMResult;
@@ -579,7 +578,6 @@ impl crate::runner::VM for NearVM {
         ext: &mut dyn External,
         context: &VMContext,
         fees_config: Arc<RuntimeFeesConfig>,
-        promise_results: Arc<[PromiseResult]>,
         cache: Option<&dyn ContractRuntimeCache>,
     ) -> Result<VMOutcome, VMRunnerError> {
         let cache = cache.unwrap_or(&NoContractRuntimeCache);
@@ -592,8 +590,7 @@ impl crate::runner::VM for NearVM {
             // FIXME: this mostly duplicates the `run_module` method.
             // Note that we don't clone the actual backing memory, just increase the RC.
             let vmmemory = memory.vm();
-            let mut logic =
-                VMLogic::new(ext, context, fees_config, promise_results, result_state, memory);
+            let mut logic = VMLogic::new(ext, context, fees_config, result_state, memory);
             let import =
                 build_imports(vmmemory, &mut logic, Arc::clone(&self.config), artifact.engine());
             let entrypoint = match get_entrypoint_index(&*artifact, &context.method) {

--- a/runtime/near-vm-runner/src/near_vm_runner/runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner/runner.rs
@@ -619,6 +619,7 @@ impl crate::runner::VM for NearVM {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum PreparedContract {
     Outcome(VMOutcome),
     Ready {

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -48,7 +48,6 @@ pub(crate) type VMResult<T = VMOutcome> = Result<T, VMRunnerError>;
     compute_usage = tracing::field::Empty,
 ))]
 pub fn run(
-    method_name: &str,
     ext: &mut (dyn External + Send),
     context: &VMContext,
     wasm_config: Arc<Config>,
@@ -61,7 +60,7 @@ pub fn run(
     let runtime = vm_kind
         .runtime(wasm_config)
         .unwrap_or_else(|| panic!("the {vm_kind:?} runtime has not been enabled at compile time"));
-    let outcome = runtime.run(method_name, ext, context, fees_config, promise_results, cache);
+    let outcome = runtime.run(ext, context, fees_config, promise_results, cache);
     let outcome = match outcome {
         Ok(o) => o,
         e @ Err(_) => return e,
@@ -89,7 +88,6 @@ pub trait VM {
     /// implementation.
     fn run(
         &self,
-        method_name: &str,
         ext: &mut dyn External,
         context: &VMContext,
         fees_config: Arc<RuntimeFeesConfig>,

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -23,6 +23,26 @@ use std::sync::Arc;
 /// validators, even when a guest error occurs, or else their state will diverge.
 pub(crate) type VMResult<T = VMOutcome> = Result<T, VMRunnerError>;
 
+#[tracing::instrument(target = "vm", level = "debug", "prepare", skip_all, fields(
+    code.hash = %ext.code_hash(),
+    method_name,
+    vm_kind = ?wasm_config.vm_kind,
+    burnt_gas = tracing::field::Empty,
+    compute_usage = tracing::field::Empty,
+))]
+pub fn prepare(
+    ext: &(dyn External + Send),
+    context: &VMContext,
+    wasm_config: Arc<Config>,
+    cache: Option<&dyn ContractRuntimeCache>,
+) -> Box<dyn crate::PreparedContract> {
+    let vm_kind = wasm_config.vm_kind;
+    let runtime = vm_kind
+        .runtime(wasm_config)
+        .unwrap_or_else(|| panic!("the {vm_kind:?} runtime has not been enabled at compile time"));
+    runtime.prepare(ext, context, cache)
+}
+
 /// Validate and run the specified contract.
 ///
 /// This is the entry point for executing a NEAR protocol contract. Before the
@@ -54,11 +74,8 @@ pub fn run(
     cache: Option<&dyn ContractRuntimeCache>,
 ) -> VMResult {
     let span = tracing::Span::current();
-    let vm_kind = wasm_config.vm_kind;
-    let runtime = vm_kind
-        .runtime(wasm_config)
-        .unwrap_or_else(|| panic!("the {vm_kind:?} runtime has not been enabled at compile time"));
-    let outcome = runtime.run(ext, context, fees_config, cache);
+    let prepared = prepare(ext, context, wasm_config, cache);
+    let outcome = prepared.run(ext, context, fees_config);
     let outcome = match outcome {
         Ok(o) => o,
         e @ Err(_) => return e,
@@ -69,24 +86,38 @@ pub fn run(
     Ok(outcome)
 }
 
-pub trait VM {
-    /// Validate and run the specified contract.
+pub trait PreparedContract {
+    /// Run the prepared contract.
     ///
-    /// This is the entry point for executing a NEAR protocol contract. Before the entry point (as
-    /// specified by the `VMContext::method` argument) of the contract code is executed, the
-    /// contract will be validated (see [`crate::prepare::prepare_contract`]), instrumented (e.g.
-    /// for gas accounting), and linked with the externs specified via the `ext` argument.
+    /// This is the entry point for executing a NEAR protocol contract. The entry point (as
+    /// specified by the `VMContext::method` argument) of the contract code is executed.
     ///
-    /// [`VMContext::input`] will be passed to the contract entrypoint as an argument.
-    ///
-    /// The gas cost for contract preparation will be subtracted by the VM implementation.
+    /// [`VMContext::input`] will be made available to the contract.
     fn run(
-        &self,
+        self: Box<Self>,
         ext: &mut dyn External,
         context: &VMContext,
         fees_config: Arc<RuntimeFeesConfig>,
-        cache: Option<&dyn ContractRuntimeCache>,
     ) -> VMResult;
+}
+
+pub trait VM {
+    /// Prepare a contract for execution.
+    ///
+    /// Work that goes into the preparation is runtime implementation specific, and depending on
+    /// the runtime may not do anything at all (and instead prepare everything when the contract is
+    /// `run`.)
+    ///
+    /// ## Return
+    ///
+    /// This method does not report any errors. If the contract is invalid in any way, the errors
+    /// will be reported when the returned value is `run`.
+    fn prepare(
+        self: Box<Self>,
+        ext: &dyn External,
+        context: &VMContext,
+        cache: Option<&dyn ContractRuntimeCache>,
+    ) -> Box<dyn PreparedContract>;
 
     /// Precompile a WASM contract to a VM specific format and store the result
     /// into the `cache`.

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -86,7 +86,7 @@ pub fn run(
     Ok(outcome)
 }
 
-pub trait PreparedContract {
+pub trait PreparedContract: Send {
     /// Run the prepared contract.
     ///
     /// This is the entry point for executing a NEAR protocol contract. The entry point (as

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -60,6 +60,7 @@ fn create_context(method: &str, input: Vec<u8>) -> VMContext {
         predecessor_account_id: PREDECESSOR_ACCOUNT_ID.parse().unwrap(),
         method: method.into(),
         input,
+        promise_results: Vec::new().into(),
         block_height: 10,
         block_timestamp: 42,
         epoch_height: 1,

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -52,12 +52,13 @@ pub(crate) fn with_vm_variants(
     }
 }
 
-fn create_context(input: Vec<u8>) -> VMContext {
+fn create_context(method: &str, input: Vec<u8>) -> VMContext {
     VMContext {
         current_account_id: CURRENT_ACCOUNT_ID.parse().unwrap(),
         signer_account_id: SIGNER_ACCOUNT_ID.parse().unwrap(),
         signer_account_pk: Vec::from(&SIGNER_ACCOUNT_PK[..]),
         predecessor_account_id: PREDECESSOR_ACCOUNT_ID.parse().unwrap(),
+        method: method.into(),
         input,
         block_height: 10,
         block_timestamp: 42,

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -124,10 +124,9 @@ fn make_cached_contract_call_vm(
     fake_external.code_hash = code_hash;
     let mut context = create_context(method_name, vec![]);
     let fees = Arc::new(RuntimeFeesConfig::test());
-    let promise_results = [].into();
     context.prepaid_gas = prepaid_gas;
     let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
-    runtime.run(&mut fake_external, &context, fees, promise_results, Some(cache))
+    runtime.run(&mut fake_external, &context, fees, Some(cache))
 }
 
 #[test]

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -122,12 +122,12 @@ fn make_cached_contract_call_vm(
         MockedExternal::new()
     };
     fake_external.code_hash = code_hash;
-    let mut context = create_context(vec![]);
+    let mut context = create_context(method_name, vec![]);
     let fees = Arc::new(RuntimeFeesConfig::test());
     let promise_results = [].into();
     context.prepaid_gas = prepaid_gas;
     let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
-    runtime.run(method_name, &mut fake_external, &context, fees, promise_results, Some(cache))
+    runtime.run(&mut fake_external, &context, fees, promise_results, Some(cache))
 }
 
 #[test]

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -126,7 +126,7 @@ fn make_cached_contract_call_vm(
     let fees = Arc::new(RuntimeFeesConfig::test());
     context.prepaid_gas = prepaid_gas;
     let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
-    runtime.run(&mut fake_external, &context, fees, Some(cache))
+    runtime.prepare(&fake_external, &context, Some(cache)).run(&mut fake_external, &context, fees)
 }
 
 #[test]

--- a/runtime/near-vm-runner/src/tests/fuzzers.rs
+++ b/runtime/near-vm-runner/src/tests/fuzzers.rs
@@ -47,6 +47,7 @@ pub fn create_context(method: &str, input: Vec<u8>) -> VMContext {
         predecessor_account_id: "carol".parse().unwrap(),
         method: method.into(),
         input,
+        promise_results: Vec::new().into(),
         block_height: 10,
         block_timestamp: 42,
         epoch_height: 1,
@@ -118,12 +119,10 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMResult {
     config.limit_config.contract_prepare_version = ContractPrepareVersion::V2;
 
     let fees = Arc::new(RuntimeFeesConfig::test());
-    let promise_results = [].into();
     let mut res = vm_kind.runtime(config.into()).unwrap().run(
         &mut fake_external,
         &context,
         Arc::clone(&fees),
-        promise_results,
         None,
     );
 

--- a/runtime/near-vm-runner/src/tests/fuzzers.rs
+++ b/runtime/near-vm-runner/src/tests/fuzzers.rs
@@ -119,12 +119,11 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMResult {
     config.limit_config.contract_prepare_version = ContractPrepareVersion::V2;
 
     let fees = Arc::new(RuntimeFeesConfig::test());
-    let mut res = vm_kind.runtime(config.into()).unwrap().run(
-        &mut fake_external,
-        &context,
-        Arc::clone(&fees),
-        None,
-    );
+    let mut res = vm_kind
+        .runtime(config.into())
+        .unwrap()
+        .prepare(&fake_external, &context, None)
+        .run(&mut fake_external, &context, Arc::clone(&fees));
 
     // Remove the VMError message details as they can differ between runtimes
     // TODO: maybe there's actually things we could check for equality here too?

--- a/runtime/near-vm-runner/src/tests/fuzzers.rs
+++ b/runtime/near-vm-runner/src/tests/fuzzers.rs
@@ -39,12 +39,13 @@ pub fn find_entry_point(contract: &ContractCode) -> Option<String> {
     None
 }
 
-pub fn create_context(input: Vec<u8>) -> VMContext {
+pub fn create_context(method: &str, input: Vec<u8>) -> VMContext {
     VMContext {
         current_account_id: "alice".parse().unwrap(),
         signer_account_id: "bob".parse().unwrap(),
         signer_account_pk: vec![0, 1, 2, 3, 4],
         predecessor_account_id: "carol".parse().unwrap(),
+        method: method.into(),
         input,
         block_height: 10,
         block_timestamp: 42,
@@ -108,7 +109,8 @@ impl fmt::Debug for ArbitraryModule {
 
 fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMResult {
     let mut fake_external = MockedExternal::with_code(code.clone_for_tests());
-    let mut context = create_context(vec![]);
+    let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
+    let mut context = create_context(&method_name, vec![]);
     context.prepaid_gas = 10u64.pow(14);
 
     let mut config = test_vm_config();
@@ -117,9 +119,7 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMResult {
 
     let fees = Arc::new(RuntimeFeesConfig::test());
     let promise_results = [].into();
-    let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
     let mut res = vm_kind.runtime(config.into()).unwrap().run(
-        &method_name,
         &mut fake_external,
         &context,
         Arc::clone(&fees),

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -55,12 +55,11 @@ pub fn test_read_write() {
     with_vm_variants(&config, |vm_kind: VMKind| {
         let code = test_contract(vm_kind);
         let mut fake_external = MockedExternal::with_code(code);
-        let context = create_context(encode(&[10u64, 20u64]));
+        let context = create_context("write_key_value", encode(&[10u64, 20u64]));
 
         let promise_results = [].into();
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
         let result = runtime.run(
-            "write_key_value",
             &mut fake_external,
             &context,
             Arc::clone(&fees),
@@ -69,15 +68,9 @@ pub fn test_read_write() {
         );
         assert_run_result(result, 0);
 
-        let context = create_context(encode(&[10u64]));
-        let result = runtime.run(
-            "read_value",
-            &mut fake_external,
-            &context,
-            Arc::clone(&fees),
-            promise_results,
-            None,
-        );
+        let context = create_context("read_value", encode(&[10u64]));
+        let result =
+            runtime.run(&mut fake_external, &context, Arc::clone(&fees), promise_results, None);
         assert_run_result(result, 20);
     });
 }
@@ -125,11 +118,11 @@ fn run_test_ext(
     fake_external.validators =
         validators.into_iter().map(|(s, b)| (s.parse().unwrap(), b)).collect();
     let fees = Arc::new(RuntimeFeesConfig::test());
-    let context = create_context(input.to_vec());
+    let context = create_context(method, input.to_vec());
     let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
 
     let outcome = runtime
-        .run(method, &mut fake_external, &context, Arc::clone(&fees), [].into(), None)
+        .run(&mut fake_external, &context, Arc::clone(&fees), [].into(), None)
         .unwrap_or_else(|err| panic!("Failed execution: {:?}", err));
 
     assert_eq!(outcome.profile.action_gas(), 0);
@@ -230,12 +223,12 @@ pub fn test_out_of_memory() {
 
         let code = test_contract(vm_kind);
         let mut fake_external = MockedExternal::with_code(code);
-        let context = create_context(Vec::new());
+        let context = create_context("out_of_memory", Vec::new());
         let fees = Arc::new(RuntimeFeesConfig::free());
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
         let promise_results = [].into();
         let result = runtime
-            .run("out_of_memory", &mut fake_external, &context, fees, promise_results, None)
+            .run(&mut fake_external, &context, fees, promise_results, None)
             .expect("execution failed");
         assert_eq!(
             result.aborted,
@@ -254,7 +247,7 @@ fn function_call_weight_contract() -> ContractCode {
 
 #[test]
 fn attach_unspent_gas_but_use_all_gas() {
-    let mut context = create_context(vec![]);
+    let mut context = create_context("attach_unspent_gas_but_use_all_gas", vec![]);
     context.prepaid_gas = 100 * 10u64.pow(12);
 
     let mut config = test_vm_config();
@@ -268,14 +261,7 @@ fn attach_unspent_gas_but_use_all_gas() {
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
 
         let outcome = runtime
-            .run(
-                "attach_unspent_gas_but_use_all_gas",
-                &mut external,
-                &context,
-                fees,
-                [].into(),
-                None,
-            )
+            .run(&mut external, &context, fees, [].into(), None)
             .unwrap_or_else(|err| panic!("Failed execution: {:?}", err));
 
         let err = outcome.aborted.as_ref().unwrap();

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -57,20 +57,12 @@ pub fn test_read_write() {
         let mut fake_external = MockedExternal::with_code(code);
         let context = create_context("write_key_value", encode(&[10u64, 20u64]));
 
-        let promise_results = [].into();
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
-        let result = runtime.run(
-            &mut fake_external,
-            &context,
-            Arc::clone(&fees),
-            Arc::clone(&promise_results),
-            None,
-        );
+        let result = runtime.run(&mut fake_external, &context, Arc::clone(&fees), None);
         assert_run_result(result, 0);
 
         let context = create_context("read_value", encode(&[10u64]));
-        let result =
-            runtime.run(&mut fake_external, &context, Arc::clone(&fees), promise_results, None);
+        let result = runtime.run(&mut fake_external, &context, Arc::clone(&fees), None);
         assert_run_result(result, 20);
     });
 }
@@ -122,7 +114,7 @@ fn run_test_ext(
     let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
 
     let outcome = runtime
-        .run(&mut fake_external, &context, Arc::clone(&fees), [].into(), None)
+        .run(&mut fake_external, &context, Arc::clone(&fees), None)
         .unwrap_or_else(|err| panic!("Failed execution: {:?}", err));
 
     assert_eq!(outcome.profile.action_gas(), 0);
@@ -226,10 +218,8 @@ pub fn test_out_of_memory() {
         let context = create_context("out_of_memory", Vec::new());
         let fees = Arc::new(RuntimeFeesConfig::free());
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
-        let promise_results = [].into();
-        let result = runtime
-            .run(&mut fake_external, &context, fees, promise_results, None)
-            .expect("execution failed");
+        let result =
+            runtime.run(&mut fake_external, &context, fees, None).expect("execution failed");
         assert_eq!(
             result.aborted,
             match vm_kind {
@@ -261,7 +251,7 @@ fn attach_unspent_gas_but_use_all_gas() {
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
 
         let outcome = runtime
-            .run(&mut external, &context, fees, [].into(), None)
+            .run(&mut external, &context, fees, None)
             .unwrap_or_else(|err| panic!("Failed execution: {:?}", err));
 
         let err = outcome.aborted.as_ref().unwrap();

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -16,6 +16,7 @@ pub(crate) fn test_builder() -> TestBuilder {
         signer_account_pk: vec![0, 1, 2],
         predecessor_account_id: "carol".parse().unwrap(),
         input: Vec::new(),
+        promise_results: Vec::new().into(),
         method: "main".into(),
         block_height: 10,
         block_timestamp: 42,
@@ -216,14 +217,12 @@ impl TestBuilder {
                 let fees = Arc::new(RuntimeFeesConfig::test());
                 let context = self.context.clone();
 
-                let promise_results = [].into();
-
                 let Some(runtime) = vm_kind.runtime(config) else {
                     panic!("runtime for {:?} has not been compiled", vm_kind);
                 };
                 println!("Running {:?} for protocol version {}", vm_kind, protocol_version);
                 let outcome = runtime
-                    .run(&mut fake_external, &context, fees, promise_results, None)
+                    .run(&mut fake_external, &context, fees, None)
                     .expect("execution failed");
 
                 let mut got = String::new();

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -222,7 +222,8 @@ impl TestBuilder {
                 };
                 println!("Running {:?} for protocol version {}", vm_kind, protocol_version);
                 let outcome = runtime
-                    .run(&mut fake_external, &context, fees, None)
+                    .prepare(&fake_external, &context, None)
+                    .run(&mut fake_external, &context, fees)
                     .expect("execution failed");
 
                 let mut got = String::new();

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -16,6 +16,7 @@ pub(crate) fn test_builder() -> TestBuilder {
         signer_account_pk: vec![0, 1, 2],
         predecessor_account_id: "carol".parse().unwrap(),
         input: Vec::new(),
+        method: "main".into(),
         block_height: 10,
         block_timestamp: 42,
         epoch_height: 1,
@@ -37,7 +38,6 @@ pub(crate) fn test_builder() -> TestBuilder {
     TestBuilder {
         code: ContractCode::new(Vec::new(), None),
         context,
-        method: "main".to_string(),
         protocol_versions: vec![u32::MAX],
         skip,
         opaque_error: false,
@@ -49,7 +49,6 @@ pub(crate) struct TestBuilder {
     code: ContractCode,
     context: VMContext,
     protocol_versions: Vec<ProtocolVersion>,
-    method: String,
     skip: HashSet<VMKind>,
     opaque_error: bool,
     opaque_outcome: bool,
@@ -74,7 +73,7 @@ impl TestBuilder {
     }
 
     pub(crate) fn method(mut self, method: &str) -> Self {
-        self.method = method.to_string();
+        self.context.method = method.to_string();
         self
     }
 
@@ -224,7 +223,7 @@ impl TestBuilder {
                 };
                 println!("Running {:?} for protocol version {}", vm_kind, protocol_version);
                 let outcome = runtime
-                    .run(&self.method, &mut fake_external, &context, fees, promise_results, None)
+                    .run(&mut fake_external, &context, fees, promise_results, None)
                     .expect("execution failed");
 
                 let mut got = String::new();

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -16,14 +16,13 @@ pub fn test_ts_contract() {
     with_vm_variants(&config, |vm_kind: VMKind| {
         let code = ContractCode::new(near_test_contracts::ts_contract().to_vec(), None);
         let mut fake_external = MockedExternal::with_code(code);
-        let context = create_context(Vec::new());
+        let context = create_context("try_panic", Vec::new());
         let fees = Arc::new(RuntimeFeesConfig::test());
 
         // Call method that panics.
         let promise_results = [].into();
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
         let result = runtime.run(
-            "try_panic",
             &mut fake_external,
             &context,
             Arc::clone(&fees),
@@ -39,10 +38,9 @@ pub fn test_ts_contract() {
         );
 
         // Call method that writes something into storage.
-        let context = create_context(b"foo bar".to_vec());
+        let context = create_context("try_storage_write", b"foo bar".to_vec());
         runtime
             .run(
-                "try_storage_write",
                 &mut fake_external,
                 &context,
                 Arc::clone(&fees),
@@ -60,10 +58,9 @@ pub fn test_ts_contract() {
         }
 
         // Call method that reads the value from storage using registers.
-        let context = create_context(b"foo".to_vec());
+        let context = create_context("try_storage_read", b"foo".to_vec());
         let outcome = runtime
             .run(
-                "try_storage_read",
                 &mut fake_external,
                 &context,
                 Arc::clone(&fees),

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -21,7 +21,11 @@ pub fn test_ts_contract() {
 
         // Call method that panics.
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
-        let result = runtime.run(&mut fake_external, &context, Arc::clone(&fees), None);
+        let result = runtime.prepare(&fake_external, &context, None).run(
+            &mut fake_external,
+            &context,
+            Arc::clone(&fees),
+        );
         let outcome = result.expect("execution failed");
         assert_eq!(
             outcome.aborted,
@@ -32,7 +36,11 @@ pub fn test_ts_contract() {
 
         // Call method that writes something into storage.
         let context = create_context("try_storage_write", b"foo bar".to_vec());
-        runtime.run(&mut fake_external, &context, Arc::clone(&fees), None).expect("bad failure");
+        let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
+        runtime
+            .prepare(&fake_external, &context, None)
+            .run(&mut fake_external, &context, Arc::clone(&fees))
+            .expect("bad failure");
         // Verify by looking directly into the storage of the host.
         {
             let res = fake_external.storage_get(b"foo", StorageGetMode::Trie);
@@ -44,8 +52,10 @@ pub fn test_ts_contract() {
 
         // Call method that reads the value from storage using registers.
         let context = create_context("try_storage_read", b"foo".to_vec());
+        let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
         let outcome = runtime
-            .run(&mut fake_external, &context, Arc::clone(&fees), None)
+            .prepare(&fake_external, &context, None)
+            .run(&mut fake_external, &context, Arc::clone(&fees))
             .expect("execution failed");
 
         if let ReturnData::Value(value) = outcome.return_data {

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -20,15 +20,8 @@ pub fn test_ts_contract() {
         let fees = Arc::new(RuntimeFeesConfig::test());
 
         // Call method that panics.
-        let promise_results = [].into();
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
-        let result = runtime.run(
-            &mut fake_external,
-            &context,
-            Arc::clone(&fees),
-            Arc::clone(&promise_results),
-            None,
-        );
+        let result = runtime.run(&mut fake_external, &context, Arc::clone(&fees), None);
         let outcome = result.expect("execution failed");
         assert_eq!(
             outcome.aborted,
@@ -39,15 +32,7 @@ pub fn test_ts_contract() {
 
         // Call method that writes something into storage.
         let context = create_context("try_storage_write", b"foo bar".to_vec());
-        runtime
-            .run(
-                &mut fake_external,
-                &context,
-                Arc::clone(&fees),
-                Arc::clone(&promise_results),
-                None,
-            )
-            .expect("bad failure");
+        runtime.run(&mut fake_external, &context, Arc::clone(&fees), None).expect("bad failure");
         // Verify by looking directly into the storage of the host.
         {
             let res = fake_external.storage_get(b"foo", StorageGetMode::Trie);
@@ -60,13 +45,7 @@ pub fn test_ts_contract() {
         // Call method that reads the value from storage using registers.
         let context = create_context("try_storage_read", b"foo".to_vec());
         let outcome = runtime
-            .run(
-                &mut fake_external,
-                &context,
-                Arc::clone(&fees),
-                Arc::clone(&promise_results),
-                None,
-            )
+            .run(&mut fake_external, &context, Arc::clone(&fees), None)
             .expect("execution failed");
 
         if let ReturnData::Value(value) = outcome.return_data {

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -4,7 +4,6 @@ use crate::logic::errors::{
     CacheError, CompilationError, FunctionCallError, MethodResolveError, VMRunnerError, WasmTrap,
 };
 use crate::logic::gas_counter::FastGasCounter;
-use crate::logic::types::PromiseResult;
 use crate::logic::{
     Config, ExecutionResultState, External, MemSlice, MemoryLike, VMContext, VMLogic, VMOutcome,
 };
@@ -569,7 +568,6 @@ impl crate::runner::VM for Wasmer2VM {
         ext: &mut dyn External,
         context: &VMContext,
         fees_config: Arc<RuntimeFeesConfig>,
-        promise_results: Arc<[PromiseResult]>,
         cache: Option<&dyn ContractRuntimeCache>,
     ) -> Result<VMOutcome, VMRunnerError> {
         let Some(code) = ext.get_contract() else {
@@ -611,8 +609,7 @@ impl crate::runner::VM for Wasmer2VM {
         // FIXME: this mostly duplicates the `run_module` method.
         // Note that we don't clone the actual backing memory, just increase the RC.
         let vmmemory = memory.vm();
-        let mut logic =
-            VMLogic::new(ext, context, fees_config, promise_results, result_state, memory);
+        let mut logic = VMLogic::new(ext, context, fees_config, result_state, memory);
         let import =
             build_imports(vmmemory, &mut logic, Arc::clone(&self.config), artifact.engine());
         match self.run_method(&artifact, import, entrypoint)? {

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -566,7 +566,6 @@ impl wasmer_vm::Tunables for &Wasmer2VM {
 impl crate::runner::VM for Wasmer2VM {
     fn run(
         &self,
-        method_name: &str,
         ext: &mut dyn External,
         context: &VMContext,
         fees_config: Arc<RuntimeFeesConfig>,
@@ -578,7 +577,8 @@ impl crate::runner::VM for Wasmer2VM {
         };
         let mut result_state = ExecutionResultState::new(&context, Arc::clone(&self.config));
 
-        let result = result_state.before_loading_executable(method_name, code.code().len() as u64);
+        let result =
+            result_state.before_loading_executable(&context.method, code.code().len() as u64);
         if let Err(e) = result {
             return Ok(VMOutcome::abort(result_state, e));
         }
@@ -598,7 +598,7 @@ impl crate::runner::VM for Wasmer2VM {
         if let Err(e) = result {
             return Ok(VMOutcome::abort(result_state, e));
         }
-        let entrypoint = match get_entrypoint_index(&*artifact, method_name) {
+        let entrypoint = match get_entrypoint_index(&*artifact, &context.method) {
             Ok(index) => index,
             Err(e) => return Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(result_state, e)),
         };

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -632,6 +632,7 @@ impl crate::runner::VM for Wasmer2VM {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum PreparedContract {
     Outcome(VMOutcome),
     Ready {

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -3,7 +3,6 @@ use crate::errors::ContractPrecompilatonResult;
 use crate::logic::errors::{
     CacheError, CompilationError, FunctionCallError, MethodResolveError, VMRunnerError, WasmTrap,
 };
-use crate::logic::types::PromiseResult;
 use crate::logic::{ExecutionResultState, External, VMContext, VMLogic, VMLogicError, VMOutcome};
 use crate::logic::{MemSlice, MemoryLike};
 use crate::prepare;
@@ -420,7 +419,6 @@ impl crate::runner::VM for Wasmer0VM {
         ext: &mut dyn External,
         context: &VMContext,
         fees_config: Arc<RuntimeFeesConfig>,
-        promise_results: std::sync::Arc<[PromiseResult]>,
         cache: Option<&dyn ContractRuntimeCache>,
     ) -> Result<VMOutcome, VMRunnerError> {
         let Some(code) = ext.get_contract() else {
@@ -478,8 +476,7 @@ impl crate::runner::VM for Wasmer0VM {
         );
         // Note that we don't clone the actual backing memory, just increase the RC.
         let memory_copy = memory.clone();
-        let mut logic =
-            VMLogic::new(ext, context, fees_config, promise_results, execution_state, memory);
+        let mut logic = VMLogic::new(ext, context, fees_config, execution_state, memory);
         let import_object = build_imports(memory_copy, &self.config, &mut logic);
         match run_method(&module, &import_object, &context.method)? {
             Ok(()) => Ok(VMOutcome::ok(logic.result_state)),

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -472,9 +472,7 @@ impl crate::runner::VM for Wasmer0VM {
                     FunctionCallError::CompilationError(err),
                 ))))
             }
-            Err(err) => {
-                return Box::new(Result::Err(err))
-            }
+            Err(err) => return Box::new(Result::Err(err)),
         };
 
         let result = result_state.after_loading_executable(code.code().len() as u64);
@@ -495,6 +493,7 @@ impl crate::runner::VM for Wasmer0VM {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum PreparedContract {
     Outcome(VMOutcome),
     Ready {

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -337,6 +337,7 @@ impl crate::runner::VM for WasmtimeVM {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum PreparedContract {
     Outcome(VMOutcome),
     Ready {

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -3,7 +3,6 @@ use crate::logic::errors::{
     CacheError, CompilationError, FunctionCallError, MethodResolveError, PrepareError,
     VMLogicError, VMRunnerError, WasmTrap,
 };
-use crate::logic::types::PromiseResult;
 use crate::logic::{Config, ExecutionResultState};
 use crate::logic::{External, MemSlice, MemoryLike, VMContext, VMLogic, VMOutcome};
 use crate::runner::VMResult;
@@ -275,7 +274,6 @@ impl crate::runner::VM for WasmtimeVM {
         ext: &mut dyn External,
         context: &VMContext,
         fees_config: Arc<RuntimeFeesConfig>,
-        promise_results: Arc<[PromiseResult]>,
         cache: Option<&dyn ContractRuntimeCache>,
     ) -> Result<VMOutcome, VMRunnerError> {
         let cache = cache.unwrap_or(&NoContractRuntimeCache);
@@ -318,8 +316,7 @@ impl crate::runner::VM for WasmtimeVM {
             )
             .unwrap();
             let memory_copy = memory.0;
-            let mut logic =
-                VMLogic::new(ext, context, fees_config, promise_results, result_state, memory);
+            let mut logic = VMLogic::new(ext, context, fees_config, result_state, memory);
             let mut linker = Linker::new(&(&self.engine));
             link(&mut linker, memory_copy, &store, &self.config, &mut logic);
             match linker.instantiate(&mut store, &module) {

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -72,14 +72,13 @@ fn compute_function_call_cost(
     let runtime = vm_kind.runtime(vm_config).expect("runtime has not been enabled");
     let fees = runtime_config.fees.clone();
     let mut fake_external = MockedExternal::with_code(contract.clone_for_tests());
-    let fake_context = create_context(vec![]);
+    let fake_context = create_context("hello0", vec![]);
     let promise_results = Arc::from([]);
 
     // Warmup.
     for _ in 0..warmup_repeats {
         let result = runtime
             .run(
-                "hello0",
                 &mut fake_external,
                 &fake_context,
                 Arc::clone(&fees),
@@ -94,7 +93,6 @@ fn compute_function_call_cost(
     for _ in 0..repeats {
         let result = runtime
             .run(
-                "hello0",
                 &mut fake_external,
                 &fake_context,
                 Arc::clone(&fees),

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -73,18 +73,11 @@ fn compute_function_call_cost(
     let fees = runtime_config.fees.clone();
     let mut fake_external = MockedExternal::with_code(contract.clone_for_tests());
     let fake_context = create_context("hello0", vec![]);
-    let promise_results = Arc::from([]);
 
     // Warmup.
     for _ in 0..warmup_repeats {
         let result = runtime
-            .run(
-                &mut fake_external,
-                &fake_context,
-                Arc::clone(&fees),
-                Arc::clone(&promise_results),
-                cache,
-            )
+            .run(&mut fake_external, &fake_context, Arc::clone(&fees), cache)
             .expect("fatal error");
         assert!(result.aborted.is_none());
     }
@@ -92,13 +85,7 @@ fn compute_function_call_cost(
     let start = GasCost::measure(gas_metric);
     for _ in 0..repeats {
         let result = runtime
-            .run(
-                &mut fake_external,
-                &fake_context,
-                Arc::clone(&fees),
-                Arc::clone(&promise_results),
-                cache,
-            )
+            .run(&mut fake_external, &fake_context, Arc::clone(&fees), cache)
             .expect("fatal_error");
         assert!(result.aborted.is_none());
     }

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -141,18 +141,11 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     let fees = runtime_config.fees.clone();
     let mut fake_external = MockedExternal::with_code(contract.clone_for_tests());
     let fake_context = create_context("hello", vec![]);
-    let promise_results = Arc::from([]);
 
     // Warmup with gas metering
     for _ in 0..warmup_repeats {
         let result = runtime
-            .run(
-                &mut fake_external,
-                &fake_context,
-                Arc::clone(&fees),
-                Arc::clone(&promise_results),
-                cache,
-            )
+            .run(&mut fake_external, &fake_context, Arc::clone(&fees), cache)
             .expect("fatal_error");
         if let Some(err) = &result.aborted {
             eprintln!("error: {}", err);
@@ -164,13 +157,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     let start = GasCost::measure(gas_metric);
     for _ in 0..repeats {
         let result = runtime
-            .run(
-                &mut fake_external,
-                &fake_context,
-                Arc::clone(&fees),
-                Arc::clone(&promise_results),
-                cache,
-            )
+            .run(&mut fake_external, &fake_context, Arc::clone(&fees), cache)
             .expect("fatal_error");
         assert!(result.aborted.is_none());
     }
@@ -179,13 +166,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     // Warmup without gas metering
     for _ in 0..warmup_repeats {
         let result = runtime_free_gas
-            .run(
-                &mut fake_external,
-                &fake_context,
-                Arc::clone(&fees),
-                Arc::clone(&promise_results),
-                cache,
-            )
+            .run(&mut fake_external, &fake_context, Arc::clone(&fees), cache)
             .expect("fatal_error");
         assert!(result.aborted.is_none());
     }
@@ -194,13 +175,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     let start = GasCost::measure(gas_metric);
     for _ in 0..repeats {
         let result = runtime_free_gas
-            .run(
-                &mut fake_external,
-                &fake_context,
-                Arc::clone(&fees),
-                Arc::clone(&promise_results),
-                cache,
-            )
+            .run(&mut fake_external, &fake_context, Arc::clone(&fees), cache)
             .expect("fatal_error");
         assert!(result.aborted.is_none());
     }

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -140,14 +140,13 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     let runtime_free_gas = vm_kind.runtime(vm_config_free).expect("runtime has not been enabled");
     let fees = runtime_config.fees.clone();
     let mut fake_external = MockedExternal::with_code(contract.clone_for_tests());
-    let fake_context = create_context(vec![]);
+    let fake_context = create_context("hello", vec![]);
     let promise_results = Arc::from([]);
 
     // Warmup with gas metering
     for _ in 0..warmup_repeats {
         let result = runtime
             .run(
-                "hello",
                 &mut fake_external,
                 &fake_context,
                 Arc::clone(&fees),
@@ -166,7 +165,6 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     for _ in 0..repeats {
         let result = runtime
             .run(
-                "hello",
                 &mut fake_external,
                 &fake_context,
                 Arc::clone(&fees),
@@ -182,7 +180,6 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     for _ in 0..warmup_repeats {
         let result = runtime_free_gas
             .run(
-                "hello",
                 &mut fake_external,
                 &fake_context,
                 Arc::clone(&fees),
@@ -198,7 +195,6 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     for _ in 0..repeats {
         let result = runtime_free_gas
             .run(
-                "hello",
                 &mut fake_external,
                 &fake_context,
                 Arc::clone(&fees),

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -896,7 +896,8 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
         let vm_result = vm_kind
             .runtime(config.clone())
             .unwrap()
-            .run(&mut fake_external, &context, Arc::clone(&fees), Some(&cache))
+            .prepare(&fake_external, &context, Some(&cache))
+            .run(&mut fake_external, &context, Arc::clone(&fees))
             .expect("fatal_error");
         assert!(vm_result.aborted.is_some());
         vm_result

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -889,7 +889,6 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
     let config_store = RuntimeConfigStore::new(None);
     let config = config_store.get_config(PROTOCOL_VERSION).wasm_config.clone();
     let fees = Arc::new(RuntimeFeesConfig::test());
-    let promise_results = [].into();
     let cache = MockContractRuntimeCache::default();
 
     let mut run = || {
@@ -897,13 +896,7 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
         let vm_result = vm_kind
             .runtime(config.clone())
             .unwrap()
-            .run(
-                &mut fake_external,
-                &context,
-                Arc::clone(&fees),
-                Arc::clone(&promise_results),
-                Some(&cache),
-            )
+            .run(&mut fake_external, &context, Arc::clone(&fees), Some(&cache))
             .expect("fatal_error");
         assert!(vm_result.aborted.is_some());
         vm_result

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -893,12 +893,11 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
     let cache = MockContractRuntimeCache::default();
 
     let mut run = || {
-        let context = create_context(vec![]);
+        let context = create_context("cpu_ram_soak_test", vec![]);
         let vm_result = vm_kind
             .runtime(config.clone())
             .unwrap()
             .run(
-                "cpu_ram_soak_test",
                 &mut fake_external,
                 &context,
                 Arc::clone(&fees),

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -23,6 +23,7 @@ pub(crate) fn create_context(method: &str, input: Vec<u8>) -> VMContext {
         predecessor_account_id: PREDECESSOR_ACCOUNT_ID.parse().unwrap(),
         method: method.into(),
         input,
+        promise_results: vec![].into(),
         block_height: 10,
         block_timestamp: 42,
         epoch_height: 0,

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -15,12 +15,13 @@ const SIGNER_ACCOUNT_ID: &str = "bob";
 const SIGNER_ACCOUNT_PK: [u8; 3] = [0, 1, 2];
 const PREDECESSOR_ACCOUNT_ID: &str = "carol";
 
-pub(crate) fn create_context(input: Vec<u8>) -> VMContext {
+pub(crate) fn create_context(method: &str, input: Vec<u8>) -> VMContext {
     VMContext {
         current_account_id: CURRENT_ACCOUNT_ID.parse().unwrap(),
         signer_account_id: SIGNER_ACCOUNT_ID.parse().unwrap(),
         signer_account_pk: Vec::from(&SIGNER_ACCOUNT_PK[..]),
         predecessor_account_id: PREDECESSOR_ACCOUNT_ID.parse().unwrap(),
+        method: method.into(),
         input,
         block_height: 10,
         block_timestamp: 42,

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -76,6 +76,7 @@ pub(crate) fn execute_function_call(
         signer_account_pk: borsh::to_vec(&action_receipt.signer_public_key)
             .expect("Failed to serialize"),
         predecessor_account_id: predecessor_id.clone(),
+        method: function_call.method_name.clone(),
         input: function_call.args.clone(),
         block_height: apply_state.block_height,
         block_timestamp: apply_state.block_timestamp,
@@ -102,7 +103,6 @@ pub(crate) fn execute_function_call(
     };
     let mode_guard = runtime_ext.trie_update.with_trie_cache_mode(mode);
     let result = near_vm_runner::run(
-        &function_call.method_name,
         runtime_ext,
         &context,
         Arc::clone(&config.wasm_config),

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -78,6 +78,7 @@ pub(crate) fn execute_function_call(
         predecessor_account_id: predecessor_id.clone(),
         method: function_call.method_name.clone(),
         input: function_call.args.clone(),
+        promise_results,
         block_height: apply_state.block_height,
         block_timestamp: apply_state.block_timestamp,
         epoch_height: apply_state.epoch_height,
@@ -107,7 +108,6 @@ pub(crate) fn execute_function_call(
         &context,
         Arc::clone(&config.wasm_config),
         Arc::clone(&config.fees),
-        promise_results,
         apply_state.cache.as_deref(),
     );
     drop(mode_guard);


### PR DESCRIPTION
This is a very exciting step forward! Finally we got up to the point where we can do some work in preparing the contract to run separately from actual running of the contract. And all of this is encapsulated in a very neat API that gives out `Send + 'static` types for users to pass around between threads or whatever so that they can pipeline these processes.

It will remain to see whether the requirement to have `&External` and `&VMContext` in both calls is a problem, and how much of a problem it is, but that might be very well solvable with some scoped threads or smart use of channels, or even just `Arc<Mutex>`, especially since both of these structures generally tend to be unique to a contract execution...

Part of https://github.com/near/nearcore/issues/11319