### PR TITLE
fix(gc): don't garbage collect before cold storage is set up

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -547,7 +547,7 @@ impl NightshadeRuntime {
             } else {
                 // If kind is DbKind::Hot but cold_head is not set, it means the initial cold storage
                 // migration has not finished yet, in which case we should not garbage collect anything.
-                return Ok(0);
+                return Ok(self.genesis_config.genesis_height);
             }
         }
         Ok(epoch_start_height)


### PR DESCRIPTION
in `NightshadeRuntime::get_gc_stop_height_impl()`, we check if the db kind is Hot *and* cold_head is set to Some(), and if so we modify the stopping point of garbage collection to not be higher than the cold head epoch's first block. The problem is that the cold storage migration loop can run before the genesis block has been built and stored on disk, in which case updating the cold storage head in cold_store_migration() [here](https://github.com/near/nearcore/blob/42a0c224d6777f65c0d3d0b6010842ae774f93d6/nearcore/src/cold_storage.rs#L294) fails [here](https://github.com/near/nearcore/blob/42a0c224d6777f65c0d3d0b6010842ae774f93d6/core/store/src/cold_storage.rs#L274), because the genesis block height has not yet been written to the BlockHeight column.

This is not a problem for the cold storage migration because it retries on error after a delay, but it means that we skip modifying the return value of `NightshadeRuntime::get_gc_stop_height_impl()` because cold_head is None. So we can fix it by returning 0 if the db kind is hot but there's no cold_head, because the db kind should only be Hot for split storage archival nodes.

To check that this is what is happening before this change, run block_sync_archival.py and it should fail in get_all_blocks() with a not found error. Then if you run `neard --home ~/.near/test2_finished/ run`, you will see an error like this:

```
start_with_config: Cold head is behind hot tail. cold head height: 0 hot tail height 8
```

After this change block_sync_archival.py still fails, but at a later point for a different reason