### PR TITLE
apply-range: add ability to operate with memtries & a new benchmark mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,7 +1423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
- "unicode-width",
+ "unicode-width 0.1.9",
 ]
 
 [[package]]
@@ -1473,15 +1473,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.5"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "unicode-width",
- "windows-sys 0.42.0",
+ "unicode-width 0.1.9",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3171,15 +3171,16 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.15.0"
+version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
+checksum = "cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281"
 dependencies = [
  "console",
- "lazy_static",
  "number_prefix",
+ "portable-atomic",
  "rayon",
- "regex",
+ "unicode-width 0.2.0",
+ "web-time",
 ]
 
 [[package]]
@@ -4747,6 +4748,7 @@ dependencies = [
  "anyhow",
  "borsh",
  "clap",
+ "indicatif",
  "itertools 0.12.1",
  "near-chain",
  "near-chain-configs",
@@ -5545,9 +5547,9 @@ dependencies = [
 
 [[package]]
 name = "number_prefix"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -6047,6 +6049,12 @@ name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
+name = "portable-atomic"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "postcard"
@@ -7466,6 +7474,7 @@ dependencies = [
  "chrono",
  "clap",
  "cloud-storage",
+ "indicatif",
  "insta",
  "itertools 0.12.1",
  "near-chain",
@@ -8283,6 +8292,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8896,7 +8911,7 @@ checksum = "9bb4f48a8b083dbc50e291e430afb8f524092bb00428957bcc63f49f856c64ac"
 dependencies = [
  "leb128",
  "memchr",
- "unicode-width",
+ "unicode-width 0.1.9",
 ]
 
 [[package]]
@@ -9021,21 +9036,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -9094,12 +9094,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
@@ -9118,12 +9112,6 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
@@ -9139,12 +9127,6 @@ name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9172,12 +9154,6 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
@@ -9196,12 +9172,6 @@ checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
@@ -9211,12 +9181,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9235,12 +9199,6 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,7 +199,7 @@ hyper = { version = "0.14", features = ["full"] }
 hyper-tls = "0.5.0"
 im = "15"
 indexmap = "2"
-indicatif = { version = "0.15.0", features = ["with_rayon"] }
+indicatif = { version = "0.17.0", features = ["rayon"] }
 insta = { version = "1.41.0", features = ["json", "yaml", "redactions"] }
 integration-tests = { path = "integration-tests" }
 inventory = "0.3.15"

--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -146,7 +146,9 @@ pub fn load_trie_from_flat_state_and_delta(
     // already loaded.
     let mut sorted_deltas: BTreeSet<(BlockHeight, CryptoHash, CryptoHash)> = Default::default();
     for delta in flat_store.get_all_deltas_metadata(shard_uid).unwrap() {
-        sorted_deltas.insert((delta.block.height, delta.block.hash, delta.block.prev_hash));
+        if delta.block.height <= flat_head.height {
+            sorted_deltas.insert((delta.block.height, delta.block.hash, delta.block.prev_hash));
+        }
     }
 
     debug!(target: "memtrie", %shard_uid, "{} deltas to apply", sorted_deltas.len());

--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -146,9 +146,7 @@ pub fn load_trie_from_flat_state_and_delta(
     // already loaded.
     let mut sorted_deltas: BTreeSet<(BlockHeight, CryptoHash, CryptoHash)> = Default::default();
     for delta in flat_store.get_all_deltas_metadata(shard_uid).unwrap() {
-        if delta.block.height <= flat_head.height {
-            sorted_deltas.insert((delta.block.height, delta.block.hash, delta.block.prev_hash));
-        }
+        sorted_deltas.insert((delta.block.height, delta.block.hash, delta.block.prev_hash));
     }
 
     debug!(target: "memtrie", %shard_uid, "{} deltas to apply", sorted_deltas.len());

--- a/deny.toml
+++ b/deny.toml
@@ -136,4 +136,7 @@ skip = [
     { name = "thiserror", version = "<2.0" },
     { name = "thiserror-impl", version = "<2.0" },
     { name = "derive_more", version = "<1" },
+
+    # indicatif brings in a newer version
+    { name = "unicode-width", version = "<0.2" },
 ]

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -164,7 +164,7 @@ impl GenesisBuilder {
         let bar = ProgressBar::new(total_accounts_num as _);
         bar.set_style(ProgressStyle::default_bar().template(
             "[elapsed {elapsed_precise} remaining {eta_precise}] Writing into storage {bar} {pos:>7}/{len:7}",
-        ));
+        ).unwrap());
         // Add records in chunks of 3000 per shard for memory efficiency reasons.
         for i in 0..total_accounts_num {
             let account_id = get_account_id(i);

--- a/nearcore/src/download_file.rs
+++ b/nearcore/src/download_file.rs
@@ -56,14 +56,15 @@ async fn download_file_impl(
         bar.set_style(
             ProgressStyle::default_bar().template(
                 "{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} [{bytes_per_sec}] ({eta})"
-            ).progress_chars("#>-")
+            ).unwrap().progress_chars("#>-")
         );
         bar
     } else {
         let bar = ProgressBar::new_spinner();
         bar.set_style(
             ProgressStyle::default_bar()
-                .template("{spinner:.green} [{elapsed_precise}] {bytes} [{bytes_per_sec}]"),
+                .template("{spinner:.green} [{elapsed_precise}] {bytes} [{bytes_per_sec}]")
+                .unwrap(),
         );
         bar
     };

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -50,7 +50,7 @@ enum SubCommand {
     /// The trie is constructed for the block height equal to flat_head
     ConstructTrieFromFlat(ConstructTriedFromFlatCmd),
 
-    /// Move flat head forward.
+    /// Move flat head forward or backward.
     MoveFlatHead(MoveFlatHeadCmd),
 }
 
@@ -110,8 +110,9 @@ pub enum MoveFlatHeadMode {
         new_flat_head_height: BlockHeight,
     },
     /// Moves head back by specific number of blocks.
-    /// Note: it doesn't record deltas on the way and should be used
-    /// only for replaying chain forward.
+    ///
+    /// Note: it doesn't record deltas on the way and should be used only for replaying chain
+    /// forward.
     Back {
         #[clap(long)]
         blocks: usize,

--- a/tools/replay-archive/Cargo.toml
+++ b/tools/replay-archive/Cargo.toml
@@ -16,6 +16,7 @@ anyhow.workspace = true
 borsh.workspace = true
 clap.workspace = true
 itertools.workspace = true
+indicatif.workspace = true
 
 near-chain.workspace = true
 near-chain-primitives.workspace = true

--- a/tools/state-viewer/Cargo.toml
+++ b/tools/state-viewer/Cargo.toml
@@ -33,6 +33,7 @@ tempfile.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 yansi.workspace = true
+indicatif.workspace = true
 
 near-time.workspace = true
 near-chain-configs.workspace = true

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -16,7 +16,7 @@ use near_primitives::trie_key::TrieKey;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{BlockHeight, ShardId};
 use near_store::adapter::StoreAdapter;
-use near_store::flat::{BlockInfo, FlatStateChanges, FlatStorageReadyStatus, FlatStorageStatus};
+use near_store::flat::{BlockInfo, FlatStateChanges, FlatStorageStatus};
 use near_store::{DBCol, Store};
 use nearcore::NightshadeRuntime;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -289,16 +289,16 @@ impl ApplyChunkCmd {
 #[derive(clap::Parser, Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ApplyRangeMode {
     /// Applies chunks one after another in order of increasing heights.
+    ///
+    /// Great for profiling.
     Sequential,
     /// Applies chunks in parallel.
+    ///
     /// Useful for quick correctness check of applying chunks by comparing
     /// results with `ChunkExtra`s.
     Parallel,
-    /// Sequentially applies chunks from flat storage head until chain
-    /// final head, moving flat head forward. Use in combination with
-    /// `MoveFlatHeadCmd` and `MoveFlatHeadMode::Back`.
-    /// Useful for benchmarking.
-    Benchmarking,
+    /// Applies a single block repeatedly without committing any state changes.
+    Benchmark,
 }
 
 #[derive(clap::Parser)]
@@ -332,7 +332,7 @@ impl ApplyRangeCmd {
         store: Store,
         node_storage: NodeStorage,
     ) {
-        if matches!(self.mode, ApplyRangeMode::Benchmarking) && self.save_state.is_some() {
+        if matches!(self.mode, ApplyRangeMode::Benchmark) && self.save_state.is_some() {
             panic!("Persisting trie nodes in storage is not compatible with benchmark mode!");
         }
         apply_range(

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -208,7 +208,10 @@ pub enum StorageSource {
     /// Use the data stored in trie, but without paying extra gas costs.
     /// This could be used to simulate flat storage when the latter is not present.
     TrieFree,
+    #[value(alias("flat"))]
     FlatStorage,
+    /// Implies flat storage and loads the memtries as well.
+    Memtrie,
 }
 
 impl StorageSource {
@@ -217,6 +220,9 @@ impl StorageSource {
             StorageSource::Trie => RuntimeStorageConfig::new(state_root, false),
             StorageSource::TrieFree => RuntimeStorageConfig::new_with_db_trie_only(state_root),
             StorageSource::FlatStorage => RuntimeStorageConfig::new(state_root, true),
+            // This is the same as FlatStorage handling. That's because memtrie initialization
+            // happens as part of `ShardTries::load_mem_trie` function call.
+            StorageSource::Memtrie => RuntimeStorageConfig::new(state_root, true),
         }
     }
 }

--- a/tools/state-viewer/src/progress_reporter.rs
+++ b/tools/state-viewer/src/progress_reporter.rs
@@ -7,23 +7,36 @@ pub fn timestamp_ms() -> u64 {
 
 const TGAS: u64 = 1024 * 1024 * 1024 * 1024;
 
+pub fn default_indicatif(len: Option<u64>) -> indicatif::ProgressBar {
+    indicatif::ProgressBar::with_draw_target(
+        len,
+        indicatif::ProgressDrawTarget::stderr_with_hz(5)
+    ).with_style(indicatif::ProgressStyle::with_template(
+        "{prefix}{pos}/{len} blocks applied in {elapsed} at a rate of {per_sec}. {eta} remaining. {msg}"
+    ).unwrap())
+}
+
 pub struct ProgressReporter {
     pub cnt: AtomicU64,
-    // Timestamp to make relative measurements of block processing speed (in ms)
-    pub ts: AtomicU64,
-    pub all: u64,
     pub skipped: AtomicU64,
     // Fields below get cleared after each print.
     pub empty_blocks: AtomicU64,
     pub non_empty_blocks: AtomicU64,
     // Total gas burned (in TGas)
     pub tgas_burned: AtomicU64,
+    pub indicatif: indicatif::ProgressBar,
 }
 
 impl ProgressReporter {
-    pub fn inc_and_report_progress(&self, gas_burnt: u64) {
-        let ProgressReporter { cnt, ts, all, skipped, empty_blocks, non_empty_blocks, tgas_burned } =
-            self;
+    pub fn inc_and_report_progress(&self, block_height: u64, gas_burnt: u64) {
+        let ProgressReporter {
+            cnt,
+            skipped,
+            empty_blocks,
+            non_empty_blocks,
+            tgas_burned,
+            indicatif,
+        } = self;
         if gas_burnt == 0 {
             empty_blocks.fetch_add(1, Ordering::Relaxed);
         } else {
@@ -33,12 +46,9 @@ impl ProgressReporter {
 
         const PRINT_PER: u64 = 100;
         let prev = cnt.fetch_add(1, Ordering::Relaxed);
-        if (prev + 1) % PRINT_PER == 0 {
-            let prev_ts = ts.load(Ordering::Relaxed);
-            let new_ts = timestamp_ms();
-            let per_second = (PRINT_PER as f64 / (new_ts - prev_ts) as f64) * 1000.0;
-            ts.store(new_ts, Ordering::Relaxed);
-            let secs_remaining = (all - prev) as f64 / per_second;
+        let current = 1 + prev;
+        indicatif.set_position(current);
+        if current % PRINT_PER == 0 {
             let avg_gas = if non_empty_blocks.load(Ordering::Relaxed) == 0 {
                 0.0
             } else {
@@ -46,15 +56,12 @@ impl ProgressReporter {
                     / non_empty_blocks.load(Ordering::Relaxed) as f64
             };
 
-            println!(
-                "Processed {} blocks, {:.4} blocks per second ({} skipped), {:.2} secs remaining {} empty blocks {:.2} avg gas per non-empty block",
-                prev + 1,
-                per_second,
-                skipped.load(Ordering::Relaxed),
-                secs_remaining,
-                empty_blocks.load(Ordering::Relaxed),
-                avg_gas,
-            );
+            indicatif.set_message(format!(
+                "Skipped {skipped} blocks. \
+                 Over last 100 blocks to {block_height}: {empty} empty blocks, {avg_gas:.2} avg gas per non-empty block",
+                skipped = skipped.load(Ordering::Relaxed),
+                empty = empty_blocks.load(Ordering::Relaxed),
+            ));
             empty_blocks.store(0, Ordering::Relaxed);
             non_empty_blocks.store(0, Ordering::Relaxed);
             tgas_burned.store(0, Ordering::Relaxed);

--- a/tools/state-viewer/src/progress_reporter.rs
+++ b/tools/state-viewer/src/progress_reporter.rs
@@ -58,7 +58,7 @@ impl ProgressReporter {
 
             indicatif.set_message(format!(
                 "Skipped {skipped} blocks. \
-                 Over last 100 blocks to {block_height}: {empty} empty blocks, {avg_gas:.2} avg gas per non-empty block",
+                 Over last 100 blocks to height {block_height}: {empty} empty blocks, averaging {avg_gas:.2} Tgas per non-empty block",
                 skipped = skipped.load(Ordering::Relaxed),
                 empty = empty_blocks.load(Ordering::Relaxed),
             ));


### PR DESCRIPTION
With this PR the original `benchmarking` functionality has been subsumed by the `sequential` mode which has been extended to operate on flat and memtrie storage modes.

`benchmark` is then changed to not commit any results to the storage, effectively leading to the same starting block being applied over and over again, thus ideally demonstrating the time spent inside `Runtime::apply`.

I've seen this to sometimes handle a huge number of blocks per second which would make the output somewhat difficult keep track of, so I went ahead and integrated indicatif-based progress bar (which then also comes with a built-in mechanism to estimate duration and rate of blocks per second.)