### PR TITLE
feat: request only missing witness contracts

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -1342,6 +1342,10 @@ impl RuntimeAdapter for NightshadeRuntime {
         let epoch_manager = self.epoch_manager.read();
         Ok(epoch_manager.will_shard_layout_change(parent_hash)?)
     }
+
+    fn compiled_contract_cache(&self) -> &dyn ContractRuntimeCache {
+        self.compiled_contract_cache.as_ref()
+    }
 }
 
 /// Get the limit on the number of new receipts imposed by the local congestion control.

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -55,6 +55,7 @@ use near_store::{
     set_genesis_hash, set_genesis_state_roots, DBCol, ShardTries, Store, StoreUpdate, Trie,
     TrieChanges, WrappedTrieChanges,
 };
+use near_vm_runner::{ContractRuntimeCache, NoContractRuntimeCache};
 use num_rational::Ratio;
 use rand::Rng;
 use std::cmp::Ordering;
@@ -87,6 +88,7 @@ pub struct KeyValueRuntime {
     state: RwLock<HashMap<StateRoot, KVState>>,
     state_size: RwLock<HashMap<StateRoot, u64>>,
     headers_cache: RwLock<HashMap<CryptoHash, BlockHeader>>,
+    contract_cache: NoContractRuntimeCache,
 }
 
 /// DEPRECATED. DO NOT USE for new tests. Use the real EpochManager, familiarize
@@ -373,6 +375,7 @@ impl KeyValueRuntime {
             headers_cache: RwLock::new(HashMap::new()),
             state: RwLock::new(state),
             state_size: RwLock::new(state_size),
+            contract_cache: NoContractRuntimeCache,
         })
     }
 
@@ -1569,5 +1572,9 @@ impl RuntimeAdapter for KeyValueRuntime {
         _parent_hash: &CryptoHash,
     ) -> Result<bool, Error> {
         Ok(false)
+    }
+
+    fn compiled_contract_cache(&self) -> &dyn ContractRuntimeCache {
+        &self.contract_cache
     }
 }

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -40,6 +40,7 @@ use near_primitives::views::{QueryRequest, QueryResponse};
 use near_schema_checker_lib::ProtocolSchema;
 use near_store::flat::FlatStorageManager;
 use near_store::{PartialStorage, ShardTries, Store, Trie, WrappedTrieChanges};
+use near_vm_runner::ContractRuntimeCache;
 use num_rational::Rational32;
 use tracing::instrument;
 
@@ -527,6 +528,8 @@ pub trait RuntimeAdapter: Send + Sync {
 
     fn get_runtime_config(&self, protocol_version: ProtocolVersion)
         -> Result<RuntimeConfig, Error>;
+
+    fn compiled_contract_cache(&self) -> &dyn ContractRuntimeCache;
 }
 
 /// The last known / checked height and time when we have processed it.

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
@@ -5,6 +5,7 @@ use itertools::Itertools;
 use near_async::messaging::{Actor, CanSend, Handler, Sender};
 use near_async::time::Clock;
 use near_async::{MultiSend, MultiSenderFrom};
+use near_chain::types::RuntimeAdapter;
 use near_chain::Error;
 use near_chain_configs::MutableValidatorSigner;
 use near_epoch_manager::EpochManagerAdapter;
@@ -28,7 +29,8 @@ use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::types::{AccountId, EpochId};
 use near_primitives::validator_signer::ValidatorSigner;
 use near_store::adapter::trie_store::TrieStoreAdapter;
-use near_store::{StorageError, Store, TrieDBStorage, TrieStorage};
+use near_store::{StorageError, TrieDBStorage, TrieStorage};
+use near_vm_runner::get_contract_cache_key;
 
 use crate::client_actor::ClientSenderForPartialWitness;
 use crate::metrics;
