### PR TITLE
feat: disable prefetch and shard cache when memtrie is enabled

### DIFF
--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -113,13 +113,17 @@ impl ShardTries {
         is_view: bool,
         block_hash: Option<CryptoHash>,
     ) -> Trie {
+        // Do not use memtries for view queries, for two reasons: memtries do not provide historical state,
+        // and also this can introduce lock contention on memtries.
+        let memtries = if is_view { None } else { self.get_mem_tries(shard_uid) };
         let cache = self.get_trie_cache_for(shard_uid, is_view);
         // Do not enable prefetching on view caches.
         // 1) Performance of view calls is not crucial.
         // 2) A lot of the prefetcher code assumes there is only one "main-thread" per shard active.
         //    If you want to enable it for view calls, at least make sure they don't share
         //    the `PrefetchApi` instances with the normal calls.
-        let prefetch_enabled = !is_view && self.0.trie_config.prefetch_enabled();
+        let prefetch_enabled =
+            !is_view && memtries.is_none() && self.0.trie_config.prefetch_enabled();
         let prefetch_api = prefetch_enabled.then(|| {
             self.0
                 .prefetchers
@@ -147,9 +151,6 @@ impl ShardTries {
         ));
         let flat_storage_chunk_view = block_hash
             .and_then(|block_hash| self.0.flat_storage_manager.chunk_view(shard_uid, block_hash));
-        // Do not use memtries for view queries, for two reasons: memtries do not provide historical state,
-        // and also this can introduce lock contention on memtries.
-        let memtries = if is_view { None } else { self.get_mem_tries(shard_uid) };
         Trie::new_with_memtries(storage, memtries, state_root, flat_storage_chunk_view)
     }
 

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -119,18 +119,17 @@ impl ShardTries {
         is_view: bool,
         block_hash: Option<CryptoHash>,
     ) -> Trie {
-        // Do not use memtries for view queries, for two reasons: memtries do not provide historical state,
-        // and also this can introduce lock contention on memtries.
-        let memtries = if is_view { None } else { self.get_mem_tries(shard_uid) };
         let storage: Arc<dyn TrieStorage> =
             if let Some(cache) = self.get_trie_cache_for(shard_uid, is_view) {
                 Arc::new(self.create_caching_storage(cache, shard_uid, is_view))
             } else {
                 Arc::new(TrieDBStorage::new(self.0.store.clone(), shard_uid))
             };
-
         let flat_storage_chunk_view = block_hash
             .and_then(|block_hash| self.0.flat_storage_manager.chunk_view(shard_uid, block_hash));
+        // Do not use memtries for view queries, for two reasons: memtries do not provide historical state,
+        // and also this can introduce lock contention on memtries.
+        let memtries = if is_view { None } else { self.get_mem_tries(shard_uid) };
         Trie::new_with_memtries(storage, memtries, state_root, flat_storage_chunk_view)
     }
 


### PR DESCRIPTION
Part of #11912.

See [zulip thread](https://near.zulipchat.com/#narrow/stream/313099-storage/topic/Disabling.20prefetcher.20when.20memtrie.20is.20enabled/near/462370532) for more context around removing prefetcher.

Shard cache is removed since it doesn't provide any additional caching on top of memtrie since `TRIE_LIMIT_CACHED_VALUE_SIZE` value is lower than `INLINE_DISK_VALUE_THRESHOLD`. This was confirmed by `near_shard_cache_hits` metric. 