### PR TITLE
fix: always garbage collect state transition data

### DIFF
--- a/chain/chain/src/stateless_validation/state_transition_data.rs
+++ b/chain/chain/src/stateless_validation/state_transition_data.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 
 use near_chain_primitives::error::Error;
 use near_primitives::block::Block;
-use near_primitives::checked_feature;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::{BlockHeight, ShardId};
 use near_primitives::utils::{get_block_shard_id, get_block_shard_id_rev};
@@ -18,21 +17,15 @@ type StateTransitionStartHeights = HashMap<ShardId, BlockHeight>;
 
 impl Chain {
     pub(crate) fn garbage_collect_state_transition_data(&self, block: &Block) -> Result<(), Error> {
-        let protocol_version =
-            self.epoch_manager.get_epoch_protocol_version(block.header().epoch_id())?;
-        if cfg!(feature = "shadow_chunk_validation")
-            || checked_feature!("stable", StatelessValidation, protocol_version)
-        {
-            let chain_store = self.chain_store();
-            let final_block_hash = *block.header().last_final_block();
-            if final_block_hash == CryptoHash::default() {
-                return Ok(());
-            }
-            let final_block = chain_store.get_block(&final_block_hash)?;
-            let final_block_chunk_created_heights =
-                final_block.chunks().iter().map(|chunk| chunk.height_created()).collect::<Vec<_>>();
-            clear_before_last_final_block(chain_store, &final_block_chunk_created_heights)?;
+        let chain_store = self.chain_store();
+        let final_block_hash = *block.header().last_final_block();
+        if final_block_hash == CryptoHash::default() {
+            return Ok(());
         }
+        let final_block = chain_store.get_block(&final_block_hash)?;
+        let final_block_chunk_created_heights =
+            final_block.chunks().iter().map(|chunk| chunk.height_created()).collect::<Vec<_>>();
+        clear_before_last_final_block(chain_store, &final_block_chunk_created_heights)?;
         Ok(())
     }
 }


### PR DESCRIPTION
We noticed that the first block of the epoch where stateless validation gets enabled takes a lot of time (~30 seconds). @robin-near  [pinpointed](https://near.zulipchat.com/#narrow/stream/308695-nearone.2Fprivate/topic/Slow.20first.20block.20in.20protocol.20v69/near/454062961) `garbage_collect_state_transition_data` to be the cause. In particular it is caused by `compute_start_heights`. The expectation was that it will read only a few entries from `StateTransitionData` column on the first run to initialise `StateTransitionStartHeights`. The issue is that currently it is only triggered when stateless validation is already enabled with `checked_feature!("stable", StatelessValidation, protocol_version)` check. But we start saving state transition data one epoch before that, see [`should_produce_state_witness_for_this_or_next_epoch`](https://github.com/near/nearcore/blob/6a6483373554327d941d0731dbd19d2c80ec1a3d/chain/chain/src/chain.rs#L3518). So `compute_start_heights` has to read `StateTransitionData` for the whole epoch.
This PR fixes the issue by removing the protocol version check to always garbage collect state transition data. This is also valid if don't have any state transition data instances in the db: start height [is initialised to the last final block height](https://github.com/near/nearcore/blob/6a6483373554327d941d0731dbd19d2c80ec1a3d/chain/chain/src/stateless_validation/state_transition_data.rs#L70) in that case.