### PR TITLE
chore: enable simd-accel feature for reed solomon crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6794,6 +6794,8 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7263373d500d4d4f505d43a2a662d475a894aa94503a1ee28e9188b5f3960d4f"
 dependencies = [
+ "cc",
+ "libc",
  "libm",
  "lru 0.7.8",
  "parking_lot 0.11.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -321,7 +321,7 @@ rand_hc = "0.3.1"
 rand_xorshift = "0.3"
 rayon = "1.5"
 redis = "0.23.0"
-reed-solomon-erasure = "6.0.0"
+reed-solomon-erasure = { version = "6.0.0", features = ["simd-accel"] }
 regex = "1.7.1"
 region = "3.0"
 reqwest = { version = "0.11.14", features = ["blocking"] }


### PR DESCRIPTION
Using simd will speed up the reed solomon encoding and decoding