### PR TITLE
[memtrie] Fix refcount for HybridArena

### DIFF
--- a/core/store/src/trie/mem/arena/concurrent.rs
+++ b/core/store/src/trie/mem/arena/concurrent.rs
@@ -121,6 +121,10 @@ impl ArenaMemory for ConcurrentArenaMemory {
 }
 
 impl ArenaMemoryMut for ConcurrentArenaMemory {
+    fn is_mutable(&self, _pos: ArenaPos) -> bool {
+        true
+    }
+
     fn raw_slice_mut(&mut self, pos: ArenaPos, len: usize) -> &mut [u8] {
         &mut self.chunk_mut(pos.chunk())[pos.pos()..pos.pos() + len]
     }

--- a/core/store/src/trie/mem/arena/frozen.rs
+++ b/core/store/src/trie/mem/arena/frozen.rs
@@ -39,3 +39,16 @@ impl Arena for FrozenArena {
         &self.memory
     }
 }
+
+impl FrozenArena {
+    /// Number of active allocations (alloc calls minus dealloc calls).
+    #[cfg(test)]
+    pub fn num_active_allocs(&self) -> usize {
+        self.active_allocs_count
+    }
+
+    #[cfg(test)]
+    pub fn active_allocs_bytes(&self) -> usize {
+        self.active_allocs_bytes
+    }
+}

--- a/core/store/src/trie/mem/arena/hybrid.rs
+++ b/core/store/src/trie/mem/arena/hybrid.rs
@@ -55,6 +55,10 @@ impl ArenaMemory for HybridArenaMemory {
 }
 
 impl ArenaMemoryMut for HybridArenaMemory {
+    fn is_mutable(&self, pos: ArenaPos) -> bool {
+        pos.chunk >= self.chunks_offset()
+    }
+
     fn raw_slice_mut(&mut self, mut pos: ArenaPos, len: usize) -> &mut [u8] {
         debug_assert!(!pos.is_invalid());
         assert!(pos.chunk >= self.chunks_offset(), "Cannot mutate shared memory");

--- a/core/store/src/trie/mem/arena/mod.rs
+++ b/core/store/src/trie/mem/arena/mod.rs
@@ -64,6 +64,11 @@ pub trait ArenaMemory: Sized + 'static {
 /// A mutable reference to `ArenaMemory` can be used to mutate allocated
 /// memory, but not to allocate or deallocate memory.
 pub trait ArenaMemoryMut: ArenaMemory {
+    /// Returns whether the memory at the given position is mutable or not.
+    /// Normally, all memory is mutable, but in case of HybridArenaMemory,
+    /// we could be referring to a read-only memory part.
+    fn is_mutable(&self, _pos: ArenaPos) -> bool;
+
     fn raw_slice_mut(&mut self, pos: ArenaPos, len: usize) -> &mut [u8];
 
     /// Provides write access to a region of memory in the arena.

--- a/core/store/src/trie/mem/arena/single_thread.rs
+++ b/core/store/src/trie/mem/arena/single_thread.rs
@@ -17,6 +17,10 @@ impl ArenaMemory for STArenaMemory {
 }
 
 impl ArenaMemoryMut for STArenaMemory {
+    fn is_mutable(&self, _pos: ArenaPos) -> bool {
+        true
+    }
+
     fn raw_slice_mut(&mut self, pos: ArenaPos, len: usize) -> &mut [u8] {
         &mut self.chunks[pos.chunk()][pos.pos()..pos.pos() + len]
     }

--- a/core/store/src/trie/mem/mem_tries.rs
+++ b/core/store/src/trie/mem/mem_tries.rs
@@ -26,7 +26,7 @@ use super::updating::{construct_root_from_changes, MemTrieUpdate};
 /// its children nodes. The `roots` field of this struct logically
 /// holds an Rc of the root of each trie.
 pub struct MemTries {
-    arena: HybridArena,
+    pub(super) arena: HybridArena,
     /// Maps a state root to a list of nodes that have the same root hash.
     /// The reason why this is a list is because we do not have a node
     /// deduplication mechanism so we can't guarantee that nodes of the


### PR DESCRIPTION
On converting existing arena memory to shared memory, we lose the ability to refcount the shared memory part.

However, while adding new nodes and new entries in the owned memory part, we could potentially be referring to the shared memory.

In such cases, while adding or removing nodes, we would like to ignore all increments and decrements to refcounts in the shared part of memory.

Added a unit test for expected scenario.