### PR TITLE
chore(resharding): remove outdated TODO

### DIFF
--- a/chain/chain/src/flat_storage_resharder.rs
+++ b/chain/chain/src/flat_storage_resharder.rs
@@ -732,7 +732,6 @@ impl FlatStorageResharder {
                     merged_changes.merge(changes);
                     store_update.remove_delta(shard_uid, flat_head.hash);
                 }
-                // TODO(resharding): if flat_head_block_hash == state sync hash -> do snapshot
             }
 
             // Commit all changes to store.


### PR DESCRIPTION
this was fixed in https://github.com/near/nearcore/pull/12589 but this TODO was left around