### PR TITLE
refactor: move `tx_cost` out of `validate_transaction`

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -18,7 +18,7 @@ use near_primitives::apply::ApplyChunkReason;
 use near_primitives::congestion_info::{
     CongestionControl, ExtendedCongestionInfo, RejectTransactionReason, ShardAcceptsTransactions,
 };
-use near_primitives::errors::{InvalidTxError, RuntimeError, StorageError};
+use near_primitives::errors::{IntegerOverflowError, InvalidTxError, RuntimeError, StorageError};
 use near_primitives::hash::{CryptoHash, hash};
 use near_primitives::receipt::{DelayedReceiptIndices, Receipt};
 use near_primitives::runtime::migration_data::{MigrationData, MigrationFlags};
@@ -46,6 +46,7 @@ use near_store::{
 use near_vm_runner::ContractCode;
 use near_vm_runner::{ContractRuntimeCache, precompile_contract};
 use node_runtime::adapter::ViewRuntimeAdapter;
+use node_runtime::config::tx_cost;
 use node_runtime::state_viewer::{TrieViewer, ViewApplyState};
 use node_runtime::{
     ApplyState, Runtime, ValidatorAccountsUpdate, validate_transaction,
@@ -523,10 +524,9 @@ impl RuntimeAdapter for NightshadeRuntime {
         Ok(epoch_manager.get_shard_layout(epoch_id)?)
     }
 
-    fn validate_tx_metadata(
+    fn validate_tx(
         &self,
         shard_layout: &ShardLayout,
-        gas_price: Balance,
         transaction: &SignedTransaction,
         current_protocol_version: ProtocolVersion,
         receiver_congestion_info: Option<ExtendedCongestionInfo>,
@@ -559,11 +559,10 @@ impl RuntimeAdapter for NightshadeRuntime {
             }
         }
 
-        validate_transaction(runtime_config, gas_price, transaction, true, current_protocol_version)
-            .map(|_cost| ())
+        validate_transaction(runtime_config, transaction, current_protocol_version)
     }
 
-    fn validate_tx_against_state(
+    fn can_verify_and_charge_tx(
         &self,
         shard_layout: &ShardLayout,
         gas_price: Balance,
@@ -573,14 +572,8 @@ impl RuntimeAdapter for NightshadeRuntime {
     ) -> Result<(), InvalidTxError> {
         let runtime_config = self.runtime_config_store.get_config(current_protocol_version);
 
-        let cost = validate_transaction(
-            runtime_config,
-            gas_price,
-            transaction,
-            false,
-            current_protocol_version,
-        )?;
-
+        let cost =
+            tx_cost(runtime_config, &transaction.transaction, gas_price, current_protocol_version)?;
         let shard_uid = shard_layout.account_id_to_shard_uid(transaction.transaction.signer_id());
         let mut state_update = self.tries.new_trie_update(shard_uid, state_root);
 
@@ -770,23 +763,26 @@ impl RuntimeAdapter for NightshadeRuntime {
                     continue;
                 }
 
-                let verify_result = validate_transaction(
-                    runtime_config,
-                    prev_block.next_gas_price,
-                    &tx,
-                    true,
-                    protocol_version,
-                )
-                .and_then(|cost| {
-                    verify_and_charge_transaction(
-                        runtime_config,
-                        &mut state_update,
-                        &tx,
-                        &cost,
-                        Some(next_block_height),
-                        protocol_version,
-                    )
-                });
+                let verify_result = validate_transaction(runtime_config, &tx, protocol_version)
+                    .and_then(|()| {
+                        tx_cost(
+                            runtime_config,
+                            &tx.transaction,
+                            prev_block.next_gas_price,
+                            protocol_version,
+                        )
+                        .map_err(|e: IntegerOverflowError| e.into())
+                        .and_then(|cost| {
+                            verify_and_charge_transaction(
+                                runtime_config,
+                                &mut state_update,
+                                &tx,
+                                &cost,
+                                Some(next_block_height),
+                                protocol_version,
+                            )
+                        })
+                    });
 
                 match verify_result {
                     Ok(cost) => {

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -999,10 +999,9 @@ impl RuntimeAdapter for KeyValueRuntime {
     fn get_shard_layout(&self, _epoch_id: &EpochId) -> Result<ShardLayout, Error> {
         Ok(ShardLayout::multi_shard(self.num_shards, 0))
     }
-    fn validate_tx_metadata(
+    fn validate_tx(
         &self,
         _shard_layout: &ShardLayout,
-        _gas_price: Balance,
         _transaction: &SignedTransaction,
         _current_protocol_version: ProtocolVersion,
         _receiver_congestion_info: Option<ExtendedCongestionInfo>,
@@ -1010,7 +1009,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         Ok(())
     }
 
-    fn validate_tx_against_state(
+    fn can_verify_and_charge_tx(
         &self,
         _shard_layout: &ShardLayout,
         _gas_price: Balance,

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -436,6 +436,10 @@ pub trait RuntimeAdapter: Send + Sync {
         receiver_congestion_info: Option<ExtendedCongestionInfo>,
     ) -> Result<(), InvalidTxError>;
 
+    /// It is assumed that this function is only called if `validate_tx` was
+    /// called successfully earlier. TODO: introduce some type safety to ensure
+    /// that this function can only be called if `validate_tx` was successfully
+    /// called.
     fn can_verify_and_charge_tx(
         &self,
         shard_layout: &ShardLayout,

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -428,16 +428,15 @@ pub trait RuntimeAdapter: Send + Sync {
 
     fn get_shard_layout(&self, epoch_id: &EpochId) -> Result<ShardLayout, Error>;
 
-    fn validate_tx_metadata(
+    fn validate_tx(
         &self,
         shard_layout: &ShardLayout,
-        gas_price: Balance,
         transaction: &SignedTransaction,
         current_protocol_version: ProtocolVersion,
         receiver_congestion_info: Option<ExtendedCongestionInfo>,
     ) -> Result<(), InvalidTxError>;
 
-    fn validate_tx_against_state(
+    fn can_verify_and_charge_tx(
         &self,
         shard_layout: &ShardLayout,
         gas_price: Balance,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2227,9 +2227,8 @@ impl Client {
             cur_block.block_congestion_info().get(&receiver_shard).copied();
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
 
-        if let Err(err) = self.runtime_adapter.validate_tx_metadata(
+        if let Err(err) = self.runtime_adapter.validate_tx(
             &shard_layout,
-            gas_price,
             tx,
             protocol_version,
             receiver_congestion_info,
@@ -2263,7 +2262,7 @@ impl Client {
                     }
                 }
             };
-            if let Err(err) = self.runtime_adapter.validate_tx_against_state(
+            if let Err(err) = self.runtime_adapter.can_verify_and_charge_tx(
                 &shard_layout,
                 gas_price,
                 state_root,

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -613,6 +613,7 @@ mod tests {
     use near_crypto::{InMemorySigner, KeyType, PublicKey, Signature, Signer};
     use near_primitives::account::{AccessKey, AccountContract, FunctionCallPermission};
     use near_primitives::action::delegate::{DelegateAction, NonDelegateAction};
+    use near_primitives::errors::IntegerOverflowError;
     use near_primitives::hash::{CryptoHash, hash};
     use near_primitives::receipt::ReceiptPriority;
     use near_primitives::test_utils::account_new;
@@ -749,7 +750,7 @@ mod tests {
             match tx_cost(config, &signed_transaction.transaction, gas_price, PROTOCOL_VERSION) {
                 Ok(c) => c,
                 Err(err) => {
-                    assert_eq!(err, expected_err);
+                    assert_eq!(InvalidTxError::from(err), expected_err);
                     return;
                 }
             };

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -1,5 +1,5 @@
 use crate::VerificationResult;
-use crate::config::{TransactionCost, total_prepaid_gas, tx_cost};
+use crate::config::{TransactionCost, total_prepaid_gas};
 use crate::near_primitives::account::Account;
 use near_crypto::key_conversion::is_valid_staking_key;
 use near_parameters::RuntimeConfig;
@@ -88,21 +88,18 @@ fn is_zero_balance_account(account: &Account) -> bool {
 /// transaction before forwarding it to the node that tracks the `signer_id` account.
 pub fn validate_transaction(
     config: &RuntimeConfig,
-    gas_price: Balance,
     signed_transaction: &SignedTransaction,
-    verify_signature: bool,
     current_protocol_version: ProtocolVersion,
-) -> Result<TransactionCost, InvalidTxError> {
+) -> Result<(), InvalidTxError> {
     // Don't allow V1 currently. This will be changed when the new protocol version is introduced.
     if matches!(signed_transaction.transaction, near_primitives::transaction::Transaction::V1(_)) {
         return Err(InvalidTxError::InvalidTransactionVersion);
     }
     let transaction = &signed_transaction.transaction;
 
-    if verify_signature
-        && !signed_transaction
-            .signature
-            .verify(signed_transaction.get_hash().as_ref(), transaction.public_key())
+    if !signed_transaction
+        .signature
+        .verify(signed_transaction.get_hash().as_ref(), transaction.public_key())
     {
         return Err(InvalidTxError::InvalidSignature);
     }
@@ -122,10 +119,7 @@ pub fn validate_transaction(
         transaction.actions(),
         current_protocol_version,
     )
-    .map_err(InvalidTxError::ActionsValidation)?;
-
-    tx_cost(&config, transaction, gas_price, current_protocol_version)
-        .map_err(|_| InvalidTxError::CostOverflow.into())
+    .map_err(InvalidTxError::ActionsValidation)
 }
 
 /// Verifies the signed transaction on top of given state, charges transaction fees
@@ -612,8 +606,10 @@ fn check_global_contracts_enabled(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
+    use super::*;
+    use crate::config::tx_cost;
+    use crate::near_primitives::shard_layout::ShardUId;
+    use crate::near_primitives::trie_key::TrieKey;
     use near_crypto::{InMemorySigner, KeyType, PublicKey, Signature, Signer};
     use near_primitives::account::{AccessKey, AccountContract, FunctionCallPermission};
     use near_primitives::action::delegate::{DelegateAction, NonDelegateAction};
@@ -625,15 +621,11 @@ mod tests {
     };
     use near_primitives::types::{AccountId, Balance, MerkleHash, StateChangeCause};
     use near_primitives::version::PROTOCOL_VERSION;
-    use near_store::test_utils::TestTriesBuilder;
-    use testlib::runtime_utils::{alice_account, bob_account, eve_dot_alice_account};
-
-    use crate::near_primitives::shard_layout::ShardUId;
-
-    use super::*;
-    use crate::near_primitives::trie_key::TrieKey;
     use near_store::set;
+    use near_store::test_utils::TestTriesBuilder;
     use near_vm_runner::ContractCode;
+    use std::sync::Arc;
+    use testlib::runtime_utils::{alice_account, bob_account, eve_dot_alice_account};
 
     /// Initial balance used in tests.
     const TESTING_INIT_BALANCE: Balance = 1_000_000_000 * NEAR_BASE;
@@ -749,25 +741,30 @@ mod tests {
         signed_transaction: &SignedTransaction,
         expected_err: InvalidTxError,
     ) {
-        match validate_transaction(config, gas_price, signed_transaction, true, PROTOCOL_VERSION) {
-            Ok(cost) => {
-                // Validation passed, now verification should fail with expected_err
-                let err = verify_and_charge_transaction(
-                    config,
-                    state_update,
-                    signed_transaction,
-                    &cost,
-                    None,
-                    PROTOCOL_VERSION,
-                )
-                .expect_err("expected an error");
-                assert_eq!(err, expected_err);
-            }
-            Err(err) => {
-                // Validation itself returned an error
-                assert_eq!(err, expected_err);
-            }
+        if let Err(err) = validate_transaction(config, signed_transaction, PROTOCOL_VERSION) {
+            assert_eq!(err, expected_err);
+            return;
         }
+        let cost =
+            match tx_cost(config, &signed_transaction.transaction, gas_price, PROTOCOL_VERSION) {
+                Ok(c) => c,
+                Err(err) => {
+                    assert_eq!(err, expected_err);
+                    return;
+                }
+            };
+
+        // Validation passed, now verification should fail with expected_err
+        let err = verify_and_charge_transaction(
+            config,
+            state_update,
+            signed_transaction,
+            &cost,
+            None,
+            PROTOCOL_VERSION,
+        )
+        .expect_err("expected an error");
+        assert_eq!(err, expected_err);
     }
 
     pub fn validate_verify_and_charge_transaction(
@@ -778,13 +775,9 @@ mod tests {
         block_height: Option<BlockHeight>,
         current_protocol_version: ProtocolVersion,
     ) -> Result<VerificationResult, InvalidTxError> {
-        let transaction_cost = validate_transaction(
-            config,
-            gas_price,
-            signed_transaction,
-            true,
-            current_protocol_version,
-        )?;
+        validate_transaction(config, signed_transaction, current_protocol_version)?;
+        let transaction_cost =
+            tx_cost(config, &signed_transaction.transaction, gas_price, current_protocol_version)?;
         verify_and_charge_transaction(
             config,
             state_update,
@@ -1557,7 +1550,7 @@ mod tests {
             wasm_config.limit_config.max_transaction_size = transaction_size - 1;
         }
 
-        let err = validate_transaction(&config, gas_price, &transaction, false, PROTOCOL_VERSION)
+        let err = validate_transaction(&config, &transaction, PROTOCOL_VERSION)
             .expect_err("expected validation error - size exceeded");
         assert_eq!(
             err,

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -613,7 +613,6 @@ mod tests {
     use near_crypto::{InMemorySigner, KeyType, PublicKey, Signature, Signer};
     use near_primitives::account::{AccessKey, AccountContract, FunctionCallPermission};
     use near_primitives::action::delegate::{DelegateAction, NonDelegateAction};
-    use near_primitives::errors::IntegerOverflowError;
     use near_primitives::hash::{CryptoHash, hash};
     use near_primitives::receipt::ReceiptPriority;
     use near_primitives::test_utils::account_new;


### PR DESCRIPTION
This change allows for a number of simplifications.

- `validate_tx_metadata`: does not need to compute the tx cost unnecessarily just to drop it.  It also needs fewer arguments.
- `validate_tx_against_state` does not need to call `validate_transaction` anymore removing duplicate checks and it can just call `tx_cost`.
- `validate_transaction` now always verifies signatures so it needs one fewer argument.
- rename `validate_tx_against_state` to `can_verify_and_charge_tx` to make it clear what the function is actually doing.
- rename `validate_tx_metadata` to just `validate_tx` as that is what this function is now doing.