### PR TITLE
feat(resharding) - Resharding mapping state update

### DIFF
--- a/core/store/src/adapter/trie_store.rs
+++ b/core/store/src/adapter/trie_store.rs
@@ -106,12 +106,14 @@ impl<'a> TrieStoreUpdateAdapter<'a> {
         hash: &CryptoHash,
         decrement: NonZero<u32>,
     ) {
-        let key = get_key_from_shard_uid_and_hash(shard_uid, hash);
+        let mapped_shard_uid = self.read_shard_uid_mapping_from_db(shard_uid)?;
+        let key = get_key_from_shard_uid_and_hash(mapped_shard_uid, hash);
         self.store_update.decrement_refcount_by(DBCol::State, key.as_ref(), decrement);
     }
 
     pub fn decrement_refcount(&mut self, shard_uid: ShardUId, hash: &CryptoHash) {
-        let key = get_key_from_shard_uid_and_hash(shard_uid, hash);
+        let mapped_shard_uid = self.read_shard_uid_mapping_from_db(shard_uid)?;
+        let key = get_key_from_shard_uid_and_hash(mapped_shard_uid, hash);
         self.store_update.decrement_refcount(DBCol::State, key.as_ref());
     }
 
@@ -122,7 +124,8 @@ impl<'a> TrieStoreUpdateAdapter<'a> {
         data: &[u8],
         decrement: NonZero<u32>,
     ) {
-        let key = get_key_from_shard_uid_and_hash(shard_uid, hash);
+        let mapped_shard_uid = self.read_shard_uid_mapping_from_db(shard_uid)?;
+        let key = get_key_from_shard_uid_and_hash(mapped_shard_uid, hash);
         self.store_update.increment_refcount_by(DBCol::State, key.as_ref(), data, decrement);
     }
 

--- a/core/store/src/adapter/trie_store.rs
+++ b/core/store/src/adapter/trie_store.rs
@@ -11,8 +11,8 @@ use crate::{DBCol, KeyForStateChanges, Store, StoreUpdate, TrieChanges, STATE_SN
 
 use super::{StoreAdapter, StoreUpdateAdapter, StoreUpdateHolder};
 
-/// Accesses to State column should use mapped ShardUId (either itself or ancestor in the resharding tree),
-/// according to State mapping strategy introduced in Resharding V3.
+/// Accesses to the State column should use the mapped ShardUId (either itself or ancestor in the resharding tree),
+/// according to the State mapping strategy introduced in Resharding V3.
 pub struct MappedShardUId(ShardUId);
 
 #[derive(Clone)]

--- a/core/store/src/adapter/trie_store.rs
+++ b/core/store/src/adapter/trie_store.rs
@@ -172,8 +172,8 @@ impl<'a> TrieStoreUpdateAdapter<'a> {
         )
     }
 
-    /// Reads shard_uid mapping for given shard.
-    /// If the mapping does not exist, it means that `shard_uid` maps to itself.
+    /// Set the mapping from `child_shard_uid` to `parent_shard_uid`.
+    /// Used by Resharding V3 for State mapping.
     #[cfg(test)]
     fn set_shard_uid_mapping(&mut self, child_shard_uid: ShardUId, parent_shard_uid: ShardUId) {
         self.store_update.set(
@@ -289,7 +289,7 @@ mod tests {
             store_update.increment_refcount_by(child_shard, &dummy_hash, &[0], ONE);
             store_update.commit().unwrap();
         }
-        // The data is not visible at both shards again.
+        // The data is now visible at both shards again.
         assert_eq!(*store.get(child_shard, &dummy_hash).unwrap(), [0]);
         assert_eq!(*store.get(parent_shard, &dummy_hash).unwrap(), [0]);
     }

--- a/core/store/src/cold_storage.rs
+++ b/core/store/src/cold_storage.rs
@@ -326,6 +326,7 @@ pub fn copy_all_data_to_cold(
                     tracing::debug!(target: "cold_store", "stopping copy_all_data_to_cold");
                     return Ok(CopyAllDataToColdStatus::Interrupted);
                 }
+                // TODO(reshardingV3) Should do mapping here?
                 let (key, value) = result?;
                 transaction.set_and_write_if_full(col, key.to_vec(), value.to_vec())?;
             }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -735,7 +735,6 @@ impl StoreUpdate {
                 }
             }
         }
-        // TODO(reshardingV3) Map shard_uid for ops referencing State column.
         self.storage.write(self.transaction)
     }
 }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -327,7 +327,7 @@ impl Store {
     }
 
     pub fn store_update(&self) -> StoreUpdate {
-        StoreUpdate { transaction: DBTransaction::new(), storage: Arc::clone(&self.storage) }
+        StoreUpdate { transaction: DBTransaction::new(), store: self.clone() }
     }
 
     pub fn iter<'a>(&'a self, col: DBCol) -> DBIterator<'a> {
