### PR TITLE
chore: keep build artifacts for test contracts out of source

### DIFF
--- a/runtime/near-test-contracts/README.md
+++ b/runtime/near-test-contracts/README.md
@@ -7,7 +7,7 @@ is build manually and committed to the git repository.
 and it's for reproduce a performance issue encountered in EVM
 contracts.
 
-If you want to use a contract from rust core, add
+If you want to use a contract from rust code, add
 
 ```toml
 [dev-dependencies]
@@ -15,7 +15,3 @@ near-test-contracts = { path = "../near-test-contracts" }
 ```
 
 to the Cargo.toml and use `near_test_contract::rs_contract()`.
-
-If you want to use a contract from an integration test, you can read
-the wasm file directly from the `./res` directory.  To populate
-`./res`, you need to make sure that this crate was compiled.

--- a/runtime/near-test-contracts/build.rs
+++ b/runtime/near-test-contracts/build.rs
@@ -61,6 +61,7 @@ fn res_contract(name: &str) {
         PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").expect("manifest dir"));
     manifest_dir.push("res");
     manifest_dir.push(format!("{name}.wasm"));
+    println!("cargo:rerun-if-changed={}", manifest_dir.display());
     println!("cargo::rustc-env=CONTRACT_{}={}", name, manifest_dir.display());
 }
 

--- a/runtime/near-test-contracts/build.rs
+++ b/runtime/near-test-contracts/build.rs
@@ -5,6 +5,7 @@
 /// any other messages with prefix other than `cargo::`) but can be seen in the
 /// build logs.
 use std::env;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 type Error = Box<dyn std::error::Error>;
@@ -21,6 +22,7 @@ fn main() {
 fn try_main() -> Result<(), Error> {
     let mut test_contract_features = vec!["latest_protocol"];
 
+    let is_nightly = std::env::var_os("CARGO_FEATURE_nightly").is_some();
     let test_features = &env::var(TEST_FEATURES_ENV);
     println!("cargo:rerun-if-env-changed={TEST_FEATURES_ENV}");
     println!("debug: test_features = {test_features:?}");
@@ -43,13 +45,23 @@ fn try_main() -> Result<(), Error> {
         "nightly_test_contract_rs",
     )?;
     build_contract("./contract-for-fuzzing-rs", &[], "contract_for_fuzzing_rs")?;
-    build_contract("./estimator-contract", &[], "stable_estimator_contract")?;
     build_contract(
         "./estimator-contract",
-        &["--features", "nightly"],
-        "nightly_estimator_contract",
+        if is_nightly { &["--features", "nightly"] } else { &[] },
+        "estimator_contract",
     )?;
+    res_contract("backwards_compatible_rs_contract");
+    res_contract("test_contract_ts");
+    res_contract("fungible_token");
     Ok(())
+}
+
+fn res_contract(name: &str) {
+    let mut manifest_dir =
+        PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").expect("manifest dir"));
+    manifest_dir.push("res");
+    manifest_dir.push(format!("{name}.wasm"));
+    println!("cargo::rustc-env=CONTRACT_{}={}", name, manifest_dir.display());
 }
 
 /// build the contract and copy the wasm file to the `res` directory
@@ -63,21 +75,19 @@ fn build_contract(dir: &str, args: &[&str], output: &str) -> Result<(), Error> {
     check_status(cmd)?;
 
     // copy the wasm file to the `res` directory
-    let target_path = format!("wasm32-unknown-unknown/release/{}.wasm", dir.replace('-', "_"));
-    let from = target_dir.join(target_path);
-    let to = format!("./res/{}.wasm", output);
-    let copy_result = std::fs::copy(&from, &to);
-    copy_result.map_err(|err| format!("failed to copy `{}`: {}", from.display(), err))?;
-
+    let file_path = format!("wasm32-unknown-unknown/release/{}.wasm", dir.replace('-', "_"));
+    let from = target_dir.join(file_path);
+    let to = target_dir.join(format!("{}.wasm", output));
+    std::fs::rename(&from, &to)
+        .map_err(|err| format!("failed to copy `{}`: {}", from.display(), err))?;
+    println!("cargo::rustc-env=CONTRACT_{}={}", output, to.display());
     println!("cargo:rerun-if-changed=./{}/src/lib.rs", dir);
     println!("cargo:rerun-if-changed=./{}/Cargo.toml", dir);
-
     println!("debug: from = {from:?}, to = {to:?}");
-
     Ok(())
 }
 
-fn cargo_build_cmd(target_dir: &std::path::Path) -> Command {
+fn cargo_build_cmd(target_dir: &Path) -> Command {
     let mut res = Command::new("cargo");
 
     res.env_remove("CARGO_BUILD_RUSTFLAGS");

--- a/runtime/near-test-contracts/build.rs
+++ b/runtime/near-test-contracts/build.rs
@@ -2,7 +2,7 @@
 /// `res` directory.
 ///
 /// It writes a few logs with the `debug` prefix. Those are ignored by cargo (as
-/// any other messages with prefix other than `cargo::`) but can be seen in the
+/// any other messages with prefix other than `cargo:`) but can be seen in the
 /// build logs.
 use std::env;
 use std::path::{Path, PathBuf};
@@ -62,7 +62,7 @@ fn res_contract(name: &str) {
     manifest_dir.push("res");
     manifest_dir.push(format!("{name}.wasm"));
     println!("cargo:rerun-if-changed={}", manifest_dir.display());
-    println!("cargo::rustc-env=CONTRACT_{}={}", name, manifest_dir.display());
+    println!("cargo:rustc-env=CONTRACT_{}={}", name, manifest_dir.display());
 }
 
 /// build the contract and copy the wasm file to the `res` directory
@@ -81,7 +81,7 @@ fn build_contract(dir: &str, args: &[&str], output: &str) -> Result<(), Error> {
     let to = target_dir.join(format!("{}.wasm", output));
     std::fs::rename(&from, &to)
         .map_err(|err| format!("failed to copy `{}`: {}", from.display(), err))?;
-    println!("cargo::rustc-env=CONTRACT_{}={}", output, to.display());
+    println!("cargo:rustc-env=CONTRACT_{}={}", output, to.display());
     println!("cargo:rerun-if-changed=./{}/src/lib.rs", dir);
     println!("cargo:rerun-if-changed=./{}/Cargo.toml", dir);
     println!("debug: from = {from:?}, to = {to:?}");

--- a/runtime/near-test-contracts/src/lib.rs
+++ b/runtime/near-test-contracts/src/lib.rs
@@ -2,7 +2,6 @@
 
 use arbitrary::Arbitrary;
 use rand::{Fill, SeedableRng};
-use std::path::Path;
 use std::sync::OnceLock;
 
 /// Parse a WASM contract from WAT representation.
@@ -47,7 +46,7 @@ pub fn sized_contract(size: usize) -> Vec<u8> {
 /// not work for tests using an older version. In particular, if a test depends
 /// on a specific protocol version, it should use [`backwards_compatible_rs_contract`].
 pub fn rs_contract() -> &'static [u8] {
-    include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/res/", "test_contract_rs.wasm"))
+    include_bytes!(env!("CONTRACT_test_contract_rs"))
 }
 
 /// Standard test contract which is compatible any protocol version, including
@@ -66,25 +65,21 @@ pub fn rs_contract() -> &'static [u8] {
 /// contracts content, we can build it manually with an older compiler and check
 /// in the new WASM.
 pub fn backwards_compatible_rs_contract() -> &'static [u8] {
-    static CONTRACT: OnceLock<Vec<u8>> = OnceLock::new();
-    CONTRACT.get_or_init(|| read_contract("backwards_compatible_rs_contract.wasm")).as_slice()
+    include_bytes!(env!("CONTRACT_backwards_compatible_rs_contract"))
 }
 
 /// Standard test contract which additionally includes all host functions from
 /// the nightly protocol.
 pub fn nightly_rs_contract() -> &'static [u8] {
-    static CONTRACT: OnceLock<Vec<u8>> = OnceLock::new();
-    CONTRACT.get_or_init(|| read_contract("nightly_test_contract_rs.wasm")).as_slice()
+    include_bytes!(env!("CONTRACT_nightly_test_contract_rs"))
 }
 
 pub fn ts_contract() -> &'static [u8] {
-    static CONTRACT: OnceLock<Vec<u8>> = OnceLock::new();
-    CONTRACT.get_or_init(|| read_contract("test_contract_ts.wasm")).as_slice()
+    include_bytes!(env!("CONTRACT_test_contract_ts"))
 }
 
 pub fn fuzzing_contract() -> &'static [u8] {
-    static CONTRACT: OnceLock<Vec<u8>> = OnceLock::new();
-    CONTRACT.get_or_init(|| read_contract("contract_for_fuzzing_rs.wasm")).as_slice()
+    include_bytes!(env!("CONTRACT_contract_for_fuzzing_rs"))
 }
 
 /// NEP-141 implementation (fungible token contract).
