### PR TITLE
Chore: Benchmark workflow fix

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Install jq json processor
-        run: sudo apt install jq
+        run: sudo apt-get update && apt-get install jq
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Install jq json processor
-        run: sudo apt-get update && apt-get install jq
+        run: sudo apt-get update && sudo apt-get install jq
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tx-injection-single-node:
     name: "tx injections single-node benchmark"
-    runs-on: warp-ubuntu-2204-x64-16x
+    runs-on: warp-ubuntu-2404-x64-16x
     timeout-minutes: 60
     if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
 


### PR DESCRIPTION
Changing ubuntu version as we need jq 1.7.1 and ubuntu 22 comes with 1.6.2
https://packages.ubuntu.com/search?keywords=jq