### PR TITLE
refactor: move account_id_to_shard_id to ShardLayout

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -63,7 +63,7 @@ use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::merkle::{merklize, verify_path, PartialMerkleTree};
 use near_primitives::receipt::Receipt;
 use near_primitives::sandbox::state_patch::SandboxStatePatch;
-use near_primitives::shard_layout::{account_id_to_shard_id, ShardLayout, ShardUId};
+use near_primitives::shard_layout::{ShardLayout, ShardUId};
 use near_primitives::sharding::{
     ChunkHash, ChunkHashHeight, EncodedShardChunk, ReceiptList, ReceiptProof, ShardChunk,
     ShardChunkHeader, ShardProof, StateSyncInfo,
@@ -4451,7 +4451,7 @@ impl Chain {
     ) -> HashMap<ShardId, Vec<Receipt>> {
         let mut result = HashMap::new();
         for receipt in receipts {
-            let shard_id = account_id_to_shard_id(receipt.receiver_id(), shard_layout);
+            let shard_id = shard_layout.account_id_to_shard_id(receipt.receiver_id());
             let entry = result.entry(shard_id).or_insert_with(Vec::new);
             entry.push(receipt)
         }
@@ -4476,7 +4476,7 @@ impl Chain {
         for receipt in receipts {
             let &mut shard_id = cache
                 .entry(receipt.receiver_id())
-                .or_insert_with(|| account_id_to_shard_id(receipt.receiver_id(), shard_layout));
+                .or_insert_with(|| shard_layout.account_id_to_shard_id(receipt.receiver_id()));
             // This unwrap should be safe as we pre-populated the map with all
             // valid shard ids.
             let shard_index = shard_layout.get_shard_index(shard_id).unwrap();

--- a/chain/chain/src/flat_storage_resharder.rs
+++ b/chain/chain/src/flat_storage_resharder.rs
@@ -19,7 +19,7 @@ use crate::{ChainStore, ChainStoreAccess};
 use itertools::Itertools;
 use near_primitives::block::Tip;
 use near_primitives::hash::CryptoHash;
-use near_primitives::shard_layout::{account_id_to_shard_id, ShardLayout};
+use near_primitives::shard_layout::ShardLayout;
 use near_primitives::state::FlatStateValue;
 use near_primitives::trie_key::col::{self};
 use near_primitives::trie_key::trie_key_parsers::{
@@ -899,7 +899,7 @@ fn copy_kv_to_child(
         &split_params;
     // Derive the shard uid for this account in the new shard layout.
     let account_id = account_id_parser(&key)?;
-    let new_shard_id = account_id_to_shard_id(&account_id, shard_layout);
+    let new_shard_id = shard_layout.account_id_to_shard_id(&account_id);
     let new_shard_uid = ShardUId::from_shard_id_and_layout(new_shard_id, &shard_layout);
 
     // Sanity check we are truly writing to one of the expected children shards.

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -372,7 +372,7 @@ impl TestEnv {
         let shard_layout = self.epoch_manager.get_shard_layout_from_prev_block(&new_hash).unwrap();
         let mut new_receipts = HashMap::<_, Vec<Receipt>>::new();
         for receipt in all_receipts {
-            let shard_id = account_id_to_shard_id(receipt.receiver_id(), &shard_layout);
+            let shard_id = shard_layout.account_id_to_shard_id(receipt.receiver_id());
             new_receipts.entry(shard_id).or_default().push(receipt);
         }
         self.last_receipts = new_receipts;

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -14,7 +14,6 @@ use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{MerklePath, PartialMerkleTree};
 use near_primitives::receipt::Receipt;
-use near_primitives::shard_layout::account_id_to_shard_id;
 use near_primitives::shard_layout::{get_block_shard_uid, ShardLayout, ShardUId};
 use near_primitives::sharding::{
     ChunkHash, EncodedShardChunk, PartialEncodedChunk, ReceiptProof, ShardChunk, ShardChunkHeader,
@@ -380,7 +379,7 @@ fn filter_incoming_receipts_for_shard(
         let ReceiptProof(receipts, shard_proof) = receipt_proof.clone();
         for receipt in receipts {
             let receiver_shard_id =
-                account_id_to_shard_id(receipt.receiver_id(), target_shard_layout);
+                target_shard_layout.account_id_to_shard_id(receipt.receiver_id());
             if receiver_shard_id == target_shard_id {
                 tracing::trace!(target: "chain", receipt_id=?receipt.receipt_id(), "including receipt");
                 filtered_receipts.push(receipt);

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -286,7 +286,7 @@ mod test {
 
     use crate::Chain;
 
-    use near_primitives::shard_layout::{account_id_to_shard_id, ShardLayout};
+    use near_primitives::shard_layout::ShardLayout;
 
     fn naive_build_receipt_hashes(
         receipts: &[Receipt],
@@ -297,7 +297,7 @@ mod test {
             let shard_receipts: Vec<Receipt> = receipts
                 .iter()
                 .filter(|&receipt| {
-                    account_id_to_shard_id(receipt.receiver_id(), shard_layout) == shard_id
+                    shard_layout.account_id_to_shard_id(receipt.receiver_id()) == shard_id
                 })
                 .cloned()
                 .collect();

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -27,7 +27,6 @@ use near_primitives::epoch_manager::ValidatorSelectionConfig;
 use near_primitives::errors::{EpochError, InvalidTxError};
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::receipt::{ActionReceipt, Receipt, ReceiptEnum, ReceiptV0};
-use near_primitives::shard_layout;
 use near_primitives::shard_layout::{ShardLayout, ShardUId};
 use near_primitives::sharding::ChunkHash;
 use near_primitives::state_part::PartId;
@@ -405,7 +404,7 @@ impl KeyValueRuntime {
 pub fn account_id_to_shard_id(account_id: &AccountId, num_shards: NumShards) -> ShardId {
     #[allow(deprecated)]
     let shard_layout = ShardLayout::v0(num_shards, 0);
-    shard_layout::account_id_to_shard_id(account_id, &shard_layout)
+    shard_layout.account_id_to_shard_id(account_id)
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -8,7 +8,7 @@ use near_primitives::epoch_info::EpochInfo;
 use near_primitives::epoch_manager::{EpochConfig, ShardConfig};
 use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
-use near_primitives::shard_layout::{account_id_to_shard_id, ShardLayout};
+use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
 use near_primitives::stateless_validation::chunk_endorsement::ChunkEndorsement;
 use near_primitives::stateless_validation::contract_distribution::{
@@ -545,7 +545,7 @@ impl EpochManagerAdapter for EpochManagerHandle {
     ) -> Result<ShardId, EpochError> {
         let epoch_manager = self.read();
         let shard_layout = epoch_manager.get_shard_layout(epoch_id)?;
-        Ok(account_id_to_shard_id(account_id, &shard_layout))
+        Ok(shard_layout.account_id_to_shard_id(account_id))
     }
 
     fn account_id_to_shard_info(
@@ -555,7 +555,7 @@ impl EpochManagerAdapter for EpochManagerHandle {
     ) -> Result<ShardUIdAndIndex, EpochError> {
         let epoch_manager = self.read();
         let shard_layout = epoch_manager.get_shard_layout(epoch_id)?;
-        let shard_id = account_id_to_shard_id(account_id, &shard_layout);
+        let shard_id = shard_layout.account_id_to_shard_id(account_id);
         let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
         let shard_index = shard_layout.get_shard_index(shard_id)?;
         Ok(ShardUIdAndIndex { shard_uid, shard_index })

--- a/core/store/src/genesis/initialization.rs
+++ b/core/store/src/genesis/initialization.rs
@@ -13,7 +13,7 @@ use near_chain_configs::{Genesis, GenesisContents};
 use near_parameters::RuntimeConfigStore;
 use near_primitives::{
     epoch_manager::EpochConfig,
-    shard_layout::{account_id_to_shard_id, ShardLayout},
+    shard_layout::ShardLayout,
     state_record::{state_record_to_account_id, StateRecord},
     types::{AccountId, NumShards, ShardId, StateRoot},
 };
@@ -151,7 +151,7 @@ fn genesis_state_from_genesis(
                 .validators
                 .iter()
                 .filter_map(|account_info| {
-                    if account_id_to_shard_id(&account_info.account_id, &shard_layout) == shard_id {
+                    if shard_layout.account_id_to_shard_id(&account_info.account_id) == shard_id {
                         Some((
                             account_info.account_id.clone(),
                             account_info.public_key.clone(),
@@ -177,5 +177,5 @@ fn genesis_state_from_genesis(
 }
 
 fn state_record_to_shard_id(state_record: &StateRecord, shard_layout: &ShardLayout) -> ShardId {
-    account_id_to_shard_id(state_record_to_account_id(state_record), shard_layout)
+    shard_layout.account_id_to_shard_id(state_record_to_account_id(state_record))
 }

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -15,7 +15,7 @@ use near_primitives::block::{genesis_chunks, Tip};
 use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::epoch_block_info::BlockInfo;
 use near_primitives::hash::{hash, CryptoHash};
-use near_primitives::shard_layout::{account_id_to_shard_id, ShardUId};
+use near_primitives::shard_layout::ShardUId;
 use near_primitives::state_record::StateRecord;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{AccountId, Balance, EpochId, ShardId, StateChangeCause, StateRoot};
@@ -328,7 +328,7 @@ impl GenesisBuilder {
     fn add_additional_account(&mut self, account_id: AccountId) -> Result<()> {
         let testing_init_balance: Balance = 10u128.pow(30);
         let testing_init_stake: Balance = 0;
-        let shard_id = account_id_to_shard_id(&account_id, &self.genesis.config.shard_layout);
+        let shard_id = self.genesis.config.shard_layout.account_id_to_shard_id(&account_id);
         let mut records = self.unflushed_records.remove(&shard_id).unwrap_or_default();
         let mut state_update =
             self.state_updates.remove(&shard_id).expect("State update should have been added");

--- a/integration-tests/src/test_loop/tests/bandwidth_scheduler.rs
+++ b/integration-tests/src/test_loop/tests/bandwidth_scheduler.rs
@@ -26,7 +26,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{
     ActionReceipt, Receipt, ReceiptEnum, ReceiptOrStateStoredReceipt, ReceiptV0,
 };
-use near_primitives::shard_layout::{account_id_to_shard_id, ShardLayout};
+use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::test_utils::create_user_test_signer;
 use near_primitives::transaction::SignedTransaction;
@@ -75,7 +75,7 @@ fn slow_test_bandwidth_scheduler_request_generation() {
     let workload_accounts: Vec<AccountId> =
         (0..num_shards).map(|i| format!("shard{}_workload_sender", i).parse().unwrap()).collect();
     let workload_accounts_shards: BTreeSet<ShardId> =
-        workload_accounts.iter().map(|a| account_id_to_shard_id(a, &shard_layout)).collect();
+        workload_accounts.iter().map(|a| shard_layout.account_id_to_shard_id(a)).collect();
     assert_eq!(workload_accounts_shards, shard_layout.shard_ids().collect::<BTreeSet<_>>());
 
     // Account of the only producer/validator in the chain

--- a/integration-tests/src/tests/client/features/congestion_control.rs
+++ b/integration-tests/src/tests/client/features/congestion_control.rs
@@ -12,7 +12,7 @@ use near_primitives::errors::{
     ActionErrorKind, FunctionCallError, InvalidTxError, TxExecutionError,
 };
 use near_primitives::hash::CryptoHash;
-use near_primitives::shard_layout::{account_id_to_shard_id, ShardLayout};
+use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::{ShardChunk, ShardChunkHeader};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{EpochId, ShardId};
@@ -196,7 +196,7 @@ fn check_congestion_info(env: &TestEnv, check_congested_protocol_upgrade: bool) 
 
     let shard_layout = client.epoch_manager.get_shard_layout(&EpochId::default()).unwrap();
     let contract_id = CONTRACT_ID.parse().unwrap();
-    let contract_shard_id = account_id_to_shard_id(&contract_id, &shard_layout);
+    let contract_shard_id = shard_layout.account_id_to_shard_id(&contract_id);
 
     for height in genesis_height..head_height + 1 {
         let block = client.chain.get_block_by_height(height);
@@ -698,9 +698,9 @@ fn measure_remote_tx_limit(
 
     let tip = env.clients[0].chain.head().unwrap();
     let shard_layout = env.clients[0].epoch_manager.get_shard_layout(&tip.epoch_id).unwrap();
-    let contract_shard_id = account_id_to_shard_id(&contract_id, &shard_layout);
-    let remote_shard_id = account_id_to_shard_id(&remote_id, &shard_layout);
-    let dummy_shard_id = account_id_to_shard_id(&dummy_id, &shard_layout);
+    let contract_shard_id = shard_layout.account_id_to_shard_id(&contract_id);
+    let remote_shard_id = shard_layout.account_id_to_shard_id(&remote_id);
+    let dummy_shard_id = shard_layout.account_id_to_shard_id(&dummy_id);
 
     // For a clean test setup, ensure we use 3 different shards.
     assert_ne!(remote_shard_id, contract_shard_id);
@@ -740,8 +740,8 @@ fn measure_tx_limit(
         InMemorySigner::from_seed(contract_id.clone(), KeyType::ED25519, contract_id.as_str());
     let tip = env.clients[0].chain.head().unwrap();
     let shard_layout = env.clients[0].epoch_manager.get_shard_layout(&tip.epoch_id).unwrap();
-    let remote_shard_id = account_id_to_shard_id(&remote_id, &shard_layout);
-    let contract_shard_id = account_id_to_shard_id(&contract_id, &shard_layout);
+    let remote_shard_id = shard_layout.account_id_to_shard_id(&remote_id);
+    let contract_shard_id = shard_layout.account_id_to_shard_id(&contract_id);
 
     // put in enough transactions to create up to
     // `reject_tx_congestion_threshold` incoming congestion

--- a/integration-tests/src/tests/client/features/stateless_validation.rs
+++ b/integration-tests/src/tests/client/features/stateless_validation.rs
@@ -14,7 +14,7 @@ use near_primitives::account::{AccessKeyPermission, FunctionCallPermission};
 use near_primitives::action::{Action, AddKeyAction, TransferAction};
 use near_primitives::epoch_manager::AllEpochConfigTestOverrides;
 use near_primitives::num_rational::Rational32;
-use near_primitives::shard_layout::{account_id_to_shard_id, ShardLayout};
+use near_primitives::shard_layout::ShardLayout;
 use near_primitives::state_record::StateRecord;
 use near_primitives::stateless_validation::state_witness::ChunkStateWitness;
 use near_primitives::test_utils::{create_test_signer, create_user_test_signer};
@@ -356,7 +356,7 @@ fn get_accounts_and_shard_layout(
     // The number of accounts in each shard.
     let mut shard_account_count: HashMap<ShardId, u32> = HashMap::new();
     for account in &accounts[..num_validators] {
-        let shard_id = account_id_to_shard_id(account, &shard_layout);
+        let shard_id = shard_layout.account_id_to_shard_id(account);
         *shard_account_count.entry(shard_id).or_default() += 1;
     }
     for shard_id in shard_layout.shard_ids() {

--- a/integration-tests/src/tests/client/features/yield_resume.rs
+++ b/integration-tests/src/tests/client/features/yield_resume.rs
@@ -6,7 +6,6 @@ use near_o11y::testonly::init_test_logger;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
 use near_primitives::receipt::ReceiptEnum::{PromiseResume, PromiseYield};
-use near_primitives::shard_layout::account_id_to_shard_id;
 use near_primitives::transaction::{
     Action, DeployContractAction, FunctionCallAction, SignedTransaction,
 };
@@ -21,7 +20,7 @@ fn get_outgoing_receipts_from_latest_block(env: &TestEnv) -> Vec<Receipt> {
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let epoch_id = *genesis_block.header().epoch_id();
     let shard_layout = env.clients[0].epoch_manager.get_shard_layout(&epoch_id).unwrap();
-    let shard_id = account_id_to_shard_id(&"test0".parse::<AccountId>().unwrap(), &shard_layout);
+    let shard_id = shard_layout.account_id_to_shard_id(&"test0".parse::<AccountId>().unwrap());
     let last_block_hash = env.clients[0].chain.head().unwrap().last_block_hash;
     let last_block_height = env.clients[0].chain.head().unwrap().height;
 

--- a/integration-tests/src/tests/client/features/yield_timeouts.rs
+++ b/integration-tests/src/tests/client/features/yield_timeouts.rs
@@ -6,7 +6,6 @@ use near_o11y::testonly::init_test_logger;
 use near_parameters::config::TEST_CONFIG_YIELD_TIMEOUT_LENGTH;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::ReceiptEnum::{PromiseResume, PromiseYield};
-use near_primitives::shard_layout::account_id_to_shard_id;
 use near_primitives::transaction::{
     Action, DeployContractAction, FunctionCallAction, SignedTransaction,
 };
@@ -30,7 +29,7 @@ fn find_yield_data_ids_from_latest_block(env: &TestEnv) -> Vec<CryptoHash> {
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let epoch_id = *genesis_block.header().epoch_id();
     let shard_layout = env.clients[0].epoch_manager.get_shard_layout(&epoch_id).unwrap();
-    let shard_id = account_id_to_shard_id(&"test0".parse::<AccountId>().unwrap(), &shard_layout);
+    let shard_id = shard_layout.account_id_to_shard_id(&"test0".parse::<AccountId>().unwrap());
     let last_block_hash = env.clients[0].chain.head().unwrap().last_block_hash;
     let last_block_height = env.clients[0].chain.head().unwrap().height;
 

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -42,7 +42,7 @@ use near_primitives::errors::{ActionError, ActionErrorKind, InvalidTxError};
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::merkle::{verify_hash, PartialMerkleTree};
 use near_primitives::receipt::DelayedReceiptIndices;
-use near_primitives::shard_layout::{account_id_to_shard_id, get_block_shard_uid, ShardUId};
+use near_primitives::shard_layout::{get_block_shard_uid, ShardUId};
 use near_primitives::sharding::{ShardChunkHeader, ShardChunkHeaderInner, ShardChunkHeaderV3};
 use near_primitives::state_part::PartId;
 use near_primitives::state_sync::StatePartKey;
@@ -1242,8 +1242,8 @@ fn test_bad_chunk_mask() {
     tracing::info!(target: "test", ?shard_layout, "shard layout");
 
     let [s0, s1] = shard_layout.shard_ids().collect_vec()[..] else { panic!("Expected 2 shards") };
-    assert_eq!(s0, account_id_to_shard_id(&account0, &shard_layout));
-    assert_eq!(s1, account_id_to_shard_id(&account1, &shard_layout));
+    assert_eq!(s0, shard_layout.account_id_to_shard_id(&account0));
+    assert_eq!(s1, shard_layout.account_id_to_shard_id(&account1));
 
     // Generate 4 blocks
     let shard_id = s0;

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -1538,7 +1538,6 @@ mod tests {
     use near_async::time::Duration;
     use near_chain_configs::{GCConfig, Genesis, GenesisValidationMode};
     use near_crypto::InMemorySigner;
-    use near_primitives::shard_layout::account_id_to_shard_id;
     use near_primitives::types::{AccountId, NumShards, ShardId};
     use tempfile::tempdir;
 
@@ -1580,19 +1579,19 @@ mod tests {
             panic!("Expected 3 shards, got {:?}", shard_ids);
         };
         assert_eq!(
-            account_id_to_shard_id(&AccountId::from_str("foobar.near").unwrap(), &shard_layout),
+            shard_layout.account_id_to_shard_id(&AccountId::from_str("foobar.near").unwrap()),
             s0
         );
         assert_eq!(
-            account_id_to_shard_id(&AccountId::from_str("test0.near").unwrap(), &shard_layout,),
+            shard_layout.account_id_to_shard_id(&AccountId::from_str("test0.near").unwrap()),
             s0
         );
         assert_eq!(
-            account_id_to_shard_id(&AccountId::from_str("test1.near").unwrap(), &shard_layout,),
+            shard_layout.account_id_to_shard_id(&AccountId::from_str("test1.near").unwrap()),
             s1
         );
         assert_eq!(
-            account_id_to_shard_id(&AccountId::from_str("test2.near").unwrap(), &shard_layout,),
+            shard_layout.account_id_to_shard_id(&AccountId::from_str("test2.near").unwrap()),
             s2
         );
     }

--- a/tools/database/src/analyse_gas_usage.rs
+++ b/tools/database/src/analyse_gas_usage.rs
@@ -9,7 +9,7 @@ use near_epoch_manager::EpochManager;
 use nearcore::config::load_config;
 
 use near_primitives::hash::CryptoHash;
-use near_primitives::shard_layout::{account_id_to_shard_id, ShardUId};
+use near_primitives::shard_layout::ShardUId;
 use near_primitives::types::{AccountId, BlockHeight};
 
 use nearcore::open_storage;
@@ -243,7 +243,7 @@ fn get_gas_usage_in_block(
                 .outcome;
 
             // Sanity check - make sure that the executor of this outcome belongs to this shard
-            let account_shard_id = account_id_to_shard_id(&outcome.executor_id, &shard_layout);
+            let account_shard_id = shard_layout.account_id_to_shard_id(&outcome.executor_id);
             assert_eq!(account_shard_id, shard_id);
 
             gas_usage_in_shard.add_used_gas(outcome.executor_id, outcome.gas_burnt.into());

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -7,7 +7,7 @@ use near_chain::{ChainStore, ChainStoreAccess};
 use near_chain_configs::GenesisValidationMode;
 use near_epoch_manager::{EpochManager, EpochManagerAdapter, EpochManagerHandle};
 use near_primitives::errors::EpochError;
-use near_primitives::shard_layout::{account_id_to_shard_id, ShardVersion};
+use near_primitives::shard_layout::ShardVersion;
 use near_primitives::state::FlatStateValue;
 use near_primitives::types::{BlockHeight, ShardId};
 use near_store::adapter::flat_store::FlatStoreAdapter;
@@ -512,7 +512,7 @@ impl FlatStorageCommand {
                     )?;
                 let maybe_trie_key = match maybe_account_id {
                     Some(account_id) => {
-                        let account_shard_id = account_id_to_shard_id(&account_id, &shard_layout);
+                        let account_shard_id = shard_layout.account_id_to_shard_id(&account_id);
                         if shard_id == account_shard_id {
                             Some(maybe_trie_key)
                         } else {

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -13,7 +13,6 @@ use near_primitives::block::MaybeNew;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::combine_hash;
 use near_primitives::receipt::Receipt;
-use near_primitives::shard_layout;
 use near_primitives::sharding::{ChunkHash, ReceiptProof};
 use near_primitives::state_sync::ReceiptProofResponse;
 use near_primitives::types::{BlockHeight, ShardId};
@@ -227,8 +226,7 @@ fn find_tx_or_receipt(
             if &receipt.get_hash() == hash {
                 let shard_layout =
                     epoch_manager.get_shard_layout_from_prev_block(chunk.prev_block())?;
-                let to_shard =
-                    shard_layout::account_id_to_shard_id(receipt.receiver_id(), &shard_layout);
+                let to_shard = shard_layout.account_id_to_shard_id(receipt.receiver_id());
                 return Ok(Some((HashType::Receipt, to_shard)));
             }
         }
@@ -423,10 +421,7 @@ fn apply_receipt_in_chunk(
                     if receipt.get_hash() == *id {
                         let shard_layout =
                             epoch_manager.get_shard_layout_from_prev_block(chunk.prev_block())?;
-                        let to_shard = shard_layout::account_id_to_shard_id(
-                            receipt.receiver_id(),
-                            &shard_layout,
-                        );
+                        let to_shard = shard_layout.account_id_to_shard_id(receipt.receiver_id());
                         to_apply.insert((height, to_shard));
                         println!(
                             "found receipt in chunk {}. Receiver is in shard {}",
@@ -510,7 +505,6 @@ mod test {
     use near_crypto::{InMemorySigner, KeyType};
     use near_epoch_manager::{EpochManager, EpochManagerAdapter};
     use near_primitives::hash::CryptoHash;
-    use near_primitives::shard_layout;
     use near_primitives::transaction::SignedTransaction;
     use near_primitives::utils::get_num_seats_per_shard;
     use near_store::genesis::initialize_genesis_state;
@@ -712,10 +706,8 @@ mod test {
                     }
 
                     for receipt in chunk.prev_outgoing_receipts() {
-                        let to_shard_id = shard_layout::account_id_to_shard_id(
-                            receipt.receiver_id(),
-                            &shard_layout,
-                        );
+                        let to_shard_id =
+                            shard_layout.account_id_to_shard_id(receipt.receiver_id());
                         let to_shard_index = shard_layout.get_shard_index(to_shard_id).unwrap();
 
                         let results = crate::apply_chunk::apply_receipt(


### PR DESCRIPTION
This refactor simplifies the API and aligns with the ShardLayout abstraction (#12480). It implements account_id_to_shard_id as a method within ShardLayout.

The standalone function is deprecated. Usages updated