### PR TITLE
refactor: remove EpochManager get_chunk_producer

### DIFF
--- a/chain/chain/src/blocks_delay_tracker.rs
+++ b/chain/chain/src/blocks_delay_tracker.rs
@@ -4,6 +4,7 @@ use near_primitives::block::{Block, Tip};
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
+use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::types::{BlockHeight, ShardId};
 use near_primitives::views::{
     BlockProcessingInfo, BlockProcessingStatus, ChainProcessingInfo, ChunkProcessingInfo,
@@ -104,7 +105,13 @@ impl ChunkTrackingStats {
         let created_by = epoch_manager
             .get_epoch_id_from_prev_block(&self.prev_block_hash)
             .and_then(|epoch_id| {
-                epoch_manager.get_chunk_producer(&epoch_id, self.height_created, self.shard_id)
+                epoch_manager
+                    .get_chunk_producer_info(&ChunkProductionKey {
+                        epoch_id,
+                        height_created: self.height_created,
+                        shard_id: self.shard_id,
+                    })
+                    .map(|info| info.take_account_id())
             })
             .ok();
         let request_duration = if let Some(requested_timestamp) = self.requested_timestamp {

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -19,6 +19,7 @@ use near_epoch_manager::shard_tracker::ShardTracker;
 use near_epoch_manager::{EpochManager, EpochManagerHandle};
 use near_primitives::block::Block;
 use near_primitives::hash::CryptoHash;
+use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::{AccountId, NumBlocks, NumShards};
 use near_primitives::utils::MaybeValidated;
@@ -231,12 +232,13 @@ pub fn display_chain(me: &Option<AccountId>, chain: &mut Chain, tail: bool) {
             if let Some(block) = maybe_block {
                 for chunk_header in block.chunks().iter_deprecated() {
                     let chunk_producer = epoch_manager
-                        .get_chunk_producer(
-                            &epoch_id,
-                            chunk_header.height_created(),
-                            chunk_header.shard_id(),
-                        )
-                        .unwrap();
+                        .get_chunk_producer_info(&ChunkProductionKey {
+                            epoch_id,
+                            height_created: chunk_header.height_created(),
+                            shard_id: chunk_header.shard_id(),
+                        })
+                        .unwrap()
+                        .take_account_id();
                     if let Ok(chunk) = chain_store.get_chunk(&chunk_header.chunk_hash()) {
                         debug!(
                             "    {: >3} {} | {} | {: >10} | tx = {: >2}, receipts = {: >2}",

--- a/chain/chain/src/validate.rs
+++ b/chain/chain/src/validate.rs
@@ -13,6 +13,7 @@ use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::merklize;
 use near_primitives::sharding::{ShardChunk, ShardChunkHeader};
+use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{AccountId, BlockHeight, EpochId, Nonce};
@@ -299,11 +300,13 @@ fn validate_chunk_authorship(
         &epoch_id,
         &chunk_header.prev_block_hash(),
     )? {
-        let chunk_producer = epoch_manager.get_chunk_producer(
-            &epoch_id,
-            chunk_header.height_created(),
-            chunk_header.shard_id(),
-        )?;
+        let chunk_producer = epoch_manager
+            .get_chunk_producer_info(&ChunkProductionKey {
+                epoch_id,
+                height_created: chunk_header.height_created(),
+                shard_id: chunk_header.shard_id(),
+            })?
+            .take_account_id();
         Ok(chunk_producer)
     } else {
         Err(Error::InvalidChallenge)

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -15,6 +15,7 @@ use near_primitives::sharding::{
     EncodedShardChunk, PartialEncodedChunk, PartialEncodedChunkPart, PartialEncodedChunkV2,
     ShardChunkHeader,
 };
+use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::MerkleHash;
 use near_primitives::types::{AccountId, EpochId, ShardId};
@@ -96,8 +97,14 @@ impl ChunkTestFixture {
         let mock_shard_id: ShardId = ShardId::new(0);
         let mock_epoch_id =
             epoch_manager.get_epoch_id_from_prev_block(&mock_ancestor_hash).unwrap();
-        let mock_chunk_producer =
-            epoch_manager.get_chunk_producer(&mock_epoch_id, mock_height, mock_shard_id).unwrap();
+        let mock_chunk_producer = epoch_manager
+            .get_chunk_producer_info(&ChunkProductionKey {
+                epoch_id: mock_epoch_id,
+                height_created: mock_height,
+                shard_id: mock_shard_id,
+            })
+            .unwrap()
+            .take_account_id();
         let signer = create_test_signer(mock_chunk_producer.as_str());
         let validators: Vec<_> = epoch_manager
             .get_epoch_block_producers_ordered(&EpochId::default(), &CryptoHash::default())

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -22,6 +22,7 @@ use near_primitives::congestion_info::CongestionControl;
 use near_primitives::errors::EpochError;
 use near_primitives::state_sync::get_num_state_parts;
 use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
+use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::types::{
     AccountId, BlockHeight, NumShards, ShardId, ShardIndex, ValidatorInfoIdentifier,
 };
@@ -144,8 +145,13 @@ impl BlockProductionTracker {
                     chunk_included: true,
                 });
             } else {
-                let chunk_producer =
-                    epoch_manager.get_chunk_producer(epoch_id, block_height, shard_id)?;
+                let chunk_producer = epoch_manager
+                    .get_chunk_producer_info(&ChunkProductionKey {
+                        epoch_id: *epoch_id,
+                        height_created: block_height,
+                        shard_id,
+                    })?
+                    .take_account_id();
                 chunk_collection_info.push(ChunkCollection {
                     chunk_producer,
                     received_time: None,
@@ -511,11 +517,12 @@ impl ClientActorInner {
                                 chunk_producer: self
                                     .client
                                     .epoch_manager
-                                    .get_chunk_producer(
-                                        block_header.epoch_id(),
-                                        block_header.height(),
-                                        chunk.shard_id(),
-                                    )
+                                    .get_chunk_producer_info(&ChunkProductionKey {
+                                        epoch_id: *block_header.epoch_id(),
+                                        height_created: block_header.height(),
+                                        shard_id: chunk.shard_id(),
+                                    })
+                                    .map(|info| info.take_account_id())
                                     .ok(),
                                 gas_used: chunk.prev_gas_used(),
                                 processing_time_ms: CryptoHashTimer::get_timer_value(
@@ -629,8 +636,12 @@ impl ClientActorInner {
                     let chunk_producer = self
                         .client
                         .epoch_manager
-                        .get_chunk_producer(&epoch_id, height, shard_id)
-                        .map(|f| f.to_string())
+                        .get_chunk_producer_info(&ChunkProductionKey {
+                            epoch_id,
+                            height_created: height,
+                            shard_id,
+                        })
+                        .map(|info| info.take_account_id().to_string())
                         .unwrap_or_default();
                     if chunk_producer == validator_id {
                         production.chunk_production.insert(

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
@@ -374,8 +374,10 @@ impl PartialWitnessActor {
     ) -> Result<(), Error> {
         let ChunkProductionKey { shard_id, epoch_id, height_created } =
             partial_witness.chunk_production_key();
-        let chunk_producer =
-            self.epoch_manager.get_chunk_producer(&epoch_id, height_created, shard_id)?;
+        let chunk_producer = self
+            .epoch_manager
+            .get_chunk_producer_info(&ChunkProductionKey { epoch_id, height_created, shard_id })?
+            .take_account_id();
 
         // Forward witness part to chunk validators except the validator that produced the chunk and witness.
         let target_chunk_validators = self

--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -28,6 +28,7 @@ use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::{ChunkHash, PartialEncodedChunk};
 use near_primitives::stateless_validation::state_witness::ChunkStateWitness;
+use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::transaction::{Action, FunctionCallAction, SignedTransaction};
 use near_primitives::types::{AccountId, Balance, BlockHeight, EpochId, NumSeats, ShardId};
@@ -685,7 +686,14 @@ impl TestEnv {
         let epoch_id = epoch_manager.get_epoch_id_from_prev_block(parent_hash).unwrap();
         let height = head.height + height_offset;
 
-        epoch_manager.get_chunk_producer(&epoch_id, height, shard_id).unwrap()
+        epoch_manager
+            .get_chunk_producer_info(&ChunkProductionKey {
+                epoch_id,
+                height_created: height,
+                shard_id,
+            })
+            .unwrap()
+            .take_account_id()
     }
 
     pub fn get_runtime_config(&self, idx: usize, epoch_id: EpochId) -> RuntimeConfig {

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -241,17 +241,6 @@ pub trait EpochManagerAdapter: Send + Sync {
         key: &ChunkProductionKey,
     ) -> Result<ValidatorStake, EpochError>;
 
-    /// TODO(pugachag): deprecate this by inlining usage
-    fn get_chunk_producer(
-        &self,
-        epoch_id: &EpochId,
-        height: BlockHeight,
-        shard_id: ShardId,
-    ) -> Result<AccountId, EpochError> {
-        let key = ChunkProductionKey { epoch_id: *epoch_id, height_created: height, shard_id };
-        self.get_chunk_producer_info(&key).map(|info| info.take_account_id())
-    }
-
     /// Gets the chunk validators for a given height and shard.
     fn get_chunk_validator_assignments(
         &self,

--- a/integration-tests/src/tests/client/features/adversarial_behaviors.rs
+++ b/integration-tests/src/tests/client/features/adversarial_behaviors.rs
@@ -16,11 +16,11 @@ use near_network::{
     types::{NetworkRequests, PeerManagerMessageRequest},
 };
 use near_o11y::testonly::init_test_logger;
-use near_primitives::utils::from_timestamp;
 use near_primitives::{
     shard_layout::ShardLayout,
     types::{AccountId, EpochId, ShardId},
 };
+use near_primitives::{stateless_validation::ChunkProductionKey, utils::from_timestamp};
 use near_primitives_core::{checked_feature, version::PROTOCOL_VERSION};
 use nearcore::test_utils::TestEnvNightshadeSetupExt;
 use tracing::log::debug;
@@ -251,12 +251,13 @@ fn test_banning_chunk_producer_when_seeing_invalid_chunk_base(
             }
             for shard_id in shard_layout.shard_ids() {
                 let chunk_producer = epoch_manager
-                    .get_chunk_producer(
-                        &epoch_id,
-                        block.header().prev_height().unwrap() + 1,
+                    .get_chunk_producer_info(&ChunkProductionKey {
+                        epoch_id,
+                        height_created: block.header().prev_height().unwrap() + 1,
                         shard_id,
-                    )
-                    .unwrap();
+                    })
+                    .unwrap()
+                    .take_account_id();
                 if &chunk_producer == &bad_chunk_producer {
                     invalid_chunks_in_this_block.insert(shard_id);
                     if !epochs_seen_invalid_chunk.contains(&epoch_id) {

--- a/integration-tests/src/tests/client/resharding_v2.rs
+++ b/integration-tests/src/tests/client/resharding_v2.rs
@@ -13,6 +13,7 @@ use near_primitives::epoch_manager::{AllEpochConfig, AllEpochConfigTestOverrides
 use near_primitives::hash::CryptoHash;
 use near_primitives::serialize::to_base64;
 use near_primitives::shard_layout::account_id_to_shard_uid;
+use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::transaction::{
     Action, DeployContractAction, FunctionCallAction, SignedTransaction,
 };
@@ -506,7 +507,10 @@ fn get_chunk_producer(env: &TestEnv, block: &Block, shard_id: ShardId) -> Accoun
     let parent_hash = block.header().prev_hash();
     let epoch_id = epoch_manager.get_epoch_id_from_prev_block(parent_hash).unwrap();
     let height = block.header().height() + 1;
-    let chunk_producer = epoch_manager.get_chunk_producer(&epoch_id, height, shard_id).unwrap();
+    let chunk_producer = epoch_manager
+        .get_chunk_producer_info(&ChunkProductionKey { epoch_id, height_created: height, shard_id })
+        .unwrap()
+        .take_account_id();
     chunk_producer
 }
 

--- a/nearcore/src/entity_debug.rs
+++ b/nearcore/src/entity_debug.rs
@@ -26,6 +26,7 @@ use near_primitives::state_sync::StateSyncDumpProgress;
 use near_primitives::stateless_validation::stored_chunk_state_transition_data::{
     StoredChunkStateTransitionData, StoredChunkStateTransitionDataV1,
 };
+use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::transaction::{ExecutionOutcomeWithProof, SignedTransaction};
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{AccountId, Balance, BlockHeight, StateRoot};
@@ -119,11 +120,14 @@ impl EntityDebugHandlerImpl {
                     .ok_or_else(|| anyhow!("Chunk not found"))?;
                 let epoch_id =
                     self.epoch_manager.get_epoch_id_from_prev_block(chunk.prev_block())?;
-                let author = self.epoch_manager.get_chunk_producer(
-                    &epoch_id,
-                    chunk.height_created(),
-                    chunk.shard_id(),
-                )?;
+                let author = self
+                    .epoch_manager
+                    .get_chunk_producer_info(&ChunkProductionKey {
+                        epoch_id,
+                        height_created: chunk.height_created(),
+                        shard_id: chunk.shard_id(),
+                    })?
+                    .take_account_id();
                 Ok(serialize_entity(&ChunkView::from_author_chunk(author, chunk)))
             }
             EntityQuery::ChunkExtraByBlockHashShardUId { block_hash, shard_uid } => {
@@ -419,7 +423,12 @@ impl EntityDebugHandlerImpl {
                     .shard_ids()
                     .map(|shard_id| {
                         self.epoch_manager
-                            .get_chunk_producer(&epoch_id, block_height, shard_id)
+                            .get_chunk_producer_info(&ChunkProductionKey {
+                                epoch_id,
+                                height_created: block_height,
+                                shard_id,
+                            })
+                            .map(|info| info.take_account_id())
                             .context("Getting chunk producer")
                     })
                     .collect::<Result<Vec<_>, _>>()?;

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -35,6 +35,7 @@ use near_primitives::sharding::{ChunkHash, ShardChunk};
 use near_primitives::state::FlatStateValue;
 use near_primitives::state_record::state_record_to_account_id;
 use near_primitives::state_record::StateRecord;
+use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::trie_key::col::COLUMNS_WITH_ACCOUNT_ID_IN_KEY;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{BlockHeight, EpochId, ShardId};
@@ -630,8 +631,12 @@ pub(crate) fn print_chain(
                     let shard_layout = epoch_manager.get_shard_layout(&epoch_id).unwrap();
                     for (shard_index, shard_id) in shard_layout.shard_ids().enumerate() {
                         let chunk_producer = epoch_manager
-                            .get_chunk_producer(&epoch_id, header.height(), shard_id)
-                            .map(|account_id| account_id.to_string())
+                            .get_chunk_producer_info(&ChunkProductionKey {
+                                epoch_id,
+                                height_created: header.height(),
+                                shard_id,
+                            })
+                            .map(|info| info.account_id().to_string())
                             .unwrap_or_else(|_| "CP Unknown".to_owned());
                         if header.chunk_mask()[shard_index] {
                             let chunk_hash = &block.chunks()[shard_index].chunk_hash();


### PR DESCRIPTION
Replace all usages with `get_chunk_producer_info`, follow-up to #12409.