### PR TITLE
test: remove build_genesis_and_epoch_config_store 

### DIFF
--- a/test-loop-tests/src/tests/chunk_validator_kickout.rs
+++ b/test-loop-tests/src/tests/chunk_validator_kickout.rs
@@ -1,16 +1,14 @@
 use crate::builder::TestLoopBuilder;
 use crate::env::TestLoopEnv;
+use crate::utils::ONE_NEAR;
 use crate::utils::validators::get_epoch_all_validators;
 use itertools::Itertools;
 use near_async::test_loop::data::TestLoopData;
 use near_async::time::Duration;
-use near_chain_configs::test_genesis::{
-    GenesisAndEpochConfigParams, ValidatorsSpec, build_genesis_and_epoch_config_store,
-};
+use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::AccountId;
-use near_primitives::version::PROTOCOL_VERSION;
 
 const NUM_ACCOUNTS: usize = 8;
 const NUM_PRODUCER_ACCOUNTS: usize = 6;
@@ -77,22 +75,17 @@ fn run_test_chunk_validator_kickout(accounts: Vec<AccountId>, test_case: TestCas
     let validators_spec =
         ValidatorsSpec::desired_roles(block_and_chunk_producers, chunk_validators_only);
 
-    let (genesis, epoch_config_store) = build_genesis_and_epoch_config_store(
-        GenesisAndEpochConfigParams {
-            epoch_length,
-            protocol_version: PROTOCOL_VERSION,
-            shard_layout,
-            validators_spec,
-            accounts: &accounts,
-        },
-        |genesis_builder| genesis_builder,
-        |epoch_config_builder| {
-            epoch_config_builder
-                // Set up config to kick out only chunk validators for low performance.
-                .kickouts_for_chunk_validators_only()
-                .target_validator_mandates_per_shard(num_validator_mandates_per_shard)
-        },
-    );
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .epoch_length(epoch_length)
+        .shard_layout(shard_layout)
+        .validators_spec(validators_spec)
+        .add_user_accounts_simple(&accounts, 1_000_000 * ONE_NEAR)
+        .build();
+    let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
+        // Set up config to kick out only chunk validators for low performance.
+        .kickouts_for_chunk_validators_only()
+        .target_validator_mandates_per_shard(num_validator_mandates_per_shard)
+        .build_store_for_single_version(genesis.config.protocol_version);
 
     let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } =
         builder.genesis(genesis).epoch_config_store(epoch_config_store).clients(clients).build();

--- a/test-loop-tests/src/tests/contract_distribution_cross_shard.rs
+++ b/test-loop-tests/src/tests/contract_distribution_cross_shard.rs
@@ -1,12 +1,9 @@
 use itertools::Itertools;
 use near_async::time::Duration;
-use near_chain_configs::test_genesis::{
-    GenesisAndEpochConfigParams, ValidatorsSpec, build_genesis_and_epoch_config_store,
-};
+use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::AccountId;
-use near_primitives::version::PROTOCOL_VERSION;
 use near_vm_runner::ContractCode;
 
 use crate::builder::TestLoopBuilder;
@@ -15,8 +12,8 @@ use crate::utils::contract_distribution::{
     assert_all_chunk_endorsements_received, clear_compiled_contract_caches,
     run_until_caches_contain_contract,
 };
-use crate::utils::get_head_height;
 use crate::utils::transactions::{call_contract, check_txs, deploy_contract, make_accounts};
+use crate::utils::{ONE_NEAR, get_head_height};
 
 const EPOCH_LENGTH: u64 = 10;
 const GENESIS_HEIGHT: u64 = 1000;
