### PR TITLE
benchmark: add shortcut to mirror.py

### DIFF
--- a/benchmarks/sharded-bm/README.md
+++ b/benchmarks/sharded-bm/README.md
@@ -154,6 +154,14 @@ export FORKNET_START_HEIGHT=<forknet start height>
 
 Grafana mostly, [Blockchain utilization dashboard](https://grafana.nearone.org/goto/3bS1Lr2Ng?orgId=1).
 
+### Forknet specific commands
+
+- Shortcut to call `mirror.py`:
+
+    ```sh
+    ./bench.sh mirror <ARGS>
+    ```
+
 ### Known issues
 
 - starting and stopping `neard` in forknet could be done with `mirror` commands

--- a/benchmarks/sharded-bm/bench.sh
+++ b/benchmarks/sharded-bm/bench.sh
@@ -4,7 +4,7 @@
 
 set -o errexit
 
-CASE="${2:-$CASE}"
+CASE="${CASE:-$2}"
 BM_PARAMS=${CASE}/params.json
 
 if ! [[ -d $CASE ]]; then
@@ -88,6 +88,13 @@ else
 fi
 
 RPC_URL="http://${RPC_ADDR}"
+
+mirror_cmd() {
+    shift
+    cd ${PYTEST_PATH}
+    $MIRROR --host-type nodes "$@"
+    cd -
+}
 
 start_nodes_forknet() {
     cd ${PYTEST_PATH}
@@ -644,6 +651,10 @@ stop-injection)
     stop_injection
     ;;
 
+mirror)
+    mirror_cmd "$@"
+    ;;
+
 # Forknet specific methods, not part of user API.
 tweak-config-forknet-node)
     tweak_config_forknet_node ${2} ${3}
@@ -666,6 +677,6 @@ create-accounts-on-tracked-shard)
     ;;
 
 *)
-    echo "Usage: ${0} {reset|init|tweak-config|create-accounts|native-transfers|monitor|start-nodes|stop-nodes|stop-injection} <CASE>"
+    echo "Usage: ${0} {reset|init|tweak-config|create-accounts|native-transfers|monitor|start-nodes|stop-nodes|stop-injection|mirror}"
     ;;
 esac


### PR DESCRIPTION
Very small change to add a `mirror` command to the bench script, that just calls `mirror.py` on the forknet cluster in use. 