### PR TITLE
feat(resharding) - Make shard ids non-contiguous - part 2

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -29,8 +29,8 @@ use near_primitives::state_part::PartId;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{
-    new_shard_id_tmp, AccountId, Balance, BlockHeight, EpochHeight, EpochId, EpochInfoProvider,
-    Gas, MerkleHash, ShardId, StateChangeCause, StateRoot, StateRootNode,
+    shard_id_as_u32, AccountId, Balance, BlockHeight, EpochHeight, EpochId, EpochInfoProvider, Gas,
+    MerkleHash, ShardId, StateChangeCause, StateRoot, StateRootNode,
 };
 use near_primitives::version::{ProtocolFeature, ProtocolVersion};
 use near_primitives::views::{
@@ -223,7 +223,7 @@ impl NightshadeRuntime {
             epoch_manager.get_epoch_id_from_prev_block(prev_hash).map_err(Error::from)?;
         let shard_version =
             epoch_manager.get_shard_layout(&epoch_id).map_err(Error::from)?.version();
-        Ok(ShardUId { version: shard_version, shard_id: new_shard_id_tmp(shard_id) as u32 })
+        Ok(ShardUId { version: shard_version, shard_id: shard_id_as_u32(shard_id) })
     }
 
     fn get_shard_uid_from_epoch_id(
@@ -234,7 +234,7 @@ impl NightshadeRuntime {
         let epoch_manager = self.epoch_manager.read();
         let shard_version =
             epoch_manager.get_shard_layout(epoch_id).map_err(Error::from)?.version();
-        Ok(ShardUId { version: shard_version, shard_id: new_shard_id_tmp(shard_id) as u32 })
+        Ok(ShardUId { version: shard_version, shard_id: shard_id_as_u32(shard_id) })
     }
 
     fn account_id_to_shard_uid(

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -30,7 +30,8 @@ use near_primitives::block::Tip;
 use near_primitives::challenge::{ChallengesResult, PartialState, SlashedValidator};
 use near_primitives::transaction::{Action, DeleteAccountAction, StakeAction, TransferAction};
 use near_primitives::types::{
-    BlockHeightDelta, Nonce, ValidatorId, ValidatorInfoIdentifier, ValidatorKickoutReason,
+    new_shard_id_tmp, BlockHeightDelta, Nonce, ValidatorId, ValidatorInfoIdentifier,
+    ValidatorKickoutReason,
 };
 use near_primitives::validator_signer::ValidatorSigner;
 use near_primitives::views::{

--- a/chain/chunks/src/client.rs
+++ b/chain/chunks/src/client.rs
@@ -6,6 +6,7 @@ use itertools::Itertools;
 use near_pool::types::TransactionGroupIterator;
 use near_pool::{InsertTransactionResult, PoolIteratorWrapper, TransactionPool};
 use near_primitives::shard_layout::{account_id_to_shard_uid, ShardLayout, ShardUId};
+use near_primitives::types::shard_id_as_u16;
 use near_primitives::{
     epoch_info::RngSeed,
     sharding::{EncodedShardChunk, PartialEncodedChunk, ShardChunk, ShardChunkHeader},
@@ -74,6 +75,7 @@ impl ShardedTransactionPool {
     /// For better security we want the seed to different in each shard.
     /// For testing purposes we want it to be the reproducible and derived from the `self.rng_seed` and `shard_id`
     fn random_seed(base_seed: &RngSeed, shard_id: ShardId) -> RngSeed {
+        let shard_id = shard_id_as_u16(shard_id);
         let mut res = *base_seed;
         res[0] = shard_id as u8;
         res[1] = (shard_id / 256) as u8;

--- a/chain/client/src/stateless_validation/chunk_validator/orphan_witness_pool.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/orphan_witness_pool.rs
@@ -180,7 +180,7 @@ mod tests {
     use near_primitives::hash::{hash, CryptoHash};
     use near_primitives::sharding::{ShardChunkHeader, ShardChunkHeaderInner};
     use near_primitives::stateless_validation::state_witness::ChunkStateWitness;
-    use near_primitives::types::{new_shard_id_tmp, BlockHeight, ShardId};
+    use near_primitives::types::{new_shard_id_tmp, shard_id_max, BlockHeight, ShardId};
 
     use super::OrphanStateWitnessPool;
 
@@ -336,7 +336,7 @@ mod tests {
     fn large_shard_id() {
         let mut pool = OrphanStateWitnessPool::new(10);
 
-        let large_shard_id = ShardId::MAX;
+        let large_shard_id = shard_id_max();
         let witness = make_witness(101, large_shard_id.into(), block(99), 0);
         pool.add_orphan_state_witness(witness.clone(), 0);
 

--- a/chain/client/src/tests/bug_repros.rs
+++ b/chain/client/src/tests/bug_repros.rs
@@ -10,6 +10,7 @@ use futures::FutureExt;
 use near_async::messaging::CanSend;
 use near_async::time::Clock;
 use near_network::shards_manager::ShardsManagerRequestFromNetwork;
+use near_primitives::types::shard_id_as_usize;
 use rand::{thread_rng, Rng};
 
 use crate::test_utils::{setup_mock_all_validators, ActorHandlesForTesting};
@@ -112,7 +113,7 @@ fn repro_1183() {
                             // This test uses the V0 shard layout so it's ok to
                             // cast ShardId to ShardIndex.
                             let shard_id = account_id_to_shard_id(&from, 4);
-                            let shard_index = shard_id as usize;
+                            let shard_index = shard_id_as_usize(shard_id);
                             connectors1.write().unwrap()[shard_index].client_actor.do_send(
                                 ProcessTxRequest {
                                     transaction: SignedTransaction::send_money(

--- a/chain/client/src/tests/cross_shard_tx.rs
+++ b/chain/client/src/tests/cross_shard_tx.rs
@@ -17,7 +17,7 @@ use near_o11y::testonly::init_integration_logger;
 use near_o11y::WithSpanContextExt;
 use near_primitives::hash::CryptoHash;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{AccountId, BlockId, BlockReference};
+use near_primitives::types::{shard_id_as_usize, AccountId, BlockId, BlockReference};
 use near_primitives::views::QueryResponseKind::ViewAccount;
 use near_primitives::views::{QueryRequest, QueryResponse};
 use std::collections::HashSet;
@@ -192,7 +192,7 @@ fn test_cross_shard_tx_callback(
             // This test uses the V0 shard layout so it's ok to cast ShardId to
             // ShardIndex.
             let shard_id = account_id_to_shard_id(&account_id, 8);
-            let shard_index = shard_id as usize;
+            let shard_index = shard_id_as_usize(shard_id);
             let actor = &connectors_[shard_index + (*presumable_epoch.read().unwrap() * 8) % 24]
                 .view_client_actor;
             let actor = actor.send(
@@ -260,7 +260,7 @@ fn test_cross_shard_tx_callback(
                 // This test uses the V0 shard layout so it's ok to cast ShardId to
                 // ShardIndex.
                 let shard_id = account_id_to_shard_id(&validators[from], 8);
-                let shard_index = shard_id as usize;
+                let shard_index = shard_id_as_usize(shard_id);
 
                 send_tx(
                     validators.len(),
@@ -299,7 +299,7 @@ fn test_cross_shard_tx_callback(
                     // This test uses the V0 shard layout so it's ok to cast ShardId to
                     // ShardIndex.
                     let shard_id = account_id_to_shard_id(&validators[i], 8);
-                    let shard_index = shard_id as usize;
+                    let shard_index = shard_id_as_usize(shard_id);
 
                     let actor = &connectors_
                         [shard_index + (*presumable_epoch.read().unwrap() * 8) % 24]
@@ -359,7 +359,7 @@ fn test_cross_shard_tx_callback(
             // This test uses the V0 shard layout so it's ok to cast ShardId to
             // ShardIndex.
             let shard_id = account_id_to_shard_id(&account_id, 8);
-            let shard_index = shard_id as usize;
+            let shard_index = shard_id_as_usize(shard_id);
 
             let actor = &connectors_[shard_index + (*presumable_epoch.read().unwrap() * 8) % 24]
                 .view_client_actor;
@@ -521,7 +521,7 @@ fn test_cross_shard_tx_common(
             // This test uses the V0 shard layout so it's ok to cast ShardId to
             // ShardIndex.
             let shard_id = account_id_to_shard_id(&validators[i], 8);
-            let shard_index = shard_id as usize;
+            let shard_index = shard_id_as_usize(shard_id);
 
             let actor =
                 &connectors_[shard_index + *presumable_epoch.read().unwrap() * 8].view_client_actor;

--- a/chain/network/src/peer_manager/tests/snapshot_hosts.rs
+++ b/chain/network/src/peer_manager/tests/snapshot_hosts.rs
@@ -18,6 +18,8 @@ use near_o11y::WithSpanContextExt;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
 use near_primitives::types::new_shard_id_tmp;
+use near_primitives::types::shard_id_as_u64;
+use near_primitives::types::shard_id_max;
 use near_primitives::types::EpochHeight;
 use near_primitives::types::ShardId;
 use peer_manager::testonly::FDS_PER_PEER;
@@ -371,12 +373,16 @@ async fn large_shard_id_in_cache() {
     let peer1 = pm.start_inbound(chain.clone(), peer1_config.clone()).await.handshake(clock).await;
 
     tracing::info!(target:"test", "Send a SnapshotHostInfo message with very large shard ids.");
-    let max_shard_id: ShardId = ShardId::MAX;
+    let max_shard_id = shard_id_max();
+    let max_shard_id_minus_one = shard_id_as_u64(max_shard_id) - 1;
+    let max_shard_id_minus_one = new_shard_id_tmp(max_shard_id_minus_one);
     let big_shard_info = Arc::new(SnapshotHostInfo::new(
         peer1_config.node_id(),
         CryptoHash::hash_borsh(1234_u64),
         1234,
-        vec![0, 1232232, max_shard_id - 1, max_shard_id].into_iter().map(Into::into).collect(),
+        vec![new_shard_id_tmp(0), new_shard_id_tmp(1232232), max_shard_id_minus_one, max_shard_id]
+            .into_iter()
+            .collect(),
         &peer1_config.node_key,
     ));
 
@@ -447,7 +453,7 @@ async fn too_many_shards_truncate() {
     assert_eq!(info.shards.len(), MAX_SHARDS_PER_SNAPSHOT_HOST_INFO);
     for &shard_id in &info.shards {
         // Shard ids are taken from the original vector
-        assert!(shard_id < 2 * MAX_SHARDS_PER_SNAPSHOT_HOST_INFO as u64);
+        assert!(shard_id_as_u64(shard_id) < 2 * MAX_SHARDS_PER_SNAPSHOT_HOST_INFO as u64);
     }
     // The shard_ids are sorted and unique (no two elements are equal, hence the < condition instead of <=)
     assert!(info.shards.windows(2).all(|twoelems| twoelems[0] < twoelems[1]));

--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -33,8 +33,8 @@ insta.workspace = true
 expect-test.workspace = true
 
 [features]
-# default = ["new_shard_id"] # DO NOT COMMIT THIS
-default = []
+default = ["new_shard_id"] # DO NOT COMMIT THIS
+# default = []
 protocol_feature_fix_staking_threshold = []
 protocol_feature_fix_contract_loading_cost = []
 protocol_feature_reject_blocks_with_outdated_protocol_version = []

--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -33,11 +33,15 @@ insta.workspace = true
 expect-test.workspace = true
 
 [features]
+# default = ["new_shard_id"] # DO NOT COMMIT THIS
 default = []
 protocol_feature_fix_staking_threshold = []
 protocol_feature_fix_contract_loading_cost = []
 protocol_feature_reject_blocks_with_outdated_protocol_version = []
 protocol_feature_nonrefundable_transfer_nep491 = []
+
+# TODO(wacban) remove after the transition is done
+new_shard_id = []
 
 nightly = [
   "nightly_protocol",

--- a/core/primitives-core/Cargo.toml
+++ b/core/primitives-core/Cargo.toml
@@ -33,14 +33,14 @@ insta.workspace = true
 expect-test.workspace = true
 
 [features]
-default = ["new_shard_id"] # DO NOT COMMIT THIS
-# default = []
+default = []
 protocol_feature_fix_staking_threshold = []
 protocol_feature_fix_contract_loading_cost = []
 protocol_feature_reject_blocks_with_outdated_protocol_version = []
 protocol_feature_nonrefundable_transfer_nep491 = []
 
 # TODO(wacban) remove after the transition is done
+# default = ["new_shard_id"] # DO NOT COMMIT THIS
 new_shard_id = []
 
 nightly = [

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -76,6 +76,14 @@ pub fn new_shard_id_vec_tmp(vec: &[u64]) -> Vec<ShardId> {
     vec.iter().copied().map(new_shard_id_tmp).collect()
 }
 
+pub fn shard_id_max() -> ShardId {
+    #[cfg(not(feature = "new_shard_id"))]
+    return ShardId::MAX;
+
+    #[cfg(feature = "new_shard_id")]
+    return ShardId::max();
+}
+
 // TODO(wacban) This is a temporary solution to aid the transition to having
 // ShardId as a newtype. It should be replaced / removed / inlined once the
 // transition is complete.

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "new_shard_id")]
 use std::fmt::Display;
 
 use crate::hash::CryptoHash;
@@ -46,9 +47,10 @@ pub type PromiseId = Vec<ReceiptIndex>;
 
 pub type ProtocolVersion = u32;
 
-// /// The shard identifier. The ShardId is currently being migrated to a newtype -
-// /// please see the new ShardId definition below.
-// pub type ShardId = u64;
+/// The shard identifier. The ShardId is currently being migrated to a newtype -
+/// please see the new ShardId definition below.
+#[cfg(not(feature = "new_shard_id"))]
+pub type ShardId = u64;
 
 /// The ShardIndex is the index of the shard in an array of shard data.
 /// Historically the ShardId was always in the range 0..NUM_SHARDS and was used
@@ -60,16 +62,11 @@ pub type ShardIndex = usize;
 // ShardId as a newtype. It should be replaced / removed / inlined once the
 // transition is complete.
 pub const fn new_shard_id_tmp(id: u64) -> ShardId {
-    // id
-    ShardId::new(id)
-}
+    #[cfg(not(feature = "new_shard_id"))]
+    return id;
 
-// TODO(wacban) This is a temporary solution to aid the transition to having
-// ShardId as a newtype. It should be replaced / removed / inlined once the
-// transition is complete.
-pub const fn shard_id_as_usize(id: ShardId) -> usize {
-    id.get() as usize
-    // id
+    #[cfg(feature = "new_shard_id")]
+    return ShardId::new(id);
 }
 
 // TODO(wacban) This is a temporary solution to aid the transition to having
@@ -82,25 +79,45 @@ pub fn new_shard_id_vec_tmp(vec: &[u64]) -> Vec<ShardId> {
 // TODO(wacban) This is a temporary solution to aid the transition to having
 // ShardId as a newtype. It should be replaced / removed / inlined once the
 // transition is complete.
+pub const fn shard_id_as_usize(id: ShardId) -> usize {
+    #[cfg(not(feature = "new_shard_id"))]
+    return id as usize;
+
+    #[cfg(feature = "new_shard_id")]
+    return id.get() as usize;
+}
+
+// TODO(wacban) This is a temporary solution to aid the transition to having
+// ShardId as a newtype. It should be replaced / removed / inlined once the
+// transition is complete.
 pub const fn shard_id_as_u16(id: ShardId) -> u16 {
-    id.get() as u16
-    // id as u16
+    #[cfg(not(feature = "new_shard_id"))]
+    return id as u16;
+
+    #[cfg(feature = "new_shard_id")]
+    return id.get() as u16;
 }
 
 // TODO(wacban) This is a temporary solution to aid the transition to having
 // ShardId as a newtype. It should be replaced / removed / inlined once the
 // transition is complete.
 pub const fn shard_id_as_u32(id: ShardId) -> u32 {
-    id.get() as u32
-    // id as u32
+    #[cfg(not(feature = "new_shard_id"))]
+    return id as u32;
+
+    #[cfg(feature = "new_shard_id")]
+    return id.get() as u32;
 }
 
 // TODO(wacban) This is a temporary solution to aid the transition to having
 // ShardId as a newtype. It should be replaced / removed / inlined once the
 // transition is complete.
 pub const fn shard_id_as_u64(id: ShardId) -> u64 {
-    id.get()
-    // id
+    #[cfg(not(feature = "new_shard_id"))]
+    return id as u64;
+
+    #[cfg(feature = "new_shard_id")]
+    return id.get() as u64;
 }
 
 // TODO(wacban) Complete the transition to ShardId as a newtype.
@@ -111,6 +128,7 @@ pub const fn shard_id_as_u64(id: ShardId) -> u64 {
 /// The shard id is wrapped in a newtype to prevent the old pattern of using
 /// indices in range 0..NUM_SHARDS and casting to ShardId. Once the transition
 /// if fully complete it potentially may be simplified to a regular type alias.
+#[cfg(feature = "new_shard_id")]
 #[derive(
     arbitrary::Arbitrary,
     borsh::BorshSerialize,
@@ -128,6 +146,7 @@ pub const fn shard_id_as_u64(id: ShardId) -> u64 {
 )]
 pub struct ShardId(u64);
 
+#[cfg(feature = "new_shard_id")]
 impl ShardId {
     /// Create a new shard id. Please note that this function should not be used
     /// to convert a shard index (a number in 0..num_shards range) to ShardId.
@@ -174,54 +193,63 @@ impl ShardId {
     }
 }
 
+#[cfg(feature = "new_shard_id")]
 impl Display for ShardId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
+#[cfg(feature = "new_shard_id")]
 impl From<u64> for ShardId {
     fn from(id: u64) -> Self {
         Self(id)
     }
 }
 
+#[cfg(feature = "new_shard_id")]
 impl Into<u64> for ShardId {
     fn into(self) -> u64 {
         self.0
     }
 }
 
+#[cfg(feature = "new_shard_id")]
 impl From<u32> for ShardId {
     fn from(id: u32) -> Self {
         Self(id as u64)
     }
 }
 
+#[cfg(feature = "new_shard_id")]
 impl Into<u32> for ShardId {
     fn into(self) -> u32 {
         self.0 as u32
     }
 }
 
+#[cfg(feature = "new_shard_id")]
 impl From<i32> for ShardId {
     fn from(id: i32) -> Self {
         Self(id as u64)
     }
 }
 
+#[cfg(feature = "new_shard_id")]
 impl From<usize> for ShardId {
     fn from(id: usize) -> Self {
         Self(id as u64)
     }
 }
 
+#[cfg(feature = "new_shard_id")]
 impl From<u16> for ShardId {
     fn from(id: u16) -> Self {
         Self(id as u64)
     }
 }
 
+#[cfg(feature = "new_shard_id")]
 impl Into<u16> for ShardId {
     fn into(self) -> u16 {
         self.0 as u16

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::hash::CryptoHash;
 
 /// Account identifier. Provides access to user's state.
@@ -44,9 +46,9 @@ pub type PromiseId = Vec<ReceiptIndex>;
 
 pub type ProtocolVersion = u32;
 
-/// The shard identifier. The ShardId is currently being migrated to a newtype -
-/// please see the new ShardId definition below.
-pub type ShardId = u64;
+// /// The shard identifier. The ShardId is currently being migrated to a newtype -
+// /// please see the new ShardId definition below.
+// pub type ShardId = u64;
 
 /// The ShardIndex is the index of the shard in an array of shard data.
 /// Historically the ShardId was always in the range 0..NUM_SHARDS and was used
@@ -58,7 +60,16 @@ pub type ShardIndex = usize;
 // ShardId as a newtype. It should be replaced / removed / inlined once the
 // transition is complete.
 pub const fn new_shard_id_tmp(id: u64) -> ShardId {
-    id
+    // id
+    ShardId::new(id)
+}
+
+// TODO(wacban) This is a temporary solution to aid the transition to having
+// ShardId as a newtype. It should be replaced / removed / inlined once the
+// transition is complete.
+pub const fn shard_id_as_usize(id: ShardId) -> usize {
+    id.get() as usize
+    // id
 }
 
 // TODO(wacban) This is a temporary solution to aid the transition to having
@@ -71,131 +82,148 @@ pub fn new_shard_id_vec_tmp(vec: &[u64]) -> Vec<ShardId> {
 // TODO(wacban) This is a temporary solution to aid the transition to having
 // ShardId as a newtype. It should be replaced / removed / inlined once the
 // transition is complete.
+pub const fn shard_id_as_u16(id: ShardId) -> u16 {
+    id.get() as u16
+    // id as u16
+}
+
+// TODO(wacban) This is a temporary solution to aid the transition to having
+// ShardId as a newtype. It should be replaced / removed / inlined once the
+// transition is complete.
 pub const fn shard_id_as_u32(id: ShardId) -> u32 {
-    id as u32
+    id.get() as u32
+    // id as u32
+}
+
+// TODO(wacban) This is a temporary solution to aid the transition to having
+// ShardId as a newtype. It should be replaced / removed / inlined once the
+// transition is complete.
+pub const fn shard_id_as_u64(id: ShardId) -> u64 {
+    id.get()
+    // id
 }
 
 // TODO(wacban) Complete the transition to ShardId as a newtype.
-// /// The shard identifier. It may be a arbitrary number - it does not need to be
-// /// a number in the range 0..NUM_SHARDS. The shard ids do not need to be
-// /// sequential or contiguous.
-// ///
-// /// The shard id is wrapped in a newtype to prevent the old pattern of using
-// /// indices in range 0..NUM_SHARDS and casting to ShardId. Once the transition
-// /// if fully complete it potentially may be simplified to a regular type alias.
-// #[derive(
-//     arbitrary::Arbitrary,
-//     borsh::BorshSerialize,
-//     borsh::BorshDeserialize,
-//     serde::Serialize,
-//     serde::Deserialize,
-//     Hash,
-//     Clone,
-//     Copy,
-//     Debug,
-//     PartialEq,
-//     Eq,
-//     PartialOrd,
-//     Ord,
-// )]
-// pub struct ShardId(u64);
+/// The shard identifier. It may be a arbitrary number - it does not need to be
+/// a number in the range 0..NUM_SHARDS. The shard ids do not need to be
+/// sequential or contiguous.
+///
+/// The shard id is wrapped in a newtype to prevent the old pattern of using
+/// indices in range 0..NUM_SHARDS and casting to ShardId. Once the transition
+/// if fully complete it potentially may be simplified to a regular type alias.
+#[derive(
+    arbitrary::Arbitrary,
+    borsh::BorshSerialize,
+    borsh::BorshDeserialize,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+)]
+pub struct ShardId(u64);
 
-// impl ShardId {
-//     /// Create a new shard id. Please note that this function should not be used
-//     /// to convert a shard index (a number in 0..num_shards range) to ShardId.
-//     /// Instead the ShardId should be obtained from the shard_layout.
-//     ///
-//     /// ```
-//     /// // BAD USAGE:
-//     /// for shard_index in 1..num_shards {
-//     ///     let shard_id = ShardId::new(shard_index); // Incorrect!!!
-//     /// }
-//     /// ```
-//     /// ```
-//     /// // GOOD USAGE 1:
-//     /// for shard_index in 1..num_shards {
-//     ///     let shard_id = shard_layout.get_shard_id(shard_index);
-//     /// }
-//     /// // GOOD USAGE 2:
-//     /// for shard_id in shard_layout.shard_ids() {
-//     ///     let shard_id = shard_layout.get_shard_id(shard_index);
-//     /// }
-//     /// ```
-//     pub const fn new(id: u64) -> Self {
-//         Self(id)
-//     }
+impl ShardId {
+    /// Create a new shard id. Please note that this function should not be used
+    /// to convert a shard index (a number in 0..num_shards range) to ShardId.
+    /// Instead the ShardId should be obtained from the shard_layout.
+    ///
+    /// ```
+    /// // BAD USAGE:
+    /// for shard_index in 1..num_shards {
+    ///     let shard_id = ShardId::new(shard_index); // Incorrect!!!
+    /// }
+    /// ```
+    /// ```
+    /// // GOOD USAGE 1:
+    /// for shard_index in 1..num_shards {
+    ///     let shard_id = shard_layout.get_shard_id(shard_index);
+    /// }
+    /// // GOOD USAGE 2:
+    /// for shard_id in shard_layout.shard_ids() {
+    ///     let shard_id = shard_layout.get_shard_id(shard_index);
+    /// }
+    /// ```
+    pub const fn new(id: u64) -> Self {
+        Self(id)
+    }
 
-//     /// Get the numerical value of the shard id. This should not be used as an
-//     /// index into an array, as the shard id may be any arbitrary number.
-//     pub fn get(self) -> u64 {
-//         self.0
-//     }
+    /// Get the numerical value of the shard id. This should not be used as an
+    /// index into an array, as the shard id may be any arbitrary number.
+    pub const fn get(self) -> u64 {
+        self.0
+    }
 
-//     pub fn to_le_bytes(self) -> [u8; 8] {
-//         self.0.to_le_bytes()
-//     }
+    pub fn to_le_bytes(self) -> [u8; 8] {
+        self.0.to_le_bytes()
+    }
 
-//     pub fn from_le_bytes(bytes: [u8; 8]) -> Self {
-//         Self(u64::from_le_bytes(bytes))
-//     }
+    pub fn from_le_bytes(bytes: [u8; 8]) -> Self {
+        Self(u64::from_le_bytes(bytes))
+    }
 
-//     // TODO This is not great, in ShardUId shard_id is u32.
-//     // Currently used for some metrics so kinda ok.
-//     pub fn max() -> Self {
-//         Self(u64::MAX)
-//     }
-// }
+    // TODO This is not great, in ShardUId shard_id is u32.
+    // Currently used for some metrics so kinda ok.
+    pub fn max() -> Self {
+        Self(u64::MAX)
+    }
+}
 
-// impl Display for ShardId {
-//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-//         write!(f, "{}", self.0)
-//     }
-// }
+impl Display for ShardId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
-// impl From<u64> for ShardId {
-//     fn from(id: u64) -> Self {
-//         Self(id)
-//     }
-// }
+impl From<u64> for ShardId {
+    fn from(id: u64) -> Self {
+        Self(id)
+    }
+}
 
-// impl Into<u64> for ShardId {
-//     fn into(self) -> u64 {
-//         self.0
-//     }
-// }
+impl Into<u64> for ShardId {
+    fn into(self) -> u64 {
+        self.0
+    }
+}
 
-// impl From<u32> for ShardId {
-//     fn from(id: u32) -> Self {
-//         Self(id as u64)
-//     }
-// }
+impl From<u32> for ShardId {
+    fn from(id: u32) -> Self {
+        Self(id as u64)
+    }
+}
 
-// impl Into<u32> for ShardId {
-//     fn into(self) -> u32 {
-//         self.0 as u32
-//     }
-// }
+impl Into<u32> for ShardId {
+    fn into(self) -> u32 {
+        self.0 as u32
+    }
+}
 
-// impl From<i32> for ShardId {
-//     fn from(id: i32) -> Self {
-//         Self(id as u64)
-//     }
-// }
+impl From<i32> for ShardId {
+    fn from(id: i32) -> Self {
+        Self(id as u64)
+    }
+}
 
-// impl From<usize> for ShardId {
-//     fn from(id: usize) -> Self {
-//         Self(id as u64)
-//     }
-// }
+impl From<usize> for ShardId {
+    fn from(id: usize) -> Self {
+        Self(id as u64)
+    }
+}
 
-// impl From<u16> for ShardId {
-//     fn from(id: u16) -> Self {
-//         Self(id as u64)
-//     }
-// }
+impl From<u16> for ShardId {
+    fn from(id: u16) -> Self {
+        Self(id as u64)
+    }
+}
 
-// impl Into<u16> for ShardId {
-//     fn into(self) -> u16 {
-//         self.0 as u16
-//     }
-// }
+impl Into<u16> for ShardId {
+    fn into(self) -> u16 {
+        self.0 as u16
+    }
+}

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -128,6 +128,8 @@ pub const fn shard_id_as_u64(id: ShardId) -> u64 {
     return id.get() as u64;
 }
 
+/*
+
 // TODO(wacban) Complete the transition to ShardId as a newtype.
 /// The shard identifier. It may be a arbitrary number - it does not need to be
 /// a number in the range 0..NUM_SHARDS. The shard ids do not need to be
@@ -263,3 +265,5 @@ impl Into<u16> for ShardId {
         self.0 as u16
     }
 }
+
+*/

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -1,5 +1,5 @@
-#[cfg(feature = "new_shard_id")]
-use std::fmt::Display;
+// #[cfg(feature = "new_shard_id")]
+// use std::fmt::Display;
 
 use crate::hash::CryptoHash;
 
@@ -49,7 +49,7 @@ pub type ProtocolVersion = u32;
 
 /// The shard identifier. The ShardId is currently being migrated to a newtype -
 /// please see the new ShardId definition below.
-#[cfg(not(feature = "new_shard_id"))]
+// #[cfg(not(feature = "new_shard_id"))]
 pub type ShardId = u64;
 
 /// The ShardIndex is the index of the shard in an array of shard data.
@@ -62,11 +62,11 @@ pub type ShardIndex = usize;
 // ShardId as a newtype. It should be replaced / removed / inlined once the
 // transition is complete.
 pub const fn new_shard_id_tmp(id: u64) -> ShardId {
-    #[cfg(not(feature = "new_shard_id"))]
+    // #[cfg(not(feature = "new_shard_id"))]
     return id;
 
-    #[cfg(feature = "new_shard_id")]
-    return ShardId::new(id);
+    // #[cfg(feature = "new_shard_id")]
+    // return ShardId::new(id);
 }
 
 // TODO(wacban) This is a temporary solution to aid the transition to having
@@ -77,55 +77,55 @@ pub fn new_shard_id_vec_tmp(vec: &[u64]) -> Vec<ShardId> {
 }
 
 pub fn shard_id_max() -> ShardId {
-    #[cfg(not(feature = "new_shard_id"))]
+    // #[cfg(not(feature = "new_shard_id"))]
     return ShardId::MAX;
 
-    #[cfg(feature = "new_shard_id")]
-    return ShardId::max();
+    // #[cfg(feature = "new_shard_id")]
+    // return ShardId::max();
 }
 
 // TODO(wacban) This is a temporary solution to aid the transition to having
 // ShardId as a newtype. It should be replaced / removed / inlined once the
 // transition is complete.
 pub const fn shard_id_as_usize(id: ShardId) -> usize {
-    #[cfg(not(feature = "new_shard_id"))]
+    // #[cfg(not(feature = "new_shard_id"))]
     return id as usize;
 
-    #[cfg(feature = "new_shard_id")]
-    return id.get() as usize;
+    // #[cfg(feature = "new_shard_id")]
+    // return id.get() as usize;
 }
 
 // TODO(wacban) This is a temporary solution to aid the transition to having
 // ShardId as a newtype. It should be replaced / removed / inlined once the
 // transition is complete.
 pub const fn shard_id_as_u16(id: ShardId) -> u16 {
-    #[cfg(not(feature = "new_shard_id"))]
+    // #[cfg(not(feature = "new_shard_id"))]
     return id as u16;
 
-    #[cfg(feature = "new_shard_id")]
-    return id.get() as u16;
+    // #[cfg(feature = "new_shard_id")]
+    // return id.get() as u16;
 }
 
 // TODO(wacban) This is a temporary solution to aid the transition to having
 // ShardId as a newtype. It should be replaced / removed / inlined once the
 // transition is complete.
 pub const fn shard_id_as_u32(id: ShardId) -> u32 {
-    #[cfg(not(feature = "new_shard_id"))]
+    // #[cfg(not(feature = "new_shard_id"))]
     return id as u32;
 
-    #[cfg(feature = "new_shard_id")]
-    return id.get() as u32;
+    // #[cfg(feature = "new_shard_id")]
+    // return id.get() as u32;
 }
 
 // TODO(wacban) This is a temporary solution to aid the transition to having
 // ShardId as a newtype. It should be replaced / removed / inlined once the
 // transition is complete.
 pub const fn shard_id_as_u64(id: ShardId) -> u64 {
-    #[cfg(not(feature = "new_shard_id"))]
+    // #[cfg(not(feature = "new_shard_id"))]
     return id as u64;
 
-    #[cfg(feature = "new_shard_id")]
-    return id.get() as u64;
+    // #[cfg(feature = "new_shard_id")]
+    // return id.get() as u64;
 }
 
 /*

--- a/core/primitives/benches/serialization.rs
+++ b/core/primitives/benches/serialization.rs
@@ -13,7 +13,7 @@ use near_primitives::test_utils::account_new;
 use near_primitives::transaction::{
     Action, SignedTransaction, Transaction, TransactionV0, TransferAction,
 };
-use near_primitives::types::{EpochId, StateRoot};
+use near_primitives::types::{new_shard_id_vec_tmp, EpochId, StateRoot};
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives_core::types::MerkleHash;
@@ -39,7 +39,7 @@ fn create_transaction() -> SignedTransaction {
 }
 
 fn create_block() -> Block {
-    let shard_ids = vec![0];
+    let shard_ids = new_shard_id_vec_tmp(&[0]);
     let genesis_chunks = genesis_chunks(
         vec![StateRoot::new()],
         vec![Default::default(); shard_ids.len()],

--- a/core/primitives/src/congestion_info.rs
+++ b/core/primitives/src/congestion_info.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use crate::errors::RuntimeError;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_parameters::config::CongestionControlConfig;
-use near_primitives_core::types::{Gas, ShardId};
+use near_primitives_core::types::{shard_id_as_u16, Gas, ShardId};
 use near_schema_checker_lib::ProtocolSchema;
 use ordered_float::NotNan;
 
@@ -85,7 +85,7 @@ impl CongestionControl {
         // `clamped_f64_fraction` clamps to exactly 1.0.
         if congestion == 1.0 {
             // Red traffic light: reduce to minimum speed
-            if sender_shard == self.info.allowed_shard() as u64 {
+            if shard_id_as_u16(sender_shard) == self.info.allowed_shard() {
                 self.config.allowed_shard_outgoing_gas
             } else {
                 0
@@ -97,7 +97,7 @@ impl CongestionControl {
 
     /// How much data another shard can send to us in the next block.
     pub fn outgoing_size_limit(&self, sender_shard: ShardId) -> Gas {
-        if sender_shard == self.info.allowed_shard() as u64 {
+        if shard_id_as_u16(sender_shard) == self.info.allowed_shard() {
             // The allowed shard is allowed to send more data to us.
             self.config.outgoing_receipts_big_size_limit
         } else {
@@ -347,7 +347,7 @@ impl CongestionInfo {
         congestion_seed: u64,
     ) {
         let allowed_shard = Self::get_new_allowed_shard(own_shard, all_shards, congestion_seed);
-        self.set_allowed_shard(allowed_shard as u16);
+        self.set_allowed_shard(shard_id_as_u16(allowed_shard));
     }
 
     fn get_new_allowed_shard(

--- a/core/primitives/src/congestion_info.rs
+++ b/core/primitives/src/congestion_info.rs
@@ -844,7 +844,7 @@ mod tests {
 
         // Full congestion - only the allowed shard should be able to send something.
         for shard in all_shards {
-            if shard == control.info.allowed_shard() as u64 {
+            if shard_id_as_u16(shard) == control.info.allowed_shard() {
                 assert_eq!(control.outgoing_gas_limit(shard), config.allowed_shard_outgoing_gas);
             } else {
                 assert_eq!(control.outgoing_gas_limit(shard), 0);

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -20,7 +20,9 @@ use crate::version::PROTOCOL_VERSION;
 use crate::views::{ExecutionStatusView, FinalExecutionOutcomeView, FinalExecutionStatus};
 use near_crypto::vrf::Value;
 use near_crypto::{EmptySigner, PublicKey, SecretKey, Signature, Signer};
-use near_primitives_core::types::{BlockHeight, MerkleHash, ProtocolVersion, ShardId};
+use near_primitives_core::types::{
+    new_shard_id_tmp, BlockHeight, MerkleHash, ProtocolVersion, ShardId,
+};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -1011,7 +1013,7 @@ impl EpochInfoProvider for MockEpochInfoProvider {
         _account_id: &AccountId,
         _epoch_id: &EpochId,
     ) -> Result<ShardId, EpochError> {
-        Ok(0)
+        Ok(new_shard_id_tmp(0))
     }
 }
 

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -853,7 +853,7 @@ mod tests {
         let shard_layout = ShardLayout::for_protocol_version(PROTOCOL_VERSION);
         let max_id = shard_layout.shard_ids().max().unwrap();
         assert!(
-            max_id <= u16::MAX as u64,
+            shard_id_as_u64(max_id) <= u16::MAX as u64,
             "buffered receipt trie key optimization broken, must fit in a u16"
         );
     }

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -2,7 +2,7 @@ use crate::hash::CryptoHash;
 use crate::types::AccountId;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_crypto::PublicKey;
-use near_primitives_core::types::ShardId;
+use near_primitives_core::types::{shard_id_as_u16, shard_id_as_u64, ShardId};
 use near_schema_checker_lib::ProtocolSchema;
 use std::mem::size_of;
 
@@ -292,10 +292,11 @@ impl TrieKey {
             }
             TrieKey::BufferedReceiptIndices => buf.push(col::BUFFERED_RECEIPT_INDICES),
             TrieKey::BufferedReceipt { index, receiving_shard } => {
+                let receiving_shard = *receiving_shard;
                 buf.push(col::BUFFERED_RECEIPT);
                 // Use  u16 for shard id to reduce depth in trie.
-                assert!(*receiving_shard <= u16::MAX as u64, "Shard ID too big.");
-                buf.extend(&(*receiving_shard as u16).to_le_bytes());
+                assert!(shard_id_as_u64(receiving_shard) <= u16::MAX as u64, "Shard ID too big.");
+                buf.extend(&shard_id_as_u16(receiving_shard).to_le_bytes());
                 buf.extend(&index.to_le_bytes());
             }
         };

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -128,8 +128,8 @@ impl Trie {
         &self,
         part_id: PartId,
     ) -> Result<(PartialState, Vec<u8>, Vec<u8>), StorageError> {
-        let shard_id: ShardId = self.flat_storage_chunk_view.as_ref().map_or(
-            shard_id_max(), // Fake value for metrics.
+        let shard_id: ShardId = self.flat_storage_chunk_view.as_ref().map_or_else(
+            shard_id_max, // Fake value for metrics.
             |chunk_view| chunk_view.shard_uid().shard_id(),
         );
         let _span = tracing::debug_span!(
@@ -182,8 +182,8 @@ impl Trie {
         nibbles_end: Vec<u8>,
         state_trie: &Trie,
     ) -> Result<PartialState, StorageError> {
-        let shard_id: ShardId = self.flat_storage_chunk_view.as_ref().map_or(
-            shard_id_max(), // Fake value for metrics.
+        let shard_id: ShardId = self.flat_storage_chunk_view.as_ref().map_or_else(
+            shard_id_max, // Fake value for metrics.
             |chunk_view| chunk_view.shard_uid().shard_id(),
         );
         let _span = tracing::debug_span!(

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -30,7 +30,7 @@ use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::state::FlatStateValue;
 use near_primitives::state_part::PartId;
 use near_primitives::state_record::is_contract_code_key;
-use near_primitives::types::{ShardId, StateRoot};
+use near_primitives::types::{shard_id_max, ShardId, StateRoot};
 use near_vm_runner::ContractCode;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -129,7 +129,7 @@ impl Trie {
         part_id: PartId,
     ) -> Result<(PartialState, Vec<u8>, Vec<u8>), StorageError> {
         let shard_id: ShardId = self.flat_storage_chunk_view.as_ref().map_or(
-            ShardId::MAX, // Fake value for metrics.
+            shard_id_max(), // Fake value for metrics.
             |chunk_view| chunk_view.shard_uid().shard_id(),
         );
         let _span = tracing::debug_span!(
@@ -183,7 +183,7 @@ impl Trie {
         state_trie: &Trie,
     ) -> Result<PartialState, StorageError> {
         let shard_id: ShardId = self.flat_storage_chunk_view.as_ref().map_or(
-            ShardId::MAX, // Fake value for metrics.
+            shard_id_max(), // Fake value for metrics.
             |chunk_view| chunk_view.shard_uid().shard_id(),
         );
         let _span = tracing::debug_span!(

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -10,7 +10,7 @@ use near_o11y::metrics::prometheus::core::{GenericCounter, GenericGauge};
 use near_primitives::challenge::PartialState;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardUId;
-use near_primitives::types::ShardId;
+use near_primitives::types::{shard_id_as_u64, ShardId};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
@@ -103,7 +103,7 @@ impl TrieCacheInner {
         assert!(total_size_limit > 0);
         // `itoa` is much faster for printing shard_id to a string than trivial alternatives.
         let mut buffer = itoa::Buffer::new();
-        let shard_id_str = buffer.format(shard_id);
+        let shard_id_str = buffer.format(shard_id_as_u64(shard_id));
 
         let metrics_labels: [&str; 2] = [&shard_id_str, if is_view { "1" } else { "0" }];
         let metrics = TrieCacheMetrics {

--- a/runtime/runtime/src/congestion_control.rs
+++ b/runtime/runtime/src/congestion_control.rs
@@ -9,7 +9,7 @@ use near_primitives::receipt::{
     Receipt, ReceiptEnum, ReceiptOrStateStoredReceipt, StateStoredReceipt,
     StateStoredReceiptMetadata,
 };
-use near_primitives::types::{new_shard_id_tmp, EpochInfoProvider, Gas, ShardId};
+use near_primitives::types::{shard_id_as_u16, EpochInfoProvider, Gas, ShardId};
 use near_primitives::version::ProtocolFeature;
 use near_store::trie::receipts_column_helper::{
     DelayedReceiptQueue, ReceiptIterator, ShardsOutgoingReceiptBuffer, TrieQueue,
@@ -460,7 +460,7 @@ pub fn bootstrap_congestion_info(
         // It is also irrelevant, since the bootstrapped value is only used at
         // the start of applying a chunk on this shard. Other shards will only
         // see and act on the first congestion info after that.
-        allowed_shard: new_shard_id_tmp(shard_id) as u16,
+        allowed_shard: shard_id_as_u16(shard_id),
     }))
 }
 

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -26,7 +26,8 @@ use near_primitives::transaction::{
 };
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{
-    Balance, Compute, EpochInfoProvider, Gas, MerkleHash, ShardId, StateChangeCause,
+    new_shard_id_tmp, shard_id_as_u32, Balance, Compute, EpochInfoProvider, Gas, MerkleHash,
+    ShardId, StateChangeCause,
 };
 use near_primitives::utils::create_receipt_id_from_transaction;
 use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
@@ -1247,9 +1248,9 @@ fn test_congestion_buffering() {
     // shard 0. Hence all receipts will be forwarded to shard 0. We don't
     // want local forwarding in the test, hence we need to use a different
     // shard id.
-    let local_shard = 1 as ShardId;
-    let local_shard_uid = ShardUId { version: 0, shard_id: local_shard as u32 };
-    let receiver_shard = 0 as ShardId;
+    let local_shard = new_shard_id_tmp(1);
+    let local_shard_uid = ShardUId { version: 0, shard_id: shard_id_as_u32(local_shard) };
+    let receiver_shard = new_shard_id_tmp(0);
 
     let initial_balance = to_yocto(1_000_000);
     let initial_locked = to_yocto(500_000);

--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -10,7 +10,7 @@ use near_primitives::shard_layout::ShardUId;
 use near_primitives::state_record::{state_record_to_account_id, StateRecord};
 use near_primitives::test_utils::MockEpochInfoProvider;
 use near_primitives::transaction::{ExecutionOutcomeWithId, SignedTransaction};
-use near_primitives::types::{AccountId, AccountInfo, Balance};
+use near_primitives::types::{new_shard_id_tmp, AccountId, AccountInfo, Balance};
 use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_primitives_core::account::id::AccountIdRef;
 use near_store::genesis::GenesisStateApplier;
@@ -81,7 +81,8 @@ impl StandaloneRuntime {
             account_ids.insert(state_record_to_account_id(record).clone());
         });
         let writers = std::sync::atomic::AtomicUsize::new(0);
-        let shard_uid = ShardUId::from_shard_id_and_layout(0, &genesis.config.shard_layout);
+        let shard_uid =
+            ShardUId::from_shard_id_and_layout(new_shard_id_tmp(0), &genesis.config.shard_layout);
         let root = GenesisStateApplier::apply(
             &writers,
             tries.clone(),


### PR DESCRIPTION
More of the same. I added a rust feature to quickly switch between the old and new shard ids to speed up work. 

No interesting changes here, just syntax everywhere. I hope. 