### PR TITLE
refactor: remove slashing info and signature verification from epoch manager

### DIFF
--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -702,13 +702,7 @@ fn test_verify_validator_signature() {
     let signature = signer.sign(&data);
     assert!(env
         .epoch_manager
-        .verify_validator_signature(
-            &env.head.epoch_id,
-            &env.head.last_block_hash,
-            &validators[0],
-            &data,
-            &signature
-        )
+        .verify_validator_signature(&env.head.epoch_id, &validators[0], &data, &signature)
         .unwrap());
 }
 
@@ -1021,6 +1015,7 @@ fn test_get_validator_info() {
     assert_eq!(response.epoch_start_height, 3);
 }
 
+#[ignore = "Ignoring challenge and slashing related tests"]
 #[test]
 fn test_challenges() {
     let mut env =
@@ -1043,16 +1038,16 @@ fn test_challenges() {
     let msg = vec![0, 1, 2];
     let signer = InMemorySigner::test_signer(&"test2".parse().unwrap());
     let signature = signer.sign(&msg);
-    assert!(!env
-        .epoch_manager
-        .verify_validator_signature(
-            &env.head.epoch_id,
-            &env.head.last_block_hash,
-            &"test2".parse().unwrap(),
-            &msg,
-            &signature,
-        )
-        .unwrap());
+    assert!(
+        !env.epoch_manager
+            .verify_validator_signature(
+                &env.head.epoch_id,
+                &"test2".parse().unwrap(),
+                &msg,
+                &signature,
+            )
+            .unwrap()
+    );
     // Run for 3 epochs, to finalize the given block and make sure that slashed stake actually correctly propagates.
     for _ in 0..6 {
         env.step(vec![vec![]], vec![true], vec![]);
@@ -1061,6 +1056,7 @@ fn test_challenges() {
 
 /// Test that in case of a double sign, not all stake is slashed if the double signed stake is
 /// less than 33% and all stake is slashed if the stake is more than 33%
+#[ignore = "Ignoring challenge and slashing related tests"]
 #[test]
 fn test_double_sign_challenge_not_all_slashed() {
     init_test_logger();
@@ -1099,16 +1095,16 @@ fn test_double_sign_challenge_not_all_slashed() {
     let msg = vec![0, 1, 2];
     let signer = InMemorySigner::test_signer(&"test2".parse().unwrap());
     let signature = signer.sign(&msg);
-    assert!(!env
-        .epoch_manager
-        .verify_validator_signature(
-            &env.head.epoch_id,
-            &env.head.last_block_hash,
-            &"test2".parse().unwrap(),
-            &msg,
-            &signature,
-        )
-        .unwrap());
+    assert!(
+        !env.epoch_manager
+            .verify_validator_signature(
+                &env.head.epoch_id,
+                &"test2".parse().unwrap(),
+                &msg,
+                &signature,
+            )
+            .unwrap()
+    );
 
     for _ in 2..11 {
         env.step(vec![vec![]], vec![true], vec![]);
@@ -1141,6 +1137,7 @@ fn test_double_sign_challenge_not_all_slashed() {
 }
 
 /// Test that double sign from multiple accounts may result in all of their stake slashed.
+#[ignore = "Ignoring challenge and slashing related tests"]
 #[test]
 fn test_double_sign_challenge_all_slashed() {
     init_test_logger();
@@ -1159,7 +1156,6 @@ fn test_double_sign_challenge_all_slashed() {
             .epoch_manager
             .verify_validator_signature(
                 &env.head.epoch_id,
-                &env.head.last_block_hash,
                 &AccountId::try_from(format!("test{}", i + 1)).unwrap(),
                 &msg,
                 &signature,

--- a/chain/chain/src/stateless_validation/chunk_endorsement.rs
+++ b/chain/chain/src/stateless_validation/chunk_endorsement.rs
@@ -88,11 +88,7 @@ pub fn validate_chunk_endorsements_in_block(
         let mut endorsed_chunk_validators = HashMap::new();
         for (account_id, signature) in ordered_chunk_validators.iter().zip(signatures) {
             let Some(signature) = signature else { continue };
-            let (validator, _) = epoch_manager.get_validator_by_account_id(
-                &epoch_id,
-                block.header().prev_hash(),
-                account_id,
-            )?;
+            let validator = epoch_manager.get_validator_by_account_id(&epoch_id, account_id)?;
 
             // Block should not be produced with an invalid signature.
             if !ChunkEndorsement::validate_signature(

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -963,7 +963,7 @@ impl ClientActorInner {
             .get_next_epoch_id_from_prev_block(&prev_block_hash));
 
         // Check client is part of the futures validators
-        if self.client.is_validator(&next_epoch_id, &prev_block_hash, validator_signer) {
+        if self.client.is_validator(&next_epoch_id, validator_signer) {
             debug!(target: "client", "Sending announce account for {}", signer.validator_id());
             self.last_validator_announce_time = Some(now);
 
@@ -1327,8 +1327,8 @@ impl ClientActorInner {
         match chain_store_update.commit() {
             Ok(_) => {
                 let head = unwrap_or_return!(self.client.chain.head());
-                if self.client.is_validator(&head.epoch_id, &head.last_block_hash, &signer)
-                    || self.client.is_validator(&head.next_epoch_id, &head.last_block_hash, &signer)
+                if self.client.is_validator(&head.epoch_id, &signer)
+                    || self.client.is_validator(&head.next_epoch_id, &signer)
                 {
                     for approval in approvals {
                         if let Err(e) = self.client.send_block_approval(

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -746,11 +746,9 @@ impl ClientActorInner {
             let mut endorsed_chunk_validators = HashMap::new();
             for (account_id, signature) in ordered_chunk_validators.iter().zip(signatures) {
                 let Some(signature) = signature else { continue };
-                let Ok((validator, _)) = self.client.epoch_manager.get_validator_by_account_id(
-                    &epoch_id,
-                    block.header().prev_hash(),
-                    account_id,
-                ) else {
+                let Ok(validator) =
+                    self.client.epoch_manager.get_validator_by_account_id(&epoch_id, account_id)
+                else {
                     continue;
                 };
                 if !ChunkEndorsement::validate_signature(

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -317,14 +317,7 @@ impl InfoHelper {
                 self.get_num_validators(client.epoch_manager.as_ref(), &head.epoch_id);
             let account_id = signer.as_ref().map(|x| x.validator_id());
             let is_validator = if let Some(account_id) = account_id {
-                match client.epoch_manager.get_validator_by_account_id(
-                    &head.epoch_id,
-                    &head.last_block_hash,
-                    account_id,
-                ) {
-                    Ok((_, is_slashed)) => !is_slashed,
-                    Err(_) => false,
-                }
+                client.epoch_manager.get_validator_by_account_id(&head.epoch_id, account_id).is_ok()
             } else {
                 false
             };

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -655,12 +655,9 @@ impl ViewClientActorInner {
         announce_account: &AnnounceAccount,
     ) -> Result<bool, Error> {
         let announce_hash = announce_account.hash();
-        let head = self.chain.head()?;
-
         self.epoch_manager
             .verify_validator_signature(
                 &announce_account.epoch_id,
-                &head.last_block_hash,
                 &announce_account.account_id,
                 announce_hash.as_ref(),
                 &announce_account.signature,

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -1213,18 +1213,6 @@ impl EpochManager {
             .ok_or_else(|| EpochError::NotAValidator(account_id.clone(), *epoch_id))
     }
 
-    /// Returns fisherman for given account id for given epoch.
-    pub fn get_fisherman_by_account_id(
-        &self,
-        epoch_id: &EpochId,
-        account_id: &AccountId,
-    ) -> Result<ValidatorStake, EpochError> {
-        let epoch_info = self.get_epoch_info(epoch_id)?;
-        epoch_info
-            .get_fisherman_by_account(account_id)
-            .ok_or_else(|| EpochError::NotAValidator(account_id.clone(), *epoch_id))
-    }
-
     pub fn get_epoch_id(&self, block_hash: &CryptoHash) -> Result<EpochId, EpochError> {
         Ok(*self.get_block_info(block_hash)?.epoch_id())
     }

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -3355,8 +3355,7 @@ fn test_verify_partial_witness_signature() {
     let epoch_id = epoch_manager.get_epoch_id(&h[1]).unwrap();
 
     // Verify if the test signer has same public key as the chunk validator.
-    let (validator, _) =
-        epoch_manager.get_validator_by_account_id(&epoch_id, &h[0], &account_id).unwrap();
+    let validator = epoch_manager.get_validator_by_account_id(&epoch_id, &account_id).unwrap();
     let chunk_producer: AccountId = "test1".parse().unwrap();
     let signer = Arc::new(create_test_signer(chunk_producer.as_str()));
     assert_eq!(signer.public_key(), validator.public_key().clone());

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -133,7 +133,6 @@ fn test_verify_block_double_sign_challenge() {
             env.clients[1].chain.epoch_manager.as_ref(),
             env.clients[1].chain.runtime_adapter.as_ref(),
             &epoch_id,
-            genesis.hash(),
             &valid_challenge
         )
         .unwrap()
@@ -151,7 +150,6 @@ fn test_verify_block_double_sign_challenge() {
         env.clients[1].chain.epoch_manager.as_ref(),
         env.clients[1].chain.runtime_adapter.as_ref(),
         &epoch_id,
-        genesis.hash(),
         &invalid_challenge,
     )
     .is_err());
@@ -167,7 +165,6 @@ fn test_verify_block_double_sign_challenge() {
         env.clients[1].chain.epoch_manager.as_ref(),
         env.clients[1].chain.runtime_adapter.as_ref(),
         &epoch_id,
-        genesis.hash(),
         &invalid_challenge,
     )
     .is_err());
@@ -330,7 +327,6 @@ fn challenge(
         env.clients[0].chain.epoch_manager.as_ref(),
         env.clients[0].chain.runtime_adapter.as_ref(),
         block.header().epoch_id(),
-        block.header().prev_hash(),
         &valid_challenge,
     )
 }
@@ -493,7 +489,6 @@ fn test_verify_chunk_invalid_state_challenge() {
             client.chain.epoch_manager.as_ref(),
             client.chain.runtime_adapter.as_ref(),
             block.header().epoch_id(),
-            block.header().prev_hash(),
             &challenge,
         )
         .unwrap_err(),


### PR DESCRIPTION
* `get_validator_by_account_id` no longer returns slashing info and `get_fisherman_by_account` is removed
* all functions for signature verification (except `verify_validator_signature`) are moved out of EpochManager as free functions
* bunch of slashing tests are disabled