### PR TITLE
feat(testloop) - new testloop features and cc test draft

### DIFF
--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -450,8 +450,7 @@ impl InfoHelper {
             paint(yansi::Color::Blue, machine_info_log),
         );
         if !catchup_status_log.is_empty() {
-            let catchup_status_log = catchup_status_log.replace("\n", " ");
-            info!(target: "stats", "Catchups {}", catchup_status_log);
+            info!(target: "stats", "Catchups\n{}", catchup_status_log);
         }
         if let Some(config_updater) = &config_updater {
             config_updater.report_status();

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -450,7 +450,8 @@ impl InfoHelper {
             paint(yansi::Color::Blue, machine_info_log),
         );
         if !catchup_status_log.is_empty() {
-            info!(target: "stats", "Catchups\n{}", catchup_status_log);
+            let catchup_status_log = catchup_status_log.replace("\n", " ");
+            info!(target: "stats", "Catchups {}", catchup_status_log);
         }
         if let Some(config_updater) = &config_updater {
             config_updater.report_status();

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -89,6 +89,7 @@ test_features = [
   "nearcore/test_features",
   "near-store/test_features",
   "near-vm-runner/test_features",
+  "near-test-contracts/test_features",
 ]
 protocol_feature_fix_contract_loading_cost = [
   "nearcore/protocol_feature_fix_contract_loading_cost",

--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -164,10 +164,11 @@ impl TestLoopBuilder {
         // Configure tracked shards.
         // * single shard tracking for validators
         // * all shard tracking for RPCs
-        let bp_num = genesis.config.num_block_producer_seats;
-        let cp_num = genesis.config.num_chunk_producer_seats;
-        let v_num = genesis.config.num_chunk_validator_seats;
-        let validator_num = bp_num.max(cp_num).max(v_num) as usize;
+        let num_block_producer = genesis.config.num_block_producer_seats;
+        let num_chunk_producer = genesis.config.num_chunk_producer_seats;
+        let num_chunk_validator = genesis.config.num_chunk_validator_seats;
+        let validator_num =
+            num_block_producer.max(num_chunk_producer).max(num_chunk_validator) as usize;
         if idx < validator_num {
             client_config.tracked_shards = Vec::new();
         } else {

--- a/integration-tests/src/test_loop/env.rs
+++ b/integration-tests/src/test_loop/env.rs
@@ -16,12 +16,14 @@ use near_primitives_core::types::BlockHeight;
 use nearcore::state_sync::StateSyncDumper;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use tempfile::TempDir;
 
 const NETWORK_DELAY: Duration = Duration::milliseconds(10);
 
 pub struct TestLoopEnv {
     pub test_loop: TestLoopV2,
     pub datas: Vec<TestData>,
+    pub tempdir: TempDir,
 }
 
 impl TestLoopEnv {
@@ -31,7 +33,7 @@ impl TestLoopEnv {
     /// Needed because for smaller heights blocks may not get all chunks and/or
     /// approvals.
     pub fn warmup(self) -> Self {
-        let Self { mut test_loop, datas } = self;
+        let Self { mut test_loop, datas, tempdir } = self;
 
         let client_handle = datas[0].client_sender.actor_handle();
         let genesis_height = test_loop.data.get(&client_handle).client.chain.genesis().height();
@@ -55,7 +57,7 @@ impl TestLoopEnv {
         }
         test_loop.run_instant();
 
-        Self { test_loop, datas }
+        Self { test_loop, datas, tempdir }
     }
 
     /// Used to finish off remaining events that are still in the loop. This can be necessary if the

--- a/integration-tests/src/test_loop/tests/chunk_validator_kickout.rs
+++ b/integration-tests/src/test_loop/tests/chunk_validator_kickout.rs
@@ -56,7 +56,7 @@ fn run_test_chunk_validator_kickout(select_chunk_validator_only: bool) {
     }
     let genesis = genesis_builder.build();
 
-    let TestLoopEnv { mut test_loop, datas: node_datas } = builder
+    let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } = builder
         .genesis(genesis)
         .clients(clients)
         // Drop only chunks validated by `account_id`.
@@ -97,7 +97,7 @@ fn run_test_chunk_validator_kickout(select_chunk_validator_only: bool) {
         Duration::seconds((5 * epoch_length) as i64),
     );
 
-    TestLoopEnv { test_loop, datas: node_datas }
+    TestLoopEnv { test_loop, datas: node_datas, tempdir }
         .shutdown_and_drain_remaining_events(Duration::seconds(20));
 }
 

--- a/integration-tests/src/test_loop/tests/congestion_control_adv_chunk_produce.rs
+++ b/integration-tests/src/test_loop/tests/congestion_control_adv_chunk_produce.rs
@@ -1,0 +1,150 @@
+use core::panic;
+
+use itertools::Itertools;
+use near_async::test_loop::data::{TestLoopData, TestLoopDataHandle};
+use near_async::test_loop::TestLoopV2;
+use near_async::time::Duration;
+use near_chain_configs::test_genesis::TestGenesisBuilder;
+use near_client::client_actor::ClientActorInner;
+use near_client::test_utils::test_loop::ClientQueries;
+use near_client::Client;
+use near_o11y::testonly::init_test_logger;
+use near_primitives::hash::CryptoHash;
+use near_primitives::types::{AccountId, BlockHeight};
+
+use crate::test_loop::builder::TestLoopBuilder;
+use crate::test_loop::env::{TestData, TestLoopEnv};
+use crate::test_loop::utils::{call_contract, deploy_contracts, ONE_NEAR};
+
+const NUM_PRODUCERS: usize = 2;
+const NUM_VALIDATORS: usize = 2;
+const NUM_RPC: usize = 1;
+const NUM_CLIENTS: usize = NUM_PRODUCERS + NUM_VALIDATORS + NUM_RPC;
+
+/// This test checks that a chunk with too many transactions is rejected by the
+/// chunk validators.
+#[test]
+fn test_congestion_control_adv_chunk_produce() {
+    init_test_logger();
+
+    let builder = TestLoopBuilder::new();
+
+    let initial_balance = 10000 * ONE_NEAR;
+    let accounts =
+        (0..100).map(|i| format!("account{}", i).parse().unwrap()).collect::<Vec<AccountId>>();
+    let clients = accounts.iter().take(NUM_CLIENTS).cloned().collect_vec();
+
+    // split the clients into producers, validators, and rpc nodes
+    let tmp = clients.clone();
+    let (producers, tmp) = tmp.split_at(NUM_PRODUCERS);
+    let (validators, tmp) = tmp.split_at(NUM_VALIDATORS);
+    let (rpcs, tmp) = tmp.split_at(NUM_RPC);
+    assert!(tmp.is_empty());
+
+    let producers = producers.iter().map(|account| account.as_str()).collect_vec();
+    let validators = validators.iter().map(|account| account.as_str()).collect_vec();
+    let [rpc] = rpcs else { panic!("Expected exactly one rpc node") };
+
+    let mut genesis_builder = TestGenesisBuilder::new();
+    genesis_builder
+        .genesis_time_from_clock(&builder.clock())
+        .protocol_version_latest()
+        .genesis_height(10000)
+        .gas_prices_free()
+        .gas_limit_one_petagas()
+        .shard_layout_simple_v1(&["account3", "account5", "account7"])
+        .transaction_validity_period(1000)
+        .epoch_length(10)
+        .validators_desired_roles(&producers, &validators)
+        .shuffle_shard_assignment_for_chunk_producers(true);
+    for account in &accounts {
+        genesis_builder.add_user_account_simple(account.clone(), initial_balance);
+    }
+    let genesis = genesis_builder.build();
+
+    let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } =
+        builder.genesis(genesis).clients(clients).disable_gc().build();
+
+    let first_epoch_tracked_shards = get_tracked_shards(&test_loop, &node_datas);
+    tracing::info!("First epoch tracked shards: {:?}", first_epoch_tracked_shards);
+
+    // Deploy the contracts.
+    let txs = deploy_contracts(&mut test_loop, &node_datas);
+    test_loop.run_for(Duration::seconds(5));
+
+    tracing::info!(target: "test", "deployed contracts");
+    log_txs(&test_loop, &node_datas, &rpc, &txs);
+
+    // Call the contracts.
+    let mut txs = vec![];
+    for account in accounts.iter().take(NUM_PRODUCERS + NUM_VALIDATORS) {
+        let tx = call_contract(&mut test_loop, &node_datas, account);
+        txs.push(tx);
+    }
+    test_loop.run_for(Duration::seconds(20));
+
+    tracing::info!(target: "test", "called contracts");
+    log_txs(&test_loop, &node_datas, &rpc, &txs);
+
+    // Make sure the chain progresses for several epochs.
+    let client_handle = node_datas[0].client_sender.actor_handle();
+    test_loop.run_until(
+        |test_loop_data: &mut TestLoopData| height_condition(test_loop_data, &client_handle, 10050),
+        Duration::seconds(100),
+    );
+
+    let later_epoch_tracked_shards = get_tracked_shards(&test_loop, &node_datas);
+    tracing::info!("Later epoch tracked shards: {:?}", later_epoch_tracked_shards);
+    assert_ne!(first_epoch_tracked_shards, later_epoch_tracked_shards);
+
+    // Give the test a chance to finish off remaining events in the event loop, which can
+    // be important for properly shutting down the nodes.
+    TestLoopEnv { test_loop, datas: node_datas, tempdir }
+        .shutdown_and_drain_remaining_events(Duration::seconds(20));
+}
+
+fn height_condition(
+    test_loop_data: &mut TestLoopData,
+    client_handle: &TestLoopDataHandle<ClientActorInner>,
+    target_height: BlockHeight,
+) -> bool {
+    test_loop_data.get(&client_handle).client.chain.head().unwrap().height > target_height
+}
+
+fn get_tracked_shards(test_loop: &TestLoopV2, node_datas: &Vec<TestData>) -> Vec<Vec<u64>> {
+    let clients = node_datas
+        .iter()
+        .map(|data| &test_loop.data.get(&data.client_sender.actor_handle()).client)
+        .collect_vec();
+    clients.tracked_shards_for_each_client()
+}
+
+fn rpc_client<'a>(
+    test_loop: &'a TestLoopV2,
+    node_datas: &'a Vec<TestData>,
+    rpc: &AccountId,
+) -> &'a Client {
+    for node_data in node_datas {
+        if &node_data.account_id == rpc {
+            let handle = node_data.client_sender.actor_handle();
+            let client_actor = test_loop.data.get(&handle);
+            return &client_actor.client;
+        }
+    }
+    panic!("RPC client not found");
+}
+
+fn log_txs(
+    test_loop: &TestLoopV2,
+    node_datas: &Vec<TestData>,
+    rpc: &AccountId,
+    txs: &Vec<CryptoHash>,
+) {
+    let rpc = rpc_client(test_loop, node_datas, rpc);
+
+    for &tx in txs {
+        let tx_outcome = rpc.chain.get_partial_transaction_result(&tx);
+        let status = tx_outcome.as_ref().map(|o| o.status.clone());
+        tracing::info!(target: "test", ?tx, ?status, "transaction status");
+    }
+}

--- a/integration-tests/src/test_loop/tests/in_memory_tries.rs
+++ b/integration-tests/src/test_loop/tests/in_memory_tries.rs
@@ -47,7 +47,7 @@ fn test_load_memtrie_after_empty_chunks() {
     }
     let genesis = genesis_builder.build();
 
-    let TestLoopEnv { mut test_loop, datas: node_datas } =
+    let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } =
         builder.genesis(genesis).clients(client_accounts).build();
 
     execute_money_transfers(&mut test_loop, &node_datas, &accounts);
@@ -92,6 +92,6 @@ fn test_load_memtrie_after_empty_chunks() {
 
     // Give the test a chance to finish off remaining events in the event loop, which can
     // be important for properly shutting down the nodes.
-    TestLoopEnv { test_loop, datas: node_datas }
+    TestLoopEnv { test_loop, datas: node_datas, tempdir }
         .shutdown_and_drain_remaining_events(Duration::seconds(20));
 }

--- a/integration-tests/src/test_loop/tests/mod.rs
+++ b/integration-tests/src/test_loop/tests/mod.rs
@@ -1,4 +1,5 @@
 mod chunk_validator_kickout;
+pub mod congestion_control_adv_chunk_produce;
 pub mod in_memory_tries;
 pub mod multinode_stateless_validators;
 pub mod multinode_test_loop_example;

--- a/integration-tests/src/test_loop/tests/multinode_stateless_validators.rs
+++ b/integration-tests/src/test_loop/tests/multinode_stateless_validators.rs
@@ -63,7 +63,7 @@ fn test_stateless_validators_with_multi_test_loop() {
     }
     let genesis = genesis_builder.build();
 
-    let TestLoopEnv { mut test_loop, datas: node_datas } =
+    let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } =
         builder.genesis(genesis).clients(clients).build();
 
     // Capture the initial validator info in the first epoch.
