### PR TITLE
replace interval_duration_micros by requests_per_second as an argument to benchmark_native_transfers

### DIFF
--- a/benchmarks/synth-bm/justfile
+++ b/benchmarks/synth-bm/justfile
@@ -18,7 +18,7 @@ create_sub_accounts:
         --num-sub-accounts 100 \
         --deposit 953060601875000000010000 \
         --channel-buffer-size 1200 \
-        --requests-per-second 2000 \
+        --requests-per-second 1250 \
         --user-data-dir user-data
 
 benchmark_native_transfers:

--- a/benchmarks/synth-bm/justfile
+++ b/benchmarks/synth-bm/justfile
@@ -18,7 +18,7 @@ create_sub_accounts:
         --num-sub-accounts 100 \
         --deposit 953060601875000000010000 \
         --channel-buffer-size 1200 \
-        --interval-duration-micros 800 \
+        --requests-per-second 2000 \
         --user-data-dir user-data
 
 benchmark_native_transfers:
@@ -28,7 +28,7 @@ benchmark_native_transfers:
         --user-data-dir user-data/ \
         --num-transfers 200 \
         --channel-buffer-size 30000 \
-        --interval-duration-micros 550 \
+        --requests-per-second 2000 \
         --amount 1
 
 benchmark_mpc_sign:
@@ -37,7 +37,7 @@ benchmark_mpc_sign:
         --rpc-url {{rpc_url}} \
         --user-data-dir user-data/ \
         --num-transactions 500 \
-        --transactions-per-second 100 \
+        --requests-per-second 100 \
         --receiver-id 'v1.signer-dev.testnet' \
         --key-version 0 \
         --channel-buffer-size 500 \

--- a/benchmarks/synth-bm/src/account.rs
+++ b/benchmarks/synth-bm/src/account.rs
@@ -55,10 +55,9 @@ pub struct CreateSubAccountsArgs {
     #[arg(long)]
     /// Acts as upper bound on the number of concurrently open RPC requests.
     pub channel_buffer_size: usize,
-    /// After each tick (in microseconds) a transaction is sent. If the hardware cannot keep up with
-    /// that or if the NEAR node is congested, transactions are sent at a slower rate.
+    /// Upper bound on request rate to the network for transaction (and other auxiliary) calls. The actual rate may be lower in case of congestions.
     #[arg(long)]
-    pub interval_duration_micros: u64,
+    pub requests_per_second: u64,
     /// Directory where created user account data (incl. key and nonce) is stored.
     #[arg(long)]
     pub user_data_dir: PathBuf,
@@ -149,7 +148,7 @@ pub async fn create_sub_accounts(args: &CreateSubAccountsArgs) -> anyhow::Result
     let block_service = Arc::new(BlockService::new(client.clone()).await);
     block_service.clone().start().await;
 
-    let mut interval = time::interval(Duration::from_micros(args.interval_duration_micros));
+    let mut interval = time::interval(Duration::from_micros(1_000_000/args.requests_per_second));
     let timer = Instant::now();
 
     let mut sub_accounts: Vec<Account> =

--- a/benchmarks/synth-bm/src/contract.rs
+++ b/benchmarks/synth-bm/src/contract.rs
@@ -31,7 +31,7 @@ pub struct BenchmarkMpcSignArgs {
     /// The number of transactions to send per second. May be lower when reaching hardware limits or
     /// network congestion.
     #[arg(long)]
-    pub transactions_per_second: u64,
+    pub requests_per_second: u64,
     /// The total number of transactions to send.
     #[arg(long)]
     pub num_transactions: u64,
@@ -61,8 +61,7 @@ pub async fn benchmark_mpc_sign(args: &BenchmarkMpcSignArgs) -> anyhow::Result<(
     );
 
     // Pick interval to achieve desired TPS.
-    let mut interval =
-        time::interval(Duration::from_micros(1_000_000 / args.transactions_per_second));
+    let mut interval = time::interval(Duration::from_micros(1_000_000 / args.requests_per_second));
 
     let client = JsonRpcClient::connect(&args.rpc_url);
     let block_service = Arc::new(BlockService::new(client.clone()).await);

--- a/benchmarks/synth-bm/src/native_transfer.rs
+++ b/benchmarks/synth-bm/src/native_transfer.rs
@@ -27,10 +27,11 @@ pub struct BenchmarkArgs {
     /// Acts as upper bound on the number of concurrently open RPC requests.
     #[arg(long)]
     pub channel_buffer_size: usize,
-    /// After each tick (in microseconds) a transaction is sent. If the hardware cannot keep up with
-    /// that or if the NEAR node is congested, transactions are sent at a slower rate.
+
+    /// Upper bound on request rate to the network for transaction (and other auxiliary) calls. The actual rate may be lower in case of congestions.
     #[arg(long)]
-    pub interval_duration_micros: u64,
+    pub requests_per_second: u64,
+
     #[arg(long)]
     pub amount: u128,
 }
@@ -39,7 +40,7 @@ pub async fn benchmark(args: &BenchmarkArgs) -> anyhow::Result<()> {
     let mut accounts = accounts_from_dir(&args.user_data_dir)?;
     assert!(accounts.len() >= 2);
 
-    let mut interval = time::interval(Duration::from_micros(args.interval_duration_micros));
+    let mut interval = time::interval(Duration::from_micros(1_000_000 / args.requests_per_second));
     let timer = Instant::now();
 
     let between = Uniform::from(0..accounts.len());


### PR DESCRIPTION
Issue [12835](https://github.com/near/nearcore/issues/12835). 

Using "requests-per-second" instead of suggested "transactions_per_second" as this value can be used to limit the rate of the other requests to the network as well (client data sync for example). 
Renamed the corresponding parameter in the `bencmark_mpc_sign` as well.