### PR TITLE
fix(state sync): delete get_cached_state_parts

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -35,7 +35,6 @@ use crate::{
     Provenance,
 };
 use crate::{metrics, DoomslugThresholdMode};
-use borsh::BorshDeserialize;
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use itertools::Itertools;
 use lru::LruCache;
@@ -69,8 +68,8 @@ use near_primitives::sharding::{
 };
 use near_primitives::state_part::PartId;
 use near_primitives::state_sync::{
-    get_num_state_parts, BitArray, CachedParts, ReceiptProofResponse, RootProof,
-    ShardStateSyncResponseHeader, ShardStateSyncResponseHeaderV2, StateHeaderKey, StatePartKey,
+    get_num_state_parts, ReceiptProofResponse, RootProof, ShardStateSyncResponseHeader,
+    ShardStateSyncResponseHeaderV2, StateHeaderKey, StatePartKey,
 };
 use near_primitives::stateless_validation::state_witness::{
     ChunkStateWitness, ChunkStateWitnessSize,
@@ -3863,41 +3862,6 @@ impl Chain {
         let delete_snapshot = !make_snapshot && is_epoch_boundary;
 
         Ok((make_snapshot, delete_snapshot))
-    }
-
-    /// Returns a description of state parts cached for the given shard of the given epoch.
-    pub fn get_cached_state_parts(
-        &self,
-        sync_hash: CryptoHash,
-        shard_id: ShardId,
-        num_parts: u64,
-    ) -> Result<CachedParts, Error> {
-        let _span = tracing::debug_span!(target: "chain", "get_cached_state_parts").entered();
-        // DBCol::StateParts is keyed by StatePartKey: (BlockHash || ShardId || PartId (u64)).
-        let lower_bound = StatePartKey(sync_hash, shard_id, 0);
-        let lower_bound = borsh::to_vec(&lower_bound)?;
-        let upper_bound = StatePartKey(sync_hash, shard_id + 1, 0);
-        let upper_bound = borsh::to_vec(&upper_bound)?;
-        let mut num_cached_parts = 0;
-        let mut bit_array = BitArray::new(num_parts);
-        for item in self.chain_store.store().iter_range(
-            DBCol::StateParts,
-            Some(&lower_bound),
-            Some(&upper_bound),
-        ) {
-            let key = item?.0;
-            let key = StatePartKey::try_from_slice(&key)?;
-            let part_id = key.2;
-            num_cached_parts += 1;
-            bit_array.set_bit(part_id);
-        }
-        Ok(if num_cached_parts == 0 {
-            CachedParts::NoParts
-        } else if num_cached_parts == num_parts {
-            CachedParts::AllParts
-        } else {
-            CachedParts::BitArray(bit_array)
-        })
     }
 }
 

