### PR TITLE
chore: reenable integration tests on macos

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -2,7 +2,7 @@
 # them at earliest convenience :)
 # Also in addition to this, the `nextest-integration` test is currently disabled on macos
 platform_excludes := if os() == "macos" {
-    "--exclude node-runtime --exclude runtime-params-estimator --exclude near-network --exclude estimator-warehouse --exclude integration-tests"
+    "--exclude runtime-params-estimator --exclude near-network --exclude estimator-warehouse"
 } else if os() == "windows" {
     "--exclude node-runtime --exclude runtime-params-estimator --exclude near-network --exclude estimator-warehouse --exclude integration-tests"
 } else {

--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,5 @@
 # FIXME: some of these tests don't work very well on MacOS at the moment. Should fix
 # them at earliest convenience :)
-# Also in addition to this, the `nextest-integration` test is currently disabled on macos
 platform_excludes := if os() == "macos" {
     "--exclude runtime-params-estimator --exclude near-network --exclude estimator-warehouse"
 } else if os() == "windows" {


### PR DESCRIPTION
I recall we fixed some issues with integration tests and they work on macs as well.
I just want to run `just nextest-all nightly --color=always` and have all integration tests launched as well. Locally it worked for me, except like `ultra_slow_test_cross_shard_tx_8_iterations` which are disabled anyway. We don't have macos in CI anymore, so there is no impact on others, right?