### PR TITLE
fix: Fix db_migration.py test

### DIFF
--- a/pytest/tests/sanity/db_migration.py
+++ b/pytest/tests/sanity/db_migration.py
@@ -20,10 +20,20 @@ logging.basicConfig(level=logging.INFO)
 
 NUM_SHARDS = 4
 EPOCH_LENGTH = 5
+# Used while the node is running with the old binary.
+GC_NUM_EPOCHS_TO_KEEP = 15
 
 # Config to track all shards.
 node_config = {
     "tracked_shards": list(range(NUM_SHARDS)),
+    # We should have large enough GC window while the node running with the old binary (1.40), because we need to
+    # bootstrap the congestion info from the genesis block and the genesis block should not be garbage collected.
+    # The new binary (2.0) has a mechnanism to save the congestion info on disk to be resilient against GC of
+    # genesis block, however the old binary does not have this mechanism, thus we need to prevent GC to kick in
+    # before the node transitions to the new binary. Note that, after restarting the node with the new binary
+    # we can switch back to the usual GC window (see below).
+    # TODO: This change for GC can be removed when the old binary version becomes 2.0 in this test.
+    "gc_num_epochs_to_keep": GC_NUM_EPOCHS_TO_KEEP,
 }
 
 
@@ -117,6 +127,9 @@ def main():
     send_some_tx(node)
     unstake_and_stake(nodes[1], node)
 
+    height, _ = utils.wait_for_blocks(node, count=1)
+    assert height < EPOCH_LENGTH * GC_NUM_EPOCHS_TO_KEEP, "Node should run without GC"
+
     node.kill()
 
     logging.info(
@@ -126,6 +139,7 @@ def main():
     logging.info("Starting the current node...")
     node.near_root = executables.current.root
     node.binary_name = executables.current.neard
+    node.change_config({"gc_num_epochs_to_keep": 5})
     node.start(boot_node=node)
 
     logging.info("Running the current node...")

--- a/pytest/tests/sanity/db_migration.py
+++ b/pytest/tests/sanity/db_migration.py
@@ -21,19 +21,21 @@ logging.basicConfig(level=logging.INFO)
 NUM_SHARDS = 4
 EPOCH_LENGTH = 5
 # Used while the node is running with the old binary.
-GC_NUM_EPOCHS_TO_KEEP = 15
+LARGE_GC_NUM_EPOCHS_TO_KEEP = 15
+# Used while the node is running with the new binary.
+DEFAULT_GC_NUM_EPOCHS_TO_KEEP = 5
 
 # Config to track all shards.
 node_config = {
     "tracked_shards": list(range(NUM_SHARDS)),
     # We should have large enough GC window while the node running with the old binary (1.40), because we need to
     # bootstrap the congestion info from the genesis block and the genesis block should not be garbage collected.
-    # The new binary (2.0) has a mechnanism to save the congestion info on disk to be resilient against GC of
+    # The new binary (2.0) has a mechanism to save the congestion info on disk to be resilient against GC of
     # genesis block, however the old binary does not have this mechanism, thus we need to prevent GC to kick in
     # before the node transitions to the new binary. Note that, after restarting the node with the new binary
     # we can switch back to the usual GC window (see below).
     # TODO: This change for GC can be removed when the old binary version becomes 2.0 in this test.
-    "gc_num_epochs_to_keep": GC_NUM_EPOCHS_TO_KEEP,
+    "gc_num_epochs_to_keep": LARGE_GC_NUM_EPOCHS_TO_KEEP,
 }
 
 
@@ -128,7 +130,7 @@ def main():
     unstake_and_stake(nodes[1], node)
 
     height, _ = utils.wait_for_blocks(node, count=1)
-    assert height < EPOCH_LENGTH * GC_NUM_EPOCHS_TO_KEEP, "Node should run without GC"
+    assert height < EPOCH_LENGTH * LARGE_GC_NUM_EPOCHS_TO_KEEP, "Node should run without GC"
 
     node.kill()
 
@@ -139,7 +141,7 @@ def main():
     logging.info("Starting the current node...")
     node.near_root = executables.current.root
     node.binary_name = executables.current.neard
-    node.change_config({"gc_num_epochs_to_keep": 5})
+    node.change_config({"gc_num_epochs_to_keep": DEFAULT_GC_NUM_EPOCHS_TO_KEEP})
     node.start(boot_node=node)
 
     logging.info("Running the current node...")


### PR DESCRIPTION
Related discussion: https://near.zulipchat.com/#narrow/stream/295302-general/topic/Database.20migration.20CI.20check.20is.20consistently.20failing/near/457036240

We fix it by increasing the GC window for the old binary (which does not have the mechanism to compute and save the congestion info in disk, this we lose the genesis block if GC is enabled).
See the comment in the test file for more context.
