### PR TITLE
fix(tests): Mark some tests as slower

### DIFF
--- a/core/store/src/opener.rs
+++ b/core/store/src/opener.rs
@@ -648,7 +648,7 @@ mod tests {
     }
 
     #[test]
-    fn test_checkpoint_hot_storage_and_cleanup_columns() {
+    fn slow_test_checkpoint_hot_storage_and_cleanup_columns() {
         let (home_dir, opener) = NodeStorage::test_opener();
         let node_storage = opener.open().unwrap();
         let hot_store = Store { storage: node_storage.hot_storage.clone() };

--- a/integration-tests/src/tests/client/state_dump.rs
+++ b/integration-tests/src/tests/client/state_dump.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 #[test]
 /// Produce several blocks, wait for the state dump thread to notice and
 /// write files to a temp dir.
-fn test_state_dump() {
+fn slow_test_state_dump() {
     init_test_logger();
 
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);

--- a/integration-tests/src/tests/client/sync_state_nodes.rs
+++ b/integration-tests/src/tests/client/sync_state_nodes.rs
@@ -443,7 +443,7 @@ fn ultra_slow_test_sync_state_dump() {
 
 #[test]
 // Test that state sync behaves well when the chunks are absent at the end of the epoch.
-fn slow_test_dump_epoch_missing_chunk_in_last_block() {
+fn ultra_slow_test_dump_epoch_missing_chunk_in_last_block() {
     heavy_test(|| {
         init_test_logger();
         let epoch_length = 10;


### PR DESCRIPTION
When I run the tests with `--test-threads 16` these three tests often timeout. They work with `--test-threads 1`, but then it takes forever to run the tests.

Could we move them one slowness class up?