### PR TITLE
test: add test loop example for triggering missing chunk

### DIFF
--- a/test-loop-tests/src/examples/missing_chunk.rs
+++ b/test-loop-tests/src/examples/missing_chunk.rs
@@ -1,0 +1,92 @@
+use near_async::messaging::CanSend;
+use near_async::time::Duration;
+use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
+use near_client::NetworkAdversarialMessage;
+use near_client::client_actor::AdvProduceChunksMode;
+use near_primitives::shard_layout::ShardLayout;
+use near_primitives::types::{AccountId, BlockHeight};
+
+use crate::setup::builder::TestLoopBuilder;
+use crate::setup::env::TestLoopEnv;
+use crate::utils::{get_node_client, get_node_data, run_until_node_head_height};
+
+/// This test demonstrates how to trigger missing chunk at a certain height
+#[test]
+#[cfg_attr(not(feature = "test_features"), ignore)]
+fn missing_chunk_example_test() {
+    let validators = ["validator0", "validator1"];
+    let missing_chunk_heigh = 8;
+    let shard_layout = ShardLayout::multi_shard(2, 1);
+    let clients = validators.map(|acc| acc.parse::<AccountId>().unwrap()).to_vec();
+    let target_client = &clients[0];
+    let validators_spec = ValidatorsSpec::desired_roles(&validators, &[]);
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .shard_layout(shard_layout)
+        .validators_spec(validators_spec)
+        .build();
+    let epoch_config_store = TestEpochConfigBuilder::build_store_from_genesis(&genesis);
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store(epoch_config_store)
+        .clients(clients.clone())
+        .build()
+        .warmup();
+
+    // Note: waiting for height H results in chunk already produced for H+1.
+    // That is why if we want to have missing chunk at H we do the following:
+    // 1. Wait for H-2, chunk at H-1 is produced at this point
+    // 2. Disable chunk production
+    // 3. Wait for H-1, chunk is skipped at H
+    // 4. Enable chunk production, chunks are produced again after H
+    run_until_node_head_height(
+        &mut env,
+        target_client,
+        missing_chunk_heigh - 2,
+        Duration::seconds(10),
+    );
+    send_adv_produce_chunks(&env, target_client, AdvProduceChunksMode::StopProduce);
+    run_until_node_head_height(
+        &mut env,
+        target_client,
+        missing_chunk_heigh - 1,
+        Duration::seconds(3),
+    );
+    send_adv_produce_chunks(&env, target_client, AdvProduceChunksMode::Valid);
+    run_until_node_head_height(
+        &mut env,
+        target_client,
+        missing_chunk_heigh + 1,
+        Duration::seconds(3),
+    );
+
+    assert_eq!(get_chunk_mask(&env, target_client, missing_chunk_heigh - 1), vec![true, true]);
+    assert_eq!(get_chunk_mask(&env, target_client, missing_chunk_heigh), vec![false, true]);
+    assert_eq!(get_chunk_mask(&env, target_client, missing_chunk_heigh + 1), vec![true, true]);
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(10));
+}
+
+fn send_adv_produce_chunks(
+    env: &TestLoopEnv,
+    client_account_id: &AccountId,
+    mode: AdvProduceChunksMode,
+) {
+    let client_sender = get_node_data(&env.node_datas, client_account_id).client_sender.clone();
+    env.test_loop.send_adhoc_event(format!("send {mode:?} to {client_account_id}"), move |_| {
+        client_sender.send(NetworkAdversarialMessage::AdvProduceChunks(mode));
+    });
+}
+
+fn get_chunk_mask(
+    env: &TestLoopEnv,
+    client_account_id: &AccountId,
+    block_height: BlockHeight,
+) -> Vec<bool> {
+    get_node_client(env, client_account_id)
+        .chain
+        .get_block_by_height(block_height)
+        .unwrap()
+        .header()
+        .chunk_mask()
+        .to_vec()
+}

--- a/test-loop-tests/src/examples/mod.rs
+++ b/test-loop-tests/src/examples/mod.rs
@@ -1,3 +1,4 @@
+mod missing_chunk;
 mod multinode;
 mod restart_node;
 mod simple;

--- a/test-loop-tests/src/tests/contract_distribution_cross_shard.rs
+++ b/test-loop-tests/src/tests/contract_distribution_cross_shard.rs
@@ -13,7 +13,7 @@ use crate::utils::contract_distribution::{
     run_until_caches_contain_contract,
 };
 use crate::utils::transactions::{call_contract, check_txs, deploy_contract, make_accounts};
-use crate::utils::{ONE_NEAR, get_head_height};
+use crate::utils::{ONE_NEAR, get_node_head_height};
 
 const EPOCH_LENGTH: u64 = 10;
 const GENESIS_HEIGHT: u64 = 1000;
