### PR TITLE
fix: Fix concurrent fn calls test

### DIFF
--- a/pytest/tests/sanity/concurrent_function_calls.py
+++ b/pytest/tests/sanity/concurrent_function_calls.py
@@ -55,30 +55,32 @@ def process():
         key[0] = i % 10
         data = {
             'method': 'query',
-            'params': { 
-                "request_type": "call_function", 
-                "account_id": acc_id, 
-                "method_name": "read_value", 
-                "finality": "optimistic", 
-                "args_base64": base64.b64encode(bytes(key)).decode("ascii") 
+            'params': {
+                "request_type": "call_function",
+                "account_id": acc_id,
+                "method_name": "read_value",
+                "finality": "optimistic",
+                "args_base64": base64.b64encode(bytes(key)).decode("ascii")
             },
             'id': 'dontcare',
             'jsonrpc': '2.0'
         }
 
         session = requests.Session()
-        retries = Retry(total=5,
-                backoff_factor=0.1)
+        retries = Retry(total=5, backoff_factor=0.1)
 
         session.mount('http://', HTTPAdapter(max_retries=retries))
 
-        res = session.post("http://%s:%s" % nodes[4].rpc_addr(), json=data, timeout=2)
-        
+        res = session.post("http://%s:%s" % nodes[4].rpc_addr(),
+                           json=data,
+                           timeout=2)
+
         assert res.status_code == 200
         res = json.loads(res.text)
         res = int.from_bytes(res["result"]["result"], byteorder='little')
         assert res == (i % 10)
     logger.info("all done")
+
 
 ps = [multiprocessing.Process(target=process, args=()) for i in range(6)]
 for p in ps:

--- a/pytest/tests/sanity/concurrent_function_calls.py
+++ b/pytest/tests/sanity/concurrent_function_calls.py
@@ -5,12 +5,15 @@
 import sys, time
 import base58
 import base64
+import json
 import multiprocessing
 import pathlib
+import requests
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 from cluster import start_cluster
 from configured_logger import logger
+from requests.adapters import HTTPAdapter, Retry
 from transaction import sign_deploy_contract_tx, sign_function_call_tx
 from utils import load_test_contract
 
@@ -45,13 +48,41 @@ for i in range(10):
 time.sleep(3)
 acc_id = nodes[0].signer_key.account_id
 
-# Read values from storage
-for i in range(100):
-    key = bytearray(8)
-    key[0] = i % 10
-    res = nodes[4].call_function(
-        acc_id, 'read_value',
-        base64.b64encode(bytes(key)).decode("ascii"), timeout=10)
-    res = int.from_bytes(res["result"]["result"], byteorder='little')
-    assert res == (i % 10)
-logger.info("all done")
+
+def process():
+    for i in range(100):
+        key = bytearray(8)
+        key[0] = i % 10
+        data = {
+            'method': 'query',
+            'params': { 
+                "request_type": "call_function", 
+                "account_id": acc_id, 
+                "method_name": "read_value", 
+                "finality": "optimistic", 
+                "args_base64": base64.b64encode(bytes(key)).decode("ascii") 
+            },
+            'id': 'dontcare',
+            'jsonrpc': '2.0'
+        }
+
+        session = requests.Session()
+        retries = Retry(total=5,
+                backoff_factor=0.1)
+
+        session.mount('http://', HTTPAdapter(max_retries=retries))
+
+        res = session.post("http://%s:%s" % nodes[4].rpc_addr(), json=data, timeout=2)
+        
+        assert res.status_code == 200
+        res = json.loads(res.text)
+        res = int.from_bytes(res["result"]["result"], byteorder='little')
+        assert res == (i % 10)
+    logger.info("all done")
+
+ps = [multiprocessing.Process(target=process, args=()) for i in range(6)]
+for p in ps:
+    p.start()
+
+for p in ps:
+    p.join()

--- a/pytest/tests/sanity/concurrent_function_calls.py
+++ b/pytest/tests/sanity/concurrent_function_calls.py
@@ -45,22 +45,13 @@ for i in range(10):
 time.sleep(3)
 acc_id = nodes[0].signer_key.account_id
 
-
-def process():
-    for i in range(100):
-        key = bytearray(8)
-        key[0] = i % 10
-        res = nodes[4].call_function(
-            acc_id, 'read_value',
-            base64.b64encode(bytes(key)).decode("ascii"))
-        res = int.from_bytes(res["result"]["result"], byteorder='little')
-        assert res == (i % 10)
-    logger.info("all done")
-
-
-ps = [multiprocessing.Process(target=process, args=()) for i in range(6)]
-for p in ps:
-    p.start()
-
-for p in ps:
-    p.join()
+# Read values from storage
+for i in range(100):
+    key = bytearray(8)
+    key[0] = i % 10
+    res = nodes[4].call_function(
+        acc_id, 'read_value',
+        base64.b64encode(bytes(key)).decode("ascii"), timeout=10)
+    res = int.from_bytes(res["result"]["result"], byteorder='little')
+    assert res == (i % 10)
+logger.info("all done")


### PR DESCRIPTION
The test fails because the HTTP requests for `call_function` get stuck when invoked from `multiprocessing` object, even if number of processes is set to one. 
The node was working as expected.

I solved the issue by using the native python `Session` object to do the requests.