### PR TITLE
refactor: remove unnecessary code and clarify some small code

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -216,10 +216,8 @@ impl NightshadeRuntime {
         prev_hash: &CryptoHash,
     ) -> Result<ShardUId, Error> {
         let epoch_manager = self.epoch_manager.read();
-        let epoch_id =
-            epoch_manager.get_epoch_id_from_prev_block(prev_hash).map_err(Error::from)?;
-        let shard_version =
-            epoch_manager.get_shard_layout(&epoch_id).map_err(Error::from)?.version();
+        let epoch_id = epoch_manager.get_epoch_id_from_prev_block(prev_hash)?;
+        let shard_version = epoch_manager.get_shard_layout(&epoch_id)?.version();
         Ok(ShardUId::new(shard_version, shard_id))
     }
 
@@ -229,8 +227,7 @@ impl NightshadeRuntime {
         epoch_id: &EpochId,
     ) -> Result<ShardUId, Error> {
         let epoch_manager = self.epoch_manager.read();
-        let shard_version =
-            epoch_manager.get_shard_layout(epoch_id).map_err(Error::from)?.version();
+        let shard_version = epoch_manager.get_shard_layout(epoch_id)?.version();
         Ok(ShardUId::new(shard_version, shard_id))
     }
 
@@ -240,7 +237,7 @@ impl NightshadeRuntime {
         epoch_id: &EpochId,
     ) -> Result<ShardUId, Error> {
         let epoch_manager = self.epoch_manager.read();
-        let shard_layout = epoch_manager.get_shard_layout(epoch_id).map_err(Error::from)?;
+        let shard_layout = epoch_manager.get_shard_layout(epoch_id)?;
         let shard_id = account_id_to_shard_id(account_id, &shard_layout);
         Ok(ShardUId::from_shard_id_and_layout(shard_id, &shard_layout))
     }

--- a/runtime/near-test-contracts/build.rs
+++ b/runtime/near-test-contracts/build.rs
@@ -111,16 +111,17 @@ fn cargo_build_cmd(target_dir: &Path) -> Command {
 
 fn check_status(mut cmd: Command) -> Result<(), Error> {
     println!("debug: running command: {cmd:?}");
-    cmd.status()
-        .map_err(|err| format!("command `{cmd:?}` failed to run: {err}"))
-        .and_then(|status| {
+    match cmd.status() {
+        Ok(status) => {
             if status.success() {
                 Ok(())
             } else {
                 Err(format!("command `{cmd:?}` exited with non-zero status: {status:?}"))
             }
-        })
-        .map_err(Error::from)
+        }
+        Err(err) => Err(format!("command `{cmd:?}` failed to run: {err}")),
+    }
+    .map_err(Error::from)
 }
 
 fn out_dir() -> std::path::PathBuf {


### PR DESCRIPTION
- Removes some unnecessary `map_err`
- Replaces some functional code with a simple `match` statement to improve readability.