### PR TITLE
[tests] Use consistent runtime config across tests

### DIFF
--- a/integration-tests/src/node/runtime_node.rs
+++ b/integration-tests/src/node/runtime_node.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, RwLock};
 
 use near_chain_configs::Genesis;
 use near_crypto::{InMemorySigner, KeyType, Signer};
-use near_parameters::RuntimeConfig;
+use near_parameters::{RuntimeConfig, RuntimeConfigStore};
 use near_primitives::types::AccountId;
 use testlib::runtime_utils::{add_test_contract, alice_account, bob_account, carol_account};
 
@@ -48,7 +48,9 @@ impl RuntimeNode {
     }
 
     pub fn new_from_genesis(account_id: &AccountId, genesis: Genesis) -> Self {
-        Self::new_from_genesis_and_config(account_id, genesis, RuntimeConfig::test())
+        let store = RuntimeConfigStore::new(None);
+        let config = RuntimeConfig::clone(store.get_config(genesis.config.protocol_version));
+        Self::new_from_genesis_and_config(account_id, genesis, config)
     }
 
     /// Same as `RuntimeNode::new`, but allows to modify the RuntimeConfig.
@@ -61,7 +63,9 @@ impl RuntimeNode {
         add_test_contract(&mut genesis, &bob_account());
         add_test_contract(&mut genesis, &carol_account());
 
-        let mut runtime_config = RuntimeConfig::test();
+        let store = RuntimeConfigStore::new(None);
+        let mut runtime_config =
+            RuntimeConfig::clone(store.get_config(genesis.config.protocol_version));
         modify_config(&mut runtime_config);
         Self::new_from_genesis_and_config(account_id, genesis, runtime_config)
     }

--- a/integration-tests/src/tests/client/features/nonrefundable_transfer.rs
+++ b/integration-tests/src/tests/client/features/nonrefundable_transfer.rs
@@ -10,6 +10,7 @@ use near_chain_configs::Genesis;
 use near_chain_configs::NEAR_BASE;
 use near_client::test_utils::TestEnv;
 use near_crypto::{InMemorySigner, KeyType, PublicKey};
+use near_parameters::RuntimeConfigStore;
 use near_primitives::errors::{
     ActionError, ActionErrorKind, ActionsValidationError, InvalidTxError, TxExecutionError,
 };
@@ -86,7 +87,11 @@ fn setup_env_with_protocol_version(protocol_version: Option<ProtocolVersion>) ->
     if let Some(protocol_version) = protocol_version {
         genesis.config.protocol_version = protocol_version;
     }
-    TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build()
+    // Must match the config store used by the `fee_helper()`.
+    let store = RuntimeConfigStore::new(None);
+    TestEnv::builder(&genesis.config)
+        .nightshade_runtimes_with_runtime_config_store(&genesis, vec![store; 2])
+        .build()
 }
 
 /// Creates a test environment using default protocol version.

--- a/integration-tests/src/tests/runtime/test_evil_contracts.rs
+++ b/integration-tests/src/tests/runtime/test_evil_contracts.rs
@@ -87,10 +87,6 @@ fn test_evil_deep_trie() {
 
 /// Test delaying the conclusion of a receipt for as long as possible through the use of self
 /// cross-contract calls.
-///
-/// I hear that the protocol-level limit on the depth here is 64, so given the current fee
-/// structure this limit cannot be reached by this contract, but once they decrease it might very
-/// well be necessary to adjust the `expected_depth` to at most that limit.
 #[test]
 fn test_self_delay() {
     let node = setup_test_contract(near_test_contracts::rs_contract());
@@ -112,7 +108,9 @@ fn test_self_delay() {
     // The test makes sure that the depth is within the expected range, but it doesn't check an exact value
     // to avoid having separate cases for every possible combination of features.
     let min_expected_depth = 56;
-    let max_expected_depth = 62;
+    // The upper limit has been recently bumped to 221 from the previous value of 62 after the
+    // adjustment of a function call gas costs.
+    let max_expected_depth = 221;
     match res.status {
         FinalExecutionStatus::SuccessValue(depth_bytes) => {
             let depth = u32::from_be_bytes(depth_bytes.try_into().unwrap());

--- a/integration-tests/src/tests/standard_cases/mod.rs
+++ b/integration-tests/src/tests/standard_cases/mod.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 
 use crate::node::Node;
 use crate::user::User;
-use near_parameters::RuntimeConfig;
+use near_parameters::{RuntimeConfig, RuntimeConfigStore};
 use near_primitives::receipt::{ActionReceipt, Receipt, ReceiptEnum, ReceiptV0};
 use near_primitives::test_utils;
 use near_primitives::transaction::{Action, DeployContractAction, FunctionCallAction};
@@ -39,7 +39,9 @@ use testlib::runtime_utils::{
 const FUNCTION_CALL_AMOUNT: Balance = TESTING_INIT_BALANCE / 10;
 
 pub(crate) fn fee_helper(node: &impl Node) -> FeeHelper {
-    FeeHelper::new(RuntimeConfig::test(), node.genesis().config.min_gas_price)
+    let store = RuntimeConfigStore::new(None);
+    let config = RuntimeConfig::clone(store.get_config(node.genesis().config.protocol_version));
+    FeeHelper::new(config, node.genesis().config.min_gas_price)
 }
 
 /// Adds given access key to the given account_id using signer2.


### PR DESCRIPTION
There was a discrepancy between the costs used by the started nodes and the ones used by the fee_helper which was exposed when gas costs changed.

There were a number of places where we select which RuntimeConfig to use:
1. Multiple NEAR nodes started in separate threads with random chain_id `test-chain-*`
2. `RuntimeNode` class
3. `fee_helper()` function
4. `TestEnv` builder

All these places must use the same config for the gas calculations to match.
I've decided to align all of these cases with the configs used in 1, which matches the current mainnet config.
I think that's generally a good choice if available as we want the test environment to catch the problems that we will see on mainnet.

There could be some tests that still rely on the values from `free` or `test` configs, but I argue that they should be using them explicitly.

Fixes https://github.com/near/nearcore/issues/11031.