### PR TITLE
resharding: verify proof

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3756,19 +3756,13 @@ impl Chain {
             self.shard_tracker.care_about_shard(me.as_ref(), prev_hash, shard_id, true);
         let cares_about_shard_next_epoch =
             self.shard_tracker.will_care_about_shard(me.as_ref(), prev_hash, shard_id, true);
-        let will_shard_layout_change = self.epoch_manager.will_shard_layout_change(prev_hash)?;
         let should_apply_chunk = get_should_apply_chunk(
             mode,
             cares_about_shard_this_epoch,
             cares_about_shard_next_epoch,
         );
         let shard_uid = self.epoch_manager.shard_id_to_uid(shard_id, epoch_id)?;
-        Ok(ShardContext {
-            shard_uid,
-            cares_about_shard_this_epoch,
-            will_shard_layout_change,
-            should_apply_chunk,
-        })
+        Ok(ShardContext { shard_uid, should_apply_chunk })
     }
 
     /// This method returns the closure that is responsible for updating a shard.

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -580,7 +580,6 @@ pub fn validate_chunk_state_witness(
     let epoch_id = epoch_manager.get_epoch_id(&block_hash)?;
     let shard_uid = epoch_manager
         .shard_id_to_uid(pre_validation_output.main_transition_params.shard_id(), &epoch_id)?;
-    tracing::debug!(target: "client", "shard_uid: {:?}", shard_uid);
     let protocol_version = epoch_manager.get_epoch_protocol_version(&epoch_id)?;
     let cache_result = {
         let mut shard_cache = main_state_transition_cache.lock().unwrap();

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -691,7 +691,6 @@ pub fn validate_chunk_state_witness(
                 retain_mode,
                 child_shard_uid,
             ) => {
-                panic!("resharding should not be validated");
                 let old_root = *chunk_extra.state_root();
                 let trie = Trie::from_recorded_storage(
                     PartialStorage { nodes: transition.base_state },

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -70,10 +70,6 @@ pub enum ShardUpdateReason {
 /// Information about shard to update.
 pub struct ShardContext {
     pub shard_uid: ShardUId,
-    /// Whether node cares about shard in this epoch.
-    pub cares_about_shard_this_epoch: bool,
-    /// Whether shard layout changes in the next epoch.
-    pub will_shard_layout_change: bool,
     /// Whether transactions should be applied.
     pub should_apply_chunk: bool,
 }

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -95,18 +95,6 @@ impl ChunkValidator {
         let chunk_header = state_witness.chunk_header.clone();
         let network_sender = self.network_sender.clone();
         let epoch_manager = self.epoch_manager.clone();
-        if matches!(
-            pre_validation_result.main_transition_params,
-            chunk_validation::MainTransition::ShardLayoutChange
-        ) {
-            send_chunk_endorsement_to_block_producers(
-                &chunk_header,
-                epoch_manager.as_ref(),
-                signer,
-                &network_sender,
-            );
-            return Ok(());
-        }
 
         // If we have the chunk extra for the previous block, we can validate
         // the chunk without state witness.

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -108,17 +108,17 @@ impl ChunkValidator {
             return Ok(());
         }
 
-        // If we have the chunk extra for the previous block, we can validate the chunk without state witness.
+        // If we have the chunk extra for the previous block, we can validate
+        // the chunk without state witness.
         // This usually happens because we are a chunk producer and
         // therefore have the chunk extra for the previous block saved on disk.
         // We can also skip validating the chunk state witness in this case.
+        // We don't need to switch to parent shard uid, because resharding
+        // creates chunk extra for new shard uid.
+        let shard_uid = epoch_manager.shard_id_to_uid(shard_id, &epoch_id)?;
         let prev_block = chain.get_block(prev_block_hash)?;
-        let last_header = Chain::get_prev_chunk_header(
-            epoch_manager.as_ref(),
-            &prev_block,
-            chunk_header.shard_id(),
-        )?;
-        let shard_uid = epoch_manager.shard_id_to_uid(last_header.shard_id(), &epoch_id)?;
+        let last_header =
+            Chain::get_prev_chunk_header(epoch_manager.as_ref(), &prev_block, shard_id)?;
 
         if let Ok(prev_chunk_extra) = chain.get_chunk_extra(prev_block_hash, &shard_uid) {
             match validate_chunk_with_chunk_extra(

--- a/nearcore/src/state_sync.rs
+++ b/nearcore/src/state_sync.rs
@@ -257,20 +257,22 @@ fn get_current_state(
         _ => None,
     };
 
-    let latest_epoch_info = get_latest_epoch(shard_id, &chain, epoch_manager.clone());
-    let LatestEpochInfo {
+    let maybe_latest_epoch_info = get_latest_epoch(shard_id, &chain, epoch_manager.clone());
+    let latest_epoch_info = match maybe_latest_epoch_info {
+        Ok(latest_epoch_info) => latest_epoch_info,
+        Err(err) => {
+            tracing::error!(target: "state_sync_dump", ?shard_id, ?err, "Failed to get the latest epoch");
+            return Err(err);
+        }
+    };
+    let Some(LatestEpochInfo {
         prev_epoch_id,
         epoch_id: new_epoch_id,
         epoch_height: new_epoch_height,
         sync_hash: new_sync_hash,
-    } = latest_epoch_info.map_err(|err| {
-        tracing::error!(target: "state_sync_dump", ?shard_id, ?err, "Failed to get the latest epoch");
-        err
-    })?;
-
-    let new_sync_hash = match new_sync_hash {
-        Some(h) => h,
-        None => return Ok(StateDumpAction::Wait),
+    }) = latest_epoch_info
+    else {
+        return Ok(StateDumpAction::Wait);
     };
 
     if Some(&new_epoch_id) == was_last_epoch_done.as_ref() {
@@ -656,7 +658,7 @@ struct LatestEpochInfo {
     prev_epoch_id: EpochId,
     epoch_id: EpochId,
     epoch_height: EpochHeight,
-    sync_hash: Option<CryptoHash>,
+    sync_hash: CryptoHash,
 }
 
 /// return epoch_id and sync_hash of the latest complete epoch available locally.
@@ -664,13 +666,18 @@ fn get_latest_epoch(
     shard_id: &ShardId,
     chain: &Chain,
     epoch_manager: Arc<dyn EpochManagerAdapter>,
-) -> Result<LatestEpochInfo, Error> {
+) -> Result<Option<LatestEpochInfo>, Error> {
     let head = chain.head()?;
     tracing::debug!(target: "state_sync_dump", ?shard_id, "Check if a new complete epoch is available");
     let hash = head.last_block_hash;
     let header = chain.get_block_header(&hash)?;
     let final_hash = header.last_final_block();
-    let sync_hash = chain.get_sync_hash(final_hash)?;
+    if final_hash == &CryptoHash::default() {
+        return Ok(None);
+    }
+    let Some(sync_hash) = chain.get_sync_hash(final_hash)? else {
+        return Ok(None);
+    };
     let final_block_header = chain.get_block_header(&final_hash)?;
     let epoch_id = *final_block_header.epoch_id();
     let epoch_info = epoch_manager.get_epoch_info(&epoch_id)?;
@@ -679,5 +686,5 @@ fn get_latest_epoch(
 
     tracing::debug!(target: "state_sync_dump", ?final_hash, ?sync_hash, ?epoch_id, epoch_height, "get_latest_epoch");
 
-    Ok(LatestEpochInfo { prev_epoch_id, epoch_id, epoch_height, sync_hash })
+    Ok(Some(LatestEpochInfo { prev_epoch_id, epoch_id, epoch_height, sync_hash }))
 }

--- a/tools/replay-archive/src/cli.rs
+++ b/tools/replay-archive/src/cli.rs
@@ -305,7 +305,7 @@ impl ReplayController {
         )?;
 
         let shard_id = shard_uid.shard_id();
-        let shard_context = self.get_shard_context(block_header, shard_uid)?;
+        let shard_context = self.get_shard_context(shard_uid)?;
 
         let storage_context = StorageContext {
             storage_data_source: StorageDataSource::DbTrieOnly,
@@ -488,19 +488,8 @@ impl ReplayController {
 
     /// Generates a ShardContext specific to replaying the blocks, which indicates that
     /// we care about all the shards and should always apply chunk.
-    fn get_shard_context(
-        &self,
-        block_header: &BlockHeader,
-        shard_uid: ShardUId,
-    ) -> Result<ShardContext> {
-        let prev_hash = block_header.prev_hash();
-        let will_shard_layout_change = self.epoch_manager.will_shard_layout_change(prev_hash)?;
-        let shard_context = ShardContext {
-            shard_uid,
-            cares_about_shard_this_epoch: true,
-            will_shard_layout_change: will_shard_layout_change,
-            should_apply_chunk: true,
-        };
+    fn get_shard_context(&self, shard_uid: ShardUId) -> Result<ShardContext> {
+        let shard_context = ShardContext { shard_uid, should_apply_chunk: true };
         Ok(shard_context)
     }
 


### PR DESCRIPTION
Completes the resharding validation flow on the chunk validator side.

The code replaces `MainTransition::ShardLayoutChange` with actual logic. The whole preparation is needed to call `let new_root = trie.retain_split_shard(&boundary_account, retain_mode)?;`, to verify it against state root provided in transition.

The main complexity is to introduce implicit transition for resharding to the right place - after applying last chunk in old shard layout, potentially missing, and before applying first chunk in the new layout. To do that, I needed to modify `get_state_witness_block_range` once again, and to make it readable, I rewrote it using `TraversalPosition`. The point of that is to change all parameters of the loop at once, instead of changing them one-by-one in the loop. Then, I generate `ImplicitTransitionParams` right in the loop. Finally, this allows to insert resharding transition before jumping to the previous block hash and child shard id, if needed. Note that this flow happens in reverse to chain flow.

Also unfortunately this is not triggered on production tests, because when nodes track all shards, the condition `if let Ok(prev_chunk_extra) = chain.get_chunk_extra(prev_block_hash, &shard_uid) { ... }` is triggered - if latest chunk extra is already computed, we skip unnecessary validations. So for now I checked the correctness by commenting this path and running tests locally.