### PR TITLE
feat(resharding) - Make shard ids non-contiguous

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4782,6 +4782,7 @@ dependencies = [
  "serde_repr",
  "sha2 0.10.6",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4782,7 +4782,6 @@ dependencies = [
  "serde_repr",
  "sha2 0.10.6",
  "thiserror",
- "tracing",
 ]
 
 [[package]]

--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -199,7 +199,7 @@ pub enum Error {
     InvalidBlockMerkleRoot,
     /// Invalid split shard ids.
     #[error("Invalid Split Shard Ids when resharding. shard_id: {0}, parent_shard_id: {1}")]
-    InvalidSplitShardsIds(u64, u64),
+    InvalidSplitShardsIds(ShardId, ShardId),
     /// Someone is not a validator. Usually happens in signature verification
     #[error("Not A Validator: {0}")]
     NotAValidator(String),

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3626,14 +3626,17 @@ impl Chain {
         let prev_chunk_headers =
             Chain::get_prev_chunk_headers(self.epoch_manager.as_ref(), prev_block)?;
 
+        let epoch_id = block.header().epoch_id();
+        let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
+
         let mut maybe_jobs = vec![];
-        for (chunk_header, prev_chunk_header) in
-            block.chunks().iter().zip(prev_chunk_headers.iter())
+        for (shard_index, (chunk_header, prev_chunk_header)) in
+            block.chunks().iter().zip(prev_chunk_headers.iter()).enumerate()
         {
             // XXX: This is a bit questionable -- sandbox state patching works
             // only for a single shard. This so far has been enough.
             let state_patch = state_patch.take();
-            let shard_id = chunk_header.shard_id();
+            let shard_id = shard_layout.get_shard_id(shard_index);
 
             let storage_context =
                 StorageContext { storage_data_source: StorageDataSource::Db, state_patch };

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3916,7 +3916,7 @@ impl Chain {
 
         // The upper bound shard id is not a valid ShardId. It should only be
         // used as a uppoer bound for the shard id in the database.
-        let upper_bound_shard_id = (shard_id.get() + 1).into();
+        let upper_bound_shard_id = (shard_id + 1).into();
         let upper_bound = StatePartKey(sync_hash, upper_bound_shard_id, 0);
         let upper_bound = borsh::to_vec(&upper_bound)?;
         let mut num_cached_parts = 0;
@@ -4558,7 +4558,7 @@ impl Chain {
         let prev_chunks = prev_block.chunks();
         Ok(prev_shard_ids
             .into_iter()
-            .map(|(shard_id, shard_index)| prev_chunks.get(shard_index).unwrap().clone())
+            .map(|(_, shard_index)| prev_chunks.get(shard_index).unwrap().clone())
             .collect())
     }
 

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1315,9 +1315,8 @@ impl Chain {
         let epoch_id = block.header().epoch_id();
         let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
 
-        for chunk_header in block.chunks().iter() {
-            let shard_id = chunk_header.shard_id();
-            let shard_index = shard_layout.get_shard_index(shard_id);
+        for (shard_index, chunk_header) in block.chunks().iter().enumerate() {
+            let shard_id = shard_layout.get_shard_id(shard_index);
             // Check if any chunks are invalid in this block.
             if let Some(encoded_chunk) =
                 self.chain_store.is_invalid_chunk(&chunk_header.chunk_hash())?
@@ -2483,7 +2482,6 @@ impl Chain {
         let chunks = sync_prev_block.chunks();
         let chunk_header =
             chunks.get(shard_index).ok_or_else(|| Error::InvalidShardId(shard_id))?;
-        debug_assert!(shard_id == chunk_header.shard_id());
         let (chunk_headers_root, chunk_proofs) = merklize(
             &sync_prev_block
                 .chunks()

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -822,9 +822,8 @@ impl Chain {
         let epoch_id = block.header().epoch_id();
         let shard_layout = epoch_manager.get_shard_layout(&epoch_id)?;
 
-        for chunk_header in block.chunks().iter() {
-            let shard_id = chunk_header.shard_id();
-            let shard_index = shard_layout.get_shard_index(shard_id);
+        for (shard_index, chunk_header) in block.chunks().iter().enumerate() {
+            let shard_id = shard_layout.get_shard_id(shard_index);
             if chunk_header.height_created() == genesis_block.header().height() {
                 // Special case: genesis chunks can be in non-genesis blocks and don't have a signature
                 // We must verify that content matches and signature is empty.

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1335,7 +1335,6 @@ impl Chain {
                 };
                 return Err(Error::InvalidChunkProofs(Box::new(chunk_proof)));
             }
-            let shard_id = shard_id;
             if chunk_header.is_new_chunk(block_height) {
                 let chunk_hash = chunk_header.chunk_hash();
 

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -613,23 +613,26 @@ impl Chain {
 
     pub fn genesis_chunk_extra(
         &self,
+        shard_layout: &ShardLayout,
         shard_id: ShardId,
         genesis_protocol_version: ProtocolVersion,
         congestion_info: Option<CongestionInfo>,
     ) -> Result<ChunkExtra, Error> {
-        let shard_index = shard_id as usize;
+        let shard_index = shard_layout.get_shard_index(shard_id);
         let state_root = *get_genesis_state_roots(self.chain_store.store())?
             .ok_or_else(|| Error::Other("genesis state roots do not exist in the db".to_owned()))?
             .get(shard_index)
             .ok_or_else(|| {
-                Error::Other(format!("genesis state root does not exist for shard {shard_index}"))
+                Error::Other(format!("genesis state root does not exist for shard id {shard_id} shard index {shard_index}"))
             })?;
         let gas_limit = self
             .genesis
             .chunks()
             .get(shard_index)
             .ok_or_else(|| {
-                Error::Other(format!("genesis chunk does not exist for shard {shard_index}"))
+                Error::Other(format!(
+                    "genesis chunk does not exist for shard {shard_id} shard index {shard_index}"
+                ))
             })?
             .gas_limit();
         Ok(Self::create_genesis_chunk_extra(
@@ -781,13 +784,16 @@ impl Chain {
             Ok(None)
         } else {
             debug!(target: "chain", "Downloading state for {:?}, I'm {:?}", shards_to_state_sync, me);
+            let epoch_id = block.header().epoch_id();
+            let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
 
             let state_sync_info = StateSyncInfo {
                 epoch_tail_hash: *block.header().hash(),
                 shards: shards_to_state_sync
                     .iter()
                     .map(|shard_id| {
-                        let chunk = &prev_block.chunks()[*shard_id as usize];
+                        let shard_index = shard_layout.get_shard_index(*shard_id);
+                        let chunk = &prev_block.chunks()[shard_index];
                         ShardInfo(*shard_id, chunk.chunk_hash())
                     })
                     .collect(),
@@ -813,14 +819,19 @@ impl Chain {
         genesis_block: &Block,
         block: &Block,
     ) -> Result<(), Error> {
-        for (shard_id, chunk_header) in block.chunks().iter().enumerate() {
+        let epoch_id = block.header().epoch_id();
+        let shard_layout = epoch_manager.get_shard_layout(&epoch_id)?;
+
+        for chunk_header in block.chunks().iter() {
+            let shard_id = chunk_header.shard_id();
+            let shard_index = shard_layout.get_shard_index(shard_id);
             if chunk_header.height_created() == genesis_block.header().height() {
                 // Special case: genesis chunks can be in non-genesis blocks and don't have a signature
                 // We must verify that content matches and signature is empty.
                 // TODO: this code will not work when genesis block has different number of chunks as the current block
                 // https://github.com/near/nearcore/issues/4908
                 let chunks = genesis_block.chunks();
-                let genesis_chunk = chunks.get(shard_id);
+                let genesis_chunk = chunks.get(shard_index);
                 let genesis_chunk = genesis_chunk.ok_or_else(|| {
                     Error::InvalidChunk(format!(
                         "genesis chunk not found for shard {}, genesis block has {} chunks",
@@ -842,7 +853,7 @@ impl Chain {
                     )));
                 }
             } else if chunk_header.height_created() == block.header().height() {
-                if chunk_header.shard_id() != shard_id as ShardId {
+                if chunk_header.shard_id() != shard_id {
                     return Err(Error::InvalidShardId(chunk_header.shard_id()));
                 }
                 if !epoch_manager.verify_chunk_header_signature(
@@ -1302,15 +1313,20 @@ impl Chain {
         }
         let mut missing = vec![];
         let block_height = block.header().height();
-        for (shard_id, chunk_header) in block.chunks().iter().enumerate() {
+
+        let epoch_id = block.header().epoch_id();
+        let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
+
+        for chunk_header in block.chunks().iter() {
+            let shard_id = chunk_header.shard_id();
+            let shard_index = shard_layout.get_shard_index(shard_id);
             // Check if any chunks are invalid in this block.
             if let Some(encoded_chunk) =
                 self.chain_store.is_invalid_chunk(&chunk_header.chunk_hash())?
             {
                 let merkle_paths = Block::compute_chunk_headers_root(block.chunks().iter()).1;
-                let merkle_proof = merkle_paths
-                    .get(shard_id)
-                    .ok_or_else(|| Error::InvalidShardId(shard_id as ShardId))?;
+                let merkle_proof =
+                    merkle_paths.get(shard_index).ok_or_else(|| Error::InvalidShardId(shard_id))?;
                 let chunk_proof = ChunkProofs {
                     block_header: borsh::to_vec(&block.header()).expect("Failed to serialize"),
                     merkle_proof: merkle_proof.clone(),
@@ -1320,7 +1336,7 @@ impl Chain {
                 };
                 return Err(Error::InvalidChunkProofs(Box::new(chunk_proof)));
             }
-            let shard_id = shard_id as ShardId;
+            let shard_id = shard_id;
             if chunk_header.is_new_chunk(block_height) {
                 let chunk_hash = chunk_header.chunk_hash();
 
@@ -1898,15 +1914,20 @@ impl Chain {
             height = block.header().height())
         .entered();
 
+        let epoch_id = block.header().epoch_id();
+        let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
+
         let prev_head = self.chain_store.head()?;
         let is_caught_up = block_preprocess_info.is_caught_up;
         let provenance = block_preprocess_info.provenance.clone();
         let block_start_processing_time = block_preprocess_info.block_start_processing_time;
         // TODO(#8055): this zip relies on the ordering of the apply_results.
+        // TODO(wacban): do the above todo
         for (shard_id, apply_result) in apply_results.iter() {
+            let shard_index = shard_layout.get_shard_index(*shard_id);
             if let Err(err) = apply_result {
                 if err.is_bad_data() {
-                    let chunk = block.chunks()[*shard_id as usize].clone();
+                    let chunk = block.chunks()[shard_index].clone();
                     block_processing_artifacts.invalid_chunks.push(chunk);
                 }
             }
@@ -1951,7 +1972,7 @@ impl Chain {
                 // during catchup of this block.
                 care_about_shard
             };
-            tracing::debug!(target: "chain", shard_id, need_storage_update, "Updating storage");
+            tracing::debug!(target: "chain", ?shard_id, need_storage_update, "Updating storage");
 
             if need_storage_update {
                 // TODO(#12019): consider adding to catchup flow.
@@ -2005,7 +2026,12 @@ impl Chain {
                 .as_seconds_f64()
                 .max(0.0),
         );
-        self.blocks_delay_tracker.finish_block_processing(&block_hash, new_head.clone());
+        let shard_layout = self.epoch_manager.get_shard_layout(epoch_id)?;
+        self.blocks_delay_tracker.finish_block_processing(
+            &shard_layout,
+            &block_hash,
+            new_head.clone(),
+        );
 
         timer.observe_duration();
         let _timer = CryptoHashTimer::new_with_start(
@@ -2444,12 +2470,17 @@ impl Chain {
         if sync_block_epoch_id == sync_prev_block.header().epoch_id() {
             return Err(sync_hash_not_first_hash(sync_hash));
         }
+
+        let epoch_id = sync_prev_block.header().epoch_id();
+        let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
+        let shard_index = shard_layout.get_shard_index(shard_id);
+
         // Chunk header here is the same chunk header as at the `current` height.
         let sync_prev_hash = sync_prev_block.hash();
         let chunks = sync_prev_block.chunks();
-        let chunk_header = chunks
-            .get(shard_id as usize)
-            .ok_or_else(|| Error::InvalidShardId(shard_id as ShardId))?;
+        let chunk_header =
+            chunks.get(shard_index).ok_or_else(|| Error::InvalidShardId(shard_id))?;
+        debug_assert!(shard_id == chunk_header.shard_id());
         let (chunk_headers_root, chunk_proofs) = merklize(
             &sync_prev_block
                 .chunks()
@@ -2462,10 +2493,8 @@ impl Chain {
         assert_eq!(&chunk_headers_root, sync_prev_block.header().chunk_headers_root());
 
         let chunk = self.get_chunk_clone_from_header(chunk_header)?;
-        let chunk_proof = chunk_proofs
-            .get(shard_id as usize)
-            .ok_or_else(|| Error::InvalidShardId(shard_id as ShardId))?
-            .clone();
+        let chunk_proof =
+            chunk_proofs.get(shard_index).ok_or_else(|| Error::InvalidShardId(shard_id))?.clone();
         let block_header =
             self.get_block_header_on_chain_by_height(&sync_hash, chunk_header.height_included())?;
 
@@ -2476,8 +2505,8 @@ impl Chain {
             Ok(prev_block) => {
                 let prev_chunk_header = prev_block
                     .chunks()
-                    .get(shard_id as usize)
-                    .ok_or_else(|| Error::InvalidShardId(shard_id as ShardId))?
+                    .get(shard_index)
+                    .ok_or_else(|| Error::InvalidShardId(shard_id))?
                     .clone();
                 let (prev_chunk_headers_root, prev_chunk_proofs) = merklize(
                     &prev_block
@@ -2491,8 +2520,8 @@ impl Chain {
                 assert_eq!(&prev_chunk_headers_root, prev_block.header().chunk_headers_root());
 
                 let prev_chunk_proof = prev_chunk_proofs
-                    .get(shard_id as usize)
-                    .ok_or_else(|| Error::InvalidShardId(shard_id as ShardId))?
+                    .get(shard_index)
+                    .ok_or_else(|| Error::InvalidShardId(shard_id))?
                     .clone();
                 let prev_chunk_height_included = prev_chunk_header.height_included();
 
@@ -2543,18 +2572,18 @@ impl Chain {
                 let ReceiptProof(receipts, shard_proof) = receipt_proof;
                 let ShardProof { from_shard_id, to_shard_id: _, proof } = shard_proof;
                 let receipts_hash = CryptoHash::hash_borsh(ReceiptList(shard_id, receipts));
-                let from_shard_id = *from_shard_id as usize;
+                let from_shard_index = shard_layout.get_shard_index(*from_shard_id);
 
-                let root_proof = block.chunks()[from_shard_id].prev_outgoing_receipts_root();
+                let root_proof = block.chunks()[from_shard_index].prev_outgoing_receipts_root();
                 root_proofs_cur
-                    .push(RootProof(root_proof, block_receipts_proofs[from_shard_id].clone()));
+                    .push(RootProof(root_proof, block_receipts_proofs[from_shard_index].clone()));
 
                 // Make sure we send something reasonable.
                 assert_eq!(block_header.prev_chunk_outgoing_receipts_root(), &block_receipts_root);
                 assert!(verify_path(root_proof, proof, &receipts_hash));
                 assert!(verify_path(
                     block_receipts_root,
-                    &block_receipts_proofs[from_shard_id],
+                    &block_receipts_proofs[from_shard_index],
                     &root_proof,
                 ));
             }
@@ -2627,7 +2656,7 @@ impl Chain {
         let _span = tracing::debug_span!(
             target: "sync",
             "get_state_response_part",
-            shard_id,
+            ?shard_id,
             part_id,
             ?sync_hash)
         .entered();
@@ -2642,6 +2671,7 @@ impl Chain {
             .log_storage_error("block has already been checked for existence")?;
         let header = block.header();
         let epoch_id = block.header().epoch_id();
+        let shard_layout = self.epoch_manager.get_shard_layout(epoch_id)?;
         let shard_ids = self.epoch_manager.shard_ids(epoch_id)?;
         if !shard_ids.contains(&shard_id) {
             return Err(shard_id_out_of_bounds(shard_id));
@@ -2650,10 +2680,11 @@ impl Chain {
         if epoch_id == prev_block.header().epoch_id() {
             return Err(sync_hash_not_first_hash(sync_hash));
         }
+        let shard_index = shard_layout.get_shard_index(shard_id);
         let state_root = prev_block
             .chunks()
-            .get(shard_id as usize)
-            .ok_or_else(|| Error::InvalidShardId(shard_id as ShardId))?
+            .get(shard_index)
+            .ok_or_else(|| Error::InvalidShardId(shard_id))?
             .prev_state_root();
         let prev_hash = *prev_block.hash();
         let prev_prev_hash = *prev_block.header().prev_hash();
@@ -3100,9 +3131,14 @@ impl Chain {
     ) -> Result<(), Error> {
         if !validate_transactions_order(chunk.transactions()) {
             let merkle_paths = Block::compute_chunk_headers_root(block.chunks().iter()).1;
+            let epoch_id = block.header().epoch_id();
+            let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
+            let shard_id = chunk.shard_id();
+            let shard_index = shard_layout.get_shard_index(shard_id);
+
             let chunk_proof = ChunkProofs {
                 block_header: borsh::to_vec(&block.header()).expect("Failed to serialize"),
-                merkle_proof: merkle_paths[chunk.shard_id() as usize].clone(),
+                merkle_proof: merkle_paths[shard_index].clone(),
                 chunk: MaybeEncodedShardChunk::Decoded(chunk.clone()).into(),
             };
             return Err(Error::InvalidChunkProofs(Box::new(chunk_proof)));
@@ -3418,12 +3454,14 @@ impl Chain {
         block: &Block,
         chunk_header: &ShardChunkHeader,
     ) -> Result<ChunkState, Error> {
-        let chunk_shard_id = chunk_header.shard_id();
+        let epoch_id = block.header().epoch_id();
+        let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
+        let shard_id = chunk_header.shard_id();
+        let shard_index = shard_layout.get_shard_index(shard_id);
         let prev_merkle_proofs = Block::compute_chunk_headers_root(prev_block.chunks().iter()).1;
         let merkle_proofs = Block::compute_chunk_headers_root(block.chunks().iter()).1;
-        let prev_chunk = self
-            .get_chunk_clone_from_header(&prev_block.chunks()[chunk_shard_id as usize].clone())
-            .unwrap();
+        let prev_chunk =
+            self.get_chunk_clone_from_header(&prev_block.chunks()[shard_index].clone()).unwrap();
 
         // TODO (#6316): enable storage proof generation
         // let prev_chunk_header = &prev_block.chunks()[chunk_shard_id as usize];
@@ -3474,8 +3512,8 @@ impl Chain {
         Ok(ChunkState {
             prev_block_header: borsh::to_vec(&prev_block.header())?,
             block_header: borsh::to_vec(&block.header())?,
-            prev_merkle_proof: prev_merkle_proofs[chunk_shard_id as usize].clone(),
-            merkle_proof: merkle_proofs[chunk_shard_id as usize].clone(),
+            prev_merkle_proof: prev_merkle_proofs[shard_index].clone(),
+            merkle_proof: merkle_proofs[shard_index].clone(),
             prev_chunk,
             chunk_header: chunk_header.clone(),
             partial_state: PartialState::TrieValues(vec![]),
@@ -3586,12 +3624,13 @@ impl Chain {
             Chain::get_prev_chunk_headers(self.epoch_manager.as_ref(), prev_block)?;
 
         let mut maybe_jobs = vec![];
-        for (shard_id, (chunk_header, prev_chunk_header)) in
-            block.chunks().iter().zip(prev_chunk_headers.iter()).enumerate()
+        for (chunk_header, prev_chunk_header) in
+            block.chunks().iter().zip(prev_chunk_headers.iter())
         {
             // XXX: This is a bit questionable -- sandbox state patching works
             // only for a single shard. This so far has been enough.
             let state_patch = state_patch.take();
+            let shard_id = chunk_header.shard_id();
 
             let storage_context =
                 StorageContext { storage_data_source: StorageDataSource::Db, state_patch };
@@ -3601,7 +3640,7 @@ impl Chain {
                 prev_block,
                 chunk_header,
                 prev_chunk_header,
-                shard_id as ShardId,
+                shard_id,
                 mode,
                 incoming_receipts,
                 storage_context,
@@ -3616,10 +3655,14 @@ impl Chain {
                 Ok(None) => {}
                 Err(err) => {
                     if err.is_bad_data() {
+                        let epoch_id = block.header().epoch_id();
+                        let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
+                        let shard_index = shard_layout.get_shard_index(shard_id);
+
                         let chunk_header = block
                             .chunks()
-                            .get(shard_id)
-                            .ok_or_else(|| Error::InvalidShardId(shard_id as ShardId))?
+                            .get(shard_index)
+                            .ok_or_else(|| Error::InvalidShardId(shard_id))?
                             .clone();
                         invalid_chunks.push(chunk_header);
                     }
@@ -3669,7 +3712,7 @@ impl Chain {
         prev_chunk_header: &ShardChunkHeader,
         shard_id: ShardId,
         mode: ApplyChunksMode,
-        incoming_receipts: &HashMap<u64, Vec<ReceiptProof>>,
+        incoming_receipts: &HashMap<ShardId, Vec<ReceiptProof>>,
         storage_context: StorageContext,
     ) -> Result<Option<UpdateShardJob>, Error> {
         let _span = tracing::debug_span!(target: "chain", "get_update_shard_job").entered();
@@ -3708,7 +3751,7 @@ impl Chain {
                         ?err,
                         prev_block_hash=?prev_hash,
                         block_hash=?block.header().hash(),
-                        shard_id,
+                        ?shard_id,
                         prev_chunk_height_included,
                         ?prev_chunk_extra,
                         ?chunk_header,
@@ -3870,7 +3913,11 @@ impl Chain {
         // DBCol::StateParts is keyed by StatePartKey: (BlockHash || ShardId || PartId (u64)).
         let lower_bound = StatePartKey(sync_hash, shard_id, 0);
         let lower_bound = borsh::to_vec(&lower_bound)?;
-        let upper_bound = StatePartKey(sync_hash, shard_id + 1, 0);
+
+        // The upper bound shard id is not a valid ShardId. It should only be
+        // used as a uppoer bound for the shard id in the database.
+        let upper_bound_shard_id = (shard_id.get() + 1).into();
+        let upper_bound = StatePartKey(sync_hash, upper_bound_shard_id, 0);
         let upper_bound = borsh::to_vec(&upper_bound)?;
         let mut num_cached_parts = 0;
         let mut bit_array = BitArray::new(num_parts);
@@ -3918,6 +3965,7 @@ fn get_genesis_congestion_infos_impl(
     let genesis_prev_hash = CryptoHash::default();
     let genesis_epoch_id = epoch_manager.get_epoch_id_from_prev_block(&genesis_prev_hash)?;
     let genesis_protocol_version = epoch_manager.get_epoch_protocol_version(&genesis_epoch_id)?;
+    let genesis_shard_layout = epoch_manager.get_shard_layout(&genesis_epoch_id)?;
     // If congestion control is not enabled at the genesis block, we return None (congestion info) for each shard.
     if !ProtocolFeature::CongestionControl.enabled(genesis_protocol_version) {
         return Ok(std::iter::repeat(None).take(state_roots.len()).collect());
@@ -3930,8 +3978,8 @@ fn get_genesis_congestion_infos_impl(
     }
 
     let mut new_infos = vec![];
-    for (shard_id, &state_root) in state_roots.iter().enumerate() {
-        let shard_id = shard_id as ShardId;
+    for (shard_index, &state_root) in state_roots.iter().enumerate() {
+        let shard_id = genesis_shard_layout.get_shard_id(shard_index);
         let congestion_info = get_genesis_congestion_info(
             runtime,
             genesis_protocol_version,
@@ -4353,9 +4401,9 @@ impl Chain {
             let block = self.get_block(&block_hash)?;
             let chunks = block.chunks();
             for &shard_id in shard_ids.iter() {
-                let chunk_header = &chunks
-                    .get(shard_id as usize)
-                    .ok_or_else(|| Error::InvalidShardId(shard_id as ShardId))?;
+                let shard_index = shard_layout.get_shard_index(shard_id);
+                let chunk_header =
+                    &chunks.get(shard_index).ok_or_else(|| Error::InvalidShardId(shard_id))?;
                 if chunk_header.height_included() == block.header().height() {
                     return Ok(Some((block_hash, shard_id)));
                 }
@@ -4505,11 +4553,17 @@ impl Chain {
     ) -> Result<Vec<ShardChunkHeader>, Error> {
         let epoch_id = epoch_manager.get_epoch_id_from_prev_block(prev_block.hash())?;
         let shard_ids = epoch_manager.shard_ids(&epoch_id)?;
+
+        let prev_epoch_id = prev_block.header().epoch_id();
+        let prev_shard_layout = epoch_manager.get_shard_layout(&prev_epoch_id)?;
         let prev_shard_ids = epoch_manager.get_prev_shard_ids(prev_block.hash(), shard_ids)?;
-        let chunks = prev_block.chunks();
+        let prev_chunks = prev_block.chunks();
         Ok(prev_shard_ids
             .into_iter()
-            .map(|shard_id| chunks.get(shard_id as usize).unwrap().clone())
+            .map(|shard_id| {
+                let shard_index = prev_shard_layout.get_shard_index(shard_id);
+                prev_chunks.get(shard_index).unwrap().clone()
+            })
             .collect())
     }
 
@@ -4518,10 +4572,13 @@ impl Chain {
         prev_block: &Block,
         shard_id: ShardId,
     ) -> Result<ShardChunkHeader, Error> {
+        let prev_epoch_id = prev_block.header().epoch_id();
+        let prev_shard_layout = epoch_manager.get_shard_layout(&prev_epoch_id)?;
         let prev_shard_id = epoch_manager.get_prev_shard_id(prev_block.hash(), shard_id)?;
+        let prev_shard_index = prev_shard_layout.get_shard_index(prev_shard_id);
         Ok(prev_block
             .chunks()
-            .get(prev_shard_id as usize)
+            .get(prev_shard_index)
             .ok_or(Error::InvalidShardId(shard_id))?
             .clone())
     }

--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -209,7 +209,7 @@ impl<'a> ChainUpdate<'a> {
         let prev_hash = block.header().prev_hash();
         let results = apply_chunks_results.into_iter().map(|(shard_id, x)| {
             if let Err(err) = &x {
-                warn!(target: "chain", shard_id, hash = %block.hash(), %err, "Error in applying chunk for block");
+                warn!(target: "chain", ?shard_id, hash = %block.hash(), %err, "Error in applying chunk for block");
             }
             x
         }).collect::<Result<Vec<_>, Error>>()?;
@@ -465,7 +465,7 @@ impl<'a> ChainUpdate<'a> {
         shard_state_header: ShardStateSyncResponseHeader,
     ) -> Result<ShardUId, Error> {
         let _span =
-            tracing::debug_span!(target: "sync", "chain_update_set_state_finalize", shard_id, ?sync_hash).entered();
+            tracing::debug_span!(target: "sync", "chain_update_set_state_finalize", ?shard_id, ?sync_hash).entered();
         let (chunk, incoming_receipts_proofs) = match shard_state_header {
             ShardStateSyncResponseHeader::V1(shard_state_header) => (
                 ShardChunk::V1(shard_state_header.chunk),
@@ -596,7 +596,7 @@ impl<'a> ChainUpdate<'a> {
         sync_hash: CryptoHash,
     ) -> Result<bool, Error> {
         let _span =
-            tracing::debug_span!(target: "sync", "set_state_finalize_on_height", height, shard_id)
+            tracing::debug_span!(target: "sync", "set_state_finalize_on_height", height, ?shard_id)
                 .entered();
         let block_header_result =
             self.chain_store_update.get_block_header_on_chain_by_height(&sync_hash, height);

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -587,7 +587,8 @@ impl<'a> ChainStoreUpdate<'a> {
         let height = block.header().height();
 
         // 2. Delete shard_id-indexed data (Receipts, State Headers and Parts, etc.)
-        for shard_id in 0..block.header().chunk_mask().len() as ShardId {
+        for chunk_header in block.chunks().iter() {
+            let shard_id = chunk_header.shard_id();
             let block_shard_id = get_block_shard_id(&block_hash, shard_id);
             self.gc_outgoing_receipts(&block_hash, shard_id);
             self.gc_col(DBCol::IncomingReceipts, &block_shard_id);
@@ -682,7 +683,8 @@ impl<'a> ChainStoreUpdate<'a> {
         let head_height = block.header().height();
 
         // 1. Delete shard_id-indexed data (TrieChanges, Receipts, ChunkExtra, State Headers and Parts, FlatStorage data)
-        for shard_id in 0..block.header().chunk_mask().len() as ShardId {
+        for chunk_header in block.chunks().iter() {
+            let shard_id = chunk_header.shard_id();
             let shard_uid = epoch_manager.shard_id_to_uid(shard_id, epoch_id).unwrap();
             let block_shard_id = get_block_shard_uid(&block_hash, &shard_uid);
 

--- a/chain/chain/src/migrations.rs
+++ b/chain/chain/src/migrations.rs
@@ -29,7 +29,7 @@ pub fn check_if_block_is_first_with_chunk_of_version(
     if is_first_epoch_with_protocol_version(epoch_manager, prev_block_hash)? {
         // Compare only epochs because we already know that current epoch is the first one with current protocol version
         // convert shard id to shard id of previous epoch because number of shards may change
-        let shard_id = epoch_manager.get_prev_shard_ids(prev_block_hash, vec![shard_id])?[0];
+        let (shard_id, _) = epoch_manager.get_prev_shard_ids(prev_block_hash, vec![shard_id])?[0];
         let prev_epoch_id = chain_store.get_epoch_id_of_last_block_with_chunk(
             epoch_manager,
             prev_block_hash,

--- a/chain/chain/src/runtime/migrations.rs
+++ b/chain/chain/src/runtime/migrations.rs
@@ -33,6 +33,7 @@ mod tests {
     use near_mainnet_res::mainnet_restored_receipts;
     use near_mainnet_res::mainnet_storage_usage_delta;
     use near_primitives::hash::hash;
+    use near_primitives::types::new_shard_id_tmp;
 
     #[test]
     fn test_migration_data() {
@@ -55,7 +56,10 @@ mod tests {
             "48ZMJukN7RzvyJSW9MJ5XmyQkQFfjy2ZxPRaDMMHqUcT"
         );
         let mainnet_migration_data = load_migration_data(near_primitives::chains::MAINNET);
-        assert_eq!(mainnet_migration_data.restored_receipts.get(&0.into()).unwrap().len(), 383);
+        assert_eq!(
+            mainnet_migration_data.restored_receipts.get(&new_shard_id_tmp(0)).unwrap().len(),
+            383
+        );
         let testnet_migration_data = load_migration_data(near_primitives::chains::TESTNET);
         assert!(testnet_migration_data.restored_receipts.is_empty());
     }

--- a/chain/chain/src/runtime/migrations.rs
+++ b/chain/chain/src/runtime/migrations.rs
@@ -55,7 +55,7 @@ mod tests {
             "48ZMJukN7RzvyJSW9MJ5XmyQkQFfjy2ZxPRaDMMHqUcT"
         );
         let mainnet_migration_data = load_migration_data(near_primitives::chains::MAINNET);
-        assert_eq!(mainnet_migration_data.restored_receipts.get(&0u64).unwrap().len(), 383);
+        assert_eq!(mainnet_migration_data.restored_receipts.get(&0.into()).unwrap().len(), 383);
         let testnet_migration_data = load_migration_data(near_primitives::chains::TESTNET);
         assert!(testnet_migration_data.restored_receipts.is_empty());
     }

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -219,7 +219,7 @@ impl NightshadeRuntime {
             epoch_manager.get_epoch_id_from_prev_block(prev_hash).map_err(Error::from)?;
         let shard_version =
             epoch_manager.get_shard_layout(&epoch_id).map_err(Error::from)?.version();
-        Ok(ShardUId { version: shard_version, shard_id: shard_id as u32 })
+        Ok(ShardUId { version: shard_version, shard_id: shard_id.into() })
     }
 
     fn get_shard_uid_from_epoch_id(
@@ -230,7 +230,7 @@ impl NightshadeRuntime {
         let epoch_manager = self.epoch_manager.read();
         let shard_version =
             epoch_manager.get_shard_layout(epoch_id).map_err(Error::from)?.version();
-        Ok(ShardUId { version: shard_version, shard_id: shard_id as u32 })
+        Ok(ShardUId { version: shard_version, shard_id: shard_id.into() })
     }
 
     fn account_id_to_shard_uid(
@@ -562,7 +562,7 @@ impl NightshadeRuntime {
             target: "runtime",
             "obtain_state_part",
             part_id = part_id.idx,
-            shard_id,
+            ?shard_id,
             %prev_hash,
             num_parts = part_id.total)
         .entered();
@@ -949,7 +949,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         }
     }
 
-    #[instrument(target = "runtime", level = "info", skip_all, fields(shard_id = chunk.shard_id))]
+    #[instrument(target = "runtime", level = "info", skip_all, fields(shard_id = ?chunk.shard_id))]
     fn apply_chunk(
         &self,
         storage_config: RuntimeStorageConfig,
@@ -1187,7 +1187,7 @@ impl RuntimeAdapter for NightshadeRuntime {
             target: "runtime",
             "obtain_state_part",
             part_id = part_id.idx,
-            shard_id,
+            ?shard_id,
             %prev_hash,
             ?state_root,
             num_parts = part_id.total)
@@ -1365,7 +1365,7 @@ fn chunk_tx_gas_limit(
     protocol_version: u32,
     runtime_config: &RuntimeConfig,
     prev_block: &PrepareTransactionsBlockContext,
-    shard_id: u64,
+    shard_id: ShardId,
     gas_limit: u64,
 ) -> u64 {
     if !ProtocolFeature::CongestionControl.enabled(protocol_version) {

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -29,8 +29,8 @@ use near_primitives::state_part::PartId;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{
-    AccountId, Balance, BlockHeight, EpochHeight, EpochId, EpochInfoProvider, Gas, MerkleHash,
-    ShardId, StateChangeCause, StateRoot, StateRootNode,
+    new_shard_id_tmp, AccountId, Balance, BlockHeight, EpochHeight, EpochId, EpochInfoProvider,
+    Gas, MerkleHash, ShardId, StateChangeCause, StateRoot, StateRootNode,
 };
 use near_primitives::version::{ProtocolFeature, ProtocolVersion};
 use near_primitives::views::{
@@ -219,7 +219,7 @@ impl NightshadeRuntime {
             epoch_manager.get_epoch_id_from_prev_block(prev_hash).map_err(Error::from)?;
         let shard_version =
             epoch_manager.get_shard_layout(&epoch_id).map_err(Error::from)?.version();
-        Ok(ShardUId { version: shard_version, shard_id: shard_id.into() })
+        Ok(ShardUId { version: shard_version, shard_id: new_shard_id_tmp(shard_id) as u32 })
     }
 
     fn get_shard_uid_from_epoch_id(
@@ -230,7 +230,7 @@ impl NightshadeRuntime {
         let epoch_manager = self.epoch_manager.read();
         let shard_version =
             epoch_manager.get_shard_layout(epoch_id).map_err(Error::from)?.version();
-        Ok(ShardUId { version: shard_version, shard_id: shard_id.into() })
+        Ok(ShardUId { version: shard_version, shard_id: new_shard_id_tmp(shard_id) as u32 })
     }
 
     fn account_id_to_shard_uid(

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -214,12 +214,14 @@ impl TestEnv {
         // TODO(congestion_control): pass down prev block info and read congestion info from there
         // For now, just use default.
         let prev_block_hash = self.head.last_block_hash;
-        let state_root = self.state_roots[shard_id as usize];
+        let epoch_id =
+            self.epoch_manager.get_epoch_id_from_prev_block(&prev_block_hash).unwrap_or_default();
+        let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id).unwrap();
+        let shard_index = shard_layout.get_shard_index(shard_id);
+        let state_root = self.state_roots[shard_index];
         let gas_limit = u64::MAX;
         let height = self.head.height + 1;
         let block_timestamp = 0;
-        let epoch_id =
-            self.epoch_manager.get_epoch_id_from_prev_block(&prev_block_hash).unwrap_or_default();
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id).unwrap();
         let gas_price = self.runtime.genesis_config.min_gas_price;
         let congestion_info = if !ProtocolFeature::CongestionControl.enabled(protocol_version) {
@@ -316,19 +318,21 @@ impl TestEnv {
     ) {
         let new_hash = hash(&[(self.head.height + 1) as u8]);
         let shard_ids = self.epoch_manager.shard_ids(&self.head.epoch_id).unwrap();
+        let shard_layout = self.epoch_manager.get_shard_layout(&self.head.epoch_id).unwrap();
         assert_eq!(transactions.len(), shard_ids.len());
         assert_eq!(chunk_mask.len(), shard_ids.len());
         let mut all_proposals = vec![];
         let mut all_receipts = vec![];
         for shard_id in shard_ids {
+            let shard_index = shard_layout.get_shard_index(shard_id);
             let (state_root, proposals, receipts) = self.update_runtime(
                 shard_id,
                 new_hash,
-                &transactions[shard_id as usize],
+                &transactions[shard_index],
                 self.last_receipts.get(&shard_id).map_or(&[], |v| v.as_slice()),
                 challenges_result.clone(),
             );
-            self.state_roots[shard_id as usize] = state_root;
+            self.state_roots[shard_index] = state_root;
             all_receipts.extend(receipts);
             all_proposals.append(&mut proposals.clone());
             self.last_shard_proposals.insert(shard_id, proposals);
@@ -391,9 +395,11 @@ impl TestEnv {
             &self.head.epoch_id,
         )
         .unwrap();
+        let shard_layout = self.epoch_manager.get_shard_layout(&self.head.epoch_id).unwrap();
+        let shard_index = shard_layout.get_shard_index(shard_id);
         let shard_uid = self.epoch_manager.shard_id_to_uid(shard_id, &self.head.epoch_id).unwrap();
         self.runtime
-            .view_account(&shard_uid, self.state_roots[shard_id as usize], account_id)
+            .view_account(&shard_uid, self.state_roots[shard_index], account_id)
             .unwrap()
             .into()
     }
@@ -727,9 +733,10 @@ fn test_state_sync() {
     let block_hash = hash(&[env.head.height as u8]);
     let state_part = env
         .runtime
-        .obtain_state_part(0, &block_hash, &env.state_roots[0], PartId::new(0, 1))
+        .obtain_state_part(0.into(), &block_hash, &env.state_roots[0], PartId::new(0, 1))
         .unwrap();
-    let root_node = env.runtime.get_state_root_node(0, &block_hash, &env.state_roots[0]).unwrap();
+    let root_node =
+        env.runtime.get_state_root_node(0.into(), &block_hash, &env.state_roots[0]).unwrap();
     let mut new_env = TestEnv::new(vec![validators], 2, false);
     for i in 1..=2 {
         let prev_hash = hash(&[new_env.head.height as u8]);
@@ -786,7 +793,7 @@ fn test_state_sync() {
     let epoch_id = &new_env.head.epoch_id;
     new_env
         .runtime
-        .apply_state_part(0, &env.state_roots[0], PartId::new(0, 1), &state_part, epoch_id)
+        .apply_state_part(0.into(), &env.state_roots[0], PartId::new(0, 1), &state_part, epoch_id)
         .unwrap();
     new_env.state_roots[0] = env.state_roots[0];
     for _ in 3..=5 {
@@ -827,9 +834,9 @@ fn test_get_validator_info() {
             let height = env.head.height;
             let em = env.runtime.epoch_manager.read();
             let bp = em.get_block_producer_info(&epoch_id, height).unwrap();
-            let cp = em.get_chunk_producer_info(&epoch_id, height, 0).unwrap();
+            let cp = em.get_chunk_producer_info(&epoch_id, height, 0.into()).unwrap();
             let stateless_validators =
-                em.get_chunk_validator_assignments(&epoch_id, 0, height).ok();
+                em.get_chunk_validator_assignments(&epoch_id, 0.into(), height).ok();
 
             if let Some(vs) = stateless_validators {
                 if vs.contains(&validators[0]) {
@@ -876,7 +883,7 @@ fn test_get_validator_info() {
             public_key: block_producers[0].public_key(),
             is_slashed: false,
             stake: TESTING_INIT_STAKE,
-            shards: vec![0],
+            shards: vec![0.into()],
             num_produced_blocks: expected_blocks[0],
             num_expected_blocks: expected_blocks[0],
             num_produced_chunks: expected_chunks[0],
@@ -893,7 +900,7 @@ fn test_get_validator_info() {
             public_key: block_producers[1].public_key(),
             is_slashed: false,
             stake: TESTING_INIT_STAKE,
-            shards: vec![0],
+            shards: vec![0.into()],
             num_produced_blocks: expected_blocks[1],
             num_expected_blocks: expected_blocks[1],
             num_produced_chunks: expected_chunks[1],
@@ -911,13 +918,13 @@ fn test_get_validator_info() {
             account_id: "test1".parse().unwrap(),
             public_key: block_producers[0].public_key(),
             stake: TESTING_INIT_STAKE,
-            shards: vec![0],
+            shards: vec![0.into()],
         },
         NextEpochValidatorInfo {
             account_id: "test2".parse().unwrap(),
             public_key: block_producers[1].public_key(),
             stake: TESTING_INIT_STAKE,
-            shards: vec![0],
+            shards: vec![0.into()],
         },
     ];
     let response = env
@@ -988,7 +995,7 @@ fn test_get_validator_info() {
             account_id: "test2".parse().unwrap(),
             public_key: block_producers[1].public_key(),
             stake: TESTING_INIT_STAKE,
-            shards: vec![0],
+            shards: vec![0.into()],
         }]
     );
     assert!(response.current_proposals.is_empty());
@@ -1461,13 +1468,13 @@ fn test_flat_state_usage() {
     let env = TestEnv::new(vec![vec!["test1".parse().unwrap()]], 4, false);
     let trie = env
         .runtime
-        .get_trie_for_shard(0, &env.head.prev_block_hash, Trie::EMPTY_ROOT, true)
+        .get_trie_for_shard(0.into(), &env.head.prev_block_hash, Trie::EMPTY_ROOT, true)
         .unwrap();
     assert!(trie.has_flat_storage_chunk_view());
 
     let trie = env
         .runtime
-        .get_view_trie_for_shard(0, &env.head.prev_block_hash, Trie::EMPTY_ROOT)
+        .get_view_trie_for_shard(0.into(), &env.head.prev_block_hash, Trie::EMPTY_ROOT)
         .unwrap();
     assert!(!trie.has_flat_storage_chunk_view());
 }
@@ -1505,9 +1512,10 @@ fn test_trie_and_flat_state_equality() {
     // - using view state, which should never use flat state
     let head_prev_block_hash = env.head.prev_block_hash;
     let state_root = env.state_roots[0];
-    let state = env.runtime.get_trie_for_shard(0, &head_prev_block_hash, state_root, true).unwrap();
+    let state =
+        env.runtime.get_trie_for_shard(0.into(), &head_prev_block_hash, state_root, true).unwrap();
     let view_state =
-        env.runtime.get_view_trie_for_shard(0, &head_prev_block_hash, state_root).unwrap();
+        env.runtime.get_view_trie_for_shard(0.into(), &head_prev_block_hash, state_root).unwrap();
     let trie_key = TrieKey::Account { account_id: validators[1].clone() };
     let key = trie_key.to_vec();
 
@@ -1651,7 +1659,7 @@ fn prepare_transactions(
     transaction_groups: &mut dyn TransactionGroupIterator,
     storage_config: RuntimeStorageConfig,
 ) -> Result<PreparedTransactions, Error> {
-    let shard_id = 0;
+    let shard_id = 0.into();
     let block = chain.get_block(&env.head.prev_block_hash).unwrap();
     let congestion_info = block.block_congestion_info();
 
@@ -1773,7 +1781,7 @@ fn test_prepare_transactions_empty_storage_proof() {
 #[test]
 #[cfg_attr(not(feature = "test_features"), ignore)]
 fn test_storage_proof_garbage() {
-    let shard_id = 0;
+    let shard_id = 0.into();
     let signer = create_test_signer("test1");
     let env = TestEnv::new(vec![vec![signer.validator_id().clone()]], 100, false);
     let garbage_size_mb = 50usize;

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -214,8 +214,7 @@ impl TestEnv {
         // TODO(congestion_control): pass down prev block info and read congestion info from there
         // For now, just use default.
         let prev_block_hash = self.head.last_block_hash;
-        let epoch_id =
-            self.epoch_manager.get_epoch_id_from_prev_block(&prev_block_hash).unwrap_or_default();
+        let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(&prev_block_hash).unwrap();
         let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id).unwrap();
         let shard_index = shard_layout.get_shard_index(shard_id);
         let state_root = self.state_roots[shard_index];

--- a/chain/chain/src/state_snapshot_actor.rs
+++ b/chain/chain/src/state_snapshot_actor.rs
@@ -5,7 +5,7 @@ use near_performance_metrics_macros::perf;
 use near_primitives::block::Block;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardUId;
-use near_primitives::types::{EpochHeight, ShardId};
+use near_primitives::types::EpochHeight;
 use near_store::flat::FlatStorageManager;
 use near_store::ShardTries;
 use std::sync::Arc;

--- a/chain/chain/src/state_snapshot_actor.rs
+++ b/chain/chain/src/state_snapshot_actor.rs
@@ -92,7 +92,7 @@ impl StateSnapshotActor {
                     NetworkRequests::SnapshotHostInfo {
                         sync_hash: prev_block_hash,
                         epoch_height,
-                        shards: res_shard_uids.iter().map(|uid| uid.shard_id as ShardId).collect(),
+                        shards: res_shard_uids.iter().map(|uid| uid.shard_id.into()).collect(),
                     },
                 ));
             }

--- a/chain/chain/src/stateless_validation/chunk_endorsement.rs
+++ b/chain/chain/src/stateless_validation/chunk_endorsement.rs
@@ -43,8 +43,10 @@ pub fn validate_chunk_endorsements_in_block(
     }
 
     let epoch_id = epoch_manager.get_epoch_id_from_prev_block(block.header().prev_hash())?;
+    let shard_layout = epoch_manager.get_shard_layout(&epoch_id)?;
     for (chunk_header, signatures) in block.chunks().iter().zip(block.chunk_endorsements()) {
         let shard_id = chunk_header.shard_id();
+        let shard_index = shard_layout.get_shard_index(shard_id);
         // For old chunks, we optimize the block by not including the chunk endorsements.
         if chunk_header.height_included() != block.header().height() {
             if !signatures.is_empty() {
@@ -117,14 +119,14 @@ pub fn validate_chunk_endorsements_in_block(
         // Validate the chunk endorsements bitmap (if present) in the block header against the endorsement signatures in the body.
         if let Some(endorsements_bitmap) = endorsements_bitmap {
             // Bitmap's length must be equal to the min bytes needed to encode one bit per validator assignment.
-            if endorsements_bitmap.len(shard_id).unwrap() != signatures.len().div_ceil(8) * 8 {
+            if endorsements_bitmap.len(shard_index).unwrap() != signatures.len().div_ceil(8) * 8 {
                 return Err(Error::InvalidChunkEndorsementBitmap(format!(
                     "Bitmap's length {} is inconsistent with the number of signatures {} for shard {} ",
-                    endorsements_bitmap.len(shard_id).unwrap(), signatures.len(), shard_id,
+                    endorsements_bitmap.len(shard_index).unwrap(), signatures.len(), shard_id,
                 )));
             }
             // Bits in the bitmap must match the existence of signature for the corresponding validator in the body.
-            for (bit, signature) in endorsements_bitmap.iter(shard_id).zip(signatures.iter()) {
+            for (bit, signature) in endorsements_bitmap.iter(shard_index).zip(signatures.iter()) {
                 if bit != signature.is_some() {
                     return Err(Error::InvalidChunkEndorsementBitmap(
                         format!("Chunk endorsement bit in header does not match endorsement in body. shard={}, bit={}, signature={}",
@@ -132,7 +134,7 @@ pub fn validate_chunk_endorsements_in_block(
                 }
             }
             // All extra positions after the assignments must be left as false.
-            for value in endorsements_bitmap.iter(shard_id).skip(signatures.len()) {
+            for value in endorsements_bitmap.iter(shard_index).skip(signatures.len()) {
                 if value {
                     return Err(Error::InvalidChunkEndorsementBitmap(
                         format!("Extra positions in the bitmap after {} validator assignments are not all false for shard {}",
@@ -157,6 +159,7 @@ pub fn validate_chunk_endorsements_in_header(
         )));
     };
     let epoch_id = epoch_manager.get_epoch_id_from_prev_block(header.prev_hash())?;
+    let shard_layout = epoch_manager.get_shard_layout(&epoch_id)?;
     let shard_ids = epoch_manager.get_shard_layout(&epoch_id)?.shard_ids().collect_vec();
     if chunk_endorsements.num_shards() != shard_ids.len() {
         return Err(Error::InvalidChunkEndorsementBitmap(
@@ -165,12 +168,13 @@ pub fn validate_chunk_endorsements_in_header(
     }
     let chunk_mask = header.chunk_mask();
     for shard_id in shard_ids.into_iter() {
+        let shard_index = shard_layout.get_shard_index(shard_id);
         // For old chunks, we optimize the block and its header by not including the chunk endorsements and
         // corresponding bitmaps. Thus, we expect that the bitmap is empty for shard with no new chunk.
-        if chunk_mask[shard_id as usize] != (chunk_endorsements.len(shard_id).unwrap() > 0) {
+        if chunk_mask[shard_index] != (chunk_endorsements.len(shard_index).unwrap() > 0) {
             return Err(Error::InvalidChunkEndorsementBitmap(format!(
                 "Bitmap must be non-empty iff shard {} has new chunk in the block. Chunk mask={}, Bitmap length={}",
-                shard_id, chunk_mask[shard_id as usize], chunk_endorsements.len(shard_id).unwrap(),
+                shard_id, chunk_mask[shard_index], chunk_endorsements.len(shard_index).unwrap(),
             )));
         }
     }

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -53,6 +53,8 @@ impl MainTransition {
     pub fn shard_id(&self) -> ShardId {
         match self {
             Self::Genesis { shard_id, .. } => *shard_id,
+            // It is ok to use the shard id from the header because it is a new
+            // chunk. An old chunk may have the shard id from the parent shard.
             Self::NewChunk(data) => data.chunk_header.shard_id(),
         }
     }
@@ -115,6 +117,8 @@ pub fn pre_validate_chunk_state_witness(
     let epoch_id = state_witness.epoch_id;
     let shard_layout = epoch_manager.get_shard_layout(&epoch_id)?;
 
+    // It is ok to use the shard id from the header because it is a new
+    // chunk. An old chunk may have the shard id from the parent shard.
     let shard_id = state_witness.chunk_header.shard_id();
     let shard_index = shard_layout.get_shard_index(shard_id);
 

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -21,7 +21,7 @@ use near_primitives::block::Block;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::merkle::merklize;
 use near_primitives::receipt::Receipt;
-use near_primitives::shard_layout::{self, ShardUId};
+use near_primitives::shard_layout::ShardUId;
 use near_primitives::sharding::{ChunkHash, ReceiptProof, ShardChunkHeader};
 use near_primitives::stateless_validation::state_witness::{
     ChunkStateWitness, EncodedChunkStateWitness,

--- a/chain/chain/src/stateless_validation/state_transition_data.rs
+++ b/chain/chain/src/stateless_validation/state_transition_data.rs
@@ -116,7 +116,7 @@ mod tests {
     use near_primitives::block_header::{BlockHeader, BlockHeaderInnerLite, BlockHeaderV4};
     use near_primitives::hash::{hash, CryptoHash};
     use near_primitives::stateless_validation::stored_chunk_state_transition_data::StoredChunkStateTransitionData;
-    use near_primitives::types::{BlockHeight, EpochId, ShardId};
+    use near_primitives::types::{new_shard_id_tmp, BlockHeight, EpochId, ShardId};
     use near_primitives::utils::{get_block_shard_id, get_block_shard_id_rev, index_to_bytes};
     use near_store::db::STATE_TRANSITION_START_HEIGHTS;
     use near_store::test_utils::create_test_store;
@@ -127,7 +127,7 @@ mod tests {
 
     #[test]
     fn initial_state_transition_data_gc() {
-        let shard_id = 0.into();
+        let shard_id = new_shard_id_tmp(0);
         let block_at_1 = hash(&[1]);
         let block_at_2 = hash(&[2]);
         let block_at_3 = hash(&[3]);
@@ -146,7 +146,7 @@ mod tests {
     }
     #[test]
     fn multiple_state_transition_data_gc() {
-        let shard_id = 0.into();
+        let shard_id = new_shard_id_tmp(0);
         let store = create_test_store();
         let chain_store = create_chain_store(&store);
         save_state_transition_data(&store, hash(&[1]), 1, shard_id);

--- a/chain/chain/src/stateless_validation/state_transition_data.rs
+++ b/chain/chain/src/stateless_validation/state_transition_data.rs
@@ -23,8 +23,11 @@ impl Chain {
             return Ok(());
         }
         let final_block = chain_store.get_block(&final_block_hash)?;
-        let final_block_chunk_created_heights =
-            final_block.chunks().iter().map(|chunk| chunk.height_created()).collect::<Vec<_>>();
+        let final_block_chunk_created_heights = final_block
+            .chunks()
+            .iter()
+            .map(|chunk| (chunk.shard_id(), chunk.height_created()))
+            .collect::<Vec<_>>();
         clear_before_last_final_block(chain_store, &final_block_chunk_created_heights)?;
         Ok(())
     }
@@ -38,7 +41,7 @@ impl Chain {
 /// TODO(resharding): this doesn't work after shard layout change
 fn clear_before_last_final_block(
     chain_store: &ChainStore,
-    last_final_block_chunk_created_heights: &[BlockHeight],
+    last_final_block_chunk_created_heights: &[(ShardId, BlockHeight)],
 ) -> Result<(), Error> {
     let mut start_heights = if let Some(start_heights) =
         chain_store
@@ -56,10 +59,7 @@ fn clear_before_last_final_block(
         "garbage collecting state transition data"
     );
     let mut store_update = chain_store.store().store_update();
-    for (shard_index, &last_final_block_height) in
-        last_final_block_chunk_created_heights.iter().enumerate()
-    {
-        let shard_id = shard_index as ShardId;
+    for &(shard_id, last_final_block_height) in last_final_block_chunk_created_heights.iter() {
         let start_height = *start_heights.get(&shard_id).unwrap_or(&last_final_block_height);
         let mut potentially_deleted_count = 0;
         for height in start_height..last_final_block_height {
@@ -72,7 +72,7 @@ fn clear_before_last_final_block(
         }
         tracing::debug!(
             target: "state_transition_data",
-            shard_id,
+            ?shard_id,
             start_height,
             potentially_deleted_count,
             "garbage collected state transition data for shard"
@@ -127,7 +127,7 @@ mod tests {
 
     #[test]
     fn initial_state_transition_data_gc() {
-        let shard_id = 0;
+        let shard_id = 0.into();
         let block_at_1 = hash(&[1]);
         let block_at_2 = hash(&[2]);
         let block_at_3 = hash(&[3]);
@@ -136,8 +136,9 @@ mod tests {
         for (hash, height) in [(block_at_1, 1), (block_at_2, 2), (block_at_3, 3)] {
             save_state_transition_data(&store, hash, height, shard_id);
         }
-        clear_before_last_final_block(&create_chain_store(&store), &[final_height]).unwrap();
-        check_start_heights(&store, vec![final_height]);
+        clear_before_last_final_block(&create_chain_store(&store), &[(shard_id, final_height)])
+            .unwrap();
+        check_start_heights(&store, vec![(shard_id, final_height)]);
         check_existing_state_transition_data(
             &store,
             vec![(block_at_2, shard_id), (block_at_3, shard_id)],
@@ -145,34 +146,27 @@ mod tests {
     }
     #[test]
     fn multiple_state_transition_data_gc() {
-        let shard_id = 0;
+        let shard_id = 0.into();
         let store = create_test_store();
         let chain_store = create_chain_store(&store);
         save_state_transition_data(&store, hash(&[1]), 1, shard_id);
         save_state_transition_data(&store, hash(&[2]), 2, shard_id);
-        clear_before_last_final_block(&chain_store, &[2]).unwrap();
+        clear_before_last_final_block(&chain_store, &[(shard_id, 2)]).unwrap();
         let block_at_3 = hash(&[3]);
         let final_height = 3;
         save_state_transition_data(&store, block_at_3, final_height, shard_id);
-        clear_before_last_final_block(&chain_store, &[3]).unwrap();
-        check_start_heights(&store, vec![final_height]);
+        clear_before_last_final_block(&chain_store, &[(shard_id, 3)]).unwrap();
+        check_start_heights(&store, vec![(shard_id, final_height)]);
         check_existing_state_transition_data(&store, vec![(block_at_3, shard_id)]);
     }
 
     #[track_caller]
-    fn check_start_heights(store: &Store, expected: Vec<BlockHeight>) {
+    fn check_start_heights(store: &Store, expected: Vec<(ShardId, BlockHeight)>) {
         let start_heights = store
             .get_ser::<StateTransitionStartHeights>(DBCol::Misc, STATE_TRANSITION_START_HEIGHTS)
             .unwrap()
             .unwrap();
-        assert_eq!(
-            start_heights,
-            expected
-                .into_iter()
-                .enumerate()
-                .map(|(i, h)| (i as ShardId, h))
-                .collect::<HashMap<_, _>>()
-        );
+        assert_eq!(start_heights, expected.into_iter().collect::<HashMap<_, _>>());
     }
 
     #[track_caller]

--- a/chain/chain/src/store/latest_witnesses.rs
+++ b/chain/chain/src/store/latest_witnesses.rs
@@ -113,7 +113,7 @@ impl ChainStore {
             target: "client",
             "save_latest_chunk_state_witness",
             witness_height = witness.chunk_header.height_created(),
-            witness_shard = witness.chunk_header.shard_id(),
+            witness_shard = ?witness.chunk_header.shard_id(),
         )
         .entered();
 
@@ -173,7 +173,7 @@ impl ChainStore {
         OsRng.fill_bytes(&mut random_uuid);
         let key = LatestWitnessesKey {
             height: witness.chunk_header.height_created(),
-            shard_id: witness.chunk_header.shard_id(),
+            shard_id: witness.chunk_header.shard_id().into(),
             epoch_id: witness.epoch_id,
             witness_size: serialized_witness_size,
             random_uuid,

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -2177,8 +2177,8 @@ impl<'a> ChainStoreUpdate<'a> {
                 source_store.get_chunk_extra(block_hash, &shard_uid)?.clone(),
             );
         }
-        for chunk_header in block.chunks().iter() {
-            let shard_id = chunk_header.shard_id();
+        for (shard_index, chunk_header) in block.chunks().iter().enumerate() {
+            let shard_id = shard_layout.get_shard_id(shard_index);
             let chunk_hash = chunk_header.chunk_hash();
             chain_store_update
                 .chain_store_cache_update

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -578,8 +578,9 @@ pub(crate) fn trie_changes_chunk_extra_exists(
 
     // 5. There should be ShardChunk with ShardId `shard_id`
     let shard_id = shard_uid.shard_id();
+    let shard_index = shard_layout.get_shard_index(shard_id);
     let chunks = block.chunks();
-    if let Some(chunk_header) = chunks.get(shard_id as usize) {
+    if let Some(chunk_header) = chunks.get(shard_index) {
         // if the chunk is not a new chunk, skip the check
         if chunk_header.height_included() != block.header().height() {
             return Ok(());

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -170,7 +170,7 @@ impl MockEpochManager {
                     })
                     .collect();
 
-                let validators_per_shard = block_producers.len() as ShardId / vs.validator_groups;
+                let validators_per_shard = block_producers.len() / vs.validator_groups;
                 let coef = block_producers.len() as ShardId / vs.num_shards;
 
                 let chunk_producers: Vec<Vec<ValidatorStake>> = (0..vs.num_shards)

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -43,7 +43,7 @@ use near_primitives::transaction::{
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
     AccountId, ApprovalStake, Balance, BlockHeight, EpochHeight, EpochId, Nonce, NumShards,
-    ShardId, StateRoot, StateRootNode, ValidatorInfoIdentifier,
+    ShardId, ShardIndex, StateRoot, StateRootNode, ValidatorInfoIdentifier,
 };
 use near_primitives::version::{ProtocolFeature, ProtocolVersion, PROTOCOL_VERSION};
 use near_primitives::views::{
@@ -170,14 +170,15 @@ impl MockEpochManager {
                     })
                     .collect();
 
-                let validators_per_shard = block_producers.len() / vs.validator_groups;
-                let coef = block_producers.len() as ShardId / vs.num_shards;
+                let validators_per_shard = block_producers.len() / vs.validator_groups as usize;
+                let coef = block_producers.len() / vs.num_shards as usize;
 
                 let chunk_producers: Vec<Vec<ValidatorStake>> = (0..vs.num_shards)
-                    .map(|shard_id| {
-                        let offset = (shard_id * coef / validators_per_shard * validators_per_shard)
-                            as usize;
-                        block_producers[offset..offset + validators_per_shard as usize].to_vec()
+                    .map(|shard_index| {
+                        let shard_index = shard_index as usize;
+                        let offset =
+                            shard_index * coef / validators_per_shard * validators_per_shard;
+                        block_producers[offset..offset + validators_per_shard].to_vec()
                     })
                     .collect();
 
@@ -289,8 +290,8 @@ impl MockEpochManager {
         &self.validators_by_valset[valset].block_producers
     }
 
-    fn get_chunk_producers(&self, valset: usize, shard_id: ShardId) -> Vec<ValidatorStake> {
-        self.validators_by_valset[valset].chunk_producers[shard_id as usize].clone()
+    fn get_chunk_producers(&self, valset: usize, shard_index: ShardIndex) -> Vec<ValidatorStake> {
+        self.validators_by_valset[valset].chunk_producers[shard_index].clone()
     }
 
     fn get_valset_for_epoch(&self, epoch_id: &EpochId) -> Result<usize, EpochError> {
@@ -423,8 +424,8 @@ impl EpochManagerAdapter for MockEpochManager {
         self.hash_to_valset.write().unwrap().contains_key(epoch_id)
     }
 
-    fn shard_ids(&self, _epoch_id: &EpochId) -> Result<Vec<ShardId>, EpochError> {
-        Ok((0..self.num_shards).collect())
+    fn shard_ids(&self, epoch_id: &EpochId) -> Result<Vec<ShardId>, EpochError> {
+        Ok(self.get_shard_layout(epoch_id)?.shard_ids().collect())
     }
 
     fn num_total_parts(&self) -> usize {
@@ -463,7 +464,7 @@ impl EpochManagerAdapter for MockEpochManager {
         shard_id: ShardId,
         _epoch_id: &EpochId,
     ) -> Result<ShardUId, EpochError> {
-        Ok(ShardUId { version: 0, shard_id: shard_id as u32 })
+        Ok(ShardUId { version: 0, shard_id: shard_id.into() })
     }
 
     fn get_block_info(&self, _hash: &CryptoHash) -> Result<Arc<BlockInfo>, EpochError> {
@@ -589,16 +590,21 @@ impl EpochManagerAdapter for MockEpochManager {
         &self,
         _prev_hash: &CryptoHash,
         shard_ids: Vec<ShardId>,
-    ) -> Result<Vec<ShardId>, Error> {
-        Ok(shard_ids)
+    ) -> Result<Vec<(ShardId, ShardIndex)>, Error> {
+        // This is incorrect in ShardLayoutV2 where the shard ids don't have to
+        // be ordered and contiguous.
+        let num_shards = shard_ids.len();
+        Ok(shard_ids.into_iter().zip(0..num_shards).collect())
     }
 
     fn get_prev_shard_id(
         &self,
         _prev_hash: &CryptoHash,
         shard_id: ShardId,
-    ) -> Result<ShardId, Error> {
-        Ok(shard_id)
+    ) -> Result<(ShardId, ShardIndex), Error> {
+        // This is incorrect in ShardLayoutV2 where the shard ids don't have to
+        // be ordered and contiguous.
+        Ok((shard_id, shard_id.get() as ShardIndex))
     }
 
     fn get_shard_layout_from_prev_block(
@@ -728,8 +734,10 @@ impl EpochManagerAdapter for MockEpochManager {
         shard_id: ShardId,
     ) -> Result<AccountId, EpochError> {
         let valset = self.get_valset_for_epoch(epoch_id)?;
-        let chunk_producers = self.get_chunk_producers(valset, shard_id);
-        let index = (shard_id + height + 1) as usize % chunk_producers.len();
+        let shard_layout = self.get_shard_layout(epoch_id)?;
+        let shard_index = shard_layout.get_shard_index(shard_id);
+        let chunk_producers = self.get_chunk_producers(valset, shard_index);
+        let index = (shard_index + height as usize + 1) % chunk_producers.len();
         Ok(chunk_producers[index].account_id().clone())
     }
 
@@ -977,7 +985,9 @@ impl EpochManagerAdapter for MockEpochManager {
         //    we check if we care about a shard. Please do not remove the unwrap, fix the logic of
         //    the calling function.
         let epoch_valset = self.get_valset_for_epoch(&epoch_id).unwrap();
-        let chunk_producers = self.get_chunk_producers(epoch_valset, shard_id);
+        let shard_layout = self.get_shard_layout(&epoch_id)?;
+        let shard_index = shard_layout.get_shard_index(shard_id);
+        let chunk_producers = self.get_chunk_producers(epoch_valset, shard_index);
         for validator in chunk_producers {
             if validator.account_id() == account_id {
                 return Ok(true);
@@ -996,7 +1006,9 @@ impl EpochManagerAdapter for MockEpochManager {
         //    we check if we care about a shard. Please do not remove the unwrap, fix the logic of
         //    the calling function.
         let epoch_valset = self.get_epoch_and_valset(*parent_hash).unwrap();
-        let chunk_producers = self.get_chunk_producers(epoch_valset.1, shard_id);
+        let shard_layout = self.get_shard_layout_from_prev_block(parent_hash)?;
+        let shard_index = shard_layout.get_shard_index(shard_id);
+        let chunk_producers = self.get_chunk_producers(epoch_valset.1, shard_index);
         for validator in chunk_producers {
             if validator.account_id() == account_id {
                 return Ok(true);
@@ -1015,8 +1027,12 @@ impl EpochManagerAdapter for MockEpochManager {
         //    we check if we care about a shard. Please do not remove the unwrap, fix the logic of
         //    the calling function.
         let epoch_valset = self.get_epoch_and_valset(*parent_hash).unwrap();
-        let chunk_producers = self
-            .get_chunk_producers((epoch_valset.1 + 1) % self.validators_by_valset.len(), shard_id);
+        let shard_layout = self.get_shard_layout_from_prev_block(parent_hash)?;
+        let shard_index = shard_layout.get_shard_index(shard_id);
+        let chunk_producers = self.get_chunk_producers(
+            (epoch_valset.1 + 1) % self.validators_by_valset.len(),
+            shard_index,
+        );
         for validator in chunk_producers {
             if validator.account_id() == account_id {
                 return Ok(true);
@@ -1079,7 +1095,7 @@ impl RuntimeAdapter for KeyValueRuntime {
     ) -> Result<Trie, Error> {
         Ok(self
             .tries
-            .get_trie_for_shard(ShardUId { version: 0, shard_id: shard_id as u32 }, state_root))
+            .get_trie_for_shard(ShardUId { version: 0, shard_id: shard_id.into() }, state_root))
     }
 
     fn get_flat_storage_manager(&self) -> near_store::flat::FlatStorageManager {
@@ -1093,7 +1109,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         state_root: StateRoot,
     ) -> Result<Trie, Error> {
         Ok(self.tries.get_view_trie_for_shard(
-            ShardUId { version: 0, shard_id: shard_id as u32 },
+            ShardUId { version: 0, shard_id: shard_id.into() },
             state_root,
         ))
     }
@@ -1278,7 +1294,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         Ok(ApplyChunkResult {
             trie_changes: WrappedTrieChanges::new(
                 self.get_tries(),
-                ShardUId { version: 0, shard_id: shard_id as u32 },
+                ShardUId { version: 0, shard_id: shard_id.into() },
                 TrieChanges::empty(state_root),
                 Default::default(),
                 block.block_hash,

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -42,8 +42,8 @@ use near_primitives::transaction::{
 };
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
-    AccountId, ApprovalStake, Balance, BlockHeight, EpochHeight, EpochId, Nonce, NumShards,
-    ShardId, ShardIndex, StateRoot, StateRootNode, ValidatorInfoIdentifier,
+    shard_id_as_u32, AccountId, ApprovalStake, Balance, BlockHeight, EpochHeight, EpochId, Nonce,
+    NumShards, ShardId, ShardIndex, StateRoot, StateRootNode, ValidatorInfoIdentifier,
 };
 use near_primitives::version::{ProtocolFeature, ProtocolVersion, PROTOCOL_VERSION};
 use near_primitives::views::{
@@ -464,7 +464,7 @@ impl EpochManagerAdapter for MockEpochManager {
         shard_id: ShardId,
         _epoch_id: &EpochId,
     ) -> Result<ShardUId, EpochError> {
-        Ok(ShardUId { version: 0, shard_id: shard_id.into() })
+        Ok(ShardUId { version: 0, shard_id: shard_id_as_u32(shard_id) })
     }
 
     fn get_block_info(&self, _hash: &CryptoHash) -> Result<Arc<BlockInfo>, EpochError> {
@@ -604,7 +604,7 @@ impl EpochManagerAdapter for MockEpochManager {
     ) -> Result<(ShardId, ShardIndex), Error> {
         // This is incorrect in ShardLayoutV2 where the shard ids don't have to
         // be ordered and contiguous.
-        Ok((shard_id, shard_id.get() as ShardIndex))
+        Ok((shard_id, shard_id as ShardIndex))
     }
 
     fn get_shard_layout_from_prev_block(
@@ -1093,9 +1093,10 @@ impl RuntimeAdapter for KeyValueRuntime {
         state_root: StateRoot,
         _use_flat_storage: bool,
     ) -> Result<Trie, Error> {
-        Ok(self
-            .tries
-            .get_trie_for_shard(ShardUId { version: 0, shard_id: shard_id.into() }, state_root))
+        Ok(self.tries.get_trie_for_shard(
+            ShardUId { version: 0, shard_id: shard_id_as_u32(shard_id) },
+            state_root,
+        ))
     }
 
     fn get_flat_storage_manager(&self) -> near_store::flat::FlatStorageManager {
@@ -1109,7 +1110,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         state_root: StateRoot,
     ) -> Result<Trie, Error> {
         Ok(self.tries.get_view_trie_for_shard(
-            ShardUId { version: 0, shard_id: shard_id.into() },
+            ShardUId { version: 0, shard_id: shard_id_as_u32(shard_id) },
             state_root,
         ))
     }
@@ -1294,7 +1295,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         Ok(ApplyChunkResult {
             trie_changes: WrappedTrieChanges::new(
                 self.get_tries(),
-                ShardUId { version: 0, shard_id: shard_id.into() },
+                ShardUId { version: 0, shard_id: shard_id_as_u32(shard_id) },
                 TrieChanges::empty(state_root),
                 Default::default(),
                 block.block_hash,

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -547,7 +547,7 @@ mod tests {
 
     #[test]
     fn test_block_produce() {
-        let shard_ids: Vec<_> = (0..32).collect();
+        let shard_ids: Vec<_> = (0..32).map(Into::into).collect();
         let genesis_chunks = genesis_chunks(
             vec![Trie::EMPTY_ROOT],
             vec![Default::default(); shard_ids.len()],

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -540,6 +540,7 @@ mod tests {
     use near_primitives::merkle::verify_path;
     use near_primitives::test_utils::{create_test_signer, TestBlockBuilder};
     use near_primitives::transaction::{ExecutionMetadata, ExecutionOutcome, ExecutionStatus};
+    use near_primitives::types::new_shard_id_tmp;
     use near_primitives::version::PROTOCOL_VERSION;
     use std::sync::Arc;
 
@@ -547,7 +548,7 @@ mod tests {
 
     #[test]
     fn test_block_produce() {
-        let shard_ids: Vec<_> = (0..32).map(Into::into).collect();
+        let shard_ids: Vec<_> = (0..32).map(new_shard_id_tmp).collect();
         let genesis_chunks = genesis_chunks(
             vec![Trie::EMPTY_ROOT],
             vec![Default::default(); shard_ids.len()],

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -133,7 +133,7 @@ pub fn apply_new_chunk(
         target: "chain",
         parent: parent_span,
         "apply_new_chunk",
-        shard_id,
+        ?shard_id,
         ?apply_reason)
     .entered();
     let gas_limit = chunk_header.gas_limit();
@@ -182,7 +182,7 @@ pub fn apply_old_chunk(
         target: "chain",
         parent: parent_span,
         "apply_old_chunk",
-        shard_id,
+        ?shard_id,
         ?apply_reason)
     .entered();
 

--- a/chain/chunks/src/chunk_cache.rs
+++ b/chain/chunks/src/chunk_cache.rs
@@ -274,7 +274,7 @@ mod tests {
     use near_crypto::KeyType;
     use near_primitives::hash::CryptoHash;
     use near_primitives::sharding::{PartialEncodedChunkV2, ShardChunkHeader, ShardChunkHeaderV2};
-    use near_primitives::types::ShardId;
+    use near_primitives::types::{new_shard_id_tmp, ShardId};
     use near_primitives::validator_signer::InMemoryValidatorSigner;
 
     use crate::chunk_cache::EncodedChunksCache;
@@ -304,8 +304,8 @@ mod tests {
     #[test]
     fn test_incomplete_chunks() {
         let mut cache = EncodedChunksCache::new();
-        let header0 = create_chunk_header(1, 0.into());
-        let header1 = create_chunk_header(1, 1.into());
+        let header0 = create_chunk_header(1, new_shard_id_tmp(0));
+        let header1 = create_chunk_header(1, new_shard_id_tmp(1));
         cache.get_or_insert_from_header(&header0);
         cache.merge_in_partial_encoded_chunk(&PartialEncodedChunkV2 {
             header: header1.clone(),
@@ -328,7 +328,7 @@ mod tests {
     #[test]
     fn test_cache_removal() {
         let mut cache = EncodedChunksCache::new();
-        let header = create_chunk_header(1, 0.into());
+        let header = create_chunk_header(1, new_shard_id_tmp(0));
         let partial_encoded_chunk =
             PartialEncodedChunkV2 { header: header, parts: vec![], prev_outgoing_receipts: vec![] };
         cache.merge_in_partial_encoded_chunk(&partial_encoded_chunk);

--- a/chain/chunks/src/chunk_cache.rs
+++ b/chain/chunks/src/chunk_cache.rs
@@ -274,12 +274,13 @@ mod tests {
     use near_crypto::KeyType;
     use near_primitives::hash::CryptoHash;
     use near_primitives::sharding::{PartialEncodedChunkV2, ShardChunkHeader, ShardChunkHeaderV2};
+    use near_primitives::types::ShardId;
     use near_primitives::validator_signer::InMemoryValidatorSigner;
 
     use crate::chunk_cache::EncodedChunksCache;
     use crate::shards_manager_actor::ChunkRequestInfo;
 
-    fn create_chunk_header(height: u64, shard_id: u64) -> ShardChunkHeader {
+    fn create_chunk_header(height: u64, shard_id: ShardId) -> ShardChunkHeader {
         let signer =
             InMemoryValidatorSigner::from_random("test".parse().unwrap(), KeyType::ED25519);
         ShardChunkHeader::V2(ShardChunkHeaderV2::new(
@@ -303,8 +304,8 @@ mod tests {
     #[test]
     fn test_incomplete_chunks() {
         let mut cache = EncodedChunksCache::new();
-        let header0 = create_chunk_header(1, 0);
-        let header1 = create_chunk_header(1, 1);
+        let header0 = create_chunk_header(1, 0.into());
+        let header1 = create_chunk_header(1, 1.into());
         cache.get_or_insert_from_header(&header0);
         cache.merge_in_partial_encoded_chunk(&PartialEncodedChunkV2 {
             header: header1.clone(),
@@ -327,7 +328,7 @@ mod tests {
     #[test]
     fn test_cache_removal() {
         let mut cache = EncodedChunksCache::new();
-        let header = create_chunk_header(1, 0);
+        let header = create_chunk_header(1, 0.into());
         let partial_encoded_chunk =
             PartialEncodedChunkV2 { header: header, parts: vec![], prev_outgoing_receipts: vec![] };
         cache.merge_in_partial_encoded_chunk(&partial_encoded_chunk);

--- a/chain/chunks/src/client.rs
+++ b/chain/chunks/src/client.rs
@@ -75,8 +75,8 @@ impl ShardedTransactionPool {
     /// For testing purposes we want it to be the reproducible and derived from the `self.rng_seed` and `shard_id`
     fn random_seed(base_seed: &RngSeed, shard_id: ShardId) -> RngSeed {
         let mut res = *base_seed;
-        res[0] = shard_id as u8;
-        res[1] = (shard_id / 256) as u8;
+        res[0] = shard_id.get() as u8;
+        res[1] = (shard_id.get() / 256) as u8;
         res
     }
 
@@ -162,7 +162,7 @@ mod tests {
         hash::CryptoHash,
         shard_layout::{account_id_to_shard_uid, ShardLayout},
         transaction::SignedTransaction,
-        types::AccountId,
+        types::{AccountId, ShardId},
     };
     use near_store::ShardUId;
     use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
@@ -172,11 +172,11 @@ mod tests {
 
     #[test]
     fn test_random_seed_with_shard_id() {
-        let seed0 = ShardedTransactionPool::random_seed(&TEST_SEED, 0);
-        let seed10 = ShardedTransactionPool::random_seed(&TEST_SEED, 10);
-        let seed256 = ShardedTransactionPool::random_seed(&TEST_SEED, 256);
-        let seed1000 = ShardedTransactionPool::random_seed(&TEST_SEED, 1000);
-        let seed1000000 = ShardedTransactionPool::random_seed(&TEST_SEED, 1_000_000);
+        let seed0 = ShardedTransactionPool::random_seed(&TEST_SEED, 0.into());
+        let seed10 = ShardedTransactionPool::random_seed(&TEST_SEED, 10.into());
+        let seed256 = ShardedTransactionPool::random_seed(&TEST_SEED, 256.into());
+        let seed1000 = ShardedTransactionPool::random_seed(&TEST_SEED, 1000.into());
+        let seed1000000 = ShardedTransactionPool::random_seed(&TEST_SEED, 1_000_000.into());
         assert_ne!(seed0, seed10);
         assert_ne!(seed0, seed256);
         assert_ne!(seed0, seed1000);
@@ -197,12 +197,12 @@ mod tests {
 
         let mut pool = ShardedTransactionPool::new(TEST_SEED, None);
 
-        let mut shard_id_to_accounts = HashMap::new();
-        shard_id_to_accounts.insert(0, vec!["aaa", "abcd", "a-a-a-a-a"]);
-        shard_id_to_accounts.insert(1, vec!["aurora"]);
-        shard_id_to_accounts.insert(2, vec!["aurora-0", "bob", "kkk"]);
+        let mut shard_id_to_accounts: HashMap<ShardId, _> = HashMap::new();
+        shard_id_to_accounts.insert(0.into(), vec!["aaa", "abcd", "a-a-a-a-a"]);
+        shard_id_to_accounts.insert(1.into(), vec!["aurora"]);
+        shard_id_to_accounts.insert(2.into(), vec!["aurora-0", "bob", "kkk"]);
         // this shard is split, make sure there are accounts for both shards 3' and 4'
-        shard_id_to_accounts.insert(3, vec!["mmm", "rrr", "sweat", "ttt", "www", "zzz"]);
+        shard_id_to_accounts.insert(3.into(), vec!["mmm", "rrr", "sweat", "ttt", "www", "zzz"]);
 
         let deposit = 222;
 
@@ -236,7 +236,7 @@ mod tests {
             );
 
             let shard_uid =
-                ShardUId { shard_id: signer_shard_id as u32, version: old_shard_layout.version() };
+                ShardUId { shard_id: signer_shard_id.into(), version: old_shard_layout.version() };
             pool.insert_transaction(shard_uid, tx);
         }
 
@@ -251,7 +251,7 @@ mod tests {
         {
             let shard_ids: Vec<_> = new_shard_layout.shard_ids().collect();
             for &shard_id in shard_ids.iter() {
-                let shard_id = shard_id as u32;
+                let shard_id = shard_id.into();
                 let shard_uid = ShardUId { shard_id, version: new_shard_layout.version() };
                 let pool = pool.pool_for_shard(shard_uid);
                 let pool_len = pool.len();
@@ -261,7 +261,7 @@ mod tests {
 
             let mut total = 0;
             for shard_id in shard_ids {
-                let shard_id = shard_id as u32;
+                let shard_id = shard_id.into();
                 let shard_uid = ShardUId { shard_id, version: new_shard_layout.version() };
                 let mut pool_iter = pool.get_pool_iterator(shard_uid).unwrap();
                 while let Some(group) = pool_iter.next() {

--- a/chain/chunks/src/logic.rs
+++ b/chain/chunks/src/logic.rs
@@ -110,8 +110,8 @@ pub fn make_outgoing_receipts_proofs(
 
     let mut receipts_by_shard =
         Chain::group_receipts_by_shard(outgoing_receipts.to_vec(), &shard_layout);
-    let it = proofs.into_iter().enumerate().map(move |(proof_shard_id, proof)| {
-        let proof_shard_id = proof_shard_id as u64;
+    let it = proofs.into_iter().enumerate().map(move |(proof_shard_index, proof)| {
+        let proof_shard_id = shard_layout.get_shard_id(proof_shard_index);
         let receipts = receipts_by_shard.remove(&proof_shard_id).unwrap_or_else(Vec::new);
         let shard_proof =
             ShardProof { from_shard_id: shard_id, to_shard_id: proof_shard_id, proof };
@@ -174,7 +174,7 @@ pub fn decode_encoded_chunk(
         target: "chunks",
         "decode_encoded_chunk",
         height_included = encoded_chunk.cloned_header().height_included(),
-        shard_id = encoded_chunk.cloned_header().shard_id(),
+        shard_id = ?encoded_chunk.cloned_header().shard_id(),
         ?chunk_hash)
     .entered();
 

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -524,7 +524,7 @@ impl ShardsManagerActor {
                 debug!(
                     target: "chunks",
                     ?part_ords,
-                    shard_id,
+                    ?shard_id,
                     ?target_account,
                     prefer_peer,
                     "Requesting parts",
@@ -684,18 +684,18 @@ impl ShardsManagerActor {
             target: "chunks",
             "request_chunk_single",
             ?chunk_hash,
-            shard_id,
+            ?shard_id,
             height_created = height)
         .entered();
 
         if self.requested_partial_encoded_chunks.contains_key(&chunk_hash) {
-            debug!(target: "chunks", height, shard_id, ?chunk_hash, "Not requesting chunk, already being requested.");
+            debug!(target: "chunks", height, ?shard_id, ?chunk_hash, "Not requesting chunk, already being requested.");
             return;
         }
 
         if let Some(entry) = self.encoded_chunks.get(&chunk_header.chunk_hash()) {
             if entry.complete {
-                debug!(target: "chunks", height, shard_id, ?chunk_hash, "Not requesting chunk, already complete.");
+                debug!(target: "chunks", height, ?shard_id, ?chunk_hash, "Not requesting chunk, already complete.");
                 return;
             }
         } else {
@@ -703,7 +703,7 @@ impl ShardsManagerActor {
             // However, if the chunk had just been processed and marked as complete, it might have
             // been removed from the cache if it is out of horizon. So in this case, the chunk is
             // already complete and we don't need to request anything.
-            debug!(target: "chunks", height, shard_id, ?chunk_hash, "Not requesting chunk, already complete and GC-ed.");
+            debug!(target: "chunks", height, ?shard_id, ?chunk_hash, "Not requesting chunk, already complete and GC-ed.");
             return;
         }
 
@@ -721,7 +721,7 @@ impl ShardsManagerActor {
         );
 
         if mark_only {
-            debug!(target: "chunks", height, shard_id, ?chunk_hash, "Marked the chunk as being requested but did not send the request yet.");
+            debug!(target: "chunks", height, ?shard_id, ?chunk_hash, "Marked the chunk as being requested but did not send the request yet.");
             return;
         }
 
@@ -749,7 +749,7 @@ impl ShardsManagerActor {
         // we want to give some time for any `PartialEncodedChunkForward` messages to arrive
         // before we send requests.
         if !should_wait_for_chunk_forwarding || fetch_from_archival || old_block {
-            debug!(target: "chunks", height, shard_id, ?chunk_hash, "Requesting.");
+            debug!(target: "chunks", height, ?shard_id, ?chunk_hash, "Requesting.");
             let request_result = self.request_partial_encoded_chunk(
                 height,
                 &ancestor_hash,
@@ -1108,7 +1108,7 @@ impl ShardsManagerActor {
             target: "chunks",
             "check_chunk_complete",
             height_included = chunk.cloned_header().height_included(),
-            shard_id = chunk.cloned_header().shard_id(),
+            shard_id = ?chunk.cloned_header().shard_id(),
             chunk_hash = ?chunk.chunk_hash())
         .entered();
 
@@ -1471,7 +1471,7 @@ impl ShardsManagerActor {
             target: "chunks",
             "process_partial_encoded_chunk",
             ?chunk_hash,
-            shard_id = header.shard_id(),
+            shard_id = ?header.shard_id(),
             height_created = header.height_created(),
             height_included = header.height_included())
         .entered();
@@ -2322,7 +2322,7 @@ mod test {
                 height: 0,
                 ancestor_hash: Default::default(),
                 prev_block_hash: Default::default(),
-                shard_id: 0,
+                shard_id: 0.into(),
                 added,
                 last_requested: added,
             },

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -2263,7 +2263,7 @@ mod test {
     use near_network::types::NetworkRequests;
     use near_primitives::block::Tip;
     use near_primitives::hash::{hash, CryptoHash};
-    use near_primitives::types::EpochId;
+    use near_primitives::types::{new_shard_id_tmp, EpochId};
     use near_primitives::validator_signer::EmptyValidatorSigner;
     use near_store::test_utils::create_test_store;
     use std::sync::Arc;
@@ -2322,7 +2322,7 @@ mod test {
                 height: 0,
                 ancestor_hash: Default::default(),
                 prev_block_hash: Default::default(),
-                shard_id: 0.into(),
+                shard_id: new_shard_id_tmp(0),
                 added,
                 last_requested: added,
             },

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -92,7 +92,7 @@ impl ChunkTestFixture {
         let (mock_parent_hash, mock_height) =
             if orphan_chunk { (CryptoHash::hash_bytes(&[]), 2) } else { (mock_ancestor_hash, 1) };
         // setting this to 2 instead of 0 so that when chunk producers
-        let mock_shard_id: ShardId = 0;
+        let mock_shard_id: ShardId = 0.into();
         let mock_epoch_id =
             epoch_manager.get_epoch_id_from_prev_block(&mock_ancestor_hash).unwrap();
         let mock_chunk_producer =

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -15,7 +15,7 @@ use near_primitives::sharding::{
     ShardChunkHeader,
 };
 use near_primitives::test_utils::create_test_signer;
-use near_primitives::types::MerkleHash;
+use near_primitives::types::{new_shard_id_tmp, MerkleHash};
 use near_primitives::types::{AccountId, EpochId, ShardId};
 use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_store::adapter::chunk_store::ChunkStoreAdapter;
@@ -92,7 +92,7 @@ impl ChunkTestFixture {
         let (mock_parent_hash, mock_height) =
             if orphan_chunk { (CryptoHash::hash_bytes(&[]), 2) } else { (mock_ancestor_hash, 1) };
         // setting this to 2 instead of 0 so that when chunk producers
-        let mock_shard_id: ShardId = 0.into();
+        let mock_shard_id: ShardId = new_shard_id_tmp(0);
         let mock_epoch_id =
             epoch_manager.get_epoch_id_from_prev_block(&mock_ancestor_hash).unwrap();
         let mock_chunk_producer =

--- a/chain/client-primitives/src/debug.rs
+++ b/chain/client-primitives/src/debug.rs
@@ -2,7 +2,7 @@
 //! without backwards compatibility of JSON encoding.
 use crate::types::StatusError;
 use near_primitives::congestion_info::CongestionInfo;
-use near_primitives::types::EpochId;
+use near_primitives::types::{EpochId, ShardId};
 use near_primitives::views::{
     CatchupStatusView, ChainProcessingInfo, EpochValidatorInfo, RequestedStatePartsView,
     SyncStatusView,
@@ -143,7 +143,7 @@ pub struct ProductionAtHeight {
     // None if we are not responsible for producing this block.
     pub block_production: Option<BlockProduction>,
     // Map from shard_id to chunk that we are responsible to produce at this height
-    pub chunk_production: HashMap<u64, ChunkProduction>,
+    pub chunk_production: HashMap<ShardId, ChunkProduction>,
 }
 
 // Information about the approvals that we received.

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -479,7 +479,7 @@ pub enum GetChunkError {
     #[error("Block either has never been observed on the node or has been garbage collected: {error_message}")]
     UnknownBlock { error_message: String },
     #[error("Shard ID {shard_id} is invalid")]
-    InvalidShardId { shard_id: u64 },
+    InvalidShardId { shard_id: ShardId },
     #[error("Chunk with hash {chunk_hash:?} has never been observed on this node")]
     UnknownChunk { chunk_hash: ChunkHash },
     // NOTE: Currently, the underlying errors are too broad, and while we tried to handle

--- a/chain/client/src/chunk_distribution_network.rs
+++ b/chain/client/src/chunk_distribution_network.rs
@@ -226,6 +226,7 @@ mod tests {
             PartialEncodedChunkV2, ShardChunkHeaderInner, ShardChunkHeaderInnerV3,
             ShardChunkHeaderV3,
         },
+        types::new_shard_id_tmp,
         validator_signer::EmptyValidatorSigner,
     };
     use std::{collections::HashMap, convert::Infallible, future::Future};
@@ -235,7 +236,7 @@ mod tests {
     fn test_request_chunks() {
         let (mock_sender, mut message_receiver) = mpsc::unbounded_channel();
         let mut client = MockClient::default();
-        let missing_chunk = mock_shard_chunk(0, 0.into());
+        let missing_chunk = mock_shard_chunk(0, 0u64.into());
         let mut blocks_delay_tracker = BlocksDelayTracker::new(Clock::real());
         let shards_manager = MockSender::new(mock_sender);
         let shards_manager_adapter = shards_manager.into_sender();
@@ -309,8 +310,8 @@ mod tests {
 
         // When chunks are known by the client, the shards manager
         // is told to process the chunk directly
-        let known_chunk_1 = mock_shard_chunk(1, 0.into());
-        let known_chunk_2 = mock_shard_chunk(2, 0.into());
+        let known_chunk_1 = mock_shard_chunk(1, new_shard_id_tmp(0));
+        let known_chunk_2 = mock_shard_chunk(2, new_shard_id_tmp(0));
         client.publish_chunk(&known_chunk_1).now_or_never();
         client.publish_chunk(&known_chunk_2).now_or_never();
         let blocks_missing_chunks = vec![BlockMissingChunks {

--- a/chain/client/src/chunk_distribution_network.rs
+++ b/chain/client/src/chunk_distribution_network.rs
@@ -235,7 +235,7 @@ mod tests {
     fn test_request_chunks() {
         let (mock_sender, mut message_receiver) = mpsc::unbounded_channel();
         let mut client = MockClient::default();
-        let missing_chunk = mock_shard_chunk(0, 0);
+        let missing_chunk = mock_shard_chunk(0, 0.into());
         let mut blocks_delay_tracker = BlocksDelayTracker::new(Clock::real());
         let shards_manager = MockSender::new(mock_sender);
         let shards_manager_adapter = shards_manager.into_sender();
@@ -309,8 +309,8 @@ mod tests {
 
         // When chunks are known by the client, the shards manager
         // is told to process the chunk directly
-        let known_chunk_1 = mock_shard_chunk(1, 0);
-        let known_chunk_2 = mock_shard_chunk(2, 0);
+        let known_chunk_1 = mock_shard_chunk(1, 0.into());
+        let known_chunk_2 = mock_shard_chunk(2, 0.into());
         client.publish_chunk(&known_chunk_1).now_or_never();
         client.publish_chunk(&known_chunk_2).now_or_never();
         let blocks_missing_chunks = vec![BlockMissingChunks {
@@ -392,7 +392,7 @@ mod tests {
         });
     }
 
-    fn mock_shard_chunk(height: u64, shard_id: u64) -> PartialEncodedChunk {
+    fn mock_shard_chunk(height: u64, shard_id: ShardId) -> PartialEncodedChunk {
         let prev_block_hash =
             hash(&[height.to_le_bytes().as_slice(), shard_id.to_le_bytes().as_slice()].concat());
         let mut mock_hashes = MockHashes::new(prev_block_hash);

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -428,8 +428,9 @@ impl Client {
         block: &Block,
     ) -> Result<(), Error> {
         let epoch_id = self.epoch_manager.get_epoch_id(block.hash())?;
-        for chunk_header in block.chunks().iter() {
-            let shard_id = chunk_header.shard_id();
+        let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
+        for (shard_index, chunk_header) in block.chunks().iter().enumerate() {
+            let shard_id = shard_layout.get_shard_id(shard_index);
             let shard_uid = self.epoch_manager.shard_id_to_uid(shard_id, &epoch_id)?;
             if block.header().height() == chunk_header.height_included() {
                 if cares_about_shard_this_or_next_epoch(
@@ -458,8 +459,10 @@ impl Client {
         block: &Block,
     ) -> Result<(), Error> {
         let epoch_id = self.epoch_manager.get_epoch_id(block.hash())?;
-        for chunk_header in block.chunks().iter() {
-            let shard_id = chunk_header.shard_id();
+        let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
+
+        for (shard_index, chunk_header) in block.chunks().iter().enumerate() {
+            let shard_id = shard_layout.get_shard_id(shard_index);
             let shard_uid = self.epoch_manager.shard_id_to_uid(shard_id, &epoch_id)?;
 
             if block.header().height() == chunk_header.height_included() {

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -75,11 +75,11 @@ use near_primitives::sharding::{
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{AccountId, ApprovalStake, BlockHeight, EpochId, NumBlocks, ShardId};
+use near_primitives::unwrap_or_return;
 use near_primitives::utils::MaybeValidated;
 use near_primitives::validator_signer::ValidatorSigner;
 use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_primitives::views::{CatchupStatusView, DroppedReason};
-use near_primitives::{shard_layout, unwrap_or_return};
 use near_store::ShardUId;
 use reed_solomon_erasure::galois_8::ReedSolomon;
 use std::cmp::max;

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -65,7 +65,7 @@ use near_primitives::block::Tip;
 use near_primitives::block_header::ApprovalType;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
-use near_primitives::types::{AccountId, BlockHeight, EpochId};
+use near_primitives::types::{AccountId, BlockHeight, EpochId, ShardId};
 use near_primitives::unwrap_or_return;
 use near_primitives::utils::MaybeValidated;
 use near_primitives::validator_signer::ValidatorSigner;
@@ -1912,7 +1912,7 @@ impl ClientActorInner {
         &mut self,
         epoch_id: EpochId,
         sync_hash: CryptoHash,
-        shards_to_sync: &Vec<u64>,
+        shards_to_sync: &Vec<ShardId>,
     ) {
         let shard_layout =
             self.client.epoch_manager.get_shard_layout(&epoch_id).expect("Cannot get shard layout");

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -38,7 +38,7 @@ use time::ext::InstantExt as _;
 
 use near_client_primitives::debug::{DebugBlockStatus, DebugChunkStatus};
 use near_network::types::{ConnectedPeerInfo, NetworkInfo, PeerType};
-use near_primitives::sharding::{shard_chunk_header_inner, ChunkHash};
+use near_primitives::sharding::ChunkHash;
 use near_primitives::views::{
     AccountDataView, KnownProducerView, NetworkInfoView, PeerInfoView, Tier1ProxyView,
 };

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -21,7 +21,9 @@ use near_performance_metrics_macros::perf;
 use near_primitives::congestion_info::CongestionControl;
 use near_primitives::state_sync::get_num_state_parts;
 use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
-use near_primitives::types::{AccountId, BlockHeight, NumShards, ShardId, ValidatorInfoIdentifier};
+use near_primitives::types::{
+    AccountId, BlockHeight, NumShards, ShardId, ShardIndex, ValidatorInfoIdentifier,
+};
 use near_primitives::{
     hash::CryptoHash,
     state_sync::{ShardStateSyncResponseHeader, StateHeaderKey},
@@ -36,7 +38,7 @@ use time::ext::InstantExt as _;
 
 use near_client_primitives::debug::{DebugBlockStatus, DebugChunkStatus};
 use near_network::types::{ConnectedPeerInfo, NetworkInfo, PeerType};
-use near_primitives::sharding::ChunkHash;
+use near_primitives::sharding::{shard_chunk_header_inner, ChunkHash};
 use near_primitives::views::{
     AccountDataView, KnownProducerView, NetworkInfoView, PeerInfoView, Tier1ProxyView,
 };
@@ -104,11 +106,11 @@ impl BlockProductionTracker {
 
     /// Record chunk collected after a block is produced if the block didn't include a chunk for the shard.
     /// If called before the block was produced, nothing happens.
-    pub(crate) fn record_chunk_collected(&mut self, height: BlockHeight, shard_id: ShardId) {
+    pub(crate) fn record_chunk_collected(&mut self, height: BlockHeight, shard_index: ShardIndex) {
         if let Some(block_production) = self.0.get_mut(&height) {
             let chunk_collections = &mut block_production.chunks_collection_time;
             // Check that chunk_collection is set and we haven't received this chunk yet.
-            if let Some(chunk_collection) = chunk_collections.get_mut(shard_id as usize) {
+            if let Some(chunk_collection) = chunk_collections.get_mut(shard_index) {
                 if chunk_collection.received_time.is_none() {
                     chunk_collection.received_time = Some(Clock::real().now_utc());
                 }
@@ -121,13 +123,15 @@ impl BlockProductionTracker {
     pub(crate) fn construct_chunk_collection_info(
         block_height: BlockHeight,
         epoch_id: &EpochId,
-        num_shards: ShardId,
+        num_shards: usize,
         new_chunks: &HashMap<ShardId, ChunkHash>,
         epoch_manager: &dyn EpochManagerAdapter,
         chunk_inclusion_tracker: &ChunkInclusionTracker,
     ) -> Result<Vec<ChunkCollection>, Error> {
         let mut chunk_collection_info = vec![];
-        for shard_id in 0..num_shards {
+        for shard_index in 0..num_shards {
+            let shard_layout = epoch_manager.get_shard_layout(epoch_id)?;
+            let shard_id = shard_layout.get_shard_id(shard_index);
             if let Some(chunk_hash) = new_chunks.get(&shard_id) {
                 let (chunk_producer, received_time) =
                     chunk_inclusion_tracker.get_chunk_producer_and_received_time(chunk_hash)?;
@@ -234,10 +238,10 @@ impl ClientActorInner {
         let shards_size_and_parts: Vec<(u64, u64)> = block
             .chunks()
             .iter()
-            .enumerate()
-            .map(|(shard_id, chunk)| {
+            .map(|chunk| {
+                let shard_id = chunk.shard_id();
                 let state_root_node = self.client.runtime_adapter.get_state_root_node(
-                    shard_id as u64,
+                    shard_id,
                     block.hash(),
                     &chunk.prev_state_root(),
                 );
@@ -252,9 +256,12 @@ impl ClientActorInner {
             })
             .collect();
 
-        let state_header_exists: Vec<bool> = (0..block.chunks().len())
-            .map(|shard_id| {
-                let key = borsh::to_vec(&StateHeaderKey(shard_id as u64, *block.hash()));
+        let state_header_exists: Vec<bool> = block
+            .chunks()
+            .iter()
+            .map(|chunk_header| {
+                let shard_id = chunk_header.shard_id();
+                let key = borsh::to_vec(&StateHeaderKey(shard_id, *block.hash()));
                 match key {
                     Ok(key) => {
                         matches!(
@@ -490,7 +497,7 @@ impl ClientActorInner {
                                 });
 
                             DebugChunkStatus {
-                                shard_id: chunk.shard_id(),
+                                shard_id: chunk.shard_id().into(),
                                 chunk_hash: chunk.chunk_hash(),
                                 chunk_producer: self
                                     .client

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -210,6 +210,7 @@ impl InfoHelper {
         let epoch_info = client.epoch_manager.get_epoch_info(&head.epoch_id);
         let blocks_in_epoch = client.config.epoch_length;
         let shard_ids = client.epoch_manager.shard_ids(&head.epoch_id).unwrap_or_default();
+        let shard_layout = client.epoch_manager.get_shard_layout(&head.epoch_id).unwrap();
         if let Ok(epoch_info) = epoch_info {
             metrics::VALIDATORS_CHUNKS_EXPECTED_IN_EPOCH.reset();
             metrics::VALIDATORS_BLOCKS_EXPECTED_IN_EPOCH.reset();
@@ -250,10 +251,11 @@ impl InfoHelper {
             });
 
             for shard_id in shard_ids {
+                let shard_index = shard_layout.get_shard_index(shard_id);
                 let mut stake_per_cp = HashMap::<ValidatorId, Balance>::new();
                 stake_sum = 0;
                 let chunk_producers_settlement = &epoch_info.chunk_producers_settlement();
-                let chunk_producers = chunk_producers_settlement.get(shard_id as usize);
+                let chunk_producers = chunk_producers_settlement.get(shard_index);
                 let Some(chunk_producers) = chunk_producers else {
                     tracing::warn!(target: "stats", ?shard_id, ?chunk_producers_settlement, "invalid shard id, not found in the shard settlement");
                     continue;

--- a/chain/client/src/stateless_validation/chunk_endorsement/tracker_v1.rs
+++ b/chain/client/src/stateless_validation/chunk_endorsement/tracker_v1.rs
@@ -90,7 +90,7 @@ impl ChunkEndorsementTracker {
         chunk_header: &ShardChunkHeader,
         endorsement: ChunkEndorsementV1,
     ) -> Result<(), Error> {
-        let _span = tracing::debug_span!(target: "client", "process_chunk_endorsement", chunk_hash=?chunk_header.chunk_hash(), shard_id=chunk_header.shard_id()).entered();
+        let _span = tracing::debug_span!(target: "client", "process_chunk_endorsement", chunk_hash=?chunk_header.chunk_hash(), shard_id=?chunk_header.shard_id()).entered();
         // Validate the endorsement before locking the mutex to improve performance.
         if !self.epoch_manager.verify_chunk_endorsement(&chunk_header, &endorsement)? {
             tracing::error!(target: "client", ?endorsement, "Invalid chunk endorsement.");

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -214,7 +214,7 @@ pub(crate) fn send_chunk_endorsement_to_block_producers(
     tracing::debug!(
         target: "client",
         chunk_hash=?chunk_hash,
-        shard_id=chunk_header.shard_id(),
+        shard_id=?chunk_header.shard_id(),
         ?block_producers,
         "send_chunk_endorsement",
     );
@@ -243,7 +243,7 @@ impl Client {
         tracing::debug!(
             target: "client",
             chunk_hash=?witness.chunk_header.chunk_hash(),
-            shard_id=witness.chunk_header.shard_id(),
+            shard_id=?witness.chunk_header.shard_id(),
             "process_chunk_state_witness",
         );
 

--- a/chain/client/src/stateless_validation/chunk_validator/orphan_witness_handling.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/orphan_witness_handling.rs
@@ -35,7 +35,7 @@ impl Client {
         let _span = tracing::debug_span!(target: "client",
             "handle_orphan_state_witness",
             witness_height,
-            witness_shard,
+            ?witness_shard,
             witness_chunk = ?chunk_header.chunk_hash(),
             witness_prev_block = ?chunk_header.prev_block_hash(),
         )
@@ -63,7 +63,7 @@ impl Client {
             tracing::warn!(
                 target: "client",
                 witness_height,
-                witness_shard,
+                ?witness_shard,
                 witness_chunk = ?chunk_header.chunk_hash(),
                 witness_prev_block = ?chunk_header.prev_block_hash(),
                 witness_size,
@@ -87,7 +87,7 @@ impl Client {
             tracing::debug!(
                 target: "client",
                 witness_height = header.height_created(),
-                witness_shard = header.shard_id(),
+                witness_shard = ?header.shard_id(),
                 witness_chunk = ?header.chunk_hash(),
                 witness_prev_block = ?header.prev_block_hash(),
                 "Processing an orphaned ChunkStateWitness, its previous block has arrived."

--- a/chain/client/src/stateless_validation/chunk_validator/orphan_witness_pool.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/orphan_witness_pool.rs
@@ -180,7 +180,7 @@ mod tests {
     use near_primitives::hash::{hash, CryptoHash};
     use near_primitives::sharding::{ShardChunkHeader, ShardChunkHeaderInner};
     use near_primitives::stateless_validation::state_witness::ChunkStateWitness;
-    use near_primitives::types::{BlockHeight, ShardId};
+    use near_primitives::types::{new_shard_id_tmp, BlockHeight, ShardId};
 
     use super::OrphanStateWitnessPool;
 
@@ -253,10 +253,10 @@ mod tests {
     fn basic() {
         let mut pool = OrphanStateWitnessPool::new(10);
 
-        let witness1 = make_witness(100, 1.into(), block(99), 0);
-        let witness2 = make_witness(100, 2.into(), block(99), 0);
-        let witness3 = make_witness(101, 1.into(), block(100), 0);
-        let witness4 = make_witness(101, 2.into(), block(100), 0);
+        let witness1 = make_witness(100, new_shard_id_tmp(1), block(99), 0);
+        let witness2 = make_witness(100, new_shard_id_tmp(2), block(99), 0);
+        let witness3 = make_witness(101, new_shard_id_tmp(1), block(100), 0);
+        let witness4 = make_witness(101, new_shard_id_tmp(2), block(100), 0);
 
         pool.add_orphan_state_witness(witness1.clone(), 0);
         pool.add_orphan_state_witness(witness2.clone(), 0);
@@ -280,8 +280,8 @@ mod tests {
 
         // The old witness is replaced when the awaited block is the same
         {
-            let witness1 = make_witness(100, 1.into(), block(99), 0);
-            let witness2 = make_witness(100, 1.into(), block(99), 1);
+            let witness1 = make_witness(100, new_shard_id_tmp(1), block(99), 0);
+            let witness2 = make_witness(100, new_shard_id_tmp(1), block(99), 1);
             pool.add_orphan_state_witness(witness1, 0);
             pool.add_orphan_state_witness(witness2.clone(), 0);
 
@@ -291,8 +291,8 @@ mod tests {
 
         // The old witness is replaced when the awaited block is different, waiting_for_block is cleaned as expected
         {
-            let witness3 = make_witness(102, 1.into(), block(100), 0);
-            let witness4 = make_witness(102, 1.into(), block(101), 0);
+            let witness3 = make_witness(102, new_shard_id_tmp(1), block(100), 0);
+            let witness4 = make_witness(102, new_shard_id_tmp(1), block(101), 0);
             pool.add_orphan_state_witness(witness3, 0);
             pool.add_orphan_state_witness(witness4.clone(), 0);
 
@@ -311,9 +311,9 @@ mod tests {
     fn limited_capacity() {
         let mut pool = OrphanStateWitnessPool::new(2);
 
-        let witness1 = make_witness(102, 1.into(), block(101), 0);
-        let witness2 = make_witness(101, 1.into(), block(100), 0);
-        let witness3 = make_witness(101, 2.into(), block(100), 0);
+        let witness1 = make_witness(102, new_shard_id_tmp(1), block(101), 0);
+        let witness2 = make_witness(101, new_shard_id_tmp(1), block(100), 0);
+        let witness3 = make_witness(101, new_shard_id_tmp(2), block(100), 0);
 
         pool.add_orphan_state_witness(witness1, 0);
         pool.add_orphan_state_witness(witness2.clone(), 0);
@@ -336,7 +336,7 @@ mod tests {
     fn large_shard_id() {
         let mut pool = OrphanStateWitnessPool::new(10);
 
-        let large_shard_id = ShardId::max();
+        let large_shard_id = ShardId::MAX;
         let witness = make_witness(101, large_shard_id.into(), block(99), 0);
         pool.add_orphan_state_witness(witness.clone(), 0);
 
@@ -351,10 +351,10 @@ mod tests {
     fn remove_below_height() {
         let mut pool = OrphanStateWitnessPool::new(10);
 
-        let witness1 = make_witness(100, 1.into(), block(99), 0);
-        let witness2 = make_witness(101, 1.into(), block(100), 0);
-        let witness3 = make_witness(102, 1.into(), block(101), 0);
-        let witness4 = make_witness(103, 1.into(), block(102), 0);
+        let witness1 = make_witness(100, new_shard_id_tmp(1), block(99), 0);
+        let witness2 = make_witness(101, new_shard_id_tmp(1), block(100), 0);
+        let witness3 = make_witness(102, new_shard_id_tmp(1), block(101), 0);
+        let witness4 = make_witness(103, new_shard_id_tmp(1), block(102), 0);
 
         pool.add_orphan_state_witness(witness1, 0);
         pool.add_orphan_state_witness(witness2.clone(), 0);
@@ -382,10 +382,10 @@ mod tests {
     #[test]
     fn destructor_doesnt_crash() {
         let mut pool = OrphanStateWitnessPool::new(10);
-        pool.add_orphan_state_witness(make_witness(100, 0.into(), block(99), 0), 0);
-        pool.add_orphan_state_witness(make_witness(100, 2.into(), block(99), 0), 0);
-        pool.add_orphan_state_witness(make_witness(100, 2.into(), block(99), 0), 1);
-        pool.add_orphan_state_witness(make_witness(101, 0.into(), block(100), 0), 0);
+        pool.add_orphan_state_witness(make_witness(100, new_shard_id_tmp(0), block(99), 0), 0);
+        pool.add_orphan_state_witness(make_witness(100, new_shard_id_tmp(2), block(99), 0), 0);
+        pool.add_orphan_state_witness(make_witness(100, new_shard_id_tmp(2), block(99), 0), 1);
+        pool.add_orphan_state_witness(make_witness(101, new_shard_id_tmp(0), block(100), 0), 0);
         std::mem::drop(pool);
     }
 
@@ -395,24 +395,24 @@ mod tests {
         let mut pool = OrphanStateWitnessPool::new(5);
 
         // Witnesses for shards 0, 1, 2, 3 at height 1000, looking for block 99
-        let witness0 = make_witness(100, 0.into(), block(99), 0);
-        let witness1 = make_witness(100, 1.into(), block(99), 0);
-        let witness2 = make_witness(100, 2.into(), block(99), 0);
-        let witness3 = make_witness(100, 3.into(), block(99), 0);
+        let witness0 = make_witness(100, new_shard_id_tmp(0), block(99), 0);
+        let witness1 = make_witness(100, new_shard_id_tmp(1), block(99), 0);
+        let witness2 = make_witness(100, new_shard_id_tmp(2), block(99), 0);
+        let witness3 = make_witness(100, new_shard_id_tmp(3), block(99), 0);
         pool.add_orphan_state_witness(witness0, 0);
         pool.add_orphan_state_witness(witness1, 0);
         pool.add_orphan_state_witness(witness2, 0);
         pool.add_orphan_state_witness(witness3, 0);
 
         // Another witness on shard 1, height 100. Should replace witness1
-        let witness5 = make_witness(100, 1.into(), block(99), 1);
+        let witness5 = make_witness(100, new_shard_id_tmp(1), block(99), 1);
         pool.add_orphan_state_witness(witness5.clone(), 0);
 
         // Witnesses for shards 0, 1, 2, 3 at height 101, looking for block 100
-        let witness6 = make_witness(101, 0.into(), block(100), 0);
-        let witness7 = make_witness(101, 1.into(), block(100), 0);
-        let witness8 = make_witness(101, 2.into(), block(100), 0);
-        let witness9 = make_witness(101, 3.into(), block(100), 0);
+        let witness6 = make_witness(101, new_shard_id_tmp(0), block(100), 0);
+        let witness7 = make_witness(101, new_shard_id_tmp(1), block(100), 0);
+        let witness8 = make_witness(101, new_shard_id_tmp(2), block(100), 0);
+        let witness9 = make_witness(101, new_shard_id_tmp(3), block(100), 0);
         pool.add_orphan_state_witness(witness6, 0);
         pool.add_orphan_state_witness(witness7.clone(), 0);
         pool.add_orphan_state_witness(witness8.clone(), 0);
@@ -424,9 +424,9 @@ mod tests {
         assert_contents(looking_for_99, vec![witness5]);
 
         // Let's add a few more witnesses
-        let witness10 = make_witness(102, 1.into(), block(101), 0);
-        let witness11 = make_witness(102, 4.into(), block(100), 0);
-        let witness12 = make_witness(102, 1.into(), block(77), 0);
+        let witness10 = make_witness(102, new_shard_id_tmp(1), block(101), 0);
+        let witness11 = make_witness(102, new_shard_id_tmp(4), block(100), 0);
+        let witness12 = make_witness(102, new_shard_id_tmp(1), block(77), 0);
         pool.add_orphan_state_witness(witness10, 0);
         pool.add_orphan_state_witness(witness11.clone(), 0);
         pool.add_orphan_state_witness(witness12.clone(), 0);

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
@@ -158,7 +158,7 @@ impl PartialEncodedStateWitnessTracker {
                     tracing::error!(
                         target: "client",
                         ?err,
-                        shard_id = key.shard_id,
+                        shard_id = ?key.shard_id,
                         height_created = key.height_created,
                         "Failed to reed solomon decode witness parts. Maybe malicious or corrupt data."
                     );

--- a/chain/client/src/stateless_validation/state_witness_producer.rs
+++ b/chain/client/src/stateless_validation/state_witness_producer.rs
@@ -256,15 +256,14 @@ impl Client {
         let mut source_receipt_proofs = HashMap::new();
         for receipt_proof_response in incoming_receipt_proofs {
             let from_block = self.chain.chain_store().get_block(&receipt_proof_response.0)?;
+            let shard_layout =
+                self.epoch_manager.get_shard_layout(from_block.header().epoch_id())?;
             for proof in receipt_proof_response.1.iter() {
-                let from_shard_id: usize = proof
-                    .1
-                    .from_shard_id
-                    .try_into()
-                    .map_err(|_| Error::Other("Couldn't convert u64 to usize!".into()))?;
+                let from_shard_id = proof.1.from_shard_id;
+                let from_shard_index = shard_layout.get_shard_index(from_shard_id);
                 let from_chunk_hash = from_block
                     .chunks()
-                    .get(from_shard_id)
+                    .get(from_shard_index)
                     .ok_or_else(|| Error::InvalidShardId(proof.1.from_shard_id))?
                     .chunk_hash();
                 let insert_res =

--- a/chain/client/src/stateless_validation/state_witness_tracker.rs
+++ b/chain/client/src/stateless_validation/state_witness_tracker.rs
@@ -205,7 +205,7 @@ mod state_witness_tracker_tests {
     }
 
     fn dummy_witness() -> ChunkStateWitness {
-        ChunkStateWitness::new_dummy(100, 2 as ShardId, hash("fake hash".as_bytes()))
+        ChunkStateWitness::new_dummy(100, 2.into(), hash("fake hash".as_bytes()))
     }
 
     fn dummy_clock() -> FakeClock {

--- a/chain/client/src/stateless_validation/state_witness_tracker.rs
+++ b/chain/client/src/stateless_validation/state_witness_tracker.rs
@@ -153,6 +153,7 @@ mod state_witness_tracker_tests {
     use near_async::time::{Duration, FakeClock, Utc};
     use near_primitives::hash::hash;
     use near_primitives::stateless_validation::state_witness::ChunkStateWitness;
+    use near_primitives::types::new_shard_id_tmp;
 
     const NUM_VALIDATORS: usize = 3;
 
@@ -204,7 +205,7 @@ mod state_witness_tracker_tests {
     }
 
     fn dummy_witness() -> ChunkStateWitness {
-        ChunkStateWitness::new_dummy(100, 2.into(), hash("fake hash".as_bytes()))
+        ChunkStateWitness::new_dummy(100, new_shard_id_tmp(2), hash("fake hash".as_bytes()))
     }
 
     fn dummy_clock() -> FakeClock {

--- a/chain/client/src/stateless_validation/state_witness_tracker.rs
+++ b/chain/client/src/stateless_validation/state_witness_tracker.rs
@@ -153,7 +153,6 @@ mod state_witness_tracker_tests {
     use near_async::time::{Duration, FakeClock, Utc};
     use near_primitives::hash::hash;
     use near_primitives::stateless_validation::state_witness::ChunkStateWitness;
-    use near_primitives::types::ShardId;
 
     const NUM_VALIDATORS: usize = 3;
 

--- a/chain/client/src/sync/external.rs
+++ b/chain/client/src/sync/external.rs
@@ -410,6 +410,7 @@ mod test {
         ExternalConnection, StateFileType,
     };
     use near_o11y::testonly::init_test_logger;
+    use near_primitives::types::new_shard_id_tmp;
     use rand::distributions::{Alphanumeric, DistString};
 
     fn random_string(rand_len: usize) -> String {
@@ -460,23 +461,28 @@ mod test {
         let file_type = StateFileType::StatePart { part_id: 0, num_parts: 1 };
 
         // Before uploading we shouldn't see filename in the list of files.
-        let files = rt.block_on(async { connection.list_objects(0.into(), &dir).await.unwrap() });
+        let files = rt
+            .block_on(async { connection.list_objects(new_shard_id_tmp(0), &dir).await.unwrap() });
         tracing::debug!("Files before upload: {:?}", files);
         assert_eq!(files.into_iter().filter(|x| *x == filename).collect::<Vec<String>>().len(), 0);
 
         // Uploading the file.
         rt.block_on(async {
-            connection.put_file(file_type.clone(), &data, 0.into(), &full_filename).await.unwrap()
+            connection
+                .put_file(file_type.clone(), &data, new_shard_id_tmp(0), &full_filename)
+                .await
+                .unwrap()
         });
 
         // After uploading we should see filename in the list of files.
-        let files = rt.block_on(async { connection.list_objects(0.into(), &dir).await.unwrap() });
+        let files = rt
+            .block_on(async { connection.list_objects(new_shard_id_tmp(0), &dir).await.unwrap() });
         tracing::debug!("Files after upload: {:?}", files);
         assert_eq!(files.into_iter().filter(|x| *x == filename).collect::<Vec<String>>().len(), 1);
 
         // And the data should match generates data.
         let download_data = rt.block_on(async {
-            connection.get_file(0.into(), &full_filename, &file_type).await.unwrap()
+            connection.get_file(new_shard_id_tmp(0), &full_filename, &file_type).await.unwrap()
         });
         assert_eq!(download_data, data);
 
@@ -484,8 +490,9 @@ mod test {
         let filename = random_string(8);
         let full_filename = format!("{}/{}", dir, filename);
 
-        let download_data =
-            rt.block_on(async { connection.get_file(0.into(), &full_filename, &file_type).await });
+        let download_data = rt.block_on(async {
+            connection.get_file(new_shard_id_tmp(0), &full_filename, &file_type).await
+        });
         assert!(download_data.is_err(), "{:?}", download_data);
     }
 }

--- a/chain/client/src/sync/external.rs
+++ b/chain/client/src/sync/external.rs
@@ -143,7 +143,7 @@ impl ExternalConnection {
         match self {
             ExternalConnection::S3 { bucket } => {
                 bucket.put_object(&location, data).await?;
-                tracing::debug!(target: "state_sync_dump", shard_id, part_length = data.len(), ?location, ?file_type, "Wrote a state part to S3");
+                tracing::debug!(target: "state_sync_dump", ?shard_id, part_length = data.len(), ?location, ?file_type, "Wrote a state part to S3");
                 Ok(())
             }
             ExternalConnection::Filesystem { root_dir } => {
@@ -157,7 +157,7 @@ impl ExternalConnection {
                     .truncate(true)
                     .open(&path)?;
                 file.write_all(data)?;
-                tracing::debug!(target: "state_sync_dump", shard_id, part_length = data.len(), ?location, ?file_type, "Wrote a state part to a file");
+                tracing::debug!(target: "state_sync_dump", ?shard_id, part_length = data.len(), ?location, ?file_type, "Wrote a state part to a file");
                 Ok(())
             }
             ExternalConnection::GCS { gcs_client, bucket, .. } => {
@@ -165,7 +165,7 @@ impl ExternalConnection {
                     .object()
                     .create(bucket, data.to_vec(), location, "application/octet-stream")
                     .await?;
-                tracing::debug!(target: "state_sync_dump", shard_id, part_length = data.len(), ?location, ?file_type, "Wrote a state part to GCS");
+                tracing::debug!(target: "state_sync_dump", ?shard_id, part_length = data.len(), ?location, ?file_type, "Wrote a state part to GCS");
                 Ok(())
             }
         }
@@ -194,7 +194,7 @@ impl ExternalConnection {
             ExternalConnection::S3 { bucket } => {
                 let prefix = format!("{}/", directory_path);
                 let list_results = bucket.list(prefix.clone(), Some("/".to_string())).await?;
-                tracing::debug!(target: "state_sync_dump", shard_id, ?directory_path, "List state parts in s3");
+                tracing::debug!(target: "state_sync_dump", ?shard_id, ?directory_path, "List state parts in s3");
                 let mut file_names = vec![];
                 for res in list_results {
                     for obj in res.contents {
@@ -205,7 +205,7 @@ impl ExternalConnection {
             }
             ExternalConnection::Filesystem { root_dir } => {
                 let path = root_dir.join(directory_path);
-                tracing::debug!(target: "state_sync_dump", shard_id, ?path, "List state parts in local directory");
+                tracing::debug!(target: "state_sync_dump", ?shard_id, ?path, "List state parts in local directory");
                 std::fs::create_dir_all(&path)?;
                 let mut file_names = vec![];
                 let files = std::fs::read_dir(&path)?;
@@ -217,7 +217,7 @@ impl ExternalConnection {
             }
             ExternalConnection::GCS { gcs_client, bucket, .. } => {
                 let prefix = format!("{}/", directory_path);
-                tracing::debug!(target: "state_sync_dump", shard_id, ?directory_path, "List state parts in GCS");
+                tracing::debug!(target: "state_sync_dump", ?shard_id, ?directory_path, "List state parts in GCS");
                 Ok(gcs_client
                     .object()
                     .list(
@@ -277,7 +277,7 @@ pub fn external_storage_location(
     chain_id: &str,
     epoch_id: &EpochId,
     epoch_height: u64,
-    shard_id: u64,
+    shard_id: ShardId,
     file_type: &StateFileType,
 ) -> String {
     format!(
@@ -291,7 +291,7 @@ pub fn external_storage_location_directory(
     chain_id: &str,
     epoch_id: &EpochId,
     epoch_height: u64,
-    shard_id: u64,
+    shard_id: ShardId,
     obj_type: &StateFileType,
 ) -> String {
     location_prefix(chain_id, epoch_height, epoch_id, shard_id, obj_type)
@@ -301,7 +301,7 @@ pub fn location_prefix(
     chain_id: &str,
     epoch_height: u64,
     epoch_id: &EpochId,
-    shard_id: u64,
+    shard_id: ShardId,
     obj_type: &StateFileType,
 ) -> String {
     match obj_type {
@@ -460,23 +460,24 @@ mod test {
         let file_type = StateFileType::StatePart { part_id: 0, num_parts: 1 };
 
         // Before uploading we shouldn't see filename in the list of files.
-        let files = rt.block_on(async { connection.list_objects(0, &dir).await.unwrap() });
+        let files = rt.block_on(async { connection.list_objects(0.into(), &dir).await.unwrap() });
         tracing::debug!("Files before upload: {:?}", files);
         assert_eq!(files.into_iter().filter(|x| *x == filename).collect::<Vec<String>>().len(), 0);
 
         // Uploading the file.
         rt.block_on(async {
-            connection.put_file(file_type.clone(), &data, 0, &full_filename).await.unwrap()
+            connection.put_file(file_type.clone(), &data, 0.into(), &full_filename).await.unwrap()
         });
 
         // After uploading we should see filename in the list of files.
-        let files = rt.block_on(async { connection.list_objects(0, &dir).await.unwrap() });
+        let files = rt.block_on(async { connection.list_objects(0.into(), &dir).await.unwrap() });
         tracing::debug!("Files after upload: {:?}", files);
         assert_eq!(files.into_iter().filter(|x| *x == filename).collect::<Vec<String>>().len(), 1);
 
         // And the data should match generates data.
-        let download_data = rt
-            .block_on(async { connection.get_file(0, &full_filename, &file_type).await.unwrap() });
+        let download_data = rt.block_on(async {
+            connection.get_file(0.into(), &full_filename, &file_type).await.unwrap()
+        });
         assert_eq!(download_data, data);
 
         // Also try to download some data at nonexistent location and expect to fail.
@@ -484,7 +485,7 @@ mod test {
         let full_filename = format!("{}/{}", dir, filename);
 
         let download_data =
-            rt.block_on(async { connection.get_file(0, &full_filename, &file_type).await });
+            rt.block_on(async { connection.get_file(0.into(), &full_filename, &file_type).await });
         assert!(download_data.is_err(), "{:?}", download_data);
     }
 }

--- a/chain/client/src/sync_jobs_actor.rs
+++ b/chain/client/src/sync_jobs_actor.rs
@@ -9,7 +9,6 @@ use near_chain::chain::{
 use near_performance_metrics_macros::perf;
 use near_primitives::state_part::PartId;
 use near_primitives::state_sync::StatePartKey;
-use near_primitives::types::ShardId;
 use near_store::adapter::StoreUpdateAdapter;
 use near_store::DBCol;
 
@@ -73,7 +72,7 @@ impl SyncJobsActor {
             tracing::debug_span!(target: "sync", "apply_parts").entered();
         let store = msg.runtime_adapter.store();
 
-        let shard_id = msg.shard_uid.shard_id as ShardId;
+        let shard_id = msg.shard_uid.shard_id();
         for part_id in 0..msg.num_parts {
             let key = borsh::to_vec(&StatePartKey(msg.sync_hash, shard_id, part_id))?;
             let part = store.get(DBCol::StateParts, &key)?.unwrap();
@@ -124,7 +123,7 @@ impl SyncJobsActor {
         // Unload mem-trie (in case it is still loaded) before we apply state parts.
         msg.runtime_adapter.get_tries().unload_mem_trie(&msg.shard_uid);
 
-        let shard_id = msg.shard_uid.shard_id as ShardId;
+        let shard_id = msg.shard_uid.shard_id();
         match self.clear_flat_state(&msg) {
             Err(err) => {
                 self.client_sender.send(ApplyStatePartsResponse {

--- a/chain/client/src/test_utils/client.rs
+++ b/chain/client/src/test_utils/client.rs
@@ -22,7 +22,7 @@ use near_primitives::merkle::{merklize, PartialMerkleTree};
 use near_primitives::sharding::{EncodedShardChunk, ShardChunk};
 use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsementV1;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{BlockHeight, ShardId};
+use near_primitives::types::{new_shard_id_tmp, BlockHeight, ShardId};
 use near_primitives::utils::MaybeValidated;
 use near_primitives::version::PROTOCOL_VERSION;
 use num_rational::Ratio;
@@ -159,7 +159,7 @@ fn create_chunk_on_height_for_shard(
 }
 
 pub fn create_chunk_on_height(client: &mut Client, next_height: BlockHeight) -> ProduceChunkResult {
-    create_chunk_on_height_for_shard(client, next_height, 0.into())
+    create_chunk_on_height_for_shard(client, next_height, new_shard_id_tmp(0))
 }
 
 pub fn create_chunk_with_transactions(
@@ -190,7 +190,7 @@ pub fn create_chunk(
             last_block.header().epoch_id(),
             last_block.chunks()[0].clone(),
             next_height,
-            0.into(),
+            new_shard_id_tmp(0),
             signer.as_ref(),
         )
         .unwrap()

--- a/chain/client/src/test_utils/client.rs
+++ b/chain/client/src/test_utils/client.rs
@@ -159,7 +159,7 @@ fn create_chunk_on_height_for_shard(
 }
 
 pub fn create_chunk_on_height(client: &mut Client, next_height: BlockHeight) -> ProduceChunkResult {
-    create_chunk_on_height_for_shard(client, next_height, 0)
+    create_chunk_on_height_for_shard(client, next_height, 0.into())
 }
 
 pub fn create_chunk_with_transactions(
@@ -190,7 +190,7 @@ pub fn create_chunk(
             last_block.header().epoch_id(),
             last_block.chunks()[0].clone(),
             next_height,
-            0,
+            0.into(),
             signer.as_ref(),
         )
         .unwrap()

--- a/chain/client/src/test_utils/setup.rs
+++ b/chain/client/src/test_utils/setup.rs
@@ -448,7 +448,7 @@ fn process_peer_manager_message_default(
                             height: last_height[i],
                             hash: CryptoHash::default(),
                         }),
-                        tracked_shards: vec![0, 1, 2, 3],
+                        tracked_shards: vec![0.into(), 1.into(), 2.into(), 3.into()],
                         archival: true,
                     },
                 },

--- a/chain/client/src/test_utils/setup.rs
+++ b/chain/client/src/test_utils/setup.rs
@@ -56,7 +56,9 @@ use near_primitives::epoch_info::RngSeed;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::network::PeerId;
 use near_primitives::test_utils::create_test_signer;
-use near_primitives::types::{AccountId, BlockHeightDelta, EpochId, NumBlocks, NumSeats};
+use near_primitives::types::{
+    new_shard_id_tmp, AccountId, BlockHeightDelta, EpochId, NumBlocks, NumSeats,
+};
 use near_primitives::validator_signer::{EmptyValidatorSigner, ValidatorSigner};
 use near_primitives::version::PROTOCOL_VERSION;
 use near_store::adapter::StoreAdapter;
@@ -448,7 +450,10 @@ fn process_peer_manager_message_default(
                             height: last_height[i],
                             hash: CryptoHash::default(),
                         }),
-                        tracked_shards: vec![0.into(), 1.into(), 2.into(), 3.into()],
+                        tracked_shards: vec![0, 1, 2, 3]
+                            .into_iter()
+                            .map(new_shard_id_tmp)
+                            .collect(),
                         archival: true,
                     },
                 },

--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -524,8 +524,10 @@ impl TestEnv {
         let last_block = client.chain.get_block(&head.last_block_hash).unwrap();
         let shard_id =
             client.epoch_manager.account_id_to_shard_id(&account_id, &head.epoch_id).unwrap();
+        let shard_layout = client.epoch_manager.get_shard_layout(&head.epoch_id).unwrap();
+        let shard_index = shard_layout.get_shard_index(shard_id);
         let shard_uid = client.epoch_manager.shard_id_to_uid(shard_id, &head.epoch_id).unwrap();
-        let last_chunk_header = &last_block.chunks()[shard_id as usize];
+        let last_chunk_header = &last_block.chunks()[shard_index];
 
         for i in 0..self.clients.len() {
             let tracks_shard = self.clients[i]
@@ -582,7 +584,9 @@ impl TestEnv {
         let shard_id =
             client.epoch_manager.account_id_to_shard_id(&account_id, &head.epoch_id).unwrap();
         let shard_uid = client.epoch_manager.shard_id_to_uid(shard_id, &head.epoch_id).unwrap();
-        let last_chunk_header = &last_block.chunks()[shard_id as usize];
+        let shard_layout = client.epoch_manager.get_shard_layout(&head.epoch_id).unwrap();
+        let shard_index = shard_layout.get_shard_index(shard_id);
+        let last_chunk_header = &last_block.chunks()[shard_index];
         let response = client
             .runtime_adapter
             .query(

--- a/chain/client/src/test_utils/test_loop.rs
+++ b/chain/client/src/test_utils/test_loop.rs
@@ -58,7 +58,9 @@ where
         let shard_id =
             client.epoch_manager.account_id_to_shard_id(&account_id, &head.epoch_id).unwrap();
         let shard_uid = client.epoch_manager.shard_id_to_uid(shard_id, &head.epoch_id).unwrap();
-        let last_chunk_header = &last_block.chunks()[shard_id as usize];
+        let shard_layout = client.epoch_manager.get_shard_layout(&head.epoch_id).unwrap();
+        let shard_index = shard_layout.get_shard_index(shard_id);
+        let last_chunk_header = &last_block.chunks()[shard_index];
 
         client
             .runtime_adapter

--- a/chain/client/src/tests/bug_repros.rs
+++ b/chain/client/src/tests/bug_repros.rs
@@ -109,28 +109,30 @@ fn repro_1183() {
                     for from in ["test1", "test2", "test3", "test4"].iter() {
                         for to in ["test1", "test2", "test3", "test4"].iter() {
                             let (from, to) = (from.parse().unwrap(), to.parse().unwrap());
-                            connectors1.write().unwrap()[account_id_to_shard_id(&from, 4) as usize]
-                                .client_actor
-                                .do_send(
-                                    ProcessTxRequest {
-                                        transaction: SignedTransaction::send_money(
-                                            block.header().height() * 16 + nonce_delta,
+                            // This test uses the V0 shard layout so it's ok to
+                            // cast ShardId to ShardIndex.
+                            let shard_id = account_id_to_shard_id(&from, 4);
+                            let shard_index = shard_id.get() as usize;
+                            connectors1.write().unwrap()[shard_index].client_actor.do_send(
+                                ProcessTxRequest {
+                                    transaction: SignedTransaction::send_money(
+                                        block.header().height() * 16 + nonce_delta,
+                                        from.clone(),
+                                        to,
+                                        &InMemorySigner::from_seed(
                                             from.clone(),
-                                            to,
-                                            &InMemorySigner::from_seed(
-                                                from.clone(),
-                                                KeyType::ED25519,
-                                                from.as_ref(),
-                                            )
-                                            .into(),
-                                            1,
-                                            *block.header().prev_hash(),
-                                        ),
-                                        is_forwarded: false,
-                                        check_only: false,
-                                    }
-                                    .with_span_context(),
-                                );
+                                            KeyType::ED25519,
+                                            from.as_ref(),
+                                        )
+                                        .into(),
+                                        1,
+                                        *block.header().prev_hash(),
+                                    ),
+                                    is_forwarded: false,
+                                    check_only: false,
+                                }
+                                .with_span_context(),
+                            );
                             nonce_delta += 1
                         }
                     }

--- a/chain/client/src/tests/bug_repros.rs
+++ b/chain/client/src/tests/bug_repros.rs
@@ -112,7 +112,7 @@ fn repro_1183() {
                             // This test uses the V0 shard layout so it's ok to
                             // cast ShardId to ShardIndex.
                             let shard_id = account_id_to_shard_id(&from, 4);
-                            let shard_index = shard_id.get() as usize;
+                            let shard_index = shard_id as usize;
                             connectors1.write().unwrap()[shard_index].client_actor.do_send(
                                 ProcessTxRequest {
                                     transaction: SignedTransaction::send_money(

--- a/chain/client/src/tests/catching_up.rs
+++ b/chain/client/src/tests/catching_up.rs
@@ -23,7 +23,7 @@ use near_primitives::network::PeerId;
 use near_primitives::receipt::Receipt;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{AccountId, BlockHeight, BlockHeightDelta, BlockReference};
+use near_primitives::types::{AccountId, BlockHeight, BlockHeightDelta, BlockReference, ShardId};
 use near_primitives::views::QueryRequest;
 use near_primitives::views::QueryResponseKind::ViewAccount;
 
@@ -99,7 +99,7 @@ enum ReceiptsSyncPhases {
 
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct StateRequestStruct {
-    pub shard_id: u64,
+    pub shard_id: ShardId,
     pub sync_hash: CryptoHash,
     pub sync_prev_prev_hash: Option<CryptoHash>,
     pub part_id: Option<u64>,
@@ -714,7 +714,8 @@ fn test_all_chunks_accepted_common(
 
         let verbose = false;
 
-        let seen_chunk_same_sender = Arc::new(RwLock::new(HashSet::<(AccountId, u64, u64)>::new()));
+        let seen_chunk_same_sender =
+            Arc::new(RwLock::new(HashSet::<(AccountId, u64, ShardId)>::new()));
         let requested = Arc::new(RwLock::new(HashSet::<(AccountId, Vec<u64>, ChunkHash)>::new()));
         let responded = Arc::new(RwLock::new(HashSet::<(CryptoHash, Vec<u64>, ChunkHash)>::new()));
 

--- a/chain/client/src/tests/cross_shard_tx.rs
+++ b/chain/client/src/tests/cross_shard_tx.rs
@@ -192,7 +192,7 @@ fn test_cross_shard_tx_callback(
             // This test uses the V0 shard layout so it's ok to cast ShardId to
             // ShardIndex.
             let shard_id = account_id_to_shard_id(&account_id, 8);
-            let shard_index = shard_id.get() as usize;
+            let shard_index = shard_id as usize;
             let actor = &connectors_[shard_index + (*presumable_epoch.read().unwrap() * 8) % 24]
                 .view_client_actor;
             let actor = actor.send(
@@ -260,7 +260,7 @@ fn test_cross_shard_tx_callback(
                 // This test uses the V0 shard layout so it's ok to cast ShardId to
                 // ShardIndex.
                 let shard_id = account_id_to_shard_id(&validators[from], 8);
-                let shard_index = shard_id.get() as usize;
+                let shard_index = shard_id as usize;
 
                 send_tx(
                     validators.len(),
@@ -299,7 +299,7 @@ fn test_cross_shard_tx_callback(
                     // This test uses the V0 shard layout so it's ok to cast ShardId to
                     // ShardIndex.
                     let shard_id = account_id_to_shard_id(&validators[i], 8);
-                    let shard_index = shard_id.get() as usize;
+                    let shard_index = shard_id as usize;
 
                     let actor = &connectors_
                         [shard_index + (*presumable_epoch.read().unwrap() * 8) % 24]
@@ -359,7 +359,7 @@ fn test_cross_shard_tx_callback(
             // This test uses the V0 shard layout so it's ok to cast ShardId to
             // ShardIndex.
             let shard_id = account_id_to_shard_id(&account_id, 8);
-            let shard_index = shard_id.get() as usize;
+            let shard_index = shard_id as usize;
 
             let actor = &connectors_[shard_index + (*presumable_epoch.read().unwrap() * 8) % 24]
                 .view_client_actor;
@@ -521,7 +521,7 @@ fn test_cross_shard_tx_common(
             // This test uses the V0 shard layout so it's ok to cast ShardId to
             // ShardIndex.
             let shard_id = account_id_to_shard_id(&validators[i], 8);
-            let shard_index = shard_id.get() as usize;
+            let shard_index = shard_id as usize;
 
             let actor =
                 &connectors_[shard_index + *presumable_epoch.read().unwrap() * 8].view_client_actor;

--- a/chain/client/src/tests/cross_shard_tx.rs
+++ b/chain/client/src/tests/cross_shard_tx.rs
@@ -189,8 +189,11 @@ fn test_cross_shard_tx_callback(
             let balances1 = balances;
             let observed_balances1 = observed_balances;
             let presumable_epoch1 = presumable_epoch.clone();
-            let actor = &connectors_[account_id_to_shard_id(&account_id, 8) as usize
-                + (*presumable_epoch.read().unwrap() * 8) % 24]
+            // This test uses the V0 shard layout so it's ok to cast ShardId to
+            // ShardIndex.
+            let shard_id = account_id_to_shard_id(&account_id, 8);
+            let shard_index = shard_id.get() as usize;
+            let actor = &connectors_[shard_index + (*presumable_epoch.read().unwrap() * 8) % 24]
                 .view_client_actor;
             let actor = actor.send(
                 Query::new(
@@ -254,10 +257,15 @@ fn test_cross_shard_tx_callback(
                 let amount = (5 + iteration_local) as u128;
                 let next_nonce = nonce.fetch_add(1, Ordering::Relaxed);
 
+                // This test uses the V0 shard layout so it's ok to cast ShardId to
+                // ShardIndex.
+                let shard_id = account_id_to_shard_id(&validators[from], 8);
+                let shard_index = shard_id.get() as usize;
+
                 send_tx(
                     validators.len(),
                     connectors.clone(),
-                    account_id_to_shard_id(&validators[from], 8) as usize,
+                    shard_index,
                     validators[from].clone(),
                     validators[to].clone(),
                     amount,
@@ -287,8 +295,14 @@ fn test_cross_shard_tx_callback(
                     let presumable_epoch1 = presumable_epoch.clone();
                     let account_id1 = validators[i].clone();
                     let block_stats1 = block_stats.clone();
-                    let actor = &connectors_[account_id_to_shard_id(&validators[i], 8) as usize
-                        + (*presumable_epoch.read().unwrap() * 8) % 24]
+
+                    // This test uses the V0 shard layout so it's ok to cast ShardId to
+                    // ShardIndex.
+                    let shard_id = account_id_to_shard_id(&validators[i], 8);
+                    let shard_index = shard_id.get() as usize;
+
+                    let actor = &connectors_
+                        [shard_index + (*presumable_epoch.read().unwrap() * 8) % 24]
                         .view_client_actor;
                     let actor = actor.send(
                         Query::new(
@@ -341,8 +355,13 @@ fn test_cross_shard_tx_callback(
             let connectors_ = connectors.write().unwrap();
             let connectors1 = connectors.clone();
             let presumable_epoch1 = presumable_epoch.clone();
-            let actor = &connectors_[account_id_to_shard_id(&account_id, 8) as usize
-                + (*presumable_epoch.read().unwrap() * 8) % 24]
+
+            // This test uses the V0 shard layout so it's ok to cast ShardId to
+            // ShardIndex.
+            let shard_id = account_id_to_shard_id(&account_id, 8);
+            let shard_index = shard_id.get() as usize;
+
+            let actor = &connectors_[shard_index + (*presumable_epoch.read().unwrap() * 8) % 24]
                 .view_client_actor;
             let actor = actor.send(
                 Query::new(
@@ -498,9 +517,14 @@ fn test_cross_shard_tx_common(
             let presumable_epoch1 = presumable_epoch.clone();
             let account_id1 = validators[i].clone();
             let block_stats1 = block_stats.clone();
-            let actor = &connectors_[account_id_to_shard_id(&validators[i], 8) as usize
-                + *presumable_epoch.read().unwrap() * 8]
-                .view_client_actor;
+
+            // This test uses the V0 shard layout so it's ok to cast ShardId to
+            // ShardIndex.
+            let shard_id = account_id_to_shard_id(&validators[i], 8);
+            let shard_index = shard_id.get() as usize;
+
+            let actor =
+                &connectors_[shard_index + *presumable_epoch.read().unwrap() * 8].view_client_actor;
             let actor = actor.send(
                 Query::new(
                     BlockReference::latest(),

--- a/chain/client/src/tests/process_blocks.rs
+++ b/chain/client/src/tests/process_blocks.rs
@@ -12,6 +12,7 @@ use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::sharding::ShardChunkHeaderV3;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::validator_stake::ValidatorStake;
+use near_primitives::types::ShardId;
 use near_primitives::utils::MaybeValidated;
 use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_store::ShardUId;
@@ -78,7 +79,7 @@ fn test_bad_shard_id() {
         chunk.encoded_merkle_root(),
         chunk.encoded_length(),
         2,
-        1,
+        1.into(),
         chunk.prev_gas_used(),
         chunk.gas_limit(),
         chunk.prev_balance_burnt(),
@@ -102,7 +103,11 @@ fn test_bad_shard_id() {
     let err = env.clients[0]
         .process_block_test(MaybeValidated::from(block), Provenance::NONE)
         .unwrap_err();
-    assert_matches!(err, near_chain::Error::InvalidShardId(1));
+    if let near_chain::Error::InvalidShardId(shard_id) = err {
+        assert!(shard_id == 1.into());
+    } else {
+        panic!("Expected InvalidShardId error, got {:?}", err);
+    }
 }
 
 /// Test that if a block's content (vrf_value) is corrupted, the invalid block will not affect the node's block processing

--- a/chain/client/src/tests/process_blocks.rs
+++ b/chain/client/src/tests/process_blocks.rs
@@ -11,8 +11,8 @@ use near_primitives::network::PeerId;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::sharding::ShardChunkHeaderV3;
 use near_primitives::test_utils::create_test_signer;
+use near_primitives::types::new_shard_id_tmp;
 use near_primitives::types::validator_stake::ValidatorStake;
-use near_primitives::types::ShardId;
 use near_primitives::utils::MaybeValidated;
 use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_store::ShardUId;
@@ -79,7 +79,7 @@ fn test_bad_shard_id() {
         chunk.encoded_merkle_root(),
         chunk.encoded_length(),
         2,
-        1.into(),
+        new_shard_id_tmp(1),
         chunk.prev_gas_used(),
         chunk.gas_limit(),
         chunk.prev_balance_burnt(),
@@ -104,7 +104,7 @@ fn test_bad_shard_id() {
         .process_block_test(MaybeValidated::from(block), Provenance::NONE)
         .unwrap_err();
     if let near_chain::Error::InvalidShardId(shard_id) = err {
-        assert!(shard_id == 1.into());
+        assert!(shard_id == new_shard_id_tmp(1));
     } else {
         panic!("Expected InvalidShardId error, got {:?}", err);
     }

--- a/chain/client/src/tests/query_client.rs
+++ b/chain/client/src/tests/query_client.rs
@@ -20,7 +20,7 @@ use near_primitives::block::{Block, BlockHeader};
 use near_primitives::merkle::PartialMerkleTree;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{BlockId, BlockReference, EpochId};
+use near_primitives::types::{new_shard_id_tmp, BlockId, BlockReference, EpochId};
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{QueryRequest, QueryResponseKind};
 use num_rational::Ratio;
@@ -210,7 +210,7 @@ fn test_execution_outcome_for_chunk() {
                 .unwrap()
                 .unwrap();
             assert_eq!(execution_outcomes_in_block.len(), 1);
-            let outcomes = execution_outcomes_in_block.remove(&0.into()).unwrap();
+            let outcomes = execution_outcomes_in_block.remove(&new_shard_id_tmp(0)).unwrap();
             assert_eq!(outcomes[0].id, tx_hash);
             System::current().stop();
         });
@@ -249,7 +249,7 @@ fn test_state_request() {
             for _ in 0..30 {
                 let res = view_client
                     .send(
-                        StateRequestHeader { shard_id: 0.into(), sync_hash: block_hash }
+                        StateRequestHeader { shard_id: new_shard_id_tmp(0), sync_hash: block_hash }
                             .with_span_context(),
                     )
                     .await
@@ -258,7 +258,7 @@ fn test_state_request() {
             }
 
             // immediately query again, should be rejected
-            let shard_id = 0.into();
+            let shard_id = new_shard_id_tmp(0);
             let res = view_client
                 .send(StateRequestHeader { shard_id, sync_hash: block_hash }.with_span_context())
                 .await

--- a/chain/client/src/tests/query_client.rs
+++ b/chain/client/src/tests/query_client.rs
@@ -210,7 +210,7 @@ fn test_execution_outcome_for_chunk() {
                 .unwrap()
                 .unwrap();
             assert_eq!(execution_outcomes_in_block.len(), 1);
-            let outcomes = execution_outcomes_in_block.remove(&0).unwrap();
+            let outcomes = execution_outcomes_in_block.remove(&0.into()).unwrap();
             assert_eq!(outcomes[0].id, tx_hash);
             System::current().stop();
         });
@@ -249,7 +249,7 @@ fn test_state_request() {
             for _ in 0..30 {
                 let res = view_client
                     .send(
-                        StateRequestHeader { shard_id: 0, sync_hash: block_hash }
+                        StateRequestHeader { shard_id: 0.into(), sync_hash: block_hash }
                             .with_span_context(),
                     )
                     .await
@@ -258,14 +258,15 @@ fn test_state_request() {
             }
 
             // immediately query again, should be rejected
+            let shard_id = 0.into();
             let res = view_client
-                .send(StateRequestHeader { shard_id: 0, sync_hash: block_hash }.with_span_context())
+                .send(StateRequestHeader { shard_id, sync_hash: block_hash }.with_span_context())
                 .await
                 .unwrap();
             assert!(res.is_none());
             actix::clock::sleep(std::time::Duration::from_secs(40)).await;
             let res = view_client
-                .send(StateRequestHeader { shard_id: 0, sync_hash: block_hash }.with_span_context())
+                .send(StateRequestHeader { shard_id, sync_hash: block_hash }.with_span_context())
                 .await
                 .unwrap();
             assert!(res.is_some());

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -118,6 +118,8 @@ pub trait EpochManagerAdapter: Send + Sync {
     /// resharding happened and some shards were split.
     /// If there was no resharding, it just returns `shard_ids` as is, without any validation.
     /// The resulting Vec will always be of the same length as the `shard_ids` argument.
+    ///
+    /// TODO(wacban) - rename to reflect the new return type
     fn get_prev_shard_ids(
         &self,
         prev_hash: &CryptoHash,
@@ -130,6 +132,8 @@ pub trait EpochManagerAdapter: Send + Sync {
     /// Most of the times parent of the shard is the shard itself, unless a
     /// resharding happened and some shards were split.
     /// If there was no resharding, it just returns the `shard_id` as is, without any validation.
+    ///
+    /// TODO(wacban) - rename to reflect the new return type
     fn get_prev_shard_id(
         &self,
         prev_hash: &CryptoHash,

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -12,7 +12,7 @@ use near_primitives::epoch_manager::{
 };
 use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
-use near_primitives::shard_layout::ShardLayout;
+use near_primitives::shard_layout::{self, ShardLayout};
 use near_primitives::stateless_validation::validator_assignment::ChunkValidatorAssignments;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
@@ -1038,15 +1038,17 @@ impl EpochManager {
         }
 
         let epoch_info = self.get_epoch_info(epoch_id)?;
+        let shard_layout = self.get_shard_layout(epoch_id)?;
         let chunk_validators_per_shard = epoch_info.sample_chunk_validators(height);
-        for (shard_id, chunk_validators) in chunk_validators_per_shard.into_iter().enumerate() {
+        for (shard_index, chunk_validators) in chunk_validators_per_shard.into_iter().enumerate() {
             let chunk_validators = chunk_validators
                 .into_iter()
                 .map(|(validator_id, assignment_weight)| {
                     (epoch_info.get_validator(validator_id).take_account_id(), assignment_weight)
                 })
                 .collect();
-            let cache_key = (*epoch_id, shard_id as ShardId, height);
+            let shard_id = shard_layout.get_shard_id(shard_index);
+            let cache_key = (*epoch_id, shard_id, height);
             self.chunk_validators_cache
                 .put(cache_key, Arc::new(ChunkValidatorAssignments::new(chunk_validators)));
         }
@@ -1131,7 +1133,9 @@ impl EpochManager {
         shard_id: ShardId,
     ) -> Result<ValidatorStake, EpochError> {
         let epoch_info = self.get_epoch_info(epoch_id)?;
-        let validator_id = Self::chunk_producer_from_info(&epoch_info, height, shard_id)?;
+        let shard_layout = self.get_shard_layout(epoch_id)?;
+        let validator_id =
+            Self::chunk_producer_from_info(&epoch_info, &shard_layout, shard_id, height)?;
         Ok(epoch_info.get_validator(validator_id))
     }
 
@@ -1190,9 +1194,13 @@ impl EpochManager {
         shard_id: ShardId,
     ) -> Result<bool, EpochError> {
         let epoch_info = self.get_epoch_info(&epoch_id)?;
+
+        let shard_layout = self.get_shard_layout(&epoch_id)?;
+        let shard_index = shard_layout.get_shard_index(shard_id);
+
         let chunk_producers_settlement = epoch_info.chunk_producers_settlement();
         let chunk_producers = chunk_producers_settlement
-            .get(shard_id as usize)
+            .get(shard_index)
             .ok_or_else(|| EpochError::ShardingError(format!("invalid shard id {shard_id}")))?;
         for validator_id in chunk_producers.iter() {
             if epoch_info.validator_account_id(*validator_id) == account_id {
@@ -1409,16 +1417,18 @@ impl EpochManager {
             ValidatorInfoIdentifier::BlockHash(ref b) => self.get_epoch_id(b)?,
         };
         let cur_epoch_info = self.get_epoch_info(&epoch_id)?;
+        let cur_shard_layout = self.get_shard_layout(&epoch_id)?;
         let epoch_height = cur_epoch_info.epoch_height();
         let epoch_start_height = self.get_epoch_start_from_epoch_id(&epoch_id)?;
         let mut validator_to_shard = (0..cur_epoch_info.validators_len())
             .map(|_| HashSet::default())
             .collect::<Vec<HashSet<ShardId>>>();
-        for (shard_id, validators) in
+        for (shard_index, validators) in
             cur_epoch_info.chunk_producers_settlement().into_iter().enumerate()
         {
+            let shard_id = cur_shard_layout.get_shard_id(shard_index);
             for validator_id in validators {
-                validator_to_shard[*validator_id as usize].insert(shard_id as ShardId);
+                validator_to_shard[*validator_id as usize].insert(shard_id);
             }
         }
 
@@ -1581,14 +1591,16 @@ impl EpochManager {
         };
 
         let next_epoch_info = self.get_epoch_info(&next_epoch_id)?;
+        let next_shard_layout = self.get_shard_layout(&next_epoch_id)?;
         let mut next_validator_to_shard = (0..next_epoch_info.validators_len())
             .map(|_| HashSet::default())
             .collect::<Vec<HashSet<ShardId>>>();
-        for (shard_id, validators) in
+        for (shard_index, validators) in
             next_epoch_info.chunk_producers_settlement().iter().enumerate()
         {
+            let shard_id = next_shard_layout.get_shard_id(shard_index);
             for validator_id in validators {
-                next_validator_to_shard[*validator_id as usize].insert(shard_id as u64);
+                next_validator_to_shard[*validator_id as usize].insert(shard_id);
             }
         }
         let next_validators = next_epoch_info
@@ -1693,10 +1705,11 @@ impl EpochManager {
     #[inline]
     pub(crate) fn chunk_producer_from_info(
         epoch_info: &EpochInfo,
-        height: BlockHeight,
+        shard_layout: &ShardLayout,
         shard_id: ShardId,
+        height: BlockHeight,
     ) -> Result<ValidatorId, EpochError> {
-        epoch_info.sample_chunk_producer(height, shard_id).ok_or_else(|| {
+        epoch_info.sample_chunk_producer(shard_layout, shard_id, height).ok_or_else(|| {
             EpochError::ChunkProducerSelectionError(format!(
                 "Invalid shard {shard_id} for height {height}"
             ))

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -1998,6 +1998,7 @@ impl EpochManager {
 
         let epoch_id = *self.get_block_info(block_hash)?.epoch_id();
         let epoch_info = self.get_epoch_info(&epoch_id)?;
+        let shard_layout = self.get_shard_layout(&epoch_id)?;
 
         let mut aggregator = EpochInfoAggregator::new(epoch_id, *block_hash);
         let mut cur_hash = *block_hash;
@@ -2053,7 +2054,7 @@ impl EpochManager {
             };
 
             let block_info = self.get_block_info(&cur_hash)?;
-            aggregator.update_tail(&block_info, &epoch_info, prev_height);
+            aggregator.update_tail(&block_info, &epoch_info, &shard_layout, prev_height);
 
             if prev_hash == self.epoch_info_aggregator.last_block_hash {
                 // We’ve reached sync point of the old aggregator.  If old

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -12,7 +12,7 @@ use near_primitives::epoch_manager::{
 };
 use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
-use near_primitives::shard_layout::{self, ShardLayout};
+use near_primitives::shard_layout::ShardLayout;
 use near_primitives::stateless_validation::validator_assignment::ChunkValidatorAssignments;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{

--- a/chain/epoch-manager/src/shard_assignment.rs
+++ b/chain/epoch-manager/src/shard_assignment.rs
@@ -342,8 +342,7 @@ pub(crate) fn assign_chunk_producers_to_shards(
 
 pub(crate) mod old_validator_selection {
     use crate::shard_assignment::{assign_to_satisfy_shards_inner, HasStake, NotEnoughValidators};
-    use near_primitives::types::{Balance, NumShards, ShardId};
-    use near_primitives::utils::min_heap::MinHeap;
+    use near_primitives::types::NumShards;
 
     use super::{
         StakeFirstShardAssignment, StakeFirstShardAssignmentItem, ValidatorsFirstShardAssignment,

--- a/chain/epoch-manager/src/shard_assignment.rs
+++ b/chain/epoch-manager/src/shard_assignment.rs
@@ -1,7 +1,8 @@
 use crate::EpochInfo;
 use crate::RngSeed;
 use near_primitives::types::validator_stake::ValidatorStake;
-use near_primitives::types::{Balance, NumShards, ShardId};
+use near_primitives::types::ShardIndex;
+use near_primitives::types::{Balance, NumShards};
 use near_primitives::utils::min_heap::{MinHeap, PeekMut};
 use rand::Rng;
 use std::collections::{BTreeSet, HashMap, HashSet};
@@ -22,21 +23,48 @@ impl HasStake for ValidatorStake {
     }
 }
 
+/// A helper struct to maintain the shard assignment sorted by the number of
+/// validators assigned to each shard.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct ValidatorsFirstShardAssignmentItem {
+    validators: usize,
+    stake: Balance,
+    shard_index: ShardIndex,
+}
+
+type ValidatorsFirstShardAssignment = MinHeap<ValidatorsFirstShardAssignmentItem>;
+
+/// A helper struct to maintain the shard assignment sorted by the stake
+/// assigned to each shard.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct StakeFirstShardAssignmentItem {
+    stake: Balance,
+    validators: usize,
+    shard_index: ShardIndex,
+}
+
+type StakeFirstShardAssignment = MinHeap<StakeFirstShardAssignmentItem>;
+
+impl From<ValidatorsFirstShardAssignmentItem> for StakeFirstShardAssignmentItem {
+    fn from(v: ValidatorsFirstShardAssignmentItem) -> Self {
+        Self { validators: v.validators, stake: v.stake, shard_index: v.shard_index }
+    }
+}
+
 fn assign_to_satisfy_shards_inner<T: HasStake + Eq, I: Iterator<Item = (usize, T)>>(
-    shard_index: &mut MinHeap<(usize, Balance, ShardId)>,
+    shard_assignment: &mut ValidatorsFirstShardAssignment,
     result: &mut Vec<Vec<T>>,
     cp_iter: &mut I,
     min_validators_per_shard: usize,
 ) {
-    let mut buffer = Vec::with_capacity(shard_index.len());
-    // Stores (shard_id, cp_index) meaning that cp at cp_index has already been
-    // added to shard shard_id.  Used to make sure we don’t add a cp to the same
+    let mut buffer = Vec::with_capacity(shard_assignment.len());
+    // Stores (shard_index, cp_index) meaning that cp at cp_index has already been
+    // added to shard shard_index.  Used to make sure we don’t add a cp to the same
     // shard multiple times.
-    let mut seen = std::collections::HashSet::<(ShardId, usize)>::with_capacity(
-        result.len() * min_validators_per_shard,
-    );
+    let seen_capacity = result.len() * min_validators_per_shard;
+    let mut seen = HashSet::<(ShardIndex, usize)>::with_capacity(seen_capacity);
 
-    while shard_index.peek().unwrap().0 < min_validators_per_shard {
+    while shard_assignment.peek().unwrap().validators < min_validators_per_shard {
         // cp_iter is an infinite cycle iterator so getting next value can never
         // fail.  cp_index is index of each element in the iterator but the
         // indexing is done before cycling thus the same cp always gets the same
@@ -45,26 +73,26 @@ fn assign_to_satisfy_shards_inner<T: HasStake + Eq, I: Iterator<Item = (usize, T
         // Decide which shard to assign this chunk producer to.  We mustn’t
         // assign producers to a single shard multiple times.
         loop {
-            match shard_index.peek_mut() {
+            match shard_assignment.peek_mut() {
                 None => {
                     // No shards left which don’t already contain this chunk
                     // producer.  Skip it and move to another producer.
                     break;
                 }
-                Some(top) if top.0 >= min_validators_per_shard => {
-                    // `shard_index` is sorted by number of chunk producers,
+                Some(top) if top.validators >= min_validators_per_shard => {
+                    // `shard_assignment` is sorted by number of chunk producers,
                     // thus all remaining shards have min_validators_per_shard
                     // producers already assigned to them.  Don’t assign current
                     // one to any shard and move to next cp.
                     break;
                 }
-                Some(mut top) if seen.insert((top.2, cp_index)) => {
+                Some(mut top) if seen.insert((top.shard_index, cp_index)) => {
                     // Chunk producer is not yet assigned to the shard and the
                     // shard still needs more producers.  Assign `cp` to it and
                     // move to next one.
-                    top.0 += 1;
-                    top.1 += cp.get_stake();
-                    result[usize::try_from(top.2).unwrap()].push(cp);
+                    top.validators += 1;
+                    top.stake += cp.get_stake();
+                    result[top.shard_index].push(cp);
                     break;
                 }
                 Some(top) => {
@@ -78,7 +106,7 @@ fn assign_to_satisfy_shards_inner<T: HasStake + Eq, I: Iterator<Item = (usize, T
         }
         // Any shards we skipped over (because `cp` was already assigned to
         // them) need to be put back into the heap.
-        shard_index.extend(buffer.drain(..));
+        shard_assignment.extend(buffer.drain(..));
     }
 }
 
@@ -93,15 +121,21 @@ fn assign_to_satisfy_shards<T: HasStake + Eq + Clone>(
     let mut result: Vec<Vec<T>> = (0..num_shards).map(|_| Vec::new()).collect();
 
     // Initially, sort by number of validators first so we fill shards up.
-    let mut shard_index: MinHeap<(usize, Balance, ShardId)> =
-        (0..num_shards).map(|s| (0, 0, s)).collect();
+    let mut shard_assignment: ValidatorsFirstShardAssignment = (0..num_shards)
+        .map(|shard_index| shard_index as usize)
+        .map(|shard_index| ValidatorsFirstShardAssignmentItem {
+            validators: 0,
+            stake: 0,
+            shard_index,
+        })
+        .collect();
 
     // Distribute chunk producers until all shards have at least the
     // minimum requested number.  If there are not enough validators to satisfy
     // that requirement, assign some of the validators to multiple shards.
     let mut chunk_producers = chunk_producers.into_iter().enumerate().cycle();
     assign_to_satisfy_shards_inner(
-        &mut shard_index,
+        &mut shard_assignment,
         &mut result,
         &mut chunk_producers,
         min_validators_per_shard,
@@ -153,7 +187,11 @@ struct ShardSetItem {
 ///
 /// Caller must guarantee that `min_validators_per_shard` is achievable and
 /// `prev_chunk_producers_assignment` corresponds to the same number of shards.
+///
 /// TODO(resharding) - implement shard assignment
+/// The current shard assignment works fully based on the ShardIndex. During
+/// resharding those indices will change and the assignment will move many
+/// validators to different shards. This should be avoided.
 fn assign_to_balance_shards(
     chunk_producers: Vec<ValidatorStake>,
     num_shards: NumShards,
@@ -307,6 +345,11 @@ pub(crate) mod old_validator_selection {
     use near_primitives::types::{Balance, NumShards, ShardId};
     use near_primitives::utils::min_heap::MinHeap;
 
+    use super::{
+        StakeFirstShardAssignment, StakeFirstShardAssignmentItem, ValidatorsFirstShardAssignment,
+        ValidatorsFirstShardAssignmentItem,
+    };
+
     /// Assign chunk producers (a.k.a. validators) to shards.  The i-th element
     /// of the output corresponds to the validators assigned to the i-th shard.
     ///
@@ -344,15 +387,21 @@ pub(crate) mod old_validator_selection {
         let mut result: Vec<Vec<T>> = (0..num_shards).map(|_| Vec::new()).collect();
 
         // Initially, sort by number of validators first so we fill shards up.
-        let mut shard_index: MinHeap<(usize, Balance, ShardId)> =
-            (0..num_shards).map(|s| (0, 0, s)).collect();
+        let mut shard_assignment: ValidatorsFirstShardAssignment = (0..num_shards)
+            .map(|shard_index| shard_index as usize)
+            .map(|shard_index| ValidatorsFirstShardAssignmentItem {
+                validators: 0,
+                stake: 0,
+                shard_index,
+            })
+            .collect();
 
         // First, distribute chunk producers until all shards have at least the
         // minimum requested number.  If there are not enough validators to satisfy
         // that requirement, assign some of the validators to multiple shards.
         let mut chunk_producers = chunk_producers.into_iter().enumerate().cycle();
         assign_to_satisfy_shards_inner(
-            &mut shard_index,
+            &mut shard_assignment,
             &mut result,
             &mut chunk_producers,
             min_validators_per_shard,
@@ -364,20 +413,21 @@ pub(crate) mod old_validator_selection {
             num_chunk_producers.saturating_sub(num_shards as usize * min_validators_per_shard);
         if remaining_producers > 0 {
             // Re-index shards to favour lowest stake first.
-            let mut shard_index: MinHeap<(Balance, usize, ShardId)> = shard_index
-                .into_iter()
-                .map(|(count, stake, shard_id)| (stake, count, shard_id))
-                .collect();
+            let mut shard_assignment: StakeFirstShardAssignment =
+                shard_assignment.into_iter().map(Into::into).collect();
 
             for (_, cp) in chunk_producers.take(remaining_producers) {
-                let (least_stake, least_validator_count, shard_id) =
-                    shard_index.pop().expect("shard_index should never be empty");
-                shard_index.push((
-                    least_stake + cp.get_stake(),
-                    least_validator_count + 1,
-                    shard_id,
-                ));
-                result[usize::try_from(shard_id).unwrap()].push(cp);
+                let StakeFirstShardAssignmentItem {
+                    stake: least_stake,
+                    validators: least_validator_count,
+                    shard_index,
+                } = shard_assignment.pop().expect("shard_assignment should never be empty");
+                shard_assignment.push(StakeFirstShardAssignmentItem {
+                    stake: least_stake + cp.get_stake(),
+                    validators: least_validator_count + 1,
+                    shard_index,
+                });
+                result[shard_index].push(cp);
             }
         }
 
@@ -390,7 +440,7 @@ mod tests {
     use crate::shard_assignment::{assign_chunk_producers_to_shards, NotEnoughValidators};
     use crate::RngSeed;
     use near_primitives::types::validator_stake::ValidatorStake;
-    use near_primitives::types::{AccountId, Balance, NumShards};
+    use near_primitives::types::{AccountId, Balance, NumShards, ShardIndex};
     use std::collections::{HashMap, HashSet};
 
     const EXPONENTIAL_STAKES: [Balance; 12] = [100, 90, 81, 73, 66, 59, 53, 48, 43, 39, 35, 31];
@@ -486,12 +536,12 @@ mod tests {
         let mut assignments = assignments
             .into_iter()
             .enumerate()
-            .map(|(shard_id, cps)| {
+            .map(|(shard_index, cps)| {
                 // All shards must have at least min_validators_per_shard validators.
                 assert!(
                     cps.len() >= min_validators_per_shard,
                     "Shard {} has only {} chunk producers; expected at least {}",
-                    shard_id,
+                    shard_index,
                     cps.len(),
                     min_validators_per_shard
                 );
@@ -500,7 +550,7 @@ mod tests {
                     cps.len(),
                     cps.iter().map(|cp| cp.0).collect::<HashSet<_>>().len(),
                     "Shard {} contains duplicate chunk producers: {:?}",
-                    shard_id,
+                    shard_index,
                     cps
                 );
                 // If all is good, aggregate as (cps_count, total_stake) pair.
@@ -520,12 +570,12 @@ mod tests {
             / (stakes.len() as Balance);
         let assignment = assign_shards(stakes, num_shards, min_validators_per_shard)
             .expect("There should have been enough validators");
-        for (shard_id, &cps) in assignment.iter().enumerate() {
+        for (shard_index, &cps) in assignment.iter().enumerate() {
             // Validator distribution should be even.
             assert_eq!(
                 validators_per_shard, cps.0,
                 "Shard {} has {} validators, expected {}",
-                shard_id, cps.0, validators_per_shard
+                shard_index, cps.0, validators_per_shard
             );
 
             // Stake distribution should be even
@@ -533,7 +583,7 @@ mod tests {
             assert!(
                 diff.abs() < diff_tolerance,
                 "Shard {}'s stake {} is {} away from average; expected less than {} away",
-                shard_id,
+                shard_index,
                 cps.1,
                 diff.abs(),
                 diff_tolerance
@@ -724,12 +774,12 @@ mod tests {
         assert_eq!(assignment, target_assignment);
     }
 
-    fn validator_to_shard(assignment: &[Vec<ValidatorStake>]) -> HashMap<AccountId, usize> {
+    fn validator_to_shard(assignment: &[Vec<ValidatorStake>]) -> HashMap<AccountId, ShardIndex> {
         assignment
             .iter()
             .enumerate()
-            .flat_map(|(shard_id, cps)| {
-                cps.iter().map(move |cp| (cp.account_id().clone(), shard_id))
+            .flat_map(|(shard_index, cps)| {
+                cps.iter().map(move |cp| (cp.account_id().clone(), shard_index))
             })
             .collect()
     }

--- a/chain/epoch-manager/src/shard_tracker.rs
+++ b/chain/epoch-manager/src/shard_tracker.rs
@@ -218,7 +218,9 @@ mod tests {
     use near_primitives::hash::CryptoHash;
     use near_primitives::shard_layout::ShardLayout;
     use near_primitives::types::validator_stake::ValidatorStake;
-    use near_primitives::types::{BlockHeight, EpochId, NumShards, ProtocolVersion, ShardId};
+    use near_primitives::types::{
+        new_shard_id_tmp, BlockHeight, EpochId, NumShards, ProtocolVersion, ShardId,
+    };
     use near_primitives::version::ProtocolFeature::SimpleNightshade;
     use near_primitives::version::PROTOCOL_VERSION;
     use near_store::test_utils::create_test_store;
@@ -337,7 +339,7 @@ mod tests {
 
     #[test]
     fn test_track_accounts() {
-        let shard_ids = (0..4).map(Into::into).collect_vec();
+        let shard_ids = (0..4).map(new_shard_id_tmp).collect_vec();
         let epoch_manager =
             get_epoch_manager(PROTOCOL_VERSION, shard_ids.len() as NumShards, false);
         let shard_layout = epoch_manager.read().get_shard_layout(&EpochId::default()).unwrap();
@@ -362,7 +364,7 @@ mod tests {
 
     #[test]
     fn test_track_all_shards() {
-        let shard_ids = (0..4).map(Into::into).collect_vec();
+        let shard_ids = (0..4).map(new_shard_id_tmp).collect_vec();
         let epoch_manager =
             get_epoch_manager(PROTOCOL_VERSION, shard_ids.len() as NumShards, false);
         let tracker = ShardTracker::new(TrackedConfig::AllShards, Arc::new(epoch_manager));
@@ -381,13 +383,16 @@ mod tests {
     #[test]
     fn test_track_schedule() {
         // Creates a ShardTracker that changes every epoch tracked shards.
-        let shard_ids = (0..4).map(Into::into).collect_vec();
+        let shard_ids = (0..4).map(new_shard_id_tmp).collect_vec();
 
         let epoch_manager =
             Arc::new(get_epoch_manager(PROTOCOL_VERSION, shard_ids.len() as NumShards, false));
-        let subset1: HashSet<ShardId> = HashSet::from([0, 1]).into_iter().map(Into::into).collect();
-        let subset2: HashSet<ShardId> = HashSet::from([1, 2]).into_iter().map(Into::into).collect();
-        let subset3: HashSet<ShardId> = HashSet::from([2, 3]).into_iter().map(Into::into).collect();
+        let subset1: HashSet<ShardId> =
+            HashSet::from([0, 1]).into_iter().map(new_shard_id_tmp).collect();
+        let subset2: HashSet<ShardId> =
+            HashSet::from([1, 2]).into_iter().map(new_shard_id_tmp).collect();
+        let subset3: HashSet<ShardId> =
+            HashSet::from([2, 3]).into_iter().map(new_shard_id_tmp).collect();
         let tracker = ShardTracker::new(
             TrackedConfig::Schedule(vec![
                 subset1.clone().into_iter().collect(),

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -23,10 +23,10 @@ use near_primitives::sharding::{ShardChunkHeader, ShardChunkHeaderV3};
 use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsementV1;
 use near_primitives::stateless_validation::chunk_endorsements_bitmap::ChunkEndorsementsBitmap;
 use near_primitives::stateless_validation::partial_witness::PartialEncodedStateWitness;
-use near_primitives::types::ShardIndex;
 use near_primitives::types::ValidatorKickoutReason::{
     NotEnoughBlocks, NotEnoughChunkEndorsements, NotEnoughChunks,
 };
+use near_primitives::types::{new_shard_id_tmp, ShardIndex};
 use near_primitives::validator_signer::ValidatorSigner;
 use near_primitives::version::ProtocolFeature::{self, SimpleNightshade};
 use near_primitives::version::PROTOCOL_VERSION;
@@ -1101,7 +1101,7 @@ fn test_expected_chunks_prev_block_not_produced() {
         let expected_chunk_producer = EpochManager::chunk_producer_from_info(
             &epoch_info,
             &shard_layout,
-            0.into(),
+            new_shard_id_tmp(0),
             prev_height + 1,
         )
         .unwrap();
@@ -2601,13 +2601,13 @@ fn test_validator_kickout_determinism() {
         (4, ChunkStats::new_with_endorsement(89, 100)),
     ]);
     let chunk_stats_tracker1 = HashMap::from([
-        (0.into(), chunk_stats0.clone().into_iter().collect()),
-        (1.into(), chunk_stats1.clone().into_iter().collect()),
+        (new_shard_id_tmp(0), chunk_stats0.clone().into_iter().collect()),
+        (new_shard_id_tmp(1), chunk_stats1.clone().into_iter().collect()),
     ]);
     let chunk_stats0: Vec<_> = chunk_stats0.into_iter().rev().collect();
     let chunk_stats_tracker2 = HashMap::from([
-        (0.into(), chunk_stats0.into_iter().collect()),
-        (1.into(), chunk_stats1.into_iter().collect()),
+        (new_shard_id_tmp(0), chunk_stats0.into_iter().collect()),
+        (new_shard_id_tmp(1), chunk_stats1.into_iter().collect()),
     ]);
     let (_validator_stats, kickouts1) = EpochManager::compute_validators_to_reward_and_kickout(
         &epoch_config,
@@ -2670,8 +2670,8 @@ fn test_chunk_validators_with_different_endorsement_ratio() {
         (3, ChunkStats::new_with_endorsement(60, 100)),
     ]);
     let chunk_stats_tracker = HashMap::from([
-        (0.into(), chunk_stats0.into_iter().collect()),
-        (1.into(), chunk_stats1.into_iter().collect()),
+        (new_shard_id_tmp(0), chunk_stats0.into_iter().collect()),
+        (new_shard_id_tmp(1), chunk_stats1.into_iter().collect()),
     ]);
     let (_validator_stats, kickouts) = EpochManager::compute_validators_to_reward_and_kickout(
         &epoch_config,
@@ -2732,8 +2732,8 @@ fn test_chunk_validators_with_same_endorsement_ratio_and_different_stake() {
         (3, ChunkStats::new_with_endorsement(65, 100)),
     ]);
     let chunk_stats_tracker = HashMap::from([
-        (0.into(), chunk_stats0.into_iter().collect()),
-        (1.into(), chunk_stats1.into_iter().collect()),
+        (new_shard_id_tmp(0), chunk_stats0.into_iter().collect()),
+        (new_shard_id_tmp(1), chunk_stats1.into_iter().collect()),
     ]);
     let (_validator_stats, kickouts) = EpochManager::compute_validators_to_reward_and_kickout(
         &epoch_config,
@@ -2794,8 +2794,8 @@ fn test_chunk_validators_with_same_endorsement_ratio_and_stake() {
         (3, ChunkStats::new_with_endorsement(65, 100)),
     ]);
     let chunk_stats_tracker = HashMap::from([
-        (0.into(), chunk_stats0.into_iter().collect()),
-        (1.into(), chunk_stats1.into_iter().collect()),
+        (new_shard_id_tmp(0), chunk_stats0.into_iter().collect()),
+        (new_shard_id_tmp(1), chunk_stats1.into_iter().collect()),
     ]);
     let (_validator_stats, kickouts) = EpochManager::compute_validators_to_reward_and_kickout(
         &epoch_config,
@@ -2843,7 +2843,7 @@ fn test_validator_kickout_sanity() {
     ]);
     let chunk_stats_tracker = HashMap::from([
         (
-            0.into(),
+            new_shard_id_tmp(0),
             HashMap::from([
                 (0, ChunkStats::new_with_production(100, 100)),
                 (
@@ -2861,7 +2861,7 @@ fn test_validator_kickout_sanity() {
             ]),
         ),
         (
-            1.into(),
+            new_shard_id_tmp(1),
             HashMap::from([
                 (0, ChunkStats::new_with_production(70, 100)),
                 (
@@ -2981,7 +2981,7 @@ fn test_chunk_endorsement_stats() {
         ]),
         &HashMap::from([
             (
-                0.into(),
+                new_shard_id_tmp(0),
                 HashMap::from([
                     (0, ChunkStats::new(100, 100, 100, 100)),
                     (1, ChunkStats::new(90, 100, 100, 100)),
@@ -2990,7 +2990,7 @@ fn test_chunk_endorsement_stats() {
                 ]),
             ),
             (
-                1.into(),
+                new_shard_id_tmp(1),
                 HashMap::from([
                     (0, ChunkStats::new(95, 100, 100, 100)),
                     (1, ChunkStats::new(95, 100, 90, 100)),
@@ -3062,14 +3062,14 @@ fn test_max_kickout_stake_ratio() {
     ]);
     let chunk_stats_tracker = HashMap::from([
         (
-            0.into(),
+            new_shard_id_tmp(0),
             HashMap::from([
                 (0, ChunkStats::new_with_production(0, 100)),
                 (1, ChunkStats::new_with_production(0, 100)),
             ]),
         ),
         (
-            1.into(),
+            new_shard_id_tmp(1),
             HashMap::from([
                 (2, ChunkStats::new_with_production(100, 100)),
                 (4, ChunkStats::new_with_production(50, 100)),
@@ -3192,7 +3192,7 @@ fn test_chunk_validator_kickout(
     ]);
     let chunk_stats_tracker = HashMap::from([
         (
-            0.into(),
+            new_shard_id_tmp(0),
             HashMap::from([
                 (0, ChunkStats::new_with_production(90, 100)),
                 (1, ChunkStats::new_with_production(90, 100)),
@@ -3202,7 +3202,7 @@ fn test_chunk_validator_kickout(
             ]),
         ),
         (
-            1.into(),
+            new_shard_id_tmp(1),
             HashMap::from([
                 (0, ChunkStats::new_with_production(90, 100)),
                 (2, ChunkStats::new_with_production(90, 100)),
@@ -3270,7 +3270,7 @@ fn test_block_and_chunk_producer_not_kicked_out_for_low_endorsements() {
     ]);
     let chunk_stats_tracker = HashMap::from([
         (
-            0.into(),
+            new_shard_id_tmp(0),
             HashMap::from([
                 (0, ChunkStats::new(90, 100, 10, 100)),
                 (1, ChunkStats::new(90, 100, 10, 100)),
@@ -3278,7 +3278,7 @@ fn test_block_and_chunk_producer_not_kicked_out_for_low_endorsements() {
             ]),
         ),
         (
-            1.into(),
+            new_shard_id_tmp(1),
             HashMap::from([
                 (0, ChunkStats::new(90, 100, 10, 100)),
                 (1, ChunkStats::new(90, 100, 10, 100)),
@@ -3312,7 +3312,7 @@ fn test_chunk_header(h: &[CryptoHash], signer: &ValidatorSigner) -> ShardChunkHe
         h[2],
         0,
         1,
-        0.into(),
+        new_shard_id_tmp(0),
         0,
         0,
         0,
@@ -3346,7 +3346,7 @@ fn test_verify_chunk_endorsements() {
 
     // verify if we have one chunk validator
     let chunk_validator_assignments =
-        &epoch_manager.get_chunk_validator_assignments(&epoch_id, 0.into(), 1).unwrap();
+        &epoch_manager.get_chunk_validator_assignments(&epoch_id, new_shard_id_tmp(0), 1).unwrap();
     assert_eq!(chunk_validator_assignments.ordered_chunk_validators().len(), 1);
     assert!(chunk_validator_assignments.contains(&account_id));
 

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -18,7 +18,7 @@ use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::epoch_block_info::BlockInfoV3;
 use near_primitives::epoch_manager::EpochConfig;
 use near_primitives::hash::hash;
-use near_primitives::shard_layout::{self, ShardLayout};
+use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::{ShardChunkHeader, ShardChunkHeaderV3};
 use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsementV1;
 use near_primitives::stateless_validation::chunk_endorsements_bitmap::ChunkEndorsementsBitmap;

--- a/chain/epoch-manager/src/tests/random_epochs.rs
+++ b/chain/epoch-manager/src/tests/random_epochs.rs
@@ -327,7 +327,6 @@ fn verify_block_stats(
                 epoch_manager.get_epoch_info_aggregator_upto_last(&block_hashes[i]).unwrap();
             let epoch_id = block_infos[i].epoch_id();
             let epoch_info = epoch_manager.get_epoch_info(epoch_id).unwrap();
-            let shard_layout = epoch_manager.get_shard_layout(epoch_id).unwrap();
             for key in aggregator.block_tracker.keys().copied() {
                 assert!(key < epoch_info.validators_iter().len() as u64);
             }

--- a/chain/epoch-manager/src/tests/random_epochs.rs
+++ b/chain/epoch-manager/src/tests/random_epochs.rs
@@ -342,7 +342,10 @@ fn verify_block_stats(
                 aggregator.block_tracker.values().map(|value| value.expected).sum::<u64>();
             assert_eq!(sum_produced, blocks_in_epoch);
             assert_eq!(sum_expected, blocks_in_epoch_expected);
-            for shard_id in shard_layout.shard_ids() {
+            // TODO: The following sophisticated check doesn't do anything. The
+            // shard tracker is empty because the chunk mask in all block infos
+            // is empty.
+            for &shard_id in aggregator.shard_tracker.keys() {
                 let sum_produced = aggregator
                     .shard_tracker
                     .get(&shard_id)

--- a/chain/epoch-manager/src/tests/random_epochs.rs
+++ b/chain/epoch-manager/src/tests/random_epochs.rs
@@ -325,7 +325,9 @@ fn verify_block_stats(
         {
             let aggregator =
                 epoch_manager.get_epoch_info_aggregator_upto_last(&block_hashes[i]).unwrap();
-            let epoch_info = epoch_manager.get_epoch_info(block_infos[i].epoch_id()).unwrap();
+            let epoch_id = block_infos[i].epoch_id();
+            let epoch_info = epoch_manager.get_epoch_info(epoch_id).unwrap();
+            let shard_layout = epoch_manager.get_shard_layout(epoch_id).unwrap();
             for key in aggregator.block_tracker.keys().copied() {
                 assert!(key < epoch_info.validators_iter().len() as u64);
             }
@@ -340,7 +342,7 @@ fn verify_block_stats(
                 aggregator.block_tracker.values().map(|value| value.expected).sum::<u64>();
             assert_eq!(sum_produced, blocks_in_epoch);
             assert_eq!(sum_expected, blocks_in_epoch_expected);
-            for shard_id in 0..(aggregator.shard_tracker.len() as u64) {
+            for shard_id in shard_layout.shard_ids() {
                 let sum_produced = aggregator
                     .shard_tracker
                     .get(&shard_id)

--- a/chain/epoch-manager/src/types.rs
+++ b/chain/epoch-manager/src/types.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 use near_primitives::epoch_block_info::BlockInfo;
 use near_primitives::epoch_info::EpochInfo;
 use near_primitives::hash::CryptoHash;
-use near_primitives::shard_layout::{self, ShardLayout};
+use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
     AccountId, BlockHeight, ChunkStats, EpochId, ShardId, ValidatorId, ValidatorStats,

--- a/chain/epoch-manager/src/types.rs
+++ b/chain/epoch-manager/src/types.rs
@@ -3,6 +3,7 @@ use itertools::Itertools;
 use near_primitives::epoch_block_info::BlockInfo;
 use near_primitives::epoch_info::EpochInfo;
 use near_primitives::hash::CryptoHash;
+use near_primitives::shard_layout::{self, ShardLayout};
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
     AccountId, BlockHeight, ChunkStats, EpochId, ShardId, ValidatorId, ValidatorStats,
@@ -69,6 +70,7 @@ impl EpochInfoAggregator {
         &mut self,
         block_info: &BlockInfo,
         epoch_info: &EpochInfo,
+        shard_layout: &ShardLayout,
         prev_block_height: BlockHeight,
     ) {
         let _span =
@@ -105,12 +107,13 @@ impl EpochInfoAggregator {
         // TODO(#11900): Call EpochManager::get_chunk_validator_assignments to access the cached validator assignments.
         let chunk_validator_assignment = epoch_info.sample_chunk_validators(prev_block_height + 1);
 
-        for (i, mask) in block_info.chunk_mask().iter().enumerate() {
-            let shard_id: ShardId = i as ShardId;
+        for (shard_index, mask) in block_info.chunk_mask().iter().enumerate() {
+            let shard_id = shard_layout.get_shard_id(shard_index);
             let chunk_producer_id = EpochManager::chunk_producer_from_info(
                 epoch_info,
+                shard_layout,
+                shard_id,
                 prev_block_height + 1,
-                i as ShardId,
             )
             .unwrap();
             let tracker = self.shard_tracker.entry(shard_id).or_insert_with(HashMap::new);
@@ -123,7 +126,7 @@ impl EpochInfoAggregator {
                         debug!(
                             target: "epoch_tracker",
                             chunk_validator = ?epoch_info.validator_account_id(chunk_producer_id),
-                            shard_id = i,
+                            ?shard_id,
                             block_height = prev_block_height + 1,
                             "Missed chunk");
                     }
@@ -132,7 +135,7 @@ impl EpochInfoAggregator {
                 .or_insert_with(|| ChunkStats::new_with_production(u64::from(*mask), 1));
 
             let chunk_validators = chunk_validator_assignment
-                .get(i)
+                .get(shard_index)
                 .map_or::<&[(u64, u128)], _>(&[], Vec::as_slice)
                 .iter()
                 .map(|(id, _)| *id)
@@ -148,14 +151,14 @@ impl EpochInfoAggregator {
                 // For old chunks, we optimize the block and its header by not including the chunk endorsements and
                 // corresponding bitmaps. Thus, we expect that the bitmap is non-empty for new chunks only.
                 if *mask {
-                    debug_assert!(chunk_endorsements.len(shard_id).unwrap() == chunk_validators.len().div_ceil(8) * 8,
-                            "Chunk endorsement bitmap length is inconsistent with number of chunk validators. Bitmap length={}, num validators={}, shard_id={}",
-                            chunk_endorsements.len(shard_id).unwrap(), chunk_validators.len(), shard_id);
-                    chunk_endorsements.iter(shard_id)
+                    debug_assert!(chunk_endorsements.len(shard_index).unwrap() == chunk_validators.len().div_ceil(8) * 8,
+                            "Chunk endorsement bitmap length is inconsistent with number of chunk validators. Bitmap length={}, num validators={}, shard_index={}",
+                            chunk_endorsements.len(shard_index).unwrap(), chunk_validators.len(), shard_index);
+                    chunk_endorsements.iter(shard_index)
                 } else {
-                    debug_assert_eq!(chunk_endorsements.len(shard_id).unwrap(), 0,
-                            "Chunk endorsement bitmap must be empty for missing chunk. Bitmap length={}, shard_id={}",
-                            chunk_endorsements.len(shard_id).unwrap(), shard_id);
+                    debug_assert_eq!(chunk_endorsements.len(shard_index).unwrap(), 0,
+                            "Chunk endorsement bitmap must be empty for missing chunk. Bitmap length={}, shard_index={}",
+                            chunk_endorsements.len(shard_index).unwrap(), shard_index);
                     Box::new(std::iter::repeat(false).take(chunk_validators.len()))
                 }
             } else {

--- a/chain/epoch-manager/src/validator_selection.rs
+++ b/chain/epoch-manager/src/validator_selection.rs
@@ -964,9 +964,10 @@ mod tests {
         )
         .unwrap();
 
+        let shard_layout = &epoch_config.shard_layout;
         for shard_id in 0..num_shards {
             for h in 0..100_000 {
-                let cp = epoch_info.sample_chunk_producer(h, shard_id);
+                let cp = epoch_info.sample_chunk_producer(shard_layout, shard_id, h);
                 // Don't read too much into this. The reason the ValidatorId always
                 // equals the ShardId is because the validators are assigned to shards in order.
                 assert_eq!(cp, Some(shard_id))
@@ -992,10 +993,10 @@ mod tests {
         )
         .unwrap();
 
-        for shard_id in 0..num_shards {
+        for shard_id in shard_layout.shard_ids() {
             let mut counts: [i32; 2] = [0, 0];
             for h in 0..100_000 {
-                let cp = epoch_info.sample_chunk_producer(h, shard_id).unwrap();
+                let cp = epoch_info.sample_chunk_producer(shard_layout, shard_id, h).unwrap();
                 // if ValidatorId is in the second half then it is the lower
                 // stake validator (because they are sorted by decreasing stake).
                 let index = if cp >= num_shards { 1 } else { 0 };

--- a/chain/epoch-manager/src/validator_selection.rs
+++ b/chain/epoch-manager/src/validator_selection.rs
@@ -591,12 +591,12 @@ mod old_validator_selection {
             all_validators.push(bp.clone());
         }
 
-        let shard_ids: Vec<_> = epoch_config.shard_layout.shard_ids().collect();
+        let num_shards = epoch_config.shard_layout.shard_ids().count();
         if chunk_producers.is_empty() {
             // All validators tried to unstake?
             return Err(EpochError::NotEnoughValidators {
                 num_validators: 0u64,
-                num_shards: shard_ids.len() as NumShards,
+                num_shards: num_shards as u64,
             });
         }
 
@@ -605,11 +605,9 @@ mod old_validator_selection {
         // each validator as even as possible). Note that in prod configuration number of seats
         // per shard is the same as maximal number of block producers, so normally all
         // validators would be assigned to all chunks
-        let chunk_producers_settlement = shard_ids
-            .iter()
-            .map(|&shard_id| shard_id as usize)
-            .map(|shard_id| {
-                (0..epoch_config.num_block_producer_seats_per_shard[shard_id]
+        let chunk_producers_settlement = (0..num_shards)
+            .map(|shard_index| {
+                (0..epoch_config.num_block_producer_seats_per_shard[shard_index]
                     .min(block_producers_settlement.len() as u64))
                     .map(|_| {
                         let res = block_producers_settlement[id];
@@ -637,6 +635,7 @@ mod tests {
     use near_primitives::epoch_manager::ValidatorSelectionConfig;
     use near_primitives::shard_layout::ShardLayout;
     use near_primitives::types::validator_stake::ValidatorStake;
+    use near_primitives::types::ShardIndex;
     use near_primitives::version::PROTOCOL_VERSION;
     use num_rational::Ratio;
 
@@ -965,12 +964,14 @@ mod tests {
         .unwrap();
 
         let shard_layout = &epoch_config.shard_layout;
-        for shard_id in 0..num_shards {
+        for shard_index in 0..num_shards {
+            let shard_index = shard_index as ShardIndex;
+            let shard_id = shard_layout.get_shard_id(shard_index);
             for h in 0..100_000 {
                 let cp = epoch_info.sample_chunk_producer(shard_layout, shard_id, h);
                 // Don't read too much into this. The reason the ValidatorId always
                 // equals the ShardId is because the validators are assigned to shards in order.
-                assert_eq!(cp, Some(shard_id))
+                assert_eq!(cp, Some(shard_index as u64))
             }
         }
 

--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -79,8 +79,6 @@ pub async fn build_streamer_message(
     let chunks = fetch_block_chunks(&client, &block).await?;
 
     let protocol_config_view = fetch_protocol_config(&client, block.header.hash).await?;
-    let num_shards = protocol_config_view.num_block_producer_seats_per_shard.len()
-        as near_primitives::types::NumShards;
     let shard_ids = protocol_config_view.shard_layout.shard_ids();
 
     let runtime_config_store = near_parameters::RuntimeConfigStore::new(None);
@@ -105,8 +103,6 @@ pub async fn build_streamer_message(
     for (shard_index, chunk) in chunks.into_iter().enumerate() {
         let views::ChunkView { transactions, author, header, receipts: chunk_non_local_receipts } =
             chunk;
-
-        let shard_id = header.shard_id;
 
         let mut outcomes = shards_outcomes
             .remove(&header.shard_id)

--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -81,6 +81,7 @@ pub async fn build_streamer_message(
     let protocol_config_view = fetch_protocol_config(&client, block.header.hash).await?;
     let num_shards = protocol_config_view.num_block_producer_seats_per_shard.len()
         as near_primitives::types::NumShards;
+    let shard_ids = protocol_config_view.shard_layout.shard_ids();
 
     let runtime_config_store = near_parameters::RuntimeConfigStore::new(None);
     let runtime_config = runtime_config_store.get_config(protocol_config_view.protocol_version);
@@ -92,7 +93,7 @@ pub async fn build_streamer_message(
         near_primitives::types::EpochId(block.header.epoch_id),
     )
     .await?;
-    let mut indexer_shards = (0..num_shards)
+    let mut indexer_shards = shard_ids
         .map(|shard_id| IndexerShard {
             shard_id,
             chunk: None,
@@ -101,11 +102,11 @@ pub async fn build_streamer_message(
         })
         .collect::<Vec<_>>();
 
-    for chunk in chunks {
+    for (shard_index, chunk) in chunks.into_iter().enumerate() {
         let views::ChunkView { transactions, author, header, receipts: chunk_non_local_receipts } =
             chunk;
 
-        let shard_id = header.shard_id as usize;
+        let shard_id = header.shard_id;
 
         let mut outcomes = shards_outcomes
             .remove(&header.shard_id)
@@ -236,9 +237,9 @@ pub async fn build_streamer_message(
 
         chunk_receipts.extend(chunk_non_local_receipts);
 
-        indexer_shards[shard_id].receipt_execution_outcomes = receipt_execution_outcomes;
+        indexer_shards[shard_index].receipt_execution_outcomes = receipt_execution_outcomes;
         // Put the chunk into corresponding indexer shard
-        indexer_shards[shard_id].chunk = Some(IndexerChunkView {
+        indexer_shards[shard_index].chunk = Some(IndexerChunkView {
             author,
             header,
             transactions: indexer_transactions,
@@ -250,12 +251,13 @@ pub async fn build_streamer_message(
     // chunks and we end up with non-empty `shards_outcomes` we want to be sure we put them into IndexerShard
     // That might happen before the fix https://github.com/near/nearcore/pull/4228
     for (shard_id, outcomes) in shards_outcomes {
-        indexer_shards[shard_id as usize].receipt_execution_outcomes.extend(
-            outcomes.into_iter().map(|outcome| IndexerExecutionOutcomeWithReceipt {
+        let shard_index = protocol_config_view.shard_layout.get_shard_index(shard_id);
+        indexer_shards[shard_index].receipt_execution_outcomes.extend(outcomes.into_iter().map(
+            |outcome| IndexerExecutionOutcomeWithReceipt {
                 execution_outcome: outcome.execution_outcome,
                 receipt: outcome.receipt.expect("`receipt` must be present at this moment"),
-            }),
-        )
+            },
+        ))
     }
 
     Ok(StreamerMessage { block, shards: indexer_shards })

--- a/chain/jsonrpc-primitives/src/types/chunks.rs
+++ b/chain/jsonrpc-primitives/src/types/chunks.rs
@@ -34,6 +34,7 @@ pub enum RpcChunkError {
         #[serde(skip_serializing)]
         error_message: String,
     },
+    // TODO Should use ShardId instead of u64
     #[error("Shard id {shard_id} does not exist")]
     InvalidShardId { shard_id: u64 },
     #[error("Chunk with hash {chunk_hash:?} has never been observed on this node")]

--- a/chain/jsonrpc/jsonrpc-tests/tests/rpc_query.rs
+++ b/chain/jsonrpc/jsonrpc-tests/tests/rpc_query.rs
@@ -15,7 +15,7 @@ use near_network::test_utils::wait_or_timeout;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::account::{AccessKey, AccessKeyPermission};
 use near_primitives::hash::CryptoHash;
-use near_primitives::types::{BlockId, BlockReference, EpochId, SyncCheckpoint};
+use near_primitives::types::{new_shard_id_tmp, BlockId, BlockReference, EpochId, SyncCheckpoint};
 use near_primitives::views::QueryRequest;
 use near_time::Clock;
 
@@ -90,8 +90,10 @@ fn test_block_query() {
 #[test]
 fn test_chunk_by_hash() {
     test_with_client!(test_utils::NodeType::NonValidator, client, async move {
-        let chunk =
-            client.chunk(ChunkId::BlockShardId(BlockId::Height(0), 0.into())).await.unwrap();
+        let chunk = client
+            .chunk(ChunkId::BlockShardId(BlockId::Height(0), new_shard_id_tmp(0)))
+            .await
+            .unwrap();
         assert_eq!(chunk.author, "test1");
         assert_eq!(chunk.header.balance_burnt, 0);
         assert_eq!(chunk.header.chunk_hash.as_ref().len(), 32);
@@ -105,7 +107,7 @@ fn test_chunk_by_hash() {
         assert_eq!(chunk.header.prev_block_hash.as_ref().len(), 32);
         assert_eq!(chunk.header.prev_state_root.as_ref().len(), 32);
         assert_eq!(chunk.header.rent_paid, 0);
-        assert_eq!(chunk.header.shard_id, 0.into());
+        assert_eq!(chunk.header.shard_id, new_shard_id_tmp(0));
         assert!(if let Signature::ED25519(_) = chunk.header.signature { true } else { false });
         assert_eq!(chunk.header.tx_root.as_ref(), &[0; 32]);
         assert_eq!(chunk.header.validator_proposals, vec![]);
@@ -119,7 +121,8 @@ fn test_chunk_by_hash() {
 #[test]
 fn test_chunk_invalid_shard_id() {
     test_with_client!(test_utils::NodeType::NonValidator, client, async move {
-        let chunk = client.chunk(ChunkId::BlockShardId(BlockId::Height(0), 100.into())).await;
+        let chunk =
+            client.chunk(ChunkId::BlockShardId(BlockId::Height(0), new_shard_id_tmp(100))).await;
         match chunk {
             Ok(_) => panic!("should result in an error"),
             Err(e) => {
@@ -650,7 +653,7 @@ fn test_get_chunk_with_object_in_params() {
         assert_eq!(chunk.header.prev_block_hash.as_ref().len(), 32);
         assert_eq!(chunk.header.prev_state_root.as_ref().len(), 32);
         assert_eq!(chunk.header.rent_paid, 0);
-        assert_eq!(chunk.header.shard_id, 0.into());
+        assert_eq!(chunk.header.shard_id, new_shard_id_tmp(0));
         assert!(if let Signature::ED25519(_) = chunk.header.signature { true } else { false });
         assert_eq!(chunk.header.tx_root.as_ref(), &[0; 32]);
         assert_eq!(chunk.header.validator_proposals, vec![]);

--- a/chain/jsonrpc/jsonrpc-tests/tests/rpc_query.rs
+++ b/chain/jsonrpc/jsonrpc-tests/tests/rpc_query.rs
@@ -90,7 +90,8 @@ fn test_block_query() {
 #[test]
 fn test_chunk_by_hash() {
     test_with_client!(test_utils::NodeType::NonValidator, client, async move {
-        let chunk = client.chunk(ChunkId::BlockShardId(BlockId::Height(0), 0u64)).await.unwrap();
+        let chunk =
+            client.chunk(ChunkId::BlockShardId(BlockId::Height(0), 0.into())).await.unwrap();
         assert_eq!(chunk.author, "test1");
         assert_eq!(chunk.header.balance_burnt, 0);
         assert_eq!(chunk.header.chunk_hash.as_ref().len(), 32);
@@ -104,7 +105,7 @@ fn test_chunk_by_hash() {
         assert_eq!(chunk.header.prev_block_hash.as_ref().len(), 32);
         assert_eq!(chunk.header.prev_state_root.as_ref().len(), 32);
         assert_eq!(chunk.header.rent_paid, 0);
-        assert_eq!(chunk.header.shard_id, 0);
+        assert_eq!(chunk.header.shard_id, 0.into());
         assert!(if let Signature::ED25519(_) = chunk.header.signature { true } else { false });
         assert_eq!(chunk.header.tx_root.as_ref(), &[0; 32]);
         assert_eq!(chunk.header.validator_proposals, vec![]);
@@ -118,7 +119,7 @@ fn test_chunk_by_hash() {
 #[test]
 fn test_chunk_invalid_shard_id() {
     test_with_client!(test_utils::NodeType::NonValidator, client, async move {
-        let chunk = client.chunk(ChunkId::BlockShardId(BlockId::Height(0), 100)).await;
+        let chunk = client.chunk(ChunkId::BlockShardId(BlockId::Height(0), 100.into())).await;
         match chunk {
             Ok(_) => panic!("should result in an error"),
             Err(e) => {
@@ -649,7 +650,7 @@ fn test_get_chunk_with_object_in_params() {
         assert_eq!(chunk.header.prev_block_hash.as_ref().len(), 32);
         assert_eq!(chunk.header.prev_state_root.as_ref().len(), 32);
         assert_eq!(chunk.header.rent_paid, 0);
-        assert_eq!(chunk.header.shard_id, 0);
+        assert_eq!(chunk.header.shard_id, 0.into());
         assert!(if let Signature::ED25519(_) = chunk.header.signature { true } else { false });
         assert_eq!(chunk.header.tx_root.as_ref(), &[0; 32]);
         assert_eq!(chunk.header.validator_proposals, vec![]);

--- a/chain/jsonrpc/src/api/chunks.rs
+++ b/chain/jsonrpc/src/api/chunks.rs
@@ -57,7 +57,9 @@ impl RpcFrom<GetChunkError> for RpcChunkError {
         match error {
             GetChunkError::IOError { error_message } => Self::InternalError { error_message },
             GetChunkError::UnknownBlock { error_message } => Self::UnknownBlock { error_message },
-            GetChunkError::InvalidShardId { shard_id } => Self::InvalidShardId { shard_id },
+            GetChunkError::InvalidShardId { shard_id } => {
+                Self::InvalidShardId { shard_id: shard_id.into() }
+            }
             GetChunkError::UnknownChunk { chunk_hash } => Self::UnknownChunk { chunk_hash },
             GetChunkError::Unreachable { ref error_message } => {
                 tracing::warn!(target: "jsonrpc", "Unreachable error occurred: {}", error_message);

--- a/chain/network/src/network_protocol/proto_conv/handshake.rs
+++ b/chain/network/src/network_protocol/proto_conv/handshake.rs
@@ -42,7 +42,7 @@ impl From<&PeerChainInfoV2> for proto::PeerChainInfo {
         Self {
             genesis_id: MF::some((&x.genesis_id).into()),
             height: x.height,
-            tracked_shards: x.tracked_shards.clone(),
+            tracked_shards: x.tracked_shards.clone().into_iter().map(Into::into).collect(),
             archival: x.archival,
             ..Self::default()
         }
@@ -55,7 +55,7 @@ impl TryFrom<&proto::PeerChainInfo> for PeerChainInfoV2 {
         Ok(Self {
             genesis_id: try_from_required(&p.genesis_id).map_err(Self::Error::GenesisId)?,
             height: p.height,
-            tracked_shards: p.tracked_shards.clone(),
+            tracked_shards: p.tracked_shards.clone().into_iter().map(Into::into).collect(),
             archival: p.archival,
         })
     }

--- a/chain/network/src/network_protocol/proto_conv/peer_message.rs
+++ b/chain/network/src/network_protocol/proto_conv/peer_message.rs
@@ -179,7 +179,7 @@ impl From<&SnapshotHostInfo> for proto::SnapshotHostInfo {
             peer_id: MF::some((&x.peer_id).into()),
             sync_hash: MF::some((&x.sync_hash).into()),
             epoch_height: x.epoch_height,
-            shards: x.shards.clone(),
+            shards: x.shards.clone().into_iter().map(Into::into).collect(),
             signature: MF::some((&x.signature).into()),
             ..Default::default()
         }
@@ -193,7 +193,7 @@ impl TryFrom<&proto::SnapshotHostInfo> for SnapshotHostInfo {
             peer_id: try_from_required(&x.peer_id).map_err(Self::Error::PeerId)?,
             sync_hash: try_from_required(&x.sync_hash).map_err(Self::Error::SyncHash)?,
             epoch_height: x.epoch_height,
-            shards: x.shards.clone(),
+            shards: x.shards.clone().into_iter().map(Into::into).collect(),
             signature: try_from_required(&x.signature).map_err(Self::Error::Signature)?,
         })
     }
@@ -313,14 +313,14 @@ impl From<&PeerMessage> for proto::PeerMessage {
                 PeerMessage::SyncSnapshotHosts(ssh) => ProtoMT::SyncSnapshotHosts(ssh.into()),
                 PeerMessage::StateRequestHeader(shard_id, sync_hash) => {
                     ProtoMT::StateRequestHeader(proto::StateRequestHeader {
-                        shard_id: *shard_id,
+                        shard_id: (*shard_id).into(),
                         sync_hash: MF::some(sync_hash.into()),
                         ..Default::default()
                     })
                 }
                 PeerMessage::StateRequestPart(shard_id, sync_hash, part_id) => {
                     ProtoMT::StateRequestPart(proto::StateRequestPart {
-                        shard_id: *shard_id,
+                        shard_id: (*shard_id).into(),
                         sync_hash: MF::some(sync_hash.into()),
                         part_id: *part_id,
                         ..Default::default()
@@ -477,11 +477,11 @@ impl TryFrom<&proto::PeerMessage> for PeerMessage {
                 Challenge::try_from_slice(&c.borsh).map_err(Self::Error::Challenge)?,
             ),
             ProtoMT::StateRequestHeader(srh) => PeerMessage::StateRequestHeader(
-                srh.shard_id,
+                srh.shard_id.into(),
                 try_from_required(&srh.sync_hash).map_err(Self::Error::BlockRequest)?,
             ),
             ProtoMT::StateRequestPart(srp) => PeerMessage::StateRequestPart(
-                srp.shard_id,
+                srp.shard_id.into(),
                 try_from_required(&srp.sync_hash).map_err(Self::Error::BlockRequest)?,
                 srp.part_id,
             ),

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -211,7 +211,7 @@ impl ChunkSet {
         Self { chunks: HashMap::default() }
     }
     pub fn make(&mut self) -> Vec<ShardChunk> {
-        let shard_ids: Vec<_> = (0..4).collect();
+        let shard_ids: Vec<_> = (0..4).into_iter().map(Into::into).collect();
         // TODO: these are always genesis chunks.
         // Consider making this more realistic.
         let chunks = genesis_chunks(

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -18,7 +18,7 @@ use near_primitives::sharding::{
     ChunkHash, EncodedShardChunkBody, PartialEncodedChunkPart, ShardChunk,
 };
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{AccountId, BlockHeight, EpochId, StateRoot};
+use near_primitives::types::{new_shard_id_tmp, AccountId, BlockHeight, EpochId, StateRoot};
 use near_primitives::validator_signer::{InMemoryValidatorSigner, ValidatorSigner};
 use near_primitives::version;
 use rand::distributions::Standard;
@@ -211,7 +211,7 @@ impl ChunkSet {
         Self { chunks: HashMap::default() }
     }
     pub fn make(&mut self) -> Vec<ShardChunk> {
-        let shard_ids: Vec<_> = (0..4).into_iter().map(Into::into).collect();
+        let shard_ids: Vec<_> = (0..4).into_iter().map(new_shard_id_tmp).collect();
         // TODO: these are always genesis chunks.
         // Consider making this more realistic.
         let chunks = genesis_chunks(

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1373,7 +1373,7 @@ impl actix::Handler<GetDebugStatus> for PeerManagerActor {
                         peer_id: h.peer_id.clone(),
                         sync_hash: h.sync_hash,
                         epoch_height: h.epoch_height,
-                        shards: h.shards.clone(),
+                        shards: h.shards.clone().into_iter().map(Into::into).collect(),
                     })
                     .collect::<Vec<_>>(),
             }),

--- a/chain/network/src/raw/tests.rs
+++ b/chain/network/src/raw/tests.rs
@@ -8,6 +8,7 @@ use near_crypto::{KeyType, SecretKey};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
+use near_primitives::types::new_shard_id_tmp;
 use std::sync::Arc;
 
 #[tokio::test]
@@ -38,7 +39,7 @@ async fn test_raw_conn_pings() {
         &genesis_id.chain_id,
         genesis_id.hash,
         0,
-        vec![0.into()],
+        vec![new_shard_id_tmp(0)],
         time::Duration::SECOND,
     )
     .await
@@ -99,7 +100,7 @@ async fn test_raw_conn_state_parts() {
         &genesis_id.chain_id,
         genesis_id.hash,
         0,
-        vec![0.into()],
+        vec![new_shard_id_tmp(0)],
         time::Duration::SECOND,
     )
     .await
@@ -110,9 +111,13 @@ async fn test_raw_conn_state_parts() {
     // But the fake node simply ignores the block hash.
     let block_hash = CryptoHash::new();
     for part_id in 0..num_parts {
-        conn.send_message(raw::DirectMessage::StateRequestPart(0.into(), block_hash, part_id))
-            .await
-            .unwrap();
+        conn.send_message(raw::DirectMessage::StateRequestPart(
+            new_shard_id_tmp(0),
+            block_hash,
+            part_id,
+        ))
+        .await
+        .unwrap();
     }
 
     let mut part_id_received = -1i64;
@@ -174,7 +179,7 @@ async fn test_listener() {
         &genesis_id.chain_id,
         genesis_id.hash,
         0,
-        vec![0.into()],
+        vec![new_shard_id_tmp(0)],
         false,
         time::Duration::SECOND,
     )

--- a/chain/network/src/raw/tests.rs
+++ b/chain/network/src/raw/tests.rs
@@ -38,7 +38,7 @@ async fn test_raw_conn_pings() {
         &genesis_id.chain_id,
         genesis_id.hash,
         0,
-        vec![0],
+        vec![0.into()],
         time::Duration::SECOND,
     )
     .await
@@ -99,7 +99,7 @@ async fn test_raw_conn_state_parts() {
         &genesis_id.chain_id,
         genesis_id.hash,
         0,
-        vec![0],
+        vec![0.into()],
         time::Duration::SECOND,
     )
     .await
@@ -110,7 +110,7 @@ async fn test_raw_conn_state_parts() {
     // But the fake node simply ignores the block hash.
     let block_hash = CryptoHash::new();
     for part_id in 0..num_parts {
-        conn.send_message(raw::DirectMessage::StateRequestPart(0, block_hash, part_id))
+        conn.send_message(raw::DirectMessage::StateRequestPart(0.into(), block_hash, part_id))
             .await
             .unwrap();
     }
@@ -174,7 +174,7 @@ async fn test_listener() {
         &genesis_id.chain_id,
         genesis_id.hash,
         0,
-        vec![0],
+        vec![0.into()],
         false,
         time::Duration::SECOND,
     )

--- a/chain/network/src/snapshot_hosts/tests.rs
+++ b/chain/network/src/snapshot_hosts/tests.rs
@@ -10,8 +10,8 @@ use near_crypto::SecretKey;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
-use near_primitives::types::EpochHeight;
 use near_primitives::types::ShardId;
+use near_primitives::types::{new_shard_id_tmp, EpochHeight};
 use rand::Rng;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -330,7 +330,7 @@ async fn run_select_peer_test(
                 assert!(err.is_none());
             }
             SelectPeerAction::CallSelect(wanted) => {
-                let peer = cache.select_host_for_part(sync_hash, 0.into(), part_id);
+                let peer = cache.select_host_for_part(sync_hash, new_shard_id_tmp(0), part_id);
                 let wanted = match wanted {
                     Some(idx) => Some(&peers[*idx].peer_id),
                     None => None,
@@ -338,7 +338,7 @@ async fn run_select_peer_test(
                 assert!(peer.as_ref() == wanted, "got: {:?} want: {:?}", &peer, &wanted);
             }
             SelectPeerAction::PartReceived => {
-                let shard_id = 0.into();
+                let shard_id = new_shard_id_tmp(0);
                 assert!(cache.has_selector(shard_id, part_id));
                 cache.part_received(shard_id, part_id);
                 assert!(!cache.has_selector(shard_id, part_id));
@@ -361,7 +361,7 @@ async fn test_select_peer() {
     for _ in 0..num_peers {
         let key = data::make_secret_key(&mut rng);
         let peer_id = PeerId::new(key.public_key());
-        let score = priority_score(&peer_id, 0.into(), part_id);
+        let score = priority_score(&peer_id, new_shard_id_tmp(0), part_id);
         let info =
             Arc::new(SnapshotHostInfo::new(peer_id, sync_hash, 123, sid_vec(&[0, 1, 2, 3]), &key));
         peers.push((info, score));

--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -23,6 +23,7 @@ serde.workspace = true
 serde_repr.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 
 near-account-id.workspace = true
 near-schema-checker-lib.workspace = true

--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -23,7 +23,6 @@ serde.workspace = true
 serde_repr.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-tracing.workspace = true
 
 near-account-id.workspace = true
 near-schema-checker-lib.workspace = true

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -118,6 +118,12 @@ impl From<u64> for ShardId {
     }
 }
 
+impl Into<u64> for ShardId {
+    fn into(self) -> u64 {
+        self.0
+    }
+}
+
 impl From<u32> for ShardId {
     fn from(id: u32) -> Self {
         Self(id as u64)

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -72,6 +72,12 @@ pub type ProtocolVersion = u32;
 )]
 pub struct ShardId(u64);
 
+/// The ShardIndex is the index of the shard in an array of shard data.
+/// Historically the ShardId was always in the range 0..NUM_SHARDS and was used
+/// as the shard index. This is no longer the case, and the ShardIndex should be
+/// used instead.
+pub type ShardIndex = usize;
+
 impl ShardId {
     /// Create a new shard id. Please note that this function should not be used
     /// directly. Instead the ShardId should be obtained from the shard_layout.

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -141,3 +141,15 @@ impl From<usize> for ShardId {
         Self(id as u64)
     }
 }
+
+impl From<u16> for ShardId {
+    fn from(id: u16) -> Self {
+        Self(id as u64)
+    }
+}
+
+impl Into<u16> for ShardId {
+    fn into(self) -> u16 {
+        self.0 as u16
+    }
+}

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -102,7 +102,25 @@ pub const fn shard_id_as_u32(id: ShardId) -> u32 {
 
 // impl ShardId {
 //     /// Create a new shard id. Please note that this function should not be used
-//     /// directly. Instead the ShardId should be obtained from the shard_layout.
+//     /// to convert a shard index (a number in 0..num_shards range) to ShardId.
+//     /// Instead the ShardId should be obtained from the shard_layout.
+//     ///
+//     /// ```
+//     /// // BAD USAGE:
+//     /// for shard_index in 1..num_shards {
+//     ///     let shard_id = ShardId::new(shard_index); // Incorrect!!!
+//     /// }
+//     /// ```
+//     /// ```
+//     /// // GOOD USAGE 1:
+//     /// for shard_index in 1..num_shards {
+//     ///     let shard_id = shard_layout.get_shard_id(shard_index);
+//     /// }
+//     /// // GOOD USAGE 2:
+//     /// for shard_id in shard_layout.shard_ids() {
+//     ///     let shard_id = shard_layout.get_shard_id(shard_index);
+//     /// }
+//     /// ```
 //     pub const fn new(id: u64) -> Self {
 //         Self(id)
 //     }

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -92,6 +92,12 @@ impl ShardId {
     pub fn from_le_bytes(bytes: [u8; 8]) -> Self {
         Self(u64::from_le_bytes(bytes))
     }
+
+    // TODO This is not great, in ShardUId shard_id is u32.
+    // Currently used for some metrics so kinda ok.
+    pub fn max() -> Self {
+        Self(u64::MAX)
+    }
 }
 
 impl Display for ShardId {

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -44,15 +44,45 @@ pub type PromiseId = Vec<ReceiptIndex>;
 
 pub type ProtocolVersion = u32;
 
-/// The shard identifier. It may be a arbitrary number - it does not need to be
-/// a number in the range 0..NUM_SHARDS. The shard ids do not need to be
-/// sequential or contiguous.
-///
-/// The shard id is wrapped in a newtype to prevent the old pattern of using
-/// indices in range 0..NUM_SHARDS and casting to ShardId. Once the transition
-/// if fully complete it potentially may be simplified to a regular type alias.
-///
-/// TODO get rid of serde
+/// The shard identifier. The ShardId is currently being migrated to a newtype -
+/// please see the new ShardId definition below.
+pub type ShardId = u64;
+
+/// The ShardIndex is the index of the shard in an array of shard data.
+/// Historically the ShardId was always in the range 0..NUM_SHARDS and was used
+/// as the shard index. This is no longer the case, and the ShardIndex should be
+/// used instead.
+pub type ShardIndex = usize;
+
+// TODO(wacban) This is a temporary solution to aid the transition to having
+// ShardId as a newtype. It should be replaced / removed / inlined once the
+// transition is complete.
+pub const fn new_shard_id_tmp(id: u64) -> ShardId {
+    id
+}
+
+// TODO(wacban) This is a temporary solution to aid the transition to having
+// ShardId as a newtype. It should be replaced / removed / inlined once the
+// transition is complete.
+pub fn new_shard_id_vec_tmp(vec: &[u64]) -> Vec<ShardId> {
+    vec.iter().copied().map(new_shard_id_tmp).collect()
+}
+
+// TODO(wacban) This is a temporary solution to aid the transition to having
+// ShardId as a newtype. It should be replaced / removed / inlined once the
+// transition is complete.
+pub const fn shard_id_as_u32(id: ShardId) -> u32 {
+    id as u32
+}
+
+// TODO(wacban) Complete the transition to ShardId as a newtype.
+// /// The shard identifier. It may be a arbitrary number - it does not need to be
+// /// a number in the range 0..NUM_SHARDS. The shard ids do not need to be
+// /// sequential or contiguous.
+// ///
+// /// The shard id is wrapped in a newtype to prevent the old pattern of using
+// /// indices in range 0..NUM_SHARDS and casting to ShardId. Once the transition
+// /// if fully complete it potentially may be simplified to a regular type alias.
 // #[derive(
 //     arbitrary::Arbitrary,
 //     borsh::BorshSerialize,
@@ -69,35 +99,6 @@ pub type ProtocolVersion = u32;
 //     Ord,
 // )]
 // pub struct ShardId(u64);
-
-pub type ShardId = u64;
-
-/// The ShardIndex is the index of the shard in an array of shard data.
-/// Historically the ShardId was always in the range 0..NUM_SHARDS and was used
-/// as the shard index. This is no longer the case, and the ShardIndex should be
-/// used instead.
-pub type ShardIndex = usize;
-
-// TODO(wacban) This is a temporary solution to aid the transition to having
-// ShardId as a newtype. It should be removed / inlined once the transition
-// is complete.
-pub const fn new_shard_id_tmp(id: u64) -> ShardId {
-    id
-}
-
-// TODO(wacban) This is a temporary solution to aid the transition to having
-// ShardId as a newtype. It should be removed / inlined once the transition
-// is complete.
-pub fn new_shard_id_vec_tmp(vec: &[u64]) -> Vec<ShardId> {
-    vec.iter().copied().map(new_shard_id_tmp).collect()
-}
-
-// TODO(wacban) This is a temporary solution to aid the transition to having
-// ShardId as a newtype. It should be removed / inlined once the transition
-// is complete.
-pub const fn shard_id_as_u32(id: ShardId) -> u32 {
-    id as u32
-}
 
 // impl ShardId {
 //     /// Create a new shard id. Please note that this function should not be used

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -81,7 +81,7 @@ pub type ShardIndex = usize;
 impl ShardId {
     /// Create a new shard id. Please note that this function should not be used
     /// directly. Instead the ShardId should be obtained from the shard_layout.
-    pub fn new(id: u64) -> Self {
+    pub const fn new(id: u64) -> Self {
         Self(id)
     }
 

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -130,6 +130,12 @@ impl From<u32> for ShardId {
     }
 }
 
+impl Into<u32> for ShardId {
+    fn into(self) -> u32 {
+        self.0 as u32
+    }
+}
+
 impl From<i32> for ShardId {
     fn from(id: i32) -> Self {
         Self(id as u64)

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 use crate::hash::CryptoHash;
 
 /// Account identifier. Provides access to user's state.
@@ -55,22 +53,24 @@ pub type ProtocolVersion = u32;
 /// if fully complete it potentially may be simplified to a regular type alias.
 ///
 /// TODO get rid of serde
-#[derive(
-    arbitrary::Arbitrary,
-    borsh::BorshSerialize,
-    borsh::BorshDeserialize,
-    serde::Serialize,
-    serde::Deserialize,
-    Hash,
-    Clone,
-    Copy,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-)]
-pub struct ShardId(u64);
+// #[derive(
+//     arbitrary::Arbitrary,
+//     borsh::BorshSerialize,
+//     borsh::BorshDeserialize,
+//     serde::Serialize,
+//     serde::Deserialize,
+//     Hash,
+//     Clone,
+//     Copy,
+//     Debug,
+//     PartialEq,
+//     Eq,
+//     PartialOrd,
+//     Ord,
+// )]
+// pub struct ShardId(u64);
+
+pub type ShardId = u64;
 
 /// The ShardIndex is the index of the shard in an array of shard data.
 /// Historically the ShardId was always in the range 0..NUM_SHARDS and was used
@@ -78,84 +78,105 @@ pub struct ShardId(u64);
 /// used instead.
 pub type ShardIndex = usize;
 
-impl ShardId {
-    /// Create a new shard id. Please note that this function should not be used
-    /// directly. Instead the ShardId should be obtained from the shard_layout.
-    pub const fn new(id: u64) -> Self {
-        Self(id)
-    }
-
-    /// Get the numerical value of the shard id. This should not be used as an
-    /// index into an array, as the shard id may be any arbitrary number.
-    pub fn get(self) -> u64 {
-        self.0
-    }
-
-    pub fn to_le_bytes(self) -> [u8; 8] {
-        self.0.to_le_bytes()
-    }
-
-    pub fn from_le_bytes(bytes: [u8; 8]) -> Self {
-        Self(u64::from_le_bytes(bytes))
-    }
-
-    // TODO This is not great, in ShardUId shard_id is u32.
-    // Currently used for some metrics so kinda ok.
-    pub fn max() -> Self {
-        Self(u64::MAX)
-    }
+// TODO(wacban) This is a temporary solution to aid the transition to having
+// ShardId as a newtype. It should be removed / inlined once the transition
+// is complete.
+pub const fn new_shard_id_tmp(id: u64) -> ShardId {
+    id
 }
 
-impl Display for ShardId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
+// TODO(wacban) This is a temporary solution to aid the transition to having
+// ShardId as a newtype. It should be removed / inlined once the transition
+// is complete.
+pub fn new_shard_id_vec_tmp(vec: &[u64]) -> Vec<ShardId> {
+    vec.iter().copied().map(new_shard_id_tmp).collect()
 }
 
-impl From<u64> for ShardId {
-    fn from(id: u64) -> Self {
-        Self(id)
-    }
+// TODO(wacban) This is a temporary solution to aid the transition to having
+// ShardId as a newtype. It should be removed / inlined once the transition
+// is complete.
+pub const fn shard_id_as_u32(id: ShardId) -> u32 {
+    id as u32
 }
 
-impl Into<u64> for ShardId {
-    fn into(self) -> u64 {
-        self.0
-    }
-}
+// impl ShardId {
+//     /// Create a new shard id. Please note that this function should not be used
+//     /// directly. Instead the ShardId should be obtained from the shard_layout.
+//     pub const fn new(id: u64) -> Self {
+//         Self(id)
+//     }
 
-impl From<u32> for ShardId {
-    fn from(id: u32) -> Self {
-        Self(id as u64)
-    }
-}
+//     /// Get the numerical value of the shard id. This should not be used as an
+//     /// index into an array, as the shard id may be any arbitrary number.
+//     pub fn get(self) -> u64 {
+//         self.0
+//     }
 
-impl Into<u32> for ShardId {
-    fn into(self) -> u32 {
-        self.0 as u32
-    }
-}
+//     pub fn to_le_bytes(self) -> [u8; 8] {
+//         self.0.to_le_bytes()
+//     }
 
-impl From<i32> for ShardId {
-    fn from(id: i32) -> Self {
-        Self(id as u64)
-    }
-}
+//     pub fn from_le_bytes(bytes: [u8; 8]) -> Self {
+//         Self(u64::from_le_bytes(bytes))
+//     }
 
-impl From<usize> for ShardId {
-    fn from(id: usize) -> Self {
-        Self(id as u64)
-    }
-}
+//     // TODO This is not great, in ShardUId shard_id is u32.
+//     // Currently used for some metrics so kinda ok.
+//     pub fn max() -> Self {
+//         Self(u64::MAX)
+//     }
+// }
 
-impl From<u16> for ShardId {
-    fn from(id: u16) -> Self {
-        Self(id as u64)
-    }
-}
+// impl Display for ShardId {
+//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//         write!(f, "{}", self.0)
+//     }
+// }
 
-impl Into<u16> for ShardId {
-    fn into(self) -> u16 {
-        self.0 as u16
-    }
-}
+// impl From<u64> for ShardId {
+//     fn from(id: u64) -> Self {
+//         Self(id)
+//     }
+// }
+
+// impl Into<u64> for ShardId {
+//     fn into(self) -> u64 {
+//         self.0
+//     }
+// }
+
+// impl From<u32> for ShardId {
+//     fn from(id: u32) -> Self {
+//         Self(id as u64)
+//     }
+// }
+
+// impl Into<u32> for ShardId {
+//     fn into(self) -> u32 {
+//         self.0 as u32
+//     }
+// }
+
+// impl From<i32> for ShardId {
+//     fn from(id: i32) -> Self {
+//         Self(id as u64)
+//     }
+// }
+
+// impl From<usize> for ShardId {
+//     fn from(id: usize) -> Self {
+//         Self(id as u64)
+//     }
+// }
+
+// impl From<u16> for ShardId {
+//     fn from(id: u16) -> Self {
+//         Self(id as u64)
+//     }
+// }
+
+// impl Into<u16> for ShardId {
+//     fn into(self) -> u16 {
+//         self.0 as u16
+//     }
+// }

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -112,9 +112,26 @@ impl Display for ShardId {
     }
 }
 
-// TODO remove that!!!!
 impl From<u64> for ShardId {
     fn from(id: u64) -> Self {
         Self(id)
+    }
+}
+
+impl From<u32> for ShardId {
+    fn from(id: u32) -> Self {
+        Self(id as u64)
+    }
+}
+
+impl From<i32> for ShardId {
+    fn from(id: i32) -> Self {
+        Self(id as u64)
+    }
+}
+
+impl From<usize> for ShardId {
+    fn from(id: usize) -> Self {
+        Self(id as u64)
     }
 }

--- a/core/primitives/benches/serialization.rs
+++ b/core/primitives/benches/serialization.rs
@@ -13,7 +13,7 @@ use near_primitives::test_utils::account_new;
 use near_primitives::transaction::{
     Action, SignedTransaction, Transaction, TransactionV0, TransferAction,
 };
-use near_primitives::types::{EpochId, StateRoot};
+use near_primitives::types::{EpochId, ShardId, StateRoot};
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives_core::types::MerkleHash;
@@ -39,7 +39,7 @@ fn create_transaction() -> SignedTransaction {
 }
 
 fn create_block() -> Block {
-    let shard_ids = vec![0];
+    let shard_ids = vec![ShardId::new(0)];
     let genesis_chunks = genesis_chunks(
         vec![StateRoot::new()],
         vec![Default::default(); shard_ids.len()],

--- a/core/primitives/benches/serialization.rs
+++ b/core/primitives/benches/serialization.rs
@@ -13,7 +13,7 @@ use near_primitives::test_utils::account_new;
 use near_primitives::transaction::{
     Action, SignedTransaction, Transaction, TransactionV0, TransferAction,
 };
-use near_primitives::types::{EpochId, ShardId, StateRoot};
+use near_primitives::types::{EpochId, StateRoot};
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives_core::types::MerkleHash;
@@ -39,7 +39,7 @@ fn create_transaction() -> SignedTransaction {
 }
 
 fn create_block() -> Block {
-    let shard_ids = vec![ShardId::new(0)];
+    let shard_ids = vec![0];
     let genesis_chunks = genesis_chunks(
         vec![StateRoot::new()],
         vec![Default::default(); shard_ids.len()],

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -14,6 +14,7 @@ use crate::sharding::{ChunkHashHeight, ShardChunkHeader, ShardChunkHeaderV1};
 use crate::types::{Balance, BlockHeight, EpochId, Gas};
 use crate::version::{ProtocolVersion, SHARD_CHUNK_HEADER_UPGRADE_VERSION};
 use borsh::{BorshDeserialize, BorshSerialize};
+use near_primitives_core::types::ShardId;
 use near_schema_checker_lib::ProtocolSchema;
 use near_time::Utc;
 use primitive_types::U256;
@@ -88,6 +89,7 @@ pub enum Block {
 #[cfg(feature = "solomon")]
 type ShardChunkReedSolomon = reed_solomon_erasure::galois_8::ReedSolomon;
 
+/// The shard_ids, state_roots and congestion_infos must be in the same order.
 #[cfg(feature = "solomon")]
 pub fn genesis_chunks(
     state_roots: Vec<crate::types::StateRoot>,
@@ -110,10 +112,9 @@ pub fn genesis_chunks(
     let num = shard_ids.len();
     assert_eq!(state_roots.len(), num);
 
-    for shard_id in 0..num {
-        let state_root = state_roots[shard_id];
-        let congestion_info = congestion_infos[shard_id];
-        let shard_id = shard_id as crate::types::ShardId;
+    for (shard_index, &shard_id) in shard_ids.iter().enumerate() {
+        let state_root = state_roots[shard_index];
+        let congestion_info = congestion_infos[shard_index];
 
         let encoded_chunk = genesis_chunk(
             &rs,
@@ -140,7 +141,7 @@ fn genesis_chunk(
     genesis_protocol_version: u32,
     genesis_height: u64,
     initial_gas_limit: u64,
-    shard_id: u64,
+    shard_id: ShardId,
     state_root: CryptoHash,
     congestion_info: Option<crate::congestion_info::CongestionInfo>,
 ) -> crate::sharding::EncodedShardChunk {

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -14,7 +14,7 @@ use crate::sharding::{ChunkHashHeight, ShardChunkHeader, ShardChunkHeaderV1};
 use crate::types::{Balance, BlockHeight, EpochId, Gas};
 use crate::version::{ProtocolVersion, SHARD_CHUNK_HEADER_UPGRADE_VERSION};
 use borsh::{BorshDeserialize, BorshSerialize};
-use near_primitives_core::types::ShardId;
+use near_primitives_core::types::{ShardId, ShardIndex};
 use near_schema_checker_lib::ProtocolSchema;
 use near_time::Utc;
 use primitive_types::U256;
@@ -782,7 +782,7 @@ impl<'a> ExactSizeIterator for VersionedChunksIter<'a> {
     }
 }
 
-impl<'a> Index<usize> for ChunksCollection<'a> {
+impl<'a> Index<ShardIndex> for ChunksCollection<'a> {
     type Output = ShardChunkHeader;
 
     /// Deprecated. Please use get instead, it's safer.
@@ -809,7 +809,7 @@ impl<'a> ChunksCollection<'a> {
         }
     }
 
-    pub fn get(&self, index: usize) -> Option<&ShardChunkHeader> {
+    pub fn get(&self, index: ShardIndex) -> Option<&ShardChunkHeader> {
         match self {
             ChunksCollection::V1(chunks) => chunks.get(index),
             ChunksCollection::V2(chunks) => chunks.get(index),

--- a/core/primitives/src/congestion_info.rs
+++ b/core/primitives/src/congestion_info.rs
@@ -85,7 +85,7 @@ impl CongestionControl {
         // `clamped_f64_fraction` clamps to exactly 1.0.
         if congestion == 1.0 {
             // Red traffic light: reduce to minimum speed
-            if sender_shard == self.info.allowed_shard() as u64 {
+            if sender_shard.get() == self.info.allowed_shard() as u64 {
                 self.config.allowed_shard_outgoing_gas
             } else {
                 0
@@ -97,7 +97,7 @@ impl CongestionControl {
 
     /// How much data another shard can send to us in the next block.
     pub fn outgoing_size_limit(&self, sender_shard: ShardId) -> Gas {
-        if sender_shard == self.info.allowed_shard() as u64 {
+        if sender_shard.get() == self.info.allowed_shard() as u64 {
             // The allowed shard is allowed to send more data to us.
             self.config.outgoing_receipts_big_size_limit
         } else {
@@ -347,7 +347,7 @@ impl CongestionInfo {
         congestion_seed: u64,
     ) {
         let allowed_shard = Self::get_new_allowed_shard(own_shard, all_shards, congestion_seed);
-        self.set_allowed_shard(allowed_shard as u16);
+        self.set_allowed_shard(allowed_shard.get() as u16);
     }
 
     fn get_new_allowed_shard(

--- a/core/primitives/src/epoch_info.rs
+++ b/core/primitives/src/epoch_info.rs
@@ -677,7 +677,7 @@ impl EpochInfo {
             let mut buffer = [0u8; 48];
             buffer[0..32].copy_from_slice(seed);
             buffer[32..40].copy_from_slice(&height.to_le_bytes());
-            buffer[40..48].copy_from_slice(&shard_id.get().to_le_bytes());
+            buffer[40..48].copy_from_slice(&shard_id.to_le_bytes());
             hash(&buffer).0
         }
     }

--- a/core/primitives/src/epoch_info.rs
+++ b/core/primitives/src/epoch_info.rs
@@ -3,7 +3,7 @@ use smart_default::SmartDefault;
 use std::collections::{BTreeMap, HashMap};
 
 use crate::rand::WeightedIndex;
-use crate::shard_layout::{self, ShardLayout};
+use crate::shard_layout::ShardLayout;
 use crate::types::validator_stake::{ValidatorStake, ValidatorStakeIter};
 use crate::types::{AccountId, ValidatorKickoutReason, ValidatorStakeV1};
 use crate::validator_mandates::ValidatorMandates;

--- a/core/primitives/src/epoch_info.rs
+++ b/core/primitives/src/epoch_info.rs
@@ -3,6 +3,7 @@ use smart_default::SmartDefault;
 use std::collections::{BTreeMap, HashMap};
 
 use crate::rand::WeightedIndex;
+use crate::shard_layout::{self, ShardLayout};
 use crate::types::validator_stake::{ValidatorStake, ValidatorStakeIter};
 use crate::types::{AccountId, ValidatorKickoutReason, ValidatorStakeV1};
 use crate::validator_mandates::ValidatorMandates;
@@ -601,35 +602,35 @@ impl EpochInfo {
 
     pub fn sample_chunk_producer(
         &self,
-        height: BlockHeight,
+        shard_layout: &ShardLayout,
         shard_id: ShardId,
+        height: BlockHeight,
     ) -> Option<ValidatorId> {
+        let shard_index = shard_layout.get_shard_index(shard_id);
         match &self {
             Self::V1(v1) => {
                 let cp_settlement = &v1.chunk_producers_settlement;
-                let shard_cps = cp_settlement.get(shard_id as usize)?;
+                let shard_cps = cp_settlement.get(shard_index)?;
                 shard_cps.get((height as u64 % (shard_cps.len() as u64)) as usize).copied()
             }
             Self::V2(v2) => {
                 let cp_settlement = &v2.chunk_producers_settlement;
-                let shard_cps = cp_settlement.get(shard_id as usize)?;
+                let shard_cps = cp_settlement.get(shard_index)?;
                 shard_cps.get((height as u64 % (shard_cps.len() as u64)) as usize).copied()
             }
             Self::V3(v3) => {
                 let protocol_version = self.protocol_version();
                 let seed =
                     Self::chunk_produce_seed(protocol_version, &v3.rng_seed, height, shard_id);
-                let shard_id = shard_id as usize;
-                let sample = v3.chunk_producers_sampler.get(shard_id)?.sample(seed);
-                v3.chunk_producers_settlement.get(shard_id)?.get(sample).copied()
+                let sample = v3.chunk_producers_sampler.get(shard_index)?.sample(seed);
+                v3.chunk_producers_settlement.get(shard_index)?.get(sample).copied()
             }
             Self::V4(v4) => {
                 let protocol_version = self.protocol_version();
                 let seed =
                     Self::chunk_produce_seed(protocol_version, &v4.rng_seed, height, shard_id);
-                let shard_id = shard_id as usize;
-                let sample = v4.chunk_producers_sampler.get(shard_id)?.sample(seed);
-                v4.chunk_producers_settlement.get(shard_id)?.get(sample).copied()
+                let sample = v4.chunk_producers_sampler.get(shard_index)?.sample(seed);
+                v4.chunk_producers_settlement.get(shard_index)?.get(sample).copied()
             }
         }
     }
@@ -676,7 +677,7 @@ impl EpochInfo {
             let mut buffer = [0u8; 48];
             buffer[0..32].copy_from_slice(seed);
             buffer[32..40].copy_from_slice(&height.to_le_bytes());
-            buffer[40..48].copy_from_slice(&shard_id.to_le_bytes());
+            buffer[40..48].copy_from_slice(&shard_id.get().to_le_bytes());
             hash(&buffer).0
         }
     }

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -156,7 +156,7 @@ pub struct ShardLayoutV2 {
     id_to_index_map: BTreeMap<ShardId, ShardIndex>,
 
     /// The mapping from shard index to shard id.
-    /// TODO this is identical to the shard_ids, remove it.
+    /// TODO(wacban) this is identical to the shard_ids, remove it.
     index_to_id_map: BTreeMap<ShardIndex, ShardId>,
 
     /// A mapping from the parent shard to child shards. Maps shards from the

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -433,8 +433,8 @@ impl ShardLayout {
 
     pub fn shard_ids(&self) -> impl Iterator<Item = ShardId> + '_ {
         match self {
-            Self::V0(_) => (0..self.num_shards()).collect_vec().into_iter(),
-            Self::V1(_) => (0..self.num_shards()).collect_vec().into_iter(),
+            Self::V0(_) => (0..self.num_shards()).map(ShardId::new).collect_vec().into_iter(),
+            Self::V1(_) => (0..self.num_shards()).map(ShardId::new).collect_vec().into_iter(),
             Self::V2(v2) => v2.shard_ids.clone().into_iter(),
         }
     }
@@ -443,6 +443,10 @@ impl ShardLayout {
     /// shards in the shard layout
     pub fn shard_uids(&self) -> impl Iterator<Item = ShardUId> + '_ {
         self.shard_ids().map(|shard_id| ShardUId::from_shard_id_and_layout(shard_id, self))
+    }
+
+    pub(crate) fn get_shard_index(&self, shard_id: ShardId) -> usize {
+        todo!()
     }
 }
 

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -2,7 +2,7 @@ use crate::hash::CryptoHash;
 use crate::types::{AccountId, NumShards};
 use borsh::{BorshDeserialize, BorshSerialize};
 use itertools::Itertools;
-use near_primitives_core::types::ShardId;
+use near_primitives_core::types::{ShardId, ShardIndex};
 use near_schema_checker_lib::ProtocolSchema;
 use std::collections::BTreeMap;
 use std::{fmt, str};
@@ -477,7 +477,7 @@ impl ShardLayout {
         self.shard_ids().map(|shard_id| ShardUId::from_shard_id_and_layout(shard_id, self))
     }
 
-    pub fn get_shard_index(&self, _shard_id: ShardId) -> usize {
+    pub fn get_shard_index(&self, _shard_id: ShardId) -> ShardIndex {
         todo!()
     }
 

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -498,6 +498,8 @@ impl ShardLayout {
         self.shard_ids().map(|shard_id| ShardUId::from_shard_id_and_layout(shard_id, self))
     }
 
+    /// Returns the shard index for a given shard id. The shard index should be
+    /// used when indexing into an array of chunk data.
     pub fn get_shard_index(&self, shard_id: ShardId) -> ShardIndex {
         match self {
             Self::V0(_) => shard_id as ShardIndex,
@@ -506,6 +508,8 @@ impl ShardLayout {
         }
     }
 
+    /// Get the shard id for a given shard index. The shard id should be used to
+    /// identify the shard and starting from the ShardLayoutV2 it is unique.
     pub fn get_shard_id(&self, shard_index: usize) -> ShardId {
         match self {
             Self::V0(_) => shard_index as ShardId,

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -4,7 +4,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use itertools::Itertools;
 use near_primitives_core::types::ShardId;
 use near_schema_checker_lib::ProtocolSchema;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::{fmt, str};
 
 /// This file implements two data structure `ShardLayout` and `ShardUId`
@@ -88,6 +88,18 @@ type ShardsSplitMapV2 = BTreeMap<ShardId, Vec<ShardId>>;
 /// A mapping from the child shard to the parent shard.
 type ShardsParentMapV2 = BTreeMap<ShardId, ShardId>;
 
+fn new_shard_ids_vec(shard_ids: Vec<u64>) -> Vec<ShardId> {
+    shard_ids.into_iter().map(ShardId::new).collect()
+}
+
+fn new_shards_split_map(shards_split_map: Vec<Vec<u64>>) -> ShardsSplitMap {
+    shards_split_map.into_iter().map(new_shard_ids_vec).collect()
+}
+
+fn new_shards_split_map_v2(shards_split_map: BTreeMap<u64, Vec<u64>>) -> ShardsSplitMapV2 {
+    shards_split_map.into_iter().map(|(k, v)| (ShardId::new(k), new_shard_ids_vec(v))).collect()
+}
+
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct ShardLayoutV1 {
     /// The boundary accounts are the accounts on boundaries between shards.
@@ -110,14 +122,14 @@ impl ShardLayoutV1 {
     // In this shard layout the accounts are divided into ranges, each range is
     // mapped to a shard. The shards are contiguous and start from 0.
     fn account_id_to_shard_id(&self, account_id: &AccountId) -> ShardId {
-        let mut shard_id: ShardId = 0;
+        let mut shard_id = 0;
         for boundary_account in &self.boundary_accounts {
             if account_id < boundary_account {
                 break;
             }
             shard_id += 1;
         }
-        shard_id
+        ShardId::new(shard_id)
     }
 }
 
@@ -192,16 +204,21 @@ impl ShardLayout {
         version: ShardVersion,
     ) -> Self {
         let to_parent_shard_map = if let Some(shards_split_map) = &shards_split_map {
-            let mut to_parent_shard_map = HashMap::new();
+            let mut to_parent_shard_map = BTreeMap::new();
             let num_shards = (boundary_accounts.len() + 1) as NumShards;
             for (parent_shard_id, shard_ids) in shards_split_map.iter().enumerate() {
+                let parent_shard_id = ShardId::new(parent_shard_id as u64);
                 for &shard_id in shard_ids {
-                    let prev = to_parent_shard_map.insert(shard_id, parent_shard_id as ShardId);
+                    let prev = to_parent_shard_map.insert(shard_id, parent_shard_id);
                     assert!(prev.is_none(), "no shard should appear in the map twice");
-                    assert!(shard_id < num_shards, "shard id should be valid");
+                    assert!(shard_id.get() < num_shards, "shard id should be valid");
                 }
             }
-            Some((0..num_shards).map(|shard_id| to_parent_shard_map[&shard_id]).collect())
+            Some(
+                (0..num_shards)
+                    .map(|shard_id| to_parent_shard_map[&ShardId::new(shard_id)])
+                    .collect(),
+            )
         } else {
             None
         };
@@ -263,7 +280,7 @@ impl ShardLayout {
     pub fn v1_test() -> Self {
         ShardLayout::v1(
             vec!["abc", "foo", "test0"].into_iter().map(|s| s.parse().unwrap()).collect(),
-            Some(vec![vec![0, 1, 2, 3]]),
+            Some(new_shards_split_map(vec![vec![0, 1, 2, 3]])),
             1,
         )
     }
@@ -275,7 +292,7 @@ impl ShardLayout {
                 .into_iter()
                 .map(|s| s.parse().unwrap())
                 .collect(),
-            Some(vec![vec![0, 1, 2, 3]]),
+            Some(new_shards_split_map(vec![vec![0, 1, 2, 3]])),
             1,
         )
     }
@@ -287,7 +304,7 @@ impl ShardLayout {
                 .into_iter()
                 .map(|s| s.parse().unwrap())
                 .collect(),
-            Some(vec![vec![0], vec![1], vec![2], vec![3, 4]]),
+            Some(new_shards_split_map(vec![vec![0], vec![1], vec![2], vec![3, 4]])),
             2,
         )
     }
@@ -305,7 +322,7 @@ impl ShardLayout {
             .into_iter()
             .map(|s| s.parse().unwrap())
             .collect(),
-            Some(vec![vec![0], vec![1], vec![2, 3], vec![4], vec![5]]),
+            Some(new_shards_split_map(vec![vec![0], vec![1], vec![2, 3], vec![4], vec![5]])),
             3,
         )
     }
@@ -331,6 +348,7 @@ impl ShardLayout {
         ];
 
         let shard_ids = vec![0, 1, 6, 7, 3, 4, 5];
+        let shard_ids = new_shard_ids_vec(shard_ids);
 
         let shards_split_map = BTreeMap::from([
             (0, vec![0]),
@@ -340,6 +358,7 @@ impl ShardLayout {
             (4, vec![4]),
             (5, vec![5]),
         ]);
+        let shards_split_map = new_shards_split_map_v2(shards_split_map);
         let shards_split_map = Some(shards_split_map);
 
         ShardLayout::v2(boundary_accounts, shard_ids, shards_split_map)
@@ -361,7 +380,14 @@ impl ShardLayout {
             .into_iter()
             .map(|s| s.parse().unwrap())
             .collect(),
-            Some(vec![vec![0], vec![1], vec![2], vec![3], vec![4, 5], vec![6]]),
+            Some(new_shards_split_map(vec![
+                vec![0],
+                vec![1],
+                vec![2],
+                vec![3],
+                vec![4, 5],
+                vec![6],
+            ])),
             4,
         )
     }
@@ -380,7 +406,10 @@ impl ShardLayout {
         match self {
             Self::V0(_) => None,
             Self::V1(v1) => match &v1.shards_split_map {
-                Some(shards_split_map) => shards_split_map.get(parent_shard_id as usize).cloned(),
+                Some(shards_split_map) => {
+                    let parent_shard_index = parent_shard_id.get() as usize;
+                    shards_split_map.get(parent_shard_index).cloned()
+                }
                 None => None,
             },
             Self::V2(v2) => match &v2.shards_split_map {
@@ -403,7 +432,10 @@ impl ShardLayout {
             Self::V1(v1) => match &v1.to_parent_shard_map {
                 // we can safely unwrap here because the construction of to_parent_shard_map guarantees
                 // that every shard has a parent shard
-                Some(to_parent_shard_map) => *to_parent_shard_map.get(shard_id as usize).unwrap(),
+                Some(to_parent_shard_map) => {
+                    let shard_index = self.get_shard_index(shard_id);
+                    *to_parent_shard_map.get(shard_index).unwrap()
+                }
                 None => panic!("shard_layout has no parent shard"),
             },
             Self::V2(v2) => match &v2.shards_parent_map {
@@ -445,7 +477,7 @@ impl ShardLayout {
         self.shard_ids().map(|shard_id| ShardUId::from_shard_id_and_layout(shard_id, self))
     }
 
-    pub(crate) fn get_shard_index(&self, shard_id: ShardId) -> usize {
+    pub fn get_shard_index(&self, shard_id: ShardId) -> usize {
         todo!()
     }
 }
@@ -460,7 +492,8 @@ pub fn account_id_to_shard_id(account_id: &AccountId, shard_layout: &ShardLayout
         ShardLayout::V0(ShardLayoutV0 { num_shards, .. }) => {
             let hash = CryptoHash::hash_bytes(account_id.as_bytes());
             let (bytes, _) = stdx::split_array::<32, 8, 24>(hash.as_bytes());
-            u64::from_le_bytes(*bytes) % num_shards
+            let shard_id = u64::from_le_bytes(*bytes) % num_shards;
+            ShardId::new(shard_id)
         }
         ShardLayout::V1(v1) => v1.account_id_to_shard_id(account_id),
         ShardLayout::V2(v2) => v2.account_id_to_shard_id(account_id),
@@ -527,12 +560,12 @@ impl ShardUId {
     /// Constructs a shard uid from shard id and a shard layout
     pub fn from_shard_id_and_layout(shard_id: ShardId, shard_layout: &ShardLayout) -> Self {
         assert!(shard_layout.shard_ids().any(|i| i == shard_id));
-        Self { shard_id: shard_id as u32, version: shard_layout.version() }
+        Self { shard_id: shard_id.get() as u32, version: shard_layout.version() }
     }
 
     /// Returns shard id
     pub fn shard_id(&self) -> ShardId {
-        ShardId::from(self.shard_id)
+        ShardId::new(self.shard_id as u64)
     }
 }
 
@@ -675,7 +708,10 @@ impl<'de> serde::de::Visitor<'de> for ShardUIdVisitor {
 #[cfg(test)]
 mod tests {
     use crate::epoch_manager::{AllEpochConfig, EpochConfig, ValidatorSelectionConfig};
-    use crate::shard_layout::{account_id_to_shard_id, ShardLayout, ShardLayoutV1, ShardUId};
+    use crate::shard_layout::{
+        account_id_to_shard_id, new_shard_ids_vec, new_shards_split_map, ShardLayout,
+        ShardLayoutV1, ShardUId,
+    };
     use itertools::Itertools;
     use near_primitives_core::types::ProtocolVersion;
     use near_primitives_core::types::{AccountId, ShardId};
@@ -685,7 +721,7 @@ mod tests {
     use rand::{Rng, SeedableRng};
     use std::collections::{BTreeMap, HashMap};
 
-    use super::{ShardVersion, ShardsSplitMap};
+    use super::{new_shards_split_map_v2, ShardVersion, ShardsSplitMap};
 
     // The old ShardLayoutV1, before fixed shards were removed. tests only
     #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -747,15 +783,15 @@ mod tests {
         let num_shards = 4;
         let shard_layout = ShardLayout::v0(num_shards, 0);
         let mut shard_id_distribution: HashMap<_, _> =
-            shard_layout.shard_ids().map(|shard_id| (shard_id, 0)).collect();
+            shard_layout.shard_ids().map(|shard_id| (shard_id.get(), 0)).collect();
         let mut rng = StdRng::from_seed([0; 32]);
         for _i in 0..1000 {
             let s: Vec<u8> = (&mut rng).sample_iter(&Alphanumeric).take(10).collect();
             let s = String::from_utf8(s).unwrap();
             let account_id = s.to_lowercase().parse().unwrap();
             let shard_id = account_id_to_shard_id(&account_id, &shard_layout);
-            assert!(shard_id < num_shards);
-            *shard_id_distribution.get_mut(&shard_id).unwrap() += 1;
+            assert!(shard_id.get() < num_shards);
+            *shard_id_distribution.get_mut(&shard_id.get()).unwrap() += 1;
         }
         let expected_distribution: HashMap<_, _> =
             [(0, 247), (1, 268), (2, 233), (3, 252)].into_iter().collect();
@@ -766,38 +802,39 @@ mod tests {
     fn test_shard_layout_v1() {
         let shard_layout = ShardLayout::v1(
             parse_account_ids(&["aurora", "bar", "foo", "foo.baz", "paz"]),
-            Some(vec![vec![0, 1, 2], vec![3, 4, 5]]),
+            Some(new_shards_split_map(vec![vec![0, 1, 2], vec![3, 4, 5]])),
             1,
         );
         assert_eq!(
-            shard_layout.get_children_shards_uids(0).unwrap(),
+            shard_layout.get_children_shards_uids(ShardId::new(0)).unwrap(),
             (0..3).map(|x| ShardUId { version: 1, shard_id: x }).collect::<Vec<_>>()
         );
         assert_eq!(
-            shard_layout.get_children_shards_uids(1).unwrap(),
+            shard_layout.get_children_shards_uids(ShardId::new(1)).unwrap(),
             (3..6).map(|x| ShardUId { version: 1, shard_id: x }).collect::<Vec<_>>()
         );
         for x in 0..3 {
-            assert_eq!(shard_layout.get_parent_shard_id(x).unwrap(), 0);
-            assert_eq!(shard_layout.get_parent_shard_id(x + 3).unwrap(), 1);
+            assert_eq!(shard_layout.get_parent_shard_id(ShardId::new(x)).unwrap().get(), 0);
+            assert_eq!(shard_layout.get_parent_shard_id(ShardId::new(x + 3)).unwrap().get(), 1);
         }
 
-        assert_eq!(account_id_to_shard_id(&"aurora".parse().unwrap(), &shard_layout), 1);
-        assert_eq!(account_id_to_shard_id(&"foo.aurora".parse().unwrap(), &shard_layout), 3);
-        assert_eq!(account_id_to_shard_id(&"bar.foo.aurora".parse().unwrap(), &shard_layout), 2);
-        assert_eq!(account_id_to_shard_id(&"bar".parse().unwrap(), &shard_layout), 2);
-        assert_eq!(account_id_to_shard_id(&"bar.bar".parse().unwrap(), &shard_layout), 2);
-        assert_eq!(account_id_to_shard_id(&"foo".parse().unwrap(), &shard_layout), 3);
-        assert_eq!(account_id_to_shard_id(&"baz.foo".parse().unwrap(), &shard_layout), 2);
-        assert_eq!(account_id_to_shard_id(&"foo.baz".parse().unwrap(), &shard_layout), 4);
-        assert_eq!(account_id_to_shard_id(&"a.foo.baz".parse().unwrap(), &shard_layout), 0);
+        let aid = |s: &str| s.parse().unwrap();
+        assert_eq!(account_id_to_shard_id(&aid("aurora"), &shard_layout).get(), 1);
+        assert_eq!(account_id_to_shard_id(&aid("foo.aurora"), &shard_layout).get(), 3);
+        assert_eq!(account_id_to_shard_id(&aid("bar.foo.aurora"), &shard_layout).get(), 2);
+        assert_eq!(account_id_to_shard_id(&aid("bar"), &shard_layout).get(), 2);
+        assert_eq!(account_id_to_shard_id(&aid("bar.bar"), &shard_layout).get(), 2);
+        assert_eq!(account_id_to_shard_id(&aid("foo"), &shard_layout).get(), 3);
+        assert_eq!(account_id_to_shard_id(&aid("baz.foo"), &shard_layout).get(), 2);
+        assert_eq!(account_id_to_shard_id(&aid("foo.baz"), &shard_layout).get(), 4);
+        assert_eq!(account_id_to_shard_id(&aid("a.foo.baz"), &shard_layout).get(), 0);
 
-        assert_eq!(account_id_to_shard_id(&"aaa".parse().unwrap(), &shard_layout), 0);
-        assert_eq!(account_id_to_shard_id(&"abc".parse().unwrap(), &shard_layout), 0);
-        assert_eq!(account_id_to_shard_id(&"bbb".parse().unwrap(), &shard_layout), 2);
-        assert_eq!(account_id_to_shard_id(&"foo.goo".parse().unwrap(), &shard_layout), 4);
-        assert_eq!(account_id_to_shard_id(&"goo".parse().unwrap(), &shard_layout), 4);
-        assert_eq!(account_id_to_shard_id(&"zoo".parse().unwrap(), &shard_layout), 5);
+        assert_eq!(account_id_to_shard_id(&aid("aaa"), &shard_layout).get(), 0);
+        assert_eq!(account_id_to_shard_id(&aid("abc"), &shard_layout).get(), 0);
+        assert_eq!(account_id_to_shard_id(&aid("bbb"), &shard_layout).get(), 2);
+        assert_eq!(account_id_to_shard_id(&aid("foo.goo"), &shard_layout).get(), 4);
+        assert_eq!(account_id_to_shard_id(&aid("goo"), &shard_layout).get(), 4);
+        assert_eq!(account_id_to_shard_id(&aid("zoo"), &shard_layout).get(), 5);
     }
 
     // check that after removing the fixed shards from the shard layout v1
@@ -808,8 +845,8 @@ mod tests {
         let old = OldShardLayoutV1 {
             fixed_shards: vec![],
             boundary_accounts: parse_account_ids(&["aaa", "bbb"]),
-            shards_split_map: Some(vec![vec![0, 1, 2]]),
-            to_parent_shard_map: Some(vec![0, 0, 0]),
+            shards_split_map: Some(new_shards_split_map(vec![vec![0, 1, 2]])),
+            to_parent_shard_map: Some(new_shard_ids_vec(vec![0, 0, 0])),
             version: 1,
         };
         let json = serde_json::to_string_pretty(&old).unwrap();
@@ -832,18 +869,18 @@ mod tests {
         let shard_layout = get_test_shard_layout_v2();
 
         // check accounts mapping in the middle of each range
-        assert_eq!(account_id_to_shard_id(&"aaa".parse().unwrap(), &shard_layout), 3);
-        assert_eq!(account_id_to_shard_id(&"ddd".parse().unwrap(), &shard_layout), 8);
-        assert_eq!(account_id_to_shard_id(&"mmm".parse().unwrap(), &shard_layout), 4);
-        assert_eq!(account_id_to_shard_id(&"rrr".parse().unwrap(), &shard_layout), 7);
+        assert_eq!(account_id_to_shard_id(&"aaa".parse().unwrap(), &shard_layout).get(), 3);
+        assert_eq!(account_id_to_shard_id(&"ddd".parse().unwrap(), &shard_layout).get(), 8);
+        assert_eq!(account_id_to_shard_id(&"mmm".parse().unwrap(), &shard_layout).get(), 4);
+        assert_eq!(account_id_to_shard_id(&"rrr".parse().unwrap(), &shard_layout).get(), 7);
 
         // check accounts mapping for the boundary accounts
-        assert_eq!(account_id_to_shard_id(&"ccc".parse().unwrap(), &shard_layout), 8);
-        assert_eq!(account_id_to_shard_id(&"kkk".parse().unwrap(), &shard_layout), 4);
-        assert_eq!(account_id_to_shard_id(&"ppp".parse().unwrap(), &shard_layout), 7);
+        assert_eq!(account_id_to_shard_id(&"ccc".parse().unwrap(), &shard_layout).get(), 8);
+        assert_eq!(account_id_to_shard_id(&"kkk".parse().unwrap(), &shard_layout).get(), 4);
+        assert_eq!(account_id_to_shard_id(&"ppp".parse().unwrap(), &shard_layout).get(), 7);
 
         // check shard ids
-        assert_eq!(shard_layout.shard_ids().collect_vec(), vec![3, 8, 4, 7]);
+        assert_eq!(shard_layout.shard_ids().collect_vec(), new_shard_ids_vec(vec![3, 8, 4, 7]));
 
         // check shard uids
         let version = 3;
@@ -851,15 +888,24 @@ mod tests {
         assert_eq!(shard_layout.shard_uids().collect_vec(), vec![u(3), u(8), u(4), u(7)]);
 
         // check parent
-        assert_eq!(shard_layout.get_parent_shard_id(3).unwrap(), 3);
-        assert_eq!(shard_layout.get_parent_shard_id(8).unwrap(), 1);
-        assert_eq!(shard_layout.get_parent_shard_id(4).unwrap(), 4);
-        assert_eq!(shard_layout.get_parent_shard_id(7).unwrap(), 1);
+        assert_eq!(shard_layout.get_parent_shard_id(ShardId::new(3)).unwrap().get(), 3);
+        assert_eq!(shard_layout.get_parent_shard_id(ShardId::new(8)).unwrap().get(), 1);
+        assert_eq!(shard_layout.get_parent_shard_id(ShardId::new(4)).unwrap().get(), 4);
+        assert_eq!(shard_layout.get_parent_shard_id(ShardId::new(7)).unwrap().get(), 1);
 
         // check child
-        assert_eq!(shard_layout.get_children_shards_ids(1).unwrap(), vec![7, 8]);
-        assert_eq!(shard_layout.get_children_shards_ids(3).unwrap(), vec![3]);
-        assert_eq!(shard_layout.get_children_shards_ids(4).unwrap(), vec![4]);
+        assert_eq!(
+            shard_layout.get_children_shards_ids(ShardId::new(1)).unwrap(),
+            new_shard_ids_vec(vec![7, 8])
+        );
+        assert_eq!(
+            shard_layout.get_children_shards_ids(ShardId::new(3)).unwrap(),
+            new_shard_ids_vec(vec![3])
+        );
+        assert_eq!(
+            shard_layout.get_children_shards_ids(ShardId::new(4)).unwrap(),
+            new_shard_ids_vec(vec![4])
+        );
     }
 
     fn get_test_shard_layout_v2() -> ShardLayout {
@@ -869,10 +915,12 @@ mod tests {
 
         let boundary_accounts = vec![b0, b1, b2];
         let shard_ids = vec![3, 8, 4, 7];
+        let shard_ids = new_shard_ids_vec(shard_ids);
 
         // the mapping from parent to the child
         // shard 1 is split into shards 7 & 8 while other shards stay the same
         let shards_split_map = BTreeMap::from([(1, vec![7, 8]), (3, vec![3]), (4, vec![4])]);
+        let shards_split_map = new_shards_split_map_v2(shards_split_map);
         let shards_split_map = Some(shards_split_map);
 
         ShardLayout::v2(boundary_accounts, shard_ids, shards_split_map)

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -480,6 +480,10 @@ impl ShardLayout {
     pub fn get_shard_index(&self, shard_id: ShardId) -> usize {
         todo!()
     }
+
+    pub fn get_shard_id(&self, shard_index: usize) -> ShardId {
+        todo!()
+    }
 }
 
 /// Maps an account to the shard that it belongs to given a shard_layout

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -477,11 +477,11 @@ impl ShardLayout {
         self.shard_ids().map(|shard_id| ShardUId::from_shard_id_and_layout(shard_id, self))
     }
 
-    pub fn get_shard_index(&self, shard_id: ShardId) -> usize {
+    pub fn get_shard_index(&self, _shard_id: ShardId) -> usize {
         todo!()
     }
 
-    pub fn get_shard_id(&self, shard_index: usize) -> ShardId {
+    pub fn get_shard_id(&self, _shard_index: usize) -> ShardId {
         todo!()
     }
 }

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -1213,7 +1213,7 @@ impl EncodedShardChunk {
             "decode_chunk",
             data_parts,
             height_included = self.cloned_header().height_included(),
-            shard_id = self.cloned_header().shard_id(),
+            shard_id = ?self.cloned_header().shard_id(),
             chunk_hash = ?self.chunk_hash())
         .entered();
 

--- a/core/primitives/src/stateless_validation/chunk_endorsements_bitmap.rs
+++ b/core/primitives/src/stateless_validation/chunk_endorsements_bitmap.rs
@@ -1,6 +1,5 @@
 use bitvec::prelude::*;
 use borsh::{BorshDeserialize, BorshSerialize};
-use near_primitives_core::types::ShardId;
 use near_schema_checker_lib::ProtocolSchema;
 
 /// Represents a collection of bitmaps, one per shard, to store whether the endorsements from the chunk validators has been received.
@@ -90,7 +89,6 @@ impl ChunkEndorsementsBitmap {
 mod tests {
     use super::ChunkEndorsementsBitmap;
     use itertools::Itertools;
-    use near_primitives_core::types::ShardId;
     use rand::Rng;
 
     const NUM_SHARDS: usize = 4;

--- a/core/primitives/src/stateless_validation/chunk_endorsements_bitmap.rs
+++ b/core/primitives/src/stateless_validation/chunk_endorsements_bitmap.rs
@@ -56,21 +56,21 @@ impl ChunkEndorsementsBitmap {
     // Creates an endorsement bitmap for all the shards.
     pub fn from_endorsements(shards_to_endorsements: Vec<Vec<bool>>) -> Self {
         let mut bitmap = ChunkEndorsementsBitmap::new(shards_to_endorsements.len());
-        for (shard_id, endorsements) in shards_to_endorsements.into_iter().enumerate() {
-            bitmap.add_endorsements(shard_id as ShardId, endorsements);
+        for (shard_index, endorsements) in shards_to_endorsements.into_iter().enumerate() {
+            bitmap.add_endorsements(shard_index, endorsements);
         }
         bitmap
     }
 
     /// Adds the provided endorsements to the bitmap for the specified shard.
-    pub fn add_endorsements(&mut self, shard_id: ShardId, endorsements: Vec<bool>) {
+    pub fn add_endorsements(&mut self, shard_index: usize, endorsements: Vec<bool>) {
         let bitvec: BitVecType = endorsements.iter().collect();
-        self.inner[shard_id as usize] = bitvec.into();
+        self.inner[shard_index] = bitvec.into();
     }
 
     /// Returns an iterator over the endorsements (yields true if the endorsement for the respective position was received).
-    pub fn iter(&self, shard_id: ShardId) -> Box<dyn Iterator<Item = bool>> {
-        let bitvec = BitVecType::from_vec(self.inner[shard_id as usize].clone());
+    pub fn iter(&self, shard_index: usize) -> Box<dyn Iterator<Item = bool>> {
+        let bitvec = BitVecType::from_vec(self.inner[shard_index].clone());
         Box::new(bitvec.into_iter())
     }
 
@@ -81,8 +81,8 @@ impl ChunkEndorsementsBitmap {
 
     /// Returns the full length of the bitmap for a given shard.
     /// Note that the size may be greater than the number of validator assignments.
-    pub fn len(&self, shard_id: ShardId) -> Option<usize> {
-        self.inner.get(shard_id as usize).map(|v| v.len() * 8)
+    pub fn len(&self, shard_index: usize) -> Option<usize> {
+        self.inner.get(shard_index).map(|v| v.len() * 8)
     }
 }
 
@@ -102,9 +102,9 @@ mod tests {
         expected_endorsements: &Vec<Vec<bool>>,
     ) {
         // Endorsements from the bitmap iterator must match the endorsements given previously.
-        for (shard_id, endorsements) in expected_endorsements.iter().enumerate() {
-            let num_bits = bitmap.len(shard_id as ShardId).unwrap();
-            let bits = bitmap.iter(shard_id as ShardId).collect_vec();
+        for (shard_index, endorsements) in expected_endorsements.iter().enumerate() {
+            let num_bits = bitmap.len(shard_index).unwrap();
+            let bits = bitmap.iter(shard_index).collect_vec();
             // Number of bits must be equal to the size of the bit iterator for the corresponding shard.
             assert_eq!(num_bits, bits.len());
             // Bitmap must contain the minimal number of bits to represent the endorsements.
@@ -121,13 +121,13 @@ mod tests {
         let mut rng = rand::thread_rng();
         let mut bitmap = ChunkEndorsementsBitmap::new(NUM_SHARDS);
         let mut expected_endorsements = vec![];
-        for shard_id in 0..NUM_SHARDS {
+        for shard_index in 0..NUM_SHARDS {
             let mut endorsements = vec![false; num_assignments];
             for _ in 0..num_produced {
                 endorsements[rng.gen_range(0..num_assignments)] = true;
             }
             expected_endorsements.push(endorsements.clone());
-            bitmap.add_endorsements(shard_id as ShardId, endorsements);
+            bitmap.add_endorsements(shard_index, endorsements);
         }
         // Check before serialization.
         assert_bitmap(&bitmap, num_assignments, &expected_endorsements);

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -1011,7 +1011,7 @@ impl EpochInfoProvider for MockEpochInfoProvider {
         _account_id: &AccountId,
         _epoch_id: &EpochId,
     ) -> Result<ShardId, EpochError> {
-        Ok(ShardId::new(0))
+        Ok(0)
     }
 }
 

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -1011,7 +1011,7 @@ impl EpochInfoProvider for MockEpochInfoProvider {
         _account_id: &AccountId,
         _epoch_id: &EpochId,
     ) -> Result<ShardId, EpochError> {
-        Ok(0)
+        Ok(ShardId::new(0))
     }
 }
 

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -294,8 +294,8 @@ impl TrieKey {
             TrieKey::BufferedReceipt { index, receiving_shard } => {
                 buf.push(col::BUFFERED_RECEIPT);
                 // Use  u16 for shard id to reduce depth in trie.
-                assert!(receiving_shard.get() <= u16::MAX as u64, "Shard ID too big.");
-                buf.extend(&(receiving_shard.get() as u16).to_le_bytes());
+                assert!(*receiving_shard <= u16::MAX as u64, "Shard ID too big.");
+                buf.extend(&(*receiving_shard as u16).to_le_bytes());
                 buf.extend(&index.to_le_bytes());
             }
         };
@@ -852,7 +852,7 @@ mod tests {
         let shard_layout = ShardLayout::for_protocol_version(PROTOCOL_VERSION);
         let max_id = shard_layout.shard_ids().max().unwrap();
         assert!(
-            max_id.get() <= u16::MAX as u64,
+            max_id <= u16::MAX as u64,
             "buffered receipt trie key optimization broken, must fit in a u16"
         );
     }

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -294,8 +294,8 @@ impl TrieKey {
             TrieKey::BufferedReceipt { index, receiving_shard } => {
                 buf.push(col::BUFFERED_RECEIPT);
                 // Use  u16 for shard id to reduce depth in trie.
-                assert!(*receiving_shard <= u16::MAX as u64, "Shard ID too big.");
-                buf.extend(&(*receiving_shard as u16).to_le_bytes());
+                assert!(receiving_shard.get() <= u16::MAX as u64, "Shard ID too big.");
+                buf.extend(&(receiving_shard.get() as u16).to_le_bytes());
                 buf.extend(&index.to_le_bytes());
             }
         };
@@ -852,7 +852,7 @@ mod tests {
         let shard_layout = ShardLayout::for_protocol_version(PROTOCOL_VERSION);
         let max_id = shard_layout.shard_ids().max().unwrap();
         assert!(
-            max_id <= u16::MAX as u64,
+            max_id.get() <= u16::MAX as u64,
             "buffered receipt trie key optimization broken, must fit in a u16"
         );
     }

--- a/core/store/benches/finalize_bench.rs
+++ b/core/store/benches/finalize_bench.rs
@@ -30,7 +30,7 @@ use near_primitives::sharding::{
     ShardChunkV2, ShardProof,
 };
 use near_primitives::transaction::{Action, FunctionCallAction, SignedTransaction};
-use near_primitives::types::AccountId;
+use near_primitives::types::{AccountId, ShardId};
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_store::DBCol;
@@ -115,7 +115,7 @@ fn create_benchmark_receipts() -> Vec<Receipt> {
     ]
 }
 
-fn create_chunk_header(height: u64, shard_id: u64) -> ShardChunkHeader {
+fn create_chunk_header(height: u64, shard_id: ShardId) -> ShardChunkHeader {
     let congestion_info = ProtocolFeature::CongestionControl
         .enabled(PROTOCOL_VERSION)
         .then_some(CongestionInfo::default());
@@ -177,7 +177,7 @@ fn create_shard_chunk(
 ) -> ShardChunk {
     ShardChunk::V2(ShardChunkV2 {
         chunk_hash: chunk_hash.clone(),
-        header: create_chunk_header(0, 0),
+        header: create_chunk_header(0, 0.into()),
         transactions,
         prev_outgoing_receipts: receipts,
     })
@@ -198,7 +198,7 @@ fn create_encoded_shard_chunk(
         Default::default(),
         Default::default(),
         Default::default(),
-        Default::default(),
+        0.into(),
         Default::default(),
         Default::default(),
         Default::default(),
@@ -231,8 +231,8 @@ fn encoded_chunk_to_partial_encoded_chunk(
     let receipt_proofs = proofs
         .into_iter()
         .enumerate()
-        .map(move |(proof_shard_id, proof)| {
-            let proof_shard_id = proof_shard_id as u64;
+        .map(move |(proof_shard_index, proof)| {
+            let proof_shard_id = shard_layout.get_shard_id(proof_shard_index);
             let receipts = receipts_by_shard.remove(&proof_shard_id).unwrap_or_else(Vec::new);
             let shard_proof =
                 ShardProof { from_shard_id: shard_id, to_shard_id: proof_shard_id, proof };

--- a/core/store/benches/finalize_bench.rs
+++ b/core/store/benches/finalize_bench.rs
@@ -30,7 +30,7 @@ use near_primitives::sharding::{
     ShardChunkV2, ShardProof,
 };
 use near_primitives::transaction::{Action, FunctionCallAction, SignedTransaction};
-use near_primitives::types::{AccountId, ShardId};
+use near_primitives::types::{new_shard_id_tmp, AccountId, ShardId};
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_store::DBCol;
@@ -177,7 +177,7 @@ fn create_shard_chunk(
 ) -> ShardChunk {
     ShardChunk::V2(ShardChunkV2 {
         chunk_hash: chunk_hash.clone(),
-        header: create_chunk_header(0, 0.into()),
+        header: create_chunk_header(0, new_shard_id_tmp(0)),
         transactions,
         prev_outgoing_receipts: receipts,
     })
@@ -198,7 +198,7 @@ fn create_encoded_shard_chunk(
         Default::default(),
         Default::default(),
         Default::default(),
-        0.into(),
+        new_shard_id_tmp(0),
         Default::default(),
         Default::default(),
         Default::default(),

--- a/core/store/src/flat/storage.rs
+++ b/core/store/src/flat/storage.rs
@@ -130,7 +130,7 @@ impl FlatStorageInner {
         if blocks.len() >= Self::HOPS_LIMIT {
             warn!(
                 target: "chain",
-                shard_id = self.shard_uid.shard_id(),
+                shard_id = ?self.shard_uid.shard_id(),
                 flat_head_height = flat_head.height,
                 cached_deltas = self.deltas.len(),
                 num_hops = blocks.len(),
@@ -160,7 +160,7 @@ impl FlatStorageInner {
         if cached_changes_size_bytes >= Self::CACHED_CHANGES_SIZE_LIMIT {
             warn!(
                 target: "chain",
-                shard_id = self.shard_uid.shard_id(),
+                shard_id = ?self.shard_uid.shard_id(),
                 flat_head_height = self.flat_head.height,
                 cached_deltas,
                 %cached_changes_size_bytes,
@@ -380,7 +380,7 @@ impl FlatStorage {
         let shard_uid = guard.shard_uid;
         let shard_id = shard_uid.shard_id();
 
-        tracing::debug!(target: "store", flat_head = ?guard.flat_head.hash, ?new_head, shard_id, "Moving flat head");
+        tracing::debug!(target: "store", flat_head = ?guard.flat_head.hash, ?new_head, ?shard_id, "Moving flat head");
         let blocks = guard.get_blocks_to_head(&new_head)?;
 
         for block_hash in blocks.into_iter().rev() {

--- a/core/store/src/trie/prefetching_trie_storage.rs
+++ b/core/store/src/trie/prefetching_trie_storage.rs
@@ -593,12 +593,13 @@ mod tests_utils {
 mod tests {
     use super::{PrefetchStagingArea, PrefetcherResult};
     use near_primitives::hash::CryptoHash;
+    use near_primitives::types::new_shard_id_tmp;
 
     #[test]
     fn test_prefetch_staging_area_blocking_get_after_update() {
         let key = CryptoHash::hash_bytes(&[1, 2, 3]);
         let value: std::sync::Arc<[u8]> = vec![4, 5, 6].into();
-        let prefetch_staging_area = PrefetchStagingArea::new(0.into());
+        let prefetch_staging_area = PrefetchStagingArea::new(new_shard_id_tmp(0));
         assert!(matches!(
             prefetch_staging_area.get_or_set_fetching(key),
             PrefetcherResult::SlotReserved

--- a/core/store/src/trie/prefetching_trie_storage.rs
+++ b/core/store/src/trie/prefetching_trie_storage.rs
@@ -598,7 +598,7 @@ mod tests {
     fn test_prefetch_staging_area_blocking_get_after_update() {
         let key = CryptoHash::hash_bytes(&[1, 2, 3]);
         let value: std::sync::Arc<[u8]> = vec![4, 5, 6].into();
-        let prefetch_staging_area = PrefetchStagingArea::new(0);
+        let prefetch_staging_area = PrefetchStagingArea::new(0.into());
         assert!(matches!(
             prefetch_staging_area.get_or_set_fetching(key),
             PrefetcherResult::SlotReserved

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -286,7 +286,7 @@ impl ShardTries {
         level = "trace",
         target = "store::trie::shard_tries",
         "ShardTries::apply_insertions",
-        fields(num_insertions = trie_changes.insertions().len(), shard_id = shard_uid.shard_id()),
+        fields(num_insertions = trie_changes.insertions().len(), shard_id = ?shard_uid.shard_id()),
         skip_all,
     )]
     pub fn apply_insertions(
@@ -309,7 +309,7 @@ impl ShardTries {
         level = "trace",
         target = "store::trie::shard_tries",
         "ShardTries::apply_deletions",
-        fields(num_deletions = trie_changes.deletions().len(), shard_id = shard_uid.shard_id()),
+        fields(num_deletions = trie_changes.deletions().len(), shard_id = ?shard_uid.shard_id()),
         skip_all,
     )]
     pub fn apply_deletions(
@@ -553,7 +553,7 @@ impl WrappedTrieChanges {
         level = "debug",
         target = "store::trie::shard_tries",
         "ShardTries::state_changes_into",
-        fields(num_state_changes = self.state_changes.len(), shard_id = self.shard_uid.shard_id()),
+        fields(num_state_changes = self.state_changes.len(), shard_id = ?self.shard_uid.shard_id()),
         skip_all,
     )]
     pub fn state_changes_into(&mut self, store_update: &mut TrieStoreUpdateAdapter) {

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -129,7 +129,7 @@ impl Trie {
         part_id: PartId,
     ) -> Result<(PartialState, Vec<u8>, Vec<u8>), StorageError> {
         let shard_id: ShardId = self.flat_storage_chunk_view.as_ref().map_or(
-            ShardId::max(), // Fake value for metrics.
+            ShardId::MAX, // Fake value for metrics.
             |chunk_view| chunk_view.shard_uid().shard_id(),
         );
         let _span = tracing::debug_span!(
@@ -183,7 +183,7 @@ impl Trie {
         state_trie: &Trie,
     ) -> Result<PartialState, StorageError> {
         let shard_id: ShardId = self.flat_storage_chunk_view.as_ref().map_or(
-            ShardId::max(), // Fake value for metrics.
+            ShardId::MAX, // Fake value for metrics.
             |chunk_view| chunk_view.shard_uid().shard_id(),
         );
         let _span = tracing::debug_span!(

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -129,8 +129,8 @@ impl Trie {
         part_id: PartId,
     ) -> Result<(PartialState, Vec<u8>, Vec<u8>), StorageError> {
         let shard_id: ShardId = self.flat_storage_chunk_view.as_ref().map_or(
-            ShardId::MAX, // Fake value for metrics.
-            |chunk_view| chunk_view.shard_uid().shard_id as ShardId,
+            ShardId::max(), // Fake value for metrics.
+            |chunk_view| chunk_view.shard_uid().shard_id(),
         );
         let _span = tracing::debug_span!(
             target: "state-parts",
@@ -183,8 +183,8 @@ impl Trie {
         state_trie: &Trie,
     ) -> Result<PartialState, StorageError> {
         let shard_id: ShardId = self.flat_storage_chunk_view.as_ref().map_or(
-            ShardId::MAX, // Fake value for metrics.
-            |chunk_view| chunk_view.shard_uid().shard_id as ShardId,
+            ShardId::max(), // Fake value for metrics.
+            |chunk_view| chunk_view.shard_uid().shard_id(),
         );
         let _span = tracing::debug_span!(
             target: "state-parts",

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -103,7 +103,7 @@ impl TrieCacheInner {
         assert!(total_size_limit > 0);
         // `itoa` is much faster for printing shard_id to a string than trivial alternatives.
         let mut buffer = itoa::Buffer::new();
-        let shard_id_str = buffer.format(shard_id);
+        let shard_id_str = buffer.format(shard_id.get());
 
         let metrics_labels: [&str; 2] = [&shard_id_str, if is_view { "1" } else { "0" }];
         let metrics = TrieCacheMetrics {

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -103,7 +103,7 @@ impl TrieCacheInner {
         assert!(total_size_limit > 0);
         // `itoa` is much faster for printing shard_id to a string than trivial alternatives.
         let mut buffer = itoa::Buffer::new();
-        let shard_id_str = buffer.format(shard_id.get());
+        let shard_id_str = buffer.format(shard_id);
 
         let metrics_labels: [&str; 2] = [&shard_id_str, if is_view { "1" } else { "0" }];
         let metrics = TrieCacheMetrics {
@@ -612,7 +612,7 @@ mod trie_cache_tests {
     use crate::{StoreConfig, TrieCache, TrieConfig};
     use near_primitives::hash::hash;
     use near_primitives::shard_layout::ShardUId;
-    use near_primitives::types::ShardId;
+    use near_primitives::types::{new_shard_id_tmp, shard_id_as_u32, ShardId};
 
     fn put_value(cache: &mut TrieCacheInner, value: &[u8]) {
         cache.put(hash(value), value.into());
@@ -622,7 +622,8 @@ mod trie_cache_tests {
     fn test_size_limit() {
         let value_size_sum = 5;
         let memory_overhead = 2 * TrieCacheInner::PER_ENTRY_OVERHEAD;
-        let mut cache = TrieCacheInner::new(100, value_size_sum + memory_overhead, 0.into(), false);
+        let mut cache =
+            TrieCacheInner::new(100, value_size_sum + memory_overhead, new_shard_id_tmp(0), false);
         // Add three values. Before each put, condition on total size should not be triggered.
         put_value(&mut cache, &[1, 1]);
         assert_eq!(cache.current_total_size(), 2 + TrieCacheInner::PER_ENTRY_OVERHEAD);
@@ -640,7 +641,7 @@ mod trie_cache_tests {
 
     #[test]
     fn test_deletions_queue() {
-        let mut cache = TrieCacheInner::new(2, 1000, 0.into(), false);
+        let mut cache = TrieCacheInner::new(2, 1000, new_shard_id_tmp(0), false);
         // Add two values to the cache.
         put_value(&mut cache, &[1]);
         put_value(&mut cache, &[1, 1]);
@@ -659,7 +660,7 @@ mod trie_cache_tests {
     fn test_cache_capacity() {
         let capacity = 2;
         let total_size_limit = TrieCacheInner::PER_ENTRY_OVERHEAD * capacity;
-        let mut cache = TrieCacheInner::new(100, total_size_limit, 0.into(), false);
+        let mut cache = TrieCacheInner::new(100, total_size_limit, new_shard_id_tmp(0), false);
         put_value(&mut cache, &[1]);
         put_value(&mut cache, &[2]);
         put_value(&mut cache, &[3]);
@@ -672,7 +673,7 @@ mod trie_cache_tests {
     #[test]
     fn test_small_memory_limit() {
         let total_size_limit = 1;
-        let mut cache = TrieCacheInner::new(100, total_size_limit, 0.into(), false);
+        let mut cache = TrieCacheInner::new(100, total_size_limit, new_shard_id_tmp(0), false);
         put_value(&mut cache, &[1, 2, 3]);
         put_value(&mut cache, &[2, 3, 4]);
         put_value(&mut cache, &[3, 4, 5]);
@@ -699,10 +700,10 @@ mod trie_cache_tests {
         store_config.view_trie_cache.per_shard_max_bytes.insert(s0, S0_VIEW_SIZE);
         let trie_config = TrieConfig::from_store_config(&store_config);
 
-        check_cache_size(&trie_config, 1.into(), false, DEFAULT_SIZE);
-        check_cache_size(&trie_config, 0.into(), false, S0_SIZE);
-        check_cache_size(&trie_config, 1.into(), true, DEFAULT_VIEW_SIZE);
-        check_cache_size(&trie_config, 0.into(), true, S0_VIEW_SIZE);
+        check_cache_size(&trie_config, new_shard_id_tmp(1), false, DEFAULT_SIZE);
+        check_cache_size(&trie_config, new_shard_id_tmp(0), false, S0_SIZE);
+        check_cache_size(&trie_config, new_shard_id_tmp(1), true, DEFAULT_VIEW_SIZE);
+        check_cache_size(&trie_config, new_shard_id_tmp(0), true, S0_VIEW_SIZE);
     }
 
     #[track_caller]
@@ -712,7 +713,7 @@ mod trie_cache_tests {
         is_view: bool,
         expected_size: bytesize::ByteSize,
     ) {
-        let shard_uid = ShardUId { version: 0, shard_id: shard_id.into() };
+        let shard_uid = ShardUId { version: 0, shard_id: shard_id_as_u32(shard_id) };
         let trie_cache = TrieCache::new(&trie_config, shard_uid, is_view);
         assert_eq!(expected_size.as_u64(), trie_cache.lock().total_size_limit);
         assert_eq!(is_view, trie_cache.lock().is_view);

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -622,7 +622,7 @@ mod trie_cache_tests {
     fn test_size_limit() {
         let value_size_sum = 5;
         let memory_overhead = 2 * TrieCacheInner::PER_ENTRY_OVERHEAD;
-        let mut cache = TrieCacheInner::new(100, value_size_sum + memory_overhead, 0, false);
+        let mut cache = TrieCacheInner::new(100, value_size_sum + memory_overhead, 0.into(), false);
         // Add three values. Before each put, condition on total size should not be triggered.
         put_value(&mut cache, &[1, 1]);
         assert_eq!(cache.current_total_size(), 2 + TrieCacheInner::PER_ENTRY_OVERHEAD);
@@ -640,7 +640,7 @@ mod trie_cache_tests {
 
     #[test]
     fn test_deletions_queue() {
-        let mut cache = TrieCacheInner::new(2, 1000, 0, false);
+        let mut cache = TrieCacheInner::new(2, 1000, 0.into(), false);
         // Add two values to the cache.
         put_value(&mut cache, &[1]);
         put_value(&mut cache, &[1, 1]);
@@ -659,7 +659,7 @@ mod trie_cache_tests {
     fn test_cache_capacity() {
         let capacity = 2;
         let total_size_limit = TrieCacheInner::PER_ENTRY_OVERHEAD * capacity;
-        let mut cache = TrieCacheInner::new(100, total_size_limit, 0, false);
+        let mut cache = TrieCacheInner::new(100, total_size_limit, 0.into(), false);
         put_value(&mut cache, &[1]);
         put_value(&mut cache, &[2]);
         put_value(&mut cache, &[3]);
@@ -672,7 +672,7 @@ mod trie_cache_tests {
     #[test]
     fn test_small_memory_limit() {
         let total_size_limit = 1;
-        let mut cache = TrieCacheInner::new(100, total_size_limit, 0, false);
+        let mut cache = TrieCacheInner::new(100, total_size_limit, 0.into(), false);
         put_value(&mut cache, &[1, 2, 3]);
         put_value(&mut cache, &[2, 3, 4]);
         put_value(&mut cache, &[3, 4, 5]);
@@ -699,10 +699,10 @@ mod trie_cache_tests {
         store_config.view_trie_cache.per_shard_max_bytes.insert(s0, S0_VIEW_SIZE);
         let trie_config = TrieConfig::from_store_config(&store_config);
 
-        check_cache_size(&trie_config, 1, false, DEFAULT_SIZE);
-        check_cache_size(&trie_config, 0, false, S0_SIZE);
-        check_cache_size(&trie_config, 1, true, DEFAULT_VIEW_SIZE);
-        check_cache_size(&trie_config, 0, true, S0_VIEW_SIZE);
+        check_cache_size(&trie_config, 1.into(), false, DEFAULT_SIZE);
+        check_cache_size(&trie_config, 0.into(), false, S0_SIZE);
+        check_cache_size(&trie_config, 1.into(), true, DEFAULT_VIEW_SIZE);
+        check_cache_size(&trie_config, 0.into(), true, S0_VIEW_SIZE);
     }
 
     #[track_caller]
@@ -712,7 +712,7 @@ mod trie_cache_tests {
         is_view: bool,
         expected_size: bytesize::ByteSize,
     ) {
-        let shard_uid = ShardUId { version: 0, shard_id: shard_id as u32 };
+        let shard_uid = ShardUId { version: 0, shard_id: shard_id.into() };
         let trie_cache = TrieCache::new(&trie_config, shard_uid, is_view);
         assert_eq!(expected_size.as_u64(), trie_cache.lock().total_size_limit);
         assert_eq!(is_view, trie_cache.lock().is_view);

--- a/genesis-tools/genesis-csv-to-json/src/csv_to_json_configs.rs
+++ b/genesis-tools/genesis-csv-to-json/src/csv_to_json_configs.rs
@@ -5,7 +5,7 @@ use near_chain_configs::{
     MIN_GAS_PRICE, NEAR_BASE, NUM_BLOCKS_PER_YEAR, NUM_BLOCK_PRODUCER_SEATS, PROTOCOL_REWARD_RATE,
     PROTOCOL_UPGRADE_STAKE_THRESHOLD, TRANSACTION_VALIDITY_PERIOD,
 };
-use near_primitives::types::{Balance, NumShards, ShardId};
+use near_primitives::types::{new_shard_id_tmp, Balance, NumShards, ShardId};
 use near_primitives::utils::get_num_seats_per_shard;
 use near_primitives::version::PROTOCOL_VERSION;
 use nearcore::config::{Config, CONFIG_FILENAME, NODE_KEY_FILE};
@@ -15,14 +15,14 @@ use std::path::Path;
 
 const ACCOUNTS_FILE: &str = "accounts.csv";
 const SHARDS: &'static [ShardId] = &[
-    ShardId::new(0),
-    ShardId::new(1),
-    ShardId::new(2),
-    ShardId::new(3),
-    ShardId::new(4),
-    ShardId::new(5),
-    ShardId::new(6),
-    ShardId::new(7),
+    new_shard_id_tmp(0),
+    new_shard_id_tmp(1),
+    new_shard_id_tmp(2),
+    new_shard_id_tmp(3),
+    new_shard_id_tmp(4),
+    new_shard_id_tmp(5),
+    new_shard_id_tmp(6),
+    new_shard_id_tmp(7),
 ];
 
 fn verify_total_supply(total_supply: Balance, chain_id: &str) {

--- a/genesis-tools/genesis-csv-to-json/src/csv_to_json_configs.rs
+++ b/genesis-tools/genesis-csv-to-json/src/csv_to_json_configs.rs
@@ -14,7 +14,16 @@ use std::fs::File;
 use std::path::Path;
 
 const ACCOUNTS_FILE: &str = "accounts.csv";
-const SHARDS: &'static [ShardId] = &[0, 1, 2, 3, 4, 5, 6, 7];
+const SHARDS: &'static [ShardId] = &[
+    ShardId::new(0),
+    ShardId::new(1),
+    ShardId::new(2),
+    ShardId::new(3),
+    ShardId::new(4),
+    ShardId::new(5),
+    ShardId::new(6),
+    ShardId::new(7),
+];
 
 fn verify_total_supply(total_supply: Balance, chain_id: &str) {
     if chain_id == near_primitives::chains::MAINNET {

--- a/genesis-tools/genesis-csv-to-json/src/main.rs
+++ b/genesis-tools/genesis-csv-to-json/src/main.rs
@@ -35,7 +35,7 @@ fn main() {
             if s.is_empty() {
                 HashSet::default()
             } else {
-                s.split(',').map(|v| v.parse::<ShardId>().unwrap()).collect()
+                s.split(',').map(|v| v.parse::<u64>().unwrap().into()).collect()
             }
         }
         None => HashSet::default(),

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -134,15 +134,15 @@ impl GenesisBuilder {
         let roots = get_genesis_state_roots(self.runtime.store())?
             .expect("genesis state roots not initialized.");
         let genesis_shard_version = self.genesis.config.shard_layout.version();
-        self.roots = roots.into_iter().enumerate().map(|(k, v)| (k as u64, v)).collect();
+        self.roots = roots.into_iter().enumerate().map(|(k, v)| (k.into(), v)).collect();
         self.state_updates = self
             .roots
             .iter()
-            .map(|(shard_idx, root)| {
+            .map(|(&shard_id, root)| {
                 (
-                    *shard_idx,
+                    shard_id,
                     self.runtime.get_tries().new_trie_update(
-                        ShardUId { version: genesis_shard_version, shard_id: *shard_idx as u32 },
+                        ShardUId { version: genesis_shard_version, shard_id: shard_id.into() },
                         *root,
                     ),
                 )

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -200,7 +200,7 @@ impl GenesisBuilder {
         state_update.commit(StateChangeCause::InitialState);
         let (_, trie_changes, state_changes) = state_update.finalize()?;
         let genesis_shard_version = self.genesis.config.shard_layout.version();
-        let shard_uid = ShardUId { version: genesis_shard_version, shard_id: shard_idx as u32 };
+        let shard_uid = ShardUId { version: genesis_shard_version, shard_id: shard_idx.into() };
         let mut store_update = tries.store_update();
         let root = tries.apply_all(&trie_changes, shard_uid, &mut store_update);
         near_store::flat::FlatStateChanges::from_state_changes(&state_changes)
@@ -300,7 +300,7 @@ impl GenesisBuilder {
         &self,
         protocol_version: ProtocolVersion,
         genesis: &Block,
-        shard_id: u64,
+        shard_id: ShardId,
         state_root: CryptoHash,
     ) -> Result<Option<CongestionInfo>> {
         if !ProtocolFeature::CongestionControl.enabled(protocol_version) {

--- a/integration-tests/src/runtime_utils.rs
+++ b/integration-tests/src/runtime_utils.rs
@@ -51,7 +51,7 @@ pub fn get_runtime_and_trie_from_genesis(genesis: &Genesis) -> (Runtime, ShardTr
     let genesis_root = GenesisStateApplier::apply(
         &writers,
         tries.clone(),
-        ShardUId::from_shard_id_and_layout(0, shard_layout),
+        ShardUId::from_shard_id_and_layout(0.into(), shard_layout),
         &genesis
             .config
             .validators

--- a/integration-tests/src/runtime_utils.rs
+++ b/integration-tests/src/runtime_utils.rs
@@ -7,8 +7,8 @@ use near_chain_configs::Genesis;
 use near_parameters::RuntimeConfig;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::state_record::{state_record_to_account_id, StateRecord};
-use near_primitives::types::AccountId;
 use near_primitives::types::StateRoot;
+use near_primitives::types::{new_shard_id_tmp, AccountId};
 use near_primitives_core::types::NumShards;
 use near_store::genesis::GenesisStateApplier;
 use near_store::test_utils::TestTriesBuilder;
@@ -51,7 +51,7 @@ pub fn get_runtime_and_trie_from_genesis(genesis: &Genesis) -> (Runtime, ShardTr
     let genesis_root = GenesisStateApplier::apply(
         &writers,
         tries.clone(),
-        ShardUId::from_shard_id_and_layout(0.into(), shard_layout),
+        ShardUId::from_shard_id_and_layout(new_shard_id_tmp(0), shard_layout),
         &genesis
             .config
             .validators

--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -269,7 +269,7 @@ impl TestLoopBuilder {
         if idx < validator_num {
             client_config.tracked_shards = Vec::new();
         } else {
-            client_config.tracked_shards = vec![666];
+            client_config.tracked_shards = vec![666.into()];
         }
 
         if let Some(config_modifier) = &self.config_modifier {

--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -28,7 +28,7 @@ use near_network::test_loop::{TestLoopNetworkSharedState, TestLoopPeerManagerAct
 use near_parameters::RuntimeConfigStore;
 use near_primitives::network::PeerId;
 use near_primitives::test_utils::create_test_signer;
-use near_primitives::types::AccountId;
+use near_primitives::types::{new_shard_id_tmp, AccountId};
 use near_store::adapter::StoreAdapter;
 use near_store::config::StateSnapshotType;
 use near_store::genesis::initialize_genesis_state;
@@ -269,7 +269,7 @@ impl TestLoopBuilder {
         if idx < validator_num {
             client_config.tracked_shards = Vec::new();
         } else {
-            client_config.tracked_shards = vec![666.into()];
+            client_config.tracked_shards = vec![new_shard_id_tmp(666)];
         }
 
         if let Some(config_modifier) = &self.config_modifier {

--- a/integration-tests/src/test_loop/tests/in_memory_tries.rs
+++ b/integration-tests/src/test_loop/tests/in_memory_tries.rs
@@ -74,7 +74,7 @@ fn test_load_memtrie_after_empty_chunks() {
         current_tracked_shards
             .iter()
             .enumerate()
-            .find_map(|(idx, shards)| if shards.contains(&0) { Some(idx) } else { None })
+            .find_map(|(idx, shards)| if shards.contains(&0.into()) { Some(idx) } else { None })
             .expect("Not found any client tracking shard 0")
     };
 
@@ -84,11 +84,11 @@ fn test_load_memtrie_after_empty_chunks() {
     clients[idx]
         .runtime_adapter
         .get_tries()
-        .unload_mem_trie(&ShardUId::from_shard_id_and_layout(0, &shard_layout));
+        .unload_mem_trie(&ShardUId::from_shard_id_and_layout(0.into(), &shard_layout));
     clients[idx]
         .runtime_adapter
         .get_tries()
-        .load_mem_trie(&ShardUId::from_shard_id_and_layout(0, &shard_layout), None, true)
+        .load_mem_trie(&ShardUId::from_shard_id_and_layout(0.into(), &shard_layout), None, true)
         .expect("Couldn't load memtrie");
 
     // Give the test a chance to finish off remaining events in the event loop, which can

--- a/integration-tests/src/test_loop/tests/in_memory_tries.rs
+++ b/integration-tests/src/test_loop/tests/in_memory_tries.rs
@@ -3,7 +3,7 @@ use near_async::time::Duration;
 use near_chain_configs::test_genesis::TestGenesisBuilder;
 use near_client::test_utils::test_loop::ClientQueries;
 use near_o11y::testonly::init_test_logger;
-use near_primitives::types::AccountId;
+use near_primitives::types::{new_shard_id_tmp, AccountId};
 use near_store::ShardUId;
 
 use crate::test_loop::builder::TestLoopBuilder;
@@ -74,7 +74,15 @@ fn test_load_memtrie_after_empty_chunks() {
         current_tracked_shards
             .iter()
             .enumerate()
-            .find_map(|(idx, shards)| if shards.contains(&0.into()) { Some(idx) } else { None })
+            .find_map(
+                |(idx, shards)| {
+                    if shards.contains(&new_shard_id_tmp(0)) {
+                        Some(idx)
+                    } else {
+                        None
+                    }
+                },
+            )
             .expect("Not found any client tracking shard 0")
     };
 
@@ -84,11 +92,15 @@ fn test_load_memtrie_after_empty_chunks() {
     clients[idx]
         .runtime_adapter
         .get_tries()
-        .unload_mem_trie(&ShardUId::from_shard_id_and_layout(0.into(), &shard_layout));
+        .unload_mem_trie(&ShardUId::from_shard_id_and_layout(new_shard_id_tmp(0), &shard_layout));
     clients[idx]
         .runtime_adapter
         .get_tries()
-        .load_mem_trie(&ShardUId::from_shard_id_and_layout(0.into(), &shard_layout), None, true)
+        .load_mem_trie(
+            &ShardUId::from_shard_id_and_layout(new_shard_id_tmp(0), &shard_layout),
+            None,
+            true,
+        )
         .expect("Couldn't load memtrie");
 
     // Give the test a chance to finish off remaining events in the event loop, which can

--- a/integration-tests/src/test_loop/tests/view_requests_to_archival_node.rs
+++ b/integration-tests/src/test_loop/tests/view_requests_to_archival_node.rs
@@ -222,10 +222,10 @@ impl<'a> ViewClientTester<'a> {
             chunk
         };
 
-        let chunk_by_height = GetChunk::Height(5, 0);
+        let chunk_by_height = GetChunk::Height(5, 0.into());
         get_and_check_chunk(chunk_by_height);
 
-        let chunk_by_block_hash = GetChunk::BlockHash(block.header.hash, 0);
+        let chunk_by_block_hash = GetChunk::BlockHash(block.header.hash, 0.into());
         get_and_check_chunk(chunk_by_block_hash);
 
         let chunk_by_chunk_hash = GetChunk::ChunkHash(ChunkHash(block.chunks[0].chunk_hash));
@@ -241,10 +241,10 @@ impl<'a> ViewClientTester<'a> {
             assert_eq!(shard_chunk.take_header().gas_limit(), 1_000_000_000_000_000);
         };
 
-        let chunk_by_height = GetShardChunk::Height(5, 0);
+        let chunk_by_height = GetShardChunk::Height(5, 0.into());
         get_and_check_shard_chunk(chunk_by_height);
 
-        let chunk_by_block_hash = GetShardChunk::BlockHash(block.header.hash, 0);
+        let chunk_by_block_hash = GetShardChunk::BlockHash(block.header.hash, 0.into());
         get_and_check_shard_chunk(chunk_by_block_hash);
 
         let chunk_by_chunk_hash = GetShardChunk::ChunkHash(ChunkHash(block.chunks[0].chunk_hash));
@@ -375,9 +375,9 @@ impl<'a> ViewClientTester<'a> {
         let request = GetExecutionOutcomesForBlock { block_hash: block.header.hash };
         let outcomes = self.send(request, ARCHIVAL_CLIENT).unwrap();
         assert_eq!(outcomes.len(), NUM_SHARDS);
-        assert_eq!(outcomes[&0].len(), 1);
+        assert_eq!(outcomes[&0.into()].len(), 1);
         assert!(matches!(
-            outcomes[&0][0],
+            outcomes[&0.into()][0],
             ExecutionOutcomeWithIdView {
                 outcome: ExecutionOutcomeView {
                     status: ExecutionStatusView::SuccessReceiptId(_),
@@ -386,9 +386,9 @@ impl<'a> ViewClientTester<'a> {
                 ..
             }
         ));
-        assert_eq!(outcomes[&1].len(), 1);
+        assert_eq!(outcomes[&1.into()].len(), 1);
         assert!(matches!(
-            outcomes[&1][0],
+            outcomes[&1.into()][0],
             ExecutionOutcomeWithIdView {
                 outcome: ExecutionOutcomeView {
                     status: ExecutionStatusView::SuccessReceiptId(_),
@@ -397,8 +397,8 @@ impl<'a> ViewClientTester<'a> {
                 ..
             }
         ));
-        assert_eq!(outcomes[&2].len(), 0);
-        assert_eq!(outcomes[&3].len(), 0);
+        assert_eq!(outcomes[&2.into()].len(), 0);
+        assert_eq!(outcomes[&3.into()].len(), 0);
     }
 
     /// Generates variations of the [`GetStateChanges`] request and issues them to the view client of the archival node.

--- a/integration-tests/src/test_loop/tests/view_requests_to_archival_node.rs
+++ b/integration-tests/src/test_loop/tests/view_requests_to_archival_node.rs
@@ -15,8 +15,8 @@ use near_network::client::BlockHeadersRequest;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::types::{
-    AccountId, BlockHeight, BlockId, BlockReference, EpochId, EpochReference, Finality,
-    SyncCheckpoint,
+    new_shard_id_tmp, AccountId, BlockHeight, BlockId, BlockReference, EpochId, EpochReference,
+    Finality, SyncCheckpoint,
 };
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{
@@ -222,10 +222,10 @@ impl<'a> ViewClientTester<'a> {
             chunk
         };
 
-        let chunk_by_height = GetChunk::Height(5, 0.into());
+        let chunk_by_height = GetChunk::Height(5, new_shard_id_tmp(0));
         get_and_check_chunk(chunk_by_height);
 
-        let chunk_by_block_hash = GetChunk::BlockHash(block.header.hash, 0.into());
+        let chunk_by_block_hash = GetChunk::BlockHash(block.header.hash, new_shard_id_tmp(0));
         get_and_check_chunk(chunk_by_block_hash);
 
         let chunk_by_chunk_hash = GetChunk::ChunkHash(ChunkHash(block.chunks[0].chunk_hash));
@@ -241,10 +241,10 @@ impl<'a> ViewClientTester<'a> {
             assert_eq!(shard_chunk.take_header().gas_limit(), 1_000_000_000_000_000);
         };
 
-        let chunk_by_height = GetShardChunk::Height(5, 0.into());
+        let chunk_by_height = GetShardChunk::Height(5, new_shard_id_tmp(0));
         get_and_check_shard_chunk(chunk_by_height);
 
-        let chunk_by_block_hash = GetShardChunk::BlockHash(block.header.hash, 0.into());
+        let chunk_by_block_hash = GetShardChunk::BlockHash(block.header.hash, new_shard_id_tmp(0));
         get_and_check_shard_chunk(chunk_by_block_hash);
 
         let chunk_by_chunk_hash = GetShardChunk::ChunkHash(ChunkHash(block.chunks[0].chunk_hash));
@@ -375,9 +375,9 @@ impl<'a> ViewClientTester<'a> {
         let request = GetExecutionOutcomesForBlock { block_hash: block.header.hash };
         let outcomes = self.send(request, ARCHIVAL_CLIENT).unwrap();
         assert_eq!(outcomes.len(), NUM_SHARDS);
-        assert_eq!(outcomes[&0.into()].len(), 1);
+        assert_eq!(outcomes[&new_shard_id_tmp(0)].len(), 1);
         assert!(matches!(
-            outcomes[&0.into()][0],
+            outcomes[&new_shard_id_tmp(0)][0],
             ExecutionOutcomeWithIdView {
                 outcome: ExecutionOutcomeView {
                     status: ExecutionStatusView::SuccessReceiptId(_),
@@ -386,9 +386,9 @@ impl<'a> ViewClientTester<'a> {
                 ..
             }
         ));
-        assert_eq!(outcomes[&1.into()].len(), 1);
+        assert_eq!(outcomes[&new_shard_id_tmp(1)].len(), 1);
         assert!(matches!(
-            outcomes[&1.into()][0],
+            outcomes[&new_shard_id_tmp(1)][0],
             ExecutionOutcomeWithIdView {
                 outcome: ExecutionOutcomeView {
                     status: ExecutionStatusView::SuccessReceiptId(_),
@@ -397,8 +397,8 @@ impl<'a> ViewClientTester<'a> {
                 ..
             }
         ));
-        assert_eq!(outcomes[&2.into()].len(), 0);
-        assert_eq!(outcomes[&3.into()].len(), 0);
+        assert_eq!(outcomes[&new_shard_id_tmp(2)].len(), 0);
+        assert_eq!(outcomes[&new_shard_id_tmp(3)].len(), 0);
     }
 
     /// Generates variations of the [`GetStateChanges`] request and issues them to the view client of the archival node.

--- a/integration-tests/src/tests/client/block_corruption.rs
+++ b/integration-tests/src/tests/client/block_corruption.rs
@@ -61,16 +61,17 @@ fn change_shard_id_to_invalid() {
     let mut block = env.clients[0].produce_block(2).unwrap().unwrap();
 
     // 1. Corrupt chunks
+    let bad_shard_id = 100.into();
     let mut new_chunks = vec![];
     for chunk in block.chunks().iter() {
         let mut new_chunk = chunk.clone();
         match &mut new_chunk {
-            ShardChunkHeader::V1(new_chunk) => new_chunk.inner.shard_id = 100,
-            ShardChunkHeader::V2(new_chunk) => new_chunk.inner.shard_id = 100,
+            ShardChunkHeader::V1(new_chunk) => new_chunk.inner.shard_id = bad_shard_id,
+            ShardChunkHeader::V2(new_chunk) => new_chunk.inner.shard_id = bad_shard_id,
             ShardChunkHeader::V3(new_chunk) => match &mut new_chunk.inner {
-                ShardChunkHeaderInner::V1(inner) => inner.shard_id = 100,
-                ShardChunkHeaderInner::V2(inner) => inner.shard_id = 100,
-                ShardChunkHeaderInner::V3(inner) => inner.shard_id = 100,
+                ShardChunkHeaderInner::V1(inner) => inner.shard_id = bad_shard_id,
+                ShardChunkHeaderInner::V2(inner) => inner.shard_id = bad_shard_id,
+                ShardChunkHeaderInner::V3(inner) => inner.shard_id = bad_shard_id,
             },
         };
         new_chunks.push(new_chunk);
@@ -88,7 +89,7 @@ fn change_shard_id_to_invalid() {
     // Try to process corrupt block and expect code to notice invalid shard_id
     let res = env.clients[0].process_block_test(block.into(), Provenance::NONE);
     match res {
-        Err(Error::InvalidShardId(100)) => {
+        Err(Error::InvalidShardId(bad_shard_id)) => {
             tracing::debug!("process failed successfully");
         }
         Err(e) => {

--- a/integration-tests/src/tests/client/block_corruption.rs
+++ b/integration-tests/src/tests/client/block_corruption.rs
@@ -61,7 +61,7 @@ fn change_shard_id_to_invalid() {
     let mut block = env.clients[0].produce_block(2).unwrap().unwrap();
 
     // 1. Corrupt chunks
-    let bad_shard_id = 100.into();
+    let bad_shard_id = 100;
     let mut new_chunks = vec![];
     for chunk in block.chunks().iter() {
         let mut new_chunk = chunk.clone();
@@ -89,7 +89,8 @@ fn change_shard_id_to_invalid() {
     // Try to process corrupt block and expect code to notice invalid shard_id
     let res = env.clients[0].process_block_test(block.into(), Provenance::NONE);
     match res {
-        Err(Error::InvalidShardId(bad_shard_id)) => {
+        Err(Error::InvalidShardId(shard_id)) => {
+            assert_eq!(shard_id, bad_shard_id);
             tracing::debug!("process failed successfully");
         }
         Err(e) => {

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -22,7 +22,7 @@ use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsementV1
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;
-use near_primitives::types::AccountId;
+use near_primitives::types::{AccountId, ShardId};
 use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_store::Trie;
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
@@ -200,7 +200,7 @@ fn test_verify_chunk_invalid_proofs_challenge() {
 
     let shard_id = chunk.shard_id();
     let challenge_result =
-        challenge(env, shard_id as usize, MaybeEncodedShardChunk::Encoded(chunk).into(), &block);
+        challenge(env, shard_id, MaybeEncodedShardChunk::Encoded(chunk).into(), &block);
     assert_eq!(challenge_result.unwrap(), (*block.hash(), vec!["test0".parse().unwrap()]));
 }
 
@@ -302,13 +302,13 @@ fn test_verify_chunk_proofs_challenge_transaction_order() {
 
     let shard_id = chunk.shard_id();
     let challenge_result =
-        challenge(env, shard_id as usize, MaybeEncodedShardChunk::Encoded(chunk).into(), &block);
+        challenge(env, shard_id, MaybeEncodedShardChunk::Encoded(chunk).into(), &block);
     assert_eq!(challenge_result.unwrap(), (*block.hash(), vec!["test0".parse().unwrap()]));
 }
 
 fn challenge(
     env: TestEnv,
-    shard_id: usize,
+    shard_id: ShardId,
     chunk: Box<MaybeEncodedShardChunk>,
     block: &Block,
 ) -> Result<(CryptoHash, Vec<AccountId>), Error> {

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -215,7 +215,7 @@ fn test_verify_chunk_invalid_proofs_challenge_decoded_chunk() {
 
     let shard_id = chunk.shard_id();
     let challenge_result =
-        challenge(env, shard_id as usize, MaybeEncodedShardChunk::Decoded(chunk).into(), &block);
+        challenge(env, shard_id, MaybeEncodedShardChunk::Decoded(chunk).into(), &block);
     assert_eq!(challenge_result.unwrap(), (*block.hash(), vec!["test0".parse().unwrap()]));
 }
 
@@ -228,7 +228,7 @@ fn test_verify_chunk_proofs_malicious_challenge_no_changes() {
 
     let shard_id = chunk.shard_id();
     let challenge_result =
-        challenge(env, shard_id as usize, MaybeEncodedShardChunk::Encoded(chunk).into(), &block);
+        challenge(env, shard_id, MaybeEncodedShardChunk::Encoded(chunk).into(), &block);
     assert_matches!(challenge_result.unwrap_err(), Error::MaliciousChallenge);
 }
 
@@ -265,7 +265,7 @@ fn test_verify_chunk_proofs_malicious_challenge_valid_order_transactions() {
 
     let shard_id = chunk.shard_id();
     let challenge_result =
-        challenge(env, shard_id as usize, MaybeEncodedShardChunk::Encoded(chunk).into(), &block);
+        challenge(env, shard_id, MaybeEncodedShardChunk::Encoded(chunk).into(), &block);
     assert_matches!(challenge_result.unwrap_err(), Error::MaliciousChallenge);
 }
 
@@ -317,7 +317,7 @@ fn challenge(
         ChallengeBody::ChunkProofs(ChunkProofs {
             block_header: borsh::to_vec(&block.header()).unwrap(),
             chunk,
-            merkle_proof: merkle_paths[shard_id].clone(),
+            merkle_proof: merkle_paths[shard_id as usize].clone(),
         }),
         &*env.clients[0].validator_signer.get().unwrap(),
     );

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -40,8 +40,8 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::{
-    AccountId, AccountInfo, Balance, BlockHeight, BlockHeightDelta, Gas, NumSeats, NumShards,
-    ShardId,
+    new_shard_id_tmp, AccountId, AccountInfo, Balance, BlockHeight, BlockHeightDelta, Gas,
+    NumSeats, NumShards, ShardId,
 };
 use near_primitives::utils::{from_timestamp, get_num_seats_per_shard};
 use near_primitives::validator_signer::{InMemoryValidatorSigner, ValidatorSigner};
@@ -845,7 +845,7 @@ pub fn init_configs(
     let mut config = Config::default();
     // Make sure node tracks all shards, see
     // https://github.com/near/nearcore/issues/7388
-    config.tracked_shards = vec![0.into()];
+    config.tracked_shards = vec![new_shard_id_tmp(0)];
     // If a config gets generated, block production times may need to be updated.
     set_block_production_delay(&chain_id, fast, &mut config);
 
@@ -1204,7 +1204,7 @@ fn create_localnet_config(
     // Make non-validator archival and RPC nodes track all shards.
     // Note that validator nodes may track all or some of the shards.
     config.tracked_shards = if !params.is_validator && (params.is_archival || params.is_rpc) {
-        (0..num_shards).map(Into::into).collect()
+        (0..num_shards).map(new_shard_id_tmp).collect()
     } else {
         tracked_shards.clone()
     };
@@ -1522,7 +1522,7 @@ mod tests {
     use near_chain_configs::{GCConfig, Genesis, GenesisValidationMode};
     use near_crypto::InMemorySigner;
     use near_primitives::shard_layout::account_id_to_shard_id;
-    use near_primitives::types::{AccountId, NumShards};
+    use near_primitives::types::{new_shard_id_tmp, AccountId, NumShards};
     use tempfile::tempdir;
 
     use crate::config::{
@@ -1562,21 +1562,21 @@ mod tests {
                 &AccountId::from_str("foobar.near").unwrap(),
                 &genesis.config.shard_layout,
             ),
-            0.into()
+            new_shard_id_tmp(0)
         );
         assert_eq!(
             account_id_to_shard_id(
                 &AccountId::from_str("shard1.test.near").unwrap(),
                 &genesis.config.shard_layout,
             ),
-            1.into()
+            new_shard_id_tmp(1)
         );
         assert_eq!(
             account_id_to_shard_id(
                 &AccountId::from_str("shard2.test.near").unwrap(),
                 &genesis.config.shard_layout,
             ),
-            2.into()
+            new_shard_id_tmp(2)
         );
     }
 
@@ -1746,7 +1746,10 @@ mod tests {
                 config.split_storage.clone().unwrap().enable_split_storage_view_client,
                 true
             );
-            assert_eq!(config.tracked_shards, (0..num_shards).map(Into::into).collect::<Vec<_>>());
+            assert_eq!(
+                config.tracked_shards,
+                (0..num_shards).map(new_shard_id_tmp).collect::<Vec<_>>()
+            );
         }
 
         // Check non-validator RPC nodes.
@@ -1755,7 +1758,10 @@ mod tests {
             assert_eq!(config.archive, false);
             assert!(config.cold_store.is_none());
             assert!(config.split_storage.is_none());
-            assert_eq!(config.tracked_shards, (0..num_shards).map(Into::into).collect::<Vec<_>>());
+            assert_eq!(
+                config.tracked_shards,
+                (0..num_shards).map(new_shard_id_tmp).collect::<Vec<_>>()
+            );
         }
 
         // Check other non-validator nodes.
@@ -1781,7 +1787,7 @@ mod tests {
         let prefix = "node";
 
         // Validators will track 2 shards and non-validators will track all shards.
-        let tracked_shards = vec![1.into(), 3.into()];
+        let tracked_shards = vec![new_shard_id_tmp(1), new_shard_id_tmp(3)];
 
         let (configs, _validator_signers, _network_signers, genesis, _shard_keys) =
             create_localnet_configs(
@@ -1823,7 +1829,10 @@ mod tests {
                 config.split_storage.clone().unwrap().enable_split_storage_view_client,
                 true
             );
-            assert_eq!(config.tracked_shards, (0..num_shards).map(Into::into).collect::<Vec<_>>());
+            assert_eq!(
+                config.tracked_shards,
+                (0..num_shards).map(new_shard_id_tmp).collect::<Vec<_>>()
+            );
         }
 
         // Check non-validator RPC nodes.
@@ -1832,7 +1841,10 @@ mod tests {
             assert_eq!(config.archive, false);
             assert!(config.cold_store.is_none());
             assert!(config.split_storage.is_none());
-            assert_eq!(config.tracked_shards, (0..num_shards).map(Into::into).collect::<Vec<_>>());
+            assert_eq!(
+                config.tracked_shards,
+                (0..num_shards).map(new_shard_id_tmp).collect::<Vec<_>>()
+            );
         }
 
         // Check other non-validator nodes.

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -845,7 +845,7 @@ pub fn init_configs(
     let mut config = Config::default();
     // Make sure node tracks all shards, see
     // https://github.com/near/nearcore/issues/7388
-    config.tracked_shards = vec![0];
+    config.tracked_shards = vec![0.into()];
     // If a config gets generated, block production times may need to be updated.
     set_block_production_delay(&chain_id, fast, &mut config);
 
@@ -1073,7 +1073,7 @@ pub fn create_localnet_configs_from_seeds(
     num_non_validators_archival: NumSeats,
     num_non_validators_rpc: NumSeats,
     num_non_validators: NumSeats,
-    tracked_shards: Vec<u64>,
+    tracked_shards: Vec<ShardId>,
 ) -> (Vec<Config>, Vec<ValidatorSigner>, Vec<InMemorySigner>, Genesis) {
     assert_eq!(
         seeds.len() as u64,
@@ -1163,7 +1163,7 @@ pub fn create_localnet_configs_from_seeds(
 fn create_localnet_config(
     num_shards: NumShards,
     num_validators: NumSeats,
-    tracked_shards: &Vec<u64>,
+    tracked_shards: &Vec<ShardId>,
     network_signers: &Vec<InMemorySigner>,
     boot_node_addr: &tcp::ListenerAddr,
     params: LocalnetNodeParams,
@@ -1204,7 +1204,7 @@ fn create_localnet_config(
     // Make non-validator archival and RPC nodes track all shards.
     // Note that validator nodes may track all or some of the shards.
     config.tracked_shards = if !params.is_validator && (params.is_archival || params.is_rpc) {
-        (0..num_shards).collect()
+        (0..num_shards).map(Into::into).collect()
     } else {
         tracked_shards.clone()
     };
@@ -1232,7 +1232,7 @@ pub fn create_localnet_configs(
     num_non_validators_rpc: NumSeats,
     num_non_validators: NumSeats,
     prefix: &str,
-    tracked_shards: Vec<u64>,
+    tracked_shards: Vec<ShardId>,
 ) -> (Vec<Config>, Vec<ValidatorSigner>, Vec<InMemorySigner>, Genesis, Vec<InMemorySigner>) {
     let num_all_nodes =
         num_validators + num_non_validators_archival + num_non_validators_rpc + num_non_validators;
@@ -1272,7 +1272,7 @@ pub fn init_localnet_configs(
     num_non_validators_rpc: NumSeats,
     num_non_validators: NumSeats,
     prefix: &str,
-    tracked_shards: Vec<u64>,
+    tracked_shards: Vec<ShardId>,
 ) {
     let (configs, validator_signers, network_signers, genesis, shard_keys) =
         create_localnet_configs(
@@ -1562,21 +1562,21 @@ mod tests {
                 &AccountId::from_str("foobar.near").unwrap(),
                 &genesis.config.shard_layout,
             ),
-            0
+            0.into()
         );
         assert_eq!(
             account_id_to_shard_id(
                 &AccountId::from_str("shard1.test.near").unwrap(),
                 &genesis.config.shard_layout,
             ),
-            1
+            1.into()
         );
         assert_eq!(
             account_id_to_shard_id(
                 &AccountId::from_str("shard2.test.near").unwrap(),
                 &genesis.config.shard_layout,
             ),
-            2
+            2.into()
         );
     }
 
@@ -1704,7 +1704,7 @@ mod tests {
         let prefix = "node";
 
         // Validators will track single shard but archival and RPC nodes will track all shards.
-        let empty_tracked_shards: Vec<u64> = vec![];
+        let empty_tracked_shards = vec![];
 
         let (configs, _validator_signers, _network_signers, genesis, _shard_keys) =
             create_localnet_configs(
@@ -1746,7 +1746,7 @@ mod tests {
                 config.split_storage.clone().unwrap().enable_split_storage_view_client,
                 true
             );
-            assert_eq!(config.tracked_shards, (0..num_shards).collect::<Vec<_>>());
+            assert_eq!(config.tracked_shards, (0..num_shards).map(Into::into).collect::<Vec<_>>());
         }
 
         // Check non-validator RPC nodes.
@@ -1755,7 +1755,7 @@ mod tests {
             assert_eq!(config.archive, false);
             assert!(config.cold_store.is_none());
             assert!(config.split_storage.is_none());
-            assert_eq!(config.tracked_shards, (0..num_shards).collect::<Vec<_>>());
+            assert_eq!(config.tracked_shards, (0..num_shards).map(Into::into).collect::<Vec<_>>());
         }
 
         // Check other non-validator nodes.
@@ -1781,7 +1781,7 @@ mod tests {
         let prefix = "node";
 
         // Validators will track 2 shards and non-validators will track all shards.
-        let tracked_shards: Vec<u64> = vec![1, 3];
+        let tracked_shards = vec![1.into(), 3.into()];
 
         let (configs, _validator_signers, _network_signers, genesis, _shard_keys) =
             create_localnet_configs(
@@ -1823,7 +1823,7 @@ mod tests {
                 config.split_storage.clone().unwrap().enable_split_storage_view_client,
                 true
             );
-            assert_eq!(config.tracked_shards, (0..num_shards).collect::<Vec<_>>());
+            assert_eq!(config.tracked_shards, (0..num_shards).map(Into::into).collect::<Vec<_>>());
         }
 
         // Check non-validator RPC nodes.
@@ -1832,7 +1832,7 @@ mod tests {
             assert_eq!(config.archive, false);
             assert!(config.cold_store.is_none());
             assert!(config.split_storage.is_none());
-            assert_eq!(config.tracked_shards, (0..num_shards).collect::<Vec<_>>());
+            assert_eq!(config.tracked_shards, (0..num_shards).map(Into::into).collect::<Vec<_>>());
         }
 
         // Check other non-validator nodes.

--- a/nearcore/src/config_validate.rs
+++ b/nearcore/src/config_validate.rs
@@ -179,7 +179,7 @@ mod tests {
         let mut config = Config::default();
         config.gc.gc_blocks_limit = 0;
         // set tracked_shards to be non-empty
-        config.tracked_shards.push(20);
+        config.tracked_shards.push(20.into());
         validate_config(&config).unwrap();
     }
 
@@ -192,7 +192,7 @@ mod tests {
         config.archive = false;
         config.save_trie_changes = Some(false);
         // set tracked_shards to be non-empty
-        config.tracked_shards.push(20);
+        config.tracked_shards.push(20.into());
         validate_config(&config).unwrap();
     }
 
@@ -206,7 +206,7 @@ mod tests {
         config.save_trie_changes = Some(false);
         config.gc.gc_blocks_limit = 0;
         // set tracked_shards to be non-empty
-        config.tracked_shards.push(20);
+        config.tracked_shards.push(20.into());
         validate_config(&config).unwrap();
     }
 

--- a/nearcore/src/config_validate.rs
+++ b/nearcore/src/config_validate.rs
@@ -171,6 +171,8 @@ impl<'a> ConfigValidator<'a> {
 
 #[cfg(test)]
 mod tests {
+    use near_primitives::types::new_shard_id_tmp;
+
     use super::*;
 
     #[test]
@@ -179,7 +181,7 @@ mod tests {
         let mut config = Config::default();
         config.gc.gc_blocks_limit = 0;
         // set tracked_shards to be non-empty
-        config.tracked_shards.push(20.into());
+        config.tracked_shards.push(new_shard_id_tmp(20));
         validate_config(&config).unwrap();
     }
 
@@ -192,7 +194,7 @@ mod tests {
         config.archive = false;
         config.save_trie_changes = Some(false);
         // set tracked_shards to be non-empty
-        config.tracked_shards.push(20.into());
+        config.tracked_shards.push(new_shard_id_tmp(20));
         validate_config(&config).unwrap();
     }
 
@@ -206,7 +208,7 @@ mod tests {
         config.save_trie_changes = Some(false);
         config.gc.gc_blocks_limit = 0;
         // set tracked_shards to be non-empty
-        config.tracked_shards.push(20.into());
+        config.tracked_shards.push(new_shard_id_tmp(20));
         validate_config(&config).unwrap();
     }
 

--- a/nearcore/src/entity_debug.rs
+++ b/nearcore/src/entity_debug.rs
@@ -261,9 +261,11 @@ impl EntityDebugHandlerImpl {
                 let shard_layout = self
                     .epoch_manager
                     .get_shard_layout_from_prev_block(&chunk.cloned_header().prev_block_hash())?;
+                let shard_id = chunk.shard_id();
+                let shard_index = shard_layout.get_shard_index(shard_id);
                 let shard_uid = shard_layout
                     .shard_uids()
-                    .nth(chunk.shard_id() as usize)
+                    .nth(shard_index)
                     .ok_or_else(|| anyhow!("Shard {} not found", chunk.shard_id()))?;
                 let node = store
                     .get_ser::<RawTrieNodeWithSize>(
@@ -299,9 +301,11 @@ impl EntityDebugHandlerImpl {
             }
             EntityQuery::ShardUIdByShardId { shard_id, epoch_id } => {
                 let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
+                let shard_index = shard_layout.get_shard_index(shard_id);
+
                 let shard_uid = shard_layout
                     .shard_uids()
-                    .nth(shard_id as usize)
+                    .nth(shard_index)
                     .ok_or_else(|| anyhow!("Shard {} not found", shard_id))?;
                 Ok(serialize_entity(&shard_uid))
             }
@@ -380,9 +384,11 @@ impl EntityDebugHandlerImpl {
                 let shard_layout = self
                     .epoch_manager
                     .get_shard_layout_from_prev_block(&chunk.cloned_header().prev_block_hash())?;
+                let shard_id = chunk.shard_id();
+                let shard_index = shard_layout.get_shard_index(shard_id);
                 let shard_uid = shard_layout
                     .shard_uids()
-                    .nth(chunk.shard_id() as usize)
+                    .nth(shard_index)
                     .ok_or_else(|| anyhow!("Shard {} not found", chunk.shard_id()))?;
                 let path =
                     TriePath { path: vec![], shard_uid, state_root: chunk.prev_state_root() };

--- a/nearcore/src/metrics.rs
+++ b/nearcore/src/metrics.rs
@@ -8,6 +8,7 @@ use near_o11y::metrics::{
     try_create_int_gauge, try_create_int_gauge_vec, HistogramVec, IntCounterVec, IntGauge,
     IntGaugeVec,
 };
+use near_primitives::types::ShardId;
 use near_primitives::{shard_layout::ShardLayout, state_record::StateRecord, trie_key};
 use near_store::adapter::StoreAdapter;
 use near_store::{ShardUId, Store, Trie, TrieDBStorage};
@@ -148,7 +149,7 @@ fn export_postponed_receipt_count(near_config: &NearConfig, store: &Store) -> an
 }
 
 fn get_postponed_receipt_count_for_shard(
-    shard_id: u64,
+    shard_id: ShardId,
     shard_layout: &ShardLayout,
     chain_store: &ChainStore,
     block: &Block,

--- a/runtime/runtime/src/balance_checker.rs
+++ b/runtime/runtime/src/balance_checker.rs
@@ -400,7 +400,7 @@ mod tests {
     };
     use near_primitives::test_utils::account_new;
     use near_primitives::transaction::{Action, TransferAction};
-    use near_primitives::types::{MerkleHash, StateChangeCause};
+    use near_primitives::types::{new_shard_id_tmp, MerkleHash, StateChangeCause};
     use near_store::test_utils::TestTriesBuilder;
     use near_store::{set, set_account, Trie};
     use testlib::runtime_utils::{alice_account, bob_account};
@@ -706,14 +706,15 @@ mod tests {
 
                 // create buffer with already a receipt in it, but a different balance
                 let mut indices = BufferedReceiptIndices::default();
-                indices
-                    .shard_buffers
-                    .insert(0.into(), TrieQueueIndices { first_index: 0, next_available_index: 1 });
+                indices.shard_buffers.insert(
+                    new_shard_id_tmp(0),
+                    TrieQueueIndices { first_index: 0, next_available_index: 1 },
+                );
 
                 set(trie_update, TrieKey::BufferedReceiptIndices, &indices);
                 set(
                     trie_update,
-                    TrieKey::BufferedReceipt { receiving_shard: 0.into(), index: 0 },
+                    TrieKey::BufferedReceipt { receiving_shard: new_shard_id_tmp(0), index: 0 },
                     &existing_receipt,
                 );
             },
@@ -727,14 +728,15 @@ mod tests {
 
                 // store receipt with the balance in the receipt buffer
                 let mut indices = BufferedReceiptIndices::default();
-                indices
-                    .shard_buffers
-                    .insert(0.into(), TrieQueueIndices { first_index: 0, next_available_index: 2 });
+                indices.shard_buffers.insert(
+                    new_shard_id_tmp(0),
+                    TrieQueueIndices { first_index: 0, next_available_index: 2 },
+                );
 
                 set(trie_update, TrieKey::BufferedReceiptIndices, &indices);
                 set(
                     trie_update,
-                    TrieKey::BufferedReceipt { receiving_shard: 0.into(), index: 1 },
+                    TrieKey::BufferedReceipt { receiving_shard: new_shard_id_tmp(0), index: 1 },
                     &new_receipt,
                 );
             },
@@ -776,32 +778,36 @@ mod tests {
             |trie_update| {
                 // store 2 receipts with balance in the receipt buffer
                 let mut indices = BufferedReceiptIndices::default();
-                indices
-                    .shard_buffers
-                    .insert(0.into(), TrieQueueIndices { first_index: 0, next_available_index: 2 });
+                indices.shard_buffers.insert(
+                    new_shard_id_tmp(0),
+                    TrieQueueIndices { first_index: 0, next_available_index: 2 },
+                );
 
                 set(trie_update, TrieKey::BufferedReceiptIndices, &indices);
                 set(
                     trie_update,
-                    TrieKey::BufferedReceipt { receiving_shard: 0.into(), index: 0 },
+                    TrieKey::BufferedReceipt { receiving_shard: new_shard_id_tmp(0), index: 0 },
                     &receipt0,
                 );
                 set(
                     trie_update,
-                    TrieKey::BufferedReceipt { receiving_shard: 0.into(), index: 1 },
+                    TrieKey::BufferedReceipt { receiving_shard: new_shard_id_tmp(0), index: 1 },
                     &receipt1,
                 );
             },
             |trie_update| {
                 // remove 1 receipt at index 0
                 let mut indices = BufferedReceiptIndices::default();
-                indices
-                    .shard_buffers
-                    .insert(0.into(), TrieQueueIndices { first_index: 1, next_available_index: 2 });
+                indices.shard_buffers.insert(
+                    new_shard_id_tmp(0),
+                    TrieQueueIndices { first_index: 1, next_available_index: 2 },
+                );
 
                 set(trie_update, TrieKey::BufferedReceiptIndices, &indices);
-                trie_update
-                    .remove(TrieKey::BufferedReceipt { receiving_shard: 0.into(), index: 0 });
+                trie_update.remove(TrieKey::BufferedReceipt {
+                    receiving_shard: new_shard_id_tmp(0),
+                    index: 0,
+                });
             },
         );
 
@@ -835,32 +841,36 @@ mod tests {
             |trie_update| {
                 // store receipt0 with balance in the receipt buffer
                 let mut indices = BufferedReceiptIndices::default();
-                indices
-                    .shard_buffers
-                    .insert(0.into(), TrieQueueIndices { first_index: 0, next_available_index: 1 });
+                indices.shard_buffers.insert(
+                    new_shard_id_tmp(0),
+                    TrieQueueIndices { first_index: 0, next_available_index: 1 },
+                );
 
                 set(trie_update, TrieKey::BufferedReceiptIndices, &indices);
                 set(
                     trie_update,
-                    TrieKey::BufferedReceipt { receiving_shard: 0.into(), index: 0 },
+                    TrieKey::BufferedReceipt { receiving_shard: new_shard_id_tmp(0), index: 0 },
                     &receipt0,
                 );
             },
             |trie_update| {
                 // pop receipt0 and push receipt1 with a different balance
                 let mut indices = BufferedReceiptIndices::default();
-                indices
-                    .shard_buffers
-                    .insert(0.into(), TrieQueueIndices { first_index: 1, next_available_index: 2 });
+                indices.shard_buffers.insert(
+                    new_shard_id_tmp(0),
+                    TrieQueueIndices { first_index: 1, next_available_index: 2 },
+                );
 
                 set(
                     trie_update,
-                    TrieKey::BufferedReceipt { receiving_shard: 0.into(), index: 1 },
+                    TrieKey::BufferedReceipt { receiving_shard: new_shard_id_tmp(0), index: 1 },
                     &receipt1,
                 );
                 set(trie_update, TrieKey::BufferedReceiptIndices, &indices);
-                trie_update
-                    .remove(TrieKey::BufferedReceipt { receiving_shard: 0.into(), index: 0 });
+                trie_update.remove(TrieKey::BufferedReceipt {
+                    receiving_shard: new_shard_id_tmp(0),
+                    index: 0,
+                });
             },
         );
 

--- a/runtime/runtime/src/balance_checker.rs
+++ b/runtime/runtime/src/balance_checker.rs
@@ -708,12 +708,12 @@ mod tests {
                 let mut indices = BufferedReceiptIndices::default();
                 indices
                     .shard_buffers
-                    .insert(0, TrieQueueIndices { first_index: 0, next_available_index: 1 });
+                    .insert(0.into(), TrieQueueIndices { first_index: 0, next_available_index: 1 });
 
                 set(trie_update, TrieKey::BufferedReceiptIndices, &indices);
                 set(
                     trie_update,
-                    TrieKey::BufferedReceipt { receiving_shard: 0, index: 0 },
+                    TrieKey::BufferedReceipt { receiving_shard: 0.into(), index: 0 },
                     &existing_receipt,
                 );
             },
@@ -729,12 +729,12 @@ mod tests {
                 let mut indices = BufferedReceiptIndices::default();
                 indices
                     .shard_buffers
-                    .insert(0, TrieQueueIndices { first_index: 0, next_available_index: 2 });
+                    .insert(0.into(), TrieQueueIndices { first_index: 0, next_available_index: 2 });
 
                 set(trie_update, TrieKey::BufferedReceiptIndices, &indices);
                 set(
                     trie_update,
-                    TrieKey::BufferedReceipt { receiving_shard: 0, index: 1 },
+                    TrieKey::BufferedReceipt { receiving_shard: 0.into(), index: 1 },
                     &new_receipt,
                 );
             },
@@ -778,17 +778,17 @@ mod tests {
                 let mut indices = BufferedReceiptIndices::default();
                 indices
                     .shard_buffers
-                    .insert(0, TrieQueueIndices { first_index: 0, next_available_index: 2 });
+                    .insert(0.into(), TrieQueueIndices { first_index: 0, next_available_index: 2 });
 
                 set(trie_update, TrieKey::BufferedReceiptIndices, &indices);
                 set(
                     trie_update,
-                    TrieKey::BufferedReceipt { receiving_shard: 0, index: 0 },
+                    TrieKey::BufferedReceipt { receiving_shard: 0.into(), index: 0 },
                     &receipt0,
                 );
                 set(
                     trie_update,
-                    TrieKey::BufferedReceipt { receiving_shard: 0, index: 1 },
+                    TrieKey::BufferedReceipt { receiving_shard: 0.into(), index: 1 },
                     &receipt1,
                 );
             },
@@ -797,10 +797,11 @@ mod tests {
                 let mut indices = BufferedReceiptIndices::default();
                 indices
                     .shard_buffers
-                    .insert(0, TrieQueueIndices { first_index: 1, next_available_index: 2 });
+                    .insert(0.into(), TrieQueueIndices { first_index: 1, next_available_index: 2 });
 
                 set(trie_update, TrieKey::BufferedReceiptIndices, &indices);
-                trie_update.remove(TrieKey::BufferedReceipt { receiving_shard: 0, index: 0 });
+                trie_update
+                    .remove(TrieKey::BufferedReceipt { receiving_shard: 0.into(), index: 0 });
             },
         );
 
@@ -836,12 +837,12 @@ mod tests {
                 let mut indices = BufferedReceiptIndices::default();
                 indices
                     .shard_buffers
-                    .insert(0, TrieQueueIndices { first_index: 0, next_available_index: 1 });
+                    .insert(0.into(), TrieQueueIndices { first_index: 0, next_available_index: 1 });
 
                 set(trie_update, TrieKey::BufferedReceiptIndices, &indices);
                 set(
                     trie_update,
-                    TrieKey::BufferedReceipt { receiving_shard: 0, index: 0 },
+                    TrieKey::BufferedReceipt { receiving_shard: 0.into(), index: 0 },
                     &receipt0,
                 );
             },
@@ -850,15 +851,16 @@ mod tests {
                 let mut indices = BufferedReceiptIndices::default();
                 indices
                     .shard_buffers
-                    .insert(0, TrieQueueIndices { first_index: 1, next_available_index: 2 });
+                    .insert(0.into(), TrieQueueIndices { first_index: 1, next_available_index: 2 });
 
                 set(
                     trie_update,
-                    TrieKey::BufferedReceipt { receiving_shard: 0, index: 1 },
+                    TrieKey::BufferedReceipt { receiving_shard: 0.into(), index: 1 },
                     &receipt1,
                 );
                 set(trie_update, TrieKey::BufferedReceiptIndices, &indices);
-                trie_update.remove(TrieKey::BufferedReceipt { receiving_shard: 0, index: 0 });
+                trie_update
+                    .remove(TrieKey::BufferedReceipt { receiving_shard: 0.into(), index: 0 });
             },
         );
 

--- a/runtime/runtime/src/balance_checker.rs
+++ b/runtime/runtime/src/balance_checker.rs
@@ -12,7 +12,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{Receipt, ReceiptEnum, ReceiptOrStateStoredReceipt};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::trie_key::TrieKey;
-use near_primitives::types::{AccountId, Balance};
+use near_primitives::types::{AccountId, Balance, ShardId};
 use near_store::trie::receipts_column_helper::{ShardsOutgoingReceiptBuffer, TrieQueue};
 use near_store::{
     get, get_account, get_postponed_receipt, get_promise_yield_receipt, Trie, TrieAccess,
@@ -141,7 +141,7 @@ fn buffered_receipts(
     let mut forwarded_receipts: Vec<Receipt> = vec![];
     let mut new_buffered_receipts: Vec<Receipt> = vec![];
 
-    let mut shards: BTreeSet<u64> = BTreeSet::new();
+    let mut shards: BTreeSet<ShardId> = BTreeSet::new();
     shards.extend(initial_buffers.shards().iter());
     shards.extend(final_buffers.shards().iter());
     for shard_id in shards {

--- a/runtime/runtime/src/congestion_control.rs
+++ b/runtime/runtime/src/congestion_control.rs
@@ -9,7 +9,7 @@ use near_primitives::receipt::{
     Receipt, ReceiptEnum, ReceiptOrStateStoredReceipt, StateStoredReceipt,
     StateStoredReceiptMetadata,
 };
-use near_primitives::types::{EpochInfoProvider, Gas, ShardId};
+use near_primitives::types::{new_shard_id_tmp, EpochInfoProvider, Gas, ShardId};
 use near_primitives::version::ProtocolFeature;
 use near_store::trie::receipts_column_helper::{
     DelayedReceiptQueue, ReceiptIterator, ShardsOutgoingReceiptBuffer, TrieQueue,
@@ -460,7 +460,7 @@ pub fn bootstrap_congestion_info(
         // It is also irrelevant, since the bootstrapped value is only used at
         // the start of applying a chunk on this shard. Other shards will only
         // see and act on the first congestion info after that.
-        allowed_shard: shard_id.into(),
+        allowed_shard: new_shard_id_tmp(shard_id) as u16,
     }))
 }
 

--- a/runtime/runtime/src/congestion_control.rs
+++ b/runtime/runtime/src/congestion_control.rs
@@ -193,7 +193,7 @@ impl ReceiptSinkV2<'_> {
 
     fn forward_from_buffer_to_shard(
         &mut self,
-        shard_id: u64,
+        shard_id: ShardId,
         state_update: &mut TrieUpdate,
         apply_state: &ApplyState,
     ) -> Result<(), RuntimeError> {
@@ -317,7 +317,7 @@ impl ReceiptSinkV2<'_> {
         size: u64,
         gas: u64,
         state_update: &mut TrieUpdate,
-        shard: u64,
+        shard: ShardId,
         use_state_stored_receipt: bool,
     ) -> Result<(), RuntimeError> {
         let receipt = match use_state_stored_receipt {
@@ -460,7 +460,7 @@ pub fn bootstrap_congestion_info(
         // It is also irrelevant, since the bootstrapped value is only used at
         // the start of applying a chunk on this shard. Other shards will only
         // see and act on the first congestion info after that.
-        allowed_shard: shard_id as u16,
+        allowed_shard: shard_id.into(),
     }))
 }
 

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -39,6 +39,7 @@ use near_primitives::transaction::{
     SignedTransaction, TransferAction,
 };
 use near_primitives::trie_key::TrieKey;
+use near_primitives::types::new_shard_id_tmp;
 use near_primitives::types::{
     validator_stake::ValidatorStake, AccountId, Balance, BlockHeight, Compute, EpochHeight,
     EpochId, EpochInfoProvider, Gas, RawStateChangesWithTrieKey, ShardId, StateChangeCause,
@@ -1351,7 +1352,7 @@ impl Runtime {
         {
             // Note that receipts are restored only on mainnet so restored_receipts will be empty on
             // other chains.
-            migration_data.restored_receipts.get(&0.into()).cloned().unwrap_or_default()
+            migration_data.restored_receipts.get(&new_shard_id_tmp(0)).cloned().unwrap_or_default()
         } else {
             vec![]
         };

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1351,7 +1351,7 @@ impl Runtime {
         {
             // Note that receipts are restored only on mainnet so restored_receipts will be empty on
             // other chains.
-            migration_data.restored_receipts.get(&0u64).cloned().unwrap_or_default()
+            migration_data.restored_receipts.get(&0.into()).cloned().unwrap_or_default()
         } else {
             vec![]
         };
@@ -2020,7 +2020,10 @@ impl Runtime {
             delayed_receipts.apply_congestion_changes(congestion_info)?;
             let all_shards = apply_state.congestion_info.all_shards();
 
-            let congestion_seed = apply_state.block_height.wrapping_add(apply_state.shard_id);
+            // TODO(wacban) Using non-contiguous shard id here breaks some
+            // assumptions. The shard index should be used here instead.
+            let congestion_seed =
+                apply_state.block_height.wrapping_add(apply_state.shard_id.into());
             congestion_info.finalize_allowed_shard(
                 apply_state.shard_id,
                 all_shards.as_slice(),

--- a/runtime/runtime/src/metrics.rs
+++ b/runtime/runtime/src/metrics.rs
@@ -800,7 +800,7 @@ pub fn report_recorded_column_sizes(trie: &Trie, apply_state: &ApplyState) {
     // Tracing span to measure time spent on reporting column sizes.
     let _span = tracing::debug_span!(
             target: "runtime", "report_recorded_column_sizes",
-            shard_id = apply_state.shard_id,
+            shard_id = ?apply_state.shard_id,
             block_height = apply_state.block_height)
     .entered();
 

--- a/tools/state-viewer/src/epoch_info.rs
+++ b/tools/state-viewer/src/epoch_info.rs
@@ -90,13 +90,16 @@ fn display_block_and_chunk_producers(
     let block_height_range: Range<BlockHeight> =
         get_block_height_range(epoch_id, chain_store, epoch_manager)?;
     let shard_ids = epoch_manager.shard_ids(epoch_id).unwrap();
+    let shard_layout = epoch_manager.get_shard_layout(epoch_id).unwrap();
     for block_height in block_height_range {
         let bp = epoch_info.sample_block_producer(block_height);
         let bp = epoch_info.get_validator(bp).account_id().clone();
         let cps: Vec<String> = shard_ids
             .iter()
             .map(|&shard_id| {
-                let cp = epoch_info.sample_chunk_producer(block_height, shard_id).unwrap();
+                let cp = epoch_info
+                    .sample_chunk_producer(&shard_layout, shard_id, block_height)
+                    .unwrap();
                 let cp = epoch_info.get_validator(cp).account_id().clone();
                 cp.as_str().to_string()
             })
@@ -274,13 +277,14 @@ fn display_validator_info(
         println!("Block producer for {} blocks: {bp_for_blocks:?}", bp_for_blocks.len());
 
         let shard_ids = epoch_manager.shard_ids(epoch_id).unwrap();
+        let shard_layout = epoch_manager.get_shard_layout(epoch_id).unwrap();
         let cp_for_chunks: Vec<(BlockHeight, ShardId)> = block_height_range
             .flat_map(|block_height| {
                 shard_ids
                     .iter()
                     .map(|&shard_id| (block_height, shard_id))
                     .filter(|&(block_height, shard_id)| {
-                        epoch_info.sample_chunk_producer(block_height, shard_id)
+                        epoch_info.sample_chunk_producer(&shard_layout, shard_id, block_height)
                             == Some(*validator_id)
                     })
                     .collect::<Vec<(BlockHeight, ShardId)>>()

--- a/tools/state-viewer/src/replay_headers.rs
+++ b/tools/state-viewer/src/replay_headers.rs
@@ -237,12 +237,12 @@ fn get_block_info(
             let height = header.height();
             let prev_block_epoch_id =
                 epoch_manager.get_epoch_id_from_prev_block(header.prev_hash())?;
-            for chunk_header in chunks.iter() {
+            for (shard_index, chunk_header) in chunks.iter().enumerate() {
                 let shard_id = chunk_header.shard_id();
                 let endorsements = &endorsement_signatures[shard_id as usize];
                 if !chunk_header.is_new_chunk(height) {
                     assert_eq!(endorsements.len(), 0);
-                    bitmap.add_endorsements(shard_id, vec![]);
+                    bitmap.add_endorsements(shard_index, vec![]);
                 } else {
                     let assignments = epoch_manager
                         .get_chunk_validator_assignments(
@@ -253,7 +253,7 @@ fn get_block_info(
                         .ordered_chunk_validators();
                     assert_eq!(endorsements.len(), assignments.len());
                     bitmap.add_endorsements(
-                        shard_id,
+                        shard_index,
                         endorsements.iter().map(|signature| signature.is_some()).collect_vec(),
                     );
                 }

--- a/tools/state-viewer/src/replay_headers.rs
+++ b/tools/state-viewer/src/replay_headers.rs
@@ -228,6 +228,8 @@ fn get_block_info(
         {
             let block = chain_store.get_block(header.hash())?;
             let chunks = block.chunks();
+            let epoch_id = block.header().epoch_id();
+            let shard_layout = epoch_manager.get_shard_layout(epoch_id)?;
 
             let endorsement_signatures = block.chunk_endorsements().to_vec();
             assert_eq!(endorsement_signatures.len(), chunks.len());
@@ -238,7 +240,7 @@ fn get_block_info(
             let prev_block_epoch_id =
                 epoch_manager.get_epoch_id_from_prev_block(header.prev_hash())?;
             for (shard_index, chunk_header) in chunks.iter().enumerate() {
-                let shard_id = chunk_header.shard_id();
+                let shard_id = shard_layout.get_shard_id(shard_index);
                 let endorsements = &endorsement_signatures[shard_id as usize];
                 if !chunk_header.is_new_chunk(height) {
                     assert_eq!(endorsements.len(), 0);


### PR DESCRIPTION
This is part 1 of adding support for non-contiguous shard ids. The principle idea is to make ShardId into a newtype so that it's not possible to use it to index arrays with chunk data. In addition I'm adding ShardIndex type and a mapping between shard indices and shard ids so that it's possible to covert one to another as necessary. 

The TLDR of this approach is to make the types right, fix compiler errors and pray to the software gods that things work out. 

I am now giving up on trying to make the migration in a single PR. Instead I am introducing some temporary structures and methods that are compatible with both approaches. My current plan for the migration is as follows:
1) Switch to the new ShardId definition. 
2) Fix some number of compilation errors (using the temporary objects) 
3) Switch back to the old definition 
4) PR, review, merge
5) Repeat 1-4 until there are no more errors. 
6) Cleanup the temporary objects
7) Adjust some tests to use the new ShardLayout with non-contiguous shard ids. 
8) Try to get rid of the mapping wherever possible


There are a few common themes in this PR:
* read the shard layout and convert shard id to shard index in order to use it to index some array or chunk data
* replace enumerate with reading the shard id directly from the chunk header / other chunk data
* replace using shard id by adding enumerate to get the shard index
* add `?` to shard id in tracing logs because the newtype ShardId doesn't work without it

must-review files:
* shard_layout.rs
* primitives-core/src/types.rs
* shard_assignment.rs

good-to-review files:
* state_transition_data.rs
