### PR TITLE
Fix persistence of the Receipts column if we don't track all shards.

### DIFF
--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -504,15 +504,15 @@ impl<'a> ChainUpdate<'a> {
             .get_block_header_on_chain_by_height(&sync_hash, chunk.height_included())?;
 
         // Getting actual incoming receipts.
-        let mut receipt_proof_response: Vec<ReceiptProofResponse> = vec![];
+        let mut receipt_proof_responses: Vec<ReceiptProofResponse> = vec![];
         for incoming_receipt_proof in incoming_receipts_proofs.iter() {
             let ReceiptProofResponse(hash, _) = incoming_receipt_proof;
             let block_header = self.chain_store_update.get_block_header(hash)?;
             if block_header.height() <= chunk.height_included() {
-                receipt_proof_response.push(incoming_receipt_proof.clone());
+                receipt_proof_responses.push(incoming_receipt_proof.clone());
             }
         }
-        let receipts = collect_receipts_from_response(&receipt_proof_response);
+        let receipts = collect_receipts_from_response(&receipt_proof_responses);
         // Prev block header should be present during state sync, since headers have been synced at this point.
         let gas_price = if block_header.height() == self.chain_store_update.get_genesis_height() {
             block_header.next_gas_price()
@@ -601,7 +601,7 @@ impl<'a> ChainUpdate<'a> {
             outcome_proofs,
         );
         // Saving all incoming receipts.
-        for receipt_proof_response in receipt_proof_response {
+        for receipt_proof_response in receipt_proof_responses {
             self.chain_store_update.save_incoming_receipt(
                 &receipt_proof_response.0,
                 shard_id,

--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -601,7 +601,7 @@ impl<'a> ChainUpdate<'a> {
             outcome_proofs,
         );
         // Saving all incoming receipts.
-        for receipt_proof_response in incoming_receipts_proofs {
+        for receipt_proof_response in receipt_proof_response {
             self.chain_store_update.save_incoming_receipt(
                 &receipt_proof_response.0,
                 shard_id,

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -16,6 +16,7 @@ use near_store::{DBCol, KeyForStateChanges, ShardTries, ShardUId};
 
 use crate::types::RuntimeAdapter;
 use crate::{metrics, Chain, ChainStore, ChainStoreAccess, ChainStoreUpdate};
+use near_primitives::sharding::ReceiptProof;
 
 #[derive(Clone)]
 pub enum GCMode {
@@ -433,9 +434,6 @@ impl<'a> ChainStoreUpdate<'a> {
                 for transaction in chunk.transactions() {
                     self.gc_col(DBCol::Transactions, transaction.get_hash().as_bytes());
                 }
-                for receipt in chunk.prev_outgoing_receipts() {
-                    self.gc_col(DBCol::Receipts, receipt.get_hash().as_bytes());
-                }
 
                 // 2. Delete chunk_hash-indexed data
                 let chunk_hash = chunk_hash.as_bytes();
@@ -599,7 +597,7 @@ impl<'a> ChainStoreUpdate<'a> {
         for shard_id in shard_layout.shard_ids() {
             let block_shard_id = get_block_shard_id(&block_hash, shard_id);
             self.gc_outgoing_receipts(&block_hash, shard_id);
-            self.gc_col(DBCol::IncomingReceipts, &block_shard_id);
+            self.gc_incoming_receipts(&block_hash, shard_id);
             self.gc_col(DBCol::StateTransitionData, &block_shard_id);
 
             // For incoming State Parts it's done in chain.clear_downloaded_parts()
@@ -700,7 +698,7 @@ impl<'a> ChainStoreUpdate<'a> {
 
             // delete Receipts
             self.gc_outgoing_receipts(&block_hash, shard_id);
-            self.gc_col(DBCol::IncomingReceipts, &block_shard_id);
+            self.gc_incoming_receipts(&block_hash, shard_id);
 
             self.gc_col(DBCol::StateTransitionData, &block_shard_id);
 
@@ -765,9 +763,6 @@ impl<'a> ChainStoreUpdate<'a> {
             debug_assert_eq!(chunk.cloned_header().height_created(), height);
             for transaction in chunk.transactions() {
                 self.gc_col(DBCol::Transactions, transaction.get_hash().as_bytes());
-            }
-            for receipt in chunk.prev_outgoing_receipts() {
-                self.gc_col(DBCol::Receipts, receipt.get_hash().as_bytes());
             }
 
             // 2. Delete chunk_hash-indexed data
@@ -836,6 +831,27 @@ impl<'a> ChainStoreUpdate<'a> {
         self.merge(store_update);
     }
 
+    fn gc_incoming_receipts(&mut self, block_hash: &CryptoHash, shard_id: ShardId) {
+        let mut store_update = self.store().store_update();
+        let key = get_block_shard_id(block_hash, shard_id);
+        // IncomingReceipts and Receipts are equivalent but keyed differently. So as we clean up
+        // IncomingReceipts, also clean up Receipts.
+        if let Ok(incoming_receipts) =
+            self.store().get_ser::<Vec<ReceiptProof>>(DBCol::IncomingReceipts, &key)
+        {
+            if let Some(incoming_receipts) = incoming_receipts {
+                for receipts in incoming_receipts {
+                    for receipt in receipts.0 {
+                        self.gc_col(DBCol::Receipts, receipt.receipt_id().as_bytes());
+                    }
+                }
+            }
+        }
+        store_update.delete(DBCol::IncomingReceipts, &key);
+        self.chain_store().incoming_receipts.pop(&key);
+        self.merge(store_update);
+    }
+
     fn gc_outcomes(&mut self, block: &Block) -> Result<(), Error> {
         let block_hash = block.hash();
         let store_update = self.store().store_update();
@@ -868,8 +884,7 @@ impl<'a> ChainStoreUpdate<'a> {
                 panic!("Outgoing receipts must be garbage collected by calling gc_outgoing_receipts");
             }
             DBCol::IncomingReceipts => {
-                store_update.delete(col, key);
-                self.chain_store().incoming_receipts.pop(key);
+                panic!("Incoming receipts must be garbage collected by calling gc_incoming_receipts");
             }
             DBCol::StateHeaders => {
                 store_update.delete(col, key);

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -2356,16 +2356,6 @@ impl<'a> ChainStoreUpdate<'a> {
                     );
                 }
 
-                // Increase receipt refcounts for all included receipts
-                for receipt in chunk.prev_outgoing_receipts().iter() {
-                    let bytes = borsh::to_vec(&receipt).expect("Borsh cannot fail");
-                    store_update.increment_refcount(
-                        DBCol::Receipts,
-                        receipt.get_hash().as_ref(),
-                        &bytes,
-                    );
-                }
-
                 store_update.insert_ser(DBCol::Chunks, chunk_hash.as_ref(), chunk)?;
             }
             for (height, hash_set) in chunk_hashes_by_height {
@@ -2425,6 +2415,16 @@ impl<'a> ChainStoreUpdate<'a> {
                     &get_block_shard_id(block_hash, *shard_id),
                     receipt,
                 )?;
+                for receipts in receipt.iter() {
+                    for receipt in &receipts.0 {
+                        let bytes = borsh::to_vec(&receipt).expect("Borsh cannot fail");
+                        store_update.increment_refcount(
+                            DBCol::Receipts,
+                            receipt.get_hash().as_ref(),
+                            &bytes,
+                        );
+                    }
+                }
             }
         }
 

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -160,6 +160,13 @@ impl StoreValidator {
                     self.check(&validate::block_header_exists, &block_hash, &block, col);
                     // Chunks for current Block exist
                     self.check(&validate::block_chunks_exist, &block_hash, &block, col);
+                    // IncomingReceipts for the Block are an exact mapping with the receipts in the Receipts column
+                    self.check(
+                        &validate::receipts_contain_block_incoming_receipts,
+                        &block_hash,
+                        &block,
+                        col,
+                    );
                     // Chunks for current Block have Height Created not higher than Block Height
                     self.check(&validate::block_chunks_height_validity, &block_hash, &block, col);
                     // BlockInfo for current Block exists

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -400,14 +400,7 @@ fn apply_receipt_in_chunk(
     id: &CryptoHash,
     storage: StorageSource,
 ) -> anyhow::Result<Vec<ApplyChunkResult>> {
-    if chain_store.get_receipt(id)?.is_none() {
-        // TODO: handle local/delayed receipts
-        return Err(anyhow!("receipt with ID {} not known. Is it a local or delayed receipt?", id));
-    }
-
-    println!(
-        "Receipt is known but doesn't seem to have been applied. Searching in chunks that haven't been applied..."
-    );
+    println!("Receipt is not indexed; searching in chunks that haven't been applied...");
 
     let head = chain_store.head()?.height;
     let protocol_version = chain_store.head_header()?.latest_protocol_version();


### PR DESCRIPTION
Detailed discussion here https://near.zulipchat.com/#narrow/channel/295558-core/topic/DBCol.3A.3AReceipts.20.2B.20single.20shard.20tracking

The way we choose the receipts to write to DBCol::Receipts is incorrect if the node does not track all shards. The prev_outgoing_receipts of a chunk do not represent the receipts executed by the chunk, but rather the outgoing receipts from the execution of the previous chunk, which target arbitrary shards. In other words, if a node tracks only some shards, a receipt may be executed by the node but not actually in the Receipts column.

To fix this, we change the DBCol::Receipts column to be an exact reindexing of the DBCol::IncomingReceipts column, which accurately reflects the receipts that this node would actually execute.

Even though this changes the semantics of the column, there is no DB migration, because:
* For RPC or archival nodes or any node that is not a validator, currently they all track all shards, meaning that the IncomingReceipts column for the same block is the same as the aggregation of the prev_outgoing_receipts of all new chunks in this block, so the data in the DBCol::Receipts (including refcounts) would be identical before and after this PR.
* For validator nodes, they have no use of the DBCol::Receipts column. Even though this change would introduce some inconsistency on that column (GC deleting some receipts that didn't exist before, and failing to clean up some receipts that existed before), the column is not used so it doesn't matter. The space wasted from failing to clean up some of the receipts is very limited compared to how much space could be saved later via Epoch Sync. So it's not worth doing a migration.

The store_validator has been augmented to properly check for the equivalence of DBCol::Receipts against DBCol::IncomingReceipts. (We used to only check for the refcount of whatever receipts existed in DBCol::Receipts, meaning that the store validator would not have complained if we persisted no receipts at all in that column).

One additional very subtle fix: for state sync, in set_state_finalize, we only persist the incoming receipts relevant to the chunk we executed, rather than the whole incoming_receipts_proofs, because the latter can actually include receipts *later* than the chunk being executed, causing double-counting of the sync_hash block's incoming receipts.