### PR TITLE
Revert "Panic in `CreateSnapshotRequest` handle if snapshot creation …

### DIFF
--- a/chain/chain/src/state_snapshot_actor.rs
+++ b/chain/chain/src/state_snapshot_actor.rs
@@ -97,9 +97,7 @@ impl StateSnapshotActor {
                 ));
             }
             Err(err) => {
-                tracing::error!(target: "state_snapshot", ?err, "State snapshot creation failed.\
-                State snapshot is needed for correct node performance if it is required by config.");
-                panic!("State snapshot creation failed")
+                tracing::error!(target: "state_snapshot", ?err, "State snapshot creation failed")
             }
         }
     }


### PR DESCRIPTION
…failed (#10765)"

This reverts commit 8a09a2afe136b233e33572d65bdbeeed8decaef9.

When the network was resharded, we added this panic in order to exit early if there was some failure, because the node would not be able to reshard without a valid snapshot. But now that decentralized state sync is going to be using these snapshots (and since we're reworking how resharding works anyway), this is no longer an error that requires a panic, since a node should continue to operate correctly even if this part fails.