### PR TITLE
fix(view client): remember tx status requests across view client threads

### DIFF
--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -129,6 +129,7 @@ impl ViewClientActorInner {
         config: ClientConfig,
         adv: crate::adversarial::Controls,
     ) -> Addr<ViewClientActor> {
+        let request_manager = Arc::new(RwLock::new(ViewClientRequestManager::new()));
         SyncArbiter::start(config.view_client_threads, move || {
             // TODO: should we create shared ChainStore that is passed to both Client and ViewClient?
             let chain = Chain::new_for_view_client(
@@ -152,7 +153,7 @@ impl ViewClientActorInner {
                 runtime: runtime.clone(),
                 network_adapter: network_adapter.clone(),
                 config: config.clone(),
-                request_manager: Arc::new(RwLock::new(ViewClientRequestManager::new())),
+                request_manager: request_manager.clone(),
                 state_request_cache: Arc::new(Mutex::new(VecDeque::default())),
             };
             SyncActixWrapper::new(view_client_actor)

--- a/pytest/tests/sanity/single_shard_tracking.py
+++ b/pytest/tests/sanity/single_shard_tracking.py
@@ -112,7 +112,11 @@ def main():
     # In that case congestion control will reject transactions sent right after the network starts
     # because it counts as having missed several chunks in a row for every shard. So wait a bit before
     # starting to send txs.
-    time.sleep(10)
+    blocks_seen = 0
+    for _latest in utils.poll_blocks(nodes[0]):
+        blocks_seen += 1
+        if blocks_seen >= 3:
+            break
 
     latest_block_hash = nodes[0].get_latest_block().hash_bytes
     deploy_contract_tx = transaction.sign_deploy_contract_tx(

--- a/pytest/tests/sanity/single_shard_tracking.py
+++ b/pytest/tests/sanity/single_shard_tracking.py
@@ -107,6 +107,13 @@ def main():
     print("nodes started")
     contract = utils.load_test_contract()
 
+    # When localnets are started, there is a period at the beginning
+    # when there may be a few missed blocks, and the very first block often doesn't have any chunks.
+    # In that case congestion control will reject transactions sent right after the network starts
+    # because it counts as having missed several chunks in a row for every shard. So wait a bit before
+    # starting to send txs.
+    time.sleep(10)
+
     latest_block_hash = nodes[0].get_latest_block().hash_bytes
     deploy_contract_tx = transaction.sign_deploy_contract_tx(
         nodes[0].signer_key, contract, 1, latest_block_hash)


### PR DESCRIPTION
The `ViewClientRequestManager` is meant to remember what tx status requests we've sent to other nodes so we can serve future view client requests after receiving it. But before this change, each view client has its own cache. This means that tx status responses are only available to the same view client thread, which might not have been the one that made the request. So if we share it across threads, we fix this issue

Also in this change we wait a bit in single_shard_tracking.py before sending transactions because otherwise the first block after the localnet is started often has no new chunks and the transaction is rejected by congestion control because the computed current height - height included (which is the genesis height) is too high