### PR TITLE
chore: make chunk wait multiplier configurable

### DIFF
--- a/chain/chain/src/tests/doomslug.rs
+++ b/chain/chain/src/tests/doomslug.rs
@@ -5,6 +5,7 @@ use near_primitives::block::Approval;
 use near_primitives::hash::{CryptoHash, hash};
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::{ApprovalStake, BlockHeight};
+use num_rational::Rational32;
 use rand::{Rng, thread_rng};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -57,6 +58,7 @@ fn one_iter(
             Duration::milliseconds(1000),
             Duration::milliseconds(100),
             delta * 20, // some arbitrary number larger than delta * 6
+            Rational32::new(1, 3),
             DoomslugThresholdMode::TwoThirds,
         )
     })

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -302,6 +302,7 @@ impl Client {
             config.max_block_production_delay,
             config.max_block_production_delay / 10,
             config.max_block_wait_delay,
+            config.chunk_wait_mult,
             doomslug_threshold_mode,
         );
         let chunk_endorsement_tracker =

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -7,6 +7,7 @@ use near_primitives::types::{
 };
 use near_primitives::version::Version;
 use near_time::Duration;
+use num_rational::Rational32;
 use std::cmp::{max, min};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -444,6 +445,8 @@ pub struct ClientConfig {
     pub max_block_production_delay: Duration,
     /// Maximum duration before skipping given height.
     pub max_block_wait_delay: Duration,
+    /// Multiplier for the wait time for all chunks to be received.
+    pub chunk_wait_mult: Rational32,
     /// Skip waiting for sync (for testing or single node testnet).
     pub skip_sync_wait: bool,
     /// How often to check that we are not out of sync.
@@ -599,6 +602,7 @@ impl ClientConfig {
             min_block_production_delay: Duration::milliseconds(min_block_prod_time as i64),
             max_block_production_delay: Duration::milliseconds(max_block_prod_time as i64),
             max_block_wait_delay: Duration::milliseconds(3 * min_block_prod_time as i64),
+            chunk_wait_mult: Rational32::new(1, 3),
             skip_sync_wait,
             sync_check_period: Duration::milliseconds(100),
             sync_step_period: Duration::milliseconds(10),

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -85,6 +85,9 @@ pub const TESTNET_MAX_BLOCK_PRODUCTION_DELAY: i64 = 2_500;
 /// Maximum time until skipping the previous block is ms.
 pub const MAX_BLOCK_WAIT_DELAY: i64 = 6_000;
 
+/// Multiplier for the wait time for all chunks to be received.
+pub const CHUNK_WAIT_DENOMINATOR: i32 = 3;
+
 /// Horizon at which instead of fetching block, fetch full state.
 const BLOCK_FETCH_HORIZON: BlockHeightDelta = 50;
 
@@ -131,6 +134,8 @@ pub struct Consensus {
     /// Maximum duration before skipping given height.
     #[serde(with = "near_async::time::serde_duration_as_std")]
     pub max_block_wait_delay: Duration,
+    /// Multiplier for the wait time for all chunks to be received.
+    pub chunk_wait_mult: Rational32,
     /// Produce empty blocks, use `false` for testing.
     pub produce_empty_blocks: bool,
     /// Horizon at which instead of fetching block, fetch full state.
@@ -200,6 +205,7 @@ impl Default for Consensus {
             min_block_production_delay: Duration::milliseconds(MIN_BLOCK_PRODUCTION_DELAY),
             max_block_production_delay: Duration::milliseconds(MAX_BLOCK_PRODUCTION_DELAY),
             max_block_wait_delay: Duration::milliseconds(MAX_BLOCK_WAIT_DELAY),
+            chunk_wait_mult: Rational32::new(1, CHUNK_WAIT_DENOMINATOR),
             produce_empty_blocks: true,
             block_fetch_horizon: BLOCK_FETCH_HORIZON,
             block_header_fetch_horizon: BLOCK_HEADER_FETCH_HORIZON,
@@ -519,6 +525,7 @@ impl NearConfig {
                 min_block_production_delay: config.consensus.min_block_production_delay,
                 max_block_production_delay: config.consensus.max_block_production_delay,
                 max_block_wait_delay: config.consensus.max_block_wait_delay,
+                chunk_wait_mult: config.consensus.chunk_wait_mult,
                 skip_sync_wait: config.network.skip_sync_wait,
                 sync_check_period: config.consensus.sync_check_period,
                 sync_step_period: config.consensus.sync_step_period,


### PR DESCRIPTION
Make the multiplier used to wait for all chunks configurable in config.json

Currently it is 6. We are going to use 3 since 2.6 so I'm using 3 in all test configs.