### PR TITLE
feat(epoch config): refactor epoch config to support test configs

### DIFF
--- a/chain/chain/src/flat_storage_resharder.rs
+++ b/chain/chain/src/flat_storage_resharder.rs
@@ -755,7 +755,7 @@ mod tests {
         let tempdir = tempfile::tempdir().unwrap();
         let store = create_test_store();
         initialize_genesis_state(store.clone(), &genesis, Some(tempdir.path()));
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
         let shard_tracker = ShardTracker::new_empty(epoch_manager.clone());
         let runtime =
             NightshadeRuntime::test(tempdir.path(), store, &genesis.config, epoch_manager.clone());

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -121,7 +121,7 @@ impl TestEnv {
             FilesystemContractRuntimeCache::new(&dir.as_ref(), None::<&str>).unwrap();
 
         initialize_genesis_state(store.clone(), &genesis, Some(dir.path()));
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
         let runtime = NightshadeRuntime::new(
             store.clone(),
             compiled_contract_cache.handle(),
@@ -1546,7 +1546,7 @@ fn test_genesis_hash() {
 
     let tempdir = tempfile::tempdir().unwrap();
     initialize_genesis_state(store.clone(), &genesis, Some(tempdir.path()));
-    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
     let runtime = NightshadeRuntime::test_with_runtime_config_store(
         tempdir.path(),
         store.clone(),

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -411,7 +411,7 @@ mod tests {
         let genesis = Genesis::test(vec!["test".parse().unwrap()], 1);
         let tempdir = tempfile::tempdir().unwrap();
         initialize_genesis_state(store.clone(), &genesis, Some(tempdir.path()));
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
         let shard_tracker = ShardTracker::new_empty(epoch_manager.clone());
         let runtime = NightshadeRuntime::test(
             tempdir.path(),

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -62,7 +62,7 @@ pub fn get_chain_with_epoch_length_and_num_shards(
     let tempdir = tempfile::tempdir().unwrap();
     initialize_genesis_state(store.clone(), &genesis, Some(tempdir.path()));
     let chain_genesis = ChainGenesis::new(&genesis.config);
-    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
     let shard_tracker = ShardTracker::new_empty(epoch_manager.clone());
     let runtime =
         NightshadeRuntime::test(tempdir.path(), store, &genesis.config, epoch_manager.clone());
@@ -147,7 +147,7 @@ pub fn setup_with_tx_validity_period(
     genesis.config.protocol_version = PROTOCOL_VERSION;
     let tempdir = tempfile::tempdir().unwrap();
     initialize_genesis_state(store.clone(), &genesis, Some(tempdir.path()));
-    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
     let shard_tracker = ShardTracker::new_empty(epoch_manager.clone());
     let runtime =
         NightshadeRuntime::test(tempdir.path(), store, &genesis.config, epoch_manager.clone());

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -1000,7 +1000,7 @@ mod tests {
         genesis.config.epoch_length = 123;
         let tempdir = tempfile::tempdir().unwrap();
         initialize_genesis_state(store.clone(), &genesis, Some(tempdir.path()));
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
         let shard_tracker = ShardTracker::new_empty(epoch_manager.clone());
         let runtime =
             NightshadeRuntime::test(tempdir.path(), store, &genesis.config, epoch_manager.clone());

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -32,6 +32,7 @@ use rand::Rng;
 use reward_calculator::ValidatorOnlineThresholds;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::Path;
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use tracing::{debug, warn};
 use validator_stats::{
@@ -191,12 +192,20 @@ impl EpochManager {
         )
     }
 
-    pub fn new_arc_handle(store: Store, genesis_config: &GenesisConfig) -> Arc<EpochManagerHandle> {
+    /// Creates a new instance of `EpochManager` from the given `store`, `genesis_config`, and `home_dir`.
+    /// For production environments such as mainnet ant testnet, the epoch config files will be ignored.
+    /// In the test environment, the epoch config files will be loaded from the `home_dir` if it is not `None`.
+    pub fn new_arc_handle(
+        store: Store,
+        genesis_config: &GenesisConfig,
+        home_dir: Option<&Path>,
+    ) -> Arc<EpochManagerHandle> {
         let chain_id = genesis_config.chain_id.as_str();
         if chain_id == near_primitives::chains::MAINNET
             || chain_id == near_primitives::chains::TESTNET
         {
-            let epoch_config_store = EpochConfigStore::for_chain_id(chain_id).unwrap();
+            // Do not load epoch config files for mainnet and testnet.
+            let epoch_config_store = EpochConfigStore::for_chain_id(chain_id, None).unwrap();
             return Self::new_arc_handle_from_epoch_config_store(
                 store,
                 genesis_config,
@@ -204,23 +213,22 @@ impl EpochManager {
             );
         }
 
-        let epoch_config = if chain_id.starts_with("test-chain-") {
-            // We still do this for localnet as nayduck depends on it.
-            // TODO(#11265): remove this dependency for tests using
-            // `random_chain_id`.
-            EpochConfig::from(genesis_config)
+        // Load epoch config files for other chains if home dir is not none. Otherwise, use genesis config.
+        let epoch_config_store = if home_dir.is_some() {
+            // We are using these configs for testing, so we can panic if they are not found.
+            let config_dir = home_dir.map(|home_dir| home_dir.join("epoch_configs"));
+            EpochConfigStore::for_chain_id(chain_id, config_dir).unwrap()
         } else {
-            Genesis::test_epoch_config(
+            let epoch_config = Genesis::test_epoch_config(
                 genesis_config.num_block_producer_seats,
                 genesis_config.shard_layout.clone(),
                 genesis_config.epoch_length,
-            )
+            );
+            EpochConfigStore::test(BTreeMap::from_iter(vec![(
+                genesis_config.protocol_version,
+                Arc::new(epoch_config),
+            )]))
         };
-
-        let epoch_config_store = EpochConfigStore::test(BTreeMap::from_iter(vec![(
-            genesis_config.protocol_version,
-            Arc::new(epoch_config),
-        )]));
         Self::new_arc_handle_from_epoch_config_store(store, genesis_config, epoch_config_store)
     }
 

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -219,6 +219,7 @@ impl EpochManager {
             let config_dir = home_dir.map(|home_dir| home_dir.join("epoch_configs"));
             EpochConfigStore::for_chain_id(chain_id, config_dir).unwrap()
         } else {
+            // TODO: For tests, we want to use new_arc_handle_from_epoch_config_store with EpochConfigStore::test instead of calling new_arc_handle.
             let epoch_config = Genesis::test_epoch_config(
                 genesis_config.num_block_producer_seats,
                 genesis_config.shard_layout.clone(),

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -12,7 +12,9 @@ use near_primitives_core::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_schema_checker_lib::ProtocolSchema;
 use smart_default::SmartDefault;
 use std::collections::{BTreeMap, HashMap};
+use std::fs;
 use std::ops::Bound;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 pub const AGGREGATOR_KEY: &[u8] = b"AGGREGATOR";
@@ -162,7 +164,7 @@ impl AllEpochConfig {
     ) -> Self {
         // Use the config store only for production configs and outside of tests.
         let config_store = if use_production_config && test_overrides.is_none() {
-            EpochConfigStore::for_chain_id(chain_id)
+            EpochConfigStore::for_chain_id(chain_id, None)
         } else {
             None
         };
@@ -476,8 +478,27 @@ pub struct EpochConfigStore {
 
 impl EpochConfigStore {
     /// Creates a config store to contain the EpochConfigs for the given chain parsed from the JSON files.
-    /// Returns None if there is no epoch config file stored for the given chain.
-    pub fn for_chain_id(chain_id: &str) -> Option<Self> {
+    /// If no configs are found for the given chain, try to load the configs from the file system.
+    /// If there are no configs found, return None.
+    pub fn for_chain_id(chain_id: &str, config_dir: Option<PathBuf>) -> Option<Self> {
+        let mut store = Self::load_default_epoch_configs(chain_id);
+
+        if !store.is_empty() {
+            return Some(Self { store });
+        }
+        if let Some(config_dir) = config_dir {
+            store = Self::load_epoch_config_from_file_system(config_dir.to_str().unwrap());
+        }
+
+        if store.is_empty() {
+            None
+        } else {
+            Some(Self { store })
+        }
+    }
+
+    /// Loads the default epoch configs for the given chain from the CONFIGS array.
+    fn load_default_epoch_configs(chain_id: &str) -> BTreeMap<ProtocolVersion, Arc<EpochConfig>> {
         let mut store = BTreeMap::new();
         for (chain, version, content) in CONFIGS.iter() {
             if *chain == chain_id {
@@ -490,11 +511,43 @@ impl EpochConfigStore {
                 store.insert(*version, Arc::new(config));
             }
         }
-        if store.is_empty() {
-            None
-        } else {
-            Some(Self { store })
+        store
+    }
+
+    /// Reads the json files from the epoch config directory.
+    fn load_epoch_config_from_file_system(
+        directory: &str,
+    ) -> BTreeMap<ProtocolVersion, Arc<EpochConfig>> {
+        let mut store = BTreeMap::new();
+        let entries = fs::read_dir(directory).expect("Failed opening epoch config directory");
+
+        for entry in entries {
+            if let Ok(entry) = entry {
+                let path = entry.path();
+
+                // Check if the file has a .json extension
+                if path.extension().and_then(|ext| ext.to_str()) == Some("json") {
+                    // Extract the file name (without extension)
+                    if let Some(file_stem) = path.file_stem().and_then(|s| s.to_str()) {
+                        let version: ProtocolVersion =
+                            file_stem.parse().expect("Invalid protocol version");
+
+                        let content = fs::read_to_string(&path).expect("Failed to read file");
+                        let config: EpochConfig =
+                            serde_json::from_str(&content).unwrap_or_else(|e| {
+                                panic!(
+                                "Failed to load epoch config from file system for version {}: {:#}",
+                                version, e
+                            )
+                            });
+
+                        store.insert(version, Arc::new(config));
+                    }
+                }
+            }
         }
+
+        store
     }
 
     pub fn test(store: BTreeMap<ProtocolVersion, Arc<EpochConfig>>) -> Self {
@@ -541,7 +594,7 @@ mod tests {
             None,
         );
 
-        let config_store = EpochConfigStore::for_chain_id(chain_id).unwrap();
+        let config_store = EpochConfigStore::for_chain_id(chain_id, None).unwrap();
         for protocol_version in genesis_protocol_version..=PROTOCOL_VERSION {
             let stored_config = config_store.get_config(protocol_version);
             let expected_config = all_epoch_config.generate_epoch_config(protocol_version);

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -14,7 +14,7 @@ use smart_default::SmartDefault;
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::ops::Bound;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 pub const AGGREGATOR_KEY: &[u8] = b"AGGREGATOR";

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -91,7 +91,8 @@ impl GenesisBuilder {
     pub fn from_config_and_store(home_dir: &Path, config: NearConfig, store: Store) -> Self {
         let tmpdir = tempfile::Builder::new().prefix("storage").tempdir().unwrap();
         initialize_genesis_state(store.clone(), &config.genesis, Some(tmpdir.path()));
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &config.genesis.config);
+        let epoch_manager =
+            EpochManager::new_arc_handle(store.clone(), &config.genesis.config, None);
         let runtime = NightshadeRuntime::from_config(
             tmpdir.path(),
             store.clone(),

--- a/integration-tests/src/test_loop/tests/fix_min_stake_ratio.rs
+++ b/integration-tests/src/test_loop/tests/fix_min_stake_ratio.rs
@@ -58,7 +58,7 @@ fn test_fix_min_stake_ratio() {
 
     // Take epoch configuration before the protocol upgrade, where minimum
     // stake ratio was 1/6250.
-    let epoch_config_store = EpochConfigStore::for_chain_id("mainnet").unwrap();
+    let epoch_config_store = EpochConfigStore::for_chain_id("mainnet", None).unwrap();
     let protocol_version = ProtocolFeature::FixMinStakeRatio.protocol_version() - 1;
 
     // Create chain with version before FixMinStakeRatio was enabled.

--- a/integration-tests/src/test_loop/tests/protocol_upgrade.rs
+++ b/integration-tests/src/test_loop/tests/protocol_upgrade.rs
@@ -86,7 +86,7 @@ fn test_protocol_upgrade(
     let (genesis, genesis_epoch_config_store) = genesis_builder.build();
     let genesis_epoch_info = genesis_epoch_config_store.get_config(old_protocol);
 
-    let mainnet_epoch_config_store = EpochConfigStore::for_chain_id("mainnet").unwrap();
+    let mainnet_epoch_config_store = EpochConfigStore::for_chain_id("mainnet", None).unwrap();
     let mut old_epoch_config: EpochConfig =
         mainnet_epoch_config_store.get_config(old_protocol).deref().clone();
     let mut new_epoch_config: EpochConfig =

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -86,7 +86,7 @@ fn test_resharding_v3_base(chunk_ranges_to_drop: HashMap<ShardUId, std::ops::Ran
         clients.iter().map(|account: &AccountId| account.as_str()).collect_vec();
 
     // Prepare shard split configuration.
-    let base_epoch_config_store = EpochConfigStore::for_chain_id("mainnet").unwrap();
+    let base_epoch_config_store = EpochConfigStore::for_chain_id("mainnet", None).unwrap();
     let base_protocol_version = ProtocolFeature::SimpleNightshadeV4.protocol_version() - 1;
     let mut base_epoch_config =
         base_epoch_config_store.get_config(base_protocol_version).as_ref().clone();

--- a/integration-tests/src/test_loop/tests/simple_test_loop_example.rs
+++ b/integration-tests/src/test_loop/tests/simple_test_loop_example.rs
@@ -64,7 +64,7 @@ fn test_client_with_simple_test_loop() {
     initialize_genesis_state(store.clone(), &genesis, None);
 
     let chain_genesis = ChainGenesis::new(&genesis.config);
-    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
     let shard_tracker = ShardTracker::new(TrackedConfig::AllShards, epoch_manager.clone());
     let runtime_adapter = NightshadeRuntime::test(
         Path::new("."),

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -477,7 +477,8 @@ fn test_cold_loop_on_gc_boundary() {
     near_config.client_config = env.clients[0].config.clone();
     near_config.config.save_trie_changes = Some(true);
 
-    let epoch_manager = EpochManager::new_arc_handle(storage.get_hot_store(), &genesis.config);
+    let epoch_manager =
+        EpochManager::new_arc_handle(storage.get_hot_store(), &genesis.config, None);
     spawn_cold_store_loop(&near_config, &storage, epoch_manager).unwrap();
     std::thread::sleep(std::time::Duration::from_secs(1));
 

--- a/integration-tests/src/tests/client/features/stateless_validation.rs
+++ b/integration-tests/src/tests/client/features/stateless_validation.rs
@@ -348,7 +348,7 @@ fn test_protocol_upgrade_81() {
         chunk_producer_kickout_threshold: 90,
         ..Default::default()
     };
-    let epoch_manager = EpochManager::new_arc_handle(create_test_store(), &genesis_config);
+    let epoch_manager = EpochManager::new_arc_handle(create_test_store(), &genesis_config, None);
     let config = epoch_manager.get_epoch_config(&EpochId::default()).unwrap();
     assert_eq!(config.block_producer_kickout_threshold, 90);
     assert_eq!(config.chunk_producer_kickout_threshold, 90);

--- a/integration-tests/src/tests/genesis_helpers.rs
+++ b/integration-tests/src/tests/genesis_helpers.rs
@@ -25,7 +25,7 @@ fn genesis_header(genesis: &Genesis) -> BlockHeader {
     let store = create_test_store();
     initialize_genesis_state(store.clone(), genesis, None);
     let chain_genesis = ChainGenesis::new(&genesis.config);
-    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
     let shard_tracker = ShardTracker::new_empty(epoch_manager.clone());
     let runtime =
         NightshadeRuntime::test(dir.path(), store, &genesis.config, epoch_manager.clone());
@@ -52,7 +52,7 @@ pub fn genesis_block(genesis: &Genesis) -> Block {
     let store = create_test_store();
     initialize_genesis_state(store.clone(), genesis, None);
     let chain_genesis = ChainGenesis::new(&genesis.config);
-    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
     let shard_tracker = ShardTracker::new_empty(epoch_manager.clone());
     let runtime =
         NightshadeRuntime::test(dir.path(), store, &genesis.config, epoch_manager.clone());

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -58,7 +58,8 @@ fn setup_network_node(
     genesis.config.epoch_length = 5;
     let tempdir = tempfile::tempdir().unwrap();
     initialize_genesis_state(node_storage.get_hot_store(), &genesis, Some(tempdir.path()));
-    let epoch_manager = EpochManager::new_arc_handle(node_storage.get_hot_store(), &genesis.config);
+    let epoch_manager =
+        EpochManager::new_arc_handle(node_storage.get_hot_store(), &genesis.config, None);
     let shard_tracker = ShardTracker::new_empty(epoch_manager.clone());
     let runtime = NightshadeRuntime::test(
         tempdir.path(),

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -43,7 +43,7 @@ fn read_trie_items(bench: &mut Bencher, shard_index: ShardIndex, shard_id: Shard
             ChainStore::new(store.clone(), near_config.genesis.config.genesis_height, true);
 
         let epoch_manager =
-            EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config);
+            EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config, None);
         let runtime = NightshadeRuntime::from_config(&home_dir, store, &near_config, epoch_manager)
             .unwrap_or_else(|e| panic!("could not create the transaction runtime: {e}"));
         let head = chain_store.head().unwrap();

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -255,7 +255,7 @@ pub fn start_with_config_and_synchronization(
     )?;
 
     let epoch_manager =
-        EpochManager::new_arc_handle(storage.get_hot_store(), &config.genesis.config);
+        EpochManager::new_arc_handle(storage.get_hot_store(), &config.genesis.config, None);
     let genesis_epoch_config = epoch_manager.get_epoch_config(&EpochId::default())?;
     // Initialize genesis_state in store either from genesis config or dump before other components.
     // We only initialize if the genesis state is not already initialized in store.
@@ -283,7 +283,7 @@ pub fn start_with_config_and_synchronization(
     let (view_epoch_manager, view_shard_tracker, view_runtime) =
         if let Some(split_store) = &split_store {
             let view_epoch_manager =
-                EpochManager::new_arc_handle(split_store.clone(), &config.genesis.config);
+                EpochManager::new_arc_handle(split_store.clone(), &config.genesis.config, None);
             let view_shard_tracker = ShardTracker::new(
                 TrackedConfig::from_config(&config.client_config),
                 epoch_manager.clone(),

--- a/nearcore/tests/economics.rs
+++ b/nearcore/tests/economics.rs
@@ -34,7 +34,7 @@ fn setup_env(genesis: &Genesis) -> TestEnv {
     init_integration_logger();
     let store = create_test_store();
     initialize_genesis_state(store.clone(), &genesis, None);
-    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
     let runtime = NightshadeRuntime::test(
         Path::new("."),
         store.clone(),

--- a/test-utils/runtime-tester/src/run_test.rs
+++ b/test-utils/runtime-tester/src/run_test.rs
@@ -54,7 +54,7 @@ impl Scenario {
         };
         let home_dir = tempdir.as_ref().map(|d| d.path());
         initialize_genesis_state(store.clone(), &genesis, home_dir);
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
         let home_dir = home_dir.unwrap_or_else(|| Path::new("."));
         let contract_cache = FilesystemContractRuntimeCache::new(home_dir, None::<&str>)
             .expect("filesystem contract cache")

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -39,7 +39,8 @@ fn main() {
     .open()
     .unwrap()
     .get_hot_store();
-    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config);
+    let epoch_manager =
+        EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config, Some(home_dir));
     let shard_tracker = ShardTracker::new(
         TrackedConfig::from_config(&near_config.client_config),
         epoch_manager.clone(),

--- a/tools/cold-store/src/cli.rs
+++ b/tools/cold-store/src/cli.rs
@@ -75,8 +75,11 @@ impl ColdStoreCommand {
         let storage =
             opener.open_in_mode(mode).unwrap_or_else(|e| panic!("Error opening storage: {:#}", e));
 
-        let epoch_manager =
-            EpochManager::new_arc_handle(storage.get_hot_store(), &near_config.genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(
+            storage.get_hot_store(),
+            &near_config.genesis.config,
+            Some(home_dir),
+        );
         match self.subcmd {
             SubCommand::Open => check_open(&storage),
             SubCommand::Head => print_heads(&storage),

--- a/tools/database/src/memtrie.rs
+++ b/tools/database/src/memtrie.rs
@@ -46,7 +46,8 @@ impl LoadMemTrieCommand {
         let block_header = store
             .get_ser::<BlockHeader>(DBCol::BlockHeader, &borsh::to_vec(&head).unwrap())?
             .ok_or_else(|| anyhow::anyhow!("Block header not found"))?;
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis_config);
+        let epoch_manager =
+            EpochManager::new_arc_handle(store.clone(), &genesis_config, Some(home));
 
         let all_shard_uids: Vec<ShardUId> =
             epoch_manager.get_shard_layout(block_header.epoch_id()).unwrap().shard_uids().collect();

--- a/tools/database/src/resharding_v2.rs
+++ b/tools/database/src/resharding_v2.rs
@@ -129,7 +129,8 @@ impl ReshardingV2Command {
     fn get_chain(&self, mut config: NearConfig, home_dir: &Path) -> Result<Chain, anyhow::Error> {
         let store = self.get_store(home_dir, &mut config)?;
 
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &config.genesis.config);
+        let epoch_manager =
+            EpochManager::new_arc_handle(store.clone(), &config.genesis.config, Some(home_dir));
         let genesis_epoch_config = epoch_manager.get_epoch_config(&EpochId::default())?;
         initialize_sharded_genesis_state(
             store.clone(),

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -163,8 +163,11 @@ impl FlatStorageCommand {
         mode: Mode,
     ) -> (NodeStorage, Arc<EpochManagerHandle>, Arc<NightshadeRuntime>, ChainStore, Store) {
         let node_storage = opener.open_in_mode(mode).unwrap();
-        let epoch_manager =
-            EpochManager::new_arc_handle(node_storage.get_hot_store(), &near_config.genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(
+            node_storage.get_hot_store(),
+            &near_config.genesis.config,
+            Some(home_dir.as_path()),
+        );
         let hot_runtime = NightshadeRuntime::from_config(
             home_dir,
             node_storage.get_hot_store(),

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -249,8 +249,11 @@ impl ForkNetworkCommand {
         let store = storage.get_hot_store();
         assert!(self.snapshot_db(store.clone(), near_config, home_dir)?);
 
-        let epoch_manager =
-            EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(
+            store.clone(),
+            &near_config.genesis.config,
+            Some(home_dir),
+        );
         let head = store.get_ser::<Tip>(DBCol::BlockMisc, FINAL_HEAD_KEY)?.unwrap();
         let shard_layout = epoch_manager.get_shard_layout(&head.epoch_id)?;
         let all_shard_uids: Vec<_> = shard_layout.shard_uids().collect();
@@ -329,8 +332,11 @@ impl ForkNetworkCommand {
             self.get_state_roots_and_hash(store.clone())?;
         tracing::info!(?prev_state_roots, ?epoch_id, ?prev_hash);
 
-        let epoch_manager =
-            EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(
+            store.clone(),
+            &near_config.genesis.config,
+            Some(home_dir),
+        );
         let shard_layout = epoch_manager.get_shard_layout(&epoch_id)?;
         let all_shard_uids = shard_layout.shard_uids().collect::<Vec<_>>();
         let runtime =
@@ -376,8 +382,11 @@ impl ForkNetworkCommand {
         let (prev_state_roots, _prev_hash, epoch_id, block_height) =
             self.get_state_roots_and_hash(store.clone())?;
 
-        let epoch_manager =
-            EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(
+            store.clone(),
+            &near_config.genesis.config,
+            Some(home_dir),
+        );
 
         let runtime =
             NightshadeRuntime::from_config(home_dir, store, &near_config, epoch_manager.clone())

--- a/tools/mirror/src/key_util.rs
+++ b/tools/mirror/src/key_util.rs
@@ -61,7 +61,8 @@ pub(crate) fn keys_from_source_db(
         config.genesis.config.genesis_height,
         config.client_config.save_trie_changes,
     );
-    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &config.genesis.config);
+    let epoch_manager =
+        EpochManager::new_arc_handle(store.clone(), &config.genesis.config, Some(home));
     let runtime =
         NightshadeRuntime::from_config(home.as_ref(), store, &config, epoch_manager.clone())
             .context("could not create the transaction runtime")?;

--- a/tools/mirror/src/offline.rs
+++ b/tools/mirror/src/offline.rs
@@ -45,7 +45,11 @@ impl ChainAccess {
             config.genesis.config.genesis_height,
             config.client_config.save_trie_changes,
         );
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &config.genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(
+            store.clone(),
+            &config.genesis.config,
+            Some(home.as_ref()),
+        );
         let runtime =
             NightshadeRuntime::from_config(home.as_ref(), store, &config, epoch_manager.clone())
                 .context("could not create the transaction runtime")?;

--- a/tools/mock-node/src/setup.rs
+++ b/tools/mock-node/src/setup.rs
@@ -38,7 +38,8 @@ fn setup_runtime(
             .unwrap()
             .get_hot_store()
     };
-    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &config.genesis.config);
+    let epoch_manager =
+        EpochManager::new_arc_handle(store.clone(), &config.genesis.config, Some(home_dir));
     let shard_tracker =
         ShardTracker::new(TrackedConfig::from_config(&config.client_config), epoch_manager.clone());
     let runtime = NightshadeRuntime::from_config(home_dir, store, config, epoch_manager.clone())
@@ -424,7 +425,7 @@ mod tests {
             .unwrap()
             .get_hot_store();
             let epoch_manager =
-                EpochManager::new_arc_handle(store.clone(), &near_config1.genesis.config);
+                EpochManager::new_arc_handle(store.clone(), &near_config1.genesis.config, None);
             let chain_store = ChainStore::new(
                 store,
                 near_config1.genesis.config.genesis_height,

--- a/tools/replay-archive/src/cli.rs
+++ b/tools/replay-archive/src/cli.rs
@@ -120,8 +120,11 @@ impl ReplayController {
         let start_height = start_height.unwrap_or(genesis_height);
         let end_height = end_height.unwrap_or(head_height).min(head_height);
 
-        let epoch_manager =
-            EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(
+            store.clone(),
+            &near_config.genesis.config,
+            Some(home_dir),
+        );
 
         let runtime =
             NightshadeRuntime::from_config(home_dir, store, &near_config, epoch_manager.clone())

--- a/tools/speedy_sync/src/main.rs
+++ b/tools/speedy_sync/src/main.rs
@@ -232,7 +232,8 @@ fn load_snapshot(load_cmd: LoadCmd) {
         .unwrap()
         .get_hot_store();
     let chain_genesis = ChainGenesis::new(&config.genesis.config);
-    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &config.genesis.config);
+    let epoch_manager =
+        EpochManager::new_arc_handle(store.clone(), &config.genesis.config, Some(home_dir));
     let shard_tracker =
         ShardTracker::new(TrackedConfig::from_config(&config.client_config), epoch_manager.clone());
     let runtime =

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -513,7 +513,7 @@ mod test {
         genesis.config.epoch_length = epoch_length;
         let store = create_test_store();
         initialize_genesis_state(store.clone(), &genesis, None);
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
         let nightshade_runtime = NightshadeRuntime::test(
             Path::new("."),
             store.clone(),
@@ -583,7 +583,7 @@ mod test {
         safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1, None);
 
         initialize_genesis_state(store.clone(), &genesis, None);
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
         let runtime = NightshadeRuntime::test(
             Path::new("."),
             store.clone(),
@@ -627,7 +627,7 @@ mod test {
         safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1, Some(5));
 
         initialize_genesis_state(store.clone(), &genesis, None);
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
         let runtime = NightshadeRuntime::test(
             Path::new("."),
             store.clone(),

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -531,7 +531,7 @@ mod test {
         let mut chain_store = ChainStore::new(store.clone(), genesis.config.genesis_height, false);
 
         initialize_genesis_state(store.clone(), &genesis, None);
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
         let runtime = NightshadeRuntime::test(
             Path::new("."),
             store.clone(),
@@ -618,7 +618,7 @@ mod test {
         let chain_store = ChainStore::new(store.clone(), genesis.config.genesis_height, false);
 
         initialize_genesis_state(store.clone(), &genesis, None);
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
         let runtime = NightshadeRuntime::test(
             Path::new("."),
             store.clone(),

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -167,7 +167,7 @@ impl StateViewerSubCommand {
             }
             StateViewerSubCommand::ApplyReceipt(cmd) => cmd.run(home_dir, near_config, store),
             StateViewerSubCommand::ApplyTx(cmd) => cmd.run(home_dir, near_config, store),
-            StateViewerSubCommand::Chain(cmd) => cmd.run(near_config, store),
+            StateViewerSubCommand::Chain(cmd) => cmd.run(home_dir, near_config, store),
             StateViewerSubCommand::CheckBlock => check_block_chunk_existence(near_config, store),
             StateViewerSubCommand::Chunks(cmd) => cmd.run(near_config, store),
             StateViewerSubCommand::ClearCache => clear_cache(store),
@@ -389,8 +389,15 @@ pub struct ChainCmd {
 }
 
 impl ChainCmd {
-    pub fn run(self, near_config: NearConfig, store: Store) {
-        print_chain(self.start_index, self.end_index, near_config, store, self.show_full_hashes);
+    pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
+        print_chain(
+            self.start_index,
+            self.end_index,
+            home_dir,
+            near_config,
+            store,
+            self.show_full_hashes,
+        );
     }
 }
 
@@ -433,8 +440,11 @@ impl DebugUICmd {
         store: Store,
         cold_store: Option<Store>,
     ) {
-        let epoch_manager =
-            EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(
+            store.clone(),
+            &near_config.genesis.config,
+            Some(home_dir),
+        );
         let debug_handler = EntityDebugHandlerImpl {
             hot_store: store.clone(),
             cold_store,

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -163,8 +163,11 @@ pub(crate) fn apply_block_at_height(
         near_config.genesis.config.genesis_height,
         near_config.client_config.save_trie_changes,
     );
-    let epoch_manager =
-        EpochManager::new_arc_handle(read_store.clone(), &near_config.genesis.config);
+    let epoch_manager = EpochManager::new_arc_handle(
+        read_store.clone(),
+        &near_config.genesis.config,
+        Some(home_dir),
+    );
     let runtime =
         NightshadeRuntime::from_config(home_dir, read_store, &near_config, epoch_manager.clone())
             .context("could not create the transaction runtime")?;
@@ -203,7 +206,8 @@ pub(crate) fn apply_chunk(
     target_height: Option<u64>,
     storage: StorageSource,
 ) -> anyhow::Result<()> {
-    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config);
+    let epoch_manager =
+        EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config, Some(home_dir));
     let runtime = NightshadeRuntime::from_config(
         home_dir,
         store.clone(),
@@ -258,8 +262,11 @@ pub(crate) fn apply_range(
 ) {
     let mut csv_file = csv_file.map(|filename| std::fs::File::create(filename).unwrap());
 
-    let epoch_manager =
-        EpochManager::new_arc_handle(read_store.clone(), &near_config.genesis.config);
+    let epoch_manager = EpochManager::new_arc_handle(
+        read_store.clone(),
+        &near_config.genesis.config,
+        Some(home_dir),
+    );
     let runtime = NightshadeRuntime::from_config(
         home_dir,
         read_store.clone(),
@@ -292,7 +299,8 @@ pub(crate) fn apply_receipt(
     hash: CryptoHash,
     storage: StorageSource,
 ) -> anyhow::Result<()> {
-    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config);
+    let epoch_manager =
+        EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config, Some(home_dir));
     let runtime = NightshadeRuntime::from_config(
         home_dir,
         store.clone(),
@@ -318,7 +326,8 @@ pub(crate) fn apply_tx(
     hash: CryptoHash,
     storage: StorageSource,
 ) -> anyhow::Result<()> {
-    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config);
+    let epoch_manager =
+        EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config, Some(home_dir));
     let runtime = NightshadeRuntime::from_config(
         home_dir,
         store.clone(),
@@ -552,6 +561,7 @@ pub(crate) fn get_receipt(receipt_id: CryptoHash, near_config: NearConfig, store
 pub(crate) fn print_chain(
     start_height: BlockHeight,
     end_height: BlockHeight,
+    home_dir: &Path,
     near_config: NearConfig,
     store: Store,
     show_full_hashes: bool,
@@ -561,7 +571,8 @@ pub(crate) fn print_chain(
         near_config.genesis.config.genesis_height,
         near_config.client_config.save_trie_changes,
     );
-    let epoch_manager = EpochManager::new_arc_handle(store, &near_config.genesis.config);
+    let epoch_manager =
+        EpochManager::new_arc_handle(store, &near_config.genesis.config, Some(home_dir));
     let mut account_id_to_blocks = HashMap::new();
     let mut cur_epoch_id = None;
     // TODO: Split into smaller functions.
@@ -766,7 +777,8 @@ pub(crate) fn view_genesis(
     compare: bool,
 ) {
     let chain_genesis = ChainGenesis::new(&near_config.genesis.config);
-    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config);
+    let epoch_manager =
+        EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config, Some(home_dir));
     let runtime_adapter = NightshadeRuntime::from_config(
         home_dir,
         store.clone(),
@@ -1521,7 +1533,7 @@ mod tests {
 
         let store = near_store::test_utils::create_test_store();
         initialize_genesis_state(store.clone(), &genesis, Some(home_dir));
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
         let runtime = NightshadeRuntime::test(
             home_dir,
             store.clone(),

--- a/tools/state-viewer/src/latest_witnesses.rs
+++ b/tools/state-viewer/src/latest_witnesses.rs
@@ -112,8 +112,11 @@ impl ValidateWitnessCmd {
         let witness: ChunkStateWitness = borsh::BorshDeserialize::try_from_slice(&encoded_witness)
             .expect("Failed to deserialize witness");
         let chain_genesis = ChainGenesis::new(&near_config.genesis.config);
-        let epoch_manager =
-            EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(
+            store.clone(),
+            &near_config.genesis.config,
+            Some(home_dir),
+        );
         let runtime_adapter =
             NightshadeRuntime::from_config(home_dir, store, &near_config, epoch_manager.clone())
                 .expect("could not create the transaction runtime");

--- a/tools/state-viewer/src/replay_headers.rs
+++ b/tools/state-viewer/src/replay_headers.rs
@@ -42,10 +42,11 @@ pub(crate) fn replay_headers(
         start_height.unwrap_or_else(|| chain_store.get_genesis_height());
     let end_height: BlockHeight = end_height.unwrap_or_else(|| chain_store.head().unwrap().height);
 
-    let epoch_manager = EpochManager::new_arc_handle(store, &near_config.genesis.config);
+    let epoch_manager =
+        EpochManager::new_arc_handle(store, &near_config.genesis.config, Some(home_dir));
     let replay_store = create_replay_store(home_dir, &near_config);
     let epoch_manager_replay =
-        EpochManager::new_arc_handle(replay_store, &near_config.genesis.config);
+        EpochManager::new_arc_handle(replay_store, &near_config.genesis.config, Some(home_dir));
 
     for height in start_height..=end_height {
         if let Ok(block_hash) = chain_store.get_block_hash_by_height(height) {

--- a/tools/state-viewer/src/state_changes.rs
+++ b/tools/state-viewer/src/state_changes.rs
@@ -48,7 +48,7 @@ impl StateChangesSubCommand {
                 apply_state_changes(file, shard_id, state_root, home_dir, near_config, store)
             }
             StateChangesSubCommand::Dump { height_from, height_to, file } => {
-                dump_state_changes(height_from, height_to, file, near_config, store)
+                dump_state_changes(height_from, height_to, file, home_dir, near_config, store)
             }
         }
     }
@@ -66,12 +66,14 @@ fn dump_state_changes(
     height_from: BlockHeight,
     height_to: BlockHeight,
     file: PathBuf,
+    home_dir: &Path,
     near_config: NearConfig,
     store: Store,
 ) {
     assert!(height_from <= height_to, "--height-from must be less than or equal to --height-to");
 
-    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config);
+    let epoch_manager =
+        EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config, Some(home_dir));
     let chain_store = ChainStore::new(
         store.clone(),
         near_config.genesis.config.genesis_height,
@@ -137,7 +139,8 @@ fn apply_state_changes(
     near_config: NearConfig,
     store: Store,
 ) {
-    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config);
+    let epoch_manager =
+        EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config, Some(home_dir));
     let runtime = NightshadeRuntime::from_config(
         home_dir,
         store.clone(),

--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -442,7 +442,7 @@ mod test {
         let state_roots: Vec<CryptoHash> =
             last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
         initialize_genesis_state(store.clone(), &genesis, None);
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
         let runtime =
             NightshadeRuntime::test(Path::new("."), store, &genesis.config, epoch_manager.clone());
         let records_file = tempfile::NamedTempFile::new().unwrap();
@@ -520,7 +520,7 @@ mod test {
         let state_roots: Vec<CryptoHash> =
             last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
         initialize_genesis_state(store.clone(), &genesis, None);
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
         let runtime =
             NightshadeRuntime::test(Path::new("."), store, &genesis.config, epoch_manager.clone());
         let select_account_ids = vec!["test0".parse().unwrap()];
@@ -584,7 +584,7 @@ mod test {
         let state_roots: Vec<CryptoHash> =
             last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
         initialize_genesis_state(store.clone(), &genesis, None);
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
         let runtime =
             NightshadeRuntime::test(Path::new("."), store, &genesis.config, epoch_manager.clone());
         let new_near_config = state_dump(
@@ -627,7 +627,7 @@ mod test {
         let state_roots: Vec<CryptoHash> =
             last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
         initialize_genesis_state(store.clone(), &genesis, None);
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
         let runtime =
             NightshadeRuntime::test(Path::new("."), store, &genesis.config, epoch_manager.clone());
 
@@ -682,7 +682,7 @@ mod test {
         let state_roots: Vec<CryptoHash> =
             last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
         initialize_genesis_state(store.clone(), &genesis, None);
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
         let runtime =
             NightshadeRuntime::test(Path::new("."), store, &genesis.config, epoch_manager.clone());
         let records_file = tempfile::NamedTempFile::new().unwrap();
@@ -716,8 +716,8 @@ mod test {
         let store2 = create_test_store();
         initialize_genesis_state(store1.clone(), &genesis, None);
         initialize_genesis_state(store2.clone(), &genesis, None);
-        let epoch_manager1 = EpochManager::new_arc_handle(store1.clone(), &genesis.config);
-        let epoch_manager2 = EpochManager::new_arc_handle(store2.clone(), &genesis.config);
+        let epoch_manager1 = EpochManager::new_arc_handle(store1.clone(), &genesis.config, None);
+        let epoch_manager2 = EpochManager::new_arc_handle(store2.clone(), &genesis.config, None);
         let runtime1 = NightshadeRuntime::test(
             Path::new("."),
             store1.clone(),
@@ -802,7 +802,7 @@ mod test {
         genesis.config.epoch_length = epoch_length;
         let store = create_test_store();
         initialize_genesis_state(store.clone(), &genesis, None);
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
         let nightshade_runtime = NightshadeRuntime::test(
             Path::new("."),
             store.clone(),
@@ -862,7 +862,7 @@ mod test {
         let state_roots: Vec<CryptoHash> =
             last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
         initialize_genesis_state(store.clone(), &genesis, None);
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
         let runtime =
             NightshadeRuntime::test(Path::new("."), store, &genesis.config, epoch_manager.clone());
         let records_file = tempfile::NamedTempFile::new().unwrap();
@@ -920,7 +920,7 @@ mod test {
         let state_roots: Vec<CryptoHash> =
             last_block.chunks().iter().map(|chunk| chunk.prev_state_root()).collect();
         initialize_genesis_state(store.clone(), &genesis, None);
-        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis.config, None);
         let runtime =
             NightshadeRuntime::test(Path::new("."), store, &genesis.config, epoch_manager.clone());
         let new_near_config = state_dump(

--- a/tools/state-viewer/src/state_parts.rs
+++ b/tools/state-viewer/src/state_parts.rs
@@ -101,8 +101,11 @@ impl StatePartsSubCommand {
         near_config: NearConfig,
         store: Store,
     ) {
-        let epoch_manager =
-            EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(
+            store.clone(),
+            &near_config.genesis.config,
+            Some(home_dir),
+        );
         let shard_tracker = ShardTracker::new(
             TrackedConfig::from_config(&near_config.client_config),
             epoch_manager.clone(),

--- a/tools/state-viewer/src/util.rs
+++ b/tools/state-viewer/src/util.rs
@@ -40,7 +40,8 @@ pub fn load_trie_stop_at_height(
         near_config.client_config.save_trie_changes,
     );
 
-    let epoch_manager = EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config);
+    let epoch_manager =
+        EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config, Some(home_dir));
     let runtime =
         NightshadeRuntime::from_config(home_dir, store, near_config, epoch_manager.clone());
     let runtime = runtime.expect("could not create the transaction runtime");

--- a/tools/undo-block/src/cli.rs
+++ b/tools/undo-block/src/cli.rs
@@ -31,8 +31,11 @@ impl UndoBlockCommand {
         let storage = store_opener.open_in_mode(Mode::ReadWrite).unwrap();
         let store = storage.get_hot_store();
 
-        let epoch_manager =
-            EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config);
+        let epoch_manager = EpochManager::new_arc_handle(
+            store.clone(),
+            &near_config.genesis.config,
+            Some(home_dir),
+        );
 
         let mut chain_store = ChainStore::new(
             store,


### PR DESCRIPTION
This PR introduces the option to load epoch config for each protocol version from external files. 
The new order in which we will load the epoch config is:
If mainnet or testnet => go for hardcoded json files.
If there is a non null `epoch_config` path provided and the directory exists => load the files from that folder.
Otherwise build the epoch config from the genesis.

We kept the last option to keep the compatibility with the existing tests. 