### PR TITLE
fix: Support new stateless validation messages in python serializer

### DIFF
--- a/pytest/lib/messages/block.py
+++ b/pytest/lib/messages/block.py
@@ -167,8 +167,7 @@ class ShardChunkHeaderV3:
             dict(block_schema + crypto_schema)).serialize(inner)
         inner_hash = hashlib.sha256(inner_serialized).digest()
 
-        return hashlib.sha256(inner_hash +
-                              inner.V2.encoded_merkle_root).digest()
+        return hashlib.sha256(inner_hash + inner.encoded_merkle_root).digest()
 
 
 class ShardChunkHeaderInner:
@@ -209,7 +208,13 @@ class PartialEncodedChunk:
             elif header_version == 'V2':
                 return header.V2.inner
             elif header_version == 'V3':
-                return header.V3.inner
+                v3_inner_version = header.V3.inner.enum
+                if v3_inner_version == 'V1':
+                    return header.V3.inner.V1
+                elif v3_inner_version == 'V2':
+                    return header.V3.inner.V2
+                elif v3_inner_version == 'V3':
+                    return header.V3.inner.V3
             assert False, "unknown header version"
 
     def header_version(self):

--- a/pytest/lib/messages/block.py
+++ b/pytest/lib/messages/block.py
@@ -293,8 +293,10 @@ class PartialEncodedStateWitness:
 class PartialEncodedStateWitnessInner:
     pass
 
+
 class SignatureDifferentiator:
     pass
+
 
 block_schema = [
     [
@@ -879,16 +881,6 @@ block_schema = [
         }
     ],
     [
-        ChunkEndorsementInner, {
-            'kind':
-                'struct',
-            'fields': [
-                ['chunk_hash', [32]],
-                ['signature_differentiator', ['u8']],
-            ]
-        }
-    ],
-    [
         ChunkEndorsement, {
             'kind':
                 'struct',
@@ -900,12 +892,19 @@ block_schema = [
         }
     ],
     [
-        ChunkStateWitnessAck, {
-            'kind': 
+        ChunkEndorsementInner, {
+            'kind':
                 'struct',
             'fields': [
                 ['chunk_hash', [32]],
+                ['signature_differentiator', SignatureDifferentiator],
             ]
+        }
+    ],
+    [
+        ChunkStateWitnessAck, {
+            'kind': 'struct',
+            'fields': [['chunk_hash', [32]],]
         }
     ],
     [
@@ -929,8 +928,12 @@ block_schema = [
                 ['part_ord', 'u64'],
                 ['part', ['u8']],
                 ['encoded_length', 'u64'],
-                ['signature_differentiator', ['u8']],
+                ['signature_differentiator', SignatureDifferentiator],
             ]
         }
     ],
+    [SignatureDifferentiator, {
+        'kind': 'struct',
+        'fields': [['0', 'string']]
+    }]
 ]

--- a/pytest/lib/messages/block.py
+++ b/pytest/lib/messages/block.py
@@ -274,6 +274,28 @@ class CongestionInfoV1:
     pass
 
 
+class ChunkEndorsement:
+    pass
+
+
+class ChunkEndorsementInner:
+    pass
+
+
+class ChunkStateWitnessAck:
+    pass
+
+
+class PartialEncodedStateWitness:
+    pass
+
+
+class PartialEncodedStateWitnessInner:
+    pass
+
+class SignatureDifferentiator:
+    pass
+
 block_schema = [
     [
         Block, {
@@ -855,5 +877,60 @@ block_schema = [
                 ['allowed_shard', 'u16'],
             ]
         }
-    ]
+    ],
+    [
+        ChunkEndorsementInner, {
+            'kind':
+                'struct',
+            'fields': [
+                ['chunk_hash', [32]],
+                ['signature_differentiator', ['u8']],
+            ]
+        }
+    ],
+    [
+        ChunkEndorsement, {
+            'kind':
+                'struct',
+            'fields': [
+                ['inner', ChunkEndorsementInner],
+                ['account_id', 'string'],
+                ['signature', Signature],
+            ]
+        }
+    ],
+    [
+        ChunkStateWitnessAck, {
+            'kind': 
+                'struct',
+            'fields': [
+                ['chunk_hash', [32]],
+            ]
+        }
+    ],
+    [
+        PartialEncodedStateWitness, {
+            'kind':
+                'struct',
+            'fields': [
+                ['inner', PartialEncodedStateWitnessInner],
+                ['signature', Signature],
+            ]
+        }
+    ],
+    [
+        PartialEncodedStateWitnessInner, {
+            'kind':
+                'struct',
+            'fields': [
+                ['epoch_id', [32]],
+                ['shard_id', 'u64'],
+                ['height_created', 'u64'],
+                ['part_ord', 'u64'],
+                ['part', ['u8']],
+                ['encoded_length', 'u64'],
+                ['signature_differentiator', ['u8']],
+            ]
+        }
+    ],
 ]

