### PR TITLE
fix(client): fix overflow in get_extra_sync_block_hashes()

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1847,7 +1847,7 @@ impl ClientActorInner {
                 break;
             };
 
-            if next_header.height() < min_height_included - 1 {
+            if next_header.height() + 1 < min_height_included {
                 break;
             }
 


### PR DESCRIPTION
Subtracting 1 from the smallest chunk height included crashes when it's zero, which can actually happen in many tests, and is currently causing the skip_epoch.py test to fail