### PR TITLE
Docker build toolchain version (#13034)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ RUN apt-get update -qq && apt-get install -y \
     clang \
     && rm -rf /var/lib/apt/lists/*
 
-COPY ./rust-toolchain.toml /tmp/rust-toolchain.toml
+VOLUME [ /near ]
+WORKDIR /near
+COPY . .
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
@@ -22,9 +24,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- -y --no-modify-path --default-toolchain none
 
-VOLUME [ /near ]
-WORKDIR /near
-COPY . .
+RUN rustup toolchain install
 
 ENV PORTABLE=ON
 ARG make_target=


### PR DESCRIPTION
Because of changes in rustup, we need to explicitly specify toolchain version
https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html