### PR TITLE
runtime: initial prototype to enable multi-value and reference-types

### DIFF
--- a/core/parameters/res/runtime_configs/73.yaml
+++ b/core/parameters/res/runtime_configs/73.yaml
@@ -1,1 +1,2 @@
 wasm_yield_resume_byte: { old: 1_195_627_285_210 , new: 47_683_715 }
+contract_prepare_version: { old: 2, new: 3 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__129.json.snap
@@ -211,7 +211,7 @@ expression: config_view
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,
-      "contract_prepare_version": 2,
+      "contract_prepare_version": 3,
       "initial_memory_pages": 1024,
       "max_memory_pages": 2048,
       "registers_memory_limit": 1073741824,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__73.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__73.json.snap
@@ -211,7 +211,7 @@ expression: config_view
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,
-      "contract_prepare_version": 2,
+      "contract_prepare_version": 3,
       "initial_memory_pages": 1024,
       "max_memory_pages": 2048,
       "registers_memory_limit": 1073741824,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
@@ -211,7 +211,7 @@ expression: config_view
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,
-      "contract_prepare_version": 2,
+      "contract_prepare_version": 3,
       "initial_memory_pages": 1024,
       "max_memory_pages": 2048,
       "registers_memory_limit": 1073741824,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_73.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_73.json.snap
@@ -211,7 +211,7 @@ expression: config_view
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,
-      "contract_prepare_version": 2,
+      "contract_prepare_version": 3,
       "initial_memory_pages": 1024,
       "max_memory_pages": 2048,
       "registers_memory_limit": 1073741824,

--- a/core/parameters/src/vm.rs
+++ b/core/parameters/src/vm.rs
@@ -267,6 +267,9 @@ pub enum ContractPrepareVersion {
     V1,
     /// finite-wasm 0.3.0 based contract preparation code.
     V2,
+    /// finite-wasm 0.3.0 based contract preparation code with multi-value and reference-types
+    /// enabled.
+    V3,
 }
 
 impl ContractPrepareVersion {

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -174,6 +174,10 @@ pub enum ProtocolFeature {
     StateStoredReceipt,
     /// Resharding V3
     SimpleNightshadeV4,
+
+    /// Enables preparation V3. Note that this feature is not supported at all with Wasmer0 and
+    /// Wasmer2 runtimes.
+    PreparationV3,
 }
 
 impl ProtocolFeature {
@@ -232,6 +236,8 @@ impl ProtocolFeature {
             | ProtocolFeature::ChunkEndorsementV2
             | ProtocolFeature::ChunkEndorsementsInBlockHeader
             | ProtocolFeature::StateStoredReceipt => 72,
+
+            ProtocolFeature::PreparationV3 => 73,
 
             // This protocol version is reserved for use in resharding tests. An extra resharding
             // is simulated on top of the latest shard layout in production. Note that later

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2711,6 +2711,7 @@ fn test_execution_metadata() {
         // We spend two wasm instructions (call & drop), plus 8 ops for initializing function
         // operand stack (8 bytes worth to hold the return value.)
         near_vm_runner::logic::ContractPrepareVersion::V2 => 10,
+        near_vm_runner::logic::ContractPrepareVersion::V3 => 10,
     };
 
     // Profile for what's happening *inside* wasm vm during function call.

--- a/integration-tests/src/tests/runtime/sanity_checks.rs
+++ b/integration-tests/src/tests/runtime/sanity_checks.rs
@@ -252,7 +252,9 @@ fn test_sanity_used_gas() {
         ContractPrepareVersion::V0 | ContractPrepareVersion::V1 => 0,
         // Gas accounting is precise and instructions executed between calls to the side-effectful
         // `used_gas` host function calls will be observbable.
-        ContractPrepareVersion::V2 => u64::from(runtime_config.wasm_config.regular_op_cost),
+        ContractPrepareVersion::V2 | ContractPrepareVersion::V3 => {
+            u64::from(runtime_config.wasm_config.regular_op_cost)
+        }
     };
 
     // Executing `used_gas` costs `base_cost` plus an instruction to execute the `call` itself.

--- a/runtime/near-vm-runner/src/features.rs
+++ b/runtime/near-vm-runner/src/features.rs
@@ -126,6 +126,7 @@ impl From<WasmFeatures> for near_vm_types::Features {
 #[cfg(all(feature = "wasmer2_vm", target_arch = "x86_64"))]
 impl From<WasmFeatures> for wasmer_types::Features {
     fn from(f: crate::features::WasmFeatures) -> Self {
+        assert!(!f.multi_value, "wasmer2_vm does not and will not support multi_value");
         // /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\
         //
         // There are features that this version of wasmparser enables by default, but pwasm

--- a/runtime/near-vm-runner/src/prepare.rs
+++ b/runtime/near-vm-runner/src/prepare.rs
@@ -2,7 +2,7 @@
 //! wasm module before execution.
 
 use crate::logic::errors::PrepareError;
-use near_parameters::vm::{Config, VMKind};
+use near_parameters::vm::{Config, ContractPrepareVersion, VMKind};
 
 mod prepare_v0;
 mod prepare_v1;
@@ -27,8 +27,9 @@ pub fn prepare_contract(
     let prepare = config.limit_config.contract_prepare_version;
     // NearVM => ContractPrepareVersion::V2
     assert!(
-        (kind != VMKind::NearVm) || (prepare == crate::logic::ContractPrepareVersion::V2),
-        "NearVM only works with contract prepare version V2",
+        (kind != VMKind::NearVm)
+            || (prepare == ContractPrepareVersion::V2 || prepare == ContractPrepareVersion::V3),
+        "NearVM only works with contract prepare versions >V2",
     );
     let features = crate::features::WasmFeatures::from(prepare);
     match prepare {
@@ -41,7 +42,7 @@ pub fn prepare_contract(
             prepare_v1::validate_contract(original_code, features, config)?;
             prepare_v1::prepare_contract(original_code, config)
         }
-        crate::logic::ContractPrepareVersion::V2 => {
+        crate::logic::ContractPrepareVersion::V2 | crate::logic::ContractPrepareVersion::V3 => {
             prepare_v2::prepare_contract(original_code, features, config, kind)
         }
     }

--- a/runtime/near-vm-runner/src/tests/rs_contract.rs
+++ b/runtime/near-vm-runner/src/tests/rs_contract.rs
@@ -165,6 +165,7 @@ pub fn ext_used_gas() {
             crate::logic::ContractPrepareVersion::V0 => [111, 10, 200, 15, 0, 0, 0, 0],
             crate::logic::ContractPrepareVersion::V1 => [111, 10, 200, 15, 0, 0, 0, 0],
             crate::logic::ContractPrepareVersion::V2 => [27, 180, 237, 15, 0, 0, 0, 0],
+            crate::logic::ContractPrepareVersion::V3 => [27, 180, 237, 15, 0, 0, 0, 0],
         };
         run_test_ext(Arc::clone(&config), "ext_used_gas", &expected, &[], vec![], vm_kind)
     })

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -202,6 +202,13 @@ impl TestBuilder {
                 if self.skip.contains(&vm_kind) {
                     continue;
                 }
+                if ProtocolFeature::PreparationV3.enabled(protocol_version) {
+                    if let VMKind::Wasmer0 | VMKind::Wasmer2 = vm_kind {
+                        // These runtimes cannot support multi-value or reference-types enabled
+                        // starting with this protocol version.
+                        continue;
+                    }
+                }
 
                 let runtime_config = runtime_config_store.get_config(protocol_version);
 

--- a/runtime/near-vm/compiler-singlepass/src/codegen_x64.rs
+++ b/runtime/near-vm/compiler-singlepass/src/codegen_x64.rs
@@ -284,6 +284,13 @@ impl<'a> FuncGen<'a> {
         let return_types: SmallVec<[WpType; 1]> =
             sig.results().iter().cloned().map(type_to_wp_type).collect();
 
+        if return_types.len() > 1 {
+            return Err(CodegenError {
+                message: "Call: multi-value returns not yet implemented"
+                    .to_string(),
+            })
+        }
+
         let params: SmallVec<[_; 8]> =
             self.value_stack.drain(self.value_stack.len() - param_types.len()..).collect();
         self.machine.release_locations_only_regs(&params);
@@ -1698,6 +1705,12 @@ impl<'a> FuncGen<'a> {
         let func_index = module.func_index(local_func_index);
         let sig_index = module.functions[func_index];
         let signature = module.signatures[sig_index].clone();
+        if signature.results().len() > 1 {
+            return Err(CodegenError {
+                message: "FunctionPrologue: multi-value returns not yet implemented"
+                    .to_string(),
+            })
+        }
 
         let special_labels = SpecialLabelSet {
             integer_division_by_zero: assembler.get_label(),
@@ -4684,6 +4697,12 @@ impl<'a> FuncGen<'a> {
                     sig.params().iter().cloned().map(type_to_wp_type).collect();
                 let return_types: SmallVec<[WpType; 1]> =
                     sig.results().iter().cloned().map(type_to_wp_type).collect();
+                if return_types.len() > 1 {
+                    return Err(CodegenError {
+                        message: "CallIndirect: multi-value returns not yet implemented"
+                            .to_string(),
+                    })
+                }
 
                 let func_index = self.pop_value_released();
 

--- a/runtime/near-vm/compiler-singlepass/src/compiler.rs
+++ b/runtime/near-vm/compiler-singlepass/src/compiler.rs
@@ -50,19 +50,11 @@ impl Compiler for SinglepassCompiler {
         tunables: &dyn near_vm_vm::Tunables,
         instrumentation: &finite_wasm::AnalysisOutcome,
     ) -> Result<Compilation, CompileError> {
-        /*if target.triple().operating_system == OperatingSystem::Windows {
-            return Err(CompileError::UnsupportedTarget(
-                OperatingSystem::Windows.to_string(),
-            ));
-        }*/
         if target.triple().architecture != Architecture::X86_64 {
             return Err(CompileError::UnsupportedTarget(target.triple().architecture.to_string()));
         }
         if !target.cpu_features().contains(CpuFeature::AVX) {
             return Err(CompileError::UnsupportedTarget("x86_64 without AVX".to_string()));
-        }
-        if compile_info.features.multi_value {
-            return Err(CompileError::UnsupportedFeature("multivalue".to_string()));
         }
         let calling_convention = match target.triple().default_calling_convention() {
             Ok(CallingConvention::WindowsFastcall) => CallingConvention::WindowsFastcall,

--- a/runtime/near-vm/tests/compilers/wast.rs
+++ b/runtime/near-vm/tests/compilers/wast.rs
@@ -28,9 +28,6 @@ pub fn run_wast(mut config: crate::Config, wast_path: &str) -> anyhow::Result<()
     if is_simd {
         features.simd(true);
     }
-    if config.compiler == crate::Compiler::Singlepass {
-        features.multi_value(false);
-    }
     config.set_features(features);
     config.set_nan_canonicalization(try_nan_canonicalization);
 

--- a/runtime/near-vm/types/src/features.rs
+++ b/runtime/near-vm/types/src/features.rs
@@ -35,13 +35,9 @@ impl Features {
     pub fn new() -> Self {
         Self {
             threads: false,
-            // Reference types should be on by default
             reference_types: true,
-            // SIMD should be on by default
             simd: true,
-            // Bulk Memory should be on by default
             bulk_memory: true,
-            // Multivalue should be on by default
             multi_value: true,
             tail_call: false,
             multi_memory: false,


### PR DESCRIPTION
These WASM extensions are enabled by default in 1.83 release of the Rust compiler.

We have discussed enabling these features between crt members and these are rough conclusions:

1. The enablement work is probably not super onerous, given that these features were already implemented in wasmer at the time near-vm forked off;
2. Similarly (to the best of my memory) these features have been implemented in finite-wasm;
3. However it is much more crucial to actually verify whether the new functionality does not expose new avenues that would permit non-linear compilation times, for example. With multi-value it is now possible for somebody to specify thousands of return values from a single function. Does the compilation (and execution) time remain linear with regards to the number of values here? Does finite-wasm actually handle this correctly too? We appreciated multi-value being disabled last time we were dealing with this class of problems in related areas (e.g. local initialization problem.)
4. Further, enabling reference-types requires enabling bulk-memory which introduces a new family of primitives for our system: `memory.copy` (memcpy), `memory.fill` (memset.) These are new in not only that they are "expensive" instructions that are executed in the host code and need their own fees, but in that their processing time is going to naturally depend on the arguments passed to the functions. We do have some infrastructure for this in finite-wasm (Aggregate instrumentation kind) but it hasn't been tested as rigorously as the other types of instrumentation kinds.
5. Old versions of the runtime (wasmer0) do not have an implementation for these features at all, however the choice of the runtime used and the validations performed are independent. We already have some precedent in panicking when there's an unsupported combination of the two, but at the same time we have many tests that validate "all types of the VMs." We will have to adjust these tests in a way that's not just disabling coverage for old VMs as changes in mildly related areas can break replayablility where these old versions matter.