### PR TITLE
Add congestion info script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,6 +1472,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "congestion-metrics"
+version = "0.0.0"
+dependencies = [
+ "actix",
+ "actix-rt",
+ "anyhow",
+ "clap",
+ "futures",
+ "near-actix-test-utils",
+ "near-chain",
+ "near-chain-configs",
+ "near-chunks",
+ "near-client",
+ "near-crypto",
+ "near-epoch-manager",
+ "near-jsonrpc",
+ "near-jsonrpc-client",
+ "near-network",
+ "near-o11y",
+ "near-performance-metrics",
+ "near-primitives",
+ "near-store",
+ "near-telemetry",
+ "near-time",
+ "nearcore",
+ "pin-project",
+ "rand",
+ "rayon",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "congestion-model"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ members = [
     "test-utils/testlib",
     "tools/database",
     "tools/chainsync-loadtest",
+    "tools/congestion-metrics",
     "tools/congestion-model",
     "tools/fork-network",
     "tools/indexer/example",

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -5,6 +5,9 @@ use near_jsonrpc_primitives::message::{from_slice, Message};
 use near_jsonrpc_primitives::types::changes::{
     RpcStateChangesInBlockByTypeRequest, RpcStateChangesInBlockByTypeResponse,
 };
+use near_jsonrpc_primitives::types::congestion::{
+    RpcCongestionLevelRequest, RpcCongestionLevelResponse,
+};
 use near_jsonrpc_primitives::types::transactions::{
     RpcTransactionResponse, RpcTransactionStatusRequest,
 };
@@ -232,6 +235,14 @@ impl JsonRpcClient {
         request: RpcStateChangesInBlockByTypeRequest,
     ) -> RpcRequest<RpcStateChangesInBlockByTypeResponse> {
         call_method(&self.client, &self.server_addr, "EXPERIMENTAL_changes", request)
+    }
+
+    #[allow(non_snake_case)]
+    pub fn EXPERIMENTAL_congestion_level(
+        &self,
+        request: RpcCongestionLevelRequest,
+    ) -> RpcRequest<RpcCongestionLevelResponse> {
+        call_method(&self.client, &self.server_addr, "EXPERIMENTAL_congestion_level", request)
     }
 
     #[allow(non_snake_case)]

--- a/debug_scripts/collect_congestion_info.py
+++ b/debug_scripts/collect_congestion_info.py
@@ -1,0 +1,121 @@
+import argparse
+import csv
+import requests
+import time
+
+from dataclasses import dataclass
+
+
+def get_block_with_retries(url, block_id, retries=3, delay=2):
+    payload = {
+        "jsonrpc": "2.0",
+        "id": "dontcare",
+        "method": "block",
+    }
+
+    payload["params"] = {
+        "block_id": block_id
+    } if block_id else {
+        "finality": "final"
+    }
+
+    for attempt in range(retries):
+        try:
+            response = requests.post(url, json=payload)
+            return response.json()['result']
+        except Exception as e:
+            if attempt < retries - 1:
+                print(
+                    f"Attempt {attempt + 1} failed: {e}. Retrying in {delay} seconds..."
+                )
+                time.sleep(delay)
+            else:
+                print(f"All {retries} attempts failed.")
+                raise e
+
+
+class SetURLFromChainID(argparse.Action):
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if values == 'mainnet':
+            setattr(namespace, 'url', 'https://archival-rpc.mainnet.near.org')
+        elif values == 'testnet':
+            setattr(namespace, 'url', 'https://archival-rpc.testnet.near.org')
+
+
+@dataclass(frozen=True)
+class ShardCongestionInfo:
+    allowed_shard: int
+    buffered_receipts_gas: int
+    delayed_receipts_gas: int
+    receipt_bytes: int
+
+
+@dataclass(frozen=True)
+class CongestionData:
+    block_id: int
+    congestion_info: [ShardCongestionInfo]
+
+
+def main(args):
+    start_block = get_block_with_retries(args.url, args.start_block_id)
+    end_block = get_block_with_retries(args.url, args.end_block_id)
+    current_block = end_block
+
+    with open(args.result_file, mode="w", newline="") as file:
+        writer = csv.writer(file)
+        # Write header
+        writer.writerow([
+            "block_id", "allowed_shard", "buffered_receipts_gas",
+            "delayed_receipts_gas", "receipt_bytes"
+        ])
+
+        while current_block["header"]["height"] >= start_block["header"][
+                "height"]:
+            if not current_block["header"]["height"] % 10:
+                print(current_block["header"]["height"])
+            for chunk in current_block["chunks"]:
+                shard_info = ShardCongestionInfo(**chunk["congestion_info"])
+                if args.shard_ids and shard_info.allowed_shard not in args.shard_ids:
+                    continue
+                writer.writerow([
+                    current_block["header"]["height"], shard_info.allowed_shard,
+                    shard_info.buffered_receipts_gas,
+                    shard_info.delayed_receipts_gas, shard_info.receipt_bytes
+                ])
+            current_block = get_block_with_retries(
+                args.url, current_block["header"]["prev_height"])
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Collect congestion data for a specific period.")
+    # Create a mutually exclusive group for chain_id and url
+    group = parser.add_mutually_exclusive_group(required=False)
+    group.add_argument("--url", help="RPC URL to query.")
+    group.add_argument(
+        "--chain_id",
+        choices=['mainnet', 'testnet'],
+        action=SetURLFromChainID,
+        help="Chain ID ('mainnet' or 'testnet'). Sets the RPC URL.")
+    parser.add_argument(
+        "--result_file",
+        default="congestion_data.csv",
+        help="Path to the output file (default: congestion_data.csv).")
+    parser.add_argument("--start_block_id",
+                        type=int,
+                        help="Starting block ID for congestion data.")
+    parser.add_argument(
+        "--end_block_id",
+        type=int,
+        default=0,
+        help=
+        "Ending block ID for congestion data (default: latest block at the invoke time)."
+    )
+    parser.add_argument(
+        "--shard_ids",
+        default=[],
+        help="List of shard IDs to query. Empty for all shards.")
+
+    args = parser.parse_args()
+    main(args)

--- a/tools/congestion-metrics/Cargo.toml
+++ b/tools/congestion-metrics/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "congestion-metrics"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+actix-rt.workspace = true
+actix.workspace = true
+anyhow.workspace = true
+clap.workspace = true
+futures.workspace = true
+pin-project.workspace = true
+rand.workspace = true
+rayon.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+
+near-actix-test-utils.workspace = true
+near-time.workspace = true
+near-chain.workspace = true
+near-chain-configs.workspace = true
+near-client.workspace = true
+near-crypto.workspace = true
+near-chunks.workspace = true
+near-epoch-manager.workspace = true
+near-jsonrpc.workspace = true
+near-jsonrpc-client.workspace = true
+near-network.workspace = true
+near-store.workspace = true
+near-o11y.workspace = true
+near-telemetry.workspace = true
+near-performance-metrics.workspace = true
+near-primitives.workspace = true
+nearcore.workspace = true
+
+[lints]
+workspace = true

--- a/tools/congestion-metrics/src/main.rs
+++ b/tools/congestion-metrics/src/main.rs
@@ -1,0 +1,46 @@
+use near_jsonrpc::primitives::types::chunks::ChunkReference;
+use near_jsonrpc::primitives::types::congestion::RpcCongestionLevelRequest;
+use near_jsonrpc_client::new_client;
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
+
+use near_primitives::types::{BlockId, BlockReference};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut file = File::create("data.csv").await?;
+    file.write_all(b"block_height,shard_id,congestion_level\n").await?;
+
+    let client = new_client("https://archival-rpc.mainnet.near.org");
+    let start_height: u64 = 133453990;
+    let end_height: u64 = 133454000;
+    let mut current_height = end_height;
+
+    while current_height >= start_height {
+        let block =
+            client.block(BlockReference::BlockId(BlockId::Height(current_height))).await.unwrap();
+        for chunk in block.chunks {
+            let congestion_level = client
+                .EXPERIMENTAL_congestion_level(RpcCongestionLevelRequest {
+                    chunk_reference: ChunkReference::BlockShardId {
+                        block_id: BlockId::Height(current_height),
+                        shard_id: chunk.shard_id,
+                    },
+                })
+                .await
+                .unwrap();
+            file.write_all(
+                format!(
+                    "{},{},{}\n",
+                    current_height, chunk.shard_id, congestion_level.congestion_level
+                )
+                .as_bytes(),
+            )
+            .await?;
+        }
+        current_height = block.header.prev_height.unwrap();
+    }
+
+    file.flush().await?;
+    Ok(())
+}


### PR DESCRIPTION
Add congestion info script. It collects all the data between the given interval, going from the end till start (because we have prev_height and we don't have next_height available)
The interval can be of any length, and the process can be stopped in the middle, all the collected data would be saved.

Attaching example of collected data, please share if this is enough for further investigation.
[congestion_data.csv](https://github.com/user-attachments/files/17750081/congestion_data.csv)