### PR TITLE
fix(indexer): Don't create ValidatedTransaction in indexer

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -573,7 +573,8 @@ impl RuntimeAdapter for NightshadeRuntime {
     ) -> Result<(), InvalidTxError> {
         let runtime_config = self.runtime_config_store.get_config(current_protocol_version);
 
-        let cost = tx_cost(runtime_config, &validated_tx, gas_price, current_protocol_version)?;
+        let cost =
+            tx_cost(runtime_config, &validated_tx.to_tx(), gas_price, current_protocol_version)?;
         let shard_uid = shard_layout
             .account_id_to_shard_uid(validated_tx.to_signed_tx().transaction.signer_id());
         let state_update = self.tries.new_trie_update(shard_uid, state_root);
@@ -766,7 +767,7 @@ impl RuntimeAdapter for NightshadeRuntime {
 
                 let verify_result = tx_cost(
                     runtime_config,
-                    &validated_tx,
+                    &validated_tx.to_tx(),
                     prev_block.next_gas_price,
                     protocol_version,
                 )

--- a/chain/indexer/src/streamer/utils.rs
+++ b/chain/indexer/src/streamer/utils.rs
@@ -44,6 +44,7 @@ pub(crate) async fn convert_transactions_sir_into_local_receipts(
                         .collect(),
                 },
             );
+            // Can't use ValidatedTransaction here because transactions in a chunk can be invalid (RelaxedChunkValidation feature)
             let cost =
                 tx_cost(&runtime_config, &tx, prev_block_gas_price, protocol_version).unwrap();
             views::ReceiptView {

--- a/chain/indexer/src/streamer/utils.rs
+++ b/chain/indexer/src/streamer/utils.rs
@@ -1,9 +1,7 @@
 use actix::Addr;
 
-use near_crypto::InMemorySigner;
 use near_indexer_primitives::IndexerTransactionWithOutcome;
 use near_parameters::RuntimeConfig;
-use near_primitives::transaction::ValidatedTransaction;
 use near_primitives::version::ProtocolVersion;
 use near_primitives::views;
 use node_runtime::config::tx_cost;

--- a/chain/indexer/src/streamer/utils.rs
+++ b/chain/indexer/src/streamer/utils.rs
@@ -46,13 +46,8 @@ pub(crate) async fn convert_transactions_sir_into_local_receipts(
                         .collect(),
                 },
             );
-            let signer = InMemorySigner::test_signer(&indexer_tx.transaction.signer_id);
-            let signed_tx = tx.sign(&signer);
-            let validated_tx = ValidatedTransaction::new(runtime_config, signed_tx).unwrap();
-
             let cost =
-                tx_cost(&runtime_config, &validated_tx, prev_block_gas_price, protocol_version)
-                    .unwrap();
+                tx_cost(&runtime_config, &tx, prev_block_gas_price, protocol_version).unwrap();
             views::ReceiptView {
                 predecessor_id: indexer_tx.transaction.signer_id.clone(),
                 receiver_id: indexer_tx.transaction.receiver_id.clone(),

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -463,7 +463,8 @@ impl Testbed<'_> {
         )
         .expect("expected no validation error");
         let cost =
-            tx_cost(&self.apply_state.config, &validated_tx, gas_price, PROTOCOL_VERSION).unwrap();
+            tx_cost(&self.apply_state.config, &validated_tx.to_tx(), gas_price, PROTOCOL_VERSION)
+                .unwrap();
 
         let vr = verify_and_charge_tx_ephemeral(
             &self.apply_state.config,

--- a/runtime/runtime/src/config.rs
+++ b/runtime/runtime/src/config.rs
@@ -11,7 +11,7 @@ use num_traits::pow::Pow;
 // Just re-exporting RuntimeConfig for backwards compatibility.
 use near_parameters::{ActionCosts, RuntimeConfig, transfer_exec_fee, transfer_send_fee};
 pub use near_primitives::num_rational::Rational32;
-use near_primitives::transaction::{Action, DeployContractAction, ValidatedTransaction};
+use near_primitives::transaction::{Action, DeployContractAction, Transaction};
 use near_primitives::types::{AccountId, Balance, Compute, Gas};
 
 /// Describes the cost of converting this transaction into a receipt.
@@ -249,11 +249,10 @@ pub fn exec_fee(config: &RuntimeConfig, action: &Action, receiver_id: &AccountId
 /// Returns transaction costs for a given transaction.
 pub fn tx_cost(
     config: &RuntimeConfig,
-    validated_tx: &ValidatedTransaction,
+    tx: &Transaction,
     gas_price: Balance,
     protocol_version: ProtocolVersion,
 ) -> Result<TransactionCost, IntegerOverflowError> {
-    let tx = validated_tx.to_tx();
     let sender_is_receiver = tx.receiver_id() == tx.signer_id();
     let fees = &config.fees;
     let mut gas_burnt: Gas = fees.fee(ActionCosts::new_action_receipt).send_fee(sender_is_receiver);

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -319,7 +319,7 @@ impl Runtime {
                         Ok(validated_tx) => {
                             match tx_cost(
                                 config,
-                                &validated_tx,
+                                &validated_tx.to_tx(),
                                 gas_price,
                                 current_protocol_version,
                             ) {

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -740,7 +740,7 @@ mod tests {
                 return;
             }
         };
-        let cost = match tx_cost(config, &validated_tx, gas_price, PROTOCOL_VERSION) {
+        let cost = match tx_cost(config, &validated_tx.to_tx(), gas_price, PROTOCOL_VERSION) {
             Ok(c) => c,
             Err(err) => {
                 assert_eq!(InvalidTxError::from(err), expected_err);
@@ -773,7 +773,8 @@ mod tests {
             Ok(validated_tx) => validated_tx,
             Err((err, _tx)) => return Err(err),
         };
-        let transaction_cost = tx_cost(config, &validated_tx, gas_price, current_protocol_version)?;
+        let transaction_cost =
+            tx_cost(config, &validated_tx.to_tx(), gas_price, current_protocol_version)?;
         let vr = verify_and_charge_tx_ephemeral(
             config,
             state_update,


### PR DESCRIPTION
This code caused the indexer to crash on forknet:
```rust
let signer = InMemorySigner::test_signer(&indexer_tx.transaction.signer_id);
let signed_tx = tx.sign(&signer);
let validated_tx = ValidatedTransaction::new(runtime_config, signed_tx).unwrap();
```

The transaction is signed using a dummy signer, but then in `ValidatedTransaction::new` the signature is verified against the real public key from the transaction, which fails and the `unwrap()` panics, which crashes the indexer.

To fix the problem I made `tx_cost` take a normal `Transaction` and pass the `tx` there without having to create a `ValidatedTransaction`.