### PR TITLE
[tests] Avoid top-level test contract names

### DIFF
--- a/integration-tests/src/tests/runtime/test_evil_contracts.rs
+++ b/integration-tests/src/tests/runtime/test_evil_contracts.rs
@@ -21,7 +21,7 @@ fn setup_test_contract(wasm_binary: &[u8]) -> RuntimeNode {
     let transaction_result = node_user
         .create_account(
             account_id,
-            "test_contract".parse().unwrap(),
+            "test_contract.alice.near".parse().unwrap(),
             node.signer().public_key(),
             TESTING_INIT_BALANCE / 2,
         )
@@ -29,8 +29,9 @@ fn setup_test_contract(wasm_binary: &[u8]) -> RuntimeNode {
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 2);
 
-    let transaction_result =
-        node_user.deploy_contract("test_contract".parse().unwrap(), wasm_binary.to_vec()).unwrap();
+    let transaction_result = node_user
+        .deploy_contract("test_contract.alice.near".parse().unwrap(), wasm_binary.to_vec())
+        .unwrap();
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 1);
 
@@ -51,7 +52,7 @@ fn test_evil_deep_trie() {
             .user()
             .function_call(
                 "alice.near".parse().unwrap(),
-                "test_contract".parse().unwrap(),
+                "test_contract.alice.near".parse().unwrap(),
                 "insert_strings",
                 input_data.to_vec(),
                 MAX_GAS,
@@ -72,7 +73,7 @@ fn test_evil_deep_trie() {
             .user()
             .function_call(
                 "alice.near".parse().unwrap(),
-                "test_contract".parse().unwrap(),
+                "test_contract.alice.near".parse().unwrap(),
                 "delete_strings",
                 input_data.to_vec(),
                 MAX_GAS,
@@ -97,7 +98,7 @@ fn test_self_delay() {
         .user()
         .function_call(
             "alice.near".parse().unwrap(),
-            "test_contract".parse().unwrap(),
+            "test_contract.alice.near".parse().unwrap(),
             "max_self_recursion_delay",
             vec![0; 4],
             MAX_GAS,
@@ -132,7 +133,7 @@ fn test_evil_deep_recursion() {
             .user()
             .function_call(
                 "alice.near".parse().unwrap(),
-                "test_contract".parse().unwrap(),
+                "test_contract.alice.near".parse().unwrap(),
                 "recurse",
                 n_bytes.clone(),
                 MAX_GAS,
@@ -154,7 +155,7 @@ fn test_evil_abort() {
         .user()
         .function_call(
             "alice.near".parse().unwrap(),
-            "test_contract".parse().unwrap(),
+            "test_contract.alice.near".parse().unwrap(),
             "abort_with_zero",
             vec![],
             MAX_GAS,

--- a/integration-tests/src/tests/runtime/test_yield_resume.rs
+++ b/integration-tests/src/tests/runtime/test_yield_resume.rs
@@ -17,7 +17,7 @@ fn setup_test_contract(wasm_binary: &[u8]) -> RuntimeNode {
     let transaction_result = node_user
         .create_account(
             account_id,
-            "test_contract".parse().unwrap(),
+            "test_contract.alice.near".parse().unwrap(),
             node.signer().public_key(),
             TESTING_INIT_BALANCE / 2,
         )
@@ -25,8 +25,9 @@ fn setup_test_contract(wasm_binary: &[u8]) -> RuntimeNode {
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 2);
 
-    let transaction_result =
-        node_user.deploy_contract("test_contract".parse().unwrap(), wasm_binary.to_vec()).unwrap();
+    let transaction_result = node_user
+        .deploy_contract("test_contract.alice.near".parse().unwrap(), wasm_binary.to_vec())
+        .unwrap();
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
     assert_eq!(transaction_result.receipts_outcome.len(), 1);
 
@@ -48,7 +49,7 @@ fn create_then_resume() {
         .user()
         .function_call(
             "alice.near".parse().unwrap(),
-            "test_contract".parse().unwrap(),
+            "test_contract.alice.near".parse().unwrap(),
             "call_yield_create_return_data_id",
             yield_payload.clone(),
             MAX_GAS,
@@ -68,7 +69,7 @@ fn create_then_resume() {
         .user()
         .function_call(
             "alice.near".parse().unwrap(),
-            "test_contract".parse().unwrap(),
+            "test_contract.alice.near".parse().unwrap(),
             "read_value",
             key.clone(),
             MAX_GAS,
@@ -83,7 +84,7 @@ fn create_then_resume() {
         .user()
         .function_call(
             "alice.near".parse().unwrap(),
-            "test_contract".parse().unwrap(),
+            "test_contract.alice.near".parse().unwrap(),
             "call_yield_resume",
             args,
             MAX_GAS,
@@ -101,7 +102,7 @@ fn create_then_resume() {
         .user()
         .function_call(
             "alice.near".parse().unwrap(),
-            "test_contract".parse().unwrap(),
+            "test_contract.alice.near".parse().unwrap(),
             "read_value",
             key,
             MAX_GAS,
@@ -125,7 +126,7 @@ fn create_and_resume_in_one_call() {
         .user()
         .function_call(
             "alice.near".parse().unwrap(),
-            "test_contract".parse().unwrap(),
+            "test_contract.alice.near".parse().unwrap(),
             "call_yield_create_and_resume",
             yield_payload,
             MAX_GAS,
@@ -153,7 +154,7 @@ fn resume_without_yield() {
         .user()
         .function_call(
             "alice.near".parse().unwrap(),
-            "test_contract".parse().unwrap(),
+            "test_contract.alice.near".parse().unwrap(),
             "call_yield_resume",
             args,
             MAX_GAS,


### PR DESCRIPTION
As these break when we start using a config that is closer to mainnet settings in https://github.com/near/nearcore/pull/11864 that prohibits to create top-level contracts by contracts different from "registrar".

We can alternatively lift that restriction for tests, but I think this fix is quite simple and aligns the tests with mainnet conventions.