### PR TITLE
refactor: stop using mock epoch manager in block_sync tests.

### DIFF
--- a/integration-tests/src/env/test_env.rs
+++ b/integration-tests/src/env/test_env.rs
@@ -8,7 +8,7 @@ use near_chain::stateless_validation::processing_tracker::{
 use near_chain::test_utils::ValidatorSchedule;
 use near_chain::types::Tip;
 use near_chain::{ChainGenesis, ChainStoreAccess, Provenance};
-use near_chain_configs::GenesisConfig;
+use near_chain_configs::{Genesis, GenesisConfig};
 use near_chunks::client::ShardsManagerResponse;
 use near_chunks::test_utils::{MockClientAdapterForShardsManager, SynchronousShardsManagerAdapter};
 use near_client::{Client, DistributeStateWitnessRequest};
@@ -88,6 +88,10 @@ impl TestEnv {
 
     pub fn builder(genesis_config: &GenesisConfig) -> TestEnvBuilder {
         TestEnvBuilder::new(genesis_config.clone())
+    }
+
+    pub fn builder_from_genesis(genesis: &Genesis) -> TestEnvBuilder {
+        TestEnvBuilder::from_genesis(genesis.clone())
     }
 
     /// Process a given block in the client with index `id`.

--- a/integration-tests/src/env/test_env_builder.rs
+++ b/integration-tests/src/env/test_env_builder.rs
@@ -226,26 +226,19 @@ impl TestEnvBuilder {
 
     /// Internal impl to make sure the stores are initialized.
     fn ensure_stores(self) -> Self {
-        if self.stores.is_some() {
-            if let Some(genesis) = &self.genesis {
-                for store in self.stores.as_ref().unwrap() {
-                    initialize_genesis_state(store.clone(), &genesis, None);
-                }
-            }
+        let ret = if self.stores.is_some() {
             self
         } else {
             let num_clients = self.clients.len();
-            let stores = (0..num_clients)
-                .map(|_| {
-                    let store = create_test_store();
-                    if let Some(genesis) = &self.genesis {
-                        initialize_genesis_state(store.clone(), &genesis, None);
-                    }
-                    store
-                })
-                .collect();
-            self.stores(stores)
+            self.stores((0..num_clients).map(|_| create_test_store()).collect())
+        };
+
+        if let Some(genesis) = &ret.genesis {
+            for store in ret.stores.as_ref().unwrap() {
+                initialize_genesis_state(store.clone(), &genesis, None);
+            }
         }
+        ret
     }
 
     fn ensure_contract_caches(self) -> Self {

--- a/integration-tests/src/tests/client/block_sync.rs
+++ b/integration-tests/src/tests/client/block_sync.rs
@@ -16,8 +16,6 @@ use near_o11y::testonly::TracingCapture;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
 use near_primitives::utils::MaybeValidated;
-use near_store::genesis::initialize_genesis_state;
-use near_store::test_utils::create_test_store;
 
 use crate::env::test_env::TestEnv;
 
@@ -67,19 +65,7 @@ fn test_env_with_epoch_length(epoch_length: u64) -> TestEnv {
     let mut genesis = Genesis::test(vec!["test0".parse().unwrap(), "test1".parse().unwrap()], 1);
     genesis.config.epoch_length = epoch_length;
 
-    TestEnv::builder(&genesis.config)
-        .clients_count(2)
-        .stores(
-            std::iter::repeat(())
-                .take(2)
-                .map(|_| {
-                    let store = create_test_store();
-                    initialize_genesis_state(store.clone(), &genesis, None);
-                    store
-                })
-                .collect(),
-        )
-        .build()
+    TestEnv::builder_from_genesis(&genesis).clients_count(2).build()
 }
 
 #[test]


### PR DESCRIPTION
The eventual goal is to try to get rid of mock epoch manager.

Part of https://github.com/near/nearcore/issues/10634