### PR TITLE
feat: basic global contract support

### DIFF
--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -65,6 +65,7 @@ struct TestEnv {
     pub last_receipts: HashMap<ShardId, Vec<Receipt>>,
     pub last_shard_proposals: HashMap<ShardId, Vec<ValidatorStake>>,
     pub last_proposals: Vec<ValidatorStake>,
+    global_state_root: StateRoot,
     time: u64,
 }
 
@@ -200,6 +201,7 @@ impl TestEnv {
             last_proposals: vec![],
             last_shard_proposals: HashMap::default(),
             time: 0,
+            global_state_root: CryptoHash::default(),
         }
     }
 
@@ -234,7 +236,7 @@ impl TestEnv {
         };
         self.runtime
             .apply_chunk(
-                RuntimeStorageConfig::new(state_root, true),
+                RuntimeStorageConfig::new(state_root, self.global_state_root, true),
                 ApplyChunkReason::UpdateTrackedShard,
                 ApplyChunkShardContext {
                     shard_id,
@@ -254,6 +256,7 @@ impl TestEnv {
                     challenges_result,
                     random_seed: CryptoHash::default(),
                     congestion_info,
+                    global_shard_state_root: self.global_state_root,
                 },
                 receipts,
                 transactions,
@@ -1694,6 +1697,7 @@ fn test_prepare_transactions_storage_proof() {
         use_flat_storage: true,
         source: StorageDataSource::Db,
         state_patch: Default::default(),
+        global_shard_state_root: env.global_state_root,
     };
 
     let proposed_transactions = prepare_transactions(
@@ -1714,6 +1718,7 @@ fn test_prepare_transactions_storage_proof() {
             nodes: proposed_transactions.storage_proof.unwrap(),
         }),
         state_patch: Default::default(),
+        global_shard_state_root: env.global_state_root,
     };
 
     let validated_transactions = prepare_transactions(
@@ -1738,6 +1743,7 @@ fn test_prepare_transactions_empty_storage_proof() {
         use_flat_storage: true,
         source: StorageDataSource::Db,
         state_patch: Default::default(),
+        global_shard_state_root: env.global_state_root,
     };
 
     let proposed_transactions = prepare_transactions(
@@ -1758,6 +1764,7 @@ fn test_prepare_transactions_empty_storage_proof() {
             nodes: PartialState::default(), // We use empty storage proof here.
         }),
         state_patch: Default::default(),
+        global_shard_state_root: env.global_state_root,
     };
 
     let validation_result = prepare_transactions(

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -176,6 +176,7 @@ pub fn pre_validate_chunk_state_witness(
     }
 
     // Verify that all proposed transactions are valid.
+    let global_shard_state_root = chain.chain_store().get_global_shard_state_root(state_witness.chunk_header.prev_block_hash())?;
     let new_transactions = &state_witness.new_transactions;
     if !new_transactions.is_empty() {
         let transactions_validation_storage_config = RuntimeStorageConfig {
@@ -185,6 +186,7 @@ pub fn pre_validate_chunk_state_witness(
                 nodes: state_witness.new_transactions_validation_state.clone(),
             }),
             state_patch: Default::default(),
+            global_shard_state_root,
         };
 
         match validate_prepared_transactions(
@@ -517,6 +519,7 @@ pub fn apply_result_to_chunk_extra(
         chunk.gas_limit(),
         apply_result.total_balance_burnt,
         apply_result.congestion_info,
+        apply_result.permanent_contracts_metadata,
     )
 }
 

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -1098,6 +1098,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         _epoch_id: &EpochId,
         _current_protocol_version: ProtocolVersion,
         _receiver_congestion_info: Option<ExtendedCongestionInfo>,
+        _global_shard_state_root: &StateRoot,
     ) -> Result<Option<InvalidTxError>, Error> {
         Ok(None)
     }
@@ -1286,6 +1287,7 @@ impl RuntimeAdapter for KeyValueRuntime {
             processed_yield_timeouts: vec![],
             applied_receipts_hash: hash(&borsh::to_vec(receipts).unwrap()),
             congestion_info: Self::get_congestion_info(PROTOCOL_VERSION),
+            permanent_contracts_metadata: vec![],
         })
     }
 

