### PR TITLE
test(resharding): two independent splits

### DIFF
--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -94,6 +94,10 @@ type ShardsSplitMapV2 = BTreeMap<ShardId, Vec<ShardId>>;
 /// A mapping from the child shard to the parent shard.
 type ShardsParentMapV2 = BTreeMap<ShardId, ShardId>;
 
+pub fn shard_uids_to_ids(shard_uids: &[ShardUId]) -> Vec<ShardId> {
+    shard_uids.iter().map(|shard_uid| shard_uid.shard_id()).collect_vec()
+}
+
 fn new_shard_ids_vec(shard_ids: Vec<u64>) -> Vec<ShardId> {
     shard_ids.into_iter().map(Into::into).collect()
 }

--- a/integration-tests/src/test_loop/utils/setups.rs
+++ b/integration-tests/src/test_loop/utils/setups.rs
@@ -73,6 +73,8 @@ pub fn derive_new_epoch_config_from_boundary(
     epoch_config
 }
 
+/// Two protocol upgrades would happen as soon as possible,
+/// usually in two consecutive epochs, unless upgrade voting decides differently.
 pub fn two_upgrades_voting_schedule(
     target_protocol_version: ProtocolVersion,
 ) -> ProtocolUpgradeVotingSchedule {

--- a/integration-tests/src/test_loop/utils/setups.rs
+++ b/integration-tests/src/test_loop/utils/setups.rs
@@ -5,9 +5,12 @@ use itertools::Itertools;
 use near_chain_configs::test_genesis::{
     build_genesis_and_epoch_config_store, GenesisAndEpochConfigParams, ValidatorsSpec,
 };
+use near_primitives::epoch_manager::EpochConfig;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::AccountId;
+use near_primitives::upgrade_schedule::ProtocolUpgradeVotingSchedule;
 use near_primitives::version::PROTOCOL_VERSION;
+use near_vm_runner::logic::ProtocolVersion;
 
 use crate::test_loop::builder::TestLoopBuilder;
 use crate::test_loop::env::TestLoopEnv;
@@ -56,4 +59,34 @@ pub fn standard_setup_1() -> TestLoopEnv {
         .epoch_config_store(epoch_config_store)
         .clients(clients)
         .build()
+}
+
+pub fn derive_new_epoch_config_from_boundary(
+    base_epoch_config: &EpochConfig,
+    boundary_account: &AccountId,
+) -> EpochConfig {
+    let base_shard_layout = &base_epoch_config.shard_layout;
+    let mut epoch_config = base_epoch_config.clone();
+    epoch_config.shard_layout =
+        ShardLayout::derive_shard_layout(&base_shard_layout, boundary_account.clone());
+    tracing::info!(target: "test", ?base_shard_layout, new_shard_layout=?epoch_config.shard_layout, "shard layout");
+    epoch_config
+}
+
+pub fn two_upgrades_voting_schedule(
+    target_protocol_version: ProtocolVersion,
+) -> ProtocolUpgradeVotingSchedule {
+    let past_datetime_1 =
+        ProtocolUpgradeVotingSchedule::parse_datetime("1970-01-01 00:00:00").unwrap();
+    let past_datetime_2 =
+        ProtocolUpgradeVotingSchedule::parse_datetime("1970-01-02 00:00:00").unwrap();
+    let voting_schedule = vec![
+        (past_datetime_1, target_protocol_version - 1),
+        (past_datetime_2, target_protocol_version),
+    ];
+    ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(
+        target_protocol_version,
+        voting_schedule,
+    )
+    .unwrap()
 }

--- a/integration-tests/src/test_loop/utils/sharding.rs
+++ b/integration-tests/src/test_loop/utils/sharding.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use near_chain::types::Tip;
 use near_client::Client;
 use near_epoch_manager::EpochManagerAdapter;
@@ -145,4 +146,28 @@ pub fn get_tracked_shards_from_prev_block(
 pub fn get_tracked_shards(client: &Client, block_hash: &CryptoHash) -> Vec<ShardUId> {
     let block_header = client.chain.get_block_header(block_hash).unwrap();
     get_tracked_shards_from_prev_block(client, block_header.prev_hash())
+}
+
+pub fn get_shards_needs_for_next_epoch(client: &Client, block_hash: &CryptoHash) -> Vec<ShardUId> {
+    let signer = client.validator_signer.get();
+    let account_id = signer.as_ref().map(|s| s.validator_id());
+    let prev_block_hash = *client.chain.get_block_header(block_hash).unwrap().prev_hash();
+    let shard_layout =
+        client.epoch_manager.get_shard_layout_from_prev_block(&prev_block_hash).unwrap();
+    let mut shards_needs_for_next_epoch = vec![];
+    for shard_uid in shard_layout.shard_uids() {
+        if client.shard_tracker.will_care_about_shard(
+            account_id,
+            &prev_block_hash,
+            shard_uid.shard_id(),
+            true,
+        ) {
+            shards_needs_for_next_epoch.push(shard_uid);
+        }
+    }
+    shards_needs_for_next_epoch
+}
+
+pub fn shard_uids_to_ids(shard_uids: &[ShardUId]) -> Vec<ShardId> {
+    shard_uids.iter().map(|shard_uid| shard_uid.shard_id()).collect_vec()
 }


### PR DESCRIPTION
* `test_resharding_v3_two_independent_splits` - tests basic scenario where we split two independent shards.
* `test_resharding_v3_two_splits_one_after_another_at_single_node` - tries to reproduce the scenario that we have in recent forknet test, where one node tracks (first_parent) -> (first_parent_child, second_parent) -> (second_parent_child). (Un)fortunatelly, it passes too.

Double resharding (split child after first resharding) actually needs restarts and is not supported yet in testloop.