### PR TITLE
refactor: simplify MakeSnapshotCallback

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3909,7 +3909,6 @@ impl Chain {
 
                 let make_snapshot_callback = &snapshot_callbacks.make_snapshot_callback;
                 make_snapshot_callback(
-                    *prev_prev_hash,
                     min_chunk_prev_height,
                     epoch_height,
                     shard_uids,

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3908,12 +3908,7 @@ impl Chain {
                 let shard_uids = shard_layout.shard_uids().enumerate().collect();
 
                 let make_snapshot_callback = &snapshot_callbacks.make_snapshot_callback;
-                make_snapshot_callback(
-                    min_chunk_prev_height,
-                    epoch_height,
-                    shard_uids,
-                    prev_block,
-                );
+                make_snapshot_callback(min_chunk_prev_height, epoch_height, shard_uids, prev_block);
             }
             SnapshotAction::DeleteSnapshot => {
                 let delete_snapshot_callback = &snapshot_callbacks.delete_snapshot_callback;

--- a/chain/chain/src/state_snapshot_actor.rs
+++ b/chain/chain/src/state_snapshot_actor.rs
@@ -206,7 +206,7 @@ pub struct StateSnapshotSenderForStateSnapshot {
 pub struct StateSnapshotSenderForClient(Sender<DeleteAndMaybeCreateSnapshotRequest>);
 
 type MakeSnapshotCallback = Arc<
-    dyn Fn(CryptoHash, BlockHeight, EpochHeight, Vec<(ShardIndex, ShardUId)>, Block) -> ()
+    dyn Fn(BlockHeight, EpochHeight, Vec<(ShardIndex, ShardUId)>, Block) -> ()
         + Send
         + Sync
         + 'static,
@@ -220,17 +220,17 @@ pub struct SnapshotCallbacks {
 }
 
 /// Sends a request to make a state snapshot.
-// TODO: remove the `prev_block_hash` argument. It's just block.header().prev_hash()
 pub fn get_make_snapshot_callback(
     sender: StateSnapshotSenderForClient,
     flat_storage_manager: FlatStorageManager,
 ) -> MakeSnapshotCallback {
     Arc::new(
-        move |prev_block_hash,
+        move |
               min_chunk_prev_height,
               epoch_height,
               shard_indexes_and_uids,
               block| {
+            let prev_block_hash = *block.header().prev_hash();
             tracing::info!(
             target: "state_snapshot",
             ?prev_block_hash,

--- a/chain/client/src/test_utils/test_env_builder.rs
+++ b/chain/client/src/test_utils/test_env_builder.rs
@@ -9,7 +9,7 @@ use near_async::time::Clock;
 use near_chain::state_snapshot_actor::SnapshotCallbacks;
 use near_chain::test_utils::{KeyValueRuntime, MockEpochManager, ValidatorSchedule};
 use near_chain::types::RuntimeAdapter;
-use near_chain::ChainGenesis;
+use near_chain::{Block, ChainGenesis};
 use near_chain_configs::GenesisConfig;
 use near_chunks::test_utils::MockClientAdapterForShardsManager;
 use near_epoch_manager::shard_tracker::{ShardTracker, TrackedConfig};
@@ -588,7 +588,8 @@ impl TestEnvBuilder {
                         None => TEST_SEED,
                     };
                     let tries = runtime.get_tries();
-                    let make_snapshot_callback = Arc::new(move |prev_block_hash, _min_chunk_prev_height, _epoch_height, shard_uids: Vec<(ShardIndex, ShardUId)>, block| {
+                    let make_snapshot_callback = Arc::new(move |_min_chunk_prev_height, _epoch_height, shard_uids: Vec<(ShardIndex, ShardUId)>, block: Block| {
+                        let prev_block_hash = *block.header().prev_hash();
                         tracing::info!(target: "state_snapshot", ?prev_block_hash, "make_snapshot_callback");
                         tries.delete_state_snapshot();
                         tries.create_state_snapshot(prev_block_hash, &shard_uids, &block).unwrap();


### PR DESCRIPTION
Remove one unnecessary parameter from the function type `MakeSnapshotCallback`.