### PR TITLE
feat(state-sync): enable EveryEpoch snapshot generation by default

### DIFF
--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -112,10 +112,10 @@ pub struct StateSnapshotConfig {
 pub enum StateSnapshotType {
     /// Consider this as the default "disabled" option. We need to have snapshotting enabled for resharding
     /// State snapshots involve filesystem operations and costly IO operations.
-    #[default]
     ForReshardingOnly,
     /// This is the "enabled" option where we create a snapshot at the beginning of every epoch.
     /// Needed if a node wants to be able to respond to state part requests.
+    #[default]
     EveryEpoch,
 }
 


### PR DESCRIPTION
In preparation for decentralizing state sync and deprecating cloud storage, we want to have all nodes produce snapshots so that they can share state parts with each other. 