### PR TITLE
[stateless_validation] Versioned chunk endorsement

### DIFF
--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -32,7 +32,7 @@ use near_primitives::shard_layout;
 use near_primitives::shard_layout::{ShardLayout, ShardUId};
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
 use near_primitives::state_part::PartId;
-use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
+use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsementV1;
 use near_primitives::stateless_validation::partial_witness::PartialEncodedStateWitness;
 use near_primitives::stateless_validation::validator_assignment::ChunkValidatorAssignments;
 use near_primitives::transaction::{
@@ -945,7 +945,7 @@ impl EpochManagerAdapter for MockEpochManager {
     fn verify_chunk_endorsement(
         &self,
         _chunk_header: &ShardChunkHeader,
-        _endorsement: &ChunkEndorsement,
+        _endorsement: &ChunkEndorsementV1,
     ) -> Result<bool, Error> {
         Ok(true)
     }

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -32,7 +32,7 @@ fn build_chain() {
     //     cargo insta test --accept -p near-chain --features nightly -- tests::simple_chain::build_chain
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
-        insta::assert_snapshot!(hash, @"C3zeKRZubVungxfrSdq379TSCYnuz2YzjEkcJTdm3pU4");
+        insta::assert_snapshot!(hash, @"H9qfaTFJ7jFMEmJX9eYQ3kJQ6vwATAhidfbjwa9PvCPK");
     } else {
         insta::assert_snapshot!(hash, @"EeGa9BFTyrPoM56iZBteXZfhq86g4k1tjMCPprqYyfKF");
     }
@@ -50,7 +50,7 @@ fn build_chain() {
 
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
-        insta::assert_snapshot!(hash, @"EjLaoHRiAdRp2NcDqwbMcAYYxGfcv5R7GuYUNfRpaJvB");
+        insta::assert_snapshot!(hash, @"HPRdNbp8dJL2JA5bRSmLg6GJpGXx6xmw472vVAWLpXhi");
     } else {
         insta::assert_snapshot!(hash, @"Em7E1W5xPMTToyiGbRAES2iAKJQDsZ5m8ymvy4S7adxu");
     }

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -16,7 +16,9 @@ use near_epoch_manager::EpochManagerAdapter;
 use near_network::types::{NetworkRequests, PeerManagerMessageRequest};
 use near_o11y::log_assert;
 use near_primitives::sharding::ShardChunkHeader;
-use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
+use near_primitives::stateless_validation::chunk_endorsement::{
+    ChunkEndorsement, ChunkEndorsementV1,
+};
 use near_primitives::stateless_validation::state_witness::{
     ChunkStateWitness, ChunkStateWitnessAck, ChunkStateWitnessSize,
 };
@@ -227,7 +229,7 @@ pub(crate) fn send_chunk_endorsement_to_block_producers(
         "send_chunk_endorsement",
     );
 
-    let endorsement = ChunkEndorsement::new(chunk_header.chunk_hash(), signer);
+    let endorsement = ChunkEndorsementV1::new(chunk_header.chunk_hash(), signer);
     for block_producer in block_producers {
         if signer.validator_id() == &block_producer {
             // Our own endorsements are not always valid (see issue #11750).
@@ -242,7 +244,10 @@ pub(crate) fn send_chunk_endorsement_to_block_producers(
             }
         } else {
             network_sender.send(PeerManagerMessageRequest::NetworkRequests(
-                NetworkRequests::ChunkEndorsement(block_producer, endorsement.clone()),
+                NetworkRequests::ChunkEndorsement(
+                    block_producer,
+                    ChunkEndorsement::V1(endorsement.clone()),
+                ),
             ));
         }
     }

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -16,7 +16,9 @@ use near_epoch_manager::EpochManagerAdapter;
 use near_network::types::{NetworkRequests, PeerManagerMessageRequest};
 use near_o11y::log_assert;
 use near_primitives::sharding::ShardChunkHeader;
-use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
+use near_primitives::stateless_validation::chunk_endorsement::{
+    ChunkEndorsement, ChunkEndorsementV1,
+};
 use near_primitives::stateless_validation::state_witness::{
     ChunkStateWitness, ChunkStateWitnessAck, ChunkStateWitnessSize,
 };
@@ -227,12 +229,12 @@ pub(crate) fn send_chunk_endorsement_to_block_producers(
         "send_chunk_endorsement",
     );
 
-    let endorsement = ChunkEndorsement::new_v1(chunk_header.chunk_hash(), signer);
+    let endorsement = ChunkEndorsementV1::new(chunk_header.chunk_hash(), signer);
     for block_producer in block_producers {
         if signer.validator_id() == &block_producer {
             // Our own endorsements are not always valid (see issue #11750).
             if let Err(err) = chunk_endorsement_tracker
-                .process_chunk_endorsement(chunk_header, endorsement.clone())
+                .process_chunk_endorsement(endorsement.clone(), Some(chunk_header.clone()))
             {
                 tracing::warn!(
                     target: "client",

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -16,9 +16,7 @@ use near_epoch_manager::EpochManagerAdapter;
 use near_network::types::{NetworkRequests, PeerManagerMessageRequest};
 use near_o11y::log_assert;
 use near_primitives::sharding::ShardChunkHeader;
-use near_primitives::stateless_validation::chunk_endorsement::{
-    ChunkEndorsement, ChunkEndorsementV1,
-};
+use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
 use near_primitives::stateless_validation::state_witness::{
     ChunkStateWitness, ChunkStateWitnessAck, ChunkStateWitnessSize,
 };
@@ -229,7 +227,7 @@ pub(crate) fn send_chunk_endorsement_to_block_producers(
         "send_chunk_endorsement",
     );
 
-    let endorsement = ChunkEndorsementV1::new(chunk_header.chunk_hash(), signer);
+    let endorsement = ChunkEndorsement::new_v1(chunk_header.chunk_hash(), signer);
     for block_producer in block_producers {
         if signer.validator_id() == &block_producer {
             // Our own endorsements are not always valid (see issue #11750).

--- a/chain/client/src/test_utils/client.rs
+++ b/chain/client/src/test_utils/client.rs
@@ -258,7 +258,7 @@ pub fn create_chunk(
         next_height,
         last_block.header().block_ordinal() + 1,
         vec![chunk.cloned_header()],
-        vec![vec![Some(Box::new(endorsement.signature))]],
+        vec![vec![Some(Box::new(endorsement.signature()))]],
         *last_block.header().epoch_id(),
         *last_block.header().next_epoch_id(),
         None,

--- a/chain/client/src/test_utils/client.rs
+++ b/chain/client/src/test_utils/client.rs
@@ -21,7 +21,7 @@ use near_primitives::block::Block;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{merklize, PartialMerkleTree};
 use near_primitives::sharding::{EncodedShardChunk, ShardChunk};
-use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
+use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsementV1;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{BlockHeight, ShardId};
 use near_primitives::utils::MaybeValidated;
@@ -249,7 +249,7 @@ pub fn create_chunk(
     let mut block_merkle_tree = PartialMerkleTree::clone(&block_merkle_tree);
 
     let signer = client.validator_signer.get().unwrap();
-    let endorsement = ChunkEndorsement::new(chunk.cloned_header().chunk_hash(), signer.as_ref());
+    let endorsement = ChunkEndorsementV1::new(chunk.cloned_header().chunk_hash(), signer.as_ref());
     block_merkle_tree.insert(*last_block.hash());
     let block = Block::produce(
         PROTOCOL_VERSION,
@@ -258,7 +258,7 @@ pub fn create_chunk(
         next_height,
         last_block.header().block_ordinal() + 1,
         vec![chunk.cloned_header()],
-        vec![vec![Some(Box::new(endorsement.signature()))]],
+        vec![vec![Some(Box::new(endorsement.signature))]],
         *last_block.header().epoch_id(),
         *last_block.header().next_epoch_id(),
         None,

--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -27,7 +27,9 @@ use near_primitives::epoch_manager::RngSeed;
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::{ChunkHash, PartialEncodedChunk};
-use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
+use near_primitives::stateless_validation::chunk_endorsement::{
+    ChunkEndorsement, ChunkEndorsementV1,
+};
 use near_primitives::stateless_validation::state_witness::ChunkStateWitness;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::transaction::{Action, FunctionCallAction, SignedTransaction};
@@ -432,11 +434,13 @@ impl TestEnv {
     /// Wait until an endorsement for `chunk_hash` appears in the network messages send by
     /// the Client with index `client_idx`. Times out after CHUNK_ENDORSEMENTS_TIMEOUT.
     /// Doesn't process or consume the message, it just waits until the message appears on the network_adapter.
+    /// TODO(ChunkEndorsementV2): This function is only used by orphan_chunk_state_witnesses test.
+    /// Can remove once we shift to ChunkEndorsementV2.
     pub fn wait_for_chunk_endorsement(
         &mut self,
         client_idx: usize,
         chunk_hash: &ChunkHash,
-    ) -> Result<ChunkEndorsement, TimeoutError> {
+    ) -> Result<ChunkEndorsementV1, TimeoutError> {
         let start_time = Instant::now();
         let network_adapter = self.network_adapters[client_idx].clone();
         loop {
@@ -445,8 +449,13 @@ impl TestEnv {
                 match &request {
                     PeerManagerMessageRequest::NetworkRequests(
                         NetworkRequests::ChunkEndorsement(_receiver_account_id, endorsement),
-                    ) if endorsement.chunk_hash() == chunk_hash => {
-                        endorsement_opt = Some(endorsement.clone());
+                    ) => {
+                        let endorsement = match endorsement {
+                            ChunkEndorsement::V1(endorsement) => endorsement,
+                        };
+                        if endorsement.chunk_hash() == chunk_hash {
+                            endorsement_opt = Some(endorsement.clone());
+                        }
                     }
                     _ => {}
                 };

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -13,7 +13,7 @@ use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::{account_id_to_shard_id, ShardLayout, ShardLayoutError};
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
-use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
+use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsementV1;
 use near_primitives::stateless_validation::partial_witness::PartialEncodedStateWitness;
 use near_primitives::stateless_validation::validator_assignment::ChunkValidatorAssignments;
 use near_primitives::types::validator_stake::ValidatorStake;
@@ -418,7 +418,7 @@ pub trait EpochManagerAdapter: Send + Sync {
     fn verify_chunk_endorsement(
         &self,
         chunk_header: &ShardChunkHeader,
-        endorsement: &ChunkEndorsement,
+        endorsement: &ChunkEndorsementV1,
     ) -> Result<bool, Error>;
 
     fn verify_partial_witness_signature(
@@ -1049,7 +1049,7 @@ impl EpochManagerAdapter for EpochManagerHandle {
     fn verify_chunk_endorsement(
         &self,
         chunk_header: &ShardChunkHeader,
-        endorsement: &ChunkEndorsement,
+        endorsement: &ChunkEndorsementV1,
     ) -> Result<bool, Error> {
         if &chunk_header.chunk_hash() != endorsement.chunk_hash() {
             return Err(Error::InvalidChunkEndorsement);

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -19,7 +19,7 @@ use near_primitives::epoch_manager::EpochConfig;
 use near_primitives::hash::hash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::{ShardChunkHeader, ShardChunkHeaderV3};
-use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
+use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsementV1;
 use near_primitives::stateless_validation::partial_witness::PartialEncodedStateWitness;
 use near_primitives::types::ValidatorKickoutReason::{
     NotEnoughBlocks, NotEnoughChunkEndorsements, NotEnoughChunks,
@@ -2826,7 +2826,7 @@ fn test_verify_chunk_endorsements() {
     let chunk_header = test_chunk_header(&h, signer.as_ref());
 
     // check chunk endorsement validity
-    let mut chunk_endorsement = ChunkEndorsement::new(chunk_header.chunk_hash(), signer.as_ref());
+    let mut chunk_endorsement = ChunkEndorsementV1::new(chunk_header.chunk_hash(), signer.as_ref());
     assert!(epoch_manager.verify_chunk_endorsement(&chunk_header, &chunk_endorsement).unwrap());
 
     // check invalid chunk endorsement signature
@@ -2834,7 +2834,7 @@ fn test_verify_chunk_endorsements() {
     assert!(!epoch_manager.verify_chunk_endorsement(&chunk_header, &chunk_endorsement).unwrap());
 
     // check chunk endorsement invalidity when chunk header and chunk endorsement don't match
-    let chunk_endorsement = ChunkEndorsement::new(h[3].into(), signer.as_ref());
+    let chunk_endorsement = ChunkEndorsementV1::new(h[3].into(), signer.as_ref());
     let err =
         epoch_manager.verify_chunk_endorsement(&chunk_header, &chunk_endorsement).unwrap_err();
     match err {
@@ -2844,7 +2844,7 @@ fn test_verify_chunk_endorsements() {
 
     // check chunk endorsement invalidity when signer is not chunk validator
     let bad_signer = Arc::new(create_test_signer("test2"));
-    let chunk_endorsement = ChunkEndorsement::new(chunk_header.chunk_hash(), bad_signer.as_ref());
+    let chunk_endorsement = ChunkEndorsementV1::new(chunk_header.chunk_hash(), bad_signer.as_ref());
     let err =
         epoch_manager.verify_chunk_endorsement(&chunk_header, &chunk_endorsement).unwrap_err();
     match err {

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -19,7 +19,7 @@ use near_primitives::epoch_manager::EpochConfig;
 use near_primitives::hash::hash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::{ShardChunkHeader, ShardChunkHeaderV3};
-use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsementV1;
+use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
 use near_primitives::stateless_validation::partial_witness::PartialEncodedStateWitness;
 use near_primitives::types::ValidatorKickoutReason::{
     NotEnoughBlocks, NotEnoughChunkEndorsements, NotEnoughChunks,
@@ -2826,7 +2826,8 @@ fn test_verify_chunk_endorsements() {
     let chunk_header = test_chunk_header(&h, signer.as_ref());
 
     // check chunk endorsement validity
-    let mut chunk_endorsement = ChunkEndorsementV1::new(chunk_header.chunk_hash(), signer.as_ref());
+    let mut chunk_endorsement =
+        ChunkEndorsement::new_v1(chunk_header.chunk_hash(), signer.as_ref());
     assert!(epoch_manager.verify_chunk_endorsement(&chunk_header, &chunk_endorsement).unwrap());
 
     // check invalid chunk endorsement signature
@@ -2834,7 +2835,7 @@ fn test_verify_chunk_endorsements() {
     assert!(!epoch_manager.verify_chunk_endorsement(&chunk_header, &chunk_endorsement).unwrap());
 
     // check chunk endorsement invalidity when chunk header and chunk endorsement don't match
-    let chunk_endorsement = ChunkEndorsementV1::new(h[3].into(), signer.as_ref());
+    let chunk_endorsement = ChunkEndorsement::new_v1(h[3].into(), signer.as_ref());
     let err =
         epoch_manager.verify_chunk_endorsement(&chunk_header, &chunk_endorsement).unwrap_err();
     match err {
@@ -2844,7 +2845,8 @@ fn test_verify_chunk_endorsements() {
 
     // check chunk endorsement invalidity when signer is not chunk validator
     let bad_signer = Arc::new(create_test_signer("test2"));
-    let chunk_endorsement = ChunkEndorsementV1::new(chunk_header.chunk_hash(), bad_signer.as_ref());
+    let chunk_endorsement =
+        ChunkEndorsement::new_v1(chunk_header.chunk_hash(), bad_signer.as_ref());
     let err =
         epoch_manager.verify_chunk_endorsement(&chunk_header, &chunk_endorsement).unwrap_err();
     match err {

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -19,7 +19,7 @@ use near_primitives::epoch_manager::EpochConfig;
 use near_primitives::hash::hash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::{ShardChunkHeader, ShardChunkHeaderV3};
-use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
+use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsementV1;
 use near_primitives::stateless_validation::partial_witness::PartialEncodedStateWitness;
 use near_primitives::types::ValidatorKickoutReason::{
     NotEnoughBlocks, NotEnoughChunkEndorsements, NotEnoughChunks,
@@ -2826,8 +2826,7 @@ fn test_verify_chunk_endorsements() {
     let chunk_header = test_chunk_header(&h, signer.as_ref());
 
     // check chunk endorsement validity
-    let mut chunk_endorsement =
-        ChunkEndorsement::new_v1(chunk_header.chunk_hash(), signer.as_ref());
+    let mut chunk_endorsement = ChunkEndorsementV1::new(chunk_header.chunk_hash(), signer.as_ref());
     assert!(epoch_manager.verify_chunk_endorsement(&chunk_header, &chunk_endorsement).unwrap());
 
     // check invalid chunk endorsement signature
@@ -2835,7 +2834,7 @@ fn test_verify_chunk_endorsements() {
     assert!(!epoch_manager.verify_chunk_endorsement(&chunk_header, &chunk_endorsement).unwrap());
 
     // check chunk endorsement invalidity when chunk header and chunk endorsement don't match
-    let chunk_endorsement = ChunkEndorsement::new_v1(h[3].into(), signer.as_ref());
+    let chunk_endorsement = ChunkEndorsementV1::new(h[3].into(), signer.as_ref());
     let err =
         epoch_manager.verify_chunk_endorsement(&chunk_header, &chunk_endorsement).unwrap_err();
     match err {
@@ -2845,8 +2844,7 @@ fn test_verify_chunk_endorsements() {
 
     // check chunk endorsement invalidity when signer is not chunk validator
     let bad_signer = Arc::new(create_test_signer("test2"));
-    let chunk_endorsement =
-        ChunkEndorsement::new_v1(chunk_header.chunk_hash(), bad_signer.as_ref());
+    let chunk_endorsement = ChunkEndorsementV1::new(chunk_header.chunk_hash(), bad_signer.as_ref());
     let err =
         epoch_manager.verify_chunk_endorsement(&chunk_header, &chunk_endorsement).unwrap_err();
     match err {

--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -8,6 +8,7 @@ mod proto_conv;
 mod state_sync;
 pub use edge::*;
 use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
+use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsementV1;
 use near_primitives::stateless_validation::partial_witness::PartialEncodedStateWitness;
 use near_primitives::stateless_validation::state_witness::ChunkStateWitnessAck;
 pub use peer::*;
@@ -531,10 +532,12 @@ pub enum RoutedMessageBody {
     _UnusedVersionedStateResponse,
     PartialEncodedChunkForward(PartialEncodedChunkForwardMsg),
     _UnusedChunkStateWitness,
-    ChunkEndorsement(ChunkEndorsement),
+    /// TODO(ChunkEndorsementV2): Deprecate once we move to VersionedChunkEndorsement
+    ChunkEndorsement(ChunkEndorsementV1),
     ChunkStateWitnessAck(ChunkStateWitnessAck),
     PartialEncodedStateWitness(PartialEncodedStateWitness),
     PartialEncodedStateWitnessForward(PartialEncodedStateWitness),
+    VersionedChunkEndorsement(ChunkEndorsement),
 }
 
 impl RoutedMessageBody {
@@ -606,6 +609,9 @@ impl fmt::Debug for RoutedMessageBody {
             }
             RoutedMessageBody::PartialEncodedStateWitnessForward(_) => {
                 write!(f, "PartialEncodedStateWitnessForward")
+            }
+            RoutedMessageBody::VersionedChunkEndorsement(_) => {
+                write!(f, "VersionedChunkEndorsement")
             }
         }
     }

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -45,6 +45,7 @@ use near_o11y::{handler_debug_span, log_assert, WithSpanContext};
 use near_performance_metrics_macros::perf;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
+use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
 use near_primitives::types::EpochId;
 use near_primitives::utils::DisplayOption;
 use near_primitives::version::{
@@ -1028,6 +1029,7 @@ impl PeerActor {
                 None
             }
             RoutedMessageBody::ChunkEndorsement(endorsement) => {
+                let endorsement = ChunkEndorsement::V1(endorsement);
                 network_state.client.send_async(ChunkEndorsementMessage(endorsement)).await.ok();
                 None
             }
@@ -1041,6 +1043,10 @@ impl PeerActor {
                 network_state
                     .partial_witness_adapter
                     .send(PartialEncodedStateWitnessForwardMessage(witness));
+                None
+            }
+            RoutedMessageBody::VersionedChunkEndorsement(endorsement) => {
+                network_state.client.send_async(ChunkEndorsementMessage(endorsement)).await.ok();
                 None
             }
             body => {

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -985,7 +985,6 @@ impl PeerManagerActor {
                     ChunkEndorsement::V1(endorsement) => {
                         RoutedMessageBody::ChunkEndorsement(endorsement)
                     }
-                    _ => RoutedMessageBody::VersionedChunkEndorsement(endorsement),
                 };
                 self.state.send_message_to_account(&self.clock, &target, msg);
                 NetworkResponses::NoResponse

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -30,6 +30,7 @@ use near_o11y::{handler_debug_span, handler_trace_span, WithSpanContext};
 use near_performance_metrics_macros::perf;
 use near_primitives::block::GenesisId;
 use near_primitives::network::{AnnounceAccount, PeerId};
+use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
 use near_primitives::views::{
     ConnectionInfoView, EdgeView, KnownPeerStateView, NetworkGraphView, PeerStoreView,
     RecentOutboundConnectionsView, SnapshotHostInfoView, SnapshotHostsView,
@@ -980,11 +981,13 @@ impl PeerManagerActor {
                 NetworkResponses::NoResponse
             }
             NetworkRequests::ChunkEndorsement(target, endorsement) => {
-                self.state.send_message_to_account(
-                    &self.clock,
-                    &target,
-                    RoutedMessageBody::ChunkEndorsement(endorsement),
-                );
+                let msg = match endorsement {
+                    ChunkEndorsement::V1(endorsement) => {
+                        RoutedMessageBody::ChunkEndorsement(endorsement)
+                    }
+                    _ => RoutedMessageBody::VersionedChunkEndorsement(endorsement),
+                };
+                self.state.send_message_to_account(&self.clock, &target, msg);
                 NetworkResponses::NoResponse
             }
             NetworkRequests::PartialEncodedStateWitness(validator_witness_tuple) => {

--- a/chain/network/src/rate_limits/messages_limits.rs
+++ b/chain/network/src/rate_limits/messages_limits.rs
@@ -217,6 +217,7 @@ fn get_key_and_token_cost(message: &PeerMessage) -> Option<(RateLimitedPeerMessa
             RoutedMessageBody::PartialEncodedStateWitnessForward(_) => {
                 Some((PartialEncodedStateWitnessForward, 1))
             }
+            RoutedMessageBody::VersionedChunkEndorsement(_) => Some((ChunkEndorsement, 1)),
             RoutedMessageBody::Ping(_)
             | RoutedMessageBody::Pong(_)
             | RoutedMessageBody::_UnusedChunkStateWitness

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -157,6 +157,9 @@ pub enum ProtocolFeature {
     CongestionControl,
     /// Remove account with long storage key.
     RemoveAccountWithLongStorageKey,
+    /// Change the structure of ChunkEndorsement to have (shard_id, epoch_id, height_created)
+    /// instead of chunk_hash
+    ChunkEndorsementV2,
 }
 
 impl ProtocolFeature {
@@ -228,6 +231,7 @@ impl ProtocolFeature {
             // TODO(#11201): When stabilizing this feature in mainnet, also remove the temporary code
             // that always enables this for mocknet (see config_mocknet function).
             ProtocolFeature::ShuffleShardAssignments => 143,
+            ProtocolFeature::ChunkEndorsementV2 => 144,
         }
     }
 

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -252,7 +252,7 @@ pub const PROTOCOL_VERSION: ProtocolVersion = if cfg!(feature = "statelessnet_pr
     82
 } else if cfg!(feature = "nightly_protocol") {
     // On nightly, pick big enough version to support all features.
-    143
+    144
 } else {
     // Enable all stable features.
     STABLE_PROTOCOL_VERSION

--- a/core/primitives/src/stateless_validation/chunk_endorsement.rs
+++ b/core/primitives/src/stateless_validation/chunk_endorsement.rs
@@ -17,14 +17,13 @@ pub enum ChunkEndorsement {
 
 impl ChunkEndorsement {
     pub fn new(chunk_hash: ChunkHash, signer: &ValidatorSigner) -> ChunkEndorsement {
-        ChunkEndorsement::V1(Self::new_v1(chunk_hash, signer))
+        ChunkEndorsement::V1(ChunkEndorsementV1::new(chunk_hash, signer))
     }
 
-    pub fn new_v1(chunk_hash: ChunkHash, signer: &ValidatorSigner) -> ChunkEndorsementV1 {
-        let inner = ChunkEndorsementInner::new(chunk_hash);
-        let account_id = signer.validator_id().clone();
-        let signature = signer.sign_chunk_endorsement(&inner);
-        ChunkEndorsementV1 { inner, account_id, signature }
+    pub fn chunk_hash(&self) -> &ChunkHash {
+        match self {
+            ChunkEndorsement::V1(endorsement) => endorsement.chunk_hash(),
+        }
     }
 
     pub fn signature(&self) -> Signature {
@@ -52,6 +51,13 @@ pub struct ChunkEndorsementV1 {
 }
 
 impl ChunkEndorsementV1 {
+    pub fn new(chunk_hash: ChunkHash, signer: &ValidatorSigner) -> ChunkEndorsementV1 {
+        let inner = ChunkEndorsementInner::new(chunk_hash);
+        let account_id = signer.validator_id().clone();
+        let signature = signer.sign_chunk_endorsement(&inner);
+        ChunkEndorsementV1 { inner, account_id, signature }
+    }
+
     pub fn verify(&self, public_key: &PublicKey) -> bool {
         let data = borsh::to_vec(&self.inner).unwrap();
         self.signature.verify(&data, public_key)

--- a/core/primitives/src/stateless_validation/chunk_endorsement.rs
+++ b/core/primitives/src/stateless_validation/chunk_endorsement.rs
@@ -35,7 +35,6 @@ impl ChunkEndorsement {
     pub fn serialized_inner(&self) -> Vec<u8> {
         match self {
             ChunkEndorsement::V1(endorsement) => borsh::to_vec(&endorsement.inner).unwrap(),
-            ChunkEndorsement::V2(endorsement) => borsh::to_vec(&endorsement.inner).unwrap(),
         }
     }
 

--- a/core/primitives/src/validator_signer.rs
+++ b/core/primitives/src/validator_signer.rs
@@ -9,7 +9,7 @@ use crate::challenge::ChallengeBody;
 use crate::hash::CryptoHash;
 use crate::network::{AnnounceAccount, PeerId};
 use crate::sharding::ChunkHash;
-use crate::stateless_validation::chunk_endorsement::ChunkEndorsementInner;
+use crate::stateless_validation::chunk_endorsement::ChunkEndorsementV1Inner;
 use crate::stateless_validation::partial_witness::PartialEncodedStateWitnessInner;
 use crate::stateless_validation::state_witness::EncodedChunkStateWitness;
 use crate::telemetry::TelemetryInfo;
@@ -84,7 +84,7 @@ impl ValidatorSigner {
     }
 
     /// Signs chunk endorsement to be sent to block producer.
-    pub fn sign_chunk_endorsement(&self, inner: &ChunkEndorsementInner) -> Signature {
+    pub fn sign_chunk_endorsement(&self, inner: &ChunkEndorsementV1Inner) -> Signature {
         match self {
             ValidatorSigner::Empty(signer) => signer.sign_chunk_endorsement(inner),
             ValidatorSigner::InMemory(signer) => signer.sign_chunk_endorsement(inner),
@@ -227,7 +227,7 @@ impl EmptyValidatorSigner {
         Signature::default()
     }
 
-    fn sign_chunk_endorsement(&self, _inner: &ChunkEndorsementInner) -> Signature {
+    fn sign_chunk_endorsement(&self, _inner: &ChunkEndorsementV1Inner) -> Signature {
         Signature::default()
     }
 
@@ -324,7 +324,7 @@ impl InMemoryValidatorSigner {
         self.signer.sign(&Approval::get_data_for_sig(inner, target_height))
     }
 
-    fn sign_chunk_endorsement(&self, inner: &ChunkEndorsementInner) -> Signature {
+    fn sign_chunk_endorsement(&self, inner: &ChunkEndorsementV1Inner) -> Signature {
         self.signer.sign(&borsh::to_vec(inner).unwrap())
     }
 

--- a/core/primitives/src/validator_signer.rs
+++ b/core/primitives/src/validator_signer.rs
@@ -9,7 +9,7 @@ use crate::challenge::ChallengeBody;
 use crate::hash::CryptoHash;
 use crate::network::{AnnounceAccount, PeerId};
 use crate::sharding::ChunkHash;
-use crate::stateless_validation::chunk_endorsement::ChunkEndorsementV1Inner;
+use crate::stateless_validation::chunk_endorsement::ChunkEndorsement;
 use crate::stateless_validation::partial_witness::PartialEncodedStateWitnessInner;
 use crate::stateless_validation::state_witness::EncodedChunkStateWitness;
 use crate::telemetry::TelemetryInfo;
@@ -84,10 +84,10 @@ impl ValidatorSigner {
     }
 
     /// Signs chunk endorsement to be sent to block producer.
-    pub fn sign_chunk_endorsement(&self, inner: &ChunkEndorsementV1Inner) -> Signature {
+    pub fn sign_chunk_endorsement(&self, endorsement: &ChunkEndorsement) -> Signature {
         match self {
-            ValidatorSigner::Empty(signer) => signer.sign_chunk_endorsement(inner),
-            ValidatorSigner::InMemory(signer) => signer.sign_chunk_endorsement(inner),
+            ValidatorSigner::Empty(signer) => signer.sign_chunk_endorsement(endorsement),
+            ValidatorSigner::InMemory(signer) => signer.sign_chunk_endorsement(endorsement),
         }
     }
 
@@ -227,7 +227,7 @@ impl EmptyValidatorSigner {
         Signature::default()
     }
 
-    fn sign_chunk_endorsement(&self, _inner: &ChunkEndorsementV1Inner) -> Signature {
+    fn sign_chunk_endorsement(&self, _endorsement: &ChunkEndorsement) -> Signature {
         Signature::default()
     }
 
@@ -324,8 +324,8 @@ impl InMemoryValidatorSigner {
         self.signer.sign(&Approval::get_data_for_sig(inner, target_height))
     }
 
-    fn sign_chunk_endorsement(&self, inner: &ChunkEndorsementV1Inner) -> Signature {
-        self.signer.sign(&borsh::to_vec(inner).unwrap())
+    fn sign_chunk_endorsement(&self, endorsement: &ChunkEndorsement) -> Signature {
+        self.signer.sign(&endorsement.serialized_inner())
     }
 
     fn sign_chunk_state_witness(&self, witness_bytes: &EncodedChunkStateWitness) -> Signature {

--- a/core/primitives/src/validator_signer.rs
+++ b/core/primitives/src/validator_signer.rs
@@ -9,7 +9,7 @@ use crate::challenge::ChallengeBody;
 use crate::hash::CryptoHash;
 use crate::network::{AnnounceAccount, PeerId};
 use crate::sharding::ChunkHash;
-use crate::stateless_validation::chunk_endorsement::ChunkEndorsement;
+use crate::stateless_validation::chunk_endorsement::ChunkEndorsementInner;
 use crate::stateless_validation::partial_witness::PartialEncodedStateWitnessInner;
 use crate::stateless_validation::state_witness::EncodedChunkStateWitness;
 use crate::telemetry::TelemetryInfo;
@@ -84,10 +84,10 @@ impl ValidatorSigner {
     }
 
     /// Signs chunk endorsement to be sent to block producer.
-    pub fn sign_chunk_endorsement(&self, endorsement: &ChunkEndorsement) -> Signature {
+    pub fn sign_chunk_endorsement(&self, inner: &ChunkEndorsementInner) -> Signature {
         match self {
-            ValidatorSigner::Empty(signer) => signer.sign_chunk_endorsement(endorsement),
-            ValidatorSigner::InMemory(signer) => signer.sign_chunk_endorsement(endorsement),
+            ValidatorSigner::Empty(signer) => signer.sign_chunk_endorsement(inner),
+            ValidatorSigner::InMemory(signer) => signer.sign_chunk_endorsement(inner),
         }
     }
 
@@ -227,7 +227,7 @@ impl EmptyValidatorSigner {
         Signature::default()
     }
 
-    fn sign_chunk_endorsement(&self, _endorsement: &ChunkEndorsement) -> Signature {
+    fn sign_chunk_endorsement(&self, _inner: &ChunkEndorsementInner) -> Signature {
         Signature::default()
     }
 
@@ -324,8 +324,8 @@ impl InMemoryValidatorSigner {
         self.signer.sign(&Approval::get_data_for_sig(inner, target_height))
     }
 
-    fn sign_chunk_endorsement(&self, endorsement: &ChunkEndorsement) -> Signature {
-        self.signer.sign(&endorsement.serialized_inner())
+    fn sign_chunk_endorsement(&self, inner: &ChunkEndorsementInner) -> Signature {
+        self.signer.sign(&borsh::to_vec(inner).unwrap())
     }
 
     fn sign_chunk_state_witness(&self, witness_bytes: &EncodedChunkStateWitness) -> Signature {

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -424,7 +424,7 @@ fn test_verify_chunk_invalid_state_challenge() {
         last_block.header().height() + 1,
         last_block.header().block_ordinal() + 1,
         vec![invalid_chunk.cloned_header()],
-        vec![vec![Some(Box::new(endorsement.signature))]],
+        vec![vec![Some(Box::new(endorsement.signature()))]],
         *last_block.header().epoch_id(),
         *last_block.header().next_epoch_id(),
         None,

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -18,7 +18,7 @@ use near_primitives::merkle::PartialMerkleTree;
 use near_primitives::num_rational::Ratio;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::sharding::EncodedShardChunk;
-use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
+use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsementV1;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;
@@ -416,7 +416,7 @@ fn test_verify_chunk_invalid_state_challenge() {
 
     let signer = client.validator_signer.get().unwrap();
     let endorsement =
-        ChunkEndorsement::new(invalid_chunk.cloned_header().chunk_hash(), signer.as_ref());
+        ChunkEndorsementV1::new(invalid_chunk.cloned_header().chunk_hash(), signer.as_ref());
     let block = Block::produce(
         PROTOCOL_VERSION,
         PROTOCOL_VERSION,
@@ -424,7 +424,7 @@ fn test_verify_chunk_invalid_state_challenge() {
         last_block.header().height() + 1,
         last_block.header().block_ordinal() + 1,
         vec![invalid_chunk.cloned_header()],
-        vec![vec![Some(Box::new(endorsement.signature()))]],
+        vec![vec![Some(Box::new(endorsement.signature))]],
         *last_block.header().epoch_id(),
         *last_block.header().next_epoch_id(),
         None,

--- a/integration-tests/src/tests/client/features/orphan_chunk_state_witness.rs
+++ b/integration-tests/src/tests/client/features/orphan_chunk_state_witness.rs
@@ -18,8 +18,6 @@ use near_primitives::stateless_validation::state_witness::{
     ChunkStateWitness, ChunkStateWitnessSize,
 };
 use near_primitives::types::AccountId;
-use near_primitives::version::ProtocolFeature;
-use near_primitives_core::version::PROTOCOL_VERSION;
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
 
 struct OrphanWitnessTestEnv {
@@ -207,11 +205,6 @@ fn setup_orphan_witness_test() -> OrphanWitnessTestEnv {
 fn test_orphan_witness_valid() {
     init_integration_logger();
 
-    if ProtocolFeature::ChunkEndorsementV2.enabled(PROTOCOL_VERSION) {
-        println!("Test not applicable with ChunkEndorsementV2 enabled");
-        return;
-    }
-
     let OrphanWitnessTestEnv {
         mut env,
         block1,
@@ -246,11 +239,6 @@ fn test_orphan_witness_valid() {
 fn test_orphan_witness_too_large() {
     init_integration_logger();
 
-    if ProtocolFeature::ChunkEndorsementV2.enabled(PROTOCOL_VERSION) {
-        println!("Test not applicable with ChunkEndorsementV2 enabled");
-        return;
-    }
-
     let OrphanWitnessTestEnv { mut env, witness, excluded_validator, .. } =
         setup_orphan_witness_test();
 
@@ -269,11 +257,6 @@ fn test_orphan_witness_too_large() {
 #[test]
 fn test_orphan_witness_far_from_head() {
     init_integration_logger();
-
-    if ProtocolFeature::ChunkEndorsementV2.enabled(PROTOCOL_VERSION) {
-        println!("Test not applicable with ChunkEndorsementV2 enabled");
-        return;
-    }
 
     let OrphanWitnessTestEnv { mut env, mut witness, block1, excluded_validator, .. } =
         setup_orphan_witness_test();
@@ -302,11 +285,6 @@ fn test_orphan_witness_far_from_head() {
 #[test]
 fn test_orphan_witness_not_fully_validated() {
     init_integration_logger();
-
-    if ProtocolFeature::ChunkEndorsementV2.enabled(PROTOCOL_VERSION) {
-        println!("Test not applicable with ChunkEndorsementV2 enabled");
-        return;
-    }
 
     let OrphanWitnessTestEnv { mut env, mut witness, excluded_validator, .. } =
         setup_orphan_witness_test();

--- a/integration-tests/src/tests/client/features/orphan_chunk_state_witness.rs
+++ b/integration-tests/src/tests/client/features/orphan_chunk_state_witness.rs
@@ -18,7 +18,7 @@ use near_primitives::stateless_validation::state_witness::{
     ChunkStateWitness, ChunkStateWitnessSize,
 };
 use near_primitives::types::AccountId;
-use near_primitives_core::checked_feature;
+use near_primitives::version::ProtocolFeature;
 use near_primitives_core::version::PROTOCOL_VERSION;
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
 
@@ -207,8 +207,8 @@ fn setup_orphan_witness_test() -> OrphanWitnessTestEnv {
 fn test_orphan_witness_valid() {
     init_integration_logger();
 
-    if !checked_feature!("stable", StatelessValidation, PROTOCOL_VERSION) {
-        println!("Test not applicable without StatelessValidation enabled");
+    if ProtocolFeature::ChunkEndorsementV2.enabled(PROTOCOL_VERSION) {
+        println!("Test not applicable with ChunkEndorsementV2 enabled");
         return;
     }
 
@@ -246,8 +246,8 @@ fn test_orphan_witness_valid() {
 fn test_orphan_witness_too_large() {
     init_integration_logger();
 
-    if !checked_feature!("stable", StatelessValidation, PROTOCOL_VERSION) {
-        println!("Test not applicable without StatelessValidation enabled");
+    if ProtocolFeature::ChunkEndorsementV2.enabled(PROTOCOL_VERSION) {
+        println!("Test not applicable with ChunkEndorsementV2 enabled");
         return;
     }
 
@@ -270,8 +270,8 @@ fn test_orphan_witness_too_large() {
 fn test_orphan_witness_far_from_head() {
     init_integration_logger();
 
-    if !checked_feature!("stable", StatelessValidation, PROTOCOL_VERSION) {
-        println!("Test not applicable without StatelessValidation enabled");
+    if ProtocolFeature::ChunkEndorsementV2.enabled(PROTOCOL_VERSION) {
+        println!("Test not applicable with ChunkEndorsementV2 enabled");
         return;
     }
 
@@ -303,8 +303,8 @@ fn test_orphan_witness_far_from_head() {
 fn test_orphan_witness_not_fully_validated() {
     init_integration_logger();
 
-    if !checked_feature!("stable", StatelessValidation, PROTOCOL_VERSION) {
-        println!("Test not applicable without StatelessValidation enabled");
+    if ProtocolFeature::ChunkEndorsementV2.enabled(PROTOCOL_VERSION) {
+        println!("Test not applicable with ChunkEndorsementV2 enabled");
         return;
     }
 

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -48,7 +48,7 @@ use near_primitives::shard_layout::{get_block_shard_uid, ShardUId};
 use near_primitives::sharding::{ShardChunkHeader, ShardChunkHeaderInner, ShardChunkHeaderV3};
 use near_primitives::state_part::PartId;
 use near_primitives::state_sync::StatePartKey;
-use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
+use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsementV1;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::test_utils::TestBlockBuilder;
 use near_primitives::transaction::{
@@ -2274,8 +2274,8 @@ fn test_validate_chunk_extra() {
         block.mut_header().get_mut().inner_rest.chunk_mask = vec![true];
         block.mut_header().get_mut().inner_lite.prev_outcome_root =
             Block::compute_outcome_root(block.chunks().iter());
-        let endorsement = ChunkEndorsement::new(chunk_header.chunk_hash(), &validator_signer);
-        block.set_chunk_endorsements(vec![vec![Some(Box::new(endorsement.signature()))]]);
+        let endorsement = ChunkEndorsementV1::new(chunk_header.chunk_hash(), &validator_signer);
+        block.set_chunk_endorsements(vec![vec![Some(Box::new(endorsement.signature))]]);
         block.mut_header().get_mut().inner_rest.block_body_hash =
             block.compute_block_body_hash().unwrap();
         block.mut_header().resign(&validator_signer);

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2275,7 +2275,7 @@ fn test_validate_chunk_extra() {
         block.mut_header().get_mut().inner_lite.prev_outcome_root =
             Block::compute_outcome_root(block.chunks().iter());
         let endorsement = ChunkEndorsement::new(chunk_header.chunk_hash(), &validator_signer);
-        block.set_chunk_endorsements(vec![vec![Some(Box::new(endorsement.signature))]]);
+        block.set_chunk_endorsements(vec![vec![Some(Box::new(endorsement.signature()))]]);
         block.mut_header().get_mut().inner_rest.block_body_hash =
             block.compute_block_body_hash().unwrap();
         block.mut_header().resign(&validator_signer);


### PR DESCRIPTION
This PR is a pre-step for the work around merging validation of chunk endorsement and partial witness.

This PR has the following changes
- New protocol feature ChunkEndorsementV2 which would introduce a new network message and versioning of ChunkEndorsement.
- ChunkEndorsement is changed from struct to a versioned enum. The original/old chunk endorsement message would work with ChunkEndorsementV1 till deprecated.
- The outgoing network stack would use the original RoutedMessageBody::ChunkEndorsement for V1 while we would use RoutedMessageBody::VersionedChunkEndorsement for futue versions.

No functional change in this PR.