### PR TITLE
make `TrieUpdate` non `mut` in `verify_and_charge_transaction`

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -50,7 +50,7 @@ use node_runtime::config::tx_cost;
 use node_runtime::state_viewer::{TrieViewer, ViewApplyState};
 use node_runtime::{
     ApplyState, Runtime, ValidatorAccountsUpdate, commit_charging_for_tx, validate_transaction,
-    verify_and_charge_transaction,
+    verify_and_charge_tx_ephemeral,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -577,7 +577,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         let shard_uid = shard_layout.account_id_to_shard_uid(transaction.transaction.signer_id());
         let state_update = self.tries.new_trie_update(shard_uid, state_root);
 
-        verify_and_charge_transaction(
+        verify_and_charge_tx_ephemeral(
             runtime_config,
             &state_update,
             transaction,
@@ -774,7 +774,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                         .map_err(InvalidTxError::from)
                     })
                     .and_then(|cost| {
-                        verify_and_charge_transaction(
+                        verify_and_charge_tx_ephemeral(
                             runtime_config,
                             &state_update,
                             &tx,

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -18,7 +18,7 @@ use near_primitives::apply::ApplyChunkReason;
 use near_primitives::congestion_info::{
     CongestionControl, ExtendedCongestionInfo, RejectTransactionReason, ShardAcceptsTransactions,
 };
-use near_primitives::errors::{IntegerOverflowError, InvalidTxError, RuntimeError, StorageError};
+use near_primitives::errors::{InvalidTxError, RuntimeError, StorageError};
 use near_primitives::hash::{CryptoHash, hash};
 use near_primitives::receipt::{DelayedReceiptIndices, Receipt};
 use near_primitives::runtime::migration_data::{MigrationData, MigrationFlags};
@@ -49,7 +49,7 @@ use node_runtime::adapter::ViewRuntimeAdapter;
 use node_runtime::config::tx_cost;
 use node_runtime::state_viewer::{TrieViewer, ViewApplyState};
 use node_runtime::{
-    ApplyState, Runtime, ValidatorAccountsUpdate, validate_transaction,
+    ApplyState, Runtime, ValidatorAccountsUpdate, commit_charging_for_tx, validate_transaction,
     verify_and_charge_transaction,
 };
 use std::collections::HashMap;
@@ -575,11 +575,11 @@ impl RuntimeAdapter for NightshadeRuntime {
         let cost =
             tx_cost(runtime_config, &transaction.transaction, gas_price, current_protocol_version)?;
         let shard_uid = shard_layout.account_id_to_shard_uid(transaction.transaction.signer_id());
-        let mut state_update = self.tries.new_trie_update(shard_uid, state_root);
+        let state_update = self.tries.new_trie_update(shard_uid, state_root);
 
         verify_and_charge_transaction(
             runtime_config,
-            &mut state_update,
+            &state_update,
             transaction,
             &cost,
             // here we do not know which block the transaction will be included
@@ -771,17 +771,26 @@ impl RuntimeAdapter for NightshadeRuntime {
                             prev_block.next_gas_price,
                             protocol_version,
                         )
-                        .map_err(|e: IntegerOverflowError| e.into())
-                        .and_then(|cost| {
-                            verify_and_charge_transaction(
-                                runtime_config,
-                                &mut state_update,
-                                &tx,
-                                &cost,
-                                Some(next_block_height),
-                                protocol_version,
-                            )
-                        })
+                        .map_err(InvalidTxError::from)
+                    })
+                    .and_then(|cost| {
+                        verify_and_charge_transaction(
+                            runtime_config,
+                            &state_update,
+                            &tx,
+                            &cost,
+                            Some(next_block_height),
+                            protocol_version,
+                        )
+                    })
+                    .map(|vr| {
+                        commit_charging_for_tx(
+                            &mut state_update,
+                            &tx.transaction,
+                            &vr.signer,
+                            &vr.access_key,
+                        );
+                        vr
                     });
 
                 match verify_result {

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -28,7 +28,10 @@ use near_store::{TrieCache, TrieCachingStorage, TrieConfig};
 use near_vm_runner::FilesystemContractRuntimeCache;
 use near_vm_runner::logic::LimitConfig;
 use node_runtime::config::tx_cost;
-use node_runtime::{ApplyState, Runtime, SignedValidPeriodTransactions};
+use node_runtime::{
+    ApplyState, Runtime, SignedValidPeriodTransactions, commit_charging_for_tx,
+    verify_and_charge_transaction,
+};
 use std::collections::HashMap;
 use std::iter;
 use std::sync::Arc;
@@ -458,15 +461,16 @@ impl Testbed<'_> {
         let cost = tx_cost(&self.apply_state.config, &tx.transaction, gas_price, PROTOCOL_VERSION)
             .unwrap();
 
-        node_runtime::verify_and_charge_transaction(
+        let vr = verify_and_charge_transaction(
             &self.apply_state.config,
-            &mut state_update,
+            &state_update,
             tx,
             &cost,
             block_height,
             PROTOCOL_VERSION,
         )
         .expect("tx verification should not fail in estimator");
+        commit_charging_for_tx(&mut state_update, &tx.transaction, &vr.signer, &vr.access_key);
         clock.elapsed()
     }
 

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -30,7 +30,7 @@ use near_vm_runner::logic::LimitConfig;
 use node_runtime::config::tx_cost;
 use node_runtime::{
     ApplyState, Runtime, SignedValidPeriodTransactions, commit_charging_for_tx,
-    verify_and_charge_transaction,
+    verify_and_charge_tx_ephemeral,
 };
 use std::collections::HashMap;
 use std::iter;
@@ -461,7 +461,7 @@ impl Testbed<'_> {
         let cost = tx_cost(&self.apply_state.config, &tx.transaction, gas_price, PROTOCOL_VERSION)
             .unwrap();
 
-        let vr = verify_and_charge_transaction(
+        let vr = verify_and_charge_tx_ephemeral(
             &self.apply_state.config,
             &state_update,
             tx,

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -9,7 +9,7 @@ use crate::prefetch::TriePrefetcher;
 use crate::verifier::{StorageStakingError, check_storage_stake, validate_receipt};
 pub use crate::verifier::{
     ZERO_BALANCE_ACCOUNT_STORAGE_LIMIT, commit_charging_for_tx, validate_transaction,
-    verify_and_charge_transaction,
+    verify_and_charge_tx_ephemeral,
 };
 use bandwidth_scheduler::{BandwidthSchedulerOutput, run_bandwidth_scheduler};
 use config::{TransactionCost, total_prepaid_send_fees, tx_cost};
@@ -173,7 +173,9 @@ pub struct VerificationResult {
     pub receipt_gas_price: Balance,
     /// The balance that was burnt to convert the transaction into a receipt and send it.
     pub burnt_amount: Balance,
+    /// The signer that was updated to charge for the transaction.
     pub signer: Account,
+    /// The access key that was updated to charge for the transaction.
     pub access_key: AccessKey,
 }
 
@@ -331,7 +333,7 @@ impl Runtime {
         let span = tracing::Span::current();
         metrics::TRANSACTION_PROCESSED_TOTAL.inc();
 
-        match verify_and_charge_transaction(
+        match verify_and_charge_tx_ephemeral(
             &apply_state.config,
             state_update,
             signed_transaction,

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -132,9 +132,12 @@ pub fn commit_charging_for_tx(
     set_account(state_update, tx.signer_id().clone(), &signer);
 }
 
-/// Verifies the signed transaction on top of given state, charges transaction fees
-/// and balances, and updates the state for the used account and access keys.
-pub fn verify_and_charge_transaction(
+/// Verifies the signed transaction on top of the given state; looks up the
+/// signer account and access_key from the transaction; updates them to charge
+/// for the transaction processing; returns the updated signer and access_key to
+/// the caller.  The caller can use `commit_charging_for_tx()` to commit the
+/// actual charging.
+pub fn verify_and_charge_tx_ephemeral(
     config: &RuntimeConfig,
     state_update: &TrieUpdate,
     signed_transaction: &SignedTransaction,
@@ -769,7 +772,7 @@ mod tests {
             };
 
         // Validation passed, now verification should fail with expected_err
-        let err = verify_and_charge_transaction(
+        let err = verify_and_charge_tx_ephemeral(
             config,
             state_update,
             signed_transaction,
@@ -792,7 +795,7 @@ mod tests {
         validate_transaction(config, signed_transaction, current_protocol_version)?;
         let transaction_cost =
             tx_cost(config, &signed_transaction.transaction, gas_price, current_protocol_version)?;
-        let vr = verify_and_charge_transaction(
+        let vr = verify_and_charge_tx_ephemeral(
             config,
             state_update,
             signed_transaction,

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -3,7 +3,7 @@ use crate::config::{TransactionCost, total_prepaid_gas};
 use crate::near_primitives::account::Account;
 use near_crypto::key_conversion::is_valid_staking_key;
 use near_parameters::RuntimeConfig;
-use near_primitives::account::AccessKeyPermission;
+use near_primitives::account::{AccessKey, AccessKeyPermission};
 use near_primitives::action::DeployGlobalContractAction;
 use near_primitives::action::delegate::SignedDelegateAction;
 use near_primitives::checked_feature;
@@ -11,10 +11,10 @@ use near_primitives::errors::{
     ActionsValidationError, InvalidAccessKeyError, InvalidTxError, ReceiptValidationError,
 };
 use near_primitives::receipt::{ActionReceipt, DataReceipt, Receipt, ReceiptEnum};
-use near_primitives::transaction::DeleteAccountAction;
 use near_primitives::transaction::{
     Action, AddKeyAction, DeployContractAction, FunctionCallAction, SignedTransaction, StakeAction,
 };
+use near_primitives::transaction::{DeleteAccountAction, Transaction};
 use near_primitives::types::{AccountId, Balance};
 use near_primitives::types::{BlockHeight, StorageUsage};
 use near_primitives::version::ProtocolFeature;
@@ -122,11 +122,21 @@ pub fn validate_transaction(
     .map_err(InvalidTxError::ActionsValidation)
 }
 
+pub fn commit_charging_for_tx(
+    state_update: &mut TrieUpdate,
+    tx: &Transaction,
+    signer: &Account,
+    access_key: &AccessKey,
+) {
+    set_access_key(state_update, tx.signer_id().clone(), tx.public_key().clone(), &access_key);
+    set_account(state_update, tx.signer_id().clone(), &signer);
+}
+
 /// Verifies the signed transaction on top of given state, charges transaction fees
 /// and balances, and updates the state for the used account and access keys.
 pub fn verify_and_charge_transaction(
     config: &RuntimeConfig,
-    state_update: &mut TrieUpdate,
+    state_update: &TrieUpdate,
     signed_transaction: &SignedTransaction,
     transaction_cost: &TransactionCost,
     block_height: Option<BlockHeight>,
@@ -264,10 +274,14 @@ pub fn verify_and_charge_transaction(
         }
     };
 
-    set_access_key(state_update, signer_id.clone(), transaction.public_key().clone(), &access_key);
-    set_account(state_update, signer_id.clone(), &signer);
-
-    Ok(VerificationResult { gas_burnt, gas_remaining, receipt_gas_price, burnt_amount })
+    Ok(VerificationResult {
+        gas_burnt,
+        gas_remaining,
+        receipt_gas_price,
+        burnt_amount,
+        signer,
+        access_key,
+    })
 }
 
 /// Validates a given receipt. Checks validity of the Action or Data receipt.
@@ -621,8 +635,8 @@ mod tests {
     };
     use near_primitives::types::{AccountId, Balance, MerkleHash, StateChangeCause};
     use near_primitives::version::PROTOCOL_VERSION;
-    use near_store::set;
     use near_store::test_utils::TestTriesBuilder;
+    use near_store::{set, set_access_key, set_account};
     use near_vm_runner::ContractCode;
     use std::sync::Arc;
     use testlib::runtime_utils::{alice_account, bob_account, eve_dot_alice_account};
@@ -736,7 +750,7 @@ mod tests {
 
     fn assert_err_both_validations(
         config: &RuntimeConfig,
-        state_update: &mut TrieUpdate,
+        state_update: &TrieUpdate,
         gas_price: Balance,
         signed_transaction: &SignedTransaction,
         expected_err: InvalidTxError,
@@ -778,14 +792,21 @@ mod tests {
         validate_transaction(config, signed_transaction, current_protocol_version)?;
         let transaction_cost =
             tx_cost(config, &signed_transaction.transaction, gas_price, current_protocol_version)?;
-        verify_and_charge_transaction(
+        let vr = verify_and_charge_transaction(
             config,
             state_update,
             signed_transaction,
             &transaction_cost,
             block_height,
             current_protocol_version,
-        )
+        )?;
+        commit_charging_for_tx(
+            state_update,
+            &signed_transaction.transaction,
+            &vr.signer,
+            &vr.access_key,
+        );
+        Ok(vr)
     }
 
     mod zero_balance_account_tests {


### PR DESCRIPTION
This will make usage of `TrieUpdate` inside `process_tx_internal` non `mut` and then allow us to more easily parallelise.