### PR TITLE
Do bandwidth scheduler header upgrade the same way as for congestion control

### DIFF
--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -570,7 +570,7 @@ mod tests {
         let shard_ids: Vec<_> = (0..32).map(ShardId::new).collect();
         let genesis_chunks = genesis_chunks(
             vec![Trie::EMPTY_ROOT],
-            vec![Default::default(); shard_ids.len()],
+            vec![Some(Default::default()); shard_ids.len()],
             &shard_ids,
             1_000_000,
             0,

--- a/chain/chain/src/validate.rs
+++ b/chain/chain/src/validate.rs
@@ -220,17 +220,6 @@ fn validate_bandwidth_requests(
     extra_bandwidth_requests: Option<&BandwidthRequests>,
     header_bandwidth_requests: Option<&BandwidthRequests>,
 ) -> Result<(), Error> {
-    if extra_bandwidth_requests.is_none()
-        && header_bandwidth_requests == Some(&BandwidthRequests::empty())
-    {
-        // This corner case happens for the first chunk that has the BandwidthScheduler feature enabled.
-        // The previous chunk was applied with a protocol version which doesn't have bandwidth scheduler
-        // enabled and because of that the bandwidth requests in ChunkExtra are None.
-        // The header was produced in the new protocol version, and the newer version of header always
-        // has some bandwidth requests, it's not an `Option`. Because of that the header requests are `Some(BandwidthRequests::empty())`.
-        return Ok(());
-    }
-
     if extra_bandwidth_requests != header_bandwidth_requests {
         fn requests_len(requests_opt: Option<&BandwidthRequests>) -> usize {
             match requests_opt {

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -216,7 +216,7 @@ impl ChunkSet {
         // Consider making this more realistic.
         let chunks = genesis_chunks(
             vec![StateRoot::new()],
-            vec![Default::default(); shard_ids.len()],
+            vec![Some(Default::default()); shard_ids.len()],
             &shard_ids,
             1000,
             0,

--- a/core/primitives/benches/serialization.rs
+++ b/core/primitives/benches/serialization.rs
@@ -42,7 +42,7 @@ fn create_block() -> Block {
     let shard_ids = vec![ShardId::new(0)];
     let genesis_chunks = genesis_chunks(
         vec![StateRoot::new()],
-        vec![Default::default(); shard_ids.len()],
+        vec![Some(Default::default()); shard_ids.len()],
         &shard_ids,
         1_000,
         0,

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -199,31 +199,11 @@ impl ShardChunkHeaderV3 {
         bandwidth_requests: Option<BandwidthRequests>,
         signer: &ValidatorSigner,
     ) -> Self {
-        let Some(congestion_info) = congestion_info else {
-            // Old inner without congestion info
-            let inner = ShardChunkHeaderInner::V2(ShardChunkHeaderInnerV2 {
-                prev_block_hash,
-                prev_state_root,
-                prev_outcome_root,
-                encoded_merkle_root,
-                encoded_length,
-                height_created: height,
-                shard_id,
-                prev_gas_used,
-                gas_limit,
-                prev_balance_burnt,
-                prev_outgoing_receipts_root,
-                tx_root,
-                prev_validator_proposals,
-            });
-            return Self::from_inner(inner, signer);
-        };
-        // `congestion_info`` can only be `Some` when congestion control is enabled.
-        assert!(ProtocolFeature::CongestionControl.enabled(protocol_version));
+        let inner = if let Some(bandwidth_requests) = bandwidth_requests {
+            // `bandwidth_requests` can only be `Some` when bandwidth scheduler is enabled.
+            assert!(ProtocolFeature::BandwidthScheduler.enabled(protocol_version));
 
-        let bandwidth_requests = bandwidth_requests.unwrap_or_else(BandwidthRequests::empty);
-
-        let inner = if ProtocolFeature::BandwidthScheduler.enabled(protocol_version) {
+            // Congestion control has to be enabled before bandwidth scheduler
             assert!(ProtocolFeature::CongestionControl.enabled(protocol_version));
             ShardChunkHeaderInner::V4(ShardChunkHeaderInnerV4 {
                 prev_block_hash,
@@ -239,10 +219,13 @@ impl ShardChunkHeaderV3 {
                 prev_outgoing_receipts_root,
                 tx_root,
                 prev_validator_proposals,
-                congestion_info,
+                congestion_info: congestion_info
+                    .expect("Congestion info must exist when bandwidth scheduler is enabled"),
                 bandwidth_requests,
             })
-        } else {
+        } else if let Some(congestion_info) = congestion_info {
+            // `congestion_info`` can only be `Some` when congestion control is enabled.
+            assert!(ProtocolFeature::CongestionControl.enabled(protocol_version));
             ShardChunkHeaderInner::V3(ShardChunkHeaderInnerV3 {
                 prev_block_hash,
                 prev_state_root,
@@ -258,6 +241,22 @@ impl ShardChunkHeaderV3 {
                 tx_root,
                 prev_validator_proposals,
                 congestion_info,
+            })
+        } else {
+            ShardChunkHeaderInner::V2(ShardChunkHeaderInnerV2 {
+                prev_block_hash,
+                prev_state_root,
+                prev_outcome_root,
+                encoded_merkle_root,
+                encoded_length,
+                height_created: height,
+                shard_id,
+                prev_gas_used,
+                gas_limit,
+                prev_balance_burnt,
+                prev_outgoing_receipts_root,
+                tx_root,
+                prev_validator_proposals,
             })
         };
         Self::from_inner(inner, signer)
@@ -497,10 +496,13 @@ impl ShardChunkHeader {
                 // Note that we allow V2 in the congestion control version.
                 // That is because the first chunk where this feature is
                 // enabled does not have the congestion info.
-                ShardChunkHeaderInner::V2(_) => version >= BLOCK_HEADER_V3_VERSION,
-                ShardChunkHeaderInner::V3(_) => {
-                    version >= CONGESTION_CONTROL_VERSION && version < BANDWIDTH_SCHEDULER_VERSION
+                // In bandwidth scheduler version v3 and v4 are allowed. The first chunk in
+                // the bandwidth scheduler version will be v3 because the chunk extra for the
+                // last chunk of previous version doesn't have bandwidth requests.
+                ShardChunkHeaderInner::V2(_) => {
+                    version >= BLOCK_HEADER_V3_VERSION && version < BANDWIDTH_SCHEDULER_VERSION
                 }
+                ShardChunkHeaderInner::V3(_) => version >= CONGESTION_CONTROL_VERSION,
                 ShardChunkHeaderInner::V4(_) => version >= BANDWIDTH_SCHEDULER_VERSION,
             },
         }


### PR DESCRIPTION
During review of bandwidth scheduler code, @wacban mentioned that he'd prefer the header upgrade to be done the same way as it was done for congestion control [ref](https://github.com/near/nearcore/pull/12234#discussion_r1812553819), but I wasn't convinced if it's really cleaner.

In this PR I modified the header upgrade to work the same way as it does in congestion control. We can compare the two approaches and choose the better one.

The current approach looks like this:
* Before protocol upgrade to `BandwidthScheduler` version all chunks use `InnerV3`, which doesn't have bandwidth requests in it.
* After the protocol version upgrade all newly produced chunks should have `InnerV4`. Application of the last chunk of the previous protocol version will produce a `ChunkExtra` which doesn't have bandwidth requests (they are set to `None`), so the bandwidth requests in `InnerV4` of the first chunk are set to the default value. Bandwidth requests in `InnerV4` are not an `Option`, so we can't set them to `None`.
* After the first chunk all produced `ChunkExtras` will have `bandwidth_requests` set to `Some`, and they'll be put inside `InnerV4`
* `validate_chunk_with_chunk_extra_and_receipts_root` needs to be aware of what happens at the first block and allow situations where the bandwidth requests in `ChunkExtra` are `None`, but they're `Some(Default::default())` in the chunk header.

The congestion-control-like approach looks like this:
* Before protocol upgrade to `BandwidthScheduler` version all chunks use `InnerV3`, which doesn't have bandwidth requests in it.
* The first chunk after the upgrade will still use `InnerV3` because the `bandwidth_requests` in `ChunkExtra` are None.
* For future chunks the `bandwidth_requests` in `ChunkExtra` will be `Some` and all chunks will use `InnerV4` with the requests.
* `validate_chunk_with_chunk_extra_and_receipts_root` can do a direct comparison between the bandwidth requests in chunk extra and chunk header.


In the current approach I like the exactness - all chunk headers produced with the new protocol version have a new version of `Inner`. We don't allow multiple header versions in one protocol version. The only problem is that we need to have the special corner case check in  `validate_chunk_with_chunk_extra_and_receipts_root` . I think we also need to make sure that we validate the header versions for endorsed chunks, using `is_valid_for` or something like that.

The congestion-control-like approach doesn't have the weird corner case, which is nice. It also doesn't require such strick validation of header version - headers with wrong version will get rejected by chunk extra validation because of None/Some difference. But it's much less exact. We allow multiple inner versions for one protocol version, and I find that much harder to reason about. I'm not sure what happens at genesis chunks, it looks like we set the congestion infos to None, but that means that genesis chunks would always have `InnerV2`, which would get upgraded to `Inner<latest>` on the first chunk. weird. I changed them to `Some(CongestionInfo::default())`, I think that makes things a bit better, as now the chain starts with the current version of `Inner`.

Yet another approach would be to make bandwidth requests an `Option` in `InnerV4`. They would be `None` on the first chunk and `Some` on the next chunks. We could directly compare that with the requests in `ChunkExtra`. But it's a bit sad that we'd have an `Option ` for something that's supposed to always be there :/