### PR TITLE
fix(gc) - fix the chunk_tail <= tail invariant

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1676,10 +1676,12 @@ impl Chain {
         // leading to the sync hash block.
         let min_height_included =
             prev_block.chunks().iter().map(|chunk| chunk.height_included()).min().unwrap();
+        let min_height_created =
+            prev_block.chunks().iter().map(|chunk| chunk.height_created()).min().unwrap();
 
-        tracing::debug!(target: "sync", ?min_height_included, ?new_tail, "adjusting tail for missing chunks");
+        tracing::debug!(target: "sync", ?min_height_included, ?min_height_created, ?new_tail, "adjusting tail for missing chunks");
         new_tail = std::cmp::min(new_tail, min_height_included.saturating_sub(1));
-        let new_chunk_tail = prev_block.chunks().iter().map(|x| x.height_created()).min().unwrap();
+        let new_chunk_tail = min_height_created.saturating_sub(1);
         let tip = Tip::from_header(prev_block.header());
         let final_head = Tip::from_header(self.genesis.header());
         // Update related heads now.


### PR DESCRIPTION
According to this line in the storage checker, the chunk tail should always be less or equal than the tail:
https://github.com/near/nearcore/blob/99ecfa4e8b97eda5e369d82ef00cfc06e5291552/chain/chain/src/store_validator/validate.rs#L146

This invariant is broken, I'm guessing since #12025 as shown by nayduck gc test failing at this check:
https://nayduck.nearone.org/#/test/108874 - test1 stderr last line

This is a simple mitigation but I'm not 100% sure if correct - please let me know if it makes sense or not. 

Even if not entirely correct it should not cause any problems. At worst gc will attempt to clean a little bit more data that isn't there. I hope. 

The only real change here is the added `saturating_sub(1)` to the line where we set the tail. 