### PR TITLE
Unconditionally enable SHA-NI extensions

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,4 +4,4 @@
 rustflags = ["-Cforce-unwind-tables=y"]
 
 [target.'cfg(target_arch = "x86_64")']
-rustflags = ["-Ctarget-feature=+sse4.1,+sse4.2", "-Cforce-unwind-tables=y"]
+rustflags = ["-Ctarget-feature=+sse2,+ssse3,+sse4.1,+sse4.2,+sha", "-Cforce-unwind-tables=y"]


### PR DESCRIPTION
We rely on this extension to accelerate computation of SHA2 hashes quickly. This extension not being present will slow down node beyond what's reasonable and the node will not be able to keep up with others. Enabling this extension unconditionally and having the node fail early on machines where the extension is not available seems like a reasonable option here.