### PR TITLE
fix: Revert changes to pipelined runtime implementation

### DIFF
--- a/runtime/runtime/src/congestion_control.rs
+++ b/runtime/runtime/src/congestion_control.rs
@@ -9,7 +9,7 @@ use near_primitives::receipt::{Receipt, ReceiptEnum};
 use near_primitives::types::{EpochInfoProvider, Gas, ShardId};
 use near_primitives::version::ProtocolFeature;
 use near_store::trie::receipts_column_helper::{
-    DelayedReceiptQueue, ReceiptIterator, ShardsOutgoingReceiptBuffer, TrieQueue,
+    DelayedReceiptQueue, ShardsOutgoingReceiptBuffer, TrieQueue,
 };
 use near_store::{StorageError, TrieAccess, TrieUpdate};
 use near_vm_runner::logic::ProtocolVersion;
@@ -443,10 +443,6 @@ impl DelayedReceiptQueueWrapper {
             self.removed_delayed_bytes = safe_add_gas(self.removed_delayed_bytes, delayed_bytes)?;
         }
         Ok(receipt)
-    }
-
-    pub(crate) fn peek_iter<'a>(&'a self, trie_update: &'a TrieUpdate) -> ReceiptIterator<'a> {
-        self.queue.iter(trie_update)
     }
 
     pub(crate) fn len(&self) -> u64 {

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1646,11 +1646,6 @@ impl Runtime {
         Ok(())
     }
 
-    #[instrument(target = "runtime", level = "debug", "process_local_receipts", skip_all, fields(
-        num_receipts = processing_state.local_receipts.len(),
-        gas_burnt = tracing::field::Empty,
-        compute_usage = tracing::field::Empty,
-    ))]
     fn process_local_receipts<'a>(
         &self,
         mut processing_state: &mut ApplyProcessingReceiptState<'a>,
