### PR TITLE
test: improve test loop builders

### DIFF
--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -631,6 +631,13 @@ impl EpochConfigStore {
         Self { store }
     }
 
+    pub fn test_single_version(
+        protocol_version: ProtocolVersion,
+        epoch_config: EpochConfig,
+    ) -> Self {
+        Self::test(BTreeMap::from([(protocol_version, Arc::new(epoch_config))]))
+    }
+
     /// Returns the EpochConfig for the given protocol version.
     /// This panics if no config is found for the given version, thus the initialization via `for_chain_id` should
     /// only be performed for chains with some configs stored in files.

--- a/test-loop-tests/src/builder.rs
+++ b/test-loop-tests/src/builder.rs
@@ -1,3 +1,4 @@
+use near_chain_configs::test_genesis::TestGenesisBuilder;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use tempfile::TempDir;
@@ -304,6 +305,12 @@ impl TestLoopBuilder {
             load_memtries_for_tracked_shards: true,
             upgrade_schedule: PROTOCOL_UPGRADE_SCHEDULE.clone(),
         }
+    }
+
+    // Creates TestLoop-compatible genesis builder
+    pub(crate) fn new_genesis_builder() -> TestGenesisBuilder {
+        TestGenesisBuilder::new()
+            .genesis_time_from_clock(&near_async::time::FakeClock::default().clock())
     }
 
     /// Get the clock for the test loop.

--- a/test-loop-tests/src/tests/global_contracts.rs
+++ b/test-loop-tests/src/tests/global_contracts.rs
@@ -1,6 +1,6 @@
 use assert_matches::assert_matches;
 use near_async::time::Duration;
-use near_chain_configs::test_genesis::ValidatorsSpec;
+use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_client::Client;
 use near_client::test_utils::test_loop::ClientQueries;
 use near_o11y::testonly::init_test_logger;
@@ -175,7 +175,7 @@ impl GlobalContractsTestEnv {
         let validators_spec =
             ValidatorsSpec::desired_roles(&block_and_chunk_producers, &chunk_validators_only);
 
-        let (genesis, epoch_config_store) = TestLoopBuilder::new_genesis_builder()
+        let genesis = TestLoopBuilder::new_genesis_builder()
             .validators_spec(validators_spec)
             .shard_layout(shard_layout)
             .add_user_accounts_simple(
@@ -183,7 +183,8 @@ impl GlobalContractsTestEnv {
                 initial_balance,
             )
             .gas_prices(GAS_PRICE, GAS_PRICE)
-            .build_with_simple_epoch_config_store();
+            .build();
+        let epoch_config_store = TestEpochConfigBuilder::build_store_from_genesis(&genesis);
 
         let clients = block_and_chunk_producers
             .iter()

--- a/test-loop-tests/src/tests/global_contracts.rs
+++ b/test-loop-tests/src/tests/global_contracts.rs
@@ -1,17 +1,11 @@
-use std::collections::BTreeMap;
-use std::sync::Arc;
-
 use assert_matches::assert_matches;
 use near_async::time::Duration;
-use near_chain_configs::test_genesis::{
-    TestEpochConfigBuilder, TestGenesisBuilder, ValidatorsSpec,
-};
+use near_chain_configs::test_genesis::ValidatorsSpec;
 use near_client::Client;
 use near_client::test_utils::test_loop::ClientQueries;
 use near_o11y::testonly::init_test_logger;
 use near_parameters::{ActionCosts, RuntimeConfigStore, RuntimeFeesConfig};
 use near_primitives::action::{GlobalContractDeployMode, GlobalContractIdentifier};
-use near_primitives::epoch_manager::EpochConfigStore;
 use near_primitives::errors::{
     ActionError, ActionErrorKind, FunctionCallError, MethodResolveError, TxExecutionError,
 };
@@ -181,24 +175,15 @@ impl GlobalContractsTestEnv {
         let validators_spec =
             ValidatorsSpec::desired_roles(&block_and_chunk_producers, &chunk_validators_only);
 
-        let genesis = TestGenesisBuilder::new()
-            .genesis_time_from_clock(&near_async::time::FakeClock::default().clock())
-            .validators_spec(validators_spec.clone())
-            .shard_layout(shard_layout.clone())
+        let (genesis, epoch_config_store) = TestLoopBuilder::new_genesis_builder()
+            .validators_spec(validators_spec)
+            .shard_layout(shard_layout)
             .add_user_accounts_simple(
                 &[account_shard_0.clone(), account_shard_1.clone(), deploy_account.clone()],
                 initial_balance,
             )
             .gas_prices(GAS_PRICE, GAS_PRICE)
-            .build();
-        let epoch_config = TestEpochConfigBuilder::new()
-            .shard_layout(shard_layout)
-            .validators_spec(validators_spec)
-            .build();
-        let epoch_config_store = EpochConfigStore::test(BTreeMap::from([(
-            genesis.config.protocol_version,
-            Arc::new(epoch_config),
-        )]));
+            .build_with_simple_epoch_config_store();
 
         let clients = block_and_chunk_producers
             .iter()


### PR DESCRIPTION
This PR introduces alternative way to configure genesis and epoch configs for test loop.

Currently the most common way to do that is `build_genesis_and_epoch_config_store`. I have the following issues with it:
* `GenesisAndEpochConfigParams` forces you to set values for parameters even if you are perfectly happy with `TestEpochConfigBuilder` defaults. This pollutes test setup because it is unclear which parameter values actually matter for the tests.
* Callbacks to customise genesis and epoch config builders results in weird inversion of control. Also it just looks cumbersome for simple test setup.

The alternative way is to derive epoch config builder from genesis state and use it directly.
```
        let genesis = TestLoopBuilder::new_genesis_builder()
            .validators_spec(validators_spec.clone())
            .shard_layout(shard_layout.clone())
            .add_user_accounts_simple(..)
            .build();
        let epoch_config_store = TestEpochConfigBuilder::build_store_from_genesis(&genesis);
```
and for more complicated cases where further customisation of epoch config is required:
```
let genesis = TestLoopBuilder::new_genesis_builder()
            .validators_spec(validators_spec.clone())
            .shard_layout(shard_layout.clone())
            .add_user_accounts_simple(..)
            .build().
let epoch_config_store = TestEpochConfigBuilder.from_genesis(&genesis)
            .minimum_validators_per_shard(2)
            .build_store_for_single_version();
```