### PR TITLE
rust: 1.81.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 version = "0.0.0"                               # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
-rust-version = "1.80.1"
+rust-version = "1.81.0"
 repository = "https://github.com/near/nearcore"
 license = "MIT OR Apache-2.0"
 

--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -20,6 +20,10 @@ pub(crate) mod testonly;
 mod tests;
 
 mod _proto {
+    // TODO: protobuf codegen includes `#![allow(box_pointers)]` which Clippy
+    // doesn’t like.  Allow renamed_and_removed_lints to silence that warning.
+    // Remove this once protobuf codegen is updated.
+    #![allow(renamed_and_removed_lints)]
     include!(concat!(env!("OUT_DIR"), "/proto/mod.rs"));
 }
 

--- a/chain/network/src/store/schema/mod.rs
+++ b/chain/network/src/store/schema/mod.rs
@@ -102,27 +102,6 @@ impl Column for RecentOutboundConnections {
     type Value = Vec<ConnectionInfoRepr>;
 }
 
-pub(super) struct PeerComponent;
-impl Column for PeerComponent {
-    const COL: DBCol = DBCol::PeerComponent;
-    type Key = Borsh<PeerId>;
-    type Value = Borsh<u64>;
-}
-
-pub(super) struct ComponentEdges;
-impl Column for ComponentEdges {
-    const COL: DBCol = DBCol::ComponentEdges;
-    type Key = U64LE;
-    type Value = Vec<EdgeRepr>;
-}
-
-pub(super) struct LastComponentNonce;
-impl Column for LastComponentNonce {
-    const COL: DBCol = DBCol::LastComponentNonce;
-    type Key = Borsh<()>;
-    type Value = Borsh<u64>;
-}
-
 ////////////////////////////////////////////////////
 // Storage
 

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -484,9 +484,7 @@ impl ShardTries {
         shard_uids_to_load
             .par_iter()
             .map(|shard_uid| self.load_mem_trie(shard_uid, None, parallelize))
-            .collect::<Vec<Result<_, _>>>()
-            .into_iter()
-            .collect::<Result<_, _>>()?;
+            .collect::<Result<(), StorageError>>()?;
 
         info!(target: "memtrie", "Memtries loading complete for shards {:?}", shard_uids_to_load);
         Ok(())

--- a/runtime/near-vm/tests/compilers/traps.rs
+++ b/runtime/near-vm/tests/compilers/traps.rs
@@ -1,3 +1,10 @@
+// TODO: Panics in function bodies in rust_panic_import and
+// rust_panic_start_function tests make ‘depends on never type fallback being
+// `()`’ compile-time warning trigger (with additional note: ‘in edition 2024,
+// the requirement `!: FromToNativeWasmType` will fail’).  I couldn’t figure out
+// proper annotation to make it go away.  Silence the warning for now.
+#![allow(dependency_on_unit_never_type_fallback)]
+
 use anyhow::Result;
 use near_vm_engine::RuntimeError;
 use near_vm_test_api::*;

--- a/runtime/near-wallet-contract/implementation/rust-toolchain.toml
+++ b/runtime/near-wallet-contract/implementation/rust-toolchain.toml
@@ -3,6 +3,6 @@
 # Changing this file is a protocol change because it will change the
 # bytes of the wallet contract. Therefore please only upgrade the Rust
 # version here when there is a good reason to do so.
-channel = "1.80.1"
+channel = "1.81.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 targets = ["wasm32-unknown-unknown"]

--- a/runtime/runtime-params-estimator/emu-cost/Dockerfile
+++ b/runtime/runtime-params-estimator/emu-cost/Dockerfile
@@ -1,5 +1,5 @@
 # our local base image
-FROM docker.io/rust:1.80.1
+FROM docker.io/rust:1.81.0
 
 LABEL description="Container for builds"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,6 +2,6 @@
 # This specifies the version of Rust we use to build.
 # Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
 # The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
-channel = "1.80.1"
+channel = "1.81.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 targets = ["wasm32-unknown-unknown"]

--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -152,13 +152,13 @@ pub fn state_dump_redis(
                 if let StateRecord::Account { account_id, account } = &sr {
                     println!("Account: {}", account_id);
                     let redis_key = account_id.as_bytes();
-                    redis_connection.zadd(
+                    let () = redis_connection.zadd(
                         [b"account:", redis_key].concat(),
                         block_hash.as_ref(),
                         block_height,
                     )?;
                     let value = borsh::to_vec(&account).unwrap();
-                    redis_connection.set(
+                    let () = redis_connection.set(
                         [b"account-data:", redis_key, b":", block_hash.as_ref()].concat(),
                         value,
                     )?;
@@ -168,13 +168,13 @@ pub fn state_dump_redis(
                 if let StateRecord::Data { account_id, data_key, value } = &sr {
                     println!("Data: {}", account_id);
                     let redis_key = [account_id.as_bytes(), b":", data_key.as_ref()].concat();
-                    redis_connection.zadd(
+                    let () = redis_connection.zadd(
                         [b"data:", redis_key.as_slice()].concat(),
                         block_hash.as_ref(),
                         block_height,
                     )?;
                     let value_vec: &[u8] = value.as_ref();
-                    redis_connection.set(
+                    let () = redis_connection.set(
                         [b"data-value:", redis_key.as_slice(), b":", block_hash.as_ref()].concat(),
                         value_vec,
                     )?;
@@ -184,9 +184,9 @@ pub fn state_dump_redis(
                 if let StateRecord::Contract { account_id, code } = &sr {
                     println!("Contract: {}", account_id);
                     let redis_key = [b"code:", account_id.as_bytes()].concat();
-                    redis_connection.zadd(redis_key.clone(), block_hash.as_ref(), block_height)?;
+                    let () = redis_connection.zadd(redis_key.clone(), block_hash.as_ref(), block_height)?;
                     let value_vec: &[u8] = code.as_ref();
-                    redis_connection.set(
+                    let () = redis_connection.set(
                         [redis_key.clone(), b":".to_vec(), block_hash.0.to_vec()].concat(),
                         value_vec,
                     )?;

--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -184,7 +184,11 @@ pub fn state_dump_redis(
                 if let StateRecord::Contract { account_id, code } = &sr {
                     println!("Contract: {}", account_id);
                     let redis_key = [b"code:", account_id.as_bytes()].concat();
-                    let () = redis_connection.zadd(redis_key.clone(), block_hash.as_ref(), block_height)?;
+                    let () = redis_connection.zadd(
+                        redis_key.clone(),
+                        block_hash.as_ref(),
+                        block_height,
+                    )?;
                     let value_vec: &[u8] = code.as_ref();
                     let () = redis_connection.set(
                         [redis_key.clone(), b":".to_vec(), block_hash.0.to_vec()].concat(),

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -3,7 +3,7 @@ name = "near-tracing"
 version = "0.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
-rust-version = "1.80.1"
+rust-version = "1.81.0"
 repository = "https://github.com/near/nearcore"
 license = "MIT OR Apache-2.0"
 

--- a/utils/near-performance-metrics/src/stats_enabled.rs
+++ b/utils/near-performance-metrics/src/stats_enabled.rs
@@ -303,7 +303,7 @@ where
     let took = ended.saturating_duration_since(start);
 
     if took >= SLOW_CALL_THRESHOLD {
-        let text_field = msg_text.map(|x| format!(" msg: {}", x)).unwrap_or(format!(""));
+        let text_field = msg_text.map_or(String::new(), |x| format!(" msg: {x}"));
         warn!(
             "Function exceeded time limit {}:{:?} {:?} took: {}ms {}",
             class_name,


### PR DESCRIPTION
Release notes: https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html

Addresses the following Clippy warnings:

    warning: lint `box_pointers` has been removed: it does not detect
    other kinds of allocations, and existed only for historical reasons

    warning: struct `PeerComponent` is never constructed
    warning: struct `ComponentEdges` is never constructed
    warning: struct `LastComponentNonce` is never constructed

    warning: this function depends on never type fallback being `()`
       --> core/store/src/trie/shard_tries.rs:468:5
    warning: this function depends on never type fallback being `()`
       --> tools/state-viewer/src/state_dump.rs:132:1