### PR TITLE
[stateless_validation] Refactor ChunkEndorsementsState

### DIFF
--- a/chain/chain/src/stateless_validation/chunk_endorsement.rs
+++ b/chain/chain/src/stateless_validation/chunk_endorsement.rs
@@ -107,10 +107,10 @@ pub fn validate_chunk_endorsements_in_block(
             endorsed_chunk_validators.insert(account_id, *signature.clone());
         }
 
-        let endorsement_stats =
-            chunk_validator_assignments.compute_endorsement_stats(endorsed_chunk_validators);
-        if !endorsement_stats.is_endorsed {
-            tracing::error!(target: "chain", ?endorsement_stats, "Chunk does not have enough stake to be endorsed");
+        let endorsement_state =
+            chunk_validator_assignments.compute_endorsement_state(endorsed_chunk_validators);
+        if !endorsement_state.is_endorsed {
+            tracing::error!(target: "chain", ?endorsement_state, "Chunk does not have enough stake to be endorsed");
             return Err(Error::InvalidChunkEndorsement);
         }
 

--- a/chain/chain/src/stateless_validation/chunk_endorsement.rs
+++ b/chain/chain/src/stateless_validation/chunk_endorsement.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 use itertools::Itertools;
 use near_chain_primitives::Error;
@@ -79,7 +79,7 @@ pub fn validate_chunk_endorsements_in_block(
         // Verify that the signature in block body are valid for given chunk_validator.
         // Signature can be either None, or Some(signature).
         // We calculate the stake of the chunk_validators for who we have the signature present.
-        let mut endorsed_chunk_validators = HashSet::new();
+        let mut endorsed_chunk_validators = HashMap::new();
         for (account_id, signature) in ordered_chunk_validators.iter().zip(signatures) {
             let Some(signature) = signature else { continue };
             let (validator, _) = epoch_manager.get_validator_by_account_id(
@@ -104,12 +104,12 @@ pub fn validate_chunk_endorsements_in_block(
             }
 
             // Add validators with signature in endorsed_chunk_validators. We later use this to check stake.
-            endorsed_chunk_validators.insert(account_id);
+            endorsed_chunk_validators.insert(account_id, *signature.clone());
         }
 
         let endorsement_stats =
-            chunk_validator_assignments.compute_endorsement_stats(&endorsed_chunk_validators);
-        if !endorsement_stats.has_enough_stake() {
+            chunk_validator_assignments.compute_endorsement_stats(endorsed_chunk_validators);
+        if !endorsement_stats.is_endorsed {
             tracing::error!(target: "chain", ?endorsement_stats, "Chunk does not have enough stake to be endorsed");
             return Err(Error::InvalidChunkEndorsement);
         }

--- a/chain/client/src/chunk_inclusion_tracker.rs
+++ b/chain/client/src/chunk_inclusion_tracker.rs
@@ -6,14 +6,13 @@ use near_o11y::log_assert_fail;
 use near_primitives::block_body::ChunkEndorsementSignatures;
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
+use near_primitives::stateless_validation::validator_assignment::ChunkEndorsementsState;
 use near_primitives::types::{AccountId, EpochId, ShardId};
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
 
 use crate::metrics;
-use crate::stateless_validation::chunk_endorsement::{
-    ChunkEndorsementTracker, ChunkEndorsementsState,
-};
+use crate::stateless_validation::chunk_endorsement::ChunkEndorsementTracker;
 
 const CHUNK_HEADERS_FOR_INCLUSION_CACHE_SIZE: usize = 2048;
 const NUM_EPOCH_CHUNK_PRODUCERS_TO_KEEP_IN_BLOCKLIST: usize = 1000;
@@ -25,12 +24,6 @@ struct ChunkInfo {
     pub received_time: Utc,
     pub chunk_producer: AccountId,
     pub endorsements: ChunkEndorsementsState,
-}
-
-impl ChunkInfo {
-    fn is_endorsed(&self) -> bool {
-        matches!(self.endorsements, ChunkEndorsementsState::Endorsed(_, _))
-    }
 }
 
 pub struct ChunkInclusionTracker {
@@ -88,7 +81,7 @@ impl ChunkInclusionTracker {
             chunk_header,
             received_time: Utc::now_utc(),
             chunk_producer,
-            endorsements: ChunkEndorsementsState::NotEnoughStake(None),
+            endorsements: ChunkEndorsementsState::default(),
         };
         self.chunk_hash_to_chunk_info.insert(chunk_hash, chunk_info);
     }
@@ -155,8 +148,8 @@ impl ChunkInclusionTracker {
         for (shard_id, chunk_hash) in entry {
             let chunk_info = self.chunk_hash_to_chunk_info.get(chunk_hash).unwrap();
             let banned = self.is_banned(epoch_id, &chunk_info);
-            let has_chunk_endorsements = chunk_info.is_endorsed();
-            if !has_chunk_endorsements {
+            let is_endorsed = chunk_info.endorsements.is_endorsed;
+            if !is_endorsed {
                 tracing::debug!(
                     target: "client",
                     chunk_hash = ?chunk_info.chunk_header.chunk_hash(),
@@ -164,7 +157,7 @@ impl ChunkInclusionTracker {
                     "Not including chunk because of insufficient chunk endorsements"
                 );
             }
-            if !banned && has_chunk_endorsements {
+            if !banned && is_endorsed {
                 // only add to chunk_headers_ready_for_inclusion if chunk is not from a banned chunk producer
                 // and chunk has sufficient chunk endorsements.
                 // Chunk endorsements are got as part of call to prepare_chunk_headers_ready_for_inclusion
@@ -203,10 +196,7 @@ impl ChunkInclusionTracker {
     ) -> Result<(ShardChunkHeader, ChunkEndorsementSignatures), Error> {
         let chunk_info = self.get_chunk_info(chunk_hash)?;
         let chunk_header = chunk_info.chunk_header.clone();
-        let signatures = match &chunk_info.endorsements {
-            ChunkEndorsementsState::Endorsed(_, signatures) => signatures.clone(),
-            ChunkEndorsementsState::NotEnoughStake(_) => vec![],
-        };
+        let signatures = chunk_info.endorsements.signatures.clone();
         Ok((chunk_header, signatures))
     }
 
@@ -228,9 +218,10 @@ impl ChunkInclusionTracker {
                 log_assert_fail!("Chunk info is missing for shard {shard_id} chunk {chunk_hash:?}");
                 continue;
             };
-            let Some(stats) = chunk_info.endorsements.stats() else {
+            let stats = &chunk_info.endorsements;
+            if stats.total_stake == 0 {
                 continue;
-            };
+            }
             let shard_label = shard_id.to_string();
             let label_values = &[shard_label.as_ref()];
             metrics::BLOCK_PRODUCER_ENDORSED_STAKE_RATIO

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -714,7 +714,7 @@ impl ClientActorInner {
                 continue;
             }
             // Compute total stake and endorsed stake.
-            let mut endorsed_chunk_validators = HashSet::new();
+            let mut endorsed_chunk_validators = HashMap::new();
             for (account_id, signature) in ordered_chunk_validators.iter().zip(signatures) {
                 let Some(signature) = signature else { continue };
                 let Ok((validator, _)) = self.client.epoch_manager.get_validator_by_account_id(
@@ -731,10 +731,10 @@ impl ClientActorInner {
                 ) {
                     continue;
                 }
-                endorsed_chunk_validators.insert(account_id);
+                endorsed_chunk_validators.insert(account_id, *signature.clone());
             }
             let endorsement_stats =
-                chunk_validator_assignments.compute_endorsement_stats(&endorsed_chunk_validators);
+                chunk_validator_assignments.compute_endorsement_stats(endorsed_chunk_validators);
             chunk_endorsements.insert(
                 chunk_header.chunk_hash(),
                 endorsement_stats.endorsed_stake as f64 / endorsement_stats.total_stake as f64,

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -733,11 +733,11 @@ impl ClientActorInner {
                 }
                 endorsed_chunk_validators.insert(account_id, *signature.clone());
             }
-            let endorsement_stats =
-                chunk_validator_assignments.compute_endorsement_stats(endorsed_chunk_validators);
+            let endorsement_state =
+                chunk_validator_assignments.compute_endorsement_state(endorsed_chunk_validators);
             chunk_endorsements.insert(
                 chunk_header.chunk_hash(),
-                endorsement_stats.endorsed_stake as f64 / endorsement_stats.total_stake as f64,
+                endorsement_state.endorsed_stake as f64 / endorsement_state.total_stake as f64,
             );
         }
         Some(chunk_endorsements)

--- a/chain/client/src/stateless_validation/chunk_endorsement/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement/mod.rs
@@ -3,10 +3,9 @@ use std::sync::Arc;
 use near_chain::ChainStoreAccess;
 use near_chain_primitives::Error;
 use near_epoch_manager::EpochManagerAdapter;
-use near_primitives::block_body::ChunkEndorsementSignatures;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
-use near_primitives::stateless_validation::validator_assignment::EndorsementStats;
+use near_primitives::stateless_validation::validator_assignment::ChunkEndorsementsState;
 use near_primitives::version::ProtocolFeature;
 use near_store::Store;
 
@@ -14,20 +13,6 @@ use crate::Client;
 
 mod tracker_v1;
 mod tracker_v2;
-
-pub enum ChunkEndorsementsState {
-    Endorsed(Option<EndorsementStats>, ChunkEndorsementSignatures),
-    NotEnoughStake(Option<EndorsementStats>),
-}
-
-impl ChunkEndorsementsState {
-    pub fn stats(&self) -> Option<&EndorsementStats> {
-        match self {
-            Self::Endorsed(stats, _) => stats.as_ref(),
-            Self::NotEnoughStake(stats) => stats.as_ref(),
-        }
-    }
-}
 
 /// Module to track chunk endorsements received from chunk validators.
 pub struct ChunkEndorsementTracker {

--- a/chain/client/src/stateless_validation/chunk_endorsement/tracker_v1.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement/tracker_v1.rs
@@ -203,9 +203,10 @@ impl ChunkEndorsementTrackerInner {
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
         if !checked_feature!("stable", StatelessValidation, protocol_version) {
             // Return an empty array of chunk endorsements for older protocol versions.
-            let mut endorsement_stats = ChunkEndorsementsState::default();
-            endorsement_stats.is_endorsed = true;
-            return Ok(endorsement_stats);
+            return Ok(ChunkEndorsementsState {
+                is_endorsed: true,
+                ..ChunkEndorsementsState::default()
+            });
         }
 
         let chunk_validator_assignments = self.epoch_manager.get_chunk_validator_assignments(
@@ -230,6 +231,6 @@ impl ChunkEndorsementTrackerInner {
             .map(|(account_id, endorsement)| (account_id, endorsement.signature.clone()))
             .collect();
 
-        Ok(chunk_validator_assignments.compute_endorsement_stats(validator_signatures))
+        Ok(chunk_validator_assignments.compute_endorsement_state(validator_signatures))
     }
 }

--- a/chain/client/src/stateless_validation/chunk_endorsement/tracker_v2.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement/tracker_v2.rs
@@ -73,9 +73,10 @@ impl ChunkEndorsementTracker {
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
         if !ProtocolFeature::StatelessValidation.enabled(protocol_version) {
             // Return an endorsed empty array of chunk endorsements for older protocol versions.
-            let mut endorsement_stats = ChunkEndorsementsState::default();
-            endorsement_stats.is_endorsed = true;
-            return Ok(endorsement_stats);
+            return Ok(ChunkEndorsementsState {
+                is_endorsed: true,
+                ..ChunkEndorsementsState::default()
+            });
         }
 
         let height_created = chunk_header.height_created();
@@ -100,6 +101,6 @@ impl ChunkEndorsementTracker {
             .map(|(account_id, endorsement)| (account_id, endorsement.signature()))
             .collect();
 
-        Ok(chunk_validator_assignments.compute_endorsement_stats(validator_signatures))
+        Ok(chunk_validator_assignments.compute_endorsement_state(validator_signatures))
     }
 }

--- a/chain/client/src/stateless_validation/chunk_endorsement/tracker_v2.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement/tracker_v2.rs
@@ -7,14 +7,13 @@ use near_chain_primitives::Error;
 use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsementV2;
+use near_primitives::stateless_validation::validator_assignment::ChunkEndorsementsState;
 use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::types::AccountId;
 use near_primitives::version::ProtocolFeature;
 use near_store::Store;
 
 use crate::stateless_validation::validate::validate_chunk_endorsement;
-
-use super::ChunkEndorsementsState;
 
 // This is the number of unique chunks for which we would track the chunk endorsements.
 // Ideally, we should not be processing more than num_shards chunks at a time.
@@ -64,10 +63,6 @@ impl ChunkEndorsementTracker {
     }
 
     /// This function is called by block producer potentially multiple times if there's not enough stake.
-    /// We return ChunkEndorsementsState::Endorsed if node has enough signed stake for the chunk represented
-    /// by chunk_header. Signatures have the same order as ordered_chunk_validators, thus ready to be included
-    /// in a block as is.
-    /// We returns ChunkEndorsementsState::NotEnoughStake if chunk doesn't have enough stake.
     pub(crate) fn collect_chunk_endorsements(
         &mut self,
         chunk_header: &ShardChunkHeader,
@@ -77,8 +72,10 @@ impl ChunkEndorsementTracker {
             self.epoch_manager.get_epoch_id_from_prev_block(chunk_header.prev_block_hash())?;
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
         if !ProtocolFeature::StatelessValidation.enabled(protocol_version) {
-            // Return an empty array of chunk endorsements for older protocol versions.
-            return Ok(ChunkEndorsementsState::Endorsed(None, vec![]));
+            // Return an endorsed empty array of chunk endorsements for older protocol versions.
+            let mut endorsement_stats = ChunkEndorsementsState::default();
+            endorsement_stats.is_endorsed = true;
+            return Ok(endorsement_stats);
         }
 
         let height_created = chunk_header.height_created();
@@ -96,30 +93,13 @@ impl ChunkEndorsementTracker {
         //    1. The chunk endorsements are from valid chunk_validator for this chunk.
         //    2. The chunk endorsements signatures are valid.
         //    3. We still need to validate if the chunk_hash matches the chunk_header.chunk_hash()
-        let Some(entry) = self.chunk_endorsements.get_mut(&key) else {
-            // Early return if no chunk_endorsements found in our cache.
-            return Ok(ChunkEndorsementsState::NotEnoughStake(None));
-        };
-        entry.retain(|_, endorsement| endorsement.chunk_hash() == &chunk_header.chunk_hash());
-
-        let endorsement_stats =
-            chunk_validator_assignments.compute_endorsement_stats(&entry.keys().collect());
-
-        // Check whether the current set of chunk_validators have enough stake to include chunk in block.
-        if !endorsement_stats.has_enough_stake() {
-            return Ok(ChunkEndorsementsState::NotEnoughStake(Some(endorsement_stats)));
-        }
-
-        // We've already verified the chunk_endorsements are valid, collect signatures.
-        let signatures = chunk_validator_assignments
-            .ordered_chunk_validators()
-            .iter()
-            .map(|account_id| {
-                // map Option<ChunkEndorsement> to Option<Box<Signature>>
-                entry.get(account_id).map(|endorsement| Box::new(endorsement.signature()))
-            })
+        let entry = self.chunk_endorsements.get_or_insert(key, || HashMap::new());
+        let validator_signatures = entry
+            .into_iter()
+            .filter(|(_, endorsement)| endorsement.chunk_hash() == &chunk_header.chunk_hash())
+            .map(|(account_id, endorsement)| (account_id, endorsement.signature()))
             .collect();
 
-        Ok(ChunkEndorsementsState::Endorsed(Some(endorsement_stats), signatures))
+        Ok(chunk_validator_assignments.compute_endorsement_stats(validator_signatures))
     }
 }

--- a/core/primitives/src/stateless_validation/validator_assignment.rs
+++ b/core/primitives/src/stateless_validation/validator_assignment.rs
@@ -1,24 +1,28 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 
+use near_crypto::Signature;
 use near_primitives_core::types::{AccountId, Balance};
 
-#[derive(Debug)]
-pub struct EndorsementStats {
+use crate::block_body::ChunkEndorsementSignatures;
+
+#[derive(Debug, Default)]
+pub struct ChunkEndorsementsState {
     pub total_stake: Balance,
     pub endorsed_stake: Balance,
     pub total_validators_count: usize,
     pub endorsed_validators_count: usize,
+    pub is_endorsed: bool,
+    // Signatures are empty if the chunk is not endorsed
+    pub signatures: ChunkEndorsementSignatures,
 }
 
-impl EndorsementStats {
-    pub fn has_enough_stake(&self) -> bool {
-        self.endorsed_stake >= self.required_stake()
-    }
+fn has_enough_stake(total_stake: Balance, endorsed_stake: Balance) -> bool {
+    endorsed_stake >= required_stake(total_stake)
+}
 
-    pub fn required_stake(&self) -> Balance {
-        self.total_stake * 2 / 3 + 1
-    }
+fn required_stake(total_stake: Balance) -> Balance {
+    total_stake * 2 / 3 + 1
 }
 
 #[derive(Debug, Default)]
@@ -51,23 +55,35 @@ impl ChunkValidatorAssignments {
 
     pub fn compute_endorsement_stats(
         &self,
-        endorsed_chunk_validators: &HashSet<&AccountId>,
-    ) -> EndorsementStats {
+        mut validator_signatures: HashMap<&AccountId, Signature>,
+    ) -> ChunkEndorsementsState {
         let mut total_stake = 0;
         let mut endorsed_stake = 0;
         let mut endorsed_validators_count = 0;
+        let mut signatures = vec![];
         for (account_id, stake) in &self.assignments {
             total_stake += stake;
-            if endorsed_chunk_validators.contains(account_id) {
-                endorsed_stake += stake;
-                endorsed_validators_count += 1;
+            match validator_signatures.remove(account_id) {
+                Some(signature) => {
+                    endorsed_stake += stake;
+                    endorsed_validators_count += 1;
+                    signatures.push(Some(Box::new(signature)));
+                }
+                None => signatures.push(None),
             }
         }
-        EndorsementStats {
+        // Signatures are empty if the chunk is not endorsed
+        let is_endorsed = has_enough_stake(total_stake, endorsed_stake);
+        if !is_endorsed {
+            signatures = vec![];
+        }
+        ChunkEndorsementsState {
             total_stake,
             endorsed_stake,
             endorsed_validators_count,
             total_validators_count: self.assignments.len(),
+            is_endorsed,
+            signatures,
         }
     }
 }

--- a/core/primitives/src/stateless_validation/validator_assignment.rs
+++ b/core/primitives/src/stateless_validation/validator_assignment.rs
@@ -53,7 +53,7 @@ impl ChunkValidatorAssignments {
         &self.assignments
     }
 
-    pub fn compute_endorsement_stats(
+    pub fn compute_endorsement_state(
         &self,
         mut validator_signatures: HashMap<&AccountId, Signature>,
     ) -> ChunkEndorsementsState {
@@ -75,7 +75,7 @@ impl ChunkValidatorAssignments {
         // Signatures are empty if the chunk is not endorsed
         let is_endorsed = has_enough_stake(total_stake, endorsed_stake);
         if !is_endorsed {
-            signatures = vec![];
+            signatures.clear();
         }
         ChunkEndorsementsState {
             total_stake,


### PR DESCRIPTION
I noticed in endorsement tracker, we were first checking if we have enough endorsement stake and then using that information to generate the signature vector. 

It's simpler and more efficient to generate this while calculating enough stake.

ChunkEndorsementsState doesn't have to be an enum, we can include the signatures in EndorsementStats (and rename it to ChunkEndorsementsState).