### PR TITLE
network: remove tier3_request_queue

### DIFF
--- a/chain/client/src/test_utils/peer_manager_mock.rs
+++ b/chain/client/src/test_utils/peer_manager_mock.rs
@@ -1,5 +1,6 @@
 use near_network::types::{
     PeerManagerMessageRequest, PeerManagerMessageResponse, SetChainInfo, StateSyncEvent,
+    Tier3Request,
 };
 
 pub struct PeerManagerMock {
@@ -42,4 +43,9 @@ impl actix::Handler<SetChainInfo> for PeerManagerMock {
 impl actix::Handler<StateSyncEvent> for PeerManagerMock {
     type Result = ();
     fn handle(&mut self, _msg: StateSyncEvent, _ctx: &mut Self::Context) {}
+}
+
+impl actix::Handler<Tier3Request> for PeerManagerMock {
+    type Result = ();
+    fn handle(&mut self, _msg: Tier3Request, _ctx: &mut Self::Context) {}
 }

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -973,7 +973,7 @@ impl PeerActor {
     )]
     async fn receive_routed_message(
         clock: &time::Clock,
-        network_state: &NetworkState,
+        network_state: &Arc<NetworkState>,
         peer_id: PeerId,
         msg_hash: CryptoHash,
         body: RoutedMessageBody,

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -18,9 +18,9 @@ use crate::store;
 use crate::tcp;
 use crate::types::{
     ConnectedPeerInfo, HighestHeightPeerInfo, KnownProducer, NetworkInfo, NetworkRequests,
-    NetworkResponses, PeerInfo, PeerManagerMessageRequest, PeerManagerMessageResponse, PeerType,
-    SetChainInfo, SnapshotHostInfo, StatePartRequestBody, StateSyncEvent, Tier3Request,
-    Tier3RequestBody, PeerManagerAdapter,
+    NetworkResponses, PeerInfo, PeerManagerMessageRequest, PeerManagerMessageResponse,
+    PeerManagerSenderForNetwork, PeerType, SetChainInfo, SnapshotHostInfo, StatePartRequestBody,
+    StateSyncEvent, Tier3Request, Tier3RequestBody,
 };
 use ::time::ext::InstantExt as _;
 use actix::fut::future::wrap_future;
@@ -215,7 +215,7 @@ impl PeerManagerActor {
         store: Arc<dyn near_store::db::Database>,
         config: config::NetworkConfig,
         client: ClientSenderForNetwork,
-        peer_manager_adapter: PeerManagerAdapter,
+        peer_manager_adapter: PeerManagerSenderForNetwork,
         shards_manager_adapter: Sender<ShardsManagerRequestFromNetwork>,
         partial_witness_adapter: PartialWitnessSenderForNetwork,
         genesis_id: GenesisId,

--- a/chain/network/src/stats/metrics.rs
+++ b/chain/network/src/stats/metrics.rs
@@ -296,6 +296,15 @@ pub(crate) static PEER_MANAGER_MESSAGES_TIME: LazyLock<HistogramVec> = LazyLock:
     )
     .unwrap()
 });
