### PR TITLE
config: add github action to build neard binary with test_features enabled

### DIFF
--- a/.github/workflows/neard_test_features_binary.yml
+++ b/.github/workflows/neard_test_features_binary.yml
@@ -1,0 +1,34 @@
+name: Neard test features binary release
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        default: 'master'
+        description: "Nearcore branch to build and publish"
+        type: string
+        required: true
+
+jobs:
+  binary-release:
+    name: "Build and publish neard binary"
+    runs-on: "ubuntu-20.04-16core"
+    environment: deploy
+    permissions:
+      id-token: write # required to use OIDC authentication
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::590184106962:role/GitHubActionsRunner
+          aws-region: us-west-1
+
+      - name: Checkout ${{ github.event.inputs.branch }} branch
+        if: ${{ github.event_name == 'workflow_dispatch'}}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Neard binary build and upload to S3
+        run: ./scripts/binary_release.sh test-features-release


### PR DESCRIPTION
This can be useful for forknet testing.