### PR TITLE
refactor our test separation and how we run them

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,24 +1,45 @@
+# By default tests should not take more than 5 seconds to execute and will get killed after 15
+# seconds.
+#
+# If that happens, instead of making the period longer here, change the test name to one of the
+# next test "speed tiers" by using `slow_test_` or `ultraslow_test` prefix for the test's name.
 [profile.default]
-slow-timeout = { period = "60s", terminate-after = 3, grace-period = "0s" }
+slow-timeout = { period = "5s", terminate-after = 3, grace-period = "1s" }
+default-filter = "not (test(/^(.*::slow_test|slow_test)/) | test(/^(.*::ultraslow_test|ultraslow_test)/))"
+final-status-level = "slow"
 
+# Tests that take a longer time to execute. `slow_test*` tests are given 1m30s to execute.
 [[profile.default.overrides]]
-filter = 'test(test_full_estimator)'
-slow-timeout = { period = "10m", terminate-after = 3 }
-retries = 0
-threads-required = 2
+filter = 'test(/^(.*::slow_test|slow_test)/)'
+slow-timeout = { period = "30s", terminate-after = 3, grace-period = "1s" }
+
+# Tests that take longer than the heat death of the universe of time to execute. Consider making
+# the test faster, but if you must `ultraslow_test*` tests are given 1h to execute. These are
+# generally left for nayduck to execute.
+[[profile.default.overrides]]
+filter = 'test(/^(.*::ultraslow_test|ultraslow_test)/)'
+slow-timeout = { period = "30m", terminate-after = 2, grace-period = "1s" }
+
 
 # Unfortunately no support for inheriting profiles yet:
 # https://github.com/nextest-rs/nextest/issues/387
 [profile.ci]
-slow-timeout = { period = "120s", terminate-after = 5 }
+slow-timeout = { period = "5s", terminate-after = 5, grace-period = "1s" }
+default-filter = "not test(/^(.*::ultraslow_test|ultraslow_test)/)"
 # Try a few times before failing the whole test suite on a potentially spurious tests.
 # The hope is that people will fix the spurious tests as they encounter them locally...
 retries = { backoff = "fixed", count = 3, delay = "1s" }
 failure-output = "final"
 fail-fast = false
 
+# Tests that take a longer time to execute. `slow_test*` tests are given 1m30s to execute.
 [[profile.ci.overrides]]
-filter = 'test(test_full_estimator)'
-slow-timeout = { period = "10m", terminate-after = 3 }
-retries = 0
-threads-required = 2
+filter = 'test(/^(.*::slow_test|slow_test)/)'
+slow-timeout = { period = "30s", terminate-after = 3, grace-period = "1s" }
+
+# Tests that take longer than the heat death of the universe of time to execute. Consider making
+# the test faster, but if you must `ultraslow_test*` tests are given 1h to execute. These are
+# generally left for nayduck to execute.
+[[profile.ci.overrides]]
+filter = 'test(/^(.*::ultraslow_test|ultraslow_test)/)'
+slow-timeout = { period = "30m", terminate-after = 2, grace-period = "1s" }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,10 +2,10 @@
 # seconds.
 #
 # If that happens, instead of making the period longer here, change the test name to one of the
-# next test "speed tiers" by using `slow_test_` or `ultraslow_test` prefix for the test's name.
+# next test "speed tiers" by using `slow_test_` or `ultra_slow_test` prefix for the test's name.
 [profile.default]
 slow-timeout = { period = "5s", terminate-after = 3, grace-period = "1s" }
-default-filter = "not (test(/^(.*::slow_test|slow_test)/) | test(/^(.*::ultraslow_test|ultraslow_test)/))"
+default-filter = "not (test(/^(.*::slow_test|slow_test)/) | test(/^(.*::ultra_slow_test|ultra_slow_test)/))"
 final-status-level = "slow"
 
 # Tests that take a longer time to execute. `slow_test*` tests are given 1m30s to execute.
@@ -14,10 +14,10 @@ filter = 'test(/^(.*::slow_test|slow_test)/)'
 slow-timeout = { period = "30s", terminate-after = 3, grace-period = "1s" }
 
 # Tests that take longer than the heat death of the universe of time to execute. Consider making
-# the test faster, but if you must `ultraslow_test*` tests are given 1h to execute. These are
+# the test faster, but if you must `ultra_slow_test*` tests are given 1h to execute. These are
 # generally left for nayduck to execute.
 [[profile.default.overrides]]
-filter = 'test(/^(.*::ultraslow_test|ultraslow_test)/)'
+filter = 'test(/^(.*::ultra_slow_test|ultra_slow_test)/)'
 slow-timeout = { period = "30m", terminate-after = 2, grace-period = "1s" }
 
 
@@ -25,7 +25,7 @@ slow-timeout = { period = "30m", terminate-after = 2, grace-period = "1s" }
 # https://github.com/nextest-rs/nextest/issues/387
 [profile.ci]
 slow-timeout = { period = "5s", terminate-after = 5, grace-period = "1s" }
-default-filter = "not test(/^(.*::ultraslow_test|ultraslow_test)/)"
+default-filter = "not test(/^(.*::ultra_slow_test|ultra_slow_test)/)"
 # Try a few times before failing the whole test suite on a potentially spurious tests.
 # The hope is that people will fix the spurious tests as they encounter them locally...
 retries = { backoff = "fixed", count = 3, delay = "1s" }
@@ -38,8 +38,8 @@ filter = 'test(/^(.*::slow_test|slow_test)/)'
 slow-timeout = { period = "30s", terminate-after = 3, grace-period = "1s" }
 
 # Tests that take longer than the heat death of the universe of time to execute. Consider making
-# the test faster, but if you must `ultraslow_test*` tests are given 1h to execute. These are
+# the test faster, but if you must `ultra_slow_test*` tests are given 1h to execute. These are
 # generally left for nayduck to execute.
 [[profile.ci.overrides]]
-filter = 'test(/^(.*::ultraslow_test|ultraslow_test)/)'
+filter = 'test(/^(.*::ultra_slow_test|ultra_slow_test)/)'
 slow-timeout = { period = "30m", terminate-after = 2, grace-period = "1s" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           tool: just,cargo-nextest,cargo-llvm-cov
 
       # Run the tests:
-      - run: mkdir -p coverage/profraw/{unit,integration,binaries}
+      - run: mkdir -p coverage/profraw/{unit,binaries}
       # - Run the unit tests, retrieving the coverage information
       - run: just codecov-ci "nextest-slow ${{ matrix.type }}"
       - run: mv coverage/codecov/{new,unit-${{matrix.id}}}.json
@@ -338,8 +338,6 @@ jobs:
         include:
           - type: unit
             profraws: unit
-          - type: integration
-            profraws: unit integration
     steps:
       - uses: actions/checkout@v4
         with:
@@ -413,21 +411,6 @@ jobs:
           files: unit-macos.json
           fail_ci_if_error: true
           flags: unittests,macos
-      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
-        with:
-          files: integration-linux.json
-          fail_ci_if_error: true
-          flags: integration-tests,linux
-      - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
-        with:
-          files: integration-linux-nightly.json
-          fail_ci_if_error: true
-          flags: integration-tests,linux-nightly
-      # - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
-      #   with:
-      #     files: integration-macos.json
-      #     fail_ci_if_error: true
-      #     flags: integration-tests,macos
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
           files: py-backward-compat.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,19 +27,16 @@ jobs:
             id: linux
             os: ubuntu-22.04-16core
             type: stable
-            runs_integ_tests: true
             upload_profraws: true
           - name: Linux Nightly
             id: linux-nightly
             os: ubuntu-22.04-16core
             type: nightly
-            runs_integ_tests: true
             upload_profraws: true
           - name: MacOS
             id: macos
             os: macos-latest-xlarge
             type: stable
-            runs_integ_tests: false
             # TODO: Currently only computing linux coverage, because the MacOS runners
             # have files at a different path and thus comes out duplicated.
             upload_profraws: false
@@ -55,16 +52,9 @@ jobs:
       # Run the tests:
       - run: mkdir -p coverage/profraw/{unit,integration,binaries}
       # - Run the unit tests, retrieving the coverage information
-      - run: just codecov-ci "nextest-unit ${{ matrix.type }}"
+      - run: just codecov-ci "nextest-slow ${{ matrix.type }}"
       - run: mv coverage/codecov/{new,unit-${{matrix.id}}}.json
       - run: mv coverage/profraw/{new,unit/${{matrix.id}}}.tar.zst
-      # - Run the integration tests, retrieving the coverage information
-      - run: just codecov-ci "nextest-integration ${{ matrix.type }}"
-        if: matrix.runs_integ_tests
-      - run: mv coverage/codecov/{new,integration-${{matrix.id}}}.json
-        if: matrix.runs_integ_tests
-      - run: mv coverage/profraw/{new,integration/${{matrix.id}}}.tar.zst
-        if: matrix.runs_integ_tests
 
       # Cleanup the target directory, leaving only stuff interesting to llvm-cov, and tarball it
       - run: just tar-bins-for-coverage-ci
@@ -463,7 +453,7 @@ jobs:
           files: py-upgradability.json
           fail_ci_if_error: true
           flags: pytests,upgradability,linux
-  
+
   windows_public_libraries_check:
     name: "Windows check for building public libraries"
     runs-on: "windows-latest"

--- a/Justfile
+++ b/Justfile
@@ -8,13 +8,7 @@ platform_excludes := if os() == "macos" {
 } else {
     ""
 }
-# On MacOS, not all structs are collected by `inventory`. Non-incremental build fixes that.
-# See https://github.com/dtolnay/inventory/issues/52.
-with_macos_incremental := if os() == "macos" {
-    "CARGO_INCREMENTAL=0"
-} else {
-    ""
-}
+
 nightly_flags := "--features nightly,test_features"
 public_libraries := "-p near-primitives -p near-crypto -p near-jsonrpc-primitives -p near-chain-configs -p near-primitives-core"
 
@@ -143,7 +137,10 @@ check-lychee:
              else { "Note: 'Too Many Requests' errors are allowed here but not in CI, set GITHUB_TOKEN to check them" } }}
 
 # check tools/protocol-schema-check/res/protocol_schema.toml
-check-protocol-schema: install-rustc-nightly
+# On MacOS, not all structs are collected by `inventory`. Non-incremental build fixes that.
+# See https://github.com/dtolnay/inventory/issues/52.
+protocol_schema_env := "CARGO_TARGET_DIR=" + justfile_directory() + "/target/schema-check RUSTC_BOOTSTRAP=1 RUSTFLAGS='--cfg enable_const_type_id' CARGO_INCREMENTAL=0"
+check-protocol-schema:
     # Below, we *should* have been used `cargo +nightly ...` instead of
     # `RUSTC_BOOTSTRAP=1`. However, the env var appears to be more stable.
     # `nightly` builds are updated daily and may be broken sometimes, e.g.

--- a/Justfile
+++ b/Justfile
@@ -1,8 +1,10 @@
 # FIXME: some of these tests don't work very well on MacOS at the moment. Should fix
 # them at earliest convenience :)
 # Also in addition to this, the `nextest-integration` test is currently disabled on macos
