### PR TITLE
refactor: reduce cloning when passing RuntimeConfig around

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3897,7 +3897,7 @@ fn get_genesis_congestion_info(
     // genesis and doesn't have this block in flat state and memtrie.
     let trie = runtime.get_view_trie_for_shard(shard_id, prev_hash, state_root)?;
     let runtime_config = runtime.get_runtime_config(protocol_version);
-    let congestion_info = bootstrap_congestion_info(&trie, &runtime_config, shard_id)?;
+    let congestion_info = bootstrap_congestion_info(&trie, runtime_config, shard_id)?;
     tracing::debug!(target: "chain", ?shard_id, ?state_root, ?congestion_info, "Computed genesis congestion info.");
     Ok(congestion_info)
 }

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -1183,9 +1183,8 @@ impl RuntimeAdapter for NightshadeRuntime {
         }
     }
 
-    fn get_runtime_config(&self, protocol_version: ProtocolVersion) -> RuntimeConfig {
-        let runtime_config = self.runtime_config_store.get_config(protocol_version);
-        runtime_config.as_ref().clone()
+    fn get_runtime_config(&self, protocol_version: ProtocolVersion) -> &RuntimeConfig {
+        self.runtime_config_store.get_config(protocol_version)
     }
 
     fn get_protocol_config(&self, epoch_id: &EpochId) -> Result<ProtocolConfig, Error> {

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -77,6 +77,7 @@ pub struct KeyValueRuntime {
     num_shards: NumShards,
     epoch_length: u64,
     no_gc: bool,
+    runtime_config: RuntimeConfig,
 
     // A mapping state_root => {account id => amounts}, for transactions and receipts
     state: RwLock<HashMap<StateRoot, KVState>>,
@@ -372,6 +373,7 @@ impl KeyValueRuntime {
             state: RwLock::new(state),
             state_size: RwLock::new(state_size),
             contract_cache: NoContractRuntimeCache,
+            runtime_config: RuntimeConfig::test(),
         })
     }
 
@@ -1380,8 +1382,8 @@ impl RuntimeAdapter for KeyValueRuntime {
         Err(Error::Other("get_protocol_config should not be used in KeyValueRuntime".into()))
     }
 
-    fn get_runtime_config(&self, _protocol_version: ProtocolVersion) -> RuntimeConfig {
-        RuntimeConfig::test()
+    fn get_runtime_config(&self, _protocol_version: ProtocolVersion) -> &RuntimeConfig {
+        &self.runtime_config
     }
 
     fn will_shard_layout_change_next_epoch(

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -542,7 +542,7 @@ pub trait RuntimeAdapter: Send + Sync {
 
     fn get_protocol_config(&self, epoch_id: &EpochId) -> Result<ProtocolConfig, Error>;
 
-    fn get_runtime_config(&self, protocol_version: ProtocolVersion) -> RuntimeConfig;
+    fn get_runtime_config(&self, protocol_version: ProtocolVersion) -> &RuntimeConfig;
 
     fn compiled_contract_cache(&self) -> &dyn ContractRuntimeCache;
 

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -222,7 +222,7 @@ impl TrieViewer {
             gas_limit: None,
             random_seed: root,
             current_protocol_version: view_state.current_protocol_version,
-            config: config.clone(),
+            config: Arc::clone(config),
             cache: view_state.cache,
             is_new_chunk: false,
             migration_data: Arc::new(MigrationData::default()),


### PR DESCRIPTION
We were cloning then passing around references.