### PR TITLE
chain: don't skip early transaction validity checks in state witnesses

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -240,7 +240,6 @@ pub struct Chain {
     pub(crate) orphans: OrphanBlockPool,
     pub blocks_with_missing_chunks: MissingChunksPool<Orphan>,
     genesis: Block,
-    pub transaction_validity_period: NumBlocks,
     pub epoch_length: BlockHeightDelta,
     /// Block economics, relevant to changes when new block must be produced.
     pub block_economics_config: BlockEconomicsConfig,
@@ -398,7 +397,6 @@ impl Chain {
             blocks_with_missing_chunks: MissingChunksPool::new(),
             blocks_in_processing: BlocksInProcessing::new(),
             genesis,
-            transaction_validity_period,
             epoch_length: chain_genesis.epoch_length,
             block_economics_config: BlockEconomicsConfig::from(chain_genesis),
             doomslug_threshold_mode,
@@ -588,7 +586,6 @@ impl Chain {
             blocks_in_processing: BlocksInProcessing::new(),
             invalid_blocks: LruCache::new(NonZeroUsize::new(INVALID_CHUNKS_POOL_SIZE).unwrap()),
             genesis: genesis.clone(),
-            transaction_validity_period,
             epoch_length: chain_genesis.epoch_length,
             block_economics_config: BlockEconomicsConfig::from(chain_genesis),
             doomslug_threshold_mode,
@@ -3961,6 +3958,14 @@ impl Chain {
                 }
             }
         }
+    }
+
+    pub fn transaction_validity_period(&self) -> BlockHeightDelta {
+        self.chain_store.transaction_validity_period
+    }
+
+    pub fn set_transaction_validity_period(&mut self, to: BlockHeightDelta) {
+        self.chain_store.transaction_validity_period = to;
     }
 }
 

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3213,11 +3213,7 @@ impl Chain {
     ) -> impl FnMut(&SignedTransaction) -> bool + 'a {
         move |tx: &SignedTransaction| -> bool {
             self.chain_store()
-                .check_transaction_validity_period(
-                    &prev_block_header,
-                    tx.transaction.block_hash(),
-                    self.transaction_validity_period,
-                )
+                .check_transaction_validity_period(&prev_block_header, tx.transaction.block_hash())
                 .is_ok()
         }
     }

--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -21,7 +21,7 @@ use near_primitives::shard_layout::ShardUId;
 use near_primitives::sharding::ShardChunk;
 use near_primitives::state_sync::{ReceiptProofResponse, ShardStateSyncResponseHeader};
 use near_primitives::types::chunk_extra::ChunkExtra;
-use near_primitives::types::{BlockExtra, BlockHeight, BlockHeightDelta, ShardId};
+use near_primitives::types::{BlockExtra, BlockHeight, ShardId};
 use near_primitives::views::LightClientBlockView;
 use node_runtime::SignedValidPeriodTransactions;
 use std::sync::Arc;
@@ -36,8 +36,6 @@ pub struct ChainUpdate<'a> {
     runtime_adapter: Arc<dyn RuntimeAdapter>,
     chain_store_update: ChainStoreUpdate<'a>,
     doomslug_threshold_mode: DoomslugThresholdMode,
-    #[allow(unused)]
-    transaction_validity_period: BlockHeightDelta,
 }
 
 impl<'a> ChainUpdate<'a> {
@@ -46,32 +44,18 @@ impl<'a> ChainUpdate<'a> {
         epoch_manager: Arc<dyn EpochManagerAdapter>,
         runtime_adapter: Arc<dyn RuntimeAdapter>,
         doomslug_threshold_mode: DoomslugThresholdMode,
-        transaction_validity_period: BlockHeightDelta,
     ) -> Self {
         let chain_store_update: ChainStoreUpdate<'_> = chain_store.store_update();
-        Self::new_impl(
-            epoch_manager,
-            runtime_adapter,
-            doomslug_threshold_mode,
-            transaction_validity_period,
-            chain_store_update,
-        )
+        Self::new_impl(epoch_manager, runtime_adapter, doomslug_threshold_mode, chain_store_update)
     }
 
     fn new_impl(
         epoch_manager: Arc<dyn EpochManagerAdapter>,
         runtime_adapter: Arc<dyn RuntimeAdapter>,
         doomslug_threshold_mode: DoomslugThresholdMode,
-        transaction_validity_period: BlockHeightDelta,
         chain_store_update: ChainStoreUpdate<'a>,
     ) -> Self {
-        ChainUpdate {
-            epoch_manager,
-            runtime_adapter,
-            chain_store_update,
-            doomslug_threshold_mode,
-            transaction_validity_period,
-        }
+        ChainUpdate { epoch_manager, runtime_adapter, chain_store_update, doomslug_threshold_mode }
     }
 
     /// Commit changes to the chain into the database.
@@ -514,11 +498,17 @@ impl<'a> ChainUpdate<'a> {
             }
         }
         let receipts = collect_receipts_from_response(&receipt_proof_responses);
