### PR TITLE
docs: add a TODO to flat storage resharder

### DIFF
--- a/chain/chain/src/flat_storage_resharder.rs
+++ b/chain/chain/src/flat_storage_resharder.rs
@@ -1027,6 +1027,11 @@ fn copy_kv_to_child(
     if new_shard_uid != *left_child_shard && new_shard_uid != *right_child_shard {
         let err_msg = "account id doesn't map to any child shard! - skipping it";
         warn!(target: "resharding", ?new_shard_uid, ?left_child_shard, ?right_child_shard, ?shard_layout, ?account_id, err_msg);
+
+        // TODO(resharding): add a debug assertion once the root cause is fixed. The current
+        // hypothesis is that flat storage might contain keys with account_id outside of the shard's
+        // boundary due to either a bug in traffic forwarding or corrupted state in mainnet.
+
         // Do not fail resharding. Just skip this entry.
         return Ok(());
     }

--- a/chain/chain/src/flat_storage_resharder.rs
+++ b/chain/chain/src/flat_storage_resharder.rs
@@ -1030,7 +1030,8 @@ fn copy_kv_to_child(
 
         // TODO(resharding): add a debug assertion once the root cause is fixed. The current
         // hypothesis is that flat storage might contain keys with account_id outside of the shard's
-        // boundary due to either a bug in traffic forwarding or corrupted state in mainnet.
+        // boundary due to either a bug in the state generation for forknet or corrupted state in
+        // mainnet.
 
         // Do not fail resharding. Just skip this entry.
         return Ok(());


### PR DESCRIPTION
Adding a TODO to remember to put in place a debug assertion inside the `shard_uid` sanity check.