### PR TITLE
fix(tests) - fix test_protocol_upgrade always upgrading to the latest version

### DIFF
--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -71,6 +71,7 @@ fn build_chain_with_orphans() {
     let block = Block::produce(
         PROTOCOL_VERSION,
         PROTOCOL_VERSION,
+        PROTOCOL_VERSION,
         last_block.header(),
         10,
         last_block.header().block_ordinal() + 1,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -72,7 +72,7 @@ use near_primitives::types::{AccountId, ApprovalStake, BlockHeight, EpochId, Num
 use near_primitives::unwrap_or_return;
 use near_primitives::utils::MaybeValidated;
 use near_primitives::validator_signer::ValidatorSigner;
-use near_primitives::version::{get_protocol_version, ProtocolFeature, PROTOCOL_VERSION};
+use near_primitives::version::{ProtocolFeature, PROTOCOL_UPGRADE_SCHEDULE, PROTOCOL_VERSION};
 use near_primitives::views::{CatchupStatusView, DroppedReason};
 use near_store::ShardUId;
 use reed_solomon_erasure::galois_8::ReedSolomon;
@@ -803,7 +803,8 @@ impl Client {
         let block = Block::produce(
             this_epoch_protocol_version,
             next_epoch_protocol_version,
-            get_protocol_version(next_epoch_protocol_version, self.clock.clone()),
+            PROTOCOL_UPGRADE_SCHEDULE
+                .get_protocol_version_to_vote_for_now(&self.clock, next_epoch_protocol_version),
             prev_header,
             height,
             block_ordinal,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -70,9 +70,10 @@ use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{AccountId, ApprovalStake, BlockHeight, EpochId, NumBlocks, ShardId};
 use near_primitives::unwrap_or_return;
+use near_primitives::upgrade_schedule::ProtocolUpgradeVotingSchedule;
 use near_primitives::utils::MaybeValidated;
 use near_primitives::validator_signer::ValidatorSigner;
-use near_primitives::version::{ProtocolFeature, PROTOCOL_UPGRADE_SCHEDULE, PROTOCOL_VERSION};
+use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_primitives::views::{CatchupStatusView, DroppedReason};
 use near_store::ShardUId;
 use reed_solomon_erasure::galois_8::ReedSolomon;
@@ -200,6 +201,8 @@ pub struct Client {
     pub partial_witness_adapter: PartialWitnessSenderForClient,
     // Optional value used for the Chunk Distribution Network Feature.
     chunk_distribution_network: Option<ChunkDistributionNetwork>,
+    /// Upgrade schedule which determines when the client starts voting for new protocol versions.
+    upgrade_schedule: ProtocolUpgradeVotingSchedule,
 }
 
 impl AsRef<Client> for Client {
@@ -256,6 +259,7 @@ impl Client {
         resharding_sender: ReshardingSender,
         state_sync_future_spawner: Arc<dyn FutureSpawner>,
         chain_sender_for_state_sync: ChainSenderForStateSync,
+        upgrade_schedule: ProtocolUpgradeVotingSchedule,
     ) -> Result<Self, Error> {
         let doomslug_threshold_mode = if enable_doomslug {
             DoomslugThresholdMode::TwoThirds
@@ -408,6 +412,7 @@ impl Client {
             chunk_endorsement_tracker,
             partial_witness_adapter,
             chunk_distribution_network,
+            upgrade_schedule,
         })
     }
 
@@ -803,7 +808,7 @@ impl Client {
         let block = Block::produce(
             this_epoch_protocol_version,
             next_epoch_protocol_version,
-            PROTOCOL_UPGRADE_SCHEDULE
+            self.upgrade_schedule
                 .get_protocol_version_to_vote_for_now(&self.clock, next_epoch_protocol_version),
             prev_header,
             height,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -809,7 +809,7 @@ impl Client {
             this_epoch_protocol_version,
             next_epoch_protocol_version,
             self.upgrade_schedule
-                .get_protocol_version_to_vote_for_now(&self.clock, next_epoch_protocol_version),
+                .protocol_version_to_vote_for(self.clock.now_utc(), next_epoch_protocol_version),
             prev_header,
             height,
             block_ordinal,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -72,7 +72,7 @@ use near_primitives::types::{AccountId, ApprovalStake, BlockHeight, EpochId, Num
 use near_primitives::unwrap_or_return;
 use near_primitives::utils::MaybeValidated;
 use near_primitives::validator_signer::ValidatorSigner;
-use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
+use near_primitives::version::{get_protocol_version, ProtocolFeature, PROTOCOL_VERSION};
 use near_primitives::views::{CatchupStatusView, DroppedReason};
 use near_store::ShardUId;
 use reed_solomon_erasure::galois_8::ReedSolomon;
@@ -803,6 +803,7 @@ impl Client {
         let block = Block::produce(
             this_epoch_protocol_version,
             next_epoch_protocol_version,
+            get_protocol_version(next_epoch_protocol_version, self.clock.clone()),
             prev_header,
             height,
             block_ordinal,

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -69,7 +69,7 @@ use near_primitives::types::{AccountId, BlockHeight};
 use near_primitives::unwrap_or_return;
 use near_primitives::utils::MaybeValidated;
 use near_primitives::validator_signer::ValidatorSigner;
-use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
+use near_primitives::version::{ProtocolFeature, PROTOCOL_UPGRADE_SCHEDULE, PROTOCOL_VERSION};
 use near_primitives::views::{DetailedDebugStatus, ValidatorInfo};
 #[cfg(feature = "test_features")]
 use near_store::DBCol;
@@ -166,6 +166,7 @@ pub fn start_client(
         resharding_sender,
         state_sync_future_spawner,
         chain_sender_for_state_sync.as_multi_sender(),
+        PROTOCOL_UPGRADE_SCHEDULE.clone(),
     )
     .unwrap();
     let resharding_handle = client.chain.resharding_manager.resharding_handle.clone();

--- a/chain/client/src/sync/header.rs
+++ b/chain/client/src/sync/header.rs
@@ -781,6 +781,7 @@ mod test {
             let block = Block::produce(
                 PROTOCOL_VERSION,
                 PROTOCOL_VERSION,
+                PROTOCOL_VERSION,
                 last_block.header(),
                 this_height,
                 last_block.header().block_ordinal() + 1,

--- a/chain/client/src/test_utils/client.rs
+++ b/chain/client/src/test_utils/client.rs
@@ -255,6 +255,7 @@ pub fn create_chunk(
     let block = Block::produce(
         PROTOCOL_VERSION,
         PROTOCOL_VERSION,
+        PROTOCOL_VERSION,
         last_block.header(),
         next_height,
         last_block.header().block_ordinal() + 1,

--- a/chain/client/src/test_utils/setup.rs
+++ b/chain/client/src/test_utils/setup.rs
@@ -63,7 +63,7 @@ use near_primitives::network::PeerId;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::{AccountId, BlockHeightDelta, EpochId, NumBlocks, NumSeats, ShardId};
 use near_primitives::validator_signer::{EmptyValidatorSigner, ValidatorSigner};
-use near_primitives::version::PROTOCOL_VERSION;
+use near_primitives::version::{PROTOCOL_UPGRADE_SCHEDULE, PROTOCOL_VERSION};
 use near_store::adapter::StoreAdapter;
 use near_store::test_utils::create_test_store;
 use near_telemetry::TelemetryActor;
@@ -1087,6 +1087,7 @@ pub fn setup_client_with_runtime(
         resharding_sender,
         Arc::new(ActixFutureSpawner),
         noop().into_multi_sender(), // state sync ignored for these tests
+        PROTOCOL_UPGRADE_SCHEDULE.clone(),
     )
     .unwrap();
     client.sync_status = SyncStatus::NoSync;

--- a/chain/client/src/tests/query_client.rs
+++ b/chain/client/src/tests/query_client.rs
@@ -76,6 +76,7 @@ fn query_status_not_crash() {
             let mut next_block = Block::produce(
                 PROTOCOL_VERSION,
                 PROTOCOL_VERSION,
+                PROTOCOL_VERSION,
                 &header,
                 block.header.height + 1,
                 header.block_ordinal() + 1,

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -49,6 +49,7 @@ pub fn make_block(
     Block::produce(
         version::PROTOCOL_VERSION,
         version::PROTOCOL_VERSION,
+        version::PROTOCOL_VERSION,
         prev.header(),
         prev.header().height() + 5,
         prev.header().block_ordinal() + 1,

--- a/core/primitives/benches/serialization.rs
+++ b/core/primitives/benches/serialization.rs
@@ -61,6 +61,7 @@ fn create_block() -> Block {
     Block::produce(
         PROTOCOL_VERSION,
         PROTOCOL_VERSION,
+        PROTOCOL_VERSION,
         genesis.header(),
         10,
         genesis.header().block_ordinal() + 1,

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -284,6 +284,7 @@ impl Block {
     pub fn produce(
         this_epoch_protocol_version: ProtocolVersion,
         next_epoch_protocol_version: ProtocolVersion,
+        latest_protocol_version: ProtocolVersion,
         prev: &BlockHeader,
         height: BlockHeight,
         block_ordinal: crate::types::NumBlocks,
@@ -403,6 +404,7 @@ impl Block {
         let header = BlockHeader::new(
             this_epoch_protocol_version,
             next_epoch_protocol_version,
+            latest_protocol_version,
             height,
             *prev.hash(),
             body.compute_hash(),
@@ -430,7 +432,6 @@ impl Block {
             next_bp_hash,
             block_merkle_root,
             prev.height(),
-            clock,
             chunk_endorsements_bitmap,
         );
 

--- a/core/primitives/src/block_header.rs
+++ b/core/primitives/src/block_header.rs
@@ -572,10 +572,10 @@ impl BlockHeader {
     }
 
     /// Creates BlockHeader for a newly produced block.
-    #[cfg(feature = "clock")]
     pub fn new(
         this_epoch_protocol_version: ProtocolVersion,
         next_epoch_protocol_version: ProtocolVersion,
+        latest_protocol_version: ProtocolVersion,
         height: BlockHeight,
         prev_hash: CryptoHash,
         block_body_hash: CryptoHash,
@@ -603,11 +603,8 @@ impl BlockHeader {
         next_bp_hash: CryptoHash,
         block_merkle_root: CryptoHash,
         prev_height: BlockHeight,
-        clock: near_time::Clock,
         chunk_endorsements: Option<ChunkEndorsementsBitmap>,
     ) -> Self {
-        let latest_protocol_version =
-            crate::version::get_protocol_version(next_epoch_protocol_version, clock);
         Self::new_impl(
             this_epoch_protocol_version,
             next_epoch_protocol_version,

--- a/core/primitives/src/lib.rs
+++ b/core/primitives/src/lib.rs
@@ -43,7 +43,7 @@ pub mod test_utils;
 pub mod transaction;
 pub mod trie_key;
 pub mod types;
-mod upgrade_schedule;
+pub mod upgrade_schedule;
 pub mod utils;
 pub mod validator_mandates;
 pub mod validator_signer;

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -845,6 +845,7 @@ impl TestBlockBuilder {
         Block::produce(
             PROTOCOL_VERSION,
             PROTOCOL_VERSION,
+            PROTOCOL_VERSION,
             self.prev.header(),
             self.height,
             self.prev.header().block_ordinal() + 1,

--- a/core/primitives/src/upgrade_schedule.rs
+++ b/core/primitives/src/upgrade_schedule.rs
@@ -99,9 +99,10 @@ impl ProtocolUpgradeVotingSchedule {
         Ok(Self { client_protocol_version, schedule })
     }
 
-    /// This method returns the protocol version that the node should vote for.
+    /// This method returns the protocol version that the node should vote for
+    /// at the given date and time.
     #[cfg(feature = "clock")]
-    pub(crate) fn get_protocol_version(
+    pub(crate) fn protocol_version_to_vote_for_at_date(
         &self,
         now: DateTime<Utc>,
         // Protocol version that will be used in the next epoch.
@@ -134,17 +135,22 @@ impl ProtocolUpgradeVotingSchedule {
         result
     }
 
-    /// This method returns the protocol version that the node should vote for now.
-    /// The current time is obtained from the provided clock.
+    /// This method returns the protocol version that the node should vote for
+    /// at the given time (taken from Clock::now_utc)
     #[cfg(feature = "clock")]
-    pub fn get_protocol_version_to_vote_for_now(
+    pub fn protocol_version_to_vote_for(
         &self,
-        clock: &near_time::Clock,
+        current_time: near_time::Utc,
         next_epoch_protocol_version: ProtocolVersion,
     ) -> ProtocolVersion {
-        let now = clock.now_utc();
-        let date_time = chrono::DateTime::from_timestamp(now.unix_timestamp(), now.nanosecond());
-        self.get_protocol_version(date_time.unwrap_or_default(), next_epoch_protocol_version)
+        let date_time = chrono::DateTime::from_timestamp(
+            current_time.unix_timestamp(),
+            current_time.nanosecond(),
+        );
+        self.protocol_version_to_vote_for_at_date(
+            date_time.unwrap_or_default(),
+            next_epoch_protocol_version,
+        )
     }
 
     /// Returns the schedule. Should only be used for exporting metrics.
@@ -252,15 +258,15 @@ mod tests {
 
         assert_eq!(
             client_protocol_version,
-            schedule.get_protocol_version(now, client_protocol_version - 2)
+            schedule.protocol_version_to_vote_for_at_date(now, client_protocol_version - 2)
         );
         assert_eq!(
             client_protocol_version,
-            schedule.get_protocol_version(now, client_protocol_version)
+            schedule.protocol_version_to_vote_for_at_date(now, client_protocol_version)
         );
         assert_eq!(
             client_protocol_version,
-            schedule.get_protocol_version(now, client_protocol_version + 2)
+            schedule.protocol_version_to_vote_for_at_date(now, client_protocol_version + 2)
         );
     }
 
@@ -276,21 +282,21 @@ mod tests {
         let next_epoch_protocol_version = client_protocol_version - 2;
         assert_eq!(
             next_epoch_protocol_version,
-            schedule.get_protocol_version(now, next_epoch_protocol_version)
+            schedule.protocol_version_to_vote_for_at_date(now, next_epoch_protocol_version)
         );
 
         // An upgrade happened before the scheduled time.
         let next_epoch_protocol_version = client_protocol_version;
         assert_eq!(
             next_epoch_protocol_version,
-            schedule.get_protocol_version(now, next_epoch_protocol_version)
+            schedule.protocol_version_to_vote_for_at_date(now, next_epoch_protocol_version)
         );
 
         // Several upgrades happened before the scheduled time. Announce only the currently supported protocol version.
         let next_epoch_protocol_version = client_protocol_version + 2;
         assert_eq!(
             client_protocol_version,
-            schedule.get_protocol_version(now, next_epoch_protocol_version)
+            schedule.protocol_version_to_vote_for_at_date(now, next_epoch_protocol_version)
         );
     }
 
@@ -304,15 +310,15 @@ mod tests {
         // Regardless of the protocol version of the next epoch, return the version supported by the client.
         assert_eq!(
             client_protocol_version,
-            schedule.get_protocol_version(now, client_protocol_version - 2)
+            schedule.protocol_version_to_vote_for_at_date(now, client_protocol_version - 2)
         );
         assert_eq!(
             client_protocol_version,
-            schedule.get_protocol_version(now, client_protocol_version)
+            schedule.protocol_version_to_vote_for_at_date(now, client_protocol_version)
         );
         assert_eq!(
             client_protocol_version,
-            schedule.get_protocol_version(now, client_protocol_version + 2)
+            schedule.protocol_version_to_vote_for_at_date(now, client_protocol_version + 2)
         );
     }
 
@@ -331,31 +337,31 @@ mod tests {
         let now = ProtocolUpgradeVotingSchedule::parse_datetime("2000-01-05 00:00:00").unwrap();
         assert_eq!(
             current_protocol_version,
-            schedule.get_protocol_version(now, current_protocol_version)
+            schedule.protocol_version_to_vote_for_at_date(now, current_protocol_version)
         );
 
         // Test the first upgrade.
         let now = ProtocolUpgradeVotingSchedule::parse_datetime("2000-01-10 00:00:00").unwrap();
         assert_eq!(
             current_protocol_version + 1,
-            schedule.get_protocol_version(now, current_protocol_version)
+            schedule.protocol_version_to_vote_for_at_date(now, current_protocol_version)
         );
         let now = ProtocolUpgradeVotingSchedule::parse_datetime("2000-01-12 00:00:00").unwrap();
         assert_eq!(
             current_protocol_version + 1,
-            schedule.get_protocol_version(now, current_protocol_version)
+            schedule.protocol_version_to_vote_for_at_date(now, current_protocol_version)
         );
 
         // Test the final upgrade.
         let now = ProtocolUpgradeVotingSchedule::parse_datetime("2000-01-15 00:00:00").unwrap();
         assert_eq!(
             current_protocol_version + 2,
-            schedule.get_protocol_version(now, current_protocol_version + 1)
+            schedule.protocol_version_to_vote_for_at_date(now, current_protocol_version + 1)
         );
         let now = ProtocolUpgradeVotingSchedule::parse_datetime("2000-01-20 00:00:00").unwrap();
         assert_eq!(
             current_protocol_version + 2,
-            schedule.get_protocol_version(now, current_protocol_version + 1)
+            schedule.protocol_version_to_vote_for_at_date(now, current_protocol_version + 1)
         );
     }
 
@@ -375,7 +381,7 @@ mod tests {
         let now = ProtocolUpgradeVotingSchedule::parse_datetime("2000-01-05 00:00:00").unwrap();
         assert_eq!(
             current_protocol_version,
-            schedule.get_protocol_version(now, current_protocol_version)
+            schedule.protocol_version_to_vote_for_at_date(now, current_protocol_version)
         );
 
         // Upgrades are scheduled very close to each other, but they should be voted on at a time.
@@ -383,21 +389,21 @@ mod tests {
         let now = ProtocolUpgradeVotingSchedule::parse_datetime("2000-01-10 10:00:00").unwrap();
         assert_eq!(
             current_protocol_version + 1,
-            schedule.get_protocol_version(now, current_protocol_version)
+            schedule.protocol_version_to_vote_for_at_date(now, current_protocol_version)
         );
 
         // Test the second upgrade.
         let now = ProtocolUpgradeVotingSchedule::parse_datetime("2000-01-10 10:00:00").unwrap();
         assert_eq!(
             current_protocol_version + 2,
-            schedule.get_protocol_version(now, current_protocol_version + 1)
+            schedule.protocol_version_to_vote_for_at_date(now, current_protocol_version + 1)
         );
 
         // Test the final upgrade.
         let now = ProtocolUpgradeVotingSchedule::parse_datetime("2000-01-10 10:00:00").unwrap();
         assert_eq!(
             current_protocol_version + 3,
-            schedule.get_protocol_version(now, current_protocol_version + 2)
+            schedule.protocol_version_to_vote_for_at_date(now, current_protocol_version + 2)
         );
     }
 

--- a/core/primitives/src/upgrade_schedule.rs
+++ b/core/primitives/src/upgrade_schedule.rs
@@ -134,6 +134,19 @@ impl ProtocolUpgradeVotingSchedule {
         result
     }
 
+    /// This method returns the protocol version that the node should vote for now.
+    /// The current time is obtained from the provided clock.
+    #[cfg(feature = "clock")]
+    pub fn get_protocol_version_to_vote_for_now(
+        &self,
+        clock: &near_time::Clock,
+        next_epoch_protocol_version: ProtocolVersion,
+    ) -> ProtocolVersion {
+        let now = clock.now_utc();
+        let date_time = chrono::DateTime::from_timestamp(now.unix_timestamp(), now.nanosecond());
+        self.get_protocol_version(date_time.unwrap_or_default(), next_epoch_protocol_version)
+    }
+
     /// Returns the schedule. Should only be used for exporting metrics.
     pub fn schedule(&self) -> &Vec<(chrono::DateTime<Utc>, ProtocolVersion)> {
         &self.schedule

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -84,17 +84,3 @@ pub const PROTOCOL_UPGRADE_SCHEDULE: LazyLock<ProtocolUpgradeVotingSchedule> =
 
         ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(PROTOCOL_VERSION, vec![]).unwrap()
     });
-
-/// Gives new clients an option to upgrade without announcing that they support
-/// the new version.  This gives non-validator nodes time to upgrade.  See
-/// <https://github.com/near/NEPs/issues/205>
-#[cfg(feature = "clock")]
-pub fn get_protocol_version(
-    next_epoch_protocol_version: ProtocolVersion,
-    clock: near_time::Clock,
-) -> ProtocolVersion {
-    let now = clock.now_utc();
-    let chrono = chrono::DateTime::from_timestamp(now.unix_timestamp(), now.nanosecond());
-    PROTOCOL_UPGRADE_SCHEDULE
-        .get_protocol_version(chrono.unwrap_or_default(), next_epoch_protocol_version)
-}

--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -30,6 +30,7 @@ use near_primitives::network::PeerId;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::{AccountId, ShardId};
+use near_primitives::upgrade_schedule::ProtocolUpgradeVotingSchedule;
 use near_primitives::version::PROTOCOL_UPGRADE_SCHEDULE;
 use near_store::adapter::StoreAdapter;
 use near_store::config::StateSnapshotType;
@@ -94,6 +95,8 @@ pub(crate) struct TestLoopBuilder {
     track_all_shards: bool,
     /// Whether to load mem tries for the tracked shards.
     load_mem_tries_for_tracked_shards: bool,
+    /// Upgrade schedule which determines when the clients start voting for new protocol versions.
+    upgrade_schedule: ProtocolUpgradeVotingSchedule,
 }
 
 /// Checks whether chunk is validated by the given account.
@@ -293,6 +296,7 @@ impl TestLoopBuilder {
             warmup: true,
             track_all_shards: false,
             load_mem_tries_for_tracked_shards: true,
+            upgrade_schedule: PROTOCOL_UPGRADE_SCHEDULE.clone(),
         }
     }
 
@@ -418,6 +422,11 @@ impl TestLoopBuilder {
     /// of creating a new one.
     pub fn test_loop_data_dir(mut self, dir: TempDir) -> Self {
         self.test_loop_data_dir = Some(dir);
+        self
+    }
+
+    pub fn protocol_upgrade_schedule(mut self, schedule: ProtocolUpgradeVotingSchedule) -> Self {
+        self.upgrade_schedule = schedule;
         self
     }
 
@@ -624,7 +633,7 @@ impl TestLoopBuilder {
             resharding_sender.as_multi_sender(),
             Arc::new(self.test_loop.future_spawner()),
             client_adapter.as_multi_sender(),
-            PROTOCOL_UPGRADE_SCHEDULE.clone(),
+            self.upgrade_schedule.clone(),
         )
         .unwrap();
 

--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -30,6 +30,7 @@ use near_primitives::network::PeerId;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::{AccountId, ShardId};
+use near_primitives::version::PROTOCOL_UPGRADE_SCHEDULE;
 use near_store::adapter::StoreAdapter;
 use near_store::config::StateSnapshotType;
 use near_store::genesis::initialize_genesis_state;
@@ -623,6 +624,7 @@ impl TestLoopBuilder {
             resharding_sender.as_multi_sender(),
             Arc::new(self.test_loop.future_spawner()),
             client_adapter.as_multi_sender(),
+            PROTOCOL_UPGRADE_SCHEDULE.clone(),
         )
         .unwrap();
 

--- a/integration-tests/src/test_loop/tests/protocol_upgrade.rs
+++ b/integration-tests/src/test_loop/tests/protocol_upgrade.rs
@@ -7,6 +7,7 @@ use near_o11y::testonly::init_test_logger;
 use near_primitives::epoch_manager::{EpochConfig, EpochConfigStore};
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::{AccountId, BlockHeight, ShardId, ShardIndex};
+use near_primitives::upgrade_schedule::ProtocolUpgradeVotingSchedule;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_store::ShardUId;
 use near_vm_runner::logic::ProtocolVersion;
@@ -103,6 +104,9 @@ pub(crate) fn test_protocol_upgrade(
         (new_protocol, Arc::new(new_epoch_config)),
     ]));
 
+    // Immediately start voting for the new protocol version
+    let protocol_upgrade_schedule = ProtocolUpgradeVotingSchedule::new_immediate(new_protocol);
+
     // Translate shard ids to shard uids
     let chunk_ranges_to_drop: HashMap<ShardUId, std::ops::Range<i64>> = missing_chunk_ranges
         .iter()
@@ -116,6 +120,7 @@ pub(crate) fn test_protocol_upgrade(
     let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } = builder
         .genesis(genesis)
         .epoch_config_store(epoch_config_store)
+        .protocol_upgrade_schedule(protocol_upgrade_schedule)
         .drop_protocol_upgrade_chunks(new_protocol, chunk_ranges_to_drop)
         .clients(clients)
         .build();
@@ -221,4 +226,12 @@ fn slow_test_protocol_upgrade_with_missing_chunks_two() {
         PROTOCOL_VERSION,
         HashMap::from_iter([(0, 0..0), (1, -2..0), (2, 0..2), (3, -2..2)].into_iter()),
     );
+}
+
+/// Test protocol upgrade to a version that isn't the latest version.
+/// There was a bug which caused `test_protocol_upgrade` to always upgrade to `PROTOCOL_VERSION`,
+/// this test ensures that the bug is fixed and it upgrades to the desired version, not the latest one.
+#[test]
+fn slow_test_protocol_upgrade_not_latest() {
+    test_protocol_upgrade(PROTOCOL_VERSION - 2, PROTOCOL_VERSION - 1, HashMap::new());
 }

--- a/integration-tests/src/test_loop/tests/simple_test_loop_example.rs
+++ b/integration-tests/src/test_loop/tests/simple_test_loop_example.rs
@@ -16,6 +16,7 @@ use near_primitives::network::PeerId;
 
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::AccountId;
+use near_primitives::version::PROTOCOL_UPGRADE_SCHEDULE;
 use near_store::adapter::StoreAdapter;
 
 use crate::test_loop::utils::ONE_NEAR;
@@ -101,6 +102,7 @@ fn test_client_with_simple_test_loop() {
         noop().into_multi_sender(),
         Arc::new(test_loop.future_spawner()),
         noop().into_multi_sender(),
+        PROTOCOL_UPGRADE_SCHEDULE.clone(),
     )
     .unwrap();
 

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -97,6 +97,7 @@ fn test_verify_block_double_sign_challenge() {
     let b2 = Block::produce(
         PROTOCOL_VERSION,
         PROTOCOL_VERSION,
+        PROTOCOL_VERSION,
         genesis.header(),
         2,
         genesis.header().block_ordinal() + 1,
@@ -423,6 +424,7 @@ fn test_verify_chunk_invalid_state_challenge() {
     let endorsement =
         ChunkEndorsement::new(EpochId::default(), &invalid_chunk.cloned_header(), signer.as_ref());
     let block = Block::produce(
+        PROTOCOL_VERSION,
         PROTOCOL_VERSION,
         PROTOCOL_VERSION,
         last_block.header(),

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -327,6 +327,7 @@ fn receive_network_block() {
             let block = Block::produce(
                 PROTOCOL_VERSION,
                 PROTOCOL_VERSION,
+                PROTOCOL_VERSION,
                 &last_block.header.clone().into(),
                 last_block.header.height + 1,
                 next_block_ordinal,
@@ -412,6 +413,7 @@ fn produce_block_with_approvals() {
             let chunks = last_block.chunks.into_iter().map(Into::into).collect_vec();
             let chunk_endorsements = vec![vec![]; chunks.len()];
             let block = Block::produce(
+                PROTOCOL_VERSION,
                 PROTOCOL_VERSION,
                 PROTOCOL_VERSION,
                 &last_block.header.clone().into(),
@@ -627,6 +629,7 @@ fn invalid_blocks_common(is_requested: bool) {
             let signer = create_test_signer("test");
             let next_block_ordinal = last_block.header.block_ordinal.unwrap() + 1;
             let valid_block = Block::produce(
+                PROTOCOL_VERSION,
                 PROTOCOL_VERSION,
                 PROTOCOL_VERSION,
                 &last_block.header.clone().into(),


### PR DESCRIPTION
`test_protocol_upgrade` (added in https://github.com/near/nearcore/pull/12253) is supposed to upgrade from `old_protocol` to `new_protocol`, but it actually did an upgrade from `old_protocol` to `PROTOCOL_VERSION` (latest protocol). It just so happened that all uses of the test were with `new_protocol` equal to `PROTOCOL_VERSION` and the bug wasn't noticed when the test was written.

I did some debugging and it looks like the problem is that clients are voting for the latest protocol instead of the one specified in `new_protocol`, and switch to the latest one instead of the one that they were supposed to.

The protocol version that nodes vote for is controlled by `PROTOCOL_UPGRADE_SCHEDULE`, which is a global constant. It being a global constant makes it awkward to overwrite in tests.

I dealt with the problem by adding an `upgrade_schedule` configuration parameter to `Client`, which allows to set the voting schedule that this individual client will use. With this in place, we can override the voting schedule for clients in `test_protocol_upgrade` and upgrade to the correct protocol version.

PR is meant to be reviewed commit-by-commit, I added some more comments in commit descriptions.