### PR TITLE
typo fix README.md

### DIFF
--- a/tools/speedy_sync/README.md
+++ b/tools/speedy_sync/README.md
@@ -4,7 +4,7 @@ The goal of the speedy sync is to allow people to catchup quickly with mainnet, 
 
 Currently, in order to catchup with mainnet there are two possible options:
 * download a DB backup that Pagoda provides (around 200GB)
-* sync from scrach - which can take couple days.
+* sync from scratch - which can take couple days.
 
 With SpeedySync, you're able to catchup with mainnet in around 2-3 hours.
 


### PR DESCRIPTION
### Title:
Fix Typo in `README.md`

### Description:
This pull request corrects a minor typo in the `README.md` file located in the `tools/speedy_sync/` directory of the `nearcore` repository.

### Changes:
- Fixed the typo:
  - **Before**: `sync from scrach`
  - **After**: `sync from scratch`
