### PR TITLE
fix: Fix issues with nayduck test split_storage.py

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -837,6 +837,7 @@ def init_cluster(
     genesis_config_changes: GenesisConfigChanges,
     client_config_changes: ClientConfigChanges,
     prefix="test",
+    initialize_cold_storage=True,
 ) -> typing.Tuple[str, typing.List[str]]:
     """
     Create cluster configuration
@@ -900,8 +901,9 @@ def init_cluster(
 
     # apply config changes for nodes marked as archival node.
     # for now, we do this only for local nodes (eg. nayduck tests).
-    for i, node_dir in enumerate(node_dirs):
-        configure_cold_storage_for_archival_node(node_dir)
+    if initialize_cold_storage:
+        for i, node_dir in enumerate(node_dirs):
+            configure_cold_storage_for_archival_node(node_dir)
 
     return near_root, node_dirs
 

--- a/pytest/tests/sanity/split_storage.py
+++ b/pytest/tests/sanity/split_storage.py
@@ -439,7 +439,7 @@ class TestSplitStorage(unittest.TestCase):
         logger.info("Restart legacy archival node.")
         # Restart archival node. This should trigger sync.
         archival.start(boot_node=split)
-        
+
         logger.info("Wait for legacy archival node to start syncing.")
 
         # Archival node should be able to sync to split storage without problems.

--- a/pytest/tests/sanity/split_storage.py
+++ b/pytest/tests/sanity/split_storage.py
@@ -64,7 +64,6 @@ class TestSplitStorage(unittest.TestCase):
         msg,
         node,
         expected_head_height,
-        expected_hot_db_kind,
         check_cold_head,
     ):
         info = self._get_split_storage_info(node)
@@ -80,7 +79,7 @@ class TestSplitStorage(unittest.TestCase):
         cold_head_height = result["cold_head_height"]
         hot_db_kind = result["hot_db_kind"]
 
-        self.assertEqual(hot_db_kind, expected_hot_db_kind)
+        self.assertEqual(hot_db_kind, "Hot")
         self.assertGreaterEqual(head_height, expected_head_height)
         self.assertGreaterEqual(final_head_height, expected_head_height - 10)
         if check_cold_head:
@@ -97,15 +96,12 @@ class TestSplitStorage(unittest.TestCase):
 
         # Wait until a few blocks are produced so that we're sure that the db is
         # properly created and populated with some data.
-        n = 5
-        n = wait_for_blocks(archival, target=n).height
+        n = wait_for_blocks(archival, count=5).height
 
         self._check_split_storage_info(
             "migration_phase_1",
             node=archival,
             expected_head_height=n,
-            # The hot db kind should remain archive until fully migrated.
-            expected_hot_db_kind="Archive",
             # The cold storage is not configured so cold head should be none.
             check_cold_head=False,
         )
@@ -116,17 +112,13 @@ class TestSplitStorage(unittest.TestCase):
         archival.kill()
         archival.start()
 
-        # Wait for a few seconds to:
-        # - Give the node enough time to get started.
-        # - Give the cold store loop enough time to run - it runs every 1s.
+        # Wait until enough blocks so that we produce enough blocks to fill 5
+        # epochs to trigger GC - otherwise the tail won't be set, and wait for
+        # cold store loop to have enough time to run - it runs every 1s.
         # TODO(posvyatokum) this is a quick stop-gap solution to fix nayduck, this
         # should be solved by waiting in a loop until cold store head is at
         # expected proximity to final head.
-        time.sleep(4)
-
-        # Wait until enough blocks so that we produce enough blocks to fill 5
-        # epochs to trigger GC - otherwise the tail won't be set.
-        n = max(n, wait_period) + 5
+        n = max(n, wait_period) + 10
         logger.info(f"Wait until RPC reaches #{n}")
         wait_for_blocks(rpc, target=n)
         logger.info(f"Wait until archival reaches #{n}")
@@ -136,8 +128,6 @@ class TestSplitStorage(unittest.TestCase):
             "migration_phase_2",
             node=archival,
             expected_head_height=n,
-            # The hot db kind should remain archive until fully migrated.
-            expected_hot_db_kind="Archive",
             # The cold storage head should be fully caught up by now.
             check_cold_head=True,
         )
@@ -183,24 +173,17 @@ class TestSplitStorage(unittest.TestCase):
         archival.start()
         rpc.start()
 
-        # Wait for a few seconds to:
-        # - Give the node enough time to get started.
-        # - Give the cold store loop enough time to run - it runs every 1s.
+        # Wait for a few blocks to make sure neard correctly restarted and
+        # wait for cold store loop to have enough time to run - it runs every 1s.
         # TODO(posvyatokum) this is a quick stop-gap solution to fix nayduck, this
         # should be solved by waiting in a loop until cold store head is at
         # expected proximity to final head.
-        time.sleep(4)
-
-        # Wait for just a few blocks to make sure neard correctly restarted.
-        n += 5
-        wait_for_blocks(archival, target=n)
+        wait_for_blocks(archival, count=10)
 
         self._check_split_storage_info(
             "migration_phase_4",
             node=archival,
             expected_head_height=n,
-            # The migration is over, the hot db kind should be set to hot.
-            expected_hot_db_kind="Hot",
             # The cold storage head should be fully caught up.
             check_cold_head=True,
         )
@@ -232,6 +215,9 @@ class TestSplitStorage(unittest.TestCase):
             genesis_config_changes,
             client_config_changes,
             "test_base_case_",
+            # Disable auto-configuration of cold storage for archival nodes
+            # since we configure the cold storage manually in this test.
+            initialize_cold_storage=False,
         )
 
         self._configure_cold_storage(node_dir)
@@ -251,7 +237,6 @@ class TestSplitStorage(unittest.TestCase):
             "base_case",
             node=node,
             expected_head_height=n,
-            expected_hot_db_kind="Archive",
             check_cold_head=True,
         )
 
@@ -312,6 +297,9 @@ class TestSplitStorage(unittest.TestCase):
             genesis_config_changes=genesis_config_changes,
             client_config_changes=client_config_changes,
             prefix="test_migration_",
+            # Disable auto-configuration of cold storage for archival nodes
+            # since we configure the cold storage manually in this test.
+            initialize_cold_storage=False,
         )
 
         validator = spin_up_node(
@@ -385,16 +373,20 @@ class TestSplitStorage(unittest.TestCase):
             },
         }
         config = load_config()
-        near_root, [validator_dir, split_dir, archival_dir,
-                    rpc_dir] = init_cluster(
-                        num_nodes=1,
-                        num_observers=3,
-                        num_shards=1,
-                        config=config,
-                        genesis_config_changes=genesis_config_changes,
-                        client_config_changes=client_config_changes,
-                        prefix="test_archival_node_sync_",
-                    )
+        near_root, [
+            validator_dir, split_dir, archival_dir, rpc_dir
+        ] = init_cluster(
+            num_nodes=1,
+            num_observers=3,
+            num_shards=1,
+            config=config,
+            genesis_config_changes=genesis_config_changes,
+            client_config_changes=client_config_changes,
+            prefix="test_archival_node_sync_",
+            # Disable auto-configuration of cold storage for archival nodes
+            # since we configure the cold storage manually in this test.
+            initialize_cold_storage=False,
+        )
 
         validator = spin_up_node(
             config,
@@ -447,12 +439,11 @@ class TestSplitStorage(unittest.TestCase):
         logger.info("Restart legacy archival node.")
         # Restart archival node. This should trigger sync.
         archival.start(boot_node=split)
-        time.sleep(10)
-
+        
         logger.info("Wait for legacy archival node to start syncing.")
 
         # Archival node should be able to sync to split storage without problems.
-        wait_for_blocks(archival, target=n + epoch_length, timeout=120)
+        wait_for_blocks(archival, target=n + epoch_length + 10, timeout=140)
         archival.kill()
         split.kill()
 

--- a/tools/cold-store/src/cli.rs
+++ b/tools/cold-store/src/cli.rs
@@ -43,7 +43,7 @@ enum SubCommand {
     /// the db and perform some sanity checks to make sure this db is suitable
     /// for migration to split storage.
     /// This command expects the following preconditions:
-    /// - config.store.path points to an existing database with kind Archive
+    /// - config.store.path points to an existing database with kind Hot or Archive
     /// - config.cold_store.path points to an existing database with kind Cold
     /// - store_relative_path points to an existing database with kind Rpc
     PrepareHot(PrepareHotCmd),
@@ -376,10 +376,9 @@ impl PrepareHotCmd {
         rpc_store: &Store,
     ) -> anyhow::Result<()> {
         let hot_db_kind = hot_store.get_db_kind()?;
-        if hot_db_kind != Some(DbKind::Archive) {
+        if hot_db_kind != Some(DbKind::Hot) && hot_db_kind != Some(DbKind::Archive) {
             return Err(anyhow::anyhow!(
-                "Unexpected hot_store DbKind, expected: {:?}, got: {:?}",
-                DbKind::Archive,
+                "Unexpected hot_store DbKind, expected: DbKind::Hot or DbKind::Archive, got: {:?}",
                 hot_db_kind,
             ));
         }
@@ -387,8 +386,7 @@ impl PrepareHotCmd {
         let cold_db_kind = cold_store.get_db_kind()?;
         if cold_db_kind != Some(DbKind::Cold) {
             return Err(anyhow::anyhow!(
-                "Unexpected cold_store DbKind, expected: {:?}, got: {:?}",
-                DbKind::Cold,
+                "Unexpected cold_store DbKind, expected: DbKind::Cold, got: {:?}",
                 cold_db_kind,
             ));
         }
@@ -396,8 +394,7 @@ impl PrepareHotCmd {
         let rpc_db_kind = rpc_store.get_db_kind()?;
         if rpc_db_kind != Some(DbKind::RPC) {
             return Err(anyhow::anyhow!(
-                "Unexpected rpc_store DbKind, expected: {:?}, got: {:?}",
-                DbKind::RPC,
+                "Unexpected rpc_store DbKind, expected: DbKind::RPC, got: {:?}",
                 rpc_db_kind,
             ));
         }


### PR DESCRIPTION
This is not a final fix to `split_storage.py`, because there is still some nondeterminism that makes the test fail. But the changes below are needed since without them the test consistently fails.

This PR fixes the following:
1) Change `init_cluster` to add a flag to prevent it from initializing cold-storage for archival node, since the test initializes the cold-storage after initializing the cluster. The test checks the state of the archival node before and after it has cold-storage.
2) Update the `DBKind` checks for the hot db, since the hot DB seems to be using `DBKind::Hot` only, not `DBKind::Archive` anymore.
3) Replace `time.sleep` calls with waiting for a number of blocks to be more deterministic on the chain progress.