### PR TITLE
Revise #12613 by using PartialEncodedChunk instead of IncomingReceipts

### DIFF
--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -16,7 +16,6 @@ use near_store::{DBCol, KeyForStateChanges, ShardTries, ShardUId};
 
 use crate::types::RuntimeAdapter;
 use crate::{metrics, Chain, ChainStore, ChainStoreAccess, ChainStoreUpdate};
-use near_primitives::sharding::ReceiptProof;
 
 #[derive(Clone)]
 pub enum GCMode {
@@ -435,6 +434,15 @@ impl<'a> ChainStoreUpdate<'a> {
                     self.gc_col(DBCol::Transactions, transaction.get_hash().as_bytes());
                 }
 
+                let partial_chunk = self.get_partial_chunk(&chunk_hash);
+                if let Ok(partial_chunk) = partial_chunk {
+                    for receipts in partial_chunk.prev_outgoing_receipts() {
+                        for receipt in &receipts.0 {
+                            self.gc_col(DBCol::Receipts, receipt.receipt_id().as_bytes());
+                        }
+                    }
+                }
+
                 // 2. Delete chunk_hash-indexed data
                 let chunk_hash = chunk_hash.as_bytes();
                 self.gc_col(DBCol::Chunks, chunk_hash);
@@ -597,7 +605,7 @@ impl<'a> ChainStoreUpdate<'a> {
         for shard_id in shard_layout.shard_ids() {
             let block_shard_id = get_block_shard_id(&block_hash, shard_id);
             self.gc_outgoing_receipts(&block_hash, shard_id);
-            self.gc_incoming_receipts(&block_hash, shard_id);
+            self.gc_col(DBCol::IncomingReceipts, &block_shard_id);
             self.gc_col(DBCol::StateTransitionData, &block_shard_id);
 
             // For incoming State Parts it's done in chain.clear_downloaded_parts()
@@ -698,7 +706,7 @@ impl<'a> ChainStoreUpdate<'a> {
 
             // delete Receipts
             self.gc_outgoing_receipts(&block_hash, shard_id);
-            self.gc_incoming_receipts(&block_hash, shard_id);
+            self.gc_col(DBCol::IncomingReceipts, &block_shard_id);
 
             self.gc_col(DBCol::StateTransitionData, &block_shard_id);
 
@@ -763,6 +771,15 @@ impl<'a> ChainStoreUpdate<'a> {
             debug_assert_eq!(chunk.cloned_header().height_created(), height);
             for transaction in chunk.transactions() {
                 self.gc_col(DBCol::Transactions, transaction.get_hash().as_bytes());
+            }
+
+            let partial_chunk = self.get_partial_chunk(&chunk_hash);
+            if let Ok(partial_chunk) = partial_chunk {
+                for receipts in partial_chunk.prev_outgoing_receipts() {
+                    for receipt in &receipts.0 {
+                        self.gc_col(DBCol::Receipts, receipt.receipt_id().as_bytes());
+                    }
+                }
             }
 
             // 2. Delete chunk_hash-indexed data
@@ -831,27 +848,6 @@ impl<'a> ChainStoreUpdate<'a> {
         self.merge(store_update);
     }
 
-    fn gc_incoming_receipts(&mut self, block_hash: &CryptoHash, shard_id: ShardId) {
-        let mut store_update = self.store().store_update();
-        let key = get_block_shard_id(block_hash, shard_id);
-        // IncomingReceipts and Receipts are equivalent but keyed differently. So as we clean up
-        // IncomingReceipts, also clean up Receipts.
-        if let Ok(incoming_receipts) =
-            self.store().get_ser::<Vec<ReceiptProof>>(DBCol::IncomingReceipts, &key)
-        {
-            if let Some(incoming_receipts) = incoming_receipts {
-                for receipts in incoming_receipts {
-                    for receipt in receipts.0 {
-                        self.gc_col(DBCol::Receipts, receipt.receipt_id().as_bytes());
-                    }
-                }
-            }
-        }
-        store_update.delete(DBCol::IncomingReceipts, &key);
-        self.chain_store().incoming_receipts.pop(&key);
-        self.merge(store_update);
-    }
-
     fn gc_outcomes(&mut self, block: &Block) -> Result<(), Error> {
         let block_hash = block.hash();
         let store_update = self.store().store_update();
@@ -884,7 +880,8 @@ impl<'a> ChainStoreUpdate<'a> {
                 panic!("Outgoing receipts must be garbage collected by calling gc_outgoing_receipts");
             }
             DBCol::IncomingReceipts => {
-                panic!("Incoming receipts must be garbage collected by calling gc_incoming_receipts");
+                store_update.delete(col, key);
+                self.chain_store().incoming_receipts.pop(key);
             }
             DBCol::StateHeaders => {
                 store_update.delete(col, key);

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -2371,6 +2371,20 @@ impl<'a> ChainStoreUpdate<'a> {
                     chunk_hash.as_ref(),
                     partial_chunk,
                 )?;
+
+                // We'd like the Receipts column to be exactly the same collection of receipts as
+                // the partial encoded chunks. This way, if we only track a subset of shards, we
+                // can still have all the incoming receipts for the shards we do track.
+                for receipts in partial_chunk.prev_outgoing_receipts() {
+                    for receipt in &receipts.0 {
+                        let bytes = borsh::to_vec(&receipt).expect("Borsh cannot fail");
+                        store_update.increment_refcount(
+                            DBCol::Receipts,
+                            receipt.get_hash().as_ref(),
+                            &bytes,
+                        );
+                    }
+                }
             }
         }
 
@@ -2415,16 +2429,6 @@ impl<'a> ChainStoreUpdate<'a> {
                     &get_block_shard_id(block_hash, *shard_id),
                     receipt,
                 )?;
-                for receipts in receipt.iter() {
-                    for receipt in &receipts.0 {
-                        let bytes = borsh::to_vec(&receipt).expect("Borsh cannot fail");
-                        store_update.increment_refcount(
-                            DBCol::Receipts,
-                            receipt.get_hash().as_ref(),
-                            &bytes,
-                        );
-                    }
-                }
             }
         }
 

--- a/chain/chunks/src/logic.rs
+++ b/chain/chunks/src/logic.rs
@@ -1,3 +1,4 @@
+use near_chain::ChainStoreAccess;
 use near_chain::{
     types::EpochManagerAdapter, validate::validate_chunk_proofs, BlockHeader, Chain, ChainStore,
 };
@@ -258,10 +259,17 @@ pub fn persist_chunk(
     shard_chunk: Option<ShardChunk>,
     store: &mut ChainStore,
 ) -> Result<(), Error> {
+    let need_persist_partial_chunk = store.get_partial_chunk(&partial_chunk.chunk_hash()).is_err();
+    let need_persist_shard_chunk = shard_chunk.is_some()
+        && store.get_chunk(&shard_chunk.as_ref().unwrap().chunk_hash()).is_err();
     let mut update = store.store_update();
-    update.save_partial_chunk(partial_chunk);
+    if need_persist_partial_chunk {
+        update.save_partial_chunk(partial_chunk);
+    };
     if let Some(shard_chunk) = shard_chunk {
-        update.save_chunk(shard_chunk);
+        if need_persist_shard_chunk {
+            update.save_chunk(shard_chunk);
+        }
     }
     update.commit()?;
     Ok(())

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1498,28 +1498,9 @@ impl Client {
         self.block_production_info
             .record_chunk_collected(partial_chunk.height_created(), shard_index);
 
-        // If we produced the chunk, don't persist the chunk again, because we would have already
-        // persisted it. It is fine except that we also increment refcount for each receipt in the
-        // Receipts column and that would double-count the same receipts.
-        let we_produced_the_chunk = if let Some(signer) = signer {
-            let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(&parent_hash).unwrap();
-            self.epoch_manager
-                .get_chunk_producer_info(&ChunkProductionKey {
-                    epoch_id,
-                    height_created: chunk_header.height_created(),
-                    shard_id,
-                })
-                .unwrap()
-                .account_id()
-                == signer.validator_id()
-        } else {
-            false
-        };
-        if !we_produced_the_chunk {
-            // TODO(#10569) We would like a proper error handling here instead of `expect`.
-            persist_chunk(partial_chunk, shard_chunk, self.chain.mut_chain_store())
-                .expect("Could not persist chunk");
-        }
+        // TODO(#10569) We would like a proper error handling here instead of `expect`.
+        persist_chunk(partial_chunk, shard_chunk, self.chain.mut_chain_store())
+            .expect("Could not persist chunk");
         // We're marking chunk as accepted.
         self.chain.blocks_with_missing_chunks.accept_chunk(&chunk_header.chunk_hash());
         // If this was the last chunk that was missing for a block, it will be processed now.


### PR DESCRIPTION
IncomingReceipts double counts when we do catchup state sync because we persist the state sync boundary's IncomingReceipts again. So.. switch to using PartialEncodedChunk to make the DBCol::Receipts column. It's equivalent, really.