### PR TITLE
[Epoch Sync] Compress the EpochSyncProof over the network.

### DIFF
--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -29,6 +29,7 @@ use near_primitives::stateless_validation::state_witness::{
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{ProtocolVersion, ShardId};
+use near_primitives::utils::compression::CompressedData;
 use near_store::PartialStorage;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;

--- a/chain/client/src/stateless_validation/partial_witness/encoding.rs
+++ b/chain/client/src/stateless_validation/partial_witness/encoding.rs
@@ -5,6 +5,7 @@ use near_primitives::reed_solomon::{
     reed_solomon_decode, reed_solomon_encode, reed_solomon_part_length,
 };
 use near_primitives::stateless_validation::state_witness::EncodedChunkStateWitness;
+use near_primitives::utils::compression::CompressedData;
 use reed_solomon_erasure::galois_8::ReedSolomon;
 
 /// Ratio of the number of data parts to total parts in the Reed Solomon encoding.

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
@@ -30,6 +30,7 @@ use crate::stateless_validation::validate::validate_partial_encoded_state_witnes
 
 use super::encoding::WitnessEncoderCache;
 use super::partial_witness_tracker::PartialEncodedStateWitnessTracker;
+use near_primitives::utils::compression::CompressedData;
 
 pub struct PartialWitnessActor {
     /// Adapter to send messages to the network.

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
@@ -19,6 +19,7 @@ use crate::client_actor::ClientSenderForPartialWitness;
 use crate::metrics;
 
 use super::encoding::{WitnessEncoder, WitnessEncoderCache, WitnessPart};
+use near_primitives::utils::compression::CompressedData;
 
 /// Max number of chunks to keep in the witness tracker cache. We reach here only after validation
 /// of the partial_witness so the LRU cache size need not be too large.

--- a/chain/network/src/client.rs
+++ b/chain/network/src/client.rs
@@ -4,7 +4,7 @@ use near_async::messaging::{AsyncSender, Sender};
 use near_async::{MultiSend, MultiSendMessage, MultiSenderFrom};
 use near_primitives::block::{Approval, Block, BlockHeader};
 use near_primitives::challenge::Challenge;
-use near_primitives::epoch_sync::EpochSyncProof;
+use near_primitives::epoch_sync::CompressedEpochSyncProof;
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
@@ -128,7 +128,7 @@ pub struct EpochSyncRequestMessage {
 #[rtype(result = "()")]
 pub struct EpochSyncResponseMessage {
     pub from_peer: PeerId,
-    pub proof: EpochSyncProof,
+    pub proof: CompressedEpochSyncProof,
 }
 
 #[derive(Clone, MultiSend, MultiSenderFrom, MultiSendMessage)]

--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -35,7 +35,7 @@ use near_crypto::Signature;
 use near_o11y::OpenTelemetrySpanExt;
 use near_primitives::block::{Approval, Block, BlockHeader, GenesisId};
 use near_primitives::challenge::Challenge;
-use near_primitives::epoch_sync::EpochSyncProof;
+use near_primitives::epoch_sync::CompressedEpochSyncProof;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::combine_hash;
 use near_primitives::network::{AnnounceAccount, PeerId};
@@ -547,7 +547,7 @@ pub enum RoutedMessageBody {
     PartialEncodedStateWitnessForward(PartialEncodedStateWitness),
     VersionedChunkEndorsement(ChunkEndorsement),
     EpochSyncRequest,
-    EpochSyncResponse(EpochSyncProof),
+    EpochSyncResponse(CompressedEpochSyncProof),
 }
 
 impl RoutedMessageBody {
@@ -638,12 +638,8 @@ impl fmt::Debug for RoutedMessageBody {
                 write!(f, "VersionedChunkEndorsement")
             }
             RoutedMessageBody::EpochSyncRequest => write!(f, "EpochSyncRequest"),
-            RoutedMessageBody::EpochSyncResponse(proof) => {
-                write!(
-                    f,
-                    "EpochSyncResponse(epoch: {:?})",
-                    proof.current_epoch.first_block_header_in_epoch.epoch_id(),
-                )
+            RoutedMessageBody::EpochSyncResponse(_) => {
+                write!(f, "EpochSyncResponse")
             }
         }
     }

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -16,7 +16,7 @@ use near_async::time;
 use near_crypto::PublicKey;
 use near_primitives::block::{ApprovalMessage, Block, GenesisId};
 use near_primitives::challenge::Challenge;
-use near_primitives::epoch_sync::EpochSyncProof;
+use near_primitives::epoch_sync::CompressedEpochSyncProof;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::sharding::PartialEncodedChunkWithArcReceipts;
@@ -285,7 +285,7 @@ pub enum NetworkRequests {
     /// Requests an epoch sync
     EpochSyncRequest { peer_id: PeerId },
     /// Response to an epoch sync request
-    EpochSyncResponse { route_back: CryptoHash, proof: EpochSyncProof },
+    EpochSyncResponse { route_back: CryptoHash, proof: CompressedEpochSyncProof },
 }
 
 /// Combines peer address info, chain.

--- a/core/primitives/src/stateless_validation/state_witness.rs
+++ b/core/primitives/src/stateless_validation/state_witness.rs
@@ -7,10 +7,9 @@ use crate::congestion_info::CongestionInfo;
 use crate::sharding::{ChunkHash, ReceiptProof, ShardChunkHeader, ShardChunkHeaderV3};
 use crate::transaction::SignedTransaction;
 use crate::types::EpochId;
-use crate::utils::io::{CountingRead, CountingWrite};
+use crate::utils::compression::CompressedData;
 use crate::validator_signer::EmptyValidatorSigner;
 use borsh::{BorshDeserialize, BorshSerialize};
-use bytes::{Buf, BufMut};
 use bytesize::ByteSize;
 use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::{AccountId, BlockHeight, ShardId};
@@ -19,86 +18,30 @@ use near_schema_checker_lib::ProtocolSchema;
 
 /// Represents max allowed size of the raw (not compressed) state witness,
 /// corresponds to the size of borsh-serialized ChunkStateWitness.
-pub const MAX_UNCOMPRESSED_STATE_WITNESS_SIZE: ByteSize =
-    ByteSize::mib(if cfg!(feature = "test_features") { 512 } else { 64 });
+pub const MAX_UNCOMPRESSED_STATE_WITNESS_SIZE: u64 =
+    ByteSize::mib(if cfg!(feature = "test_features") { 512 } else { 64 }).0;
 
 /// Represents bytes of encoded ChunkStateWitness.
 /// This is the compressed version of borsh-serialized state witness.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, ProtocolSchema)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    BorshSerialize,
+    BorshDeserialize,
+    ProtocolSchema,
+    derive_more::From,
+    derive_more::AsRef,
+)]
 pub struct EncodedChunkStateWitness(Box<[u8]>);
 
-pub type ChunkStateWitnessSize = usize;
-
-impl EncodedChunkStateWitness {
-    /// Only use this if you are sure that the data is already encoded.
-    pub fn from_boxed_slice(data: Box<[u8]>) -> Self {
-        Self(data)
-    }
-
-    /// Borsh-serialize and compress state witness.
-    /// Returns encoded witness along with the raw (uncompressed) witness size.
-    pub fn encode(witness: &ChunkStateWitness) -> std::io::Result<(Self, ChunkStateWitnessSize)> {
-        const STATE_WITNESS_COMPRESSION_LEVEL: i32 = 3;
-
-        // Flow of data: State witness --> Borsh serialization --> Counting write --> zstd compression --> Bytes.
-        // CountingWrite will count the number of bytes for the Borsh-serialized witness, before compression.
-        let mut counting_write = CountingWrite::new(zstd::stream::Encoder::new(
-            Vec::new().writer(),
-            STATE_WITNESS_COMPRESSION_LEVEL,
-        )?);
-        borsh::to_writer(&mut counting_write, witness)?;
-
-        let borsh_bytes_len = counting_write.bytes_written();
-        let encoded_bytes = counting_write.into_inner().finish()?.into_inner();
-
-        Ok((Self(encoded_bytes.into()), borsh_bytes_len.as_u64() as usize))
-    }
-
-    /// Decompress and borsh-deserialize encoded witness bytes.
-    /// Returns decoded witness along with the raw (uncompressed) witness size.
-    pub fn decode(&self) -> std::io::Result<(ChunkStateWitness, ChunkStateWitnessSize)> {
-        // We want to limit the size of decompressed data to address "Zip bomb" attack.
-        self.decode_with_limit(MAX_UNCOMPRESSED_STATE_WITNESS_SIZE)
-    }
-
-    /// Decompress and borsh-deserialize encoded witness bytes.
-    /// Returns decoded witness along with the raw (uncompressed) witness size.
-    pub fn decode_with_limit(
-        &self,
-        limit: ByteSize,
-    ) -> std::io::Result<(ChunkStateWitness, ChunkStateWitnessSize)> {
-        // Flow of data: Bytes --> zstd decompression --> Counting read --> Borsh deserialization --> State witness.
-        // CountingRead will count the number of bytes for the Borsh-deserialized witness, after decompression.
-        let mut counting_read = CountingRead::new_with_limit(
-            zstd::stream::Decoder::new(self.0.as_ref().reader())?,
-            limit,
-        );
-
-        match borsh::from_reader(&mut counting_read) {
-            Err(err) => {
-                // If decompressed data exceeds the limit then CountingRead will return a WriteZero error.
-                // Here we convert it to a more descriptive error to make debugging easier.
-                let err = if err.kind() == std::io::ErrorKind::WriteZero {
-                    std::io::Error::other(format!(
-                        "Decompressed data exceeded limit of {limit}: {err}"
-                    ))
-                } else {
-                    err
-                };
-                Err(err)
-            }
-            Ok(witness) => Ok((witness, counting_read.bytes_read().as_u64().try_into().unwrap())),
-        }
-    }
-
-    pub fn size_bytes(&self) -> ChunkStateWitnessSize {
-        self.0.len()
-    }
-
-    pub fn as_slice(&self) -> &[u8] {
-        &self.0
-    }
+impl CompressedData<ChunkStateWitness, MAX_UNCOMPRESSED_STATE_WITNESS_SIZE, 3>
+    for EncodedChunkStateWitness
+{
 }
+
+pub type ChunkStateWitnessSize = usize;
 
 /// An acknowledgement sent from the chunk producer upon receiving the state witness to
 /// the originator of the witness (chunk producer).
@@ -292,66 +235,4 @@ pub struct ChunkStateTransition {
     /// derived by applying the state transition onto the base state, but
     /// this makes it easier to debug why a state witness may fail to validate.
     pub post_state_root: CryptoHash,
-}
-
-#[cfg(test)]
-mod tests {
-    use bytesize::ByteSize;
-    use near_primitives_core::hash::CryptoHash;
-    use std::io::ErrorKind;
-
-    use crate::stateless_validation::state_witness::{ChunkStateWitness, EncodedChunkStateWitness};
-
-    #[test]
-    fn encode_decode_state_dummy_witness_default_limit() {
-        let original_witness = ChunkStateWitness::new_dummy(42, 0, CryptoHash::default());
-        let (encoded_witness, borsh_bytes_from_encode) =
-            EncodedChunkStateWitness::encode(&original_witness).unwrap();
-        let (decoded_witness, borsh_bytes_from_decode) =
-            EncodedChunkStateWitness::from_boxed_slice(encoded_witness.0).decode().unwrap();
-        assert_eq!(decoded_witness, original_witness);
-        assert_eq!(borsh_bytes_from_encode, borsh_bytes_from_decode);
-        assert_eq!(borsh::to_vec(&original_witness).unwrap().len(), borsh_bytes_from_encode);
-    }
-
-    #[test]
-    fn encode_decode_state_dummy_witness_within_limit() {
-        const LIMIT: ByteSize = ByteSize::mib(32);
-        let original_witness = ChunkStateWitness::new_dummy(42, 0, CryptoHash::default());
-        let (encoded_witness, borsh_bytes_from_encode) =
-            EncodedChunkStateWitness::encode(&original_witness).unwrap();
-        let (decoded_witness, borsh_bytes_from_decode) =
-            EncodedChunkStateWitness::from_boxed_slice(encoded_witness.0)
-                .decode_with_limit(LIMIT)
-                .unwrap();
-        assert_eq!(decoded_witness, original_witness);
-        assert_eq!(borsh_bytes_from_encode, borsh_bytes_from_decode);
-        assert_eq!(borsh::to_vec(&original_witness).unwrap().len(), borsh_bytes_from_encode);
-    }
-
-    #[test]
-    fn encode_decode_state_dummy_witness_exceeds_limit() {
-        const LIMIT: ByteSize = ByteSize::b(32);
-        let original_witness = ChunkStateWitness::new_dummy(42, 0, CryptoHash::default());
-        let (encoded_witness, borsh_bytes_from_encode) =
-            EncodedChunkStateWitness::encode(&original_witness).unwrap();
-        assert!(borsh_bytes_from_encode > LIMIT.as_u64() as usize);
-        let error = EncodedChunkStateWitness::from_boxed_slice(encoded_witness.0)
-            .decode_with_limit(LIMIT)
-            .unwrap_err();
-        assert_eq!(error.kind(), ErrorKind::Other);
-        assert_eq!(
-            error.to_string(),
-            "Decompressed data exceeded limit of 32 B: Exceeded the limit of 32 bytes"
-        );
-    }
-
-    #[test]
-    fn decode_state_dummy_witness_invalid_data() {
-        let invalid_data = [0; 10];
-        let error = EncodedChunkStateWitness::from_boxed_slice(Box::new(invalid_data))
-            .decode()
-            .unwrap_err();
-        assert_eq!(error.kind(), ErrorKind::Other);
-    }
 }

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -21,6 +21,7 @@ use near_primitives_core::account::id::{AccountId, AccountType};
 use std::mem::size_of;
 use std::ops::Deref;
 
+pub mod compression;
 pub mod io;
 pub mod min_heap;
 

--- a/core/primitives/src/utils/compression.rs
+++ b/core/primitives/src/utils/compression.rs
@@ -1,0 +1,129 @@
+use super::io::CountingRead;
+use crate::utils::io::CountingWrite;
+use borsh::{BorshDeserialize, BorshSerialize};
+use bytes::{Buf, BufMut};
+use bytesize::ByteSize;
+
+/// Helper trait for implementing a compressed structure for networking messages.
+/// The reason this is not a struct is because some derives do not work well on
+/// structs that have generics; e.g. ProtocolSchema.
+pub trait CompressedData<T, const MAX_UNCOMPRESSED_SIZE: u64, const COMPRESSION_LEVEL: i32>
+where
+    T: BorshSerialize + BorshDeserialize,
+    Self: From<Box<[u8]>> + AsRef<Box<[u8]>>,
+{
+    /// Only use this if you are sure that the data is already encoded.
+    fn from_boxed_slice(data: Box<[u8]>) -> Self {
+        Self::from(data)
+    }
+
+    /// Borsh-serialize and compress state witness.
+    /// Returns encoded witness along with the raw (uncompressed) witness size.
+    fn encode(witness: &T) -> std::io::Result<(Self, usize)> {
+        // Flow of data: State witness --> Borsh serialization --> Counting write --> zstd compression --> Bytes.
+        // CountingWrite will count the number of bytes for the Borsh-serialized witness, before compression.
+        let mut counting_write =
+            CountingWrite::new(zstd::stream::Encoder::new(Vec::new().writer(), COMPRESSION_LEVEL)?);
+        borsh::to_writer(&mut counting_write, witness)?;
+
+        let borsh_bytes_len = counting_write.bytes_written();
+        let encoded_bytes = counting_write.into_inner().finish()?.into_inner();
+
+        Ok((Self::from(encoded_bytes.into()), borsh_bytes_len.as_u64() as usize))
+    }
+
+    /// Decompress and borsh-deserialize encoded witness bytes.
+    /// Returns decoded witness along with the raw (uncompressed) witness size.
+    fn decode(&self) -> std::io::Result<(T, usize)> {
+        // We want to limit the size of decompressed data to address "Zip bomb" attack.
+        self.decode_with_limit(ByteSize(MAX_UNCOMPRESSED_SIZE))
+    }
+
+    /// Decompress and borsh-deserialize encoded witness bytes.
+    /// Returns decoded witness along with the raw (uncompressed) witness size.
+    fn decode_with_limit(&self, limit: ByteSize) -> std::io::Result<(T, usize)> {
+        // Flow of data: Bytes --> zstd decompression --> Counting read --> Borsh deserialization --> State witness.
+        // CountingRead will count the number of bytes for the Borsh-deserialized witness, after decompression.
+        let mut counting_read = CountingRead::new_with_limit(
+            zstd::stream::Decoder::new(self.as_ref().as_ref().reader())?,
+            limit,
+        );
+
+        match borsh::from_reader(&mut counting_read) {
+            Err(err) => {
+                // If decompressed data exceeds the limit then CountingRead will return a WriteZero error.
+                // Here we convert it to a more descriptive error to make debugging easier.
+                let err = if err.kind() == std::io::ErrorKind::WriteZero {
+                    std::io::Error::other(format!(
+                        "Decompressed data exceeded limit of {limit}: {err}"
+                    ))
+                } else {
+                    err
+                };
+                Err(err)
+            }
+            Ok(witness) => Ok((witness, counting_read.bytes_read().as_u64().try_into().unwrap())),
+        }
+    }
+
+    fn size_bytes(&self) -> usize {
+        self.as_ref().len()
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        &self.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::compression::CompressedData;
+    use borsh::{BorshDeserialize, BorshSerialize};
+    use std::io::ErrorKind;
+
+    #[derive(BorshSerialize, BorshDeserialize, PartialEq, Debug)]
+    struct MyData(Vec<u8>);
+
+    #[derive(derive_more::From, derive_more::AsRef)]
+    struct CompressedMyData(Box<[u8]>);
+
+    impl super::CompressedData<MyData, 1000, 3> for CompressedMyData {}
+
+    #[test]
+    fn encode_decode_within_limit() {
+        let data = MyData(vec![42; 100]);
+        let (compressed, uncompressed_size) = CompressedMyData::encode(&data).unwrap();
+        let (decompressed, decompressed_size) = compressed.decode().unwrap();
+        assert_eq!(&decompressed, &data);
+        assert_eq!(uncompressed_size, decompressed_size);
+        assert_eq!(borsh::to_vec(&data).unwrap().len(), uncompressed_size);
+    }
+
+    #[test]
+    fn encode_exceeding_limit() {
+        // Encode exceeding limit is OK.
+        let data = MyData(vec![42; 2000]);
+        let (_, uncompressed_size) = CompressedMyData::encode(&data).unwrap();
+        assert_eq!(borsh::to_vec(&data).unwrap().len(), uncompressed_size);
+    }
+
+    #[test]
+    fn decode_exceeding_limit() {
+        let data = MyData(vec![42; 2000]);
+        let (compressed, _) = CompressedMyData::encode(&data).unwrap();
+        let error = compressed.decode().unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::Other);
+        assert_eq!(
+            error.to_string(),
+            "Decompressed data exceeded limit of 1.0 KB: Exceeded the limit of 1000 bytes"
+        );
+    }
+
+    #[test]
+    fn decode_invalid_data() {
+        let invalid_data = [0; 10];
+        let error =
+            CompressedMyData::from_boxed_slice(Box::new(invalid_data)).decode().unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::Other);
+    }
+}

--- a/core/primitives/src/validator_signer.rs
+++ b/core/primitives/src/validator_signer.rs
@@ -16,6 +16,7 @@ use crate::stateless_validation::partial_witness::PartialEncodedStateWitnessInne
 use crate::stateless_validation::state_witness::EncodedChunkStateWitness;
 use crate::telemetry::TelemetryInfo;
 use crate::types::{AccountId, BlockHeight, EpochId};
+use crate::utils::compression::CompressedData;
 
 /// Enum for validator signer, that holds validator id and key used for signing data.
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
Closes #11933 

This compresses the EpochSyncProof similar to how we compressed ChunkStateWitness. In fact, the code is refactored out to a CompressedData trait so we don't duplicate this code.