### PR TITLE
feat(mirror): add a GetShardChunk view client type and call it in mirror subcommand

### DIFF
--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -3,7 +3,7 @@ use near_chain_configs::{ClientConfig, ProtocolConfigView};
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{MerklePath, PartialMerkleTree};
 use near_primitives::network::PeerId;
-use near_primitives::sharding::ChunkHash;
+use near_primitives::sharding::{ChunkHash, ShardChunk};
 use near_primitives::types::{
     AccountId, BlockHeight, BlockReference, EpochId, EpochReference, MaybeBlockId, ShardId,
     TransactionOrReceiptId,
@@ -444,6 +444,20 @@ pub enum GetChunk {
 
 impl Message for GetChunk {
     type Result = Result<ChunkView, GetChunkError>;
+}
+
+/// Actor message requesting a chunk by chunk hash and block hash + shard id.
+/// The difference between this and `GetChunk` is that it returns the actual `ShardChunk`
+/// instead of a `ChunkView`
+#[derive(Debug)]
+pub enum GetShardChunk {
+    Height(BlockHeight, ShardId),
+    BlockHash(CryptoHash, ShardId),
+    ChunkHash(ChunkHash),
+}
+
+impl Message for GetShardChunk {
+    type Result = Result<ShardChunk, GetChunkError>;
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -2,8 +2,8 @@ pub use near_client_primitives::types::{
     Error, GetBlock, GetBlockProof, GetBlockProofResponse, GetBlockWithMerkleTree, GetChunk,
     GetClientConfig, GetExecutionOutcome, GetExecutionOutcomeResponse,
     GetExecutionOutcomesForBlock, GetGasPrice, GetMaintenanceWindows, GetNetworkInfo,
-    GetNextLightClientBlock, GetProtocolConfig, GetReceipt, GetSplitStorageInfo, GetStateChanges,
-    GetStateChangesInBlock, GetStateChangesWithCauseInBlock,
+    GetNextLightClientBlock, GetProtocolConfig, GetReceipt, GetShardChunk, GetSplitStorageInfo,
+    GetStateChanges, GetStateChangesInBlock, GetStateChangesWithCauseInBlock,
     GetStateChangesWithCauseInBlockForTrackedShards, GetValidatorInfo, GetValidatorOrdered, Query,
     QueryError, Status, StatusResponse, SyncStatus, TxStatus, TxStatusError,
 };

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -2,8 +2,8 @@
 //! Useful for querying from RPC.
 
 use crate::{
-    metrics, sync, GetChunk, GetExecutionOutcomeResponse, GetNextLightClientBlock, GetStateChanges,
-    GetStateChangesInBlock, GetValidatorInfo, GetValidatorOrdered,
+    metrics, sync, GetChunk, GetExecutionOutcomeResponse, GetNextLightClientBlock, GetShardChunk,
+    GetStateChanges, GetStateChangesInBlock, GetValidatorInfo, GetValidatorOrdered,
 };
 use actix::{Addr, SyncArbiter};
 use near_async::actix_wrapper::SyncActixWrapper;
@@ -740,6 +740,30 @@ fn get_chunk_from_block(
         )),
     )?;
     Ok(res)
+}
+
+impl Handler<GetShardChunk> for ViewClientActorInner {
+    #[perf]
+    fn handle(&mut self, msg: GetShardChunk) -> Result<ShardChunk, GetChunkError> {
+        tracing::debug!(target: "client", ?msg);
+        let _timer =
+            metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["GetShardChunk"]).start_timer();
+
+        match msg {
+            GetShardChunk::ChunkHash(chunk_hash) => {
+                let chunk = self.chain.get_chunk(&chunk_hash)?;
+                Ok(ShardChunk::clone(&chunk))
+            }
+            GetShardChunk::BlockHash(block_hash, shard_id) => {
+                let block = self.chain.get_block(&block_hash)?;
+                Ok(get_chunk_from_block(block, shard_id, &self.chain)?)
+            }
+            GetShardChunk::Height(height, shard_id) => {
+                let block = self.chain.get_block_by_height(height)?;
+                Ok(get_chunk_from_block(block, shard_id, &self.chain)?)
+            }
+        }
+    }
 }
 
 impl Handler<GetChunk> for ViewClientActorInner {

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -721,31 +721,33 @@ impl Handler<GetBlockWithMerkleTree> for ViewClientActorInner {
     }
 }
 
