### PR TITLE
feat: Do not apply cutoff threshold when sorting the validators by uptime

### DIFF
--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -508,15 +508,7 @@ impl EpochManager {
             {
                 let mut sorted_validators = validator_block_chunk_stats
                     .iter()
-                    .map(|(account, stats)| {
-                        (
-                            get_sortable_validator_online_ratio(
-                                stats,
-                                Some(chunk_validator_only_kickout_threshold),
-                            ),
-                            account,
-                        )
-                    })
+                    .map(|(account, stats)| (get_sortable_validator_online_ratio(stats), account))
                     .collect::<Vec<_>>();
                 sorted_validators.sort();
                 sorted_validators

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -2603,6 +2603,119 @@ fn test_validator_kickout_determinism() {
     assert_eq!(kickouts1, kickouts2);
 }
 
+/// Tests the scenario that there are two chunk validators where the ordering of their endorsement ratio
+/// is the reverse of the ordering of their account ids. The exempted validator computation does not use
+/// the endorsement cutoff ratio, so the validator with the lower endorsement is kicked out.
+#[test]
+fn test_chunk_validators_with_different_endorsement_ratio() {
+    if !ProtocolFeature::ChunkEndorsementsInBlockHeader.enabled(PROTOCOL_VERSION) {
+        return;
+    }
+    let mut epoch_config = epoch_config_with_production_config(5, 2, 2, 2, 90, 90, 70, false)
+        .for_protocol_version(PROTOCOL_VERSION);
+    // Set the max kickout stake percentage so that only one of the chunk validators
+    // is kicked out, and the other chunk validator is exempted from kickout.
+    // Both chunk validators have endorsement ratio lower than the kickout threshold.
+    epoch_config.validator_max_kickout_stake_perc = 30;
+    // Test 0-1 are block+chunk producers and 2-3 are chunk validators only.
+    let accounts = vec![
+        ("test0".parse().unwrap(), 1000),
+        ("test1".parse().unwrap(), 1000),
+        ("test2".parse().unwrap(), 500),
+        ("test3".parse().unwrap(), 500),
+    ];
+    let epoch_info = epoch_info(0, accounts, vec![0, 1, 2, 3], vec![vec![0, 1, 2], vec![0, 1, 3]]);
+    let block_validator_tracker = HashMap::from([
+        (0, ValidatorStats { produced: 100, expected: 100 }),
+        (1, ValidatorStats { produced: 100, expected: 100 }),
+    ]);
+    let chunk_stats0 = Vec::from([
+        (0, ChunkStats::new_with_production(100, 100)),
+        (1, ChunkStats::new_with_production(100, 100)),
+        (2, ChunkStats::new_with_endorsement(65, 100)),
+    ]);
+    let chunk_stats1 = Vec::from([
+        (0, ChunkStats::new_with_production(100, 100)),
+        (1, ChunkStats::new_with_production(100, 100)),
+        (3, ChunkStats::new_with_endorsement(60, 100)),
+    ]);
+    let chunk_stats_tracker = HashMap::from([
+        (0, chunk_stats0.clone().into_iter().collect()),
+        (1, chunk_stats1.clone().into_iter().collect()),
+    ]);
+    let (_validator_stats, kickouts) = EpochManager::compute_validators_to_reward_and_kickout(
+        &epoch_config,
+        &epoch_info,
+        &block_validator_tracker,
+        &chunk_stats_tracker,
+        &HashMap::new(),
+        &HashMap::new(),
+    );
+    assert_eq!(
+        kickouts,
+        HashMap::from([(
+            "test3".parse().unwrap(),
+            NotEnoughChunkEndorsements { produced: 60, expected: 100 }
+        ),])
+    );
+}
+
+/// Tests the scenario that there are two chunk validators have the same online ratio, so we select
+/// the exempted validator based on the ordering of the account id.
+#[test]
+fn test_chunk_validators_with_same_endorsement_ratio() {
+    if !ProtocolFeature::ChunkEndorsementsInBlockHeader.enabled(PROTOCOL_VERSION) {
+        return;
+    }
+    let mut epoch_config = epoch_config_with_production_config(5, 2, 2, 2, 90, 90, 70, false)
+        .for_protocol_version(PROTOCOL_VERSION);
+    // Set the max kickout stake percentage so that only one of the chunk validators
+    // is kicked out, and the other chunk validator is exempted from kickout.
+    // Both chunk validators have endorsement ratio lower than the kickout threshold.
+    epoch_config.validator_max_kickout_stake_perc = 30;
+    // Test 0-1 are block+chunk producers and 2-3 are chunk validators only.
+    let accounts = vec![
+        ("test0".parse().unwrap(), 1000),
+        ("test1".parse().unwrap(), 1000),
+        ("test2".parse().unwrap(), 500),
+        ("test3".parse().unwrap(), 500),
+    ];
+    let epoch_info = epoch_info(0, accounts, vec![0, 1, 2, 3], vec![vec![0, 1, 2], vec![0, 1, 3]]);
+    let block_validator_tracker = HashMap::from([
+        (0, ValidatorStats { produced: 100, expected: 100 }),
+        (1, ValidatorStats { produced: 100, expected: 100 }),
+    ]);
+    let chunk_stats0 = Vec::from([
+        (0, ChunkStats::new_with_production(100, 100)),
+        (1, ChunkStats::new_with_production(100, 100)),
+        (2, ChunkStats::new_with_endorsement(65, 100)),
+    ]);
+    let chunk_stats1 = Vec::from([
+        (0, ChunkStats::new_with_production(100, 100)),
+        (1, ChunkStats::new_with_production(100, 100)),
+        (3, ChunkStats::new_with_endorsement(65, 100)),
+    ]);
+    let chunk_stats_tracker = HashMap::from([
+        (0, chunk_stats0.clone().into_iter().collect()),
+        (1, chunk_stats1.clone().into_iter().collect()),
+    ]);
+    let (_validator_stats, kickouts) = EpochManager::compute_validators_to_reward_and_kickout(
+        &epoch_config,
+        &epoch_info,
+        &block_validator_tracker,
+        &chunk_stats_tracker,
+        &HashMap::new(),
+        &HashMap::new(),
+    );
+    assert_eq!(
+        kickouts,
+        HashMap::from([(
+            "test2".parse().unwrap(),
+            NotEnoughChunkEndorsements { produced: 65, expected: 100 }
+        ),])
+    );
+}
+
 /// A sanity test for the compute_validators_to_reward_and_kickout function,
 /// checks that validators that don't meet their kickout thresholds are kicked out.
 #[test]

--- a/chain/epoch-manager/src/validator_stats.rs
+++ b/chain/epoch-manager/src/validator_stats.rs
@@ -106,11 +106,8 @@ pub(crate) fn get_validator_online_ratio(
 /// Instead of having a full-blown implementation of `U256`` for `num_integer::Integer`
 /// we wrap the value in a `BigInt` for now.
 /// TODO: Implement `num_integer::Integer` for `U256` and remove this function.
-pub(crate) fn get_sortable_validator_online_ratio(
-    stats: &BlockChunkValidatorStats,
-    endorsement_cutoff_threshold: Option<u8>,
-) -> BigRational {
-    let ratio = get_validator_online_ratio(stats, endorsement_cutoff_threshold);
+pub(crate) fn get_sortable_validator_online_ratio(stats: &BlockChunkValidatorStats) -> BigRational {
+    let ratio = get_validator_online_ratio(stats, None);
     let mut bytes: [u8; size_of::<U256>()] = [0; size_of::<U256>()];
     ratio.numer().to_little_endian(&mut bytes);
     let bignumer = BigUint::from_bytes_le(&bytes);
@@ -232,10 +229,8 @@ mod test {
     }
 
     #[test]
-    fn test_sortable_average_uptime_ratio_without_endorsement_cutoff() {
-        let endorsement_cutoff = None;
-        let actual_ratio: Ratio<BigInt> =
-            get_sortable_validator_online_ratio(&VALIDATOR_STATS, endorsement_cutoff);
+    fn test_sortable_average_uptime_ratio() {
+        let actual_ratio: Ratio<BigInt> = get_sortable_validator_online_ratio(&VALIDATOR_STATS);
         let expected_ratio: Ratio<i32> =
             (Rational32::new(98, 100) + Rational32::new(76, 100) + Rational32::new(42, 100)) / 3;
         assert_eq!(
@@ -245,38 +240,9 @@ mod test {
     }
 
     #[test]
-    fn test_sortable_average_uptime_ratio_with_endorsement_cutoff_passed() {
-        let endorsement_cutoff = Some(30);
-        let actual_ratio: Ratio<BigInt> =
-            get_sortable_validator_online_ratio(&VALIDATOR_STATS, endorsement_cutoff);
-        let expected_ratio: Ratio<i32> =
-            (Rational32::new(98, 100) + Rational32::new(76, 100) + Rational32::from_integer(1)) / 3;
-        assert_eq!(
-            actual_ratio.numer() * expected_ratio.denom(),
-            actual_ratio.denom() * expected_ratio.numer()
-        );
-    }
-
-    #[test]
-    fn test_sortable_average_uptime_ratio_with_endorsement_cutoff_not_passed() {
-        let endorsement_cutoff = Some(50);
-        let actual_ratio: Ratio<BigInt> =
-            get_sortable_validator_online_ratio(&VALIDATOR_STATS, endorsement_cutoff);
-        let expected_ratio: Ratio<i32> =
-            (Rational32::new(98, 100) + Rational32::new(76, 100) + Rational32::from_integer(0)) / 3;
-        assert_eq!(
-            actual_ratio.numer() * expected_ratio.denom(),
-            actual_ratio.denom() * expected_ratio.numer()
-        );
-    }
-
-    #[test]
     fn test_sortable_average_uptime_ratio_with_no_endorsement_expected() {
-        let endorsement_cutoff = Some(50);
-        let actual_ratio: Ratio<BigInt> = get_sortable_validator_online_ratio(
-            &VALIDATOR_STATS_NO_ENDORSEMENT,
-            endorsement_cutoff,
-        );
+        let actual_ratio: Ratio<BigInt> =
+            get_sortable_validator_online_ratio(&VALIDATOR_STATS_NO_ENDORSEMENT);
         let expected_ratio: Ratio<i32> = (Rational32::new(98, 100) + Rational32::new(76, 100)) / 2;
         assert_eq!(
             actual_ratio.numer() * expected_ratio.denom(),


### PR DESCRIPTION
We used the endorsement kickout threshold as the cutoff threshold for the endorsement ratio when computing the validator rewards. For context see [this thread](https://near.zulipchat.com/#narrow/stream/308695-nearone.2Fprivate/topic/Chunk.20validator.20reward.20formula.20with.20new.20min.2Fmax.20thresholds/near/467281774).

If the validator's endorsement ratio is above the cutoff threshold, the contribution of the endorsement ratio to the average uptime is 1, otherwise it is 0. Then the resulting average uptime is used in two places:
1) When calculating the validator rewards.
2) When sorting the validators by uptime ratio to get the validators exempted from kickout.

In the second case, for chunk validator-only nodes, the average uptime of the validator will be either 1 or 0. Then when calculating the exempted validators, the ordering of the validators will be based on the account id only. This is unfair. To address this fairness, in this PR, we remove the use of cutoff threshold when computing the exempted validators. This does not affect other places, such as reward calculation.