### PR TITLE
nit: use semicolon in do_update_config 

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -581,7 +581,7 @@ class NeardRunner:
             with open(self.target_near_home_path('config.json'), 'r') as f:
                 config = json.load(f)
 
-            for kv in key_value.split(','):
+            for kv in key_value.split(';'):
                 [key, value] = kv.split("=", 1)
                 key_item_list = key.split(".")
 


### PR DESCRIPTION
I realised that `,` doesn't work if we ever want to set value to a list, say, `[0, 1]`. Sorry. `;` shouldn't have collisions.