### PR TITLE
Increase gas cost of sending non-sir receipts to 50 TGas / MiB

### DIFF
--- a/core/parameters/res/runtime_configs/82.yaml
+++ b/core/parameters/res/runtime_configs/82.yaml
@@ -1,0 +1,54 @@
+# Change the cost of sending receipt to another account to 50 TGas / MiB
+
+action_deploy_contract_per_byte: {
+  old: {
+    send_sir: 6_812_999,
+    send_not_sir: 6_812_999,
+    execution: 64_572_944,
+  },
+  new: {
+    send_sir: 6_812_999,
+    send_not_sir: 47_683_715,
+    execution: 64_572_944,
+  }
+}
+action_function_call_per_byte: {
+  old: {
+    send_sir: 2_235_934,
+    send_not_sir: 2_235_934,
+    execution: 2_235_934,
+  },
+  new: {
+    send_sir: 2_235_934,
+    send_not_sir: 47_683_715,
+    execution: 2_235_934,
+  }
+}
+action_add_function_call_key_per_byte: {
+  old: {
+    send_sir: 1_925_331,
+    send_not_sir: 1_925_331,
+    execution: 1_925_331,
+  },
+  new: {
+    send_sir: 1_925_331,
+    send_not_sir: 47_683_715,
+    execution: 1_925_331,
+  }
+}
+data_receipt_creation_per_byte: {
+  old: {
+    send_sir: 17_212_011,
+    send_not_sir: 17_212_011,
+    execution: 17_212_011,
+  },
+  new: {
+    send_sir: 17_212_011,
+    send_not_sir: 47_683_715,
+    execution: 17_212_011,
+  }
+}
+wasm_yield_resume_byte: {
+  old: 17_212_011,
+  new: 47_683_715
+}

--- a/core/parameters/src/config_store.rs
+++ b/core/parameters/src/config_store.rs
@@ -43,6 +43,7 @@ static CONFIG_DIFFS: &[(ProtocolVersion, &str)] = &[
     (80, include_config!("80.yaml")),
     // Stateless Validation.
     (81, include_config!("81.yaml")),
+    (82, include_config!("82.yaml")),
     (129, include_config!("129.yaml")),
     // Introduce ETH-implicit accounts.
     (138, include_config!("138.yaml")),

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__138.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__138.json.snap
@@ -18,7 +18,7 @@ expression: config_view
       },
       "cost_per_byte": {
         "send_sir": 17212011,
-        "send_not_sir": 17212011,
+        "send_not_sir": 47683715,
         "execution": 17212011
       }
     },
@@ -35,7 +35,7 @@ expression: config_view
       },
       "deploy_contract_cost_per_byte": {
         "send_sir": 6812999,
-        "send_not_sir": 6812999,
+        "send_not_sir": 47683715,
         "execution": 64572944
       },
       "function_call_cost": {
@@ -45,7 +45,7 @@ expression: config_view
       },
       "function_call_cost_per_byte": {
         "send_sir": 2235934,
-        "send_not_sir": 2235934,
+        "send_not_sir": 47683715,
         "execution": 2235934
       },
       "transfer_cost": {
@@ -71,7 +71,7 @@ expression: config_view
         },
         "function_call_cost_per_byte": {
           "send_sir": 1925331,
-          "send_not_sir": 1925331,
+          "send_not_sir": 47683715,
           "execution": 1925331
         }
       },

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__82.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__82.json.snap
@@ -179,7 +179,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
     "storage_get_mode": "FlatStorage",
-    "fix_contract_loading_cost": true,
+    "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "math_extension": true,
     "ed25519_verify": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
@@ -18,7 +18,7 @@ expression: config_view
       },
       "cost_per_byte": {
         "send_sir": 17212011,
-        "send_not_sir": 17212011,
+        "send_not_sir": 47683715,
         "execution": 17212011
       }
     },
