### PR TITLE
mock-node: use tokio instead of actix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4008,12 +4008,9 @@ dependencies = [
 name = "mock-node"
 version = "0.0.0"
 dependencies = [
- "actix",
- "actix-rt",
  "anyhow",
  "clap",
  "futures",
- "near-actix-test-utils",
  "near-chain",
  "near-chain-configs",
  "near-chunks",

--- a/tools/mock-node/Cargo.toml
+++ b/tools/mock-node/Cargo.toml
@@ -12,8 +12,6 @@ publish = false
 workspace = true
 
 [dependencies]
-actix-rt.workspace = true
-actix.workspace = true
 anyhow.workspace = true
 clap.workspace = true
 futures.workspace = true
@@ -26,7 +24,6 @@ tempfile.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 
-near-actix-test-utils.workspace = true
 near-time.workspace = true
 near-chain.workspace = true
 near-chain-configs.workspace = true

--- a/tools/mock-node/src/lib.rs
+++ b/tools/mock-node/src/lib.rs
@@ -510,7 +510,7 @@ impl MockNode {
                 head_block.clone(),
             );
 
-            actix::spawn(async move {
+            tokio::spawn(async move {
                 if let Err(e) = peer.serve_peer(conn, target_height).await {
                     tracing::error!("error serving requests: {:?}", e);
                 }

--- a/tools/mock-node/src/main.rs
+++ b/tools/mock-node/src/main.rs
@@ -6,7 +6,6 @@
 use anyhow::Context;
 use mock_node::setup::setup_mock_node;
 use mock_node::MockNetworkConfig;
-use near_actix_test_utils::{block_on_interruptible, setup_actix};
 use near_o11y::testonly::init_integration_logger;
 use near_primitives::types::BlockHeight;
 use near_primitives::version::ProtocolVersion;
@@ -60,8 +59,8 @@ fn main() -> anyhow::Result<()> {
         network_config.response_delay = Duration::from_millis(delay);
     }
 
-    let sys = setup_actix();
-    let res = block_on_interruptible(&sys, async move {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let res = runtime.block_on(async move {
         let mock_peer = setup_mock_node(
             home_dir,
             network_config,

--- a/tools/mock-node/src/setup.rs
+++ b/tools/mock-node/src/setup.rs
@@ -44,7 +44,7 @@ pub(crate) fn setup_mock_peer(
         Some(a) => a,
         None => tcp::ListenerAddr::new("127.0.0.1".parse().unwrap()),
     };
-    let mock_peer = actix::spawn(async move {
+    let mock_peer = tokio::spawn(async move {
         let mock = MockNode::new(
             ChainStoreAdapter::new(chain.chain_store().store()),
             epoch_manager,


### PR DESCRIPTION
The actix runtime we were using will spawn all tasks on the same thread, but we want them on different threads, especially for responding to header requests. So just use tokio with the default runtime instead.