### PR TITLE
fix(epoch config): Refactor validator assignment config

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -1199,14 +1199,11 @@ impl RuntimeAdapter for NightshadeRuntime {
         genesis_config.protocol_upgrade_stake_threshold =
             epoch_config.protocol_upgrade_stake_threshold;
         genesis_config.shard_layout = epoch_config.shard_layout;
-        genesis_config.num_chunk_only_producer_seats =
-            epoch_config.validator_selection_config.num_chunk_only_producer_seats;
-        genesis_config.minimum_validators_per_shard =
-            epoch_config.validator_selection_config.minimum_validators_per_shard;
-        genesis_config.minimum_stake_ratio =
-            epoch_config.validator_selection_config.minimum_stake_ratio;
+        genesis_config.num_chunk_only_producer_seats = epoch_config.num_chunk_only_producer_seats;
+        genesis_config.minimum_validators_per_shard = epoch_config.minimum_validators_per_shard;
+        genesis_config.minimum_stake_ratio = epoch_config.minimum_stake_ratio;
         genesis_config.shuffle_shard_assignment_for_chunk_producers =
-            epoch_config.validator_selection_config.shuffle_shard_assignment_for_chunk_producers;
+            epoch_config.shuffle_shard_assignment_for_chunk_producers;
 
         let runtime_config =
             self.runtime_config_store.get_config(protocol_version).as_ref().clone();

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -23,7 +23,6 @@ use near_primitives::epoch_block_info::BlockInfo;
 use near_primitives::epoch_info::EpochInfo;
 use near_primitives::epoch_manager::EpochConfig;
 use near_primitives::epoch_manager::ShardConfig;
-use near_primitives::epoch_manager::ValidatorSelectionConfig;
 use near_primitives::errors::{EpochError, InvalidTxError};
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::receipt::{ActionReceipt, Receipt, ReceiptEnum, ReceiptV0};
@@ -55,7 +54,6 @@ use near_store::{
     TrieChanges, WrappedTrieChanges,
 };
 use near_vm_runner::{ContractCode, ContractRuntimeCache, NoContractRuntimeCache};
-use num_rational::Ratio;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, RwLock};
@@ -496,24 +494,7 @@ impl EpochManagerAdapter for MockEpochManager {
     }
 
     fn get_epoch_config(&self, epoch_id: &EpochId) -> Result<EpochConfig, EpochError> {
-        Ok(EpochConfig {
-            epoch_length: self.epoch_length,
-            num_block_producer_seats: 2,
-            num_block_producer_seats_per_shard: vec![1, 1],
-            avg_hidden_validator_seats_per_shard: vec![1, 1],
-            block_producer_kickout_threshold: 0,
-            chunk_producer_kickout_threshold: 0,
-            chunk_validator_only_kickout_threshold: 0,
-            target_validator_mandates_per_shard: 1,
-            validator_max_kickout_stake_perc: 0,
-            online_min_threshold: Ratio::new(1i32, 4i32),
-            online_max_threshold: Ratio::new(3i32, 4i32),
-            fishermen_threshold: 1,
-            minimum_stake_divisor: 1,
-            protocol_upgrade_stake_threshold: Ratio::new(3i32, 4i32),
-            shard_layout: self.get_shard_layout(epoch_id).unwrap(),
-            validator_selection_config: ValidatorSelectionConfig::default(),
-        })
+        Ok(EpochConfig::mock(self.epoch_length, self.get_shard_layout(epoch_id).unwrap()))
     }
 
     /// Return the epoch info containing the mocked data.

--- a/chain/epoch-manager/src/shard_tracker.rs
+++ b/chain/epoch-manager/src/shard_tracker.rs
@@ -252,7 +252,13 @@ mod tests {
             minimum_stake_divisor: 1,
             protocol_upgrade_stake_threshold: Ratio::new(80, 100),
             shard_layout: ShardLayout::multi_shard(num_shards, 0),
-            validator_selection_config: Default::default(),
+            num_chunk_producer_seats: 100,
+            num_chunk_validator_seats: 300,
+            num_chunk_only_producer_seats: 300,
+            minimum_validators_per_shard: 1,
+            minimum_stake_ratio: Ratio::new(160i32, 1_000_000i32),
+            chunk_producer_assignment_changes_limit: 5,
+            shuffle_shard_assignment_for_chunk_producers: false,
             validator_max_kickout_stake_perc: 100,
         };
         let reward_calculator = RewardCalculator {

--- a/chain/epoch-manager/src/test_utils.rs
+++ b/chain/epoch-manager/src/test_utils.rs
@@ -13,7 +13,7 @@ use near_crypto::{KeyType, SecretKey};
 use near_primitives::challenge::SlashedValidator;
 use near_primitives::epoch_block_info::BlockInfoV2;
 use near_primitives::epoch_info::EpochInfo;
-use near_primitives::epoch_manager::{AllEpochConfig, EpochConfig, ValidatorSelectionConfig};
+use near_primitives::epoch_manager::{AllEpochConfig, EpochConfig};
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
@@ -151,10 +151,13 @@ pub fn epoch_config_with_production_config(
         online_max_threshold: Ratio::new(99, 100),
         protocol_upgrade_stake_threshold: Ratio::new(80, 100),
         minimum_stake_divisor: 1,
-        validator_selection_config: ValidatorSelectionConfig {
-            num_chunk_producer_seats,
-            ..Default::default()
-        },
+        num_chunk_producer_seats,
+        num_chunk_validator_seats: 300,
+        num_chunk_only_producer_seats: 300,
+        minimum_validators_per_shard: 1,
+        minimum_stake_ratio: Ratio::new(160i32, 1_000_000i32),
+        chunk_producer_assignment_changes_limit: 5,
+        shuffle_shard_assignment_for_chunk_producers: false,
         shard_layout: ShardLayout::multi_shard(num_shards, 0),
         validator_max_kickout_stake_perc: 100,
     };

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -2336,7 +2336,13 @@ fn test_protocol_version_switch_with_many_seats() {
         protocol_upgrade_stake_threshold: Ratio::new(80, 100),
         minimum_stake_divisor: 1,
         shard_layout: ShardLayout::single_shard(),
-        validator_selection_config: Default::default(),
+        num_chunk_producer_seats: 100,
+        num_chunk_validator_seats: 300,
+        num_chunk_only_producer_seats: 300,
+        minimum_validators_per_shard: 1,
+        minimum_stake_ratio: Ratio::new(160i32, 1_000_000i32),
+        chunk_producer_assignment_changes_limit: 5,
+        shuffle_shard_assignment_for_chunk_producers: false,
         validator_max_kickout_stake_perc: 100,
     };
     let config = AllEpochConfig::new(false, PROTOCOL_VERSION, epoch_config, "test-chain");

--- a/chain/epoch-manager/src/validator_selection.rs
+++ b/chain/epoch-manager/src/validator_selection.rs
@@ -5,7 +5,7 @@ use near_primitives::epoch_manager::EpochConfig;
 use near_primitives::errors::EpochError;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
-    AccountId, Balance, NumShards, ProtocolVersion, ValidatorId, ValidatorKickoutReason,
+    AccountId, Balance, NumSeats, NumShards, ProtocolVersion, ValidatorId, ValidatorKickoutReason,
 };
 use near_primitives::validator_mandates::{ValidatorMandates, ValidatorMandatesConfig};
 use near_primitives::version::ProtocolFeature;
