### PR TITLE
fix(resharding): Clamp negative refcounts to 0

### DIFF
--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -23,7 +23,7 @@ pub use self::rocksdb::RocksDB;
 pub use self::splitdb::SplitDB;
 
 pub use self::slice::DBSlice;
-pub use self::testdb::{TestDB, TestDBFlags};
+pub use self::testdb::TestDB;
 use std::sync::Arc;
 
 // `DBCol::BlockMisc` keys

--- a/core/store/src/db/refcount.rs
+++ b/core/store/src/db/refcount.rs
@@ -104,8 +104,7 @@ pub(crate) fn encode_negative_refcount(rc: std::num::NonZeroU32) -> [u8; 8] {
 ///
 /// Extracts reference count from all provided value and sums them together and
 /// returns result depending on rc:
-/// - rc = 0 ⇒ empty,
-/// - rc < 0 ⇒ encoded reference count,
+/// - rc <= 0 ⇒ empty,
 /// - rc > 0 ⇒ value with encoded reference count.
 ///
 /// Assumes that all provided values with positive reference count have the same
@@ -125,6 +124,9 @@ pub(crate) fn refcount_merge<'a>(
         rc += delta;
     }
 
+    // TODO(resharding) We should preserve negative refcounts, but we don't because of ReshardingV3.
+    // Resharding can result in some data being double deleted, that would result in negative refcount forever
+    // and lead to issue if the same data will be reintroduced later.
     if rc <= 0 {
         Vec::new()
     } else {

--- a/core/store/src/db/refcount.rs
+++ b/core/store/src/db/refcount.rs
@@ -271,11 +271,11 @@ mod test {
         test(b"", &[b"foo\x02\0\0\0\0\0\0\0", MINUS_ONE, MINUS_ONE]);
         test(b"", &[b"foo\x02\0\0\0\0\0\0\0", MINUS_TWO]);
 
-        test(MINUS_ONE, &[MINUS_ONE]);
-        test(MINUS_ONE, &[b"", MINUS_ONE]);
-        test(MINUS_ONE, &[ZERO, MINUS_ONE]);
-        test(MINUS_ONE, &[b"foo\x01\0\0\0\0\0\0\0", MINUS_TWO]);
-        test(MINUS_ONE, &[b"foo\x01\0\0\0\0\0\0\0", MINUS_ONE, MINUS_ONE]);
+        test(b"", &[MINUS_ONE]);
+        test(b"", &[b"", MINUS_ONE]);
+        test(b"", &[ZERO, MINUS_ONE]);
+        test(b"", &[b"foo\x01\0\0\0\0\0\0\0", MINUS_TWO]);
+        test(b"", &[b"foo\x01\0\0\0\0\0\0\0", MINUS_ONE, MINUS_ONE]);
 
         test(b"foo\x02\0\0\0\0\0\0\0", &[b"foo\x01\0\0\0\0\0\0\0", b"foo\x01\0\0\0\0\0\0\0"]);
         test(b"foo\x01\0\0\0\0\0\0\0", &[b"foo\x01\0\0\0\0\0\0\0"]);

--- a/core/store/src/db/refcount.rs
+++ b/core/store/src/db/refcount.rs
@@ -18,7 +18,6 @@
 //! values by adding the reference counts.  When the reference count reaches
 //! zero RocksDB removes the key from the database.
 
-use std::cmp::Ordering;
 use std::io;
 
 use rocksdb::compaction_filter::Decision;
@@ -126,10 +125,10 @@ pub(crate) fn refcount_merge<'a>(
         rc += delta;
     }
 
-    match rc.cmp(&0) {
-        Ordering::Less => rc.to_le_bytes().to_vec(),
-        Ordering::Equal => Vec::new(),
-        Ordering::Greater => [payload.unwrap_or(b""), &rc.to_le_bytes()].concat(),
+    if rc <= 0 {
+        Vec::new()
+    } else {
+        [payload.unwrap_or(b""), &rc.to_le_bytes()].concat()
     }
 }
 

--- a/core/store/src/db/testdb.rs
+++ b/core/store/src/db/testdb.rs
@@ -6,13 +6,6 @@ use std::sync::{Arc, RwLock};
 use crate::db::{refcount, DBIterator, DBOp, DBSlice, DBTransaction, Database};
 use crate::{DBCol, StoreStatistics};
 
-// Overrides to `TestDB` behavior.
-#[derive(Clone, Debug, Default)]
-pub struct TestDBFlags {
-    // Ignore negative refcount being a result of a write to the database.
-    pub allow_negative_refcount: bool,
-}
-
 /// An in-memory database intended for tests and IO-agnostic estimations.
 #[derive(Default)]
 pub struct TestDB {
@@ -25,20 +18,11 @@ pub struct TestDB {
     // The TestDB doesn't produce any stats on its own, it's up to the user of
     // this class to set the stats as they need it.
     stats: RwLock<Option<StoreStatistics>>,
-
-    // Flags to change the default behavior, for testing purposes.
-    flags: TestDBFlags,
 }
 
 impl TestDB {
     pub fn new() -> Arc<TestDB> {
         Arc::new(Self::default())
-    }
-
-    pub fn new_with_flags(flags: TestDBFlags) -> Arc<TestDB> {
-        let mut this = Self::default();
-        this.flags = flags;
-        Arc::new(this)
     }
 }
 
@@ -113,12 +97,10 @@ impl Database for TestDB {
                     if merged.is_empty() {
                         db[col].remove(&key);
                     } else {
-                        if !self.flags.allow_negative_refcount {
-                            debug_assert!(
-                                refcount::decode_value_with_rc(&merged).1 > 0,
-                                "Inserting value with non-positive refcount"
-                            );
-                        }
+                        debug_assert!(
+                            refcount::decode_value_with_rc(&merged).1 > 0,
+                            "Inserting value with non-positive refcount"
+                        );
                         db[col].insert(key, merged);
                     }
                 }
@@ -155,7 +137,7 @@ impl Database for TestDB {
     }
 
     fn copy_if_test(&self, columns_to_keep: Option<&[DBCol]>) -> Option<Arc<dyn Database>> {
-        let mut copy = Self::default();
+        let copy = Self::default();
         {
             let mut db = copy.db.write().unwrap();
             for (col, map) in self.db.read().unwrap().iter() {
@@ -170,7 +152,6 @@ impl Database for TestDB {
                 }
             }
             copy.stats.write().unwrap().clone_from(&self.stats.read().unwrap());
-            copy.flags = self.flags.clone();
         }
         Some(Arc::new(copy))
     }

--- a/core/store/src/test_utils.rs
+++ b/core/store/src/test_utils.rs
@@ -1,5 +1,5 @@
 use crate::adapter::{StoreAdapter, StoreUpdateAdapter};
-use crate::db::{TestDB, TestDBFlags};
+use crate::db::TestDB;
 use crate::flat::{BlockInfo, FlatStorageManager, FlatStorageReadyStatus, FlatStorageStatus};
 use crate::metadata::{DbKind, DbVersion, DB_VERSION};
 use crate::{
@@ -66,14 +66,6 @@ pub fn create_test_node_storage_with_cold(
 /// Creates an in-memory database.
 pub fn create_test_store() -> Store {
     create_test_node_storage(DB_VERSION, DbKind::RPC).get_hot_store()
-}
-
-/// Creates an in-memory database with overrides to the default behavior.
-pub fn create_test_store_with_flags(flags: &TestDBFlags) -> Store {
-    let store = Store::new(TestDB::new_with_flags(flags.clone()));
-    store.set_db_version(DB_VERSION).unwrap();
-    store.set_db_kind(DbKind::RPC).unwrap();
-    store
 }
 
 /// Returns a pair of (Hot, Split) store to be used for setting up archival clients.

--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -35,9 +35,8 @@ use near_primitives::upgrade_schedule::ProtocolUpgradeVotingSchedule;
 use near_primitives::version::PROTOCOL_UPGRADE_SCHEDULE;
 use near_store::adapter::StoreAdapter;
 use near_store::config::StateSnapshotType;
-use near_store::db::TestDBFlags;
 use near_store::genesis::initialize_genesis_state;
-use near_store::test_utils::{create_test_split_store, create_test_store_with_flags};
+use near_store::test_utils::{create_test_split_store, create_test_store};
 use near_store::{Store, StoreConfig, TrieConfig};
 use near_vm_runner::logic::ProtocolVersion;
 use near_vm_runner::{ContractRuntimeCache, FilesystemContractRuntimeCache};
@@ -102,8 +101,6 @@ pub(crate) struct TestLoopBuilder {
     load_memtries_for_tracked_shards: bool,
     /// Upgrade schedule which determines when the clients start voting for new protocol versions.
     upgrade_schedule: ProtocolUpgradeVotingSchedule,
-    /// Overrides to test database behavior.
-    test_store_flags: TestDBFlags,
 }
 
 /// Checks whether chunk is validated by the given account.
@@ -307,7 +304,6 @@ impl TestLoopBuilder {
             track_all_shards: false,
             load_memtries_for_tracked_shards: true,
             upgrade_schedule: PROTOCOL_UPGRADE_SCHEDULE.clone(),
-            test_store_flags: Default::default(),
         }
     }
 
@@ -433,11 +429,6 @@ impl TestLoopBuilder {
 
     pub fn load_memtries_for_tracked_shards(mut self, load_memtries: bool) -> Self {
         self.load_memtries_for_tracked_shards = load_memtries;
-        self
-    }
-
-    pub(crate) fn allow_negative_refcount(mut self) -> Self {
-        self.test_store_flags.allow_negative_refcount = true;
         self
     }
 
@@ -581,7 +572,7 @@ impl TestLoopBuilder {
                 let (hot_store, split_store) = create_test_split_store();
                 (hot_store, Some(split_store))
             } else {
-                let hot_store = create_test_store_with_flags(&self.test_store_flags);
+                let hot_store = create_test_store();
                 (hot_store, None)
             };
         initialize_genesis_state(store.clone(), &genesis, None);

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -126,9 +126,6 @@ struct TestReshardingParameters {
     delay_flat_state_resharding: BlockHeightDelta,
     /// Make promise yield timeout much shorter than normal.
     short_yield_timeout: bool,
-    // TODO(resharding) Remove this when negative refcounts are properly handled.
-    /// Whether to allow negative refcount being a result of the database update.
-    allow_negative_refcount: bool,
     /// If not disabled, use testloop action that will delete an account after resharding
     /// and check that the account is accessible through archival node but not through a regular node.
     disable_temporary_account_test: bool,
@@ -266,7 +263,6 @@ impl TestReshardingParametersBuilder {
             limit_outgoing_gas: self.limit_outgoing_gas.unwrap_or(false),
             delay_flat_state_resharding: self.delay_flat_state_resharding.unwrap_or(0),
             short_yield_timeout: self.short_yield_timeout.unwrap_or(false),
-            allow_negative_refcount: self.allow_negative_refcount.unwrap_or(true),
             disable_temporary_account_test,
             temporary_account_id,
             num_epochs_to_wait,
@@ -378,10 +374,6 @@ fn test_resharding_v3_base(params: TestReshardingParameters) {
 
     if params.track_all_shards {
         builder = builder.track_all_shards();
-    }
-
-    if params.allow_negative_refcount {
-        builder = builder.allow_negative_refcount();
     }
 
     if params.limit_outgoing_gas || params.short_yield_timeout {
@@ -529,7 +521,6 @@ fn test_resharding_v3_base(params: TestReshardingParameters) {
                 client,
                 &resharding_block_hash.get().unwrap(),
                 parent_shard_uid,
-                params.allow_negative_refcount,
             );
         }
 
@@ -922,7 +913,6 @@ fn test_resharding_v3_delayed_receipts_left_child() {
             vec![account],
             ReceiptKind::Delayed,
         ))
-        .allow_negative_refcount(true)
         .build();
     test_resharding_v3_base(params);
 }
@@ -943,7 +933,6 @@ fn test_resharding_v3_delayed_receipts_right_child() {
             vec![account],
             ReceiptKind::Delayed,
         ))
-        .allow_negative_refcount(true)
         .epoch_length(INCREASED_EPOCH_LENGTH)
         .build();
     test_resharding_v3_base(params);
@@ -1199,7 +1188,6 @@ fn test_resharding_v3_yield_timeout() {
             vec![account_in_left_child, account_in_right_child],
             ReceiptKind::PromiseYield,
         ))
-        .allow_negative_refcount(true)
         .epoch_length(INCREASED_EPOCH_LENGTH)
         .build();
     test_resharding_v3_base(params);


### PR DESCRIPTION
In ReshardingV3 we shallow copy some subtries to both children, but there is just a single copy on disk.
That results in these trie nodes having negative refcounts. As a quick mitigation, we decided to clamp these negative refcounts to 0.