### PR TITLE
Small refactor to hide contract_storage in TrieUpdate

### DIFF
--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -14,6 +14,7 @@ use near_primitives::types::{
 };
 use near_primitives::version::ProtocolFeature;
 use near_vm_runner::logic::ProtocolVersion;
+use near_vm_runner::ContractCode;
 use std::collections::BTreeMap;
 
 mod iterator;
@@ -31,7 +32,7 @@ pub type TrieUpdates = BTreeMap<Vec<u8>, TrieKeyValueUpdate>;
 /// TODO (#7327): rename to StateUpdate
 pub struct TrieUpdate {
     pub trie: Trie,
-    pub contract_storage: ContractStorage,
+    contract_storage: ContractStorage,
     committed: RawStateChanges,
     prospective: TrieUpdates,
 }
@@ -79,6 +80,11 @@ impl TrieUpdate {
 
     pub fn trie(&self) -> &Trie {
         &self.trie
+    }
+
+    /// Gets a clone of the `ContractStorage`` (which internally points to the same storage).
+    pub fn contract_storage(&self) -> ContractStorage {
+        self.contract_storage.clone()
     }
 
     pub fn get_ref(
@@ -243,6 +249,11 @@ impl TrieUpdate {
             }
         }
         fallback(&key)
+    }
+
+    /// Records deployment of a contract due to a deploy-contract action.
+    pub fn record_contract_deploy(&self, code: ContractCode) {
+        self.contract_storage.record_deploy(code);
     }
 
     /// Records an access to the contract code due to a function call.

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -643,7 +643,7 @@ pub(crate) fn action_deploy_contract(
     // Inform the `store::contract::Storage` about the new deploy (so that the `get` method can
     // return the contract before the contract is written out to the underlying storage as part of
     // the `TrieUpdate` commit.)
-    state_update.contract_storage.record_deploy(code);
+    state_update.record_contract_deploy(code);
     Ok(())
 }
 

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -2460,7 +2460,7 @@ impl<'a> ApplyProcessingState<'a> {
             Arc::clone(&self.apply_state.config),
             self.apply_state.cache.as_ref().map(|v| v.handle()),
             self.apply_state.current_protocol_version,
-            self.state_update.contract_storage.clone(),
+            self.state_update.contract_storage(),
         );
         ApplyProcessingReceiptState {
             pipeline_manager,
@@ -2649,7 +2649,7 @@ pub mod estimator {
             std::sync::Arc::clone(&apply_state.config),
             apply_state.cache.as_ref().map(|c| c.handle()),
             apply_state.current_protocol_version,
-            state_update.contract_storage.clone(),
+            state_update.contract_storage(),
         );
         Runtime {}.apply_action_receipt(
             state_update,

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -252,7 +252,7 @@ impl TrieViewer {
             Arc::clone(config),
             apply_state.cache.as_ref().map(|v| v.handle()),
             apply_state.current_protocol_version,
-            state_update.contract_storage.clone(),
+            state_update.contract_storage(),
         );
         let view_config = Some(ViewConfig { max_gas_burnt: self.max_gas_burnt_view });
         let contract = pipeline.get_contract(&receipt, account.code_hash(), 0, view_config.clone());


### PR DESCRIPTION
Extracted from #12416 since it is an unrelated change and preparation for future changes to use `ContractStorage` to set and get contract code.