### PR TITLE
vm: use contract_cache_key for memory cache

### DIFF
--- a/runtime/near-vm-runner/src/near_vm_runner/runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner/runner.rs
@@ -224,9 +224,9 @@ impl NearVM {
         // To identify a cache hit from either in-memory and on-disk cache correctly, we first assume that we have a cache hit here,
         // and then we set it to false when we fail to find any entry and decide to compile (by calling compile_and_cache below).
         let mut is_cache_hit = true;
-        let code_hash = contract.hash();
+        let key = get_contract_cache_key(contract.hash(), &self.config);
         let (wasm_bytes, artifact_result) = cache.memory_cache().try_lookup(
-            code_hash,
+            key,
             || {
                 // `cache` stores compiled machine code in the database
                 //
@@ -235,7 +235,6 @@ impl NearVM {
                 // outcome). And `cache`, being a database, can fail with an `io::Error`.
                 let _span =
                     tracing::debug_span!(target: "vm", "NearVM::fetch_from_cache").entered();
-                let key = get_contract_cache_key(code_hash, &self.config);
                 let cache_record = cache.get(&key).map_err(CacheError::ReadError)?;
                 let Some(compiled_contract_info) = cache_record else {
                     let Some(code) = contract.get_code() else {

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -191,13 +191,12 @@ impl WasmtimeVM {
         method: &str,
         closure: impl FnOnce(GasCounter, Module) -> VMResult<PreparedContract>,
     ) -> VMResult<PreparedContract> {
-        let code_hash = contract.hash();
         type MemoryCacheType = (u64, Result<Module, CompilationError>);
         let to_any = |v: MemoryCacheType| -> Box<dyn std::any::Any + Send> { Box::new(v) };
+        let key = get_contract_cache_key(contract.hash(), &self.config);
         let (wasm_bytes, module_result) = cache.memory_cache().try_lookup(
-            code_hash,
+            key,
             || {
-                let key = get_contract_cache_key(code_hash, &self.config);
                 let cache_record = cache.get(&key).map_err(CacheError::ReadError)?;
                 let Some(compiled_contract_info) = cache_record else {
                     let Some(code) = contract.get_code() else {


### PR DESCRIPTION
This makes sure that changes to the configuration correctly take effect for provided contract. Otherwise the repeat executions of a contract that's already in the cache might "stick" to the old behaviour across e.g. a VM configuration change.