@@ -50,14 +50,14 @@ fn select_validators_from_proposals(
 ) -> ValidatorRoles {
     let shard_ids: Vec<_> = epoch_config.shard_layout.shard_ids().collect();
     let min_stake_ratio = {
-        let rational = epoch_config.validator_selection_config.minimum_stake_ratio;
+        let rational = epoch_config.minimum_stake_ratio;
         Ratio::new(*rational.numer() as u128, *rational.denom() as u128)
     };
 
     let chunk_producer_proposals = order_proposals(proposals.values().cloned());
     let (chunk_producers, _, cp_stake_threshold) = select_chunk_producers(
         chunk_producer_proposals,
-        epoch_config.validator_selection_config.num_chunk_producer_seats as usize,
+        epoch_config.num_chunk_producer_seats as usize,
         min_stake_ratio,
         shard_ids.len() as NumShards,
         protocol_version,
@@ -74,7 +74,7 @@ fn select_validators_from_proposals(
     let chunk_validator_proposals = order_proposals(proposals.values().cloned());
     let (chunk_validators, _, cv_stake_threshold) = select_validators(
         chunk_validator_proposals,
-        epoch_config.validator_selection_config.num_chunk_validator_seats as usize,
+        epoch_config.num_chunk_validator_seats as usize,
         min_stake_ratio,
         protocol_version,
     );
@@ -135,8 +135,7 @@ fn get_chunk_producers_assignment(
 
     // Assign chunk producers to shards.
     let num_chunk_producers = chunk_producers.len();
-    let minimum_validators_per_shard =
-        epoch_config.validator_selection_config.minimum_validators_per_shard as usize;
+    let minimum_validators_per_shard = epoch_config.minimum_validators_per_shard as usize;
     let prev_chunk_producers_assignment = if use_stable_shard_assignment {
         let mut assignment = vec![];
         for validator_ids in prev_epoch_info.chunk_producers_settlement().iter() {
@@ -156,7 +155,7 @@ fn get_chunk_producers_assignment(
         chunk_producers.clone(),
         shard_ids.len() as NumShards,
         minimum_validators_per_shard,
-        epoch_config.validator_selection_config.chunk_producer_assignment_changes_limit as usize,
+        epoch_config.chunk_producer_assignment_changes_limit as usize,
         rng_seed,
         prev_chunk_producers_assignment,
     )
@@ -262,7 +261,7 @@ pub fn proposals_to_epoch_info(
         )?
     };
 
-    if epoch_config.validator_selection_config.shuffle_shard_assignment_for_chunk_producers {
+    if epoch_config.shuffle_shard_assignment_for_chunk_producers {
         chunk_producers_settlement.shuffle(&mut EpochInfo::shard_assignment_rng(&rng_seed));
     }
 
@@ -462,7 +461,7 @@ mod old_validator_selection {
     ) -> ValidatorRoles {
         let max_bp_selected = epoch_config.num_block_producer_seats as usize;
         let min_stake_ratio = {
-            let rational = epoch_config.validator_selection_config.minimum_stake_ratio;
+            let rational = epoch_config.minimum_stake_ratio;
             Ratio::new(*rational.numer() as u128, *rational.denom() as u128)
         };
 
@@ -476,9 +475,8 @@ mod old_validator_selection {
         let (chunk_producer_proposals, chunk_producers, cp_stake_threshold) =
             if checked_feature!("stable", ChunkOnlyProducers, protocol_version) {
                 let chunk_producer_proposals = order_proposals(proposals.into_values());
-                let max_cp_selected = max_bp_selected
-                    + (epoch_config.validator_selection_config.num_chunk_only_producer_seats
-                        as usize);
+                let max_cp_selected =
+                    max_bp_selected + (epoch_config.num_chunk_only_producer_seats as usize);
                 let num_shards = epoch_config.shard_layout.shard_ids().count() as NumShards;
                 let (chunk_producers, not_chunk_producers, cp_stake_threshold) =
                     select_chunk_producers(
@@ -523,8 +521,7 @@ mod old_validator_selection {
         }
 
         let shard_ids: Vec<_> = epoch_config.shard_layout.shard_ids().collect();
-        let minimum_validators_per_shard =
-            epoch_config.validator_selection_config.minimum_validators_per_shard as usize;
+        let minimum_validators_per_shard = epoch_config.minimum_validators_per_shard as usize;
         let shard_assignment = shard_assignment::old_validator_selection::assign_shards(
             chunk_producers,
             shard_ids.len() as NumShards,
@@ -627,9 +624,9 @@ mod tests {
     use near_crypto::{KeyType, PublicKey};
     use near_primitives::account::id::AccountIdRef;
     use near_primitives::epoch_info::{EpochInfo, EpochInfoV3};
-    use near_primitives::epoch_manager::ValidatorSelectionConfig;
     use near_primitives::shard_layout::ShardLayout;
     use near_primitives::types::validator_stake::ValidatorStake;
+    use near_primitives::types::NumSeats;
     use near_primitives::version::PROTOCOL_VERSION;
     use num_rational::Ratio;
 
@@ -638,7 +635,7 @@ mod tests {
         // A simple sanity test. Given fewer proposals than the number of seats,
         // none of which has too little stake, they all get assigned as block and
         // chunk producers.
-        let epoch_config = create_epoch_config(2, 100, Default::default());
+        let epoch_config = create_epoch_config(2, 100, None, None, None, None);
         let prev_epoch_height = 7;
         let prev_epoch_info = create_prev_epoch_info(prev_epoch_height, &["test1", "test2"], &[]);
         let proposals = create_proposals(&[("test1", 1000), ("test2", 2000), ("test3", 300)]);
@@ -687,12 +684,10 @@ mod tests {
         let epoch_config = create_epoch_config(
             2,
             num_bp_seats,
-            ValidatorSelectionConfig {
-                num_chunk_producer_seats: num_bp_seats + num_cp_seats,
-                num_chunk_validator_seats: num_bp_seats + num_cp_seats,
-                num_chunk_only_producer_seats: num_cp_seats,
-                ..Default::default()
-            },
+            Some(num_bp_seats + num_cp_seats),
+            Some(num_bp_seats + num_cp_seats),
+            Some(num_cp_seats),
+            None,
         );
         let prev_epoch_height = 3;
         let test1_stake = 1000;
@@ -783,12 +778,10 @@ mod tests {
         let mut epoch_config = create_epoch_config(
             6,
             num_bp_seats,
-            ValidatorSelectionConfig {
-                num_chunk_producer_seats: num_bp_seats + num_cp_seats,
-                num_chunk_validator_seats: num_bp_seats + num_cp_seats,
-                num_chunk_only_producer_seats: num_cp_seats,
-                ..Default::default()
-            },
+            Some(num_bp_seats + num_cp_seats),
+            Some(num_bp_seats + num_cp_seats),
+            Some(num_cp_seats),
+            None,
         );
         let prev_epoch_height = 3;
         let prev_epoch_info = create_prev_epoch_info::<&str>(prev_epoch_height, &[], &[]);
@@ -828,7 +821,7 @@ mod tests {
         )
         .unwrap();
 
-        epoch_config.validator_selection_config.shuffle_shard_assignment_for_chunk_producers = true;
+        epoch_config.shuffle_shard_assignment_for_chunk_producers = true;
         let epoch_info_with_shuffling = proposals_to_epoch_info(
             &epoch_config,
             [1; 32],
@@ -888,16 +881,7 @@ mod tests {
     #[test]
     fn test_block_producer_sampling() {
         let num_shards = 4;
-        let epoch_config = create_epoch_config(
-            num_shards,
-            2,
-            ValidatorSelectionConfig {
-                num_chunk_producer_seats: 2,
-                num_chunk_validator_seats: 2,
-                num_chunk_only_producer_seats: 0,
-                ..Default::default()
-            },
-        );
+        let epoch_config = create_epoch_config(num_shards, 2, Some(2), Some(2), Some(0), None);
         let prev_epoch_height = 7;
         let prev_epoch_info = create_prev_epoch_info(prev_epoch_height, &["test1", "test2"], &[]);
         let proposals = create_proposals(&[("test1", 1000), ("test2", 2000)]);
@@ -932,12 +916,10 @@ mod tests {
         let epoch_config = create_epoch_config(
             num_shards,
             2 * num_shards,
-            ValidatorSelectionConfig {
-                num_chunk_producer_seats: 2 * num_shards,
-                num_chunk_validator_seats: 2 * num_shards,
-                num_chunk_only_producer_seats: 0,
-                ..Default::default()
-            },
+            Some(2 * num_shards),
+            Some(2 * num_shards),
+            Some(0),
+            None,
         );
         let prev_epoch_height = 7;
         let prev_epoch_info = create_prev_epoch_info(prev_epoch_height, &["test1", "test2"], &[]);
@@ -1007,14 +989,10 @@ mod tests {
         let epoch_config = create_epoch_config(
             num_shards,
             2 * num_shards,
-            ValidatorSelectionConfig {
-                num_chunk_producer_seats: 2 * num_shards,
-                num_chunk_validator_seats: 2 * num_shards,
-                num_chunk_only_producer_seats: 0,
-                // for example purposes, we choose a higher ratio than in production
-                minimum_stake_ratio: Ratio::new(1, 10),
-                ..Default::default()
-            },
+            Some(2 * num_shards),
+            Some(2 * num_shards),
+            Some(0),
+            Some(Ratio::new(1, 10)),
         );
         let prev_epoch_height = 7;
         let prev_epoch_info = create_prev_epoch_info(prev_epoch_height, &["test1", "test2"], &[]);
@@ -1094,14 +1072,10 @@ mod tests {
         let epoch_config = create_epoch_config(
             1,
             100,
-            ValidatorSelectionConfig {
-                num_chunk_producer_seats: 300,
-                num_chunk_validator_seats: 300,
-                num_chunk_only_producer_seats: 300,
-                // for example purposes, we choose a higher ratio than in production
-                minimum_stake_ratio: Ratio::new(1, 10),
-                ..Default::default()
-            },
+            Some(300),
+            Some(300),
+            Some(300),
+            Some(Ratio::new(1i32, 10i32)),
         );
         let prev_epoch_height = 7;
         // test5 and test6 are going to get kicked out for not enough stake.
@@ -1196,7 +1170,7 @@ mod tests {
     #[test]
     fn test_validator_assignment_with_kickout() {
         // kicked out validators are not selected
-        let epoch_config = create_epoch_config(1, 100, Default::default());
+        let epoch_config = create_epoch_config(1, 100, None, None, None, None);
         let prev_epoch_height = 7;
         let prev_epoch_info = create_prev_epoch_info(
             prev_epoch_height,
@@ -1228,7 +1202,7 @@ mod tests {
         // validator balances are updated based on their rewards
         let validators = [("test1", 3000), ("test2", 2000), ("test3", 1000)];
         let rewards: [u128; 3] = [7, 8, 9];
-        let epoch_config = create_epoch_config(1, 100, Default::default());
+        let epoch_config = create_epoch_config(1, 100, None, None, None, None);
         let prev_epoch_height = 7;
         let prev_epoch_info = create_prev_epoch_info(prev_epoch_height, &validators, &[]);
         let rewards_map = validators
@@ -1256,30 +1230,45 @@ mod tests {
         }
     }
 
+    /// Update the fileds of `EpochConfig` with the given value.
+    macro_rules! update_fields {
+        ($epoch_config:ident, $($field:ident),*) => {
+            $(
+                if let Some(value) = $field {
+                    $epoch_config.$field = value;
+                }
+            )*
+        };
+    }
+
     /// Create EpochConfig, only filling in the fields important for validator selection.
     fn create_epoch_config(
         num_shards: u64,
         num_block_producer_seats: u64,
-        validator_selection_config: ValidatorSelectionConfig,
+        num_chunk_producer_seats: Option<NumSeats>,
+        num_chunk_validator_seats: Option<NumSeats>,
+        num_chunk_only_producer_seats: Option<NumSeats>,
+        minimum_stake_ratio: Option<Ratio<i32>>,
     ) -> EpochConfig {
-        EpochConfig {
-            epoch_length: 10,
-            num_block_producer_seats,
-            num_block_producer_seats_per_shard: vec![num_block_producer_seats; num_shards as usize],
-            avg_hidden_validator_seats_per_shard: vec![0; num_shards as usize],
-            block_producer_kickout_threshold: 0,
-            chunk_producer_kickout_threshold: 0,
-            chunk_validator_only_kickout_threshold: 0,
-            target_validator_mandates_per_shard: 68,
-            validator_max_kickout_stake_perc: 100,
-            online_min_threshold: 0.into(),
-            online_max_threshold: 0.into(),
-            fishermen_threshold: 0,
-            minimum_stake_divisor: 0,
-            protocol_upgrade_stake_threshold: 0.into(),
-            shard_layout: ShardLayout::multi_shard(num_shards, 0),
-            validator_selection_config,
-        }
+        let mut epoch_config = EpochConfig::zero();
+        epoch_config.epoch_length = 10;
+        epoch_config.num_block_producer_seats = num_block_producer_seats;
+        epoch_config.num_block_producer_seats_per_shard =
+            vec![num_block_producer_seats; num_shards as usize];
+        epoch_config.avg_hidden_validator_seats_per_shard = vec![0; num_shards as usize];
+        epoch_config.target_validator_mandates_per_shard = 68;
+        epoch_config.validator_max_kickout_stake_perc = 100;
+        epoch_config.shard_layout = ShardLayout::multi_shard(num_shards, 0);
+
+        update_fields!(
+            epoch_config,
+            num_chunk_producer_seats,
+            num_chunk_validator_seats,
+            num_chunk_only_producer_seats,
+            minimum_stake_ratio
+        );
+
+        epoch_config
     }
 
     fn create_prev_epoch_info<T: IntoValidatorStake + Copy>(

--- a/chain/epoch-manager/src/validator_selection.rs
+++ b/chain/epoch-manager/src/validator_selection.rs
@@ -1250,7 +1250,7 @@ mod tests {
         num_chunk_only_producer_seats: Option<NumSeats>,
         minimum_stake_ratio: Option<Ratio<i32>>,
     ) -> EpochConfig {
-        let mut epoch_config = EpochConfig::zero();
+        let mut epoch_config = EpochConfig::minimal();
         epoch_config.epoch_length = 10;
         epoch_config.num_block_producer_seats = num_block_producer_seats;
         epoch_config.num_block_producer_seats_per_shard =

--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -12,7 +12,7 @@ use anyhow::Context;
 use chrono::{DateTime, Utc};
 use near_config_utils::ValidationError;
 use near_parameters::{RuntimeConfig, RuntimeConfigView};
-use near_primitives::epoch_manager::{EpochConfig, ValidatorSelectionConfig};
+use near_primitives::epoch_manager::EpochConfig;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::StateRoot;
@@ -269,17 +269,14 @@ impl From<&GenesisConfig> for EpochConfig {
             protocol_upgrade_stake_threshold: config.protocol_upgrade_stake_threshold,
             minimum_stake_divisor: config.minimum_stake_divisor,
             shard_layout: config.shard_layout.clone(),
-            validator_selection_config: near_primitives::epoch_manager::ValidatorSelectionConfig {
-                num_chunk_producer_seats: config.num_chunk_producer_seats,
-                num_chunk_validator_seats: config.num_chunk_validator_seats,
-                num_chunk_only_producer_seats: config.num_chunk_only_producer_seats,
-                minimum_validators_per_shard: config.minimum_validators_per_shard,
-                minimum_stake_ratio: config.minimum_stake_ratio,
-                chunk_producer_assignment_changes_limit: config
-                    .chunk_producer_assignment_changes_limit,
-                shuffle_shard_assignment_for_chunk_producers: config
-                    .shuffle_shard_assignment_for_chunk_producers,
-            },
+            num_chunk_producer_seats: config.num_chunk_producer_seats,
+            num_chunk_validator_seats: config.num_chunk_validator_seats,
+            num_chunk_only_producer_seats: config.num_chunk_only_producer_seats,
+            minimum_validators_per_shard: config.minimum_validators_per_shard,
+            minimum_stake_ratio: config.minimum_stake_ratio,
+            chunk_producer_assignment_changes_limit: config.chunk_producer_assignment_changes_limit,
+            shuffle_shard_assignment_for_chunk_producers: config
+                .shuffle_shard_assignment_for_chunk_producers,
             validator_max_kickout_stake_perc: config.max_kickout_stake_perc,
         }
     }
@@ -756,32 +753,22 @@ impl Genesis {
     // Create test-only epoch config.
     // Not depends on genesis!
     // TODO(#11265): move to crate with `EpochConfig`.
+    // Cannot move the configs consts to `primitives`.
     pub fn test_epoch_config(
         num_block_producer_seats: NumSeats,
         shard_layout: ShardLayout,
         epoch_length: BlockHeightDelta,
     ) -> EpochConfig {
-        EpochConfig {
-            epoch_length,
+        EpochConfig::genesis_test(
             num_block_producer_seats,
-            num_block_producer_seats_per_shard: vec![
-                num_block_producer_seats;
-                shard_layout.shard_ids().count()
-            ],
-            avg_hidden_validator_seats_per_shard: vec![],
-            target_validator_mandates_per_shard: 68,
-            validator_max_kickout_stake_perc: 100,
-            online_min_threshold: Rational32::new(90, 100),
-            online_max_threshold: Rational32::new(99, 100),
-            minimum_stake_divisor: 10,
-            protocol_upgrade_stake_threshold: PROTOCOL_UPGRADE_STAKE_THRESHOLD,
-            block_producer_kickout_threshold: BLOCK_PRODUCER_KICKOUT_THRESHOLD,
-            chunk_producer_kickout_threshold: CHUNK_PRODUCER_KICKOUT_THRESHOLD,
-            chunk_validator_only_kickout_threshold: CHUNK_VALIDATOR_ONLY_KICKOUT_THRESHOLD,
-            fishermen_threshold: FISHERMEN_THRESHOLD,
             shard_layout,
-            validator_selection_config: ValidatorSelectionConfig::default(),
-        }
+            epoch_length,
+            BLOCK_PRODUCER_KICKOUT_THRESHOLD,
+            CHUNK_PRODUCER_KICKOUT_THRESHOLD,
+            CHUNK_VALIDATOR_ONLY_KICKOUT_THRESHOLD,
+            PROTOCOL_UPGRADE_STAKE_THRESHOLD,
+            FISHERMEN_THRESHOLD,
+        )
     }
 }
 

--- a/core/chain-configs/src/test_genesis.rs
+++ b/core/chain-configs/src/test_genesis.rs
@@ -195,9 +195,8 @@ impl TestEpochConfigBuilder {
         epoch_config.block_producer_kickout_threshold = 0;
         epoch_config.chunk_producer_kickout_threshold = 0;
         epoch_config.chunk_validator_only_kickout_threshold = 0;
-        epoch_config.validator_selection_config.num_chunk_producer_seats = num_chunk_producer_seats;
-        epoch_config.validator_selection_config.num_chunk_validator_seats =
-            num_chunk_validator_seats;
+        epoch_config.num_chunk_producer_seats = num_chunk_producer_seats;
+        epoch_config.num_chunk_validator_seats = num_chunk_validator_seats;
 
         if let Some(target_validator_mandates_per_shard) = self.target_validator_mandates_per_shard
         {
@@ -236,31 +235,30 @@ impl TestEpochConfigBuilder {
             );
         }
         if let Some(minimum_stake_ratio) = self.minimum_stake_ratio {
-            epoch_config.validator_selection_config.minimum_stake_ratio = minimum_stake_ratio;
+            epoch_config.minimum_stake_ratio = minimum_stake_ratio;
         } else {
             tracing::warn!(
                 "Epoch config minimum_stake_ratio not explicitly set, defaulting to {:?}.",
-                epoch_config.validator_selection_config.minimum_stake_ratio
+                epoch_config.minimum_stake_ratio
             );
         }
         if let Some(minimum_validators_per_shard) = self.minimum_validators_per_shard {
-            epoch_config.validator_selection_config.minimum_validators_per_shard =
-                minimum_validators_per_shard;
+            epoch_config.minimum_validators_per_shard = minimum_validators_per_shard;
         } else {
             tracing::warn!(
                 "Epoch config minimum_validators_per_shard not explicitly set, defaulting to {:?}.",
-                epoch_config.validator_selection_config.minimum_validators_per_shard
+                epoch_config.minimum_validators_per_shard
             );
         }
         if let Some(shuffle_shard_assignment_for_chunk_producers) =
             self.shuffle_shard_assignment_for_chunk_producers
         {
-            epoch_config.validator_selection_config.shuffle_shard_assignment_for_chunk_producers =
+            epoch_config.shuffle_shard_assignment_for_chunk_producers =
                 shuffle_shard_assignment_for_chunk_producers;
         } else {
             tracing::warn!(
                 "Epoch config shuffle_shard_assignment_for_chunk_producers not explicitly set, defaulting to {:?}.",
-                epoch_config.validator_selection_config.shuffle_shard_assignment_for_chunk_producers
+                epoch_config.shuffle_shard_assignment_for_chunk_producers
             );
         }
 

--- a/core/chain-configs/src/test_utils.rs
+++ b/core/chain-configs/src/test_utils.rs
@@ -72,7 +72,7 @@ impl Genesis {
         }
         add_protocol_account(&mut records);
         let epoch_config =
-            Self::test_epoch_config(num_validator_seats, shard_layout, FAST_EPOCH_LENGTH);
+            Genesis::test_epoch_config(num_validator_seats, shard_layout, FAST_EPOCH_LENGTH);
         let config = GenesisConfig {
             protocol_version: PROTOCOL_VERSION,
             genesis_time: from_timestamp(clock.now_utc().unix_timestamp_nanos() as u64),
@@ -106,24 +106,14 @@ impl Genesis {
             online_min_threshold: epoch_config.online_min_threshold,
             online_max_threshold: epoch_config.online_max_threshold,
             minimum_stake_divisor: epoch_config.minimum_stake_divisor,
-            num_chunk_producer_seats: epoch_config
-                .validator_selection_config
-                .num_chunk_producer_seats,
-            num_chunk_validator_seats: epoch_config
-                .validator_selection_config
-                .num_chunk_validator_seats,
-            num_chunk_only_producer_seats: epoch_config
-                .validator_selection_config
-                .num_chunk_only_producer_seats,
-            minimum_validators_per_shard: epoch_config
-                .validator_selection_config
-                .minimum_validators_per_shard,
-            minimum_stake_ratio: epoch_config.validator_selection_config.minimum_stake_ratio,
+            num_chunk_producer_seats: epoch_config.num_chunk_producer_seats,
+            num_chunk_validator_seats: epoch_config.num_chunk_validator_seats,
+            num_chunk_only_producer_seats: epoch_config.num_chunk_only_producer_seats,
+            minimum_validators_per_shard: epoch_config.minimum_validators_per_shard,
+            minimum_stake_ratio: epoch_config.minimum_stake_ratio,
             chunk_producer_assignment_changes_limit: epoch_config
-                .validator_selection_config
                 .chunk_producer_assignment_changes_limit,
             shuffle_shard_assignment_for_chunk_producers: epoch_config
-                .validator_selection_config
                 .shuffle_shard_assignment_for_chunk_producers,
 
             ..Default::default()

--- a/core/parameters/src/config_store.rs
+++ b/core/parameters/src/config_store.rs
@@ -94,7 +94,7 @@ impl RuntimeConfigStore {
         }
 
         for (protocol_version, diff_bytes) in CONFIG_DIFFS {
-            let diff :ParameterTableDiff= diff_bytes.parse().unwrap_or_else(|err| panic!("Failed parsing runtime parameters diff for version {protocol_version}. Error: {err}"));
+            let diff :ParameterTableDiff = diff_bytes.parse().unwrap_or_else(|err| panic!("Failed parsing runtime parameters diff for version {protocol_version}. Error: {err}"));
             params.apply_diff(diff).unwrap_or_else(|err| panic!("Failed applying diff to `RuntimeConfig` for version {protocol_version}. Error: {err}"));
             #[cfg(not(feature = "calimero_zero_storage"))]
             store.insert(

--- a/core/primitives/res/epoch_configs/mainnet/100.json
+++ b/core/primitives/res/epoch_configs/mainnet/100.json
@@ -81,16 +81,14 @@
       "version": 4
     }
   },
-  "validator_selection_config": {
-    "num_chunk_producer_seats": 100,
-    "num_chunk_validator_seats": 300,
-    "num_chunk_only_producer_seats": 0,
-    "minimum_validators_per_shard": 1,
-    "minimum_stake_ratio": [
-      1,
-      62500
-    ],
-    "chunk_producer_assignment_changes_limit": 5,
-    "shuffle_shard_assignment_for_chunk_producers": false
-  }
+  "num_chunk_producer_seats": 100,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 0,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    62500
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
 }

--- a/core/primitives/res/epoch_configs/mainnet/101.json
+++ b/core/primitives/res/epoch_configs/mainnet/101.json
@@ -74,16 +74,14 @@
       "version": 3
     }
   },
-  "validator_selection_config": {
-    "num_chunk_producer_seats": 100,
-    "num_chunk_validator_seats": 300,
-    "num_chunk_only_producer_seats": 0,
-    "minimum_validators_per_shard": 1,
-    "minimum_stake_ratio": [
-      1,
-      62500
-    ],
-    "chunk_producer_assignment_changes_limit": 5,
-    "shuffle_shard_assignment_for_chunk_producers": false
-  }
+  "num_chunk_producer_seats": 100,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 0,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    62500
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
 }

--- a/core/primitives/res/epoch_configs/mainnet/143.json
+++ b/core/primitives/res/epoch_configs/mainnet/143.json
@@ -74,16 +74,14 @@
       "version": 3
     }
   },
-  "validator_selection_config": {
-    "num_chunk_producer_seats": 100,
-    "num_chunk_validator_seats": 300,
-    "num_chunk_only_producer_seats": 0,
-    "minimum_validators_per_shard": 1,
-    "minimum_stake_ratio": [
-      1,
-      62500
-    ],
-    "chunk_producer_assignment_changes_limit": 5,
-    "shuffle_shard_assignment_for_chunk_producers": true
-  }
+  "num_chunk_producer_seats": 100,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 0,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    62500
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": true
 }

--- a/core/primitives/res/epoch_configs/mainnet/29.json
+++ b/core/primitives/res/epoch_configs/mainnet/29.json
@@ -1,47 +1,45 @@
 {
-    "epoch_length": 43200,
-    "num_block_producer_seats": 100,
-    "num_block_producer_seats_per_shard": [
-      100
-    ],
-    "avg_hidden_validator_seats_per_shard": [
-      0
-    ],
-    "block_producer_kickout_threshold": 90,
-    "chunk_producer_kickout_threshold": 90,
-    "chunk_validator_only_kickout_threshold": 80,
-    "target_validator_mandates_per_shard": 68,
-    "validator_max_kickout_stake_perc": 100,
-    "online_min_threshold": [
-      90,
-      100
-    ],
-    "online_max_threshold": [
-      99,
-      100
-    ],
-    "fishermen_threshold": "340282366920938463463374607431768211455",
-    "minimum_stake_divisor": 10,
-    "protocol_upgrade_stake_threshold": [
-      4,
-      5
-    ],
-    "shard_layout": {
-      "V0": {
-        "num_shards": 1,
-        "version": 0
-      }
-    },
-    "validator_selection_config": {
-      "num_chunk_producer_seats": 100,
-      "num_chunk_validator_seats": 300,
-      "num_chunk_only_producer_seats": 300,
-      "minimum_validators_per_shard": 1,
-      "minimum_stake_ratio": [
-        1,
-        6250
-      ],
-      "chunk_producer_assignment_changes_limit": 5,
-      "shuffle_shard_assignment_for_chunk_producers": false
+  "epoch_length": 43200,
+  "num_block_producer_seats": 100,
+  "num_block_producer_seats_per_shard": [
+    100
+  ],
+  "avg_hidden_validator_seats_per_shard": [
+    0
+  ],
+  "block_producer_kickout_threshold": 90,
+  "chunk_producer_kickout_threshold": 90,
+  "chunk_validator_only_kickout_threshold": 80,
+  "target_validator_mandates_per_shard": 68,
+  "validator_max_kickout_stake_perc": 100,
+  "online_min_threshold": [
+    90,
+    100
+  ],
+  "online_max_threshold": [
+    99,
+    100
+  ],
+  "fishermen_threshold": "340282366920938463463374607431768211455",
+  "minimum_stake_divisor": 10,
+  "protocol_upgrade_stake_threshold": [
+    4,
+    5
+  ],
+  "shard_layout": {
+    "V0": {
+      "num_shards": 1,
+      "version": 0
     }
-  }
+  },
+  "num_chunk_producer_seats": 100,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 300,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    6250
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
+}

--- a/core/primitives/res/epoch_configs/mainnet/48.json
+++ b/core/primitives/res/epoch_configs/mainnet/48.json
@@ -56,16 +56,14 @@
       "version": 1
     }
   },
-  "validator_selection_config": {
-    "num_chunk_producer_seats": 100,
-    "num_chunk_validator_seats": 300,
-    "num_chunk_only_producer_seats": 300,
-    "minimum_validators_per_shard": 1,
-    "minimum_stake_ratio": [
-      1,
-      6250
-    ],
-    "chunk_producer_assignment_changes_limit": 5,
-    "shuffle_shard_assignment_for_chunk_producers": false
-  }
+  "num_chunk_producer_seats": 100,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 300,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    6250
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
 }

--- a/core/primitives/res/epoch_configs/mainnet/56.json
+++ b/core/primitives/res/epoch_configs/mainnet/56.json
@@ -56,16 +56,14 @@
       "version": 1
     }
   },
-  "validator_selection_config": {
-    "num_chunk_producer_seats": 100,
-    "num_chunk_validator_seats": 300,
-    "num_chunk_only_producer_seats": 200,
-    "minimum_validators_per_shard": 1,
-    "minimum_stake_ratio": [
-      1,
-      6250
-    ],
-    "chunk_producer_assignment_changes_limit": 5,
-    "shuffle_shard_assignment_for_chunk_producers": false
-  }
+  "num_chunk_producer_seats": 100,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 200,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    6250
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
 }

--- a/core/primitives/res/epoch_configs/mainnet/64.json
+++ b/core/primitives/res/epoch_configs/mainnet/64.json
@@ -67,16 +67,14 @@
       "version": 2
     }
   },
-  "validator_selection_config": {
-    "num_chunk_producer_seats": 100,
-    "num_chunk_validator_seats": 300,
-    "num_chunk_only_producer_seats": 200,
-    "minimum_validators_per_shard": 1,
-    "minimum_stake_ratio": [
-      1,
-      6250
-    ],
-    "chunk_producer_assignment_changes_limit": 5,
-    "shuffle_shard_assignment_for_chunk_producers": false
-  }
+  "num_chunk_producer_seats": 100,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 200,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    6250
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
 }

--- a/core/primitives/res/epoch_configs/mainnet/65.json
+++ b/core/primitives/res/epoch_configs/mainnet/65.json
@@ -74,16 +74,14 @@
       "version": 3
     }
   },
-  "validator_selection_config": {
-    "num_chunk_producer_seats": 100,
-    "num_chunk_validator_seats": 300,
-    "num_chunk_only_producer_seats": 200,
-    "minimum_validators_per_shard": 1,
-    "minimum_stake_ratio": [
-      1,
-      6250
-    ],
-    "chunk_producer_assignment_changes_limit": 5,
-    "shuffle_shard_assignment_for_chunk_producers": false
-  }
+  "num_chunk_producer_seats": 100,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 200,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    6250
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
 }

--- a/core/primitives/res/epoch_configs/mainnet/69.json
+++ b/core/primitives/res/epoch_configs/mainnet/69.json
@@ -74,16 +74,14 @@
       "version": 3
     }
   },
-  "validator_selection_config": {
-    "num_chunk_producer_seats": 100,
-    "num_chunk_validator_seats": 300,
-    "num_chunk_only_producer_seats": 0,
-    "minimum_validators_per_shard": 1,
-    "minimum_stake_ratio": [
-      1,
-      6250
-    ],
-    "chunk_producer_assignment_changes_limit": 5,
-    "shuffle_shard_assignment_for_chunk_producers": false
-  }
+  "num_chunk_producer_seats": 100,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 0,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    6250
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
 }

--- a/core/primitives/res/epoch_configs/mainnet/70.json
+++ b/core/primitives/res/epoch_configs/mainnet/70.json
@@ -1,89 +1,87 @@
 {
-    "epoch_length": 43200,
-    "num_block_producer_seats": 100,
-    "num_block_producer_seats_per_shard": [
-      100,
-      100,
-      100,
-      100,
-      100,
-      100
-    ],
-    "avg_hidden_validator_seats_per_shard": [
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
-    ],
-    "block_producer_kickout_threshold": 80,
-    "chunk_producer_kickout_threshold": 80,
-    "chunk_validator_only_kickout_threshold": 80,
-    "target_validator_mandates_per_shard": 68,
-    "validator_max_kickout_stake_perc": 30,
-    "online_min_threshold": [
-      90,
-      100
-    ],
-    "online_max_threshold": [
-      99,
-      100
-    ],
-    "fishermen_threshold": "340282366920938463463374607431768211455",
-    "minimum_stake_divisor": 10,
-    "protocol_upgrade_stake_threshold": [
-      4,
-      5
-    ],
-    "shard_layout": {
-      "V1": {
-        "boundary_accounts": [
-          "aurora",
-          "aurora-0",
-          "game.hot.tg",
-          "kkuuue2akv_1630967379.near",
-          "tge-lockup.sweat"
+  "epoch_length": 43200,
+  "num_block_producer_seats": 100,
+  "num_block_producer_seats_per_shard": [
+    100,
+    100,
+    100,
+    100,
+    100,
+    100
+  ],
+  "avg_hidden_validator_seats_per_shard": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
+  "block_producer_kickout_threshold": 80,
+  "chunk_producer_kickout_threshold": 80,
+  "chunk_validator_only_kickout_threshold": 80,
+  "target_validator_mandates_per_shard": 68,
+  "validator_max_kickout_stake_perc": 30,
+  "online_min_threshold": [
+    90,
+    100
+  ],
+  "online_max_threshold": [
+    99,
+    100
+  ],
+  "fishermen_threshold": "340282366920938463463374607431768211455",
+  "minimum_stake_divisor": 10,
+  "protocol_upgrade_stake_threshold": [
+    4,
+    5
+  ],
+  "shard_layout": {
+    "V1": {
+      "boundary_accounts": [
+        "aurora",
+        "aurora-0",
+        "game.hot.tg",
+        "kkuuue2akv_1630967379.near",
+        "tge-lockup.sweat"
+      ],
+      "shards_split_map": [
+        [
+          0
         ],
-        "shards_split_map": [
-          [
-            0
-          ],
-          [
-            1
-          ],
-          [
-            2,
-            3
-          ],
-          [
-            4
-          ],
-          [
-            5
-          ]
+        [
+          1
         ],
-        "to_parent_shard_map": [
-          0,
-          1,
+        [
           2,
-          2,
-          3,
+          3
+        ],
+        [
           4
         ],
-        "version": 3
-      }
-    },
-    "validator_selection_config": {
-      "num_chunk_producer_seats": 100,
-      "num_chunk_validator_seats": 300,
-      "num_chunk_only_producer_seats": 0,
-      "minimum_validators_per_shard": 1,
-      "minimum_stake_ratio": [
-        1,
-        6250
+        [
+          5
+        ]
       ],
-      "chunk_producer_assignment_changes_limit": 5,
-      "shuffle_shard_assignment_for_chunk_producers": false
+      "to_parent_shard_map": [
+        0,
+        1,
+        2,
+        2,
+        3,
+        4
+      ],
+      "version": 3
     }
-  }
+  },
+  "num_chunk_producer_seats": 100,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 0,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    6250
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
+}

--- a/core/primitives/res/epoch_configs/mainnet/71.json
+++ b/core/primitives/res/epoch_configs/mainnet/71.json
@@ -74,16 +74,14 @@
       "version": 3
     }
   },
-  "validator_selection_config": {
-    "num_chunk_producer_seats": 100,
-    "num_chunk_validator_seats": 300,
-    "num_chunk_only_producer_seats": 0,
-    "minimum_validators_per_shard": 1,
-    "minimum_stake_ratio": [
-      1,
-      62500
-    ],
-    "chunk_producer_assignment_changes_limit": 5,
-    "shuffle_shard_assignment_for_chunk_producers": false
-  }
+  "num_chunk_producer_seats": 100,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 0,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    62500
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
 }

--- a/core/primitives/res/epoch_configs/mainnet/72.json
+++ b/core/primitives/res/epoch_configs/mainnet/72.json
@@ -74,16 +74,14 @@
       "version": 3
     }
   },
-  "validator_selection_config": {
-    "num_chunk_producer_seats": 100,
-    "num_chunk_validator_seats": 300,
-    "num_chunk_only_producer_seats": 0,
-    "minimum_validators_per_shard": 1,
-    "minimum_stake_ratio": [
-      1,
-      62500
-    ],
-    "chunk_producer_assignment_changes_limit": 5,
-    "shuffle_shard_assignment_for_chunk_producers": false
-  }
+  "num_chunk_producer_seats": 100,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 0,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    62500
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
 }

--- a/core/primitives/res/epoch_configs/testnet/100.json
+++ b/core/primitives/res/epoch_configs/testnet/100.json
@@ -81,16 +81,14 @@
       "version": 4
     }
   },
-  "validator_selection_config": {
-    "num_chunk_producer_seats": 20,
-    "num_chunk_validator_seats": 300,
-    "num_chunk_only_producer_seats": 0,
-    "minimum_validators_per_shard": 1,
-    "minimum_stake_ratio": [
-      1,
-      62500
-    ],
-    "chunk_producer_assignment_changes_limit": 5,
-    "shuffle_shard_assignment_for_chunk_producers": false
-  }
+  "num_chunk_producer_seats": 20,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 0,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    62500
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
 }

--- a/core/primitives/res/epoch_configs/testnet/101.json
+++ b/core/primitives/res/epoch_configs/testnet/101.json
@@ -74,16 +74,14 @@
       "version": 3
     }
   },
