### PR TITLE
cleanup(resharding) - remove new_shard_id_tmp

### DIFF
--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -543,7 +543,6 @@ mod tests {
     use near_primitives::merkle::verify_path;
     use near_primitives::test_utils::{create_test_signer, TestBlockBuilder};
     use near_primitives::transaction::{ExecutionMetadata, ExecutionOutcome, ExecutionStatus};
-    use near_primitives::types::new_shard_id_tmp;
     use near_primitives::version::PROTOCOL_VERSION;
     use std::sync::Arc;
 
@@ -551,7 +550,7 @@ mod tests {
 
     #[test]
     fn test_block_produce() {
-        let shard_ids: Vec<_> = (0..32).map(new_shard_id_tmp).collect();
+        let shard_ids: Vec<_> = (0..32).map(ShardId::new).collect();
         let genesis_chunks = genesis_chunks(
             vec![Trie::EMPTY_ROOT],
             vec![Default::default(); shard_ids.len()],

--- a/chain/chunks/src/client.rs
+++ b/chain/chunks/src/client.rs
@@ -164,7 +164,7 @@ mod tests {
         hash::CryptoHash,
         shard_layout::{account_id_to_shard_uid, ShardLayout},
         transaction::SignedTransaction,
-        types::{new_shard_id_tmp, shard_id_as_u32, AccountId, ShardId},
+        types::{shard_id_as_u32, AccountId, ShardId},
     };
     use near_store::ShardUId;
     use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
@@ -178,8 +178,7 @@ mod tests {
         let seed10 = ShardedTransactionPool::random_seed(&TEST_SEED, ShardId::new(10));
         let seed256 = ShardedTransactionPool::random_seed(&TEST_SEED, ShardId::new(256));
         let seed1000 = ShardedTransactionPool::random_seed(&TEST_SEED, ShardId::new(1000));
-        let seed1000000 =
-            ShardedTransactionPool::random_seed(&TEST_SEED, new_shard_id_tmp(1_000_000));
+        let seed1000000 = ShardedTransactionPool::random_seed(&TEST_SEED, ShardId::new(1_000_000));
         assert_ne!(seed0, seed10);
         assert_ne!(seed0, seed256);
         assert_ne!(seed0, seed1000);

--- a/chain/client/src/test_utils/setup.rs
+++ b/chain/client/src/test_utils/setup.rs
@@ -61,9 +61,7 @@ use near_primitives::epoch_info::RngSeed;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::network::PeerId;
 use near_primitives::test_utils::create_test_signer;
-use near_primitives::types::{
-    new_shard_id_tmp, AccountId, BlockHeightDelta, EpochId, NumBlocks, NumSeats,
-};
+use near_primitives::types::{AccountId, BlockHeightDelta, EpochId, NumBlocks, NumSeats, ShardId};
 use near_primitives::validator_signer::{EmptyValidatorSigner, ValidatorSigner};
 use near_primitives::version::PROTOCOL_VERSION;
 use near_store::adapter::StoreAdapter;
@@ -454,10 +452,7 @@ fn process_peer_manager_message_default(
                             height: last_height[i],
                             hash: CryptoHash::default(),
                         }),
-                        tracked_shards: vec![0, 1, 2, 3]
-                            .into_iter()
-                            .map(new_shard_id_tmp)
-                            .collect(),
+                        tracked_shards: vec![0, 1, 2, 3].into_iter().map(ShardId::new).collect(),
                         archival: true,
                     },
                 },

--- a/chain/epoch-manager/src/shard_tracker.rs
+++ b/chain/epoch-manager/src/shard_tracker.rs
@@ -218,9 +218,7 @@ mod tests {
     use near_primitives::hash::CryptoHash;
     use near_primitives::shard_layout::ShardLayout;
     use near_primitives::types::validator_stake::ValidatorStake;
-    use near_primitives::types::{
-        new_shard_id_tmp, BlockHeight, EpochId, NumShards, ProtocolVersion, ShardId,
-    };
+    use near_primitives::types::{BlockHeight, EpochId, NumShards, ProtocolVersion, ShardId};
     use near_primitives::version::ProtocolFeature::SimpleNightshade;
     use near_primitives::version::PROTOCOL_VERSION;
     use near_store::test_utils::create_test_store;
@@ -339,7 +337,7 @@ mod tests {
 
     #[test]
     fn test_track_accounts() {
-        let shard_ids = (0..4).map(new_shard_id_tmp).collect_vec();
+        let shard_ids = (0..4).map(ShardId::new).collect_vec();
         let epoch_manager =
             get_epoch_manager(PROTOCOL_VERSION, shard_ids.len() as NumShards, false);
         let shard_layout = epoch_manager.read().get_shard_layout(&EpochId::default()).unwrap();
@@ -364,7 +362,7 @@ mod tests {
 
     #[test]
     fn test_track_all_shards() {
-        let shard_ids = (0..4).map(new_shard_id_tmp).collect_vec();
+        let shard_ids = (0..4).map(ShardId::new).collect_vec();
         let epoch_manager =
             get_epoch_manager(PROTOCOL_VERSION, shard_ids.len() as NumShards, false);
         let tracker = ShardTracker::new(TrackedConfig::AllShards, Arc::new(epoch_manager));
@@ -383,16 +381,16 @@ mod tests {
     #[test]
     fn test_track_schedule() {
         // Creates a ShardTracker that changes every epoch tracked shards.
-        let shard_ids = (0..4).map(new_shard_id_tmp).collect_vec();
+        let shard_ids = (0..4).map(ShardId::new).collect_vec();
 
         let epoch_manager =
             Arc::new(get_epoch_manager(PROTOCOL_VERSION, shard_ids.len() as NumShards, false));
         let subset1: HashSet<ShardId> =
-            HashSet::from([0, 1]).into_iter().map(new_shard_id_tmp).collect();
+            HashSet::from([0, 1]).into_iter().map(ShardId::new).collect();
         let subset2: HashSet<ShardId> =
-            HashSet::from([1, 2]).into_iter().map(new_shard_id_tmp).collect();
+            HashSet::from([1, 2]).into_iter().map(ShardId::new).collect();
         let subset3: HashSet<ShardId> =
-            HashSet::from([2, 3]).into_iter().map(new_shard_id_tmp).collect();
+            HashSet::from([2, 3]).into_iter().map(ShardId::new).collect();
         let tracker = ShardTracker::new(
             TrackedConfig::Schedule(vec![
                 subset1.clone().into_iter().collect(),

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -18,7 +18,7 @@ use near_primitives::sharding::{
     ChunkHash, EncodedShardChunkBody, PartialEncodedChunkPart, ShardChunk,
 };
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{new_shard_id_tmp, AccountId, BlockHeight, EpochId, StateRoot};
+use near_primitives::types::{AccountId, BlockHeight, EpochId, StateRoot};
 use near_primitives::validator_signer::{InMemoryValidatorSigner, ValidatorSigner};
 use near_primitives::version;
 use rand::distributions::Standard;
@@ -211,7 +211,7 @@ impl ChunkSet {
         Self { chunks: HashMap::default() }
     }
     pub fn make(&mut self) -> Vec<ShardChunk> {
-        let shard_ids: Vec<_> = (0..4).into_iter().map(new_shard_id_tmp).collect();
+        let shard_ids: Vec<_> = (0..4).into_iter().map(ShardId::new).collect();
         // TODO: these are always genesis chunks.
         // Consider making this more realistic.
         let chunks = genesis_chunks(

--- a/chain/network/src/peer_manager/tests/snapshot_hosts.rs
+++ b/chain/network/src/peer_manager/tests/snapshot_hosts.rs
@@ -17,7 +17,6 @@ use near_o11y::testonly::init_test_logger;
 use near_o11y::WithSpanContextExt;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
-use near_primitives::types::new_shard_id_tmp;
 use near_primitives::types::shard_id_as_u64;
 use near_primitives::types::shard_id_max;
 use near_primitives::types::EpochHeight;
@@ -39,7 +38,7 @@ fn make_snapshot_host_info(
     let max_shard_id = 32;
     let shards_num: usize = rng.gen_range(1..16);
     let shards = (0..max_shard_id).choose_multiple(rng, shards_num);
-    let shards = shards.into_iter().sorted().map(new_shard_id_tmp).collect();
+    let shards = shards.into_iter().sorted().map(ShardId::new).collect();
     let sync_hash = CryptoHash::hash_borsh(epoch_height);
     Arc::new(SnapshotHostInfo::new(peer_id.clone(), sync_hash, epoch_height, shards, secret_key))
 }
@@ -375,7 +374,7 @@ async fn large_shard_id_in_cache() {
     tracing::info!(target:"test", "Send a SnapshotHostInfo message with very large shard ids.");
     let max_shard_id = shard_id_max();
     let max_shard_id_minus_one = shard_id_as_u64(max_shard_id) - 1;
-    let max_shard_id_minus_one = new_shard_id_tmp(max_shard_id_minus_one);
+    let max_shard_id_minus_one = ShardId::new(max_shard_id_minus_one);
     let big_shard_info = Arc::new(SnapshotHostInfo::new(
         peer1_config.node_id(),
         CryptoHash::hash_borsh(1234_u64),

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -58,15 +58,8 @@ pub type ShardIndex = usize;
 // TODO(wacban) This is a temporary solution to aid the transition to having
 // ShardId as a newtype. It should be replaced / removed / inlined once the
 // transition is complete.
-pub const fn new_shard_id_tmp(id: u64) -> ShardId {
-    return ShardId::new(id);
-}
-
-// TODO(wacban) This is a temporary solution to aid the transition to having
-// ShardId as a newtype. It should be replaced / removed / inlined once the
-// transition is complete.
 pub fn new_shard_id_vec_tmp(vec: &[u64]) -> Vec<ShardId> {
-    vec.iter().copied().map(new_shard_id_tmp).collect()
+    vec.iter().copied().map(ShardId::new).collect()
 }
 
 pub fn shard_id_max() -> ShardId {

--- a/core/primitives/src/congestion_info.rs
+++ b/core/primitives/src/congestion_info.rs
@@ -501,7 +501,6 @@ impl ShardAcceptsTransactions {
 mod tests {
     use itertools::Itertools;
     use near_parameters::RuntimeConfigStore;
-    use near_primitives_core::types::new_shard_id_tmp;
     use near_primitives_core::version::{ProtocolFeature, PROTOCOL_VERSION};
 
     use super::*;
@@ -812,7 +811,7 @@ mod tests {
         info.add_buffered_receipt_gas(config.max_congestion_outgoing_gas / 2).unwrap();
 
         let shard = ShardId::new(2);
-        let all_shards = [0, 1, 2, 3, 4].into_iter().map(new_shard_id_tmp).collect_vec();
+        let all_shards = [0, 1, 2, 3, 4].into_iter().map(ShardId::new).collect_vec();
 
         // Test without missed chunks congestion.
 

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -3,7 +3,7 @@ use crate::types::{AccountId, NumShards};
 use borsh::{BorshDeserialize, BorshSerialize};
 use itertools::Itertools;
 use near_primitives_core::types::{
-    new_shard_id_tmp, shard_id_as_u32, shard_id_as_u64, shard_id_as_usize, ShardId, ShardIndex,
+    shard_id_as_u32, shard_id_as_u64, shard_id_as_usize, ShardId, ShardIndex,
 };
 use near_schema_checker_lib::ProtocolSchema;
 use std::collections::BTreeMap;
@@ -263,7 +263,7 @@ impl ShardLayout {
             let mut to_parent_shard_map = BTreeMap::new();
             let num_shards = (boundary_accounts.len() + 1) as NumShards;
             for (parent_shard_id, shard_ids) in shards_split_map.iter().enumerate() {
-                let parent_shard_id = new_shard_id_tmp(parent_shard_id as u64);
+                let parent_shard_id = ShardId::new(parent_shard_id as u64);
                 for &shard_id in shard_ids {
                     let prev = to_parent_shard_map.insert(shard_id, parent_shard_id);
                     assert!(prev.is_none(), "no shard should appear in the map twice");
@@ -562,8 +562,8 @@ impl ShardLayout {
     /// identify the shard and starting from the ShardLayoutV2 it is unique.
     pub fn get_shard_id(&self, shard_index: ShardIndex) -> ShardId {
         match self {
-            Self::V0(_) => new_shard_id_tmp(shard_index as u64),
-            Self::V1(_) => new_shard_id_tmp(shard_index as u64),
+            Self::V0(_) => ShardId::new(shard_index as u64),
+            Self::V1(_) => ShardId::new(shard_index as u64),
             Self::V2(v2) => v2.index_to_id_map[&shard_index],
         }
     }
@@ -800,7 +800,7 @@ mod tests {
         ShardLayoutV1, ShardUId,
     };
     use itertools::Itertools;
-    use near_primitives_core::types::{new_shard_id_tmp, shard_id_as_u64, ProtocolVersion};
+    use near_primitives_core::types::{shard_id_as_u64, ProtocolVersion};
     use near_primitives_core::types::{AccountId, ShardId};
     use near_primitives_core::version::{ProtocolFeature, PROTOCOL_VERSION};
     use rand::distributions::Alphanumeric;
@@ -894,7 +894,7 @@ mod tests {
     #[test]
     fn test_shard_layout_v1() {
         let aid = |s: &str| s.parse().unwrap();
-        let sid = |s: u64| new_shard_id_tmp(s);
+        let sid = |s: u64| ShardId::new(s);
 
         let shard_layout = ShardLayout::v1(
             parse_account_ids(&["aurora", "bar", "foo", "foo.baz", "paz"]),
@@ -910,8 +910,8 @@ mod tests {
             (3..6).map(|x| ShardUId { version: 1, shard_id: x }).collect::<Vec<_>>()
         );
         for x in 0..3 {
-            assert_eq!(shard_layout.get_parent_shard_id(new_shard_id_tmp(x)).unwrap(), sid(0));
-            assert_eq!(shard_layout.get_parent_shard_id(new_shard_id_tmp(x + 3)).unwrap(), sid(1));
+            assert_eq!(shard_layout.get_parent_shard_id(ShardId::new(x)).unwrap(), sid(0));
+            assert_eq!(shard_layout.get_parent_shard_id(ShardId::new(x + 3)).unwrap(), sid(1));
         }
 
         assert_eq!(account_id_to_shard_id(&aid("aurora"), &shard_layout), sid(1));
@@ -961,7 +961,7 @@ mod tests {
 
     #[test]
     fn test_shard_layout_v2() {
-        let sid = |s: u64| new_shard_id_tmp(s);
+        let sid = |s: u64| ShardId::new(s);
         let shard_layout = get_test_shard_layout_v2();
 
         // check accounts mapping in the middle of each range

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -19,8 +19,7 @@ use near_primitives::shard_layout::{account_id_to_shard_id, ShardUId};
 use near_primitives::state_record::StateRecord;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{
-    new_shard_id_tmp, shard_id_as_u32, AccountId, Balance, EpochId, ShardId, StateChangeCause,
-    StateRoot,
+    shard_id_as_u32, AccountId, Balance, EpochId, ShardId, StateChangeCause, StateRoot,
 };
 use near_primitives::utils::to_timestamp;
 use near_primitives::version::ProtocolFeature;
@@ -139,7 +138,7 @@ impl GenesisBuilder {
             .expect("genesis state roots not initialized.");
         let genesis_shard_version = self.genesis.config.shard_layout.version();
         self.roots =
-            roots.into_iter().enumerate().map(|(k, v)| (new_shard_id_tmp(k as u64), v)).collect();
+            roots.into_iter().enumerate().map(|(k, v)| (ShardId::new(k as u64), v)).collect();
         self.state_updates = self
             .roots
             .iter()

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -40,8 +40,8 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::{
-    new_shard_id_tmp, AccountId, AccountInfo, Balance, BlockHeight, BlockHeightDelta, Gas,
-    NumSeats, NumShards, ShardId,
+    AccountId, AccountInfo, Balance, BlockHeight, BlockHeightDelta, Gas, NumSeats, NumShards,
+    ShardId,
 };
 use near_primitives::utils::{from_timestamp, get_num_seats_per_shard};
 use near_primitives::validator_signer::{InMemoryValidatorSigner, ValidatorSigner};
@@ -1204,7 +1204,7 @@ fn create_localnet_config(
     // Make non-validator archival and RPC nodes track all shards.
     // Note that validator nodes may track all or some of the shards.
     config.tracked_shards = if !params.is_validator && (params.is_archival || params.is_rpc) {
-        (0..num_shards).map(new_shard_id_tmp).collect()
+        (0..num_shards).map(ShardId::new).collect()
     } else {
         tracked_shards.clone()
     };
@@ -1522,7 +1522,7 @@ mod tests {
     use near_chain_configs::{GCConfig, Genesis, GenesisValidationMode};
     use near_crypto::InMemorySigner;
     use near_primitives::shard_layout::account_id_to_shard_id;
-    use near_primitives::types::{new_shard_id_tmp, AccountId, NumShards, ShardId};
+    use near_primitives::types::{AccountId, NumShards, ShardId};
     use tempfile::tempdir;
 
     use crate::config::{
@@ -1748,7 +1748,7 @@ mod tests {
             );
             assert_eq!(
                 config.tracked_shards,
-                (0..num_shards).map(new_shard_id_tmp).collect::<Vec<_>>()
+                (0..num_shards).map(ShardId::new).collect::<Vec<_>>()
             );
         }
 
@@ -1760,7 +1760,7 @@ mod tests {
             assert!(config.split_storage.is_none());
             assert_eq!(
                 config.tracked_shards,
-                (0..num_shards).map(new_shard_id_tmp).collect::<Vec<_>>()
+                (0..num_shards).map(ShardId::new).collect::<Vec<_>>()
             );
         }
 
@@ -1831,7 +1831,7 @@ mod tests {
             );
             assert_eq!(
                 config.tracked_shards,
-                (0..num_shards).map(new_shard_id_tmp).collect::<Vec<_>>()
+                (0..num_shards).map(ShardId::new).collect::<Vec<_>>()
             );
         }
 
@@ -1843,7 +1843,7 @@ mod tests {
             assert!(config.split_storage.is_none());
             assert_eq!(
                 config.tracked_shards,
-                (0..num_shards).map(new_shard_id_tmp).collect::<Vec<_>>()
+                (0..num_shards).map(ShardId::new).collect::<Vec<_>>()
             );
         }
 


### PR DESCRIPTION
Removing the remaining usages of new_shard_id_tmp and replacing it with ShardId::new. Removed the new_shard_id_tmp too. 