### PR TITLE
indexer-example: change short option for --home-dir

### DIFF
--- a/tools/indexer/example/src/configs.rs
+++ b/tools/indexer/example/src/configs.rs
@@ -7,7 +7,7 @@ use near_indexer::near_primitives::types::Gas;
 #[clap(subcommand_required = true, arg_required_else_help = true)]
 pub(crate) struct Opts {
     /// Sets a custom config dir. Defaults to ~/.near/
-    #[clap(short, long)]
+    #[clap(short = 'd', long)]
     pub home_dir: Option<std::path::PathBuf>,
     #[clap(subcommand)]
     pub subcmd: SubCommand,


### PR DESCRIPTION
Needed to avoid this fatal error:

```
thread 'main' panicked at /Users/saketh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.2.4/src/builder/debug_asserts.rs:115:17:
Command indexer-example: Short option names must be unique for each argument, but '-h' is in use by both 'home_dir' and 'help' (call `cmd.disable_help_flag(true)` to remove the auto-generated `--help`)
```