+pub(crate) static PEER_MANAGER_TIER3_REQUEST_TIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+    try_create_histogram_vec(
+        "near_peer_manager_tier3_request_time",
+        "Time that PeerManagerActor spends on handling tier3 requests",
+        &["request"],
+        Some(exponential_buckets(0.0001, 2., 15).unwrap()),
+    )
+    .unwrap()
+});
 pub(crate) static ROUTED_MESSAGE_DROPPED: LazyLock<IntCounterVec> = LazyLock::new(|| {
     try_create_int_counter_vec(
         "near_routed_message_dropped",

--- a/chain/network/src/test_loop.rs
+++ b/chain/network/src/test_loop.rs
@@ -15,7 +15,7 @@ use crate::state_witness::{
 };
 use crate::types::{
     NetworkRequests, NetworkResponses, PeerManagerMessageRequest, PeerManagerMessageResponse,
-    SetChainInfo, StateSyncEvent,
+    SetChainInfo, StateSyncEvent, Tier3Request,
 };
 use near_async::actix::ActixResult;
 use near_async::futures::{FutureSpawner, FutureSpawnerExt};
@@ -192,6 +192,10 @@ impl Handler<SetChainInfo> for TestLoopPeerManagerActor {
 
 impl Handler<StateSyncEvent> for TestLoopPeerManagerActor {
     fn handle(&mut self, _msg: StateSyncEvent) {}
+}
+
+impl Handler<Tier3Request> for TestLoopPeerManagerActor {
+    fn handle(&mut self, _msg: Tier3Request) {}
 }
 
 impl Handler<PeerManagerMessageRequest> for TestLoopPeerManagerActor {

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -1,7 +1,7 @@
 use crate::network_protocol::PeerInfo;
 use crate::types::{
     NetworkInfo, NetworkResponses, PeerManagerMessageRequest, PeerManagerMessageResponse,
-    SetChainInfo, StateSyncEvent,
+    SetChainInfo, StateSyncEvent, Tier3Request,
 };
 use crate::PeerManagerActor;
 use actix::{Actor, ActorContext, Context, Handler};
@@ -264,6 +264,10 @@ impl CanSend<SetChainInfo> for MockPeerManagerAdapter {
 
 impl CanSend<StateSyncEvent> for MockPeerManagerAdapter {
     fn send(&self, _msg: StateSyncEvent) {}
+}
+
+impl CanSend<Tier3Request> for MockPeerManagerAdapter {
+    fn send(&self, _msg: Tier3Request) {}
 }
 
 impl MockPeerManagerAdapter {

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -12,7 +12,7 @@ pub use crate::network_protocol::{
 use crate::routing::routing_table_view::RoutingTableInfo;
 pub use crate::state_sync::StateSyncResponse;
 use near_async::messaging::{AsyncSender, Sender};
-use near_async::time;
+use near_async::{time, MultiSend, MultiSendMessage, MultiSenderFrom};
 use near_crypto::PublicKey;
 use near_primitives::block::{ApprovalMessage, Block, GenesisId};
 use near_primitives::challenge::Challenge;
@@ -421,12 +421,18 @@ pub enum NetworkResponses {
     RouteNotFound,
 }
 
-#[derive(Clone, near_async::MultiSend, near_async::MultiSenderFrom)]
+#[derive(Clone, MultiSend, MultiSenderFrom)]
 pub struct PeerManagerAdapter {
     pub async_request_sender: AsyncSender<PeerManagerMessageRequest, PeerManagerMessageResponse>,
     pub request_sender: Sender<PeerManagerMessageRequest>,
     pub set_chain_info_sender: Sender<SetChainInfo>,
     pub state_sync_event_sender: Sender<StateSyncEvent>,
+}
+
+#[derive(Clone, MultiSend, MultiSenderFrom, MultiSendMessage)]
+#[multi_send_message_derive(Debug)]
+#[multi_send_input_derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeerManagerSenderForNetwork {
     pub tier3_request_sender: Sender<Tier3Request>,
 }
 

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -427,6 +427,7 @@ pub struct PeerManagerAdapter {
     pub request_sender: Sender<PeerManagerMessageRequest>,
     pub set_chain_info_sender: Sender<SetChainInfo>,
     pub state_sync_event_sender: Sender<StateSyncEvent>,
+    pub tier3_request_sender: Sender<Tier3Request>,
 }
 
 #[cfg(test)]
@@ -527,7 +528,8 @@ pub struct AccountIdOrPeerTrackingShard {
     pub min_height: BlockHeight,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, actix::Message)]
+#[rtype(result = "()")]
 /// An inbound request to which a response should be sent over Tier3
 pub struct Tier3Request {
     /// Target peer to send the response to
@@ -536,7 +538,7 @@ pub struct Tier3Request {
     pub body: Tier3RequestBody,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, strum::IntoStaticStr)]
 pub enum Tier3RequestBody {
     StatePart(StatePartRequestBody),
 }

--- a/integration-tests/src/tests/network/peer_handshake.rs
+++ b/integration-tests/src/tests/network/peer_handshake.rs
@@ -36,6 +36,7 @@ fn make_peer_manager(
         near_store::db::TestDB::new(),
         config,
         noop().into_multi_sender(),
+        noop().into_multi_sender(),
         noop().into_sender(),
         noop().into_multi_sender(),
         GenesisId::default(),

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -153,6 +153,7 @@ fn setup_network_node(
         db.clone(),
         config,
         client_sender_for_network(client_actor, view_client_addr),
+        network_adapter.as_multi_sender(),
         shards_manager_adapter.as_sender(),
         partial_witness_actor.with_auto_span_context().into_multi_sender(),
         genesis_id,

--- a/integration-tests/src/tests/network/stress_network.rs
+++ b/integration-tests/src/tests/network/stress_network.rs
@@ -30,6 +30,7 @@ fn make_peer_manager(
         near_store::db::TestDB::new(),
         config,
         noop().into_multi_sender(),
+        noop().into_multi_sender(),
         noop().into_sender(),
         noop().into_multi_sender(),
         GenesisId::default(),

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -437,6 +437,7 @@ pub fn start_with_config_and_synchronization(
         storage.into_inner(near_store::Temperature::Hot),
         config.network_config,
         client_sender_for_network(client_actor.clone(), view_client_addr.clone()),
+        network_adapter.as_multi_sender(),
         shards_manager_adapter.as_sender(),
         partial_witness_actor.with_auto_span_context().into_multi_sender(),
         genesis_id,

--- a/tools/chainsync-loadtest/src/main.rs
+++ b/tools/chainsync-loadtest/src/main.rs
@@ -44,6 +44,7 @@ pub fn start_with_config(config: NearConfig, qps_limit: u32) -> anyhow::Result<A
         near_store::db::TestDB::new(),
         config.network_config,
         network.as_client_adapter(),
+        network_adapter.as_multi_sender(),
         noop().into_sender(),
         noop().into_multi_sender(),
         GenesisId {


### PR DESCRIPTION
Incoming state part requests are [throttled by the view client actor](https://github.com/near/nearcore/blob/8e30ccdd425ecbbeeec8d96bfc9a7e02bc35c2d3/chain/client/src/view_client_actor.rs#L1346-L1349), which drops excess requests to avoid overloading the resources of the node. This PR removes the additional layer of queueing on the network side of things. There is little benefit from queueing:

- State part requests are made at a regular rate over a long period of time and distributed well across nodes; there is no need for serving nodes to modulate spikes in demand
- If the steady flow of incoming requests is too high for the view client's throttling rate, queueing will change _which_ requests are served but does not increase _how many_ requests are served; there is no benefit in that

and a major downside:

- Queueing makes response time less predictable, forcing the requesting node to wait longer before deciding that a request was dropped/failed/lost

The queue served a secondary purpose, which is that it allowed PeerActors receiving state part requests to hand them off to the PeerManagerActor. Instead we set up an adapter so that the requests can be passed as actix messages.