### PR TITLE
fix(congestion) - remove error log in promis yield handling

### DIFF
--- a/runtime/runtime/src/congestion_control.rs
+++ b/runtime/runtime/src/congestion_control.rs
@@ -340,7 +340,6 @@ pub(crate) fn receipt_congestion_gas(
             // they never cross the shard boundaries. This makes it irrelevant
             // for the congestion MVP, which only counts gas in the outgoing
             // buffers and delayed receipts queue.
-            tracing::error!(target: "congestion_control", "Attempting to calculate congestion gas for a `PromiseYield`.");
             Ok(0)
         }
         ReceiptEnum::PromiseResume(_) => {


### PR DESCRIPTION
There is no need to print an error in this case. Congestion Control does not need to account for promise yields as indicated in the comment. This is to fix https://github.com/near/nearcore/issues/11873.