### PR TITLE
refactor: remove mock epoch manager usage from process_blocks2.

### DIFF
--- a/integration-tests/src/env/test_env_builder.rs
+++ b/integration-tests/src/env/test_env_builder.rs
@@ -15,7 +15,7 @@ use near_parameters::RuntimeConfigStore;
 use near_primitives::epoch_info::RngSeed;
 use near_primitives::epoch_manager::{AllEpochConfigTestOverrides, EpochConfig, EpochConfigStore};
 use near_primitives::test_utils::create_test_signer;
-use near_primitives::types::{AccountId, NumShards, ShardIndex};
+use near_primitives::types::{AccountId, ShardIndex};
 use near_store::config::StateSnapshotType;
 use near_store::genesis::initialize_genesis_state;
 use near_store::test_utils::create_test_store;
@@ -61,7 +61,6 @@ pub struct TestEnvBuilder {
     shard_trackers: Option<Vec<ShardTracker>>,
     runtimes: Option<Vec<Arc<dyn RuntimeAdapter>>>,
     network_adapters: Option<Vec<Arc<MockPeerManagerAdapter>>>,
-    num_shards: Option<NumShards>,
     // random seed to be inject in each client according to AccountId
     // if not set, a default constant TEST_SEED will be injected
     seeds: HashMap<AccountId, RngSeed>,
@@ -94,7 +93,6 @@ impl TestEnvBuilder {
             shard_trackers: None,
             runtimes: None,
             network_adapters: None,
-            num_shards: None,
             seeds,
             archive: false,
             save_trie_changes: true,
@@ -259,10 +257,6 @@ impl TestEnvBuilder {
         assert_eq!(epoch_managers.len(), self.clients.len());
         assert!(self.epoch_managers.is_none(), "Cannot override twice");
         assert!(
-            self.num_shards.is_none(),
-            "Cannot set both num_shards and epoch_managers at the same time"
-        );
-        assert!(
             self.shard_trackers.is_none(),
             "Cannot override epoch_managers after shard_trackers"
         );
@@ -277,10 +271,6 @@ impl TestEnvBuilder {
         self,
         test_overrides: AllEpochConfigTestOverrides,
     ) -> Self {
-        assert!(
-            self.num_shards.is_none(),
-            "Cannot set both num_shards and epoch_managers at the same time"
-        );
         let ret = self.ensure_stores();
 
         // TODO(#11265): consider initializing epoch config separately as it
@@ -341,7 +331,7 @@ impl TestEnvBuilder {
         let mut ret = self.ensure_stores();
         let epoch_managers: Vec<EpochManagerKind> = (0..ret.clients.len())
             .map(|i| {
-                let vs = ValidatorSchedule::new_with_shards(ret.num_shards.unwrap_or(1))
+                let vs = ValidatorSchedule::new_with_shards(1)
                     .block_producers_per_epoch(vec![ret.validators.clone()]);
                 MockEpochManager::new_with_validators(
                     ret.stores.as_ref().unwrap()[i].clone(),
@@ -528,15 +518,6 @@ impl TestEnvBuilder {
             let num_clients = self.clients.len();
             self.network_adapters((0..num_clients).map(|_| Arc::new(Default::default())).collect())
         }
-    }
-
-    pub fn num_shards(mut self, num_shards: NumShards) -> Self {
-        assert!(
-            self.epoch_managers.is_none(),
-            "Cannot set both num_shards and epoch_managers at the same time"
-        );
-        self.num_shards = Some(num_shards);
-        self
     }
 
     pub fn archive(mut self, archive: bool) -> Self {

--- a/integration-tests/src/tests/client/process_blocks2.rs
+++ b/integration-tests/src/tests/client/process_blocks2.rs
@@ -258,7 +258,7 @@ fn test_bad_congestion_info_impl(mode: BadCongestionInfoMode) {
 
     let modified_chunk = ShardChunkHeader::V3(modified_chunk_header);
 
-    let shard_uid = ShardUId { shard_id: chunk.shard_id().into(), version: 0 };
+    let shard_uid = ShardUId { shard_id: chunk.shard_id().into(), version: 1 };
     let prev_block_hash = block.header().prev_hash();
     let client = &env.clients[0];
     let prev_chunk_extra = client.chain.get_chunk_extra(prev_block_hash, &shard_uid).unwrap();

--- a/integration-tests/src/tests/client/process_blocks2.rs
+++ b/integration-tests/src/tests/client/process_blocks2.rs
@@ -1,6 +1,7 @@
 use assert_matches::assert_matches;
 use near_chain::validate::validate_chunk_with_chunk_extra;
 use near_chain::{Provenance, test_utils};
+use near_chain_configs::Genesis;
 use near_crypto::vrf::Value;
 use near_crypto::{KeyType, PublicKey, Signature};
 use near_network::types::{NetworkRequests, PeerManagerMessageRequest};
@@ -18,13 +19,14 @@ use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_store::ShardUId;
 
 use crate::env::test_env::TestEnv;
+use crate::env::test_env_builder::TestEnvBuilder;
 
 /// Only process one block per height
 /// Test that if a node receives two blocks at the same height, it doesn't process the second one
 /// if the second block is not requested
 #[test]
 fn test_not_process_height_twice() {
-    let mut env = TestEnv::default_builder().mock_epoch_managers().build();
+    let mut env = TestEnv::default_builder_with_genesis().build();
     let block = env.clients[0].produce_block(1).unwrap().unwrap();
     // modify the block and resign it
     let mut duplicate_block = block.clone();
@@ -61,7 +63,10 @@ fn test_not_process_height_twice() {
 /// Test that if a block contains chunks with invalid shard_ids, the client will return error.
 #[test]
 fn test_bad_shard_id() {
-    let mut env = TestEnv::default_builder().num_shards(4).mock_epoch_managers().build();
+    let accounts = TestEnvBuilder::make_accounts(1);
+    let genesis = Genesis::test_sharded_new_version(accounts, 1, vec![1, 1, 1, 1]);
+    let mut env = TestEnv::builder_from_genesis(&genesis).build();
+
     let prev_block = env.clients[0].produce_block(1).unwrap().unwrap();
     env.process_block(0, prev_block, Provenance::PRODUCED);
     let mut block = env.clients[0].produce_block(2).unwrap().unwrap(); // modify the block and resign it
@@ -116,7 +121,10 @@ fn test_bad_shard_id() {
 /// Test that if a block's content (vrf_value) is corrupted, the invalid block will not affect the node's block processing
 #[test]
 fn test_bad_block_content_vrf() {
-    let mut env = TestEnv::default_builder().num_shards(4).mock_epoch_managers().build();
+    let accounts = TestEnvBuilder::make_accounts(1);
+    let genesis = Genesis::test_sharded_new_version(accounts, 1, vec![1, 1, 1, 1]);
+    let mut env = TestEnv::builder_from_genesis(&genesis).build();
+
     let prev_block = env.clients[0].produce_block(1).unwrap().unwrap();
     env.process_block(0, prev_block, Provenance::PRODUCED);
     let block = env.clients[0].produce_block(2).unwrap().unwrap();
@@ -142,7 +150,10 @@ fn test_bad_block_content_vrf() {
 /// Test that if a block's signature is corrupted, the invalid block will not affect the node's block processing
 #[test]
 fn test_bad_block_signature() {
-    let mut env = TestEnv::default_builder().num_shards(4).mock_epoch_managers().build();
+    let accounts = TestEnvBuilder::make_accounts(1);
+    let genesis = Genesis::test_sharded_new_version(accounts, 1, vec![1, 1, 1, 1]);
+    let mut env = TestEnv::builder_from_genesis(&genesis).build();
+
     let prev_block = env.clients[0].produce_block(1).unwrap().unwrap();
     env.process_block(0, prev_block, Provenance::PRODUCED);
     let block = env.clients[0].produce_block(2).unwrap().unwrap();
@@ -208,7 +219,10 @@ fn test_bad_congestion_info_impl(mode: BadCongestionInfoMode) {
         return;
     }
 
-    let mut env = TestEnv::default_builder().num_shards(4).mock_epoch_managers().build();
+    let accounts = TestEnvBuilder::make_accounts(1);
+    let genesis = Genesis::test_sharded_new_version(accounts, 1, vec![1, 1, 1, 1]);
+    let mut env = TestEnv::builder_from_genesis(&genesis).build();
+
     let prev_block = env.clients[0].produce_block(1).unwrap().unwrap();
     env.process_block(0, prev_block, Provenance::PRODUCED);
     let block = env.clients[0].produce_block(2).unwrap().unwrap();
@@ -244,7 +258,7 @@ fn test_bad_congestion_info_impl(mode: BadCongestionInfoMode) {
 
     let modified_chunk = ShardChunkHeader::V3(modified_chunk_header);
 
-    let shard_uid = ShardUId { shard_id: 0, version: 0 };
+    let shard_uid = ShardUId { shard_id: chunk.shard_id().into(), version: 0 };
     let prev_block_hash = block.header().prev_hash();
     let client = &env.clients[0];
     let prev_chunk_extra = client.chain.get_chunk_extra(prev_block_hash, &shard_uid).unwrap();
@@ -305,7 +319,10 @@ fn check_block_produced_from_optimistic_block(block: &Block, optimistic_block: &
 // Testing the production and application of optimistic blocks
 #[test]
 fn test_process_optimistic_block() {
-    let mut env = TestEnv::default_builder().num_shards(4).mock_epoch_managers().build();
+    let accounts = TestEnvBuilder::make_accounts(1);
+    let genesis = Genesis::test_sharded_new_version(accounts, 1, vec![1, 1, 1, 1]);
+    let mut env = TestEnv::builder_from_genesis(&genesis).build();
+
     let prev_block = env.clients[0].produce_block(1).unwrap().unwrap();
     env.process_block(0, prev_block, Provenance::PRODUCED);
     assert!(!env.clients[0].is_optimistic_block_done(2), "Optimistic block should not be ready");


### PR DESCRIPTION
Part of #10634

I have also removed num_shards from test env builder, since it's no longer used. (Note also that it's only usage is with mock epoch manager.)