### PR TITLE
[Epoch Sync] Fix GC error spam and invalid height problem

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -754,7 +754,9 @@ impl Chain {
         // the block might not have been what the block producer originally produced. Either way, it's
         // OK if we miss some cases here because this is just an optimization to avoid reprocessing
         // known invalid blocks so the network recovers faster in case of any issues.
-        if error.is_bad_data() && !matches!(error, Error::InvalidSignature) {
+        if error.is_bad_data()
+            && !matches!(error, Error::InvalidSignature | Error::InvalidBlockHeight(_))
+        {
             metrics::NUM_INVALID_BLOCKS.with_label_values(&[error.prometheus_label_value()]).inc();
             self.invalid_blocks.put(block_hash, ());
         }

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -141,6 +141,10 @@ impl ChainStore {
         let _span = tracing::debug_span!(target: "garbage_collection", "clear_data").entered();
         let tries = runtime_adapter.get_tries();
         let head = self.head()?;
+        if head.height == self.get_genesis_height() {
+            // Nothing to do if head is at genesis. Return early because some of the later queries would fail.
+            return Ok(());
+        }
         let tail = self.tail()?;
         let gc_stop_height = runtime_adapter.get_gc_stop_height(&head.last_block_hash);
         if gc_stop_height > head.height {


### PR DESCRIPTION
* GC prints error because the head is at genesis. Return early in that case. Otherwise while we're doing epoch sync because head remains at genesis, this keeps spamming the logs.
* See #11930 for a header sync problem; a recently received block is marked as invalid because its height is too far ahead of where our head is (genesis). We fix this by not marking blocks as invalid if it's just because of height. The reason why we mark a block as invalid is because we think that the block can never be valid (e.g. due to some state disagreement) so we should not bother trying it again, but if invalid height is the issue, this is counterproductive.

Closes #11930 
Closes #11936 