### PR TITLE
Pipelining

### DIFF
--- a/core/store/src/contract.rs
+++ b/core/store/src/contract.rs
@@ -1,0 +1,52 @@
+use crate::TrieStorage;
+use near_primitives::hash::CryptoHash;
+use near_vm_runner::ContractCode;
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+/// Reads contract code from the trie by its hash.
+///
+/// Cloning is cheap.
+#[derive(Clone)]
+pub struct ContractStorage {
+    storage: Arc<dyn TrieStorage>,
+
+    /// During an apply of a single chunk contracts may be deployed through the
+    /// `Action::DeployContract`.
+    ///
+    /// Unfortunately `TrieStorage` does not have a way to write to the underlying storage, and the
+    /// `TrieUpdate` will only write the contract once the whole transaction is committed at the
+    /// end of the chunk's apply.
+    ///
+    /// As a temporary work-around while we're still involving `Trie` for `ContractCode` storage,
+    /// we'll keep a list of such deployed contracts here. Once the contracts are no longer part of
+    /// The State this field should be removed, and the `Storage::store` function should be
+    /// adjusted to write out the contract into the relevant part of the database immediately
+    /// (without going through transactional storage operations and such).
+    uncommitted_deploys: Arc<Mutex<BTreeMap<CryptoHash, ContractCode>>>,
+}
+
+impl ContractStorage {
+    pub fn new(storage: Arc<dyn TrieStorage>) -> Self {
+        Self { storage, uncommitted_deploys: Default::default() }
+    }
+
+    pub fn get(&self, code_hash: CryptoHash) -> Option<ContractCode> {
+        {
+            let guard = self.uncommitted_deploys.lock().expect("no panics");
+            if let Some(v) = guard.get(&code_hash) {
+                return Some(ContractCode::new(v.code().to_vec(), Some(code_hash)));
+            }
+        }
+
+        match self.storage.retrieve_raw_bytes(&code_hash) {
+            Ok(raw_code) => Some(ContractCode::new(raw_code.to_vec(), Some(code_hash))),
+            Err(_) => None,
+        }
+    }
+
+    pub fn store(&self, code: ContractCode) {
+        let mut guard = self.uncommitted_deploys.lock().expect("no panics");
+        guard.insert(*code.hash(), code);
+    }
+}

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -46,6 +46,7 @@ use strum;
 pub mod cold_storage;
 mod columns;
 pub mod config;
+pub mod contract;
 pub mod db;
 pub mod flat;
 pub mod genesis;
@@ -968,15 +969,6 @@ pub fn get_access_key_raw(
 
 pub fn set_code(state_update: &mut TrieUpdate, account_id: AccountId, code: &ContractCode) {
     state_update.set(TrieKey::ContractCode { account_id }, code.code().to_vec());
-}
-
-pub fn get_code(
-    trie: &dyn TrieAccess,
-    account_id: &AccountId,
-    code_hash: Option<CryptoHash>,
-) -> Result<Option<ContractCode>, StorageError> {
-    let key = TrieKey::ContractCode { account_id: account_id.clone() };
-    trie.get(&key).map(|opt| opt.map(|code| ContractCode::new(code, code_hash)))
 }
 
 /// Removes account, code and all access keys associated to it.

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -1142,6 +1142,18 @@ impl ContractRuntimeCache for StoreContractRuntimeCache {
     }
 }
 
