### PR TITLE
[protocol] Introduce MIN_SUPPORTED_PROTOCOL_VERSION

### DIFF
--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -286,6 +286,9 @@ impl ProtocolFeature {
     }
 }
 
+/// Minimum supported protocol version
+pub const MIN_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = 29;
+
 /// Current protocol version used on the mainnet with all stable features.
 const STABLE_PROTOCOL_VERSION: ProtocolVersion = 77;
 

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -16,6 +16,7 @@ use crate::upgrade_schedule::ProtocolUpgradeVotingSchedule;
 /// near_primitives_core re-exports
 pub use near_primitives_core::checked_feature;
 pub use near_primitives_core::types::ProtocolVersion;
+pub use near_primitives_core::version::MIN_SUPPORTED_PROTOCOL_VERSION;
 pub use near_primitives_core::version::PEER_MIN_ALLOWED_PROTOCOL_VERSION;
 pub use near_primitives_core::version::PROTOCOL_VERSION;
 pub use near_primitives_core::version::ProtocolFeature;

--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -18,7 +18,7 @@ static NEARD_FEATURES: &str = env!("NEARD_FEATURES");
 
 static NEARD_VERSION_STRING: LazyLock<String> = LazyLock::new(|| {
     format!(
-        "(release {}) (build {}) (commit {}) (rustc {}) (protocol [{},{}]) (db {})\nfeatures: [{}]",
+        "(release {}) (build {}) (commit {}) (rustc {}) (min_protocol {}) (protocol {}) (db {})\nfeatures: [{}]",
         NEARD_VERSION,
         NEARD_BUILD,
         NEARD_COMMIT,

--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -2,7 +2,7 @@ mod cli;
 
 use self::cli::NeardCmd;
 use anyhow::Context;
-use near_primitives::version::{PROTOCOL_VERSION, Version};
+use near_primitives::version::{MIN_SUPPORTED_PROTOCOL_VERSION, PROTOCOL_VERSION, Version};
 use near_store::metadata::DB_VERSION;
 use nearcore::get_default_home;
 use std::env;
@@ -18,11 +18,12 @@ static NEARD_FEATURES: &str = env!("NEARD_FEATURES");
 
 static NEARD_VERSION_STRING: LazyLock<String> = LazyLock::new(|| {
     format!(
-        "(release {}) (build {}) (commit {}) (rustc {}) (protocol {}) (db {})\nfeatures: [{}]",
+        "(release {}) (build {}) (commit {}) (rustc {}) (protocol [{},{}]) (db {})\nfeatures: [{}]",
         NEARD_VERSION,
         NEARD_BUILD,
         NEARD_COMMIT,
         RUSTC_VERSION,
+        MIN_SUPPORTED_PROTOCOL_VERSION,
         PROTOCOL_VERSION,
         DB_VERSION,
         NEARD_FEATURES


### PR DESCRIPTION
Confirmed that the protocol version in mainnet genesis is 29.