### PR TITLE
fix in the README.md

### DIFF
--- a/runtime/near-vm/test-api/README.md
+++ b/runtime/near-vm/test-api/README.md
@@ -62,7 +62,7 @@ Wasmer is not only fast, but also designed to be *highly customizable*:
 * **Cross-compilation** — Most compilers support cross-compilation. It
   means it possible to pre-compile a WebAssembly module targetting a
   different architecture or platform and serialize it, to then run it
-  on the targetted architecture and platform later.
+  on the targeted architecture and platform later.
 
 * **Run Wasmer in a JavaScript environment** — With the `js` Cargo
   feature, it is possible to compile a Rust program using Wasmer to


### PR DESCRIPTION
## Fix Typo in `README.md`

### Changes
- Corrected a typo in the `README.md` file: replaced "targetting" with "targeted."
