### PR TITLE
test: test max receipt size using TestLoop

### DIFF
--- a/integration-tests/src/test_loop/tests/max_receipt_size.rs
+++ b/integration-tests/src/test_loop/tests/max_receipt_size.rs
@@ -103,7 +103,7 @@ fn test_max_receipt_size() {
     let sum_4_tx = SignedTransaction::call(
         104,
         account0.clone(),
-        account0.clone(),
+        account0,
         &account0_signer,
         0,
         "sum_n".into(),

--- a/integration-tests/src/test_loop/tests/max_receipt_size.rs
+++ b/integration-tests/src/test_loop/tests/max_receipt_size.rs
@@ -1,0 +1,118 @@
+use assert_matches::assert_matches;
+use near_async::time::Duration;
+use near_o11y::testonly::init_test_logger;
+use near_primitives::errors::{
+    ActionErrorKind, InvalidTxError, ReceiptValidationError, TxExecutionError,
+};
+use near_primitives::test_utils::create_user_test_signer;
+use near_primitives::transaction::SignedTransaction;
+use near_primitives::types::AccountId;
+use near_primitives::views::FinalExecutionStatus;
+
+use crate::test_loop::env::TestLoopEnv;
+use crate::test_loop::utils::setups::standard_setup_1;
+use crate::test_loop::utils::transactions::{execute_tx, get_shared_block_hash, run_tx};
+use crate::test_loop::utils::TGAS;
+
+/// Generating receipts larger than the size limit should cause the transaction to fail.
+#[test]
+fn test_max_receipt_size() {
+    init_test_logger();
+    let mut env: TestLoopEnv = standard_setup_1();
+
+    let account0: AccountId = "account0".parse().unwrap();
+    let account0_signer = &create_user_test_signer(&account0).into();
+
+    // We can't test receipt limit by submitting large transactions because we hit the transaction size limit
+    // before hitting the receipt size limit.
+    let large_tx = SignedTransaction::deploy_contract(
+        100,
+        &account0,
+        vec![0u8; 2_000_000],
+        account0_signer,
+        get_shared_block_hash(&env.datas, &env.test_loop),
+    );
+    let large_tx_exec_res =
+        execute_tx(&mut env.test_loop, large_tx, &env.datas, Duration::seconds(5));
+    assert_matches!(large_tx_exec_res, Err(InvalidTxError::TransactionSizeExceeded { .. }));
+
+    // Let's test it by running a contract that generates a large receipt.
+    let deploy_contract_tx = SignedTransaction::deploy_contract(
+        101,
+        &account0,
+        near_test_contracts::rs_contract().into(),
+        &account0_signer,
+        get_shared_block_hash(&env.datas, &env.test_loop),
+    );
+    run_tx(&mut env.test_loop, deploy_contract_tx, &env.datas, Duration::seconds(5));
+
+    // Calling generate_large_receipt({"account_id": "account0", "method_name": "noop", "total_args_size": 3000000})
+    // will generate a receipt that has ~3_000_000 bytes. It'll be a single receipt with multiple FunctionCall actions.
+    // 3MB is still under the limit, so this should succeed.
+    let large_receipt_tx = SignedTransaction::call(
+        102,
+        account0.clone(),
+        account0.clone(),
+        &account0_signer,
+        0,
+        "generate_large_receipt".into(),
+        r#"{"account_id": "account0", "method_name": "noop", "total_args_size": 3000000}"#.into(),
+        300 * TGAS,
+        get_shared_block_hash(&env.datas, &env.test_loop),
+    );
+    run_tx(&mut env.test_loop, large_receipt_tx, &env.datas, Duration::seconds(5));
+
+    // Generating a receipt that is 5 MB should fail, it's above the receipt size limit.
+    let too_large_receipt_tx = SignedTransaction::call(
+        103,
+        account0.clone(),
+        account0.clone(),
+        &account0_signer,
+        0,
+        "generate_large_receipt".into(),
+        r#"{"account_id": "account0", "method_name": "noop", "total_args_size": 5000000}"#.into(),
+        300 * TGAS,
+        get_shared_block_hash(&env.datas, &env.test_loop),
+    );
+    let too_large_receipt_tx_exec_res =
+        execute_tx(&mut env.test_loop, too_large_receipt_tx, &env.datas, Duration::seconds(5))
+            .unwrap();
+
+    match too_large_receipt_tx_exec_res.status {
+        FinalExecutionStatus::Failure(TxExecutionError::ActionError(action_error)) => {
+            match action_error.kind {
+                ActionErrorKind::NewReceiptValidationError(
+                    ReceiptValidationError::ReceiptSizeExceeded { .. },
+                ) => {
+                    // Ok, got the expected error
+                }
+                _ => panic!("Expected ReceiptSizeExceeded error, got: {:?}", action_error),
+            }
+        }
+        _ => panic!(
+            "Expected FinalExecutionStatus::Failure, got: {:?}",
+            too_large_receipt_tx_exec_res
+        ),
+    };
+
+    // The runtime shouldn't die when it encounters a large receipt.
+    // Make sure that everything still works.
+
+    // Calling sum_n(5) should return 10.
+    // 1 + 2 + 3 + 4 = 10
+    let sum_4_tx = SignedTransaction::call(
+        104,
+        account0.clone(),
+        account0.clone(),
+        &account0_signer,
+        0,
+        "sum_n".into(),
+        5_u64.to_le_bytes().to_vec(),
+        300 * TGAS,
+        get_shared_block_hash(&env.datas, &env.test_loop),
+    );
+    let sum_4_res = run_tx(&mut env.test_loop, sum_4_tx, &env.datas, Duration::seconds(5));
+    assert_eq!(sum_4_res, 10u64.to_le_bytes().to_vec());
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
+}

--- a/integration-tests/src/test_loop/tests/mod.rs
+++ b/integration-tests/src/test_loop/tests/mod.rs
@@ -2,6 +2,7 @@ mod chunk_validator_kickout;
 pub mod congestion_control;
 pub mod congestion_control_genesis_bootstrap;
 pub mod in_memory_tries;
+pub mod max_receipt_size;
 pub mod multinode_stateless_validators;
 pub mod multinode_test_loop_example;
 pub mod simple_test_loop_example;

--- a/integration-tests/src/test_loop/utils/mod.rs
+++ b/integration-tests/src/test_loop/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod network;
+pub mod setups;
 pub mod transactions;
 pub mod view_client;
 

--- a/integration-tests/src/test_loop/utils/setups.rs
+++ b/integration-tests/src/test_loop/utils/setups.rs
@@ -1,0 +1,54 @@
+//! This file contains standard setups for test loop tests.
+//! Using TestLoopBuilder gives a lot of flexibility, but sometimes you just need some basic blockchain.
+
+use itertools::Itertools;
+use near_chain_configs::test_genesis::TestGenesisBuilder;
+use near_primitives::types::AccountId;
+
+use crate::test_loop::builder::TestLoopBuilder;
+use crate::test_loop::env::TestLoopEnv;
+use crate::test_loop::utils::ONE_NEAR;
+
+/// 2 producers, 2 validators, 1 rpc node, 4 shards, 20 accounts (account{i}) with 10k NEAR each.
+pub fn standard_setup_1() -> TestLoopEnv {
+    let num_clients = 5;
+    let num_producers = 2;
+    let num_validators = 2;
+    let num_rpc = 1;
+    let accounts =
+        (0..20).map(|i| format!("account{}", i).parse().unwrap()).collect::<Vec<AccountId>>();
+
+    let initial_balance = 10000 * ONE_NEAR;
+    let clients = accounts.iter().take(num_clients).cloned().collect_vec();
+
+    // split the clients into producers, validators, and rpc nodes
+    let tmp = clients.clone();
+    let (producers, tmp) = tmp.split_at(num_producers);
+    let (validators, tmp) = tmp.split_at(num_validators);
+    let (rpcs, tmp) = tmp.split_at(num_rpc);
+    assert!(tmp.is_empty());
+
+    let producers = producers.iter().map(|account| account.as_str()).collect_vec();
+    let validators = validators.iter().map(|account| account.as_str()).collect_vec();
+    let [_rpc_id] = rpcs else { panic!("Expected exactly one rpc node") };
+
+    let builder = TestLoopBuilder::new();
+    let mut genesis_builder = TestGenesisBuilder::new();
+    genesis_builder
+        .genesis_time_from_clock(&builder.clock())
+        .protocol_version_latest()
+        .genesis_height(10000)
+        .gas_prices_free()
+        .gas_limit_one_petagas()
+        .shard_layout_simple_v1(&["account3", "account5", "account7"])
+        .transaction_validity_period(1000)
+        .epoch_length(10)
+        .validators_desired_roles(&producers, &validators)
+        .shuffle_shard_assignment_for_chunk_producers(true);
+    for account in accounts {
+        genesis_builder.add_user_account_simple(account.clone(), initial_balance);
+    }
+    let genesis = genesis_builder.build();
+
+    builder.genesis(genesis).clients(clients).build()
+}

--- a/integration-tests/src/test_loop/utils/transactions.rs
+++ b/integration-tests/src/test_loop/utils/transactions.rs
@@ -123,7 +123,7 @@ pub fn deploy_contract(
         ProcessTxRequest { transaction: tx, is_forwarded: false, check_only: false };
 
     let rpc_node_data = get_node_data(node_datas, rpc_id);
-    let rpc_node_data_sender = &rpc_node_data.client_sender.clone();
+    let rpc_node_data_sender = &rpc_node_data.client_sender;
 
     let future = rpc_node_data_sender.send_async(process_tx_request);
     drop(future);
@@ -172,7 +172,7 @@ pub fn call_contract(
 
     let process_tx_request =
         ProcessTxRequest { transaction: tx, is_forwarded: false, check_only: false };
-    let future = node_datas[0].client_sender.clone().send_async(process_tx_request);
+    let future = node_datas[0].client_sender.send_async(process_tx_request);
     drop(future);
 
     tracing::debug!(target: "test", ?sender_id, ?contract_id, ?tx_hash, "called contract");
@@ -240,7 +240,7 @@ pub fn execute_tx(
     let process_result = Arc::new(Mutex::new(None));
     let process_result_clone = process_result.clone();
 
-    node_datas[rpc_node_id].client_sender.clone().send(MessageWithCallback {
+    node_datas[rpc_node_id].client_sender.send(MessageWithCallback {
         message: ProcessTxRequest { transaction: tx, is_forwarded: false, check_only: false },
         callback: Box::new(move |process_res| {
             *process_result_clone.lock().unwrap() = Some(process_res);

--- a/integration-tests/src/test_loop/utils/transactions.rs
+++ b/integration-tests/src/test_loop/utils/transactions.rs
@@ -1,15 +1,20 @@
 use crate::test_loop::env::TestData;
+use assert_matches::assert_matches;
 use itertools::Itertools;
-use near_async::messaging::SendAsync;
+use near_async::messaging::{CanSend, MessageWithCallback, SendAsync};
 use near_async::test_loop::TestLoopV2;
 use near_async::time::Duration;
 use near_client::test_utils::test_loop::ClientQueries;
+use near_client::ProcessTxResponse;
 use near_network::client::ProcessTxRequest;
+use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::test_utils::create_user_test_signer;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::AccountId;
+use near_primitives::views::{FinalExecutionOutcomeView, FinalExecutionStatus};
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 use super::{ONE_NEAR, TGAS};
 
@@ -200,4 +205,93 @@ pub fn get_node_data<'a>(node_datas: &'a [TestData], account_id: &AccountId) -> 
         }
     }
     panic!("RPC client not found");
+}
+
+/// Run a transaction until completion and assert that the result is "success".
+/// Returns the transaction result.
+pub fn run_tx(
+    test_loop: &mut TestLoopV2,
+    tx: SignedTransaction,
+    node_datas: &[TestData],
+    maximum_duration: Duration,
+) -> Vec<u8> {
+    let tx_res = execute_tx(test_loop, tx, node_datas, maximum_duration).unwrap();
+    assert_matches!(tx_res.status, FinalExecutionStatus::SuccessValue(_));
+    match tx_res.status {
+        FinalExecutionStatus::SuccessValue(res) => res,
+        _ => unreachable!(),
+    }
+}
+
+/// Submit a transaction and wait for the execution result.
+/// For invalid transactions returns an error.
+/// For valid transactions returns the execution result (which could have an execution error inside, check it!).
+pub fn execute_tx(
+    test_loop: &mut TestLoopV2,
+    tx: SignedTransaction,
+    node_datas: &[TestData],
+    maximum_duration: Duration,
+) -> Result<FinalExecutionOutcomeView, InvalidTxError> {
+    // Last node is usually the rpc node
+    let rpc_node_id = node_datas.len().checked_sub(1).unwrap();
+
+    let tx_hash = tx.get_hash();
+
+    let process_result = Arc::new(Mutex::new(None));
+    let process_result_clone = process_result.clone();
+
+    node_datas[rpc_node_id].client_sender.clone().send(MessageWithCallback {
+        message: ProcessTxRequest { transaction: tx, is_forwarded: false, check_only: false },
+        callback: Box::new(move |process_res| {
+            *process_result_clone.lock().unwrap() = Some(process_res);
+        }),
+    });
+
+    test_loop.run_until(
+        |tl_data| {
+            let mut processing_done = false;
+            if let Some(processing_outcome) = &*process_result.lock().unwrap() {
+                match processing_outcome.as_ref().unwrap() {
+                    ProcessTxResponse::NoResponse
+                    | ProcessTxResponse::RequestRouted
+                    | ProcessTxResponse::ValidTx => processing_done = true,
+                    ProcessTxResponse::InvalidTx(_err) => {
+                        // Invalid transaction, stop run_until immediately, there won't be a transaction result.
+                        return true;
+                    }
+                    ProcessTxResponse::DoesNotTrackShard => {
+                        panic!("Transaction submitted to a node that doesn't track the shard")
+                    }
+                }
+            }
+
+            let tx_result_available = tl_data
+                .get(&node_datas[rpc_node_id].client_sender.actor_handle())
+                .client
+                .chain
+                .get_final_transaction_result(&tx_hash)
+                .is_ok();
+
+            processing_done && tx_result_available
+        },
+        maximum_duration,
+    );
+
+    match process_result.lock().unwrap().take().unwrap().unwrap() {
+        ProcessTxResponse::NoResponse
+        | ProcessTxResponse::RequestRouted
+        | ProcessTxResponse::ValidTx => {}
+        ProcessTxResponse::InvalidTx(e) => return Err(e),
+        ProcessTxResponse::DoesNotTrackShard => {
+            panic!("Transaction submitted to a node that doesn't track the shard")
+        }
+    };
+
+    Ok(test_loop
+        .data
+        .get(&node_datas.last().unwrap().client_sender.actor_handle())
+        .client
+        .chain
+        .get_final_transaction_result(&tx_hash)
+        .unwrap())
 }

--- a/integration-tests/src/test_loop/utils/transactions.rs
+++ b/integration-tests/src/test_loop/utils/transactions.rs
@@ -180,7 +180,7 @@ pub fn call_contract(
 }
 
 /// Finds a block that all clients have on their chain and return its hash.
-fn get_shared_block_hash(node_datas: &[TestData], test_loop: &mut TestLoopV2) -> CryptoHash {
+pub fn get_shared_block_hash(node_datas: &[TestData], test_loop: &TestLoopV2) -> CryptoHash {
     let clients = node_datas
         .iter()
         .map(|data| &test_loop.data.get(&data.client_sender.actor_handle()).client)

--- a/integration-tests/src/tests/client/features/congestion_control.rs
+++ b/integration-tests/src/tests/client/features/congestion_control.rs
@@ -632,8 +632,8 @@ fn measure_tx_limit(
     let congestion_level = congestion_info.localized_congestion_level(&config);
     // congestion should be non-trivial and below the upper limit
     assert!(
-        incoming_congestion > upper_limit_congestion / 3.0,
-        "{incoming_congestion} > {upper_limit_congestion} / 3 failed, {congestion_info:?}"
+        incoming_congestion > upper_limit_congestion / 4.0,
+        "{incoming_congestion} > {upper_limit_congestion} / 4 failed, {congestion_info:?}"
     );
     assert!(
         congestion_level < upper_limit_congestion,

--- a/integration-tests/src/tests/runtime/test_evil_contracts.rs
+++ b/integration-tests/src/tests/runtime/test_evil_contracts.rs
@@ -105,11 +105,16 @@ fn test_self_delay() {
         )
         .unwrap();
     let expected_max_depth = 60u32;
-    assert_eq!(
-        res.status,
-        FinalExecutionStatus::SuccessValue(expected_max_depth.to_be_bytes().to_vec()),
-        "{res:?} has not recursed the expected number of times",
-    );
+    match res.status {
+        FinalExecutionStatus::SuccessValue(depth_bytes) => {
+            let depth = u32::from_be_bytes(depth_bytes.try_into().unwrap());
+            assert_eq!(
+                depth, expected_max_depth,
+                "The function has not recursed the expected number of times"
+            );
+        }
+        _ => panic!("Expected success, got: {:?}", res),
+    }
 }
 
 #[test]

--- a/integration-tests/src/tests/runtime/test_evil_contracts.rs
+++ b/integration-tests/src/tests/runtime/test_evil_contracts.rs
@@ -89,7 +89,7 @@ fn test_evil_deep_trie() {
 ///
 /// I hear that the protocol-level limit on the depth here is 64, so given the current fee
 /// structure this limit cannot be reached by this contract, but once they decrease it might very
-/// well be necessary to adjust the `expected_max_depth` to at most that limit.
+/// well be necessary to adjust the `expected_depth` to at most that limit.
 #[test]
 fn test_self_delay() {
     let node = setup_test_contract(near_test_contracts::rs_contract());
@@ -104,14 +104,19 @@ fn test_self_delay() {
             0,
         )
         .unwrap();
-    let expected_max_depth = 60u32;
+
+    // The exact expected depth varies depending on the set of enabled features.
+    // When test_features are enabled, the test contract becomes larger and the calls to it are more expensive.
+    // When nightly is enabled, the gas costs change a bit.
+    // The test makes sure that the depth is within the expected range, but it doesn't check an exact value
+    // to avoid having separate cases for every possible combination of features.
+    let min_expected_depth = 56;
+    let max_expected_depth = 62;
     match res.status {
         FinalExecutionStatus::SuccessValue(depth_bytes) => {
             let depth = u32::from_be_bytes(depth_bytes.try_into().unwrap());
-            assert_eq!(
-                depth, expected_max_depth,
-                "The function has not recursed the expected number of times"
-            );
+            assert!(depth >= min_expected_depth, "The function has recursed fewer times than expected: {depth} < {min_expected_depth}",);
+            assert!(depth <= max_expected_depth, "The function has recursed more times than expected: {depth} > {max_expected_depth}",);
         }
         _ => panic!("Expected success, got: {:?}", res),
     }

--- a/runtime/near-test-contracts/test-contract-rs/src/lib.rs
+++ b/runtime/near-test-contracts/test-contract-rs/src/lib.rs
@@ -1612,3 +1612,42 @@ pub unsafe fn sanity_check_panic_utf8() {
     let data = b"xyz";
     panic_utf8(data.len() as u64, data.as_ptr() as u64);
 }
+
+/// Generate a single large receipt that has many FunctionCall actions with large args.
+/// Accepts json parmeters:
+/// account_id - the account id to send the FunctionCall actions to.
+/// method_name - the method name to call in FunctionCalls.
+/// total_args_size - the total size of the arguments to send in the FunctionCalls.
+#[no_mangle]
+pub unsafe fn generate_large_receipt() {
+    input(0);
+    let data = vec![0u8; register_len(0) as usize];
+    read_register(0, data.as_ptr() as u64);
+    let input_args: serde_json::Value = serde_json::from_slice(&data).unwrap();
+    let account_id = input_args["account_id"].as_str().unwrap().as_bytes();
+    let method_name = input_args["method_name"].as_str().unwrap().as_bytes();
+    let mut total_size_to_send = input_args["total_args_size"].as_u64().unwrap();
+
+    // Up to 500 kB of arguments in a single function call.
+    let single_call_size = 500_000;
+
+    let promise_idx = promise_batch_create(account_id.len() as u64, account_id.as_ptr() as u64);
+    while total_size_to_send > 0 {
+        let args_size = std::cmp::min(total_size_to_send, single_call_size);
+        let args = vec![0u8; args_size as usize];
+        let amount = 0u128;
+        let gas_fixed = 0;
+        let gas_weight = 1;
+        promise_batch_action_function_call_weight(
+            promise_idx,
+            method_name.len() as u64,
+            method_name.as_ptr() as u64,
+            args_size,
+            args.as_ptr() as u64,
+            &amount as *const u128 as u64,
+            gas_fixed,
+            gas_weight,
+        );
+        total_size_to_send = total_size_to_send.checked_sub(args_size).unwrap();
+    }
+}

--- a/runtime/near-test-contracts/test-contract-rs/src/lib.rs
+++ b/runtime/near-test-contracts/test-contract-rs/src/lib.rs
@@ -1092,11 +1092,7 @@ pub unsafe fn call_yield_resume_read_data_id_from_storage() {
     read_register(0, payload.as_ptr() as u64);
 
     let data_id_key = 42u64.to_le_bytes().to_vec();
-    storage_read(
-        data_id_key.len() as u64,
-        data_id_key.as_ptr() as u64,
-        0
-    );
+    storage_read(data_id_key.len() as u64, data_id_key.as_ptr() as u64, 0);
     let data_id = vec![0u8; register_len(0) as usize];
     read_register(0, data_id.as_ptr() as u64);
 


### PR DESCRIPTION
Test the `max_receipt_size` limit added in 8f8a73b6e5184e2e8773c9b6ac641d85e0fd5f8c using TestLoop.

Receipts larger than `4_194_304` bytes should be rejected.

We can't easily generate a 4MB receipt because the transaction size limit is 1.5MB. To deal with this I generate the receipt from within a contract. The contract creates a single receipt with multiple `FunctionCall` actions, each of which has a lot of data in the `args`. All those actions sum up to more than 4MB and the receipt size limit is hit.
The transaction fails properly and the runtime doesn't die when it encounters an invalid receipt.

I had to add the functionality to execute a transaction and wait for the result. I implemented something similar to the old `TestEnv::execute_tx` function.

I also added a "default setup" utility function which generates a basic `TestLoop` setup. This allows to get a test going in 1 line instead of 30.