### PR TITLE
feat(congestion_control) - relax congestion control - part 2

### DIFF
--- a/core/parameters/res/runtime_configs/73.yaml
+++ b/core/parameters/res/runtime_configs/73.yaml
@@ -2,10 +2,10 @@ wasm_yield_resume_byte: { old: 1_195_627_285_210 , new: 47_683_715 }
 
 # Congestion Control
 
-# 40 PGAS
+# 400 PGAS
 max_congestion_incoming_gas: {
   old : 20_000_000_000_000_000,
-  new : 40_000_000_000_000_000,
+  new : 400_000_000_000_000_000,
 }
 
 # 0.7

--- a/core/parameters/res/runtime_configs/parameters.snap
+++ b/core/parameters/res/runtime_configs/parameters.snap
@@ -208,7 +208,7 @@ vm_kind                                 NearVm
 eth_implicit_accounts                   true
 yield_resume                            true
 discard_custom_sections                 true
-max_congestion_incoming_gas             40_000_000_000_000_000
+max_congestion_incoming_gas             400_000_000_000_000_000
 max_congestion_outgoing_gas             10_000_000_000_000_000
 max_congestion_memory_consumption              1_000_000_000
 max_congestion_missed_chunks                               5

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__129.json.snap
@@ -246,7 +246,7 @@ expression: config_view
     "registrar_account_id": "registrar"
   },
   "congestion_control_config": {
-    "max_congestion_incoming_gas": 40000000000000000,
+    "max_congestion_incoming_gas": 400000000000000000,
     "max_congestion_outgoing_gas": 10000000000000000,
     "max_congestion_memory_consumption": 1000000000,
     "max_congestion_missed_chunks": 5,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__73.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__73.json.snap
@@ -246,7 +246,7 @@ expression: config_view
     "registrar_account_id": "registrar"
   },
   "congestion_control_config": {
-    "max_congestion_incoming_gas": 40000000000000000,
+    "max_congestion_incoming_gas": 400000000000000000,
     "max_congestion_outgoing_gas": 10000000000000000,
     "max_congestion_memory_consumption": 1000000000,
     "max_congestion_missed_chunks": 5,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
@@ -246,7 +246,7 @@ expression: config_view
     "registrar_account_id": "registrar"
   },
   "congestion_control_config": {
-    "max_congestion_incoming_gas": 40000000000000000,
+    "max_congestion_incoming_gas": 400000000000000000,
     "max_congestion_outgoing_gas": 10000000000000000,
     "max_congestion_memory_consumption": 1000000000,
     "max_congestion_missed_chunks": 5,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_73.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_73.json.snap
@@ -246,7 +246,7 @@ expression: config_view
     "registrar_account_id": "registrar"
   },
   "congestion_control_config": {
-    "max_congestion_incoming_gas": 40000000000000000,
+    "max_congestion_incoming_gas": 400000000000000000,
     "max_congestion_outgoing_gas": 10000000000000000,
     "max_congestion_memory_consumption": 1000000000,
     "max_congestion_missed_chunks": 5,

--- a/core/parameters/src/snapshots/near_parameters__view__tests__runtime_config_view.snap
+++ b/core/parameters/src/snapshots/near_parameters__view__tests__runtime_config_view.snap
@@ -246,7 +246,7 @@ expression: "&view"
     "registrar_account_id": "registrar"
   },
   "congestion_control_config": {
-    "max_congestion_incoming_gas": 40000000000000000,
+    "max_congestion_incoming_gas": 400000000000000000,
     "max_congestion_outgoing_gas": 10000000000000000,
     "max_congestion_memory_consumption": 1000000000,
     "max_congestion_missed_chunks": 5,

--- a/core/primitives-core/src/chains.rs
+++ b/core/primitives-core/src/chains.rs
@@ -11,3 +11,6 @@ pub const MOCKNET: &str = "mocknet";
 
 /// Used by ft-benchmark.  http://go/crt-benchmark
 pub const BENCHMARKNET: &str = "benchmarknet";
+
+/// Used by congestion control tests in nayduck.
+pub const CONGESTION_CONTROL_TEST: &str = "congestion_control_test";

--- a/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
+++ b/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
@@ -246,7 +246,7 @@ expression: "&view"
     "registrar_account_id": "registrar"
   },
   "congestion_control_config": {
-    "max_congestion_incoming_gas": 40000000000000000,
+    "max_congestion_incoming_gas": 400000000000000000,
     "max_congestion_outgoing_gas": 10000000000000000,
     "max_congestion_memory_consumption": 1000000000,
     "max_congestion_missed_chunks": 5,

--- a/integration-tests/src/tests/client/features/congestion_control.rs
+++ b/integration-tests/src/tests/client/features/congestion_control.rs
@@ -32,15 +32,24 @@ fn get_runtime_config(
     let mut config = config_store.get_config(protocol_version).clone();
     let mut_config = Arc::make_mut(&mut config);
 
-    adjust_runtime_config(mut_config);
+    set_wasm_cost(mut_config);
 
     config
 }
 
 // Make 1 wasm op cost ~4 GGas, to let "loop_forever" finish more quickly.
-fn adjust_runtime_config(config: &mut RuntimeConfig) {
+fn set_wasm_cost(config: &mut RuntimeConfig) {
     let wasm_config = Arc::make_mut(&mut config.wasm_config);
     wasm_config.regular_op_cost = u32::MAX;
+}
+
+// Set the default congestion control parameters for the given runtime config.
+// This is important to prevent needing to fix the congestion control tests
+// every time the parameters are updated.
+fn set_default_congestion_control(config_store: &RuntimeConfigStore, config: &mut RuntimeConfig) {
+    let cc_protocol_version = ProtocolFeature::CongestionControl.protocol_version();
+    let cc_config = get_runtime_config(&config_store, cc_protocol_version);
+    config.congestion_control_config = cc_config.congestion_control_config.clone();
 }
 
 /// Set up the test runtime with the given protocol version and runtime configs.
@@ -53,10 +62,12 @@ fn setup_test_runtime(sender_id: AccountId, protocol_version: ProtocolVersion) -
     // Chain must be sharded to test cross-shard congestion control.
     genesis.config.shard_layout = ShardLayout::v1_test();
 
+    let config_store = RuntimeConfigStore::new(None);
     let mut config = RuntimeConfig::test_protocol_version(protocol_version);
-    adjust_runtime_config(&mut config);
-    let runtime_configs = vec![RuntimeConfigStore::with_one_config(config)];
+    set_wasm_cost(&mut config);
+    set_default_congestion_control(&config_store, &mut config);
 
+    let runtime_configs = vec![RuntimeConfigStore::with_one_config(config)];
     TestEnv::builder(&genesis.config)
         .nightshade_runtimes_with_runtime_config_store(&genesis, runtime_configs)
         .build()
@@ -73,9 +84,14 @@ fn setup_real_runtime(sender_id: AccountId, protocol_version: ProtocolVersion) -
     // Chain must be sharded to test cross-shard congestion control.
     genesis.config.shard_layout = ShardLayout::v1_test();
 
+    // Get the runtime configs for before and after the protocol upgrade.
     let config_store = RuntimeConfigStore::new(None);
     let pre_config = get_runtime_config(&config_store, protocol_version);
-    let post_config = get_runtime_config(&config_store, PROTOCOL_VERSION);
+    let mut post_config = get_runtime_config(&config_store, PROTOCOL_VERSION);
+
+    // Use the original congestion control parameters for the post config.
+    let post_runtime_config = Arc::get_mut(&mut post_config).unwrap();
+    set_default_congestion_control(&config_store, post_runtime_config);
 
     // Checking the migration from Receipt to StateStoredReceipt requires the
     // relevant config to be disabled before the protocol upgrade and enabled
@@ -520,13 +536,10 @@ fn test_transaction_limit_for_local_congestion() {
     if !ProtocolFeature::CongestionControl.enabled(PROTOCOL_VERSION) {
         return;
     }
-    let runtime_config_store = RuntimeConfigStore::new(None);
-
     // Fix the initial configuration of congestion control for the tests.
     let protocol_version = ProtocolFeature::CongestionControl.protocol_version();
-    let config = runtime_config_store.get_config(protocol_version);
     // We don't want to go into the TX rejection limit in this test.
-    let upper_limit_congestion = config.congestion_control_config.reject_tx_congestion_threshold;
+    let upper_limit_congestion = UpperLimitCongestion::BelowRejectThreshold;
 
     // For this test, the contract and the sender are on the same shard, even
     // the same account.
@@ -572,13 +585,12 @@ fn test_transaction_limit_for_local_congestion() {
 /// rejection.
 #[test]
 fn test_transaction_limit_for_remote_congestion() {
+    init_test_logger();
     if !ProtocolFeature::CongestionControl.enabled(PROTOCOL_VERSION) {
         return;
     }
-    let runtime_config_store = RuntimeConfigStore::new(None);
-    let config = runtime_config_store.get_config(PROTOCOL_VERSION);
     // We don't want to go into the TX rejection limit in this test.
-    let upper_limit_congestion = config.congestion_control_config.reject_tx_congestion_threshold;
+    let upper_limit_congestion = UpperLimitCongestion::BelowRejectThreshold;
 
     let (
         remote_tx_included_without_congestion,
@@ -612,11 +624,8 @@ fn test_transaction_filtering() {
     if !ProtocolFeature::CongestionControl.enabled(PROTOCOL_VERSION) {
         return;
     }
-    let runtime_config_store = RuntimeConfigStore::new(None);
-    let config = runtime_config_store.get_config(PROTOCOL_VERSION);
     // This test should go beyond into the TX rejection limit in this test.
-    let upper_limit_congestion =
-        3.0 * config.congestion_control_config.reject_tx_congestion_threshold;
+    let upper_limit_congestion = UpperLimitCongestion::AboveRejectThreshold;
 
     let (
         remote_tx_included_without_congestion,
@@ -638,8 +647,15 @@ fn test_transaction_filtering() {
     assert_eq!(remote_tx_included_with_congestion, 0);
 }
 
+enum UpperLimitCongestion {
+    BelowRejectThreshold,
+    AboveRejectThreshold,
+}
+
 /// Calls [`measure_tx_limit`] with accounts on three different shards.
-fn measure_remote_tx_limit(upper_limit_congestion: f64) -> (usize, usize, usize, usize) {
+fn measure_remote_tx_limit(
+    upper_limit_congestion: UpperLimitCongestion,
+) -> (usize, usize, usize, usize) {
     let remote_id: AccountId = "test0".parse().unwrap();
     let contract_id: AccountId = CONTRACT_ID.parse().unwrap();
     let dummy_id: AccountId = "a_dummy_receiver".parse().unwrap();
@@ -677,7 +693,7 @@ fn measure_tx_limit(
     remote_id: AccountId,
     contract_id: AccountId,
     dummy_receiver: AccountId,
-    upper_limit_congestion: f64,
+    upper_limit_congestion: UpperLimitCongestion,
 ) -> (usize, usize, usize, usize) {
     let remote_signer =
         InMemorySigner::from_seed(remote_id.clone(), KeyType::ED25519, remote_id.as_str());
@@ -694,6 +710,11 @@ fn measure_tx_limit(
     // put in enough transactions to create up to
     // `reject_tx_congestion_threshold` incoming congestion
     let config = head_congestion_control_config(&env);
+    let upper_limit_congestion = match upper_limit_congestion {
+        UpperLimitCongestion::BelowRejectThreshold => config.reject_tx_congestion_threshold,
+        UpperLimitCongestion::AboveRejectThreshold => config.reject_tx_congestion_threshold * 2.0,
+    };
+
     let num_full_congestion = config.max_congestion_incoming_gas / (100 * 10u64.pow(12));
     let n = num_full_congestion as f64 * upper_limit_congestion;
     // Key of new account starts at block_height * 1_000_000
@@ -714,10 +735,11 @@ fn measure_tx_limit(
         let height = tip.height + i;
         env.produce_block(0, height);
 
-        let sender_chunk = head_chunk(&env, remote_shard_id);
+        let remote_chunk = head_chunk(&env, remote_shard_id);
         let contract_chunk = head_chunk(&env, contract_shard_id);
-        let remote_num_tx = sender_chunk.transactions().len();
+        let remote_num_tx = remote_chunk.transactions().len();
         let local_num_tx = contract_chunk.transactions().len();
+
         if i == 2 {
             remote_tx_included_without_congestion = remote_num_tx;
             local_tx_included_without_congestion = local_num_tx;

--- a/integration-tests/src/tests/client/features/congestion_control.rs
+++ b/integration-tests/src/tests/client/features/congestion_control.rs
@@ -49,7 +49,7 @@ fn set_wasm_cost(config: &mut RuntimeConfig) {
 fn set_default_congestion_control(config_store: &RuntimeConfigStore, config: &mut RuntimeConfig) {
     let cc_protocol_version = ProtocolFeature::CongestionControl.protocol_version();
     let cc_config = get_runtime_config(&config_store, cc_protocol_version);
-    config.congestion_control_config = cc_config.congestion_control_config.clone();
+    config.congestion_control_config = cc_config.congestion_control_config;
 }
 
 /// Set up the test runtime with the given protocol version and runtime configs.

--- a/pytest/tests/sanity/congestion_control.py
+++ b/pytest/tests/sanity/congestion_control.py
@@ -105,7 +105,7 @@ class CongestionControlTest(unittest.TestCase):
     def __run_under_congestion(self, node):
         logger.info("Checking the chain under congestion")
         (start_height, _) = node.get_latest_block()
-        target = start_height + 20
+        target = start_height + 10
         for height, hash in poll_blocks(node, __target=target):
             # Wait for a few blocks to congest the chain.
             if height < start_height + 5:
@@ -265,6 +265,11 @@ class CongestionControlTest(unittest.TestCase):
         genesis_config_changes = [
             ("epoch_length", epoch_length),
             ("shard_layout", SHARD_LAYOUT),
+            # This is a custom chain id that will set the congestion control
+            # runtime parameters to their original values. This is needed so
+            # that the test doesn't need to be updated every time the parameters
+            # are changed.
+            ("chain_id", "congestion_control_test"),
         ]
         client_config_changes = {
             0: {

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -2308,7 +2308,7 @@ fn test_congestion_buffering() {
         .get_mut(&receiver_shard)
         .unwrap()
         .congestion_info
-        .remove_delayed_receipt_gas(10)
+        .remove_delayed_receipt_gas(100)
         .unwrap();
 
     let min_outgoing_gas: Gas = apply_state.config.congestion_control_config.min_outgoing_gas;


### PR DESCRIPTION
relaxing the congestion control to allow more gas (receipts) in the delayed receipts queue.

Please note I'm adding it directly to protocol version 73 because it wasn't released yet. @staffik Will it be possible to get it into 2.4? 