### PR TITLE
Do not mandate use of SHA-NI instruction

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,4 +4,4 @@
 rustflags = ["-Cforce-unwind-tables=y"]
 
 [target.'cfg(target_arch = "x86_64")']
-rustflags = ["-Ctarget-feature=+sse2,+ssse3,+sse4.1,+sse4.2,+sha,+popcnt,+fma,+bmi,+bmi2,+lzcnt,+movbe,+pclmul,+sahf", "-Cforce-unwind-tables=y"]
+rustflags = ["-Ctarget-feature=+sse2,+ssse3,+sse4.1,+sse4.2,+popcnt,+fma,+bmi1,+bmi2,+lzcnt,+movbe,+pclmulqdq", "-Cforce-unwind-tables=y"]


### PR DESCRIPTION
That said, development currently happens on machines with this
instruction enabled and our fee structure will assume use of this
instruction in the long run, meaning that this instruction will become
required to keep up with the network in due time anyway.

This also fixes other feature names. I had looked at the LLVM names,
rather than Rust ones in the list 🤦