### PR TITLE
fix(network): stop_tier3_idle_connections

### DIFF
--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -629,14 +629,13 @@ impl PeerManagerActor {
     /// retry logic anyway. TODO(saketh): consider if we can improve this in a simple way.
     fn stop_tier3_idle_connections(&self) {
         let now = self.clock.now();
-        let _ = self
-            .state
+        self.state
             .tier3
             .load()
             .ready
             .values()
             .filter(|p| now - p.last_time_received_message.load() > TIER3_IDLE_TIMEOUT)
-            .map(|p| p.stop(None));
+            .for_each(|p| p.stop(None));
     }
 
     /// Periodically monitor list of peers and:


### PR DESCRIPTION
Idle tier3 connections were not actually being closed because `map` is lazy. 