### PR TITLE
benchmark: run tx generation tasks in parallel + report mean processing rate

### DIFF
--- a/benchmarks/synth-bm/src/rpc.rs
+++ b/benchmarks/synth-bm/src/rpc.rs
@@ -17,7 +17,7 @@ use near_primitives::{
     },
 };
 use tokio::sync::mpsc::Receiver;
-use tracing::{info, warn};
+use tracing::{info, warn, debug};
 
 pub fn new_request(
     transaction: Transaction,

--- a/benchmarks/transactions-generator/justfile
+++ b/benchmarks/transactions-generator/justfile
@@ -32,7 +32,7 @@ create-accounts:
         --user-data-dir user-data
 
 enable-tx tps:
-    jq '.tx_generator={"tps": {{tps}}, "volume": 0, "accounts_path": "{{near_accounts_path}}"}' {{near_config_file}} > tmp_config.json
+    jq '.tx_generator={"tps": {{tps}}, "volume": 0, "accounts_path": "{{near_accounts_path}}", "thread_count": 2}' {{near_config_file}} > tmp_config.json
     mv tmp_config.json {{near_config_file}}
 
 unlimit:

--- a/benchmarks/transactions-generator/src/welford.rs
+++ b/benchmarks/transactions-generator/src/welford.rs
@@ -1,0 +1,28 @@
+use std::ops::{AddAssign, Div, Sub};
+
+#[derive(Debug, Clone)]
+pub struct Mean<T> {
+    mean: T,
+    count: i64,
+}
+
+impl<T> Mean<T>
+where
+    T: Default + Clone,
+    T: Sub,
+    <T as Sub>::Output: Div<i64>,
+    T: AddAssign<<<T as Sub>::Output as Div<i64>>::Output>,
+{
+    pub fn new() -> Self {
+        Self { mean: T::default(), count: 0 }
+    }
+
+    pub fn add_measurement(&mut self, x: T) {
+        self.count += 1;
+        self.mean += (x - self.mean.clone()) / self.count;
+    }
+
+    pub fn mean(&self) -> &T {
+        &self.mean
+    }
+}


### PR DESCRIPTION
Running the tx generation in a single task results in effectively measuring the pool insertion latency instead of throughput. That made sense in a single-threaded pool injection setup. 
Current change enables generating sufficient load to benchmark the transaction injection for multithreaded `process_tx`.

Unbreak the synth-bm on the way.