### PR TITLE
Extract process_tx functionality from the Client and run it multithreaded

### DIFF
--- a/benchmarks/transactions-generator/justfile
+++ b/benchmarks/transactions-generator/justfile
@@ -39,7 +39,8 @@ unlimit:
     jq '.gas_limit=20000000000000000' {{near_genesis_file}} > tmp_genesis.json && mv tmp_genesis.json {{near_genesis_file}}
     jq '.view_client_threads=8 \
      | .store.load_mem_tries_for_tracked_shards=true \
-     | .produce_chunk_add_transactions_time_limit={"secs": 0, "nanos": 800000000}' {{near_config_file}} > tmp_config.json \
+     | .produce_chunk_add_transactions_time_limit={"secs": 0, "nanos": 800000000} \
+     | .transaction_request_handler_threads = 4' {{near_config_file}} > tmp_config.json \
     && mv tmp_config.json {{near_config_file}}
 
 do-it tps:

--- a/chain/chain/src/lib.rs
+++ b/chain/chain/src/lib.rs
@@ -8,7 +8,8 @@ pub use lightclient::{create_light_client_block_view, get_epoch_block_producers_
 pub use near_chain_primitives::{self, Error};
 pub use near_primitives::receipt::ReceiptResult;
 pub use store::utils::{
-    get_chunk_clone_from_header, get_incoming_receipts_for_shard, retrieve_headers,
+    check_transaction_validity_period, get_chunk_clone_from_header,
+    get_incoming_receipts_for_shard, retrieve_headers,
 };
 pub use store::{
     ChainStore, ChainStoreAccess, ChainStoreUpdate, LatestWitnessesInfo, MerkleProofAccess,

--- a/chain/client/src/adapter.rs
+++ b/chain/client/src/adapter.rs
@@ -1,5 +1,5 @@
-use crate::ViewClientActor;
 use crate::client_actor::ClientActor;
+use crate::{TxRequestHandlerActor, ViewClientActor};
 use near_async::actix::AddrWithAutoSpanContextExt;
 use near_async::messaging::IntoSender;
 use near_network::client::ClientSenderForNetwork;
@@ -7,9 +7,11 @@ use near_network::client::ClientSenderForNetwork;
 pub fn client_sender_for_network(
     client_addr: actix::Addr<ClientActor>,
     view_client_addr: actix::Addr<ViewClientActor>,
+    tx_processor: actix::Addr<TxRequestHandlerActor>,
 ) -> ClientSenderForNetwork {
     let client_addr = client_addr.with_auto_span_context();
     let view_client_addr = view_client_addr.with_auto_span_context();
+    let tx_processor = tx_processor.with_auto_span_context();
     ClientSenderForNetwork {
         block: client_addr.clone().into_sender(),
         block_headers: client_addr.clone().into_sender(),
@@ -21,9 +23,9 @@ pub fn client_sender_for_network(
         state_request_header: view_client_addr.clone().into_sender(),
         state_request_part: view_client_addr.clone().into_sender(),
         state_response: client_addr.clone().into_sender(),
-        transaction: client_addr.clone().into_sender(),
         tx_status_request: view_client_addr.clone().into_sender(),
         tx_status_response: view_client_addr.clone().into_sender(),
+        transaction: tx_processor.into_sender(),
         announce_account: view_client_addr.into_sender(),
         chunk_endorsement: client_addr.clone().into_sender(),
         epoch_sync_request: client_addr.clone().into_sender(),

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -40,14 +40,12 @@ use near_chunks::adapter::ShardsManagerRequestFromClient;
 use near_chunks::logic::{decode_encoded_chunk, persist_chunk};
 use near_client_primitives::types::{Error, StateSyncStatus, SyncStatus};
 use near_epoch_manager::EpochManagerAdapter;
-use near_epoch_manager::shard_assignment::{account_id_to_shard_id, shard_id_to_uid};
+use near_epoch_manager::shard_assignment::shard_id_to_uid;
 use near_epoch_manager::shard_tracker::ShardTracker;
-use near_network::client::ProcessTxResponse;
 use near_network::types::{AccountKeys, ChainInfo, PeerManagerMessageRequest, SetChainInfo};
 use near_network::types::{
     HighestHeightPeerInfo, NetworkRequests, PeerManagerAdapter, ReasonForBan,
 };
-use near_pool::InsertTransactionResult;
 use near_primitives::block::{Approval, ApprovalInner, ApprovalMessage, Block, BlockHeader, Tip};
 use near_primitives::block_header::ApprovalType;
 use near_primitives::challenge::{Challenge, ChallengeBody};
@@ -63,8 +61,8 @@ use near_primitives::sharding::{
     StateSyncInfoV1,
 };
 use near_primitives::stateless_validation::ChunkProductionKey;
-use near_primitives::transaction::{SignedTransaction, ValidatedTransaction};
-use near_primitives::types::{AccountId, ApprovalStake, BlockHeight, EpochId, NumBlocks, ShardId};
+use near_primitives::transaction::ValidatedTransaction;
+use near_primitives::types::{AccountId, ApprovalStake, BlockHeight, EpochId, NumBlocks};
 use near_primitives::unwrap_or_return;
 use near_primitives::upgrade_schedule::ProtocolUpgradeVotingSchedule;
 use near_primitives::utils::MaybeValidated;
@@ -72,10 +70,10 @@ use near_primitives::validator_signer::ValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{CatchupStatusView, DroppedReason};
 use std::cmp::max;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
-use tracing::{debug, debug_span, error, info, trace, warn};
+use tracing::{debug, debug_span, error, info, warn};
 
 #[cfg(feature = "test_features")]
 use crate::chunk_producer::AdvProduceChunksMode;
@@ -409,9 +407,8 @@ impl Client {
                     // By now the chunk must be in store, otherwise the block would have been orphaned
                     let chunk = self.chain.get_chunk(&chunk_header.chunk_hash()).unwrap();
                     let transactions = chunk.transactions();
-                    self.chunk_producer
-                        .sharded_tx_pool
-                        .remove_transactions(shard_uid, transactions);
+                    let mut pool_guard = self.chunk_producer.sharded_tx_pool.lock().unwrap();
+                    pool_guard.remove_transactions(shard_uid, transactions);
                 }
             }
         }
@@ -467,10 +464,11 @@ impl Client {
                         })
                         .collect::<Vec<_>>();
 
-                    let reintroduced_count = self
-                        .chunk_producer
-                        .sharded_tx_pool
-                        .reintroduce_transactions(shard_uid, validated_txs);
+                    let reintroduced_count = {
+                        let mut pool_guard = self.chunk_producer.sharded_tx_pool.lock().unwrap();
+                        pool_guard.reintroduce_transactions(shard_uid, validated_txs)
+                    };
+
                     if reintroduced_count < chunk.transactions().len() {
                         debug!(target: "client",
                             reintroduced_count,
@@ -1572,9 +1570,9 @@ impl Client {
                 match (old_shard_layout, new_shard_layout) {
                     (Ok(old_shard_layout), Ok(new_shard_layout)) => {
                         if old_shard_layout != new_shard_layout {
-                            self.chunk_producer
-                                .sharded_tx_pool
-                                .reshard(&old_shard_layout, &new_shard_layout);
+                            let mut guarded_pool =
+                                self.chunk_producer.sharded_tx_pool.lock().unwrap();
+                            guarded_pool.reshard(&old_shard_layout, &new_shard_layout);
                         }
                     }
                     (old_shard_layout, new_shard_layout) => {
@@ -2076,297 +2074,6 @@ impl Client {
                 }
             };
         self.doomslug.on_approval_message(approval, &block_producer_stakes);
-    }
-
-    /// Forwards given transaction to upcoming validators.
-    fn forward_tx(
-        &self,
-        epoch_id: &EpochId,
-        tx: &SignedTransaction,
-        signer: &Option<Arc<ValidatorSigner>>,
-    ) -> Result<(), Error> {
-        let shard_id = account_id_to_shard_id(
-            self.epoch_manager.as_ref(),
-            tx.transaction.signer_id(),
-            epoch_id,
-        )?;
-        // Use the header head to make sure the list of validators is as
-        // up-to-date as possible.
-        let head = self.chain.header_head()?;
-        let maybe_next_epoch_id = self.get_next_epoch_id_if_at_boundary(&head)?;
-
-        let mut validators = HashSet::new();
-        for horizon in (2..=self.config.tx_routing_height_horizon)
-            .chain(vec![self.config.tx_routing_height_horizon * 2].into_iter())
-        {
-            let target_height = head.height + horizon - 1;
-            let validator = self
-                .epoch_manager
-                .get_chunk_producer_info(&ChunkProductionKey {
-                    epoch_id: *epoch_id,
-                    height_created: target_height,
-                    shard_id,
-                })?
-                .take_account_id();
-            validators.insert(validator);
-            if let Some(next_epoch_id) = &maybe_next_epoch_id {
-                let next_shard_id = account_id_to_shard_id(
-                    self.epoch_manager.as_ref(),
-                    tx.transaction.signer_id(),
-                    next_epoch_id,
-                )?;
-                let validator = self
-                    .epoch_manager
-                    .get_chunk_producer_info(&ChunkProductionKey {
-                        epoch_id: *next_epoch_id,
-                        height_created: target_height,
-                        shard_id: next_shard_id,
-                    })?
-                    .take_account_id();
-                validators.insert(validator);
-            }
-        }
-
-        if let Some(account_id) = signer.as_ref().map(|bp| bp.validator_id()) {
-            validators.remove(account_id);
-        }
-        let tx_hash = tx.get_hash();
-        for validator in validators {
-            trace!(target: "client", me = ?signer.as_ref().map(|bp| bp.validator_id()), ?tx_hash, ?validator, ?shard_id, "Routing a transaction");
-
-            // Send message to network to actually forward transaction.
-            self.network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
-                NetworkRequests::ForwardTx(validator, tx.clone()),
-            ));
-        }
-
-        Ok(())
-    }
-
-    /// Submits the transaction for future inclusion into the chain.
-    ///
-    /// If accepted, it will be added to the transaction pool and possibly forwarded to another
-    /// validator.
-    #[must_use]
-    pub fn process_tx(
-        &mut self,
-        tx: SignedTransaction,
-        is_forwarded: bool,
-        check_only: bool,
-    ) -> ProcessTxResponse {
-        let signer = self.validator_signer.get();
-        unwrap_or_return!(self.process_tx_internal(&tx, is_forwarded, check_only, &signer), {
-            let me = signer.as_ref().map(|signer| signer.validator_id());
-            warn!(target: "client", ?me, ?tx, "Dropping tx");
-            ProcessTxResponse::NoResponse
-        })
-    }
-
-    /// If we are close to epoch boundary, return next epoch id, otherwise return None.
-    fn get_next_epoch_id_if_at_boundary(&self, head: &Tip) -> Result<Option<EpochId>, Error> {
-        let next_epoch_started =
-            self.epoch_manager.is_next_block_epoch_start(&head.last_block_hash)?;
-        if next_epoch_started {
-            return Ok(None);
-        }
-        let next_epoch_estimated_height =
-            self.epoch_manager.get_epoch_start_height(&head.last_block_hash)?
-                + self.config.epoch_length;
-
-        let epoch_boundary_possible =
-            head.height + self.config.tx_routing_height_horizon >= next_epoch_estimated_height;
-        if epoch_boundary_possible {
-            Ok(Some(self.epoch_manager.get_next_epoch_id_from_prev_block(&head.last_block_hash)?))
-        } else {
-            Ok(None)
-        }
-    }
-
-    /// If we're a validator in one of the next few chunks, but epoch switch could happen soon,
-    /// we forward to a validator from next epoch.
-    fn possibly_forward_tx_to_next_epoch(
-        &mut self,
-        tx: &SignedTransaction,
-        signer: &Option<Arc<ValidatorSigner>>,
-    ) -> Result<(), Error> {
-        let head = self.chain.head()?;
-        if let Some(next_epoch_id) = self.get_next_epoch_id_if_at_boundary(&head)? {
-            self.forward_tx(&next_epoch_id, tx, signer)?;
-        } else {
-            self.forward_tx(&head.epoch_id, tx, signer)?;
-        }
-        Ok(())
-    }
-
-    /// Process transaction and either add it to the mempool or return to redirect to another validator.
-    fn process_tx_internal(
-        &mut self,
-        signed_tx: &SignedTransaction,
-        is_forwarded: bool,
-        check_only: bool,
-        signer: &Option<Arc<ValidatorSigner>>,
-    ) -> Result<ProcessTxResponse, Error> {
-        let head = self.chain.head()?;
-        let me = signer.as_ref().map(|vs| vs.validator_id());
-        let cur_block = self.chain.get_head_block()?;
-        let cur_block_header = cur_block.header();
-        // here it is fine to use `cur_block_header` as it is a best effort estimate. If the transaction
-        // were to be included, the block that the chunk points to will have height >= height of
-        // `cur_block_header`.
-        if let Err(e) = self.chain.chain_store().check_transaction_validity_period(
-            &cur_block_header,
-            signed_tx.transaction.block_hash(),
-        ) {
-            debug!(target: "client", ?signed_tx, "Invalid tx: expired or from a different fork");
-            return Ok(ProcessTxResponse::InvalidTx(e));
-        }
-        let gas_price = cur_block_header.next_gas_price();
-        let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(&head.last_block_hash)?;
-        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
-        let shard_layout =
-            self.epoch_manager.get_shard_layout_from_protocol_version(protocol_version);
-        let receiver_shard =
-            shard_layout.account_id_to_shard_id(signed_tx.transaction.receiver_id());
-        let receiver_congestion_info =
-            cur_block.block_congestion_info().get(&receiver_shard).copied();
-
-        let validated_tx = match self.runtime_adapter.validate_tx(
-            &shard_layout,
-            signed_tx.clone(),
-            protocol_version,
-            receiver_congestion_info,
-        ) {
-            Ok(validated_tx) => validated_tx,
-            Err((err, signed_tx)) => {
-                debug!(target: "client", tx_hash = ?signed_tx.get_hash(), ?err, "Invalid tx during basic validation");
-                return Ok(ProcessTxResponse::InvalidTx(err));
-            }
-        };
-
-        let shard_uid = shard_layout.account_id_to_shard_uid(signed_tx.transaction.signer_id());
-        let shard_id = shard_uid.shard_id();
-        let cares_about_shard =
-            self.shard_tracker.cares_about_shard(me, &head.last_block_hash, shard_id, true);
-        let will_care_about_shard =
-            self.shard_tracker.will_care_about_shard(me, &head.last_block_hash, shard_id, true);
-
-        if cares_about_shard || will_care_about_shard {
-            let state_root = match self.chain.get_chunk_extra(&head.last_block_hash, &shard_uid) {
-                Ok(chunk_extra) => *chunk_extra.state_root(),
-                Err(_) => {
-                    // Not being able to fetch a state root most likely implies that we haven't
-                    //     caught up with the next epoch yet.
-                    if is_forwarded {
-                        return Err(Error::Other("Node has not caught up yet".to_string()));
-                    } else {
-                        self.forward_tx(&epoch_id, signed_tx, signer)?;
-                        return Ok(ProcessTxResponse::RequestRouted);
-                    }
-                }
-            };
-            if let Err(err) = self.runtime_adapter.can_verify_and_charge_tx(
-                &shard_layout,
-                gas_price,
-                state_root,
-                &validated_tx,
-                protocol_version,
-            ) {
-                debug!(target: "client", ?err, "Invalid tx");
-                return Ok(ProcessTxResponse::InvalidTx(err));
-            }
-            if check_only {
-                return Ok(ProcessTxResponse::ValidTx);
-            }
-            // Transactions only need to be recorded if the node is a validator.
-            if me.is_some() {
-                match self
-                    .chunk_producer
-                    .sharded_tx_pool
-                    .insert_transaction(shard_uid, validated_tx)
-                {
-                    InsertTransactionResult::Success => {
-                        trace!(target: "client", ?shard_uid, tx_hash = ?signed_tx.get_hash(), "Recorded a transaction.");
-                    }
-                    InsertTransactionResult::Duplicate => {
-                        trace!(target: "client", ?shard_uid, tx_hash = ?signed_tx.get_hash(), "Duplicate transaction, not forwarding it.");
-                        return Ok(ProcessTxResponse::ValidTx);
-                    }
-                    InsertTransactionResult::NoSpaceLeft => {
-                        if is_forwarded {
-                            trace!(target: "client", ?shard_uid, tx_hash = ?signed_tx.get_hash(), "Transaction pool is full, dropping the transaction.");
-                        } else {
-                            trace!(target: "client", ?shard_uid, tx_hash = ?signed_tx.get_hash(), "Transaction pool is full, trying to forward the transaction.");
-                        }
-                    }
-                }
-            }
-
-            // Active validator:
-            //   possibly forward to next epoch validators
-            // Not active validator:
-            //   forward to current epoch validators,
-            //   possibly forward to next epoch validators
-            if self.active_validator(shard_id, signer)? {
-                trace!(target: "client", account = ?me, ?shard_id, tx_hash = ?signed_tx.get_hash(), is_forwarded, "Recording a transaction.");
-                metrics::TRANSACTION_RECEIVED_VALIDATOR.inc();
-
-                if !is_forwarded {
-                    self.possibly_forward_tx_to_next_epoch(signed_tx, signer)?;
-                }
-                return Ok(ProcessTxResponse::ValidTx);
-            }
-            if !is_forwarded {
-                trace!(target: "client", ?shard_id, tx_hash = ?signed_tx.get_hash(), "Forwarding a transaction.");
-                metrics::TRANSACTION_RECEIVED_NON_VALIDATOR.inc();
-                self.forward_tx(&epoch_id, signed_tx, signer)?;
-                return Ok(ProcessTxResponse::RequestRouted);
-            }
-            trace!(target: "client", ?shard_id, tx_hash = ?signed_tx.get_hash(), "Non-validator received a forwarded transaction, dropping it.");
-            metrics::TRANSACTION_RECEIVED_NON_VALIDATOR_FORWARDED.inc();
-            return Ok(ProcessTxResponse::NoResponse);
-        }
-
-        if check_only {
-            return Ok(ProcessTxResponse::DoesNotTrackShard);
-        }
-        if is_forwarded {
-            // Received forwarded transaction but we are not tracking the shard
-            debug!(target: "client", ?me, ?shard_id, tx_hash = ?signed_tx.get_hash(), "Received forwarded transaction but no tracking shard");
-            return Ok(ProcessTxResponse::NoResponse);
-        }
-        // We are not tracking this shard, so there is no way to validate this tx. Just rerouting.
-        self.forward_tx(&epoch_id, signed_tx, signer).map(|()| ProcessTxResponse::RequestRouted)
-    }
-
-    /// Determine if I am a validator in next few blocks for specified shard, assuming epoch doesn't change.
-    fn active_validator(
-        &self,
-        shard_id: ShardId,
-        signer: &Option<Arc<ValidatorSigner>>,
-    ) -> Result<bool, Error> {
-        let head = self.chain.head()?;
-        let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(&head.last_block_hash)?;
-
-        let account_id = if let Some(vs) = signer.as_ref() {
-            vs.validator_id()
-        } else {
-            return Ok(false);
-        };
-
-        for i in 1..=self.config.tx_routing_height_horizon {
-            let chunk_producer = self
-                .epoch_manager
-                .get_chunk_producer_info(&ChunkProductionKey {
-                    epoch_id,
-                    height_created: head.height + i,
-                    shard_id,
-                })?
-                .take_account_id();
-            if &chunk_producer == account_id {
-                return Ok(true);
-            }
-        }
-        Ok(false)
     }
 
     /// Find the sync hash. Most of the time it will already be set in `state_sync_info`. If not, try to find it,

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -44,7 +44,7 @@ use near_chain::{
 use near_chain_configs::{ClientConfig, MutableValidatorSigner, ReshardingHandle};
 use near_chain_primitives::error::EpochErrorResultToChainError;
 use near_chunks::adapter::ShardsManagerRequestFromClient;
-use near_chunks::client::ShardsManagerResponse;
+use near_chunks::client::{ShardedTransactionPool, ShardsManagerResponse};
 use near_client_primitives::types::{
     Error, GetClientConfig, GetClientConfigError, GetNetworkInfo, NetworkInfoResponse,
     StateSyncStatus, Status, StatusError, StatusSyncInfo, SyncStatus,
@@ -53,8 +53,7 @@ use near_epoch_manager::EpochManagerAdapter;
 use near_epoch_manager::shard_tracker::ShardTracker;
 use near_network::client::{
     BlockApproval, BlockHeadersResponse, BlockResponse, ChunkEndorsementMessage,
-    OptimisticBlockMessage, ProcessTxRequest, ProcessTxResponse, RecvChallenge, SetNetworkInfo,
-    StateResponseReceived,
+    OptimisticBlockMessage, RecvChallenge, SetNetworkInfo, StateResponseReceived,
 };
 use near_network::types::ReasonForBan;
 use near_network::types::{
@@ -79,7 +78,7 @@ use near_telemetry::TelemetryEvent;
 use rand::seq::SliceRandom;
 use rand::{Rng, thread_rng};
 use std::fmt;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
 use tracing::{debug, debug_span, error, info, trace, warn};
 
@@ -119,6 +118,7 @@ pub struct StartClientResult {
     pub client_actor: actix::Addr<ClientActor>,
     pub client_arbiter_handle: actix::ArbiterHandle,
     pub resharding_handle: ReshardingHandle,
+    pub tx_pool: Arc<Mutex<ShardedTransactionPool>>,
 }
 
 /// Starts client in a separate Arbiter (thread).
@@ -179,19 +179,21 @@ pub fn start_client(
     let sync_jobs_actor = SyncJobsActor::new(client_sender_for_sync_jobs.as_multi_sender());
     let sync_jobs_actor_addr = sync_jobs_actor.spawn_actix_actor();
 
+    let client_actor_inner = ClientActorInner::new(
+        clock,
+        client,
+        node_id,
+        network_adapter,
+        telemetry_sender,
+        sender,
+        adv,
+        config_updater,
+        sync_jobs_actor_addr.with_auto_span_context().into_multi_sender(),
+    )
+    .unwrap();
+    let tx_pool = client_actor_inner.client.chunk_producer.sharded_tx_pool.clone();
+
     let client_addr = ClientActor::start_in_arbiter(&client_arbiter_handle, move |_| {
-        let client_actor_inner = ClientActorInner::new(
-            clock,
-            client,
-            node_id,
-            network_adapter,
-            telemetry_sender,
-            sender,
-            adv,
-            config_updater,
-            sync_jobs_actor_addr.with_auto_span_context().into_multi_sender(),
-        )
-        .unwrap();
         ActixWrapper::new(client_actor_inner)
     });
 
@@ -201,7 +203,12 @@ pub fn start_client(
     chain_sender_for_state_sync
         .bind(client_addr.clone().with_auto_span_context().into_multi_sender());
 
-    StartClientResult { client_actor: client_addr, client_arbiter_handle, resharding_handle }
+    StartClientResult {
+        client_actor: client_addr,
+        client_arbiter_handle,
+        resharding_handle,
+        tx_pool,
+    }
 }
 
 #[derive(Clone, MultiSend, MultiSenderFrom)]
@@ -498,13 +505,6 @@ impl Handler<NetworkAdversarialMessage> for ClientActorInner {
                 None
             }
         }
-    }
-}
-
-impl Handler<ProcessTxRequest> for ClientActorInner {
-    fn handle(&mut self, msg: ProcessTxRequest) -> ProcessTxResponse {
-        let ProcessTxRequest { transaction, is_forwarded, check_only } = msg;
-        self.client.process_tx(transaction, is_forwarded, check_only)
     }
 }
 

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -14,6 +14,9 @@ pub use crate::client_actor::NetworkAdversarialMessage;
 pub use crate::client_actor::{ClientActor, StartClientResult, start_client};
 pub use crate::config_updater::ConfigUpdater;
 pub use crate::stateless_validation::chunk_validator::orphan_witness_handling::HandleOrphanWitnessOutcome;
+pub use crate::tx_request_handler::{
+    TxRequestHandler, TxRequestHandlerActor, TxRequestHandlerConfig, spawn_tx_request_handler_actor,
+};
 pub use crate::view_client_actor::{ViewClientActor, ViewClientActorInner};
 pub use chunk_producer::ProduceChunkResult;
 pub use near_chain::stateless_validation::processing_tracker::{
@@ -43,4 +46,5 @@ mod stateless_validation;
 pub mod sync;
 pub mod sync_jobs_actor;
 pub mod test_utils;
+mod tx_request_handler;
 mod view_client_actor;

--- a/chain/client/src/tx_request_handler.rs
+++ b/chain/client/src/tx_request_handler.rs
@@ -1,0 +1,405 @@
+use near_async::actix_wrapper::SyncActixWrapper;
+use near_async::messaging;
+use near_async::messaging::CanSend;
+use near_async::messaging::Handler;
+use near_chain::check_transaction_validity_period;
+use near_chain::types::RuntimeAdapter;
+use near_chain::types::Tip;
+use near_chain_configs::MutableValidatorSigner;
+use near_chunks::client::ShardedTransactionPool;
+use near_epoch_manager::EpochManagerAdapter;
+use near_epoch_manager::shard_assignment::account_id_to_shard_id;
+use near_epoch_manager::shard_tracker::ShardTracker;
+use near_network::client::ProcessTxRequest;
+use near_network::client::ProcessTxResponse;
+use near_network::types::NetworkRequests;
+use near_network::types::PeerManagerAdapter;
+use near_network::types::PeerManagerMessageRequest;
+use near_pool::InsertTransactionResult;
+use near_primitives::stateless_validation::ChunkProductionKey;
+use near_primitives::transaction::SignedTransaction;
+use near_primitives::types::BlockHeightDelta;
+use near_primitives::types::EpochId;
+use near_primitives::types::ShardId;
+use near_primitives::unwrap_or_return;
+use near_primitives::validator_signer::ValidatorSigner;
+use near_store::adapter::StoreAdapter;
+use near_store::adapter::chain_store::ChainStoreAdapter;
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use crate::metrics;
+
+pub type TxRequestHandlerActor = SyncActixWrapper<TxRequestHandler>;
+
+impl Handler<ProcessTxRequest> for TxRequestHandler {
+    fn handle(&mut self, msg: ProcessTxRequest) -> ProcessTxResponse {
+        let ProcessTxRequest { transaction, is_forwarded, check_only } = msg;
+        self.process_tx(transaction, is_forwarded, check_only)
+    }
+}
+
+impl messaging::Actor for TxRequestHandler {}
+
+pub fn spawn_tx_request_handler_actor(
+    config: TxRequestHandlerConfig,
+    tx_pool: Arc<Mutex<ShardedTransactionPool>>,
+    epoch_manager: Arc<dyn EpochManagerAdapter>,
+    shard_tracker: ShardTracker,
+    validator_signer: MutableValidatorSigner,
+    runtime: Arc<dyn RuntimeAdapter>,
+    network_adapter: PeerManagerAdapter,
+) -> actix::Addr<TxRequestHandlerActor> {
+    let actor = TxRequestHandler::new(
+        config.clone(),
+        tx_pool,
+        epoch_manager,
+        shard_tracker,
+        validator_signer,
+        runtime,
+        network_adapter,
+    )
+    .unwrap();
+    actix::SyncArbiter::start(config.handler_threads, move || SyncActixWrapper::new(actor.clone()))
+}
+
+#[derive(Clone)]
+pub struct TxRequestHandlerConfig {
+    pub handler_threads: usize,
+    pub tx_routing_height_horizon: u64,
+    pub epoch_length: u64,
+    pub transaction_validity_period: BlockHeightDelta,
+}
+
+/// Accepts `process_tx` requests. Pushes the incoming transactions to the pool.
+#[derive(Clone)]
+pub struct TxRequestHandler {
+    config: TxRequestHandlerConfig,
+    tx_pool: Arc<Mutex<ShardedTransactionPool>>,
+    chain_store: ChainStoreAdapter,
+    epoch_manager: Arc<dyn EpochManagerAdapter>,
+    shard_tracker: ShardTracker,
+    validator_signer: MutableValidatorSigner,
+    runtime: Arc<dyn RuntimeAdapter>,
+    network_adapter: PeerManagerAdapter,
+}
+
+impl TxRequestHandler {
+    pub fn new(
+        config: TxRequestHandlerConfig,
+        tx_pool: Arc<Mutex<ShardedTransactionPool>>,
+        epoch_manager: Arc<dyn EpochManagerAdapter>,
+        shard_tracker: ShardTracker,
+        validator_signer: MutableValidatorSigner,
+        runtime: Arc<dyn RuntimeAdapter>,
+        network_adapter: PeerManagerAdapter,
+    ) -> Result<Self, near_client_primitives::types::Error> {
+        let chain_store = runtime.store().chain_store();
+        Ok(Self {
+            config,
+            tx_pool,
+            validator_signer,
+            chain_store,
+            epoch_manager,
+            runtime,
+            shard_tracker,
+            network_adapter,
+        })
+    }
+
+    /// Submits the transaction for future inclusion into the chain.
+    ///
+    /// If accepted, it will be added to the transaction pool and possibly forwarded to another validator.
+    #[must_use]
+    pub fn process_tx(
+        &self,
+        tx: SignedTransaction,
+        is_forwarded: bool,
+        check_only: bool,
+    ) -> ProcessTxResponse {
+        let signer = self.validator_signer.get();
+        unwrap_or_return!(self.process_tx_internal(&tx, is_forwarded, check_only, &signer), {
+            let me = signer.as_ref().map(|signer| signer.validator_id());
+            tracing::debug!(target: "client", ?me, ?tx, "Dropping tx");
+            ProcessTxResponse::NoResponse
+        })
+    }
+
+    /// Process transaction and either add it to the mempool or return to redirect to another validator.
+    fn process_tx_internal(
+        &self,
+        signed_tx: &SignedTransaction,
+        is_forwarded: bool,
+        check_only: bool,
+        signer: &Option<Arc<ValidatorSigner>>,
+    ) -> Result<ProcessTxResponse, near_client_primitives::types::Error> {
+        let head = self.chain_store.head()?;
+        let me = signer.as_ref().map(|vs| vs.validator_id());
+        let cur_block = self.chain_store.get_block(&head.last_block_hash)?;
+        let cur_block_header = cur_block.header();
+        // here it is fine to use `cur_block_header` as it is a best effort estimate. If the transaction
+        // were to be included, the block that the chunk points to will have height >= height of
+        // `cur_block_header`.
+        if let Err(e) = check_transaction_validity_period(
+            &self.chain_store,
+            &cur_block_header,
+            signed_tx.transaction.block_hash(),
+            self.config.transaction_validity_period,
+        ) {
+            tracing::debug!(target: "client", ?signed_tx, "Invalid tx: expired or from a different fork");
+            return Ok(ProcessTxResponse::InvalidTx(e));
+        }
+        let gas_price = cur_block_header.next_gas_price();
+        let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(&head.last_block_hash)?;
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
+        let shard_layout =
+            self.epoch_manager.get_shard_layout_from_protocol_version(protocol_version);
+        let receiver_shard =
+            shard_layout.account_id_to_shard_id(signed_tx.transaction.receiver_id());
+        let receiver_congestion_info =
+            cur_block.block_congestion_info().get(&receiver_shard).copied();
+
+        let validated_tx = match self.runtime.validate_tx(
+            &shard_layout,
+            signed_tx.clone(),
+            protocol_version,
+            receiver_congestion_info,
+        ) {
+            Ok(validated_tx) => validated_tx,
+            Err((err, signed_tx)) => {
+                tracing::debug!(target: "client", tx_hash = ?signed_tx.get_hash(), ?err, "Invalid tx during basic validation");
+                return Ok(ProcessTxResponse::InvalidTx(err));
+            }
+        };
+
+        let shard_uid = shard_layout.account_id_to_shard_uid(signed_tx.transaction.signer_id());
+        let shard_id = shard_uid.shard_id();
+        let cares_about_shard =
+            self.shard_tracker.cares_about_shard(me, &head.last_block_hash, shard_id, true);
+        let will_care_about_shard =
+            self.shard_tracker.will_care_about_shard(me, &head.last_block_hash, shard_id, true);
+
+        if cares_about_shard || will_care_about_shard {
+            let state_root =
+                match self.chain_store.get_chunk_extra(&head.last_block_hash, &shard_uid) {
+                    Ok(chunk_extra) => *chunk_extra.state_root(),
+                    Err(_) => {
+                        // Not being able to fetch a state root most likely implies that we haven't
+                        //     caught up with the next epoch yet.
+                        if is_forwarded {
+                            return Err(near_client_primitives::types::Error::Other(
+                                "Node has not caught up yet".to_string(),
+                            ));
+                        } else {
+                            self.forward_tx(&epoch_id, signed_tx, signer)?;
+                            return Ok(ProcessTxResponse::RequestRouted);
+                        }
+                    }
+                };
+            if let Err(err) = self.runtime.can_verify_and_charge_tx(
+                &shard_layout,
+                gas_price,
+                state_root,
+                &validated_tx,
+                protocol_version,
+            ) {
+                tracing::debug!(target: "client", ?err, "Invalid tx");
+                return Ok(ProcessTxResponse::InvalidTx(err));
+            }
+            if check_only {
+                return Ok(ProcessTxResponse::ValidTx);
+            }
+            // Transactions only need to be recorded if the node is a validator.
+            if me.is_some() {
+                let mut pool = self.tx_pool.lock().unwrap();
+                match pool.insert_transaction(shard_uid, validated_tx) {
+                    InsertTransactionResult::Success => {
+                        tracing::trace!(target: "client", ?shard_uid, tx_hash = ?signed_tx.get_hash(), "Recorded a transaction.");
+                    }
+                    InsertTransactionResult::Duplicate => {
+                        tracing::trace!(target: "client", ?shard_uid, tx_hash = ?signed_tx.get_hash(), "Duplicate transaction, not forwarding it.");
+                        return Ok(ProcessTxResponse::ValidTx);
+                    }
+                    InsertTransactionResult::NoSpaceLeft => {
+                        if is_forwarded {
+                            tracing::trace!(target: "client", ?shard_uid, tx_hash = ?signed_tx.get_hash(), "Transaction pool is full, dropping the transaction.");
+                        } else {
+                            tracing::trace!(target: "client", ?shard_uid, tx_hash = ?signed_tx.get_hash(), "Transaction pool is full, trying to forward the transaction.");
+                        }
+                    }
+                }
+            }
+
+            // Active validator:
+            //   possibly forward to next epoch validators
+            // Not active validator:
+            //   forward to current epoch validators,
+            //   possibly forward to next epoch validators
+            if self.active_validator(shard_id, signer)? {
+                tracing::trace!(target: "client", account = ?me, ?shard_id, tx_hash = ?signed_tx.get_hash(), is_forwarded, "Recording a transaction.");
+                metrics::TRANSACTION_RECEIVED_VALIDATOR.inc();
+
+                if !is_forwarded {
+                    self.possibly_forward_tx_to_next_epoch(signed_tx, signer)?;
+                }
+                return Ok(ProcessTxResponse::ValidTx);
+            }
+            if !is_forwarded {
+                tracing::trace!(target: "client", ?shard_id, tx_hash = ?signed_tx.get_hash(), "Forwarding a transaction.");
+                metrics::TRANSACTION_RECEIVED_NON_VALIDATOR.inc();
+                self.forward_tx(&epoch_id, signed_tx, signer)?;
+                return Ok(ProcessTxResponse::RequestRouted);
+            }
+            tracing::trace!(target: "client", ?shard_id, tx_hash = ?signed_tx.get_hash(), "Non-validator received a forwarded transaction, dropping it.");
+            metrics::TRANSACTION_RECEIVED_NON_VALIDATOR_FORWARDED.inc();
+            return Ok(ProcessTxResponse::NoResponse);
+        }
+
+        if check_only {
+            return Ok(ProcessTxResponse::DoesNotTrackShard);
+        }
+        if is_forwarded {
+            // Received forwarded transaction but we are not tracking the shard
+            tracing::debug!(target: "client", ?me, ?shard_id, tx_hash = ?signed_tx.get_hash(), "Received forwarded transaction but no tracking shard");
+            return Ok(ProcessTxResponse::NoResponse);
+        }
+        // We are not tracking this shard, so there is no way to validate this tx. Just rerouting.
+        self.forward_tx(&epoch_id, signed_tx, signer).map(|()| ProcessTxResponse::RequestRouted)
+    }
+
+    /// Forwards given transaction to upcoming validators.
+    fn forward_tx(
+        &self,
+        epoch_id: &EpochId,
+        tx: &SignedTransaction,
+        signer: &Option<Arc<ValidatorSigner>>,
+    ) -> Result<(), near_client_primitives::types::Error> {
+        let shard_id = account_id_to_shard_id(
+            self.epoch_manager.as_ref(),
+            tx.transaction.signer_id(),
+            epoch_id,
+        )?;
+        // Use the header head to make sure the list of validators is as
+        // up-to-date as possible.
+        let head = self.chain_store.header_head()?;
+        let maybe_next_epoch_id = self.get_next_epoch_id_if_at_boundary(&head)?;
+
+        let mut validators = HashSet::new();
+        for horizon in (2..=self.config.tx_routing_height_horizon)
+            .chain(vec![self.config.tx_routing_height_horizon * 2].into_iter())
+        {
+            let target_height = head.height + horizon - 1;
+            let validator = self
+                .epoch_manager
+                .get_chunk_producer_info(&ChunkProductionKey {
+                    epoch_id: *epoch_id,
+                    height_created: target_height,
+                    shard_id,
+                })?
+                .take_account_id();
+            validators.insert(validator);
+            if let Some(next_epoch_id) = &maybe_next_epoch_id {
+                let next_shard_id = account_id_to_shard_id(
+                    self.epoch_manager.as_ref(),
+                    tx.transaction.signer_id(),
+                    next_epoch_id,
+                )?;
+                let validator = self
+                    .epoch_manager
+                    .get_chunk_producer_info(&ChunkProductionKey {
+                        epoch_id: *next_epoch_id,
+                        height_created: target_height,
+                        shard_id: next_shard_id,
+                    })?
+                    .take_account_id();
+                validators.insert(validator);
+            }
+        }
+
+        if let Some(account_id) = signer.as_ref().map(|bp| bp.validator_id()) {
+            validators.remove(account_id);
+        }
+        for validator in validators {
+            let tx_hash = tx.get_hash();
+            tracing::trace!(target: "client", me = ?signer.as_ref().map(|bp| bp.validator_id()), ?tx_hash, ?validator, ?shard_id, "Routing a transaction");
+
+            // Send message to network to actually forward transaction.
+            self.network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
+                NetworkRequests::ForwardTx(validator, tx.clone()),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Determine if I am a validator in next few blocks for specified shard, assuming epoch doesn't change.
+    fn active_validator(
+        &self,
+        shard_id: ShardId,
+        signer: &Option<Arc<ValidatorSigner>>,
+    ) -> Result<bool, near_client_primitives::types::Error> {
+        let head = self.chain_store.head()?;
+        let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(&head.last_block_hash)?;
+
+        let account_id = if let Some(vs) = signer.as_ref() {
+            vs.validator_id()
+        } else {
+            return Ok(false);
+        };
+
+        for i in 1..=self.config.tx_routing_height_horizon {
+            let chunk_producer = self
+                .epoch_manager
+                .get_chunk_producer_info(&ChunkProductionKey {
+                    epoch_id,
+                    height_created: head.height + i,
+                    shard_id,
+                })?
+                .take_account_id();
+            if &chunk_producer == account_id {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// If we're a validator in one of the next few chunks, but epoch switch could happen soon,
+    /// we forward to a validator from next epoch.
+    fn possibly_forward_tx_to_next_epoch(
+        &self,
+        tx: &SignedTransaction,
+        signer: &Option<Arc<ValidatorSigner>>,
+    ) -> Result<(), near_client_primitives::types::Error> {
+        let head = self.chain_store.head()?;
+        if let Some(next_epoch_id) = self.get_next_epoch_id_if_at_boundary(&head)? {
+            self.forward_tx(&next_epoch_id, tx, signer)?;
+        } else {
+            self.forward_tx(&head.epoch_id, tx, signer)?;
+        }
+        Ok(())
+    }
+
+    /// If we are close to epoch boundary, return next epoch id, otherwise return None.
+    fn get_next_epoch_id_if_at_boundary(
+        &self,
+        head: &Tip,
+    ) -> Result<Option<EpochId>, near_client_primitives::types::Error> {
+        let next_epoch_started =
+            self.epoch_manager.is_next_block_epoch_start(&head.last_block_hash)?;
+        if next_epoch_started {
+            return Ok(None);
+        }
+        let next_epoch_estimated_height =
+            self.epoch_manager.get_epoch_start_height(&head.last_block_hash)?
+                + self.config.epoch_length;
+
+        let epoch_boundary_possible =
+            head.height + self.config.tx_routing_height_horizon >= next_epoch_estimated_height;
+        if epoch_boundary_possible {
+            Ok(Some(self.epoch_manager.get_next_epoch_id_from_prev_block(&head.last_block_hash)?))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -95,6 +95,7 @@ pub struct Indexer {
     near_config: nearcore::NearConfig,
     view_client: actix::Addr<near_client::ViewClientActor>,
     client: actix::Addr<near_client::ClientActor>,
+    tx_processor: actix::Addr<near_client::TxRequestHandlerActor>,
     shard_tracker: ShardTracker,
 }
 
@@ -123,10 +124,10 @@ impl Indexer {
             or `\"tracked_accounts\": [\"some_account.near\"]` (which tracks whatever shard the account is on)",
             indexer_config.home_dir.join("config.json").display()
         );
-        let nearcore::NearNode { client, view_client, shard_tracker, .. } =
+        let nearcore::NearNode { client, view_client, tx_processor, shard_tracker, .. } =
             nearcore::start_with_config(&indexer_config.home_dir, near_config.clone())
                 .with_context(|| "start_with_config")?;
-        Ok(Self { view_client, client, near_config, indexer_config, shard_tracker })
+        Ok(Self { view_client, client, tx_processor, near_config, indexer_config, shard_tracker })
     }
 
     /// Boots up `near_indexer::streamer`, so it monitors the new blocks with chunks, transactions, receipts, and execution outcomes inside. The returned stream handler should be drained and handled on the user side.
@@ -151,8 +152,12 @@ impl Indexer {
     /// Internal client actors just in case. Use on your own risk, backward compatibility is not guaranteed
     pub fn client_actors(
         &self,
-    ) -> (actix::Addr<near_client::ViewClientActor>, actix::Addr<near_client::ClientActor>) {
-        (self.view_client.clone(), self.client.clone())
+    ) -> (
+        actix::Addr<near_client::ViewClientActor>,
+        actix::Addr<near_client::ClientActor>,
+        actix::Addr<near_client::TxRequestHandlerActor>,
+    ) {
+        (self.view_client.clone(), self.client.clone(), self.tx_processor.clone())
     }
 }
 

--- a/chain/jsonrpc/jsonrpc-tests/src/lib.rs
+++ b/chain/jsonrpc/jsonrpc-tests/src/lib.rs
@@ -58,6 +58,7 @@ pub fn start_all_with_validity_period(
         TEST_GENESIS_CONFIG.clone(),
         actor_handles.client_actor.clone().with_auto_span_context().into_multi_sender(),
         actor_handles.view_client_actor.clone().with_auto_span_context().into_multi_sender(),
+        actor_handles.tx_processor_actor.clone().with_auto_span_context().into_multi_sender(),
         noop().into_multi_sender(),
         #[cfg(feature = "test_features")]
         noop().into_multi_sender(),

--- a/chain/network/src/client.rs
+++ b/chain/network/src/client.rs
@@ -152,11 +152,11 @@ pub struct OptimisticBlockMessage {
 pub struct ClientSenderForNetwork {
     pub tx_status_request: AsyncSender<TxStatusRequest, Option<Box<FinalExecutionOutcomeView>>>,
     pub tx_status_response: AsyncSender<TxStatusResponse, ()>,
+    pub transaction: AsyncSender<ProcessTxRequest, ProcessTxResponse>,
     pub state_request_header: AsyncSender<StateRequestHeader, Option<StateResponse>>,
     pub state_request_part: AsyncSender<StateRequestPart, Option<StateResponse>>,
     pub state_response: AsyncSender<StateResponseReceived, ()>,
     pub block_approval: AsyncSender<BlockApproval, ()>,
-    pub transaction: AsyncSender<ProcessTxRequest, ProcessTxResponse>,
     pub block_request: AsyncSender<BlockRequest, Option<Box<Block>>>,
     pub block_headers_request: AsyncSender<BlockHeadersRequest, Option<Vec<BlockHeader>>>,
     pub block: AsyncSender<BlockResponse, ()>,

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -576,6 +576,7 @@ pub struct ClientConfig {
     /// which can cause extra load on the database. This option is not recommended for production use,
     /// as a large number of incoming witnesses could cause denial of service.
     pub save_latest_witnesses: bool,
+    pub transaction_request_handler_threads: usize,
 }
 
 impl ClientConfig {
@@ -666,6 +667,7 @@ impl ClientConfig {
             orphan_state_witness_pool_size: default_orphan_state_witness_pool_size(),
             orphan_state_witness_max_size: default_orphan_state_witness_max_size(),
             save_latest_witnesses: false,
+            transaction_request_handler_threads: 4,
         }
     }
 }

--- a/integration-tests/src/env/test_env.rs
+++ b/integration-tests/src/env/test_env.rs
@@ -11,7 +11,7 @@ use near_chain::{ChainGenesis, ChainStoreAccess, Provenance};
 use near_chain_configs::{Genesis, GenesisConfig};
 use near_chunks::client::ShardsManagerResponse;
 use near_chunks::test_utils::{MockClientAdapterForShardsManager, SynchronousShardsManagerAdapter};
-use near_client::{Client, DistributeStateWitnessRequest};
+use near_client::{Client, DistributeStateWitnessRequest, TxRequestHandler};
 use near_crypto::{InMemorySigner, Signer};
 use near_epoch_manager::shard_assignment::{account_id_to_shard_id, shard_id_to_uid};
 use near_network::client::ProcessTxResponse;
@@ -65,6 +65,7 @@ pub struct TestEnv {
     pub partial_witness_adapters: Vec<MockPartialWitnessAdapter>,
     pub shards_manager_adapters: Vec<SynchronousShardsManagerAdapter>,
     pub clients: Vec<Client>,
+    pub tx_request_handlers: Vec<TxRequestHandler>,
     pub(crate) account_indices: AccountIndices,
     pub(crate) paused_blocks: Arc<Mutex<HashMap<CryptoHash, Arc<OnceCell<()>>>>>,
     // random seed to be inject in each client according to AccountId
@@ -216,6 +217,10 @@ impl TestEnv {
 
     pub fn client(&mut self, account_id: &AccountId) -> &mut Client {
         self.account_indices.lookup_mut(&mut self.clients, account_id)
+    }
+
+    pub fn tx_processor(&self, account_id: &AccountId) -> &TxRequestHandler {
+        self.account_indices.lookup(&self.tx_request_handlers, account_id)
     }
 
     pub fn shards_manager(&self, account: &AccountId) -> &SynchronousShardsManagerAdapter {
@@ -527,7 +532,7 @@ impl TestEnv {
             100,
             self.clients[id].chain.head().unwrap().last_block_hash,
         );
-        self.clients[id].process_tx(tx, false, false)
+        self.tx_request_handlers[id].process_tx(tx, false, false)
     }
 
     /// This function used to be able to upgrade to a specific protocol version
@@ -812,7 +817,7 @@ impl TestEnv {
         tx: SignedTransaction,
     ) -> Result<FinalExecutionOutcomeView, InvalidTxError> {
         let tx_hash = tx.get_hash();
-        let response = self.clients[0].process_tx(tx, false, false);
+        let response = self.tx_request_handlers[0].process_tx(tx, false, false);
         // Check if the transaction got rejected
         match response {
             ProcessTxResponse::NoResponse

--- a/integration-tests/src/tests/client/benchmarks.rs
+++ b/integration-tests/src/tests/client/benchmarks.rs
@@ -45,7 +45,10 @@ fn benchmark_large_chunk_production_time() {
             last_block_hash,
             0,
         );
-        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+        assert_eq!(
+            env.tx_request_handlers[0].process_tx(tx, false, false),
+            ProcessTxResponse::ValidTx
+        );
     }
 
     let t = std::time::Instant::now();

--- a/integration-tests/src/tests/client/block_corruption.rs
+++ b/integration-tests/src/tests/client/block_corruption.rs
@@ -46,7 +46,10 @@ fn change_shard_id_to_invalid() {
 
     let txs = create_tx_load(1, &last_block);
     for tx in txs {
-        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+        assert_eq!(
+            env.tx_request_handlers[0].process_tx(tx, false, false),
+            ProcessTxResponse::ValidTx
+        );
     }
 
     let block = env.clients[0].produce_block(1).unwrap().unwrap();
@@ -57,7 +60,10 @@ fn change_shard_id_to_invalid() {
 
     let txs = create_tx_load(2, &last_block);
     for tx in txs {
-        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+        assert_eq!(
+            env.tx_request_handlers[0].process_tx(tx, false, false),
+            ProcessTxResponse::ValidTx
+        );
     }
 
     let mut block = env.clients[0].produce_block(2).unwrap().unwrap();
@@ -191,7 +197,10 @@ fn check_process_flipped_block_fails_on_bit(
     for h in last_block_height + 1..=mid_height {
         let txs = create_tx_load(h, &last_block);
         for tx in txs {
-            assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+            assert_eq!(
+                env.tx_request_handlers[0].process_tx(tx, false, false),
+                ProcessTxResponse::ValidTx
+            );
         }
 
         let block = env.clients[0].produce_block(h).unwrap().unwrap();
@@ -203,7 +212,10 @@ fn check_process_flipped_block_fails_on_bit(
 
     let txs = create_tx_load(h, &last_block);
     for tx in txs {
-        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+        assert_eq!(
+            env.tx_request_handlers[0].process_tx(tx, false, false),
+            ProcessTxResponse::ValidTx
+        );
     }
 
     let correct_block = env.clients[0]

--- a/integration-tests/src/tests/client/bug_repro.rs
+++ b/integration-tests/src/tests/client/bug_repro.rs
@@ -115,7 +115,7 @@ fn slow_test_repro_1183() {
                             // cast ShardId to ShardIndex.
                             let shard_id = account_id_to_shard_id(&from, 4);
                             let shard_index: ShardIndex = shard_id.into();
-                            connectors1.write().unwrap()[shard_index].client_actor.do_send(
+                            connectors1.write().unwrap()[shard_index].tx_processor_actor.do_send(
                                 ProcessTxRequest {
                                     transaction: SignedTransaction::send_money(
                                         block.header().height() * 16 + nonce_delta,

--- a/integration-tests/src/tests/client/catching_up.rs
+++ b/integration-tests/src/tests/client/catching_up.rs
@@ -9,7 +9,7 @@ use near_actix_test_utils::run_actix;
 use near_async::time::Clock;
 use near_chain::test_utils::{ValidatorSchedule, account_id_to_shard_id};
 use near_chain_configs::TEST_STATE_SYNC_TIMEOUT;
-use near_client::{ClientActor, Query};
+use near_client::{Query, TxRequestHandlerActor};
 use near_crypto::InMemorySigner;
 use near_network::client::ProcessTxRequest;
 use near_network::types::PeerInfo;
@@ -64,7 +64,7 @@ fn get_validators_and_key_pairs() -> (ValidatorSchedule, Vec<PeerInfo>) {
 }
 
 fn send_tx(
-    connector: &Addr<ClientActor>,
+    connector: &Addr<TxRequestHandlerActor>,
     from: AccountId,
     to: AccountId,
     amount: u128,
@@ -189,7 +189,7 @@ fn test_catchup_receipts_sync_common(wait_till: u64, send: u64, sync_hold: bool)
                                 );
                                 for i in 0..16 {
                                     send_tx(
-                                        &connectors1.write().unwrap()[i].client_actor,
+                                        &connectors1.write().unwrap()[i].tx_processor_actor,
                                         account_from.clone(),
                                         account_to.clone(),
                                         111,
@@ -488,7 +488,8 @@ fn test_catchup_random_single_part_sync_common(skip_15: bool, non_zero: bool, he
                                         );
                                         for conn in 0..validators.len() {
                                             send_tx(
-                                                &connectors1.write().unwrap()[conn].client_actor,
+                                                &connectors1.write().unwrap()[conn]
+                                                    .tx_processor_actor,
                                                 validator1.clone(),
                                                 validator2.clone(),
                                                 amount,

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -347,7 +347,7 @@ fn test_verify_chunk_invalid_state_challenge() {
     let genesis_hash = *env.clients[0].chain.genesis().hash();
     env.produce_block(0, 1);
     assert_eq!(
-        env.clients[0].process_tx(
+        env.tx_request_handlers[0].process_tx(
             SignedTransaction::send_money(
                 1,
                 "test0".parse().unwrap(),

--- a/integration-tests/src/tests/client/chunks_management.rs
+++ b/integration-tests/src/tests/client/chunks_management.rs
@@ -170,7 +170,7 @@ impl Test {
         let actor = actor.then(move |res| {
             let block_hash = res.unwrap().unwrap().header.hash;
             let connectors_ = connectors.write().unwrap();
-            connectors_[0].client_actor.do_send(
+            connectors_[0].tx_processor_actor.do_send(
                 ProcessTxRequest {
                     transaction: SignedTransaction::empty(block_hash),
                     is_forwarded: false,
@@ -178,7 +178,7 @@ impl Test {
                 }
                 .with_span_context(),
             );
-            connectors_[1].client_actor.do_send(
+            connectors_[1].tx_processor_actor.do_send(
                 ProcessTxRequest {
                     transaction: SignedTransaction::empty(block_hash),
                     is_forwarded: false,
@@ -186,7 +186,7 @@ impl Test {
                 }
                 .with_span_context(),
             );
-            connectors_[2].client_actor.do_send(
+            connectors_[2].tx_processor_actor.do_send(
                 ProcessTxRequest {
                     transaction: SignedTransaction::empty(block_hash),
                     is_forwarded: false,

--- a/integration-tests/src/tests/client/cold_storage.rs
+++ b/integration-tests/src/tests/client/cold_storage.rs
@@ -127,7 +127,10 @@ fn test_storage_after_commit_of_cold_update() {
         let signer = InMemorySigner::test_signer(&test0());
         if height == 1 {
             let tx = create_tx_deploy_contract(height, &signer, last_hash);
-            assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+            assert_eq!(
+                env.tx_request_handlers[0].process_tx(tx, false, false),
+                ProcessTxResponse::ValidTx
+            );
         }
         // Don't send transactions in last two blocks. Because on last block production a chunk from
         // the next block will be produced and information about these transactions will be written
@@ -135,11 +138,17 @@ fn test_storage_after_commit_of_cold_update() {
         if height + 2 < max_height {
             for i in 0..5 {
                 let tx = create_tx_function_call(height * 10 + i, &signer, last_hash);
-                assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+                assert_eq!(
+                    env.tx_request_handlers[0].process_tx(tx, false, false),
+                    ProcessTxResponse::ValidTx
+                );
             }
             for i in 0..5 {
                 let tx = create_tx_send_money(height * 10 + i, &signer, last_hash);
-                assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+                assert_eq!(
+                    env.tx_request_handlers[0].process_tx(tx, false, false),
+                    ProcessTxResponse::ValidTx
+                );
             }
         }
 
@@ -270,7 +279,10 @@ fn test_cold_db_copy_with_height_skips() {
         if height < 16 {
             for i in 0..5 {
                 let tx = create_tx_send_money(height * 10 + i, &signer, last_hash);
-                assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+                assert_eq!(
+                    env.tx_request_handlers[0].process_tx(tx, false, false),
+                    ProcessTxResponse::ValidTx
+                );
             }
         }
 
@@ -355,7 +367,10 @@ fn test_initial_copy_to_cold(batch_size: usize) {
         let signer = InMemorySigner::test_signer(&test0());
         for i in 0..5 {
             let tx = create_tx_send_money(height * 10 + i, &signer, last_hash);
-            assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+            assert_eq!(
+                env.tx_request_handlers[0].process_tx(tx, false, false),
+                ProcessTxResponse::ValidTx
+            );
         }
 
         let block = env.clients[0].produce_block(height).unwrap().unwrap();
@@ -442,7 +457,10 @@ fn test_cold_loop_on_gc_boundary() {
         let signer = InMemorySigner::test_signer(&test0());
         for i in 0..5 {
             let tx = create_tx_send_money(height * 10 + i, &signer, last_hash);
-            assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+            assert_eq!(
+                env.tx_request_handlers[0].process_tx(tx, false, false),
+                ProcessTxResponse::ValidTx
+            );
         }
 
         let block = env.clients[0].produce_block(height).unwrap().unwrap();
@@ -461,7 +479,10 @@ fn test_cold_loop_on_gc_boundary() {
         let signer = InMemorySigner::test_signer(&test0());
         for i in 0..5 {
             let tx = create_tx_send_money(height * 10 + i, &signer, last_hash);
-            assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+            assert_eq!(
+                env.tx_request_handlers[0].process_tx(tx, false, false),
+                ProcessTxResponse::ValidTx
+            );
         }
 
         let block = env.clients[0].produce_block(height).unwrap().unwrap();

--- a/integration-tests/src/tests/client/cross_shard_tx.rs
+++ b/integration-tests/src/tests/client/cross_shard_tx.rs
@@ -107,7 +107,7 @@ fn send_tx(
     let signer = InMemorySigner::test_signer(&from);
     actix::spawn(
         connectors.write().unwrap()[connector_ordinal]
-            .client_actor
+            .tx_processor_actor
             .send(
                 ProcessTxRequest {
                     transaction: SignedTransaction::send_money(

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -128,7 +128,10 @@ fn test_not_supported_block() {
             1,
             genesis_hash,
         );
-        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+        assert_eq!(
+            env.tx_request_handlers[0].process_tx(tx, false, false),
+            ProcessTxResponse::ValidTx
+        );
     }
 
     let flat_head_height = START_HEIGHT - 4;

--- a/integration-tests/src/tests/client/invalid_txs.rs
+++ b/integration-tests/src/tests/client/invalid_txs.rs
@@ -79,10 +79,11 @@ fn test_invalid_transactions_no_panic() {
             let chunk_producer = env.get_chunk_producer_at_offset(&tip, 1, ShardId::new(0));
             let block_producer = env.get_block_producer_at_offset(&tip, 1);
 
+            let tx_processor = env.tx_processor(&chunk_producer).clone();
             let client = env.client(&chunk_producer);
             let transactions = if height == start_height { vec![tx.clone()] } else { vec![] };
             if height == start_height {
-                let res = client.process_tx(valid_tx.clone(), false, false);
+                let res = tx_processor.process_tx(valid_tx.clone(), false, false);
                 assert!(matches!(res, ProcessTxResponse::ValidTx))
             }
 

--- a/integration-tests/src/tests/client/query_client.rs
+++ b/integration-tests/src/tests/client/query_client.rs
@@ -173,7 +173,7 @@ fn test_execution_outcome_for_chunk() {
             );
             let tx_hash = transaction.get_hash();
             let res = actor_handles
-                .client_actor
+                .tx_processor_actor
                 .send(
                     ProcessTxRequest { transaction, is_forwarded: false, check_only: false }
                         .with_span_context(),

--- a/integration-tests/src/tests/client/resharding_v2.rs
+++ b/integration-tests/src/tests/client/resharding_v2.rs
@@ -320,7 +320,7 @@ impl TestReshardingEnv {
         let mut response_valid_count = 0;
         let mut response_routed_count = 0;
         for j in 0..env.validators.len() {
-            let response = env.clients[j].process_tx(tx.clone(), false, false);
+            let response = env.tx_request_handlers[j].process_tx(tx.clone(), false, false);
             tracing::trace!(target: "test", client=j, tx=?tx.get_hash(), ?response, "process tx");
             match response {
                 ProcessTxResponse::ValidTx => response_valid_count += 1,

--- a/integration-tests/src/tests/client/sandbox.rs
+++ b/integration-tests/src/tests/client/sandbox.rs
@@ -72,7 +72,7 @@ fn send_tx(
     let hash = env.clients[0].chain.head().unwrap().last_block_hash;
     let tx =
         SignedTransaction::from_actions(nonce, signer_id, receiver_id, signer, actions, hash, 0);
-    env.clients[0].process_tx(tx, false, false)
+    env.tx_request_handlers[0].process_tx(tx, false, false)
 }
 
 #[test]

--- a/integration-tests/src/tests/client/state_dump.rs
+++ b/integration-tests/src/tests/client/state_dump.rs
@@ -203,7 +203,10 @@ fn run_state_sync_with_dumped_parts(
                 &signer,
                 genesis_hash,
             );
-            assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+            assert_eq!(
+                env.tx_request_handlers[0].process_tx(tx, false, false),
+                ProcessTxResponse::ValidTx
+            );
         }
         let block = env.clients[0].produce_block(i).unwrap().unwrap();
         blocks.push(block.clone());

--- a/integration-tests/src/tests/client/state_snapshot.rs
+++ b/integration-tests/src/tests/client/state_snapshot.rs
@@ -222,7 +222,10 @@ fn slow_test_make_state_snapshot() {
             &signer,
             genesis_hash,
         );
-        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+        assert_eq!(
+            env.tx_request_handlers[0].process_tx(tx, false, false),
+            ProcessTxResponse::ValidTx
+        );
         let block = env.clients[0].produce_block(i).unwrap().unwrap();
         blocks.push(block.clone());
         env.process_block(0, block.clone(), Provenance::PRODUCED);

--- a/integration-tests/src/tests/client/sync_state_nodes.rs
+++ b/integration-tests/src/tests/client/sync_state_nodes.rs
@@ -543,7 +543,10 @@ fn ultra_slow_test_dump_epoch_missing_chunk_in_last_block() {
                     1,
                     *genesis_block.hash(),
                 );
-                assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+                assert_eq!(
+                    env.tx_request_handlers[0].process_tx(tx, false, false),
+                    ProcessTxResponse::ValidTx
+                );
             }
 
             // Simulate state sync

--- a/integration-tests/src/tests/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/features/access_key_nonce_for_implicit_accounts.rs
@@ -38,7 +38,7 @@ fn check_tx_processing(
     blocks_number: u64,
 ) -> BlockHeight {
     let tx_hash = tx.get_hash();
-    assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(env.tx_request_handlers[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
     let next_height = produce_blocks_from_height(env, blocks_number, height);
     let final_outcome = env.clients[0].chain.get_final_transaction_result(&tx_hash).unwrap();
     assert_matches!(final_outcome.status, FinalExecutionStatus::SuccessValue(_));
@@ -74,11 +74,11 @@ fn test_transaction_hash_collision() {
     );
 
     assert_eq!(
-        env.clients[0].process_tx(send_money_tx.clone(), false, false),
+        env.tx_request_handlers[0].process_tx(send_money_tx.clone(), false, false),
         ProcessTxResponse::ValidTx
     );
     assert_eq!(
-        env.clients[0].process_tx(delete_account_tx, false, false),
+        env.tx_request_handlers[0].process_tx(delete_account_tx, false, false),
         ProcessTxResponse::ValidTx
     );
 
@@ -96,7 +96,7 @@ fn test_transaction_hash_collision() {
         *genesis_block.hash(),
     );
     assert_eq!(
-        env.clients[0].process_tx(create_account_tx, false, false),
+        env.tx_request_handlers[0].process_tx(create_account_tx, false, false),
         ProcessTxResponse::ValidTx
     );
     for i in 4..8 {
@@ -104,7 +104,7 @@ fn test_transaction_hash_collision() {
     }
 
     assert_matches!(
-        env.clients[0].process_tx(send_money_tx, false, false),
+        env.tx_request_handlers[0].process_tx(send_money_tx, false, false),
         ProcessTxResponse::InvalidTx(_)
     );
 }
@@ -175,8 +175,11 @@ fn get_status_of_tx_hash_collision_for_near_implicit_account(
         100,
         *block.hash(),
     );
-    let response =
-        env.clients[0].process_tx(send_money_from_near_implicit_account_tx, false, false);
+    let response = env.tx_request_handlers[0].process_tx(
+        send_money_from_near_implicit_account_tx,
+        false,
+        false,
+    );
 
     // Check that sending money from NEAR-implicit account with correct nonce is still valid.
     let send_money_from_near_implicit_account_tx = SignedTransaction::send_money(
@@ -282,7 +285,7 @@ fn test_transaction_nonce_too_large() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
-    let mut env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
+    let env = TestEnv::builder(&genesis.config).nightshade_runtimes(&genesis).build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let large_nonce = AccessKey::ACCESS_KEY_NONCE_RANGE_MULTIPLIER + 1;
@@ -295,7 +298,7 @@ fn test_transaction_nonce_too_large() {
         *genesis_block.hash(),
     );
     assert_matches!(
-        env.clients[0].process_tx(tx, false, false),
+        env.tx_request_handlers[0].process_tx(tx, false, false),
         ProcessTxResponse::InvalidTx(InvalidTxError::InvalidAccessKeyError(_))
     );
 }

--- a/integration-tests/src/tests/features/account_id_in_function_call_permission.rs
+++ b/integration-tests/src/tests/features/account_id_in_function_call_permission.rs
@@ -66,7 +66,7 @@ fn test_account_id_in_function_call_permission_upgrade() {
         })
         .sign(&signer);
         assert_eq!(
-            env.clients[0].process_tx(signed_transaction, false, false),
+            env.tx_request_handlers[0].process_tx(signed_transaction, false, false),
             ProcessTxResponse::ValidTx
         );
         for i in 0..3 {
@@ -83,7 +83,7 @@ fn test_account_id_in_function_call_permission_upgrade() {
             Transaction::V0(TransactionV0 { nonce: 11, block_hash: tip.last_block_hash, ..tx })
                 .sign(&signer);
         assert_eq!(
-            env.clients[0].process_tx(signed_transaction, false, false),
+            env.tx_request_handlers[0].process_tx(signed_transaction, false, false),
             ProcessTxResponse::InvalidTx(InvalidTxError::ActionsValidation(
                 ActionsValidationError::InvalidAccountId { account_id: "#".to_string() }
             ))
@@ -93,7 +93,7 @@ fn test_account_id_in_function_call_permission_upgrade() {
 
 #[test]
 fn test_very_long_account_id() {
-    let mut env = {
+    let env = {
         let genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
         TestEnv::builder(&genesis.config)
             .nightshade_runtimes_with_runtime_config_store(
@@ -126,7 +126,7 @@ fn test_very_long_account_id() {
     .sign(&signer);
 
     assert_eq!(
-        env.clients[0].process_tx(tx, false, false),
+        env.tx_request_handlers[0].process_tx(tx, false, false),
         ProcessTxResponse::InvalidTx(InvalidTxError::ActionsValidation(
             ActionsValidationError::InvalidAccountId { account_id: "A".repeat(128) }
         ))

--- a/integration-tests/src/tests/features/chunk_nodes_cache.rs
+++ b/integration-tests/src/tests/features/chunk_nodes_cache.rs
@@ -54,7 +54,7 @@ fn process_transaction(
         0,
     );
     let tx_hash = tx.get_hash();
-    assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(env.tx_request_handlers[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
 
     for i in next_height..next_height + num_blocks {
         let mut block = env.clients[0].produce_block(i).unwrap().unwrap();

--- a/integration-tests/src/tests/features/congestion_control.rs
+++ b/integration-tests/src/tests/features/congestion_control.rs
@@ -528,7 +528,7 @@ fn submit_n_100tgas_fns(env: &mut TestEnv, n: u32, nonce: &mut u64, signer: &Sig
     for _ in 0..n {
         let fn_tx = new_fn_call_100tgas(nonce, signer, *block.hash());
         // this only adds the tx to the pool, no chain progress is made
-        let response = env.clients[0].process_tx(fn_tx, false, false);
+        let response = env.tx_request_handlers[0].process_tx(fn_tx, false, false);
         match response {
             ProcessTxResponse::ValidTx => {
                 included += 1;
@@ -552,7 +552,7 @@ fn submit_n_cheap_fns(
     for _ in 0..n {
         let fn_tx = new_cheap_fn_call(nonce, signer, receiver.clone(), *block.hash());
         // this only adds the tx to the pool, no chain progress is made
-        let response = env.clients[0].process_tx(fn_tx, false, false);
+        let response = env.tx_request_handlers[0].process_tx(fn_tx, false, false);
         assert_eq!(response, ProcessTxResponse::ValidTx);
     }
 }
@@ -840,7 +840,7 @@ fn test_rpc_client_rejection() {
         &signer,
         *env.clients[0].chain.head_header().unwrap().hash(),
     );
-    let response = env.clients[0].process_tx(fn_tx, false, false);
+    let response = env.tx_request_handlers[0].process_tx(fn_tx, false, false);
     assert_eq!(response, ProcessTxResponse::ValidTx);
 
     // Congest the network with a burst of 100 PGas.
@@ -859,7 +859,7 @@ fn test_rpc_client_rejection() {
         &signer,
         *env.clients[0].chain.head_header().unwrap().hash(),
     );
-    let response = env.clients[0].process_tx(fn_tx, false, false);
+    let response = env.tx_request_handlers[0].process_tx(fn_tx, false, false);
 
     if ProtocolFeature::CongestionControl.enabled(PROTOCOL_VERSION) {
         assert_matches!(

--- a/integration-tests/src/tests/features/flat_storage.rs
+++ b/integration-tests/src/tests/features/flat_storage.rs
@@ -81,7 +81,7 @@ fn test_flat_storage_upgrade() {
         .sign(&signer);
         let tx_hash = signed_transaction.get_hash();
         assert_eq!(
-            env.clients[0].process_tx(signed_transaction, false, false),
+            env.tx_request_handlers[0].process_tx(signed_transaction, false, false),
             ProcessTxResponse::ValidTx
         );
         for i in 0..blocks_to_process_txn {
@@ -109,7 +109,7 @@ fn test_flat_storage_upgrade() {
             .sign(&signer);
             let tx_hash = signed_transaction.get_hash();
             assert_eq!(
-                env.clients[0].process_tx(signed_transaction, false, false),
+                env.tx_request_handlers[0].process_tx(signed_transaction, false, false),
                 ProcessTxResponse::ValidTx
             );
             for i in 0..blocks_to_process_txn {

--- a/integration-tests/src/tests/features/in_memory_tries.rs
+++ b/integration-tests/src/tests/features/in_memory_tries.rs
@@ -259,8 +259,8 @@ fn run_chain_for_some_blocks_while_sending_money_around(
                 );
                 // Process the txn in all shards, because they may not always
                 // get a chance to produce the txn if they don't track the shard.
-                for client in &mut env.clients {
-                    match client.process_tx(txn.clone(), false, false) {
+                for tx_processor in &env.tx_request_handlers {
+                    match tx_processor.process_tx(txn.clone(), false, false) {
                         ProcessTxResponse::NoResponse => panic!("No response"),
                         ProcessTxResponse::InvalidTx(err) => panic!("Invalid tx: {}", err),
                         _ => {}

--- a/integration-tests/src/tests/features/increase_storage_compute_cost.rs
+++ b/integration-tests/src/tests/features/increase_storage_compute_cost.rs
@@ -331,7 +331,10 @@ fn produce_saturated_chunk(
         tx_ids.push(tx.get_hash());
 
         // add tx to the mempool but don't execute it yet
-        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+        assert_eq!(
+            env.tx_request_handlers[0].process_tx(tx, false, false),
+            ProcessTxResponse::ValidTx
+        );
     }
 
     // process the queued transactions

--- a/integration-tests/src/tests/features/lower_storage_key_limit.rs
+++ b/integration-tests/src/tests/features/lower_storage_key_limit.rs
@@ -86,7 +86,10 @@ fn protocol_upgrade() {
         })
         .sign(&signer);
         let tx_hash = signed_tx.get_hash();
-        assert_eq!(env.clients[0].process_tx(signed_tx, false, false), ProcessTxResponse::ValidTx);
+        assert_eq!(
+            env.tx_request_handlers[0].process_tx(signed_tx, false, false),
+            ProcessTxResponse::ValidTx
+        );
         produce_blocks_from_height_with_protocol_version(
             &mut env,
             epoch_length,
@@ -109,7 +112,10 @@ fn protocol_upgrade() {
         })
         .sign(&signer);
         let tx_hash = signed_tx.get_hash();
-        assert_eq!(env.clients[0].process_tx(signed_tx, false, false), ProcessTxResponse::ValidTx);
+        assert_eq!(
+            env.tx_request_handlers[0].process_tx(signed_tx, false, false),
+            ProcessTxResponse::ValidTx
+        );
         for i in 0..epoch_length {
             let block = env.clients[0].produce_block(tip.height + i + 1).unwrap().unwrap();
             env.process_block(0, block.clone(), Provenance::PRODUCED);
@@ -149,7 +155,10 @@ fn protocol_upgrade() {
         })
         .sign(&signer);
         let tx_hash = signed_tx.get_hash();
-        assert_eq!(env.clients[0].process_tx(signed_tx, false, false), ProcessTxResponse::ValidTx);
+        assert_eq!(
+            env.tx_request_handlers[0].process_tx(signed_tx, false, false),
+            ProcessTxResponse::ValidTx
+        );
         for i in 0..epoch_length {
             let block = env.clients[0].produce_block(tip.height + i + 1).unwrap().unwrap();
             env.process_block(0, block.clone(), Provenance::PRODUCED);

--- a/integration-tests/src/tests/features/nearvm.rs
+++ b/integration-tests/src/tests/features/nearvm.rs
@@ -69,7 +69,7 @@ fn test_nearvm_upgrade() {
         })
         .sign(&signer);
         assert_eq!(
-            env.clients[0].process_tx(signed_transaction, false, false),
+            env.tx_request_handlers[0].process_tx(signed_transaction, false, false),
             ProcessTxResponse::ValidTx
         );
         for i in 0..3 {
@@ -87,7 +87,7 @@ fn test_nearvm_upgrade() {
             Transaction::V0(TransactionV0 { nonce: 11, block_hash: tip.last_block_hash, ..tx })
                 .sign(&signer);
         assert_eq!(
-            env.clients[0].process_tx(signed_transaction, false, false),
+            env.tx_request_handlers[0].process_tx(signed_transaction, false, false),
             ProcessTxResponse::ValidTx
         );
         for i in 0..3 {

--- a/integration-tests/src/tests/features/stateless_validation.rs
+++ b/integration-tests/src/tests/features/stateless_validation.rs
@@ -162,7 +162,7 @@ fn run_chunk_validation_test(
                 tip.last_block_hash,
             );
             tx_hashes.push(tx.get_hash());
-            let _ = env.clients[0].process_tx(tx, false, false);
+            let _ = env.tx_request_handlers[0].process_tx(tx, false, false);
         }
 
         let height_offset = height - tip.height;
@@ -432,10 +432,13 @@ fn test_eth_implicit_accounts() {
     );
 
     assert_eq!(
-        env.clients[0].process_tx(create_alice_tx, false, false),
+        env.tx_request_handlers[0].process_tx(create_alice_tx, false, false),
         ProcessTxResponse::ValidTx
     );
-    assert_eq!(env.clients[0].process_tx(create_bob_tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(
+        env.tx_request_handlers[0].process_tx(create_bob_tx, false, false),
+        ProcessTxResponse::ValidTx
+    );
 
     // Process some blocks to ensure the transactions are complete.
     for _ in 0..10 {
@@ -471,7 +474,7 @@ fn test_eth_implicit_accounts() {
     );
 
     assert_eq!(
-        env.clients[0].process_tx(signed_transaction, false, false),
+        env.tx_request_handlers[0].process_tx(signed_transaction, false, false),
         ProcessTxResponse::ValidTx
     );
 
@@ -496,7 +499,7 @@ fn test_eth_implicit_accounts() {
     );
 
     assert_eq!(
-        env.clients[0].process_tx(signed_transaction, false, false),
+        env.tx_request_handlers[0].process_tx(signed_transaction, false, false),
         ProcessTxResponse::ValidTx
     );
 

--- a/integration-tests/src/tests/features/storage_proof_size_limit.rs
+++ b/integration-tests/src/tests/features/storage_proof_size_limit.rs
@@ -132,7 +132,7 @@ fn test_storage_proof_size_limit() {
     let read2_txs =
         [make_read_transaction(0, 3), make_read_transaction(3, 6), make_read_transaction(6, 9)];
     for read2_tx in &read2_txs {
-        let response = env.clients[0].process_tx(read2_tx.clone(), false, false);
+        let response = env.tx_request_handlers[0].process_tx(read2_tx.clone(), false, false);
         assert_eq!(response, ProcessTxResponse::ValidTx);
     }
 

--- a/integration-tests/src/tests/features/wallet_contract.rs
+++ b/integration-tests/src/tests/features/wallet_contract.rs
@@ -40,7 +40,7 @@ fn check_tx_processing(
     blocks_number: u64,
 ) -> BlockHeight {
     let tx_hash = tx.get_hash();
-    assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(env.tx_request_handlers[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
     let next_height = produce_blocks_from_height(env, blocks_number, height);
     let final_outcome = env.clients[0].chain.get_final_transaction_result(&tx_hash).unwrap();
     println!("{final_outcome:?}");
@@ -105,7 +105,10 @@ fn test_eth_implicit_account_creation() {
         0,
         *genesis_block.hash(),
     );
-    assert_eq!(env.clients[0].process_tx(transfer_tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(
+        env.tx_request_handlers[0].process_tx(transfer_tx, false, false),
+        ProcessTxResponse::ValidTx
+    );
     for i in 1..5 {
         env.produce_block(0, i);
     }
@@ -181,7 +184,11 @@ fn test_transaction_from_eth_implicit_account_fail() {
         100,
         *block.hash(),
     );
-    let response = env.clients[0].process_tx(send_money_from_eth_implicit_account_tx, false, false);
+    let response = env.tx_request_handlers[0].process_tx(
+        send_money_from_eth_implicit_account_tx,
+        false,
+        false,
+    );
     let expected_tx_error = ProcessTxResponse::InvalidTx(InvalidTxError::InvalidAccessKeyError(
         InvalidAccessKeyError::AccessKeyNotFound {
             account_id: eth_implicit_account_id.clone(),
@@ -199,7 +206,8 @@ fn test_transaction_from_eth_implicit_account_fail() {
         &eth_implicit_account_signer,
         *block.hash(),
     );
-    let response = env.clients[0].process_tx(delete_eth_implicit_account_tx, false, false);
+    let response =
+        env.tx_request_handlers[0].process_tx(delete_eth_implicit_account_tx, false, false);
     assert_eq!(response, expected_tx_error);
 
     // Try to add an access key to the ETH-implicit account. Should fail because there is no access key.
@@ -215,8 +223,11 @@ fn test_transaction_from_eth_implicit_account_fail() {
         *block.hash(),
         0,
     );
-    let response =
-        env.clients[0].process_tx(add_access_key_to_eth_implicit_account_tx, false, false);
+    let response = env.tx_request_handlers[0].process_tx(
+        add_access_key_to_eth_implicit_account_tx,
+        false,
+        false,
+    );
     assert_eq!(response, expected_tx_error);
 
     // Try to deploy the Wallet Contract again to the ETH-implicit account. Should fail because there is no access key.
@@ -231,8 +242,11 @@ fn test_transaction_from_eth_implicit_account_fail() {
         *block.hash(),
         0,
     );
-    let response =
-        env.clients[0].process_tx(add_access_key_to_eth_implicit_account_tx, false, false);
+    let response = env.tx_request_handlers[0].process_tx(
+        add_access_key_to_eth_implicit_account_tx,
+        false,
+        false,
+    );
     assert_eq!(response, expected_tx_error);
 }
 

--- a/integration-tests/src/tests/features/yield_resume.rs
+++ b/integration-tests/src/tests/features/yield_resume.rs
@@ -75,7 +75,7 @@ fn prepare_env(test_env_gas_limit: Option<u64>) -> TestEnv {
         0,
     );
     let tx_hash = tx.get_hash();
-    assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(env.tx_request_handlers[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
 
     // Allow two blocks for the contract to be deployed
     for i in 1..3 {
@@ -118,7 +118,7 @@ fn yield_then_resume() {
     );
     let yield_tx_hash = yield_transaction.get_hash();
     assert_eq!(
-        env.clients[0].process_tx(yield_transaction, false, false),
+        env.tx_request_handlers[0].process_tx(yield_transaction, false, false),
         ProcessTxResponse::ValidTx
     );
 
@@ -149,7 +149,7 @@ fn yield_then_resume() {
         0,
     );
     assert_eq!(
-        env.clients[0].process_tx(resume_transaction, false, false),
+        env.tx_request_handlers[0].process_tx(resume_transaction, false, false),
         ProcessTxResponse::ValidTx
     );
 

--- a/integration-tests/src/tests/features/yield_timeouts.rs
+++ b/integration-tests/src/tests/features/yield_timeouts.rs
@@ -80,7 +80,7 @@ fn prepare_env_with_yield(
         0,
     );
     let tx_hash = tx.get_hash();
-    assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(env.tx_request_handlers[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
 
     // Allow two blocks for the contract to be deployed
     for i in 1..3 {
@@ -108,7 +108,7 @@ fn prepare_env_with_yield(
     );
     let yield_tx_hash = yield_transaction.get_hash();
     assert_eq!(
-        env.clients[0].process_tx(yield_transaction, false, false),
+        env.tx_request_handlers[0].process_tx(yield_transaction, false, false),
         ProcessTxResponse::ValidTx
     );
 
@@ -151,7 +151,7 @@ fn invoke_yield_resume(
     );
     let tx_hash = resume_transaction.get_hash();
     assert_eq!(
-        env.clients[0].process_tx(resume_transaction, false, false),
+        env.tx_request_handlers[0].process_tx(resume_transaction, false, false),
         ProcessTxResponse::ValidTx
     );
     tx_hash
@@ -184,7 +184,7 @@ fn create_congestion(env: &mut TestEnv) {
         );
         tx_hashes.push(signed_transaction.get_hash());
         assert_eq!(
-            env.clients[0].process_tx(signed_transaction, false, false),
+            env.tx_request_handlers[0].process_tx(signed_transaction, false, false),
             ProcessTxResponse::ValidTx
         );
     }

--- a/integration-tests/src/tests/features/zero_balance_account.rs
+++ b/integration-tests/src/tests/features/zero_balance_account.rs
@@ -70,7 +70,7 @@ fn test_zero_balance_account_creation() {
         *genesis_block.hash(),
     );
     assert_eq!(
-        env.clients[0].process_tx(create_account_tx, false, false),
+        env.tx_request_handlers[0].process_tx(create_account_tx, false, false),
         ProcessTxResponse::ValidTx
     );
     for i in 1..5 {
@@ -94,7 +94,7 @@ fn test_zero_balance_account_creation() {
     );
     let tx_hash = create_account_tx.get_hash();
     assert_eq!(
-        env.clients[0].process_tx(create_account_tx, false, false),
+        env.tx_request_handlers[0].process_tx(create_account_tx, false, false),
         ProcessTxResponse::ValidTx
     );
     for i in 5..10 {
@@ -153,7 +153,7 @@ fn test_zero_balance_account_add_key() {
         *genesis_block.hash(),
     );
     assert_eq!(
-        env.clients[0].process_tx(create_account_tx, false, false),
+        env.tx_request_handlers[0].process_tx(create_account_tx, false, false),
         ProcessTxResponse::ValidTx
     );
     for i in 1..5 {
@@ -198,7 +198,10 @@ fn test_zero_balance_account_add_key() {
         *genesis_block.hash(),
         0,
     );
-    assert_eq!(env.clients[0].process_tx(add_key_tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(
+        env.tx_request_handlers[0].process_tx(add_key_tx, false, false),
+        ProcessTxResponse::ValidTx
+    );
     for i in 5..10 {
         env.produce_block(0, i);
     }
@@ -214,7 +217,7 @@ fn test_zero_balance_account_add_key() {
         *genesis_block.hash(),
     );
     assert_matches!(
-        env.clients[0].process_tx(send_money_tx.clone(), false, false),
+        env.tx_request_handlers[0].process_tx(send_money_tx.clone(), false, false),
         ProcessTxResponse::InvalidTx(InvalidTxError::LackBalanceForState { .. })
     );
 
@@ -229,11 +232,17 @@ fn test_zero_balance_account_add_key() {
         *genesis_block.hash(),
         0,
     );
-    assert_eq!(env.clients[0].process_tx(delete_key_tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(
+        env.tx_request_handlers[0].process_tx(delete_key_tx, false, false),
+        ProcessTxResponse::ValidTx
+    );
     for i in 10..15 {
         env.produce_block(0, i);
     }
-    assert_eq!(env.clients[0].process_tx(send_money_tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(
+        env.tx_request_handlers[0].process_tx(send_money_tx, false, false),
+        ProcessTxResponse::ValidTx
+    );
     for i in 15..20 {
         env.produce_block(0, i);
     }
@@ -274,7 +283,7 @@ fn test_zero_balance_account_upgrade() {
     );
     let first_tx_hash = first_create_account_tx.get_hash();
     assert_eq!(
-        env.clients[0].process_tx(first_create_account_tx, false, false),
+        env.tx_request_handlers[0].process_tx(first_create_account_tx, false, false),
         ProcessTxResponse::ValidTx
     );
     for i in 1..12 {
@@ -300,7 +309,7 @@ fn test_zero_balance_account_upgrade() {
     );
     let second_tx_hash = second_create_account_tx.get_hash();
     assert_eq!(
-        env.clients[0].process_tx(second_create_account_tx, false, false),
+        env.tx_request_handlers[0].process_tx(second_create_account_tx, false, false),
         ProcessTxResponse::ValidTx
     );
     for i in 12..20 {

--- a/integration-tests/src/tests/nearcore/economics.rs
+++ b/integration-tests/src/tests/nearcore/economics.rs
@@ -74,7 +74,7 @@ fn test_burn_mint() {
     let initial_total_supply = env.chain_genesis.total_supply;
     let genesis_hash = *env.clients[0].chain.genesis().hash();
     assert_eq!(
-        env.clients[0].process_tx(
+        env.tx_request_handlers[0].process_tx(
             SignedTransaction::send_money(
                 1,
                 "test0".parse().unwrap(),

--- a/integration-tests/src/tests/nearcore/sync_nodes.rs
+++ b/integration-tests/src/tests/nearcore/sync_nodes.rs
@@ -44,8 +44,9 @@ fn ultra_slow_test_sync_state_stake_change() {
         let dir1 = tempfile::Builder::new().prefix("sync_state_stake_change_1").tempdir().unwrap();
         let dir2 = tempfile::Builder::new().prefix("sync_state_stake_change_2").tempdir().unwrap();
         run_actix(async {
-            let nearcore::NearNode { client: client1, view_client: view_client1, .. } =
-                start_with_config(dir1.path(), near1.clone()).expect("start_with_config");
+            let nearcore::NearNode {
+                view_client: view_client1, tx_processor: tx_processor1, ..
+            } = start_with_config(dir1.path(), near1.clone()).expect("start_with_config");
 
             let genesis_hash = *genesis_block(&genesis).hash();
             let signer = Arc::new(InMemorySigner::test_signer(&"test1".parse().unwrap()));
@@ -58,7 +59,7 @@ fn ultra_slow_test_sync_state_stake_change() {
                 genesis_hash,
             );
             actix::spawn(
-                client1
+                tx_processor1
                     .send(
                         ProcessTxRequest {
                             transaction: unstake_transaction,

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -11,7 +11,10 @@ use near_chain::{Chain, ChainGenesis};
 use near_chain_configs::{ClientConfig, Genesis, GenesisConfig, MutableConfigValue};
 use near_chunks::shards_manager_actor::start_shards_manager;
 use near_client::adapter::client_sender_for_network;
-use near_client::{PartialWitnessActor, ViewClientActorInner, start_client};
+use near_client::{
+    PartialWitnessActor, StartClientResult, TxRequestHandlerConfig, ViewClientActorInner,
+    spawn_tx_request_handler_actor, start_client,
+};
 use near_epoch_manager::EpochManager;
 use near_epoch_manager::shard_tracker::ShardTracker;
 use near_network::PeerManagerActor;
@@ -96,7 +99,7 @@ fn setup_network_node(
     let network_adapter = LateBoundSender::new();
     let shards_manager_adapter = LateBoundSender::new();
     let adv = near_client::adversarial::Controls::default();
-    let client_actor = start_client(
+    let StartClientResult { client_actor, tx_pool, .. } = start_client(
         Clock::real(),
         client_config.clone(),
         chain_genesis.clone(),
@@ -117,8 +120,7 @@ fn setup_network_node(
         true,
         None,
         noop().into_multi_sender(),
-    )
-    .client_actor;
+    );
     let view_client_addr = ViewClientActorInner::spawn_actix_actor(
         Clock::real(),
         validator_signer.clone(),
@@ -129,6 +131,21 @@ fn setup_network_node(
         network_adapter.as_multi_sender(),
         client_config.clone(),
         adv,
+    );
+    let tx_processor_config = TxRequestHandlerConfig {
+        handler_threads: client_config.transaction_request_handler_threads,
+        tx_routing_height_horizon: client_config.tx_routing_height_horizon,
+        epoch_length: client_config.epoch_length,
+        transaction_validity_period: genesis.config.transaction_validity_period,
+    };
+    let tx_processor = spawn_tx_request_handler_actor(
+        tx_processor_config,
+        tx_pool,
+        epoch_manager.clone(),
+        shard_tracker.clone(),
+        validator_signer.clone(),
+        runtime.clone(),
+        network_adapter.as_multi_sender(),
     );
     let (shards_manager_actor, _) = start_shards_manager(
         epoch_manager.clone(),
@@ -155,7 +172,7 @@ fn setup_network_node(
         time::Clock::real(),
         db.clone(),
         config,
-        client_sender_for_network(client_actor, view_client_addr),
+        client_sender_for_network(client_actor, view_client_addr, tx_processor),
         network_adapter.as_multi_sender(),
         shards_manager_adapter.as_sender(),
         partial_witness_actor.with_auto_span_context().into_multi_sender(),

--- a/integration-tests/src/tests/tools/apply_chain_range.rs
+++ b/integration-tests/src/tests/tools/apply_chain_range.rs
@@ -85,7 +85,7 @@ fn test_apply_chain_range() {
         signer.public_key(),
         genesis_hash,
     );
-    assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(env.tx_request_handlers[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
 
     safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1, None);
 
@@ -128,7 +128,7 @@ fn test_apply_chain_range_no_chunks() {
         signer.public_key(),
         genesis_hash,
     );
-    assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(env.tx_request_handlers[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
 
     safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1, Some(5));
 

--- a/integration-tests/src/tests/tools/apply_chunk.rs
+++ b/integration-tests/src/tests/tools/apply_chunk.rs
@@ -31,7 +31,10 @@ fn send_txs(env: &mut TestEnv, signers: &[Signer], height: u64, hash: CryptoHash
             100,
             hash,
         );
-        assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+        assert_eq!(
+            env.tx_request_handlers[0].process_tx(tx, false, false),
+            ProcessTxResponse::ValidTx
+        );
     }
 }
 

--- a/integration-tests/src/tests/tools/state_dump.rs
+++ b/integration-tests/src/tests/tools/state_dump.rs
@@ -108,7 +108,7 @@ fn test_dump_state_preserve_validators() {
         signer.public_key(),
         genesis_hash,
     );
-    assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(env.tx_request_handlers[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
 
     safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1);
 
@@ -169,8 +169,14 @@ fn test_dump_state_respect_select_account_ids() {
         signer0.public_key(),
         genesis_hash,
     );
-    assert_eq!(env.clients[0].process_tx(tx00, false, false), ProcessTxResponse::ValidTx);
-    assert_eq!(env.clients[0].process_tx(tx01, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(
+        env.tx_request_handlers[0].process_tx(tx00, false, false),
+        ProcessTxResponse::ValidTx
+    );
+    assert_eq!(
+        env.tx_request_handlers[0].process_tx(tx01, false, false),
+        ProcessTxResponse::ValidTx
+    );
 
     let signer1 = InMemorySigner::test_signer(&"test1".parse().unwrap());
     let tx1 = SignedTransaction::stake(
@@ -181,7 +187,10 @@ fn test_dump_state_respect_select_account_ids() {
         signer1.public_key(),
         genesis_hash,
     );
-    assert_eq!(env.clients[0].process_tx(tx1, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(
+        env.tx_request_handlers[0].process_tx(tx1, false, false),
+        ProcessTxResponse::ValidTx
+    );
 
     safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1);
 
@@ -240,7 +249,7 @@ fn test_dump_state_preserve_validators_in_memory() {
         signer.public_key(),
         genesis_hash,
     );
-    assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(env.tx_request_handlers[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
 
     safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1);
 
@@ -288,7 +297,7 @@ fn test_dump_state_return_locked() {
         signer.public_key(),
         genesis_hash,
     );
-    assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(env.tx_request_handlers[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
     for i in 1..=epoch_length + 1 {
         env.produce_block(0, i);
     }
@@ -410,7 +419,7 @@ fn test_dump_state_not_track_shard() {
         1,
         genesis_hash,
     );
-    assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(env.tx_request_handlers[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
 
     let mut blocks = vec![];
     for i in 1..epoch_length {
@@ -493,7 +502,7 @@ fn test_dump_state_with_delayed_receipt() {
         signer.public_key(),
         genesis_hash,
     );
-    assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(env.tx_request_handlers[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
 
     safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1);
 
@@ -560,7 +569,7 @@ fn test_dump_state_respect_select_whitelist_validators() {
         signer.public_key(),
         genesis_hash,
     );
-    assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(env.tx_request_handlers[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
 
     safe_produce_blocks(&mut env, 1, epoch_length * 2 + 1);
 

--- a/integration-tests/src/utils/process_blocks.rs
+++ b/integration-tests/src/utils/process_blocks.rs
@@ -75,7 +75,7 @@ pub fn create_account(
         *block.hash(),
     );
     let tx_hash = tx.get_hash();
-    assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(env.tx_request_handlers[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
     produce_blocks_from_height_with_protocol_version(env, epoch_length, height, protocol_version);
     tx_hash
 }
@@ -100,7 +100,7 @@ pub fn deploy_test_contract_with_protocol_version(
         *block.hash(),
         0,
     );
-    assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(env.tx_request_handlers[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
     produce_blocks_from_height_with_protocol_version(env, epoch_length, height, protocol_version)
 }
 
@@ -152,7 +152,7 @@ pub fn prepare_env_with_congestion(
         *genesis_block.hash(),
         0,
     );
-    assert_eq!(env.clients[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
+    assert_eq!(env.tx_request_handlers[0].process_tx(tx, false, false), ProcessTxResponse::ValidTx);
     for i in 1..3 {
         env.produce_block(0, i);
     }
@@ -189,7 +189,7 @@ pub fn prepare_env_with_congestion(
         );
         tx_hashes.push(signed_transaction.get_hash());
         assert_eq!(
-            env.clients[0].process_tx(signed_transaction, false, false),
+            env.tx_request_handlers[0].process_tx(signed_transaction, false, false),
             ProcessTxResponse::ValidTx
         );
     }

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -349,6 +349,7 @@ pub struct Config {
     /// which can cause extra load on the database. This option is not recommended for production use,
     /// as a large number of incoming witnesses could cause denial of service.
     pub save_latest_witnesses: bool,
+    pub transaction_request_handler_threads: usize,
 }
 
 fn is_false(value: &bool) -> bool {
@@ -402,6 +403,7 @@ impl Default for Config {
             orphan_state_witness_max_size: default_orphan_state_witness_max_size(),
             max_loaded_contracts: 256,
             save_latest_witnesses: false,
+            transaction_request_handler_threads: 4,
         }
     }
 }
@@ -587,6 +589,7 @@ impl NearConfig {
                 orphan_state_witness_pool_size: config.orphan_state_witness_pool_size,
                 orphan_state_witness_max_size: config.orphan_state_witness_max_size,
                 save_latest_witnesses: config.save_latest_witnesses,
+                transaction_request_handler_threads: config.transaction_request_handler_threads,
             },
             #[cfg(feature = "tx_generator")]
             tx_generator: config.tx_generator,

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -28,8 +28,9 @@ use near_chunks::shards_manager_actor::start_shards_manager;
 use near_client::adapter::client_sender_for_network;
 use near_client::gc_actor::GCActor;
 use near_client::{
-    ClientActor, ConfigUpdater, PartialWitnessActor, StartClientResult, ViewClientActor,
-    ViewClientActorInner, start_client,
+    ClientActor, ConfigUpdater, PartialWitnessActor, StartClientResult, TxRequestHandlerActor,
+    TxRequestHandlerConfig, ViewClientActor, ViewClientActorInner, spawn_tx_request_handler_actor,
+    start_client,
 };
 use near_epoch_manager::EpochManager;
 use near_epoch_manager::EpochManagerAdapter;
@@ -214,6 +215,7 @@ fn get_split_store(config: &NearConfig, storage: &NodeStorage) -> anyhow::Result
 pub struct NearNode {
     pub client: Addr<ClientActor>,
     pub view_client: Addr<ViewClientActor>,
+    pub tx_processor: Addr<TxRequestHandlerActor>,
     #[cfg(feature = "tx_generator")]
     pub tx_generator: Addr<TxGeneratorActor>,
     pub arbiters: Vec<ArbiterHandle>,
@@ -342,7 +344,7 @@ pub fn start_with_config_and_synchronization(
         config.validator_signer.clone(),
         chain_genesis.clone(),
         view_epoch_manager.clone(),
-        view_shard_tracker,
+        view_shard_tracker.clone(),
         view_runtime.clone(),
         network_adapter.as_multi_sender(),
         config.client_config.clone(),
@@ -397,28 +399,29 @@ pub fn start_with_config_and_synchronization(
         Arc::new(tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap());
 
     let state_sync_spawner = Arc::new(TokioRuntimeFutureSpawner(state_sync_runtime.clone()));
-    let StartClientResult { client_actor, client_arbiter_handle, resharding_handle } = start_client(
-        Clock::real(),
-        config.client_config.clone(),
-        chain_genesis.clone(),
-        epoch_manager.clone(),
-        shard_tracker.clone(),
-        runtime.clone(),
-        node_id,
-        state_sync_spawner.clone(),
-        network_adapter.as_multi_sender(),
-        shards_manager_adapter.as_sender(),
-        config.validator_signer.clone(),
-        telemetry.with_auto_span_context().into_sender(),
-        Some(snapshot_callbacks),
-        shutdown_signal,
-        adv,
-        config_updater,
-        partial_witness_actor.clone().with_auto_span_context().into_multi_sender(),
-        true,
-        None,
-        resharding_sender.into_multi_sender(),
-    );
+    let StartClientResult { client_actor, client_arbiter_handle, resharding_handle, tx_pool } =
+        start_client(
+            Clock::real(),
+            config.client_config.clone(),
+            chain_genesis.clone(),
+            epoch_manager.clone(),
+            shard_tracker.clone(),
+            runtime.clone(),
+            node_id,
+            state_sync_spawner.clone(),
+            network_adapter.as_multi_sender(),
+            shards_manager_adapter.as_sender(),
+            config.validator_signer.clone(),
+            telemetry.with_auto_span_context().into_sender(),
+            Some(snapshot_callbacks),
+            shutdown_signal,
+            adv,
+            config_updater,
+            partial_witness_actor.clone().with_auto_span_context().into_multi_sender(),
+            true,
+            None,
+            resharding_sender.into_multi_sender(),
+        );
     client_adapter_for_shards_manager.bind(client_actor.clone().with_auto_span_context());
     client_adapter_for_partial_witness_actor.bind(client_actor.clone().with_auto_span_context());
     let (shards_manager_actor, shards_manager_arbiter_handle) = start_shards_manager(
@@ -432,6 +435,22 @@ pub fn start_with_config_and_synchronization(
         config.client_config.chunk_request_retry_period,
     );
     shards_manager_adapter.bind(shards_manager_actor.with_auto_span_context());
+
+    let tx_processor_config = TxRequestHandlerConfig {
+        handler_threads: config.client_config.transaction_request_handler_threads,
+        tx_routing_height_horizon: config.client_config.tx_routing_height_horizon,
+        epoch_length: config.client_config.epoch_length,
+        transaction_validity_period: config.genesis.config.transaction_validity_period,
+    };
+    let tx_processor = spawn_tx_request_handler_actor(
+        tx_processor_config,
+        tx_pool,
+        view_epoch_manager.clone(),
+        view_shard_tracker,
+        config.validator_signer.clone(),
+        view_runtime.clone(),
+        network_adapter.as_multi_sender(),
+    );
 
     let mut state_sync_dumper = StateSyncDumper {
         clock: Clock::real(),
@@ -454,7 +473,11 @@ pub fn start_with_config_and_synchronization(
         time::Clock::real(),
         storage.into_inner(near_store::Temperature::Hot),
         config.network_config,
-        client_sender_for_network(client_actor.clone(), view_client_addr.clone()),
+        client_sender_for_network(
+            client_actor.clone(),
+            view_client_addr.clone(),
+            tx_processor.clone(),
+        ),
         network_adapter.as_multi_sender(),
         shards_manager_adapter.as_sender(),
         partial_witness_actor.with_auto_span_context().into_multi_sender(),
@@ -475,6 +498,7 @@ pub fn start_with_config_and_synchronization(
             config.genesis.config.clone(),
             client_actor.clone().with_auto_span_context().into_multi_sender(),
             view_client_addr.clone().with_auto_span_context().into_multi_sender(),
+            tx_processor.clone().with_auto_span_context().into_multi_sender(),
             network_actor.into_multi_sender(),
             #[cfg(feature = "test_features")]
             _gc_actor.with_auto_span_context().into_multi_sender(),
@@ -492,6 +516,7 @@ pub fn start_with_config_and_synchronization(
                 genesis_block.header().hash(),
                 client_actor.clone(),
                 view_client_addr.clone(),
+                tx_processor.clone(),
             ),
         ));
     }
@@ -515,13 +540,14 @@ pub fn start_with_config_and_synchronization(
     #[cfg(feature = "tx_generator")]
     let tx_generator = near_transactions_generator::actix_actor::start_tx_generator(
         config.tx_generator.unwrap_or_default(),
-        client_actor.clone().with_auto_span_context().into_multi_sender(),
+        tx_processor.clone().with_auto_span_context().into_multi_sender(),
         view_client_addr.clone().with_auto_span_context().into_multi_sender(),
     );
 
     Ok(NearNode {
         client: client_actor,
         view_client: view_client_addr,
+        tx_processor,
         #[cfg(feature = "tx_generator")]
         tx_generator,
         rpc_servers,

--- a/test-loop-tests/src/setup/state.rs
+++ b/test-loop-tests/src/setup/state.rs
@@ -8,7 +8,7 @@ use near_async::time::Duration;
 use near_chain_configs::{ClientConfig, Genesis};
 use near_chunks::shards_manager_actor::ShardsManagerActor;
 use near_client::client_actor::ClientActorInner;
-use near_client::{PartialWitnessActor, ViewClientActorInner};
+use near_client::{PartialWitnessActor, TxRequestHandler, ViewClientActorInner};
 use near_jsonrpc::ViewClientSenderForRpc;
 use near_network::shards_manager::ShardsManagerRequestFromNetwork;
 use near_network::state_witness::PartialWitnessSenderForNetwork;
@@ -25,7 +25,7 @@ use tempfile::TempDir;
 
 use crate::utils::peer_manager_actor::{
     ClientSenderForTestLoopNetwork, TestLoopNetworkSharedState, TestLoopPeerManagerActor,
-    ViewClientSenderForTestLoopNetwork,
+    TxRequestHandleSenderForTestLoopNetwork, ViewClientSenderForTestLoopNetwork,
 };
 
 use super::drop_condition::{DropCondition, TestLoopChunksStorage};
@@ -72,6 +72,7 @@ pub struct NodeExecutionData {
     pub peer_id: PeerId,
     pub client_sender: TestLoopSender<ClientActorInner>,
     pub view_client_sender: TestLoopSender<ViewClientActorInner>,
+    pub tx_processor_sender: TestLoopSender<TxRequestHandler>,
     pub shards_manager_sender: TestLoopSender<ShardsManagerActor>,
     pub partial_witness_sender: TestLoopSender<PartialWitnessActor>,
     pub peer_manager_sender: TestLoopSender<TestLoopPeerManagerActor>,
@@ -141,5 +142,11 @@ impl From<&NodeExecutionData> for PartialWitnessSenderForNetwork {
 impl From<&NodeExecutionData> for Sender<ShardsManagerRequestFromNetwork> {
     fn from(data: &NodeExecutionData) -> Sender<ShardsManagerRequestFromNetwork> {
         data.shards_manager_sender.clone().with_delay(NETWORK_DELAY).into_sender()
+    }
+}
+
+impl From<&NodeExecutionData> for TxRequestHandleSenderForTestLoopNetwork {
+    fn from(data: &NodeExecutionData) -> TxRequestHandleSenderForTestLoopNetwork {
+        data.tx_processor_sender.clone().with_delay(NETWORK_DELAY).into_multi_sender()
     }
 }

--- a/test-loop-tests/src/tests/bandwidth_scheduler.rs
+++ b/test-loop-tests/src/tests/bandwidth_scheduler.rs
@@ -25,8 +25,7 @@ use near_async::test_loop::sender::TestLoopSender;
 use near_async::time::Duration;
 use near_chain::{ChainStoreAccess, ReceiptFilter, get_incoming_receipts_for_shard};
 use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
-use near_client::Client;
-use near_client::client_actor::ClientActorInner;
+use near_client::{Client, TxRequestHandler};
 use near_crypto::Signer;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::account::{AccessKey, AccessKeyPermission};
@@ -183,7 +182,7 @@ fn run_bandwidth_scheduler_test(scenario: TestScenario, tx_concurrency: usize) -
     );
 
     let client_handle = node_datas[0].client_sender.actor_handle();
-    let client_sender = node_datas[0].client_sender.clone();
+    let tx_processor_sender = node_datas[0].tx_processor_sender.clone();
     let future_spawner = test_loop.future_spawner("WorkloadGenerator");
 
     // Run the workload for a number of blocks and verify that the bandwidth requests are generated correctly.
@@ -210,7 +209,7 @@ fn run_bandwidth_scheduler_test(scenario: TestScenario, tx_concurrency: usize) -
         }
 
         // Run the transactions which generate cross-shard receipts.
-        workload_generator.run(&client_sender, client, &future_spawner);
+        workload_generator.run(&tx_processor_sender, client, &future_spawner);
 
         false
     };
@@ -616,7 +615,7 @@ impl WorkloadGenerator {
 
     pub fn run(
         &mut self,
-        client_sender: &TestLoopSender<ClientActorInner>,
+        client_sender: &TestLoopSender<TxRequestHandler>,
         client: &Client,
         future_spawner: &TestLoopFutureSpawner,
     ) {
@@ -667,7 +666,7 @@ impl WorkloadSender {
 
     pub fn run(
         &mut self,
-        client_sender: &TestLoopSender<ClientActorInner>,
+        client_sender: &TestLoopSender<TxRequestHandler>,
         client: &Client,
         future_spawner: &TestLoopFutureSpawner,
         rng: &mut ChaCha20Rng,
@@ -688,7 +687,7 @@ impl WorkloadSender {
 
     pub fn start_new_transaction(
         &mut self,
-        client_sender: &TestLoopSender<ClientActorInner>,
+        client_sender: &TestLoopSender<TxRequestHandler>,
         client: &Client,
         future_spawner: &TestLoopFutureSpawner,
         rng: &mut ChaCha20Rng,

--- a/test-loop-tests/src/tests/fix_min_stake_ratio.rs
+++ b/test-loop-tests/src/tests/fix_min_stake_ratio.rs
@@ -92,7 +92,7 @@ fn slow_test_fix_min_stake_ratio() {
         .build()
         .warmup();
 
-    let client_sender = node_datas[0].client_sender.clone();
+    let tx_processor_sender = node_datas[0].tx_processor_sender.clone();
     let client_handle = node_datas[0].client_sender.actor_handle();
     let initial_validators = get_epoch_all_validators(&test_loop.data.get(&client_handle).client);
     assert_eq!(initial_validators.len(), 2);
@@ -117,7 +117,7 @@ fn slow_test_fix_min_stake_ratio() {
                 near_primitives::test_utils::create_test_signer(accounts[2].as_str()).public_key(),
                 prev_block_hash,
             );
-            let future = client_sender.send_async(ProcessTxRequest {
+            let future = tx_processor_sender.send_async(ProcessTxRequest {
                 transaction: tx,
                 is_forwarded: false,
                 check_only: false,

--- a/test-loop-tests/src/tests/malicious_chunk_producer.rs
+++ b/test-loop-tests/src/tests/malicious_chunk_producer.rs
@@ -79,7 +79,7 @@ fn test_producer_with_expired_transactions() {
             );
             let process_tx_request =
                 ProcessTxRequest { transaction: tx, is_forwarded: false, check_only: false };
-            chunk_producer.client_sender.send(process_tx_request);
+            chunk_producer.tx_processor_sender.send(process_tx_request);
         });
     }
 

--- a/test-loop-tests/src/tests/state_sync.rs
+++ b/test-loop-tests/src/tests/state_sync.rs
@@ -236,7 +236,7 @@ fn send_txs_between_shards(
         *nonce += 1;
 
         let future = get_wrapped(node_datas, client_idx)
-            .client_sender
+            .tx_processor_sender
             .clone()
             //.with_delay(Duration::milliseconds(300 * txs_sent as i64))
             .send_async(ProcessTxRequest {

--- a/test-utils/runtime-tester/src/run_test.rs
+++ b/test-utils/runtime-tester/src/run_test.rs
@@ -95,7 +95,7 @@ impl Scenario {
                 if !self.is_fuzzing {
                     // fuzzing can generate invalid transactions
                     assert_eq!(
-                        env.clients[0].process_tx(signed_tx, false, false),
+                        env.tx_request_handlers[0].process_tx(signed_tx, false, false),
                         ProcessTxResponse::ValidTx
                     );
                 }

--- a/tools/chainsync-loadtest/src/network.rs
+++ b/tools/chainsync-loadtest/src/network.rs
@@ -231,11 +231,11 @@ impl Network {
         ClientSenderForNetwork {
             tx_status_request: Sender::from_async_fn(|_| None),
             tx_status_response: noop().into_sender(),
+            transaction: noop().into_sender(),
             state_request_header: Sender::from_async_fn(|_| None),
             state_request_part: Sender::from_async_fn(|_| None),
             state_response: noop().into_sender(),
             block_approval: noop().into_sender(),
-            transaction: noop().into_sender(),
             block_request: Sender::from_async_fn(|_| None),
             block_headers_request: Sender::from_async_fn(|_| None),
             block: Sender::from_async_fn(move |block: BlockResponse| {


### PR DESCRIPTION
# Why
Extracts the transaction processing responsibility from the `Client`. 
Reduces (but does not eliminate, but enables further work to completely decouple) CPU contention between chunk production and handling the transactions ingress.
Removes the `Client` ingress bottleneck at ~5k TPS.

# How
- moved `process_tx` - related functionality from the `Client` to `TxRequestHandler`
   + put a mutex on the transaction pool
- run the `TxProcessor` on several threads (configurable, default is 4, that's roughly enough to reach 20K TPS ingress) 
- connect the `JsonRpc` and `PeerNetwork` to it for the TxRequest processing
- fix all the tests expecting `process_tx` as a part of `Client` () (the bulk of PR)

# Benchmarks
Attempts to inject 20 KTPS native token transactions with 1000 accounts
```
cd benchmarks/transactions-generator
just do-it 20000
```

## master
[perf](https://profiler.firefox.com/from-file/calltree/?globalTrackOrder=0&hiddenLocalTracksByPid=843881-3w58wxh&profileName=neard-master&thread=0&timelineType=category&v=10)
```
# neard.log
2025-03-12T10:17:57.175042Z  INFO transaction-generator: total="Stats { pool_accepted: 867269, pool_rejected: 339759, processed: 623285, failed: 0 }"
2025-03-12T10:17:57.175049Z  INFO transaction-generator: diff="Stats { pool_accepted: 6218, pool_rejected: 3520, processed: 5931, failed: 0 }" rate_processed=4329
```
## txpool-mt-take2
[perf](https://profiler.firefox.com/from-file/calltree/?globalTrackOrder=0&hiddenLocalTracksByPid=851845-9acwxl&profileName=neard-tx-processor&thread=0&timelineType=category&v=10)
```
# neard.log
2025-03-12T10:36:08.495660Z  INFO transaction-generator: total="Stats { pool_accepted: 1110529, pool_rejected: 291835, processed: 860184, failed: 0 }"
2025-03-12T10:36:08.495667Z  INFO transaction-generator: diff="Stats { pool_accepted: 9609, pool_rejected: 3593, processed: 7934, failed: 0 }" rate_processed=6771
```
