### PR TITLE
test(resharding) - Test resharding with both V1 and V2 base shard layout

### DIFF
--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -129,6 +129,7 @@ struct TestReshardingParameters {
     chunk_ranges_to_drop: HashMap<ShardUId, std::ops::Range<i64>>,
     accounts: Vec<AccountId>,
     clients: Vec<AccountId>,
+    base_shard_layout_version: u64,
     block_and_chunk_producers: Vec<AccountId>,
     initial_balance: u128,
     epoch_length: BlockHeightDelta,
@@ -190,10 +191,12 @@ impl TestReshardingParameters {
 
         let block_and_chunk_producers = clients.clone();
         let load_mem_tries_for_tracked_shards = true;
+        let base_shard_layout_version = 2;
 
         Self {
             accounts,
             clients,
+            base_shard_layout_version,
             block_and_chunk_producers,
             initial_balance,
             epoch_length,
@@ -215,6 +218,11 @@ impl TestReshardingParameters {
     #[allow(unused)]
     fn clients(mut self, clients: Vec<AccountId>) -> Self {
         self.clients = clients;
+        self
+    }
+
+    fn base_shard_layout_version(mut self, base_shard_layout_version: u64) -> Self {
+        self.base_shard_layout_version = base_shard_layout_version;
         self
     }
 
@@ -882,6 +890,24 @@ impl TrieSanityCheck {
     }
 }
 
+fn get_base_shard_layout(version: u64) -> ShardLayout {
+    let boundary_accounts = vec!["account1".parse().unwrap(), "account3".parse().unwrap()];
+    match version {
+        1 => {
+            let shards_split_map = vec![vec![ShardId::new(0), ShardId::new(1), ShardId::new(2)]];
+            #[allow(deprecated)]
+            ShardLayout::v1(boundary_accounts, Some(shards_split_map), 3)
+        }
+        2 => {
+            let shard_ids = vec![ShardId::new(5), ShardId::new(3), ShardId::new(6)];
+            let shards_split_map = [(ShardId::new(0), shard_ids.clone())].into_iter().collect();
+            let shards_split_map = Some(shards_split_map);
+            ShardLayout::v2(boundary_accounts, shard_ids, shards_split_map)
+        }
+        _ => panic!("Unsupported shard layout version {}", version),
+    }
+}
+
 /// Base setup to check sanity of Resharding V3.
 /// TODO(#11881): add the following scenarios:
 /// - Nodes must not track all shards. State sync must succeed.
@@ -919,19 +945,12 @@ fn test_resharding_v3_base(params: TestReshardingParameters) {
         base_epoch_config.chunk_validator_only_kickout_threshold = 0;
     }
 
-    // Set the base shard layout to V1 with non-unique shard ids. This is what
-    // we have on mainnet before the ReshardingV3 release.
-    // TODO(resharding) test both V1->V2 and V2->V2
-    let boundary_accounts = vec!["account1".parse().unwrap(), "account3".parse().unwrap()];
-    let split_map = vec![vec![ShardId::new(0), ShardId::new(1), ShardId::new(2)]];
-    #[allow(deprecated)]
-    let base_shard_layout = ShardLayout::v1(boundary_accounts, Some(split_map), 3);
-
+    let base_shard_layout = get_base_shard_layout(params.base_shard_layout_version);
     base_epoch_config.shard_layout = base_shard_layout.clone();
-    let new_boundary_account = "account6".parse().unwrap();
-    let mut epoch_config = base_epoch_config.clone();
-    let parent_shard_uid = account_id_to_shard_uid(&new_boundary_account, &base_shard_layout);
 
+    let new_boundary_account = "account6".parse().unwrap();
+    let parent_shard_uid = account_id_to_shard_uid(&new_boundary_account, &base_shard_layout);
+    let mut epoch_config = base_epoch_config.clone();
     epoch_config.shard_layout =
         ShardLayout::derive_shard_layout(&base_shard_layout, new_boundary_account);
     tracing::info!(target: "test", ?base_shard_layout, new_shard_layout=?epoch_config.shard_layout, "shard layout");
@@ -1187,14 +1206,13 @@ fn test_resharding_v3_delayed_receipts_right_child() {
     test_resharding_v3_base(params);
 }
 
-#[test]
-#[cfg_attr(not(feature = "test_features"), ignore)]
-fn test_resharding_v3_split_parent_buffered_receipts() {
+fn test_resharding_v3_split_parent_buffered_receipts_base(base_shard_layout_version: u64) {
     let receiver_account: AccountId = "account0".parse().unwrap();
     let account_in_parent: AccountId = "account4".parse().unwrap();
     let account_in_left_child: AccountId = "account4".parse().unwrap();
     let account_in_right_child: AccountId = "account6".parse().unwrap();
     let params = TestReshardingParameters::new()
+        .base_shard_layout_version(base_shard_layout_version)
         .deploy_test_contract(receiver_account.clone())
         .limit_outgoing_gas()
         .add_loop_action(call_burn_gas_contract(
@@ -1215,12 +1233,25 @@ fn test_resharding_v3_split_parent_buffered_receipts() {
 
 #[test]
 #[cfg_attr(not(feature = "test_features"), ignore)]
-fn test_resharding_v3_buffered_receipts_towards_splitted_shard() {
+fn test_resharding_v3_split_parent_buffered_receipts_v1() {
+    test_resharding_v3_split_parent_buffered_receipts_base(1);
+}
+
+#[test]
+#[cfg_attr(not(feature = "test_features"), ignore)]
+fn test_resharding_v3_split_parent_buffered_receipts_v2() {
+    test_resharding_v3_split_parent_buffered_receipts_base(2);
+}
+
+fn test_resharding_v3_buffered_receipts_towards_splitted_shard_base(
+    base_shard_layout_version: u64,
+) {
     let account_in_left_child: AccountId = "account4".parse().unwrap();
     let account_in_right_child: AccountId = "account6".parse().unwrap();
     let account_in_stable_shard: AccountId = "account1".parse().unwrap();
 
     let params = TestReshardingParameters::new()
+        .base_shard_layout_version(base_shard_layout_version)
         .deploy_test_contract(account_in_left_child.clone())
         .deploy_test_contract(account_in_right_child.clone())
         .limit_outgoing_gas()
@@ -1242,39 +1273,29 @@ fn test_resharding_v3_buffered_receipts_towards_splitted_shard() {
 
 #[test]
 #[cfg_attr(not(feature = "test_features"), ignore)]
-fn test_resharding_v3_outgoing_receipts_towards_splitted_shard() {
-    let receiver_account: AccountId = "account4".parse().unwrap();
-    let account_1_in_stable_shard: AccountId = "account1".parse().unwrap();
-    let account_2_in_stable_shard: AccountId = "account2".parse().unwrap();
-    let params = TestReshardingParameters::new()
-        .deploy_test_contract(receiver_account.clone())
-        .add_loop_action(call_burn_gas_contract(
-            vec![account_1_in_stable_shard, account_2_in_stable_shard],
-            vec![receiver_account],
-            5 * TGAS,
-        ));
-    test_resharding_v3_base(params);
+fn test_resharding_v3_buffered_receipts_towards_splitted_shard_v1() {
+    test_resharding_v3_buffered_receipts_towards_splitted_shard_base(1);
 }
 
 #[test]
 #[cfg_attr(not(feature = "test_features"), ignore)]
-fn test_resharding_v3_outgoing_receipts_from_splitted_shard() {
-    let receiver_account: AccountId = "account0".parse().unwrap();
-    let account_in_left_child: AccountId = "account4".parse().unwrap();
-    let account_in_right_child: AccountId = "account6".parse().unwrap();
+fn test_resharding_v3_buffered_receipts_towards_splitted_shard_v2() {
+    test_resharding_v3_buffered_receipts_towards_splitted_shard_base(2);
+}
+
+#[test]
+fn test_resharding_v3_load_mem_trie_v1() {
     let params = TestReshardingParameters::new()
-        .deploy_test_contract(receiver_account.clone())
-        .add_loop_action(call_burn_gas_contract(
-            vec![account_in_left_child, account_in_right_child],
-            vec![receiver_account],
-            5 * TGAS,
-        ));
+        .base_shard_layout_version(1)
+        .load_mem_tries_for_tracked_shards(false);
     test_resharding_v3_base(params);
 }
 
 #[test]
-fn test_resharding_v3_load_mem_trie() {
-    let params = TestReshardingParameters::new().load_mem_tries_for_tracked_shards(false);
+fn test_resharding_v3_load_mem_trie_v2() {
+    let params = TestReshardingParameters::new()
+        .base_shard_layout_version(2)
+        .load_mem_tries_for_tracked_shards(false);
     test_resharding_v3_base(params);
 }
 

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -1284,6 +1284,38 @@ fn test_resharding_v3_buffered_receipts_towards_splitted_shard_v2() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "test_features"), ignore)]
+fn test_resharding_v3_outgoing_receipts_towards_splitted_shard() {
+    let receiver_account: AccountId = "account4".parse().unwrap();
+    let account_1_in_stable_shard: AccountId = "account1".parse().unwrap();
+    let account_2_in_stable_shard: AccountId = "account2".parse().unwrap();
+    let params = TestReshardingParameters::new()
+        .deploy_test_contract(receiver_account.clone())
+        .add_loop_action(call_burn_gas_contract(
+            vec![account_1_in_stable_shard, account_2_in_stable_shard],
+            vec![receiver_account],
+            5 * TGAS,
+        ));
+    test_resharding_v3_base(params);
+}
+
+#[test]
+#[cfg_attr(not(feature = "test_features"), ignore)]
+fn test_resharding_v3_outgoing_receipts_from_splitted_shard() {
+    let receiver_account: AccountId = "account0".parse().unwrap();
+    let account_in_left_child: AccountId = "account4".parse().unwrap();
+    let account_in_right_child: AccountId = "account6".parse().unwrap();
+    let params = TestReshardingParameters::new()
+        .deploy_test_contract(receiver_account.clone())
+        .add_loop_action(call_burn_gas_contract(
+            vec![account_in_left_child, account_in_right_child],
+            vec![receiver_account],
+            5 * TGAS,
+        ));
+    test_resharding_v3_base(params);
+}
+
+#[test]
 fn test_resharding_v3_load_mem_trie_v1() {
     let params = TestReshardingParameters::new()
         .base_shard_layout_version(1)


### PR DESCRIPTION
* Added base_shard_layout_version to the resharding test loop params. 
* Refactored the buffered receipts tests to have one test for each base shard layout
* Refactored the load memtrie tests to have one test for each base shard layout
* ~Removed what seems to be an old copy of some tests - we have tests for both `buffered` and `outgoing` receipts that look like old and new versions of the same test. Please let me know if that's not the case and those were actually testing different things.~

Let me know if any other tests deserve to cover both cases. For now the default is set to V2 because that's what we'll use in the long term. 

I'm curious if there is any rust library for automatically creating tests for various test parameters combinations. Thoughts on whether that would be useful? 