### PR TITLE
network: gate graph_v2 behind a feature flag

### DIFF
--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -813,6 +813,7 @@ impl JsonRpcHandler {
                         )
                         .await?
                         .rpc_into(),
+                    #[cfg(feature = "distance_vector_routing")]
                     "/debug/api/network_routes" => self
                         .peer_manager_send(near_network::debug::GetDebugStatus::Routes)
                         .await?

--- a/chain/network/src/debug.rs
+++ b/chain/network/src/debug.rs
@@ -1,7 +1,7 @@
 use ::actix::Message;
+use near_primitives::views::NetworkRoutesView;
 use near_primitives::views::{
-    NetworkGraphView, NetworkRoutesView, PeerStoreView, RecentOutboundConnectionsView,
-    SnapshotHostsView,
+    NetworkGraphView, PeerStoreView, RecentOutboundConnectionsView, SnapshotHostsView,
 };
 
 // Different debug requests that can be sent by HTML pages, via GET.

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -33,8 +33,8 @@ use near_performance_metrics_macros::perf;
 use near_primitives::block::GenesisId;
 use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::views::{
-    ConnectionInfoView, EdgeView, KnownPeerStateView, NetworkGraphView, PeerStoreView,
-    RecentOutboundConnectionsView, SnapshotHostInfoView, SnapshotHostsView,
+    ConnectionInfoView, EdgeView, KnownPeerStateView, NetworkGraphView, NetworkRoutesView,
+    PeerStoreView, RecentOutboundConnectionsView, SnapshotHostInfoView, SnapshotHostsView,
 };
 use network_protocol::MAX_SHARDS_PER_SNAPSHOT_HOST_INFO;
 use rand::seq::{IteratorRandom, SliceRandom};
@@ -1387,7 +1387,12 @@ impl actix::Handler<GetDebugStatus> for PeerManagerActor {
                         .collect::<Vec<_>>(),
                 })
             }
-            GetDebugStatus::Routes => DebugStatus::Routes(self.state.graph_v2.get_debug_view()),
+            GetDebugStatus::Routes => {
+                #[cfg(feature = "distance_vector_routing")]
+                return DebugStatus::Routes(self.state.graph_v2.get_debug_view());
+                #[cfg(not(feature = "distance_vector_routing"))]
+                return DebugStatus::Routes(NetworkRoutesView::default());
+            }
             GetDebugStatus::SnapshotHosts => DebugStatus::SnapshotHosts(SnapshotHostsView {
                 hosts: self
                     .state

--- a/chain/network/src/peer_manager/tests/routing.rs
+++ b/chain/network/src/peer_manager/tests/routing.rs
@@ -1307,6 +1307,7 @@ async fn connect_to_unbanned_peer() {
 }
 
 /// Awaits a DistanceVector message from a given `peer_id`
+#[cfg(feature = "distance_vector_routing")]
 async fn wait_for_distance_vector(events: &mut broadcast::Receiver<Event>, peer_id: PeerId) {
     events
         .recv_until(|ev| match ev {
@@ -1321,6 +1322,7 @@ async fn wait_for_distance_vector(events: &mut broadcast::Receiver<Event>, peer_
 
 /// Check that connecting to a peer triggers exchange of DistanceVectors
 #[tokio::test]
+#[cfg(feature = "distance_vector_routing")]
 async fn peer_connect_send_distance_vector() {
     abort_on_panic();
     let mut rng = make_rng(921853233);

--- a/chain/network/src/routing/mod.rs
+++ b/chain/network/src/routing/mod.rs
@@ -1,10 +1,13 @@
 mod bfs;
 pub(crate) mod edge;
+#[cfg(feature = "distance_vector_routing")]
 mod edge_cache;
 mod graph;
+#[cfg(feature = "distance_vector_routing")]
 mod graph_v2;
 pub(crate) mod route_back_cache;
 pub mod routing_table_view;
 
 pub(crate) use graph::{DistanceTable, Graph, GraphConfig, NextHopTable};
+#[cfg(feature = "distance_vector_routing")]
 pub(crate) use graph_v2::{GraphConfigV2, GraphV2, NetworkTopologyChange};

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -479,7 +479,7 @@ pub struct LabeledEdgeView {
     pub nonce: u64,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Default)]
 pub struct EdgeCacheView {
     pub peer_labels: HashMap<PeerId, u32>,
     pub spanning_trees: HashMap<u32, Vec<LabeledEdgeView>>,
@@ -491,7 +491,7 @@ pub struct PeerDistancesView {
     pub min_nonce: u64,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Default)]
 pub struct NetworkRoutesView {
     pub edge_cache: EdgeCacheView,
     pub local_edges: HashMap<PeerId, EdgeView>,


### PR DESCRIPTION
This feature is not production ready and in its current state consumes a lot of bandwidth, impacting costs for node operators. We should disable it for now. 