### PR TITLE
[mocknet] Add ability to specify mocknet-id

### DIFF
--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -502,6 +502,12 @@ class ParseFraction(Action):
 
 if __name__ == '__main__':
     parser = ArgumentParser(description='Control a mocknet instance')
+    parser.add_argument('--mocknet-id',
+                        type=str,
+                        help='''
+                        Identifier of the mocknet instance to use. Can be used instead of specifying
+                        `chain-id`, `start-height` and `unique-id`.
+                        ''')
     parser.add_argument('--chain-id', type=str)
     parser.add_argument('--start-height', type=int)
     parser.add_argument('--unique-id', type=str)
@@ -695,19 +701,26 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.local_test:
-        if args.chain_id is not None or args.start_height is not None or args.unique_id is not None:
+        if (args.chain_id is not None or args.start_height is not None or
+                args.unique_id is not None or args.mocknet_id is not None):
             sys.exit(
-                f'cannot give --chain-id --start-height or --unique-id along with --local-test'
+                f'cannot give --chain-id, --start-height, --unique-id or --mocknet-id along with --local-test'
             )
         traffic_generator, nodes = local_test_node.get_nodes()
         node_config.configure_nodes(nodes + [traffic_generator],
                                     node_config.TEST_CONFIG)
     else:
-        if args.chain_id is None or args.start_height is None or args.unique_id is None:
+        if (args.chain_id is not None and args.start_height is not None and
+                args.unique_id is not None):
+            mocknet_id = args.chain_id + '-' + str(
+                args.start_height) + '-' + args.unique_id
+        elif args.mocknet_id is not None:
+            mocknet_id = args.mocknet_id
+        else:
             sys.exit(
-                f'must give all of --chain-id --start-height and --unique-id')
-        traffic_generator, nodes = remote_node.get_nodes(
-            args.chain_id, args.start_height, args.unique_id)
+                f'must give all of --chain-id --start-height and --unique-id or --mocknet-id'
+            )
+        traffic_generator, nodes = remote_node.get_nodes(mocknet_id)
         node_config.configure_nodes(nodes + [traffic_generator],
                                     node_config.REMOTE_CONFIG)
 

--- a/pytest/tests/mocknet/remote_node.py
+++ b/pytest/tests/mocknet/remote_node.py
@@ -95,11 +95,10 @@ class RemoteNeardRunner:
         return self.node.get_validators()
 
 
-def get_nodes(chain_id, start_height, unique_id):
-    pattern = chain_id + '-' + str(start_height) + '-' + unique_id
-    all_nodes = mocknet.get_nodes(pattern=pattern)
+def get_nodes(mocknet_id: str):
+    all_nodes = mocknet.get_nodes(pattern=mocknet_id)
     if len(all_nodes) < 1:
-        sys.exit(f'no known nodes matching {pattern}')
+        sys.exit(f'no known nodes matching {mocknet_id}')
 
     traffic_generator = None
     nodes = []


### PR DESCRIPTION
This is necessary for mocknet instances of FT benchmark that don't follow the previous naming pattern of "{chain_id}-{height}-{unique_id}".