### PR TITLE
feat(congestion): More info on shard congested RPC error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4625,6 +4625,7 @@ dependencies = [
  "near-time",
  "num-rational 0.3.2",
  "once_cell",
+ "ordered-float",
  "primitive-types 0.10.1",
  "rand",
  "rand_chacha",
@@ -5611,7 +5612,10 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
+ "borsh 1.2.0",
  "num-traits",
+ "rand",
+ "serde",
 ]
 
 [[package]]
@@ -6227,6 +6231,7 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -6255,6 +6260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.9",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -286,6 +286,7 @@ opentelemetry = { version = "0.22.0", features = ["trace"] }
 opentelemetry_sdk = { version = "0.22.0", features = ["rt-tokio"] }
 opentelemetry-otlp = "0.15.0"
 opentelemetry-semantic-conventions = "0.14.0"
+ordered-float = { version = "4.2.0", features = ["serde", "borsh"] }
 paperclip = { version = "0.8.0", features = ["actix4"] }
 parity-wasm = { version = "0.42", default-features = false }
 parity-wasm_41 = { package = "parity-wasm", version = "0.41" }

--- a/chain/jsonrpc/res/rpc_errors_schema.json
+++ b/chain/jsonrpc/res/rpc_errors_schema.json
@@ -573,7 +573,8 @@
         "TransactionSizeExceeded",
         "InvalidTransactionVersion",
         "StorageError",
-        "ShardCongested"
+        "ShardCongested",
+        "ShardStuck"
       ],
       "props": {}
     },
@@ -789,6 +790,15 @@
       "name": "ShardCongested",
       "subtypes": [],
       "props": {
+        "congestion_level": "",
+        "shard_id": ""
+      }
+    },
+    "ShardStuck": {
+      "name": "ShardStuck",
+      "subtypes": [],
+      "props": {
+        "missed_chunks": "",
         "shard_id": ""
       }
     },

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -25,6 +25,7 @@ hex.workspace = true
 itertools = { workspace = true, optional = true }
 num-rational.workspace = true
 once_cell.workspace = true
+ordered-float.workspace = true
 primitive-types.workspace = true
 rand = { workspace = true, optional = true }
 rand_chacha = { workspace = true, optional = true }