@@ -90,23 +87,18 @@ fn setup(accounts: &Vec<AccountId>) -> (TestLoopEnv, AccountId) {
     let validators_spec =
         ValidatorsSpec::desired_roles(&block_and_chunk_producers, &chunk_validators_only);
 
-    let (genesis, epoch_config_store) = build_genesis_and_epoch_config_store(
-        GenesisAndEpochConfigParams {
-            epoch_length: EPOCH_LENGTH,
-            protocol_version: PROTOCOL_VERSION,
-            shard_layout,
-            validators_spec,
-            accounts: &accounts,
-        },
-        |genesis_builder| {
-            genesis_builder.genesis_height(GENESIS_HEIGHT).transaction_validity_period(1000)
-        },
-        |epoch_config_builder| {
-            epoch_config_builder
-                .shuffle_shard_assignment_for_chunk_producers(true)
-                .minimum_validators_per_shard(2)
-        },
-    );
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .epoch_length(EPOCH_LENGTH)
+        .shard_layout(shard_layout)
+        .validators_spec(validators_spec)
+        .add_user_accounts_simple(&accounts, 1_000_000 * ONE_NEAR)
+        .genesis_height(GENESIS_HEIGHT)
+        .transaction_validity_period(1000)
+        .build();
+    let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
+        .shuffle_shard_assignment_for_chunk_producers(true)
+        .minimum_validators_per_shard(2)
+        .build_store_for_single_version(genesis.config.protocol_version);
 
     let env =
         builder.genesis(genesis).epoch_config_store(epoch_config_store).clients(clients).build();

--- a/test-loop-tests/src/tests/create_delete_account.rs
+++ b/test-loop-tests/src/tests/create_delete_account.rs
@@ -1,14 +1,10 @@
 use itertools::Itertools;
 use near_async::futures::{DelayedActionRunner, DelayedActionRunnerExt};
 use near_async::time::Duration;
-use near_chain_configs::test_genesis::{
-    GenesisAndEpochConfigParams, ValidatorsSpec, build_genesis_and_epoch_config_store,
-};
+use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_client::client_actor::ClientActorInner;
 use near_o11y::testonly::init_test_logger;
-use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::AccountId;
-use near_primitives::version::PROTOCOL_VERSION;
 
 use crate::builder::TestLoopBuilder;
 use crate::env::TestLoopEnv;
@@ -77,18 +73,12 @@ fn test_create_delete_account() {
     assert!(tmp.is_empty());
 
     // Build test environment.
-    let (genesis, epoch_config_store) = build_genesis_and_epoch_config_store(
-        GenesisAndEpochConfigParams {
-            epoch_length,
-            protocol_version: PROTOCOL_VERSION,
-            shard_layout: ShardLayout::single_shard(),
-            validators_spec: ValidatorsSpec::desired_roles(&producers, &validators),
-            accounts: &accounts,
-        },
-        |genesis_builder| genesis_builder,
-        |epoch_config_builder| epoch_config_builder,
-    );
-
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .epoch_length(epoch_length)
+        .validators_spec(ValidatorsSpec::desired_roles(&producers, &validators))
+        .add_user_accounts_simple(&accounts, 1_000_000 * ONE_NEAR)
+        .build();
+    let epoch_config_store = TestEpochConfigBuilder::build_store_from_genesis(&genesis);
     let mut env =
         builder.genesis(genesis).epoch_config_store(epoch_config_store).clients(clients).build();
 

--- a/test-loop-tests/src/tests/epoch_sync.rs
+++ b/test-loop-tests/src/tests/epoch_sync.rs
@@ -1,20 +1,18 @@
 use itertools::Itertools;
 use near_async::time::Duration;
-use near_chain_configs::test_genesis::{
-    GenesisAndEpochConfigParams, ValidatorsSpec, build_genesis_and_epoch_config_store,
-};
+use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_chain_configs::{Genesis, GenesisConfig};
 use near_client::test_utils::test_loop::ClientQueries;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::epoch_manager::EpochConfigStore;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::{AccountId, BlockHeightDelta};
-use near_primitives::version::PROTOCOL_VERSION;
 use near_store::{DBCol, Store};
 use tempfile::TempDir;
 
 use crate::builder::TestLoopBuilder;
 use crate::env::TestLoopEnv;
+use crate::utils::ONE_NEAR;
 use crate::utils::transactions::{BalanceMismatchError, execute_money_transfers};
 use near_async::messaging::CanSend;
 use near_chain::{ChainStore, ChainStoreAccess};
@@ -52,23 +50,17 @@ fn setup_initial_blockchain(
     let validators_spec =
         ValidatorsSpec::desired_roles(&clients.iter().map(|t| t.as_str()).collect_vec(), &[]);
 
-    let (genesis, epoch_config_store) = build_genesis_and_epoch_config_store(
-        GenesisAndEpochConfigParams {
-            epoch_length,
-            protocol_version: PROTOCOL_VERSION,
-            shard_layout,
-            validators_spec,
-            accounts: &accounts,
-        },
-        |genesis_builder| {
-            genesis_builder
-                .genesis_height(10000)
-                .transaction_validity_period(transaction_validity_period)
-        },
-        |epoch_config_builder| {
-            epoch_config_builder.shuffle_shard_assignment_for_chunk_producers(true)
-        },
-    );
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .epoch_length(epoch_length)
+        .shard_layout(shard_layout)
+        .validators_spec(validators_spec)
+        .add_user_accounts_simple(&accounts, 1_000_000 * ONE_NEAR)
+        .genesis_height(10000)
+        .transaction_validity_period(transaction_validity_period)
+        .build();
+    let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
+        .shuffle_shard_assignment_for_chunk_producers(true)
+        .build_store_for_single_version(genesis.config.protocol_version);
 
     let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } = builder
         .genesis(genesis.clone())

--- a/test-loop-tests/src/tests/multinode_stateless_validators.rs
+++ b/test-loop-tests/src/tests/multinode_stateless_validators.rs
@@ -3,18 +3,16 @@ use std::collections::HashMap;
 use itertools::Itertools;
 use near_async::messaging::Handler;
 use near_async::time::Duration;
-use near_chain_configs::test_genesis::{
-    GenesisAndEpochConfigParams, ValidatorsSpec, build_genesis_and_epoch_config_store,
-};
+use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_client::{GetValidatorInfo, ViewClientActorInner};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::{AccountId, EpochId, EpochReference};
-use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{CurrentEpochValidatorInfo, EpochValidatorInfo};
 
 use crate::builder::TestLoopBuilder;
 use crate::env::TestLoopEnv;
+use crate::utils::ONE_NEAR;
 use crate::utils::transactions::execute_money_transfers;
 
 const NUM_ACCOUNTS: usize = 20;
@@ -46,21 +44,17 @@ fn slow_test_stateless_validators_with_multi_test_loop() {
     let shard_layout = ShardLayout::simple_v1(&["account3", "account5", "account7"]);
     let validators_spec =
         ValidatorsSpec::desired_roles(&block_and_chunk_producers, &chunk_validators_only);
-
-    let (genesis, epoch_config_store) = build_genesis_and_epoch_config_store(
-        GenesisAndEpochConfigParams {
-            epoch_length: EPOCH_LENGTH,
-            protocol_version: PROTOCOL_VERSION,
-            shard_layout,
-            validators_spec,
-            accounts: &accounts,
-        },
-        |genesis_builder| genesis_builder.genesis_height(10000).transaction_validity_period(1000),
-        |epoch_config_builder| {
-            epoch_config_builder.shuffle_shard_assignment_for_chunk_producers(true)
-        },
-    );
-
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .epoch_length(EPOCH_LENGTH)
+        .shard_layout(shard_layout)
+        .validators_spec(validators_spec)
+        .add_user_accounts_simple(&accounts, 1_000_000 * ONE_NEAR)
+        .genesis_height(10000)
+        .transaction_validity_period(1000)
+        .build();
+    let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
+        .shuffle_shard_assignment_for_chunk_producers(true)
+        .build_store_for_single_version(genesis.config.protocol_version);
     let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } =
         builder.genesis(genesis).epoch_config_store(epoch_config_store).clients(clients).build();
 

--- a/test-loop-tests/src/tests/multinode_test_loop_example.rs
+++ b/test-loop-tests/src/tests/multinode_test_loop_example.rs
@@ -1,16 +1,14 @@
 use itertools::Itertools;
 use near_async::time::Duration;
-use near_chain_configs::test_genesis::{
-    GenesisAndEpochConfigParams, ValidatorsSpec, build_genesis_and_epoch_config_store,
-};
+use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_client::test_utils::test_loop::ClientQueries;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::AccountId;
-use near_primitives::version::PROTOCOL_VERSION;
 
 use crate::builder::TestLoopBuilder;
 use crate::env::TestLoopEnv;
+use crate::utils::ONE_NEAR;
 use crate::utils::transactions::execute_money_transfers;
 
 const NUM_CLIENTS: usize = 4;
@@ -28,21 +26,17 @@ fn slow_test_client_with_multi_test_loop() {
     let shard_layout = ShardLayout::simple_v1(&["account3", "account5", "account7"]);
     let validators_spec =
         ValidatorsSpec::desired_roles(&clients.iter().map(|t| t.as_str()).collect_vec(), &[]);
-
-    let (genesis, epoch_config_store) = build_genesis_and_epoch_config_store(
-        GenesisAndEpochConfigParams {
-            epoch_length,
-            protocol_version: PROTOCOL_VERSION,
-            shard_layout,
-            validators_spec,
-            accounts: &accounts,
-        },
-        |genesis_builder| genesis_builder.genesis_height(10000).transaction_validity_period(1000),
-        |epoch_config_builder| {
-            epoch_config_builder.shuffle_shard_assignment_for_chunk_producers(true)
-        },
-    );
-
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .epoch_length(epoch_length)
+        .shard_layout(shard_layout)
+        .validators_spec(validators_spec)
+        .add_user_accounts_simple(&accounts, 1_000_000 * ONE_NEAR)
+        .genesis_height(10000)
+        .transaction_validity_period(1000)
+        .build();
+    let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
+        .shuffle_shard_assignment_for_chunk_producers(true)
+        .build_store_for_single_version(genesis.config.protocol_version);
     let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } =
         builder.genesis(genesis).epoch_config_store(epoch_config_store).clients(clients).build();
 

--- a/test-loop-tests/src/tests/syncing.rs
+++ b/test-loop-tests/src/tests/syncing.rs
@@ -1,13 +1,12 @@
 use crate::builder::TestLoopBuilder;
 use crate::env::TestLoopEnv;
+use crate::utils::ONE_NEAR;
 use crate::utils::transactions::execute_money_transfers;
 use itertools::Itertools;
 use near_async::messaging::CanSend;
 use near_async::time::Duration;
 use near_chain::ChainStoreAccess;
-use near_chain_configs::test_genesis::{
-    GenesisAndEpochConfigParams, ValidatorsSpec, build_genesis_and_epoch_config_store,
-};
+use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_client::SetNetworkInfo;
 use near_client::test_utils::test_loop::ClientQueries;
 use near_network::types::{HighestHeightPeerInfo, NetworkInfo, PeerInfo};
@@ -15,7 +14,6 @@ use near_o11y::testonly::init_test_logger;
 use near_primitives::block::GenesisId;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::AccountId;
-use near_primitives::version::PROTOCOL_VERSION;
 use near_store::test_utils::create_test_store;
 
 const NUM_CLIENTS: usize = 4;
@@ -35,21 +33,17 @@ fn slow_test_sync_from_genesis() {
     let shard_layout = ShardLayout::simple_v1(&["account3", "account5", "account7"]);
     let validators_spec =
         ValidatorsSpec::desired_roles(&clients.iter().map(|t| t.as_str()).collect_vec(), &[]);
-
-    let (genesis, epoch_config_store) = build_genesis_and_epoch_config_store(
-        GenesisAndEpochConfigParams {
-            epoch_length,
-            protocol_version: PROTOCOL_VERSION,
-            shard_layout,
-            validators_spec,
-            accounts: &accounts,
-        },
-        |genesis_builder| genesis_builder.genesis_height(10000).transaction_validity_period(1000),
-        |epoch_config_builder| {
-            epoch_config_builder.shuffle_shard_assignment_for_chunk_producers(true)
-        },
-    );
-
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .epoch_length(epoch_length)
+        .shard_layout(shard_layout)
+        .validators_spec(validators_spec)
+        .add_user_accounts_simple(&accounts, 1_000_000 * ONE_NEAR)
+        .genesis_height(10000)
+        .transaction_validity_period(1000)
+        .build();
+    let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
+        .shuffle_shard_assignment_for_chunk_producers(true)
+        .build_store_for_single_version(genesis.config.protocol_version);
     let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } = builder
         .genesis(genesis.clone())
         .epoch_config_store(epoch_config_store.clone())


### PR DESCRIPTION
This PR replaces `build_genesis_and_epoch_config_store` with direct usage of builders introduced in #12995.