### PR TITLE
[Epoch Sync] Support bootstrapping a node from another epoch-synced node.

### DIFF
--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -991,6 +991,7 @@ impl<'a> ChainStoreUpdate<'a> {
             | DBCol::FlatStateChanges
             | DBCol::FlatStateDeltaMetadata
             | DBCol::FlatStorageStatus
+            | DBCol::EpochSyncProof
             | DBCol::Misc
             | DBCol::_ReceiptIdToShardId
             => unreachable!(),

--- a/core/async/src/test_loop.rs
+++ b/core/async/src/test_loop.rs
@@ -98,7 +98,7 @@ pub struct TestLoopV2 {
     /// The next ID to assign to an event we receive.
     next_event_index: usize,
     /// The current virtual time.
-    current_time: Duration,
+    pub current_time: Duration,
     /// Fake clock that always returns the virtual time.
     clock: near_time::FakeClock,
     /// Shutdown flag. When this flag is true, delayed action runners will no

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -293,6 +293,13 @@ pub enum DBCol {
     /// Witnesses with the lowest index are garbage collected first.
     /// u64 -> LatestWitnessesKey
     LatestWitnessesByIndex,
+    /// A valid epoch sync proof that proves the transition from the genesis to some epoch,
+    /// beyond which we keep all headers in this node. Nodes bootstrapped via Epoch Sync will
+    /// have this column, which allows it to compute a more recent EpochSyncProof using block
+    /// headers collected after the stored EpochSyncProof.
+    /// - *Rows*: only one key with 0 bytes.
+    /// - *Column type*: `EpochSyncProof`
+    EpochSyncProof,
 }
 
 /// Defines different logical parts of a db key.
@@ -494,7 +501,8 @@ impl DBCol {
             | DBCol::FlatState
             | DBCol::FlatStateChanges
             | DBCol::FlatStateDeltaMetadata
-            | DBCol::FlatStorageStatus => false,
+            | DBCol::FlatStorageStatus
+            | DBCol::EpochSyncProof => false,
         }
     }
 
@@ -566,6 +574,7 @@ impl DBCol {
             DBCol::StateTransitionData => &[DBKeyType::BlockHash, DBKeyType::ShardId],
             DBCol::LatestChunkStateWitnesses => &[DBKeyType::LatestWitnessesKey],
             DBCol::LatestWitnessesByIndex => &[DBKeyType::LatestWitnessIndex],
+            DBCol::EpochSyncProof => &[DBKeyType::Empty],
         }
     }
 }

--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -112,6 +112,7 @@ impl TestLoopBuilder {
         self
     }
 
+    /// Like stores_override, but all cold stores are None.
     pub fn stores_override_hot_only(mut self, stores: Vec<Store>) -> Self {
         self.stores_override = Some(stores.into_iter().map(|store| (store, None)).collect());
         self

--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -112,6 +112,11 @@ impl TestLoopBuilder {
         self
     }
 
+    pub fn stores_override_hot_only(mut self, stores: Vec<Store>) -> Self {
+        self.stores_override = Some(stores.into_iter().map(|store| (store, None)).collect());
+        self
+    }
+
     /// Set the accounts whose clients should be configured as archival nodes in the test loop.
     /// These accounts should be a subset of the accounts provided to the `clients` method.
     pub(crate) fn archival_clients(mut self, clients: HashSet<AccountId>) -> Self {

--- a/integration-tests/src/test_loop/tests/epoch_sync.rs
+++ b/integration-tests/src/test_loop/tests/epoch_sync.rs
@@ -338,7 +338,7 @@ fn test_epoch_sync_proof_sanity_from_epoch_synced_node() {
     let final_head_height_old = setup.chain_final_head_height(0);
     let final_head_height_new = setup.chain_final_head_height(4);
     sanity_check_epoch_sync_proof(&new_proof, final_head_height_new, &setup.genesis.config);
-    // Test loop shutdown mechainsm should not have left any new block messages unhandled,
+    // Test loop shutdown mechanism should not have left any new block messages unhandled,
     // so the nodes should be at the same height in the end.
     assert_eq!(final_head_height_old, final_head_height_new);
     assert_eq!(old_proof, new_proof);


### PR DESCRIPTION
* Store EpochSyncProof locally after as part of bootstrapping the node.
* Use the stored EpochSyncProof to derive a new EpochSyncProof in order to handle EpochSyncRequests.
* Add a new testloop test to check that one can bootstrap a new node via epoch sync from a node that was bootstrapped with epoch sync itself
* Add new testloop tests to check that the EpochSyncProof derived based on an older EpochSyncProof is exactly equal to an EpochSync derived from genesis.