--- a/chain/chain/src/tests/garbage_collection.rs
+++ b/chain/chain/src/tests/garbage_collection.rs
@@ -94,7 +94,7 @@ fn do_fork(
         if i == 0 {
             store_update.save_block_merkle_tree(*prev_block.hash(), PartialMerkleTree::default());
         }
-        store_update.save_block(block.clone());
+        store_update.save_block(block.clone()).unwrap();
         store_update.inc_block_refcount(block.header().prev_hash()).unwrap();
         store_update.save_block_header(block.header().clone()).unwrap();
         let tip = Tip::from_header(block.header());
@@ -755,7 +755,7 @@ fn add_block(
             .build()
     };
     blocks.push(block.clone());
-    store_update.save_block(block.clone());
+    store_update.save_block(block.clone()).unwrap();
     store_update.inc_block_refcount(block.header().prev_hash()).unwrap();
     store_update.save_block_header(block.header().clone()).unwrap();
     store_update.save_head(&Tip::from_header(block.header())).unwrap();
@@ -870,7 +870,7 @@ fn test_clear_old_data_too_many_heights_common(gc_blocks_limit: NumBlocks) {
         blocks.push(block.clone());
 
         let mut store_update = chain.mut_chain_store().store_update();
-        store_update.save_block(block.clone());
+        store_update.save_block(block.clone()).unwrap();
         store_update.inc_block_refcount(block.header().prev_hash()).unwrap();
         store_update.save_block_header(block.header().clone()).unwrap();
         store_update.save_head(&Tip::from_header(&block.header())).unwrap();

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -88,6 +88,7 @@ fn build_chain_with_orphans() {
         &*signer,
         *last_block.header().next_bp_hash(),
         CryptoHash::default(),
+        CryptoHash::default(),
         clock,
         None,
     );

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -189,6 +189,7 @@ pub fn apply_new_chunk(
         use_flat_storage: true,
         source: storage_context.storage_data_source,
         state_patch: storage_context.state_patch,
+        global_shard_state_root: block.global_shard_state_root,
     };
     match runtime.apply_chunk(
         storage_config,
@@ -253,6 +254,7 @@ pub fn apply_old_chunk(
         use_flat_storage: true,
         source: storage_context.storage_data_source,
         state_patch: storage_context.state_patch,
+        global_shard_state_root: block.global_shard_state_root,
     };
     match runtime.apply_chunk(
         storage_config,

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -1984,6 +1984,7 @@ impl ShardsManagerActor {
         prev_outgoing_receipts_root: CryptoHash,
         tx_root: CryptoHash,
         congestion_info: Option<CongestionInfo>,
+        permanent_contracts_metadata: Vec<(AccountId, CryptoHash)>,
         signer: &ValidatorSigner,
         rs: &ReedSolomon,
         protocol_version: ProtocolVersion,
@@ -2004,6 +2005,7 @@ impl ShardsManagerActor {
             prev_outgoing_receipts,
             prev_outgoing_receipts_root,
             congestion_info,
+            permanent_contracts_metadata,
             signer,
             protocol_version,
         )

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -152,6 +152,7 @@ impl ChunkTestFixture {
             receipts_root,
             MerkleHash::default(),
             congestion_info,
+            vec![],
             &signer,
             &rs,
             PROTOCOL_VERSION,

--- a/chain/client/src/stateless_validation/shadow_validate.rs
+++ b/chain/client/src/stateless_validation/shadow_validate.rs
@@ -47,12 +47,14 @@ impl Client {
     ) -> Result<(), Error> {
         let chunk_header = chunk.cloned_header();
         let last_chunk = self.chain.get_chunk(&prev_chunk_header.chunk_hash())?;
+        let global_shard_state_root = self.chain.get_global_shard_state_root(&prev_block_header.hash())?;
 
         let transactions_validation_storage_config = RuntimeStorageConfig {
             state_root: chunk_header.prev_state_root(),
             use_flat_storage: true,
             source: StorageDataSource::Db,
             state_patch: Default::default(),
+            global_shard_state_root,
         };
 
         // We call `validate_prepared_transactions()` here because we need storage proof for transactions validation.

--- a/chain/client/src/sync/header.rs
+++ b/chain/client/src/sync/header.rs
@@ -402,6 +402,7 @@ mod test {
         BlockInfo, FullPeerInfo, HighestHeightPeerInfo, NetworkRequests, PeerInfo,
     };
     use near_primitives::block::{Approval, Block, GenesisId};
+    use near_primitives::hash::CryptoHash;
     use near_primitives::merkle::PartialMerkleTree;
     use near_primitives::network::PeerId;
     use near_primitives::test_utils::TestBlockBuilder;
@@ -812,6 +813,7 @@ mod test {
                 signer2.as_ref(),
                 *last_block.header().next_bp_hash(),
                 block_merkle_tree.root(),
+                CryptoHash::default(),
                 clock.clock(),
                 None,
             );

--- a/chain/client/src/test_utils/client.rs
+++ b/chain/client/src/test_utils/client.rs
@@ -229,6 +229,7 @@ pub fn create_chunk(
             decoded_chunk.prev_outgoing_receipts(),
             header.prev_outgoing_receipts_root(),
             header.congestion_info(),
+            header.permanent_contracts_metadata().to_vec(),
             &*signer,
             PROTOCOL_VERSION,
         )
@@ -247,6 +248,7 @@ pub fn create_chunk(
     let block_merkle_tree =
         client.chain.chain_store().get_block_merkle_tree(last_block.hash()).unwrap();
     let mut block_merkle_tree = PartialMerkleTree::clone(&block_merkle_tree);
+    let global_shard_state_root = client.chain.get_global_shard_state_root(last_block.hash()).unwrap();
 
     let signer = client.validator_signer.get().unwrap();
     let endorsement = ChunkEndorsementV1::new(chunk.cloned_header().chunk_hash(), signer.as_ref());
@@ -272,6 +274,7 @@ pub fn create_chunk(
         &*client.validator_signer.get().unwrap(),
         *last_block.header().next_bp_hash(),
         block_merkle_tree.root(),
+        global_shard_state_root,
         client.clock.clone(),
         None,
     );

--- a/chain/client/src/tests/process_blocks.rs
+++ b/chain/client/src/tests/process_blocks.rs
@@ -86,6 +86,7 @@ fn test_bad_shard_id() {
         chunk.tx_root(),
         chunk.prev_validator_proposals().collect(),
         congestion_info,
+        chunk.permanent_contracts_metadata().to_vec(),
         &validator_signer,
     );
     modified_chunk.height_included = 2;
@@ -229,6 +230,7 @@ fn test_bad_congestion_info_impl(mode: BadCongestionInfoMode) {
         chunk.tx_root(),
         chunk.prev_validator_proposals().collect(),
         Some(congestion_info),
+        chunk.permanent_contracts_metadata().to_vec(),
         &validator_signer,
     );
     modified_chunk_header.height_included = 2;

--- a/chain/client/src/tests/query_client.rs
+++ b/chain/client/src/tests/query_client.rs
@@ -17,6 +17,7 @@ use near_network::types::PeerInfo;
 use near_o11y::testonly::init_test_logger;
 use near_o11y::WithSpanContextExt;
 use near_primitives::block::{Block, BlockHeader};
+use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::PartialMerkleTree;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::transaction::SignedTransaction;
@@ -99,6 +100,7 @@ fn query_status_not_crash() {
                 &signer,
                 block.header.next_bp_hash,
                 block_merkle_tree.root(),
+                CryptoHash::default(),
                 Clock::real(),
                 None,
             );

--- a/chain/epoch-manager/src/shard_tracker.rs
+++ b/chain/epoch-manager/src/shard_tracker.rs
@@ -6,7 +6,7 @@ use near_chain_configs::ClientConfig;
 use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::account_id_to_shard_id;
-use near_primitives::types::{AccountId, EpochId, ShardId};
+use near_primitives::types::{AccountId, EpochId, ShardId, GLOBAL_SHARD_ID};
 
 #[derive(Clone)]
 pub enum TrackedConfig {
@@ -129,6 +129,9 @@ impl ShardTracker {
         shard_id: ShardId,
         is_me: bool,
     ) -> bool {
+        if shard_id == GLOBAL_SHARD_ID {
+            return true;
+        }
         // TODO: fix these unwrap_or here and handle error correctly. The current behavior masks potential errors and bugs
         // https://github.com/near/nearcore/issues/4936
         if let Some(account_id) = account_id {
@@ -173,6 +176,9 @@ impl ShardTracker {
         shard_id: ShardId,
         is_me: bool,
     ) -> bool {
+        if shard_id == GLOBAL_SHARD_ID {
+            return true;
+        }
         if let Some(account_id) = account_id {
             let account_cares_about_shard = {
                 self.epoch_manager

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -2948,6 +2948,7 @@ fn test_chunk_header(h: &[CryptoHash], signer: &ValidatorSigner) -> ShardChunkHe
         h[2],
         vec![],
         congestion_info,
+        vec![],
         signer,
     ))
 }

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -67,6 +67,7 @@ pub fn make_block(
         signer,
         CryptoHash::default(),
         CryptoHash::default(),
+        CryptoHash::default(),
         clock,
         None,
     )

--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -500,6 +500,10 @@ impl From<NearActions> for Vec<crate::models::Operation> {
 
                     operations.extend(delegated_operations);
                 } // TODO(#8469): Implement delegate action support, for now they are ignored.
+                #[cfg(feature = "protocol_feature_global_contracts")]
+                near_primitives::action::Action::DeployPermanentContract(_) => {
+                    // TODO: figure out whether `DeployPermanentContract` should be supported
+                }
             }
         }
         operations

--- a/chain/rosetta-rpc/src/adapters/transactions.rs
+++ b/chain/rosetta-rpc/src/adapters/transactions.rs
@@ -160,6 +160,9 @@ fn convert_cause_to_transaction_id(
         StateChangeCauseView::Resharding => Err(crate::errors::ErrorKind::InternalInvariantError(
             "State Change 'Resharding' should never be observed".to_string(),
         )),
+        StateChangeCauseView::GlobalStateUpdate => {
+            Ok((TransactionIdentifier::block_event("global state update", block_hash), None))
+        }
     }
 }
 

--- a/core/parameters/res/runtime_configs/145.yaml
+++ b/core/parameters/res/runtime_configs/145.yaml
@@ -1,0 +1,1 @@
+storage_contract_code_burnt_amount_per_byte: { old: 0, new: 100_000_000_000_000_000_000}

--- a/core/parameters/res/runtime_configs/parameters.yaml
+++ b/core/parameters/res/runtime_configs/parameters.yaml
@@ -28,6 +28,7 @@ registrar_account_id: "registrar"
 storage_amount_per_byte: 100_000_000_000_000_000_000
 storage_num_bytes_account: 100
 storage_num_extra_bytes_record: 40
+storage_contract_code_burnt_amount_per_byte: 0
 
 # Static action costs:
 # send_sir / send_not_sir is burned when creating a receipt on the signer shard

--- a/core/parameters/src/config.rs
+++ b/core/parameters/src/config.rs
@@ -81,6 +81,10 @@ impl RuntimeConfig {
     pub fn storage_amount_per_byte(&self) -> Balance {
         self.fees.storage_usage_config.storage_amount_per_byte
     }
+
+    pub fn storage_burnt_amount_per_byte(&self) -> Balance {
+        self.fees.storage_usage_config.storage_contract_code_burnt_amount_per_byte
+    }
 }
 
 /// The structure describes configuration for creation of new accounts.

--- a/core/parameters/src/config_store.rs
+++ b/core/parameters/src/config_store.rs
@@ -48,6 +48,7 @@ static CONFIG_DIFFS: &[(ProtocolVersion, &str)] = &[
     // Introduce ETH-implicit accounts.
     (70, include_config!("70.yaml")),
     (129, include_config!("129.yaml")),
+    (145, include_config!("145.yaml")),
 ];
 
 /// Testnet parameters for versions <= 29, which (incorrectly) differed from mainnet parameters

--- a/core/parameters/src/cost.rs
+++ b/core/parameters/src/cost.rs
@@ -428,6 +428,9 @@ pub struct StorageUsageConfig {
     pub num_bytes_account: u64,
     /// Additional number of bytes for a k/v record
     pub num_extra_bytes_record: u64,
+    /// Amount of yN per byte required to permanently deploy one byte of contract code.
+    /// This amount is burned when a permanent contract is deployed.
+    pub storage_contract_code_burnt_amount_per_byte: Balance,
 }
 
 impl RuntimeFeesConfig {
@@ -553,11 +556,17 @@ impl StorageUsageConfig {
             num_bytes_account: 100,
             num_extra_bytes_record: 40,
             storage_amount_per_byte: 909 * 100_000_000_000_000_000,
+            storage_contract_code_burnt_amount_per_byte: 100_000_000_000_000_000_000,
         }
     }
 
     pub(crate) fn free() -> StorageUsageConfig {
-        Self { num_bytes_account: 0, num_extra_bytes_record: 0, storage_amount_per_byte: 0 }
+        Self {
+            num_bytes_account: 0,
+            num_extra_bytes_record: 0,
+            storage_amount_per_byte: 0,
+            storage_contract_code_burnt_amount_per_byte: 0,
+        }
     }
 }
 

--- a/core/parameters/src/parameter.rs
+++ b/core/parameters/src/parameter.rs
@@ -49,6 +49,7 @@ pub enum Parameter {
     StorageAmountPerByte,
     StorageNumBytesAccount,
     StorageNumExtraBytesRecord,
+    StorageContractCodeBurntAmountPerByte,
 
     // Static action costs
     // send_sir / send_not_sir is burned when creating a receipt on the signer shard.

--- a/core/parameters/src/parameter_table.rs
+++ b/core/parameters/src/parameter_table.rs
@@ -302,6 +302,8 @@ impl TryFrom<&ParameterTable> for RuntimeConfig {
                     storage_amount_per_byte: params.get(Parameter::StorageAmountPerByte)?,
                     num_bytes_account: params.get(Parameter::StorageNumBytesAccount)?,
                     num_extra_bytes_record: params.get(Parameter::StorageNumExtraBytesRecord)?,
+                    storage_contract_code_burnt_amount_per_byte: params
+                        .get(Parameter::StorageContractCodeBurntAmountPerByte)?,
                 },
             }),
             wasm_config: Arc::new(Config {

--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -38,6 +38,7 @@ protocol_feature_fix_staking_threshold = []
 protocol_feature_fix_contract_loading_cost = []
 protocol_feature_reject_blocks_with_outdated_protocol_version = []
 protocol_feature_nonrefundable_transfer_nep491 = []
+protocol_feature_global_contracts = []
 
 nightly = [
   "nightly_protocol",
@@ -45,6 +46,7 @@ nightly = [
   "protocol_feature_fix_staking_threshold",
   "protocol_feature_nonrefundable_transfer_nep491",
   "protocol_feature_reject_blocks_with_outdated_protocol_version",
+  "protocol_feature_global_contracts"
 ]
 
 nightly_protocol = [

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -20,6 +20,7 @@ pub type BlockHeight = u64;
 pub type EpochHeight = u64;
 /// Shard index, from 0 to NUM_SHARDS - 1.
 pub type ShardId = u64;
+pub const GLOBAL_SHARD_ID: ShardId = ShardId::MAX;
 /// Balance is type for storing amounts of tokens.
 pub type Balance = u128;
 /// Gas is a type for storing amount of gas.

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -167,6 +167,8 @@ pub enum ProtocolFeature {
     // Include a bitmap of endorsements from chunk validator in the block header
     // in order to calculate the rewards and kickouts for the chunk validators.
     ChunkEndorsementsInBlockHeader,
+    /// Introduce permanently stored contract code
+    GlobalContracts,
 }
 
 impl ProtocolFeature {
@@ -241,6 +243,7 @@ impl ProtocolFeature {
             ProtocolFeature::ShuffleShardAssignments => 143,
             ProtocolFeature::ChunkEndorsementV2 => 144,
             ProtocolFeature::ChunkEndorsementsInBlockHeader => 145,
+            ProtocolFeature::GlobalContracts => 145,
         }
     }
 

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -70,6 +70,10 @@ protocol_feature_nonrefundable_transfer_nep491 = [
   "near-primitives-core/protocol_feature_nonrefundable_transfer_nep491",
 ]
 
+protocol_feature_global_contracts = [
+  "near-primitives-core/protocol_feature_global_contracts",
+]
+
 nightly = [
   "near-fmt/nightly",
   "near-parameters/nightly",
@@ -80,6 +84,7 @@ nightly = [
   "protocol_feature_fix_staking_threshold",
   "protocol_feature_nonrefundable_transfer_nep491",
   "protocol_feature_reject_blocks_with_outdated_protocol_version",
+  "protocol_feature_global_contracts",
 ]
 
 nightly_protocol = [
@@ -91,9 +96,7 @@ nightly_protocol = [
 
 calimero_zero_storage = []
 
-protocol_schema = [
-  "near-schema-checker-lib/protocol_schema",
-]
+protocol_schema = ["near-schema-checker-lib/protocol_schema"]
 
 [dev-dependencies]
 chrono = { workspace = true, features = ["clock"] }

--- a/core/primitives/benches/serialization.rs
+++ b/core/primitives/benches/serialization.rs
@@ -79,6 +79,7 @@ fn create_block() -> Block {
         &signer.into(),
         CryptoHash::default(),
         CryptoHash::default(),
+        CryptoHash::default(),
         Clock::real(),
         None,
     )

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -160,6 +160,7 @@ fn genesis_chunk(
         &[],
         CryptoHash::default(),
         congestion_info,
+        vec![],
         &crate::validator_signer::EmptyValidatorSigner::default().into(),
         genesis_protocol_version,
     )
@@ -297,6 +298,7 @@ impl Block {
         signer: &crate::validator_signer::ValidatorSigner,
         next_bp_hash: CryptoHash,
         block_merkle_root: CryptoHash,
+        global_shard_state_root: CryptoHash,
         clock: near_time::Clock,
         sandbox_delta_time: Option<near_time::Duration>,
     ) -> Self {
@@ -358,6 +360,9 @@ impl Block {
             BlockHeader::BlockHeaderV4(_) => {
                 debug_assert_eq!(prev.block_ordinal() + 1, block_ordinal)
             }
+            BlockHeader::BlockHeaderV5(_) => {
+                debug_assert_eq!(prev.block_ordinal() + 1, block_ordinal)
+            }
         };
 
         let body = BlockBody::new(
@@ -399,6 +404,7 @@ impl Block {
             block_merkle_root,
             prev.height(),
             clock,
+            global_shard_state_root,
         );
 
         Self::block_from_protocol_version(

--- a/core/primitives/src/block_header.rs
+++ b/core/primitives/src/block_header.rs
@@ -223,6 +223,64 @@ pub struct BlockHeaderInnerRestV4 {
     pub latest_protocol_version: ProtocolVersion,
 }
 
+/// Add `block_body_hash`
+#[derive(
+    BorshSerialize,
+    BorshDeserialize,
+    serde::Serialize,
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Default,
+    ProtocolSchema,
+)]
+pub struct BlockHeaderInnerRestV5 {
+    /// Hash of block body
+    pub block_body_hash: CryptoHash,
+    /// Root hash of the previous chunks' outgoing receipts in the given block.
+    pub prev_chunk_outgoing_receipts_root: MerkleHash,
+    /// Root hash of the chunk headers in the given block.
+    pub chunk_headers_root: MerkleHash,
+    /// Root hash of the chunk transactions in the given block.
+    pub chunk_tx_root: MerkleHash,
+    /// Root hash of the challenges in the given block.
+    pub challenges_root: MerkleHash,
+    /// The output of the randomness beacon
+    pub random_value: CryptoHash,
+    /// Validator proposals from the previous chunks.
+    pub prev_validator_proposals: Vec<ValidatorStake>,
+    /// Mask for new chunks included in the block
+    pub chunk_mask: Vec<bool>,
+    /// Gas price for chunks in the next block.
+    pub next_gas_price: Balance,
+    /// Total supply of tokens in the system
+    pub total_supply: Balance,
+    /// List of challenges result from previous block.
+    pub challenges_result: ChallengesResult,
+
+    /// Last block that has full BFT finality
+    pub last_final_block: CryptoHash,
+    /// Last block that has doomslug finality
+    pub last_ds_final_block: CryptoHash,
+
+    /// The ordinal of the Block on the Canonical Chain
+    pub block_ordinal: NumBlocks,
+
+    pub prev_height: BlockHeight,
+
+    /// Merkle root of all permanent contract hashes
+    pub global_contract_root: CryptoHash,
+
+    pub epoch_sync_data_hash: Option<CryptoHash>,
+
+    /// All the approvals included in this block
+    pub approvals: Vec<Option<Box<Signature>>>,
+
+    /// Latest protocol version that this block producer has.
+    pub latest_protocol_version: ProtocolVersion,
+}
+
 /// The part of the block approval that is different for endorsements and skips
 #[derive(
     BorshSerialize,
@@ -406,6 +464,35 @@ pub struct BlockHeaderV4 {
     pub hash: CryptoHash,
 }
 
+/// V4 -> V5: Add permanent_contracts_root to inner_rest
+#[derive(
+    BorshSerialize,
+    BorshDeserialize,
+    serde::Serialize,
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Default,
+    ProtocolSchema,
+)]
+#[borsh(init=init)]
+pub struct BlockHeaderV5 {
+    pub prev_hash: CryptoHash,
+
+    /// Inner part of the block header that gets hashed, split into two parts, one that is sent
+    ///    to light clients, and the rest
+    pub inner_lite: BlockHeaderInnerLite,
+    pub inner_rest: BlockHeaderInnerRestV5,
+
+    /// Signature of the block producer.
+    pub signature: Signature,
+
+    /// Cached value of hash for this block.
+    #[borsh(skip)]
+    pub hash: CryptoHash,
+}
+
 impl BlockHeaderV2 {
     pub fn init(&mut self) {
         self.hash = BlockHeader::compute_hash(
@@ -436,6 +523,16 @@ impl BlockHeaderV4 {
     }
 }
 
+impl BlockHeaderV5 {
+    pub fn init(&mut self) {
+        self.hash = BlockHeader::compute_hash(
+            self.prev_hash,
+            &borsh::to_vec(&self.inner_lite).expect("Failed to serialize"),
+            &borsh::to_vec(&self.inner_rest).expect("Failed to serialize"),
+        );
+    }
+}
+
 /// Versioned BlockHeader data structure.
 /// For each next version, document what are the changes between versions.
 #[derive(
@@ -446,6 +543,7 @@ pub enum BlockHeader {
     BlockHeaderV2(Arc<BlockHeaderV2>),
     BlockHeaderV3(Arc<BlockHeaderV3>),
     BlockHeaderV4(Arc<BlockHeaderV4>),
+    BlockHeaderV5(Arc<BlockHeaderV5>),
 }
 
 impl BlockHeader {
@@ -493,6 +591,7 @@ impl BlockHeader {
         block_merkle_root: CryptoHash,
         prev_height: BlockHeight,
         clock: near_time::Clock,
+        permanent_contracts_root: CryptoHash,
     ) -> Self {
         let inner_lite = BlockHeaderInnerLite {
             height,
@@ -509,6 +608,9 @@ impl BlockHeader {
         // So we still keep the old code here.
         let last_header_v2_version =
             crate::version::ProtocolFeature::BlockHeaderV3.protocol_version() - 1;
+
+        let last_header_v3_version =
+            crate::version::ProtocolFeature::BlockHeaderV4.protocol_version() - 1;
         // Previously we passed next_epoch_protocol_version here, which is incorrect, but we need
         // to preserve this for archival nodes
         if next_epoch_protocol_version <= 29 {
@@ -577,7 +679,7 @@ impl BlockHeader {
                 signature,
                 hash,
             }))
-        } else if !crate::checked_feature!("stable", BlockHeaderV4, this_epoch_protocol_version) {
+        } else if this_epoch_protocol_version <= last_header_v3_version {
             let inner_rest = BlockHeaderInnerRestV3 {
                 prev_chunk_outgoing_receipts_root,
                 chunk_headers_root,
@@ -612,7 +714,9 @@ impl BlockHeader {
                 signature,
                 hash,
             }))
-        } else {
+        } else if crate::checked_feature!("stable", BlockHeaderV4, this_epoch_protocol_version)
+            && !crate::checked_feature!("stable", GlobalContracts, this_epoch_protocol_version)
+        {
             let inner_rest = BlockHeaderInnerRestV4 {
                 block_body_hash,
                 prev_chunk_outgoing_receipts_root,
@@ -642,6 +746,43 @@ impl BlockHeader {
                 &borsh::to_vec(&inner_rest).expect("Failed to serialize"),
             );
             Self::BlockHeaderV4(Arc::new(BlockHeaderV4 {
+                prev_hash,
+                inner_lite,
+                inner_rest,
+                signature,
+                hash,
+            }))
+        } else {
+            let inner_rest = BlockHeaderInnerRestV5 {
+                block_body_hash,
+                prev_chunk_outgoing_receipts_root,
+                chunk_headers_root,
+                chunk_tx_root,
+                challenges_root,
+                random_value,
+                prev_validator_proposals,
+                chunk_mask,
+                next_gas_price,
+                block_ordinal,
+                total_supply,
+                challenges_result,
+                last_final_block,
+                last_ds_final_block,
+                prev_height,
+                epoch_sync_data_hash,
+                approvals,
+                latest_protocol_version: crate::version::get_protocol_version(
+                    next_epoch_protocol_version,
+                    clock,
+                ),
+                global_contract_root: permanent_contracts_root,
+            };
+            let (hash, signature) = signer.sign_block_header_parts(
+                prev_hash,
+                &borsh::to_vec(&inner_lite).expect("Failed to serialize"),
+                &borsh::to_vec(&inner_rest).expect("Failed to serialize"),
+            );
+            Self::BlockHeaderV5(Arc::new(BlockHeaderV5 {
                 prev_hash,
                 inner_lite,
                 inner_rest,
@@ -818,6 +959,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => &header.hash,
             BlockHeader::BlockHeaderV3(header) => &header.hash,
             BlockHeader::BlockHeaderV4(header) => &header.hash,
+            BlockHeader::BlockHeaderV5(header) => &header.hash,
         }
     }
 
@@ -828,6 +970,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => &header.prev_hash,
             BlockHeader::BlockHeaderV3(header) => &header.prev_hash,
             BlockHeader::BlockHeaderV4(header) => &header.prev_hash,
+            BlockHeader::BlockHeaderV5(header) => &header.prev_hash,
         }
     }
 
@@ -838,6 +981,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => &header.signature,
             BlockHeader::BlockHeaderV3(header) => &header.signature,
             BlockHeader::BlockHeaderV4(header) => &header.signature,
+            BlockHeader::BlockHeaderV5(header) => &header.signature,
         }
     }
 
@@ -848,6 +992,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => header.inner_lite.height,
             BlockHeader::BlockHeaderV3(header) => header.inner_lite.height,
             BlockHeader::BlockHeaderV4(header) => header.inner_lite.height,
+            BlockHeader::BlockHeaderV5(header) => header.inner_lite.height,
         }
     }
 
@@ -858,6 +1003,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(_) => None,
             BlockHeader::BlockHeaderV3(header) => Some(header.inner_rest.prev_height),
             BlockHeader::BlockHeaderV4(header) => Some(header.inner_rest.prev_height),
+            BlockHeader::BlockHeaderV5(header) => Some(header.inner_rest.prev_height),
         }
     }
 
@@ -868,6 +1014,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => &header.inner_lite.epoch_id,
             BlockHeader::BlockHeaderV3(header) => &header.inner_lite.epoch_id,
             BlockHeader::BlockHeaderV4(header) => &header.inner_lite.epoch_id,
+            BlockHeader::BlockHeaderV5(header) => &header.inner_lite.epoch_id,
         }
     }
 
@@ -878,6 +1025,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => &header.inner_lite.next_epoch_id,
             BlockHeader::BlockHeaderV3(header) => &header.inner_lite.next_epoch_id,
             BlockHeader::BlockHeaderV4(header) => &header.inner_lite.next_epoch_id,
+            BlockHeader::BlockHeaderV5(header) => &header.inner_lite.next_epoch_id,
         }
     }
 
@@ -888,6 +1036,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => &header.inner_lite.prev_state_root,
             BlockHeader::BlockHeaderV3(header) => &header.inner_lite.prev_state_root,
             BlockHeader::BlockHeaderV4(header) => &header.inner_lite.prev_state_root,
+            BlockHeader::BlockHeaderV5(header) => &header.inner_lite.prev_state_root,
         }
     }
 
@@ -906,6 +1055,9 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV4(header) => {
                 &header.inner_rest.prev_chunk_outgoing_receipts_root
             }
+            BlockHeader::BlockHeaderV5(header) => {
+                &header.inner_rest.prev_chunk_outgoing_receipts_root
+            }
         }
     }
 
@@ -916,6 +1068,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => &header.inner_rest.chunk_headers_root,
             BlockHeader::BlockHeaderV3(header) => &header.inner_rest.chunk_headers_root,
             BlockHeader::BlockHeaderV4(header) => &header.inner_rest.chunk_headers_root,
+            BlockHeader::BlockHeaderV5(header) => &header.inner_rest.chunk_headers_root,
         }
     }
 
