### PR TITLE
mirror: don't require an archival dir for the traffic generator

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -386,8 +386,6 @@ class NeardRunner:
         config['consensus']['min_block_production_delay']['nanos'] = 300000000
         config['consensus']['max_block_production_delay']['secs'] = 3
         config['consensus']['max_block_production_delay']['nanos'] = 0
-        if self.is_traffic_generator():
-            config['archive'] = True
         with open(self.tmp_near_home_path('config.json'), 'w') as f:
             json.dump(config, f, indent=2)
 

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -837,13 +837,6 @@ impl<T: ChainAccess> TxMirror<T> {
         let target_config =
             nearcore::config::load_config(target_home, GenesisValidationMode::UnsafeFast)
                 .with_context(|| format!("Error loading target config from {:?}", target_home))?;
-        if !target_config.client_config.archive {
-            // this is probably not going to come up, but we want to avoid a situation where
-            // we go offline for a long time and then come back online, and we state sync to
-            // the head of the target chain without looking for our outcomes that made it on
-            // chain right before we went offline
-            anyhow::bail!("config file in {} has archive: false, but archive must be set to true for the target chain", target_home.display());
-        }
         let db = match mirror_db_path {
             Some(mirror_db_path) => open_db(mirror_db_path),
             None => {


### PR DESCRIPTION
The reason this was done originally was to make sure we apply all chunks so that in `on_target_block()` we can look through all the outcomes and keep track of how many of our txs made it on chain, and so that we can figure out what unstake actions need to be sent to undo stakes that came from staking pool contract calls. The first one is just best effort anyway, and the second one won't even be that relevant in the case where the traffic generator is offline for several epochs and state syncs, since by that time it will be too late to unstake them. So just remove this check and don't make the traffic generator an archival node