### PR TITLE
[Epoch Sync] Enable epoch sync by default in configs.

### DIFF
--- a/chain/client/src/sync/epoch.rs
+++ b/chain/client/src/sync/epoch.rs
@@ -590,7 +590,7 @@ impl EpochSync {
         highest_height: BlockHeight,
         highest_height_peers: &[HighestHeightPeerInfo],
     ) -> Result<(), Error> {
-        if !self.config.enabled {
+        if self.config.disable_epoch_sync_for_bootstrapping {
             return Ok(());
         }
         let tip_height = chain.chain_store().header_head()?.height;
@@ -966,9 +966,8 @@ impl EpochSync {
 impl Handler<EpochSyncRequestMessage> for ClientActorInner {
     #[perf]
     fn handle(&mut self, msg: EpochSyncRequestMessage) {
-        if !self.client.epoch_sync.config.enabled {
-            // TODO(#11937): before we have rate limiting, don't respond to epoch sync requests
-            // unless config is enabled.
+        if self.client.epoch_sync.config.ignore_epoch_sync_network_requests {
+            // Temporary killswitch for the rare case there were issues with this network request.
             return;
         }
         let store = self.client.chain.chain_store.store().clone();

--- a/integration-tests/src/test_loop/tests/epoch_sync.rs
+++ b/integration-tests/src/test_loop/tests/epoch_sync.rs
@@ -141,7 +141,6 @@ fn bootstrap_node_via_epoch_sync(setup: TestNetworkSetup, source_node: usize) ->
         .test_loop_data_dir(tempdir)
         .config_modifier(|config, _| {
             // Enable epoch sync, and make the horizon small enough to trigger it.
-            config.epoch_sync.enabled = true;
             config.epoch_sync.epoch_sync_horizon = 30;
             // Make header sync horizon small enough to trigger it.
             config.block_header_fetch_horizon = 8;


### PR DESCRIPTION
The previous config defaulted to false, which is not good, because we want all nodes to default it to true. This change renames the fields to "disable_..." because (1) we need a field name change to apply new defaults because some nodes may already have reinitialized the config; (2) defaulting a field to false is more natural and less error-prone, so using "disable" rather than "enable" will more naturally default to enabling.

Also document the config fields.

Closes #12347 