### PR TITLE
fix(CI) - fix the check_build_public_libraries workflow

### DIFF
--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -15,7 +15,7 @@ use crate::sharding::{ChunkHashHeight, ShardChunkHeader, ShardChunkHeaderV1};
 use crate::types::{Balance, BlockHeight, EpochId, Gas};
 use crate::version::{ProtocolVersion, SHARD_CHUNK_HEADER_UPGRADE_VERSION};
 use borsh::{BorshDeserialize, BorshSerialize};
-use near_primitives_core::types::{ShardId, ShardIndex};
+use near_primitives_core::types::ShardIndex;
 use near_schema_checker_lib::ProtocolSchema;
 use near_time::Utc;
 use primitive_types::U256;
@@ -142,7 +142,7 @@ fn genesis_chunk(
     genesis_protocol_version: u32,
     genesis_height: u64,
     initial_gas_limit: u64,
-    shard_id: ShardId,
+    shard_id: crate::types::ShardId,
     state_root: CryptoHash,
     congestion_info: Option<crate::congestion_info::CongestionInfo>,
 ) -> crate::sharding::EncodedShardChunk {

--- a/core/primitives/src/block_header.rs
+++ b/core/primitives/src/block_header.rs
@@ -536,6 +536,9 @@ impl BlockHeaderV5 {
 /// Used in the BlockHeader::new_impl to specify the source of the block header signature.
 enum SignatureSource<'a> {
     /// Use the given signer to sign a new block header.
+    /// This variant is used only when some features are enabled. There is a warning
+    /// because it's unsued in the default configuration, where the features are disabled.
+    #[allow(dead_code)]
     Signer(&'a ValidatorSigner),
     /// Use a previously-computed signature (for reconstructing an already-produced block header).
     Signature(Signature),

--- a/core/primitives/src/stateless_validation/contract_distribution.rs
+++ b/core/primitives/src/stateless_validation/contract_distribution.rs
@@ -7,6 +7,7 @@ use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::AccountId;
 use near_schema_checker_lib::ProtocolSchema;
 
+#[cfg(feature = "solomon")]
 use crate::reed_solomon::{ReedSolomonEncoderDeserialize, ReedSolomonEncoderSerialize};
 use crate::{utils::compression::CompressedData, validator_signer::ValidatorSigner};
 
@@ -338,7 +339,9 @@ impl ChunkContractDeploys {
     }
 }
 
+#[cfg(feature = "solomon")]
 impl ReedSolomonEncoderSerialize for ChunkContractDeploys {}
+#[cfg(feature = "solomon")]
 impl ReedSolomonEncoderDeserialize for ChunkContractDeploys {}
 
 #[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, ProtocolSchema)]

--- a/core/primitives/src/stateless_validation/state_witness.rs
+++ b/core/primitives/src/stateless_validation/state_witness.rs
@@ -5,6 +5,7 @@ use super::{ChunkProductionKey, SignatureDifferentiator};
 use crate::bandwidth_scheduler::BandwidthRequests;
 use crate::challenge::PartialState;
 use crate::congestion_info::CongestionInfo;
+#[cfg(feature = "solomon")]
 use crate::reed_solomon::{ReedSolomonEncoderDeserialize, ReedSolomonEncoderSerialize};
 use crate::sharding::{ChunkHash, ReceiptProof, ShardChunkHeader, ShardChunkHeaderV3};
 use crate::transaction::SignedTransaction;
@@ -48,12 +49,14 @@ impl
 {
 }
 
+#[cfg(feature = "solomon")]
 impl ReedSolomonEncoderSerialize for EncodedChunkStateWitness {
     fn serialize_single_part(&self) -> std::io::Result<Vec<u8>> {
         Ok(self.as_slice().to_vec())
     }
 }
 
+#[cfg(feature = "solomon")]
 impl ReedSolomonEncoderDeserialize for EncodedChunkStateWitness {
     fn deserialize_single_part(data: &[u8]) -> std::io::Result<Self> {
         Ok(EncodedChunkStateWitness::from_boxed_slice(data.to_vec().into_boxed_slice()))


### PR DESCRIPTION
It looks like the "Windows check for building public libraries" CI check was broken by https://github.com/near/nearcore/pull/12341

Running `just check_build_public_libraries` produced errors and warnings:
```
cargo check -p near-primitives -p near-crypto -p near-jsonrpc-primitives -p near-chain-configs -p near-primitives-core
    Checking near-primitives v0.0.0 (/home/jan/code/nearcore/core/primitives)
error[E0432]: unresolved import `crate::reed_solomon`
  --> core/primitives/src/stateless_validation/contract_distribution.rs:10:12
   |
10 | use crate::reed_solomon::{ReedSolomonEncoderDeserialize, ReedSolomonEncoderSerialize};
   |            ^^^^^^^^^^^^ could not find `reed_solomon` in the crate root
   |
note: found an item that was configured out
  --> core/primitives/src/lib.rs:30:9
   |
30 | pub mod reed_solomon;
   |         ^^^^^^^^^^^^
note: the item is gated behind the `solomon` feature
  --> core/primitives/src/lib.rs:29:7
   |
29 | #[cfg(feature = "solomon")]
   |       ^^^^^^^^^^^^^^^^^^^

error[E0432]: unresolved import `crate::reed_solomon`
  --> core/primitives/src/stateless_validation/state_witness.rs:8:12
   |
8  | use crate::reed_solomon::{ReedSolomonEncoderDeserialize, ReedSolomonEncoderSerialize};
   |            ^^^^^^^^^^^^ could not find `reed_solomon` in the crate root
   |
note: found an item that was configured out
  --> core/primitives/src/lib.rs:30:9
   |
30 | pub mod reed_solomon;
   |         ^^^^^^^^^^^^
note: the item is gated behind the `solomon` feature
  --> core/primitives/src/lib.rs:29:7
   |
29 | #[cfg(feature = "solomon")]
   |       ^^^^^^^^^^^^^^^^^^^

warning: unused import: `ShardId`
  --> core/primitives/src/block.rs:18:35
   |
18 | use near_primitives_core::types::{ShardId, ShardIndex};
   |                                   ^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
```

The main problems is that there's code that requires the `solomon` feature to be enabled, but it isn't guarded behind a `cfg(feature)`, so the compilation fails when the feature isn't enabled.