### PR TITLE
[trie] Introduce GenericTrieNode as replacement of GenericUpdatedTrieNode

### DIFF
--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -18,7 +18,7 @@ pub use crate::trie::trie_storage::{TrieCache, TrieCachingStorage, TrieDBStorage
 use crate::StorageError;
 use borsh::{BorshDeserialize, BorshSerialize};
 pub use from_flat::construct_trie_from_flat;
-use mem::mem_trie_update::{TrackingMode, UpdatedMemTrieNodeId, UpdatedMemTrieNodeWithSize};
+use mem::mem_trie_update::{TrackingMode, UpdatedMemTrieNodeWithSize};
 use mem::mem_tries::MemTries;
 use near_primitives::challenge::PartialState;
 use near_primitives::hash::{hash, CryptoHash};
@@ -31,9 +31,9 @@ use near_primitives::types::{AccountId, StateRoot, StateRootNode};
 use near_schema_checker_lib::ProtocolSchema;
 use near_vm_runner::ContractCode;
 use ops::insert_delete::GenericTrieUpdateInsertDelete;
-use ops::interface::GenericTrieValue;
 #[cfg(test)]
-use ops::interface::{GenericNodeOrIndex, GenericTrieUpdate};
+use ops::interface::{GenericNodeOrIndex, GenericTrieNode, GenericTrieUpdate};
+use ops::interface::{GenericTrieValue, UpdatedNodeId};
 pub use raw_node::{Children, RawTrieNode, RawTrieNodeWithSize};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashSet};
@@ -43,9 +43,9 @@ use std::ops::DerefMut;
 use std::str;
 use std::sync::{Arc, RwLock, RwLockReadGuard};
 pub use trie_recording::{SubtreeSize, TrieRecorder, TrieRecorderStats};
-#[cfg(test)]
-use trie_storage_update::UpdatedTrieStorageNode;
-use trie_storage_update::{TrieStorageUpdate, UpdatedTrieStorageNodeWithSize};
+use trie_storage_update::{
+    TrieStorageNodeWithSize, TrieStorageUpdate, UpdatedTrieStorageNodeWithSize,
+};
 
 pub mod accounting_cache;
 mod config;
