### PR TITLE
feat(debug): small improvements to validator debug page

### DIFF
--- a/tools/debug-ui/src/EpochValidatorsView.scss
+++ b/tools/debug-ui/src/EpochValidatorsView.scss
@@ -82,37 +82,34 @@
 
         &:nth-child(2),
         &:nth-child(3),
-        &:nth-child(4),
-        &:nth-child(5) {
+        &:nth-child(4) {
             opacity: 0.5;
         }
 
-        &:nth-child(6) {
+        &:nth-child(5) {
             border-left: $current-border;
         }
 
-        &:nth-child(11) {
+        &:nth-child(9) {
             border-right: $current-border;
         }
     }
 
     thead tr:nth-child(2) th {
+        &:nth-child(5),
         &:nth-child(6),
         &:nth-child(7),
         &:nth-child(8),
-        &:nth-child(9),
-        &:nth-child(10),
-        &:nth-child(11) {
+        &:nth-child(9) {
             background-color: #d6ffd0;
         }
     }
 
     tbody tr:last-child td {
+        &:nth-child(5),
         &:nth-child(6),
         &:nth-child(7),
-        &:nth-child(8),
-        &:nth-child(9),
-        &:nth-child(10) {
+        &:nth-child(8) {
             border-bottom: $current-border;
         }
     }

--- a/tools/debug-ui/src/EpochValidatorsView.tsx
+++ b/tools/debug-ui/src/EpochValidatorsView.tsx
@@ -203,11 +203,11 @@ export const EpochValidatorsView = ({ addr }: EpochValidatorViewProps) => {
                 <tr>
                     <th>Validator</th>
 
-                    <th className="small-text">Roles</th>
+                    <th className="small-text">Roles (shards)</th>
                     <th>Stake</th>
                     <th>Proposal</th>
 
-                    <th className="small-text">Roles</th>
+                    <th className="small-text">Roles (shards)</th>
                     <th>Stake</th>
                     <th>Blocks</th>
                     <th>Produced Chunks</th>


### PR DESCRIPTION
Following up on the ideas shared by @Longarithm, I removed the `shards` column and merged the `shards` information into the role of `CP` (chunk producer), recovering some space in the page.

Also fix to display the role CP in the next epoch. 