### PR TITLE
[network] Remove spurious instances of AsyncSender

### DIFF
--- a/chain/network/src/client.rs
+++ b/chain/network/src/client.rs
@@ -1,6 +1,6 @@
 use crate::network_protocol::StateResponseInfo;
 use crate::types::{NetworkInfo, ReasonForBan};
-use near_async::messaging::AsyncSender;
+use near_async::messaging::{AsyncSender, Sender};
 use near_async::{MultiSend, MultiSendMessage, MultiSenderFrom};
 use near_primitives::block::{Approval, Block, BlockHeader};
 use near_primitives::challenge::Challenge;
@@ -122,19 +122,19 @@ pub struct ChunkEndorsementMessage(pub ChunkEndorsement);
 #[multi_send_input_derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClientSenderForNetwork {
     pub tx_status_request: AsyncSender<TxStatusRequest, Option<Box<FinalExecutionOutcomeView>>>,
-    pub tx_status_response: AsyncSender<TxStatusResponse, ()>,
+    pub tx_status_response: Sender<TxStatusResponse>,
     pub state_request_header: AsyncSender<StateRequestHeader, Option<StateResponse>>,
     pub state_request_part: AsyncSender<StateRequestPart, Option<StateResponse>>,
-    pub state_response: AsyncSender<StateResponse, ()>,
-    pub block_approval: AsyncSender<BlockApproval, ()>,
+    pub state_response: Sender<StateResponse>,
+    pub block_approval: Sender<BlockApproval>,
     pub transaction: AsyncSender<ProcessTxRequest, ProcessTxResponse>,
     pub block_request: AsyncSender<BlockRequest, Option<Box<Block>>>,
     pub block_headers_request: AsyncSender<BlockHeadersRequest, Option<Vec<BlockHeader>>>,
-    pub block: AsyncSender<BlockResponse, ()>,
+    pub block: Sender<BlockResponse>,
     pub block_headers: AsyncSender<BlockHeadersResponse, Result<(), ReasonForBan>>,
-    pub challenge: AsyncSender<RecvChallenge, ()>,
-    pub network_info: AsyncSender<SetNetworkInfo, ()>,
+    pub challenge: Sender<RecvChallenge>,
+    pub network_info: Sender<SetNetworkInfo>,
     pub announce_account:
         AsyncSender<AnnounceAccountRequest, Result<Vec<AnnounceAccount>, ReasonForBan>>,
-    pub chunk_endorsement: AsyncSender<ChunkEndorsementMessage, ()>,
+    pub chunk_endorsement: Sender<ChunkEndorsementMessage>,
 }

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -975,11 +975,11 @@ impl PeerActor {
                 .flatten()
                 .map(|response| RoutedMessageBody::TxStatusResponse(*response)),
             RoutedMessageBody::TxStatusResponse(tx_result) => {
-                network_state.client.send_async(TxStatusResponse(tx_result.into())).await.ok();
+                network_state.client.send(TxStatusResponse(tx_result.into()));
                 None
             }
             RoutedMessageBody::BlockApproval(approval) => {
-                network_state.client.send_async(BlockApproval(approval, peer_id)).await.ok();
+                network_state.client.send(BlockApproval(approval, peer_id));
                 None
             }
             RoutedMessageBody::ForwardTx(transaction) => {
@@ -1030,7 +1030,7 @@ impl PeerActor {
             }
             RoutedMessageBody::ChunkEndorsement(endorsement) => {
                 let endorsement = ChunkEndorsement::V1(endorsement);
-                network_state.client.send_async(ChunkEndorsementMessage(endorsement)).await.ok();
+                network_state.client.send(ChunkEndorsementMessage(endorsement));
                 None
             }
             RoutedMessageBody::PartialEncodedStateWitness(witness) => {
@@ -1046,7 +1046,7 @@ impl PeerActor {
                 None
             }
             RoutedMessageBody::VersionedChunkEndorsement(endorsement) => {
-                network_state.client.send_async(ChunkEndorsementMessage(endorsement)).await.ok();
+                network_state.client.send(ChunkEndorsementMessage(endorsement));
                 None
             }
             body => {
@@ -1127,11 +1127,7 @@ impl PeerActor {
                     .flatten()
                     .map(PeerMessage::BlockHeaders),
                 PeerMessage::Block(block) => {
-                    network_state
-                        .client
-                        .send_async(BlockResponse { block, peer_id, was_requested })
-                        .await
-                        .ok();
+                    network_state.client.send(BlockResponse { block, peer_id, was_requested });
                     None
                 }
                 PeerMessage::Transaction(transaction) => {
@@ -1157,7 +1153,7 @@ impl PeerActor {
                     None
                 }
                 PeerMessage::Challenge(challenge) => {
-                    network_state.client.send_async(RecvChallenge(challenge)).await.ok();
+                    network_state.client.send(RecvChallenge(challenge));
                     None
                 }
                 PeerMessage::StateRequestHeader(shard_id, sync_hash) => network_state
@@ -1176,7 +1172,7 @@ impl PeerActor {
                     .map(|response| PeerMessage::VersionedStateResponse(*response.0)),
                 PeerMessage::VersionedStateResponse(info) => {
                     //TODO: Route to state sync actor.
-                    network_state.client.send_async(StateResponse(info.into())).await.ok();
+                    network_state.client.send(StateResponse(info.into()));
                     None
                 }
                 msg => {

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -563,6 +563,9 @@ impl NetworkState {
         account_id: &AccountId,
         msg: RoutedMessageBody,
     ) -> bool {
+        // self.client.send(message)
+        // self.message_for_me(target)
+
         let accounts_data = self.accounts_data.load();
         if tcp::Tier::T1.is_allowed_routed(&msg) {
             for key in accounts_data.keys_by_id.get(account_id).iter().flat_map(|keys| keys.iter())

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -563,9 +563,6 @@ impl NetworkState {
         account_id: &AccountId,
         msg: RoutedMessageBody,
     ) -> bool {
-        // self.client.send(message)
-        // self.message_for_me(target)
-
         let accounts_data = self.accounts_data.load();
         if tcp::Tier::T1.is_allowed_routed(&msg) {
             for key in accounts_data.keys_by_id.get(account_id).iter().flat_map(|keys| keys.iter())

--- a/tools/chainsync-loadtest/src/network.rs
+++ b/tools/chainsync-loadtest/src/network.rs
@@ -238,7 +238,7 @@ impl Network {
             transaction: noop().into_sender(),
             block_request: Sender::from_async_fn(|_| None),
             block_headers_request: Sender::from_async_fn(|_| None),
-            block: Sender::from_async_fn(move |block: BlockResponse| {
+            block: Sender::from_fn(move |block: BlockResponse| {
                 blocks.get(&block.block.hash().clone()).map(|p| p.set(block.block));
             }),
             block_headers: Sender::from_async_fn(move |headers: BlockHeadersResponse| {
@@ -249,7 +249,7 @@ impl Network {
                 Ok(())
             }),
             challenge: noop().into_sender(),
-            network_info: Sender::from_async_fn(move |info: SetNetworkInfo| {
+            network_info: Sender::from_fn(move |info: SetNetworkInfo| {
                 let mut n = data.lock().unwrap();
                 n.info_ = Arc::new(info.0);
                 if n.info_.num_connected_peers < min_peers {


### PR DESCRIPTION
Converting messages from async to sync in case they don't have a defined return type.