### PR TITLE
[wip]perf: cache block related data in `ChainStore`

### DIFF
--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -39,6 +39,8 @@ impl fmt::Debug for GCMode {
     }
 }
 
+// TODO add plumbing to clear ChainStoreCache automatically from within gc_col
+
 /// Both functions here are only used for testing as they create convenient
 /// wrappers that allow us to do correctness integration testing without having
 /// to fully spin up GCActor
@@ -672,6 +674,7 @@ impl<'a> ChainStoreUpdate<'a> {
 
         // 3. Delete block_hash-indexed data
         self.gc_col(DBCol::Block, block_hash.as_bytes());
+        self.chain_store.delete_block(&block_hash);
         self.gc_col(DBCol::BlockExtra, block_hash.as_bytes());
         self.gc_col(DBCol::NextBlockHashes, block_hash.as_bytes());
         self.gc_col(DBCol::ChallengedBlocks, block_hash.as_bytes());
@@ -773,6 +776,7 @@ impl<'a> ChainStoreUpdate<'a> {
 
         // 2. Delete block_hash-indexed data
         self.gc_col(DBCol::Block, block_hash.as_bytes());
+        self.chain_store.delete_block(&block_hash);
         self.gc_col(DBCol::BlockExtra, block_hash.as_bytes());
         self.gc_col(DBCol::NextBlockHashes, block_hash.as_bytes());
         self.gc_col(DBCol::ChallengedBlocks, block_hash.as_bytes());

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -311,6 +311,10 @@ impl ChainStoreCache {
         self.blocks.borrow_mut().insert(hash, block);
     }
 
+    fn delete_block(&self, hash: &CryptoHash) {
+        self.blocks.borrow_mut().remove(hash);
+    }
+
     fn block(&self, hash: &CryptoHash) -> Option<Block> {
         self.blocks.borrow().get(hash).cloned()
     }
@@ -333,6 +337,9 @@ impl ChainStore {
         self.cache.set_block(hash, block);
     }
 
+    pub fn delete_block(&mut self, hash: &CryptoHash) {
+        self.cache.delete_block(hash);
+    }
     fn cache_block_header(&mut self, hash: CryptoHash, header: BlockHeader) {
         self.cache.set_block_header(hash, header);
     }
@@ -1202,8 +1209,8 @@ pub(crate) struct ChainStoreCacheUpdate {
 /// Provides layer to update chain without touching the underlying database.
 /// This serves few purposes, main one is that even if executable exists/fails during update the database is in consistent state.
 pub struct ChainStoreUpdate<'a> {
-    // TODO find another way to allow clearing data from cache in garbage_collection.rs
-    pub(crate) chain_store: &'a mut ChainStore,
+    // TODO make private again. pub to facilitate access in garbage_collection.rs
+    pub chain_store: &'a mut ChainStore,
     store_updates: Vec<StoreUpdate>,
     /// Blocks added during this update. Takes ownership (unclear how to not do it because of failure exists).
     pub(crate) chain_store_cache_update: ChainStoreCacheUpdate,

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -285,13 +285,6 @@ pub struct ChainStore {
     pub(super) transaction_validity_period: BlockHeightDelta,
     /// Guarantueed to be updated when storage is updated, so can be considered a source of truth.
     cache: ChainStoreCache,
-
-    // TODO make caches evict oldest blocks when growing above threashold.
-    // Refcell for inner mutability, has traits require getters to take immutable `&self`.
-    /// Blockheaders are indexed by their hash.
-    block_cache: RefCell<HashMap<CryptoHash, Block>>,
-    block_header_cache: RefCell<HashMap<CryptoHash, BlockHeader>>,
-    block_hash_by_height_cache: RefCell<HashMap<BlockHeight, CryptoHash>>,
 }
 
 #[derive(Default)]
@@ -381,9 +374,6 @@ impl ChainStore {
             save_trie_changes,
             transaction_validity_period,
             cache: Default::default(),
-            block_cache: RefCell::new(Default::default()),
-            block_header_cache: RefCell::new(Default::default()),
-            block_hash_by_height_cache: RefCell::new(Default::default()),
         }
     }
 

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -297,9 +297,18 @@ pub struct ChainStore {
 #[derive(Default)]
 pub struct ChainStoreCache {
     // TODO max_distance: u64
+
     // TODO Consider which container to use.
     // Interior mutability will not be required anymore once the apply-range command takes
     // care of populating the cache. See comments below regarding apply-range not calling finalize.
+    //
+    // Why multiple caches?
+    // Different ChainStore queries hit different db columns. E.g. get_block hits DBCol::Block
+    // while get_block_header hits DBCol::BlockHeader. Each column may be treated differently by
+    // ChainStoreUpdate::finalize or in garbage collection. Hence it may happen that for fixed h
+    // cache.block(h).hash() != cache.block_header(h).
+    // This can be demonstrated by changing get_block_header below to return cache.block(h).hash(),
+    // which causes hundreds of tests to fail.
     blocks: RefCell<HashMap<CryptoHash, Block>>,
     block_headers: RefCell<HashMap<CryptoHash, BlockHeader>>,
 }

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -1121,7 +1121,7 @@ impl ChainStoreAccess for ChainStore {
         // Next step: let the apply-range command instead take care of populating the cache,
         // e.g. when or after calling `ChainStore::new` in apply_chain_range.rs
         if let Ok(ref hash) = res {
-            self.cache.set_block_hash_by_height(height, hash.clone());
+            self.cache.set_block_hash_by_height(height, *hash);
         }
         res
     }
@@ -2044,7 +2044,7 @@ impl<'a> ChainStoreUpdate<'a> {
                     .block_hash_per_height
                     .insert(block.header().height(), map);
                 store_update.insert_ser(DBCol::Block, hash.as_ref(), block)?;
-                self.chain_store.cache_block(hash.clone(), block.clone());
+                self.chain_store.cache_block(*hash, block.clone());
             }
             // This is a BTreeMap because the update_sync_hashes() calls below must be done in order of height
             let mut headers_by_height: BTreeMap<BlockHeight, Vec<&BlockHeader>> = BTreeMap::new();
@@ -2055,7 +2055,7 @@ impl<'a> ChainStoreUpdate<'a> {
                 }
                 headers_by_height.entry(header.height()).or_default().push(header);
                 store_update.insert_ser(DBCol::BlockHeader, hash.as_ref(), header)?;
-                self.chain_store.cache_block_header(hash.clone(), header.clone());
+                self.chain_store.cache_block_header(*hash, header.clone());
             }
             for (height, headers) in headers_by_height {
                 let mut hash_set = match self.chain_store.get_all_header_hashes_by_height(height) {
@@ -2159,7 +2159,7 @@ impl<'a> ChainStoreUpdate<'a> {
         for (height, hash) in self.chain_store_cache_update.height_to_hashes.iter() {
             if let Some(hash) = hash {
                 store_update.set_ser(DBCol::BlockHeight, &index_to_bytes(*height), hash)?;
-                self.chain_store.cache_block_header_by_height(*height, hash.clone());
+                self.chain_store.cache_block_header_by_height(*height, *hash);
             } else {
                 store_update.delete(DBCol::BlockHeight, &index_to_bytes(*height));
                 self.chain_store.delete_block_hash_by_height(*height);


### PR DESCRIPTION
`ChainStore` queries currently go to rocksdb, as described in #12997. In particular the queries triggered by `check_transaction_validity_period` account for 21% in the profile.

Currently this PR is a proof of concept to validate and measure performance improvements of adding a cache. On my local workstation I observed the following improvements for `apply-range` with native transfers (vs the recent commit on master this PR is based on):

- With 100 accounts: 29% increase from 60k to 77.5k TPS
- With 10k accounts: 6% increase from 17.1k to 18.2k

### Next steps

- [x] Verify it improves `apply-range` performance
- [ ] Check native-transfer benchmark performance. Due to other bottlenecks it might not lead to an improvement, but at least performance shouldn't degrade.
- [ ] Add metrics for: distance of queried heights to head, cache hits/misses.
- [ ] Run it for a while under synthetic and under mainnet traffic to observe metrics. 
- [ ] Based on observed metrics, pick a cache size/range. Make `ChainStoreUpdate::finalize` trigger cache cleanup.
- [x] Integrate with garbage collection.
  - [ ] Add plumbing to clear caches automatically in `gc_col` 
- [ ] Add/extend tests.
- [ ] Check if there other are scenarios in which block related data may update on disk. If any, make them update/clear the cache.
- [ ] There are more get operations that could use caching (`get_chunk_extra, get_ligth_client_block, ...`). If profiles show they take up a lot of time, consider caching them too.
- [ ] Make the `apply-range` command populate the cache on `ChainStore` construction (it doesn't call `ChainStoreUpdate::finalize`). 