### PR TITLE
docs: fix typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can join all the active networks:
 
 Check the `nearup` repository for [more details](https://github.com/near/nearup) on how to run with or without docker.
 
-To learn how to become validator, checkout [documentation](https://docs.near.org/docs/develop/node/validator/staking-and-delegation).
+To learn how to become a validator, checkout [documentation](https://docs.near.org/docs/develop/node/validator/staking-and-delegation).
 
 ## Contributing
 


### PR DESCRIPTION
<img width="508" alt="Снимок экрана 2025-01-08 в 22 14 05" src="https://github.com/user-attachments/assets/9a8b630b-463a-4973-a4e6-17b2be0010ad" />

"become validator": Should be "become a validator" (missing the article "a").

Corrected.