### PR TITLE
chore: marking all resharding v3 tests as slow

### DIFF
--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -324,7 +324,7 @@ fn get_base_shard_layout(version: u64) -> ShardLayout {
 }
 
 /// Base setup to check sanity of Resharding V3.
-fn test_resharding_v3_base(params: TestReshardingParameters) {
+fn slow_test_resharding_v3_base(params: TestReshardingParameters) {
     if !ProtocolFeature::SimpleNightshadeV4.enabled(PROTOCOL_VERSION) {
         return;
     }
@@ -605,13 +605,13 @@ fn test_resharding_v3_base(params: TestReshardingParameters) {
 }
 
 #[test]
-fn test_resharding_v3() {
+fn slow_test_resharding_v3() {
     test_resharding_v3_base(TestReshardingParametersBuilder::default().build());
 }
 
 // TODO(resharding) Add test with double resharding (not independent) when it is supported.
 #[test]
-fn test_resharding_v3_two_independent_splits() {
+fn slow_test_resharding_v3_two_independent_splits() {
     let second_resharding_boundary_account = "account2".parse().unwrap();
     test_resharding_v3_base(
         TestReshardingParametersBuilder::default()
@@ -637,7 +637,7 @@ fn shard_sequence_to_schedule(
 }
 
 #[test]
-fn test_resharding_v3_two_splits_one_after_another_at_single_node() {
+fn slow_test_resharding_v3_two_splits_one_after_another_at_single_node() {
     let first_resharding_boundary_account: AccountId = NEW_BOUNDARY_ACCOUNT.parse().unwrap();
     let second_resharding_boundary_account: AccountId = "account2".parse().unwrap();
 
@@ -694,7 +694,7 @@ fn test_resharding_v3_two_splits_one_after_another_at_single_node() {
 // Track parent shard before resharding, child shard after resharding, and then an unrelated shard forever.
 // Eventually, the State column should only contain entries belonging to the last tracked shard.
 #[test]
-fn test_resharding_v3_state_cleanup() {
+fn slow_test_resharding_v3_state_cleanup() {
     let account_in_stable_shard: AccountId = "account0".parse().unwrap();
     let split_boundary_account: AccountId = NEW_BOUNDARY_ACCOUNT.parse().unwrap();
     let base_shard_layout = get_base_shard_layout(DEFAULT_SHARD_LAYOUT_VERSION);
@@ -723,7 +723,7 @@ fn test_resharding_v3_state_cleanup() {
 
 // Track parent shard before resharding, but do not track any child shard after resharding.
 #[test]
-fn test_resharding_v3_do_not_track_children_after_resharding() {
+fn slow_test_resharding_v3_do_not_track_children_after_resharding() {
     let account_in_stable_shard: AccountId = "account0".parse().unwrap();
     let split_boundary_account: AccountId = NEW_BOUNDARY_ACCOUNT.parse().unwrap();
     let base_shard_layout = get_base_shard_layout(DEFAULT_SHARD_LAYOUT_VERSION);
@@ -754,7 +754,7 @@ fn test_resharding_v3_do_not_track_children_after_resharding() {
 // We expect all parent state and mapping have been removed,
 // then child shard was state synced without mapping.
 #[test]
-fn test_resharding_v3_stop_track_child_for_5_epochs() {
+fn slow_test_resharding_v3_stop_track_child_for_5_epochs() {
     let account_in_stable_shard: AccountId = "account0".parse().unwrap();
     let split_boundary_account: AccountId = NEW_BOUNDARY_ACCOUNT.parse().unwrap();
     let base_shard_layout = get_base_shard_layout(DEFAULT_SHARD_LAYOUT_VERSION);
@@ -797,7 +797,7 @@ fn test_resharding_v3_stop_track_child_for_5_epochs() {
 // We expect the mapping to parent to be preserved, because there were not enough
 // epochs where we did not track any child for mapping to be removed.
 #[test]
-fn test_resharding_v3_stop_track_child_for_5_epochs_with_sibling_in_between() {
+fn slow_test_resharding_v3_stop_track_child_for_5_epochs_with_sibling_in_between() {
     let account_in_stable_shard: AccountId = "account0".parse().unwrap();
     let split_boundary_account: AccountId = NEW_BOUNDARY_ACCOUNT.parse().unwrap();
     let base_shard_layout = get_base_shard_layout(DEFAULT_SHARD_LAYOUT_VERSION);
@@ -837,7 +837,7 @@ fn test_resharding_v3_stop_track_child_for_5_epochs_with_sibling_in_between() {
 // Sets up an extra node that doesn't track the parent, doesn't track the child in the first post-resharding
 // epoch, and then tracks a child in the epoch after that. This checks that state sync works in that case.
 #[test]
-fn test_resharding_v3_sync_child() {
+fn slow_test_resharding_v3_sync_child() {
     let account_in_stable_shard: AccountId = "account0".parse().unwrap();
     let split_boundary_account: AccountId = NEW_BOUNDARY_ACCOUNT.parse().unwrap();
     let base_shard_layout = get_base_shard_layout(DEFAULT_SHARD_LAYOUT_VERSION);
@@ -864,7 +864,7 @@ fn test_resharding_v3_sync_child() {
 }
 
 #[test]
-fn test_resharding_v3_track_all_shards() {
+fn slow_test_resharding_v3_track_all_shards() {
     test_resharding_v3_base(
         TestReshardingParametersBuilder::default()
             .track_all_shards(true)
@@ -874,7 +874,7 @@ fn test_resharding_v3_track_all_shards() {
 }
 
 #[test]
-fn test_resharding_v3_drop_chunks_before() {
+fn slow_test_resharding_v3_drop_chunks_before() {
     let chunk_ranges_to_drop = HashMap::from([(1, -2..0)]);
     test_resharding_v3_base(
         TestReshardingParametersBuilder::default()
@@ -885,7 +885,7 @@ fn test_resharding_v3_drop_chunks_before() {
 }
 
 #[test]
-fn test_resharding_v3_drop_chunks_after() {
+fn slow_test_resharding_v3_drop_chunks_after() {
     let chunk_ranges_to_drop = HashMap::from([(2, 0..2)]);
     test_resharding_v3_base(
         TestReshardingParametersBuilder::default()
@@ -895,7 +895,7 @@ fn test_resharding_v3_drop_chunks_after() {
 }
 
 #[test]
-fn test_resharding_v3_drop_chunks_before_and_after() {
+fn slow_test_resharding_v3_drop_chunks_before_and_after() {
     let chunk_ranges_to_drop = HashMap::from([(0, -2..2)]);
     test_resharding_v3_base(
         TestReshardingParametersBuilder::default()
@@ -906,7 +906,7 @@ fn test_resharding_v3_drop_chunks_before_and_after() {
 }
 
 #[test]
-fn test_resharding_v3_drop_chunks_all() {
+fn slow_test_resharding_v3_drop_chunks_all() {
     let chunk_ranges_to_drop = HashMap::from([(0, -1..2), (1, -3..0), (2, 0..3), (3, 0..1)]);
     test_resharding_v3_base(
         TestReshardingParametersBuilder::default()
@@ -918,7 +918,7 @@ fn test_resharding_v3_drop_chunks_all() {
 
 #[test]
 #[cfg(feature = "test_features")]
-fn test_resharding_v3_resharding_block_in_fork() {
+fn slow_test_resharding_v3_resharding_block_in_fork() {
     test_resharding_v3_base(
         TestReshardingParametersBuilder::default()
             .num_clients(1)
@@ -937,7 +937,7 @@ fn test_resharding_v3_resharding_block_in_fork() {
 //                   In the current scenario the real resharding happens on block B'. Low priority TODO
 //                   since it's a very rare corner case.
 #[cfg(feature = "test_features")]
-fn test_resharding_v3_double_sign_resharding_block() {
+fn slow_test_resharding_v3_double_sign_resharding_block() {
     test_resharding_v3_base(
         TestReshardingParametersBuilder::default()
             .num_clients(1)
@@ -951,7 +951,7 @@ fn test_resharding_v3_double_sign_resharding_block() {
 }
 
 #[test]
-fn test_resharding_v3_shard_shuffling() {
+fn slow_test_resharding_v3_shard_shuffling() {
     let params = TestReshardingParametersBuilder::default()
         .shuffle_shard_assignment_for_chunk_producers(true)
         .num_epochs_to_wait(INCREASED_TESTLOOP_NUM_EPOCHS_TO_WAIT)
@@ -964,7 +964,7 @@ fn test_resharding_v3_shard_shuffling() {
 /// in the next epoch after that. In that case we don't want to state sync because we can just perform
 /// the resharding and continue applying chunks for the child in the first epoch post-resharding.
 #[test]
-fn test_resharding_v3_shard_shuffling_untrack_then_track() {
+fn slow_test_resharding_v3_shard_shuffling_untrack_then_track() {
     let account_in_stable_shard: AccountId = "account0".parse().unwrap();
     let split_boundary_account: AccountId = NEW_BOUNDARY_ACCOUNT.parse().unwrap();
     let base_shard_layout = get_base_shard_layout(DEFAULT_SHARD_LAYOUT_VERSION);
@@ -993,7 +993,7 @@ fn test_resharding_v3_shard_shuffling_untrack_then_track() {
 }
 
 #[test]
-fn test_resharding_v3_shard_shuffling_intense() {
+fn slow_test_resharding_v3_shard_shuffling_intense() {
     let chunk_ranges_to_drop = HashMap::from([(0, -1..2), (1, -3..0), (2, -3..3), (3, 0..1)]);
     let params = TestReshardingParametersBuilder::default()
         .num_accounts(8)
@@ -1012,7 +1012,7 @@ fn test_resharding_v3_shard_shuffling_intense() {
 /// resharding. Caught a bug with invalid storage costs computed during flat
 /// storage resharding.
 #[test]
-fn test_resharding_v3_storage_operations() {
+fn slow_test_resharding_v3_storage_operations() {
     let sender_account: AccountId = "account1".parse().unwrap();
     let account_in_parent: AccountId = "account4".parse().unwrap();
     let params = TestReshardingParametersBuilder::default()
@@ -1027,7 +1027,7 @@ fn test_resharding_v3_storage_operations() {
 
 #[test]
 #[cfg_attr(not(feature = "test_features"), ignore)]
-fn test_resharding_v3_delayed_receipts_left_child() {
+fn slow_test_resharding_v3_delayed_receipts_left_child() {
     let account: AccountId = "account4".parse().unwrap();
     let params = TestReshardingParametersBuilder::default()
         .deploy_test_contract(account.clone())
@@ -1047,7 +1047,7 @@ fn test_resharding_v3_delayed_receipts_left_child() {
 
 #[test]
 #[cfg_attr(not(feature = "test_features"), ignore)]
-fn test_resharding_v3_delayed_receipts_right_child() {
+fn slow_test_resharding_v3_delayed_receipts_right_child() {
     let account: AccountId = "account6".parse().unwrap();
     let params = TestReshardingParametersBuilder::default()
         .deploy_test_contract(account.clone())
@@ -1066,7 +1066,7 @@ fn test_resharding_v3_delayed_receipts_right_child() {
     test_resharding_v3_base(params);
 }
 
-fn test_resharding_v3_split_parent_buffered_receipts_base(base_shard_layout_version: u64) {
+fn slow_test_resharding_v3_split_parent_buffered_receipts_base(base_shard_layout_version: u64) {
     let receiver_account: AccountId = "account0".parse().unwrap();
     let account_in_parent: AccountId = "account4".parse().unwrap();
     let account_in_left_child: AccountId = "account4".parse().unwrap();
@@ -1096,17 +1096,17 @@ fn test_resharding_v3_split_parent_buffered_receipts_base(base_shard_layout_vers
 
 #[test]
 #[cfg_attr(not(feature = "test_features"), ignore)]
-fn test_resharding_v3_split_parent_buffered_receipts_v1() {
+fn slow_test_resharding_v3_split_parent_buffered_receipts_v1() {
     test_resharding_v3_split_parent_buffered_receipts_base(1);
 }
 
 #[test]
 #[cfg_attr(not(feature = "test_features"), ignore)]
-fn test_resharding_v3_split_parent_buffered_receipts_v2() {
+fn slow_test_resharding_v3_split_parent_buffered_receipts_v2() {
     test_resharding_v3_split_parent_buffered_receipts_base(2);
 }
 
-fn test_resharding_v3_buffered_receipts_towards_splitted_shard_base(
+fn slow_test_resharding_v3_buffered_receipts_towards_splitted_shard_base(
     base_shard_layout_version: u64,
 ) {
     let account_in_left_child: AccountId = "account4".parse().unwrap();
@@ -1138,13 +1138,13 @@ fn test_resharding_v3_buffered_receipts_towards_splitted_shard_base(
 
 #[test]
 #[cfg_attr(not(feature = "test_features"), ignore)]
-fn test_resharding_v3_buffered_receipts_towards_splitted_shard_v1() {
+fn slow_test_resharding_v3_buffered_receipts_towards_splitted_shard_v1() {
     test_resharding_v3_buffered_receipts_towards_splitted_shard_base(1);
 }
 
 #[test]
 #[cfg_attr(not(feature = "test_features"), ignore)]
-fn test_resharding_v3_buffered_receipts_towards_splitted_shard_v2() {
+fn slow_test_resharding_v3_buffered_receipts_towards_splitted_shard_v2() {
     test_resharding_v3_buffered_receipts_towards_splitted_shard_base(2);
 }
 
@@ -1153,7 +1153,9 @@ fn test_resharding_v3_buffered_receipts_towards_splitted_shard_v2() {
 /// buffer contains receipts to the shard that was split. Bandwidth requests to the child where the
 /// receipts will be sent must include the receipts stored in outgoing buffer to the parent shard,
 /// otherwise there will be no bandwidth grants to send them.
-fn test_resharding_v3_large_receipts_towards_splitted_shard_base(base_shard_layout_version: u64) {
+fn slow_test_resharding_v3_large_receipts_towards_splitted_shard_base(
+    base_shard_layout_version: u64,
+) {
     let account_in_left_child: AccountId = "account4".parse().unwrap();
     let account_in_right_child: AccountId = "account6".parse().unwrap();
     let account_in_stable_shard: AccountId = "account1".parse().unwrap();
@@ -1191,7 +1193,7 @@ fn slow_test_resharding_v3_large_receipts_towards_splitted_shard_v2() {
 
 #[test]
 #[cfg_attr(not(feature = "test_features"), ignore)]
-fn test_resharding_v3_outgoing_receipts_towards_splitted_shard() {
+fn slow_test_resharding_v3_outgoing_receipts_towards_splitted_shard() {
     let receiver_account: AccountId = "account4".parse().unwrap();
     let account_1_in_stable_shard: AccountId = "account1".parse().unwrap();
     let account_2_in_stable_shard: AccountId = "account2".parse().unwrap();
@@ -1209,7 +1211,7 @@ fn test_resharding_v3_outgoing_receipts_towards_splitted_shard() {
 
 #[test]
 #[cfg_attr(not(feature = "test_features"), ignore)]
-fn test_resharding_v3_outgoing_receipts_from_splitted_shard() {
+fn slow_test_resharding_v3_outgoing_receipts_from_splitted_shard() {
     let receiver_account: AccountId = "account0".parse().unwrap();
     let account_in_left_child: AccountId = "account4".parse().unwrap();
     let account_in_right_child: AccountId = "account6".parse().unwrap();
@@ -1227,7 +1229,7 @@ fn test_resharding_v3_outgoing_receipts_from_splitted_shard() {
 }
 
 #[test]
-fn test_resharding_v3_load_memtrie_v1() {
+fn slow_test_resharding_v3_load_memtrie_v1() {
     let params = TestReshardingParametersBuilder::default()
         .base_shard_layout_version(1)
         .load_memtries_for_tracked_shards(false)
@@ -1236,7 +1238,7 @@ fn test_resharding_v3_load_memtrie_v1() {
 }
 
 #[test]
-fn test_resharding_v3_load_memtrie_v2() {
+fn slow_test_resharding_v3_load_memtrie_v2() {
     let params = TestReshardingParametersBuilder::default()
         .base_shard_layout_version(2)
         .load_memtries_for_tracked_shards(false)
@@ -1246,7 +1248,7 @@ fn test_resharding_v3_load_memtrie_v2() {
 
 #[test]
 #[cfg_attr(not(feature = "test_features"), ignore)]
-fn test_resharding_v3_slower_post_processing_tasks() {
+fn slow_test_resharding_v3_slower_post_processing_tasks() {
     // When there's a resharding task delay and single-shard tracking, the delay might be pushed out
     // even further because the resharding task might have to wait for the state snapshot to be made
     // before it can proceed, which might mean that flat storage won't be ready for the child shard for a whole epoch.
@@ -1261,7 +1263,7 @@ fn test_resharding_v3_slower_post_processing_tasks() {
 
 #[test]
 #[cfg_attr(not(feature = "test_features"), ignore)]
-fn test_resharding_v3_shard_shuffling_slower_post_processing_tasks() {
+fn slow_test_resharding_v3_shard_shuffling_slower_post_processing_tasks() {
     let params = TestReshardingParametersBuilder::default()
         .shuffle_shard_assignment_for_chunk_producers(true)
         .num_epochs_to_wait(INCREASED_TESTLOOP_NUM_EPOCHS_TO_WAIT)
@@ -1272,7 +1274,7 @@ fn test_resharding_v3_shard_shuffling_slower_post_processing_tasks() {
 }
 
 #[test]
-fn test_resharding_v3_yield_resume() {
+fn slow_test_resharding_v3_yield_resume() {
     let account_in_left_child: AccountId = "account4".parse().unwrap();
     let account_in_right_child: AccountId = "account6".parse().unwrap();
     let params = TestReshardingParametersBuilder::default()
@@ -1296,7 +1298,7 @@ fn test_resharding_v3_yield_resume() {
 }
 
 #[test]
-fn test_resharding_v3_yield_timeout() {
+fn slow_test_resharding_v3_yield_timeout() {
     let account_in_left_child: AccountId = "account4".parse().unwrap();
     let account_in_right_child: AccountId = "account6".parse().unwrap();
     let params = TestReshardingParametersBuilder::default()

--- a/integration-tests/src/test_loop/tests/resharding_v3.rs
+++ b/integration-tests/src/test_loop/tests/resharding_v3.rs
@@ -324,7 +324,7 @@ fn get_base_shard_layout(version: u64) -> ShardLayout {
 }
 
 /// Base setup to check sanity of Resharding V3.
-fn slow_test_resharding_v3_base(params: TestReshardingParameters) {
+fn test_resharding_v3_base(params: TestReshardingParameters) {
     if !ProtocolFeature::SimpleNightshadeV4.enabled(PROTOCOL_VERSION) {
         return;
     }
@@ -1066,7 +1066,7 @@ fn slow_test_resharding_v3_delayed_receipts_right_child() {
     test_resharding_v3_base(params);
 }
 
-fn slow_test_resharding_v3_split_parent_buffered_receipts_base(base_shard_layout_version: u64) {
+fn test_resharding_v3_split_parent_buffered_receipts_base(base_shard_layout_version: u64) {
     let receiver_account: AccountId = "account0".parse().unwrap();
     let account_in_parent: AccountId = "account4".parse().unwrap();
     let account_in_left_child: AccountId = "account4".parse().unwrap();
@@ -1106,7 +1106,7 @@ fn slow_test_resharding_v3_split_parent_buffered_receipts_v2() {
     test_resharding_v3_split_parent_buffered_receipts_base(2);
 }
 
-fn slow_test_resharding_v3_buffered_receipts_towards_splitted_shard_base(
+fn test_resharding_v3_buffered_receipts_towards_splitted_shard_base(
     base_shard_layout_version: u64,
 ) {
     let account_in_left_child: AccountId = "account4".parse().unwrap();
@@ -1153,9 +1153,7 @@ fn slow_test_resharding_v3_buffered_receipts_towards_splitted_shard_v2() {
 /// buffer contains receipts to the shard that was split. Bandwidth requests to the child where the
 /// receipts will be sent must include the receipts stored in outgoing buffer to the parent shard,
 /// otherwise there will be no bandwidth grants to send them.
-fn slow_test_resharding_v3_large_receipts_towards_splitted_shard_base(
-    base_shard_layout_version: u64,
-) {
+fn test_resharding_v3_large_receipts_towards_splitted_shard_base(base_shard_layout_version: u64) {
     let account_in_left_child: AccountId = "account4".parse().unwrap();
     let account_in_right_child: AccountId = "account6".parse().unwrap();
     let account_in_stable_shard: AccountId = "account1".parse().unwrap();


### PR DESCRIPTION
Based on CI logs like [this one](https://productionresultssa19.blob.core.windows.net/actions-results/0fa817d7-8151-4dda-add9-875200388984/workflow-job-run-e0b9291a-afac-5fd1-3237-17923e645a46/logs/job/job-logs.txt?rsct=text%2Fplain&se=2025-01-27T18%3A22%3A59Z&sig=oXPp0DDrZ4rtT%2FUoXp%2B3NGya7ns6ON88L3Dbg%2F3FJxs%3D&ske=2025-01-28T04%3A39%3A32Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2025-01-27T16%3A39%3A32Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2024-11-04&sp=r&spr=https&sr=b&st=2025-01-27T18%3A12%3A54Z&sv=2024-11-04), resharding v3 tests are consistently marked as slow, and they also were slow [on my machines as well](https://near.zulipchat.com/#narrow/channel/300659-Rust-.F0.9F.A6.80/topic/nextest.2C.20slow.20tests/near/488110325). The PR increases timeout for them.