### PR TITLE
fix: reduce benchmarknet config values

### DIFF
--- a/core/parameters/src/config.rs
+++ b/core/parameters/src/config.rs
@@ -286,11 +286,14 @@ impl BandwidthSchedulerConfig {
     /// Creates a config that effectively disables BandwidthScheduler related limits by setting them
     /// to max values. This can be useful for tests and benchmarks.
     pub fn test_disabled() -> Self {
+        // Using `u64::MAX` would lead to overflows as these numbers are used in additions and
+        // multiplications. The values below are still high enough to effectively disable limits.
+        let one_tb = 1_000_000_000_000;
         Self {
-            max_shard_bandwidth: u64::MAX,
-            max_single_grant: u64::MAX,
-            max_allowance: u64::MAX,
-            max_base_bandwidth: u64::MAX,
+            max_shard_bandwidth: 100 * one_tb,
+            max_single_grant: one_tb,
+            max_allowance: one_tb,
+            max_base_bandwidth: one_tb,
         }
     }
 }


### PR DESCRIPTION
See [this Zulip thread](https://near.zulipchat.com/#narrow/channel/295306-contract-runtime/topic/master.20broken.20for.20me.20if.20the.20chainid.20is.20set.20to.20.22benchmarknet.22) for reference.