### PR TITLE
fix(mirror.py): Fix datetime dependency

### DIFF
--- a/pytest/requirements.txt
+++ b/pytest/requirements.txt
@@ -21,3 +21,4 @@ semver
 toml
 tqdm
 urllib3<2
+datetime

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -196,7 +196,7 @@ def new_genesis_timestamp(node):
     result = version.get('result')
     if result is not None:
         if result.get('node_setup_version') == '1':
-            genesis_time = str(datetime.datetime.now(tz=datetime.UTC))
+            genesis_time = str(datetime.datetime.now(tz=datetime.timezone.utc))
     return genesis_time
 
 


### PR DESCRIPTION
The mirror.py script uses the `datetime` library, but it wasn't included in the `requirements.txt` file.
Let's add it to `requirements.txt`.

Apart from that, the script used an older version of the dependency, let's update it to work with the new version where `datetime.UTC` has been deprecated.