### PR TITLE
[Cherrypick to 2.2.2] feat: Mark PartialChunks as non-Cold column (#12105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 **No Changes**
 
 ### Non-protocol Changes
-**No Changes**
+* **Archival nodes only:** Stop saving partial chunks to `PartialChunks` column in the Cold DB. Instead, archival nodes will reconstruct partial chunks from the `Chunks` column.
 
 ## 2.1.0
 

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -436,8 +436,6 @@ impl DBCol {
             | DBCol::NextBlockHashes
             | DBCol::OutcomeIds
             | DBCol::OutgoingReceipts
-            // TODO can be changed to reconstruction on request instead of saving in cold storage.
-            | DBCol::PartialChunks
             | DBCol::Receipts
             | DBCol::State
             | DBCol::StateChanges
@@ -473,6 +471,8 @@ impl DBCol {
             DBCol::LatestWitnessesByIndex => false,
             // Deprecated.
             DBCol::_ReceiptIdToShardId => false,
+            // This can be re-constructed from the Chunks column, so no need to store in Cold DB.
+            DBCol::PartialChunks => false,
 
             // Columns that are not GC-ed need not be copied to the cold storage.
             DBCol::BlockHeader

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -7,7 +7,7 @@ use near_crypto::{InMemorySigner, KeyType, Signer};
 use near_epoch_manager::EpochManager;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::block::Tip;
-use near_primitives::sharding::{PartialEncodedChunk, ShardChunk};
+use near_primitives::sharding::ShardChunk;
 use near_primitives::transaction::{
     Action, DeployContractAction, FunctionCallAction, SignedTransaction,
 };
@@ -33,10 +33,6 @@ fn check_key(first_store: &Store, second_store: &Store, col: DBCol, key: &[u8]) 
 
     let first_res = first_store.get(col, key).unwrap();
     let second_res = second_store.get(col, key).unwrap();
-
-    if col == DBCol::PartialChunks {
-        tracing::debug!("{:?}", first_store.get_ser::<PartialEncodedChunk>(col, key));
-    }
 
     assert_eq!(first_res, second_res, "col: {:?} key: {:?}", col, pretty_key);
 }
@@ -172,15 +168,6 @@ fn test_storage_after_commit_of_cold_update() {
         }
         false
     }));
-    no_check_rules.push(Box::new(move |col, _key, value| -> bool {
-        if col == DBCol::PartialChunks {
-            let chunk = PartialEncodedChunk::try_from_slice(&*value).unwrap();
-            if *chunk.prev_block() == last_hash {
-                return true;
-            }
-        }
-        false
-    }));
     no_check_rules.push(Box::new(move |col, key, _value| -> bool {
         if col == DBCol::ChunkHashesByHeight {
             let height = u64::from_le_bytes(key[0..8].try_into().unwrap());
@@ -308,15 +295,6 @@ fn test_cold_db_copy_with_height_skips() {
     no_check_rules.push(Box::new(move |col, _key, value| -> bool {
         if col == DBCol::Chunks {
             let chunk = ShardChunk::try_from_slice(&*value).unwrap();
-            if *chunk.prev_block() == last_hash {
-                return true;
-            }
-        }
-        false
-    }));
-    no_check_rules.push(Box::new(move |col, _key, value| -> bool {
-        if col == DBCol::PartialChunks {
-            let chunk = PartialEncodedChunk::try_from_slice(&*value).unwrap();
             if *chunk.prev_block() == last_hash {
                 return true;
             }


### PR DESCRIPTION
This is re-submission of part of #12029, which was reverted in #12085.

In this PR, we only stop saving `PartialChunks` to Cold DB, BUT we dot yet clear the existing data in Cold DB. The clearing of the data will be implemented in separate PR, since the previous attempt #12029 had issues with large data size being not cleared.

PartialChunk is not needed for replaying the chain history and answering historical queries. It can be re-constructed from other information such as Chunks column. Thus, we remove it from Cold DB. This will save ~9 TB disk space for archival nodes
([dashboard](https://grafana.nearone.org/d/bdm279s7fsqgwc/disk-usage-stats?orgId=1&from=now-90d&to=now&var-chain_id=mainnet&var-node_id=rc-mainnet-canary-rpc-01-us-central1-a-2aaa0c29&var-disk_device=sdb&var-disk_mount_point=%2Fhome%2Fubuntu%2F.near%2Fdata&viewPanel=panel-18)).