### PR TITLE
feat(optimistic_block): shuffle incoming receipts based on prev hash

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -55,7 +55,7 @@ use near_chain_primitives::error::{BlockKnownError, Error, LogTransientStorageEr
 use near_epoch_manager::shard_tracker::ShardTracker;
 use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::bandwidth_scheduler::BandwidthRequests;
-use near_primitives::block::{genesis_chunks, Block, BlockValidityError, Chunks, Tip};
+use near_primitives::block::{genesis_chunks, Block, BlockValidityError, Chunks, MaybeNew, Tip};
 use near_primitives::block_header::BlockHeader;
 use near_primitives::challenge::{
     BlockDoubleSign, Challenge, ChallengeBody, ChallengesResult, ChunkProofs, ChunkState,
@@ -1418,28 +1418,30 @@ impl Chain {
         Ok(false)
     }
 
-    /// Collect all incoming receipts generated in `block`, return a map from target shard id to the
-    /// list of receipts that the target shard receives.
+    /// Collect all incoming receipts from chunks included in some block,
+    /// return a map from target shard id to the list of receipts that the
+    /// target shard receives.
     /// The receipts are sorted by the order that they will be processed.
     /// Note that the receipts returned in this function do not equal all receipts that will be
     /// processed as incoming receipts in this block, because that may include incoming receipts
     /// generated in previous blocks too, if some shards in the previous blocks did not produce
     /// new chunks.
-    pub fn collect_incoming_receipts_from_block(
+    pub fn collect_incoming_receipts_from_chunks(
         &self,
         me: &Option<AccountId>,
-        block: &Block,
+        chunks: &Chunks,
+        prev_block_hash: &CryptoHash,
+        shuffle_salt: &CryptoHash,
     ) -> Result<HashMap<ShardId, Vec<ReceiptProof>>, Error> {
-        if !self.care_about_any_shard_or_part(me, *block.header().prev_hash())? {
+        if !self.care_about_any_shard_or_part(me, *prev_block_hash)? {
             return Ok(HashMap::new());
         }
-        let block_height = block.header().height();
         let mut receipt_proofs_by_shard_id = HashMap::new();
 
-        for chunk_header in block.chunks().iter_deprecated() {
-            if !chunk_header.is_new_chunk(block_height) {
+        for chunk_header in chunks.iter() {
+            let MaybeNew::New(chunk_header) = chunk_header else {
                 continue;
-            }
+            };
             let partial_encoded_chunk =
                 self.chain_store.get_partial_chunk(&chunk_header.chunk_hash()).unwrap();
             for receipt in partial_encoded_chunk.prev_outgoing_receipts().iter() {
@@ -1453,7 +1455,7 @@ impl Chain {
         }
         // sort the receipts deterministically so the order that they will be processed is deterministic
         for (_, receipt_proofs) in receipt_proofs_by_shard_id.iter_mut() {
-            shuffle_receipt_proofs(receipt_proofs, block.hash());
+            shuffle_receipt_proofs(receipt_proofs, shuffle_salt);
         }
 
         Ok(receipt_proofs_by_shard_id)
@@ -2345,7 +2347,19 @@ impl Chain {
         }
 
         self.ping_missing_chunks(me, prev_hash, block)?;
-        let incoming_receipts = self.collect_incoming_receipts_from_block(me, block)?;
+
+        let shuffle_receipts_salt =
+            if ProtocolFeature::BlockHeightForReceiptId.enabled(protocol_version) {
+                &prev_hash
+            } else {
+                block.hash()
+            };
+        let incoming_receipts = self.collect_incoming_receipts_from_chunks(
+            me,
+            &block.chunks(),
+            &prev_hash,
+            shuffle_receipts_salt,
+        )?;
 
         // Check if block can be finalized and drop it otherwise.
         self.check_if_finalizable(header)?;
@@ -3165,8 +3179,23 @@ impl Chain {
         for pending_block in blocks_catch_up_state.pending_blocks.drain(..) {
             let block = self.chain_store.get_block(&pending_block)?.clone();
             let prev_block = self.chain_store.get_block(block.header().prev_hash())?.clone();
+            let prev_hash = *prev_block.hash();
 
-            let receipts_by_shard = self.collect_incoming_receipts_from_block(me, &block)?;
+            let protocol_version =
+                self.epoch_manager.get_epoch_protocol_version(block.header().epoch_id())?;
+            let shuffle_receipts_salt =
+                if ProtocolFeature::BlockHeightForReceiptId.enabled(protocol_version) {
+                    &prev_hash
+                } else {
+                    block.hash()
+                };
+            let receipts_by_shard = self.collect_incoming_receipts_from_chunks(
+                me,
+                &block.chunks(),
+                &prev_hash,
+                shuffle_receipts_salt,
+            )?;
+
             let work = self.apply_chunks_preprocessing(
                 me,
                 &block,

--- a/tools/replay-archive/src/cli.rs
+++ b/tools/replay-archive/src/cli.rs
@@ -497,7 +497,7 @@ impl ReplayController {
         let shuffle_salt = if ProtocolFeature::BlockHeightForReceiptId.enabled(protocol_version) {
             block.header().prev_hash()
         } else {
-            block.hash()
+            block_hash
         };
         for (shard_id, mut receipts) in receipt_proofs_by_shard_id.into_iter() {
             shuffle_receipt_proofs(&mut receipts, shuffle_salt);


### PR DESCRIPTION
#10584

There is another unexpected dependency on block hash during chunk application - it is used in `shuffle_receipt_proofs` to shuffle new receipts targeting our shard. As block hash is unknown in optimistic block, I replace it with prev block hash with a protocol upgrade.

Additionally, use `Chunks` instead of `Block` in `collect_incoming_receipts_from_chunks` - it will be useful for optimistic block execution flow later.

## Security

Some block producer can brute force hashes to get salt which gives more desirable order. But block hash is prone to that as well, prev hash has equivalent safety.

## Upgrade

I use `BlockHeightForReceiptId` feature because it has similar goal and it is going to be released soon. Adding separate feature makes code harder to read I think.

## Testing

IMO it makes sense only to check consistency of the shuffling, I don't see much value in checking that specific salt is used. So I claim that running existing tests is enough to test that change.