### PR TITLE
chore: deduplicate borsh dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,7 +675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0137a412059ef8c93654805c6639229cd2e21ecd9bdabe2be2a912f7bb819b5"
 dependencies = [
  "base64 0.21.0",
- "borsh 1.2.0",
+ "borsh",
  "bs58 0.5.1",
  "hex",
  "primitive-types 0.12.2",
@@ -1067,35 +1067,12 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
-dependencies = [
- "borsh-derive 0.9.3",
- "hashbrown 0.11.2",
-]
-
-[[package]]
-name = "borsh"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf617fabf5cdbdc92f774bfe5062d870f228b80056d41180797abf48bed4056e"
 dependencies = [
- "borsh-derive 1.2.1",
+ "borsh-derive",
  "cfg_aliases",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
-dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "syn 1.0.103",
 ]
 
 [[package]]
@@ -1110,28 +1087,6 @@ dependencies = [
  "quote",
  "syn 2.0.87",
  "syn_derive",
-]
-
-[[package]]
-name = "borsh-derive-internal"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.103",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.103",
 ]
 
 [[package]]
@@ -1488,7 +1443,7 @@ name = "cold-store-tool"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "borsh 1.2.0",
+ "borsh",
  "clap",
  "near-chain-configs",
  "near-epoch-manager",
