### PR TITLE
feat(state-sync): drop old state parts at the end of epoch

### DIFF
--- a/o
+++ b/o
@@ -1,0 +1,9 @@
+
+running 0 tests
+
+successes:
+
+successes:
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 394 filtered out; finished in 0.00s
+


### PR DESCRIPTION
The current gc logic cleans state part column along with the blocks. By default 5 epochs. State parts older than an epoch are not needed. This introduces a change to drop the state sync files at the end of the epoch.