### PR TITLE
chore: ignore RUSTSEC-2024-0384

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -32,7 +32,11 @@ ignore = [
     # Follow https://github.com/Kyuuhachi/syn_derive/issues/4
     "RUSTSEC-2024-0370",
 
-    # instant is unmaintained, but hard to replace because parking_lot depends
-    # on it.
+    # The instant package is unmaintained, but hard to replace right now because
+    # parking_lot depends on it.
     "RUSTSEC-2024-0384",
+
+    # The derivative package is unmainained, but hard to replace right now
+    # because ark-poly depends on it.
+    "RUSTSEC-2024-0388"
 ]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -31,4 +31,8 @@ ignore = [
     # proc-macro-error is unmaintained, but hard to replace right now.
     # Follow https://github.com/Kyuuhachi/syn_derive/issues/4
     "RUSTSEC-2024-0370",
+
+    # instant is unmaintained, but hard to replace because parking_lot depends
+    # on it.
+    "RUSTSEC-2024-0384",
 ]


### PR DESCRIPTION
instant & derivative are breaking audit in CI:
https://github.com/near/nearcore/actions/runs/11779066830/job/32806748238

This is a poor fix. Please let me know if we should find a proper one. 