### PR TITLE
Mac OS release workflow: no store validator

### DIFF
--- a/scripts/mac-release.sh
+++ b/scripts/mac-release.sh
@@ -67,7 +67,6 @@ function upload_binary {
 }
 
 upload_binary neard
-upload_binary store-validator
 
 if [ "$release" == "release" ]
 then


### PR DESCRIPTION
we don't build store validator on neard release anymore and wf upload is failing https://github.com/near/nearcore/actions/runs/9765365593/job/26955860213