@@ -197,14 +197,14 @@ impl UpdatedTrieStorageNodeWithSize {
         spaces: &mut String,
     ) -> std::fmt::Result {
         match &self.node {
-            UpdatedTrieStorageNode::Empty => {
+            GenericTrieNode::Empty => {
                 write!(f, "{}Empty", spaces)?;
             }
-            UpdatedTrieStorageNode::Leaf { extension, .. } => {
+            GenericTrieNode::Leaf { extension, .. } => {
                 let slice = NibbleSlice::from_encoded(&extension);
                 write!(f, "{}Leaf({:?}, val)", spaces, slice.0)?;
             }
-            UpdatedTrieStorageNode::Branch { children, value } => {
+            GenericTrieNode::Branch { children, value } => {
                 writeln!(
                     f,
                     "{}Branch({}){{",
@@ -231,7 +231,7 @@ impl UpdatedTrieStorageNodeWithSize {
                 spaces.remove(spaces.len() - 1);
                 write!(f, "{}}}", spaces)?;
             }
-            UpdatedTrieStorageNode::Extension { extension, child } => {
+            GenericTrieNode::Extension { extension, child } => {
                 let slice = NibbleSlice::from_encoded(&extension);
                 writeln!(f, "{}Extension({:?})", spaces, slice)?;
                 spaces.push(' ');
@@ -532,7 +532,7 @@ pub struct MemTrieChanges {
     /// Node ids with hashes of updated nodes.
     /// Should be in the post-order traversal of the updated nodes.
     /// It implies that the root node is the last one in the list.
-    node_ids_with_hashes: Vec<(UpdatedMemTrieNodeId, CryptoHash)>,
+    node_ids_with_hashes: Vec<(UpdatedNodeId, CryptoHash)>,
     updated_nodes: Vec<Option<UpdatedMemTrieNodeWithSize>>,
 }
 
@@ -765,7 +765,7 @@ impl Trie {
         trie
     }
 
-    /// Get statisitics about the recorded trie. Useful for observability and debugging.
+    /// Get statistics about the recorded trie. Useful for observability and debugging.
     /// This scans all of the recorded data, so could potentially be expensive to run.
     pub fn recorder_stats(&self) -> Option<TrieRecorderStats> {
         self.recorder.as_ref().map(|recorder| recorder.borrow().get_stats(&self.root))
@@ -876,15 +876,15 @@ impl Trie {
                     .expect("storage failure")
                     .expect("node cannot be Empty")
                     .1;
-                UpdatedTrieStorageNodeWithSize::from_raw_trie_node_with_size(raw_node)
+                TrieStorageNodeWithSize::from_raw_trie_node_with_size(raw_node).into()
             }
         };
 
         let mut memory_usage_naive = node.memory_usage_direct();
         match &node {
-            UpdatedTrieStorageNode::Empty => {}
-            UpdatedTrieStorageNode::Leaf { .. } => {}
-            UpdatedTrieStorageNode::Branch { children, .. } => {
+            GenericTrieNode::Empty => {}
+            GenericTrieNode::Leaf { .. } => {}
+            GenericTrieNode::Branch { children, .. } => {
                 memory_usage_naive += children
                     .iter()
                     .filter_map(|handle| {
@@ -892,7 +892,7 @@ impl Trie {
                     })
                     .sum::<u64>();
             }
-            UpdatedTrieStorageNode::Extension { child, .. } => {
+            GenericTrieNode::Extension { child, .. } => {
                 memory_usage_naive += self.memory_usage_verify(trie_update, *child);
             }
         };
@@ -1247,7 +1247,7 @@ impl Trie {
             None => Ok(trie_update.store(UpdatedTrieStorageNodeWithSize::empty())),
             Some((_, node)) => {
                 let result = trie_update
-                    .store(UpdatedTrieStorageNodeWithSize::from_raw_trie_node_with_size(node));
+                    .store(TrieStorageNodeWithSize::from_raw_trie_node_with_size(node).into());
                 trie_update.refcount_changes.subtract(*hash, 1);
                 Ok(result)
             }

--- a/core/store/src/trie/ops/insert_delete.rs
+++ b/core/store/src/trie/ops/insert_delete.rs
@@ -3,8 +3,8 @@ use near_primitives::errors::StorageError;
 use crate::NibbleSlice;
 
 use super::interface::{
-    GenericNodeOrIndex, GenericTrieUpdate, GenericTrieValue, GenericUpdatedNodeId,
-    GenericUpdatedTrieNode, GenericUpdatedTrieNodeWithSize, HasValueLength,
+    GenericNodeOrIndex, GenericTrieUpdate, GenericTrieValue, GenericUpdatedTrieNode,
+    GenericUpdatedTrieNodeWithSize, HasValueLength, UpdatedNodeId,
 };
 use super::squash::GenericTrieUpdateSquash;
 
@@ -16,10 +16,10 @@ where
 {
     fn calc_memory_usage_and_store(
         &mut self,
-        node_id: GenericUpdatedNodeId,
+        node_id: UpdatedNodeId,
         children_memory_usage: u64,
         new_node: GenericUpdatedTrieNode<N, V>,
-        old_child: Option<GenericUpdatedNodeId>,
+        old_child: Option<UpdatedNodeId>,
     ) {
         let new_memory_usage =
             children_memory_usage.saturating_add(new_node.memory_usage_direct()).saturating_sub(
@@ -38,7 +38,7 @@ where
     /// created nodes - that's done at the end.
     fn generic_insert(
         &mut self,
-        mut node_id: GenericUpdatedNodeId,
+        mut node_id: UpdatedNodeId,
         key: &[u8],
         value: GenericTrieValue,
     ) -> Result<(), StorageError> {
@@ -304,7 +304,7 @@ where
     /// Deleting a non-existent key is allowed, and is a no-op.
     fn generic_delete(
         &mut self,
-        mut node_id: GenericUpdatedNodeId,
+        mut node_id: UpdatedNodeId,
         key: &[u8],
     ) -> Result<(), StorageError> {
         let mut partial = NibbleSlice::new(key);

--- a/core/store/src/trie/ops/interface.rs
+++ b/core/store/src/trie/ops/interface.rs
@@ -50,7 +50,7 @@ pub enum GenericNodeOrIndex<GenericTrieNodePtr> {
 
 /// A generic representation of a trie node
 /// TrieNodePtr can potentially be of any type including GenericTrieNodePtr for normal nodes or
-/// GenericNodeOrIndex<GenericTrieNodePtr> for updated nodes. 
+/// GenericNodeOrIndex<GenericTrieNodePtr> for updated nodes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GenericTrieNode<TrieNodePtr, GenericValueHandle> {
     /// Used for either an empty root node (indicating an empty trie), or as a temporary

--- a/core/store/src/trie/ops/interface.rs
+++ b/core/store/src/trie/ops/interface.rs
@@ -4,7 +4,7 @@ use near_primitives::state::FlatStateValue;
 use crate::trie::{ValueHandle, TRIE_COSTS};
 
 /// For updated nodes, the ID is simply the index into the array of updated nodes we keep.
-pub type GenericUpdatedNodeId = usize;
+pub type UpdatedNodeId = usize;
 
 /// Value to insert to trie or update existing value in the trie.
 #[derive(Debug, Clone)]
@@ -37,18 +37,22 @@ impl HasValueLength for ValueHandle {
     }
 }
 
-/// An old node means a node in the current in-memory trie. An updated node means a
-/// node we're going to store in the in-memory trie but have not constructed there yet.
+/// This enum represents pointer to a node in trie or pointer to an updated node in trie.
+///
+/// An old node is the pointer to a node currently in trie.
+/// An updated node is the index in the TrieUpdate struct where we temporarily store updates
+/// These eventually get written back to the trie during finalization and commit of trie update.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GenericNodeOrIndex<GenericTrieNodePtr> {
     Old(GenericTrieNodePtr),
-    Updated(GenericUpdatedNodeId),
+    Updated(UpdatedNodeId),
 }
 
-/// An updated node - a node that will eventually become a trie node.
-/// It references children that are either old or updated nodes.
+/// A generic representation of a trie node
+/// TrieNodePtr can potentially be of any type including GenericTrieNodePtr for normal nodes or
+/// GenericNodeOrIndex<GenericTrieNodePtr> for updated nodes. 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum GenericUpdatedTrieNode<GenericTrieNodePtr, GenericValueHandle> {
+pub enum GenericTrieNode<TrieNodePtr, GenericValueHandle> {
     /// Used for either an empty root node (indicating an empty trie), or as a temporary
     /// node to ease implementation.
     Empty,
@@ -58,19 +62,18 @@ pub enum GenericUpdatedTrieNode<GenericTrieNodePtr, GenericValueHandle> {
     },
     Extension {
         extension: Box<[u8]>,
-        child: GenericNodeOrIndex<GenericTrieNodePtr>,
+        child: TrieNodePtr,
     },
     /// Corresponds to either a Branch or BranchWithValue node.
     Branch {
-        children: Box<[Option<GenericNodeOrIndex<GenericTrieNodePtr>>; 16]>,
+        children: Box<[Option<TrieNodePtr>; 16]>,
         value: Option<GenericValueHandle>,
     },
 }
 
-impl<GenericTrieNodePtr, GenericValueHandle>
-    GenericUpdatedTrieNode<GenericTrieNodePtr, GenericValueHandle>
+impl<N, V> GenericTrieNode<N, V>
 where
-    GenericValueHandle: HasValueLength,
+    V: HasValueLength,
 {
     fn memory_usage_value(value_length: u64) -> u64 {
         value_length * TRIE_COSTS.byte_of_value + TRIE_COSTS.node_cost
@@ -102,6 +105,37 @@ where
     }
 }
 
+/// An updated node - a node that will eventually become a trie node.
+/// It references children that are of type GenericNodeOrIndex<GenericTrieNodePtr>
+/// i.e. either old nodes or updated nodes.
+pub type GenericUpdatedTrieNode<GenericTrieNodePtr, GenericValueHandle> =
+    GenericTrieNode<GenericNodeOrIndex<GenericTrieNodePtr>, GenericValueHandle>;
+
+/// Simple conversion from GenericTrieNode to GenericUpdatedTrieNode
+/// We change all occurrences of GenericTrieNodePtr to GenericNodeOrIndex::Old(ptr)
+impl<N, V> From<GenericTrieNode<N, V>> for GenericUpdatedTrieNode<N, V> {
+    fn from(node: GenericTrieNode<N, V>) -> Self {
+        match node {
+            GenericTrieNode::Empty => Self::Empty,
+            GenericTrieNode::Leaf { extension, value } => Self::Leaf { extension, value },
+            GenericTrieNode::Extension { extension, child } => {
+                Self::Extension { extension, child: GenericNodeOrIndex::Old(child) }
+            }
+            GenericTrieNode::Branch { children, value } => {
+                let children = Box::new(children.map(|child| child.map(GenericNodeOrIndex::Old)));
+                Self::Branch { children, value }
+            }
+        }
+    }
+}
+
+/// A trie node with its memory usage.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenericTrieNodeWithSize<GenericTrieNodePtr, GenericValueHandle> {
+    pub node: GenericTrieNode<GenericTrieNodePtr, GenericValueHandle>,
+    pub memory_usage: u64,
+}
+
 /// An updated node with its memory usage.
 /// Needed to recompute subtree function (memory usage) on the fly.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -116,6 +150,12 @@ impl<N, V> GenericUpdatedTrieNodeWithSize<N, V> {
     }
 }
 
+impl<N, V> From<GenericTrieNodeWithSize<N, V>> for GenericUpdatedTrieNodeWithSize<N, V> {
+    fn from(node: GenericTrieNodeWithSize<N, V>) -> Self {
+        Self { node: node.node.into(), memory_usage: node.memory_usage }
+    }
+}
+
 /// Trait for trie updates to handle updated nodes.
 ///
 /// So far, this is used to handle key-value insertions, deletions and range
@@ -125,20 +165,20 @@ impl<N, V> GenericUpdatedTrieNodeWithSize<N, V> {
 /// `GenericTrieUpdate` abstracts the storage of updated nodes for the original
 /// node type `GenericTrieNodePtr`.
 ///
-/// In this storage, nodes are indexed by `GenericUpdatedNodeId`.
+/// In this storage, nodes are indexed by `UpdatedNodeId`.
 /// Node is stored as `GenericUpdatedTrieNodeWithSize`, which stores children
 /// as `GenericNodeOrIndex`. Each child may be either an old node or an updated
 /// node.
 ///
 /// The flow of interaction with this storage is:
 /// - In the beginning, call `ensure_updated` for the
-/// `GenericNodeOrIndex::Old(root_node)` which returns `GenericUpdatedNodeId`,
+/// `GenericNodeOrIndex::Old(root_node)` which returns `UpdatedNodeId`,
 /// it should be zero.
 /// - For every update (single insert, single delete, recursive range
-/// operation...), call corresponding method with `GenericUpdatedNodeId` for
+/// operation...), call corresponding method with `UpdatedNodeId` for
 /// the root.
 /// - Then, we hold the invariant that on every descent we have
-/// `GenericUpdatedNodeId`.
+/// `UpdatedNodeId`.
 /// - So, first, we call `take_node` to get `GenericUpdatedTrieNodeWithSize`
 /// back;
 /// - We possibly descend into its children and modify the node;
@@ -157,21 +197,21 @@ pub(crate) trait GenericTrieUpdate<'a, GenericTrieNodePtr, GenericValueHandle> {
     fn ensure_updated(
         &mut self,
         node: GenericNodeOrIndex<GenericTrieNodePtr>,
-    ) -> Result<GenericUpdatedNodeId, StorageError>;
+    ) -> Result<UpdatedNodeId, StorageError>;
 
     /// Takes a node from the set of updated nodes, setting it to None.
     /// It is expected that place_node is then called to return the node to
     /// the same slot.
     fn take_node(
         &mut self,
-        node_id: GenericUpdatedNodeId,
+        node_id: UpdatedNodeId,
     ) -> GenericUpdatedTrieNodeWithSize<GenericTrieNodePtr, GenericValueHandle>;
 
     /// Puts a node to the set of updated nodes at specific index.
     /// Needed when reference to node from parent needs to be preserved.
     fn place_node_at(
         &mut self,
-        node_id: GenericUpdatedNodeId,
+        node_id: UpdatedNodeId,
         node: GenericUpdatedTrieNodeWithSize<GenericTrieNodePtr, GenericValueHandle>,
     );
 
@@ -179,12 +219,12 @@ pub(crate) trait GenericTrieUpdate<'a, GenericTrieNodePtr, GenericValueHandle> {
     fn place_node(
         &mut self,
         node: GenericUpdatedTrieNodeWithSize<GenericTrieNodePtr, GenericValueHandle>,
-    ) -> GenericUpdatedNodeId;
+    ) -> UpdatedNodeId;
 
     /// Gets a node reference in the set of updated nodes.
     fn get_node_ref(
         &self,
-        node_id: GenericUpdatedNodeId,
+        node_id: UpdatedNodeId,
     ) -> &GenericUpdatedTrieNodeWithSize<GenericTrieNodePtr, GenericValueHandle>;
 
     /// Stores a state value in the trie.

--- a/core/store/src/trie/ops/resharding.rs
+++ b/core/store/src/trie/ops/resharding.rs
@@ -8,7 +8,7 @@ use near_primitives::types::AccountId;
 use crate::NibbleSlice;
 
 use super::interface::{
-    GenericNodeOrIndex, GenericTrieUpdate, GenericUpdatedNodeId, GenericUpdatedTrieNode,
+    GenericNodeOrIndex, GenericTrieUpdate, UpdatedNodeId, GenericUpdatedTrieNode,
     GenericUpdatedTrieNodeWithSize, HasValueLength,
 };
 use super::squash::GenericTrieUpdateSquash;
@@ -78,7 +78,7 @@ where
     /// `intervals_nibbles` is the list of ranges to be retained.
     fn retain_multi_range_recursive(
         &mut self,
-        node_id: GenericUpdatedNodeId,
+        node_id: UpdatedNodeId,
         key_nibbles: Vec<u8>,
         intervals_nibbles: &[Range<Vec<u8>>],
     ) -> Result<(), StorageError> {

--- a/core/store/src/trie/ops/resharding.rs
+++ b/core/store/src/trie/ops/resharding.rs
@@ -8,8 +8,8 @@ use near_primitives::types::AccountId;
 use crate::NibbleSlice;
 
 use super::interface::{
-    GenericNodeOrIndex, GenericTrieUpdate, UpdatedNodeId, GenericUpdatedTrieNode,
-    GenericUpdatedTrieNodeWithSize, HasValueLength,
+    GenericNodeOrIndex, GenericTrieUpdate, GenericUpdatedTrieNode, GenericUpdatedTrieNodeWithSize,
+    HasValueLength, UpdatedNodeId,
 };
 use super::squash::GenericTrieUpdateSquash;
 

--- a/core/store/src/trie/ops/squash.rs
+++ b/core/store/src/trie/ops/squash.rs
@@ -3,8 +3,8 @@ use near_primitives::errors::StorageError;
 use crate::NibbleSlice;
 
 use super::interface::{
-    GenericNodeOrIndex, GenericTrieUpdate, UpdatedNodeId, GenericUpdatedTrieNode,
-    GenericUpdatedTrieNodeWithSize, HasValueLength,
+    GenericNodeOrIndex, GenericTrieUpdate, GenericUpdatedTrieNode, GenericUpdatedTrieNodeWithSize,
+    HasValueLength, UpdatedNodeId,
 };
 
 pub(crate) trait GenericTrieUpdateSquash<'a, N, V>: GenericTrieUpdate<'a, N, V>

--- a/core/store/src/trie/ops/squash.rs
+++ b/core/store/src/trie/ops/squash.rs
@@ -3,7 +3,7 @@ use near_primitives::errors::StorageError;
 use crate::NibbleSlice;
 
 use super::interface::{
-    GenericNodeOrIndex, GenericTrieUpdate, GenericUpdatedNodeId, GenericUpdatedTrieNode,
+    GenericNodeOrIndex, GenericTrieUpdate, UpdatedNodeId, GenericUpdatedTrieNode,
     GenericUpdatedTrieNodeWithSize, HasValueLength,
 };
 
@@ -27,7 +27,7 @@ where
     /// the leaf to the root.
     /// For range removal, it is called in the end of recursive range removal
     /// function, which is the definition of post-order traversal.
-    fn squash_node(&mut self, node_id: GenericUpdatedNodeId) -> Result<(), StorageError> {
+    fn squash_node(&mut self, node_id: UpdatedNodeId) -> Result<(), StorageError> {
         let GenericUpdatedTrieNodeWithSize { node, memory_usage } = self.take_node(node_id);
         match node {
             GenericUpdatedTrieNode::Empty => {
@@ -107,7 +107,7 @@ where
     fn extend_child(
         &mut self,
         // The node being squashed.
-        node_id: GenericUpdatedNodeId,
+        node_id: UpdatedNodeId,
         // The current extension.
         extension: Box<[u8]>,
         // The current child.


### PR DESCRIPTION
This PR introduces the GenericTrieNode which is a generalization on top of GenericUpdatedTrieNode where the nodes need not be an update type node.

This is useful in scenarios where we are not dealing with just updates, for example generalizing iterators over tries etc.

Along with this change this PR renames `GenericUpdatedNodeId` to `UpdatedNodeId` which is more appropriate as for both memtries and store tries we have UpdatedNodeId as usize.