### PR TITLE
2.3.0 release updates

### DIFF
--- a/.github/workflows/master_fuzzer_binaries.yml
+++ b/.github/workflows/master_fuzzer_binaries.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build_fuzzers:
     name: Build Fuzzers
-    runs-on: "ubuntu-20.04-32core"
+    runs-on: "ubuntu-22.04-16core"
 
     permissions:
       contents: "read"

--- a/.github/workflows/master_fuzzer_binaries.yml
+++ b/.github/workflows/master_fuzzer_binaries.yml
@@ -39,10 +39,12 @@ jobs:
           crate: cargo-bolero
           # TODO: remove the below once https://github.com/camshaft/bolero/pull/195 is released on crates.io
           # and https://github.com/camshaft/bolero/pull/196 has a proper fix
-          git: https://github.com/Ekleog-NEAR/bolero
-          rev: 56da8e6d1d018519a30b36d85d3a53fe35a42eaf
+          git: https://github.com/near/bolero
+          rev: 1b43f78f25009695493b0e5fb72f9f82d1905845
 
-      - run: rustup target add --toolchain nightly wasm32-unknown-unknown
+      - run: | 
+          rustup target add --toolchain nightly wasm32-unknown-unknown
+          rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
 
       - name: "Set up GCP SDK"
         uses: "google-github-actions/setup-gcloud@v1"
@@ -52,6 +54,5 @@ jobs:
       - name: "Compile fuzzers and upload to GCS"
         run: |
           NAME="nearcore-${{ github.ref_name }}-$(env TZ=Etc/UTC  date +"%Y%m%d%H%M%S")"
-          # Our Clusterfuzz setup currently (2024-02) runs on Cascade Lake CPUs
-          RUSTFLAGS="--cfg fuzz -C target-cpu=cascadelake" cargo +nightly bolero build-clusterfuzz --all-features --profile fuzz
+          RUSTFLAGS="--cfg fuzz" cargo +nightly bolero build-clusterfuzz --all-features --profile fuzz
           gsutil cp -Z target/fuzz/clusterfuzz.tar "gs://nearone_fuzzer_targets/${{ github.ref_name }}/$NAME.tar.gz"

--- a/.github/workflows/ondemand_fuzzer_binaries.yml
+++ b/.github/workflows/ondemand_fuzzer_binaries.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   build_fuzzers:
     name: Build Fuzzers
-    runs-on: "ubuntu-20.04-32core"
+    runs-on: "ubuntu-22.04-16core"
 
     permissions:
       contents: "read"

--- a/.github/workflows/ondemand_fuzzer_binaries.yml
+++ b/.github/workflows/ondemand_fuzzer_binaries.yml
@@ -65,7 +65,9 @@ jobs:
           git: https://github.com/Ekleog-NEAR/bolero
           rev: 56da8e6d1d018519a30b36d85d3a53fe35a42eaf
 
-      - run: rustup target add --toolchain nightly wasm32-unknown-unknown
+      - run: | 
+          rustup target add --toolchain nightly wasm32-unknown-unknown
+          rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
 
       - name: "Set up GCP SDK"
         uses: "google-github-actions/setup-gcloud@v2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,7 +1321,7 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chainsync-loadtest"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "cold-store-tool"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh 1.2.0",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "congestion-model"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "bytesize",
  "chrono",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "estimator-warehouse"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-csv-to-json"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-populate"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "borsh 1.2.0",
  "clap",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-example"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3418,7 +3418,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "keypair-generator"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "clap",
  "near-crypto",
