### PR TITLE
fix(state-snapshots): handle multiple incoming requests correctly

### DIFF
--- a/chain/chain/src/flat_storage_resharder.rs
+++ b/chain/chain/src/flat_storage_resharder.rs
@@ -710,7 +710,7 @@ impl FlatStorageResharder {
     /// code a chance to finish first.
     fn coordinate_snapshot(&self, height: BlockHeight) -> bool {
         let manager = self.runtime.get_flat_storage_manager();
-        let Some(min_chunk_prev_height) = manager.snapshot_wanted() else {
+        let Some(min_chunk_prev_height) = manager.snapshot_height_wanted() else {
             return false;
         };
         height >= min_chunk_prev_height

--- a/core/store/src/flat/manager.rs
+++ b/core/store/src/flat/manager.rs
@@ -327,7 +327,7 @@ impl FlatStorageManager {
 
     // Returns Some() if a state snapshot should be taken, and therefore any resharding flat storage code should not advance
     // past the given hash
-    pub fn snapshot_wanted(&self) -> Option<BlockHeight> {
+    pub fn snapshot_height_wanted(&self) -> Option<BlockHeight> {
         let want_snapshot = self.0.want_snapshot.lock().expect(POISONED_LOCK_ERR);
         *want_snapshot
     }

--- a/core/store/src/flat/manager.rs
+++ b/core/store/src/flat/manager.rs
@@ -22,6 +22,12 @@ use super::{
 #[derive(Clone)]
 pub struct FlatStorageManager(Arc<FlatStorageManagerInner>);
 
+/// Stores the reference block hash and min height of all the prev hashes of that block's chunks.
+struct SnapshotBlock {
+    block_hash: CryptoHash,
+    min_chunk_prev_height: BlockHeight,
+}
+
 pub struct FlatStorageManagerInner {
     store: FlatStoreAdapter,
     /// Here we store the flat_storage per shard. The reason why we don't use the same
@@ -35,7 +41,7 @@ pub struct FlatStorageManagerInner {
     flat_storages: Mutex<HashMap<ShardUId, FlatStorage>>,
     /// Set to Some() when there's a state snapshot in progress. Used to signal to the resharding flat
     /// storage catchup code that it shouldn't advance past this block height
-    want_snapshot: Mutex<Option<BlockHeight>>,
+    want_snapshot: Mutex<Option<SnapshotBlock>>,
 }
 
 impl FlatStorageManager {
@@ -299,10 +305,10 @@ impl FlatStorageManager {
 
     /// Should be called when we want to take a state snapshot. Disallows flat head updates, and signals to any resharding
     /// flat storage code that it should not advance beyond this hash
-    pub fn want_snapshot(&self, min_chunk_prev_height: BlockHeight) {
+    pub fn want_snapshot(&self, block_hash: CryptoHash, min_chunk_prev_height: BlockHeight) {
         {
             let mut want_snapshot = self.0.want_snapshot.lock().expect(POISONED_LOCK_ERR);
-            *want_snapshot = Some(min_chunk_prev_height);
+            *want_snapshot = Some(SnapshotBlock { block_hash, min_chunk_prev_height });
         }
         let flat_storages = self.0.flat_storages.lock().expect(POISONED_LOCK_ERR);
         for flat_storage in flat_storages.values() {
@@ -311,11 +317,18 @@ impl FlatStorageManager {
         tracing::debug!(target: "store", "Locked flat head updates");
     }
 
-    /// Should be called when we're done taking a state snapshot. Allows flat head updates, and signals to any resharding
-    /// flat storage code that it can advance now.
-    pub fn snapshot_taken(&self) {
+    /// Should be called when we're done taking a state snapshot. If `block_hash` was the most recently requested snapshot, this
+    /// allows flat head updates, and signals to any resharding flat storage code that it can advance now.
+    pub fn snapshot_taken(&self, block_hash: &CryptoHash) {
         {
             let mut want_snapshot = self.0.want_snapshot.lock().expect(POISONED_LOCK_ERR);
+            if let Some(want) = &*want_snapshot {
+                if &want.block_hash != block_hash {
+                    return;
+                }
+            } else {
+                tracing::warn!(target: "store", %block_hash, "State snapshot being marked as taken without a corresponding pending request set");
+            }
             *want_snapshot = None;
         }
         let flat_storages = self.0.flat_storages.lock().expect(POISONED_LOCK_ERR);
@@ -329,6 +342,12 @@ impl FlatStorageManager {
     // past the given hash
     pub fn snapshot_height_wanted(&self) -> Option<BlockHeight> {
         let want_snapshot = self.0.want_snapshot.lock().expect(POISONED_LOCK_ERR);
-        *want_snapshot
+        want_snapshot.as_ref().map(|s| s.min_chunk_prev_height)
+    }
+
+    // Returns Some() with the corresponding block hash if a state snapshot has been requested
+    pub fn snapshot_hash_wanted(&self) -> Option<CryptoHash> {
+        let want_snapshot = self.0.want_snapshot.lock().expect(POISONED_LOCK_ERR);
+        want_snapshot.as_ref().map(|s| s.block_hash)
     }
 }

--- a/core/store/src/flat/manager.rs
+++ b/core/store/src/flat/manager.rs
@@ -305,6 +305,9 @@ impl FlatStorageManager {
 
     /// Should be called when we want to take a state snapshot. Disallows flat head updates, and signals to any resharding
     /// flat storage code that it should not advance beyond this hash
+    // TODO(#12919): This sets the currently active snapshot request to `block_hash` in favor of any previous requests. We
+    // should modify this to be sure that the correct block hash that will end up on the canonical chain is taken. Right now
+    // we rely on the canonical one being requested after any other forks, which may not be the case.
     pub fn want_snapshot(&self, block_hash: CryptoHash, min_chunk_prev_height: BlockHeight) {
         {
             let mut want_snapshot = self.0.want_snapshot.lock().expect(POISONED_LOCK_ERR);

--- a/core/store/src/flat/storage.rs
+++ b/core/store/src/flat/storage.rs
@@ -495,7 +495,10 @@ impl FlatStorage {
         guard.shard_uid
     }
 
-    /// Updates `move_head_enabled` and returns whether the change was done.
+    /// Updates `move_head_enabled`. If false, this will prevent flat storage updates and deltas will accumulate
+    /// until this is called again with `enabled=true`.
+    /// TODO: This could be improved by setting a maximum block height instead of a bool that disables all updates,
+    /// by using the `want_snapshot` field of the flat storage manager we already have.
     pub fn set_flat_head_update_mode(&self, enabled: bool) {
         let mut guard = self.0.write().expect(crate::flat::POISONED_LOCK_ERR);
         guard.move_head_enabled = enabled;

--- a/integration-tests/src/test_loop/builder.rs
+++ b/integration-tests/src/test_loop/builder.rs
@@ -604,7 +604,6 @@ impl TestLoopBuilder {
             runtime_adapter.get_flat_storage_manager(),
             network_adapter.as_multi_sender(),
             runtime_adapter.get_tries(),
-            state_snapshot_adapter.as_multi_sender(),
         );
 
         let delete_snapshot_callback =

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -351,7 +351,6 @@ pub fn start_with_config_and_synchronization(
         runtime.get_flat_storage_manager(),
         network_adapter.as_multi_sender(),
         runtime.get_tries(),
-        state_snapshot_sender.as_multi_sender(),
     );
     let (state_snapshot_addr, state_snapshot_arbiter) = spawn_actix_actor(state_snapshot_actor);
     state_snapshot_sender.bind(state_snapshot_addr.clone().with_auto_span_context());


### PR DESCRIPTION
The state snapshot actor's logic does not work if several requests come in quick succession. There are a couple problems that this PR fixes.

One is that we first handle a `DeleteAndMaybeCreateSnapshotRequest` message and delete the state snapshot, and then send a `CreateSnapshotRequest` to `Self` that will be handled later. But this means that if several requests come in a period of time shorter than the amount of time it takes to create the state snapshot, several deletions might all run in a row before the corresponding creations run, and the extra state snapshots will not get cleaned up

The second more important problem is that we call `snapshot_taken()` to allow flat storage updates after the snapshot has been created, but this is done even if there have been other snapshot requests in the meantime. So we end up allowing flat head updates when we shouldn't have, and the second snapshot request will take a snapshot of flat storage that's advanced too far in the chain

This was seen recently because it was triggered by the extra snapshot request we generate before https://github.com/near/nearcore/pull/12907, but it has always been possible in theory in the case of a fork. So even with that PR, this is still worth fixing