@@ -47,7 +47,7 @@ fn test_contract_distribution_cross_shard() {
     let contract_ids = [&accounts[0], &accounts[4]];
     let sender_ids = [&accounts[0], &accounts[1], &accounts[4], &accounts[5]];
 
-    let start_height = get_head_height(&mut env);
+    let start_height = get_node_head_height(&env, &accounts[0]);
 
     // First deploy and call the contracts as described above.
     // Next, clear the compiled contract cache and repeat the same contract calls.
@@ -63,7 +63,7 @@ fn test_contract_distribution_cross_shard() {
 
     call_contracts(&mut env, &rpc_id, &contract_ids, &sender_ids, &mut nonce);
 
-    let end_height = get_head_height(&mut env);
+    let end_height = get_node_head_height(&env, &accounts[0]);
     assert_all_chunk_endorsements_received(&mut env, start_height, end_height);
 
     env.shutdown_and_drain_remaining_events(Duration::seconds(20));

--- a/test-loop-tests/src/tests/contract_distribution_simple.rs
+++ b/test-loop-tests/src/tests/contract_distribution_simple.rs
@@ -15,7 +15,7 @@ use crate::utils::contract_distribution::{
 use crate::utils::transactions::{
     do_call_contract, do_delete_account, do_deploy_contract, make_account, make_accounts,
 };
-use crate::utils::{ONE_NEAR, get_head_height};
+use crate::utils::{ONE_NEAR, get_node_head_height};
 
 const EPOCH_LENGTH: u64 = 10;
 const GENESIS_HEIGHT: u64 = 1000;
@@ -39,7 +39,7 @@ fn test_contract_distribution_single_account(wait_cache_populate: bool, clear_ca
     let method_name = "main".to_owned();
     let args = vec![];
 
-    let start_height = get_head_height(&mut env);
+    let start_height = get_node_head_height(&mut env, &accounts[0]);
 
     do_deploy_contract(&mut env, &rpc_id, &contract_id, contract.code().to_vec());
 
@@ -63,7 +63,7 @@ fn test_contract_distribution_single_account(wait_cache_populate: bool, clear_ca
 
     do_delete_account(&mut env, &rpc_id, &contract_id, &rpc_id);
 
-    let end_height = get_head_height(&mut env);
+    let end_height = get_node_head_height(&env, &accounts[0]);
     assert_all_chunk_endorsements_received(&mut env, start_height, end_height);
 
     env.shutdown_and_drain_remaining_events(Duration::seconds(20));
@@ -106,7 +106,7 @@ fn test_contract_distribution_different_accounts(wait_cache_populate: bool, clea
     let method_name = "main".to_owned();
     let args = vec![];
 
-    let start_height = get_head_height(&mut env);
+    let start_height = get_node_head_height(&env, &accounts[0]);
 
     do_deploy_contract(&mut env, &rpc_id, &contract_id1, contract.code().to_vec());
     do_deploy_contract(&mut env, &rpc_id, &contract_id2, contract.code().to_vec());
@@ -132,7 +132,7 @@ fn test_contract_distribution_different_accounts(wait_cache_populate: bool, clea
     do_delete_account(&mut env, &rpc_id, &contract_id1, &rpc_id);
     do_delete_account(&mut env, &rpc_id, &contract_id2, &rpc_id);
 
-    let end_height = get_head_height(&mut env);
+    let end_height = get_node_head_height(&env, &accounts[0]);
     assert_all_chunk_endorsements_received(&mut env, start_height, end_height);
 
     env.shutdown_and_drain_remaining_events(Duration::seconds(20));
@@ -177,7 +177,7 @@ fn test_contract_distribution_deploy_and_call_multiple_contracts() {
     let method_name = "main".to_owned();
     let args = vec![];
 
-    let start_height = get_head_height(&mut env);
+    let start_height = get_node_head_height(&env, &accounts[0]);
 
     for contract in contracts.iter() {
         do_deploy_contract(&mut env, &rpc_id, &contract_id, contract.code().to_vec());
@@ -204,7 +204,7 @@ fn test_contract_distribution_deploy_and_call_multiple_contracts() {
 
     do_delete_account(&mut env, &rpc_id, &contract_id, &rpc_id);
 
-    let end_height = get_head_height(&mut env);
+    let end_height = get_node_head_height(&env, &accounts[0]);
     assert_all_chunk_endorsements_received(&mut env, start_height, end_height);
 
     env.shutdown_and_drain_remaining_events(Duration::seconds(20));


### PR DESCRIPTION
This PR adds a test loop example test for triggering missing chunk at a certain height using adversarial behaviour.
It also includes a bit of refactoring around common utils.