### PR TITLE
feat: add metrics around witness contracts distribution

### DIFF
--- a/chain/chain/src/stateless_validation/metrics.rs
+++ b/chain/chain/src/stateless_validation/metrics.rs
@@ -14,6 +14,7 @@ pub static SAVE_LATEST_WITNESS_GENERATE_UPDATE_TIME: LazyLock<HistogramVec> = La
     )
     .unwrap()
 });
+
 pub static SAVE_LATEST_WITNESS_COMMIT_UPDATE_TIME: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
         "near_save_latest_witness_commit_update_time",
@@ -23,6 +24,7 @@ pub static SAVE_LATEST_WITNESS_COMMIT_UPDATE_TIME: LazyLock<HistogramVec> = Lazy
     )
     .unwrap()
 });
+
 pub static SAVED_LATEST_WITNESSES_COUNT: LazyLock<IntGauge> = LazyLock::new(|| {
     try_create_int_gauge(
         "near_saved_latest_witnesses_count",
@@ -30,6 +32,7 @@ pub static SAVED_LATEST_WITNESSES_COUNT: LazyLock<IntGauge> = LazyLock::new(|| {
     )
     .unwrap()
 });
+
 pub static SAVED_LATEST_WITNESSES_SIZE: LazyLock<IntGauge> = LazyLock::new(|| {
     try_create_int_gauge(
         "near_saved_latest_witnesses_size",

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -1,8 +1,8 @@
 use near_o11y::metrics::{
-    exponential_buckets, linear_buckets, try_create_counter, try_create_gauge,
-    try_create_histogram, try_create_histogram_vec, try_create_int_counter,
-    try_create_int_counter_vec, try_create_int_gauge, try_create_int_gauge_vec, Counter, Gauge,
-    Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
+    exponential_buckets, linear_buckets, try_create_counter, try_create_counter_vec,
+    try_create_gauge, try_create_histogram, try_create_histogram_vec, try_create_int_counter,
+    try_create_int_counter_vec, try_create_int_gauge, try_create_int_gauge_vec, Counter,
+    CounterVec, Gauge, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
 };
 use std::sync::LazyLock;
 
@@ -637,3 +637,35 @@ pub(crate) static PARTIAL_WITNESS_CACHE_SIZE: LazyLock<Gauge> = LazyLock::new(||
     )
     .unwrap()
 });
+
+pub(crate) static RECEIVE_WITNESS_ACCESSED_CONTRACT_CODES_TIME: LazyLock<HistogramVec> =
+    LazyLock::new(|| {
+        try_create_histogram_vec(
+            "near_receive_witness_accessed_contract_codes_time",
+            "Time it takes to retrieve missing contract codes",
+            &["shard_id"],
+            Some(linear_buckets(0.025, 0.025, 40).unwrap()),
+        )
+        .unwrap()
+    });
+
+pub(crate) static WITNESS_ACCESSED_CONTRACT_CODES_DELAY: LazyLock<HistogramVec> =
+    LazyLock::new(|| {
+        try_create_histogram_vec(
+            "near_witness_accessed_contract_codes_delay",
+            "Delay in witness processing caused by waiting for accessed contract codes",
+            &["shard_id"],
+            Some(linear_buckets(0.025, 0.025, 40).unwrap()),
+        )
+        .unwrap()
+    });
+
+pub(crate) static DECODE_PARTIAL_WITNESS_ACCESSED_CONTRACTS_STATE_COUNT: LazyLock<CounterVec> =
+    LazyLock::new(|| {
+        try_create_counter_vec(
+            "near_decode_partial_witness_accessed_contracts_state_count",
+            "State of the accessed contracts when collected enough parts to decode the witness",
+            &["shard_id", "state"],
+        )
+        .unwrap()
+    });


### PR DESCRIPTION
Added metrics should help identify if accessed contracts causing delays in witness processing for chunk validators. 