### PR TITLE
moving slow tests to nayduck - bls12381

### DIFF
--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -73,6 +73,11 @@ rosetta_rpc = ["nearcore/rosetta_rpc"]
 json_rpc = ["nearcore/json_rpc"]
 protocol_feature_fix_staking_threshold = ["nearcore/protocol_feature_fix_staking_threshold"]
 protocol_feature_nonrefundable_transfer_nep491 = ["near-state-viewer/protocol_feature_nonrefundable_transfer_nep491"]
+# TODO - this is a hack to make neard compile with the prepare feature enabled.
+# This is required for nayduck to be able to build neard in the near-vm-runner
+# expensive tests suite. The build isn't actually used for those tests so it's
+# ok that it's not passed on to the near-vm-runner.
+prepare=[]
 
 nightly = [
   "near-chain-configs/nightly",

--- a/nightly/bls12381.txt
+++ b/nightly/bls12381.txt
@@ -1,0 +1,42 @@
+# bls12381 fuzzer tests
+
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_g1_multiexp_incorrect_input_fuzzer --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_g1_multiexp_invariants_checks_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_g1_multiexp_many_points_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_g1_multiexp_mul_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_g2_multiexp_incorrect_input_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_g2_multiexp_invariants_checks_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_g2_multiexp_many_points_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_g2_multiexp_mul_fuzzer  --features prepare
+
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_map_fp2_to_g2_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_map_fp2_to_g2_many_points_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_map_fp_to_g1_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_map_fp_to_g1_many_points_fuzzer  --features prepare
+
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_p1_crosscheck_sum_and_multiexp_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_p1_decompress_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_p1_decompress_incorrect_input_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_p1_decompress_many_points_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_p1_sum_edge_cases_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_p1_sum_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_p1_sum_incorrect_input_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_p1_sum_inverse_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_p1_sum_many_points_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_p1_sum_not_g1_points_fuzzer  --features prepare
+
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_p2_crosscheck_sum_and_multiexp_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_p2_decompress_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_p2_decompress_incorrect_input_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_p2_decompress_many_points_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_p2_sum_edge_cases_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_p2_sum_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_p2_sum_incorrect_input_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_p2_sum_inverse_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_p2_sum_many_points_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_p2_sum_not_g2_points_fuzzer  --features prepare
+
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_pairing_check_many_points_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_pairing_check_one_point_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_pairing_check_two_points_fuzzer  --features prepare
+expensive near-vm-runner near_vm_runner logic::tests::bls12381::tests::test_bls12381_pairing_incorrect_input_point_fuzzer  --features prepare

--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -231,3 +231,4 @@ expensive integration-tests integration_tests tests::nearcore::stake_nodes::test
 
 expensive integration-tests integration_tests tests::nearcore::track_shards::track_shards
 expensive integration-tests integration_tests tests::nearcore::track_shards::track_shards --features nightly
+

--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -231,4 +231,3 @@ expensive integration-tests integration_tests tests::nearcore::stake_nodes::test
 
 expensive integration-tests integration_tests tests::nearcore::track_shards::track_shards
 expensive integration-tests integration_tests tests::nearcore::track_shards::track_shards --features nightly
-

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -139,6 +139,7 @@ protocol_feature_fix_contract_loading_cost = [
 
 metrics = ["prometheus", "near-o11y"]
 
+expensive_tests = []
 
 nightly = [
   "near-o11y/nightly",

--- a/runtime/near-vm-runner/src/logic/tests/bls12381.rs
+++ b/runtime/near-vm-runner/src/logic/tests/bls12381.rs
@@ -424,6 +424,7 @@ mod tests {
             $test_bls12381_sum_incorrect_input:ident
         ) => {
             #[test]
+            #[cfg_attr(not(feature = "expensive_tests"), ignore)]
             fn $test_bls12381_sum_edge_cases() {
                 // 0 + 0
                 let zero = get_zero($GOp::POINT_LEN);
@@ -481,6 +482,7 @@ mod tests {
             }
 
             #[test]
+            #[cfg_attr(not(feature = "expensive_tests"), ignore)]
             fn $test_bls12381_sum() {
                 bolero::check!().with_type().for_each(|(p, q): &($EPoint, $EPoint)| {
                     $check_sum(p.p, q.p);
@@ -498,6 +500,7 @@ mod tests {
             }
 
             #[test]
+            #[cfg_attr(not(feature = "expensive_tests"), ignore)]
             fn $test_bls12381_sum_not_g_points() {
                 //points not from G
                 bolero::check!().with_type().for_each(|(p, q): &($EnotGPoint, $EnotGPoint)| {
@@ -506,6 +509,7 @@ mod tests {
             }
 
             #[test]
+            #[cfg_attr(not(feature = "expensive_tests"), ignore)]
             fn $test_bls12381_sum_inverse() {
                 let zero = get_zero($GOp::POINT_LEN);
 
@@ -541,6 +545,7 @@ mod tests {
             }
 
             #[test]
+            #[cfg_attr(not(feature = "expensive_tests"), ignore)]
             fn $test_bls12381_sum_many_points() {
                 let zero = get_zero($GOp::POINT_LEN);
                 //empty input
@@ -573,6 +578,7 @@ mod tests {
             }
 
             #[test]
+            #[cfg_attr(not(feature = "expensive_tests"), ignore)]
             fn $test_bls12381_crosscheck_sum_and_multiexp() {
                 bolero::check!()
                     .with_generator(
@@ -593,6 +599,7 @@ mod tests {
             }
 
             #[test]
+            #[cfg_attr(not(feature = "expensive_tests"), ignore)]
             fn $test_bls12381_sum_incorrect_input() {
                 bolero::check!().with_type().for_each(|p: &$EPoint| {
                     let mut test_vecs: Vec<Vec<Vec<u8>>> = $GOp::get_incorrect_points(p)
@@ -709,6 +716,7 @@ mod tests {
             $test_bls12381_error_encoding: ident
         ) => {
             #[test]
+            #[cfg_attr(not(feature = "expensive_tests"), ignore)]
             fn $test_bls12381_multiexp_mul() {
                 bolero::check!()
                     .with_generator((
@@ -734,6 +742,7 @@ mod tests {
             }
 
             #[test]
+            #[cfg_attr(not(feature = "expensive_tests"), ignore)]
             fn $test_bls12381_multiexp_many_points() {
                 bolero::check!()
                     .with_generator(
@@ -755,6 +764,7 @@ mod tests {
             }
 
             #[test]
+            #[cfg_attr(not(feature = "expensive_tests"), ignore)]
             fn $test_bls12381_multiexp_incorrect_input() {
                 let zero_scalar = vec![0u8; 32];
                 bolero::check!().with_type().for_each(|p: &$EPoint| {
@@ -776,6 +786,7 @@ mod tests {
             }
 
             #[test]
+            #[cfg_attr(not(feature = "expensive_tests"), ignore)]
             fn $test_bls12381_multiexp_invariants_checks() {
                 let zero1 = get_zero($GOp::POINT_LEN);
                 let r = Fr::from_str(R).unwrap();
@@ -883,6 +894,7 @@ mod tests {
             }
 
             #[test]
+            #[cfg_attr(not(feature = "expensive_tests"), ignore)]
             fn $test_bls12381_map_fp_to_g() {
                 bolero::check!().with_type().for_each(|fp: &$FP| {
                     $check_map_fp(fp.p);
@@ -890,6 +902,7 @@ mod tests {
             }
 
             #[test]
+            #[cfg_attr(not(feature = "expensive_tests"), ignore)]
             fn $test_bls12381_map_fp_to_g_many_points() {
                 bolero::check!()
                     .with_generator(bolero::gen::<Vec<$FP>>().with().len(0usize..=$GOp::MAX_N_MAP))
@@ -964,6 +977,7 @@ mod tests {
             $test_bls12381_decompress_incorrect_input:ident
         ) => {
             #[test]
+            #[cfg_attr(not(feature = "expensive_tests"), ignore)]
             fn $test_bls12381_decompress() {
                 bolero::check!().with_type().for_each(|p1: &$GPoint| {
                     let res1 = $GOp::decompress_p(vec![p1.p.clone()]);
@@ -984,6 +998,7 @@ mod tests {
             }
 
             #[test]
+            #[cfg_attr(not(feature = "expensive_tests"), ignore)]
             fn $test_bls12381_decompress_many_points() {
                 bolero::check!()
                     .with_generator(
@@ -1017,6 +1032,7 @@ mod tests {
             }
 
             #[test]
+            #[cfg_attr(not(feature = "expensive_tests"), ignore)]
             fn $test_bls12381_decompress_incorrect_input() {
                 // Incorrect encoding of the point at infinity
                 let mut zero = vec![0u8; $POINT_LEN];
@@ -1082,6 +1098,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "expensive_tests"), ignore)]
     fn test_bls12381_pairing_check_one_point_fuzzer() {
         bolero::check!().with_type().for_each(|(p1, p2): &(G1Point, G2Point)| {
             let zero1 = G1Affine::zero();
@@ -1098,6 +1115,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "expensive_tests"), ignore)]
     fn test_bls12381_pairing_check_two_points_fuzzer() {
         bolero::check!().with_type().for_each(
             |(p1, p2, s1, s2): &(G1Point, G2Point, Scalar, Scalar)| {
@@ -1134,6 +1152,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "expensive_tests"), ignore)]
     fn test_bls12381_pairing_check_many_points_fuzzer() {
         bolero::check!()
             .with_generator(
@@ -1180,6 +1199,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "expensive_tests"), ignore)]
     fn test_bls12381_pairing_incorrect_input_point_fuzzer() {
         bolero::check!().with_type().for_each(
             |(p1_not_from_g1, p2, p1, p2_not_from_g2, curve_p1, curve_p2): &(

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -31,6 +31,7 @@ pub(crate) fn with_vm_variants(
     #[allow(unused)] cfg: &near_parameters::vm::Config,
     runner: impl Fn(VMKind) -> (),
 ) {
+    #[allow(unused)]
     let run = move |kind| {
         println!("running test with {kind:?}");
         runner(kind)

--- a/scripts/nayduck.py
+++ b/scripts/nayduck.py
@@ -253,13 +253,16 @@ def run_locally(args, tests):
 
         if fields[0] == 'expensive':
             # TODO --test doesn't work
+            features = ['expensive_tests']
+            if fields[4] == '--features':
+                features.extend(fields[5].split(','))
             cmd = [
                 'cargo',
                 'test',
                 '-p',
                 fields[1],  # '--test', fields[2],
                 '--features',
-                'expensive_tests',
+                ','.join(features),
                 '--',
                 '--exact',
                 fields[3]


### PR DESCRIPTION
The bls fuzzer tests are really slow. This slows down and increases the cost of CI, and is generally annoying. Moving those to nayduck. 

* marked the bls fuzzer tests as expensive
* added them to nayduck

The tests are implemented as some crazy macros so I'm not exactly sure what I'm doing is right. 

Here are the tests when executed in nayduck - https://nayduck.nearone.org/#/run/705
I also checked that they can be run locally and it does with a small fix: `./scripts/nayduck.py -t nightly/bls12381.txt -l`

Due to some features fun I needed to hackily add `prepare` feature to neard. I'm looking for suggestion how to do it better. This is because nayduck actually builds neard with the same features as for the test. The neard binary is not used, the test is then run using cargo e.g.
```
cargo test -pnear-vm-runner --features prepare,test_features,expensive_tests -- --exact --nocapture logic::tests::bls12381::tests::test_bls12381_g1_multiexp_incorrect_input_fuzzer
```