### PR TITLE
[stateless_validation] Stabilize ChunkEndorsementV2

### DIFF
--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -223,7 +223,8 @@ impl ProtocolFeature {
             ProtocolFeature::StatelessValidation => 69,
             ProtocolFeature::BLS12381 | ProtocolFeature::EthImplicitAccounts => 70,
             ProtocolFeature::FixMinStakeRatio => 71,
-            ProtocolFeature::IncreaseStorageProofSizeSoftLimit => 72,
+            ProtocolFeature::IncreaseStorageProofSizeSoftLimit
+            | ProtocolFeature::ChunkEndorsementV2 => 72,
 
             // This protocol version is reserved for use in resharding tests. An extra resharding
             // is simulated on top of the latest shard layout in production. Note that later
@@ -242,7 +243,6 @@ impl ProtocolFeature {
             // TODO(#11201): When stabilizing this feature in mainnet, also remove the temporary code
             // that always enables this for mocknet (see config_mocknet function).
             ProtocolFeature::ShuffleShardAssignments => 143,
-            ProtocolFeature::ChunkEndorsementV2 => 144,
             ProtocolFeature::ChunkEndorsementsInBlockHeader => 145,
         }
     }


### PR DESCRIPTION
Move ChunkEndorsementV2 to stable protocol version.

With the next release, we should be able to get rid of tracker_v1 code.