### PR TITLE
forknet: reduce validator name length

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -556,7 +556,7 @@ class NeardRunner:
                     code=-32600,
                     message='Can only call network_init after a call to init')
 
-            if len(validators) < 3:
+            if len(validators) <= 3:
                 with open(self.target_near_home_path('config.json'), 'r') as f:
                     config = json.load(f)
                 config['consensus']['min_num_peers'] = len(validators) - 1

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -371,7 +371,7 @@ class NeardRunner:
                 # the same validator ID. But should be fine for now.
                 # This last part of the hostname should be short, but we truncate it just in case it's not
                 unique_part = host_name.split("-")[-1][:6]
-                validator_id = f'node-{unique_part}.near'
+                validator_id = f'node-{unique_part}'
             cmd += ['--account-id', validator_id]
         else:
             if validator_id is not None:

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -365,7 +365,13 @@ class NeardRunner:
         ]
         if not self.is_traffic_generator():
             if validator_id is None:
-                validator_id = f'{socket.gethostname()}.near'
+                host_name = socket.gethostname()
+                # Note that here we are assuming the last part is the unique part of the name
+                # If that changes for some reason then this will fail because multiple nodes will have
+                # the same validator ID. But should be fine for now.
+                # This last part of the hostname should be short, but we truncate it just in case it's not
+                unique_part = host_name.split("-")[-1][:6]
+                validator_id = f'node-{unique_part}.near'
             cmd += ['--account-id', validator_id]
         else:
             if validator_id is not None:


### PR DESCRIPTION
The hostnames can be quite long, which is inconvenient for creating subaccounts. So here we just take the last unique part of the hostname and use `node-$name.near` as the validator ID