### PR TITLE
[EpochSync] Cache epoch sync proof in memory for multiple requests.

### DIFF
--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -445,6 +445,15 @@ pub(crate) fn export_version(neard_version: &near_primitives::version::Version) 
         .inc();
 }
 
+pub(crate) static EPOCH_SYNC_LAST_GENERATED_COMPRESSED_PROOF_SIZE: LazyLock<IntGauge> =
+    LazyLock::new(|| {
+        try_create_int_gauge(
+            "near_epoch_sync_last_generated_compressed_proof_size",
+            "Size of the last generated compressed epoch sync proof, in bytes",
+        )
+        .unwrap()
+    });
+
 pub(crate) static STATE_SYNC_STAGE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
     try_create_int_gauge_vec(
         "near_state_sync_stage",

--- a/integration-tests/src/test_loop/tests/epoch_sync.rs
+++ b/integration-tests/src/test_loop/tests/epoch_sync.rs
@@ -21,6 +21,7 @@ use near_network::types::{HighestHeightPeerInfo, NetworkInfo, PeerInfo};
 use near_primitives::block::GenesisId;
 use near_primitives::epoch_sync::EpochSyncProof;
 use near_primitives::hash::CryptoHash;
+use near_primitives::utils::compression::CompressedData;
 use near_store::test_utils::create_test_store;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -281,7 +282,7 @@ fn test_epoch_sync_from_another_epoch_synced_node() {
 impl TestNetworkSetup {
     fn derive_epoch_sync_proof(&self, node_index: usize) -> EpochSyncProof {
         let store = self.stores[node_index].clone();
-        EpochSync::derive_epoch_sync_proof(store).unwrap()
+        EpochSync::derive_epoch_sync_proof(store, Default::default()).unwrap().decode().unwrap().0
     }
 
     fn chain_final_head_height(&self, node_index: usize) -> u64 {


### PR DESCRIPTION
It's a very simple cache. We only cache the most recent epoch sync proof, in compressed format. The key of the cache is the EpochId. So whenever the EpochId changes, we recompute it.

Why don't we just store this on disk instead? It's unnecessary, and introduces more state to keep. Deriving the proof is not very expensive anyway (maybe a couple of seconds).