### PR TITLE
refactor: remove get_random_chunk_producer_for_shard from EpochManager interface

### DIFF
--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -59,7 +59,6 @@ use near_store::{
 };
 use near_vm_runner::{ContractCode, ContractRuntimeCache, NoContractRuntimeCache};
 use num_rational::Ratio;
-use rand::Rng;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, RwLock};
@@ -1150,19 +1149,6 @@ impl EpochManagerAdapter for MockEpochManager {
         _epoch_id: &EpochId,
     ) -> Result<Vec<ValidatorStake>, EpochError> {
         Ok(self.validators.iter().map(|(_, v)| v.clone()).collect())
-    }
-
-    fn get_random_chunk_producer_for_shard(
-        &self,
-        epoch_id: &EpochId,
-        shard_id: ShardId,
-    ) -> Result<AccountId, EpochError> {
-        let valset = self.get_valset_for_epoch(epoch_id)?;
-        let shard_layout = self.get_shard_layout(epoch_id)?;
-        let shard_index = shard_layout.get_shard_index(shard_id)?;
-        let chunk_producers = self.get_chunk_producers(valset, shard_index);
-        let index = rand::thread_rng().gen_range(0..chunk_producers.len());
-        Ok(chunk_producers[index].account_id().clone())
     }
 }
 

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -222,12 +222,6 @@ pub trait EpochManagerAdapter: Send + Sync {
         shard_id: ShardId,
     ) -> Result<Vec<AccountId>, EpochError>;
 
-    fn get_random_chunk_producer_for_shard(
-        &self,
-        epoch_id: &EpochId,
-        shard_id: ShardId,
-    ) -> Result<AccountId, EpochError>;
-
     /// Returns all validators for a given epoch.
     fn get_epoch_all_validators(
         &self,
@@ -812,15 +806,6 @@ impl EpochManagerAdapter for EpochManagerHandle {
     ) -> Result<Vec<AccountId>, EpochError> {
         let epoch_manager = self.read();
         epoch_manager.get_epoch_chunk_producers_for_shard(epoch_id, shard_id)
-    }
-
-    fn get_random_chunk_producer_for_shard(
-        &self,
-        epoch_id: &EpochId,
-        shard_id: ShardId,
-    ) -> Result<AccountId, EpochError> {
-        let epoch_manager = self.read();
-        epoch_manager.get_random_chunk_producer_for_shard(epoch_id, shard_id)
     }
 
     fn get_block_producer(

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -29,7 +29,6 @@ use near_primitives::views::{
 use near_store::{DBCol, Store, StoreUpdate, HEADER_HEAD_KEY};
 use num_rational::BigRational;
 use primitive_types::U256;
-use rand::Rng;
 use reward_calculator::ValidatorOnlineThresholds;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -1106,22 +1105,6 @@ impl EpochManager {
             .iter()
             .map(|index| epoch_info.validator_account_id(*index).clone())
             .collect())
-    }
-
-    pub fn get_random_chunk_producer_for_shard(
-        &self,
-        epoch_id: &EpochId,
-        shard_id: ShardId,
-    ) -> Result<AccountId, EpochError> {
-        let epoch_info = self.get_epoch_info(&epoch_id)?;
-        let shard_layout = self.get_shard_layout(&epoch_id)?;
-        let shard_index = shard_layout.get_shard_index(shard_id)?;
-        let chunk_producers = epoch_info
-            .chunk_producers_settlement()
-            .get(shard_index)
-            .ok_or_else(|| EpochError::ShardingError(format!("invalid shard id {shard_id}")))?;
-        let random_index = rand::thread_rng().gen_range(0..chunk_producers.len());
-        Ok(epoch_info.validator_account_id(chunk_producers[random_index]).clone())
     }
 
     /// Returns the list of chunk_validators for the given shard_id and height and set of account ids.


### PR DESCRIPTION
Replaced with the implementation on the client side using `get_epoch_chunk_producers_for_shard`