### PR TITLE
feat: generate large state witness

### DIFF
--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -68,6 +68,8 @@ expensive_tests = []
 test_features = [
   "near-vm-runner/test_features",
   "near-primitives/test_features",
+  "near-store/test_features",
+  "node-runtime/test_features",
 ]
 shadow_chunk_validation = []
 no_cache = ["near-store/no_cache"]

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -1767,6 +1767,7 @@ fn test_prepare_transactions_empty_storage_proof() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "test_features"), ignore)]
 fn test_storage_proof_garbage() {
     if !checked_feature!("stable", StatelessValidationV0, PROTOCOL_VERSION) {
         return;

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -1773,8 +1773,8 @@ fn test_storage_proof_garbage() {
         return;
     }
     let shard_id = 0;
-    let (env, _, _) = get_test_env_with_chain_and_pool();
     let signer = create_test_signer("test1");
+    let env = TestEnv::new(vec![vec![signer.validator_id().clone()]], 100, false);
     let garbage_size_mb = 50usize;
     let receipt = Receipt::V1(ReceiptV1 {
         predecessor_id: signer.validator_id().clone(),

--- a/core/primitives/src/stateless_validation.rs
+++ b/core/primitives/src/stateless_validation.rs
@@ -18,11 +18,16 @@ use near_primitives_core::version::{ProtocolFeature, PROTOCOL_VERSION};
 
 /// Represents max allowed size of the compressed state witness,
 /// corresponds to EncodedChunkStateWitness struct size.
-pub const MAX_COMPRESSED_STATE_WITNESS_SIZE: ByteSize = ByteSize::mib(48);
+/// The value is set to max network message size when `test_features`
+/// is enabled to make it possible to test blockchain behaviour with
+/// arbitrary large witness (see #11703).
+pub const MAX_COMPRESSED_STATE_WITNESS_SIZE: ByteSize =
+    ByteSize::mib(if cfg!(feature = "test_features") { 512 } else { 48 });
 
 /// Represents max allowed size of the raw (not compressed) state witness,
 /// corresponds to the size of borsh-serialized ChunkStateWitness.
-pub const MAX_UNCOMPRESSED_STATE_WITNESS_SIZE: ByteSize = ByteSize::mib(64);
+pub const MAX_UNCOMPRESSED_STATE_WITNESS_SIZE: ByteSize =
+    ByteSize::mib(if cfg!(feature = "test_features") { 512 } else { 64 });
 
 /// An arbitrary static string to make sure that this struct cannot be
 /// serialized to look identical to another serialized struct. For chunk

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -751,6 +751,16 @@ impl Trie {
         }
     }
 
+    pub fn record_storage_garbage(&self, size_mbs: usize) -> bool {
+        let Some(recorder) = &self.recorder else {
+            return false;
+        };
+        let mut data = vec![0u8; (size_mbs as usize) * 1000_000];
+        rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut data);
+        recorder.borrow_mut().record_unaccounted(&CryptoHash::hash_bytes(&data), data.into());
+        true
+    }
+
     /// All access to trie nodes or values must go through this method, so it
     /// can be properly cached and recorded.
     ///

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -751,6 +751,7 @@ impl Trie {
         }
     }
 
+    #[cfg(feature = "test_features")]
     pub fn record_storage_garbage(&self, size_mbs: usize) -> bool {
         let Some(recorder) = &self.recorder else {
             return false;

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -758,7 +758,14 @@ impl Trie {
         };
         let mut data = vec![0u8; (size_mbs as usize) * 1000_000];
         rand::RngCore::fill_bytes(&mut rand::thread_rng(), &mut data);
-        recorder.borrow_mut().record_unaccounted(&CryptoHash::hash_bytes(&data), data.into());
+        // We want to have at most 1 instance of garbage data included per chunk so
+        // that it is possible to generated continuous stream of witnesses with a fixed
+        // size. Using static key achieves that since in case of multiple receipts garbage
+        // data will simply be overwritten, not accumulated.
+        recorder.borrow_mut().record_unaccounted(
+            &CryptoHash::hash_bytes(b"__garbage_data_key_1720025071757228"),
+            data.into(),
+        );
         true
     }
 

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -29,6 +29,10 @@ impl TrieRecorder {
         }
     }
 
+    pub fn record_unaccounted(&mut self, hash: &CryptoHash, node: Arc<[u8]>) {
+        self.recorded.insert(*hash, node);
+    }
+
     pub fn record(&mut self, hash: &CryptoHash, node: Arc<[u8]>) {
         let size = node.len();
         if self.recorded.insert(*hash, node).is_none() {
@@ -51,7 +55,6 @@ impl TrieRecorder {
     }
 
     pub fn recorded_storage_size(&self) -> usize {
-        debug_assert!(self.size == self.recorded.values().map(|v| v.len()).sum::<usize>());
         self.size
     }
 

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -29,6 +29,7 @@ impl TrieRecorder {
         }
     }
 
+    #[cfg(feature = "test_features")]
     pub fn record_unaccounted(&mut self, hash: &CryptoHash, node: Arc<[u8]>) {
         self.recorded.insert(*hash, node);
     }

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -29,7 +29,7 @@ impl TrieRecorder {
         }
     }
 
-    /// Records value without increasing the size.
+    /// Records value without increasing the recorded size.
     /// This is used to bypass witness size checks in order to generate
     /// large witness for testing.
     #[cfg(feature = "test_features")]

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -29,6 +29,9 @@ impl TrieRecorder {
         }
     }
 
