### PR TITLE
bench: unlimit BandwithSchedulerConfig in BENCHMARKNET

### DIFF
--- a/core/parameters/src/config.rs
+++ b/core/parameters/src/config.rs
@@ -283,7 +283,7 @@ pub struct BandwidthSchedulerConfig {
 }
 
 impl BandwidthSchedulerConfig {
-    /// Creates a config that effectively disables BandwithScheduler related limits by setting them
+    /// Creates a config that effectively disables BandwidthScheduler related limits by setting them
     /// to max values. This can be useful for tests and benchmarks.
     pub fn test_disabled() -> Self {
         Self {

--- a/core/parameters/src/config.rs
+++ b/core/parameters/src/config.rs
@@ -281,3 +281,16 @@ pub struct BandwidthSchedulerConfig {
     /// Max value of `base_bandwidth` that is granted on all links by default.
     pub max_base_bandwidth: u64,
 }
+
+impl BandwidthSchedulerConfig {
+    /// Creates a config that effectively disables BandwithScheduler related limits by setting them
+    /// to max values. This can be useful for tests and benchmarks.
+    pub fn test_disabled() -> Self {
+        Self {
+            max_shard_bandwidth: u64::MAX,
+            max_single_grant: u64::MAX,
+            max_allowance: u64::MAX,
+            max_base_bandwidth: u64::MAX,
+        }
+    }
+}

--- a/core/parameters/src/config_store.rs
+++ b/core/parameters/src/config_store.rs
@@ -1,4 +1,6 @@
-use crate::config::{CongestionControlConfig, RuntimeConfig, WitnessConfig};
+use crate::config::{
+    BandwidthSchedulerConfig, CongestionControlConfig, RuntimeConfig, WitnessConfig,
+};
 use crate::parameter_table::{ParameterTable, ParameterTableDiff};
 use crate::vm;
 use near_primitives_core::types::ProtocolVersion;
@@ -180,6 +182,7 @@ impl RuntimeConfigStore {
                 let mut config_store = Self::new(None);
                 let mut config = RuntimeConfig::clone(config_store.get_config(PROTOCOL_VERSION));
                 config.congestion_control_config = CongestionControlConfig::test_disabled();
+                config.bandwidth_scheduler_config = BandwidthSchedulerConfig::test_disabled();
                 config.witness_config = WitnessConfig::test_disabled();
                 let mut wasm_config = vm::Config::clone(&config.wasm_config);
                 wasm_config.limit_config.per_receipt_storage_proof_size_limit = usize::max_value();


### PR DESCRIPTION
`BandwithScheduler` was added quite recently and its config has not yet been unlimited for benchmarknet. Follows the approach to unlimit other configs, e.g. `WitnessConfig`.