### PR TITLE
fix: tentative fix for test gc_after_sync1

### DIFF
--- a/pytest/tests/sanity/gc_after_sync1.py
+++ b/pytest/tests/sanity/gc_after_sync1.py
@@ -63,7 +63,11 @@ nodes[0].kill()
 
 for i in range(1, EPOCH_LENGTH * 6):
     res = nodes[1].json_rpc('block', [i], timeout=10)
-    assert 'error' in res, f'height {i}, {res}'
+    # State sync fetches a block at height EPOCH * LENGTH - 1
+    if i == EPOCH_LENGTH * 3 - 1:
+        assert 'result' in res, f'height {i}, {res}'
+    else:
+        assert 'error' in res, f'height {i}, {res}'
 
 for i in range(EPOCH_LENGTH * 6, EPOCH_LENGTH * 10 + 1):
     res = nodes[1].json_rpc('block', [i], timeout=10)


### PR DESCRIPTION
Quoting the test description:

> Spin up one validating node and one nonvalidating node
> stop the nonvalidating node in the second epoch and
> restart it in the fourth epoch to trigger state sync
> Check that after 10 epochs the node has properly garbage
> collected blocks.

After 10 epochs the test checks that the 6 epochs are garbage collected. The problem is: one particular block (89 - the last block of epoch before state sync) is explicitly requested by state sync so it will be returned by the RPC call.

This PR changes the test to expect the presence of block 89.
If instead the block shouldn't be there, it's a bug in state sync / GC.
 