### PR TITLE
store: move concerns about TTN and storage types outta contract runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5320,7 +5320,6 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "assert_matches",
- "base64 0.21.0",
  "blst",
  "bolero",
  "borsh",
@@ -5628,6 +5627,7 @@ name = "node-runtime"
 version = "0.0.0"
 dependencies = [
  "assert_matches",
+ "base64 0.21.0",
  "borsh",
  "bytesize",
  "enum-map",

--- a/integration-tests/src/tests/features/chunk_nodes_cache.rs
+++ b/integration-tests/src/tests/features/chunk_nodes_cache.rs
@@ -1,3 +1,6 @@
+use crate::env::nightshade_setup::TestEnvNightshadeSetupExt;
+use crate::env::test_env::TestEnv;
+use crate::utils::process_blocks::{deploy_test_contract, set_block_protocol_version};
 use assert_matches::assert_matches;
 use near_chain::Provenance;
 use near_chain_configs::Genesis;
@@ -12,11 +15,8 @@ use near_primitives::transaction::{
 use near_primitives::types::{BlockHeightDelta, Gas};
 use near_primitives::version::{ProtocolFeature, ProtocolVersion};
 use near_primitives::views::FinalExecutionStatus;
-use near_vm_runner::logic::TrieNodesCount;
+use near_store::trie::TrieNodesCount;
 
-use crate::env::nightshade_setup::TestEnvNightshadeSetupExt;
-use crate::env::test_env::TestEnv;
-use crate::utils::process_blocks::{deploy_test_contract, set_block_protocol_version};
 
 fn process_transaction(
     env: &mut TestEnv,

--- a/integration-tests/src/tests/features/chunk_nodes_cache.rs
+++ b/integration-tests/src/tests/features/chunk_nodes_cache.rs
@@ -17,7 +17,6 @@ use near_primitives::version::{ProtocolFeature, ProtocolVersion};
 use near_primitives::views::FinalExecutionStatus;
 use near_store::trie::TrieNodesCount;
 
-
 fn process_transaction(
     env: &mut TestEnv,
     signer: &Signer,

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -172,7 +172,7 @@ sandbox = [
   "near-o11y/sandbox",
   "node-runtime/sandbox",
 ]
-io_trace = ["near-vm-runner/io_trace"]
+io_trace = ["node-runtime/io_trace"]
 
 calimero_zero_storage = ["near-primitives/calimero_zero_storage"]
 tx_generator = ["near-transactions-generator"]

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
-base64 = { workspace = true, optional = true }
 blst.workspace = true
 bn.workspace = true
 borsh.workspace = true
@@ -146,7 +145,6 @@ nightly = [
   "protocol_feature_fix_contract_loading_cost",
 ]
 sandbox = ["near-o11y/sandbox"]
-io_trace = ["base64"]
 test_features = []
 protocol_schema = [
   "near-crypto/protocol_schema",

--- a/runtime/near-vm-runner/src/logic/dependencies.rs
+++ b/runtime/near-vm-runner/src/logic/dependencies.rs
@@ -1,6 +1,6 @@
 //! External dependencies of the near-vm-logic.
-use super::types::ReceiptIndex;
 use super::VMLogicError;
+use super::types::ReceiptIndex;
 use near_crypto::PublicKey;
 use near_parameters::vm::StorageGetMode;
 use near_primitives_core::hash::CryptoHash;

--- a/runtime/near-vm-runner/src/logic/dependencies.rs
+++ b/runtime/near-vm-runner/src/logic/dependencies.rs
@@ -227,38 +227,6 @@ pub trait External {
         key: &[u8],
     ) -> Result<Option<Vec<u8>>>;
 
-    /// Note: The method is currently unused and untested.
-    ///
-    /// Removes all keys with a given `prefix` from the storage trie associated with current
-    /// account.
-    ///
-    /// # Arguments
-    ///
-    /// * `prefix` - a prefix for all keys to remove
-    ///
-    /// # Errors
-    ///
-    /// This function could return [`near_vm_runner::logic::VMError`].
-    ///
-    /// # Example
-    /// ```
-    /// # use near_vm_runner::logic::mocks::mock_external::MockedExternal;
-    /// # use near_vm_runner::logic::gas_counter::FreeGasCounter;
-    /// # use near_vm_runner::logic::{External, StorageGetMode};
-    ///
-    /// # let mut external = MockedExternal::new();
-    /// external.storage_set(&mut FreeGasCounter, b"key1", b"value1337").unwrap();
-    /// external.storage_set(&mut FreeGasCounter, b"key2", b"value1337").unwrap();
-    /// assert_eq!(external.storage_remove_subtree(&mut FreeGasCounter, b"key"), Ok(()));
-    /// assert!(!external.storage_has_key(&mut FreeGasCounter, b"key1", StorageGetMode::Trie).unwrap());
-    /// assert!(!external.storage_has_key(&mut FreeGasCounter, b"key2", StorageGetMode::Trie).unwrap());
-    /// ```
-    fn storage_remove_subtree(
-        &mut self,
-        access_tracker: &mut dyn StorageAccessTracker,
-        prefix: &[u8],
-    ) -> Result<()>;
-
     /// Check whether the `key` is present in the storage trie associated with the current account.
     ///
     /// Returns `Ok(true)` if key is present, `Ok(false)` if the key is not present.

--- a/runtime/near-vm-runner/src/logic/gas_counter.rs
+++ b/runtime/near-vm-runner/src/logic/gas_counter.rs
@@ -1,7 +1,7 @@
-use super::dependencies::TrieNodesCount;
+use super::dependencies::StorageAccessTracker;
+use super::dependencies::sealed::StorageAccessTrackerSeal;
 use super::errors::{HostError, VMLogicError};
 use crate::ProfileDataV3;
-use near_parameters::ExtCosts::{read_cached_trie_node, touching_trie_node};
 use near_parameters::{ActionCosts, ExtCosts, ExtCostsConfig};
 use near_primitives_core::types::Gas;
 use std::collections::HashMap;
@@ -38,6 +38,27 @@ pub(crate) struct FastGasCounter {
     pub gas_limit: u64,
     /// Cost for one opcode. Used only by VMs preceding near_vm.
     pub opcode_cost: u64,
+}
+
+/// A gas counter type that does not actually count any gas.
+///
+/// For use in tests or when an operation does not need to account for TTN fees.
+pub struct FreeGasCounter;
+
+impl StorageAccessTrackerSeal for FreeGasCounter {}
+impl StorageAccessTracker for FreeGasCounter {
+    fn trie_node_touched(&mut self, _: u64) -> Result<()> {
+        Ok(())
+    }
+    fn cached_trie_node_access(&mut self, _: u64) -> Result<()> {
+        Ok(())
+    }
+    fn deref_write_evicted_value_bytes(&mut self, _: u64) -> Result<()> {
+        Ok(())
+    }
+    fn deref_removed_value_bytes(&mut self, _: u64) -> Result<()> {
+        Ok(())
+    }
 }
 
 /// Gas counter (a part of VMlogic)
@@ -317,12 +338,6 @@ impl GasCounter {
         deduct_gas_result
     }
 
-    pub(crate) fn add_trie_fees(&mut self, count: &TrieNodesCount) -> Result<()> {
-        self.pay_per(touching_trie_node, count.db_reads)?;
-        self.pay_per(read_cached_trie_node, count.mem_reads)?;
-        Ok(())
-    }
-
     pub(crate) fn prepay_gas(&mut self, use_gas: Gas) -> Result<()> {
         self.deduct_gas(0, use_gas)
     }
@@ -338,6 +353,24 @@ impl GasCounter {
 
     pub(crate) fn profile_data(&self) -> ProfileDataV3 {
         self.profile.clone()
+    }
+}
+
+impl StorageAccessTrackerSeal for GasCounter {}
+impl StorageAccessTracker for GasCounter {
+    fn trie_node_touched(&mut self, count: u64) -> Result<()> {
+        self.pay_per(ExtCosts::touching_trie_node, count)
+    }
+
+    fn cached_trie_node_access(&mut self, count: u64) -> Result<()> {
+        self.pay_per(ExtCosts::read_cached_trie_node, count)
+    }
+
+    fn deref_write_evicted_value_bytes(&mut self, bytes: u64) -> super::dependencies::Result<()> {
+        self.pay_per(ExtCosts::storage_write_evicted_byte, bytes)
+    }
+    fn deref_removed_value_bytes(&mut self, bytes: u64) -> Result<()> {
+        self.pay_per(ExtCosts::storage_remove_ret_value_byte, bytes)
     }
 }
 

--- a/runtime/near-vm-runner/src/logic/gas_counter.rs
+++ b/runtime/near-vm-runner/src/logic/gas_counter.rs
@@ -366,7 +366,7 @@ impl StorageAccessTracker for GasCounter {
         self.pay_per(ExtCosts::read_cached_trie_node, count)
     }
 
-    fn deref_write_evicted_value_bytes(&mut self, bytes: u64) -> super::dependencies::Result<()> {
+    fn deref_write_evicted_value_bytes(&mut self, bytes: u64) -> Result<()> {
         self.pay_per(ExtCosts::storage_write_evicted_byte, bytes)
     }
     fn deref_removed_value_bytes(&mut self, bytes: u64) -> Result<()> {

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -25,12 +25,6 @@ use std::sync::Arc;
 
 pub type Result<T, E = VMLogicError> = ::std::result::Result<T, E>;
 
-#[cfg(feature = "io_trace")]
-fn base64(s: &[u8]) -> String {
-    use base64::Engine;
-    base64::engine::general_purpose::STANDARD.encode(s)
-}
-
 /// Structure representing the results and outcomes of a contract execution.
 ///
 /// This is a subset of [`VMLogic`] that's strictly necessary to produce `VMOutcome`s.

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -1,4 +1,3 @@
-use super::ValuePtr;
 use super::context::VMContext;
 use super::dependencies::{External, MemSlice, MemoryLike};
 use super::errors::{FunctionCallError, InconsistentStateError};
@@ -9,9 +8,10 @@ use super::utils::split_method_names;
 use super::{HostError, VMLogicError};
 use crate::ProfileDataV3;
 use crate::bls12381_impl;
+use crate::logic::gas_counter::FreeGasCounter;
 use ExtCosts::*;
 use near_crypto::Secp256K1Signature;
-use near_parameters::vm::{Config, StorageGetMode};
+use near_parameters::vm::Config;
 use near_parameters::{
     ActionCosts, ExtCosts, RuntimeFeesConfig, transfer_exec_fee, transfer_send_fee,
 };
@@ -3057,34 +3057,7 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
         }
         self.result_state.gas_counter.pay_per(storage_write_key_byte, key.len() as u64)?;
         self.result_state.gas_counter.pay_per(storage_write_value_byte, value.len() as u64)?;
-        let nodes_before = self.ext.get_trie_nodes_count();
-        // For storage write, we need to first perform a read on the key to calculate the TTN cost.
-        // This storage_get must be performed through trie instead of through FlatStorage
-        let evicted_ptr = self.ext.storage_get(&key, StorageGetMode::Trie)?;
-        let evicted = Self::deref_value(
-            &mut self.result_state.gas_counter,
-            storage_write_evicted_byte,
-            evicted_ptr,
-        )?;
-        let nodes_delta = self
-            .ext
-            .get_trie_nodes_count()
-            .checked_sub(&nodes_before)
-            .ok_or(InconsistentStateError::IntegerOverflow)?;
-
-        #[cfg(feature = "io_trace")]
-        tracing::trace!(
-            target = "io_tracer",
-            storage_op = "write",
-            key = base64(&key),
-            size = value_len,
-            evicted_len = evicted.as_ref().map(Vec::len),
-            tn_mem_reads = nodes_delta.mem_reads,
-            tn_db_reads = nodes_delta.db_reads,
-        );
-
-        self.result_state.gas_counter.add_trie_fees(&nodes_delta)?;
-        self.ext.storage_set(&key, &value)?;
+        let evicted = self.ext.storage_set(&mut self.result_state.gas_counter, &key, &value)?;
         let storage_config = &self.fees_config.storage_usage_config;
         self.recorded_storage_counter.observe_size(self.ext.get_recorded_storage_size())?;
         match evicted {
@@ -3125,20 +3098,6 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
         }
     }
 
-    fn deref_value<'s>(
-        gas_counter: &mut GasCounter,
-        cost_per_byte: ExtCosts,
-        value_ptr: Option<Box<dyn ValuePtr + 's>>,
-    ) -> Result<Option<Vec<u8>>> {
-        match value_ptr {
-            Some(value_ptr) => {
-                gas_counter.pay_per(cost_per_byte, value_ptr.len() as u64)?;
-                value_ptr.deref().map(Some)
-            }
-            None => Ok(None),
-        }
-    }
-
     /// Reads the value stored under the given key.
     /// * If key is used copies the content of the value into the `register_id`, even if the content
     ///   is zero bytes. Returns `1`;
@@ -3168,14 +3127,11 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
             .into());
         }
         self.result_state.gas_counter.pay_per(storage_read_key_byte, key.len() as u64)?;
-        let nodes_before = self.ext.get_trie_nodes_count();
-        let read = self.ext.storage_get(&key, self.config.storage_get_mode);
-        let nodes_delta = self
-            .ext
-            .get_trie_nodes_count()
-            .checked_sub(&nodes_before)
-            .ok_or(InconsistentStateError::IntegerOverflow)?;
-        self.result_state.gas_counter.add_trie_fees(&nodes_delta)?;
+        let read = self.ext.storage_get(
+            &mut self.result_state.gas_counter,
+            &key,
+            self.config.storage_get_mode,
+        );
         let read = match read? {
             Some(read) => {
                 // Here we'll do u32 -> usize -> u64, which is always infallible
@@ -3187,20 +3143,10 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
                         .gas_counter
                         .pay_per(storage_large_read_overhead_byte, read_len as u64)?;
                 }
-                Some(read.deref()?)
+                Some(read.deref(&mut FreeGasCounter)?)
             }
             None => None,
         };
-
-        #[cfg(feature = "io_trace")]
-        tracing::trace!(
-            target = "io_tracer",
-            storage_op = "read",
-            key = base64(&key),
-            size = read.as_ref().map(Vec::len),
-            tn_db_reads = nodes_delta.db_reads,
-            tn_mem_reads = nodes_delta.mem_reads,
-        );
 
         self.recorded_storage_counter.observe_size(self.ext.get_recorded_storage_size())?;
         match read {
@@ -3253,34 +3199,7 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
             .into());
         }
         self.result_state.gas_counter.pay_per(storage_remove_key_byte, key.len() as u64)?;
