### PR TITLE
parameters: use value that does not exceed 32-bit usize for initial placeholders

### DIFF
--- a/core/parameters/res/runtime_configs/69.yaml
+++ b/core/parameters/res/runtime_configs/69.yaml
@@ -2,19 +2,19 @@
 
 max_transaction_size: {old: 4_194_304, new: 1_572_864}
 
-per_receipt_storage_proof_size_limit: {old: 999_999_999_999_999, new: 4_000_000}
-main_storage_proof_size_soft_limit: {old: 999_999_999_999_999, new: 3_000_000}
+per_receipt_storage_proof_size_limit: {old: 4_294_967_295, new: 4_000_000}
+main_storage_proof_size_soft_limit: {old: 4_294_967_295, new: 3_000_000}
 
-max_receipt_size: {old: 999_999_999_999_999, new: 4_194_304}
-new_transactions_validation_state_size_soft_limit: {old: 999_999_999_999_999, new: 572_864}
+max_receipt_size: {old: 4_294_967_295, new: 4_194_304}
+new_transactions_validation_state_size_soft_limit: {old: 4_294_967_295, new: 572_864}
 
 # 100 kiB
-outgoing_receipts_usual_size_limit: {old: 999_999_999_999_999, new: 102_400}
+outgoing_receipts_usual_size_limit: {old: 4_294_967_295, new: 102_400}
 
 # 4.5 MiB
-outgoing_receipts_big_size_limit: {old: 999_999_999_999_999, new: 4_718_592}
+outgoing_receipts_big_size_limit: {old: 4_294_967_295, new: 4_718_592}
 
-combined_transactions_size_limit: {old: 999_999_999_999_999, new: 4_194_304}
+combined_transactions_size_limit: {old: 4_294_967_295, new: 4_194_304}
 
 
 # Change the cost of sending receipt to another account to 50 TGas / MiB

--- a/core/parameters/res/runtime_configs/parameters.yaml
+++ b/core/parameters/res/runtime_configs/parameters.yaml
@@ -13,12 +13,12 @@ pessimistic_gas_price_inflation: {
 }
 
 # Stateless validation config
-main_storage_proof_size_soft_limit: 999_999_999_999_999
-per_receipt_storage_proof_size_limit: 999_999_999_999_999
-combined_transactions_size_limit: 999_999_999_999_999
-new_transactions_validation_state_size_soft_limit: 999_999_999_999_999
-outgoing_receipts_usual_size_limit: 999_999_999_999_999
-outgoing_receipts_big_size_limit: 999_999_999_999_999
+main_storage_proof_size_soft_limit: 4_294_967_295
+per_receipt_storage_proof_size_limit: 4_294_967_295
+combined_transactions_size_limit: 4_294_967_295
+new_transactions_validation_state_size_soft_limit: 4_294_967_295
+outgoing_receipts_usual_size_limit: 4_294_967_295
+outgoing_receipts_big_size_limit: 4_294_967_295
 
 # Account creation config
 min_allowed_top_level_account_length: 32
@@ -224,7 +224,7 @@ max_arguments_length: 4_194_304
 max_length_returned_data: 4_194_304
 max_contract_size: 4_194_304
 max_transaction_size: 4_194_304
-max_receipt_size: 999_999_999_999_999
+max_receipt_size: 4_294_967_295
 max_length_storage_key: 4_194_304
 max_length_storage_value: 4_194_304
 max_promises_per_function_call_action: 1_024

--- a/core/parameters/res/runtime_configs/parameters_testnet.yaml
+++ b/core/parameters/res/runtime_configs/parameters_testnet.yaml
@@ -9,12 +9,12 @@ pessimistic_gas_price_inflation: {
 }
 
 # Stateless validation config
-main_storage_proof_size_soft_limit: 999_999_999_999_999
-per_receipt_storage_proof_size_limit: 999_999_999_999_999
-combined_transactions_size_limit: 999_999_999_999_999
-new_transactions_validation_state_size_soft_limit: 999_999_999_999_999
-outgoing_receipts_usual_size_limit: 999_999_999_999_999
-outgoing_receipts_big_size_limit: 999_999_999_999_999
+main_storage_proof_size_soft_limit: 4_294_967_295
+per_receipt_storage_proof_size_limit: 4_294_967_295
+combined_transactions_size_limit: 4_294_967_295
+new_transactions_validation_state_size_soft_limit: 4_294_967_295
+outgoing_receipts_usual_size_limit: 4_294_967_295
+outgoing_receipts_big_size_limit: 4_294_967_295
 
 # Account creation config
 min_allowed_top_level_account_length: 0
@@ -221,7 +221,7 @@ max_arguments_length: 4_194_304
 max_length_returned_data: 4_194_304
 max_contract_size: 4_194_304
 max_transaction_size: 4_194_304
