### PR TITLE
runtime: start lifting contract preparation up through tx runtime layers 

### DIFF
--- a/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
@@ -29,11 +29,11 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMOutcome {
     let mut wasm_config = near_parameters::vm::Config::clone(&config.wasm_config);
     wasm_config.limit_config.contract_prepare_version =
         near_vm_runner::logic::ContractPrepareVersion::V2;
-
+    let gas_counter = context.make_gas_counter(&wasm_config);
     let res = vm_kind
         .runtime(wasm_config.into())
         .unwrap()
-        .prepare(&fake_external, &context, None)
+        .prepare(&fake_external, None, gas_counter, &method_name)
         .run(&mut fake_external, &context, fees);
 
     // Remove the VMError message details as they can differ between runtimes

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/diffrunner.rs
@@ -21,7 +21,7 @@ libfuzzer_sys::fuzz_target!(|module: ArbitraryModule| {
 fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMOutcome {
     let mut fake_external = MockedExternal::with_code(code.clone_for_tests());
     let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
-    let mut context = create_context(&method_name, vec![]);
+    let mut context = create_context(vec![]);
     context.prepaid_gas = 10u64.pow(14);
     let config_store = RuntimeConfigStore::new(None);
     let config = config_store.get_config(PROTOCOL_VERSION);

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
@@ -19,7 +19,7 @@ libfuzzer_sys::fuzz_target!(|module: ArbitraryModule| {
 fn run_fuzz(code: &ContractCode, config: Arc<RuntimeConfig>) -> VMOutcome {
     let mut fake_external = MockedExternal::with_code(code.clone_for_tests());
     let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
-    let mut context = create_context(&method_name, vec![]);
+    let mut context = create_context(vec![]);
     context.prepaid_gas = 10u64.pow(14);
     let mut wasm_config = near_parameters::vm::Config::clone(&config.wasm_config);
     wasm_config.limit_config.wasmer2_stack_limit = i32::MAX; // If we can crash wasmer2 even without the secondary stack limit it's still good to know

--- a/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
+++ b/runtime/near-vm-runner/fuzz/fuzz_targets/runner.rs
@@ -25,10 +25,11 @@ fn run_fuzz(code: &ContractCode, config: Arc<RuntimeConfig>) -> VMOutcome {
     wasm_config.limit_config.wasmer2_stack_limit = i32::MAX; // If we can crash wasmer2 even without the secondary stack limit it's still good to know
     let vm_kind = config.wasm_config.vm_kind;
     let fees = Arc::clone(&config.fees);
+    let gas_counter = context.make_gas_counter(&wasm_config);
     vm_kind
         .runtime(wasm_config.into())
         .unwrap()
-        .prepare(&fake_external, &context, None)
+        .prepare(&fake_external, None, gas_counter, &method_name)
         .run(&mut fake_external, &context, fees)
         .unwrap_or_else(|err| panic!("fatal error: {err:?}"))
 }

--- a/runtime/near-vm-runner/fuzz/src/lib.rs
+++ b/runtime/near-vm-runner/fuzz/src/lib.rs
@@ -30,13 +30,12 @@ pub fn find_entry_point(contract: &ContractCode) -> Option<String> {
     None
 }
 
-pub fn create_context(method: &str, input: Vec<u8>) -> VMContext {
+pub fn create_context(input: Vec<u8>) -> VMContext {
     VMContext {
         current_account_id: "alice".parse().unwrap(),
         signer_account_id: "bob".parse().unwrap(),
         signer_account_pk: vec![0, 1, 2, 3, 4],
         predecessor_account_id: "carol".parse().unwrap(),
-        method: method.into(),
         input,
         promise_results: Vec::new().into(),
         block_height: 10,

--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -36,7 +36,7 @@ pub use code::ContractCode;
 #[cfg(feature = "metrics")]
 pub use metrics::{report_metrics, reset_metrics};
 pub use profile::ProfileDataV3;
-pub use runner::{run, prepare, PreparedContract, VM};
+pub use runner::{run, prepare, PreparedContract, Contract, VM};
 
 /// This is public for internal experimentation use only, and should otherwise be considered an
 /// implementation detail of `near-vm-runner`.

--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -36,7 +36,7 @@ pub use code::ContractCode;
 #[cfg(feature = "metrics")]
 pub use metrics::{report_metrics, reset_metrics};
 pub use profile::ProfileDataV3;
-pub use runner::{run, prepare, PreparedContract, Contract, VM};
+pub use runner::{prepare, run, Contract, PreparedContract, VM};
 
 /// This is public for internal experimentation use only, and should otherwise be considered an
 /// implementation detail of `near-vm-runner`.

--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -36,7 +36,7 @@ pub use code::ContractCode;
 #[cfg(feature = "metrics")]
 pub use metrics::{report_metrics, reset_metrics};
 pub use profile::ProfileDataV3;
-pub use runner::{run, PreparedContract, VM};
+pub use runner::{run, prepare, PreparedContract, VM};
 
 /// This is public for internal experimentation use only, and should otherwise be considered an
 /// implementation detail of `near-vm-runner`.

--- a/runtime/near-vm-runner/src/logic/context.rs
+++ b/runtime/near-vm-runner/src/logic/context.rs
@@ -61,6 +61,9 @@ impl VMContext {
         self.view_config.is_some()
     }
 
+    /// Make a gas counter based on the configuration in this VMContext.
+    ///
+    /// Meant for use in tests only.
     pub fn make_gas_counter(&self, config: &near_parameters::vm::Config) -> super::GasCounter {
         let max_gas_burnt = match self.view_config {
             Some(near_primitives_core::config::ViewConfig { max_gas_burnt }) => max_gas_burnt,

--- a/runtime/near-vm-runner/src/logic/context.rs
+++ b/runtime/near-vm-runner/src/logic/context.rs
@@ -20,8 +20,6 @@ pub struct VMContext {
     /// If this execution is the result of direct execution of transaction then it
     /// is equal to `signer_account_id`.
     pub predecessor_account_id: AccountId,
-    /// The name of the method to invoke.
-    pub method: String,
     /// The input to the contract call.
     /// Encoded as base64 string to be able to pass input in borsh binary format.
     pub input: Vec<u8>,

--- a/runtime/near-vm-runner/src/logic/context.rs
+++ b/runtime/near-vm-runner/src/logic/context.rs
@@ -62,4 +62,18 @@ impl VMContext {
     pub fn is_view(&self) -> bool {
         self.view_config.is_some()
     }
+
+    pub fn make_gas_counter(&self, config: &near_parameters::vm::Config) -> super::GasCounter {
+        let max_gas_burnt = match self.view_config {
+            Some(near_primitives_core::config::ViewConfig { max_gas_burnt }) => max_gas_burnt,
+            None => config.limit_config.max_gas_burnt,
+        };
+        crate::logic::GasCounter::new(
+            config.ext_costs.clone(),
+            max_gas_burnt,
+            config.regular_op_cost,
+            self.prepaid_gas,
+            self.is_view(),
+        )
+    }
 }

--- a/runtime/near-vm-runner/src/logic/dependencies.rs
+++ b/runtime/near-vm-runner/src/logic/dependencies.rs
@@ -488,10 +488,4 @@ pub trait External {
     ///
     /// Panics if `ReceiptIndex` is invalid.
     fn get_receipt_receiver(&self, receipt_index: ReceiptIndex) -> &AccountId;
-
-    /// Hash of the contract for the current account.
-    fn code_hash(&self) -> CryptoHash;
-
-    /// Get the contract code
-    fn get_contract(&self) -> Option<std::sync::Arc<crate::ContractCode>>;
 }

--- a/runtime/near-vm-runner/src/logic/gas_counter.rs
+++ b/runtime/near-vm-runner/src/logic/gas_counter.rs
@@ -179,18 +179,10 @@ impl GasCounter {
     }
 
     /// Very special function to get the gas counter pointer for generated machine code.
+    ///
     /// Please do not use, unless fully understand Rust aliasing and other consequences.
-    /// Can be used to emit inlined code like `pay_wasm_gas()`, i.e.
-    ///    mov base, gas_counter_raw_ptr
-    ///    mov rax, [base + 0] ; current burnt gas
-    ///    mov rcx, [base + 16] ; opcode cost
-    ///    imul rcx, block_ops_count ; block cost
-    ///    add rax, rcx ; new burnt gas
-    ///    jo emit_integer_overflow
-    ///    cmp rax, [base + 8] ; unsigned compare with burnt limit
-    ///    mov [base + 0], rax
-    ///    ja emit_gas_exceeded
-    pub(crate) fn gas_counter_raw_ptr(&mut self) -> *mut FastGasCounter {
+    #[cfg(all(any(feature = "wasmer2_vm", feature = "near_vm"), target_arch = "x86_64"))]
+    pub(crate) fn fast_counter_raw_ptr(&mut self) -> *mut FastGasCounter {
         use std::ptr;
         ptr::addr_of_mut!(self.fast_counter)
     }

--- a/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
+++ b/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
@@ -320,12 +320,14 @@ impl External for MockedExternal {
             _ => panic!("not a valid receipt index!"),
         }
     }
+}
 
-    fn code_hash(&self) -> CryptoHash {
+impl crate::Contract for MockedExternal {
+    fn hash(&self) -> CryptoHash {
         self.code_hash
     }
 
-    fn get_contract(&self) -> Option<Arc<ContractCode>> {
+    fn get_code(&self) -> Option<Arc<ContractCode>> {
         self.code.clone()
     }
 }

--- a/runtime/near-vm-runner/src/logic/mod.rs
+++ b/runtime/near-vm-runner/src/logic/mod.rs
@@ -18,7 +18,7 @@ mod vmstate;
 pub use context::VMContext;
 pub use dependencies::{External, MemSlice, MemoryLike, TrieNodesCount, ValuePtr};
 pub use errors::{HostError, VMLogicError};
-pub use gas_counter::with_ext_cost_counter;
+pub use gas_counter::{with_ext_cost_counter, GasCounter};
 pub use logic::{ExecutionResultState, VMLogic, VMOutcome};
 pub use near_parameters::vm::{Config, ContractPrepareVersion, LimitConfig, StorageGetMode};
 pub use near_primitives_core::types::ProtocolVersion;

--- a/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
+++ b/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
@@ -70,7 +70,6 @@ fn get_context() -> VMContext {
         signer_account_id: "bob.near".parse().unwrap(),
         signer_account_pk: vec![0, 1, 2, 3, 4],
         predecessor_account_id: "carol.near".parse().unwrap(),
-        method: "VMLogicBuilder::method_not_specified".into(),
         input: vec![0, 1, 2, 3, 4],
         promise_results: vec![].into(),
         block_height: 10,

--- a/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
+++ b/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
@@ -35,7 +35,11 @@ impl VMLogicBuilder {
     }
 
     pub fn build(&mut self) -> TestVMLogic<'_> {
-        let result_state = ExecutionResultState::new(&self.context, Arc::new(self.config.clone()));
+        let result_state = ExecutionResultState::new(
+            &self.context,
+            self.context.make_gas_counter(&self.config),
+            Arc::new(self.config.clone()),
+        );
         TestVMLogic::from(VMLogic::new(
             &mut self.ext,
             &self.context,

--- a/runtime/near-vm-runner/src/near_vm_runner/runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner/runner.rs
@@ -346,7 +346,7 @@ impl NearVM {
             offset_of!(FastGasCounter, gas_limit),
             offset_of!(near_vm_types::FastGasCounter, gas_limit)
         );
-        let gas = import.vmlogic.gas_counter_pointer() as *mut near_vm_types::FastGasCounter;
+        let gas = import.vmlogic.gas_counter().fast_counter_raw_ptr();
         unsafe {
             let instance = {
                 let _span = tracing::debug_span!(target: "vm", "run_method/instantiate").entered();
@@ -365,7 +365,7 @@ impl NearVM {
                     // by the virtue of it being contained within `import` which lives for the
                     // entirety of this function.
                     InstanceConfig::with_stack_limit(self.config.limit_config.max_stack_height)
-                        .with_counter(gas),
+                        .with_counter(gas.cast()),
                 );
                 let handle = match maybe_handle {
                     Ok(handle) => handle,

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -40,15 +40,16 @@ pub(crate) type VMResult<T = VMOutcome> = Result<T, VMRunnerError>;
 ))]
 pub fn prepare(
     contract: &dyn Contract,
-    context: &VMContext,
     wasm_config: Arc<Config>,
     cache: Option<&dyn ContractRuntimeCache>,
+    gas_counter: crate::logic::GasCounter,
+    method: &str,
 ) -> Box<dyn crate::PreparedContract> {
     let vm_kind = wasm_config.vm_kind;
     let runtime = vm_kind
         .runtime(wasm_config)
         .unwrap_or_else(|| panic!("the {vm_kind:?} runtime has not been enabled at compile time"));
-    runtime.prepare(contract, context, cache)
+    runtime.prepare(contract, cache, gas_counter, method)
 }
 
 /// Validate and run the specified contract.
@@ -131,8 +132,9 @@ pub trait VM {
     fn prepare(
         self: Box<Self>,
         ext: &dyn Contract,
-        context: &VMContext,
         cache: Option<&dyn ContractRuntimeCache>,
+        gas_counter: crate::logic::GasCounter,
+        method: &str,
     ) -> Box<dyn PreparedContract>;
 
     /// Precompile a WASM contract to a VM specific format and store the result

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -52,13 +52,12 @@ pub(crate) fn with_vm_variants(
     }
 }
 
-fn create_context(method: &str, input: Vec<u8>) -> VMContext {
+fn create_context(input: Vec<u8>) -> VMContext {
     VMContext {
         current_account_id: CURRENT_ACCOUNT_ID.parse().unwrap(),
         signer_account_id: SIGNER_ACCOUNT_ID.parse().unwrap(),
         signer_account_pk: Vec::from(&SIGNER_ACCOUNT_PK[..]),
         predecessor_account_id: PREDECESSOR_ACCOUNT_ID.parse().unwrap(),
-        method: method.into(),
         input,
         promise_results: Vec::new().into(),
         block_height: 10,

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -122,7 +122,7 @@ fn make_cached_contract_call_vm(
         MockedExternal::new()
     };
     fake_external.code_hash = code_hash;
-    let mut context = create_context(method_name, vec![]);
+    let mut context = create_context(vec![]);
     let fees = Arc::new(RuntimeFeesConfig::test());
     context.prepaid_gas = prepaid_gas;
     let gas_counter = context.make_gas_counter(&config);

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -125,8 +125,13 @@ fn make_cached_contract_call_vm(
     let mut context = create_context(method_name, vec![]);
     let fees = Arc::new(RuntimeFeesConfig::test());
     context.prepaid_gas = prepaid_gas;
+    let gas_counter = context.make_gas_counter(&config);
     let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
-    runtime.prepare(&fake_external, &context, Some(cache)).run(&mut fake_external, &context, fees)
+    runtime.prepare(&fake_external, Some(cache), gas_counter, method_name).run(
+        &mut fake_external,
+        &context,
+        fees,
+    )
 }
 
 #[test]

--- a/runtime/near-vm-runner/src/tests/fuzzers.rs
+++ b/runtime/near-vm-runner/src/tests/fuzzers.rs
@@ -39,13 +39,12 @@ pub fn find_entry_point(contract: &ContractCode) -> Option<String> {
     None
 }
 
-pub fn create_context(method: &str, input: Vec<u8>) -> VMContext {
+pub fn create_context(input: Vec<u8>) -> VMContext {
     VMContext {
         current_account_id: "alice".parse().unwrap(),
         signer_account_id: "bob".parse().unwrap(),
         signer_account_pk: vec![0, 1, 2, 3, 4],
         predecessor_account_id: "carol".parse().unwrap(),
-        method: method.into(),
         input,
         promise_results: Vec::new().into(),
         block_height: 10,
@@ -111,7 +110,7 @@ impl fmt::Debug for ArbitraryModule {
 fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMResult {
     let mut fake_external = MockedExternal::with_code(code.clone_for_tests());
     let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
-    let mut context = create_context(&method_name, vec![]);
+    let mut context = create_context(vec![]);
     context.prepaid_gas = 10u64.pow(14);
 
     let mut config = test_vm_config();

--- a/runtime/near-vm-runner/src/tests/fuzzers.rs
+++ b/runtime/near-vm-runner/src/tests/fuzzers.rs
@@ -119,10 +119,11 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMResult {
     config.limit_config.contract_prepare_version = ContractPrepareVersion::V2;
 
     let fees = Arc::new(RuntimeFeesConfig::test());
+    let gas_counter = context.make_gas_counter(&config);
     let mut res = vm_kind
         .runtime(config.into())
         .unwrap()
-        .prepare(&fake_external, &context, None)
+        .prepare(&fake_external, None, gas_counter, &method_name)
         .run(&mut fake_external, &context, Arc::clone(&fees));
 
     // Remove the VMError message details as they can differ between runtimes

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -55,21 +55,21 @@ pub fn test_read_write() {
     with_vm_variants(&config, |vm_kind: VMKind| {
         let code = test_contract(vm_kind);
         let mut fake_external = MockedExternal::with_code(code);
-        let context = create_context("write_key_value", encode(&[10u64, 20u64]));
+        let context = create_context(encode(&[10u64, 20u64]));
 
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
         let gas_counter = context.make_gas_counter(&config);
-        let result = runtime.prepare(&fake_external, None, gas_counter, &context.method).run(
+        let result = runtime.prepare(&fake_external, None, gas_counter, "write_key_value").run(
             &mut fake_external,
             &context,
             Arc::clone(&fees),
         );
         assert_run_result(result, 0);
 
-        let context = create_context("read_value", encode(&[10u64]));
+        let context = create_context(encode(&[10u64]));
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
         let gas_counter = context.make_gas_counter(&config);
-        let result = runtime.prepare(&fake_external, None, gas_counter, &context.method).run(
+        let result = runtime.prepare(&fake_external, None, gas_counter, "read_value").run(
             &mut fake_external,
             &context,
             Arc::clone(&fees),
@@ -121,11 +121,11 @@ fn run_test_ext(
     fake_external.validators =
         validators.into_iter().map(|(s, b)| (s.parse().unwrap(), b)).collect();
     let fees = Arc::new(RuntimeFeesConfig::test());
-    let context = create_context(method, input.to_vec());
+    let context = create_context(input.to_vec());
     let gas_counter = context.make_gas_counter(&config);
     let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
     let outcome = runtime
-        .prepare(&fake_external, None, gas_counter, &context.method)
+        .prepare(&fake_external, None, gas_counter, &method)
         .run(&mut fake_external, &context, Arc::clone(&fees))
         .unwrap_or_else(|err| panic!("Failed execution: {:?}", err));
 
@@ -227,12 +227,12 @@ pub fn test_out_of_memory() {
 
         let code = test_contract(vm_kind);
         let mut fake_external = MockedExternal::with_code(code);
-        let context = create_context("out_of_memory", Vec::new());
+        let context = create_context(Vec::new());
         let fees = Arc::new(RuntimeFeesConfig::free());
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
         let gas_counter = context.make_gas_counter(&config);
         let result = runtime
-            .prepare(&fake_external, None, gas_counter, &context.method)
+            .prepare(&fake_external, None, gas_counter, "out_of_memory")
             .run(&mut fake_external, &context, fees)
             .expect("execution failed");
         assert_eq!(
@@ -252,7 +252,7 @@ fn function_call_weight_contract() -> ContractCode {
 
 #[test]
 fn attach_unspent_gas_but_use_all_gas() {
-    let mut context = create_context("attach_unspent_gas_but_use_all_gas", vec![]);
+    let mut context = create_context(vec![]);
     context.prepaid_gas = 100 * 10u64.pow(12);
 
     let mut config = test_vm_config();
@@ -267,7 +267,7 @@ fn attach_unspent_gas_but_use_all_gas() {
 
         let gas_counter = context.make_gas_counter(&config);
         let outcome = runtime
-            .prepare(&external, None, gas_counter, &context.method)
+            .prepare(&external, None, gas_counter, "attach_unspent_gas_but_use_all_gas")
             .run(&mut external, &context, fees)
             .unwrap_or_else(|err| panic!("Failed execution: {:?}", err));
 

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -58,7 +58,8 @@ pub fn test_read_write() {
         let context = create_context("write_key_value", encode(&[10u64, 20u64]));
 
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
-        let result = runtime.prepare(&fake_external, &context, None).run(
+        let gas_counter = context.make_gas_counter(&config);
+        let result = runtime.prepare(&fake_external, None, gas_counter, &context.method).run(
             &mut fake_external,
             &context,
             Arc::clone(&fees),
@@ -67,7 +68,8 @@ pub fn test_read_write() {
 
         let context = create_context("read_value", encode(&[10u64]));
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
-        let result = runtime.prepare(&fake_external, &context, None).run(
+        let gas_counter = context.make_gas_counter(&config);
+        let result = runtime.prepare(&fake_external, None, gas_counter, &context.method).run(
             &mut fake_external,
             &context,
             Arc::clone(&fees),
@@ -120,10 +122,10 @@ fn run_test_ext(
         validators.into_iter().map(|(s, b)| (s.parse().unwrap(), b)).collect();
     let fees = Arc::new(RuntimeFeesConfig::test());
     let context = create_context(method, input.to_vec());
+    let gas_counter = context.make_gas_counter(&config);
     let runtime = vm_kind.runtime(config).expect("runtime has not been compiled");
-
     let outcome = runtime
-        .prepare(&fake_external, &context, None)
+        .prepare(&fake_external, None, gas_counter, &context.method)
         .run(&mut fake_external, &context, Arc::clone(&fees))
         .unwrap_or_else(|err| panic!("Failed execution: {:?}", err));
 
@@ -228,8 +230,9 @@ pub fn test_out_of_memory() {
         let context = create_context("out_of_memory", Vec::new());
         let fees = Arc::new(RuntimeFeesConfig::free());
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
+        let gas_counter = context.make_gas_counter(&config);
         let result = runtime
-            .prepare(&fake_external, &context, None)
+            .prepare(&fake_external, None, gas_counter, &context.method)
             .run(&mut fake_external, &context, fees)
             .expect("execution failed");
         assert_eq!(
@@ -262,8 +265,9 @@ fn attach_unspent_gas_but_use_all_gas() {
         let fees = Arc::new(RuntimeFeesConfig::test());
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
 
+        let gas_counter = context.make_gas_counter(&config);
         let outcome = runtime
-            .prepare(&external, &context, None)
+            .prepare(&external, None, gas_counter, &context.method)
             .run(&mut external, &context, fees)
             .unwrap_or_else(|err| panic!("Failed execution: {:?}", err));
 

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -216,13 +216,13 @@ impl TestBuilder {
                 let config = runtime_config.wasm_config.clone();
                 let fees = Arc::new(RuntimeFeesConfig::test());
                 let context = self.context.clone();
-
+                let gas_counter = context.make_gas_counter(&config);
                 let Some(runtime) = vm_kind.runtime(config) else {
                     panic!("runtime for {:?} has not been compiled", vm_kind);
                 };
                 println!("Running {:?} for protocol version {}", vm_kind, protocol_version);
                 let outcome = runtime
-                    .prepare(&fake_external, &context, None)
+                    .prepare(&fake_external, None, gas_counter, &context.method)
                     .run(&mut fake_external, &context, fees)
                     .expect("execution failed");
 

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -17,7 +17,6 @@ pub(crate) fn test_builder() -> TestBuilder {
         predecessor_account_id: "carol".parse().unwrap(),
         input: Vec::new(),
         promise_results: Vec::new().into(),
-        method: "main".into(),
         block_height: 10,
         block_timestamp: 42,
         epoch_height: 1,
@@ -43,6 +42,7 @@ pub(crate) fn test_builder() -> TestBuilder {
         skip,
         opaque_error: false,
         opaque_outcome: false,
+        method: "main".into(),
     }
 }
 
@@ -53,6 +53,7 @@ pub(crate) struct TestBuilder {
     skip: HashSet<VMKind>,
     opaque_error: bool,
     opaque_outcome: bool,
+    method: String,
 }
 
 impl TestBuilder {
@@ -74,7 +75,7 @@ impl TestBuilder {
     }
 
     pub(crate) fn method(mut self, method: &str) -> Self {
-        self.context.method = method.to_string();
+        self.method = method.to_string();
         self
     }
 
@@ -222,7 +223,7 @@ impl TestBuilder {
                 };
                 println!("Running {:?} for protocol version {}", vm_kind, protocol_version);
                 let outcome = runtime
-                    .prepare(&fake_external, None, gas_counter, &context.method)
+                    .prepare(&fake_external, None, gas_counter, &self.method)
                     .run(&mut fake_external, &context, fees)
                     .expect("execution failed");
 

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -16,13 +16,13 @@ pub fn test_ts_contract() {
     with_vm_variants(&config, |vm_kind: VMKind| {
         let code = ContractCode::new(near_test_contracts::ts_contract().to_vec(), None);
         let mut fake_external = MockedExternal::with_code(code);
-        let context = create_context("try_panic", Vec::new());
+        let context = create_context(Vec::new());
         let fees = Arc::new(RuntimeFeesConfig::test());
 
         // Call method that panics.
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
         let gas_counter = context.make_gas_counter(&config);
-        let result = runtime.prepare(&fake_external, None, gas_counter, &context.method).run(
+        let result = runtime.prepare(&fake_external, None, gas_counter, "try_panic").run(
             &mut fake_external,
             &context,
             Arc::clone(&fees),
@@ -36,11 +36,11 @@ pub fn test_ts_contract() {
         );
 
         // Call method that writes something into storage.
-        let context = create_context("try_storage_write", b"foo bar".to_vec());
+        let context = create_context(b"foo bar".to_vec());
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
         let gas_counter = context.make_gas_counter(&config);
         runtime
-            .prepare(&fake_external, None, gas_counter, &context.method)
+            .prepare(&fake_external, None, gas_counter, "try_storage_write")
             .run(&mut fake_external, &context, Arc::clone(&fees))
             .expect("bad failure");
         // Verify by looking directly into the storage of the host.
@@ -53,11 +53,11 @@ pub fn test_ts_contract() {
         }
 
         // Call method that reads the value from storage using registers.
-        let context = create_context("try_storage_read", b"foo".to_vec());
+        let context = create_context(b"foo".to_vec());
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
         let gas_counter = context.make_gas_counter(&config);
         let outcome = runtime
-            .prepare(&fake_external, None, gas_counter, &context.method)
+            .prepare(&fake_external, None, gas_counter, "try_storage_read")
             .run(&mut fake_external, &context, Arc::clone(&fees))
             .expect("execution failed");
 

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -21,7 +21,8 @@ pub fn test_ts_contract() {
 
         // Call method that panics.
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
-        let result = runtime.prepare(&fake_external, &context, None).run(
+        let gas_counter = context.make_gas_counter(&config);
+        let result = runtime.prepare(&fake_external, None, gas_counter, &context.method).run(
             &mut fake_external,
             &context,
             Arc::clone(&fees),
@@ -37,8 +38,9 @@ pub fn test_ts_contract() {
         // Call method that writes something into storage.
         let context = create_context("try_storage_write", b"foo bar".to_vec());
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
+        let gas_counter = context.make_gas_counter(&config);
         runtime
-            .prepare(&fake_external, &context, None)
+            .prepare(&fake_external, None, gas_counter, &context.method)
             .run(&mut fake_external, &context, Arc::clone(&fees))
             .expect("bad failure");
         // Verify by looking directly into the storage of the host.
@@ -53,8 +55,9 @@ pub fn test_ts_contract() {
         // Call method that reads the value from storage using registers.
         let context = create_context("try_storage_read", b"foo".to_vec());
         let runtime = vm_kind.runtime(config.clone()).expect("runtime has not been compiled");
+        let gas_counter = context.make_gas_counter(&config);
         let outcome = runtime
-            .prepare(&fake_external, &context, None)
+            .prepare(&fake_external, None, gas_counter, &context.method)
             .run(&mut fake_external, &context, Arc::clone(&fees))
             .expect("execution failed");
 

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -7,9 +7,9 @@ use crate::logic::gas_counter::FastGasCounter;
 use crate::logic::{
     Config, ExecutionResultState, External, MemSlice, MemoryLike, VMContext, VMLogic, VMOutcome,
 };
-use crate::prepare;
 use crate::runner::VMResult;
 use crate::{get_contract_cache_key, imports, ContractCode};
+use crate::{prepare, Contract};
 use memoffset::offset_of;
 use near_parameters::vm::VMKind;
 use near_parameters::RuntimeFeesConfig;
@@ -578,12 +578,12 @@ impl crate::runner::VM for Wasmer2VM {
 
     fn prepare(
         self: Box<Self>,
-        ext: &dyn External,
+        contract: &dyn Contract,
         context: &VMContext,
         cache: Option<&dyn ContractRuntimeCache>,
     ) -> Box<dyn crate::PreparedContract> {
         type Result = VMResult<PreparedContract>;
-        let Some(code) = ext.get_contract() else {
+        let Some(code) = contract.get_code() else {
             return Box::new(Result::Err(VMRunnerError::ContractCodeNotPresent));
         };
         let mut result_state = ExecutionResultState::new(&context, Arc::clone(&self.config));

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -416,7 +416,7 @@ impl Wasmer2VM {
             offset_of!(FastGasCounter, opcode_cost),
             offset_of!(wasmer_types::FastGasCounter, opcode_cost)
         );
-        let gas = import.vmlogic.gas_counter_pointer() as *mut wasmer_types::FastGasCounter;
+        let gas = import.vmlogic.gas_counter().fast_counter_raw_ptr();
         unsafe {
             let instance = {
                 let _span = tracing::debug_span!(target: "vm", "run_method/instantiate").entered();
@@ -435,7 +435,7 @@ impl Wasmer2VM {
                     // by the virtue of it being contained within `import` which lives for the
                     // entirety of this function.
                     InstanceConfig::default()
-                        .with_counter(gas)
+                        .with_counter(gas.cast())
                         .with_stack_limit(self.config.limit_config.wasmer2_stack_limit),
                 );
                 let handle = match maybe_handle {

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -5,9 +5,9 @@ use crate::logic::errors::{
 };
 use crate::logic::{ExecutionResultState, External, VMContext, VMLogic, VMLogicError, VMOutcome};
 use crate::logic::{MemSlice, MemoryLike};
-use crate::{prepare, Contract};
 use crate::runner::VMResult;
 use crate::{get_contract_cache_key, imports, ContractCode};
+use crate::{prepare, Contract};
 use near_parameters::vm::{Config, VMKind};
 use near_parameters::RuntimeFeesConfig;
 use std::borrow::Cow;

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -5,7 +5,7 @@ use crate::logic::errors::{
 };
 use crate::logic::{ExecutionResultState, External, VMContext, VMLogic, VMLogicError, VMOutcome};
 use crate::logic::{MemSlice, MemoryLike};
-use crate::prepare;
+use crate::{prepare, Contract};
 use crate::runner::VMResult;
 use crate::{get_contract_cache_key, imports, ContractCode};
 use near_parameters::vm::{Config, VMKind};
@@ -429,12 +429,12 @@ impl crate::runner::VM for Wasmer0VM {
 
     fn prepare(
         self: Box<Self>,
-        ext: &dyn External,
+        contract: &dyn Contract,
         context: &VMContext,
         cache: Option<&dyn ContractRuntimeCache>,
     ) -> Box<dyn crate::PreparedContract> {
         type Result = VMResult<PreparedContract>;
-        let Some(code) = ext.get_contract() else {
+        let Some(code) = contract.get_code() else {
             return Box::new(Result::Err(VMRunnerError::ContractCodeNotPresent));
         };
         if !cfg!(target_arch = "x86") && !cfg!(target_arch = "x86_64") {

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -75,9 +75,10 @@ fn compute_function_call_cost(
 
     // Warmup.
     for _ in 0..warmup_repeats {
+        let gas_counter = fake_context.make_gas_counter(&vm_config);
         let runtime = vm_kind.runtime(vm_config.clone()).expect("runtime has not been enabled");
         let result = runtime
-            .prepare(&fake_external, &fake_context, cache)
+            .prepare(&fake_external, cache, gas_counter, &fake_context.method)
             .run(&mut fake_external, &fake_context, Arc::clone(&fees))
             .expect("fatal error");
         assert!(result.aborted.is_none());
@@ -85,9 +86,10 @@ fn compute_function_call_cost(
     // Run with gas metering.
     let start = GasCost::measure(gas_metric);
     for _ in 0..repeats {
+        let gas_counter = fake_context.make_gas_counter(&vm_config);
         let runtime = vm_kind.runtime(vm_config.clone()).expect("runtime has not been enabled");
         let result = runtime
-            .prepare(&fake_external, &fake_context, cache)
+            .prepare(&fake_external, cache, gas_counter, &fake_context.method)
             .run(&mut fake_external, &fake_context, Arc::clone(&fees))
             .expect("fatal_error");
         assert!(result.aborted.is_none());

--- a/runtime/runtime-params-estimator/src/function_call.rs
+++ b/runtime/runtime-params-estimator/src/function_call.rs
@@ -71,14 +71,14 @@ fn compute_function_call_cost(
     let vm_config = runtime_config.wasm_config.clone();
     let fees = runtime_config.fees.clone();
     let mut fake_external = MockedExternal::with_code(contract.clone_for_tests());
-    let fake_context = create_context("hello0", vec![]);
+    let fake_context = create_context(vec![]);
 
     // Warmup.
     for _ in 0..warmup_repeats {
         let gas_counter = fake_context.make_gas_counter(&vm_config);
         let runtime = vm_kind.runtime(vm_config.clone()).expect("runtime has not been enabled");
         let result = runtime
-            .prepare(&fake_external, cache, gas_counter, &fake_context.method)
+            .prepare(&fake_external, cache, gas_counter, "hello0")
             .run(&mut fake_external, &fake_context, Arc::clone(&fees))
             .expect("fatal error");
         assert!(result.aborted.is_none());
@@ -89,7 +89,7 @@ fn compute_function_call_cost(
         let gas_counter = fake_context.make_gas_counter(&vm_config);
         let runtime = vm_kind.runtime(vm_config.clone()).expect("runtime has not been enabled");
         let result = runtime
-            .prepare(&fake_external, cache, gas_counter, &fake_context.method)
+            .prepare(&fake_external, cache, gas_counter, "hello0")
             .run(&mut fake_external, &fake_context, Arc::clone(&fees))
             .expect("fatal_error");
         assert!(result.aborted.is_none());

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -142,9 +142,10 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
 
     // Warmup with gas metering
     for _ in 0..warmup_repeats {
+        let gas_counter = fake_context.make_gas_counter(&vm_config_gas);
         let runtime = vm_kind.runtime(vm_config_gas.clone()).expect("runtime has not been enabled");
         let result = runtime
-            .prepare(&fake_external, &fake_context, cache)
+            .prepare(&fake_external, cache, gas_counter, &fake_context.method)
             .run(&mut fake_external, &fake_context, Arc::clone(&fees))
             .expect("fatal_error");
         if let Some(err) = &result.aborted {
@@ -156,9 +157,10 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     // Run with gas metering.
     let start = GasCost::measure(gas_metric);
     for _ in 0..repeats {
+        let gas_counter = fake_context.make_gas_counter(&vm_config_gas);
         let runtime = vm_kind.runtime(vm_config_gas.clone()).expect("runtime has not been enabled");
         let result = runtime
-            .prepare(&fake_external, &fake_context, cache)
+            .prepare(&fake_external, cache, gas_counter, &fake_context.method)
             .run(&mut fake_external, &fake_context, Arc::clone(&fees))
             .expect("fatal_error");
         assert!(result.aborted.is_none());
@@ -167,10 +169,11 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
 
     // Warmup without gas metering
     for _ in 0..warmup_repeats {
+        let gas_counter = fake_context.make_gas_counter(&vm_config_free);
         let runtime_free_gas =
             vm_kind.runtime(vm_config_free.clone()).expect("runtime has not been enabled");
         let result = runtime_free_gas
-            .prepare(&fake_external, &fake_context, cache)
+            .prepare(&fake_external, cache, gas_counter, &fake_context.method)
             .run(&mut fake_external, &fake_context, Arc::clone(&fees))
             .expect("fatal_error");
         assert!(result.aborted.is_none());
@@ -179,10 +182,11 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     // Run without gas metering.
     let start = GasCost::measure(gas_metric);
     for _ in 0..repeats {
+        let gas_counter = fake_context.make_gas_counter(&vm_config_free);
         let runtime_free_gas =
             vm_kind.runtime(vm_config_free.clone()).expect("runtime has not been enabled");
         let result = runtime_free_gas
-            .prepare(&fake_external, &fake_context, cache)
+            .prepare(&fake_external, cache, gas_counter, &fake_context.method)
             .run(&mut fake_external, &fake_context, Arc::clone(&fees))
             .expect("fatal_error");
         assert!(result.aborted.is_none());

--- a/runtime/runtime-params-estimator/src/gas_metering.rs
+++ b/runtime/runtime-params-estimator/src/gas_metering.rs
@@ -138,14 +138,14 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
     });
     let fees = runtime_config.fees.clone();
     let mut fake_external = MockedExternal::with_code(contract.clone_for_tests());
-    let fake_context = create_context("hello", vec![]);
+    let fake_context = create_context(vec![]);
 
     // Warmup with gas metering
     for _ in 0..warmup_repeats {
         let gas_counter = fake_context.make_gas_counter(&vm_config_gas);
         let runtime = vm_kind.runtime(vm_config_gas.clone()).expect("runtime has not been enabled");
         let result = runtime
-            .prepare(&fake_external, cache, gas_counter, &fake_context.method)
+            .prepare(&fake_external, cache, gas_counter, "hello")
             .run(&mut fake_external, &fake_context, Arc::clone(&fees))
             .expect("fatal_error");
         if let Some(err) = &result.aborted {
@@ -160,7 +160,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
         let gas_counter = fake_context.make_gas_counter(&vm_config_gas);
         let runtime = vm_kind.runtime(vm_config_gas.clone()).expect("runtime has not been enabled");
         let result = runtime
-            .prepare(&fake_external, cache, gas_counter, &fake_context.method)
+            .prepare(&fake_external, cache, gas_counter, "hello")
             .run(&mut fake_external, &fake_context, Arc::clone(&fees))
             .expect("fatal_error");
         assert!(result.aborted.is_none());
@@ -173,7 +173,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
         let runtime_free_gas =
             vm_kind.runtime(vm_config_free.clone()).expect("runtime has not been enabled");
         let result = runtime_free_gas
-            .prepare(&fake_external, cache, gas_counter, &fake_context.method)
+            .prepare(&fake_external, cache, gas_counter, "hello")
             .run(&mut fake_external, &fake_context, Arc::clone(&fees))
             .expect("fatal_error");
         assert!(result.aborted.is_none());
@@ -186,7 +186,7 @@ pub(crate) fn compute_gas_metering_cost(config: &Config, contract: &ContractCode
         let runtime_free_gas =
             vm_kind.runtime(vm_config_free.clone()).expect("runtime has not been enabled");
         let result = runtime_free_gas
-            .prepare(&fake_external, cache, gas_counter, &fake_context.method)
+            .prepare(&fake_external, cache, gas_counter, "hello")
             .run(&mut fake_external, &fake_context, Arc::clone(&fees))
             .expect("fatal_error");
         assert!(result.aborted.is_none());

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -928,12 +928,12 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
     let cache = MockContractRuntimeCache::default();
 
     let mut run = || {
-        let context = create_context("cpu_ram_soak_test", vec![]);
+        let context = create_context(vec![]);
         let gas_counter = context.make_gas_counter(&config);
         let vm_result = vm_kind
             .runtime(config.clone())
             .unwrap()
-            .prepare(&fake_external, Some(&cache), gas_counter, &context.method)
+            .prepare(&fake_external, Some(&cache), gas_counter, "cpu_ram_soak_test")
             .run(&mut fake_external, &context, Arc::clone(&fees))
             .expect("fatal_error");
         assert!(vm_result.aborted.is_some());

--- a/runtime/runtime-params-estimator/src/lib.rs
+++ b/runtime/runtime-params-estimator/src/lib.rs
@@ -929,10 +929,11 @@ fn wasm_instruction(ctx: &mut EstimatorContext) -> GasCost {
 
     let mut run = || {
         let context = create_context("cpu_ram_soak_test", vec![]);
+        let gas_counter = context.make_gas_counter(&config);
         let vm_result = vm_kind
             .runtime(config.clone())
             .unwrap()
-            .prepare(&fake_external, &context, Some(&cache))
+            .prepare(&fake_external, Some(&cache), gas_counter, &context.method)
             .run(&mut fake_external, &context, Arc::clone(&fees))
             .expect("fatal_error");
         assert!(vm_result.aborted.is_some());

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -15,13 +15,12 @@ const SIGNER_ACCOUNT_ID: &str = "bob";
 const SIGNER_ACCOUNT_PK: [u8; 3] = [0, 1, 2];
 const PREDECESSOR_ACCOUNT_ID: &str = "carol";
 
-pub(crate) fn create_context(method: &str, input: Vec<u8>) -> VMContext {
+pub(crate) fn create_context(input: Vec<u8>) -> VMContext {
     VMContext {
         current_account_id: CURRENT_ACCOUNT_ID.parse().unwrap(),
         signer_account_id: SIGNER_ACCOUNT_ID.parse().unwrap(),
         signer_account_pk: Vec::from(&SIGNER_ACCOUNT_PK[..]),
         predecessor_account_id: PREDECESSOR_ACCOUNT_ID.parse().unwrap(),
-        method: method.into(),
         input,
         promise_results: vec![].into(),
         block_height: 10,

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -87,7 +87,7 @@ pub(crate) fn execute_function_call(
         attached_deposit: function_call.deposit,
         prepaid_gas: function_call.gas,
         random_seed,
-        view_config: view_config.clone(),
+        view_config,
         output_data_receivers,
     };
 

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -103,13 +103,13 @@ pub(crate) fn execute_function_call(
         false => None,
     };
     let mode_guard = runtime_ext.trie_update.with_trie_cache_mode(mode);
-    let result = near_vm_runner::run(
+    let contract = near_vm_runner::prepare(
         runtime_ext,
         &context,
         Arc::clone(&config.wasm_config),
-        Arc::clone(&config.fees),
         apply_state.cache.as_deref(),
     );
+    let result = near_vm_runner::run(contract, runtime_ext, &context, Arc::clone(&config.fees));
     drop(mode_guard);
     near_vm_runner::report_metrics(
         &apply_state.shard_id.to_string(),

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -192,16 +192,15 @@ pub(crate) fn action_function_call(
     state_update: &mut TrieUpdate,
     apply_state: &ApplyState,
     account: &mut Account,
-    receipt: &Receipt,
     action_receipt: &ActionReceipt,
-    promise_results: Arc<[PromiseResult]>,
     result: &mut ActionResult,
     account_id: &AccountId,
     function_call: &FunctionCallAction,
     action_hash: &CryptoHash,
     config: &RuntimeConfig,
-    is_last_action: bool,
     epoch_info_provider: &(dyn EpochInfoProvider),
+    context: VMContext,
+    contract: Box<dyn PreparedContract>,
 ) -> Result<(), RuntimeError> {
     if account.amount().checked_add(function_call.deposit).is_none() {
         return Err(StorageError::StorageInconsistentState(
@@ -213,20 +212,6 @@ pub(crate) fn action_function_call(
     #[cfg(feature = "test_features")]
     apply_recorded_storage_garbage(function_call, state_update);
 
-    let (context, contract) = prepare_function_call(
-        state_update,
-        apply_state,
-        account,
-        receipt,
-        action_receipt,
-        promise_results,
-        account_id,
-        function_call,
-        action_hash,
-        config,
-        is_last_action,
-        epoch_info_provider,
-    );
     let mut receipt_manager = ReceiptManager::default();
     let mut runtime_ext = RuntimeExt::new(
         state_update,

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -127,10 +127,10 @@ pub(crate) fn execute_function_call(
 }
 
 pub(crate) fn prepare_function_call(
-    state_update: &mut TrieUpdate,
+    state_update: &TrieUpdate,
     apply_state: &ApplyState,
-    account: &mut Account,
-    receipt: &Receipt,
+    account: &Account,
+    predecessor_id: AccountId,
     action_receipt: &ActionReceipt,
     promise_results: Arc<[PromiseResult]>,
     account_id: &AccountId,
@@ -156,7 +156,7 @@ pub(crate) fn prepare_function_call(
         signer_account_id: action_receipt.signer_id.clone(),
         signer_account_pk: borsh::to_vec(&action_receipt.signer_public_key)
             .expect("Failed to serialize"),
-        predecessor_account_id: receipt.predecessor_id().clone(),
+        predecessor_account_id: predecessor_id,
         method: function_call.method_name.clone(),
         input: function_call.args.clone(),
         promise_results,

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -1,5 +1,4 @@
-use crate::conversions::Convert;
-use crate::receipt_manager::ReceiptManager;
+use crate::conversions::Convert; use crate::receipt_manager::ReceiptManager;
 use near_primitives::account::id::AccountType;
 use near_primitives::account::Account;
 use near_primitives::checked_feature;
@@ -13,7 +12,7 @@ use near_store::{has_promise_yield_receipt, KeyLookupMode, TrieUpdate, TrieUpdat
 use near_vm_runner::logic::errors::{AnyError, VMLogicError};
 use near_vm_runner::logic::types::ReceiptIndex;
 use near_vm_runner::logic::{External, StorageGetMode, ValuePtr};
-use near_vm_runner::ContractCode;
+use near_vm_runner::{Contract, ContractCode};
 use near_wallet_contract::{wallet_contract, wallet_contract_magic_bytes};
 use std::sync::Arc;
 
@@ -359,16 +358,26 @@ impl<'a> External for RuntimeExt<'a> {
     fn get_receipt_receiver(&self, receipt_index: ReceiptIndex) -> &AccountId {
         self.receipt_manager.get_receipt_receiver(receipt_index)
     }
+}
 
-    fn code_hash(&self) -> CryptoHash {
+pub(crate) struct RuntimeContractExt<'a> {
+    pub(crate) trie_update: &'a TrieUpdate,
+    pub(crate) account_id: &'a AccountId,
+    pub(crate) account: &'a Account,
+    pub(crate) chain_id: &'a str,
+    pub(crate) current_protocol_version: ProtocolVersion,
+}
+
+impl<'a> Contract for RuntimeContractExt<'a> {
+    fn hash(&self) -> CryptoHash {
         self.account.code_hash()
     }
 
-    fn get_contract(&self) -> Option<Arc<ContractCode>> {
-        let account_id = self.account_id();
-        let code_hash = self.code_hash();
+    fn get_code(&self) -> Option<Arc<ContractCode>> {
+        let account_id = self.account_id;
+        let code_hash = self.hash();
         let version = self.current_protocol_version;
-        let chain_id = self.chain_id();
+        let chain_id = self.chain_id;
         if checked_feature!("stable", EthImplicitAccounts, self.current_protocol_version)
             && account_id.get_account_type() == AccountType::EthImplicitAccount
             && &code_hash == wallet_contract_magic_bytes(&chain_id).hash()

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -1,4 +1,5 @@
-use crate::conversions::Convert; use crate::receipt_manager::ReceiptManager;
+use crate::conversions::Convert;
+use crate::receipt_manager::ReceiptManager;
 use near_primitives::account::id::AccountType;
 use near_primitives::account::Account;
 use near_primitives::checked_feature;

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -434,42 +434,7 @@ impl Runtime {
                 )?;
             }
             Action::FunctionCall(function_call) => {
-                let is_last_action = action_index + 1 == actions.len();
-                let output_data_receivers: Vec<_> = if is_last_action {
-                    action_receipt
-                        .output_data_receivers
-                        .iter()
-                        .map(|r| r.receiver_id.clone())
-                        .collect()
-                } else {
-                    vec![]
-                };
-                let random_seed = near_primitives::utils::create_random_seed(
-                    apply_state.current_protocol_version,
-                    *action_hash,
-                    apply_state.random_seed,
-                );
                 let account = account.as_mut().expect(EXPECT_ACCOUNT_EXISTS);
-                let context = near_vm_runner::logic::VMContext {
-                    current_account_id: account_id.clone(),
-                    signer_account_id: action_receipt.signer_id.clone(),
-                    signer_account_pk: borsh::to_vec(&action_receipt.signer_public_key)
-                        .expect("Failed to serialize"),
-                    predecessor_account_id: receipt.predecessor_id().clone(),
-                    input: function_call.args.clone(),
-                    promise_results,
-                    block_height: apply_state.block_height,
-                    block_timestamp: apply_state.block_timestamp,
-                    epoch_height: apply_state.epoch_height,
-                    account_balance: account.amount(),
-                    account_locked_balance: account.locked(),
-                    storage_usage: account.storage_usage(),
-                    attached_deposit: function_call.deposit,
-                    prepaid_gas: function_call.gas,
-                    random_seed,
-                    view_config: None,
-                    output_data_receivers,
-                };
                 let contract = prepare_function_call(
                     state_update,
                     apply_state,
@@ -480,18 +445,21 @@ impl Runtime {
                     epoch_info_provider,
                     None,
                 );
+                let is_last_action = action_index + 1 == actions.len();
                 action_function_call(
                     state_update,
                     apply_state,
                     account,
+                    receipt,
                     action_receipt,
+                    promise_results,
                     &mut result,
                     account_id,
                     function_call,
                     action_hash,
                     &apply_state.config,
+                    is_last_action,
                     epoch_info_provider,
-                    context,
                     contract,
                 )?;
             }

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -456,7 +456,6 @@ impl Runtime {
                     signer_account_pk: borsh::to_vec(&action_receipt.signer_public_key)
                         .expect("Failed to serialize"),
                     predecessor_account_id: receipt.predecessor_id().clone(),
-                    method: function_call.method_name.clone(),
                     input: function_call.args.clone(),
                     promise_results,
                     block_height: apply_state.block_height,

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -437,8 +437,8 @@ impl Runtime {
                 let (context, contract) = prepare_function_call(
                     state_update,
                     apply_state,
-                    account.as_mut().expect(EXPECT_ACCOUNT_EXISTS),
-                    receipt,
+                    account.as_ref().expect(EXPECT_ACCOUNT_EXISTS),
+                    receipt.predecessor_id().clone(),
                     action_receipt,
                     Arc::clone(&promise_results),
                     account_id,

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -447,6 +447,7 @@ impl Runtime {
                     &apply_state.config,
                     action_index + 1 == actions.len(),
                     epoch_info_provider,
+                    None,
                 );
                 action_function_call(
                     state_update,

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -2329,12 +2329,6 @@ impl<'a> ApplyProcessingReceiptState<'a> {
     fn next_local_receipt(&mut self) -> Option<Receipt> {
         self.local_receipts.pop_front()
     }
-
-    /// Observe the information about a receipt that would be processed `ahead` receipts later.
-    #[allow(dead_code)] // TODO
-    fn peek_receipt(&self, ahead: usize) -> Option<&Receipt> {
-        self.local_receipts.get(ahead)
-    }
 }
 
 #[cfg(test)]

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -434,20 +434,33 @@ impl Runtime {
                 )?;
             }
             Action::FunctionCall(function_call) => {
-                action_function_call(
+                let (context, contract) = prepare_function_call(
                     state_update,
                     apply_state,
                     account.as_mut().expect(EXPECT_ACCOUNT_EXISTS),
                     receipt,
                     action_receipt,
-                    promise_results,
-                    &mut result,
+                    Arc::clone(&promise_results),
                     account_id,
                     function_call,
                     action_hash,
                     &apply_state.config,
                     action_index + 1 == actions.len(),
                     epoch_info_provider,
+                );
+                action_function_call(
+                    state_update,
+                    apply_state,
+                    account.as_mut().expect(EXPECT_ACCOUNT_EXISTS),
+                    action_receipt,
+                    &mut result,
+                    account_id,
+                    function_call,
+                    action_hash,
+                    &apply_state.config,
+                    epoch_info_provider,
+                    context,
+                    contract,
                 )?;
             }
             Action::Transfer(TransferAction { deposit }) => {

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -1,7 +1,7 @@
 use crate::actions::execute_function_call;
 use crate::ext::RuntimeExt;
 use crate::receipt_manager::ReceiptManager;
-use crate::ApplyState;
+use crate::{prepare_function_call, ApplyState};
 use near_crypto::{KeyType, PublicKey};
 use near_parameters::RuntimeConfigStore;
 use near_primitives::account::{AccessKey, Account};
@@ -237,46 +237,19 @@ impl TrieViewer {
             gas: self.max_gas_burnt_view,
             deposit: 0,
         };
-        let output_data_receivers =
-            action_receipt.output_data_receivers.iter().map(|r| r.receiver_id.clone()).collect();
-        let random_seed = near_primitives::utils::create_random_seed(
-            apply_state.current_protocol_version,
-            empty_hash,
-            apply_state.random_seed,
-        );
-        let context = near_vm_runner::logic::VMContext {
-            current_account_id: contract_id.clone(),
-            signer_account_id: action_receipt.signer_id.clone(),
-            signer_account_pk: borsh::to_vec(&action_receipt.signer_public_key)
-                .expect("Failed to serialize"),
-            predecessor_account_id: originator_id.clone(),
-            method: function_call.method_name.clone(),
-            input: function_call.args.clone(),
-            promise_results: [].into(),
-            block_height: apply_state.block_height,
-            block_timestamp: apply_state.block_timestamp,
-            epoch_height: apply_state.epoch_height,
-            account_balance: account.amount(),
-            account_locked_balance: account.locked(),
-            storage_usage: account.storage_usage(),
-            attached_deposit: function_call.deposit,
-            prepaid_gas: function_call.gas,
-            random_seed,
-            view_config: None,
-            output_data_receivers,
-        };
-        let code_ext = crate::ext::RuntimeContractExt {
-            trie_update: &state_update,
-            account_id: contract_id,
-            account: &account,
-            chain_id: &epoch_info_provider.chain_id(),
-            current_protocol_version: apply_state.current_protocol_version,
-        };
-        let contract = near_vm_runner::prepare(
-            &code_ext,
-            &context,
-            Arc::clone(&config.wasm_config),
-            apply_state.cache.as_deref(),
+        let (context, contract) = prepare_function_call(
+            &state_update,
+            &apply_state,
+            &account,
+            originator_id.clone(),
+            &action_receipt,
+            [].into(),
+            contract_id,
+            &function_call,
+            &empty_hash,
+            config,
+            true,
+            epoch_info_provider,
         );
         let mut runtime_ext = RuntimeExt::new(
             &mut state_update,

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -250,7 +250,6 @@ impl TrieViewer {
             signer_account_pk: borsh::to_vec(&action_receipt.signer_public_key)
                 .expect("Failed to serialize"),
             predecessor_account_id: originator_id.clone(),
-            method: function_call.method_name.clone(),
             input: function_call.args.clone(),
             promise_results: [].into(),
             block_height: apply_state.block_height,

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -250,6 +250,7 @@ impl TrieViewer {
             config,
             true,
             epoch_info_provider,
+            Some(ViewConfig { max_gas_burnt: self.max_gas_burnt_view }),
         );
         let mut runtime_ext = RuntimeExt::new(
             &mut state_update,
@@ -270,7 +271,6 @@ impl TrieViewer {
             &mut runtime_ext,
             &function_call,
             config,
-            Some(ViewConfig { max_gas_burnt: self.max_gas_burnt_view }),
         )
         .map_err(|e| errors::CallFunctionError::InternalError { error_message: e.to_string() })?;
         let elapsed = now.elapsed();


### PR DESCRIPTION
Best reviewed commit-by-commit.

This ultimately lifts the contract preparation up through a several function call layers in the transaction runtime up to the layer where all the currently necessary data are available.

This PR also establishes in broad strokes where the pipelining decisions will be made (`ApplyProcessingReceiptState`) and makes some minor changes to the type to have it contain local receipts (in addition to the previously contained delayed receipts etc) in a queue of sorts which would allow the pipelining code to look-ahead of the ongoing processing work and queue-up preparation of the upcoming contracts there.

This work so far is intended to have no functional changes.

Part of #11319