### PR TITLE
mock-node: don't exit on errors during the handdshake phase

### DIFF
--- a/chain/network/src/raw/connection.rs
+++ b/chain/network/src/raw/connection.rs
@@ -178,6 +178,8 @@ pub enum ConnectError {
     UnexpectedFirstMessage(Box<PeerMessage>),
     #[error(transparent)]
     TcpConnect(anyhow::Error),
+    #[error(transparent)]
+    Accept(std::io::Error),
 }
 
 impl From<RecvError> for ConnectError {
@@ -661,7 +663,7 @@ impl Listener {
         // TODO: get rid of this listener type and make Connection::on_accept() pub. That way
         // the calling code can just accept in a loop and then call Connection::on_accept() in
         // different tasks
-        let stream = self.listener.accept().await.map_err(ConnectError::IO)?;
+        let stream = self.listener.accept().await.map_err(ConnectError::Accept)?;
         Connection::on_accept(
             stream,
             self.secret_key.clone(),


### PR DESCRIPTION
If an error occurs during this part we don't want to exit with an error, since everything is probably fine and we can continue serving requests.

One way for this to happen is a ^C on neard while the handshake is in progress, which of course shouldn't cause us to exit. But a more likely cause of the mock-node program exiting because of an accept() error that actually has happened is that under certain conditions, if the mock node closes the connection, the peer manager might open a TCP connection to it while trying to reconnect but then [close it right after](https://github.com/near/nearcore/blob/f527efeafe915514137099f16db9acef9a172999/chain/network/src/peer_manager/network_state/mod.rs#L479) with `outbound not allowed: already connected to this peer`.

So add a ConnectError::Accept variant and only exit with an error if that is returned, since that would actually mean something is really wrong locally