### PR TITLE
Chore: throttle gc error logs

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -54,6 +54,8 @@ use node_runtime::{
 };
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{debug, error, info, instrument};
 
 pub mod errors;
@@ -828,26 +830,18 @@ impl RuntimeAdapter for NightshadeRuntime {
     }
 
     fn get_gc_stop_height(&self, block_hash: &CryptoHash) -> BlockHeight {
-        use std::sync::atomic::{AtomicI64, Ordering};
-        use std::time::{SystemTime, UNIX_EPOCH};
-
-        // Use AtomicI64 to store unix timestamp in seconds
-        static LAST_LOG_TIME: AtomicI64 = AtomicI64::new(0);
-        // Log throttling interval (10 seconds)
-        const LOG_THROTTLE_INTERVAL: i64 = 10;
+        static LAST_LOG_TIME: AtomicU64 = AtomicU64::new(0);
+        const LOG_THROTTLE_INTERVAL: u64 = 10;
 
         let result = self.get_gc_stop_height_impl(block_hash);
         match result {
             Ok(gc_stop_height) => gc_stop_height,
             Err(error) => {
-                // Get current time as Unix timestamp in seconds
-                let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
-                    as i64;
+                let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
 
                 // Only log if LOG_THROTTLE_INTERVAL has passed since the last log
                 let last_log = LAST_LOG_TIME.load(Ordering::Relaxed);
                 if now - last_log >= LOG_THROTTLE_INTERVAL {
-                    // Update the last log time before logging to prevent race conditions
                     LAST_LOG_TIME.store(now, Ordering::Relaxed);
 
                     info!(target: "runtime", "Error when getting the gc stop height. This error may naturally occur after the gc_num_epochs_to_keep config is increased. It should disappear as soon as the node builds up all epochs it wants. Error: {}", error);


### PR DESCRIPTION
With epoch and state sync implemented, gc is spamming logs when nodes are just bootstrapped.
Fixing by implementing a 10 seconds throttle for get_gc_stop_height logs.

```
$ journalctl -fu neard  |grep Error
Mar 16 01:24:35 neard[586239]: 2025-03-16T01:24:35.232735Z  INFO runtime: Error when getting the gc stop height. This error may naturally occur after the gc_num_epochs_to_keep config is increased. It should disappear as soon as the node builds up all epochs it wants. Error: DB Not Found Error: epoch block: BDbsSDd7aP5qbrFubk4kM57xpn8zWa1X9MWvyJ1DkK75
Mar 16 01:24:45 neard[586239]: 2025-03-16T01:24:45.135321Z  INFO runtime: Error when getting the gc stop height. This error may naturally occur after the gc_num_epochs_to_keep config is increased. It should disappear as soon as the node builds up all epochs it wants. Error: DB Not Found Error: epoch block: BDbsSDd7aP5qbrFubk4kM57xpn8zWa1X9MWvyJ1DkK75
Mar 16 01:24:55 neard[586239]: 2025-03-16T01:24:55.261914Z  INFO runtime: Error when getting the gc stop height. This error may naturally occur after the gc_num_epochs_to_keep config is increased. It should disappear as soon as the node builds up all epochs it wants. Error: DB Not Found Error: epoch block: BDbsSDd7aP5qbrFubk4kM57xpn8zWa1X9MWvyJ1DkK75
Mar 16 01:25:05 neard[586239]: 2025-03-16T01:25:05.277381Z  INFO runtime: Error when getting the gc stop height. This error may naturally occur after the gc_num_epochs_to_keep config is increased. It should disappear as soon as the node builds up all epochs it wants. Error: DB Not Found Error: epoch block: BDbsSDd7aP5qbrFubk4kM57xpn8zWa1X9MWvyJ1DkK75
Mar 16 01:25:15 neard[586239]: 2025-03-16T01:25:15.291761Z  INFO runtime: Error when getting the gc stop height. This error may naturally occur after the gc_num_epochs_to_keep config is increased. It should disappear as soon as the node builds up all epochs it wants. Error: DB Not Found Error: epoch block: BDbsSDd7aP5qbrFubk4kM57xpn8zWa1X9MWvyJ1DkK75
Mar 16 01:25:25 neard[586239]: 2025-03-16T01:25:25.305938Z  INFO runtime: Error when getting the gc stop height. This error may naturally occur after the gc_num_epochs_to_keep config is increased. It should disappear as soon as the node builds up all epochs it wants. Error: DB Not Found Error: epoch block: BDbsSDd7aP5qbrFubk4kM57xpn8zWa1X9MWvyJ1DkK75
```