### PR TITLE
bench-synth: Fix the (mis)usage of tokio::select in transactions generator

### DIFF
--- a/benchmarks/transactions-generator/justfile
+++ b/benchmarks/transactions-generator/justfile
@@ -4,12 +4,15 @@ near_localnet_home := script_dir / ".near"
 near_accounts_path := script_dir / "user-data"
 near_config_file := near_localnet_home / "config.json"
 near_genesis_file := near_localnet_home / "genesis.json"
-rpc_url := "http://127.0.0.1:3030"
+rpc_url := "http://127.0.0.1:4040"
 
 
 init-localnet:
     rm -rf {{near_localnet_home}} && rm -rf {{near_accounts_path}}
     {{neard}} --home {{near_localnet_home}} init --chain-id localnet
+    jq '.rpc.addr="0.0.0.0:4040"' {{near_config_file}} > tmp_config.json
+    mv tmp_config.json {{near_config_file}}
+
 
 run-localnet loglevel="info":
     RUST_LOG={{loglevel}} \

--- a/benchmarks/transactions-generator/justfile
+++ b/benchmarks/transactions-generator/justfile
@@ -10,8 +10,8 @@ rpc_url := "http://127.0.0.1:4040"
 init-localnet:
     rm -rf {{near_localnet_home}} && rm -rf {{near_accounts_path}}
     {{neard}} --home {{near_localnet_home}} init --chain-id localnet
-    jq '.rpc.addr="0.0.0.0:4040"' {{near_config_file}} > tmp_config.json
-    mv tmp_config.json {{near_config_file}}
+    jq '.chain_id="benchmarknet"' {{near_genesis_file}} > tmp_genesis.json && mv tmp_genesis.json {{near_genesis_file}}
+    jq '.rpc.addr="0.0.0.0:4040"' {{near_config_file}} > tmp_config.json && mv tmp_config.json {{near_config_file}}
 
 
 run-localnet loglevel="info":
@@ -36,12 +36,11 @@ enable-tx tps:
     mv tmp_config.json {{near_config_file}}
 
 unlimit:
-    jq '.chain_id="benchmarknet" | .gas_limit=20000000000000000' {{near_genesis_file}} > tmp_genesis.json
-    mv tmp_genesis.json {{near_genesis_file}}
+    jq '.gas_limit=20000000000000000' {{near_genesis_file}} > tmp_genesis.json && mv tmp_genesis.json {{near_genesis_file}}
     jq '.view_client_threads=8 \
      | .store.load_mem_tries_for_tracked_shards=true \
-     | .produce_chunk_add_transactions_time_limit={"secs": 0, "nanos": 800000000}' {{near_config_file}} > tmp_config.json
-    mv tmp_config.json {{near_config_file}}
+     | .produce_chunk_add_transactions_time_limit={"secs": 0, "nanos": 800000000}' {{near_config_file}} > tmp_config.json \
+    && mv tmp_config.json {{near_config_file}}
 
 do-it tps:
     just init-localnet

--- a/benchmarks/transactions-generator/readme.md
+++ b/benchmarks/transactions-generator/readme.md
@@ -23,7 +23,8 @@ For a more fine-grained control feel free to dive into the `justfile` for the co
 ...
 2025-02-12T16:42:37.351118Z  INFO stats: #    1584 6nxZon12xBTmARmUm3ngtgaA2K7V9dX1J13EtPZ2kEhe Validator | 1 validator 0 peers ⬇ 0 B/s ⬆ 0 B/s 1.60 bps 131 Tgas/s CPU: 70%, Mem: 2.98 GB
 ...
