### PR TITLE
fix: reenable test_full_estimator

### DIFF
--- a/runtime/runtime-params-estimator/estimator-warehouse/src/main.rs
+++ b/runtime/runtime-params-estimator/estimator-warehouse/src/main.rs
@@ -146,11 +146,7 @@ mod tests {
     /// - This is an expensive test. We run it like any other test for now but
     ///   it might make sense to put it in a separate CI job.
     /// - QEMU based estimation is skipped - it would be too slow.
-    /// TODO(#11705) - This test is disabled due to errors in the congestion
-    /// control stack. It's likely due to missing congestion info boostrappng.
-    /// Fix the issue and re-enabled the test.
     #[test]
-    #[ignore]
     fn test_full_estimator() -> anyhow::Result<()> {
         let stats_path = Path::new("tmp_db.sqlite");
         let db = Db::open(stats_path)?;


### PR DESCRIPTION
resolves #11705

Two things needed to be changed.

1. Copy previous congestion info output over to the next chunk as input.
2. Disable congestion info to not mess with existing estimations. In particular, `DataReceiptCreationPerByte` requires large amounts of data to be processed and forwarded every round.