--- a/pytest/lib/messages/network.py
+++ b/pytest/lib/messages/network.py
@@ -1,6 +1,6 @@
 from messages.crypto import Signature, PublicKey, MerklePath, ShardProof
 from messages.tx import SignedTransaction, Receipt
-from messages.block import Block, Approval, PartialEncodedChunk, PartialEncodedChunkV1, PartialEncodedChunkRequestMsg, PartialEncodedChunkResponseMsg, PartialEncodedChunkForwardMsg, BlockHeader, ShardChunk, ShardChunkHeader, ShardChunkHeaderV1
+from messages.block import Block, Approval, PartialEncodedChunk, PartialEncodedChunkV1, PartialEncodedChunkRequestMsg, PartialEncodedChunkResponseMsg, PartialEncodedChunkForwardMsg, BlockHeader, ShardChunk, ShardChunkHeader, ShardChunkHeaderV1, ChunkEndorsement, ChunkStateWitnessAck, PartialEncodedStateWitness
 from messages.shard import StateRootNode
 
 
@@ -371,7 +371,14 @@ network_schema = [
                 ['Pong', PingPong],
                 ['VersionedPartialEncodedChunk', PartialEncodedChunk],
                 ['VersionedStateResponse', StateResponseInfo],
-                ['PartialEncodedChunkForward', PartialEncodedChunkForwardMsg]
+                ['PartialEncodedChunkForward', PartialEncodedChunkForwardMsg],
+                ['ChunkEndorsement', ChunkEndorsement],
+                ['ChunkStateWitnessAck', ChunkStateWitnessAck],
+                ['PartialEncodedStateWitness', PartialEncodedStateWitness],
+                [
+                    'PartialEncodedStateWitnessForward',
+                    PartialEncodedStateWitness
+                ]
             ]
         }
     ],

