### PR TITLE
fix(state-snapshots): fix skipped state snapshot after header sync

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3633,11 +3633,7 @@ impl Chain {
                         Ok(SnapshotAction::None)
                     }
                 } else {
-                    let is_sync_prev = crate::state_sync::is_sync_prev_hash(
-                        &self.chain_store.store(),
-                        &head.last_block_hash,
-                        &head.prev_block_hash,
-                    )?;
+                    let is_sync_prev = self.state_sync_adapter.is_sync_prev_hash(&head)?;
                     if is_sync_prev {
                         // Here the head block is the prev block of what the sync hash will be, and the previous
                         // block is the point in the chain we want to snapshot state for

--- a/chain/chain/src/state_sync/adapter.rs
+++ b/chain/chain/src/state_sync/adapter.rs
@@ -9,6 +9,7 @@ use crate::{byzantine_assert, metrics, ReceiptFilter};
 use near_async::time::{Clock, Instant};
 use near_chain_primitives::error::{Error, LogTransientStorageError};
 use near_epoch_manager::EpochManagerAdapter;
+use near_primitives::block::Tip;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{merklize, verify_path};
 use near_primitives::sharding::{
@@ -544,5 +545,10 @@ impl ChainStateSyncAdapter {
 
     pub fn get_requested_state_parts(&self) -> Vec<RequestedStatePartsView> {
         self.requested_state_parts.get_requested_state_parts()
+    }
+
+    /// Returns whether `tip.last_block_hash` is the block that will appear immediately before the "sync_hash" block.
+    pub fn is_sync_prev_hash(&self, tip: &Tip) -> Result<bool, Error> {
+        crate::state_sync::utils::is_sync_prev_hash(&self.chain_store, tip)
     }
 }

--- a/chain/chain/src/state_sync/mod.rs
+++ b/chain/chain/src/state_sync/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) use adapter::ChainStateSyncAdapter;
-pub(crate) use utils::{is_sync_prev_hash, update_sync_hashes};
+pub(crate) use utils::update_sync_hashes;
 
 mod adapter;
 mod state_request_tracker;

--- a/chain/chain/src/state_sync/utils.rs
+++ b/chain/chain/src/state_sync/utils.rs
@@ -1,7 +1,10 @@
 use near_chain_primitives::error::Error;
+use near_primitives::block::Tip;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::EpochId;
 use near_primitives::version::ProtocolFeature;
+use near_store::adapter::chain_store::ChainStoreAdapter;
+use near_store::adapter::StoreAdapter;
 use near_store::{DBCol, Store, StoreUpdate};
 
 use borsh::BorshDeserialize;
@@ -203,10 +206,10 @@ pub(crate) fn update_sync_hashes<T: ChainStoreAccess>(
     on_new_header(chain_store, store_update, header)
 }
 
-///. Returns whether `block_hash` is the block that will appear immediately before the "sync_hash" block. That is,
-/// whether it is going to be the prev_hash of the "sync_hash" block, when it is found.
+/// Returns whether `tip.last_block_hash` is the block that will appear immediately before the "sync_hash" block.
+/// That is, whether it is going to be the prev_hash of the "sync_hash" block, when it is found.
 ///
-/// `block_hash` is the prev_hash of the future "sync_hash" block iff it is the first block for which the
+/// `tip.last_block_hash` is the prev_hash of the future "sync_hash" block iff it is the first block for which the
 /// number of new chunks in the epoch in each shard is at least 2
 ///
 /// This function can only return true before we save the "sync_hash" block to the `StateSyncHashes` column,
@@ -214,19 +217,20 @@ pub(crate) fn update_sync_hashes<T: ChainStoreAccess>(
 ///
 /// This is used when making state snapshots, because in that case we don't need to wait for the "sync_hash"
 /// block to be finalized to take a snapshot of the state as of its prev prev block
-pub(crate) fn is_sync_prev_hash(
-    store: &Store,
-    block_hash: &CryptoHash,
-    prev_hash: &CryptoHash,
-) -> Result<bool, Error> {
-    let Some(new_chunks) = get_state_sync_new_chunks(store, block_hash)? else {
+pub(crate) fn is_sync_prev_hash(chain_store: &ChainStoreAdapter, tip: &Tip) -> Result<bool, Error> {
+    if let Some(sync_hash) = chain_store.get_current_epoch_sync_hash(&tip.epoch_id)? {
+        let sync_header = chain_store.get_block_header(&sync_hash)?;
+        return Ok(sync_header.prev_hash() == &tip.last_block_hash);
+    }
+    let store = chain_store.store_ref();
+    let Some(new_chunks) = get_state_sync_new_chunks(store, &tip.last_block_hash)? else {
         return Ok(false);
     };
     let done = new_chunks.iter().all(|num_chunks| *num_chunks >= 2);
     if !done {
         return Ok(false);
     }
-    let Some(prev_new_chunks) = get_state_sync_new_chunks(store, prev_hash)? else {
+    let Some(prev_new_chunks) = get_state_sync_new_chunks(store, &tip.prev_block_hash)? else {
         return Ok(false);
     };
     let prev_done = prev_new_chunks.iter().all(|num_chunks| *num_chunks >= 2);

--- a/chain/chain/src/state_sync/utils.rs
+++ b/chain/chain/src/state_sync/utils.rs
@@ -218,6 +218,11 @@ pub(crate) fn update_sync_hashes<T: ChainStoreAccess>(
 /// This is used when making state snapshots, because in that case we don't need to wait for the "sync_hash"
 /// block to be finalized to take a snapshot of the state as of its prev prev block
 pub(crate) fn is_sync_prev_hash(chain_store: &ChainStoreAdapter, tip: &Tip) -> Result<bool, Error> {
+    // Usually, if we're returning true from this function, this call to get_current_epoch_sync_hash()
+    // will return None because we're calling it during block preprocessing and the sync hash hasn't been
+    // found yet. But we still need to check this because it's possible that the sync hash was found
+    // during header sync, in which case the contents of the StateSyncNewChunks column will have been cleared,
+    // and the conditions below can't be checked.
     if let Some(sync_hash) = chain_store.get_current_epoch_sync_hash(&tip.epoch_id)? {
         let sync_header = chain_store.get_block_header(&sync_hash)?;
         return Ok(sync_header.prev_hash() == &tip.last_block_hash);


### PR DESCRIPTION
We decide whether to take a snapshot based on the return value of is_sync_prev_hash(), which looks at the StateSyncNewChunks column to tell whether the given hash will be the prev_hash of the sync_hash. But the current logic assumes that this will be called only before the sync hash is actually found, because we clear that column after it is found since the contents are not needed anymore.

This means that if we processed the sync header during header sync instead of during normal block processing, then is_sync_prev_hash() will not return true when it should. We can fix it by just checking if the sync hash is already set before looking at the values in StateSyncNewChunks.