### PR TITLE
[cleanup] Remove check for stateless validation protocol version in tests

### DIFF
--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -11,12 +11,10 @@ use near_pool::{
 };
 use near_primitives::action::FunctionCallAction;
 use near_primitives::apply::ApplyChunkReason;
-use near_primitives::checked_feature;
 use near_primitives::congestion_info::{BlockCongestionInfo, ExtendedCongestionInfo};
 use near_primitives::receipt::{ActionReceipt, ReceiptV1};
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::validator_stake::{ValidatorStake, ValidatorStakeIter};
-use near_primitives::version::PROTOCOL_VERSION;
 use near_store::flat::{FlatStateChanges, FlatStateDelta, FlatStateDeltaMetadata};
 use near_store::genesis::initialize_genesis_state;
 use num_rational::Ratio;
@@ -1679,11 +1677,6 @@ fn prepare_transactions(
 /// Check that transactions validation works the same when using recorded storage proof instead of db.
 #[test]
 fn test_prepare_transactions_storage_proof() {
-    if !checked_feature!("stable", StatelessValidation, PROTOCOL_VERSION) {
-        println!("Test not applicable without StatelessValidation enabled");
-        return;
-    }
-
     let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool();
     let transactions_count = transaction_pool.len();
 
@@ -1728,11 +1721,6 @@ fn test_prepare_transactions_storage_proof() {
 /// Check that transactions validation fails if provided empty storage proof.
 #[test]
 fn test_prepare_transactions_empty_storage_proof() {
-    if !checked_feature!("stable", StatelessValidation, PROTOCOL_VERSION) {
-        println!("Test not applicable without StatelessValidation enabled");
-        return;
-    }
-
     let (env, chain, mut transaction_pool) = get_test_env_with_chain_and_pool();
     let transactions_count = transaction_pool.len();
 
@@ -1776,9 +1764,6 @@ fn test_prepare_transactions_empty_storage_proof() {
 #[test]
 #[cfg_attr(not(feature = "test_features"), ignore)]
 fn test_storage_proof_garbage() {
-    if !checked_feature!("stable", StatelessValidation, PROTOCOL_VERSION) {
-        return;
-    }
     let shard_id = 0;
     let signer = create_test_signer("test1");
     let env = TestEnv::new(vec![vec![signer.validator_id().clone()]], 100, false);

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -1126,13 +1126,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         while let Some(iter) = transaction_groups.next() {
             res.push(iter.next().unwrap());
         }
-        let storage_proof = if ProtocolFeature::StatelessValidation.enabled(PROTOCOL_VERSION)
-            || cfg!(feature = "shadow_chunk_validation")
-        {
-            Some(Default::default())
-        } else {
-            None
-        };
+        let storage_proof = Some(Default::default());
         Ok(PreparedTransactions { transactions: res, limited_by: None, storage_proof })
     }
 
@@ -1282,13 +1276,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         let state_root = hash(&data);
         self.state.write().unwrap().insert(state_root, state);
         self.state_size.write().unwrap().insert(state_root, state_size);
-        let storage_proof = if ProtocolFeature::StatelessValidation.enabled(PROTOCOL_VERSION)
-            || cfg!(feature = "shadow_chunk_validation")
-        {
-            Some(Default::default())
-        } else {
-            None
-        };
+        let storage_proof = Some(Default::default());
         Ok(ApplyChunkResult {
             trie_changes: WrappedTrieChanges::new(
                 self.get_tries(),

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -25,7 +25,7 @@ use near_primitives::types::ValidatorKickoutReason::{
     NotEnoughBlocks, NotEnoughChunkEndorsements, NotEnoughChunks,
 };
 use near_primitives::validator_signer::ValidatorSigner;
-use near_primitives::version::ProtocolFeature::{self, SimpleNightshade, StatelessValidation};
+use near_primitives::version::ProtocolFeature::{self, SimpleNightshade};
 use near_primitives::version::PROTOCOL_VERSION;
 use near_store::test_utils::create_test_store;
 use num_rational::Ratio;
@@ -1528,9 +1528,6 @@ fn test_chunk_producer_kickout() {
 /// validator is not kicked out.
 #[test]
 fn test_chunk_validator_kickout() {
-    if !StatelessValidation.enabled(PROTOCOL_VERSION) {
-        return;
-    }
     let stake_amount = 1_000_000;
     let validators: Vec<(AccountId, Balance)> =
         (0..3).map(|i| (format!("test{i}").parse().unwrap(), stake_amount + 100 - i)).collect();
@@ -2792,11 +2789,6 @@ fn test_verify_chunk_endorsements() {
     use near_primitives::test_utils::create_test_signer;
     use std::str::FromStr;
 
-    if !checked_feature!("stable", StatelessValidation, PROTOCOL_VERSION) {
-        println!("Test not applicable without ChunkValidation enabled");
-        return;
-    }
-
     let amount_staked = 1_000_000;
     let account_id = AccountId::from_str("test1").unwrap();
     let validators = vec![(account_id.clone(), amount_staked)];
@@ -2858,11 +2850,6 @@ fn test_verify_partial_witness_signature() {
     use near_crypto::Signature;
     use near_primitives::test_utils::create_test_signer;
     use std::str::FromStr;
-
-    if !checked_feature!("stable", StatelessValidation, PROTOCOL_VERSION) {
-        println!("Test not applicable without ChunkValidation enabled");
-        return;
-    }
 
     let amount_staked = 1_000_000;
     let account_id = AccountId::from_str("test1").unwrap();

--- a/integration-tests/src/test_loop/tests/chunk_validator_kickout.rs
+++ b/integration-tests/src/test_loop/tests/chunk_validator_kickout.rs
@@ -8,16 +8,9 @@ use near_chain_configs::test_genesis::TestGenesisBuilder;
 use near_client::Client;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::types::AccountId;
-use near_primitives_core::checked_feature;
-use near_primitives_core::version::PROTOCOL_VERSION;
 use std::string::ToString;
 
 fn run_test_chunk_validator_kickout(select_chunk_validator_only: bool) {
-    if !checked_feature!("stable", StatelessValidation, PROTOCOL_VERSION) {
-        println!("Test not applicable without StatelessValidation enabled");
-        return;
-    }
-
     init_test_logger();
     let builder = TestLoopBuilder::new();
 

--- a/integration-tests/src/test_loop/tests/multinode_stateless_validators.rs
+++ b/integration-tests/src/test_loop/tests/multinode_stateless_validators.rs
@@ -7,8 +7,6 @@ use near_chain_configs::test_genesis::TestGenesisBuilder;
 use near_client::{GetValidatorInfo, ViewClientActorInner};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::types::{AccountId, EpochId, EpochReference};
-use near_primitives::version::ProtocolFeature::StatelessValidation;
-use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{CurrentEpochValidatorInfo, EpochValidatorInfo};
 
 use crate::test_loop::builder::TestLoopBuilder;
@@ -26,11 +24,6 @@ const NUM_VALIDATORS: usize = NUM_BLOCK_AND_CHUNK_PRODUCERS + NUM_CHUNK_VALIDATO
 
 #[test]
 fn test_stateless_validators_with_multi_test_loop() {
-    if !StatelessValidation.enabled(PROTOCOL_VERSION) {
-        println!("Test not applicable without StatelessValidation enabled");
-        return;
-    }
-
     init_test_logger();
     let builder = TestLoopBuilder::new();
 

--- a/integration-tests/src/tests/client/benchmarks.rs
+++ b/integration-tests/src/tests/client/benchmarks.rs
@@ -9,7 +9,6 @@ use near_client::test_utils::{create_chunk_on_height, TestEnv};
 use near_client::{ProcessTxResponse, ProduceChunkResult};
 use near_crypto::{InMemorySigner, KeyType};
 use near_primitives::transaction::{Action, DeployContractAction, SignedTransaction};
-use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
 
 /// How long does it take to produce a large chunk?
@@ -25,11 +24,7 @@ fn benchmark_large_chunk_production_time() {
     let mb = 1024usize.pow(2);
 
     let n_txes = 20;
-    let tx_size = if ProtocolFeature::StatelessValidation.enabled(PROTOCOL_VERSION) {
-        mb / 2
-    } else {
-        3 * mb
-    };
+    let tx_size = mb / 2;
 
     let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
@@ -63,10 +58,6 @@ fn benchmark_large_chunk_production_time() {
 
     // Check that we limit the size of the chunk and not include all `n_txes`
     // transactions in the chunk.
-    if ProtocolFeature::StatelessValidation.enabled(PROTOCOL_VERSION) {
-        assert!(6 * mb < size && size < 8 * mb, "{size}");
-        assert_eq!(decoded_chunk.transactions().len(), 7); // 4MiB limit allows for 7 x 0.5MiB transactions
-    } else {
-        assert!(30 * mb < size && size < 40 * mb, "{size}");
-    }
+    assert!(6 * mb < size && size < 8 * mb, "{size}");
+    assert_eq!(decoded_chunk.transactions().len(), 7); // 4MiB limit allows for 7 x 0.5MiB transactions
 }

--- a/integration-tests/src/tests/client/features/stateless_validation.rs
+++ b/integration-tests/src/tests/client/features/stateless_validation.rs
@@ -29,7 +29,6 @@ use near_primitives::utils::derive_eth_implicit_account_id;
 use near_primitives::version::{ProtocolVersion, PROTOCOL_VERSION};
 use near_primitives::views::FinalExecutionStatus;
 use near_primitives_core::account::{AccessKey, Account};
-use near_primitives_core::checked_feature;
 use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::{AccountId, NumSeats};
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
@@ -43,11 +42,6 @@ fn run_chunk_validation_test(
     genesis_protocol_version: ProtocolVersion,
 ) {
     init_integration_logger();
-
-    if !checked_feature!("stable", StatelessValidation, PROTOCOL_VERSION) {
-        println!("Test not applicable without StatelessValidation enabled");
-        return;
-    }
 
     let initial_balance = 100 * ONE_NEAR;
     let validator_stake = 1000000 * ONE_NEAR;
@@ -318,10 +312,6 @@ fn test_chunk_validation_protocol_upgrade_mid_missing_prob() {
 fn test_protocol_upgrade_81() {
     init_integration_logger();
 
-    if !checked_feature!("stable", StatelessValidation, PROTOCOL_VERSION) {
-        println!("Test not applicable without StatelessValidation enabled");
-        return;
-    }
     for is_statelessnet in [true, false] {
         let validator_stake = 1000000 * ONE_NEAR;
         let num_accounts = 9;
@@ -382,11 +372,6 @@ fn test_protocol_upgrade_81() {
 #[test]
 fn test_chunk_state_witness_bad_shard_id() {
     init_integration_logger();
-
-    if !checked_feature!("stable", StatelessValidation, PROTOCOL_VERSION) {
-        println!("Test not applicable without StatelessValidation enabled");
-        return;
-    }
 
     let accounts = vec!["test0".parse().unwrap()];
     let genesis = Genesis::test(accounts.clone(), 1);
@@ -554,13 +539,6 @@ fn test_invalid_transactions() {
 /// Tests that eth-implicit accounts still work with stateless validation.
 #[test]
 fn test_eth_implicit_accounts() {
-    if !(checked_feature!("stable", StatelessValidation, PROTOCOL_VERSION)
-        && checked_feature!("stable", EthImplicitAccounts, PROTOCOL_VERSION))
-    {
-        println!("Test not applicable without both StatelessValidation and eth-implicit accounts enabled");
-        return;
-    }
-
     let accounts =
         vec!["test0".parse().unwrap(), "test1".parse().unwrap(), "test2".parse().unwrap()];
     let genesis = Genesis::test(accounts.clone(), 2);

--- a/integration-tests/src/tests/client/features/storage_proof_size_limit.rs
+++ b/integration-tests/src/tests/client/features/storage_proof_size_limit.rs
@@ -11,7 +11,7 @@ use near_primitives::errors::{ActionErrorKind, TxExecutionError};
 use near_primitives::receipt::{Receipt, ReceiptEnum};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::AccountId;
-use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
+use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::FinalExecutionStatus;
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
 
@@ -112,25 +112,20 @@ fn test_storage_proof_size_limit() {
     // Now perform a 20MB read (keys 0..20), which should fail due to the hard per-receipt storage proof size limit.
     let read20_tx = make_read_transaction(0, 20);
     let res = env.execute_tx(read20_tx).unwrap();
-    // PerReceiptHardStorageProofLimit
-    if ProtocolFeature::StatelessValidation.enabled(PROTOCOL_VERSION) {
-        assert_matches!(res.status, FinalExecutionStatus::Failure(_));
-        let error_string = match res.status {
-            FinalExecutionStatus::Failure(TxExecutionError::ActionError(action_error)) => {
-                match action_error.kind {
-                    ActionErrorKind::FunctionCallError(FunctionCallError::ExecutionError(
-                        error_string,
-                    )) => error_string,
-                    other => panic!("Bad ActionErrorKind: {:?}", other),
-                }
+    assert_matches!(res.status, FinalExecutionStatus::Failure(_));
+    let error_string = match res.status {
+        FinalExecutionStatus::Failure(TxExecutionError::ActionError(action_error)) => {
+            match action_error.kind {
+                ActionErrorKind::FunctionCallError(FunctionCallError::ExecutionError(
+                    error_string,
+                )) => error_string,
+                other => panic!("Bad ActionErrorKind: {:?}", other),
             }
-            other => panic!("Bad FinalExecutionStatus: {:?}", other),
-        };
-        assert!(error_string
-            .contains("Size of the recorded trie storage proof has exceeded the allowed limit"));
-    } else {
-        assert_matches!(res.status, FinalExecutionStatus::SuccessValue(_));
-    }
+        }
+        other => panic!("Bad FinalExecutionStatus: {:?}", other),
+    };
+    assert!(error_string
+        .contains("Size of the recorded trie storage proof has exceeded the allowed limit"));
 
     // Now test the per-chunk soft limit.
     // Spawn 3 transactions, each reading 2MB of data. The first two should end up in the same chunk.
@@ -170,24 +165,13 @@ fn test_storage_proof_size_limit() {
     let chunk = next_chunk();
     assert_eq!(chunk.transactions().len(), 0);
     assert_eq!(count_function_call_receipts(chunk.prev_outgoing_receipts()), 0);
-    // PerReceiptHardStorageProofLimit
-    if ProtocolFeature::StatelessValidation.enabled(PROTOCOL_VERSION) {
-        assert_eq!(count_transfer_receipts(chunk.prev_outgoing_receipts()), 2);
-    } else {
-        // Without soft limit the receipts are processed immediately.
-        assert_eq!(count_transfer_receipts(chunk.prev_outgoing_receipts()), 3);
-    }
+    assert_eq!(count_transfer_receipts(chunk.prev_outgoing_receipts()), 2);
 
     // Chunk D - 1 transfer receipt from the third FunctionCall
     let chunk = next_chunk();
     assert_eq!(chunk.transactions().len(), 0);
     assert_eq!(count_function_call_receipts(chunk.prev_outgoing_receipts()), 0);
-    // PerReceiptHardStorageProofLimit
-    if ProtocolFeature::StatelessValidation.enabled(PROTOCOL_VERSION) {
-        assert_eq!(count_transfer_receipts(chunk.prev_outgoing_receipts()), 1);
-    } else {
-        assert_eq!(count_transfer_receipts(chunk.prev_outgoing_receipts()), 0);
-    }
+    assert_eq!(count_transfer_receipts(chunk.prev_outgoing_receipts()), 1);
 }
 
 fn count_function_call_receipts(receipts: &[Receipt]) -> usize {

--- a/nearcore/tests/economics.rs
+++ b/nearcore/tests/economics.rs
@@ -10,8 +10,6 @@ use near_client::test_utils::TestEnv;
 use near_crypto::{InMemorySigner, KeyType};
 use near_o11y::testonly::init_integration_logger;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::version::ProtocolFeature::StatelessValidation;
-use near_primitives::version::PROTOCOL_VERSION;
 use near_store::{genesis::initialize_genesis_state, test_utils::create_test_store};
 use nearcore::NightshadeRuntime;
 use testlib::fees_utils::FeeHelper;
@@ -114,13 +112,9 @@ fn test_burn_mint() {
         .as_u128()
     };
     // In stateless validation, chunk endorsements are also included in the reward calculation.
-    let expected_total_supply = if StatelessValidation.enabled(PROTOCOL_VERSION) {
-        // supply + 1% of protocol rewards + 2/3 * 9% of validator rewards.
-        initial_total_supply + epoch_total_reward * 700 / 1000 - half_transfer_cost
-    } else {
-        // supply + 1% of protocol rewards + 3/4 * 9% of validator rewards.
-        initial_total_supply + epoch_total_reward * 775 / 1000 - half_transfer_cost
-    };
+    // supply + 1% of protocol rewards + 2/3 * 9% of validator rewards.
+    let expected_total_supply =
+        initial_total_supply + epoch_total_reward * 700 / 1000 - half_transfer_cost;
     assert_eq!(block3.header().total_supply(), expected_total_supply);
     assert_eq!(block3.chunks()[0].prev_balance_burnt(), half_transfer_cost);
     // Block 4: subtract 2nd part of transfer.


### PR DESCRIPTION
Now that stateless validation is in prod, we no longer need to check the protocol version for stateless validation specific tests.