### PR TITLE
fix: Fix test rpc_tx_forwarding nayduck test

### DIFF
--- a/pytest/tests/sanity/rpc_tx_forwarding.py
+++ b/pytest/tests/sanity/rpc_tx_forwarding.py
@@ -4,20 +4,21 @@
 # The second observer is used to query balances
 # We then send one transaction synchronously through the first observer, and expect it to pass and apply due to rpc tx forwarding
 
-import sys, time, base58, random
+import sys, base58
 import pathlib
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 
 from cluster import start_cluster
 from configured_logger import logger
-from utils import TxContext
 from transaction import sign_payment_tx
+import utils
 
 nodes = start_cluster(
     2, 2, 4, None, [["min_gas_price", 0], ["epoch_length", 10],
                     ["block_producer_kickout_threshold", 70]], {
                         0: {
+                            "tracked_shards": [],
                             "consensus": {
                                 "state_sync_timeout": {
                                     "secs": 2,
@@ -26,6 +27,7 @@ nodes = start_cluster(
                             }
                         },
                         1: {
+                            "tracked_shards": [],
                             "consensus": {
                                 "state_sync_timeout": {
                                     "secs": 2,
@@ -34,6 +36,7 @@ nodes = start_cluster(
                             }
                         },
                         2: {
+                            "tracked_shards": [],
                             "consensus": {
                                 "state_sync_timeout": {
                                     "secs": 2,
@@ -52,25 +55,33 @@ nodes = start_cluster(
                         }
                     })
 
-time.sleep(3)
-started = time.time()
+_ = utils.wait_for_blocks(nodes[3], count=3)
 
 old_balances = [
-    int(nodes[-1].get_account("test%s" % x)['result']['amount'])
+    int(nodes[3].get_account("test%s" % x)['result']['amount'])
     for x in [0, 1, 2]
 ]
 logger.info(f"BALANCES BEFORE {old_balances}")
 
-hash_ = nodes[1].get_latest_block().hash
-
-time.sleep(5)
-
+# NOTE: While we can forward a transaction through a node tracking no shards,
+# the result of the transaction should be fetched from a node tracking the respective shard.
+# Thus, while we sent the transaction via node2, we fetch the result from node3.
+_, hash = utils.wait_for_blocks(nodes[3], count=1)
 tx = sign_payment_tx(nodes[0].signer_key, 'test1', 100, 1,
-                     base58.b58decode(hash_.encode('utf8')))
-logger.info(nodes[-2].send_tx_and_wait(tx, timeout=20))
+                     base58.b58decode(hash.encode('utf8')))
+result = nodes[2].send_tx(tx)
+assert 'result' in result and 'error' not in result, (
+    'Expected "result" and no "error" in response, got: {}'.format(result))
+tx_hash = result['result']
+
+_ = utils.wait_for_blocks(nodes[3], count=3)
+
+result = nodes[3].get_tx(tx_hash, 'test1', timeout=10)
+assert 'result' in result and 'error' not in result, (
+    'Expected "result" and no "error" in response, got: {}'.format(result))
 
 new_balances = [
-    int(nodes[-1].get_account("test%s" % x)['result']['amount'])
+    int(nodes[3].get_account("test%s" % x)['result']['amount'])
     for x in [0, 1, 2]
 ]
 logger.info(f"BALANCES AFTER {new_balances}")


### PR DESCRIPTION
The problem in rpc_tx_forwarding is that it attempts to run `send_tx_and_wait` function (which both sends the tx and fetches its result) on a node tracking no shards. Forwarding transaction in `send_tx_and_wait` works, but fetching the result does not work for a node tracking no shard. Splitting it into two parts, sending tx with the same node but fetching the tx result from another node makes the test pass.

We also replace sleep functions with waiting for few blocks.