### PR TITLE
refactor: move fns as default implementation in EpochManagerAdapter trait

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -137,9 +137,8 @@ impl NightshadeRuntime {
         shard_id: ShardId,
         prev_hash: &CryptoHash,
     ) -> Result<ShardUId, Error> {
-        let epoch_manager = self.epoch_manager.read();
-        let epoch_id = epoch_manager.get_epoch_id_from_prev_block(prev_hash)?;
-        let shard_version = epoch_manager.get_shard_layout(&epoch_id)?.version();
+        let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(prev_hash)?;
+        let shard_version = self.epoch_manager.get_shard_layout(&epoch_id)?.version();
         Ok(ShardUId::new(shard_version, shard_id))
     }
 

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -1227,8 +1227,7 @@ impl RuntimeAdapter for NightshadeRuntime {
     }
 
     fn will_shard_layout_change_next_epoch(&self, parent_hash: &CryptoHash) -> Result<bool, Error> {
-        let epoch_manager = self.epoch_manager.read();
-        Ok(epoch_manager.will_shard_layout_change(parent_hash)?)
+        Ok(self.epoch_manager.will_shard_layout_change(parent_hash)?)
     }
 
     fn compiled_contract_cache(&self) -> &dyn ContractRuntimeCache {

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -548,6 +548,13 @@ impl EpochManagerAdapter for MockEpochManager {
         Ok(0)
     }
 
+    fn get_epoch_start_from_epoch_id(
+        &self,
+        _epoch_id: &EpochId,
+    ) -> Result<BlockHeight, EpochError> {
+        Ok(0)
+    }
+
     fn get_next_epoch_id(&self, block_hash: &CryptoHash) -> Result<EpochId, EpochError> {
         let (_, _, next_epoch_id) = self.get_epoch_and_valset(*block_hash)?;
         Ok(next_epoch_id)

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -17,7 +17,7 @@ use near_primitives::stateless_validation::validator_assignment::ChunkValidatorA
 use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
-    AccountId, ApprovalStake, Balance, BlockChunkValidatorStats, BlockHeight, ChunkStats, EpochId,
+    AccountId, Balance, BlockChunkValidatorStats, BlockHeight, ChunkStats, EpochId,
     EpochInfoProvider, NumSeats, ShardId, ValidatorId, ValidatorInfoIdentifier,
     ValidatorKickoutReason, ValidatorStats,
 };
@@ -372,56 +372,57 @@ impl EpochManager {
     /// Note that this function doesn't copy info stored in EpochInfoAggregator, so `block_hash` must be
     /// the last block in an epoch in order for the epoch manager to work properly after this function
     /// is called
-    pub fn copy_epoch_info_as_of_block(
-        &mut self,
-        block_hash: &CryptoHash,
-        source_epoch_manager: &EpochManager,
-    ) -> Result<(), EpochError> {
-        let block_info = source_epoch_manager.get_block_info(block_hash)?;
-        let prev_hash = block_info.prev_hash();
-        let epoch_id = &source_epoch_manager.get_epoch_id_from_prev_block(prev_hash)?;
-        let next_epoch_id = &source_epoch_manager.get_next_epoch_id_from_prev_block(prev_hash)?;
-        let mut store_update = self.store.store_update();
-        self.save_epoch_info(
-            &mut store_update,
-            epoch_id,
-            source_epoch_manager.get_epoch_info(epoch_id)?,
-        )?;
-        // save next epoch info too
-        self.save_epoch_info(
-            &mut store_update,
-            next_epoch_id,
-            source_epoch_manager.get_epoch_info(next_epoch_id)?,
-        )?;
-        // save next next epoch info if the block is the last block
-        if source_epoch_manager.is_next_block_epoch_start(block_hash)? {
-            let next_next_epoch_id =
-                source_epoch_manager.get_next_epoch_id_from_prev_block(block_hash)?;
-            self.save_epoch_info(
-                &mut store_update,
-                &next_next_epoch_id,
-                source_epoch_manager.get_epoch_info(&next_next_epoch_id)?,
-            )?;
-        }
+    // pub fn copy_epoch_info_as_of_block(
+    //     &mut self,
+    //     block_hash: &CryptoHash,
+    //     source_epoch_manager: &EpochManager,
+    // ) -> Result<(), EpochError> {
+    //     let source_epoch_manager = source_epoch_manager.into_handle();
+    //     let block_info = source_epoch_manager.get_block_info(block_hash)?;
+    //     let prev_hash = block_info.prev_hash();
+    //     let epoch_id = &source_epoch_manager.get_epoch_id_from_prev_block(prev_hash)?;
+    //     let next_epoch_id = &source_epoch_manager.get_next_epoch_id_from_prev_block(prev_hash)?;
+    //     let mut store_update = self.store.store_update();
+    //     self.save_epoch_info(
+    //         &mut store_update,
+    //         epoch_id,
+    //         source_epoch_manager.get_epoch_info(epoch_id)?,
+    //     )?;
+    //     // save next epoch info too
+    //     self.save_epoch_info(
+    //         &mut store_update,
+    //         next_epoch_id,
+    //         source_epoch_manager.get_epoch_info(next_epoch_id)?,
+    //     )?;
+    //     // save next next epoch info if the block is the last block
+    //     if source_epoch_manager.is_next_block_epoch_start(block_hash)? {
+    //         let next_next_epoch_id =
+    //             source_epoch_manager.get_next_epoch_id_from_prev_block(block_hash)?;
+    //         self.save_epoch_info(
+    //             &mut store_update,
+    //             &next_next_epoch_id,
+    //             source_epoch_manager.get_epoch_info(&next_next_epoch_id)?,
+    //         )?;
+    //     }
 
-        // save block info for the first block in the epoch
-        let epoch_first_block = block_info.epoch_first_block();
-        self.save_block_info(
-            &mut store_update,
-            source_epoch_manager.get_block_info(epoch_first_block)?,
-        )?;
+    //     // save block info for the first block in the epoch
+    //     let epoch_first_block = block_info.epoch_first_block();
+    //     self.save_block_info(
+    //         &mut store_update,
+    //         source_epoch_manager.get_block_info(epoch_first_block)?,
+    //     )?;
 
-        self.save_block_info(&mut store_update, block_info)?;
+    //     self.save_block_info(&mut store_update, block_info)?;
 
-        self.save_epoch_start(
-            &mut store_update,
-            epoch_id,
-            source_epoch_manager.get_epoch_start_from_epoch_id(epoch_id)?,
-        )?;
+    //     self.save_epoch_start(
+    //         &mut store_update,
+    //         epoch_id,
+    //         source_epoch_manager.get_epoch_start_from_epoch_id(epoch_id)?,
+    //     )?;
 
-        store_update.commit()?;
-        Ok(())
-    }
+    //     store_update.commit()?;
+    //     Ok(())
+    // }
 
     pub fn init_after_epoch_sync(
         &mut self,
@@ -1141,48 +1142,48 @@ impl EpochManager {
         })
     }
 
-    pub fn get_all_block_approvers_ordered(
-        &self,
-        parent_hash: &CryptoHash,
-    ) -> Result<Vec<(ApprovalStake, bool)>, EpochError> {
-        let current_epoch_id = self.get_epoch_id_from_prev_block(parent_hash)?;
-        let next_epoch_id = self.get_next_epoch_id_from_prev_block(parent_hash)?;
+    // pub fn get_all_block_approvers_ordered(
+    //     &self,
+    //     parent_hash: &CryptoHash,
+    // ) -> Result<Vec<(ApprovalStake, bool)>, EpochError> {
+    //     let current_epoch_id = self.get_epoch_id_from_prev_block(parent_hash)?;
+    //     let next_epoch_id = self.get_next_epoch_id_from_prev_block(parent_hash)?;
 
-        let mut settlement =
-            self.get_all_block_producers_settlement(&current_epoch_id, parent_hash)?.to_vec();
+    //     let mut settlement =
+    //         self.get_all_block_producers_settlement(&current_epoch_id, parent_hash)?.to_vec();
 
-        let settlement_epoch_boundary = settlement.len();
+    //     let settlement_epoch_boundary = settlement.len();
 
-        let block_info = self.get_block_info(parent_hash)?;
-        if self.next_block_need_approvals_from_next_epoch(&block_info)? {
-            settlement.extend(
-                self.get_all_block_producers_settlement(&next_epoch_id, parent_hash)?
-                    .iter()
-                    .cloned(),
-            );
-        }
+    //     let block_info = self.get_block_info(parent_hash)?;
+    //     if self.next_block_need_approvals_from_next_epoch(&block_info)? {
+    //         settlement.extend(
+    //             self.get_all_block_producers_settlement(&next_epoch_id, parent_hash)?
+    //                 .iter()
+    //                 .cloned(),
+    //         );
+    //     }
 
-        let mut result = vec![];
-        let mut validators: HashMap<AccountId, usize> = HashMap::default();
-        for (ord, (validator_stake, is_slashed)) in settlement.into_iter().enumerate() {
-            let account_id = validator_stake.account_id();
-            match validators.get(account_id) {
-                None => {
-                    validators.insert(account_id.clone(), result.len());
-                    result.push((
-                        validator_stake.get_approval_stake(ord >= settlement_epoch_boundary),
-                        is_slashed,
-                    ));
-                }
-                Some(old_ord) => {
-                    if ord >= settlement_epoch_boundary {
-                        result[*old_ord].0.stake_next_epoch = validator_stake.stake();
-                    };
-                }
-            };
-        }
-        Ok(result)
-    }
+    //     let mut result = vec![];
+    //     let mut validators: HashMap<AccountId, usize> = HashMap::default();
+    //     for (ord, (validator_stake, is_slashed)) in settlement.into_iter().enumerate() {
+    //         let account_id = validator_stake.account_id();
+    //         match validators.get(account_id) {
+    //             None => {
+    //                 validators.insert(account_id.clone(), result.len());
+    //                 result.push((
+    //                     validator_stake.get_approval_stake(ord >= settlement_epoch_boundary),
+    //                     is_slashed,
+    //                 ));
+    //             }
+    //             Some(old_ord) => {
+    //                 if ord >= settlement_epoch_boundary {
+    //                     result[*old_ord].0.stake_next_epoch = validator_stake.stake();
+    //                 };
+    //             }
+    //         };
+    //     }
+    //     Ok(result)
+    // }
 
     /// For given epoch_id, height and shard_id returns validator that is chunk producer.
     pub fn get_chunk_producer_info(
@@ -1308,31 +1309,16 @@ impl EpochManager {
         self.is_next_block_in_next_epoch(&block_info)
     }
 
-    /// Relies on the fact that last block hash of an epoch is an EpochId of next next epoch.
-    /// If this block is the last one in some epoch, and we fully processed it, there will be `EpochInfo` record with `hash` key.
-    fn is_last_block_in_finished_epoch(&self, hash: &CryptoHash) -> Result<bool, EpochError> {
-        match self.get_epoch_info(&EpochId(*hash)) {
-            Ok(_) => Ok(true),
-            Err(EpochError::IOErr(msg)) => Err(EpochError::IOErr(msg)),
-            Err(EpochError::EpochOutOfBounds(_)) => Ok(false),
-            Err(EpochError::MissingBlock(_)) => Ok(false),
-            Err(err) => {
-                warn!(target: "epoch_manager", ?err, "Unexpected error in is_last_block_in_finished_epoch");
-                Ok(false)
-            }
-        }
-    }
-
-    pub fn get_epoch_id_from_prev_block(
-        &self,
-        parent_hash: &CryptoHash,
-    ) -> Result<EpochId, EpochError> {
-        if self.is_next_block_epoch_start(parent_hash)? {
-            self.get_next_epoch_id(parent_hash)
-        } else {
-            self.get_epoch_id(parent_hash)
-        }
-    }
+    // pub fn get_epoch_id_from_prev_block(
+    //     &self,
+    //     parent_hash: &CryptoHash,
+    // ) -> Result<EpochId, EpochError> {
+    //     if self.is_next_block_epoch_start(parent_hash)? {
+    //         self.get_next_epoch_id(parent_hash)
+    //     } else {
+    //         self.get_epoch_id(parent_hash)
+    //     }
+    // }
 
     pub fn get_next_epoch_id_from_prev_block(
         &self,

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -1273,35 +1273,35 @@ impl EpochManager {
     // `shard_id` always refers to a shard in the current epoch that the next block from `parent_hash` belongs
     // If shard layout will change next epoch, returns true if it cares about any shard
     // that `shard_id` will split to
-    pub fn cares_about_shard_next_epoch_from_prev_block(
-        &self,
-        parent_hash: &CryptoHash,
-        account_id: &AccountId,
-        shard_id: ShardId,
-    ) -> Result<bool, EpochError> {
-        let next_epoch_id = self.get_next_epoch_id_from_prev_block(parent_hash)?;
-        if self.will_shard_layout_change(parent_hash)? {
-            let shard_layout = self.get_shard_layout(&next_epoch_id)?;
-            // The expect below may be triggered when the protocol version
-            // changes by multiple versions at once and multiple shard layout
-            // changes are captured. In this case the shards from the original
-            // shard layout are not valid parents in the final shard layout.
-            //
-            // This typically occurs in tests that are pegged to start at a
-            // certain protocol version and then upgrade to stable.
-            let split_shards = shard_layout
-                .get_children_shards_ids(shard_id)
-                .unwrap_or_else(|| panic!("all shard layouts expect the first one must have a split map, shard_id={shard_id}, shard_layout={shard_layout:?}"));
-            for next_shard_id in split_shards {
-                if self.cares_about_shard_in_epoch(&next_epoch_id, account_id, next_shard_id)? {
-                    return Ok(true);
-                }
-            }
-            Ok(false)
-        } else {
-            self.cares_about_shard_in_epoch(&next_epoch_id, account_id, shard_id)
-        }
-    }
+    // pub fn cares_about_shard_next_epoch_from_prev_block(
+    //     &self,
+    //     parent_hash: &CryptoHash,
+    //     account_id: &AccountId,
+    //     shard_id: ShardId,
+    // ) -> Result<bool, EpochError> {
+    //     let next_epoch_id = self.get_next_epoch_id_from_prev_block(parent_hash)?;
+    //     if self.will_shard_layout_change(parent_hash)? {
+    //         let shard_layout = self.get_shard_layout(&next_epoch_id)?;
+    //         // The expect below may be triggered when the protocol version
+    //         // changes by multiple versions at once and multiple shard layout
+    //         // changes are captured. In this case the shards from the original
+    //         // shard layout are not valid parents in the final shard layout.
+    //         //
+    //         // This typically occurs in tests that are pegged to start at a
+    //         // certain protocol version and then upgrade to stable.
+    //         let split_shards = shard_layout
+    //             .get_children_shards_ids(shard_id)
+    //             .unwrap_or_else(|| panic!("all shard layouts expect the first one must have a split map, shard_id={shard_id}, shard_layout={shard_layout:?}"));
+    //         for next_shard_id in split_shards {
+    //             if self.cares_about_shard_in_epoch(&next_epoch_id, account_id, next_shard_id)? {
+    //                 return Ok(true);
+    //             }
+    //         }
+    //         Ok(false)
+    //     } else {
+    //         self.cares_about_shard_in_epoch(&next_epoch_id, account_id, shard_id)
+    //     }
+    // }
 
     /// Returns true if next block after given block hash is in the new epoch.
     pub fn is_next_block_epoch_start(&self, parent_hash: &CryptoHash) -> Result<bool, EpochError> {
@@ -1827,13 +1827,13 @@ impl EpochManager {
         Ok(shard_layout)
     }
 
-    pub fn will_shard_layout_change(&self, parent_hash: &CryptoHash) -> Result<bool, EpochError> {
-        let epoch_id = self.get_epoch_id_from_prev_block(parent_hash)?;
-        let next_epoch_id = self.get_next_epoch_id_from_prev_block(parent_hash)?;
-        let shard_layout = self.get_shard_layout(&epoch_id)?;
-        let next_shard_layout = self.get_shard_layout(&next_epoch_id)?;
-        Ok(shard_layout != next_shard_layout)
-    }
+    // pub fn will_shard_layout_change(&self, parent_hash: &CryptoHash) -> Result<bool, EpochError> {
+    //     let epoch_id = self.get_epoch_id_from_prev_block(parent_hash)?;
+    //     let next_epoch_id = self.get_next_epoch_id_from_prev_block(parent_hash)?;
+    //     let shard_layout = self.get_shard_layout(&epoch_id)?;
+    //     let next_shard_layout = self.get_shard_layout(&next_epoch_id)?;
+    //     Ok(shard_layout != next_shard_layout)
+    // }
 
     pub fn get_epoch_info(&self, epoch_id: &EpochId) -> Result<Arc<EpochInfo>, EpochError> {
         self.epochs_info.get_or_try_put(*epoch_id, |epoch_id| {

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -366,64 +366,6 @@ impl EpochManager {
         EpochManagerHandle { inner }
     }
 
-    /// Only used in mock node
-    /// Copy the necessary epoch info related to `block_hash` from `source_epoch_manager` to
-    /// the current epoch manager.
-    /// Note that this function doesn't copy info stored in EpochInfoAggregator, so `block_hash` must be
-    /// the last block in an epoch in order for the epoch manager to work properly after this function
-    /// is called
-    // pub fn copy_epoch_info_as_of_block(
-    //     &mut self,
-    //     block_hash: &CryptoHash,
-    //     source_epoch_manager: &EpochManager,
-    // ) -> Result<(), EpochError> {
-    //     let source_epoch_manager = source_epoch_manager.into_handle();
-    //     let block_info = source_epoch_manager.get_block_info(block_hash)?;
-    //     let prev_hash = block_info.prev_hash();
-    //     let epoch_id = &source_epoch_manager.get_epoch_id_from_prev_block(prev_hash)?;
-    //     let next_epoch_id = &source_epoch_manager.get_next_epoch_id_from_prev_block(prev_hash)?;
-    //     let mut store_update = self.store.store_update();
-    //     self.save_epoch_info(
-    //         &mut store_update,
-    //         epoch_id,
-    //         source_epoch_manager.get_epoch_info(epoch_id)?,
-    //     )?;
-    //     // save next epoch info too
-    //     self.save_epoch_info(
-    //         &mut store_update,
-    //         next_epoch_id,
-    //         source_epoch_manager.get_epoch_info(next_epoch_id)?,
-    //     )?;
-    //     // save next next epoch info if the block is the last block
-    //     if source_epoch_manager.is_next_block_epoch_start(block_hash)? {
-    //         let next_next_epoch_id =
-    //             source_epoch_manager.get_next_epoch_id_from_prev_block(block_hash)?;
-    //         self.save_epoch_info(
-    //             &mut store_update,
-    //             &next_next_epoch_id,
-    //             source_epoch_manager.get_epoch_info(&next_next_epoch_id)?,
-    //         )?;
-    //     }
-
-    //     // save block info for the first block in the epoch
-    //     let epoch_first_block = block_info.epoch_first_block();
-    //     self.save_block_info(
-    //         &mut store_update,
-    //         source_epoch_manager.get_block_info(epoch_first_block)?,
-    //     )?;
-
-    //     self.save_block_info(&mut store_update, block_info)?;
-
-    //     self.save_epoch_start(
-    //         &mut store_update,
-    //         epoch_id,
-    //         source_epoch_manager.get_epoch_start_from_epoch_id(epoch_id)?,
-    //     )?;
-
-    //     store_update.commit()?;
-    //     Ok(())
-    // }
-
     pub fn init_after_epoch_sync(
         &mut self,
         store_update: &mut StoreUpdate,
@@ -1237,88 +1179,11 @@ impl EpochManager {
         self.get_epoch_info(&epoch_id)
     }
 
-    pub fn cares_about_shard_in_epoch(
-        &self,
-        epoch_id: &EpochId,
-        account_id: &AccountId,
-        shard_id: ShardId,
-    ) -> Result<bool, EpochError> {
-        let epoch_info = self.get_epoch_info(epoch_id)?;
-
-        let shard_layout = self.get_shard_layout(epoch_id)?;
-        let shard_index = shard_layout.get_shard_index(shard_id)?;
-
-        let chunk_producers_settlement = epoch_info.chunk_producers_settlement();
-        let chunk_producers = chunk_producers_settlement
-            .get(shard_index)
-            .ok_or_else(|| EpochError::ShardingError(format!("invalid shard id {shard_id}")))?;
-        for validator_id in chunk_producers.iter() {
-            if epoch_info.validator_account_id(*validator_id) == account_id {
-                return Ok(true);
-            }
-        }
-        Ok(false)
-    }
-
-    pub fn cares_about_shard_from_prev_block(
-        &self,
-        parent_hash: &CryptoHash,
-        account_id: &AccountId,
-        shard_id: ShardId,
-    ) -> Result<bool, EpochError> {
-        let epoch_id = self.get_epoch_id_from_prev_block(parent_hash)?;
-        self.cares_about_shard_in_epoch(&epoch_id, account_id, shard_id)
-    }
-
-    // `shard_id` always refers to a shard in the current epoch that the next block from `parent_hash` belongs
-    // If shard layout will change next epoch, returns true if it cares about any shard
-    // that `shard_id` will split to
-    // pub fn cares_about_shard_next_epoch_from_prev_block(
-    //     &self,
-    //     parent_hash: &CryptoHash,
-    //     account_id: &AccountId,
-    //     shard_id: ShardId,
-    // ) -> Result<bool, EpochError> {
-    //     let next_epoch_id = self.get_next_epoch_id_from_prev_block(parent_hash)?;
-    //     if self.will_shard_layout_change(parent_hash)? {
-    //         let shard_layout = self.get_shard_layout(&next_epoch_id)?;
-    //         // The expect below may be triggered when the protocol version
-    //         // changes by multiple versions at once and multiple shard layout
-    //         // changes are captured. In this case the shards from the original
-    //         // shard layout are not valid parents in the final shard layout.
-    //         //
-    //         // This typically occurs in tests that are pegged to start at a
-    //         // certain protocol version and then upgrade to stable.
-    //         let split_shards = shard_layout
-    //             .get_children_shards_ids(shard_id)
-    //             .unwrap_or_else(|| panic!("all shard layouts expect the first one must have a split map, shard_id={shard_id}, shard_layout={shard_layout:?}"));
-    //         for next_shard_id in split_shards {
-    //             if self.cares_about_shard_in_epoch(&next_epoch_id, account_id, next_shard_id)? {
-    //                 return Ok(true);
-    //             }
-    //         }
-    //         Ok(false)
-    //     } else {
-    //         self.cares_about_shard_in_epoch(&next_epoch_id, account_id, shard_id)
-    //     }
-    // }
-
     /// Returns true if next block after given block hash is in the new epoch.
     pub fn is_next_block_epoch_start(&self, parent_hash: &CryptoHash) -> Result<bool, EpochError> {
         let block_info = self.get_block_info(parent_hash)?;
         self.is_next_block_in_next_epoch(&block_info)
     }
-
-    // pub fn get_epoch_id_from_prev_block(
-    //     &self,
-    //     parent_hash: &CryptoHash,
-    // ) -> Result<EpochId, EpochError> {
-    //     if self.is_next_block_epoch_start(parent_hash)? {
-    //         self.get_next_epoch_id(parent_hash)
-    //     } else {
-    //         self.get_epoch_id(parent_hash)
-    //     }
-    // }
 
     pub fn get_next_epoch_id_from_prev_block(
         &self,

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -1084,49 +1084,6 @@ impl EpochManager {
         })
     }
 
-    // pub fn get_all_block_approvers_ordered(
-    //     &self,
-    //     parent_hash: &CryptoHash,
-    // ) -> Result<Vec<(ApprovalStake, bool)>, EpochError> {
-    //     let current_epoch_id = self.get_epoch_id_from_prev_block(parent_hash)?;
-    //     let next_epoch_id = self.get_next_epoch_id_from_prev_block(parent_hash)?;
-
-    //     let mut settlement =
-    //         self.get_all_block_producers_settlement(&current_epoch_id, parent_hash)?.to_vec();
-
-    //     let settlement_epoch_boundary = settlement.len();
-
-    //     let block_info = self.get_block_info(parent_hash)?;
-    //     if self.next_block_need_approvals_from_next_epoch(&block_info)? {
-    //         settlement.extend(
-    //             self.get_all_block_producers_settlement(&next_epoch_id, parent_hash)?
-    //                 .iter()
-    //                 .cloned(),
-    //         );
-    //     }
-
-    //     let mut result = vec![];
-    //     let mut validators: HashMap<AccountId, usize> = HashMap::default();
-    //     for (ord, (validator_stake, is_slashed)) in settlement.into_iter().enumerate() {
-    //         let account_id = validator_stake.account_id();
-    //         match validators.get(account_id) {
-    //             None => {
-    //                 validators.insert(account_id.clone(), result.len());
-    //                 result.push((
-    //                     validator_stake.get_approval_stake(ord >= settlement_epoch_boundary),
-    //                     is_slashed,
-    //                 ));
-    //             }
-    //             Some(old_ord) => {
-    //                 if ord >= settlement_epoch_boundary {
-    //                     result[*old_ord].0.stake_next_epoch = validator_stake.stake();
-    //                 };
-    //             }
-    //         };
-    //     }
-    //     Ok(result)
-    // }
-
     /// For given epoch_id, height and shard_id returns validator that is chunk producer.
     pub fn get_chunk_producer_info(
         &self,
@@ -1691,14 +1648,6 @@ impl EpochManager {
         let shard_layout = self.config.for_protocol_version(protocol_version).shard_layout;
         Ok(shard_layout)
     }
-
-    // pub fn will_shard_layout_change(&self, parent_hash: &CryptoHash) -> Result<bool, EpochError> {
-    //     let epoch_id = self.get_epoch_id_from_prev_block(parent_hash)?;
-    //     let next_epoch_id = self.get_next_epoch_id_from_prev_block(parent_hash)?;
-    //     let shard_layout = self.get_shard_layout(&epoch_id)?;
-    //     let next_shard_layout = self.get_shard_layout(&next_epoch_id)?;
-    //     Ok(shard_layout != next_shard_layout)
-    // }
 
     pub fn get_epoch_info(&self, epoch_id: &EpochId) -> Result<Arc<EpochInfo>, EpochError> {
         self.epochs_info.get_or_try_put(*epoch_id, |epoch_id| {

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -2340,6 +2340,7 @@ fn test_protocol_version_switch_with_shard_layout_change() {
 
     // Check split shards
     // h[5] is the first block of epoch epochs[1] and shard layout will change at epochs[2]
+    let epoch_manager = epoch_manager.into_handle();
     assert_eq!(epoch_manager.will_shard_layout_change(&h[3]).unwrap(), false);
     for i in 4..=5 {
         assert_eq!(epoch_manager.will_shard_layout_change(&h[i]).unwrap(), true);

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -192,16 +192,16 @@ fn test_fork_finalization() {
         ("test3".parse().unwrap(), amount_staked),
     ];
     let epoch_length = 20;
-    let mut epoch_manager =
-        setup_default_epoch_manager(validators.clone(), epoch_length, 1, 3, 90, 60);
+    let epoch_manager =
+        setup_default_epoch_manager(validators.clone(), epoch_length, 1, 3, 90, 60).into_handle();
 
     let h = hash_range((5 * epoch_length - 1) as usize);
     // Have an alternate set of hashes to use on the other branch to avoid collisions.
     let h2: Vec<CryptoHash> = h.iter().map(|x| hash(x.as_ref())).collect();
 
-    record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
+    record_block(&mut epoch_manager.write(), CryptoHash::default(), h[0], 0, vec![]);
 
-    let build_branch = |epoch_manager: &mut EpochManager,
+    let build_branch = |epoch_manager: EpochManagerHandle,
                         base_block: CryptoHash,
                         hashes: &[CryptoHash],
                         validator_accounts: &[&str]|
@@ -216,7 +216,7 @@ fn test_fork_finalization() {
             let block_producer = epoch_info.get_validator(block_producer_id);
             let account_id = block_producer.account_id();
             if validator_accounts.iter().any(|v| *v == account_id) {
-                record_block(epoch_manager, prev_block, *curr_block, height, vec![]);
+                record_block(&mut epoch_manager.write(), prev_block, *curr_block, height, vec![]);
                 prev_block = *curr_block;
                 branch_blocks.push(*curr_block);
             }
@@ -226,19 +226,20 @@ fn test_fork_finalization() {
 
     // build test2/test4 fork
     record_block(
-        &mut epoch_manager,
+        &mut epoch_manager.write(),
         h[0],
         h[1],
         1,
         vec![stake("test4".parse().unwrap(), amount_staked)],
     );
-    let blocks_test2 = build_branch(&mut epoch_manager, h[1], &h, &["test2", "test4"]);
+    let blocks_test2 = build_branch(epoch_manager.clone(), h[1], &h, &["test2", "test4"]);
 
     // build test1/test3 fork
-    let blocks_test1 = build_branch(&mut epoch_manager, h[0], &h2, &["test1", "test3"]);
+    let blocks_test1 = build_branch(epoch_manager.clone(), h[0], &h2, &["test1", "test3"]);
 
     let epoch1 = epoch_manager.get_epoch_id(&h[1]).unwrap();
     let mut bps = epoch_manager
+        .read()
         .get_all_block_producers_ordered(&epoch1, &h[1])
         .unwrap()
         .iter()
@@ -258,6 +259,7 @@ fn test_fork_finalization() {
     let epoch2_1 = epoch_manager.get_epoch_id(last_block).unwrap();
     assert_eq!(
         epoch_manager
+            .read()
             .get_all_block_producers_ordered(&epoch2_1, &h[1])
             .unwrap()
             .iter()
@@ -270,6 +272,7 @@ fn test_fork_finalization() {
     let epoch2_2 = epoch_manager.get_epoch_id(last_block).unwrap();
     assert_eq!(
         epoch_manager
+            .read()
             .get_all_block_producers_ordered(&epoch2_2, &h[1])
             .unwrap()
             .iter()
@@ -279,9 +282,10 @@ fn test_fork_finalization() {
     );
 
     // Check that if we have a different epoch manager and apply only second branch we get the same results.
-    let mut epoch_manager2 = setup_default_epoch_manager(validators, epoch_length, 1, 3, 90, 60);
-    record_block(&mut epoch_manager2, CryptoHash::default(), h[0], 0, vec![]);
-    build_branch(&mut epoch_manager2, h[0], &h2, &["test1", "test3"]);
+    let epoch_manager2 =
+        setup_default_epoch_manager(validators, epoch_length, 1, 3, 90, 60).into_handle();
+    record_block(&mut epoch_manager2.write(), CryptoHash::default(), h[0], 0, vec![]);
+    build_branch(epoch_manager2.clone(), h[0], &h2, &["test1", "test3"]);
     assert_eq!(epoch_manager.get_epoch_info(&epoch2_2), epoch_manager2.get_epoch_info(&epoch2_2));
 }
 
@@ -324,10 +328,11 @@ fn test_validator_kickout() {
     let validators =
         vec![("test1".parse().unwrap(), amount_staked), ("test2".parse().unwrap(), amount_staked)];
     let epoch_length = 10;
-    let mut epoch_manager = setup_default_epoch_manager(validators, epoch_length, 1, 2, 90, 60);
+    let epoch_manager =
+        setup_default_epoch_manager(validators, epoch_length, 1, 2, 90, 60).into_handle();
     let h = hash_range((3 * epoch_length) as usize);
 
-    record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
+    record_block(&mut epoch_manager.write(), CryptoHash::default(), h[0], 0, vec![]);
     let mut prev_block = h[0];
     let mut test2_expected_blocks = 0;
     let init_epoch_id = epoch_manager.get_epoch_id_from_prev_block(&prev_block).unwrap();
@@ -342,7 +347,7 @@ fn test_validator_kickout() {
             // test1 skips its blocks in subsequent epochs
             ()
         } else {
-            record_block(&mut epoch_manager, prev_block, *curr_block, height, vec![]);
+            record_block(&mut epoch_manager.write(), prev_block, *curr_block, height, vec![]);
             prev_block = *curr_block;
         }
     }
@@ -856,7 +861,7 @@ fn test_reward_multiple_shards() {
         num_seconds_per_year: 1_000_000,
     };
     let num_shards = 2;
-    let mut epoch_manager = setup_epoch_manager(
+    let epoch_manager = setup_epoch_manager(
         validators,
         epoch_length,
         num_shards,
@@ -865,10 +870,11 @@ fn test_reward_multiple_shards() {
         60,
         0,
         reward_calculator.clone(),
-    );
+    )
+    .into_handle();
     let h = hash_range((2 * epoch_length + 1) as usize);
     record_with_block_info(
-        &mut epoch_manager,
+        &mut epoch_manager.write(),
         block_info(
             h[0],
             0,
@@ -903,7 +909,7 @@ fn test_reward_multiple_shards() {
             })
             .collect();
         record_with_block_info(
-            &mut epoch_manager,
+            &mut epoch_manager.write(),
             block_info(h[i], height, height, h[i - 1], h[i - 1], h[i], chunk_mask, total_supply),
         );
     }
@@ -1012,7 +1018,7 @@ fn test_expected_chunks() {
 
     let epoch_config =
         epoch_config_with_production_config(epoch_length, num_shards, 3, 3, 90, 60, 60, false);
-    let mut epoch_manager = EpochManager::new(
+    let epoch_manager = EpochManager::new(
         create_test_store(),
         epoch_config,
         PROTOCOL_VERSION,
@@ -1022,10 +1028,11 @@ fn test_expected_chunks() {
             .map(|(account_id, balance)| stake(account_id.clone(), *balance))
             .collect(),
     )
-    .unwrap();
+    .unwrap()
+    .into_handle();
     let rng_seed = [0; 32];
     let hashes = hash_range((2 * epoch_length) as usize);
-    record_block(&mut epoch_manager, Default::default(), hashes[0], 0, vec![]);
+    record_block(&mut epoch_manager.write(), Default::default(), hashes[0], 0, vec![]);
     let mut expected = 0;
     let mut prev_block = hashes[0];
     let initial_epoch_id = epoch_manager.get_epoch_id_from_prev_block(&prev_block).unwrap();
@@ -1041,6 +1048,7 @@ fn test_expected_chunks() {
         }
 
         epoch_manager
+            .write()
             .record_block_info(
                 block_info(
                     *curr_block,
@@ -1086,11 +1094,12 @@ fn test_expected_chunks_prev_block_not_produced() {
     ];
     let epoch_length = 50;
     let total_supply = stake_amount * validators.len() as u128;
-    let mut epoch_manager =
-        setup_epoch_manager(validators, epoch_length, 1, 3, 90, 90, 0, default_reward_calculator());
+    let epoch_manager =
+        setup_epoch_manager(validators, epoch_length, 1, 3, 90, 90, 0, default_reward_calculator())
+            .into_handle();
     let rng_seed = [0; 32];
     let hashes = hash_range((2 * epoch_length) as usize);
-    record_block(&mut epoch_manager, Default::default(), hashes[0], 0, vec![]);
+    record_block(&mut epoch_manager.write(), Default::default(), hashes[0], 0, vec![]);
     let mut expected = 0;
     let mut prev_block = hashes[0];
     let initial_epoch_id = epoch_manager.get_epoch_id_from_prev_block(&prev_block).unwrap();
@@ -1116,6 +1125,7 @@ fn test_expected_chunks_prev_block_not_produced() {
             // test1 also misses all their chunks
             let should_produce_chunk = expected_chunk_producer != 0;
             epoch_manager
+                .write()
                 .record_block_info(
                     block_info(
                         *curr_block,
@@ -1185,18 +1195,19 @@ fn test_rewards_with_kickouts() {
         protocol_treasury_account: "near".parse().unwrap(),
         num_seconds_per_year: NUM_SECONDS_IN_A_YEAR,
     };
-    let mut em = setup_epoch_manager(validators, epoch_length, 1, 3, 10, 10, 0, reward_calculator);
+    let em = setup_epoch_manager(validators, epoch_length, 1, 3, 10, 10, 0, reward_calculator)
+        .into_handle();
 
     let mut height: BlockHeight = 0;
     let genesis_hash = hash(height.to_le_bytes().as_ref());
-    record_block(&mut em, Default::default(), genesis_hash, height, vec![]);
+    record_block(&mut em.write(), Default::default(), genesis_hash, height, vec![]);
 
     height += 1;
     let first_hash = hash(height.to_le_bytes().as_ref());
 
     // unstake test3 in the first block so we can see it in the kickouts later
     record_block(
-        &mut em,
+        &mut em.write(),
         genesis_hash,
         first_hash,
         height,
@@ -1217,7 +1228,7 @@ fn test_rewards_with_kickouts() {
 
         // don't produce blocks for test2 so we can see it in the kickouts
         if block_producer.as_str() != "test2" {
-            record_block(&mut em, prev_hash, block_hash, height, vec![]);
+            record_block(&mut em.write(), prev_hash, block_hash, height, vec![]);
             prev_hash = block_hash;
         }
 
@@ -1493,11 +1504,12 @@ fn test_chunk_producer_kickout() {
         vec![("test1".parse().unwrap(), stake_amount), ("test2".parse().unwrap(), stake_amount)];
     let epoch_length = 10;
     let total_supply = stake_amount * validators.len() as u128;
-    let mut em =
-        setup_epoch_manager(validators, epoch_length, 4, 2, 90, 70, 0, default_reward_calculator());
+    let em =
+        setup_epoch_manager(validators, epoch_length, 4, 2, 90, 70, 0, default_reward_calculator())
+            .into_handle();
     let rng_seed = [0; 32];
     let hashes = hash_range((epoch_length + 2) as usize);
-    record_block(&mut em, Default::default(), hashes[0], 0, vec![]);
+    record_block(&mut em.write(), Default::default(), hashes[0], 0, vec![]);
     let mut expected = 0;
     for (prev_block, (height, curr_block)) in hashes.iter().zip(hashes.iter().enumerate().skip(1)) {
         let height = height as u64;
@@ -1527,20 +1539,21 @@ fn test_chunk_producer_kickout() {
             })
             .collect();
 
-        em.record_block_info(
-            block_info(
-                *curr_block,
-                height,
-                height - 1,
-                *prev_block,
-                *prev_block,
-                epoch_id.0,
-                chunk_mask,
-                total_supply,
-            ),
-            rng_seed,
-        )
-        .unwrap();
+        em.write()
+            .record_block_info(
+                block_info(
+                    *curr_block,
+                    height,
+                    height - 1,
+                    *prev_block,
+                    *prev_block,
+                    epoch_id.0,
+                    chunk_mask,
+                    total_supply,
+                ),
+                rng_seed,
+            )
+            .unwrap();
     }
 
     let last_epoch_info = hashes.iter().filter_map(|x| em.get_epoch_info(&EpochId(*x)).ok()).last();
@@ -1564,7 +1577,7 @@ fn test_chunk_validator_kickout_using_production_stats() {
     let num_shards = 2;
     let epoch_config =
         epoch_config_with_production_config(epoch_length, num_shards, 2, 2, 90, 40, 75, false);
-    let mut em = EpochManager::new(
+    let em = EpochManager::new(
         create_test_store(),
         epoch_config,
         PROTOCOL_VERSION,
@@ -1574,10 +1587,11 @@ fn test_chunk_validator_kickout_using_production_stats() {
             .map(|(account_id, balance)| stake(account_id.clone(), *balance))
             .collect(),
     )
-    .unwrap();
+    .unwrap()
+    .into_handle();
     let rng_seed = [0; 32];
     let hashes = hash_range((epoch_length + 2) as usize);
-    record_block(&mut em, Default::default(), hashes[0], 0, vec![]);
+    record_block(&mut em.write(), Default::default(), hashes[0], 0, vec![]);
     for (prev_block, (height, curr_block)) in hashes.iter().zip(hashes.iter().enumerate().skip(1)) {
         let height = height as u64;
         let epoch_id = em.get_epoch_id_from_prev_block(prev_block).unwrap();
@@ -1586,20 +1600,21 @@ fn test_chunk_validator_kickout_using_production_stats() {
         } else {
             vec![true; num_shards as usize]
         };
-        em.record_block_info(
-            block_info(
-                *curr_block,
-                height,
-                height - 1,
-                *prev_block,
-                *prev_block,
-                epoch_id.0,
-                chunk_mask,
-                total_supply,
-            ),
-            rng_seed,
-        )
-        .unwrap();
+        em.write()
+            .record_block_info(
+                block_info(
+                    *curr_block,
+                    height,
+                    height - 1,
+                    *prev_block,
+                    *prev_block,
+                    epoch_id.0,
+                    chunk_mask,
+                    total_supply,
+                ),
+                rng_seed,
+            )
+            .unwrap();
     }
 
     let last_epoch_info = hashes.iter().filter_map(|x| em.get_epoch_info(&EpochId(*x)).ok()).last();
@@ -1636,7 +1651,7 @@ fn test_chunk_validator_kickout_using_endorsement_stats() {
     let num_shards = 2;
     let epoch_config =
         epoch_config_with_production_config(epoch_length, num_shards, 2, 2, 90, 40, 75, false);
-    let mut em = EpochManager::new(
+    let em = EpochManager::new(
         create_test_store(),
         epoch_config,
         PROTOCOL_VERSION,
@@ -1646,10 +1661,11 @@ fn test_chunk_validator_kickout_using_endorsement_stats() {
             .map(|(account_id, balance)| stake(account_id.clone(), *balance))
             .collect(),
     )
-    .unwrap();
+    .unwrap()
+    .into_handle();
     let rng_seed = [0; 32];
     let hashes = hash_range((epoch_length + 2) as usize);
-    record_block(&mut em, Default::default(), hashes[0], 0, vec![]);
+    record_block(&mut em.write(), Default::default(), hashes[0], 0, vec![]);
     for (prev_block, (height, curr_block)) in hashes.iter().zip(hashes.iter().enumerate().skip(1)) {
         let height = height as u64;
         let epoch_id = em.get_epoch_id_from_prev_block(prev_block).unwrap();
@@ -1675,26 +1691,27 @@ fn test_chunk_validator_kickout_using_endorsement_stats() {
                     .collect(),
             )
         }
-        em.record_block_info(
-            BlockInfo::V3(BlockInfoV3 {
-                hash: *curr_block,
-                height,
-                last_finalized_height: height - 1,
-                last_final_block_hash: *prev_block,
-                prev_hash: *prev_block,
-                epoch_id: Default::default(),
-                epoch_first_block: epoch_id.0,
-                proposals: vec![],
-                chunk_mask,
-                latest_protocol_version: PROTOCOL_VERSION,
-                slashed: Default::default(),
-                total_supply,
-                timestamp_nanosec: height * NUM_NS_IN_SECOND,
-                chunk_endorsements: bitmap,
-            }),
-            rng_seed,
-        )
-        .unwrap();
+        em.write()
+            .record_block_info(
+                BlockInfo::V3(BlockInfoV3 {
+                    hash: *curr_block,
+                    height,
+                    last_finalized_height: height - 1,
+                    last_final_block_hash: *prev_block,
+                    prev_hash: *prev_block,
+                    epoch_id: Default::default(),
+                    epoch_first_block: epoch_id.0,
+                    proposals: vec![],
+                    chunk_mask,
+                    latest_protocol_version: PROTOCOL_VERSION,
+                    slashed: Default::default(),
+                    total_supply,
+                    timestamp_nanosec: height * NUM_NS_IN_SECOND,
+                    chunk_endorsements: bitmap,
+                }),
+                rng_seed,
+            )
+            .unwrap();
     }
 
     let last_epoch_info = hashes.iter().filter_map(|x| em.get_epoch_info(&EpochId(*x)).ok()).last();
@@ -2139,10 +2156,11 @@ fn test_all_kickout_edge_case() {
         ("test3".parse().unwrap(), stake_amount),
     ];
     const EPOCH_LENGTH: u64 = 10;
-    let mut epoch_manager = setup_default_epoch_manager(validators, EPOCH_LENGTH, 1, 3, 90, 60);
+    let epoch_manager =
+        setup_default_epoch_manager(validators, EPOCH_LENGTH, 1, 3, 90, 60).into_handle();
     let hashes = hash_range((8 * EPOCH_LENGTH + 1) as usize);
 
-    record_block(&mut epoch_manager, CryptoHash::default(), hashes[0], 0, vec![]);
+    record_block(&mut epoch_manager.write(), CryptoHash::default(), hashes[0], 0, vec![]);
     let mut prev_block = hashes[0];
     for (height, curr_block) in hashes.iter().enumerate().skip(1) {
         let height = height as u64;
@@ -2153,12 +2171,18 @@ fn test_all_kickout_edge_case() {
         if height < EPOCH_LENGTH {
             // kickout test2 during first epoch
             if block_producer == "test1" || block_producer == "test3" {
-                record_block(&mut epoch_manager, prev_block, *curr_block, height, Vec::new());
+                record_block(
+                    &mut epoch_manager.write(),
+                    prev_block,
+                    *curr_block,
+                    height,
+                    Vec::new(),
+                );
                 prev_block = *curr_block;
             }
         } else if height < 2 * EPOCH_LENGTH {
             // produce blocks as normal during the second epoch
-            record_block(&mut epoch_manager, prev_block, *curr_block, height, Vec::new());
+            record_block(&mut epoch_manager.write(), prev_block, *curr_block, height, Vec::new());
             prev_block = *curr_block;
         } else if height < 5 * EPOCH_LENGTH {
             // no one produces blocks during epochs 3, 4, 5
@@ -2166,18 +2190,24 @@ fn test_all_kickout_edge_case() {
             ()
         } else if height < 6 * EPOCH_LENGTH {
             // produce blocks normally during epoch 6
-            record_block(&mut epoch_manager, prev_block, *curr_block, height, Vec::new());
+            record_block(&mut epoch_manager.write(), prev_block, *curr_block, height, Vec::new());
             prev_block = *curr_block;
         } else if height < 7 * EPOCH_LENGTH {
             // the validator which was not kicked out in epoch 6 stops producing blocks,
             // but cannot be kicked out now because they are the last validator
             if block_producer != epoch_info.validator_account_id(0) {
-                record_block(&mut epoch_manager, prev_block, *curr_block, height, Vec::new());
+                record_block(
+                    &mut epoch_manager.write(),
+                    prev_block,
+                    *curr_block,
+                    height,
+                    Vec::new(),
+                );
                 prev_block = *curr_block;
             }
         } else {
             // produce blocks normally again
-            record_block(&mut epoch_manager, prev_block, *curr_block, height, Vec::new());
+            record_block(&mut epoch_manager.write(), prev_block, *curr_block, height, Vec::new());
             prev_block = *curr_block;
         }
     }


### PR DESCRIPTION
The PR makes some functions as default implementation in the `EpochManagerAdapter` trait and deletes unused functions like `copy_epoch_info_as_of_block` and `get_all_block_approvers_ordered`