### PR TITLE
[testloop] Add support to add new node

### DIFF
--- a/test-loop-tests/src/setup/builder.rs
+++ b/test-loop-tests/src/setup/builder.rs
@@ -1,6 +1,7 @@
 use itertools::Itertools;
 use near_chain_configs::test_genesis::TestGenesisBuilder;
 use std::collections::HashSet;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tempfile::TempDir;
@@ -58,7 +59,7 @@ pub(crate) struct TestLoopBuilder {
     /// Overrides the directory used for test loop shared data; rather than
     /// constructing fresh new tempdir, use the provided one (to test with
     /// existing data from a previous test loop run).
-    test_loop_data_dir: Option<TempDir>,
+    test_loop_data_dir: TempDir,
     /// Accounts whose clients should be configured as an archival node.
     /// This should be a subset of the accounts in the `clients` list.
     archival_clients: HashSet<AccountId>,
@@ -86,7 +87,7 @@ impl TestLoopBuilder {
             epoch_config_store: None,
             clients: vec![],
             stores_override: None,
-            test_loop_data_dir: None,
+            test_loop_data_dir: tempfile::tempdir().unwrap(),
             archival_clients: HashSet::new(),
             gc_num_epochs_to_keep: None,
             runtime_config_store: None,
@@ -187,7 +188,7 @@ impl TestLoopBuilder {
     /// Overrides the tempdir (which contains state dump, etc.) instead
     /// of creating a new one.
     pub fn test_loop_data_dir(mut self, dir: TempDir) -> Self {
-        self.test_loop_data_dir = Some(dir);
+        self.test_loop_data_dir = dir;
         self
     }
 
@@ -196,13 +197,21 @@ impl TestLoopBuilder {
         self
     }
 
+    /// Builder for creating a new node state from some of the parameters we have supplied
+    /// to the test loop builder.
+    /// This includes things like genesis, tempdir, couple of client configs, etc.
+    pub(crate) fn new_node_state_builder(&self) -> NodeStateBuilder {
+        NodeStateBuilder::new(
+            self.genesis.as_ref().expect("Genesis must be provided").clone(),
+            self.test_loop_data_dir.path().to_path_buf(),
+            self.gc_num_epochs_to_keep,
+            self.track_all_shards,
+        )
+    }
+
     /// Build the test loop environment.
     pub(crate) fn build(self) -> TestLoopEnv {
-        self.ensure_genesis()
-            .ensure_epoch_config_store()
-            .ensure_clients()
-            .ensure_tempdir()
-            .build_impl()
+        self.ensure_genesis().ensure_epoch_config_store().ensure_clients().build_impl()
     }
 
     fn ensure_genesis(self) -> Self {
@@ -221,11 +230,6 @@ impl TestLoopBuilder {
             self.archival_clients.is_subset(&HashSet::from_iter(self.clients.iter().cloned())),
             "Archival accounts must be subset of the clients"
         );
-        self
-    }
-
-    fn ensure_tempdir(mut self) -> Self {
-        self.test_loop_data_dir.get_or_insert_with(|| tempfile::tempdir().unwrap());
         self
     }
 
@@ -255,7 +259,7 @@ impl TestLoopBuilder {
     fn setup_shared_state(self) -> (TestLoopV2, SharedState) {
         let shared_state = SharedState {
             genesis: self.genesis.unwrap(),
-            tempdir: self.test_loop_data_dir.unwrap(),
+            tempdir: self.test_loop_data_dir,
             epoch_config_store: self.epoch_config_store.unwrap(),
             runtime_config_store: self.runtime_config_store,
             network_shared_state: TestLoopNetworkSharedState::new(),
@@ -270,19 +274,80 @@ impl TestLoopBuilder {
 
     fn setup_node_state(&mut self, idx: usize) -> NodeState {
         let account_id = self.clients[idx].clone();
-        let client_config = self.setup_client_config(idx);
-        let (store, split_store) = self.setup_store(idx);
-        NodeState { account_id, client_config, store, split_store }
+        let is_archival = self.archival_clients.contains(&account_id);
+        let store_override = self.stores_override.as_ref().map(|stores| stores[idx].clone());
+        let config_modifier = |client_config: &mut ClientConfig| {
+            if let Some(config_modifier) = &self.config_modifier {
+                config_modifier(client_config, idx);
+            }
+        };
+        let node_state_builder = self.new_node_state_builder();
+        node_state_builder
+            .account_id(account_id)
+            .archive(is_archival)
+            .config_modifier(config_modifier)
+            .store_override(store_override)
+            .build()
+    }
+}
+
+pub struct NodeStateBuilder<'a> {
+    genesis: Genesis,
+    tempdir_path: PathBuf,
+    gc_num_epochs_to_keep: Option<u64>,
+    track_all_shards: bool,
+
+    account_id: Option<AccountId>,
+    archive: bool,
+    config_modifier: Option<Box<dyn Fn(&mut ClientConfig) + 'a>>,
+    store_override: Option<(Store, Option<Store>)>,
+}
+
+impl<'a> NodeStateBuilder<'a> {
+    fn new(
+        genesis: Genesis,
+        tempdir_path: PathBuf,
+        gc_num_epochs_to_keep: Option<u64>,
+        track_all_shards: bool,
+    ) -> Self {
+        Self {
+            genesis,
+            tempdir_path,
+            gc_num_epochs_to_keep,
+            track_all_shards,
+            account_id: None,
+            archive: false,
+            config_modifier: None,
+            store_override: None,
+        }
     }
 
-    fn setup_client_config(&mut self, idx: usize) -> ClientConfig {
-        let account_id = &self.clients[idx];
-        let is_archival = self.archival_clients.contains(account_id);
+    pub fn account_id(mut self, account_id: AccountId) -> Self {
+        self.account_id = Some(account_id);
+        self
+    }
 
-        let genesis = self.genesis.as_ref().unwrap();
-        let tempdir = self.test_loop_data_dir.as_ref().unwrap();
-        let mut client_config = ClientConfig::test(true, 600, 2000, 4, is_archival, true, false);
-        client_config.epoch_length = genesis.config.epoch_length;
+    pub fn archive(mut self, archive: bool) -> Self {
+        self.archive = archive;
+        self
+    }
+
+    pub fn config_modifier(mut self, modifier: impl Fn(&mut ClientConfig) + 'a) -> Self {
+        self.config_modifier = Some(Box::new(modifier));
+        self
+    }
+
+    fn store_override(mut self, stores: Option<(Store, Option<Store>)>) -> Self {
+        self.store_override = stores;
+        self
+    }
+
+    pub fn build(self) -> NodeState {
+        let (store, split_store) = self.setup_store();
+        let account_id = self.account_id.unwrap();
+
+        let mut client_config = ClientConfig::test(true, 600, 2000, 4, self.archive, true, false);
+        client_config.epoch_length = self.genesis.config.epoch_length;
         client_config.max_block_wait_delay = Duration::seconds(6);
         client_config.state_sync_enabled = true;
         client_config.state_sync_external_timeout = Duration::milliseconds(100);
@@ -293,7 +358,7 @@ impl TestLoopBuilder {
             client_config.gc.gc_num_epochs_to_keep = num_epochs;
         }
         let external_storage_location =
-            ExternalStorageLocation::Filesystem { root_dir: tempdir.path().join("state_sync") };
+            ExternalStorageLocation::Filesystem { root_dir: self.tempdir_path.join("state_sync") };
         client_config.state_sync = StateSyncConfig {
             dump: Some(DumpConfig {
                 iteration_delay: Some(Duration::seconds(1)),
@@ -317,35 +382,31 @@ impl TestLoopBuilder {
         // * single shard tracking for validators
         // * all shard tracking for non-validators (RPCs and archival)
         let is_validator =
-            genesis.config.validators.iter().any(|validator| validator.account_id == *account_id);
+            self.genesis.config.validators.iter().any(|v| v.account_id == account_id);
         if is_validator && !self.track_all_shards {
             client_config.tracked_shards = Vec::new();
         } else {
             client_config.tracked_shards = vec![ShardId::new(666)];
         }
 
-        if let Some(config_modifier) = &self.config_modifier {
-            config_modifier(&mut client_config, idx);
+        if let Some(config_modifier) = self.config_modifier {
+            config_modifier(&mut client_config);
         }
 
-        client_config
+        NodeState { account_id, client_config, store, split_store }
     }
 
-    fn setup_store(&mut self, idx: usize) -> (Store, Option<Store>) {
-        let account_id = &self.clients[idx];
-        let is_archival = self.archival_clients.contains(account_id);
-
-        let (store, split_store) = if let Some(stores_override) = &self.stores_override {
-            stores_override[idx].clone()
-        } else if is_archival {
+    fn setup_store(&self) -> (Store, Option<Store>) {
+        let (store, split_store) = if let Some(stores_override) = &self.store_override {
+            stores_override.clone()
+        } else if self.archive {
             let (hot_store, split_store) = create_test_split_store();
             (hot_store, Some(split_store))
         } else {
             (create_test_store(), None)
         };
 
-        let genesis = self.genesis.as_ref().unwrap();
-        initialize_genesis_state(store.clone(), genesis, None);
+        initialize_genesis_state(store.clone(), &self.genesis, None);
         (store, split_store)
     }
 }

--- a/test-loop-tests/src/setup/env.rs
+++ b/test-loop-tests/src/setup/env.rs
@@ -143,6 +143,15 @@ impl TestLoopEnv {
         self.node_datas.push(node_data);
     }
 
+    /// Function to add a new node in test loop environment. This function takes in the identifier
+    /// and node_state of the new node as input.
+    ///
+    /// We set the NetworkInfo for this node which is required for state sync to work.
+    pub fn add_node(&mut self, identifier: &str, node_state: NodeState) {
+        // Logically this function is the same as restart_node
+        self.restart_node(identifier, node_state);
+    }
+
     /// Used to finish off remaining events that are still in the loop. This can be necessary if the
     /// destructor of some components wait for certain condition to become true. Otherwise, the
     /// destructors may end up waiting forever. This also helps avoid a panic when destructing

--- a/test-loop-tests/src/setup/env.rs
+++ b/test-loop-tests/src/setup/env.rs
@@ -130,14 +130,9 @@ impl TestLoopEnv {
         // Note: TestLoopEnv does not currently propagate the network info to other peers. This is because
         // the networking layer is completely mocked out. So in order to allow the new node to sync, we
         // need to manually propagate the network info to the new node.
-        let client_sender = node_data.client_sender.clone();
-        self.test_loop.send_adhoc_event("set_network_info".to_string(), move |_| {
-            // highest_height_peers is the only field that matters for sync.
-            client_sender.send(SetNetworkInfo(NetworkInfo {
-                highest_height_peers,
-                ..NetworkInfo::default()
-            }))
-        });
+        node_data
+            .client_sender
+            .send(SetNetworkInfo(NetworkInfo { highest_height_peers, ..NetworkInfo::default() }));
 
         // Finally push node_data into node_datas
         self.node_datas.push(node_data);


### PR DESCRIPTION
We need to add `NodeStateBuilder` as now we need the ability to build the node startup state (i.e. mainly client_config) outside of the test_loop_env build function.

See test-loop-tests/src/tests/restart_node.rs for example use.