### PR TITLE
test(resharding): skipped chunks on protocol upgrade

### DIFF
--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -152,7 +152,7 @@ impl InfoHelper {
         let me = validator_signer.as_ref().map(|x| x.validator_id());
         for shard_id in shard_layout.shard_ids() {
             let tracked =
-                client.shard_tracker.care_about_shard(me, &head.last_block_hash, shard_id, true);
+                client.shard_tracker.care_about_shard(me, &head.prev_block_hash, shard_id, true);
             metrics::TRACKED_SHARDS.with_label_values(&[&shard_id.to_string()]).set(if tracked {
                 1
             } else {

--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -87,7 +87,7 @@ pub(crate) struct TestLoopBuilder {
     track_all_shards: bool,
 }
 
-// Checks whether chunk is validated by the given account.
+/// Checks whether chunk is validated by the given account.
 fn is_chunk_validated_by(
     epoch_manager_adapter: Arc<dyn EpochManagerAdapter>,
     chunk: ShardChunkHeader,

--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -132,7 +132,7 @@ fn should_drop_chunk_for_protocol_upgrade(
         let epoch_start_height =
             epoch_manager_adapter.get_epoch_start_height(&prev_block_hash).unwrap();
         range.contains(&(height_created as i64 - epoch_start_height as i64))
-    } else if epoch_protocol_version < protocol_version {
+    } else if epoch_protocol_version + 1 == protocol_version {
         // Drop condition for the last epoch with old protocol version.
         let maybe_upgrade_height = epoch_manager_adapter
             .get_estimated_protocol_upgrade_block_height(*prev_block_hash)

--- a/integration-tests/src/test_loop/utils/network.rs
+++ b/integration-tests/src/test_loop/utils/network.rs
@@ -12,7 +12,7 @@ type DropChunkCondition = Box<dyn Fn(ShardChunkHeader) -> bool>;
 pub fn partial_encoded_chunks_dropper(
     chunks_storage: Arc<Mutex<TestLoopChunksStorage>>,
     epoch_manager_adapter: Arc<dyn EpochManagerAdapter>,
-    drop_chunks_condition: DropChunkCondition,
+    drop_chunk_condition: DropChunkCondition,
 ) -> Box<dyn Fn(NetworkRequests) -> Option<NetworkRequests>> {
     Box::new(move |request| {
         // Filter out only messages related to distributing chunk in the
@@ -57,7 +57,7 @@ pub fn partial_encoded_chunks_dropper(
             return Some(request);
         };
 
-        if drop_chunks_condition(chunk) {
+        if drop_chunk_condition(chunk) {
             return None;
         }
 


### PR DESCRIPTION
Enhance the test by dropping certain ranges of chunks, based on **height relative to protocol upgrade height**. For example, if upgrade height is 100 and range is `-3..2`, then chunks at heights `97, 98, 99, 100, 101` should be dropped.

This allowed to catch a bug in `InfoHelper`: because inside `cares_about_shard_from_prev_block` is called, previous block should be passed instead of current one. Otherwise shard layout is incorrect.

For now I add a test to skip two chunks just after upgrade. I wanted to add more, but **surprisingly the test starts to fail for various reasons**. I added TODOs and resolve them later.

The main piece of logic is `should_drop_chunk_for_protocol_upgrade`. It is a bit complex because if protocol upgrade didn't happen yet, its height is hard to retrieve. Everything else is necessary refactoring, e.g. uniting all drop conditions under one enum.