+    /// Records value without increasing the size.
+    /// This is used to bypass witness size checks in order to generate
+    /// large witness for testing.
     #[cfg(feature = "test_features")]
     pub fn record_unaccounted(&mut self, hash: &CryptoHash, node: Arc<[u8]>) {
         self.recorded.insert(*hash, node);

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -70,6 +70,7 @@ sandbox = ["near-o11y/sandbox", "near-vm-runner/sandbox"]
 test_features = [
   "near-primitives/test_features",
   "near-vm-runner/test_features",
+  "near-store/test_features",
 ]
 
 [dev-dependencies]

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -189,6 +189,15 @@ pub(crate) fn action_function_call(
         .into());
     }
     state_update.trie.request_code_recording(account_id.clone());
+    if let Some(garbage_size_mbs) = function_call
+        .method_name
+        .strip_prefix("internal_record_storage_garbage_")
+        .and_then(|suf| suf.parse::<usize>().ok())
+    {
+        if state_update.trie.record_storage_garbage(garbage_size_mbs) {
+            tracing::warn!(target: "runtime", %garbage_size_mbs, "Generated storage proof garbage");
+        }
+    }
     let mut receipt_manager = ReceiptManager::default();
     let mut runtime_ext = RuntimeExt::new(
         state_update,

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -189,15 +189,8 @@ pub(crate) fn action_function_call(
         .into());
     }
     state_update.trie.request_code_recording(account_id.clone());
-    if let Some(garbage_size_mbs) = function_call
-        .method_name
-        .strip_prefix("internal_record_storage_garbage_")
-        .and_then(|suf| suf.parse::<usize>().ok())
-    {
-        if state_update.trie.record_storage_garbage(garbage_size_mbs) {
-            tracing::warn!(target: "runtime", %garbage_size_mbs, "Generated storage proof garbage");
-        }
-    }
+    #[cfg(feature = "test_features")]
+    apply_recorded_storage_garbage(function_call, state_update);
     let mut receipt_manager = ReceiptManager::default();
     let mut runtime_ext = RuntimeExt::new(
         state_update,
@@ -1133,6 +1126,22 @@ fn check_transfer_to_nonexisting_account(
         Ok(())
     } else {
         Err(ActionErrorKind::AccountDoesNotExist { account_id: account_id.clone() }.into())
+    }
+}
+
+#[cfg(feature = "test_features")]
+fn apply_recorded_storage_garbage(
+    function_call: &FunctionCallAction,
+    state_update: &mut TrieUpdate,
+) {
+    if let Some(garbage_size_mbs) = function_call
+        .method_name
+        .strip_prefix("internal_record_storage_garbage_")
+        .and_then(|suf| suf.parse::<usize>().ok())
+    {
+        if state_update.trie.record_storage_garbage(garbage_size_mbs) {
+            tracing::warn!(target: "runtime", %garbage_size_mbs, "Generated storage proof garbage");
+        }
     }
 }
 

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -1129,6 +1129,7 @@ fn check_transfer_to_nonexisting_account(
     }
 }
 
+/// See #11703 for more details
 #[cfg(feature = "test_features")]
 fn apply_recorded_storage_garbage(
     function_call: &FunctionCallAction,


### PR DESCRIPTION
This PR introduces a way to generate arbitrary large chunk state witness as a result of processing a single receipt. This is needed to test what happens with the blockchain if we missed something in the witness size checks.
Part of #11656.

Large witness generation is triggered by a function call action with a method name `internal_record_storage_garbage_<GARBAGE_SIZE>` with `<GARBAGE_SIZE>` corresponding to a number of megabytes of random data to be added to the storage proof. For example `internal_record_storage_garbage_20` would result in 20MB of garbage data in the witness. Having size as part of the method name (and not as an argument) makes it easier to send a transaction using near cli (`args` needs to be base64 encoded).  Note that we don't need to deploy any contracts, failed receipt will still result in garbage added to the witness. This makes it very easy to use, just sending a transaction with a single function call action is enough. The functionality is enabled only when neard is complied with `test_features` enabled.

Alternative approaches considered:
* Adding a new feature that disables witness size checks. Then we can deploy a contract that read/writes a lot of storage data to make the storage proof large. We decided not to proceed with this approach since this is considerably harder to use and also at some point we will still hit compute/gas limits. Another benefit of the chosen approach is that it doesn't increase apply chunk latency, so it allows us to test large witness in isolation from slow chunk application.
* #11687. The resulting behaviour diverges significantly from what we would expect to happen in the real world when large witness is a result of applying some chunk. For example when testing doomsday scenario we want the next chunk producer to try distributing the same witness after the chunk is missed. This PR also covers the underlying use case #11184.

Large part of this PR is refactoring around runtime tests in chain to make it easier to reuse the existing test setup code.