### PR TITLE
nit: do not keep copying the hash

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2117,8 +2117,8 @@ impl Client {
         if let Some(account_id) = signer.as_ref().map(|bp| bp.validator_id()) {
             validators.remove(account_id);
         }
+        let tx_hash = tx.get_hash();
         for validator in validators {
-            let tx_hash = tx.get_hash();
             trace!(target: "client", me = ?signer.as_ref().map(|bp| bp.validator_id()), ?tx_hash, ?validator, ?shard_id, "Routing a transaction");
 
             // Send message to network to actually forward transaction.


### PR DESCRIPTION
when forwarding the tx, we can just pull the hash once.  Not sure if the compiler would already optimise this away but doesn't hurt to clean up the code.