### PR TITLE
Protocol voting schedule

### DIFF
--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -82,5 +82,20 @@ pub const PROTOCOL_UPGRADE_SCHEDULE: LazyLock<ProtocolUpgradeVotingSchedule> =
         // let schedule = vec![(v1_datetime, v1_protocol_version), (v2_datetime, v2_protocol_version)];
         // ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(PROTOCOL_VERSION, schedule).unwrap()
 
-        ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(PROTOCOL_VERSION, vec![]).unwrap()
+        let v1_protocol_version = 74;
+        let v2_protocol_version = 75;
+        let v3_protocol_version = 76;
+        let v1_datetime =
+            ProtocolUpgradeVotingSchedule::parse_datetime("2025-02-16 18:00:00").unwrap();
+        let v2_datetime =
+            ProtocolUpgradeVotingSchedule::parse_datetime("2025-02-17 18:00:00").unwrap();
+        let v3_datetime =
+            ProtocolUpgradeVotingSchedule::parse_datetime("2025-02-18 18:00:00").unwrap();
+
+        let schedule = vec![
+            (v1_datetime, v1_protocol_version),
+            (v2_datetime, v2_protocol_version),
+            (v3_datetime, v3_protocol_version),
+        ];
+        ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(PROTOCOL_VERSION, schedule).unwrap()
     });


### PR DESCRIPTION
We picked the voting date based on the following epoch start prediction:
```
Predicted start of epoch 13: 2025-02-16 13:53:33 UTC+0000 Sunday
Predicted start of epoch 14: 2025-02-17 01:29:29 UTC+0000 Monday
**Predicted start of epoch 15: 2025-02-17 13:05:25 UTC+0000 Monday**  Protocol upgrade
Predicted start of epoch 16: 2025-02-18 00:41:22 UTC+0000 Tuesday
**Predicted start of epoch 17: 2025-02-18 12:17:18 UTC+0000 Tuesday**   Protocol upgrade
Predicted start of epoch 18: 2025-02-18 23:53:14 UTC+0000 Tuesday
**Predicted start of epoch 19: 2025-02-19 11:29:11 UTC+0000 Wednesday**   Protocol upgrade
Predicted start of epoch 20: 2025-02-19 23:05:07 UTC+0000 Wednesday
Predicted start of epoch 21: 2025-02-20 10:41:03 UTC+0000 Thursday
Predicted start of epoch 22: 2025-02-20 22:17:00 UTC+0000 Thursday
Predicted start of epoch 23: 2025-02-21 09:52:56 UTC+0000 Friday
```