@@ -1661,7 +1656,7 @@ impl Runtime {
     ) -> Result<(), RuntimeError> {
         let local_processing_start = std::time::Instant::now();
         let local_receipts = std::mem::take(&mut processing_state.local_receipts);
-        let local_receipt_count = processing_state.local_receipts.len();
+        let local_receipt_count = local_receipts.len();
         if let Some(prefetcher) = &mut processing_state.prefetcher {
             // Prefetcher is allowed to fail
             let (front, back) = local_receipts.as_slices();
@@ -1670,15 +1665,30 @@ impl Runtime {
         }
 
         let mut prep_lookahead_iter = local_receipts.iter();
+        let mut schedule_preparation = |pstate: &mut ApplyProcessingReceiptState| {
+            let scheduled_receipt_offset = prep_lookahead_iter.position(|peek| {
+                let account_id = peek.receiver_id();
+                let receiver = get_account(&pstate.state_update, account_id);
+                let Ok(Some(receiver)) = receiver else {
+                    tracing::error!(
+                        target: "runtime",
+                        message="unable to read receiver of an upcoming local receipt",
+                        ?account_id,
+                        receipt=%peek.get_hash()
+                    );
+                    return false;
+                };
+                // This returns `true` if work may have been scheduled (thus we currently prepare
+                // actions in at most 2 "interesting" receipts in parallel due to staggering.)
+                pstate.pipeline_manager.submit(peek, &receiver, None)
+            });
+            scheduled_receipt_offset
+        };
         // Advance the preparation by one step (stagger it) so that we're preparing one interesting
         // receipt in advance.
-        let mut next_schedule_after = schedule_contract_preparation(
-            &mut processing_state.pipeline_manager,
-            &processing_state.state_update,
-            &mut prep_lookahead_iter,
-        );
+        let mut next_schedule_index = schedule_preparation(&mut processing_state);
 
-        for receipt in local_receipts.iter() {
+        for (index, receipt) in local_receipts.iter().enumerate() {
             if processing_state.total.compute >= compute_limit
                 || proof_size_limit.is_some_and(|limit| {
                     processing_state.state_update.trie.recorded_storage_size_upper_bound() > limit
@@ -1690,17 +1700,13 @@ impl Runtime {
                     &processing_state.apply_state.config,
                 )?;
             } else {
-                if let Some(nsi) = &mut next_schedule_after {
-                    *nsi = nsi.saturating_sub(1);
-                    if *nsi == 0 {
+                if let Some(nsi) = next_schedule_index {
+                    if index >= nsi {
                         // We're about to process a receipt that has been submitted for
                         // preparation, so lets submit the next one in anticipation that it might
                         // be processed too (it might also be not if we run out of gas/compute.)
-                        next_schedule_after = schedule_contract_preparation(
-                            &mut processing_state.pipeline_manager,
-                            &processing_state.state_update,
-                            &mut prep_lookahead_iter,
-                        );
+                        next_schedule_index = schedule_preparation(&mut processing_state)
+                            .and_then(|adv| nsi.checked_add(1)?.checked_add(adv));
                     }
                 }
                 // NOTE: We don't need to validate the local receipt, because it's just validated in
@@ -1713,10 +1719,6 @@ impl Runtime {
                 )?
             }
         }
-
-        let span = tracing::Span::current();
-        span.record("gas_burnt", processing_state.total.gas);
-        span.record("compute_usage", processing_state.total.compute);
         processing_state.metrics.local_receipts_done(
             local_receipt_count as u64,
             local_processing_start.elapsed(),
@@ -1726,11 +1728,6 @@ impl Runtime {
         Ok(())
     }
 
-    #[instrument(target = "runtime", level = "debug", "process_delayed_receipts", skip_all, fields(
-        num_receipts = processing_state.delayed_receipts.len(),
-        gas_burnt = tracing::field::Empty,
-        compute_usage = tracing::field::Empty,
-    ))]
     fn process_delayed_receipts<'a>(
         &self,
         mut processing_state: &mut ApplyProcessingReceiptState<'a>,
@@ -1743,17 +1740,6 @@ impl Runtime {
         let protocol_version = processing_state.protocol_version;
         let mut delayed_receipt_count = 0;
         let mut processed_delayed_receipts = vec![];
-
-        let mut prep_lookahead_iter = processing_state
-            .delayed_receipts
-            .peek_iter(&processing_state.state_update)
-            .map_while(Result::ok);
-        let mut next_schedule_after = schedule_contract_preparation(
-            &mut processing_state.pipeline_manager,
-            &processing_state.state_update,
-            &mut prep_lookahead_iter,
-        );
-
         while processing_state.delayed_receipts.len() > 0 {
             if processing_state.total.compute >= compute_limit
                 || proof_size_limit.is_some_and(|limit| {
@@ -1762,26 +1748,11 @@ impl Runtime {
             {
                 break;
             }
-
             delayed_receipt_count += 1;
             let receipt = processing_state
                 .delayed_receipts
                 .pop(&mut processing_state.state_update, &processing_state.apply_state.config)?
                 .expect("queue is not empty");
-            if let Some(nsi) = &mut next_schedule_after {
-                *nsi = nsi.saturating_sub(1);
-                if *nsi == 0 {
-                    let mut prep_lookahead_iter = processing_state
-                        .delayed_receipts
-                        .peek_iter(&processing_state.state_update)
-                        .map_while(Result::ok);
-                    next_schedule_after = schedule_contract_preparation(
-                        &mut processing_state.pipeline_manager,
-                        &processing_state.state_update,
-                        &mut prep_lookahead_iter,
-                    );
-                }
-            }
 
             if let Some(prefetcher) = &mut processing_state.prefetcher {
                 // Prefetcher is allowed to fail
@@ -1809,9 +1780,6 @@ impl Runtime {
             )?;
             processed_delayed_receipts.push(receipt);
         }
-        let span = tracing::Span::current();
-        span.record("gas_burnt", processing_state.total.gas);
-        span.record("compute_usage", processing_state.total.compute);
         processing_state.metrics.delayed_receipts_done(
             delayed_receipt_count,
             delayed_processing_start.elapsed(),
@@ -1822,11 +1790,6 @@ impl Runtime {
         Ok(processed_delayed_receipts)
     }
 
-    #[instrument(target = "runtime", level = "debug", "process_incoming_receipts", skip_all, fields(
-        num_receipts = processing_state.incoming_receipts.len(),
-        gas_burnt = tracing::field::Empty,
-        compute_usage = tracing::field::Empty,
-    ))]
     fn process_incoming_receipts<'a>(
         &self,
         mut processing_state: &mut ApplyProcessingReceiptState<'a>,
@@ -1841,16 +1804,6 @@ impl Runtime {
             // Prefetcher is allowed to fail
             _ = prefetcher.prefetch_receipts_data(&processing_state.incoming_receipts);
         }
-
-        let mut prep_lookahead_iter = processing_state.incoming_receipts.iter();
-        // Advance the preparation by one step (stagger it) so that we're preparing one interesting
-        // receipt in advance.
-        let mut next_schedule_after = schedule_contract_preparation(
-            &mut processing_state.pipeline_manager,
-            &processing_state.state_update,
-            &mut prep_lookahead_iter,
-        );
-
         for receipt in processing_state.incoming_receipts.iter() {
             // Validating new incoming no matter whether we have available gas or not. We don't
             // want to store invalid receipts in state as delayed.
@@ -1871,20 +1824,6 @@ impl Runtime {
                     &processing_state.apply_state.config,
                 )?;
             } else {
-                if let Some(nsi) = &mut next_schedule_after {
-                    *nsi = nsi.saturating_sub(1);
-                    if *nsi == 0 {
-                        // We're about to process a receipt that has been submitted for
-                        // preparation, so lets submit the next one in anticipation that it might
-                        // be processed too (it might also be not if we run out of gas/compute.)
-                        next_schedule_after = schedule_contract_preparation(
-                            &mut processing_state.pipeline_manager,
-                            &processing_state.state_update,
-                            &mut prep_lookahead_iter,
-                        );
-                    }
-                }
-
                 self.process_receipt_with_metrics(
                     &receipt,
                     &mut processing_state,
@@ -1893,9 +1832,6 @@ impl Runtime {
                 )?;
             }
         }
-        let span = tracing::Span::current();
-        span.record("gas_burnt", processing_state.total.gas);
-        span.record("compute_usage", processing_state.total.compute);
         processing_state.metrics.incoming_receipts_done(
             processing_state.incoming_receipts.len() as u64,
             incoming_processing_start.elapsed(),
@@ -2440,96 +2376,6 @@ struct ApplyProcessingReceiptState<'a> {
     incoming_receipts: &'a [Receipt],
     delayed_receipts: DelayedReceiptQueueWrapper,
     pipeline_manager: pipelining::ReceiptPreparationPipeline,
-}
-
-trait MaybeRefReceipt {
-    fn as_ref(&self) -> &Receipt;
-}
-
-impl MaybeRefReceipt for Receipt {
-    fn as_ref(&self) -> &Receipt {
-        self
-    }
-}
-
-impl<'a> MaybeRefReceipt for &'a Receipt {
-    fn as_ref(&self) -> &Receipt {
-        *self
-    }
-}
-
-/// Schedule a one receipt for contract preparation.
-///
-/// The caller should call this method again after the returned number of receipts from `iterator`
-/// are processed.
-fn schedule_contract_preparation<'b, R: MaybeRefReceipt>(
-    pipeline_manager: &mut pipelining::ReceiptPreparationPipeline,
-    state_update: &TrieUpdate,
-    mut iterator: impl Iterator<Item = R>,
-) -> Option<usize> {
-    let scheduled_receipt_offset = iterator.position(|peek| {
-        let peek = peek.as_ref();
-        let account_id = peek.receiver_id();
-        let receiver = get_account(state_update, account_id);
-        let Ok(Some(receiver)) = receiver else {
-            // Most likely reason this can happen is because the receipt is for an account that
-            // does not yet exist. This is a routine occurrence as accounts are created by sending
-            // some NEAR to a name that's about to be created.
-            return false;
-        };
-
-        // We need to inspect each receipt recursively in case these are data receipts, thus a
-        // function.
-        fn handle_receipt(
-            mgr: &mut ReceiptPreparationPipeline,
-            state_update: &TrieUpdate,
-            receiver: &Account,
-            account_id: &AccountId,
-            receipt: &Receipt,
-        ) -> bool {
-            match receipt.receipt() {
-                ReceiptEnum::Action(_) | ReceiptEnum::PromiseYield(_) => {
-                    // This returns `true` if work may have been scheduled (thus we currently
-                    // prepare actions in at most 2 "interesting" receipts in parallel due to
-                    // staggering.)
-                    mgr.submit(receipt, &receiver, None)
-                }
-                ReceiptEnum::Data(dr) => {
-                    let key = TrieKey::PostponedReceiptId {
-                        receiver_id: account_id.clone(),
-                        data_id: dr.data_id,
-                    };
-                    let Ok(Some(rid)) = get::<CryptoHash>(state_update, &key) else {
-                        return false;
-                    };
-                    let key = TrieKey::PendingDataCount {
-                        receiver_id: account_id.clone(),
-                        receipt_id: rid,
-                    };
-                    let Ok(Some(data_count)) = get::<u32>(state_update, &key) else {
-                        return false;
-                    };
-                    if data_count > 1 {
-                        return false;
-                    }
-                    let Ok(Some(pr)) = get_postponed_receipt(state_update, account_id, rid) else {
-                        return false;
-                    };
-                    return handle_receipt(mgr, state_update, receiver, account_id, &pr);
-                }
-                ReceiptEnum::PromiseResume(dr) => {
-                    let Ok(Some(yr)) =
-                        get_promise_yield_receipt(state_update, account_id, dr.data_id)
-                    else {
-                        return false;
-                    };
-                    return handle_receipt(mgr, state_update, receiver, account_id, &yr);
-                }
-            }
-        }
-        handle_receipt(pipeline_manager, state_update, &receiver, account_id, peek)
-    })?;
-    Some(scheduled_receipt_offset.saturating_add(1))
 }
 
 /// Interface provided for gas cost estimations.

--- a/runtime/runtime/src/metrics.rs
+++ b/runtime/runtime/src/metrics.rs
@@ -1,10 +1,10 @@
 use crate::congestion_control::ReceiptSink;
 use crate::ApplyState;
 use near_o11y::metrics::{
-    exponential_buckets, linear_buckets, try_create_counter, try_create_counter_vec,
-    try_create_gauge_vec, try_create_histogram_vec, try_create_int_counter,
-    try_create_int_counter_vec, try_create_int_gauge_vec, Counter, CounterVec, GaugeVec,
-    HistogramVec, IntCounter, IntCounterVec, IntGaugeVec,
+    exponential_buckets, linear_buckets, try_create_counter_vec, try_create_gauge_vec,
+    try_create_histogram_vec, try_create_int_counter, try_create_int_counter_vec,
+    try_create_int_gauge_vec, CounterVec, GaugeVec, HistogramVec, IntCounter, IntCounterVec,
+    IntGaugeVec,
 };
 use near_parameters::config::CongestionControlConfig;
 use near_primitives::congestion_info::CongestionInfo;
@@ -438,72 +438,6 @@ pub(crate) static CHUNK_RECEIPTS_LIMITED_BY: LazyLock<IntCounterVec> = LazyLock:
         "near_chunk_receipts_limited_by",
         "Number of chunks where the number of processed receipts was limited by a certain factor.",
         &["shard_id", "limited_by"],
-    )
-    .unwrap()
-});
-
-pub(crate) static PIPELINING_ACTIONS_SUBMITTED: LazyLock<IntCounter> = LazyLock::new(|| {
-    try_create_int_counter(
-        "near_pipelininig_actions_submitted_count",
-        "Number of actions submitted to the pipeline for preparation.",
-    )
-    .unwrap()
-});
-
-pub(crate) static PIPELINING_ACTIONS_PREPARED_IN_MAIN_THREAD: LazyLock<IntCounter> =
-    LazyLock::new(|| {
-        try_create_int_counter(
-            "near_pipelininig_actions_prepared_in_main_thread_count",
-            "Number of actions prepared in the main thread, rather than the pipeline.",
-        )
-        .unwrap()
-    });
-
-pub(crate) static PIPELINING_ACTIONS_NOT_SUBMITTED: LazyLock<IntCounter> = LazyLock::new(|| {
-    try_create_int_counter(
-        "near_pipelininig_actions_not_submitted_count",
-        "Number of actions prepared in the main thread, because they were never submitted.",
-    )
-    .unwrap()
-});
-
-pub(crate) static PIPELINING_ACTIONS_FOUND_PREPARED: LazyLock<IntCounter> = LazyLock::new(|| {
-    try_create_int_counter(
-        "near_pipelininig_actions_found_prepared_count",
-        "Number of actions that were found prepared by the time they were needed.",
-    )
-    .unwrap()
-});
-
-pub(crate) static PIPELINING_ACTIONS_WAITING_TIME: LazyLock<Counter> = LazyLock::new(|| {
-    try_create_counter(
-        "near_pipelininig_waiting_seconds_total",
-        "Time spent waiting for the task results to be ready.",
-    )
-    .unwrap()
-});
-
-pub(crate) static PIPELINING_ACTIONS_MAIN_THREAD_WORKING_TIME: LazyLock<Counter> =
-    LazyLock::new(|| {
-        try_create_counter(
-            "near_pipelininig_main_thread_seconds_total",
-            "Time spent preparing contracts on the main thread (for whatever reason.)",
-        )
-        .unwrap()
-    });
-
-pub(crate) static PIPELINING_ACTIONS_TASK_DELAY_TIME: LazyLock<Counter> = LazyLock::new(|| {
-    try_create_counter(
-        "near_pipelininig_delay_seconds_total",
-        "Time spent waiting for the preparation task to be scheduled on thread pool.",
-    )
-    .unwrap()
-});
-
-pub(crate) static PIPELINING_ACTIONS_TASK_WORKING_TIME: LazyLock<Counter> = LazyLock::new(|| {
-    try_create_counter(
-        "near_pipelininig_working_seconds_total",
-        "Time spent working to produce the results for work scheduled on the pipeline.",
     )
     .unwrap()
 });

--- a/runtime/runtime/src/pipelining.rs
+++ b/runtime/runtime/src/pipelining.rs
@@ -1,12 +1,6 @@
 #![allow(dead_code)]
 
 use crate::ext::RuntimeContractExt;
-use crate::metrics::{
-    PIPELINING_ACTIONS_FOUND_PREPARED, PIPELINING_ACTIONS_MAIN_THREAD_WORKING_TIME,
-    PIPELINING_ACTIONS_NOT_SUBMITTED, PIPELINING_ACTIONS_PREPARED_IN_MAIN_THREAD,
-    PIPELINING_ACTIONS_SUBMITTED, PIPELINING_ACTIONS_TASK_DELAY_TIME,
-    PIPELINING_ACTIONS_TASK_WORKING_TIME, PIPELINING_ACTIONS_WAITING_TIME,
-};
 use near_parameters::RuntimeConfig;
 use near_primitives::account::Account;
 use near_primitives::action::Action;
@@ -19,7 +13,6 @@ use near_vm_runner::logic::{GasCounter, ProtocolVersion};
 use near_vm_runner::{ContractRuntimeCache, PreparedContract};
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Condvar, Mutex};
-use std::time::Instant;
 
 pub(crate) struct ReceiptPreparationPipeline {
     /// Mapping from a Receipt's ID to a parallel "task" to prepare the receipt's data.
@@ -154,22 +147,25 @@ impl ReceiptPreparationPipeline {
                     let chain_id = self.chain_id.clone();
                     let protocol_version = self.protocol_version;
                     let code_hash = account.code_hash();
-                    let created = Instant::now();
-                    let method_name = function_call.method_name.clone();
                     let status = Mutex::new(PrepareTaskStatus::Pending);
                     let task = Arc::new(PrepareTask { status, condvar: Condvar::new() });
+                    let method_name = function_call.method_name.clone();
                     entry.insert(Arc::clone(&task));
-                    PIPELINING_ACTIONS_SUBMITTED.inc_by(1);
+                    // FIXME: don't spawn all tasks at once. We want to keep some capacity for
+                    // other things and also to control (in a way) the concurrency here.
                     rayon::spawn_fifo(move || {
                         let task_status = {
                             let mut status = task.status.lock().expect("mutex lock");
                             std::mem::replace(&mut *status, PrepareTaskStatus::Working)
                         };
-                        let PrepareTaskStatus::Pending = task_status else {
-                            return;
+                        match &task_status {
+                            PrepareTaskStatus::Pending => {}
+                            PrepareTaskStatus::Working => return,
+                            // TODO: seeing Prepared here may mean there's double spawning for the
+                            // same receipt index. Maybe output a warning?
+                            PrepareTaskStatus::Prepared(..) => return,
+                            PrepareTaskStatus::Finished => return,
                         };
-                        PIPELINING_ACTIONS_TASK_DELAY_TIME.inc_by(created.elapsed().as_secs_f64());
-                        let start = Instant::now();
                         let contract = prepare_function_call(
                             &storage,
                             cache.as_deref(),
@@ -184,7 +180,6 @@ impl ReceiptPreparationPipeline {
 
                         let mut status = task.status.lock().expect("mutex lock");
                         *status = PrepareTaskStatus::Prepared(contract);
-                        PIPELINING_ACTIONS_TASK_WORKING_TIME.inc_by(start.elapsed().as_secs_f64());
                         task.condvar.notify_all();
                     });
                     any_function_calls = true;
@@ -235,17 +230,8 @@ impl ReceiptPreparationPipeline {
         };
         let key = PrepareTaskKey { receipt_id: receipt.get_hash(), action_index };
         let Some(task) = self.map.get(&key) else {
-            let start = Instant::now();
             let gas_counter = self.gas_counter(view_config.as_ref(), function_call.gas);
-            if !self.block_accounts.contains(account_id) {
-                tracing::debug!(
-                    target: "runtime::pipelining",
-                    message="function call task was not submitted for preparation",
-                    receipt=%receipt.get_hash(),
-                    action_index,
-                );
-            }
-            let result = prepare_function_call(
+            return prepare_function_call(
                 &self.storage,
                 self.contract_cache.as_deref(),
                 &self.chain_id,
@@ -256,9 +242,6 @@ impl ReceiptPreparationPipeline {
                 &account_id,
                 &function_call.method_name,
             );
-            PIPELINING_ACTIONS_NOT_SUBMITTED.inc_by(1);
-            PIPELINING_ACTIONS_MAIN_THREAD_WORKING_TIME.inc_by(start.elapsed().as_secs_f64());
-            return result;
         };
         let mut status_guard = task.status.lock().unwrap();
         loop {
@@ -267,40 +250,26 @@ impl ReceiptPreparationPipeline {
                 PrepareTaskStatus::Pending => {
                     *status_guard = PrepareTaskStatus::Finished;
                     drop(status_guard);
-                    let start = Instant::now();
-                    tracing::trace!(
-                        target: "runtime::pipelining",
-                        message="function call preparation on the main thread",
-                        receipt=%receipt.get_hash(),
-                        action_index
-                    );
+
                     let gas_counter = self.gas_counter(view_config.as_ref(), function_call.gas);
-                    let cache = self.contract_cache.as_ref().map(|c| c.handle());
-                    let method_name = function_call.method_name.clone();
                     let contract = prepare_function_call(
                         &self.storage,
-                        cache.as_deref(),
+                        self.contract_cache.as_deref(),
                         &self.chain_id,
                         self.protocol_version,
                         Arc::clone(&self.config.wasm_config),
                         gas_counter,
                         code_hash,
                         &account_id,
-                        &method_name,
+                        &function_call.method_name,
                     );
-                    PIPELINING_ACTIONS_PREPARED_IN_MAIN_THREAD.inc_by(1);
-                    PIPELINING_ACTIONS_MAIN_THREAD_WORKING_TIME
-                        .inc_by(start.elapsed().as_secs_f64());
                     return contract;
                 }
                 PrepareTaskStatus::Working => {
-                    let start = Instant::now();
                     status_guard = task.condvar.wait(status_guard).unwrap();
-                    PIPELINING_ACTIONS_WAITING_TIME.inc_by(start.elapsed().as_secs_f64());
                     continue;
                 }
                 PrepareTaskStatus::Prepared(c) => {
-                    PIPELINING_ACTIONS_FOUND_PREPARED.inc_by(1);
                     *status_guard = PrepareTaskStatus::Finished;
                     return c;
                 }


### PR DESCRIPTION
This reverts commit 781805d5075c7e8fffb1cbe3512df90c2d461a97

The commit above is causing issues in processing chunks both in testnet and mainnet. The issue can be reproduced on an healthy node by applying the commit and then running:

```
/home/ubuntu/neard view-state -t hot apply-range --start-index 125812312 --end-index 125812312 --shard-id 2 --storage trie-free sequential
```

Note: block 125812312 will sooner or later be GC'd so the repro steps will need an archival node and cold storage.

Fix tested locally on a mainnet canary.