@@ -926,6 +1079,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => &header.inner_rest.chunk_tx_root,
             BlockHeader::BlockHeaderV3(header) => &header.inner_rest.chunk_tx_root,
             BlockHeader::BlockHeaderV4(header) => &header.inner_rest.chunk_tx_root,
+            BlockHeader::BlockHeaderV5(header) => &header.inner_rest.chunk_tx_root,
         }
     }
 
@@ -935,6 +1089,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => &header.inner_rest.chunk_mask,
             BlockHeader::BlockHeaderV3(header) => &header.inner_rest.chunk_mask,
             BlockHeader::BlockHeaderV4(header) => &header.inner_rest.chunk_mask,
+            BlockHeader::BlockHeaderV5(header) => &header.inner_rest.chunk_mask,
         };
         mask.iter().map(|&x| u64::from(x)).sum::<u64>()
     }
@@ -946,6 +1101,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => &header.inner_rest.challenges_root,
             BlockHeader::BlockHeaderV3(header) => &header.inner_rest.challenges_root,
             BlockHeader::BlockHeaderV4(header) => &header.inner_rest.challenges_root,
+            BlockHeader::BlockHeaderV5(header) => &header.inner_rest.challenges_root,
         }
     }
 
@@ -956,6 +1112,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => &header.inner_lite.prev_outcome_root,
             BlockHeader::BlockHeaderV3(header) => &header.inner_lite.prev_outcome_root,
             BlockHeader::BlockHeaderV4(header) => &header.inner_lite.prev_outcome_root,
