### PR TITLE
cleanup(resharding) - remove temporary methods after the ShardId transition

### DIFF
--- a/chain/chain/src/resharding/event_type.rs
+++ b/chain/chain/src/resharding/event_type.rs
@@ -3,7 +3,7 @@
 use near_chain_primitives::Error;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
-use near_primitives::types::{shard_id_as_u32, AccountId};
+use near_primitives::types::AccountId;
 use near_store::ShardUId;
 use tracing::error;
 
@@ -77,10 +77,7 @@ impl ReshardingEventType {
                         return log_and_error("can't perform two reshardings at the same time!");
                     }
                     // Parent shard is no longer part of this shard layout.
-                    let parent_shard = ShardUId {
-                        version: next_shard_layout.version(),
-                        shard_id: shard_id_as_u32(*parent_id),
-                    };
+                    let parent_shard = ShardUId::new(next_shard_layout.version(), *parent_id);
                     let left_child_shard =
                         ShardUId::from_shard_id_and_layout(children_ids[0], next_shard_layout);
                     let right_child_shard =

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -29,8 +29,8 @@ use near_primitives::state_part::PartId;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{
-    shard_id_as_u32, AccountId, Balance, BlockHeight, EpochHeight, EpochId, EpochInfoProvider, Gas,
-    MerkleHash, ShardId, StateChangeCause, StateRoot, StateRootNode,
+    AccountId, Balance, BlockHeight, EpochHeight, EpochId, EpochInfoProvider, Gas, MerkleHash,
+    ShardId, StateChangeCause, StateRoot, StateRootNode,
 };
 use near_primitives::version::{ProtocolFeature, ProtocolVersion};
 use near_primitives::views::{
@@ -223,7 +223,7 @@ impl NightshadeRuntime {
             epoch_manager.get_epoch_id_from_prev_block(prev_hash).map_err(Error::from)?;
         let shard_version =
             epoch_manager.get_shard_layout(&epoch_id).map_err(Error::from)?.version();
-        Ok(ShardUId { version: shard_version, shard_id: shard_id_as_u32(shard_id) })
+        Ok(ShardUId::new(shard_version, shard_id))
     }
 
     fn get_shard_uid_from_epoch_id(
@@ -234,7 +234,7 @@ impl NightshadeRuntime {
         let epoch_manager = self.epoch_manager.read();
         let shard_version =
             epoch_manager.get_shard_layout(epoch_id).map_err(Error::from)?.version();
-        Ok(ShardUId { version: shard_version, shard_id: shard_id_as_u32(shard_id) })
+        Ok(ShardUId::new(shard_version, shard_id))
     }
 
     fn account_id_to_shard_uid(

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -43,8 +43,8 @@ use near_primitives::transaction::{
 };
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
-    shard_id_as_u32, AccountId, ApprovalStake, Balance, BlockHeight, EpochHeight, EpochId, Nonce,
-    NumShards, ShardId, ShardIndex, StateRoot, StateRootNode, ValidatorInfoIdentifier,
+    AccountId, ApprovalStake, Balance, BlockHeight, EpochHeight, EpochId, Nonce, NumShards,
+    ShardId, ShardIndex, StateRoot, StateRootNode, ValidatorInfoIdentifier,
 };
 use near_primitives::version::{ProtocolFeature, ProtocolVersion, PROTOCOL_VERSION};
 use near_primitives::views::{
@@ -481,7 +481,7 @@ impl EpochManagerAdapter for MockEpochManager {
         shard_id: ShardId,
         _epoch_id: &EpochId,
     ) -> Result<ShardUId, EpochError> {
-        Ok(ShardUId { version: 0, shard_id: shard_id_as_u32(shard_id) })
+        Ok(ShardUId::new(0, shard_id))
     }
 
     fn shard_id_to_index(
@@ -1165,10 +1165,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         state_root: StateRoot,
         _use_flat_storage: bool,
     ) -> Result<Trie, Error> {
-        Ok(self.tries.get_trie_for_shard(
-            ShardUId { version: 0, shard_id: shard_id_as_u32(shard_id) },
-            state_root,
-        ))
+        Ok(self.tries.get_trie_for_shard(ShardUId::new(0, shard_id), state_root))
     }
 
     fn get_flat_storage_manager(&self) -> near_store::flat::FlatStorageManager {
@@ -1181,10 +1178,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         _block_hash: &CryptoHash,
         state_root: StateRoot,
     ) -> Result<Trie, Error> {
-        Ok(self.tries.get_view_trie_for_shard(
-            ShardUId { version: 0, shard_id: shard_id_as_u32(shard_id) },
-            state_root,
-        ))
+        Ok(self.tries.get_view_trie_for_shard(ShardUId::new(0, shard_id), state_root))
     }
 
     fn validate_tx(
@@ -1367,7 +1361,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         Ok(ApplyChunkResult {
             trie_changes: WrappedTrieChanges::new(
                 self.get_tries(),
-                ShardUId { version: 0, shard_id: shard_id_as_u32(shard_id) },
+                ShardUId::new(0, shard_id),
                 TrieChanges::empty(state_root),
                 Default::default(),
                 block.block_hash,

--- a/chain/chunks/src/client.rs
+++ b/chain/chunks/src/client.rs
@@ -163,7 +163,7 @@ mod tests {
         hash::CryptoHash,
         shard_layout::{account_id_to_shard_uid, ShardLayout},
         transaction::SignedTransaction,
-        types::{shard_id_as_u32, AccountId, ShardId},
+        types::{AccountId, ShardId},
     };
     use near_store::ShardUId;
     use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
@@ -237,10 +237,7 @@ mod tests {
                 CryptoHash::default(),
             );
 
-            let shard_uid = ShardUId {
-                shard_id: shard_id_as_u32(signer_shard_id),
-                version: old_shard_layout.version(),
-            };
+            let shard_uid = ShardUId::new(old_shard_layout.version(), signer_shard_id);
             pool.insert_transaction(shard_uid, tx);
         }
 
@@ -255,8 +252,7 @@ mod tests {
         {
             let shard_ids: Vec<_> = new_shard_layout.shard_ids().collect();
             for &shard_id in shard_ids.iter() {
-                let shard_id = shard_id_as_u32(shard_id);
-                let shard_uid = ShardUId { shard_id, version: new_shard_layout.version() };
+                let shard_uid = ShardUId::new(new_shard_layout.version(), shard_id);
                 let pool = pool.pool_for_shard(shard_uid);
                 let pool_len = pool.len();
                 tracing::debug!("checking shard_uid {shard_uid:?}, the pool len is {pool_len}");
@@ -265,8 +261,7 @@ mod tests {
 
             let mut total = 0;
             for shard_id in shard_ids {
-                let shard_id = shard_id_as_u32(shard_id);
-                let shard_uid = ShardUId { shard_id, version: new_shard_layout.version() };
+                let shard_uid = ShardUId::new(new_shard_layout.version(), shard_id);
                 let mut pool_iter = pool.get_pool_iterator(shard_uid).unwrap();
                 while let Some(group) = pool_iter.next() {
                     while let Some(tx) = group.next() {

--- a/chain/chunks/src/client.rs
+++ b/chain/chunks/src/client.rs
@@ -6,7 +6,6 @@ use itertools::Itertools;
 use near_pool::types::TransactionGroupIterator;
 use near_pool::{InsertTransactionResult, PoolIteratorWrapper, TransactionPool};
 use near_primitives::shard_layout::{account_id_to_shard_uid, ShardLayout, ShardUId};
-use near_primitives::types::shard_id_as_u16;
 use near_primitives::{
     epoch_info::RngSeed,
     sharding::{EncodedShardChunk, PartialEncodedChunk, ShardChunk, ShardChunkHeader},
@@ -76,7 +75,7 @@ impl ShardedTransactionPool {
     /// For better security we want the seed to different in each shard.
     /// For testing purposes we want it to be the reproducible and derived from the `self.rng_seed` and `shard_id`
     fn random_seed(base_seed: &RngSeed, shard_id: ShardId) -> RngSeed {
-        let shard_id = shard_id_as_u16(shard_id);
+        let shard_id: u16 = shard_id.into();
         let mut res = *base_seed;
         res[0] = shard_id as u8;
         res[1] = (shard_id / 256) as u8;

--- a/chain/client/src/stateless_validation/chunk_validator/orphan_witness_pool.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/orphan_witness_pool.rs
@@ -180,7 +180,7 @@ mod tests {
     use near_primitives::hash::{hash, CryptoHash};
     use near_primitives::sharding::{ShardChunkHeader, ShardChunkHeaderInner};
     use near_primitives::stateless_validation::state_witness::ChunkStateWitness;
-    use near_primitives::types::{shard_id_max, BlockHeight, ShardId};
+    use near_primitives::types::{BlockHeight, ShardId};
 
     use super::OrphanStateWitnessPool;
 
@@ -337,7 +337,7 @@ mod tests {
     fn large_shard_id() {
         let mut pool = OrphanStateWitnessPool::new(10);
 
-        let large_shard_id = shard_id_max();
+        let large_shard_id = ShardId::max();
         let witness = make_witness(101, large_shard_id.into(), block(99), 0);
         pool.add_orphan_state_witness(witness.clone(), 0);
 

--- a/chain/client/src/tests/bug_repros.rs
+++ b/chain/client/src/tests/bug_repros.rs
@@ -10,7 +10,7 @@ use futures::FutureExt;
 use near_async::messaging::CanSend;
 use near_async::time::Clock;
 use near_network::shards_manager::ShardsManagerRequestFromNetwork;
-use near_primitives::types::shard_id_as_usize;
+use near_primitives::types::ShardIndex;
 use rand::{thread_rng, Rng};
 
 use crate::test_utils::{setup_mock_all_validators, ActorHandlesForTesting};
@@ -113,7 +113,7 @@ fn repro_1183() {
                             // This test uses the V0 shard layout so it's ok to
                             // cast ShardId to ShardIndex.
                             let shard_id = account_id_to_shard_id(&from, 4);
-                            let shard_index = shard_id_as_usize(shard_id);
+                            let shard_index: ShardIndex = shard_id.into();
                             connectors1.write().unwrap()[shard_index].client_actor.do_send(
                                 ProcessTxRequest {
                                     transaction: SignedTransaction::send_money(

--- a/chain/client/src/tests/cross_shard_tx.rs
+++ b/chain/client/src/tests/cross_shard_tx.rs
@@ -481,13 +481,6 @@ fn test_cross_shard_tx_common(
             let msg = near_client_primitives::types::GetBlock(block_reference);
             conn[0].view_client_actor.send(msg.with_span_context()).await.unwrap().unwrap()
         };
-        let shard_layout = {
-            let block_reference = BlockReference::BlockId(BlockId::Height(0));
-            let msg = near_client_primitives::types::GetProtocolConfig(block_reference);
-            let msg = msg.with_span_context();
-            let protocol_config = conn[0].view_client_actor.send(msg).await.unwrap().unwrap();
-            protocol_config.shard_layout
-        };
         *connectors.write().unwrap() = conn;
         let block_hash = genesis_block.header.hash;
 
@@ -518,7 +511,7 @@ fn test_cross_shard_tx_common(
             let block_stats1 = block_stats.clone();
 
             let shard_id = account_id_to_shard_id(&validators[i], 8);
-            let shard_index = shard_layout.get_shard_index(shard_id);
+            let shard_index: ShardIndex = shard_id.into();
 
             let actor =
                 &connectors_[shard_index + *presumable_epoch.read().unwrap() * 8].view_client_actor;

--- a/chain/client/src/tests/cross_shard_tx.rs
+++ b/chain/client/src/tests/cross_shard_tx.rs
@@ -17,7 +17,7 @@ use near_o11y::testonly::init_integration_logger;
 use near_o11y::WithSpanContextExt;
 use near_primitives::hash::CryptoHash;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{shard_id_as_usize, AccountId, BlockId, BlockReference};
+use near_primitives::types::{AccountId, BlockId, BlockReference, ShardIndex};
 use near_primitives::views::QueryResponseKind::ViewAccount;
 use near_primitives::views::{QueryRequest, QueryResponse};
 use std::collections::HashSet;
@@ -192,7 +192,7 @@ fn test_cross_shard_tx_callback(
             // This test uses the V0 shard layout so it's ok to cast ShardId to
             // ShardIndex.
             let shard_id = account_id_to_shard_id(&account_id, 8);
-            let shard_index = shard_id_as_usize(shard_id);
+            let shard_index: ShardIndex = shard_id.into();
             let actor = &connectors_[shard_index + (*presumable_epoch.read().unwrap() * 8) % 24]
                 .view_client_actor;
             let actor = actor.send(
@@ -260,7 +260,7 @@ fn test_cross_shard_tx_callback(
                 // This test uses the V0 shard layout so it's ok to cast ShardId to
                 // ShardIndex.
                 let shard_id = account_id_to_shard_id(&validators[from], 8);
-                let shard_index = shard_id_as_usize(shard_id);
+                let shard_index: ShardIndex = shard_id.into();
 
                 send_tx(
                     validators.len(),
@@ -299,7 +299,7 @@ fn test_cross_shard_tx_callback(
                     // This test uses the V0 shard layout so it's ok to cast ShardId to
                     // ShardIndex.
                     let shard_id = account_id_to_shard_id(&validators[i], 8);
-                    let shard_index = shard_id_as_usize(shard_id);
+                    let shard_index: ShardIndex = shard_id.into();
 
                     let actor = &connectors_
                         [shard_index + (*presumable_epoch.read().unwrap() * 8) % 24]
@@ -359,7 +359,7 @@ fn test_cross_shard_tx_callback(
             // This test uses the V0 shard layout so it's ok to cast ShardId to
             // ShardIndex.
             let shard_id = account_id_to_shard_id(&account_id, 8);
-            let shard_index = shard_id_as_usize(shard_id);
+            let shard_index: ShardIndex = shard_id.into();
 
             let actor = &connectors_[shard_index + (*presumable_epoch.read().unwrap() * 8) % 24]
                 .view_client_actor;

--- a/chain/client/src/tests/cross_shard_tx.rs
+++ b/chain/client/src/tests/cross_shard_tx.rs
@@ -477,17 +477,16 @@ fn test_cross_shard_tx_common(
             }),
         );
         let genesis_block = {
-            conn[0]
-                .view_client_actor
-                .send(
-                    near_client_primitives::types::GetBlock(BlockReference::BlockId(
-                        BlockId::Height(0),
-                    ))
-                    .with_span_context(),
-                )
-                .await
-                .unwrap()
-                .unwrap()
+            let block_reference = BlockReference::BlockId(BlockId::Height(0));
+            let msg = near_client_primitives::types::GetBlock(block_reference);
+            conn[0].view_client_actor.send(msg.with_span_context()).await.unwrap().unwrap()
+        };
+        let shard_layout = {
+            let block_reference = BlockReference::BlockId(BlockId::Height(0));
+            let msg = near_client_primitives::types::GetProtocolConfig(block_reference);
+            let msg = msg.with_span_context();
+            let protocol_config = conn[0].view_client_actor.send(msg).await.unwrap().unwrap();
+            protocol_config.shard_layout
         };
         *connectors.write().unwrap() = conn;
         let block_hash = genesis_block.header.hash;
@@ -518,10 +517,8 @@ fn test_cross_shard_tx_common(
             let account_id1 = validators[i].clone();
             let block_stats1 = block_stats.clone();
 
-            // This test uses the V0 shard layout so it's ok to cast ShardId to
-            // ShardIndex.
             let shard_id = account_id_to_shard_id(&validators[i], 8);
-            let shard_index = shard_id_as_usize(shard_id);
+            let shard_index = shard_layout.get_shard_index(shard_id);
 
             let actor =
                 &connectors_[shard_index + *presumable_epoch.read().unwrap() * 8].view_client_actor;

--- a/chain/network/src/peer_manager/tests/snapshot_hosts.rs
+++ b/chain/network/src/peer_manager/tests/snapshot_hosts.rs
@@ -17,7 +17,6 @@ use near_o11y::testonly::init_test_logger;
 use near_o11y::WithSpanContextExt;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
-use near_primitives::types::shard_id_as_u64;
 use near_primitives::types::EpochHeight;
 use near_primitives::types::ShardId;
 use peer_manager::testonly::FDS_PER_PEER;
@@ -371,14 +370,13 @@ async fn large_shard_id_in_cache() {
     let peer1 = pm.start_inbound(chain.clone(), peer1_config.clone()).await.handshake(clock).await;
 
     tracing::info!(target:"test", "Send a SnapshotHostInfo message with very large shard ids.");
-    let max_shard_id = ShardId::max();
-    let max_shard_id_minus_one = shard_id_as_u64(max_shard_id) - 1;
-    let max_shard_id_minus_one = ShardId::new(max_shard_id_minus_one);
+    let large_shard_id_1 = ShardId::new(u64::MAX - 1);
+    let large_shard_id_2 = ShardId::new(u64::MAX);
     let big_shard_info = Arc::new(SnapshotHostInfo::new(
         peer1_config.node_id(),
         CryptoHash::hash_borsh(1234_u64),
         1234,
-        vec![ShardId::new(0), ShardId::new(1232232), max_shard_id_minus_one, max_shard_id]
+        vec![ShardId::new(0), ShardId::new(1232232), large_shard_id_1, large_shard_id_2]
             .into_iter()
             .collect(),
         &peer1_config.node_key,
@@ -451,7 +449,7 @@ async fn too_many_shards_truncate() {
     assert_eq!(info.shards.len(), MAX_SHARDS_PER_SNAPSHOT_HOST_INFO);
     for &shard_id in &info.shards {
         // Shard ids are taken from the original vector
-        assert!(shard_id_as_u64(shard_id) < 2 * MAX_SHARDS_PER_SNAPSHOT_HOST_INFO as u64);
+        assert!(shard_id.get() < 2 * MAX_SHARDS_PER_SNAPSHOT_HOST_INFO as u64);
     }
     // The shard_ids are sorted and unique (no two elements are equal, hence the < condition instead of <=)
     assert!(info.shards.windows(2).all(|twoelems| twoelems[0] < twoelems[1]));

--- a/chain/network/src/peer_manager/tests/snapshot_hosts.rs
+++ b/chain/network/src/peer_manager/tests/snapshot_hosts.rs
@@ -449,7 +449,7 @@ async fn too_many_shards_truncate() {
     assert_eq!(info.shards.len(), MAX_SHARDS_PER_SNAPSHOT_HOST_INFO);
     for &shard_id in &info.shards {
         // Shard ids are taken from the original vector
-        assert!(shard_id.get() < 2 * MAX_SHARDS_PER_SNAPSHOT_HOST_INFO as u64);
+        assert!(shard_id < 2 * MAX_SHARDS_PER_SNAPSHOT_HOST_INFO as u64);
     }
     // The shard_ids are sorted and unique (no two elements are equal, hence the < condition instead of <=)
     assert!(info.shards.windows(2).all(|twoelems| twoelems[0] < twoelems[1]));

--- a/chain/network/src/peer_manager/tests/snapshot_hosts.rs
+++ b/chain/network/src/peer_manager/tests/snapshot_hosts.rs
@@ -18,7 +18,6 @@ use near_o11y::WithSpanContextExt;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
 use near_primitives::types::shard_id_as_u64;
-use near_primitives::types::shard_id_max;
 use near_primitives::types::EpochHeight;
 use near_primitives::types::ShardId;
 use peer_manager::testonly::FDS_PER_PEER;
@@ -372,7 +371,7 @@ async fn large_shard_id_in_cache() {
     let peer1 = pm.start_inbound(chain.clone(), peer1_config.clone()).await.handshake(clock).await;
 
     tracing::info!(target:"test", "Send a SnapshotHostInfo message with very large shard ids.");
-    let max_shard_id = shard_id_max();
+    let max_shard_id = ShardId::max();
     let max_shard_id_minus_one = shard_id_as_u64(max_shard_id) - 1;
     let max_shard_id_minus_one = ShardId::new(max_shard_id_minus_one);
     let big_shard_info = Arc::new(SnapshotHostInfo::new(

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -84,23 +84,22 @@ impl ShardId {
     /// to convert a shard index (a number in 0..num_shards range) to ShardId.
     /// Instead the ShardId should be obtained from the shard_layout.
     ///
+    /// ```rust, ignore
+    /// // BAD USAGE:
+    /// for shard_index in 0..num_shards {
+    ///     let shard_id = ShardId::new(shard_index); // Incorrect!!!
+    /// }
     /// ```
-    // // BAD USAGE:
-    // for shard_index in 1..num_shards {
-    //     let shard_id = ShardId::new(shard_index); // Incorrect!!!
-    // }
-    // ```
-    // ```
-    // // GOOD USAGE 1:
-    // for shard_index in 1..num_shards {
-    //     let shard_id = shard_layout.get_shard_id(shard_index);
-    // }
-    // // GOOD USAGE 2:
-    // for shard_id in shard_layout.shard_ids() {
-    //     let shard_id = shard_layout.get_shard_id(shard_index);
-    // }
-    // ```
-    // TODO - fix doctests
+    /// ```rust, ignore
+    /// // GOOD USAGE 1:
+    /// for shard_index in 0..num_shards {
+    ///     let shard_id = shard_layout.get_shard_id(shard_index);
+    /// }
+    /// // GOOD USAGE 2:
+    /// for shard_id in shard_layout.shard_ids() {
+    ///     let shard_id = shard_layout.get_shard_id(shard_index);
+    /// }
+    /// ```
     pub const fn new(id: u64) -> Self {
         Self(id)
     }

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -55,13 +55,6 @@ pub type ProtocolVersion = u32;
 /// used instead.
 pub type ShardIndex = usize;
 
-// TODO(wacban) This is a temporary solution to aid the transition to having
-// ShardId as a newtype. It should be replaced / removed / inlined once the
-// transition is complete.
-pub const fn shard_id_as_u64(id: ShardId) -> u64 {
-    return id.get();
-}
-
 // TODO(wacban) Complete the transition to ShardId as a newtype.
 /// The shard identifier. It may be a arbitrary number - it does not need to be
 /// a number in the range 0..NUM_SHARDS. The shard ids do not need to be

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -58,13 +58,6 @@ pub type ShardIndex = usize;
 // TODO(wacban) This is a temporary solution to aid the transition to having
 // ShardId as a newtype. It should be replaced / removed / inlined once the
 // transition is complete.
-pub const fn shard_id_as_u16(id: ShardId) -> u16 {
-    return id.get() as u16;
-}
-
-// TODO(wacban) This is a temporary solution to aid the transition to having
-// ShardId as a newtype. It should be replaced / removed / inlined once the
-// transition is complete.
 pub const fn shard_id_as_u32(id: ShardId) -> u32 {
     return id.get() as u32;
 }

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -55,10 +55,6 @@ pub type ProtocolVersion = u32;
 /// used instead.
 pub type ShardIndex = usize;
 
-pub fn shard_id_max() -> ShardId {
-    return ShardId::max();
-}
-
 // TODO(wacban) This is a temporary solution to aid the transition to having
 // ShardId as a newtype. It should be replaced / removed / inlined once the
 // transition is complete.

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -55,7 +55,6 @@ pub type ProtocolVersion = u32;
 /// used instead.
 pub type ShardIndex = usize;
 
-// TODO(wacban) Complete the transition to ShardId as a newtype.
 /// The shard identifier. It may be a arbitrary number - it does not need to be
 /// a number in the range 0..NUM_SHARDS. The shard ids do not need to be
 /// sequential or contiguous.
@@ -106,14 +105,12 @@ impl ShardId {
         Self(id)
     }
 
-    /// Get the numerical value of the shard id. This should not be used as an
-    /// index into an array, as the shard id may be any arbitrary number.
-    pub const fn get(self) -> u64 {
-        self.0
-    }
-
     pub fn to_le_bytes(self) -> [u8; 8] {
         self.0.to_le_bytes()
+    }
+
+    pub fn to_be_bytes(self) -> [u8; 8] {
+        self.0.to_be_bytes()
     }
 
     pub fn from_le_bytes(bytes: [u8; 8]) -> Self {
@@ -195,6 +192,18 @@ where
 
     fn add(self, rhs: T) -> Self::Output {
         Self(T::add(rhs, self.0))
+    }
+}
+
+impl PartialEq<u64> for ShardId {
+    fn eq(&self, other: &u64) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialOrd<u64> for ShardId {
+    fn partial_cmp(&self, other: &u64) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(other)
     }
 }
 

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -58,13 +58,6 @@ pub type ShardIndex = usize;
 // TODO(wacban) This is a temporary solution to aid the transition to having
 // ShardId as a newtype. It should be replaced / removed / inlined once the
 // transition is complete.
-pub const fn shard_id_as_u32(id: ShardId) -> u32 {
-    return id.get() as u32;
-}
-
-// TODO(wacban) This is a temporary solution to aid the transition to having
-// ShardId as a newtype. It should be replaced / removed / inlined once the
-// transition is complete.
 pub const fn shard_id_as_u64(id: ShardId) -> u64 {
     return id.get();
 }

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -58,13 +58,6 @@ pub type ShardIndex = usize;
 // TODO(wacban) This is a temporary solution to aid the transition to having
 // ShardId as a newtype. It should be replaced / removed / inlined once the
 // transition is complete.
-pub const fn shard_id_as_usize(id: ShardId) -> usize {
-    return id.get() as usize;
-}
-
-// TODO(wacban) This is a temporary solution to aid the transition to having
-// ShardId as a newtype. It should be replaced / removed / inlined once the
-// transition is complete.
 pub const fn shard_id_as_u16(id: ShardId) -> u16 {
     return id.get() as u16;
 }
@@ -206,6 +199,12 @@ impl From<u16> for ShardId {
 impl Into<u16> for ShardId {
     fn into(self) -> u16 {
         self.0 as u16
+    }
+}
+
+impl Into<usize> for ShardId {
+    fn into(self) -> usize {
+        self.0 as usize
     }
 }
 

--- a/core/primitives/src/congestion_info.rs
+++ b/core/primitives/src/congestion_info.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use crate::errors::RuntimeError;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_parameters::config::CongestionControlConfig;
-use near_primitives_core::types::{shard_id_as_u16, Gas, ShardId};
+use near_primitives_core::types::{Gas, ShardId};
 use near_schema_checker_lib::ProtocolSchema;
 use ordered_float::NotNan;
 
@@ -85,7 +85,7 @@ impl CongestionControl {
         // `clamped_f64_fraction` clamps to exactly 1.0.
         if congestion == 1.0 {
             // Red traffic light: reduce to minimum speed
-            if shard_id_as_u16(sender_shard) == self.info.allowed_shard() {
+            if sender_shard == ShardId::from(self.info.allowed_shard()) {
                 self.config.allowed_shard_outgoing_gas
             } else {
                 0
@@ -97,7 +97,7 @@ impl CongestionControl {
 
     /// How much data another shard can send to us in the next block.
     pub fn outgoing_size_limit(&self, sender_shard: ShardId) -> Gas {
-        if shard_id_as_u16(sender_shard) == self.info.allowed_shard() {
+        if sender_shard == ShardId::from(self.info.allowed_shard()) {
             // The allowed shard is allowed to send more data to us.
             self.config.outgoing_receipts_big_size_limit
         } else {
@@ -347,7 +347,7 @@ impl CongestionInfo {
         congestion_seed: u64,
     ) {
         let allowed_shard = Self::get_new_allowed_shard(own_shard, all_shards, congestion_seed);
-        self.set_allowed_shard(shard_id_as_u16(allowed_shard));
+        self.set_allowed_shard(allowed_shard.into());
     }
 
     fn get_new_allowed_shard(
@@ -845,7 +845,7 @@ mod tests {
 
         // Full congestion - only the allowed shard should be able to send something.
         for shard in all_shards {
-            if shard_id_as_u16(shard) == control.info.allowed_shard() {
+            if shard == ShardId::from(control.info.allowed_shard()) {
                 assert_eq!(control.outgoing_gas_limit(shard), config.allowed_shard_outgoing_gas);
             } else {
                 assert_eq!(control.outgoing_gas_limit(shard), 0);

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -2,7 +2,7 @@ use crate::hash::CryptoHash;
 use crate::types::{AccountId, NumShards};
 use borsh::{BorshDeserialize, BorshSerialize};
 use itertools::Itertools;
-use near_primitives_core::types::{shard_id_as_u32, shard_id_as_u64, ShardId, ShardIndex};
+use near_primitives_core::types::{shard_id_as_u64, ShardId, ShardIndex};
 use near_schema_checker_lib::ProtocolSchema;
 use std::collections::BTreeMap;
 use std::{fmt, str};
@@ -618,6 +618,10 @@ pub struct ShardUId {
 }
 
 impl ShardUId {
+    pub fn new(version: ShardVersion, shard_id: ShardId) -> Self {
+        Self { version, shard_id: shard_id.into() }
+    }
+
     pub fn single_shard() -> Self {
         Self { version: 0, shard_id: 0 }
     }
@@ -651,7 +655,7 @@ impl ShardUId {
     /// Constructs a shard uid from shard id and a shard layout
     pub fn from_shard_id_and_layout(shard_id: ShardId, shard_layout: &ShardLayout) -> Self {
         assert!(shard_layout.shard_ids().any(|i| i == shard_id));
-        Self { shard_id: shard_id_as_u32(shard_id), version: shard_layout.version() }
+        Self::new(shard_layout.version(), shard_id)
     }
 
     /// Returns shard id

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -2,7 +2,7 @@ use crate::hash::CryptoHash;
 use crate::types::{AccountId, NumShards};
 use borsh::{BorshDeserialize, BorshSerialize};
 use itertools::Itertools;
-use near_primitives_core::types::{shard_id_as_u64, ShardId, ShardIndex};
+use near_primitives_core::types::{ShardId, ShardIndex};
 use near_schema_checker_lib::ProtocolSchema;
 use std::collections::BTreeMap;
 use std::{fmt, str};
@@ -265,7 +265,7 @@ impl ShardLayout {
                 for &shard_id in shard_ids {
                     let prev = to_parent_shard_map.insert(shard_id, parent_shard_id);
                     assert!(prev.is_none(), "no shard should appear in the map twice");
-                    assert!(shard_id_as_u64(shard_id) < num_shards, "shard id should be valid");
+                    assert!(shard_id.get() < num_shards, "shard id should be valid");
                 }
             }
             Some((0..num_shards).map(|shard_id| to_parent_shard_map[&shard_id.into()]).collect())
@@ -808,7 +808,7 @@ mod tests {
         ShardLayoutV1, ShardUId,
     };
     use itertools::Itertools;
-    use near_primitives_core::types::{shard_id_as_u64, ProtocolVersion};
+    use near_primitives_core::types::ProtocolVersion;
     use near_primitives_core::types::{AccountId, ShardId};
     use near_primitives_core::version::{ProtocolFeature, PROTOCOL_VERSION};
     use rand::distributions::Alphanumeric;
@@ -885,7 +885,7 @@ mod tests {
             let s = String::from_utf8(s).unwrap();
             let account_id = s.to_lowercase().parse().unwrap();
             let shard_id = account_id_to_shard_id(&account_id, &shard_layout);
-            assert!(shard_id_as_u64(shard_id) < num_shards);
+            assert!(shard_id.get() < num_shards);
             *shard_id_distribution.get_mut(&shard_id).unwrap() += 1;
         }
         let expected_distribution: HashMap<ShardId, _> = [

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -265,7 +265,7 @@ impl ShardLayout {
                 for &shard_id in shard_ids {
                     let prev = to_parent_shard_map.insert(shard_id, parent_shard_id);
                     assert!(prev.is_none(), "no shard should appear in the map twice");
-                    assert!(shard_id.get() < num_shards, "shard id should be valid");
+                    assert!(shard_id < num_shards, "shard id should be valid");
                 }
             }
             Some((0..num_shards).map(|shard_id| to_parent_shard_map[&shard_id.into()]).collect())
@@ -885,7 +885,7 @@ mod tests {
             let s = String::from_utf8(s).unwrap();
             let account_id = s.to_lowercase().parse().unwrap();
             let shard_id = account_id_to_shard_id(&account_id, &shard_layout);
-            assert!(shard_id.get() < num_shards);
+            assert!(shard_id < num_shards);
             *shard_id_distribution.get_mut(&shard_id).unwrap() += 1;
         }
         let expected_distribution: HashMap<ShardId, _> = [

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -331,7 +331,7 @@ impl TrieKey {
                 let receiving_shard = *receiving_shard;
                 buf.push(col::BUFFERED_RECEIPT);
                 // Use  u16 for shard id to reduce depth in trie.
-                assert!(receiving_shard.get() <= u16::MAX as u64, "Shard ID too big.");
+                assert!(receiving_shard <= u16::MAX as u64, "Shard ID too big.");
                 let receiving_shard: u16 = receiving_shard.into();
                 buf.extend(&receiving_shard.to_le_bytes());
                 buf.extend(&index.to_le_bytes());
@@ -892,7 +892,7 @@ mod tests {
         let shard_layout = ShardLayout::for_protocol_version(PROTOCOL_VERSION);
         let max_id = shard_layout.shard_ids().max().unwrap();
         assert!(
-            max_id.get() <= u16::MAX as u64,
+            max_id <= u16::MAX as u64,
             "buffered receipt trie key optimization broken, must fit in a u16"
         );
     }

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -2,7 +2,7 @@ use crate::hash::CryptoHash;
 use crate::types::AccountId;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_crypto::PublicKey;
-use near_primitives_core::types::{shard_id_as_u16, shard_id_as_u64, ShardId};
+use near_primitives_core::types::{shard_id_as_u64, ShardId};
 use near_schema_checker_lib::ProtocolSchema;
 use std::mem::size_of;
 
@@ -332,7 +332,8 @@ impl TrieKey {
                 buf.push(col::BUFFERED_RECEIPT);
                 // Use  u16 for shard id to reduce depth in trie.
                 assert!(shard_id_as_u64(receiving_shard) <= u16::MAX as u64, "Shard ID too big.");
-                buf.extend(&shard_id_as_u16(receiving_shard).to_le_bytes());
+                let receiving_shard: u16 = receiving_shard.into();
+                buf.extend(&receiving_shard.to_le_bytes());
                 buf.extend(&index.to_le_bytes());
             }
             TrieKey::BandwidthSchedulerState => buf.push(col::BANDWIDTH_SCHEDULER_STATE),

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -2,7 +2,7 @@ use crate::hash::CryptoHash;
 use crate::types::AccountId;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_crypto::PublicKey;
-use near_primitives_core::types::{shard_id_as_u64, ShardId};
+use near_primitives_core::types::ShardId;
 use near_schema_checker_lib::ProtocolSchema;
 use std::mem::size_of;
 
@@ -331,7 +331,7 @@ impl TrieKey {
                 let receiving_shard = *receiving_shard;
                 buf.push(col::BUFFERED_RECEIPT);
                 // Use  u16 for shard id to reduce depth in trie.
-                assert!(shard_id_as_u64(receiving_shard) <= u16::MAX as u64, "Shard ID too big.");
+                assert!(receiving_shard.get() <= u16::MAX as u64, "Shard ID too big.");
                 let receiving_shard: u16 = receiving_shard.into();
                 buf.extend(&receiving_shard.to_le_bytes());
                 buf.extend(&index.to_le_bytes());
@@ -892,7 +892,7 @@ mod tests {
         let shard_layout = ShardLayout::for_protocol_version(PROTOCOL_VERSION);
         let max_id = shard_layout.shard_ids().max().unwrap();
         assert!(
-            shard_id_as_u64(max_id) <= u16::MAX as u64,
+            max_id.get() <= u16::MAX as u64,
             "buffered receipt trie key optimization broken, must fit in a u16"
         );
     }

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -30,7 +30,7 @@ use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::state::FlatStateValue;
 use near_primitives::state_part::PartId;
 use near_primitives::state_record::is_contract_code_key;
-use near_primitives::types::{shard_id_max, ShardId, StateRoot};
+use near_primitives::types::{ShardId, StateRoot};
 use near_vm_runner::ContractCode;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -128,10 +128,11 @@ impl Trie {
         &self,
         part_id: PartId,
     ) -> Result<(PartialState, Vec<u8>, Vec<u8>), StorageError> {
-        let shard_id: ShardId = self.flat_storage_chunk_view.as_ref().map_or_else(
-            shard_id_max, // Fake value for metrics.
-            |chunk_view| chunk_view.shard_uid().shard_id(),
-        );
+        // If chunk view is missing us ShardId::max() as fake value for metrics.
+        let shard_id = self
+            .flat_storage_chunk_view
+            .as_ref()
+            .map_or_else(ShardId::max, |chunk_view| chunk_view.shard_uid().shard_id());
         let _span = tracing::debug_span!(
             target: "state-parts",
             "get_state_part_boundaries",
@@ -182,10 +183,11 @@ impl Trie {
         nibbles_end: Vec<u8>,
         state_trie: &Trie,
     ) -> Result<PartialState, StorageError> {
-        let shard_id: ShardId = self.flat_storage_chunk_view.as_ref().map_or_else(
-            shard_id_max, // Fake value for metrics.
-            |chunk_view| chunk_view.shard_uid().shard_id(),
-        );
+        // If chunk view is missing us ShardId::max() as fake value for metrics.
+        let shard_id = self
+            .flat_storage_chunk_view
+            .as_ref()
+            .map_or_else(ShardId::max, |chunk_view| chunk_view.shard_uid().shard_id());
         let _span = tracing::debug_span!(
             target: "state-parts",
             "get_trie_nodes_for_part_with_flat_storage",

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -613,7 +613,7 @@ mod trie_cache_tests {
     use crate::{StoreConfig, TrieCache, TrieConfig};
     use near_primitives::hash::hash;
     use near_primitives::shard_layout::ShardUId;
-    use near_primitives::types::{shard_id_as_u32, ShardId};
+    use near_primitives::types::ShardId;
 
     fn put_value(cache: &mut TrieCacheInner, value: &[u8]) {
         cache.put(hash(value), value.into());
@@ -714,7 +714,7 @@ mod trie_cache_tests {
         is_view: bool,
         expected_size: bytesize::ByteSize,
     ) {
-        let shard_uid = ShardUId { version: 0, shard_id: shard_id_as_u32(shard_id) };
+        let shard_uid = ShardUId::new(0, shard_id);
         let trie_cache = TrieCache::new(&trie_config, shard_uid, is_view);
         assert_eq!(expected_size.as_u64(), trie_cache.lock().total_size_limit);
         assert_eq!(is_view, trie_cache.lock().is_view);

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -103,7 +103,8 @@ impl TrieCacheInner {
         assert!(total_size_limit > 0);
         // `itoa` is much faster for printing shard_id to a string than trivial alternatives.
         let mut buffer = itoa::Buffer::new();
-        let shard_id_str = buffer.format(shard_id.get());
+        let shard_id_int: u64 = shard_id.into();
+        let shard_id_str = buffer.format(shard_id_int);
 
         let metrics_labels: [&str; 2] = [&shard_id_str, if is_view { "1" } else { "0" }];
         let metrics = TrieCacheMetrics {

--- a/core/store/src/trie/trie_storage.rs
+++ b/core/store/src/trie/trie_storage.rs
@@ -10,7 +10,7 @@ use near_o11y::metrics::prometheus::core::{GenericCounter, GenericGauge};
 use near_primitives::challenge::PartialState;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardUId;
-use near_primitives::types::{shard_id_as_u64, ShardId};
+use near_primitives::types::ShardId;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
@@ -103,7 +103,7 @@ impl TrieCacheInner {
         assert!(total_size_limit > 0);
         // `itoa` is much faster for printing shard_id to a string than trivial alternatives.
         let mut buffer = itoa::Buffer::new();
-        let shard_id_str = buffer.format(shard_id_as_u64(shard_id));
+        let shard_id_str = buffer.format(shard_id.get());
 
         let metrics_labels: [&str; 2] = [&shard_id_str, if is_view { "1" } else { "0" }];
         let metrics = TrieCacheMetrics {

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -18,9 +18,7 @@ use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::shard_layout::{account_id_to_shard_id, ShardUId};
 use near_primitives::state_record::StateRecord;
 use near_primitives::types::chunk_extra::ChunkExtra;
-use near_primitives::types::{
-    shard_id_as_u32, AccountId, Balance, EpochId, ShardId, StateChangeCause, StateRoot,
-};
+use near_primitives::types::{AccountId, Balance, EpochId, ShardId, StateChangeCause, StateRoot};
 use near_primitives::utils::to_timestamp;
 use near_primitives::version::ProtocolFeature;
 use near_store::adapter::StoreUpdateAdapter;
@@ -146,13 +144,9 @@ impl GenesisBuilder {
             .map(|(&shard_id, root)| {
                 (
                     shard_id,
-                    self.runtime.get_tries().new_trie_update(
-                        ShardUId {
-                            version: genesis_shard_version,
-                            shard_id: shard_id_as_u32(shard_id),
-                        },
-                        *root,
-                    ),
+                    self.runtime
+                        .get_tries()
+                        .new_trie_update(ShardUId::new(genesis_shard_version, shard_id), *root),
                 )
             })
             .collect();
@@ -187,13 +181,13 @@ impl GenesisBuilder {
         Ok(self)
     }
 
-    fn flush_shard_records(&mut self, shard_idx: ShardId) -> Result<()> {
-        let records = self.unflushed_records.insert(shard_idx, vec![]).unwrap_or_default();
+    fn flush_shard_records(&mut self, shard_id: ShardId) -> Result<()> {
+        let records = self.unflushed_records.insert(shard_id, vec![]).unwrap_or_default();
         if records.is_empty() {
             return Ok(());
         }
         let mut state_update =
-            self.state_updates.remove(&shard_idx).expect("State updates are always available");
+            self.state_updates.remove(&shard_id).expect("State updates are always available");
         let protocol_config = self.runtime.get_protocol_config(&EpochId::default())?;
         let storage_usage_config = protocol_config.runtime_config.fees.storage_usage_config.clone();
 
@@ -208,16 +202,15 @@ impl GenesisBuilder {
         state_update.commit(StateChangeCause::InitialState);
         let TrieUpdateResult { trie_changes, state_changes, .. } = state_update.finalize()?;
         let genesis_shard_version = self.genesis.config.shard_layout.version();
-        let shard_uid =
-            ShardUId { version: genesis_shard_version, shard_id: shard_id_as_u32(shard_idx) };
+        let shard_uid = ShardUId::new(genesis_shard_version, shard_id);
         let mut store_update = tries.store_update();
         let root = tries.apply_all(&trie_changes, shard_uid, &mut store_update);
         near_store::flat::FlatStateChanges::from_state_changes(&state_changes)
             .apply_to_flat_state(&mut store_update.flat_store_update(), shard_uid);
         store_update.commit()?;
 
-        self.roots.insert(shard_idx, root);
-        self.state_updates.insert(shard_idx, tries.new_trie_update(shard_uid, root));
+        self.roots.insert(shard_id, root);
+        self.state_updates.insert(shard_id, tries.new_trie_update(shard_uid, root));
         Ok(())
     }
 

--- a/integration-tests/src/test_loop/tests/protocol_upgrade.rs
+++ b/integration-tests/src/test_loop/tests/protocol_upgrade.rs
@@ -119,8 +119,8 @@ pub(crate) fn test_protocol_upgrade(
     // Translate shard ids to shard uids
     let chunk_ranges_to_drop: HashMap<ShardUId, std::ops::Range<i64>> = missing_chunk_ranges
         .iter()
-        .map(|(shard_id, range)| {
-            let shard_uid = ShardUId { version: 1, shard_id: shard_id.get().try_into().unwrap() };
+        .map(|(&shard_id, range)| {
+            let shard_uid = ShardUId::new(1, shard_id);
             (shard_uid, range.clone())
         })
         .collect();

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -11,7 +11,7 @@ use near_primitives::errors::StorageError;
 use near_primitives::shard_layout::{ShardLayout, ShardUId};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::trie_key::TrieKey;
-use near_primitives::types::{shard_id_as_u64, AccountId, ShardId};
+use near_primitives::types::{AccountId, ShardId};
 use near_primitives::version::ProtocolFeature;
 use near_primitives_core::types::BlockHeight;
 use near_store::adapter::StoreAdapter;
@@ -460,7 +460,7 @@ fn test_flat_storage_iter() {
         let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
         let items: Vec<_> = store.iter(shard_uid).collect();
 
-        match shard_id_as_u64(shard_id) {
+        match shard_id.get() {
             0 => {
                 let expected = 2 + protocol_version_modifier;
                 assert_eq!(expected, items.len());

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -460,7 +460,8 @@ fn test_flat_storage_iter() {
         let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
         let items: Vec<_> = store.iter(shard_uid).collect();
 
-        match shard_id.get() {
+        let shard_id: u64 = shard_id.into();
+        match shard_id {
             0 => {
                 let expected = 2 + protocol_version_modifier;
                 assert_eq!(expected, items.len());

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -57,7 +57,7 @@ use near_primitives::transaction::{
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
-    shard_id_as_u32, AccountId, BlockHeight, EpochId, NumBlocks, ProtocolVersion, ShardId,
+    AccountId, BlockHeight, EpochId, NumBlocks, ProtocolVersion, ShardId,
 };
 use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_primitives::views::{
@@ -1419,11 +1419,11 @@ fn test_archival_save_trie_changes() {
 
         // Go through chunks and test that trie changes were correctly saved to the store.
         let chunks = block.chunks();
+        let version = shard_layout.version();
         for chunk in chunks.iter_deprecated() {
             let shard_id = chunk.shard_id();
-            let version = shard_layout.version();
+            let shard_uid = ShardUId::new(version, shard_id);
 
-            let shard_uid = ShardUId { version, shard_id: shard_id_as_u32(shard_id) };
             let key = get_block_shard_uid(&block.hash(), &shard_uid);
             let trie_changes: Option<TrieChanges> =
                 store.store().get_ser(DBCol::TrieChanges, &key).unwrap();

--- a/runtime/runtime/src/bandwidth_scheduler/mod.rs
+++ b/runtime/runtime/src/bandwidth_scheduler/mod.rs
@@ -29,7 +29,7 @@ pub fn run_bandwidth_scheduler(
         target: "runtime",
         "run_bandwidth_scheduler",
         height = apply_state.block_height,
-        shard_id = apply_state.shard_id.get());
+        shard_id = ?apply_state.shard_id);
 
     // Read the current scheduler state from the Trie
     let mut scheduler_state = match get_bandwidth_scheduler_state(state_update)? {
@@ -100,7 +100,7 @@ pub fn generate_mock_bandwidth_requests(
         target: "runtime",
         "generate_mock_bandwidth_requests",
         height = apply_state.block_height,
-        shard_id = apply_state.shard_id.get());
+        shard_id = ?apply_state.shard_id);
 
     let Some(scheduler_output) = scheduler_output_opt else {
         tracing::debug!(
@@ -112,7 +112,7 @@ pub fn generate_mock_bandwidth_requests(
 
     let mut data = Vec::new();
     data.extend_from_slice(scheduler_output.mock_data.as_slice());
-    data.extend_from_slice(apply_state.shard_id.get().to_be_bytes().as_slice());
+    data.extend_from_slice(apply_state.shard_id.to_be_bytes().as_slice());
     let hash_data: [u8; 32] = hash(data.as_slice()).into();
 
     let mut requests = Vec::new();

--- a/runtime/runtime/src/congestion_control.rs
+++ b/runtime/runtime/src/congestion_control.rs
@@ -9,7 +9,7 @@ use near_primitives::receipt::{
     Receipt, ReceiptEnum, ReceiptOrStateStoredReceipt, StateStoredReceipt,
     StateStoredReceiptMetadata,
 };
-use near_primitives::types::{shard_id_as_u16, EpochInfoProvider, Gas, ShardId};
+use near_primitives::types::{EpochInfoProvider, Gas, ShardId};
 use near_primitives::version::ProtocolFeature;
 use near_store::trie::receipts_column_helper::{
     DelayedReceiptQueue, ReceiptIterator, ShardsOutgoingReceiptBuffer, TrieQueue,
@@ -461,7 +461,7 @@ pub fn bootstrap_congestion_info(
         // It is also irrelevant, since the bootstrapped value is only used at
         // the start of applying a chunk on this shard. Other shards will only
         // see and act on the first congestion info after that.
-        allowed_shard: shard_id_as_u16(shard_id),
+        allowed_shard: shard_id.into(),
     }))
 }
 

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -27,8 +27,7 @@ use near_primitives::transaction::{
 };
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{
-    shard_id_as_u32, AccountId, Balance, EpochInfoProvider, Gas, MerkleHash, ShardId,
-    StateChangeCause,
+    AccountId, Balance, EpochInfoProvider, Gas, MerkleHash, ShardId, StateChangeCause,
 };
 use near_primitives::utils::create_receipt_id_from_transaction;
 use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
@@ -2018,7 +2017,7 @@ fn test_congestion_buffering() {
     // want local forwarding in the test, hence we need to use a different
     // shard id.
     let local_shard = ShardId::new(1);
-    let local_shard_uid = ShardUId { version: 0, shard_id: shard_id_as_u32(local_shard) };
+    let local_shard_uid = ShardUId::new(0, local_shard);
     let receiver_shard = ShardId::new(0);
 
     let initial_balance = to_yocto(1_000_000);
@@ -2172,7 +2171,7 @@ fn commit_apply_result(
 ) -> CryptoHash {
     // congestion control requires an update on
     let shard_id = apply_state.shard_id;
-    let shard_uid = ShardUId { version: 0, shard_id: shard_id_as_u32(shard_id) };
+    let shard_uid = ShardUId::new(0, shard_id);
     if let Some(congestion_info) = apply_result.congestion_info {
         apply_state
             .congestion_info

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -8,7 +8,7 @@ use near_chain_configs::GenesisValidationMode;
 use near_epoch_manager::{EpochManager, EpochManagerAdapter, EpochManagerHandle};
 use near_primitives::shard_layout::{account_id_to_shard_id, ShardVersion};
 use near_primitives::state::FlatStateValue;
-use near_primitives::types::{shard_id_as_u32, BlockHeight, ShardId};
+use near_primitives::types::{BlockHeight, ShardId};
 use near_store::adapter::flat_store::FlatStoreAdapter;
 use near_store::adapter::StoreAdapter;
 use near_store::flat::{
@@ -586,7 +586,7 @@ impl FlatStorageCommand {
         let (_, epoch_manager, runtime, chain_store, _) =
             Self::get_db(&opener, home_dir, &near_config, near_store::Mode::ReadWriteExisting);
 
-        let shard_uid = ShardUId { version: cmd.version, shard_id: shard_id_as_u32(cmd.shard_id) };
+        let shard_uid = ShardUId::new(cmd.version, cmd.shard_id);
         let flat_storage_manager = runtime.get_flat_storage_manager();
         flat_storage_manager.create_flat_storage_for_shard(shard_uid)?;
         let flat_storage = flat_storage_manager.get_flat_storage_for_shard(shard_uid).unwrap();


### PR DESCRIPTION
Removed a bunch of temporary methods that were used as a glue between the old and new ShardId. 

The parts worth reviewing are:
* core/primitives-core/src/types.rs
* ShardUId::new - it's safe now to make it into a method as ShardId is strongly typed and shard id and version won't get mixed up. I am also very tempted to refactor the `from_shard_id_and_layout` function to a method in the shard layout but I'll leave that for later. 