### PR TITLE
refactor: move serialisation out of ValidatorSigner

### DIFF
--- a/chain/network/src/network_protocol/mod.rs
+++ b/chain/network/src/network_protocol/mod.rs
@@ -194,7 +194,7 @@ impl VersionedAccountData {
                 MAX_ACCOUNT_DATA_SIZE_BYTES
             );
         }
-        let signature = signer.sign_account_key_payload(&payload);
+        let signature = signer.sign_bytes(&payload);
         Ok(SignedAccountData {
             account_data: self,
             payload: AccountKeySignedPayload { payload, signature },
@@ -273,7 +273,7 @@ impl OwnedAccount {
             "OwnedAccount.account_key doesn't match the signer's account_key"
         );
         let payload = proto::AccountKeyPayload::from(&self).write_to_bytes().unwrap();
-        let signature = signer.sign_account_key_payload(&payload);
+        let signature = signer.sign_bytes(&payload);
         SignedOwnedAccount {
             owned_account: self,
             payload: AccountKeySignedPayload { payload, signature },

--- a/core/primitives/src/stateless_validation/contract_distribution.rs
+++ b/core/primitives/src/stateless_validation/contract_distribution.rs
@@ -82,7 +82,7 @@ impl ChunkContractAccessesV1 {
         signer: &ValidatorSigner,
     ) -> Self {
         let inner = ChunkContractAccessesInner::new(next_chunk, contracts, main_transition);
-        let signature = signer.sign_chunk_contract_accesses(&inner);
+        let signature = signer.sign_bytes(&borsh::to_vec(&inner).unwrap());
         Self { inner, signature }
     }
 
@@ -190,7 +190,7 @@ impl ContractCodeRequestV1 {
             contracts,
             main_transition,
         );
-        let signature = signer.sign_contract_code_request(&inner);
+        let signature = signer.sign_bytes(&borsh::to_vec(&inner).unwrap());
         Self { inner, signature }
     }
 
@@ -466,7 +466,7 @@ impl PartialEncodedContractDeploysV1 {
         signer: &ValidatorSigner,
     ) -> Self {
         let inner = PartialEncodedContractDeploysInner::new(key, part);
-        let signature = signer.sign_partial_encoded_contract_deploys(&inner);
+        let signature = signer.sign_bytes(&borsh::to_vec(&inner).unwrap());
         Self { inner, signature }
     }
 


### PR DESCRIPTION
Currently we add a method to `ValidatorSigner` for every data type we want to sign. I'm not sure what exactly is a benefit of doing that, but such approach results in quite a few annoying issues:
* Overly verbose code: need to add 3 methods for every data type to be signed.
* Not consistent with signature verification: we just call `verify` method on public key passing signature and bytes, why should signing be any different?
* It blows up `ValidatorSigner` public API making it awkward to work with.

This PR repurposes `sign_chunk_contract_accesses` to be a generic `sign_bytes` method and replaces usage for witness contract code distribution related types. The rest will be addressed in a separate PR. 