### PR TITLE
feat: add metric for excluded chunks on the block producer side

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1132,8 +1132,8 @@ impl ClientActorInner {
                     .client
                     .chunk_inclusion_tracker
                     .num_chunk_headers_ready_for_inclusion(&epoch_id, &head.last_block_hash);
-                let have_all_chunks = head.height == 0
-                    || num_chunks == self.client.epoch_manager.shard_ids(&epoch_id).unwrap().len();
+                let shard_ids = self.client.epoch_manager.shard_ids(&epoch_id).unwrap();
+                let have_all_chunks = head.height == 0 || num_chunks == shard_ids.len();
 
                 if self.client.doomslug.ready_to_produce_block(
                     height,
@@ -1142,7 +1142,7 @@ impl ClientActorInner {
                 ) {
                     self.client
                         .chunk_inclusion_tracker
-                        .record_endorsement_metrics(&head.last_block_hash);
+                        .record_endorsement_metrics(&head.last_block_hash, &shard_ids);
                     if let Err(err) = self.produce_block(height, signer) {
                         // If there is an error, report it and let it retry on the next loop step.
                         error!(target: "client", height, "Block production failed: {}", err);

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -602,12 +602,12 @@ pub(crate) static ORPHAN_CHUNK_STATE_WITNESS_POOL_MEMORY_USED: LazyLock<IntGauge
         .unwrap()
     });
 
-pub(crate) static BLOCK_PRODUCER_INSUFFICIENT_ENDORSEMENT_CHUNK_COUNT: LazyLock<CounterVec> =
+pub(crate) static BLOCK_PRODUCER_EXCLUDED_CHUNKS_COUNT: LazyLock<CounterVec> =
     LazyLock::new(|| {
         try_create_counter_vec(
-            "near_block_producer_insufficient_endorsement_chunk_count",
+            "near_block_producer_excluded_chunks_count",
             "Number of chunks excluded from the block due to insufficient chunk endorsements",
-            &["shard_id"],
+            &["shard_id", "reason"],
         )
         .unwrap()
     });


### PR DESCRIPTION
This PR extends `near_block_producer_insufficient_endorsement_chunk_count` metric to `near_block_producer_excluded_chunks_count` with `reason` label. 