### PR TITLE
[pytest] Add json-rpc dependency

### DIFF
--- a/pytest/requirements.txt
+++ b/pytest/requirements.txt
@@ -4,6 +4,7 @@ cachetools
 cython
 deepdiff
 ed25519
+json-rpc
 locust>=2.28
 geventhttpclient>=2.3.1
 nearup


### PR DESCRIPTION
As it is needed for the mocknet neard-runner: https://github.com/near/nearcore/blob/00fbeec47e686c90814264af6b9e603bdd6cf523/pytest/tests/mocknet/helpers/neard_runner.py#L9