### PR TITLE
fix(pytests): remove check that applies to legacy archivals in test

### DIFF
--- a/pytest/tests/sanity/block_sync_archival.py
+++ b/pytest/tests/sanity/block_sync_archival.py
@@ -192,12 +192,8 @@ def run_test(cluster: Cluster) -> None:
         assert False
 
     # Since Fred’s in-memory cache is clear, all Barney’s requests are served
-    # from storage.  Since DBCol::PartialChunks is garbage collected, some of the
-    # requests are served from DBCol::Chunks.
-    assert_metrics(get_metrics('fred', fred), (
-        'chunk/ok',
-        'partial/ok',
-    ))
+    # from storage.
+    assert_metrics(get_metrics('fred', fred), ('partial/ok',))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
At the end of block_sync_archival.py we check that the `near_partial_encoded_chunk_request_processing_time` metric reports that a node that got restarted served partial encoded chunks both by looking them up in `DBCol::PartialChunks`, and also by reconstructing them from chunks for the ones that were garbage collected. But now that archival nodes started from scratch are split storage nodes, `DBCol::PartialChunks` is no longer garbage collected, since that only happens in `ChainStore::clear_archive_data()`, which is only called for legacy archival nodes