### PR TITLE
fix(gc): don't garbage collect Hot DB when there's no Cold DB

### DIFF
--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -294,6 +294,7 @@ impl TestLoopBuilder {
                 epoch_manager.clone(),
                 client_config.gc.clone(),
                 client_config.archive,
+                false,
             );
             // We don't send messages to `GCActor` so adapter is not needed.
             self.test_loop.register_actor_for_index(idx, gc_actor, None);

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -377,6 +377,7 @@ pub fn start_with_config_and_synchronization(
         epoch_manager.clone(),
         config.client_config.gc.clone(),
         config.client_config.archive,
+        split_store.is_some(),
     ));
 
     let StartClientResult { client_actor, client_arbiter_handle, resharding_handle } = start_client(


### PR DESCRIPTION
https://github.com/near/nearcore/pull/10906 made a change that will create a database with store type set to `Hot` when starting a node with archive=true with no existing database. Then https://github.com/near/nearcore/pull/10960 fixed a bug that would have made such a node crash when checking whether it's archival. The result is that the assumption that we can proceed to garbase collect an archival database if the type is `Hot` doesn't hold anymore, because nodes created like this but with no "cold_store" set in the config will just have a hot database, but no cold one that data gets moved to. This was causing block_sync_archival.py to fail because blocks were being garbage collected.