### PR TITLE
fix(epoch-manager): fix nondeterminism in EpochManager::compute_exempted_kickout()

### DIFF
--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -430,12 +430,13 @@ impl EpochManager {
                                 stats.block_stats.expected as i64,
                             )) / 2
                         };
-                    (account, production_ratio)
+                    (production_ratio, account)
                 })
                 .collect::<Vec<_>>();
-            sorted_validators.sort_by_key(|a| a.1);
+            sorted_validators.sort();
+
             let mut exempted_stake: Balance = 0;
-            for (account_id, _) in sorted_validators.into_iter().rev() {
+            for (_, account_id) in sorted_validators.into_iter().rev() {
                 if exempted_stake >= min_keep_stake {
                     break;
                 }

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -2480,8 +2480,8 @@ fn test_validator_kickout_determinism() {
     ]);
     let chunk_stats0: Vec<_> = chunk_stats0.into_iter().rev().collect();
     let chunk_stats_tracker2 = HashMap::from([
-        (0, chunk_stats0.clone().into_iter().collect()),
-        (1, chunk_stats1.clone().into_iter().into_iter().collect()),
+        (0, chunk_stats0.into_iter().collect()),
+        (1, chunk_stats1.into_iter().collect()),
     ]);
     let (_validator_stats, kickouts1) = EpochManager::compute_validators_to_reward_and_kickout(
         &epoch_config,


### PR DESCRIPTION
In this function, we compute and collect ratios of expected blocks and chunks for all validators in the epoch, and we exempt the top validators from being kicked based on the `validator_max_kickout_stake_perc` epoch config field. We build this list from a hashmap, which has nondeterministic iteration order, and then sort by this ratio. But if there are many with the same ratio, then the ones we pick are not deterministic because we don't also sort by account ID. Fix it by also sorting by account ID