### PR TITLE
vm: Discard custom sections in prepared code

### DIFF
--- a/core/parameters/res/runtime_configs/143.yaml
+++ b/core/parameters/res/runtime_configs/143.yaml
@@ -1,0 +1,1 @@
+discard_custom_sections: { old: false, new: true }

--- a/core/parameters/res/runtime_configs/parameters.snap
+++ b/core/parameters/res/runtime_configs/parameters.snap
@@ -205,6 +205,7 @@ function_call_weight                    true
 vm_kind                                 NearVm
 eth_implicit_accounts                   false
 yield_resume                            true
+discard_custom_sections                 false
 max_congestion_incoming_gas             20_000_000_000_000_000
 max_congestion_outgoing_gas             10_000_000_000_000_000
 max_congestion_memory_consumption              1_000_000_000

--- a/core/parameters/res/runtime_configs/parameters.yaml
+++ b/core/parameters/res/runtime_configs/parameters.yaml
@@ -243,6 +243,7 @@ function_call_weight: false
 vm_kind: Wasmer0
 eth_implicit_accounts: false
 yield_resume: false
+discard_custom_sections: false
 
 
 # Congestion Control configuration

--- a/core/parameters/res/runtime_configs/parameters_testnet.yaml
+++ b/core/parameters/res/runtime_configs/parameters_testnet.yaml
@@ -238,8 +238,9 @@ function_call_weight: false
 vm_kind: Wasmer0
 eth_implicit_accounts: false
 yield_resume: false
+discard_custom_sections: false
 
-# TODO What should be the config for testnet? 
+# TODO What should be the config for testnet?
 
 max_congestion_incoming_gas: 9_223_372_036_854_775_807
 max_congestion_outgoing_gas: 9_223_372_036_854_775_807

--- a/core/parameters/src/config_store.rs
+++ b/core/parameters/src/config_store.rs
@@ -47,6 +47,7 @@ static CONFIG_DIFFS: &[(ProtocolVersion, &str)] = &[
     // Introduce ETH-implicit accounts.
     (138, include_config!("138.yaml")),
     (141, include_config!("141.yaml")),
+    (143, include_config!("143.yaml")),
 ];
 
 /// Testnet parameters for versions <= 29, which (incorrectly) differed from mainnet parameters

--- a/core/parameters/src/parameter.rs
+++ b/core/parameters/src/parameter.rs
@@ -204,6 +204,7 @@ pub enum Parameter {
     VmKind,
     EthImplicitAccounts,
     YieldResume,
+    DiscardCustomSections,
 
     // Congestion Control
     MaxCongestionIncomingGas,

--- a/core/parameters/src/parameter_table.rs
+++ b/core/parameters/src/parameter_table.rs
@@ -4,8 +4,8 @@ use crate::cost::{
     ActionCosts, ExtCostsConfig, Fee, ParameterCost, RuntimeFeesConfig, StorageUsageConfig,
 };
 use crate::parameter::{FeeParameter, Parameter};
-use crate::vm::VMKind;
 use crate::vm::{Config, StorageGetMode};
+use crate::vm::{ContractPrepareVersion, VMKind};
 use near_primitives_core::account::id::ParseAccountError;
 use near_primitives_core::types::AccountId;
 use num_rational::Rational32;
@@ -314,6 +314,7 @@ impl TryFrom<&ParameterTable> for RuntimeConfig {
                 grow_mem_cost: params.get(Parameter::WasmGrowMemCost)?,
                 regular_op_cost: params.get(Parameter::WasmRegularOpCost)?,
                 disable_9393_fix: params.get(Parameter::Disable9393Fix)?,
+                discard_custom_sections: params.get(Parameter::DiscardCustomSections)?,
                 limit_config: serde_yaml::from_value(params.yaml_map(Parameter::vm_limits()))
                     .map_err(InvalidConfigError::InvalidYaml)?,
                 fix_contract_loading_cost: params.get(Parameter::FixContractLoadingCost)?,

--- a/core/parameters/src/parameter_table.rs
+++ b/core/parameters/src/parameter_table.rs
@@ -4,8 +4,8 @@ use crate::cost::{
     ActionCosts, ExtCostsConfig, Fee, ParameterCost, RuntimeFeesConfig, StorageUsageConfig,
 };
 use crate::parameter::{FeeParameter, Parameter};
+use crate::vm::VMKind;
 use crate::vm::{Config, StorageGetMode};
-use crate::vm::{ContractPrepareVersion, VMKind};
 use near_primitives_core::account::id::ParseAccountError;
 use near_primitives_core::types::AccountId;
 use num_rational::Rational32;

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__0.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__0.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 3856371,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": false,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__129.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": true,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__138.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__138.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": true,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__141.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__141.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": true,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__143.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__143.json.snap
@@ -18,15 +18,15 @@ expression: config_view
       },
       "cost_per_byte": {
         "send_sir": 17212011,
-        "send_not_sir": 17212011,
+        "send_not_sir": 47683715,
         "execution": 17212011
       }
     },
     "action_creation_config": {
       "create_account_cost": {
-        "send_sir": 99607375000,
-        "send_not_sir": 99607375000,
-        "execution": 99607375000
+        "send_sir": 3850000000000,
+        "send_not_sir": 3850000000000,
+        "execution": 3850000000000
       },
       "deploy_contract_cost": {
         "send_sir": 184765750000,
@@ -35,17 +35,17 @@ expression: config_view
       },
       "deploy_contract_cost_per_byte": {
         "send_sir": 6812999,
-        "send_not_sir": 6812999,
-        "execution": 6812999
+        "send_not_sir": 47683715,
+        "execution": 64572944
       },
       "function_call_cost": {
-        "send_sir": 2319861500000,
-        "send_not_sir": 2319861500000,
-        "execution": 2319861500000
+        "send_sir": 200000000000,
+        "send_not_sir": 200000000000,
+        "execution": 780000000000
       },
       "function_call_cost_per_byte": {
         "send_sir": 2235934,
-        "send_not_sir": 2235934,
+        "send_not_sir": 47683715,
         "execution": 2235934
       },
       "transfer_cost": {
@@ -71,7 +71,7 @@ expression: config_view
         },
         "function_call_cost_per_byte": {
           "send_sir": 1925331,
-          "send_not_sir": 1925331,
+          "send_not_sir": 47683715,
           "execution": 1925331
         }
       },