@@ -3852,7 +3852,7 @@ dependencies = [
 
 [[package]]
 name = "mock-node"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "near-actix-test-utils"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix-rt",
  "near-store",
@@ -3930,7 +3930,7 @@ dependencies = [
 
 [[package]]
 name = "near-amend-genesis"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh 1.2.0",
@@ -3949,7 +3949,7 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "derive-enum-from-into",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -3980,7 +3980,7 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "bencher",
  "lru 0.12.3",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "assert_matches",
@@ -4040,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "near-crypto",
  "near-primitives",
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "assert_matches",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -4116,7 +4116,7 @@ dependencies = [
 
 [[package]]
 name = "near-client"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4175,7 +4175,7 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "chrono",
@@ -4196,7 +4196,7 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "blake2",
  "bolero",
@@ -4234,7 +4234,7 @@ dependencies = [
 
 [[package]]
 name = "near-database-tool"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh 1.2.0",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -4278,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "borsh 1.2.0",
  "chrono",
@@ -4304,7 +4304,7 @@ dependencies = [
 
 [[package]]
 name = "near-flat-storage"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh 1.2.0",
@@ -4322,14 +4322,14 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "near-primitives-core",
 ]
 
 [[package]]
 name = "near-fork-network"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -4355,7 +4355,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "near-primitives",
  "serde",
@@ -4390,7 +4390,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-adversarial-primitives"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "near-primitives",
  "serde",
@@ -4428,7 +4428,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix-http",
  "awc",
@@ -4441,7 +4441,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-fuzz"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "arbitrary",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -4475,7 +4475,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-tests"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "awc",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -4509,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "near-mirror"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4554,7 +4554,7 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "base64 0.21.0",
@@ -4644,7 +4644,7 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "borsh 1.2.0",
@@ -4664,7 +4664,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4679,7 +4679,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "quote",
  "syn 2.0.70",
@@ -4687,7 +4687,7 @@ dependencies = [
 
 [[package]]
 name = "near-ping"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -4705,7 +4705,7 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "borsh 1.2.0",
  "near-crypto",
@@ -4716,7 +4716,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "arbitrary",
  "base64 0.21.0",
@@ -4786,7 +4786,7 @@ dependencies = [
 
 [[package]]
 name = "near-replay-archive-tool"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh 1.2.0",
@@ -4808,7 +4808,7 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4841,14 +4841,14 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "inventory",
 ]
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "inventory",
  "near-schema-checker-core",
@@ -4857,7 +4857,7 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4866,11 +4866,11 @@ dependencies = [
 
 [[package]]
 name = "near-stable-hasher"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 
 [[package]]
 name = "near-state-parts"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4889,7 +4889,7 @@ dependencies = [
 
 [[package]]
 name = "near-state-parts-dump-check"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "actix-web",
@@ -4911,11 +4911,11 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 
 [[package]]
 name = "near-store"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4963,7 +4963,7 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "awc",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "near-test-contracts"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "arbitrary",
  "rand",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5002,7 +5002,7 @@ dependencies = [
 
 [[package]]
 name = "near-undo-block"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -5034,7 +5034,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-test-derive"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -5087,7 +5087,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -5161,7 +5161,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner-fuzz"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-api"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -5204,14 +5204,14 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-generator"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "near-vm-types"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "bolero",
  "indexmap 1.9.2",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "backtrace",
  "cc",
@@ -5242,7 +5242,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-wast"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "near-vm-test-api",
@@ -5252,7 +5252,7 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "near-primitives-core",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "neard"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -5399,7 +5399,7 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "assert_matches",
  "borsh 1.2.0",
@@ -6319,7 +6319,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-schema-check"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "inventory",
  "near-chain",
@@ -6648,7 +6648,7 @@ dependencies = [
 
 [[package]]
 name = "restaked"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "clap",
  "integration-tests",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-params-estimator"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "borsh 1.2.0",
@@ -6794,7 +6794,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "bolero",
  "cpu-time",
@@ -6821,7 +6821,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester-fuzz"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "libfuzzer-sys",
  "runtime-tester",
@@ -7440,7 +7440,7 @@ dependencies = [
 
 [[package]]
 name = "speedy_sync"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "borsh 1.2.0",
  "clap",
@@ -7482,7 +7482,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-viewer"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -7532,7 +7532,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-usage-delta-calculator"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -7547,7 +7547,7 @@ dependencies = [
 
 [[package]]
 name = "store-validator"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "clap",
  "near-chain",
@@ -7724,7 +7724,7 @@ dependencies = [
 
 [[package]]
 name = "testlib"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "near-chain",
  "near-chain-configs",
@@ -7737,7 +7737,7 @@ dependencies = [
 
 [[package]]
 name = "themis"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "2.3.0-rc.4"                               # managed by cargo-workspaces, see below
+version = "2.3.0"                               # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.81.0"

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -44,7 +44,7 @@ curve25519-dalek = { workspace = true, features = ["rand_core"] }
 [features]
 default = ["rand"]
 rand = ["secp256k1/rand", "rand/getrandom", "ed25519-dalek/rand_core"]
-
+rand-std = ["secp256k1/rand-std"]
 protocol_schema = [
     "near-schema-checker-lib/protocol_schema",
 ]

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -85,7 +85,7 @@ pub const PROTOCOL_UPGRADE_SCHEDULE: LazyLock<ProtocolUpgradeVotingSchedule> =
         let protocol_version = 72;
         // Monday
         let datetime =
-            ProtocolUpgradeVotingSchedule::parse_datetime("2024-10-07 10:00:00").unwrap();
+            ProtocolUpgradeVotingSchedule::parse_datetime("2024-11-05 10:00:00").unwrap();
         let schedule = vec![(datetime, protocol_version)];
         ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(PROTOCOL_VERSION, schedule).unwrap()
     });


### PR DESCRIPTION
2.3.0

Set the voting date for mainnet protocol 72 to November 5th.

Cherry pick two changes to fixing fuzzing infrastructure issues:

https://github.com/near/nearcore/pull/12184
https://github.com/near/nearcore/pull/12274