### PR TITLE
[testloop] Support to kill a node

### DIFF
--- a/test-loop-tests/src/env.rs
+++ b/test-loop-tests/src/env.rs
@@ -64,6 +64,10 @@ impl TestLoopEnv {
         Self { test_loop, datas, tempdir }
     }
 
+    pub fn kill_node(&mut self, identifier: &str) {
+        self.test_loop.remove_events_with_identifier(identifier);
+    }
+
     /// Used to finish off remaining events that are still in the loop. This can be necessary if the
     /// destructor of some components wait for certain condition to become true. Otherwise, the
     /// destructors may end up waiting forever. This also helps avoid a panic when destructing

--- a/test-loop-tests/src/tests/mod.rs
+++ b/test-loop-tests/src/tests/mod.rs
@@ -20,6 +20,7 @@ mod optimistic_block;
 mod protocol_upgrade;
 mod reject_outdated_blocks;
 mod resharding_v3;
+mod restart_node;
 mod simple_test_loop_example;
 mod state_sync;
 mod syncing;

--- a/test-loop-tests/src/tests/restart_node.rs
+++ b/test-loop-tests/src/tests/restart_node.rs
@@ -1,0 +1,50 @@
+use itertools::Itertools;
+use near_async::time::Duration;
+use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
+use near_o11y::testonly::init_test_logger;
+use near_primitives::types::AccountId;
+
+use crate::builder::TestLoopBuilder;
+use crate::utils::ONE_NEAR;
+
+const NUM_CLIENTS: usize = 4;
+
+#[test]
+fn test_restart_node() {
+    init_test_logger();
+    let builder = TestLoopBuilder::new();
+
+    let accounts =
+        (0..100).map(|i| format!("account{}", i).parse().unwrap()).collect::<Vec<AccountId>>();
+    let clients = accounts.iter().take(NUM_CLIENTS).cloned().collect_vec();
+
+    let epoch_length = 4;
+    let validators_spec =
+        ValidatorsSpec::desired_roles(&clients.iter().map(|t| t.as_str()).collect_vec(), &[]);
+
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .epoch_length(epoch_length)
+        .validators_spec(validators_spec)
+        .add_user_accounts_simple(&accounts, 1_000_000 * ONE_NEAR)
+        .gas_limit_one_petagas()
+        .build();
+
+    let epoch_config_store = TestEpochConfigBuilder::from_genesis(&genesis)
+        .shuffle_shard_assignment_for_chunk_producers(true)
+        .build_store_for_genesis_protocol_version();
+
+    let mut env =
+        builder.genesis(genesis).epoch_config_store(epoch_config_store).clients(clients).build();
+
+    env.test_loop.run_for(Duration::seconds(5));
+
+    // kill node
+    env.kill_node(accounts[0].as_str());
+    env.test_loop.run_for(Duration::seconds(5));
+
+    // TODO: implement restart node
+
+    // Give the test a chance to finish off remaining events in the event loop, which can
+    // be important for properly shutting down the nodes.
+    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
+}

--- a/tools/debug-ui/src/log_visualizer/LogVisualizer.scss
+++ b/tools/debug-ui/src/log_visualizer/LogVisualizer.scss
@@ -41,6 +41,12 @@
                 background-color: #cfc;
             }
 
+            &.ignored {
+                border: 1px solid red;
+                box-shadow: 0 0 2px 0 rgba(255, 0, 0, 0.5);
+                background-color: rgb(255, 204, 204);
+            }
+
             .content {
                 overflow: hidden;
 

--- a/tools/debug-ui/src/log_visualizer/LogVisualizer.tsx
+++ b/tools/debug-ui/src/log_visualizer/LogVisualizer.tsx
@@ -182,10 +182,11 @@ export const LogVisualizer = () => {
 
                 {/* Render all the events (other than attachments). */}
                 {events.getAllNonAttachedItems().map((event) => {
+                    const className = event.ignored ? 'event ignored' : event.id == selectedEventId ? 'event selected' : 'event';
                     return (
                         <div
                             key={`event ${event.id}`}
-                            className={'event' + (event.id == selectedEventId ? ' selected' : '')}
+                            className={className}
                             style={{
                                 left: layouts.getItemXOffset(event.columnNumber),
                                 top: layouts.getItemYOffset(event.rowNumber),

--- a/tools/debug-ui/src/log_visualizer/events.ts
+++ b/tools/debug-ui/src/log_visualizer/events.ts
@@ -24,6 +24,8 @@ export class EventItem {
     // The parent event whose handler spawned this event. See the parsing logic
     // for how this is derived.
     public readonly parentId: number | null = null;
+    // Whether this event was executed or ignored. Emitted from the Rust side.
+    public readonly ignored: boolean;
 
     // The row and column of the event in the log visualizer. This is set during layout.
     public rowNumber = 0;
@@ -33,12 +35,13 @@ export class EventItem {
     // The log lines emitted by the Rust program while handling this event.
     public readonly logRows: string[] = [];
 
-    constructor(id: number, identifier: string, parentId: number | null, time: number, eventDump: string) {
+    constructor(id: number, identifier: string, parentId: number | null, time: number, eventDump: string, eventIgnored: boolean) {
         this.id = id;
         this.time = time;
         this.parentId = parentId;
         this.identifier = identifier;
         this.data = eventDump;
+        this.ignored = eventIgnored;
 
         // Parse the title and subtitle; for example, if the event dump is
         // "OutboundNetwork(NetworkRequests(...))""
@@ -197,6 +200,7 @@ export class EventItemCollection {
                     identifier: string;
                     current_event: string;
                     current_time_ms: number;
+                    event_ignored: boolean;
                 };
                 const startData = JSON.parse(
                     line.substring(startIndex + startMarker.length)
@@ -207,7 +211,8 @@ export class EventItemCollection {
                     startData.identifier,
                     parentIds[startData.current_index] ?? null,
                     startData.current_time_ms,
-                    startData.current_event
+                    startData.current_event,
+                    startData.event_ignored
                 );
                 items.add(event);
             } else if (endIndex != -1) {


### PR DESCRIPTION
This is the first step for adding support to restart nodes in testloop.

Here we begin by providing the support to kill a node.

TestLoop visualizer is updated appropriately to show events to a killed node in red.

![image](https://github.com/user-attachments/assets/205349fa-6302-4e3b-8960-230bf9822358)

Next step would be to add support to start/restart a node