### PR TITLE
fix: use epoch id from the witness when determining protocol version

### DIFF
--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -246,12 +246,12 @@ pub fn pre_validate_chunk_state_witness(
         )));
     }
 
-    let epoch_id = last_chunk_block.header().epoch_id();
-    let protocol_version = epoch_manager.get_epoch_protocol_version(&epoch_id)?;
+    let current_protocol_version =
+        epoch_manager.get_epoch_protocol_version(&state_witness.epoch_id)?;
     if !checked_feature!(
         "protocol_feature_relaxed_chunk_validation",
         RelaxedChunkValidation,
-        protocol_version
+        current_protocol_version
     ) {
         // Verify that all proposed transactions are valid.
         let new_transactions = &state_witness.new_transactions;
@@ -294,6 +294,7 @@ pub fn pre_validate_chunk_state_witness(
     }
 
     let main_transition_params = if last_chunk_block.header().is_genesis() {
+        let epoch_id = last_chunk_block.header().epoch_id();
         let shard_layout = epoch_manager.get_shard_layout(&epoch_id)?;
         let congestion_info = last_chunk_block
             .block_congestion_info()

--- a/core/primitives/src/stateless_validation/state_witness.rs
+++ b/core/primitives/src/stateless_validation/state_witness.rs
@@ -94,9 +94,6 @@ pub struct ChunkStateWitness {
     /// EpochId corresponds to the next block after chunk's previous block.
     /// This is effectively the output of EpochManager::get_epoch_id_from_prev_block
     /// with chunk_header.prev_block_hash().
-    /// This is needed to validate signature when the previous block is not yet
-    /// available on the validator side (aka orphan state witness).
-    // TODO(stateless_validation): Deprecate this field in the next version of the state witness.
     pub epoch_id: EpochId,
     /// The chunk header that this witness is for. While this is not needed
     /// to apply the state transition, it is needed for a chunk validator to


### PR DESCRIPTION
Currently we use epoch_id from the last block with non-missing chunk for that shard which is incorrect.