### PR TITLE
perf: update enum-map for perf gains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,22 +2294,22 @@ dependencies = [
 
 [[package]]
 name = "enum-map"
-version = "2.1.0"
+version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0348b2a57c82f98b9dbd8098b1abb2416f221823d3e50cbe24eaebdd16896826"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
 dependencies = [
  "enum-map-derive",
 ]
 
 [[package]]
 name = "enum-map-derive"
-version = "0.8.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a63b7a0ddec6f38dcec5e36257750b7a8fcaf4227e12ceb306e341d63634da05"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.103",
+ "syn 2.0.87",
 ]
 
 [[package]]


### PR DESCRIPTION
(Reality show narrator voice) Previously on enum-map:

    test   %rdi,%rdi
    je     0x38011ee
    cmp    $0x1,%rdi
    jne    0x38011f1
    mov    $0x1,%al
    ret
    xor    %eax,%eax
    ret
    mov    $0x2,%al
    cmp    $0x3,%rdi
    jb     0x3801415
    mov    $0x3,%al
    je     0x3801415
    mov    $0x4,%al
    cmp    $0x5,%rdi
    jb     0x3801415
    mov    $0x5,%al
    je     0x3801415
    mov    $0x6,%al
    cmp    $0x7,%rdi
    jb     0x3801415
    mov    $0x7,%al
    je     0x3801415
    <narration continues on for ~30 minutes of airtime>

(Reality show narrator voice) Next up:

    cmp    $0x54,%rdi
    ja     0x31db9d9
    mov    %edi,%eax
    ret
    sub    $0x38,%rsp
    lea    0x1d121a4(%rip),%rax
    mov    %rax,0x8(%rsp)
    movq   $0x1,0x10(%rsp)
    movq   $0x8,0x18(%rsp)
    xorps  %xmm0,%xmm0
    movups %xmm0,0x20(%rsp)
    lea    0x1d1218e(%rip),%rsi
    lea    0x8(%rsp),%rdi
    call   *0x1e8db0b(%rip)

---

This results in slightly more than 5% increase in throughput for the `apply-range` benchmark.