### PR TITLE
fix: block apply in the past 

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -748,6 +748,7 @@ impl RuntimeAdapter for NightshadeRuntime {
             StorageDataSource::DbTrieOnly => {
                 // If there is no flat storage on disk, use trie but simulate costs with enabled
                 // flat storage by not charging gas for trie nodes.
+                // WARNING: should never be used in production! Consider this option only for debugging or replaying blocks.
                 let mut trie = self.tries.get_trie_for_shard(shard_uid, storage_config.state_root);
                 trie.dont_charge_gas_for_trie_node_access();
                 trie
@@ -968,6 +969,7 @@ impl RuntimeAdapter for NightshadeRuntime {
             StorageDataSource::DbTrieOnly => {
                 // If there is no flat storage on disk, use trie but simulate costs with enabled
                 // flat storage by not charging gas for trie nodes.
+                // WARNING: should never be used in production! Consider this option only for debugging or replaying blocks.
                 let mut trie = self.get_trie_for_shard(
                     shard_id,
                     &block.prev_block_hash,

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -287,6 +287,19 @@ impl RuntimeStorageConfig {
             state_patch: Default::default(),
         }
     }
+
+    /// Creates a [RuntimeStorageConfig] with [StorageDataSource::DbTrieOnly].
+    /// Flat storage is disabled because it is implied to be missing.
+    ///
+    /// This's meant to be used only to replay blocks.
+    pub fn with_db_trie_only(state_root: StateRoot) -> Self {
+        Self {
+            state_root,
+            use_flat_storage: false,
+            source: StorageDataSource::DbTrieOnly,
+            state_patch: Default::default(),
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -264,6 +264,7 @@ pub enum StorageDataSource {
     /// Trie is present in DB and flat storage is not.
     /// Used to reply past blocks and simulate gas costs as if flat storage
     /// was present.
+    /// WARNING: do not use this variant in production!
     DbTrieOnly,
     /// State data is supplied from state witness, there is no state data
     /// stored on disk.

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -261,6 +261,10 @@ impl ChainGenesis {
 pub enum StorageDataSource {
     /// Full state data is present in DB.
     Db,
+    /// Trie is present in DB and flat storage is not.
+    /// Used to reply past blocks and simulate gas costs as if flat storage
+    /// was present.
+    DbTrieOnly,
     /// State data is supplied from state witness, there is no state data
     /// stored on disk.
     Recorded(PartialStorage),

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -292,7 +292,7 @@ impl RuntimeStorageConfig {
     /// Flat storage is disabled because it is implied to be missing.
     ///
     /// This's meant to be used only to replay blocks.
-    pub fn with_db_trie_only(state_root: StateRoot) -> Self {
+    pub fn new_with_db_trie_only(state_root: StateRoot) -> Self {
         Self {
             state_root,
             use_flat_storage: false,

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -660,6 +660,11 @@ impl Trie {
         }
     }
 
+    /// Helper to simulate gas costs as if flat storage was present.
+    pub fn dont_charge_gas_for_trie_node_access(&mut self) {
+        self.charge_gas_for_trie_node_access = false;
+    }
+
     /// Makes a new trie that has everything the same except that access
     /// through that trie accumulates a state proof for all nodes accessed.
     pub fn recording_reads(&self) -> Self {

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -1,9 +1,8 @@
-use crate::cli::ApplyRangeMode;
+use crate::cli::{ApplyRangeMode, StorageSource};
 use near_chain::chain::collect_receipts_from_response;
 use near_chain::migrations::check_if_block_is_first_with_chunk_of_version;
 use near_chain::types::{
     ApplyChunkBlockContext, ApplyChunkResult, ApplyChunkShardContext, RuntimeAdapter,
-    RuntimeStorageConfig, StorageDataSource,
 };
 use near_chain::{ChainStore, ChainStoreAccess, ChainStoreUpdate};
 use near_chain_configs::Genesis;
@@ -125,8 +124,7 @@ fn apply_block_from_range(
     verbose_output: bool,
     csv_file_mutex: &Mutex<Option<&mut File>>,
     only_contracts: bool,
-    use_flat_storage: bool,
-    use_trie_for_free: bool,
+    storage: StorageSource,
 ) {
     // normally save_trie_changes depends on whether the node is
     // archival, but here we don't care, and can just set it to false
@@ -234,15 +232,9 @@ fn apply_block_from_range(
             }
         }
 
-        let mut storage =
-            RuntimeStorageConfig::new(*chunk_inner.prev_state_root(), use_flat_storage);
-        if use_trie_for_free {
-            storage.source = StorageDataSource::DbTrieOnly;
-        }
-
         runtime_adapter
             .apply_chunk(
-                storage,
+                storage.create_runtime_storage(*chunk_inner.prev_state_root()),
                 ApplyChunkReason::UpdateTrackedShard,
                 ApplyChunkShardContext {
                     shard_id,
@@ -266,14 +258,9 @@ fn apply_block_from_range(
             chain_store.get_chunk_extra(block.header().prev_hash(), &shard_uid).unwrap();
         prev_chunk_extra = Some(chunk_extra.clone());
 
-        let mut storage = RuntimeStorageConfig::new(*chunk_extra.state_root(), use_flat_storage);
-        if use_trie_for_free {
-            storage.source = StorageDataSource::DbTrieOnly;
-        }
-
         runtime_adapter
             .apply_chunk(
-                storage,
+                storage.create_runtime_storage(*chunk_extra.state_root()),
                 ApplyChunkReason::UpdateTrackedShard,
                 ApplyChunkShardContext {
                     shard_id,
@@ -389,8 +376,7 @@ pub fn apply_chain_range(
     verbose_output: bool,
     csv_file: Option<&mut File>,
     only_contracts: bool,
-    use_flat_storage: bool,
-    use_trie_for_free: bool,
+    storage: StorageSource,
 ) {
     let parent_span = tracing::debug_span!(
         target: "state_viewer",
@@ -400,16 +386,14 @@ pub fn apply_chain_range(
         ?end_height,
         %shard_id,
         only_contracts,
-        use_flat_storage,
-        use_trie_for_free)
+        ?storage)
     .entered();
     let chain_store = ChainStore::new(store.clone(), genesis.config.genesis_height, false);
     let (start_height, end_height) = match mode {
         ApplyRangeMode::Benchmarking => {
             // Benchmarking mode requires flat storage and retrieves start and
             // end heights from flat storage and chain.
-            assert!(use_flat_storage);
-            assert!(!use_trie_for_free);
+            assert!(matches!(storage, StorageSource::FlatStorage));
             assert!(start_height.is_none());
             assert!(end_height.is_none());
 
@@ -473,8 +457,7 @@ pub fn apply_chain_range(
             verbose_output,
             &csv_file_mutex,
             only_contracts,
-            use_flat_storage,
-            use_trie_for_free,
+            storage,
         );
     };
 
@@ -559,7 +542,7 @@ mod test {
     use nearcore::NightshadeRuntime;
 
     use crate::apply_chain_range::apply_chain_range;
-    use crate::cli::ApplyRangeMode;
+    use crate::cli::{ApplyRangeMode, StorageSource};
 
     fn setup(epoch_length: NumBlocks) -> (Store, Genesis, TestEnv) {
         let mut genesis =
@@ -658,8 +641,7 @@ mod test {
             true,
             None,
             false,
-            false,
-            false,
+            StorageSource::Trie,
         );
     }
 
@@ -703,8 +685,7 @@ mod test {
             true,
             Some(file.as_file_mut()),
             false,
-            false,
-            false,
+            StorageSource::Trie,
         );
         let mut csv = String::new();
         file.as_file_mut().seek(SeekFrom::Start(0)).unwrap();

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -242,14 +242,10 @@ impl ApplyChunkCmd {
 #[derive(clap::Parser, Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ApplyRangeMode {
     /// Applies chunks one after another in order of increasing heights.
-    /// TODO(#8741): doesn't work. Remove dependency on flat storage
-    /// by simulating correct costs. Consider reintroducing DbTrieOnly
-    /// read mode removed at #10490.
     Sequential,
     /// Applies chunks in parallel.
     /// Useful for quick correctness check of applying chunks by comparing
     /// results with `ChunkExtra`s.
-    /// TODO(#8741): doesn't work, same as above.
     Parallel,
     /// Sequentially applies chunks from flat storage head until chain
     /// final head, moving flat head forward. Use in combination with
@@ -274,6 +270,10 @@ pub struct ApplyRangeCmd {
     only_contracts: bool,
     #[clap(long)]
     use_flat_storage: bool,
+    /// Use the data stored in trie, but without paying extra gas costs.
+    /// This could be used to simulate flat storage when the latter is not present.
+    #[clap(long)]
+    use_trie_for_free: bool,
     #[clap(subcommand)]
     mode: ApplyRangeMode,
 }
@@ -292,6 +292,7 @@ impl ApplyRangeCmd {
             store,
             self.only_contracts,
             self.use_flat_storage,
+            self.use_trie_for_free,
         );
     }
 }

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -188,6 +188,10 @@ pub struct ApplyCmd {
     shard_id: ShardId,
     #[clap(long)]
     use_flat_storage: bool,
+    /// Use the data stored in trie, but without paying extra gas costs.
+    /// This could be used to simulate flat storage when the latter is not present.
+    #[clap(long)]
+    use_trie_for_free: bool,
 }
 
 impl ApplyCmd {
@@ -196,6 +200,7 @@ impl ApplyCmd {
             self.height,
             self.shard_id,
             self.use_flat_storage,
+            self.use_trie_for_free,
             home_dir,
             near_config,
             store,
@@ -212,13 +217,25 @@ pub struct ApplyChunkCmd {
     target_height: Option<u64>,
     #[clap(long)]
     use_flat_storage: bool,
+    /// Use the data stored in trie, but without paying extra gas costs.
+    /// This could be used to simulate flat storage when the latter is not present.
+    #[clap(long)]
+    use_trie_for_free: bool,
 }
 
 impl ApplyChunkCmd {
     pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
         let hash = ChunkHash::from(CryptoHash::from_str(&self.chunk_hash).unwrap());
-        apply_chunk(home_dir, near_config, store, hash, self.target_height, self.use_flat_storage)
-            .unwrap()
+        apply_chunk(
+            home_dir,
+            near_config,
+            store,
+            hash,
+            self.target_height,
+            self.use_flat_storage,
+            self.use_trie_for_free,
+        )
+        .unwrap()
     }
 }
 
@@ -285,12 +302,24 @@ pub struct ApplyReceiptCmd {
     hash: String,
     #[clap(long)]
     use_flat_storage: bool,
+    /// Use the data stored in trie, but without paying extra gas costs.
+    /// This could be used to simulate flat storage when the latter is not present.
+    #[clap(long)]
+    use_trie_for_free: bool,
 }
 
 impl ApplyReceiptCmd {
     pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
         let hash = CryptoHash::from_str(&self.hash).unwrap();
-        apply_receipt(home_dir, near_config, store, hash, self.use_flat_storage).unwrap();
+        apply_receipt(
+            home_dir,
+            near_config,
+            store,
+            hash,
+            self.use_flat_storage,
+            self.use_trie_for_free,
+        )
+        .unwrap();
     }
 }
 
@@ -300,12 +329,17 @@ pub struct ApplyTxCmd {
     hash: String,
     #[clap(long)]
     use_flat_storage: bool,
+    /// Use the data stored in trie, but without paying extra gas costs.
+    /// This could be used to simulate flat storage when the latter is not present.
+    #[clap(long)]
+    use_trie_for_free: bool,
 }
 
 impl ApplyTxCmd {
     pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
         let hash = CryptoHash::from_str(&self.hash).unwrap();
-        apply_tx(home_dir, near_config, store, hash, self.use_flat_storage).unwrap();
+        apply_tx(home_dir, near_config, store, hash, self.use_flat_storage, self.use_trie_for_free)
+            .unwrap();
     }
 }
 

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -195,7 +195,7 @@ impl StorageSource {
     pub fn create_runtime_storage(&self, state_root: StateRoot) -> RuntimeStorageConfig {
         match self {
             StorageSource::Trie => RuntimeStorageConfig::new(state_root, false),
-            StorageSource::TrieFree => RuntimeStorageConfig::with_db_trie_only(state_root),
+            StorageSource::TrieFree => RuntimeStorageConfig::new_with_db_trie_only(state_root),
             StorageSource::FlatStorage => RuntimeStorageConfig::new(state_root, true),
         }
     }

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -246,6 +246,7 @@ pub(crate) fn apply_range(
     store: Store,
     only_contracts: bool,
     use_flat_storage: bool,
+    use_trie_for_free: bool,
 ) {
     let mut csv_file = csv_file.map(|filename| std::fs::File::create(filename).unwrap());
 
@@ -270,6 +271,7 @@ pub(crate) fn apply_range(
         csv_file.as_mut(),
         only_contracts,
         use_flat_storage,
+        use_trie_for_free,
     );
 }
 

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -225,11 +225,19 @@ pub(crate) fn apply_chunk(
         use_flat_storage,
         use_trie_for_free,
     )?;
+    let protocol_version = if let Some(height) = target_height {
+        // Retrieve the protocol version at the given height.
+        let block_hash = chain_store.get_block_hash_by_height(height)?;
+        chain_store.get_block(&block_hash)?.header().latest_protocol_version()
+    } else {
+        // No block height specified, fallback to current protocol version.
+        PROTOCOL_VERSION
+    };
     // Most probably `PROTOCOL_VERSION` won't work if the target_height points to a time
     // before congestion control has been introduced.
     println!(
         "resulting chunk extra:\n{:?}",
-        resulting_chunk_extra(&apply_result, gas_limit, PROTOCOL_VERSION)
+        resulting_chunk_extra(&apply_result, gas_limit, protocol_version)
     );
     Ok(())
 }


### PR DESCRIPTION
This PR fixes commands such as `neard view-state apply` and `neard view-state apply-range` when used on a block height that doesn't have flat storage built for it. 

It works by re enabling the feature of accessing trie nodes without paying gas costs (removed in #10490).

Probably it also fixes #8741.

