### PR TITLE
Update otel-traces documentation

### DIFF
--- a/docs/practices/workflows/otel_traces.md
+++ b/docs/practices/workflows/otel_traces.md
@@ -110,6 +110,16 @@ Or optionally with `rust_log` setting to reduce logging on stdout:
 
 and invoke `sudo pkill -HUP neard`. Double check that the collector is running as well.
 
+Note that the `rust_log` log level has to be higher than the `opentelemetry` level. Traces won't be generated if the logs aren't emitted.\
+This wouldn't work because the default `rust_log` level doesn't emit debug logs for runtime:
+```json
+{ "opentelemetry": "info,runtime=debug,vm=debug"}
+```
+But this works:
+```json
+{ "opentelemetry": "info,runtime=debug,vm=debug", "rust_log": "info,runtime=debug,vm=debug" }
+```
+
 <blockquote style="background: rgba(255, 200, 0, 0.1); border: 5px solid rgba(255, 200, 0, 0.4);">
 
 **Good to know**: You can modify the event/span/log targets you’re interested in just like when


### PR DESCRIPTION
Mention that the `rust_log` level has to be higher than the `opentelemetry` level.
I tried to setup a node where `log_config.json` looked like this:
```json
{ "opentelemetry": "info,runtime=debug,vm=debug"}
```

But it didn't work because the `rust_log` log level was too low.
Setting it to:
```json
{ "opentelemetry": "info,runtime=debug,vm=debug", "rust_log": "info,runtime=debug,vm=debug" }
```
fixed the problem.

Refs: [zulip conversation](https://near.zulipchat.com/#narrow/stream/308695-nearone.2Fprivate/topic/Running.20Kent's.20workload.20on.20statelessnet/near/451039992)