### PR TITLE
proto ver 70 & stabilize discard_custom_sections

### DIFF
--- a/core/parameters/res/runtime_configs/143.yaml
+++ b/core/parameters/res/runtime_configs/143.yaml
@@ -1,1 +1,0 @@
-discard_custom_sections: { old: false, new: true }

--- a/core/parameters/res/runtime_configs/70.yaml
+++ b/core/parameters/res/runtime_configs/70.yaml
@@ -1,1 +1,2 @@
 eth_implicit_accounts: { old: false, new: true }
+discard_custom_sections: { old: false, new: true }

--- a/core/parameters/res/runtime_configs/parameters.snap
+++ b/core/parameters/res/runtime_configs/parameters.snap
@@ -205,7 +205,7 @@ function_call_weight                    true
 vm_kind                                 NearVm
 eth_implicit_accounts                   true
 yield_resume                            true
-discard_custom_sections                 false
+discard_custom_sections                 true
 max_congestion_incoming_gas             20_000_000_000_000_000
 max_congestion_outgoing_gas             10_000_000_000_000_000
 max_congestion_memory_consumption              1_000_000_000

--- a/core/parameters/src/config_store.rs
+++ b/core/parameters/src/config_store.rs
@@ -47,7 +47,6 @@ static CONFIG_DIFFS: &[(ProtocolVersion, &str)] = &[
     (70, include_config!("70.yaml")),
     (129, include_config!("129.yaml")),
     (141, include_config!("141.yaml")),
-    (143, include_config!("143.yaml")),
 ];
 
 /// Testnet parameters for versions <= 29, which (incorrectly) differed from mainnet parameters

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__129.json.snap
@@ -178,7 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
-    "discard_custom_sections": false,
+    "discard_custom_sections": true,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": true,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__141.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__141.json.snap
@@ -178,7 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
-    "discard_custom_sections": false,
+    "discard_custom_sections": true,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": true,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__70.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__70.json.snap
@@ -178,7 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
-    "discard_custom_sections": false,
+    "discard_custom_sections": true,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
@@ -178,7 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
-    "discard_custom_sections": false,
+    "discard_custom_sections": true,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": true,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_141.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_141.json.snap
@@ -178,7 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
-    "discard_custom_sections": false,
+    "discard_custom_sections": true,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": true,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_70.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_70.json.snap
@@ -178,7 +178,7 @@ expression: config_view
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
-    "discard_custom_sections": false,
+    "discard_custom_sections": true,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__view__tests__runtime_config_view.snap
+++ b/core/parameters/src/snapshots/near_parameters__view__tests__runtime_config_view.snap
@@ -178,7 +178,7 @@ expression: "&view"
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
-    "discard_custom_sections": false,
+    "discard_custom_sections": true,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
+++ b/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
@@ -178,7 +178,7 @@ expression: "&view"
     "regular_op_cost": 822756,
     "vm_kind": "<REDACTED>",
     "disable_9393_fix": false,
-    "discard_custom_sections": false,
+    "discard_custom_sections": true,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,


### PR DESCRIPTION
This stabilizes the recently implemented #11721. As the protocol version for 2.0 has already been bumped to 69, this is now 70 for the release that comes after 2.0.