### PR TITLE
fix: orphaned optimistic blocks

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1574,7 +1574,7 @@ impl Chain {
         let block_height = block.height();
         match self.process_optimistic_block(me, block, chunks, apply_chunks_done_sender) {
             Ok(()) => {
-                info!(
+                debug!(
                     target: "chain", prev_block_hash = ?prev_block_hash,
                     hash = ?block_hash, height = block_height,
                     "Processed optimistic block"

--- a/chain/chain/src/metrics.rs
+++ b/chain/chain/src/metrics.rs
@@ -67,6 +67,10 @@ pub static VALIDATOR_ACTIVE_TOTAL: LazyLock<IntGauge> = LazyLock::new(|| {
 });
 pub static NUM_ORPHANS: LazyLock<IntGauge> =
     LazyLock::new(|| try_create_int_gauge("near_num_orphans", "Number of orphan blocks.").unwrap());
+pub static NUM_OPTIMISTIC_ORPHANS: LazyLock<IntGauge> = LazyLock::new(|| {
+    try_create_int_gauge("near_num_optimistic_orphans", "Number of optimistic orphan blocks.")
+        .unwrap()
+});
 pub static HEADER_HEAD_HEIGHT: LazyLock<IntGauge> = LazyLock::new(|| {
     try_create_int_gauge("near_header_head_height", "Height of the header head").unwrap()
 });
@@ -148,6 +152,13 @@ pub static STATE_PART_CACHE_MISS: LazyLock<IntCounter> = LazyLock::new(|| {
 pub static NUM_INVALID_BLOCKS: LazyLock<IntGaugeVec> = LazyLock::new(|| {
     try_create_int_gauge_vec("near_num_invalid_blocks", "Number of invalid blocks", &["error"])
         .unwrap()
+});
+pub static NUM_INVALID_OPTIMISTIC_BLOCKS: LazyLock<IntCounter> = LazyLock::new(|| {
+    try_create_int_counter(
+        "near_num_invalid_optimistic_blocks",
+        "Number of invalid optimistic blocks",
+    )
+    .unwrap()
 });
 pub(crate) static SCHEDULED_CATCHUP_BLOCK: LazyLock<IntGauge> = LazyLock::new(|| {
     try_create_int_gauge(

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1406,7 +1406,13 @@ impl ClientActorInner {
         // We’ve produced the optimistic block, mark it as done so we don't produce it again.
         self.client.save_optimistic_block(&optimistic_block);
         self.client.chain.optimistic_block_chunks.add_block(optimistic_block);
-        self.client.maybe_process_optimistic_block();
+
+        let signer = self.client.validator_signer.get();
+        let me = signer.as_ref().map(|signer| signer.validator_id().clone());
+        self.client.chain.maybe_process_optimistic_block(
+            &me,
+            Some(self.client.myself_sender.apply_chunks_done.clone()),
+        );
 
         Ok(())
     }

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -6,14 +6,6 @@ use near_o11y::metrics::{
 };
 use std::sync::LazyLock;
 
-pub(crate) static NUM_INVALID_OPTIMISTIC_BLOCKS: LazyLock<IntCounter> = LazyLock::new(|| {
-    try_create_int_counter(
-        "near_num_invalid_optimistic_blocks",
-        "Number of invalid optimistic blocks",
-    )
-    .unwrap()
-});
-
 pub(crate) static BLOCK_PRODUCED_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
     try_create_int_counter(
         "near_block_produced_total",

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -53,6 +53,8 @@ mod reward_calculator;
 pub mod shard_assignment;
 pub mod shard_tracker;
 pub mod test_utils;
+pub mod validate;
+
 #[cfg(test)]
 mod tests;
 mod validator_selection;

--- a/chain/epoch-manager/src/validate.rs
+++ b/chain/epoch-manager/src/validate.rs
@@ -1,0 +1,54 @@
+use near_chain_primitives::Error;
+use near_primitives::block::Tip;
+use near_primitives::errors::EpochError;
+use near_primitives::optimistic_block::OptimisticBlock;
+use near_store::{HEAD_KEY, Store};
+
+use crate::EpochManagerAdapter;
+
+/// Validate whether Optimistic Block is relevant to be processed,
+/// even if its epoch id is not known yet.
+/// TODO: move to the same crate as `validate_chunk_relevant`.
+pub fn validate_optimistic_block_relevant(
+    epoch_manager_adapter: &dyn EpochManagerAdapter,
+    block: &OptimisticBlock,
+    store: &Store,
+) -> Result<bool, Error> {
+    let head = store.get_ser::<Tip>(near_store::DBCol::BlockMisc, HEAD_KEY)?;
+    let Some(head) = head else {
+        return Ok(true);
+    };
+
+    if block.height() <= head.height {
+        return Err(Error::InvalidBlockHeight(block.height()));
+    }
+
+    // A heuristic to prevent block height to jump too fast towards BlockHeight::max and cause
+    // overflow-related problems
+    let epoch_config = epoch_manager_adapter.get_epoch_config(&head.epoch_id)?;
+    if block.height() > head.height + epoch_config.epoch_length * 20 {
+        return Err(Error::InvalidBlockHeight(block.height()));
+    }
+
+    if !epoch_manager_adapter.should_validate_signatures() {
+        return Ok(true);
+    }
+    // A heuristic to check signature of the block even if prev block hash is not saved yet
+    let epoch_ids =
+        match epoch_manager_adapter.get_epoch_id_from_prev_block(&block.prev_block_hash()) {
+            Ok(epoch_id) => vec![epoch_id],
+            Err(EpochError::MissingBlock(_)) => {
+                epoch_manager_adapter.possible_epochs_of_height_around_tip(&head, block.height())?
+            }
+            Err(err) => return Err(err.into()),
+        };
+
+    for epoch_id in epoch_ids {
+        let validator = epoch_manager_adapter.get_block_producer_info(&epoch_id, block.height())?;
+        if block.signature.verify(block.hash().as_bytes(), validator.public_key()) {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}

--- a/chain/epoch-manager/src/validate.rs
+++ b/chain/epoch-manager/src/validate.rs
@@ -33,6 +33,7 @@ pub fn validate_optimistic_block_relevant(
     if !epoch_manager_adapter.should_validate_signatures() {
         return Ok(true);
     }
+
     // A heuristic to check signature of the block even if prev block hash is not saved yet
     let epoch_ids =
         match epoch_manager_adapter.get_epoch_id_from_prev_block(&block.prev_block_hash()) {


### PR DESCRIPTION
I discovered that with small block delays, we often may not even have previous block when we receive OB.
So we need to put OB into the orphan pool until prev block is postprocessed and we can fully process it again.

In such case, we also cannot fully verify OB, so I reuse heuristic from the state witness validation - we check which epoch ids it may correspond to and try to verify signature for each such potential epoch. This limits malicious behaviour to the block producers.

We are in a bit of a rush before 2.6.0, so I've just checked manually that the new code path is indeed used.

I also had to move `maybe_process_optimistic_block` to Chain because orphans are part of Chain.

(1)
<img width="1784" alt="image" src="https://github.com/user-attachments/assets/4c2bf29c-cfde-40b5-ac79-c56f08dc2662" />

(2)
<img width="1784" alt="image" src="https://github.com/user-attachments/assets/eb457b45-acc3-4607-902b-86ffb35f7916" />
