### PR TITLE
[Epoch Sync] Fix some epoch sync proof verification problems.

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -589,15 +589,15 @@ impl Chain {
         let protocol_version = epoch_manager.get_epoch_protocol_version(&prev_epoch_id)?;
         Self::compute_bp_hash_from_validator_stakes(
             &validator_stakes,
-            !ProtocolFeature::BlockHeaderV3.enabled(protocol_version),
+            ProtocolFeature::BlockHeaderV3.enabled(protocol_version),
         )
     }
 
     pub fn compute_bp_hash_from_validator_stakes(
         validator_stakes: &Vec<ValidatorStake>,
-        use_old_bp_has_format: bool,
+        use_versioned_bp_hash_format: bool,
     ) -> Result<CryptoHash, Error> {
-        if !use_old_bp_has_format {
+        if use_versioned_bp_hash_format {
             Ok(CryptoHash::hash_borsh_iter(validator_stakes))
         } else {
             let stakes = validator_stakes.into_iter().map(|stake| stake.clone().into_v1());

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -587,14 +587,17 @@ impl Chain {
         let bps = epoch_manager.get_epoch_block_producers_ordered(&epoch_id, last_known_hash)?;
         let validator_stakes = bps.into_iter().map(|(bp, _)| bp).collect_vec();
         let protocol_version = epoch_manager.get_epoch_protocol_version(&prev_epoch_id)?;
-        Self::compute_bp_hash_from_validator_stakes(&validator_stakes, protocol_version)
+        Self::compute_bp_hash_from_validator_stakes(
+            &validator_stakes,
+            !ProtocolFeature::BlockHeaderV3.enabled(protocol_version),
+        )
     }
 
     pub fn compute_bp_hash_from_validator_stakes(
         validator_stakes: &Vec<ValidatorStake>,
-        protocol_version: ProtocolVersion,
+        use_old_bp_has_format: bool,
     ) -> Result<CryptoHash, Error> {
-        if checked_feature!("stable", BlockHeaderV3, protocol_version) {
+        if !use_old_bp_has_format {
             Ok(CryptoHash::hash_borsh_iter(validator_stakes))
         } else {
             let stakes = validator_stakes.into_iter().map(|stake| stake.clone().into_v1());

--- a/chain/client/src/sync/epoch.rs
+++ b/chain/client/src/sync/epoch.rs
@@ -5,7 +5,7 @@ use near_async::futures::{AsyncComputationSpawner, AsyncComputationSpawnerExt};
 use near_async::messaging::{CanSend, Handler};
 use near_async::time::Clock;
 use near_chain::types::Tip;
-use near_chain::{BlockHeader, Chain, ChainStoreAccess, Doomslug, DoomslugThresholdMode, Error};
+use near_chain::{BlockHeader, Chain, ChainStoreAccess, Error};
 use near_chain_configs::EpochSyncConfig;
 use near_client_primitives::types::{EpochSyncStatus, SyncStatus};
 use near_crypto::Signature;

--- a/core/primitives/src/epoch_sync.rs
+++ b/core/primitives/src/epoch_sync.rs
@@ -11,7 +11,7 @@ use near_primitives_core::types::ProtocolVersion;
 use near_schema_checker_lib::ProtocolSchema;
 use std::fmt::Debug;
 
-/// Proof that the blockchain history had progressed from the genesis (not included here) to the
+/// Proof that the blockchain history had progressed from the genesis to the
 /// current epoch indicated in the proof.
 ///
 /// A side note to better understand the fields in this proof: the last three blocks of any
@@ -21,9 +21,11 @@ use std::fmt::Debug;
 ///   - H + 2: The last block of the epoch
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EpochSyncProof {
-    /// All the past epochs, starting from the first epoch after genesis, to
-    /// the last epoch before the current epoch.
-    pub past_epochs: Vec<EpochSyncProofPastEpochData>,
+    /// All the relevant epochs, starting from the second epoch after genesis (i.e. genesis is
+    /// epoch EpochId::default, and then the next epoch after genesis is fully determined by
+    /// the genesis; after that would be the first epoch included here), to and including the
+    /// current epoch, in that order.
+    pub all_epochs: Vec<EpochSyncProofEpochData>,
     /// Some extra data for the last epoch before the current epoch.
     pub last_epoch: EpochSyncProofLastEpochData,
     /// Extra information to initialize the current epoch we're syncing to.
@@ -62,9 +64,9 @@ impl Debug for CompressedEpochSyncProof {
     }
 }
 
-/// Data needed for each epoch in the past.
+/// Data needed for each epoch covered in the epoch sync proof.
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
-pub struct EpochSyncProofPastEpochData {
+pub struct EpochSyncProofEpochData {
     /// The block producers and their stake, for this epoch. This is verified
     /// against the `next_bp_hash` of the `last_final_block_header` of the epoch before this.
     pub block_producers: Vec<ValidatorStake>,
@@ -85,29 +87,22 @@ pub struct EpochSyncProofPastEpochData {
 pub struct EpochSyncProofLastEpochData {
     /// The following six fields are used to derive the epoch_sync_data_hash included in any
     /// BlockHeaderV3. This is used to verify all the data we need around the epoch sync
-    /// boundary.
+    /// boundary, against `last_final_block_header` in the second last epoch data.
     pub epoch_info: EpochInfo,
     pub next_epoch_info: EpochInfo,
     pub next_next_epoch_info: EpochInfo,
     pub first_block_in_epoch: BlockInfo,
     pub last_block_in_epoch: BlockInfo,
     pub second_last_block_in_epoch: BlockInfo,
-
-    /// Any final block header in the next epoch (i.e. current epoch for the whole proof).
-    /// This is used to provide the `epoch_sync_data_hash` mentioned above.
-    pub final_block_header_in_next_epoch: BlockHeader,
-    /// Approvals for `final_block_header_in_next_epoch`, used to prove that block header
-    /// is valid.
-    pub approvals_for_final_block_in_next_epoch: Vec<Option<Box<Signature>>>,
 }
 
 /// Data needed to initialize the current epoch we're syncing to.
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct EpochSyncProofCurrentEpochData {
     /// The first block header that begins the epoch. It is proven using a merkle proof
-    /// against the final block provided in the LastEpochData. Note that we cannot use signatures
-    /// to prove this like the other cases, because the first block header may not have a
-    /// consecutive height afterwards.
+    /// against `last_final_block_header` in the current epoch data. Note that we cannot
+    /// use signatures to prove this like for the final block, because the first block
+    /// header may not have a consecutive height afterwards.
     pub first_block_header_in_epoch: BlockHeader,
     // The last two block headers are also needed for various purposes after epoch sync.
     // TODO(#11931): do we really need these?

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -510,6 +510,11 @@ pub mod validator_stake {
     #[serde(tag = "validator_stake_struct_version")]
     pub enum ValidatorStake {
         V1(ValidatorStakeV1),
+        // Warning: if you're adding a new version, make sure that the borsh encoding of
+        // any `ValidatorStake` cannot be equal to the borsh encoding of any `ValidatorStakeV1`.
+        // See `EpochSyncProofEpochData::use_versioned_bp_hash_format` for an explanation.
+        // The simplest way to ensure that is to make sure that any new `ValidatorStakeVx`
+        // begins with a field of type `AccountId`.
     }
 
     pub struct ValidatorStakeIter<'a> {

--- a/integration-tests/src/test_loop/tests/epoch_sync.rs
+++ b/integration-tests/src/test_loop/tests/epoch_sync.rs
@@ -369,14 +369,14 @@ fn sanity_check_epoch_sync_proof(
     // EpochSyncProof starts with epoch height 2 because the first height is proven by
     // genesis.
     let mut epoch_height = 2;
-    for past_epoch in &proof.past_epochs {
+    for past_epoch in &proof.all_epochs {
         assert_eq!(
             past_epoch.last_final_block_header.height(),
             genesis_config.genesis_height + epoch_height * genesis_config.epoch_length - 2
         );
         epoch_height += 1;
     }
-    assert_eq!(epoch_height, expected_current_epoch_height);
+    assert_eq!(epoch_height, expected_current_epoch_height + 1);
 }
 
 #[test]


### PR DESCRIPTION
Fix several issues:
* The endorsements for last final block of each epoch actually contain signatures from both that and the next epoch's block producers. While we only need the verify the signatures of this epoch's block producers, the list of approvals included in the next block needs to be trimmed down to exactly these block producers. So when producing the epoch sync proof, we trim down these approvals.
* The endorsements for the last final blocks were verified, but the total stake was not verified to be more than 2/3. This PR fixes that by calling `Doomslug::can_approved_block_be_produced`.
* The block producers list was incorrectly derived from the `EpochInfo`. The `EpochInfo::block_producers_settlement()` returns a list with repeated validator indexes. This PR introduces a `get_epoch_info_block_producers` function that correctly implements this, which is needed for correct verification against the `next_bp_hash`.
* We now use the first block of the target epoch to verify the previous epoch's `epoch_sync_data_hash`. Note that the verification of the first block itself is still pending, due to #12255 .
* As an improvement, the target epoch's final block is now moved from EpochSyncLastEpochData to the past_epochs list, now renamed all_epochs, so we can reduce code duplication for the production and verification of the target epoch's data.

With these fixes, epoch sync proof verification passes tests as well as a manual mainnet epoch sync check.