### PR TITLE
fix(resharding): split shard twice

### DIFF
--- a/chain/chain/src/resharding/manager.rs
+++ b/chain/chain/src/resharding/manager.rs
@@ -14,6 +14,7 @@ use near_primitives::challenge::PartialState;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::{get_block_shard_uid, ShardLayout};
 use near_primitives::types::chunk_extra::ChunkExtra;
+use near_store::adapter::trie_store::get_shard_uid_mapping;
 use near_store::adapter::{StoreAdapter, StoreUpdateAdapter};
 use near_store::trie::mem::mem_trie_update::TrackingMode;
 use near_store::trie::ops::resharding::RetainMode;
@@ -140,16 +141,18 @@ impl ReshardingManager {
     }
 
     /// Store in the database the mapping of ShardUId from children to the parent shard,
-    /// so that subsequent accesses to the State will use the parent shard's UId as a prefix for the database key.
+    /// so that subsequent accesses to the State will use the parent shard's UId prefix
+    /// as a prefix for the database key.
     fn set_state_shard_uid_mapping(
         &mut self,
         split_shard_event: &ReshardingSplitShardParams,
     ) -> io::Result<()> {
         let mut store_update = self.store.trie_store().store_update();
         let parent_shard_uid = split_shard_event.parent_shard;
+        let parent_shard_uid_prefix = get_shard_uid_mapping(&self.store, parent_shard_uid);
         // TODO(resharding) No need to set the mapping for children shards that we won't track just after resharding?
         for child_shard_uid in split_shard_event.children_shards() {
-            store_update.set_shard_uid_mapping(child_shard_uid, parent_shard_uid);
+            store_update.set_shard_uid_mapping(child_shard_uid, parent_shard_uid_prefix);
         }
         store_update.commit()
     }

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -33,7 +33,7 @@ fn build_chain() {
     //     cargo insta test --accept -p near-chain --features nightly -- tests::simple_chain::build_chain
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
-        insta::assert_snapshot!(hash, @"GARF4HBtQJ41quFA9fvjHpbVYT4o15syhL3FkH1o7poT");
+        insta::assert_snapshot!(hash, @"HFGqymaNkpz8xX4SGmCZfW8rf47iKzzmo8BYWV66pZAX");
     } else {
         insta::assert_snapshot!(hash, @"5LkmueLrB2cc3vURr6VKvT9acRTuNzWGTvzLGFJkRD9c");
     }
@@ -51,7 +51,7 @@ fn build_chain() {
 
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
-        insta::assert_snapshot!(hash, @"HiXuBfW5Xd6e8ZTbMhwtPEXeZxe7macc8DvaWryNdvcf");
+        insta::assert_snapshot!(hash, @"AwMuxKfwTSGTJJbmAhK4zzjgdHeTUN8wUziNikkSVJhJ");
     } else {
         insta::assert_snapshot!(hash, @"5txsrLCmQp9kn3jYRp1VHrCDt7oBTnhyi71rEPZmm8Ce");
     }

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -270,11 +270,13 @@ impl ProtocolFeature {
             ProtocolFeature::ShuffleShardAssignments => 143,
             ProtocolFeature::CurrentEpochStateSync => 144,
             ProtocolFeature::SimpleNightshadeV4 => 145,
+            // Protocol version 146 is reserved for resharding tests.
+            // ProtocolFeature::SimpleNightshadeV4 => 146,
             #[cfg(feature = "protocol_feature_relaxed_chunk_validation")]
-            ProtocolFeature::RelaxedChunkValidation => 146,
-            ProtocolFeature::ExcludeExistingCodeFromWitnessForCodeLen => 147,
-            ProtocolFeature::BandwidthScheduler => 148,
-            ProtocolFeature::BlockHeightForReceiptId => 149,
+            ProtocolFeature::RelaxedChunkValidation => 147,
+            ProtocolFeature::ExcludeExistingCodeFromWitnessForCodeLen => 148,
+            ProtocolFeature::BandwidthScheduler => 149,
+            ProtocolFeature::BlockHeightForReceiptId => 150,
             // Place features that are not yet in Nightly below this line.
         }
     }
