### PR TITLE
DO NOT MERGE: witness size without contract code

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3670,7 +3670,8 @@ impl Chain {
         }
         let Some(account_id) = me.as_ref() else { return Ok(false) };
         Ok(self.epoch_manager.is_chunk_producer_for_epoch(epoch_id, account_id)?
-            || self.epoch_manager.is_chunk_producer_for_epoch(&next_epoch_id, account_id)?)
+            || self.epoch_manager.is_chunk_producer_for_epoch(&next_epoch_id, account_id)?
+            || true)
     }
 
     /// Creates jobs which will update shards for the given block and incoming
@@ -3887,11 +3888,19 @@ impl Chain {
         Ok(Some((
             shard_id,
             Box::new(move |parent_span| -> Result<ShardUpdateResult, Error> {
+                let _ = process_shard_update(
+                    parent_span,
+                    runtime.as_ref(),
+                    shard_update_reason.clone(),
+                    shard_context.clone(),
+                    near_primitives::apply::ApplyChunkReason::Experiment,
+                );
                 Ok(process_shard_update(
                     parent_span,
                     runtime.as_ref(),
                     shard_update_reason,
                     shard_context,
+                    near_primitives::apply::ApplyChunkReason::UpdateTrackedShard,
                 )?)
             }),
         )))

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -253,6 +253,7 @@ impl ChainGenesis {
     }
 }
 
+#[derive(Clone)]
 pub enum StorageDataSource {
     /// Full state data is present in DB.
     Db,

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -40,6 +40,7 @@ pub enum ShardUpdateResult {
     OldChunk(OldChunkResult),
 }
 
+#[derive(Clone)]
 pub struct NewChunkData {
     pub chunk_header: ShardChunkHeader,
     pub transactions: Vec<SignedTransaction>,
@@ -49,6 +50,7 @@ pub struct NewChunkData {
     pub storage_context: StorageContext,
 }
 
+#[derive(Clone)]
 pub struct OldChunkData {
     pub prev_chunk_extra: ChunkExtra,
     pub block: ApplyChunkBlockContext,
@@ -57,6 +59,7 @@ pub struct OldChunkData {
 
 /// Reason to update a shard when new block appears on chain.
 #[allow(clippy::large_enum_variant)]
+#[derive(Clone)]
 pub enum ShardUpdateReason {
     /// Block has a new chunk for the shard.
     /// Contains chunk itself and all new incoming receipts to the shard.
@@ -68,6 +71,7 @@ pub enum ShardUpdateReason {
 }
 
 /// Information about shard to update.
+#[derive(Clone)]
 pub struct ShardContext {
     pub shard_uid: ShardUId,
     /// Whether node cares about shard in this epoch.
@@ -79,6 +83,7 @@ pub struct ShardContext {
 }
 
 /// Information about storage used for applying txs and receipts.
+#[derive(Clone)]
 pub struct StorageContext {
     /// Data source used for processing shard update.
     pub storage_data_source: StorageDataSource,
@@ -92,17 +97,18 @@ pub fn process_shard_update(
     runtime: &dyn RuntimeAdapter,
     shard_update_reason: ShardUpdateReason,
     shard_context: ShardContext,
+    apply_chunk_reason: ApplyChunkReason,
 ) -> Result<ShardUpdateResult, Error> {
     Ok(match shard_update_reason {
         ShardUpdateReason::NewChunk(data) => ShardUpdateResult::NewChunk(apply_new_chunk(
-            ApplyChunkReason::UpdateTrackedShard,
+            apply_chunk_reason,
             parent_span,
             data,
             shard_context,
             runtime,
         )?),
         ShardUpdateReason::OldChunk(data) => ShardUpdateResult::OldChunk(apply_old_chunk(
-            ApplyChunkReason::UpdateTrackedShard,
+            apply_chunk_reason,
             parent_span,
             data,
             shard_context,

--- a/core/primitives-core/src/apply.rs
+++ b/core/primitives-core/src/apply.rs
@@ -14,6 +14,7 @@ pub enum ApplyChunkReason {
     ValidateChunkStateWitness,
     /// Apply-chunk is invoked to view the state of a tracked shard (eg. calling a function from a specific state).
     ViewTrackedShard,
+    Experiment,
 }
 
 impl ApplyChunkReason {
@@ -23,6 +24,7 @@ impl ApplyChunkReason {
             ApplyChunkReason::UpdateTrackedShard => "update_shard",
             ApplyChunkReason::ValidateChunkStateWitness => "validate_chunk",
             ApplyChunkReason::ViewTrackedShard => "view_shard",
+            ApplyChunkReason::Experiment => "experiment",
         }
     }
 }

--- a/core/primitives/src/sandbox.rs
+++ b/core/primitives/src/sandbox.rs
@@ -50,7 +50,7 @@ pub mod state_patch {
 pub mod state_patch {
     use crate::state_record::StateRecord;
 
-    #[derive(Default)]
+    #[derive(Default, Clone)]
     pub struct SandboxStatePatch;
 
     impl SandboxStatePatch {

--- a/tools/replay-archive/src/cli.rs
+++ b/tools/replay-archive/src/cli.rs
@@ -350,8 +350,13 @@ impl ReplayController {
             })
         };
 
-        let shard_update_result =
-            process_shard_update(&span, self.runtime.as_ref(), update_reason, shard_context)?;
+        let shard_update_result = process_shard_update(
+            &span,
+            self.runtime.as_ref(),
+            update_reason,
+            shard_context,
+            near_primitives::apply::ApplyChunkReason::UpdateTrackedShard,
+        )?;
 
         let output = match shard_update_result {
             ShardUpdateResult::NewChunk(NewChunkResult {


### PR DESCRIPTION
This PR adds second chunk application without storage proof limit as well as extended metrics to track the results.
The goal is to measure storage proof size without including contract code.

[This dasboard](https://grafana.nearone.org/d/cdub6uu06vklcd/experiment?orgId=1&from=now-3h&to=now&timezone=browser&var-node=pugachag-dev&var-node_exp=pugachag-dev&var-shard_id=$__all&viewPanel=panel-28) shows the impact on the max size of the storage proof.