### PR TITLE
forknet: support arbitrary shard layouts

### DIFF
--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -304,7 +304,7 @@ impl ForkNetworkCommand {
                     format!("failed parsing shard layout file at {}", shard_layout_file.display())
                 })?
             }
-            None => shard_layout.clone(),
+            None => shard_layout,
         };
 
         // Flat state can be at different heights for different shards.
@@ -327,8 +327,8 @@ impl ForkNetworkCommand {
 
         // Advance flat heads to the same (max) block height to ensure
         // consistency of state across the shards.
-        let state_roots: Vec<(ShardUId, StateRoot)> = shard_layout
-            .shard_uids()
+        let state_roots: Vec<(ShardUId, StateRoot)> = all_shard_uids
+            .into_iter()
             .map(|shard_uid| {
                 flat_storage_manager.create_flat_storage_for_shard(shard_uid).unwrap();
                 let flat_storage =
@@ -467,13 +467,9 @@ impl ForkNetworkCommand {
         let (prev_state_roots, flat_head, _epoch_id, target_shard_layout) =
             self.get_state_roots_and_hash(store.clone())?;
 
-        let runtime = NightshadeRuntime::from_config(
-            home_dir,
-            store.clone(),
-            &near_config,
-            epoch_manager.clone(),
-        )
-        .context("could not create the transaction runtime")?;
+        let runtime =
+            NightshadeRuntime::from_config(home_dir, store.clone(), &near_config, epoch_manager)
+                .context("could not create the transaction runtime")?;
 
         let runtime_config_store = RuntimeConfigStore::new(None);
         let runtime_config = runtime_config_store.get_config(PROTOCOL_VERSION);

--- a/tools/fork-network/src/storage_mutator.rs
+++ b/tools/fork-network/src/storage_mutator.rs
@@ -8,16 +8,17 @@ use near_primitives::receipt::Receipt;
 use near_primitives::shard_layout::{ShardLayout, ShardUId};
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{
-    AccountId, BlockHeight, ShardId, ShardIndex, StateRoot, StoreKey, StoreValue,
+    AccountId, BlockHeight, ShardIndex, StateChangeCause, StateRoot, StoreKey, StoreValue,
 };
 use near_store::adapter::flat_store::FlatStoreAdapter;
 use near_store::adapter::StoreUpdateAdapter;
 use near_store::flat::{FlatStateChanges, FlatStorageStatus};
+use near_store::trie::update::TrieUpdateResult;
 use near_store::{DBCol, ShardTries};
 use nearcore::NightshadeRuntime;
 
 use anyhow::Context;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 /// Stores the state root and next height we want to pass to apply_memtrie_changes() and delete_until_height()
@@ -32,14 +33,14 @@ struct InProgressRoot {
 
 #[derive(Clone)]
 pub(crate) struct ShardUpdateState {
-    root: Arc<Mutex<InProgressRoot>>,
+    root: Arc<Mutex<Option<InProgressRoot>>>,
 }
 
 impl ShardUpdateState {
     // here we set the given state root as the one we start with, and we set Self::update_height to be
     // one bigger than the highest block height we have flat state for. The reason for this is that the
     // memtries will initially be loaded with nodes referenced by each block height we have deltas for.
-    pub(crate) fn new(
+    fn new(
         flat_store: &FlatStoreAdapter,
         shard_uid: ShardUId,
         state_root: CryptoHash,
@@ -65,33 +66,57 @@ impl ShardUpdateState {
             }
         };
         Ok(Self {
-            root: Arc::new(Mutex::new(InProgressRoot {
+            root: Arc::new(Mutex::new(Some(InProgressRoot {
                 state_root,
                 update_height: max_delta_height + 1,
-            })),
+            }))),
         })
     }
 
-    pub(crate) fn new_sharded(
+    fn new_empty() -> Self {
+        Self { root: Arc::new(Mutex::new(None)) }
+    }
+
+    /// Returns a vec of length equal to the number of shards in `target_shard_layout`,
+    /// indexed by ShardIndex.
+    /// `state_roots` should have ShardUIds belonging to source_shard_layout
+    pub(crate) fn new_update_state(
         flat_store: &FlatStoreAdapter,
-        shard_layout: &ShardLayout,
-        state_roots: HashMap<ShardId, CryptoHash>,
+        source_shard_layout: &ShardLayout,
+        target_shard_layout: &ShardLayout,
+        state_roots: HashMap<ShardUId, CryptoHash>,
     ) -> anyhow::Result<Vec<Self>> {
-        assert_eq!(state_roots.len(), shard_layout.shard_ids().count());
-        let mut update_state = vec![None; state_roots.len()];
-        for (shard_id, state_root) in state_roots {
-            let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, shard_layout);
+        let source_shards = source_shard_layout.shard_uids().collect::<HashSet<_>>();
+        assert_eq!(&source_shards, &state_roots.iter().map(|(k, _v)| *k).collect::<HashSet<_>>());
+        let target_shards = target_shard_layout.shard_uids().collect::<HashSet<_>>();
+        let mut update_state = vec![None; target_shards.len()];
+        for (shard_uid, state_root) in state_roots {
+            if !target_shards.contains(&shard_uid) {
+                continue;
+            }
+
             let state = Self::new(&flat_store, shard_uid, state_root)?;
 
-            let shard_idx = shard_layout.get_shard_index(shard_id).unwrap();
+            let shard_idx = target_shard_layout.get_shard_index(shard_uid.shard_id()).unwrap();
             assert!(update_state[shard_idx].is_none());
             update_state[shard_idx] = Some(state);
         }
+        for shard_uid in target_shards {
+            if source_shards.contains(&shard_uid) {
+                continue;
+            }
+            let state = Self::new_empty();
+
+            let shard_idx = target_shard_layout.get_shard_index(shard_uid.shard_id()).unwrap();
+            assert!(update_state[shard_idx].is_none());
+            update_state[shard_idx] = Some(state);
+        }
+
         Ok(update_state.into_iter().map(|s| s.unwrap()).collect())
     }
 
     pub(crate) fn state_root(&self) -> CryptoHash {
-        self.root.lock().unwrap().state_root
+        self.root.lock().unwrap().as_ref().map_or(CryptoHash::default(), |s| s.state_root)
     }
 }
 
@@ -116,20 +141,38 @@ impl ShardUpdates {
 pub(crate) struct StorageMutator {
     updates: Vec<ShardUpdates>,
     shard_tries: ShardTries,
-    shard_layout: ShardLayout,
+    source_shard_layout: ShardLayout,
+    target_shard_layout: ShardLayout,
+    // For efficiency/convenience
+    target_shards: HashSet<ShardUId>,
+}
+
+struct MappedAccountId {
+    new_account_id: AccountId,
+    source: Option<ShardIndex>,
+    target: ShardIndex,
+    need_rewrite: bool,
 }
 
 impl StorageMutator {
     pub(crate) fn new(
         runtime: &NightshadeRuntime,
         update_state: Vec<ShardUpdateState>,
-        shard_layout: ShardLayout,
+        source_shard_layout: ShardLayout,
+        target_shard_layout: ShardLayout,
     ) -> anyhow::Result<Self> {
         let updates = update_state
             .into_iter()
             .map(|update_state| ShardUpdates { update_state, updates: Vec::new() })
             .collect();
-        Ok(Self { updates, shard_tries: runtime.get_tries(), shard_layout })
+        let target_shards = target_shard_layout.shard_uids().collect();
+        Ok(Self {
+            updates,
+            shard_tries: runtime.get_tries(),
+            source_shard_layout,
+            target_shard_layout,
+            target_shards,
+        })
     }
 
     fn set(&mut self, shard_idx: ShardIndex, key: TrieKey, value: Vec<u8>) -> anyhow::Result<()> {
@@ -151,21 +194,38 @@ impl StorageMutator {
         self.set(shard_idx, TrieKey::Account { account_id }, borsh::to_vec(&value)?)
     }
 
+    fn mapped_account_id(
+        &self,
+        source_shard_uid: ShardUId,
+        account_id: &AccountId,
+    ) -> MappedAccountId {
+        let new_account_id = map_account(&account_id, None);
+        let target_shard_id = self.target_shard_layout.account_id_to_shard_id(&new_account_id);
+        let target = self.target_shard_layout.get_shard_index(target_shard_id).unwrap();
+        let source = if self.target_shards.contains(&source_shard_uid) {
+            Some(self.target_shard_layout.get_shard_index(source_shard_uid.shard_id()).unwrap())
+        } else {
+            None
+        };
+        let need_rewrite = account_id != &new_account_id || source != Some(target);
+        MappedAccountId { new_account_id, source, target, need_rewrite }
+    }
+
     pub(crate) fn map_account(
         &mut self,
-        source_shard_idx: ShardIndex,
+        source_shard_uid: ShardUId,
         account_id: AccountId,
         account: Account,
     ) -> anyhow::Result<()> {
-        let new_account_id = map_account(&account_id, None);
-        let new_shard_id = self.shard_layout.account_id_to_shard_id(&new_account_id);
-        let new_shard_idx = self.shard_layout.get_shard_index(new_shard_id).unwrap();
+        let mapped = self.mapped_account_id(source_shard_uid, &account_id);
 
-        if new_account_id != account_id || source_shard_idx != new_shard_idx {
-            self.remove(source_shard_idx, TrieKey::Account { account_id })?;
+        if mapped.need_rewrite {
+            if let Some(source_shard_idx) = mapped.source {
+                self.remove(source_shard_idx, TrieKey::Account { account_id })?;
+            }
             self.set(
-                new_shard_idx,
-                TrieKey::Account { account_id: new_account_id },
+                mapped.target,
+                TrieKey::Account { account_id: mapped.new_account_id },
                 borsh::to_vec(&account).unwrap(),
             )?;
         }
@@ -174,11 +234,16 @@ impl StorageMutator {
 
     pub(crate) fn remove_access_key(
         &mut self,
-        shard_idx: ShardIndex,
+        source_shard_uid: ShardUId,
         account_id: AccountId,
         public_key: PublicKey,
     ) -> anyhow::Result<()> {
-        self.remove(shard_idx, TrieKey::AccessKey { account_id, public_key })
+        if self.target_shards.contains(&source_shard_uid) {
+            let shard_idx =
+                self.target_shard_layout.get_shard_index(source_shard_uid.shard_id()).unwrap();
+            self.remove(shard_idx, TrieKey::AccessKey { account_id, public_key })?;
+        }
+        Ok(())
     }
 
     pub(crate) fn set_access_key(
@@ -197,23 +262,23 @@ impl StorageMutator {
 
     pub(crate) fn map_data(
         &mut self,
-        source_shard_idx: ShardIndex,
+        source_shard_uid: ShardUId,
         account_id: AccountId,
         data_key: &StoreKey,
         value: StoreValue,
     ) -> anyhow::Result<()> {
-        let new_account_id = map_account(&account_id, None);
-        let new_shard_id = self.shard_layout.account_id_to_shard_id(&new_account_id);
-        let new_shard_idx = self.shard_layout.get_shard_index(new_shard_id).unwrap();
+        let mapped = self.mapped_account_id(source_shard_uid, &account_id);
 
-        if new_account_id != account_id || source_shard_idx != new_shard_idx {
-            self.remove(
-                source_shard_idx,
-                TrieKey::ContractData { account_id, key: data_key.to_vec() },
-            )?;
+        if mapped.need_rewrite {
+            if let Some(source_shard_idx) = mapped.source {
+                self.remove(
+                    source_shard_idx,
+                    TrieKey::ContractData { account_id, key: data_key.to_vec() },
+                )?;
+            }
             self.set(
-                new_shard_idx,
-                TrieKey::ContractData { account_id: new_account_id, key: data_key.to_vec() },
+                mapped.target,
+                TrieKey::ContractData { account_id: mapped.new_account_id, key: data_key.to_vec() },
                 borsh::to_vec(&value)?,
             )?;
         }
@@ -222,28 +287,37 @@ impl StorageMutator {
 
     pub(crate) fn map_code(
         &mut self,
-        source_shard_idx: ShardIndex,
+        source_shard_uid: ShardUId,
         account_id: AccountId,
         value: Vec<u8>,
     ) -> anyhow::Result<()> {
-        let new_account_id = map_account(&account_id, None);
-        let new_shard_id = self.shard_layout.account_id_to_shard_id(&new_account_id);
-        let new_shard_idx = self.shard_layout.get_shard_index(new_shard_id).unwrap();
+        let mapped = self.mapped_account_id(source_shard_uid, &account_id);
 
-        if new_account_id != account_id || source_shard_idx != new_shard_idx {
-            self.remove(source_shard_idx, TrieKey::ContractCode { account_id })?;
-            self.set(new_shard_idx, TrieKey::ContractCode { account_id: new_account_id }, value)?;
+        if mapped.need_rewrite {
+            if let Some(source_shard_idx) = mapped.source {
+                self.remove(source_shard_idx, TrieKey::ContractCode { account_id })?;
+            }
+            self.set(
+                mapped.target,
+                TrieKey::ContractCode { account_id: mapped.new_account_id },
+                value,
+            )?;
         }
         Ok(())
     }
 
     pub(crate) fn remove_postponed_receipt(
         &mut self,
-        shard_idx: ShardIndex,
+        source_shard_uid: ShardUId,
         receiver_id: AccountId,
         receipt_id: CryptoHash,
     ) -> anyhow::Result<()> {
-        self.remove(shard_idx, TrieKey::PostponedReceipt { receiver_id, receipt_id })
+        if self.target_shards.contains(&source_shard_uid) {
+            let shard_idx =
+                self.target_shard_layout.get_shard_index(source_shard_uid.shard_id()).unwrap();
+            self.remove(shard_idx, TrieKey::PostponedReceipt { receiver_id, receipt_id })?;
+        }
+        Ok(())
     }
 
     pub(crate) fn set_postponed_receipt(
@@ -263,23 +337,23 @@ impl StorageMutator {
 
     pub(crate) fn map_received_data(
         &mut self,
-        source_shard_idx: ShardIndex,
+        source_shard_uid: ShardUId,
         account_id: AccountId,
         data_id: CryptoHash,
         data: &Option<Vec<u8>>,
     ) -> anyhow::Result<()> {
-        let new_account_id = map_account(&account_id, None);
-        let new_shard_id = self.shard_layout.account_id_to_shard_id(&new_account_id);
-        let new_shard_idx = self.shard_layout.get_shard_index(new_shard_id).unwrap();
+        let mapped = self.mapped_account_id(source_shard_uid, &account_id);
 
-        if new_account_id != account_id || source_shard_idx != new_shard_idx {
-            self.remove(
-                source_shard_idx,
-                TrieKey::ReceivedData { receiver_id: account_id, data_id },
-            )?;
+        if mapped.need_rewrite {
+            if let Some(source_shard_idx) = mapped.source {
+                self.remove(
+                    source_shard_idx,
+                    TrieKey::ReceivedData { receiver_id: account_id, data_id },
+                )?;
+            }
             self.set(
-                new_shard_idx,
-                TrieKey::ReceivedData { receiver_id: new_account_id, data_id },
+                mapped.target,
+                TrieKey::ReceivedData { receiver_id: mapped.new_account_id, data_id },
                 borsh::to_vec(data)?,
             )?;
         }
@@ -292,38 +366,36 @@ impl StorageMutator {
 
     /// Commits any pending trie changes for all shards
     pub(crate) fn commit(self) -> anyhow::Result<()> {
-        let Self { updates, shard_tries, shard_layout } = self;
+        let Self { updates, shard_tries, target_shard_layout, .. } = self;
 
         for (shard_index, update) in updates.into_iter().enumerate() {
-            let shard_id = shard_layout.get_shard_id(shard_index).unwrap();
-            let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &shard_layout);
+            let shard_id = target_shard_layout.get_shard_id(shard_index).unwrap();
+            let shard_uid = ShardUId::from_shard_id_and_layout(shard_id, &target_shard_layout);
             commit_shard(shard_uid, &shard_tries, &update.update_state, update.updates)?;
         }
         Ok(())
     }
 }
 
-pub(crate) fn commit_shard(
-    shard_uid: ShardUId,
+fn commit_to_existing_state(
     shard_tries: &ShardTries,
-    update_state: &ShardUpdateState,
+    shard_uid: ShardUId,
+    root: &mut InProgressRoot,
     updates: Vec<(TrieKey, Option<Vec<u8>>)>,
 ) -> anyhow::Result<()> {
-    if updates.is_empty() {
-        return Ok(());
-    }
     let updates =
         updates.into_iter().map(|(trie_key, value)| (trie_key.to_vec(), value)).collect::<Vec<_>>();
 
-    let mut root = update_state.root.lock().unwrap();
     let num_updates = updates.len();
     tracing::info!(?shard_uid, num_updates, "commit");
     let flat_state_changes = FlatStateChanges::from_raw_key_value(&updates);
     let mut update = shard_tries.store_update();
     flat_state_changes.apply_to_flat_state(&mut update.flat_store_update(), shard_uid);
 
-    let trie_changes =
-        shard_tries.get_trie_for_shard(shard_uid, root.state_root).update(updates)?;
+    let trie_changes = shard_tries
+        .get_trie_for_shard(shard_uid, root.state_root)
+        .update(updates)
+        .with_context(|| format!("failed updating trie for shard {}", shard_uid))?;
     tracing::info!(
         ?shard_uid,
         num_trie_node_insertions = trie_changes.insertions().len(),
@@ -349,3 +421,74 @@ pub(crate) fn commit_shard(
     tracing::info!(?shard_uid, ?state_root, "Commit is done");
     Ok(())
 }
+
+fn commit_to_new_state(
+    shard_tries: &ShardTries,
+    shard_uid: ShardUId,
+    updates: Vec<(TrieKey, Option<Vec<u8>>)>,
+) -> anyhow::Result<StateRoot> {
+    let num_updates = updates.len();
+    tracing::info!(?shard_uid, num_updates, "commit new");
+
+    let mut trie_update = shard_tries.new_trie_update(shard_uid, StateRoot::default());
+    for (key, value) in updates {
+        match value {
+            Some(value) => trie_update.set(key, value),
+            None => trie_update.remove(key),
+        }
+    }
+    trie_update.commit(StateChangeCause::InitialState);
+    let TrieUpdateResult { trie_changes, state_changes, .. } =
+        trie_update.finalize().with_context(|| {
+            format!("Initial trie update finalization failed for shard {}", shard_uid)
+        })?;
+    let mut store_update = shard_tries.store_update();
+    let state_root = shard_tries.apply_all(&trie_changes, shard_uid, &mut store_update);
+    FlatStateChanges::from_state_changes(&state_changes)
+        .apply_to_flat_state(&mut store_update.flat_store_update(), shard_uid);
+    store_update.store_update().set_ser(
+        DBCol::Misc,
+        format!("FORK_TOOL_SHARD_ID:{}", shard_uid.shard_id).as_bytes(),
+        &state_root,
+    )?;
+    tracing::info!(?shard_uid, "committing initial state to new shard");
+    store_update
+        .commit()
+        .with_context(|| format!("Initial flat storage commit failed for shard {}", shard_uid))?;
+
+    Ok(state_root)
+}
+
+pub(crate) fn commit_shard(
+    shard_uid: ShardUId,
+    // TODO: Don't create the Trie object every time
+    shard_tries: &ShardTries,
+    update_state: &ShardUpdateState,
+    updates: Vec<(TrieKey, Option<Vec<u8>>)>,
+) -> anyhow::Result<()> {
+    if updates.is_empty() {
+        return Ok(());
+    }
+
+    let mut root = update_state.root.lock().unwrap();
+
+    match root.as_mut() {
+        Some(root) => commit_to_existing_state(shard_tries, shard_uid, root, updates)?,
+        None => {
+            let state_root = commit_to_new_state(shard_tries, shard_uid, updates)?;
+            // TODO: load memtrie
+            *root = Some(InProgressRoot { state_root, update_height: 1 });
+        }
+    };
+
+    Ok(())
+}
+
+// After we rewrite everything in the trie to the target shards, remove all state that belongs to
+// source shards not in the target shard layout
+// pub(crate) fn delete_old_shard_state(
+//     shard_tries: &ShardTries,
+//     source_shard_layout: &ShardLayout,
+//     target_shard_layout: &ShardLayout,
+// ) -> anyhow::Result<()> {
+// }

--- a/tools/fork-network/src/storage_mutator.rs
+++ b/tools/fork-network/src/storage_mutator.rs
@@ -523,8 +523,8 @@ pub(crate) fn write_bandwidth_scheduler_state(
     mutator.commit()
 }
 
-// After we rewrite everything in the trie to the target shards, remove all state that belongs to
-// source shards not in the target shard layout, and write flat storage statuses for new shards
+// After we rewrite everything in the trie to the target shards, write flat storage statuses for new shards
+// TODO: remove all state that belongs to source shards not in the target shard layout
 pub(crate) fn finalize_state(
     shard_tries: &ShardTries,
     source_shard_layout: &ShardLayout,

--- a/tools/fork-network/src/storage_mutator.rs
+++ b/tools/fork-network/src/storage_mutator.rs
@@ -117,7 +117,7 @@ impl ShardUpdateState {
     }
 
     pub(crate) fn state_root(&self) -> CryptoHash {
-        self.root.lock().unwrap().as_ref().map_or(CryptoHash::default(), |s| s.state_root)
+        self.root.lock().unwrap().as_ref().map_or_else(CryptoHash::default, |s| s.state_root)
     }
 }
 


### PR DESCRIPTION
We'd like to use forknet with more shards than we have currently on mainnet, or just any arbitrary shard layout. But it won't work to just change the shard layout in the genesis file, since we need to rewrite everything in the tries. So this PR implements support for an optional custom shard layout when generating the state.

To do this, we use the existing `StorageMutator` that keeps a list of updates per shard, and we change it to be aware of which shards belong to the source shard layout and which belong to the target. We still have one thread per source shard, but now it writes state to shards that possibly don't exist in the shard layout.

This also requires writing a new bandwidth scheduler state in each target shard that doesn't exist in the source shard layout