-        // Prev block header should be present during state sync, since headers have been synced at this point.
-        let gas_price = if block_header.height() == self.chain_store_update.get_genesis_height() {
-            block_header.next_gas_price()
+        let is_genesis = block_header.height() == self.chain_store_update.get_genesis_height();
+        let prev_block_header = is_genesis
+            .then(|| self.chain_store_update.get_block_header(block_header.prev_hash()))
+            .transpose()?;
+
+        // Prev block header should be present during state sync, since headers have been synced at
+        // this point, except for genesis.
+        let gas_price = if let Some(prev_block_header) = &prev_block_header {
+            prev_block_header.next_gas_price()
         } else {
-            self.chain_store_update.get_block_header(block_header.prev_hash())?.next_gas_price()
+            block_header.next_gas_price()
         };
 
         let chunk_header = chunk.cloned_header();
@@ -529,9 +519,18 @@ impl<'a> ChainUpdate<'a> {
         let is_first_block_with_chunk_of_version = false;
 
         let block = self.chain_store_update.get_block(block_header.hash())?;
+        let epoch_id = self.epoch_manager.get_epoch_id(block_header.hash())?;
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
         let transactions = chunk.transactions();
-        // All transactions in state sync are assumed to have had correct validity period.
-        let transaction_validity = vec![true; transactions.len()];
+        let transaction_validity = if let Some(prev_block_header) = prev_block_header {
+            self.chain_store_update.chain_store().compute_transaction_validity(
+                protocol_version,
+                &prev_block_header,
+                &chunk,
+            )?
+        } else {
+            vec![true; transactions.len()]
+        };
         let transactions = SignedValidPeriodTransactions::new(transactions, &transaction_validity);
         let apply_result = self.runtime_adapter.apply_chunk(
             RuntimeStorageConfig::new(chunk_header.prev_state_root(), true),
@@ -575,9 +574,6 @@ impl<'a> ChainUpdate<'a> {
         self.chain_store_update.merge(store_update.into());
 
         self.chain_store_update.save_trie_changes(apply_result.trie_changes);
-
-        let epoch_id = self.epoch_manager.get_epoch_id(block_header.hash())?;
-        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
 
         let chunk_extra = ChunkExtra::new(
             protocol_version,

--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -499,7 +499,7 @@ impl<'a> ChainUpdate<'a> {
         }
         let receipts = collect_receipts_from_response(&receipt_proof_responses);
         let is_genesis = block_header.height() == self.chain_store_update.get_genesis_height();
-        let prev_block_header = is_genesis
+        let prev_block_header = (!is_genesis)
             .then(|| self.chain_store_update.get_block_header(block_header.prev_hash()))
             .transpose()?;
 

--- a/chain/chain/src/flat_storage_resharder.rs
+++ b/chain/chain/src/flat_storage_resharder.rs
@@ -65,7 +65,7 @@ use std::iter;
 ///     - Children shard catchup can be cancelled and will resume from the point where it left.
 /// - Resilience to chain forks.
 ///     - Resharding events will perform changes on the state only after their resharding block
-///       becomes final.  
+///       becomes final.
 #[derive(Clone)]
 pub struct FlatStorageResharder {
     runtime: Arc<dyn RuntimeAdapter>,
@@ -1353,7 +1353,12 @@ mod tests {
             epoch_manager.clone(),
         );
         let chain_genesis = ChainGenesis::new(&genesis.config);
-        let sender = Arc::new(T::new(ChainStore::new(store, chain_genesis.height, false)));
+        let sender = Arc::new(T::new(ChainStore::new(
+            store,
+            chain_genesis.height,
+            false,
+            chain_genesis.transaction_validity_period,
+        )));
         let chain = Chain::new(
             Clock::real(),
             epoch_manager,
@@ -2370,7 +2375,7 @@ mod tests {
         assert_eq!(sender.memtrie_reload_requests(), vec![left_child_shard, right_child_shard]);
     }
 
-    /// Creates a new account through a state change saved as flat storage deltas.  
+    /// Creates a new account through a state change saved as flat storage deltas.
     fn create_new_account_through_deltas(
         manager: &FlatStorageManager,
         account: AccountId,

--- a/chain/chain/src/resharding/resharding_actor.rs
+++ b/chain/chain/src/resharding/resharding_actor.rs
@@ -2,11 +2,10 @@ use super::types::{
     FlatStorageShardCatchupRequest, FlatStorageSplitShardRequest, MemtrieReloadRequest,
 };
 use crate::flat_storage_resharder::{FlatStorageResharder, FlatStorageReshardingTaskResult};
-use crate::ChainStore;
+use crate::{ChainGenesis, ChainStore};
 use near_async::futures::{DelayedActionRunner, DelayedActionRunnerExt};
 use near_async::messaging::{self, Handler, HandlerWithContext};
 use near_primitives::shard_layout::ShardUId;
-use near_primitives::types::BlockHeight;
 use near_store::Store;
 use time::Duration;
 
@@ -44,8 +43,15 @@ impl Handler<MemtrieReloadRequest> for ReshardingActor {
 }
 
 impl ReshardingActor {
-    pub fn new(store: Store, genesis_height: BlockHeight) -> Self {
-        Self { chain_store: ChainStore::new(store, genesis_height, false) }
+    pub fn new(store: Store, genesis: &ChainGenesis) -> Self {
+        Self {
+            chain_store: ChainStore::new(
+                store,
+                genesis.height,
+                false,
+                genesis.transaction_validity_period,
+            ),
+        }
     }
 
     fn handle_flat_storage_split_shard(

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -172,7 +172,7 @@ impl NightshadeRuntime {
         chunk: ApplyChunkShardContext,
         block: ApplyChunkBlockContext,
         receipts: &[Receipt],
-        transactions: &[SignedTransaction],
+        transactions: node_runtime::SignedValidPeriodTransactions<'_>,
         state_patch: SandboxStatePatch,
     ) -> Result<ApplyChunkResult, Error> {
         let ApplyChunkBlockContext {
@@ -838,7 +838,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         chunk: ApplyChunkShardContext,
         block: ApplyChunkBlockContext,
         receipts: &[Receipt],
-        transactions: &[SignedTransaction],
+        transactions: node_runtime::SignedValidPeriodTransactions<'_>,
     ) -> Result<ApplyChunkResult, Error> {
         let shard_id = chunk.shard_id;
         let _timer = metrics::APPLYING_CHUNKS_TIME

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -1662,11 +1662,7 @@ fn prepare_transactions(
         &mut |tx: &SignedTransaction| -> bool {
             chain
                 .chain_store()
-                .check_transaction_validity_period(
-                    &block.header(),
-                    tx.transaction.block_hash(),
-                    chain.transaction_validity_period,
-                )
+                .check_transaction_validity_period(&block.header(), tx.transaction.block_hash())
                 .is_ok()
         },
         default_produce_chunk_add_transactions_time_limit(),

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -26,6 +26,7 @@ use near_store::genesis::initialize_genesis_state;
 use near_vm_runner::{
     get_contract_cache_key, CompiledContract, CompiledContractInfo, FilesystemContractRuntimeCache,
 };
+use node_runtime::SignedValidPeriodTransactions;
 use num_rational::Ratio;
 use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 
@@ -244,6 +245,8 @@ impl TestEnv {
                 .collect();
             BlockCongestionInfo::new(shards_congestion_info)
         };
+        let transaction_validity = vec![true; transactions.len()];
+        let transactions = SignedValidPeriodTransactions::new(transactions, &transaction_validity);
         self.runtime
             .apply_chunk(
                 RuntimeStorageConfig::new(state_root, true),

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -378,7 +378,7 @@ pub fn pre_validate_chunk_state_witness(
             vec![true; state_witness.transactions.len()]
         } else {
             let prev_block_header =
-                store.get_block_header(last_chunk_block.header().prev_hash())?;
+                store.get_block_header(state_witness.chunk_header.prev_block_hash())?;
             let mut check = chain.transaction_validity_check(prev_block_header);
             state_witness.transactions.iter().map(|t| check(t)).collect::<Vec<_>>()
         }

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -386,9 +386,13 @@ pub fn pre_validate_chunk_state_witness(
         RelaxedChunkValidation,
         current_protocol_version
     ) {
-        let prev_block_header = store.get_block_header(last_chunk_block.header().prev_hash())?;
-        let mut check = chain.transaction_validity_check(prev_block_header);
-        state_witness.transactions.iter().map(|t| check(t)).collect::<Vec<_>>()
+        if last_chunk_block.header().is_genesis() {
+            vec![true; state_witness.transactions.len()]
+        } else {
+            let prev_block_header = store.get_block_header(last_chunk_block.header().prev_hash())?;
+            let mut check = chain.transaction_validity_check(prev_block_header);
+            state_witness.transactions.iter().map(|t| check(t)).collect::<Vec<_>>()
+        }
     } else {
         let new_transactions = &state_witness.new_transactions;
         let (new_tx_root_from_state_witness, _) = merklize(&new_transactions);

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -378,7 +378,7 @@ pub fn pre_validate_chunk_state_witness(
             vec![true; state_witness.transactions.len()]
         } else {
             let prev_block_header =
-                store.get_block_header(state_witness.chunk_header.prev_block_hash())?;
+                store.get_block_header(last_chunk_block.header().prev_hash())?;
             let mut check = chain.transaction_validity_check(prev_block_header);
             state_witness.transactions.iter().map(|t| check(t)).collect::<Vec<_>>()
         }

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -389,7 +389,8 @@ pub fn pre_validate_chunk_state_witness(
         if last_chunk_block.header().is_genesis() {
             vec![true; state_witness.transactions.len()]
         } else {
-            let prev_block_header = store.get_block_header(last_chunk_block.header().prev_hash())?;
+            let prev_block_header =
+                store.get_block_header(last_chunk_block.header().prev_hash())?;
             let mut check = chain.transaction_validity_check(prev_block_header);
             state_witness.transactions.iter().map(|t| check(t)).collect::<Vec<_>>()
         }

--- a/chain/chain/src/stateless_validation/state_transition_data.rs
+++ b/chain/chain/src/stateless_validation/state_transition_data.rs
@@ -182,7 +182,7 @@ mod tests {
     }
 
     fn create_chain_store(store: &Store) -> ChainStore {
-        ChainStore::new(store.clone(), 0, true, 100)
+        ChainStore::new(store.clone(), 0, true, 5)
     }
 
     fn save_state_transition_data(

--- a/chain/chain/src/stateless_validation/state_transition_data.rs
+++ b/chain/chain/src/stateless_validation/state_transition_data.rs
@@ -182,7 +182,7 @@ mod tests {
     }
 
     fn create_chain_store(store: &Store) -> ChainStore {
-        ChainStore::new(store.clone(), 0, true)
+        ChainStore::new(store.clone(), 0, true, 100)
     }
 
     fn save_state_transition_data(

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -2807,13 +2807,13 @@ mod tests {
         let cur_header = &long_fork.last().unwrap().header();
         assert!(chain
             .mut_chain_store()
-            .check_transaction_validity_period(cur_header, valid_base_hash,)
+            .check_transaction_validity_period(cur_header, valid_base_hash)
             .is_ok());
         let invalid_base_hash = long_fork[0].hash();
         assert_eq!(
             chain
                 .mut_chain_store()
-                .check_transaction_validity_period(cur_header, invalid_base_hash,),
+                .check_transaction_validity_period(cur_header, invalid_base_hash),
             Err(InvalidTxError::Expired)
         );
     }

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -54,6 +54,7 @@ use near_store::{
     TrieChanges, WrappedTrieChanges,
 };
 use near_vm_runner::{ContractCode, ContractRuntimeCache, NoContractRuntimeCache};
+use node_runtime::SignedValidPeriodTransactions;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, RwLock};
@@ -1091,7 +1092,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         chunk: ApplyChunkShardContext,
         block: ApplyChunkBlockContext,
         receipts: &[Receipt],
-        transactions: &[SignedTransaction],
+        transactions: SignedValidPeriodTransactions<'_>,
     ) -> Result<ApplyChunkResult, Error> {
         let mut tx_results = vec![];
         let shard_id = chunk.shard_id;
@@ -1128,7 +1129,7 @@ impl RuntimeAdapter for KeyValueRuntime {
             }
         }
 
-        for transaction in transactions {
+        for transaction in transactions.iter_nonexpired_transactions() {
             assert_eq!(
                 account_id_to_shard_id(transaction.transaction.signer_id(), self.num_shards),
                 shard_id

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -42,6 +42,7 @@ use near_store::flat::FlatStorageManager;
 use near_store::{PartialStorage, ShardTries, Store, Trie, WrappedTrieChanges};
 use near_vm_runner::ContractCode;
 use near_vm_runner::ContractRuntimeCache;
+use node_runtime::SignedValidPeriodTransactions;
 use num_rational::Rational32;
 use tracing::instrument;
 
@@ -472,7 +473,7 @@ pub trait RuntimeAdapter: Send + Sync {
         chunk: ApplyChunkShardContext,
         block: ApplyChunkBlockContext,
         receipts: &[Receipt],
-        transactions: &[SignedTransaction],
+        transactions: SignedValidPeriodTransactions<'_>,
     ) -> Result<ApplyChunkResult, Error>;
 
     /// Query runtime with given `path` and `data`.

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -13,6 +13,7 @@ use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::Gas;
+use node_runtime::SignedValidPeriodTransactions;
 
 /// Result of updating a shard for some block when it has a new chunk for this
 /// shard.
@@ -43,6 +44,7 @@ pub enum ShardUpdateResult {
 pub struct NewChunkData {
     pub chunk_header: ShardChunkHeader,
     pub transactions: Vec<SignedTransaction>,
+    pub transaction_validity_check_results: Vec<bool>,
     pub receipts: Vec<Receipt>,
     pub block: ApplyChunkBlockContext,
     pub is_first_block_with_chunk_of_version: bool,
@@ -119,6 +121,7 @@ pub fn apply_new_chunk(
     let NewChunkData {
         chunk_header,
         transactions,
+        transaction_validity_check_results,
         block,
         receipts,
         is_first_block_with_chunk_of_version,
@@ -153,7 +156,7 @@ pub fn apply_new_chunk(
         },
         block,
         &receipts,
-        &transactions,
+        SignedValidPeriodTransactions::new(&transactions, &transaction_validity_check_results),
     ) {
         Ok(apply_result) => {
             Ok(NewChunkResult { gas_limit, shard_uid: shard_context.shard_uid, apply_result })
@@ -200,7 +203,7 @@ pub fn apply_old_chunk(
         },
         block,
         &[],
-        &[],
+        SignedValidPeriodTransactions::new(&[], &[]),
     ) {
         Ok(apply_result) => Ok(OldChunkResult { shard_uid: shard_context.shard_uid, apply_result }),
         Err(err) => Err(err),

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -183,7 +183,7 @@ impl ChunkTestFixture {
             Vec::new(),
             &mock_merkle_paths,
         );
-        let chain_store = ChainStore::new(store.clone(), 0, true);
+        let chain_store = ChainStore::new(store.clone(), 0, true, 5);
 
         ChunkTestFixture {
             store: store.chunk_store(),

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2333,15 +2333,14 @@ impl Client {
         let me = signer.as_ref().map(|vs| vs.validator_id());
         let cur_block = self.chain.get_head_block()?;
         let cur_block_header = cur_block.header();
-        let transaction_validity_period = self.chain.transaction_validity_period;
         // here it is fine to use `cur_block_header` as it is a best effort estimate. If the transaction
         // were to be included, the block that the chunk points to will have height >= height of
         // `cur_block_header`.
-        if let Err(e) = self.chain.chain_store().check_transaction_validity_period(
-            &cur_block_header,
-            tx.transaction.block_hash(),
-            transaction_validity_period,
-        ) {
+        if let Err(e) = self
+            .chain
+            .chain_store()
+            .check_transaction_validity_period(&cur_block_header, tx.transaction.block_hash())
+        {
             debug!(target: "client", ?tx, "Invalid tx: expired or from a different fork");
             return Ok(ProcessTxResponse::InvalidTx(e));
         }

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1908,7 +1908,7 @@ impl ClientActorInner {
                 return Ok(false);
             }
             if epoch_sync_boundary_block_header.height()
-                + self.client.chain.transaction_validity_period
+                + self.client.chain.transaction_validity_period()
                 > current_epoch_start
             {
                 // We also do not want to state sync, if by doing so we would not have enough headers to

--- a/chain/client/src/gc_actor.rs
+++ b/chain/client/src/gc_actor.rs
@@ -3,10 +3,10 @@ use near_async::futures::{DelayedActionRunner, DelayedActionRunnerExt};
 use near_async::messaging::Actor;
 #[cfg(feature = "test_features")]
 use near_async::messaging::Handler;
+use near_chain::ChainGenesis;
 use near_chain::{types::RuntimeAdapter, ChainStore, ChainStoreAccess};
 use near_chain_configs::GCConfig;
 use near_epoch_manager::EpochManagerAdapter;
-use near_primitives::types::BlockHeight;
 use near_store::{metadata::DbKind, Store};
 use std::sync::Arc;
 use tracing::warn;
@@ -27,14 +27,19 @@ pub struct GCActor {
 impl GCActor {
     pub fn new(
         store: Store,
-        genesis_height: BlockHeight,
+        genesis: &ChainGenesis,
         runtime_adapter: Arc<dyn RuntimeAdapter>,
         epoch_manager: Arc<dyn EpochManagerAdapter>,
         gc_config: GCConfig,
         is_archive: bool,
     ) -> Self {
         GCActor {
-            store: ChainStore::new(store, genesis_height, true),
+            store: ChainStore::new(
+                store,
+                genesis.height,
+                true,
+                genesis.transaction_validity_period,
+            ),
             runtime_adapter,
             gc_config,
             epoch_manager,

--- a/chain/client/src/sync/epoch.rs
+++ b/chain/client/src/sync/epoch.rs
@@ -652,7 +652,7 @@ impl EpochSync {
                 .current_epoch
                 .first_block_header_in_epoch
                 .height()
-                .saturating_add(chain.epoch_length.max(chain.transaction_validity_period))
+                .saturating_add(chain.epoch_length.max(chain.transaction_validity_period()))
                 >= status.source_peer_height
             {
                 tracing::error!(
@@ -994,7 +994,7 @@ impl Handler<EpochSyncRequestMessage> for ClientActorInner {
         let network_adapter = self.client.network_adapter.clone();
         let requester_peer_id = msg.from_peer;
         let cache = self.client.epoch_sync.last_epoch_sync_response_cache.clone();
-        let transaction_validity_period = self.client.chain.transaction_validity_period;
+        let transaction_validity_period = self.client.chain.transaction_validity_period();
         self.client.epoch_sync.async_computation_spawner.spawn(
             "respond to epoch sync request",
             move || {

--- a/chain/client/src/test_utils/setup.rs
+++ b/chain/client/src/test_utils/setup.rs
@@ -168,7 +168,7 @@ pub fn setup(
     let partial_witness_adapter = partial_witness_addr.with_auto_span_context();
 
     let (resharding_sender_addr, _) =
-        spawn_actix_actor(ReshardingActor::new(store.clone(), chain_genesis.height));
+        spawn_actix_actor(ReshardingActor::new(store.clone(), &chain_genesis));
     let resharding_sender = resharding_sender_addr.with_auto_span_context();
 
     let shards_manager_adapter_for_client = LateBoundSender::new();

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -254,8 +254,12 @@ impl GenesisBuilder {
             )?,
         );
 
-        let mut store =
-            ChainStore::new(self.store.clone(), self.genesis.config.genesis_height, true);
+        let mut store = ChainStore::new(
+            self.store.clone(),
+            self.genesis.config.genesis_height,
+            true,
+            self.genesis.config.transaction_validity_period,
+        );
         let mut store_update = store.store_update();
 
         store_update.merge(

--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -728,7 +728,7 @@ impl TestLoopBuilder {
 
         let gc_actor = GCActor::new(
             runtime_adapter.store().clone(),
-            chain_genesis.height,
+            &chain_genesis,
             runtime_adapter.clone(),
             epoch_manager.clone(),
             client_config.gc.clone(),
@@ -738,7 +738,7 @@ impl TestLoopBuilder {
         self.test_loop.register_actor_for_index(idx, gc_actor, None);
 
         let resharding_actor =
-            ReshardingActor::new(runtime_adapter.store().clone(), chain_genesis.height);
+            ReshardingActor::new(runtime_adapter.store().clone(), &chain_genesis);
 
         let future_spawner = self.test_loop.future_spawner();
         let state_sync_dumper = StateSyncDumper {

--- a/integration-tests/src/test_loop/tests/epoch_sync.rs
+++ b/integration-tests/src/test_loop/tests/epoch_sync.rs
@@ -330,7 +330,12 @@ impl TestNetworkSetup {
 
     fn chain_final_head_height(&self, node_index: usize) -> u64 {
         let store = self.stores[node_index].clone();
-        let chain_store = ChainStore::new(store, self.genesis.config.genesis_height, false);
+        let chain_store = ChainStore::new(
+            store,
+            self.genesis.config.genesis_height,
+            false,
+            self.genesis.config.transaction_validity_period,
+        );
         chain_store.final_head().unwrap().height
     }
 

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2324,9 +2324,12 @@ fn test_validate_chunk_extra() {
     // using `capture`
 
     env.pause_block_processing(&mut capture, block2.hash());
-
-    let mut chain_store =
-        ChainStore::new(env.clients[0].chain.chain_store().store().clone(), genesis_height, true);
+    let mut chain_store = ChainStore::new(
+        env.clients[0].chain.chain_store().store().clone(),
+        genesis_height,
+        true,
+        genesis.config.transaction_validity_period,
+    );
     let chunk_header = encoded_chunk.cloned_header();
     let signer = env.clients[0].validator_signer.get();
     let validator_id = signer.as_ref().unwrap().validator_id().clone();

--- a/integration-tests/src/tests/client/undo_block.rs
+++ b/integration-tests/src/tests/client/undo_block.rs
@@ -34,8 +34,12 @@ fn test_undo_block(epoch_length: u64, stop_height: u64) {
         env.process_block(0, block, Provenance::PRODUCED);
     }
 
-    let mut chain_store =
-        ChainStore::new(store.clone(), genesis.config.genesis_height, save_trie_changes);
+    let mut chain_store = ChainStore::new(
+        store.clone(),
+        genesis.config.genesis_height,
+        save_trie_changes,
+        genesis.config.transaction_validity_period,
+    );
 
     let current_head = chain_store.head().unwrap();
     let prev_block_hash = current_head.prev_block_hash;

--- a/integration-tests/src/user/runtime_user.rs
+++ b/integration-tests/src/user/runtime_user.rs
@@ -26,6 +26,7 @@ use near_primitives::views::{
 use near_store::adapter::StoreUpdateAdapter;
 use near_store::{ShardTries, TrieUpdate};
 use node_runtime::state_viewer::TrieViewer;
+use node_runtime::SignedValidPeriodTransactions;
 use node_runtime::{state_viewer::ViewApplyState, ApplyState, Runtime};
 
 use crate::user::{User, POISONED_LOCK_ERR};
@@ -111,7 +112,7 @@ impl RuntimeUser {
                     &None,
                     &apply_state,
                     &receipts,
-                    &txs,
+                    SignedValidPeriodTransactions::new(&txs, &vec![true; txs.len()]),
                     &self.epoch_info_provider,
                     Default::default(),
                 )

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -37,10 +37,12 @@ fn read_trie_items(bench: &mut Bencher, shard_index: ShardIndex, shard_id: Shard
         .open_in_mode(mode)
         .unwrap()
         .get_hot_store();
-
-        let chain_store =
-            ChainStore::new(store.clone(), near_config.genesis.config.genesis_height, true);
-
+        let chain_store = ChainStore::new(
+            store.clone(),
+            near_config.genesis.config.genesis_height,
+            true,
+            near_config.genesis.config.transaction_validity_period,
+        );
         let epoch_manager =
             EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config, None);
         let runtime = NightshadeRuntime::from_config(&home_dir, store, &near_config, epoch_manager)

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -376,7 +376,7 @@ pub fn start_with_config_and_synchronization(
 
     let (_gc_actor, gc_arbiter) = spawn_actix_actor(GCActor::new(
         runtime.store().clone(),
-        chain_genesis.height,
+        &chain_genesis,
         runtime.clone(),
         epoch_manager.clone(),
         config.client_config.gc.clone(),
@@ -384,7 +384,7 @@ pub fn start_with_config_and_synchronization(
     ));
 
     let (resharding_sender_addr, _) =
-        spawn_actix_actor(ReshardingActor::new(runtime.store().clone(), chain_genesis.height));
+        spawn_actix_actor(ReshardingActor::new(runtime.store().clone(), &chain_genesis));
     let resharding_sender = resharding_sender_addr.with_auto_span_context();
     let state_sync_runtime =
         Arc::new(tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap());

--- a/nearcore/src/metrics.rs
+++ b/nearcore/src/metrics.rs
@@ -112,6 +112,7 @@ fn export_postponed_receipt_count(near_config: &NearConfig, store: &Store) -> an
         store.clone(),
         near_config.genesis.config.genesis_height,
         near_config.client_config.save_trie_changes,
+        near_config.genesis.config.transaction_validity_period,
     );
     let epoch_manager =
         EpochManager::new_from_genesis_config(store.clone(), &near_config.genesis.config)?;

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -22,8 +22,12 @@ pub fn do_migrate_30_to_31(
     store: &Store,
     genesis_config: &near_chain_configs::GenesisConfig,
 ) -> anyhow::Result<()> {
-    let genesis_height = genesis_config.genesis_height;
-    let chain_store = ChainStore::new(store.clone(), genesis_height, false);
+    let chain_store = ChainStore::new(
+        store.clone(),
+        genesis_config.genesis_height,
+        false,
+        genesis_config.transaction_validity_period,
+    );
     let head = chain_store.head()?;
     let mut store_update = BatchedStoreUpdate::new(store, 10_000_000);
     let mut count = 0;

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -26,7 +26,7 @@ use near_store::{ShardTries, ShardUId, StateSnapshotConfig, TrieUpdate};
 use near_store::{TrieCache, TrieCachingStorage, TrieConfig};
 use near_vm_runner::logic::LimitConfig;
 use near_vm_runner::FilesystemContractRuntimeCache;
-use node_runtime::{ApplyState, Runtime};
+use node_runtime::{ApplyState, Runtime, SignedValidPeriodTransactions};
 use std::collections::HashMap;
 use std::iter;
 use std::sync::Arc;
@@ -355,7 +355,7 @@ impl Testbed<'_> {
                 &None,
                 &self.apply_state,
                 &self.prev_receipts,
-                transactions,
+                SignedValidPeriodTransactions::new(transactions, &vec![true; transactions.len()]),
                 &self.epoch_info_provider,
                 Default::default(),
             )

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1419,7 +1419,7 @@ impl Runtime {
         validator_accounts_update: &Option<ValidatorAccountsUpdate>,
         apply_state: &ApplyState,
         incoming_receipts: &[Receipt],
-        transactions: &[SignedTransaction],
+        transactions: SignedValidPeriodTransactions<'_>,
         epoch_info_provider: &dyn EpochInfoProvider,
         state_patch: SandboxStatePatch,
     ) -> Result<ApplyResult, RuntimeError> {
@@ -1586,7 +1586,8 @@ impl Runtime {
         let total = &mut processing_state.total;
         let apply_state = &mut processing_state.apply_state;
         let state_update = &mut processing_state.state_update;
-        for signed_transaction in processing_state.transactions {
+
+        for signed_transaction in processing_state.transactions.iter_nonexpired_transactions() {
             let tx_result = self.process_transaction(
                 state_update,
                 apply_state,
@@ -2486,7 +2487,7 @@ struct ApplyProcessingState<'a> {
     prefetcher: Option<TriePrefetcher>,
     state_update: TrieUpdate,
     epoch_info_provider: &'a dyn EpochInfoProvider,
-    transactions: &'a [SignedTransaction],
+    transactions: SignedValidPeriodTransactions<'a>,
     total: TotalResourceGuard,
     stats: ApplyStats,
 }
@@ -2496,7 +2497,7 @@ impl<'a> ApplyProcessingState<'a> {
         apply_state: &'a ApplyState,
         trie: Trie,
         epoch_info_provider: &'a dyn EpochInfoProvider,
-        transactions: &'a [SignedTransaction],
+        transactions: SignedValidPeriodTransactions<'a>,
     ) -> Self {
         let protocol_version = apply_state.current_protocol_version;
         let prefetcher = TriePrefetcher::new_if_enabled(&trie);
@@ -2552,6 +2553,43 @@ impl<'a> ApplyProcessingState<'a> {
     }
 }
 
+#[derive(Clone, Copy)]
+pub struct SignedValidPeriodTransactions<'a> {
+    transactions: &'a [SignedTransaction],
+    /// List of the transactions that are valid and should be processed by `apply`.
+    ///
+    /// This list is exactly the length of the corresponding `Self::transactions` field. Element at
+    /// the index N in this array corresponds to an element at index N in the transactions list.
+    ///
+    /// Transactions for which a `false` is stored here must be ignored/dropped/skipped.
+    ///
+    /// All elements will be true for protocol versions where `RelaxedChunkValidation` is not
+    /// enabled.
+    transaction_validity_check_passed: &'a [bool],
+}
+
+impl<'a> SignedValidPeriodTransactions<'a> {
+    pub fn new(transactions: &'a [SignedTransaction], validity_check_results: &'a [bool]) -> Self {
+        assert_eq!(transactions.len(), validity_check_results.len());
+        Self { transactions, transaction_validity_check_passed: validity_check_results }
+    }
+
+    pub fn empty() -> Self {
+        Self::new(&[], &[])
+    }
+
+    pub fn iter_nonexpired_transactions(&self) -> impl Iterator<Item = &'a SignedTransaction> {
+        self.transactions
+            .into_iter()
+            .zip(self.transaction_validity_check_passed.into_iter())
+            .filter_map(|(t, v)| v.then_some(t))
+    }
+
+    pub fn len(&self) -> usize {
+        self.transactions.len()
+    }
+}
+
 /// Similar to [ApplyProcessingState], with the difference that this contains extra state used
 /// by receipt processing.
 struct ApplyProcessingReceiptState<'a> {
@@ -2560,7 +2598,7 @@ struct ApplyProcessingReceiptState<'a> {
     prefetcher: Option<TriePrefetcher>,
     state_update: TrieUpdate,
     epoch_info_provider: &'a dyn EpochInfoProvider,
-    transactions: &'a [SignedTransaction],
+    transactions: SignedValidPeriodTransactions<'a>,
     total: TotalResourceGuard,
     stats: ApplyStats,
     outcomes: Vec<ExecutionOutcomeWithId>,

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -5,7 +5,7 @@ use crate::tests::{
     create_receipt_for_create_account, create_receipt_with_actions, set_sha256_cost,
     MAX_ATTACHED_GAS,
 };
-use crate::total_prepaid_exec_fees;
+use crate::{total_prepaid_exec_fees, SignedValidPeriodTransactions};
 use crate::{ApplyResult, ApplyState, Runtime, ValidatorAccountsUpdate};
 use assert_matches::assert_matches;
 use near_crypto::{InMemorySigner, KeyType, PublicKey, Signer};
@@ -149,7 +149,7 @@ fn test_apply_no_op() {
             &None,
             &apply_state,
             &[],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -182,7 +182,7 @@ fn test_apply_check_balance_validation_rewards() {
                 small_refund,
                 ReceiptPriority::NoPriority,
             )],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -211,7 +211,7 @@ fn test_apply_refund_receipts() {
                 &None,
                 &apply_state,
                 prev_receipts,
-                &[],
+                SignedValidPeriodTransactions::empty(),
                 &epoch_info_provider,
                 Default::default(),
             )
@@ -255,7 +255,7 @@ fn test_apply_delayed_receipts_feed_all_at_once() {
                 &None,
                 &apply_state,
                 prev_receipts,
-                &[],
+                SignedValidPeriodTransactions::empty(),
                 &epoch_info_provider,
                 Default::default(),
             )
@@ -300,7 +300,7 @@ fn test_apply_delayed_receipts_add_more_using_chunks() {
                 &None,
                 &apply_state,
                 prev_receipts,
-                &[],
+                SignedValidPeriodTransactions::empty(),
                 &epoch_info_provider,
                 Default::default(),
             )
@@ -353,7 +353,7 @@ fn test_apply_delayed_receipts_adjustable_gas_limit() {
                 &None,
                 &apply_state,
                 prev_receipts,
-                &[],
+                SignedValidPeriodTransactions::empty(),
                 &epoch_info_provider,
                 Default::default(),
             )
@@ -514,7 +514,7 @@ fn test_apply_delayed_receipts_local_tx() {
             &None,
             &apply_state,
             &receipts[0..2],
-            &local_transactions[0..4],
+            SignedValidPeriodTransactions::new(&local_transactions[0..4], &[true; 4]),
             &epoch_info_provider,
             Default::default(),
         )
@@ -563,7 +563,7 @@ fn test_apply_delayed_receipts_local_tx() {
             &None,
             &apply_state,
             &receipts[2..3],
-            &local_transactions[4..5],
+            SignedValidPeriodTransactions::new(&local_transactions[4..5], &[true]),
             &epoch_info_provider,
             Default::default(),
         )
@@ -605,7 +605,7 @@ fn test_apply_delayed_receipts_local_tx() {
             &None,
             &apply_state,
             &receipts[3..4],
-            &local_transactions[5..9],
+            SignedValidPeriodTransactions::new(&local_transactions[5..9], &[true; 4]),
             &epoch_info_provider,
             Default::default(),
         )
@@ -656,7 +656,7 @@ fn test_apply_delayed_receipts_local_tx() {
             &None,
             &apply_state,
             &receipts[4..5],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -690,7 +690,7 @@ fn test_apply_delayed_receipts_local_tx() {
             &None,
             &apply_state,
             &receipts[5..6],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -732,7 +732,7 @@ fn test_apply_deficit_gas_for_transfer() {
             &None,
             &apply_state,
             &receipts,
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -789,7 +789,7 @@ fn test_apply_deficit_gas_for_function_call_covered() {
             &None,
             &apply_state,
             &receipts,
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -856,7 +856,7 @@ fn test_apply_deficit_gas_for_function_call_partial() {
             &None,
             &apply_state,
             &receipts,
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -892,7 +892,7 @@ fn test_delete_key_add_key() {
             &None,
             &apply_state,
             &receipts,
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -935,7 +935,7 @@ fn test_delete_key_underflow() {
             &None,
             &apply_state,
             &receipts,
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -974,7 +974,7 @@ fn test_contract_precompilation() {
             &None,
             &apply_state,
             &receipts,
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -1047,7 +1047,7 @@ fn test_compute_usage_limit() {
                 first_call_receipt.clone(),
                 second_call_receipt.clone(),
             ],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -1071,7 +1071,7 @@ fn test_compute_usage_limit() {
             &None,
             &apply_state,
             &[],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -1114,7 +1114,7 @@ fn test_compute_usage_limit_with_failed_receipt() {
             &None,
             &apply_state,
             &[deploy_contract_receipt.clone(), first_call_receipt.clone()],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -1160,7 +1160,7 @@ fn test_main_storage_proof_size_soft_limit() {
                 create_acc_fn(alice_account(), signers[0].clone()),
                 create_acc_fn(bob_account(), signers[1].clone()),
             ],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -1202,7 +1202,7 @@ fn test_main_storage_proof_size_soft_limit() {
                 function_call_fn(alice_account(), signers[0].clone()),
                 function_call_fn(bob_account(), signers[1].clone()),
             ],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -1265,7 +1265,7 @@ fn test_exclude_contract_code_from_witness() {
                 create_acc_fn(alice_account(), signers[0].clone()),
                 create_acc_fn(bob_account(), signers[1].clone()),
             ],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -1307,7 +1307,7 @@ fn test_exclude_contract_code_from_witness() {
                 function_call_fn(alice_account(), signers[0].clone()),
                 function_call_fn(bob_account(), signers[1].clone()),
             ],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -1379,7 +1379,7 @@ fn test_exclude_contract_code_from_witness_with_failed_call() {
                 create_acc_fn(alice_account(), signers[0].clone()),
                 create_acc_fn(bob_account(), signers[1].clone()),
             ],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -1420,7 +1420,7 @@ fn test_exclude_contract_code_from_witness_with_failed_call() {
                 function_call_fn(alice_account(), signers[0].clone()),
                 function_call_fn(bob_account(), signers[1].clone()),
             ],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -1510,7 +1510,7 @@ fn test_deploy_and_call_different_contracts() {
             &None,
             &apply_state,
             &[first_deploy_receipt, second_deploy_receipt],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -1537,7 +1537,7 @@ fn test_deploy_and_call_different_contracts() {
             &None,
             &apply_state,
             &[first_call_receipt, second_call_receipt],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -1616,7 +1616,7 @@ fn test_deploy_and_call_different_contracts_with_failed_call() {
             &None,
             &apply_state,
             &[first_deploy_receipt, second_deploy_receipt],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -1643,7 +1643,7 @@ fn test_deploy_and_call_different_contracts_with_failed_call() {
             &None,
             &apply_state,
             &[first_call_receipt, second_call_receipt],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -1720,7 +1720,7 @@ fn test_deploy_and_call_in_apply() {
             &None,
             &apply_state,
             &[first_deploy_receipt, second_deploy_receipt, first_call_receipt, second_call_receipt],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -1799,7 +1799,7 @@ fn test_deploy_and_call_in_apply_with_failed_call() {
             &None,
             &apply_state,
             &[first_deploy_receipt, second_deploy_receipt, first_call_receipt, second_call_receipt],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -1854,7 +1854,7 @@ fn test_deploy_existing_contract_to_different_account() {
             &None,
             &apply_state,
             &[first_deploy_receipt, first_call_receipt],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -1896,7 +1896,7 @@ fn test_deploy_existing_contract_to_different_account() {
             &None,
             &apply_state,
             &[second_deploy_receipt, second_call_receipt],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -1945,7 +1945,7 @@ fn test_deploy_and_call_in_same_receipt() {
             &None,
             &apply_state,
             &[receipt],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -1994,7 +1994,7 @@ fn test_deploy_and_call_in_same_receipt_with_failed_call() {
             &None,
             &apply_state,
             &[receipt],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -2030,7 +2030,7 @@ fn test_call_account_without_contract() {
             &None,
             &apply_state,
             &[receipt],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -2074,7 +2074,7 @@ fn test_contract_accesses_when_validating_chunk() {
             &None,
             &apply_state,
             &[deploy_receipt],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -2100,7 +2100,7 @@ fn test_contract_accesses_when_validating_chunk() {
             &None,
             &apply_state,
             &[call_receipt.clone()],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -2121,7 +2121,7 @@ fn test_contract_accesses_when_validating_chunk() {
             &None,
             &apply_state,
             &[call_receipt],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -2168,7 +2168,7 @@ fn test_exclude_existing_contract_code_for_deploy_action() {
             &None,
             &apply_state,
             &[deploy_receipt1],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -2192,7 +2192,7 @@ fn test_exclude_existing_contract_code_for_deploy_action() {
             &None,
             &apply_state,
             &[deploy_receipt2],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -2269,7 +2269,7 @@ fn test_exclude_existing_contract_code_for_delete_account_action() {
             &None,
             &apply_state,
             &[create_account_receipt, deploy_receipt],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -2293,7 +2293,7 @@ fn test_exclude_existing_contract_code_for_delete_account_action() {
             &None,
             &apply_state,
             &[delete_account_receipt],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -2337,7 +2337,6 @@ fn test_empty_apply() {
         setup_runtime(vec![alice_account()], initial_balance, initial_locked, gas_limit);
 
     let receipts = [];
-    let transactions = [];
 
     let apply_result = runtime
         .apply(
@@ -2345,7 +2344,7 @@ fn test_empty_apply() {
             &None,
             &apply_state,
             &receipts,
-            &transactions,
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -2387,7 +2386,7 @@ fn test_congestion_delayed_receipts_accounting() {
             &None,
             &apply_state,
             &receipts,
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -2490,7 +2489,7 @@ fn test_congestion_buffering() {
                 &None,
                 &apply_state,
                 prev_receipts,
-                &[],
+                SignedValidPeriodTransactions::empty(),
                 &epoch_info_provider,
                 Default::default(),
             )
@@ -2551,7 +2550,7 @@ fn test_congestion_buffering() {
                 &None,
                 &apply_state,
                 prev_receipts,
-                &[],
+                SignedValidPeriodTransactions::empty(),
                 &epoch_info_provider,
                 Default::default(),
             )
@@ -2633,7 +2632,7 @@ fn check_congestion_info_bootstrapping(is_new_chunk: bool, want: Option<Congesti
             &None,
             &apply_state,
             &[],
-            &[],
+            SignedValidPeriodTransactions::empty(),
             &epoch_info_provider,
             Default::default(),
         )
@@ -2697,7 +2696,7 @@ fn test_deploy_and_call_local_receipt() {
             &None,
             &apply_state,
             &[],
-            &[tx],
+            SignedValidPeriodTransactions::new(&[tx], &[true]),
             &epoch_info_provider,
             Default::default(),
         )
@@ -2768,7 +2767,7 @@ fn test_deploy_and_call_local_receipts() {
             &None,
             &apply_state,
             &[],
-            &[tx1, tx2],
+            SignedValidPeriodTransactions::new(&[tx1, tx2], &[true; 2]),
             &epoch_info_provider,
             Default::default(),
         )

--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -18,7 +18,7 @@ use near_primitives_core::account::id::AccountIdRef;
 use near_store::genesis::GenesisStateApplier;
 use near_store::test_utils::TestTriesBuilder;
 use near_store::ShardTries;
-use node_runtime::{ApplyState, Runtime};
+use node_runtime::{ApplyState, Runtime, SignedValidPeriodTransactions};
 use random_config::random_config;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Condvar, Mutex};
@@ -148,6 +148,8 @@ impl StandaloneRuntime {
         let shard_id = self.apply_state.shard_id;
         let shard_uid = ShardUId::new(0, shard_id);
         let trie = self.tries.get_trie_for_shard(shard_uid, self.root);
+        let validity = vec![true; transactions.len()];
+        let transactions = SignedValidPeriodTransactions::new(transactions, &validity);
         let apply_result = self
             .runtime
             .apply(

--- a/tools/database/src/analyse_gas_usage.rs
+++ b/tools/database/src/analyse_gas_usage.rs
@@ -60,6 +60,7 @@ impl AnalyseGasUsageCommand {
             store.clone(),
             near_config.genesis.config.genesis_height,
             false,
+            near_config.genesis.config.transaction_validity_period,
         ));
         let epoch_manager =
             EpochManager::new_from_genesis_config(store, &near_config.genesis.config).unwrap();

--- a/tools/database/src/analyze_contract_sizes.rs
+++ b/tools/database/src/analyze_contract_sizes.rs
@@ -84,6 +84,7 @@ impl AnalyzeContractSizesCommand {
             store.clone(),
             near_config.genesis.config.genesis_height,
             false,
+            near_config.genesis.config.transaction_validity_period,
         ));
 
         let head = chain_store.head().unwrap();

--- a/tools/database/src/analyze_delayed_receipt.rs
+++ b/tools/database/src/analyze_delayed_receipt.rs
@@ -50,6 +50,7 @@ impl AnalyzeDelayedReceiptCommand {
             store.clone(),
             near_config.genesis.config.genesis_height,
             false,
+            near_config.genesis.config.transaction_validity_period,
         ));
         let epoch_manager =
             EpochManager::new_from_genesis_config(store.clone(), &near_config.genesis.config)

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -172,7 +172,7 @@ impl FlatStorageCommand {
             epoch_manager.clone(),
         )
         .expect("could not create transaction runtime");
-        let chain_store = ChainStore::new(node_storage.get_hot_store(), 0, false);
+        let chain_store = ChainStore::new(node_storage.get_hot_store(), 0, false, 100);
         let hot_store = node_storage.get_hot_store();
         (node_storage, epoch_manager, hot_runtime, chain_store, hot_store)
     }

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -283,8 +283,12 @@ impl ForkNetworkCommand {
         let fork_heads = get_fork_heads(&all_shard_uids, store.clone())?;
         tracing::info!(?fork_heads);
 
-        let chain =
-            ChainStore::new(store.clone(), near_config.genesis.config.genesis_height, false);
+        let chain = ChainStore::new(
+            store.clone(),
+            near_config.genesis.config.genesis_height,
+            false,
+            near_config.genesis.config.transaction_validity_period,
+        );
 
         // Move flat storage to the max height for consistency across shards.
         let (block_height, desired_block_hash) =

--- a/tools/mirror/src/key_util.rs
+++ b/tools/mirror/src/key_util.rs
@@ -60,6 +60,7 @@ pub(crate) fn keys_from_source_db(
         store.clone(),
         config.genesis.config.genesis_height,
         config.client_config.save_trie_changes,
+        config.genesis.config.transaction_validity_period,
     );
     let epoch_manager =
         EpochManager::new_arc_handle(store.clone(), &config.genesis.config, Some(home));

--- a/tools/mirror/src/offline.rs
+++ b/tools/mirror/src/offline.rs
@@ -44,6 +44,7 @@ impl ChainAccess {
             store.clone(),
             config.genesis.config.genesis_height,
             config.client_config.save_trie_changes,
+            config.genesis.config.transaction_validity_period,
         );
         let epoch_manager = EpochManager::new_arc_handle(
             store.clone(),

--- a/tools/mock-node/src/setup.rs
+++ b/tools/mock-node/src/setup.rs
@@ -144,11 +144,13 @@ pub fn setup_mock_node(
             client_runtime.store().clone(),
             config.genesis.config.genesis_height,
             config.client_config.save_trie_changes,
+            config.genesis.config.transaction_validity_period,
         );
         let mut network_chain_store = ChainStore::new(
             mock_network_runtime.store().clone(),
             config.genesis.config.genesis_height,
             config.client_config.save_trie_changes,
+            config.genesis.config.transaction_validity_period,
         );
 
         let network_tail_height = network_chain_store.tail().unwrap();

--- a/tools/replay-archive/src/cli.rs
+++ b/tools/replay-archive/src/cli.rs
@@ -116,7 +116,12 @@ impl ReplayController {
         let store = Store::new(storage.clone());
 
         let genesis_height = near_config.genesis.config.genesis_height;
-        let chain_store = ChainStore::new(store.clone(), genesis_height, false);
+        let chain_store = ChainStore::new(
+            store.clone(),
+            genesis_height,
+            false,
+            near_config.genesis.config.transaction_validity_period,
+        );
 
         let head_height = chain_store.head().context("Failed to get head of the chain")?.height;
         let start_height = start_height.unwrap_or(genesis_height);

--- a/tools/replay-archive/src/cli.rs
+++ b/tools/replay-archive/src/cli.rs
@@ -341,6 +341,8 @@ impl ReplayController {
             ShardUpdateReason::NewChunk(NewChunkData {
                 chunk_header: chunk_header.clone(),
                 transactions: chunk.transactions().to_vec(),
+                // FIXME: see the `validate_chunk` thing above.
+                transaction_validity_check_results: vec![true; chunk.transactions().len()],
                 receipts,
                 block: block_context,
                 is_first_block_with_chunk_of_version,
@@ -438,6 +440,8 @@ impl ReplayController {
         {
             bail!("Failed to validate chunk proofs");
         }
+        // FIXME: this should be using Chain::validate_chunk_transactions instead of doing its own
+        // thing?
         if !validate_transactions_order(chunk.transactions()) {
             bail!("Failed to validate transactions order in the chunk");
         }

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -73,8 +73,12 @@ fn apply_block_from_range(
     // normally save_trie_changes depends on whether the node is
     // archival, but here we don't care, and can just set it to false
     // since we're not writing anything to the read store anyway
-    let mut read_chain_store =
-        ChainStore::new(read_store.clone(), genesis.config.genesis_height, false);
+    let mut read_chain_store = ChainStore::new(
+        read_store.clone(),
+        genesis.config.genesis_height,
+        false,
+        genesis.config.transaction_validity_period,
+    );
     let block_hash = match read_chain_store.get_block_hash_by_height(height) {
         Ok(block_hash) => block_hash,
         Err(_) => {
@@ -335,7 +339,7 @@ fn apply_block_from_range(
         (_, StorageSource::Trie | StorageSource::TrieFree | StorageSource::Memtrie) => {
             if let Err(err) = maybe_save_trie_changes(
                 write_store,
-                genesis.config.genesis_height,
+                &genesis.config,
                 apply_result,
                 height,
                 shard_id,
@@ -373,7 +377,12 @@ pub fn apply_chain_range(
         only_contracts,
         ?storage)
     .entered();
-    let chain_store = ChainStore::new(read_store.clone(), genesis.config.genesis_height, false);
+    let chain_store = ChainStore::new(
+        read_store.clone(),
+        genesis.config.genesis_height,
+        false,
+        genesis.config.transaction_validity_period,
+    );
     let final_head = chain_store.final_head().unwrap();
     let shard_layout = epoch_manager.get_shard_layout(&final_head.epoch_id).unwrap();
     let shard_uid =

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -19,6 +19,7 @@ use near_store::adapter::StoreAdapter;
 use near_store::flat::{BlockInfo, FlatStateChanges, FlatStorageStatus};
 use near_store::{DBCol, Store};
 use nearcore::NightshadeRuntime;
+use node_runtime::SignedValidPeriodTransactions;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::fs::File;
 use std::io::Write;
@@ -168,6 +169,7 @@ fn apply_block_from_range(
 
         num_receipt = receipts.len();
         num_tx = chunk.transactions().len();
+
         if only_contracts {
             let mut has_contracts = false;
             for tx in chunk.transactions() {
@@ -182,6 +184,7 @@ fn apply_block_from_range(
             }
         }
 
+        let transactions = chunk.transactions();
         runtime_adapter
             .apply_chunk(
                 storage.create_runtime_storage(*chunk_inner.prev_state_root()),
@@ -200,7 +203,7 @@ fn apply_block_from_range(
                     block.block_bandwidth_requests(),
                 ),
                 &receipts,
-                chunk.transactions(),
+                SignedValidPeriodTransactions::new(&transactions, &vec![true; transactions.len()]),
             )
             .unwrap()
     } else {
@@ -227,7 +230,7 @@ fn apply_block_from_range(
                     block.block_bandwidth_requests(),
                 ),
                 &[],
-                &[],
+                SignedValidPeriodTransactions::empty(),
             )
             .unwrap()
     };

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -21,6 +21,7 @@ use near_primitives_core::hash::hash;
 use near_primitives_core::types::Gas;
 use near_store::DBCol;
 use near_store::Store;
+use node_runtime::SignedValidPeriodTransactions;
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -203,7 +204,7 @@ pub(crate) fn apply_chunk(
                 bandwidth_requests: block_bandwidth_requests,
             },
             &receipts,
-            transactions,
+            SignedValidPeriodTransactions::new(transactions, &vec![true; transactions.len()]),
         )?,
         chunk_header.gas_limit(),
     ))

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -106,6 +106,13 @@ pub(crate) fn apply_block(
         .unwrap();
 
         let transactions = chunk.transactions();
+        let valid_txs = chain_store
+            .compute_transaction_validity(
+                block.header().latest_protocol_version(),
+                prev_block.header(),
+                &chunk,
+            )
+            .unwrap();
         runtime
             .apply_chunk(
                 storage.create_runtime_storage(*chunk_inner.prev_state_root()),
@@ -124,7 +131,7 @@ pub(crate) fn apply_block(
                     block.block_bandwidth_requests(),
                 ),
                 &receipts,
-                SignedValidPeriodTransactions::new(transactions, &vec![true; transactions.len()]),
+                SignedValidPeriodTransactions::new(transactions, &valid_txs),
             )
             .unwrap()
     } else {

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -52,6 +52,7 @@ use near_store::{DBCol, Store, Trie, TrieCache, TrieCachingStorage, TrieConfig, 
 use nearcore::NightshadeRuntimeExt;
 use nearcore::{NearConfig, NightshadeRuntime};
 use node_runtime::adapter::ViewRuntimeAdapter;
+use node_runtime::SignedValidPeriodTransactions;
 use serde_json::json;
 use std::collections::HashMap;
 use std::collections::{BTreeMap, BinaryHeap};
@@ -104,6 +105,7 @@ pub(crate) fn apply_block(
         )
         .unwrap();
 
+        let transactions = chunk.transactions();
         runtime
             .apply_chunk(
                 storage.create_runtime_storage(*chunk_inner.prev_state_root()),
@@ -122,7 +124,7 @@ pub(crate) fn apply_block(
                     block.block_bandwidth_requests(),
                 ),
                 &receipts,
-                chunk.transactions(),
+                SignedValidPeriodTransactions::new(transactions, &vec![true; transactions.len()]),
             )
             .unwrap()
     } else {
@@ -148,7 +150,7 @@ pub(crate) fn apply_block(
                     prev_block.block_bandwidth_requests(),
                 ),
                 &[],
-                &[],
+                SignedValidPeriodTransactions::empty(),
             )
             .unwrap()
     };

--- a/tools/state-viewer/src/congestion_control.rs
+++ b/tools/state-viewer/src/congestion_control.rs
@@ -54,6 +54,7 @@ impl PrintCmd {
             store,
             near_config.genesis.config.genesis_height,
             near_config.client_config.save_trie_changes,
+            near_config.genesis.config.transaction_validity_period,
         );
         let head = chain_store.head().unwrap();
         let block = chain_store.get_block(&head.last_block_hash).unwrap();

--- a/tools/state-viewer/src/latest_witnesses.rs
+++ b/tools/state-viewer/src/latest_witnesses.rs
@@ -56,8 +56,12 @@ enum DumpWitnessesMode {
 
 impl DumpWitnessesCmd {
     pub(crate) fn run(&self, near_config: NearConfig, store: Store) {
-        let chain_store =
-            Rc::new(ChainStore::new(store, near_config.genesis.config.genesis_height, false));
+        let chain_store = Rc::new(ChainStore::new(
+            store,
+            near_config.genesis.config.genesis_height,
+            false,
+            near_config.genesis.config.transaction_validity_period,
+        ));
 
         let witnesses =
             chain_store.get_latest_witnesses(self.height, self.shard_id, self.epoch_id).unwrap();

--- a/tools/state-viewer/src/replay_headers.rs
+++ b/tools/state-viewer/src/replay_headers.rs
@@ -37,6 +37,7 @@ pub(crate) fn replay_headers(
         store.clone(),
         near_config.genesis.config.genesis_height,
         near_config.client_config.save_trie_changes,
+        near_config.genesis.config.transaction_validity_period,
     );
     let start_height: BlockHeight =
         start_height.unwrap_or_else(|| chain_store.get_genesis_height());

--- a/tools/state-viewer/src/state_changes.rs
+++ b/tools/state-viewer/src/state_changes.rs
@@ -78,6 +78,7 @@ fn dump_state_changes(
         store.clone(),
         near_config.genesis.config.genesis_height,
         near_config.client_config.save_trie_changes,
+        near_config.genesis.config.transaction_validity_period,
     );
 
     let blocks = (height_from..=height_to).filter_map(|block_height| {
@@ -152,6 +153,7 @@ fn apply_state_changes(
         store,
         near_config.genesis.config.genesis_height,
         near_config.client_config.save_trie_changes,
+        near_config.genesis.config.transaction_validity_period,
     );
 
     let data = std::fs::read(&file).unwrap();

--- a/tools/state-viewer/src/trie_iteration_benchmark.rs
+++ b/tools/state-viewer/src/trie_iteration_benchmark.rs
@@ -110,6 +110,7 @@ impl TrieIterationBenchmarkCmd {
             store.clone(),
             genesis_config.genesis_height,
             near_config.client_config.save_trie_changes,
+            genesis_config.transaction_validity_period,
         );
         let head = chain_store.head().unwrap();
         let block = chain_store.get_block(&head.last_block_hash).unwrap();

--- a/tools/state-viewer/src/util.rs
+++ b/tools/state-viewer/src/util.rs
@@ -39,6 +39,7 @@ pub fn load_trie_stop_at_height(
         store.clone(),
         near_config.genesis.config.genesis_height,
         near_config.client_config.save_trie_changes,
+        near_config.genesis.config.transaction_validity_period,
     );
 
     let epoch_manager =

--- a/tools/undo-block/src/cli.rs
+++ b/tools/undo-block/src/cli.rs
@@ -40,6 +40,7 @@ impl UndoBlockCommand {
             store,
             near_config.genesis.config.genesis_height,
             near_config.client_config.save_trie_changes,
+            near_config.genesis.config.transaction_validity_period,
         );
 
         if self.reset_only_body {


### PR DESCRIPTION
The invalid transactions are still simply ignored, rather than fully invalidating the chunk in the relaxed chunk validation setup.