### PR TITLE
[test] Ignore flaky tests causing CI failures

### DIFF
--- a/integration-tests/src/tests/client/bug_repro.rs
+++ b/integration-tests/src/tests/client/bug_repro.rs
@@ -29,6 +29,7 @@ use near_primitives::types::ShardIndex;
 use rand::{Rng, thread_rng};
 
 #[test]
+#[ignore = "Test is flaky and causing CI failures"]
 fn slow_test_repro_1183() {
     init_test_logger();
     run_actix(async {
@@ -273,6 +274,7 @@ fn slow_test_sync_from_archival_node() {
 }
 
 #[test]
+#[ignore = "Test is flaky and causing CI failures"]
 fn slow_test_long_gap_between_blocks() {
     init_test_logger();
     let vs = ValidatorSchedule::new()


### PR DESCRIPTION
These tests have been causing a bit of a headache, very recently I've hit them being flaky a couple of time. One example is [this](https://github.com/near/nearcore/actions/runs/13521612958/job/37781967085) CI merge queue run.

Ignoring the tests while we figure out a solution.