### PR TITLE
debug(nayduck) - adding debug logs to the near test contracts build.rs

### DIFF
--- a/runtime/near-test-contracts/build.rs
+++ b/runtime/near-test-contracts/build.rs
@@ -1,7 +1,15 @@
+/// This script is used to build the contracts and copy the wasm files to the
+/// `res` directory.
+///
+/// It writes a few logs with the `debug` prefix. Those are ignored by cargo (as
+/// any other messages with prefix other than `cargo::`) but can be seen in the
+/// build logs.
 use std::env;
 use std::process::Command;
 
 type Error = Box<dyn std::error::Error>;
+
+const TEST_FEATURES_ENV: &str = "CARGO_FEATURE_TEST_FEATURES";
 
 fn main() {
     if let Err(err) = try_main() {
@@ -9,11 +17,14 @@ fn main() {
         std::process::exit(1);
     }
 }
+
 fn try_main() -> Result<(), Error> {
     let mut test_contract_features = vec!["latest_protocol"];
 
-    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_TEST_FEATURES");
-    if env::var("CARGO_FEATURE_TEST_FEATURES").is_ok() {
+    let test_features = &env::var(TEST_FEATURES_ENV);
+    println!("cargo:rerun-if-env-changed={TEST_FEATURES_ENV}");
+    println!("debug: test_features = {test_features:?}");
+    if test_features.is_ok() {
         test_contract_features.push("test_features");
     }
 
@@ -41,20 +52,28 @@ fn try_main() -> Result<(), Error> {
     Ok(())
 }
 
+/// build the contract and copy the wasm file to the `res` directory
 fn build_contract(dir: &str, args: &[&str], output: &str) -> Result<(), Error> {
     let target_dir = out_dir();
 
+    // build the contract
     let mut cmd = cargo_build_cmd(&target_dir);
     cmd.args(args);
     cmd.current_dir(dir);
     check_status(cmd)?;
 
-    let src =
-        target_dir.join(format!("wasm32-unknown-unknown/release/{}.wasm", dir.replace('-', "_")));
-    std::fs::copy(&src, format!("./res/{}.wasm", output))
-        .map_err(|err| format!("failed to copy `{}`: {}", src.display(), err))?;
+    // copy the wasm file to the `res` directory
+    let target_path = format!("wasm32-unknown-unknown/release/{}.wasm", dir.replace('-', "_"));
+    let from = target_dir.join(target_path);
+    let to = format!("./res/{}.wasm", output);
+    let copy_result = std::fs::copy(&from, &to);
+    copy_result.map_err(|err| format!("failed to copy `{}`: {}", from.display(), err))?;
+
     println!("cargo:rerun-if-changed=./{}/src/lib.rs", dir);
     println!("cargo:rerun-if-changed=./{}/Cargo.toml", dir);
+
+    println!("debug: from = {from:?}, to = {to:?}");
+
     Ok(())
 }
 
@@ -74,6 +93,7 @@ fn cargo_build_cmd(target_dir: &std::path::Path) -> Command {
 }
 
 fn check_status(mut cmd: Command) -> Result<(), Error> {
+    println!("debug: running command: {cmd:?}");
     cmd.status()
         .map_err(|err| format!("command `{cmd:?}` failed to run: {err}"))
         .and_then(|status| {


### PR DESCRIPTION
The slow chunk test in nayduck is still failing due to the test contract being built without the test_features. In my previous attempt it worked once, likely only because I made changes to the build.rs file. My current debug plan is to 
* Add logs to the build script
* ssh to the nayduck builder and see what's going on in there

This PR is the first part. Here is a sample output:
```
 ~/near/nearcore $ cargo clean && cargo build -p near-test-contracts --features test_features
 ~/near/nearcore $ cat target/debug/build/near-test-contracts-c89ce330453445c7/output
cargo:rerun-if-env-changed=CARGO_FEATURE_TEST_FEATURES
debug: test_features = Ok("1")
debug: running command: cd "./test-contract-rs" && env -u CARGO_BUILD_RUSTFLAGS -u CARGO_ENCODED_RUSTFLAGS -u RUSTC_WORKSPACE_WRAPPER CARGO_TARGET_DIR="/home/wacban-near/near/nearcore/target/debug/build/near-test-contracts-c89ce330453445c7/out" RUSTFLAGS="-Dwarnings" "cargo" "build" "--target=wasm32-unknown-unknown" "--release" "--features" "latest_protocol,test_features"
cargo:rerun-if-changed=././test-contract-rs/src/lib.rs
cargo:rerun-if-changed=././test-contract-rs/Cargo.toml
debug: from = "/home/wacban-near/near/nearcore/target/debug/build/near-test-contracts-c89ce330453445c7/out/wasm32-unknown-unknown/release/./test_contract_rs.wasm", to = "./res/test_contract_rs.wasm"
debug: running command: cd "./test-contract-rs" && env -u CARGO_BUILD_RUSTFLAGS -u CARGO_ENCODED_RUSTFLAGS -u RUSTC_WORKSPACE_WRAPPER CARGO_TARGET_DIR="/home/wacban-near/near/nearcore/target/debug/build/near-test-contracts-c89ce330453445c7/out" RUSTFLAGS="-Dwarnings" "cargo" "build" "--target=wasm32-unknown-unknown" "--release" "--features" "latest_protocol,test_features,nightly"
cargo:rerun-if-changed=././test-contract-rs/src/lib.rs
cargo:rerun-if-changed=././test-contract-rs/Cargo.toml
debug: from = "/home/wacban-near/near/nearcore/target/debug/build/near-test-contracts-c89ce330453445c7/out/wasm32-unknown-unknown/release/./test_contract_rs.wasm", to = "./res/nightly_test_contract_rs.wasm"
debug: running command: cd "./contract-for-fuzzing-rs" && env -u CARGO_BUILD_RUSTFLAGS -u CARGO_ENCODED_RUSTFLAGS -u RUSTC_WORKSPACE_WRAPPER CARGO_TARGET_DIR="/home/wacban-near/near/nearcore/target/debug/build/near-test-contracts-c89ce330453445c7/out" RUSTFLAGS="-Dwarnings" "cargo" "build" "--target=wasm32-unknown-unknown" "--release"
cargo:rerun-if-changed=././contract-for-fuzzing-rs/src/lib.rs
cargo:rerun-if-changed=././contract-for-fuzzing-rs/Cargo.toml
debug: from = "/home/wacban-near/near/nearcore/target/debug/build/near-test-contracts-c89ce330453445c7/out/wasm32-unknown-unknown/release/./contract_for_fuzzing_rs.wasm", to = "./res/contract_for_fuzzing_rs.wasm"
debug: running command: cd "./estimator-contract" && env -u CARGO_BUILD_RUSTFLAGS -u CARGO_ENCODED_RUSTFLAGS -u RUSTC_WORKSPACE_WRAPPER CARGO_TARGET_DIR="/home/wacban-near/near/nearcore/target/debug/build/near-test-contracts-c89ce330453445c7/out" RUSTFLAGS="-Dwarnings" "cargo" "build" "--target=wasm32-unknown-unknown" "--release"
cargo:rerun-if-changed=././estimator-contract/src/lib.rs
cargo:rerun-if-changed=././estimator-contract/Cargo.toml
debug: from = "/home/wacban-near/near/nearcore/target/debug/build/near-test-contracts-c89ce330453445c7/out/wasm32-unknown-unknown/release/./estimator_contract.wasm", to = "./res/stable_estimator_contract.wasm"
debug: running command: cd "./estimator-contract" && env -u CARGO_BUILD_RUSTFLAGS -u CARGO_ENCODED_RUSTFLAGS -u RUSTC_WORKSPACE_WRAPPER CARGO_TARGET_DIR="/home/wacban-near/near/nearcore/target/debug/build/near-test-contracts-c89ce330453445c7/out" RUSTFLAGS="-Dwarnings" "cargo" "build" "--target=wasm32-unknown-unknown" "--release" "--features" "nightly"
cargo:rerun-if-changed=././estimator-contract/src/lib.rs
cargo:rerun-if-changed=././estimator-contract/Cargo.toml
debug: from = "/home/wacban-near/near/nearcore/target/debug/build/near-test-contracts-c89ce330453445c7/out/wasm32-unknown-unknown/release/./estimator_contract.wasm", to = "./res/nightly_estimator_contract.wasm"
```