### PR TITLE
fix(tracing-server): fix Dockerfile

### DIFF
--- a/tracing/Dockerfile
+++ b/tracing/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.80-buster as builder
+FROM rust:1.81-bullseye as builder
 
 ADD Cargo.toml /build/Cargo.toml
 ADD Cargo.lock /build/Cargo.lock
@@ -6,6 +6,6 @@ ADD src /build/src
 WORKDIR /build
 RUN cargo build --release
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 COPY --from=builder /build/target/release/near-tracing /app/near-tracing
 CMD ["/app/near-tracing"]


### PR DESCRIPTION
It seems the rust buster image tags don't exist anymore, so this bumps it up one to bullseye. Also bumps the rust version to 1.81 to match up with what's in Cargo.toml, because otherwise that part will fail, too.