-        let nodes_before = self.ext.get_trie_nodes_count();
-        // To delete a key, we need to first perform a read on the key to calculate the TTN cost.
-        // This storage_get must be performed through trie instead of through FlatStorage
-        let removed_ptr = self.ext.storage_get(&key, StorageGetMode::Trie)?;
-        let removed = Self::deref_value(
-            &mut self.result_state.gas_counter,
-            storage_remove_ret_value_byte,
-            removed_ptr,
-        )?;
-
-        self.ext.storage_remove(&key)?;
-        let nodes_delta = self
-            .ext
-            .get_trie_nodes_count()
-            .checked_sub(&nodes_before)
-            .ok_or(InconsistentStateError::IntegerOverflow)?;
-
-        #[cfg(feature = "io_trace")]
-        tracing::trace!(
-            target = "io_tracer",
-            storage_op = "remove",
-            key = base64(&key),
-            evicted_len = removed.as_ref().map(Vec::len),
-            tn_mem_reads = nodes_delta.mem_reads,
-            tn_db_reads = nodes_delta.db_reads,
-        );
-
-        self.result_state.gas_counter.add_trie_fees(&nodes_delta)?;
+        let removed = self.ext.storage_remove(&mut self.result_state.gas_counter, &key)?;
         let storage_config = &self.fees_config.storage_usage_config;
         self.recorded_storage_counter.observe_size(self.ext.get_recorded_storage_size())?;
         match removed {
@@ -3331,24 +3250,12 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
             .into());
         }
         self.result_state.gas_counter.pay_per(storage_has_key_byte, key.len() as u64)?;
