### PR TITLE
fix(resharding) - minor fixes and improvements

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2378,8 +2378,6 @@ impl Client {
             self.shard_tracker.care_about_shard(me, &head.last_block_hash, shard_id, true);
         let will_care_about_shard =
             self.shard_tracker.will_care_about_shard(me, &head.last_block_hash, shard_id, true);
-        // TODO(resharding) will_care_about_shard should be called with the
-        // account shard id from the next epoch, in case shard layout changes
         if care_about_shard || will_care_about_shard {
             let shard_uid = self.epoch_manager.shard_id_to_uid(shard_id, &epoch_id)?;
             let state_root = match self.chain.get_chunk_extra(&head.last_block_hash, &shard_uid) {

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -633,18 +633,17 @@ impl ShardLayout {
                 // that every shard has a parent shard
                 Some(to_parent_shard_map) => {
                     let shard_index = self.get_shard_index(shard_id)?;
-                    let parent_shard_id = to_parent_shard_map
-                        .get(shard_index)
-                        .ok_or(ShardLayoutError::InvalidShardIdError { shard_id })?;
+                    let parent_shard_id = to_parent_shard_map.get(shard_index).unwrap();
                     Some(*parent_shard_id)
                 }
                 None => None,
             },
             Self::V2(v2) => match &v2.shards_parent_map {
+                // we can safely unwrap here because the construction of to_parent_shard_map guarantees
+                // that every shard has a parent shard
                 Some(to_parent_shard_map) => {
                     let parent_shard_id = to_parent_shard_map.get(&shard_id);
-                    let parent_shard_id = parent_shard_id
-                        .ok_or(ShardLayoutError::InvalidShardIdError { shard_id })?;
+                    let parent_shard_id = parent_shard_id.unwrap();
                     Some(*parent_shard_id)
                 }
                 None => None,


### PR DESCRIPTION
Some minor fixes and improvements. 
* Removed old todo that is not accurate - `will_care_about_shard` does check for the future shard layout
  * https://github.com/near/nearcore/blob/fc9aaa3606d9500edac3e02a7a9d04dcb1af7e03/chain/epoch-manager/src/shard_tracker.rs#L165-L174
* Replaced bad errors in shard layout with unwraps. The shard layout must have either of the following. It is invalid to have a parent shard map without a parent for some shard. 
  * `Some` parent shard map with a parent for every shard
  * `None` parent shard map
*  Added traffic towards the right child in the `buffered_receipts_towards_splitted_shard` + refactoring to allow multiple contracts. 
* Replaced shard id with shard index as seed for the allowed shard in congestion control. The ShardId being arbitrary may have bad fairness properties. Please note that this is not a protocol upgrade because currently in production shard id is always the same as shard index. 