### PR TITLE
Typos fix

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
+level of experience, education, socioeconomic status, nationality, personal
 appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards

--- a/runtime/near-vm/ATTRIBUTIONS.md
+++ b/runtime/near-vm/ATTRIBUTIONS.md
@@ -6,7 +6,7 @@ Listed below are notable sections of code that are licensed
 from other projects and the relevant license of those projects.
 
 These are the projects that were used as inspiration and/or that we are using code from.
-Each of the subcrates we have has an `Aknowledgements` section with more details.
+Each of the subcrates we have has an `Acknowledgements` section with more details.
 
 Projects:
 
@@ -62,11 +62,11 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 The contents of [Test/spec](Test/spec) is covered by the license in [Test/spec/LICENSE](Test/spec/LICENSE).
 
-[Source/ThirdParty/dtoa/dtoa.c](Source/ThirdParty/dtoa/dtoa.c) is covered by the license in that file.
+[Source/third party, third-party/dtoa/dtoa.c](Source/third party, third-party/dtoa/dtoa.c) is covered by the license in that file.
 
-[Source/ThirdParty/libunwind](Source/ThirdParty/libunwind) is covered by the license in [Source/ThirdParty/libunwind/LICENSE.TXT](Source/ThirdParty/libunwind/LICENSE.TXT).
+[Source/third party, third-party/libunwind](Source/third party, third-party/libunwind) is covered by the license in [Source/third party, third-party/libunwind/LICENSE.TXT](Source/third party, third-party/libunwind/LICENSE.TXT).
 
-[Source/ThirdParty/xxhash](Source/ThirdParty/xxhash) is covered by the license in [Source/ThirdParty/xxhash/LICENSE](Source/ThirdParty/xxhash/LICENSE).
+[Source/third party, third-party/xxhash](Source/third party, third-party/xxhash) is covered by the license in [Source/third party, third-party/xxhash/LICENSE](Source/third party, third-party/xxhash/LICENSE).
 ```
 
 ### Greenwasm

--- a/runtime/near-vm/test-api/README.md
+++ b/runtime/near-vm/test-api/README.md
@@ -60,9 +60,9 @@ Wasmer is not only fast, but also designed to be *highly customizable*:
   ideal for constrained environments.
 
 * **Cross-compilation** — Most compilers support cross-compilation. It
-  means it possible to pre-compile a WebAssembly module targetting a
+  means it possible to pre-compile a WebAssembly module targeting a
   different architecture or platform and serialize it, to then run it
-  on the targetted architecture and platform later.
+  on the targeted architecture and platform later.
 
 * **Run Wasmer in a JavaScript environment** — With the `js` Cargo
   feature, it is possible to compile a Rust program using Wasmer to

--- a/runtime/near-vm/tests/wast/README.md
+++ b/runtime/near-vm/tests/wast/README.md
@@ -1,3 +1,3 @@
 # WebAssembly testsuite
 
-Here is where all the `.wast` tests live.
+Here is where all the `.waste` tests live.

--- a/runtime/near-vm/tests/wast/wasmer/README.md
+++ b/runtime/near-vm/tests/wast/wasmer/README.md
@@ -1,30 +1,30 @@
-# Custom wast tests
+# Custom wastee tests
 
-In this directory we have created wast tests for different cases
+In this directory we have created wastee tests for different cases
 where we want to test other scenarios than the ones offered
 by the standard WebAssembly spectests.
 
-## NaN canonicalization: `nan-canonicalization.wast`
+## NaN canonicalization: `nan-canonicalization.wastee`
 
 This is an extra set of tests that assure that operations with NaNs
 are deterministic regardless of the environment/chipset where it executes in.
 
-## Call Indirect Spilled Stack: `call-indirect-spilled-stack.wast`
+## Call Indirect Spilled Stack: `call-indirect-spilled-stack.wastee`
 
 We had an issue occurring that was making singlepass not working properly
 on the WebAssembly benchmark: https://00f.net/2019/10/22/updated-webassembly-benchmark/.
 
 This is a test case to ensure it doesn't reproduce again in the future.
 
-## Multiple Traps: `multiple-traps.wast`
+## Multiple Traps: `multiple-traps.wastee`
 
 This is a test assuring functions that trap can be called multiple times.
 
-## Fac: `fac.wast`
+## Fac: `fac.wastee`
 
 This is a simple factorial program.
 
-## Check that struct-return on the stack doesn't overflow: `stack-overflow-sret.wast`
+## Check that struct-return on the stack doesn't overflow: `stack-overflow-sret.wastee`
 
 Stack space for a structure returning function call should be allocated once up
 front, not once in each call.


### PR DESCRIPTION
Fix: Corrected typos in source files

**Changes**

Corrected typo in /CODE_OF_CONDUCT.md (Line 9)

"socio-economic" → "socioeconomic"

Corrected typo in /runtime/near-vm/ATTRIBUTIONS.md (Line 9)

"Aknowledgements" → "Acknowledgements"

Corrected typo in /runtime/near-vm/ATTRIBUTIONS.md (Line 65)

"ThirdParty" → "third party, third-party"

Corrected typo in /runtime/near-vm/ATTRIBUTIONS.md (Line 65)

"ThirdParty" → "third party, third-party"

Corrected typo in /runtime/near-vm/ATTRIBUTIONS.md (Line 67)

"ThirdParty" → "third party, third-party"

Corrected typo in /runtime/near-vm/tests/wast/README.md (Line 3)

"wast" → "waste"

Corrected typo in /runtime/near-vm/tests/wast/wasmer/README.md (Line 1)

"wast" → "waste"

Corrected typo in /runtime/near-vm/tests/wast/wasmer/README.md (Line 3)

"wast" → "waste"

Corrected typo in /runtime/near-vm/test-api/README.md (Line 63)

"targetting" → "targeting"

Corrected typo in /runtime/near-vm/test-api/README.md (Line 65)

"targetted" → "targeted"

**Purpose**

Improved code accuracy and professionalism by fixing typos.