### PR TITLE
[cleanup] Rename epoch() to epoch_store() in store adapters

### DIFF
--- a/chain/client/src/sync/epoch.rs
+++ b/chain/client/src/sync/epoch.rs
@@ -60,7 +60,7 @@ impl EpochSync {
         store: &Store,
     ) -> Self {
         let my_own_epoch_sync_boundary_block_header = store
-            .epoch()
+            .epoch_store()
             .get_epoch_sync_proof()
             .expect("IO error querying epoch sync proof")
             .map(|proof| proof.current_epoch.first_block_header_in_epoch);
@@ -150,7 +150,7 @@ impl EpochSync {
         transaction_validity_period: BlockHeightDelta,
     ) -> Result<CryptoHash, Error> {
         let chain_store = store.chain_store();
-        let epoch_store = store.epoch();
+        let epoch_store = store.epoch_store();
 
         let tip = chain_store.final_head()?;
         let current_epoch_start_height = epoch_store.get_epoch_start(&tip.epoch_id)?;
@@ -183,7 +183,7 @@ impl EpochSync {
         next_block_header_after_last_final_block_of_current_epoch: BlockHeader,
     ) -> Result<EpochSyncProof, Error> {
         let chain_store = store.chain_store();
-        let epoch_store = store.epoch();
+        let epoch_store = store.epoch_store();
 
         let last_final_block_header_in_current_epoch = chain_store.get_block_header(
             next_block_header_after_last_final_block_of_current_epoch.prev_hash(),
@@ -304,7 +304,7 @@ impl EpochSync {
         current_epoch_second_last_block_approvals: Vec<Option<Box<Signature>>>,
     ) -> Result<Vec<EpochSyncProofEpochData>, Error> {
         let chain_store = store.chain_store();
-        let epoch_store = store.epoch();
+        let epoch_store = store.epoch_store();
 
         // We're going to get all the epochs and then figure out the correct chain of
         // epochs. The reason is that (1) epochs may, in very rare cases, have forks,

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -1605,7 +1605,7 @@ impl EpochManager {
 
     pub fn get_epoch_info(&self, epoch_id: &EpochId) -> Result<Arc<EpochInfo>, EpochError> {
         self.epochs_info.get_or_try_put(*epoch_id, |epoch_id| {
-            self.store.epoch().get_epoch_info(epoch_id).map(Arc::new)
+            self.store.epoch_store().get_epoch_info(epoch_id).map(Arc::new)
         })
     }
 
@@ -1657,8 +1657,9 @@ impl EpochManager {
     }
 
     pub fn get_block_info(&self, hash: &CryptoHash) -> Result<Arc<BlockInfo>, EpochError> {
-        self.blocks_info
-            .get_or_try_put(*hash, |hash| self.store.epoch().get_block_info(hash).map(Arc::new))
+        self.blocks_info.get_or_try_put(*hash, |hash| {
+            self.store.epoch_store().get_block_info(hash).map(Arc::new)
+        })
     }
 
     fn save_block_info(
@@ -1684,8 +1685,9 @@ impl EpochManager {
     }
 
     fn get_epoch_start_from_epoch_id(&self, epoch_id: &EpochId) -> Result<BlockHeight, EpochError> {
-        self.epoch_id_to_start
-            .get_or_try_put(*epoch_id, |epoch_id| self.store.epoch().get_epoch_start(epoch_id))
+        self.epoch_id_to_start.get_or_try_put(*epoch_id, |epoch_id| {
+            self.store.epoch_store().get_epoch_start(epoch_id)
+        })
     }
 
     /// Updates epoch info aggregator to state as of `last_final_block_hash`

--- a/core/store/src/adapter/mod.rs
+++ b/core/store/src/adapter/mod.rs
@@ -101,7 +101,7 @@ pub trait StoreAdapter {
         chunk_store::ChunkStoreAdapter::new(self.store())
     }
 
-    fn epoch(&self) -> epoch_store::EpochStoreAdapter {
+    fn epoch_store(&self) -> epoch_store::EpochStoreAdapter {
         epoch_store::EpochStoreAdapter::new(self.store())
     }
 


### PR DESCRIPTION
Originally a typo