### PR TITLE
Add a metric showing how much space nodes and values take up in the recorded Trie

### DIFF
--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -40,7 +40,7 @@ use std::fmt::Write;
 use std::hash::Hash;
 use std::str;
 use std::sync::{Arc, RwLock, RwLockReadGuard};
-pub use trie_recording::TrieRecorderStats;
+pub use trie_recording::{SubtreeSize, TrieRecorderStats};
 
 pub mod accounting_cache;
 mod config;

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -263,6 +263,15 @@ impl TrieRecorder {
     }
 }
 
+impl SubtreeSize {
+    pub fn saturating_add(self, other: Self) -> Self {
+        SubtreeSize {
+            nodes_size: self.nodes_size.saturating_add(other.nodes_size),
+            values_size: self.values_size.saturating_add(other.values_size),
+        }
+    }
+}
+
 #[cfg(test)]
 mod trie_recording_tests {
     use crate::db::refcount::decode_value_with_rc;

--- a/runtime/runtime/src/metrics.rs
+++ b/runtime/runtime/src/metrics.rs
@@ -9,6 +9,7 @@ use near_o11y::metrics::{
 use near_parameters::config::CongestionControlConfig;
 use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::types::ShardId;
+use near_store::trie::SubtreeSize;
 use near_store::Trie;
 use once_cell::sync::Lazy;
 use std::time::Duration;
@@ -416,6 +417,16 @@ static CHUNK_RECORDED_TRIE_COLUMN_SIZE: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
+static CHUNK_RECORDED_TRIE_NODES_VALUES_SIZE: Lazy<HistogramVec> = Lazy::new(|| {
+    try_create_histogram_vec(
+        "near_chunk_recorded_trie_nodes_values_size",
+        "Measures size of values and non-value nodes in the recorded trie. Allows to measure how much overhead there is from non-value nodes.",
+        &["shard_id", "trie_part"], // trie_part is either "values" or "nodes"
+        Some(buckets_for_chunk_storage_proof_size()),
+    )
+    .unwrap()
+});
+
 pub(crate) static CHUNK_RECEIPTS_LIMITED_BY: Lazy<IntCounterVec> = Lazy::new(|| {
     try_create_int_counter_vec(
         "near_chunk_receipts_limited_by",
@@ -725,11 +736,22 @@ pub fn report_recorded_column_sizes(trie: &Trie, apply_state: &ApplyState) {
         return;
     };
 
+    let mut total_size = SubtreeSize::default();
+
     let shard_id_str = apply_state.shard_id.to_string();
     for column in trie_recorder_stats.trie_column_sizes.iter() {
         let column_size = column.size.nodes_size.saturating_add(column.size.values_size);
         CHUNK_RECORDED_TRIE_COLUMN_SIZE
             .with_label_values(&[shard_id_str.as_str(), column.column_name])
             .observe(column_size as f64);
+
+        total_size = total_size.saturating_add(column.size);
     }
+
+    CHUNK_RECORDED_TRIE_NODES_VALUES_SIZE
+        .with_label_values(&[shard_id_str.as_str(), "nodes"])
+        .observe(total_size.nodes_size as f64);
+    CHUNK_RECORDED_TRIE_NODES_VALUES_SIZE
+        .with_label_values(&[shard_id_str.as_str(), "values"])
+        .observe(total_size.values_size as f64);
 }

--- a/runtime/runtime/src/metrics.rs
+++ b/runtime/runtime/src/metrics.rs
@@ -727,8 +727,9 @@ pub fn report_recorded_column_sizes(trie: &Trie, apply_state: &ApplyState) {
 
     let shard_id_str = apply_state.shard_id.to_string();
     for column in trie_recorder_stats.trie_column_sizes.iter() {
+        let column_size = column.size.nodes_size.saturating_add(column.size.values_size);
         CHUNK_RECORDED_TRIE_COLUMN_SIZE
             .with_label_values(&[shard_id_str.as_str(), column.column_name])
-            .observe(column.size as f64);
+            .observe(column_size as f64);
     }
 }


### PR DESCRIPTION
Follow up on https://github.com/near/nearcore/pull/11567

Trie is made up of nodes and values referenced by the leaf nodes. Let's add a metric which shows how much space is taken up by the nodes and the values in the recorded trie. It'll help us estimate how much overhead there is from using Merkle trees.

To get the total size I summed the sizes of subtrees for all trie columns. This is a little bit inaccurate, because it doesn't include the root node, but it should be good enough, the root node is small so it doesn't change the results much.

Here's how the trie metrics look like on the current mainnet traffic:
![image](https://github.com/near/nearcore/assets/149345204/b0616400-42a0-4888-94ff-771d8642b872)
![image](https://github.com/near/nearcore/assets/149345204/2ae3eefd-6901-48f4-b876-ea3eb621c529)

You can see a preview here:
https://grafana.nearone.org/d/ddrc1ewgllb0gf/witness-size?var-query0=&var-chain_id=mainnet&var-query0-2=&var-role=dev&var-query0-3=&var-node_type=$__all&var-query0-4=&var-node_id=jan-mainnet-node&var-query0-5=&editIndex=4&var-shard_id=$__all&refresh=1m&from=now-3h&to=now&timezone=browser&showCategory=Bar%20chart