### PR TITLE
refactor:`process_transactions` does not drop validated txs

### DIFF
--- a/runtime/runtime/src/balance_checker.rs
+++ b/runtime/runtime/src/balance_checker.rs
@@ -2,8 +2,7 @@ use crate::config::{
     safe_add_balance, safe_add_gas, safe_gas_to_balance, total_deposit, total_prepaid_exec_fees,
     total_prepaid_gas, total_prepaid_send_fees,
 };
-use crate::safe_add_balance_apply;
-use crate::{DelayedReceiptIndices, ValidatorAccountsUpdate};
+use crate::{DelayedReceiptIndices, ValidatorAccountsUpdate, safe_add_balance_apply};
 use near_parameters::{ActionCosts, RuntimeConfig};
 use near_primitives::chunk_apply_stats::BalanceStats;
 use near_primitives::errors::{

--- a/runtime/runtime/src/balance_checker.rs
+++ b/runtime/runtime/src/balance_checker.rs
@@ -197,14 +197,14 @@ fn all_touched_accounts(
         .map(|vt| vt.signer_id().clone());
     let mut all_account_ids = receipts_account_ids.chain(txs_account_ids).collect::<HashSet<_>>();
     if let Some(update) = validator_accounts_update {
-        let validate_accounts = update
+        let accounts = update
             .stake_info
             .keys()
             .chain(update.validator_rewards.keys())
             .chain(update.last_proposals.keys())
             .chain(update.slashing_info.keys())
             .cloned();
-        all_account_ids.extend(validate_accounts);
+        all_account_ids.extend(accounts);
         if let Some(account) = &update.protocol_treasury_account_id {
             all_account_ids.insert(account.clone());
         }


### PR DESCRIPTION
Related to the work being tracked in #13140 

This PR combined with https://github.com/near/nearcore/pull/13122 allows us to remove an expensive unnecessary cloning of signed transactions in https://github.com/near/nearcore/blob/master/runtime/runtime/src/lib.rs#L1716.

Reviewer: if you do not like the intermediate state of this PR, I am happy to combine it with #13122 but I thought that will be too ugly to review.