### PR TITLE
chore: fix feature dependencies in near-crypto crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4228,6 +4228,7 @@ dependencies = [
  "near-schema-checker-lib",
  "near-stdx",
  "primitive-types 0.10.1",
+ "rand",
  "secp256k1",
  "serde",
  "serde_json",

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -32,6 +32,7 @@ subtle.workspace = true
 thiserror.workspace = true
 near-config-utils.workspace = true
 near-schema-checker-lib.workspace = true
+rand = { workspace = true, default-features = false, optional = true }
 
 [dev-dependencies]
 bolero.workspace = true
@@ -42,7 +43,7 @@ curve25519-dalek = { workspace = true, features = ["rand_core"] }
 
 [features]
 default = ["rand"]
-rand = ["secp256k1/rand", "ed25519-dalek/rand_core"]
+rand = ["secp256k1/rand", "rand/getrandom", "ed25519-dalek/rand_core"]
 
 protocol_schema = [
     "near-schema-checker-lib/protocol_schema",


### PR DESCRIPTION
Unfortunately Rust does not appear to have a neat way to enable `getrandom` feature of `rand` that's re-exported by `secp256k1` requiring some synchronization between versions in the future.