### PR TITLE
yield_resume: fix resume per-byte cost

### DIFF
--- a/core/parameters/res/runtime_configs/67.yaml
+++ b/core/parameters/res/runtime_configs/67.yaml
@@ -2,4 +2,4 @@ yield_resume: { old: false, new: true }
 wasm_yield_create_base: { old: 300_000_000_000_000, new: 153_411_779_276 }
 wasm_yield_create_byte: { old: 300_000_000_000_000, new: 15_643_988 }
 wasm_yield_resume_base: { old: 300_000_000_000_000, new: 1_195_627_285_210 }
-wasm_yield_resume_byte: { old: 300_000_000_000_000, new: 17_212_011 }
+wasm_yield_resume_byte: { old: 300_000_000_000_000, new: 1_195_627_285_210 }

--- a/core/parameters/res/runtime_configs/69.yaml
+++ b/core/parameters/res/runtime_configs/69.yaml
@@ -67,7 +67,3 @@ data_receipt_creation_per_byte: {
     execution: 17_212_011,
   }
 }
-wasm_yield_resume_byte: {
-  old: 17_212_011,
-  new: 47_683_715
-}

--- a/core/parameters/res/runtime_configs/73.yaml
+++ b/core/parameters/res/runtime_configs/73.yaml
@@ -1,0 +1,1 @@
+wasm_yield_resume_byte: { old: 1_195_627_285_210 , new: 47_683_715 }

--- a/core/parameters/res/runtime_configs/parameters.snap
+++ b/core/parameters/res/runtime_configs/parameters.snap
@@ -147,7 +147,7 @@ wasm_alt_bn128_g1_sum_element                  5_000_000_000
 wasm_yield_create_base                       153_411_779_276
 wasm_yield_create_byte                            15_643_988
 wasm_yield_resume_base                     1_195_627_285_210
-wasm_yield_resume_byte                            47_683_715
+wasm_yield_resume_byte                     1_195_627_285_210
 wasm_bls12381_p1_sum_base                     16_500_000_000
 wasm_bls12381_p1_sum_element                   6_000_000_000
 wasm_bls12381_p2_sum_base                     18_600_000_000

--- a/core/parameters/src/config_store.rs
+++ b/core/parameters/src/config_store.rs
@@ -49,6 +49,7 @@ static CONFIG_DIFFS: &[(ProtocolVersion, &str)] = &[
     (70, include_config!("70.yaml")),
     // Increase main_storage_proof_size_soft_limit and introduces StateStoredReceipt
     (72, include_config!("72.yaml")),
+    (73, include_config!("73.yaml")),
     (129, include_config!("129.yaml")),
 ];
 

--- a/core/parameters/src/cost.rs
+++ b/core/parameters/src/cost.rs
@@ -390,7 +390,7 @@ impl ExtCosts {
             ExtCosts::yield_create_base => Parameter::WasmYieldCreateBase,
             ExtCosts::yield_create_byte => Parameter::WasmYieldCreateByte,
             ExtCosts::yield_resume_base => Parameter::WasmYieldResumeBase,
-            ExtCosts::yield_resume_byte => Parameter::WasmYieldResumeBase,
+            ExtCosts::yield_resume_byte => Parameter::WasmYieldResumeByte,
             ExtCosts::bls12381_p1_sum_base => Parameter::WasmBls12381P1SumBase,
             ExtCosts::bls12381_p1_sum_element => Parameter::WasmBls12381P1SumElement,
             ExtCosts::bls12381_p2_sum_base => Parameter::WasmBls12381P2SumBase,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__73.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__73.json.snap
@@ -200,7 +200,7 @@ expression: config_view
     "disable_9393_fix": false,
     "discard_custom_sections": true,
     "storage_get_mode": "FlatStorage",
-    "fix_contract_loading_cost": true,
+    "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "math_extension": true,
     "ed25519_verify": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
@@ -174,7 +174,7 @@ expression: config_view
       "yield_create_base": 153411779276,
       "yield_create_byte": 15643988,
       "yield_resume_base": 1195627285210,
-      "yield_resume_byte": 1195627285210,
+      "yield_resume_byte": 47683715,
       "bls12381_p1_sum_base": 16500000000,
       "bls12381_p1_sum_element": 6000000000,
       "bls12381_p2_sum_base": 18600000000,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_73.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_73.json.snap
@@ -200,7 +200,7 @@ expression: config_view
     "disable_9393_fix": false,
     "discard_custom_sections": true,
     "storage_get_mode": "FlatStorage",
-    "fix_contract_loading_cost": true,
+    "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "math_extension": true,
     "ed25519_verify": true,


### PR DESCRIPTION
This was intended to match the cost of the per-byte of function call payloads, but an unfortunate two-letter typo led to it becoming the same as the base cost instead.

This change requires a protocol version bump (to 73) but otherwise is fairly straightforward in that I just set the cost of the fee to the incorrect value back in 67 and corrected it in code and protocol version 73.