@@ -97,7 +97,7 @@ fn test_stateless_validators_with_multi_test_loop() {
 
     // Give the test a chance to finish off remaining events in the event loop, which can
     // be important for properly shutting down the nodes.
-    TestLoopEnv { test_loop, datas: node_datas }
+    TestLoopEnv { test_loop, datas: node_datas, tempdir }
         .shutdown_and_drain_remaining_events(Duration::seconds(20));
 }
 

--- a/integration-tests/src/test_loop/tests/multinode_test_loop_example.rs
+++ b/integration-tests/src/test_loop/tests/multinode_test_loop_example.rs
@@ -38,7 +38,7 @@ fn test_client_with_multi_test_loop() {
     }
     let genesis = genesis_builder.build();
 
-    let TestLoopEnv { mut test_loop, datas: node_datas } =
+    let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } =
         builder.genesis(genesis).clients(clients).build();
 
     let first_epoch_tracked_shards = {
@@ -71,6 +71,6 @@ fn test_client_with_multi_test_loop() {
 
     // Give the test a chance to finish off remaining events in the event loop, which can
     // be important for properly shutting down the nodes.
-    TestLoopEnv { test_loop, datas: node_datas }
+    TestLoopEnv { test_loop, datas: node_datas, tempdir }
         .shutdown_and_drain_remaining_events(Duration::seconds(20));
 }

--- a/integration-tests/src/test_loop/utils.rs
+++ b/integration-tests/src/test_loop/utils.rs
@@ -4,13 +4,17 @@ use near_async::messaging::SendAsync;
 use near_async::test_loop::TestLoopV2;
 use near_async::time::Duration;
 use near_client::test_utils::test_loop::ClientQueries;
+use near_crypto::{KeyType, PublicKey};
 use near_network::client::ProcessTxRequest;
+use near_primitives::hash::CryptoHash;
 use near_primitives::test_utils::create_user_test_signer;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::AccountId;
 use std::collections::HashMap;
 
 pub(crate) const ONE_NEAR: u128 = 1_000_000_000_000_000_000_000_000;
+
+const TGAS: u64 = 1_000_000_000_000;
 
 /// Execute money transfers within given `TestLoop` between given accounts.
 /// Runs chain long enough for the transfers to be optimistically executed.
@@ -89,4 +93,101 @@ pub(crate) fn execute_money_transfers(
             account
         );
     }
