### PR TITLE
refactor: make witness reed solomon parts reusable 

### DIFF
--- a/chain/client/src/stateless_validation/partial_witness/encoding.rs
+++ b/chain/client/src/stateless_validation/partial_witness/encoding.rs
@@ -1,100 +1,13 @@
-use std::collections::HashMap;
-use std::sync::Arc;
-
-use near_primitives::reed_solomon::{
-    reed_solomon_decode, reed_solomon_encode, reed_solomon_part_length,
-};
-use near_primitives::stateless_validation::state_witness::EncodedChunkStateWitness;
-use near_primitives::utils::compression::CompressedData;
-use reed_solomon_erasure::galois_8::ReedSolomon;
+use near_primitives::reed_solomon::{reed_solomon_num_data_parts, reed_solomon_part_length};
 
 /// Ratio of the number of data parts to total parts in the Reed Solomon encoding.
 /// The tradeoff here is having a higher ratio is better for handling missing parts and network errors
 /// but increases the size of the encoded state witness and the total network bandwidth requirements.
-const RATIO_DATA_PARTS: f32 = 0.6;
-
-/// Type alias around what ReedSolomon represents data part as.
-/// This should help with making the code a bit more understandable.
-pub type WitnessPart = Option<Box<[u8]>>;
-
-/// Reed Solomon encoder wrapper for encoding and decoding state witness parts.
-pub struct WitnessEncoder {
-    /// None corresponds to the case when we are the only validator for the chunk
-    /// since ReedSolomon does not support having exactly 1 total part count and
-    /// no parity parts.
-    rs: Option<ReedSolomon>,
-}
-
-impl WitnessEncoder {
-    fn new(total_parts: usize) -> WitnessEncoder {
-        let rs = if total_parts > 1 {
-            let data_parts = num_witness_data_parts(total_parts);
-            Some(ReedSolomon::new(data_parts, total_parts - data_parts).unwrap())
-        } else {
-            None
-        };
-        Self { rs }
-    }
-
-    pub fn total_parts(&self) -> usize {
-        match self.rs {
-            Some(ref rs) => rs.total_shard_count(),
-            None => 1,
-        }
-    }
-
-    pub fn data_parts(&self) -> usize {
-        match self.rs {
-            Some(ref rs) => rs.data_shard_count(),
-            None => 1,
-        }
-    }
-
-    pub fn encode(&self, witness: &EncodedChunkStateWitness) -> (Vec<WitnessPart>, usize) {
-        match self.rs {
-            Some(ref rs) => reed_solomon_encode(rs, witness),
-            None => {
-                (vec![Some(witness.as_slice().to_vec().into_boxed_slice())], witness.size_bytes())
-            }
-        }
-    }
-
-    pub fn decode(
-        &self,
-        parts: &mut [WitnessPart],
-        encoded_length: usize,
-    ) -> Result<EncodedChunkStateWitness, std::io::Error> {
-        match self.rs {
-            Some(ref rs) => reed_solomon_decode(rs, parts, encoded_length),
-            None => {
-                Ok(EncodedChunkStateWitness::from_boxed_slice(parts[0].as_ref().unwrap().clone()))
-            }
-        }
-    }
-}
-
-/// We keep one encoder for each length of chunk_validators to avoid re-creating the encoder.
-pub struct WitnessEncoderCache {
-    instances: HashMap<usize, Arc<WitnessEncoder>>,
-}
-
-impl WitnessEncoderCache {
-    pub fn new() -> Self {
-        Self { instances: HashMap::new() }
-    }
-
-    pub fn entry(&mut self, total_parts: usize) -> Arc<WitnessEncoder> {
-        self.instances
-            .entry(total_parts)
-            .or_insert_with(|| Arc::new(WitnessEncoder::new(total_parts)))
-            .clone()
-    }
-}
+pub const WITNESS_RATIO_DATA_PARTS: f64 = 0.6;
 
 pub fn witness_part_length(encoded_witness_size: usize, total_parts: usize) -> usize {
-    reed_solomon_part_length(encoded_witness_size, num_witness_data_parts(total_parts))
-}
-
-fn num_witness_data_parts(total_parts: usize) -> usize {
-    std::cmp::max((total_parts as f32 * RATIO_DATA_PARTS) as usize, 1)
+    reed_solomon_part_length(
+        encoded_witness_size,
+        reed_solomon_num_data_parts(total_parts, WITNESS_RATIO_DATA_PARTS),
+    )
 }

--- a/core/primitives/src/reed_solomon.rs
+++ b/core/primitives/src/reed_solomon.rs
@@ -1,13 +1,19 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use itertools::Itertools;
 use reed_solomon_erasure::galois_8::ReedSolomon;
