### PR TITLE
feat: add `tx_root` check for state witness `new_transactions`

### DIFF
--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -253,8 +253,16 @@ pub fn pre_validate_chunk_state_witness(
         RelaxedChunkValidation,
         current_protocol_version
     ) {
-        // Verify that all proposed transactions are valid.
         let new_transactions = &state_witness.new_transactions;
+        let (new_tx_root_from_state_witness, _) = merklize(&new_transactions);
+        let chunk_tx_root = state_witness.chunk_header.tx_root();
+        if new_tx_root_from_state_witness != chunk_tx_root {
+            return Err(Error::InvalidChunkStateWitness(format!(
+                "Witness new transactions root {:?} does not match chunk {:?}",
+                new_tx_root_from_state_witness, chunk_tx_root
+            )));
+        }
+        // Verify that all proposed transactions are valid.
         if !new_transactions.is_empty() {
             let transactions_validation_storage_config = RuntimeStorageConfig {
                 state_root: state_witness.chunk_header.prev_state_root(),


### PR DESCRIPTION
The same check as we already have for the `transactions` field.
See [zulip thread](https://near.zulipchat.com/#narrow/channel/308695-nearone.2Fprivate/topic/Missing.20.60tx_root.60.20check.20for.20state.20witness.20.60new_transactions.60) for more context.