### PR TITLE
fix(network): include correct features from near-primitives

### DIFF
--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -58,7 +58,7 @@ near-chain-configs.workspace = true
 near-crypto.workspace = true
 near-performance-metrics.workspace = true
 near-performance-metrics-macros.workspace = true
-near-primitives = { workspace = true, features = ["rand"] }
+near-primitives = { workspace = true, features = ["rand", "solomon", "clock"] }
 near-store.workspace = true
 near-schema-checker-lib.workspace = true
 


### PR DESCRIPTION
In #11597 some new feature flags were introduced in the near-primitives package.

near-network depends on some of the gated features. Currently running `cargo test -p near-network` results in compile errors. This PR restores the ability to build and run the tests of the near-network package independently. 