### PR TITLE
docs: Corrected usage of pipenv sync Update READEME.md

### DIFF
--- a/debug_scripts/READEME.md
+++ b/debug_scripts/READEME.md
@@ -28,7 +28,7 @@ export PYTHONPATH="<absolute path>/nearcore/debug_scripts:$PYTHONPATH"
 
 ```
 cd <absolute path>/nearcore/debug_scripts
-python3 -m pipenv sync
+pipenv sync
 python3 -m pipenv shell
 python3 -m unittest tests.send_validator_logs_test 
 ```


### PR DESCRIPTION
I noticed a issue in the documentation regarding the use of the `pipenv sync` command. The command is typically run without the `-m` flag, as `pipenv` is executed directly rather than as a module through `python3`.  

This change updates the relevant section to remove `python3 -m` before `pipenv`, ensuring the documentation reflects the correct usage and avoids potential confusion for users.