### PR TITLE
fix: typo in profiling instructions

### DIFF
--- a/docs/practices/workflows/profiling.md
+++ b/docs/practices/workflows/profiling.md
@@ -13,7 +13,7 @@ used too. In order to use either, first prepare your system:
 
 ```command
 $ sudo sysctl kernel.perf_event_paranoid=0
-$ sudo sysctl kernel.restrict_kptr=0
+$ sudo sysctl kernel.kptr_restrict=0
 ```
 
 <blockquote style="background: rgba(255, 200, 0, 0.1); border: 5px solid rgba(255, 200, 0, 0.4);">


### PR DESCRIPTION
It should be `kptr_restrict` as [documented here](https://www.kernel.org/doc/html/latest/admin-guide/sysctl/kernel.html#kptr-restrict). The command with `restrict_kptr` fails on a GCP node running Ubuntu.