@@ -288,7 +290,7 @@ impl ProtocolFeature {
 const STABLE_PROTOCOL_VERSION: ProtocolVersion = 74;
 
 // On nightly, pick big enough version to support all features.
-const NIGHTLY_PROTOCOL_VERSION: ProtocolVersion = 149;
+const NIGHTLY_PROTOCOL_VERSION: ProtocolVersion = 150;
 
 /// Largest protocol version supported by the current binary.
 pub const PROTOCOL_VERSION: ProtocolVersion = if cfg!(feature = "nightly_protocol") {

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -25,6 +25,9 @@ use crate::test_loop::utils::receipts::{
     check_receipts_presence_after_resharding_block, check_receipts_presence_at_resharding_block,
     ReceiptKind,
 };
+use crate::test_loop::utils::setups::{
+    derive_new_epoch_config_from_boundary, two_upgrades_voting_schedule,
+};
 use crate::test_loop::utils::sharding::{
     next_block_has_new_shard_layout, print_and_assert_shard_accounts,
 };
@@ -35,7 +38,6 @@ use crate::test_loop::utils::transactions::{
 use crate::test_loop::utils::trie_sanity::{
     check_state_shard_uid_mapping_after_resharding, TrieSanityCheck,
 };
-use crate::test_loop::utils::setups::{derive_new_epoch_config_from_boundary, two_upgrades_voting_schedule};
 use crate::test_loop::utils::{get_node_data, retrieve_client_actor, LoopActionFn, ONE_NEAR, TGAS};
 use assert_matches::assert_matches;
 use near_crypto::Signer;
@@ -822,11 +824,7 @@ fn test_resharding_v3() {
 #[test]
 // TODO(resharding) un-ignore the test if multiple reshardings are supported
 fn test_resharding_v3_twice() {
-    test_resharding_v3_base(
-        TestReshardingParametersBuilder::default()
-        .reshard_twice(true)
-        .build(),
-    );
+    test_resharding_v3_base(TestReshardingParametersBuilder::default().reshard_twice(true).build());
 }
 
 #[test]

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -823,6 +823,7 @@ fn test_resharding_v3() {
 
 #[test]
 // TODO(resharding) un-ignore the test if multiple reshardings are supported
+#[ignore]
 fn test_resharding_v3_twice() {
     test_resharding_v3_base(TestReshardingParametersBuilder::default().reshard_twice(true).build());
 }

--- a/integration-tests/src/test_loop/utils/setups.rs
+++ b/integration-tests/src/test_loop/utils/setups.rs
@@ -5,9 +5,12 @@ use itertools::Itertools;
 use near_chain_configs::test_genesis::{
     build_genesis_and_epoch_config_store, GenesisAndEpochConfigParams, ValidatorsSpec,
 };
+use near_primitives::epoch_manager::EpochConfig;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::AccountId;
+use near_primitives::upgrade_schedule::ProtocolUpgradeVotingSchedule;
 use near_primitives::version::PROTOCOL_VERSION;
+use near_vm_runner::logic::ProtocolVersion;
 
 use crate::test_loop::builder::TestLoopBuilder;
 use crate::test_loop::env::TestLoopEnv;
@@ -56,4 +59,27 @@ pub fn standard_setup_1() -> TestLoopEnv {
         .epoch_config_store(epoch_config_store)
         .clients(clients)
         .build()
+}
+
+
+pub fn derive_new_epoch_config_from_boundary(
+    base_epoch_config: &EpochConfig,
+    boundary_account: &AccountId,
+) -> EpochConfig {
+    let base_shard_layout = &base_epoch_config.shard_layout;
+    let mut epoch_config = base_epoch_config.clone();
+    epoch_config.shard_layout =
+        ShardLayout::derive_shard_layout(&base_shard_layout, boundary_account.clone());
+    tracing::info!(target: "test", ?base_shard_layout, new_shard_layout=?epoch_config.shard_layout, "shard layout");
+    epoch_config
+}
+
+pub fn two_upgrades_voting_schedule(target_protocol_version: ProtocolVersion) -> ProtocolUpgradeVotingSchedule {
+    let past_datetime_1 = ProtocolUpgradeVotingSchedule::parse_datetime("1970-01-01 00:00:00").unwrap();
+    let past_datetime_2 = ProtocolUpgradeVotingSchedule::parse_datetime("1970-01-02 00:00:00").unwrap();
+    let voting_schedule = vec![
+        (past_datetime_1, target_protocol_version - 1),
+        (past_datetime_2, target_protocol_version),
+    ];
+    ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(target_protocol_version, voting_schedule).unwrap()
 }

--- a/integration-tests/src/test_loop/utils/setups.rs
+++ b/integration-tests/src/test_loop/utils/setups.rs
@@ -61,7 +61,6 @@ pub fn standard_setup_1() -> TestLoopEnv {
         .build()
 }
 
-
 pub fn derive_new_epoch_config_from_boundary(
     base_epoch_config: &EpochConfig,
     boundary_account: &AccountId,
@@ -74,12 +73,20 @@ pub fn derive_new_epoch_config_from_boundary(
     epoch_config
 }
 
-pub fn two_upgrades_voting_schedule(target_protocol_version: ProtocolVersion) -> ProtocolUpgradeVotingSchedule {
-    let past_datetime_1 = ProtocolUpgradeVotingSchedule::parse_datetime("1970-01-01 00:00:00").unwrap();
-    let past_datetime_2 = ProtocolUpgradeVotingSchedule::parse_datetime("1970-01-02 00:00:00").unwrap();
+pub fn two_upgrades_voting_schedule(
+    target_protocol_version: ProtocolVersion,
+) -> ProtocolUpgradeVotingSchedule {
+    let past_datetime_1 =
+        ProtocolUpgradeVotingSchedule::parse_datetime("1970-01-01 00:00:00").unwrap();
+    let past_datetime_2 =
+        ProtocolUpgradeVotingSchedule::parse_datetime("1970-01-02 00:00:00").unwrap();
     let voting_schedule = vec![
         (past_datetime_1, target_protocol_version - 1),
         (past_datetime_2, target_protocol_version),
     ];
-    ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(target_protocol_version, voting_schedule).unwrap()
+    ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(
+        target_protocol_version,
+        voting_schedule,
+    )
+    .unwrap()
 }

--- a/integration-tests/src/test_loop/utils/trie_sanity.rs
+++ b/integration-tests/src/test_loop/utils/trie_sanity.rs
@@ -347,6 +347,7 @@ pub fn check_state_shard_uid_mapping_after_resharding(client: &Client, parent_sh
     assert_eq!(children_shard_uids.len(), 2);
 
     let store = client.chain.chain_store.store().trie_store();
+    let mut checked_any = false;
     for kv in store.store().iter_raw_bytes(DBCol::State) {
         let (key, value) = kv.unwrap();
         let shard_uid = ShardUId::try_from_slice(&key[0..8]).unwrap();
@@ -355,6 +356,7 @@ pub fn check_state_shard_uid_mapping_after_resharding(client: &Client, parent_sh
         if shard_uid != parent_shard_uid {
             continue;
         }
+        checked_any = true;
         let node_hash = CryptoHash::try_from_slice(&key[8..]).unwrap();
         let (value, _) = decode_value_with_rc(&value);
         let parent_value = store.get(parent_shard_uid, &node_hash);
@@ -366,4 +368,5 @@ pub fn check_state_shard_uid_mapping_after_resharding(client: &Client, parent_sh
             assert_eq!(&child_value.unwrap()[..], value.unwrap());
         }
     }
+    assert!(checked_any);
 }


### PR DESCRIPTION
In the case a shard is split again, we should use `ShardUId` prefix of grandparent.
Add a testloop for this scenario. The test is ignored for now, since we currently do not support multiple reshardings without node restart.