### PR TITLE
fix: some fixes to check optimistic block

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2388,11 +2388,7 @@ impl Chain {
     }
 
     /// Check if optimistic block is valid and relevant to the current chain.
-    pub fn check_optimistic_block(
-        &self,
-        block: &OptimisticBlock,
-        _peer_id: &PeerId,
-    ) -> Result<(), Error> {
+    pub fn check_optimistic_block(&self, block: &OptimisticBlock) -> Result<(), Error> {
         // Refuse blocks from the too distant future.
         let ob_timestamp =
             OffsetDateTime::from_unix_timestamp_nanos(block.block_timestamp().into())

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -68,7 +68,6 @@ use near_primitives::epoch_block_info::BlockInfo;
 use near_primitives::errors::EpochError;
 use near_primitives::hash::{CryptoHash, hash};
 use near_primitives::merkle::PartialMerkleTree;
-use near_primitives::network::PeerId;
 use near_primitives::optimistic_block::{
     BlockToApply, CachedShardUpdateKey, OptimisticBlock, OptimisticBlockKeySource,
 };

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1038,11 +1038,12 @@ impl Client {
     }
 
     /// Check optimistic block and start processing if is valid.
-    pub fn receive_optimistic_block(&mut self, block: OptimisticBlock, peer_id: PeerId) {
+    pub fn receive_optimistic_block(&mut self, block: OptimisticBlock, peer_id: &PeerId) {
         let _span = debug_span!(target: "client", "receive_optimistic_block").entered();
+        debug!(target: "client", ?block, ?peer_id, "Received optimistic block");
         // Validate the optimistic block.
         // Discard the block if it is old or not created by the right producer.
-        if let Err(e) = self.chain.check_optimistic_block(&block, &peer_id) {
+        if let Err(e) = self.chain.check_optimistic_block(&block) {
             metrics::NUM_INVALID_OPTIMISTIC_BLOCKS.inc();
             debug!(target: "client", ?e, "Optimistic block is invalid");
             return;

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1043,6 +1043,7 @@ impl Client {
         // Validate the optimistic block.
         // Discard the block if it is old or not created by the right producer.
         if let Err(e) = self.chain.check_optimistic_block(&block, &peer_id) {
+            metrics::NUM_INVALID_OPTIMISTIC_BLOCKS.inc();
             debug!(target: "client", ?e, "Optimistic block is invalid");
             return;
         }

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -513,7 +513,7 @@ impl Handler<OptimisticBlockMessage> for ClientActorInner {
         let OptimisticBlockMessage { optimistic_block, from_peer } = msg;
         debug!(target: "client", block_height = optimistic_block.inner.block_height, prev_block_hash = ?optimistic_block.inner.prev_block_hash, ?from_peer, "OptimisticBlockMessage");
 
-        self.client.receive_optimistic_block(optimistic_block, from_peer);
+        self.client.receive_optimistic_block(optimistic_block, &from_peer);
     }
 }
 

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -6,6 +6,14 @@ use near_o11y::metrics::{
 };
 use std::sync::LazyLock;
 
+pub(crate) static NUM_INVALID_OPTIMISTIC_BLOCKS: LazyLock<IntCounter> = LazyLock::new(|| {
+    try_create_int_counter(
+        "near_num_invalid_optimistic_blocks",
+        "Number of invalid optimistic blocks",
+    )
+    .unwrap()
+});
+
 pub(crate) static BLOCK_PRODUCED_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
     try_create_int_counter(
         "near_block_produced_total",

--- a/test-loop-tests/src/tests/optimistic_block.rs
+++ b/test-loop-tests/src/tests/optimistic_block.rs
@@ -70,10 +70,7 @@ fn test_optimistic_block() {
 
 #[cfg(feature = "test_features")]
 /// Create an invalid optimistic block based on the adversarial type.
-fn make_invalid_ob(
-    env: &TestLoopEnv,
-    adv_type: OptimisticBlockAdvType,
-) -> (OptimisticBlock, PeerId) {
+fn make_invalid_ob(env: &TestLoopEnv, adv_type: OptimisticBlockAdvType) -> OptimisticBlock {
     let client = &env.test_loop.data.get(&env.datas[0].client_sender.actor_handle()).client;
 
     let epoch_manager = &client.epoch_manager;
@@ -92,16 +89,13 @@ fn make_invalid_ob(
 
     let validator_signer = client.validator_signer.get().unwrap();
 
-    (
-        OptimisticBlock::adv_produce(
-            &prev_header,
-            height,
-            &*validator_signer,
-            client.clock.clone(),
-            None,
-            adv_type,
-        ),
-        client_data.peer_id.clone(),
+    OptimisticBlock::adv_produce(
+        &prev_header,
+        height,
+        &*validator_signer,
+        client.clock.clone(),
+        None,
+        adv_type,
     )
 }
 
@@ -125,11 +119,11 @@ fn test_invalid_optimistic_block() {
         OptimisticBlockAdvType::InvalidSignature,
     ];
     for adv in adversarial_behaviour.into_iter() {
-        let (ob, peer_id) = make_invalid_ob(&env, adv);
-        assert!(&chain.check_optimistic_block(&ob, &peer_id).is_err());
+        let ob = make_invalid_ob(&env, adv);
+        assert!(&chain.check_optimistic_block(&ob).is_err());
     }
-    let (ob, peer_id) = make_invalid_ob(&env, OptimisticBlockAdvType::Normal);
-    assert!(&chain.check_optimistic_block(&ob, &peer_id).is_ok());
+    let ob = make_invalid_ob(&env, OptimisticBlockAdvType::Normal);
+    assert!(&chain.check_optimistic_block(&ob).is_ok());
 
     env.shutdown_and_drain_remaining_events(Duration::seconds(20));
 }

--- a/test-loop-tests/src/tests/optimistic_block.rs
+++ b/test-loop-tests/src/tests/optimistic_block.rs
@@ -3,8 +3,6 @@ use near_async::time::Duration;
 use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_o11y::testonly::init_test_logger;
 #[cfg(feature = "test_features")]
-use near_primitives::network::PeerId;
-#[cfg(feature = "test_features")]
 use near_primitives::optimistic_block::{OptimisticBlock, OptimisticBlockAdvType};
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::AccountId;

--- a/test-loop-tests/src/tests/optimistic_block.rs
+++ b/test-loop-tests/src/tests/optimistic_block.rs
@@ -130,7 +130,6 @@ fn test_invalid_optimistic_block() {
     }
     let (ob, peer_id) = make_invalid_ob(&env, OptimisticBlockAdvType::Normal);
     assert!(&chain.check_optimistic_block(&ob, &peer_id).is_ok());
-    assert!(&chain.check_optimistic_block(&ob, &PeerId::random()).is_err());
 
     env.shutdown_and_drain_remaining_events(Duration::seconds(20));
 }


### PR DESCRIPTION
It is incorrect to compare `peer_id.public_key() != validator.public_key()` - it rejects all blocks, in fact. Instead, we just check the signature.

Also, add block height check to prevent overflow.

There is still a potential issue that optimistic block can be received and verified many times, but well, it's malicious block producer behaviour which is unlikely.