-max_receipt_size: 999_999_999_999_999
+max_receipt_size: 4_294_967_295
 max_length_storage_key: 4_194_304
 max_length_storage_value: 4_194_304
 max_promises_per_function_call_action: 1_024

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__0.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__0.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 4194304,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -236,7 +236,7 @@ expression: config_view
       "account_id_validity_rules_version": 0,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -254,12 +254,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__35.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__35.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 4194304,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -236,7 +236,7 @@ expression: config_view
       "account_id_validity_rules_version": 0,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -254,12 +254,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__42.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__42.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 4194304,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -236,7 +236,7 @@ expression: config_view
       "account_id_validity_rules_version": 0,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -254,12 +254,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__46.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__46.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 4194304,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -236,7 +236,7 @@ expression: config_view
       "account_id_validity_rules_version": 0,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -254,12 +254,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__48.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__48.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 4194304,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -236,7 +236,7 @@ expression: config_view
       "account_id_validity_rules_version": 0,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -254,12 +254,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__49.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__49.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 4194304,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -237,7 +237,7 @@ expression: config_view
       "account_id_validity_rules_version": 0,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -255,12 +255,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__50.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__50.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 4194304,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -237,7 +237,7 @@ expression: config_view
       "account_id_validity_rules_version": 0,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -255,12 +255,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__52.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__52.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 4194304,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -237,7 +237,7 @@ expression: config_view
       "account_id_validity_rules_version": 0,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -255,12 +255,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__53.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__53.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 0,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__55.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__55.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 0,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__57.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__57.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 1,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__59.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__59.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 1,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__61.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__61.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 1,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__62.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__62.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 1,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__63.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__63.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 1,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__64.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__64.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 1,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__66.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__66.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 1,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__67.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__67.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 1,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__68.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__68.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 1,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 500000000000000,
     "min_tx_gas": 20000000000000,
     "reject_tx_congestion_threshold": 0.5,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_0.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_0.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 4194304,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -236,7 +236,7 @@ expression: config_view
       "account_id_validity_rules_version": 0,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -254,12 +254,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_35.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_35.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 4194304,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -236,7 +236,7 @@ expression: config_view
       "account_id_validity_rules_version": 0,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -254,12 +254,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_42.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_42.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 4194304,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -236,7 +236,7 @@ expression: config_view
       "account_id_validity_rules_version": 0,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -254,12 +254,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_46.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_46.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 4194304,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -236,7 +236,7 @@ expression: config_view
       "account_id_validity_rules_version": 0,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -254,12 +254,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_48.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_48.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 4194304,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -236,7 +236,7 @@ expression: config_view
       "account_id_validity_rules_version": 0,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -254,12 +254,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_49.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_49.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 4194304,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -237,7 +237,7 @@ expression: config_view
       "account_id_validity_rules_version": 0,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -255,12 +255,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_50.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_50.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 4194304,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -237,7 +237,7 @@ expression: config_view
       "account_id_validity_rules_version": 0,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -255,12 +255,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_52.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_52.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 4194304,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -237,7 +237,7 @@ expression: config_view
       "account_id_validity_rules_version": 0,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -255,12 +255,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_53.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_53.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 0,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_55.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_55.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 0,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_57.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_57.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 1,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_59.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_59.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 1,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_61.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_61.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 1,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_62.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_62.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 1,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_63.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_63.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 1,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_64.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_64.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 1,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_66.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_66.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 1,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_67.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_67.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 1,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 9223372036854775807,
     "min_tx_gas": 9223372036854775807,
     "reject_tx_congestion_threshold": 1.0,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_68.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_68.json.snap
@@ -227,7 +227,7 @@ expression: config_view
       "max_length_returned_data": 4194304,
       "max_contract_size": 4194304,
       "max_transaction_size": 4194304,
-      "max_receipt_size": 999999999999999,
+      "max_receipt_size": 4294967295,
       "max_length_storage_key": 2048,
       "max_length_storage_value": 4194304,
       "max_promises_per_function_call_action": 1024,
@@ -238,7 +238,7 @@ expression: config_view
       "account_id_validity_rules_version": 1,
       "yield_timeout_length_in_blocks": 200,
       "max_yield_payload_size": 1024,
-      "per_receipt_storage_proof_size_limit": 999999999999999
+      "per_receipt_storage_proof_size_limit": 4294967295
     }
   },
   "account_creation_config": {
@@ -256,12 +256,12 @@ expression: config_view
     "max_tx_gas": 500000000000000,
     "min_tx_gas": 20000000000000,
     "reject_tx_congestion_threshold": 0.5,
-    "outgoing_receipts_usual_size_limit": 999999999999999,
-    "outgoing_receipts_big_size_limit": 999999999999999
+    "outgoing_receipts_usual_size_limit": 4294967295,
+    "outgoing_receipts_big_size_limit": 4294967295
   },
   "witness_config": {
-    "main_storage_proof_size_soft_limit": 999999999999999,
-    "combined_transactions_size_limit": 999999999999999,
-    "new_transactions_validation_state_size_soft_limit": 999999999999999
+    "main_storage_proof_size_soft_limit": 4294967295,
+    "combined_transactions_size_limit": 4294967295,
+    "new_transactions_validation_state_size_soft_limit": 4294967295
   }
 }


### PR DESCRIPTION
I'm working on a project that utilizes near-parameters in a 32-bit
environment and 999_999_999_999_999 is well outside the supported range
for a 32-bit usize.