### PR TITLE
fix: remove long storage key on testnet

### DIFF
--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -157,6 +157,8 @@ pub enum ProtocolFeature {
     PerReceiptHardStorageProofLimit,
     /// Cross-shard congestion control according to <https://github.com/near/NEPs/pull/539>.
     CongestionControl,
+    /// Remove account with long storage key.
+    RemoveAccountWithLongStorageKey,
     // Stateless validation: Distribute state witness as reed solomon encoded parts
     PartialEncodedStateWitness,
     /// Size limits for transactions included in a ChunkStateWitness.
@@ -220,7 +222,8 @@ impl ProtocolFeature {
             ProtocolFeature::SimpleNightshadeV3 => 65,
             ProtocolFeature::DecreaseFunctionCallBaseCost => 66,
             ProtocolFeature::YieldExecution => 67,
-            ProtocolFeature::CongestionControl => 68,
+            ProtocolFeature::CongestionControl
+            | ProtocolFeature::RemoveAccountWithLongStorageKey => 68,
             // Stateless validation features.
             // TODO All of the stateless validation features should be collapsed
             // into a single protocol feature.

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -15,7 +15,6 @@ pub use congestion_control::bootstrap_congestion_info;
 use congestion_control::ReceiptSink;
 use metrics::ApplyMetrics;
 pub use near_crypto;
-use near_parameters::ActionCosts::delete_account;
 use near_parameters::{ActionCosts, RuntimeConfig};
 pub use near_primitives;
 use near_primitives::account::Account;

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1330,7 +1330,7 @@ impl Runtime {
             vec![]
         };
 
-        // Remove testnet account with large storage key.
+        // Remove the only testnet account with large storage key.
         if ProtocolFeature::RemoveAccountWithLongStorageKey.protocol_version() == protocol_version
             && migration_flags.is_first_block_with_chunk_of_version
         {


### PR DESCRIPTION
Removes the only storage key in testnet which violates key length restriction.

I verified locally that protocol upgrade works: https://github.com/Longarithm/nearcore/compare/a3828e8738...fecdca4237
I need some time to polish the test, but this PR can be merged anytime.