### PR TITLE
test: reshardingV3 test loop for buffered receipts

### DIFF
--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -308,6 +308,11 @@ impl TestLoopBuilder {
         self
     }
 
+    pub(crate) fn runtime_config_store(mut self, runtime_config_store: RuntimeConfigStore) -> Self {
+        self.runtime_config_store = Some(runtime_config_store);
+        self
+    }
+
     /// Set the clients for the test loop.
     pub(crate) fn clients(mut self, clients: Vec<AccountId>) -> Self {
         self.clients = clients;

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -699,7 +699,7 @@ fn test_resharding_v3_split_parent_buffered_receipts() {
         .limit_outgoing_gas()
         .add_loop_action(call_burn_gas_contract(
             vec![account_in_left_child, account_in_right_child.clone()],
-            receiver_account.clone(),
+            receiver_account,
             5 * TGAS,
         ))
         .add_loop_action(check_receipts_presence_at_resharding_block(

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -708,3 +708,25 @@ fn test_resharding_v3_split_parent_buffered_receipts() {
         ));
     test_resharding_v3_base(params);
 }
+
+#[test]
+// TODO(resharding): fix nearcore and replace the line below with #[cfg_attr(not(feature = "test_features"), ignore)]
+#[ignore]
+fn test_resharding_v3_buffered_receipts_towards_splitted_shard() {
+    let receiver_account: AccountId = "account4".parse().unwrap();
+    let account_1_in_stable_shard: AccountId = "account1".parse().unwrap();
+    let account_2_in_stable_shard: AccountId = "account2".parse().unwrap();
+    let params = TestReshardingParameters::new()
+        .deploy_test_contract(receiver_account.clone())
+        .limit_outgoing_gas()
+        .add_loop_action(call_burn_gas_contract(
+            vec![account_1_in_stable_shard.clone(), account_2_in_stable_shard],
+            receiver_account,
+            5 * TGAS,
+        ))
+        .add_loop_action(check_receipts_presence_at_resharding_block(
+            account_1_in_stable_shard,
+            ReceiptKind::Buffered,
+        ));
+    test_resharding_v3_base(params);
+}

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -336,19 +336,31 @@ fn check_receipts_presence_at_resharding_block(
             match kind {
                 ReceiptKind::Delayed => {
                     assert_ne!(congestion_info.delayed_receipts_gas(), 0);
-                    check_delayed_receipts_exist_in_memtrie(&client_actor.client, &shard_uid, &tip.prev_block_hash);
+                    check_delayed_receipts_exist_in_memtrie(
+                        &client_actor.client,
+                        &shard_uid,
+                        &tip.prev_block_hash,
+                    );
                 }
                 ReceiptKind::Buffered => {
                     assert_ne!(congestion_info.buffered_receipts_gas(), 0);
-                    check_buffered_receipts_exist_in_memtrie(&client_actor.client, &shard_uid, &tip.prev_block_hash);
-                },
+                    check_buffered_receipts_exist_in_memtrie(
+                        &client_actor.client,
+                        &shard_uid,
+                        &tip.prev_block_hash,
+                    );
+                }
             }
         },
     )
 }
 
 /// Asserts that a non zero amount of delayed receipts exist in MemTrie for the given shard.
-fn check_delayed_receipts_exist_in_memtrie(client: &Client, shard_uid: &ShardUId, prev_block_hash: &CryptoHash) {
+fn check_delayed_receipts_exist_in_memtrie(
+    client: &Client,
+    shard_uid: &ShardUId,
+    prev_block_hash: &CryptoHash,
+) {
     let memtrie = get_memtrie_for_shard(client, shard_uid, prev_block_hash);
     let indices: DelayedReceiptIndices =
         get(&memtrie, &TrieKey::DelayedReceiptIndices).unwrap().unwrap();
@@ -356,7 +368,11 @@ fn check_delayed_receipts_exist_in_memtrie(client: &Client, shard_uid: &ShardUId
 }
 
 /// Asserts that a non zero amount of buffered receipts exist in MemTrie for the given shard.
-fn check_buffered_receipts_exist_in_memtrie(client: &Client, shard_uid: &ShardUId, prev_block_hash: &CryptoHash) {
+fn check_buffered_receipts_exist_in_memtrie(
+    client: &Client,
+    shard_uid: &ShardUId,
+    prev_block_hash: &CryptoHash,
+) {
     let memtrie = get_memtrie_for_shard(client, shard_uid, prev_block_hash);
     let indices: BufferedReceiptIndices =
         get(&memtrie, &TrieKey::BufferedReceiptIndices).unwrap().unwrap();

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -730,3 +730,35 @@ fn test_resharding_v3_buffered_receipts_towards_splitted_shard() {
         ));
     test_resharding_v3_base(params);
 }
+
+#[test]
+#[cfg_attr(not(feature = "test_features"), ignore)]
+fn test_resharding_v3_outgoing_receipts_towards_splitted_shard() {
+    let receiver_account: AccountId = "account4".parse().unwrap();
+    let account_1_in_stable_shard: AccountId = "account1".parse().unwrap();
+    let account_2_in_stable_shard: AccountId = "account2".parse().unwrap();
+    let params = TestReshardingParameters::new()
+        .deploy_test_contract(receiver_account.clone())
+        .add_loop_action(call_burn_gas_contract(
+            vec![account_1_in_stable_shard, account_2_in_stable_shard],
+            receiver_account,
+            5 * TGAS,
+        ));
+    test_resharding_v3_base(params);
+}
+
+#[test]
+#[cfg_attr(not(feature = "test_features"), ignore)]
+fn test_resharding_v3_outgoing_receipts_from_splitted_shard() {
+    let receiver_account: AccountId = "account0".parse().unwrap();
+    let account_in_left_child: AccountId = "account4".parse().unwrap();
+    let account_in_right_child: AccountId = "account6".parse().unwrap();
+    let params = TestReshardingParameters::new()
+        .deploy_test_contract(receiver_account.clone())
+        .add_loop_action(call_burn_gas_contract(
+            vec![account_in_left_child, account_in_right_child],
+            receiver_account,
+            5 * TGAS,
+        ));
+    test_resharding_v3_base(params);
+}


### PR DESCRIPTION
New test loop test for buffered receipts during resharding.

- Added a new static shard in the starting shard layout to make facilitate cross shard testing
  New state before resharding:
  ```
  accounts for shard s2.v3: ["account0"]
  accounts for shard s1.v3: ["account1", "account2"]
  accounts for shard s0.v3: ["account3", "account4", "account5", "account6", "account7", "near"]
  ```
- `test_resharding_v3_split_parent_buffered_receipts` fails when buffered receipts are present in resharded shard, it works when target shard is not changing at epoch boundary
- Changed `loop_action` to execute multiple functions, not just one