### PR TITLE
[locust] Attach less gas to FT transfers

### DIFF
--- a/pytest/tests/loadtest/locust/common/ft.py
+++ b/pytest/tests/loadtest/locust/common/ft.py
@@ -10,6 +10,7 @@ from locust import events
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[4] / 'lib'))
 
 import key
+from account import TGAS
 from common.base import Account, Deploy, NearNodeProxy, NearUser, FunctionCall, INIT_DONE
 
 
@@ -131,6 +132,15 @@ class TransferFT(FunctionCall):
             "receiver_id": self.recipient_id,
             "amount": str(int(self.how_much)),
         }
+
+    def attached_gas(self) -> int:
+        """
+        We overwrite this setting to minimize effects on congestion control that relies on attached
+        gas to determine the capacity of delayed receipt queues. See
+        https://near.zulipchat.com/#narrow/stream/295306-contract-runtime/topic/ft_transfer.20benchmark/near/448814523
+        for more details.
+        """
+        return 10 * TGAS
 
     def sender_account(self) -> Account:
         return self.sender


### PR DESCRIPTION
As attaching 300 TGAS leads to a lower network throughput due to recently enabled congestion control. See https://near.zulipchat.com/#narrow/stream/295306-contract-runtime/topic/ft_transfer.20benchmark/near/448814523 for more details.