### PR TITLE
fix(ping): prepend "near_" to metric names

### DIFF
--- a/tools/ping/src/metrics.rs
+++ b/tools/ping/src/metrics.rs
@@ -6,7 +6,7 @@ use std::sync::LazyLock;
 
 pub(crate) static PONG_RECEIVED: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
-        "ping_pong_received",
+        "near_ping_pong_received",
         "Round-trip time of ping-pong",
         &["chain_id", "account_id"],
         Some(exponential_buckets(0.00001, 1.6, 40).unwrap()),
@@ -16,7 +16,7 @@ pub(crate) static PONG_RECEIVED: LazyLock<HistogramVec> = LazyLock::new(|| {
 
 pub(crate) static PONG_TIMEOUTS: LazyLock<IntCounterVec> = LazyLock::new(|| {
     try_create_int_counter_vec(
-        "ping_pong_timeout",
+        "near_ping_pong_timeout",
         "Number of pongs that were not received",
         &["chain_id", "account_id"],
     )
@@ -25,7 +25,7 @@ pub(crate) static PONG_TIMEOUTS: LazyLock<IntCounterVec> = LazyLock::new(|| {
 
 pub(crate) static PING_SENT: LazyLock<IntCounterVec> = LazyLock::new(|| {
     try_create_int_counter_vec(
-        "ping_ping_sent",
+        "near_ping_ping_sent",
         "Number of pings sent",
         &["chain_id", "account_id"],
     )


### PR DESCRIPTION
The ping tool currently crashes when initializing these metrics because the names starting with "near_" is now enforced with a panic