### PR TITLE
Set Content-Type: text/plain for /metrics endpoint

### DIFF
--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 use actix_cors::Cors;
-use actix_web::http::header;
+use actix_web::http::header::{self, ContentType};
 use actix_web::HttpRequest;
 use actix_web::{get, http, middleware, web, App, Error as HttpError, HttpResponse, HttpServer};
 pub use api::{RpcFrom, RpcInto, RpcRequest};
@@ -1496,7 +1496,9 @@ pub async fn prometheus_handler() -> Result<HttpResponse, HttpError> {
     encoder.encode(&prometheus::gather(), &mut buffer).unwrap();
 
     match String::from_utf8(buffer) {
-        Ok(text) => Ok(HttpResponse::Ok().body(text)),
+        Ok(text) => Ok(HttpResponse::Ok()
+            .content_type(ContentType("text/plain".parse().unwrap()))
+            .body(text)),
         Err(_) => Ok(HttpResponse::ServiceUnavailable().finish()),
     }
 }


### PR DESCRIPTION
There was a complaint that the `/metrics` endpoint doesn't set `content-type` in the HTTP response.
Let's set it to `text/plain`, as described in the prometheus docs: https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md

Refs: https://near.zulipchat.com/#narrow/channel/308695-nearone.2Fprivate/topic/.E2.9C.94.20Reported.20issue.20with.20telemetry.3F

I manually confirmed that the change sets content-type:

```rust
$ curl -vvv 127.0.0.1:3030/metrics 2>&1 | grep -i content
< content-length: 276846
< content-type: text/plain
```