@@ -108,7 +108,7 @@ expression: config_view
     "ext_costs": {
       "base": 264768111,
       "contract_loading_base": 35445963,
-      "contract_loading_bytes": 216750,
+      "contract_loading_bytes": 1089295,
       "read_memory_base": 2609863200,
       "read_memory_byte": 3801333,
       "write_memory_base": 2803794861,
@@ -169,29 +169,29 @@ expression: config_view
       "alt_bn128_g1_sum_element": 5000000000,
       "alt_bn128_pairing_check_base": 9686000000000,
       "alt_bn128_pairing_check_element": 5102000000000,
-      "yield_create_base": 300000000000000,
-      "yield_create_byte": 300000000000000,
-      "yield_resume_base": 300000000000000,
-      "yield_resume_byte": 300000000000000
+      "yield_create_base": 153411779276,
+      "yield_create_byte": 15643988,
+      "yield_resume_base": 1195627285210,
+      "yield_resume_byte": 1195627285210
     },
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
-    "discard_custom_sections": false,
-    "storage_get_mode": "Trie",
-    "fix_contract_loading_cost": false,
+    "discard_custom_sections": true,
+    "storage_get_mode": "FlatStorage",
+    "fix_contract_loading_cost": true,
     "implicit_account_creation": true,
     "math_extension": true,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
