### PR TITLE
feat: clean up resharding v2 part 3

### DIFF
--- a/chain/chain/src/metrics.rs
+++ b/chain/chain/src/metrics.rs
@@ -143,30 +143,6 @@ pub(crate) static LARGEST_FINAL_HEIGHT: LazyLock<IntGauge> = LazyLock::new(|| {
     .unwrap()
 });
 
-pub(crate) enum ReshardingStatus {
-    /// The ReshardingRequest was send to the SyncJobsActor.
-    Scheduled,
-    /// The SyncJobsActor is performing the resharding.
-    BuildingState,
-    /// The resharding is finished.
-    Finished,
-    /// The resharding failed. Manual recovery is necessary!
-    Failed,
-}
-
-impl From<ReshardingStatus> for i64 {
-    /// Converts status to integer to export to prometheus later.
-    /// Cast inside enum does not work because it is not fieldless.
-    fn from(value: ReshardingStatus) -> Self {
-        match value {
-            ReshardingStatus::Scheduled => 0,
-            ReshardingStatus::BuildingState => 1,
-            ReshardingStatus::Finished => 2,
-            ReshardingStatus::Failed => -1,
-        }
-    }
-}
-
 pub(crate) static SHARD_LAYOUT_VERSION: LazyLock<IntGauge> = LazyLock::new(|| {
     try_create_int_gauge(
         "near_shard_layout_version",
@@ -179,63 +155,6 @@ pub(crate) static SHARD_LAYOUT_NUM_SHARDS: LazyLock<IntGauge> = LazyLock::new(||
     try_create_int_gauge(
         "near_shard_layout_num_shards",
         "The number of shards in the shard layout of the current head.",
-    )
-    .unwrap()
-});
-
-pub(crate) static RESHARDING_BATCH_COUNT: LazyLock<IntGaugeVec> = LazyLock::new(|| {
-    try_create_int_gauge_vec(
-        "near_resharding_batch_count",
-        "The number of batches committed to the db.",
-        &["shard_uid"],
-    )
-    .unwrap()
-});
-
-pub(crate) static RESHARDING_BATCH_SIZE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
-    try_create_int_gauge_vec(
-        "near_resharding_batch_size",
-        "The size of batches committed to the db.",
-        &["shard_uid"],
-    )
-    .unwrap()
-});
-
-pub static RESHARDING_BATCH_PREPARE_TIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-    try_create_histogram_vec(
-        "near_resharding_batch_prepare_time",
-        "Time needed to prepare a batch in resharding.",
-        &["shard_uid"],
-        Some(exponential_buckets(0.001, 1.6, 20).unwrap()),
-    )
-    .unwrap()
-});
-
-pub static RESHARDING_BATCH_APPLY_TIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-    try_create_histogram_vec(
-        "near_resharding_batch_apply_time",
-        "Time needed to apply a batch in resharding.",
-        &["shard_uid"],
-        Some(exponential_buckets(0.001, 1.6, 20).unwrap()),
-    )
-    .unwrap()
-});
-
-pub static RESHARDING_BATCH_COMMIT_TIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-    try_create_histogram_vec(
-        "near_resharding_batch_commit_time",
-        "Time needed to commit a batch in resharding.",
-        &["shard_uid"],
-        Some(exponential_buckets(0.001, 1.6, 20).unwrap()),
-    )
-    .unwrap()
-});
-
-pub(crate) static RESHARDING_STATUS: LazyLock<IntGaugeVec> = LazyLock::new(|| {
-    try_create_int_gauge_vec(
-        "near_resharding_status",
-        "The status of the resharding process.",
-        &["shard_uid"],
     )
     .unwrap()
 });

--- a/chain/chain/src/resharding/resharding_v2.rs
+++ b/chain/chain/src/resharding/resharding_v2.rs
@@ -153,7 +153,7 @@ fn apply_delayed_receipts<'a>(
         store_update.commit()?;
     }
 
-    tracing::debug!(target: "resharding", ?orig_shard_uid, ?total_count, "Applied delayed receipts");
+    tracing::debug!(target: "resharding-v2", ?orig_shard_uid, ?total_count, "Applied delayed receipts");
     Ok(new_state_roots)
 }
 
@@ -185,7 +185,7 @@ fn apply_promise_yield_timeouts<'a>(
         store_update.commit()?;
     }
 
-    tracing::debug!(target: "resharding", ?orig_shard_uid, ?total_count, "Applied PromiseYield timeouts");
+    tracing::debug!(target: "resharding-v2", ?orig_shard_uid, ?total_count, "Applied PromiseYield timeouts");
     Ok(new_state_roots)
 }
 
