### PR TITLE
[epoch config] Make config files source of truth

### DIFF
--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -1534,7 +1534,7 @@ fn test_genesis_hash() {
     .unwrap();
     assert_eq!(block.header().hash().to_string(), "EPnLgE7iEq9s7yTkos96M3cWymH5avBAPm3qx3NXqR8H");
 
-    let epoch_manager = EpochManager::new_from_genesis_config(store, &genesis.config).unwrap();
+    let epoch_manager = EpochManager::new_arc_handle(store, &genesis.config, None);
     let epoch_info = epoch_manager.get_epoch_info(&EpochId::default()).unwrap();
     // Verify the order of the block producers.
     assert_eq!(

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -173,21 +173,6 @@ pub struct EpochManager {
 }
 
 impl EpochManager {
-    pub fn new_from_genesis_config(
-        store: Store,
-        genesis_config: &GenesisConfig,
-    ) -> Result<Self, EpochError> {
-        let reward_calculator = RewardCalculator::new(genesis_config, genesis_config.epoch_length);
-        let all_epoch_config = Self::new_all_epoch_config(genesis_config);
-        Self::new(
-            store,
-            all_epoch_config,
-            genesis_config.protocol_version,
-            reward_calculator,
-            genesis_config.validators(),
-        )
-    }
-
     /// Creates a new instance of `EpochManager` from the given `store`, `genesis_config`, and `home_dir`.
     /// For production environments such as mainnet ant testnet, the epoch config files will be ignored.
     /// In the test environment, the epoch config files will be loaded from the `home_dir` if it is not `None`.
@@ -232,30 +217,6 @@ impl EpochManager {
         Self::new_arc_handle_from_epoch_config_store(store, genesis_config, epoch_config_store)
     }
 
-    /// DEPRECATED.
-    /// Old version of deriving epoch config from genesis config.
-    /// Can be used for testing.
-    /// Keep it until #11265 is closed and the new code is released.
-    #[allow(unused)]
-    pub fn new_arc_handle_deprecated(
-        store: Store,
-        genesis_config: &GenesisConfig,
-    ) -> Arc<EpochManagerHandle> {
-        let reward_calculator = RewardCalculator::new(genesis_config, genesis_config.epoch_length);
-        let all_epoch_config = Self::new_all_epoch_config(genesis_config);
-        Arc::new(
-            Self::new(
-                store,
-                all_epoch_config,
-                genesis_config.protocol_version,
-                reward_calculator,
-                genesis_config.validators(),
-            )
-            .unwrap()
-            .into_handle(),
-        )
-    }
-
     pub fn new_arc_handle_from_epoch_config_store(
         store: Store,
         genesis_config: &GenesisConfig,
@@ -280,17 +241,6 @@ impl EpochManager {
             .unwrap()
             .into_handle(),
         )
-    }
-
-    fn new_all_epoch_config(genesis_config: &GenesisConfig) -> AllEpochConfig {
-        let initial_epoch_config = EpochConfig::from(genesis_config);
-        let epoch_config = AllEpochConfig::new(
-            genesis_config.use_production_config(),
-            genesis_config.protocol_version,
-            initial_epoch_config,
-            &genesis_config.chain_id,
-        );
-        epoch_config
     }
 
     pub fn new(

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -8,7 +8,6 @@ use crate::types::{
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::serialize::dec_format;
-use near_primitives_core::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_schema_checker_lib::ProtocolSchema;
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
@@ -219,274 +218,32 @@ pub struct AllEpochConfigTestOverrides {
 pub struct AllEpochConfig {
     /// Store for EpochConfigs, provides configs per protocol version.
     /// Initialized only for production, ie. when `use_protocol_version` is true.
-    config_store: Option<EpochConfigStore>,
+    config_store: EpochConfigStore,
     /// Chain Id. Some parameters are specific to certain chains.
     chain_id: String,
     epoch_length: BlockHeightDelta,
-    /// The fields below are DEPRECATED.
-    /// Epoch config must be controlled by `config_store` only.
-    /// TODO(#11265): remove these fields.
-    /// Whether this is for production (i.e., mainnet or testnet). This is a temporary implementation
-    /// to allow us to change protocol config for mainnet and testnet without changing the genesis config
-    _use_production_config: bool,
-    /// EpochConfig from genesis
-    _genesis_epoch_config: EpochConfig,
-
-    /// Testing overrides to apply to the EpochConfig returned by the `for_protocol_version`.
-    _test_overrides: AllEpochConfigTestOverrides,
 }
 
 impl AllEpochConfig {
-    pub fn new(
-        use_production_config: bool,
-        genesis_protocol_version: ProtocolVersion,
-        genesis_epoch_config: EpochConfig,
-        chain_id: &str,
-    ) -> Self {
-        Self::new_with_test_overrides(
-            use_production_config,
-            genesis_protocol_version,
-            genesis_epoch_config,
-            chain_id,
-            Some(AllEpochConfigTestOverrides::default()),
-        )
-    }
-
     pub fn from_epoch_config_store(
         chain_id: &str,
         epoch_length: BlockHeightDelta,
-        epoch_config_store: EpochConfigStore,
+        config_store: EpochConfigStore,
     ) -> Self {
-        let genesis_epoch_config = epoch_config_store.get_config(PROTOCOL_VERSION).as_ref().clone();
-        Self {
-            config_store: Some(epoch_config_store),
-            chain_id: chain_id.to_string(),
-            epoch_length,
-            // The fields below must be DEPRECATED. Don't use it for epoch
-            // config creation.
-            // TODO(#11265): remove them.
-            _use_production_config: false,
-            _genesis_epoch_config: genesis_epoch_config,
-            _test_overrides: AllEpochConfigTestOverrides::default(),
-        }
-    }
-
-    /// DEPRECATED.
-    pub fn new_with_test_overrides(
-        use_production_config: bool,
-        genesis_protocol_version: ProtocolVersion,
-        genesis_epoch_config: EpochConfig,
-        chain_id: &str,
-        test_overrides: Option<AllEpochConfigTestOverrides>,
-    ) -> Self {
-        // Use the config store only for production configs and outside of tests.
-        let config_store = if use_production_config && test_overrides.is_none() {
-            EpochConfigStore::for_chain_id(chain_id, None)
-        } else {
-            None
-        };
-        let all_epoch_config = Self {
-            config_store: config_store.clone(),
-            chain_id: chain_id.to_string(),
-            epoch_length: genesis_epoch_config.epoch_length,
-            _use_production_config: use_production_config,
-            _genesis_epoch_config: genesis_epoch_config,
-            _test_overrides: test_overrides.unwrap_or_default(),
-        };
-        // Sanity check: Validate that the stored genesis config equals to the config generated for the genesis protocol version.
-        // Note that we cannot do this in unittests because we do not have direct access to the genesis config for mainnet/testnet.
-        // Thus, by making sure that the generated and store configs match for the genesis, we complement the unittests, which
-        // check that the generated and stored configs match for the versions after the genesis.
-        if config_store.is_some() {
-            debug_assert_eq!(
-                config_store.as_ref().unwrap().get_config(genesis_protocol_version).as_ref(),
-                &all_epoch_config.generate_epoch_config(genesis_protocol_version),
-                "Provided genesis EpochConfig for protocol version {} does not match the stored config",
-                genesis_protocol_version
-            );
-        }
-        all_epoch_config
+        Self { config_store, chain_id: chain_id.to_string(), epoch_length }
     }
 
     pub fn for_protocol_version(&self, protocol_version: ProtocolVersion) -> EpochConfig {
-        if self.config_store.is_some() {
-            let mut config =
-                self.config_store.as_ref().unwrap().get_config(protocol_version).as_ref().clone();
-            // TODO(#11265): epoch length is overridden in many tests so we
-            // need to support it here. Consider removing `epoch_length` from
-            // EpochConfig.
-            config.epoch_length = self.epoch_length;
-            config
-        } else {
-            self.generate_epoch_config(protocol_version)
-        }
-    }
-
-    /// TODO(#11265): Remove this and use the stored configs only.
-    pub fn generate_epoch_config(&self, protocol_version: ProtocolVersion) -> EpochConfig {
-        let mut config = self._genesis_epoch_config.clone();
-
-        Self::config_mocknet(&mut config, &self.chain_id);
-
-        if !self._use_production_config {
-            return config;
-        }
-
-        Self::config_validator_selection(&mut config, protocol_version);
-
-        Self::config_nightshade(&mut config, protocol_version);
-
-        Self::config_chunk_only_producers(&mut config, &self.chain_id, protocol_version);
-
-        Self::config_max_kickout_stake(&mut config, protocol_version);
-
-        Self::config_fix_min_stake_ratio(&mut config, protocol_version);
-
-        Self::config_chunk_endorsement_thresholds(&mut config, protocol_version);
-
-        Self::config_test_overrides(&mut config, &self._test_overrides);
-
+        let mut config = self.config_store.get_config(protocol_version).as_ref().clone();
+        // TODO(#11265): epoch length is overridden in many tests so we
+        // need to support it here. Consider removing `epoch_length` from
+        // EpochConfig.
+        config.epoch_length = self.epoch_length;
         config
     }
 
     pub fn chain_id(&self) -> &str {
         &self.chain_id
-    }
-
-    /// Configures mocknet-specific features only.
-    fn config_mocknet(config: &mut EpochConfig, chain_id: &str) {
-        if chain_id != near_primitives_core::chains::MOCKNET {
-            return;
-        }
-        // In production (mainnet/testnet) and nightly environments this setting is guarded by
-        // ProtocolFeature::ShuffleShardAssignments. (see config_validator_selection function).
-        // For pre-release environment such as mocknet, which uses features between production and nightly
-        // (eg. stateless validation) we enable it by default with stateless validation in order to exercise
-        // the codepath for state sync more often.
-        // TODO(#11201): When stabilizing "ShuffleShardAssignments" in mainnet,
-        // also remove this temporary code and always rely on ShuffleShardAssignments.
-        config.shuffle_shard_assignment_for_chunk_producers = true;
-    }
-
-    /// Configures validator-selection related features.
-    fn config_validator_selection(config: &mut EpochConfig, protocol_version: ProtocolVersion) {
-        // Shuffle shard assignments every epoch, to trigger state sync more
-        // frequently to exercise that code path.
-        if ProtocolFeature::ShuffleShardAssignments.enabled(protocol_version) {
-            config.shuffle_shard_assignment_for_chunk_producers = true;
-        }
-    }
-
-    fn config_nightshade(config: &mut EpochConfig, protocol_version: ProtocolVersion) {
-        if ProtocolFeature::SimpleNightshadeV5.enabled(protocol_version) {
-            Self::config_nightshade_impl(config, ShardLayout::get_simple_nightshade_layout_v5());
-            return;
-        }
-
-        if ProtocolFeature::SimpleNightshadeV4.enabled(protocol_version) {
-            Self::config_nightshade_impl(config, ShardLayout::get_simple_nightshade_layout_v4());
-            return;
-        }
-
-        if ProtocolFeature::SimpleNightshadeV3.enabled(protocol_version) {
-            Self::config_nightshade_impl(config, ShardLayout::get_simple_nightshade_layout_v3());
-            return;
-        }
-
-        if ProtocolFeature::SimpleNightshadeV2.enabled(protocol_version) {
-            Self::config_nightshade_impl(config, ShardLayout::get_simple_nightshade_layout_v2());
-            return;
-        }
-
-        if ProtocolFeature::SimpleNightshade.enabled(protocol_version) {
-            Self::config_nightshade_impl(config, ShardLayout::get_simple_nightshade_layout());
-            return;
-        }
-    }
-
-    fn config_nightshade_impl(config: &mut EpochConfig, shard_layout: ShardLayout) {
-        let num_block_producer_seats = config.num_block_producer_seats;
-        config.num_block_producer_seats_per_shard =
-            shard_layout.shard_ids().map(|_| num_block_producer_seats).collect();
-        config.avg_hidden_validator_seats_per_shard = shard_layout.shard_ids().map(|_| 0).collect();
-        config.shard_layout = shard_layout;
-    }
-
-    fn config_chunk_only_producers(
-        config: &mut EpochConfig,
-        chain_id: &str,
-        protocol_version: u32,
-    ) {
-        if ProtocolFeature::ChunkOnlyProducers.enabled(protocol_version) {
-            // On testnet, genesis config set num_block_producer_seats to 200
-            // This is to bring it back to 100 to be the same as on mainnet
-            config.num_block_producer_seats = 100;
-            // Technically, after ChunkOnlyProducers is enabled, this field is no longer used
-            // We still set it here just in case
-            config.num_block_producer_seats_per_shard =
-                config.shard_layout.shard_ids().map(|_| 100).collect();
-            config.block_producer_kickout_threshold = 80;
-            config.chunk_producer_kickout_threshold = 80;
-            config.num_chunk_only_producer_seats = 200;
-        }
-
-        // Adjust the number of block and chunk producers for testnet, to make it easier to test the change.
-        if chain_id == near_primitives_core::chains::TESTNET
-            && ProtocolFeature::TestnetFewerBlockProducers.enabled(protocol_version)
-        {
-            let shard_ids = config.shard_layout.shard_ids();
-            // Decrease the number of block and chunk producers from 100 to 20.
-            config.num_block_producer_seats = 20;
-            // Checking feature NoChunkOnlyProducers in stateless validation
-            if ProtocolFeature::StatelessValidation.enabled(protocol_version) {
-                config.num_chunk_producer_seats = 20;
-            }
-            config.num_block_producer_seats_per_shard =
-                shard_ids.map(|_| config.num_block_producer_seats).collect();
-            // Decrease the number of chunk producers.
-            config.num_chunk_only_producer_seats = 100;
-        }
-
-        // Checking feature NoChunkOnlyProducers in stateless validation
-        if ProtocolFeature::StatelessValidation.enabled(protocol_version) {
-            // Make sure there is no chunk only producer in stateless validation
-            config.num_chunk_only_producer_seats = 0;
-        }
-    }
-
-    fn config_max_kickout_stake(config: &mut EpochConfig, protocol_version: u32) {
-        if ProtocolFeature::MaxKickoutStake.enabled(protocol_version) {
-            config.validator_max_kickout_stake_perc = 30;
-        }
-    }
-
-    fn config_fix_min_stake_ratio(config: &mut EpochConfig, protocol_version: u32) {
-        if ProtocolFeature::FixMinStakeRatio.enabled(protocol_version) {
-            config.minimum_stake_ratio = Rational32::new(1, 62_500);
-        }
-    }
-
-    fn config_chunk_endorsement_thresholds(config: &mut EpochConfig, protocol_version: u32) {
-        if ProtocolFeature::ChunkEndorsementsInBlockHeader.enabled(protocol_version) {
-            config.chunk_validator_only_kickout_threshold = 70;
-        }
-    }
-
-    fn config_test_overrides(
-        config: &mut EpochConfig,
-        test_overrides: &AllEpochConfigTestOverrides,
-    ) {
-        if let Some(block_producer_kickout_threshold) =
-            test_overrides.block_producer_kickout_threshold
-        {
-            config.block_producer_kickout_threshold = block_producer_kickout_threshold;
-        }
-
-        if let Some(chunk_producer_kickout_threshold) =
-            test_overrides.chunk_producer_kickout_threshold
-        {
-            config.chunk_producer_kickout_threshold = chunk_producer_kickout_threshold;
-        }
     }
 }
 
@@ -681,77 +438,11 @@ impl EpochConfigStore {
 
 #[cfg(test)]
 mod tests {
+    use super::EpochConfigStore;
+    use crate::epoch_manager::EpochConfig;
+    use near_primitives_core::types::ProtocolVersion;
     use std::fs;
     use std::path::Path;
-
-    use near_primitives_core::types::ProtocolVersion;
-    use near_primitives_core::version::PROTOCOL_VERSION;
-
-    use crate::epoch_manager::{AllEpochConfig, EpochConfig};
-
-    use super::EpochConfigStore;
-
-    /// Checks that stored epoch config for latest protocol version matches the
-    /// one generated by overrides from genesis config.
-    /// If the test fails, it is either a configuration bug or the stored
-    /// epoch config must be updated.
-    fn test_epoch_config_store(chain_id: &str, genesis_protocol_version: ProtocolVersion) {
-        let genesis_epoch_config = parse_config_file(chain_id, genesis_protocol_version).unwrap();
-        let all_epoch_config = AllEpochConfig::new_with_test_overrides(
-            true,
-            genesis_protocol_version,
-            genesis_epoch_config,
-            chain_id,
-            None,
-        );
-
-        let config_store = EpochConfigStore::for_chain_id(chain_id, None).unwrap();
-        for protocol_version in genesis_protocol_version..=PROTOCOL_VERSION {
-            let stored_config = config_store.get_config(protocol_version);
-            let expected_config = all_epoch_config.generate_epoch_config(protocol_version);
-            if stored_config.as_ref() != &expected_config {
-                println!(
-                    "Mismatching epoch configs for protocol version {protocol_version}.
-                    Please update the appropriate <version>.json file."
-                );
-                println!("stored\n{:#?}", stored_config);
-                println!("expected\n{:#?}", expected_config);
-                panic!("Mismatch for protocol version {protocol_version}");
-            }
-        }
-    }
-
-    #[test]
-    fn test_epoch_config_store_mainnet() {
-        test_epoch_config_store("mainnet", 29);
-    }
-
-    #[test]
-    fn test_epoch_config_store_testnet() {
-        test_epoch_config_store("testnet", 29);
-    }
-
-    #[allow(unused)]
-    fn generate_epoch_configs(chain_id: &str, genesis_protocol_version: ProtocolVersion) {
-        let genesis_epoch_config = parse_config_file(chain_id, genesis_protocol_version).unwrap();
-        let all_epoch_config = AllEpochConfig::new_with_test_overrides(
-            true,
-            genesis_protocol_version,
-            genesis_epoch_config.clone(),
-            chain_id,
-            None,
-        );
-
-        let mut prev_config = genesis_epoch_config;
-        for protocol_version in genesis_protocol_version + 1..=PROTOCOL_VERSION {
-            let next_config = all_epoch_config.generate_epoch_config(protocol_version);
-            if next_config != prev_config {
-                tracing::info!("Writing config for protocol version {}", protocol_version);
-                dump_config_file(&next_config, chain_id, protocol_version);
-            }
-            prev_config = next_config;
-        }
-    }
 
     #[test]
     fn test_dump_epoch_configs_mainnet() {
@@ -778,19 +469,6 @@ mod tests {
         assert_eq!(epoch_config_55, epoch_config_48);
     }
 
-    #[test]
-    #[ignore]
-    fn generate_epoch_configs_mainnet() {
-        generate_epoch_configs("mainnet", 29);
-    }
-
-    #[test]
-    #[ignore]
-    fn generate_epoch_configs_testnet() {
-        generate_epoch_configs("testnet", 29);
-    }
-
-    #[allow(unused)]
     fn parse_config_file(chain_id: &str, protocol_version: ProtocolVersion) -> Option<EpochConfig> {
         let path = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("res/epoch_configs")
@@ -803,18 +481,5 @@ mod tests {
         } else {
             None
         }
-    }
-
-    #[allow(unused)]
-    fn dump_config_file(config: &EpochConfig, chain_id: &str, protocol_version: ProtocolVersion) {
-        let content = serde_json::to_string_pretty(config).unwrap();
-        fs::write(
-            Path::new(env!("CARGO_MANIFEST_DIR"))
-                .join("res/epoch_configs")
-                .join(chain_id)
-                .join(format!("{}.json", protocol_version)),
-            content,
-        )
-        .unwrap()
     }
 }

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -1102,14 +1102,14 @@ impl ShardInfo {
 
 #[cfg(test)]
 mod tests {
-    use crate::epoch_manager::{AllEpochConfig, EpochConfig};
+    use crate::epoch_manager::EpochConfigStore;
     use crate::shard_layout::{
         ShardLayout, ShardLayoutV1, ShardUId, new_shard_ids_vec, new_shards_split_map,
     };
     use itertools::Itertools;
     use near_primitives_core::types::ProtocolVersion;
     use near_primitives_core::types::{AccountId, ShardId};
-    use near_primitives_core::version::{PROTOCOL_VERSION, ProtocolFeature};
+    use near_primitives_core::version::ProtocolFeature;
     use rand::distributions::Alphanumeric;
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
@@ -1139,19 +1139,8 @@ mod tests {
     impl ShardLayout {
         /// Constructor for tests that need a shard layout for a specific protocol version.
         pub fn for_protocol_version(protocol_version: ProtocolVersion) -> Self {
-            // none of the epoch config fields matter, we only need the shard layout
-            // constructed through [`AllEpochConfig::for_protocol_version()`].
-            let genesis_epoch_config = EpochConfig::minimal();
-
-            let genesis_protocol_version = PROTOCOL_VERSION;
-            let all_epoch_config = AllEpochConfig::new(
-                true,
-                genesis_protocol_version,
-                genesis_epoch_config,
-                "test-chain",
-            );
-            let latest_epoch_config = all_epoch_config.for_protocol_version(protocol_version);
-            latest_epoch_config.shard_layout
+            let config_store = EpochConfigStore::for_chain_id("mainnet", None).unwrap();
+            config_store.get_config(protocol_version).shard_layout.clone()
         }
     }
 

--- a/tools/database/src/analyze_contract_sizes.rs
+++ b/tools/database/src/analyze_contract_sizes.rs
@@ -2,7 +2,7 @@ use bytesize::ByteSize;
 use clap::Parser;
 use near_chain::{ChainStore, ChainStoreAccess};
 use near_chain_configs::GenesisValidationMode;
-use near_epoch_manager::EpochManager;
+use near_epoch_manager::{EpochManager, EpochManagerAdapter};
 use near_primitives::trie_key::col;
 use near_primitives::types::AccountId;
 use near_store::adapter::StoreAdapter;
@@ -89,8 +89,7 @@ impl AnalyzeContractSizesCommand {
 
         let head = chain_store.head().unwrap();
         let epoch_manager =
-            EpochManager::new_from_genesis_config(store.clone(), &near_config.genesis.config)
-                .unwrap();
+            EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config, None);
         let shard_layout = epoch_manager.get_shard_layout(&head.epoch_id).unwrap();
 
         let mut stats = ContractSizeStats::new(self.topn);

--- a/tools/database/src/analyze_delayed_receipt.rs
+++ b/tools/database/src/analyze_delayed_receipt.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 use near_chain::ChainStore;
 use near_chain::ChainStoreAccess;
 use near_chain_configs::GenesisValidationMode;
-use near_epoch_manager::EpochManager;
+use near_epoch_manager::{EpochManager, EpochManagerAdapter};
 use nearcore::config::load_config;
 
 use near_primitives::hash::CryptoHash;
@@ -52,8 +52,7 @@ impl AnalyzeDelayedReceiptCommand {
             near_config.genesis.config.transaction_validity_period,
         ));
         let epoch_manager =
-            EpochManager::new_from_genesis_config(store.clone(), &near_config.genesis.config)
-                .unwrap();
+            EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config, None);
 
         let tip = chain_store.head().unwrap();
         let shard_layout = epoch_manager.get_shard_layout(&tip.epoch_id).unwrap();

--- a/tools/database/src/analyze_gas_usage.rs
+++ b/tools/database/src/analyze_gas_usage.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use clap::Parser;
 use near_chain::{Block, ChainStore};
 use near_chain_configs::GenesisValidationMode;
-use near_epoch_manager::EpochManager;
+use near_epoch_manager::{EpochManager, EpochManagerAdapter, EpochManagerHandle};
 use nearcore::config::load_config;
 
 use near_primitives::hash::CryptoHash;
@@ -61,8 +61,7 @@ impl AnalyzeGasUsageCommand {
             false,
             near_config.genesis.config.transaction_validity_period,
         ));
-        let epoch_manager =
-            EpochManager::new_from_genesis_config(store, &near_config.genesis.config).unwrap();
+        let epoch_manager = EpochManager::new_arc_handle(store, &near_config.genesis.config, None);
 
         // Create an iterator over the blocks that should be analyzed
         let blocks_iter_opt = make_block_iterator_from_command_args(
@@ -216,7 +215,7 @@ impl GasUsageStats {
 fn get_gas_usage_in_block(
     block: &Block,
     chain_store: &ChainStore,
-    epoch_manager: &EpochManager,
+    epoch_manager: &EpochManagerHandle,
 ) -> GasUsageStats {
     let block_info = epoch_manager.get_block_info(block.hash()).unwrap();
     let epoch_id = block_info.epoch_id();
@@ -323,7 +322,7 @@ fn display_shard_split_stats<'a>(
 fn analyze_gas_usage(
     blocks_iter: impl Iterator<Item = Block>,
     chain_store: &ChainStore,
-    epoch_manager: &EpochManager,
+    epoch_manager: &EpochManagerHandle,
 ) {
     // Gather statistics about gas usage in all of the blocks
     let mut blocks_count: usize = 0;

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -949,9 +949,7 @@ pub(crate) fn print_epoch_info(
         near_config.genesis.config.transaction_validity_period,
     );
     let epoch_manager =
-        EpochManager::new_from_genesis_config(store.clone(), &near_config.genesis.config)
-            .expect("Failed to start Epoch Manager")
-            .into_handle();
+        EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config, None);
 
     epoch_info::print_epoch_info(
         epoch_selection,
@@ -970,8 +968,8 @@ pub(crate) fn print_epoch_analysis(
     store: Store,
 ) {
     let epoch_manager =
-        EpochManager::new_from_genesis_config(store.clone(), &near_config.genesis.config)
-            .expect("Failed to start Epoch Manager");
+        EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config, None);
+    let epoch_manager = epoch_manager.read();
 
     let epoch_ids = iterate_and_filter(store, |_| true);
     let epoch_infos: HashMap<EpochId, Arc<EpochInfo>> = HashMap::from_iter(

--- a/tools/state-viewer/src/trie_iteration_benchmark.rs
+++ b/tools/state-viewer/src/trie_iteration_benchmark.rs
@@ -1,5 +1,5 @@
 use near_chain::{ChainStore, ChainStoreAccess};
-use near_epoch_manager::EpochManager;
+use near_epoch_manager::{EpochManager, EpochManagerAdapter};
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::state_record::{StateRecord, state_record_to_account_id};
@@ -113,8 +113,7 @@ impl TrieIterationBenchmarkCmd {
         );
         let head = chain_store.head().unwrap();
         let block = chain_store.get_block(&head.last_block_hash).unwrap();
-        let epoch_manager =
-            EpochManager::new_from_genesis_config(store.clone(), &genesis_config).unwrap();
+        let epoch_manager = EpochManager::new_arc_handle(store.clone(), &genesis_config, None);
         let shard_layout = epoch_manager.get_shard_layout(block.header().epoch_id()).unwrap();
 
         for (shard_index, chunk_header) in block.chunks().iter_deprecated().enumerate() {


### PR DESCRIPTION
Follow up on issue #11265 

We've had both epoch config in files and epoch config generated. At this point it seems like it's fine to stabilize reading config from config files.

Simplify the AllEpochConfig and EpochManager constructors and remove some tests that were too specific to be useful.