### PR TITLE
fix(state-snapshot): correctly return included shard uids

### DIFF
--- a/core/store/src/flat/manager.rs
+++ b/core/store/src/flat/manager.rs
@@ -204,11 +204,6 @@ impl FlatStorageManager {
         Some(FlatStorageChunkView::new(self.0.store.clone(), block_hash, flat_storage))
     }
 
-    pub fn get_shard_uids(&self) -> Vec<ShardUId> {
-        let flat_storages = self.0.flat_storages.lock().expect(POISONED_LOCK_ERR);
-        flat_storages.keys().cloned().collect()
-    }
-
     // TODO (#7327): consider returning Result<FlatStorage, Error> when we expect flat storage to exist
     pub fn get_flat_storage_for_shard(&self, shard_uid: ShardUId) -> Option<FlatStorage> {
         let flat_storages = self.0.flat_storages.lock().expect(POISONED_LOCK_ERR);

--- a/core/store/src/trie/state_snapshot.rs
+++ b/core/store/src/trie/state_snapshot.rs
@@ -122,7 +122,7 @@ impl StateSnapshot {
     }
 
     /// Returns the UIds for the shards included in the snapshot.
-    pub fn get_shard_uids(&self) -> Vec<ShardUId> {
+    pub fn get_included_shard_uids(&self) -> Vec<ShardUId> {
         self.included_shard_uids.clone()
     }
 
@@ -242,7 +242,7 @@ impl ShardTries {
 
         metrics::HAS_STATE_SNAPSHOT.set(1);
         tracing::info!(target: "state_snapshot", ?prev_block_hash, "Made a checkpoint");
-        Ok(Some(state_snapshot_lock.as_ref().unwrap().get_shard_uids()))
+        Ok(Some(state_snapshot_lock.as_ref().unwrap().get_included_shard_uids()))
     }
 
     /// Deletes all snapshots and unsets the STATE_SNAPSHOT_KEY.


### PR DESCRIPTION
The StateSnapshot class provides a function called `get_shard_uids`, which is intended to return the UIDs of the shards included in the snapshot.

However, this function was incorrectly returning the entire set of flat storage keys from the flat storage manager. As a result, if a flat storage exists but the snapshot process fails to update the flat storage head, the snapshot would incorrectly report that the shard was successfully included.