@@ -35,7 +35,7 @@ expression: config_view
       },
       "deploy_contract_cost_per_byte": {
         "send_sir": 6812999,
-        "send_not_sir": 6812999,
+        "send_not_sir": 47683715,
         "execution": 64572944
       },
       "function_call_cost": {
@@ -45,7 +45,7 @@ expression: config_view
       },
       "function_call_cost_per_byte": {
         "send_sir": 2235934,
-        "send_not_sir": 2235934,
+        "send_not_sir": 47683715,
         "execution": 2235934
       },
       "transfer_cost": {
@@ -71,7 +71,7 @@ expression: config_view
         },
         "function_call_cost_per_byte": {
           "send_sir": 1925331,
-          "send_not_sir": 1925331,
+          "send_not_sir": 47683715,
           "execution": 1925331
         }
       },

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_138.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_138.json.snap
@@ -18,7 +18,7 @@ expression: config_view
       },
       "cost_per_byte": {
         "send_sir": 17212011,
-        "send_not_sir": 17212011,
+        "send_not_sir": 47683715,
         "execution": 17212011
       }
     },
@@ -35,7 +35,7 @@ expression: config_view
       },
       "deploy_contract_cost_per_byte": {
         "send_sir": 6812999,
-        "send_not_sir": 6812999,
+        "send_not_sir": 47683715,
         "execution": 64572944
       },
       "function_call_cost": {
@@ -45,7 +45,7 @@ expression: config_view
       },
       "function_call_cost_per_byte": {
         "send_sir": 2235934,
-        "send_not_sir": 2235934,
+        "send_not_sir": 47683715,
         "execution": 2235934
       },
       "transfer_cost": {
@@ -71,7 +71,7 @@ expression: config_view
         },
         "function_call_cost_per_byte": {
           "send_sir": 1925331,
-          "send_not_sir": 1925331,
+          "send_not_sir": 47683715,
           "execution": 1925331
         }
       },

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_82.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_82.json.snap
@@ -179,7 +179,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
     "storage_get_mode": "FlatStorage",