@@ -2781,7 +2736,7 @@ dependencies = [
 name = "genesis-populate"
 version = "0.0.0"
 dependencies = [
- "borsh 1.2.0",
+ "borsh",
  "clap",
  "indicatif",
  "near-chain",
@@ -2881,15 +2836,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92c171d55b98633f4ed3860808f004099b36c1cc29c42cfc53aa8591b21efcf2"
 dependencies = [
  "crunchy",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash 0.7.8",
 ]
 
 [[package]]
@@ -3277,7 +3223,7 @@ dependencies = [
  "assert_matches",
  "aurora-engine-transactions",
  "aurora-engine-types",
- "borsh 1.2.0",
+ "borsh",
  "bytesize",
  "chrono",
  "clap",
@@ -3916,7 +3862,7 @@ version = "1.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d10d45a9c49c3e975c362cf4d1dc1d7b72a716b30394bea56ee2a8fb225f50b7"
 dependencies = [
- "borsh 1.2.0",
+ "borsh",
  "serde",
 ]
 
@@ -3933,7 +3879,7 @@ name = "near-amend-genesis"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "borsh 1.2.0",
+ "borsh",
  "clap",
  "near-chain-configs",
  "near-crypto",
@@ -3993,7 +3939,7 @@ version = "0.0.0"
 dependencies = [
  "actix",
  "assert_matches",
- "borsh 1.2.0",
+ "borsh",
  "bytesize",
  "chrono",
  "crossbeam-channel",
@@ -4081,7 +4027,7 @@ version = "0.0.0"
 dependencies = [
  "actix",
  "assert_matches",
- "borsh 1.2.0",
+ "borsh",
  "chrono",
  "derive-enum-from-into",
  "derive_more",
@@ -4125,7 +4071,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-trait",
- "borsh 1.2.0",
+ "borsh",
  "bytesize",
  "chrono",
  "cloud-storage",
@@ -4213,7 +4159,7 @@ version = "0.0.0"
 dependencies = [
  "blake2",
  "bolero",
- "borsh 1.2.0",
+ "borsh",
  "bs58 0.4.0",
  "curve25519-dalek",
  "derive_more",
@@ -4240,7 +4186,7 @@ name = "near-database-tool"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "borsh 1.2.0",
+ "borsh",
  "bytesize",
  "clap",
  "indicatif",
@@ -4283,7 +4229,7 @@ dependencies = [
 name = "near-epoch-manager"
 version = "0.0.0"
 dependencies = [
- "borsh 1.2.0",
+ "borsh",
  "chrono",
  "itertools",
  "near-cache",
@@ -4310,7 +4256,7 @@ name = "near-flat-storage"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "borsh 1.2.0",
+ "borsh",
  "clap",
  "near-chain",
  "near-chain-configs",
@@ -4482,7 +4428,7 @@ version = "0.0.0"
 dependencies = [
  "actix",
  "awc",
- "borsh 1.2.0",
+ "borsh",
  "futures",
  "near-actix-test-utils",
  "near-async",
@@ -4518,7 +4464,7 @@ dependencies = [
  "actix-rt",
  "anyhow",
  "async-trait",
- "borsh 1.2.0",
+ "borsh",
  "bs58 0.4.0",
  "clap",
  "ed25519-dalek",
@@ -4565,7 +4511,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "bolero",
- "borsh 1.2.0",
+ "borsh",
  "bytes",
  "bytesize",
  "chrono",
@@ -4650,7 +4596,7 @@ name = "near-parameters"
 version = "0.0.0"
 dependencies = [
  "assert_matches",
- "borsh 1.2.0",
+ "borsh",
  "clap",
  "enum-map",
  "insta",
@@ -4710,7 +4656,7 @@ dependencies = [
 name = "near-pool"
 version = "0.0.0"
 dependencies = [
- "borsh 1.2.0",
+ "borsh",
  "near-crypto",
  "near-o11y",
  "near-primitives",
@@ -4727,7 +4673,7 @@ dependencies = [
  "bencher",
  "bitvec",
  "bolero",
- "borsh 1.2.0",
+ "borsh",
  "bytes",
  "bytesize",
  "cfg-if 1.0.0",
@@ -4772,7 +4718,7 @@ version = "0.0.0"
 dependencies = [
  "arbitrary",
  "base64 0.21.0",
- "borsh 1.2.0",
+ "borsh",
  "bs58 0.4.0",
  "derive_more",
  "enum-map",
@@ -4793,7 +4739,7 @@ name = "near-replay-archive-tool"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "borsh 1.2.0",
+ "borsh",
  "clap",
  "itertools",
  "near-chain",
@@ -4898,7 +4844,7 @@ dependencies = [
  "actix",
  "actix-web",
  "anyhow",
- "borsh 1.2.0",
+ "borsh",
  "clap",
  "cloud-storage",
  "near-client",
@@ -4926,7 +4872,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "bencher",
- "borsh 1.2.0",
+ "borsh",
  "bytesize",
  "crossbeam",
  "derive-where",
@@ -5104,7 +5050,7 @@ dependencies = [
  "base64 0.21.0",
  "blst",
  "bolero",
- "borsh 1.2.0",
+ "borsh",
  "bytesize",
  "cov-mark",
  "csv",
@@ -5273,7 +5219,7 @@ dependencies = [
  "anyhow",
  "awc",
  "bencher",
- "borsh 1.2.0",
+ "borsh",
  "bytesize",
  "chrono",
  "cloud-storage",
@@ -5406,7 +5352,7 @@ name = "node-runtime"
 version = "0.0.0"
 dependencies = [
  "assert_matches",
- "borsh 1.2.0",
+ "borsh",
  "enum-map",
  "hex",
  "near-chain-configs",
@@ -5766,7 +5712,7 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
- "borsh 1.2.0",
+ "borsh",
  "num-traits",
  "rand",
  "serde",
@@ -6158,15 +6104,6 @@ dependencies = [
  "impl-serde",
  "scale-info",
  "uint",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml",
 ]
 
 [[package]]
@@ -6760,7 +6697,7 @@ name = "runtime-params-estimator"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "borsh 1.2.0",
+ "borsh",
  "bs58 0.4.0",
  "bytesize",
  "cfg-if 1.0.0",
@@ -7446,7 +7383,7 @@ dependencies = [
 name = "speedy_sync"
 version = "0.0.0"
 dependencies = [
- "borsh 1.2.0",
+ "borsh",
  "clap",
  "near-async",
  "near-chain",
@@ -7491,7 +7428,7 @@ version = "0.0.0"
 dependencies = [
  "actix",
  "anyhow",
- "borsh 1.2.0",
+ "borsh",
  "bytesize",
  "chrono",
  "clap",
@@ -8594,13 +8531,13 @@ dependencies = [
 
 [[package]]
 name = "wasmer-runtime-core-near"
-version = "0.18.3"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3fac37da3c625e98708c5dd92d3f642aaf700fd077168d3d0fff277ec6a165"
+checksum = "1fbac9b3eac2921f85f809bdd0b6cbe90f5ed154e10b5aeeb8cf3e0ba69c1b6f"
 dependencies = [
  "bincode",
  "blake3",
- "borsh 0.9.3",
+ "borsh",
  "cc",
  "digest 0.8.1",
  "errno 0.2.8",
@@ -8638,12 +8575,12 @@ dependencies = [
 
 [[package]]
 name = "wasmer-singlepass-backend-near"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6edd0ba6c0bcf9b279186d4dbe81649dda3e5ef38f586865943de4dcd653f8"
+checksum = "9358673d39c3b4a15374fba0536bfe5e50485e7c826de50d2dbef8c96df07674"
 dependencies = [
  "bincode",
- "borsh 0.9.3",
+ "borsh",
  "byteorder",
  "dynasm 1.2.3",
  "dynasmrt 1.2.3",

--- a/deny.toml
+++ b/deny.toml
@@ -95,11 +95,8 @@ skip = [
     { name = "semver-parser", version = "=0.7.0" },
     { name = "semver", version = "=0.9.0" },
 
-    # wasmer-runtime-core-near and parity-secp256k1 use an older version
+    # blake3 (through wasmer0) uses an older version
     { name = "arrayvec", version = "=0.5.2" },
-
-    # borsh uses a very old version of proc-macro-crate
-    { name = "proc-macro-crate", version = "=0.1.5" },
 
     # criterion and wasmer-runtime-core-near depend on this older
     # version of the crate.
@@ -107,7 +104,6 @@ skip = [
     { name = "errno", version = "=0.2.8" },
 
     # Bolero requires a newer version and the rest of the ecosystem hasn't caught up yet.
-    { name = "hashbrown", version = "0.11.0" },
     { name = "hashbrown", version = "0.12.0" },
     { name = "hashbrown", version = "0.13.2" },
     { name = "bitflags", version = "=1.3.2" },
@@ -118,12 +114,6 @@ skip = [
 
     # rust-s3 is using an old version of smartstring
     { name = "smartstring", version = "=0.2.10" },
-
-    # zeropool-bn uses borsh 0.9
-    { name = "borsh", version = "=0.9.3" },
-    { name = "borsh-derive", version = "=0.9.3" },
-    { name = "borsh-derive-internal", version = "=0.9.3" },
-    { name = "borsh-schema-derive-internal", version = "=0.9.3" },
 
     # near-test-contracts
     { name = "wasm-encoder", version = "=0.11.0" },


### PR DESCRIPTION
Somewhat of a spring cleaning thing to save a build of an entire borsh deptree. We don't use borsh serialization for wasmer0 purposes in nearcore, so there is no risk that something would change behaviourally.