### PR TITLE
chore: Remove code that refers to "statelessnet"

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3941,15 +3941,6 @@ fn get_genesis_congestion_infos_impl(
         return Ok(std::iter::repeat(None).take(state_roots.len()).collect());
     }
 
-    // Since the congestion info is already bootstrapped in statelessnet, skip another bootstrap.
-    // TODO: This is temporary mitigation for the failing genesis congestion info due to garbage
-    // collected genesis state roots. It can be removed after the statelessnet network is turned down.
-    if let Ok(protocol_config) = runtime.get_protocol_config(&genesis_epoch_id) {
-        if protocol_config.genesis_config.chain_id == near_primitives::chains::STATELESSNET {
-            return Ok(std::iter::repeat(None).take(state_roots.len()).collect());
-        }
-    }
-
     // Check we had already computed the congestion infos from the genesis state roots.
     if let Some(saved_infos) = near_store::get_genesis_congestion_infos(runtime.store())? {
         tracing::debug!(target: "chain", "Reading genesis congestion infos from database.");

--- a/core/primitives-core/src/chains.rs
+++ b/core/primitives-core/src/chains.rs
@@ -6,9 +6,6 @@ pub const MAINNET: &str = "mainnet";
 /// Primary testing environment.
 pub const TESTNET: &str = "testnet";
 
-/// Temporary StatelessNet active from 2024-02-01.
-pub const STATELESSNET: &str = "statelessnet";
-
 /// Pre-release testing environment.
 pub const MOCKNET: &str = "mocknet";
 

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -134,8 +134,6 @@ impl AllEpochConfig {
 
         Self::config_mocknet(&mut config, &self.chain_id);
 
-        Self::config_stateless_net(&mut config, &self.chain_id, protocol_version);
-
         if !self.use_production_config {
             return config;
         }
@@ -170,25 +168,6 @@ impl AllEpochConfig {
         // TODO(#11201): When stabilizing "ShuffleShardAssignments" in mainnet,
         // also remove this temporary code and always rely on ShuffleShardAssignments.
         config.validator_selection_config.shuffle_shard_assignment_for_chunk_producers = true;
-    }
-
-    /// Configures statelessnet-specific features only.
-    /// TODO: Remove this function when statelessnet is no longer used.
-    fn config_stateless_net(
-        config: &mut EpochConfig,
-        chain_id: &str,
-        protocol_version: ProtocolVersion,
-    ) {
-        if chain_id != near_primitives_core::chains::STATELESSNET {
-            return;
-        }
-        // Lower the kickout threshold so the network is more stable while
-        // we figure out issues with block and chunk production.
-        if ProtocolFeature::StatelessValidation.enabled(protocol_version) {
-            config.block_producer_kickout_threshold = 50;
-            config.chunk_producer_kickout_threshold = 50;
-            config.chunk_validator_only_kickout_threshold = 50;
-        }
     }
 
     /// Configures validator-selection related features.


### PR DESCRIPTION
Statelessnet is about to be turned down, thus we can now remove the code that behaves differently for the statelessnet.

NOTE: This will be merged after the statelessnet is really turned down.