### PR TITLE
[stateless_validation] Prohibit all-shards-tracking post-stateless-validation

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -302,19 +302,28 @@ impl messaging::Actor for ClientActorInner {
 /// Before stateless validation we require validators to track all shards, see
 /// https://github.com/near/nearcore/issues/7388
 fn check_validator_tracked_shards(client: &Client) -> Result<(), Error> {
+    if !matches!(
+        client.config.chain_id.as_ref(),
+        near_primitives::chains::MAINNET | near_primitives::chains::TESTNET
+    ) {
+        return Ok(());
+    }
     let head = client.chain.head()?;
     let protocol_version =
         client.epoch_manager.get_epoch_protocol_version(&head.epoch_id).into_chain_error()?;
 
     if !ProtocolFeature::StatelessValidationV0.enabled(protocol_version)
         && client.config.tracked_shards.is_empty()
-        && matches!(
-            client.config.chain_id.as_ref(),
-            near_primitives::chains::MAINNET | near_primitives::chains::TESTNET
-        )
     {
         panic!("The `chain_id` field specified in genesis is among mainnet/testnet, so validator must track all shards. Please change `tracked_shards` field in config.json to be any non-empty vector");
     }
+
+    if ProtocolFeature::StatelessValidationV0.enabled(protocol_version)
+        && !client.config.tracked_shards.is_empty()
+    {
+        panic!("The `chain_id` field specified in genesis is among mainnet/testnet, so validator must not track all shards. Please change `tracked_shards` field in config.json to be an empty vector");
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
When stateless validation kicks in, we no longer want validators to track all shards - 
the `tracked_shards` field in `config.json` should be set to an empty-list.

It is not critical that they stop tracking all shards immediately after the upgrade to protocol v69,
but at least we add this check so that validators are enforced to set `tracked_shards=[]` during the next restart (e.g. while downgrading the machine to lower RAM).

Tested on a testnet node:
* For non-validator it started normally regardless of `tracked_shards` value.
* For validator node:
  * It started normally when `tracked_shards=[]`.
  * If panicked when `tracked_shards=[0]`.