### PR TITLE
debug: add new validator roles in debug page and endorsement info

### DIFF
--- a/tools/debug-ui/src/EpochValidatorsView.scss
+++ b/tools/debug-ui/src/EpochValidatorsView.scss
@@ -91,7 +91,7 @@
             border-left: $current-border;
         }
 
-        &:nth-child(10) {
+        &:nth-child(11) {
             border-right: $current-border;
         }
     }
@@ -101,7 +101,8 @@
         &:nth-child(7),
         &:nth-child(8),
         &:nth-child(9),
-        &:nth-child(10) {
+        &:nth-child(10),
+        &:nth-child(11) {
             background-color: #d6ffd0;
         }
     }
@@ -115,4 +116,28 @@
             border-bottom: $current-border;
         }
     }
+}
+
+.validator-role {
+    padding: 4px 8px;
+    border-radius: 8px;
+    color: black;
+    margin: 0px 2px;
+    font-size: 12px;
+    font-weight: bold;
+}
+
+.block-producer {
+    @extend .validator-role;
+    background-color: thistle;
+}
+
+.chunk-producer {
+    @extend .validator-role;
+    background-color: lightblue;
+}
+
+.chunk-validator {
+    @extend .validator-role;
+    background-color: bisque;
 }

--- a/tools/debug-ui/src/EpochValidatorsView.tsx
+++ b/tools/debug-ui/src/EpochValidatorsView.tsx
@@ -9,13 +9,14 @@ interface ProducedAndExpected {
     expected: number;
 }
 
