### PR TITLE
chore: fix typo in command help message

### DIFF
--- a/tools/database/src/commands.rs
+++ b/tools/database/src/commands.rs
@@ -41,7 +41,7 @@ enum SubCommand {
     /// Make snapshot of the database
     MakeSnapshot(MakeSnapshotCommand),
 
-    /// Run migrations,
+    /// Run migrations
     RunMigrations(RunMigrationsCommand),
 
     /// Run performance test for State column reads.


### PR DESCRIPTION
Removing the extra comma.