### PR TITLE
Move balance check into debug assertion

### DIFF
--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -2084,16 +2084,20 @@ impl Runtime {
 
         let bandwidth_requests = receipt_sink.generate_bandwidth_requests(&state_update, true)?;
 
-        check_balance(
-            &apply_state.config,
-            &state_update,
-            validator_accounts_update,
-            processing_state.incoming_receipts,
-            &promise_yield_result.timeout_receipts,
-            processing_state.transactions,
-            &receipt_sink.outgoing_receipts(),
-            &processing_state.stats,
-        )?;
+        debug_assert_eq!(
+            check_balance(
+                &apply_state.config,
+                &state_update,
+                validator_accounts_update,
+                processing_state.incoming_receipts,
+                &promise_yield_result.timeout_receipts,
+                processing_state.transactions,
+                &receipt_sink.outgoing_receipts(),
+                &processing_state.stats,
+            ),
+            Ok(()),
+            "balance check failed"
+        );
 
         state_update.commit(StateChangeCause::UpdatedDelayedReceipts);
         self.apply_state_patch(&mut state_update, state_patch);

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -2096,8 +2096,12 @@ impl Runtime {
                 &processing_state.stats,
             ) {
                 panic!(
-                    "Balance check failed for shard {} at height {} with block hash {}: {}",
-                    apply_state.shard_id, apply_state.block_height, apply_state.block_hash, err
+                    "The runtime's balance_checker failed for shard {} at height {} with block hash {} and protocol version {}: {}",
+                    apply_state.shard_id,
+                    apply_state.block_height,
+                    apply_state.block_hash,
+                    apply_state.current_protocol_version,
+                    err
                 );
             }
         }


### PR DESCRIPTION
It was decided offline that `check_balance` should not be called in release builds anymore. This PR implements this change by gating `check_balance(...)` behind `cfg!(debug_assertions)`.