--- a/pytest/lib/messages/network.py
+++ b/pytest/lib/messages/network.py
@@ -356,22 +356,23 @@ network_schema = [
                 ['BlockApproval', Approval],
                 ['ForwardTx', SignedTransaction],
                 ['TxStatusRequest', ('string', [32])],
-                ['TxStatusResponse', None],  # TODO
-                ['QueryRequest', None],  # TODO
-                ['QueryResponse', None],  # TODO
-                ['ReceiptOutcomeRequest', [32]],
-                ['ReceiptOutcomeResponse', None],  # TODO
-                ['StateRequestHeader', ('u64', [32])],
-                ['StateRequestPart', ('u64', [32], 'u64')],
-                ['StateResponseInfo', StateResponseInfoV1],
+                ['TxStatusResponse', None],  # TODO: Implement this.
+                ['_UnusedQueryRequest', None],
+                ['_UnusedQueryResponse', None],
+                ['_UnusedReceiptOutcomeRequest', None],
+                ['_UnusedReceiptOutcomeResponse', None],
+                ['_UnusedStateRequestHeader', None],
+                ['_UnusedStateRequestPart', None],
+                ['StateResponse', StateResponseInfoV1],
                 ['PartialEncodedChunkRequest', PartialEncodedChunkRequestMsg],
                 ['PartialEncodedChunkResponse', PartialEncodedChunkResponseMsg],
-                ['PartialEncodedChunk', PartialEncodedChunkV1],
+                ['_UnusedPartialEncodedChunk', None],
                 ['Ping', PingPong],
                 ['Pong', PingPong],
                 ['VersionedPartialEncodedChunk', PartialEncodedChunk],
-                ['VersionedStateResponse', StateResponseInfo],
+                ['_UnusedVersionedStateResponse', None],
                 ['PartialEncodedChunkForward', PartialEncodedChunkForwardMsg],
+                ['_UnusedChunkStateWitness', None],
                 ['ChunkEndorsement', ChunkEndorsement],
                 ['ChunkStateWitnessAck', ChunkStateWitnessAck],
                 ['PartialEncodedStateWitness', PartialEncodedStateWitness],

--- a/pytest/lib/serializer.py
+++ b/pytest/lib/serializer.py
@@ -3,6 +3,8 @@
 import logging
 import pathlib
 import sys
+import jsonpickle  # pip install jsonpickle
+import json
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 
@@ -194,10 +196,14 @@ class BinarySerializer:
         self.serialize_struct(obj)
         return bytes(self.array)
 
+    def dump(self, obj):
+        serialized = jsonpickle.encode(obj)
+        return (json.dumps(json.loads(serialized), indent=2))
+
     def deserialize(self, bytes_, type_):
         self.array = bytearray(bytes_)
         self.offset = 0
         ret = self.deserialize_field(type_)
-        assert self.offset == len(bytes_), "%s != %s" % (self.offset,
-                                                         len(bytes_))
+        assert self.offset == len(bytes_), "%s != %s, ret=%s" % (
+            self.offset, len(bytes_), self.dump(ret))
         return ret

--- a/pytest/tests/sanity/sync_chunks_from_archival.py
+++ b/pytest/tests/sanity/sync_chunks_from_archival.py
@@ -53,23 +53,19 @@ class Handler(ProxyHandler):
                 self.hash_to_metadata[hash_] = (height, shard_id)
 
             if msg_kind == 'VersionedPartialEncodedChunk':
-                header = msg.Routed.body.VersionedPartialEncodedChunk.inner_header(
+                inner_header = msg.Routed.body.VersionedPartialEncodedChunk.inner_header(
                 )
                 header_version = msg.Routed.body.VersionedPartialEncodedChunk.header_version(
                 )
-                if header_version == 'V3':
-                    height = header.V2.height_created
-                    shard_id = header.V2.shard_id
-                else:
-                    height = header.height_created
-                    shard_id = header.shard_id
+                height = inner_header.height_created
+                shard_id = inner_header.shard_id
 
                 if header_version == 'V1':
-                    hash_ = ShardChunkHeaderV1.chunk_hash(header)
+                    hash_ = ShardChunkHeaderV1.chunk_hash(inner_header)
                 elif header_version == 'V2':
-                    hash_ = ShardChunkHeaderV2.chunk_hash(header)
+                    hash_ = ShardChunkHeaderV2.chunk_hash(inner_header)
                 elif header_version == 'V3':
-                    hash_ = ShardChunkHeaderV3.chunk_hash(header)
+                    hash_ = ShardChunkHeaderV3.chunk_hash(inner_header)
                 self.hash_to_metadata[hash_] = (height, shard_id)
 
             if msg_kind == 'PartialEncodedChunkRequest':


### PR DESCRIPTION
Nayduck test `sync_chunks_from_archival.py` has been failing. While debugging it, noticed that the failure reasons pre-stateless and post-stateless are different. This PR does NOT fix the test but addresses 2 issues that makes the test fail due to different reason when stateless protocol is enabled:

1) Stateless validation messages not represented in python serializer (used in the nayduck test to parse borsh-serialized messages)
2) New chunk header/inner structure was not correctly handled.

This PR addresses these issues. Note that the test is still failing after this change, but the failure is now the same as pre-stateless validation. Will follow-up with that failure separately.