-    "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
+    "ed25519_verify": true,
+    "alt_bn128": true,
+    "function_call_weight": true,
+    "eth_implicit_accounts": true,
+    "yield_resume_host_functions": true,
     "limit_config": {
-      "max_gas_burnt": 200000000000000,
-      "max_stack_height": 16384,
-      "contract_prepare_version": 0,
+      "max_gas_burnt": 300000000000000,
+      "max_stack_height": 262144,
+      "contract_prepare_version": 2,
       "initial_memory_pages": 1024,
       "max_memory_pages": 2048,
       "registers_memory_limit": 1073741824,
@@ -206,41 +206,42 @@ expression: config_view
       "max_arguments_length": 4194304,
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
-      "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
-      "max_length_storage_key": 4194304,
+      "max_transaction_size": 1572864,
+      "max_receipt_size": 4194304,
+      "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
       "max_number_input_data_dependencies": 128,
       "max_functions_number_per_contract": 10000,
-      "wasmer2_stack_limit": 102400,
-      "account_id_validity_rules_version": 0,
+      "wasmer2_stack_limit": 204800,
+      "max_locals_per_contract": 1000000,
+      "account_id_validity_rules_version": 1,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4000000
     }
   },
   "account_creation_config": {
-    "min_allowed_top_level_account_length": 32,
+    "min_allowed_top_level_account_length": 65,
     "registrar_account_id": "registrar"
   },
   "congestion_control_config": {
-    "max_congestion_incoming_gas": 9223372036854775807,
-    "max_congestion_outgoing_gas": 9223372036854775807,
-    "max_congestion_memory_consumption": 9223372036854775807,
-    "max_congestion_missed_chunks": 9223372036854775807,
-    "max_outgoing_gas": 9223372036854775807,
-    "min_outgoing_gas": 9223372036854775807,
-    "allowed_shard_outgoing_gas": 9223372036854775807,
-    "max_tx_gas": 9223372036854775807,
-    "min_tx_gas": 9223372036854775807,
-    "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "max_congestion_incoming_gas": 20000000000000000,
+    "max_congestion_outgoing_gas": 10000000000000000,
+    "max_congestion_memory_consumption": 1000000000,
+    "max_congestion_missed_chunks": 5,
+    "max_outgoing_gas": 300000000000000000,
+    "min_outgoing_gas": 1000000000000000,
+    "allowed_shard_outgoing_gas": 1000000000000000,
+    "max_tx_gas": 500000000000000,
+    "min_tx_gas": 20000000000000,
+    "reject_tx_congestion_threshold": 0.5,
+    "outgoing_receipts_usual_size_limit": 102400,
+    "outgoing_receipts_big_size_limit": 4718592
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 3000000,
+    "combined_transactions_size_limit": 4194304,
+    "new_transactions_validation_state_size_soft_limit": 572864
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__35.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__35.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 3856371,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__42.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__42.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 3856371,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__46.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__46.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 3856371,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__48.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__48.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 2207874,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__50.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__50.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__52.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__52.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__53.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__53.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__55.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__55.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__57.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__57.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__59.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__59.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__61.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__61.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__62.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__62.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": true,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__63.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__63.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__64.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__64.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__66.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__66.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__67.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__67.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__68.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__68.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__69.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__69.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_0.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_0.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 3856371,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": false,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": true,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_138.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_138.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": true,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_141.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_141.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": true,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_143.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_143.json.snap
@@ -18,15 +18,15 @@ expression: config_view
       },
       "cost_per_byte": {
         "send_sir": 17212011,
-        "send_not_sir": 17212011,
+        "send_not_sir": 47683715,
         "execution": 17212011
       }
     },
     "action_creation_config": {
       "create_account_cost": {
-        "send_sir": 99607375000,
-        "send_not_sir": 99607375000,
-        "execution": 99607375000
+        "send_sir": 3850000000000,
+        "send_not_sir": 3850000000000,
+        "execution": 3850000000000
       },
       "deploy_contract_cost": {
         "send_sir": 184765750000,
@@ -35,17 +35,17 @@ expression: config_view
       },
       "deploy_contract_cost_per_byte": {
         "send_sir": 6812999,
-        "send_not_sir": 6812999,
-        "execution": 6812999
+        "send_not_sir": 47683715,
+        "execution": 64572944
       },
       "function_call_cost": {
-        "send_sir": 2319861500000,
-        "send_not_sir": 2319861500000,
-        "execution": 2319861500000
+        "send_sir": 200000000000,
+        "send_not_sir": 200000000000,
+        "execution": 780000000000
       },
       "function_call_cost_per_byte": {
         "send_sir": 2235934,
-        "send_not_sir": 2235934,
+        "send_not_sir": 47683715,
         "execution": 2235934
       },
       "transfer_cost": {
@@ -71,7 +71,7 @@ expression: config_view
         },
         "function_call_cost_per_byte": {
           "send_sir": 1925331,
-          "send_not_sir": 1925331,
+          "send_not_sir": 47683715,
           "execution": 1925331
         }
       },