-  "validator_selection_config": {
-    "num_chunk_producer_seats": 20,
-    "num_chunk_validator_seats": 300,
-    "num_chunk_only_producer_seats": 0,
-    "minimum_validators_per_shard": 1,
-    "minimum_stake_ratio": [
-      1,
-      62500
-    ],
-    "chunk_producer_assignment_changes_limit": 5,
-    "shuffle_shard_assignment_for_chunk_producers": false
-  }
+  "num_chunk_producer_seats": 20,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 0,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    62500
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
 }

--- a/core/primitives/res/epoch_configs/testnet/143.json
+++ b/core/primitives/res/epoch_configs/testnet/143.json
@@ -74,16 +74,14 @@
       "version": 3
     }
   },
-  "validator_selection_config": {
-    "num_chunk_producer_seats": 20,
-    "num_chunk_validator_seats": 300,
-    "num_chunk_only_producer_seats": 0,
-    "minimum_validators_per_shard": 1,
-    "minimum_stake_ratio": [
-      1,
-      62500
-    ],
-    "chunk_producer_assignment_changes_limit": 5,
-    "shuffle_shard_assignment_for_chunk_producers": true
-  }
+  "num_chunk_producer_seats": 20,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 0,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    62500
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": true
 }

--- a/core/primitives/res/epoch_configs/testnet/29.json
+++ b/core/primitives/res/epoch_configs/testnet/29.json
@@ -1,47 +1,45 @@
 {
-    "epoch_length": 43200,
-    "num_block_producer_seats": 200,
-    "num_block_producer_seats_per_shard": [
-      200
-    ],
-    "avg_hidden_validator_seats_per_shard": [
-      0
-    ],
-    "block_producer_kickout_threshold": 80,
-    "chunk_producer_kickout_threshold": 90,
-    "chunk_validator_only_kickout_threshold": 80,
-    "target_validator_mandates_per_shard": 68,
-    "validator_max_kickout_stake_perc": 100,
-    "online_min_threshold": [
-      90,
-      100
-    ],
-    "online_max_threshold": [
-      99,
-      100
-    ],
-    "fishermen_threshold": "340282366920938463463374607431768211455",
-    "minimum_stake_divisor": 10,
-    "protocol_upgrade_stake_threshold": [
-      4,
-      5
-    ],
-    "shard_layout": {
-      "V0": {
-        "num_shards": 1,
-        "version": 0
-      }
-    },
-    "validator_selection_config": {
-      "num_chunk_producer_seats": 100,
-      "num_chunk_validator_seats": 300,
-      "num_chunk_only_producer_seats": 300,
-      "minimum_validators_per_shard": 1,
-      "minimum_stake_ratio": [
-        1,
-        6250
-      ],
-      "chunk_producer_assignment_changes_limit": 5,
-      "shuffle_shard_assignment_for_chunk_producers": false
+  "epoch_length": 43200,
+  "num_block_producer_seats": 200,
+  "num_block_producer_seats_per_shard": [
+    200
+  ],
+  "avg_hidden_validator_seats_per_shard": [
+    0
+  ],
+  "block_producer_kickout_threshold": 80,
+  "chunk_producer_kickout_threshold": 90,
+  "chunk_validator_only_kickout_threshold": 80,
+  "target_validator_mandates_per_shard": 68,
+  "validator_max_kickout_stake_perc": 100,
+  "online_min_threshold": [
+    90,
+    100
+  ],
+  "online_max_threshold": [
+    99,
+    100
+  ],
+  "fishermen_threshold": "340282366920938463463374607431768211455",
+  "minimum_stake_divisor": 10,
+  "protocol_upgrade_stake_threshold": [
+    4,
+    5
+  ],
+  "shard_layout": {
+    "V0": {
+      "num_shards": 1,
+      "version": 0
     }
-  }
+  },
+  "num_chunk_producer_seats": 100,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 300,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    6250
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
+}