+fn get_chunk_from_block(
+    block: Block,
+    shard_id: ShardId,
+    chain: &Chain,
+) -> Result<ShardChunk, near_chain::Error> {
+    let chunk_header = block
+        .chunks()
+        .get(shard_id as usize)
+        .ok_or_else(|| near_chain::Error::InvalidShardId(shard_id))?
+        .clone();
+    let chunk_hash = chunk_header.chunk_hash();
+    let chunk = chain.get_chunk(&chunk_hash)?;
+    let res = ShardChunk::with_header(ShardChunk::clone(&chunk), chunk_header).ok_or(
+        near_chain::Error::Other(format!(
+            "Mismatched versions for chunk with hash {}",
+            chunk_hash.0
+        )),
+    )?;
+    Ok(res)
+}
+
 impl Handler<GetChunk> for ViewClientActorInner {
     #[perf]
     fn handle(&mut self, msg: GetChunk) -> Result<ChunkView, GetChunkError> {
         tracing::debug!(target: "client", ?msg);
         let _timer =
             metrics::VIEW_CLIENT_MESSAGE_TIME.with_label_values(&["GetChunk"]).start_timer();
-        let get_chunk_from_block = |block: Block,
-                                    shard_id: ShardId,
-                                    chain: &Chain|
-         -> Result<ShardChunk, near_chain::Error> {
-            let chunk_header = block
-                .chunks()
-                .get(shard_id as usize)
-                .ok_or_else(|| near_chain::Error::InvalidShardId(shard_id))?
-                .clone();
-            let chunk_hash = chunk_header.chunk_hash();
-            let chunk = chain.get_chunk(&chunk_hash)?;
-            let res = ShardChunk::with_header(ShardChunk::clone(&chunk), chunk_header).ok_or(
-                near_chain::Error::Other(format!(
-                    "Mismatched versions for chunk with hash {}",
-                    chunk_hash.0
-                )),
-            )?;
-            Ok(res)
-        };
 
         let chunk = match msg {
             GetChunk::ChunkHash(chunk_hash) => {

--- a/pytest/tools/mirror/online_test.py
+++ b/pytest/tools/mirror/online_test.py
@@ -36,7 +36,7 @@ def main():
                               mirror.restart_once)
 
     end_source_height = source_nodes[0].get_latest_block().height
-    time.sleep(5)
+    time.sleep(30)
     # we don't need these anymore
     for node in source_nodes[1:]:
         node.kill()

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -1869,7 +1869,6 @@ async fn run<P: AsRef<Path>>(
             .run(Some(stop_height))
             .await
     } else {
-        tracing::warn!(target: "mirror", "FIXME: currently --online-source will skip DeployContract actions");
         TxMirror::new(crate::online::ChainAccess::new(source_home)?, target_home, secret, config)?
             .run(stop_height)
             .await

--- a/tools/mirror/src/offline.rs
+++ b/tools/mirror/src/offline.rs
@@ -131,8 +131,8 @@ impl crate::ChainAccess for ChainAccess {
             };
             chunks.push(SourceChunk {
                 shard_id: chunk.shard_id(),
-                transactions: chunk.transactions().iter().map(|t| t.clone().into()).collect(),
-                receipts: chunk.prev_outgoing_receipts().iter().cloned().collect(),
+                transactions: chunk.transactions().to_vec(),
+                receipts: chunk.prev_outgoing_receipts().to_vec(),
             })
         }
         Ok(SourceBlock { hash: block_hash, chunks })

--- a/tools/mirror/src/online.rs
+++ b/tools/mirror/src/online.rs
@@ -141,8 +141,8 @@ impl crate::ChainAccess for ChainAccess {
             if chunk.height_included() == height {
                 chunks.push(SourceChunk {
                     shard_id: chunk.shard_id(),
-                    transactions: chunk.transactions().iter().map(|t| t.clone().into()).collect(),
-                    receipts: chunk.prev_outgoing_receipts().iter().cloned().collect(),
+                    transactions: chunk.transactions().to_vec(),
+                    receipts: chunk.prev_outgoing_receipts().to_vec(),
                 })
             }
         }

--- a/tools/mirror/src/online.rs
+++ b/tools/mirror/src/online.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use near_chain_configs::GenesisValidationMode;
 use near_client::ViewClientActor;
 use near_client_primitives::types::{
-    GetBlock, GetBlockError, GetChunk, GetChunkError, GetExecutionOutcome, GetReceipt, Query,
+    GetBlock, GetBlockError, GetChunkError, GetExecutionOutcome, GetReceipt, GetShardChunk, Query,
 };
 use near_crypto::PublicKey;
 use near_o11y::WithSpanContextExt;
@@ -122,7 +122,7 @@ impl crate::ChainAccess for ChainAccess {
         for c in block.chunks {
             let chunk = match self
                 .view_client
-                .send(GetChunk::ChunkHash(ChunkHash(c.chunk_hash)).with_span_context())
+                .send(GetShardChunk::ChunkHash(ChunkHash(c.chunk_hash)).with_span_context())
                 .await
                 .unwrap()
             {
@@ -138,11 +138,11 @@ impl crate::ChainAccess for ChainAccess {
                     _ => return Err(e.into()),
                 },
             };
-            if chunk.header.height_included == height {
+            if chunk.height_included() == height {
                 chunks.push(SourceChunk {
-                    shard_id: chunk.header.shard_id,
-                    transactions: chunk.transactions.into_iter().map(Into::into).collect(),
-                    receipts: chunk.receipts.into_iter().map(|r| r.try_into().unwrap()).collect(),
+                    shard_id: chunk.shard_id(),
+                    transactions: chunk.transactions().iter().map(|t| t.clone().into()).collect(),
+                    receipts: chunk.prev_outgoing_receipts().iter().cloned().collect(),
                 })
             }
         }


### PR DESCRIPTION
Before this change, the only way to get a chunk from the view client actor is to send a `GetChunk` message which returns a `ChunkView`. This is what we do when running `neard mirror run` with the `--online-source` flag, which is used to start a source chain node that applies mainnet blocks so that we don't run out of transactions. This is normally completely fine, but there is a problem with Deploy Contract actions, where the deploy contract action in the `ChunkView` type actually only contains the hash of the contract code instead of the whole thing, which means that we can't mirror any deploy contract transactions.

To fix it, we can add a new `GetShardChunk` view client type that is the same as the existing `GetChunk` except that it returns the full shard chunk. It's a much smaller change with less refactoring involved to just add a new type, but it could be worth changing the existing `GetChunk` behavior to just return the full chunk, and to modify all the callers so that we get the same behavior everywhere (especially in RPC calls), because there is probably a nontrivial amount of work involved in changing a large `ShardChunk` into a `ChunkView`, especially if it's used in a place where we don't care about the formatting changes that that conversion makes

context: https://near.zulipchat.com/#narrow/stream/295558-core/topic/View.20Structs/near/437337420

This pulls in changes to master that are included in the branch `marcelodg-stateless-forknet-mirror` which is the one we're using to mirror transactions on statelessnet