### PR TITLE
Check that header version is valid for the current protocol version in witness validation

### DIFF
--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -2,7 +2,7 @@ use near_primitives::block::BlockValidityError;
 use near_primitives::challenge::{ChunkProofs, ChunkState};
 use near_primitives::errors::{ChunkAccessError, EpochError, StorageError};
 use near_primitives::shard_layout::ShardLayoutError;
-use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
+use near_primitives::sharding::{BadHeaderForProtocolVersionError, ChunkHash, ShardChunkHeader};
 use near_primitives::types::{BlockHeight, EpochId, ShardId};
 use near_time::Utc;
 use std::io;
@@ -241,6 +241,9 @@ pub enum Error {
     /// EpochSyncProof validation error.
     #[error("EpochSyncProof Validation Error: {0}")]
     InvalidEpochSyncProof(String),
+    /// Invalid chunk header version for protocol version
+    #[error(transparent)]
+    BadHeaderForProtocolVersion(#[from] BadHeaderForProtocolVersionError),
     /// Anything else
     #[error("Other Error: {0}")]
     Other(String),
@@ -326,7 +329,8 @@ impl Error {
             | Error::InvalidProtocolVersion
             | Error::NotAValidator(_)
             | Error::NotAChunkValidator
-            | Error::InvalidChallengeRoot => true,
+            | Error::InvalidChallengeRoot
+            | Error::BadHeaderForProtocolVersion(_) => true,
         }
     }
 
@@ -407,6 +411,7 @@ impl Error {
             Error::NotAChunkValidator => "not_a_chunk_validator",
             Error::InvalidChallengeRoot => "invalid_challenge_root",
             Error::ReshardingError(_) => "resharding_error",
+            Error::BadHeaderForProtocolVersion(_) => "bad_header_for_protocol_version",
         }
     }
 }

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -191,6 +191,11 @@ pub fn pre_validate_chunk_state_witness(
 ) -> Result<PreValidationOutput, Error> {
     let store = chain.chain_store();
 
+    // Ensure that the chunk header version is supported in this protocol version
+    let protocol_version =
+        epoch_manager.get_epoch_info(&state_witness.epoch_id)?.protocol_version();
+    state_witness.chunk_header.valid_for(protocol_version)?;
+
     // First, go back through the blockchain history to locate the last new chunk
     // and last last new chunk for the shard.
     let StateWitnessBlockRange {

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -194,7 +194,7 @@ pub fn pre_validate_chunk_state_witness(
     // Ensure that the chunk header version is supported in this protocol version
     let protocol_version =
         epoch_manager.get_epoch_info(&state_witness.epoch_id)?.protocol_version();
-    state_witness.chunk_header.valid_for(protocol_version)?;
+    state_witness.chunk_header.validate_version(protocol_version)?;
 
     // First, go back through the blockchain history to locate the last new chunk
     // and last last new chunk for the shard.

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -1398,7 +1398,7 @@ impl ShardsManagerActor {
 
         // 2. check protocol version
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
-        if header.valid_for(protocol_version) {
+        if header.valid_for(protocol_version).is_ok() {
             Ok(())
         } else if epoch_id_confirmed {
             Err(Error::InvalidChunkHeader)

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -1398,7 +1398,7 @@ impl ShardsManagerActor {
 
         // 2. check protocol version
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
-        if header.valid_for(protocol_version).is_ok() {
+        if header.validate_version(protocol_version).is_ok() {
             Ok(())
         } else if epoch_id_confirmed {
             Err(Error::InvalidChunkHeader)

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -610,7 +610,7 @@ impl ShardChunkHeader {
                 // the bandwidth scheduler version will be v3 because the chunk extra for the
                 // last chunk of previous version doesn't have bandwidth requests.
                 // v2 is also allowed in the bandwidth scheduler version because there
-                // are multiple tests which upgrade from an old version directtly to the
+                // are multiple tests which upgrade from an old version directly to the
                 // latest version. TODO(#12328) - don't allow InnerV2 in bandwidth scheduler version.
                 ShardChunkHeaderInner::V2(_) => version >= BLOCK_HEADER_V3_VERSION,
                 ShardChunkHeaderInner::V3(_) => version >= CONGESTION_CONTROL_VERSION,

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -644,10 +644,12 @@ impl ShardChunkHeader {
     pub(crate) fn inner_version_number(&self) -> u64 {
         match self {
             ShardChunkHeader::V1(v1) => {
+                // Shows that Header V1 contains Inner V1
                 let _inner_v1: &ShardChunkHeaderInnerV1 = &v1.inner;
                 1
             }
             ShardChunkHeader::V2(v2) => {
+                // Shows that Header V2 also contains Inner V1, not Inner V2
                 let _inner_v1: &ShardChunkHeaderInnerV1 = &v2.inner;
                 1
             }

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -583,7 +583,7 @@ impl ShardChunkHeader {
     }
 
     /// Returns whether the header is valid for given `ProtocolVersion`.
-    pub fn valid_for(
+    pub fn validate_version(
         &self,
         version: ProtocolVersion,
     ) -> Result<(), BadHeaderForProtocolVersionError> {

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -609,9 +609,10 @@ impl ShardChunkHeader {
                 // In bandwidth scheduler version v3 and v4 are allowed. The first chunk in
                 // the bandwidth scheduler version will be v3 because the chunk extra for the
                 // last chunk of previous version doesn't have bandwidth requests.
-                ShardChunkHeaderInner::V2(_) => {
-                    version >= BLOCK_HEADER_V3_VERSION && version < BANDWIDTH_SCHEDULER_VERSION
-                }
+                // v2 is also allowed in the bandwidth scheduler version because there
+                // are multiple tests which upgrade from an old version directtly to the
+                // latest version. TODO(#12328) - don't allow InnerV2 in bandwidth scheduler version.
+                ShardChunkHeaderInner::V2(_) => version >= BLOCK_HEADER_V3_VERSION,
                 ShardChunkHeaderInner::V3(_) => version >= CONGESTION_CONTROL_VERSION,
                 ShardChunkHeaderInner::V4(_) => version >= BANDWIDTH_SCHEDULER_VERSION,
             },

--- a/core/primitives/src/sharding/shard_chunk_header_inner.rs
+++ b/core/primitives/src/sharding/shard_chunk_header_inner.rs
@@ -164,6 +164,17 @@ impl ShardChunkHeaderInner {
             Self::V4(inner) => Some(&inner.bandwidth_requests),
         }
     }
+
+    /// Used for error messages, use `match` for other code.
+    #[inline]
+    pub(crate) fn version_number(&self) -> u64 {
+        match self {
+            Self::V1(_) => 1,
+            Self::V2(_) => 2,
+            Self::V3(_) => 3,
+            Self::V4(_) => 4,
+        }
+    }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, PartialEq, Eq, Debug, ProtocolSchema)]


### PR DESCRIPTION
Add one more check in `pre_validate_chunk_state_witness` - make sure that the chunk header is valid in this protocol version. We already have a `valid_for` function, but it looks like it's only used in shards manager actor.

AFAIU not having this check is not a problem at the moment - only the newest chunk header will match the chunk extra with congestion control info, so other versions of chunk headers won't be endorsed.

But there's the concern that there could be a new version of chunk header which can match older chunk extra. For example for bandwidth scheduler I added a new version of `ShardChunkHeaderInner` and accepted cases where `ChunkExtra` had `None` while the list of requests in `ShardChunkHeaderInner` was empty. It was needed to handle protocol upgrades. Chunk validators would endorse the newer chunk header, even though it's not supposed to be used in the current protocol version. This is no longer a problem after https://github.com/near/nearcore/pull/12307, but there could be a similar case in the future.

Let's add a check and make sure that chunk validators don't endorse headers with the wrong version, just to be safe.