--- a/core/primitives/res/epoch_configs/testnet/48.json
+++ b/core/primitives/res/epoch_configs/testnet/48.json
@@ -56,16 +56,14 @@
       "version": 1
     }
   },
-  "validator_selection_config": {
-    "num_chunk_producer_seats": 100,
-    "num_chunk_validator_seats": 300,
-    "num_chunk_only_producer_seats": 300,
-    "minimum_validators_per_shard": 1,
-    "minimum_stake_ratio": [
-      1,
-      6250
-    ],
-    "chunk_producer_assignment_changes_limit": 5,
-    "shuffle_shard_assignment_for_chunk_producers": false
-  }
+  "num_chunk_producer_seats": 100,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 300,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    6250
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
 }

--- a/core/primitives/res/epoch_configs/testnet/56.json
+++ b/core/primitives/res/epoch_configs/testnet/56.json
@@ -56,16 +56,14 @@
       "version": 1
     }
   },
-  "validator_selection_config": {
-    "num_chunk_producer_seats": 100,
-    "num_chunk_validator_seats": 300,
-    "num_chunk_only_producer_seats": 200,
-    "minimum_validators_per_shard": 1,
-    "minimum_stake_ratio": [
-      1,
-      6250
-    ],
-    "chunk_producer_assignment_changes_limit": 5,
-    "shuffle_shard_assignment_for_chunk_producers": false
-  }
+  "num_chunk_producer_seats": 100,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 200,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    6250
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
 }

