### PR TITLE
Add database rollback-to25 command

### DIFF
--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -66,7 +66,7 @@ pub mod trie;
 pub use crate::config::{Mode, StoreConfig};
 pub use crate::opener::{
     StoreMigrator, StoreOpener, StoreOpenerError, checkpoint_hot_storage_and_cleanup_columns,
-    clear_columns,
+    clear_columns, rollback_database_from_26_to_25,
 };
 
 /// Specifies temperature of a storage.

--- a/core/store/src/opener.rs
+++ b/core/store/src/opener.rs
@@ -700,12 +700,16 @@ pub fn rollback_database_from_26_to_25<'a>(
     }
     println!("Starting rollback");
     let cols_to_drop = [DBCol::ChunkApplyStats];
+    println!("Removing ChunkApplyStats column from hot storage");
     hot_db.clear_cols(&cols_to_drop)?;
     let hot_store = Store::new(Arc::new(hot_db));
+    println!("Setting hot DB version to {}", PREV_DB_VERSION);
     hot_store.set_db_version(PREV_DB_VERSION)?;
     if let Some(mut cold) = cold_db {
+        println!("Removing ChunkApplyStats column from cold storage");
         cold.clear_cols(&cols_to_drop)?;
         let cold_store = Store::new(Arc::new(cold));
+        println!("Setting cold DB version to {}", PREV_DB_VERSION);
         cold_store.set_db_version(PREV_DB_VERSION)?;
     }
     println!("Rollback successful. You can now start neard 2.5");

--- a/core/store/src/opener.rs
+++ b/core/store/src/opener.rs
@@ -687,6 +687,11 @@ pub fn rollback_database_from_26_to_25<'a>(
 ) -> anyhow::Result<()> {
     const PREV_DB_VERSION: DbVersion = 43;
     let opener = StoreOpener::new(home_dir, &config, archival_config);
+
+    // First open in read-only mode to ensure that db version is correct
+    // Opening in ReadWrite mode would create nonexisting columns before failing, corrupting the db :/
+    let _ = opener.open_dbs(Mode::ReadOnly)?;
+
     let (mut hot_db, _hot_snapshot, cold_db, _cold_snapshot) =
         opener.open_dbs(Mode::ReadWriteExisting)?;
     if !get_confirmation() {

--- a/core/store/src/opener.rs
+++ b/core/store/src/opener.rs
@@ -698,6 +698,7 @@ pub fn rollback_database_from_26_to_25<'a>(
         println!("Rollback cancelled.");
         return Ok(());
     }
+    println!("Starting rollback");
     let cols_to_drop = [DBCol::ChunkApplyStats];
     hot_db.clear_cols(&cols_to_drop)?;
     let hot_store = Store::new(Arc::new(hot_db));

--- a/tools/database/src/commands.rs
+++ b/tools/database/src/commands.rs
@@ -11,6 +11,7 @@ use crate::make_snapshot::MakeSnapshotCommand;
 use crate::memtrie::LoadMemTrieCommand;
 use crate::reset_version::ResetVersionCommand;
 use crate::resharding_v2::ReshardingV2Command;
+use crate::rollback_to_25::RollbackTo25Command;
 use crate::run_migrations::RunMigrationsCommand;
 use crate::state_perf::StatePerfCommand;
 use crate::write_to_db::WriteCryptoHashCommand;
@@ -72,6 +73,10 @@ enum SubCommand {
 
     /// Perform on demand resharding V2
     Resharding(ReshardingV2Command),
+
+    /// Rollback the database from format used by neard 2.6 to the format used by neard 2.5.
+    /// Removes ChunkApplyStats column and sets DB version to 43.
+    RollbackTo25(RollbackTo25Command),
 }
 
 impl DatabaseCommand {
@@ -103,6 +108,7 @@ impl DatabaseCommand {
                 let near_config = load_config(home, genesis_validation);
                 cmd.run(near_config, home)
             }
+            SubCommand::RollbackTo25(cmd) => cmd.run(home, genesis_validation),
         }
     }
 }

--- a/tools/database/src/lib.rs
+++ b/tools/database/src/lib.rs
@@ -13,6 +13,7 @@ mod make_snapshot;
 mod memtrie;
 mod reset_version;
 mod resharding_v2;
+mod rollback_to_25;
 mod run_migrations;
 mod state_perf;
 mod utils;

--- a/tools/database/src/rollback_to_25.rs
+++ b/tools/database/src/rollback_to_25.rs
@@ -1,0 +1,24 @@
+use clap::Parser;
+use near_chain_configs::GenesisValidationMode;
+use std::path::Path;
+
+/// Rollback the database from format used by neard 2.6 to the format used by neard 2.5.
+/// Removes ChunkApplyStats column and sets DB version to 43.
+#[derive(Parser)]
+pub(crate) struct RollbackTo25Command;
+
+impl RollbackTo25Command {
+    pub(crate) fn run(
+        &self,
+        home_dir: &Path,
+        genesis_validation: GenesisValidationMode,
+    ) -> anyhow::Result<()> {
+        let config = nearcore::config::load_config(&home_dir, genesis_validation)?;
+        near_store::rollback_database_from_26_to_25(
+            home_dir,
+            &config.config.store,
+            config.config.archival_config(),
+        )?;
+        Ok(())
+    }
+}

--- a/tools/database/src/rollback_to_25.rs
+++ b/tools/database/src/rollback_to_25.rs
@@ -2,6 +2,8 @@ use clap::Parser;
 use near_chain_configs::GenesisValidationMode;
 use std::path::Path;
 
+use crate::utils::get_user_confirmation;
+
 /// Rollback the database from format used by neard 2.6 to the format used by neard 2.5.
 /// Removes ChunkApplyStats column and sets DB version to 43.
 #[derive(Parser)]
@@ -14,10 +16,20 @@ impl RollbackTo25Command {
         genesis_validation: GenesisValidationMode,
     ) -> anyhow::Result<()> {
         let config = nearcore::config::load_config(&home_dir, genesis_validation)?;
+
+        let get_confirmation = || {
+            get_user_confirmation(
+                "You are about to roll back the database from format used by neard 2.6 to the format used by neard 2.5.
+                Do not interrupt the rollback operation, stopping the process in the middle of it could corrupt the database.
+                Do you want to continue?",
+            )
+        };
+
         near_store::rollback_database_from_26_to_25(
             home_dir,
             &config.config.store,
             config.config.archival_config(),
+            get_confirmation,
         )?;
         Ok(())
     }


### PR DESCRIPTION
Add a command which allows to roll back the database from version 44 (used by 2.6) to version 43 (used by 2.5).
This will allows node operators to roll back their nodes from 2.6 to 2.5 in case something is wrong with 2.6.

We already have `database drop-column` and `database set-version`, and the hope was that these could be used to perform the roll back by first removing the column and the setting the version, but sadly it doesn't work.
`set-version` recreates the `ChunkApplyStats` column, and `drop-column` doesn't work with db version 43, so we can't use both of them in any order.

This command is also safer than the previous to, it's almost impossible to break a node with it.
Running it on database with version 44 will correctly roll it back to 43.
Running it on database with version 43 will panic, storage opener will refuse to open the database.
The only real problem can happen if a user kills the process during the rollback process, but luckily it's pretty quick so that's unlikely to happen.

This command will be present on `2.6.0`, I don't plan to merge it into `master`, it's 2.6 - specific

I tested it on a local node.