### PR TITLE
fix: rewards expectation in test_inflation

### DIFF
--- a/integration-tests/src/tests/nearcore/stake_nodes.rs
+++ b/integration-tests/src/tests/nearcore/stake_nodes.rs
@@ -570,8 +570,6 @@ fn test_inflation() {
                                 && block.header.height < epoch_length * 2
                             {
                                 tracing::info!(?block.header.total_supply, ?block.header.height, ?initial_total_supply, epoch_length, "Step2: epoch2");
-                                // It's expected that validator will miss first chunk, hence will only be 95% online, getting 5/9 of their reward.
-                                // +10% of protocol reward = 60% of max inflation are allocated.
                                 let base_reward = {
                                     let genesis_block_view = view_client
                                         .send(
@@ -602,9 +600,19 @@ fn test_inflation() {
                                     .as_u128()
                                 };
                                 // To match rounding, split into protocol reward and validator reward.
+                                // Protocol reward is one tenth of the base reward, while validator reward is the remainder.
+                                // There's only one validator so the second part of the computation is easier.
+                                // The validator rewards depend on its uptime; in other words, the more blocks, chunks and endorsements
+                                // it produces the bigger is the reward. 
+                                // In this test the validator produces 10 blocks out 10, 9 chunks out of 10 and 9 endorsements out of 10. 
+                                // Then there's a formula to translate 28/30 successes to a 10/27 reward multiplier.
+                                //
+                                // For additional details check: chain/epoch-manager/src/reward_calculator.rs or
+                                // https://nomicon.io/Economics/Economic#validator-rewards-calculation 
                                 let protocol_reward = base_reward * 1 / 10;
+                                let validator_reward = base_reward - protocol_reward;
                                 let inflation =
-                                    base_reward * 1 / 10 + (base_reward - protocol_reward) * 5 / 9;
+                                    protocol_reward + validator_reward * 10 / 27;
                                 tracing::info!(?block.header.total_supply, ?block.header.height, ?initial_total_supply, epoch_length, ?inflation, "Step2: epoch2");
                                 if block.header.total_supply == initial_total_supply + inflation {
                                     done2_copy2.store(true, Ordering::SeqCst);


### PR DESCRIPTION
Fix for the failing nayduck test: `test_inflation`.

The issue was that, since stateless validation has been introduced, the validator reward computation has changed to include produced chunk endorsements.

Tested locally by running the test several times in both `nightly` and `stable`