### PR TITLE
fix(congestion_control) - don't assume that gas is nonzero when buffers are not empty

### DIFF
--- a/runtime/runtime/src/congestion_control.rs
+++ b/runtime/runtime/src/congestion_control.rs
@@ -277,7 +277,9 @@ impl ReceiptSinkV2 {
         }
 
         // Assert that empty buffers match zero buffered gas.
-        assert_eq!(all_buffers_empty, self.own_congestion_info.buffered_receipts_gas() == 0);
+        if all_buffers_empty {
+            assert_eq!(self.own_congestion_info.buffered_receipts_gas(), 0);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Previously the assert was:
```rust
assert_eq!(all_buffers_empty, self.own_congestion_info.buffered_receipts_gas() == 0);
```

But this is wrong. It could happen that buffers are not empty, but `buffered_receipts_gas` is zero. Data receipts have zero gas, so having only Data receipts in the outgoing buffer would trigger the assert.

Let's instead assert that gas is zero when there are no receipts, that should always be true.