@@ -108,7 +108,7 @@ expression: config_view
     "ext_costs": {
       "base": 264768111,
       "contract_loading_base": 35445963,
-      "contract_loading_bytes": 216750,
+      "contract_loading_bytes": 1089295,
       "read_memory_base": 2609863200,
       "read_memory_byte": 3801333,
       "write_memory_base": 2803794861,
@@ -169,29 +169,29 @@ expression: config_view
       "alt_bn128_g1_sum_element": 5000000000,
       "alt_bn128_pairing_check_base": 9686000000000,
       "alt_bn128_pairing_check_element": 5102000000000,
-      "yield_create_base": 300000000000000,
-      "yield_create_byte": 300000000000000,
-      "yield_resume_base": 300000000000000,
-      "yield_resume_byte": 300000000000000
+      "yield_create_base": 153411779276,
+      "yield_create_byte": 15643988,
+      "yield_resume_base": 1195627285210,
+      "yield_resume_byte": 1195627285210
     },
     "grow_mem_cost": 1,
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
-    "discard_custom_sections": false,
-    "storage_get_mode": "Trie",
-    "fix_contract_loading_cost": false,
+    "discard_custom_sections": true,
+    "storage_get_mode": "FlatStorage",
+    "fix_contract_loading_cost": true,
     "implicit_account_creation": true,
     "math_extension": true,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
