### PR TITLE
fix(metrics): pass the epoch manager to spawn_trie_metrics_loop

### DIFF
--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -250,17 +250,19 @@ pub fn start_with_config_and_synchronization(
         None
     };
 
-    let trie_metrics_arbiter = spawn_trie_metrics_loop(
-        config.clone(),
-        storage.get_hot_store(),
-        config.client_config.log_summary_period,
-    )?;
-
     let epoch_manager = EpochManager::new_arc_handle(
         storage.get_hot_store(),
         &config.genesis.config,
         Some(home_dir),
     );
+
+    let trie_metrics_arbiter = spawn_trie_metrics_loop(
+        config.clone(),
+        storage.get_hot_store(),
+        config.client_config.log_summary_period,
+        epoch_manager.clone(),
+    )?;
+
     let genesis_epoch_config = epoch_manager.get_epoch_config(&EpochId::default())?;
     // Initialize genesis_state in store either from genesis config or dump before other components.
     // We only initialize if the genesis state is not already initialized in store.


### PR DESCRIPTION
This function creates its own epoch manager with new_from_genesis_config(), but this is not how the main epoch manager is created at startup, which is done with new_arc_handle(). These result in epoch managers that return different EpochConfigs for a given protocol version, since only the second one initializes an epoch config store from the genesis config, and the first one generates epoch configs with generate_epoch_config(). In this case it leads to a crash if the shard layouts are different because the call to `ShardUId::from_shard_id_and_layout()` will see the wrong shard IDs and crash at `assert!(shard_layout.shard_ids().any(|i| i == shard_id));`