### PR TITLE
Docker build toolchain version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH
 
 RUN curl https://sh.rustup.rs -sSf | \
-    sh -s -- -y --no-modify-path
+    sh -s -- -y --no-modify-path --default-toolchain none
 
 RUN rustup toolchain install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,12 @@ RUN apt-get update -qq && apt-get install -y \
     clang \
     && rm -rf /var/lib/apt/lists/*
 
-COPY ./rust-toolchain.toml /tmp/rust-toolchain.toml
-
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
 RUN curl https://sh.rustup.rs -sSf | \
-    sh -s -- -y --no-modify-path --default-toolchain none
+    sh -s -- -y --no-modify-path
 
 VOLUME [ /near ]
 WORKDIR /near

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,6 @@ RUN apt-get update -qq && apt-get install -y \
     curl \
     llvm \
     clang \
-    python3-pip \
-    jq \
     && rm -rf /var/lib/apt/lists/*
 
 VOLUME [ /near ]
@@ -23,13 +21,10 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
-RUN pip3 install yq
+RUN curl https://sh.rustup.rs -sSf | \
+    sh -s -- -y --no-modify-path
 
-RUN channel=$(tomlq -r '.workspace.package."rust-version"' Cargo.toml) && \
-    echo "Installing Rust toolchain: $channel" && \
-    curl https://sh.rustup.rs -sSf | \
-    sh -s -- -y --no-modify-path --default-toolchain $channel
-
+RUN rustup toolchain install
 
 ENV PORTABLE=ON
 ARG make_target=

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,18 +11,25 @@ RUN apt-get update -qq && apt-get install -y \
     curl \
     llvm \
     clang \
+    python3-pip \
+    jq \
     && rm -rf /var/lib/apt/lists/*
+
+VOLUME [ /near ]
+WORKDIR /near
+COPY . .
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
-RUN curl https://sh.rustup.rs -sSf | \
-    sh -s -- -y --no-modify-path
+RUN pip3 install yq
 
-VOLUME [ /near ]
-WORKDIR /near
-COPY . .
+RUN channel=$(tomlq -r '.workspace.package."rust-version"' Cargo.toml) && \
+    echo "Installing Rust toolchain: $channel" && \
+    curl https://sh.rustup.rs -sSf | \
+    sh -s -- -y --no-modify-path --default-toolchain $channel
+
 
 ENV PORTABLE=ON
 ARG make_target=


### PR DESCRIPTION
Because of changes in rustup, we need to explicitly specify toolchain version
https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html