### PR TITLE
Chores: trigger metadata wf on GH release events

### DIFF
--- a/.github/workflows/neard_release.yml
+++ b/.github/workflows/neard_release.yml
@@ -78,6 +78,15 @@ jobs:
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/PagodaPlatform/pkr-node/dispatches \
           -d '{"event_type":"packer-build","client_payload":{"image-name":"near-node-${BRANCH}-${SHORT_SHA}","neard-binary-s3-uri":"s3://build.nearprotocol.com/nearcore/Linux/${BRANCH}/${COMMIT}/neard"}}'
+      
+      - name: Trigger release metadata update workflow
+        if: github.event_name != 'workflow_dispatch' && github.event_name == 'release'
+        run: |
+          curl -L -X POST -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.NEARONE_GITHUB_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/Near-One/infra-ops/dispatches \
+          -d '{"event_type":"metadata-update","client_payload":{"release":"${{ github.ref_name }}"}}'
 
   docker-release:
     name: "Build and publish nearcore Docker image"


### PR DESCRIPTION
This WF will update metadata on release events:
https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/testnet/latest_release
https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/mainnet/latest_release