### PR TITLE
test(nayduck): more warmup for flaky tests

### DIFF
--- a/pytest/tests/sanity/epoch_switches.py
+++ b/pytest/tests/sanity/epoch_switches.py
@@ -100,7 +100,7 @@ def wait_until_available(get_fn, fields):
         time.sleep(0.1)
 
 
-for largest_height in range(2, HEIGHT_GOAL + 1):
+for largest_height in range(5, HEIGHT_GOAL + 1):
     assert time.time() - started < TIMEOUT
 
     block = wait_until_available(

--- a/pytest/tests/sanity/validator_switch.py
+++ b/pytest/tests/sanity/validator_switch.py
@@ -26,8 +26,7 @@ nodes = start_cluster(
     [["epoch_length", EPOCH_LENGTH], ["block_producer_kickout_threshold", 10],
      ["chunk_producer_kickout_threshold", 10]], {3: tracked_shards})
 
-time.sleep(3)
-
+utils.wait_for_blocks(nodes[0], target=5)
 hash_ = nodes[0].get_latest_block().hash_bytes
 
 for i in range(4):


### PR DESCRIPTION
Checked locally that it makes impacted tests not flaky. Example reason is that for near genesis heights, not all chunks are created, so some txs, like staking, may not go through due to congestion control.