### PR TITLE
chore fix cargo dependencies

### DIFF
--- a/chain/chain-primitives/Cargo.toml
+++ b/chain/chain-primitives/Cargo.toml
@@ -21,4 +21,4 @@ near-primitives.workspace = true
 near-crypto.workspace = true
 
 [features]
-new_epoch_sync = []
+new_epoch_sync = ["near-primitives/new_epoch_sync"]

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -92,7 +92,7 @@ nightly_protocol = [
 statelessnet_protocol = ["near-primitives-core/statelessnet_protocol"]
 
 new_epoch_sync = []
-default = ["near-primitives/rand"]
+default = ["rand", "clock"]
 calimero_zero_storage = []
 
 protocol_schema = [

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -1,5 +1,6 @@
 pub use crate::config::NightshadeRuntimeExt;
 pub use crate::config::{init_configs, load_config, load_test_config, NearConfig};
+#[cfg(feature = "json_rpc")]
 use crate::entity_debug::EntityDebugHandlerImpl;
 use crate::metrics::spawn_trie_metrics_loop;
 

--- a/runtime/near-vm-runner/fuzz/Cargo.toml
+++ b/runtime/near-vm-runner/fuzz/Cargo.toml
@@ -23,7 +23,7 @@ wasmprinter.workspace = true
 near-parameters.workspace = true
 near-primitives.workspace = true
 near-test-contracts.workspace = true
-near-vm-runner.workspace = true
+near-vm-runner = { workspace = true, features = ["prepare"] }
 
 [[bin]]
 name = "runner"

--- a/tools/storage-usage-delta-calculator/Cargo.toml
+++ b/tools/storage-usage-delta-calculator/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 serde_json.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 
 near-chain-configs.workspace = true


### PR DESCRIPTION
Fix the crates publishing process.
tested with:
```
cargo ws exec -- cargo check --all-features                 
cargo ws exec -- cargo check --no-default-features
cargo ws exec -- cargo check      # This is the one that we needs to be pass. Others are nice to have for now.
```