### PR TITLE
[testloop] Fix broken visualizer

### DIFF
--- a/core/async/src/test_loop.rs
+++ b/core/async/src/test_loop.rs
@@ -171,6 +171,8 @@ struct EventStartLogOutput {
     current_index: usize,
     /// See `EventEndLogOutput::total_events`.
     total_events: usize,
+    /// The identifier of the event, usually the node_id.
+    identifier: String,
     /// The Debug representation of the event payload.
     current_event: String,
     /// The current virtual time.
@@ -333,11 +335,11 @@ impl TestLoopV2 {
 
     /// Processes the given event, by logging a line first and then finding a handler to run it.
     fn process_event(&mut self, event: EventInHeap) {
-        let description = format!("({},{})", event.event.identifier, event.event.description);
         let start_json = serde_json::to_string(&EventStartLogOutput {
             current_index: event.id,
             total_events: self.next_event_index,
-            current_event: description,
+            identifier: event.event.identifier,
+            current_event: event.event.description,
             current_time_ms: event.due.whole_milliseconds() as u64,
         })
         .unwrap();

--- a/tools/debug-ui/src/log_visualizer/LogVisualizer.tsx
+++ b/tools/debug-ui/src/log_visualizer/LogVisualizer.tsx
@@ -73,7 +73,7 @@ export const LogVisualizer = () => {
                     })}
                 </div>
                 {/* Render the column headers. */}
-                {layouts.columns.map((_, i) => {
+                {layouts.columns.map((col, i) => {
                     return (
                         <div
                             key={i}
@@ -82,7 +82,7 @@ export const LogVisualizer = () => {
                                 left: layouts.getGridColumnXOffset(i),
                                 width: layouts.getGridColumnWidth(i),
                             }}>
-                            Node {i}
+                            {col.identifier}
                         </div>
                     );
                 })}
@@ -157,17 +157,17 @@ export const LogVisualizer = () => {
                                             className={
                                                 'attached-event' +
                                                 (event.id == selectedEventId ||
-                                                parent.id == selectedEventId
+                                                    parent.id == selectedEventId
                                                     ? ' selected'
                                                     : '')
                                             }
                                             style={{
                                                 left: layouts.getArrowColumnXOffset(
-                                                    new ArrowColumn(parent.column, 'middle'),
+                                                    new ArrowColumn(parent.columnNumber, 'middle'),
                                                     arrowGroupId
                                                 ),
                                                 top:
-                                                    layouts.getItemYOffset(parent.row) +
+                                                    layouts.getItemYOffset(parent.rowNumber) +
                                                     layouts.sizes.itemHeight,
                                             }}
                                             onClick={(e) => {
@@ -187,9 +187,9 @@ export const LogVisualizer = () => {
                             key={`event ${event.id}`}
                             className={'event' + (event.id == selectedEventId ? ' selected' : '')}
                             style={{
-                                left: layouts.getItemXOffset(event.column),
-                                top: layouts.getItemYOffset(event.row),
-                                width: layouts.getItemWidth(event.column),
+                                left: layouts.getItemXOffset(event.columnNumber),
+                                top: layouts.getItemYOffset(event.rowNumber),
+                                width: layouts.getItemWidth(event.columnNumber),
                                 height: layouts.sizes.itemHeight,
                             }}
                             onClick={(e) => {

--- a/tools/debug-ui/src/log_visualizer/arrows.ts
+++ b/tools/debug-ui/src/log_visualizer/arrows.ts
@@ -90,7 +90,7 @@ export type ArrowRowPosition = 'above' | 'inbound' | 'outbound';
 export const ARROW_ROW_POSITIONS: ArrowRowPosition[] = ['above', 'inbound', 'outbound'];
 
 export class ArrowRow {
-    constructor(public readonly gridRow: number, public readonly positioning: ArrowRowPosition) {}
+    constructor(public readonly gridRow: number, public readonly positioning: ArrowRowPosition) { }
 
     // Gets a unique key for this ArrowRow that is larger if it's more
     // vertically down.
@@ -120,7 +120,7 @@ export class ArrowColumn {
     constructor(
         public readonly gridColumn: number,
         public readonly positioning: ArrowColumnPosition
-    ) {}
+    ) { }
 
     get key(): number {
         return this.gridColumn * 2 + (this.positioning == 'left' ? 0 : 1);
@@ -265,8 +265,8 @@ export function makeOutgoingArrowsForItem(
         for (const targetId of targetIds) {
             const child = items.get(targetId)!;
             columnToMaxRow.set(
-                child.column,
-                Math.max(columnToMaxRow.get(child.column) ?? 0, child.row)
+                child.columnNumber,
+                Math.max(columnToMaxRow.get(child.columnNumber) ?? 0, child.rowNumber)
             );
         }
         let minColumn = 100000,
@@ -279,22 +279,22 @@ export function makeOutgoingArrowsForItem(
         const verticalParts = [] as ArrowPartVertical[];
         // If we only have children to the same instance, then draw them in the
         // first fashion (see comment at beginning of file).
-        if (minColumn == maxColumn && minColumn == item.column && attachmentId === null) {
-            horizontalParts.push(ArrowPartHorizontal.outOfItem(item.row, item.column));
+        if (minColumn == maxColumn && minColumn == item.columnNumber && attachmentId === null) {
+            horizontalParts.push(ArrowPartHorizontal.outOfItem(item.rowNumber, item.columnNumber));
             verticalParts.push(
                 ArrowPartVertical.acrossRows(
-                    new ArrowRow(item.row, 'outbound'),
-                    new ArrowRow(columnToMaxRow.get(item.column)!, 'inbound'),
-                    item.column
+                    new ArrowRow(item.rowNumber, 'outbound'),
+                    new ArrowRow(columnToMaxRow.get(item.columnNumber)!, 'inbound'),
+                    item.columnNumber
                 )
             );
         } else {
             // Otherwise we draw them in the second fashion.
-            const verticalOut = ArrowPartVertical.outOfItem(item.row, item.column);
+            const verticalOut = ArrowPartVertical.outOfItem(item.rowNumber, item.columnNumber);
             verticalParts.push(verticalOut);
             horizontalParts.push(
                 ArrowPartHorizontal.acrossColumns(
-                    item.row + 1,
+                    item.rowNumber + 1,
                     verticalOut.column.min(new ArrowColumn(minColumn, 'left')),
                     verticalOut.column.max(new ArrowColumn(maxColumn, 'left'))
                 )
@@ -302,7 +302,7 @@ export function makeOutgoingArrowsForItem(
             for (const column of columnToMaxRow.keys()) {
                 verticalParts.push(
                     ArrowPartVertical.acrossRows(
-                        new ArrowRow(item.row + 1, 'above'),
+                        new ArrowRow(item.rowNumber + 1, 'above'),
                         new ArrowRow(columnToMaxRow.get(column)!, 'inbound'),
                         column
                     )
@@ -311,7 +311,7 @@ export function makeOutgoingArrowsForItem(
         }
         for (const targetId of targetIds) {
             const child = items.get(targetId)!;
-            horizontalParts.push(ArrowPartHorizontal.intoItem(child.row, child.column));
+            horizontalParts.push(ArrowPartHorizontal.intoItem(child.rowNumber, child.columnNumber));
         }
         arrowGroups.push({
             horizontalParts,


### PR DESCRIPTION
The recent change in https://github.com/near/nearcore/pull/13016 to shift from index to identifier broke the testloop visualizer.

We now have the visualizer showing the identifier instead of just index.

![image](https://github.com/user-attachments/assets/9f062810-8737-4e15-a96d-65e1bf83a484)