@@ -97,8 +92,7 @@ pub fn fuzzing_contract() -> &'static [u8] {
 /// defined by NEP-141 is sufficient. But for future reference, the WASM was
 /// compiled with SDK version 4.1.1.
 pub fn ft_contract() -> &'static [u8] {
-    static CONTRACT: OnceLock<Vec<u8>> = OnceLock::new();
-    CONTRACT.get_or_init(|| read_contract("fungible_token.wasm")).as_slice()
+    include_bytes!(env!("CONTRACT_fungible_token"))
 }
 
 /// Smallest (reasonable) contract possible to build.
@@ -128,23 +122,7 @@ pub fn smallest_rs_contract() -> &'static [u8] {
 
 /// Contract that has all methods required by the gas parameter estimator.
 pub fn estimator_contract() -> &'static [u8] {
-    static CONTRACT: OnceLock<Vec<u8>> = OnceLock::new();
-    let file_name = if cfg!(feature = "nightly") {
-        "nightly_estimator_contract.wasm"
-    } else {
-        "stable_estimator_contract.wasm"
-    };
-    CONTRACT.get_or_init(|| read_contract(file_name)).as_slice()
-}
-
-/// Read given wasm file or panic if unable to.
-fn read_contract(file_name: &str) -> Vec<u8> {
-    let base = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let path = base.join("res").join(file_name);
-    match std::fs::read(&path) {
-        Ok(data) => data,
-        Err(err) => panic!("{}: {}", path.display(), err),
-    }
+    include_bytes!(env!("CONTRACT_estimator_contract"))
 }
 
 #[test]


### PR DESCRIPTION
Placing build artifacts into source directories has a nasty property of readily doing the wrong thing in situations where there's parallel compilation of different feature combinations, for example.

In my case, I would locally never be able to run integration tests as R-A would quickly rebuild the test contracts crate with its own feature set during a run of the tests.

There has historically been problems with this in the context of nayduck too.

This PR does the right thing wherein it places the build-time artifacts exactly where they belong: $OUT_DIR.