### PR TITLE
state-snapshot: fix protocol version calculation when creating snapshot

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3616,7 +3616,9 @@ impl Chain {
             self.epoch_manager.is_next_block_epoch_start(&head.last_block_hash)?;
         let will_shard_layout_change =
             self.epoch_manager.will_shard_layout_change(&head.last_block_hash)?;
-        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&head.epoch_id)?;
+        let next_block_epoch =
+            self.epoch_manager.get_epoch_id_from_prev_block(&head.last_block_hash)?;
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&next_block_epoch)?;
 
         let tries = self.runtime_adapter.get_tries();
         let snapshot_config = tries.state_snapshot_config();


### PR DESCRIPTION
We want the protocol version of the block after the head block, because if we check the current head's protocol version, then we'll take a snapshot the old way when we see the last block in the epoch before we switch to the current epoch state sync. This did not cause any tests to fail because by itself it is not strictly a bug (although suboptimal) since we'll take another snapshot later when we see the new sync hash in the next epoch. But it triggers a long-standing bug when multiple state snapshot requests are made within a short time, where the state snapshot actor might unlock flat storage updates after the first one is created even though there's another one still to go.