-        let nodes_before = self.ext.get_trie_nodes_count();
-        let res = self.ext.storage_has_key(&key, self.config.storage_get_mode);
-        let nodes_delta = self
-            .ext
-            .get_trie_nodes_count()
-            .checked_sub(&nodes_before)
-            .ok_or(InconsistentStateError::IntegerOverflow)?;
-
-        #[cfg(feature = "io_trace")]
-        tracing::trace!(
-            target = "io_tracer",
-            storage_op = "exists",
-            key = base64(&key),
-            tn_mem_reads = nodes_delta.mem_reads,
-            tn_db_reads = nodes_delta.db_reads,
+        let res = self.ext.storage_has_key(
+            &mut self.result_state.gas_counter,
+            &key,
+            self.config.storage_get_mode,
         );
 
-        self.result_state.gas_counter.add_trie_fees(&nodes_delta)?;
         self.recorded_storage_counter.observe_size(self.ext.get_recorded_storage_size())?;
         Ok(res? as u64)
     }

--- a/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
+++ b/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
@@ -148,7 +148,11 @@ impl External for MockedExternal {
             .map(|value| Box::new(MockedValuePtr { value: value.clone() }) as Box<_>))
     }
 
-    fn storage_remove(&mut self, _: &mut dyn StorageAccessTracker, key: &[u8]) -> Result<Option<Vec<u8>>> {
+    fn storage_remove(
+        &mut self,
+        _: &mut dyn StorageAccessTracker,
+        key: &[u8],
+    ) -> Result<Option<Vec<u8>>> {
         let value = self.fake_trie.remove(key);
         Ok(value)
     }

--- a/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
+++ b/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
@@ -157,15 +157,6 @@ impl External for MockedExternal {
         Ok(value)
     }
 
-    fn storage_remove_subtree(
-        &mut self,
-        _: &mut dyn StorageAccessTracker,
-        prefix: &[u8],
-    ) -> Result<()> {
-        self.fake_trie.retain(|key, _| !key.starts_with(prefix));
-        Ok(())
-    }
-
     fn storage_has_key(
         &mut self,
         _: &mut dyn StorageAccessTracker,

--- a/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
+++ b/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
@@ -1,5 +1,5 @@
 use crate::ContractCode;
-use crate::logic::dependencies::{Result, TrieNodesCount};
+use crate::logic::dependencies::{Result, StorageAccessTracker};
 use crate::logic::types::ReceiptIndex;
 use crate::logic::{External, StorageGetMode, ValuePtr};
 use near_primitives_core::hash::{CryptoHash, hash};
@@ -103,7 +103,10 @@ impl ValuePtr for MockedValuePtr {
         self.value.len() as u32
     }
 
-    fn deref(&self) -> crate::logic::dependencies::Result<Vec<u8>> {
+    fn deref(
+        &self,
+        _: &mut dyn StorageAccessTracker,
+    ) -> crate::logic::dependencies::Result<Vec<u8>> {
         Ok(self.value.clone())
     }
 }
@@ -123,29 +126,48 @@ impl MockedExternal {
 }
 
 impl External for MockedExternal {
-    fn storage_set(&mut self, key: &[u8], value: &[u8]) -> Result<()> {
-        self.fake_trie.insert(key.to_vec(), value.to_vec());
-        Ok(())
+    fn storage_set<'a>(
+        &'a mut self,
+        _: &mut dyn StorageAccessTracker,
+        key: &[u8],
+        value: &[u8],
+    ) -> Result<Option<Vec<u8>>> {
+        let value = self.fake_trie.insert(key.to_vec(), value.to_vec());
+        Ok(value)
     }
 
-    fn storage_get(&self, key: &[u8], _mode: StorageGetMode) -> Result<Option<Box<dyn ValuePtr>>> {
+    fn storage_get(
+        &self,
+        _: &mut dyn StorageAccessTracker,
+        key: &[u8],
+        _mode: StorageGetMode,
+    ) -> Result<Option<Box<dyn ValuePtr>>> {
         Ok(self
             .fake_trie
             .get(key)
             .map(|value| Box::new(MockedValuePtr { value: value.clone() }) as Box<_>))
     }
 
-    fn storage_remove(&mut self, key: &[u8]) -> Result<()> {
-        self.fake_trie.remove(key);
-        Ok(())
+    fn storage_remove(&mut self, _: &mut dyn StorageAccessTracker, key: &[u8]) -> Result<Option<Vec<u8>>> {
+        let value = self.fake_trie.remove(key);
+        Ok(value)
     }
 
-    fn storage_remove_subtree(&mut self, prefix: &[u8]) -> Result<()> {
+    fn storage_remove_subtree(
+        &mut self,
+        _: &mut dyn StorageAccessTracker,
+        prefix: &[u8],
+    ) -> Result<()> {
         self.fake_trie.retain(|key, _| !key.starts_with(prefix));
         Ok(())
     }
 
-    fn storage_has_key(&mut self, key: &[u8], _mode: StorageGetMode) -> Result<bool> {
+    fn storage_has_key(
+        &mut self,
+        _: &mut dyn StorageAccessTracker,
+        key: &[u8],
+        _mode: StorageGetMode,
+    ) -> Result<bool> {
         Ok(self.fake_trie.contains_key(key))
     }
 
@@ -155,10 +177,6 @@ impl External for MockedExternal {
         let data_id = hash(&self.data_count.to_le_bytes());
         self.data_count += 1;
         data_id
-    }
-
-    fn get_trie_nodes_count(&self) -> TrieNodesCount {
-        TrieNodesCount { db_reads: 0, mem_reads: 0 }
     }
 
     fn get_recorded_storage_size(&self) -> usize {

--- a/runtime/near-vm-runner/src/logic/mod.rs
+++ b/runtime/near-vm-runner/src/logic/mod.rs
@@ -15,7 +15,7 @@ mod utils;
 mod vmstate;
 
 pub use context::VMContext;
-pub use dependencies::{External, MemSlice, MemoryLike, TrieNodesCount, ValuePtr};
+pub use dependencies::{External, StorageAccessTracker, MemSlice, MemoryLike, ValuePtr};
 pub use errors::{HostError, VMLogicError};
 pub use gas_counter::{GasCounter, with_ext_cost_counter};
 pub use logic::{ExecutionResultState, VMLogic, VMOutcome};

--- a/runtime/near-vm-runner/src/logic/mod.rs
+++ b/runtime/near-vm-runner/src/logic/mod.rs
@@ -15,7 +15,7 @@ mod utils;
 mod vmstate;
 
 pub use context::VMContext;
-pub use dependencies::{External, StorageAccessTracker, MemSlice, MemoryLike, ValuePtr};
+pub use dependencies::{External, MemSlice, MemoryLike, StorageAccessTracker, ValuePtr};
 pub use errors::{HostError, VMLogicError};
 pub use gas_counter::{GasCounter, with_ext_cost_counter};
 pub use logic::{ExecutionResultState, VMLogic, VMOutcome};

--- a/runtime/near-vm-runner/src/logic/tests/storage_read_write.rs
+++ b/runtime/near-vm-runner/src/logic/tests/storage_read_write.rs
@@ -1,3 +1,4 @@
+use crate::logic::gas_counter::FreeGasCounter;
 use crate::logic::tests::vm_logic_builder::VMLogicBuilder;
 use crate::logic::{External, StorageGetMode};
 
@@ -14,8 +15,12 @@ fn test_storage_write_with_register() {
 
     logic.storage_write(u64::MAX, 1 as _, u64::MAX, 2 as _, 0).expect("storage write ok");
 
-    let value_ptr = logic_builder.ext.storage_get(key, StorageGetMode::Trie).unwrap().unwrap();
-    assert_eq!(value_ptr.deref().unwrap(), val.to_vec());
+    let value_ptr = logic_builder
+        .ext
+        .storage_get(&mut FreeGasCounter, key, StorageGetMode::Trie)
+        .unwrap()
+        .unwrap();
+    assert_eq!(value_ptr.deref(&mut FreeGasCounter).unwrap(), val.to_vec());
 }
 
 #[test]
@@ -24,8 +29,7 @@ fn test_storage_read_with_register() {
 
     let key: &[u8] = b"foo";
     let val: &[u8] = b"bar";
-
-    logic_builder.ext.storage_set(key, val).unwrap();
+    logic_builder.ext.storage_set(&mut FreeGasCounter, key, val).unwrap();
     let mut logic = logic_builder.build();
 
     logic.wrapped_internal_write_register(1, key).unwrap();
@@ -55,7 +59,7 @@ fn test_storage_has_key_with_register() {
 
     let key: &[u8] = b"foo";
     let val: &[u8] = b"bar";
-    logic_builder.ext.storage_set(key, val).unwrap();
+    logic_builder.ext.storage_set(&mut FreeGasCounter, key, val).unwrap();
 
     let mut logic = logic_builder.build();
 

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -1,4 +1,5 @@
 use super::test_vm_config;
+use crate::logic::gas_counter::FreeGasCounter;
 use crate::ContractCode;
 use crate::logic::errors::{FunctionCallError, HostError};
 use crate::logic::mocks::mock_external::MockedExternal;
@@ -45,9 +46,9 @@ pub fn test_ts_contract() {
             .expect("bad failure");
         // Verify by looking directly into the storage of the host.
         {
-            let res = fake_external.storage_get(b"foo", StorageGetMode::Trie);
+            let res = fake_external.storage_get(&mut FreeGasCounter, b"foo", StorageGetMode::Trie);
             let value_ptr = res.unwrap().unwrap();
-            let value = value_ptr.deref().unwrap();
+            let value = value_ptr.deref(&mut FreeGasCounter).unwrap();
             let value = String::from_utf8(value).unwrap();
             assert_eq!(value.as_str(), "bar");
         }

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -1,7 +1,7 @@
 use super::test_vm_config;
-use crate::logic::gas_counter::FreeGasCounter;
 use crate::ContractCode;
 use crate::logic::errors::{FunctionCallError, HostError};
+use crate::logic::gas_counter::FreeGasCounter;
 use crate::logic::mocks::mock_external::MockedExternal;
 use crate::logic::types::ReturnData;
 use crate::logic::{External, StorageGetMode};

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -89,4 +89,4 @@ nightly_protocol = [
   "node-runtime/nightly_protocol",
 ]
 sandbox = ["near-o11y/sandbox", "node-runtime/sandbox"]
-io_trace = ["near-store/io_trace", "near-o11y/io_trace", "near-vm-runner/io_trace"]
+io_trace = ["near-store/io_trace", "near-o11y/io_trace", "node-runtime/io_trace"]

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 workspace = true
 
 [dependencies]
+base64 = { workspace = true, optional = true }
 borsh.workspace = true
 itertools.workspace = true
 num-bigint.workspace = true
@@ -37,6 +38,7 @@ near-wallet-contract.workspace = true
 [features]
 default = []
 estimator = ["near-primitives/test_utils"]
+io_trace = ["base64"]
 nightly = [
   "near-chain-configs/nightly",
   "near-o11y/nightly",

--- a/runtime/runtime/src/conversions.rs
+++ b/runtime/runtime/src/conversions.rs
@@ -76,12 +76,6 @@ mod function_call_error {
     }
 }
 
-impl Convert<near_store::trie::TrieNodesCount> for near_vm_runner::logic::TrieNodesCount {
-    fn convert(other: near_store::trie::TrieNodesCount) -> Self {
-        Self { db_reads: other.db_reads, mem_reads: other.mem_reads }
-    }
-}
-
 mod profile_data_v3 {
     use near_vm_runner::ProfileDataV3 as From;
     impl super::Convert<From> for near_primitives::profile_data_v3::ProfileDataV3 {

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -1,4 +1,3 @@
-use crate::conversions::Convert;
 use crate::receipt_manager::ReceiptManager;
 use near_primitives::account::Account;
 use near_primitives::account::id::AccountType;
@@ -11,9 +10,9 @@ use near_primitives::utils::create_receipt_id_from_action_hash;
 use near_primitives::version::ProtocolVersion;
 use near_store::contract::ContractStorage;
 use near_store::{KeyLookupMode, TrieUpdate, TrieUpdateValuePtr, has_promise_yield_receipt};
-use near_vm_runner::logic::errors::{AnyError, VMLogicError};
+use near_vm_runner::logic::errors::{AnyError, InconsistentStateError, VMLogicError};
 use near_vm_runner::logic::types::ReceiptIndex;
-use near_vm_runner::logic::{External, StorageGetMode, ValuePtr};
+use near_vm_runner::logic::{External, StorageAccessTracker, StorageGetMode, ValuePtr};
 use near_vm_runner::{Contract, ContractCode};
 use near_wallet_contract::wallet_contract;
 use std::sync::Arc;
@@ -56,8 +55,21 @@ impl<'a> ValuePtr for RuntimeExtValuePtr<'a> {
         self.0.len()
     }
 
-    fn deref(&self) -> ExtResult<Vec<u8>> {
-        self.0.deref_value().map_err(wrap_storage_error)
+    fn deref(&self, access_tracker: &mut dyn StorageAccessTracker) -> ExtResult<Vec<u8>> {
+        match &self.0 {
+            TrieUpdateValuePtr::MemoryRef(data) => Ok(data.to_vec()),
+            TrieUpdateValuePtr::Ref(trie, optimized_value_ref) => {
+                let ttn = trie.get_trie_nodes_count();
+                let result = trie.deref_optimized(&optimized_value_ref);
+                let delta = trie
+                    .get_trie_nodes_count()
+                    .checked_sub(&ttn)
+                    .ok_or(InconsistentStateError::IntegerOverflow)?;
+                access_tracker.trie_node_touched(delta.db_reads)?;
+                access_tracker.cached_trie_node_access(delta.mem_reads)?;
+                Ok(result.map_err(wrap_storage_error)?)
+            }
+        }
     }
 }
 
@@ -121,48 +133,177 @@ fn wrap_storage_error(error: StorageError) -> VMLogicError {
 
 type ExtResult<T> = ::std::result::Result<T, VMLogicError>;
 
+// fn trie_node_counter(&mut self) -> near_vm_runner::logic::TrieNodesCounter {
+//     Convert::convert(self.trie_update.trie().get_trie_nodes_count())
+// }
+
 impl<'a> External for RuntimeExt<'a> {
-    fn storage_set(&mut self, key: &[u8], value: &[u8]) -> ExtResult<()> {
+    fn storage_set<'b>(
+        &'b mut self,
+        access_tracker: &mut dyn StorageAccessTracker,
+        key: &[u8],
+        value: &[u8],
+    ) -> ExtResult<Option<Vec<u8>>> {
+        // SUBTLE: Storage writes don't actually touch anything in the trie, at least not during
+        // the contract execution -- they just put a value as a prospective in a map in
+        // `TrieUpdate`. However we do need to grab the value for the evicted result and for all
+        // intents and purposes we need to both account for TTN fees and record the path to the
+        // value for the state witness. For that reason the lookup below has to happen through the
+        // Trie.
+        let ttn = self.trie_update.trie().get_trie_nodes_count();
         let storage_key = self.create_storage_key(key);
+        let evicted_ptr = self
+            .trie_update
+            .get_ref(&storage_key, KeyLookupMode::Trie)
+            .map_err(wrap_storage_error)?;
+        let evicted = match evicted_ptr {
+            None => None,
+            Some(ptr) => {
+                access_tracker.deref_write_evicted_value_bytes(u64::from(ptr.len()))?;
+                Some(ptr.deref_value().map_err(wrap_storage_error)?)
+            }
+        };
+        let ttn2 = self.trie_update.trie().get_trie_nodes_count();
+        let delta = ttn2.checked_sub(&ttn).ok_or(InconsistentStateError::IntegerOverflow)?;
+        access_tracker.trie_node_touched(delta.db_reads)?;
+        access_tracker.cached_trie_node_access(delta.mem_reads)?;
         self.trie_update.set(storage_key, Vec::from(value));
-        Ok(())
+        #[cfg(feature = "io_trace")]
+        tracing::trace!(
+            target = "io_tracer",
+            storage_op = "write",
+            key = base64(&key),
+            size = value_len,
+            evicted_len = evicted.as_ref().map(Vec::len),
+            tn_mem_reads = nodes_delta.mem_reads,
+            tn_db_reads = nodes_delta.db_reads,
+        );
+        Ok(evicted)
     }
 
     fn storage_get<'b>(
         &'b self,
+        access_tracker: &mut dyn StorageAccessTracker,
         key: &[u8],
         mode: StorageGetMode,
     ) -> ExtResult<Option<Box<dyn ValuePtr + 'b>>> {
+        let ttn = self.trie_update.trie().get_trie_nodes_count();
         let storage_key = self.create_storage_key(key);
         let mode = match mode {
             StorageGetMode::FlatStorage => KeyLookupMode::FlatStorage,
             StorageGetMode::Trie => KeyLookupMode::Trie,
         };
-        self.trie_update
+        let result = self
+            .trie_update
             .get_ref(&storage_key, mode)
             .map_err(wrap_storage_error)
-            .map(|option| option.map(|ptr| Box::new(RuntimeExtValuePtr(ptr)) as Box<_>))
+            .map(|option| option.map(|ptr| Box::new(RuntimeExtValuePtr(ptr)) as Box<_>));
+        let delta = self
+            .trie_update
+            .trie()
+            .get_trie_nodes_count()
+            .checked_sub(&ttn)
+            .ok_or(InconsistentStateError::IntegerOverflow)?;
+        access_tracker.trie_node_touched(delta.db_reads)?;
+        access_tracker.cached_trie_node_access(delta.mem_reads)?;
+
+        #[cfg(feature = "io_trace")]
+        tracing::trace!(
+            target = "io_tracer",
+            storage_op = "read",
+            key = base64(&key),
+            size = read.as_ref().map(Vec::len),
+            tn_db_reads = nodes_delta.db_reads,
+            tn_mem_reads = nodes_delta.mem_reads,
+        );
+        Ok(result?)
     }
 
-    fn storage_remove(&mut self, key: &[u8]) -> ExtResult<()> {
+    fn storage_remove(
+        &mut self,
+        access_tracker: &mut dyn StorageAccessTracker,
+        key: &[u8],
+    ) -> ExtResult<Option<Vec<u8>>> {
+        // SUBTLE: Storage removals don't actually touch anything in the trie, at least not during
+        // the contract execution -- they just put a value as a prospective in a map in
+        // `TrieUpdate`. However we do need to grab the value for the evicted result and for all
+        // intents and purposes we need to both account for TTN fees and record the path to the
+        // value for the state witness. For that reason the lookup below has to happen through the
+        // Trie.
+        let ttn = self.trie_update.trie().get_trie_nodes_count();
         let storage_key = self.create_storage_key(key);
+        let removed = self
+            .trie_update
+            .get_ref(&storage_key, KeyLookupMode::Trie)
+            .map_err(wrap_storage_error)?;
+        let removed = match removed {
+            None => None,
+            Some(ptr) => {
+                access_tracker.deref_removed_value_bytes(u64::from(ptr.len()))?;
+                Some(ptr.deref_value().map_err(wrap_storage_error)?)
+            }
+        };
         self.trie_update.remove(storage_key);
-        Ok(())
+        let ttn2 = self.trie_update.trie().get_trie_nodes_count();
+        let delta = ttn2.checked_sub(&ttn).ok_or(InconsistentStateError::IntegerOverflow)?;
+        access_tracker.trie_node_touched(delta.db_reads)?;
+        access_tracker.cached_trie_node_access(delta.mem_reads)?;
+
+        #[cfg(feature = "io_trace")]
+        tracing::trace!(
+            target = "io_tracer",
+            storage_op = "remove",
+            key = base64(&key),
+            evicted_len = removed.as_ref().map(Vec::len),
+            tn_mem_reads = delta.mem_reads,
+            tn_db_reads = delta.db_reads,
+        );
+
+        Ok(removed)
     }
 
-    fn storage_has_key(&mut self, key: &[u8], mode: StorageGetMode) -> ExtResult<bool> {
+    fn storage_has_key(
+        &mut self,
+        access_tracker: &mut dyn StorageAccessTracker,
+        key: &[u8],
+        mode: StorageGetMode,
+    ) -> ExtResult<bool> {
+        let ttn = self.trie_update.trie().get_trie_nodes_count();
         let storage_key = self.create_storage_key(key);
         let mode = match mode {
             StorageGetMode::FlatStorage => KeyLookupMode::FlatStorage,
             StorageGetMode::Trie => KeyLookupMode::Trie,
         };
-        self.trie_update
+        let result = self
+            .trie_update
             .get_ref(&storage_key, mode)
             .map(|x| x.is_some())
-            .map_err(wrap_storage_error)
+            .map_err(wrap_storage_error);
+        let delta = self
+            .trie_update
+            .trie()
+            .get_trie_nodes_count()
+            .checked_sub(&ttn)
+            .ok_or(InconsistentStateError::IntegerOverflow)?;
+        access_tracker.trie_node_touched(delta.db_reads)?;
+        access_tracker.cached_trie_node_access(delta.mem_reads)?;
+        #[cfg(feature = "io_trace")]
+        tracing::trace!(
+            target = "io_tracer",
+            storage_op = "exists",
+            key = base64(&key),
+            tn_mem_reads = delta.mem_reads,
+            tn_db_reads = delta.db_reads,
+        );
+        Ok(result?)
     }
 
-    fn storage_remove_subtree(&mut self, prefix: &[u8]) -> ExtResult<()> {
+    fn storage_remove_subtree(
+        &mut self,
+        access_tracker: &mut dyn StorageAccessTracker,
+        prefix: &[u8],
+    ) -> ExtResult<()> {
+        let ttn = self.trie_update.trie().get_trie_nodes_count();
         let data_keys = self
             .trie_update
             .iter(&trie_key_parsers::get_raw_prefix_for_contract_data(&self.account_id, prefix))
@@ -182,6 +323,14 @@ impl<'a> External for RuntimeExt<'a> {
             self.trie_update
                 .remove(TrieKey::ContractData { account_id: self.account_id.clone(), key });
         }
+        let delta = self
+            .trie_update
+            .trie()
+            .get_trie_nodes_count()
+            .checked_sub(&ttn)
+            .ok_or(InconsistentStateError::IntegerOverflow)?;
+        access_tracker.trie_node_touched(delta.db_reads)?;
+        access_tracker.cached_trie_node_access(delta.mem_reads)?;
         Ok(())
     }
 
@@ -196,10 +345,6 @@ impl<'a> External for RuntimeExt<'a> {
         );
         self.data_count += 1;
         data_id
-    }
-
-    fn get_trie_nodes_count(&self) -> near_vm_runner::logic::TrieNodesCount {
-        Convert::convert(self.trie_update.trie().get_trie_nodes_count())
     }
 
     fn get_recorded_storage_size(&self) -> usize {


### PR DESCRIPTION
Contract runtime has no business knowing anything about the storage implementation details outside of the specifics around particular gas fees.

This change reflects this reality by moving the concerns about how TTNs are counted into the glue layer that's the implementation of `Externals` in the transaction runtime.

In principle I would say that the transaction runtime has no business knowing much about TTNs and such *either* so I anticipate that e.g. the newly added `dyn AccessTracker` would get passed deeper into the storage calls wherein the TrieAccountingCache would be able to call `trie_node_touched` and similar methods almost on an individual node basis. But this seemed like a lovely intermediate point and a great improvement already.

Part of #13008