### PR TITLE
bugfix: wasmtime: instantiating function type incompatibility

### DIFF
--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -144,11 +144,12 @@ pub(crate) fn wasmtime_vm_hash() -> u64 {
 
 pub(crate) struct WasmtimeVM {
     config: Arc<Config>,
+    engine: Engine,
 }
 
 impl WasmtimeVM {
     pub(crate) fn new(config: Arc<Config>) -> Self {
-        Self { config }
+        Self { config, engine: get_engine(&default_wasmtime_config(&config)) }
     }
 
     #[tracing::instrument(target = "vm", level = "debug", "WasmtimeVM::compile_uncached", skip_all)]
@@ -156,8 +157,7 @@ impl WasmtimeVM {
         let start = std::time::Instant::now();
         let prepared_code = prepare::prepare_contract(code.code(), &self.config, VMKind::Wasmtime)
             .map_err(CompilationError::PrepareError)?;
-        let engine = get_engine(&default_wasmtime_config(&self.config));
-        let serialized = engine.precompile_module(&prepared_code).map_err(|err| {
+        let serialized = self.engine.precompile_module(&prepared_code).map_err(|err| {
             tracing::error!(?err, "wasmtime failed to compile the prepared code (this is defense-in-depth, the error was recovered from but should be reported to the developers)");
             CompilationError::WasmtimeCompileError { msg: err.to_string() }
         });
@@ -206,11 +206,8 @@ impl WasmtimeVM {
                         code.code().len() as u64,
                         match self.compile_and_cache(&code, cache)? {
                             Ok(serialized_module) => Ok(unsafe {
-                                Module::deserialize(
-                                    &get_engine(&default_wasmtime_config(&self.config)),
-                                    serialized_module,
-                                )
-                                .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?
+                                Module::deserialize(&self.engine, serialized_module)
+                                    .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?
                             }),
                             Err(err) => Err(err),
                         },
@@ -233,11 +230,8 @@ impl WasmtimeVM {
                             //
                             // There should definitely be some validation in near_vm to ensure
                             // we load what we think we load.
-                            let module = Module::deserialize(
-                                &get_engine(&default_wasmtime_config(&self.config)),
-                                &serialized_module,
-                            )
-                            .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?;
+                            let module = Module::deserialize(&self.engine, serialized_module)
+                                .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?;
                             Ok(to_any((compiled_contract_info.wasm_bytes, Ok(module))))
                         }
                     }

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -144,12 +144,12 @@ pub(crate) fn wasmtime_vm_hash() -> u64 {
 
 pub(crate) struct WasmtimeVM {
     config: Arc<Config>,
-    engine: Engine,
+    engine: wasmtime::Engine,
 }
 
 impl WasmtimeVM {
     pub(crate) fn new(config: Arc<Config>) -> Self {
-        Self { config, engine: get_engine(&default_wasmtime_config(&config)) }
+        Self { engine: get_engine(&default_wasmtime_config(&config)), config }
     }
 
     #[tracing::instrument(target = "vm", level = "debug", "WasmtimeVM::compile_uncached", skip_all)]
@@ -230,7 +230,7 @@ impl WasmtimeVM {
                             //
                             // There should definitely be some validation in near_vm to ensure
                             // we load what we think we load.
-                            let module = Module::deserialize(&self.engine, serialized_module)
+                            let module = Module::deserialize(&self.engine, &serialized_module)
                                 .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?;
                             Ok(to_any((compiled_contract_info.wasm_bytes, Ok(module))))
                         }


### PR DESCRIPTION
Resolves: #12062 

This PR resolves the issue with the wasmtime function type incompatibility.
To understand the issue, I highly recommend my investigation comments on the issue itself: https://github.com/near/nearcore/issues/12062

To be honest, I'm not sure it's a proper fix as I guess the root cause of the issue is somewhere outside of the file that leads to running under different engines/settings, leading to instantiating failures. It's a bit weird that the WasmtimeVM instance and Module instance could be different somehow as wasmtime::Engine is an arc wrapper. And module seems to clone it inside which should be still the same instance.

I could reproduce the issue only by tweaking the code manually by recreating an engine before the linking. It means that something more complex happens and we need a test on that

But this fix resolves an issue reported by #12062: https://github.com/near/near-workspaces-rs/actions/runs/10835958697/job/30200440749


CC @race-of-sloths