### PR TITLE
[limited replayability] Isolate bp_hash computation for genesis & epoch_sync

### DIFF
--- a/chain/chain/src/genesis.rs
+++ b/chain/chain/src/genesis.rs
@@ -40,6 +40,8 @@ impl Chain {
             chain_genesis.height,
             chain_genesis.protocol_version,
         );
+        let validator_stakes =
+            epoch_manager.get_epoch_block_producers_ordered(&EpochId::default())?;
         let genesis_block = Block::genesis(
             chain_genesis.protocol_version,
             genesis_chunks.iter().map(|chunk| chunk.cloned_header()).collect(),
@@ -47,7 +49,7 @@ impl Chain {
             chain_genesis.height,
             chain_genesis.min_gas_price,
             chain_genesis.total_supply,
-            Chain::compute_bp_hash(epoch_manager, EpochId::default(), EpochId::default())?,
+            &validator_stakes,
         );
 
         // verify that the genesis block hash matches either mainnet or testnet

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -584,7 +584,7 @@ mod tests {
             0,
             100,
             1_000_000_000,
-            CryptoHash::hash_borsh(genesis_bps),
+            &genesis_bps,
         );
         let signer = Arc::new(create_test_signer("other"));
         let b1 = TestBlockBuilder::new(Clock::real(), &genesis, signer.clone()).build();

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -37,7 +37,7 @@ pub fn make_genesis_block(clock: &time::Clock, chunks: Vec<ShardChunk>) -> Block
         0,
         1000,
         1000,
-        CryptoHash::default(),
+        &vec![],
     )
 }
 

--- a/core/primitives/benches/serialization.rs
+++ b/core/primitives/benches/serialization.rs
@@ -56,7 +56,7 @@ fn create_block() -> Block {
         0,
         1_000,
         1_000,
-        CryptoHash::default(),
+        &vec![],
     );
     let signer = InMemoryValidatorSigner::from_random("test".parse().unwrap(), KeyType::ED25519);
     Block::produce(

--- a/core/primitives/src/block_header.rs
+++ b/core/primitives/src/block_header.rs
@@ -1494,3 +1494,15 @@ impl BlockHeader {
         }
     }
 }
+
+pub fn compute_bp_hash_from_validator_stakes(
+    validator_stakes: &Vec<ValidatorStake>,
+    use_versioned_bp_hash_format: bool,
+) -> CryptoHash {
+    if use_versioned_bp_hash_format {
+        CryptoHash::hash_borsh_iter(validator_stakes)
+    } else {
+        let stakes = validator_stakes.into_iter().map(|stake| stake.clone().into_v1());
+        CryptoHash::hash_borsh_iter(stakes)
+    }
+}

--- a/core/primitives/src/epoch_sync.rs
+++ b/core/primitives/src/epoch_sync.rs
@@ -3,10 +3,12 @@ use crate::epoch_info::EpochInfo;
 use crate::merkle::PartialMerkleTree;
 use crate::types::validator_stake::ValidatorStake;
 use crate::utils::compression::CompressedData;
+use crate::version::BLOCK_HEADER_V3_PROTOCOL_VERSION;
 use crate::{block_header::BlockHeader, merkle::MerklePathItem};
 use borsh::{BorshDeserialize, BorshSerialize};
 use bytesize::ByteSize;
 use near_crypto::Signature;
+use near_primitives_core::types::ProtocolVersion;
 use near_schema_checker_lib::ProtocolSchema;
 use std::fmt::Debug;
 
@@ -89,6 +91,12 @@ impl Debug for CompressedEpochSyncProof {
             .field("proof", &self.decode())
             .finish()
     }
+}
+
+/// For epoch sync we need to keep track of when the block producer hash format changed.
+/// This is required for the correct calculation of the proof. See [`use_versioned_bp_hash_format`]
+pub fn should_use_versioned_bp_hash_format(protocol_version: ProtocolVersion) -> bool {
+    protocol_version >= BLOCK_HEADER_V3_PROTOCOL_VERSION
 }
 
 /// Data needed for each epoch covered in the epoch sync proof.

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -27,6 +27,10 @@ pub const MIN_GAS_PRICE_NEP_92: Balance = 1_000_000_000;
 /// Minimum gas price proposed in NEP 92 (fixed) and the associated protocol version
 pub const MIN_GAS_PRICE_NEP_92_FIX: Balance = 100_000_000;
 
+/// The protocol version for the block header v3. This is also when we started using
+/// versioned block producer hash format.
+pub const BLOCK_HEADER_V3_PROTOCOL_VERSION: ProtocolVersion = 49;
+
 /// The points in time after which the voting for the latest protocol version
 /// should start.
 ///

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -6,7 +6,7 @@ use crate::state_dump::StateDump;
 use indicatif::{ProgressBar, ProgressStyle};
 use near_chain::genesis::get_genesis_congestion_infos;
 use near_chain::types::RuntimeAdapter;
-use near_chain::{Block, Chain, ChainStore};
+use near_chain::{Block, ChainStore};
 use near_chain_configs::Genesis;
 use near_crypto::InMemorySigner;
 use near_epoch_manager::{EpochManager, EpochManagerAdapter, EpochManagerHandle};
@@ -239,6 +239,8 @@ impl GenesisBuilder {
             self.genesis.config.genesis_height,
             self.genesis.config.protocol_version,
         );
+        let validator_stakes =
+            self.epoch_manager.get_epoch_block_producers_ordered(&EpochId::default())?;
         let genesis = Block::genesis(
             self.genesis.config.protocol_version,
             genesis_chunks.into_iter().map(|chunk| chunk.take_header()).collect(),
@@ -247,11 +249,7 @@ impl GenesisBuilder {
             self.genesis.config.genesis_height,
             self.genesis.config.min_gas_price,
             self.genesis.config.total_supply,
-            Chain::compute_bp_hash(
-                self.epoch_manager.as_ref(),
-                EpochId::default(),
-                EpochId::default(),
-            )?,
+            &validator_stakes,
         );
 
         let mut store = ChainStore::new(


### PR DESCRIPTION
Along with genesis, epoch_sync also relies on old protocol version to generate the proof chain. In particular, we changed the way we calculate next block producer hash based on BLOCK_HEADER_V3_PROTOCOL_VERSION.

Specifically, `use_versioned_bp_hash_format`, is set as `ProtocolFeature::BlockHeaderV3.enabled(protocol_version)`

This PR isolates the code to use versioned bp_hash for epoch sync and prod genesis.