### PR TITLE
feat(workflow) Allow ci workflow to be started on demand.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ concurrency:
 on:
   pull_request:
   merge_group:
+  workflow_dispatch:
 
 env:
   CI_HACKS: 1


### PR DESCRIPTION
now you can start this workflow with `gh workflow run ci.yml --repo near/nearcore --ref <branch>`