### PR TITLE
refactor: avoid specifying genesis version for TestEpochConfigBuilder::build_store_for_single_version

### DIFF
--- a/integration-tests/src/tests/features/in_memory_tries.rs
+++ b/integration-tests/src/tests/features/in_memory_tries.rs
@@ -433,7 +433,7 @@ fn test_in_memory_trie_consistency_with_state_sync_base_case(track_all_shards: b
         .build();
     let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
         .minimum_validators_per_shard(NUM_VALIDATORS_PER_SHARD as u64)
-        .build_store_for_single_version(genesis.config.protocol_version);
+        .build_store_for_genesis_protocol_version();
 
     let stores = (0..NUM_VALIDATORS).map(|_| create_test_store()).collect::<Vec<_>>();
     let mut env = TestEnv::builder(&genesis.config)

--- a/test-loop-tests/src/tests/chunk_validator_kickout.rs
+++ b/test-loop-tests/src/tests/chunk_validator_kickout.rs
@@ -85,7 +85,7 @@ fn run_test_chunk_validator_kickout(accounts: Vec<AccountId>, test_case: TestCas
         // Set up config to kick out only chunk validators for low performance.
         .kickouts_for_chunk_validators_only()
         .target_validator_mandates_per_shard(num_validator_mandates_per_shard)
-        .build_store_for_single_version(genesis.config.protocol_version);
+        .build_store_for_genesis_protocol_version();
 
     let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } =
         builder.genesis(genesis).epoch_config_store(epoch_config_store).clients(clients).build();

--- a/test-loop-tests/src/tests/congestion_control.rs
+++ b/test-loop-tests/src/tests/congestion_control.rs
@@ -86,7 +86,7 @@ fn setup(accounts: &Vec<AccountId>) -> (TestLoopEnv, AccountId) {
         .build();
     let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
         .shuffle_shard_assignment_for_chunk_producers(true)
-        .build_store_for_single_version(genesis.config.protocol_version);
+        .build_store_for_genesis_protocol_version();
 
     let env = TestLoopBuilder::new()
         .genesis(genesis)

--- a/test-loop-tests/src/tests/congestion_control_genesis_bootstrap.rs
+++ b/test-loop-tests/src/tests/congestion_control_genesis_bootstrap.rs
@@ -41,7 +41,7 @@ fn test_congestion_control_genesis_bootstrap() {
         .build();
     let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
         .minimum_validators_per_shard(1)
-        .build_store_for_single_version(genesis.config.protocol_version);
+        .build_store_for_genesis_protocol_version();
 
     let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } = builder
         .genesis(genesis)

--- a/test-loop-tests/src/tests/contract_distribution_cross_shard.rs
+++ b/test-loop-tests/src/tests/contract_distribution_cross_shard.rs
@@ -98,7 +98,7 @@ fn setup(accounts: &Vec<AccountId>) -> (TestLoopEnv, AccountId) {
     let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
         .shuffle_shard_assignment_for_chunk_producers(true)
         .minimum_validators_per_shard(2)
-        .build_store_for_single_version(genesis.config.protocol_version);
+        .build_store_for_genesis_protocol_version();
 
     let env =
         builder.genesis(genesis).epoch_config_store(epoch_config_store).clients(clients).build();

--- a/test-loop-tests/src/tests/contract_distribution_simple.rs
+++ b/test-loop-tests/src/tests/contract_distribution_simple.rs
@@ -236,7 +236,7 @@ fn setup(accounts: &Vec<AccountId>) -> TestLoopEnv {
         .build();
     let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
         .shuffle_shard_assignment_for_chunk_producers(true)
-        .build_store_for_single_version(genesis.config.protocol_version);
+        .build_store_for_genesis_protocol_version();
 
     let env =
         builder.genesis(genesis).epoch_config_store(epoch_config_store).clients(clients).build();

--- a/test-loop-tests/src/tests/epoch_sync.rs
+++ b/test-loop-tests/src/tests/epoch_sync.rs
@@ -60,7 +60,7 @@ fn setup_initial_blockchain(
         .build();
     let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
         .shuffle_shard_assignment_for_chunk_producers(true)
-        .build_store_for_single_version(genesis.config.protocol_version);
+        .build_store_for_genesis_protocol_version();
 
     let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } = builder
         .genesis(genesis.clone())

--- a/test-loop-tests/src/tests/multinode_stateless_validators.rs
+++ b/test-loop-tests/src/tests/multinode_stateless_validators.rs
@@ -54,7 +54,7 @@ fn slow_test_stateless_validators_with_multi_test_loop() {
         .build();
     let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
         .shuffle_shard_assignment_for_chunk_producers(true)
-        .build_store_for_single_version(genesis.config.protocol_version);
+        .build_store_for_genesis_protocol_version();
     let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } =
         builder.genesis(genesis).epoch_config_store(epoch_config_store).clients(clients).build();
 

--- a/test-loop-tests/src/tests/multinode_test_loop_example.rs
+++ b/test-loop-tests/src/tests/multinode_test_loop_example.rs
@@ -36,7 +36,7 @@ fn slow_test_client_with_multi_test_loop() {
         .build();
     let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
         .shuffle_shard_assignment_for_chunk_producers(true)
-        .build_store_for_single_version(genesis.config.protocol_version);
+        .build_store_for_genesis_protocol_version();
     let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } =
         builder.genesis(genesis).epoch_config_store(epoch_config_store).clients(clients).build();
 

--- a/test-loop-tests/src/tests/syncing.rs
+++ b/test-loop-tests/src/tests/syncing.rs
@@ -43,7 +43,7 @@ fn slow_test_sync_from_genesis() {
         .build();
     let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
         .shuffle_shard_assignment_for_chunk_producers(true)
-        .build_store_for_single_version(genesis.config.protocol_version);
+        .build_store_for_genesis_protocol_version();
     let TestLoopEnv { mut test_loop, datas: node_datas, tempdir } = builder
         .genesis(genesis.clone())
         .epoch_config_store(epoch_config_store.clone())

--- a/test-loop-tests/src/utils/setups.rs
+++ b/test-loop-tests/src/utils/setups.rs
@@ -47,7 +47,7 @@ pub fn standard_setup_1() -> TestLoopEnv {
         .build();
     let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
         .shuffle_shard_assignment_for_chunk_producers(true)
-        .build_store_for_single_version(genesis.config.protocol_version);
+        .build_store_for_genesis_protocol_version();
     TestLoopBuilder::new()
         .genesis(genesis)
         .epoch_config_store(epoch_config_store)


### PR DESCRIPTION
A followup to [this comment](https://github.com/near/nearcore/pull/13004#discussion_r1972728146).
