### PR TITLE
nayduck: ignore slow_chunk.py

### DIFF
--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -179,7 +179,7 @@ pytest sanity/meta_tx.py --features nightly
 # pytest --timeout=120 sanity/resharding_error_handling.py --features nightly
 
 # Tests for slow chunks and extreme undercharging
-# TODO: this test is broken after an adjustment to the contracts on the workers.
+# TODO(#12847): this test is broken after an adjustment to the contracts on the workers.
 # This should be uncommented again after we find the issue and fix it.
 # pytest sanity/slow_chunk.py
 # pytest sanity/slow_chunk.py --features nightly

--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -179,8 +179,10 @@ pytest sanity/meta_tx.py --features nightly
 # pytest --timeout=120 sanity/resharding_error_handling.py --features nightly
 
 # Tests for slow chunks and extreme undercharging
-pytest sanity/slow_chunk.py
-pytest sanity/slow_chunk.py --features nightly
+# TODO: this test is broken after an adjustment to the contracts on the workers.
+# This should be uncommented again after we find the issue and fix it.
+# pytest sanity/slow_chunk.py
+# pytest sanity/slow_chunk.py --features nightly
 
 pytest sanity/large_witness.py --features nightly
 


### PR DESCRIPTION
This test is failing with insuficient prepaid gas errors, and it seems to have started failing after the contracts were updated on the nayduck workers: https://nayduck.nearone.org/#/test/414086. This should be investigated, but it shouldn't block PRs for now