### PR TITLE
fix(congestion_control) - fix congestion info from wrong block used in catchup

### DIFF
--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -702,7 +702,7 @@ impl<'a> ChainUpdate<'a> {
         // TODO(nikurt): Determine the value correctly.
         let is_first_block_with_chunk_of_version = false;
 
-        let prev_block = self.chain_store_update.get_block(block_header.prev_hash())?;
+        let block = self.chain_store_update.get_block(block_header.hash())?;
 
         let apply_result = self.runtime_adapter.apply_chunk(
             RuntimeStorageConfig::new(chunk_header.prev_state_root(), true),
@@ -722,7 +722,7 @@ impl<'a> ChainUpdate<'a> {
                 gas_price,
                 challenges_result: block_header.challenges_result().clone(),
                 random_seed: *block_header.random_value(),
-                congestion_info: prev_block.block_congestion_info(),
+                congestion_info: block.block_congestion_info(),
             },
             &receipts,
             chunk.transactions(),
@@ -807,8 +807,9 @@ impl<'a> ChainUpdate<'a> {
             // Don't continue
             return Ok(false);
         }
+        let block = self.chain_store_update.get_block(block_header.hash())?;
+
         let prev_hash = block_header.prev_hash();
-        let prev_block = self.chain_store_update.get_block(prev_hash)?;
         let prev_block_header = self.chain_store_update.get_block_header(prev_hash)?;
 
         let shard_uid = self.epoch_manager.shard_id_to_uid(shard_id, block_header.epoch_id())?;
@@ -827,7 +828,7 @@ impl<'a> ChainUpdate<'a> {
             ApplyChunkBlockContext::from_header(
                 &block_header,
                 prev_block_header.next_gas_price(),
-                prev_block.block_congestion_info(),
+                block.block_congestion_info(),
             ),
             &[],
             &[],


### PR DESCRIPTION
Since #11381 the congestion info from the current block, not the previous block, should be used when applying chunks. The same logic change needs to be applied in state sync / catchup. 

I found this issue while working on a unrelated test loop test for congestion control. I will follow up with the test separately because I would like to get this merged ASAP and the test still requires some work. 

Sadly the existing test - `state_sync_missing_chunks.py` - does not catch this issue despite covering the relevant lines. This is because in this test there is no congestion so it doesn't matter what block is used.  