-2025-02-13T16:42:38.175452Z  INFO transaction-generator: transactions pool_accepted=189571 pool_rejected=2 total_processed=186494 total_failed=0
+2025-02-18T13:04:29.790195Z  INFO transaction-generator: total="Stats { pool_accepted: 158247, pool_rejected: 237, processed: 155338, failed:0 }"
+2025-02-18T13:04:29.790208Z  INFO transaction-generator: diff="Stats { pool_accepted: 6049, pool_rejected: 0, processed: 6439, failed: 0 }"
 ...
 ```
 - see the number of processed transactions in the metrics

--- a/benchmarks/transactions-generator/src/lib.rs
+++ b/benchmarks/transactions-generator/src/lib.rs
@@ -11,6 +11,7 @@ use node_runtime::metrics::TRANSACTION_PROCESSED_SUCCESSFULLY_TOTAL;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::task;
 
@@ -45,7 +46,13 @@ pub struct TxGenerator {
     pub params: TxGeneratorConfig,
     client_sender: ClientSender,
     view_client_sender: ViewClientSender,
-    runner: Option<task::JoinHandle<()>>,
+    runner: Option<(task::JoinHandle<()>, task::JoinHandle<()>, task::JoinHandle<()>)>,
+}
+
+#[derive(Clone)]
+struct RunnerState {
+    block_hash: Arc<std::sync::Mutex<CryptoHash>>,
+    stats: Arc<std::sync::Mutex<Stats>>,
 }
 
 #[derive(Debug, Clone)]
@@ -82,61 +89,31 @@ impl TxGenerator {
         if self.runner.is_some() {
             anyhow::bail!("attempt to (re)start the running transaction generator");
         }
-        // TODO(slavas): generate accounts on the fly?
-        let mut accounts = account::accounts_from_dir(&self.params.accounts_path)?;
-        if accounts.is_empty() {
-            anyhow::bail!("No active accounts available");
-        }
         let client_sender = self.client_sender.clone();
         let view_client_sender = self.view_client_sender.clone();
 
         if self.params.tps == 0 {
             anyhow::bail!("target TPS should be > 0");
         }
-        let mut stats = Stats { pool_accepted: 0, pool_rejected: 0, processed: 0, failed: 0 };
-        let mut stats_prev = stats.clone();
-        let mut tx_interval =
-            tokio::time::interval(Duration::from_micros(1_000_000 / self.params.tps));
-        let mut block_interval = tokio::time::interval(Duration::from_secs(5));
-        let mut report_interval = tokio::time::interval(Duration::from_secs(1));
 
-        let handle = tokio::spawn(async move {
-            let mut rnd: StdRng = SeedableRng::from_entropy();
-            let mut block_hash = CryptoHash::default();
-            tracing::debug!(target: "transaction-generator", "tx generation loop starting");
-            loop {
-                tokio::select! {
-                    _ = tx_interval.tick() => {
-                        Self::generate_send_transaction(
-                            &mut rnd,
-                            &mut accounts,
-                            &block_hash,
-                            &client_sender,
-                            &mut stats).await;
-                    }
-                    _ = block_interval.tick() => {
-                        if let Ok(Ok(block_view)) = view_client_sender.block_request_sender.send_async( GetBlock(BlockReference::latest())).await {
-                             block_hash = block_view.header.hash;
-                             tracing::trace!(target: "transaction-generator",
-                                 block_hash=format!("{block_hash:?}"), "update");
-                        } else {
-                            tracing::warn!(target: "transaction-generator", "block_hash update failed");
-                        }
-                    }
-                    _ = report_interval.tick() => {
-                        stats.processed = TRANSACTION_PROCESSED_SUCCESSFULLY_TOTAL.get();
-                        stats.failed = TRANSACTION_PROCESSED_FAILED_TOTAL.get();
-                        tracing::info!(target: "transaction-generator",
-                            total=format!("{stats:?}"),);
-                        tracing::info!(target: "transaction-generator",
-                            diff=format!("{:?}", stats.clone() - stats_prev),);
-                        stats_prev = stats.clone();
-                    }
-                }
-            }
-        });
+        let runner_state = RunnerState {
+            block_hash: Arc::new(std::sync::Mutex::new(CryptoHash::default())),
+            stats: Arc::new(std::sync::Mutex::new(Stats {
+                pool_accepted: 0,
+                pool_rejected: 0,
+                processed: 0,
+                failed: 0,
+            })),
+        };
 
-        self.runner = Some(handle);
+        let transactions =
+            Self::start_transactions_loop(&self.params, client_sender, runner_state.clone())?;
+
+        let block_updates = Self::start_block_updates(view_client_sender, runner_state.clone());
+
+        let report_updates = Self::start_report_updates(runner_state);
+
+        self.runner = Some((transactions, block_updates, report_updates));
         Ok(())
     }
 
@@ -146,8 +123,7 @@ impl TxGenerator {
         accounts: &mut [account::Account],
         block_hash: &CryptoHash,
         client_sender: &ClientSender,
-        stats: &mut Stats,
-    ) {
+    ) -> bool {
         const AMOUNT: near_primitives::types::Balance = 1_000;
 
         let idx = rand::seq::index::sample(rnd, accounts.len(), 2);
@@ -173,35 +149,100 @@ impl TxGenerator {
             .await
         {
             Ok(res) => match res {
-                ProcessTxResponse::NoResponse => {
-                    stats.pool_rejected += 1;
+                ProcessTxResponse::ValidTx => true,
+                _ => {
                     tracing::debug!(target: "transaction-generator",
-                            processTxRequest="NoResponse", "error");
-                }
-                ProcessTxResponse::ValidTx => {
-                    stats.pool_accepted += 1;
-                }
-                ProcessTxResponse::InvalidTx(err) => {
-                    stats.pool_rejected += 1;
-                    tracing::debug!(target: "transaction-generator",
-                            processTxRequest=format!("{err:?}"), "error");
-                }
-                ProcessTxResponse::RequestRouted => {
-                    stats.pool_rejected += 1;
-                    tracing::debug!(target: "transaction-generator",
-                            processTxRequest="routed", "error");
-                }
-                ProcessTxResponse::DoesNotTrackShard => {
-                    stats.pool_rejected += 1;
-                    tracing::debug!(target: "transaction-generator",
-                            processTxRequest="DoesNotTrackShard", "error");
+                        request_rsp=format!("res?:"));
+                    false
                 }
             },
             Err(err) => {
-                stats.pool_rejected += 1;
                 tracing::debug!(target: "transaction-generator",
-                    processTxRequest=format!("{err}"), "error");
+                    request_err=format!("{err}"), "error");
+                false
             }
         }
     }
-} // impl TxGenerator
+
+    fn start_transactions_loop(
+        params: &TxGeneratorConfig,
+        client_sender: ClientSender,
+        runner_state: RunnerState,
+    ) -> anyhow::Result<task::JoinHandle<()>> {
+        let mut tx_interval = tokio::time::interval(Duration::from_micros(1_000_000 / params.tps));
+        // TODO(slavas): generate accounts on the fly?
+        let mut accounts = account::accounts_from_dir(&params.accounts_path)?;
+        if accounts.is_empty() {
+            anyhow::bail!("No active accounts available");
+        }
+
+        Ok(tokio::spawn(async move {
+            let mut rnd: StdRng = SeedableRng::from_entropy();
+            let block_hash = runner_state.block_hash.clone();
+            loop {
+                tx_interval.tick().await;
+                let block_hash = *block_hash.lock().unwrap();
+                let ok = Self::generate_send_transaction(
+                    &mut rnd,
+                    &mut accounts,
+                    &block_hash,
+                    &client_sender,
+                )
+                .await;
+
+                let mut stats = runner_state.stats.lock().unwrap();
+                if ok {
+                    stats.pool_accepted += 1;
+                } else {
+                    stats.pool_rejected += 1;
+                }
+            }
+        }))
+    }
+
+    fn start_block_updates(
+        view_client_sender: ViewClientSender,
+        runner_state: RunnerState,
+    ) -> task::JoinHandle<()> {
+        let mut block_interval = tokio::time::interval(Duration::from_secs(5));
+        tokio::spawn(async move {
+            loop {
+                block_interval.tick().await;
+                if let Ok(Ok(block_view)) = view_client_sender
+                    .block_request_sender
+                    .send_async(GetBlock(BlockReference::latest()))
+                    .await
+                {
+                    let mut block_hash = runner_state.block_hash.lock().unwrap();
+                    *block_hash = block_view.header.hash;
+                } else {
+                    tracing::warn!(target: "transaction-generator", "block_hash update failed");
+                }
+            }
+        })
+    }
+
+    fn start_report_updates(runner_state: RunnerState) -> task::JoinHandle<()> {
+        let mut report_interval = tokio::time::interval(Duration::from_secs(1));
+        tokio::spawn(async move {
+            let mut stats_prev = runner_state.stats.lock().unwrap().clone();
+            loop {
+                report_interval.tick().await;
+                let stats = {
+                    let processed = TRANSACTION_PROCESSED_SUCCESSFULLY_TOTAL.get();
+                    let failed = TRANSACTION_PROCESSED_FAILED_TOTAL.get();
+
+                    let mut stats = runner_state.stats.lock().unwrap();
+                    stats.processed = processed;
+                    stats.failed = failed;
+                    stats.clone()
+                };
+                tracing::info!(target: "transaction-generator",
+                    total=format!("{stats:?}"),);
+                tracing::info!(target: "transaction-generator",
+                    diff=format!("{:?}", stats.clone() - stats_prev),);
+                stats_prev = stats.clone();
+            }
+        })
+    }
+}

--- a/benchmarks/transactions-generator/src/lib.rs
+++ b/benchmarks/transactions-generator/src/lib.rs
@@ -197,7 +197,7 @@ impl TxGenerator {
             let block_hash = runner_state.block_hash.clone();
             loop {
                 tx_interval.tick().await;
-                let block_hash = block_hash.lock().unwrap().clone();
+                let block_hash = *block_hash.lock().unwrap();
                 let ok = Self::generate_send_transaction(
                     &mut rnd,
                     &mut accounts,


### PR DESCRIPTION
Replaces the tokio::select picking the events from the transaction generation, block hash updates  and reporting sources to all those running in a dedicated tasks to avoid the interference.