### PR TITLE
refactor(resharding) - Removing ShardId Ord

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -4479,7 +4479,6 @@ impl Chain {
         for shard_info in shard_layout.shard_infos() {
             result_map.insert(shard_info.shard_index(), (shard_info.shard_id(), vec![]));
         }
-
         let mut cache = HashMap::new();
         for receipt in receipts {
             let &mut shard_id = cache

--- a/chain/network/src/peer_manager/tests/snapshot_hosts.rs
+++ b/chain/network/src/peer_manager/tests/snapshot_hosts.rs
@@ -449,7 +449,8 @@ async fn too_many_shards_truncate() {
     assert_eq!(info.shards.len(), MAX_SHARDS_PER_SNAPSHOT_HOST_INFO);
     for &shard_id in &info.shards {
         // Shard ids are taken from the original vector
-        assert!(shard_id < 2 * MAX_SHARDS_PER_SNAPSHOT_HOST_INFO as u64);
+        let shard_id: usize = shard_id.into();
+        assert!(shard_id < 2 * MAX_SHARDS_PER_SNAPSHOT_HOST_INFO);
     }
     // The shard_ids are sorted and unique (no two elements are equal, hence the < condition instead of <=)
     assert!(info.shards.windows(2).all(|twoelems| twoelems[0] < twoelems[1]));

--- a/core/primitives-core/src/types.rs
+++ b/core/primitives-core/src/types.rs
@@ -200,12 +200,6 @@ impl PartialEq<u64> for ShardId {
     }
 }
 
-impl PartialOrd<u64> for ShardId {
-    fn partial_cmp(&self, other: &u64) -> Option<std::cmp::Ordering> {
-        self.0.partial_cmp(other)
-    }
-}
-
 impl FromStr for ShardId {
     type Err = ParseIntError;
 

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -392,6 +392,7 @@ impl ShardLayout {
                 for &shard_id in shard_ids {
                     let prev = to_parent_shard_map.insert(shard_id, parent_shard_id);
                     assert!(prev.is_none(), "no shard should appear in the map twice");
+                    let shard_id: u64 = shard_id.into();
                     assert!(shard_id < num_shards, "shard id should be valid");
                 }
             }
@@ -1077,8 +1078,10 @@ mod tests {
             let s = String::from_utf8(s).unwrap();
             let account_id = s.to_lowercase().parse().unwrap();
             let shard_id = account_id_to_shard_id(&account_id, &shard_layout);
-            assert!(shard_id < num_shards);
             *shard_id_distribution.get_mut(&shard_id).unwrap() += 1;
+
+            let shard_id: u64 = shard_id.into();
+            assert!(shard_id < num_shards);
         }
         let expected_distribution: HashMap<ShardId, _> = [
             (ShardId::new(0), 247),

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -331,8 +331,9 @@ impl TrieKey {
                 let receiving_shard = *receiving_shard;
                 buf.push(col::BUFFERED_RECEIPT);
                 // Use  u16 for shard id to reduce depth in trie.
+                let receiving_shard: u64 = receiving_shard.into();
                 assert!(receiving_shard <= u16::MAX as u64, "Shard ID too big.");
-                let receiving_shard: u16 = receiving_shard.into();
+                let receiving_shard: u16 = receiving_shard as u16;
                 buf.extend(&receiving_shard.to_le_bytes());
                 buf.extend(&index.to_le_bytes());
             }
@@ -891,6 +892,7 @@ mod tests {
     fn test_shard_id_u16_optimization() {
         let shard_layout = ShardLayout::for_protocol_version(PROTOCOL_VERSION);
         let max_id = shard_layout.shard_ids().max().unwrap();
+        let max_id: u64 = max_id.into();
         assert!(
             max_id <= u16::MAX as u64,
             "buffered receipt trie key optimization broken, must fit in a u16"


### PR DESCRIPTION
The non-contiguous ShardIds should be treated as abritrary identifiers. In particular they should not be comparable. Removing the Ord implementation from this type. 

This is a follow up to #12419 where I found a bug caused by sorting receipts by shard id instead of shard index. 