### PR TITLE
Fix spelling

### DIFF
--- a/runtime/near-vm/test-api/src/sys/externals/global.rs
+++ b/runtime/near-vm/test-api/src/sys/externals/global.rs
@@ -115,7 +115,7 @@ impl Global {
     /// g.set(Value::I32(2)).unwrap();
     /// ```
     ///
-    /// Trying to set a value of a incompatible type will raise an error:
+    /// Trying to set a value of an incompatible type will raise an error:
     ///
     /// ```should_panic
     /// # use near_vm_test_api::{Global, Store, Value};

--- a/runtime/near-vm/test-generator/src/processors.rs
+++ b/runtime/near-vm/test-generator/src/processors.rs
@@ -24,7 +24,7 @@ pub fn wast_processor(_out: &mut Testsuite, p: PathBuf) -> Option<Test> {
     Some(Test { name: testname, body })
 }
 
-/// Given a Testsuite and a path, process the path in case is a Emscripten
+/// Given a Testsuite and a path, process the path in case is an Emscripten
 /// wasm file.
 pub fn emscripten_processor(_out: &mut Testsuite, p: PathBuf) -> Option<Test> {
     let ext = p.extension()?;


### PR DESCRIPTION
- Fixed "a incompatible type" → "an incompatible type" in `global.rs`.
- Corrected "is a Emscripten" → "is an Emscripten" in `processors.rs`.
