### PR TITLE
[tests] Fix gas cost calculation in delegation tests

### DIFF
--- a/integration-tests/src/tests/client/features/delegate_action.rs
+++ b/integration-tests/src/tests/client/features/delegate_action.rs
@@ -246,7 +246,7 @@ fn check_meta_tx_fn_call(
 
     // calculate contract rewards as reward("gas burnt in fn call receipt" - "static exec costs")
     let gas_burnt_for_function_call =
-        tx_result.receipts_outcome[1].outcome.gas_burnt - static_send_gas;
+        tx_result.receipts_outcome[1].outcome.gas_burnt - static_exec_gas;
     let dyn_cost = fee_helper.gas_to_balance(gas_burnt_for_function_call);
     let contract_reward = fee_helper.gas_burnt_to_reward(gas_burnt_for_function_call);
 


### PR DESCRIPTION
As comment above suggests, we need to use exec gas in calculation instead of send. This didn't cause the test to fail because all of the costs are zero, but I've tested that increasing them fails before and passes with this change.

This fixes some of the failures in https://github.com/near/nearcore/pull/11864