### PR TITLE
bench(synth-bench):  Add `read_nonces_from_network` flag to benchmark binaries

### DIFF
--- a/benchmarks/synth-bm/Cargo.lock
+++ b/benchmarks/synth-bm/Cargo.lock
@@ -1403,6 +1403,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/benchmarks/synth-bm/Cargo.toml
+++ b/benchmarks/synth-bm/Cargo.toml
@@ -20,3 +20,4 @@ rand = "0.8.4"
 tokio = { version = "1.40.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tracing = { version = "0.1.40", features = ["std"] }

--- a/benchmarks/synth-bm/justfile
+++ b/benchmarks/synth-bm/justfile
@@ -26,6 +26,7 @@ benchmark_native_transfers:
     cargo run --release -- benchmark-native-transfers \
         --rpc-url {{rpc_url}} \
         --user-data-dir user-data/ \
+        --read-nonces-from-network \
         --num-transfers 200 \
         --channel-buffer-size 30000 \
         --interval-duration-micros 550 \
@@ -36,6 +37,7 @@ benchmark_mpc_sign:
     cargo run --release -- benchmark-mpc-sign \
         --rpc-url {{rpc_url}} \
         --user-data-dir user-data/ \
+        --read-nonces-from-network \
         --num-transactions 500 \
         --transactions-per-second 100 \
         --receiver-id 'v1.signer-dev.testnet' \
@@ -43,3 +45,4 @@ benchmark_mpc_sign:
         --channel-buffer-size 500 \
         --gas 300000000000000 \
         --deposit 100000000000000000000000
+

--- a/benchmarks/synth-bm/src/account.rs
+++ b/benchmarks/synth-bm/src/account.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
+use tokio::task::JoinSet;
 use tokio::time;
 
 use crate::block_service::BlockService;
@@ -142,6 +143,39 @@ pub fn accounts_from_dir(dir: &Path) -> anyhow::Result<Vec<Account>> {
     Ok(accounts)
 }
 
+/// Updates accounts with the nonce values requested from the network and optionally writes the updated values to the disk.
+pub async fn update_account_nonces(
+    client: JsonRpcClient,
+    mut accounts: Vec<Account>,
+    tps_limit: u64,
+    accounts_path: Option<&PathBuf>,
+) -> anyhow::Result<Vec<Account>> {
+    let mut tasks = JoinSet::new();
+
+    let mut interval = time::interval(Duration::from_micros(1_000_000u64 / tps_limit));
+    for (i, account) in accounts.iter().enumerate() {
+        interval.tick().await;
+        let client = client.clone();
+        let (id, pk) = (account.id.clone(), account.public_key.clone());
+        tasks.spawn(async move { (i, view_access_key(&client, id, pk).await) });
+    }
+
+    while let Some(res) = tasks.join_next().await {
+        let (idx, response) = res.expect("join should succeed");
+        let nonce = response?.nonce;
+        let account = accounts.get_mut(idx).unwrap();
+        if account.nonce != nonce {
+            log::trace!("updating nonce for a user {} ({}->{})", account.id, account.nonce, nonce);
+            account.nonce = nonce;
+            if let Some(path) = accounts_path {
+                account.write_to_dir(path)?;
+            }
+        }
+    }
+
+    Ok(accounts)
+}
+
 pub async fn create_sub_accounts(args: &CreateSubAccountsArgs) -> anyhow::Result<()> {
     let signer = InMemorySigner::from_file(&args.signer_key_path)?;
 
@@ -218,25 +252,9 @@ pub async fn create_sub_accounts(args: &CreateSubAccountsArgs) -> anyhow::Result
 
     info!("Querying nonces of newly created sub accounts.");
 
-    // Nonces of new access keys are set by nearcore: https://github.com/near/nearcore/pull/4064
-    // Query them from the rpc to write `Accounts` with valid nonces to disk.
-    // TODO use `JoinSet`, e.g. by storing accounts in map instead of vec.
-    let mut get_access_key_tasks = Vec::with_capacity(sub_accounts.len());
-    // Use an interval to avoid overwhelming the node with requests.
-    let mut interval = time::interval(Duration::from_micros(150));
-    for account in sub_accounts.clone().into_iter() {
-        interval.tick().await;
-        let client = client.clone();
-        get_access_key_tasks.push(tokio::spawn(async move {
-            view_access_key(&client, account.id.clone(), account.public_key.clone()).await
-        }))
-    }
+    sub_accounts = update_account_nonces(client.clone(), sub_accounts, 5_000, None).await?;
 
-    for (i, task) in get_access_key_tasks.into_iter().enumerate() {
-        let response = task.await.expect("join should succeed");
-        let nonce = response?.nonce;
-        let account = sub_accounts.get_mut(i).unwrap();
-        account.nonce = nonce;
+    for account in sub_accounts.iter() {
         account.write_to_dir(&args.user_data_dir)?;
     }
 

--- a/benchmarks/synth-bm/src/account.rs
+++ b/benchmarks/synth-bm/src/account.rs
@@ -165,11 +165,10 @@ pub async fn update_account_nonces(
         let nonce = response?.nonce;
         let account = accounts.get_mut(idx).unwrap();
         if account.nonce != nonce {
-            tracing::debug!(
-                "updating nonce for a user {} ({}->{})",
-                account.id,
-                account.nonce,
-                nonce
+            tracing::debug!(name: "nonce updated",
+                user = account.id.to_string(),
+                nonce.old = account.nonce,
+                nonce.new = nonce,
             );
             account.nonce = nonce;
             if let Some(path) = accounts_path {

--- a/benchmarks/synth-bm/src/account.rs
+++ b/benchmarks/synth-bm/src/account.rs
@@ -165,7 +165,12 @@ pub async fn update_account_nonces(
         let nonce = response?.nonce;
         let account = accounts.get_mut(idx).unwrap();
         if account.nonce != nonce {
-            log::trace!("updating nonce for a user {} ({}->{})", account.id, account.nonce, nonce);
+            tracing::debug!(
+                "updating nonce for a user {} ({}->{})",
+                account.id,
+                account.nonce,
+                nonce
+            );
             account.nonce = nonce;
             if let Some(path) = accounts_path {
                 account.write_to_dir(path)?;

--- a/benchmarks/synth-bm/src/contract.rs
+++ b/benchmarks/synth-bm/src/contract.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use crate::account::accounts_from_dir;
+use crate::account::{accounts_from_dir, update_account_nonces};
 use crate::block_service::BlockService;
 use crate::rpc::{ResponseCheckSeverity, RpcResponseHandler};
 use clap::Args;
@@ -50,6 +50,10 @@ pub struct BenchmarkMpcSignArgs {
     /// The deposit (in yoctoNEAR) attached to each `sign` function call transaction.
     #[arg(long)]
     pub deposit: u128,
+
+    /// If set, this flag updates the nonce values from the network.
+    #[arg(default_value_t = false, long)]
+    pub read_nonces_from_network: bool,
 }
 
 pub async fn benchmark_mpc_sign(args: &BenchmarkMpcSignArgs) -> anyhow::Result<()> {
@@ -65,6 +69,11 @@ pub async fn benchmark_mpc_sign(args: &BenchmarkMpcSignArgs) -> anyhow::Result<(
         time::interval(Duration::from_micros(1_000_000 / args.transactions_per_second));
 
     let client = JsonRpcClient::connect(&args.rpc_url);
+    if args.read_nonces_from_network {
+        accounts =
+            update_account_nonces(client.clone(), accounts, 5_000, Some(&args.user_data_dir))
+                .await?;
+    }
     let block_service = Arc::new(BlockService::new(client.clone()).await);
     block_service.clone().start().await;
     let mut rng = thread_rng();

--- a/benchmarks/synth-bm/src/contract.rs
+++ b/benchmarks/synth-bm/src/contract.rs
@@ -70,9 +70,13 @@ pub async fn benchmark_mpc_sign(args: &BenchmarkMpcSignArgs) -> anyhow::Result<(
 
     let client = JsonRpcClient::connect(&args.rpc_url);
     if args.read_nonces_from_network {
-        accounts =
-            update_account_nonces(client.clone(), accounts, 5_000, Some(&args.user_data_dir))
-                .await?;
+        accounts = update_account_nonces(
+            client.clone(),
+            accounts,
+            1_000_000 / args.transactions_per_second,
+            Some(&args.user_data_dir),
+        )
+        .await?;
     }
     let block_service = Arc::new(BlockService::new(client.clone()).await);
     block_service.clone().start().await;

--- a/benchmarks/synth-bm/src/native_transfer.rs
+++ b/benchmarks/synth-bm/src/native_transfer.rs
@@ -40,7 +40,6 @@ pub struct BenchmarkArgs {
 }
 
 pub async fn benchmark(args: &BenchmarkArgs) -> anyhow::Result<()> {
-    println!("read_nonces_from_network = {}", &args.read_nonces_from_network);
     let mut accounts = accounts_from_dir(&args.user_data_dir)?;
     assert!(accounts.len() >= 2);
 
@@ -55,9 +54,13 @@ pub async fn benchmark(args: &BenchmarkArgs) -> anyhow::Result<()> {
     let block_service = Arc::new(BlockService::new(client.clone()).await);
 
     if args.read_nonces_from_network {
-        accounts =
-            update_account_nonces(client.clone(), accounts, 5_000, Some(&args.user_data_dir))
-                .await?;
+        accounts = update_account_nonces(
+            client.clone(),
+            accounts,
+            1_000_000 / args.interval_duration_micros,
+            Some(&args.user_data_dir),
+        )
+        .await?;
     }
 
     block_service.clone().start().await;

--- a/benchmarks/synth-bm/src/native_transfer.rs
+++ b/benchmarks/synth-bm/src/native_transfer.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use crate::account::accounts_from_dir;
+use crate::account::{accounts_from_dir, update_account_nonces};
 use crate::block_service::BlockService;
 use crate::rpc::{ResponseCheckSeverity, RpcResponseHandler};
 use clap::Args;
@@ -33,9 +33,14 @@ pub struct BenchmarkArgs {
     pub interval_duration_micros: u64,
     #[arg(long)]
     pub amount: u128,
+
+    /// If set, this flag updates the nonce values from the network.
+    #[arg(default_value_t = false, long)]
+    pub read_nonces_from_network: bool,
 }
 
 pub async fn benchmark(args: &BenchmarkArgs) -> anyhow::Result<()> {
+    println!("read_nonces_from_network = {}", &args.read_nonces_from_network);
     let mut accounts = accounts_from_dir(&args.user_data_dir)?;
     assert!(accounts.len() >= 2);
 
@@ -46,7 +51,15 @@ pub async fn benchmark(args: &BenchmarkArgs) -> anyhow::Result<()> {
     let mut rng = rand::thread_rng();
 
     let client = JsonRpcClient::connect(&args.rpc_url);
+
     let block_service = Arc::new(BlockService::new(client.clone()).await);
+
+    if args.read_nonces_from_network {
+        accounts =
+            update_account_nonces(client.clone(), accounts, 5_000, Some(&args.user_data_dir))
+                .await?;
+    }
+
     block_service.clone().start().await;
 
     // Before a request is made, a permit to send into the channel is awaited. Hence buffer size


### PR DESCRIPTION
[issue 12805](https://github.com/near/nearcore/issues/12805)
The flag (default=false) triggers the update of the account nonces from the network before generating the transactions.

impl details:
  - extract the `update_account_nonces()` function
  - add a corresponding flag to benhmark_native_transfers and benchmark_mpc binaries
    + apply the `update_account_nonces()` depending on the flag value

tested:
   - run the benchmark from the clean state
   - edit the `a_user_0.test.near.json`, set "nonce" to 7000001
   - update the log level to "trace" in the justfile
   - re-run the benchmark
   - find the `[2025-01-29T13:06:56Z TRACE near_synth_bm::account] updating nonce for a user a_user_0.test.near (7000001->7000020)` in the log