### PR TITLE
fix(forknet): use old snapshot config values for backward compatibility

### DIFF
--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -234,6 +234,7 @@ def _apply_config_changes(node, state_sync_location):
         }
         if node.want_state_dump:
             changes['state_sync.dump.location'] = state_sync_location
+            # TODO: Change this to Enabled once we remove support the for EveryEpoch alias.
             changes[
                 'store.state_snapshot_config.state_snapshot_type'] = "EveryEpoch"
     for key, change in changes.items():

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -235,7 +235,7 @@ def _apply_config_changes(node, state_sync_location):
         if node.want_state_dump:
             changes['state_sync.dump.location'] = state_sync_location
             changes[
-                'store.state_snapshot_config.state_snapshot_type'] = "Enabled"
+                'store.state_snapshot_config.state_snapshot_type'] = "EveryEpoch"
     for key, change in changes.items():
         do_update_config(node, f'{key}={json.dumps(change)}')
 


### PR DESCRIPTION
This tool can be used with older binaries that are not aware fo the new config values. 