-with_macos_excludes := if os() == "macos" {
-    "--exclude node-runtime --exclude runtime-params-estimator --exclude near-network --exclude estimator-warehouse"
+platform_excludes := if os() == "macos" {
+    "--exclude node-runtime --exclude runtime-params-estimator --exclude near-network --exclude estimator-warehouse --exclude integration-tests"
+} else if os() == "windows" {
+    "--exclude node-runtime --exclude runtime-params-estimator --exclude near-network --exclude estimator-warehouse --exclude integration-tests"
 } else {
     ""
 }
@@ -39,46 +41,23 @@ test-ci *FLAGS: check-cargo-fmt \
 # tests that are as close to CI as possible, but not exactly the same code
 test-extra: check-lychee
 
-# all cargo tests, TYPE is "stable" or "nightly"
-nextest TYPE *FLAGS: (nextest-unit TYPE FLAGS) (nextest-integration TYPE FLAGS)
-
-# cargo unit tests, TYPE is "stable" or "nightly"
-nextest-unit TYPE *FLAGS:
-    RUSTFLAGS="-D warnings" \
+# all cargo tests,
+# TYPE is one of "stable", "nightly"
+nextest TYPE *FLAGS:
+    env RUSTFLAGS="-D warnings" \
     cargo nextest run \
         --locked \
         --workspace \
-        --exclude integration-tests \
         --cargo-profile dev-release \
         {{ ci_hack_nextest_profile }} \
-        {{ with_macos_excludes }} \
+        {{ platform_excludes }} \
         {{ if TYPE == "nightly" { nightly_flags } \
            else if TYPE == "stable" { "" } \
            else { error("TYPE is neighter 'nightly' nor 'stable'") } }} \
         {{ FLAGS }}
 
-# cargo integration tests, TYPE is "stable" or "nightly"
-[linux]
-nextest-integration TYPE *FLAGS:
-    RUSTFLAGS="-D warnings" \
-    cargo nextest run \
-        --locked \
-        --package integration-tests \
-        --cargo-profile dev-release \
-        {{ ci_hack_nextest_profile }} \
-        {{ if TYPE == "nightly" { nightly_flags } \
-           else if TYPE == "stable" { "" } \
-           else { error("TYPE is neither 'nightly' nor 'stable'") } }} \
-        {{ FLAGS }}
-# Note: when re-enabling this on macos, ci.yml will need to be adjusted to report code coverage again
-[macos]
-nextest-integration TYPE *FLAGS:
-    @echo "Nextest integration tests are currently disabled on macos!"
-
-[windows]
-nextest-integration TYPE *FLAGS:
-    @echo "Nextest integration tests are currently disabled on windows!"
-
+nextest-slow TYPE *FLAGS: (nextest TYPE "--ignore-default-filter -E 'default() + test(/^(.*::slow_test|slow_test)/)'" FLAGS)
+nextest-all TYPE *FLAGS: (nextest TYPE "--ignore-default-filter -E 'all()'" FLAGS)
 
 doctests:
     cargo test --doc
@@ -171,15 +150,8 @@ check-protocol-schema: install-rustc-nightly
     # https://github.com/rust-lang/rust/issues/130769.
     #
     # If there is an issue with the env var, fall back to `cargo +nightly ...`.
-
-    # Test that checker is not broken
-    RUSTC_BOOTSTRAP=1 RUSTFLAGS="--cfg enable_const_type_id" \
-        cargo test -p protocol-schema-check --profile dev-artifacts
-
-    # Run the checker
-    RUSTC_BOOTSTRAP=1 RUSTFLAGS="--cfg enable_const_type_id" \
-        {{ with_macos_incremental }} \
-        cargo run -p protocol-schema-check --profile dev-artifacts
+    env {{protocol_schema_env}} cargo test -p protocol-schema-check --profile dev-artifacts
+    env {{protocol_schema_env}} cargo run -p protocol-schema-check --profile dev-artifacts
 
 check_build_public_libraries:
     cargo check {{public_libraries}}

--- a/chain/chain/src/tests/doomslug.rs
+++ b/chain/chain/src/tests/doomslug.rs
@@ -284,8 +284,7 @@ fn one_iter(
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_fuzzy_doomslug_liveness_and_safety() {
+fn ultraslow_test_fuzzy_doomslug_liveness_and_safety() {
     for (time_to_gst_millis, height_goal) in
         &[(0, 200), (1000, 200), (10000, 300), (100000, 400), (500000, 500)]
     {

--- a/chain/chain/src/tests/doomslug.rs
+++ b/chain/chain/src/tests/doomslug.rs
@@ -284,7 +284,7 @@ fn one_iter(
 }
 
 #[test]
-fn ultraslow_test_fuzzy_doomslug_liveness_and_safety() {
+fn ultra_slow_test_fuzzy_doomslug_liveness_and_safety() {
     for (time_to_gst_millis, height_goal) in
         &[(0, 200), (1000, 200), (10000, 300), (100000, 400), (500000, 500)]
     {

--- a/chain/chain/src/tests/garbage_collection.rs
+++ b/chain/chain/src/tests/garbage_collection.rs
@@ -350,8 +350,7 @@ fn test_gc_remove_fork_small() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_gc_remove_fork_large() {
+fn ultraslow_test_gc_remove_fork_large() {
     test_gc_remove_fork_common(20)
 }
 
@@ -397,8 +396,7 @@ fn test_gc_not_remove_fork_small() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_gc_not_remove_fork_large() {
+fn ultraslow_test_gc_not_remove_fork_large() {
     test_gc_not_remove_fork_common(20)
 }
 
@@ -416,7 +414,7 @@ fn test_gc_not_remove_longer_fork() {
 
 // This test creates forks from genesis
 #[test]
-fn test_gc_forks_from_genesis() {
+fn slow_test_gc_forks_from_genesis() {
     for fork_length in 1..=10 {
         let chains = vec![
             SimpleChain { from: 0, length: 101, is_removed: false },
@@ -450,7 +448,7 @@ fn test_gc_forks_from_genesis() {
 }
 
 #[test]
-fn test_gc_overlap() {
+fn slow_test_gc_overlap() {
     for max_changes in 1..=20 {
         let chains = vec![
             SimpleChain { from: 0, length: 101, is_removed: false },
@@ -483,8 +481,7 @@ fn test_gc_boundaries_small() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_gc_boundaries_large() {
+fn ultraslow_test_gc_boundaries_large() {
     test_gc_boundaries_common(20)
 }
 
@@ -507,13 +504,12 @@ fn test_gc_random_common(runs: u64) {
 }
 
 #[test]
-fn test_gc_random_small() {
+fn slow_test_gc_random_small() {
     test_gc_random_common(3);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_gc_random_large() {
+fn ultraslow_test_gc_random_large() {
     test_gc_random_common(25);
 }
 
@@ -545,8 +541,7 @@ fn test_gc_pine_small() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_gc_pine() {
+fn ultraslow_test_gc_pine() {
     for max_changes in 1..=20 {
         let mut chains = vec![SimpleChain { from: 0, length: 101, is_removed: false }];
         for i in 1..100 {
@@ -578,8 +573,7 @@ fn test_gc_star_small() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_gc_star_large() {
+fn ultraslow_test_gc_star_large() {
     test_gc_star_common(20)
 }
 
@@ -834,9 +828,8 @@ fn test_clear_old_data_fixed_height() {
 
 /// Test that `gc_blocks_limit` works properly
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
 #[allow(unreachable_code)]
-fn test_clear_old_data_too_many_heights() {
+fn ultraslow_test_clear_old_data_too_many_heights() {
     // TODO(#10634): panics on `clear_data` -> `clear_resharding_data` ->
     // `MockEpochManager::is_next_block_epoch_start` apparently because
     // epoch manager is not updated at all. Should we fix it together with

--- a/chain/chain/src/tests/garbage_collection.rs
+++ b/chain/chain/src/tests/garbage_collection.rs
@@ -350,7 +350,7 @@ fn test_gc_remove_fork_small() {
 }
 
 #[test]
-fn ultraslow_test_gc_remove_fork_large() {
+fn ultra_slow_test_gc_remove_fork_large() {
     test_gc_remove_fork_common(20)
 }
 
@@ -396,7 +396,7 @@ fn test_gc_not_remove_fork_small() {
 }
 
 #[test]
-fn ultraslow_test_gc_not_remove_fork_large() {
+fn ultra_slow_test_gc_not_remove_fork_large() {
     test_gc_not_remove_fork_common(20)
 }
 
@@ -481,7 +481,7 @@ fn test_gc_boundaries_small() {
 }
 
 #[test]
-fn ultraslow_test_gc_boundaries_large() {
+fn ultra_slow_test_gc_boundaries_large() {
     test_gc_boundaries_common(20)
 }
 
@@ -509,7 +509,7 @@ fn slow_test_gc_random_small() {
 }
 
 #[test]
-fn ultraslow_test_gc_random_large() {
+fn ultra_slow_test_gc_random_large() {
     test_gc_random_common(25);
 }
 
@@ -541,7 +541,7 @@ fn test_gc_pine_small() {
 }
 
 #[test]
-fn ultraslow_test_gc_pine() {
+fn ultra_slow_test_gc_pine() {
     for max_changes in 1..=20 {
         let mut chains = vec![SimpleChain { from: 0, length: 101, is_removed: false }];
         for i in 1..100 {
@@ -573,7 +573,7 @@ fn test_gc_star_small() {
 }
 
 #[test]
-fn ultraslow_test_gc_star_large() {
+fn ultra_slow_test_gc_star_large() {
     test_gc_star_common(20)
 }
 
@@ -829,7 +829,7 @@ fn test_clear_old_data_fixed_height() {
 /// Test that `gc_blocks_limit` works properly
 #[test]
 #[allow(unreachable_code)]
-fn ultraslow_test_clear_old_data_too_many_heights() {
+fn ultra_slow_test_clear_old_data_too_many_heights() {
     // TODO(#10634): panics on `clear_data` -> `clear_resharding_data` ->
     // `MockEpochManager::is_next_block_epoch_start` apparently because
     // epoch manager is not updated at all. Should we fix it together with

--- a/chain/client/src/sync/header.rs
+++ b/chain/client/src/sync/header.rs
@@ -651,7 +651,7 @@ mod test {
     /// the peer doesn't get banned. (specifically, that the expected height downloaded gets properly
     /// adjusted for time passed)
     #[test]
-    fn test_slow_header_sync() {
+    fn slow_test_slow_header_sync() {
         let network_adapter = Arc::new(MockPeerManagerAdapter::default());
         let highest_height = 1000;
 
@@ -751,7 +751,7 @@ mod test {
     }
 
     #[test]
-    fn test_sync_from_very_behind() {
+    fn slow_test_sync_from_very_behind() {
         let mock_adapter = Arc::new(MockPeerManagerAdapter::default());
         let mut header_sync = HeaderSync::new(
             Clock::real(),

--- a/chain/client/src/tests/bug_repros.rs
+++ b/chain/client/src/tests/bug_repros.rs
@@ -30,7 +30,7 @@ use near_primitives::block::Block;
 use near_primitives::transaction::SignedTransaction;
 
 #[test]
-fn repro_1183() {
+fn slow_test_repro_1183() {
     init_test_logger();
     run_actix(async {
         let connectors: Arc<RwLock<Vec<ActorHandlesForTesting>>> = Arc::new(RwLock::new(vec![]));
@@ -169,7 +169,7 @@ fn repro_1183() {
 }
 
 #[test]
-fn test_sync_from_archival_node() {
+fn slow_test_sync_from_archival_node() {
     init_test_logger();
     let vs = ValidatorSchedule::new().num_shards(4).block_producers_per_epoch(vec![vec![
         "test1".parse().unwrap(),
@@ -279,7 +279,7 @@ fn test_sync_from_archival_node() {
 }
 
 #[test]
-fn test_long_gap_between_blocks() {
+fn slow_test_long_gap_between_blocks() {
     init_test_logger();
     let vs = ValidatorSchedule::new()
         .num_shards(2)

--- a/chain/client/src/tests/catching_up.rs
+++ b/chain/client/src/tests/catching_up.rs
@@ -108,7 +108,7 @@ pub struct StateRequestStruct {
 
 /// Sanity checks that the incoming and outgoing receipts are properly sent and received
 #[test]
-fn ultraslow_test_catchup_receipts_sync_third_epoch() {
+fn ultra_slow_test_catchup_receipts_sync_third_epoch() {
     test_catchup_receipts_sync_common(13, 1, false)
 }
 
@@ -120,17 +120,17 @@ fn ultraslow_test_catchup_receipts_sync_third_epoch() {
 /// The reason of increasing block_prod_time in the test is to allow syncing complete.
 /// Otherwise epochs will be changing faster than state sync happen.
 #[test]
-fn ultraslow_test_catchup_receipts_sync_hold() {
+fn ultra_slow_test_catchup_receipts_sync_hold() {
     test_catchup_receipts_sync_common(13, 1, true)
 }
 
 #[test]
-fn ultraslow_test_catchup_receipts_sync_last_block() {
+fn ultra_slow_test_catchup_receipts_sync_last_block() {
     test_catchup_receipts_sync_common(13, 5, false)
 }
 
 #[test]
-fn ultraslow_test_catchup_receipts_sync_distant_epoch() {
+fn ultra_slow_test_catchup_receipts_sync_distant_epoch() {
     test_catchup_receipts_sync_common(35, 1, false)
 }
 
@@ -380,7 +380,7 @@ enum RandomSinglePartPhases {
 /// assigned to were to have incorrect receipts, the balances in the fourth epoch would have
 /// been incorrect due to wrong receipts applied during the third epoch.
 #[test]
-fn ultraslow_test_catchup_random_single_part_sync() {
+fn ultra_slow_test_catchup_random_single_part_sync() {
     test_catchup_random_single_part_sync_common(false, false, 13)
 }
 
@@ -388,24 +388,24 @@ fn ultraslow_test_catchup_random_single_part_sync() {
 // It causes all the receipts to be applied only on height 16, which is the next epoch.
 // It tests that the incoming receipts are property synced through epochs
 #[test]
-fn ultraslow_test_catchup_random_single_part_sync_skip_15() {
+fn ultra_slow_test_catchup_random_single_part_sync_skip_15() {
     test_catchup_random_single_part_sync_common(true, false, 13)
 }
 
 #[test]
-fn ultraslow_test_catchup_random_single_part_sync_send_15() {
+fn ultra_slow_test_catchup_random_single_part_sync_send_15() {
     test_catchup_random_single_part_sync_common(false, false, 15)
 }
 
 // Make sure that transactions are at least applied.
 #[test]
-fn ultraslow_test_catchup_random_single_part_sync_non_zero_amounts() {
+fn ultra_slow_test_catchup_random_single_part_sync_non_zero_amounts() {
     test_catchup_random_single_part_sync_common(false, true, 13)
 }
 
 // Use another height to send txs.
 #[test]
-fn ultraslow_test_catchup_random_single_part_sync_height_6() {
+fn ultra_slow_test_catchup_random_single_part_sync_height_6() {
     test_catchup_random_single_part_sync_common(false, false, 6)
 }
 
@@ -607,7 +607,7 @@ fn test_catchup_random_single_part_sync_common(skip_15: bool, non_zero: bool, he
 /// This test would fail if at any point validators got stuck with state sync, or block
 /// production stalled for any other reason.
 #[test]
-fn ultraslow_test_catchup_sanity_blocks_produced() {
+fn ultra_slow_test_catchup_sanity_blocks_produced() {
     init_integration_logger();
     run_actix(async move {
         let connectors: Arc<RwLock<Vec<ActorHandlesForTesting>>> = Arc::new(RwLock::new(vec![]));
@@ -673,17 +673,17 @@ fn ultraslow_test_catchup_sanity_blocks_produced() {
 }
 
 #[test]
-fn ultraslow_test_all_chunks_accepted_1000() {
+fn ultra_slow_test_all_chunks_accepted_1000() {
     test_all_chunks_accepted_common(1000, 3000, 5)
 }
 
 #[test]
-fn ultraslow_test_all_chunks_accepted_1000_slow() {
+fn ultra_slow_test_all_chunks_accepted_1000_slow() {
     test_all_chunks_accepted_common(1000, 6000, 5)
 }
 
 #[test]
-fn ultraslow_test_all_chunks_accepted_1000_rare_epoch_changing() {
+fn ultra_slow_test_all_chunks_accepted_1000_rare_epoch_changing() {
     test_all_chunks_accepted_common(1000, 1500, 100)
 }
 

--- a/chain/client/src/tests/catching_up.rs
+++ b/chain/client/src/tests/catching_up.rs
@@ -108,8 +108,7 @@ pub struct StateRequestStruct {
 
 /// Sanity checks that the incoming and outgoing receipts are properly sent and received
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_catchup_receipts_sync_third_epoch() {
+fn ultraslow_test_catchup_receipts_sync_third_epoch() {
     test_catchup_receipts_sync_common(13, 1, false)
 }
 
@@ -121,20 +120,17 @@ fn test_catchup_receipts_sync_third_epoch() {
 /// The reason of increasing block_prod_time in the test is to allow syncing complete.
 /// Otherwise epochs will be changing faster than state sync happen.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_catchup_receipts_sync_hold() {
+fn ultraslow_test_catchup_receipts_sync_hold() {
     test_catchup_receipts_sync_common(13, 1, true)
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_catchup_receipts_sync_last_block() {
+fn ultraslow_test_catchup_receipts_sync_last_block() {
     test_catchup_receipts_sync_common(13, 5, false)
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_catchup_receipts_sync_distant_epoch() {
+fn ultraslow_test_catchup_receipts_sync_distant_epoch() {
     test_catchup_receipts_sync_common(35, 1, false)
 }
 
@@ -384,8 +380,7 @@ enum RandomSinglePartPhases {
 /// assigned to were to have incorrect receipts, the balances in the fourth epoch would have
 /// been incorrect due to wrong receipts applied during the third epoch.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_catchup_random_single_part_sync() {
+fn ultraslow_test_catchup_random_single_part_sync() {
     test_catchup_random_single_part_sync_common(false, false, 13)
 }
 
@@ -393,28 +388,24 @@ fn test_catchup_random_single_part_sync() {
 // It causes all the receipts to be applied only on height 16, which is the next epoch.
 // It tests that the incoming receipts are property synced through epochs
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_catchup_random_single_part_sync_skip_15() {
+fn ultraslow_test_catchup_random_single_part_sync_skip_15() {
     test_catchup_random_single_part_sync_common(true, false, 13)
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_catchup_random_single_part_sync_send_15() {
+fn ultraslow_test_catchup_random_single_part_sync_send_15() {
     test_catchup_random_single_part_sync_common(false, false, 15)
 }
 
 // Make sure that transactions are at least applied.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_catchup_random_single_part_sync_non_zero_amounts() {
+fn ultraslow_test_catchup_random_single_part_sync_non_zero_amounts() {
     test_catchup_random_single_part_sync_common(false, true, 13)
 }
 
 // Use another height to send txs.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_catchup_random_single_part_sync_height_6() {
+fn ultraslow_test_catchup_random_single_part_sync_height_6() {
     test_catchup_random_single_part_sync_common(false, false, 6)
 }
 
@@ -616,8 +607,7 @@ fn test_catchup_random_single_part_sync_common(skip_15: bool, non_zero: bool, he
 /// This test would fail if at any point validators got stuck with state sync, or block
 /// production stalled for any other reason.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_catchup_sanity_blocks_produced() {
+fn ultraslow_test_catchup_sanity_blocks_produced() {
     init_integration_logger();
     run_actix(async move {
         let connectors: Arc<RwLock<Vec<ActorHandlesForTesting>>> = Arc::new(RwLock::new(vec![]));
@@ -683,20 +673,17 @@ fn test_catchup_sanity_blocks_produced() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_all_chunks_accepted_1000() {
+fn ultraslow_test_all_chunks_accepted_1000() {
     test_all_chunks_accepted_common(1000, 3000, 5)
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_all_chunks_accepted_1000_slow() {
+fn ultraslow_test_all_chunks_accepted_1000_slow() {
     test_all_chunks_accepted_common(1000, 6000, 5)
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_all_chunks_accepted_1000_rare_epoch_changing() {
+fn ultraslow_test_all_chunks_accepted_1000_rare_epoch_changing() {
     test_all_chunks_accepted_common(1000, 1500, 100)
 }
 

--- a/chain/client/src/tests/consensus.rs
+++ b/chain/client/src/tests/consensus.rs
@@ -23,7 +23,7 @@ use near_primitives::types::{AccountId, BlockHeight};
 /// Periodically verify finality is not violated.
 /// This test is designed to reproduce finality bugs on the epoch boundaries.
 #[test]
-fn ultraslow_test_consensus_with_epoch_switches() {
+fn ultra_slow_test_consensus_with_epoch_switches() {
     init_integration_logger();
 
     const HEIGHT_GOAL: u64 = 120;

--- a/chain/client/src/tests/consensus.rs
+++ b/chain/client/src/tests/consensus.rs
@@ -23,8 +23,7 @@ use near_primitives::types::{AccountId, BlockHeight};
 /// Periodically verify finality is not violated.
 /// This test is designed to reproduce finality bugs on the epoch boundaries.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_consensus_with_epoch_switches() {
+fn ultraslow_test_consensus_with_epoch_switches() {
     init_integration_logger();
 
     const HEIGHT_GOAL: u64 = 120;

--- a/chain/client/src/tests/cross_shard_tx.rs
+++ b/chain/client/src/tests/cross_shard_tx.rs
@@ -557,34 +557,29 @@ fn test_cross_shard_tx_common(
 /// Doesn't drop chunks, disabled doomslug, no validator rotation (each epoch
 /// has the same set of validators).
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_cross_shard_tx() {
+fn ultraslow_test_cross_shard_tx() {
     test_cross_shard_tx_common(64, false, false, false, 70, Some(2.3), None);
 }
 
 /// Same as above, but doomslug is enabled.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_cross_shard_tx_doomslug() {
+fn ultraslow_test_cross_shard_tx_doomslug() {
     test_cross_shard_tx_common(64, false, false, true, 200, None, Some(1.5));
 }
 
 /// Same as the first one but the chunks are sometimes dropped.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_cross_shard_tx_drop_chunks() {
+fn ultraslow_test_cross_shard_tx_drop_chunks() {
     test_cross_shard_tx_common(64, false, true, false, 250, None, None);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_cross_shard_tx_8_iterations() {
+fn ultraslow_test_cross_shard_tx_8_iterations() {
     test_cross_shard_tx_common(8, false, false, false, 200, Some(2.4), None);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_cross_shard_tx_8_iterations_drop_chunks() {
+fn ultraslow_test_cross_shard_tx_8_iterations_drop_chunks() {
     test_cross_shard_tx_common(8, false, true, false, 200, Some(2.4), None);
 }
 
@@ -594,13 +589,11 @@ fn test_cross_shard_tx_8_iterations_drop_chunks() {
 /// the allocated time. (the one with lower block production time is expected to
 /// finish fewer because it has higher forkfulness).
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_cross_shard_tx_with_validator_rotation_1() {
+fn ultraslow_test_cross_shard_tx_with_validator_rotation_1() {
     test_cross_shard_tx_common(8, true, false, false, 220, Some(2.4), None);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_cross_shard_tx_with_validator_rotation_2() {
+fn ultraslow_test_cross_shard_tx_with_validator_rotation_2() {
     test_cross_shard_tx_common(24, true, false, false, 400, Some(2.4), None);
 }

--- a/chain/client/src/tests/cross_shard_tx.rs
+++ b/chain/client/src/tests/cross_shard_tx.rs
@@ -557,29 +557,29 @@ fn test_cross_shard_tx_common(
 /// Doesn't drop chunks, disabled doomslug, no validator rotation (each epoch
 /// has the same set of validators).
 #[test]
-fn ultraslow_test_cross_shard_tx() {
+fn ultra_slow_test_cross_shard_tx() {
     test_cross_shard_tx_common(64, false, false, false, 70, Some(2.3), None);
 }
 
 /// Same as above, but doomslug is enabled.
 #[test]
-fn ultraslow_test_cross_shard_tx_doomslug() {
+fn ultra_slow_test_cross_shard_tx_doomslug() {
     test_cross_shard_tx_common(64, false, false, true, 200, None, Some(1.5));
 }
 
 /// Same as the first one but the chunks are sometimes dropped.
 #[test]
-fn ultraslow_test_cross_shard_tx_drop_chunks() {
+fn ultra_slow_test_cross_shard_tx_drop_chunks() {
     test_cross_shard_tx_common(64, false, true, false, 250, None, None);
 }
 
 #[test]
-fn ultraslow_test_cross_shard_tx_8_iterations() {
+fn ultra_slow_test_cross_shard_tx_8_iterations() {
     test_cross_shard_tx_common(8, false, false, false, 200, Some(2.4), None);
 }
 
 #[test]
-fn ultraslow_test_cross_shard_tx_8_iterations_drop_chunks() {
+fn ultra_slow_test_cross_shard_tx_8_iterations_drop_chunks() {
     test_cross_shard_tx_common(8, false, true, false, 200, Some(2.4), None);
 }
 
@@ -589,11 +589,11 @@ fn ultraslow_test_cross_shard_tx_8_iterations_drop_chunks() {
 /// the allocated time. (the one with lower block production time is expected to
 /// finish fewer because it has higher forkfulness).
 #[test]
-fn ultraslow_test_cross_shard_tx_with_validator_rotation_1() {
+fn ultra_slow_test_cross_shard_tx_with_validator_rotation_1() {
     test_cross_shard_tx_common(8, true, false, false, 220, Some(2.4), None);
 }
 
 #[test]
-fn ultraslow_test_cross_shard_tx_with_validator_rotation_2() {
+fn ultra_slow_test_cross_shard_tx_with_validator_rotation_2() {
     test_cross_shard_tx_common(24, true, false, false, 400, Some(2.4), None);
 }

--- a/chain/jsonrpc/jsonrpc-tests/tests/rpc_query.rs
+++ b/chain/jsonrpc/jsonrpc-tests/tests/rpc_query.rs
@@ -578,7 +578,7 @@ fn test_parse_error_status_code() {
 }
 
 #[test]
-fn test_bad_handler_error_status_code() {
+fn slow_test_bad_handler_error_status_code() {
     test_with_client!(test_utils::NodeType::NonValidator, client, async move {
         let json = serde_json::json!({
             "jsonrpc": "2.0",

--- a/chain/network/src/peer/tests/rate_limits.rs
+++ b/chain/network/src/peer/tests/rate_limits.rs
@@ -49,7 +49,7 @@ async fn test_message_rate_limits() -> anyhow::Result<()> {
 #[tokio::test]
 // Verifies that peer traffic is not rate limited when messages are sent at regular intervals,
 // and the total number of messages is below the limit.
-async fn test_message_rate_limits_over_time() -> anyhow::Result<()> {
+async fn slow_test_message_rate_limits_over_time() -> anyhow::Result<()> {
     init_test_logger();
     tracing::info!("test_message_rate_limits_over_time");
 

--- a/chain/network/src/peer_manager/tests/accounts_data.rs
+++ b/chain/network/src/peer_manager/tests/accounts_data.rs
@@ -165,7 +165,7 @@ async fn gradual_epoch_change() {
 // - 3rd 5 and 4th 5 ...
 // All of them are validators.
 #[tokio::test(flavor = "multi_thread")]
-async fn rate_limiting() {
+async fn slow_test_rate_limiting() {
     init_test_logger();
     // Adjust the file descriptors limit, so that we can create many connection in the test.
     const MAX_CONNECTIONS: usize = 300;

--- a/chain/network/src/peer_manager/tests/connection_pool.rs
+++ b/chain/network/src/peer_manager/tests/connection_pool.rs
@@ -19,7 +19,7 @@ use near_primitives::version::PROTOCOL_VERSION;
 use std::sync::Arc;
 
 #[tokio::test]
-async fn connection_spam_security_test() {
+async fn slow_test_connection_spam_security_test() {
     init_test_logger();
     let mut rng = make_rng(921853233);
     let rng = &mut rng;

--- a/chain/network/src/peer_manager/tests/fuzzers.rs
+++ b/chain/network/src/peer_manager/tests/fuzzers.rs
@@ -45,7 +45,7 @@ async fn random_handshake_connect(input: &[u8]) {
 }
 
 #[test]
-fn random_handshake_connect_fuzzer() {
+fn slow_test_random_handshake_connect_fuzzer() {
     // init_test_logger(); // Enable only when reproducing a failure, to avoid slowing down the fuzzers too much
     bolero::check!().for_each(|input| in_tokio(random_handshake_connect(input)))
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 codecov:
   notify:
-    after_n_builds: 10 # Keep in sync with .github/workflows/ci.yml
+    after_n_builds: 8 # Keep in sync with .github/workflows/ci.yml
   # Dear h4xx0rz reading this,
   # Feel free to use this token to upload arbitrary coverage information to codecov.
   # We do not care. The best you can do is make us facepalm.

--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -362,7 +362,7 @@ mod tests {
     }
 
     #[test]
-    fn test_memtrie_rand_large_data() {
+    fn slow_test_memtrie_rand_large_data() {
         check_random(32, 100000, 1);
     }
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -269,11 +269,11 @@ changes.
 Not all tests are created equal though and while some may only need
 milliseconds to run, others may run for several seconds or even
 minutes.  Tests that take a long time should be marked as such by
-prefixing their name with `slow_test_` or `ultraslow_test_`:
+prefixing their name with `slow_test_` or `ultra_slow_test_`:
 
 ```rust
 #[test]
-fn ultraslow_test_catchup_random_single_part_sync() {
+fn ultra_slow_test_catchup_random_single_part_sync() {
     test_catchup_random_single_part_sync_common(false, false, 13)
 }
 ```
@@ -281,14 +281,14 @@ fn ultraslow_test_catchup_random_single_part_sync() {
 During local development both slow and ultra-slow tests will not run
 with a typical `just nextest` invocation. You can run them with `just
 nextest-slow` or `just nextest-all` locally. CI will run the slow
-tests and the ultraslow ones are left to run on Nayduck.
+tests and the `ultra_slow` ones are left to run on Nayduck.
 
-Because ultraslow tests are run on nayduck, they need to be explicitly
+Because `ultra_slow` tests are run on nayduck, they need to be explicitly
 included in `nightly/expensive.txt` file; for example:
 
 ```text
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_random_single_part_sync
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_random_single_part_sync --features nightly
 ```
 
 For more details regarding nightly tests see `nightly/README.md`.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -268,35 +268,30 @@ changes.
 
 Not all tests are created equal though and while some may only need
 milliseconds to run, others may run for several seconds or even
-minutes.  Tests that take a long time should be marked as such with an
-`expensive_tests` feature, for example:
+minutes.  Tests that take a long time should be marked as such by
+prefixing their name with `slow_test_` or `ultraslow_test_`:
 
 ```rust
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_catchup_random_single_part_sync() {
+fn ultraslow_test_catchup_random_single_part_sync() {
     test_catchup_random_single_part_sync_common(false, false, 13)
 }
 ```
 
-Such tests will be ignored by default and can be executed by using
-`--ignored` or `--include-ignored` flag as in `cargo test --
---ignored` or by compiling the tests with `expensive_tests` feature
-enabled.
+During local development both slow and ultra-slow tests will not run
+with a typical `just nextest` invocation. You can run them with `just
+nextest-slow` or `just nextest-all` locally. CI will run the slow
+tests and the ultraslow ones are left to run on Nayduck.
 
-Because expensive tests are not run by default, they are also not run
-in CI.  Instead, they are run nightly and need to be explicitly
+Because ultraslow tests are run on nayduck, they need to be explicitly
 included in `nightly/expensive.txt` file; for example:
 
 ```text
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync --features nightly
 ```
 
 For more details regarding nightly tests see `nightly/README.md`.
 
-Note that what counts as a slow test isn’t exactly defined as of now.
-If it takes just a couple seconds then it’s probably fine.  Anything
-slower should probably be classified as an expensive test.  In
-particular, if libtest complains the test takes more than 60 seconds
-then it definitely is an expensive test.
+Note that what counts as a slow test is defined in
+`.config/nextest.toml`.

--- a/integration-tests/src/test_loop/tests/chunk_validator_kickout.rs
+++ b/integration-tests/src/test_loop/tests/chunk_validator_kickout.rs
@@ -137,7 +137,7 @@ fn run_test_chunk_validator_kickout(accounts: Vec<AccountId>, test_case: TestCas
 
 /// Checks that chunk validator with low endorsement stats is kicked out when the chunks it would validate are all dropped.
 #[test]
-fn test_chunk_validator_kicked_out_when_chunks_dropped() {
+fn slow_test_chunk_validator_kicked_out_when_chunks_dropped() {
     let accounts = create_accounts();
     let test_case = TestCase::DropChunksValidatedBy(accounts[NUM_PRODUCER_ACCOUNTS + 1].clone());
     run_test_chunk_validator_kickout(accounts, test_case);
@@ -145,7 +145,7 @@ fn test_chunk_validator_kicked_out_when_chunks_dropped() {
 
 /// Checks that block producer with low chunk endorsement stats is not kicked out when the chunks it would validate are all dropped.
 #[test]
-fn test_block_producer_not_kicked_out_when_chunks_dropped() {
+fn slow_test_block_producer_not_kicked_out_when_chunks_dropped() {
     let accounts = create_accounts();
     let test_case = TestCase::DropChunksValidatedBy(accounts[NUM_PRODUCER_ACCOUNTS - 1].clone());
     run_test_chunk_validator_kickout(accounts, test_case);
@@ -153,7 +153,7 @@ fn test_block_producer_not_kicked_out_when_chunks_dropped() {
 
 /// Checks that chunk validator with low endorsement stats is kicked out when the endorsements it generates are all dropped.
 #[test]
-fn test_chunk_validator_kicked_out_when_endorsements_dropped() {
+fn slow_test_chunk_validator_kicked_out_when_endorsements_dropped() {
     let accounts = create_accounts();
     let test_case = TestCase::DropEndorsementsFrom(accounts[NUM_PRODUCER_ACCOUNTS + 1].clone());
     run_test_chunk_validator_kickout(accounts, test_case);
@@ -161,7 +161,7 @@ fn test_chunk_validator_kicked_out_when_endorsements_dropped() {
 
 /// Checks that block producer with low chunk endorsement stats is not kicked out when the endorsements it generates are all dropped.
 #[test]
-fn test_block_producer_not_kicked_out_when_endorsements_dropped() {
+fn slow_test_block_producer_not_kicked_out_when_endorsements_dropped() {
     let accounts = create_accounts();
     let test_case = TestCase::DropEndorsementsFrom(accounts[NUM_PRODUCER_ACCOUNTS - 1].clone());
     run_test_chunk_validator_kickout(accounts, test_case);

--- a/integration-tests/src/test_loop/tests/epoch_sync.rs
+++ b/integration-tests/src/test_loop/tests/epoch_sync.rs
@@ -274,7 +274,7 @@ fn bootstrap_node_via_epoch_sync(setup: TestNetworkSetup, source_node: usize) ->
 // Test that a new node that only has genesis can use Epoch Sync to bring itself
 // up to date.
 #[test]
-fn test_epoch_sync_from_genesis() {
+fn slow_test_epoch_sync_from_genesis() {
     init_test_logger();
     let setup = setup_initial_blockchain(4, 20);
     bootstrap_node_via_epoch_sync(setup, 0);
@@ -283,7 +283,7 @@ fn test_epoch_sync_from_genesis() {
 // Tests that after epoch syncing, we can use the new node to bootstrap another
 // node via epoch sync.
 #[test]
-fn test_epoch_sync_from_another_epoch_synced_node() {
+fn slow_test_epoch_sync_from_another_epoch_synced_node() {
     init_test_logger();
     let setup = setup_initial_blockchain(4, 20);
     let setup = bootstrap_node_via_epoch_sync(setup, 0);
@@ -291,7 +291,7 @@ fn test_epoch_sync_from_another_epoch_synced_node() {
 }
 
 #[test]
-fn test_epoch_sync_transaction_validity_period_one_epoch() {
+fn slow_test_epoch_sync_transaction_validity_period_one_epoch() {
     init_test_logger();
     let setup = setup_initial_blockchain(4, 10);
     let setup = bootstrap_node_via_epoch_sync(setup, 0);
@@ -299,7 +299,7 @@ fn test_epoch_sync_transaction_validity_period_one_epoch() {
 }
 
 #[test]
-fn test_epoch_sync_with_expired_transactions() {
+fn slow_test_epoch_sync_with_expired_transactions() {
     init_test_logger();
     let setup = setup_initial_blockchain(4, 1);
     let setup = bootstrap_node_via_epoch_sync(setup, 0);
@@ -380,7 +380,7 @@ fn sanity_check_epoch_sync_proof(
 }
 
 #[test]
-fn test_initial_epoch_sync_proof_sanity() {
+fn slow_test_initial_epoch_sync_proof_sanity() {
     init_test_logger();
     let setup = setup_initial_blockchain(4, 20);
     let proof = setup.derive_epoch_sync_proof(0);
@@ -393,7 +393,7 @@ fn test_initial_epoch_sync_proof_sanity() {
 }
 
 #[test]
-fn test_epoch_sync_proof_sanity_from_epoch_synced_node() {
+fn slow_test_epoch_sync_proof_sanity_from_epoch_synced_node() {
     init_test_logger();
     let setup = setup_initial_blockchain(4, 20);
     let setup = bootstrap_node_via_epoch_sync(setup, 0);
@@ -417,7 +417,7 @@ fn test_epoch_sync_proof_sanity_from_epoch_synced_node() {
 }
 
 #[test]
-fn test_epoch_sync_proof_sanity_shorter_transaction_validity_period() {
+fn slow_test_epoch_sync_proof_sanity_shorter_transaction_validity_period() {
     init_test_logger();
     let setup = setup_initial_blockchain(4, 10);
     let proof = setup.derive_epoch_sync_proof(0);
@@ -426,7 +426,7 @@ fn test_epoch_sync_proof_sanity_shorter_transaction_validity_period() {
 }
 
 #[test]
-fn test_epoch_sync_proof_sanity_zero_transaction_validity_period() {
+fn slow_test_epoch_sync_proof_sanity_zero_transaction_validity_period() {
     init_test_logger();
     let setup = setup_initial_blockchain(4, 0);
     let proof = setup.derive_epoch_sync_proof(0);

--- a/integration-tests/src/test_loop/tests/fix_min_stake_ratio.rs
+++ b/integration-tests/src/test_loop/tests/fix_min_stake_ratio.rs
@@ -22,7 +22,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// Check that small validator is included in the validator set after
 /// enabling protocol feature `FixMinStakeRatio`.
 #[test]
-fn test_fix_min_stake_ratio() {
+fn slow_test_fix_min_stake_ratio() {
     init_test_logger();
     let builder = TestLoopBuilder::new();
 

--- a/integration-tests/src/test_loop/tests/max_receipt_size.rs
+++ b/integration-tests/src/test_loop/tests/max_receipt_size.rs
@@ -16,7 +16,7 @@ use crate::test_loop::utils::TGAS;
 
 /// Generating receipts larger than the size limit should cause the transaction to fail.
 #[test]
-fn test_max_receipt_size() {
+fn slow_test_max_receipt_size() {
     init_test_logger();
     let mut env: TestLoopEnv = standard_setup_1();
 

--- a/integration-tests/src/test_loop/tests/multinode_stateless_validators.rs
+++ b/integration-tests/src/test_loop/tests/multinode_stateless_validators.rs
@@ -23,7 +23,7 @@ const NUM_CHUNK_VALIDATORS_ONLY: usize = 4;
 const NUM_VALIDATORS: usize = NUM_BLOCK_AND_CHUNK_PRODUCERS + NUM_CHUNK_VALIDATORS_ONLY;
 
 #[test]
-fn test_stateless_validators_with_multi_test_loop() {
+fn slow_test_stateless_validators_with_multi_test_loop() {
     init_test_logger();
     let builder = TestLoopBuilder::new();
 

--- a/integration-tests/src/test_loop/tests/multinode_test_loop_example.rs
+++ b/integration-tests/src/test_loop/tests/multinode_test_loop_example.rs
@@ -13,7 +13,7 @@ use crate::test_loop::utils::ONE_NEAR;
 const NUM_CLIENTS: usize = 4;
 
 #[test]
-fn test_client_with_multi_test_loop() {
+fn slow_test_client_with_multi_test_loop() {
     init_test_logger();
     let builder = TestLoopBuilder::new();
 

--- a/integration-tests/src/test_loop/tests/protocol_upgrade.rs
+++ b/integration-tests/src/test_loop/tests/protocol_upgrade.rs
@@ -212,12 +212,12 @@ pub(crate) fn test_protocol_upgrade(
 }
 
 #[test]
-fn test_protocol_upgrade_no_missing_chunks() {
+fn slow_test_protocol_upgrade_no_missing_chunks() {
     test_protocol_upgrade(PROTOCOL_VERSION - 1, PROTOCOL_VERSION, HashMap::new());
 }
 
 #[test]
-fn test_protocol_upgrade_with_missing_chunk_one() {
+fn slow_test_protocol_upgrade_with_missing_chunk_one() {
     test_protocol_upgrade(
         PROTOCOL_VERSION - 1,
         PROTOCOL_VERSION,
@@ -234,7 +234,7 @@ fn test_protocol_upgrade_with_missing_chunk_one() {
 }
 
 #[test]
-fn test_protocol_upgrade_with_missing_chunks_two() {
+fn slow_test_protocol_upgrade_with_missing_chunks_two() {
     test_protocol_upgrade(
         PROTOCOL_VERSION - 1,
         PROTOCOL_VERSION,

--- a/integration-tests/src/test_loop/tests/state_sync.rs
+++ b/integration-tests/src/test_loop/tests/state_sync.rs
@@ -292,7 +292,7 @@ static TEST_CASES: &[StateSyncTest] = &[
 ];
 
 #[test]
-fn test_state_sync_current_epoch() {
+fn slow_test_state_sync_current_epoch() {
     init_test_logger();
 
     for t in TEST_CASES.iter() {
@@ -354,7 +354,7 @@ fn spam_state_sync_header_reqs(env: &mut TestLoopEnv) {
 }
 
 #[test]
-fn test_state_request() {
+fn slow_test_state_request() {
     init_test_logger();
 
     let TestState { mut env, .. } = setup_initial_blockchain(4, HashMap::default());

--- a/integration-tests/src/test_loop/tests/syncing.rs
+++ b/integration-tests/src/test_loop/tests/syncing.rs
@@ -20,7 +20,7 @@ const NUM_CLIENTS: usize = 4;
 // Test that a new node that only has genesis can use whatever method available
 // to sync up to the current state of the network.
 #[test]
-fn test_sync_from_genesis() {
+fn slow_test_sync_from_genesis() {
     init_test_logger();
     let builder = TestLoopBuilder::new();
 

--- a/integration-tests/src/test_loop/tests/view_requests_to_archival_node.rs
+++ b/integration-tests/src/test_loop/tests/view_requests_to_archival_node.rs
@@ -44,7 +44,7 @@ const NUM_SHARDS: usize = 4;
 /// The goal is to exercise the codepath that answers the requests, rather than checking
 /// it returns a fully correct response.
 #[test]
-fn test_view_requests_to_archival_node() {
+fn slow_test_view_requests_to_archival_node() {
     init_test_logger();
     let builder = TestLoopBuilder::new();
 
@@ -345,7 +345,7 @@ impl<'a> ViewClientTester<'a> {
         get_and_check_ordered_validators(ordered_validators_latest);
     }
 
-    /// Generates variations of the [`GetBlockStateChangesInBlock`] request and issues them to the view client of the archival node.    
+    /// Generates variations of the [`GetBlockStateChangesInBlock`] request and issues them to the view client of the archival node.
     fn check_get_state_changes_in_block(&mut self) {
         let block = self.get_block_at_height(6);
 

--- a/integration-tests/src/tests/client/block_corruption.rs
+++ b/integration-tests/src/tests/client/block_corruption.rs
@@ -240,8 +240,7 @@ fn check_process_flipped_block_fails_on_bit(
 /// `oks` are printed to check the sanity of the test.
 /// This vector should include various validation errors that correspond to data changed with a bit flip.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn check_process_flipped_block_fails() {
+fn ultraslow_check_process_flipped_block_fails() {
     init_test_logger();
     let mut corrupted_bit_idx = 0;
     // List of reasons `check_process_flipped_block_fails_on_bit` returned `Err`.

--- a/integration-tests/src/tests/client/block_corruption.rs
+++ b/integration-tests/src/tests/client/block_corruption.rs
@@ -240,7 +240,7 @@ fn check_process_flipped_block_fails_on_bit(
 /// `oks` are printed to check the sanity of the test.
 /// This vector should include various validation errors that correspond to data changed with a bit flip.
 #[test]
-fn ultraslow_check_process_flipped_block_fails() {
+fn ultraslow_test_check_process_flipped_block_fails() {
     init_test_logger();
     let mut corrupted_bit_idx = 0;
     // List of reasons `check_process_flipped_block_fails_on_bit` returned `Err`.

--- a/integration-tests/src/tests/client/block_corruption.rs
+++ b/integration-tests/src/tests/client/block_corruption.rs
@@ -240,7 +240,7 @@ fn check_process_flipped_block_fails_on_bit(
 /// `oks` are printed to check the sanity of the test.
 /// This vector should include various validation errors that correspond to data changed with a bit flip.
 #[test]
-fn ultraslow_test_check_process_flipped_block_fails() {
+fn ultra_slow_test_check_process_flipped_block_fails() {
     init_test_logger();
     let mut corrupted_bit_idx = 0;
     // List of reasons `check_process_flipped_block_fails_on_bit` returned `Err`.

--- a/integration-tests/src/tests/client/chunks_management.rs
+++ b/integration-tests/src/tests/client/chunks_management.rs
@@ -334,7 +334,7 @@ fn chunks_produced_and_distributed_all_in_all_shards() {
 }
 
 #[test]
-fn ultraslow_test_chunks_produced_and_distributed_2_vals_per_shard() {
+fn ultra_slow_test_chunks_produced_and_distributed_2_vals_per_shard() {
     Test {
         validator_groups: 2,
         chunk_only_producers: false,
@@ -346,7 +346,7 @@ fn ultraslow_test_chunks_produced_and_distributed_2_vals_per_shard() {
 }
 
 #[test]
-fn ultraslow_test_chunks_produced_and_distributed_one_val_per_shard() {
+fn ultra_slow_test_chunks_produced_and_distributed_one_val_per_shard() {
     Test {
         validator_groups: 4,
         chunk_only_producers: false,
@@ -361,7 +361,7 @@ fn ultraslow_test_chunks_produced_and_distributed_one_val_per_shard() {
 // because we always fallback on the p2p mechanism. This test runs with a config
 // where `enabled: false`.
 #[test]
-fn ultraslow_test_chunks_produced_and_distributed_chunk_distribution_network_disabled() {
+fn ultra_slow_test_chunks_produced_and_distributed_chunk_distribution_network_disabled() {
     let config = ChunkDistributionNetworkConfig {
         enabled: false,
         uris: ChunkDistributionUris { set: String::new(), get: String::new() },
@@ -380,7 +380,7 @@ fn ultraslow_test_chunks_produced_and_distributed_chunk_distribution_network_dis
 // because we always fallback on the p2p mechanism. This test runs with a config
 // where the URIs are not real endpoints.
 #[test]
-fn ultraslow_test_chunks_produced_and_distributed_chunk_distribution_network_wrong_urls() {
+fn ultra_slow_test_chunks_produced_and_distributed_chunk_distribution_network_wrong_urls() {
     let config = ChunkDistributionNetworkConfig {
         enabled: false,
         uris: ChunkDistributionUris {
@@ -403,7 +403,7 @@ fn ultraslow_test_chunks_produced_and_distributed_chunk_distribution_network_wro
 // where the `get` URI points at a random http server (therefore it does not
 // return valid chunks).
 #[test]
-fn ultraslow_test_chunks_produced_and_distributed_chunk_distribution_network_incorrect_get_return()
+fn ultra_slow_test_chunks_produced_and_distributed_chunk_distribution_network_incorrect_get_return()
 {
     let config = ChunkDistributionNetworkConfig {
         enabled: false,
@@ -433,7 +433,7 @@ fn chunks_produced_and_distributed_all_in_all_shards_should_succeed_even_without
 }
 
 #[test]
-fn ultraslow_test_chunks_produced_and_distributed_2_vals_per_shard_should_succeed_even_without_forwarding(
+fn ultra_slow_test_chunks_produced_and_distributed_2_vals_per_shard_should_succeed_even_without_forwarding(
 ) {
     Test {
         validator_groups: 2,
@@ -446,7 +446,7 @@ fn ultraslow_test_chunks_produced_and_distributed_2_vals_per_shard_should_succee
 }
 
 #[test]
-fn ultraslow_test_chunks_produced_and_distributed_one_val_per_shard_should_succeed_even_without_forwarding(
+fn ultra_slow_test_chunks_produced_and_distributed_one_val_per_shard_should_succeed_even_without_forwarding(
 ) {
     Test {
         validator_groups: 4,
@@ -470,7 +470,7 @@ fn ultraslow_test_chunks_produced_and_distributed_one_val_per_shard_should_succe
 /// TODO: this test is broken due to (#8395) - with fix in #8211
 
 #[test]
-fn ultraslow_test_chunks_recovered_from_others() {
+fn ultra_slow_test_chunks_recovered_from_others() {
     Test {
         validator_groups: 2,
         chunk_only_producers: false,
@@ -486,7 +486,7 @@ fn ultraslow_test_chunks_recovered_from_others() {
 /// but they won't do it for the first 3 seconds, and 3s block_timeout means that the block producers
 /// only wait for 3000/2 milliseconds until they produce a block with some chunks missing
 #[test]
-fn ultraslow_test_chunks_recovered_from_full_timeout_too_short() {
+fn ultra_slow_test_chunks_recovered_from_full_timeout_too_short() {
     Test {
         validator_groups: 4,
         chunk_only_producers: false,
@@ -500,7 +500,7 @@ fn ultraslow_test_chunks_recovered_from_full_timeout_too_short() {
 /// Same test as above, but the timeout is sufficiently large for test4 now to reconstruct the full
 /// chunk
 #[test]
-fn ultraslow_test_chunks_recovered_from_full() {
+fn ultra_slow_test_chunks_recovered_from_full() {
     Test {
         validator_groups: 4,
         chunk_only_producers: false,
@@ -515,7 +515,7 @@ fn ultraslow_test_chunks_recovered_from_full() {
 
 /// Happy case -- each shard is handled by one cop and one block producers.
 #[test]
-fn ultraslow_test_chunks_produced_and_distributed_one_val_shard_cop() {
+fn ultra_slow_test_chunks_produced_and_distributed_one_val_shard_cop() {
     Test {
         validator_groups: 4,
         chunk_only_producers: true,
@@ -528,7 +528,7 @@ fn ultraslow_test_chunks_produced_and_distributed_one_val_shard_cop() {
 
 /// `test4` can't talk to `test1`, so it'll fetch the chunk for first shard from `cop1`.
 #[test]
-fn ultraslow_test_chunks_recovered_from_others_cop() {
+fn ultra_slow_test_chunks_recovered_from_others_cop() {
     Test {
         validator_groups: 1,
         chunk_only_producers: true,
@@ -542,7 +542,7 @@ fn ultraslow_test_chunks_recovered_from_others_cop() {
 /// `test4` can't talk neither to `cop1` nor to `test1`, so it can't fetch chunk
 /// from chunk producers and has to reconstruct it.
 #[test]
-fn ultraslow_test_chunks_recovered_from_full_timeout_too_short_cop() {
+fn ultra_slow_test_chunks_recovered_from_full_timeout_too_short_cop() {
     Test {
         validator_groups: 4,
         chunk_only_producers: true,
@@ -558,7 +558,7 @@ fn ultraslow_test_chunks_recovered_from_full_timeout_too_short_cop() {
 
 /// Same as above, but with longer block production timeout which should allow for full reconstruction.
 #[test]
-fn ultraslow_test_chunks_recovered_from_full_cop() {
+fn ultra_slow_test_chunks_recovered_from_full_cop() {
     Test {
         validator_groups: 4,
         chunk_only_producers: true,

--- a/integration-tests/src/tests/client/chunks_management.rs
+++ b/integration-tests/src/tests/client/chunks_management.rs
@@ -334,8 +334,7 @@ fn chunks_produced_and_distributed_all_in_all_shards() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn chunks_produced_and_distributed_2_vals_per_shard() {
+fn ultraslow_chunks_produced_and_distributed_2_vals_per_shard() {
     Test {
         validator_groups: 2,
         chunk_only_producers: false,
@@ -347,8 +346,7 @@ fn chunks_produced_and_distributed_2_vals_per_shard() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn chunks_produced_and_distributed_one_val_per_shard() {
+fn ultraslow_chunks_produced_and_distributed_one_val_per_shard() {
     Test {
         validator_groups: 4,
         chunk_only_producers: false,
@@ -363,8 +361,7 @@ fn chunks_produced_and_distributed_one_val_per_shard() {
 // because we always fallback on the p2p mechanism. This test runs with a config
 // where `enabled: false`.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn chunks_produced_and_distributed_chunk_distribution_network_disabled() {
+fn ultraslow_chunks_produced_and_distributed_chunk_distribution_network_disabled() {
     let config = ChunkDistributionNetworkConfig {
         enabled: false,
         uris: ChunkDistributionUris { set: String::new(), get: String::new() },
@@ -383,8 +380,7 @@ fn chunks_produced_and_distributed_chunk_distribution_network_disabled() {
 // because we always fallback on the p2p mechanism. This test runs with a config
 // where the URIs are not real endpoints.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn chunks_produced_and_distributed_chunk_distribution_network_wrong_urls() {
+fn ultraslow_chunks_produced_and_distributed_chunk_distribution_network_wrong_urls() {
     let config = ChunkDistributionNetworkConfig {
         enabled: false,
         uris: ChunkDistributionUris {
@@ -407,8 +403,7 @@ fn chunks_produced_and_distributed_chunk_distribution_network_wrong_urls() {
 // where the `get` URI points at a random http server (therefore it does not
 // return valid chunks).
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn chunks_produced_and_distributed_chunk_distribution_network_incorrect_get_return() {
+fn ultraslow_chunks_produced_and_distributed_chunk_distribution_network_incorrect_get_return() {
     let config = ChunkDistributionNetworkConfig {
         enabled: false,
         uris: ChunkDistributionUris { set: String::new(), get: "https://www.google.com".into() },
@@ -437,8 +432,7 @@ fn chunks_produced_and_distributed_all_in_all_shards_should_succeed_even_without
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn chunks_produced_and_distributed_2_vals_per_shard_should_succeed_even_without_forwarding() {
+fn ultraslow_chunks_produced_and_distributed_2_vals_per_shard_should_succeed_even_without_forwarding() {
     Test {
         validator_groups: 2,
         chunk_only_producers: false,
@@ -450,8 +444,7 @@ fn chunks_produced_and_distributed_2_vals_per_shard_should_succeed_even_without_
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn chunks_produced_and_distributed_one_val_per_shard_should_succeed_even_without_forwarding() {
+fn ultraslow_chunks_produced_and_distributed_one_val_per_shard_should_succeed_even_without_forwarding() {
     Test {
         validator_groups: 4,
         chunk_only_producers: false,
@@ -474,8 +467,7 @@ fn chunks_produced_and_distributed_one_val_per_shard_should_succeed_even_without
 /// TODO: this test is broken due to (#8395) - with fix in #8211
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn chunks_recovered_from_others() {
+fn ultraslow_chunks_recovered_from_others() {
     Test {
         validator_groups: 2,
         chunk_only_producers: false,
@@ -491,8 +483,7 @@ fn chunks_recovered_from_others() {
 /// but they won't do it for the first 3 seconds, and 3s block_timeout means that the block producers
 /// only wait for 3000/2 milliseconds until they produce a block with some chunks missing
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn chunks_recovered_from_full_timeout_too_short() {
+fn ultraslow_chunks_recovered_from_full_timeout_too_short() {
     Test {
         validator_groups: 4,
         chunk_only_producers: false,
@@ -506,8 +497,7 @@ fn chunks_recovered_from_full_timeout_too_short() {
 /// Same test as above, but the timeout is sufficiently large for test4 now to reconstruct the full
 /// chunk
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn chunks_recovered_from_full() {
+fn ultraslow_chunks_recovered_from_full() {
     Test {
         validator_groups: 4,
         chunk_only_producers: false,
@@ -522,8 +512,7 @@ fn chunks_recovered_from_full() {
 
 /// Happy case -- each shard is handled by one cop and one block producers.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn chunks_produced_and_distributed_one_val_shard_cop() {
+fn ultraslow_chunks_produced_and_distributed_one_val_shard_cop() {
     Test {
         validator_groups: 4,
         chunk_only_producers: true,
@@ -536,8 +525,7 @@ fn chunks_produced_and_distributed_one_val_shard_cop() {
 
 /// `test4` can't talk to `test1`, so it'll fetch the chunk for first shard from `cop1`.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn chunks_recovered_from_others_cop() {
+fn ultraslow_chunks_recovered_from_others_cop() {
     Test {
         validator_groups: 1,
         chunk_only_producers: true,
@@ -551,8 +539,7 @@ fn chunks_recovered_from_others_cop() {
 /// `test4` can't talk neither to `cop1` nor to `test1`, so it can't fetch chunk
 /// from chunk producers and has to reconstruct it.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn chunks_recovered_from_full_timeout_too_short_cop() {
+fn ultraslow_chunks_recovered_from_full_timeout_too_short_cop() {
     Test {
         validator_groups: 4,
         chunk_only_producers: true,
@@ -568,8 +555,7 @@ fn chunks_recovered_from_full_timeout_too_short_cop() {
 
 /// Same as above, but with longer block production timeout which should allow for full reconstruction.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn chunks_recovered_from_full_cop() {
+fn ultraslow_chunks_recovered_from_full_cop() {
     Test {
         validator_groups: 4,
         chunk_only_producers: true,

--- a/integration-tests/src/tests/client/chunks_management.rs
+++ b/integration-tests/src/tests/client/chunks_management.rs
@@ -334,7 +334,7 @@ fn chunks_produced_and_distributed_all_in_all_shards() {
 }
 
 #[test]
-fn ultraslow_chunks_produced_and_distributed_2_vals_per_shard() {
+fn ultraslow_test_chunks_produced_and_distributed_2_vals_per_shard() {
     Test {
         validator_groups: 2,
         chunk_only_producers: false,
@@ -346,7 +346,7 @@ fn ultraslow_chunks_produced_and_distributed_2_vals_per_shard() {
 }
 
 #[test]
-fn ultraslow_chunks_produced_and_distributed_one_val_per_shard() {
+fn ultraslow_test_chunks_produced_and_distributed_one_val_per_shard() {
     Test {
         validator_groups: 4,
         chunk_only_producers: false,
@@ -361,7 +361,7 @@ fn ultraslow_chunks_produced_and_distributed_one_val_per_shard() {
 // because we always fallback on the p2p mechanism. This test runs with a config
 // where `enabled: false`.
 #[test]
-fn ultraslow_chunks_produced_and_distributed_chunk_distribution_network_disabled() {
+fn ultraslow_test_chunks_produced_and_distributed_chunk_distribution_network_disabled() {
     let config = ChunkDistributionNetworkConfig {
         enabled: false,
         uris: ChunkDistributionUris { set: String::new(), get: String::new() },
@@ -380,7 +380,7 @@ fn ultraslow_chunks_produced_and_distributed_chunk_distribution_network_disabled
 // because we always fallback on the p2p mechanism. This test runs with a config
 // where the URIs are not real endpoints.
 #[test]
-fn ultraslow_chunks_produced_and_distributed_chunk_distribution_network_wrong_urls() {
+fn ultraslow_test_chunks_produced_and_distributed_chunk_distribution_network_wrong_urls() {
     let config = ChunkDistributionNetworkConfig {
         enabled: false,
         uris: ChunkDistributionUris {
@@ -403,7 +403,8 @@ fn ultraslow_chunks_produced_and_distributed_chunk_distribution_network_wrong_ur
 // where the `get` URI points at a random http server (therefore it does not
 // return valid chunks).
 #[test]
-fn ultraslow_chunks_produced_and_distributed_chunk_distribution_network_incorrect_get_return() {
+fn ultraslow_test_chunks_produced_and_distributed_chunk_distribution_network_incorrect_get_return()
+{
     let config = ChunkDistributionNetworkConfig {
         enabled: false,
         uris: ChunkDistributionUris { set: String::new(), get: "https://www.google.com".into() },
@@ -432,7 +433,8 @@ fn chunks_produced_and_distributed_all_in_all_shards_should_succeed_even_without
 }
 
 #[test]
-fn ultraslow_chunks_produced_and_distributed_2_vals_per_shard_should_succeed_even_without_forwarding() {
+fn ultraslow_test_chunks_produced_and_distributed_2_vals_per_shard_should_succeed_even_without_forwarding(
+) {
     Test {
         validator_groups: 2,
         chunk_only_producers: false,
@@ -444,7 +446,8 @@ fn ultraslow_chunks_produced_and_distributed_2_vals_per_shard_should_succeed_eve
 }
 
 #[test]
-fn ultraslow_chunks_produced_and_distributed_one_val_per_shard_should_succeed_even_without_forwarding() {
+fn ultraslow_test_chunks_produced_and_distributed_one_val_per_shard_should_succeed_even_without_forwarding(
+) {
     Test {
         validator_groups: 4,
         chunk_only_producers: false,
@@ -467,7 +470,7 @@ fn ultraslow_chunks_produced_and_distributed_one_val_per_shard_should_succeed_ev
 /// TODO: this test is broken due to (#8395) - with fix in #8211
 
 #[test]
-fn ultraslow_chunks_recovered_from_others() {
+fn ultraslow_test_chunks_recovered_from_others() {
     Test {
         validator_groups: 2,
         chunk_only_producers: false,
@@ -483,7 +486,7 @@ fn ultraslow_chunks_recovered_from_others() {
 /// but they won't do it for the first 3 seconds, and 3s block_timeout means that the block producers
 /// only wait for 3000/2 milliseconds until they produce a block with some chunks missing
 #[test]
-fn ultraslow_chunks_recovered_from_full_timeout_too_short() {
+fn ultraslow_test_chunks_recovered_from_full_timeout_too_short() {
     Test {
         validator_groups: 4,
         chunk_only_producers: false,
@@ -497,7 +500,7 @@ fn ultraslow_chunks_recovered_from_full_timeout_too_short() {
 /// Same test as above, but the timeout is sufficiently large for test4 now to reconstruct the full
 /// chunk
 #[test]
-fn ultraslow_chunks_recovered_from_full() {
+fn ultraslow_test_chunks_recovered_from_full() {
     Test {
         validator_groups: 4,
         chunk_only_producers: false,
@@ -512,7 +515,7 @@ fn ultraslow_chunks_recovered_from_full() {
 
 /// Happy case -- each shard is handled by one cop and one block producers.
 #[test]
-fn ultraslow_chunks_produced_and_distributed_one_val_shard_cop() {
+fn ultraslow_test_chunks_produced_and_distributed_one_val_shard_cop() {
     Test {
         validator_groups: 4,
         chunk_only_producers: true,
@@ -525,7 +528,7 @@ fn ultraslow_chunks_produced_and_distributed_one_val_shard_cop() {
 
 /// `test4` can't talk to `test1`, so it'll fetch the chunk for first shard from `cop1`.
 #[test]
-fn ultraslow_chunks_recovered_from_others_cop() {
+fn ultraslow_test_chunks_recovered_from_others_cop() {
     Test {
         validator_groups: 1,
         chunk_only_producers: true,
@@ -539,7 +542,7 @@ fn ultraslow_chunks_recovered_from_others_cop() {
 /// `test4` can't talk neither to `cop1` nor to `test1`, so it can't fetch chunk
 /// from chunk producers and has to reconstruct it.
 #[test]
-fn ultraslow_chunks_recovered_from_full_timeout_too_short_cop() {
+fn ultraslow_test_chunks_recovered_from_full_timeout_too_short_cop() {
     Test {
         validator_groups: 4,
         chunk_only_producers: true,
@@ -555,7 +558,7 @@ fn ultraslow_chunks_recovered_from_full_timeout_too_short_cop() {
 
 /// Same as above, but with longer block production timeout which should allow for full reconstruction.
 #[test]
-fn ultraslow_chunks_recovered_from_full_cop() {
+fn ultraslow_test_chunks_recovered_from_full_cop() {
     Test {
         validator_groups: 4,
         chunk_only_producers: true,

--- a/integration-tests/src/tests/client/features/adversarial_behaviors.rs
+++ b/integration-tests/src/tests/client/features/adversarial_behaviors.rs
@@ -136,7 +136,7 @@ impl AdversarialBehaviorTestData {
 }
 
 #[test]
-fn test_non_adversarial_case() {
+fn slow_test_non_adversarial_case() {
     init_test_logger();
     let mut test = AdversarialBehaviorTestData::new();
     let epoch_manager = test.env.clients[0].epoch_manager.clone();

--- a/integration-tests/src/tests/client/features/congestion_control.rs
+++ b/integration-tests/src/tests/client/features/congestion_control.rs
@@ -281,7 +281,7 @@ fn head_chunk(env: &TestEnv, shard_id: ShardId) -> Arc<ShardChunk> {
 }
 
 #[test]
-fn test_protocol_upgrade_under_congestion() {
+fn slow_test_protocol_upgrade_under_congestion() {
     init_test_logger();
 
     // The following only makes sense to test if the feature is enabled in the current build.
@@ -606,7 +606,7 @@ fn test_transaction_limit_for_remote_congestion() {
 
 /// Test that clients stop including transactions to fully congested receivers.
 #[test]
-fn test_transaction_filtering() {
+fn slow_test_transaction_filtering() {
     init_test_logger();
 
     if !ProtocolFeature::CongestionControl.enabled(PROTOCOL_VERSION) {

--- a/integration-tests/src/tests/client/features/in_memory_tries.rs
+++ b/integration-tests/src/tests/client/features/in_memory_tries.rs
@@ -26,7 +26,7 @@ use std::collections::{HashMap, HashSet};
 const ONE_NEAR: u128 = 1_000_000_000_000_000_000_000_000;
 
 #[test]
-fn test_in_memory_trie_node_consistency() {
+fn slow_test_in_memory_trie_node_consistency() {
     // Recommended to run with RUST_LOG=memtrie=debug,chunks=error,info
     init_test_logger();
     let initial_balance = 10000 * ONE_NEAR;
@@ -527,11 +527,11 @@ fn test_in_memory_trie_consistency_with_state_sync_base_case(track_all_shards: b
 }
 
 #[test]
-fn test_in_memory_trie_consistency_with_state_sync_base_case_track_single_shard() {
+fn slow_test_in_memory_trie_consistency_with_state_sync_base_case_track_single_shard() {
     test_in_memory_trie_consistency_with_state_sync_base_case(false);
 }
 
 #[test]
-fn test_in_memory_trie_consistency_with_state_sync_base_case_track_all_shards() {
+fn slow_test_in_memory_trie_consistency_with_state_sync_base_case_track_all_shards() {
     test_in_memory_trie_consistency_with_state_sync_base_case(true);
 }

--- a/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
@@ -133,7 +133,7 @@ fn test_non_storage() {
 
 /// Test the case where a function call fails and the limit is unaffected by compute costs.
 #[test]
-fn test_non_storage_gas_exceeded() {
+fn slow_test_non_storage_gas_exceeded() {
     // `loop_forever()` loops until either gas is exhausted.
     // It should not be affected by compute costs, as it doesn't access storage.
     let method_name = "loop_forever".to_owned();

--- a/integration-tests/src/tests/client/features/stateless_validation.rs
+++ b/integration-tests/src/tests/client/features/stateless_validation.rs
@@ -265,7 +265,7 @@ fn run_chunk_validation_test(
 }
 
 #[test]
-fn test_chunk_validation_no_missing_chunks() {
+fn slow_test_chunk_validation_no_missing_chunks() {
     run_chunk_validation_test(42, 0.0, 0.0, PROTOCOL_VERSION);
 }
 
@@ -290,7 +290,7 @@ fn test_chunk_validation_protocol_upgrade_no_missing() {
 }
 
 #[test]
-fn test_chunk_validation_protocol_upgrade_low_missing_prob() {
+fn slow_test_chunk_validation_protocol_upgrade_low_missing_prob() {
     run_chunk_validation_test(
         42,
         0.2,
@@ -300,7 +300,7 @@ fn test_chunk_validation_protocol_upgrade_low_missing_prob() {
 }
 
 #[test]
-fn test_chunk_validation_protocol_upgrade_mid_missing_prob() {
+fn slow_test_chunk_validation_protocol_upgrade_mid_missing_prob() {
     run_chunk_validation_test(
         42,
         0.6,

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -232,7 +232,7 @@ fn test_flat_storage_creation_sanity() {
 
 /// Check that client can create flat storage on some shard while it already exists on another shard.
 #[test]
-fn test_flat_storage_creation_two_shards() {
+fn slow_test_flat_storage_creation_two_shards() {
     init_test_logger();
     let num_shards = 2;
     let genesis =

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -1635,7 +1635,7 @@ fn test_gc_execution_outcome() {
 }
 
 #[test]
-fn ultraslow_test_gc_after_state_sync() {
+fn ultra_slow_test_gc_after_state_sync() {
     let epoch_length = 1024;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
@@ -1663,7 +1663,7 @@ fn ultraslow_test_gc_after_state_sync() {
 }
 
 #[test]
-fn ultraslow_test_process_block_after_state_sync() {
+fn ultra_slow_test_process_block_after_state_sync() {
     let epoch_length = 1024;
     // test with shard_version > 0
     let mut genesis = Genesis::test_sharded_new_version(

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -478,7 +478,7 @@ fn produce_block_with_approvals() {
 
 /// When approvals arrive early, they should be properly cached.
 #[test]
-fn produce_block_with_approvals_arrived_early() {
+fn slow_test_produce_block_with_approvals_arrived_early() {
     init_test_logger();
     let vs = ValidatorSchedule::new().num_shards(4).block_producers_per_epoch(vec![vec![
         "test1".parse().unwrap(),
@@ -1635,8 +1635,7 @@ fn test_gc_execution_outcome() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_gc_after_state_sync() {
+fn ultraslow_test_gc_after_state_sync() {
     let epoch_length = 1024;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
@@ -1664,8 +1663,7 @@ fn test_gc_after_state_sync() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_process_block_after_state_sync() {
+fn ultraslow_test_process_block_after_state_sync() {
     let epoch_length = 1024;
     // test with shard_version > 0
     let mut genesis = Genesis::test_sharded_new_version(
@@ -2396,7 +2394,7 @@ fn test_validate_chunk_extra() {
 }
 
 #[test]
-fn test_catchup_gas_price_change() {
+fn slow_test_catchup_gas_price_change() {
     init_test_logger();
     let epoch_length = 5;
     let min_gas_price = 10000;
@@ -2953,7 +2951,7 @@ fn test_epoch_multi_protocol_version_change() {
 }
 
 #[test]
-fn test_epoch_multi_protocol_version_change_epoch_overlap() {
+fn slow_test_epoch_multi_protocol_version_change_epoch_overlap() {
     init_test_logger();
 
     let v0 = PROTOCOL_VERSION - 2;
@@ -3717,7 +3715,7 @@ mod contract_precompilation_tests {
 
     #[test]
     #[cfg_attr(all(target_arch = "aarch64", target_vendor = "apple"), ignore)]
-    fn test_sync_and_call_cached_contract() {
+    fn slow_test_sync_and_call_cached_contract() {
         init_integration_logger();
         let num_clients = 2;
         let mut genesis =
@@ -3817,7 +3815,7 @@ mod contract_precompilation_tests {
 
     #[test]
     #[cfg_attr(all(target_arch = "aarch64", target_vendor = "apple"), ignore)]
-    fn test_two_deployments() {
+    fn slow_test_two_deployments() {
         init_integration_logger();
         let num_clients = 2;
         let mut genesis =
@@ -3893,7 +3891,7 @@ mod contract_precompilation_tests {
 
     #[test]
     #[cfg_attr(all(target_arch = "aarch64", target_vendor = "apple"), ignore)]
-    fn test_sync_after_delete_account() {
+    fn slow_test_sync_after_delete_account() {
         init_test_logger();
         let num_clients = 3;
         let mut genesis = Genesis::test(

--- a/integration-tests/src/tests/client/resharding_v2.rs
+++ b/integration-tests/src/tests/client/resharding_v2.rs
@@ -893,16 +893,16 @@ fn test_latest_protocol_missing_chunks(p_missing: f64, rng_seed: u64) {
 // latest protocol
 
 #[test]
-fn test_latest_protocol_missing_chunks_low_missing_prob() {
+fn slow_test_latest_protocol_missing_chunks_low_missing_prob() {
     test_latest_protocol_missing_chunks(0.1, 25);
 }
 
 #[test]
-fn test_latest_protocol_missing_chunks_mid_missing_prob() {
+fn slow_test_latest_protocol_missing_chunks_mid_missing_prob() {
     test_latest_protocol_missing_chunks(0.5, 26);
 }
 
 #[test]
-fn test_latest_protocol_missing_chunks_high_missing_prob() {
+fn slow_test_latest_protocol_missing_chunks_high_missing_prob() {
     test_latest_protocol_missing_chunks(0.9, 27);
 }

--- a/integration-tests/src/tests/client/state_dump.rs
+++ b/integration-tests/src/tests/client/state_dump.rs
@@ -373,37 +373,37 @@ fn run_state_sync_with_dumped_parts(
 /// - the dumping node's head is in new epoch but final block is not;
 /// - the dumping node's head and final block are in same epoch
 #[test]
-fn test_state_sync_with_dumped_parts_2_non_final() {
+fn slow_test_state_sync_with_dumped_parts_2_non_final() {
     init_test_logger();
     run_state_sync_with_dumped_parts(false, 2, 5);
 }
 
 #[test]
-fn test_state_sync_with_dumped_parts_2_final() {
+fn slow_test_state_sync_with_dumped_parts_2_final() {
     init_test_logger();
     run_state_sync_with_dumped_parts(true, 2, 5);
 }
 
 #[test]
-fn test_state_sync_with_dumped_parts_3_non_final() {
+fn slow_test_state_sync_with_dumped_parts_3_non_final() {
     init_test_logger();
     run_state_sync_with_dumped_parts(false, 3, 5);
 }
 
 #[test]
-fn test_state_sync_with_dumped_parts_3_final() {
+fn slow_test_state_sync_with_dumped_parts_3_final() {
     init_test_logger();
     run_state_sync_with_dumped_parts(true, 3, 5);
 }
 
 #[test]
-fn test_state_sync_with_dumped_parts_4_non_final() {
+fn slow_test_state_sync_with_dumped_parts_4_non_final() {
     init_test_logger();
     run_state_sync_with_dumped_parts(false, 4, 5);
 }
 
 #[test]
-fn test_state_sync_with_dumped_parts_4_final() {
+fn slow_test_state_sync_with_dumped_parts_4_final() {
     init_test_logger();
     run_state_sync_with_dumped_parts(true, 4, 5);
 }

--- a/integration-tests/src/tests/client/state_snapshot.rs
+++ b/integration-tests/src/tests/client/state_snapshot.rs
@@ -190,7 +190,7 @@ fn delete_content_at_path(path: &str) -> std::io::Result<()> {
 // Runs a validator node.
 // Makes a state snapshot after processing every block. Each block contains a
 // transaction creating an account.
-fn test_make_state_snapshot() {
+fn slow_test_make_state_snapshot() {
     init_test_logger();
     let genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
     let mut env = TestEnv::builder(&genesis.config)

--- a/integration-tests/src/tests/client/sync_state_nodes.rs
+++ b/integration-tests/src/tests/client/sync_state_nodes.rs
@@ -33,8 +33,7 @@ use crate::tests::test_helpers::heavy_test;
 
 /// One client is in front, another must sync to it using state (fast) sync.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn sync_state_nodes() {
+fn ultraslow_test_sync_state_nodes() {
     heavy_test(|| {
         init_integration_logger();
 
@@ -135,10 +134,8 @@ fn sync_state_nodes() {
 }
 
 /// One client is in front, another must sync to it using state (fast) sync.
-#[cfg(feature = "expensive_tests")]
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn sync_state_nodes_multishard() {
+fn ultraslow_test_sync_state_nodes_multishard() {
     heavy_test(|| {
         init_integration_logger();
 
@@ -298,8 +295,7 @@ fn sync_state_nodes_multishard() {
 /// Start a validator that validators four shards. Since we only have 3 accounts one shard must have
 /// empty state. Start another node that does state sync. Check state sync on empty state works.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn sync_empty_state() {
+fn ultraslow_test_sync_empty_state() {
     heavy_test(|| {
         init_integration_logger();
 
@@ -425,13 +421,12 @@ fn sync_empty_state() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
 // FIXME(#9650): locks should not be held across await points, allowed currently only because the
 // lint started triggering during a toolchain bump.
 #[allow(clippy::await_holding_lock)]
 /// Runs one node for some time, which dumps state to a temp directory.
 /// Start the second node which gets state parts from that temp directory.
-fn sync_state_dump() {
+fn ultraslow_test_sync_state_dump() {
     heavy_test(|| {
         init_integration_logger();
 
@@ -574,7 +569,7 @@ fn sync_state_dump() {
 
 #[test]
 // Test that state sync behaves well when the chunks are absent at the end of the epoch.
-fn test_dump_epoch_missing_chunk_in_last_block() {
+fn slow_test_dump_epoch_missing_chunk_in_last_block() {
     heavy_test(|| {
         init_test_logger();
         let epoch_length = 10;
@@ -802,7 +797,7 @@ fn test_dump_epoch_missing_chunk_in_last_block() {
 
 #[test]
 // Tests StateRequestHeader and StateRequestPart.
-fn test_state_sync_headers() {
+fn slow_test_state_sync_headers() {
     heavy_test(|| {
         init_test_logger();
 
@@ -959,7 +954,7 @@ fn test_state_sync_headers() {
 
 #[test]
 // Tests StateRequestHeader and StateRequestPart.
-fn test_state_sync_headers_no_tracked_shards() {
+fn slow_test_state_sync_headers_no_tracked_shards() {
     heavy_test(|| {
         init_test_logger();
 

--- a/integration-tests/src/tests/client/sync_state_nodes.rs
+++ b/integration-tests/src/tests/client/sync_state_nodes.rs
@@ -33,7 +33,7 @@ use crate::tests::test_helpers::heavy_test;
 
 /// One client is in front, another must sync to it using state (fast) sync.
 #[test]
-fn ultraslow_test_sync_state_nodes() {
+fn ultra_slow_test_sync_state_nodes() {
     heavy_test(|| {
         init_integration_logger();
 
@@ -135,7 +135,7 @@ fn ultraslow_test_sync_state_nodes() {
 
 /// One client is in front, another must sync to it using state (fast) sync.
 #[test]
-fn ultraslow_test_sync_state_nodes_multishard() {
+fn ultra_slow_test_sync_state_nodes_multishard() {
     heavy_test(|| {
         init_integration_logger();
 
@@ -295,7 +295,7 @@ fn ultraslow_test_sync_state_nodes_multishard() {
 /// Start a validator that validators four shards. Since we only have 3 accounts one shard must have
 /// empty state. Start another node that does state sync. Check state sync on empty state works.
 #[test]
-fn ultraslow_test_sync_empty_state() {
+fn ultra_slow_test_sync_empty_state() {
     heavy_test(|| {
         init_integration_logger();
 
@@ -426,7 +426,7 @@ fn ultraslow_test_sync_empty_state() {
 #[allow(clippy::await_holding_lock)]
 /// Runs one node for some time, which dumps state to a temp directory.
 /// Start the second node which gets state parts from that temp directory.
-fn ultraslow_test_sync_state_dump() {
+fn ultra_slow_test_sync_state_dump() {
     heavy_test(|| {
         init_integration_logger();
 

--- a/integration-tests/src/tests/dependencies.rs
+++ b/integration-tests/src/tests/dependencies.rs
@@ -87,7 +87,7 @@ struct CrateDeps {
 }
 
 #[test]
-fn test_public_libs_are_small_enough() {
+fn slow_test_public_libs_are_small_enough() {
     let results = LIBS_THRESHOLDS
         .into_iter()
         .map(|(name, limit)| (name, get_and_assert_crate_dependencies(name, limit), limit));

--- a/integration-tests/src/tests/nearcore/rpc_error_structs.rs
+++ b/integration-tests/src/tests/nearcore/rpc_error_structs.rs
@@ -21,7 +21,7 @@ use near_primitives::types::BlockId;
 // Queries json-rpc block that doesn't exists
 // Checks if the struct is expected and contains the proper data
 #[test]
-fn ultraslow_test_block_unknown_block_error() {
+fn ultra_slow_test_block_unknown_block_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -80,7 +80,7 @@ fn ultraslow_test_block_unknown_block_error() {
 // (randomish chunk hash, we hope it won't happen in test case)
 // Checks if the struct is expected and contains the proper data
 #[test]
-fn ultraslow_test_chunk_unknown_chunk_error() {
+fn ultra_slow_test_chunk_unknown_chunk_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -149,7 +149,7 @@ fn ultraslow_test_chunk_unknown_chunk_error() {
 // Queries json-rpc EXPERIMENTAL_protocol_config that doesn't exists
 // Checks if the struct is expected and contains the proper data
 #[test]
-fn ultraslow_test_protocol_config_unknown_block_error() {
+fn ultra_slow_test_protocol_config_unknown_block_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -212,7 +212,7 @@ fn ultraslow_test_protocol_config_unknown_block_error() {
 // Queries json-rpc gas_price that doesn't exists
 // Checks if the struct is expected and contains the proper data
 #[test]
-fn ultraslow_test_gas_price_unknown_block_error() {
+fn ultra_slow_test_gas_price_unknown_block_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -271,7 +271,7 @@ fn ultraslow_test_gas_price_unknown_block_error() {
 // Queries json-rpc EXPERIMENTAL_receipt that doesn't exists
 // Checks if the struct is expected and contains the proper data
 #[test]
-fn ultraslow_test_receipt_id_unknown_receipt_error() {
+fn ultra_slow_test_receipt_id_unknown_receipt_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -344,7 +344,7 @@ fn ultraslow_test_receipt_id_unknown_receipt_error() {
 /// Checks if the struct is expected and contains the proper data
 #[test]
 #[ignore = "Invalid test setup. broadcast_tx_commit times out because we haven't implemented forwarding logic. Fix and reenable."]
-fn ultraslow_test_tx_invalid_tx_error() {
+fn ultra_slow_test_tx_invalid_tx_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -418,7 +418,7 @@ fn ultraslow_test_tx_invalid_tx_error() {
 }
 
 #[test]
-fn ultraslow_test_query_rpc_account_view_unknown_block_must_return_error() {
+fn ultra_slow_test_query_rpc_account_view_unknown_block_must_return_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()

--- a/integration-tests/src/tests/nearcore/rpc_error_structs.rs
+++ b/integration-tests/src/tests/nearcore/rpc_error_structs.rs
@@ -21,8 +21,7 @@ use near_primitives::types::BlockId;
 // Queries json-rpc block that doesn't exists
 // Checks if the struct is expected and contains the proper data
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_block_unknown_block_error() {
+fn ultraslow_test_block_unknown_block_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -81,8 +80,7 @@ fn test_block_unknown_block_error() {
 // (randomish chunk hash, we hope it won't happen in test case)
 // Checks if the struct is expected and contains the proper data
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_chunk_unknown_chunk_error() {
+fn ultraslow_test_chunk_unknown_chunk_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -151,7 +149,7 @@ fn test_chunk_unknown_chunk_error() {
 // Queries json-rpc EXPERIMENTAL_protocol_config that doesn't exists
 // Checks if the struct is expected and contains the proper data
 #[test]
-fn test_protocol_config_unknown_block_error() {
+fn ultraslow_test_protocol_config_unknown_block_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -214,8 +212,7 @@ fn test_protocol_config_unknown_block_error() {
 // Queries json-rpc gas_price that doesn't exists
 // Checks if the struct is expected and contains the proper data
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_gas_price_unknown_block_error() {
+fn ultraslow_test_gas_price_unknown_block_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -274,8 +271,7 @@ fn test_gas_price_unknown_block_error() {
 // Queries json-rpc EXPERIMENTAL_receipt that doesn't exists
 // Checks if the struct is expected and contains the proper data
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_receipt_id_unknown_receipt_error() {
+fn ultraslow_test_receipt_id_unknown_receipt_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -348,8 +344,7 @@ fn test_receipt_id_unknown_receipt_error() {
 /// Checks if the struct is expected and contains the proper data
 #[test]
 #[ignore = "Invalid test setup. broadcast_tx_commit times out because we haven't implemented forwarding logic. Fix and reenable."]
-// #[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_tx_invalid_tx_error() {
+fn ultraslow_test_tx_invalid_tx_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -423,8 +418,7 @@ fn test_tx_invalid_tx_error() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_query_rpc_account_view_unknown_block_must_return_error() {
+fn ultraslow_test_query_rpc_account_view_unknown_block_must_return_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()

--- a/integration-tests/src/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/src/tests/nearcore/rpc_nodes.rs
@@ -27,7 +27,7 @@ use near_primitives::views::{ExecutionOutcomeView, ExecutionStatusView, TxExecut
 use std::time::Duration;
 
 #[test]
-fn ultraslow_test_get_validator_info_rpc() {
+fn ultra_slow_test_get_validator_info_rpc() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -207,17 +207,17 @@ fn test_get_execution_outcome(is_tx_successful: bool) {
 }
 
 #[test]
-fn ultraslow_test_get_execution_outcome_tx_success() {
+fn ultra_slow_test_get_execution_outcome_tx_success() {
     test_get_execution_outcome(true);
 }
 
 #[test]
-fn ultraslow_test_get_execution_outcome_tx_failure() {
+fn ultra_slow_test_get_execution_outcome_tx_failure() {
     test_get_execution_outcome(false);
 }
 
 #[test]
-fn ultraslow_test_protocol_config_rpc() {
+fn ultra_slow_test_protocol_config_rpc() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -258,7 +258,7 @@ fn ultraslow_test_protocol_config_rpc() {
 }
 
 #[test]
-fn ultraslow_test_query_rpc_account_view_must_succeed() {
+fn ultra_slow_test_query_rpc_account_view_must_succeed() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -296,7 +296,7 @@ fn ultraslow_test_query_rpc_account_view_must_succeed() {
 }
 
 #[test]
-fn ultraslow_test_query_rpc_account_view_account_doesnt_exist_must_return_error() {
+fn ultra_slow_test_query_rpc_account_view_account_doesnt_exist_must_return_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -345,7 +345,7 @@ fn ultraslow_test_query_rpc_account_view_account_doesnt_exist_must_return_error(
 }
 
 #[test]
-fn ultraslow_test_tx_not_enough_balance_must_return_error() {
+fn ultra_slow_test_tx_not_enough_balance_must_return_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -407,7 +407,7 @@ fn ultraslow_test_tx_not_enough_balance_must_return_error() {
 }
 
 #[test]
-fn ultraslow_test_check_unknown_tx_must_return_error() {
+fn ultra_slow_test_check_unknown_tx_must_return_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -472,7 +472,7 @@ fn ultraslow_test_check_unknown_tx_must_return_error() {
 
 #[test]
 #[ignore = "Need to implement forwarding and fix the test"]
-fn ultraslow_test_tx_status_on_lightclient_must_return_does_not_track_shard() {
+fn ultra_slow_test_tx_status_on_lightclient_must_return_does_not_track_shard() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -528,7 +528,7 @@ fn ultraslow_test_tx_status_on_lightclient_must_return_does_not_track_shard() {
 }
 
 #[test]
-fn ultraslow_test_validators_by_epoch_id_current_epoch_not_fails() {
+fn ultra_slow_test_validators_by_epoch_id_current_epoch_not_fails() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()

--- a/integration-tests/src/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/src/tests/nearcore/rpc_nodes.rs
@@ -27,8 +27,7 @@ use near_primitives::views::{ExecutionOutcomeView, ExecutionStatusView, TxExecut
 use std::time::Duration;
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_get_validator_info_rpc() {
+fn ultraslow_test_get_validator_info_rpc() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -208,20 +207,17 @@ fn test_get_execution_outcome(is_tx_successful: bool) {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_get_execution_outcome_tx_success() {
+fn ultraslow_test_get_execution_outcome_tx_success() {
     test_get_execution_outcome(true);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_get_execution_outcome_tx_failure() {
+fn ultraslow_test_get_execution_outcome_tx_failure() {
     test_get_execution_outcome(false);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_protocol_config_rpc() {
+fn ultraslow_test_protocol_config_rpc() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -262,8 +258,7 @@ fn test_protocol_config_rpc() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_query_rpc_account_view_must_succeed() {
+fn ultraslow_test_query_rpc_account_view_must_succeed() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -301,8 +296,7 @@ fn test_query_rpc_account_view_must_succeed() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_query_rpc_account_view_account_doesnt_exist_must_return_error() {
+fn ultraslow_test_query_rpc_account_view_account_doesnt_exist_must_return_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -351,8 +345,7 @@ fn test_query_rpc_account_view_account_doesnt_exist_must_return_error() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_tx_not_enough_balance_must_return_error() {
+fn ultraslow_test_tx_not_enough_balance_must_return_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -414,8 +407,7 @@ fn test_tx_not_enough_balance_must_return_error() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_check_unknown_tx_must_return_error() {
+fn ultraslow_test_check_unknown_tx_must_return_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -480,8 +472,7 @@ fn test_check_unknown_tx_must_return_error() {
 
 #[test]
 #[ignore = "Need to implement forwarding and fix the test"]
-// #[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_tx_status_on_lightclient_must_return_does_not_track_shard() {
+fn ultraslow_test_tx_status_on_lightclient_must_return_does_not_track_shard() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()
@@ -537,8 +528,7 @@ fn test_tx_status_on_lightclient_must_return_does_not_track_shard() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_validators_by_epoch_id_current_epoch_not_fails() {
+fn ultraslow_test_validators_by_epoch_id_current_epoch_not_fails() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()

--- a/integration-tests/src/tests/nearcore/run_nodes.rs
+++ b/integration-tests/src/tests/nearcore/run_nodes.rs
@@ -55,24 +55,24 @@ fn run_heavy_nodes(
 
 /// Runs two nodes that should produce blocks one after another.
 #[test]
-fn ultraslow_run_nodes_1_2_2() {
+fn ultraslow_test_run_nodes_1_2_2() {
     run_heavy_nodes(1, 2, 2, 10, 30);
 }
 
 /// Runs two nodes, where only one is a validator.
 #[test]
-fn ultraslow_run_nodes_1_2_1() {
+fn ultraslow_test_run_nodes_1_2_1() {
     run_heavy_nodes(1, 2, 1, 10, 30);
 }
 
 /// Runs 4 nodes that should produce blocks one after another.
 #[test]
-fn ultraslow_run_nodes_1_4_4() {
+fn ultraslow_test_run_nodes_1_4_4() {
     run_heavy_nodes(1, 4, 4, 8, 32);
 }
 
 /// Run 4 nodes, 4 shards, 2 validators, other two track 2 shards.
 #[test]
-fn ultraslow_run_nodes_4_4_2() {
+fn ultraslow_test_run_nodes_4_4_2() {
     run_heavy_nodes(4, 4, 2, 8, 32);
 }

--- a/integration-tests/src/tests/nearcore/run_nodes.rs
+++ b/integration-tests/src/tests/nearcore/run_nodes.rs
@@ -55,28 +55,24 @@ fn run_heavy_nodes(
 
 /// Runs two nodes that should produce blocks one after another.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn run_nodes_1_2_2() {
+fn ultraslow_run_nodes_1_2_2() {
     run_heavy_nodes(1, 2, 2, 10, 30);
 }
 
 /// Runs two nodes, where only one is a validator.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn run_nodes_1_2_1() {
+fn ultraslow_run_nodes_1_2_1() {
     run_heavy_nodes(1, 2, 1, 10, 30);
 }
 
 /// Runs 4 nodes that should produce blocks one after another.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn run_nodes_1_4_4() {
+fn ultraslow_run_nodes_1_4_4() {
     run_heavy_nodes(1, 4, 4, 8, 32);
 }
 
 /// Run 4 nodes, 4 shards, 2 validators, other two track 2 shards.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn run_nodes_4_4_2() {
+fn ultraslow_run_nodes_4_4_2() {
     run_heavy_nodes(4, 4, 2, 8, 32);
 }

--- a/integration-tests/src/tests/nearcore/run_nodes.rs
+++ b/integration-tests/src/tests/nearcore/run_nodes.rs
@@ -55,24 +55,24 @@ fn run_heavy_nodes(
 
 /// Runs two nodes that should produce blocks one after another.
 #[test]
-fn ultraslow_test_run_nodes_1_2_2() {
+fn ultra_slow_test_run_nodes_1_2_2() {
     run_heavy_nodes(1, 2, 2, 10, 30);
 }
 
 /// Runs two nodes, where only one is a validator.
 #[test]
-fn ultraslow_test_run_nodes_1_2_1() {
+fn ultra_slow_test_run_nodes_1_2_1() {
     run_heavy_nodes(1, 2, 1, 10, 30);
 }
 
 /// Runs 4 nodes that should produce blocks one after another.
 #[test]
-fn ultraslow_test_run_nodes_1_4_4() {
+fn ultra_slow_test_run_nodes_1_4_4() {
     run_heavy_nodes(1, 4, 4, 8, 32);
 }
 
 /// Run 4 nodes, 4 shards, 2 validators, other two track 2 shards.
 #[test]
-fn ultraslow_test_run_nodes_4_4_2() {
+fn ultra_slow_test_run_nodes_4_4_2() {
     run_heavy_nodes(4, 4, 2, 8, 32);
 }

--- a/integration-tests/src/tests/nearcore/stake_nodes.rs
+++ b/integration-tests/src/tests/nearcore/stake_nodes.rs
@@ -103,8 +103,7 @@ fn init_test_staking(
 /// Runs one validator network, sends staking transaction for the second node and
 /// waits until it becomes a validator.
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_stake_nodes() {
+fn ultraslow_test_stake_nodes() {
     heavy_test(|| {
         let num_nodes = 2;
         let dirs = (0..num_nodes)
@@ -186,8 +185,7 @@ fn test_stake_nodes() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_validator_kickout() {
+fn ultraslow_test_validator_kickout() {
     heavy_test(|| {
         let num_nodes = 4;
         let dirs = (0..num_nodes)
@@ -341,14 +339,13 @@ fn test_validator_kickout() {
     })
 }
 
-#[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
 /// Starts 4 nodes, genesis has 2 validator seats.
 /// Node1 unstakes, Node2 stakes.
 /// Submit the transactions via Node1 and Node2.
 /// Poll `/status` until you see the change of validator assignments.
 /// Afterwards check that `locked` amount on accounts Node1 and Node2 are 0 and TESTING_INIT_STAKE.
-fn test_validator_join() {
+#[test]
+fn ultraslow_test_validator_join() {
     heavy_test(|| {
         let num_nodes = 4;
         let dirs = (0..num_nodes)
@@ -511,11 +508,10 @@ fn test_validator_join() {
     });
 }
 
-#[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
 /// Checks that during the first epoch, total_supply matches total_supply in genesis.
 /// Checks that during the second epoch, total_supply matches the expected inflation rate.
-fn test_inflation() {
+#[test]
+fn ultraslow_test_inflation() {
     heavy_test(|| {
         let num_nodes = 1;
         let dirs = (0..num_nodes)
@@ -602,13 +598,13 @@ fn test_inflation() {
                                 // Protocol reward is one tenth of the base reward, while validator reward is the remainder.
                                 // There's only one validator so the second part of the computation is easier.
                                 // The validator rewards depend on its uptime; in other words, the more blocks, chunks and endorsements
-                                // it produces the bigger is the reward. 
-                                // In this test the validator produces 10 blocks out 10, 9 chunks out of 10 and 9 endorsements out of 10. 
+                                // it produces the bigger is the reward.
+                                // In this test the validator produces 10 blocks out 10, 9 chunks out of 10 and 9 endorsements out of 10.
                                 // Then there's a formula to translate 28/30 successes to a 10/27 reward multiplier
                                 // (using min_online_threshold=9/10 and max_online_threshold=99/100).
                                 //
                                 // For additional details check: chain/epoch-manager/src/reward_calculator.rs or
-                                // https://nomicon.io/Economics/Economic#validator-rewards-calculation 
+                                // https://nomicon.io/Economics/Economic#validator-rewards-calculation
                                 let protocol_reward = base_reward * 1 / 10;
                                 let validator_reward = base_reward - protocol_reward;
                                 // Chunk endorsement ratio 9/10 is mapped to 1 so the reward multiplier becomes 20/27.

--- a/integration-tests/src/tests/nearcore/stake_nodes.rs
+++ b/integration-tests/src/tests/nearcore/stake_nodes.rs
@@ -103,7 +103,7 @@ fn init_test_staking(
 /// Runs one validator network, sends staking transaction for the second node and
 /// waits until it becomes a validator.
 #[test]
-fn ultraslow_test_stake_nodes() {
+fn ultra_slow_test_stake_nodes() {
     heavy_test(|| {
         let num_nodes = 2;
         let dirs = (0..num_nodes)
@@ -185,7 +185,7 @@ fn ultraslow_test_stake_nodes() {
 }
 
 #[test]
-fn ultraslow_test_validator_kickout() {
+fn ultra_slow_test_validator_kickout() {
     heavy_test(|| {
         let num_nodes = 4;
         let dirs = (0..num_nodes)
@@ -345,7 +345,7 @@ fn ultraslow_test_validator_kickout() {
 /// Poll `/status` until you see the change of validator assignments.
 /// Afterwards check that `locked` amount on accounts Node1 and Node2 are 0 and TESTING_INIT_STAKE.
 #[test]
-fn ultraslow_test_validator_join() {
+fn ultra_slow_test_validator_join() {
     heavy_test(|| {
         let num_nodes = 4;
         let dirs = (0..num_nodes)
@@ -511,7 +511,7 @@ fn ultraslow_test_validator_join() {
 /// Checks that during the first epoch, total_supply matches total_supply in genesis.
 /// Checks that during the second epoch, total_supply matches the expected inflation rate.
 #[test]
-fn ultraslow_test_inflation() {
+fn ultra_slow_test_inflation() {
     heavy_test(|| {
         let num_nodes = 1;
         let dirs = (0..num_nodes)

--- a/integration-tests/src/tests/nearcore/sync_nodes.rs
+++ b/integration-tests/src/tests/nearcore/sync_nodes.rs
@@ -20,7 +20,7 @@ use std::sync::{Arc, RwLock};
 /// Starts one validation node, it reduces it's stake to 1/2 of the stake.
 /// Second node starts after 1s, needs to catchup & state sync and then make sure it's
 #[test]
-fn ultraslow_sync_state_stake_change() {
+fn ultraslow_test_sync_state_stake_change() {
     heavy_test(|| {
         init_integration_logger();
 

--- a/integration-tests/src/tests/nearcore/sync_nodes.rs
+++ b/integration-tests/src/tests/nearcore/sync_nodes.rs
@@ -20,8 +20,7 @@ use std::sync::{Arc, RwLock};
 /// Starts one validation node, it reduces it's stake to 1/2 of the stake.
 /// Second node starts after 1s, needs to catchup & state sync and then make sure it's
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn sync_state_stake_change() {
+fn ultraslow_sync_state_stake_change() {
     heavy_test(|| {
         init_integration_logger();
 

--- a/integration-tests/src/tests/nearcore/sync_nodes.rs
+++ b/integration-tests/src/tests/nearcore/sync_nodes.rs
@@ -20,7 +20,7 @@ use std::sync::{Arc, RwLock};
 /// Starts one validation node, it reduces it's stake to 1/2 of the stake.
 /// Second node starts after 1s, needs to catchup & state sync and then make sure it's
 #[test]
-fn ultraslow_test_sync_state_stake_change() {
+fn ultra_slow_test_sync_state_stake_change() {
     heavy_test(|| {
         init_integration_logger();
 

--- a/integration-tests/src/tests/nearcore/track_shards.rs
+++ b/integration-tests/src/tests/nearcore/track_shards.rs
@@ -13,7 +13,7 @@ use near_primitives::types::ShardId;
 use crate::tests::nearcore::node_cluster::NodeCluster;
 
 #[test]
-fn ultraslow_track_shards() {
+fn ultraslow_test_track_shards() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()

--- a/integration-tests/src/tests/nearcore/track_shards.rs
+++ b/integration-tests/src/tests/nearcore/track_shards.rs
@@ -13,8 +13,7 @@ use near_primitives::types::ShardId;
 use crate::tests::nearcore::node_cluster::NodeCluster;
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn track_shards() {
+fn ultraslow_track_shards() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()

--- a/integration-tests/src/tests/nearcore/track_shards.rs
+++ b/integration-tests/src/tests/nearcore/track_shards.rs
@@ -13,7 +13,7 @@ use near_primitives::types::ShardId;
 use crate::tests::nearcore::node_cluster::NodeCluster;
 
 #[test]
-fn ultraslow_test_track_shards() {
+fn ultra_slow_test_track_shards() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()

--- a/integration-tests/src/tests/runtime/test_evil_contracts.rs
+++ b/integration-tests/src/tests/runtime/test_evil_contracts.rs
@@ -39,7 +39,7 @@ fn setup_test_contract(wasm_binary: &[u8]) -> RuntimeNode {
 }
 
 #[test]
-fn test_evil_deep_trie() {
+fn slow_test_evil_deep_trie() {
     let node = setup_test_contract(near_test_contracts::rs_contract());
     for i in 0..50 {
         println!("insertStrings #{}", i);
@@ -88,7 +88,7 @@ fn test_evil_deep_trie() {
 /// Test delaying the conclusion of a receipt for as long as possible through the use of self
 /// cross-contract calls.
 #[test]
-fn test_self_delay() {
+fn slow_test_self_delay() {
     let node = setup_test_contract(near_test_contracts::rs_contract());
     let res = node
         .user()

--- a/integration-tests/src/tests/standard_cases/rpc.rs
+++ b/integration-tests/src/tests/standard_cases/rpc.rs
@@ -55,163 +55,136 @@ macro_rules! run_testnet_test {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_smart_contract_simple_testnet() {
+fn ultraslow_test_smart_contract_simple_testnet() {
     run_testnet_test!(test_smart_contract_simple);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_smart_contract_self_call_testnet() {
+fn ultraslow_test_smart_contract_self_call_testnet() {
     run_testnet_test!(test_smart_contract_self_call);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_smart_contract_bad_method_name_testnet() {
+fn ultraslow_test_smart_contract_bad_method_name_testnet() {
     run_testnet_test!(test_smart_contract_bad_method_name);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_smart_contract_empty_method_name_with_no_tokens_testnet() {
+fn ultraslow_test_smart_contract_empty_method_name_with_no_tokens_testnet() {
     run_testnet_test!(test_smart_contract_empty_method_name_with_no_tokens);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_smart_contract_empty_method_name_with_tokens_testnet() {
+fn ultraslow_test_smart_contract_empty_method_name_with_tokens_testnet() {
     run_testnet_test!(test_smart_contract_empty_method_name_with_tokens);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_smart_contract_with_args_testnet() {
+fn ultraslow_test_smart_contract_with_args_testnet() {
     run_testnet_test!(test_smart_contract_with_args);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_nonce_update_when_deploying_contract_testnet() {
+fn ultraslow_test_nonce_update_when_deploying_contract_testnet() {
     run_testnet_test!(test_nonce_update_when_deploying_contract);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_nonce_updated_when_tx_failed_testnet() {
+fn ultraslow_test_nonce_updated_when_tx_failed_testnet() {
     run_testnet_test!(test_nonce_updated_when_tx_failed);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_upload_contract_testnet() {
+fn ultraslow_test_upload_contract_testnet() {
     run_testnet_test!(test_upload_contract);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_redeploy_contract_testnet() {
+fn ultraslow_test_redeploy_contract_testnet() {
     run_testnet_test!(test_redeploy_contract);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_send_money_testnet() {
+fn ultraslow_test_send_money_testnet() {
     run_testnet_test!(test_send_money);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_send_money_over_balance_testnet() {
+fn ultraslow_test_send_money_over_balance_testnet() {
     run_testnet_test!(test_send_money_over_balance);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_refund_on_send_money_to_non_existent_account_testnet() {
+fn ultraslow_test_refund_on_send_money_to_non_existent_account_testnet() {
     run_testnet_test!(test_refund_on_send_money_to_non_existent_account);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_create_account_testnet() {
+fn ultraslow_test_create_account_testnet() {
     run_testnet_test!(test_create_account);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_create_account_again_testnet() {
+fn ultraslow_test_create_account_again_testnet() {
     run_testnet_test!(test_create_account_again);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_create_account_failure_already_exists_testnet() {
+fn ultraslow_test_create_account_failure_already_exists_testnet() {
     run_testnet_test!(test_create_account_failure_already_exists);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_swap_key_testnet() {
+fn ultraslow_test_swap_key_testnet() {
     run_testnet_test!(test_swap_key);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_add_access_key_function_call_testnet() {
+fn ultraslow_test_add_access_key_function_call_testnet() {
     run_testnet_test!(test_add_access_key_function_call);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_add_existing_key_testnet() {
+fn ultraslow_test_add_existing_key_testnet() {
     run_testnet_test!(test_add_existing_key);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_delete_key_testnet() {
+fn ultraslow_test_delete_key_testnet() {
     run_testnet_test!(test_delete_key);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_delete_key_not_owned_testnet() {
+fn ultraslow_test_delete_key_not_owned_testnet() {
     run_testnet_test!(test_delete_key_not_owned);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_delete_key_last_testnet() {
+fn ultraslow_test_delete_key_last_testnet() {
     run_testnet_test!(test_delete_key_last);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_add_key_testnet() {
+fn ultraslow_test_add_key_testnet() {
     run_testnet_test!(test_add_key);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_delete_access_key_testnet() {
+fn ultraslow_test_delete_access_key_testnet() {
     run_testnet_test!(test_delete_access_key);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_add_access_key_with_allowance_testnet() {
+fn ultraslow_test_add_access_key_with_allowance_testnet() {
     run_testnet_test!(test_add_access_key_with_allowance);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_delete_access_key_with_allowance_testnet() {
+fn ultraslow_test_delete_access_key_with_allowance_testnet() {
     run_testnet_test!(test_delete_access_key_with_allowance);
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_access_key_smart_contract_testnet() {
+fn ultraslow_test_access_key_smart_contract_testnet() {
     run_testnet_test!(test_access_key_smart_contract);
 }

--- a/integration-tests/src/tests/standard_cases/rpc.rs
+++ b/integration-tests/src/tests/standard_cases/rpc.rs
@@ -55,136 +55,136 @@ macro_rules! run_testnet_test {
 }
 
 #[test]
-fn ultraslow_test_smart_contract_simple_testnet() {
+fn ultra_slow_test_smart_contract_simple_testnet() {
     run_testnet_test!(test_smart_contract_simple);
 }
 
 #[test]
-fn ultraslow_test_smart_contract_self_call_testnet() {
+fn ultra_slow_test_smart_contract_self_call_testnet() {
     run_testnet_test!(test_smart_contract_self_call);
 }
 
 #[test]
-fn ultraslow_test_smart_contract_bad_method_name_testnet() {
+fn ultra_slow_test_smart_contract_bad_method_name_testnet() {
     run_testnet_test!(test_smart_contract_bad_method_name);
 }
 
 #[test]
-fn ultraslow_test_smart_contract_empty_method_name_with_no_tokens_testnet() {
+fn ultra_slow_test_smart_contract_empty_method_name_with_no_tokens_testnet() {
     run_testnet_test!(test_smart_contract_empty_method_name_with_no_tokens);
 }
 
 #[test]
-fn ultraslow_test_smart_contract_empty_method_name_with_tokens_testnet() {
+fn ultra_slow_test_smart_contract_empty_method_name_with_tokens_testnet() {
     run_testnet_test!(test_smart_contract_empty_method_name_with_tokens);
 }
 
 #[test]
-fn ultraslow_test_smart_contract_with_args_testnet() {
+fn ultra_slow_test_smart_contract_with_args_testnet() {
     run_testnet_test!(test_smart_contract_with_args);
 }
 
 #[test]
-fn ultraslow_test_nonce_update_when_deploying_contract_testnet() {
+fn ultra_slow_test_nonce_update_when_deploying_contract_testnet() {
     run_testnet_test!(test_nonce_update_when_deploying_contract);
 }
 
 #[test]
-fn ultraslow_test_nonce_updated_when_tx_failed_testnet() {
+fn ultra_slow_test_nonce_updated_when_tx_failed_testnet() {
     run_testnet_test!(test_nonce_updated_when_tx_failed);
 }
 
 #[test]
-fn ultraslow_test_upload_contract_testnet() {
+fn ultra_slow_test_upload_contract_testnet() {
     run_testnet_test!(test_upload_contract);
 }
 
 #[test]
-fn ultraslow_test_redeploy_contract_testnet() {
+fn ultra_slow_test_redeploy_contract_testnet() {
     run_testnet_test!(test_redeploy_contract);
 }
 
 #[test]
-fn ultraslow_test_send_money_testnet() {
+fn ultra_slow_test_send_money_testnet() {
     run_testnet_test!(test_send_money);
 }
 
 #[test]
-fn ultraslow_test_send_money_over_balance_testnet() {
+fn ultra_slow_test_send_money_over_balance_testnet() {
     run_testnet_test!(test_send_money_over_balance);
 }
 
 #[test]
-fn ultraslow_test_refund_on_send_money_to_non_existent_account_testnet() {
+fn ultra_slow_test_refund_on_send_money_to_non_existent_account_testnet() {
     run_testnet_test!(test_refund_on_send_money_to_non_existent_account);
 }
 
 #[test]
-fn ultraslow_test_create_account_testnet() {
+fn ultra_slow_test_create_account_testnet() {
     run_testnet_test!(test_create_account);
 }
 
 #[test]
-fn ultraslow_test_create_account_again_testnet() {
+fn ultra_slow_test_create_account_again_testnet() {
     run_testnet_test!(test_create_account_again);
 }
 
 #[test]
-fn ultraslow_test_create_account_failure_already_exists_testnet() {
+fn ultra_slow_test_create_account_failure_already_exists_testnet() {
     run_testnet_test!(test_create_account_failure_already_exists);
 }
 
 #[test]
-fn ultraslow_test_swap_key_testnet() {
+fn ultra_slow_test_swap_key_testnet() {
     run_testnet_test!(test_swap_key);
 }
 
 #[test]
-fn ultraslow_test_add_access_key_function_call_testnet() {
+fn ultra_slow_test_add_access_key_function_call_testnet() {
     run_testnet_test!(test_add_access_key_function_call);
 }
 
 #[test]
-fn ultraslow_test_add_existing_key_testnet() {
+fn ultra_slow_test_add_existing_key_testnet() {
     run_testnet_test!(test_add_existing_key);
 }
 
 #[test]
-fn ultraslow_test_delete_key_testnet() {
+fn ultra_slow_test_delete_key_testnet() {
     run_testnet_test!(test_delete_key);
 }
 
 #[test]
-fn ultraslow_test_delete_key_not_owned_testnet() {
+fn ultra_slow_test_delete_key_not_owned_testnet() {
     run_testnet_test!(test_delete_key_not_owned);
 }
 
 #[test]
-fn ultraslow_test_delete_key_last_testnet() {
+fn ultra_slow_test_delete_key_last_testnet() {
     run_testnet_test!(test_delete_key_last);
 }
 
 #[test]
-fn ultraslow_test_add_key_testnet() {
+fn ultra_slow_test_add_key_testnet() {
     run_testnet_test!(test_add_key);
 }
 
 #[test]
-fn ultraslow_test_delete_access_key_testnet() {
+fn ultra_slow_test_delete_access_key_testnet() {
     run_testnet_test!(test_delete_access_key);
 }
 
 #[test]
-fn ultraslow_test_add_access_key_with_allowance_testnet() {
+fn ultra_slow_test_add_access_key_with_allowance_testnet() {
     run_testnet_test!(test_add_access_key_with_allowance);
 }
 
 #[test]
-fn ultraslow_test_delete_access_key_with_allowance_testnet() {
+fn ultra_slow_test_delete_access_key_with_allowance_testnet() {
     run_testnet_test!(test_delete_access_key_with_allowance);
 }
 
 #[test]
-fn ultraslow_test_access_key_smart_contract_testnet() {
+fn ultra_slow_test_access_key_smart_contract_testnet() {
     run_testnet_test!(test_access_key_smart_contract);
 }

--- a/integration-tests/src/tests/test_catchup.rs
+++ b/integration-tests/src/tests/test_catchup.rs
@@ -7,8 +7,7 @@ use std::sync::{Arc, RwLock};
 use super::test_helpers::{heavy_test, wait};
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_catchup() {
+fn ultraslow_test_catchup() {
     /// Creates a network of `num_nodes` nodes, but starts only `num_nodes - 1`. After
     /// `num_blocks_to_wait` starts the last node and verifies that it can start validating within
     /// `catchup_timeout`.

--- a/integration-tests/src/tests/test_catchup.rs
+++ b/integration-tests/src/tests/test_catchup.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, RwLock};
 use super::test_helpers::{heavy_test, wait};
 
 #[test]
-fn ultraslow_test_catchup() {
+fn ultra_slow_test_catchup() {
     /// Creates a network of `num_nodes` nodes, but starts only `num_nodes - 1`. After
     /// `num_blocks_to_wait` starts the last node and verifies that it can start validating within
     /// `catchup_timeout`.

--- a/integration-tests/src/tests/test_simple.rs
+++ b/integration-tests/src/tests/test_simple.rs
@@ -68,19 +68,16 @@ fn run_multiple_nodes(num_nodes: usize, num_trials: usize, test_prefix: &str) {
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_2_10_multiple_nodes() {
+fn ultraslow_test_2_10_multiple_nodes() {
     heavy_test(|| run_multiple_nodes(2, 10, "2_10"));
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_4_10_multiple_nodes() {
+fn ultraslow_test_4_10_multiple_nodes() {
     heavy_test(|| run_multiple_nodes(4, 10, "4_10"));
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_7_10_multiple_nodes() {
+fn ultraslow_test_7_10_multiple_nodes() {
     heavy_test(|| run_multiple_nodes(7, 10, "7_10"));
 }

--- a/integration-tests/src/tests/test_simple.rs
+++ b/integration-tests/src/tests/test_simple.rs
@@ -68,16 +68,16 @@ fn run_multiple_nodes(num_nodes: usize, num_trials: usize, test_prefix: &str) {
 }
 
 #[test]
-fn ultraslow_test_2_10_multiple_nodes() {
+fn ultra_slow_test_2_10_multiple_nodes() {
     heavy_test(|| run_multiple_nodes(2, 10, "2_10"));
 }
 
 #[test]
-fn ultraslow_test_4_10_multiple_nodes() {
+fn ultra_slow_test_4_10_multiple_nodes() {
     heavy_test(|| run_multiple_nodes(4, 10, "4_10"));
 }
 
 #[test]
-fn ultraslow_test_7_10_multiple_nodes() {
+fn ultra_slow_test_7_10_multiple_nodes() {
     heavy_test(|| run_multiple_nodes(7, 10, "7_10"));
 }

--- a/integration-tests/src/tests/test_tps_regression.rs
+++ b/integration-tests/src/tests/test_tps_regression.rs
@@ -160,8 +160,7 @@ fn run_multiple_nodes(
 }
 
 #[test]
-#[cfg_attr(not(feature = "expensive_tests"), ignore)]
-fn test_highload() {
+fn ultraslow_test_highload() {
     // Run 4 nodes with 20 input tps and check the output tps to be 20.
     heavy_test(|| run_multiple_nodes(4, 20, 20, Duration::from_secs(120), "4_20"));
 }

--- a/integration-tests/src/tests/test_tps_regression.rs
+++ b/integration-tests/src/tests/test_tps_regression.rs
@@ -160,7 +160,7 @@ fn run_multiple_nodes(
 }
 
 #[test]
-fn ultraslow_test_highload() {
+fn ultra_slow_test_highload() {
     // Run 4 nodes with 20 input tps and check the output tps to be 20.
     heavy_test(|| run_multiple_nodes(4, 20, 20, Duration::from_secs(120), "4_20"));
 }

--- a/nightly/README.md
+++ b/nightly/README.md
@@ -42,13 +42,11 @@ implicitly set.
 The `expensive` tests run a test binary and execute specific test in
 it.  (Test binaries are those built via `cargo test --no-run`).  While
 this can be used to run any Rust test, the intention is to run
-expensive tests only.  Those are the tests which are ignored unless
-`expensive_tests` crate feature is enabled.  Such tests should be
-marked with a `cfg_attr` macro, e.g.:
+expensive tests only.  Those are the tests which are normally ignored unless
+their name is prefixed with `ultraslow_test` like so:
 
     #[test]
-    #[cfg_attr(not(feature = "expensive_tests"), ignore)]
-    fn test_gc_boundaries_large() {
+    fn ultraslow_test_gc_boundaries_large() {
         /* ... */
     }
 
@@ -56,7 +54,7 @@ The arguments of an expensive test specify package in which the test
 is defined, test binary name and the full path to the test function.
 For example:
 
-    expensive nearcore test_tps_regression test::test_highload
+    expensive nearcore test_tps_regression test::ultraslow_test_highload
 
 (Currently the package name is ignored but it may change in the future
 so make sure it’s set correctly).  The path to the test function must
@@ -157,13 +155,11 @@ run can take over an hour to finish.
 New tests can be created either as a Rust test or a pytest.
 
 If a Rust test is long-running (or otherwise requires a lot of
-resources) and intended to be run as a nightly test on NayDuck it
-should be marked with a `#[cfg(feature = "expensive_tests")]`
-directive (either on the test function or module containing it).  With
-that, the tests will not be part of a `cargo test` run performed on
-every commit, but NayDuck will be able to execute them.  Apart from
-that, expensive Rust tests work exactly the same as any other Rust
-tests.
+resources) and intended to be run as a nightly test on NayDuck it's
+name should be marked prefixed with `ultraslow_test`.  With that, the
+tests will not be part of a `cargo test` run performed on every
+commit, but NayDuck will be able to execute them. Apart from that,
+expensive Rust tests work exactly the same as any other Rust tests.
 
 pytests are defined as scripts in the `pytest/tests` directory.  As
 previously mentioned, even though the directory is called pytest, when

--- a/nightly/README.md
+++ b/nightly/README.md
@@ -43,10 +43,10 @@ The `expensive` tests run a test binary and execute specific test in
 it.  (Test binaries are those built via `cargo test --no-run`).  While
 this can be used to run any Rust test, the intention is to run
 expensive tests only.  Those are the tests which are normally ignored unless
-their name is prefixed with `ultraslow_test` like so:
+their name is prefixed with `ultra_slow_test` like so:
 
     #[test]
-    fn ultraslow_test_gc_boundaries_large() {
+    fn ultra_slow_test_gc_boundaries_large() {
         /* ... */
     }
 
@@ -54,7 +54,7 @@ The arguments of an expensive test specify package in which the test
 is defined, test binary name and the full path to the test function.
 For example:
 
-    expensive nearcore test_tps_regression test::ultraslow_test_highload
+    expensive nearcore test_tps_regression test::ultra_slow_test_highload
 
 (Currently the package name is ignored but it may change in the future
 so make sure it’s set correctly).  The path to the test function must
@@ -156,7 +156,7 @@ New tests can be created either as a Rust test or a pytest.
 
 If a Rust test is long-running (or otherwise requires a lot of
 resources) and intended to be run as a nightly test on NayDuck it's
-name should be marked prefixed with `ultraslow_test`.  With that, the
+name should be marked prefixed with `ultra_slow_test`.  With that, the
 tests will not be part of a `cargo test` run performed on every
 commit, but NayDuck will be able to execute them. Apart from that,
 expensive Rust tests work exactly the same as any other Rust tests.

--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -231,3 +231,5 @@ expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultr
 
 expensive integration-tests integration_tests tests::nearcore::track_shards::ultraslow_test_track_shards
 expensive integration-tests integration_tests tests::nearcore::track_shards::ultraslow_test_track_shards --features nightly
+
+expensive estimator-warehouse estimator-warehouse tests::ultraslow_test_full_estimator

--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -1,124 +1,124 @@
 # catchup tests
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_receipts_sync_third_epoch
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_receipts_sync_third_epoch --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_receipts_sync_last_block
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_receipts_sync_last_block --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_receipts_sync_distant_epoch
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_receipts_sync_distant_epoch --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync_skip_15
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync_skip_15 --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync_send_15
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync_send_15 --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync_non_zero_amounts
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync_non_zero_amounts --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync_height_6
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_random_single_part_sync_height_6 --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_sanity_blocks_produced
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_sanity_blocks_produced --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_receipts_sync_hold
-expensive --timeout=1800 near-client near_client tests::catching_up::test_catchup_receipts_sync_hold --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_receipts_sync_third_epoch
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_receipts_sync_third_epoch --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_receipts_sync_last_block
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_receipts_sync_last_block --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_receipts_sync_distant_epoch
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_receipts_sync_distant_epoch --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync_skip_15
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync_skip_15 --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync_send_15
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync_send_15 --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync_non_zero_amounts
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync_non_zero_amounts --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync_height_6
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync_height_6 --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_sanity_blocks_produced
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_sanity_blocks_produced --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_receipts_sync_hold
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_receipts_sync_hold --features nightly
 
-expensive integration-tests integration_tests tests::test_catchup::test_catchup
-expensive integration-tests integration_tests tests::test_catchup::test_catchup --features nightly
+expensive integration-tests integration_tests tests::test_catchup::ultraslow_test_catchup
+expensive integration-tests integration_tests tests::test_catchup::ultraslow_test_catchup --features nightly
 
 # cross-shard transactions tests
 # TODO(#4618): Those tests are currently broken.  Comment out while we’re
 # working on a fix / deciding whether to remove them.
-# expensive --timeout=3000 near-client near_client tests::cross_shard_tx::test_cross_shard_tx
-# expensive --timeout=3000 near-client near_client tests::cross_shard_tx::test_cross_shard_tx --features nightly
-expensive --timeout=3000 near-client near_client tests::cross_shard_tx::test_cross_shard_tx_doomslug
-expensive --timeout=3000 near-client near_client tests::cross_shard_tx::test_cross_shard_tx_doomslug --features nightly
-expensive --timeout=3000 near-client near_client tests::cross_shard_tx::test_cross_shard_tx_drop_chunks
-expensive --timeout=3000 near-client near_client tests::cross_shard_tx::test_cross_shard_tx_drop_chunks --features nightly
+# expensive --timeout=3000 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx
+# expensive --timeout=3000 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx --features nightly
+expensive --timeout=3000 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx_doomslug
+expensive --timeout=3000 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx_doomslug --features nightly
+expensive --timeout=3000 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx_drop_chunks
+expensive --timeout=3000 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx_drop_chunks --features nightly
 # TODO(#4618): Those tests are currently broken.  Comment out while we’re
 # working on a fix / deciding whether to remove them.
-# expensive --timeout=5400 near-client near_client tests::cross_shard_tx::test_cross_shard_tx_with_validator_rotation_1
-# expensive --timeout=5400 near-client near_client tests::cross_shard_tx::test_cross_shard_tx_with_validator_rotation_1 --features nightly
-# expensive --timeout=5400 near-client near_client tests::cross_shard_tx::test_cross_shard_tx_with_validator_rotation_2
-# expensive --timeout=5400 near-client near_client tests::cross_shard_tx::test_cross_shard_tx_with_validator_rotation_2 --features nightly
-# expensive --timeout=4800 near-client near_client tests::cross_shard_tx::test_cross_shard_tx_8_iterations
-# expensive --timeout=4800 near-client near_client tests::cross_shard_tx::test_cross_shard_tx_8_iterations_drop_chunks
+# expensive --timeout=5400 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx_with_validator_rotation_1
+# expensive --timeout=5400 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx_with_validator_rotation_1 --features nightly
+# expensive --timeout=5400 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx_with_validator_rotation_2
+# expensive --timeout=5400 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx_with_validator_rotation_2 --features nightly
+# expensive --timeout=4800 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx_8_iterations
+# expensive --timeout=4800 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx_8_iterations_drop_chunks
 
 # consensus tests
-expensive --timeout=3000 near-chain near_chain tests::doomslug::test_fuzzy_doomslug_liveness_and_safety
-expensive --timeout=3000 near-chain near_chain tests::doomslug::test_fuzzy_doomslug_liveness_and_safety --features nightly
-expensive --timeout=500 near-client near_client tests::consensus::test_consensus_with_epoch_switches
-expensive --timeout=500 near-client near_client tests::consensus::test_consensus_with_epoch_switches --features nightly
+expensive --timeout=3000 near-chain near_chain tests::doomslug::ultraslow_test_fuzzy_doomslug_liveness_and_safety
+expensive --timeout=3000 near-chain near_chain tests::doomslug::ultraslow_test_fuzzy_doomslug_liveness_and_safety --features nightly
+expensive --timeout=500 near-client near_client tests::consensus::ultraslow_test_consensus_with_epoch_switches
+expensive --timeout=500 near-client near_client tests::consensus::ultraslow_test_consensus_with_epoch_switches --features nightly
 
 # testnet rpc
-expensive integration-tests integration_tests tests::test_tps_regression::test_highload
-expensive integration-tests integration_tests tests::test_tps_regression::test_highload --features nightly
+expensive integration-tests integration_tests tests::test_tps_regression::ultraslow_test_highload
+expensive integration-tests integration_tests tests::test_tps_regression::ultraslow_test_highload --features nightly
 
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_access_key_smart_contract_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_access_key_smart_contract_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_add_access_key_function_call_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_add_access_key_function_call_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_add_access_key_with_allowance_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_add_access_key_with_allowance_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_add_existing_key_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_add_existing_key_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_add_key_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_add_key_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_create_account_again_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_create_account_again_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_create_account_failure_already_exists_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_create_account_failure_already_exists_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_create_account_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_create_account_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_delete_access_key_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_delete_access_key_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_delete_access_key_with_allowance_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_delete_access_key_with_allowance_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_delete_key_last_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_delete_key_last_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_delete_key_not_owned_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_delete_key_not_owned_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_delete_key_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_delete_key_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_nonce_update_when_deploying_contract_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_nonce_update_when_deploying_contract_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_nonce_updated_when_tx_failed_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_nonce_updated_when_tx_failed_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_redeploy_contract_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_redeploy_contract_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_refund_on_send_money_to_non_existent_account_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_refund_on_send_money_to_non_existent_account_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_send_money_over_balance_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_send_money_over_balance_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_send_money_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_send_money_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_smart_contract_bad_method_name_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_smart_contract_bad_method_name_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_smart_contract_empty_method_name_with_no_tokens_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_smart_contract_empty_method_name_with_no_tokens_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_smart_contract_empty_method_name_with_tokens_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_smart_contract_empty_method_name_with_tokens_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_smart_contract_self_call_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_smart_contract_self_call_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_smart_contract_simple_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_smart_contract_simple_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_smart_contract_with_args_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_smart_contract_with_args_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_swap_key_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_swap_key_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_upload_contract_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::test_upload_contract_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_access_key_smart_contract_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_access_key_smart_contract_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_add_access_key_function_call_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_add_access_key_function_call_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_add_access_key_with_allowance_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_add_access_key_with_allowance_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_add_existing_key_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_add_existing_key_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_add_key_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_add_key_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_create_account_again_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_create_account_again_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_create_account_failure_already_exists_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_create_account_failure_already_exists_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_create_account_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_create_account_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_delete_access_key_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_delete_access_key_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_delete_access_key_with_allowance_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_delete_access_key_with_allowance_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_delete_key_last_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_delete_key_last_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_delete_key_not_owned_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_delete_key_not_owned_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_delete_key_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_delete_key_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_nonce_update_when_deploying_contract_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_nonce_update_when_deploying_contract_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_nonce_updated_when_tx_failed_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_nonce_updated_when_tx_failed_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_redeploy_contract_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_redeploy_contract_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_refund_on_send_money_to_non_existent_account_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_refund_on_send_money_to_non_existent_account_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_send_money_over_balance_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_send_money_over_balance_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_send_money_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_send_money_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_bad_method_name_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_bad_method_name_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_empty_method_name_with_no_tokens_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_empty_method_name_with_no_tokens_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_empty_method_name_with_tokens_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_empty_method_name_with_tokens_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_self_call_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_self_call_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_simple_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_simple_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_with_args_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_with_args_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_swap_key_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_swap_key_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_upload_contract_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_upload_contract_testnet --features nightly
 
 # GC tests
-expensive --timeout=900 near-chain near_chain tests::garbage_collection::test_gc_remove_fork_large
-expensive --timeout=900 near-chain near_chain tests::garbage_collection::test_gc_remove_fork_large --features nightly
-expensive --timeout=1200 near-chain near_chain tests::garbage_collection::test_gc_not_remove_fork_large
-expensive --timeout=1200 near-chain near_chain tests::garbage_collection::test_gc_not_remove_fork_large --features nightly
-expensive --timeout=1200 near-chain near_chain tests::garbage_collection::test_gc_boundaries_large
-expensive --timeout=1200 near-chain near_chain tests::garbage_collection::test_gc_boundaries_large --features nightly
-expensive --timeout=900 near-chain near_chain tests::garbage_collection::test_gc_random_large
-expensive --timeout=900 near-chain near_chain tests::garbage_collection::test_gc_random_large --features nightly
-expensive --timeout=600 near-chain near_chain tests::garbage_collection::test_gc_pine
-expensive --timeout=600 near-chain near_chain tests::garbage_collection::test_gc_pine --features nightly
-expensive --timeout=700 near-chain near_chain tests::garbage_collection::test_gc_star_large
-expensive --timeout=700 near-chain near_chain tests::garbage_collection::test_gc_star_large --features nightly
+expensive --timeout=900 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_remove_fork_large
+expensive --timeout=900 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_remove_fork_large --features nightly
+expensive --timeout=1200 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_not_remove_fork_large
+expensive --timeout=1200 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_not_remove_fork_large --features nightly
+expensive --timeout=1200 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_boundaries_large
+expensive --timeout=1200 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_boundaries_large --features nightly
+expensive --timeout=900 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_random_large
+expensive --timeout=900 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_random_large --features nightly
+expensive --timeout=600 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_pine
+expensive --timeout=600 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_pine --features nightly
+expensive --timeout=700 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_star_large
+expensive --timeout=700 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_star_large --features nightly
 
 expensive --timeout=1200 integration-tests integration_tests tests::client::block_corruption::check_process_flipped_block_fails
 expensive --timeout=1200 integration-tests integration_tests tests::client::block_corruption::check_process_flipped_block_fails --features nightly
@@ -150,10 +150,10 @@ expensive integration-tests integration_tests tests::client::chunks_management::
 expensive integration-tests integration_tests tests::client::chunks_management::chunks_produced_and_distributed_one_val_per_shard_should_succeed_even_without_forwarding --features nightly
 expensive integration-tests integration_tests tests::client::chunks_management::chunks_produced_and_distributed_one_val_shard_cop
 expensive integration-tests integration_tests tests::client::chunks_management::chunks_produced_and_distributed_one_val_shard_cop --features nightly
-expensive integration-tests integration_tests tests::client::process_blocks::test_gc_after_state_sync
-expensive integration-tests integration_tests tests::client::process_blocks::test_gc_after_state_sync --features nightly
-expensive integration-tests integration_tests tests::client::process_blocks::test_process_block_after_state_sync
-expensive integration-tests integration_tests tests::client::process_blocks::test_process_block_after_state_sync --features nightly
+expensive integration-tests integration_tests tests::client::process_blocks::ultraslow_test_gc_after_state_sync
+expensive integration-tests integration_tests tests::client::process_blocks::ultraslow_test_gc_after_state_sync --features nightly
+expensive integration-tests integration_tests tests::client::process_blocks::ultraslow_test_process_block_after_state_sync
+expensive integration-tests integration_tests tests::client::process_blocks::ultraslow_test_process_block_after_state_sync --features nightly
 expensive integration-tests integration_tests tests::client::sync_state_nodes::sync_empty_state
 expensive integration-tests integration_tests tests::client::sync_state_nodes::sync_empty_state --features nightly
 expensive integration-tests integration_tests tests::client::sync_state_nodes::sync_state_dump
@@ -164,53 +164,53 @@ expensive integration-tests integration_tests tests::client::sync_state_nodes::s
 expensive integration-tests integration_tests tests::client::sync_state_nodes::sync_state_nodes_multishard --features nightly
 
 # other tests
-expensive --timeout=300 near-chain near_chain tests::garbage_collection::test_clear_old_data_too_many_heights
+expensive --timeout=300 near-chain near_chain tests::garbage_collection::ultraslow_test_clear_old_data_too_many_heights
 
-expensive integration-tests integration_tests tests::test_simple::test_2_10_multiple_nodes
-expensive integration-tests integration_tests tests::test_simple::test_2_10_multiple_nodes --features nightly
-expensive integration-tests integration_tests tests::test_simple::test_4_10_multiple_nodes
-expensive integration-tests integration_tests tests::test_simple::test_4_10_multiple_nodes --features nightly
-expensive integration-tests integration_tests tests::test_simple::test_7_10_multiple_nodes
-expensive integration-tests integration_tests tests::test_simple::test_7_10_multiple_nodes --features nightly
+expensive integration-tests integration_tests tests::test_simple::ultraslow_test_2_10_multiple_nodes
+expensive integration-tests integration_tests tests::test_simple::ultraslow_test_2_10_multiple_nodes --features nightly
+expensive integration-tests integration_tests tests::test_simple::ultraslow_test_4_10_multiple_nodes
+expensive integration-tests integration_tests tests::test_simple::ultraslow_test_4_10_multiple_nodes --features nightly
+expensive integration-tests integration_tests tests::test_simple::ultraslow_test_7_10_multiple_nodes
+expensive integration-tests integration_tests tests::test_simple::ultraslow_test_7_10_multiple_nodes --features nightly
 
 expensive integration-tests integration_tests tests::nearcore::sync_nodes::sync_state_stake_change
 expensive integration-tests integration_tests tests::nearcore::sync_nodes::sync_state_stake_change --features nightly
 
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::test_block_unknown_block_error
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::test_block_unknown_block_error --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::test_chunk_unknown_chunk_error
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::test_chunk_unknown_chunk_error --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::test_gas_price_unknown_block_error
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::test_gas_price_unknown_block_error --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::test_protocol_config_unknown_block_error
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::test_protocol_config_unknown_block_error --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::test_query_rpc_account_view_unknown_block_must_return_error
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::test_query_rpc_account_view_unknown_block_must_return_error --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::test_receipt_id_unknown_receipt_error
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::test_receipt_id_unknown_receipt_error --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::test_tx_invalid_tx_error
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::test_tx_invalid_tx_error --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_block_unknown_block_error
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_block_unknown_block_error --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_chunk_unknown_chunk_error
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_chunk_unknown_chunk_error --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_gas_price_unknown_block_error
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_gas_price_unknown_block_error --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_protocol_config_unknown_block_error
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_protocol_config_unknown_block_error --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_query_rpc_account_view_unknown_block_must_return_error
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_query_rpc_account_view_unknown_block_must_return_error --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_receipt_id_unknown_receipt_error
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_receipt_id_unknown_receipt_error --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_tx_invalid_tx_error
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_tx_invalid_tx_error --features nightly
 
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_tx_status_on_lightclient_must_return_does_not_track_shard
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_tx_status_on_lightclient_must_return_does_not_track_shard --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_check_unknown_tx_must_return_error
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_check_unknown_tx_must_return_error --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_get_execution_outcome_tx_failure
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_get_execution_outcome_tx_failure --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_get_execution_outcome_tx_success
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_get_execution_outcome_tx_success --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_get_validator_info_rpc
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_get_validator_info_rpc --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_protocol_config_rpc
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_protocol_config_rpc --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_query_rpc_account_view_account_doesnt_exist_must_return_error
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_query_rpc_account_view_account_doesnt_exist_must_return_error --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_query_rpc_account_view_must_succeed
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_query_rpc_account_view_must_succeed --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_tx_not_enough_balance_must_return_error
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_tx_not_enough_balance_must_return_error --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_validators_by_epoch_id_current_epoch_not_fails
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::test_validators_by_epoch_id_current_epoch_not_fails --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_tx_status_on_lightclient_must_return_does_not_track_shard
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_tx_status_on_lightclient_must_return_does_not_track_shard --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_check_unknown_tx_must_return_error
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_check_unknown_tx_must_return_error --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_get_execution_outcome_tx_failure
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_get_execution_outcome_tx_failure --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_get_execution_outcome_tx_success
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_get_execution_outcome_tx_success --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_get_validator_info_rpc
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_get_validator_info_rpc --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_protocol_config_rpc
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_protocol_config_rpc --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_query_rpc_account_view_account_doesnt_exist_must_return_error
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_query_rpc_account_view_account_doesnt_exist_must_return_error --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_query_rpc_account_view_must_succeed
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_query_rpc_account_view_must_succeed --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_tx_not_enough_balance_must_return_error
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_tx_not_enough_balance_must_return_error --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_validators_by_epoch_id_current_epoch_not_fails
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_validators_by_epoch_id_current_epoch_not_fails --features nightly
 expensive integration-tests integration_tests tests::nearcore::run_nodes::run_nodes_1_2_1
 expensive integration-tests integration_tests tests::nearcore::run_nodes::run_nodes_1_2_1 --features nightly
 expensive integration-tests integration_tests tests::nearcore::run_nodes::run_nodes_1_2_2
@@ -220,14 +220,14 @@ expensive integration-tests integration_tests tests::nearcore::run_nodes::run_no
 expensive integration-tests integration_tests tests::nearcore::run_nodes::run_nodes_4_4_2
 expensive integration-tests integration_tests tests::nearcore::run_nodes::run_nodes_4_4_2 --features nightly
 
-expensive integration-tests integration_tests tests::nearcore::stake_nodes::test_inflation
-expensive integration-tests integration_tests tests::nearcore::stake_nodes::test_inflation --features nightly
-expensive integration-tests integration_tests tests::nearcore::stake_nodes::test_stake_nodes
-expensive integration-tests integration_tests tests::nearcore::stake_nodes::test_stake_nodes --features nightly
-expensive integration-tests integration_tests tests::nearcore::stake_nodes::test_validator_join
-expensive integration-tests integration_tests tests::nearcore::stake_nodes::test_validator_join --features nightly
-expensive integration-tests integration_tests tests::nearcore::stake_nodes::test_validator_kickout
-expensive integration-tests integration_tests tests::nearcore::stake_nodes::test_validator_kickout --features nightly
+expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultraslow_test_inflation
+expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultraslow_test_inflation --features nightly
+expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultraslow_test_stake_nodes
+expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultraslow_test_stake_nodes --features nightly
+expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultraslow_test_validator_join
+expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultraslow_test_validator_join --features nightly
+expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultraslow_test_validator_kickout
+expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultraslow_test_validator_kickout --features nightly
 
 expensive integration-tests integration_tests tests::nearcore::track_shards::track_shards
 expensive integration-tests integration_tests tests::nearcore::track_shards::track_shards --features nightly

--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -1,235 +1,235 @@
 # catchup tests
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_receipts_sync_third_epoch
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_receipts_sync_third_epoch --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_receipts_sync_last_block
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_receipts_sync_last_block --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_receipts_sync_distant_epoch
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_receipts_sync_distant_epoch --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync_skip_15
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync_skip_15 --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync_send_15
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync_send_15 --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync_non_zero_amounts
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync_non_zero_amounts --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync_height_6
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_random_single_part_sync_height_6 --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_sanity_blocks_produced
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_sanity_blocks_produced --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_receipts_sync_hold
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_catchup_receipts_sync_hold --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_receipts_sync_third_epoch
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_receipts_sync_third_epoch --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_receipts_sync_last_block
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_receipts_sync_last_block --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_receipts_sync_distant_epoch
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_receipts_sync_distant_epoch --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_random_single_part_sync
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_random_single_part_sync --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_random_single_part_sync_skip_15
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_random_single_part_sync_skip_15 --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_random_single_part_sync_send_15
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_random_single_part_sync_send_15 --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_random_single_part_sync_non_zero_amounts
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_random_single_part_sync_non_zero_amounts --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_random_single_part_sync_height_6
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_random_single_part_sync_height_6 --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_sanity_blocks_produced
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_sanity_blocks_produced --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_receipts_sync_hold
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_catchup_receipts_sync_hold --features nightly
 
-expensive integration-tests integration_tests tests::test_catchup::ultraslow_test_catchup
-expensive integration-tests integration_tests tests::test_catchup::ultraslow_test_catchup --features nightly
+expensive integration-tests integration_tests tests::test_catchup::ultra_slow_test_catchup
+expensive integration-tests integration_tests tests::test_catchup::ultra_slow_test_catchup --features nightly
 
 # cross-shard transactions tests
 # TODO(#4618): Those tests are currently broken.  Comment out while we’re
 # working on a fix / deciding whether to remove them.
-# expensive --timeout=3000 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx
-# expensive --timeout=3000 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx --features nightly
-expensive --timeout=3000 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx_doomslug
-expensive --timeout=3000 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx_doomslug --features nightly
-expensive --timeout=3000 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx_drop_chunks
-expensive --timeout=3000 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx_drop_chunks --features nightly
+# expensive --timeout=3000 near-client near_client tests::cross_shard_tx::ultra_slow_test_cross_shard_tx
+# expensive --timeout=3000 near-client near_client tests::cross_shard_tx::ultra_slow_test_cross_shard_tx --features nightly
+expensive --timeout=3000 near-client near_client tests::cross_shard_tx::ultra_slow_test_cross_shard_tx_doomslug
+expensive --timeout=3000 near-client near_client tests::cross_shard_tx::ultra_slow_test_cross_shard_tx_doomslug --features nightly
+expensive --timeout=3000 near-client near_client tests::cross_shard_tx::ultra_slow_test_cross_shard_tx_drop_chunks
+expensive --timeout=3000 near-client near_client tests::cross_shard_tx::ultra_slow_test_cross_shard_tx_drop_chunks --features nightly
 # TODO(#4618): Those tests are currently broken.  Comment out while we’re
 # working on a fix / deciding whether to remove them.
-# expensive --timeout=5400 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx_with_validator_rotation_1
-# expensive --timeout=5400 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx_with_validator_rotation_1 --features nightly
-# expensive --timeout=5400 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx_with_validator_rotation_2
-# expensive --timeout=5400 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx_with_validator_rotation_2 --features nightly
-# expensive --timeout=4800 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx_8_iterations
-# expensive --timeout=4800 near-client near_client tests::cross_shard_tx::ultraslow_test_cross_shard_tx_8_iterations_drop_chunks
+# expensive --timeout=5400 near-client near_client tests::cross_shard_tx::ultra_slow_test_cross_shard_tx_with_validator_rotation_1
+# expensive --timeout=5400 near-client near_client tests::cross_shard_tx::ultra_slow_test_cross_shard_tx_with_validator_rotation_1 --features nightly
+# expensive --timeout=5400 near-client near_client tests::cross_shard_tx::ultra_slow_test_cross_shard_tx_with_validator_rotation_2
+# expensive --timeout=5400 near-client near_client tests::cross_shard_tx::ultra_slow_test_cross_shard_tx_with_validator_rotation_2 --features nightly
+# expensive --timeout=4800 near-client near_client tests::cross_shard_tx::ultra_slow_test_cross_shard_tx_8_iterations
+# expensive --timeout=4800 near-client near_client tests::cross_shard_tx::ultra_slow_test_cross_shard_tx_8_iterations_drop_chunks
 
 # consensus tests
-expensive --timeout=3000 near-chain near_chain tests::doomslug::ultraslow_test_fuzzy_doomslug_liveness_and_safety
-expensive --timeout=3000 near-chain near_chain tests::doomslug::ultraslow_test_fuzzy_doomslug_liveness_and_safety --features nightly
-expensive --timeout=500 near-client near_client tests::consensus::ultraslow_test_consensus_with_epoch_switches
-expensive --timeout=500 near-client near_client tests::consensus::ultraslow_test_consensus_with_epoch_switches --features nightly
+expensive --timeout=3000 near-chain near_chain tests::doomslug::ultra_slow_test_fuzzy_doomslug_liveness_and_safety
+expensive --timeout=3000 near-chain near_chain tests::doomslug::ultra_slow_test_fuzzy_doomslug_liveness_and_safety --features nightly
+expensive --timeout=500 near-client near_client tests::consensus::ultra_slow_test_consensus_with_epoch_switches
+expensive --timeout=500 near-client near_client tests::consensus::ultra_slow_test_consensus_with_epoch_switches --features nightly
 
 # testnet rpc
-expensive integration-tests integration_tests tests::test_tps_regression::ultraslow_test_highload
-expensive integration-tests integration_tests tests::test_tps_regression::ultraslow_test_highload --features nightly
+expensive integration-tests integration_tests tests::test_tps_regression::ultra_slow_test_highload
+expensive integration-tests integration_tests tests::test_tps_regression::ultra_slow_test_highload --features nightly
 
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_access_key_smart_contract_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_access_key_smart_contract_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_add_access_key_function_call_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_add_access_key_function_call_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_add_access_key_with_allowance_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_add_access_key_with_allowance_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_add_existing_key_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_add_existing_key_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_add_key_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_add_key_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_create_account_again_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_create_account_again_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_create_account_failure_already_exists_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_create_account_failure_already_exists_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_create_account_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_create_account_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_delete_access_key_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_delete_access_key_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_delete_access_key_with_allowance_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_delete_access_key_with_allowance_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_delete_key_last_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_delete_key_last_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_delete_key_not_owned_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_delete_key_not_owned_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_delete_key_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_delete_key_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_nonce_update_when_deploying_contract_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_nonce_update_when_deploying_contract_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_nonce_updated_when_tx_failed_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_nonce_updated_when_tx_failed_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_redeploy_contract_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_redeploy_contract_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_refund_on_send_money_to_non_existent_account_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_refund_on_send_money_to_non_existent_account_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_send_money_over_balance_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_send_money_over_balance_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_send_money_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_send_money_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_bad_method_name_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_bad_method_name_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_empty_method_name_with_no_tokens_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_empty_method_name_with_no_tokens_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_empty_method_name_with_tokens_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_empty_method_name_with_tokens_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_self_call_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_self_call_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_simple_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_simple_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_with_args_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_smart_contract_with_args_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_swap_key_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_swap_key_testnet --features nightly
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_upload_contract_testnet
-expensive integration-tests integration_tests tests::standard_cases::rpc::ultraslow_test_upload_contract_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_access_key_smart_contract_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_access_key_smart_contract_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_add_access_key_function_call_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_add_access_key_function_call_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_add_access_key_with_allowance_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_add_access_key_with_allowance_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_add_existing_key_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_add_existing_key_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_add_key_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_add_key_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_create_account_again_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_create_account_again_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_create_account_failure_already_exists_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_create_account_failure_already_exists_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_create_account_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_create_account_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_delete_access_key_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_delete_access_key_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_delete_access_key_with_allowance_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_delete_access_key_with_allowance_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_delete_key_last_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_delete_key_last_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_delete_key_not_owned_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_delete_key_not_owned_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_delete_key_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_delete_key_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_nonce_update_when_deploying_contract_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_nonce_update_when_deploying_contract_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_nonce_updated_when_tx_failed_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_nonce_updated_when_tx_failed_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_redeploy_contract_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_redeploy_contract_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_refund_on_send_money_to_non_existent_account_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_refund_on_send_money_to_non_existent_account_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_send_money_over_balance_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_send_money_over_balance_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_send_money_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_send_money_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_smart_contract_bad_method_name_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_smart_contract_bad_method_name_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_smart_contract_empty_method_name_with_no_tokens_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_smart_contract_empty_method_name_with_no_tokens_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_smart_contract_empty_method_name_with_tokens_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_smart_contract_empty_method_name_with_tokens_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_smart_contract_self_call_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_smart_contract_self_call_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_smart_contract_simple_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_smart_contract_simple_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_smart_contract_with_args_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_smart_contract_with_args_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_swap_key_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_swap_key_testnet --features nightly
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_upload_contract_testnet
+expensive integration-tests integration_tests tests::standard_cases::rpc::ultra_slow_test_upload_contract_testnet --features nightly
 
 # GC tests
-expensive --timeout=900 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_remove_fork_large
-expensive --timeout=900 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_remove_fork_large --features nightly
-expensive --timeout=1200 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_not_remove_fork_large
-expensive --timeout=1200 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_not_remove_fork_large --features nightly
-expensive --timeout=1200 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_boundaries_large
-expensive --timeout=1200 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_boundaries_large --features nightly
-expensive --timeout=900 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_random_large
-expensive --timeout=900 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_random_large --features nightly
-expensive --timeout=600 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_pine
-expensive --timeout=600 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_pine --features nightly
-expensive --timeout=700 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_star_large
-expensive --timeout=700 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_star_large --features nightly
+expensive --timeout=900 near-chain near_chain tests::garbage_collection::ultra_slow_test_gc_remove_fork_large
+expensive --timeout=900 near-chain near_chain tests::garbage_collection::ultra_slow_test_gc_remove_fork_large --features nightly
+expensive --timeout=1200 near-chain near_chain tests::garbage_collection::ultra_slow_test_gc_not_remove_fork_large
+expensive --timeout=1200 near-chain near_chain tests::garbage_collection::ultra_slow_test_gc_not_remove_fork_large --features nightly
+expensive --timeout=1200 near-chain near_chain tests::garbage_collection::ultra_slow_test_gc_boundaries_large
+expensive --timeout=1200 near-chain near_chain tests::garbage_collection::ultra_slow_test_gc_boundaries_large --features nightly
+expensive --timeout=900 near-chain near_chain tests::garbage_collection::ultra_slow_test_gc_random_large
+expensive --timeout=900 near-chain near_chain tests::garbage_collection::ultra_slow_test_gc_random_large --features nightly
+expensive --timeout=600 near-chain near_chain tests::garbage_collection::ultra_slow_test_gc_pine
+expensive --timeout=600 near-chain near_chain tests::garbage_collection::ultra_slow_test_gc_pine --features nightly
+expensive --timeout=700 near-chain near_chain tests::garbage_collection::ultra_slow_test_gc_star_large
+expensive --timeout=700 near-chain near_chain tests::garbage_collection::ultra_slow_test_gc_star_large --features nightly
 
-expensive --timeout=1200 integration-tests integration_tests tests::client::block_corruption::ultraslow_test_check_process_flipped_block_fails
-expensive --timeout=1200 integration-tests integration_tests tests::client::block_corruption::ultraslow_test_check_process_flipped_block_fails --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_full
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_full --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_full_cop
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_full_cop --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_full_timeout_too_short
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_full_timeout_too_short --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_full_timeout_too_short_cop
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_full_timeout_too_short_cop --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_others
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_others --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_others_cop
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_others_cop --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_2_vals_per_shard
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_2_vals_per_shard --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_one_val_per_shard
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_one_val_per_shard --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_chunk_distribution_network_disabled
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_chunk_distribution_network_disabled --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_chunk_distribution_network_wrong_urls
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_chunk_distribution_network_wrong_urls --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_chunk_distribution_network_incorrect_get_return
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_chunk_distribution_network_incorrect_get_return --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_2_vals_per_shard_should_succeed_even_without_forwarding
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_2_vals_per_shard_should_succeed_even_without_forwarding --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_one_val_per_shard_should_succeed_even_without_forwarding
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_one_val_per_shard_should_succeed_even_without_forwarding --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_one_val_shard_cop
-expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_one_val_shard_cop --features nightly
-expensive integration-tests integration_tests tests::client::process_blocks::ultraslow_test_gc_after_state_sync
-expensive integration-tests integration_tests tests::client::process_blocks::ultraslow_test_gc_after_state_sync --features nightly
-expensive integration-tests integration_tests tests::client::process_blocks::ultraslow_test_process_block_after_state_sync
-expensive integration-tests integration_tests tests::client::process_blocks::ultraslow_test_process_block_after_state_sync --features nightly
-expensive integration-tests integration_tests tests::client::sync_state_nodes::ultraslow_test_sync_empty_state
-expensive integration-tests integration_tests tests::client::sync_state_nodes::ultraslow_test_sync_empty_state --features nightly
-expensive integration-tests integration_tests tests::client::sync_state_nodes::ultraslow_test_sync_state_dump
-expensive integration-tests integration_tests tests::client::sync_state_nodes::ultraslow_test_sync_state_dump --features nightly
-expensive integration-tests integration_tests tests::client::sync_state_nodes::ultraslow_test_sync_state_nodes
-expensive integration-tests integration_tests tests::client::sync_state_nodes::ultraslow_test_sync_state_nodes --features nightly
-expensive integration-tests integration_tests tests::client::sync_state_nodes::ultraslow_test_sync_state_nodes_multishard
-expensive integration-tests integration_tests tests::client::sync_state_nodes::ultraslow_test_sync_state_nodes_multishard --features nightly
+expensive --timeout=1200 integration-tests integration_tests tests::client::block_corruption::ultra_slow_test_check_process_flipped_block_fails
+expensive --timeout=1200 integration-tests integration_tests tests::client::block_corruption::ultra_slow_test_check_process_flipped_block_fails --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_recovered_from_full
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_recovered_from_full --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_recovered_from_full_cop
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_recovered_from_full_cop --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_recovered_from_full_timeout_too_short
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_recovered_from_full_timeout_too_short --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_recovered_from_full_timeout_too_short_cop
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_recovered_from_full_timeout_too_short_cop --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_recovered_from_others
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_recovered_from_others --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_recovered_from_others_cop
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_recovered_from_others_cop --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_produced_and_distributed_2_vals_per_shard
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_produced_and_distributed_2_vals_per_shard --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_produced_and_distributed_one_val_per_shard
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_produced_and_distributed_one_val_per_shard --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_produced_and_distributed_chunk_distribution_network_disabled
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_produced_and_distributed_chunk_distribution_network_disabled --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_produced_and_distributed_chunk_distribution_network_wrong_urls
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_produced_and_distributed_chunk_distribution_network_wrong_urls --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_produced_and_distributed_chunk_distribution_network_incorrect_get_return
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_produced_and_distributed_chunk_distribution_network_incorrect_get_return --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_produced_and_distributed_2_vals_per_shard_should_succeed_even_without_forwarding
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_produced_and_distributed_2_vals_per_shard_should_succeed_even_without_forwarding --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_produced_and_distributed_one_val_per_shard_should_succeed_even_without_forwarding
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_produced_and_distributed_one_val_per_shard_should_succeed_even_without_forwarding --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_produced_and_distributed_one_val_shard_cop
+expensive integration-tests integration_tests tests::client::chunks_management::ultra_slow_test_chunks_produced_and_distributed_one_val_shard_cop --features nightly
+expensive integration-tests integration_tests tests::client::process_blocks::ultra_slow_test_gc_after_state_sync
+expensive integration-tests integration_tests tests::client::process_blocks::ultra_slow_test_gc_after_state_sync --features nightly
+expensive integration-tests integration_tests tests::client::process_blocks::ultra_slow_test_process_block_after_state_sync
+expensive integration-tests integration_tests tests::client::process_blocks::ultra_slow_test_process_block_after_state_sync --features nightly
+expensive integration-tests integration_tests tests::client::sync_state_nodes::ultra_slow_test_sync_empty_state
+expensive integration-tests integration_tests tests::client::sync_state_nodes::ultra_slow_test_sync_empty_state --features nightly
+expensive integration-tests integration_tests tests::client::sync_state_nodes::ultra_slow_test_sync_state_dump
+expensive integration-tests integration_tests tests::client::sync_state_nodes::ultra_slow_test_sync_state_dump --features nightly
+expensive integration-tests integration_tests tests::client::sync_state_nodes::ultra_slow_test_sync_state_nodes
+expensive integration-tests integration_tests tests::client::sync_state_nodes::ultra_slow_test_sync_state_nodes --features nightly
+expensive integration-tests integration_tests tests::client::sync_state_nodes::ultra_slow_test_sync_state_nodes_multishard
+expensive integration-tests integration_tests tests::client::sync_state_nodes::ultra_slow_test_sync_state_nodes_multishard --features nightly
 
 # other tests
-expensive --timeout=300 near-chain near_chain tests::garbage_collection::ultraslow_test_clear_old_data_too_many_heights
+expensive --timeout=300 near-chain near_chain tests::garbage_collection::ultra_slow_test_clear_old_data_too_many_heights
 
-expensive integration-tests integration_tests tests::test_simple::ultraslow_test_2_10_multiple_nodes
-expensive integration-tests integration_tests tests::test_simple::ultraslow_test_2_10_multiple_nodes --features nightly
-expensive integration-tests integration_tests tests::test_simple::ultraslow_test_4_10_multiple_nodes
-expensive integration-tests integration_tests tests::test_simple::ultraslow_test_4_10_multiple_nodes --features nightly
-expensive integration-tests integration_tests tests::test_simple::ultraslow_test_7_10_multiple_nodes
-expensive integration-tests integration_tests tests::test_simple::ultraslow_test_7_10_multiple_nodes --features nightly
+expensive integration-tests integration_tests tests::test_simple::ultra_slow_test_2_10_multiple_nodes
+expensive integration-tests integration_tests tests::test_simple::ultra_slow_test_2_10_multiple_nodes --features nightly
+expensive integration-tests integration_tests tests::test_simple::ultra_slow_test_4_10_multiple_nodes
+expensive integration-tests integration_tests tests::test_simple::ultra_slow_test_4_10_multiple_nodes --features nightly
+expensive integration-tests integration_tests tests::test_simple::ultra_slow_test_7_10_multiple_nodes
+expensive integration-tests integration_tests tests::test_simple::ultra_slow_test_7_10_multiple_nodes --features nightly
 
-expensive integration-tests integration_tests tests::nearcore::sync_nodes::ultraslow_test_sync_state_stake_change
-expensive integration-tests integration_tests tests::nearcore::sync_nodes::ultraslow_test_sync_state_stake_change --features nightly
+expensive integration-tests integration_tests tests::nearcore::sync_nodes::ultra_slow_test_sync_state_stake_change
+expensive integration-tests integration_tests tests::nearcore::sync_nodes::ultra_slow_test_sync_state_stake_change --features nightly
 
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_block_unknown_block_error
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_block_unknown_block_error --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_chunk_unknown_chunk_error
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_chunk_unknown_chunk_error --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_gas_price_unknown_block_error
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_gas_price_unknown_block_error --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_protocol_config_unknown_block_error
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_protocol_config_unknown_block_error --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_query_rpc_account_view_unknown_block_must_return_error
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_query_rpc_account_view_unknown_block_must_return_error --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_receipt_id_unknown_receipt_error
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_receipt_id_unknown_receipt_error --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_tx_invalid_tx_error
-expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_tx_invalid_tx_error --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultra_slow_test_block_unknown_block_error
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultra_slow_test_block_unknown_block_error --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultra_slow_test_chunk_unknown_chunk_error
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultra_slow_test_chunk_unknown_chunk_error --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultra_slow_test_gas_price_unknown_block_error
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultra_slow_test_gas_price_unknown_block_error --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultra_slow_test_protocol_config_unknown_block_error
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultra_slow_test_protocol_config_unknown_block_error --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultra_slow_test_query_rpc_account_view_unknown_block_must_return_error
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultra_slow_test_query_rpc_account_view_unknown_block_must_return_error --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultra_slow_test_receipt_id_unknown_receipt_error
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultra_slow_test_receipt_id_unknown_receipt_error --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultra_slow_test_tx_invalid_tx_error
+expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultra_slow_test_tx_invalid_tx_error --features nightly
 
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_tx_status_on_lightclient_must_return_does_not_track_shard
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_tx_status_on_lightclient_must_return_does_not_track_shard --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_check_unknown_tx_must_return_error
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_check_unknown_tx_must_return_error --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_get_execution_outcome_tx_failure
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_get_execution_outcome_tx_failure --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_get_execution_outcome_tx_success
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_get_execution_outcome_tx_success --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_get_validator_info_rpc
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_get_validator_info_rpc --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_protocol_config_rpc
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_protocol_config_rpc --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_query_rpc_account_view_account_doesnt_exist_must_return_error
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_query_rpc_account_view_account_doesnt_exist_must_return_error --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_query_rpc_account_view_must_succeed
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_query_rpc_account_view_must_succeed --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_tx_not_enough_balance_must_return_error
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_tx_not_enough_balance_must_return_error --features nightly
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_validators_by_epoch_id_current_epoch_not_fails
-expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_validators_by_epoch_id_current_epoch_not_fails --features nightly
-expensive integration-tests integration_tests tests::nearcore::run_nodes::ultraslow_test_run_nodes_1_2_1
-expensive integration-tests integration_tests tests::nearcore::run_nodes::ultraslow_test_run_nodes_1_2_1 --features nightly
-expensive integration-tests integration_tests tests::nearcore::run_nodes::ultraslow_test_run_nodes_1_2_2
-expensive integration-tests integration_tests tests::nearcore::run_nodes::ultraslow_test_run_nodes_1_2_2 --features nightly
-expensive integration-tests integration_tests tests::nearcore::run_nodes::ultraslow_test_run_nodes_1_4_4
-expensive integration-tests integration_tests tests::nearcore::run_nodes::ultraslow_test_run_nodes_1_4_4 --features nightly
-expensive integration-tests integration_tests tests::nearcore::run_nodes::ultraslow_test_run_nodes_4_4_2
-expensive integration-tests integration_tests tests::nearcore::run_nodes::ultraslow_test_run_nodes_4_4_2 --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_tx_status_on_lightclient_must_return_does_not_track_shard
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_tx_status_on_lightclient_must_return_does_not_track_shard --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_check_unknown_tx_must_return_error
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_check_unknown_tx_must_return_error --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_get_execution_outcome_tx_failure
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_get_execution_outcome_tx_failure --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_get_execution_outcome_tx_success
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_get_execution_outcome_tx_success --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_get_validator_info_rpc
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_get_validator_info_rpc --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_protocol_config_rpc
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_protocol_config_rpc --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_query_rpc_account_view_account_doesnt_exist_must_return_error
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_query_rpc_account_view_account_doesnt_exist_must_return_error --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_query_rpc_account_view_must_succeed
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_query_rpc_account_view_must_succeed --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_tx_not_enough_balance_must_return_error
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_tx_not_enough_balance_must_return_error --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_validators_by_epoch_id_current_epoch_not_fails
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_validators_by_epoch_id_current_epoch_not_fails --features nightly
+expensive integration-tests integration_tests tests::nearcore::run_nodes::ultra_slow_test_run_nodes_1_2_1
+expensive integration-tests integration_tests tests::nearcore::run_nodes::ultra_slow_test_run_nodes_1_2_1 --features nightly
+expensive integration-tests integration_tests tests::nearcore::run_nodes::ultra_slow_test_run_nodes_1_2_2
+expensive integration-tests integration_tests tests::nearcore::run_nodes::ultra_slow_test_run_nodes_1_2_2 --features nightly
+expensive integration-tests integration_tests tests::nearcore::run_nodes::ultra_slow_test_run_nodes_1_4_4
+expensive integration-tests integration_tests tests::nearcore::run_nodes::ultra_slow_test_run_nodes_1_4_4 --features nightly
+expensive integration-tests integration_tests tests::nearcore::run_nodes::ultra_slow_test_run_nodes_4_4_2
+expensive integration-tests integration_tests tests::nearcore::run_nodes::ultra_slow_test_run_nodes_4_4_2 --features nightly
 
-expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultraslow_test_inflation
-expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultraslow_test_inflation --features nightly
-expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultraslow_test_stake_nodes
-expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultraslow_test_stake_nodes --features nightly
-expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultraslow_test_validator_join
-expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultraslow_test_validator_join --features nightly
-expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultraslow_test_validator_kickout
-expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultraslow_test_validator_kickout --features nightly
+expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultra_slow_test_inflation
+expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultra_slow_test_inflation --features nightly
+expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultra_slow_test_stake_nodes
+expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultra_slow_test_stake_nodes --features nightly
+expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultra_slow_test_validator_join
+expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultra_slow_test_validator_join --features nightly
+expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultra_slow_test_validator_kickout
+expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultra_slow_test_validator_kickout --features nightly
 
-expensive integration-tests integration_tests tests::nearcore::track_shards::ultraslow_test_track_shards
-expensive integration-tests integration_tests tests::nearcore::track_shards::ultraslow_test_track_shards --features nightly
+expensive integration-tests integration_tests tests::nearcore::track_shards::ultra_slow_test_track_shards
+expensive integration-tests integration_tests tests::nearcore::track_shards::ultra_slow_test_track_shards --features nightly
 
-expensive estimator-warehouse estimator-warehouse tests::ultraslow_test_full_estimator
+expensive estimator-warehouse estimator-warehouse tests::ultra_slow_test_full_estimator

--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -232,4 +232,4 @@ expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultr
 expensive integration-tests integration_tests tests::nearcore::track_shards::ultra_slow_test_track_shards
 expensive integration-tests integration_tests tests::nearcore::track_shards::ultra_slow_test_track_shards --features nightly
 
-expensive estimator-warehouse estimator_warehouse tests::ultra_slow_test_full_estimator
+expensive --timeout=1800 estimator-warehouse estimator_warehouse tests::ultra_slow_test_full_estimator

--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -232,4 +232,4 @@ expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultr
 expensive integration-tests integration_tests tests::nearcore::track_shards::ultra_slow_test_track_shards
 expensive integration-tests integration_tests tests::nearcore::track_shards::ultra_slow_test_track_shards --features nightly
 
-expensive estimator-warehouse estimator-warehouse tests::ultra_slow_test_full_estimator
+expensive estimator-warehouse estimator_warehouse tests::ultra_slow_test_full_estimator

--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -120,48 +120,48 @@ expensive --timeout=600 near-chain near_chain tests::garbage_collection::ultrasl
 expensive --timeout=700 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_star_large
 expensive --timeout=700 near-chain near_chain tests::garbage_collection::ultraslow_test_gc_star_large --features nightly
 
-expensive --timeout=1200 integration-tests integration_tests tests::client::block_corruption::check_process_flipped_block_fails
-expensive --timeout=1200 integration-tests integration_tests tests::client::block_corruption::check_process_flipped_block_fails --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_recovered_from_full
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_recovered_from_full --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_recovered_from_full_cop
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_recovered_from_full_cop --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_recovered_from_full_timeout_too_short
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_recovered_from_full_timeout_too_short --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_recovered_from_full_timeout_too_short_cop
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_recovered_from_full_timeout_too_short_cop --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_recovered_from_others
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_recovered_from_others --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_recovered_from_others_cop
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_recovered_from_others_cop --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_produced_and_distributed_2_vals_per_shard
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_produced_and_distributed_2_vals_per_shard --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_produced_and_distributed_one_val_per_shard
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_produced_and_distributed_one_val_per_shard --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_produced_and_distributed_chunk_distribution_network_disabled
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_produced_and_distributed_chunk_distribution_network_disabled --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_produced_and_distributed_chunk_distribution_network_wrong_urls
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_produced_and_distributed_chunk_distribution_network_wrong_urls --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_produced_and_distributed_chunk_distribution_network_incorrect_get_return
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_produced_and_distributed_chunk_distribution_network_incorrect_get_return --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_produced_and_distributed_2_vals_per_shard_should_succeed_even_without_forwarding
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_produced_and_distributed_2_vals_per_shard_should_succeed_even_without_forwarding --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_produced_and_distributed_one_val_per_shard_should_succeed_even_without_forwarding
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_produced_and_distributed_one_val_per_shard_should_succeed_even_without_forwarding --features nightly
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_produced_and_distributed_one_val_shard_cop
-expensive integration-tests integration_tests tests::client::chunks_management::chunks_produced_and_distributed_one_val_shard_cop --features nightly
+expensive --timeout=1200 integration-tests integration_tests tests::client::block_corruption::ultraslow_test_check_process_flipped_block_fails
+expensive --timeout=1200 integration-tests integration_tests tests::client::block_corruption::ultraslow_test_check_process_flipped_block_fails --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_full
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_full --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_full_cop
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_full_cop --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_full_timeout_too_short
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_full_timeout_too_short --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_full_timeout_too_short_cop
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_full_timeout_too_short_cop --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_others
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_others --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_others_cop
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_recovered_from_others_cop --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_2_vals_per_shard
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_2_vals_per_shard --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_one_val_per_shard
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_one_val_per_shard --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_chunk_distribution_network_disabled
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_chunk_distribution_network_disabled --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_chunk_distribution_network_wrong_urls
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_chunk_distribution_network_wrong_urls --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_chunk_distribution_network_incorrect_get_return
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_chunk_distribution_network_incorrect_get_return --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_2_vals_per_shard_should_succeed_even_without_forwarding
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_2_vals_per_shard_should_succeed_even_without_forwarding --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_one_val_per_shard_should_succeed_even_without_forwarding
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_one_val_per_shard_should_succeed_even_without_forwarding --features nightly
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_one_val_shard_cop
+expensive integration-tests integration_tests tests::client::chunks_management::ultraslow_test_chunks_produced_and_distributed_one_val_shard_cop --features nightly
 expensive integration-tests integration_tests tests::client::process_blocks::ultraslow_test_gc_after_state_sync
 expensive integration-tests integration_tests tests::client::process_blocks::ultraslow_test_gc_after_state_sync --features nightly
 expensive integration-tests integration_tests tests::client::process_blocks::ultraslow_test_process_block_after_state_sync
 expensive integration-tests integration_tests tests::client::process_blocks::ultraslow_test_process_block_after_state_sync --features nightly
-expensive integration-tests integration_tests tests::client::sync_state_nodes::sync_empty_state
-expensive integration-tests integration_tests tests::client::sync_state_nodes::sync_empty_state --features nightly
-expensive integration-tests integration_tests tests::client::sync_state_nodes::sync_state_dump
-expensive integration-tests integration_tests tests::client::sync_state_nodes::sync_state_dump --features nightly
-expensive integration-tests integration_tests tests::client::sync_state_nodes::sync_state_nodes
-expensive integration-tests integration_tests tests::client::sync_state_nodes::sync_state_nodes --features nightly
-expensive integration-tests integration_tests tests::client::sync_state_nodes::sync_state_nodes_multishard
-expensive integration-tests integration_tests tests::client::sync_state_nodes::sync_state_nodes_multishard --features nightly
+expensive integration-tests integration_tests tests::client::sync_state_nodes::ultraslow_test_sync_empty_state
+expensive integration-tests integration_tests tests::client::sync_state_nodes::ultraslow_test_sync_empty_state --features nightly
+expensive integration-tests integration_tests tests::client::sync_state_nodes::ultraslow_test_sync_state_dump
+expensive integration-tests integration_tests tests::client::sync_state_nodes::ultraslow_test_sync_state_dump --features nightly
+expensive integration-tests integration_tests tests::client::sync_state_nodes::ultraslow_test_sync_state_nodes
+expensive integration-tests integration_tests tests::client::sync_state_nodes::ultraslow_test_sync_state_nodes --features nightly
+expensive integration-tests integration_tests tests::client::sync_state_nodes::ultraslow_test_sync_state_nodes_multishard
+expensive integration-tests integration_tests tests::client::sync_state_nodes::ultraslow_test_sync_state_nodes_multishard --features nightly
 
 # other tests
 expensive --timeout=300 near-chain near_chain tests::garbage_collection::ultraslow_test_clear_old_data_too_many_heights
@@ -173,8 +173,8 @@ expensive integration-tests integration_tests tests::test_simple::ultraslow_test
 expensive integration-tests integration_tests tests::test_simple::ultraslow_test_7_10_multiple_nodes
 expensive integration-tests integration_tests tests::test_simple::ultraslow_test_7_10_multiple_nodes --features nightly
 
-expensive integration-tests integration_tests tests::nearcore::sync_nodes::sync_state_stake_change
-expensive integration-tests integration_tests tests::nearcore::sync_nodes::sync_state_stake_change --features nightly
+expensive integration-tests integration_tests tests::nearcore::sync_nodes::ultraslow_test_sync_state_stake_change
+expensive integration-tests integration_tests tests::nearcore::sync_nodes::ultraslow_test_sync_state_stake_change --features nightly
 
 expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_block_unknown_block_error
 expensive integration-tests integration_tests tests::nearcore::rpc_error_structs::ultraslow_test_block_unknown_block_error --features nightly
@@ -211,14 +211,14 @@ expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultras
 expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_tx_not_enough_balance_must_return_error --features nightly
 expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_validators_by_epoch_id_current_epoch_not_fails
 expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultraslow_test_validators_by_epoch_id_current_epoch_not_fails --features nightly
-expensive integration-tests integration_tests tests::nearcore::run_nodes::run_nodes_1_2_1
-expensive integration-tests integration_tests tests::nearcore::run_nodes::run_nodes_1_2_1 --features nightly
-expensive integration-tests integration_tests tests::nearcore::run_nodes::run_nodes_1_2_2
-expensive integration-tests integration_tests tests::nearcore::run_nodes::run_nodes_1_2_2 --features nightly
-expensive integration-tests integration_tests tests::nearcore::run_nodes::run_nodes_1_4_4
-expensive integration-tests integration_tests tests::nearcore::run_nodes::run_nodes_1_4_4 --features nightly
-expensive integration-tests integration_tests tests::nearcore::run_nodes::run_nodes_4_4_2
-expensive integration-tests integration_tests tests::nearcore::run_nodes::run_nodes_4_4_2 --features nightly
+expensive integration-tests integration_tests tests::nearcore::run_nodes::ultraslow_test_run_nodes_1_2_1
+expensive integration-tests integration_tests tests::nearcore::run_nodes::ultraslow_test_run_nodes_1_2_1 --features nightly
+expensive integration-tests integration_tests tests::nearcore::run_nodes::ultraslow_test_run_nodes_1_2_2
+expensive integration-tests integration_tests tests::nearcore::run_nodes::ultraslow_test_run_nodes_1_2_2 --features nightly
+expensive integration-tests integration_tests tests::nearcore::run_nodes::ultraslow_test_run_nodes_1_4_4
+expensive integration-tests integration_tests tests::nearcore::run_nodes::ultraslow_test_run_nodes_1_4_4 --features nightly
+expensive integration-tests integration_tests tests::nearcore::run_nodes::ultraslow_test_run_nodes_4_4_2
+expensive integration-tests integration_tests tests::nearcore::run_nodes::ultraslow_test_run_nodes_4_4_2 --features nightly
 
 expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultraslow_test_inflation
 expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultraslow_test_inflation --features nightly
@@ -229,5 +229,5 @@ expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultr
 expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultraslow_test_validator_kickout
 expensive integration-tests integration_tests tests::nearcore::stake_nodes::ultraslow_test_validator_kickout --features nightly
 
-expensive integration-tests integration_tests tests::nearcore::track_shards::track_shards
-expensive integration-tests integration_tests tests::nearcore::track_shards::track_shards --features nightly
+expensive integration-tests integration_tests tests::nearcore::track_shards::ultraslow_test_track_shards
+expensive integration-tests integration_tests tests::nearcore::track_shards::ultraslow_test_track_shards --features nightly

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -3,12 +3,12 @@
 ./expensive.txt
 
 # Very expensive catchup tests
-expensive --timeout=3600 near-client near_client tests::catching_up::ultraslow_test_all_chunks_accepted_1000
-expensive --timeout=3600 near-client near_client tests::catching_up::ultraslow_test_all_chunks_accepted_1000 --features nightly
-expensive --timeout=7200 near-client near_client tests::catching_up::ultraslow_test_all_chunks_accepted_1000_slow
-expensive --timeout=7200 near-client near_client tests::catching_up::ultraslow_test_all_chunks_accepted_1000_slow --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_all_chunks_accepted_1000_rare_epoch_changing
-expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_all_chunks_accepted_1000_rare_epoch_changing --features nightly
+expensive --timeout=3600 near-client near_client tests::catching_up::ultra_slow_test_all_chunks_accepted_1000
+expensive --timeout=3600 near-client near_client tests::catching_up::ultra_slow_test_all_chunks_accepted_1000 --features nightly
+expensive --timeout=7200 near-client near_client tests::catching_up::ultra_slow_test_all_chunks_accepted_1000_slow
+expensive --timeout=7200 near-client near_client tests::catching_up::ultra_slow_test_all_chunks_accepted_1000_slow --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_all_chunks_accepted_1000_rare_epoch_changing
+expensive --timeout=1800 near-client near_client tests::catching_up::ultra_slow_test_all_chunks_accepted_1000_rare_epoch_changing --features nightly
 
 # Very expensive test: make sure Docker image can be build and run
 pytest --skip-build --timeout=1h sanity/docker.py

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -3,12 +3,12 @@
 ./expensive.txt
 
 # Very expensive catchup tests
-expensive --timeout=3600 near-client near_client tests::catching_up::test_all_chunks_accepted_1000
-expensive --timeout=3600 near-client near_client tests::catching_up::test_all_chunks_accepted_1000 --features nightly
-expensive --timeout=7200 near-client near_client tests::catching_up::test_all_chunks_accepted_1000_slow
-expensive --timeout=7200 near-client near_client tests::catching_up::test_all_chunks_accepted_1000_slow --features nightly
-expensive --timeout=1800 near-client near_client tests::catching_up::test_all_chunks_accepted_1000_rare_epoch_changing
-expensive --timeout=1800 near-client near_client tests::catching_up::test_all_chunks_accepted_1000_rare_epoch_changing --features nightly
+expensive --timeout=3600 near-client near_client tests::catching_up::ultraslow_test_all_chunks_accepted_1000
+expensive --timeout=3600 near-client near_client tests::catching_up::ultraslow_test_all_chunks_accepted_1000 --features nightly
+expensive --timeout=7200 near-client near_client tests::catching_up::ultraslow_test_all_chunks_accepted_1000_slow
+expensive --timeout=7200 near-client near_client tests::catching_up::ultraslow_test_all_chunks_accepted_1000_slow --features nightly
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_all_chunks_accepted_1000_rare_epoch_changing
+expensive --timeout=1800 near-client near_client tests::catching_up::ultraslow_test_all_chunks_accepted_1000_rare_epoch_changing --features nightly
 
 # Very expensive test: make sure Docker image can be build and run
 pytest --skip-build --timeout=1h sanity/docker.py

--- a/runtime/near-vm-runner/src/logic/tests/bls12381.rs
+++ b/runtime/near-vm-runner/src/logic/tests/bls12381.rs
@@ -619,13 +619,13 @@ mod tests {
         G1Affine,
         bls12381_p1_sum,
         check_sum_p1,
-        test_bls12381_p1_sum_edge_cases_fuzzer,
-        test_bls12381_p1_sum_fuzzer,
-        test_bls12381_p1_sum_not_g1_points_fuzzer,
-        test_bls12381_p1_sum_inverse_fuzzer,
-        test_bls12381_p1_sum_many_points_fuzzer,
-        test_bls12381_p1_crosscheck_sum_and_multiexp_fuzzer,
-        test_bls12381_p1_sum_incorrect_input_fuzzer
+        slow_test_bls12381_p1_sum_edge_cases_fuzzer,
+        slow_test_bls12381_p1_sum_fuzzer,
+        slow_test_bls12381_p1_sum_not_g1_points_fuzzer,
+        slow_test_bls12381_p1_sum_inverse_fuzzer,
+        slow_test_bls12381_p1_sum_many_points_fuzzer,
+        slow_test_bls12381_p1_crosscheck_sum_and_multiexp_fuzzer,
+        slow_test_bls12381_p1_sum_incorrect_input_fuzzer
     );
     test_bls12381_sum!(
         G2Operations,
@@ -635,13 +635,13 @@ mod tests {
         G2Affine,
         bls12381_p2_sum,
         check_sum_p2,
-        test_bls12381_p2_sum_edge_cases_fuzzer,
-        test_bls12381_p2_sum_fuzzer,
-        test_bls12381_p2_sum_not_g2_points_fuzzer,
-        test_bls12381_p2_sum_inverse_fuzzer,
-        test_bls12381_p2_sum_many_points_fuzzer,
-        test_bls12381_p2_crosscheck_sum_and_multiexp_fuzzer,
-        test_bls12381_p2_sum_incorrect_input_fuzzer
+        slow_test_bls12381_p2_sum_edge_cases_fuzzer,
+        slow_test_bls12381_p2_sum_fuzzer,
+        slow_test_bls12381_p2_sum_not_g2_points_fuzzer,
+        slow_test_bls12381_p2_sum_inverse_fuzzer,
+        slow_test_bls12381_p2_sum_many_points_fuzzer,
+        slow_test_bls12381_p2_crosscheck_sum_and_multiexp_fuzzer,
+        slow_test_bls12381_p2_sum_incorrect_input_fuzzer
     );
 
     macro_rules! test_bls12381_memory_limit {
@@ -824,8 +824,8 @@ mod tests {
         bls12381_p1_sum,
         test_bls12381_g1_multiexp_mul_fuzzer,
         test_bls12381_g1_multiexp_many_points_fuzzer,
-        test_bls12381_g1_multiexp_incorrect_input_fuzzer,
-        test_bls12381_g1_multiexp_invariants_checks_fuzzer,
+        slow_test_bls12381_g1_multiexp_incorrect_input_fuzzer,
+        slow_test_bls12381_g1_multiexp_invariants_checks_fuzzer,
         test_bls12381_error_g1_encoding
     );
     test_bls12381_multiexp!(
@@ -838,8 +838,8 @@ mod tests {
         bls12381_p2_sum,
         test_bls12381_g2_multiexp_mul_fuzzer,
         test_bls12381_g2_multiexp_many_points_fuzzer,
-        test_bls12381_g2_multiexp_incorrect_input_fuzzer,
-        test_bls12381_g2_multiexp_invariants_checks_fuzzer,
+        slow_test_bls12381_g2_multiexp_incorrect_input_fuzzer,
+        slow_test_bls12381_g2_multiexp_invariants_checks_fuzzer,
         test_bls12381_error_g2_encoding
     );
 
@@ -917,8 +917,8 @@ mod tests {
         Fq,
         FP,
         check_map_fp,
-        test_bls12381_map_fp_to_g1_fuzzer,
-        test_bls12381_map_fp_to_g1_many_points_fuzzer
+        slow_test_bls12381_map_fp_to_g1_fuzzer,
+        slow_test_bls12381_map_fp_to_g1_many_points_fuzzer
     );
 
     test_bls12381_map_fp_to_g!(
@@ -927,8 +927,8 @@ mod tests {
         Fq2,
         FP2,
         check_map_fp2,
-        test_bls12381_map_fp2_to_g2_fuzzer,
-        test_bls12381_map_fp2_to_g2_many_points_fuzzer
+        slow_test_bls12381_map_fp2_to_g2_fuzzer,
+        slow_test_bls12381_map_fp2_to_g2_many_points_fuzzer
     );
 
     #[test]
@@ -1051,9 +1051,9 @@ mod tests {
         48,
         bls12381_p1_decompress,
         add_p_x,
-        test_bls12381_p1_decompress_fuzzer,
-        test_bls12381_p1_decompress_many_points_fuzzer,
-        test_bls12381_p1_decompress_incorrect_input_fuzzer
+        slow_test_bls12381_p1_decompress_fuzzer,
+        slow_test_bls12381_p1_decompress_many_points_fuzzer,
+        slow_test_bls12381_p1_decompress_incorrect_input_fuzzer
     );
 
     test_bls12381_decompress!(
@@ -1064,9 +1064,9 @@ mod tests {
         96,
         bls12381_p2_decompress,
         add2_p_x,
-        test_bls12381_p2_decompress_fuzzer,
-        test_bls12381_p2_decompress_many_points_fuzzer,
-        test_bls12381_p2_decompress_incorrect_input_fuzzer
+        slow_test_bls12381_p2_decompress_fuzzer,
+        slow_test_bls12381_p2_decompress_many_points_fuzzer,
+        slow_test_bls12381_p2_decompress_incorrect_input_fuzzer
     );
 
     fn add_p_x(point: &G1Affine) -> Vec<u8> {
@@ -1082,7 +1082,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bls12381_pairing_check_one_point_fuzzer() {
+    fn slow_test_bls12381_pairing_check_one_point_fuzzer() {
         bolero::check!().with_type().for_each(|(p1, p2): &(G1Point, G2Point)| {
             let zero1 = G1Affine::zero();
             let zero2 = G2Affine::zero();
@@ -1098,7 +1098,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bls12381_pairing_check_two_points_fuzzer() {
+    fn slow_test_bls12381_pairing_check_two_points_fuzzer() {
         bolero::check!().with_type().for_each(
             |(p1, p2, s1, s2): &(G1Point, G2Point, Scalar, Scalar)| {
                 let p1_neg = p1.p.neg();
@@ -1134,7 +1134,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bls12381_pairing_check_many_points_fuzzer() {
+    fn slow_test_bls12381_pairing_check_many_points_fuzzer() {
         bolero::check!()
             .with_generator(
                 bolero::gen::<Vec<(Scalar, Scalar)>>().with().len(0usize..MAX_N_PAIRING),
@@ -1180,7 +1180,7 @@ mod tests {
     }
 
     #[test]
-    fn test_bls12381_pairing_incorrect_input_point_fuzzer() {
+    fn slow_test_bls12381_pairing_incorrect_input_point_fuzzer() {
         bolero::check!().with_type().for_each(
             |(p1_not_from_g1, p2, p1, p2_not_from_g2, curve_p1, curve_p2): &(
                 EnotG1Point,

--- a/runtime/near-vm-runner/src/tests/compile_errors.rs
+++ b/runtime/near-vm-runner/src/tests/compile_errors.rs
@@ -138,7 +138,7 @@ fn test_evil_function_index() {
 }
 
 #[test]
-fn test_limit_contract_functions_number() {
+fn slow_test_limit_contract_functions_number() {
     let functions_number_limit: u32 = 10_000;
 
     test_builder().wasm(

--- a/runtime/near-vm-runner/src/tests/fuzzers.rs
+++ b/runtime/near-vm-runner/src/tests/fuzzers.rs
@@ -141,7 +141,7 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMResult {
 }
 
 #[test]
-fn current_vm_does_not_crash_fuzzer() {
+fn slow_test_current_vm_does_not_crash_fuzzer() {
     let config = test_vm_config();
     if config.vm_kind.is_available() {
         bolero::check!().with_arbitrary::<ArbitraryModule>().for_each(
@@ -155,7 +155,7 @@ fn current_vm_does_not_crash_fuzzer() {
 
 #[test]
 #[cfg_attr(not(all(feature = "wasmtime_vm", feature = "near_vm", target_arch = "x86_64")), ignore)]
-fn near_vm_and_wasmtime_agree_fuzzer() {
+fn slow_test_near_vm_and_wasmtime_agree_fuzzer() {
     bolero::check!().with_arbitrary::<ArbitraryModule>().for_each(|module: &ArbitraryModule| {
         let code = ContractCode::new(module.0.module.to_bytes(), None);
         let near_vm = run_fuzz(&code, VMKind::NearVm).expect("fatal failure");
@@ -166,7 +166,7 @@ fn near_vm_and_wasmtime_agree_fuzzer() {
 
 #[test]
 #[cfg(all(feature = "near_vm", target_arch = "x86_64"))]
-fn near_vm_is_reproducible_fuzzer() {
+fn slow_test_near_vm_is_reproducible_fuzzer() {
     use crate::near_vm_runner::NearVM;
     use near_primitives_core::hash::CryptoHash;
 

--- a/runtime/near-vm-runner/src/tests/regression_tests.rs
+++ b/runtime/near-vm-runner/src/tests/regression_tests.rs
@@ -82,7 +82,7 @@ fn gas_intrinsic_did_not_multiply_by_opcode_cost() {
 }
 
 #[test]
-fn parallel_runtime_invocations() {
+fn slow_test_parallel_runtime_invocations() {
     let mut join_handles = Vec::new();
     for _ in 0..128 {
         let handle = std::thread::spawn(|| {

--- a/runtime/runtime-params-estimator/estimator-warehouse/src/main.rs
+++ b/runtime/runtime-params-estimator/estimator-warehouse/src/main.rs
@@ -147,7 +147,7 @@ mod tests {
     ///   it might make sense to put it in a separate CI job.
     /// - QEMU based estimation is skipped - it would be too slow.
     #[test]
-    fn test_full_estimator() -> anyhow::Result<()> {
+    fn ultraslow_test_full_estimator() -> anyhow::Result<()> {
         let stats_path = Path::new("tmp_db.sqlite");
         let db = Db::open(stats_path)?;
         let config = EstimateConfig {

--- a/runtime/runtime-params-estimator/estimator-warehouse/src/main.rs
+++ b/runtime/runtime-params-estimator/estimator-warehouse/src/main.rs
@@ -147,7 +147,7 @@ mod tests {
     ///   it might make sense to put it in a separate CI job.
     /// - QEMU based estimation is skipped - it would be too slow.
     #[test]
-    fn ultraslow_test_full_estimator() -> anyhow::Result<()> {
+    fn ultra_slow_test_full_estimator() -> anyhow::Result<()> {
         let stats_path = Path::new("tmp_db.sqlite");
         let db = Db::open(stats_path)?;
         let config = EstimateConfig {

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -526,7 +526,7 @@ mod tests {
     /// enabled. It will not cover all compilation errors for building the
     /// params-estimator in isolation.
     #[test]
-    fn sanity_check() {
+    fn slow_test_sanity_check() {
         // select a mix of estimations that are all fast
         let costs = vec![Cost::WasmInstruction, Cost::StorageHasKeyByte, Cost::AltBn128G1SumBase];
         let args = CliArgs {

--- a/scripts/check_nightly.py
+++ b/scripts/check_nightly.py
@@ -33,7 +33,7 @@ import nayduck
 
 IGNORED_SUBDIRS = ('target', 'target_expensive', 'sandbox')
 
-EXPENSIVE_DIRECTIVE = 'ultraslow_test'
+EXPENSIVE_DIRECTIVE = 'ultra_slow_test_'
 TEST_DIRECTIVE = '#[test]'
 
 
@@ -67,7 +67,7 @@ def expensive_tests_in_file(path: pathlib.Path) -> typing.Iterable[str]:
                 pass
             elif line.startswith('#'):
                 is_test = is_test or line == TEST_DIRECTIVE
-            elif line.startswith('fn ultraslow_test_'):
+            elif line.startswith('fn ultra_slow_test_'):
                 if is_test:
                     match = re.search(r'\bfn\s+([A-Za-z_][A-Za-z_0-9]*)\b',
                                       line)

--- a/scripts/check_nightly.py
+++ b/scripts/check_nightly.py
@@ -33,7 +33,7 @@ import nayduck
 
 IGNORED_SUBDIRS = ('target', 'target_expensive', 'sandbox')
 
-EXPENSIVE_DIRECTIVE = '#[cfg_attr(not(feature = "expensive_tests"), ignore)]'
+EXPENSIVE_DIRECTIVE = 'ultraslow_test'
 TEST_DIRECTIVE = '#[test]'
 
 
@@ -66,10 +66,9 @@ def expensive_tests_in_file(path: pathlib.Path) -> typing.Iterable[str]:
             if not line:
                 pass
             elif line.startswith('#'):
-                is_expensive = is_expensive or line == EXPENSIVE_DIRECTIVE
                 is_test = is_test or line == TEST_DIRECTIVE
-            elif is_expensive or is_test:
-                if is_expensive and is_test:
+            elif line.startswith('fn ultraslow_test_'):
+                if is_test:
                     match = re.search(r'\bfn\s+([A-Za-z_][A-Za-z_0-9]*)\b',
                                       line)
                     if match:


### PR DESCRIPTION
This fundamentally removes the differentiation between "integration" and "unit" tests from the test runner perspective, as well as removes the reliance on the "expensive-tests" compile-time feature.

Instead tests are categorized by the underlying reason for which we had the separation in the first place -- test execution speed. These are now annotated with `slow_test_` and `ultraslow_test_` prefixes, and their execution time is enforced by time limits in `nextest.toml`.

By using `nextest` filters we can cleanly filter out tests from these three categories to be run in various contexts. For instance, maybe quick checks locally don't need to run the slow tests every time -- `just nextest` by default now takes just 9 seconds (on my machine) to run all the tests. Whereas previously (due to e.g. estimator smoke test) it would take at least a minute.

Then a `just nextest-slow` is added in the rarer cases where one might want to run the full suite that runs on CI. CI will run these mildly slower tests for each PR.

Then what remains are the ultraslow tests which only run on nayduck and can take quite some time to complete. These can now be trivially run locally as well with `just nextest-all` without necessarily rebuilding the entire project or "unignoring" tests that are marked as ignored for other reasons (like for instance because they're just broken.)