### PR TITLE
chore: docs fix spelling issues

### DIFF
--- a/tools/state-viewer/src/trie_iteration_benchmark.rs
+++ b/tools/state-viewer/src/trie_iteration_benchmark.rs
@@ -242,7 +242,7 @@ impl TrieIterationBenchmarkCmd {
             col::DELAYED_RECEIPT_OR_INDICES => false,
 
             // Most columns use the ACCOUNT_DATA_SEPARATOR to indicate the end
-            // of the accound id in the trie key. For those columns the
+            // of the account id in the trie key. For those columns the
             // partial_parse_account_id method should be used.
             // The only exception is the ACCESS_KEY and dedicated method
             // partial_parse_account_id_from_access_key should be used.

--- a/tools/themis/src/rules.rs
+++ b/tools/themis/src/rules.rs
@@ -403,7 +403,7 @@ pub fn recursively_publishable(workspace: &Workspace) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Ensure that top-level `Cargo.toml` does not contain superfluouos dependencies.
+/// Ensure that top-level `Cargo.toml` does not contain superfluous dependencies.
 pub fn no_superfluous_deps(workspace: &Workspace) -> anyhow::Result<()> {
     let mut workspace_deps = BTreeSet::<String>::new();
     let mut read_deps = |manifest: &toml::value::Value, table_name: &'static str| {

--- a/tools/undo-block/src/lib.rs
+++ b/tools/undo-block/src/lib.rs
@@ -63,7 +63,7 @@ pub fn undo_only_block_head(
     tracing::info!(target: "neard", ?tail_height, ?current_head_height, ?current_header_height, "Trying to update head");
 
     if current_head_height == tail_height {
-        tracing::info!(target: "neard", "Body head is alreay at the oldest block.");
+        tracing::info!(target: "neard", "Body head is already at the oldest block.");
         return Ok(());
     }
 


### PR DESCRIPTION
- Fixed typo: "`accound `" → "Creates a new `account `"
- Fixed typo: "`superfluouos `" → "Creates a new `superfluous `"
- Fixed typo: "`alreay `" → "Creates a new `already `"
