### PR TITLE
fix(resharding) - fix loading shards when no resharding is scheduled

### DIFF
--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -1,4 +1,5 @@
 use crate::EpochManagerHandle;
+use itertools::Itertools;
 use near_chain_primitives::Error;
 use near_crypto::Signature;
 use near_primitives::block::Tip;
@@ -437,12 +438,15 @@ pub trait EpochManagerAdapter: Send + Sync {
         head_protocol_version: ProtocolVersion,
         client_protocol_version: ProtocolVersion,
     ) -> Result<HashSet<ShardUId>, Error> {
+        tracing::info!(target: "memtrie", head_protocol_version, client_protocol_version, "get shard uids pending resharding");
         let mut shard_layouts = vec![];
         for protocol_version in head_protocol_version + 1..=client_protocol_version {
             let shard_layout = self.get_shard_layout_from_protocol_version(protocol_version);
 
             let last_shard_layout = shard_layouts.last();
             if last_shard_layout == None || last_shard_layout != Some(&shard_layout) {
+                let shard_ids = shard_layout.shard_ids().collect_vec();
+                tracing::info!(target: "memtrie", ?protocol_version, ?shard_ids, "adding shard layout");
                 shard_layouts.push(shard_layout);
             }
         }
@@ -457,6 +461,7 @@ pub trait EpochManagerAdapter: Send + Sync {
                     break;
                 };
                 if children.len() > 1 {
+                    tracing::info!(target: "memtrie", ?shard_uid, "adding shard id");
                     result.insert(shard_uid);
                     break;
                 }

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -3786,6 +3786,22 @@ fn test_get_shard_uids_pending_resharding_none() {
     assert_eq!(shard_uids.len(), 0);
 }
 
+/// Test there are no ShardUIds pending resharding when there are no planned
+/// reshardings in the simple nightshade v3 shard layout that is used in prod.
+///
+/// This test checks that when then protocol version is changing but the shard
+/// layout is not, no shard is pending resharding.
+#[test]
+fn test_get_shard_uids_pending_resharding_simple_nightshade() {
+    let v3 = ShardLayout::get_simple_nightshade_layout_v3();
+    let shard_uids = test_get_shard_uids_pending_resharding_base(&[v3.clone(), v3]);
+    assert_eq!(shard_uids.len(), 0);
+
+    let v4 = ShardLayout::get_simple_nightshade_layout_v4();
+    let shard_uids = test_get_shard_uids_pending_resharding_base(&[v4.clone(), v4]);
+    assert_eq!(shard_uids.len(), 0);
+}
+
 /// Test that there is only one ShardUId pending resharding during a single
 /// resharding.
 #[test]


### PR DESCRIPTION
The issue was that since `STABLE_PROTOCOL_VERSION` was higher than what's in mainnet the implementation was including the current shard layout in the calculation. Additionally the current shard layout is V1 and it has non-unique shard ids which made it seem like there is a resharding pending. 

The fix is to exclude the head shard layout from the calculation. 