@@ -48,8 +50,8 @@ pub struct PartialWitnessActor {
     /// Lock the value of mutable validator signer for the duration of a request to ensure consistency.
     /// Please note that the locked value should not be stored anywhere or passed through the thread boundary.
     my_signer: MutableValidatorSigner,
-    /// Epoch manager to get the set of chunk validators
     epoch_manager: Arc<dyn EpochManagerAdapter>,
+    runtime: Arc<dyn RuntimeAdapter>,
     /// Tracks the parts of the state witness sent from chunk producers to chunk validators.
     partial_witness_tracker: PartialEncodedStateWitnessTracker,
     /// Tracks a collection of state witnesses sent from chunk producers to chunk validators.
@@ -57,9 +59,6 @@ pub struct PartialWitnessActor {
     /// Reed Solomon encoder for encoding state witness parts.
     /// We keep one wrapper for each length of chunk_validators to avoid re-creating the encoder.
     encoders: WitnessEncoderCache,
-    /// Currently used to find the chain HEAD when validating partial witnesses,
-    /// but should be removed if we implement retrieving this info from the client
-    store: Store,
 }
 
 impl Actor for PartialWitnessActor {}
@@ -147,7 +146,7 @@ impl PartialWitnessActor {
         client_sender: ClientSenderForPartialWitness,
         my_signer: MutableValidatorSigner,
         epoch_manager: Arc<dyn EpochManagerAdapter>,
-        store: Store,
+        runtime: Arc<dyn RuntimeAdapter>,
     ) -> Self {
         let partial_witness_tracker =
             PartialEncodedStateWitnessTracker::new(client_sender, epoch_manager.clone());
@@ -158,7 +157,7 @@ impl PartialWitnessActor {
             partial_witness_tracker,
             state_witness_tracker: ChunkStateWitnessTracker::new(clock),
             encoders: WitnessEncoderCache::new(),
-            store,
+            runtime,
         }
     }
 
@@ -309,7 +308,7 @@ impl PartialWitnessActor {
             self.epoch_manager.as_ref(),
             &partial_witness,
             &signer,
-            &self.store,
+            self.runtime.store(),
         )? {
             self.forward_state_witness_part(partial_witness)?;
         }
@@ -330,7 +329,7 @@ impl PartialWitnessActor {
             self.epoch_manager.as_ref(),
             &partial_witness,
             &signer,
-            &self.store,
+            self.runtime.store(),
         )? {
             self.partial_witness_tracker.store_partial_encoded_state_witness(partial_witness)?;
         }
@@ -359,19 +358,34 @@ impl PartialWitnessActor {
             self.epoch_manager.as_ref(),
             &accesses,
             &signer,
-            &self.store,
+            self.runtime.store(),
         )? {
             return Ok(());
         }
         let key = accesses.chunk_production_key();
-        let contract_hashes = BTreeSet::from_iter(accesses.contracts().iter().cloned());
+        let contracts_cache = self.runtime.compiled_contract_cache();
+        let runtime_config = self
+            .runtime
+            .get_runtime_config(self.epoch_manager.get_epoch_protocol_version(&key.epoch_id)?)?;
+        let missing_contract_hashes = BTreeSet::from_iter(
+            accesses
+                .contracts()
+                .iter()
+                .filter(|hash| {
+                    !contracts_cache
+                        .has(&get_contract_cache_key(hash.0, &runtime_config.wasm_config))
+                        .is_ok_and(|has| has)
+                })
+                .cloned(),
+        );
+        if missing_contract_hashes.is_empty() {
+            return Ok(());
+        }
         self.partial_witness_tracker
-            .store_accessed_contract_hashes(key.clone(), contract_hashes.clone())?;
-        // TODO(#11099): currently we always request all hashes to test worst case scenario.
-        // Eventually we want to only request ones that are missing from the compiled contracts cache.
+            .store_accessed_contract_hashes(key.clone(), missing_contract_hashes.clone())?;
         let random_chunk_producer =
             self.epoch_manager.get_random_chunk_producer_for_shard(&key.epoch_id, key.shard_id)?;
-        let request = ContractCodeRequest::new(key.clone(), contract_hashes, &signer);
+        let request = ContractCodeRequest::new(key.clone(), missing_contract_hashes, &signer);
         self.network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
             NetworkRequests::ContractCodeRequest(random_chunk_producer, request),
         ));