-type ValidatorRole = 'BlockProducer' | 'ChunkOnlyProducer' | 'None';
+type ValidatorRole = 'BlockProducer' | 'ChunkProducer' | 'ChunkValidator';
 
 interface CurrentValidatorInfo {
     stake: number;
     shards: number[];
     blocks: ProducedAndExpected;
     chunks: ProducedAndExpected;
+    endorsements: ProducedAndExpected;
 }
 
 interface NextValidatorInfo {
@@ -29,7 +30,7 @@ interface ValidatorInfo {
     next: NextValidatorInfo | null;
     proposalStake: number | null;
     kickoutReason: ValidatorKickoutReason | null;
-    roles: ValidatorRole[];
+    roles: ValidatorRole[][];
 }
 
 class Validators {
@@ -41,9 +42,9 @@ class Validators {
         if (this.validators.has(accountId)) {
             return this.validators.get(accountId)!;
         }
-        const roles = [] as ValidatorRole[];
+        const roles = [] as ValidatorRole[][];
         for (let i = 0; i < this.numEpochs; i++) {
-            roles.push('None');
+            roles.push([]);
         }
         this.validators.set(accountId, {
             accountId,
@@ -56,9 +57,9 @@ class Validators {
         return this.validators.get(accountId)!;
     }
 
-    setValidatorRole(accountId: string, epochIndex: number, role: ValidatorRole) {
+    addValidatorRole(accountId: string, epochIndex: number, role: ValidatorRole) {
         const validator = this.validator(accountId);
-        validator.roles[epochIndex] = role;
+        validator.roles[epochIndex].push(role);
     }
 
     sorted(): ValidatorInfo[] {
@@ -107,7 +108,8 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
     let maxStake = 0,
         totalStake = 0,
         maxExpectedBlocks = 0,
-        maxExpectedChunks = 0;
+        maxExpectedChunks = 0,
+        maxExpectedEndorsements = 0;
     const epochs = epochData!.status_response.EpochInfo;
     const validators = new Validators(epochs.length);
     const currentValidatorInfo = epochData!.status_response.EpochInfo[1].validator_info;
@@ -125,11 +127,19 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
                 produced: validatorInfo.num_produced_chunks,
                 expected: validatorInfo.num_expected_chunks,
             },
+            endorsements: {
+                produced: validatorInfo.num_produced_endorsements,
+                expected: validatorInfo.num_expected_endorsements,
+            },
         };
         maxStake = Math.max(maxStake, stake);
         totalStake += stake;
         maxExpectedBlocks = Math.max(maxExpectedBlocks, validatorInfo.num_expected_blocks);
         maxExpectedChunks = Math.max(maxExpectedChunks, validatorInfo.num_expected_chunks);
+        maxExpectedEndorsements = Math.max(
+            maxExpectedEndorsements,
+            validatorInfo.num_expected_endorsements
+        );
     }
     for (const validatorInfo of currentValidatorInfo.next_validators) {
         const validator = validators.validator(validatorInfo.account_id);
@@ -147,11 +157,18 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
         validator.kickoutReason = kickout.reason;
     }
     epochs.forEach((epochInfo, index) => {
-        for (const chunkOnlyProducer of epochInfo.chunk_only_producers) {
-            validators.setValidatorRole(chunkOnlyProducer, index, 'ChunkOnlyProducer');
-        }
         for (const blockProducer of epochInfo.block_producers) {
-            validators.setValidatorRole(blockProducer.account_id, index, 'BlockProducer');
+            validators.addValidatorRole(blockProducer.account_id, index, 'BlockProducer');
+        }
+        if (epochInfo.validator_info != null) {
+            for (const validator of epochInfo.validator_info.current_validators) {
+                if (validator.num_expected_chunks > 0) {
+                    validators.addValidatorRole(validator.account_id, index, 'ChunkProducer');
+                }
+                if (validator.num_expected_endorsements > 0) {
+                    validators.addValidatorRole(validator.account_id, index, 'ChunkValidator');
+                }
+            }
         }
     });
 
@@ -161,22 +178,23 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
                 <tr>
                     <th></th>
                     <th colSpan={4}>Next Epoch</th>
-                    <th colSpan={5}>Current Epoch</th>
+                    <th colSpan={6}>Current Epoch</th>
                     <th colSpan={1 + epochs.length - 2}>Past Epochs</th>
                 </tr>
                 <tr>
                     <th>Validator</th>
 
-                    <th className="small-text">Role</th>
+                    <th className="small-text">Roles</th>
                     <th className="small-text">Shards</th>
                     <th>Stake</th>
                     <th>Proposal</th>
 
-                    <th className="small-text">Role</th>
+                    <th className="small-text">Roles</th>
                     <th className="small-text">Shards</th>
                     <th>Stake</th>
                     <th>Blocks</th>
-                    <th>Chunks</th>
+                    <th>Produced Chunks</th>
+                    <th>Endorsed Chunks</th>
 
                     <th>Kickout</th>
                     {epochs.slice(2).map((epoch) => {
@@ -193,14 +211,14 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
                     return (
                         <tr key={validator.accountId}>
                             <td>{validator.accountId}</td>
-                            <td>{renderRole(validator.roles[0])}</td>
+                            <td>{renderRoles(validator.roles[0])}</td>
                             <td>{validator.next?.shards?.join(',') ?? ''}</td>
                             <td>
                                 {drawStakeBar(validator.next?.stake ?? null, maxStake, totalStake)}
                             </td>
                             <td>{drawStakeBar(validator.proposalStake, maxStake, totalStake)}</td>
 
-                            <td>{renderRole(validator.roles[1])}</td>
+                            <td>{renderRoles(validator.roles[1])}</td>
                             <td>{validator.current?.shards?.join(',') ?? ''}</td>
                             <td>
                                 {drawStakeBar(
@@ -221,12 +239,19 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
                                     maxExpectedChunks
                                 )}
                             </td>
+                            <td>
+                                {drawProducedAndExpectedBar(
+                                    validator.current?.endorsements ?? null,
+                                    maxExpectedChunks,
+                                    0.05
+                                )}
+                            </td>
 
                             <td>
                                 <KickoutReason reason={validator.kickoutReason} />
                             </td>
-                            {validator.roles.slice(2).map((role, i) => {
-                                return <td key={i}>{renderRole(role)}</td>;
+                            {validator.roles.slice(2).map((roles, i) => {
+                                return <td key={i}>{renderRoles(roles)}</td>;
                             })}
                         </tr>
                     );
@@ -238,7 +263,8 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
 
 function drawProducedAndExpectedBar(
     producedAndExpected: ProducedAndExpected | null,
-    maxExpected: number
+    maxExpected: number,
+    scale = 1
 ): JSX.Element {
     if (producedAndExpected === null) {
         return <></>;
@@ -263,10 +289,10 @@ function drawProducedAndExpectedBar(
     return (
         <div className="produced-and-expected-bar">
             <div className="produced-count">{produced}</div>
-            <div className="produced" style={{ width: producedWidth }}></div>
+            <div className="produced" style={{ width: producedWidth * scale }}></div>
             {produced !== expected && (
                 <>
-                    <div className="missed" style={{ width: missedWidth }}></div>
+                    <div className="missed" style={{ width: missedWidth * scale }}></div>
                     <div className="missed-count">{expected - produced}</div>
                 </>
             )}
@@ -291,15 +317,22 @@ function drawStakeBar(stake: number | null, maxStake: number, totalStake: number
     );
 }
 
-function renderRole(role: ValidatorRole): JSX.Element {
-    switch (role) {
-        case 'BlockProducer':
-            return <span className="role-block-producer">BP</span>;
-        case 'ChunkOnlyProducer':
-            return <span className="role-chunk-only-producer">CP</span>;
-        default:
-            return <></>;
+function renderRoles(roles: ValidatorRole[]): JSX.Element {
+    const renderedItems = [];
+    for (const role of roles) {
+        switch (role) {
+            case 'BlockProducer':
+                renderedItems.push(<span className="block-producer">BP</span>);
+                break;
+            case 'ChunkProducer':
+                renderedItems.push(<span className="chunk-producer">CP</span>);
+                break;
+            case 'ChunkValidator':
+                renderedItems.push(<span className="chunk-validator">CV</span>);
+                break;
+        }
     }
+    return <>{renderedItems}</>;
 }
 
 const KickoutReason = ({ reason }: { reason: ValidatorKickoutReason | null }) => {

--- a/tools/debug-ui/src/SnapshotHostsView.tsx
+++ b/tools/debug-ui/src/SnapshotHostsView.tsx
@@ -19,7 +19,7 @@ export const SnapshotHostsView = ({ addr }: SnapshotHostsViewProps) => {
         return <div className="error">{(error as Error).stack}</div>;
     }
 
-    let snapshot_hosts = snapshotHosts!.status_response.SnapshotHosts.hosts;
+    const snapshot_hosts = snapshotHosts!.status_response.SnapshotHosts.hosts;
     snapshot_hosts.sort((a, b) => {
         if (a.epoch_height != b.epoch_height) {
             return b.epoch_height - a.epoch_height;

--- a/tools/debug-ui/src/api.tsx
+++ b/tools/debug-ui/src/api.tsx
@@ -204,6 +204,8 @@ export interface CurrentEpochValidatorInfo {
     num_expected_blocks: number;
     num_produced_chunks: number;
     num_expected_chunks: number;
+    num_produced_endorsements: number;
+    num_expected_endorsements: number;
 }
 
 export interface NextEpochValidatorInfo {


### PR DESCRIPTION
Quick change to improve the debug experience of statelessnet. 
Changes are scoped to the EpochInfo/Validators page.

- Validators can now have multiple roles: chunk validator, chunk producer, block producer. **Note**: I haven't included the role `Block validator` from [NEP-509](https://github.com/near/NEPs/pull/509/files) because I don't fully understand if it's useful nor how to compute this role
- Chunks column renamed -> Produced Chunks
- New column -> Endorsed Chunks 
