### PR TITLE
rewrite cache put to not use tempfile

### DIFF
--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -26,6 +26,8 @@ memoffset = { workspace = true, optional = true }
 num-rational.workspace = true
 parity-wasm = { workspace = true, optional = true }
 prefix-sum-vec = { workspace = true, optional = true }
+prometheus = { workspace = true, optional = true }
+rand.workspace = true
 rayon.workspace = true
 ripemd.workspace = true
 rustix = { workspace = true, features = ["fs"] }
@@ -38,7 +40,6 @@ strum.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-prometheus = { workspace = true, optional = true }
 wasm-encoder = { workspace = true, optional = true }
 wasmparser = { workspace = true, optional = true }
 wasmtime = { workspace = true, features = ["runtime"], optional = true }
@@ -85,7 +86,6 @@ cov-mark.workspace = true
 expect-test.workspace = true
 hex.workspace = true
 near-test-contracts.workspace = true
-rand.workspace = true
 serde_json = { workspace = true, features = ["preserve_order"] }
 wasmprinter.workspace = true
 wasm-smith.workspace = true


### PR DESCRIPTION
use of tempfile was a stretch anyway and only really used for generating random file names. Well, now that a new release of tempfile has broken this use-case we'll have to implement this logic ourselves.