@@ -397,7 +411,7 @@ impl PartialWitnessActor {
         // TODO(#11099): validate request
         let key = request.chunk_production_key();
         let storage = TrieDBStorage::new(
-            TrieStoreAdapter::new(self.store.clone()),
+            TrieStoreAdapter::new(self.runtime.store().clone()),
             self.epoch_manager.shard_id_to_uid(key.shard_id, &key.epoch_id)?,
         );
         let mut contracts = Vec::new();

--- a/chain/client/src/test_utils/setup.rs
+++ b/chain/client/src/test_utils/setup.rs
@@ -162,7 +162,7 @@ pub fn setup(
         client_adapter_for_partial_witness_actor.as_multi_sender(),
         signer.clone(),
         epoch_manager.clone(),
-        store.clone(),
+        runtime.clone(),
     ));
     let partial_witness_adapter = partial_witness_addr.with_auto_span_context();
 

--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -626,7 +626,7 @@ impl TestLoopBuilder {
             client_adapter.as_multi_sender(),
             validator_signer.clone(),
             epoch_manager.clone(),
-            store,
+            runtime_adapter.clone(),
         );
 
         let gc_actor = GCActor::new(

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -144,7 +144,7 @@ fn setup_network_node(
         client_actor.clone().with_auto_span_context().into_multi_sender(),
         validator_signer,
         epoch_manager,
-        runtime.store().clone(),
+        runtime,
     ));
     shards_manager_adapter.bind(shards_manager_actor.with_auto_span_context());
     let peer_manager = PeerManagerActor::spawn(

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -362,7 +362,7 @@ pub fn start_with_config_and_synchronization(
             client_adapter_for_partial_witness_actor.as_multi_sender(),
             config.validator_signer.clone(),
             epoch_manager.clone(),
-            storage.get_hot_store(),
+            runtime.clone(),
         ));
 
     let (_gc_actor, gc_arbiter) = spawn_actix_actor(GCActor::new(

--- a/runtime/near-vm-runner/src/cache.rs
+++ b/runtime/near-vm-runner/src/cache.rs
@@ -472,10 +472,7 @@ impl AnyCache {
     }
 
     /// Checks if the cache contains the key without modifying the cache.
-    pub fn contains(
-        &self,
-        key: CryptoHash,
-    ) -> bool {
+    pub fn contains(&self, key: CryptoHash) -> bool {
         let Some(cache) = &self.cache else { return false };
         let guard = cache.lock().unwrap();
         guard.contains(&key)

--- a/runtime/near-vm-runner/src/cache.rs
+++ b/runtime/near-vm-runner/src/cache.rs
@@ -470,6 +470,16 @@ impl AnyCache {
         }
         Ok(result)
     }
+
+    /// Checks if the cache contains the key without modifying the cache.
+    pub fn contains(
+        &self,
+        key: CryptoHash,
+    ) -> bool {
+        let Some(cache) = &self.cache else { return false };
+        let guard = cache.lock().unwrap();
+        guard.contains(&key)
+    }
 }
 
 /// Precompiles contract for the current default VM, and stores result to the cache.


### PR DESCRIPTION
This PR adds compiled contracts cache check for contract hashes for witness accessed contracts. We only request contract code for the missing contracts.

Tested in forknet: number of `ContractCodeRequest` and `ContractCodeResponse` became significantly lower than `ChunkContractAccesses`.
Before:
<img width="1489" alt="Screenshot 2024-10-24 at 10 38 03" src="https://github.com/user-attachments/assets/659e0f94-aa1d-4611-b0d7-cb4059423621">
After:
<img width="1491" alt="Screenshot 2024-10-24 at 10 38 32" src="https://github.com/user-attachments/assets/71bd7dac-7429-4c91-89e2-f1e204984838">