### PR TITLE
feat(debug-ui): Show type of network message in logviz

### DIFF
--- a/integration-tests/src/test_loop/tests/mod.rs
+++ b/integration-tests/src/test_loop/tests/mod.rs
@@ -9,3 +9,4 @@ pub mod multinode_test_loop_example;
 pub mod simple_test_loop_example;
 pub mod syncing;
 pub mod view_requests_to_archival_node;
+pub mod visualisation;

--- a/integration-tests/src/test_loop/tests/mod.rs
+++ b/integration-tests/src/test_loop/tests/mod.rs
@@ -9,4 +9,3 @@ pub mod multinode_test_loop_example;
 pub mod simple_test_loop_example;
 pub mod syncing;
 pub mod view_requests_to_archival_node;
-pub mod visualisation;

--- a/tools/debug-ui/src/log_visualizer/events.ts
+++ b/tools/debug-ui/src/log_visualizer/events.ts
@@ -69,6 +69,15 @@ export class EventItem {
                         afterFirstParens.length - 1
                     );
                 }
+
+                // Show type of the message for network messages
+                if (this.subtitle === "NetworkRequests") {
+                    const afterSecondBracket = afterFirstParens.substring(secondBracket.index + 1);
+                    const thirdBracket = /[({]/.exec(afterSecondBracket);
+                    if (thirdBracket !== null) {
+                        this.subtitle = "Network::" + afterSecondBracket.substring(0, thirdBracket.index);
+                    }
+                }
             } else {
                 this.subtitle = afterFirstParens;
             }


### PR DESCRIPTION
logviz used to display all network messages as `NetworkRequest`, this isn't very useful, it'd be better to show what type of message it is. Let's parse the network event and set the subtitle to message type. There's still a `Network` prefix to indicate that this is a network message.