### PR TITLE
chore(lychee): replaced near examples URL and gnuplot url with working urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Overall, *NEAR* provides a wide range of tools for developers to easily build ap
 [js-api]: https://github.com/near/near-api-js
 [rust-sdk]: https://github.com/near/near-sdk-rs
 [js-sdk]: https://github.com/near/near-sdk-js
-[examples-url]: https://near.dev
+[examples-url]: https://github.com/near-examples
 [docs-url]: https://docs.near.org
 [tutorials-url]: https://docs.near.org/tutorials/welcome
 [api-docs-url]: https://docs.near.org/api/rpc/introduction

--- a/runtime/runtime-params-estimator/README.md
+++ b/runtime/runtime-params-estimator/README.md
@@ -47,7 +47,7 @@ Use this tool to measure the running time of elementary runtime operations that 
 
 3. **Continuous Estimation**: Take a look at [`estimator-warehouse/README.md`](./estimator-warehouse/README.md) to learn about the automated setup around the parameter estimator.
 
-Note, if you use the plotting functionality you would need to install [gnuplot](http://www.gnuplot.vt.edu/) to see the graphs.
+Note, if you use the plotting functionality you would need to install [gnuplot](http://www.gnuplot.info/) to see the graphs.
 
 ## Replaying IO traces
 


### PR DESCRIPTION
This simple PR replaces the breaking URLs from the Lychee CI test with working URLs. 