### PR TITLE
refactor: move EpochManager functions as default impl for EpochManagerAdapter

### DIFF
--- a/chain/chain/src/approval_verification.rs
+++ b/chain/chain/src/approval_verification.rs
@@ -14,7 +14,7 @@ pub fn verify_approval_with_approvers_info(
     prev_block_height: BlockHeight,
     block_height: BlockHeight,
     approvals: &[Option<Box<near_crypto::Signature>>],
-    info: Vec<(ApprovalStake, bool)>,
+    info: Vec<ApprovalStake>,
 ) -> Result<bool, Error> {
     if approvals.len() > info.len() {
         return Ok(false);
@@ -29,9 +29,9 @@ pub fn verify_approval_with_approvers_info(
         block_height,
     );
 
-    for ((validator, is_slashed), may_be_signature) in info.into_iter().zip(approvals.iter()) {
+    for (validator, may_be_signature) in info.into_iter().zip(approvals.iter()) {
         if let Some(signature) = may_be_signature {
-            if is_slashed || !signature.verify(message_to_sign.as_ref(), &validator.public_key) {
+            if !signature.verify(message_to_sign.as_ref(), &validator.public_key) {
                 return Ok(false);
             }
         }
@@ -43,7 +43,7 @@ pub fn verify_approval_with_approvers_info(
 pub fn verify_approvals_and_threshold_orphan(
     can_approved_block_be_produced: &dyn Fn(
         &[Option<Box<Signature>>],
-        &[(Balance, Balance, bool)],
+        &[(Balance, Balance)],
     ) -> bool,
     prev_block_hash: &CryptoHash,
     prev_block_height: BlockHeight,
@@ -70,7 +70,7 @@ pub fn verify_approvals_and_threshold_orphan(
     }
     let stakes = block_approvers
         .iter()
-        .map(|stake| (stake.stake_this_epoch, stake.stake_next_epoch, false))
+        .map(|stake| (stake.stake_this_epoch, stake.stake_next_epoch))
         .collect::<Vec<_>>();
     if !can_approved_block_be_produced(approvals, &stakes) {
         Err(Error::NotEnoughApprovals)

--- a/chain/chain/src/lightclient.rs
+++ b/chain/chain/src/lightclient.rs
@@ -1,7 +1,7 @@
 use near_chain_primitives::Error;
 use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::block::BlockHeader;
-use near_primitives::hash::{hash, CryptoHash};
+use near_primitives::hash::hash;
 use near_primitives::types::EpochId;
 use near_primitives::views::validator_stake_view::ValidatorStakeView;
 use near_primitives::views::{BlockHeaderInnerLiteView, LightClientBlockView};
@@ -10,13 +10,12 @@ use crate::ChainStoreAccess;
 
 pub fn get_epoch_block_producers_view(
     epoch_id: &EpochId,
-    prev_hash: &CryptoHash,
     epoch_manager: &dyn EpochManagerAdapter,
 ) -> Result<Vec<ValidatorStakeView>, Error> {
     Ok(epoch_manager
-        .get_epoch_block_producers_ordered(epoch_id, prev_hash)?
+        .get_epoch_block_producers_ordered(epoch_id)?
         .iter()
-        .map(|x| x.0.clone().into())
+        .map(|x| x.clone().into())
         .collect::<Vec<_>>())
 }
 

--- a/chain/chain/src/tests/doomslug.rs
+++ b/chain/chain/src/tests/doomslug.rs
@@ -43,7 +43,6 @@ fn one_iter(
             stake_next_epoch: 1,
             public_key: SecretKey::from_seed(KeyType::ED25519, account_id).public_key(),
         })
-        .map(|stake| (stake, false))
         .collect::<Vec<_>>();
     let signers = account_ids
         .iter()

--- a/chain/chain/src/tests/garbage_collection.rs
+++ b/chain/chain/src/tests/garbage_collection.rs
@@ -55,7 +55,6 @@ fn do_fork(
         let block = if next_epoch_id == *prev_block.header().next_epoch_id() {
             TestBlockBuilder::new(Clock::real(), &prev_block, signer.clone()).build()
         } else {
-            let prev_hash = prev_block.hash();
             let epoch_id = *prev_block.header().next_epoch_id();
             if verbose {
                 println!(
@@ -64,13 +63,9 @@ fn do_fork(
                     prev_block.header().height() + 1
                 );
             }
-            let next_bp_hash = Chain::compute_bp_hash(
-                chain.epoch_manager.as_ref(),
-                next_epoch_id,
-                epoch_id,
-                &prev_hash,
-            )
-            .unwrap();
+            let next_bp_hash =
+                Chain::compute_bp_hash(chain.epoch_manager.as_ref(), next_epoch_id, epoch_id)
+                    .unwrap();
             TestBlockBuilder::new(Clock::real(), &prev_block, signer.clone())
                 .epoch_id(epoch_id)
                 .next_epoch_id(next_epoch_id)
@@ -740,10 +735,8 @@ fn add_block(
     let block = if next_epoch_id == *prev_block.header().next_epoch_id() {
         TestBlockBuilder::new(Clock::real(), &prev_block, signer).height(height).build()
     } else {
-        let prev_hash = prev_block.hash();
         let epoch_id = *prev_block.header().next_epoch_id();
-        let next_bp_hash =
-            Chain::compute_bp_hash(epoch_manager, next_epoch_id, epoch_id, &prev_hash).unwrap();
+        let next_bp_hash = Chain::compute_bp_hash(epoch_manager, next_epoch_id, epoch_id).unwrap();
         TestBlockBuilder::new(Clock::real(), &prev_block, signer)
             .height(height)
             .epoch_id(epoch_id)

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -113,10 +113,10 @@ impl ChunkTestFixture {
             .take_account_id();
         let signer = create_test_signer(mock_chunk_producer.as_str());
         let validators: Vec<_> = epoch_manager
-            .get_epoch_block_producers_ordered(&EpochId::default(), &CryptoHash::default())
+            .get_epoch_block_producers_ordered(&EpochId::default())
             .unwrap()
             .into_iter()
-            .map(|v| v.0.account_id().clone())
+            .map(|v| v.account_id().clone())
             .collect();
         let mock_shard_tracker = validators
             .iter()

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -781,12 +781,8 @@ impl Client {
             .epoch_manager
             .get_epoch_block_approvers_ordered(&prev_hash)?
             .into_iter()
-            .map(|(ApprovalStake { account_id, .. }, is_slashed)| {
-                if is_slashed {
-                    None
-                } else {
-                    approvals_map.remove(&account_id).map(|x| x.0.signature.into())
-                }
+            .map(|ApprovalStake { account_id, .. }| {
+                approvals_map.remove(&account_id).map(|x| x.0.signature.into())
             })
             .collect();
 
@@ -804,12 +800,7 @@ impl Client {
         let max_gas_price = self.chain.block_economics_config.max_gas_price(protocol_version);
 
         let next_bp_hash = if prev_epoch_id != epoch_id {
-            Chain::compute_bp_hash(
-                self.epoch_manager.as_ref(),
-                next_epoch_id,
-                epoch_id,
-                &prev_hash,
-            )?
+            Chain::compute_bp_hash(self.epoch_manager.as_ref(), next_epoch_id, epoch_id)?
         } else {
             prev_next_bp_hash
         };
@@ -2835,10 +2826,7 @@ impl Client {
                     .or_default()
                     .insert(cp.public_key().clone());
             }
-            for (bp, _) in self
-                .epoch_manager
-                .get_epoch_block_producers_ordered(epoch_id, &tip.last_block_hash)?
-            {
+            for bp in self.epoch_manager.get_epoch_block_producers_ordered(epoch_id)? {
                 account_keys
                     .entry(bp.account_id().clone())
                     .or_default()

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -703,12 +703,12 @@ impl Handler<Status> for ClientActorInner {
         let validators: Vec<ValidatorInfo> = self
             .client
             .epoch_manager
-            .get_epoch_block_producers_ordered(&head.epoch_id, &head.last_block_hash)
+            .get_epoch_block_producers_ordered(&head.epoch_id)
             .into_chain_error()?
             .into_iter()
-            .map(|(validator_stake, is_slashed)| ValidatorInfo {
+            .map(|validator_stake| ValidatorInfo {
                 account_id: validator_stake.take_account_id(),
-                is_slashed,
+                is_slashed: false,
             })
             .collect();
 

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -168,8 +168,8 @@ impl InfoHelper {
             // Don't set the metric in this case.
             client
                 .epoch_manager
-                .get_epoch_block_producers_ordered(&head.epoch_id, &head.last_block_hash)
-                .map_or(None, |bp| Some(bp.iter().any(|bp| bp.0.account_id() == &account_id)))
+                .get_epoch_block_producers_ordered(&head.epoch_id)
+                .map_or(None, |bp| Some(bp.iter().any(|bp| bp.account_id() == &account_id)))
         }) {
             metrics::IS_BLOCK_PRODUCER.set(if is_bp { 1 } else { 0 });
         }
@@ -979,7 +979,6 @@ mod tests {
     use near_epoch_manager::test_utils::*;
     use near_epoch_manager::EpochManager;
     use near_network::test_utils::peer_id_from_seed;
-    use near_primitives::hash::CryptoHash;
     use near_store::genesis::initialize_genesis_state;
 
     #[test]
@@ -1081,7 +1080,6 @@ mod tests {
             "for this test, make sure number of validators are more than block producer seats"
         );
 
-        let last_block_hash = CryptoHash::default();
         let epoch_id = EpochId::default();
         let epoch_length = 2;
         let num_shards = 2;
@@ -1101,10 +1099,7 @@ mod tests {
         // First check that we have different number of block and chunk producers.
         assert_eq!(
             num_block_producer_seats,
-            epoch_manager_adapter
-                .get_epoch_block_producers_ordered(&epoch_id, &last_block_hash)
-                .unwrap()
-                .len()
+            epoch_manager_adapter.get_epoch_block_producers_ordered(&epoch_id).unwrap().len()
         );
         assert_eq!(
             num_validators,

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -908,11 +908,7 @@ impl Handler<GetValidatorOrdered> for ViewClientActorInner {
             .with_label_values(&["GetValidatorOrdered"])
             .start_timer();
         Ok(self.maybe_block_id_to_block_header(msg.block_id).and_then(|header| {
-            get_epoch_block_producers_view(
-                header.epoch_id(),
-                header.prev_hash(),
-                self.epoch_manager.as_ref(),
-            )
+            get_epoch_block_producers_view(header.epoch_id(), self.epoch_manager.as_ref())
         })?)
     }
 }

--- a/chain/epoch-manager/src/test_utils.rs
+++ b/chain/epoch-manager/src/test_utils.rs
@@ -299,9 +299,8 @@ pub fn setup_epoch_manager_with_block_and_chunk_producers(
     )
     .unwrap();
     // Sanity check that the election results are indeed as expected.
-    let actual_block_producers = epoch_manager
-        .get_all_block_producers_ordered(&EpochId::default(), &CryptoHash::default())
-        .unwrap();
+    let actual_block_producers =
+        epoch_manager.get_all_block_producers_ordered(&EpochId::default()).unwrap();
     assert_eq!(actual_block_producers.len(), block_producers.len());
     let actual_chunk_producers =
         epoch_manager.get_all_chunk_producers(&EpochId::default()).unwrap();

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -250,7 +250,6 @@ impl GenesisBuilder {
                 self.epoch_manager.as_ref(),
                 EpochId::default(),
                 EpochId::default(),
-                &CryptoHash::default(),
             )?,
         );
 

--- a/integration-tests/src/tests/client/features/adversarial_behaviors.rs
+++ b/integration-tests/src/tests/client/features/adversarial_behaviors.rs
@@ -199,9 +199,8 @@ fn slow_test_non_adversarial_case() {
     let final_prev_block_hash = test.env.clients[0].chain.head().unwrap().prev_block_hash;
     let final_epoch_id =
         epoch_manager.get_epoch_id_from_prev_block(&final_prev_block_hash).unwrap();
-    let final_block_producers = epoch_manager
-        .get_epoch_block_producers_ordered(&final_epoch_id, &final_prev_block_hash)
-        .unwrap();
+    let final_block_producers =
+        epoch_manager.get_epoch_block_producers_ordered(&final_epoch_id).unwrap();
     // No producers should be kicked out.
     assert_eq!(final_block_producers.len(), 4);
     let final_chunk_producers = epoch_manager.get_epoch_chunk_producers(&final_epoch_id).unwrap();
@@ -355,9 +354,8 @@ fn test_banning_chunk_producer_when_seeing_invalid_chunk_base(
     let final_prev_block_hash = test.env.clients[0].chain.head().unwrap().prev_block_hash;
     let final_epoch_id =
         epoch_manager.get_epoch_id_from_prev_block(&final_prev_block_hash).unwrap();
-    let final_block_producers = epoch_manager
-        .get_epoch_block_producers_ordered(&final_epoch_id, &final_prev_block_hash)
-        .unwrap();
+    let final_block_producers =
+        epoch_manager.get_epoch_block_producers_ordered(&final_epoch_id).unwrap();
     assert!(final_block_producers.len() >= 3); // 3 validators if the bad validator was a block producer
     let final_chunk_producers = epoch_manager.get_epoch_chunk_producers(&final_epoch_id).unwrap();
     assert_eq!(final_chunk_producers.len(), 7);

--- a/integration-tests/src/tests/client/features/in_memory_tries.rs
+++ b/integration-tests/src/tests/client/features/in_memory_tries.rs
@@ -82,10 +82,7 @@ fn slow_test_in_memory_trie_node_consistency() {
     assert_eq!(
         env.clients[0]
             .epoch_manager
-            .get_epoch_block_producers_ordered(
-                &EpochId::default(),
-                &env.clients[0].chain.head().unwrap().last_block_hash
-            )
+            .get_epoch_block_producers_ordered(&EpochId::default())
             .unwrap()
             .len(),
         2
@@ -469,10 +466,7 @@ fn test_in_memory_trie_consistency_with_state_sync_base_case(track_all_shards: b
     assert_eq!(
         env.clients[0]
             .epoch_manager
-            .get_epoch_block_producers_ordered(
-                &EpochId::default(),
-                &env.clients[0].chain.head().unwrap().last_block_hash
-            )
+            .get_epoch_block_producers_ordered(&EpochId::default())
             .unwrap()
             .len(),
         NUM_VALIDATORS

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -615,8 +615,7 @@ pub(crate) fn print_chain(
                             println!(
                                 "Epoch {} Validators {:?}",
                                 format_hash(epoch_id.0, show_full_hashes),
-                                epoch_manager
-                                    .get_epoch_block_producers_ordered(&epoch_id, header.hash())
+                                epoch_manager.get_epoch_block_producers_ordered(&epoch_id)
                             );
                         }
                         Err(err) => {

--- a/tools/state-viewer/src/state_dump.rs
+++ b/tools/state-viewer/src/state_dump.rs
@@ -41,18 +41,13 @@ pub fn state_dump(
         last_block_header.hash()
     );
     let genesis_height = last_block_header.height() + 1;
-    let block_producers = epoch_manager
-        .get_epoch_block_producers_ordered(last_block_header.epoch_id(), last_block_header.hash())
-        .unwrap();
+    let block_producers =
+        epoch_manager.get_epoch_block_producers_ordered(last_block_header.epoch_id()).unwrap();
     let validators = block_producers
         .into_iter()
-        .filter_map(|(info, is_slashed)| {
-            if !is_slashed {
-                let (account_id, public_key, stake) = info.destructure();
-                Some((account_id, (public_key, stake)))
-            } else {
-                None
-            }
+        .map(|info| {
+            let (account_id, public_key, stake) = info.destructure();
+            (account_id, (public_key, stake))
         })
         .collect::<HashMap<_, _>>();
 
@@ -479,14 +474,11 @@ mod test {
         safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1);
 
         let head = env.clients[0].chain.head().unwrap();
-        let last_block_hash = head.last_block_hash;
         let cur_epoch_id = head.epoch_id;
-        let block_producers = env.clients[0]
-            .epoch_manager
-            .get_epoch_block_producers_ordered(&cur_epoch_id, &last_block_hash)
-            .unwrap();
+        let block_producers =
+            env.clients[0].epoch_manager.get_epoch_block_producers_ordered(&cur_epoch_id).unwrap();
         assert_eq!(
-            block_producers.into_iter().map(|(r, _)| r.take_account_id()).collect::<HashSet<_>>(),
+            block_producers.into_iter().map(|r| r.take_account_id()).collect::<HashSet<_>>(),
             HashSet::from_iter(vec!["test0".parse().unwrap(), "test1".parse().unwrap()])
         );
         let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
@@ -555,14 +547,11 @@ mod test {
         safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1);
 
         let head = env.clients[0].chain.head().unwrap();
-        let last_block_hash = head.last_block_hash;
         let cur_epoch_id = head.epoch_id;
-        let block_producers = env.clients[0]
-            .epoch_manager
-            .get_epoch_block_producers_ordered(&cur_epoch_id, &last_block_hash)
-            .unwrap();
+        let block_producers =
+            env.clients[0].epoch_manager.get_epoch_block_producers_ordered(&cur_epoch_id).unwrap();
         assert_eq!(
-            block_producers.into_iter().map(|(r, _)| r.take_account_id()).collect::<HashSet<_>>(),
+            block_producers.into_iter().map(|r| r.take_account_id()).collect::<HashSet<_>>(),
             HashSet::from_iter(vec!["test0".parse().unwrap(), "test1".parse().unwrap()]),
         );
         let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
@@ -618,14 +607,11 @@ mod test {
         safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1);
 
         let head = env.clients[0].chain.head().unwrap();
-        let last_block_hash = head.last_block_hash;
         let cur_epoch_id = head.epoch_id;
-        let block_producers = env.clients[0]
-            .epoch_manager
-            .get_epoch_block_producers_ordered(&cur_epoch_id, &last_block_hash)
-            .unwrap();
+        let block_producers =
+            env.clients[0].epoch_manager.get_epoch_block_producers_ordered(&cur_epoch_id).unwrap();
         assert_eq!(
-            block_producers.into_iter().map(|(r, _)| r.take_account_id()).collect::<HashSet<_>>(),
+            block_producers.into_iter().map(|r| r.take_account_id()).collect::<HashSet<_>>(),
             HashSet::from_iter(vec!["test0".parse().unwrap(), "test1".parse().unwrap()])
         );
         let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
@@ -899,14 +885,11 @@ mod test {
         )
         .unwrap();
         let head = env.clients[0].chain.head().unwrap();
-        let last_block_hash = head.last_block_hash;
         let cur_epoch_id = head.epoch_id;
-        let block_producers = env.clients[0]
-            .epoch_manager
-            .get_epoch_block_producers_ordered(&cur_epoch_id, &last_block_hash)
-            .unwrap();
+        let block_producers =
+            env.clients[0].epoch_manager.get_epoch_block_producers_ordered(&cur_epoch_id).unwrap();
         assert_eq!(
-            block_producers.into_iter().map(|(r, _)| r.take_account_id()).collect::<HashSet<_>>(),
+            block_producers.into_iter().map(|r| r.take_account_id()).collect::<HashSet<_>>(),
             HashSet::from_iter(vec!["test0".parse().unwrap(), "test1".parse().unwrap()])
         );
         let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap();
@@ -952,14 +935,11 @@ mod test {
         safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1);
 
         let head = env.clients[0].chain.head().unwrap();
-        let last_block_hash = head.last_block_hash;
         let cur_epoch_id = head.epoch_id;
-        let block_producers = env.clients[0]
-            .epoch_manager
-            .get_epoch_block_producers_ordered(&cur_epoch_id, &last_block_hash)
-            .unwrap();
+        let block_producers =
+            env.clients[0].epoch_manager.get_epoch_block_producers_ordered(&cur_epoch_id).unwrap();
         assert_eq!(
-            block_producers.into_iter().map(|(r, _)| r.take_account_id()).collect::<HashSet<_>>(),
+            block_producers.into_iter().map(|r| r.take_account_id()).collect::<HashSet<_>>(),
             HashSet::from_iter(vec!["test0".parse().unwrap(), "test1".parse().unwrap()]),
         );
 


### PR DESCRIPTION
This PR moves implementation for a bunch of functions from `EpochManager` to be the default implementation in `EpochManagerAdapter` trait.
Also `is_slashed` is removed from the API since we do not properly support slashing.