### PR TITLE
fix: is_new_chunk condition on block validation

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -846,7 +846,7 @@ impl Chain {
 
         for (shard_index, chunk_header) in block.chunks().iter_deprecated().enumerate() {
             let shard_id = shard_layout.get_shard_id(shard_index)?;
-            if chunk_header.height_created() == genesis_block.header().height() {
+            if chunk_header.is_genesis() {
                 // Special case: genesis chunks can be in non-genesis blocks and don't have a signature
                 // We must verify that content matches and signature is empty.
                 // TODO: this code will not work when genesis block has different number of chunks as the current block
@@ -873,7 +873,7 @@ impl Chain {
                         chunk_header.signature()
                     )));
                 }
-            } else if chunk_header.height_created() == block.header().height() {
+            } else if chunk_header.is_new_chunk(block.header().height()) {
                 if chunk_header.shard_id() != shard_id {
                     return Err(Error::InvalidShardId(chunk_header.shard_id()));
                 }


### PR DESCRIPTION
`height_created` shouldn't be used to check that chunk is new, because in the case of block skip block height will be strictly greater. `height_included` must be used and that's what method `is_new_chunk` does.

Also using `is_genesis` for genesis case check (`self.prev_block_hash() == &CryptoHash::default()`) because it's equivalent and a little more neat.