### PR TITLE
docs: wrong path for trie.md

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -23,7 +23,7 @@
   - [Malicious producers and phase 2](./architecture/next/malicious_chunk_producer_and_phase2.md)
 - [Storage](./architecture/storage.md)
   - [Storage Request Flow](./architecture/storage/flow.md)
-  - [Trie](./architecture/storage/trie.md)
+  - [Trie Storage](./architecture/storage/trie_storage.md)
   - [Database Format](./architecture/storage/database.md)
   - [Flat Storage](./architecture/storage/flat_storage.md)
 - [Network](./architecture/network.md)

--- a/docs/architecture/storage/flat_storage.md
+++ b/docs/architecture/storage/flat_storage.md
@@ -2,7 +2,7 @@
 
 When mainnet launched, the neard client stored all the chain's state in a single
 RocksDB column `DBCol::State`. This column embeds the entire [NEAR state
-trie](./trie.md) directly in the key-value database, using roughly
+trie](./trie_storage.md) directly in the key-value database, using roughly
 `hash(borsh_encode(trie_node))` as the key to store a `trie_node`. This gives a
 content-addressed storage system that can easily self-verify.
 


### PR DESCRIPTION
### Summary

With PR #12381 the name of `trie.md` was changed to [trie_storage.md](https://github.com/near/nearcore/pull/12381/files#diff-241b373494cf811201567825847b904ff1e29134525b86d5f6f5c1e35d0e0e83)