### PR TITLE
feat(contract-distribution): Improve testloop tests for contract distribution for more observability

### DIFF
--- a/integration-tests/src/test_loop/tests/contract_distribution_cross_shard.rs
+++ b/integration-tests/src/test_loop/tests/contract_distribution_cross_shard.rs
@@ -4,13 +4,18 @@ use near_async::time::Duration;
 use near_chain_configs::test_genesis::TestGenesisBuilder;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::types::AccountId;
+use near_vm_runner::ContractCode;
 
 use crate::test_loop::builder::TestLoopBuilder;
 use crate::test_loop::env::{TestData, TestLoopEnv};
+use crate::test_loop::utils::contract_distribution::{
+    assert_all_chunk_endorsements_received, clear_compiled_contract_caches,
+    run_until_cache_contains_contract,
+};
 use crate::test_loop::utils::transactions::{
     call_contract, check_txs, deploy_contract, make_accounts,
 };
-use crate::test_loop::utils::ONE_NEAR;
+use crate::test_loop::utils::{get_head_height, ONE_NEAR};
 
 const EPOCH_LENGTH: u64 = 10;
 const GENESIS_HEIGHT: u64 = 1000;
@@ -36,6 +41,8 @@ fn test_contract_distribution_cross_shard() {
     let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } = env;
 
     let mut nonce = 2;
+    let rpc_index = 8;
+    assert_eq!(accounts[rpc_index], rpc_id);
 
     // Deploy a contract for each shard (account0 from first one, and account4 from second one).
     // Then take two accounts from each shard (one with a contract deployed and one without) and
