### PR TITLE
chore: separated rand and test_utils features in the near-primitives

### DIFF
--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -20,7 +20,12 @@ bytesize.workspace = true
 bytes.workspace = true
 cfg-if.workspace = true
 chrono.workspace = true
-derive_more = { workspace = true, features = ["as_ref", "from", "into", "deref" ] }
+derive_more = { workspace = true, features = [
+  "as_ref",
+  "from",
+  "into",
+  "deref",
+] }
 easy-ext.workspace = true
 hex.workspace = true
 itertools.workspace = true
@@ -52,7 +57,7 @@ near-schema-checker-lib.workspace = true
 [features]
 sandbox = []
 test_features = []
-test_utils = ["rand"]
+test_utils = []
 solomon = ["reed-solomon-erasure"]
 rand = ["dep:rand", "rand_chacha", "near-crypto/rand"]
 clock = ["near-time/clock", "near-time/serde"]
@@ -86,13 +91,16 @@ nightly_protocol = [
 
 calimero_zero_storage = []
 
-protocol_schema = [
-  "near-schema-checker-lib/protocol_schema",
-]
+protocol_schema = ["near-schema-checker-lib/protocol_schema"]
 
 [dev-dependencies]
 chrono = { workspace = true, features = ["clock"] }
-near-primitives = { path = ".", features = ["clock", "solomon", "rand", "test_utils"] }
+near-primitives = { path = ".", features = [
+  "clock",
+  "solomon",
+  "rand",
+  "test_utils",
+] }
 assert_matches.workspace = true
 bencher.workspace = true
 bolero.workspace = true

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -16,8 +16,6 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use itertools::Itertools;
 use near_primitives_core::types::{ShardId, ShardIndex};
 use near_schema_checker_lib::ProtocolSchema;
-#[cfg(feature = "test_utils")]
-use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 use std::collections::{BTreeMap, BTreeSet};
 use std::{fmt, str};
 
@@ -359,7 +357,7 @@ impl ShardLayout {
     /// version and default boundary accounts. It should be used for tests only.
     /// The shard ids are deterministic but arbitrary in order to test the
     /// non-contiguous ShardIds.
-    #[cfg(feature = "test_utils")]
+    #[cfg(all(feature = "test_utils", feature = "rand"))]
     pub fn multi_shard(num_shards: NumShards, version: ShardVersion) -> Self {
         assert!(num_shards > 0, "at least 1 shard is required");
 
@@ -374,8 +372,10 @@ impl ShardLayout {
     /// version and provided boundary accounts. It should be used for tests
     /// only. The shard ids are deterministic but arbitrary in order to test the
     /// non-contiguous ShardIds.
-    #[cfg(feature = "test_utils")]
+    #[cfg(all(feature = "test_utils", feature = "rand"))]
     pub fn multi_shard_custom(boundary_accounts: Vec<AccountId>, version: ShardVersion) -> Self {
+        use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
+
         let num_shards = (boundary_accounts.len() + 1) as u64;
 
         // In order to test the non-contiguous shard ids randomize the order and
@@ -403,7 +403,7 @@ impl ShardLayout {
 
     /// Test-only helper to create a simple multi-shard ShardLayout with the provided boundaries.
     /// The shard ids are deterministic but arbitrary in order to test the non-contiguous ShardIds.
-    #[cfg(feature = "test_utils")]
+    #[cfg(all(feature = "test_utils", feature = "rand"))]
     pub fn simple_v1(boundary_accounts: &[&str]) -> ShardLayout {
         // TODO these test methods should go into a different namespace
         let boundary_accounts = boundary_accounts.iter().map(|a| a.parse().unwrap()).collect();


### PR DESCRIPTION
Simple PR with a motivation to avoid loading extra dependencies when using `test-utils`.
`near-json-rpc-client` uses `test-utils` feature for transaction.sign() API, but it doesn't really need random in the scope

@race-of-sloths