+            BlockHeader::BlockHeaderV5(header) => &header.inner_lite.prev_outcome_root,
         }
     }
 
@@ -966,6 +1123,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(_) => None,
             BlockHeader::BlockHeaderV3(_) => None,
             BlockHeader::BlockHeaderV4(header) => Some(header.inner_rest.block_body_hash),
+            BlockHeader::BlockHeaderV5(header) => Some(header.inner_rest.block_body_hash),
         }
     }
 
@@ -976,6 +1134,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => header.inner_lite.timestamp,
             BlockHeader::BlockHeaderV3(header) => header.inner_lite.timestamp,
             BlockHeader::BlockHeaderV4(header) => header.inner_lite.timestamp,
+            BlockHeader::BlockHeaderV5(header) => header.inner_lite.timestamp,
         }
     }
 
@@ -994,6 +1153,9 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV4(header) => {
                 ValidatorStakeIter::new(&header.inner_rest.prev_validator_proposals)
             }
+            BlockHeader::BlockHeaderV5(header) => {
+                ValidatorStakeIter::new(&header.inner_rest.prev_validator_proposals)
+            }
         }
     }
 
@@ -1004,6 +1166,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => &header.inner_rest.chunk_mask,
             BlockHeader::BlockHeaderV3(header) => &header.inner_rest.chunk_mask,
             BlockHeader::BlockHeaderV4(header) => &header.inner_rest.chunk_mask,
+            BlockHeader::BlockHeaderV5(header) => &header.inner_rest.chunk_mask,
         }
     }
 
@@ -1014,6 +1177,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(_) => 0, // not applicable
             BlockHeader::BlockHeaderV3(header) => header.inner_rest.block_ordinal,
             BlockHeader::BlockHeaderV4(header) => header.inner_rest.block_ordinal,
+            BlockHeader::BlockHeaderV5(header) => header.inner_rest.block_ordinal,
         }
     }
 
@@ -1024,6 +1188,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => header.inner_rest.next_gas_price,
             BlockHeader::BlockHeaderV3(header) => header.inner_rest.next_gas_price,
             BlockHeader::BlockHeaderV4(header) => header.inner_rest.next_gas_price,
+            BlockHeader::BlockHeaderV5(header) => header.inner_rest.next_gas_price,
         }
     }
 
@@ -1034,6 +1199,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => header.inner_rest.total_supply,
             BlockHeader::BlockHeaderV3(header) => header.inner_rest.total_supply,
             BlockHeader::BlockHeaderV4(header) => header.inner_rest.total_supply,
+            BlockHeader::BlockHeaderV5(header) => header.inner_rest.total_supply,
         }
     }
 
@@ -1044,6 +1210,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => &header.inner_rest.random_value,
             BlockHeader::BlockHeaderV3(header) => &header.inner_rest.random_value,
             BlockHeader::BlockHeaderV4(header) => &header.inner_rest.random_value,
+            BlockHeader::BlockHeaderV5(header) => &header.inner_rest.random_value,
         }
     }
 
@@ -1054,6 +1221,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => &header.inner_rest.last_final_block,
             BlockHeader::BlockHeaderV3(header) => &header.inner_rest.last_final_block,
             BlockHeader::BlockHeaderV4(header) => &header.inner_rest.last_final_block,
+            BlockHeader::BlockHeaderV5(header) => &header.inner_rest.last_final_block,
         }
     }
 
@@ -1064,6 +1232,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => &header.inner_rest.last_ds_final_block,
             BlockHeader::BlockHeaderV3(header) => &header.inner_rest.last_ds_final_block,
             BlockHeader::BlockHeaderV4(header) => &header.inner_rest.last_ds_final_block,
+            BlockHeader::BlockHeaderV5(header) => &header.inner_rest.last_ds_final_block,
         }
     }
 
@@ -1074,6 +1243,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => &header.inner_rest.challenges_result,
             BlockHeader::BlockHeaderV3(header) => &header.inner_rest.challenges_result,
             BlockHeader::BlockHeaderV4(header) => &header.inner_rest.challenges_result,
+            BlockHeader::BlockHeaderV5(header) => &header.inner_rest.challenges_result,
         }
     }
 
@@ -1084,6 +1254,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => &header.inner_lite.next_bp_hash,
             BlockHeader::BlockHeaderV3(header) => &header.inner_lite.next_bp_hash,
             BlockHeader::BlockHeaderV4(header) => &header.inner_lite.next_bp_hash,
+            BlockHeader::BlockHeaderV5(header) => &header.inner_lite.next_bp_hash,
         }
     }
 
@@ -1094,6 +1265,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => &header.inner_lite.block_merkle_root,
             BlockHeader::BlockHeaderV3(header) => &header.inner_lite.block_merkle_root,
             BlockHeader::BlockHeaderV4(header) => &header.inner_lite.block_merkle_root,
+            BlockHeader::BlockHeaderV5(header) => &header.inner_lite.block_merkle_root,
         }
     }
 
@@ -1104,6 +1276,18 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(_) => None,
             BlockHeader::BlockHeaderV3(header) => header.inner_rest.epoch_sync_data_hash,
             BlockHeader::BlockHeaderV4(header) => header.inner_rest.epoch_sync_data_hash,
+            BlockHeader::BlockHeaderV5(header) => header.inner_rest.epoch_sync_data_hash,
+        }
+    }
+
+    #[inline]
+    pub fn global_contract_root(&self) -> CryptoHash {
+        match self {
+            BlockHeader::BlockHeaderV1(_) => CryptoHash::default(),
+            BlockHeader::BlockHeaderV2(_) => CryptoHash::default(),
+            BlockHeader::BlockHeaderV3(_) => CryptoHash::default(),
+            BlockHeader::BlockHeaderV4(_) => CryptoHash::default(),
+            BlockHeader::BlockHeaderV5(header) => header.inner_rest.global_contract_root.clone(),
         }
     }
 
@@ -1114,6 +1298,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => &header.inner_rest.approvals,
             BlockHeader::BlockHeaderV3(header) => &header.inner_rest.approvals,
             BlockHeader::BlockHeaderV4(header) => &header.inner_rest.approvals,
+            BlockHeader::BlockHeaderV5(header) => &header.inner_rest.approvals,
         }
     }
 
@@ -1139,6 +1324,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(_header) => true,
             BlockHeader::BlockHeaderV3(_header) => true,
             BlockHeader::BlockHeaderV4(_header) => true,
+            BlockHeader::BlockHeaderV5(_header) => true,
         }
     }
 
@@ -1149,6 +1335,7 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV2(header) => header.inner_rest.latest_protocol_version,
             BlockHeader::BlockHeaderV3(header) => header.inner_rest.latest_protocol_version,
             BlockHeader::BlockHeaderV4(header) => header.inner_rest.latest_protocol_version,
+            BlockHeader::BlockHeaderV5(header) => header.inner_rest.latest_protocol_version,
         }
     }
 
@@ -1166,6 +1353,9 @@ impl BlockHeader {
             BlockHeader::BlockHeaderV4(header) => {
                 borsh::to_vec(&header.inner_lite).expect("Failed to serialize")
             }
+            BlockHeader::BlockHeaderV5(header) => {
+                borsh::to_vec(&header.inner_lite).expect("Failed to serialize")
+            }
         }
     }
 
@@ -1181,6 +1371,9 @@ impl BlockHeader {
                 borsh::to_vec(&header.inner_rest).expect("Failed to serialize")
             }
             BlockHeader::BlockHeaderV4(header) => {
+                borsh::to_vec(&header.inner_rest).expect("Failed to serialize")
+            }
+            BlockHeader::BlockHeaderV5(header) => {
                 borsh::to_vec(&header.inner_rest).expect("Failed to serialize")
             }
         }

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -586,6 +586,8 @@ pub enum ActionErrorKind {
     DelegateActionNonceTooLarge { delegate_nonce: Nonce, upper_bound: Nonce },
     /// Non-refundable storage transfer to an existing account is not allowed according to NEP-491.
     NonRefundableTransferToExistingAccount { account_id: AccountId },
+    /// An error occurs during the deployment of a contract. Currently only used for permanent contract deployment errors due to legacy reasons.
+    CompilationError { account_id: AccountId, err_msg: String },
 }
 
 impl From<ActionErrorKind> for ActionError {
@@ -931,6 +933,7 @@ impl Display for ActionErrorKind {
             ActionErrorKind::NonRefundableTransferToExistingAccount { account_id} => {
                 write!(f, "Can't make non-refundable storage transfer to {} because it already exists", account_id)
             }
+            ActionErrorKind::CompilationError { account_id, err_msg } => write!(f, "Error during contract deployment from account {}: {}", account_id, err_msg),
         }
     }
 }

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -361,6 +361,10 @@ impl ShardUId {
     pub fn shard_id(&self) -> ShardId {
         ShardId::from(self.shard_id)
     }
+
+    pub fn global() -> Self {
+        Self { version: 0, shard_id: u32::MAX }
+    }
 }
 
 impl TryFrom<&[u8]> for ShardUId {

--- a/core/primitives/src/stateless_validation/state_witness.rs
+++ b/core/primitives/src/stateless_validation/state_witness.rs
@@ -257,6 +257,7 @@ impl ChunkStateWitness {
             Default::default(),
             Default::default(),
             congestion_info,
+            vec![],
             &EmptyValidatorSigner::default().into(),
         ));
         Self::new(

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -2,7 +2,8 @@
 pub use crate::action::NonrefundableStorageTransferAction;
 pub use crate::action::{
     Action, AddKeyAction, CreateAccountAction, DeleteAccountAction, DeleteKeyAction,
-    DeployContractAction, FunctionCallAction, StakeAction, TransferAction,
+    DeployContractAction, DeployExistingContractAction, DeployPermanentContractAction,
+    FunctionCallAction, StakeAction, TransferAction,
 };
 use crate::errors::TxExecutionError;
 use crate::hash::{hash, CryptoHash};

--- a/core/store/benches/finalize_bench.rs
+++ b/core/store/benches/finalize_bench.rs
@@ -136,6 +136,7 @@ fn create_chunk_header(height: u64, shard_id: u64) -> ShardChunkHeader {
         CryptoHash::default(),
         vec![],
         congestion_info,
+        vec![],
         &validator_signer().into(),
     ))
 }
