### PR TITLE
fix: set genesis height for mirror

### DIFF
--- a/tools/mirror/src/offline.rs
+++ b/tools/mirror/src/offline.rs
@@ -15,6 +15,7 @@ use near_primitives::types::{AccountId, BlockHeight, TransactionOrReceiptId};
 use near_primitives::views::{
     AccessKeyPermissionView, ExecutionOutcomeWithIdView, QueryRequest, QueryResponseKind,
 };
+use near_store::genesis::initialize_genesis_state;
 use nearcore::{NightshadeRuntime, NightshadeRuntimeExt};
 use std::path::Path;
 use std::sync::Arc;
@@ -41,6 +42,7 @@ impl ChainAccess {
         let node_storage =
             nearcore::open_storage(home.as_ref(), &mut config).context("failed opening storage")?;
         let store = node_storage.get_hot_store();
+        initialize_genesis_state(store.clone(), &config.genesis, Some(home.as_ref()));
         let chain = ChainStore::new(
             store.clone(),
             config.client_config.save_trie_changes,


### PR DESCRIPTION
I recall we discussed some assumption that `initialize_genesis_state` must be called before `ChainStore` is created. This is the case generally but not for the mirror tool.

It fixes the issue of genesis height not set for mirror traffic node launched for the current images.