### PR TITLE
[Epoch Sync] EpochSyncProof validation

### DIFF
--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -235,6 +235,9 @@ pub enum Error {
     /// Resharding error.
     #[error("Resharding Error: {0}")]
     ReshardingError(String),
+    /// EpochSyncProof validation error.
+    #[error("EpochSyncProof Validation Error: {0}")]
+    InvalidEpochSyncProof(String),
     /// Anything else
     #[error("Other Error: {0}")]
     Other(String),
@@ -300,6 +303,7 @@ impl Error {
             | Error::MaliciousChallenge
             | Error::IncorrectNumberOfChunkHeaders
             | Error::InvalidEpochHash
+            | Error::InvalidEpochSyncProof(_)
             | Error::InvalidNextBPHash
             | Error::NotEnoughApprovals
             | Error::InvalidFinalityInfo
@@ -377,6 +381,7 @@ impl Error {
             Error::MaliciousChallenge => "malicious_challenge",
             Error::IncorrectNumberOfChunkHeaders => "incorrect_number_of_chunk_headers",
             Error::InvalidEpochHash => "invalid_epoch_hash",
+            Error::InvalidEpochSyncProof(_) => "invalid_epoch_sync_proof",
             Error::InvalidNextBPHash => "invalid_next_bp_hash",
             Error::NotEnoughApprovals => "not_enough_approvals",
             Error::InvalidFinalityInfo => "invalid_finality_info",

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -586,15 +586,14 @@ impl Chain {
     ) -> Result<CryptoHash, Error> {
         let bps = epoch_manager.get_epoch_block_producers_ordered(&epoch_id, last_known_hash)?;
         let validator_stakes = bps.into_iter().map(|(bp, _)| bp).collect_vec();
-        Self::compute_bp_hash_from_validator_stakes(&validator_stakes, epoch_manager, prev_epoch_id)
+        let protocol_version = epoch_manager.get_epoch_protocol_version(&prev_epoch_id)?;
+        Self::compute_bp_hash_from_validator_stakes(&validator_stakes, protocol_version)
     }
 
     pub fn compute_bp_hash_from_validator_stakes(
         validator_stakes: &Vec<ValidatorStake>,
-        epoch_manager: &dyn EpochManagerAdapter,
-        prev_epoch_id: EpochId,
+        protocol_version: ProtocolVersion,
     ) -> Result<CryptoHash, Error> {
-        let protocol_version = epoch_manager.get_epoch_protocol_version(&prev_epoch_id)?;
         if checked_feature!("stable", BlockHeaderV3, protocol_version) {
             Ok(CryptoHash::hash_borsh_iter(validator_stakes))
         } else {

--- a/chain/chain/src/lib.rs
+++ b/chain/chain/src/lib.rs
@@ -7,7 +7,9 @@ pub use doomslug::{Doomslug, DoomslugBlockProductionReadiness, DoomslugThreshold
 pub use lightclient::{create_light_client_block_view, get_epoch_block_producers_view};
 pub use near_chain_primitives::{self, Error};
 pub use near_primitives::receipt::ReceiptResult;
-pub use store::{ChainStore, ChainStoreAccess, ChainStoreUpdate, LatestWitnessesInfo};
+pub use store::{
+    ChainStore, ChainStoreAccess, ChainStoreUpdate, LatestWitnessesInfo, MerkleProofAccess,
+};
 pub use store_validator::{ErrorMessage, StoreValidator};
 pub use types::{Block, BlockHeader, BlockStatus, ChainGenesis, LatestKnown, Provenance};
 

--- a/chain/chain/src/store/merkle_proof.rs
+++ b/chain/chain/src/store/merkle_proof.rs
@@ -1,0 +1,196 @@
+use std::{collections::HashMap, sync::Arc};
+
+use near_chain_primitives::Error;
+use near_primitives::{
+    hash::CryptoHash,
+    merkle::{combine_hash, Direction, MerklePath, MerklePathItem, PartialMerkleTree},
+    types::{MerkleHash, NumBlocks},
+};
+
+/// Implement block merkle proof retrieval.
+
+pub trait MerkleProofAccess {
+    fn get_block_merkle_tree(
+        &self,
+        block_hash: &CryptoHash,
+    ) -> Result<Arc<PartialMerkleTree>, Error>;
+
+    fn get_block_hash_from_ordinal(&self, block_ordinal: NumBlocks) -> Result<CryptoHash, Error>;
+
+    fn get_block_merkle_tree_from_ordinal(
+        &self,
+        block_ordinal: NumBlocks,
+    ) -> Result<Arc<PartialMerkleTree>, Error> {
+        let block_hash = self.get_block_hash_from_ordinal(block_ordinal)?;
+        self.get_block_merkle_tree(&block_hash)
+    }
+
+    /// Get merkle proof for block with hash `block_hash` in the merkle tree of `head_block_hash`.
+    fn get_block_proof(
+        &self,
+        block_hash: &CryptoHash,
+        head_block_hash: &CryptoHash,
+    ) -> Result<MerklePath, Error> {
+        let leaf_index = self.get_block_merkle_tree(block_hash)?.size();
+        let tree_size = self.get_block_merkle_tree(head_block_hash)?.size();
+        if leaf_index >= tree_size {
+            if block_hash == head_block_hash {
+                // special case if the block to prove is the same as head
+                return Ok(vec![]);
+            }
+            return Err(Error::Other(format!(
+                "block {} is ahead of head block {}",
+                block_hash, head_block_hash
+            )));
+        }
+        let mut level = 0;
+        let mut counter = 1;
+        let mut cur_index = leaf_index;
+        let mut path = vec![];
+        let mut tree_nodes = HashMap::new();
+        let mut iter = tree_size;
+        while iter > 1 {
+            if cur_index % 2 == 0 {
+                cur_index += 1
+            } else {
+                cur_index -= 1;
+            }
+            let direction = if cur_index % 2 == 0 { Direction::Left } else { Direction::Right };
+            let maybe_hash = if cur_index % 2 == 1 {
+                // node not immediately available. Needs to be reconstructed
+                self.reconstruct_merkle_tree_node(
+                    cur_index,
+                    level,
+                    counter,
+                    tree_size,
+                    &mut tree_nodes,
+                )?
+            } else {
+                self.get_merkle_tree_node(cur_index, level, counter, tree_size, &mut tree_nodes)?
+            };
+            if let Some(hash) = maybe_hash {
+                path.push(MerklePathItem { hash, direction });
+            }
+            cur_index /= 2;
+            iter = (iter + 1) / 2;
+            level += 1;
+            counter *= 2;
+        }
+        Ok(path)
+    }
+
+    /// Get node at given position (index, level). If the node does not exist, return `None`.
+    fn get_merkle_tree_node(
+        &self,
+        index: u64,
+        level: u64,
+        counter: u64,
+        tree_size: u64,
+        tree_nodes: &mut HashMap<(u64, u64), Option<MerkleHash>>,
+    ) -> Result<Option<MerkleHash>, Error> {
+        if let Some(hash) = tree_nodes.get(&(index, level)) {
+            Ok(*hash)
+        } else {
+            if level == 0 {
+                let maybe_hash = if index >= tree_size {
+                    None
+                } else {
+                    Some(self.get_block_hash_from_ordinal(index)?)
+                };
+                tree_nodes.insert((index, level), maybe_hash);
+                Ok(maybe_hash)
+            } else {
+                let cur_tree_size = (index + 1) * counter;
+                let maybe_hash = if cur_tree_size > tree_size {
+                    if index * counter <= tree_size {
+                        let left_hash = self.get_merkle_tree_node(
+                            index * 2,
+                            level - 1,
+                            counter / 2,
+                            tree_size,
+                            tree_nodes,
+                        )?;
+                        let right_hash = self.reconstruct_merkle_tree_node(
+                            index * 2 + 1,
+                            level - 1,
+                            counter / 2,
+                            tree_size,
+                            tree_nodes,
+                        )?;
+                        combine_maybe_hashes(left_hash, right_hash)
+                    } else {
+                        None
+                    }
+                } else {
+                    Some(
+                        *self
+                            .get_block_merkle_tree_from_ordinal(cur_tree_size)?
+                            .get_path()
+                            .last()
+                            .ok_or_else(|| Error::Other("Merkle tree node missing".to_string()))?,
+                    )
+                };
+                tree_nodes.insert((index, level), maybe_hash);
+                Ok(maybe_hash)
+            }
+        }
+    }
+
+    /// Reconstruct node at given position (index, level). If the node does not exist, return `None`.
+    fn reconstruct_merkle_tree_node(
+        &self,
+        index: u64,
+        level: u64,
+        counter: u64,
+        tree_size: u64,
+        tree_nodes: &mut HashMap<(u64, u64), Option<MerkleHash>>,
+    ) -> Result<Option<MerkleHash>, Error> {
+        if let Some(hash) = tree_nodes.get(&(index, level)) {
+            Ok(*hash)
+        } else {
+            if level == 0 {
+                let maybe_hash = if index >= tree_size {
+                    None
+                } else {
+                    Some(self.get_block_hash_from_ordinal(index)?)
+                };
+                tree_nodes.insert((index, level), maybe_hash);
+                Ok(maybe_hash)
+            } else {
+                let left_hash = self.get_merkle_tree_node(
+                    index * 2,
+                    level - 1,
+                    counter / 2,
+                    tree_size,
+                    tree_nodes,
+                )?;
+                let right_hash = self.reconstruct_merkle_tree_node(
+                    index * 2 + 1,
+                    level - 1,
+                    counter / 2,
+                    tree_size,
+                    tree_nodes,
+                )?;
+                let maybe_hash = combine_maybe_hashes(left_hash, right_hash);
+                tree_nodes.insert((index, level), maybe_hash);
+
+                Ok(maybe_hash)
+            }
+        }
+    }
+}
+
+fn combine_maybe_hashes(
+    hash1: Option<MerkleHash>,
+    hash2: Option<MerkleHash>,
+) -> Option<MerkleHash> {
+    match (hash1, hash2) {
+        (Some(h1), Some(h2)) => Some(combine_hash(&h1, &h2)),
+        (Some(h1), None) => Some(h1),
+        (None, Some(_)) => {
+            debug_assert!(false, "Inconsistent state in merkle proof computation: left node is None but right node exists");
+            None
+        }
+        _ => None,
+    }
+}

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -56,7 +56,9 @@ use near_store::db::{StoreStatistics, STATE_SYNC_DUMP_KEY};
 use std::sync::Arc;
 
 mod latest_witnesses;
+mod merkle_proof;
 pub use latest_witnesses::LatestWitnessesInfo;
+pub use merkle_proof::MerkleProofAccess;
 
 /// lru cache size
 #[cfg(not(feature = "no_cache"))]
@@ -330,14 +332,6 @@ pub trait ChainStoreAccess {
     ) -> Result<Arc<PartialMerkleTree>, Error>;
 
     fn get_block_hash_from_ordinal(&self, block_ordinal: NumBlocks) -> Result<CryptoHash, Error>;
-
-    fn get_block_merkle_tree_from_ordinal(
-        &self,
-        block_ordinal: NumBlocks,
-    ) -> Result<Arc<PartialMerkleTree>, Error> {
-        let block_hash = self.get_block_hash_from_ordinal(block_ordinal)?;
-        self.get_block_merkle_tree(&block_hash)
-    }
 
     fn is_height_processed(&self, height: BlockHeight) -> Result<bool, Error>;
 

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -947,6 +947,17 @@ impl EpochManagerAdapter for MockEpochManager {
         Ok(true)
     }
 
+    fn verify_approval_with_approvers_info(
+        &self,
+        _prev_block_hash: &CryptoHash,
+        _prev_block_height: BlockHeight,
+        _block_height: BlockHeight,
+        _approvals: &[Option<Box<Signature>>],
+        _info: Vec<(ApprovalStake, bool)>,
+    ) -> Result<bool, Error> {
+        Ok(true)
+    }
+
     fn verify_approvals_and_threshold_orphan(
         &self,
         epoch_id: &EpochId,

--- a/chain/client/src/sync/epoch.rs
+++ b/chain/client/src/sync/epoch.rs
@@ -245,7 +245,7 @@ impl EpochSync {
             )?
             .ok_or_else(|| Error::Other("Could not find first block of next epoch".to_string()))?;
 
-        // TODO(#11932) That currently does not work because we might need some old block hashes
+        // TODO(#12255) That currently does not work because we might need some old block hashes
         // in order to build the merkle proof.
         // let merkle_proof_for_first_block_of_current_epoch = store
         //     .compute_past_block_proof_in_merkle_tree_of_later_block(
@@ -624,7 +624,7 @@ impl EpochSync {
     ) -> Result<(), Error> {
         // Verify first_block_header_in_epoch
         let first_block_header = &current_epoch.first_block_header_in_epoch;
-        // TODO(#11932) Uncomment the check below when `merkle_proof_for_first_block` is generated.
+        // TODO(#12255) Uncomment the check below when `merkle_proof_for_first_block` is generated.
         // if !merkle::verify_hash(
         //     *final_block_header.block_merkle_root(),
         //     &current_epoch.merkle_proof_for_first_block,
@@ -643,7 +643,7 @@ impl EpochSync {
                 "invalid path in partial_merkle_tree_for_first_block".to_string(),
             ));
         }
-        // TODO(#11932) Investigate why "+1" was needed here, looks like it should not be there.
+        // TODO(#12256) Investigate why "+1" was needed here, looks like it should not be there.
         if current_epoch.partial_merkle_tree_for_first_block.size() + 1
             != first_block_header.block_ordinal()
         {
@@ -669,7 +669,7 @@ impl EpochSync {
             &last_epoch.next_epoch_info,
             &last_epoch.next_next_epoch_info,
         ));
-        // TODO(#11932) This currently fails because `epoch_sync_data_hash` is missing in `final_block_header_in_next_epoch`.
+        // TODO(#12258) This currently fails because `epoch_sync_data_hash` is missing in `final_block_header_in_next_epoch`.
         // let expected_epoch_sync_data_hash = last_epoch
         //     .final_block_header_in_next_epoch
         //     .epoch_sync_data_hash()

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -1196,7 +1196,10 @@ impl Handler<GetBlockProof> for ViewClientActorInner {
         let head_block_header = self.chain.get_block_header(&msg.head_block_hash)?;
         self.chain.check_blocks_final_and_canonical(&[block_header.clone(), head_block_header])?;
         let block_header_lite = block_header.into();
-        let proof = self.chain.get_block_proof(&msg.block_hash, &msg.head_block_hash)?;
+        let proof = self.chain.compute_past_block_proof_in_merkle_tree_of_later_block(
+            &msg.block_hash,
+            &msg.head_block_hash,
+        )?;
         Ok(GetBlockProofResponse { block_header_lite, proof })
     }
 }

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -12,7 +12,9 @@ use near_async::time::{Clock, Duration, Instant};
 use near_chain::types::{RuntimeAdapter, Tip};
 use near_chain::{
     get_epoch_block_producers_view, Chain, ChainGenesis, ChainStoreAccess, DoomslugThresholdMode,
+    MerkleProofAccess,
 };
+
 use near_chain_configs::{ClientConfig, MutableValidatorSigner, ProtocolConfigView};
 use near_chain_primitives::error::EpochErrorResultToChainError;
 use near_client_primitives::types::{

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -423,6 +423,16 @@ pub trait EpochManagerAdapter: Send + Sync {
         approvals: &[Option<Box<Signature>>],
     ) -> Result<bool, Error>;
 
+    /// Verify aggregated bls signature given block approvers info
+    fn verify_approval_with_approvers_info(
+        &self,
+        prev_block_hash: &CryptoHash,
+        prev_block_height: BlockHeight,
+        block_height: BlockHeight,
+        approvals: &[Option<Box<Signature>>],
+        info: Vec<(ApprovalStake, bool)>,
+    ) -> Result<bool, Error>;
+
     /// Verify approvals and check threshold, but ignore next epoch approvals and slashing
     fn verify_approvals_and_threshold_orphan(
         &self,
@@ -1022,6 +1032,23 @@ impl EpochManagerAdapter for EpochManagerHandle {
             let epoch_manager = self.read();
             epoch_manager.get_all_block_approvers_ordered(prev_block_hash)?
         };
+        self.verify_approval_with_approvers_info(
+            prev_block_hash,
+            prev_block_height,
+            block_height,
+            approvals,
+            info,
+        )
+    }
+
+    fn verify_approval_with_approvers_info(
+        &self,
+        prev_block_hash: &CryptoHash,
+        prev_block_height: BlockHeight,
+        block_height: BlockHeight,
+        approvals: &[Option<Box<Signature>>],
+        info: Vec<(ApprovalStake, bool)>,
+    ) -> Result<bool, Error> {
         if approvals.len() > info.len() {
             return Ok(false);
         }

--- a/core/primitives/src/epoch_sync.rs
+++ b/core/primitives/src/epoch_sync.rs
@@ -1,9 +1,8 @@
-use crate::block_header::BlockHeader;
 use crate::epoch_block_info::BlockInfo;
 use crate::epoch_info::EpochInfo;
-use crate::merkle::PartialMerkleTree;
 use crate::types::validator_stake::ValidatorStake;
 use crate::utils::compression::CompressedData;
+use crate::{block_header::BlockHeader, merkle::MerklePathItem};
 use borsh::{BorshDeserialize, BorshSerialize};
 use bytesize::ByteSize;
 use near_crypto::Signature;
@@ -105,14 +104,11 @@ pub struct EpochSyncProofCurrentEpochData {
     /// to prove this like the other cases, because the first block header may not have a
     /// consecutive height afterwards.
     pub first_block_header_in_epoch: BlockHeader,
-    // TODO(#11932): can this be proven or derived?
-    pub first_block_info_in_epoch: BlockInfo,
     // The last two block headers are also needed for various purposes after epoch sync.
     // TODO(#11931): do we really need these?
     pub last_block_header_in_prev_epoch: BlockHeader,
     pub second_last_block_header_in_prev_epoch: BlockHeader,
-    // TODO(#11932): I'm not sure if this can be used to prove the block against the merkle root
-    // included in the final block in this next epoch (included in LastEpochData). We may need to
-    // include another merkle proof.
-    pub merkle_proof_for_first_block: PartialMerkleTree,
+    // Used to prove the block against the merkle root
+    // included in the final block in this next epoch (included in LastEpochData).
+    pub merkle_proof_for_first_block: Vec<MerklePathItem>,
 }

--- a/core/primitives/src/epoch_sync.rs
+++ b/core/primitives/src/epoch_sync.rs
@@ -111,11 +111,12 @@ pub struct EpochSyncProofCurrentEpochData {
     pub first_block_header_in_epoch: BlockHeader,
     // The last two block headers are also needed for various purposes after epoch sync.
     // TODO(#11931): do we really need these?
+    // TODO(#12259) These 2 fields are currently unverified.
     pub last_block_header_in_prev_epoch: BlockHeader,
     pub second_last_block_header_in_prev_epoch: BlockHeader,
     // Used to prove the block against the merkle root
     // included in the final block in this next epoch (included in LastEpochData).
-    // TODO(#11932) This field is currently ungenerated and unverified.
+    // TODO(#12255) This field is currently ungenerated and unverified.
     pub merkle_proof_for_first_block: Vec<MerklePathItem>,
     // Partial merkle tree for the first block in this next epoch.
     // It is necessary and sufficient to calculate next blocks merkle roots.

--- a/core/primitives/src/epoch_sync.rs
+++ b/core/primitives/src/epoch_sync.rs
@@ -1,11 +1,13 @@
 use crate::epoch_block_info::BlockInfo;
 use crate::epoch_info::EpochInfo;
+use crate::merkle::PartialMerkleTree;
 use crate::types::validator_stake::ValidatorStake;
 use crate::utils::compression::CompressedData;
 use crate::{block_header::BlockHeader, merkle::MerklePathItem};
 use borsh::{BorshDeserialize, BorshSerialize};
 use bytesize::ByteSize;
 use near_crypto::Signature;
+use near_primitives_core::types::ProtocolVersion;
 use near_schema_checker_lib::ProtocolSchema;
 use std::fmt::Debug;
 
@@ -73,6 +75,9 @@ pub struct EpochSyncProofPastEpochData {
     /// Since it has a consecutive height from the final block, the approvals are guaranteed to
     /// be endorsements which directly endorse the final block.
     pub approvals_for_last_final_block: Vec<Option<Box<Signature>>>,
+    /// Protocol version for this epoch. This is verified together with `block_producers`
+    /// against the `next_bp_hash` of the `last_final_block_header` of the epoch before this.
+    pub protocol_version: ProtocolVersion,
 }
 
 /// Data needed to initialize the epoch sync boundary.
@@ -111,4 +116,8 @@ pub struct EpochSyncProofCurrentEpochData {
     // Used to prove the block against the merkle root
     // included in the final block in this next epoch (included in LastEpochData).
     pub merkle_proof_for_first_block: Vec<MerklePathItem>,
+    // Partial merkle tree for the first block in this next epoch.
+    // It is necessary and sufficient to calculate next blocks merkle roots.
+    // It is proven using `first_block_header_in_epoch`.
+    pub partial_merkle_tree_for_first_block: PartialMerkleTree,
 }

--- a/core/primitives/src/epoch_sync.rs
+++ b/core/primitives/src/epoch_sync.rs
@@ -115,6 +115,7 @@ pub struct EpochSyncProofCurrentEpochData {
     pub second_last_block_header_in_prev_epoch: BlockHeader,
     // Used to prove the block against the merkle root
     // included in the final block in this next epoch (included in LastEpochData).
+    // TODO(#11932) This field is currently ungenerated and unverified.
     pub merkle_proof_for_first_block: Vec<MerklePathItem>,
     // Partial merkle tree for the first block in this next epoch.
     // It is necessary and sufficient to calculate next blocks merkle roots.

--- a/integration-tests/src/test_loop/tests/epoch_sync.rs
+++ b/integration-tests/src/test_loop/tests/epoch_sync.rs
@@ -315,7 +315,7 @@ fn sanity_check_epoch_sync_proof(
         (final_head_height - genesis_config.genesis_height - 1) / genesis_config.epoch_length + 1;
     let expected_current_epoch_height = epoch_height_of_final_block - 1;
     assert_eq!(
-        proof.current_epoch.first_block_info_in_epoch.height(),
+        proof.current_epoch.first_block_header_in_epoch.height(),
         genesis_config.genesis_height
             + (expected_current_epoch_height - 1) * genesis_config.epoch_length
             + 1

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -12,8 +12,8 @@ use near_async::time::{Clock, Duration};
 use near_chain::test_utils::ValidatorSchedule;
 use near_chain::types::{LatestKnown, RuntimeAdapter};
 use near_chain::validate::validate_chunk_with_chunk_extra;
-use near_chain::ChainStore;
 use near_chain::{Block, BlockProcessingArtifact, ChainStoreAccess, Error, Provenance};
+use near_chain::{ChainStore, MerkleProofAccess};
 use near_chain_configs::test_utils::{TESTING_INIT_BALANCE, TESTING_INIT_STAKE};
 use near_chain_configs::{Genesis, GenesisConfig, DEFAULT_GC_NUM_EPOCHS_TO_KEEP, NEAR_BASE};
 use near_client::test_utils::{

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2064,7 +2064,10 @@ fn test_block_merkle_proof_with_len(n: NumBlocks, rng: &mut StdRng) {
         }
     }
     for block in blocks {
-        let proof = env.clients[0].chain.get_block_proof(block.hash(), head.hash()).unwrap();
+        let proof = env.clients[0]
+            .chain
+            .compute_past_block_proof_in_merkle_tree_of_later_block(block.hash(), head.hash())
+            .unwrap();
         assert!(verify_hash(*root, &proof, *block.hash()));
     }
 }
@@ -2081,8 +2084,13 @@ fn test_block_merkle_proof() {
 fn test_block_merkle_proof_same_hash() {
     let env = TestEnv::default_builder().mock_epoch_managers().build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
-    let proof =
-        env.clients[0].chain.get_block_proof(genesis_block.hash(), genesis_block.hash()).unwrap();
+    let proof = env.clients[0]
+        .chain
+        .compute_past_block_proof_in_merkle_tree_of_later_block(
+            genesis_block.hash(),
+            genesis_block.hash(),
+        )
+        .unwrap();
     assert!(proof.is_empty());
 }
 


### PR DESCRIPTION
Issue: https://github.com/near/nearcore/issues/11932

Implements EpochSyncProof validation, according to:
- [design doc](https://docs.google.com/document/d/14Itc9Hs7ewTRmcGANid9UCaYcJzaLzzM7FsvYYIFKDY/edit#heading=h.p2oiicluwd6o)
- [`epoch_sync.rs`](https://github.com/near/nearcore/blob/d6d6e4782f7d57a7b7acc2894e1668355012ff74/core/primitives/src/epoch_sync.rs)

Summary:
- Move block merkle proof retrieval logic from `Chain` to a separate trait (`MerkleProofAccess`). Make `Store` implements this trait so that we can `get_block_proof` while serving `EpochSyncRequest` from a separate thread and having no access to `Chain`.
- Refactor `verify_approval` and `compute_bp_hash` so that we can use it for proof validation.
- Derive `first_block_info_in_epoch` from block header.
- Implement the validation logic.
- Add 2 more fields to the proof
  - `EpochSyncProofPastEpochData::protocol_version`
  -  `merkle_proof_for_first_block` generated at height of final block of current epoch.
  - Apparently, we need to add even more to enable generating `merkle_proof_for_first_block` at the bootstrapped node. That will be done as a follow-up issue: https://github.com/near/nearcore/issues/12255.
- Create a bunch of follow-up issues (added to the [tracking issue](https://github.com/near/near-one-project-tracking/issues/73)):
  - https://github.com/near/nearcore/issues/12255
  - https://github.com/near/nearcore/issues/12256
  - https://github.com/near/nearcore/issues/12258
  - https://github.com/near/nearcore/issues/12259
  - https://github.com/near/nearcore/issues/12260