### PR TITLE
fix(mocknet) add x permissions on the backup binary

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -1210,7 +1210,7 @@ class NeardRunner:
         # Binaries can be replaced during a test.
         # Save the binary that was used to make the backup to prevent db version incompatibility when restoring the backup.
         neard_path = os.path.join(backup_dir, "neard")
-        shutil.copyfile(self.data['current_neard_path'], neard_path)
+        shutil.copy2(self.data['current_neard_path'], neard_path)
 
         backups = self.data.get('backups', {})
         if name in backups:


### PR DESCRIPTION
`shutil.copyfile` does not preserve permissions