### PR TITLE
refactor(InMemorySigner, InMemoryValidatorSigner) factory methods 

### DIFF
--- a/chain/chunks/src/chunk_cache.rs
+++ b/chain/chunks/src/chunk_cache.rs
@@ -297,7 +297,7 @@ mod tests {
             CryptoHash::default(),
             CryptoHash::default(),
             vec![],
-            &signer.into(),
+            &signer,
         ))
     }
 

--- a/chain/client/src/tests/doomslug.rs
+++ b/chain/client/src/tests/doomslug.rs
@@ -31,7 +31,7 @@ fn test_processing_skips_on_forks() {
     env.process_block(1, b2, Provenance::NONE);
     let validator_signer =
         InMemoryValidatorSigner::from_seed("test1".parse().unwrap(), KeyType::ED25519, "test1");
-    let approval = Approval::new(CryptoHash::default(), 1, 3, &validator_signer.into());
+    let approval = Approval::new(CryptoHash::default(), 1, 3, &validator_signer);
     let client_signer = env.clients[1].validator_signer.get();
     env.clients[1].collect_block_approval(&approval, ApprovalType::SelfApproval, &client_signer);
     assert!(!env.clients[1].doomslug.approval_status_at_height(&3).approvals.is_empty());

--- a/chain/network/src/accounts_data/tests.rs
+++ b/chain/network/src/accounts_data/tests.rs
@@ -4,7 +4,7 @@ use crate::network_protocol::SignedAccountData;
 use crate::testonly::{assert_is_superset, make_rng, AsSet as _, Rng};
 use near_async::time;
 use near_o11y::testonly::init_test_logger;
-use near_primitives::validator_signer::InMemoryValidatorSigner;
+use near_primitives::validator_signer::ValidatorSigner;
 use pretty_assertions::assert_eq;
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -13,11 +13,11 @@ fn make_account_data(
     rng: &mut Rng,
     clock: &time::Clock,
     version: u64,
-    signer: &InMemoryValidatorSigner,
+    signer: &ValidatorSigner,
 ) -> SignedAccountData {
     let peer_id = data::make_peer_id(rng);
     data::make_account_data(rng, version, clock.now_utc(), signer.public_key(), peer_id)
-        .sign(&signer.clone().into())
+        .sign(&signer)
         .unwrap()
 }
 
@@ -30,7 +30,7 @@ fn unwrap<'a, T: std::hash::Hash + std::cmp::Eq, E: std::fmt::Debug>(
     &v.0
 }
 
