### PR TITLE
Add a way to artificially increase the size of ChunkStateWitness

### DIFF
--- a/chain/chain/src/stateless_validation/metrics.rs
+++ b/chain/chain/src/stateless_validation/metrics.rs
@@ -71,7 +71,7 @@ pub(crate) static CHUNK_STATE_WITNESS_TOTAL_SIZE: Lazy<HistogramVec> = Lazy::new
         "near_chunk_state_witness_total_size",
         "Stateless validation compressed state witness size in bytes",
         &["shard_id"],
-        Some(exponential_buckets(100_000.0, 1.2, 32).unwrap()),
+        Some(exponential_buckets(100_000.0, 1.2, 40).unwrap()),
     )
     .unwrap()
 });
@@ -81,7 +81,7 @@ pub(crate) static CHUNK_STATE_WITNESS_RAW_SIZE: Lazy<HistogramVec> = Lazy::new(|
         "near_chunk_state_witness_raw_size",
         "Stateless validation uncompressed (raw) state witness size in bytes",
         &["shard_id"],
-        Some(exponential_buckets(100_000.0, 1.2, 32).unwrap()),
+        Some(exponential_buckets(100_000.0, 1.2, 40).unwrap()),
     )
     .unwrap()
 });

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -74,6 +74,7 @@ near-actix-test-utils.workspace = true
 # if enabled, we assert in most situations that are impossible unless some byzantine behavior is observed.
 byzantine_asserts = ["near-chain/byzantine_asserts"]
 shadow_chunk_validation = ["near-chain/shadow_chunk_validation"]
+artificial_witness_size = []
 expensive_tests = []
 test_features = [
   "near-network/test_features",

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -219,6 +219,10 @@ impl Client {
             .config
             .produce_chunk_add_transactions_time_limit
             .update(update_client_config.produce_chunk_add_transactions_time_limit);
+        is_updated |= self
+            .config
+            .artificial_witness_size_to_add
+            .update(update_client_config.artificial_witness_size_to_add);
         is_updated
     }
 

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -483,6 +483,10 @@ pub struct ClientConfig {
     /// which can cause extra load on the database. This option is not recommended for production use,
     /// as a large number of incoming witnesses could cause denial of service.
     pub save_latest_witnesses: bool,
+    /// Add this much artifical data to all produced instances of ChunkStateWitness.
+    /// Data is added by injecting a dummy transaction with random contract code of desired size.
+    /// Has effect only when the `artificial_witness_size` feature is enabled in the binary.
+    pub artificial_witness_size_to_add: MutableConfigValue<ByteSize>,
 }
 
 impl ClientConfig {
@@ -570,6 +574,10 @@ impl ClientConfig {
             orphan_state_witness_pool_size: default_orphan_state_witness_pool_size(),
             orphan_state_witness_max_size: default_orphan_state_witness_max_size(),
             save_latest_witnesses: false,
+            artificial_witness_size_to_add: MutableConfigValue::new(
+                ByteSize::b(0),
+                "artificial_witness_size_to_add",
+            ),
         }
     }
 }

--- a/core/chain-configs/src/updateable_config.rs
+++ b/core/chain-configs/src/updateable_config.rs
@@ -1,3 +1,4 @@
+use bytesize::ByteSize;
 use near_primitives::types::BlockHeight;
 use near_primitives::validator_signer::ValidatorSigner;
 #[cfg(feature = "metrics")]
@@ -108,6 +109,11 @@ pub struct UpdateableClientConfig {
     #[serde(default)]
     #[serde(with = "near_time::serde_opt_duration_as_std")]
     pub produce_chunk_add_transactions_time_limit: Option<Duration>,
+
+    /// Add this much artifical data to all produced instances of ChunkStateWitness.
+    /// Data is added by injecting a dummy transaction with random contract code of desired size.
+    /// Has effect only when the `artificial_witness_size` feature is enabled in the binary.
+    pub artificial_witness_size_to_add: ByteSize,
 }
 
 pub type MutableValidatorSigner = MutableConfigValue<Option<Arc<ValidatorSigner>>>;

--- a/core/primitives/src/stateless_validation.rs
+++ b/core/primitives/src/stateless_validation.rs
@@ -18,11 +18,13 @@ use near_primitives_core::version::{ProtocolFeature, PROTOCOL_VERSION};
 
 /// Represents max allowed size of the compressed state witness,
 /// corresponds to EncodedChunkStateWitness struct size.
-pub const MAX_COMPRESSED_STATE_WITNESS_SIZE: ByteSize = ByteSize::mib(32);
+pub const MAX_COMPRESSED_STATE_WITNESS_SIZE: ByteSize =
+    if cfg!(feature = "aritficial_witness_size") { ByteSize::mib(256) } else { ByteSize::mib(32) };
 
 /// Represents max allowed size of the raw (not compressed) state witness,
 /// corresponds to the size of borsh-serialized ChunkStateWitness.
