### PR TITLE
fix: fix test gc_sync_after_sync

### DIFF
--- a/pytest/tests/sanity/gc_sync_after_sync.py
+++ b/pytest/tests/sanity/gc_sync_after_sync.py
@@ -51,6 +51,8 @@ node0_height, _ = utils.wait_for_blocks(nodes[0], target=TARGET_HEIGHT1)
 
 logger.info('Starting back node 1')
 nodes[1].start(boot_node=nodes[1])
+# State Sync makes the storage seem inconsistent.
+nodes[1].stop_checking_store()
 time.sleep(3)
 
 node1_height, _ = utils.wait_for_blocks(nodes[1], target=node0_height)


### PR DESCRIPTION
Attempt to fix the failing test `gc_sync_after_sync.py`. Example: https://nayduck.nearone.org/#/test/62087

The reasoning here is to disable database storage checks in both instances when node is restarted; previously it was done only in one of the two restarts.