@@ -459,7 +459,7 @@ impl Store {
 /// Keeps track of current changes to the database and can commit all of them to the database.
 pub struct StoreUpdate {
     transaction: DBTransaction,
-    storage: Arc<dyn Database>,
+    store: Store,
 }
 
 impl StoreUpdateAdapter for StoreUpdate {
@@ -618,7 +618,10 @@ impl StoreUpdate {
     ///
     /// Panics if `self`’s and `other`’s storage are incompatible.
     pub fn merge(&mut self, other: StoreUpdate) {
-        assert!(core::ptr::addr_eq(Arc::as_ptr(&self.storage), Arc::as_ptr(&other.storage)));
+        assert!(core::ptr::addr_eq(
+            Arc::as_ptr(&self.store.storage),
+            Arc::as_ptr(&other.store.storage)
+        ));
         self.transaction.merge(other.transaction)
     }
 
@@ -735,7 +738,7 @@ impl StoreUpdate {
                 }
             }
         }
-        self.storage.write(self.transaction)
+        self.store.storage.write(self.transaction)
     }
 }
 

--- a/nearcore/src/entity_debug.rs
+++ b/nearcore/src/entity_debug.rs
@@ -33,9 +33,7 @@ use near_primitives::views::{
     BlockHeaderView, BlockView, ChunkView, ExecutionOutcomeView, ReceiptView, SignedTransactionView,
 };
 use near_store::adapter::flat_store::encode_flat_state_db_key;
-use near_store::adapter::trie_store::{
-    get_key_from_shard_uid_and_hash, read_shard_uid_mapping_from_db,
-};
+use near_store::adapter::trie_store::{get_key_from_shard_uid_and_hash, get_mapped_shard_uid};
 use near_store::db::GENESIS_CONGESTION_INFO_KEY;
 use near_store::flat::delta::KeyForFlatStateDelta;
 use near_store::flat::{FlatStateChanges, FlatStateDeltaMetadata, FlatStorageStatus};
@@ -250,7 +248,7 @@ impl EntityDebugHandlerImpl {
                 Ok(serialize_entity(&ExecutionOutcomeView::from(outcome.outcome)))
             }
             EntityQuery::RawTrieNodeByHash { trie_node_hash, shard_uid } => {
-                let mapped_shard_uid = read_shard_uid_mapping_from_db(&store, shard_uid);
+                let mapped_shard_uid = get_mapped_shard_uid(&store, shard_uid);
                 let key = get_key_from_shard_uid_and_hash(mapped_shard_uid, &trie_node_hash);
                 let node = store
                     .get_ser::<RawTrieNodeWithSize>(DBCol::State, &key)?
@@ -270,7 +268,7 @@ impl EntityDebugHandlerImpl {
                     .shard_uids()
                     .nth(shard_index)
                     .ok_or_else(|| anyhow!("Shard {} not found", chunk.shard_id()))?;
-                let mapped_shard_uid = read_shard_uid_mapping_from_db(&store, shard_uid);
+                let mapped_shard_uid = get_mapped_shard_uid(&store, shard_uid);
                 let key =
                     get_key_from_shard_uid_and_hash(mapped_shard_uid, &chunk.prev_state_root());
                 let node = store
@@ -279,7 +277,7 @@ impl EntityDebugHandlerImpl {
                 Ok(serialize_raw_trie_node(node))
             }
             EntityQuery::RawTrieValueByHash { trie_value_hash, shard_uid } => {
-                let mapped_shard_uid = read_shard_uid_mapping_from_db(&store, shard_uid);
+                let mapped_shard_uid = get_mapped_shard_uid(&store, shard_uid);
                 let key = get_key_from_shard_uid_and_hash(mapped_shard_uid, &trie_value_hash);
                 let value = store
                     .get(DBCol::State, &key)?
@@ -459,7 +457,7 @@ impl EntityDebugHandlerImpl {
         state: FlatStateValue,
         shard_uid: ShardUId,
     ) -> anyhow::Result<Vec<u8>> {
-        let mapped_shard_uid = read_shard_uid_mapping_from_db(&store, shard_uid);
+        let mapped_shard_uid = get_mapped_shard_uid(&store, shard_uid);
         Ok(match state {
             FlatStateValue::Ref(value) => store
                 .get(DBCol::State, &get_key_from_shard_uid_and_hash(mapped_shard_uid, &value.hash))?


### PR DESCRIPTION
The [previous PR](https://github.com/near/nearcore/pull/12084) introduced mapping for read operations.

This PR extends that functionality to write operations and adds some testing for State mapping.

Following the [Zulip discussion](https://near.zulipchat.com/#narrow/stream/407288-core.2Fresharding/topic/State.20mapping/near/476959235), we decided to implement a panic inside the `TrieStoreUpdateAdapter` methods. Other strategies considered were:
1. Propagating the error instead of panicking: This was rejected because the error would need to be propagated through multiple layers that currently don't expect errors. Additionally, an error here would indicate a misconfiguration in the database, justifying the use of panic.
2. Performing the mapping later in `TrieStoreUpdateAdapter::commit()`: This would require iterating through all `DBOp`s, parsing each operation, extracting the `shard_uid` from the database key, mapping it, and re-encoding. This approach would make `TrieStoreUpdateAdapter` dependent on the internal workings of `DBTransaction`. Also, `StoreUpdate::merge()` makes me feel uneasy.