### PR TITLE
[fix] `check_balance` removal under protocol feature flag (#13053)

### DIFF
--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -189,6 +189,8 @@ pub enum ProtocolFeature {
     /// Chunks no longer become entirely invalid in case invalid transactions are included in the
     /// chunk. Instead the transactions are discarded during their conversion to receipts.
     RelaxedChunkValidation,
+    /// This enables us to remove the expensive check_balance call from the runtime.
+    RemoveCheckBalance,
     /// Exclude existing contract code in deploy-contract and delete-account actions from the chunk state witness.
     /// Instead of sending code in the witness, the code checks the code-size using the internal trie nodes.
     ExcludeExistingCodeFromWitnessForCodeLen,
@@ -260,6 +262,7 @@ impl ProtocolFeature {
             | ProtocolFeature::RejectBlocksWithOutdatedProtocolVersions
             | ProtocolFeature::FixChunkProducerStakingThreshold
             | ProtocolFeature::RelaxedChunkValidation
+            | ProtocolFeature::RemoveCheckBalance
             // BandwidthScheduler and CurrentEpochStateSync must be enabled
             // before ReshardingV3! When releasing this feature please make sure
             // to schedule separate protocol upgrades for these features.

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -2115,6 +2115,7 @@ impl Runtime {
         let apply_state = processing_state.apply_state;
         let epoch_info_provider = processing_state.epoch_info_provider;
         let mut state_update = processing_state.state_update;
+        let protocol_version = apply_state.current_protocol_version;
         let pending_delayed_receipts = processing_state.delayed_receipts;
         let processed_delayed_receipts = process_receipts_result.processed_delayed_receipts;
         let promise_yield_result = process_receipts_result.promise_yield_result;
@@ -2136,7 +2137,6 @@ impl Runtime {
         let mut own_congestion_info = receipt_sink.own_congestion_info();
         if let Some(congestion_info) = &mut own_congestion_info {
             pending_delayed_receipts.apply_congestion_changes(congestion_info)?;
-            let protocol_version = apply_state.current_protocol_version;
 
             let (all_shards, shard_seed) =
                 if ProtocolFeature::SimpleNightshadeV4.enabled(protocol_version) {
@@ -2163,8 +2163,8 @@ impl Runtime {
         let bandwidth_requests =
             receipt_sink.generate_bandwidth_requests(&state_update, &shard_layout, true)?;
 
-        if cfg!(debug_assertions) {
-            if let Err(err) = check_balance(
+        if !ProtocolFeature::RemoveCheckBalance.enabled(protocol_version) {
+            check_balance(
                 &apply_state.config,
                 &state_update,
                 validator_accounts_update,
@@ -2174,16 +2174,7 @@ impl Runtime {
                 processing_state.transactions,
                 &receipt_sink.outgoing_receipts(),
                 &processing_state.stats,
-            ) {
-                panic!(
-                    "The runtime's balance_checker failed for shard {} at height {} with block hash {} and protocol version {}: {}",
-                    apply_state.shard_id,
-                    apply_state.block_height,
-                    apply_state.block_hash,
-                    apply_state.current_protocol_version,
-                    err
-                );
-            }
+            )?;
         }
 
         state_update.commit(StateChangeCause::UpdatedDelayedReceipts);


### PR DESCRIPTION
`check_balance` was converted to a debug assert in PR https://github.com/near/nearcore/pull/12516

Unfortunately, this was a protocol change and meant old and new nodes were not in coordination any more.

This PR puts `check_ balance` behind a protocol feature flag