--- a/core/primitives/src/congestion_info.rs
+++ b/core/primitives/src/congestion_info.rs
@@ -130,7 +130,8 @@ impl CongestionControl {
             .max(missed_chunks_congestion);
 
         // Convert to NotNan here, if not possible, the max above is already meaningless.
-        let congestion_level = NotNan::new(congestion_level).unwrap_or(NotNan::new(1.0).unwrap());
+        let congestion_level =
+            NotNan::new(congestion_level).unwrap_or_else(|_| NotNan::new(1.0).unwrap());
         if *congestion_level < self.config.reject_tx_congestion_threshold {
             return None;
         }

--- a/core/primitives/src/congestion_info.rs
+++ b/core/primitives/src/congestion_info.rs
@@ -112,13 +112,10 @@ impl CongestionControl {
     }
 
     /// Whether we can accept new transaction with the receiver set to this shard.
-    pub fn shard_accepts_transactions(&self) -> bool {
-        self.rejection_reason().is_none()
-    }
-
+    ///
     /// If the shard doesn't accept new transaction, provide the reason for
     /// extra debugging information.
-    pub fn rejection_reason(&self) -> Option<RejectTransactionReason> {
+    pub fn shard_accepts_transactions(&self) -> ShardAcceptsTransactions {
         let incoming_congestion = self.incoming_congestion();
         let outgoing_congestion = self.outgoing_congestion();
         let memory_congestion = self.memory_congestion();
@@ -133,19 +130,26 @@ impl CongestionControl {
         let congestion_level =
             NotNan::new(congestion_level).unwrap_or_else(|_| NotNan::new(1.0).unwrap());
         if *congestion_level < self.config.reject_tx_congestion_threshold {
-            return None;
+            return ShardAcceptsTransactions::Yes;
         }
 
-        if missed_chunks_congestion >= *congestion_level {
-            Some(RejectTransactionReason::MissedChunks { missed_chunks: self.missed_chunks_count })
+        let reason = if missed_chunks_congestion >= *congestion_level {
+            RejectTransactionReason::MissedChunks { missed_chunks: self.missed_chunks_count }
         } else if incoming_congestion >= *congestion_level {
-            Some(RejectTransactionReason::IncomingCongestion { congestion_level })
+            RejectTransactionReason::IncomingCongestion { congestion_level }
         } else if outgoing_congestion >= *congestion_level {
-            Some(RejectTransactionReason::OutgoingCongestion { congestion_level })
+            RejectTransactionReason::OutgoingCongestion { congestion_level }
         } else {
-            Some(RejectTransactionReason::MemoryCongestion { congestion_level })
-        }
+            RejectTransactionReason::MemoryCongestion { congestion_level }
+        };
+        ShardAcceptsTransactions::No(reason)
     }
+}
+
+/// Result of [`CongestionControl::shard_accepts_transactions`].
+pub enum ShardAcceptsTransactions {
+    Yes,
+    No(RejectTransactionReason),
 }
 
 /// Detailed information for why a shard rejects new transactions.
@@ -480,6 +484,16 @@ fn mix(left: u64, right: u64, ratio: f64) -> u64 {
     return total.round() as u64;
 }
 
+impl ShardAcceptsTransactions {
+    pub fn is_yes(&self) -> bool {
+        matches!(self, ShardAcceptsTransactions::Yes)
+    }
+
+    pub fn is_no(&self) -> bool {
+        !self.is_yes()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use near_parameters::RuntimeConfigStore;
@@ -562,7 +576,7 @@ mod tests {
         assert!(config.max_outgoing_gas.abs_diff(congestion_control.outgoing_gas_limit(0)) <= 1);
 
         assert!(config.max_tx_gas.abs_diff(congestion_control.process_tx_limit()) <= 1);
-        assert!(congestion_control.shard_accepts_transactions());
+        assert!(congestion_control.shard_accepts_transactions().is_yes());
     }
 
     #[test]
@@ -583,7 +597,7 @@ mod tests {
             assert_eq!(1.0, control.congestion_level());
             // fully congested, no more forwarding allowed
             assert_eq!(0, control.outgoing_gas_limit(1));
-            assert!(!control.shard_accepts_transactions());
+            assert!(control.shard_accepts_transactions().is_no());
             // processing to other shards is not restricted by memory congestion
             assert_eq!(config.max_tx_gas, control.process_tx_limit());
         }
@@ -599,7 +613,7 @@ mod tests {
                 control.outgoing_gas_limit(1)
             );
             // at 50%, still no new transactions are allowed
-            assert!(!control.shard_accepts_transactions());
+            assert!(control.shard_accepts_transactions().is_no());
         }
 
         // reduce congestion to 1/8
@@ -613,7 +627,7 @@ mod tests {
                 control.outgoing_gas_limit(1)
             );
             // at 12.5%, new transactions are allowed (threshold is 0.25)
-            assert!(control.shard_accepts_transactions());
+            assert!(control.shard_accepts_transactions().is_yes());
         }
     }
 
@@ -635,7 +649,7 @@ mod tests {
             assert_eq!(1.0, control.congestion_level());
             // fully congested, no more forwarding allowed
             assert_eq!(0, control.outgoing_gas_limit(1));
-            assert!(!control.shard_accepts_transactions());
+            assert!(control.shard_accepts_transactions().is_no());
             // processing to other shards is restricted by own incoming congestion
             assert_eq!(config.min_tx_gas, control.process_tx_limit());
         }
@@ -651,7 +665,7 @@ mod tests {
                 control.outgoing_gas_limit(1)
             );
             // at 50%, still no new transactions to us are allowed
-            assert!(!control.shard_accepts_transactions());
+            assert!(control.shard_accepts_transactions().is_no());
             // but we accept new transactions to other shards
             assert_eq!(
                 (0.5 * config.min_tx_gas as f64 + 0.5 * config.max_tx_gas as f64) as u64,
@@ -670,7 +684,7 @@ mod tests {
                 control.outgoing_gas_limit(1)
             );
             // at 12.5%, new transactions are allowed (threshold is 0.25)
-            assert!(control.shard_accepts_transactions());
+            assert!(control.shard_accepts_transactions().is_yes());
             assert_eq!(
                 (0.125 * config.min_tx_gas as f64 + 0.875 * config.max_tx_gas as f64) as u64,
                 control.process_tx_limit()
@@ -695,7 +709,7 @@ mod tests {
         assert_eq!(1.0, control.congestion_level());
         // fully congested, no more forwarding allowed
         assert_eq!(0, control.outgoing_gas_limit(1));
-        assert!(!control.shard_accepts_transactions());
+        assert!(control.shard_accepts_transactions().is_no());
         // processing to other shards is not restricted by own outgoing congestion
         assert_eq!(config.max_tx_gas, control.process_tx_limit());
 
@@ -708,7 +722,7 @@ mod tests {
             control.outgoing_gas_limit(1)
         );
         // at 50%, still no new transactions to us are allowed
-        assert!(!control.shard_accepts_transactions());
+        assert!(control.shard_accepts_transactions().is_no());
 
         // reduce congestion to 1/8
         info.remove_buffered_receipt_gas(3 * config.max_congestion_outgoing_gas / 8).unwrap();
@@ -720,7 +734,7 @@ mod tests {
             control.outgoing_gas_limit(1)
         );
         // at 12.5%, new transactions are allowed (threshold is 0.25)
-        assert!(control.shard_accepts_transactions());
+        assert!(control.shard_accepts_transactions().is_yes());
     }
 
     #[test]

--- a/integration-tests/src/tests/client/features/congestion_control.rs
+++ b/integration-tests/src/tests/client/features/congestion_control.rs
@@ -194,7 +194,7 @@ fn test_protocol_upgrade_simple() {
             .expect("chunk header must have congestion info after upgrade");
         let congestion_control = CongestionControl::new(config, congestion_info, 0);
         assert_eq!(congestion_control.congestion_level(), 0.0);
-        assert!(congestion_control.shard_accepts_transactions());
+        assert!(congestion_control.shard_accepts_transactions().is_yes());
     }
 
     let check_congested_protocol_upgrade = false;

--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -674,6 +674,7 @@ class ShardCongestedError(RpcError):
         self.shard_id = shard_id
         self.congestion_level = congestion_level
 
+
 class ShardStuckError(RpcError):
 
     def __init__(

--- a/pytest/tests/loadtest/locust/common/base.py
+++ b/pytest/tests/loadtest/locust/common/base.py
@@ -664,13 +664,30 @@ class ShardCongestedError(RpcError):
     def __init__(
         self,
         shard_id,
+        congestion_level,
     ):
         super().__init__(
             message="Shard congested",
             details=
-            f"Shard {shard_id} is currently congested and rejects new transactions"
+            f"Shard {shard_id} is currently at congestion level {congestion_level} and rejects new transactions"
         )
         self.shard_id = shard_id
+        self.congestion_level = congestion_level
+
+class ShardStuckError(RpcError):
+
+    def __init__(
+        self,
+        shard_id,
+        missed_chunks,
+    ):
+        super().__init__(
+            message="Shard stuck",
+            details=
+            f"Shard {shard_id} missed {missed_chunks} chunks and rejects new transactions"
+        )
+        self.shard_id = shard_id
+        self.missed_chunks = missed_chunks
 
 
 class TxError(NearError):
@@ -724,7 +741,12 @@ def evaluate_rpc_result(rpc_result):
                     err_description["InvalidNonce"]["ak_nonce"])
             elif "ShardCongested" in err_description:
                 raise ShardCongestedError(
-                    err_description["ShardCongested"]["shard_id"])
+                    err_description["ShardCongested"]["shard_id"],
+                    err_description["ShardCongested"]["congestion_level"])
+            elif "ShardStuck" in err_description:
+                raise ShardStuckError(
+                    err_description["ShardStuck"]["shard_id"],
+                    err_description["ShardStuck"]["missed_chunks"])
         raise RpcError(details=rpc_result["error"])
 
     result = rpc_result["result"]


### PR DESCRIPTION
With the congestion level already included in the response, we clients
don't have to query the congestion info afterwards if they want to use
it to determine a fitting timeout for a retry.

We could also provide more detailed information, like which specific limit
of congestion was hit but I don't think it's appropriate for the RPC API. I would
say this is implementation detail and we want to be able to change it without
worrying about what is exposed on the API.

However, since "missed chunk congestion" is fundamentally different, I think
we should provide a separate error for it. I've added `ShardStuck` error for it,
which includes the number of missed chunks in the error message rather than
the congestion level.