### PR TITLE
fix(resharding): call start_resharding() when catching up blocks

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3312,6 +3312,13 @@ impl Chain {
                 shard_id,
                 true,
             ) {
+                let shard_uid = self.epoch_manager.shard_id_to_uid(shard_id, &epoch_id)?;
+                self.resharding_manager.start_resharding(
+                    self.chain_store.store_update(),
+                    &block,
+                    shard_uid,
+                    self.runtime_adapter.get_tries(),
+                )?;
                 self.update_flat_storage_and_memtrie(&block, shard_id)?;
             }
         }


### PR DESCRIPTION
Currently we only call start_resharding() in postprocess_ready_block() if the node either tracks the parent shard currently, or will track it (meaning it will produce chunks for a child in the next epoch) *and* is caught up (meaning it has downloaded state for the parent and applied parent chunks from the sync_hash until the HEAD).  If it doesn't currently track it but will in the future and catchup is not done, we will not initiate the resharding and will get stuck at the beginning of the next epoch.

We can fix it by just calling start_resharding() in the same place where update_flat_storage_and_memtrie() is called during catchup, because in that case (in block_catch_up_postprocess()), we call update_flat_storage_and_memtrie() if the shard is not currently tracked but will be tracked, which means we didn't call this in postprocess_ready_block(). This is the same condition we want for deciding whether to call start_resharding()