### PR TITLE
refactor: split `validate_tx` into two functions

### DIFF
--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -999,16 +999,24 @@ impl RuntimeAdapter for KeyValueRuntime {
     fn get_shard_layout(&self, _epoch_id: &EpochId) -> Result<ShardLayout, Error> {
         Ok(ShardLayout::multi_shard(self.num_shards, 0))
     }
-
-    fn validate_tx(
+    fn validate_tx_metadata(
         &self,
-        _gas_price: Balance,
-        _state_update: Option<StateRoot>,
         _shard_layout: &ShardLayout,
+        _gas_price: Balance,
         _transaction: &SignedTransaction,
-        _verify_signature: bool,
         _current_protocol_version: ProtocolVersion,
         _receiver_congestion_info: Option<ExtendedCongestionInfo>,
+    ) -> Result<(), InvalidTxError> {
+        Ok(())
+    }
+
+    fn validate_tx_against_state(
+        &self,
+        _shard_layout: &ShardLayout,
+        _gas_price: Balance,
+        _state_root: StateRoot,
+        _transaction: &SignedTransaction,
+        _current_protocol_version: ProtocolVersion,
     ) -> Result<(), InvalidTxError> {
         Ok(())
     }

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -428,18 +428,22 @@ pub trait RuntimeAdapter: Send + Sync {
 
     fn get_shard_layout(&self, epoch_id: &EpochId) -> Result<ShardLayout, Error>;
 
-    /// Validates a given signed transaction.
-    /// If the state root is given, then the verification will use the account. Otherwise it will
-    /// only validate the transaction math, limits and signatures.
-    fn validate_tx(
+    fn validate_tx_metadata(
         &self,
-        gas_price: Balance,
-        state_root: Option<StateRoot>,
         shard_layout: &ShardLayout,
+        gas_price: Balance,
         transaction: &SignedTransaction,
-        verify_signature: bool,
         current_protocol_version: ProtocolVersion,
         receiver_congestion_info: Option<ExtendedCongestionInfo>,
+    ) -> Result<(), InvalidTxError>;
+
+    fn validate_tx_against_state(
+        &self,
+        shard_layout: &ShardLayout,
+        gas_price: Balance,
+        state_root: StateRoot,
+        transaction: &SignedTransaction,
+        current_protocol_version: ProtocolVersion,
     ) -> Result<(), InvalidTxError>;
 
     /// Returns an ordered list of valid transactions from the pool up the given limits.

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2220,12 +2220,10 @@ impl Client {
             cur_block.block_congestion_info().get(&receiver_shard).copied();
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
 
-        if let Err(err) = self.runtime_adapter.validate_tx(
-            gas_price,
-            None,
+        if let Err(err) = self.runtime_adapter.validate_tx_metadata(
             &shard_layout,
+            gas_price,
             tx,
-            true,
             protocol_version,
             receiver_congestion_info,
         ) {
@@ -2258,14 +2256,12 @@ impl Client {
                     }
                 }
             };
-            if let Err(err) = self.runtime_adapter.validate_tx(
-                gas_price,
-                Some(state_root),
+            if let Err(err) = self.runtime_adapter.validate_tx_against_state(
                 &shard_layout,
+                gas_price,
+                state_root,
                 tx,
-                false,
                 protocol_version,
-                receiver_congestion_info,
             ) {
                 debug!(target: "client", ?err, "Invalid tx");
                 return Ok(ProcessTxResponse::InvalidTx(err));


### PR DESCRIPTION
Depending on the args passed to `validate_tx`, it does two different types of checks.  This PR splits them into separate calls so that the code becomes easier to follow.  This will also introduce the new type: `SignatureVerifiedTransaction` that we are aiming to do.  