--- a/core/primitives/src/state_sync.rs
+++ b/core/primitives/src/state_sync.rs
@@ -180,11 +180,8 @@ pub struct ShardStateSyncResponseV2 {
 pub struct ShardStateSyncResponseV3 {
     pub header: Option<ShardStateSyncResponseHeaderV2>,
     pub part: Option<(u64, Vec<u8>)>,
-    /// Parts that can be provided **cheaply**.
-    // Can be `None` only if both `header` and `part` are `None`.
+    // TODO(saketh): deprecate unused fields cached_parts and can_generate
     pub cached_parts: Option<CachedParts>,
-    /// Whether the node can provide parts for this epoch of this shard.
-    /// Assumes that a node can either provide all state parts or no state parts.
     pub can_generate: bool,
 }
 

--- a/integration-tests/src/tests/client/sync_state_nodes.rs
+++ b/integration-tests/src/tests/client/sync_state_nodes.rs
@@ -18,7 +18,7 @@ use near_o11y::testonly::{init_integration_logger, init_test_logger};
 use near_o11y::WithSpanContextExt;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::state_part::PartId;
-use near_primitives::state_sync::{CachedParts, StatePartKey};
+use near_primitives::state_sync::StatePartKey;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{BlockId, BlockReference, EpochId, EpochReference};
 use near_primitives::utils::MaybeValidated;
@@ -858,7 +858,6 @@ fn test_state_sync_headers() {
                         None => return ControlFlow::Continue(()),
                     };
                     let state_response = state_response_info.take_state_response();
-                    let cached_parts = state_response.cached_parts().clone();
                     let can_generate = state_response.can_generate();
                     assert!(state_response.part().is_none());
                     if let Some(_header) = state_response.take_header() {
@@ -866,7 +865,6 @@ fn test_state_sync_headers() {
                             tracing::info!(
                                 ?sync_hash,
                                 shard_id,
-                                ?cached_parts,
                                 can_generate,
                                 "got header but cannot generate"
                             );
@@ -875,7 +873,6 @@ fn test_state_sync_headers() {
                         tracing::info!(
                             ?sync_hash,
                             shard_id,
-                            ?cached_parts,
                             can_generate,
                             "got header"
                         );
@@ -883,7 +880,6 @@ fn test_state_sync_headers() {
                         tracing::info!(
                             ?sync_hash,
                             shard_id,
-                            ?cached_parts,
                             can_generate,
                             "got no header"
                         );
@@ -916,13 +912,12 @@ fn test_state_sync_headers() {
                     assert!(state_response.take_header().is_none());
                     if let Some((part_id, _part)) = part {
                         if !can_generate
-                            || cached_parts != Some(CachedParts::AllParts)
+                            || cached_parts != None
                             || part_id != 0
                         {
                             tracing::info!(
                                 ?sync_hash,
                                 shard_id,
-                                ?cached_parts,
                                 can_generate,
                                 part_id,
                                 "got part but shard info is unexpected"
@@ -932,7 +927,6 @@ fn test_state_sync_headers() {
                         tracing::info!(
                             ?sync_hash,
                             shard_id,
-                            ?cached_parts,
                             can_generate,
                             part_id,
                             "got part"
@@ -941,7 +935,6 @@ fn test_state_sync_headers() {
                         tracing::info!(
                             ?sync_hash,
                             shard_id,
-                            ?cached_parts,
                             can_generate,
                             "got no part"
                         );

--- a/integration-tests/src/tests/client/sync_state_nodes.rs
+++ b/integration-tests/src/tests/client/sync_state_nodes.rs
@@ -870,19 +870,9 @@ fn test_state_sync_headers() {
                             );
                             return ControlFlow::Continue(());
                         }
-                        tracing::info!(
-                            ?sync_hash,
-                            shard_id,
-                            can_generate,
-                            "got header"
-                        );
+                        tracing::info!(?sync_hash, shard_id, can_generate, "got header");
                     } else {
-                        tracing::info!(
-                            ?sync_hash,
-                            shard_id,
-                            can_generate,
-                            "got no header"
-                        );
+                        tracing::info!(?sync_hash, shard_id, can_generate, "got no header");
                         return ControlFlow::Continue(());
                     }
 
@@ -911,10 +901,7 @@ fn test_state_sync_headers() {
                     let part = state_response.part().clone();
                     assert!(state_response.take_header().is_none());
                     if let Some((part_id, _part)) = part {
-                        if !can_generate
-                            || cached_parts != None
-                            || part_id != 0
-                        {
+                        if !can_generate || cached_parts != None || part_id != 0 {
                             tracing::info!(
                                 ?sync_hash,
                                 shard_id,
@@ -924,20 +911,9 @@ fn test_state_sync_headers() {
                             );
                             return ControlFlow::Continue(());
                         }
-                        tracing::info!(
-                            ?sync_hash,
-                            shard_id,
-                            can_generate,
-                            part_id,
-                            "got part"
-                        );
+                        tracing::info!(?sync_hash, shard_id, can_generate, part_id, "got part");
                     } else {
-                        tracing::info!(
-                            ?sync_hash,
-                            shard_id,
-                            can_generate,
-                            "got no part"
-                        );
+                        tracing::info!(?sync_hash, shard_id, can_generate, "got no part");
                         return ControlFlow::Continue(());
                     }
                 }


### PR DESCRIPTION
In testnet we observed `get_cached_state_parts` consistently taking ~58 seconds to run. 

Returning the list of cached state parts is a relic of the old decentralized state sync design. We no longer need this at all.