--- a/core/primitives/res/epoch_configs/testnet/64.json
+++ b/core/primitives/res/epoch_configs/testnet/64.json
@@ -67,16 +67,14 @@
       "version": 2
     }
   },
-  "validator_selection_config": {
-    "num_chunk_producer_seats": 100,
-    "num_chunk_validator_seats": 300,
-    "num_chunk_only_producer_seats": 100,
-    "minimum_validators_per_shard": 1,
-    "minimum_stake_ratio": [
-      1,
-      6250
-    ],
-    "chunk_producer_assignment_changes_limit": 5,
-    "shuffle_shard_assignment_for_chunk_producers": false
-  }
+  "num_chunk_producer_seats": 100,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 100,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    6250
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
 }

--- a/core/primitives/res/epoch_configs/testnet/65.json
+++ b/core/primitives/res/epoch_configs/testnet/65.json
@@ -74,16 +74,14 @@
       "version": 3
     }
   },
-  "validator_selection_config": {
-    "num_chunk_producer_seats": 100,
-    "num_chunk_validator_seats": 300,
-    "num_chunk_only_producer_seats": 100,
-    "minimum_validators_per_shard": 1,
-    "minimum_stake_ratio": [
-      1,
-      6250
-    ],
-    "chunk_producer_assignment_changes_limit": 5,
-    "shuffle_shard_assignment_for_chunk_producers": false
-  }
+  "num_chunk_producer_seats": 100,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 100,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    6250
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
 }

