### PR TITLE
feat(rosetta-rpc): added custom status code for a missed block

### DIFF
--- a/chain/rosetta-rpc/src/errors.rs
+++ b/chain/rosetta-rpc/src/errors.rs
@@ -8,6 +8,8 @@ pub(crate) enum ErrorKind {
     InvalidInput(String),
     #[error("Not found: {0}")]
     NotFound(String),
+    #[error("Missing block: {0}")]
+    MissingBlock(String),
     #[error("Wrong network: {0}")]
     WrongNetwork(String),
     #[error("Timeout: {0}")]

--- a/chain/rosetta-rpc/src/models.rs
+++ b/chain/rosetta-rpc/src/models.rs
@@ -544,6 +544,9 @@ impl Error {
             crate::errors::ErrorKind::NotFound(message) => {
                 Self { code: 404, message: format!("Not Found: {}", message), retriable: false }
             }
+            crate::errors::ErrorKind::MissingBlock(message) => {
+                Self { code: 422, message: format!("Missing Block: {}", message), retriable: false }
+            }
             crate::errors::ErrorKind::WrongNetwork(message) => {
                 Self { code: 403, message: format!("Wrong Network: {}", message), retriable: false }
             }

--- a/chain/rosetta-rpc/src/utils.rs
+++ b/chain/rosetta-rpc/src/utils.rs
@@ -522,7 +522,24 @@ pub(crate) async fn get_block_if_final(
         .await?
     {
         Ok(block) => block,
-        Err(near_client_primitives::types::GetBlockError::UnknownBlock { .. }) => return Ok(None),
+        Err(near_client_primitives::types::GetBlockError::UnknownBlock { .. }) => {
+            let near_primitives::types::BlockReference::BlockId(
+                near_primitives::types::BlockId::Height(height),
+            ) = block_id
+            else {
+                return Ok(None);
+            };
+
+            if height < &final_block.header.height {
+                return Err(errors::ErrorKind::MissingBlock(format!(
+                    "Block at height {} is missing",
+                    height
+                ))
+                .into());
+            }
+
+            return Ok(None);
+        }
         Err(err) => return Err(errors::ErrorKind::InternalError(err.to_string()).into()),
     };
     // if block height is larger than the last final block height, then the block is not final


### PR DESCRIPTION
Implemented similar logic to #12402 for Rosetta RPC