### PR TITLE
test: fix test loop missing chunk example compilation

### DIFF
--- a/test-loop-tests/src/examples/missing_chunk.rs
+++ b/test-loop-tests/src/examples/missing_chunk.rs
@@ -10,9 +10,9 @@ use crate::setup::builder::TestLoopBuilder;
 use crate::setup::env::TestLoopEnv;
 use crate::utils::{get_node_client, get_node_data, run_until_node_head_height};
 
-/// This test demonstrates how to trigger missing chunk at a certain height
+/// This test demonstrates how to trigger missing chunk at a certain height.
+/// Requires "test_features" feature to be enabled.
 #[test]
-#[cfg_attr(not(feature = "test_features"), ignore)]
 fn missing_chunk_example_test() {
     let validators = ["validator0", "validator1"];
     let missing_chunk_heigh = 8;

--- a/test-loop-tests/src/examples/mod.rs
+++ b/test-loop-tests/src/examples/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "test_features")]
 mod missing_chunk;
 mod multinode;
 mod restart_node;

--- a/test-loop-tests/src/utils/mod.rs
+++ b/test-loop-tests/src/utils/mod.rs
@@ -39,6 +39,7 @@ pub(crate) fn get_node_head_height(
     get_node_client(env, client_account_id).chain.head().unwrap().height
 }
 
+#[allow(dead_code)]
 pub(crate) fn run_until_node_head_height(
     env: &mut TestLoopEnv,
     client_account_id: &AccountId,


### PR DESCRIPTION
With #13161 test-loop-tests build fails when `test_features` is not enabled:
```
% cargo test -p test-loop-tests -- global_contracts
error[E0432]: unresolved import `near_client::NetworkAdversarialMessage`
  --> test-loop-tests/src/examples/missing_chunk.rs:4:5
   |
4  | use near_client::NetworkAdversarialMessage;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `NetworkAdversarialMessage` in the root
   |
```