### PR TITLE
feat(contract-distribution): Update testloop test to use new utils and add delete-account test

### DIFF
--- a/integration-tests/src/test_loop/tests/contract_distribution_simple.rs
+++ b/integration-tests/src/test_loop/tests/contract_distribution_simple.rs
@@ -26,7 +26,7 @@ const NUM_VALIDATORS: usize = NUM_BLOCK_AND_CHUNK_PRODUCERS + NUM_CHUNK_VALIDATO
 /// Executes a test that deploys to a contract to an account and calls it.
 fn test_contract_distribution_single_account(wait_cache_populate: bool, clear_cache: bool) {
     init_test_logger();
-   // We need 1 more non-validator account to create, deploy-contract, and delete.
+    // We need 1 more non-validator account to create, deploy-contract, and delete.
     let accounts = make_accounts(NUM_VALIDATORS + 1);
 
     let mut env = setup(&accounts);

--- a/integration-tests/src/test_loop/tests/contract_distribution_simple.rs
+++ b/integration-tests/src/test_loop/tests/contract_distribution_simple.rs
@@ -22,20 +22,18 @@ const GENESIS_HEIGHT: u64 = 1000;
 const NUM_BLOCK_AND_CHUNK_PRODUCERS: usize = 1;
 const NUM_CHUNK_VALIDATORS_ONLY: usize = 1;
 const NUM_VALIDATORS: usize = NUM_BLOCK_AND_CHUNK_PRODUCERS + NUM_CHUNK_VALIDATORS_ONLY;
-// We need 2 additional accounts to create, deploy-contract, and delete.
-const NUM_ACCOUNTS: usize = NUM_VALIDATORS + 2;
 
 /// Executes a test that deploys to a contract to an account and calls it.
 fn test_contract_distribution_single_account(wait_cache_populate: bool, clear_cache: bool) {
     init_test_logger();
-    let accounts = make_accounts(NUM_ACCOUNTS);
+   // We need 1 more non-validator account to create, deploy-contract, and delete.
+    let accounts = make_accounts(NUM_VALIDATORS + 1);
 
     let mut env = setup(&accounts);
 
     let rpc_id = make_account(0);
-    // Choose an account that is not a validator.
+    // Choose an account that is not a validator, so we can delete it.
     let contract_id = accounts[NUM_VALIDATORS].clone();
-    let sender_id = contract_id.clone();
     let contract = ContractCode::new(near_test_contracts::sized_contract(100), None);
     let method_name = "main".to_owned();
     let args = vec![];
@@ -55,12 +53,12 @@ fn test_contract_distribution_single_account(wait_cache_populate: bool, clear_ca
     do_call_contract(
         &mut env,
         &rpc_id,
-        &sender_id,
+        &contract_id,
         &contract_id,
         method_name.clone(),
         args.clone(),
     );
-    do_call_contract(&mut env, &rpc_id, &sender_id, &contract_id, method_name, args);
+    do_call_contract(&mut env, &rpc_id, &contract_id, &contract_id, method_name, args);
 
     do_delete_account(&mut env, &rpc_id, &contract_id, &rpc_id);
 
@@ -94,15 +92,15 @@ fn test_contract_distribution_call_after_clear_single_account() {
 /// Executes a test that deploys to a contract to two different accounts and calls them.
 fn test_contract_distribution_different_accounts(wait_cache_populate: bool, clear_cache: bool) {
     init_test_logger();
-    let accounts = make_accounts(NUM_ACCOUNTS);
+    // We need 2 more non-validator accounts to create, deploy-contract, and delete.
+    let accounts = make_accounts(NUM_VALIDATORS + 2);
 
     let mut env = setup(&accounts);
 
     let rpc_id = make_account(0);
-    // Choose accounts that are not validators.
+    // Choose accounts that are not validators, so we can delete them.
     let contract_id1 = accounts[NUM_VALIDATORS].clone();
     let contract_id2 = accounts[NUM_VALIDATORS + 1].clone();
-    let sender_id = rpc_id.clone();
     let contract = ContractCode::new(near_test_contracts::sized_contract(100), None);
     let method_name = "main".to_owned();
     let args = vec![];
@@ -123,12 +121,12 @@ fn test_contract_distribution_different_accounts(wait_cache_populate: bool, clea
     do_call_contract(
         &mut env,
         &rpc_id,
-        &sender_id,
+        &contract_id1,
         &contract_id1,
         method_name.clone(),
         args.clone(),
     );
-    do_call_contract(&mut env, &rpc_id, &sender_id, &contract_id2, method_name, args);
+    do_call_contract(&mut env, &rpc_id, &contract_id2, &contract_id2, method_name, args);
 
     do_delete_account(&mut env, &rpc_id, &contract_id1, &rpc_id);
     do_delete_account(&mut env, &rpc_id, &contract_id2, &rpc_id);
@@ -164,14 +162,14 @@ fn test_contract_distribution_call_after_clear_different_accounts() {
 #[test]
 fn test_contract_distribution_deply_and_call_multiple_contracts() {
     init_test_logger();
-    let accounts = make_accounts(NUM_ACCOUNTS);
+    // We need 1 more non-validator account to create, deploy-contract, and delete.
+    let accounts = make_accounts(NUM_VALIDATORS + 1);
 
     let mut env = setup(&accounts);
 
     let rpc_id = make_account(0);
     // Choose accounts that are not validators.
     let contract_id = accounts[NUM_VALIDATORS].clone();
-    let sender_id = rpc_id.clone();
     let contracts = (0..3)
         .map(|i| ContractCode::new(near_test_contracts::sized_contract((i + 1) * 100), None))
         .collect_vec();
@@ -188,7 +186,7 @@ fn test_contract_distribution_deply_and_call_multiple_contracts() {
         do_call_contract(
             &mut env,
             &rpc_id,
-            &sender_id,
+            &contract_id,
             &contract_id,
             method_name.clone(),
             args.clone(),
@@ -196,7 +194,7 @@ fn test_contract_distribution_deply_and_call_multiple_contracts() {
         do_call_contract(
             &mut env,
             &rpc_id,
-            &sender_id,
+            &contract_id,
             &contract_id,
             method_name.clone(),
             args.clone(),

--- a/integration-tests/src/test_loop/utils/mod.rs
+++ b/integration-tests/src/test_loop/utils/mod.rs
@@ -1,6 +1,4 @@
-use near_async::test_loop::TestLoopV2;
-
-use super::env::TestData;
+use super::env::TestLoopEnv;
 
 pub mod contract_distribution;
 pub mod network;
@@ -12,8 +10,8 @@ pub(crate) const ONE_NEAR: u128 = 1_000_000_000_000_000_000_000_000;
 pub(crate) const TGAS: u64 = 1_000_000_000_000;
 
 /// Returns the height of the chain head, by querying node at index 0.
-pub(crate) fn get_head_height(test_loop: &mut TestLoopV2, node_datas: &Vec<TestData>) -> u64 {
-    let client_handle = node_datas[0].client_sender.actor_handle();
-    let client = &test_loop.data.get(&client_handle).client;
+pub(crate) fn get_head_height(env: &mut TestLoopEnv) -> u64 {
+    let client_handle = env.datas[0].client_sender.actor_handle();
+    let client = &env.test_loop.data.get(&client_handle).client;
     client.chain.head().unwrap().height
 }

--- a/integration-tests/src/test_loop/utils/transactions.rs
+++ b/integration-tests/src/test_loop/utils/transactions.rs
@@ -185,6 +185,30 @@ pub fn do_deploy_contract(
     check_txs(&env.test_loop, &env.datas, rpc_id, &[tx]);
 }
 
+pub fn do_call_contract(
+    env: &mut TestLoopEnv,
+    rpc_id: &AccountId,
+    sender_id: &AccountId,
+    contract_id: &AccountId,
+    method_name: String,
+    args: Vec<u8>,
+) {
+    tracing::info!(target: "test", "Calling contract.");
+    let nonce = get_next_nonce(env, contract_id);
+    let tx = call_contract(
+        &mut env.test_loop,
+        &env.datas,
+        rpc_id,
+        sender_id,
+        contract_id,
+        method_name,
+        args,
+        nonce,
+    );
+    env.test_loop.run_for(Duration::seconds(2));
+    check_txs(&env.test_loop, &env.datas, rpc_id, &[tx]);
+}
+
 pub fn create_account(
     env: &mut TestLoopEnv,
     rpc_id: &AccountId,
@@ -311,40 +335,6 @@ pub fn submit_tx(node_datas: &[TestData], rpc_id: &AccountId, tx: SignedTransact
 
     let future = rpc_node_data_sender.send_async(process_tx_request);
     drop(future);
-}
-
-pub fn delete_account(
-    test_loop: &mut TestLoopV2,
-    node_datas: &[TestData],
-    rpc_id: &AccountId,
-    account: &AccountId,
-    beneficiary: &AccountId,
-    nonce: u64,
-) -> CryptoHash {
-    let block_hash = get_shared_block_hash(node_datas, test_loop);
-
-    let signer = create_user_test_signer(&account).into();
-
-    let tx = SignedTransaction::delete_account(
-        nonce,
-        account.clone(),
-        account.clone(),
-        beneficiary.clone(),
-        &signer,
-        block_hash,
-    );
-    let tx_hash = tx.get_hash();
-    let process_tx_request =
-        ProcessTxRequest { transaction: tx, is_forwarded: false, check_only: false };
-
-    let rpc_node_data = get_node_data(node_datas, rpc_id);
-    let rpc_node_data_sender = &rpc_node_data.client_sender;
-
-    let future = rpc_node_data_sender.send_async(process_tx_request);
-    drop(future);
-
-    tracing::debug!(target: "test", ?account, ?tx_hash, "deleted account");
-    tx_hash
 }
 
 /// Check the status of the transactions and assert that they are successful.

--- a/integration-tests/src/test_loop/utils/transactions.rs
+++ b/integration-tests/src/test_loop/utils/transactions.rs
@@ -313,6 +313,40 @@ pub fn submit_tx(node_datas: &[TestData], rpc_id: &AccountId, tx: SignedTransact
     drop(future);
 }
 
+pub fn delete_account(
+    test_loop: &mut TestLoopV2,
+    node_datas: &[TestData],
+    rpc_id: &AccountId,
+    account: &AccountId,
+    beneficiary: &AccountId,
+    nonce: u64,
+) -> CryptoHash {
+    let block_hash = get_shared_block_hash(node_datas, test_loop);
+
+    let signer = create_user_test_signer(&account).into();
+
+    let tx = SignedTransaction::delete_account(
+        nonce,
+        account.clone(),
+        account.clone(),
+        beneficiary.clone(),
+        &signer,
+        block_hash,
+    );
+    let tx_hash = tx.get_hash();
+    let process_tx_request =
+        ProcessTxRequest { transaction: tx, is_forwarded: false, check_only: false };
+
+    let rpc_node_data = get_node_data(node_datas, rpc_id);
+    let rpc_node_data_sender = &rpc_node_data.client_sender;
+
+    let future = rpc_node_data_sender.send_async(process_tx_request);
+    drop(future);
+
+    tracing::debug!(target: "test", ?account, ?tx_hash, "deleted account");
+    tx_hash
+}
+
 /// Check the status of the transactions and assert that they are successful.
 ///
 /// Please note that it's important to use an rpc node that tracks all shards.


### PR DESCRIPTION
Add new testloop tests for deleting the account after deploying and calling contracts on them. For this, we use accounts separate from the validator accounts.

Also update the tests to reuse the new utils added in other PRs to share code.

Extracted from #12416. 