### PR TITLE
runtime: validate transactions in parallel

### DIFF
--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -453,12 +453,20 @@ impl Testbed<'_> {
         let verify_signature = true;
 
         let clock = GasCost::measure(metric);
+        let cost = node_runtime::validate_transaction(
+            &self.apply_state.config,
+            gas_price,
+            tx,
+            verify_signature,
+            PROTOCOL_VERSION,
+        )
+        .expect("expected no validation error");
         node_runtime::verify_and_charge_transaction(
             &self.apply_state.config,
             &mut state_update,
             gas_price,
             tx,
-            verify_signature,
+            &cost,
             block_height,
             PROTOCOL_VERSION,
         )

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -464,7 +464,6 @@ impl Testbed<'_> {
         node_runtime::verify_and_charge_transaction(
             &self.apply_state.config,
             &mut state_update,
-            gas_price,
             tx,
             &cost,
             block_height,

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -11,7 +11,7 @@ pub use crate::verifier::{
     validate_transaction, verify_and_charge_transaction, ZERO_BALANCE_ACCOUNT_STORAGE_LIMIT,
 };
 use bandwidth_scheduler::{run_bandwidth_scheduler, BandwidthSchedulerOutput};
-use config::total_prepaid_send_fees;
+use config::{total_prepaid_send_fees, TransactionCost};
 pub use congestion_control::bootstrap_congestion_info;
 use congestion_control::ReceiptSink;
 use itertools::Itertools;
@@ -70,6 +70,7 @@ use near_vm_runner::ContractCode;
 use near_vm_runner::ContractRuntimeCache;
 use near_vm_runner::ProfileDataV3;
 use pipelining::ReceiptPreparationPipeline;
+use rayon::prelude::*;
 use std::cmp::max;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
@@ -289,6 +290,45 @@ impl Runtime {
         debug!(target: "runtime", "{}", log_str);
     }
 
+    /// Parallel validation for all transactions with early short-circuit on first error.
+    ///
+    /// If all validations pass, returns a HashMap of tx_hash -> TransactionCost.
+    /// If any validation fails, returns the first InvalidTxError encountered.
+    fn parallel_validate_transactions(
+        config: &RuntimeConfig,
+        gas_price: Balance,
+        transactions: &[SignedTransaction],
+        current_protocol_version: ProtocolVersion,
+    ) -> Result<HashMap<CryptoHash, TransactionCost>, InvalidTxError> {
+        tracing::debug!(target: "runtime", "parallel validation: starting threads");
+
+        let results = transactions
+            .par_iter()
+            .try_fold(
+                || Vec::new(),
+                |mut acc, tx| {
+                    let cost = validate_transaction(
+                        config,
+                        gas_price,
+                        tx,
+                        true,
+                        current_protocol_version,
+                    )?;
+                    acc.push((tx.get_hash(), cost));
+                    Ok::<_, InvalidTxError>(acc)
+                },
+            )
+            .try_reduce(
+                || Vec::new(),
+                |mut acc1, mut acc2| {
+                    acc1.append(&mut acc2);
+                    Ok::<_, InvalidTxError>(acc1)
+                },
+            )?;
+
+        Ok(results.into_iter().collect())
+    }
+
     /// Takes one signed transaction, verifies it and converts it to a receipt.
     ///
     /// Add the produced receipt either to the new local receipts if the signer is the same
@@ -312,6 +352,7 @@ impl Runtime {
         state_update: &mut TrieUpdate,
         apply_state: &ApplyState,
         signed_transaction: &SignedTransaction,
+        transaction_cost: &TransactionCost,
         stats: &mut ApplyStats,
     ) -> Result<(Receipt, ExecutionOutcomeWithId), InvalidTxError> {
         let span = tracing::Span::current();
@@ -322,7 +363,7 @@ impl Runtime {
             state_update,
             apply_state.gas_price,
             signed_transaction,
-            true,
+            transaction_cost,
             Some(apply_state.block_height),
             apply_state.current_protocol_version,
         ) {
@@ -1589,11 +1630,21 @@ impl Runtime {
         let apply_state = &mut processing_state.apply_state;
         let state_update = &mut processing_state.state_update;
 
+        let tx_costs = Self::parallel_validate_transactions(
+            &apply_state.config,
+            apply_state.gas_price,
+            &processing_state.transactions.transactions,
+            apply_state.current_protocol_version,
+        )
+        .map_err(RuntimeError::from)?;
+
         for signed_transaction in processing_state.transactions.iter_nonexpired_transactions() {
+            let cost = tx_costs.get(&signed_transaction.get_hash()).expect("Must have cost for tx");
             let tx_result = self.process_transaction(
                 state_update,
                 apply_state,
                 signed_transaction,
+                cost,
                 &mut processing_state.stats,
             );
             let (receipt, outcome_with_id) = match tx_result {

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -140,7 +140,6 @@ pub fn validate_transaction(
 pub fn verify_and_charge_transaction(
     config: &RuntimeConfig,
     state_update: &mut TrieUpdate,
-    _gas_price: Balance,
     signed_transaction: &SignedTransaction,
     transaction_cost: &TransactionCost,
     block_height: Option<BlockHeight>,
@@ -738,7 +737,6 @@ mod tests {
                 let err = verify_and_charge_transaction(
                     config,
                     state_update,
-                    gas_price,
                     signed_transaction,
                     &cost,
                     None,
@@ -874,7 +872,6 @@ mod tests {
         let verification_result = verify_and_charge_transaction(
             &config,
             &mut state_update,
-            gas_price,
             &transaction,
             &cost,
             None,
@@ -953,7 +950,6 @@ mod tests {
         let err = verify_and_charge_transaction(
             &config,
             &mut state_update,
-            gas_price,
             &transaction,
             &cost,
             None,
@@ -1023,7 +1019,6 @@ mod tests {
         let err = verify_and_charge_transaction(
             &config,
             &mut state_update,
-            gas_price,
             &transaction,
             &cost,
             None,
@@ -1056,7 +1051,6 @@ mod tests {
         let err = verify_and_charge_transaction(
             &config,
             &mut state_update,
-            gas_price,
             &transaction,
             &cost,
             None,
@@ -1131,7 +1125,6 @@ mod tests {
         let err = verify_and_charge_transaction(
             &config,
             &mut state_update,
-            gas_price,
             &transaction,
             &cost,
             None,
@@ -1183,7 +1176,6 @@ mod tests {
         let err = verify_and_charge_transaction(
             &config,
             &mut state_update,
-            gas_price,
             &transaction,
             &cost,
             None,
@@ -1230,7 +1222,6 @@ mod tests {
         let verification_result = verify_and_charge_transaction(
             &config,
             &mut state_update,
-            gas_price,
             &transaction,
             &cost,
             None,
@@ -1274,7 +1265,6 @@ mod tests {
         let res = verify_and_charge_transaction(
             &config,
             &mut state_update,
-            gas_price,
             &transaction,
             &cost,
             None,
@@ -1332,7 +1322,6 @@ mod tests {
         verify_and_charge_transaction(
             &config,
             &mut state_update,
-            gas_price,
             &transaction,
             &cost,
             None,
@@ -1355,7 +1344,6 @@ mod tests {
         verify_and_charge_transaction(
             &config,
             &mut state_update,
-            gas_price,
             &transaction,
             &cost,
             None,
@@ -1378,7 +1366,6 @@ mod tests {
         verify_and_charge_transaction(
             &config,
             &mut state_update,
-            gas_price,
             &transaction,
             &cost,
             None,
@@ -1423,7 +1410,6 @@ mod tests {
         let err = verify_and_charge_transaction(
             &config,
             &mut state_update,
-            gas_price,
             &transaction,
             &cost,
             None,
@@ -1475,7 +1461,6 @@ mod tests {
         let err = verify_and_charge_transaction(
             &config,
             &mut state_update,
-            gas_price,
             &transaction,
             &cost,
             None,
@@ -1526,7 +1511,6 @@ mod tests {
         let err = verify_and_charge_transaction(
             &config,
             &mut state_update,
-            gas_price,
             &transaction,
             &cost,
             None,
@@ -1582,7 +1566,6 @@ mod tests {
         verify_and_charge_transaction(
             &config,
             &mut state_update,
-            gas_price,
             &transaction,
             &cost,
             None,

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -140,21 +140,16 @@ pub fn validate_transaction(
 pub fn verify_and_charge_transaction(
     config: &RuntimeConfig,
     state_update: &mut TrieUpdate,
-    gas_price: Balance,
+    _gas_price: Balance,
     signed_transaction: &SignedTransaction,
-    verify_signature: bool,
+    transaction_cost: &TransactionCost,
     block_height: Option<BlockHeight>,
     current_protocol_version: ProtocolVersion,
 ) -> Result<VerificationResult, InvalidTxError> {
     let _span = tracing::debug_span!(target: "runtime", "verify_and_charge_transaction").entered();
+
     let TransactionCost { gas_burnt, gas_remaining, receipt_gas_price, total_cost, burnt_amount } =
-        validate_transaction(
-            config,
-            gas_price,
-            signed_transaction,
-            verify_signature,
-            current_protocol_version,
-        )?;
+        *transaction_cost;
 
     let transaction = &signed_transaction.transaction;
     let signer_id = transaction.signer_id();
@@ -165,6 +160,7 @@ pub fn verify_and_charge_transaction(
             return Err(InvalidTxError::SignerDoesNotExist { signer_id: signer_id.clone() });
         }
     };
+
     let mut access_key = match get_access_key(state_update, signer_id, transaction.public_key())? {
         Some(access_key) => access_key,
         None => {
@@ -736,34 +732,35 @@ mod tests {
         signed_transaction: &SignedTransaction,
         expected_err: InvalidTxError,
     ) {
-        assert_eq!(
-            validate_transaction(config, gas_price, signed_transaction, true, PROTOCOL_VERSION)
-                .expect_err("expected an error"),
-            expected_err,
-        );
-        assert_eq!(
-            verify_and_charge_transaction(
-                config,
-                state_update,
-                gas_price,
-                signed_transaction,
-                true,
-                None,
-                PROTOCOL_VERSION,
-            )
-            .expect_err("expected an error"),
-            expected_err,
-        );
+        match validate_transaction(config, gas_price, signed_transaction, true, PROTOCOL_VERSION) {
+            Ok(cost) => {
+                // Validation passed, now verification should fail with expected_err
+                let err = verify_and_charge_transaction(
+                    config,
+                    state_update,
+                    gas_price,
+                    signed_transaction,
+                    &cost,
+                    None,
+                    PROTOCOL_VERSION,
+                )
+                .expect_err("expected an error");
+                assert_eq!(err, expected_err);
+            }
+            Err(err) => {
+                // Validation itself returned an error
+                assert_eq!(err, expected_err);
+            }
+        }
     }
 
     mod zero_balance_account_tests {
         use crate::near_primitives::account::id::AccountId;
         use crate::near_primitives::account::{
-            AccessKeyPermission, Account, FunctionCallPermission,
+            AccessKey, AccessKeyPermission, Account, FunctionCallPermission,
         };
         use crate::verifier::tests::{setup_accounts, TESTING_INIT_BALANCE};
         use crate::verifier::{is_zero_balance_account, ZERO_BALANCE_ACCOUNT_STORAGE_LIMIT};
-        use near_primitives::account::AccessKey;
         use near_store::{get_account, TrieUpdate};
         use testlib::runtime_utils::{alice_account, bob_account};
 
@@ -843,7 +840,7 @@ mod tests {
                     permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
                         allowance: Some(100),
                         receiver_id: bob_account().into(),
-                        method_names: method_names,
+                        method_names,
                     }),
                 }],
                 false,
@@ -871,14 +868,15 @@ mod tests {
             deposit,
             CryptoHash::default(),
         );
-        validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
+
+        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
             .expect("valid transaction");
         let verification_result = verify_and_charge_transaction(
             &config,
             &mut state_update,
             gas_price,
             &transaction,
-            true,
+            &cost,
             None,
             PROTOCOL_VERSION,
         )
@@ -892,7 +890,7 @@ mod tests {
         );
 
         let account = get_account(&state_update, &alice_account()).unwrap().unwrap();
-        // Balance is decreased by the (TX fees + transfer balance).
+        // Balance is decreased by (TX fees + transfer balance).
         assert_eq!(
             account.amount(),
             TESTING_INIT_BALANCE
@@ -937,28 +935,37 @@ mod tests {
         let config = RuntimeConfig::test();
         let (bad_signer, mut state_update, gas_price) = setup_common(TESTING_INIT_BALANCE, 0, None);
 
+        let transaction = SignedTransaction::send_money(
+            1,
+            alice_account(),
+            bob_account(),
+            &*bad_signer,
+            100,
+            CryptoHash::default(),
+        );
+
+        let maybe_cost =
+            validate_transaction(&config, gas_price, &transaction, false, PROTOCOL_VERSION);
+        // Validation might pass if it doesn't require the access key check at this stage
+        let cost =
+            maybe_cost.expect("expected validation to succeed (no access key check at this stage)");
+
+        let err = verify_and_charge_transaction(
+            &config,
+            &mut state_update,
+            gas_price,
+            &transaction,
+            &cost,
+            None,
+            PROTOCOL_VERSION,
+        )
+        .expect_err("expected an error");
         assert_eq!(
-            verify_and_charge_transaction(
-                &config,
-                &mut state_update,
-                gas_price,
-                &SignedTransaction::send_money(
-                    1,
-                    alice_account(),
-                    bob_account(),
-                    &*bad_signer,
-                    100,
-                    CryptoHash::default(),
-                ),
-                false,
-                None,
-                PROTOCOL_VERSION,
-            )
-            .expect_err("expected an error"),
+            err,
             InvalidTxError::InvalidAccessKeyError(InvalidAccessKeyError::AccessKeyNotFound {
                 account_id: alice_account(),
                 public_key: bad_signer.public_key().into(),
-            },),
+            })
         );
     }
 
@@ -1002,26 +1009,28 @@ mod tests {
         let (signer, mut state_update, gas_price) =
             setup_common(TESTING_INIT_BALANCE, 0, Some(AccessKey::full_access()));
 
-        assert_eq!(
-            verify_and_charge_transaction(
-                &config,
-                &mut state_update,
-                gas_price,
-                &SignedTransaction::send_money(
-                    1,
-                    bob_account(),
-                    alice_account(),
-                    &*signer,
-                    100,
-                    CryptoHash::default(),
-                ),
-                true,
-                None,
-                PROTOCOL_VERSION,
-            )
-            .expect_err("expected an error"),
-            InvalidTxError::SignerDoesNotExist { signer_id: bob_account() },
+        let transaction = SignedTransaction::send_money(
+            1,
+            bob_account(),
+            alice_account(),
+            &*signer,
+            100,
+            CryptoHash::default(),
         );
+
+        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
+            .expect("expected no validation error");
+        let err = verify_and_charge_transaction(
+            &config,
+            &mut state_update,
+            gas_price,
+            &transaction,
+            &cost,
+            None,
+            PROTOCOL_VERSION,
+        )
+        .expect_err("expected an error");
+        assert_eq!(err, InvalidTxError::SignerDoesNotExist { signer_id: bob_account() });
     }
 
     #[test]
@@ -1033,26 +1042,28 @@ mod tests {
             Some(AccessKey { nonce: 2, permission: AccessKeyPermission::FullAccess }),
         );
 
-        assert_eq!(
-            verify_and_charge_transaction(
-                &config,
-                &mut state_update,
-                gas_price,
-                &SignedTransaction::send_money(
-                    1,
-                    alice_account(),
-                    bob_account(),
-                    &*signer,
-                    100,
-                    CryptoHash::default(),
-                ),
-                true,
-                None,
-                PROTOCOL_VERSION,
-            )
-            .expect_err("expected an error"),
-            InvalidTxError::InvalidNonce { tx_nonce: 1, ak_nonce: 2 },
+        let transaction = SignedTransaction::send_money(
+            1,
+            alice_account(),
+            bob_account(),
+            &*signer,
+            100,
+            CryptoHash::default(),
         );
+
+        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
+            .expect("expected no validation error");
+        let err = verify_and_charge_transaction(
+            &config,
+            &mut state_update,
+            gas_price,
+            &transaction,
+            &cost,
+            None,
+            PROTOCOL_VERSION,
+        )
+        .expect_err("expected an error");
+        assert_eq!(err, InvalidTxError::InvalidNonce { tx_nonce: 1, ak_nonce: 2 });
     }
 
     #[test]
@@ -1106,19 +1117,23 @@ mod tests {
         let (signer, mut state_update, gas_price) =
             setup_common(TESTING_INIT_BALANCE, 0, Some(AccessKey::full_access()));
 
+        let transaction = SignedTransaction::send_money(
+            1,
+            alice_account(),
+            bob_account(),
+            &*signer,
+            TESTING_INIT_BALANCE,
+            CryptoHash::default(),
+        );
+
+        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
+            .expect("expected cost from validation");
         let err = verify_and_charge_transaction(
             &config,
             &mut state_update,
             gas_price,
-            &SignedTransaction::send_money(
-                1,
-                alice_account(),
-                bob_account(),
-                &*signer,
-                TESTING_INIT_BALANCE,
-                CryptoHash::default(),
-            ),
-            true,
+            &transaction,
+            &cost,
             None,
             PROTOCOL_VERSION,
         )
@@ -1148,25 +1163,29 @@ mod tests {
             }),
         );
 
+        let transaction = SignedTransaction::from_actions(
+            1,
+            alice_account(),
+            bob_account(),
+            &*signer,
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
+                method_name: "hello".to_string(),
+                args: b"abc".to_vec(),
+                gas: 300,
+                deposit: 0,
+            }))],
+            CryptoHash::default(),
+            0,
+        );
+
+        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
+            .expect("expected cost from validation");
         let err = verify_and_charge_transaction(
             &config,
             &mut state_update,
             gas_price,
-            &SignedTransaction::from_actions(
-                1,
-                alice_account(),
-                bob_account(),
-                &*signer,
-                vec![Action::FunctionCall(Box::new(FunctionCallAction {
-                    method_name: "hello".to_string(),
-                    args: b"abc".to_vec(),
-                    gas: 300,
-                    deposit: 0,
-                }))],
-                CryptoHash::default(),
-                0,
-            ),
-            true,
+            &transaction,
+            &cost,
             None,
             PROTOCOL_VERSION,
         )
@@ -1187,9 +1206,6 @@ mod tests {
         }
     }
 
-    /// Setup: account has 1B yoctoN and is 180 bytes. Storage requirement is 1M per byte.
-    /// Test that such account can not send 950M yoctoN out as that will leave it under storage requirements.
-    /// If zero balance account is enabled, however, the transaction should succeed
     #[test]
     fn test_validate_transaction_invalid_low_balance() {
         let mut config = RuntimeConfig::free();
@@ -1200,23 +1216,27 @@ mod tests {
         let (signer, mut state_update, gas_price) =
             setup_common(initial_balance, 0, Some(AccessKey::full_access()));
 
-        let res = verify_and_charge_transaction(
+        let transaction = SignedTransaction::send_money(
+            1,
+            alice_account(),
+            bob_account(),
+            &*signer,
+            transfer_amount,
+            CryptoHash::default(),
+        );
+
+        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
+            .expect("expected cost from validation");
+        let verification_result = verify_and_charge_transaction(
             &config,
             &mut state_update,
             gas_price,
-            &SignedTransaction::send_money(
-                1,
-                alice_account(),
-                bob_account(),
-                &*signer,
-                transfer_amount,
-                CryptoHash::default(),
-            ),
-            true,
+            &transaction,
+            &cost,
             None,
             PROTOCOL_VERSION,
-        );
-        let verification_result = res.unwrap();
+        )
+        .unwrap();
         assert_eq!(verification_result.gas_burnt, 0);
         assert_eq!(verification_result.gas_remaining, 0);
         assert_eq!(verification_result.burnt_amount, 0);
@@ -1240,19 +1260,23 @@ mod tests {
             false,
         )]);
 
+        let transaction = SignedTransaction::send_money(
+            1,
+            account_id.clone(),
+            bob_account(),
+            &*signer,
+            transfer_amount,
+            CryptoHash::default(),
+        );
+
+        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
+            .expect("expected cost from validation");
         let res = verify_and_charge_transaction(
             &config,
             &mut state_update,
             gas_price,
-            &SignedTransaction::send_money(
-                1,
-                account_id.clone(),
-                bob_account(),
-                &*signer,
-                transfer_amount,
-                CryptoHash::default(),
-            ),
-            true,
+            &transaction,
+            &cost,
             None,
             PROTOCOL_VERSION,
         )
@@ -1285,79 +1309,82 @@ mod tests {
             }),
         );
 
-        assert_eq!(
-            verify_and_charge_transaction(
-                &config,
-                &mut state_update,
-                gas_price,
-                &SignedTransaction::from_actions(
-                    1,
-                    alice_account(),
-                    bob_account(),
-                    &*signer,
-                    vec![
-                        Action::FunctionCall(Box::new(FunctionCallAction {
-                            method_name: "hello".to_string(),
-                            args: b"abc".to_vec(),
-                            gas: 100,
-                            deposit: 0,
-                        })),
-                        Action::CreateAccount(CreateAccountAction {})
-                    ],
-                    CryptoHash::default(),
-                    0
-                ),
-                true,
-                None,
-                PROTOCOL_VERSION,
-            )
-            .expect_err("expected an error"),
-            InvalidTxError::InvalidAccessKeyError(InvalidAccessKeyError::RequiresFullAccess),
+        // Case 1
+        let transaction = SignedTransaction::from_actions(
+            1,
+            alice_account(),
+            bob_account(),
+            &*signer,
+            vec![
+                Action::FunctionCall(Box::new(FunctionCallAction {
+                    method_name: "hello".to_string(),
+                    args: b"abc".to_vec(),
+                    gas: 100,
+                    deposit: 0,
+                })),
+                Action::CreateAccount(CreateAccountAction {}),
+            ],
+            CryptoHash::default(),
+            0,
         );
+        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
+            .expect("expected no validation error");
+        verify_and_charge_transaction(
+            &config,
+            &mut state_update,
+            gas_price,
+            &transaction,
+            &cost,
+            None,
+            PROTOCOL_VERSION,
+        )
+        .expect_err("expected an error");
 
-        assert_eq!(
-            verify_and_charge_transaction(
-                &config,
-                &mut state_update,
-                gas_price,
-                &SignedTransaction::from_actions(
-                    1,
-                    alice_account(),
-                    bob_account(),
-                    &*signer,
-                    vec![],
-                    CryptoHash::default(),
-                    0
-                ),
-                true,
-                None,
-                PROTOCOL_VERSION,
-            )
-            .expect_err("expected an error"),
-            InvalidTxError::InvalidAccessKeyError(InvalidAccessKeyError::RequiresFullAccess),
+        // Case 2
+        let transaction = SignedTransaction::from_actions(
+            1,
+            alice_account(),
+            bob_account(),
+            &*signer,
+            vec![],
+            CryptoHash::default(),
+            0,
         );
+        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
+            .expect("expected no validation error");
+        verify_and_charge_transaction(
+            &config,
+            &mut state_update,
+            gas_price,
+            &transaction,
+            &cost,
+            None,
+            PROTOCOL_VERSION,
+        )
+        .expect_err("expected an error");
 
-        assert_eq!(
-            verify_and_charge_transaction(
-                &config,
-                &mut state_update,
-                gas_price,
-                &SignedTransaction::from_actions(
-                    1,
-                    alice_account(),
-                    bob_account(),
-                    &*signer,
-                    vec![Action::CreateAccount(CreateAccountAction {})],
-                    CryptoHash::default(),
-                    0
-                ),
-                true,
-                None,
-                PROTOCOL_VERSION,
-            )
-            .expect_err("expected an error"),
-            InvalidTxError::InvalidAccessKeyError(InvalidAccessKeyError::RequiresFullAccess),
+        // Case 3
+        let transaction = SignedTransaction::from_actions(
+            1,
+            alice_account(),
+            bob_account(),
+            &*signer,
+            vec![Action::CreateAccount(CreateAccountAction {})],
+            CryptoHash::default(),
+            0,
         );
+        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
+            .expect("expected no validation error");
+        verify_and_charge_transaction(
+            &config,
+            &mut state_update,
+            gas_price,
+            &transaction,
+            &cost,
+            None,
+            PROTOCOL_VERSION,
+        )
+        .expect_err("expected an error");
     }
 
     #[test]
@@ -1376,30 +1403,35 @@ mod tests {
             }),
         );
 
+        let transaction = SignedTransaction::from_actions(
+            1,
+            alice_account(),
+            eve_dot_alice_account(),
+            &*signer,
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
+                method_name: "hello".to_string(),
+                args: b"abc".to_vec(),
+                gas: 100,
+                deposit: 0,
+            }))],
+            CryptoHash::default(),
+            0,
+        );
+
+        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
+            .expect("expected no validation error");
+        let err = verify_and_charge_transaction(
+            &config,
+            &mut state_update,
+            gas_price,
+            &transaction,
+            &cost,
+            None,
+            PROTOCOL_VERSION,
+        )
+        .expect_err("expected an error");
         assert_eq!(
-            verify_and_charge_transaction(
-                &config,
-                &mut state_update,
-                gas_price,
-                &SignedTransaction::from_actions(
-                    1,
-                    alice_account(),
-                    eve_dot_alice_account(),
-                    &*signer,
-                    vec![Action::FunctionCall(Box::new(FunctionCallAction {
-                        method_name: "hello".to_string(),
-                        args: b"abc".to_vec(),
-                        gas: 100,
-                        deposit: 0,
-                    })),],
-                    CryptoHash::default(),
-                    0
-                ),
-                true,
-                None,
-                PROTOCOL_VERSION,
-            )
-            .expect_err("expected an error"),
+            err,
             InvalidTxError::InvalidAccessKeyError(InvalidAccessKeyError::ReceiverMismatch {
                 tx_receiver: eve_dot_alice_account(),
                 ak_receiver: bob_account().into()
@@ -1423,30 +1455,35 @@ mod tests {
             }),
         );
 
+        let transaction = SignedTransaction::from_actions(
+            1,
+            alice_account(),
+            bob_account(),
+            &*signer,
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
+                method_name: "hello".to_string(),
+                args: b"abc".to_vec(),
+                gas: 100,
+                deposit: 0,
+            }))],
+            CryptoHash::default(),
+            0,
+        );
+
+        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
+            .expect("expected no validation error");
+        let err = verify_and_charge_transaction(
+            &config,
+            &mut state_update,
+            gas_price,
+            &transaction,
+            &cost,
+            None,
+            PROTOCOL_VERSION,
+        )
+        .expect_err("expected an error");
         assert_eq!(
-            verify_and_charge_transaction(
-                &config,
-                &mut state_update,
-                gas_price,
-                &SignedTransaction::from_actions(
-                    1,
-                    alice_account(),
-                    bob_account(),
-                    &*signer,
-                    vec![Action::FunctionCall(Box::new(FunctionCallAction {
-                        method_name: "hello".to_string(),
-                        args: b"abc".to_vec(),
-                        gas: 100,
-                        deposit: 0,
-                    })),],
-                    CryptoHash::default(),
-                    0
-                ),
-                true,
-                None,
-                PROTOCOL_VERSION,
-            )
-            .expect_err("expected an error"),
+            err,
             InvalidTxError::InvalidAccessKeyError(InvalidAccessKeyError::MethodNameMismatch {
                 method_name: "hello".to_string()
             }),
@@ -1469,31 +1506,36 @@ mod tests {
             }),
         );
 
+        let transaction = SignedTransaction::from_actions(
+            1,
+            alice_account(),
+            bob_account(),
+            &*signer,
+            vec![Action::FunctionCall(Box::new(FunctionCallAction {
+                method_name: "hello".to_string(),
+                args: b"abc".to_vec(),
+                gas: 100,
+                deposit: 100,
+            }))],
+            CryptoHash::default(),
+            0,
+        );
+
+        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
+            .expect("expected no validation error");
+        let err = verify_and_charge_transaction(
+            &config,
+            &mut state_update,
+            gas_price,
+            &transaction,
+            &cost,
+            None,
+            PROTOCOL_VERSION,
+        )
+        .expect_err("expected an error");
         assert_eq!(
-            verify_and_charge_transaction(
-                &config,
-                &mut state_update,
-                gas_price,
-                &SignedTransaction::from_actions(
-                    1,
-                    alice_account(),
-                    bob_account(),
-                    &*signer,
-                    vec![Action::FunctionCall(Box::new(FunctionCallAction {
-                        method_name: "hello".to_string(),
-                        args: b"abc".to_vec(),
-                        gas: 100,
-                        deposit: 100,
-                    })),],
-                    CryptoHash::default(),
-                    0
-                ),
-                true,
-                None,
-                PROTOCOL_VERSION,
-            )
-            .expect_err("expected an error"),
-            InvalidTxError::InvalidAccessKeyError(InvalidAccessKeyError::DepositWithFunctionCall,),
+            err,
+            InvalidTxError::InvalidAccessKeyError(InvalidAccessKeyError::DepositWithFunctionCall,)
         );
     }
 
@@ -1515,34 +1557,34 @@ mod tests {
 
         let mut config = RuntimeConfig::test();
         let max_transaction_size = transaction_size - 1;
-        let wasm_config = Arc::make_mut(&mut config.wasm_config);
-        wasm_config.limit_config.max_transaction_size = transaction_size - 1;
+        {
+            let wasm_config = Arc::make_mut(&mut config.wasm_config);
+            wasm_config.limit_config.max_transaction_size = transaction_size - 1;
+        }
 
+        let err = validate_transaction(&config, gas_price, &transaction, false, PROTOCOL_VERSION)
+            .expect_err("expected validation error - size exceeded");
         assert_eq!(
-            verify_and_charge_transaction(
-                &config,
-                &mut state_update,
-                gas_price,
-                &transaction,
-                false,
-                None,
-                PROTOCOL_VERSION,
-            )
-            .expect_err("expected an error"),
+            err,
             InvalidTxError::TransactionSizeExceeded {
                 size: transaction_size,
                 limit: max_transaction_size
-            },
+            }
         );
 
-        let wasm_config = Arc::make_mut(&mut config.wasm_config);
-        wasm_config.limit_config.max_transaction_size = transaction_size + 1;
+        {
+            let wasm_config = Arc::make_mut(&mut config.wasm_config);
+            wasm_config.limit_config.max_transaction_size = transaction_size + 1;
+        }
+
+        let cost = validate_transaction(&config, gas_price, &transaction, false, PROTOCOL_VERSION)
+            .expect("expected no validation error");
         verify_and_charge_transaction(
             &config,
             &mut state_update,
             gas_price,
             &transaction,
-            false,
+            &cost,
             None,
             PROTOCOL_VERSION,
         )


### PR DESCRIPTION
In the old flow, validation (including signature checks) happened inside `verify_and_charge_transaction()`. In the new flow, we first run `parallel_validate_transactions()` to validate and compute the transaction cost (including signature checks) in parallel. Only after a transaction passes validation do we call `verify_and_charge_transaction()` with the known `cost`.


```mermaid
graph TD;
    subgraph Old_Flow
    A[Runtime::apply]
    A-->B[self.process_transactions]
    B-->C[process_transaction]
    C-->D[verify_and_charge_transaction]
    D-->E[validate_transaction incl. signature]
    E-->|Valid|F[charge fees & finalize]
    E-->|Invalid|G[reject tx]
    end

    subgraph New_Flow
    A2[Runtime::apply]
    A2-->H[self.process_transactions]
    H-->|parallel|I[parallel_validate_transactions incl. signature]
    I-->|Valid, get cost|J[process_transaction]
    J-->K[verify_and_charge_transaction]
    K-->L[charge fees & finalize]
    I-->|Invalid|M[reject tx early]
    classDef threaded fill:#3240a8,stroke:#333,stroke-width:2px;
    class I threaded;
    end
```

(blue = running in parallel)

## Testing
The change brings ~20% throughput improvement on `n2d-standard-16`
```sh
1006/1006 blocks applied in 2m at a rate of 7.5129/s. 0s remaining. Skipped 0 blocks. Over last 100 blocks to height 1073: 0 empty blocks, averaging 413.00 Tgas per non-empty block
```
```sh
1007/1007 blocks applied in 2m at a rate of 8.9972/s. 0s remaining. Skipped 0 blocks. Over last 100 blocks to height 1073: 0 empty blocks, averaging 413.00 Tgas per non-empty block
```
Additionally, profiles before and after the change are available: [before](https://share.firefox.dev/4a5W9tO), [after](https://share.firefox.dev/40pd4oe)