--- a/core/primitives/res/epoch_configs/testnet/69.json
+++ b/core/primitives/res/epoch_configs/testnet/69.json
@@ -74,16 +74,14 @@
       "version": 3
     }
   },
-  "validator_selection_config": {
-    "num_chunk_producer_seats": 20,
-    "num_chunk_validator_seats": 300,
-    "num_chunk_only_producer_seats": 0,
-    "minimum_validators_per_shard": 1,
-    "minimum_stake_ratio": [
-      1,
-      6250
-    ],
-    "chunk_producer_assignment_changes_limit": 5,
-    "shuffle_shard_assignment_for_chunk_producers": false
-  }
+  "num_chunk_producer_seats": 20,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 0,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    6250
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
 }

--- a/core/primitives/res/epoch_configs/testnet/70.json
+++ b/core/primitives/res/epoch_configs/testnet/70.json
@@ -1,89 +1,87 @@
 {
-    "epoch_length": 43200,
-    "num_block_producer_seats": 20,
-    "num_block_producer_seats_per_shard": [
-      20,
-      20,
-      20,
-      20,
-      20,
-      20
-    ],
-    "avg_hidden_validator_seats_per_shard": [
-      0,
-      0,
-      0,
-      0,
-      0,
-      0
-    ],
-    "block_producer_kickout_threshold": 80,
-    "chunk_producer_kickout_threshold": 80,
-    "chunk_validator_only_kickout_threshold": 80,
-    "target_validator_mandates_per_shard": 68,
-    "validator_max_kickout_stake_perc": 30,
-    "online_min_threshold": [
-      90,
-      100
-    ],
-    "online_max_threshold": [
-      99,
-      100
-    ],
-    "fishermen_threshold": "340282366920938463463374607431768211455",
-    "minimum_stake_divisor": 10,
-    "protocol_upgrade_stake_threshold": [
-      4,
-      5
-    ],
-    "shard_layout": {
-      "V1": {
-        "boundary_accounts": [
-          "aurora",
-          "aurora-0",
-          "game.hot.tg",
-          "kkuuue2akv_1630967379.near",
-          "tge-lockup.sweat"
+  "epoch_length": 43200,
+  "num_block_producer_seats": 20,
+  "num_block_producer_seats_per_shard": [
+    20,
+    20,
+    20,
+    20,
+    20,
+    20
+  ],
+  "avg_hidden_validator_seats_per_shard": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
+  "block_producer_kickout_threshold": 80,
+  "chunk_producer_kickout_threshold": 80,
+  "chunk_validator_only_kickout_threshold": 80,
+  "target_validator_mandates_per_shard": 68,
+  "validator_max_kickout_stake_perc": 30,
+  "online_min_threshold": [
+    90,
+    100
+  ],
+  "online_max_threshold": [
+    99,
+    100
+  ],
+  "fishermen_threshold": "340282366920938463463374607431768211455",
+  "minimum_stake_divisor": 10,
+  "protocol_upgrade_stake_threshold": [
+    4,
+    5
+  ],
+  "shard_layout": {
+    "V1": {
+      "boundary_accounts": [
+        "aurora",
+        "aurora-0",
+        "game.hot.tg",
+        "kkuuue2akv_1630967379.near",
+        "tge-lockup.sweat"
+      ],
+      "shards_split_map": [
+        [
+          0
         ],
-        "shards_split_map": [
-          [
-            0
-          ],
-          [
-            1
-          ],
-          [
-            2,
-            3
-          ],
-          [
-            4
-          ],
-          [
-            5
-          ]
+        [
+          1
         ],
-        "to_parent_shard_map": [
-          0,
-          1,
+        [
           2,
-          2,
-          3,
+          3
+        ],
+        [
           4
         ],
-        "version": 3
-      }
-    },
-    "validator_selection_config": {
-      "num_chunk_producer_seats": 20,
-      "num_chunk_validator_seats": 300,
-      "num_chunk_only_producer_seats": 0,
-      "minimum_validators_per_shard": 1,
-      "minimum_stake_ratio": [
-        1,
-        6250
+        [
+          5
+        ]
       ],
-      "chunk_producer_assignment_changes_limit": 5,
-      "shuffle_shard_assignment_for_chunk_producers": false
+      "to_parent_shard_map": [
+        0,
+        1,
+        2,
+        2,
+        3,
+        4
+      ],
+      "version": 3
     }
-  }
+  },
+  "num_chunk_producer_seats": 20,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 0,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    6250
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
+}

--- a/core/primitives/res/epoch_configs/testnet/71.json
+++ b/core/primitives/res/epoch_configs/testnet/71.json
@@ -74,16 +74,14 @@
       "version": 3
     }
   },
-  "validator_selection_config": {
-    "num_chunk_producer_seats": 20,
-    "num_chunk_validator_seats": 300,
-    "num_chunk_only_producer_seats": 0,
-    "minimum_validators_per_shard": 1,
-    "minimum_stake_ratio": [
-      1,
-      62500
-    ],
-    "chunk_producer_assignment_changes_limit": 5,
-    "shuffle_shard_assignment_for_chunk_producers": false
-  }
+  "num_chunk_producer_seats": 20,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 0,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    62500
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
 }

--- a/core/primitives/res/epoch_configs/testnet/72.json
+++ b/core/primitives/res/epoch_configs/testnet/72.json
@@ -74,16 +74,14 @@
       "version": 3
     }
   },