-pub const MAX_UNCOMPRESSED_STATE_WITNESS_SIZE: ByteSize = ByteSize::mib(64);
+pub const MAX_UNCOMPRESSED_STATE_WITNESS_SIZE: ByteSize =
+    if cfg!(feature = "aritficial_witness_size") { ByteSize::mib(256) } else { ByteSize::mib(64) };
 
 /// An arbitrary static string to make sure that this struct cannot be
 /// serialized to look identical to another serialized struct. For chunk

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -317,6 +317,10 @@ pub struct Config {
     /// which can cause extra load on the database. This option is not recommended for production use,
     /// as a large number of incoming witnesses could cause denial of service.
     pub save_latest_witnesses: bool,
+    /// Add this much artifical data to all produced instances of ChunkStateWitness.
+    /// Data is added by injecting a dummy transaction with random contract code of desired size.
+    /// Has effect only when the `artificial_witness_size` feature is enabled in the binary.
+    pub artificial_witness_size_to_add: ByteSize,
 }
 
 fn is_false(value: &bool) -> bool {
@@ -366,6 +370,7 @@ impl Default for Config {
             orphan_state_witness_max_size: default_orphan_state_witness_max_size(),
             max_loaded_contracts: 256,
             save_latest_witnesses: false,
+            artificial_witness_size_to_add: ByteSize::b(0),
         }
     }
 }
@@ -588,6 +593,10 @@ impl NearConfig {
                 orphan_state_witness_pool_size: config.orphan_state_witness_pool_size,
                 orphan_state_witness_max_size: config.orphan_state_witness_max_size,
                 save_latest_witnesses: config.save_latest_witnesses,
+                artificial_witness_size_to_add: MutableConfigValue::new(
+                    config.artificial_witness_size_to_add,
+                    "artificial_witness_size_to_add",
+                ),
             },
             network_config: NetworkConfig::new(
                 config.network,

--- a/nearcore/src/dyn_config.rs
+++ b/nearcore/src/dyn_config.rs
@@ -63,6 +63,7 @@ pub fn get_updateable_client_config(config: &Config) -> UpdateableClientConfig {
         expected_shutdown: config.expected_shutdown,
         resharding_config: config.resharding_config,
         produce_chunk_add_transactions_time_limit: config.produce_chunk_add_transactions_time_limit,
+        artificial_witness_size_to_add: config.artificial_witness_size_to_add,
     }
 }
 

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -123,6 +123,21 @@ shadow_chunk_validation = [
   "near-client/shadow_chunk_validation",
 ]
 
+# A feature which allows to artificially increase the size of all produced instances of `ChunkStateWitness`.
+# When enabled, the node will read "artificial_witness_size_to_add" from config.json and add this many
+# bytes of data to all produced witnesses. Data is added by injecting a dummy transaction with
+# random contract code of desired size. The injected transaction is automatically removed before witness validation.
+# The feature has to be enabled on all nodes in the network because chunk validators will reject witnesses with
+# the injected transaction when the feature isn't enabled.
+# The extra transaction is only added when "artificial_witness_size_to_add" is larger than zero, so it's safe to
+# go back to using binaries where this feature is disabled.
+#
+# This feature can be used to test how the protocol behaves when witness size gets really large, how much data the
+# witness distribution logic can handle in real-world networks.
+artificial_witness_size = [
+  "near-client/artificial_witness_size",
+]
+
 calimero_zero_storage = [
   "near-primitives/calimero_zero_storage",
 ]


### PR DESCRIPTION
This PR adds a new feature to `neard`: `artificial_witness_size`.
When enabled, the node will read `artificial_witness_size_to_add` from `config.json` and add this many bytes of data to all produced witnesses. Data is added by injecting a dummy transaction with random contract code of desired size. The injected transaction is automatically removed before witness validation.

`artificial_witness_size_to_add` is a `MutableConfigValue` so it can be adjusted on the fly without restarting the node.

The feature has to be enabled on all nodes in the network because normal chunk validators will reject witnesses with the injected transaction when the feature isn't enabled.

Doing it by injecting transactions doesn't change the serialization format, so it's compatible with existing networks.

The extra transaction is only added when `artificial_witness_size_to_add` is larger than zero, so it's safe to go back to using binaries where this feature is disabled by setting `artificial_witness_size_to_add` to zero and then disabling the feature.

We can use it to test how witness distribution behaves at larger sizes and to simulate doomsday scenarios.

I manually tested that the feature works on `localnet` by setting up a 4 node/6 shard localnet and forcing it to send 100 MB witnesses. The network struggled, but it went forward at 0.1 bps.

I increased the number of buckets for witness size because the current ones go only up to 28 MB. After the change they go up to 120 MB.

Refs: https://github.com/near/nearcore/issues/11184