### PR TITLE
feat: add mirror tool logging when node is not ready yet

### DIFF
--- a/pytest/tests/mocknet/node_handle.py
+++ b/pytest/tests/mocknet/node_handle.py
@@ -65,6 +65,9 @@ class NodeHandle:
             except (ConnectionRefusedError,
                     requests.exceptions.ConnectionError) as e:
                 pass
+            logger.info(
+                f'Node {self.node.name()} is not ready yet, will check again in 10 seconds'
+            )
             time.sleep(10)
 
     # Same as neard_runner_jsonrpc() without checking the error


### PR DESCRIPTION
This is useful to identify faulty node when `mirror start-traffic` hangs in `waiting for validators to be up` mode for a long time.