### PR TITLE
test: warmup before tx execution

### DIFF
--- a/pytest/tests/sanity/rpc_state_changes.py
+++ b/pytest/tests/sanity/rpc_state_changes.py
@@ -15,7 +15,7 @@ import deepdiff
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 from cluster import start_cluster
 from key import Key
-from utils import load_test_contract
+from utils import load_test_contract, wait_for_blocks
 import transaction
 
 nodes = start_cluster(
@@ -71,6 +71,7 @@ def test_changes_with_new_account_with_access_key():
         balance=10**24,
         nonce=7,
         block_hash=latest_block_hash)
+    wait_for_blocks(nodes[0], target=5)
     new_account_response = nodes[0].send_tx_and_wait(create_account_tx, 10)
 
     # Step 2


### PR DESCRIPTION
https://nayduck.nearone.org/#/test/117339 was flaky on some run.
The failure happens because of ShardStuck error for the single shard we have.
Looks like it is specific to the height 3, where there is a high probability that no chunks can be produced which triggers ShardStuck.
But if we wait for height 5, everything is fine.

Another finding: sometimes `load_test_contract` seems to serve as an unintended delay to ensure warmup. In some of the cases we do `time.sleep` or `wait_for_blocks` as well.