### PR TITLE
test(resharding): allow negative refc in testdb for resharding

### DIFF
--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -23,7 +23,7 @@ pub use self::rocksdb::RocksDB;
 pub use self::splitdb::SplitDB;
 
 pub use self::slice::DBSlice;
-pub use self::testdb::TestDB;
+pub use self::testdb::{TestDB, TestStoreFlags};
 use std::sync::Arc;
 
 // `DBCol::BlockMisc` keys

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -23,7 +23,7 @@ pub use self::rocksdb::RocksDB;
 pub use self::splitdb::SplitDB;
 
 pub use self::slice::DBSlice;
-pub use self::testdb::{TestDB, TestStoreFlags};
+pub use self::testdb::{TestDB, TestDBFlags};
 use std::sync::Arc;
 
 // `DBCol::BlockMisc` keys

--- a/core/store/src/db/testdb.rs
+++ b/core/store/src/db/testdb.rs
@@ -8,7 +8,7 @@ use crate::{DBCol, StoreStatistics};
 
 // Overrides to `TestDB` behavior.
 #[derive(Clone, Debug, Default)]
-pub struct TestStoreFlags {
+pub struct TestDBFlags {
     // Ignore negative refcount being a result of a write to the database.
     pub allow_negative_refcount: bool,
 }
@@ -27,7 +27,7 @@ pub struct TestDB {
     stats: RwLock<Option<StoreStatistics>>,
 
     // Flags to change the default behavior, for testing purposes.
-    flags: TestStoreFlags,
+    flags: TestDBFlags,
 }
 
 impl TestDB {
@@ -35,7 +35,7 @@ impl TestDB {
         Arc::new(Self::default())
     }
 
-    pub fn new_with_flags(flags: TestStoreFlags) -> Arc<TestDB> {
+    pub fn new_with_flags(flags: TestDBFlags) -> Arc<TestDB> {
         let mut this = Self::default();
         this.flags = flags;
         Arc::new(this)

--- a/core/store/src/db/testdb.rs
+++ b/core/store/src/db/testdb.rs
@@ -7,16 +7,10 @@ use crate::db::{refcount, DBIterator, DBOp, DBSlice, DBTransaction, Database};
 use crate::{DBCol, StoreStatistics};
 
 // Overrides to `TestDB` behavior.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct TestStoreFlags {
     // Ignore negative refcount being a result of a write to the database.
     pub allow_negative_refcount: bool,
-}
-
-impl Default for TestStoreFlags {
-    fn default() -> Self {
-        Self { allow_negative_refcount: false }
-    }
 }
 
 /// An in-memory database intended for tests and IO-agnostic estimations.

--- a/core/store/src/db/testdb.rs
+++ b/core/store/src/db/testdb.rs
@@ -6,8 +6,10 @@ use std::sync::{Arc, RwLock};
 use crate::db::{refcount, DBIterator, DBOp, DBSlice, DBTransaction, Database};
 use crate::{DBCol, StoreStatistics};
 
+// Overrides to `TestDB` behavior.
 #[derive(Clone, Debug)]
 pub struct TestStoreFlags {
+    // Ignore negative refcount being a result of a write to the database.
     pub allow_negative_refcount: bool,
 }
 

--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -70,9 +70,7 @@ pub fn create_test_store() -> Store {
 
 /// Creates an in-memory database with overrides to the default behavior.
 pub fn create_test_store_with_flags(flags: &TestStoreFlags) -> Store {
-    let test_db = TestDB::new();
-    test_db.set_store_flags(flags.clone());
-    let store = Store::new(test_db);
+    let store = Store::new(TestDB::new_with_flags(flags.clone()));
     store.set_db_version(DB_VERSION).unwrap();
     store.set_db_kind(DbKind::RPC).unwrap();
     store

--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -1,5 +1,5 @@
 use crate::adapter::{StoreAdapter, StoreUpdateAdapter};
-use crate::db::{TestDB, TestStoreFlags};
+use crate::db::{TestDB, TestDBFlags};
 use crate::flat::{BlockInfo, FlatStorageManager, FlatStorageReadyStatus, FlatStorageStatus};
 use crate::metadata::{DbKind, DbVersion, DB_VERSION};
 use crate::{
@@ -69,7 +69,7 @@ pub fn create_test_store() -> Store {
 }
 
 /// Creates an in-memory database with overrides to the default behavior.
-pub fn create_test_store_with_flags(flags: &TestStoreFlags) -> Store {
+pub fn create_test_store_with_flags(flags: &TestDBFlags) -> Store {
     let store = Store::new(TestDB::new_with_flags(flags.clone()));
     store.set_db_version(DB_VERSION).unwrap();
     store.set_db_kind(DbKind::RPC).unwrap();

--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -1,5 +1,5 @@
 use crate::adapter::{StoreAdapter, StoreUpdateAdapter};
-use crate::db::TestDB;
+use crate::db::{TestDB, TestStoreFlags};
 use crate::flat::{BlockInfo, FlatStorageManager, FlatStorageReadyStatus, FlatStorageStatus};
 use crate::metadata::{DbKind, DbVersion, DB_VERSION};
 use crate::{
@@ -66,6 +66,16 @@ pub fn create_test_node_storage_with_cold(
 /// Creates an in-memory database.
 pub fn create_test_store() -> Store {
     create_test_node_storage(DB_VERSION, DbKind::RPC).get_hot_store()
+}
+
+/// Creates an in-memory database with overrides to the default behavior.
+pub fn create_test_store_with_flags(flags: &TestStoreFlags) -> Store {
+    let test_db = TestDB::new();
+    test_db.set_store_flags(flags.clone());
+    let store = Store::new(test_db);
+    store.set_db_version(DB_VERSION).unwrap();
+    store.set_db_kind(DbKind::RPC).unwrap();
+    store
 }
 
 /// Returns a pair of (Hot, Split) store to be used for setting up archival clients.

--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -101,7 +101,7 @@ pub(crate) struct TestLoopBuilder {
     /// Upgrade schedule which determines when the clients start voting for new protocol versions.
     upgrade_schedule: ProtocolUpgradeVotingSchedule,
     /// Overrides to test database behavior.
-    test_store_flags: Option<TestStoreFlags>,
+    test_store_flags: TestStoreFlags,
 }
 
 /// Checks whether chunk is validated by the given account.
@@ -302,7 +302,7 @@ impl TestLoopBuilder {
             track_all_shards: false,
             load_mem_tries_for_tracked_shards: true,
             upgrade_schedule: PROTOCOL_UPGRADE_SCHEDULE.clone(),
-            test_store_flags: None,
+            test_store_flags: Default::default(),
         }
     }
 
@@ -424,8 +424,8 @@ impl TestLoopBuilder {
         self
     }
 
-    pub(crate) fn test_store_flags(mut self, flags: TestStoreFlags) -> Self {
-        self.test_store_flags = Some(flags);
+    pub(crate) fn allow_negative_refcount(mut self) -> Self {
+        self.test_store_flags.allow_negative_refcount = true;
         self
     }
 
@@ -567,11 +567,8 @@ impl TestLoopBuilder {
             } else if is_archival {
                 let (hot_store, split_store) = create_test_split_store();
                 (hot_store, Some(split_store))
-            } else if let Some(ref flags) = self.test_store_flags {
-                let hot_store = create_test_store_with_flags(flags);
-                (hot_store, None)
             } else {
-                let hot_store = create_test_store();
+                let hot_store = create_test_store_with_flags(&self.test_store_flags);
                 (hot_store, None)
             };
         initialize_genesis_state(store.clone(), &genesis, None);

--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -100,6 +100,7 @@ pub(crate) struct TestLoopBuilder {
     load_mem_tries_for_tracked_shards: bool,
     /// Upgrade schedule which determines when the clients start voting for new protocol versions.
     upgrade_schedule: ProtocolUpgradeVotingSchedule,
+    /// Overrides to test database behavior.
     test_store_flags: Option<TestStoreFlags>,
 }
 

--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -35,7 +35,7 @@ use near_primitives::upgrade_schedule::ProtocolUpgradeVotingSchedule;
 use near_primitives::version::PROTOCOL_UPGRADE_SCHEDULE;
 use near_store::adapter::StoreAdapter;
 use near_store::config::StateSnapshotType;
-use near_store::db::TestStoreFlags;
+use near_store::db::TestDBFlags;
 use near_store::genesis::initialize_genesis_state;
 use near_store::test_utils::{create_test_split_store, create_test_store_with_flags};
 use near_store::{ShardUId, Store, StoreConfig, TrieConfig};
@@ -99,7 +99,7 @@ pub(crate) struct TestLoopBuilder {
     /// Upgrade schedule which determines when the clients start voting for new protocol versions.
     upgrade_schedule: ProtocolUpgradeVotingSchedule,
     /// Overrides to test database behavior.
-    test_store_flags: TestStoreFlags,
+    test_store_flags: TestDBFlags,
 }
 
 /// Checks whether chunk is validated by the given account.

--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -38,7 +38,7 @@ use near_store::config::StateSnapshotType;
 use near_store::db::TestStoreFlags;
 use near_store::genesis::initialize_genesis_state;
 use near_store::test_utils::{
-    create_test_split_store, create_test_store, create_test_store_with_flags,
+    create_test_split_store, create_test_store_with_flags,
 };
 use near_store::{ShardUId, Store, StoreConfig, TrieConfig};
 use near_vm_runner::logic::ProtocolVersion;

--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -35,8 +35,11 @@ use near_primitives::upgrade_schedule::ProtocolUpgradeVotingSchedule;
 use near_primitives::version::PROTOCOL_UPGRADE_SCHEDULE;
 use near_store::adapter::StoreAdapter;
 use near_store::config::StateSnapshotType;
+use near_store::db::TestStoreFlags;
 use near_store::genesis::initialize_genesis_state;
-use near_store::test_utils::{create_test_split_store, create_test_store};
+use near_store::test_utils::{
+    create_test_split_store, create_test_store, create_test_store_with_flags,
+};
 use near_store::{ShardUId, Store, StoreConfig, TrieConfig};
 use near_vm_runner::logic::ProtocolVersion;
 use near_vm_runner::{ContractRuntimeCache, FilesystemContractRuntimeCache};
@@ -97,6 +100,7 @@ pub(crate) struct TestLoopBuilder {
     load_mem_tries_for_tracked_shards: bool,
     /// Upgrade schedule which determines when the clients start voting for new protocol versions.
     upgrade_schedule: ProtocolUpgradeVotingSchedule,
+    test_store_flags: Option<TestStoreFlags>,
 }
 
 /// Checks whether chunk is validated by the given account.
@@ -297,6 +301,7 @@ impl TestLoopBuilder {
             track_all_shards: false,
             load_mem_tries_for_tracked_shards: true,
             upgrade_schedule: PROTOCOL_UPGRADE_SCHEDULE.clone(),
+            test_store_flags: None,
         }
     }
 
@@ -415,6 +420,11 @@ impl TestLoopBuilder {
 
     pub fn load_mem_tries_for_tracked_shards(mut self, load_mem_tries: bool) -> Self {
         self.load_mem_tries_for_tracked_shards = load_mem_tries;
+        self
+    }
+
+    pub(crate) fn test_store_flags(mut self, flags: TestStoreFlags) -> Self {
+        self.test_store_flags = Some(flags);
         self
     }
 
@@ -556,6 +566,9 @@ impl TestLoopBuilder {
             } else if is_archival {
                 let (hot_store, split_store) = create_test_split_store();
                 (hot_store, Some(split_store))
+            } else if let Some(ref flags) = self.test_store_flags {
+                let hot_store = create_test_store_with_flags(flags);
+                (hot_store, None)
             } else {
                 let hot_store = create_test_store();
                 (hot_store, None)

--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -37,9 +37,7 @@ use near_store::adapter::StoreAdapter;
 use near_store::config::StateSnapshotType;
 use near_store::db::TestStoreFlags;
 use near_store::genesis::initialize_genesis_state;
-use near_store::test_utils::{
-    create_test_split_store, create_test_store_with_flags,
-};
+use near_store::test_utils::{create_test_split_store, create_test_store_with_flags};
 use near_store::{ShardUId, Store, StoreConfig, TrieConfig};
 use near_vm_runner::logic::ProtocolVersion;
 use near_vm_runner::{ContractRuntimeCache, FilesystemContractRuntimeCache};

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -1186,6 +1186,10 @@ fn test_resharding_v3_base(params: TestReshardingParameters) {
         builder = builder.track_all_shards();
     }
 
+    if params.allow_negative_refcount {
+        builder = builder.allow_negative_refcount();
+    }
+
     if params.limit_outgoing_gas || params.short_yield_timeout {
         let mut runtime_config = RuntimeConfig::test();
         if params.limit_outgoing_gas {
@@ -1201,10 +1205,6 @@ fn test_resharding_v3_base(params: TestReshardingParameters) {
         }
         let runtime_config_store = RuntimeConfigStore::with_one_config(runtime_config);
         builder = builder.runtime_config_store(runtime_config_store);
-    }
-
-    if params.allow_negative_refcount {
-        builder = builder.test_store_flags(TestStoreFlags { allow_negative_refcount: true });
     }
 
     let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } = builder

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -156,6 +156,8 @@ struct TestReshardingParameters {
     delay_flat_state_resharding: BlockHeightDelta,
     /// Make promise yield timeout much shorter than normal.
     short_yield_timeout: bool,
+    // TODO(resharding) Remove this when negative refcounts are properly handled.
+    /// Whether to allow negative refcount being a result of the database update.
     allow_negative_refcount: bool,
 }
 

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -16,7 +16,6 @@ use near_primitives::types::{AccountId, BlockHeightDelta, EpochId, Gas, NumShard
 use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_store::adapter::StoreAdapter;
 use near_store::db::refcount::decode_value_with_rc;
-use near_store::db::TestStoreFlags;
 use near_store::{get, DBCol, ShardUId, Trie};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;


### PR DESCRIPTION
With reshardingV3, parent's delayed receipts are copied (shared) to both children and irrelevant receipts are ignored by children. However, it causes the same delayed receipt to be removed twice (by both children) during garbage collection, which causes `TestDB` to panic in resharding testloop tests. But it works in real setting, where apparently rocksdb allow negative refcounts.
After [discussion](https://near.zulipchat.com/#narrow/channel/407288-core.2Fresharding/topic/Delayed.20Receipts), we decided to ignore negative refcounts in `TestDB` for resharding only, and may think about proper solution later.