### PR TITLE
fix: display correct number of validators in stats logging

### DIFF
--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -1035,6 +1035,13 @@ impl EpochManagerAdapter for MockEpochManager {
 
     #[cfg(feature = "new_epoch_sync")]
     fn force_update_aggregator(&self, _epoch_id: &EpochId, _hash: &CryptoHash) {}
+    
+    fn get_epoch_all_validators(
+        &self,
+        _epoch_id: &EpochId,
+    )-> Result<Vec<ValidatorStake>, EpochError> {
+        Ok(self.validators.iter().map(|(_, v)| v.clone()).collect())
+    }
 }
 
 impl RuntimeAdapter for KeyValueRuntime {

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -1035,11 +1035,11 @@ impl EpochManagerAdapter for MockEpochManager {
 
     #[cfg(feature = "new_epoch_sync")]
     fn force_update_aggregator(&self, _epoch_id: &EpochId, _hash: &CryptoHash) {}
-    
+
     fn get_epoch_all_validators(
         &self,
         _epoch_id: &EpochId,
-    )-> Result<Vec<ValidatorStake>, EpochError> {
+    ) -> Result<Vec<ValidatorStake>, EpochError> {
         Ok(self.validators.iter().map(|(_, v)| v.clone()).collect())
     }
 }

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -9,7 +9,6 @@ use near_client_primitives::types::StateSyncStatus;
 use near_epoch_manager::EpochManagerAdapter;
 use near_network::types::NetworkInfo;
 use near_primitives::block::Tip;
-use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
 use near_primitives::telemetry::{
     TelemetryAgentInfo, TelemetryChainInfo, TelemetryInfo, TelemetrySystemInfo,
@@ -27,7 +26,7 @@ use near_primitives::views::{
 };
 use near_telemetry::TelemetryEvent;
 use std::cmp::min;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fmt::Write;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -289,22 +288,9 @@ impl InfoHelper {
         &mut self,
         epoch_manager: &dyn EpochManagerAdapter,
         epoch_id: &EpochId,
-        last_block_hash: &CryptoHash,
     ) -> usize {
         *self.num_validators_per_epoch.get_or_insert(*epoch_id, || {
-            let block_producers: HashSet<AccountId> = epoch_manager
-                .get_epoch_block_producers_ordered(epoch_id, last_block_hash)
-                .unwrap_or(vec![])
-                .into_iter()
-                .map(|(validator_stake, _)| validator_stake.account_id().clone())
-                .collect();
-            let chunk_producers: HashSet<AccountId> = epoch_manager
-                .get_epoch_chunk_producers(epoch_id)
-                .unwrap_or(vec![])
-                .into_iter()
-                .map(|validator_stake| validator_stake.account_id().clone())
-                .collect();
-            block_producers.union(&chunk_producers).count()
+            epoch_manager.get_epoch_all_validators(epoch_id).unwrap_or_default().len()
         })
     }
 
@@ -323,7 +309,6 @@ impl InfoHelper {
             let num_validators = self.get_num_validators(
                 client.epoch_manager.as_ref(),
                 &head.epoch_id,
-                &head.last_block_hash,
             );
             let account_id = signer.as_ref().map(|x| x.validator_id());
             let is_validator = if let Some(account_id) = account_id {
@@ -923,6 +908,7 @@ mod tests {
     use near_epoch_manager::EpochManager;
     use near_network::test_utils::peer_id_from_seed;
     use near_store::genesis::initialize_genesis_state;
+    use near_primitives::hash::CryptoHash;
 
     #[test]
     fn test_pretty_number() {
@@ -1057,7 +1043,7 @@ mod tests {
         let mut info_helper = InfoHelper::new(Clock::real(), noop().into_sender(), &client_config);
         assert_eq!(
             num_validators,
-            info_helper.get_num_validators(&epoch_manager_adapter, &epoch_id, &last_block_hash)
+            info_helper.get_num_validators(&epoch_manager_adapter, &epoch_id)
         );
     }
 }

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -306,10 +306,8 @@ impl InfoHelper {
         let is_syncing = client.sync_status.is_syncing();
         let head = unwrap_or_return!(client.chain.head());
         let validator_info = if !is_syncing {
-            let num_validators = self.get_num_validators(
-                client.epoch_manager.as_ref(),
-                &head.epoch_id,
-            );
+            let num_validators =
+                self.get_num_validators(client.epoch_manager.as_ref(), &head.epoch_id);
             let account_id = signer.as_ref().map(|x| x.validator_id());
             let is_validator = if let Some(account_id) = account_id {
                 match client.epoch_manager.get_validator_by_account_id(
@@ -907,8 +905,8 @@ mod tests {
     use near_epoch_manager::test_utils::*;
     use near_epoch_manager::EpochManager;
     use near_network::test_utils::peer_id_from_seed;
-    use near_store::genesis::initialize_genesis_state;
     use near_primitives::hash::CryptoHash;
+    use near_store::genesis::initialize_genesis_state;
 
     #[test]
     fn test_pretty_number() {

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -190,6 +190,12 @@ pub trait EpochManagerAdapter: Send + Sync {
         epoch_id: &EpochId,
     ) -> Result<Vec<ValidatorStake>, EpochError>;
 
+    /// Returns all validators for a given epoch.
+    fn get_epoch_all_validators(
+        &self,
+        epoch_id: &EpochId,
+    ) -> Result<Vec<ValidatorStake>, EpochError>;
+
     /// Block producers for given height for the main block. Return EpochError if outside of known boundaries.
     fn get_block_producer(
         &self,
@@ -1126,5 +1132,14 @@ impl EpochManagerAdapter for EpochManagerHandle {
     fn force_update_aggregator(&self, epoch_id: &EpochId, hash: &CryptoHash) {
         let mut epoch_manager = self.write();
         epoch_manager.epoch_info_aggregator = EpochInfoAggregator::new(*epoch_id, *hash);
+    }
+
+    /// Returns the set of chunk validators for a given epoch
+    fn get_epoch_all_validators(
+        &self,
+        epoch_id: &EpochId,
+    ) -> Result<Vec<ValidatorStake>, EpochError> {
+        let epoch_manager = self.read();
+        Ok(epoch_manager.get_epoch_info(epoch_id)?.validators_iter().collect::<Vec<_>>())
     }
 }


### PR DESCRIPTION
The number of validators displayed in the `INFO stats` logging currently does not include chunk validators, which could be misleading post stateless validation launch. This fix works for both before stateless validation and post stateless validation. I verified a fix on a statelessnet node.