### PR TITLE
spellcheck: utils directory

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -115,6 +115,7 @@
         "kickout",
         "Kickouts",
         "kkuuue",
+        "libc",
         "libcore",
         "libfuzzer",
         "librocksdb",

--- a/cspell.json
+++ b/cspell.json
@@ -11,7 +11,7 @@
         "docs/images/**",
         "pytest/requirements.txt",
         "pytest/tests/sandbox/patch_state.py",
-        "utils/mainnet-res/res/storage_usage_delta.json"
+        "utils/mainnet-res/res/**.json"
     ],
     "dictionaryDefinitions": [],
     "dictionaries": [],

--- a/cspell.json
+++ b/cspell.json
@@ -10,7 +10,8 @@
         "debug_scripts/Pipfile",
         "docs/images/**",
         "pytest/requirements.txt",
-        "pytest/tests/sandbox/patch_state.py"
+        "pytest/tests/sandbox/patch_state.py",
+        "utils/mainnet-res/res/storage_usage_delta.json"
     ],
     "dictionaryDefinitions": [],
     "dictionaries": [],

--- a/utils/fmt/src/lib.rs
+++ b/utils/fmt/src/lib.rs
@@ -121,7 +121,7 @@ impl<'a> std::fmt::Display for AbbrBytes<Option<&'a [u8]>> {
 /// A wrapper for bytes slice which tries to guess best way to format it.
 ///
 /// If the slice is exactly 32-byte long, it’s assumed to be a hash and is
-/// converted into base58 and printed surrounded by backtics.  Otherwise,
+/// converted into base58 and printed surrounded by backticks.  Otherwise,
 /// behaves like [`Bytes`] representing the data as string if it contains ASCII
 /// printable bytes only or base64 otherwise.
 ///
@@ -238,6 +238,7 @@ fn truncated_bytes_format(bytes: &[u8], fmt: &mut std::fmt::Formatter<'_>) -> st
     }
 }
 
+// cspell:words Zółw Zvby Ffoo HTBBNBNCLX Ypei rabarbar
 #[cfg(test)]
 macro_rules! do_test_bytes_formatting {
     ($type:ident, $consider_hash:expr, $truncate:expr) => {{

--- a/utils/near-performance-metrics/src/stats_enabled.rs
+++ b/utils/near-performance-metrics/src/stats_enabled.rs
@@ -11,6 +11,8 @@ use std::task::Poll;
 use std::time::{Duration, Instant};
 use tracing::{info, warn};
 
+// cspell:words NTHREADS
+
 pub static NTHREADS: AtomicUsize = AtomicUsize::new(0);
 pub(crate) const SLOW_CALL_THRESHOLD: Duration = Duration::from_millis(500);
 const MIN_OCCUPANCY_RATIO_THRESHOLD: f64 = 0.02;

--- a/utils/stdx/src/lib.rs
+++ b/utils/stdx/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(clippy::arithmetic_side_effects)]
 
 // TODO(mina86): Replace usage of the split functions by split_array_ref et al
-// methods of array and slice types once those are stabilised.
+// methods of array and slice types once those are stabilized.
 
 /// Splits `&[u8; L + R]` into `(&[u8; L], &[u8; R])`.
 pub fn split_array<const N: usize, const L: usize, const R: usize>(
@@ -62,7 +62,7 @@ fn test_join() {
 }
 
 /// Splits a slice into a slice of N-element arrays.
-// TODO(mina86): Replace with [T]::as_chunks once that’s stabilised.
+// TODO(mina86): Replace with [T]::as_chunks once that’s stabilized.
 pub fn as_chunks<const N: usize, T>(slice: &[T]) -> (&[[T; N]], &[T]) {
     const {
         if N == 0 {


### PR DESCRIPTION
Fix the spellchecker errors in `nearcore/utils`