### PR TITLE
refactor: remove get_epoch_sync_data and get_epoch_sync_data_hash from epoch manager

### DIFF
--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -869,25 +869,6 @@ impl EpochManagerAdapter for MockEpochManager {
         Ok(PROTOCOL_VERSION)
     }
 
-    fn get_epoch_sync_data(
-        &self,
-        _prev_epoch_last_block_hash: &CryptoHash,
-        _epoch_id: &EpochId,
-        _next_epoch_id: &EpochId,
-    ) -> Result<
-        (
-            Arc<BlockInfo>,
-            Arc<BlockInfo>,
-            Arc<BlockInfo>,
-            Arc<EpochInfo>,
-            Arc<EpochInfo>,
-            Arc<EpochInfo>,
-        ),
-        EpochError,
-    > {
-        Ok(Default::default())
-    }
-
     fn init_after_epoch_sync(
         &self,
         _store_update: &mut StoreUpdate,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -769,11 +769,31 @@ impl Client {
         };
 
         let epoch_sync_data_hash = if self.epoch_manager.is_next_block_epoch_start(&prev_hash)? {
-            Some(self.epoch_manager.get_epoch_sync_data_hash(
-                prev_block.hash(),
-                &epoch_id,
-                &next_epoch_id,
-            )?)
+            let last_block_info = self.epoch_manager.get_block_info(prev_block.hash())?;
+            let prev_epoch_id = *last_block_info.epoch_id();
+            let (
+                prev_epoch_first_block_info,
+                prev_epoch_prev_last_block_info,
+                prev_epoch_last_block_info,
+                prev_epoch_info,
+                cur_epoch_info,
+                next_epoch_info,
+            ) = (
+                self.epoch_manager.get_block_info(last_block_info.epoch_first_block())?,
+                self.epoch_manager.get_block_info(last_block_info.prev_hash())?,
+                last_block_info,
+                self.epoch_manager.get_epoch_info(&prev_epoch_id)?,
+                self.epoch_manager.get_epoch_info(&epoch_id)?,
+                self.epoch_manager.get_epoch_info(&next_epoch_id)?,
+            );
+            Some(CryptoHash::hash_borsh(&(
+                prev_epoch_first_block_info,
+                prev_epoch_prev_last_block_info,
+                prev_epoch_last_block_info,
+                prev_epoch_info,
+                cur_epoch_info,
+                next_epoch_info,
+            )))
         } else {
             None
         };

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -771,25 +771,17 @@ impl Client {
         let epoch_sync_data_hash = if self.epoch_manager.is_next_block_epoch_start(&prev_hash)? {
             let last_block_info = self.epoch_manager.get_block_info(prev_block.hash())?;
             let prev_epoch_id = *last_block_info.epoch_id();
-            let (
-                prev_epoch_first_block_info,
-                prev_epoch_prev_last_block_info,
-                prev_epoch_last_block_info,
-                prev_epoch_info,
-                cur_epoch_info,
-                next_epoch_info,
-            ) = (
-                self.epoch_manager.get_block_info(last_block_info.epoch_first_block())?,
-                self.epoch_manager.get_block_info(last_block_info.prev_hash())?,
-                last_block_info,
-                self.epoch_manager.get_epoch_info(&prev_epoch_id)?,
-                self.epoch_manager.get_epoch_info(&epoch_id)?,
-                self.epoch_manager.get_epoch_info(&next_epoch_id)?,
-            );
+            let prev_epoch_first_block_info =
+                self.epoch_manager.get_block_info(last_block_info.epoch_first_block())?;
+            let prev_epoch_prev_last_block_info =
+                self.epoch_manager.get_block_info(last_block_info.prev_hash())?;
+            let prev_epoch_info = self.epoch_manager.get_epoch_info(&prev_epoch_id)?;
+            let cur_epoch_info = self.epoch_manager.get_epoch_info(&epoch_id)?;
+            let next_epoch_info = self.epoch_manager.get_epoch_info(&next_epoch_id)?;
             Some(CryptoHash::hash_borsh(&(
                 prev_epoch_first_block_info,
                 prev_epoch_prev_last_block_info,
-                prev_epoch_last_block_info,
+                last_block_info,
                 prev_epoch_info,
                 cur_epoch_info,
                 next_epoch_info,

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -301,49 +301,6 @@ pub trait EpochManagerAdapter: Send + Sync {
     }
 
     // TODO #3488 this likely to be updated
-    /// Data that is necessary for prove Epochs in Epoch Sync.
-    fn get_epoch_sync_data(
-        &self,
-        prev_epoch_last_block_hash: &CryptoHash,
-        epoch_id: &EpochId,
-        next_epoch_id: &EpochId,
-    ) -> Result<
-        (
-            Arc<BlockInfo>,
-            Arc<BlockInfo>,
-            Arc<BlockInfo>,
-            Arc<EpochInfo>,
-            Arc<EpochInfo>,
-            Arc<EpochInfo>,
-        ),
-        EpochError,
-    >;
-
-    // TODO #3488 this likely to be updated
-    /// Hash that is necessary for prove Epochs in Epoch Sync.
-    fn get_epoch_sync_data_hash(
-        &self,
-        prev_epoch_last_block_hash: &CryptoHash,
-        epoch_id: &EpochId,
-        next_epoch_id: &EpochId,
-    ) -> Result<CryptoHash, EpochError> {
-        let (
-            prev_epoch_first_block_info,
-            prev_epoch_prev_last_block_info,
-            prev_epoch_last_block_info,
-            prev_epoch_info,
-            cur_epoch_info,
-            next_epoch_info,
-        ) = self.get_epoch_sync_data(prev_epoch_last_block_hash, epoch_id, next_epoch_id)?;
-        Ok(CryptoHash::hash_borsh(&(
-            prev_epoch_first_block_info,
-            prev_epoch_prev_last_block_info,
-            prev_epoch_last_block_info,
-            prev_epoch_info,
-            cur_epoch_info,
-            next_epoch_info,
-        )))
-    }
 
     fn is_chunk_producer_for_epoch(
         &self,
@@ -875,36 +832,6 @@ impl EpochManagerAdapter for EpochManagerHandle {
     ) -> Result<ProtocolVersion, EpochError> {
         let epoch_manager = self.read();
         Ok(epoch_manager.get_epoch_info(epoch_id)?.protocol_version())
-    }
-
-    // TODO #3488 this likely to be updated
-    fn get_epoch_sync_data(
-        &self,
-        prev_epoch_last_block_hash: &CryptoHash,
-        epoch_id: &EpochId,
-        next_epoch_id: &EpochId,
-    ) -> Result<
-        (
-            Arc<BlockInfo>,
-            Arc<BlockInfo>,
-            Arc<BlockInfo>,
-            Arc<EpochInfo>,
-            Arc<EpochInfo>,
-            Arc<EpochInfo>,
-        ),
-        EpochError,
-    > {
-        let epoch_manager = self.read();
-        let last_block_info = epoch_manager.get_block_info(prev_epoch_last_block_hash)?;
-        let prev_epoch_id = *last_block_info.epoch_id();
-        Ok((
-            epoch_manager.get_block_info(last_block_info.epoch_first_block())?,
-            epoch_manager.get_block_info(last_block_info.prev_hash())?,
-            last_block_info,
-            epoch_manager.get_epoch_info(&prev_epoch_id)?,
-            epoch_manager.get_epoch_info(epoch_id)?,
-            epoch_manager.get_epoch_info(next_epoch_id)?,
-        ))
     }
 
     fn init_after_epoch_sync(


### PR DESCRIPTION
The MR removes `get_epoch_sync_data` and `get_epoch_sync_data_hash` form the epoch manager trait inlines the code