### PR TITLE
fix(fork-network): fix handling of shard IDs

### DIFF
--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -335,6 +335,8 @@ impl fmt::Display for ShardLayoutError {
     }
 }
 
+impl std::error::Error for ShardLayoutError {}
+
 impl ShardLayout {
     /// Handy constructor for a single-shard layout, mostly for test purposes
     pub fn single_shard() -> Self {


### PR DESCRIPTION
When the `init` command is run, the fork-network command writes state roots to the DB by key "FORK_TOOL_SHARD_ID:{shard_id}", and later reads them back by iterating over that prefix. But there is inconsistent treatment of these ShardIds sometimes as ShardIds and sometimes as ShardIndexes. Firstly, the name of the key itself indicates we should expect ShardIds to be there. But when we write them, we collect the state roots in a Vec in order of ShardLayout::shard_ids(), and then iter().enumerate() over that to write the (shard_id, state_root), which is really a shard index. Then when we read them back, we index into that array with `shard_uid.shard_id as usize`, which doesn't work when the ShardIds are shuffled.

When running this on a localnet where shard IDs are shuffled, this gives us this error:

```
thread '<unnamed>' panicked at tools/fork-network/src/cli.rs:732:22:
called `Result::unwrap()` on an `Err` value: StorageInconsistentState("Failed to find root node EEMN57dXxneVQHDZ5aZreA8SHF6Xtee95CKpGfeMEmGN in memtrie")
```

So fix it by actually writing a real ShardId to the `FORK_TOOL_SHARD_ID:...` keys, and actually parsing the ShardId from that key when iterating (instead of an enumerate() to get the shard ID). And just be more careful about the ShardId <-> ShardIndex mapping throughout.