### PR TITLE
refactor: explicitly list all message types in tcp::Tier::is_allowed

### DIFF
--- a/chain/network/src/peer_manager/connection/mod.rs
+++ b/chain/network/src/peer_manager/connection/mod.rs
@@ -43,7 +43,24 @@ impl tcp::Tier {
                 self == tcp::Tier::T2 || self == tcp::Tier::T3
             }
             PeerMessage::Routed(msg) => self.is_allowed_routed(&msg.body),
-            _ => self == tcp::Tier::T2,
+            PeerMessage::SyncRoutingTable(..)
+            | PeerMessage::DistanceVector(..)
+            | PeerMessage::RequestUpdateNonce(..)
+            | PeerMessage::SyncAccountsData(..)
+            | PeerMessage::PeersRequest(..)
+            | PeerMessage::PeersResponse(..)
+            | PeerMessage::BlockHeadersRequest(..)
+            | PeerMessage::BlockHeaders(..)
+            | PeerMessage::BlockRequest(..)
+            | PeerMessage::Block(..)
+            | PeerMessage::Transaction(..)
+            | PeerMessage::Disconnect(..)
+            | PeerMessage::Challenge(..)
+            | PeerMessage::SyncSnapshotHosts(..)
+            | PeerMessage::StateRequestHeader(..)
+            | PeerMessage::StateRequestPart(..)
+            | PeerMessage::EpochSyncRequest
+            | PeerMessage::EpochSyncResponse(..) => self == tcp::Tier::T2,
         }
     }
 


### PR DESCRIPTION
See [this comment](https://github.com/near/nearcore/pull/12634#pullrequestreview-2508723983).