### PR TITLE
docs: Fix grammatical error Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the nearcore development guide!
 
-The target audience of this guide are developers of nearcore itself. If you are
+The target audience of this guide is developers of nearcore itself. If you are
 a user of NEAR (either a contract developer, or validator running a node),
 please refer to the user docs at <https://docs.near.org>.
 


### PR DESCRIPTION
### Description:  
While reviewing the Introduction section of the guide, I noticed a minor grammatical error in the sentence:  

**Current:**  
> The target audience of this guide are developers of nearcore itself.  

The issue lies in the use of "are" instead of "is." The subject "audience" is singular, so the correct verb form should be "is."  

**Fixed:**  
> The target audience of this guide is developers of nearcore itself.  

This update ensures grammatical accuracy and improves the readability of the text.