### PR TITLE
fix: fix CSS border display at the end of the page

### DIFF
--- a/tools/debug-ui/src/EpochValidatorsView.scss
+++ b/tools/debug-ui/src/EpochValidatorsView.scss
@@ -109,7 +109,8 @@
         &:nth-child(5),
         &:nth-child(6),
         &:nth-child(7),
-        &:nth-child(8) {
+        &:nth-child(8),
+        &:nth-child(9) {
             border-bottom: $current-border;
         }
     }


### PR DESCRIPTION
Fixes a little display error of the table bottom border, in the validators debug page.