### PR TITLE
Add Clone derive for RPC errors structs

### DIFF
--- a/chain/jsonrpc-primitives/src/types/blocks.rs
+++ b/chain/jsonrpc-primitives/src/types/blocks.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-#[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcBlockError {
     #[error("Block not found: {error_message}")]

--- a/chain/jsonrpc-primitives/src/types/changes.rs
+++ b/chain/jsonrpc-primitives/src/types/changes.rs
@@ -24,7 +24,7 @@ pub struct RpcStateChangesInBlockByTypeResponse {
     pub changes: near_primitives::views::StateChangesKindsView,
 }
 
-#[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcStateChangesError {
     #[error("Block not found: {error_message}")]

--- a/chain/jsonrpc-primitives/src/types/chunks.rs
+++ b/chain/jsonrpc-primitives/src/types/chunks.rs
@@ -24,7 +24,7 @@ pub struct RpcChunkResponse {
     pub chunk_view: near_primitives::views::ChunkView,
 }
 
-#[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcChunkError {
     #[error("The node reached its limits. Try again later. More details: {error_message}")]

--- a/chain/jsonrpc-primitives/src/types/client_config.rs
+++ b/chain/jsonrpc-primitives/src/types/client_config.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 #[derive(Serialize)]
@@ -7,7 +7,7 @@ pub struct RpcClientConfigResponse {
     pub client_config: near_chain_configs::ClientConfig,
 }
 
-#[derive(thiserror::Error, Debug, Serialize)]
+#[derive(thiserror::Error, Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcClientConfigError {
     #[error("The node reached its limits. Try again later. More details: {error_message}")]

--- a/chain/jsonrpc-primitives/src/types/config.rs
+++ b/chain/jsonrpc-primitives/src/types/config.rs
@@ -12,7 +12,7 @@ pub struct RpcProtocolConfigResponse {
     pub config_view: near_chain_configs::ProtocolConfigView,
 }
 
-#[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcProtocolConfigError {
     #[error("Block has never been observed: {error_message}")]

--- a/chain/jsonrpc-primitives/src/types/gas_price.rs
+++ b/chain/jsonrpc-primitives/src/types/gas_price.rs
@@ -12,7 +12,7 @@ pub struct RpcGasPriceResponse {
     pub gas_price_view: near_primitives::views::GasPriceView,
 }
 
-#[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcGasPriceError {
     #[error("Internal error: {error_message}")]

--- a/chain/jsonrpc-primitives/src/types/light_client.rs
+++ b/chain/jsonrpc-primitives/src/types/light_client.rs
@@ -39,7 +39,7 @@ pub struct RpcLightClientBlockProofResponse {
     pub block_proof: near_primitives::merkle::MerklePath,
 }
 
-#[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcLightClientProofError {
     #[error("Block either has never been observed on the node or has been garbage collected: {error_message}")]
@@ -65,7 +65,7 @@ pub enum RpcLightClientProofError {
     InternalError { error_message: String },
 }
 
-#[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcLightClientNextBlockError {
     #[error("Internal error: {error_message}")]

--- a/chain/jsonrpc-primitives/src/types/maintenance.rs
+++ b/chain/jsonrpc-primitives/src/types/maintenance.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 pub type RpcMaintenanceWindowsResponse =
     Vec<(near_primitives::types::BlockHeight, near_primitives::types::BlockHeight)>;
 
-#[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcMaintenanceWindowsError {
     #[error("The node reached its limits. Try again later. More details: {error_message}")]

--- a/chain/jsonrpc-primitives/src/types/network_info.rs
+++ b/chain/jsonrpc-primitives/src/types/network_info.rs
@@ -27,7 +27,7 @@ pub struct RpcNetworkInfoResponse {
     pub known_producers: Vec<RpcKnownProducer>,
 }
 
-#[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcNetworkInfoError {
     #[error("Internal error: {error_message}")]

