### PR TITLE
fix: add missing chrono feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,7 @@ cargo_metadata = "0.14.1"
 cc = "1.0"
 cfg-if = "1.0"
 chrono = { version = "0.4", default-features = false, features = [
+    "clock",
     "alloc",
     "serde",
 ] }


### PR DESCRIPTION
My local build fails with the following error:
```
> cargo test -p near-chain --no-run 
   Compiling near-chain-configs v0.0.0 (/Users/pugachag/Projects/near/nearcore/core/chain-configs)
   Compiling near-vm-runner v0.0.0 (/Users/pugachag/Projects/near/nearcore/runtime/near-vm-runner)
error[E0599]: no function or associated item named `now` found for struct `Utc` in the current scope
   --> core/chain-configs/src/test_genesis.rs:282:40
    |
282 |             let default = chrono::Utc::now();
    |                                        ^^^ function or associated item not found in `Utc`

```

`Utc::now()` is only available with `clock` feature. 