### PR TITLE
fix(resharding) Deduplicate shard uids for gc

### DIFF
--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::{fmt, io};
 
@@ -501,6 +501,7 @@ impl<'a> ChainStoreUpdate<'a> {
         Ok(())
     }
 
+    // TODO(reshardingV3) Revisit this function, probably it is not needed anymore.
     fn get_shard_uids_to_gc(
         &mut self,
         epoch_manager: &dyn EpochManagerAdapter,
@@ -522,7 +523,8 @@ impl<'a> ChainStoreUpdate<'a> {
         if shard_layout != next_shard_layout {
             shard_uids_to_gc.extend(next_shard_layout.shard_uids());
         }
-        shard_uids_to_gc
+        let unique_shard_uids_to_gc = shard_uids_to_gc.into_iter().collect::<HashSet<_>>();
+        unique_shard_uids_to_gc.into_iter().collect()
     }
 
     // Clearing block data of `block_hash`, if on a fork.

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -4,6 +4,7 @@ use near_async::test_loop::data::{TestLoopData, TestLoopDataHandle};
 use near_async::time::Duration;
 use near_chain::ChainStoreAccess;
 use near_chain_configs::test_genesis::TestGenesisBuilder;
+use near_chain_configs::DEFAULT_GC_NUM_EPOCHS_TO_KEEP;
 use near_client::Client;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::block::Tip;
@@ -717,6 +718,9 @@ fn test_resharding_v3_base(params: TestReshardingParameters) {
         // Give enough time to produce ~7 epochs.
         Duration::seconds((7 * params.epoch_length) as i64),
     );
+    // Wait for garbage collection to kick in, so that it is tested as well.
+    test_loop
+        .run_for(Duration::seconds((DEFAULT_GC_NUM_EPOCHS_TO_KEEP * params.epoch_length) as i64));
 
     // At the end of the test we know for sure resharding has been completed.
     // Verify that state is equal across tries and flat storage for all children shards.


### PR DESCRIPTION
GC was failing after resharding because of duplications in the list of shard uids to gc.
It worked with previous resharding because all shard uids had version bumped, which is not the case since resharding v3.
Note that does this not handle delayed receipts etc.