-fn make_signers(rng: &mut Rng, n: usize) -> Vec<InMemoryValidatorSigner> {
+fn make_signers(rng: &mut Rng, n: usize) -> Vec<ValidatorSigner> {
     (0..n).map(|_| data::make_validator_signer(rng)).collect()
 }
 

--- a/core/crypto/src/signer.rs
+++ b/core/crypto/src/signer.rs
@@ -113,11 +113,11 @@ impl InMemorySigner {
     #[cfg(feature = "rand")]
     pub fn from_seed(account_id: AccountId, key_type: KeyType, seed: &str) -> Signer {
         let secret_key = SecretKey::from_seed(key_type, seed);
-        Signer::InMemory(Self { account_id, public_key: secret_key.public_key(), secret_key })
+        InMemorySigner::from_secret_key(account_id, secret_key)
     }
 
-    pub fn from_secret_key(account_id: AccountId, secret_key: SecretKey) -> Self {
-        Self { account_id, public_key: secret_key.public_key(), secret_key }
+    pub fn from_secret_key(account_id: AccountId, secret_key: SecretKey) -> Signer {
+        Signer::InMemory(Self { account_id, public_key: secret_key.public_key(), secret_key })
     }
 
     pub fn from_file(path: &Path) -> io::Result<Signer> {

--- a/core/primitives/benches/serialization.rs
+++ b/core/primitives/benches/serialization.rs
@@ -77,7 +77,7 @@ fn create_block() -> Block {
         Some(0),
         vec![],
         vec![],
-        &signer.into(),
+        &signer,
         CryptoHash::default(),
         CryptoHash::default(),
         Clock::real(),

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -1064,7 +1064,6 @@ pub fn create_test_signer(account_name: &str) -> ValidatorSigner {
         near_crypto::KeyType::ED25519,
         account_name,
     )
-    .into()
 }
 
 /// Helper function that creates a new signer for a given account, that uses the account name as seed.

--- a/core/primitives/src/validator_signer.rs
+++ b/core/primitives/src/validator_signer.rs
@@ -65,12 +65,6 @@ impl From<EmptyValidatorSigner> for ValidatorSigner {
     }
 }
 
-impl From<InMemoryValidatorSigner> for ValidatorSigner {
-    fn from(signer: InMemoryValidatorSigner) -> Self {
-        ValidatorSigner::InMemory(signer)
-    }
-}
-
 /// Test-only signer that "signs" everything with 0s.
 /// Don't use in any production or code that requires signature verification.
 #[derive(smart_default::SmartDefault, Clone, Debug, PartialEq)]
@@ -106,26 +100,29 @@ pub struct InMemoryValidatorSigner {
 
 impl InMemoryValidatorSigner {
     #[cfg(feature = "rand")]
-    pub fn from_random(account_id: AccountId, key_type: KeyType) -> Self {
+    pub fn from_random(account_id: AccountId, key_type: KeyType) -> ValidatorSigner {
         let signer = Arc::new(InMemorySigner::from_random(account_id.clone(), key_type).into());
-        Self { account_id, signer }
+        ValidatorSigner::InMemory(Self { account_id, signer })
     }
 
     #[cfg(feature = "rand")]
-    pub fn from_seed(account_id: AccountId, key_type: KeyType, seed: &str) -> Self {
+    pub fn from_seed(account_id: AccountId, key_type: KeyType, seed: &str) -> ValidatorSigner {
         let signer = Arc::new(InMemorySigner::from_seed(account_id.clone(), key_type, seed));
-        Self { account_id, signer }
+        ValidatorSigner::InMemory(Self { account_id, signer })
     }
 
     pub fn public_key(&self) -> PublicKey {
         self.signer.public_key()
     }
 
-    pub fn from_signer(signer: Signer) -> Self {
-        Self { account_id: signer.get_account_id(), signer: Arc::new(signer) }
+    pub fn from_signer(signer: Signer) -> ValidatorSigner {
+        ValidatorSigner::InMemory(Self {
+            account_id: signer.get_account_id(),
+            signer: Arc::new(signer),
+        })
     }
 
-    pub fn from_file(path: &Path) -> std::io::Result<Self> {
+    pub fn from_file(path: &Path) -> std::io::Result<ValidatorSigner> {
         let signer = InMemorySigner::from_file(path)?;
         Ok(Self::from_signer(signer))
     }

--- a/core/store/benches/finalize_bench.rs
+++ b/core/store/benches/finalize_bench.rs
@@ -32,7 +32,7 @@ use near_primitives::sharding::{
 };
 use near_primitives::transaction::{Action, FunctionCallAction, SignedTransaction};
 use near_primitives::types::{AccountId, ShardId};
-use near_primitives::validator_signer::InMemoryValidatorSigner;
+use near_primitives::validator_signer::{InMemoryValidatorSigner, ValidatorSigner};
 use near_primitives::version::{ProtocolFeature, PROTOCOL_VERSION};
 use near_store::DBCol;
 use rand::prelude::SliceRandom;
@@ -86,7 +86,7 @@ fn benchmark_write_partial_encoded_chunk(bench: &mut Bencher) {
     });
 }
 
-fn validator_signer() -> InMemoryValidatorSigner {
+fn validator_signer() -> ValidatorSigner {
     InMemoryValidatorSigner::from_random("test".parse().unwrap(), KeyType::ED25519)
 }
 
@@ -138,7 +138,7 @@ fn create_chunk_header(height: u64, shard_id: ShardId) -> ShardChunkHeader {
         vec![],
         congestion_info,
         BandwidthRequests::default_for_protocol_version(PROTOCOL_VERSION),
-        &validator_signer().into(),
+        &validator_signer(),
     ))
 }
 
@@ -211,7 +211,7 @@ fn create_encoded_shard_chunk(
         Default::default(),
         congestion_info,
         BandwidthRequests::default_for_protocol_version(PROTOCOL_VERSION),
-        &validator_signer().into(),
+        &validator_signer(),
         &rs,
         100,
     )

--- a/integration-tests/src/tests/client/block_corruption.rs
+++ b/integration-tests/src/tests/client/block_corruption.rs
@@ -83,10 +83,11 @@ fn change_shard_id_to_invalid() {
     // 2. Rehash and resign
     let body_hash = block.compute_block_body_hash().unwrap();
     block.mut_header().set_block_body_hash(body_hash);
-    block.mut_header().resign(
-        &InMemoryValidatorSigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "test0")
-            .into(),
-    );
+    block.mut_header().resign(&InMemoryValidatorSigner::from_seed(
+        "test0".parse().unwrap(),
+        KeyType::ED25519,
+        "test0",
+    ));
 
     // Try to process corrupt block and expect code to notice invalid shard_id
     let res = env.clients[0].process_block_test(block.into(), Provenance::NONE);
@@ -128,14 +129,11 @@ fn check_corrupt_block(
     if let Ok(mut corrupt_block) = Block::try_from_slice(corrupt_block_vec.as_slice()) {
         let body_hash = corrupt_block.compute_block_body_hash().unwrap();
         corrupt_block.mut_header().set_block_body_hash(body_hash);
-        corrupt_block.mut_header().resign(
-            &InMemoryValidatorSigner::from_seed(
-                "test0".parse().unwrap(),
-                KeyType::ED25519,
-                "test0",
-            )
-            .into(),
-        );
+        corrupt_block.mut_header().resign(&InMemoryValidatorSigner::from_seed(
+            "test0".parse().unwrap(),
+            KeyType::ED25519,
+            "test0",
+        ));
 
         if !is_breaking_block_change(&correct_block, &corrupt_block) {
             return Ok(anyhow::anyhow!(NOT_BREAKING_CHANGE_MSG));

--- a/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/client/features/access_key_nonce_for_implicit_accounts.rs
@@ -7,7 +7,7 @@ use near_chain_configs::{Genesis, NEAR_BASE};
 use near_chunks::metrics::PARTIAL_ENCODED_CHUNK_FORWARD_CACHED_WITHOUT_HEADER;
 use near_client::test_utils::{create_chunk_with_transactions, TestEnv};
 use near_client::{ProcessTxResponse, ProduceChunkResult};
-use near_crypto::{InMemorySigner, KeyType, SecretKey};
+use near_crypto::{InMemorySigner, KeyType, SecretKey, Signer};
 use near_network::shards_manager::ShardsManagerRequestFromNetwork;
 use near_network::types::{NetworkRequests, PeerManagerMessageRequest};
 use near_o11y::testonly::init_test_logger;
@@ -113,7 +113,7 @@ fn test_transaction_hash_collision() {
 /// should fail since the protocol upgrade.
 fn get_status_of_tx_hash_collision_for_near_implicit_account(
     protocol_version: ProtocolVersion,
-    near_implicit_account_signer: InMemorySigner,
+    near_implicit_account_signer: Signer,
 ) -> ProcessTxResponse {
     let epoch_length = 100;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
@@ -125,8 +125,7 @@ fn get_status_of_tx_hash_collision_for_near_implicit_account(
     let mut height = 1;
     let blocks_number = 5;
     let signer1 = InMemorySigner::test_signer(&"test1".parse().unwrap());
-    let near_implicit_account_id = near_implicit_account_signer.account_id.clone();
-    let near_implicit_account_signer = near_implicit_account_signer.into();
+    let near_implicit_account_id = near_implicit_account_signer.get_account_id();
 
     // Send money to NEAR-implicit account, invoking its creation.
     let send_money_tx = SignedTransaction::send_money(

--- a/integration-tests/src/tests/client/runtimes.rs
+++ b/integration-tests/src/tests/client/runtimes.rs
@@ -59,8 +59,7 @@ fn test_invalid_approvals() {
     assert_eq!(env.clients[0].pending_approvals.len(), 0);
     // Approval with invalid signature. Should be dropped
     let signer =
-        InMemoryValidatorSigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "random")
-            .into();
+        InMemoryValidatorSigner::from_seed("test0".parse().unwrap(), KeyType::ED25519, "random");
     let genesis_hash = *env.clients[0].chain.genesis().hash();
     let approval = Approval::new(genesis_hash, 0, 1, &signer);
     env.clients[0].collect_block_approval(

--- a/integration-tests/src/tests/client/state_dump.rs
+++ b/integration-tests/src/tests/client/state_dump.rs
@@ -143,7 +143,7 @@ fn run_state_sync_with_dumped_parts(
 
     let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let validator = MutableConfigValue::new(
-        Some(Arc::new(InMemoryValidatorSigner::from_signer(signer.clone()).into())),
+        Some(Arc::new(InMemoryValidatorSigner::from_signer(signer.clone()))),
         "validator_signer",
     );
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -1366,7 +1366,7 @@ pub fn load_validator_key(validator_file: &Path) -> anyhow::Result<Option<Arc<Va
         return Ok(None);
     }
     match InMemoryValidatorSigner::from_file(&validator_file) {
-        Ok(signer) => Ok(Some(Arc::new(signer.into()))),
+        Ok(signer) => Ok(Some(Arc::new(signer))),
         Err(_) => {
             let error_message =
                 format!("Failed initializing validator signer from {}", validator_file.display());

--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -374,10 +374,10 @@ mod test {
                 secret_key: SecretKey::from_random(KeyType::ED25519),
             },
             MutableConfigValue::new(
-                Some(Arc::new(
-                    InMemoryValidatorSigner::from_random("test".parse().unwrap(), KeyType::ED25519)
-                        .into(),
-                )),
+                Some(Arc::new(InMemoryValidatorSigner::from_random(
+                    "test".parse().unwrap(),
+                    KeyType::ED25519,
+                ))),
                 "validator_signer",
             ),
         )
@@ -763,10 +763,10 @@ mod test {
                 secret_key: SecretKey::from_random(KeyType::ED25519),
             },
             MutableConfigValue::new(
-                Some(Arc::new(
-                    InMemoryValidatorSigner::from_random("test".parse().unwrap(), KeyType::ED25519)
-                        .into(),
-                )),
+                Some(Arc::new(InMemoryValidatorSigner::from_random(
+                    "test".parse().unwrap(),
+                    KeyType::ED25519,
+                ))),
                 "validator_signer",
             ),
         )
@@ -839,10 +839,10 @@ mod test {
                 secret_key: SecretKey::from_random(KeyType::ED25519),
             },
             MutableConfigValue::new(
-                Some(Arc::new(
-                    InMemoryValidatorSigner::from_random("test".parse().unwrap(), KeyType::ED25519)
-                        .into(),
-                )),
+                Some(Arc::new(InMemoryValidatorSigner::from_random(
+                    "test".parse().unwrap(),
+                    KeyType::ED25519,
+                ))),
                 "validator_signer",
             ),
         )


### PR DESCRIPTION
Following #11531  InMemorySigner's and InMemoryValidatorSigner's factory methods should return Signer and ValidatorSigner interfaces respectively. The PR provides such implementation for:
- InMemorySigner::from_secret_key
- InMemoryValidatorSigner::from_random
- InMemoryValidatorSigner::from_seed
- InMemoryValidatorSigner::from_signer
- InMemoryValidatorSigner::from_file