### PR TITLE
(jsonrpc): Make trait `RpcRequest` a public and reimport `near_jsonrpc_primitives` as `primitives`

### DIFF
--- a/chain/jsonrpc/src/api/mod.rs
+++ b/chain/jsonrpc/src/api/mod.rs
@@ -22,7 +22,7 @@ mod status;
 mod transactions;
 mod validator;
 
-pub(crate) trait RpcRequest: Sized {
+pub trait RpcRequest: Sized {
     fn parse(value: Value) -> Result<Self, RpcParseError>;
 }
 

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -4,8 +4,7 @@ use actix_cors::Cors;
 use actix_web::http::header;
 use actix_web::HttpRequest;
 use actix_web::{get, http, middleware, web, App, Error as HttpError, HttpResponse, HttpServer};
-use api::RpcRequest;
-pub use api::{RpcFrom, RpcInto};
+pub use api::{RpcFrom, RpcInto, RpcRequest};
 use near_async::actix::ActixResult;
 use near_async::messaging::{
     AsyncSendError, AsyncSender, CanSend, MessageWithCallback, SendAsync, Sender,
@@ -19,6 +18,7 @@ use near_client::{
 };
 use near_client_primitives::types::GetSplitStorageInfo;
 pub use near_jsonrpc_client as client;
+pub use near_jsonrpc_primitives as primitives;
 use near_jsonrpc_primitives::errors::{RpcError, RpcErrorKind};
 use near_jsonrpc_primitives::message::{Message, Request};
 use near_jsonrpc_primitives::types::config::{RpcProtocolConfigError, RpcProtocolConfigResponse};


### PR DESCRIPTION
 This PR makes the `RpcRequest` trait public to allow for broader usage in external crates. Additionally, it re-imports `near_jsonrpc_primitives` as `primitives` to simplify references and improve code readability. This change is aimed at improving modularity and maintainability in the codebase.