### PR TITLE
feat: handle `RpcError` properly

### DIFF
--- a/chain/jsonrpc/jsonrpc-tests/tests/rpc_query.rs
+++ b/chain/jsonrpc/jsonrpc-tests/tests/rpc_query.rs
@@ -2,6 +2,7 @@ use std::ops::ControlFlow;
 use std::str::FromStr;
 
 use actix::System;
+use awc::http::StatusCode;
 use futures::{future, FutureExt};
 use serde_json::json;
 
@@ -534,6 +535,8 @@ fn test_invalid_methods() {
                 .await
                 .unwrap();
 
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
             let response =
                 serde_json::from_value::<serde_json::Value>(response.json().await.unwrap())
                     .unwrap();
@@ -544,6 +547,78 @@ fn test_invalid_methods() {
                 method_name
             );
         }
+    });
+}
+
+#[test]
+fn test_parse_error_status_code() {
+    test_with_client!(test_utils::NodeType::NonValidator, client, async move {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "dontcare",
+            "method": "tx",
+            "params": serde_json::json!({
+                "tx": "badtx",
+                "sender_account_id": "frolik.near"
+            }),
+        });
+
+        let response = &mut client
+            .client
+            .post(&client.server_addr)
+            .insert_header(("Content-Type", "application/json"))
+            .send_json(&json)
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    });
+}
+
+#[test]
+fn test_bad_handler_error_status_code() {
+    test_with_client!(test_utils::NodeType::NonValidator, client, async move {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "dontcare",
+            "method": "tx",
+            "params": serde_json::json!({
+                "tx_hash": CryptoHash::new().to_string(),
+                "sender_account_id": "frolik.near"
+            }),
+        });
+
+        let response = &mut client
+            .client
+            .post(&client.server_addr)
+            .insert_header(("Content-Type", "application/json"))
+            .send_json(&json)
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::REQUEST_TIMEOUT);
+    });
+}
+
+#[test]
+fn test_good_handler_error_status_code() {
+    test_with_client!(test_utils::NodeType::NonValidator, client, async move {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "dontcare",
+            "method": "EXPERIMENTAL_receipt",
+            "params": serde_json::json!({"receipt_id": CryptoHash::new().to_string()})
+        });
+
+        let response = &mut client
+            .client
+            .post(&client.server_addr)
+            .insert_header(("Content-Type", "application/json"))
+            .send_json(&json)
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
     });
 }
 

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1360,9 +1360,7 @@ async fn rpc_handler(
         match &response.result {
             Ok(_) => HttpResponse::Ok(),
             Err(err) => match err.error_struct {
-                Some(RpcErrorKind::InternalError(_)) | Some(RpcErrorKind::HandlerError(_)) => {
-                    HttpResponse::InternalServerError()
-                }
+                Some(RpcErrorKind::InternalError(_)) => HttpResponse::InternalServerError(),
                 _ => HttpResponse::Ok(),
             },
         }

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -442,8 +442,8 @@ class BaseNode(object):
                 else:
                     if res['result'] == 0:
                         logger.error(
-                            "Storage for %s:%s in inconsistent state, stopping" %
-                            self.addr())
+                            "Storage for %s:%s in inconsistent state, stopping"
+                            % self.addr())
                         self.kill()
                     self.store_tests += res['result']
             except useragent.BadStatusCode:


### PR DESCRIPTION
This PR fixes a small issue that was introduced in #11806

Internal error - 500 status code
Handler error - 408 if it's a `TIMEOUT_ERROR`, otherwise 200
Request validation error - 400 status code

closes #11792