### PR TITLE
feat: add apply_reason label for apply chunk metric

### DIFF
--- a/chain/chain/src/runtime/metrics.rs
+++ b/chain/chain/src/runtime/metrics.rs
@@ -82,7 +82,7 @@ pub static APPLYING_CHUNKS_TIME: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
         "near_applying_chunks_time",
         "Time taken to apply chunks per shard",
-        &["shard_id"],
+        &["apply_reason", "shard_id"],
         Some(processing_time_buckets()),
     )
     .unwrap()

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -961,8 +961,9 @@ impl RuntimeAdapter for NightshadeRuntime {
         transactions: &[SignedTransaction],
     ) -> Result<ApplyChunkResult, Error> {
         let shard_id = chunk.shard_id;
-        let _timer =
-            metrics::APPLYING_CHUNKS_TIME.with_label_values(&[&shard_id.to_string()]).start_timer();
+        let _timer = metrics::APPLYING_CHUNKS_TIME
+            .with_label_values(&[&apply_reason.to_string(), &shard_id.to_string()])
+            .start_timer();
 
         let mut trie = match storage_config.source {
             StorageDataSource::Db => self.get_trie_for_shard(


### PR DESCRIPTION
This can be helpful when we need to distinguish between applications from chunk producer and chunk validator. One example is to compare memtrie vs recorded storage perf.