### PR TITLE
runtime: implement a receipt preparation pipeline

### DIFF
--- a/core/store/src/contract.rs
+++ b/core/store/src/contract.rs
@@ -6,10 +6,6 @@ use std::sync::{Arc, Mutex};
 
 /// Reads contract code from the trie by its hash.
 ///
-/// Currently, uses `TrieStorage`. Consider implementing separate logic for
-/// requesting and compiling contracts, as any contract code read and
-/// compilation is a major bottleneck during chunk execution.
-///
 /// Cloning is cheap.
 #[derive(Clone)]
 pub struct Storage {

--- a/core/store/src/contract.rs
+++ b/core/store/src/contract.rs
@@ -1,0 +1,56 @@
+use crate::TrieStorage;
+use near_primitives::hash::CryptoHash;
+use near_vm_runner::ContractCode;
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+/// Reads contract code from the trie by its hash.
+///
+/// Currently, uses `TrieStorage`. Consider implementing separate logic for
+/// requesting and compiling contracts, as any contract code read and
+/// compilation is a major bottleneck during chunk execution.
+///
+/// Cloning is cheap.
+#[derive(Clone)]
+pub struct Storage {
+    storage: Arc<dyn TrieStorage>,
+
+    /// During an apply of a single chunk contracts may be deployed through the
+    /// `Action::DeployContract`.
+    ///
+    /// Unfortunately `TrieStorage` does not have a way to write to the underlying storage, and the
+    /// `TrieUpdate` will only write the contract once the whole transaction is committed at the
+    /// end of the chunk's apply.
+    ///
+    /// As a temporary work-around while we're still involving `Trie` for `ContractCode` storage,
+    /// we'll keep a list of such deployed contracts here. Once the contracts are no longer part of
+    /// The State this field should be removed, and the `Storage::store` function should be
+    /// adjusted to write out the contract into the relevant part of the database immediately
+    /// (without going through transactional storage operations and such).
+    uncommitted_deploys: Arc<Mutex<BTreeMap<CryptoHash, ContractCode>>>,
+}
+
+impl Storage {
+    pub fn new(storage: Arc<dyn TrieStorage>) -> Self {
+        Self { storage, uncommitted_deploys: Default::default() }
+    }
+
+    pub fn get(&self, code_hash: CryptoHash) -> Option<ContractCode> {
+        {
+            let guard = self.uncommitted_deploys.lock().expect("no panics");
+            if let Some(v) = guard.get(&code_hash) {
+                return Some(ContractCode::new(v.code().to_vec(), Some(code_hash)));
+            }
+        }
+
+        match self.storage.retrieve_raw_bytes(&code_hash) {
+            Ok(raw_code) => Some(ContractCode::new(raw_code.to_vec(), Some(code_hash))),
+            Err(_) => None,
+        }
+    }
+
+    pub fn store(&self, code: ContractCode) {
+        let mut guard = self.uncommitted_deploys.lock().expect("no panics");
+        guard.insert(*code.hash(), code);
+    }
+}

--- a/core/store/src/contract.rs
+++ b/core/store/src/contract.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 ///
 /// Cloning is cheap.
 #[derive(Clone)]
-pub struct Storage {
+pub struct ContractStorage {
     storage: Arc<dyn TrieStorage>,
 
     /// During an apply of a single chunk contracts may be deployed through the
@@ -26,7 +26,7 @@ pub struct Storage {
     uncommitted_deploys: Arc<Mutex<BTreeMap<CryptoHash, ContractCode>>>,
 }
 
-impl Storage {
+impl ContractStorage {
     pub fn new(storage: Arc<dyn TrieStorage>) -> Self {
         Self { storage, uncommitted_deploys: Default::default() }
     }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -55,6 +55,7 @@ mod rocksdb_metrics;
 mod sync_utils;
 pub mod test_utils;
 pub mod trie;
+pub mod contract;
 
 pub use crate::config::{Mode, StoreConfig};
 pub use crate::opener::{
@@ -948,15 +949,6 @@ pub fn get_access_key_raw(
 
 pub fn set_code(state_update: &mut TrieUpdate, account_id: AccountId, code: &ContractCode) {
     state_update.set(TrieKey::ContractCode { account_id }, code.code().to_vec());
-}
-
-pub fn get_code(
-    trie: &dyn TrieAccess,
-    account_id: &AccountId,
-    code_hash: Option<CryptoHash>,
-) -> Result<Option<ContractCode>, StorageError> {
-    let key = TrieKey::ContractCode { account_id: account_id.clone() };
-    trie.get(&key).map(|opt| opt.map(|code| ContractCode::new(code, code_hash)))
 }
 
 /// Removes account, code and all access keys associated to it.

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -44,6 +44,7 @@ use strum;
 pub mod cold_storage;
 mod columns;
 pub mod config;
+pub mod contract;
 pub mod db;
 pub mod flat;
 pub mod genesis;
@@ -55,7 +56,6 @@ mod rocksdb_metrics;
 mod sync_utils;
 pub mod test_utils;
 pub mod trie;
-pub mod contract;
 
 pub use crate::config::{Mode, StoreConfig};
 pub use crate::opener::{

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -1,6 +1,7 @@
 pub use self::iterator::TrieUpdateIterator;
 use super::accounting_cache::TrieAccountingCacheSwitch;
 use super::{OptimizedValueRef, Trie, TrieWithReadLock};
+use crate::contract::ContractStorage;
 use crate::trie::{KeyLookupMode, TrieChanges};
 use crate::StorageError;
 use near_primitives::hash::CryptoHash;
@@ -26,7 +27,7 @@ pub type TrieUpdates = BTreeMap<Vec<u8>, TrieKeyValueUpdate>;
 /// TODO (#7327): rename to StateUpdate
 pub struct TrieUpdate {
     pub trie: Trie,
-    pub contract_storage: crate::contract::Storage,
+    pub contract_storage: ContractStorage,
     committed: RawStateChanges,
     prospective: TrieUpdates,
 }
@@ -57,7 +58,7 @@ impl TrieUpdate {
         let trie_storage = trie.storage.clone();
         Self {
             trie,
-            contract_storage: crate::contract::Storage::new(trie_storage),
+            contract_storage: ContractStorage::new(trie_storage),
             committed: Default::default(),
             prospective: Default::default(),
         }

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -2,39 +2,16 @@ pub use self::iterator::TrieUpdateIterator;
 use super::accounting_cache::TrieAccountingCacheSwitch;
 use super::{OptimizedValueRef, Trie, TrieWithReadLock};
 use crate::trie::{KeyLookupMode, TrieChanges};
-use crate::{StorageError, TrieStorage};
+use crate::StorageError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{
     AccountId, RawStateChange, RawStateChanges, RawStateChangesWithTrieKey, StateChangeCause,
     StateRoot, TrieCacheMode,
 };
-use near_vm_runner::ContractCode;
 use std::collections::BTreeMap;
-use std::sync::Arc;
 
 mod iterator;
-
-/// Reads contract code from the trie by its hash.
-/// Currently, uses `TrieStorage`. Consider implementing separate logic for
-/// requesting and compiling contracts, as any contract code read and
-/// compilation is a major bottleneck during chunk execution.
-struct ContractStorage {
-    storage: Arc<dyn TrieStorage>,
-}
-
-impl ContractStorage {
-    fn new(storage: Arc<dyn TrieStorage>) -> Self {
-        Self { storage }
-    }
-
-    pub fn get(&self, code_hash: CryptoHash) -> Option<ContractCode> {
-        match self.storage.retrieve_raw_bytes(&code_hash) {
-            Ok(raw_code) => Some(ContractCode::new(raw_code.to_vec(), Some(code_hash))),
-            Err(_) => None,
-        }
-    }
-}
 
 /// Key-value update. Contains a TrieKey and a value.
 pub struct TrieKeyValueUpdate {
@@ -49,7 +26,7 @@ pub type TrieUpdates = BTreeMap<Vec<u8>, TrieKeyValueUpdate>;
 /// TODO (#7327): rename to StateUpdate
 pub struct TrieUpdate {
     pub trie: Trie,
-    contract_storage: ContractStorage,
+    pub contract_storage: crate::contract::Storage,
     committed: RawStateChanges,
     prospective: TrieUpdates,
 }
@@ -80,7 +57,7 @@ impl TrieUpdate {
         let trie_storage = trie.storage.clone();
         Self {
             trie,
-            contract_storage: ContractStorage::new(trie_storage),
+            contract_storage: crate::contract::Storage::new(trie_storage),
             committed: Default::default(),
             prospective: Default::default(),
         }

--- a/integration-tests/src/tests/runtime/sanity_checks.rs
+++ b/integration-tests/src/tests/runtime/sanity_checks.rs
@@ -115,8 +115,8 @@ fn test_cost_sanity() {
     let res = node
         .user()
         .function_call(
-            dbg!(alice_account()),
-            dbg!(test_contract_account()),
+            alice_account(),
+            test_contract_account(),
             "sanity_check",
             args.into_bytes(),
             MAX_GAS,

--- a/integration-tests/src/tests/runtime/sanity_checks.rs
+++ b/integration-tests/src/tests/runtime/sanity_checks.rs
@@ -115,8 +115,8 @@ fn test_cost_sanity() {
     let res = node
         .user()
         .function_call(
-            alice_account(),
-            test_contract_account(),
+            dbg!(alice_account()),
+            dbg!(test_contract_account()),
             "sanity_check",
             args.into_bytes(),
             MAX_GAS,

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -626,7 +626,7 @@ pub(crate) fn action_deploy_contract(
     // Legacy: populate the mapping from `AccountId => sha256(code)` thus making contracts part of
     // The State. For the time being we are also relying on the `TrieUpdate` to actually write the
     // contracts into the storage as part of the commit routine, however no code should be relying
-    // on this per se.
+    // that the contracts are written to The State.
     set_code(state_update, account_id.clone(), &code);
     // Precompile the contract and store result (compiled code or error) in the contract runtime
     // cache.

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -37,8 +37,8 @@ use near_vm_runner::logic::errors::{
     CompilationError, FunctionCallError, InconsistentStateError, VMRunnerError,
 };
 use near_vm_runner::logic::{VMContext, VMOutcome};
-use near_vm_runner::{ContractCode, ContractRuntimeCache};
 use near_vm_runner::{precompile_contract, PreparedContract};
+use near_vm_runner::{ContractCode, ContractRuntimeCache};
 use near_wallet_contract::{wallet_contract, wallet_contract_magic_bytes};
 use std::sync::Arc;
 
@@ -670,12 +670,7 @@ pub(crate) fn action_deploy_contract(
     // cache.
     // Note, that contract compilation costs are already accounted in deploy cost using special
     // logic in estimator (see get_runtime_config() function).
-    precompile_contract(
-        &code,
-        config,
-        cache,
-    )
-    .ok();
+    precompile_contract(&code, config, cache).ok();
     // Inform the `store::contract::Storage` about the new deploy (so that the `get` method can
     // return the contract before the contract is written out to the underlying storage as part of
     // the `TrieUpdate` commit.)

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -2,7 +2,7 @@ use crate::config::{
     safe_add_compute, safe_add_gas, total_prepaid_exec_fees, total_prepaid_gas,
     total_prepaid_send_fees,
 };
-use crate::ext::{ExternalError, RuntimeContractExt, RuntimeExt};
+use crate::ext::{ContractStorage, ExternalError, RuntimeContractExt, RuntimeExt};
 use crate::receipt_manager::ReceiptManager;
 use crate::{metrics, ActionResult, ApplyState};
 use near_crypto::PublicKey;
@@ -183,7 +183,7 @@ pub(crate) fn prepare_function_call(
         view_config.is_some(),
     );
     let code_ext = RuntimeContractExt {
-        trie_update: state_update,
+        storage: ContractStorage::Transaction(state_update),
         account_id,
         account,
         chain_id: &epoch_info_provider.chain_id(),

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -9,6 +9,7 @@ use near_primitives::trie_key::{trie_key_parsers, TrieKey};
 use near_primitives::types::{AccountId, Balance, EpochId, EpochInfoProvider, Gas};
 use near_primitives::utils::create_receipt_id_from_action_hash;
 use near_primitives::version::ProtocolVersion;
+use near_store::contract::ContractStorage;
 use near_store::{has_promise_yield_receipt, KeyLookupMode, TrieUpdate, TrieUpdateValuePtr};
 use near_vm_runner::logic::errors::{AnyError, VMLogicError};
 use near_vm_runner::logic::types::ReceiptIndex;
@@ -362,7 +363,7 @@ impl<'a> External for RuntimeExt<'a> {
 }
 
 pub(crate) struct RuntimeContractExt<'a> {
-    pub(crate) storage: near_store::contract::Storage,
+    pub(crate) storage: ContractStorage,
     pub(crate) account_id: &'a AccountId,
     pub(crate) code_hash: CryptoHash,
     pub(crate) chain_id: &'a str,

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -364,14 +364,14 @@ impl<'a> External for RuntimeExt<'a> {
 pub(crate) struct RuntimeContractExt<'a> {
     pub(crate) storage: near_store::contract::Storage,
     pub(crate) account_id: &'a AccountId,
-    pub(crate) account: &'a Account,
+    pub(crate) code_hash: CryptoHash,
     pub(crate) chain_id: &'a str,
     pub(crate) current_protocol_version: ProtocolVersion,
 }
 
 impl<'a> Contract for RuntimeContractExt<'a> {
     fn hash(&self) -> CryptoHash {
-        self.account.code_hash()
+        self.code_hash
     }
 
     fn get_code(&self) -> Option<Arc<ContractCode>> {

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -9,7 +9,9 @@ use near_primitives::trie_key::{trie_key_parsers, TrieKey};
 use near_primitives::types::{AccountId, Balance, EpochId, EpochInfoProvider, Gas, TrieCacheMode};
 use near_primitives::utils::create_receipt_id_from_action_hash;
 use near_primitives::version::ProtocolVersion;
-use near_store::{has_promise_yield_receipt, KeyLookupMode, TrieUpdate, TrieUpdateValuePtr};
+use near_store::{
+    has_promise_yield_receipt, KeyLookupMode, TrieStorage, TrieUpdate, TrieUpdateValuePtr,
+};
 use near_vm_runner::logic::errors::{AnyError, VMLogicError};
 use near_vm_runner::logic::types::ReceiptIndex;
 use near_vm_runner::logic::{External, StorageGetMode, ValuePtr};
@@ -361,8 +363,19 @@ impl<'a> External for RuntimeExt<'a> {
     }
 }
 
+pub(crate) enum ContractStorage<'a> {
+    /// Access the transaction first.
+    Transaction(&'a TrieUpdate),
+    /// Access the storage layer directly, forgoing the transaction.
+    ///
+    /// When using this, care must be taken to not accidentally access outdated contract code (i.e.
+    /// old code for an account that has deployed a contract but for which the code has not been
+    /// committed yet.)
+    DB(&'a dyn TrieStorage),
+}
+
 pub(crate) struct RuntimeContractExt<'a> {
-    pub(crate) trie_update: &'a TrieUpdate,
+    pub(crate) storage: ContractStorage<'a>,
     pub(crate) account_id: &'a AccountId,
     pub(crate) account: &'a Account,
     pub(crate) chain_id: &'a str,
@@ -389,7 +402,17 @@ impl<'a> Contract for RuntimeContractExt<'a> {
             true => Some(TrieCacheMode::CachingShard),
             false => None,
         };
-        let _guard = self.trie_update.with_trie_cache_mode(mode);
-        self.trie_update.get_code(self.account_id.clone(), code_hash).map(Arc::new)
+        match self.storage {
+            ContractStorage::Transaction(trie_update) => {
+                let _guard = trie_update.with_trie_cache_mode(mode);
+                trie_update.get_code(self.account_id.clone(), code_hash).map(Arc::new)
+            }
+            ContractStorage::DB(db) => match db.retrieve_raw_bytes(&code_hash) {
+                Ok(raw_code) => {
+                    Some(Arc::new(ContractCode::new(raw_code.to_vec(), Some(code_hash))))
+                }
+                Err(_) => None,
+            },
+        }
     }
 }

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -76,11 +76,11 @@ mod congestion_control;
 mod conversions;
 pub mod ext;
 mod metrics;
+mod pipelining;
 mod prefetch;
 pub mod receipt_manager;
 pub mod state_viewer;
 mod verifier;
-mod pipelining;
 
 const EXPECT_ACCOUNT_EXISTS: &str = "account exists, checked above";
 

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1689,6 +1689,8 @@ impl Runtime {
                         );
                         return false;
                     };
+                    // This returns `true` if work has been scheduled (thus we currently prepare
+                    // actions in at most 1 receipt in advance.)
                     processing_state.pipeline_manager.submit(peek, &receiver, None)
                 });
 

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1681,7 +1681,7 @@ impl Runtime {
                     let Ok(Some(receiver)) = receiver else {
                         tracing::error!(
                             target: "runtime",
-                            message="unable to read receiver of a upcoming local receipt",
+                            message="unable to read receiver of an upcoming local receipt",
                             ?peek_account_id,
                             receipt=%receipt.get_hash()
                         );

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1704,7 +1704,7 @@ impl Runtime {
                         // preparation, so lets submit the next one in anticipation that it might
                         // be processed too (it might also be not if we run out of gas/compute.)
                         next_schedule_index = schedule_preparation(&mut processing_state)
-                            .and_then(|adv| nsi.checked_add(adv));
+                            .and_then(|adv| nsi.checked_add(1)?.checked_add(adv));
                     }
                 }
                 // NOTE: We don't need to validate the local receipt, because it's just validated in

--- a/runtime/runtime/src/pipelining.rs
+++ b/runtime/runtime/src/pipelining.rs
@@ -1,0 +1,182 @@
+use near_parameters::RuntimeConfig;
+use near_primitives::account::Account;
+use near_primitives::action::Action;
+use near_primitives::config::ViewConfig;
+use near_primitives::hash::CryptoHash;
+use near_primitives::receipt::{Receipt, ReceiptEnum};
+use near_primitives::types::AccountId;
+use near_vm_runner::logic::GasCounter;
+use near_vm_runner::{ContractRuntimeCache, PreparedContract};
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, Condvar, Mutex};
+
+use crate::ext::{ContractStorage, RuntimeContractExt};
+
+pub(crate) struct ReceiptPreparationPipeline {
+    /// Mapping from a Receipt's ID to a parallel "task" to prepare the receipt's data.
+    ///
+    /// The task itself may be run in the current thread, a separate thread or forced in any other
+    /// way.
+    map: BTreeMap<PrepareTaskKey, Arc<PrepareTask>>,
+
+    /// List of Receipt receiver IDs that must not be prepared for this chunk.
+    ///
+    /// This solves an issue wherein the pipelining implementation only has access to the committed
+    /// storage (read: data as a result of applying the previous chunk,) and not the state that has
+    /// been built up as a result of processing the current chunk. One notable thing that may have
+    /// occurred there is a contract deployment. Once that happens, we can no longer get the
+    /// "current" contract code for the account.
+    ///
+    /// However, even if we had access to the transaction of the current chunk and were able to
+    /// access the new code, there's a risk of a race between when the deployment is executed
+    /// and when a parallel preparation may occur, leading back to needing to hold prefetching of
+    /// that account's contracts until the deployment is executed.
+    ///
+    /// As deployments are a relatively rare event, it is probably just fine to entirely disable
+    /// pipelining for the account in question for that particular block. This field implements
+    /// exactly that.
+    ///
+    /// In the future, however, it may make sense to either move the responsibility of executing
+    /// deployment actions to this pipelining thingy OR, even better, modify the protocol such that
+    /// contract deployments in block N only take effect in the block N+1 as that, among other
+    /// things, would give the runtime more time to compile the contract.
+    block_accounts: BTreeSet<AccountId>,
+
+    /// The Runtime config for these pipelining  requests.
+    config: Arc<RuntimeConfig>,
+
+    /// The contract cache.
+    contract_cache: Option<Box<dyn ContractRuntimeCache>>,
+
+    /// The chain ID being processed.
+    chain_id: String,
+
+    /// Protocol version for this chunk.
+    protocol_version: u32,
+
+    /// Storage.
+    storage: Arc<dyn near_store::TrieStorage>,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct PrepareTaskKey {
+    receipt_id: CryptoHash,
+    action_index: usize,
+}
+
+struct PrepareTask {
+    status: Mutex<PrepareTaskStatus>,
+    condvar: Condvar,
+}
+
+enum PrepareTaskStatus {
+    FunctionCallTask { method: String },
+    Working,
+    Done(Box<dyn PreparedContract>),
+}
+
+impl ReceiptPreparationPipeline {
+    pub(crate) fn new(
+        config: Arc<RuntimeConfig>,
+        contract_cache: Option<Box<dyn ContractRuntimeCache>>,
+        chain_id: String,
+        protocol_version: u32,
+        storage: Arc<dyn near_store::TrieStorage>,
+    ) -> Self {
+        Self {
+            map: Default::default(),
+            block_accounts: Default::default(),
+            config,
+            contract_cache,
+            chain_id,
+            protocol_version,
+            storage,
+        }
+    }
+    /// Submit a receipt to the "pipeline" for preparation of likely eventual execution.
+    ///
+    /// Note that not all receipts submitted here must be actually handled in some way. That said,
+    /// while it is perfectly fine to not use the results of submitted work (e.g. because a
+    /// applying a chunk ran out of gas or compute cost,) this work would eventually get lost, so
+    /// for the most part it is best to submit work with limited look-ahead.
+    ///
+    /// Returns `true` if the receipt is interesting and work has been scheduled for its
+    /// preparation.
+    pub(crate) fn submit(
+        &mut self,
+        receipt: &Receipt,
+        account: &Account,
+        view_config: Option<ViewConfig>,
+    ) -> bool {
+        let account_id = receipt.receiver_id();
+        if self.block_accounts.contains(account_id) {
+            return false;
+        }
+        let actions = match receipt.receipt() {
+            ReceiptEnum::Action(a) | ReceiptEnum::PromiseYield(a) => &a.actions,
+            ReceiptEnum::Data(_) | ReceiptEnum::PromiseResume(_) => return false,
+        };
+        let mut any_function_calls = false;
+        for (action_index, action) in actions.iter().enumerate() {
+            match action {
+                Action::DeployContract(_) => {
+                    self.block_accounts.insert(account_id.clone());
+                    break;
+                }
+                Action::FunctionCall(function_call) => {
+                    let key = PrepareTaskKey { receipt_id: receipt.get_hash(), action_index };
+                    let entry = match self.map.entry(key) {
+                        std::collections::btree_map::Entry::Vacant(v) => v,
+                        // Already been submitted.
+                        std::collections::btree_map::Entry::Occupied(_) => continue,
+                    };
+                    let max_gas_burnt = match view_config {
+                        Some(ViewConfig { max_gas_burnt }) => max_gas_burnt,
+                        None => self.config.wasm_config.limit_config.max_gas_burnt,
+                    };
+                    let gas_counter = GasCounter::new(
+                        self.config.wasm_config.ext_costs.clone(),
+                        max_gas_burnt,
+                        self.config.wasm_config.regular_op_cost,
+                        function_call.gas,
+                        view_config.is_some(),
+                    );
+                    // TODO: This part needs to be executed in a thread eventually.
+                    let code_ext = RuntimeContractExt {
+                        storage: ContractStorage::DB(&*self.storage),
+                        account_id,
+                        account,
+                        chain_id: &self.chain_id,
+                        current_protocol_version: self.protocol_version,
+                    };
+                    let contract = near_vm_runner::prepare(
+                        &code_ext,
+                        Arc::clone(&self.config.wasm_config),
+                        self.contract_cache.as_deref(),
+                        gas_counter,
+                        &function_call.method_name,
+                    );
+                    let task = Arc::new(PrepareTask {
+                        status: Mutex::new(PrepareTaskStatus::Done(contract)),
+                        condvar: Condvar::new(),
+                    });
+                    // let task = Arc::new(Mutex::new(PrepareTaskStatus::FunctionCallTask {
+                    //     method: function_call.method_name.clone(),
+                    // }));
+                    entry.insert(Arc::clone(&task));
+                    any_function_calls = true;
+                }
+                // No need to handle this receipt as it only generates other new receipts.
+                Action::Delegate(_) => {}
+                // No handling for these.
+                Action::CreateAccount(_)
+                | Action::Transfer(_)
+                | Action::Stake(_)
+                | Action::AddKey(_)
+                | Action::DeleteKey(_)
+                | Action::DeleteAccount(_) => {}
+            }
+        }
+        return any_function_calls;
+    }
+}

--- a/runtime/runtime/src/pipelining.rs
+++ b/runtime/runtime/src/pipelining.rs
@@ -8,6 +8,7 @@ use near_primitives::config::ViewConfig;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{Receipt, ReceiptEnum};
 use near_primitives::types::{AccountId, Gas};
+use near_store::contract::ContractStorage;
 use near_vm_runner::logic::{GasCounter, ProtocolVersion};
 use near_vm_runner::{ContractRuntimeCache, PreparedContract};
 use std::collections::{BTreeMap, BTreeSet};
@@ -56,7 +57,7 @@ pub(crate) struct ReceiptPreparationPipeline {
     protocol_version: u32,
 
     /// Storage for WASM code.
-    storage: near_store::contract::Storage,
+    storage: ContractStorage,
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
@@ -83,7 +84,7 @@ impl ReceiptPreparationPipeline {
         contract_cache: Option<Box<dyn ContractRuntimeCache>>,
         chain_id: String,
         protocol_version: u32,
-        storage: near_store::contract::Storage,
+        storage: ContractStorage,
     ) -> Self {
         Self {
             map: Default::default(),
@@ -298,7 +299,7 @@ impl ReceiptPreparationPipeline {
 }
 
 fn prepare_function_call(
-    contract_storage: &near_store::contract::Storage,
+    contract_storage: &ContractStorage,
     cache: Option<&dyn ContractRuntimeCache>,
 
     chain_id: &str,

--- a/runtime/runtime/src/pipelining.rs
+++ b/runtime/runtime/src/pipelining.rs
@@ -246,6 +246,9 @@ impl ReceiptPreparationPipeline {
             let current = std::mem::replace(&mut *status_guard, PrepareTaskStatus::Working);
             match current {
                 PrepareTaskStatus::Pending => {
+                    *status_guard = PrepareTaskStatus::Finished;
+                    drop(status_guard);
+
                     let gas_counter = self.gas_counter(view_config.as_ref(), function_call.gas);
                     let contract = prepare_function_call(
                         &self.storage,
@@ -258,7 +261,6 @@ impl ReceiptPreparationPipeline {
                         &account_id,
                         &function_call.method_name,
                     );
-                    *status_guard = PrepareTaskStatus::Finished;
                     return contract;
                 }
                 PrepareTaskStatus::Working => {

--- a/runtime/runtime/src/pipelining.rs
+++ b/runtime/runtime/src/pipelining.rs
@@ -127,7 +127,7 @@ impl ReceiptPreparationPipeline {
                     // FIXME: instead of blocking these accounts, move the handling of
                     // deploy action into here, so that the necessary data dependencies can be
                     // established.
-                    self.block_accounts.insert(account_id.clone());
+                    self.block_accounts.insert(account_id);
                     break;
                 }
                 Action::FunctionCall(function_call) => {
@@ -157,7 +157,7 @@ impl ReceiptPreparationPipeline {
                             std::mem::replace(&mut *status, PrepareTaskStatus::Working)
                         };
                         match &task_status {
-                            PrepareTaskStatus::Pending => {},
+                            PrepareTaskStatus::Pending => {}
                             PrepareTaskStatus::Working => return,
                             // TODO: seeing Prepared here may mean there's double spawning for the
                             // same receipt index. Maybe output a warning?

--- a/runtime/runtime/src/pipelining.rs
+++ b/runtime/runtime/src/pipelining.rs
@@ -121,6 +121,9 @@ impl ReceiptPreparationPipeline {
         for (action_index, action) in actions.iter().enumerate() {
             match action {
                 Action::DeployContract(_) => {
+                    // FIXME: instead of blocking these accounts, move the handling of
+                    // deploy action into here, so that the necessary data dependencies can be
+                    // established.
                     self.block_accounts.insert(account_id.clone());
                     break;
                 }
@@ -176,6 +179,8 @@ impl ReceiptPreparationPipeline {
                 | Action::AddKey(_)
                 | Action::DeleteKey(_)
                 | Action::DeleteAccount(_) => {}
+                #[cfg(feature = "protocol_feature_nonrefundable_transfer_nep491")]
+                Action::NonrefundableStorageTransfer(_) => {}
             }
         }
         return any_function_calls;

--- a/runtime/runtime/src/pipelining.rs
+++ b/runtime/runtime/src/pipelining.rs
@@ -112,7 +112,7 @@ impl ReceiptPreparationPipeline {
         view_config: Option<ViewConfig>,
     ) -> bool {
         let account_id = receipt.receiver_id();
-        if self.block_accounts.contains(account_id) || true {
+        if self.block_accounts.contains(account_id) {
             return false;
         }
         let actions = match receipt.receipt() {

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -17,7 +17,7 @@ use near_primitives::types::{
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{StateItem, ViewStateResult};
 use near_primitives_core::config::ViewConfig;
-use near_store::{get_access_key, get_account, get_code, TrieUpdate};
+use near_store::{get_access_key, get_account, TrieUpdate};
 use near_vm_runner::logic::{ProtocolVersion, ReturnData};
 use near_vm_runner::{ContractCode, ContractRuntimeCache};
 use std::{str, sync::Arc, time::Instant};
@@ -89,7 +89,7 @@ impl TrieViewer {
         account_id: &AccountId,
     ) -> Result<ContractCode, errors::ViewContractCodeError> {
         let account = self.view_account(state_update, account_id)?;
-        get_code(state_update, account_id, Some(account.code_hash()))?.ok_or_else(|| {
+        state_update.contract_storage.get(account.code_hash()).ok_or_else(|| {
             errors::ViewContractCodeError::NoContractCode {
                 contract_account_id: account_id.clone(),
             }
@@ -146,7 +146,7 @@ impl TrieViewer {
     ) -> Result<ViewStateResult, errors::ViewStateError> {
         match get_account(state_update, account_id)? {
             Some(account) => {
-                let code_len = get_code(state_update, account_id, Some(account.code_hash()))?
+                let code_len = state_update.contract_storage.get(account.code_hash())
                     .map(|c| c.code().len() as u64)
                     .unwrap_or_default();
                 if let Some(limit) = self.state_size_limit {

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -1,13 +1,14 @@
 use crate::actions::execute_function_call;
 use crate::ext::RuntimeExt;
+use crate::pipelining::ReceiptPreparationPipeline;
 use crate::receipt_manager::ReceiptManager;
-use crate::{prepare_function_call, ApplyState};
+use crate::ApplyState;
 use near_crypto::{KeyType, PublicKey};
 use near_parameters::RuntimeConfigStore;
 use near_primitives::account::{AccessKey, Account};
 use near_primitives::borsh::BorshDeserialize;
 use near_primitives::hash::CryptoHash;
-use near_primitives::receipt::ActionReceipt;
+use near_primitives::receipt::{ActionReceipt, Receipt, ReceiptEnum, ReceiptV1};
 use near_primitives::runtime::migration_data::{MigrationData, MigrationFlags};
 use near_primitives::transaction::FunctionCallAction;
 use near_primitives::trie_key::trie_key_parsers;
@@ -225,31 +226,37 @@ impl TrieViewer {
             migration_flags: MigrationFlags::default(),
             congestion_info: Default::default(),
         };
-        let action_receipt = ActionReceipt {
-            signer_id: originator_id.clone(),
-            signer_public_key: public_key,
-            gas_price: 0,
-            output_data_receivers: vec![],
-            input_data_ids: vec![],
-            actions: vec![],
-        };
         let function_call = FunctionCallAction {
             method_name: method_name.to_string(),
             args: args.to_vec(),
             gas: self.max_gas_burnt_view,
             deposit: 0,
         };
-        let view_config = Some(ViewConfig { max_gas_burnt: self.max_gas_burnt_view });
-        let contract = prepare_function_call(
-            &state_update,
-            &apply_state,
-            &account,
-            &contract_id,
-            &function_call,
-            config,
-            epoch_info_provider,
-            view_config.clone(),
+        let action_receipt = ActionReceipt {
+            signer_id: originator_id.clone(),
+            signer_public_key: public_key,
+            gas_price: 0,
+            output_data_receivers: vec![],
+            input_data_ids: vec![],
+            actions: vec![function_call.clone().into()],
+        };
+        let receipt = Receipt::V1(ReceiptV1 {
+            predecessor_id: contract_id.clone(),
+            receiver_id: contract_id.clone(),
+            receipt_id: empty_hash,
+            receipt: ReceiptEnum::Action(action_receipt.clone()),
+            priority: 0,
+        });
+        let pipeline = ReceiptPreparationPipeline::new(
+            Arc::clone(config),
+            apply_state.cache.as_ref().map(|v| v.handle()),
+            epoch_info_provider.chain_id(),
+            apply_state.current_protocol_version,
+            state_update.contract_storage.clone(),
         );
+        let view_config = Some(ViewConfig { max_gas_burnt: self.max_gas_burnt_view });
+        let contract = pipeline.get_contract(&receipt, account.code_hash(), 0, view_config.clone());
+
         let mut runtime_ext = RuntimeExt::new(
             &mut state_update,
             &mut receipt_manager,

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -146,7 +146,9 @@ impl TrieViewer {
     ) -> Result<ViewStateResult, errors::ViewStateError> {
         match get_account(state_update, account_id)? {
             Some(account) => {
-                let code_len = state_update.contract_storage.get(account.code_hash())
+                let code_len = state_update
+                    .contract_storage
+                    .get(account.code_hash())
                     .map(|c| c.code().len() as u64)
                     .unwrap_or_default();
                 if let Some(limit) = self.state_size_limit {


### PR DESCRIPTION
This PR implements a very basic form of pipelining of the contract preparation. In particular with this PR only actions from one upcoming "interesting" local receipt is handled, with other receipt kinds (incoming, delayed) being left for a future change. I don't anticipate any trouble integrating them as they largely have similar data and structure as the local receipts seen here.

The primary reason I want this reviewed separately, however, is due to the changes to storage. You will notice that I have largely changed the code to read contracts without going through The State (i.e. it now reads the contract code directly via the code hash.) However at the same time writing of the contract continues involving The State; largely because I don't want to deal with migrations and similar such complexities… but also because `TrieStorage` does not provide write access. This also means that writing is transactional and I had to add some work-arounds to the `store::contract::Storage` in order to make deployed contracts visible before the commit.