### PR TITLE
feat: added custom status code for a missed block

### DIFF
--- a/chain/jsonrpc/CHANGELOG.md
+++ b/chain/jsonrpc/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.4.0
+## 2.3.1
 
 * Introduced a new status code for a missing block - 422 Unprocessable Content
 > Block is considered as missing if rpc returned `UNKNOWN_BLOCK` error while requested block height is less than the latest block height

--- a/chain/jsonrpc/CHANGELOG.md
+++ b/chain/jsonrpc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.0
+
+* Introduced a new status code for a missing block - 422 Unprocessable Content
+> Block is considered as missing if rpc returned `UNKNOWN_BLOCK` error while requested block height is less than the latest block height
 
 ## 2.3.0
 

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1366,16 +1366,18 @@ async fn handle_unknown_block(
         return HttpResponse::Ok();
     };
 
+    let Some(block_height) = block_id.as_u64() else {
+        return HttpResponse::Ok();
+    };
+
     let Ok(latest_block) =
         handler.block(RpcBlockRequest { block_reference: BlockReference::latest() }).await
     else {
         return HttpResponse::Ok();
     };
 
-    if let Some(block_height) = block_id.as_u64() {
-        if block_height < latest_block.block_view.header.height {
-            return HttpResponse::UnprocessableEntity();
-        }
+    if block_height < latest_block.block_view.header.height {
+        return HttpResponse::UnprocessableEntity();
     }
 
     HttpResponse::Ok()

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -40,6 +40,7 @@ use near_primitives::types::{AccountId, BlockHeight, BlockId, BlockReference};
 use near_primitives::views::{QueryRequest, TxExecutionStatus};
 use serde_json::{json, Value};
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::time::{sleep, timeout};
@@ -1374,11 +1375,13 @@ async fn handle_unknown_block(
     };
 
     if let Some(block_hash) = block_id.as_str() {
+        let Ok(block_hash) = CryptoHash::from_str(block_hash) else {
+            return HttpResponse::Ok();
+        };
+
         if let Ok(block) = handler
             .block(RpcBlockRequest {
-                block_reference: BlockReference::BlockId(BlockId::Hash(CryptoHash::hash_bytes(
-                    block_hash.as_bytes(),
-                ))),
+                block_reference: BlockReference::BlockId(BlockId::Hash(block_hash)),
             })
             .await
         {

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -40,7 +40,6 @@ use near_primitives::types::{AccountId, BlockHeight, BlockId, BlockReference};
 use near_primitives::views::{QueryRequest, TxExecutionStatus};
 use serde_json::{json, Value};
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::time::{sleep, timeout};
@@ -1373,22 +1372,7 @@ async fn handle_unknown_block(
         return HttpResponse::Ok();
     };
 
-    if let Some(block_hash) = block_id.as_str() {
-        let Ok(block_hash) = CryptoHash::from_str(block_hash) else {
-            return HttpResponse::Ok();
-        };
-
-        if let Ok(block) = handler
-            .block(RpcBlockRequest {
-                block_reference: BlockReference::BlockId(BlockId::Hash(block_hash)),
-            })
-            .await
-        {
-            if block.block_view.header.height < latest_block.block_view.header.height {
-                return HttpResponse::UnprocessableEntity();
-            }
-        }
-    } else if let Some(block_height) = block_id.as_u64() {
+    if let Some(block_height) = block_id.as_u64() {
         if block_height < latest_block.block_view.header.height {
             return HttpResponse::UnprocessableEntity();
         }

--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -59,6 +59,8 @@ pytest sanity/sync_chunks_from_archival.py
 pytest sanity/sync_chunks_from_archival.py --features nightly
 pytest sanity/rpc_tx_forwarding.py
 pytest sanity/rpc_tx_forwarding.py --features nightly
+pytest sanity/rpc_missing_block.py
+pytest sanity/rpc_missing_block.py --features nightly
 pytest --timeout=240 sanity/one_val.py
 pytest --timeout=240 sanity/one_val.py nightly --features nightly
 pytest --timeout=240 sanity/lightclnt.py

--- a/pytest/tests/sanity/rpc_missing_block.py
+++ b/pytest/tests/sanity/rpc_missing_block.py
@@ -8,7 +8,6 @@ from configured_logger import logger
 import utils
 from geventhttpclient import useragent
 
-
 nodes = start_cluster(
     num_nodes=4,
     num_observers=1,
@@ -22,12 +21,45 @@ nodes = start_cluster(
         ["block_producer_kickout_threshold", 70],
     ],
     client_config_changes={
-        0: {"consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
-        1: {"consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
-        2: {"consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
-        3: {"consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
+        0: {
+            "consensus": {
+                "state_sync_timeout": {
+                    "secs": 2,
+                    "nanos": 0
+                }
+            }
+        },
+        1: {
+            "consensus": {
+                "state_sync_timeout": {
+                    "secs": 2,
+                    "nanos": 0
+                }
+            }
+        },
+        2: {
+            "consensus": {
+                "state_sync_timeout": {
+                    "secs": 2,
+                    "nanos": 0
+                }
+            }
+        },
+        3: {
+            "consensus": {
+                "state_sync_timeout": {
+                    "secs": 2,
+                    "nanos": 0
+                }
+            }
+        },
         4: {
-            "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}},
+            "consensus": {
+                "state_sync_timeout": {
+                    "secs": 2,
+                    "nanos": 0
+                }
+            },
             "tracked_shards": [0, 1, 2, 3],
         },
     },
@@ -41,7 +73,8 @@ def check_bad_block(node, height):
         node.get_block_by_height(height)
         assert False, "Expected an exception for block height 1 but none was raised"
     except useragent.BadStatusCode as e:
-        assert "code=422" in str(e), f"Expected status code 422 in exception, got: {e}"
+        assert "code=422" in str(
+            e), f"Expected status code 422 in exception, got: {e}"
     except Exception as e:
         assert False, f"Unexpected exception type raised: {type(e)}. Exception: {e}"
 

--- a/pytest/tests/sanity/rpc_missing_block.py
+++ b/pytest/tests/sanity/rpc_missing_block.py
@@ -1,0 +1,48 @@
+import sys, time
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / "lib"))
+
+from cluster import start_cluster
+from geventhttpclient import useragent
+
+
+nodes = start_cluster(
+    num_nodes=4,
+    num_observers=1,
+    num_shards=4,
+    config=None,
+    extra_state_dumper=True,
+    genesis_config_changes=[
+        ["min_gas_price", 0],
+        ["max_inflation_rate", [0, 1]],
+        ["epoch_length", 10],
+        ["block_producer_kickout_threshold", 70],
+    ],
+    client_config_changes={
+        0: {"consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
+        1: {"consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
+        2: {"consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
+        3: {"consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}}},
+        4: {
+            "consensus": {"state_sync_timeout": {"secs": 2, "nanos": 0}},
+            "tracked_shards": [0, 1, 2, 3],
+        },
+    },
+)
+
+time.sleep(20)
+
+response = nodes[0].get_block_by_height(9999)
+assert "error" in response, f"Expected an error for block height 9999, got: {response}"
+assert (
+    response["error"]["cause"]["name"] == "UNKNOWN_BLOCK"
+), f"Expected UNKNOWN_BLOCK error, got: {response['error']['cause']['name']}"
+
+try:
+    nodes[0].get_block_by_height(1)
+    assert False, "Expected an exception for block height 1 but none was raised"
+except useragent.BadStatusCode as e:
+    assert "code=422" in str(e), f"Expected status code 422 in exception, got: {e}"
+except Exception as e:
+    assert False, f"Unexpected exception type raised: {type(e)}. Exception: {e}"

--- a/pytest/tests/sanity/rpc_missing_block.py
+++ b/pytest/tests/sanity/rpc_missing_block.py
@@ -92,7 +92,7 @@ for height, hash in utils.poll_blocks(nodes[0]):
     if last_height != -1:
         for bad_height in range(last_height + 1, height):
             response = check_bad_block(nodes[0], bad_height)
-            logger.info(f"422 response for: {height}")
+            logger.info(f"422 response for: {bad_height}")
 
     last_height = height
 

--- a/pytest/tests/sanity/rpc_missing_block.py
+++ b/pytest/tests/sanity/rpc_missing_block.py
@@ -71,7 +71,7 @@ nodes[1].kill()
 def check_bad_block(node, height):
     try:
         node.get_block_by_height(height)
-        assert False, "Expected an exception for block height 1 but none was raised"
+        assert False, f"Expected an exception for block height {height} but none was raised"
     except useragent.BadStatusCode as e:
         assert "code=422" in str(
             e), f"Expected status code 422 in exception, got: {e}"


### PR DESCRIPTION
As requested from our partner, custom status code for a missing block was added. I decided to go with 422 Unprocessable Content which seems pretty logical to me, but let me know if this is a bad choice

closes #12399 