### PR TITLE
Fix minor errors and improve consistency in documentation and script

### DIFF
--- a/docs/practices/style.md
+++ b/docs/practices/style.md
@@ -17,7 +17,7 @@ into this document.
 
 ## Formatting
 
-Use `rustfmt` for minor code formatting decisions. This rule is enforced by CI
+Use `rustfmt` for minor code formatting decisions. This rule is enforced by CI.
 
 **Rationale:** `rustfmt` style is almost always good enough, even if not always
 perfect. The amount of bike shedding saved by `rustfmt` far outweighs any
@@ -32,7 +32,7 @@ considered idiomatic Rust, a good start are the
 (but keep in mind that `nearcore` is not a library with public API, not all
 advice applies literally).
 
-When in doubt, ask question in the [Rust
+When in doubt, ask a question in the [Rust
 🦀](https://near.zulipchat.com/#narrow/stream/300659-Rust-.F0.9F.A6.80) Zulip
 stream or during code review.
 

--- a/scripts/nayduck.py
+++ b/scripts/nayduck.py
@@ -48,8 +48,8 @@ def _parse_args():
     parser.add_argument(
         "--sha",
         "-s",
-        help=
-        "Commit sha to test. By default gets current one. This is ignored if branch name is provided",
+        help="Commit SHA to test. By default, it gets the current one. This is ignored if a branch name is provided.",
+
     )
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
@@ -260,7 +260,7 @@ def run_locally(args, tests):
         del fields[1:index]
         message = f'Running ‘{"".join(fields)}’'
         if ignored:
-            message = f'{message} (ignoring flags ‘{" ".join(ignored)}`)'
+            message = f'{message} (ignoring flags: {" ".join(ignored)})'
         if not args.dry_run:
             print(message)
 
@@ -284,7 +284,7 @@ def run_locally(args, tests):
             cmd = fields
             cwd = REPO_DIR / "pytest"
         else:
-            print(f"Unrecognized test category ‘{fields[0]}’", file=sys.stderr)
+            print(f"Unrecognized test category '{fields[0]}'", file=sys.stderr)
             continue
         if args.dry_run:
             print("( cd {} && {} )".format(


### PR DESCRIPTION
1. docs/practices/style.md:
  - Fixed a grammatical issue in a sentence: *"ask question"* → *"ask a question"*
  - Added a missing period to a sentence for consistency.
  
2. scripts/nayduck.py:
  - Corrected inconsistent capitalization: *"sha"* → *"SHA"*
  - Fixed incorrect use of curly quotes in formatted strings.
  - Improved clarity in error messages.
