### PR TITLE
memtrie: improve the performance of memtrie_lookup

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,4 +4,4 @@
 rustflags = ["-Cforce-unwind-tables=y"]
 
 [target.'cfg(target_arch = "x86_64")']
-rustflags = ["-Ctarget-feature=+sse2,+ssse3,+sse4.1,+sse4.2,+sha", "-Cforce-unwind-tables=y"]
+rustflags = ["-Ctarget-feature=+sse2,+ssse3,+sse4.1,+sse4.2,+sha,+popcnt,+fma,+bmi,+bmi2,+lzcnt,+movbe,+pclmul,+sahf", "-Cforce-unwind-tables=y"]

--- a/core/store/src/trie/mem/arena/mod.rs
+++ b/core/store/src/trie/mem/arena/mod.rs
@@ -285,6 +285,7 @@ impl<'a, Memory: ArenaMemory> ArenaSlice<'a, Memory> {
 
     /// Reads an usize at the given offset in the slice (bounds checked),
     /// and returns it as a pointer.
+    #[inline]
     pub fn read_ptr_at(&self, pos: usize) -> ArenaPtr<'a, Memory> {
         let pos = ArenaPos::try_from_slice(&self.raw_slice()[pos..][..size_of::<usize>()]).unwrap();
         ArenaPtr { arena: self.arena, pos }

--- a/core/store/src/trie/mem/flexible_data/children.rs
+++ b/core/store/src/trie/mem/flexible_data/children.rs
@@ -84,16 +84,35 @@ impl<'a, M: ArenaMemory> ChildrenView<'a, M> {
 
     /// Converts to a Children struct used in RawTrieNode.
     pub fn to_children(&self) -> Children {
-        let mut children = Children::default();
-        let mut j = 0;
-        for i in 0..16 {
-            if self.mask & (1 << i) != 0 {
-                let child = MemTrieNodePtr::from(self.children.read_ptr_at(j));
-                children.0[i] = Some(child.view().node_hash());
-                j += size_of::<usize>();
+        let mut nodes = [None; 16];
+        if self.mask == 0 {
+            return Children(nodes);
+        };
+
+        let mut node_ptrs = [None; 16];
+        let mut j = size_of::<usize>() * self.mask.count_ones() as usize;
+        // Execute all `read_ptr_at` in reverse to avoid repeat bound checks.
+        // Additionally, issue reads for the node kinds before moving on to compute sha256 hashes,
+        // thus hopefully giving CPU more time to load the relevant lines into the cache.
+        for i in (0..16).rev() {
+            let bit = self.mask & (1 << i);
+            if bit != 0 {
+                j -= size_of::<usize>();
+                let ptr = MemTrieNodePtr::from(self.children.read_ptr_at(j));
+                let kind = ptr.get_kind();
+                node_ptrs[i] = Some((ptr, kind));
             }
         }
-        children
+
+        for (node, node_ptr) in std::iter::zip(nodes.iter_mut().rev(), node_ptrs.into_iter().rev())
+        {
+            if let Some((node_ptr, kind)) = node_ptr {
+                let node_view = node_ptr.view_kind(kind);
+                *node = Some(node_view.node_hash());
+            }
+        }
+
+        Children(nodes)
     }
 
     /// Iterates only through existing children.

--- a/core/store/src/trie/mem/node/encoding.rs
+++ b/core/store/src/trie/mem/node/encoding.rs
@@ -12,11 +12,19 @@ use std::mem::size_of;
 use smallvec::SmallVec;
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, BorshSerialize, BorshDeserialize)]
+#[borsh(use_discriminant = true)]
 pub(crate) enum NodeKind {
-    Leaf,
-    Extension,
-    Branch,
-    BranchWithValue,
+    Leaf = 0,
+    Extension = 1,
+    Branch = 2,
+    BranchWithValue = 3,
+}
+
+impl NodeKind {
+    const DISCRIMINANT_LEAF: u8 = Self::Leaf as u8;
+    const DISCRIMINANT_EXTENSION: u8 = Self::Extension as u8;
+    const DISCRIMINANT_BRANCH: u8 = Self::Branch as u8;
+    const DISCRIMINANT_BRANCH_WITH_VALUE: u8 = Self::BranchWithValue as u8;
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]
@@ -260,15 +268,16 @@ impl<'a, M: ArenaMemory> MemTrieNodePtr<'a, M> {
     /// Decodes the data.
     pub(crate) fn view_impl(&self) -> MemTrieNodeView<'a, M> {
         let mut decoder = self.decoder();
-        let kind = decoder.peek::<CommonHeader>().kind;
+        let header = self.ptr.slice(0, CommonHeader::SERIALIZED_SIZE).raw_slice();
+        let kind = header[CommonHeader::SERIALIZED_SIZE - 1];
         match kind {
-            NodeKind::Leaf => {
+            NodeKind::DISCRIMINANT_LEAF => {
                 let header = decoder.decode::<LeafHeader>();
                 let extension = decoder.decode_flexible(&header.extension);
                 let value = decoder.decode_flexible(&header.value);
                 MemTrieNodeView::Leaf { extension, value }
             }
-            NodeKind::Extension => {
+            NodeKind::DISCRIMINANT_EXTENSION => {
                 let header = decoder.decode::<ExtensionHeader>();
                 let extension = decoder.decode_flexible(&header.extension);
                 MemTrieNodeView::Extension {
@@ -278,7 +287,7 @@ impl<'a, M: ArenaMemory> MemTrieNodePtr<'a, M> {
                     child: MemTrieNodePtr::from(self.ptr.arena().ptr(header.child)),
                 }
             }
-            NodeKind::Branch => {
+            NodeKind::DISCRIMINANT_BRANCH => {
                 let header = decoder.decode::<BranchHeader>();
                 let children = decoder.decode_flexible(&header.children);
                 MemTrieNodeView::Branch {
@@ -287,7 +296,7 @@ impl<'a, M: ArenaMemory> MemTrieNodePtr<'a, M> {
                     children,
                 }
             }
-            NodeKind::BranchWithValue => {
+            NodeKind::DISCRIMINANT_BRANCH_WITH_VALUE => {
                 let header = decoder.decode::<BranchWithValueHeader>();
                 let children = decoder.decode_flexible(&header.children);
                 let value = decoder.decode_flexible(&header.value);
@@ -298,6 +307,7 @@ impl<'a, M: ArenaMemory> MemTrieNodePtr<'a, M> {
                     value,
                 }
             }
+            _ => panic!("unknown node type"),
         }
     }
 

--- a/core/store/src/trie/mem/node/encoding.rs
+++ b/core/store/src/trie/mem/node/encoding.rs
@@ -265,11 +265,15 @@ impl<'a, M: ArenaMemory> MemTrieNodePtr<'a, M> {
         RawDecoder::new(self.ptr)
     }
 
-    /// Decodes the data.
-    pub(crate) fn view_impl(&self) -> MemTrieNodeView<'a, M> {
-        let mut decoder = self.decoder();
+    #[inline]
+    pub(crate) fn get_kind(&self) -> u8 {
         let header = self.ptr.slice(0, CommonHeader::SERIALIZED_SIZE).raw_slice();
-        let kind = header[CommonHeader::SERIALIZED_SIZE - 1];
+        header[CommonHeader::SERIALIZED_SIZE - 1]
+    }
+
+    /// Decodes the data.
+    pub(crate) fn view_kind(&self, kind: u8) -> MemTrieNodeView<'a, M> {
+        let mut decoder = self.decoder();
         match kind {
             NodeKind::DISCRIMINANT_LEAF => {
                 let header = decoder.decode::<LeafHeader>();

--- a/core/store/src/trie/mem/node/mod.rs
+++ b/core/store/src/trie/mem/node/mod.rs
@@ -72,7 +72,7 @@ impl<'a, M: ArenaMemory> MemTrieNodePtr<'a, M> {
     }
 
     pub fn view(&self) -> MemTrieNodeView<'a, M> {
-        self.view_impl()
+        self.view_kind(self.get_kind())
     }
 
     pub fn id(&self) -> MemTrieNodeId {


### PR DESCRIPTION
This set of changes applies a set of small changes which all ultimately end up in a some appreciable wins to the performance of memtrie_lookup function.

Although the two profiles I'm about to reference come from distinct workloads (they are 60 seconds of recording of a node tracking mainnet 2 days across, on different machines) the contextual information suggests that these two profiles are roughly comparable still (in particular the duration of `node_hash` and `decode` between the two profiles is pretty similar.) Here's the [old run](https://share.firefox.dev/3YO6es2) where you can see that `view_impl` is taking a relatively obscene amount of time in relation to what it is doing. In particular samples were showing that reading the one header byte was accounting for ~70% of the total runtime! And here's the [profile after these changes](https://share.firefox.dev/4dFJrTT). You can see `view_impl` (now `view_kind`) still taking a substantial amount of time, but overall time for this function and `memtrie_lookup` itself is appreciably lower.

I have root-caused the majority of the performance problem to come from the fact that there's a double-dereference needed to execute `get_kind` and other memtrie data accesses and that it was causing the CPU to stall, as these data were immediately used to execute an unpredictable multi-branch (the match.) That meant that the CPU had a penalty worth a full memory access latency for each execution of this `view_impl` function.

I have explored using memory prefetching instructions (`prefetcht*` on x86_64) but have found it to be difficult to apply in such a way that gives me the desired results. The alternative approach of splitting the loop in `to_children` was much more successful. Loading all the (up-to) 16 kinds through the double dereference into an array (fully pipelined with no data dependencies) in the first loop gives the CPU sufficient early notice on where the data will be coming from. The code then moves on to process nodes in sequence as before, but by the time it gets there (or in the worst case -- by the time it gets around to processing the 2nd element) data for all the children will have been loaded into the caches already.

One somewhat less obvious change is the one that I made to `target_feature` list. I was seeing that LLVM was not using `popcnt` for `count_ones` and then realized that since we require `sha` anyway, I might as well explicitly specify all the other features that are ~guaranteed to exist in implementations where SHA-NI is already available. I have avoided enabling the big ones such as `avx`, but the others, to the best of my knowledge, are fine wine.