### PR TITLE
Fix typographical errors

### DIFF
--- a/chain/chain/src/orphan.rs
+++ b/chain/chain/src/orphan.rs
@@ -66,7 +66,7 @@ impl Orphan {
 /// 2) size of the pool exceeds MAX_ORPHAN_SIZE and the orphan was added a long time ago
 ///    or the height is high
 pub struct OrphanBlockPool {
-    /// A map from block hash to a orphan block
+    /// A map from block hash to an orphan block
     orphans: HashMap<CryptoHash, Orphan>,
     /// A set that contains all orphans for which we have requested missing chunks for them
     /// An orphan can be added to this set when it was first added to the pool, or later

--- a/core/async/README.md
+++ b/core/async/README.md
@@ -4,7 +4,7 @@ This crate contains helpers related to common asynchronous programming patterns
 used in nearcore:
 
 * messaging: common interfaces for sending messages between components.
-* test_loop: a event-loop-based test framework that can test multiple components
+* test_loop: an event-loop-based test framework that can test multiple components
   together in a synchronous way.
 
 

--- a/core/primitives/src/stateless_validation/stored_chunk_state_transition_data.rs
+++ b/core/primitives/src/stateless_validation/stored_chunk_state_transition_data.rs
@@ -23,7 +23,7 @@ impl StoredChunkStateTransitionData {
 #[derive(Debug, BorshSerialize, BorshDeserialize, ProtocolSchema)]
 pub struct StoredChunkStateTransitionDataV1 {
     /// The partial state that is needed to apply the state transition,
-    /// whether it is a new chunk state transition or a implicit missing chunk
+    /// whether it is a new chunk state transition or an implicit missing chunk
     /// state transition.
     pub base_state: PartialState,
     /// If this is a new chunk state transition, the hash of the receipts that

--- a/runtime/near-vm-runner/src/instrument/stack_height/thunk.rs
+++ b/runtime/near-vm-runner/src/instrument/stack_height/thunk.rs
@@ -105,7 +105,7 @@ pub(crate) fn generate_thunks(
 
     // And finally, fixup thunks in export and table sections.
 
-    // Fixup original function index to a index of a thunk generated earlier.
+    // Fixup original function index to an index of a thunk generated earlier.
     let fixup = |function_idx: &mut u32| {
         // Check whether this function is in replacement_map, since
         // we can skip thunk generation (e.g. if stack_cost of function is 0).

--- a/runtime/near-vm/test-api/src/sys/externals/global.rs
+++ b/runtime/near-vm/test-api/src/sys/externals/global.rs
@@ -104,7 +104,7 @@ impl Global {
     ///
     /// # Errors
     ///
-    /// Trying to mutate a immutable global will raise an error:
+    /// Trying to mutate an immutable global will raise an error:
     ///
     /// ```should_panic
     /// # use near_vm_test_api::{Global, Store, Value};

--- a/runtime/runtime-params-estimator/src/trie.rs
+++ b/runtime/runtime-params-estimator/src/trie.rs
@@ -58,7 +58,7 @@ pub(crate) fn write_node(
     );
     let nodes_touched_delta = ext_cost_long_key[&ExtCosts::touching_trie_node]
         - ext_cost_short_key[&ExtCosts::touching_trie_node];
-    // The exact number of touched nodes is a implementation that we don't want
+    // The exact number of touched nodes is an implementation that we don't want
     // to test here but it should be close to 2*final_key_len
     assert!(nodes_touched_delta as usize <= 2 * final_key_len + 10);
     assert!(nodes_touched_delta as usize >= 2 * final_key_len - 10);

--- a/tools/congestion-model/src/main.rs
+++ b/tools/congestion-model/src/main.rs
@@ -130,7 +130,7 @@ fn run_model(
     let mut model = Model::new(strategy, workload);
     let mut max_queues = ShardQueueLengths::default();
 
-    // Set the start time to an half hour ago to make it visible by default in
+    // Set the start time to a half hour ago to make it visible by default in
     // grafana. Each round is 1 virtual second so hald an hour is good for
     // looking at a maximum of 1800 rounds, beyond that you'll need to customize
     // the grafana time range.


### PR DESCRIPTION
### **Description**

This pull request addresses several typographical errors across multiple files in the repository. Specifically, it corrects the usage of indefinite articles ("a" vs. "an") and other minor grammatical issues for improved readability and accuracy. Below are the key changes:

1. **File:** `chain/chain/src/orphan.rs`
   - Fixed: "a orphan block" → "an orphan block"

2. **File:** `core/async/README.md`
   - Fixed: "a event-loop-based" → "an event-loop-based"

3. **File:** `core/primitives/src/stateless_validation/stored_chunk_state_transition_data.rs`
   - Fixed: "a implicit missing chunk" → "an implicit missing chunk"

4. **File:** `runtime/near-vm-runner/src/instrument/stack_height/thunk.rs`
   - Fixed: "a index of a thunk" → "an index of a thunk"

5. **File:** `runtime/near-vm/test-api/src/sys/externals/global.rs`
   - Fixed: "a immutable global" → "an immutable global"

6. **File:** `runtime/runtime-params-estimator/src/trie.rs`
   - Fixed: "a implementation" → "an implementation"

7. **File:** `tools/congestion-model/src/main.rs`
   - Fixed: "an half hour ago" → "a half hour ago"
