### PR TITLE
feat(tests): add resharding chain fork tests

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -2066,8 +2066,8 @@ impl ClientActorInner {
         true
     }
 
-    /// Produces `num_blocks` number of blocks. 
-    /// 
+    /// Produces `num_blocks` number of blocks.
+    ///
     /// New blocks are placed on top of `prev_block_height`,
     /// if present, otherwise on top of current chain's head.
     /// The parameter `block_height` controls the new blocks' own height.
@@ -2076,7 +2076,7 @@ impl ClientActorInner {
         &mut self,
         num_blocks: BlockHeight,
         only_valid: bool,
-        block_height: Option<BlockHeight>, 
+        block_height: Option<BlockHeight>,
         prev_block_height: Option<BlockHeight>,
     ) {
         info!(target: "adversary", num_blocks, "Starting adversary blocks production");
@@ -2085,9 +2085,11 @@ impl ClientActorInner {
         } else {
             self.client.adv_produce_blocks = Some(AdvProduceBlocksMode::All);
         }
-        let start_height = block_height.unwrap_or_else(|| prev_block_height.unwrap_or_else(|| {
-            self.client.chain.mut_chain_store().get_latest_known().unwrap().height
-        }) + 1);
+        let start_height = block_height.unwrap_or_else(|| {
+            prev_block_height.unwrap_or_else(|| {
+                self.client.chain.mut_chain_store().get_latest_known().unwrap().height
+            }) + 1
+        });
         let signer = self.client.validator_signer.get();
         let mut blocks_produced = 0;
         for height in start_height.. {

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -401,6 +401,29 @@ pub enum AdvProduceChunksMode {
 }
 
 #[cfg(feature = "test_features")]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub enum AdvProduceBlockHeightSelection {
+    /// Place the new block on top of the latest known block. Block's height will be the next
+    /// integer.
+    NextHeightOnLatestKnown,
+    /// Place the new block on top of the latest known block. Block height is arbitrary.
+    SelectedHeightOnLatestKnown { produced_block_height: BlockHeight },
+    /// Place the new block on top of the current head. Block's height will be the next integer.
+    NextHeightOnCurrentHead,
+    /// Place the new block on top of current head. Block height is arbitrary.
+    SelectedHeightOnCurrentHead { produced_block_height: BlockHeight },
+    /// Place the new block on top of an existing block at height `base_block_height`. Block's
+    /// height will be the next integer.
+    NextHeightOnSelectedBlock { base_block_height: BlockHeight },
+    /// Place the new block on top of an existing block at height `base_block_height`. Block height
+    /// is arbitrary.
+    SelectedHeightOnSelectedBlock {
+        produced_block_height: BlockHeight,
+        base_block_height: BlockHeight,
+    },
+}
+
+#[cfg(feature = "test_features")]
 #[derive(actix::Message, Debug)]
 #[rtype(result = "Option<u64>")]
 pub enum NetworkAdversarialMessage {
@@ -430,7 +453,11 @@ impl Handler<NetworkAdversarialMessage> for ClientActorInner {
                 None
             }
             NetworkAdversarialMessage::AdvProduceBlocks(num_blocks, only_valid) => {
-                self.adv_produce_blocks_on(num_blocks, only_valid, None, None);
+                self.adv_produce_blocks_on(
+                    num_blocks,
+                    only_valid,
+                    AdvProduceBlockHeightSelection::NextHeightOnLatestKnown,
+                );
                 None
             }
             NetworkAdversarialMessage::AdvSwitchToHeight(height) => {
@@ -2068,44 +2095,64 @@ impl ClientActorInner {
 
     /// Produces `num_blocks` number of blocks.
     ///
-    /// New blocks are placed on top of `prev_block_height`,
-    /// if present, otherwise on top of current chain's head.
-    /// The parameter `block_height` controls the new blocks' own height.
+    /// The parameter `height_selection` governs the produced blocks' heights and what base block
+    /// height they are placed.
     #[cfg(feature = "test_features")]
     pub fn adv_produce_blocks_on(
         &mut self,
         num_blocks: BlockHeight,
         only_valid: bool,
-        block_height: Option<BlockHeight>,
-        prev_block_height: Option<BlockHeight>,
+        height_selection: AdvProduceBlockHeightSelection,
     ) {
+        use AdvProduceBlockHeightSelection::*;
+
         info!(target: "adversary", num_blocks, "Starting adversary blocks production");
         if only_valid {
             self.client.adv_produce_blocks = Some(AdvProduceBlocksMode::OnlyValid);
         } else {
             self.client.adv_produce_blocks = Some(AdvProduceBlocksMode::All);
         }
-        let start_height = block_height.unwrap_or_else(|| {
-            prev_block_height.unwrap_or_else(|| {
-                self.client.chain.mut_chain_store().get_latest_known().unwrap().height
-            }) + 1
-        });
+        let (start_height, prev_block_height) = match height_selection {
+            NextHeightOnLatestKnown => {
+                let latest_height =
+                    self.client.chain.mut_chain_store().get_latest_known().unwrap().height;
+                (latest_height + 1, latest_height)
+            }
+            SelectedHeightOnLatestKnown { produced_block_height } => (
+                produced_block_height,
+                self.client.chain.mut_chain_store().get_latest_known().unwrap().height,
+            ),
+            NextHeightOnCurrentHead => {
+                let head_height = self.client.chain.mut_chain_store().head().unwrap().height;
+                (head_height + 1, head_height)
+            }
+            SelectedHeightOnCurrentHead { produced_block_height } => {
+                (produced_block_height, self.client.chain.mut_chain_store().head().unwrap().height)
+            }
+            NextHeightOnSelectedBlock { base_block_height } => {
+                (base_block_height + 1, base_block_height)
+            }
+            SelectedHeightOnSelectedBlock { produced_block_height, base_block_height } => {
+                (produced_block_height, base_block_height)
+            }
+        };
+        let is_based_on_current_head =
+            prev_block_height == self.client.chain.mut_chain_store().head().unwrap().height;
         let signer = self.client.validator_signer.get();
         let mut blocks_produced = 0;
         for height in start_height.. {
-            let block: Option<Block> = match prev_block_height {
-                Some(prev_block_height) => {
-                    let prev_block_hash = self
-                        .client
-                        .chain
-                        .chain_store()
-                        .get_block_hash_by_height(prev_block_height)
-                        .expect("prev block should exist");
-                    self.client
-                        .produce_block_on(height, prev_block_hash)
-                        .expect("block should be produced")
-                }
-                None => self.client.produce_block(height).expect("block should be produced"),
+            let block: Option<Block> = if is_based_on_current_head {
+                self.client.produce_block(height).expect("block should be produced")
+            } else {
+                let prev_block_hash = self
+                    .client
+                    .chain
+                    .chain_store()
+                    .get_block_hash_by_height(prev_block_height)
+                    .expect("prev block should exist");
+                self.client
+                    .produce_block_on(height, prev_block_hash)
+                    .expect("block should be produced")
             };
             if only_valid && block == None {
                 continue;

--- a/chain/network/src/test_loop.rs
+++ b/chain/network/src/test_loop.rs
@@ -288,7 +288,7 @@ fn network_message_to_client_handler(
             None
         }
         NetworkRequests::StateRequestPart { .. } => None,
-
+        NetworkRequests::Challenge(_) => None,
         _ => Some(request),
     })
 }

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -151,12 +151,12 @@ impl TestReshardingParameters {
 fn fork_before_resharding_block(
     double_signing: bool,
 ) -> Box<dyn Fn(&mut TestLoopData, TestLoopDataHandle<ClientActorInner>)> {
-    let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let done = std::cell::Cell::new(false);
     Box::new(
         move |test_loop_data: &mut TestLoopData,
               client_handle: TestLoopDataHandle<ClientActorInner>| {
             // It must happen only for the first resharding block encountered.
-            if done.load(std::sync::atomic::Ordering::SeqCst) {
+            if done.get() {
                 return;
             }
 
@@ -185,7 +185,7 @@ fn fork_before_resharding_block(
                     Some(tip.height + 1)
                 };
                 client_actor.adv_produce_blocks_on(3, true, block_height, Some(tip.height - 1));
-                done.store(true, std::sync::atomic::Ordering::SeqCst);
+                done.set(true);
             }
         },
     )

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -148,7 +148,7 @@ impl TestReshardingParameters {
 
 // Returns a callable function that, when invoked inside a test loop iteration, can force the creation of a chain fork.
 #[cfg(feature = "test_features")]
-fn create_chain_fork(
+fn fork_before_resharding_block(
     double_signing: bool,
 ) -> Box<dyn Fn(&mut TestLoopData, TestLoopDataHandle<ClientActorInner>)> {
     let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -360,25 +360,25 @@ fn test_resharding_v3_drop_chunks_all() {
 #[test]
 #[ignore]
 #[cfg(feature = "test_features")]
-fn test_resharding_v3_fork_before_resharding_block() {
+fn test_resharding_v3_resharding_block_in_fork() {
     let mut params = TestReshardingParameters::default();
     let client = params.clients[0].clone();
     params = params
         .clients(vec![client.clone()])
         .block_and_chunk_producers(vec![client])
-        .loop_action(Some(create_chain_fork(false)));
+        .loop_action(Some(fork_before_resharding_block(false)));
     test_resharding_v3_base(params);
 }
 
 #[test]
 #[ignore]
 #[cfg(feature = "test_features")]
-fn test_resharding_v3_double_sign_reshading_block() {
+fn test_resharding_v3_double_sign_resharding_block() {
     let mut params = TestReshardingParameters::default();
     let client = params.clients[0].clone();
     params = params
         .clients(vec![client.clone()])
         .block_and_chunk_producers(vec![client])
-        .loop_action(Some(create_chain_fork(true)));
+        .loop_action(Some(fork_before_resharding_block(true)));
     test_resharding_v3_base(params);
 }

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -390,6 +390,7 @@ fn test_resharding_v3_drop_chunks_all() {
 }
 
 #[test]
+// TODO(resharding): fix nearcore and un-ignore this test
 #[ignore]
 #[cfg(feature = "test_features")]
 fn test_resharding_v3_resharding_block_in_fork() {
@@ -400,6 +401,9 @@ fn test_resharding_v3_resharding_block_in_fork() {
 }
 
 #[test]
+// TODO(resharding): fix nearcore and un-ignore this test
+// TODO(resharding): duplicate this test so that in one case resharding is performed on block
+//                   B(height=13) and in another case resharding is performed on block B'(height=13)
 #[ignore]
 #[cfg(feature = "test_features")]
 fn test_resharding_v3_double_sign_resharding_block() {

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -148,7 +148,9 @@ impl TestReshardingParameters {
 
 // Returns a callable function that, when invoked inside a test loop iteration, can force the creation of a chain fork.
 #[cfg(feature = "test_features")]
-fn create_chain_fork(double_signing: bool) -> Box<dyn Fn(&mut TestLoopData, TestLoopDataHandle<ClientActorInner>)> {
+fn create_chain_fork(
+    double_signing: bool,
+) -> Box<dyn Fn(&mut TestLoopData, TestLoopDataHandle<ClientActorInner>)> {
     let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
     Box::new(
         move |test_loop_data: &mut TestLoopData,


### PR DESCRIPTION
PR to add simple chain fork and block double signing tests to the existing resharding_v3 test loop.

The implementation is a bit hacky, but I couldn't find a better way.

- Refactored adversarial block production to extrapolate a method in `Client` with additional functionality.
- Ignoring `Challenge`s in test loop.
- Refactored `resharding_v3` test structure to pass more parameters to the base test scenario.
- Added an "hook" to execute arbitrary test code inside test loop iteration of `resharding_v3`.

Both tests fail at the moment. They seems to do trigger the behavior we want to test.

For forks consecutive resharding starts:
```
{block_hash=F5zmejS8RxnGwnJhtfH5JK4V5VbciBDrfJMwKuxpio1L block_height=13 parent_shard_uid=s1.v3}: memtrie: Freezing parent memtrie, creating children memtries... parent_shard_uid=s1.v3 children_shard_uids=[s2.v3, s3.v3]
...
{block_hash=9kPADkyL3uKKFfupzunTxXTTchu5ek4CZ5eeWyvxzken block_height=18 parent_shard_uid=s1.v3}: memtrie: Freezing parent memtrie, creating children memtries... parent_shard_uid=s1.v3 children_shard_uids=[s2.v3, s3.v3]
```

For double signing two resharding at the same height:
```
{block_hash=F5zmejS8RxnGwnJhtfH5JK4V5VbciBDrfJMwKuxpio1L block_height=13 parent_shard_uid=s1.v3}: memtrie: Freezing parent memtrie, creating children memtries... parent_shard_uid=s1.v3 children_shard_uids=[s2.v3, s3.v3]
...
{block_hash=EjweFJq1aekKSQKgZpMQ9sgNt6RrHYCADV91p7uLLUnv block_height=13 parent_shard_uid=s1.v3}: memtrie: Freezing parent memtrie, creating children memtries... parent_shard_uid=s1.v3 children_shard_uids=[s2.v3, s3.v3]
```