### PR TITLE
chore(mirror): minor user improvements

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -581,18 +581,18 @@ class NeardRunner:
             with open(self.target_near_home_path('config.json'), 'r') as f:
                 config = json.load(f)
 
-            [key, value] = key_value.split("=", 1)
-            key_item_list = key.split(".")
+            for kv in key_value.split(','):
+                [key, value] = kv.split("=", 1)
+                key_item_list = key.split(".")
 
-            object = config
-            for key_item in key_item_list[:-1]:
-                if key_item not in object:
-                    object[key_item] = {}
-                object = object[key_item]
+                object = config
+                for key_item in key_item_list[:-1]:
+                    if key_item not in object:
+                        object[key_item] = {}
+                    object = object[key_item]
 
-            value = json.loads(value)
-
-            object[key_item_list[-1]] = value
+                value = json.loads(value)
+                object[key_item_list[-1]] = value
 
             with open(self.target_near_home_path('config.json'), 'w') as f:
                 json.dump(config, f, indent=2)

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -75,7 +75,7 @@ def prompt_init_flags(args):
 
 def init_neard_runners(args, traffic_generator, nodes, remove_home_dir=False):
     prompt_init_flags(args)
-    if args.neard_upgrade_binary_url is None:
+    if args.neard_upgrade_binary_url is None or args.neard_upgrade_binary_url == '':
         configs = [{
             "is_traffic_generator": False,
             "binaries": [{


### PR DESCRIPTION
1. Now, if you call init like `mirror init-neard-runner --neard-binary-url $NODE_BINARY_URL --neard-upgrade-binary-url ""`, it won't ask you for upgrade binary url, as it always do.
2. Update config can simply accept many arg changes separated by comma, if you want to update many of them instantly. Calling it multiple times is a waste. 
Example: `mirror update-config --set 'consensus.min_block_production_delay.secs=0,consensus.min_block_production_delay.nanos=600000000,consensus.max_block_production_delay.secs=1,consensus.max_block_production_delay.nanos=800000000,consensus.max_block_wait_delay.secs=6,consensus.max_block_wait_delay.nanos=0`