### PR TITLE
mock-node: use the client's protocol version in the handshake

### DIFF
--- a/chain/network/src/raw/tests.rs
+++ b/chain/network/src/raw/tests.rs
@@ -182,6 +182,7 @@ async fn test_listener() {
         vec![ShardId::new(0)],
         false,
         time::Duration::SECOND,
+        None,
     )
     .await
     .unwrap();

--- a/tools/mock-node/src/lib.rs
+++ b/tools/mock-node/src/lib.rs
@@ -13,6 +13,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::types::{BlockHeight, ShardId};
+use near_primitives::version::ProtocolVersion;
 use near_store::adapter::chain_store::ChainStoreAdapter;
 
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -468,6 +469,7 @@ impl MockNode {
         shard_layout: ShardLayout,
         network_start_height: BlockHeight,
         network_config: MockNetworkConfig,
+        handshake_protocol_version: Option<ProtocolVersion>,
     ) -> anyhow::Result<Self> {
         let listener = Listener::bind(
             listen_addr,
@@ -478,6 +480,7 @@ impl MockNode {
             shard_layout.shard_ids().collect(),
             archival,
             30 * near_time::Duration::SECOND,
+            handshake_protocol_version,
         )
         .await?;
 

--- a/tools/mock-node/src/main.rs
+++ b/tools/mock-node/src/main.rs
@@ -9,6 +9,8 @@ use mock_node::MockNetworkConfig;
 use near_actix_test_utils::{block_on_interruptible, setup_actix};
 use near_o11y::testonly::init_integration_logger;
 use near_primitives::types::BlockHeight;
+use near_primitives::version::ProtocolVersion;
+
 use std::path::Path;
 use std::time::Duration;
 
@@ -36,6 +38,9 @@ struct Cli {
     /// use the height of the last block in chain history
     #[clap(long)]
     target_height: Option<BlockHeight>,
+    /// Protocol version to advertise in handshakes
+    #[clap(long)]
+    handshake_protocol_version: Option<ProtocolVersion>,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -57,9 +62,14 @@ fn main() -> anyhow::Result<()> {
 
     let sys = setup_actix();
     let res = block_on_interruptible(&sys, async move {
-        let mock_peer =
-            setup_mock_node(home_dir, network_config, args.network_height, args.target_height)
-                .context("failed setting up mock node")?;
+        let mock_peer = setup_mock_node(
+            home_dir,
+            network_config,
+            args.network_height,
+            args.target_height,
+            args.handshake_protocol_version,
+        )
+        .context("failed setting up mock node")?;
 
         mock_peer.await.context("failed running mock peer task")?.context("mock peer failed")
     });

--- a/tools/mock-node/src/setup.rs
+++ b/tools/mock-node/src/setup.rs
@@ -9,6 +9,7 @@ use near_epoch_manager::{EpochManager, EpochManagerAdapter};
 use near_network::tcp;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::BlockHeight;
+use near_primitives::version::ProtocolVersion;
 use near_store::adapter::chain_store::ChainStoreAdapter;
 use near_store::adapter::StoreAdapter;
 
@@ -28,6 +29,7 @@ pub(crate) fn setup_mock_peer(
     network_config: MockNetworkConfig,
     target_height: BlockHeight,
     shard_layout: ShardLayout,
+    handshake_protocol_version: Option<ProtocolVersion>,
 ) -> tokio::task::JoinHandle<anyhow::Result<()>> {
     let network_start_height = match network_start_height {
         None => target_height,
@@ -55,6 +57,7 @@ pub(crate) fn setup_mock_peer(
             shard_layout,
             network_start_height,
             network_config,
+            handshake_protocol_version,
         )
         .await?;
         mock.run(target_height).await
@@ -72,6 +75,7 @@ pub fn setup_mock_node(
     network_config: MockNetworkConfig,
     network_start_height: Option<BlockHeight>,
     target_height: Option<BlockHeight>,
+    handshake_protocol_version: Option<ProtocolVersion>,
 ) -> anyhow::Result<tokio::task::JoinHandle<anyhow::Result<()>>> {
     let near_config = nearcore::config::load_config(home_dir, GenesisValidationMode::Full)
         .context("Error loading config")?;
@@ -120,5 +124,6 @@ pub fn setup_mock_node(
         network_config,
         target_height,
         shard_layout,
+        handshake_protocol_version,
     ))
 }


### PR DESCRIPTION
When using mock-node to test older versions of neard, they might not be able to connect to each other if the protocol versions are different. But they probably are actually compatible since the mock-node program is doing nothing but providing serialized blocks and chunks. So just respond with whatever protocol version the client specified in its handshake, and add a --handshake-protocol-version flag to set it explicitly if desired.