### PR TITLE
feat(resharding) - brute force congestion info computation

### DIFF
--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -958,6 +958,16 @@ pub mod chunk_extra {
         }
 
         #[inline]
+        pub fn congestion_info_mut(&mut self) -> Option<&mut CongestionInfo> {
+            match self {
+                Self::V1(_) => None,
+                Self::V2(_) => None,
+                Self::V3(v3) => Some(&mut v3.congestion_info),
+                Self::V4(v4) => Some(&mut v4.congestion_info),
+            }
+        }
+
+        #[inline]
         pub fn bandwidth_requests(&self) -> Option<&BandwidthRequests> {
             match self {
                 Self::V1(_) | Self::V2(_) | Self::V3(_) => None,

--- a/runtime/runtime/src/congestion_control.rs
+++ b/runtime/runtime/src/congestion_control.rs
@@ -612,6 +612,9 @@ pub fn bootstrap_congestion_info(
     config: &RuntimeConfig,
     shard_id: ShardId,
 ) -> Result<CongestionInfo, StorageError> {
+    tracing::warn!(target: "runtime", "starting to bootstrap congestion info, this might take a while");
+    let start = std::time::Instant::now();
+
     let mut receipt_bytes: u64 = 0;
     let mut delayed_receipts_gas: u128 = 0;
     let mut buffered_receipts_gas: u128 = 0;
@@ -639,6 +642,9 @@ pub fn bootstrap_congestion_info(
             receipt_bytes = receipt_bytes.checked_add(memory).ok_or_else(overflow_storage_err)?;
         }
     }
+
+    let time = start.elapsed();
+    tracing::warn!(target: "runtime","bootstrapping congestion info done after {time:#.1?}");
 
     Ok(CongestionInfo::V1(CongestionInfoV1 {
         delayed_receipts_gas: delayed_receipts_gas as u128,

--- a/runtime/runtime/src/congestion_control.rs
+++ b/runtime/runtime/src/congestion_control.rs
@@ -250,17 +250,27 @@ impl ReceiptSinkV2 {
             parent_shard_ids.intersection(&shard_ids.clone().into_iter().collect()).count() == 0
         );
 
+        let mut all_buffers_empty = true;
+
         // First forward any receipts that may still be in the outgoing buffers
         // of the parent shards.
         for &shard_id in &parent_shard_ids {
             self.forward_from_buffer_to_shard(shard_id, state_update, apply_state, &shard_layout)?;
+            let is_buffer_empty = self.outgoing_buffers.to_shard(shard_id).len() == 0;
+            all_buffers_empty &= is_buffer_empty;
         }
 
         // Then forward receipts from the outgoing buffers of the shard in the
         // current shard layout.
         for &shard_id in &shard_ids {
             self.forward_from_buffer_to_shard(shard_id, state_update, apply_state, &shard_layout)?;
+            let is_buffer_empty = self.outgoing_buffers.to_shard(shard_id).len() == 0;
+            all_buffers_empty &= is_buffer_empty;
         }
+
+        // Assert that empty buffers match zero buffered gas.
+        assert_eq!(all_buffers_empty, self.own_congestion_info.buffered_receipts_gas() == 0);
+
         Ok(())
     }
 

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -2213,13 +2213,8 @@ impl ApplyState {
             return Ok(Some(congestion_info.congestion_info));
         }
 
-        tracing::warn!(target: "runtime", "starting to bootstrap congestion info, this might take a while");
-        let start = std::time::Instant::now();
-        let result = bootstrap_congestion_info(trie, &self.config, self.shard_id);
-        let time = start.elapsed();
-        tracing::warn!(target: "runtime","bootstrapping congestion info done after {time:#.1?}");
-        let computed = result?;
-        Ok(Some(computed))
+        let congestion_info = bootstrap_congestion_info(trie, &self.config, self.shard_id)?;
+        Ok(Some(congestion_info))
     }
 }
 


### PR DESCRIPTION
While we're waiting for the bandwidth scheduler to give us an efficient way to do the same, here is a quick implementation for brute force congestion info computation. It may be slow and bloat the state witness but should be correct. 

I added assertion checking that the buffered gas in congestion info is zero iff the buffers are empty. With this in place the `test_resharding_v3_buffered_receipts_towards_splitted_shard` tests fail without the updated congestion info and pass with it in place. 

Also moved the bootstrapping logs to inside of the bootstrap method so that I don't have to duplicate them. 