### PR TITLE
refactor: Simplify `get_epoch_config`

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -101,8 +101,7 @@ impl NightshadeRuntime {
         let runtime = Runtime::new();
         let trie_viewer = TrieViewer::new(trie_viewer_state_size_limit, max_gas_burnt_view);
         let flat_storage_manager = FlatStorageManager::new(store.flat_store());
-        let epoch_config =
-            epoch_manager.read().get_config_for_protocol_version(genesis_config.protocol_version);
+        let epoch_config = epoch_manager.read().get_epoch_config(genesis_config.protocol_version);
         let shard_uids: Vec<_> = epoch_config.shard_layout.shard_uids().collect();
         let tries = ShardTries::new(
             store.trie_store(),

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -608,7 +608,8 @@ impl EpochManagerAdapter for EpochManagerHandle {
 
     fn get_epoch_config(&self, epoch_id: &EpochId) -> Result<EpochConfig, EpochError> {
         let epoch_manager = self.read();
-        epoch_manager.get_epoch_config(epoch_id)
+        let protocol_version = self.get_epoch_info(epoch_id)?.protocol_version();
+        Ok(epoch_manager.get_epoch_config(protocol_version))
     }
 
     fn get_epoch_info(&self, epoch_id: &EpochId) -> Result<Arc<EpochInfo>, EpochError> {
@@ -623,7 +624,8 @@ impl EpochManagerAdapter for EpochManagerHandle {
 
     fn get_shard_config(&self, epoch_id: &EpochId) -> Result<ShardConfig, EpochError> {
         let epoch_manager = self.read();
-        let epoch_config = epoch_manager.get_epoch_config(epoch_id)?;
+        let protocol_version = self.get_epoch_info(epoch_id)?.protocol_version();
+        let epoch_config = epoch_manager.get_epoch_config(protocol_version);
         Ok(ShardConfig::new(epoch_config))
     }
 

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -969,8 +969,7 @@ pub(crate) fn print_epoch_analysis(
     // stored on disk.
     let mut next_epoch_info =
         epoch_heights_to_infos.get(&min_epoch_height.saturating_add(1)).unwrap().as_ref().clone();
-    let mut next_next_epoch_config =
-        epoch_manager.get_config_for_protocol_version(PROTOCOL_VERSION);
+    let mut next_next_epoch_config = epoch_manager.get_epoch_config(PROTOCOL_VERSION);
     let mut has_same_shard_layout;
     let mut epoch_protocol_version;
     let mut next_next_protocol_version;
@@ -1007,7 +1006,9 @@ pub(crate) fn print_epoch_analysis(
         let next_epoch_id = epoch_heights_to_ids.get(&next_epoch_height).unwrap();
         let next_next_epoch_id = epoch_heights_to_ids.get(&next_next_epoch_height).unwrap();
         let epoch_summary = epoch_heights_to_validator_infos.get(epoch_height).unwrap();
-        let next_epoch_config = epoch_manager.get_epoch_config(next_epoch_id).unwrap();
+        let next_epoch_config = epoch_manager.get_epoch_config(
+            epoch_manager.get_epoch_info(next_epoch_id).unwrap().protocol_version(),
+        );
         let original_next_next_protocol_version = epoch_summary.next_next_epoch_version;
 
         match mode {
@@ -1016,8 +1017,9 @@ pub(crate) fn print_epoch_analysis(
                 // about epochs.
                 next_epoch_info =
                     epoch_heights_to_infos.get(&next_epoch_height).unwrap().as_ref().clone();
-                next_next_epoch_config =
-                    epoch_manager.get_epoch_config(next_next_epoch_id).unwrap();
+                next_next_epoch_config = epoch_manager.get_epoch_config(
+                    epoch_manager.get_epoch_info(next_next_epoch_id).unwrap().protocol_version(),
+                );
                 has_same_shard_layout =
                     next_epoch_config.shard_layout == next_next_epoch_config.shard_layout;
                 epoch_protocol_version = epoch_info.protocol_version();


### PR DESCRIPTION
There are two versions of this function, one that looks up the `protocol_version` and can fail and the other that gets the `protocol_version` and does not fail.  This PR removes the first version and moves all uses to the second version.  This allows us to simplify some of the code and remove some error paths in the code.  