### PR TITLE
hack: experimental chunk execution

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3789,15 +3789,25 @@ impl Chain {
 
         let runtime = self.runtime_adapter.clone();
         let epoch_manager = self.epoch_manager.clone();
+
         Ok(Some((
             shard_id,
             Box::new(move |parent_span| -> Result<ShardUpdateResult, Error> {
+                let _ = process_shard_update(
+                    parent_span,
+                    runtime.as_ref(),
+                    epoch_manager.as_ref(),
+                    shard_update_reason.clone(),
+                    shard_context.clone(),
+                    near_primitives::apply::ApplyChunkReason::Experiment,
+                );
                 Ok(process_shard_update(
                     parent_span,
                     runtime.as_ref(),
                     epoch_manager.as_ref(),
                     shard_update_reason,
                     shard_context,
+                    near_primitives::apply::ApplyChunkReason::UpdateTrackedShard,
                 )?)
             }),
         )))

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -263,6 +263,7 @@ impl ChainGenesis {
     }
 }
 
+#[derive(Clone)]
 pub enum StorageDataSource {
     /// Full state data is present in DB.
     Db,

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -58,6 +58,7 @@ pub enum ShardUpdateResult {
 /// State roots of children shards which are ready.
 type ReshardingStateRoots = HashMap<ShardUId, StateRoot>;
 
+#[derive(Clone)]
 pub struct NewChunkData {
     pub chunk_header: ShardChunkHeader,
     pub transactions: Vec<SignedTransaction>,
@@ -68,6 +69,7 @@ pub struct NewChunkData {
     pub storage_context: StorageContext,
 }
 
+#[derive(Clone)]
 pub struct OldChunkData {
     pub prev_chunk_extra: ChunkExtra,
     pub resharding_state_roots: Option<ReshardingStateRoots>,
@@ -75,6 +77,7 @@ pub struct OldChunkData {
     pub storage_context: StorageContext,
 }
 
+#[derive(Clone)]
 pub struct ReshardingData {
     pub resharding_state_roots: ReshardingStateRoots,
     pub state_changes: StateChangesForResharding,
@@ -85,6 +88,7 @@ pub struct ReshardingData {
 /// Reason to update a shard when new block appears on chain.
 /// All types include state roots for children shards in case of resharding.
 #[allow(clippy::large_enum_variant)]
+#[derive(Clone)]
 pub enum ShardUpdateReason {
     /// Block has a new chunk for the shard.
     /// Contains chunk itself and all new incoming receipts to the shard.
@@ -99,6 +103,7 @@ pub enum ShardUpdateReason {
 }
 
 /// Information about shard to update.
+#[derive(Clone)]
 pub struct ShardContext {
     pub shard_uid: ShardUId,
     /// Whether node cares about shard in this epoch.
@@ -112,6 +117,7 @@ pub struct ShardContext {
 }
 
 /// Information about storage used for applying txs and receipts.
+#[derive(Clone)]
 pub struct StorageContext {
     /// Data source used for processing shard update.
     pub storage_data_source: StorageDataSource,
@@ -126,10 +132,11 @@ pub fn process_shard_update(
     epoch_manager: &dyn EpochManagerAdapter,
     shard_update_reason: ShardUpdateReason,
     shard_context: ShardContext,
+    apply_chunk_reason: ApplyChunkReason,
 ) -> Result<ShardUpdateResult, Error> {
     Ok(match shard_update_reason {
         ShardUpdateReason::NewChunk(data) => ShardUpdateResult::NewChunk(apply_new_chunk(
-            ApplyChunkReason::UpdateTrackedShard,
+            apply_chunk_reason,
             parent_span,
             data,
             shard_context,
@@ -137,7 +144,7 @@ pub fn process_shard_update(
             epoch_manager,
         )?),
         ShardUpdateReason::OldChunk(data) => ShardUpdateResult::OldChunk(apply_old_chunk(
-            ApplyChunkReason::UpdateTrackedShard,
+            apply_chunk_reason,
             parent_span,
             data,
             shard_context,

--- a/core/primitives-core/src/apply.rs
+++ b/core/primitives-core/src/apply.rs
@@ -11,6 +11,7 @@ pub enum ApplyChunkReason {
     UpdateTrackedShard,
     /// Apply-chunk is invoked to validate the state witness for a shard in the context of stateless validation.
     ValidateChunkStateWitness,
+    Experiment,
 }
 
 impl ApplyChunkReason {
@@ -19,6 +20,7 @@ impl ApplyChunkReason {
         match self {
             ApplyChunkReason::UpdateTrackedShard => "update_shard",
             ApplyChunkReason::ValidateChunkStateWitness => "validate_chunk",
+            ApplyChunkReason::Experiment => "experiment",
         }
     }
 }

--- a/core/primitives/src/sandbox.rs
+++ b/core/primitives/src/sandbox.rs
@@ -9,7 +9,7 @@ pub mod state_patch {
     /// object can be non-empty only if `sandbox` feature is enabled.  On
     /// non-sandbox build, this struct is ZST and its methods are essentially
     /// short-circuited by treating the type as always empty.
-    #[derive(Default)]
+    #[derive(Default, Clone)]
     pub struct SandboxStatePatch {
         records: Vec<StateRecord>,
     }
@@ -50,7 +50,7 @@ pub mod state_patch {
 pub mod state_patch {
     use crate::state_record::StateRecord;
 
-    #[derive(Default)]
+    #[derive(Default, Clone)]
     pub struct SandboxStatePatch;
 
     impl SandboxStatePatch {

--- a/runtime/runtime/src/metrics.rs
+++ b/runtime/runtime/src/metrics.rs
@@ -437,7 +437,7 @@ pub(crate) static CHUNK_RECEIPTS_LIMITED_BY: LazyLock<IntCounterVec> = LazyLock:
     try_create_int_counter_vec(
         "near_chunk_receipts_limited_by",
         "Number of chunks where the number of processed receipts was limited by a certain factor.",
-        &["shard_id", "limited_by"],
+        &["shard_id", "apply_reason", "limited_by"],
     )
     .unwrap()
 });

--- a/tools/replay-archive/src/cli.rs
+++ b/tools/replay-archive/src/cli.rs
@@ -365,6 +365,7 @@ impl ReplayController {
             self.epoch_manager.as_ref(),
             update_reason,
             shard_context,
+            near_primitives::apply::ApplyChunkReason::UpdateTrackedShard
         )?;
 
         let output = match shard_update_result {


### PR DESCRIPTION
This PR executes `apply_chunk` with `ApplyChunkReason::Experiment` along with the normal execution with `ApplyChunkReason::UpdateTrackedShard`. This way we can modify runtime behaviour based on `apply_state.apply_reason` and compare the metrics we are interested in. 