@@ -208,6 +209,7 @@ fn create_encoded_shard_chunk(
         Default::default(),
         Default::default(),
         congestion_info,
+        vec![],
         &validator_signer().into(),
         &rs,
         100,

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -639,11 +639,13 @@ impl StoreUpdate {
                         | DBOp::DeleteRange { .. } => None,
                     })
                     .collect::<Vec<_>>();
+                let non_refcount_keys_unique = non_refcount_keys.iter().collect::<std::collections::HashSet<_>>();
+                
                 non_refcount_keys.len()
-                    == non_refcount_keys.iter().collect::<std::collections::HashSet<_>>().len()
+                    == non_refcount_keys_unique.len()
             },
             "Transaction overwrites itself: {:?}",
-            self
+            self,
         );
         let span = tracing::Span::current();
         if !span.is_disabled() {

--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -120,9 +120,10 @@ impl TestTriesBuilder {
             panic!("In-memory tries require flat storage");
         }
         let store = self.store.unwrap_or_else(create_test_store);
-        let shard_uids = (0..self.num_shards)
+        let mut shard_uids = (0..self.num_shards)
             .map(|shard_id| ShardUId { shard_id: shard_id as u32, version: self.shard_version })
             .collect::<Vec<_>>();
+        shard_uids.push(ShardUId::global());
         let flat_storage_manager = FlatStorageManager::new(store.clone());
         let tries = ShardTries::new(
             store.clone(),
@@ -174,6 +175,7 @@ impl TestTriesBuilder {
                 0,
                 0,
                 congestion_info,
+                vec![]
             );
             let mut update_for_chunk_extra = store.store_update();
             for shard_uid in &shard_uids {

--- a/core/store/src/trie/global.rs
+++ b/core/store/src/trie/global.rs
@@ -1,0 +1,48 @@
+use near_primitives::{errors::StorageError, hash::CryptoHash, types::AccountId};
+
+use crate::Trie;
+
+pub struct GlobalShard(Trie);
+
+impl GlobalShard {
+    pub fn new(trie: Trie) -> Self {
+        Self(trie)
+    }
+
+    pub fn trie(self) -> Trie {
+        self.0
+    }
+
+    pub fn get(&self, key: &GlobalTrieKey) -> Result<Option<Vec<u8>>, StorageError> {
+        self.0.get(&key.to_vec())
+    }
+
+    pub fn contains_key(&self, key: &GlobalTrieKey) -> Result<bool, StorageError> {
+        self.0.contains_key(&key.to_vec())
+    }
+}
+
+pub enum GlobalTrieKey {
+    /// Account -> Contract hash
+    Account { account_id: AccountId },
+    /// Contract hash -> Contract code
+    ContractHash { hash: CryptoHash },
+}
+
+impl GlobalTrieKey {
+    /// Convert trie key to a byte array with a prefix that indicates the type of the key.
+    pub fn to_vec(&self) -> Vec<u8> {
+        match self {
+            GlobalTrieKey::Account { account_id } => {
+                let mut res = vec![0];
+                res.extend_from_slice(account_id.as_bytes());
+                res
+            },
+            GlobalTrieKey::ContractHash { hash } =>  {
+                let mut res = vec![1];
+                res.extend_from_slice(hash.as_ref());
+                res
+            }
+        }
+    }
+}

--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -583,6 +583,7 @@ mod tests {
             0,
             0,
             congestion_info,
+            vec![]
         );
         let mut store_update = store.store_update();
         store_update

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -62,6 +62,7 @@ mod trie_storage;
 #[cfg(test)]
 mod trie_tests;
 pub mod update;
+pub mod global;
 
 const POISONED_LOCK_ERR: &str = "The lock was poisoned.";
 

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -590,9 +590,11 @@ impl WrappedTrieChanges {
 
             // Resharding changes must not be finalized, however they may be introduced here when we are
             // evaluating changes for resharding in process_resharding_results function
+            // We also do not persist global state updates because global shard is write only and no GC is needed
+            // Since the primary reason for persisting state changes is to GC properly, we can skip these changes
             change_with_trie_key
                 .changes
-                .retain(|change| change.cause != StateChangeCause::Resharding);
+                .retain(|change| change.cause != StateChangeCause::Resharding && change.cause != StateChangeCause::GlobalStateUpdate);
             if change_with_trie_key.changes.is_empty() {
                 continue;
             }

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -359,6 +359,7 @@ mod trie_recording_tests {
             0,
             0,
             congestion_info,
+            vec![],
         );
         let mut update_for_chunk_extra = tries_for_building.store_update();
         update_for_chunk_extra

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -53,7 +53,6 @@ pub struct TrieUpdate {
     committed: RawStateChanges,
     prospective: TrieUpdates,
 }
-
 pub enum TrieUpdateValuePtr<'a> {
     Ref(&'a Trie, OptimizedValueRef),
     MemoryRef(&'a [u8]),

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -260,7 +260,7 @@ impl GenesisBuilder {
         store_update
             .save_block_header(genesis.header().clone())
             .expect("save genesis block header shouldn't fail");
-        store_update.save_block(genesis.clone());
+        store_update.save_block(genesis.clone()).unwrap();
 
         let protocol_version = self.genesis.config.protocol_version;
         for (chunk_header, &state_root) in genesis.chunks().iter().zip(self.roots.values()) {
@@ -283,6 +283,7 @@ impl GenesisBuilder {
                     self.genesis.config.gas_limit,
                     0,
                     congestion_info,
+                    vec![],
                 ),
             );
         }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -100,6 +100,10 @@ protocol_feature_reject_blocks_with_outdated_protocol_version = [
 protocol_feature_nonrefundable_transfer_nep491 = [
   "near-primitives/protocol_feature_nonrefundable_transfer_nep491",
 ]
+protocol_feature_global_contracts = [
+  "near-primitives/protocol_feature_global_contracts",
+  "node-runtime/protocol_feature_global_contracts",
+]
 
 nightly = [
   "near-actix-test-utils/nightly",
@@ -130,6 +134,7 @@ nightly = [
   "protocol_feature_fix_contract_loading_cost",
   "protocol_feature_nonrefundable_transfer_nep491",
   "protocol_feature_reject_blocks_with_outdated_protocol_version",
+  "protocol_feature_global_contracts",
   "testlib/nightly",
 ]
 nightly_protocol = [

--- a/integration-tests/src/node/runtime_node.rs
+++ b/integration-tests/src/node/runtime_node.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, RwLock};
 use near_chain_configs::Genesis;
 use near_crypto::{InMemorySigner, KeyType, Signer};
 use near_parameters::{RuntimeConfig, RuntimeConfigStore};
+use near_primitives::hash::CryptoHash;
 use near_primitives::types::AccountId;
 use testlib::runtime_utils::{add_test_contract, alice_account, bob_account, carol_account};
 
@@ -43,6 +44,7 @@ impl RuntimeNode {
             state_root: root,
             epoch_length: genesis.config.epoch_length,
             runtime_config,
+            global_shard_state_root: CryptoHash::default(),
         }));
         RuntimeNode { signer, client, genesis, account_id: account_id.clone() }
     }

--- a/integration-tests/src/test_loop/tests/congestion_control.rs
+++ b/integration-tests/src/test_loop/tests/congestion_control.rs
@@ -1,21 +1,17 @@
 use core::panic;
 
-use assert_matches::assert_matches;
 use itertools::Itertools;
 use near_async::test_loop::data::{TestLoopData, TestLoopDataHandle};
 use near_async::test_loop::TestLoopV2;
 use near_async::time::Duration;
 use near_chain_configs::test_genesis::TestGenesisBuilder;
 use near_client::client_actor::ClientActorInner;
-use near_client::Client;
 use near_o11y::testonly::init_test_logger;
-use near_primitives::hash::CryptoHash;
 use near_primitives::types::{AccountId, BlockHeight};
-use near_primitives::views::FinalExecutionStatus;
 
 use crate::test_loop::builder::TestLoopBuilder;
 use crate::test_loop::env::{TestData, TestLoopEnv};
-use crate::test_loop::utils::transactions::{call_contract, deploy_contract, get_node_data};
+use crate::test_loop::utils::transactions::{call_contract, check_txs, deploy_contract};
 use crate::test_loop::utils::ONE_NEAR;
 
 const NUM_PRODUCERS: usize = 2;
@@ -128,27 +124,6 @@ fn do_call_contract(
     check_txs(&*test_loop, node_datas, &rpc_id, &txs);
 }
 
-/// Check the status of the transactions and assert that they are successful.
-///
-/// Please note that it's important to use an rpc node that tracks all shards.
-/// Otherwise, the transactions may not be found.
-fn check_txs(
-    test_loop: &TestLoopV2,
-    node_datas: &Vec<TestData>,
-    rpc: &AccountId,
-    txs: &[CryptoHash],
-) {
-    let rpc = rpc_client(test_loop, node_datas, rpc);
-
-    for &tx in txs {
-        let tx_outcome = rpc.chain.get_partial_transaction_result(&tx);
-        let status = tx_outcome.as_ref().map(|o| o.status.clone());
-        let status = status.unwrap();
-        tracing::info!(target: "test", ?tx, ?status, "transaction status");
-        assert_matches!(status, FinalExecutionStatus::SuccessValue(_));
-    }
-}
-
 /// The condition that can be used for the test loop to wait until the chain
 /// height is greater than the target height.
 fn height_condition(
@@ -157,18 +132,6 @@ fn height_condition(
     target_height: BlockHeight,
 ) -> bool {
     test_loop_data.get(&client_handle).client.chain.head().unwrap().height > target_height
-}
-
-/// Get the client for the provided rpd node account id.
-fn rpc_client<'a>(
-    test_loop: &'a TestLoopV2,
-    node_datas: &'a Vec<TestData>,
-    rpc_id: &AccountId,
-) -> &'a Client {
-    let node_data = get_node_data(node_datas, rpc_id);
-    let client_actor_handle = node_data.client_sender.actor_handle();
-    let client_actor = test_loop.data.get(&client_actor_handle);
-    &client_actor.client
 }
 
 /// Make the account id for the provided index.

--- a/integration-tests/src/test_loop/tests/global_contract.rs
+++ b/integration-tests/src/test_loop/tests/global_contract.rs
@@ -1,0 +1,128 @@
+use itertools::Itertools;
+use near_async::test_loop::TestLoopV2;
+use near_async::time::Duration;
+use near_chain_configs::test_genesis::TestGenesisBuilder;
+use near_primitives::hash::CryptoHash;
+use near_primitives::types::{AccountId, Nonce};
+
+use crate::test_loop::builder::TestLoopBuilder;
+use crate::test_loop::env::{TestData, TestLoopEnv};
+use crate::test_loop::utils::transactions::{check_txs, deploy_permanent_contract};
+use crate::test_loop::utils::ONE_NEAR;
+
+const NUM_PRODUCERS: usize = 2;
+const NUM_VALIDATORS: usize = 2;
+const NUM_RPC: usize = 1;
+const NUM_CLIENTS: usize = NUM_PRODUCERS + NUM_VALIDATORS + NUM_RPC;
+
+fn setup(accounts: &Vec<AccountId>) -> (TestLoopEnv, AccountId) {
+    let initial_balance = 10000 * ONE_NEAR;
+    let clients = accounts.iter().take(NUM_CLIENTS).cloned().collect_vec();
+
+    // split the clients into producers, validators, and rpc nodes
+    let tmp = clients.clone();
+    let (producers, tmp) = tmp.split_at(NUM_PRODUCERS);
+    let (validators, tmp) = tmp.split_at(NUM_VALIDATORS);
+    let (rpcs, tmp) = tmp.split_at(NUM_RPC);
+    assert!(tmp.is_empty());
+
+    let producers = producers.iter().map(|account| account.as_str()).collect_vec();
+    let validators = validators.iter().map(|account| account.as_str()).collect_vec();
+    let [rpc_id] = rpcs else { panic!("Expected exactly one rpc node") };
+
+    let builder = TestLoopBuilder::new();
+    let mut genesis_builder = TestGenesisBuilder::new();
+    genesis_builder
+        .genesis_time_from_clock(&builder.clock())
+        .protocol_version_latest()
+        .genesis_height(10000)
+        .gas_prices_free()
+        .gas_limit_one_petagas()
+        .shard_layout_simple_v1(&["account0", "account1", "account2"])
+        .transaction_validity_period(1000)
+        .epoch_length(10)
+        .validators_desired_roles(&producers, &validators)
+        .shuffle_shard_assignment_for_chunk_producers(true);
+    for account in accounts {
+        genesis_builder.add_user_account_simple(account.clone(), initial_balance);
+    }
+    let genesis = genesis_builder.build();
+
+    let env = builder.genesis(genesis).clients(clients).build();
+    (env, rpc_id.clone())
+}
+
+#[test]
+fn test_permanent_contracts_root() {
+    // init_integration_logger();
+    let accounts =
+        (0..10).map(|i| format!("account{}", i).parse().unwrap()).collect::<Vec<AccountId>>();
+    let (env, rpc_id) = setup(&accounts);
+    let contract_id = "account0".parse().unwrap();
+    let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } = env;
+
+    let code = near_test_contracts::rs_contract();
+
+    let mut nonce = 1;
+    do_deploy_permanent_contract(
+        &mut test_loop,
+        &node_datas,
+        &rpc_id,
+        &contract_id,
+        code.to_vec(),
+        nonce,
+    );
+    nonce += 1;
+    let client_handle = node_datas[0].client_sender.actor_handle();
+    let block = test_loop.data.get(&client_handle).client.chain.get_head_block().unwrap();
+    let root1 = block.header().global_contract_root();
+    assert_ne!(root1, CryptoHash::default());
+    // deploy another contract and check that the root is updated
+    let new_code = near_test_contracts::ft_contract();
+    do_deploy_permanent_contract(
+        &mut test_loop,
+        &node_datas,
+        &rpc_id,
+        &contract_id,
+        new_code.to_vec(),
+        nonce,
+    );
+    nonce += 1;
+
+    let block = test_loop.data.get(&client_handle).client.chain.get_head_block().unwrap();
+    let root2 = block.header().global_contract_root();
+    assert_ne!(root1, root2);
+    // deploy the same contract again. This time the root should not change
+    do_deploy_permanent_contract(
+        &mut test_loop,
+        &node_datas,
+        &rpc_id,
+        &contract_id,
+        new_code.to_vec(),
+        nonce,
+    );
+    let block = test_loop.data.get(&client_handle).client.chain.get_head_block().unwrap();
+    let root3 = block.header().global_contract_root();
+    assert_eq!(root2, root3);
+
+    // Give the test a chance to finish off remaining events in the event loop, which can
+    // be important for properly shutting down the nodes.
+    TestLoopEnv { test_loop, datas: node_datas, tempdir }
+        .shutdown_and_drain_remaining_events(Duration::seconds(20));
+}
+
+/// Deploy a permanent contract and wait until the transaction is executed.
+fn do_deploy_permanent_contract(
+    test_loop: &mut TestLoopV2,
+    node_datas: &Vec<TestData>,
+    rpc_id: &AccountId,
+    contract_id: &AccountId,
+    contract_code: Vec<u8>,
+    nonce: Nonce,
+) {
+    tracing::info!(target: "test", ?rpc_id, ?contract_id, "Deploying contract.");
+    let tx =
+        deploy_permanent_contract(test_loop, node_datas, rpc_id, contract_id, contract_code, nonce);
+    test_loop.run_for(Duration::seconds(3));
+    check_txs(&*test_loop, node_datas, rpc_id, &[tx]);
+}

--- a/integration-tests/src/test_loop/tests/mod.rs
+++ b/integration-tests/src/test_loop/tests/mod.rs
@@ -9,3 +9,5 @@ pub mod multinode_test_loop_example;
 pub mod simple_test_loop_example;
 pub mod syncing;
 pub mod view_requests_to_archival_node;
+#[cfg(feature = "protocol_feature_global_contracts")]
+mod global_contract;

--- a/integration-tests/src/tests/client/block_corruption.rs
+++ b/integration-tests/src/tests/client/block_corruption.rs
@@ -71,6 +71,7 @@ fn change_shard_id_to_invalid() {
                 ShardChunkHeaderInner::V1(inner) => inner.shard_id = 100,
                 ShardChunkHeaderInner::V2(inner) => inner.shard_id = 100,
                 ShardChunkHeaderInner::V3(inner) => inner.shard_id = 100,
+                ShardChunkHeaderInner::V4(inner) => inner.shard_id = 100,
             },
         };
         new_chunks.push(new_chunk);

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -115,6 +115,7 @@ fn test_verify_block_double_sign_challenge() {
         &signer,
         *b1.header().next_bp_hash(),
         block_merkle_tree.root(),
+        CryptoHash::default(),
         Clock::real(),
         None,
     );
@@ -383,6 +384,7 @@ fn test_verify_chunk_invalid_state_challenge() {
         last_block.chunks()[0].prev_outgoing_receipts_root(),
         CryptoHash::default(),
         congestion_info,
+        vec![],
         &validator_signer,
         &rs,
         PROTOCOL_VERSION,
@@ -438,6 +440,7 @@ fn test_verify_chunk_invalid_state_challenge() {
         &validator_signer,
         *last_block.header().next_bp_hash(),
         block_merkle_tree.root(),
+        CryptoHash::default(),
         Clock::real(),
         None,
     );

--- a/integration-tests/src/tests/client/features.rs
+++ b/integration-tests/src/tests/client/features.rs
@@ -11,6 +11,8 @@ mod delegate_action;
 mod fix_contract_loading_cost;
 mod fix_storage_usage;
 mod flat_storage;
+#[cfg(feature = "protocol_feature_global_contracts")]
+mod global_contract;
 mod in_memory_tries;
 mod increase_deployment_cost;
 mod increase_storage_compute_cost;

--- a/integration-tests/src/tests/client/features/global_contract.rs
+++ b/integration-tests/src/tests/client/features/global_contract.rs
@@ -1,0 +1,68 @@
+use near_chain::Provenance;
+use near_chain_configs::Genesis;
+use near_client::{test_utils::TestEnv, ProcessTxResponse};
+use near_crypto::{InMemorySigner, KeyType};
+use near_primitives::{hash::CryptoHash, transaction::SignedTransaction};
+use nearcore::test_utils::TestEnvNightshadeSetupExt;
+
+/// Test that in case there is a fork, the global contract root is properly maintained
+#[test]
+fn test_global_contract_fork_simple() {
+    let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
+    let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
+    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
+    assert_eq!(genesis_block.header().global_contract_root(), CryptoHash::default());
+
+    let signer =
+        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let code = near_test_contracts::rs_contract();
+    let tx = SignedTransaction::deploy_permanent_contract(
+        1,
+        &"test0".parse().unwrap(),
+        code.to_vec(),
+        &signer,
+        *genesis_block.hash(),
+    );
+
+    let res = env.clients[0].process_tx(tx, false, false);
+    assert!(matches!(res, ProcessTxResponse::ValidTx));
+    let mut next_height = 1;
+    env.produce_block(0, next_height);
+    next_height += 1;
+    let block1 = env.clients[0].produce_block(next_height).unwrap().unwrap();
+    let block2 = env.clients[0].produce_block(next_height + 1).unwrap().unwrap();
+    env.process_block(0, block1, Provenance::PRODUCED);
+    env.process_block(0, block2, Provenance::PRODUCED);
+    for height in 4..7 {
+        env.produce_block(0, height);
+    }
+    let head = env.clients[0].chain.head().unwrap();
+    let block = env.clients[0].chain.get_block_by_height(head.height).unwrap();
+    let root = block.header().global_contract_root();
+    assert_ne!(root, CryptoHash::default());
+    
+    
+    let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1").into();
+
+    let tx = SignedTransaction::deploy_permanent_contract(
+        1,
+        &"test1".parse().unwrap(),
+        code.to_vec(),
+        &signer,
+        head.last_block_hash,
+    );
+    let res = env.clients[0].process_tx(tx, false, false);
+    assert!(matches!(res, ProcessTxResponse::ValidTx));
+    for height in head.height + 1 ..head.height + 3 {
+        env.produce_block(0, height);
+    }
+    let new_block = env.clients[0].produce_block_on(head.height + 3, head.last_block_hash).unwrap().unwrap();
+    env.process_block(0, new_block, Provenance::PRODUCED);
+    for height in head.height + 4..head.height + 7 {
+        env.produce_block(0, height);
+    }
+    let head = env.clients[0].chain.head().unwrap();
+    let block = env.clients[0].chain.get_block_by_height(head.height).unwrap();
+    assert_ne!(block.header().global_contract_root(), root);
+
+}

--- a/integration-tests/src/tests/client/features/orphan_chunk_state_witness.rs
+++ b/integration-tests/src/tests/client/features/orphan_chunk_state_witness.rs
@@ -266,6 +266,7 @@ fn test_orphan_witness_far_from_head() {
         ShardChunkHeaderInner::V1(inner) => inner.height_created = bad_height,
         ShardChunkHeaderInner::V2(inner) => inner.height_created = bad_height,
         ShardChunkHeaderInner::V3(inner) => inner.height_created = bad_height,
+        ShardChunkHeaderInner::V4(inner) => inner.height_created = bad_height,
     });
 
     let outcome =

--- a/integration-tests/src/tests/client/features/zero_balance_account.rs
+++ b/integration-tests/src/tests/client/features/zero_balance_account.rs
@@ -128,6 +128,7 @@ fn test_zero_balance_account_add_key() {
         storage_amount_per_byte: 10u128.pow(19),
         num_bytes_account: 100,
         num_extra_bytes_record: 40,
+        storage_contract_code_burnt_amount_per_byte: 0,
     };
     let wasm_config = Arc::make_mut(&mut runtime_config.wasm_config);
     wasm_config.ext_costs = ExtCostsConfig::test();

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -349,6 +349,7 @@ fn receive_network_block() {
                 &signer,
                 last_block.header.next_bp_hash,
                 block_merkle_tree.root(),
+                CryptoHash::default(),
                 Clock::real(),
                 None,
             );
@@ -436,6 +437,7 @@ fn produce_block_with_approvals() {
                 &signer1,
                 last_block.header.next_bp_hash,
                 block_merkle_tree.root(),
+                CryptoHash::default(),
                 Clock::real(),
                 None,
             );
@@ -651,6 +653,7 @@ fn invalid_blocks_common(is_requested: bool) {
                 &signer,
                 last_block.header.next_bp_hash,
                 block_merkle_tree.root(),
+                CryptoHash::default(),
                 Clock::real(),
                 None,
             );
@@ -1173,6 +1176,7 @@ fn test_bad_orphan() {
                 ShardChunkHeaderInner::V1(inner) => inner.prev_outcome_root = CryptoHash([1; 32]),
                 ShardChunkHeaderInner::V2(inner) => inner.prev_outcome_root = CryptoHash([1; 32]),
                 ShardChunkHeaderInner::V3(inner) => inner.prev_outcome_root = CryptoHash([1; 32]),
+                ShardChunkHeaderInner::V4(inner) => inner.prev_outcome_root = CryptoHash([1; 32]),
             }
             chunk.hash = ShardChunkHeaderV3::compute_hash(&chunk.inner);
         }
@@ -1883,7 +1887,7 @@ fn test_gc_tail_update() {
     env.clients[1].chain.save_block(prev_sync_block.into()).unwrap();
     let mut store_update = env.clients[1].chain.mut_chain_store().store_update();
     store_update.inc_block_refcount(&prev_sync_hash).unwrap();
-    store_update.save_block(sync_block.clone());
+    store_update.save_block(sync_block.clone()).unwrap();
     store_update.commit().unwrap();
     env.clients[1]
         .chain

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -58,6 +58,7 @@ nightly_protocol = [
   "testlib/nightly_protocol",
 ]
 protocol_feature_nonrefundable_transfer_nep491 = []
+protocol_feature_global_contracts = ["near-primitives/protocol_feature_global_contracts"]
 no_cpu_compatibility_checks = ["near-vm-runner/no_cpu_compatibility_checks"]
 
 no_cache = [

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -31,6 +31,7 @@ use near_primitives::types::{
 use near_primitives::utils::create_receipt_id_from_transaction;
 use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_store::test_utils::TestTriesBuilder;
+use near_store::trie::global::GlobalShard;
 use near_store::trie::receipts_column_helper::ShardsOutgoingReceiptBuffer;
 use near_store::{get_account, set_access_key, set_account, ShardTries, Trie};
 use near_vm_runner::FilesystemContractRuntimeCache;
@@ -111,9 +112,11 @@ fn setup_runtime_for_shard(
 fn test_apply_no_op() {
     let (runtime, tries, root, apply_state, _, epoch_info_provider) =
         setup_runtime(to_yocto(1_000_000), 0, 10u64.pow(15));
+    let global_shard_state = tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default());
     runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            GlobalShard::new(global_shard_state),
             &None,
             &apply_state,
             &[],
@@ -143,6 +146,7 @@ fn test_apply_check_balance_validation_rewards() {
     runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &Some(validator_accounts_update),
             &apply_state,
             &[Receipt::new_balance_refund(
@@ -175,6 +179,9 @@ fn test_apply_refund_receipts() {
         let apply_result = runtime
             .apply(
                 tries.get_trie_for_shard(ShardUId::single_shard(), root),
+                GlobalShard::new(
+                    tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default()),
+                ),
                 &None,
                 &apply_state,
                 prev_receipts,
@@ -214,6 +221,9 @@ fn test_apply_delayed_receipts_feed_all_at_once() {
         let apply_result = runtime
             .apply(
                 tries.get_trie_for_shard(ShardUId::single_shard(), root),
+                GlobalShard::new(
+                    tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default()),
+                ),
                 &None,
                 &apply_state,
                 prev_receipts,
@@ -258,6 +268,9 @@ fn test_apply_delayed_receipts_add_more_using_chunks() {
         let apply_result = runtime
             .apply(
                 tries.get_trie_for_shard(ShardUId::single_shard(), root),
+                GlobalShard::new(
+                    tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default()),
+                ),
                 &None,
                 &apply_state,
                 prev_receipts,
@@ -310,6 +323,9 @@ fn test_apply_delayed_receipts_adjustable_gas_limit() {
         let apply_result = runtime
             .apply(
                 tries.get_trie_for_shard(ShardUId::single_shard(), root),
+                GlobalShard::new(
+                    tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default()),
+                ),
                 &None,
                 &apply_state,
                 prev_receipts,
@@ -474,6 +490,7 @@ fn test_apply_delayed_receipts_local_tx() {
     let apply_result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &None,
             &apply_state,
             &receipts[0..2],
@@ -520,6 +537,7 @@ fn test_apply_delayed_receipts_local_tx() {
     let apply_result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &None,
             &apply_state,
             &receipts[2..3],
@@ -561,6 +579,7 @@ fn test_apply_delayed_receipts_local_tx() {
     let apply_result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &None,
             &apply_state,
             &receipts[3..4],
@@ -610,6 +629,7 @@ fn test_apply_delayed_receipts_local_tx() {
     let apply_result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &None,
             &apply_state,
             &receipts[4..5],
@@ -644,6 +664,7 @@ fn test_apply_delayed_receipts_local_tx() {
     let apply_result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &None,
             &apply_state,
             &receipts[5..6],
@@ -682,6 +703,7 @@ fn test_apply_deficit_gas_for_transfer() {
     let result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &None,
             &apply_state,
             &receipts,
@@ -735,6 +757,7 @@ fn test_apply_deficit_gas_for_function_call_covered() {
     let result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &None,
             &apply_state,
             &receipts,
@@ -798,6 +821,7 @@ fn test_apply_deficit_gas_for_function_call_partial() {
     let result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &None,
             &apply_state,
             &receipts,
@@ -834,6 +858,7 @@ fn test_delete_key_add_key() {
     let apply_result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &None,
             &apply_state,
             &receipts,
@@ -877,6 +902,7 @@ fn test_delete_key_underflow() {
     let apply_result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &None,
             &apply_state,
             &receipts,
@@ -990,6 +1016,7 @@ fn test_compute_usage_limit() {
     let apply_result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &None,
             &apply_state,
             &[
@@ -1017,6 +1044,7 @@ fn test_compute_usage_limit() {
     let apply_result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &None,
             &apply_state,
             &[],
@@ -1060,6 +1088,7 @@ fn test_compute_usage_limit_with_failed_receipt() {
     let apply_result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &None,
             &apply_state,
             &[deploy_contract_receipt.clone(), first_call_receipt.clone()],
@@ -1105,6 +1134,7 @@ fn test_main_storage_proof_size_soft_limit() {
     let apply_result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root).recording_reads(),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &None,
             &apply_state,
             &[create_acc_fn(alice_account()), create_acc_fn(bob_account())],
@@ -1136,6 +1166,7 @@ fn test_main_storage_proof_size_soft_limit() {
     let apply_result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root).recording_reads(),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &None,
             &apply_state,
             &[function_call_fn(alice_account()), function_call_fn(bob_account())],
@@ -1177,6 +1208,7 @@ fn test_empty_apply() {
     let apply_result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root_before),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &None,
             &apply_state,
             &receipts,
@@ -1208,6 +1240,7 @@ fn test_congestion_delayed_receipts_accounting() {
     let apply_result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &None,
             &apply_state,
             &receipts,
@@ -1290,6 +1323,9 @@ fn test_congestion_buffering() {
         let apply_result = runtime
             .apply(
                 tries.get_trie_for_shard(local_shard_uid, root),
+                GlobalShard::new(
+                    tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default()),
+                ),
                 &None,
                 &apply_state,
                 prev_receipts,
@@ -1351,6 +1387,9 @@ fn test_congestion_buffering() {
         let apply_result = runtime
             .apply(
                 tries.get_trie_for_shard(local_shard_uid, root),
+                GlobalShard::new(
+                    tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default()),
+                ),
                 &None,
                 &apply_state,
                 prev_receipts,
@@ -1434,6 +1473,7 @@ fn check_congestion_info_bootstrapping(is_new_chunk: bool, want: Option<Congesti
     let apply_result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &None,
             &apply_state,
             &[],
@@ -1498,6 +1538,7 @@ fn test_deploy_and_call_local_receipt() {
     let apply_result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &None,
             &apply_state,
             &[],
@@ -1569,6 +1610,7 @@ fn test_deploy_and_call_local_receipts() {
     let apply_result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
             &None,
             &apply_state,
             &[],
@@ -1593,4 +1635,39 @@ fn test_deploy_and_call_local_receipts() {
         action_error.kind,
         ActionErrorKind::FunctionCallError(FunctionCallError::MethodResolveError(_))
     );
+}
+
+#[test]
+#[cfg(feature = "protocol_feature_global_contracts")]
+fn test_deploy_invalid_global_contract() {
+    let (runtime, tries, root, apply_state, signer, epoch_info_provider) =
+        setup_runtime(to_yocto(1_000_000), to_yocto(500_000), 10u64.pow(15));
+
+    let code = vec![1, 2, 3, 4, 5];
+    let tx = SignedTransaction::deploy_permanent_contract(
+        1,
+        &alice_account(),
+        code,
+        &*signer,
+        CryptoHash::default(),
+    );
+
+    let apply_result = runtime
+        .apply(
+            tries.get_trie_for_shard(ShardUId::single_shard(), root),
+            GlobalShard::new(tries.get_trie_for_shard(ShardUId::global(), CryptoHash::default())),
+            &None,
+            &apply_state,
+            &[],
+            &[tx],
+            &epoch_info_provider,
+            Default::default(),
+        )
+        .unwrap();
+    let (o1, o2) = assert_matches!(
+        &apply_result.outcomes[..],
+        [ExecutionOutcomeWithId { id: _, outcome: o1 }, ExecutionOutcomeWithId { id: _, outcome: o2 }] => (o1, o2)
+    );
+    assert_matches!(o1.status, ExecutionStatus::SuccessReceiptId(_));
+    assert_matches!(o2.status, ExecutionStatus::Failure(TxExecutionError::ActionError(_)));
 }

--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -15,6 +15,7 @@ use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_primitives_core::account::id::AccountIdRef;
 use near_store::genesis::GenesisStateApplier;
 use near_store::test_utils::TestTriesBuilder;
+use near_store::trie::global::GlobalShard;
 use near_store::ShardTries;
 use node_runtime::{ApplyState, Runtime};
 use random_config::random_config;
@@ -40,6 +41,7 @@ pub struct StandaloneRuntime {
     pub tries: ShardTries,
     pub signer: InMemorySigner,
     pub root: CryptoHash,
+    pub global_state_root: CryptoHash,
     pub epoch_info_provider: MockEpochInfoProvider,
 }
 
@@ -131,6 +133,7 @@ impl StandaloneRuntime {
             signer,
             root,
             epoch_info_provider: MockEpochInfoProvider::default(),
+            global_state_root: CryptoHash::default(),
         }
     }
 
@@ -143,6 +146,9 @@ impl StandaloneRuntime {
             .runtime
             .apply(
                 self.tries.get_trie_for_shard(ShardUId::single_shard(), self.root),
+                GlobalShard::new(
+                    self.tries.get_trie_for_shard(ShardUId::global(), self.global_state_root),
+                ),
                 &None,
                 &self.apply_state,
                 receipts,

--- a/runtime/runtime/tests/runtime_group_tools/random_config.rs
+++ b/runtime/runtime/tests/runtime_group_tools/random_config.rs
@@ -18,6 +18,7 @@ pub fn random_config() -> RuntimeConfig {
                 num_bytes_account: rng.next_u64() % 10000,
                 num_extra_bytes_record: rng.next_u64() % 10000,
                 storage_amount_per_byte: rng.next_u64() as u128,
+                storage_contract_code_burnt_amount_per_byte: rng.next_u64() as u128,
             },
             burnt_gas_reward: Rational32::new((rng.next_u32() % 100).try_into().unwrap(), 100),
             pessimistic_gas_price_inflation_ratio: Rational32::new(

--- a/test-utils/testlib/src/process_blocks.rs
+++ b/test-utils/testlib/src/process_blocks.rs
@@ -67,6 +67,20 @@ pub fn set_no_chunk_in_block(block: &mut Block, prev_block: &Block) {
             header.inner_rest.total_supply += balance_burnt;
             header.inner_rest.block_body_hash = block_body_hash.unwrap();
         }
+        BlockHeader::BlockHeaderV5(header) => {
+            let header = Arc::make_mut(header);
+            header.inner_rest.chunk_headers_root =
+                Block::compute_chunk_headers_root(&chunk_headers).0;
+            header.inner_rest.chunk_tx_root = Block::compute_chunk_tx_root(&chunk_headers);
+            header.inner_rest.prev_chunk_outgoing_receipts_root =
+                Block::compute_chunk_prev_outgoing_receipts_root(&chunk_headers);
+            header.inner_lite.prev_state_root = Block::compute_state_root(&chunk_headers);
+            header.inner_lite.prev_outcome_root = Block::compute_outcome_root(&chunk_headers);
+            header.inner_rest.chunk_mask = vec![false];
+            header.inner_rest.next_gas_price = prev_block.header().next_gas_price();
+            header.inner_rest.total_supply += balance_burnt;
+            header.inner_rest.block_body_hash = block_body_hash.unwrap();
+        }
     }
     let validator_signer = create_test_signer("test0");
     block.mut_header().resign(&validator_signer);

--- a/tools/state-viewer/Cargo.toml
+++ b/tools/state-viewer/Cargo.toml
@@ -65,6 +65,9 @@ sandbox = [
 protocol_feature_nonrefundable_transfer_nep491 = [
   "near-primitives/protocol_feature_nonrefundable_transfer_nep491",
 ]
+protocol_feature_global_contracts = [
+  "near-primitives/protocol_feature_global_contracts",
+]
 
 nightly = [
   "near-chain-configs/nightly",
@@ -80,6 +83,7 @@ nightly = [
   "nightly_protocol",
   "node-runtime/nightly",
   "protocol_feature_nonrefundable_transfer_nep491",
+  "protocol_feature_global_contracts",
   "testlib/nightly",
 ]
 nightly_protocol = [

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -177,7 +177,7 @@ fn apply_block_from_range(
 
         runtime_adapter
             .apply_chunk(
-                storage.create_runtime_storage(*chunk_inner.prev_state_root()),
+                storage.create_runtime_storage(*chunk_inner.prev_state_root(), block.header().global_contract_root()),
                 ApplyChunkReason::UpdateTrackedShard,
                 ApplyChunkShardContext {
                     shard_id,
@@ -203,7 +203,7 @@ fn apply_block_from_range(
 
         runtime_adapter
             .apply_chunk(
-                storage.create_runtime_storage(*chunk_extra.state_root()),
+                storage.create_runtime_storage(*chunk_extra.state_root(), block.header().global_contract_root()),
                 ApplyChunkReason::UpdateTrackedShard,
                 ApplyChunkShardContext {
                     shard_id,
@@ -235,6 +235,7 @@ fn apply_block_from_range(
         genesis.config.gas_limit,
         apply_result.total_balance_burnt,
         apply_result.congestion_info,
+        apply_result.permanent_contracts_metadata.clone(),
     );
 
     let state_update =

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -132,10 +132,11 @@ pub(crate) fn apply_chunk(
         prev_block_hash,
         shard_id,
     )?;
+    let global_shard_state_root = chain_store.get_global_shard_state_root(&prev_block_hash)?;
 
     Ok((
         runtime.apply_chunk(
-            storage.create_runtime_storage(prev_state_root),
+            storage.create_runtime_storage(prev_state_root, global_shard_state_root),
             ApplyChunkReason::UpdateTrackedShard,
             ApplyChunkShardContext {
                 shard_id,
@@ -156,6 +157,7 @@ pub(crate) fn apply_chunk(
                 gas_price,
                 random_seed: hash("random seed".as_ref()),
                 congestion_info: prev_block.block_congestion_info(),
+                global_shard_state_root,
             },
             &receipts,
             transactions,

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -199,11 +199,19 @@ pub enum StorageSource {
 }
 
 impl StorageSource {
-    pub fn create_runtime_storage(&self, state_root: StateRoot) -> RuntimeStorageConfig {
+    pub fn create_runtime_storage(
+        &self,
+        state_root: StateRoot,
+        global_state_root: StateRoot,
+    ) -> RuntimeStorageConfig {
         match self {
-            StorageSource::Trie => RuntimeStorageConfig::new(state_root, false),
-            StorageSource::TrieFree => RuntimeStorageConfig::new_with_db_trie_only(state_root),
-            StorageSource::FlatStorage => RuntimeStorageConfig::new(state_root, true),
+            StorageSource::Trie => RuntimeStorageConfig::new(state_root, global_state_root, false),
+            StorageSource::TrieFree => {
+                RuntimeStorageConfig::new_with_db_trie_only(state_root, global_state_root)
+            }
+            StorageSource::FlatStorage => {
+                RuntimeStorageConfig::new(state_root, global_state_root, true)
+            }
         }
     }
 }

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -95,7 +95,7 @@ pub(crate) fn apply_block(
 
         runtime
             .apply_chunk(
-                storage.create_runtime_storage(*chunk_inner.prev_state_root()),
+                storage.create_runtime_storage(*chunk_inner.prev_state_root(), block.header().global_contract_root()),
                 ApplyChunkReason::UpdateTrackedShard,
                 ApplyChunkShardContext {
                     shard_id,
@@ -120,7 +120,7 @@ pub(crate) fn apply_block(
 
         runtime
             .apply_chunk(
-                storage.create_runtime_storage(*chunk_extra.state_root()),
+                storage.create_runtime_storage(*chunk_extra.state_root(), block.header().global_contract_root()),
                 ApplyChunkReason::UpdateTrackedShard,
                 ApplyChunkShardContext {
                     shard_id,

--- a/tools/state-viewer/src/contract_accounts.rs
+++ b/tools/state-viewer/src/contract_accounts.rs
@@ -136,6 +136,8 @@ pub(crate) enum ActionType {
     DeleteAccount,
     DataReceipt,
     Delegate,
+    #[cfg(feature = "protocol_feature_global_contracts")]
+    DeployPermanentContract,
 }
 
 impl ContractAccount {
@@ -348,6 +350,10 @@ fn try_find_actions_spawned_by_receipt(
                                     Action::DeleteKey(_) => ActionType::DeleteKey,
                                     Action::DeleteAccount(_) => ActionType::DeleteAccount,
                                     Action::Delegate(_) => ActionType::Delegate,
+                                    #[cfg(feature = "protocol_feature_global_contracts")]
+                                    Action::DeployPermanentContract(_) => {
+                                        ActionType::DeployPermanentContract
+                                    }
                                 };
                                 entry
                                     .actions

--- a/tools/state-viewer/src/util.rs
+++ b/tools/state-viewer/src/util.rs
@@ -105,10 +105,13 @@ fn chunk_extras_equal(l: &ChunkExtra, r: &ChunkExtra) -> bool {
         (ChunkExtra::V1(l), ChunkExtra::V1(r)) => return l == r,
         (ChunkExtra::V2(l), ChunkExtra::V2(r)) => return l == r,
         (ChunkExtra::V3(l), ChunkExtra::V3(r)) => return l == r,
+        (ChunkExtra::V4(l), ChunkExtra::V4(r)) => return l == r,
         (ChunkExtra::V1(_), ChunkExtra::V2(_))
         | (ChunkExtra::V2(_), ChunkExtra::V1(_))
         | (_, ChunkExtra::V3(_))
-        | (ChunkExtra::V3(_), _) => {}
+        | (ChunkExtra::V3(_), _) 
+        | (ChunkExtra::V4(_), _)
+        | (_, ChunkExtra::V4(_)) => {}
     };
     if l.state_root() != r.state_root() {
         return false;
@@ -146,6 +149,7 @@ pub fn resulting_chunk_extra(
         gas_limit,
         result.total_balance_burnt,
         result.congestion_info,
+        vec![]
     )
 }
 


### PR DESCRIPTION
A first step towards https://github.com/near/NEPs/issues/556. This PR implements the following:
* Global contract shard that stores account id -> global contract mapping. It uses the existing MPT state implementation with state root included in block headers.
* `DeployPermanentContractAction` that allows an account to deploy a global contract. The contract is immediately compiled upon deployment and only gets deployed if it can be compiled successfully.
* The logic of propagating the deployment information from runtime to chain to update global contract root and back from chain to runtime to charge properly for new transactions.

A few important things that are not implemented in this PR:
* `DeployExistingContractAction` which references a global contract
* The logic of actually propagating deployed global contract code across the network to each node.

This PR is light on testing because `DeployExistingContractAction` is not yet implemented and it is hard to test on the interface level as a result. Most of the testing focuses on whether global contract root is properly updated.