### PR TITLE
build: bump shared version of public crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 # anything to the list of stable crates.
 # Only bump  0.x.* to 0.(x+1).0 on any nearcore release as nearcore does not guarantee
 # semver compatibility. i.e. api can change without a protocol upgrade.
-version = "0.20.1"
+version = "0.25.0"
 exclude = ["neard"]
 
 [workspace]


### PR DESCRIPTION
The shared version is bumped on release branches (e.g. [here](https://github.com/near/nearcore/commit/d630c63d45bf2a98039ee15364af1717224e924a)) but not on master. This PR brings it up to date with the latest version of `near-*` crates published on crates.io. Having master in synch with crates.io is required for #12039.

More info can be found on [Zulip](https://near.zulipchat.com/#narrow/stream/295302-general/topic/Version.20mismatch.20workspace.20vs.20published.20crates.3F).