-    "fix_contract_loading_cost": true,
+    "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "math_extension": true,
     "ed25519_verify": true,

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -169,6 +169,8 @@ pub enum ProtocolFeature {
     ChangePartialWitnessDataPartsRequired,
     /// Increase the `combined_transactions_size_limit` to 4MiB to allow higher throughput.
     BiggerCombinedTransactionLimit,
+    /// Increase gas cost of sending receipt to another account to 50 TGas / MiB
+    HigherSendingCost,
 }
 
 impl ProtocolFeature {
@@ -234,6 +236,7 @@ impl ProtocolFeature {
             | ProtocolFeature::NoChunkOnlyProducers
             | ProtocolFeature::ChangePartialWitnessDataPartsRequired
             | ProtocolFeature::BiggerCombinedTransactionLimit => 81,
+            ProtocolFeature::HigherSendingCost => 82,
 
             // This protocol version is reserved for use in resharding tests. An extra resharding
             // is simulated on top of the latest shard layout in production. Note that later
@@ -269,7 +272,7 @@ const STABLE_PROTOCOL_VERSION: ProtocolVersion = 67;
 /// Largest protocol version supported by the current binary.
 pub const PROTOCOL_VERSION: ProtocolVersion = if cfg!(feature = "statelessnet_protocol") {
     // Current StatelessNet protocol version.
-    81
+    82
 } else if cfg!(feature = "nightly_protocol") {
     // On nightly, pick big enough version to support all features.
     143

--- a/integration-tests/src/tests/runtime/sanity_checks.rs
+++ b/integration-tests/src/tests/runtime/sanity_checks.rs
@@ -152,6 +152,8 @@ fn test_cost_sanity() {
     insta::assert_debug_snapshot!(
         if cfg!(feature = "nightly") {
             "receipts_gas_profile_nightly"
+        } else if cfg!(feature = "statelessnet_protocol") {
+            "receipts_gas_profile_statelessnet_protocol"
         } else {
             "receipts_gas_profile"
         },

--- a/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile.snap
+++ b/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile.snap
@@ -17,7 +17,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "ACTION_COST",
             cost: "ADD_FUNCTION_CALL_KEY_BYTE",
-            gas_used: 9626655,
+            gas_used: 238418575,
         },
         CostGasUsed {
             cost_category: "ACTION_COST",
@@ -42,7 +42,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "ACTION_COST",
             cost: "DEPLOY_CONTRACT_BYTE",
-            gas_used: 231641966,
+            gas_used: 1621246310,
         },
         CostGasUsed {
             cost_category: "ACTION_COST",
@@ -52,7 +52,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "ACTION_COST",
             cost: "FUNCTION_CALL_BYTE",
-            gas_used: 207941862,
+            gas_used: 571524110,
         },
         CostGasUsed {
             cost_category: "ACTION_COST",

--- a/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile.snap
+++ b/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile.snap
@@ -17,7 +17,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "ACTION_COST",
             cost: "ADD_FUNCTION_CALL_KEY_BYTE",
-            gas_used: 238418575,
+            gas_used: 9626655,
         },
         CostGasUsed {
             cost_category: "ACTION_COST",
@@ -42,7 +42,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "ACTION_COST",
             cost: "DEPLOY_CONTRACT_BYTE",
-            gas_used: 1621246310,
+            gas_used: 231641966,
         },
         CostGasUsed {
             cost_category: "ACTION_COST",
@@ -52,7 +52,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "ACTION_COST",
             cost: "FUNCTION_CALL_BYTE",
-            gas_used: 571524110,
+            gas_used: 207941862,
         },
         CostGasUsed {
             cost_category: "ACTION_COST",

--- a/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile_nightly.snap
+++ b/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile_nightly.snap
@@ -17,7 +17,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "ACTION_COST",
             cost: "ADD_FUNCTION_CALL_KEY_BYTE",
-            gas_used: 9626655,
+            gas_used: 238418575,
         },
         CostGasUsed {
             cost_category: "ACTION_COST",
@@ -42,7 +42,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "ACTION_COST",
             cost: "DEPLOY_CONTRACT_BYTE",
-            gas_used: 231641966,
+            gas_used: 1621246310,
         },
         CostGasUsed {
             cost_category: "ACTION_COST",
@@ -52,7 +52,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "ACTION_COST",
             cost: "FUNCTION_CALL_BYTE",
-            gas_used: 207941862,
+            gas_used: 571524110,
         },
         CostGasUsed {
             cost_category: "ACTION_COST",

--- a/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile_statelessnet_protocol.snap
+++ b/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile_statelessnet_protocol.snap
@@ -1,0 +1,500 @@
+---
+source: integration-tests/src/tests/runtime/sanity_checks.rs
+expression: receipts_gas_profile
+---
+[
+    [
+        CostGasUsed {
+            cost_category: "ACTION_COST",
+            cost: "ADD_FULL_ACCESS_KEY",
+            gas_used: 101765125000,
+        },
+        CostGasUsed {
+            cost_category: "ACTION_COST",
+            cost: "ADD_FUNCTION_CALL_KEY_BASE",
+            gas_used: 102217625000,
+        },
+        CostGasUsed {
+            cost_category: "ACTION_COST",
+            cost: "ADD_FUNCTION_CALL_KEY_BYTE",
+            gas_used: 238418575,
+        },
+        CostGasUsed {
+            cost_category: "ACTION_COST",
+            cost: "CREATE_ACCOUNT",
+            gas_used: 7700000000000,
+        },
+        CostGasUsed {
+            cost_category: "ACTION_COST",
+            cost: "DELETE_ACCOUNT",
+            gas_used: 147489000000,
+        },
+        CostGasUsed {
+            cost_category: "ACTION_COST",
+            cost: "DELETE_KEY",
+            gas_used: 94946625000,
+        },
+        CostGasUsed {
+            cost_category: "ACTION_COST",
+            cost: "DEPLOY_CONTRACT_BASE",
+            gas_used: 184765750000,
+        },
+        CostGasUsed {
+            cost_category: "ACTION_COST",
+            cost: "DEPLOY_CONTRACT_BYTE",
+            gas_used: 1621246310,
+        },
+        CostGasUsed {
+            cost_category: "ACTION_COST",
+            cost: "FUNCTION_CALL_BASE",
+            gas_used: 1800000000000,
+        },
+        CostGasUsed {
+            cost_category: "ACTION_COST",
+            cost: "FUNCTION_CALL_BYTE",
+            gas_used: 571524110,
+        },
+        CostGasUsed {
+            cost_category: "ACTION_COST",
+            cost: "NEW_ACTION_RECEIPT",
+            gas_used: 1480548358496,
+        },
+        CostGasUsed {
+            cost_category: "ACTION_COST",
+            cost: "STAKE",
+            gas_used: 141715687500,
+        },
+        CostGasUsed {
+            cost_category: "ACTION_COST",
+            cost: "TRANSFER",
+            gas_used: 230246125000,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "ALT_BN128_G1_MULTIEXP_BASE",
+            gas_used: 713000000000,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "ALT_BN128_G1_MULTIEXP_ELEMENT",
+            gas_used: 320000000000,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "ALT_BN128_G1_SUM_BASE",
+            gas_used: 3000000000,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "ALT_BN128_G1_SUM_ELEMENT",
+            gas_used: 5000000000,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "ALT_BN128_PAIRING_CHECK_BASE",
+            gas_used: 9686000000000,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "ALT_BN128_PAIRING_CHECK_ELEMENT",
+            gas_used: 5102000000000,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "BASE",
+            gas_used: 17209927215,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "CONTRACT_LOADING_BASE",
+            gas_used: 35445963,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "CONTRACT_LOADING_BYTES",
+            gas_used: 0,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "LOG_BASE",
+            gas_used: 7086626100,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "LOG_BYTE",
+            gas_used: 131987910,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "PROMISE_AND_BASE",
+            gas_used: 1465013400,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "PROMISE_AND_PER_PROMISE",
+            gas_used: 87234816,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "PROMISE_RETURN",
+            gas_used: 560152386,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "READ_CACHED_TRIE_NODE",
+            gas_used: 4560000000,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "READ_MEMORY_BASE",
+            gas_used: 182690424000,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "READ_MEMORY_BYTE",
+            gas_used: 4744063584,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "READ_REGISTER_BASE",
+            gas_used: 7551495558,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "READ_REGISTER_BYTE",
+            gas_used: 25034748,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "RIPEMD160_BASE",
+            gas_used: 853675086,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "RIPEMD160_BLOCK",
+            gas_used: 680107584,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "SHA256_BASE",
+            gas_used: 4540970250,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "SHA256_BYTE",
+            gas_used: 120586755,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "STORAGE_HAS_KEY_BASE",
+            gas_used: 108079793250,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "STORAGE_HAS_KEY_BYTE",
+            gas_used: 277117605,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "STORAGE_READ_BASE",
+            gas_used: 112713691500,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "STORAGE_READ_KEY_BYTE",
+            gas_used: 278572797,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "STORAGE_READ_VALUE_BYTE",
+            gas_used: 28055025,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "STORAGE_REMOVE_BASE",
+            gas_used: 106946061000,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "STORAGE_REMOVE_KEY_BYTE",
+            gas_used: 343983456,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "STORAGE_REMOVE_RET_VALUE_BYTE",
+            gas_used: 57657780,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "STORAGE_WRITE_BASE",
+            gas_used: 128393472000,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "STORAGE_WRITE_EVICTED_BYTE",
+            gas_used: 160586535,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "STORAGE_WRITE_KEY_BYTE",
+            gas_used: 281931468,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "STORAGE_WRITE_VALUE_BYTE",
+            gas_used: 310185390,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "TOUCHING_TRIE_NODE",
+            gas_used: 32203911852,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "UTF16_DECODING_BASE",
+            gas_used: 3543313050,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "UTF16_DECODING_BYTE",
+            gas_used: 1635774930,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "UTF8_DECODING_BASE",
+            gas_used: 46676685915,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "UTF8_DECODING_BYTE",
+            gas_used: 98262621423,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "VALIDATOR_STAKE_BASE",
+            gas_used: 911834726400,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "VALIDATOR_TOTAL_STAKE_BASE",
+            gas_used: 911834726400,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "WASM_INSTRUCTION",
+            gas_used: 0,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "WRITE_MEMORY_BASE",
+            gas_used: 19626564027,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "WRITE_MEMORY_BYTE",
+            gas_used: 866159496,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "WRITE_REGISTER_BASE",
+            gas_used: 37251792318,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "WRITE_REGISTER_BYTE",
+            gas_used: 1904583564,
+        },
+    ],
+    [
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "BASE",
+            gas_used: 264768111,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "CONTRACT_LOADING_BASE",
+            gas_used: 35445963,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "CONTRACT_LOADING_BYTES",
+            gas_used: 0,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "WASM_INSTRUCTION",
+            gas_used: 0,
+        },
+    ],
+    [],
+    [
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "BASE",
+            gas_used: 264768111,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "CONTRACT_LOADING_BASE",
+            gas_used: 35445963,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "CONTRACT_LOADING_BYTES",
+            gas_used: 0,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "READ_MEMORY_BASE",
+            gas_used: 2609863200,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "READ_MEMORY_BYTE",
+            gas_used: 11403999,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "UTF8_DECODING_BASE",
+            gas_used: 3111779061,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "UTF8_DECODING_BYTE",
+            gas_used: 874741437,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "WASM_INSTRUCTION",
+            gas_used: 0,
+        },
+    ],
+    [],
+    [
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "CONTRACT_LOADING_BASE",
+            gas_used: 35445963,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "CONTRACT_LOADING_BYTES",
+            gas_used: 0,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "WASM_INSTRUCTION",
+            gas_used: 0,
+        },
+    ],
+    [],
+    [
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "CONTRACT_LOADING_BASE",
+            gas_used: 35445963,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "CONTRACT_LOADING_BYTES",
+            gas_used: 0,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "WASM_INSTRUCTION",
+            gas_used: 0,
+        },
+    ],
+    [],
+    [
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "CONTRACT_LOADING_BASE",
+            gas_used: 35445963,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "CONTRACT_LOADING_BYTES",
+            gas_used: 0,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "WASM_INSTRUCTION",
+            gas_used: 0,
+        },
+    ],
+    [],
+    [],
+    [],
+    [],
+    [],
+    [
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "CONTRACT_LOADING_BASE",
+            gas_used: 70891926,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "CONTRACT_LOADING_BYTES",
+            gas_used: 0,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "WASM_INSTRUCTION",
+            gas_used: 0,
+        },
+    ],
+    [],
+    [],
+    [],
+    [],
+    [
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "CONTRACT_LOADING_BASE",
+            gas_used: 35445963,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "CONTRACT_LOADING_BYTES",
+            gas_used: 0,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "WASM_INSTRUCTION",
+            gas_used: 0,
+        },
+    ],
+    [],
+    [
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "BASE",
+            gas_used: 529536222,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "CONTRACT_LOADING_BASE",
+            gas_used: 35445963,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "CONTRACT_LOADING_BYTES",
+            gas_used: 0,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "WASM_INSTRUCTION",
+            gas_used: 0,
+        },
+        CostGasUsed {
+            cost_category: "WASM_HOST_COST",
+            cost: "WRITE_REGISTER_BASE",
+            gas_used: 2865522486,
+        },
+    ],
+    [],
+    [],
+]


### PR DESCRIPTION
The gas cost of sending receipts between shards is currently too low - it doesn't reflect the limitations caused by network bandwidth. Let's increase the cost of sending a receipt to another account to 50 Tgas / MiB.
The increase is low enough so that it shouldn't break any contracts, while still being a big improvement over the previous situation.

Refs: https://github.com/near/nearcore-private/issues/107