+/// Get the contract WASM code from The State.
+///
+/// Executing all the usual storage access side-effects.
+pub fn get_code(
+    trie: &dyn TrieAccess,
+    account_id: &AccountId,
+    code_hash: Option<CryptoHash>,
+) -> Result<Option<ContractCode>, StorageError> {
+    let key = TrieKey::ContractCode { account_id: account_id.clone() };
+    trie.get(&key).map(|opt| opt.map(|code| ContractCode::new(code, code_hash)))
+}
+
 #[cfg(test)]
 mod tests {
     use near_primitives::hash::CryptoHash;

--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -271,7 +271,7 @@ mod tests {
             // Check that the accessed nodes are consistent with those from disk.
             for (node_hash, serialized_node) in nodes_accessed {
                 let expected_serialized_node =
-                    trie.internal_retrieve_trie_node(&node_hash, false).unwrap();
+                    trie.internal_retrieve_trie_node(&node_hash, false, true).unwrap();
                 assert_eq!(expected_serialized_node, serialized_node);
             }
         }

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -1756,9 +1756,12 @@ impl TrieAccess for Trie {
         };
         match node {
             Some(optimized_ref) => Ok(Some(match &optimized_ref {
-                OptimizedValueRef::Ref(value_ref) => self.retrieve_value(&value_ref.hash),
-                OptimizedValueRef::AvailableValue(ValueAccessToken { value }) => Ok(value.clone()),
-            }?)),
+                OptimizedValueRef::Ref(value_ref) => {
+                    let bytes = self.internal_retrieve_trie_node(&value_ref.hash, false, false)?;
+                    bytes.to_vec()
+                }
+                OptimizedValueRef::AvailableValue(ValueAccessToken { value }) => value.clone(),
+            })),
             None => Ok(None),
         }
     }

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -370,6 +370,9 @@ pub trait TrieAccess {
     /// argument.
     fn get(&self, key: &TrieKey) -> Result<Option<Vec<u8>>, StorageError>;
 
+    /// Retrieves value with given key without incurring any side-effects.
+    fn get_no_side_effects(&self, key: &TrieKey) -> Result<Option<Vec<u8>>, StorageError>;
+
     /// Check if the key is present.
     ///
     /// Equivalent to `Self::get(k)?.is_some()`, but avoids reading out the value.
@@ -817,16 +820,19 @@ impl Trie {
         &self,
         hash: &CryptoHash,
         use_accounting_cache: bool,
+        side_effects: bool,
     ) -> Result<Arc<[u8]>, StorageError> {
-        let result = if use_accounting_cache {
+        let result = if side_effects && use_accounting_cache {
             self.accounting_cache
                 .borrow_mut()
                 .retrieve_raw_bytes_with_accounting(hash, &*self.storage)?
         } else {
             self.storage.retrieve_raw_bytes(hash)?
         };
-        if let Some(recorder) = &self.recorder {
-            recorder.borrow_mut().record(hash, result.clone());
+        if side_effects {
+            if let Some(recorder) = &self.recorder {
+                recorder.borrow_mut().record(hash, result.clone());
+            }
         }
         Ok(result)
     }
@@ -887,7 +893,7 @@ impl Trie {
     ) -> Result<(), StorageError> {
         match value {
             ValueHandle::HashAndSize(value) => {
-                self.internal_retrieve_trie_node(&value.hash, true)?;
+                self.internal_retrieve_trie_node(&value.hash, true, true)?;
                 memory.refcount_changes.subtract(value.hash, 1);
             }
             ValueHandle::InMemory(_) => {
@@ -1088,7 +1094,7 @@ impl Trie {
         }
         *limit -= 1;
 
-        let (bytes, raw_node, mem_usage) = match self.retrieve_raw_node(hash, true) {
+        let (bytes, raw_node, mem_usage) = match self.retrieve_raw_node(hash, true, true) {
             Ok(Some((bytes, raw_node))) => (bytes, raw_node.node, raw_node.memory_usage),
             Ok(None) => return writeln!(f, "{spaces}EmptyNode"),
             Err(err) => return writeln!(f, "{spaces}error {err}"),
@@ -1194,11 +1200,12 @@ impl Trie {
         &self,
         hash: &CryptoHash,
         use_accounting_cache: bool,
+        side_effects: bool,
     ) -> Result<Option<(std::sync::Arc<[u8]>, RawTrieNodeWithSize)>, StorageError> {
         if hash == &Self::EMPTY_ROOT {
             return Ok(None);
         }
-        let bytes = self.internal_retrieve_trie_node(hash, use_accounting_cache)?;
+        let bytes = self.internal_retrieve_trie_node(hash, use_accounting_cache, side_effects)?;
         let node = RawTrieNodeWithSize::try_from_slice(&bytes).map_err(|err| {
             StorageError::StorageInconsistentState(format!("Failed to decode node {hash}: {err}"))
         })?;
@@ -1212,7 +1219,7 @@ impl Trie {
         &self,
         hash: &CryptoHash,
     ) -> Result<NodeOrValue, StorageError> {
-        let bytes = self.internal_retrieve_trie_node(hash, true)?;
+        let bytes = self.internal_retrieve_trie_node(hash, true, true)?;
         match RawTrieNodeWithSize::try_from_slice(&bytes) {
             Ok(_) => Ok(NodeOrValue::Node),
             Err(_) => Ok(NodeOrValue::Value(bytes)),
@@ -1224,7 +1231,7 @@ impl Trie {
         memory: &mut NodesStorage,
         hash: &CryptoHash,
     ) -> Result<StorageHandle, StorageError> {
-        match self.retrieve_raw_node(hash, true)? {
+        match self.retrieve_raw_node(hash, true, true)? {
             None => Ok(memory.store(TrieNodeWithSize::empty())),
             Some((_, node)) => {
                 let result = memory.store(TrieNodeWithSize::from_raw(node));
@@ -1244,14 +1251,14 @@ impl Trie {
         &self,
         hash: &CryptoHash,
     ) -> Result<(Option<std::sync::Arc<[u8]>>, TrieNodeWithSize), StorageError> {
-        match self.retrieve_raw_node(hash, true)? {
+        match self.retrieve_raw_node(hash, true, true)? {
             None => Ok((None, TrieNodeWithSize::empty())),
             Some((bytes, node)) => Ok((Some(bytes), TrieNodeWithSize::from_raw(node))),
         }
     }
 
     pub fn retrieve_root_node(&self) -> Result<StateRootNode, StorageError> {
-        match self.retrieve_raw_node(&self.root, true)? {
+        match self.retrieve_raw_node(&self.root, true, true)? {
             None => Ok(StateRootNode::empty()),
             Some((bytes, node)) => {
                 Ok(StateRootNode { data: bytes, memory_usage: node.memory_usage })
@@ -1277,16 +1284,17 @@ impl Trie {
     fn lookup_from_flat_storage(
         &self,
         key: &[u8],
+        side_effects: bool,
     ) -> Result<Option<OptimizedValueRef>, StorageError> {
         let flat_storage_chunk_view = self.flat_storage_chunk_view.as_ref().unwrap();
         let value = flat_storage_chunk_view.get_value(key)?;
-        if self.recorder.is_some() {
+        if side_effects && self.recorder.is_some() {
             // If recording, we need to look up in the trie as well to record the trie nodes,
             // as they are needed to prove the value. Also, it's important that this lookup
             // is done even if the key was not found, because intermediate trie nodes may be
             // needed to prove the non-existence of the key.
             let value_ref_from_trie =
-                self.lookup_from_state_column(NibbleSlice::new(key), false)?;
+                self.lookup_from_state_column(NibbleSlice::new(key), false, side_effects)?;
             debug_assert_eq!(
                 &value_ref_from_trie,
                 &value.as_ref().map(|value| value.to_value_ref())
@@ -1305,10 +1313,15 @@ impl Trie {
         &self,
         mut key: NibbleSlice<'_>,
         charge_gas_for_trie_node_access: bool,
+        side_effects: bool,
     ) -> Result<Option<ValueRef>, StorageError> {
         let mut hash = self.root;
         loop {
-            let node = match self.retrieve_raw_node(&hash, charge_gas_for_trie_node_access)? {
+            let node = match self.retrieve_raw_node(
+                &hash,
+                charge_gas_for_trie_node_access,
+                side_effects,
+            )? {
                 None => return Ok(None),
                 Some((_bytes, node)) => node.node,
             };
@@ -1372,6 +1385,7 @@ impl Trie {
         &self,
         key: &[u8],
         charge_gas_for_trie_node_access: bool,
+        side_effects: bool,
         map_result: impl FnOnce(ValueView<'_>) -> R,
     ) -> Result<Option<R>, StorageError> {
         if self.root == Self::EMPTY_ROOT {
@@ -1387,9 +1401,11 @@ impl Trie {
                     .retroactively_account(*node_hash, serialized_node.clone());
             }
         }
-        if let Some(recorder) = &self.recorder {
-            for (node_hash, serialized_node) in accessed_nodes {
-                recorder.borrow_mut().record(&node_hash, serialized_node);
+        if side_effects {
+            if let Some(recorder) = &self.recorder {
+                for (node_hash, serialized_node) in accessed_nodes {
+                    recorder.borrow_mut().record(&node_hash, serialized_node);
+                }
             }
         }
         Ok(mem_value.map(map_result))
@@ -1425,7 +1441,7 @@ impl Trie {
 
         // The rest of the logic is very similar to the standard lookup() function, except
         // we return the raw node and don't expect to hit a leaf.
-        let mut node = self.retrieve_raw_node(&self.root, true)?;
+        let mut node = self.retrieve_raw_node(&self.root, true, true)?;
         while !key.is_empty() {
             match node {
                 Some((_, raw_node)) => match raw_node.node {
@@ -1437,7 +1453,7 @@ impl Trie {
                         let child = children[key.at(0)];
                         match child {
                             Some(child) => {
-                                node = self.retrieve_raw_node(&child, true)?;
+                                node = self.retrieve_raw_node(&child, true, true)?;
                                 key = key.mid(1);
                             }
                             None => return Ok(None),
@@ -1446,7 +1462,7 @@ impl Trie {
                     RawTrieNode::Extension(existing_key, child) => {
                         let existing_key = NibbleSlice::from_encoded(&existing_key).0;
                         if key.starts_with(&existing_key) {
-                            node = self.retrieve_raw_node(&child, true)?;
+                            node = self.retrieve_raw_node(&child, true, true)?;
                             key = key.mid(existing_key.len());
                         } else {
                             return Ok(None);
@@ -1465,7 +1481,7 @@ impl Trie {
     /// Returns the raw bytes corresponding to a ValueRef that came from a node with
     /// value (either Leaf or BranchWithValue).
     pub fn retrieve_value(&self, hash: &CryptoHash) -> Result<Vec<u8>, StorageError> {
-        let bytes = self.internal_retrieve_trie_node(hash, true)?;
+        let bytes = self.internal_retrieve_trie_node(hash, true, true)?;
         Ok(bytes.to_vec())
     }
 
@@ -1486,7 +1502,7 @@ impl Trie {
             mode == KeyLookupMode::Trie || self.charge_gas_for_trie_node_access;
         if self.memtries.is_some() {
             return Ok(self
-                .lookup_from_memory(key, charge_gas_for_trie_node_access, |_| ())?
+                .lookup_from_memory(key, charge_gas_for_trie_node_access, true, |_| ())?
                 .is_some());
         }
 
@@ -1500,14 +1516,14 @@ impl Trie {
                 // is done even if the key was not found, because intermediate trie nodes may be
                 // needed to prove the non-existence of the key.
                 let value_ref_from_trie =
-                    self.lookup_from_state_column(NibbleSlice::new(key), false)?;
+                    self.lookup_from_state_column(NibbleSlice::new(key), false, true)?;
                 debug_assert_eq!(&value_ref_from_trie.is_some(), &value);
             }
             return Ok(value);
         }
 
         Ok(self
-            .lookup_from_state_column(NibbleSlice::new(key), charge_gas_for_trie_node_access)?
+            .lookup_from_state_column(NibbleSlice::new(key), charge_gas_for_trie_node_access, true)?
             .is_some())
     }
 
@@ -1530,14 +1546,18 @@ impl Trie {
         let charge_gas_for_trie_node_access =
             mode == KeyLookupMode::Trie || self.charge_gas_for_trie_node_access;
         if self.memtries.is_some() {
-            self.lookup_from_memory(key, charge_gas_for_trie_node_access, |v| {
+            self.lookup_from_memory(key, charge_gas_for_trie_node_access, true, |v| {
                 v.to_optimized_value_ref()
             })
         } else if mode == KeyLookupMode::FlatStorage && self.flat_storage_chunk_view.is_some() {
-            self.lookup_from_flat_storage(key)
+            self.lookup_from_flat_storage(key, true)
         } else {
             Ok(self
-                .lookup_from_state_column(NibbleSlice::new(key), charge_gas_for_trie_node_access)?
+                .lookup_from_state_column(
+                    NibbleSlice::new(key),
+                    charge_gas_for_trie_node_access,
+                    true,
+                )?
                 .map(OptimizedValueRef::Ref))
         }
     }
@@ -1718,6 +1738,25 @@ impl<'a> TrieWithReadLock<'a> {
 impl TrieAccess for Trie {
     fn get(&self, key: &TrieKey) -> Result<Option<Vec<u8>>, StorageError> {
         Trie::get(self, &key.to_vec())
+    }
+
+    fn get_no_side_effects(&self, key: &TrieKey) -> Result<Option<Vec<u8>>, StorageError> {
+        let key = key.to_vec();
+        let node = if self.memtries.is_some() {
+            self.lookup_from_memory(&key, false, false, |v| v.to_optimized_value_ref())?
+        } else if self.flat_storage_chunk_view.is_some() {
+            self.lookup_from_flat_storage(&key, false)?
+        } else {
+            self.lookup_from_state_column(NibbleSlice::new(&key), false, false)?
+                .map(OptimizedValueRef::Ref)
+        };
+        match node {
+            Some(optimized_ref) => Ok(Some(match &optimized_ref {
+                OptimizedValueRef::Ref(value_ref) => self.retrieve_value(&value_ref.hash),
+                OptimizedValueRef::AvailableValue(ValueAccessToken { value }) => Ok(value.clone()),
+            }?)),
+            None => Ok(None),
+        }
     }
 
     fn contains_key(&self, key: &TrieKey) -> Result<bool, StorageError> {

--- a/core/store/src/trie/receipts_column_helper.rs
+++ b/core/store/src/trie/receipts_column_helper.rs
@@ -277,7 +277,9 @@ impl<'a> DoubleEndedIterator for ReceiptIterator<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
         let index = self.indices.next_back()?;
         let key = self.trie_queue.trie_key(index);
-        let result = match get(self.trie, &key) {
+        let value =
+            if self.side_effects { get(self.trie, &key) } else { get_pure(self.trie, &key) };
+        let result = match value {
             Err(e) => Err(e),
             Ok(None) => Err(StorageError::StorageInconsistentState(
                 "Receipt referenced by index should be in the state".to_owned(),

--- a/core/store/src/trie/receipts_column_helper.rs
+++ b/core/store/src/trie/receipts_column_helper.rs
@@ -1,4 +1,4 @@
-use crate::{get, set, TrieAccess, TrieUpdate};
+use crate::{get, get_pure, set, TrieAccess, TrieUpdate};
 use near_primitives::errors::{IntegerOverflowError, StorageError};
 use near_primitives::receipt::{BufferedReceiptIndices, Receipt, TrieQueueIndices};
 use near_primitives::trie_key::TrieKey;
@@ -12,6 +12,7 @@ pub struct ReceiptIterator<'a> {
     indices: std::ops::Range<u64>,
     trie_queue: &'a dyn TrieQueue,
     trie: &'a dyn TrieAccess,
+    side_effects: bool,
 }
 
 /// Type safe access to delayed receipts queue stored in the state. Only use one
@@ -144,15 +145,18 @@ pub trait TrieQueue {
         self.indices().len()
     }
 
-    fn iter<'a>(&'a self, trie: &'a dyn TrieAccess) -> ReceiptIterator<'a>
+    fn iter<'a>(&'a self, trie: &'a dyn TrieAccess, side_effects: bool) -> ReceiptIterator<'a>
     where
         Self: Sized,
     {
-        self.debug_check_unchanged(trie);
+        if side_effects {
+            self.debug_check_unchanged(trie);
+        }
         ReceiptIterator {
             indices: self.indices().first_index..self.indices().next_available_index,
             trie_queue: self,
             trie,
+            side_effects,
         }
     }
 
@@ -256,7 +260,9 @@ impl<'a> Iterator for ReceiptIterator<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let index = self.indices.next()?;
         let key = self.trie_queue.trie_key(index);
-        let result = match get(self.trie, &key) {
+        let value =
+            if self.side_effects { get(self.trie, &key) } else { get_pure(self.trie, &key) };
+        let result = match value {
             Err(e) => Err(e),
             Ok(None) => Err(StorageError::StorageInconsistentState(
                 "Receipt referenced by index should be in the state".to_owned(),
@@ -405,7 +411,7 @@ mod tests {
             queue.push(trie, receipt).expect("pushing must not fail");
         }
         let iterated_receipts: Vec<Receipt> =
-            queue.iter(trie).collect::<Result<_, _>>().expect("iterating should not fail");
+            queue.iter(trie, true).collect::<Result<_, _>>().expect("iterating should not fail");
 
         // check 1: receipts should be in queue and contained in the iterator
         assert_eq!(input_receipts, iterated_receipts, "receipts were not recorded in queue");
@@ -421,7 +427,7 @@ mod tests {
     ) {
         // check 2: assert newly loaded queue still contains the receipts
         let iterated_receipts: Vec<Receipt> =
-            queue.iter(trie).collect::<Result<_, _>>().expect("iterating should not fail");
+            queue.iter(trie, true).collect::<Result<_, _>>().expect("iterating should not fail");
         assert_eq!(input_receipts, iterated_receipts, "receipts were not persisted correctly");
 
         // check 3: pop receipts from queue and check if all are returned in the right order

--- a/core/store/src/trie/resharding_v2.rs
+++ b/core/store/src/trie/resharding_v2.rs
@@ -1,6 +1,7 @@
 use crate::flat::FlatStateChanges;
 use crate::{
-    get, get_delayed_receipt_indices, get_promise_yield_indices, set, ShardTries, StoreUpdate, Trie, TrieAccess as _, TrieUpdate
+    get, get_delayed_receipt_indices, get_promise_yield_indices, set, ShardTries, StoreUpdate,
+    Trie, TrieAccess as _, TrieUpdate,
 };
 use borsh::BorshDeserialize;
 use bytesize::ByteSize;

--- a/core/store/src/trie/resharding_v2.rs
+++ b/core/store/src/trie/resharding_v2.rs
@@ -1,7 +1,6 @@
 use crate::flat::FlatStateChanges;
 use crate::{
-    get, get_delayed_receipt_indices, get_promise_yield_indices, set, ShardTries, StoreUpdate,
-    Trie, TrieUpdate,
+    get, get_delayed_receipt_indices, get_promise_yield_indices, set, ShardTries, StoreUpdate, Trie, TrieAccess as _, TrieUpdate
 };
 use borsh::BorshDeserialize;
 use bytesize::ByteSize;

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -1,40 +1,18 @@
 pub use self::iterator::TrieUpdateIterator;
 use super::accounting_cache::TrieAccountingCacheSwitch;
 use super::{OptimizedValueRef, Trie, TrieWithReadLock};
+use crate::contract::ContractStorage;
 use crate::trie::{KeyLookupMode, TrieChanges};
-use crate::{StorageError, TrieStorage};
+use crate::StorageError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{
     AccountId, RawStateChange, RawStateChanges, RawStateChangesWithTrieKey, StateChangeCause,
     StateRoot, TrieCacheMode,
 };
-use near_vm_runner::ContractCode;
 use std::collections::BTreeMap;
-use std::sync::Arc;
 
 mod iterator;
-
-/// Reads contract code from the trie by its hash.
-/// Currently, uses `TrieStorage`. Consider implementing separate logic for
-/// requesting and compiling contracts, as any contract code read and
-/// compilation is a major bottleneck during chunk execution.
-struct ContractStorage {
-    storage: Arc<dyn TrieStorage>,
-}
-
-impl ContractStorage {
-    fn new(storage: Arc<dyn TrieStorage>) -> Self {
-        Self { storage }
-    }
-
-    pub fn get(&self, code_hash: CryptoHash) -> Option<ContractCode> {
-        match self.storage.retrieve_raw_bytes(&code_hash) {
-            Ok(raw_code) => Some(ContractCode::new(raw_code.to_vec(), Some(code_hash))),
-            Err(_) => None,
-        }
-    }
-}
 
 /// Key-value update. Contains a TrieKey and a value.
 pub struct TrieKeyValueUpdate {
@@ -49,7 +27,7 @@ pub type TrieUpdates = BTreeMap<Vec<u8>, TrieKeyValueUpdate>;
 /// TODO (#7327): rename to StateUpdate
 pub struct TrieUpdate {
     pub trie: Trie,
-    contract_storage: ContractStorage,
+    pub contract_storage: ContractStorage,
     committed: RawStateChanges,
     prospective: TrieUpdates,
 }

--- a/integration-tests/src/tests/client/features/fix_storage_usage.rs
+++ b/integration-tests/src/tests/client/features/fix_storage_usage.rs
@@ -5,7 +5,7 @@ use near_client::test_utils::TestEnv;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::version::ProtocolFeature;
 use near_primitives::{trie_key::TrieKey, types::AccountId};
-use near_store::{ShardUId, TrieUpdate};
+use near_store::{ShardUId, TrieAccess, TrieUpdate};
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
 
 use crate::tests::client::process_blocks::set_block_protocol_version;

--- a/integration-tests/src/tests/client/features/nearvm.rs
+++ b/integration-tests/src/tests/client/features/nearvm.rs
@@ -96,6 +96,14 @@ fn test_nearvm_upgrade() {
         capture.drain()
     };
 
-    assert!(logs_at_old_version.iter().any(|l| l.contains(&"vm_kind=Wasmer2")));
-    assert!(dbg!(logs_at_new_version).iter().any(|l| l.contains(&"vm_kind=NearVm")));
+    assert!(
+        logs_at_old_version.iter().any(|l| l.contains(&"Wasmer2VM::run_method")),
+        "{:#?}",
+        logs_at_old_version
+    );
+    assert!(
+        logs_at_new_version.iter().any(|l| l.contains(&"NearVM::run_method")),
+        "{:#?}",
+        logs_at_new_version
+    );
 }

--- a/integration-tests/src/tests/runtime/state_viewer.rs
+++ b/integration-tests/src/tests/runtime/state_viewer.rs
@@ -1,12 +1,11 @@
 use std::{collections::HashMap, io, sync::Arc};
 
 use borsh::BorshDeserialize;
-use near_vm_runner::ContractCode;
 
 use crate::runtime_utils::{get_runtime_and_trie, get_test_trie_viewer, TEST_SHARD_UID};
 use near_primitives::{
     account::Account,
-    hash::CryptoHash,
+    hash::{hash as sha256, CryptoHash},
     serialize::to_base64,
     trie_key::trie_key_parsers,
     types::{AccountId, StateRoot},
@@ -375,14 +374,12 @@ fn test_view_state_with_large_contract() {
     let (_, tries, root) = get_runtime_and_trie();
     let mut state_update = tries.new_trie_update(TEST_SHARD_UID, root);
     let contract_code = [0; Account::MAX_ACCOUNT_DELETION_STORAGE_USAGE as usize].to_vec();
-    let code = ContractCode::new(contract_code, None);
     set_account(
         &mut state_update,
         alice_account(),
-        &Account::new(0, 0, 0, *code.hash(), 50_001, PROTOCOL_VERSION),
+        &Account::new(0, 0, 0, sha256(&contract_code), 50_001, PROTOCOL_VERSION),
     );
-    // FIXME: this really should use the deploy action.
-    state_update.contract_storage.store(code);
+    state_update.set(TrieKey::ContractCode { account_id: alice_account() }, contract_code);
     let trie_viewer = TrieViewer::new(Some(50_000), None);
     let result = trie_viewer.view_state(&state_update, &alice_account(), b"", false);
     assert!(result.is_ok());

--- a/runtime/near-vm-runner/src/near_vm_runner/runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner/runner.rs
@@ -331,7 +331,7 @@ impl NearVM {
         mut import: NearVmImports<'_, '_, '_>,
         entrypoint: FunctionIndex,
     ) -> Result<Result<(), FunctionCallError>, VMRunnerError> {
-        let _span = tracing::debug_span!(target: "vm", "run_method").entered();
+        let _span = tracing::debug_span!(target: "vm", "NearVM::run_method").entered();
 
         // FastGasCounter in Nearcore must be reinterpret_cast-able to the one in NearVm.
         assert_eq!(
@@ -349,7 +349,8 @@ impl NearVM {
         let gas = import.vmlogic.gas_counter().fast_counter_raw_ptr();
         unsafe {
             let instance = {
-                let _span = tracing::debug_span!(target: "vm", "run_method/instantiate").entered();
+                let _span =
+                    tracing::debug_span!(target: "vm", "NearVM::run_method/instantiate").entered();
                 // An important caveat is that the `'static` lifetime here refers to the lifetime
                 // of `VMLogic` reference to which is retained by the `InstanceHandle` we create.
                 // However this `InstanceHandle` only lives during the execution of this body, so
@@ -396,7 +397,7 @@ impl NearVM {
                 handle
             };
             if let Some(function) = instance.function_by_index(entrypoint) {
-                let _span = tracing::debug_span!(target: "vm", "run_method/call").entered();
+                let _span = tracing::debug_span!(target: "vm", "NearVM::run_method/call").entered();
                 // Signature for the entry point should be `() -> ()`. This is only a sanity check
                 // – this should've been already checked by `get_entrypoint_index`.
                 let signature = artifact

--- a/runtime/near-vm-runner/src/wasmer2_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer2_runner.rs
@@ -400,7 +400,7 @@ impl Wasmer2VM {
         mut import: Wasmer2Imports<'_, '_, '_>,
         entrypoint: FunctionIndex,
     ) -> Result<Result<(), FunctionCallError>, VMRunnerError> {
-        let _span = tracing::debug_span!(target: "vm", "run_method").entered();
+        let _span = tracing::debug_span!(target: "vm", "Wasmer2VM::run_method").entered();
 
         // FastGasCounter in Nearcore and Wasmer must match in layout.
         assert_eq!(size_of::<FastGasCounter>(), size_of::<wasmer_types::FastGasCounter>());
@@ -419,7 +419,8 @@ impl Wasmer2VM {
         let gas = import.vmlogic.gas_counter().fast_counter_raw_ptr();
         unsafe {
             let instance = {
-                let _span = tracing::debug_span!(target: "vm", "run_method/instantiate").entered();
+                let _span = tracing::debug_span!(target: "vm", "Wasmer2VM::run_method/instantiate")
+                    .entered();
                 // An important caveat is that the `'static` lifetime here refers to the lifetime
                 // of `VMLogic` reference to which is retained by the `InstanceHandle` we create.
                 // However this `InstanceHandle` only lives during the execution of this body, so
@@ -467,7 +468,8 @@ impl Wasmer2VM {
                 handle
             };
             if let Some(function) = instance.function_by_index(entrypoint) {
-                let _span = tracing::debug_span!(target: "vm", "run_method/call").entered();
+                let _span =
+                    tracing::debug_span!(target: "vm", "Wasmer2VM::run_method/call").entered();
                 // Signature for the entry point should be `() -> ()`. This is only a sanity check
                 // – this should've been already checked by `get_entrypoint_index`.
                 let signature = artifact
@@ -502,7 +504,8 @@ impl Wasmer2VM {
 
             {
                 let _span =
-                    tracing::debug_span!(target: "vm", "run_method/drop_instance").entered();
+                    tracing::debug_span!(target: "vm", "Wasmer2VM::run_method/drop_instance")
+                        .entered();
                 drop(instance)
             }
         }

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -262,10 +262,11 @@ fn run_method(
     import: &ImportObject,
     method_name: &str,
 ) -> Result<Result<(), FunctionCallError>, VMRunnerError> {
-    let _span = tracing::debug_span!(target: "vm", "run_method").entered();
+    let _span = tracing::debug_span!(target: "vm", "Wasmer0VM::run_method").entered();
 
     let instance = {
-        let _span = tracing::debug_span!(target: "vm", "run_method/instantiate").entered();
+        let _span =
+            tracing::debug_span!(target: "vm", "Wasmer0VM::run_method/instantiate").entered();
         match module.instantiate(import) {
             Ok(instance) => instance,
             Err(err) => {
@@ -276,7 +277,7 @@ fn run_method(
     };
 
     {
-        let _span = tracing::debug_span!(target: "vm", "run_method/call").entered();
+        let _span = tracing::debug_span!(target: "vm", "Wasmer0VM::run_method/call").entered();
         if let Err(err) = instance.call(method_name, &[]) {
             let guest_aborted = err.into_vm_error()?;
             return Ok(Err(guest_aborted));
@@ -284,7 +285,8 @@ fn run_method(
     }
 
     {
-        let _span = tracing::debug_span!(target: "vm", "run_method/drop_instance").entered();
+        let _span =
+            tracing::debug_span!(target: "vm", "Wasmer0VM::run_method/drop_instance").entered();
         drop(instance)
     }
 

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -30,7 +30,9 @@ use near_primitives::version::{
 };
 use near_primitives_core::account::id::AccountType;
 use near_store::{
-    enqueue_promise_yield_timeout, get_access_key, get_code, get_promise_yield_indices, remove_access_key, remove_account, set_access_key, set_code, set_promise_yield_indices, StorageError, TrieUpdate
+    enqueue_promise_yield_timeout, get_access_key, get_code, get_promise_yield_indices,
+    remove_access_key, remove_account, set_access_key, set_code, set_promise_yield_indices,
+    StorageError, TrieUpdate,
 };
 use near_vm_runner::logic::errors::{
     CompilationError, FunctionCallError, InconsistentStateError, VMRunnerError,

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -2,7 +2,7 @@ use crate::config::{
     safe_add_compute, safe_add_gas, total_prepaid_exec_fees, total_prepaid_gas,
     total_prepaid_send_fees,
 };
-use crate::ext::{ExternalError, RuntimeContractExt, RuntimeExt};
+use crate::ext::{ExternalError, RuntimeExt};
 use crate::receipt_manager::ReceiptManager;
 use crate::{metrics, ActionResult, ApplyState};
 use near_crypto::PublicKey;
@@ -30,16 +30,15 @@ use near_primitives::version::{
 };
 use near_primitives_core::account::id::AccountType;
 use near_store::{
-    enqueue_promise_yield_timeout, get_access_key, get_code, get_promise_yield_indices,
-    remove_access_key, remove_account, set_access_key, set_code, set_promise_yield_indices,
-    StorageError, TrieUpdate,
+    enqueue_promise_yield_timeout, get_access_key, get_promise_yield_indices, remove_access_key,
+    remove_account, set_access_key, set_code, set_promise_yield_indices, StorageError, TrieUpdate,
 };
 use near_vm_runner::logic::errors::{
     CompilationError, FunctionCallError, InconsistentStateError, VMRunnerError,
 };
 use near_vm_runner::logic::{VMContext, VMOutcome};
-use near_vm_runner::ContractCode;
 use near_vm_runner::{precompile_contract, PreparedContract};
+use near_vm_runner::{ContractCode, ContractRuntimeCache};
 use near_wallet_contract::{wallet_contract, wallet_contract_magic_bytes};
 use std::sync::Arc;
 
@@ -159,42 +158,6 @@ pub(crate) fn execute_function_call(
     }
 
     Ok(outcome)
-}
-
-pub(crate) fn prepare_function_call(
-    state_update: &TrieUpdate,
-    apply_state: &ApplyState,
-    account: &Account,
-    account_id: &AccountId,
-    function_call: &FunctionCallAction,
-    config: &RuntimeConfig,
-    view_config: Option<ViewConfig>,
-) -> Box<dyn PreparedContract> {
-    let max_gas_burnt = match view_config {
-        Some(ViewConfig { max_gas_burnt }) => max_gas_burnt,
-        None => config.wasm_config.limit_config.max_gas_burnt,
-    };
-    let gas_counter = near_vm_runner::logic::GasCounter::new(
-        config.wasm_config.ext_costs.clone(),
-        max_gas_burnt,
-        config.wasm_config.regular_op_cost,
-        function_call.gas,
-        view_config.is_some(),
-    );
-    let code_ext = RuntimeContractExt {
-        trie_update: state_update,
-        account_id,
-        account,
-        current_protocol_version: apply_state.current_protocol_version,
-    };
-    let contract = near_vm_runner::prepare(
-        &code_ext,
-        Arc::clone(&config.wasm_config),
-        apply_state.cache.as_deref(),
-        gas_counter,
-        &function_call.method_name,
-    );
-    contract
 }
 
 pub(crate) fn action_function_call(
@@ -644,11 +607,12 @@ pub(crate) fn action_deploy_contract(
     account: &mut Account,
     account_id: &AccountId,
     deploy_contract: &DeployContractAction,
-    apply_state: &ApplyState,
+    config: Arc<near_parameters::vm::Config>,
+    cache: Option<&dyn ContractRuntimeCache>,
 ) -> Result<(), StorageError> {
     let _span = tracing::debug_span!(target: "runtime", "action_deploy_contract").entered();
     let code = ContractCode::new(deploy_contract.code.clone(), None);
-    let prev_code = get_code(state_update, account_id, Some(account.code_hash()))?;
+    let prev_code = state_update.contract_storage.get(account.code_hash());
     let prev_code_length = prev_code.map(|code| code.code().len() as u64).unwrap_or_default();
     account.set_storage_usage(account.storage_usage().saturating_sub(prev_code_length));
     account.set_storage_usage(
@@ -660,16 +624,20 @@ pub(crate) fn action_deploy_contract(
         })?,
     );
     account.set_code_hash(*code.hash());
+    // Legacy: populate the mapping from `AccountId => sha256(code)` thus making contracts part of
+    // The State. For the time being we are also relying on the `TrieUpdate` to actually write the
+    // contracts into the storage as part of the commit routine, however no code should be relying
+    // that the contracts are written to The State.
     set_code(state_update, account_id.clone(), &code);
-    // Precompile the contract and store result (compiled code or error) in the database.
-    // Note, that contract compilation costs are already accounted in deploy cost using
-    // special logic in estimator (see get_runtime_config() function).
-    precompile_contract(
-        &code,
-        Arc::clone(&apply_state.config.wasm_config),
-        apply_state.cache.as_deref(),
-    )
-    .ok();
+    // Precompile the contract and store result (compiled code or error) in the contract runtime
+    // cache.
+    // Note, that contract compilation costs are already accounted in deploy cost using special
+    // logic in estimator (see get_runtime_config() function).
+    precompile_contract(&code, config, cache).ok();
+    // Inform the `store::contract::Storage` about the new deploy (so that the `get` method can
+    // return the contract before the contract is written out to the underlying storage as part of
+    // the `TrieUpdate` commit.)
+    state_update.contract_storage.store(code);
     Ok(())
 }
 
@@ -686,7 +654,7 @@ pub(crate) fn action_delete_account(
     if current_protocol_version >= ProtocolFeature::DeleteActionRestriction.protocol_version() {
         let account = account.as_ref().unwrap();
         let mut account_storage_usage = account.storage_usage();
-        let contract_code = get_code(state_update, account_id, Some(account.code_hash()))?;
+        let contract_code = state_update.contract_storage.get(account.code_hash());
         if let Some(code) = contract_code {
             // account storage usage should be larger than code size
             let code_len = code.code().len() as u64;
@@ -1189,10 +1157,8 @@ mod tests {
     use near_primitives::action::delegate::NonDelegateAction;
     use near_primitives::congestion_info::BlockCongestionInfo;
     use near_primitives::errors::InvalidAccessKeyError;
-    use near_primitives::hash::hash;
     use near_primitives::runtime::migration_data::MigrationFlags;
     use near_primitives::transaction::CreateAccountAction;
-    use near_primitives::trie_key::TrieKey;
     use near_primitives::types::{EpochId, StateChangeCause};
     use near_primitives_core::version::PROTOCOL_VERSION;
     use near_store::set_account;
@@ -1354,11 +1320,25 @@ mod tests {
         let mut state_update =
             tries.new_trie_update(ShardUId::single_shard(), CryptoHash::default());
         let account_id = "alice".parse::<AccountId>().unwrap();
-        let trie_key = TrieKey::ContractCode { account_id: account_id.clone() };
-        let empty_contract = [0; 10_000].to_vec();
-        let contract_hash = hash(&empty_contract);
-        state_update.set(trie_key, empty_contract);
-        test_delete_large_account(&account_id, &contract_hash, storage_usage, &mut state_update)
+        let deploy_action = DeployContractAction { code: [0; 10_000].to_vec() };
+        let mut account =
+            Account::new(100, 0, 0, CryptoHash::default(), storage_usage, PROTOCOL_VERSION);
+        let apply_state = create_apply_state(0);
+        let res = action_deploy_contract(
+            &mut state_update,
+            &mut account,
+            &account_id,
+            &deploy_action,
+            Arc::clone(&apply_state.config.wasm_config),
+            None,
+        );
+        assert!(res.is_ok());
+        test_delete_large_account(
+            &account_id,
+            &account.code_hash(),
+            storage_usage,
+            &mut state_update,
+        )
     }
 
     #[test]

--- a/runtime/runtime/src/balance_checker.rs
+++ b/runtime/runtime/src/balance_checker.rs
@@ -151,7 +151,7 @@ fn buffered_receipts(
         // in which case the final index can be 0 and the initial index larger.
         if let Some(num_forwarded) = after.first_index.checked_sub(before.first_index) {
             // The first n receipts were forwarded.
-            for receipt in initial_buffer.iter(initial_state).take(num_forwarded as usize) {
+            for receipt in initial_buffer.iter(initial_state, true).take(num_forwarded as usize) {
                 forwarded_receipts.push(receipt?)
             }
         }
@@ -159,7 +159,7 @@ fn buffered_receipts(
             after.next_available_index.checked_sub(before.next_available_index)
         {
             // The last n receipts are new. ("rev" to take from the back)
-            for receipt in final_buffer.iter(final_state).rev().take(num_buffered as usize) {
+            for receipt in final_buffer.iter(final_state, true).rev().take(num_buffered as usize) {
                 new_buffered_receipts.push(receipt?);
             }
         }

--- a/runtime/runtime/src/congestion_control.rs
+++ b/runtime/runtime/src/congestion_control.rs
@@ -9,7 +9,7 @@ use near_primitives::receipt::{Receipt, ReceiptEnum};
 use near_primitives::types::{EpochInfoProvider, Gas, ShardId};
 use near_primitives::version::ProtocolFeature;
 use near_store::trie::receipts_column_helper::{
-    DelayedReceiptQueue, ShardsOutgoingReceiptBuffer, TrieQueue,
+    DelayedReceiptQueue, ReceiptIterator, ShardsOutgoingReceiptBuffer, TrieQueue,
 };
 use near_store::{StorageError, TrieAccess, TrieUpdate};
 use near_vm_runner::logic::ProtocolVersion;
@@ -443,6 +443,10 @@ impl DelayedReceiptQueueWrapper {
             self.removed_delayed_bytes = safe_add_gas(self.removed_delayed_bytes, delayed_bytes)?;
         }
         Ok(receipt)
+    }
+
+    pub(crate) fn peek_iter<'a>(&'a self, trie_update: &'a TrieUpdate) -> ReceiptIterator<'a> {
+        self.queue.iter(trie_update)
     }
 
     pub(crate) fn len(&self) -> u64 {

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -366,7 +366,6 @@ pub(crate) struct RuntimeContractExt<'a> {
     pub(crate) storage: ContractStorage,
     pub(crate) account_id: &'a AccountId,
     pub(crate) code_hash: CryptoHash,
-    pub(crate) chain_id: &'a str,
     pub(crate) current_protocol_version: ProtocolVersion,
 }
 

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -6,9 +6,10 @@ use near_primitives::checked_feature;
 use near_primitives::errors::{EpochError, StorageError};
 use near_primitives::hash::CryptoHash;
 use near_primitives::trie_key::{trie_key_parsers, TrieKey};
-use near_primitives::types::{AccountId, Balance, EpochId, EpochInfoProvider, Gas, TrieCacheMode};
+use near_primitives::types::{AccountId, Balance, EpochId, EpochInfoProvider, Gas};
 use near_primitives::utils::create_receipt_id_from_action_hash;
 use near_primitives::version::ProtocolVersion;
+use near_store::contract::ContractStorage;
 use near_store::{has_promise_yield_receipt, KeyLookupMode, TrieUpdate, TrieUpdateValuePtr};
 use near_vm_runner::logic::errors::{AnyError, VMLogicError};
 use near_vm_runner::logic::types::ReceiptIndex;
@@ -362,9 +363,10 @@ impl<'a> External for RuntimeExt<'a> {
 }
 
 pub(crate) struct RuntimeContractExt<'a> {
-    pub(crate) trie_update: &'a TrieUpdate,
+    pub(crate) storage: ContractStorage,
     pub(crate) account_id: &'a AccountId,
-    pub(crate) account: &'a Account,
+    pub(crate) code_hash: CryptoHash,
+    pub(crate) chain_id: &'a str,
     pub(crate) current_protocol_version: ProtocolVersion,
 }
 
@@ -377,19 +379,17 @@ impl<'a> Contract for RuntimeContractExt<'a> {
         {
             // There are old eth implicit accounts without magic bytes in the code hash.
             // Result can be None and it's a valid option. See https://github.com/near/nearcore/pull/11606
-            if let Some(wallet_contract) = wallet_contract(self.account.code_hash()) {
+            if let Some(wallet_contract) = wallet_contract(self.code_hash) {
                 return *wallet_contract.hash();
             }
         }
 
-        self.account.code_hash()
+        self.code_hash
     }
 
     fn get_code(&self) -> Option<Arc<ContractCode>> {
         let account_id = self.account_id;
-        let code_hash = self.account.code_hash();
         let version = self.current_protocol_version;
-
         if checked_feature!("stable", EthImplicitAccounts, version)
             && account_id.get_account_type() == AccountType::EthImplicitAccount
         {
@@ -398,16 +398,10 @@ impl<'a> Contract for RuntimeContractExt<'a> {
             // description of #11606) may have something else deployed to them. Only return
             // something here if the accounts have a wallet contract hash. Otherwise use the
             // regular path to grab the deployed contract.
-            if let Some(wc) = wallet_contract(code_hash) {
+            if let Some(wc) = wallet_contract(self.code_hash) {
                 return Some(wc);
             }
         }
-
-        let mode = match checked_feature!("stable", ChunkNodesCache, version) {
-            true => Some(TrieCacheMode::CachingShard),
-            false => None,
-        };
-        let _guard = self.trie_update.with_trie_cache_mode(mode);
-        self.trie_update.get_code(self.account_id.clone(), code_hash).map(Arc::new)
+        self.storage.get(self.code_hash).map(Arc::new)
     }
 }

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -2401,7 +2401,6 @@ impl<'a> ApplyProcessingState<'a> {
         let pipeline_manager = pipelining::ReceiptPreparationPipeline::new(
             Arc::clone(&self.apply_state.config),
             self.apply_state.cache.as_ref().map(|v| v.handle()),
-            self.epoch_info_provider.chain_id(),
             self.apply_state.current_protocol_version,
             self.state_update.contract_storage.clone(),
         );
@@ -2579,7 +2578,6 @@ pub mod estimator {
         let empty_pipeline = ReceiptPreparationPipeline::new(
             std::sync::Arc::clone(&apply_state.config),
             apply_state.cache.as_ref().map(|c| c.handle()),
-            epoch_info_provider.chain_id(),
             apply_state.current_protocol_version,
             state_update.contract_storage.clone(),
         );

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -63,6 +63,7 @@ pub use near_vm_runner::with_ext_cost_counter;
 use near_vm_runner::ContractCode;
 use near_vm_runner::ContractRuntimeCache;
 use near_vm_runner::ProfileDataV3;
+use pipelining::ReceiptPreparationPipeline;
 use std::cmp::max;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
@@ -76,6 +77,7 @@ mod congestion_control;
 mod conversions;
 pub mod ext;
 mod metrics;
+mod pipelining;
 mod prefetch;
 pub mod receipt_manager;
 pub mod state_viewer;
@@ -367,6 +369,7 @@ impl Runtime {
         action: &Action,
         state_update: &mut TrieUpdate,
         apply_state: &ApplyState,
+        preparation_pipeline: &ReceiptPreparationPipeline,
         account: &mut Option<Account>,
         actor_id: &mut AccountId,
         receipt: &Receipt,
@@ -432,18 +435,16 @@ impl Runtime {
                     account.as_mut().expect(EXPECT_ACCOUNT_EXISTS),
                     account_id,
                     deploy_contract,
-                    apply_state,
+                    Arc::clone(&apply_state.config.wasm_config),
+                    apply_state.cache.as_deref(),
                 )?;
             }
             Action::FunctionCall(function_call) => {
                 let account = account.as_mut().expect(EXPECT_ACCOUNT_EXISTS);
-                let contract = prepare_function_call(
-                    state_update,
-                    apply_state,
-                    account,
-                    account_id,
-                    function_call,
-                    &apply_state.config,
+                let contract = preparation_pipeline.get_contract(
+                    receipt,
+                    account.code_hash(),
+                    action_index,
                     None,
                 );
                 let is_last_action = action_index + 1 == actions.len();
@@ -558,6 +559,7 @@ impl Runtime {
         &self,
         state_update: &mut TrieUpdate,
         apply_state: &ApplyState,
+        preparation_pipeline: &ReceiptPreparationPipeline,
         receipt: &Receipt,
         receipt_sink: &mut ReceiptSink,
         validator_proposals: &mut Vec<ValidatorStake>,
@@ -628,6 +630,7 @@ impl Runtime {
                 action,
                 state_update,
                 apply_state,
+                preparation_pipeline,
                 &mut account,
                 &mut actor_id,
                 receipt,
@@ -975,14 +978,19 @@ impl Runtime {
 
     fn process_receipt(
         &self,
-        state_update: &mut TrieUpdate,
-        apply_state: &ApplyState,
+        processing_state: &mut ApplyProcessingReceiptState,
         receipt: &Receipt,
         receipt_sink: &mut ReceiptSink,
         validator_proposals: &mut Vec<ValidatorStake>,
-        stats: &mut ApplyStats,
-        epoch_info_provider: &(dyn EpochInfoProvider),
     ) -> Result<Option<ExecutionOutcomeWithId>, RuntimeError> {
+        let ApplyProcessingReceiptState {
+            ref mut state_update,
+            apply_state,
+            epoch_info_provider,
+            ref pipeline_manager,
+            ref mut stats,
+            ..
+        } = *processing_state;
         let account_id = receipt.receiver_id();
         match receipt.receipt() {
             ReceiptEnum::Data(ref data_receipt) => {
@@ -1045,6 +1053,7 @@ impl Runtime {
                             .apply_action_receipt(
                                 state_update,
                                 apply_state,
+                                pipeline_manager,
                                 &ready_receipt,
                                 receipt_sink,
                                 validator_proposals,
@@ -1099,6 +1108,7 @@ impl Runtime {
                         .apply_action_receipt(
                             state_update,
                             apply_state,
+                            pipeline_manager,
                             receipt,
                             receipt_sink,
                             validator_proposals,
@@ -1150,6 +1160,7 @@ impl Runtime {
                         .apply_action_receipt(
                             state_update,
                             apply_state,
+                            pipeline_manager,
                             &yield_receipt,
                             receipt_sink,
                             validator_proposals,
@@ -1575,24 +1586,22 @@ impl Runtime {
             compute_usage = tracing::field::Empty,
         )
         .entered();
-        let total = &mut processing_state.total;
         let state_update = &mut processing_state.state_update;
         let node_counter_before = state_update.trie().get_trie_nodes_count();
         let recorded_storage_size_before = state_update.trie().recorded_storage_size();
         let storage_proof_size_upper_bound_before =
             state_update.trie().recorded_storage_size_upper_bound();
         let result = self.process_receipt(
-            state_update,
-            processing_state.apply_state,
+            processing_state,
             receipt,
             &mut receipt_sink,
             &mut validator_proposals,
-            &mut processing_state.stats,
-            processing_state.epoch_info_provider,
         );
+
+        let total = &mut processing_state.total;
+        let state_update = &mut processing_state.state_update;
         let node_counter_after = state_update.trie().get_trie_nodes_count();
         tracing::trace!(target: "runtime", ?node_counter_before, ?node_counter_after);
-
         let recorded_storage_diff = state_update
             .trie()
             .recorded_storage_size()
@@ -1646,14 +1655,40 @@ impl Runtime {
         validator_proposals: &mut Vec<ValidatorStake>,
     ) -> Result<(), RuntimeError> {
         let local_processing_start = std::time::Instant::now();
-        let local_receipt_count = processing_state.local_receipts.len();
+        let local_receipts = std::mem::take(&mut processing_state.local_receipts);
+        let local_receipt_count = local_receipts.len();
         if let Some(prefetcher) = &mut processing_state.prefetcher {
             // Prefetcher is allowed to fail
-            let (front, back) = processing_state.local_receipts.as_slices();
+            let (front, back) = local_receipts.as_slices();
             _ = prefetcher.prefetch_receipts_data(front);
             _ = prefetcher.prefetch_receipts_data(back);
         }
-        while let Some(receipt) = processing_state.next_local_receipt() {
+
+        let mut prep_lookahead_iter = local_receipts.iter();
+        let mut schedule_preparation = |pstate: &mut ApplyProcessingReceiptState| {
+            let scheduled_receipt_offset = prep_lookahead_iter.position(|peek| {
+                let account_id = peek.receiver_id();
+                let receiver = get_account(&pstate.state_update, account_id);
+                let Ok(Some(receiver)) = receiver else {
+                    tracing::error!(
+                        target: "runtime",
+                        message="unable to read receiver of an upcoming local receipt",
+                        ?account_id,
+                        receipt=%peek.get_hash()
+                    );
+                    return false;
+                };
+                // This returns `true` if work may have been scheduled (thus we currently prepare
+                // actions in at most 2 "interesting" receipts in parallel due to staggering.)
+                pstate.pipeline_manager.submit(peek, &receiver, None)
+            });
+            scheduled_receipt_offset
+        };
+        // Advance the preparation by one step (stagger it) so that we're preparing one interesting
+        // receipt in advance.
+        let mut next_schedule_index = schedule_preparation(&mut processing_state);
+
+        for (index, receipt) in local_receipts.iter().enumerate() {
             if processing_state.total.compute >= compute_limit
                 || proof_size_limit.is_some_and(|limit| {
                     processing_state.state_update.trie.recorded_storage_size_upper_bound() > limit
@@ -1665,6 +1700,15 @@ impl Runtime {
                     &processing_state.apply_state.config,
                 )?;
             } else {
+                if let Some(nsi) = next_schedule_index {
+                    if index >= nsi {
+                        // We're about to process a receipt that has been submitted for
+                        // preparation, so lets submit the next one in anticipation that it might
+                        // be processed too (it might also be not if we run out of gas/compute.)
+                        next_schedule_index = schedule_preparation(&mut processing_state)
+                            .and_then(|adv| nsi.checked_add(1)?.checked_add(adv));
+                    }
+                }
                 // NOTE: We don't need to validate the local receipt, because it's just validated in
                 // the `verify_and_charge_transaction`.
                 self.process_receipt_with_metrics(
@@ -2289,7 +2333,15 @@ impl<'a> ApplyProcessingState<'a> {
         incoming_receipts: &'a [Receipt],
         delayed_receipts: DelayedReceiptQueueWrapper,
     ) -> ApplyProcessingReceiptState<'a> {
+        let pipeline_manager = pipelining::ReceiptPreparationPipeline::new(
+            Arc::clone(&self.apply_state.config),
+            self.apply_state.cache.as_ref().map(|v| v.handle()),
+            self.epoch_info_provider.chain_id(),
+            self.apply_state.current_protocol_version,
+            self.state_update.contract_storage.clone(),
+        );
         ApplyProcessingReceiptState {
+            pipeline_manager,
             protocol_version: self.protocol_version,
             apply_state: self.apply_state,
             prefetcher: self.prefetcher,
@@ -2323,19 +2375,14 @@ struct ApplyProcessingReceiptState<'a> {
     local_receipts: VecDeque<Receipt>,
     incoming_receipts: &'a [Receipt],
     delayed_receipts: DelayedReceiptQueueWrapper,
-}
-
-impl<'a> ApplyProcessingReceiptState<'a> {
-    /// Obtain the next receipt that should be executed.
-    fn next_local_receipt(&mut self) -> Option<Receipt> {
-        self.local_receipts.pop_front()
-    }
+    pipeline_manager: pipelining::ReceiptPreparationPipeline,
 }
 
 /// Interface provided for gas cost estimations.
 pub mod estimator {
     use super::{ReceiptSink, Runtime};
     use crate::congestion_control::ReceiptSinkV2;
+    use crate::pipelining::ReceiptPreparationPipeline;
     use crate::{ApplyState, ApplyStats};
     use near_primitives::congestion_info::CongestionInfo;
     use near_primitives::errors::RuntimeError;
@@ -2367,9 +2414,17 @@ pub mod estimator {
             outgoing_buffers: ShardsOutgoingReceiptBuffer::load(&state_update.trie)?,
             outgoing_receipts,
         });
+        let empty_pipeline = ReceiptPreparationPipeline::new(
+            std::sync::Arc::clone(&apply_state.config),
+            apply_state.cache.as_ref().map(|c| c.handle()),
+            epoch_info_provider.chain_id(),
+            apply_state.current_protocol_version,
+            state_update.contract_storage.clone(),
+        );
         Runtime {}.apply_action_receipt(
             state_update,
             apply_state,
+            &empty_pipeline,
             receipt,
             &mut receipt_sink,
             validator_proposals,

--- a/runtime/runtime/src/metrics.rs
+++ b/runtime/runtime/src/metrics.rs
@@ -1,10 +1,10 @@
 use crate::congestion_control::ReceiptSink;
 use crate::ApplyState;
 use near_o11y::metrics::{
-    exponential_buckets, linear_buckets, try_create_counter_vec, try_create_gauge_vec,
-    try_create_histogram_vec, try_create_int_counter, try_create_int_counter_vec,
-    try_create_int_gauge_vec, CounterVec, GaugeVec, HistogramVec, IntCounter, IntCounterVec,
-    IntGaugeVec,
+    exponential_buckets, linear_buckets, try_create_counter, try_create_counter_vec,
+    try_create_gauge_vec, try_create_histogram_vec, try_create_int_counter,
+    try_create_int_counter_vec, try_create_int_gauge_vec, Counter, CounterVec, GaugeVec,
+    HistogramVec, IntCounter, IntCounterVec, IntGaugeVec,
 };
 use near_parameters::config::CongestionControlConfig;
 use near_primitives::congestion_info::CongestionInfo;
@@ -438,6 +438,72 @@ pub(crate) static CHUNK_RECEIPTS_LIMITED_BY: LazyLock<IntCounterVec> = LazyLock:
         "near_chunk_receipts_limited_by",
         "Number of chunks where the number of processed receipts was limited by a certain factor.",
         &["shard_id", "limited_by"],
+    )
+    .unwrap()
+});
+
+pub(crate) static PIPELINING_ACTIONS_SUBMITTED: LazyLock<IntCounter> = LazyLock::new(|| {
+    try_create_int_counter(
+        "near_pipelininig_actions_submitted_count",
+        "Number of actions submitted to the pipeline for preparation.",
+    )
+    .unwrap()
+});
+
+pub(crate) static PIPELINING_ACTIONS_PREPARED_IN_MAIN_THREAD: LazyLock<IntCounter> =
+    LazyLock::new(|| {
+        try_create_int_counter(
+            "near_pipelininig_actions_prepared_in_main_thread_count",
+            "Number of actions prepared in the main thread, rather than the pipeline.",
+        )
+        .unwrap()
+    });
+
+pub(crate) static PIPELINING_ACTIONS_NOT_SUBMITTED: LazyLock<IntCounter> = LazyLock::new(|| {
+    try_create_int_counter(
+        "near_pipelininig_actions_not_submitted_count",
+        "Number of actions prepared in the main thread, because they were never submitted.",
+    )
+    .unwrap()
+});
+
+pub(crate) static PIPELINING_ACTIONS_FOUND_PREPARED: LazyLock<IntCounter> = LazyLock::new(|| {
+    try_create_int_counter(
+        "near_pipelininig_actions_found_prepared_count",
+        "Number of actions that were found prepared by the time they were needed.",
+    )
+    .unwrap()
+});
+
+pub(crate) static PIPELINING_ACTIONS_WAITING_TIME: LazyLock<Counter> = LazyLock::new(|| {
+    try_create_counter(
+        "near_pipelininig_waiting_seconds_total",
+        "Time spent waiting for the task results to be ready.",
+    )
+    .unwrap()
+});
+
+pub(crate) static PIPELINING_ACTIONS_MAIN_THREAD_WORKING_TIME: LazyLock<Counter> =
+    LazyLock::new(|| {
+        try_create_counter(
+            "near_pipelininig_main_thread_seconds_total",
+            "Time spent preparing contracts on the main thread (for whatever reason.)",
+        )
+        .unwrap()
+    });
+
+pub(crate) static PIPELINING_ACTIONS_TASK_DELAY_TIME: LazyLock<Counter> = LazyLock::new(|| {
+    try_create_counter(
+        "near_pipelininig_delay_seconds_total",
+        "Time spent waiting for the preparation task to be scheduled on thread pool.",
+    )
+    .unwrap()
+});
+
+pub(crate) static PIPELINING_ACTIONS_TASK_WORKING_TIME: LazyLock<Counter> = LazyLock::new(|| {
+    try_create_counter(
+        "near_pipelininig_working_seconds_total",
+        "Time spent working to produce the results for work scheduled on the pipeline.",
     )
     .unwrap()
 });

--- a/runtime/runtime/src/pipelining.rs
+++ b/runtime/runtime/src/pipelining.rs
@@ -55,9 +55,6 @@ pub(crate) struct ReceiptPreparationPipeline {
     /// The contract cache.
     contract_cache: Option<Box<dyn ContractRuntimeCache>>,
 
-    /// The chain ID being processed.
-    chain_id: String,
-
     /// Protocol version for this chunk.
     protocol_version: u32,
 
@@ -87,7 +84,6 @@ impl ReceiptPreparationPipeline {
     pub(crate) fn new(
         config: Arc<RuntimeConfig>,
         contract_cache: Option<Box<dyn ContractRuntimeCache>>,
-        chain_id: String,
         protocol_version: u32,
         storage: ContractStorage,
     ) -> Self {
@@ -96,7 +92,6 @@ impl ReceiptPreparationPipeline {
             block_accounts: Default::default(),
             config,
             contract_cache,
-            chain_id,
             protocol_version,
             storage,
         }
@@ -149,7 +144,6 @@ impl ReceiptPreparationPipeline {
                     let config = Arc::clone(&self.config.wasm_config);
                     let cache = self.contract_cache.as_ref().map(|c| c.handle());
                     let storage = self.storage.clone();
-                    let chain_id = self.chain_id.clone();
                     let protocol_version = self.protocol_version;
                     let code_hash = account.code_hash();
                     let created = Instant::now();
@@ -171,7 +165,6 @@ impl ReceiptPreparationPipeline {
                         let contract = prepare_function_call(
                             &storage,
                             cache.as_deref(),
-                            &chain_id,
                             protocol_version,
                             config,
                             gas_counter,
@@ -246,7 +239,6 @@ impl ReceiptPreparationPipeline {
             let result = prepare_function_call(
                 &self.storage,
                 self.contract_cache.as_deref(),
-                &self.chain_id,
                 self.protocol_version,
                 Arc::clone(&self.config.wasm_config),
                 gas_counter,
@@ -278,7 +270,6 @@ impl ReceiptPreparationPipeline {
                     let contract = prepare_function_call(
                         &self.storage,
                         cache.as_deref(),
-                        &self.chain_id,
                         self.protocol_version,
                         Arc::clone(&self.config.wasm_config),
                         gas_counter,
@@ -331,7 +322,6 @@ fn prepare_function_call(
     contract_storage: &ContractStorage,
     cache: Option<&dyn ContractRuntimeCache>,
 
-    chain_id: &str,
     protocol_version: ProtocolVersion,
     config: Arc<near_parameters::vm::Config>,
     gas_counter: GasCounter,
@@ -344,7 +334,6 @@ fn prepare_function_call(
         storage: contract_storage.clone(),
         account_id,
         code_hash,
-        chain_id,
         current_protocol_version: protocol_version,
     };
     let contract = near_vm_runner::prepare(&code_ext, config, cache, gas_counter, method_name);

--- a/runtime/runtime/src/pipelining.rs
+++ b/runtime/runtime/src/pipelining.rs
@@ -1,0 +1,323 @@
+#![allow(dead_code)]
+
+use crate::ext::RuntimeContractExt;
+use near_parameters::RuntimeConfig;
+use near_primitives::account::Account;
+use near_primitives::action::Action;
+use near_primitives::config::ViewConfig;
+use near_primitives::hash::CryptoHash;
+use near_primitives::receipt::{Receipt, ReceiptEnum};
+use near_primitives::types::{AccountId, Gas};
+use near_store::contract::ContractStorage;
+use near_vm_runner::logic::{GasCounter, ProtocolVersion};
+use near_vm_runner::{ContractRuntimeCache, PreparedContract};
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, Condvar, Mutex};
+
+pub(crate) struct ReceiptPreparationPipeline {
+    /// Mapping from a Receipt's ID to a parallel "task" to prepare the receipt's data.
+    ///
+    /// The task itself may be run in the current thread, a separate thread or forced in any other
+    /// way.
+    map: BTreeMap<PrepareTaskKey, Arc<PrepareTask>>,
+
+    /// List of Receipt receiver IDs that must not be prepared for this chunk.
+    ///
+    /// This solves an issue wherein the pipelining implementation only has access to the committed
+    /// storage (read: data as a result of applying the previous chunk,) and not the state that has
+    /// been built up as a result of processing the current chunk. One notable thing that may have
+    /// occurred there is a contract deployment. Once that happens, we can no longer get the
+    /// "current" contract code for the account.
+    ///
+    /// However, even if we had access to the transaction of the current chunk and were able to
+    /// access the new code, there's a risk of a race between when the deployment is executed
+    /// and when a parallel preparation may occur, leading back to needing to hold prefetching of
+    /// that account's contracts until the deployment is executed.
+    ///
+    /// As deployments are a relatively rare event, it is probably just fine to entirely disable
+    /// pipelining for the account in question for that particular block. This field implements
+    /// exactly that.
+    ///
+    /// In the future, however, it may make sense to either move the responsibility of executing
+    /// deployment actions to this pipelining thingy OR, even better, modify the protocol such that
+    /// contract deployments in block N only take effect in the block N+1 as that, among other
+    /// things, would give the runtime more time to compile the contract.
+    block_accounts: BTreeSet<AccountId>,
+
+    /// The Runtime config for these pipelining  requests.
+    config: Arc<RuntimeConfig>,
+
+    /// The contract cache.
+    contract_cache: Option<Box<dyn ContractRuntimeCache>>,
+
+    /// The chain ID being processed.
+    chain_id: String,
+
+    /// Protocol version for this chunk.
+    protocol_version: u32,
+
+    /// Storage for WASM code.
+    storage: ContractStorage,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+struct PrepareTaskKey {
+    receipt_id: CryptoHash,
+    action_index: usize,
+}
+
+struct PrepareTask {
+    status: Mutex<PrepareTaskStatus>,
+    condvar: Condvar,
+}
+
+enum PrepareTaskStatus {
+    Pending,
+    Working,
+    Prepared(Box<dyn PreparedContract>),
+    Finished,
+}
+
+impl ReceiptPreparationPipeline {
+    pub(crate) fn new(
+        config: Arc<RuntimeConfig>,
+        contract_cache: Option<Box<dyn ContractRuntimeCache>>,
+        chain_id: String,
+        protocol_version: u32,
+        storage: ContractStorage,
+    ) -> Self {
+        Self {
+            map: Default::default(),
+            block_accounts: Default::default(),
+            config,
+            contract_cache,
+            chain_id,
+            protocol_version,
+            storage,
+        }
+    }
+
+    /// Submit a receipt to the "pipeline" for preparation of likely eventual execution.
+    ///
+    /// Note that not all receipts submitted here must be actually handled in some way. That said,
+    /// while it is perfectly fine to not use the results of submitted work (e.g. because a
+    /// applying a chunk ran out of gas or compute cost,) this work would eventually get lost, so
+    /// for the most part it is best to submit work with limited look-ahead.
+    ///
+    /// Returns `true` if the receipt is interesting and that pipelining has acted on it in some
+    /// way. Currently `true` is returned for any receipts containing `Action::DeployContract` (in
+    /// which case no further processing for the receiver account will be done), and
+    /// `Action::FunctionCall` (provided the account has not been blocked.)
+    pub(crate) fn submit(
+        &mut self,
+        receipt: &Receipt,
+        account: &Account,
+        view_config: Option<ViewConfig>,
+    ) -> bool {
+        let account_id = receipt.receiver_id();
+        if self.block_accounts.contains(account_id) {
+            return false;
+        }
+        let actions = match receipt.receipt() {
+            ReceiptEnum::Action(a) | ReceiptEnum::PromiseYield(a) => &a.actions,
+            ReceiptEnum::Data(_) | ReceiptEnum::PromiseResume(_) => return false,
+        };
+        let mut any_function_calls = false;
+        for (action_index, action) in actions.iter().enumerate() {
+            let account_id = account_id.clone();
+            match action {
+                Action::DeployContract(_) => {
+                    // FIXME: instead of blocking these accounts, move the handling of
+                    // deploy action into here, so that the necessary data dependencies can be
+                    // established.
+                    return self.block_accounts.insert(account_id);
+                }
+                Action::FunctionCall(function_call) => {
+                    let key = PrepareTaskKey { receipt_id: receipt.get_hash(), action_index };
+                    let gas_counter = self.gas_counter(view_config.as_ref(), function_call.gas);
+                    let entry = match self.map.entry(key) {
+                        std::collections::btree_map::Entry::Vacant(v) => v,
+                        // Already been submitted.
+                        // TODO: Warning?
+                        std::collections::btree_map::Entry::Occupied(_) => continue,
+                    };
+                    let config = Arc::clone(&self.config.wasm_config);
+                    let cache = self.contract_cache.as_ref().map(|c| c.handle());
+                    let storage = self.storage.clone();
+                    let chain_id = self.chain_id.clone();
+                    let protocol_version = self.protocol_version;
+                    let code_hash = account.code_hash();
+                    let status = Mutex::new(PrepareTaskStatus::Pending);
+                    let task = Arc::new(PrepareTask { status, condvar: Condvar::new() });
+                    let method_name = function_call.method_name.clone();
+                    entry.insert(Arc::clone(&task));
+                    // FIXME: don't spawn all tasks at once. We want to keep some capacity for
+                    // other things and also to control (in a way) the concurrency here.
+                    rayon::spawn_fifo(move || {
+                        let task_status = {
+                            let mut status = task.status.lock().expect("mutex lock");
+                            std::mem::replace(&mut *status, PrepareTaskStatus::Working)
+                        };
+                        match &task_status {
+                            PrepareTaskStatus::Pending => {}
+                            PrepareTaskStatus::Working => return,
+                            // TODO: seeing Prepared here may mean there's double spawning for the
+                            // same receipt index. Maybe output a warning?
+                            PrepareTaskStatus::Prepared(..) => return,
+                            PrepareTaskStatus::Finished => return,
+                        };
+                        let contract = prepare_function_call(
+                            &storage,
+                            cache.as_deref(),
+                            &chain_id,
+                            protocol_version,
+                            config,
+                            gas_counter,
+                            code_hash,
+                            &account_id,
+                            &method_name,
+                        );
+
+                        let mut status = task.status.lock().expect("mutex lock");
+                        *status = PrepareTaskStatus::Prepared(contract);
+                        task.condvar.notify_all();
+                    });
+                    any_function_calls = true;
+                }
+                // No need to handle this receipt as it only generates other new receipts.
+                Action::Delegate(_) => {}
+                // No handling for these.
+                Action::CreateAccount(_)
+                | Action::Transfer(_)
+                | Action::Stake(_)
+                | Action::AddKey(_)
+                | Action::DeleteKey(_)
+                | Action::DeleteAccount(_) => {}
+                #[cfg(feature = "protocol_feature_nonrefundable_transfer_nep491")]
+                Action::NonrefundableStorageTransfer(_) => {}
+            }
+        }
+        return any_function_calls;
+    }
+
+    /// Obtain the prepared contract for the provided receipt.
+    ///
+    /// If the contract is currently being prepared this function will block waiting for the
+    /// preparation to complete.
+    ///
+    /// If the preparation hasn't been started yet (either because it hasn't been scheduled for any
+    /// reason, or because the pipeline didn't make it in time), this function will prepare the
+    /// contract in the calling thread.
+    pub(crate) fn get_contract(
+        &self,
+        receipt: &Receipt,
+        code_hash: CryptoHash,
+        action_index: usize,
+        view_config: Option<ViewConfig>,
+    ) -> Box<dyn PreparedContract> {
+        let account_id = receipt.receiver_id();
+        let action = match receipt.receipt() {
+            ReceiptEnum::Action(r) | ReceiptEnum::PromiseYield(r) => r
+                .actions
+                .get(action_index)
+                .expect("indexing receipt actions by an action_index failed!"),
+            ReceiptEnum::Data(_) | ReceiptEnum::PromiseResume(_) => {
+                panic!("attempting to get_contract with a non-action receipt!?")
+            }
+        };
+        let Action::FunctionCall(function_call) = action else {
+            panic!("referenced receipt action is not a function call!");
+        };
+        let key = PrepareTaskKey { receipt_id: receipt.get_hash(), action_index };
+        let Some(task) = self.map.get(&key) else {
+            let gas_counter = self.gas_counter(view_config.as_ref(), function_call.gas);
+            return prepare_function_call(
+                &self.storage,
+                self.contract_cache.as_deref(),
+                &self.chain_id,
+                self.protocol_version,
+                Arc::clone(&self.config.wasm_config),
+                gas_counter,
+                code_hash,
+                &account_id,
+                &function_call.method_name,
+            );
+        };
+        let mut status_guard = task.status.lock().unwrap();
+        loop {
+            let current = std::mem::replace(&mut *status_guard, PrepareTaskStatus::Working);
+            match current {
+                PrepareTaskStatus::Pending => {
+                    *status_guard = PrepareTaskStatus::Finished;
+                    drop(status_guard);
+
+                    let gas_counter = self.gas_counter(view_config.as_ref(), function_call.gas);
+                    let contract = prepare_function_call(
+                        &self.storage,
+                        self.contract_cache.as_deref(),
+                        &self.chain_id,
+                        self.protocol_version,
+                        Arc::clone(&self.config.wasm_config),
+                        gas_counter,
+                        code_hash,
+                        &account_id,
+                        &function_call.method_name,
+                    );
+                    return contract;
+                }
+                PrepareTaskStatus::Working => {
+                    status_guard = task.condvar.wait(status_guard).unwrap();
+                    continue;
+                }
+                PrepareTaskStatus::Prepared(c) => {
+                    *status_guard = PrepareTaskStatus::Finished;
+                    return c;
+                }
+                PrepareTaskStatus::Finished => {
+                    *status_guard = PrepareTaskStatus::Finished;
+                    // Don't poison the lock.
+                    drop(status_guard);
+                    panic!("attempting to get_contract that has already been taken");
+                }
+            }
+        }
+    }
+
+    fn gas_counter(&self, view_config: Option<&ViewConfig>, gas: Gas) -> GasCounter {
+        let max_gas_burnt = match view_config {
+            Some(ViewConfig { max_gas_burnt }) => *max_gas_burnt,
+            None => self.config.wasm_config.limit_config.max_gas_burnt,
+        };
+        GasCounter::new(
+            self.config.wasm_config.ext_costs.clone(),
+            max_gas_burnt,
+            self.config.wasm_config.regular_op_cost,
+            gas,
+            view_config.is_some(),
+        )
+    }
+}
+
+fn prepare_function_call(
+    contract_storage: &ContractStorage,
+    cache: Option<&dyn ContractRuntimeCache>,
+
+    chain_id: &str,
+    protocol_version: ProtocolVersion,
+    config: Arc<near_parameters::vm::Config>,
+    gas_counter: GasCounter,
+
+    code_hash: CryptoHash,
+    account_id: &AccountId,
+    method_name: &str,
+) -> Box<dyn PreparedContract> {
+    let code_ext = RuntimeContractExt {
+        storage: contract_storage.clone(),
+        account_id,
+        code_hash,
+        chain_id,
+        current_protocol_version: protocol_version,
+    };
+    let contract = near_vm_runner::prepare(&code_ext, config, cache, gas_counter, method_name);
+    contract
+}

--- a/runtime/runtime/src/pipelining.rs
+++ b/runtime/runtime/src/pipelining.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::ext::RuntimeContractExt;
 use crate::metrics::{
     PIPELINING_ACTIONS_FOUND_PREPARED, PIPELINING_ACTIONS_MAIN_THREAD_WORKING_TIME,

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -248,7 +248,6 @@ impl TrieViewer {
         let pipeline = ReceiptPreparationPipeline::new(
             Arc::clone(config),
             apply_state.cache.as_ref().map(|v| v.handle()),
-            epoch_info_provider.chain_id(),
             apply_state.current_protocol_version,
             state_update.contract_storage.clone(),
         );

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -18,7 +18,7 @@ use near_primitives::types::{
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{StateItem, ViewStateResult};
 use near_primitives_core::config::ViewConfig;
-use near_store::{get_access_key, get_account, TrieUpdate};
+use near_store::{get_access_key, get_account, get_code, TrieUpdate};
 use near_vm_runner::logic::{ProtocolVersion, ReturnData};
 use near_vm_runner::{ContractCode, ContractRuntimeCache};
 use std::{str, sync::Arc, time::Instant};
@@ -90,7 +90,7 @@ impl TrieViewer {
         account_id: &AccountId,
     ) -> Result<ContractCode, errors::ViewContractCodeError> {
         let account = self.view_account(state_update, account_id)?;
-        state_update.contract_storage.get(account.code_hash()).ok_or_else(|| {
+        get_code(state_update, account_id, Some(account.code_hash()))?.ok_or_else(|| {
             errors::ViewContractCodeError::NoContractCode {
                 contract_account_id: account_id.clone(),
             }
@@ -147,9 +147,7 @@ impl TrieViewer {
     ) -> Result<ViewStateResult, errors::ViewStateError> {
         match get_account(state_update, account_id)? {
             Some(account) => {
-                let code_len = state_update
-                    .contract_storage
-                    .get(account.code_hash())
+                let code_len = get_code(state_update, account_id, Some(account.code_hash()))?
                     .map(|c| c.code().len() as u64)
                     .unwrap_or_default();
                 if let Some(limit) = self.state_size_limit {

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -1,13 +1,14 @@
 use crate::actions::execute_function_call;
 use crate::ext::RuntimeExt;
+use crate::pipelining::ReceiptPreparationPipeline;
 use crate::receipt_manager::ReceiptManager;
-use crate::{prepare_function_call, ApplyState};
+use crate::ApplyState;
 use near_crypto::{KeyType, PublicKey};
 use near_parameters::RuntimeConfigStore;
 use near_primitives::account::{AccessKey, Account};
 use near_primitives::borsh::BorshDeserialize;
 use near_primitives::hash::CryptoHash;
-use near_primitives::receipt::ActionReceipt;
+use near_primitives::receipt::{ActionReceipt, Receipt, ReceiptEnum, ReceiptV1};
 use near_primitives::runtime::migration_data::{MigrationData, MigrationFlags};
 use near_primitives::transaction::FunctionCallAction;
 use near_primitives::trie_key::trie_key_parsers;
@@ -17,7 +18,7 @@ use near_primitives::types::{
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{StateItem, ViewStateResult};
 use near_primitives_core::config::ViewConfig;
-use near_store::{get_access_key, get_account, get_code, TrieUpdate};
+use near_store::{get_access_key, get_account, TrieUpdate};
 use near_vm_runner::logic::{ProtocolVersion, ReturnData};
 use near_vm_runner::{ContractCode, ContractRuntimeCache};
 use std::{str, sync::Arc, time::Instant};
@@ -89,7 +90,7 @@ impl TrieViewer {
         account_id: &AccountId,
     ) -> Result<ContractCode, errors::ViewContractCodeError> {
         let account = self.view_account(state_update, account_id)?;
-        get_code(state_update, account_id, Some(account.code_hash()))?.ok_or_else(|| {
+        state_update.contract_storage.get(account.code_hash()).ok_or_else(|| {
             errors::ViewContractCodeError::NoContractCode {
                 contract_account_id: account_id.clone(),
             }
@@ -146,7 +147,9 @@ impl TrieViewer {
     ) -> Result<ViewStateResult, errors::ViewStateError> {
         match get_account(state_update, account_id)? {
             Some(account) => {
-                let code_len = get_code(state_update, account_id, Some(account.code_hash()))?
+                let code_len = state_update
+                    .contract_storage
+                    .get(account.code_hash())
                     .map(|c| c.code().len() as u64)
                     .unwrap_or_default();
                 if let Some(limit) = self.state_size_limit {
@@ -223,30 +226,37 @@ impl TrieViewer {
             migration_flags: MigrationFlags::default(),
             congestion_info: Default::default(),
         };
-        let action_receipt = ActionReceipt {
-            signer_id: originator_id.clone(),
-            signer_public_key: public_key,
-            gas_price: 0,
-            output_data_receivers: vec![],
-            input_data_ids: vec![],
-            actions: vec![],
-        };
         let function_call = FunctionCallAction {
             method_name: method_name.to_string(),
             args: args.to_vec(),
             gas: self.max_gas_burnt_view,
             deposit: 0,
         };
-        let view_config = Some(ViewConfig { max_gas_burnt: self.max_gas_burnt_view });
-        let contract = prepare_function_call(
-            &state_update,
-            &apply_state,
-            &account,
-            &contract_id,
-            &function_call,
-            config,
-            view_config.clone(),
+        let action_receipt = ActionReceipt {
+            signer_id: originator_id.clone(),
+            signer_public_key: public_key,
+            gas_price: 0,
+            output_data_receivers: vec![],
+            input_data_ids: vec![],
+            actions: vec![function_call.clone().into()],
+        };
+        let receipt = Receipt::V1(ReceiptV1 {
+            predecessor_id: contract_id.clone(),
+            receiver_id: contract_id.clone(),
+            receipt_id: empty_hash,
+            receipt: ReceiptEnum::Action(action_receipt.clone()),
+            priority: 0,
+        });
+        let pipeline = ReceiptPreparationPipeline::new(
+            Arc::clone(config),
+            apply_state.cache.as_ref().map(|v| v.handle()),
+            epoch_info_provider.chain_id(),
+            apply_state.current_protocol_version,
+            state_update.contract_storage.clone(),
         );
+        let view_config = Some(ViewConfig { max_gas_burnt: self.max_gas_burnt_view });
+        let contract = pipeline.get_contract(&receipt, account.code_hash(), 0, view_config.clone());
+
         let mut runtime_ext = RuntimeExt::new(
             &mut state_update,
             &mut receipt_manager,


### PR DESCRIPTION
This reverts commit 4e93e4680bfcc8e8e445d30bd3106188e18eb234.
This reverts commit 86cd45b1a6f58a190fb7ac518eb7ee309f7874a4.

To address the issues seen that led to the functionality being reverted in the first place I had to add some mechanisms to query The State in a side-effect-free (pure) manner and to also revert some changes from the original change-set where we the new code would *not* produce the side-effects that were expected by the other nodes.