### PR TITLE
[Debug UI] Allow querying raw trie nodes by hash in entity debug UI

### DIFF
--- a/chain/jsonrpc-primitives/src/types/entity_debug.rs
+++ b/chain/jsonrpc-primitives/src/types/entity_debug.rs
@@ -37,6 +37,10 @@ impl EntityDataStruct {
     pub fn add(&mut self, name: &str, value: EntityDataValue) {
         self.entries.push(EntityDataEntry { name: name.to_string(), value });
     }
+
+    pub fn add_string(&mut self, name: &str, value: &str) {
+        self.add(name, EntityDataValue::String(value.to_string()));
+    }
 }
 
 /// All queries supported by the Entity Debug UI.
@@ -74,6 +78,9 @@ pub enum EntityQuery {
     OutcomeByReceiptIdAndBlockHash { receipt_id: CryptoHash, block_hash: CryptoHash },
     OutcomeByTransactionHash { transaction_hash: CryptoHash },
     OutcomeByTransactionHashAndBlockHash { transaction_hash: CryptoHash, block_hash: CryptoHash },
+    RawTrieNodeByHash { trie_node_hash: CryptoHash, shard_uid: ShardUId },
+    RawTrieRootByChunkHash { chunk_hash: CryptoHash },
+    RawTrieValueByHash { trie_value_hash: CryptoHash, shard_uid: ShardUId },
     ReceiptById { receipt_id: CryptoHash },
     ShardIdByAccountId { account_id: String, epoch_id: EpochId },
     ShardLayoutByEpochId { epoch_id: EpochId },

--- a/core/store/src/trie/raw_node.rs
+++ b/core/store/src/trie/raw_node.rs
@@ -10,7 +10,7 @@ use near_schema_checker_lib::ProtocolSchema;
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq, ProtocolSchema)]
 pub struct RawTrieNodeWithSize {
     pub node: RawTrieNode,
-    pub(super) memory_usage: u64,
+    pub memory_usage: u64,
 }
 
 impl RawTrieNodeWithSize {

--- a/tools/debug-ui/scripts/compare_tries.py
+++ b/tools/debug-ui/scripts/compare_tries.py
@@ -3,25 +3,17 @@ This is useful when a node is stuck at InvalidStateRoot to debug why.'''
 import json
 import requests
 
-USE_COLD_STORAGE = False
-
 class EntityAPI:
     def __init__(self, host):
         self.endpoint = "http://{}/debug/api/entity".format(host)
 
-    def query(self, query_name, cold_storage=False, **kwargs):
+    def query(self, query_name, **kwargs):
         args = kwargs
         if len(args) == 0:
             args = None
-        if cold_storage:
-            query = {
-                query_name: args,
-                "use_cold_storage": cold_storage
-            }
-        else:
-            query = {
-                query_name: args,
-            }
+        query = {
+            query_name: args,
+        }
         result = requests.post(self.endpoint, json=query)
         return EntityDataValue.of(result.json())
     

--- a/tools/debug-ui/scripts/compare_tries.py
+++ b/tools/debug-ui/scripts/compare_tries.py
@@ -1,0 +1,189 @@
+'''Performs diff of two tries between two nodes, by querying their Entity Debug API.
+This is useful when a node is stuck at InvalidStateRoot to debug why.'''
+import json
+import requests
+
+USE_COLD_STORAGE = False
+
+class EntityAPI:
+    def __init__(self, host):
+        self.endpoint = "http://{}/debug/api/entity".format(host)
+
+    def query(self, query_name, cold_storage=False, **kwargs):
+        args = kwargs
+        if len(args) == 0:
+            args = None
+        if cold_storage:
+            query = {
+                query_name: args,
+                "use_cold_storage": cold_storage
+            }
+        else:
+            query = {
+                query_name: args,
+            }
+        result = requests.post(self.endpoint, json=query)
+        return EntityDataValue.of(result.json())
+    
+    def get_trie_node(self, shard_uid, trie_node_hash):
+        return self.query('RawTrieNodeByHash', shard_uid=shard_uid, trie_node_hash=trie_node_hash)
+    
+    def get_trie_value(self, shard_uid, trie_value_hash):
+        return self.query('RawTrieValueByHash', shard_uid=shard_uid, trie_value_hash=trie_value_hash)
+
+
+class EntityDataValue:
+    @staticmethod
+    def of(value):
+        if isinstance(value, str) or value is None:
+            return value
+        return EntityDataValue(value)
+
+    def __init__(self, value):
+        self.value = value
+
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            key = str(key)
+        entries = self.value['entries']
+
+        return EntityDataValue.of([entry['value'] for entry in entries if entry['name'] == key][0])
+    
+    def __contains__(self, key):
+        entries = self.value['entries']
+
+        return any(entry['name'] == key for entry in entries)
+    
+    def array(self):
+        return [EntityDataValue.of(entry['value']) for entry in self.value['entries']]
+    
+    def __iter__(self):
+        return iter(self.array())
+    
+    def __str__(self):
+        return json.dumps(self.value)
+
+class TrieIterator:
+    def __init__(self, api: EntityAPI, shard_uid: str, state_root: str):
+        self.api = api
+        self.shard_uid = shard_uid
+        self.state_root = state_root
+        self.node = None
+
+    def iterate(self):
+        yield from self.iterate_node_hash(self.state_root, '')
+    
+    def iterate_node_hash(self, hash, path):
+        dig = yield path, 'node', hash
+        if dig:
+            body = self.api.get_trie_node(self.shard_uid, hash)
+            yield from self.iterate_node_body(body, path)
+
+    def iterate_value_hash(self, hash, path):
+        dig = yield path, 'value_ref', hash
+        if dig:
+            value = self.api.get_trie_value(self.shard_uid, hash)
+            yield path + ' ', 'value', value
+    
+    def iterate_node_body(self, node, path):
+        if 'value_hash' in node:
+            leaf_path = path
+            if 'extension' in node:
+                leaf_path += node['extension']
+            yield from self.iterate_value_hash(node['value_hash'], leaf_path)
+        if 'children' in node:
+            for i in range(16):
+                child = node['children'][i]
+                if child == 'null':
+                    continue
+                nibble = '0123456789abcdef'[i]
+                if child is not None:
+                    yield from self.iterate_node_hash(child, path + nibble)
+        if 'child' in node:
+            next_path = path + node['extension']
+            yield from self.iterate_node_hash(node['child'], next_path)
+
+class IterWithCurrent:
+    def __init__(self, iter):
+        self.iter = iter
+        self.current = None
+        self.done = False
+        self.next(None)
+    
+    def next(self, to_send):
+        if self.done:
+            raise Exception('Iteration done')
+        try:
+            self.current = self.iter.send(to_send)
+        except StopIteration:
+            self.current = None
+            self.done = True
+
+class TrieDiffer:
+    def __init__(self, api_a: EntityAPI, api_b: EntityAPI, shard_uid: str):
+        self.api_a = api_a
+        self.api_b = api_b
+        self.shard_uid = shard_uid
+
+    def diff_tries(self, root_a: str, root_b: str):
+        diffs = []
+        iter_a = IterWithCurrent(TrieIterator(self.api_a, self.shard_uid, root_a).iterate())
+        iter_b = IterWithCurrent(TrieIterator(self.api_b, self.shard_uid, root_b).iterate())
+        while not iter_a.done or not iter_b.done:
+            if len(diffs) > 100:
+                print("Too many diffs; stopping.")
+                break
+            (path_a, kind_a, value_a) = iter_a.current
+            (path_b, kind_b, value_b) = iter_b.current
+            if path_a == path_b and kind_a == kind_b and value_a == value_b:
+                print('\033[A\u001b[32m[Match] {} {} {}\u001b[0m'.format(path_a, kind_a, value_a))
+                iter_a.next(False)
+                iter_b.next(False)
+            elif path_a == path_b and kind_a == kind_b == 'value':
+                print('\033[A\u001b[31m[Mismatch] {} value {} <=> {}\u001b[0m\n'.format(path_a, value_a, value_b))
+                diffs.append((path_a[:-1], value_a, value_b))
+                iter_a.next(None)
+                iter_b.next(None)
+            elif path_a <= path_b:
+                if kind_a == 'value':
+                    print('\033[A\u001b[31m[Mismatch] {} value {} <=> {}\u001b[0m\n'.format(path_a, value_a, None))
+                    diffs.append((path_a[:-1], value_a, None))
+                iter_a.next(True)
+            else:
+                if kind_b == 'value':
+                    print('\033[A\u001b[31m[Mismatch] {} value {} <=> {}\u001b[0m\n'.format(path_b, None, value_b))
+                    diffs.append((path_b[:-1], None, value_b))
+                iter_b.next(True)
+        print()
+        return diffs
+
+good_node_addr = input('Enter the address of the good node, including port (e.g. 127.0.0.1:3030): ')
+stuck_node_addr = input('Enter the address of the stuck node, including port (e.g. 127.0.0.1:3030): ')
+
+good_node = EntityAPI(good_node_addr)
+stuck_node = EntityAPI(stuck_node_addr)
+
+print("[Sanity check] Good node head is at ", good_node.query('TipAtHead')['height'])
+print("[Sanity check] Stuck node head is at ", stuck_node.query('TipAtHead')['height'])
+
+good_state_root = input('Enter the good state root available on the good node: ')
+stuck_state_root = input('Enter the bad state root available on the stuck node: ')
+shard_uid = input('Enter the shard UID (e.g. s0.v3): ')
+
+print('[Sanity check] Querying good state root...', end='')
+good_node.query('RawTrieNodeByHash', shard_uid=shard_uid, trie_node_hash=good_state_root)
+print('valid.')
+print('[Sanity check] Querying bad state root...', end='')
+stuck_node.query('RawTrieNodeByHash', shard_uid=shard_uid, trie_node_hash=stuck_state_root)
+print('valid.')
+
+print('Comparing trie roots:', good_state_root, stuck_state_root)
+
+differ = TrieDiffer(good_node, stuck_node, shard_uid)
+diffs = differ.diff_tries(good_state_root, stuck_state_root)
+for (path, value_a, value_b) in diffs:
+    print('Mismatch in trie at path:', path)
+    print('  Good:', value_a)
+    print('  Bad: ', value_b)
+    print()
+print('Diff done.')

--- a/tools/debug-ui/src/entity_debug/BottomBarView.scss
+++ b/tools/debug-ui/src/entity_debug/BottomBarView.scss
@@ -1,4 +1,4 @@
-.pinned-keys {
+.bottom-bar {
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
@@ -56,5 +56,25 @@
 
     .pinned-keys-empty {
         color: gray;
+    }
+
+    .spacer {
+        flex: 1;
+    }
+
+    .show-ascii {
+        display: flex;
+        align-items: center;
+        border-left: 1px solid gray;
+        padding-left: 10px;
+
+        input {
+            margin-right: 4px;
+            cursor: pointer;
+        }
+
+        label {
+            cursor: pointer;
+        }
     }
 }

--- a/tools/debug-ui/src/entity_debug/BottomBarView.tsx
+++ b/tools/debug-ui/src/entity_debug/BottomBarView.tsx
@@ -1,12 +1,14 @@
 import { useContext } from 'react';
 import { ColdStorageChoiceContext, PinnedKeysContext } from './pinned_keys';
-import './PinnedKeysView.scss';
+import './BottomBarView.scss';
+import { ShowAsciiCharactersInHexContext } from './view_options';
 
-export const PinnedKeysView = () => {
+export const BottomBarView = () => {
     const { keys, dispatch } = useContext(PinnedKeysContext);
     const { coldStorage, dispatch: setColdStorage } = useContext(ColdStorageChoiceContext);
+    const { showAscii, dispatch: setShowAscii } = useContext(ShowAsciiCharactersInHexContext);
     return (
-        <div className="pinned-keys">
+        <div className="bottom-bar">
             <div className="cold-storage-choice">
                 <input
                     id="cold-storage-checkbox"
@@ -31,6 +33,16 @@ export const PinnedKeysView = () => {
             {keys.length == 0 && (
                 <div className="pinned-keys-empty">(Click an entity key to pin it)</div>
             )}
+            <div className="spacer"></div>
+            <div className="show-ascii">
+                <input
+                    id="show-ascii-checkbox"
+                    type="checkbox"
+                    checked={showAscii}
+                    onChange={(e) => setShowAscii(e.target.checked)}
+                />
+                <label htmlFor="show-ascii-checkbox">Show ASCII in hex</label>
+            </div>
         </div>
     );
 };

--- a/tools/debug-ui/src/entity_debug/EntityDataValueView.tsx
+++ b/tools/debug-ui/src/entity_debug/EntityDataValueView.tsx
@@ -15,6 +15,7 @@ import {
 import { ColdStorageChoiceContext, PinnedKeysContext } from './pinned_keys';
 import { EntityDataRootView } from './EntityDataRootView';
 import './EntityDataValueView.scss';
+import { ShowAsciiCharactersInHexContext } from './view_options';
 
 export type EntityDataValueViewProps = {
     entry: EntityDataValueNode;
@@ -28,6 +29,7 @@ export const EntityDataValueView = ({ entry, hideName }: EntityDataValueViewProp
     const [, setChildrenVersion] = useState(0);
     const { keys: pinnedKeys, dispatch: pinnedKeysDispatch } = useContext(PinnedKeysContext);
     const { coldStorage } = useContext(ColdStorageChoiceContext);
+    const { showAscii } = useContext(ShowAsciiCharactersInHexContext);
 
     const addQuery = useCallback(
         (query: EntityQuery) => {
@@ -58,12 +60,14 @@ export const EntityDataValueView = ({ entry, hideName }: EntityDataValueViewProp
                         <span className="value-trie-path">
                             <span className="shard-uid">{shard_uid}</span>
                             <span className="state-root">{state_root}</span>
-                            <span className="nibbles">{visualizeNibbles(nibbles)}</span>
+                            <span className="nibbles">{visualizeNibbles(nibbles, showAscii)}</span>
                         </span>
                     );
                 }
             } else if (display === 'nibbles') {
-                entryValue = <span className="nibbles">{visualizeNibbles(entry.value)}</span>;
+                entryValue = (
+                    <span className="nibbles">{visualizeNibbles(entry.value, showAscii)}</span>
+                );
             }
         }
     } else if (entry.semantic?.titleKey !== undefined) {
@@ -106,9 +110,9 @@ export const EntityDataValueView = ({ entry, hideName }: EntityDataValueViewProp
                             onClick={(e) =>
                                 e.currentTarget.classList.contains('selected')
                                     ? pinnedKeysDispatch({
-                                        type: 'remove-key',
-                                        keyType: key.type(),
-                                    })
+                                          type: 'remove-key',
+                                          keyType: key.type(),
+                                      })
                                     : pinnedKeysDispatch({ type: 'add-key', key })
                             }>
                             {selected ? '☑' : '☐'} {key.type()}
@@ -248,11 +252,11 @@ function getAvailableQueries(keys: EntityKey[], pinnedKeys: EntityKey[]): Availa
     return result;
 }
 
-function visualizeNibbles(nibbles: string): JSX.Element {
+function visualizeNibbles(nibbles: string, showAscii: boolean): JSX.Element {
     const children = [];
     for (let i = 0; i < Math.floor(nibbles.length / 2); i++) {
         const byte = parseInt(nibbles.substring(i * 2, i * 2 + 2), 16);
-        if (byte >= 0x20 && byte <= 0x7e) {
+        if (showAscii && byte >= 0x20 && byte <= 0x7e) {
             children.push(
                 <span className="ascii-char" key={i}>
                     {String.fromCharCode(byte)}

--- a/tools/debug-ui/src/entity_debug/EntityDebugView.tsx
+++ b/tools/debug-ui/src/entity_debug/EntityDebugView.tsx
@@ -3,10 +3,11 @@ import { Fetcher, FetcherContext } from './fetcher';
 import { AllQueriesContext, allQueriesReducer } from './all_queries';
 import { ColdStorageChoiceContext, PinnedKeysContext, pinnedKeysReducer } from './pinned_keys';
 import { AllQueriesDisplay } from './AllQueriesDisplay';
-import { PinnedKeysView } from './PinnedKeysView';
+import { BottomBarView } from './BottomBarView';
 import { EntityDataRootView } from './EntityDataRootView';
 import { EntityQueryComposer } from './EntityQueryComposer';
 import './EntityDebugView.scss';
+import { ShowAsciiCharactersInHexContext } from './view_options';
 
 export type EntityDebugViewProps = {
     addr: string;
@@ -23,6 +24,10 @@ export const EntityDebugView = ({ addr }: EntityDebugViewProps) => {
     const [coldStorage, coldStorageDispatcher] = useReducer(
         (_: boolean, value: boolean) => value,
         false
+    );
+    const [showAscii, showAsciiDispatcher] = useReducer(
+        (_showAscii: boolean, value: boolean) => value,
+        true
     );
     const selectedQueryResult =
         allQueries.selectedIndex === -1 ? null : allQueries.results[allQueries.selectedIndex];
@@ -45,7 +50,7 @@ export const EntityDebugView = ({ addr }: EntityDebugViewProps) => {
                     )}
                 </div>
                 <div className="right-panel-pinned-keys">
-                    <PinnedKeysView />
+                    <BottomBarView />
                 </div>
             </div>
         </div>
@@ -69,7 +74,13 @@ export const EntityDebugView = ({ addr }: EntityDebugViewProps) => {
                             coldStorage: coldStorage,
                             dispatch: coldStorageDispatcher,
                         }}>
-                        {render}
+                        <ShowAsciiCharactersInHexContext.Provider
+                            value={{
+                                showAscii: showAscii,
+                                dispatch: showAsciiDispatcher,
+                            }}>
+                            {render}
+                        </ShowAsciiCharactersInHexContext.Provider>
                     </ColdStorageChoiceContext.Provider>
                 </PinnedKeysContext.Provider>
             </AllQueriesContext.Provider>

--- a/tools/debug-ui/src/entity_debug/fields.tsx
+++ b/tools/debug-ui/src/entity_debug/fields.tsx
@@ -24,6 +24,8 @@ const chunkHash = stringField('chunk_hash');
 const epochId = stringField('epoch_id');
 const transactionHash = stringField('transaction_hash');
 const receiptId = stringField('receipt_id');
+const trieNodeHash = stringField('trie_node_hash');
+const trieValueHash = stringField('trie_value_hash');
 const accountId = stringField('account_id');
 const shardId = numericField('shard_id');
 const shardUId: FieldSemantic = {
@@ -333,6 +335,15 @@ const validatorAssignmentsAtHeight = {
     },
 };
 
+const rawTrieNode = {
+    struct: {
+        extension: nibbles,
+        value_hash: trieValueHash,
+        children: { array: trieNodeHash },
+        child: trieNodeHash,
+    },
+};
+
 export const fieldSemantics: Record<EntityType, FieldSemantic> = {
     AllShards: { array: shardUId },
     Block: block,
@@ -341,6 +352,7 @@ export const fieldSemantics: Record<EntityType, FieldSemantic> = {
     BlockInfo: blockInfo,
     BlockMerkleTree: undefined,
     BlockMiscData: blockMiscData,
+    Bytes: nibbles,
     Chunk: chunk,
     ChunkExtra: chunkExtra,
     EpochInfo: epochInfo,
@@ -350,6 +362,7 @@ export const fieldSemantics: Record<EntityType, FieldSemantic> = {
     FlatStateChanges: flatStateChanges,
     FlatStateDeltaMetadata: flatStateDeltaMetadata,
     FlatStorageStatus: flatStorageStatus,
+    RawTrieNode: rawTrieNode,
     Receipt: receipt,
     ShardId: shardId,
     ShardLayout: undefined,

--- a/tools/debug-ui/src/entity_debug/keys.tsx
+++ b/tools/debug-ui/src/entity_debug/keys.tsx
@@ -48,6 +48,8 @@ export function parseEntityKey(keyType: EntityKeyType, input: string): EntityKey
         case 'receipt_id':
         case 'transaction_hash':
         case 'state_root':
+        case 'trie_node_hash':
+        case 'trie_value_hash':
             // Length of 32-byte array encoded in base58 is 43 or 44 characters,
             // depending on whether we need additional character or not.
             //

--- a/tools/debug-ui/src/entity_debug/types.tsx
+++ b/tools/debug-ui/src/entity_debug/types.tsx
@@ -12,6 +12,8 @@ export type EntityKeyType =
     | 'state_root'
     | 'transaction_hash'
     | 'trie_key'
+    | 'trie_node_hash'
+    | 'trie_value_hash'
     | 'trie_path';
 
 /// Each entity type represents a unique kind of output from an entity debug
@@ -24,6 +26,7 @@ export type EntityType =
     | 'BlockInfo'
     | 'BlockMerkleTree'
     | 'BlockMiscData'
+    | 'Bytes'
     | 'Chunk'
     | 'ChunkExtra'
     | 'EpochInfo'
@@ -33,6 +36,7 @@ export type EntityType =
     | 'FlatStateChanges'
     | 'FlatStateDeltaMetadata'
     | 'FlatStorageStatus'
+    | 'RawTrieNode'
     | 'Receipt'
     | 'ShardId'
     | 'ShardLayout'
@@ -148,6 +152,9 @@ export type EntityQuery = {
     OutcomeByReceiptIdAndBlockHash?: { receipt_id: string; block_hash: string };
     OutcomeByTransactionHash?: { transaction_hash: string };
     OutcomeByTransactionHashAndBlockHash?: { transaction_hash: string; block_hash: string };
+    RawTrieNodeByHash?: { trie_node_hash: string; shard_uid: string };
+    RawTrieRootByChunkHash?: { chunk_hash: string };
+    RawTrieValueByHash?: { trie_value_hash: string; shard_uid: string };
     ReceiptById?: { receipt_id: string };
     ShardIdByAccountId?: { account_id: string };
     ShardLayoutByEpochId?: { epoch_id: string };
@@ -195,6 +202,9 @@ export const entityQueryTypes: EntityQueryType[] = [
     'OutcomeByReceiptIdAndBlockHash',
     'OutcomeByTransactionHash',
     'OutcomeByTransactionHashAndBlockHash',
+    'RawTrieNodeByHash',
+    'RawTrieRootByChunkHash',
+    'RawTrieValueByHash',
     'ReceiptById',
     'ShardIdByAccountId',
     'ShardLayoutByEpochId',
@@ -265,6 +275,9 @@ export const entityQueryKeyTypes: Record<EntityQueryType, EntityQueryKeySpec[]> 
         queryKey('transaction_hash'),
         implicitQueryKey('block_hash'),
     ],
+    RawTrieNodeByHash: [queryKey('trie_node_hash'), queryKey('shard_uid')],
+    RawTrieRootByChunkHash: [queryKey('chunk_hash')],
+    RawTrieValueByHash: [queryKey('trie_value_hash'), queryKey('shard_uid')],
     ReceiptById: [queryKey('receipt_id')],
     ShardIdByAccountId: [queryKey('account_id'), implicitQueryKey('epoch_id')],
     ShardLayoutByEpochId: [queryKey('epoch_id')],
@@ -303,6 +316,9 @@ export const entityQueryOutputType: Record<EntityQueryType, EntityType> = {
     OutcomeByReceiptIdAndBlockHash: 'ExecutionOutcome',
     OutcomeByTransactionHash: 'ExecutionOutcome',
     OutcomeByTransactionHashAndBlockHash: 'ExecutionOutcome',
+    RawTrieNodeByHash: 'RawTrieNode',
+    RawTrieRootByChunkHash: 'RawTrieNode',
+    RawTrieValueByHash: 'Bytes',
     ReceiptById: 'Receipt',
     ShardIdByAccountId: 'ShardId',
     ShardLayoutByEpochId: 'ShardLayout',

--- a/tools/debug-ui/src/entity_debug/view_options.tsx
+++ b/tools/debug-ui/src/entity_debug/view_options.tsx
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+export const ShowAsciiCharactersInHexContext = createContext<{
+    showAscii: boolean;
+    dispatch: React.Dispatch<boolean>;
+}>({
+    showAscii: false,
+    dispatch: () => {},
+});


### PR DESCRIPTION
Example:
![image](https://github.com/user-attachments/assets/2088da78-8c55-4cad-93b9-da7c81046816)

It's similar to the existing trie queries, but this one is by hash, not by path. It allows more low-level trie access that can be used by a script.

Also:
* Add a script for diffing tries given disagreeing state roots.

![image](https://github.com/user-attachments/assets/06ebc09d-1267-4e53-858c-abc55e21b470)

* Add an option to display ascii in hex vs not.
[Screencast from 09-12-2024 10:36:48 AM.webm](https://github.com/user-attachments/assets/0c9a1937-1f19-489d-9825-2b11f98ed7dd)
