### PR TITLE
test(nayduck): re-enable state_sync_routed

### DIFF
--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -41,6 +41,8 @@ pytest --timeout=240 sanity/state_sync5.py --features nightly
 #pytest --timeout=300 sanity/state_sync_late.py notx --features nightly
 pytest sanity/state_sync_missing_chunks.py
 pytest sanity/state_sync_missing_chunks.py --features nightly
+pytest --timeout=600 sanity/state_sync_routed.py manytx 115
+pytest --timeout=600 sanity/state_sync_routed.py manytx 115 --features nightly
 
 pytest --timeout=270 sanity/single_shard_tracking.py
 pytest --timeout=270 sanity/single_shard_tracking.py --features nightly


### PR DESCRIPTION
This test was disabled because it was flaky, but it was fixed in #12366