+}
+
+/// Deploy the test contracts to all of the provided accounts.
+pub(crate) fn deploy_contracts(
+    test_loop: &mut TestLoopV2,
+    node_datas: &[TestData],
+) -> Vec<CryptoHash> {
+    let block_hash = get_shared_block_hash(node_datas, test_loop);
+
+    let mut txs = vec![];
+    for node_data in node_datas {
+        let account = node_data.account_id.clone();
+
+        let contract = near_test_contracts::rs_contract();
+        let contract_id = format!("contract.{}", account);
+        let signer = create_user_test_signer(&account).into();
+        let public_key = PublicKey::from_seed(KeyType::ED25519, &contract_id);
+        let nonce = 1;
+
+        let transaction = SignedTransaction::create_contract(
+            nonce,
+            account,
+            contract_id.parse().unwrap(),
+            contract.to_vec(),
+            10 * ONE_NEAR,
+            public_key,
+            &signer,
+            block_hash,
+        );
+
+        txs.push(transaction.get_hash());
+
+        let process_tx_request =
+            ProcessTxRequest { transaction, is_forwarded: false, check_only: false };
+        let future = node_data.client_sender.clone().send_async(process_tx_request);
+        drop(future);
+
+        tracing::info!(target: "test", ?contract_id, "deployed contract");
+    }
+    txs
+}
+
+pub fn call_contract(
+    test_loop: &mut TestLoopV2,
+    node_datas: &[TestData],
+    account: &AccountId,
+) -> CryptoHash {
+    let block_hash = get_shared_block_hash(node_datas, test_loop);
+
+    let nonce = 2;
+    let signer = create_user_test_signer(&account);
+    let contract_id = format!("contract.{}", account).parse().unwrap();
+
+    let burn_gas = 250 * TGAS;
+    let attach_gas = 300 * TGAS;
+
+    let deposit = 0;
+    let method_name = "burn_gas_raw".to_owned();
+    let args = burn_gas.to_le_bytes().to_vec();
+
+    let transaction = SignedTransaction::call(
+        nonce,
+        signer.account_id.clone(),
+        contract_id,
+        &signer.into(),
+        deposit,
+        method_name,
+        args,
+        attach_gas,
+        block_hash,
+    );
+
+    let tx_hash = transaction.get_hash();
+
+    let process_tx_request =
+        ProcessTxRequest { transaction, is_forwarded: false, check_only: false };
+    let future = node_datas[0].client_sender.clone().send_async(process_tx_request);
+    drop(future);
+
+    tx_hash
+}
+
+fn get_shared_block_hash(node_datas: &[TestData], test_loop: &mut TestLoopV2) -> CryptoHash {
+    let clients = node_datas
+        .iter()
+        .map(|data| &test_loop.data.get(&data.client_sender.actor_handle()).client)
+        .collect_vec();
+
+    let (_, block_hash) = clients
+        .iter()
+        .map(|client| {
+            let head = client.chain.head().unwrap();
+            (head.height, head.last_block_hash)
+        })
+        .min_by_key(|&(height, _)| height)
+        .unwrap();
+    block_hash
 }

--- a/runtime/near-vm-runner/src/logic/errors.rs
+++ b/runtime/near-vm-runner/src/logic/errors.rs
@@ -58,9 +58,9 @@ pub enum FunctionCallError {
 
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
 pub enum CacheError {
-    #[error("cache read error")]
+    #[error("cache read error: {0}")]
     ReadError(#[source] io::Error),
-    #[error("cache write error")]
+    #[error("cache write error: {0}")]
     WriteError(#[source] io::Error),
     #[error("cache deserialization error")]
     DeserializationError,


### PR DESCRIPTION
* Added the capability to have RPC nodes that track all shards. 
* Added storing the tempdir for the whole duration of testloop so that the test can do something meaningful in the db e.g. store a contract in the cache
* Added a draft for the congestion control test - for now only deploying and calling some contracts. I'm intentionally separating the test loop specific stuff and the real logic for congestion control test will be added later. 