-    "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
+    "ed25519_verify": true,
+    "alt_bn128": true,
+    "function_call_weight": true,
+    "eth_implicit_accounts": true,
+    "yield_resume_host_functions": true,
     "limit_config": {
-      "max_gas_burnt": 200000000000000,
-      "max_stack_height": 16384,
-      "contract_prepare_version": 0,
+      "max_gas_burnt": 300000000000000,
+      "max_stack_height": 262144,
+      "contract_prepare_version": 2,
       "initial_memory_pages": 1024,
       "max_memory_pages": 2048,
       "registers_memory_limit": 1073741824,
@@ -206,41 +206,42 @@ expression: config_view
       "max_arguments_length": 4194304,
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
-      "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
-      "max_length_storage_key": 4194304,
+      "max_transaction_size": 1572864,
+      "max_receipt_size": 4194304,
+      "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
       "max_number_input_data_dependencies": 128,
       "max_functions_number_per_contract": 10000,
-      "wasmer2_stack_limit": 102400,
-      "account_id_validity_rules_version": 0,
+      "wasmer2_stack_limit": 204800,
+      "max_locals_per_contract": 1000000,
+      "account_id_validity_rules_version": 1,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4000000
     }
   },
   "account_creation_config": {
-    "min_allowed_top_level_account_length": 32,
+    "min_allowed_top_level_account_length": 65,
     "registrar_account_id": "registrar"
   },
   "congestion_control_config": {
-    "max_congestion_incoming_gas": 9223372036854775807,
-    "max_congestion_outgoing_gas": 9223372036854775807,
-    "max_congestion_memory_consumption": 9223372036854775807,
-    "max_congestion_missed_chunks": 9223372036854775807,
-    "max_outgoing_gas": 9223372036854775807,
-    "min_outgoing_gas": 9223372036854775807,
-    "allowed_shard_outgoing_gas": 9223372036854775807,
-    "max_tx_gas": 9223372036854775807,
-    "min_tx_gas": 9223372036854775807,
-    "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "max_congestion_incoming_gas": 20000000000000000,
+    "max_congestion_outgoing_gas": 10000000000000000,
+    "max_congestion_memory_consumption": 1000000000,
+    "max_congestion_missed_chunks": 5,
+    "max_outgoing_gas": 300000000000000000,
+    "min_outgoing_gas": 1000000000000000,
+    "allowed_shard_outgoing_gas": 1000000000000000,
+    "max_tx_gas": 500000000000000,
+    "min_tx_gas": 20000000000000,
+    "reject_tx_congestion_threshold": 0.5,
+    "outgoing_receipts_usual_size_limit": 102400,
+    "outgoing_receipts_big_size_limit": 4718592
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 3000000,
+    "combined_transactions_size_limit": 4194304,
+    "new_transactions_validation_state_size_soft_limit": 572864
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_35.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_35.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 3856371,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_42.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_42.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 3856371,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_46.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_46.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 3856371,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_48.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_48.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 2207874,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_49.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_49.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_50.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_50.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_52.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_52.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_53.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_53.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_55.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_55.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_57.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_57.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_59.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_59.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_61.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_61.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_62.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_62.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": true,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_63.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_63.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_64.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_64.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_66.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_66.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_67.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_67.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_68.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_68.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_69.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_69.json.snap
@@ -178,6 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__view__tests__runtime_config_view.snap
+++ b/core/parameters/src/snapshots/near_parameters__view__tests__runtime_config_view.snap
@@ -178,6 +178,7 @@ expression: "&view"
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/view.rs
+++ b/core/parameters/src/view.rs
@@ -214,6 +214,9 @@ pub struct VMConfigView {
     pub vm_kind: crate::vm::VMKind,
     /// See [VMConfig::disable_9393_fix](crate::vm::Config::disable_9393_fix).
     pub disable_9393_fix: bool,
+    /// See [VMConfig::discard_custom_sections](crate::vm::Config::discard_custom_sections).
+    pub discard_custom_sections: bool,
+
     /// See [VMConfig::storage_get_mode](crate::vm::Config::storage_get_mode).
     pub storage_get_mode: crate::vm::StorageGetMode,
     /// See [VMConfig::fix_contract_loading_cost](crate::vm::Config::fix_contract_loading_cost).
@@ -247,6 +250,7 @@ impl From<crate::vm::Config> for VMConfigView {
             grow_mem_cost: config.grow_mem_cost,
             regular_op_cost: config.regular_op_cost,
             disable_9393_fix: config.disable_9393_fix,
+            discard_custom_sections: config.discard_custom_sections,
             limit_config: config.limit_config,
             storage_get_mode: config.storage_get_mode,
             fix_contract_loading_cost: config.fix_contract_loading_cost,
@@ -269,6 +273,7 @@ impl From<VMConfigView> for crate::vm::Config {
             grow_mem_cost: view.grow_mem_cost,
             regular_op_cost: view.regular_op_cost,
             disable_9393_fix: view.disable_9393_fix,
+            discard_custom_sections: view.discard_custom_sections,
             limit_config: view.limit_config,
             storage_get_mode: view.storage_get_mode,
             fix_contract_loading_cost: view.fix_contract_loading_cost,

--- a/core/parameters/src/vm.rs
+++ b/core/parameters/src/vm.rs
@@ -194,6 +194,9 @@ pub struct Config {
     /// Enable the `promise_yield_create` and `promise_yield_resume` host functions.
     pub yield_resume_host_functions: bool,
 
+    /// Whether to discard custom sections.
+    pub discard_custom_sections: bool,
+
     /// Describes limits for VM and Runtime.
     pub limit_config: LimitConfig,
 }

--- a/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
+++ b/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
@@ -178,6 +178,7 @@ expression: "&view"
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
+    "discard_custom_sections": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/runtime/near-vm-runner/src/prepare/prepare_v2.rs
+++ b/runtime/near-vm-runner/src/prepare/prepare_v2.rs
@@ -172,11 +172,9 @@ impl<'a> PrepareContext<'a> {
                     func_validator.validate(&func).map_err(|_| PrepareError::Deserialization)?;
                     self.func_validator_allocations = func_validator.into_allocations();
                 }
-                wp::Payload::CustomSection(reader) => {
-                    self.ensure_import_section();
-                    self.copy_section(SectionId::Custom, reader.range())?;
-                }
 
+                // Discard custom sections as they have no semantic meaning for us.
+                wp::Payload::CustomSection(_) => {}
                 // Extensions not supported.
                 wp::Payload::UnknownSection { .. }
                 | wp::Payload::TagSection(_)

--- a/runtime/near-vm-runner/src/prepare/prepare_v2.rs
+++ b/runtime/near-vm-runner/src/prepare/prepare_v2.rs
@@ -172,9 +172,13 @@ impl<'a> PrepareContext<'a> {
                     func_validator.validate(&func).map_err(|_| PrepareError::Deserialization)?;
                     self.func_validator_allocations = func_validator.into_allocations();
                 }
+                wp::Payload::CustomSection(reader) => {
+                    if !self.config.discard_custom_sections {
+                        self.ensure_import_section();
+                        self.copy_section(SectionId::Custom, reader.range())?;
+                    }
+                }
 
-                // Discard custom sections as they have no semantic meaning for us.
-                wp::Payload::CustomSection(_) => {}
                 // Extensions not supported.
                 wp::Payload::UnknownSection { .. }
                 | wp::Payload::TagSection(_)


### PR DESCRIPTION
These have no semantic effect on the compiled code, so there is no reason for us to preserve them.