### PR TITLE
fix(chunk-producers): guard the chunk producers change

### DIFF
--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -264,7 +264,9 @@ impl AllEpochConfig {
             let shard_ids = config.shard_layout.shard_ids();
             // Decrease the number of block and chunk producers from 100 to 20.
             config.num_block_producer_seats = 20;
-            config.validator_selection_config.num_chunk_producer_seats = 20;
+            if checked_feature!("stable", NoChunkOnlyProducers, protocol_version) {
+                config.validator_selection_config.num_chunk_producer_seats = 20;
+            }
             config.num_block_producer_seats_per_shard =
                 shard_ids.map(|_| config.num_block_producer_seats).collect();
             // Decrease the number of chunk producers.


### PR DESCRIPTION
This value is only introduced with `NoChunkOnlyProducers` feature, so I will guard it behind it.