### PR TITLE
feat: remove stateless validation panic in test environment

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -444,16 +444,12 @@ impl Client {
             epoch_manager.clone(),
             chain.chain_store().store().clone(),
         );
-        // Chunk validator should panic if there is a validator error in non-production chains (eg. mocket and localnet).
-        let panic_on_validation_error = config.chain_id != near_primitives::chains::MAINNET
-            && config.chain_id != near_primitives::chains::TESTNET;
         let chunk_validator = ChunkValidator::new(
             epoch_manager.clone(),
             network_adapter.clone().into_sender(),
             runtime_adapter.clone(),
             config.orphan_state_witness_pool_size,
             async_computation_spawner,
-            panic_on_validation_error,
         );
         let chunk_distribution_network = ChunkDistributionNetwork::from_config(&config);
         Ok(Self {

--- a/integration-tests/src/tests/client/features/adversarial_behaviors.rs
+++ b/integration-tests/src/tests/client/features/adversarial_behaviors.rs
@@ -373,9 +373,6 @@ fn test_banning_chunk_producer_when_seeing_invalid_chunk() {
     init_test_logger();
     let mut test = AdversarialBehaviorTestData::new();
     test.env.clients[7].produce_invalid_chunks = true;
-    for client in test.env.clients.iter_mut() {
-        client.chunk_validator.set_should_panic_on_validation_error(false);
-    }
     test_banning_chunk_producer_when_seeing_invalid_chunk_base(test);
 }
 
@@ -385,8 +382,5 @@ fn test_banning_chunk_producer_when_seeing_invalid_tx_in_chunk() {
     init_test_logger();
     let mut test = AdversarialBehaviorTestData::new();
     test.env.clients[7].produce_invalid_tx_in_chunks = true;
-    for client in test.env.clients.iter_mut() {
-        client.chunk_validator.set_should_panic_on_validation_error(false);
-    }
     test_banning_chunk_producer_when_seeing_invalid_chunk_base(test);
 }


### PR DESCRIPTION
With async witness code distribution occasional chunk validation failures are expected due to network delays or message loss.  