### PR TITLE
Add EpochConfigByEpochId to entity debug

### DIFF
--- a/chain/jsonrpc-primitives/src/types/entity_debug.rs
+++ b/chain/jsonrpc-primitives/src/types/entity_debug.rs
@@ -69,6 +69,7 @@ pub enum EntityQuery {
     ChunkExtraByBlockHashShardUId { block_hash: CryptoHash, shard_uid: ShardUId },
     EpochInfoAggregator(()),
     EpochInfoByEpochId { epoch_id: EpochId },
+    EpochConfigByEpochId { epoch_id: EpochId },
     FlatStateByTrieKey { trie_key: String, shard_uid: ShardUId },
     FlatStateChangesByBlockHash { block_hash: CryptoHash, shard_uid: ShardUId },
     FlatStateDeltaMetadataByBlockHash { block_hash: CryptoHash, shard_uid: ShardUId },

--- a/nearcore/src/entity_debug.rs
+++ b/nearcore/src/entity_debug.rs
@@ -172,6 +172,10 @@ impl EntityDebugHandlerImpl {
                 let epoch_info = self.epoch_manager.get_epoch_info(&epoch_id)?;
                 Ok(serialize_entity(&*epoch_info))
             }
+            EntityQuery::EpochConfigByEpochId { epoch_id } => {
+                let epoch_config = self.epoch_manager.get_epoch_config(&epoch_id)?;
+                Ok(serialize_entity(&epoch_config))
+            }
             EntityQuery::FlatStateByTrieKey { trie_key, shard_uid } => {
                 let state = store
                     .get_ser::<FlatStateValue>(

--- a/tools/debug-ui/src/entity_debug/fields.tsx
+++ b/tools/debug-ui/src/entity_debug/fields.tsx
@@ -183,6 +183,11 @@ const epochInfoAggregator = {
     },
 };
 
+const epochConfig = {
+    struct: {
+    }
+}
+
 const executionOutcome = {
     struct: {
         receipt_ids: { array: receiptId },
@@ -357,6 +362,7 @@ export const fieldSemantics: Record<EntityType, FieldSemantic> = {
     ChunkExtra: chunkExtra,
     EpochInfo: epochInfo,
     EpochInfoAggregator: epochInfoAggregator,
+    EpochConfig: epochConfig,
     ExecutionOutcome: executionOutcome,
     FlatState: undefined,
     FlatStateChanges: flatStateChanges,

--- a/tools/debug-ui/src/entity_debug/types.tsx
+++ b/tools/debug-ui/src/entity_debug/types.tsx
@@ -30,6 +30,7 @@ export type EntityType =
     | 'Chunk'
     | 'ChunkExtra'
     | 'EpochInfo'
+    | 'EpochConfig'
     | 'EpochInfoAggregator'
     | 'ExecutionOutcome'
     | 'FlatState'
@@ -143,6 +144,7 @@ export type EntityQuery = {
     ChunkExtraByChunkHash?: { chunk_hash: string };
     EpochInfoAggregator?: null;
     EpochInfoByEpochId?: { epoch_id: string };
+    EpochConfigByEpochId?: { epoch_id: string };
     FlatStateByTrieKey?: { trie_key: string };
     FlatStateChangesByBlockHash?: { block_hash: string };
     FlatStateDeltaMetadataByBlockHash?: { block_hash: string };
@@ -193,6 +195,7 @@ export const entityQueryTypes: EntityQueryType[] = [
     'ChunkExtraByChunkHash',
     'EpochInfoAggregator',
     'EpochInfoByEpochId',
+    'EpochConfigByEpochId',
     'FlatStateByTrieKey',
     'FlatStateChangesByBlockHash',
     'FlatStateDeltaMetadataByBlockHash',
@@ -263,6 +266,7 @@ export const entityQueryKeyTypes: Record<EntityQueryType, EntityQueryKeySpec[]> 
     ChunkExtraByChunkHash: [queryKey('chunk_hash')],
     EpochInfoAggregator: [],
     EpochInfoByEpochId: [queryKey('epoch_id')],
+    EpochConfigByEpochId: [queryKey('epoch_id')],
     FlatStateByTrieKey: [queryKey('trie_key'), implicitQueryKey('shard_uid')],
     FlatStateChangesByBlockHash: [queryKey('block_hash'), implicitQueryKey('shard_uid')],
     FlatStateDeltaMetadataByBlockHash: [queryKey('block_hash'), implicitQueryKey('shard_uid')],
@@ -307,6 +311,7 @@ export const entityQueryOutputType: Record<EntityQueryType, EntityType> = {
     ChunkExtraByChunkHash: 'ChunkExtra',
     EpochInfoAggregator: 'EpochInfoAggregator',
     EpochInfoByEpochId: 'EpochInfo',
+    EpochConfigByEpochId: 'EpochConfig',
     FlatStateByTrieKey: 'FlatState',
     FlatStateChangesByBlockHash: 'FlatStateChanges',
     FlatStateDeltaMetadataByBlockHash: 'FlatStateDeltaMetadata',


### PR DESCRIPTION
Add the ability to fetch `EpochConfig` by `EpochId` in debug ui.
It's hard to get this information from some other source, so it'd be useful to have it in entity debug.

Tested on my mainnet node, seems to be working fine:
![image](https://github.com/user-attachments/assets/df39af59-2710-4b16-b40e-3f4998ac5041)
