### PR TITLE
refactor: remove a panic in `process_tx_internal` by refactoring `validate_tx`

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -23,7 +23,7 @@ use near_primitives::hash::{CryptoHash, hash};
 use near_primitives::receipt::{DelayedReceiptIndices, Receipt};
 use near_primitives::runtime::migration_data::{MigrationData, MigrationFlags};
 use near_primitives::sandbox::state_patch::SandboxStatePatch;
-use near_primitives::shard_layout::ShardUId;
+use near_primitives::shard_layout::{ShardLayout, ShardUId};
 use near_primitives::state_part::PartId;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::trie_key::TrieKey;
@@ -155,12 +155,10 @@ impl NightshadeRuntime {
     fn account_id_to_shard_uid(
         &self,
         account_id: &AccountId,
-        epoch_id: &EpochId,
-    ) -> Result<ShardUId, Error> {
-        let epoch_manager = self.epoch_manager.read();
-        let shard_layout = epoch_manager.get_shard_layout(epoch_id)?;
+        shard_layout: &ShardLayout,
+    ) -> ShardUId {
         let shard_id = shard_layout.account_id_to_shard_id(account_id);
-        Ok(ShardUId::from_shard_id_and_layout(shard_id, &shard_layout))
+        ShardUId::from_shard_id_and_layout(shard_id, &shard_layout)
     }
 
     /// Processes state update.
@@ -529,16 +527,21 @@ impl RuntimeAdapter for NightshadeRuntime {
         self.tries.get_flat_storage_manager()
     }
 
+    fn get_shard_layout(&self, epoch_id: &EpochId) -> Result<ShardLayout, Error> {
+        let epoch_manager = self.epoch_manager.read();
+        Ok(epoch_manager.get_shard_layout(epoch_id)?)
+    }
+
     fn validate_tx(
         &self,
         gas_price: Balance,
         state_root: Option<StateRoot>,
+        shard_layout: &ShardLayout,
         transaction: &SignedTransaction,
         verify_signature: bool,
-        epoch_id: &EpochId,
         current_protocol_version: ProtocolVersion,
         receiver_congestion_info: Option<ExtendedCongestionInfo>,
-    ) -> Result<Option<InvalidTxError>, Error> {
+    ) -> Result<(), InvalidTxError> {
         let runtime_config = self.runtime_config_store.get_config(current_protocol_version);
 
         if let Some(congestion_info) = receiver_congestion_info {
@@ -550,8 +553,8 @@ impl RuntimeAdapter for NightshadeRuntime {
             if let ShardAcceptsTransactions::No(reason) =
                 congestion_control.shard_accepts_transactions()
             {
-                let receiver_shard =
-                    self.account_id_to_shard_uid(transaction.transaction.receiver_id(), epoch_id)?;
+                let receiver_shard = self
+                    .account_id_to_shard_uid(transaction.transaction.receiver_id(), &shard_layout);
                 let shard_id = receiver_shard.shard_id;
                 let err = match reason {
                     RejectTransactionReason::IncomingCongestion { congestion_level }
@@ -563,7 +566,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                         InvalidTxError::ShardStuck { shard_id, missed_chunks }
                     }
                 };
-                return Ok(Some(err));
+                return Err(err);
             }
         }
 
@@ -575,12 +578,12 @@ impl RuntimeAdapter for NightshadeRuntime {
             current_protocol_version,
         ) {
             Ok(cost) => cost,
-            Err(e) => return Ok(Some(e)),
+            Err(e) => return Err(e),
         };
 
         if let Some(state_root) = state_root {
             let shard_uid =
-                self.account_id_to_shard_uid(transaction.transaction.signer_id(), epoch_id)?;
+                self.account_id_to_shard_uid(transaction.transaction.signer_id(), &shard_layout);
             let mut state_update = self.tries.new_trie_update(shard_uid, state_root);
 
             match verify_and_charge_transaction(
@@ -593,12 +596,12 @@ impl RuntimeAdapter for NightshadeRuntime {
                 None,
                 current_protocol_version,
             ) {
-                Ok(_) => Ok(None),
-                Err(e) => Ok(Some(e)),
+                Ok(_) => Ok(()),
+                Err(e) => Err(e),
             }
         } else {
             // Without a state root, verification is skipped
-            Ok(None)
+            Ok(())
         }
     }
 

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -996,17 +996,22 @@ impl RuntimeAdapter for KeyValueRuntime {
         Ok(self.tries.get_view_trie_for_shard(ShardUId::new(0, shard_id), state_root))
     }
 
+    fn get_shard_layout(&self, _epoch_id: &EpochId) -> Result<ShardLayout, Error> {
+        #[allow(deprecated)]
+        Ok(ShardLayout::v0(self.num_shards, 0))
+    }
+
     fn validate_tx(
         &self,
         _gas_price: Balance,
         _state_update: Option<StateRoot>,
+        _shard_layout: &ShardLayout,
         _transaction: &SignedTransaction,
         _verify_signature: bool,
-        _epoch_id: &EpochId,
         _current_protocol_version: ProtocolVersion,
         _receiver_congestion_info: Option<ExtendedCongestionInfo>,
-    ) -> Result<Option<InvalidTxError>, Error> {
-        Ok(None)
+    ) -> Result<(), InvalidTxError> {
+        Ok(())
     }
 
     fn prepare_transactions(

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -997,8 +997,7 @@ impl RuntimeAdapter for KeyValueRuntime {
     }
 
     fn get_shard_layout(&self, _epoch_id: &EpochId) -> Result<ShardLayout, Error> {
-        #[allow(deprecated)]
-        Ok(ShardLayout::v0(self.num_shards, 0))
+        Ok(ShardLayout::multi_shard(self.num_shards, 0))
     }
 
     fn validate_tx(

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -23,6 +23,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{MerklePath, merklize};
 use near_primitives::receipt::{PromiseYieldTimeout, Receipt};
 use near_primitives::sandbox::state_patch::SandboxStatePatch;
+use near_primitives::shard_layout::ShardLayout;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::state::PartialState;
 use near_primitives::state_part::PartId;
@@ -425,23 +426,21 @@ pub trait RuntimeAdapter: Send + Sync {
 
     fn get_flat_storage_manager(&self) -> FlatStorageManager;
 
+    fn get_shard_layout(&self, epoch_id: &EpochId) -> Result<ShardLayout, Error>;
+
     /// Validates a given signed transaction.
     /// If the state root is given, then the verification will use the account. Otherwise it will
     /// only validate the transaction math, limits and signatures.
-    /// Returns an option of `InvalidTxError`, it contains `Some(InvalidTxError)` if there is
-    /// a validation error, or `None` in case the transaction succeeded.
-    /// Throws an `Error` with `ErrorKind::StorageError` in case the runtime throws
-    /// `RuntimeError::StorageError`.
     fn validate_tx(
         &self,
         gas_price: Balance,
         state_root: Option<StateRoot>,
+        shard_layout: &ShardLayout,
         transaction: &SignedTransaction,
         verify_signature: bool,
-        epoch_id: &EpochId,
         current_protocol_version: ProtocolVersion,
         receiver_congestion_info: Option<ExtendedCongestionInfo>,
-    ) -> Result<Option<InvalidTxError>, Error>;
+    ) -> Result<(), InvalidTxError>;
 
     /// Returns an ordered list of valid transactions from the pool up the given limits.
     /// Pulls transactions from the given pool iterators one by one. Validates each transaction

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2210,6 +2210,7 @@ impl Client {
         }
         let gas_price = cur_block_header.next_gas_price();
         let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(&head.last_block_hash)?;
+        let shard_layout = self.runtime_adapter.get_shard_layout(&epoch_id)?;
         let receiver_shard = account_id_to_shard_id(
             self.epoch_manager.as_ref(),
             tx.transaction.receiver_id(),
@@ -2219,19 +2220,15 @@ impl Client {
             cur_block.block_congestion_info().get(&receiver_shard).copied();
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
 
-        if let Some(err) = self
-            .runtime_adapter
-            .validate_tx(
-                gas_price,
-                None,
-                tx,
-                true,
-                &epoch_id,
-                protocol_version,
-                receiver_congestion_info,
-            )
-            .expect("no storage errors")
-        {
+        if let Err(err) = self.runtime_adapter.validate_tx(
+            gas_price,
+            None,
+            &shard_layout,
+            tx,
+            true,
+            protocol_version,
+            receiver_congestion_info,
+        ) {
             debug!(target: "client", tx_hash = ?tx.get_hash(), ?err, "Invalid tx during basic validation");
             return Ok(ProcessTxResponse::InvalidTx(err));
         }
@@ -2260,19 +2257,15 @@ impl Client {
                     }
                 }
             };
-            if let Some(err) = self
-                .runtime_adapter
-                .validate_tx(
-                    gas_price,
-                    Some(state_root),
-                    tx,
-                    false,
-                    &epoch_id,
-                    protocol_version,
-                    receiver_congestion_info,
-                )
-                .expect("no storage errors")
-            {
+            if let Err(err) = self.runtime_adapter.validate_tx(
+                gas_price,
+                Some(state_root),
+                &shard_layout,
+                tx,
+                false,
+                protocol_version,
+                receiver_congestion_info,
+            ) {
                 debug!(target: "client", ?err, "Invalid tx");
                 Ok(ProcessTxResponse::InvalidTx(err))
             } else if check_only {


### PR DESCRIPTION
If we pass in the `ShardLayout` to `validate_tx` instead of the `EpochId`, we can simplify what it returns and then remove a panic from `process_tx_internal`.