### PR TITLE
[stateless_validation] Introduce ChunkEndorsementTracker V2

### DIFF
--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -32,7 +32,9 @@ use near_primitives::shard_layout;
 use near_primitives::shard_layout::{ShardLayout, ShardUId};
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
 use near_primitives::state_part::PartId;
-use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsementV1;
+use near_primitives::stateless_validation::chunk_endorsement::{
+    ChunkEndorsementV1, ChunkEndorsementV2,
+};
 use near_primitives::stateless_validation::partial_witness::PartialEncodedStateWitness;
 use near_primitives::stateless_validation::validator_assignment::ChunkValidatorAssignments;
 use near_primitives::transaction::{
@@ -946,6 +948,13 @@ impl EpochManagerAdapter for MockEpochManager {
         &self,
         _chunk_header: &ShardChunkHeader,
         _endorsement: &ChunkEndorsementV1,
+    ) -> Result<bool, Error> {
+        Ok(true)
+    }
+
+    fn verify_chunk_endorsement_signature(
+        &self,
+        _endorsement: &ChunkEndorsementV2,
     ) -> Result<bool, Error> {
         Ok(true)
     }

--- a/chain/client/src/chunk_inclusion_tracker.rs
+++ b/chain/client/src/chunk_inclusion_tracker.rs
@@ -119,7 +119,7 @@ impl ChunkInclusionTracker {
         for chunk_hash in entry.values() {
             let chunk_info = self.chunk_hash_to_chunk_info.get_mut(chunk_hash).unwrap();
             chunk_info.endorsements =
-                endorsement_tracker.compute_chunk_endorsements(&chunk_info.chunk_header)?;
+                endorsement_tracker.collect_chunk_endorsements(&chunk_info.chunk_header)?;
         }
         Ok(())
     }

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -329,8 +329,10 @@ impl Client {
             config.max_block_wait_delay,
             doomslug_threshold_mode,
         );
-        let chunk_endorsement_tracker =
-            Arc::new(ChunkEndorsementTracker::new(epoch_manager.clone()));
+        let chunk_endorsement_tracker = Arc::new(ChunkEndorsementTracker::new(
+            epoch_manager.clone(),
+            chain.chain_store().store().clone(),
+        ));
         // Chunk validator should panic if there is a validator error in non-production chains (eg. mocket and localnet).
         let panic_on_validation_error = config.chain_id != near_primitives::chains::MAINNET
             && config.chain_id != near_primitives::chains::TESTNET;

--- a/chain/client/src/stateless_validation/chunk_endorsement/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement/mod.rs
@@ -42,14 +42,14 @@ impl Client {
         endorsement: ChunkEndorsement,
     ) -> Result<(), Error> {
         // TODO(ChunkEndorsementV2): Remove chunk_header once tracker_v1 is deprecated
-        let chunk_header = if let ChunkEndorsement::V2(endorsement) = &endorsement {
-            match self.chain.chain_store().get_partial_chunk(endorsement.chunk_hash()) {
-                Ok(chunk) => Some(chunk.cloned_header()),
-                Err(Error::ChunkMissing(_)) => None,
-                Err(error) => return Err(error),
-            }
-        } else {
-            None
+        let chunk_hash = match &endorsement {
+            ChunkEndorsement::V1(endorsement) => endorsement.chunk_hash(),
+            ChunkEndorsement::V2(endorsement) => endorsement.chunk_hash(),
+        };
+        let chunk_header = match self.chain.chain_store().get_partial_chunk(chunk_hash) {
+            Ok(chunk) => Some(chunk.cloned_header()),
+            Err(Error::ChunkMissing(_)) => None,
+            Err(error) => return Err(error),
         };
         self.chunk_endorsement_tracker.process_chunk_endorsement(endorsement, chunk_header)
     }

--- a/chain/client/src/stateless_validation/chunk_endorsement/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement/mod.rs
@@ -7,10 +7,13 @@ use near_primitives::block_body::ChunkEndorsementSignatures;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
 use near_primitives::stateless_validation::validator_assignment::EndorsementStats;
+use near_primitives::version::ProtocolFeature;
+use near_store::Store;
 
 use crate::Client;
 
 mod tracker_v1;
+mod tracker_v2;
 
 pub enum ChunkEndorsementsState {
     Endorsed(Option<EndorsementStats>, ChunkEndorsementSignatures),
@@ -28,7 +31,9 @@ impl ChunkEndorsementsState {
 
 /// Module to track chunk endorsements received from chunk validators.
 pub struct ChunkEndorsementTracker {
+    epoch_manager: Arc<dyn EpochManagerAdapter>,
     pub tracker_v1: tracker_v1::ChunkEndorsementTracker,
+    pub tracker_v2: tracker_v2::ChunkEndorsementTracker,
 }
 
 impl Client {
@@ -37,19 +42,26 @@ impl Client {
         endorsement: ChunkEndorsement,
     ) -> Result<(), Error> {
         // TODO(ChunkEndorsementV2): Remove chunk_header once tracker_v1 is deprecated
-        let chunk_header =
+        let chunk_header = if let ChunkEndorsement::V2(endorsement) = &endorsement {
             match self.chain.chain_store().get_partial_chunk(endorsement.chunk_hash()) {
                 Ok(chunk) => Some(chunk.cloned_header()),
                 Err(Error::ChunkMissing(_)) => None,
                 Err(error) => return Err(error),
-            };
+            }
+        } else {
+            None
+        };
         self.chunk_endorsement_tracker.process_chunk_endorsement(endorsement, chunk_header)
     }
 }
 
 impl ChunkEndorsementTracker {
-    pub fn new(epoch_manager: Arc<dyn EpochManagerAdapter>) -> Self {
-        Self { tracker_v1: tracker_v1::ChunkEndorsementTracker::new(epoch_manager) }
+    pub fn new(epoch_manager: Arc<dyn EpochManagerAdapter>, store: Store) -> Self {
+        Self {
+            tracker_v1: tracker_v1::ChunkEndorsementTracker::new(epoch_manager.clone()),
+            tracker_v2: tracker_v2::ChunkEndorsementTracker::new(epoch_manager.clone(), store),
+            epoch_manager,
+        }
     }
 
     // TODO(ChunkEndorsementV2): Remove chunk_header once tracker_v1 is deprecated
@@ -58,17 +70,27 @@ impl ChunkEndorsementTracker {
         endorsement: ChunkEndorsement,
         chunk_header: Option<ShardChunkHeader>,
     ) -> Result<(), Error> {
-        let endorsement = match endorsement {
-            ChunkEndorsement::V1(endorsement) => endorsement,
-            ChunkEndorsement::V2(endorsement) => endorsement.into_v1(),
-        };
-        self.tracker_v1.process_chunk_endorsement(endorsement, chunk_header)
+        match endorsement {
+            ChunkEndorsement::V1(endorsement) => {
+                self.tracker_v1.process_chunk_endorsement(endorsement, chunk_header)
+            }
+            ChunkEndorsement::V2(endorsement) => {
+                self.tracker_v2.process_chunk_endorsement(endorsement)
+            }
+        }
     }
 
     pub fn compute_chunk_endorsements(
         &self,
         chunk_header: &ShardChunkHeader,
     ) -> Result<ChunkEndorsementsState, Error> {
-        self.tracker_v1.compute_chunk_endorsements(chunk_header)
+        let epoch_id =
+            self.epoch_manager.get_epoch_id_from_prev_block(chunk_header.prev_block_hash())?;
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
+        if !ProtocolFeature::ChunkEndorsementV2.enabled(protocol_version) {
+            self.tracker_v1.compute_chunk_endorsements(chunk_header)
+        } else {
+            self.tracker_v2.compute_chunk_endorsements(chunk_header)
+        }
     }
 }

--- a/chain/client/src/stateless_validation/chunk_endorsement/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement/mod.rs
@@ -80,7 +80,7 @@ impl ChunkEndorsementTracker {
         }
     }
 
-    pub fn compute_chunk_endorsements(
+    pub fn collect_chunk_endorsements(
         &self,
         chunk_header: &ShardChunkHeader,
     ) -> Result<ChunkEndorsementsState, Error> {
@@ -88,9 +88,9 @@ impl ChunkEndorsementTracker {
             self.epoch_manager.get_epoch_id_from_prev_block(chunk_header.prev_block_hash())?;
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
         if !ProtocolFeature::ChunkEndorsementV2.enabled(protocol_version) {
-            self.tracker_v1.compute_chunk_endorsements(chunk_header)
+            self.tracker_v1.collect_chunk_endorsements(chunk_header)
         } else {
-            self.tracker_v2.compute_chunk_endorsements(chunk_header)
+            self.tracker_v2.collect_chunk_endorsements(chunk_header)
         }
     }
 }

--- a/chain/client/src/stateless_validation/chunk_endorsement/tracker_v1.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement/tracker_v1.rs
@@ -111,7 +111,7 @@ impl ChunkEndorsementTracker {
     /// Returns ChunkEndorsementsState::NotEnoughStake if chunk doesn't have enough stake.
     /// For older protocol version, we return ChunkEndorsementsState::Endorsed with an empty array of
     /// chunk endorsements.
-    pub fn compute_chunk_endorsements(
+    pub fn collect_chunk_endorsements(
         &self,
         chunk_header: &ShardChunkHeader,
     ) -> Result<ChunkEndorsementsState, Error> {

--- a/chain/client/src/stateless_validation/chunk_endorsement/tracker_v2.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement/tracker_v2.rs
@@ -62,8 +62,9 @@ impl ChunkEndorsementTracker {
 
         // Validate the chunk endorsement and store it in the cache.
         if validate_chunk_endorsement(self.epoch_manager.as_ref(), &endorsement, &self.store)? {
-            let mut chunk_endorsements = self.chunk_endorsements.lock().unwrap();
-            chunk_endorsements
+            self.chunk_endorsements
+                .lock()
+                .unwrap()
                 .get_or_insert_mut(key, || HashMap::new())
                 .insert(account_id.clone(), endorsement);
         };

--- a/chain/client/src/stateless_validation/chunk_endorsement/tracker_v2.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement/tracker_v2.rs
@@ -1,0 +1,132 @@
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
+
+use lru::LruCache;
+use near_chain_primitives::Error;
+use near_epoch_manager::EpochManagerAdapter;
+use near_primitives::sharding::ShardChunkHeader;
+use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsementV2;
+use near_primitives::stateless_validation::ChunkProductionKey;
+use near_primitives::types::AccountId;
+use near_primitives::version::ProtocolFeature;
+use near_store::Store;
+
+use crate::stateless_validation::validate::validate_chunk_endorsement;
+
+use super::ChunkEndorsementsState;
+
+// This is the number of unique chunks for which we would track the chunk endorsements.
+// Ideally, we should not be processing more than num_shards chunks at a time.
+const NUM_CHUNKS_IN_CHUNK_ENDORSEMENTS_CACHE: usize = 100;
+
+/// Module to track chunk endorsements received from chunk validators.
+pub struct ChunkEndorsementTracker {
+    epoch_manager: Arc<dyn EpochManagerAdapter>,
+    /// Used to find the chain HEAD when validating partial witnesses.
+    store: Store,
+    /// We store the validated chunk endorsements received from chunk validators.
+    /// Interior mutability is required to update the cache in process_chunk_endorsement & compute_chunk_endorsements.
+    chunk_endorsements: Mutex<LruCache<ChunkProductionKey, HashMap<AccountId, ChunkEndorsementV2>>>,
+}
+
+impl ChunkEndorsementTracker {
+    pub(crate) fn new(epoch_manager: Arc<dyn EpochManagerAdapter>, store: Store) -> Self {
+        Self {
+            epoch_manager,
+            store,
+            chunk_endorsements: Mutex::new(LruCache::new(
+                NonZeroUsize::new(NUM_CHUNKS_IN_CHUNK_ENDORSEMENTS_CACHE).unwrap(),
+            )),
+        }
+    }
+
+    // Validate the chunk endorsement and store it in the cache.
+    pub(crate) fn process_chunk_endorsement(
+        &self,
+        endorsement: ChunkEndorsementV2,
+    ) -> Result<(), Error> {
+        // Check if we have already received chunk endorsement from this validator.
+        let key = endorsement.chunk_production_key();
+        let account_id = endorsement.account_id();
+        if self
+            .chunk_endorsements
+            .lock()
+            .unwrap()
+            .peek(&key)
+            .is_some_and(|entry| entry.contains_key(account_id))
+        {
+            tracing::debug!(target: "client", ?endorsement, "Already received chunk endorsement.");
+            return Ok(());
+        }
+
+        // Validate the chunk endorsement and store it in the cache.
+        if validate_chunk_endorsement(self.epoch_manager.as_ref(), &endorsement, &self.store)? {
+            let mut chunk_endorsements = self.chunk_endorsements.lock().unwrap();
+            let entry = chunk_endorsements.get_or_insert_mut(key, || HashMap::new());
+            entry.insert(account_id.clone(), endorsement);
+        };
+        Ok(())
+    }
+
+    /// Called by block producer.
+    /// Returns ChunkEndorsementsState::Endorsed if node has enough signed stake for the chunk
+    /// represented by chunk_header.
+    /// Signatures have the same order as ordered_chunk_validators, thus ready to be included in a block as is.
+    /// Returns ChunkEndorsementsState::NotEnoughStake if chunk doesn't have enough stake.
+    pub(crate) fn compute_chunk_endorsements(
+        &self,
+        chunk_header: &ShardChunkHeader,
+    ) -> Result<ChunkEndorsementsState, Error> {
+        let shard_id = chunk_header.shard_id();
+        let epoch_id =
+            self.epoch_manager.get_epoch_id_from_prev_block(chunk_header.prev_block_hash())?;
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
+        if !ProtocolFeature::StatelessValidation.enabled(protocol_version) {
+            // Return an empty array of chunk endorsements for older protocol versions.
+            return Ok(ChunkEndorsementsState::Endorsed(None, vec![]));
+        }
+
+        let height_created = chunk_header.height_created();
+        let key = ChunkProductionKey { shard_id, epoch_id, height_created };
+
+        let chunk_validator_assignments = self.epoch_manager.get_chunk_validator_assignments(
+            &epoch_id,
+            chunk_header.shard_id(),
+            chunk_header.height_created(),
+        )?;
+
+        // Get the chunk_endorsements for the chunk from our cache.
+        // Note that these chunk endorsements are already validated as part of process_chunk_endorsement.
+        // We can safely rely on the following details
+        //    1. The chunk endorsements are from valid chunk_validator for this chunk.
+        //    2. The chunk endorsements signatures are valid.
+        //    3. We still need to validate if the chunk_hash matches the chunk_header.chunk_hash()
+        let mut chunk_endorsements = self.chunk_endorsements.lock().unwrap();
+        let Some(entry) = chunk_endorsements.get_mut(&key) else {
+            // Early return if no chunk_endorsements found in our cache.
+            return Ok(ChunkEndorsementsState::NotEnoughStake(None));
+        };
+        entry.retain(|_, endorsement| endorsement.chunk_hash() == &chunk_header.chunk_hash());
+
+        let endorsement_stats =
+            chunk_validator_assignments.compute_endorsement_stats(&entry.keys().collect());
+
+        // Check whether the current set of chunk_validators have enough stake to include chunk in block.
+        if !endorsement_stats.has_enough_stake() {
+            return Ok(ChunkEndorsementsState::NotEnoughStake(Some(endorsement_stats)));
+        }
+
+        // We've already verified the chunk_endorsements are valid, collect signatures.
+        let signatures = chunk_validator_assignments
+            .ordered_chunk_validators()
+            .iter()
+            .map(|account_id| {
+                // map Option<ChunkEndorsement> to Option<Box<Signature>>
+                entry.get(account_id).map(|endorsement| Box::new(endorsement.signature()))
+            })
+            .collect();
+
+        Ok(ChunkEndorsementsState::Endorsed(Some(endorsement_stats), signatures))
+    }
+}

--- a/chain/client/src/stateless_validation/mod.rs
+++ b/chain/client/src/stateless_validation/mod.rs
@@ -4,3 +4,4 @@ pub mod partial_witness;
 mod shadow_validate;
 mod state_witness_producer;
 pub mod state_witness_tracker;
+mod validate;

--- a/chain/client/src/stateless_validation/partial_witness/mod.rs
+++ b/chain/client/src/stateless_validation/partial_witness/mod.rs
@@ -1,3 +1,5 @@
 mod encoding;
 pub mod partial_witness_actor;
 mod partial_witness_tracker;
+
+pub use encoding::witness_part_length;

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
@@ -13,23 +13,22 @@ use near_network::state_witness::{
 };
 use near_network::types::{NetworkRequests, PeerManagerAdapter, PeerManagerMessageRequest};
 use near_performance_metrics_macros::perf;
-use near_primitives::block::Tip;
 use near_primitives::sharding::ShardChunkHeader;
-use near_primitives::stateless_validation::partial_witness::{
-    PartialEncodedStateWitness, MAX_COMPRESSED_STATE_WITNESS_SIZE,
-};
+use near_primitives::stateless_validation::partial_witness::PartialEncodedStateWitness;
 use near_primitives::stateless_validation::state_witness::{
     ChunkStateWitness, ChunkStateWitnessAck, EncodedChunkStateWitness,
 };
-use near_primitives::types::{AccountId, BlockHeightDelta, EpochId};
+use near_primitives::stateless_validation::ChunkProductionKey;
+use near_primitives::types::{AccountId, EpochId};
 use near_primitives::validator_signer::ValidatorSigner;
-use near_store::{DBCol, Store, FINAL_HEAD_KEY, HEAD_KEY};
+use near_store::Store;
 
 use crate::client_actor::ClientSenderForPartialWitness;
 use crate::metrics;
 use crate::stateless_validation::state_witness_tracker::ChunkStateWitnessTracker;
+use crate::stateless_validation::validate::validate_partial_encoded_state_witness;
 
-use super::encoding::{witness_part_length, WitnessEncoderCache};
+use super::encoding::WitnessEncoderCache;
 use super::partial_witness_tracker::PartialEncodedStateWitnessTracker;
 
 pub struct PartialWitnessActor {
@@ -52,10 +51,6 @@ pub struct PartialWitnessActor {
     /// but should be removed if we implement retrieving this info from the client
     store: Store,
 }
-
-/// This is taken to be the same value as near_chunks::chunk_cache::MAX_HEIGHTS_AHEAD, and we
-/// reject partial witnesses with height more than this value above the height of our current HEAD
-const MAX_HEIGHTS_AHEAD: BlockHeightDelta = 5;
 
 impl Actor for PartialWitnessActor {}
 
@@ -255,18 +250,13 @@ impl PartialWitnessActor {
         partial_witness: PartialEncodedStateWitness,
         signer: &ValidatorSigner,
     ) -> Result<(), Error> {
-        let chunk_producer = self.epoch_manager.get_chunk_producer(
-            partial_witness.epoch_id(),
-            partial_witness.height_created(),
-            partial_witness.shard_id(),
-        )?;
+        let ChunkProductionKey { shard_id, epoch_id, height_created } =
+            partial_witness.chunk_production_key();
+        let chunk_producer =
+            self.epoch_manager.get_chunk_producer(&epoch_id, height_created, shard_id)?;
         let ordered_chunk_validators = self
             .epoch_manager
-            .get_chunk_validator_assignments(
-                partial_witness.epoch_id(),
-                partial_witness.shard_id(),
-                partial_witness.height_created(),
-            )?
+            .get_chunk_validator_assignments(&epoch_id, shard_id, height_created)?
             .ordered_chunk_validators();
         // Forward witness part to chunk validators except for the following:
         // (1) the current validator and (2) validator that produced the chunk and witness.
@@ -298,7 +288,12 @@ impl PartialWitnessActor {
         };
 
         // Validate the partial encoded state witness.
-        if self.validate_partial_encoded_state_witness(&partial_witness, &signer)? {
+        if validate_partial_encoded_state_witness(
+            self.epoch_manager.as_ref(),
+            &partial_witness,
+            &signer,
+            &self.store,
+        )? {
             // Store the partial encoded state witness for self.
             self.partial_witness_tracker
                 .store_partial_encoded_state_witness(partial_witness.clone())?;
@@ -324,134 +319,17 @@ impl PartialWitnessActor {
         };
 
         // Validate the partial encoded state witness.
-        if self.validate_partial_encoded_state_witness(&partial_witness, &signer)? {
+        if validate_partial_encoded_state_witness(
+            self.epoch_manager.as_ref(),
+            &partial_witness,
+            &signer,
+            &self.store,
+        )? {
             // Store the partial encoded state witness for self.
             self.partial_witness_tracker.store_partial_encoded_state_witness(partial_witness)?;
         }
 
         Ok(())
-    }
-
-    /// Function to validate the partial encoded state witness. We check the following
-    /// - shard_id is valid
-    /// - we are one of the validators for the chunk
-    /// - height_created is in (last_final_height..chain_head_height + MAX_HEIGHTS_AHEAD] range
-    /// - epoch_id is within epoch_manager's possible_epochs_of_height_around_tip
-    /// - part_ord is valid and within range of the number of expected parts for this chunk
-    /// - partial_witness signature is valid and from the expected chunk_producer
-    /// TODO(stateless_validation): Include checks from handle_orphan_state_witness in orphan_witness_handling.rs
-    /// These include checks based on epoch_id validity, witness size, height_created, distance from chain head, etc.
-    /// Returns:
-    /// - Ok(true) if partial witness is valid and we should process it.
-    /// - Ok(false) if partial witness is potentially valid, but at this point we
-    ///   should not process it. One example of that is if the witness is too old.
-    /// - Err if partial witness is invalid which most probably indicates malicious
-    ///   behavior.
-    fn validate_partial_encoded_state_witness(
-        &self,
-        partial_witness: &PartialEncodedStateWitness,
-        signer: &ValidatorSigner,
-    ) -> Result<bool, Error> {
-        if !self
-            .epoch_manager
-            .get_shard_layout(&partial_witness.epoch_id())?
-            .shard_ids()
-            .contains(&partial_witness.shard_id())
-        {
-            return Err(Error::InvalidPartialChunkStateWitness(format!(
-                "Invalid shard_id in PartialEncodedStateWitness: {}",
-                partial_witness.shard_id()
-            )));
-        }
-
-        // Reject witnesses for chunks for which this node isn't a validator.
-        // It's an error, as chunk producer shouldn't send the witness to a non-validator node.
-        let chunk_validator_assignments = self.epoch_manager.get_chunk_validator_assignments(
-            &partial_witness.epoch_id(),
-            partial_witness.shard_id(),
-            partial_witness.height_created(),
-        )?;
-        if !chunk_validator_assignments.contains(signer.validator_id()) {
-            return Err(Error::NotAChunkValidator);
-        }
-
-        // The expected number of parts for the Reed Solomon encoding is the number of chunk validators.
-        let num_parts = chunk_validator_assignments.len();
-        if partial_witness.part_ord() >= num_parts {
-            return Err(Error::InvalidPartialChunkStateWitness(format!(
-                "Invalid part_ord in PartialEncodedStateWitness: {}",
-                partial_witness.part_ord()
-            )));
-        }
-
-        let max_part_len =
-            witness_part_length(MAX_COMPRESSED_STATE_WITNESS_SIZE.as_u64() as usize, num_parts);
-        if partial_witness.part_size() > max_part_len {
-            return Err(Error::InvalidPartialChunkStateWitness(format!(
-                "Part size {} exceed limit of {} (total parts: {})",
-                partial_witness.part_size(),
-                max_part_len,
-                num_parts
-            )));
-        }
-
-        // TODO(https://github.com/near/nearcore/issues/11301): replace these direct DB accesses with messages
-        // sent to the client actor. for a draft, see https://github.com/near/nearcore/commit/e186dc7c0b467294034c60758fe555c78a31ef2d
-        let head = self.store.get_ser::<Tip>(DBCol::BlockMisc, HEAD_KEY)?;
-        let final_head = self.store.get_ser::<Tip>(DBCol::BlockMisc, FINAL_HEAD_KEY)?;
-
-        // Avoid processing state witness for old chunks.
-        // In particular it is impossible for a chunk created at a height
-        // that doesn't exceed the height of the current final block to be
-        // included in the chain. This addresses both network-delayed messages
-        // as well as malicious behavior of a chunk producer.
-        if let Some(final_head) = final_head {
-            if partial_witness.height_created() <= final_head.height {
-                tracing::debug!(
-                    target: "client",
-                    ?partial_witness,
-                    final_head_height = final_head.height,
-                    "Skipping partial witness because its height created is not greater than final head height",
-                );
-                return Ok(false);
-            }
-        }
-        if let Some(head) = head {
-            if partial_witness.height_created() > head.height + MAX_HEIGHTS_AHEAD {
-                tracing::debug!(
-                    target: "client",
-                    ?partial_witness,
-                    head_height = head.height,
-                    "Skipping partial witness because its height created is more than {} blocks ahead of head height",
-                    MAX_HEIGHTS_AHEAD
-                );
-                return Ok(false);
-            }
-
-            // Try to find the EpochId to which this witness will belong based on its height.
-            // It's not always possible to determine the exact epoch_id because the exact
-            // starting height of the next epoch isn't known until it actually starts,
-            // so things can get unclear around epoch boundaries.
-            // Let's collect the epoch_ids in which the witness might possibly be.
-            let possible_epochs = self
-                .epoch_manager
-                .possible_epochs_of_height_around_tip(&head, partial_witness.height_created())?;
-            if !possible_epochs.contains(&partial_witness.epoch_id()) {
-                tracing::debug!(
-                    target: "client",
-                    ?partial_witness,
-                    ?possible_epochs,
-                    "Skipping partial witness because its EpochId is not in the possible list of epochs",
-                );
-                return Ok(false);
-            }
-        }
-
-        if !self.epoch_manager.verify_partial_witness_signature(&partial_witness)? {
-            return Err(Error::InvalidPartialChunkStateWitness("Invalid signature".to_string()));
-        }
-
-        Ok(true)
     }
 
     /// Handles the state witness ack message from the chunk validator.

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
@@ -60,8 +60,8 @@ impl CacheEntry {
         &mut self,
         partial_witness: PartialEncodedStateWitness,
     ) -> Option<std::io::Result<EncodedChunkStateWitness>> {
-        let shard_id = partial_witness.shard_id();
-        let height_created = partial_witness.height_created();
+        let ChunkProductionKey { shard_id, height_created, .. } =
+            partial_witness.chunk_production_key();
         let (part_ord, part, encoded_length) = partial_witness.decompose();
 
         // Check if the part is already present.
@@ -185,13 +185,11 @@ impl PartialEncodedStateWitnessTracker {
 
     fn get_num_parts(&self, partial_witness: &PartialEncodedStateWitness) -> Result<usize, Error> {
         // The expected number of parts for the Reed Solomon encoding is the number of chunk validators.
+        let ChunkProductionKey { shard_id, epoch_id, height_created } =
+            partial_witness.chunk_production_key();
         Ok(self
             .epoch_manager
-            .get_chunk_validator_assignments(
-                partial_witness.epoch_id(),
-                partial_witness.shard_id(),
-                partial_witness.height_created(),
-            )?
+            .get_chunk_validator_assignments(&epoch_id, shard_id, height_created)?
             .len())
     }
 

--- a/chain/client/src/stateless_validation/validate.rs
+++ b/chain/client/src/stateless_validation/validate.rs
@@ -1,0 +1,180 @@
+use super::partial_witness::witness_part_length;
+use itertools::Itertools;
+use near_chain::types::Tip;
+use near_chain_primitives::Error;
+use near_epoch_manager::EpochManagerAdapter;
+use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsementV2;
+use near_primitives::stateless_validation::partial_witness::{
+    PartialEncodedStateWitness, MAX_COMPRESSED_STATE_WITNESS_SIZE,
+};
+use near_primitives::stateless_validation::ChunkProductionKey;
+use near_primitives::types::{AccountId, BlockHeightDelta};
+use near_primitives::validator_signer::ValidatorSigner;
+use near_store::{DBCol, Store, FINAL_HEAD_KEY, HEAD_KEY};
+
+/// This is taken to be the same value as near_chunks::chunk_cache::MAX_HEIGHTS_AHEAD, and we
+/// reject partial witnesses with height more than this value above the height of our current HEAD
+const MAX_HEIGHTS_AHEAD: BlockHeightDelta = 5;
+
+/// Function to validate the partial encoded state witness. In addition of ChunkProductionKey, we check the following:
+/// - part_ord is valid and within range of the number of expected parts for this chunk
+/// - partial_witness signature is valid and from the expected chunk_producer
+/// TODO(stateless_validation): Include checks from handle_orphan_state_witness in orphan_witness_handling.rs
+/// These include checks based on epoch_id validity, witness size, height_created, distance from chain head, etc.
+pub fn validate_partial_encoded_state_witness(
+    epoch_manager: &dyn EpochManagerAdapter,
+    partial_witness: &PartialEncodedStateWitness,
+    signer: &ValidatorSigner,
+    store: &Store,
+) -> Result<bool, Error> {
+    let ChunkProductionKey { shard_id, epoch_id, height_created } =
+        partial_witness.chunk_production_key();
+    let num_parts =
+        epoch_manager.get_chunk_validator_assignments(&epoch_id, shard_id, height_created)?.len();
+    if partial_witness.part_ord() >= num_parts {
+        return Err(Error::InvalidPartialChunkStateWitness(format!(
+            "Invalid part_ord in PartialEncodedStateWitness: {}",
+            partial_witness.part_ord()
+        )));
+    }
+
+    let max_part_len =
+        witness_part_length(MAX_COMPRESSED_STATE_WITNESS_SIZE.as_u64() as usize, num_parts);
+    if partial_witness.part_size() > max_part_len {
+        return Err(Error::InvalidPartialChunkStateWitness(format!(
+            "Part size {} exceed limit of {} (total parts: {})",
+            partial_witness.part_size(),
+            max_part_len,
+            num_parts
+        )));
+    }
+
+    if !validate_chunk_production_key(
+        epoch_manager,
+        partial_witness.chunk_production_key(),
+        signer.validator_id(),
+        store,
+    )? {
+        return Ok(false);
+    }
+
+    if !epoch_manager.verify_partial_witness_signature(&partial_witness)? {
+        return Err(Error::InvalidPartialChunkStateWitness("Invalid signature".to_string()));
+    }
+
+    Ok(true)
+}
+
+/// Function to validate the chunk endorsement. In addition of ChunkProductionKey, we check the following:
+/// - signature of endorsement and metadata is valid
+pub fn validate_chunk_endorsement(
+    epoch_manager: &dyn EpochManagerAdapter,
+    endorsement: &ChunkEndorsementV2,
+    store: &Store,
+) -> Result<bool, Error> {
+    if !validate_chunk_production_key(
+        epoch_manager,
+        endorsement.chunk_production_key(),
+        endorsement.account_id(),
+        store,
+    )? {
+        return Ok(false);
+    }
+
+    if !epoch_manager.verify_chunk_endorsement_signature(endorsement)? {
+        return Err(Error::InvalidChunkEndorsement);
+    }
+
+    Ok(true)
+}
+
+/// Function to validate ChunkProductionKey. We check the following:
+/// - shard_id is valid
+/// - account_id is one of the validators for the chunk
+/// - height_created is in (last_final_height..chain_head_height + MAX_HEIGHTS_AHEAD] range
+/// - epoch_id is within epoch_manager's possible_epochs_of_height_around_tip
+/// Returns:
+/// - Ok(true) if ChunkProductionKey is valid and we should process it.
+/// - Ok(false) if ChunkProductionKey is potentially valid, but at this point we should not
+///   process it. One example of that is if the witness is too old.
+/// - Err if ChunkProductionKey is invalid which most probably indicates malicious behavior.
+fn validate_chunk_production_key(
+    epoch_manager: &dyn EpochManagerAdapter,
+    chunk_production_key: ChunkProductionKey,
+    account_id: &AccountId,
+    store: &Store,
+) -> Result<bool, Error> {
+    let shard_id = chunk_production_key.shard_id;
+    let epoch_id = chunk_production_key.epoch_id;
+    let height_created = chunk_production_key.height_created;
+
+    if !epoch_manager.get_shard_layout(&epoch_id)?.shard_ids().contains(&shard_id) {
+        tracing::error!(
+            target: "stateless_validation",
+            ?chunk_production_key,
+            "ShardId is not in the shard layout of the epoch",
+        );
+        return Err(Error::InvalidShardId(shard_id));
+    }
+
+    // Reject witnesses/endorsements for chunks for which the account_id isn't a validator.
+    // It's an error, as chunk producer shouldn't send the witness/endorsement to/from a non-validator node.
+    let chunk_validator_assignments =
+        epoch_manager.get_chunk_validator_assignments(&epoch_id, shard_id, height_created)?;
+    if !chunk_validator_assignments.contains(account_id) {
+        return Err(Error::NotAChunkValidator);
+    }
+
+    // TODO(https://github.com/near/nearcore/issues/11301): replace these direct DB accesses with messages
+    // sent to the client actor. for a draft, see https://github.com/near/nearcore/commit/e186dc7c0b467294034c60758fe555c78a31ef2d
+    let head = store.get_ser::<Tip>(DBCol::BlockMisc, HEAD_KEY)?;
+    let final_head = store.get_ser::<Tip>(DBCol::BlockMisc, FINAL_HEAD_KEY)?;
+
+    // Avoid processing state witness for old chunks.
+    // In particular it is impossible for a chunk created at a height
+    // that doesn't exceed the height of the current final block to be
+    // included in the chain. This addresses both network-delayed messages
+    // as well as malicious behavior of a chunk producer.
+    if let Some(final_head) = final_head {
+        if height_created <= final_head.height {
+            tracing::debug!(
+                target: "stateless_validation",
+                ?chunk_production_key,
+                final_head_height = final_head.height,
+                "Skipping because height created is not greater than final head height",
+            );
+            return Ok(false);
+        }
+    }
+    if let Some(head) = head {
+        if height_created > head.height + MAX_HEIGHTS_AHEAD {
+            tracing::debug!(
+                target: "stateless_validation",
+                ?chunk_production_key,
+                head_height = head.height,
+                "Skipping because height created is more than {} blocks ahead of head height",
+                MAX_HEIGHTS_AHEAD
+            );
+            return Ok(false);
+        }
+
+        // Try to find the EpochId to which this witness will belong based on its height.
+        // It's not always possible to determine the exact epoch_id because the exact
+        // starting height of the next epoch isn't known until it actually starts,
+        // so things can get unclear around epoch boundaries.
+        // Let's collect the epoch_ids in which the witness might possibly be.
+        let possible_epochs =
+            epoch_manager.possible_epochs_of_height_around_tip(&head, height_created)?;
+        if !possible_epochs.contains(&epoch_id) {
+            tracing::debug!(
+                target: "stateless_validation",
+                ?chunk_production_key,
+                ?possible_epochs,
+                "Skipping because EpochId is not in the possible list of epochs",
+            );
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -11,9 +11,12 @@ use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::{account_id_to_shard_id, ShardLayout, ShardLayoutError};
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
-use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsementV1;
+use near_primitives::stateless_validation::chunk_endorsement::{
+    ChunkEndorsementV1, ChunkEndorsementV2,
+};
 use near_primitives::stateless_validation::partial_witness::PartialEncodedStateWitness;
 use near_primitives::stateless_validation::validator_assignment::ChunkValidatorAssignments;
+use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
     AccountId, ApprovalStake, Balance, BlockHeight, EpochHeight, EpochId, ShardId,
@@ -415,6 +418,11 @@ pub trait EpochManagerAdapter: Send + Sync {
         &self,
         chunk_header: &ShardChunkHeader,
         endorsement: &ChunkEndorsementV1,
+    ) -> Result<bool, Error>;
+
+    fn verify_chunk_endorsement_signature(
+        &self,
+        endorsement: &ChunkEndorsementV2,
     ) -> Result<bool, Error>;
 
     fn verify_partial_witness_signature(
@@ -1029,6 +1037,7 @@ impl EpochManagerAdapter for EpochManagerHandle {
         }
     }
 
+    // TODO(ChunkEndorsementV2): Deprecate this after shifting to ChunkEndorsementV2
     fn verify_chunk_endorsement(
         &self,
         chunk_header: &ShardChunkHeader,
@@ -1055,17 +1064,27 @@ impl EpochManagerAdapter for EpochManagerHandle {
         Ok(endorsement.verify(validator.public_key()))
     }
 
+    fn verify_chunk_endorsement_signature(
+        &self,
+        endorsement: &ChunkEndorsementV2,
+    ) -> Result<bool, Error> {
+        let epoch_manager = self.read();
+        let epoch_id = endorsement.chunk_production_key().epoch_id;
+        let validator =
+            epoch_manager.get_validator_by_account_id(&epoch_id, &endorsement.account_id())?;
+        Ok(endorsement.verify(validator.public_key()))
+    }
+
     fn verify_partial_witness_signature(
         &self,
         partial_witness: &PartialEncodedStateWitness,
     ) -> Result<bool, Error> {
         // Get the chunk producer from the epoch_id, height_created and shard_id, verify if signature is correct
         let epoch_manager = self.read();
-        let chunk_producer = epoch_manager.get_chunk_producer_info(
-            &partial_witness.epoch_id(),
-            partial_witness.height_created(),
-            partial_witness.shard_id(),
-        )?;
+        let ChunkProductionKey { shard_id, epoch_id, height_created } =
+            partial_witness.chunk_production_key();
+        let chunk_producer =
+            epoch_manager.get_chunk_producer_info(&epoch_id, height_created, shard_id)?;
         Ok(partial_witness.verify(chunk_producer.public_key()))
     }
 

--- a/core/primitives/src/stateless_validation/partial_witness.rs
+++ b/core/primitives/src/stateless_validation/partial_witness.rs
@@ -61,27 +61,15 @@ impl PartialEncodedStateWitness {
 
     pub fn chunk_production_key(&self) -> ChunkProductionKey {
         ChunkProductionKey {
-            shard_id: self.shard_id(),
-            epoch_id: *self.epoch_id(),
-            height_created: self.height_created(),
+            shard_id: self.inner.shard_id,
+            epoch_id: self.inner.epoch_id,
+            height_created: self.inner.height_created,
         }
     }
 
     pub fn verify(&self, public_key: &PublicKey) -> bool {
         let data = borsh::to_vec(&self.inner).unwrap();
         self.signature.verify(&data, public_key)
-    }
-
-    pub fn epoch_id(&self) -> &EpochId {
-        &self.inner.epoch_id
-    }
-
-    pub fn shard_id(&self) -> ShardId {
-        self.inner.shard_id
-    }
-
-    pub fn height_created(&self) -> BlockHeight {
-        self.inner.height_created
     }
 
     pub fn part_ord(&self) -> usize {


### PR DESCRIPTION
This PR has the following
- Add a new ChunkEndorsementTracker that tracks ChunkEndorsementV2
- Add logic to separate between the two trackers
- Merge validation logic for ChunkEndorsementV2 and partial witness

Follow up on https://github.com/near/nearcore/pull/11856 and https://github.com/near/nearcore/pull/11860