### PR TITLE
chore: uncomment congestion_control.py

### DIFF
--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -186,7 +186,6 @@ pytest sanity/slow_chunk.py --features nightly
 pytest sanity/large_witness.py --features nightly
 
 # Tests for congestion control
-# TODO(congestion_control) - enable pytest on stabilization
 pytest sanity/congestion_control.py
 pytest sanity/congestion_control.py --features nightly
 pytest sanity/congestion_control_genesis_bootstrap.py

--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -187,7 +187,7 @@ pytest sanity/large_witness.py --features nightly
 
 # Tests for congestion control
 # TODO(congestion_control) - enable pytest on stabilization
-# pytest sanity/congestion_control.py
+pytest sanity/congestion_control.py
 pytest sanity/congestion_control.py --features nightly
 pytest sanity/congestion_control_genesis_bootstrap.py
 pytest sanity/congestion_control_genesis_bootstrap.py --features nightly


### PR DESCRIPTION
After https://github.com/Near-One/nayduck/pull/58, 3 consecutive runs against master shows that slow_chunk and congestion_control pass now. So it is safe to uncomment congestion_control.py.