### PR TITLE
[network] Send VersionedChunkEndorsement on T2 (#13039)

### DIFF
--- a/chain/network/src/peer_manager/connection/mod.rs
+++ b/chain/network/src/peer_manager/connection/mod.rs
@@ -103,6 +103,19 @@ impl tcp::Tier {
             | RoutedMessageBody::_UnusedEpochSyncResponse(..) => unreachable!(),
         }
     }
+
+    pub(crate) fn is_allowed_send(self, body: &RoutedMessageBody) -> bool {
+        // With release 2.5 we had changed VersionedChunkEndorsement to be allowed on T1.
+        // This lead to a compatibility issue with 2.4 nodes, which were expecting
+        // VersionedChunkEndorsement to be allowed only on T2.
+        // To fix this problem, with release 2.5 we allow to receive VersionedChunkEndorsement
+        // on T1 but send on VersionedChunkEndorsement T2.
+        // TODO: With release 2.6 remove this hack.
+        if let RoutedMessageBody::VersionedChunkEndorsement(..) = body {
+            return self == tcp::Tier::T2;
+        }
+        self.is_allowed_routed(body)
+    }
 }
 
 #[derive(Default)]

--- a/chain/network/src/peer_manager/network_state/mod.rs
+++ b/chain/network/src/peer_manager/network_state/mod.rs
@@ -643,7 +643,7 @@ impl NetworkState {
         }
 
         let accounts_data = self.accounts_data.load();
-        if tcp::Tier::T1.is_allowed_routed(&msg) {
+        if tcp::Tier::T1.is_allowed_send(&msg) {
             for key in accounts_data.keys_by_id.get(account_id).iter().flat_map(|keys| keys.iter())
             {
                 let data = match accounts_data.data.get(key) {


### PR DESCRIPTION
With release 2.5 we had changed VersionedChunkEndorsement to be allowed on T1. This lead to a compatibility issue with 2.4 nodes, which were expecting VersionedChunkEndorsement to be allowed only on T2.

To fix this problem, with release 2.5 we allow to receive VersionedChunkEndorsement on T1 but send on VersionedChunkEndorsement T2.

With next release 2.6, we can start sending VersionedChunkEndorsement on T1.

Zulip discussion:
https://near.zulipchat.com/#narrow/channel/308695-nearone.2Fprivate/topic/2.2E5.2E0.20release.20mainnet.20-.20missing.20chunks/near/503332447