### PR TITLE
Standardize naming for validator list and error handling

### DIFF
--- a/tools/debug-ui/src/CurrentPeersView.tsx
+++ b/tools/debug-ui/src/CurrentPeersView.tsx
@@ -287,7 +287,7 @@ export const CurrentPeersView = ({ addr }: NetworkInfoViewProps) => {
                                     )}
                                 </td>
                                 <td>
-                                    <CollapsableValidatorList validators={routedValidator} />
+                                    <CollapsibleValidatorList validators={routedValidator} />
                                 </td>
                             </tr>
                         );
@@ -298,7 +298,7 @@ export const CurrentPeersView = ({ addr }: NetworkInfoViewProps) => {
     );
 };
 
-const CollapsableValidatorList = ({ validators }: { validators: string[] }) => {
+const CollapsibleValidatorList = ({ validators }: { validators: string[] }) => {
     const [showAll, setShowAll] = useState(false);
     const callback = useCallback((e: MouseEvent) => {
         e.preventDefault();

--- a/utils/config/src/lib.rs
+++ b/utils/config/src/lib.rs
@@ -34,7 +34,7 @@ pub enum ValidationError {
     #[error("validator_key.json file issue: {error_message}")]
     ValidatorKeyFileError { error_message: String },
     #[error("cross config files semantic issue: {error_message}")]
-    CrossFileSematicError { error_message: String },
+    CrossFileSemanticError { error_message: String },
 }
 
 /// Used to collect errors on the go.
@@ -78,7 +78,7 @@ impl ValidationErrors {
     }
 
     pub fn push_cross_file_semantics_error(&mut self, error_message: String) {
-        self.0.push(ValidationError::CrossFileSematicError { error_message: error_message })
+        self.0.push(ValidationError::CrossFileSemanticError { error_message: error_message })
     }
 
     /// only to be used in panic_if_errors()


### PR DESCRIPTION
- **Refactored component name for clarity in `CurrentPeersView.tsx`**:
  - Renamed `CollapsableValidatorList` → `CollapsibleValidatorList` to match standard spelling.
  - Updated all references to the component in `CurrentPeersView.tsx`.
  
- **Corrected error type in `lib.rs`**:
  - Renamed `CrossFileSematicError` → `CrossFileSemanticError` for proper terminology.
  - Updated corresponding method `push_cross_file_semantics_error()` to use the corrected error type.
