### PR TITLE
Fixed spelling

### DIFF
--- a/runtime/near-vm/compiler-singlepass/src/codegen_x64.rs
+++ b/runtime/near-vm/compiler-singlepass/src/codegen_x64.rs
@@ -1191,7 +1191,7 @@ impl<'a> FuncGen<'a> {
             );
             if (stack_offset % 8) != 0 {
                 return Err(CodegenError {
-                    message: "emit_call_native: Bad restoring stack alignement".to_string(),
+                    message: "emit_call_native: Bad restoring stack alignment".to_string(),
                 });
             }
         }

--- a/runtime/near-vm/engine/src/error.rs
+++ b/runtime/near-vm/engine/src/error.rs
@@ -57,7 +57,7 @@ pub enum LinkError {
     #[error("Error while importing {0:?}.{1:?}: {2}")]
     Import(String, String, Box<ImportError>),
 
-    /// A trap ocurred during linking.
+    /// A trap occurred during linking.
     #[error("RuntimeError occurred during linking: {0}")]
     Trap(#[source] RuntimeError),
 
@@ -75,7 +75,7 @@ pub enum LinkError {
 /// start function.
 #[derive(Error, Debug)]
 pub enum InstantiationError {
-    /// A linking ocurred during instantiation.
+    /// A linking occurred during instantiation.
     #[error(transparent)]
     Link(LinkError),
 

--- a/runtime/near-vm/engine/src/universal/link.rs
+++ b/runtime/near-vm/engine/src/universal/link.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::ptr::{read_unaligned, write_unaligned};
 
 /// Add a new trampoline address, given the base address of the Section. Return the address of the jump
-/// The trampoline itself still have to be writen
+/// The trampoline itself still have to be written
 fn trampolines_add(
     map: &mut HashMap<usize, usize>,
     trampoline: &TrampolinesSection,

--- a/runtime/near-vm/test-generator/src/processors.rs
+++ b/runtime/near-vm/test-generator/src/processors.rs
@@ -1,4 +1,4 @@
-//! Here we define the processors usable for each test genrator
+//! Here we define the processors usable for each test generator
 use crate::{extract_name, Test, Testsuite};
 use std::path::PathBuf;
 

--- a/runtime/runtime-params-estimator/src/trie.rs
+++ b/runtime/runtime-params-estimator/src/trie.rs
@@ -228,8 +228,8 @@ fn read_node_from_accounting_cache_ext(
             let values_inserted = num_values * data_spread_factor;
             let values: Vec<_> = (0..values_inserted)
                 .map(|_| {
-                    let extention_key = crate::utils::random_vec(value_len);
-                    near_store::estimator::encode_extension_node(extention_key)
+                    let extension_key = crate::utils::random_vec(value_len);
+                    near_store::estimator::encode_extension_node(extension_key)
                 })
                 .collect();
             let mut setup_block = Vec::new();

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -138,7 +138,7 @@ pub(crate) fn execute_function_call(
             return Err(StorageError::StorageInconsistentState(err.to_string()).into());
         }
         Err(VMRunnerError::LoadingError(msg)) => {
-            panic!("Contract runtime failed to load a contrct: {msg}")
+            panic!("Contract runtime failed to load a contract: {msg}")
         }
         Err(VMRunnerError::Nondeterministic(msg)) => {
             panic!("Contract runner returned non-deterministic error '{}', aborting", msg)


### PR DESCRIPTION

- Fixed spelling in `codegen_x64.rs`, correcting "alignement" to "alignment."
- Corrected "ocurred" to "occurred" in error messages in `error.rs` and `link.rs`.
- Fixed "writen" to "written" in `link.rs`.
- Corrected "genrator" to "generator" in `processors.rs`.
- Fixed "extention" to "extension" in `trie.rs`.
- Corrected "contrct" to "contract" in `actions.rs`.
