### PR TITLE
feat: use T1 for when distribution chunk witness contracts messages

### DIFF
--- a/chain/network/src/peer_manager/connection/mod.rs
+++ b/chain/network/src/peer_manager/connection/mod.rs
@@ -47,14 +47,16 @@ impl tcp::Tier {
         }
     }
 
-    // TODO(#11099): Revisit here for contract code distribution messages.
     pub(crate) fn is_allowed_routed(self, body: &RoutedMessageBody) -> bool {
         match body {
             RoutedMessageBody::BlockApproval(..)
             | RoutedMessageBody::ChunkEndorsement(..)
             | RoutedMessageBody::PartialEncodedStateWitness(..)
             | RoutedMessageBody::PartialEncodedStateWitnessForward(..)
-            | RoutedMessageBody::VersionedPartialEncodedChunk(..) => true,
+            | RoutedMessageBody::VersionedPartialEncodedChunk(..)
+            | RoutedMessageBody::ChunkContractAccesses(_)
+            | RoutedMessageBody::ContractCodeRequest(_)
+            | RoutedMessageBody::ContractCodeResponse(_) => true,
             _ => self == tcp::Tier::T2,
         }
     }


### PR DESCRIPTION
Witness contracts distribution messages are as latency sensitive as `PartialEncodedStateWitness` and `PartialEncodedStateWitnessForward`, so we want to use T1 for those as well.