### PR TITLE
fix(nayduck): validator_switch

### DIFF
--- a/pytest/tests/sanity/validator_switch.py
+++ b/pytest/tests/sanity/validator_switch.py
@@ -24,10 +24,7 @@ tracked_shards = {
 nodes = start_cluster(
     3, 1, 4, None,
     [["epoch_length", EPOCH_LENGTH], ["block_producer_kickout_threshold", 10],
-     ["chunk_producer_kickout_threshold", 10]], {
-         0: tracked_shards,
-         1: tracked_shards
-     })
+     ["chunk_producer_kickout_threshold", 10]], {3: tracked_shards})
 
 time.sleep(3)
 


### PR DESCRIPTION
Non validator node was not tracking any shard and needs to state sync when it becomes a validator. This test does not test state sync so we made the non validator node track all shards to be ready to become a validator.