### PR TITLE
feat(archival-store): Add ArchivalStoreConfig to configure external storage locations

### DIFF
--- a/chain/client/src/test_utils/test_env_builder.rs
+++ b/chain/client/src/test_utils/test_env_builder.rs
@@ -204,7 +204,7 @@ impl TestEnvBuilder {
                 // this limit, we set the max_open_files config to 1000.
                 let mut store_config = StoreConfig::default();
                 store_config.max_open_files = 1000;
-                NodeStorage::opener(home_dir.as_path(), false, &store_config, None)
+                NodeStorage::opener(home_dir.as_path(), &store_config, None)
                     .open()
                     .unwrap()
                     .get_hot_store()

--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -133,7 +133,6 @@ impl Indexer {
             self.client.clone(),
             self.indexer_config.clone(),
             self.near_config.config.store.clone(),
-            self.near_config.config.archive,
             sender,
         ));
         receiver

--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -368,12 +368,11 @@ pub(crate) async fn start(
     client: Addr<near_client::ClientActor>,
     indexer_config: IndexerConfig,
     store_config: near_store::StoreConfig,
-    archive: bool,
     blocks_sink: mpsc::Sender<StreamerMessage>,
 ) {
     info!(target: INDEXER, "Starting Streamer...");
     let indexer_db_path =
-        near_store::NodeStorage::opener(&indexer_config.home_dir, archive, &store_config, None)
+        near_store::NodeStorage::opener(&indexer_config.home_dir, &store_config, None)
             .path()
             .join("indexer");
 

--- a/core/store/benches/store_bench.rs
+++ b/core/store/benches/store_bench.rs
@@ -19,7 +19,7 @@ fn benchmark_write_then_read_successful(
     let tmp_dir = tempfile::tempdir().unwrap();
     // Use default StoreConfig rather than NodeStorage::test_opener so we’re using the
     // same configuration as in production.
-    let store = NodeStorage::opener(tmp_dir.path(), false, &Default::default(), None)
+    let store = NodeStorage::opener(tmp_dir.path(), &Default::default(), None)
         .open()
         .unwrap()
         .get_hot_store();

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -450,13 +450,18 @@ impl<'a> ArchivalConfig<'a> {
     /// In the former case, the `ArchivalConfig` contains references to the archival related sub-configs provided in the params.
     /// Also validates the config, for example, panics if `archive` is true and no archival storage configuration is provided or
     /// `archive` is false but cold-storage or archival-store configuration is provided.
-    pub fn get(
+    pub fn new(
         archive: bool,
         archival_store_config: Option<&'a ArchivalStoreConfig>,
         cold_store_config: Option<&'a StoreConfig>,
         split_storage_config: Option<&'a SplitStorageConfig>,
     ) -> Option<Self> {
-        Self::validate_configs(archive, archival_store_config, cold_store_config);
+        Self::validate_configs(
+            archive,
+            archival_store_config,
+            cold_store_config,
+            split_storage_config,
+        );
         archive.then_some(Self { archival_store_config, cold_store_config, split_storage_config })
     }
 
@@ -464,6 +469,7 @@ impl<'a> ArchivalConfig<'a> {
         archive: bool,
         archival_store_config: Option<&'a ArchivalStoreConfig>,
         cold_store_config: Option<&'a StoreConfig>,
+        split_storage_config: Option<&'a SplitStorageConfig>,
     ) {
         if archive {
             // Since only ColdDB storage is supported for now, assert that cold storage is configured.
@@ -474,7 +480,9 @@ impl<'a> ArchivalConfig<'a> {
                     "Archival storage must be ColdDB and it must be configured with a valid StoreConfig");
         } else {
             assert!(
-                cold_store_config.is_none() && archival_store_config.is_none(),
+                cold_store_config.is_none()
+                    && archival_store_config.is_none()
+                    && split_storage_config.is_none(),
                 "Cold-store config and archival config must not be set for non-archival nodes"
             );
         }

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -3,6 +3,7 @@ use crate::trie::{
 };
 use crate::DBCol;
 use near_primitives::shard_layout::ShardUId;
+use near_time::Duration;
 use std::{collections::HashMap, iter::FromIterator};
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -335,6 +336,59 @@ impl Default for TrieCacheConfig {
     }
 }
 
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub struct SplitStorageConfig {
+    #[serde(default = "default_enable_split_storage_view_client")]
+    pub enable_split_storage_view_client: bool,
+
+    #[serde(default = "default_cold_store_initial_migration_batch_size")]
+    pub cold_store_initial_migration_batch_size: usize,
+    #[serde(default = "default_cold_store_initial_migration_loop_sleep_duration")]
+    #[serde(with = "near_time::serde_duration_as_std")]
+    pub cold_store_initial_migration_loop_sleep_duration: Duration,
+
+    #[serde(default = "default_cold_store_loop_sleep_duration")]
+    #[serde(with = "near_time::serde_duration_as_std")]
+    pub cold_store_loop_sleep_duration: Duration,
+
+    #[serde(default = "default_num_cold_store_read_threads")]
+    pub num_cold_store_read_threads: usize,
+}
+
+impl Default for SplitStorageConfig {
+    fn default() -> Self {
+        SplitStorageConfig {
+            enable_split_storage_view_client: default_enable_split_storage_view_client(),
+            cold_store_initial_migration_batch_size:
+                default_cold_store_initial_migration_batch_size(),
+            cold_store_initial_migration_loop_sleep_duration:
+                default_cold_store_initial_migration_loop_sleep_duration(),
+            cold_store_loop_sleep_duration: default_cold_store_loop_sleep_duration(),
+            num_cold_store_read_threads: default_num_cold_store_read_threads(),
+        }
+    }
+}
+
+fn default_enable_split_storage_view_client() -> bool {
+    false
+}
+
+fn default_cold_store_initial_migration_batch_size() -> usize {
+    500_000_000
+}
+
+fn default_cold_store_initial_migration_loop_sleep_duration() -> Duration {
+    Duration::seconds(30)
+}
+
+fn default_num_cold_store_read_threads() -> usize {
+    4
+}
+
+fn default_cold_store_loop_sleep_duration() -> Duration {
+    Duration::seconds(1)
+}
+
 /// Parameters for prefetching certain contract calls.
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 #[serde(default)]
@@ -345,4 +399,84 @@ pub struct PrefetchConfig {
     pub sender: String,
     /// Contract method name.
     pub method_name: String,
+}
+
+/// Configures the archival storage used by the archival nodes.
+///
+/// If the archival storage is ColdDB, this config is complemented by the other parts of the Near node config,
+/// for example, the `StoreConfig` stored in the `Config.cold_store` field is used to configure the cold RocksDB
+/// and the `SplitStorageConfig` stored in the `Config.split_storage` field is used to configure the process
+/// that copies database entries from hot to cold DB.
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct ArchivalStoreConfig {
+    /// The storage to persist the archival data (by default ColdDB).
+    pub storage: ArchivalStorageLocation,
+}
+
+/// Similar to External
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub enum ArchivalStorageLocation {
+    /// Archival data is persisted in the ColdDB.
+    /// In this case, the ColdDB is configured by the `Config.cold_store`
+    /// (which contain a [`StoreConfig`] that configures for the cold RocksDB),
+    /// and `Config.split_storage` (which contains a [`SplitStorageConfig`] that
+    /// configures the hot-to-cold copy process).
+    #[default]
+    ColdDB,
+    /// Archival data is persisted in the filesystem.
+    /// NOTE: This option not implemented yet.
+    Filesystem {
+        /// Root directory containing the archival storage files.
+        _path: std::path::PathBuf,
+    },
+    /// Archival data is persisted in the Google Cloud Storage.
+    /// NOTE: This option not implemented yet.
+    GCloud {
+        /// GCS bucket containing the archival storage objects.
+        _bucket: String,
+    },
+}
+
+/// Contains references to the sub-configs from the Near node config that are related to archival storage.
+pub struct ArchivalConfig<'a> {
+    pub archival_store_config: Option<&'a ArchivalStoreConfig>,
+    pub cold_store_config: Option<&'a StoreConfig>,
+    pub split_storage_config: Option<&'a SplitStorageConfig>,
+}
+
+impl<'a> ArchivalConfig<'a> {
+    /// Returns `Some(ArchivalConfig)` if the node is an archival node (ie. `archive` is true), otherwise returns None.
+    /// In the former case, the `ArchivalConfig` contains references to the archival related sub-configs provided in the params.
+    /// Also validates the config, for example, panics if `archive` is true and no archival storage configuration is provided or
+    /// `archive` is false but cold-storage or archival-store configuration is provided.
+    pub fn get(
+        archive: bool,
+        archival_store_config: Option<&'a ArchivalStoreConfig>,
+        cold_store_config: Option<&'a StoreConfig>,
+        split_storage_config: Option<&'a SplitStorageConfig>,
+    ) -> Option<Self> {
+        Self::validate_configs(archive, archival_store_config, cold_store_config);
+        archive.then_some(Self { archival_store_config, cold_store_config, split_storage_config })
+    }
+
+    fn validate_configs(
+        archive: bool,
+        archival_store_config: Option<&'a ArchivalStoreConfig>,
+        cold_store_config: Option<&'a StoreConfig>,
+    ) {
+        if archive {
+            // Since only ColdDB storage is supported for now, assert that cold storage is configured.
+            // TODO: Change this condition after supporting other archival storage options such as GCS.
+            assert!(cold_store_config.is_some()
+                    && (archival_store_config.is_none()
+                        || matches!(archival_store_config.unwrap().storage, ArchivalStorageLocation::ColdDB)),
+                    "Archival storage must be ColdDB and it must be configured with a valid StoreConfig");
+        } else {
+            assert!(
+                cold_store_config.is_none() && archival_store_config.is_none(),
+                "Cold-store config and archival config must not be set for non-archival nodes"
+            );
+        }
+    }
 }

--- a/core/store/src/db/rocksdb/snapshot.rs
+++ b/core/store/src/db/rocksdb/snapshot.rs
@@ -197,7 +197,7 @@ fn test_snapshot_recovery() {
     {
         let mut config = opener.config().clone();
         config.path = Some(path);
-        let opener = crate::NodeStorage::opener(tmpdir.path(), false, &config, None);
+        let opener = crate::NodeStorage::opener(tmpdir.path(), &config, None);
         let store = opener.open().unwrap().get_hot_store();
         assert_eq!(Some(&b"value"[..]), store.get(COL, KEY).unwrap().as_deref());
     }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -15,6 +15,7 @@ pub use crate::trie::{
 use adapter::{StoreAdapter, StoreUpdateAdapter};
 use borsh::{BorshDeserialize, BorshSerialize};
 pub use columns::DBCol;
+use config::ArchivalConfig;
 use db::{SplitDB, GENESIS_CONGESTION_INFO_KEY};
 pub use db::{
     CHUNK_TAIL_KEY, COLD_HEAD_KEY, FINAL_HEAD_KEY, FORK_TAIL_KEY, GENESIS_JSON_HASH_KEY,
@@ -126,11 +127,10 @@ impl NodeStorage {
     /// store config.
     pub fn opener<'a>(
         home_dir: &std::path::Path,
-        archive: bool,
-        config: &'a StoreConfig,
-        cold_config: Option<&'a StoreConfig>,
+        store_config: &'a StoreConfig,
+        archival_config: Option<ArchivalConfig<'a>>,
     ) -> StoreOpener<'a> {
-        StoreOpener::new(home_dir, archive, config, cold_config)
+        StoreOpener::new(home_dir, store_config, archival_config)
     }
 
     /// Constructs new object backed by given database.
@@ -161,7 +161,7 @@ impl NodeStorage {
     pub fn test_opener() -> (tempfile::TempDir, StoreOpener<'static>) {
         static CONFIG: LazyLock<StoreConfig> = LazyLock::new(StoreConfig::test_config);
         let dir = tempfile::tempdir().unwrap();
-        let opener = StoreOpener::new(dir.path(), false, &CONFIG, None);
+        let opener = NodeStorage::opener(dir.path(), &CONFIG, None);
         (dir, opener)
     }
 

--- a/core/store/src/trie/state_snapshot.rs
+++ b/core/store/src/trie/state_snapshot.rs
@@ -346,7 +346,7 @@ impl ShardTries {
 
         let store_config = StoreConfig::default();
 
-        let opener = NodeStorage::opener(&snapshot_path, false, &store_config, None);
+        let opener = NodeStorage::opener(&snapshot_path, &store_config, None);
         let storage = opener.open_in_mode(Mode::ReadOnly)?;
         let store = storage.get_hot_store().trie_store();
         let flat_storage_manager = FlatStorageManager::new(store.flat_store());

--- a/genesis-tools/genesis-populate/src/main.rs
+++ b/genesis-tools/genesis-populate/src/main.rs
@@ -36,9 +36,8 @@ fn main() {
 
     let store = near_store::NodeStorage::opener(
         home_dir,
-        near_config.config.archive,
         &near_config.config.store,
-        None,
+        near_config.config.archival_config(),
     )
     .open()
     .unwrap()

--- a/genesis-tools/genesis-populate/src/state_dump.rs
+++ b/genesis-tools/genesis-populate/src/state_dump.rs
@@ -15,12 +15,12 @@ pub struct StateDump {
 }
 
 impl StateDump {
-    pub fn from_dir(dir: &Path, store_home_dir: &Path, in_memory_db: bool, archive: bool) -> Self {
+    pub fn from_dir(dir: &Path, store_home_dir: &Path, in_memory_db: bool) -> Self {
         let node_storage = if in_memory_db {
             let storage = TestDB::new();
             near_store::NodeStorage::new(storage)
         } else {
-            near_store::NodeStorage::opener(store_home_dir, archive, &Default::default(), None)
+            near_store::NodeStorage::opener(store_home_dir, &Default::default(), None)
                 .open()
                 .unwrap()
         };

--- a/integration-tests/src/tests/client/state_snapshot.rs
+++ b/integration-tests/src/tests/client/state_snapshot.rs
@@ -161,7 +161,7 @@ fn verify_make_snapshot(
     }
     // check that the stored snapshot in file system is an actual snapshot
     let store_config = StoreConfig::default();
-    let opener = NodeStorage::opener(&snapshot_path, false, &store_config, None);
+    let opener = NodeStorage::opener(&snapshot_path, &store_config, None);
     let _storage = opener.open_in_mode(Mode::ReadOnly)?;
     // check that there's only one snapshot at the parent directory of snapshot path
     let parent_path = snapshot_path

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -31,9 +31,8 @@ fn read_trie_items(bench: &mut Bencher, shard_index: ShardIndex, shard_id: Shard
         tracing::info!(target: "neard", "{:?}", home_dir);
         let store = near_store::NodeStorage::opener(
             &home_dir,
-            near_config.config.archive,
             &near_config.config.store,
-            None,
+            near_config.config.archival_config(),
         )
         .open_in_mode(mode)
         .unwrap()

--- a/nearcore/src/cold_storage.rs
+++ b/nearcore/src/cold_storage.rs
@@ -5,13 +5,13 @@ use near_epoch_manager::{EpochManagerAdapter, EpochManagerHandle};
 use near_primitives::errors::EpochError;
 use near_primitives::{hash::CryptoHash, types::BlockHeight};
 use near_store::cold_storage::{copy_all_data_to_cold, CopyAllDataToColdStatus};
+use near_store::config::SplitStorageConfig;
 use near_store::{
     cold_storage::{update_cold_db, update_cold_head},
     db::ColdDB,
     DBCol, NodeStorage, Store, FINAL_HEAD_KEY, HEAD_KEY, TAIL_KEY,
 };
 
-use crate::config::SplitStorageConfig;
 use crate::{metrics, NearConfig};
 
 /// A handle that keeps the state of the cold store loop and can be used to stop it.

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -51,7 +51,9 @@ use near_primitives::validator_signer::{InMemoryValidatorSigner, ValidatorSigner
 use near_primitives::version::{ProtocolVersion, PROTOCOL_VERSION};
 #[cfg(feature = "rosetta_rpc")]
 use near_rosetta_rpc::RosettaRpcConfig;
-use near_store::config::StateSnapshotType;
+use near_store::config::{
+    ArchivalConfig, ArchivalStoreConfig, SplitStorageConfig, StateSnapshotType,
+};
 use near_store::{StateSnapshotConfig, Store, TrieConfig};
 use near_telemetry::TelemetryConfig;
 use near_vm_runner::{ContractRuntimeCache, FilesystemContractRuntimeCache};
@@ -274,6 +276,8 @@ pub struct Config {
     /// Configuration for the split storage.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub split_storage: Option<SplitStorageConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub archival_storage: Option<ArchivalStoreConfig>,
     /// The node will stop after the head exceeds this height.
     /// The node usually stops within several seconds after reaching the target height.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -368,6 +372,7 @@ impl Default for Config {
             store: near_store::StoreConfig::default(),
             cold_store: None,
             split_storage: None,
+            archival_storage: None,
             expected_shutdown: None,
             state_sync: None,
             epoch_sync: default_epoch_sync(),
@@ -383,59 +388,6 @@ impl Default for Config {
             orphan_state_witness_max_size: default_orphan_state_witness_max_size(),
             max_loaded_contracts: 256,
             save_latest_witnesses: false,
-        }
-    }
-}
-
-fn default_enable_split_storage_view_client() -> bool {
-    false
-}
-
-fn default_cold_store_initial_migration_batch_size() -> usize {
-    500_000_000
-}
-
-fn default_cold_store_initial_migration_loop_sleep_duration() -> Duration {
-    Duration::seconds(30)
-}
-
-fn default_num_cold_store_read_threads() -> usize {
-    4
-}
-
-fn default_cold_store_loop_sleep_duration() -> Duration {
-    Duration::seconds(1)
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
-pub struct SplitStorageConfig {
-    #[serde(default = "default_enable_split_storage_view_client")]
-    pub enable_split_storage_view_client: bool,
-
-    #[serde(default = "default_cold_store_initial_migration_batch_size")]
-    pub cold_store_initial_migration_batch_size: usize,
-    #[serde(default = "default_cold_store_initial_migration_loop_sleep_duration")]
-    #[serde(with = "near_async::time::serde_duration_as_std")]
-    pub cold_store_initial_migration_loop_sleep_duration: Duration,
-
-    #[serde(default = "default_cold_store_loop_sleep_duration")]
-    #[serde(with = "near_async::time::serde_duration_as_std")]
-    pub cold_store_loop_sleep_duration: Duration,
-
-    #[serde(default = "default_num_cold_store_read_threads")]
-    pub num_cold_store_read_threads: usize,
-}
-
-impl Default for SplitStorageConfig {
-    fn default() -> Self {
-        SplitStorageConfig {
-            enable_split_storage_view_client: default_enable_split_storage_view_client(),
-            cold_store_initial_migration_batch_size:
-                default_cold_store_initial_migration_batch_size(),
-            cold_store_initial_migration_loop_sleep_duration:
-                default_cold_store_initial_migration_loop_sleep_duration(),
-            cold_store_loop_sleep_duration: default_cold_store_loop_sleep_duration(),
-            num_cold_store_read_threads: default_num_cold_store_read_threads(),
         }
     }
 }
@@ -508,6 +460,16 @@ impl Config {
         {
             self.rpc.get_or_insert(Default::default()).addr = addr;
         }
+    }
+
+    /// Returns `ArchivalConfig` which contains references to the archival-related configs if the config is for an archival node; otherwise returns `None`.
+    pub fn archival_config(&self) -> Option<ArchivalConfig> {
+        ArchivalConfig::get(
+            self.archive,
+            self.archival_storage.as_ref(),
+            self.cold_store.as_ref(),
+            self.split_storage.as_ref(),
+        )
     }
 }
 

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -464,7 +464,7 @@ impl Config {
 
     /// Returns `ArchivalConfig` which contains references to the archival-related configs if the config is for an archival node; otherwise returns `None`.
     pub fn archival_config(&self) -> Option<ArchivalConfig> {
-        ArchivalConfig::get(
+        ArchivalConfig::new(
             self.archive,
             self.archival_storage.as_ref(),
             self.cold_store.as_ref(),

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -90,9 +90,8 @@ pub fn open_storage(home_dir: &Path, near_config: &mut NearConfig) -> anyhow::Re
     let migrator = migrations::Migrator::new(near_config);
     let opener = NodeStorage::opener(
         home_dir,
-        near_config.client_config.archive,
         &near_config.config.store,
-        near_config.config.cold_store.as_ref(),
+        near_config.config.archival_config(),
     )
     .with_migrator(&migrator);
     let storage = match opener.open() {

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -70,7 +70,6 @@ impl<'c> EstimatorContext<'c> {
             &self.config.state_dump_path,
             workdir.path(),
             self.config.in_memory_db,
-            false,
         );
         // Ensure decent RocksDB SST file layout.
         store.compact().expect("compaction failed");

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -189,9 +189,8 @@ fn run_estimation(cli_args: CliArgs) -> anyhow::Result<Option<CostTable>> {
             .context("Error loading config")?;
         let store = near_store::NodeStorage::opener(
             &state_dump_path,
-            near_config.config.archive,
             &near_config.config.store,
-            None,
+            near_config.config.archival_config(),
         )
         .open()
         .unwrap()

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -32,9 +32,8 @@ fn main() {
 
     let store = near_store::NodeStorage::opener(
         home_dir,
-        near_config.config.archive,
         &near_config.config.store,
-        None,
+        near_config.config.archival_config(),
     )
     .open()
     .unwrap()

--- a/tools/cold-store/src/cli.rs
+++ b/tools/cold-store/src/cli.rs
@@ -114,9 +114,8 @@ impl ColdStoreCommand {
 
         let opener = NodeStorage::opener(
             home_dir,
-            near_config.config.archive,
             &near_config.config.store,
-            near_config.config.cold_store.as_ref(),
+            near_config.config.archival_config(),
         );
 
         match self.subcmd {
@@ -137,9 +136,8 @@ impl ColdStoreCommand {
 
         NodeStorage::opener(
             home_dir,
-            near_config.config.archive,
             &near_config.config.store,
-            near_config.config.cold_store.as_ref(),
+            near_config.config.archival_config(),
         )
     }
 }
@@ -349,7 +347,7 @@ impl PrepareHotCmd {
         // Open the rpc_storage using the near_config with the path swapped.
         let mut rpc_store_config = near_config.config.store.clone();
         rpc_store_config.path = Some(path.to_path_buf());
-        let rpc_opener = NodeStorage::opener(home_dir, false, &rpc_store_config, None);
+        let rpc_opener = NodeStorage::opener(home_dir, &rpc_store_config, None);
         let rpc_storage = rpc_opener.open()?;
         let rpc_store = rpc_storage.get_hot_store();
 

--- a/tools/database/src/adjust_database.rs
+++ b/tools/database/src/adjust_database.rs
@@ -33,9 +33,8 @@ impl ChangeDbKindCommand {
         let near_config = nearcore::config::load_config(&home_dir, genesis_validation)?;
         let opener = NodeStorage::opener(
             home_dir,
-            near_config.config.archive,
             &near_config.config.store,
-            near_config.config.cold_store.as_ref(),
+            near_config.config.archival_config(),
         );
 
         let storage = opener.open()?;

--- a/tools/database/src/analyse_high_load.rs
+++ b/tools/database/src/analyse_high_load.rs
@@ -80,12 +80,7 @@ impl HighLoadStatsCommand {
         let near_config = nearcore::config::Config::from_file_skip_validation(
             &home.join(nearcore::config::CONFIG_FILENAME),
         )?;
-        let opener = NodeStorage::opener(
-            home,
-            near_config.archive,
-            &near_config.store,
-            near_config.cold_store.as_ref(),
-        );
+        let opener = NodeStorage::opener(home, &near_config.store, near_config.archival_config());
         let storage = opener.open()?;
         let store = std::sync::Arc::new(
             storage.get_split_store().unwrap_or_else(|| storage.get_hot_store()),

--- a/tools/database/src/commands.rs
+++ b/tools/database/src/commands.rs
@@ -80,7 +80,7 @@ impl DatabaseCommand {
             SubCommand::CorruptStateSnapshot(cmd) => cmd.run(home),
             SubCommand::MakeSnapshot(cmd) => {
                 let near_config = load_config(home, genesis_validation);
-                cmd.run(home, near_config.config.archive, &near_config.config.store)
+                cmd.run(home, &near_config.config.store, near_config.config.archival_config())
             }
             SubCommand::RunMigrations(cmd) => cmd.run(home, genesis_validation),
             SubCommand::StatePerf(cmd) => cmd.run(home),

--- a/tools/database/src/make_snapshot.rs
+++ b/tools/database/src/make_snapshot.rs
@@ -1,6 +1,6 @@
 use near_store::{
-    checkpoint_hot_storage_and_cleanup_columns, Mode, NodeStorage, StoreConfig,
-    STATE_SNAPSHOT_COLUMNS,
+    checkpoint_hot_storage_and_cleanup_columns, config::ArchivalConfig, Mode, NodeStorage,
+    StoreConfig, STATE_SNAPSHOT_COLUMNS,
 };
 use std::path::{Path, PathBuf};
 
@@ -18,10 +18,10 @@ impl MakeSnapshotCommand {
     pub(crate) fn run(
         &self,
         home_dir: &Path,
-        archive: bool,
         store_config: &StoreConfig,
+        archival_config: Option<ArchivalConfig>,
     ) -> anyhow::Result<()> {
-        let opener = NodeStorage::opener(home_dir, archive, store_config, None);
+        let opener = NodeStorage::opener(home_dir, store_config, archival_config);
         let node_storage = opener.open_in_mode(Mode::ReadWriteExisting)?;
         let columns_to_keep =
             if self.flat_state_only { Some(STATE_SNAPSHOT_COLUMNS) } else { None };
@@ -45,7 +45,7 @@ mod tests {
     fn test() {
         let home_dir = tempfile::tempdir().unwrap();
         let store_config = StoreConfig::test_config();
-        let opener = NodeStorage::opener(home_dir.path(), false, &store_config, None);
+        let opener = NodeStorage::opener(home_dir.path(), &store_config, None);
 
         let keys = vec![vec![0], vec![1], vec![2], vec![3]];
 
@@ -63,7 +63,7 @@ mod tests {
 
         let destination = home_dir.path().join("data").join("snapshot");
         let cmd = MakeSnapshotCommand { destination: destination.clone(), flat_state_only: false };
-        cmd.run(home_dir.path(), false, &store_config).unwrap();
+        cmd.run(home_dir.path(), &store_config, None).unwrap();
         println!("Made a checkpoint");
 
         {
@@ -76,7 +76,7 @@ mod tests {
         }
 
         let node_storage = opener.open_in_mode(Mode::ReadOnly).unwrap();
-        let snapshot_node_storage = NodeStorage::opener(&destination, false, &store_config, None)
+        let snapshot_node_storage = NodeStorage::opener(&destination, &store_config, None)
             .open_in_mode(Mode::ReadOnly)
             .unwrap();
         for key in keys {

--- a/tools/database/src/utils.rs
+++ b/tools/database/src/utils.rs
@@ -36,7 +36,7 @@ pub(crate) fn open_state_snapshot(home: &Path, mode: near_store::Mode) -> anyhow
     let path = snapshot_dir.path();
     println!("state snapshot path {path:?}");
 
-    let opener = NodeStorage::opener(&path, false, &store_config, None);
+    let opener = NodeStorage::opener(&path, &store_config, None);
     let storage = opener.open_in_mode(mode)?;
     let store = storage.get_hot_store();
 

--- a/tools/database/src/write_to_db.rs
+++ b/tools/database/src/write_to_db.rs
@@ -32,9 +32,8 @@ impl WriteCryptoHashCommand {
         let near_config = nearcore::config::load_config(&home_dir, genesis_validation)?;
         let opener = NodeStorage::opener(
             home_dir,
-            near_config.config.archive,
             &near_config.config.store,
-            near_config.config.cold_store.as_ref(),
+            near_config.config.archival_config(),
         );
 
         let storage = opener.open()?;

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -353,7 +353,7 @@ impl FlatStorageCommand {
             Self::get_db(&opener, home_dir, &near_config, near_store::Mode::ReadWriteExisting);
 
         let write_opener =
-            NodeStorage::opener(&cmd.write_store_path, false, &near_config.config.store, None);
+            NodeStorage::opener(&cmd.write_store_path, &near_config.config.store, None);
         let write_node_storage = write_opener.open_in_mode(Mode::Create)?;
         let write_store = write_node_storage.get_hot_store();
 
@@ -587,9 +587,8 @@ impl FlatStorageCommand {
         let near_config = load_config(home_dir, genesis_validation)?;
         let opener = NodeStorage::opener(
             home_dir,
-            near_config.config.archive,
             &near_config.config.store,
-            None,
+            near_config.config.archival_config(),
         );
 
         match &self.subcmd {

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -850,9 +850,8 @@ impl<T: ChainAccess> TxMirror<T> {
                 // keep backward compatibility
                 let mirror_db_path = near_store::NodeStorage::opener(
                     target_home,
-                    target_config.config.archive,
                     &target_config.config.store,
-                    None,
+                    target_config.config.archival_config(),
                 )
                 .path()
                 .join("mirror");

--- a/tools/mock-node/src/setup.rs
+++ b/tools/mock-node/src/setup.rs
@@ -27,23 +27,30 @@ use std::sync::Arc;
 
 fn setup_runtime(
     home_dir: &Path,
-    config: &NearConfig,
+    near_config: &NearConfig,
     in_memory_storage: bool,
 ) -> (Arc<EpochManagerHandle>, ShardTracker, Arc<NightshadeRuntime>) {
     let store = if in_memory_storage {
         create_test_store()
     } else {
-        near_store::NodeStorage::opener(home_dir, config.config.archive, &config.config.store, None)
-            .open()
-            .unwrap()
-            .get_hot_store()
+        near_store::NodeStorage::opener(
+            home_dir,
+            &near_config.config.store,
+            near_config.config.archival_config(),
+        )
+        .open()
+        .unwrap()
+        .get_hot_store()
     };
     let epoch_manager =
-        EpochManager::new_arc_handle(store.clone(), &config.genesis.config, Some(home_dir));
-    let shard_tracker =
-        ShardTracker::new(TrackedConfig::from_config(&config.client_config), epoch_manager.clone());
-    let runtime = NightshadeRuntime::from_config(home_dir, store, config, epoch_manager.clone())
-        .expect("could not create transaction runtime");
+        EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config, Some(home_dir));
+    let shard_tracker = ShardTracker::new(
+        TrackedConfig::from_config(&near_config.client_config),
+        epoch_manager.clone(),
+    );
+    let runtime =
+        NightshadeRuntime::from_config(home_dir, store, near_config, epoch_manager.clone())
+            .expect("could not create transaction runtime");
     (epoch_manager, shard_tracker, runtime)
 }
 

--- a/tools/replay-archive/src/replaydb.rs
+++ b/tools/replay-archive/src/replaydb.rs
@@ -147,9 +147,8 @@ pub(crate) fn open_storage_for_replay(
 
     let opener = NodeStorage::opener(
         home_dir,
-        near_config.client_config.archive,
         &near_config.config.store,
-        near_config.config.cold_store.as_ref(),
+        near_config.config.archival_config(),
     );
     let split_storage = opener.open_in_mode(Mode::ReadOnly).context("Failed to open storage")?;
     match split_storage.get_split_db() {

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -144,12 +144,10 @@ impl StateViewerSubCommand {
         let near_config = load_config(home_dir, genesis_validation)
             .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
 
-        let cold_config: Option<&near_store::StoreConfig> = near_config.config.cold_store.as_ref();
         let store_opener = NodeStorage::opener(
             home_dir,
-            near_config.config.archive,
             &near_config.config.store,
-            cold_config,
+            near_config.config.archival_config(),
         );
 
         let storage = store_opener.open_in_mode(mode).unwrap();

--- a/tools/state-viewer/src/replay_headers.rs
+++ b/tools/state-viewer/src/replay_headers.rs
@@ -278,9 +278,8 @@ fn get_block_info(
 fn create_replay_store(home_dir: &Path, near_config: &NearConfig) -> Store {
     let store_opener = NodeStorage::opener(
         home_dir,
-        near_config.config.archive,
         &near_config.config.store,
-        near_config.config.cold_store.as_ref(),
+        near_config.config.archival_config(),
     );
     let storage = store_opener.open_in_mode(Mode::ReadOnly).unwrap();
 

--- a/tools/undo-block/src/cli.rs
+++ b/tools/undo-block/src/cli.rs
@@ -23,9 +23,8 @@ impl UndoBlockCommand {
 
         let store_opener = NodeStorage::opener(
             home_dir,
-            near_config.config.archive,
             &near_config.config.store,
-            None,
+            near_config.config.archival_config(),
         );
 
         let storage = store_opener.open_in_mode(Mode::ReadWrite).unwrap();


### PR DESCRIPTION
Currently ColdDB is used for archival storage and it is configured by the `Config.cold_store` field (which contains a `StoreConfig`).

In order to prepare for introducing other storage alternatives, we introduce a new config called `ArchivalStoreConfig`. It defaults to `ColdDB`. We also change `NodeStorage::opener` to accept `Option<ArchivalConfig>` where `ArchivalConfig` contains references to a couple of archival-node related configurations, since the archival storage will be configured by multiple config objects. 