### PR TITLE
[resharding] Check proof size limit while reading delayed receipts

### DIFF
--- a/runtime/runtime/src/congestion_control.rs
+++ b/runtime/runtime/src/congestion_control.rs
@@ -804,16 +804,24 @@ impl<'a> DelayedReceiptQueueWrapper<'a> {
     ) -> Result<Option<ReceiptOrStateStoredReceipt>, RuntimeError> {
         // While processing receipts, we need to keep track of the gas and bytes
         // even for receipts that may be filtered out due to a resharding event
-        while let Some(receipt) = self.queue.pop_front(trie_update)? {
-            let delayed_gas = receipt_congestion_gas(&receipt, &config)?;
-            let delayed_bytes = receipt_size(&receipt)? as u64;
-            self.removed_delayed_gas = safe_add_gas(self.removed_delayed_gas, delayed_gas)?;
-            self.removed_delayed_bytes = safe_add_gas(self.removed_delayed_bytes, delayed_bytes)?;
+        loop {
+            // Check proof size limit before each receipt is popped.
+            if trie_update.trie.check_proof_size_limit_exceed() {
+                break;
+            }
+            if let Some(receipt) = self.queue.pop_front(trie_update)? {
+                let delayed_gas = receipt_congestion_gas(&receipt, &config)?;
+                let delayed_bytes = receipt_size(&receipt)? as u64;
+                self.removed_delayed_gas = safe_add_gas(self.removed_delayed_gas, delayed_gas)?;
+                self.removed_delayed_bytes =
+                    safe_add_gas(self.removed_delayed_bytes, delayed_bytes)?;
 
-            // TODO(resharding): The filter function check here is bypassing the limit check for state witness.
-            // Track gas and bytes for receipt above and return only receipt that belong to the shard.
-            if self.receipt_filter_fn(&receipt) {
-                return Ok(Some(receipt));
+                // Track gas and bytes for receipt above and return only receipt that belong to the shard.
+                if self.receipt_filter_fn(&receipt) {
+                    return Ok(Some(receipt));
+                }
+            } else {
+                break;
             }
         }
         Ok(None)


### PR DESCRIPTION
This PR builds on top of https://github.com/near/nearcore/pull/12710 and is related to issue https://github.com/near/nearcore/issues/12701

After resharding, we copy the set of delayed receipts from parent to both children. While handling delayed receipts in the new shard, we iterated over all the delayed receipts and ignored/removed the ones that did not belong to our shard.

Due to the implementation however, we bypassed checks to the state witness size limit in the specific case of when the receipt did not belong to our shard.

Now that we are doing the checks for the state witness size within the trie recorder, it's much simper to go back and check the proof size limit after reaching EVERY delayed receipt.