### PR TITLE
test: create a `WitnessConfig` that removes limits

### DIFF
--- a/core/parameters/src/config.rs
+++ b/core/parameters/src/config.rs
@@ -250,3 +250,16 @@ pub struct WitnessConfig {
     /// Soft size limit of storage proof used to validate new transactions in ChunkStateWitness.
     pub new_transactions_validation_state_size_soft_limit: usize,
 }
+
+impl WitnessConfig {
+    /// Creates a config that effectively disables ChunkStateWitness related limits by setting them
+    /// to max values. This can be useful for tests and benchmarks.
+    pub fn test_disabled() -> Self {
+        let max_value = usize::MAX;
+        Self {
+            main_storage_proof_size_soft_limit: max_value,
+            combined_transactions_size_limit: max_value,
+            new_transactions_validation_state_size_soft_limit: max_value,
+        }
+    }
+}


### PR DESCRIPTION
Such config that disables limits is useful for tests/benchmarks. An equivalent `test_disabled` already exists for `CongestionControlConfig`:

https://github.com/near/nearcore/blob/e692d204ed97add40f6fa5baea4477f9b28f9c49/core/parameters/src/config.rs#L217-L221

I plan to use `WitnessConfig::test_disabled` in a follow up PR to make `benchmarknet` config adjustments.