--- a/chain/jsonrpc-primitives/src/types/query.rs
+++ b/chain/jsonrpc-primitives/src/types/query.rs
@@ -6,7 +6,7 @@ pub struct RpcQueryRequest {
     pub request: near_primitives::views::QueryRequest,
 }
 
-#[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcQueryError {
     #[error("There are no fully synchronized blocks on the node yet")]

--- a/chain/jsonrpc-primitives/src/types/receipts.rs
+++ b/chain/jsonrpc-primitives/src/types/receipts.rs
@@ -15,7 +15,7 @@ pub struct RpcReceiptResponse {
     pub receipt_view: near_primitives::views::ReceiptView,
 }
 
-#[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcReceiptError {
     #[error("The node reached its limits. Try again later. More details: {error_message}")]

--- a/chain/jsonrpc-primitives/src/types/sandbox.rs
+++ b/chain/jsonrpc-primitives/src/types/sandbox.rs
@@ -9,7 +9,7 @@ pub struct RpcSandboxPatchStateRequest {
 #[derive(serde::Deserialize, serde::Serialize, Debug)]
 pub struct RpcSandboxPatchStateResponse {}
 
-#[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcSandboxPatchStateError {
     #[error("The node reached its limits. Try again later. More details: {error_message}")]
@@ -39,7 +39,7 @@ pub struct RpcSandboxFastForwardRequest {
 #[derive(serde::Deserialize, serde::Serialize)]
 pub struct RpcSandboxFastForwardResponse {}
 
-#[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcSandboxFastForwardError {
     #[error("The node reached its limits. Try again later. More details: {error_message}")]

--- a/chain/jsonrpc-primitives/src/types/split_storage.rs
+++ b/chain/jsonrpc-primitives/src/types/split_storage.rs
@@ -13,7 +13,7 @@ pub struct RpcSplitStorageInfoResponse {
     pub result: SplitStorageInfoView,
 }
 
-#[derive(thiserror::Error, Debug, Serialize, Deserialize)]
+#[derive(thiserror::Error, Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcSplitStorageInfoError {
     #[error("The node reached its limits. Try again later. More details: {error_message}")]

--- a/chain/jsonrpc-primitives/src/types/status.rs
+++ b/chain/jsonrpc-primitives/src/types/status.rs
@@ -47,7 +47,7 @@ pub struct RpcDebugStatusResponse {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct RpcHealthResponse;
 
-#[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcStatusError {
     #[error("Node is syncing")]

--- a/chain/jsonrpc-primitives/src/types/transactions.rs
+++ b/chain/jsonrpc-primitives/src/types/transactions.rs
@@ -31,7 +31,7 @@ pub enum SignedTransaction {
     SignedTransaction(near_primitives::transaction::SignedTransaction),
 }
 
-#[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize, Clone)]
+#[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcTransactionError {
     #[error("An error happened during transaction execution: {context:?}")]

--- a/chain/jsonrpc-primitives/src/types/validator.rs
+++ b/chain/jsonrpc-primitives/src/types/validator.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 pub type RpcValidatorsOrderedResponse =
     Vec<near_primitives::views::validator_stake_view::ValidatorStakeView>;
 
-#[derive(thiserror::Error, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "name", content = "info", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RpcValidatorError {
     #[error("Epoch not found")]


### PR DESCRIPTION
This pull request introduces the `Clone` trait for the RpcErrors structs. Implementing this trait is essential for ensuring that the RPC service can properly handle error instances, particularly for scenarios involving reading and matching errors.

- The RpcError structs now derive the `Clone` trait, allowing for instances of RpcErrors to be duplicated easily.
- The primary reason for this change is to facilitate the error handling process in the read RPC service. By enabling cloning, we ensure that error values can be reused or matched without ownership issues.
- This enhancement will improve the flexibility of error handling in the read RPC service, especially in scenarios where errors need to be logged, sent, or processed in multiple contexts.