### PR TITLE
fix(resharding) - error handling in shard layout part 1

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -644,7 +644,7 @@ impl Chain {
         genesis_protocol_version: ProtocolVersion,
         congestion_info: Option<CongestionInfo>,
     ) -> Result<ChunkExtra, Error> {
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id)?;
         let state_root = *get_genesis_state_roots(self.chain_store.store())?
             .ok_or_else(|| Error::Other("genesis state roots do not exist in the db".to_owned()))?
             .get(shard_index)
@@ -827,7 +827,7 @@ impl Chain {
                 &prev_block,
                 &shard_layout,
                 &shards_to_state_sync,
-            );
+            )?;
             Ok(Some(state_sync_info))
         }
     }
@@ -1977,7 +1977,7 @@ impl Chain {
         // TODO(#8055): this zip relies on the ordering of the apply_results.
         // TODO(wacban): do the above todo
         for (shard_id, apply_result) in apply_results.iter() {
-            let shard_index = shard_layout.get_shard_index(*shard_id);
+            let shard_index = shard_layout.get_shard_index(*shard_id)?;
             if let Err(err) = apply_result {
                 if err.is_bad_data() {
                     let chunk = block.chunks()[shard_index].clone();
@@ -2578,7 +2578,7 @@ impl Chain {
 
             let mut done = true;
             for (shard_id, num_new_chunks) in num_new_chunks.iter_mut() {
-                let shard_index = shard_layout.get_shard_index(*shard_id);
+                let shard_index = shard_layout.get_shard_index(*shard_id)?;
                 let Some(included) = header.chunk_mask().get(shard_index) else {
                     return Err(Error::Other(format!(
                         "can't get shard {} in chunk mask for block {}",
@@ -2631,7 +2631,7 @@ impl Chain {
         let shard_layout = self.epoch_manager.get_shard_layout(&sync_block_epoch_id)?;
         let prev_epoch_id = sync_prev_block.header().epoch_id();
         let prev_shard_layout = self.epoch_manager.get_shard_layout(&prev_epoch_id)?;
-        let prev_shard_index = prev_shard_layout.get_shard_index(shard_id);
+        let prev_shard_index = prev_shard_layout.get_shard_index(shard_id)?;
 
         // Chunk header here is the same chunk header as at the `current` height.
         let sync_prev_hash = sync_prev_block.hash();
@@ -2732,7 +2732,7 @@ impl Chain {
                 let ReceiptProof(receipts, shard_proof) = receipt_proof;
                 let ShardProof { from_shard_id, to_shard_id: _, proof } = shard_proof;
                 let receipts_hash = CryptoHash::hash_borsh(ReceiptList(shard_id, receipts));
-                let from_shard_index = prev_shard_layout.get_shard_index(*from_shard_id);
+                let from_shard_index = prev_shard_layout.get_shard_index(*from_shard_id)?;
 
                 let root_proof = block.chunks()[from_shard_index].prev_outgoing_receipts_root();
                 root_proofs_cur
@@ -2837,7 +2837,7 @@ impl Chain {
             return Err(shard_id_out_of_bounds(shard_id));
         }
         let prev_block = self.get_block(header.prev_hash())?;
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id)?;
         let state_root = prev_block
             .chunks()
             .get(shard_index)
@@ -3262,7 +3262,7 @@ impl Chain {
             let epoch_id = block.header().epoch_id();
             let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
             let shard_id = chunk.shard_id();
-            let shard_index = shard_layout.get_shard_index(shard_id);
+            let shard_index = shard_layout.get_shard_index(shard_id)?;
 
             let chunk_proof = ChunkProofs {
                 block_header: borsh::to_vec(&block.header()).expect("Failed to serialize"),
@@ -3593,7 +3593,7 @@ impl Chain {
         let epoch_id = block.header().epoch_id();
         let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
         let shard_id = chunk_header.shard_id();
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id)?;
         let prev_merkle_proofs =
             Block::compute_chunk_headers_root(prev_block.chunks().iter_deprecated()).1;
         let merkle_proofs = Block::compute_chunk_headers_root(block.chunks().iter_deprecated()).1;
@@ -3765,7 +3765,7 @@ impl Chain {
                     if err.is_bad_data() {
                         let epoch_id = block.header().epoch_id();
                         let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
-                        let shard_index = shard_layout.get_shard_index(shard_id);
+                        let shard_index = shard_layout.get_shard_index(shard_id)?;
 
                         let chunk_header = block
                             .chunks()
@@ -4333,7 +4333,7 @@ impl Chain {
             let block = self.get_block(&block_hash)?;
             let chunks = block.chunks();
             for &shard_id in shard_ids.iter() {
-                let shard_index = shard_layout.get_shard_index(shard_id);
+                let shard_index = shard_layout.get_shard_index(shard_id)?;
                 let chunk_header =
                     &chunks.get(shard_index).ok_or_else(|| Error::InvalidShardId(shard_id))?;
                 if chunk_header.height_included() == block.header().height() {

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -222,7 +222,7 @@ impl TestEnv {
         let prev_block_hash = self.head.last_block_hash;
         let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(&prev_block_hash).unwrap();
         let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id).unwrap();
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id).unwrap();
         let state_root = self.state_roots[shard_index];
         let gas_limit = u64::MAX;
         let height = self.head.height + 1;
@@ -330,7 +330,7 @@ impl TestEnv {
         let mut all_proposals = vec![];
         let mut all_receipts = vec![];
         for shard_id in shard_ids {
-            let shard_index = shard_layout.get_shard_index(shard_id);
+            let shard_index = shard_layout.get_shard_index(shard_id).unwrap();
             let (state_root, proposals, receipts) = self.update_runtime(
                 shard_id,
                 new_hash,
@@ -402,7 +402,7 @@ impl TestEnv {
         )
         .unwrap();
         let shard_layout = self.epoch_manager.get_shard_layout(&self.head.epoch_id).unwrap();
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id).unwrap();
         let shard_uid = self.epoch_manager.shard_id_to_uid(shard_id, &self.head.epoch_id).unwrap();
         self.runtime
             .view_account(&shard_uid, self.state_roots[shard_index], account_id)

--- a/chain/chain/src/stateless_validation/chunk_endorsement.rs
+++ b/chain/chain/src/stateless_validation/chunk_endorsement.rs
@@ -64,7 +64,7 @@ pub fn validate_chunk_endorsements_in_block(
         // Validation for chunks in each shard
         // The signatures from chunk validators for each shard must match the ordered_chunk_validators
         let shard_id = chunk_header.shard_id();
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id)?;
 
         let chunk_validator_assignments = epoch_manager.get_chunk_validator_assignments(
             &epoch_id,
@@ -172,7 +172,7 @@ pub fn validate_chunk_endorsements_in_header(
     }
     let chunk_mask = header.chunk_mask();
     for shard_id in shard_ids.into_iter() {
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id)?;
         // For old chunks, we optimize the block and its header by not including the chunk endorsements and
         // corresponding bitmaps. Thus, we expect that the bitmap is empty for shard with no new chunk.
         if chunk_mask[shard_index] != (chunk_endorsements.len(shard_index).unwrap() > 0) {

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -354,7 +354,7 @@ pub trait ChainStoreAccess {
         let block_header = self.get_block_header(&candidate_hash)?;
         let shard_layout = epoch_manager.get_shard_layout(block_header.epoch_id())?;
         let mut shard_id = shard_id;
-        let mut shard_index = shard_layout.get_shard_index(shard_id);
+        let mut shard_index = shard_layout.get_shard_index(shard_id)?;
         loop {
             let block_header = self.get_block_header(&candidate_hash)?;
             if *block_header

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -595,7 +595,8 @@ pub(crate) fn trie_changes_chunk_extra_exists(
 
     // 5. There should be ShardChunk with ShardId `shard_id`
     let shard_id = shard_uid.shard_id();
-    let shard_index = shard_layout.get_shard_index(shard_id);
+    let shard_index =
+        unwrap_or_err!(shard_layout.get_shard_index(shard_id), "error getting shard index");
     let chunks = block.chunks();
     if let Some(chunk_header) = chunks.get(shard_index) {
         // if the chunk is not a new chunk, skip the check

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -474,7 +474,7 @@ impl EpochManagerAdapter for MockEpochManager {
         let shard_layout = self.get_shard_layout(epoch_id)?;
         let shard_id = account_id_to_shard_id(account_id, self.num_shards);
         let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id)?;
         Ok(ShardUIdAndIndex { shard_uid, shard_index })
     }
 
@@ -492,7 +492,7 @@ impl EpochManagerAdapter for MockEpochManager {
         epoch_id: &EpochId,
     ) -> Result<ShardIndex, EpochError> {
         let shard_layout = self.get_shard_layout(epoch_id)?;
-        Ok(shard_layout.get_shard_index(shard_id))
+        Ok(shard_layout.get_shard_index(shard_id)?)
     }
 
     fn get_block_info(&self, _hash: &CryptoHash) -> Result<Arc<BlockInfo>, EpochError> {
@@ -626,7 +626,7 @@ impl EpochManagerAdapter for MockEpochManager {
             // This is not correct if there was a resharding event in between
             // the previous and current block.
             let prev_shard_id = shard_id;
-            let prev_shard_index = shard_layout.get_shard_index(prev_shard_id);
+            let prev_shard_index = shard_layout.get_shard_index(prev_shard_id)?;
             prev_shard_ids.push((prev_shard_id, prev_shard_index));
         }
 
@@ -642,7 +642,7 @@ impl EpochManagerAdapter for MockEpochManager {
         // This is not correct if there was a resharding event in between
         // the previous and current block.
         let prev_shard_id = shard_id;
-        let prev_shard_index = shard_layout.get_shard_index(prev_shard_id);
+        let prev_shard_index = shard_layout.get_shard_index(prev_shard_id)?;
         Ok((prev_shard_id, prev_shard_index))
     }
 
@@ -753,7 +753,7 @@ impl EpochManagerAdapter for MockEpochManager {
     ) -> Result<Vec<AccountId>, EpochError> {
         let valset = self.get_valset_for_epoch(epoch_id)?;
         let shard_layout = self.get_shard_layout(epoch_id)?;
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id)?;
         let chunk_producers = self.get_chunk_producers(valset, shard_index);
         Ok(chunk_producers.into_iter().map(|vs| vs.take_account_id()).collect())
     }
@@ -787,7 +787,7 @@ impl EpochManagerAdapter for MockEpochManager {
     ) -> Result<AccountId, EpochError> {
         let valset = self.get_valset_for_epoch(epoch_id)?;
         let shard_layout = self.get_shard_layout(epoch_id)?;
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id)?;
         let chunk_producers = self.get_chunk_producers(valset, shard_index);
         let index = (shard_index + height as usize + 1) % chunk_producers.len();
         Ok(chunk_producers[index].account_id().clone())
@@ -1056,7 +1056,7 @@ impl EpochManagerAdapter for MockEpochManager {
         //    the calling function.
         let epoch_valset = self.get_valset_for_epoch(&epoch_id).unwrap();
         let shard_layout = self.get_shard_layout(&epoch_id)?;
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id)?;
         let chunk_producers = self.get_chunk_producers(epoch_valset, shard_index);
         for validator in chunk_producers {
             if validator.account_id() == account_id {
@@ -1077,7 +1077,7 @@ impl EpochManagerAdapter for MockEpochManager {
         //    the calling function.
         let epoch_valset = self.get_epoch_and_valset(*parent_hash).unwrap();
         let shard_layout = self.get_shard_layout_from_prev_block(parent_hash)?;
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id)?;
         let chunk_producers = self.get_chunk_producers(epoch_valset.1, shard_index);
         for validator in chunk_producers {
             if validator.account_id() == account_id {
@@ -1098,7 +1098,7 @@ impl EpochManagerAdapter for MockEpochManager {
         //    the calling function.
         let epoch_valset = self.get_epoch_and_valset(*parent_hash).unwrap();
         let shard_layout = self.get_shard_layout_from_prev_block(parent_hash)?;
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id)?;
         let chunk_producers = self.get_chunk_producers(
             (epoch_valset.1 + 1) % self.validators_by_valset.len(),
             shard_index,
@@ -1153,7 +1153,7 @@ impl EpochManagerAdapter for MockEpochManager {
     ) -> Result<AccountId, EpochError> {
         let valset = self.get_valset_for_epoch(epoch_id)?;
         let shard_layout = self.get_shard_layout(epoch_id)?;
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id)?;
         let chunk_producers = self.get_chunk_producers(valset, shard_index);
         let index = rand::thread_rng().gen_range(0..chunk_producers.len());
         Ok(chunk_producers[index].account_id().clone())

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -277,7 +277,8 @@ impl NewChunkTracker {
 
         let mut done = true;
         for (shard_id, num_new_chunks) in self.num_new_chunks.iter_mut() {
-            let shard_index = shard_layout.get_shard_index(*shard_id);
+            let shard_index =
+                shard_layout.get_shard_index(*shard_id).map_err(Into::<EpochError>::into)?;
             let Some(included) = header.chunk_mask().get(shard_index) else {
                 return Err(Error::Other(format!(
                     "can't get shard {} in chunk mask for block {}",
@@ -840,7 +841,8 @@ impl Client {
         // Collect new chunk headers and endorsements.
         let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
         for (shard_id, chunk_hash) in new_chunks {
-            let shard_index = shard_layout.get_shard_index(shard_id);
+            let shard_index =
+                shard_layout.get_shard_index(shard_id).map_err(Into::<EpochError>::into)?;
             let (mut chunk_header, chunk_endorsement) =
                 self.chunk_inclusion_tracker.get_chunk_header_and_endorsements(&chunk_hash)?;
             *chunk_header.height_included_mut() = height;
@@ -1570,7 +1572,8 @@ impl Client {
             .expect("Could not obtain shard layout");
 
         let shard_id = partial_chunk.shard_id();
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index =
+            shard_layout.get_shard_index(shard_id).expect("Could not obtain shard index");
         self.block_production_info
             .record_chunk_collected(partial_chunk.height_created(), shard_index);
 

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -251,7 +251,7 @@ impl InfoHelper {
             });
 
             for shard_id in shard_ids {
-                let shard_index = shard_layout.get_shard_index(shard_id);
+                let shard_index = shard_layout.get_shard_index(shard_id).unwrap();
                 let mut stake_per_cp = HashMap::<ValidatorId, Balance>::new();
                 stake_sum = 0;
                 let chunk_producers_settlement = &epoch_info.chunk_producers_settlement();

--- a/chain/client/src/stateless_validation/state_witness_producer.rs
+++ b/chain/client/src/stateless_validation/state_witness_producer.rs
@@ -404,7 +404,7 @@ impl Client {
                 self.epoch_manager.get_shard_layout(from_block.header().epoch_id())?;
             for proof in receipt_proof_response.1.iter() {
                 let from_shard_id = proof.1.from_shard_id;
-                let from_shard_index = shard_layout.get_shard_index(from_shard_id);
+                let from_shard_index = shard_layout.get_shard_index(from_shard_id)?;
                 let from_chunk_hash = from_block
                     .chunks()
                     .get(from_shard_index)

--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -525,7 +525,7 @@ impl TestEnv {
         let shard_id =
             client.epoch_manager.account_id_to_shard_id(&account_id, &head.epoch_id).unwrap();
         let shard_layout = client.epoch_manager.get_shard_layout(&head.epoch_id).unwrap();
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id).unwrap();
         let shard_uid = client.epoch_manager.shard_id_to_uid(shard_id, &head.epoch_id).unwrap();
         let last_chunk_header = &last_block.chunks()[shard_index];
 
@@ -585,7 +585,7 @@ impl TestEnv {
             client.epoch_manager.account_id_to_shard_id(&account_id, &head.epoch_id).unwrap();
         let shard_uid = client.epoch_manager.shard_id_to_uid(shard_id, &head.epoch_id).unwrap();
         let shard_layout = client.epoch_manager.get_shard_layout(&head.epoch_id).unwrap();
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id).unwrap();
         let last_chunk_header = &last_block.chunks()[shard_index];
         let response = client
             .runtime_adapter

--- a/chain/client/src/test_utils/test_loop.rs
+++ b/chain/client/src/test_utils/test_loop.rs
@@ -50,7 +50,7 @@ where
             client.epoch_manager.account_id_to_shard_id(&account_id, &head.epoch_id).unwrap();
         let shard_uid = client.epoch_manager.shard_id_to_uid(shard_id, &head.epoch_id).unwrap();
         let shard_layout = client.epoch_manager.get_shard_layout(&head.epoch_id).unwrap();
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id).unwrap();
         let last_chunk_header = &last_block.chunks()[shard_index];
 
         client

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -760,7 +760,7 @@ fn get_chunk_from_block(
 ) -> Result<ShardChunk, near_chain::Error> {
     let epoch_id = block.header().epoch_id();
     let shard_layout = chain.epoch_manager.get_shard_layout(epoch_id)?;
-    let shard_index = shard_layout.get_shard_index(shard_id);
+    let shard_index = shard_layout.get_shard_index(shard_id)?;
     let chunk_header = block
         .chunks()
         .get(shard_index)
@@ -1092,7 +1092,10 @@ impl Handler<GetExecutionOutcome> for ViewClientActorInner {
                     .epoch_manager
                     .account_id_to_shard_id(&account_id, &epoch_id)
                     .into_chain_error()?;
-                let target_shard_index = shard_layout.get_shard_index(target_shard_id);
+                let target_shard_index = shard_layout
+                    .get_shard_index(target_shard_id)
+                    .map_err(Into::into)
+                    .into_chain_error()?;
                 let res = self.chain.get_next_block_hash_with_new_chunk(
                     &outcome_proof.block_hash,
                     target_shard_id,

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -592,7 +592,7 @@ impl EpochManagerAdapter for EpochManagerHandle {
         let shard_layout = epoch_manager.get_shard_layout(epoch_id)?;
         let shard_id = account_id_to_shard_id(account_id, &shard_layout);
         let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id)?;
         Ok(ShardUIdAndIndex { shard_uid, shard_index })
     }
 
@@ -613,7 +613,7 @@ impl EpochManagerAdapter for EpochManagerHandle {
     ) -> Result<ShardIndex, EpochError> {
         let epoch_manager = self.read();
         let shard_layout = epoch_manager.get_shard_layout(epoch_id)?;
-        Ok(shard_layout.get_shard_index(shard_id))
+        Ok(shard_layout.get_shard_index(shard_id)?)
     }
 
     fn get_block_info(&self, hash: &CryptoHash) -> Result<Arc<BlockInfo>, EpochError> {

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -692,8 +692,8 @@ impl EpochManagerAdapter for EpochManagerHandle {
         let is_resharding_boundary =
             self.is_next_block_epoch_start(prev_hash)? && prev_shard_layout != shard_layout;
 
+        let mut result = vec![];
         if is_resharding_boundary {
-            let mut result = vec![];
             for shard_id in shard_ids {
                 let parent_shard_id = shard_layout.get_parent_shard_id(shard_id)?;
                 let parent_shard_index = prev_shard_layout.get_shard_index(parent_shard_id)?;
@@ -701,7 +701,6 @@ impl EpochManagerAdapter for EpochManagerHandle {
             }
             Ok(result)
         } else {
-            let mut result = vec![];
             for shard_id in shard_ids {
                 let shard_index = shard_layout.get_shard_index(shard_id)?;
                 result.push((shard_id, shard_index));

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -8,7 +8,7 @@ use near_primitives::epoch_info::EpochInfo;
 use near_primitives::epoch_manager::{EpochConfig, ShardConfig};
 use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
-use near_primitives::shard_layout::{account_id_to_shard_id, ShardLayout, ShardLayoutError};
+use near_primitives::shard_layout::{account_id_to_shard_id, ShardLayout};
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
 use near_primitives::stateless_validation::chunk_endorsement::{
     ChunkEndorsementV1, ChunkEndorsementV2,

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -1095,7 +1095,7 @@ impl EpochManager {
         let epoch_info = self.get_epoch_info(&epoch_id)?;
 
         let shard_layout = self.get_shard_layout(&epoch_id)?;
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id)?;
 
         let chunk_producers_settlement = epoch_info.chunk_producers_settlement();
         let chunk_producers = chunk_producers_settlement
@@ -1114,7 +1114,7 @@ impl EpochManager {
     ) -> Result<AccountId, EpochError> {
         let epoch_info = self.get_epoch_info(&epoch_id)?;
         let shard_layout = self.get_shard_layout(&epoch_id)?;
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id)?;
         let chunk_producers = epoch_info
             .chunk_producers_settlement()
             .get(shard_index)
@@ -1296,7 +1296,7 @@ impl EpochManager {
         let epoch_info = self.get_epoch_info(&epoch_id)?;
 
         let shard_layout = self.get_shard_layout(&epoch_id)?;
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id)?;
 
         let chunk_producers_settlement = epoch_info.chunk_producers_settlement();
         let chunk_producers = chunk_producers_settlement

--- a/chain/epoch-manager/src/shard_tracker.rs
+++ b/chain/epoch-manager/src/shard_tracker.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::EpochManagerAdapter;
+use itertools::Itertools;
 use near_cache::SyncLruCache;
 use near_chain_configs::ClientConfig;
 use near_primitives::errors::EpochError;
@@ -76,17 +77,20 @@ impl ShardTracker {
         match &self.tracked_config {
             TrackedConfig::Accounts(tracked_accounts) => {
                 let shard_layout = self.epoch_manager.get_shard_layout(epoch_id)?;
-                let tracking_mask = self.tracking_shards_cache.get_or_put(*epoch_id, |_| {
-                    let mut tracking_mask: Vec<_> =
-                        shard_layout.shard_ids().map(|_| false).collect();
-                    for account_id in tracked_accounts {
-                        let shard_id = account_id_to_shard_id(account_id, &shard_layout);
-                        let shard_index = shard_layout.get_shard_index(shard_id);
-                        tracking_mask[shard_index] = true;
-                    }
-                    tracking_mask
-                });
-                let shard_index = shard_layout.get_shard_index(shard_id);
+                let tracking_mask = self.tracking_shards_cache.get_or_try_put(
+                    *epoch_id,
+                    |_| -> Result<Vec<bool>, EpochError> {
+                        let mut tracking_mask =
+                            shard_layout.shard_ids().map(|_| false).collect_vec();
+                        for account_id in tracked_accounts {
+                            let shard_id = account_id_to_shard_id(account_id, &shard_layout);
+                            let shard_index = shard_layout.get_shard_index(shard_id)?;
+                            tracking_mask[shard_index] = true;
+                        }
+                        Ok(tracking_mask)
+                    },
+                )?;
+                let shard_index = shard_layout.get_shard_index(shard_id)?;
                 Ok(tracking_mask.get(shard_index).copied().unwrap_or(false))
             }
             TrackedConfig::AllShards => Ok(true),

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -1655,12 +1655,11 @@ fn test_chunk_validator_kickout_using_endorsement_stats() {
         let chunk_mask = vec![true; num_shards as usize];
         // Prepare the chunk endorsements so that "test2" misses some of the endorsements.
         let mut bitmap = ChunkEndorsementsBitmap::new(num_shards as usize);
-        for shard_id in shard_layout.shard_ids() {
+        for (shard_index, shard_id) in shard_layout.shard_ids().enumerate() {
             let chunk_validators = em
                 .get_chunk_validator_assignments(&epoch_id, shard_id, height)
                 .unwrap()
                 .ordered_chunk_validators();
-            let shard_index = shard_layout.get_shard_index(shard_id);
             bitmap.add_endorsements(
                 shard_index,
                 chunk_validators

--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -247,7 +247,10 @@ pub async fn build_streamer_message(
     // chunks and we end up with non-empty `shards_outcomes` we want to be sure we put them into IndexerShard
     // That might happen before the fix https://github.com/near/nearcore/pull/4228
     for (shard_id, outcomes) in shards_outcomes {
-        let shard_index = protocol_config_view.shard_layout.get_shard_index(shard_id);
+        let shard_index = protocol_config_view
+            .shard_layout
+            .get_shard_index(shard_id)
+            .expect("Failed to get shard index");
         indexer_shards[shard_index].receipt_execution_outcomes.extend(outcomes.into_iter().map(
             |outcome| IndexerExecutionOutcomeWithReceipt {
                 execution_outcome: outcome.execution_outcome,

--- a/core/primitives/src/epoch_info.rs
+++ b/core/primitives/src/epoch_info.rs
@@ -8,7 +8,7 @@ use crate::types::validator_stake::{ValidatorStake, ValidatorStakeIter};
 use crate::types::{AccountId, ValidatorKickoutReason, ValidatorStakeV1};
 use crate::validator_mandates::ValidatorMandates;
 use crate::version::PROTOCOL_VERSION;
-use near_primitives_core::types::{Balance, EpochHeight, ProtocolVersion, ValidatorId};
+use near_primitives_core::types::{Balance, EpochHeight, ProtocolVersion, ShardIndex, ValidatorId};
 use near_primitives_core::version::ProtocolFeature;
 use near_primitives_core::{
     checked_feature,
@@ -606,7 +606,7 @@ impl EpochInfo {
         shard_id: ShardId,
         height: BlockHeight,
     ) -> Option<ValidatorId> {
-        let shard_index = shard_layout.get_shard_index(shard_id);
+        let shard_index = shard_layout.get_shard_index(shard_id).ok()?;
         match &self {
             Self::V1(v1) => {
                 let cp_settlement = &v1.chunk_producers_settlement;

--- a/core/primitives/src/epoch_info.rs
+++ b/core/primitives/src/epoch_info.rs
@@ -8,7 +8,7 @@ use crate::types::validator_stake::{ValidatorStake, ValidatorStakeIter};
 use crate::types::{AccountId, ValidatorKickoutReason, ValidatorStakeV1};
 use crate::validator_mandates::ValidatorMandates;
 use crate::version::PROTOCOL_VERSION;
-use near_primitives_core::types::{Balance, EpochHeight, ProtocolVersion, ShardIndex, ValidatorId};
+use near_primitives_core::types::{Balance, EpochHeight, ProtocolVersion, ValidatorId};
 use near_primitives_core::version::ProtocolFeature;
 use near_primitives_core::{
     checked_feature,

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -1,5 +1,6 @@
 use crate::hash::CryptoHash;
 use crate::serialize::dec_format;
+use crate::shard_layout::ShardLayoutError;
 use crate::sharding::ChunkHash;
 use crate::types::{AccountId, Balance, EpochId, Gas, Nonce};
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -1029,6 +1030,12 @@ impl Debug for EpochError {
 impl From<std::io::Error> for EpochError {
     fn from(error: std::io::Error) -> Self {
         EpochError::IOErr(error.to_string())
+    }
+}
+
+impl From<ShardLayoutError> for EpochError {
+    fn from(error: ShardLayoutError) -> Self {
+        EpochError::ShardingError(error.to_string())
     }
 }
 

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -666,14 +666,18 @@ impl ShardLayout {
 
     /// Returns the shard index for a given shard id. The shard index should be
     /// used when indexing into an array of chunk data.
-    pub fn get_shard_index(&self, shard_id: ShardId) -> ShardIndex {
+    pub fn get_shard_index(&self, shard_id: ShardId) -> Result<ShardIndex, ShardLayoutError> {
         match self {
             // In V0 the shard id and shard index are the same.
-            Self::V0(_) => shard_id.into(),
+            Self::V0(_) => Ok(shard_id.into()),
             // In V1 the shard id and shard index are the same.
-            Self::V1(_) => shard_id.into(),
+            Self::V1(_) => Ok(shard_id.into()),
             // In V2 the shard id and shard index are **not** the same.
-            Self::V2(v2) => v2.id_to_index_map[&shard_id],
+            Self::V2(v2) => v2
+                .id_to_index_map
+                .get(&shard_id)
+                .copied()
+                .ok_or_else(|| ShardLayoutError::InvalidShardIdError { shard_id }),
         }
     }
 

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -613,7 +613,12 @@ impl ShardLayout {
                 None => panic!("shard_layout has no parent shard"),
             },
             Self::V2(v2) => match &v2.shards_parent_map {
-                Some(to_parent_shard_map) => *to_parent_shard_map.get(&shard_id).unwrap(),
+                Some(to_parent_shard_map) => {
+                    let parent_shard_id = to_parent_shard_map.get(&shard_id);
+                    let parent_shard_id = parent_shard_id
+                        .ok_or_else(|| ShardLayoutError::InvalidShardIdError { shard_id })?;
+                    *parent_shard_id
+                }
                 None => panic!("shard_layout has no parent shard"),
             },
         };

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -622,7 +622,7 @@ impl ShardLayout {
                 Some(to_parent_shard_map) => {
                     let parent_shard_id = to_parent_shard_map.get(&shard_id);
                     let parent_shard_id = parent_shard_id
-                        .ok_or_else(|| ShardLayoutError::InvalidShardIdError { shard_id })?;
+                        .ok_or(ShardLayoutError::InvalidShardIdError { shard_id })?;
                     *parent_shard_id
                 }
                 None => panic!("shard_layout has no parent shard"),
@@ -683,7 +683,7 @@ impl ShardLayout {
                 .id_to_index_map
                 .get(&shard_id)
                 .copied()
-                .ok_or_else(|| ShardLayoutError::InvalidShardIdError { shard_id }),
+                .ok_or(ShardLayoutError::InvalidShardIdError { shard_id }),
         }
     }
 

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -324,6 +324,12 @@ pub enum ShardLayoutError {
     InvalidShardIdError { shard_id: ShardId },
 }
 
+impl fmt::Display for ShardLayoutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
 impl ShardLayout {
     /// Handy constructor for a single-shard layout, mostly for test purposes
     pub fn single_shard() -> Self {
@@ -607,7 +613,7 @@ impl ShardLayout {
                 // we can safely unwrap here because the construction of to_parent_shard_map guarantees
                 // that every shard has a parent shard
                 Some(to_parent_shard_map) => {
-                    let shard_index = self.get_shard_index(shard_id);
+                    let shard_index = self.get_shard_index(shard_id)?;
                     *to_parent_shard_map.get(shard_index).unwrap()
                 }
                 None => panic!("shard_layout has no parent shard"),

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 actix-rt.workspace = true
 actix.workspace = true
 anyhow.workspace = true
+assert_matches.workspace = true
 bytesize.workspace = true
 borsh.workspace = true
 chrono.workspace = true

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -315,7 +315,7 @@ fn challenge(
 ) -> Result<(CryptoHash, Vec<AccountId>), Error> {
     let epoch_id = block.header().epoch_id();
     let shard_layout = env.clients[0].chain.epoch_manager.get_shard_layout(epoch_id).unwrap();
-    let shard_index = shard_layout.get_shard_index(shard_id);
+    let shard_index = shard_layout.get_shard_index(shard_id)?;
 
     let merkle_paths = Block::compute_chunk_headers_root(block.chunks().iter_deprecated()).1;
     let valid_challenge = Challenge::produce(

--- a/integration-tests/src/tests/client/features/adversarial_behaviors.rs
+++ b/integration-tests/src/tests/client/features/adversarial_behaviors.rs
@@ -288,7 +288,7 @@ fn test_banning_chunk_producer_when_seeing_invalid_chunk_base(
             let prev_block =
                 test.env.clients[0].chain.get_block(&block.header().prev_hash()).unwrap();
             for shard_id in shard_layout.shard_ids() {
-                let shard_index = shard_layout.get_shard_index(shard_id);
+                let shard_index = shard_layout.get_shard_index(shard_id).unwrap();
                 if invalid_chunks_in_this_block.contains(&shard_id) && !this_block_should_be_skipped
                 {
                     assert_eq!(

--- a/integration-tests/src/tests/client/features/congestion_control.rs
+++ b/integration-tests/src/tests/client/features/congestion_control.rs
@@ -271,7 +271,7 @@ fn head_chunk_header(env: &TestEnv, shard_id: ShardId) -> ShardChunkHeader {
 
     let epoch_id = block.header().epoch_id();
     let shard_layout = env.clients[0].epoch_manager.get_shard_layout(epoch_id).unwrap();
-    let shard_index = shard_layout.get_shard_index(shard_id);
+    let shard_index = shard_layout.get_shard_index(shard_id).unwrap();
     chunks.get(shard_index).expect("chunk header must be available").clone()
 }
 
@@ -335,7 +335,7 @@ fn test_protocol_upgrade_under_congestion() {
         .epoch_manager
         .account_id_to_shard_id(&CONTRACT_ID.parse().unwrap(), &tip.epoch_id)
         .unwrap();
-    let contract_shard_index = shard_layout.get_shard_index(contract_shard_id);
+    let contract_shard_index = shard_layout.get_shard_index(contract_shard_id).unwrap();
 
     // Check there is still congestion, which this test is all about.
 

--- a/integration-tests/src/tests/client/features/stateless_validation.rs
+++ b/integration-tests/src/tests/client/features/stateless_validation.rs
@@ -354,10 +354,8 @@ fn test_protocol_upgrade_81() {
     assert_eq!(config.chunk_producer_kickout_threshold, 90);
 }
 
-// TODO(wacban) should not panic when V2 is ready
 /// Test that Client rejects ChunkStateWitnesses with invalid shard_id
 #[test]
-#[should_panic(expected = "no entry found for key")]
 fn test_chunk_state_witness_bad_shard_id() {
     init_integration_logger();
 

--- a/integration-tests/src/tests/client/features/stateless_validation.rs
+++ b/integration-tests/src/tests/client/features/stateless_validation.rs
@@ -1,6 +1,7 @@
 use crate::tests::client::features::wallet_contract::{
     create_rlp_execute_tx, view_balance, NearSigner,
 };
+use assert_matches::assert_matches;
 use near_client::{ProcessTxResponse, ProduceChunkResult};
 use near_epoch_manager::{EpochManager, EpochManagerAdapter};
 use near_primitives::account::id::AccountIdRef;
@@ -388,6 +389,7 @@ fn test_chunk_state_witness_bad_shard_id() {
     let error_message = format!("{}", error).to_lowercase();
     tracing::info!(target: "test", "error message: {}", error_message);
     assert!(error_message.contains("shard"));
+    assert_matches!(error, near_chain::Error::InvalidShardId(_));
 }
 
 /// Test that processing chunks with invalid transactions does not lead to panics

--- a/integration-tests/src/tests/client/resharding_v2.rs
+++ b/integration-tests/src/tests/client/resharding_v2.rs
@@ -369,7 +369,7 @@ impl TestReshardingEnv {
                 Some((new_block_hash, target_shard_id)) => {
                     let new_block = client.chain.get_block(&new_block_hash).unwrap().clone();
                     let chunks = new_block.chunks();
-                    let target_shard_index = shard_layout.get_shard_index(target_shard_id);
+                    let target_shard_index = shard_layout.get_shard_index(target_shard_id).unwrap();
                     // check that the target chunk in the new block is new
                     assert_eq!(
                         chunks.get(target_shard_index).unwrap().height_included(),
@@ -405,7 +405,7 @@ impl TestReshardingEnv {
                 };
 
                 for target_shard_id in target_shard_ids {
-                    let target_shard_index = shard_layout.get_shard_index(target_shard_id);
+                    let target_shard_index = shard_layout.get_shard_index(target_shard_id).unwrap();
                     let chunk = chunks.get(target_shard_index).unwrap();
                     assert_ne!(chunk.height_included(), last_block.header().height());
                 }
@@ -520,7 +520,7 @@ fn check_account(env: &TestEnv, account_id: &AccountId, block: &Block) {
         env.clients[0].epoch_manager.get_shard_layout_from_prev_block(prev_hash).unwrap();
     let shard_uid = account_id_to_shard_uid(account_id, &shard_layout);
     let shard_id = shard_uid.shard_id();
-    let shard_index = shard_layout.get_shard_index(shard_id);
+    let shard_index = shard_layout.get_shard_index(shard_id).unwrap();
     for (i, me) in env.validators.iter().enumerate() {
         let client = &env.clients[i];
         let care_about_shard =

--- a/nearcore/src/entity_debug.rs
+++ b/nearcore/src/entity_debug.rs
@@ -15,6 +15,7 @@ use near_primitives::challenge::{PartialState, TrieValue};
 use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::epoch_block_info::BlockInfo;
 use near_primitives::epoch_manager::AGGREGATOR_KEY;
+use near_primitives::errors::EpochError;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::merkle::PartialMerkleTree;
 use near_primitives::receipt::Receipt;
@@ -263,7 +264,8 @@ impl EntityDebugHandlerImpl {
                     .epoch_manager
                     .get_shard_layout_from_prev_block(&chunk.cloned_header().prev_block_hash())?;
                 let shard_id = chunk.shard_id();
-                let shard_index = shard_layout.get_shard_index(shard_id);
+                let shard_index =
+                    shard_layout.get_shard_index(shard_id).map_err(Into::<EpochError>::into)?;
                 let shard_uid = shard_layout
                     .shard_uids()
                     .nth(shard_index)
@@ -298,7 +300,8 @@ impl EntityDebugHandlerImpl {
             }
             EntityQuery::ShardUIdByShardId { shard_id, epoch_id } => {
                 let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
-                let shard_index = shard_layout.get_shard_index(shard_id);
+                let shard_index =
+                    shard_layout.get_shard_index(shard_id).map_err(Into::<EpochError>::into)?;
 
                 let shard_uid = shard_layout
                     .shard_uids()
@@ -396,7 +399,8 @@ impl EntityDebugHandlerImpl {
                     .epoch_manager
                     .get_shard_layout_from_prev_block(&chunk.cloned_header().prev_block_hash())?;
                 let shard_id = chunk.shard_id();
-                let shard_index = shard_layout.get_shard_index(shard_id);
+                let shard_index =
+                    shard_layout.get_shard_index(shard_id).map_err(Into::<EpochError>::into)?;
                 let shard_uid = shard_layout
                     .shard_uids()
                     .nth(shard_index)

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -6,6 +6,7 @@ use near_chain::types::RuntimeAdapter;
 use near_chain::{ChainStore, ChainStoreAccess};
 use near_chain_configs::GenesisValidationMode;
 use near_epoch_manager::{EpochManager, EpochManagerAdapter, EpochManagerHandle};
+use near_primitives::errors::EpochError;
 use near_primitives::shard_layout::{account_id_to_shard_id, ShardVersion};
 use near_primitives::state::FlatStateValue;
 use near_primitives::types::{BlockHeight, ShardId};
@@ -485,7 +486,8 @@ impl FlatStorageCommand {
             let epoch_id = header.epoch_id();
             let shard_layout = epoch_manager.get_shard_layout(&epoch_id)?;
             shard_uid = epoch_manager.shard_id_to_uid(shard_id, epoch_id)?;
-            let shard_index = shard_layout.get_shard_index(shard_id);
+            let shard_index =
+                shard_layout.get_shard_index(shard_id).map_err(Into::<EpochError>::into)?;
 
             let state_root = block.chunks().get(shard_index).unwrap().prev_state_root();
             let prev_hash = header.prev_hash();

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -108,7 +108,7 @@ pub(crate) fn apply_chunk(
         chain_store.get_block(prev_block_hash).context("Failed getting chunk's prev block")?;
     let prev_epoch_id = prev_block.header().epoch_id();
     let prev_shard_layout = epoch_manager.get_shard_layout(prev_epoch_id)?;
-    let prev_shard_index = prev_shard_layout.get_shard_index(shard_id);
+    let prev_shard_index = prev_shard_layout.get_shard_index(shard_id).unwrap();
     let prev_height_included = prev_block.chunks()[prev_shard_index].height_included();
     let prev_height = prev_block.header().height();
     let target_height = match target_height {
@@ -694,7 +694,7 @@ mod test {
 
             if height >= 2 {
                 for &shard_id in shard_ids.iter() {
-                    let shard_index = shard_layout.get_shard_index(shard_id);
+                    let shard_index = shard_layout.get_shard_index(shard_id).unwrap();
                     let chunk = chain_store.get_chunk(&chunk_hashes[shard_index]).unwrap();
 
                     for tx in chunk.transactions() {
@@ -716,7 +716,7 @@ mod test {
                             receipt.receiver_id(),
                             &shard_layout,
                         );
-                        let to_shard_index = shard_layout.get_shard_index(to_shard_id);
+                        let to_shard_index = shard_layout.get_shard_index(to_shard_id).unwrap();
 
                         let results = crate::apply_chunk::apply_receipt(
                             genesis.config.genesis_height,

--- a/tools/state-viewer/src/epoch_info.rs
+++ b/tools/state-viewer/src/epoch_info.rs
@@ -6,6 +6,7 @@ use near_epoch_manager::{EpochManagerAdapter, EpochManagerHandle};
 use near_primitives::account::id::AccountId;
 use near_primitives::epoch_info::EpochInfo;
 use near_primitives::epoch_manager::AGGREGATOR_KEY;
+use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::{BlockHeight, EpochHeight, EpochId, ProtocolVersion, ShardId};
 use near_store::{DBCol, Store};
@@ -295,7 +296,8 @@ fn display_validator_info(
         for (block_height, shard_id) in cp_for_chunks {
             if let Ok(block_hash) = chain_store.get_block_hash_by_height(block_height) {
                 let block = chain_store.get_block(&block_hash).unwrap();
-                let shard_index = shard_layout.get_shard_index(shard_id);
+                let shard_index =
+                    shard_layout.get_shard_index(shard_id).map_err(Into::<EpochError>::into)?;
                 if block.chunks()[shard_index].height_included() != block_height {
                     missing_chunks.push((block_height, shard_id));
                 }

--- a/tools/state-viewer/src/state_changes.rs
+++ b/tools/state-viewer/src/state_changes.rs
@@ -92,7 +92,7 @@ fn dump_state_changes(
         for row in key.find_rows_iter(&store) {
             let (key, value) = row.unwrap();
             let shard_id = get_state_change_shard_id(key.as_ref(), &value.trie_key, block_hash, epoch_id, epoch_manager.as_ref()).unwrap();
-            let shard_index = shard_layout.get_shard_index(shard_id);
+            let shard_index = shard_layout.get_shard_index(shard_id).unwrap();
             state_changes_per_shard[shard_index].push(value);
         }
 

--- a/tools/state-viewer/src/util.rs
+++ b/tools/state-viewer/src/util.rs
@@ -5,8 +5,9 @@ use near_chain::{
     Block, BlockHeader, ChainStore, ChainStoreAccess,
 };
 use near_epoch_manager::{EpochManager, EpochManagerAdapter, EpochManagerHandle};
-use near_primitives::types::{
-    chunk_extra::ChunkExtra, BlockHeight, Gas, ProtocolVersion, ShardId, StateRoot,
+use near_primitives::{
+    errors::EpochError,
+    types::{chunk_extra::ChunkExtra, BlockHeight, Gas, ProtocolVersion, ShardId, StateRoot},
 };
 use near_store::{ShardUId, Store};
 use nearcore::{NearConfig, NightshadeRuntime, NightshadeRuntimeExt};
@@ -169,7 +170,7 @@ pub fn check_apply_block_result(
     let protocol_version = block.header().latest_protocol_version();
     let epoch_id = block.header().epoch_id();
     let shard_layout = epoch_manager.get_shard_layout(epoch_id).unwrap();
-    let shard_index = shard_layout.get_shard_index(shard_id);
+    let shard_index = shard_layout.get_shard_index(shard_id).map_err(Into::<EpochError>::into)?;
     let new_chunk_extra = resulting_chunk_extra(
         apply_result,
         block.chunks()[shard_index].gas_limit(),


### PR DESCRIPTION
Added error handling to `get_shard_index`. There are a few places in the codebase where the shard id may be invalid - such as when a new block or a new state witness is received. Just to be future safe I'm adding this error handling in order to avoid panics during validation. 

In most production code I added `?`. I most test code I added `unwrap` or `expect`. In a few places I needed to manually convert the error with `.map_err(Into::<EpochError>::into)?;`. Small refactoring of `get_prev_shard_id` and `get_prev_shard_ids`. 