### PR TITLE
Introduce `ValidatedTransaction`

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -573,7 +573,7 @@ impl RuntimeAdapter for NightshadeRuntime {
 
         let cost = tx_cost(runtime_config, &validated_tx, gas_price, current_protocol_version)?;
         let shard_uid = shard_layout
-            .account_id_to_shard_uid(validated_tx.to_signed_transaction().transaction.signer_id());
+            .account_id_to_shard_uid(validated_tx.to_signed_tx().transaction.signer_id());
         let state_update = self.tries.new_trie_update(shard_uid, state_root);
 
         verify_and_charge_tx_ephemeral(
@@ -771,10 +771,9 @@ impl RuntimeAdapter for NightshadeRuntime {
                             prev_block.next_gas_price,
                             protocol_version,
                         ) {
-                            Err(err) => (
-                                Err(InvalidTxError::from(err)),
-                                validated_tx.into_signed_transaction(),
-                            ),
+                            Err(err) => {
+                                (Err(InvalidTxError::from(err)), validated_tx.into_signed_tx())
+                            }
                             Ok(cost) => match verify_and_charge_tx_ephemeral(
                                 runtime_config,
                                 &state_update,
@@ -783,15 +782,15 @@ impl RuntimeAdapter for NightshadeRuntime {
                                 Some(next_block_height),
                                 protocol_version,
                             ) {
-                                Err(err) => (Err(err), validated_tx.into_signed_transaction()),
+                                Err(err) => (Err(err), validated_tx.into_signed_tx()),
                                 Ok(res) => {
                                     commit_charging_for_tx(
                                         &mut state_update,
-                                        validated_tx.to_transaction(),
+                                        validated_tx.to_tx(),
                                         &res.signer,
                                         &res.access_key,
                                     );
-                                    (Ok(res), validated_tx.into_signed_transaction())
+                                    (Ok(res), validated_tx.into_signed_tx())
                                 }
                             },
                         },

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -33,7 +33,7 @@ use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::stateless_validation::validator_assignment::ChunkValidatorAssignments;
 use near_primitives::transaction::{
     Action, ExecutionMetadata, ExecutionOutcome, ExecutionOutcomeWithId, ExecutionStatus,
-    SignedTransaction, TransferAction,
+    SignedTransaction, TransferAction, ValidatedTransaction,
 };
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
@@ -1002,11 +1002,11 @@ impl RuntimeAdapter for KeyValueRuntime {
     fn validate_tx(
         &self,
         _shard_layout: &ShardLayout,
-        _transaction: &SignedTransaction,
+        transaction: SignedTransaction,
         _current_protocol_version: ProtocolVersion,
         _receiver_congestion_info: Option<ExtendedCongestionInfo>,
-    ) -> Result<(), InvalidTxError> {
-        Ok(())
+    ) -> Result<ValidatedTransaction, (InvalidTxError, SignedTransaction)> {
+        Ok(ValidatedTransaction::new(transaction).unwrap())
     }
 
     fn can_verify_and_charge_tx(
@@ -1014,7 +1014,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         _shard_layout: &ShardLayout,
         _gas_price: Balance,
         _state_root: StateRoot,
-        _transaction: &SignedTransaction,
+        _transaction: &ValidatedTransaction,
         _current_protocol_version: ProtocolVersion,
     ) -> Result<(), InvalidTxError> {
         Ok(())

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -1004,11 +1004,10 @@ impl RuntimeAdapter for KeyValueRuntime {
         &self,
         _shard_layout: &ShardLayout,
         signed_tx: SignedTransaction,
-        protocol_version: ProtocolVersion,
+        _protocol_version: ProtocolVersion,
         _receiver_congestion_info: Option<ExtendedCongestionInfo>,
     ) -> Result<ValidatedTransaction, (InvalidTxError, SignedTransaction)> {
-        let config = self.get_runtime_config(protocol_version).unwrap();
-        ValidatedTransaction::new(&config, signed_tx)
+        Ok(ValidatedTransaction::new_for_test(signed_tx))
     }
 
     fn can_verify_and_charge_tx(

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -1002,11 +1002,11 @@ impl RuntimeAdapter for KeyValueRuntime {
     fn validate_tx(
         &self,
         _shard_layout: &ShardLayout,
-        transaction: SignedTransaction,
+        signed_tx: SignedTransaction,
         _current_protocol_version: ProtocolVersion,
         _receiver_congestion_info: Option<ExtendedCongestionInfo>,
     ) -> Result<ValidatedTransaction, (InvalidTxError, SignedTransaction)> {
-        match ValidatedTransaction::new(transaction) {
+        match ValidatedTransaction::new(signed_tx) {
             Ok(validated_tx) => Ok(validated_tx),
             Err(signed_tx) => Err((InvalidTxError::InvalidSignature, signed_tx)),
         }
@@ -1017,7 +1017,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         _shard_layout: &ShardLayout,
         _gas_price: Balance,
         _state_root: StateRoot,
-        _transaction: &ValidatedTransaction,
+        _validated_tx: &ValidatedTransaction,
         _current_protocol_version: ProtocolVersion,
     ) -> Result<(), InvalidTxError> {
         Ok(())

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -1006,7 +1006,10 @@ impl RuntimeAdapter for KeyValueRuntime {
         _current_protocol_version: ProtocolVersion,
         _receiver_congestion_info: Option<ExtendedCongestionInfo>,
     ) -> Result<ValidatedTransaction, (InvalidTxError, SignedTransaction)> {
-        Ok(ValidatedTransaction::new(transaction).unwrap())
+        match ValidatedTransaction::new(transaction) {
+            Ok(validated_tx) => Ok(validated_tx),
+            Err(signed_tx) => Err((InvalidTxError::InvalidSignature, signed_tx)),
+        }
     }
 
     fn can_verify_and_charge_tx(

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -1004,13 +1004,11 @@ impl RuntimeAdapter for KeyValueRuntime {
         &self,
         _shard_layout: &ShardLayout,
         signed_tx: SignedTransaction,
-        _current_protocol_version: ProtocolVersion,
+        protocol_version: ProtocolVersion,
         _receiver_congestion_info: Option<ExtendedCongestionInfo>,
     ) -> Result<ValidatedTransaction, (InvalidTxError, SignedTransaction)> {
-        match ValidatedTransaction::new(signed_tx) {
-            Ok(validated_tx) => Ok(validated_tx),
-            Err(signed_tx) => Err((InvalidTxError::InvalidSignature, signed_tx)),
-        }
+        let config = self.get_runtime_config(protocol_version).unwrap();
+        ValidatedTransaction::new(&config, signed_tx)
     }
 
     fn can_verify_and_charge_tx(

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -429,6 +429,7 @@ pub trait RuntimeAdapter: Send + Sync {
 
     fn get_shard_layout(&self, protocol_version: ProtocolVersion) -> ShardLayout;
 
+    #[allow(clippy::result_large_err)]
     fn validate_tx(
         &self,
         shard_layout: &ShardLayout,

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -432,7 +432,7 @@ pub trait RuntimeAdapter: Send + Sync {
     fn validate_tx(
         &self,
         shard_layout: &ShardLayout,
-        transaction: SignedTransaction,
+        signed_tx: SignedTransaction,
         current_protocol_version: ProtocolVersion,
         receiver_congestion_info: Option<ExtendedCongestionInfo>,
     ) -> Result<ValidatedTransaction, (InvalidTxError, SignedTransaction)>;
@@ -442,7 +442,7 @@ pub trait RuntimeAdapter: Send + Sync {
         shard_layout: &ShardLayout,
         gas_price: Balance,
         state_root: StateRoot,
-        transaction: &ValidatedTransaction,
+        validated_tx: &ValidatedTransaction,
         current_protocol_version: ProtocolVersion,
     ) -> Result<(), InvalidTxError>;
 

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -28,6 +28,7 @@ use near_primitives::shard_layout::ShardUId;
 use near_primitives::state::PartialState;
 use near_primitives::state_part::PartId;
 use near_primitives::stateless_validation::contract_distribution::ContractUpdates;
+use near_primitives::transaction::ValidatedTransaction;
 use near_primitives::transaction::{ExecutionOutcomeWithId, SignedTransaction};
 use near_primitives::types::validator_stake::{ValidatorStake, ValidatorStakeIter};
 use near_primitives::types::{
@@ -431,21 +432,17 @@ pub trait RuntimeAdapter: Send + Sync {
     fn validate_tx(
         &self,
         shard_layout: &ShardLayout,
-        transaction: &SignedTransaction,
+        transaction: SignedTransaction,
         current_protocol_version: ProtocolVersion,
         receiver_congestion_info: Option<ExtendedCongestionInfo>,
-    ) -> Result<(), InvalidTxError>;
+    ) -> Result<ValidatedTransaction, (InvalidTxError, SignedTransaction)>;
 
-    /// It is assumed that this function is only called if `validate_tx` was
-    /// called successfully earlier. TODO: introduce some type safety to ensure
-    /// that this function can only be called if `validate_tx` was successfully
-    /// called.
     fn can_verify_and_charge_tx(
         &self,
         shard_layout: &ShardLayout,
         gas_price: Balance,
         state_root: StateRoot,
-        transaction: &SignedTransaction,
+        transaction: &ValidatedTransaction,
         current_protocol_version: ProtocolVersion,
     ) -> Result<(), InvalidTxError>;
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2286,7 +2286,7 @@ impl Client {
                 match self
                     .chunk_producer
                     .sharded_tx_pool
-                    .insert_transaction(shard_uid, validated_tx.take())
+                    .insert_transaction(shard_uid, validated_tx.into_signed_transaction())
                 {
                     InsertTransactionResult::Success => {
                         trace!(target: "client", ?shard_uid, tx_hash = ?tx.get_hash(), "Recorded a transaction.");

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2278,7 +2278,7 @@ impl Client {
                 match self
                     .chunk_producer
                     .sharded_tx_pool
-                    .insert_transaction(shard_uid, validated_tx.into_signed_transaction())
+                    .insert_transaction(shard_uid, validated_tx.into_signed_tx())
                 {
                     InsertTransactionResult::Success => {
                         trace!(target: "client", ?shard_uid, tx_hash = ?signed_tx.get_hash(), "Recorded a transaction.");

--- a/chain/indexer/src/streamer/utils.rs
+++ b/chain/indexer/src/streamer/utils.rs
@@ -1,7 +1,9 @@
 use actix::Addr;
 
+use near_crypto::InMemorySigner;
 use near_indexer_primitives::IndexerTransactionWithOutcome;
 use near_parameters::RuntimeConfig;
+use near_primitives::transaction::ValidatedTransaction;
 use near_primitives::version::ProtocolVersion;
 use near_primitives::views;
 use node_runtime::config::tx_cost;
@@ -22,53 +24,58 @@ pub(crate) async fn convert_transactions_sir_into_local_receipts(
     let prev_block = fetch_block(&client, block.header.prev_hash).await?;
     let prev_block_gas_price = prev_block.header.gas_price;
 
-    let local_receipts: Vec<views::ReceiptView> =
-        txs.into_iter()
-            .map(|tx| {
-                assert_eq!(tx.transaction.signer_id, tx.transaction.receiver_id);
-                let cost = tx_cost(
-                    &runtime_config,
-                    &near_primitives::transaction::Transaction::V0(
-                        near_primitives::transaction::TransactionV0 {
-                            signer_id: tx.transaction.signer_id.clone(),
-                            public_key: tx.transaction.public_key.clone(),
-                            nonce: tx.transaction.nonce,
-                            receiver_id: tx.transaction.receiver_id.clone(),
-                            block_hash: block.header.hash,
-                            actions: tx
-                                .transaction
-                                .actions
-                                .clone()
-                                .into_iter()
-                                .map(|action| {
-                                    near_primitives::transaction::Action::try_from(action).unwrap()
-                                })
-                                .collect(),
-                        },
-                    ),
-                    prev_block_gas_price,
-                    protocol_version,
-                )
-                .expect("TransactionCost returned IntegerOverflowError");
-                views::ReceiptView {
-                    predecessor_id: tx.transaction.signer_id.clone(),
-                    receiver_id: tx.transaction.receiver_id.clone(),
-                    receipt_id: *tx.outcome.execution_outcome.outcome.receipt_ids.first().expect(
-                        "The transaction ExecutionOutcome should have one receipt id in vec",
-                    ),
-                    receipt: views::ReceiptEnumView::Action {
-                        signer_id: tx.transaction.signer_id.clone(),
-                        signer_public_key: tx.transaction.public_key.clone(),
-                        gas_price: cost.receipt_gas_price,
-                        output_data_receivers: vec![],
-                        input_data_ids: vec![],
-                        actions: tx.transaction.actions.clone(),
-                        is_promise_yield: false,
-                    },
-                    priority: 0,
-                }
-            })
-            .collect();
+    let local_receipts: Vec<views::ReceiptView> = txs
+        .into_iter()
+        .map(|indexer_tx| {
+            assert_eq!(indexer_tx.transaction.signer_id, indexer_tx.transaction.receiver_id);
+            let tx = near_primitives::transaction::Transaction::V0(
+                near_primitives::transaction::TransactionV0 {
+                    signer_id: indexer_tx.transaction.signer_id.clone(),
+                    public_key: indexer_tx.transaction.public_key.clone(),
+                    nonce: indexer_tx.transaction.nonce,
+                    receiver_id: indexer_tx.transaction.receiver_id.clone(),
+                    block_hash: block.header.hash,
+                    actions: indexer_tx
+                        .transaction
+                        .actions
+                        .clone()
+                        .into_iter()
+                        .map(|action| {
+                            near_primitives::transaction::Action::try_from(action).unwrap()
+                        })
+                        .collect(),
+                },
+            );
+            let signer = InMemorySigner::test_signer(&indexer_tx.transaction.signer_id);
+            let signed_tx = tx.sign(&signer);
+            let validated_tx = ValidatedTransaction::new(signed_tx).unwrap();
+
+            let cost =
+                tx_cost(&runtime_config, &validated_tx, prev_block_gas_price, protocol_version)
+                    .unwrap();
+            views::ReceiptView {
+                predecessor_id: indexer_tx.transaction.signer_id.clone(),
+                receiver_id: indexer_tx.transaction.receiver_id.clone(),
+                receipt_id: *indexer_tx
+                    .outcome
+                    .execution_outcome
+                    .outcome
+                    .receipt_ids
+                    .first()
+                    .expect("The transaction ExecutionOutcome should have one receipt id in vec"),
+                receipt: views::ReceiptEnumView::Action {
+                    signer_id: indexer_tx.transaction.signer_id.clone(),
+                    signer_public_key: indexer_tx.transaction.public_key.clone(),
+                    gas_price: cost.receipt_gas_price,
+                    output_data_receivers: vec![],
+                    input_data_ids: vec![],
+                    actions: indexer_tx.transaction.actions.clone(),
+                    is_promise_yield: false,
+                },
+                priority: 0,
+            }
+        })
+        .collect();
 
     Ok(local_receipts)
 }

--- a/chain/indexer/src/streamer/utils.rs
+++ b/chain/indexer/src/streamer/utils.rs
@@ -48,7 +48,7 @@ pub(crate) async fn convert_transactions_sir_into_local_receipts(
             );
             let signer = InMemorySigner::test_signer(&indexer_tx.transaction.signer_id);
             let signed_tx = tx.sign(&signer);
-            let validated_tx = ValidatedTransaction::new(signed_tx).unwrap();
+            let validated_tx = ValidatedTransaction::new(runtime_config, signed_tx).unwrap();
 
             let cost =
                 tx_cost(&runtime_config, &validated_tx, prev_block_gas_price, protocol_version)

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -2,7 +2,7 @@ pub use crate::action::{
     Action, AddKeyAction, CreateAccountAction, DeleteAccountAction, DeleteKeyAction,
     DeployContractAction, FunctionCallAction, StakeAction, TransferAction,
 };
-use crate::errors::TxExecutionError;
+use crate::errors::{InvalidTxError, TxExecutionError};
 use crate::hash::{CryptoHash, hash};
 use crate::merkle::MerklePath;
 use crate::profile_data_v3::ProfileDataV3;
@@ -10,6 +10,7 @@ use crate::types::{AccountId, Balance, Gas, Nonce};
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_crypto::{PublicKey, Signature};
 use near_fmt::{AbbrBytes, Slice};
+use near_parameters::RuntimeConfig;
 use near_primitives_core::serialize::{from_base64, to_base64};
 use near_primitives_core::types::Compute;
 use near_schema_checker_lib::ProtocolSchema;
@@ -211,19 +212,39 @@ impl BorshDeserialize for Transaction {
     }
 }
 
+/// Using the new type pattern to construct a type of signed transaction that is
+/// guaranteed to have various checks performed on it.  In particular, ensure
+/// that the signature is verified and the max transaction size checks have been
+/// conducted.
 #[derive(Debug)]
 pub struct ValidatedTransaction(SignedTransaction);
 
 impl ValidatedTransaction {
     #[allow(clippy::result_large_err)]
-    pub fn new(signed_tx: SignedTransaction) -> Result<Self, SignedTransaction> {
+    pub fn new(
+        config: &RuntimeConfig,
+        signed_tx: SignedTransaction,
+    ) -> Result<Self, (InvalidTxError, SignedTransaction)> {
+        // Don't allow V1 currently. This will be changed when the new protocol version is introduced.
+        if matches!(signed_tx.transaction, Transaction::V1(_)) {
+            return Err((InvalidTxError::InvalidTransactionVersion, signed_tx));
+        }
+        let tx_size = signed_tx.get_size();
+        let max_tx_size = config.wasm_config.limit_config.max_transaction_size;
+        if tx_size > max_tx_size {
+            return Err((
+                InvalidTxError::TransactionSizeExceeded { size: tx_size, limit: max_tx_size },
+                signed_tx,
+            ));
+        }
+
         if signed_tx
             .signature
             .verify(signed_tx.get_hash().as_ref(), signed_tx.transaction.public_key())
         {
             Ok(Self(signed_tx))
         } else {
-            Err(signed_tx)
+            Err((InvalidTxError::InvalidSignature, signed_tx))
         }
     }
 

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -211,6 +211,27 @@ impl BorshDeserialize for Transaction {
     }
 }
 
+#[derive(Debug)]
+pub struct ValidatedTransaction(SignedTransaction);
+
+impl ValidatedTransaction {
+    pub fn new(tx: SignedTransaction) -> Result<Self, SignedTransaction> {
+        if tx.signature.verify(tx.get_hash().as_ref(), tx.transaction.public_key()) {
+            Ok(Self(tx))
+        } else {
+            Err(tx)
+        }
+    }
+
+    pub fn get(&self) -> &SignedTransaction {
+        &self.0
+    }
+
+    pub fn take(self) -> SignedTransaction {
+        self.0
+    }
+}
+
 #[derive(BorshSerialize, BorshDeserialize, Eq, Debug, Clone, ProtocolSchema)]
 #[borsh(init=init)]
 pub struct SignedTransaction {

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -248,6 +248,12 @@ impl ValidatedTransaction {
         }
     }
 
+    /// This method should only be used for test purposes.  This is because
+    /// kv_runtime is not designed to do proper signature verification.
+    pub fn new_for_test(signed_tx: SignedTransaction) -> Self {
+        Self(signed_tx)
+    }
+
     pub fn to_signed_tx(&self) -> &SignedTransaction {
         &self.0
     }
@@ -258,12 +264,6 @@ impl ValidatedTransaction {
 
     pub fn to_tx(&self) -> &Transaction {
         &self.0.transaction
-    }
-
-    /// This method should only be used for test purposes.  This is because
-    /// kv_runtime is not designed to do proper signature verification.
-    pub fn new_for_test(signed_tx: SignedTransaction) -> Self {
-        Self(signed_tx)
     }
 }
 

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -215,11 +215,14 @@ impl BorshDeserialize for Transaction {
 pub struct ValidatedTransaction(SignedTransaction);
 
 impl ValidatedTransaction {
-    pub fn new(tx: SignedTransaction) -> Result<Self, SignedTransaction> {
-        if tx.signature.verify(tx.get_hash().as_ref(), tx.transaction.public_key()) {
-            Ok(Self(tx))
+    pub fn new(signed_tx: SignedTransaction) -> Result<Self, SignedTransaction> {
+        if signed_tx
+            .signature
+            .verify(signed_tx.get_hash().as_ref(), signed_tx.transaction.public_key())
+        {
+            Ok(Self(signed_tx))
         } else {
-            Err(tx)
+            Err(signed_tx)
         }
     }
 
@@ -229,6 +232,14 @@ impl ValidatedTransaction {
 
     pub fn into_signed_transaction(self) -> SignedTransaction {
         self.0
+    }
+
+    pub fn to_transaction(&self) -> &Transaction {
+        &self.0.transaction
+    }
+
+    pub fn into_transaction(self) -> Transaction {
+        self.0.transaction
     }
 }
 

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -265,6 +265,10 @@ impl ValidatedTransaction {
     pub fn to_tx(&self) -> &Transaction {
         &self.0.transaction
     }
+
+    pub fn get_hash(&self) -> CryptoHash {
+        self.0.get_hash()
+    }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Eq, Debug, Clone, ProtocolSchema)]

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -226,20 +226,16 @@ impl ValidatedTransaction {
         }
     }
 
-    pub fn to_signed_transaction(&self) -> &SignedTransaction {
+    pub fn to_signed_tx(&self) -> &SignedTransaction {
         &self.0
     }
 
-    pub fn into_signed_transaction(self) -> SignedTransaction {
+    pub fn into_signed_tx(self) -> SignedTransaction {
         self.0
     }
 
-    pub fn to_transaction(&self) -> &Transaction {
+    pub fn to_tx(&self) -> &Transaction {
         &self.0.transaction
-    }
-
-    pub fn into_transaction(self) -> Transaction {
-        self.0.transaction
     }
 }
 

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -259,6 +259,10 @@ impl ValidatedTransaction {
     pub fn to_tx(&self) -> &Transaction {
         &self.0.transaction
     }
+
+    pub fn new_for_test(signed_tx: SignedTransaction) -> Self {
+        Self(signed_tx)
+    }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Eq, Debug, Clone, ProtocolSchema)]

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -260,6 +260,8 @@ impl ValidatedTransaction {
         &self.0.transaction
     }
 
+    /// This method should only be used for test purposes.  This is because
+    /// kv_runtime is not designed to do proper signature verification.
     pub fn new_for_test(signed_tx: SignedTransaction) -> Self {
         Self(signed_tx)
     }

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -215,6 +215,7 @@ impl BorshDeserialize for Transaction {
 pub struct ValidatedTransaction(SignedTransaction);
 
 impl ValidatedTransaction {
+    #[allow(clippy::result_large_err)]
     pub fn new(signed_tx: SignedTransaction) -> Result<Self, SignedTransaction> {
         if signed_tx
             .signature

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -223,11 +223,11 @@ impl ValidatedTransaction {
         }
     }
 
-    pub fn get(&self) -> &SignedTransaction {
+    pub fn to_signed_transaction(&self) -> &SignedTransaction {
         &self.0
     }
 
-    pub fn take(self) -> SignedTransaction {
+    pub fn into_signed_transaction(self) -> SignedTransaction {
         self.0
     }
 }

--- a/runtime/runtime-params-estimator/src/action_costs.rs
+++ b/runtime/runtime-params-estimator/src/action_costs.rs
@@ -243,7 +243,7 @@ impl ActionEstimation {
         let predecessor_id = tb.account_by_requirement(self.predecessor, Some(&signer_id));
         let receiver_id = tb.account_by_requirement(self.receiver, Some(&signer_id));
         let tx = tb.transaction_from_actions(predecessor_id, receiver_id, actions);
-        testbed.verify_transaction(&tx, self.metric)
+        testbed.verify_transaction(tx, self.metric)
     }
 
     /// Estimate the cost of applying a set of actions once.

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -459,13 +459,8 @@ impl Testbed<'_> {
         let validated_tx =
             node_runtime::validate_transaction(&self.apply_state.config, tx, PROTOCOL_VERSION)
                 .expect("expected no validation error");
-        let cost = tx_cost(
-            &self.apply_state.config,
-            &validated_tx.to_signed_transaction().transaction,
-            gas_price,
-            PROTOCOL_VERSION,
-        )
-        .unwrap();
+        let cost =
+            tx_cost(&self.apply_state.config, &validated_tx, gas_price, PROTOCOL_VERSION).unwrap();
 
         let vr = verify_and_charge_tx_ephemeral(
             &self.apply_state.config,

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -446,7 +446,7 @@ impl Testbed<'_> {
     /// Network costs for sending are not included.
     pub(crate) fn verify_transaction(
         &mut self,
-        tx: &SignedTransaction,
+        tx: SignedTransaction,
         metric: GasMetric,
     ) -> GasCost {
         let mut state_update = TrieUpdate::new(self.trie());
@@ -456,21 +456,32 @@ impl Testbed<'_> {
         let block_height = None;
 
         let clock = GasCost::measure(metric);
-        node_runtime::validate_transaction(&self.apply_state.config, tx, PROTOCOL_VERSION)
-            .expect("expected no validation error");
-        let cost = tx_cost(&self.apply_state.config, &tx.transaction, gas_price, PROTOCOL_VERSION)
-            .unwrap();
+        let validated_tx =
+            node_runtime::validate_transaction(&self.apply_state.config, tx, PROTOCOL_VERSION)
+                .expect("expected no validation error");
+        let cost = tx_cost(
+            &self.apply_state.config,
+            &validated_tx.get().transaction,
+            gas_price,
+            PROTOCOL_VERSION,
+        )
+        .unwrap();
 
         let vr = verify_and_charge_tx_ephemeral(
             &self.apply_state.config,
             &state_update,
-            tx,
+            &validated_tx,
             &cost,
             block_height,
             PROTOCOL_VERSION,
         )
         .expect("tx verification should not fail in estimator");
-        commit_charging_for_tx(&mut state_update, &tx.transaction, &vr.signer, &vr.access_key);
+        commit_charging_for_tx(
+            &mut state_update,
+            &validated_tx.get().transaction,
+            &vr.signer,
+            &vr.access_key,
+        );
         clock.elapsed()
     }
 

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -461,7 +461,7 @@ impl Testbed<'_> {
                 .expect("expected no validation error");
         let cost = tx_cost(
             &self.apply_state.config,
-            &validated_tx.get().transaction,
+            &validated_tx.to_signed_transaction().transaction,
             gas_price,
             PROTOCOL_VERSION,
         )
@@ -478,7 +478,7 @@ impl Testbed<'_> {
         .expect("tx verification should not fail in estimator");
         commit_charging_for_tx(
             &mut state_update,
-            &validated_tx.get().transaction,
+            &validated_tx.to_signed_transaction().transaction,
             &vr.signer,
             &vr.access_key,
         );

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -473,7 +473,7 @@ impl Testbed<'_> {
         .expect("tx verification should not fail in estimator");
         commit_charging_for_tx(
             &mut state_update,
-            &validated_tx.to_signed_transaction().transaction,
+            &validated_tx.to_signed_tx().transaction,
             &vr.signer,
             &vr.access_key,
         );

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -446,7 +446,7 @@ impl Testbed<'_> {
     /// Network costs for sending are not included.
     pub(crate) fn verify_transaction(
         &mut self,
-        tx: SignedTransaction,
+        signed_tx: SignedTransaction,
         metric: GasMetric,
     ) -> GasCost {
         let mut state_update = TrieUpdate::new(self.trie());
@@ -456,9 +456,12 @@ impl Testbed<'_> {
         let block_height = None;
 
         let clock = GasCost::measure(metric);
-        let validated_tx =
-            node_runtime::validate_transaction(&self.apply_state.config, tx, PROTOCOL_VERSION)
-                .expect("expected no validation error");
+        let validated_tx = node_runtime::validate_transaction(
+            &self.apply_state.config,
+            signed_tx,
+            PROTOCOL_VERSION,
+        )
+        .expect("expected no validation error");
         let cost =
             tx_cost(&self.apply_state.config, &validated_tx, gas_price, PROTOCOL_VERSION).unwrap();
 

--- a/runtime/runtime/src/config.rs
+++ b/runtime/runtime/src/config.rs
@@ -11,7 +11,7 @@ use num_traits::pow::Pow;
 // Just re-exporting RuntimeConfig for backwards compatibility.
 use near_parameters::{ActionCosts, RuntimeConfig, transfer_exec_fee, transfer_send_fee};
 pub use near_primitives::num_rational::Rational32;
-use near_primitives::transaction::{Action, DeployContractAction, Transaction};
+use near_primitives::transaction::{Action, DeployContractAction, ValidatedTransaction};
 use near_primitives::types::{AccountId, Balance, Compute, Gas};
 
 /// Describes the cost of converting this transaction into a receipt.
@@ -249,10 +249,11 @@ pub fn exec_fee(config: &RuntimeConfig, action: &Action, receiver_id: &AccountId
 /// Returns transaction costs for a given transaction.
 pub fn tx_cost(
     config: &RuntimeConfig,
-    transaction: &Transaction,
+    validated_tx: &ValidatedTransaction,
     gas_price: Balance,
     protocol_version: ProtocolVersion,
 ) -> Result<TransactionCost, IntegerOverflowError> {
+    let transaction = &validated_tx.to_signed_transaction().transaction;
     let sender_is_receiver = transaction.receiver_id() == transaction.signer_id();
     let fees = &config.fees;
     let mut gas_burnt: Gas = fees.fee(ActionCosts::new_action_receipt).send_fee(sender_is_receiver);

--- a/runtime/runtime/src/config.rs
+++ b/runtime/runtime/src/config.rs
@@ -253,7 +253,7 @@ pub fn tx_cost(
     gas_price: Balance,
     protocol_version: ProtocolVersion,
 ) -> Result<TransactionCost, IntegerOverflowError> {
-    let transaction = &validated_tx.to_signed_transaction().transaction;
+    let transaction = &validated_tx.to_signed_tx().transaction;
     let sender_is_receiver = transaction.receiver_id() == transaction.signer_id();
     let fees = &config.fees;
     let mut gas_burnt: Gas = fees.fee(ActionCosts::new_action_receipt).send_fee(sender_is_receiver);

--- a/runtime/runtime/src/config.rs
+++ b/runtime/runtime/src/config.rs
@@ -267,7 +267,7 @@ pub fn tx_cost(
     )?;
     // If signer is equals to receiver the receipt will be processed at the same block as this
     // transaction. Otherwise it will processed in the next block and the gas might be inflated.
-    let initial_receipt_hop = if tx.signer_id() == tx.receiver_id() { 0 } else { 1 };
+    let initial_receipt_hop = if sender_is_receiver { 0 } else { 1 };
     let minimum_new_receipt_gas = if protocol_version < FIXED_MINIMUM_NEW_RECEIPT_GAS_VERSION {
         fees.min_receipt_with_function_call_gas()
     } else {

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -292,8 +292,7 @@ impl Runtime {
             .map(|signed_tx| {
                 (
                     signed_tx.get_hash(),
-                    match validate_transaction(config, signed_tx.clone(), current_protocol_version)
-                    {
+                    match validate_transaction(config, signed_tx, current_protocol_version) {
                         Ok(validated_tx) => {
                             match tx_cost(
                                 config,

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -325,7 +325,7 @@ impl Runtime {
     /// In case of an error, returns either `InvalidTxError` if the transaction verification failed
     /// or a `StorageError` wrapped into `RuntimeError`.
     #[instrument(target = "runtime", level = "debug", "process_transaction", skip_all, fields(
-        tx_hash = %tx.get().get_hash(),
+        tx_hash = %tx.to_signed_transaction().get_hash(),
         gas_burnt = tracing::field::Empty,
         compute_usage = tracing::field::Empty,
     ))]
@@ -352,17 +352,17 @@ impl Runtime {
                 metrics::TRANSACTION_PROCESSED_SUCCESSFULLY_TOTAL.inc();
                 commit_charging_for_tx(
                     state_update,
-                    &tx.get().transaction,
+                    &tx.to_signed_transaction().transaction,
                     &verification_result.signer,
                     &verification_result.access_key,
                 );
                 state_update.commit(StateChangeCause::TransactionProcessing {
-                    tx_hash: tx.get().get_hash(),
+                    tx_hash: tx.to_signed_transaction().get_hash(),
                 });
-                let transaction = &tx.get().transaction;
+                let transaction = &tx.to_signed_transaction().transaction;
                 let receipt_id = create_receipt_id_from_transaction(
                     apply_state.current_protocol_version,
-                    tx.get(),
+                    tx.to_signed_transaction(),
                     &apply_state.prev_block_hash,
                     &apply_state.block_hash,
                     apply_state.block_height,
@@ -388,7 +388,7 @@ impl Runtime {
                 let gas_burnt = verification_result.gas_burnt;
                 let compute_usage = verification_result.gas_burnt;
                 let outcome = ExecutionOutcomeWithId {
-                    id: tx.get().get_hash(),
+                    id: tx.to_signed_transaction().get_hash(),
                     outcome: ExecutionOutcome {
                         status: ExecutionStatus::SuccessReceiptId(*receipt.receipt_id()),
                         logs: vec![],
@@ -1739,7 +1739,7 @@ impl Runtime {
                             continue;
                         }
                     };
-                    if receipt.receiver_id() == validated_tx.get().transaction.signer_id() {
+                    if receipt.receiver_id() == validated_tx.to_signed_transaction().transaction.signer_id() {
                         processing_state.local_receipts.push_back(receipt);
                     } else {
                         receipt_sink.forward_or_buffer_receipt(

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -326,7 +326,7 @@ impl Runtime {
     /// In case of an error, returns either `InvalidTxError` if the transaction verification failed
     /// or a `StorageError` wrapped into `RuntimeError`.
     #[instrument(target = "runtime", level = "debug", "process_transaction", skip_all, fields(
-        tx_hash = %validated_tx.to_signed_transaction().get_hash(),
+        tx_hash = %validated_tx.to_signed_tx().get_hash(),
         gas_burnt = tracing::field::Empty,
         compute_usage = tracing::field::Empty,
     ))]
@@ -353,17 +353,17 @@ impl Runtime {
                 metrics::TRANSACTION_PROCESSED_SUCCESSFULLY_TOTAL.inc();
                 commit_charging_for_tx(
                     state_update,
-                    validated_tx.to_transaction(),
+                    validated_tx.to_tx(),
                     &verification_result.signer,
                     &verification_result.access_key,
                 );
                 state_update.commit(StateChangeCause::TransactionProcessing {
-                    tx_hash: validated_tx.to_signed_transaction().get_hash(),
+                    tx_hash: validated_tx.to_signed_tx().get_hash(),
                 });
-                let transaction = &validated_tx.to_signed_transaction().transaction;
+                let transaction = &validated_tx.to_signed_tx().transaction;
                 let receipt_id = create_receipt_id_from_transaction(
                     apply_state.current_protocol_version,
-                    validated_tx.to_signed_transaction(),
+                    validated_tx.to_signed_tx(),
                     &apply_state.prev_block_hash,
                     &apply_state.block_hash,
                     apply_state.block_height,
@@ -389,7 +389,7 @@ impl Runtime {
                 let gas_burnt = verification_result.gas_burnt;
                 let compute_usage = verification_result.gas_burnt;
                 let outcome = ExecutionOutcomeWithId {
-                    id: validated_tx.to_signed_transaction().get_hash(),
+                    id: validated_tx.to_signed_tx().get_hash(),
                     outcome: ExecutionOutcome {
                         status: ExecutionStatus::SuccessReceiptId(*receipt.receipt_id()),
                         logs: vec![],
@@ -1742,7 +1742,7 @@ impl Runtime {
                             continue;
                         }
                     };
-                    if receipt.receiver_id() == validated_tx.to_transaction().signer_id() {
+                    if receipt.receiver_id() == validated_tx.to_tx().signer_id() {
                         processing_state.local_receipts.push_back(receipt);
                     } else {
                         receipt_sink.forward_or_buffer_receipt(

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -296,7 +296,7 @@ impl Runtime {
                         Ok(validated_tx) => {
                             match tx_cost(
                                 config,
-                                &tx.transaction,
+                                &validated_tx,
                                 gas_price,
                                 current_protocol_version,
                             ) {

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -41,7 +41,7 @@ use near_primitives::state_record::StateRecord;
 use near_primitives::stateless_validation::contract_distribution::ContractUpdates;
 use near_primitives::transaction::{
     Action, ExecutionMetadata, ExecutionOutcome, ExecutionOutcomeWithId, ExecutionStatus, LogEntry,
-    SignedTransaction, TransferAction,
+    SignedTransaction, TransferAction, ValidatedTransaction,
 };
 use near_primitives::trie_key::{GlobalContractCodeIdentifier, TrieKey};
 use near_primitives::types::{
@@ -281,25 +281,32 @@ impl Runtime {
         debug!(target: "runtime", "{}", log_str);
     }
 
-    /// Validates all transactions in parallel and returns an iterator of
-    /// transactions paired with their validation results.
-    ///
-    /// Returns an `Iterator` of `(&SignedTransaction, Result<TransactionCost, InvalidTxError>)`
-    fn parallel_validate_transactions<'a>(
-        config: &'a RuntimeConfig,
+    fn parallel_validate_transactions(
+        config: &RuntimeConfig,
         gas_price: Balance,
-        transactions: &'a [SignedTransaction],
+        transactions: &[SignedTransaction],
         current_protocol_version: ProtocolVersion,
-    ) -> Vec<(&'a SignedTransaction, Result<TransactionCost, InvalidTxError>)> {
+    ) -> Vec<(CryptoHash, Result<(ValidatedTransaction, TransactionCost), InvalidTxError>)> {
         transactions
             .par_iter()
-            .map(move |tx| {
-                let cost_result = validate_transaction(config, tx, current_protocol_version)
-                    .and_then(|()| {
-                        tx_cost(config, &tx.transaction, gas_price, current_protocol_version)
-                            .map_err(InvalidTxError::from)
-                    });
-                (tx, cost_result)
+            .map(|tx| {
+                (
+                    tx.get_hash(),
+                    match validate_transaction(config, tx.clone(), current_protocol_version) {
+                        Ok(validated_tx) => {
+                            match tx_cost(
+                                config,
+                                &tx.transaction,
+                                gas_price,
+                                current_protocol_version,
+                            ) {
+                                Ok(cost) => Ok((validated_tx, cost)),
+                                Err(e) => Err(InvalidTxError::from(e)),
+                            }
+                        }
+                        Err((e, _tx)) => Err(e),
+                    },
+                )
             })
             .collect()
     }
@@ -318,7 +325,7 @@ impl Runtime {
     /// In case of an error, returns either `InvalidTxError` if the transaction verification failed
     /// or a `StorageError` wrapped into `RuntimeError`.
     #[instrument(target = "runtime", level = "debug", "process_transaction", skip_all, fields(
-        tx_hash = %signed_transaction.get_hash(),
+        tx_hash = %tx.get().get_hash(),
         gas_burnt = tracing::field::Empty,
         compute_usage = tracing::field::Empty,
     ))]
@@ -326,7 +333,7 @@ impl Runtime {
         &self,
         state_update: &mut TrieUpdate,
         apply_state: &ApplyState,
-        signed_transaction: &SignedTransaction,
+        tx: &ValidatedTransaction,
         transaction_cost: &TransactionCost,
         stats: &mut ChunkApplyStatsV0,
     ) -> Result<(Receipt, ExecutionOutcomeWithId), InvalidTxError> {
@@ -336,7 +343,7 @@ impl Runtime {
         match verify_and_charge_tx_ephemeral(
             &apply_state.config,
             state_update,
-            signed_transaction,
+            tx,
             transaction_cost,
             Some(apply_state.block_height),
             apply_state.current_protocol_version,
@@ -345,17 +352,17 @@ impl Runtime {
                 metrics::TRANSACTION_PROCESSED_SUCCESSFULLY_TOTAL.inc();
                 commit_charging_for_tx(
                     state_update,
-                    &signed_transaction.transaction,
+                    &tx.get().transaction,
                     &verification_result.signer,
                     &verification_result.access_key,
                 );
                 state_update.commit(StateChangeCause::TransactionProcessing {
-                    tx_hash: signed_transaction.get_hash(),
+                    tx_hash: tx.get().get_hash(),
                 });
-                let transaction = &signed_transaction.transaction;
+                let transaction = &tx.get().transaction;
                 let receipt_id = create_receipt_id_from_transaction(
                     apply_state.current_protocol_version,
-                    signed_transaction,
+                    tx.get(),
                     &apply_state.prev_block_hash,
                     &apply_state.block_hash,
                     apply_state.block_height,
@@ -381,7 +388,7 @@ impl Runtime {
                 let gas_burnt = verification_result.gas_burnt;
                 let compute_usage = verification_result.gas_burnt;
                 let outcome = ExecutionOutcomeWithId {
-                    id: signed_transaction.get_hash(),
+                    id: tx.get().get_hash(),
                     outcome: ExecutionOutcome {
                         status: ExecutionStatus::SuccessReceiptId(*receipt.receipt_id()),
                         logs: vec![],
@@ -1706,62 +1713,61 @@ impl Runtime {
         let apply_state = &mut processing_state.apply_state;
         let state_update = &mut processing_state.state_update;
 
-        for (signed_transaction, maybe_cost) in Self::parallel_validate_transactions(
+        for (tx_hash, result) in Self::parallel_validate_transactions(
             &apply_state.config,
             apply_state.gas_price,
             &processing_state.transactions.transactions,
             apply_state.current_protocol_version,
         ) {
-            let tx_hash = signed_transaction.get_hash();
-            let cost = match maybe_cost {
-                Ok(c) => c,
-                Err(e) => {
+            match result {
+                Ok((validated_tx, cost)) => {
+                    let (receipt, outcome_with_id) = match self.process_transaction(
+                        state_update,
+                        apply_state,
+                        &validated_tx,
+                        &cost,
+                        &mut processing_state.stats,
+                    ) {
+                        Ok(outcome) => outcome,
+                        Err(err) => {
+                            Self::handle_invalid_transaction(
+                                err,
+                                &tx_hash,
+                                processing_state.protocol_version,
+                                "process_transaction error",
+                            )?;
+                            continue;
+                        }
+                    };
+                    if receipt.receiver_id() == validated_tx.get().transaction.signer_id() {
+                        processing_state.local_receipts.push_back(receipt);
+                    } else {
+                        receipt_sink.forward_or_buffer_receipt(
+                            receipt,
+                            apply_state,
+                            state_update,
+                            processing_state.epoch_info_provider,
+                        )?;
+                    }
+                    let compute = outcome_with_id.outcome.compute_usage;
+                    let compute =
+                        compute.expect("`process_transaction` must populate compute usage");
+                    total.add(outcome_with_id.outcome.gas_burnt, compute)?;
+                    if !checked_feature!("stable", ComputeCosts, processing_state.protocol_version)
+                    {
+                        assert_eq!(total.compute, total.gas, "Compute usage must match burnt gas");
+                    }
+                    processing_state.outcomes.push(outcome_with_id);
+                }
+                Err(err) => {
                     Self::handle_invalid_transaction(
-                        e.clone(),
+                        err,
                         &tx_hash,
                         processing_state.protocol_version,
                         "parallel validation error",
                     )?;
-                    continue;
                 }
-            };
-
-            let tx_result = self.process_transaction(
-                state_update,
-                apply_state,
-                signed_transaction,
-                &cost,
-                &mut processing_state.stats,
-            );
-            let (receipt, outcome_with_id) = match tx_result {
-                Ok(outcome) => outcome,
-                Err(e) => {
-                    Self::handle_invalid_transaction(
-                        e,
-                        &tx_hash,
-                        processing_state.protocol_version,
-                        "process_transaction error",
-                    )?;
-                    continue;
-                }
-            };
-            if receipt.receiver_id() == signed_transaction.transaction.signer_id() {
-                processing_state.local_receipts.push_back(receipt);
-            } else {
-                receipt_sink.forward_or_buffer_receipt(
-                    receipt,
-                    apply_state,
-                    state_update,
-                    processing_state.epoch_info_provider,
-                )?;
             }
-            let compute = outcome_with_id.outcome.compute_usage;
-            let compute = compute.expect("`process_transaction` must populate compute usage");
-            total.add(outcome_with_id.outcome.gas_burnt, compute)?;
-            if !checked_feature!("stable", ComputeCosts, processing_state.protocol_version) {
-                assert_eq!(total.compute, total.gas, "Compute usage must match burnt gas");
-            }
-            processing_state.outcomes.push(outcome_with_id);
         }
         processing_state.metrics.tx_processing_done(total.gas, total.compute);
         Ok(())

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -359,7 +359,7 @@ impl Runtime {
                 state_update.commit(StateChangeCause::TransactionProcessing {
                     tx_hash: validated_tx.to_signed_tx().get_hash(),
                 });
-                let transaction = &validated_tx.to_signed_tx().transaction;
+                let transaction = validated_tx.to_tx();
                 let receipt_id = create_receipt_id_from_transaction(
                     apply_state.current_protocol_version,
                     validated_tx.to_signed_tx(),

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -325,7 +325,7 @@ impl Runtime {
     /// In case of an error, returns either `InvalidTxError` if the transaction verification failed
     /// or a `StorageError` wrapped into `RuntimeError`.
     #[instrument(target = "runtime", level = "debug", "process_transaction", skip_all, fields(
-        tx_hash = %validated_tx.to_signed_tx().get_hash(),
+        tx_hash = %validated_tx.get_hash(),
         gas_burnt = tracing::field::Empty,
         compute_usage = tracing::field::Empty,
     ))]
@@ -357,7 +357,7 @@ impl Runtime {
                     &verification_result.access_key,
                 );
                 state_update.commit(StateChangeCause::TransactionProcessing {
-                    tx_hash: validated_tx.to_signed_tx().get_hash(),
+                    tx_hash: validated_tx.get_hash(),
                 });
                 let transaction = validated_tx.to_tx();
                 let receipt_id = create_receipt_id_from_transaction(
@@ -388,7 +388,7 @@ impl Runtime {
                 let gas_burnt = verification_result.gas_burnt;
                 let compute_usage = verification_result.gas_burnt;
                 let outcome = ExecutionOutcomeWithId {
-                    id: validated_tx.to_signed_tx().get_hash(),
+                    id: validated_tx.get_hash(),
                     outcome: ExecutionOutcome {
                         status: ExecutionStatus::SuccessReceiptId(*receipt.receipt_id()),
                         logs: vec![],

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -86,6 +86,7 @@ fn is_zero_balance_account(account: &Account) -> bool {
 
 /// Validates the transaction without using the state. It allows any node to validate a
 /// transaction before forwarding it to the node that tracks the `signer_id` account.
+#[allow(clippy::result_large_err)]
 pub fn validate_transaction(
     config: &RuntimeConfig,
     signed_tx: SignedTransaction,

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -767,12 +767,7 @@ mod tests {
                 return;
             }
         };
-        let cost = match tx_cost(
-            config,
-            &validated_tx.to_signed_transaction().transaction,
-            gas_price,
-            PROTOCOL_VERSION,
-        ) {
+        let cost = match tx_cost(config, &validated_tx, gas_price, PROTOCOL_VERSION) {
             Ok(c) => c,
             Err(err) => {
                 assert_eq!(InvalidTxError::from(err), expected_err);
@@ -805,12 +800,7 @@ mod tests {
             Ok(tx) => tx,
             Err((err, _tx)) => return Err(err),
         };
-        let transaction_cost = tx_cost(
-            config,
-            &tx.to_signed_transaction().transaction,
-            gas_price,
-            current_protocol_version,
-        )?;
+        let transaction_cost = tx_cost(config, &tx, gas_price, current_protocol_version)?;
         let vr = verify_and_charge_tx_ephemeral(
             config,
             state_update,

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -151,7 +151,7 @@ pub fn verify_and_charge_tx_ephemeral(
     let TransactionCost { gas_burnt, gas_remaining, receipt_gas_price, total_cost, burnt_amount } =
         *transaction_cost;
 
-    let tx = validated_tx.to_transaction();
+    let tx = validated_tx.to_tx();
     let signer_id = tx.signer_id();
 
     let mut signer = match get_account(state_update, signer_id)? {
@@ -807,12 +807,7 @@ mod tests {
             block_height,
             current_protocol_version,
         )?;
-        commit_charging_for_tx(
-            state_update,
-            validated_tx.to_transaction(),
-            &vr.signer,
-            &vr.access_key,
-        );
+        commit_charging_for_tx(state_update, validated_tx.to_tx(), &vr.signer, &vr.access_key);
         Ok(vr)
     }
 

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -95,30 +95,24 @@ pub fn validate_transaction(
     if matches!(signed_tx.transaction, near_primitives::transaction::Transaction::V1(_)) {
         return Err((InvalidTxError::InvalidTransactionVersion, signed_tx));
     }
-    let transaction = &signed_tx.transaction;
-
-    let transaction_size = signed_tx.get_size();
-    let max_transaction_size = config.wasm_config.limit_config.max_transaction_size;
-    if transaction_size > max_transaction_size {
+    let tx = &signed_tx.transaction;
+    let tx_size = signed_tx.get_size();
+    let max_tx_size = config.wasm_config.limit_config.max_transaction_size;
+    if tx_size > max_tx_size {
         return Err((
-            InvalidTxError::TransactionSizeExceeded {
-                size: transaction_size,
-                limit: max_transaction_size,
-            },
+            InvalidTxError::TransactionSizeExceeded { size: tx_size, limit: max_tx_size },
             signed_tx,
         ));
     }
 
-    if let Err(err) = validate_actions(
-        &config.wasm_config.limit_config,
-        transaction.actions(),
-        current_protocol_version,
-    ) {
+    if let Err(err) =
+        validate_actions(&config.wasm_config.limit_config, tx.actions(), current_protocol_version)
+    {
         return Err((InvalidTxError::ActionsValidation(err), signed_tx));
     }
 
     match ValidatedTransaction::new(signed_tx) {
-        Ok(v) => Ok(v),
+        Ok(validated_tx) => Ok(validated_tx),
         Err(signed_tx) => Err((InvalidTxError::InvalidSignature, signed_tx)),
     }
 }


### PR DESCRIPTION
This PR introduces the `ValidatedTransaction` type and starts to use it in `process_tx_internal` i.e. when a transaction is received from the rpc nodes.  In order to keep the scope small enough, this PR does not store validated transactions in the tx pool yet so we still have to do validation when we produce chunks.  

