### PR TITLE
feat(forknet) - configure log config only in new_test

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -497,6 +497,8 @@ class NeardRunner:
             self.set_state(TestState.AWAITING_NETWORK_INIT)
             self.save_data()
 
+            self.configure_log_config()
+
             return {
                 'validator_account_id': validator_account_id,
                 'validator_public_key': validator_public_key,
@@ -890,63 +892,76 @@ class NeardRunner:
 
     # If this is a regular node, starts neard run. If it's a traffic generator, starts neard mirror run
     def start_neard(self, batch_interval_millis=None):
-        with open(os.path.join(self.neard_logs_dir, self.neard_logs_file_name),
-                  'ab') as out:
+        out_path = os.path.join(self.neard_logs_dir, self.neard_logs_file_name)
+        with open(out_path, 'ab') as out:
             if self.is_traffic_generator():
-                cmd = [
-                    self.data['current_neard_path'],
-                    'mirror',
-                    'run',
-                    '--source-home',
-                    self.source_near_home_path(),
-                    '--target-home',
-                    self.target_near_home_path(),
-                ]
-                if os.path.exists(self.setup_path('mirror-secret.json')):
-                    cmd.append('--secret-file')
-                    cmd.append(self.setup_path('mirror-secret.json'))
-                else:
-                    cmd.append('--no-secret')
-                if batch_interval_millis is not None:
-                    with open(self.target_near_home_path('mirror-config.json'),
-                              'w') as f:
-                        secs = batch_interval_millis // 1000
-                        nanos = (batch_interval_millis % 1000) * 1000000
-                        json.dump(
-                            {
-                                'tx_batch_interval': {
-                                    'secs': secs,
-                                    'nanos': nanos
-                                }
-                            },
-                            f,
-                            indent=2)
-                    cmd.append('--config-path')
-                    cmd.append(self.target_near_home_path('mirror-config.json'))
+                self.get_start_traffic_generator_cmd(batch_interval_millis)
             else:
-                cmd = [
-                    self.data['current_neard_path'], '--log-span-events',
-                    '--home', self.neard_home, '--unsafe-fast-startup', 'run'
-                ]
-
-            # Save logs config file to control the level of rust and opentelemetry logs.
-            # Default config sets level to DEBUG for "client" and "chain" logs, WARN for tokio+actix, and INFO for everything else.
-            default_log_filter = 'client=debug,chain=debug,actix_web=warn,mio=warn,tokio_util=warn,actix_server=warn,actix_http=warn,info'
-            with open(self.target_near_home_path('log_config.json'),
-                      'w') as log_config_file:
-                json.dump(
-                    {
-                        'opentelemetry': default_log_filter,
-                        'rust_log': default_log_filter,
-                    },
-                    log_config_file,
-                    indent=2)
+                cmd = self.get_start_cmd()
 
             self.run_neard(
                 cmd,
                 out_file=out,
             )
             self.last_start = time.time()
+
+    # Configure the logs config file to control the level of rust and opentelemetry logs.
+    # Default config sets level to DEBUG for "client" and "chain" logs, WARN for tokio+actix, and INFO for everything else.
+    def configure_log_config(self):
+        default_log_filter = 'client=debug,chain=debug,actix_web=warn,mio=warn,tokio_util=warn,actix_server=warn,actix_http=warn,info'
+        log_config_path = self.target_near_home_path('log_config.json')
+
+        logging.info("Creating log_config.json with default log filter.")
+        with open(log_config_path, 'w') as log_config_file:
+            config_json = {
+                'opentelemetry': default_log_filter,
+                'rust_log': default_log_filter,
+            }
+            json.dump(config_json, log_config_file, indent=2)
+
+    # Get the command to start neard for regular nodes.
+    # For starting the traffic generator see the get_start_traffic_generator_cmd.
+    def get_start_cmd(self):
+        cmd = [
+            self.data['current_neard_path'],
+            '--log-span-events',
+            '--home',
+            self.neard_home,
+            '--unsafe-fast-startup',
+            'run',
+        ]
+
+        return cmd
+
+    # Get the command to start neard for traffic generator node.
+    def get_start_traffic_generator_cmd(self, batch_interval_millis):
+        cmd = [
+            self.data['current_neard_path'],
+            'mirror',
+            'run',
+            '--source-home',
+            self.source_near_home_path(),
+            '--target-home',
+            self.target_near_home_path(),
+        ]
+        if os.path.exists(self.setup_path('mirror-secret.json')):
+            cmd.append('--secret-file')
+            cmd.append(self.setup_path('mirror-secret.json'))
+        else:
+            cmd.append('--no-secret')
+
+        if batch_interval_millis is not None:
+            secs = batch_interval_millis // 1000
+            nanos = (batch_interval_millis % 1000) * 1000000
+            config_json = {'tx_batch_interval': {'secs': secs, 'nanos': nanos}}
+
+            mirror_config_path = self.target_near_home_path(
+                'mirror-config.json')
+            with open(mirror_config_path, 'w') as f:
+                json.dump(config_json, f, indent=2)
+
+            cmd.append('--config-path')
+            cmd.append(self.target_near_home_path('mirror-config.json'))
 
     # returns a bool that tells whether we should attempt a restart
     def on_neard_died(self):

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -673,8 +673,8 @@ class NeardRunner:
 
     # Updates the URL for the given epoch height or binary idx. adds a new one if the epoch height does not exit
     def update_binaries_url(self, neard_binary_url, epoch_height, binary_idx):
-        if neard_binary_url is not None and ((epoch_height is None) !=
-                                             (binary_idx is None)):
+        if neard_binary_url is not None and ((epoch_height is None)
+                                             != (binary_idx is None)):
             logging.info(
                 f'Updating binary list for height:{epoch_height} or idx:{binary_idx} with '
                 f'url: {neard_binary_url}')

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -895,7 +895,7 @@ class NeardRunner:
         out_path = os.path.join(self.neard_logs_dir, self.neard_logs_file_name)
         with open(out_path, 'ab') as out:
             if self.is_traffic_generator():
-                self.get_start_traffic_generator_cmd(batch_interval_millis)
+                cmd = self.get_start_traffic_generator_cmd(batch_interval_millis)
             else:
                 cmd = self.get_start_cmd()
 
@@ -962,6 +962,8 @@ class NeardRunner:
 
             cmd.append('--config-path')
             cmd.append(self.target_near_home_path('mirror-config.json'))
+
+        return cmd
 
     # returns a bool that tells whether we should attempt a restart
     def on_neard_died(self):

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -673,8 +673,8 @@ class NeardRunner:
 
     # Updates the URL for the given epoch height or binary idx. adds a new one if the epoch height does not exit
     def update_binaries_url(self, neard_binary_url, epoch_height, binary_idx):
-        if neard_binary_url is not None and ((epoch_height is None)
-                                             != (binary_idx is None)):
+        if neard_binary_url is not None and ((epoch_height is None) !=
+                                             (binary_idx is None)):
             logging.info(
                 f'Updating binary list for height:{epoch_height} or idx:{binary_idx} with '
                 f'url: {neard_binary_url}')
@@ -895,7 +895,8 @@ class NeardRunner:
         out_path = os.path.join(self.neard_logs_dir, self.neard_logs_file_name)
         with open(out_path, 'ab') as out:
             if self.is_traffic_generator():
-                cmd = self.get_start_traffic_generator_cmd(batch_interval_millis)
+                cmd = self.get_start_traffic_generator_cmd(
+                    batch_interval_millis)
             else:
                 cmd = self.get_start_cmd()
 


### PR DESCRIPTION
My goal is to figure out how to set the log level in forknet. Please consider this PR only as an RFC for what would be the best approach to solve this problem. I think in the perfect world the initial setup would happen only once e.g. in `new_test` or in `reset`. It may also be nice to add a command to adjust the log config but this can always be done with `run-cmd` so it's low pri. 

I also refactored things a bit, sorry for mixing it with the real change. The real change is moving `configure_log_config` from `start_neard` to `new_test`, the rest should be a noop. 