### PR TITLE
[bench] Disable tx pool state size limit

### DIFF
--- a/core/parameters/src/config_store.rs
+++ b/core/parameters/src/config_store.rs
@@ -145,6 +145,8 @@ impl RuntimeConfigStore {
                 config.congestion_control_config.max_tx_gas = 10u64.pow(16);
                 config.congestion_control_config.min_tx_gas = 10u64.pow(16);
                 config.witness_config.main_storage_proof_size_soft_limit = 999_999_999_999_999;
+                config.witness_config.new_transactions_validation_state_size_soft_limit =
+                    999_999_999_999_999;
                 let mut wasm_config = vm::Config::clone(&config.wasm_config);
                 wasm_config.limit_config.per_receipt_storage_proof_size_limit = 999_999_999_999_999;
                 config.wasm_config = Arc::new(wasm_config);


### PR DESCRIPTION
As this is limiting the throughput of FT benchmark.