### PR TITLE
mock-node: Don't time out on receiving messages

### DIFF
--- a/chain/network/src/raw/tests.rs
+++ b/chain/network/src/raw/tests.rs
@@ -40,7 +40,7 @@ async fn test_raw_conn_pings() {
         genesis_id.hash,
         0,
         vec![ShardId::new(0)],
-        time::Duration::SECOND,
+        Some(time::Duration::SECOND),
     )
     .await
     .unwrap();
@@ -101,7 +101,7 @@ async fn test_raw_conn_state_parts() {
         genesis_id.hash,
         0,
         vec![ShardId::new(0)],
-        time::Duration::SECOND,
+        Some(time::Duration::SECOND),
     )
     .await
     .unwrap();
@@ -181,7 +181,7 @@ async fn test_listener() {
         0,
         vec![ShardId::new(0)],
         false,
-        time::Duration::SECOND,
+        Some(time::Duration::SECOND),
         None,
     )
     .await

--- a/tools/mock-node/src/lib.rs
+++ b/tools/mock-node/src/lib.rs
@@ -479,7 +479,7 @@ impl MockNode {
             network_start_height,
             shard_layout.shard_ids().collect(),
             archival,
-            30 * near_time::Duration::SECOND,
+            None,
             handshake_protocol_version,
         )
         .await?;

--- a/tools/ping/src/lib.rs
+++ b/tools/ping/src/lib.rs
@@ -401,7 +401,7 @@ async fn ping_via_node(
         genesis_hash,
         head_height,
         vec![ShardId::new(0)],
-        near_time::Duration::seconds(recv_timeout_seconds.into())).await {
+        Some(near_time::Duration::seconds(recv_timeout_seconds.into()))).await {
         Ok(p) => p,
         Err(ConnectError::HandshakeFailure(reason)) => {
             match reason {

--- a/tools/state-parts/src/lib.rs
+++ b/tools/state-parts/src/lib.rs
@@ -101,7 +101,7 @@ async fn state_parts_from_node(
         genesis_hash,
         head_height,
         vec![ShardId::new(0)],
-        near_time::Duration::seconds(recv_timeout_seconds.into())).await {
+        Some(near_time::Duration::seconds(recv_timeout_seconds.into()))).await {
         Ok(p) => p,
         Err(ConnectError::HandshakeFailure(reason)) => {
             match reason {


### PR DESCRIPTION
There's not a big downside to just waiting, and in the case where a node hasn't sent a message for a while, this probably does indicate something is wrong that we should investigate, but we don't get a lot out of the test just refusing to continue, especially for other connected clients that haven't had any issues