@@ -200,7 +200,7 @@ impl Chain {
         match &new_state_roots {
             Ok(_) => {}
             Err(err) => {
-                tracing::error!(target: "resharding", ?shard_uid, ?err, "Resharding failed, manual recovery is necessary!");
+                tracing::error!(target: "resharding-v2", ?shard_uid, ?err, "Resharding failed, manual recovery is necessary!");
             }
         }
         ReshardingResponse { shard_id, sync_hash, new_state_roots }
@@ -220,7 +220,7 @@ impl Chain {
         loop {
             if !handle.get() {
                 // The keep_going is set to false, interrupt processing.
-                tracing::info!(target: "resharding", ?shard_uid, "build_state_for_split_shards_impl interrupted");
+                tracing::info!(target: "resharding-v2", ?shard_uid, "build_state_for_split_shards_impl interrupted");
                 return Err(Error::Other("Resharding interrupted.".to_string()));
             }
             // Prepare the batch.
@@ -256,7 +256,7 @@ impl Chain {
 
             batch_count += 1;
 
-            debug!(target: "resharding", ?shard_uid, ?batch_count, ?prepare_time, ?apply_time, ?commit_time, "batch processed");
+            debug!(target: "resharding-v2", ?shard_uid, ?batch_count, ?prepare_time, ?apply_time, ?commit_time, "batch processed");
 
             // sleep between batches in order to throttle resharding and leave
             // some resource for the regular node operation
@@ -278,7 +278,7 @@ impl Chain {
             on_demand,
             ..
         } = resharding_request;
-        tracing::debug!(target: "resharding", config=?config.get(), ?shard_uid, "build_state_for_split_shards_impl starting");
+        tracing::debug!(target: "resharding-v2", config=?config.get(), ?shard_uid, "build_state_for_split_shards_impl starting");
 
         let shard_id = shard_uid.shard_id();
         let new_shards = next_epoch_shard_layout
@@ -334,7 +334,7 @@ impl Chain {
             &checked_account_id_to_shard_uid,
         )?;
 
-        tracing::debug!(target: "resharding", ?shard_uid, "build_state_for_split_shards_impl finished");
+        tracing::debug!(target: "resharding-v2", ?shard_uid, "build_state_for_split_shards_impl finished");
         Ok(state_roots)
     }
 

--- a/tools/database/src/resharding_v2.rs
+++ b/tools/database/src/resharding_v2.rs
@@ -58,13 +58,13 @@ impl ReshardingV2Command {
             // In restore mode print database write statistics.
             chain.runtime_adapter.store().get_store_statistics().map(|stats| {
                 stats.data.iter().for_each(|(metric, values)| {
-                    tracing::info!(target: "resharding", %metric, ?values);
+                    tracing::info!(target: "resharding-v2", %metric, ?values);
                 })
             });
         }
 
         let state_roots = state_roots?;
-        tracing::info!(target: "resharding", ?state_roots, "state roots");
+        tracing::info!(target: "resharding-v2", ?state_roots, "state roots");
 
         chain.custom_build_state_for_split_shards_v2_postprocessing(&sync_hash, state_roots)?;
 

--- a/tools/database/src/resharding_v2.rs
+++ b/tools/database/src/resharding_v2.rs
@@ -51,8 +51,6 @@ impl ReshardingV2Command {
         let resharding_request =
             chain.custom_build_state_for_resharding_v2_preprocessing(&block_hash, self.shard_id)?;
 
-        let shard_uid = resharding_request.shard_uid;
-
         let response = Chain::build_state_for_split_shards_v2(resharding_request);
         let ReshardingResponse { sync_hash, new_state_roots: state_roots, .. } = response;
 
@@ -68,11 +66,7 @@ impl ReshardingV2Command {
         let state_roots = state_roots?;
         tracing::info!(target: "resharding", ?state_roots, "state roots");
 
-        chain.custom_build_state_for_split_shards_v2_postprocessing(
-            shard_uid,
-            &sync_hash,
-            state_roots,
-        )?;
+        chain.custom_build_state_for_split_shards_v2_postprocessing(&sync_hash, state_roots)?;
 
         Ok(())
     }


### PR DESCRIPTION
Clean up resharding V2 code, more specifically:
- Resharding metrics
- Reassigning of outgoing receipt in `chain/src/store/mod.rs`

TODO next:
- `StateSnapshotType::ForReshardingOnly`
- `ShardSyncStatus::{ReshardingScheduling, ReshardingApplying}` 
- `State_sync::resharding_state_roots`
- Resharding handle
- Pytests
