### PR TITLE
feat(synth-bm): allow multiple account prefixes

### DIFF
--- a/benchmarks/synth-bm/src/account.rs
+++ b/benchmarks/synth-bm/src/account.rs
@@ -36,17 +36,20 @@ pub struct CreateSubAccountsArgs {
     // TODO remove this field and get nonce from rpc
     #[arg(long, default_value_t = 1)]
     pub nonce: u64,
-    /// Optional prefix for sub account names to avoid generating accounts that already exist on
+    /// Optional prefixes for sub account names to avoid generating accounts that already exist on
     /// subsequent invocations.
+    /// Prefixes are separated by commas.
     ///
     /// # Example
     ///
     /// The name of the `i`-th sub account will be:
     ///
-    /// - `user_<i>.<signer_account_id>` if `sub_account_prefix == None`
-    /// - `a_user_<i>.<signer_account_id>` if `sub_account_prefix == Some("a")`
-    #[arg(long)]
-    pub sub_account_prefix: Option<String>,
+    /// - `user_<i>.<signer_account_id>` if `sub_account_prefixes == None`
+    /// - `a_user_<i>.<signer_account_id>` if `sub_account_prefixes == Some("a")`
+    /// - `a_user_<i>.<signer_account_id>,b_user_<i>.<signer_account_id>`
+    ///   if `sub_account_prefixes == Some("a,b")`
+    #[arg(long, alias = "sub_account_prefix")]
+    pub sub_account_prefixes: Option<String>,
     /// Number of sub accounts to create.
     #[arg(long)]
     pub num_sub_accounts: u64,
@@ -210,11 +213,17 @@ pub async fn create_sub_accounts(args: &CreateSubAccountsArgs) -> anyhow::Result
         rpc_response_handler.handle_all_responses().await;
     });
 
+    let prefixes = args
+        .sub_account_prefixes
+        .as_ref()
+        .map(|p| p.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()).collect::<Vec<&str>>());
+
     for i in 0..args.num_sub_accounts {
         let sub_account_key = SecretKey::from_random(KeyType::ED25519);
         let sub_account_id: AccountId = {
             // cspell:words subname
-            let subname = if let Some(prefix) = &args.sub_account_prefix {
+            let subname = if let Some(prefixes) = &prefixes {
+                let prefix = prefixes[(i as usize) % prefixes.len()];
                 format!("{prefix}_user_{i}")
             } else {
                 format!("user_{i}")

--- a/benchmarks/synth-bm/src/account.rs
+++ b/benchmarks/synth-bm/src/account.rs
@@ -48,7 +48,7 @@ pub struct CreateSubAccountsArgs {
     /// - `a_user_<i>.<signer_account_id>` if `sub_account_prefixes == Some("a")`
     /// - `a_user_<i>.<signer_account_id>,b_user_<i>.<signer_account_id>`
     ///   if `sub_account_prefixes == Some("a,b")`
-    #[arg(long, alias = "sub_account_prefix", use_value_delimiter = true)]
+    #[arg(long, alias = "sub-account-prefix", use_value_delimiter = true)]
     pub sub_account_prefixes: Option<Vec<String>>,
     /// Number of sub accounts to create.
     #[arg(long)]

--- a/benchmarks/synth-bm/src/rpc.rs
+++ b/benchmarks/synth-bm/src/rpc.rs
@@ -109,8 +109,19 @@ impl RpcResponseHandler {
                 timer = Some(Instant::now());
             }
 
-            let rpc_response = response.expect("rpc call should succeed");
-            check_tx_response(rpc_response, self.wait_until.clone(), self.response_check_severity);
+            match response {
+                Ok(rpc_response) => {
+                    check_tx_response(
+                        rpc_response,
+                        self.wait_until.clone(),
+                        self.response_check_severity,
+                    );
+                }
+                Err(err) => {
+                    let msg = format!("RPC call failed: {}", err);
+                    warn_or_panic(&msg, self.response_check_severity);
+                }
+            }
         }
 
         if let Some(timer) = timer {


### PR DESCRIPTION
During benchmarking I wanted to spawn txs between different shards, and for that it was convenient to use prefixes in the form `2,c,h,m,x`. Would it make sense in general? I retain `sub_account_prefix` as alias.

Also I had an issue with RPC node crashing: `[2025-02-13T21:19:04Z WARN  near_synth_bm::rpc] RPC call failed: error while sending payload: [error sending request for url (http://34.132.32.11:3030/)]`
However, `response_check_severity` states that we can afford such errors, and it makes sense because they are very rare. So I suggest to use `warn_or_panic` for it as well.