### PR TITLE
fix: pytest network/peers_request

### DIFF
--- a/pytest/lib/peer.py
+++ b/pytest/lib/peer.py
@@ -2,6 +2,7 @@ import asyncio
 import concurrent
 import hashlib
 import struct
+import time
 
 import base58
 
@@ -127,7 +128,11 @@ def create_handshake(my_key_pair_nacl,
     handshake.chain_info.genesis_id.chain_id = 'moo'
     handshake.chain_info.genesis_id.hash = bytes([0] * 32)
 
-    handshake.edge_info.nonce = 1
+    nonce = int(time.time())
+    if nonce % 2 == 0:
+        nonce += 1
+    handshake.edge_info.nonce = nonce
+
     handshake.edge_info.signature = Signature()
 
     handshake.edge_info.signature.keyType = 0


### PR DESCRIPTION
Before #11321, the nonce `1` never expired. Now it is no longer usable to establish a connection:

```
network: bad nonce, disconnecting: nonce timestamp too distant in the future/past: got = 1970-01-01 0:00:01.0 +00:00:00, now_timestamp = 2024-07-05 10:23:19.959609591 +00:00:00, max_delta = 20m nonce=1 
```

Instead we should replicate the correct behavior to assign a nonce:

https://github.com/near/nearcore/blob/03a8b5d4a0e6df057a9531f5452c2dbc95ffa89c/chain/network/src/network_protocol/edge.rs#L130-L138

Fixes spec/network/peers_request.py.