-  "validator_selection_config": {
-    "num_chunk_producer_seats": 20,
-    "num_chunk_validator_seats": 300,
-    "num_chunk_only_producer_seats": 0,
-    "minimum_validators_per_shard": 1,
-    "minimum_stake_ratio": [
-      1,
-      62500
-    ],
-    "chunk_producer_assignment_changes_limit": 5,
-    "shuffle_shard_assignment_for_chunk_producers": false
-  }
+  "num_chunk_producer_seats": 20,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 0,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    62500
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
 }

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -128,7 +128,7 @@ impl EpochConfig {
         }
     }
 
-    /// Minimal config for testing.
+    /// Mignimal config for testing.
     pub fn minimal() -> Self {
         Self {
             epoch_length: 0,

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -128,8 +128,8 @@ impl EpochConfig {
         }
     }
 
-    /// A dummy config for testing.
-    pub fn zero() -> Self {
+    /// Minimal config for testing.
+    pub fn minimal() -> Self {
         Self {
             epoch_length: 0,
             num_block_producer_seats: 0,

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -11,7 +11,6 @@ use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::serialize::dec_format;
 use near_primitives_core::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_schema_checker_lib::ProtocolSchema;
-use smart_default::SmartDefault;
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::ops::Bound;
@@ -55,16 +54,133 @@ pub struct EpochConfig {
     pub protocol_upgrade_stake_threshold: Rational32,
     /// Shard layout of this epoch, may change from epoch to epoch
     pub shard_layout: ShardLayout,
-    /// Additional config for validator selection algorithm
-    pub validator_selection_config: ValidatorSelectionConfig,
+    /// Additional configuration parameters for the new validator selection
+    /// algorithm. See <https://github.com/near/NEPs/pull/167> for details.
+    // #[default(100)]
+    pub num_chunk_producer_seats: NumSeats,
+    // #[default(300)]
+    pub num_chunk_validator_seats: NumSeats,
+    // TODO (#11267): deprecate after StatelessValidationV0 is in place.
+    // Use 300 for older protocol versions.
+    // #[default(300)]
+    pub num_chunk_only_producer_seats: NumSeats,
+    // #[default(1)]
+    pub minimum_validators_per_shard: NumSeats,
+    // #[default(Rational32::new(160, 1_000_000))]
+    pub minimum_stake_ratio: Rational32,
+    // #[default(5)]
+    /// Limits the number of shard changes in chunk producer assignments,
+    /// if algorithm is able to choose assignment with better balance of
+    /// number of chunk producers for shards.
+    pub chunk_producer_assignment_changes_limit: NumSeats,
+    // #[default(false)]
+    pub shuffle_shard_assignment_for_chunk_producers: bool,
 }
 
 impl EpochConfig {
     /// Total number of validator seats in the epoch since protocol version 69.
     pub fn num_validators(&self) -> NumSeats {
         self.num_block_producer_seats
-            .max(self.validator_selection_config.num_chunk_producer_seats)
-            .max(self.validator_selection_config.num_chunk_validator_seats)
+            .max(self.num_chunk_producer_seats)
+            .max(self.num_chunk_validator_seats)
+    }
+}
+
+impl EpochConfig {
+    // Create test-only epoch config.
+    // Not depends on genesis!
+    pub fn genesis_test(
+        num_block_producer_seats: NumSeats,
+        shard_layout: ShardLayout,
+        epoch_length: BlockHeightDelta,
+        block_producer_kickout_threshold: u8,
+        chunk_producer_kickout_threshold: u8,
+        chunk_validator_only_kickout_threshold: u8,
+        protocol_upgrade_stake_threshold: Rational32,
+        fishermen_threshold: Balance,
+    ) -> Self {
+        Self {
+            epoch_length,
+            num_block_producer_seats,
+            num_block_producer_seats_per_shard: vec![
+                num_block_producer_seats;
+                shard_layout.shard_ids().count()
+            ],
+            avg_hidden_validator_seats_per_shard: vec![],
+            target_validator_mandates_per_shard: 68,
+            validator_max_kickout_stake_perc: 100,
+            online_min_threshold: Rational32::new(90, 100),
+            online_max_threshold: Rational32::new(99, 100),
+            minimum_stake_divisor: 10,
+            protocol_upgrade_stake_threshold,
+            block_producer_kickout_threshold,
+            chunk_producer_kickout_threshold,
+            chunk_validator_only_kickout_threshold,
+            fishermen_threshold,
+            shard_layout,
+            num_chunk_producer_seats: 100,
+            num_chunk_validator_seats: 300,
+            num_chunk_only_producer_seats: 300,
+            minimum_validators_per_shard: 1,
+            minimum_stake_ratio: Rational32::new(160i32, 1_000_000i32),
+            chunk_producer_assignment_changes_limit: 5,
+            shuffle_shard_assignment_for_chunk_producers: false,
+        }
+    }
+
+    /// A dummy config for testing.
+    pub fn zero() -> Self {
+        Self {
+            epoch_length: 0,
+            num_block_producer_seats: 0,
+            num_block_producer_seats_per_shard: vec![],
+            avg_hidden_validator_seats_per_shard: vec![],
+            block_producer_kickout_threshold: 0,
+            chunk_producer_kickout_threshold: 0,
+            chunk_validator_only_kickout_threshold: 0,
+            target_validator_mandates_per_shard: 0,
+            validator_max_kickout_stake_perc: 0,
+            online_min_threshold: 0.into(),
+            online_max_threshold: 0.into(),
+            fishermen_threshold: 0,
+            minimum_stake_divisor: 0,
+            protocol_upgrade_stake_threshold: 0.into(),
+            shard_layout: ShardLayout::get_simple_nightshade_layout(),
+            num_chunk_producer_seats: 100,
+            num_chunk_validator_seats: 300,
+            num_chunk_only_producer_seats: 300,
+            minimum_validators_per_shard: 1,
+            minimum_stake_ratio: Rational32::new(160i32, 1_000_000i32),
+            chunk_producer_assignment_changes_limit: 5,
+            shuffle_shard_assignment_for_chunk_producers: false,
+        }
+    }
+
+    pub fn mock(epoch_length: BlockHeightDelta, shard_layout: ShardLayout) -> Self {
+        Self {
+            epoch_length,
+            num_block_producer_seats: 2,
+            num_block_producer_seats_per_shard: vec![1, 1],
+            avg_hidden_validator_seats_per_shard: vec![1, 1],
+            block_producer_kickout_threshold: 0,
+            chunk_producer_kickout_threshold: 0,
+            chunk_validator_only_kickout_threshold: 0,
+            target_validator_mandates_per_shard: 1,
+            validator_max_kickout_stake_perc: 0,
+            online_min_threshold: Rational32::new(1i32, 4i32),
+            online_max_threshold: Rational32::new(3i32, 4i32),
+            fishermen_threshold: 1,
+            minimum_stake_divisor: 1,
+            protocol_upgrade_stake_threshold: Rational32::new(3i32, 4i32),
+            shard_layout,
+            num_chunk_producer_seats: 100,
+            num_chunk_validator_seats: 300,
+            num_chunk_only_producer_seats: 300,
+            minimum_validators_per_shard: 1,
+            minimum_stake_ratio: Rational32::new(160i32, 1_000_000i32),
+            chunk_producer_assignment_changes_limit: 5,
+            shuffle_shard_assignment_for_chunk_producers: false,
+        }
     }
 }
 
@@ -249,7 +365,7 @@ impl AllEpochConfig {
         // the codepaths for state sync more often.
         // TODO(#11201): When stabilizing "ShuffleShardAssignments" in mainnet,
         // also remove this temporary code and always rely on ShuffleShardAssignments.
-        config.validator_selection_config.shuffle_shard_assignment_for_chunk_producers = true;
+        config.shuffle_shard_assignment_for_chunk_producers = true;
     }
 
     /// Configures validator-selection related features.
@@ -257,7 +373,7 @@ impl AllEpochConfig {
         // Shuffle shard assignments every epoch, to trigger state sync more
         // frequently to exercise that code path.
         if checked_feature!("stable", ShuffleShardAssignments, protocol_version) {
-            config.validator_selection_config.shuffle_shard_assignment_for_chunk_producers = true;
+            config.shuffle_shard_assignment_for_chunk_producers = true;
         }
     }
 
@@ -312,7 +428,7 @@ impl AllEpochConfig {
                 config.shard_layout.shard_ids().map(|_| 100).collect();
             config.block_producer_kickout_threshold = 80;
             config.chunk_producer_kickout_threshold = 80;
-            config.validator_selection_config.num_chunk_only_producer_seats = 200;
+            config.num_chunk_only_producer_seats = 200;
         }
 
         // Adjust the number of block and chunk producers for testnet, to make it easier to test the change.
@@ -324,18 +440,18 @@ impl AllEpochConfig {
             config.num_block_producer_seats = 20;
             // Checking feature NoChunkOnlyProducers in stateless validation
             if ProtocolFeature::StatelessValidation.enabled(protocol_version) {
-                config.validator_selection_config.num_chunk_producer_seats = 20;
+                config.num_chunk_producer_seats = 20;
             }
             config.num_block_producer_seats_per_shard =
                 shard_ids.map(|_| config.num_block_producer_seats).collect();
             // Decrease the number of chunk producers.
-            config.validator_selection_config.num_chunk_only_producer_seats = 100;
+            config.num_chunk_only_producer_seats = 100;
         }
 
         // Checking feature NoChunkOnlyProducers in stateless validation
         if ProtocolFeature::StatelessValidation.enabled(protocol_version) {
             // Make sure there is no chunk only producer in stateless validation
-            config.validator_selection_config.num_chunk_only_producer_seats = 0;
+            config.num_chunk_only_producer_seats = 0;
         }
     }
 
@@ -347,7 +463,7 @@ impl AllEpochConfig {
 
     fn config_fix_min_stake_ratio(config: &mut EpochConfig, protocol_version: u32) {
         if checked_feature!("stable", FixMinStakeRatio, protocol_version) {
-            config.validator_selection_config.minimum_stake_ratio = Rational32::new(1, 62_500);
+            config.minimum_stake_ratio = Rational32::new(1, 62_500);
         }
     }
 
@@ -373,31 +489,6 @@ impl AllEpochConfig {
             config.chunk_producer_kickout_threshold = chunk_producer_kickout_threshold;
         }
     }
-}
-
-/// Additional configuration parameters for the new validator selection
-/// algorithm.  See <https://github.com/near/NEPs/pull/167> for details.
-#[derive(Debug, Clone, SmartDefault, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct ValidatorSelectionConfig {
-    #[default(100)]
-    pub num_chunk_producer_seats: NumSeats,
-    #[default(300)]
-    pub num_chunk_validator_seats: NumSeats,
-    // TODO (#11267): deprecate after StatelessValidationV0 is in place.
-    // Use 300 for older protocol versions.
-    #[default(300)]
-    pub num_chunk_only_producer_seats: NumSeats,
-    #[default(1)]
-    pub minimum_validators_per_shard: NumSeats,
-    #[default(Rational32::new(160, 1_000_000))]
-    pub minimum_stake_ratio: Rational32,
-    #[default(5)]
-    /// Limits the number of shard changes in chunk producer assignments,
-    /// if algorithm is able to choose assignment with better balance of
-    /// number of chunk producers for shards.
-    pub chunk_producer_assignment_changes_limit: NumSeats,
-    #[default(false)]
-    pub shuffle_shard_assignment_for_chunk_producers: bool,
 }
 
 #[derive(BorshSerialize, BorshDeserialize, ProtocolSchema)]

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -1111,7 +1111,7 @@ mod tests {
         pub fn for_protocol_version(protocol_version: ProtocolVersion) -> Self {
             // none of the epoch config fields matter, we only need the shard layout
             // constructed through [`AllEpochConfig::for_protocol_version()`].
-            let genesis_epoch_config = EpochConfig::zero();
+            let genesis_epoch_config = EpochConfig::minimal();
 
             let genesis_protocol_version = PROTOCOL_VERSION;
             let all_epoch_config = AllEpochConfig::new(

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -1072,7 +1072,7 @@ impl ShardInfo {
 
 #[cfg(test)]
 mod tests {
-    use crate::epoch_manager::{AllEpochConfig, EpochConfig, ValidatorSelectionConfig};
+    use crate::epoch_manager::{AllEpochConfig, EpochConfig};
     use crate::shard_layout::{
         new_shard_ids_vec, new_shards_split_map, ShardLayout, ShardLayoutV1, ShardUId,
     };
@@ -1111,24 +1111,7 @@ mod tests {
         pub fn for_protocol_version(protocol_version: ProtocolVersion) -> Self {
             // none of the epoch config fields matter, we only need the shard layout
             // constructed through [`AllEpochConfig::for_protocol_version()`].
-            let genesis_epoch_config = EpochConfig {
-                epoch_length: 0,
-                num_block_producer_seats: 0,
-                num_block_producer_seats_per_shard: vec![],
-                avg_hidden_validator_seats_per_shard: vec![],
-                block_producer_kickout_threshold: 0,
-                chunk_producer_kickout_threshold: 0,
-                chunk_validator_only_kickout_threshold: 0,
-                target_validator_mandates_per_shard: 0,
-                validator_max_kickout_stake_perc: 0,
-                online_min_threshold: 0.into(),
-                online_max_threshold: 0.into(),
-                fishermen_threshold: 0,
-                minimum_stake_divisor: 0,
-                protocol_upgrade_stake_threshold: 0.into(),
-                shard_layout: ShardLayout::get_simple_nightshade_layout(),
-                validator_selection_config: ValidatorSelectionConfig::default(),
-            };
+            let genesis_epoch_config = EpochConfig::zero();
 
             let genesis_protocol_version = PROTOCOL_VERSION;
             let all_epoch_config = AllEpochConfig::new(

--- a/integration-tests/src/test_loop/tests/fix_min_stake_ratio.rs
+++ b/integration-tests/src/test_loop/tests/fix_min_stake_ratio.rs
@@ -140,10 +140,7 @@ fn slow_test_fix_min_stake_ratio() {
         return if validators.len() == 3 {
             assert!(validators.contains(&small_validator.to_string()));
             let epoch_config = client.epoch_manager.get_epoch_config(&tip.epoch_id).unwrap();
-            assert_eq!(
-                epoch_config.validator_selection_config.minimum_stake_ratio,
-                Rational32::new(1, 62_500)
-            );
+            assert_eq!(epoch_config.minimum_stake_ratio, Rational32::new(1, 62_500));
             true
         } else {
             false

--- a/integration-tests/src/test_loop/tests/protocol_upgrade.rs
+++ b/integration-tests/src/test_loop/tests/protocol_upgrade.rs
@@ -89,10 +89,8 @@ pub(crate) fn test_protocol_upgrade(
         config.epoch_length = epoch_length;
         config.shard_layout = shard_layout.clone();
         config.num_block_producer_seats = genesis_epoch_info.num_block_producer_seats;
-        config.validator_selection_config.num_chunk_producer_seats =
-            genesis_epoch_info.validator_selection_config.num_chunk_producer_seats;
-        config.validator_selection_config.num_chunk_validator_seats =
-            genesis_epoch_info.validator_selection_config.num_chunk_validator_seats;
+        config.num_chunk_producer_seats = genesis_epoch_info.num_chunk_producer_seats;
+        config.num_chunk_validator_seats = genesis_epoch_info.num_chunk_validator_seats;
 
         if !missing_chunk_ranges.is_empty() {
             config.block_producer_kickout_threshold = 0;

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -1133,7 +1133,7 @@ fn test_resharding_v3_base(params: TestReshardingParameters) {
     let base_protocol_version = ProtocolFeature::SimpleNightshadeV4.protocol_version() - 1;
     let mut base_epoch_config =
         base_epoch_config_store.get_config(base_protocol_version).as_ref().clone();
-    base_epoch_config.validator_selection_config.shuffle_shard_assignment_for_chunk_producers =
+    base_epoch_config.shuffle_shard_assignment_for_chunk_producers =
         params.shuffle_shard_assignment_for_chunk_producers;
     if !params.chunk_ranges_to_drop.is_empty() {
         base_epoch_config.block_producer_kickout_threshold = 0;

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -556,8 +556,8 @@ impl ForkNetworkCommand {
             let mut config = base_epoch_config_store.get_config(version).as_ref().clone();
             if let Some(num_seats) = num_seats {
                 config.num_block_producer_seats = *num_seats;
-                config.validator_selection_config.num_chunk_producer_seats = *num_seats;
-                config.validator_selection_config.num_chunk_validator_seats = *num_seats;
+                config.num_chunk_producer_seats = *num_seats;
+                config.num_chunk_validator_seats = *num_seats;
             }
             new_epoch_configs.insert(version, Arc::new(config));
         }

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -919,15 +919,10 @@ impl ForkNetworkCommand {
             minimum_stake_divisor: epoch_config.minimum_stake_divisor,
             protocol_upgrade_stake_threshold: epoch_config.protocol_upgrade_stake_threshold,
             shard_layout: epoch_config.shard_layout.clone(),
-            num_chunk_only_producer_seats: epoch_config
-                .validator_selection_config
-                .num_chunk_only_producer_seats,
-            minimum_validators_per_shard: epoch_config
-                .validator_selection_config
-                .minimum_validators_per_shard,
-            minimum_stake_ratio: epoch_config.validator_selection_config.minimum_stake_ratio,
+            num_chunk_only_producer_seats: epoch_config.num_chunk_only_producer_seats,
+            minimum_validators_per_shard: epoch_config.minimum_validators_per_shard,
+            minimum_stake_ratio: epoch_config.minimum_stake_ratio,
             shuffle_shard_assignment_for_chunk_producers: epoch_config
-                .validator_selection_config
                 .shuffle_shard_assignment_for_chunk_producers,
             dynamic_resharding: false,
             protocol_version: genesis_protocol_version,
@@ -943,14 +938,9 @@ impl ForkNetworkCommand {
             total_supply: original_config.total_supply,
             transaction_validity_period: original_config.transaction_validity_period,
             use_production_config: original_config.use_production_config,
-            num_chunk_producer_seats: epoch_config
-                .validator_selection_config
-                .num_chunk_producer_seats,
-            num_chunk_validator_seats: epoch_config
-                .validator_selection_config
-                .num_chunk_validator_seats,
+            num_chunk_producer_seats: epoch_config.num_chunk_producer_seats,
+            num_chunk_validator_seats: epoch_config.num_chunk_validator_seats,
             chunk_producer_assignment_changes_limit: epoch_config
-                .validator_selection_config
                 .chunk_producer_assignment_changes_limit,
         };
 

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -993,7 +993,7 @@ pub(crate) fn print_epoch_analysis(
             // chain/epoch-manager/src/validator_selection.rs:227:13.
             // Probably has something to do with extreme case where all
             // proposals are selected.
-            next_next_epoch_config.validator_selection_config.num_chunk_validator_seats = 100;
+            next_next_epoch_config.num_chunk_validator_seats = 100;
         }
     }
 


### PR DESCRIPTION
This PR does not change the `EpochConfig` functionality, it just flatten the `EpochConfig` struct.
Cetralize the epoch config contructors.

This PR is a precursor to the config overriedes on `EpochConfigs`.
