### PR TITLE
fix: use T1 for sending chunk endorsements

### DIFF
--- a/chain/network/src/peer_manager/connection/mod.rs
+++ b/chain/network/src/peer_manager/connection/mod.rs
@@ -50,6 +50,7 @@ impl tcp::Tier {
     pub(crate) fn is_allowed_routed(self, body: &RoutedMessageBody) -> bool {
         match body {
             RoutedMessageBody::BlockApproval(..)
+            | RoutedMessageBody::VersionedChunkEndorsement(..)
             | RoutedMessageBody::PartialEncodedStateWitness(..)
             | RoutedMessageBody::PartialEncodedStateWitnessForward(..)
             | RoutedMessageBody::VersionedPartialEncodedChunk(..)


### PR DESCRIPTION
We missed that when refactoring chunk endorsement logic. The old `ChunkEndorsement` message was removed in #12131, but we forgot to add the new message introduced in #11091.
I've noticed that by looking at mainnet metrics where `VersionedChunkEndorsement` message is only sent via T2.