### PR TITLE
test(resharding): chunk dropper fix

### DIFF
--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -166,14 +166,14 @@ fn should_drop_chunk_for_protocol_upgrade(
     let epoch_protocol_version =
         epoch_manager_adapter.get_epoch_protocol_version(&epoch_id).unwrap();
     // Drop condition for the first epoch with new protocol version.
-    if epoch_protocol_version == version_of_protocol_upgrade {
+    if epoch_protocol_version >= version_of_protocol_upgrade {
         let prev_epoch_id =
             epoch_manager_adapter.get_prev_epoch_id_from_prev_block(prev_block_hash).unwrap();
         let prev_epoch_protocol_version =
             epoch_manager_adapter.get_epoch_protocol_version(&prev_epoch_id).unwrap();
         // If this is not the first epoch with new protocol version,
         // all chunks go through.
-        if prev_epoch_protocol_version == version_of_protocol_upgrade {
+        if prev_epoch_protocol_version >= version_of_protocol_upgrade {
             return false;
         }
 
@@ -189,7 +189,7 @@ fn should_drop_chunk_for_protocol_upgrade(
         let epoch_start_height =
             epoch_manager_adapter.get_epoch_start_height(&prev_block_hash).unwrap();
         range.contains(&(height_created as i64 - epoch_start_height as i64))
-    } else if epoch_protocol_version + 1 == version_of_protocol_upgrade {
+    } else if epoch_protocol_version < version_of_protocol_upgrade {
         // Drop condition for the last epoch with old protocol version.
         let maybe_upgrade_height = epoch_manager_adapter
             .get_estimated_protocol_upgrade_block_height(*prev_block_hash)

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -1056,6 +1056,7 @@ fn test_resharding_v3_base(params: TestReshardingParameters) {
             }
             trie_sanity_check.assert_state_sanity(&clients, expected_num_shards);
             latest_block_height.set(tip.height);
+            println!("Block: {} {:?}", tip.height, block_header.chunk_mask());
             if params.all_chunks_expected && params.chunk_ranges_to_drop.is_empty() {
                 assert!(block_header.chunk_mask().iter().all(|chunk_bit| *chunk_bit));
             }
@@ -1161,10 +1162,18 @@ fn test_resharding_v3_double_sign_resharding_block() {
 
 #[test]
 fn test_resharding_v3_shard_shuffling() {
+    let chunk_ranges_to_drop = HashMap::from([
+        (ShardUId { shard_id: 0, version: 3 }, -1..2),
+        (ShardUId { shard_id: 1, version: 3 }, -3..0),
+        (ShardUId { shard_id: 2, version: 3 }, -3..0),
+        (ShardUId { shard_id: 3, version: 3 }, 0..3),
+        (ShardUId { shard_id: 4, version: 3 }, 0..1),
+    ]);
     let params = TestReshardingParameters::new()
         .shuffle_shard_assignment()
         .single_shard_tracking()
-        .chunk_miss_possible();
+        .chunk_miss_possible()
+        .chunk_ranges_to_drop(chunk_ranges_to_drop);
     test_resharding_v3_base(params);
 }
 

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -1056,7 +1056,6 @@ fn test_resharding_v3_base(params: TestReshardingParameters) {
             }
             trie_sanity_check.assert_state_sanity(&clients, expected_num_shards);
             latest_block_height.set(tip.height);
-            println!("Block: {} {:?}", tip.height, block_header.chunk_mask());
             if params.all_chunks_expected && params.chunk_ranges_to_drop.is_empty() {
                 assert!(block_header.chunk_mask().iter().all(|chunk_bit| *chunk_bit));
             }
@@ -1162,18 +1161,10 @@ fn test_resharding_v3_double_sign_resharding_block() {
 
 #[test]
 fn test_resharding_v3_shard_shuffling() {
-    let chunk_ranges_to_drop = HashMap::from([
-        (ShardUId { shard_id: 0, version: 3 }, -1..2),
-        (ShardUId { shard_id: 1, version: 3 }, -3..0),
-        (ShardUId { shard_id: 2, version: 3 }, -3..0),
-        (ShardUId { shard_id: 3, version: 3 }, 0..3),
-        (ShardUId { shard_id: 4, version: 3 }, 0..1),
-    ]);
     let params = TestReshardingParameters::new()
         .shuffle_shard_assignment()
         .single_shard_tracking()
-        .chunk_miss_possible()
-        .chunk_ranges_to_drop(chunk_ranges_to_drop);
+        .chunk_miss_possible();
     test_resharding_v3_base(params);
 }
 


### PR DESCRIPTION
Since `SimpleNightshadeV4` stopped being the latest nightly feature, the dropper stopped dropping chunks **after** protocol upgrade, because the protocol version became too high.