### PR TITLE
fix: Update tracing collector image

### DIFF
--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -3,7 +3,7 @@ name = "near-tracing"
 version = "0.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
-rust-version = "1.84.0"
+rust-version = "1.84.0" # Please update the Dockerfile to `rust:1.XX-bullseye` when bumping version here
 repository = "https://github.com/near/nearcore"
 license = "MIT OR Apache-2.0"
 

--- a/tracing/Dockerfile
+++ b/tracing/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.81-bullseye as builder
+FROM rust:1.84-bullseye as builder
 
 ADD Cargo.toml /build/Cargo.toml
 ADD Cargo.lock /build/Cargo.lock


### PR DESCRIPTION
Building the tracing collector `Dockerfile` failed with:
```console
3.198 error: rustc 1.81.0 is not supported by the following package:
3.198   near-tracing@0.0.0 requires rustc 1.84.0
3.198 
```
Because the dockerfile uses older version than the crate.

Let's bump dockerfile version to match the crate version.