### PR TITLE
refactor: remove deprecated account_id_to_shard_id

### DIFF
--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -773,12 +773,6 @@ impl ShardLayout {
     }
 }
 
-/// Maps an account to the shard that it belongs to given a shard layout.
-#[deprecated(note = "Please use `ShardLayout::account_id_to_shard_id` method instead")]
-pub fn account_id_to_shard_id(account_id: &AccountId, shard_layout: &ShardLayout) -> ShardId {
-    shard_layout.account_id_to_shard_id(account_id)
-}
-
 /// Maps an account to the shard that it belongs to given a shard_layout
 pub fn account_id_to_shard_uid(account_id: &AccountId, shard_layout: &ShardLayout) -> ShardUId {
     ShardUId::from_shard_id_and_layout(


### PR DESCRIPTION
This is a continuation of [the previous refactor pull request](https://github.com/near/nearcore/pull/12526).

Deprecated `account_id_to_shard_id` function is removed