### PR TITLE
locust: attach less gas to `InitFT[Account]` txs

### DIFF
--- a/pytest/tests/loadtest/locust/common/ft.py
+++ b/pytest/tests/loadtest/locust/common/ft.py
@@ -158,6 +158,12 @@ class InitFT(FunctionCall):
             "total_supply": str(10**33)
         }
 
+    def attached_gas(self) -> int:
+        """
+        Avoid attaching excess gas to prevent triggering false-positive congestion control.
+        """
+        return 10 * TGAS
+
     def sender_account(self) -> Account:
         return self.contract
 
@@ -174,6 +180,12 @@ class InitFTAccount(FunctionCall):
 
     def args(self) -> dict:
         return {"account_id": self.account.key.account_id}
+
+    def attached_gas(self) -> int:
+        """
+        Avoid attaching excess gas to prevent triggering false-positive congestion control.
+        """
+        return 10 * TGAS
 
     def sender_account(self) -> Account:
         return self.account


### PR DESCRIPTION
Related to #11720 which reduced the gas attached to ft transfers to prevent triggering (false positive) congestion control.

Locust already starts sending ft transfers while new users are being ramped up. Initialization transactions still have 300 TGAS attached, which triggers congestion control even for moderate load. Hence this PR reduces the gas attached to these initialization transactions.