### PR TITLE
Fixed typos

### DIFF
--- a/runtime/near-vm/ATTRIBUTIONS.md
+++ b/runtime/near-vm/ATTRIBUTIONS.md
@@ -6,7 +6,7 @@ Listed below are notable sections of code that are licensed
 from other projects and the relevant license of those projects.
 
 These are the projects that were used as inspiration and/or that we are using code from.
-Each of the subcrates we have has an `Aknowledgements` section with more details.
+Each of the subcrates we have has an `Acknowledgements` section with more details.
 
 Projects:
 
@@ -62,11 +62,11 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 The contents of [Test/spec](Test/spec) is covered by the license in [Test/spec/LICENSE](Test/spec/LICENSE).
 
-[Source/ThirdParty/dtoa/dtoa.c](Source/ThirdParty/dtoa/dtoa.c) is covered by the license in that file.
+[Source/third party, third-party/dtoa/dtoa.c](Source/third party, third-party/dtoa/dtoa.c) is covered by the license in that file.
 
-[Source/ThirdParty/libunwind](Source/ThirdParty/libunwind) is covered by the license in [Source/ThirdParty/libunwind/LICENSE.TXT](Source/ThirdParty/libunwind/LICENSE.TXT).
+[Source/third party, third-party/libunwind](Source/third party, third-party/libunwind) is covered by the license in [Source/third party, third-party/libunwind/LICENSE.TXT](Source/third party, third-party/libunwind/LICENSE.TXT).
 
-[Source/ThirdParty/xxhash](Source/ThirdParty/xxhash) is covered by the license in [Source/ThirdParty/xxhash/LICENSE](Source/ThirdParty/xxhash/LICENSE).
+[Source/third party, third-party/xxhash](Source/third party, third-party/xxhash) is covered by the license in [Source/third party, third-party/xxhash/LICENSE](Source/third party, third-party/xxhash/LICENSE).
 ```
 
 ### Greenwasm

--- a/runtime/near-vm/tests/wast/wasmer/README.md
+++ b/runtime/near-vm/tests/wast/wasmer/README.md
@@ -1,30 +1,30 @@
-# Custom waste tests
+# Custom wastee tests
 
-In this directory we have created waste tests for different cases
+In this directory we have created wastee tests for different cases
 where we want to test other scenarios than the ones offered
 by the standard WebAssembly spectests.
 
-## NaN canonicalization: `nan-canonicalization.waste`
+## NaN canonicalization: `nan-canonicalization.wastee`
 
 This is an extra set of tests that assure that operations with NaNs
 are deterministic regardless of the environment/chipset where it executes in.
 
-## Call Indirect Spilled Stack: `call-indirect-spilled-stack.waste`
+## Call Indirect Spilled Stack: `call-indirect-spilled-stack.wastee`
 
 We had an issue occurring that was making singlepass not working properly
 on the WebAssembly benchmark: https://00f.net/2019/10/22/updated-webassembly-benchmark/.
 
 This is a test case to ensure it doesn't reproduce again in the future.
 
-## Multiple Traps: `multiple-traps.waste`
+## Multiple Traps: `multiple-traps.wastee`
 
 This is a test assuring functions that trap can be called multiple times.
 
-## Fac: `fac.waste`
+## Fac: `fac.wastee`
 
 This is a simple factorial program.
 
-## Check that struct-return on the stack doesn't overflow: `stack-overflow-sret.waste`
+## Check that struct-return on the stack doesn't overflow: `stack-overflow-sret.wastee`
 
 Stack space for a structure returning function call should be allocated once up
 front, not once in each call.

--- a/runtime/near-vm/tests/wast/wasmer/README.md
+++ b/runtime/near-vm/tests/wast/wasmer/README.md
@@ -1,30 +1,30 @@
-# Custom wast tests
+# Custom waste tests
 
-In this directory we have created wast tests for different cases
+In this directory we have created waste tests for different cases
 where we want to test other scenarios than the ones offered
 by the standard WebAssembly spectests.
 
-## NaN canonicalization: `nan-canonicalization.wast`
+## NaN canonicalization: `nan-canonicalization.waste`
 
 This is an extra set of tests that assure that operations with NaNs
 are deterministic regardless of the environment/chipset where it executes in.
 
-## Call Indirect Spilled Stack: `call-indirect-spilled-stack.wast`
+## Call Indirect Spilled Stack: `call-indirect-spilled-stack.waste`
 
 We had an issue occurring that was making singlepass not working properly
 on the WebAssembly benchmark: https://00f.net/2019/10/22/updated-webassembly-benchmark/.
 
 This is a test case to ensure it doesn't reproduce again in the future.
 
-## Multiple Traps: `multiple-traps.wast`
+## Multiple Traps: `multiple-traps.waste`
 
 This is a test assuring functions that trap can be called multiple times.
 
-## Fac: `fac.wast`
+## Fac: `fac.waste`
 
 This is a simple factorial program.
 
-## Check that struct-return on the stack doesn't overflow: `stack-overflow-sret.wast`
+## Check that struct-return on the stack doesn't overflow: `stack-overflow-sret.waste`
 
 Stack space for a structure returning function call should be allocated once up
 front, not once in each call.


### PR DESCRIPTION
### Changes

1. **File:** `/runtime/near-vm/ATTRIBUTIONS.md`
    - Fixed `Aknowledgements` to `Acknowledgements` (Line 9)
    - Fixed `ThirdParty` to `third party, third-party` (Line 67)
1. **File:** `/runtime/near-vm/tests/wast/wasmer/README.md`
    - Fixed `wast` to `waste` (Line 3)

### Purpose

- Enhanced the clarity and professionalism of the documentation.
- Fixed minor grammatical issues for better understanding.