### PR TITLE
refactor(InMemorySinger) - test and test_signer methods application

### DIFF
--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -12,7 +12,7 @@ use near_chain_configs::GenesisConfig;
 use near_chain_primitives::error::QueryError;
 use near_chunks::client::ShardsManagerResponse;
 use near_chunks::test_utils::{MockClientAdapterForShardsManager, SynchronousShardsManagerAdapter};
-use near_crypto::{InMemorySigner, KeyType};
+use near_crypto::InMemorySigner;
 use near_network::client::ProcessTxResponse;
 use near_network::shards_manager::ShardsManagerRequestFromNetwork;
 use near_network::test_utils::MockPeerManagerAdapter;
@@ -760,10 +760,8 @@ impl TestEnv {
         relayer: AccountId,
         receiver_id: AccountId,
     ) -> SignedTransaction {
-        let inner_signer =
-            InMemorySigner::from_seed(sender.clone(), KeyType::ED25519, sender.as_str());
-        let relayer_signer =
-            InMemorySigner::from_seed(relayer.clone(), KeyType::ED25519, relayer.as_str());
+        let inner_signer = InMemorySigner::test(&sender);
+        let relayer_signer = InMemorySigner::test_signer(&relayer);
         let tip = self.clients[0].chain.head().unwrap();
         let user_nonce = tip.height + 1;
         let relayer_nonce = tip.height + 1;
@@ -784,7 +782,7 @@ impl TestEnv {
             relayer_nonce,
             relayer,
             sender,
-            &relayer_signer.into(),
+            &relayer_signer,
             vec![Action::Delegate(Box::new(signed_delegate_action))],
             tip.last_block_hash,
             0,
@@ -823,7 +821,7 @@ impl TestEnv {
     /// `InMemorySigner::from_seed` produces a valid signer that has it's key
     /// deployed already.
     pub fn call_main(&mut self, account: &AccountId) -> FinalExecutionOutcomeView {
-        let signer = InMemorySigner::from_seed(account.clone(), KeyType::ED25519, account.as_str());
+        let signer = InMemorySigner::test(&account.clone());
         let actions = vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "main".to_string(),
             args: vec![],

--- a/chain/client/src/tests/query_client.rs
+++ b/chain/client/src/tests/query_client.rs
@@ -6,7 +6,7 @@ use actix::System;
 use futures::{future, FutureExt};
 use near_actix_test_utils::run_actix;
 use near_async::time::{Clock, Duration};
-use near_crypto::{InMemorySigner, KeyType};
+use near_crypto::InMemorySigner;
 use near_network::client::{BlockResponse, ProcessTxRequest, ProcessTxResponse};
 use near_network::types::PeerInfo;
 use near_o11y::testonly::init_test_logger;
@@ -149,7 +149,7 @@ fn test_execution_outcome_for_chunk() {
             true,
             false,
         );
-        let signer = InMemorySigner::from_seed("test".parse().unwrap(), KeyType::ED25519, "test");
+        let signer = InMemorySigner::test_signer(&"test".parse().unwrap());
 
         actix::spawn(async move {
             let block_hash = actor_handles
@@ -165,7 +165,7 @@ fn test_execution_outcome_for_chunk() {
                 1,
                 "test".parse().unwrap(),
                 "near".parse().unwrap(),
-                &signer.into(),
+                &signer,
                 10,
                 block_hash,
             );

--- a/chain/pool/src/lib.rs
+++ b/chain/pool/src/lib.rs
@@ -560,11 +560,7 @@ mod tests {
         let transactions = (1..=10)
             .map(|i| {
                 let signer_id = AccountId::try_from(format!("user_{}", i)).unwrap();
-                let signer_seed = signer_id.as_ref();
-                let signer = Arc::new(
-                    InMemorySigner::from_seed(signer_id.clone(), KeyType::ED25519, signer_seed)
-                        .into(),
-                );
+                let signer = Arc::new(InMemorySigner::test_signer(&signer_id));
                 SignedTransaction::send_money(
                     i,
                     signer_id,

--- a/integration-tests/src/tests/client/block_corruption.rs
+++ b/integration-tests/src/tests/client/block_corruption.rs
@@ -17,12 +17,12 @@ const NOT_BREAKING_CHANGE_MSG: &str = "Not a breaking change";
 const BLOCK_NOT_PARSED_MSG: &str = "Corrupt block didn't parse";
 
 fn create_tx_load(height: BlockHeight, last_block: &Block) -> Vec<SignedTransaction> {
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let tx = SignedTransaction::send_money(
         height + 10000,
         "test0".parse().unwrap(),
         "test1".parse().unwrap(),
-        &signer.into(),
+        &signer,
         10,
         *last_block.hash(),
     );

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -6,7 +6,7 @@ use near_chain_configs::Genesis;
 use near_chunks::shards_manager_actor::ShardsManagerActor;
 use near_client::test_utils::{create_chunk, create_chunk_with_transactions, TestEnv};
 use near_client::{Client, ProcessTxResponse, ProduceChunkResult};
-use near_crypto::{InMemorySigner, KeyType};
+use near_crypto::InMemorySigner;
 use near_network::types::NetworkRequests;
 use near_primitives::bandwidth_scheduler::BandwidthRequests;
 use near_primitives::challenge::{
@@ -240,8 +240,7 @@ fn test_verify_chunk_proofs_malicious_challenge_valid_order_transactions() {
     env.produce_block(0, 1);
 
     let genesis_hash = *env.clients[0].chain.genesis().hash();
-    let signer =
-        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
 
     let (ProduceChunkResult { chunk, .. }, block) = create_chunk_with_transactions(
         &mut env.clients[0],
@@ -277,8 +276,7 @@ fn test_verify_chunk_proofs_challenge_transaction_order() {
     env.produce_block(0, 1);
 
     let genesis_hash = *env.clients[0].chain.genesis().hash();
-    let signer =
-        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
 
     let (ProduceChunkResult { chunk, .. }, block) = create_chunk_with_transactions(
         &mut env.clients[0],
@@ -341,7 +339,7 @@ fn test_verify_chunk_invalid_state_challenge() {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.min_gas_price = 0;
     let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let validator_signer = create_test_signer("test0");
     let genesis_hash = *env.clients[0].chain.genesis().hash();
     env.produce_block(0, 1);
@@ -351,7 +349,7 @@ fn test_verify_chunk_invalid_state_challenge() {
                 1,
                 "test0".parse().unwrap(),
                 "test1".parse().unwrap(),
-                &signer.into(),
+                &signer,
                 1000,
                 genesis_hash,
             ),

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -123,7 +123,7 @@ fn test_storage_after_commit_of_cold_update() {
 
     let mut last_hash = *env.clients[0].chain.genesis().hash();
     for height in 1..max_height {
-        let signer = InMemorySigner::from_seed(test0(), KeyType::ED25519, "test0").into();
+        let signer = InMemorySigner::test_signer(&test0());
         if height == 1 {
             let tx = create_tx_deploy_contract(height, &signer, last_hash);
             assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
@@ -257,7 +257,7 @@ fn test_cold_db_copy_with_height_skips() {
 
     let mut last_hash = *env.clients[0].chain.genesis().hash();
     for height in 1..max_height {
-        let signer = InMemorySigner::from_seed(test0(), KeyType::ED25519, "test0").into();
+        let signer = InMemorySigner::test_signer(&test0());
         // It is still painful to filter out transactions in last two blocks.
         // So, as block 19 is skipped, blocks 17 and 18 shouldn't contain any transactions.
         // So, we shouldn't send any transactions between block 17 and the previous block.
@@ -340,7 +340,7 @@ fn test_initial_copy_to_cold(batch_size: usize) {
 
     let mut last_hash = *env.clients[0].chain.genesis().hash();
     for height in 1..max_height {
-        let signer = InMemorySigner::from_seed(test0(), KeyType::ED25519, "test0").into();
+        let signer = InMemorySigner::test_signer(&test0());
         for i in 0..5 {
             let tx = create_tx_send_money(height * 10 + i, &signer, last_hash);
             assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
@@ -427,7 +427,7 @@ fn test_cold_loop_on_gc_boundary() {
     let mut last_hash = *env.clients[0].chain.genesis().hash();
 
     for height in 1..height_delta {
-        let signer = InMemorySigner::from_seed(test0(), KeyType::ED25519, "test0").into();
+        let signer = InMemorySigner::test_signer(&test0());
         for i in 0..5 {
             let tx = create_tx_send_money(height * 10 + i, &signer, last_hash);
             assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
@@ -446,7 +446,7 @@ fn test_cold_loop_on_gc_boundary() {
     update_cold_head(cold_db, &hot_store, &(height_delta - 1)).unwrap();
 
     for height in height_delta..height_delta * 2 {
-        let signer = InMemorySigner::from_seed(test0(), KeyType::ED25519, "test0").into();
+        let signer = InMemorySigner::test_signer(&test0());
         for i in 0..5 {
             let tx = create_tx_send_money(height * 10 + i, &signer, last_hash);
             assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);

--- a/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
@@ -52,9 +52,8 @@ fn test_transaction_hash_collision() {
     let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
-    let signer0 = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
-    let signer1 =
-        InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1").into();
+    let signer0 = InMemorySigner::test_signer(&"test0".parse().unwrap());
+    let signer1 = InMemorySigner::test_signer(&"test1".parse().unwrap());
     let send_money_tx = SignedTransaction::send_money(
         1,
         "test1".parse().unwrap(),
@@ -91,7 +90,7 @@ fn test_transaction_hash_collision() {
         "test1".parse().unwrap(),
         NEAR_BASE,
         signer1.public_key(),
-        &signer0.into(),
+        &signer0,
         *genesis_block.hash(),
     );
     assert_eq!(
@@ -125,8 +124,7 @@ fn get_status_of_tx_hash_collision_for_near_implicit_account(
     let deposit_for_account_creation = 10u128.pow(23);
     let mut height = 1;
     let blocks_number = 5;
-    let signer1 =
-        InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1").into();
+    let signer1 = InMemorySigner::test_signer(&"test1".parse().unwrap());
     let near_implicit_account_id = near_implicit_account_signer.account_id.clone();
     let near_implicit_account_signer = near_implicit_account_signer.into();
 
@@ -239,12 +237,12 @@ fn test_chunk_transaction_validity() {
     genesis.config.min_gas_price = 0;
     let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let tx = SignedTransaction::send_money(
         1,
         "test1".parse().unwrap(),
         "test0".parse().unwrap(),
-        &signer.into(),
+        &signer,
         100,
         *genesis_block.hash(),
     );
@@ -285,13 +283,13 @@ fn test_transaction_nonce_too_large() {
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let large_nonce = AccessKey::ACCESS_KEY_NONCE_RANGE_MULTIPLIER + 1;
     let tx = SignedTransaction::send_money(
         large_nonce,
         "test1".parse().unwrap(),
         "test0".parse().unwrap(),
-        &signer.into(),
+        &signer,
         100,
         *genesis_block.hash(),
     );

--- a/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
+++ b/integration-tests/src/tests/client/features/account_id_in_function_call_permission.rs
@@ -1,7 +1,7 @@
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_client::ProcessTxResponse;
-use near_crypto::{InMemorySigner, KeyType, Signer};
+use near_crypto::{InMemorySigner, Signer};
 use near_parameters::RuntimeConfigStore;
 use near_primitives::account::{AccessKey, AccessKeyPermission, FunctionCallPermission};
 use near_primitives::errors::{ActionsValidationError, InvalidTxError};
@@ -35,8 +35,7 @@ fn test_account_id_in_function_call_permission_upgrade() {
             .build()
     };
 
-    let signer: Signer =
-        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let signer: Signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let tx = TransactionV0 {
         signer_id: "test0".parse().unwrap(),
         receiver_id: "test0".parse().unwrap(),
@@ -104,7 +103,7 @@ fn test_very_long_account_id() {
     };
 
     let tip = env.clients[0].chain.head().unwrap();
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let tx = Transaction::V0(TransactionV0 {
         signer_id: "test0".parse().unwrap(),
         receiver_id: "test0".parse().unwrap(),
@@ -123,7 +122,7 @@ fn test_very_long_account_id() {
         nonce: 0,
         block_hash: tip.last_block_hash,
     })
-    .sign(&signer.into());
+    .sign(&signer);
 
     assert_eq!(
         env.clients[0].process_tx(tx, false, false),

--- a/integration-tests/src/tests/client/features/chunk_nodes_cache.rs
+++ b/integration-tests/src/tests/client/features/chunk_nodes_cache.rs
@@ -4,7 +4,7 @@ use near_chain::Provenance;
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_client::ProcessTxResponse;
-use near_crypto::{InMemorySigner, KeyType, Signer};
+use near_crypto::{InMemorySigner, Signer};
 use near_parameters::{ExtCosts, RuntimeConfigStore};
 use near_primitives::hash::CryptoHash;
 use near_primitives::test_utils::encode;
@@ -105,8 +105,7 @@ fn compare_node_counts() {
         1,
     );
 
-    let signer =
-        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let tx_node_counts: Vec<TrieNodesCount> = (0..4)
         .map(|i| {
             let touching_trie_node_cost: Gas = 16_101_955_926;

--- a/integration-tests/src/tests/client/features/congestion_control.rs
+++ b/integration-tests/src/tests/client/features/congestion_control.rs
@@ -120,7 +120,7 @@ fn setup_account(
     let block_hash = block.hash();
 
     let signer_id = account_parent_id.clone();
-    let signer = InMemorySigner::from_seed(signer_id.clone(), KeyType::ED25519, signer_id.as_str());
+    let signer = InMemorySigner::test(&signer_id);
 
     let public_key = PublicKey::from_seed(KeyType::ED25519, account_id.as_str());
     let amount = 10 * 10u128.pow(24);
@@ -149,7 +149,7 @@ fn setup_contract(env: &mut TestEnv, nonce: &mut u64) {
     let contract = near_test_contracts::rs_contract();
 
     let signer_id: AccountId = ACCOUNT_PARENT_ID.parse().unwrap();
-    let signer = InMemorySigner::from_seed(signer_id.clone(), KeyType::ED25519, signer_id.as_str());
+    let signer = InMemorySigner::test(&signer_id);
 
     *nonce += 1;
     let create_contract_tx = SignedTransaction::create_contract(
@@ -350,7 +350,7 @@ fn slow_test_protocol_upgrade_under_congestion() {
     let mut nonce = 10;
     setup_contract(&mut env, &mut nonce);
 
-    let signer = InMemorySigner::from_seed(sender_id.clone(), KeyType::ED25519, sender_id.as_str());
+    let signer = InMemorySigner::test(&sender_id);
     // Now, congest the network with ~100 Pgas, enough to have some left after the protocol upgrade.
     let n = 1000;
     submit_n_100tgas_fns(&mut env, n, &mut nonce, &signer);
@@ -734,10 +734,8 @@ fn measure_tx_limit(
         setup_account(&mut env, &mut nonce, &remote_id, &ACCOUNT_PARENT_ID.parse().unwrap());
     }
 
-    let remote_signer =
-        InMemorySigner::from_seed(remote_id.clone(), KeyType::ED25519, remote_id.as_str());
-    let local_signer =
-        InMemorySigner::from_seed(contract_id.clone(), KeyType::ED25519, contract_id.as_str());
+    let remote_signer = InMemorySigner::test(&remote_id);
+    let local_signer = InMemorySigner::test(&contract_id);
     let tip = env.clients[0].chain.head().unwrap();
     let shard_layout = env.clients[0].epoch_manager.get_shard_layout(&tip.epoch_id).unwrap();
     let remote_shard_id = shard_layout.account_id_to_shard_id(&remote_id);
@@ -831,7 +829,7 @@ fn test_rpc_client_rejection() {
     let mut nonce = 10;
     setup_contract(&mut env, &mut nonce);
 
-    let signer = InMemorySigner::from_seed(sender_id.clone(), KeyType::ED25519, sender_id.as_str());
+    let signer = InMemorySigner::test(&sender_id);
 
     // Check we can send transactions at the start.
     let fn_tx = new_fn_call_100tgas(

--- a/integration-tests/src/tests/client/features/flat_storage.rs
+++ b/integration-tests/src/tests/client/features/flat_storage.rs
@@ -2,7 +2,7 @@ use crate::tests::client::process_blocks::deploy_test_contract_with_protocol_ver
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_client::ProcessTxResponse;
-use near_crypto::{InMemorySigner, KeyType, Signer};
+use near_crypto::{InMemorySigner, Signer};
 use near_parameters::ExtCosts;
 use near_primitives::test_utils::encode;
 use near_primitives::transaction::{
@@ -51,8 +51,7 @@ fn test_flat_storage_upgrade() {
         old_protocol_version,
     );
 
-    let signer: Signer =
-        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let signer: Signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let gas = 20_000_000_000_000;
     let tx = TransactionV0 {
         signer_id: "test0".parse().unwrap(),

--- a/integration-tests/src/tests/client/features/increase_deployment_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_deployment_cost.rs
@@ -1,7 +1,7 @@
 use assert_matches::assert_matches;
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
-use near_crypto::{InMemorySigner, KeyType};
+use near_crypto::InMemorySigner;
 use near_parameters::vm::VMKind;
 use near_parameters::RuntimeConfigStore;
 use near_primitives::transaction::{Action, DeployContractAction};
@@ -41,7 +41,7 @@ fn test_deploy_cost_increased() {
             .build()
     };
 
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer = InMemorySigner::test(&"test0".parse().unwrap());
     let actions = vec![Action::DeployContract(DeployContractAction { code: test_contract })];
 
     let tx = env.tx_from_actions(actions.clone(), &signer, signer.account_id.clone());

--- a/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
+++ b/integration-tests/src/tests/client/features/increase_storage_compute_cost.rs
@@ -13,7 +13,7 @@
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_client::ProcessTxResponse;
-use near_crypto::{InMemorySigner, KeyType, Signer};
+use near_crypto::{InMemorySigner, Signer};
 use near_parameters::RuntimeConfigStore;
 use near_parameters::{ActionCosts, RuntimeConfig};
 use near_primitives::sharding::ShardChunk;
@@ -210,11 +210,7 @@ fn assert_compute_limit_reached(
         let code = near_test_contracts::backwards_compatible_rs_contract().to_vec();
         let actions = vec![Action::DeployContract(DeployContractAction { code })];
 
-        let signer = InMemorySigner::from_seed(
-            contract_account.clone(),
-            KeyType::ED25519,
-            contract_account.as_ref(),
-        );
+        let signer = InMemorySigner::test(&contract_account);
         let tx = env.tx_from_actions(actions, &signer, signer.account_id.clone());
         env.execute_tx(tx).unwrap().assert_success();
     }
@@ -301,9 +297,7 @@ fn produce_saturated_chunk(
         gas,
         deposit: 0,
     }))];
-    let signer: Signer =
-        InMemorySigner::from_seed(user_account.clone(), KeyType::ED25519, user_account.as_ref())
-            .into();
+    let signer: Signer = InMemorySigner::test_signer(&user_account);
 
     let tip = env.clients[0].chain.head().unwrap();
     let mut tx_factory = || {

--- a/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
+++ b/integration-tests/src/tests/client/features/lower_storage_key_limit.rs
@@ -3,7 +3,7 @@ use near_chain::Provenance;
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_client::ProcessTxResponse;
-use near_crypto::{InMemorySigner, KeyType, Signer};
+use near_crypto::{InMemorySigner, Signer};
 use near_o11y::testonly::init_test_logger;
 use near_parameters::RuntimeConfigStore;
 use near_primitives::errors::TxExecutionError;
@@ -60,8 +60,7 @@ fn protocol_upgrade() {
         env
     };
 
-    let signer: Signer =
-        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let signer: Signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let tx = TransactionV0 {
         signer_id: "test0".parse().unwrap(),
         receiver_id: "test0".parse().unwrap(),

--- a/integration-tests/src/tests/client/features/nearvm.rs
+++ b/integration-tests/src/tests/client/features/nearvm.rs
@@ -4,7 +4,7 @@ use crate::tests::client::process_blocks::deploy_test_contract;
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_client::ProcessTxResponse;
-use near_crypto::{InMemorySigner, KeyType, Signer};
+use near_crypto::{InMemorySigner, Signer};
 use near_parameters::RuntimeConfigStore;
 use near_primitives::hash::CryptoHash;
 use near_primitives::transaction::{Action, FunctionCallAction, Transaction, TransactionV0};
@@ -42,8 +42,7 @@ fn test_nearvm_upgrade() {
         env
     };
 
-    let signer: Signer =
-        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let signer: Signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let tx = TransactionV0 {
         signer_id: "test0".parse().unwrap(),
         receiver_id: "test0".parse().unwrap(),

--- a/integration-tests/src/tests/client/features/nonrefundable_transfer.rs
+++ b/integration-tests/src/tests/client/features/nonrefundable_transfer.rs
@@ -78,7 +78,7 @@ fn new_account_id(index: usize) -> AccountId {
 
 /// Default signer (corresponding to the default sender) to use in tests of this module.
 fn signer() -> InMemorySigner {
-    InMemorySigner::from_seed(sender(), KeyType::ED25519, "test0")
+    InMemorySigner::test(&sender())
 }
 
 /// Creates a test environment using given protocol version (if some).
@@ -273,11 +273,7 @@ fn delete_account(
 fn deleting_account_with_permanent_storage_bytes() {
     let mut env = setup_env();
     let new_account_id = new_account_id(0);
-    let new_account = InMemorySigner::from_seed(
-        new_account_id.clone(),
-        KeyType::ED25519,
-        new_account_id.as_str(),
-    );
+    let new_account = InMemorySigner::test(&new_account_id);
     let regular_amount = 10u128.pow(20);
     let nonrefundable_amount = NEAR_BASE;
     // Create account with permanent storage bytes.
@@ -325,11 +321,7 @@ fn deleting_account_with_permanent_storage_bytes() {
 fn permanent_storage_bytes_cannot_be_transferred() {
     let mut env = setup_env();
     let new_account_id = new_account_id(0);
-    let new_account = InMemorySigner::from_seed(
-        new_account_id.clone(),
-        KeyType::ED25519,
-        new_account_id.as_str(),
-    );
+    let new_account = InMemorySigner::test(&new_account_id);
     // The `new_account` is created with permanent storage bytes worth 1 NEAR.
     let create_account_tx_result = exec_transfers(
         &mut env,
@@ -451,11 +443,7 @@ fn insufficient_nonrefundable_transfer_amount() {
 fn storage_staking_and_permanent_storage_bytes_taken_into_account() {
     let mut env = setup_env();
     let new_account_id = new_account_id(0);
-    let new_account = InMemorySigner::from_seed(
-        new_account_id.clone(),
-        KeyType::ED25519,
-        new_account_id.as_str(),
-    );
+    let new_account = InMemorySigner::test(&new_account_id);
     let storage_bytes_required = calculate_named_account_storage_usage(TEST_CONTRACT_SIZE) as u128;
     // Just third of the required storage bytes will be covered by permanent storage bytes.
     let permanent_storage_bytes = storage_bytes_required / 3;

--- a/integration-tests/src/tests/client/features/stateless_validation.rs
+++ b/integration-tests/src/tests/client/features/stateless_validation.rs
@@ -160,17 +160,13 @@ fn run_chunk_validation_test(
 
         let sender_account = accounts[round % num_accounts].clone();
         let receiver_account = accounts[(round + 1) % num_accounts].clone();
-        let signer = InMemorySigner::from_seed(
-            sender_account.clone(),
-            KeyType::ED25519,
-            sender_account.as_ref(),
-        );
+        let signer = InMemorySigner::test_signer(&sender_account);
         if round > 1 {
             let tx = SignedTransaction::send_money(
                 round as u64,
                 sender_account,
                 receiver_account,
-                &signer.into(),
+                &signer,
                 ONE_NEAR,
                 tip.last_block_hash,
             );

--- a/integration-tests/src/tests/client/features/storage_proof_size_limit.rs
+++ b/integration-tests/src/tests/client/features/storage_proof_size_limit.rs
@@ -3,7 +3,7 @@ use near_chain::Provenance;
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_client::ProcessTxResponse;
-use near_crypto::{InMemorySigner, KeyType, Signer};
+use near_crypto::{InMemorySigner, Signer};
 use near_parameters::RuntimeConfigStore;
 use near_primitives::action::{Action, DeployContractAction, FunctionCallAction};
 use near_primitives::errors::FunctionCallError;
@@ -40,11 +40,7 @@ fn test_storage_proof_size_limit() {
         let code = near_test_contracts::rs_contract().to_vec();
         let actions = vec![Action::DeployContract(DeployContractAction { code })];
 
-        let signer = InMemorySigner::from_seed(
-            contract_account.clone(),
-            KeyType::ED25519,
-            contract_account.as_ref(),
-        );
+        let signer = InMemorySigner::test(&contract_account);
         let tx = env.tx_from_actions(actions, &signer, signer.account_id.clone());
         env.execute_tx(tx).unwrap().assert_success();
     }
@@ -53,9 +49,7 @@ fn test_storage_proof_size_limit() {
     // query the access key of the user. It's easier to keep a shared counter
     // that starts at 1 and increases monotonically.
     let mut nonce = 1;
-    let signer: Signer =
-        InMemorySigner::from_seed(user_account.clone(), KeyType::ED25519, user_account.as_ref())
-            .into();
+    let signer: Signer = InMemorySigner::test_signer(&user_account);
 
     // Write 1MB values under keys 0, 1, 2, 3, ..., 23.
     // 24MB of data in total

--- a/integration-tests/src/tests/client/features/wallet_contract.rs
+++ b/integration-tests/src/tests/client/features/wallet_contract.rs
@@ -92,7 +92,7 @@ fn test_eth_implicit_account_creation() {
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let chain_id = &genesis.config.chain_id;
 
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer = InMemorySigner::test(&"test0".parse().unwrap());
     let eth_implicit_account_id = eth_implicit_test_account();
 
     // Make zero-transfer to ETH-implicit account, invoking its creation.
@@ -148,7 +148,7 @@ fn test_transaction_from_eth_implicit_account_fail() {
     let deposit_for_account_creation = NEAR_BASE;
     let mut height = 1;
     let blocks_number = 5;
-    let signer1 = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
+    let signer1 = InMemorySigner::test_signer(&"test1".parse().unwrap());
 
     let secret_key = SecretKey::from_seed(KeyType::SECP256K1, "test");
     let public_key = secret_key.public_key();
@@ -161,7 +161,7 @@ fn test_transaction_from_eth_implicit_account_fail() {
         1,
         "test1".parse().unwrap(),
         eth_implicit_account_id.clone(),
-        &signer1.into(),
+        &signer1,
         deposit_for_account_creation,
         *genesis_block.hash(),
     );

--- a/integration-tests/src/tests/client/features/yield_resume.rs
+++ b/integration-tests/src/tests/client/features/yield_resume.rs
@@ -1,7 +1,7 @@
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_client::ProcessTxResponse;
-use near_crypto::{InMemorySigner, KeyType};
+use near_crypto::InMemorySigner;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
@@ -59,8 +59,7 @@ fn prepare_env(test_env_gas_limit: Option<u64>) -> TestEnv {
     }
     let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
-    let signer =
-        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
 
     // Submit transaction deploying contract to test0
     let tx = SignedTransaction::from_actions(
@@ -96,7 +95,7 @@ fn prepare_env(test_env_gas_limit: Option<u64>) -> TestEnv {
 #[test]
 fn yield_then_resume() {
     let mut env = prepare_env(None);
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let mut next_block_height = NEXT_BLOCK_HEIGHT_AFTER_SETUP;
     let yield_payload = vec![6u8; 16];
@@ -106,7 +105,7 @@ fn yield_then_resume() {
         200,
         "test0".parse().unwrap(),
         "test0".parse().unwrap(),
-        &signer.clone().into(),
+        &signer,
         vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_yield_create_return_promise".to_string(),
             args: yield_payload.clone(),
@@ -138,7 +137,7 @@ fn yield_then_resume() {
         201,
         "test0".parse().unwrap(),
         "test0".parse().unwrap(),
-        &signer.into(),
+        &signer,
         vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_yield_resume_read_data_id_from_storage".to_string(),
             args: yield_payload,

--- a/integration-tests/src/tests/client/features/yield_timeouts.rs
+++ b/integration-tests/src/tests/client/features/yield_timeouts.rs
@@ -1,7 +1,7 @@
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_client::ProcessTxResponse;
-use near_crypto::{InMemorySigner, KeyType};
+use near_crypto::InMemorySigner;
 use near_o11y::testonly::init_test_logger;
 use near_parameters::config::TEST_CONFIG_YIELD_TIMEOUT_LENGTH;
 use near_primitives::hash::CryptoHash;
@@ -64,8 +64,7 @@ fn prepare_env_with_yield(
     }
     let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
-    let signer =
-        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
 
     // Submit transaction deploying contract to test0
     let tx = SignedTransaction::from_actions(
@@ -132,14 +131,14 @@ fn invoke_yield_resume(
     data_id: CryptoHash,
     yield_payload: Vec<u8>,
 ) -> CryptoHash {
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
     let resume_transaction = SignedTransaction::from_actions(
         200,
         "test0".parse().unwrap(),
         "test0".parse().unwrap(),
-        &signer.into(),
+        &signer,
         vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_yield_resume".to_string(),
             args: yield_payload.into_iter().chain(data_id.as_bytes().iter().cloned()).collect(),
@@ -162,8 +161,7 @@ fn invoke_yield_resume(
 /// Note that these transactions start to be processed in the *second* block produced after they are
 /// inserted to client 0's mempool.
 fn create_congestion(env: &mut TestEnv) {
-    let signer =
-        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
     let mut tx_hashes = vec![];

--- a/integration-tests/src/tests/client/features/zero_balance_account.rs
+++ b/integration-tests/src/tests/client/features/zero_balance_account.rs
@@ -55,10 +55,8 @@ fn test_zero_balance_account_creation() {
 
     let new_account_id: AccountId = "hello.test0".parse().unwrap();
     let signer0_account_id: AccountId = "test0".parse().unwrap();
-    let signer0 =
-        InMemorySigner::from_seed(signer0_account_id.clone(), KeyType::ED25519, "test0").into();
-    let new_signer =
-        InMemorySigner::from_seed(new_account_id.clone(), KeyType::ED25519, "hello.test0");
+    let signer0 = InMemorySigner::test_signer(&signer0_account_id);
+    let new_signer = InMemorySigner::test_signer(&new_account_id);
 
     // create a valid zero balance account. Transaction should succeed
     let create_account_tx = SignedTransaction::create_account(
@@ -66,7 +64,7 @@ fn test_zero_balance_account_creation() {
         signer0_account_id.clone(),
         new_account_id.clone(),
         0,
-        new_signer.public_key.clone(),
+        new_signer.public_key(),
         &signer0,
         *genesis_block.hash(),
     );
@@ -89,7 +87,7 @@ fn test_zero_balance_account_creation() {
         new_account_id,
         contract.to_vec(),
         0,
-        new_signer.public_key,
+        new_signer.public_key(),
         &signer0,
         *genesis_block.hash(),
     );
@@ -139,10 +137,8 @@ fn test_zero_balance_account_add_key() {
 
     let new_account_id: AccountId = "hello.test0".parse().unwrap();
     let signer0_account_id: AccountId = "test0".parse().unwrap();
-    let signer0 =
-        InMemorySigner::from_seed(signer0_account_id.clone(), KeyType::ED25519, "test0").into();
-    let new_signer: Signer =
-        InMemorySigner::from_seed(new_account_id.clone(), KeyType::ED25519, "hello.test0").into();
+    let signer0 = InMemorySigner::test_signer(&signer0_account_id);
+    let new_signer: Signer = InMemorySigner::test_signer(&new_account_id);
 
     let amount = 10u128.pow(24);
     let create_account_tx = SignedTransaction::create_account(
@@ -259,10 +255,8 @@ fn test_zero_balance_account_upgrade() {
 
     let new_account_id: AccountId = "hello.test0".parse().unwrap();
     let signer0_account_id: AccountId = "test0".parse().unwrap();
-    let signer0: Signer =
-        InMemorySigner::from_seed(signer0_account_id.clone(), KeyType::ED25519, "test0").into();
-    let new_signer =
-        InMemorySigner::from_seed(new_account_id.clone(), KeyType::ED25519, "hello.test0");
+    let signer0 = InMemorySigner::test_signer(&signer0_account_id);
+    let new_signer = InMemorySigner::test_signer(&new_account_id);
 
     // before protocol upgrade, should not be possible to create a zero balance account
     let first_create_account_tx = SignedTransaction::create_account(
@@ -270,7 +264,7 @@ fn test_zero_balance_account_upgrade() {
         signer0_account_id.clone(),
         new_account_id.clone(),
         0,
-        new_signer.public_key.clone(),
+        new_signer.public_key(),
         &signer0,
         *genesis_block.hash(),
     );
@@ -296,7 +290,7 @@ fn test_zero_balance_account_upgrade() {
         signer0_account_id,
         new_account_id,
         0,
-        new_signer.public_key,
+        new_signer.public_key(),
         &signer0,
         *genesis_block.hash(),
     );

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -5,7 +5,7 @@ use near_async::time::Clock;
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_client::ProcessTxResponse;
-use near_crypto::{InMemorySigner, KeyType};
+use near_crypto::InMemorySigner;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::errors::StorageError;
 use near_primitives::shard_layout::{ShardLayout, ShardUId};
@@ -113,8 +113,7 @@ fn test_not_supported_block() {
     let store = create_test_store();
 
     let mut env = setup_env(&genesis, store);
-    let signer =
-        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let genesis_hash = *env.clients[0].chain.genesis().hash();
 
     // Produce blocks up to `START_HEIGHT`.

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -122,11 +122,7 @@ pub(crate) fn create_account(
     protocol_version: ProtocolVersion,
 ) -> CryptoHash {
     let block = env.clients[0].chain.get_block_by_height(height - 1).unwrap();
-    let signer = InMemorySigner::from_seed(
-        old_account_id.clone(),
-        KeyType::ED25519,
-        old_account_id.as_ref(),
-    );
+    let signer = InMemorySigner::test_signer(&old_account_id);
 
     let tx = SignedTransaction::create_account(
         height,
@@ -134,7 +130,7 @@ pub(crate) fn create_account(
         new_account_id,
         10u128.pow(24),
         signer.public_key(),
-        &signer.into(),
+        &signer,
         *block.hash(),
     );
     let tx_hash = tx.get_hash();
@@ -201,8 +197,7 @@ pub(crate) fn prepare_env_with_congestion(
     }
     let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
-    let signer =
-        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
 
     // Deploy contract to test0.
     let tx = SignedTransaction::from_actions(
@@ -1019,7 +1014,7 @@ fn test_process_invalid_tx() {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
     genesis.config.transaction_validity_period = 10;
     let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
-    let signer = InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer = InMemorySigner::test_signer(&"test1".parse().unwrap());
     let tx = SignedTransaction::new(
         Signature::empty(KeyType::ED25519),
         Transaction::V0(TransactionV0 {
@@ -1625,8 +1620,7 @@ fn test_gc_execution_outcome() {
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
     let genesis_hash = *env.clients[0].chain.genesis().hash();
-    let signer =
-        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let tx = SignedTransaction::send_money(
         1,
         "test0".parse().unwrap(),
@@ -1837,8 +1831,7 @@ fn test_tx_forward_around_epoch_boundary() {
         .nightshade_runtimes(&genesis)
         .build();
     let genesis_hash = *env.clients[0].chain.genesis().hash();
-    let signer =
-        InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1").into();
+    let signer = InMemorySigner::test_signer(&"test1".parse().unwrap());
     let tx = SignedTransaction::stake(
         1,
         "test1".parse().unwrap(),
@@ -1972,8 +1965,7 @@ fn test_gas_price_change() {
 
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let genesis_hash = *genesis_block.hash();
-    let signer =
-        InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1").into();
+    let signer = InMemorySigner::test_signer(&"test1".parse().unwrap());
     let tx = SignedTransaction::send_money(
         1,
         "test1".parse().unwrap(),
@@ -2017,8 +2009,7 @@ fn test_gas_price_overflow() {
     let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let genesis_hash = *genesis_block.hash();
-    let signer =
-        InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1").into();
+    let signer = InMemorySigner::test_signer(&"test1".parse().unwrap());
     for i in 1..100 {
         let tx = SignedTransaction::send_money(
             i,
@@ -2148,7 +2139,7 @@ fn test_data_reset_before_state_sync() {
     let epoch_length = 5;
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let genesis_hash = *genesis_block.hash();
     let tx = SignedTransaction::create_account(
@@ -2157,7 +2148,7 @@ fn test_data_reset_before_state_sync() {
         "test_account".parse().unwrap(),
         NEAR_BASE,
         signer.public_key(),
-        &signer.into(),
+        &signer,
         genesis_hash,
     );
     assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
@@ -2257,8 +2248,7 @@ fn test_validate_chunk_extra() {
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let genesis_height = genesis_block.header().height();
 
-    let signer =
-        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let tx = SignedTransaction::from_actions(
         1,
         "test0".parse().unwrap(),
@@ -2437,8 +2427,7 @@ fn slow_test_catchup_gas_price_change() {
         env.process_block(0, block.clone(), Provenance::PRODUCED);
         env.process_block(1, block, Provenance::NONE);
     }
-    let signer =
-        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     for i in 0..3 {
         let tx = SignedTransaction::send_money(
             i + 1,
@@ -2558,8 +2547,7 @@ fn test_block_execution_outcomes() {
     genesis.config.gas_limit = 1000000000000;
     let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
-    let signer =
-        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let mut tx_hashes = vec![];
     for i in 0..3 {
         // send transaction to the same account to generate local receipts
@@ -2649,8 +2637,7 @@ fn test_refund_receipts_processing() {
     genesis.config.gas_limit = 100_000_000;
     let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
-    let signer =
-        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let mut tx_hashes = vec![];
     // Send transactions to a non-existing account to generate refunds.
     for i in 0..3 {
@@ -2731,8 +2718,7 @@ fn test_delayed_receipt_count_limit() {
     let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
-    let signer =
-        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     // Send enough transactions to saturate delayed receipts capacity.
     let total_tx_count = 200usize;
     for i in 0..total_tx_count {
@@ -3179,12 +3165,12 @@ fn test_query_final_state() {
     let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let tx = SignedTransaction::send_money(
         1,
         "test0".parse().unwrap(),
         "test1".parse().unwrap(),
-        &signer.into(),
+        &signer,
         100,
         *genesis_block.hash(),
     );
@@ -3377,12 +3363,12 @@ fn prepare_env_with_transaction() -> (TestEnv, CryptoHash) {
     let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
 
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let tx = SignedTransaction::send_money(
         1,
         "test0".parse().unwrap(),
         "test1".parse().unwrap(),
-        &signer.into(),
+        &signer,
         100,
         *genesis_block.hash(),
     );
@@ -3606,12 +3592,12 @@ fn test_validator_stake_host_function() {
         epoch_length,
         1,
     );
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let signed_transaction = SignedTransaction::from_actions(
         10,
         "test0".parse().unwrap(),
         "test0".parse().unwrap(),
-        &signer.into(),
+        &signer,
         vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "ext_validator_stake".to_string(),
             args: b"test0".to_vec(),
@@ -3947,13 +3933,13 @@ mod contract_precompilation_tests {
 
         // Delete account on which test contract is stored.
         let block = env.clients[0].chain.get_block_by_height(height - 1).unwrap();
-        let signer = InMemorySigner::from_seed("test2".parse().unwrap(), KeyType::ED25519, "test2");
+        let signer = InMemorySigner::test_signer(&"test2".parse().unwrap());
         let delete_account_tx = SignedTransaction::delete_account(
             2,
             "test2".parse().unwrap(),
             "test2".parse().unwrap(),
             "test0".parse().unwrap(),
-            &signer.into(),
+            &signer,
             *block.hash(),
         );
         assert_eq!(

--- a/integration-tests/src/tests/client/resharding_v2.rs
+++ b/integration-tests/src/tests/client/resharding_v2.rs
@@ -5,7 +5,7 @@ use near_chain::Provenance;
 use near_chain_configs::{Genesis, NEAR_BASE};
 use near_client::test_utils::{run_catchup, TestEnv};
 use near_client::ProcessTxResponse;
-use near_crypto::{InMemorySigner, KeyType};
+use near_crypto::InMemorySigner;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::account::id::AccountId;
 use near_primitives::block::{Block, Tip};
@@ -781,9 +781,8 @@ fn gen_cross_contract_tx_impl(
     nonce: u64,
     block_hash: &CryptoHash,
 ) -> SignedTransaction {
-    let signer0 = InMemorySigner::from_seed(account0.clone(), KeyType::ED25519, account0.as_ref());
-    let signer_new_account =
-        InMemorySigner::from_seed(new_account.clone(), KeyType::ED25519, new_account.as_ref());
+    let signer0 = InMemorySigner::test_signer(&account0);
+    let signer_new_account = InMemorySigner::test_signer(&new_account);
     let data = serde_json::json!([
         {"create": {
         "account_id": account2.to_string(),
@@ -807,7 +806,7 @@ fn gen_cross_contract_tx_impl(
                 }, "id": 0 },
                 {"action_add_key_with_full_access": {
                     "promise_index": 0,
-                    "public_key": to_base64(&borsh::to_vec(&signer_new_account.public_key).unwrap()),
+                    "public_key": to_base64(&borsh::to_vec(&signer_new_account.public_key()).unwrap()),
                     "nonce": 0,
                 }, "id": 0 }
             ],
@@ -820,7 +819,7 @@ fn gen_cross_contract_tx_impl(
         nonce,
         account0.clone(),
         account1.clone(),
-        &signer0.into(),
+        &signer0,
         vec![Action::FunctionCall(Box::new(FunctionCallAction {
             method_name: "call_promise".to_string(),
             args: serde_json::to_vec(&data).unwrap(),

--- a/integration-tests/src/tests/client/sandbox.rs
+++ b/integration-tests/src/tests/client/sandbox.rs
@@ -2,7 +2,7 @@ use near_chain::Provenance;
 use near_chain_configs::Genesis;
 use near_client::test_utils::TestEnv;
 use near_client::ProcessTxResponse;
-use near_crypto::{InMemorySigner, KeyType, Signer};
+use near_crypto::{InMemorySigner, Signer};
 use near_primitives::account::Account;
 use near_primitives::sandbox::state_patch::SandboxStatePatch;
 use near_primitives::state_record::StateRecord;
@@ -17,8 +17,7 @@ fn test_setup() -> (TestEnv, Signer) {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
     let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
-    let signer =
-        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     assert_eq!(
         send_tx(
             &mut env,

--- a/integration-tests/src/tests/client/state_dump.rs
+++ b/integration-tests/src/tests/client/state_dump.rs
@@ -8,7 +8,7 @@ use near_chain_configs::{DumpConfig, Genesis, MutableConfigValue, NEAR_BASE};
 use near_client::sync::external::{external_storage_location, StateFileType};
 use near_client::test_utils::TestEnv;
 use near_client::ProcessTxResponse;
-use near_crypto::{InMemorySigner, KeyType, Signer};
+use near_crypto::{InMemorySigner, Signer};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::block::Tip;
 use near_primitives::shard_layout::ShardUId;
@@ -141,7 +141,7 @@ fn run_state_sync_with_dumped_parts(
         .nightshade_runtimes(&genesis)
         .build();
 
-    let signer = InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0");
+    let signer = InMemorySigner::test(&"test0".parse().unwrap());
     let validator = MutableConfigValue::new(
         Some(Arc::new(InMemoryValidatorSigner::from_signer(signer.clone()).into())),
         "validator_signer",

--- a/integration-tests/src/tests/client/state_snapshot.rs
+++ b/integration-tests/src/tests/client/state_snapshot.rs
@@ -2,7 +2,7 @@ use near_chain::{ChainStoreAccess, Provenance};
 use near_chain_configs::{Genesis, NEAR_BASE};
 use near_client::test_utils::TestEnv;
 use near_client::ProcessTxResponse;
-use near_crypto::{InMemorySigner, KeyType, Signer};
+use near_crypto::{InMemorySigner, Signer};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::block::Block;
 use near_primitives::hash::CryptoHash;
@@ -200,8 +200,7 @@ fn slow_test_make_state_snapshot() {
         .nightshade_runtimes(&genesis)
         .build();
 
-    let signer: Signer =
-        InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0").into();
+    let signer: Signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let genesis_hash = *genesis_block.hash();
 

--- a/integration-tests/src/tests/client/sync_state_nodes.rs
+++ b/integration-tests/src/tests/client/sync_state_nodes.rs
@@ -9,7 +9,7 @@ use near_chain_configs::{DumpConfig, ExternalStorageConfig, Genesis, SyncConfig}
 use near_client::test_utils::TestEnv;
 use near_client::{GetBlock, ProcessTxResponse};
 use near_client_primitives::types::GetValidatorInfo;
-use near_crypto::{InMemorySigner, KeyType};
+use near_crypto::InMemorySigner;
 use near_network::client::{StateRequestHeader, StateRequestPart, StateResponse};
 use near_network::tcp;
 use near_network::test_utils::{convert_boot_nodes, wait_or_timeout, WaitOrTimeoutActor};
@@ -469,9 +469,7 @@ fn slow_test_dump_epoch_missing_chunk_in_last_block() {
 
             let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
             let mut blocks = vec![genesis_block.clone()];
-            let signer =
-                InMemorySigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0")
-                    .into();
+            let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
 
             let next_epoch_start = epoch_length + 1;
             let protocol_version = env.clients[0]

--- a/integration-tests/src/tests/nearcore/rpc_error_structs.rs
+++ b/integration-tests/src/tests/nearcore/rpc_error_structs.rs
@@ -8,7 +8,7 @@ use crate::tests::genesis_helpers::genesis_block;
 use crate::tests::nearcore::node_cluster::NodeCluster;
 use near_actix_test_utils::spawn_interruptible;
 use near_client::GetBlock;
-use near_crypto::{InMemorySigner, KeyType};
+use near_crypto::InMemorySigner;
 use near_jsonrpc::client::new_client;
 use near_network::test_utils::WaitOrTimeoutActor;
 use near_o11y::testonly::init_integration_logger;
@@ -358,13 +358,12 @@ fn ultra_slow_test_tx_invalid_tx_error() {
         let view_client = clients[0].1.clone();
 
         let genesis_hash = *genesis_block(&genesis).hash();
-        let signer =
-            InMemorySigner::from_seed("near.5".parse().unwrap(), KeyType::ED25519, "near.5");
+        let signer = InMemorySigner::test_signer(&"near.5".parse().unwrap());
         let transaction = SignedTransaction::send_money(
             1,
             "near.5".parse().unwrap(),
             "near.2".parse().unwrap(),
-            &signer.into(),
+            &signer,
             10000,
             genesis_hash,
         );

--- a/integration-tests/src/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/src/tests/nearcore/rpc_nodes.rs
@@ -8,7 +8,7 @@ use futures::future::join_all;
 use futures::{future, FutureExt, TryFutureExt};
 use near_actix_test_utils::spawn_interruptible;
 use near_client::{GetBlock, GetExecutionOutcome, GetValidatorInfo};
-use near_crypto::{InMemorySigner, KeyType};
+use near_crypto::InMemorySigner;
 use near_jsonrpc::client::new_client;
 use near_jsonrpc_primitives::types::transactions::{RpcTransactionStatusRequest, TransactionInfo};
 use near_network::test_utils::WaitOrTimeoutActor;
@@ -105,14 +105,13 @@ fn test_get_execution_outcome(is_tx_successful: bool) {
         let view_client = clients[0].1.clone();
 
         let genesis_hash = *genesis_block(&genesis).hash();
-        let signer =
-            InMemorySigner::from_seed("near.0".parse().unwrap(), KeyType::ED25519, "near.0");
+        let signer = InMemorySigner::test_signer(&"near.0".parse().unwrap());
         let transaction = if is_tx_successful {
             SignedTransaction::send_money(
                 1,
                 "near.0".parse().unwrap(),
                 "near.1".parse().unwrap(),
-                &signer.into(),
+                &signer,
                 10000,
                 genesis_hash,
             )
@@ -122,8 +121,8 @@ fn test_get_execution_outcome(is_tx_successful: bool) {
                 "near.0".parse().unwrap(),
                 "near.1".parse().unwrap(),
                 10,
-                signer.public_key.clone(),
-                &signer.into(),
+                signer.public_key(),
+                &signer,
                 genesis_hash,
             )
         };
@@ -359,13 +358,12 @@ fn ultra_slow_test_tx_not_enough_balance_must_return_error() {
         let view_client = clients[0].1.clone();
 
         let genesis_hash = *genesis_block(&genesis).hash();
-        let signer =
-            InMemorySigner::from_seed("near.0".parse().unwrap(), KeyType::ED25519, "near.0");
+        let signer = InMemorySigner::test_signer(&"near.0".parse().unwrap());
         let transaction = SignedTransaction::send_money(
             1,
             "near.0".parse().unwrap(),
             "near.1".parse().unwrap(),
-            &signer.into(),
+            &signer,
             1100000000000000000000000000000000,
             genesis_hash,
         );
@@ -422,13 +420,12 @@ fn ultra_slow_test_check_unknown_tx_must_return_error() {
         let view_client = clients[0].1.clone();
 
         let genesis_hash = *genesis_block(&genesis).hash();
-        let signer =
-            InMemorySigner::from_seed("near.0".parse().unwrap(), KeyType::ED25519, "near.0");
+        let signer = InMemorySigner::test_signer(&"near.0".parse().unwrap());
         let transaction = SignedTransaction::send_money(
             1,
             "near.0".parse().unwrap(),
             "near.0".parse().unwrap(),
-            &signer.into(),
+            &signer,
             10000,
             genesis_hash,
         );
@@ -486,12 +483,12 @@ fn ultra_slow_test_tx_status_on_lightclient_must_return_does_not_track_shard() {
         let view_client = clients[0].1.clone();
 
         let genesis_hash = *genesis_block(&genesis).hash();
-        let signer = InMemorySigner::from_seed("near.1".parse().unwrap(), KeyType::ED25519, "near.1");
+        let signer = InMemorySigner::test_signer(&"near.1".parse().unwrap());
         let transaction = SignedTransaction::send_money(
             1,
             "near.1".parse().unwrap(),
             "near.1".parse().unwrap(),
-            &signer.into(),
+            &signer,
             10000,
             genesis_hash,
         );

--- a/integration-tests/src/tests/nearcore/sync_nodes.rs
+++ b/integration-tests/src/tests/nearcore/sync_nodes.rs
@@ -7,7 +7,7 @@ use near_async::time::Duration;
 use near_chain_configs::test_utils::TESTING_INIT_STAKE;
 use near_chain_configs::Genesis;
 use near_client::{GetBlock, ProcessTxRequest};
-use near_crypto::{InMemorySigner, KeyType};
+use near_crypto::InMemorySigner;
 use near_network::tcp;
 use near_network::test_utils::{convert_boot_nodes, WaitOrTimeoutActor};
 use near_o11y::testonly::init_integration_logger;
@@ -48,10 +48,7 @@ fn ultra_slow_test_sync_state_stake_change() {
                 start_with_config(dir1.path(), near1.clone()).expect("start_with_config");
 
             let genesis_hash = *genesis_block(&genesis).hash();
-            let signer = Arc::new(
-                InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1")
-                    .into(),
-            );
+            let signer = Arc::new(InMemorySigner::test_signer(&"test1".parse().unwrap()));
             let unstake_transaction = SignedTransaction::stake(
                 1,
                 "test1".parse().unwrap(),

--- a/integration-tests/src/tests/test_errors.rs
+++ b/integration-tests/src/tests/test_errors.rs
@@ -4,7 +4,7 @@ use crate::node::{Node, ThreadNode};
 use crate::user::CommitError;
 use near_chain_configs::test_utils::{TESTING_INIT_BALANCE, TESTING_INIT_STAKE};
 use near_chain_configs::Genesis;
-use near_crypto::{InMemorySigner, KeyType};
+use near_crypto::InMemorySigner;
 use near_jsonrpc::RpcInto;
 use near_network::tcp;
 use near_o11y::testonly::init_integration_logger;
@@ -33,8 +33,7 @@ fn start_node() -> ThreadNode {
 #[test]
 fn test_check_tx_error_log() {
     let node = start_node();
-    let signer =
-        Arc::new(InMemorySigner::from_seed(alice_account(), KeyType::ED25519, "alice.near").into());
+    let signer = Arc::new(InMemorySigner::test_signer(&alice_account()));
     let block_hash = node.user().get_best_block_hash().unwrap();
     let tx = SignedTransaction::from_actions(
         1,
@@ -75,8 +74,7 @@ fn test_deliver_tx_error_log() {
         RuntimeConfig::clone(&runtime_config),
         node.genesis().config.min_gas_price,
     );
-    let signer =
-        Arc::new(InMemorySigner::from_seed(alice_account(), KeyType::ED25519, "alice.near").into());
+    let signer = Arc::new(InMemorySigner::test_signer(&alice_account()));
     let block_hash = node.user().get_best_block_hash().unwrap();
     let cost = fee_helper.create_account_transfer_full_key_cost_no_reward();
     let tx = SignedTransaction::from_actions(

--- a/test-utils/runtime-tester/src/fuzzing.rs
+++ b/test-utils/runtime-tester/src/fuzzing.rs
@@ -148,12 +148,7 @@ impl TransactionConfig {
             let new_account = scope.new_account(u)?;
 
             let signer = scope.full_access_signer(u, &signer_account)?;
-            let new_public_key = InMemorySigner::from_seed(
-                new_account.id.clone(),
-                KeyType::ED25519,
-                new_account.id.as_ref(),
-            )
-            .public_key;
+            let new_public_key = InMemorySigner::test_signer(&new_account.id).public_key();
             Ok(TransactionConfig {
                 nonce: scope.nonce(),
                 signer_id: signer_account.id,
@@ -581,11 +576,7 @@ impl Scope {
         let possible_signers = self.accounts[account_idx].full_access_keys();
         if possible_signers.is_empty() {
             // this transaction will be invalid
-            Ok(InMemorySigner::from_seed(
-                self.accounts[account_idx].id.clone(),
-                KeyType::ED25519,
-                self.accounts[account_idx].id.as_ref(),
-            ))
+            Ok(InMemorySigner::test(&self.accounts[account_idx].id))
         } else {
             Ok(u.choose(&possible_signers)?.clone())
         }
@@ -601,11 +592,7 @@ impl Scope {
         let possible_signers = self.accounts[account_idx].function_call_keys(receiver_id);
         if possible_signers.is_empty() {
             // this transaction will be invalid
-            Ok(InMemorySigner::from_seed(
-                self.accounts[account_idx].id.clone(),
-                KeyType::ED25519,
-                self.accounts[account_idx].id.as_ref(),
-            ))
+            Ok(InMemorySigner::test(&self.accounts[account_idx].id))
         } else {
             Ok(u.choose(&possible_signers)?.clone())
         }
@@ -630,10 +617,8 @@ impl Account {
         keys.insert(
             0,
             Key {
-                signer: InMemorySigner::from_seed(
-                    AccountId::from_str(id.as_str()).expect("Invalid account_id"),
-                    KeyType::ED25519,
-                    id.as_ref(),
+                signer: InMemorySigner::test(
+                    &AccountId::from_str(id.as_str()).expect("Invalid account_id"),
                 ),
                 access_key: AccessKey { nonce: 0, permission: AccessKeyPermission::FullAccess },
             },

--- a/test-utils/runtime-tester/src/lib.rs
+++ b/test-utils/runtime-tester/src/lib.rs
@@ -10,7 +10,7 @@ pub use crate::scenario_builder::ScenarioBuilder;
 #[test]
 // Use this test as a base for creating reproducers.
 fn scenario_smoke_test() {
-    use near_crypto::{InMemorySigner, KeyType};
+    use near_crypto::InMemorySigner;
     use near_primitives::transaction::{Action, TransferAction};
     use near_primitives::types::AccountId;
 
@@ -36,8 +36,7 @@ fn scenario_smoke_test() {
         let transaction = {
             let signer_id = accounts[h as usize].clone();
             let receiver_id = accounts[(h - 1) as usize].clone();
-            let signer =
-                InMemorySigner::from_seed(signer_id.clone(), KeyType::ED25519, signer_id.as_ref());
+            let signer = InMemorySigner::test(&signer_id);
 
             TransactionConfig {
                 nonce: h,

--- a/test-utils/runtime-tester/src/scenario_builder.rs
+++ b/test-utils/runtime-tester/src/scenario_builder.rs
@@ -1,5 +1,5 @@
 use crate::run_test::{BlockConfig, NetworkConfig, RuntimeConfig, Scenario, TransactionConfig};
-use near_crypto::{InMemorySigner, KeyType};
+use near_crypto::InMemorySigner;
 use near_primitives::{
     transaction::Action,
     types::{AccountId, BlockHeight, BlockHeightDelta, Gas, Nonce},
@@ -115,8 +115,7 @@ impl ScenarioBuilder {
         let signer_id = AccountId::from_str(&id_to_seed(signer_index)).unwrap();
         let receiver_id = AccountId::from_str(&id_to_seed(receiver_index)).unwrap();
 
-        let signer =
-            InMemorySigner::from_seed(signer_id.clone(), KeyType::ED25519, signer_id.as_ref());
+        let signer = InMemorySigner::test(&signer_id);
 
         let block = {
             let last_id = self.scenario.blocks.len() - 1;
@@ -125,8 +124,8 @@ impl ScenarioBuilder {
 
         (*block).transactions.push(TransactionConfig {
             nonce: self.nonce,
-            signer_id: signer_id,
-            receiver_id: receiver_id,
+            signer_id,
+            receiver_id,
             signer,
             actions,
         });

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -496,7 +496,7 @@ mod test {
     use near_chain_configs::Genesis;
     use near_client::test_utils::TestEnv;
     use near_client::ProcessTxResponse;
-    use near_crypto::{InMemorySigner, KeyType};
+    use near_crypto::InMemorySigner;
     use near_epoch_manager::EpochManager;
     use near_primitives::transaction::SignedTransaction;
     use near_primitives::types::{BlockHeight, BlockHeightDelta, NumBlocks, ShardId};
@@ -571,8 +571,7 @@ mod test {
         let epoch_length = 4;
         let (store, genesis, mut env) = setup(epoch_length);
         let genesis_hash = *env.clients[0].chain.genesis().hash();
-        let signer =
-            InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1").into();
+        let signer = InMemorySigner::test_signer(&"test1".parse().unwrap());
         let tx = SignedTransaction::stake(
             1,
             "test1".parse().unwrap(),
@@ -615,8 +614,7 @@ mod test {
         let epoch_length = 4;
         let (store, genesis, mut env) = setup(epoch_length);
         let genesis_hash = *env.clients[0].chain.genesis().hash();
-        let signer =
-            InMemorySigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1").into();
+        let signer = InMemorySigner::test_signer(&"test1".parse().unwrap());
         let tx = SignedTransaction::stake(
             1,
             "test1".parse().unwrap(),


### PR DESCRIPTION
Two factory methods for InMemorySigner were provided in #12503. The following commit applies the methods broadly, reducing verbose test code where possible.