### PR TITLE
refactor: remove epoch manager verify_partial_deploys_signature

### DIFF
--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -34,10 +34,11 @@ use near_primitives::sharding::ChunkHash;
 use near_primitives::state_part::PartId;
 use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
 use near_primitives::stateless_validation::contract_distribution::{
-    ChunkContractAccesses, ContractCodeRequest, PartialEncodedContractDeploys,
+    ChunkContractAccesses, ContractCodeRequest,
 };
 use near_primitives::stateless_validation::partial_witness::PartialEncodedStateWitness;
 use near_primitives::stateless_validation::validator_assignment::ChunkValidatorAssignments;
+use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::transaction::{
     Action, ExecutionMetadata, ExecutionOutcome, ExecutionOutcomeWithId, ExecutionStatus,
     SignedTransaction, TransferAction,
@@ -779,18 +780,16 @@ impl EpochManagerAdapter for MockEpochManager {
         Ok(validators[(height as usize) % validators.len()].account_id().clone())
     }
 
-    fn get_chunk_producer(
+    fn get_chunk_producer_info(
         &self,
-        epoch_id: &EpochId,
-        height: BlockHeight,
-        shard_id: ShardId,
-    ) -> Result<AccountId, EpochError> {
-        let valset = self.get_valset_for_epoch(epoch_id)?;
-        let shard_layout = self.get_shard_layout(epoch_id)?;
-        let shard_index = shard_layout.get_shard_index(shard_id)?;
+        key: &ChunkProductionKey,
+    ) -> Result<ValidatorStake, EpochError> {
+        let valset = self.get_valset_for_epoch(&key.epoch_id)?;
+        let shard_layout = self.get_shard_layout(&key.epoch_id)?;
+        let shard_index = shard_layout.get_shard_index(key.shard_id)?;
         let chunk_producers = self.get_chunk_producers(valset, shard_index);
-        let index = (shard_index + height as usize + 1) % chunk_producers.len();
-        Ok(chunk_producers[index].account_id().clone())
+        let index = (shard_index + key.height_created as usize + 1) % chunk_producers.len();
+        Ok(chunk_producers[index].clone())
     }
 
     fn get_chunk_validator_assignments(
@@ -1040,13 +1039,6 @@ impl EpochManagerAdapter for MockEpochManager {
     fn verify_witness_contract_code_request_signature(
         &self,
         _request: &ContractCodeRequest,
-    ) -> Result<bool, Error> {
-        Ok(true)
-    }
-
-    fn verify_partial_deploys_signature(
-        &self,
-        _partial_deploys: &PartialEncodedContractDeploys,
     ) -> Result<bool, Error> {
         Ok(true)
     }

--- a/chain/client/src/stateless_validation/validate.rs
+++ b/chain/client/src/stateless_validation/validate.rs
@@ -79,7 +79,8 @@ pub fn validate_partial_encoded_contract_deploys(
     if !validate_chunk_relevant(epoch_manager, key, store)? {
         return Ok(false);
     }
-    if !epoch_manager.verify_partial_deploys_signature(partial_deploys)? {
+    let chunk_producer = epoch_manager.get_chunk_producer_info(key)?;
+    if !partial_deploys.verify_signature(chunk_producer.public_key()) {
         return Err(Error::Other("Invalid contract deploys signature".to_owned()));
     }
     Ok(true)

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -12,7 +12,7 @@ use near_primitives::shard_layout::{account_id_to_shard_id, ShardLayout};
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
 use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
 use near_primitives::stateless_validation::contract_distribution::{
-    ChunkContractAccesses, ContractCodeRequest, PartialEncodedContractDeploys,
+    ChunkContractAccesses, ContractCodeRequest,
 };
 use near_primitives::stateless_validation::partial_witness::PartialEncodedStateWitness;
 use near_primitives::stateless_validation::validator_assignment::ChunkValidatorAssignments;
@@ -241,13 +241,22 @@ pub trait EpochManagerAdapter: Send + Sync {
         height: BlockHeight,
     ) -> Result<AccountId, EpochError>;
 
-    /// Chunk producer for given height for given shard. Return EpochError if outside of known boundaries.
+    /// Chunk producer info for given height for given shard. Return EpochError if outside of known boundaries.
+    fn get_chunk_producer_info(
+        &self,
+        key: &ChunkProductionKey,
+    ) -> Result<ValidatorStake, EpochError>;
+
+    /// TODO(pugachag): deprecate this by inlining usage
     fn get_chunk_producer(
         &self,
         epoch_id: &EpochId,
         height: BlockHeight,
         shard_id: ShardId,
-    ) -> Result<AccountId, EpochError>;
+    ) -> Result<AccountId, EpochError> {
+        let key = ChunkProductionKey { epoch_id: *epoch_id, height_created: height, shard_id };
+        self.get_chunk_producer_info(&key).map(|info| info.take_account_id())
+    }
 
     /// Gets the chunk validators for a given height and shard.
     fn get_chunk_validator_assignments(
@@ -495,11 +504,6 @@ pub trait EpochManagerAdapter: Send + Sync {
     fn verify_witness_contract_code_request_signature(
         &self,
         request: &ContractCodeRequest,
-    ) -> Result<bool, Error>;
-
-    fn verify_partial_deploys_signature(
-        &self,
-        partial_deploys: &PartialEncodedContractDeploys,
     ) -> Result<bool, Error>;
 
     fn cares_about_shard_in_epoch(
@@ -832,15 +836,11 @@ impl EpochManagerAdapter for EpochManagerHandle {
         Ok(epoch_manager.get_block_producer_info(epoch_id, height)?.take_account_id())
     }
 
-    fn get_chunk_producer(
+    fn get_chunk_producer_info(
         &self,
-        epoch_id: &EpochId,
-        height: BlockHeight,
-        shard_id: ShardId,
-    ) -> Result<AccountId, EpochError> {
-        let epoch_manager = self.read();
-        let key = ChunkProductionKey { epoch_id: *epoch_id, height_created: height, shard_id };
-        Ok(epoch_manager.get_chunk_producer_info(&key)?.take_account_id())
+        key: &ChunkProductionKey,
+    ) -> Result<ValidatorStake, EpochError> {
+        self.read().get_chunk_producer_info(key)
     }
 
     fn get_chunk_validator_assignments(
@@ -1204,15 +1204,6 @@ impl EpochManagerAdapter for EpochManagerHandle {
             request.requester(),
         )?;
         Ok(request.verify_signature(validator.public_key()))
-    }
-
-    fn verify_partial_deploys_signature(
-        &self,
-        partial_deploys: &PartialEncodedContractDeploys,
-    ) -> Result<bool, Error> {
-        let chunk_producer =
-            self.read().get_chunk_producer_info(partial_deploys.chunk_production_key())?;
-        Ok(partial_deploys.verify_signature(chunk_producer.public_key()))
     }
 
     fn cares_about_shard_from_prev_block(


### PR DESCRIPTION
Includes replacing `get_chunk_producer` with `get_chunk_producer_info` to expose validator's public key as part of the return value.