### PR TITLE
feat(contract-distribution): Exclude old-code from witness for deploy-contract and delete-account actions

### DIFF
--- a/core/store/src/genesis/state_applier.rs
+++ b/core/store/src/genesis/state_applier.rs
@@ -2,9 +2,8 @@ use crate::adapter::StoreUpdateAdapter;
 use crate::flat::FlatStateChanges;
 use crate::trie::update::TrieUpdateResult;
 use crate::{
-    get_account, has_received_data, set, set_access_key, set_account, set_code,
-    set_delayed_receipt, set_postponed_receipt, set_promise_yield_receipt, set_received_data,
-    ShardTries, TrieUpdate,
+    get_account, has_received_data, set, set_access_key, set_account, set_delayed_receipt,
+    set_postponed_receipt, set_promise_yield_receipt, set_received_data, ShardTries, TrieUpdate,
 };
 
 use near_chain_configs::Genesis;
@@ -206,7 +205,7 @@ impl GenesisStateApplier {
                         if let Some(acc) =
                             get_account(state_update, account_id).expect("Failed to read state")
                         {
-                            set_code(state_update, account_id.clone(), &code);
+                            state_update.set_code(account_id.clone(), &code);
                             assert_eq!(*code.hash(), acc.code_hash());
                         } else {
                             tracing::error!(

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -36,7 +36,7 @@ use near_primitives::receipt::{
 pub use near_primitives::shard_layout::ShardUId;
 use near_primitives::trie_key::{trie_key_parsers, TrieKey};
 use near_primitives::types::{AccountId, BlockHeight, StateRoot};
-use near_vm_runner::{CompiledContractInfo, ContractCode, ContractRuntimeCache};
+use near_vm_runner::{CompiledContractInfo, ContractRuntimeCache};
 use std::fs::File;
 use std::path::Path;
 use std::str::FromStr;
@@ -1025,10 +1025,6 @@ pub fn get_access_key_raw(
     )
 }
 
-pub fn set_code(state_update: &mut TrieUpdate, account_id: AccountId, code: &ContractCode) {
-    state_update.set(TrieKey::ContractCode { account_id }, code.code().to_vec());
-}
-
 /// Removes account, code and all access keys associated to it.
 pub fn remove_account(
     state_update: &mut TrieUpdate,
@@ -1171,18 +1167,6 @@ impl ContractRuntimeCache for StoreContractRuntimeCache {
     fn handle(&self) -> Box<dyn ContractRuntimeCache> {
         Box::new(self.clone())
     }
-}
-
-/// Get the contract WASM code from The State.
-///
-/// Executing all the usual storage access side-effects.
-pub fn get_code(
-    trie: &dyn TrieAccess,
-    account_id: &AccountId,
-    code_hash: Option<CryptoHash>,
-) -> Result<Option<ContractCode>, StorageError> {
-    let key = TrieKey::ContractCode { account_id: account_id.clone() };
-    trie.get(&key).map(|opt| opt.map(|code| ContractCode::new(code, code_hash)))
 }
 
 #[cfg(test)]

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -648,6 +648,13 @@ impl OptimizedValueRef {
         }
     }
 
+    pub fn value_hash(&self) -> CryptoHash {
+        match self {
+            OptimizedValueRef::Ref(value_ref) => value_ref.hash,
+            OptimizedValueRef::AvailableValue(ValueAccessToken { value }) => hash(value.as_slice()),
+        }
+    }
+
     pub fn into_value_ref(self) -> ValueRef {
         match self {
             Self::Ref(value_ref) => value_ref,

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -144,10 +144,10 @@ impl TrieUpdate {
     pub fn get_code(
         &self,
         account_id: &AccountId,
-        code_hash: Option<CryptoHash>,
+        code_hash: CryptoHash,
     ) -> Result<Option<ContractCode>, StorageError> {
         let key = TrieKey::ContractCode { account_id: account_id.clone() };
-        self.get(&key).map(|opt| opt.map(|code| ContractCode::new(code, code_hash)))
+        self.get(&key).map(|opt| opt.map(|code| ContractCode::new(code, Some(code_hash))))
     }
 
     pub fn set_code(&mut self, account_id: AccountId, code: &ContractCode) {
@@ -268,7 +268,7 @@ impl TrieUpdate {
     /// In the latter case, the Trie read does not happen and the code-size does not contribute to
     /// the storage-proof limit. Instead we just record that the code with the given hash was called,
     /// so that we can identify which contract-code to distribute to the validators.
-    pub fn record_contract_call(
+    pub fn record_contract_access(
         &self,
         account_id: AccountId,
         code_hash: CryptoHash,

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -33,7 +33,7 @@ pub type TrieUpdates = BTreeMap<Vec<u8>, TrieKeyValueUpdate>;
 /// TODO (#7327): rename to StateUpdate
 pub struct TrieUpdate {
     pub trie: Trie,
-    pub contract_storage: ContractStorage,
+    contract_storage: ContractStorage,
     committed: RawStateChanges,
     prospective: TrieUpdates,
 }
@@ -81,6 +81,10 @@ impl TrieUpdate {
 
     pub fn trie(&self) -> &Trie {
         &self.trie
+    }
+
+    pub fn contract_storage(&self) -> ContractStorage {
+        self.contract_storage.clone()
     }
 
     pub fn get_ref(
@@ -258,6 +262,10 @@ impl TrieUpdate {
             }
         }
         fallback(&key)
+    }
+
+    pub fn record_contract_deploy(&self, code: ContractCode) {
+        self.contract_storage.record_deploy(code);
     }
 
     /// Records an access to the contract code due to a function call.

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -147,15 +147,16 @@ impl TrieUpdate {
 
     pub fn get_code(
         &self,
-        account_id: &AccountId,
+        account_id: AccountId,
         code_hash: CryptoHash,
     ) -> Result<Option<ContractCode>, StorageError> {
-        let key = TrieKey::ContractCode { account_id: account_id.clone() };
+        let key = TrieKey::ContractCode { account_id };
         self.get(&key).map(|opt| opt.map(|code| ContractCode::new(code, Some(code_hash))))
     }
 
     pub fn set_code(&mut self, account_id: AccountId, code: &ContractCode) {
-        self.set(TrieKey::ContractCode { account_id }, code.code().to_vec());
+        let key = TrieKey::ContractCode { account_id };
+        self.set(key, code.code().to_vec());
     }
 
     pub fn commit(&mut self, event: StateChangeCause) {
@@ -328,7 +329,7 @@ impl TrieUpdate {
     }
 }
 
-impl crate::TrieAccess for TrieUpdate {
+impl TrieAccess for TrieUpdate {
     fn get(&self, key: &TrieKey) -> Result<Option<Vec<u8>>, StorageError> {
         self.get_from_updates(key, |k| self.trie.get(k))
     }

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -25,7 +25,7 @@ use near_store::adapter::StoreUpdateAdapter;
 use near_store::genesis::{compute_storage_usage, initialize_genesis_state};
 use near_store::trie::update::TrieUpdateResult;
 use near_store::{
-    get_account, get_genesis_state_roots, set_access_key, set_account, set_code, Store, TrieUpdate,
+    get_account, get_genesis_state_roots, set_access_key, set_account, Store, TrieUpdate,
 };
 use near_time::Utc;
 use near_vm_runner::logic::ProtocolVersion;
@@ -354,7 +354,7 @@ impl GenesisBuilder {
         records.push(access_key_record);
         if let Some(wasm_binary) = self.additional_accounts_code.as_ref() {
             let code = ContractCode::new(wasm_binary.clone(), None);
-            set_code(&mut state_update, account_id.clone(), &code);
+            state_update.set_code(account_id.clone(), &code);
             let contract_record = StateRecord::Contract { account_id, code: wasm_binary.clone() };
             records.push(contract_record);
         }

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -181,7 +181,7 @@ pub(crate) fn action_function_call(
         .into());
     }
 
-    state_update.record_contract_call(
+    state_update.record_contract_access(
         account_id.clone(),
         code_hash,
         apply_state.apply_reason.clone(),
@@ -617,7 +617,7 @@ pub(crate) fn action_deploy_contract(
 ) -> Result<(), StorageError> {
     let _span = tracing::debug_span!(target: "runtime", "action_deploy_contract").entered();
     let code = ContractCode::new(deploy_contract.code.clone(), None);
-    let prev_code = state_update.get_code(account_id, Some(account.code_hash()))?;
+    let prev_code = state_update.get_code(account_id, account.code_hash())?;
     let prev_code_length = prev_code.map(|code| code.code().len() as u64).unwrap_or_default();
     account.set_storage_usage(account.storage_usage().saturating_sub(prev_code_length));
     account.set_storage_usage(
@@ -659,7 +659,7 @@ pub(crate) fn action_delete_account(
     if current_protocol_version >= ProtocolFeature::DeleteActionRestriction.protocol_version() {
         let account = account.as_ref().unwrap();
         let mut account_storage_usage = account.storage_usage();
-        let contract_code = state_update.get_code(account_id, Some(account.code_hash()))?;
+        let contract_code = state_update.get_code(account_id, account.code_hash())?;
         if let Some(code) = contract_code {
             // account storage usage should be larger than code size
             let code_len = code.code().len() as u64;

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -617,7 +617,7 @@ pub(crate) fn action_deploy_contract(
 ) -> Result<(), StorageError> {
     let _span = tracing::debug_span!(target: "runtime", "action_deploy_contract").entered();
     let code = ContractCode::new(deploy_contract.code.clone(), None);
-    let prev_code = state_update.get_code(account_id, account.code_hash())?;
+    let prev_code = state_update.get_code(account_id.clone(), account.code_hash())?;
     let prev_code_length = prev_code.map(|code| code.code().len() as u64).unwrap_or_default();
     account.set_storage_usage(account.storage_usage().saturating_sub(prev_code_length));
     account.set_storage_usage(
@@ -659,7 +659,7 @@ pub(crate) fn action_delete_account(
     if current_protocol_version >= ProtocolFeature::DeleteActionRestriction.protocol_version() {
         let account = account.as_ref().unwrap();
         let mut account_storage_usage = account.storage_usage();
-        let contract_code = state_update.get_code(account_id, account.code_hash())?;
+        let contract_code = state_update.get_code(account_id.clone(), account.code_hash())?;
         if let Some(code) = contract_code {
             // account storage usage should be larger than code size
             let code_len = code.code().len() as u64;

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -642,7 +642,7 @@ pub(crate) fn action_deploy_contract(
     // Inform the `store::contract::Storage` about the new deploy (so that the `get` method can
     // return the contract before the contract is written out to the underlying storage as part of
     // the `TrieUpdate` commit.)
-    state_update.contract_storage.record_deploy(code);
+    state_update.record_contract_deploy(code);
     Ok(())
 }
 

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -2460,7 +2460,7 @@ impl<'a> ApplyProcessingState<'a> {
             Arc::clone(&self.apply_state.config),
             self.apply_state.cache.as_ref().map(|v| v.handle()),
             self.apply_state.current_protocol_version,
-            self.state_update.contract_storage.clone(),
+            self.state_update.contract_storage(),
         );
         ApplyProcessingReceiptState {
             pipeline_manager,
@@ -2649,7 +2649,7 @@ pub mod estimator {
             std::sync::Arc::clone(&apply_state.config),
             apply_state.cache.as_ref().map(|c| c.handle()),
             apply_state.current_protocol_version,
-            state_update.contract_storage.clone(),
+            state_update.contract_storage(),
         );
         Runtime {}.apply_action_receipt(
             state_update,

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -60,9 +60,9 @@ use near_store::trie::update::TrieUpdateResult;
 use near_store::{
     get, get_account, get_postponed_receipt, get_promise_yield_receipt, get_pure,
     get_received_data, has_received_data, remove_account, remove_postponed_receipt,
-    remove_promise_yield_receipt, set, set_access_key, set_account, set_code,
-    set_postponed_receipt, set_promise_yield_receipt, set_received_data, PartialStorage,
-    StorageError, Trie, TrieAccess, TrieChanges, TrieUpdate,
+    remove_promise_yield_receipt, set, set_access_key, set_account, set_postponed_receipt,
+    set_promise_yield_receipt, set_received_data, PartialStorage, StorageError, Trie, TrieAccess,
+    TrieChanges, TrieUpdate,
 };
 use near_vm_runner::logic::types::PromiseResult;
 use near_vm_runner::logic::ReturnData;
@@ -1540,7 +1540,7 @@ impl Runtime {
                     let acc = get_account(state_update, &account_id).expect("Failed to read state").expect("Code state record should be preceded by the corresponding account record");
                     // Recompute contract code hash.
                     let code = ContractCode::new(code, None);
-                    set_code(state_update, account_id, &code);
+                    state_update.set_code(account_id, &code);
                     assert_eq!(*code.hash(), acc.code_hash());
                 }
                 StateRecord::AccessKey { account_id, public_key, access_key } => {

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -253,7 +253,7 @@ impl TrieViewer {
             Arc::clone(config),
             apply_state.cache.as_ref().map(|v| v.handle()),
             apply_state.current_protocol_version,
-            state_update.contract_storage.clone(),
+            state_update.contract_storage(),
         );
         let view_config = Some(ViewConfig { max_gas_burnt: self.max_gas_burnt_view });
         let contract = pipeline.get_contract(&receipt, account.code_hash(), 0, view_config.clone());

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -92,7 +92,7 @@ impl TrieViewer {
         account_id: &AccountId,
     ) -> Result<ContractCode, errors::ViewContractCodeError> {
         let account = self.view_account(state_update, account_id)?;
-        state_update.get_code(account_id, Some(account.code_hash()))?.ok_or_else(|| {
+        state_update.get_code(account_id, account.code_hash())?.ok_or_else(|| {
             errors::ViewContractCodeError::NoContractCode {
                 contract_account_id: account_id.clone(),
             }
@@ -150,7 +150,7 @@ impl TrieViewer {
         match get_account(state_update, account_id)? {
             Some(account) => {
                 let code_len = state_update
-                    .get_code(account_id, Some(account.code_hash()))?
+                    .get_code(account_id, account.code_hash())?
                     .map(|c| c.code().len() as u64)
                     .unwrap_or_default();
                 if let Some(limit) = self.state_size_limit {

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -150,9 +150,8 @@ impl TrieViewer {
         match get_account(state_update, account_id)? {
             Some(account) => {
                 let code_len = state_update
-                    .get_code(account_id.clone(), account.code_hash())?
-                    .map(|c| c.code().len() as u64)
-                    .unwrap_or_default();
+                    .get_code_len(account_id.clone(), account.code_hash())?
+                    .unwrap_or_default() as u64;
                 if let Some(limit) = self.state_size_limit {
                     if account.storage_usage().saturating_sub(code_len) > limit {
                         return Err(errors::ViewStateError::AccountStateTooLarge {

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -92,7 +92,7 @@ impl TrieViewer {
         account_id: &AccountId,
     ) -> Result<ContractCode, errors::ViewContractCodeError> {
         let account = self.view_account(state_update, account_id)?;
-        state_update.get_code(account_id, account.code_hash())?.ok_or_else(|| {
+        state_update.get_code(account_id.clone(), account.code_hash())?.ok_or_else(|| {
             errors::ViewContractCodeError::NoContractCode {
                 contract_account_id: account_id.clone(),
             }
@@ -150,7 +150,7 @@ impl TrieViewer {
         match get_account(state_update, account_id)? {
             Some(account) => {
                 let code_len = state_update
-                    .get_code(account_id, account.code_hash())?
+                    .get_code(account_id.clone(), account.code_hash())?
                     .map(|c| c.code().len() as u64)
                     .unwrap_or_default();
                 if let Some(limit) = self.state_size_limit {

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -20,7 +20,7 @@ use near_primitives::types::{
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{StateItem, ViewStateResult};
 use near_primitives_core::config::ViewConfig;
-use near_store::{get_access_key, get_account, get_code, TrieUpdate};
+use near_store::{get_access_key, get_account, TrieUpdate};
 use near_vm_runner::logic::{ProtocolVersion, ReturnData};
 use near_vm_runner::{ContractCode, ContractRuntimeCache};
 use std::{str, sync::Arc, time::Instant};
@@ -92,7 +92,7 @@ impl TrieViewer {
         account_id: &AccountId,
     ) -> Result<ContractCode, errors::ViewContractCodeError> {
         let account = self.view_account(state_update, account_id)?;
-        get_code(state_update, account_id, Some(account.code_hash()))?.ok_or_else(|| {
+        state_update.get_code(account_id, Some(account.code_hash()))?.ok_or_else(|| {
             errors::ViewContractCodeError::NoContractCode {
                 contract_account_id: account_id.clone(),
             }
@@ -149,7 +149,8 @@ impl TrieViewer {
     ) -> Result<ViewStateResult, errors::ViewStateError> {
         match get_account(state_update, account_id)? {
             Some(account) => {
-                let code_len = get_code(state_update, account_id, Some(account.code_hash()))?
+                let code_len = state_update
+                    .get_code(account_id, Some(account.code_hash()))?
                     .map(|c| c.code().len() as u64)
                     .unwrap_or_default();
                 if let Some(limit) = self.state_size_limit {

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -601,7 +601,7 @@ mod tests {
 
     use super::*;
     use crate::near_primitives::trie_key::TrieKey;
-    use near_store::{set, set_code};
+    use near_store::set;
     use near_vm_runner::ContractCode;
 
     /// Initial balance used in tests.
@@ -679,8 +679,7 @@ mod tests {
             if has_contract {
                 let code = vec![0; 100];
                 let code_hash = hash(&code);
-                set_code(
-                    &mut initial_state,
+                initial_state.set_code(
                     account_id.clone(),
                     &ContractCode::new(code.clone(), Some(code_hash)),
                 );


### PR DESCRIPTION
Today we record contract accesses for function calls, so we do not include the contract code in the state witness, instead we distribute these contracts separately to the validators.

There are also two other actions (`DeployContract` and `DeleteAccount`) that are seen less frequently but also reads code from the storage and contribute to state witness.

These actions do not run the code read from storage but only capture the code length to update storage usage. Thus, there is no need to add the actual code to the validators in the witness. To address this, we change the implementation of these actions to read the code length without reading the actual code.

Related changes in this PR:

- As a refactor, move `get_code` and `set_code` function from `core\store\src\lib.rs` to `TrieUpdate` as member methods. Note that, this will potentially be leveraged to change the code further to use `ContractStorage` instead of the trie and `prospective` changes.

- Add a new method to `TrieUpdate` called `get_code_len` to call `get_ref` to access the reference and capture the length of the value. Update the `DeployContract` and `DeleteAccount` actions to use this new method instead of reading the whole code.

- Small refactor: Change visibility of `contract_storage`.

- Add new tests for deleting the account after deploying and calling contracts on them. For this, we use accounts separate from the validator accounts.