+use std::collections::HashMap;
 use std::io::Error;
+use std::sync::Arc;
+
+/// Type alias around what ReedSolomon represents data part as.
+/// This should help with making the code a bit more understandable.
+pub type ReedSolomonPart = Option<Box<[u8]>>;
 
 // Encode function takes a serializable object and returns a tuple of parts and length of encoded data
 pub fn reed_solomon_encode<T: BorshSerialize>(
     rs: &ReedSolomon,
     data: T,
-) -> (Vec<Option<Box<[u8]>>>, usize) {
+) -> (Vec<ReedSolomonPart>, usize) {
     let mut bytes = borsh::to_vec(&data).unwrap();
     let encoded_length = bytes.len();
 
@@ -36,7 +42,7 @@ pub fn reed_solomon_encode<T: BorshSerialize>(
 // Return an error if the reed solomon decoding fails or borsh deserialization fails.
 pub fn reed_solomon_decode<T: BorshDeserialize>(
     rs: &ReedSolomon,
-    parts: &mut [Option<Box<[u8]>>],
+    parts: &mut [ReedSolomonPart],
     encoded_length: usize,
 ) -> Result<T, Error> {
     if let Err(err) = rs.reconstruct(parts) {
@@ -55,4 +61,183 @@ pub fn reed_solomon_decode<T: BorshDeserialize>(
 
 pub fn reed_solomon_part_length(encoded_length: usize, data_parts: usize) -> usize {
     (encoded_length + data_parts - 1) / data_parts
+}
+
+pub fn reed_solomon_num_data_parts(total_parts: usize, ratio_data_parts: f64) -> usize {
+    std::cmp::max((total_parts as f64 * ratio_data_parts) as usize, 1)
+}
+
+pub struct ReedSolomonEncoder {
+    /// ReedSolomon does not support having exactly 1 total part count and
+    /// no parity parts, so we use None for that
+    rs: Option<ReedSolomon>,
+}
+
+/// We need separate ReedSolomonEncoder[Serialize|Deserialize] traits instead
+/// of just using Borsh directly because of already existing code for handling
+/// chunk state witness where we do not use Borsh for single part encoding.
+/// This was accidental, but unfortunately we cannot change it because now
+/// it is a part of the networking protocol.
+pub trait ReedSolomonEncoderSerialize: BorshSerialize {
+    fn serialize_single_part(&self) -> std::io::Result<Vec<u8>> {
+        borsh::to_vec(self)
+    }
+}
+
+pub trait ReedSolomonEncoderDeserialize: BorshDeserialize {
+    fn deserialize_single_part(data: &[u8]) -> std::io::Result<Self> {
+        Self::try_from_slice(data)
+    }
+}
+
+impl ReedSolomonEncoder {
+    pub fn new(total_parts: usize, ratio_data_parts: f64) -> ReedSolomonEncoder {
+        let rs = if total_parts > 1 {
+            let data_parts = reed_solomon_num_data_parts(total_parts, ratio_data_parts);
+            Some(ReedSolomon::new(data_parts, total_parts - data_parts).unwrap())
+        } else {
+            None
+        };
+        Self { rs }
+    }
+
+    pub fn total_parts(&self) -> usize {
+        match self.rs {
+            Some(ref rs) => rs.total_shard_count(),
+            None => 1,
+        }
+    }
+
+    pub fn data_parts(&self) -> usize {
+        match self.rs {
+            Some(ref rs) => rs.data_shard_count(),
+            None => 1,
+        }
+    }
+
+    pub fn encode<T: ReedSolomonEncoderSerialize>(
+        &self,
+        data: &T,
+    ) -> (Vec<ReedSolomonPart>, usize) {
+        match self.rs {
+            Some(ref rs) => reed_solomon_encode(rs, data),
+            None => {
+                let bytes = T::serialize_single_part(&data).unwrap();
+                let size = bytes.len();
+                (vec![Some(bytes.into_boxed_slice())], size)
+            }
+        }
+    }
+
+    pub fn decode<T: ReedSolomonEncoderDeserialize>(
+        &self,
+        parts: &mut [ReedSolomonPart],
+        encoded_length: usize,
+    ) -> Result<T, std::io::Error> {
+        match self.rs {
+            Some(ref rs) => reed_solomon_decode(rs, parts, encoded_length),
+            None => {
+                if parts.len() != 1 {
+                    return Err(std::io::Error::other(format!(
+                        "Expected single part, received {}",
+                        parts.len()
+                    )));
+                }
+                let Some(part) = &parts[0] else {
+                    return Err(std::io::Error::other("Received part is not expected to be None"));
+                };
+                T::deserialize_single_part(part.as_ref())
+            }
+        }
+    }
+}
+
+pub struct ReedSolomonEncoderCache {
+    ratio_data_parts: f64,
+    instances: HashMap<usize, Arc<ReedSolomonEncoder>>,
+}
+
+impl ReedSolomonEncoderCache {
+    pub fn new(ratio_data_parts: f64) -> Self {
+        Self { ratio_data_parts, instances: HashMap::new() }
+    }
+
+    /// Gets an encoder (or adds a new one to the cache if not present) for a
+    /// given number of the total parts.
+    pub fn entry(&mut self, total_parts: usize) -> Arc<ReedSolomonEncoder> {
+        self.instances
+            .entry(total_parts)
+            .or_insert_with(|| {
+                Arc::new(ReedSolomonEncoder::new(total_parts, self.ratio_data_parts))
+            })
+            .clone()
+    }
+}
+
+pub struct ReedSolomonPartsTracker<T> {
+    parts: Vec<ReedSolomonPart>,
+    encoded_length: usize,
+    data_parts_present: usize,
+    encoder: Arc<ReedSolomonEncoder>,
+    total_parts_size: usize,
+    phantom: std::marker::PhantomData<T>,
+}
+
+pub enum InsertPartResult<T> {
+    Accepted,
+    PartAlreadyAvailable,
+    InvalidPartOrd,
+    Decoded(std::io::Result<T>),
+}
+
+impl<T: ReedSolomonEncoderDeserialize> ReedSolomonPartsTracker<T> {
+    pub fn new(encoder: Arc<ReedSolomonEncoder>, encoded_length: usize) -> Self {
+        Self {
+            data_parts_present: 0,
+            parts: vec![None; encoder.total_parts()],
+            total_parts_size: 0,
+            encoded_length,
+            encoder,
+            phantom: std::marker::PhantomData,
+        }
+    }
+
+    pub fn data_parts_present(&self) -> usize {
+        self.data_parts_present
+    }
+
+    pub fn total_parts_size(&self) -> usize {
+        self.total_parts_size
+    }
+
+    pub fn data_parts_required(&self) -> usize {
+        self.encoder.data_parts()
+    }
+
+    pub fn has_enough_parts(&self) -> bool {
+        self.data_parts_present >= self.data_parts_required()
+    }
+
+    pub fn encoded_length(&self) -> usize {
+        self.encoded_length
+    }
+
+    pub fn insert_part(&mut self, part_ord: usize, part: Box<[u8]>) -> InsertPartResult<T> {
+        if part_ord >= self.parts.len() {
+            return InsertPartResult::InvalidPartOrd;
+        }
+        if self.parts[part_ord].is_some() {
+            return InsertPartResult::PartAlreadyAvailable;
+        }
+
+        self.data_parts_present += 1;
+        self.total_parts_size += part.len();
+        self.parts[part_ord] = Some(part);
+
+        if self.has_enough_parts() {
+            InsertPartResult::Decoded(self.encoder.decode(&mut self.parts, self.encoded_length))
+        } else {
+            InsertPartResult::Accepted
+        }
+    }
 }

--- a/core/primitives/src/stateless_validation/state_witness.rs
+++ b/core/primitives/src/stateless_validation/state_witness.rs
@@ -5,6 +5,7 @@ use super::{ChunkProductionKey, SignatureDifferentiator};
 use crate::bandwidth_scheduler::BandwidthRequests;
 use crate::challenge::PartialState;
 use crate::congestion_info::CongestionInfo;
+use crate::reed_solomon::{ReedSolomonEncoderDeserialize, ReedSolomonEncoderSerialize};
 use crate::sharding::{ChunkHash, ReceiptProof, ShardChunkHeader, ShardChunkHeaderV3};
 use crate::transaction::SignedTransaction;
 use crate::types::EpochId;
@@ -45,6 +46,18 @@ impl
         STATE_WITNESS_COMPRESSION_LEVEL,
     > for EncodedChunkStateWitness
 {
+}
+
+impl ReedSolomonEncoderSerialize for EncodedChunkStateWitness {
+    fn serialize_single_part(&self) -> std::io::Result<Vec<u8>> {
+        Ok(self.as_slice().to_vec())
+    }
+}
+
+impl ReedSolomonEncoderDeserialize for EncodedChunkStateWitness {
+    fn deserialize_single_part(data: &[u8]) -> std::io::Result<Self> {
+        Ok(EncodedChunkStateWitness::from_boxed_slice(data.to_vec().into_boxed_slice()))
+    }
 }
 
 pub type ChunkStateWitnessSize = usize;


### PR DESCRIPTION
This PR makes code related to witness parts tracking generic so it can be reused for deployed contracts distribution.
We need to merge it ASAP, tests will be added in a separate PR.