@@ -43,16 +50,27 @@ fn test_contract_distribution_cross_shard() {
     let contract_ids = [&accounts[0], &accounts[4]];
     let sender_ids = [&accounts[0], &accounts[1], &accounts[4], &accounts[5]];
 
+    let start_height = get_head_height(&mut test_loop, &node_datas);
+
     // First deploy and call the contracts as described above.
     // Next, clear the compiled contract cache and repeat the same contract calls.
-    deploy_contracts(&mut test_loop, &node_datas, &rpc_id, &contract_ids, &mut nonce);
+    let contracts =
+        deploy_contracts(&mut test_loop, &node_datas, &rpc_id, &contract_ids, &mut nonce);
+
+    // Wait for RPC node to contains the compiled contracts in its cache before calling the contracts.
+    // This will make sure the deploy actions took effect in the network.
+    for contract in contracts.into_iter() {
+        run_until_cache_contains_contract(&mut test_loop, &node_datas, contract.hash(), rpc_index);
+    }
 
     call_contracts(&mut test_loop, &node_datas, &rpc_id, &contract_ids, &sender_ids, &mut nonce);
 
-    #[cfg(feature = "test_features")]
     clear_compiled_contract_caches(&mut test_loop, &node_datas);
 
     call_contracts(&mut test_loop, &node_datas, &rpc_id, &contract_ids, &sender_ids, &mut nonce);
+
+    let end_height = get_head_height(&mut test_loop, &node_datas);
+    assert_all_chunk_endorsements_received(&mut test_loop, &node_datas, start_height, end_height);
 
     TestLoopEnv { test_loop, datas: node_datas, tempdir }
         .shutdown_and_drain_remaining_events(Duration::seconds(20));
@@ -98,23 +116,35 @@ fn setup(accounts: &Vec<AccountId>) -> (TestLoopEnv, AccountId) {
 
 /// Deploys a contract for the given accounts (`contract_ids`) and waits until the transactions are executed.
 /// Each account in `contract_ids` gets a fake contract with a different size (thus code-hashes are different)
+/// Returns the list of contracts deployed.
 fn deploy_contracts(
     test_loop: &mut TestLoopV2,
     node_datas: &Vec<TestData>,
     rpc_id: &AccountId,
     contract_ids: &[&AccountId],
     nonce: &mut u64,
-) {
+) -> Vec<ContractCode> {
+    let mut contracts = vec![];
     let mut txs = vec![];
     for (i, contract_id) in contract_ids.into_iter().enumerate() {
         tracing::info!(target: "test", ?rpc_id, ?contract_id, "Deploying contract.");
-        let code = near_test_contracts::sized_contract((i + 1) * 100).to_vec();
-        let tx = deploy_contract(test_loop, node_datas, rpc_id, contract_id, code, *nonce);
+        let contract =
+            ContractCode::new(near_test_contracts::sized_contract((i + 1) * 100).to_vec(), None);
+        let tx = deploy_contract(
+            test_loop,
+            node_datas,
+            rpc_id,
+            contract_id,
+            contract.code().to_vec(),
+            *nonce,
+        );
         txs.push(tx);
         *nonce += 1;
+        contracts.push(contract);
     }
     test_loop.run_for(Duration::seconds(2));
     check_txs(&*test_loop, node_datas, rpc_id, &txs);
+    contracts
 }
 
 /// Makes calls to the contracts from sender_ids to the contract_ids (at which contracts are deployed).
@@ -147,15 +177,4 @@ fn call_contracts(
     }
     test_loop.run_for(Duration::seconds(2));
     check_txs(&*test_loop, node_datas, &rpc_id, &txs);
-}
-
-/// Clears the compiled contract caches for all the clients.
-#[cfg(feature = "test_features")]
-pub fn clear_compiled_contract_caches(test_loop: &mut TestLoopV2, node_datas: &Vec<TestData>) {
-    for i in 0..node_datas.len() {
-        let client_handle = node_datas[i].client_sender.actor_handle();
-        let contract_cache_handle =
-            test_loop.data.get(&client_handle).client.runtime_adapter.compiled_contract_cache();
-        contract_cache_handle.test_only_clear().unwrap();
-    }
 }

--- a/integration-tests/src/test_loop/tests/contract_distribution_cross_shard.rs
+++ b/integration-tests/src/test_loop/tests/contract_distribution_cross_shard.rs
@@ -12,7 +12,6 @@ use crate::test_loop::utils::transactions::{
 };
 use crate::test_loop::utils::ONE_NEAR;
 
-const NUM_ACCOUNTS: usize = 9;
 const EPOCH_LENGTH: u64 = 10;
 const GENESIS_HEIGHT: u64 = 1000;
 
@@ -20,6 +19,7 @@ const NUM_BLOCK_AND_CHUNK_PRODUCERS: usize = 4;
 const NUM_CHUNK_VALIDATORS_ONLY: usize = 4;
 const NUM_RPC: usize = 1;
 const NUM_VALIDATORS: usize = NUM_BLOCK_AND_CHUNK_PRODUCERS + NUM_CHUNK_VALIDATORS_ONLY;
+const NUM_ACCOUNTS: usize = NUM_VALIDATORS + NUM_RPC;
 
 /// Tests a scenario that different contracts are deployed to a number of accounts and
 /// these contracts are called from a set of accounts.
@@ -84,7 +84,8 @@ fn setup(accounts: &Vec<AccountId>) -> (TestLoopEnv, AccountId) {
         .transaction_validity_period(1000)
         .epoch_length(EPOCH_LENGTH)
         .validators_desired_roles(&block_and_chunk_producers, &chunk_validators_only)
-        .shuffle_shard_assignment_for_chunk_producers(true);
+        .shuffle_shard_assignment_for_chunk_producers(true)
+        .minimum_validators_per_shard(2);
     for account in accounts {
         genesis_builder.add_user_account_simple(account.clone(), initial_balance);
     }

--- a/integration-tests/src/test_loop/tests/contract_distribution_cross_shard.rs
+++ b/integration-tests/src/test_loop/tests/contract_distribution_cross_shard.rs
@@ -10,7 +10,7 @@ use crate::test_loop::builder::TestLoopBuilder;
 use crate::test_loop::env::{TestData, TestLoopEnv};
 use crate::test_loop::utils::contract_distribution::{
     assert_all_chunk_endorsements_received, clear_compiled_contract_caches,
-    run_until_cache_contains_contract,
+    run_until_caches_contain_contract,
 };
 use crate::test_loop::utils::transactions::{
     call_contract, check_txs, deploy_contract, make_accounts,
@@ -57,10 +57,8 @@ fn test_contract_distribution_cross_shard() {
     let contracts =
         deploy_contracts(&mut test_loop, &node_datas, &rpc_id, &contract_ids, &mut nonce);
 
-    // Wait for RPC node to contains the compiled contracts in its cache before calling the contracts.
-    // This will make sure the deploy actions took effect in the network.
     for contract in contracts.into_iter() {
-        run_until_cache_contains_contract(&mut test_loop, &node_datas, contract.hash(), rpc_index);
+        run_until_caches_contain_contract(&mut test_loop, &node_datas, contract.hash());
     }
 
     call_contracts(&mut test_loop, &node_datas, &rpc_id, &contract_ids, &sender_ids, &mut nonce);

--- a/integration-tests/src/test_loop/tests/contract_distribution_simple.rs
+++ b/integration-tests/src/test_loop/tests/contract_distribution_simple.rs
@@ -10,7 +10,7 @@ use crate::test_loop::builder::TestLoopBuilder;
 use crate::test_loop::env::{TestData, TestLoopEnv};
 use crate::test_loop::utils::contract_distribution::{
     assert_all_chunk_endorsements_received, clear_compiled_contract_caches,
-    run_until_cache_contains_contract,
+    run_until_caches_contain_contract,
 };
 use crate::test_loop::utils::transactions::{
     call_contract, check_txs, deploy_contract, make_account, make_accounts,
@@ -40,11 +40,8 @@ fn test_contract_distribution_single_account(clear_cache: bool) {
 
     do_deploy_contract(&mut test_loop, &node_datas, &rpc_id, &account, &contract, 1);
 
-    // Wait for node 0 to contains the compiled contract in its cache before calling the contract.
-    // This will make sure the deploy action took effect in the network.
-    run_until_cache_contains_contract(&mut test_loop, &node_datas, contract.hash(), 0);
-
     if clear_cache {
+        run_until_caches_contain_contract(&mut test_loop, &node_datas, contract.hash());
         clear_compiled_contract_caches(&mut test_loop, &node_datas);
     }
 
@@ -89,11 +86,8 @@ fn test_contract_distribution_different_accounts(clear_cache: bool) {
     do_deploy_contract(&mut test_loop, &node_datas, &rpc_id, &account0, &contract, 1);
     do_deploy_contract(&mut test_loop, &node_datas, &rpc_id, &account1, &contract, 2);
 
-    // Wait for node 0 to contains the compiled contract in its cache before calling the contract.
-    // This will make sure the deploy action took effect in the network.
-    run_until_cache_contains_contract(&mut test_loop, &node_datas, contract.hash(), 0);
-
     if clear_cache {
+        run_until_caches_contain_contract(&mut test_loop, &node_datas, contract.hash());
         clear_compiled_contract_caches(&mut test_loop, &node_datas);
     }
 

--- a/integration-tests/src/test_loop/tests/contract_distribution_simple.rs
+++ b/integration-tests/src/test_loop/tests/contract_distribution_simple.rs
@@ -26,7 +26,7 @@ const NUM_VALIDATORS: usize = NUM_BLOCK_AND_CHUNK_PRODUCERS + NUM_CHUNK_VALIDATO
 const NUM_ACCOUNTS: usize = NUM_VALIDATORS;
 
 /// Executes a test that deploys to a contract to an account and calls it.
-fn test_contract_distribution_single_account(clear_cache: bool) {
+fn test_contract_distribution_single_account(wait_cache_populate: bool, clear_cache: bool) {
     init_test_logger();
     let accounts = make_accounts(NUM_ACCOUNTS);
 
@@ -40,8 +40,11 @@ fn test_contract_distribution_single_account(clear_cache: bool) {
 
     do_deploy_contract(&mut test_loop, &node_datas, &rpc_id, &account, &contract, 1);
 
-    if clear_cache {
+    if wait_cache_populate {
         run_until_caches_contain_contract(&mut test_loop, &node_datas, contract.hash());
+    }
+
+    if clear_cache {
         clear_compiled_contract_caches(&mut test_loop, &node_datas);
     }
 
@@ -58,19 +61,26 @@ fn test_contract_distribution_single_account(clear_cache: bool) {
 /// Tests a simple scenario where we deploy and call a contract.
 #[test]
 fn test_contract_distribution_deploy_and_call_single_account() {
-    test_contract_distribution_single_account(false);
+    test_contract_distribution_single_account(false, false);
 }
 
-/// Tests a simple scenario where we deploy a contract, and then
-/// we clear the compiled contract cache and call the deployed contract call.
+/// Tests a simple scenario where we deploy and call a contract.
+/// Waits for deploy action to take effect in contract cache before issuing the call actions.
+#[test]
+fn test_contract_distribution_wait_cache_populate_single_account() {
+    test_contract_distribution_single_account(true, false);
+}
+
+/// Tests a simple scenario where we deploy a contract, and then we wait for cache to fill and
+/// then clear the compiled contract cache and finally call the deployed contract call.
 #[cfg_attr(not(feature = "test_features"), ignore)]
 #[test]
 fn test_contract_distribution_call_after_clear_single_account() {
-    test_contract_distribution_single_account(true);
+    test_contract_distribution_single_account(true, true);
 }
 
 /// Executes a test that deploys to a contract to two different accounts and calls them.
-fn test_contract_distribution_different_accounts(clear_cache: bool) {
+fn test_contract_distribution_different_accounts(wait_cache_populate: bool, clear_cache: bool) {
     init_test_logger();
     let accounts = make_accounts(NUM_ACCOUNTS);
 
@@ -86,8 +96,11 @@ fn test_contract_distribution_different_accounts(clear_cache: bool) {
     do_deploy_contract(&mut test_loop, &node_datas, &rpc_id, &account0, &contract, 1);
     do_deploy_contract(&mut test_loop, &node_datas, &rpc_id, &account1, &contract, 2);
 
-    if clear_cache {
+    if wait_cache_populate {
         run_until_caches_contain_contract(&mut test_loop, &node_datas, contract.hash());
+    }
+
+    if clear_cache {
         clear_compiled_contract_caches(&mut test_loop, &node_datas);
     }
 
@@ -104,15 +117,22 @@ fn test_contract_distribution_different_accounts(clear_cache: bool) {
 /// Tests a simple scenario where we deploy and call a contract on two different accounts.
 #[test]
 fn test_contract_distribution_deploy_and_call_different_accounts() {
-    test_contract_distribution_different_accounts(false);
+    test_contract_distribution_different_accounts(false, false);
 }
 
-/// Tests a simple scenario where we deploy a contract on two different accounts, and then
-/// we clear the compiled contract cache and call the contracts on the accounts.
+/// Tests a simple scenario where we deploy and call a contract on two different accounts.
+/// Waits for deploy action to take effect in contract cache before issuing the call actions.
+#[test]
+fn test_contract_distribution_wait_cache_populate_different_accounts() {
+    test_contract_distribution_different_accounts(false, false);
+}
+
+/// Tests a simple scenario where we deploy a contract on two different accounts, and then we wait for cache to fill and
+/// then clear the compiled contract cache and finally call the deployed contract on the two accounts.
 #[cfg_attr(not(feature = "test_features"), ignore)]
 #[test]
 fn test_contract_distribution_call_after_clear_different_accounts() {
-    test_contract_distribution_different_accounts(true);
+    test_contract_distribution_different_accounts(true, true);
 }
 
 fn setup(accounts: &Vec<AccountId>) -> TestLoopEnv {

--- a/integration-tests/src/test_loop/tests/contract_distribution_simple.rs
+++ b/integration-tests/src/test_loop/tests/contract_distribution_simple.rs
@@ -12,13 +12,13 @@ use crate::test_loop::utils::transactions::{
 };
 use crate::test_loop::utils::ONE_NEAR;
 
-const NUM_ACCOUNTS: usize = 2;
 const EPOCH_LENGTH: u64 = 10;
 const GENESIS_HEIGHT: u64 = 1000;
 
 const NUM_BLOCK_AND_CHUNK_PRODUCERS: usize = 1;
 const NUM_CHUNK_VALIDATORS_ONLY: usize = 1;
 const NUM_VALIDATORS: usize = NUM_BLOCK_AND_CHUNK_PRODUCERS + NUM_CHUNK_VALIDATORS_ONLY;
+const NUM_ACCOUNTS: usize = NUM_VALIDATORS;
 
 /// Executes a test that deploys to a contract to an account and calls it.
 fn test_contract_distribution_single_account(clear_cache: bool) {
@@ -38,7 +38,7 @@ fn test_contract_distribution_single_account(clear_cache: bool) {
     }
 
     do_call_contract(&mut test_loop, &node_datas, &rpc_id, &account, 2);
-
+    do_call_contract(&mut test_loop, &node_datas, &rpc_id, &account, 3);
     TestLoopEnv { test_loop, datas: node_datas, tempdir }
         .shutdown_and_drain_remaining_events(Duration::seconds(20));
 }
@@ -65,20 +65,25 @@ fn test_contract_distribution_different_accounts(clear_cache: bool) {
     let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } = setup(&accounts);
 
     let rpc_id = make_account(0);
-    let account = rpc_id.clone();
+    let account0 = make_account(0);
+    let account1 = make_account(1);
 
-    do_deploy_contract(&mut test_loop, &node_datas, &rpc_id, &account, 1);
-    do_call_contract(&mut test_loop, &node_datas, &rpc_id, &account, 2);
+    do_deploy_contract(&mut test_loop, &node_datas, &rpc_id, &account0, 1);
+    do_deploy_contract(&mut test_loop, &node_datas, &rpc_id, &account1, 2);
 
     if clear_cache {
         #[cfg(feature = "test_features")]
         clear_compiled_contract_caches(&mut test_loop, &node_datas);
     }
 
-    let account = make_account(1);
+    do_call_contract(&mut test_loop, &node_datas, &rpc_id, &account0, 3);
 
-    do_deploy_contract(&mut test_loop, &node_datas, &rpc_id, &account, 3);
-    do_call_contract(&mut test_loop, &node_datas, &rpc_id, &account, 4);
+    if clear_cache {
+        #[cfg(feature = "test_features")]
+        clear_compiled_contract_caches(&mut test_loop, &node_datas);
+    }
+
+    do_call_contract(&mut test_loop, &node_datas, &rpc_id, &account1, 4);
 
     TestLoopEnv { test_loop, datas: node_datas, tempdir }
         .shutdown_and_drain_remaining_events(Duration::seconds(20));

--- a/integration-tests/src/test_loop/utils/contract_distribution.rs
+++ b/integration-tests/src/test_loop/utils/contract_distribution.rs
@@ -31,7 +31,7 @@ pub(crate) fn run_until_caches_contain_contract(
             }
             true
         },
-        Duration::seconds(10),
+        Duration::seconds(5),
     );
 }
 

--- a/integration-tests/src/test_loop/utils/contract_distribution.rs
+++ b/integration-tests/src/test_loop/utils/contract_distribution.rs
@@ -79,14 +79,14 @@ pub(crate) fn assert_all_chunk_endorsements_received(
 
 /// Clears the compiled contract caches for all the clients.
 pub(crate) fn clear_compiled_contract_caches(
-    test_loop: &mut TestLoopV2,
-    node_datas: &Vec<TestData>,
+    _test_loop: &mut TestLoopV2,
+    _node_datas: &Vec<TestData>,
 ) {
     #[cfg(feature = "test_features")]
-    for i in 0..node_datas.len() {
-        let client_handle = node_datas[i].client_sender.actor_handle();
+    for i in 0.._node_datas.len() {
+        let client_handle = _node_datas[i].client_sender.actor_handle();
         let contract_cache_handle =
-            test_loop.data.get(&client_handle).client.runtime_adapter.compiled_contract_cache();
+            _test_loop.data.get(&client_handle).client.runtime_adapter.compiled_contract_cache();
         contract_cache_handle.test_only_clear().unwrap();
     }
 }

--- a/integration-tests/src/test_loop/utils/contract_distribution.rs
+++ b/integration-tests/src/test_loop/utils/contract_distribution.rs
@@ -1,0 +1,87 @@
+use crate::test_loop::env::TestData;
+use itertools::Itertools;
+use near_async::{
+    test_loop::{data::TestLoopData, TestLoopV2},
+    time::Duration,
+};
+use near_chain::ChainStoreAccess;
+use near_primitives::{hash::CryptoHash, version::PROTOCOL_VERSION};
+use near_vm_runner::get_contract_cache_key;
+
+/// Runs the network until the compiled-contracts cache contains the given hash, by querying node `node_index`.
+pub(crate) fn run_until_cache_contains_contract(
+    test_loop: &mut TestLoopV2,
+    node_datas: &Vec<TestData>,
+    code_hash: &CryptoHash,
+    node_index: usize,
+) {
+    let client_handle = node_datas[node_index].client_sender.actor_handle();
+    test_loop.run_until(
+        |test_loop_data: &mut TestLoopData| -> bool {
+            let client = &test_loop_data.get(&client_handle).client;
+            let runtime_config =
+                client.runtime_adapter.get_runtime_config(PROTOCOL_VERSION).unwrap();
+            let cache_key = get_contract_cache_key(*code_hash, &runtime_config.wasm_config);
+
+            let contract_cache = client.runtime_adapter.compiled_contract_cache();
+            contract_cache.has(&cache_key).unwrap()
+        },
+        Duration::seconds(10),
+    );
+}
+
+/// Asserts that no chunk validation error happened between `start_height` and `end_height` (inclusive), by querying node 0.
+/// In other words, asserts that all chunks are included and endorsements are received from all the chunk validators assigned.
+pub(crate) fn assert_all_chunk_endorsements_received(
+    test_loop: &mut TestLoopV2,
+    node_datas: &Vec<TestData>,
+    start_height: u64,
+    end_height: u64,
+) {
+    let client_handle = node_datas[0].client_sender.actor_handle();
+    let client = &test_loop.data.get(&client_handle).client;
+    let chain_store = client.chain.chain_store();
+    let epoch_manager = &client.epoch_manager;
+
+    for height in start_height..=end_height {
+        let header = chain_store.get_block_header_by_height(height).unwrap();
+
+        let epoch_id = epoch_manager.get_epoch_id_from_prev_block(header.prev_hash()).unwrap();
+        let shard_layout = epoch_manager.get_shard_layout(&epoch_id).unwrap();
+        let shard_ids =
+            epoch_manager.get_shard_layout(&epoch_id).unwrap().shard_ids().collect_vec();
+        let chunk_mask = header.chunk_mask();
+        let endorsements = header.chunk_endorsements().unwrap();
+        for shard_id in shard_ids.into_iter() {
+            let shard_index = shard_layout.get_shard_index(shard_id).unwrap();
+            let num_validator_assignments = epoch_manager
+                .get_chunk_validator_assignments(&epoch_id, shard_id, height)
+                .unwrap()
+                .ordered_chunk_validators()
+                .len();
+            let num_received_endorsements =
+                endorsements.iter(shard_index).filter(|endorsement| *endorsement).count();
+
+            assert!(chunk_mask[shard_index], "Missed chunk at shard index {}", shard_index);
+            assert_eq!(
+                num_received_endorsements, num_validator_assignments,
+                "Not all endorsements received for shard index {}",
+                shard_index
+            );
+        }
+    }
+}
+
+/// Clears the compiled contract caches for all the clients.
+pub(crate) fn clear_compiled_contract_caches(
+    test_loop: &mut TestLoopV2,
+    node_datas: &Vec<TestData>,
+) {
+    #[cfg(feature = "test_features")]
+    for i in 0..node_datas.len() {
+        let client_handle = node_datas[i].client_sender.actor_handle();
+        let contract_cache_handle =
+            test_loop.data.get(&client_handle).client.runtime_adapter.compiled_contract_cache();
+        contract_cache_handle.test_only_clear().unwrap();
+    }
+}

--- a/integration-tests/src/test_loop/utils/mod.rs
+++ b/integration-tests/src/test_loop/utils/mod.rs
@@ -1,3 +1,8 @@
+use near_async::test_loop::TestLoopV2;
+
+use super::env::TestData;
+
+pub mod contract_distribution;
 pub mod network;
 pub mod setups;
 pub mod transactions;
@@ -5,3 +10,10 @@ pub mod validators;
 
 pub(crate) const ONE_NEAR: u128 = 1_000_000_000_000_000_000_000_000;
 pub(crate) const TGAS: u64 = 1_000_000_000_000;
+
+/// Returns the height of the chain head, by querying node at index 0.
+pub(crate) fn get_head_height(test_loop: &mut TestLoopV2, node_datas: &Vec<TestData>) -> u64 {
+    let client_handle = node_datas[0].client_sender.actor_handle();
+    let client = &test_loop.data.get(&client_handle).client;
+    client.chain.head().unwrap().height
+}


### PR DESCRIPTION
Noticed that some simple tests succeed even if we remove the code distributing the code. Thus, adding more observability to the tests.

- Add `run_until_caches_contain_contract` to wait until the nodes contain the deployed code in their compiled-contracts cache. This is to make sure we clear the cache and call the contract, after the deploy action takes effect. We run additional tests with this option.

- Add `assert_all_chunk_endorsements_received` which checks if there is any missing chunk or chunk endorsements. This is to make sure that while the test was running there is no validation errors due to a problem in chunk distribution.

- Also move some shared functions to `utils/contract_distribution.rs`.