### PR TITLE
chore: print error details in log line

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3127,8 +3127,8 @@ impl Chain {
                         }
                         blocks_catch_up_state.done_blocks.push(queued_block);
                     }
-                    Err(_) => {
-                        error!("Error processing block during catch up, retrying");
+                    Err(err) => {
+                        error!(target: "chain", ?err, "Error processing block during catch up, retrying");
                         blocks_catch_up_state.pending_blocks.push(queued_block);
                     }
                 }


### PR DESCRIPTION
Write in the logs the reason for the error. Also adding the correct `target`.