### PR TITLE
fix: remove contradictory gas limit check

### DIFF
--- a/chain/chain/src/validate.rs
+++ b/chain/chain/src/validate.rs
@@ -154,10 +154,6 @@ pub fn validate_chunk_with_chunk_extra_and_receipts_root(
         return Err(Error::InvalidValidatorProposals);
     }
 
-    if prev_chunk_extra.gas_limit() != chunk_header.gas_limit() {
-        return Err(Error::InvalidGasLimit);
-    }
-
     if prev_chunk_extra.gas_used() != chunk_header.prev_gas_used() {
         return Err(Error::InvalidGasUsed);
     }


### PR DESCRIPTION
`validate_chunk_with_chunk_extra_and_receipts_root` compares `prev_chunk_extra.gas_limit()` and `chunk_header.gas_limit()` twice:

1. In the first comparison they must be equal.
2. A few lines down they might differ within the bounds of `GAS_LIMIT_ADJUSTMENT_FACTOR`.

If I'm not missing anything here, one of these checks should be removed. Since there is a `GAS_LIMIT_ADJUSTMENT_FACTOR`, I assume gas limit changes should be possible, so this PR removes the first check. Or has anything changed that requires gas limits of `prev_chunk_extra` and `chunk_header` to be equal now?