### PR TITLE
fix(epoch config): load config files on neard run

### DIFF
--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -255,8 +255,11 @@ pub fn start_with_config_and_synchronization(
         config.client_config.log_summary_period,
     )?;
 
-    let epoch_manager =
-        EpochManager::new_arc_handle(storage.get_hot_store(), &config.genesis.config, None);
+    let epoch_manager = EpochManager::new_arc_handle(
+        storage.get_hot_store(),
+        &config.genesis.config,
+        Some(home_dir),
+    );
     let genesis_epoch_config = epoch_manager.get_epoch_config(&EpochId::default())?;
     // Initialize genesis_state in store either from genesis config or dump before other components.
     // We only initialize if the genesis state is not already initialized in store.
@@ -283,8 +286,11 @@ pub fn start_with_config_and_synchronization(
     let split_store = get_split_store(&config, &storage)?;
     let (view_epoch_manager, view_shard_tracker, view_runtime) =
         if let Some(split_store) = &split_store {
-            let view_epoch_manager =
-                EpochManager::new_arc_handle(split_store.clone(), &config.genesis.config, None);
+            let view_epoch_manager = EpochManager::new_arc_handle(
+                split_store.clone(),
+                &config.genesis.config,
+                Some(home_dir),
+            );
             let view_shard_tracker = ShardTracker::new(
                 TrackedConfig::from_config(&config.client_config),
                 epoch_manager.clone(),


### PR DESCRIPTION
This one was overlooked from the previous PR. 
Pass the `home_dir` so it can load the epoch config files when necessary.