### PR TITLE
mock-node: add an --archival flag

### DIFF
--- a/tools/mock-node/src/main.rs
+++ b/tools/mock-node/src/main.rs
@@ -41,6 +41,9 @@ struct Cli {
     /// Protocol version to advertise in handshakes
     #[clap(long)]
     handshake_protocol_version: Option<ProtocolVersion>,
+    /// If set, advertise that the node is archival in the handshake
+    #[clap(long)]
+    archival: bool,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -68,6 +71,7 @@ fn main() -> anyhow::Result<()> {
             args.network_height,
             args.target_height,
             args.handshake_protocol_version,
+            args.archival,
         )
         .context("failed setting up mock node")?;
 

--- a/tools/mock-node/src/setup.rs
+++ b/tools/mock-node/src/setup.rs
@@ -30,6 +30,7 @@ pub(crate) fn setup_mock_peer(
     target_height: BlockHeight,
     shard_layout: ShardLayout,
     handshake_protocol_version: Option<ProtocolVersion>,
+    archival: bool,
 ) -> tokio::task::JoinHandle<anyhow::Result<()>> {
     let network_start_height = match network_start_height {
         None => target_height,
@@ -39,7 +40,6 @@ pub(crate) fn setup_mock_peer(
     let secret_key = config.network_config.node_key;
     let chain_id = config.genesis.config.chain_id;
     let block_production_delay = config.client_config.min_block_production_delay;
-    let archival = config.client_config.archive;
     let listen_addr = match config.network_config.node_addr {
         Some(a) => a,
         None => tcp::ListenerAddr::new("127.0.0.1".parse().unwrap()),
@@ -76,6 +76,7 @@ pub fn setup_mock_node(
     network_start_height: Option<BlockHeight>,
     target_height: Option<BlockHeight>,
     handshake_protocol_version: Option<ProtocolVersion>,
+    archival: bool,
 ) -> anyhow::Result<tokio::task::JoinHandle<anyhow::Result<()>>> {
     let near_config = nearcore::config::load_config(home_dir, GenesisValidationMode::Full)
         .context("Error loading config")?;
@@ -125,5 +126,6 @@ pub fn setup_mock_node(
         target_height,
         shard_layout,
         handshake_protocol_version,
+        archival,
     ))
 }


### PR DESCRIPTION
When using mock-node to serve requests coming from a neard client, we set .state_sync_enabled=false so that the client only block syncs even if the mock server's head is more than one epoch ahead of the client. But in that case, the node won't actually be able to block sync because after it finished header sync, it will believe that the chunk parts it needs can (only be served by archival peers)[https://github.com/near/nearcore/blob/7436639fda08d7f9a4c5c4b7da2859f1472b52d1/chain/chunks/src/logic.rs#L79] and then won't even send any chunk part requests, even though the mock server is capable of responding to them.

So here we add an --archival flag that will have the mock server call itself archival in the handshake. The current code before this PR will set the archival field of the handshake to whatever the config.json says, but just setting archival=true in config.json won't work, because then the node will believe that it should be opening an archival database and will fail. So this --archival flag will change nothing about the database opening logic, and only affect the handshake so that clients will ask us about old chunks