### PR TITLE
[testloop] Introduce identifier in testloop callback event

### DIFF
--- a/test-loop-tests/src/tests/bandwidth_scheduler.rs
+++ b/test-loop-tests/src/tests/bandwidth_scheduler.rs
@@ -181,7 +181,7 @@ fn run_bandwidth_scheduler_test(scenario: TestScenario, tx_concurrency: usize) -
 
     let client_handle = node_datas[0].client_sender.actor_handle();
     let client_sender = node_datas[0].client_sender.clone();
-    let future_spawner = test_loop.future_spawner();
+    let future_spawner = test_loop.future_spawner("WorkloadGenerator");
 
     // Run the workload for a number of blocks and verify that the bandwidth requests are generated correctly.
     let mut last_height: Option<BlockHeight> = None;

--- a/test-loop-tests/src/tests/simple_test_loop_example.rs
+++ b/test-loop-tests/src/tests/simple_test_loop_example.rs
@@ -96,10 +96,10 @@ fn test_client_with_simple_test_loop() {
         true,
         [0; 32],
         None,
-        Arc::new(test_loop.async_computation_spawner(|_| Duration::milliseconds(80))),
+        Arc::new(test_loop.async_computation_spawner("node0", |_| Duration::milliseconds(80))),
         noop().into_multi_sender(),
         noop().into_multi_sender(),
-        Arc::new(test_loop.future_spawner()),
+        Arc::new(test_loop.future_spawner("node0")),
         noop().into_multi_sender(),
         client_adapter.as_multi_sender(),
         PROTOCOL_UPGRADE_SCHEDULE.clone(),
@@ -133,9 +133,9 @@ fn test_client_with_simple_test_loop() {
     )
     .unwrap();
 
-    test_loop.register_actor(sync_jobs_actor, Some(sync_jobs_adapter));
-    test_loop.register_actor(shards_manager, Some(shards_manager_adapter));
-    test_loop.register_actor(client_actor, Some(client_adapter));
+    test_loop.data.register_actor("node0", sync_jobs_actor, Some(sync_jobs_adapter));
+    test_loop.data.register_actor("node0", shards_manager, Some(shards_manager_adapter));
+    test_loop.data.register_actor("node0", client_actor, Some(client_adapter));
 
     test_loop.run_for(Duration::seconds(10));
     test_loop.shutdown_and_drain_remaining_events(Duration::seconds(1));

--- a/test-loop-tests/src/utils/transactions.rs
+++ b/test-loop-tests/src/utils/transactions.rs
@@ -431,7 +431,7 @@ pub fn run_txs_parallel(
     let mut tx_runners = txs.into_iter().map(|tx| TransactionRunner::new(tx, true)).collect_vec();
 
     let client_sender = &node_datas[0].client_sender;
-    let future_spawner = test_loop.future_spawner();
+    let future_spawner = test_loop.future_spawner("TransactionRunner");
 
     test_loop.run_until(
         |tl_data| {
@@ -461,7 +461,7 @@ pub fn execute_tx(
     maximum_duration: Duration,
 ) -> Result<FinalExecutionOutcomeView, InvalidTxError> {
     let client_sender = &get_node_data(node_datas, rpc_id).client_sender;
-    let future_spawner = test_loop.future_spawner();
+    let future_spawner = test_loop.future_spawner("TransactionRunner");
 
     let mut tx_runner = TransactionRunner::new(tx, true);
 


### PR DESCRIPTION
Within TestLoop framework, we keep a priority queue of events to be executed. As of today there's no way to distinguish events of one client from another.

This PR introduces a new `identifier` field within the event. This is set to be the string representation of `account_id` of the client.

In the future this would be useful to implement node shutdown and restart functionality within TestLoop where we would potentially be able to filter events based on the identifier.

Couple of other cosmetic changes to test loop.