### PR TITLE
refactor: add helper function for verifier tests

### DIFF
--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -796,6 +796,31 @@ mod tests {
         }
     }
 
+    pub fn validate_verify_and_charge_transaction(
+        config: &RuntimeConfig,
+        state_update: &mut TrieUpdate,
+        signed_transaction: &SignedTransaction,
+        gas_price: Balance,
+        block_height: Option<BlockHeight>,
+        current_protocol_version: ProtocolVersion,
+    ) -> Result<VerificationResult, InvalidTxError> {
+        let transaction_cost = validate_transaction(
+            config,
+            gas_price,
+            signed_transaction,
+            true,
+            current_protocol_version,
+        )?;
+        verify_and_charge_transaction(
+            config,
+            state_update,
+            signed_transaction,
+            &transaction_cost,
+            block_height,
+            current_protocol_version,
+        )
+    }
+
     mod zero_balance_account_tests {
         use crate::near_primitives::account::id::AccountId;
         use crate::near_primitives::account::{
@@ -911,13 +936,11 @@ mod tests {
             CryptoHash::default(),
         );
 
-        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
-            .expect("valid transaction");
-        let verification_result = verify_and_charge_transaction(
+        let verification_result = validate_verify_and_charge_transaction(
             &config,
             &mut state_update,
             &transaction,
-            &cost,
+            gas_price,
             None,
             PROTOCOL_VERSION,
         )
@@ -985,17 +1008,11 @@ mod tests {
             CryptoHash::default(),
         );
 
-        let maybe_cost =
-            validate_transaction(&config, gas_price, &transaction, false, PROTOCOL_VERSION);
-        // Validation might pass if it doesn't require the access key check at this stage
-        let cost =
-            maybe_cost.expect("expected validation to succeed (no access key check at this stage)");
-
-        let err = verify_and_charge_transaction(
+        let err = validate_verify_and_charge_transaction(
             &config,
             &mut state_update,
             &transaction,
-            &cost,
+            gas_price,
             None,
             PROTOCOL_VERSION,
         )
@@ -1058,13 +1075,11 @@ mod tests {
             CryptoHash::default(),
         );
 
-        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
-            .expect("expected no validation error");
-        let err = verify_and_charge_transaction(
+        let err = validate_verify_and_charge_transaction(
             &config,
             &mut state_update,
             &transaction,
-            &cost,
+            gas_price,
             None,
             PROTOCOL_VERSION,
         )
@@ -1090,13 +1105,11 @@ mod tests {
             CryptoHash::default(),
         );
 
-        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
-            .expect("expected no validation error");
-        let err = verify_and_charge_transaction(
+        let err = validate_verify_and_charge_transaction(
             &config,
             &mut state_update,
             &transaction,
-            &cost,
+            gas_price,
             None,
             PROTOCOL_VERSION,
         )
@@ -1164,13 +1177,11 @@ mod tests {
             CryptoHash::default(),
         );
 
-        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
-            .expect("expected cost from validation");
-        let err = verify_and_charge_transaction(
+        let err = validate_verify_and_charge_transaction(
             &config,
             &mut state_update,
             &transaction,
-            &cost,
+            gas_price,
             None,
             PROTOCOL_VERSION,
         )
@@ -1215,13 +1226,11 @@ mod tests {
             0,
         );
 
-        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
-            .expect("expected cost from validation");
-        let err = verify_and_charge_transaction(
+        let err = validate_verify_and_charge_transaction(
             &config,
             &mut state_update,
             &transaction,
-            &cost,
+            gas_price,
             None,
             PROTOCOL_VERSION,
         )
@@ -1261,13 +1270,11 @@ mod tests {
             CryptoHash::default(),
         );
 
-        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
-            .expect("expected cost from validation");
-        let verification_result = verify_and_charge_transaction(
+        let verification_result = validate_verify_and_charge_transaction(
             &config,
             &mut state_update,
             &transaction,
-            &cost,
+            gas_price,
             None,
             PROTOCOL_VERSION,
         )
@@ -1304,13 +1311,11 @@ mod tests {
             CryptoHash::default(),
         );
 
-        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
-            .expect("expected cost from validation");
-        let res = verify_and_charge_transaction(
+        let err = validate_verify_and_charge_transaction(
             &config,
             &mut state_update,
             &transaction,
-            &cost,
+            gas_price,
             None,
             PROTOCOL_VERSION,
         )
@@ -1318,7 +1323,7 @@ mod tests {
         let account = get_account(&state_update, &account_id).unwrap().unwrap();
 
         assert_eq!(
-            res,
+            err,
             InvalidTxError::LackBalanceForState {
                 signer_id: account_id,
                 amount: Balance::from(account.storage_usage()) * config.storage_amount_per_byte()
@@ -1361,13 +1366,11 @@ mod tests {
             CryptoHash::default(),
             0,
         );
-        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
-            .expect("expected no validation error");
-        verify_and_charge_transaction(
+        validate_verify_and_charge_transaction(
             &config,
             &mut state_update,
             &transaction,
-            &cost,
+            gas_price,
             None,
             PROTOCOL_VERSION,
         )
@@ -1383,13 +1386,11 @@ mod tests {
             CryptoHash::default(),
             0,
         );
-        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
-            .expect("expected no validation error");
-        verify_and_charge_transaction(
+        validate_verify_and_charge_transaction(
             &config,
             &mut state_update,
             &transaction,
-            &cost,
+            gas_price,
             None,
             PROTOCOL_VERSION,
         )
@@ -1405,13 +1406,11 @@ mod tests {
             CryptoHash::default(),
             0,
         );
-        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
-            .expect("expected no validation error");
-        verify_and_charge_transaction(
+        validate_verify_and_charge_transaction(
             &config,
             &mut state_update,
             &transaction,
-            &cost,
+            gas_price,
             None,
             PROTOCOL_VERSION,
         )
@@ -1449,13 +1448,11 @@ mod tests {
             0,
         );
 
-        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
-            .expect("expected no validation error");
-        let err = verify_and_charge_transaction(
+        let err = validate_verify_and_charge_transaction(
             &config,
             &mut state_update,
             &transaction,
-            &cost,
+            gas_price,
             None,
             PROTOCOL_VERSION,
         )
@@ -1500,13 +1497,11 @@ mod tests {
             0,
         );
 
-        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
-            .expect("expected no validation error");
-        let err = verify_and_charge_transaction(
+        let err = validate_verify_and_charge_transaction(
             &config,
             &mut state_update,
             &transaction,
-            &cost,
+            gas_price,
             None,
             PROTOCOL_VERSION,
         )
@@ -1550,13 +1545,11 @@ mod tests {
             0,
         );
 
-        let cost = validate_transaction(&config, gas_price, &transaction, true, PROTOCOL_VERSION)
-            .expect("expected no validation error");
-        let err = verify_and_charge_transaction(
+        let err = validate_verify_and_charge_transaction(
             &config,
             &mut state_update,
             &transaction,
-            &cost,
+            gas_price,
             None,
             PROTOCOL_VERSION,
         )
@@ -1605,13 +1598,11 @@ mod tests {
             wasm_config.limit_config.max_transaction_size = transaction_size + 1;
         }
 
-        let cost = validate_transaction(&config, gas_price, &transaction, false, PROTOCOL_VERSION)
-            .expect("expected no validation error");
-        verify_and_charge_transaction(
+        validate_verify_and_charge_transaction(
             &config,
             &mut state_update,
             &transaction,
-            &cost,
+            gas_price,
             None,
             PROTOCOL_VERSION,
         )


### PR DESCRIPTION
Add `validate_verify_and_charge_transaction` function for verifier tests which combines `validate_transaction` and
`verify_and_charge_transaction` functions. This reduces complexity of current and future tests.