### PR TITLE
fix: don't set block sync status before it starts.

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1718,8 +1718,11 @@ impl ClientActorInner {
                     self.client.request_block(block_hash, peer_id);
                 }
             }
+            // This is the last step of state sync that is not in handle_sync_needed because it
+            // needs access to the client.
             SyncHandlerRequest::NeedProcessBlockArtifact(block_processing_artifacts) => {
                 self.client.process_block_processing_artifact(block_processing_artifacts, signer);
+                self.client.sync_handler.sync_status.update(SyncStatus::StateSyncDone);
             }
         }
     }

--- a/chain/client/src/sync/handler.rs
+++ b/chain/client/src/sync/handler.rs
@@ -176,11 +176,6 @@ impl SyncHandler {
             apply_chunks_done_sender,
         );
         unwrap_and_report_state_sync_result!(reset_heads_result);
-        self.sync_status.update(SyncStatus::BlockSync {
-            start_height: 0,
-            current_height: 0,
-            highest_height: 0,
-        });
 
         Some(SyncHandlerRequest::NeedProcessBlockArtifact(block_processing_artifacts))
     }

--- a/test-loop-tests/src/tests/epoch_sync.rs
+++ b/test-loop-tests/src/tests/epoch_sync.rs
@@ -168,6 +168,8 @@ fn bootstrap_node_via_epoch_sync(mut env: TestLoopEnv, source_node: usize) -> Te
             "HeaderSync",
             // State sync downloads the state from state dumps.
             "StateSync",
+            // State sync is done.
+            "StateSyncDone",
             // Block sync picks up from where StateSync left off, and finishes the sync.
             "BlockSync",
             // NoSync means we're up to date.


### PR DESCRIPTION
Before this PR we would set sync status to BlockSync near the end of state sync. We likely did so because that is the next step when doing the sync.

With this change after state sync is done we will set StateSyncDone status. On logic it should have no effect, but will only change log message being displayed from: `Downloading blocks 0.00%` to `State sync done` actual block sync is reached.

Note that I have moved status update to after
`process_block_processing_artifact` which was the case before https://github.com/near/nearcore/pull/12841 and likely the ordering here was changed unintentionally. I am not that familiar with how state sync works, so may be missing something here.

Closes https://github.com/near/nearcore/issues/13162