### PR TITLE
chore: change log level in synth-bm

### DIFF
--- a/benchmarks/synth-bm/src/rpc.rs
+++ b/benchmarks/synth-bm/src/rpc.rs
@@ -123,7 +123,7 @@ impl RpcResponseHandler {
                 }
             };
 
-            info!("Received {} responses; num_success={} num_rpc_error={}",
+            debug!("Received {} responses; num_success={} num_rpc_error={}",
                 num_received,
                 num_succeeded,
                 num_rpc_error


### PR DESCRIPTION
The line "received x responses.." is a little spammy for my use case, I propose to change the log level to debug.
