### PR TITLE
[fix] `check_balance` removal under protocol feature flag

### DIFF
--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -185,6 +185,8 @@ pub enum ProtocolFeature {
     /// Chunks no longer become entirely invalid in case invalid transactions are included in the
     /// chunk. Instead the transactions are discarded during their conversion to receipts.
     RelaxedChunkValidation,
+    /// This enables us to remove the expensive check_balance call from the runtime.
+    RemoveCheckBalance,
     /// Exclude existing contract code in deploy-contract and delete-account actions from the chunk state witness.
     /// Instead of sending code in the witness, the code checks the code-size using the internal trie nodes.
     ExcludeExistingCodeFromWitnessForCodeLen,
@@ -256,6 +258,7 @@ impl ProtocolFeature {
             | ProtocolFeature::RejectBlocksWithOutdatedProtocolVersions
             | ProtocolFeature::FixChunkProducerStakingThreshold
             | ProtocolFeature::RelaxedChunkValidation
+            | ProtocolFeature::RemoveCheckBalance
             // BandwidthScheduler and CurrentEpochStateSync must be enabled
             // before ReshardingV3! When releasing this feature please make sure
             // to schedule separate protocol upgrades for these features.

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -2222,30 +2222,7 @@ impl Runtime {
             &mut stats,
         )?;
 
-        if ProtocolFeature::RemoveCheckBalance.enabled(protocol_version) {
-            if cfg!(debug_assertions) {
-                if let Err(err) = check_balance(
-                    &apply_state.config,
-                    &state_update,
-                    validator_accounts_update,
-                    processing_state.incoming_receipts,
-                    &processed_delayed_receipts,
-                    &promise_yield_result.timeout_receipts,
-                    processing_state.transactions,
-                    &receipt_sink.outgoing_receipts(),
-                    &stats.balance,
-                ) {
-                    panic!(
-                        "The runtime's balance_checker failed for shard {} at height {} with block hash {} and protocol version {}: {}",
-                        apply_state.shard_id,
-                        apply_state.block_height,
-                        apply_state.block_hash,
-                        apply_state.current_protocol_version,
-                        err
-                    );
-                }
-            }
-        } else {
+        if !ProtocolFeature::RemoveCheckBalance.enabled(protocol_version) {
             check_balance(
                 &apply_state.config,
                 &state_update,


### PR DESCRIPTION
`check_balance` was converted to a debug assert in PR https://github.com/near/nearcore/pull/12516

Unfortunately, this was a protocol change and meant old and new nodes were not in coordination any more.

This PR puts `check_ balance` behind a protocol feature flag