### PR TITLE
Revert "runtime: parallel transaction verification (#12983)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6980,22 +6980,26 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
+ "autocfg",
+ "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
+ "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
+ "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -323,7 +323,7 @@ rand_chacha = "0.3.1"
 rand_core = "0.5"
 rand_hc = "0.3.1"
 rand_xorshift = "0.3"
-rayon = "1.10"
+rayon = "1.5"
 redis = "0.23.0"
 reed-solomon-erasure = { version = "6.0.0", features = ["simd-accel"] }
 regex = "1.7.1"

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -587,8 +587,6 @@ impl RuntimeAdapter for NightshadeRuntime {
             // and therefore skip the check on the nonce upper bound.
             None,
             current_protocol_version,
-            None,
-            None,
         )
         .map(|_vr| ())
     }
@@ -781,8 +779,6 @@ impl RuntimeAdapter for NightshadeRuntime {
                         &cost,
                         Some(next_block_height),
                         protocol_version,
-                        None,
-                        None,
                     )
                 })
                 .and_then(|verification_res| {

--- a/cspell.json
+++ b/cspell.json
@@ -178,7 +178,6 @@
         "MILLI",
         "Millinear",
         "millis",
-	"miloserdow",
         "mixeddb",
         "moar",
         "mocknet",

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -472,8 +472,6 @@ impl Testbed<'_> {
             &cost,
             block_height,
             PROTOCOL_VERSION,
-            None,
-            None,
         )
         .expect("tx verification should not fail in estimator");
         commit_charging_for_tx(&mut state_update, &validated_tx, &vr.signer, &vr.access_key);


### PR DESCRIPTION
This reverts commit 0d1eb42a96757d6f61cd5128194014f4c79647b5.

The reason for revert is that change brakes archival nodes / canaries.