### PR TITLE
[limited replayability] Isolate genesis epoch config initialization code

### DIFF
--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -840,7 +840,12 @@ pub trait EpochManagerAdapter: Send + Sync {
 
 impl EpochManagerAdapter for EpochManagerHandle {
     fn num_total_parts(&self) -> usize {
-        let seats = self.read().genesis_num_block_producer_seats;
+        let epoch_manager = self.read();
+        let genesis_protocol_version = epoch_manager.reward_calculator.genesis_protocol_version;
+        let seats = epoch_manager
+            .config
+            .for_protocol_version(genesis_protocol_version)
+            .num_block_producer_seats;
         if seats > 1 { seats as usize } else { 2 }
     }
 

--- a/chain/epoch-manager/src/genesis.rs
+++ b/chain/epoch-manager/src/genesis.rs
@@ -1,0 +1,178 @@
+use std::collections::HashMap;
+use std::iter;
+use std::sync::Arc;
+
+use itertools::Itertools;
+use near_primitives::chains::{MAINNET, TESTNET};
+use near_primitives::epoch_block_info::BlockInfo;
+use near_primitives::epoch_info::{EpochInfo, EpochInfoV2, RngSeed};
+use near_primitives::epoch_manager::EpochConfig;
+use near_primitives::errors::EpochError;
+use near_primitives::hash::CryptoHash;
+use near_primitives::types::validator_stake::ValidatorStake;
+use near_primitives::types::{AccountId, Balance, EpochId, NumSeats, ValidatorId};
+use near_primitives::version::PROD_GENESIS_PROTOCOL_VERSION;
+use rand::{RngCore, SeedableRng};
+use rand_hc::Hc128Rng;
+
+use crate::EpochManager;
+use crate::proposals::find_threshold;
+use crate::validator_selection::proposals_to_epoch_info;
+
+impl EpochManager {
+    pub fn initialize_genesis_epoch_info(
+        &mut self,
+        validators: Vec<ValidatorStake>,
+    ) -> Result<(), EpochError> {
+        let genesis_epoch_info = self.make_genesis_epoch_info(validators)?;
+        // Dummy block info.
+        // Artificial block we add to simplify implementation: dummy block is the
+        // parent of genesis block that points to itself.
+        // If we view it as block in epoch -1 and height -1, it naturally extends the
+        // EpochId formula using T-2 for T=1, and height field is unused.
+        let block_info = Arc::new(BlockInfo::default());
+        let mut store_update = self.store.store_update();
+        self.save_epoch_info(&mut store_update, &EpochId::default(), Arc::new(genesis_epoch_info))?;
+        self.save_block_info(&mut store_update, block_info)?;
+        store_update.commit()?;
+        Ok(())
+    }
+
+    fn make_genesis_epoch_info(
+        &self,
+        validators: Vec<ValidatorStake>,
+    ) -> Result<EpochInfo, EpochError> {
+        // Missing genesis epoch, means that there is no validator initialize yet.
+        let genesis_protocol_version = self.reward_calculator.genesis_protocol_version;
+        let genesis_epoch_config = self.config.for_protocol_version(genesis_protocol_version);
+        let validator_reward =
+            HashMap::from([(self.reward_calculator.protocol_treasury_account.clone(), 0u128)]);
+
+        // use custom code for genesis protocol version 29 used in mainnet and testnet
+        if genesis_protocol_version == PROD_GENESIS_PROTOCOL_VERSION {
+            let genesis_epoch_info =
+                Self::prod_genesis(&genesis_epoch_config, [0; 32], validators, validator_reward);
+            let digest = CryptoHash::hash_borsh(&genesis_epoch_info).to_string();
+            if self.config.chain_id() == MAINNET {
+                assert_eq!(digest, "Hsc6BpTrd77H7J29w8uLXQY7bhfQzRDcFyo8Dj2CMZCj");
+            }
+            if self.config.chain_id() == TESTNET {
+                assert_eq!(digest, "6oVGdXcDaLErQ3nHRgZVZVHPkV5gfBjVtYkjWrByrb53");
+            }
+            Ok(genesis_epoch_info)
+        } else {
+            proposals_to_epoch_info(
+                &genesis_epoch_config,
+                [0; 32],
+                &EpochInfo::default(),
+                validators,
+                HashMap::default(),
+                validator_reward,
+                0,
+                genesis_protocol_version,
+                false,
+            )
+        }
+    }
+
+    /// This code is a simplified copy of `old_validator_selection::proposals_to_epoch_info`
+    /// The epoch_info returned by this function is very specific to testnet and mainnet and should
+    /// not be used for other scenarios.
+    ///
+    /// As an additional check, we're asserting the digest of the epoch_info from testnet and mainnet.
+    fn prod_genesis(
+        epoch_config: &EpochConfig,
+        rng_seed: RngSeed,
+        mut validators: Vec<ValidatorStake>,
+        validator_reward: HashMap<AccountId, Balance>,
+    ) -> EpochInfo {
+        // Sort all validators by account id.
+        validators.sort_by_cached_key(|v| v.account_id().clone());
+
+        let validator_to_index = validators
+            .iter()
+            .enumerate()
+            .map(|(index, s)| (s.account_id().clone(), index as ValidatorId))
+            .collect();
+
+        let stake_change = validators.iter().map(|v| (v.account_id().clone(), v.stake())).collect();
+
+        // Get the threshold given current number of seats and stakes.
+        let num_hidden_validator_seats: NumSeats =
+            epoch_config.avg_hidden_validator_seats_per_shard.iter().sum();
+        let num_total_seats = epoch_config.num_block_producer_seats + num_hidden_validator_seats;
+        let stakes = validators.iter().map(|v| v.stake()).collect_vec();
+        let threshold = find_threshold(&stakes, num_total_seats).unwrap();
+
+        // Duplicate each proposal for number of seats it has.
+        let mut dup_proposals = validators
+            .iter()
+            .enumerate()
+            .flat_map(|(i, p)| iter::repeat(i as u64).take((p.stake() / threshold) as usize))
+            .collect_vec();
+
+        assert!(dup_proposals.len() >= num_total_seats as usize, "bug in find_threshold");
+        shuffle_duplicate_proposals(&mut dup_proposals, rng_seed);
+
+        // Block producers are first `num_block_producer_seats` proposals.
+        let block_producers_settlement =
+            dup_proposals[..epoch_config.num_block_producer_seats as usize].to_vec();
+
+        // Collect proposals into block producer assignments.
+        let mut chunk_producers_settlement: Vec<Vec<ValidatorId>> = vec![];
+        let mut last_index: u64 = 0;
+        for num_seats_in_shard in epoch_config.num_block_producer_seats_per_shard.iter() {
+            let mut shard_settlement: Vec<ValidatorId> = vec![];
+            for _ in 0..*num_seats_in_shard {
+                let proposal_index = block_producers_settlement[last_index as usize];
+                shard_settlement.push(proposal_index);
+                last_index = (last_index + 1) % epoch_config.num_block_producer_seats;
+            }
+            chunk_producers_settlement.push(shard_settlement);
+        }
+
+        EpochInfo::V2(EpochInfoV2 {
+            epoch_height: 1,
+            validators,
+            validator_to_index,
+            block_producers_settlement,
+            chunk_producers_settlement,
+            hidden_validators_settlement: vec![],
+            fishermen: vec![],
+            fishermen_to_index: Default::default(),
+            stake_change,
+            validator_reward,
+            validator_kickout: Default::default(),
+            minted_amount: 0,
+            seat_price: threshold,
+            protocol_version: PROD_GENESIS_PROTOCOL_VERSION,
+        })
+    }
+}
+
+fn shuffle_duplicate_proposals(dup_proposals: &mut Vec<u64>, rng_seed: RngSeed) {
+    let mut rng: Hc128Rng = SeedableRng::from_seed(rng_seed);
+    for i in (1..dup_proposals.len()).rev() {
+        dup_proposals.swap(i, gen_index_old(&mut rng, (i + 1) as u64) as usize);
+    }
+}
+
+fn gen_index_old(rng: &mut Hc128Rng, bound: u64) -> u64 {
+    // This is a simplified copy of the rand gen_index implementation to ensure that
+    // upgrades to the rand library will not cause a change in the shuffling behavior.
+    let zone = (bound << bound.leading_zeros()).wrapping_sub(1);
+    loop {
+        let v = rng.next_u64();
+        let mul = (v as u128) * (bound as u128);
+        let (hi, lo) = ((mul >> 64) as u64, mul as u64);
+        if lo < zone {
+            return hi;
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_prod_genesis_epoch_info_consistency() {}
+}

--- a/chain/epoch-manager/src/genesis.rs
+++ b/chain/epoch-manager/src/genesis.rs
@@ -170,9 +170,3 @@ fn gen_index_old(rng: &mut Hc128Rng, bound: u64) -> u64 {
         }
     }
 }
-
-#[cfg(test)]
-mod test {
-    #[test]
-    fn test_prod_genesis_epoch_info_consistency() {}
-}

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -18,8 +18,8 @@ use near_primitives::stateless_validation::validator_assignment::ChunkValidatorA
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
     AccountId, ApprovalStake, Balance, BlockChunkValidatorStats, BlockHeight, ChunkStats, EpochId,
-    EpochInfoProvider, NumSeats, ShardId, ValidatorId, ValidatorInfoIdentifier,
-    ValidatorKickoutReason, ValidatorStats,
+    EpochInfoProvider, ShardId, ValidatorId, ValidatorInfoIdentifier, ValidatorKickoutReason,
+    ValidatorStats,
 };
 use near_primitives::version::{ProtocolFeature, ProtocolVersion};
 use near_primitives::views::{
@@ -46,6 +46,7 @@ pub use near_primitives::shard_layout::ShardInfo;
 
 mod adapter;
 pub mod epoch_info_aggregator;
+mod genesis;
 mod metrics;
 mod proposals;
 mod reward_calculator;
@@ -137,9 +138,6 @@ pub struct EpochManager {
     /// Current epoch config.
     config: AllEpochConfig,
     reward_calculator: RewardCalculator,
-    /// Genesis protocol version. Useful when there are protocol upgrades.
-    genesis_protocol_version: ProtocolVersion,
-    genesis_num_block_producer_seats: NumSeats,
 
     /// Cache of epoch information.
     epochs_info: SyncLruCache<EpochId, Arc<EpochInfo>>,
@@ -222,7 +220,6 @@ impl EpochManager {
         genesis_config: &GenesisConfig,
         epoch_config_store: EpochConfigStore,
     ) -> Arc<EpochManagerHandle> {
-        let genesis_protocol_version = genesis_config.protocol_version;
         let epoch_length = genesis_config.epoch_length;
         let reward_calculator = RewardCalculator::new(genesis_config, epoch_length);
         let all_epoch_config = AllEpochConfig::from_epoch_config_store(
@@ -231,37 +228,24 @@ impl EpochManager {
             epoch_config_store,
         );
         Arc::new(
-            Self::new(
-                store,
-                all_epoch_config,
-                genesis_protocol_version,
-                reward_calculator,
-                genesis_config.validators(),
-            )
-            .unwrap()
-            .into_handle(),
+            Self::new(store, all_epoch_config, reward_calculator, genesis_config.validators())
+                .unwrap()
+                .into_handle(),
         )
     }
 
     pub fn new(
         store: Store,
         config: AllEpochConfig,
-        genesis_protocol_version: ProtocolVersion,
         reward_calculator: RewardCalculator,
         validators: Vec<ValidatorStake>,
     ) -> Result<Self, EpochError> {
-        let validator_reward =
-            HashMap::from([(reward_calculator.protocol_treasury_account.clone(), 0u128)]);
         let epoch_info_aggregator =
             store.get_ser(DBCol::EpochInfo, AGGREGATOR_KEY)?.unwrap_or_default();
-        let genesis_num_block_producer_seats =
-            config.for_protocol_version(genesis_protocol_version).num_block_producer_seats;
         let mut epoch_manager = EpochManager {
             store,
             config,
             reward_calculator,
-            genesis_protocol_version,
-            genesis_num_block_producer_seats,
             epochs_info: SyncLruCache::new(EPOCH_CACHE_SIZE),
             blocks_info: SyncLruCache::new(BLOCK_CACHE_SIZE),
             epoch_id_to_start: SyncLruCache::new(EPOCH_CACHE_SIZE),
@@ -274,37 +258,8 @@ impl EpochManager {
             epoch_info_aggregator_loop_counter: Default::default(),
             largest_final_height: 0,
         };
-        let genesis_epoch_id = EpochId::default();
-        if !epoch_manager.has_epoch_info(&genesis_epoch_id)? {
-            // Missing genesis epoch, means that there is no validator initialize yet.
-            let genesis_epoch_config =
-                epoch_manager.config.for_protocol_version(genesis_protocol_version);
-            let epoch_info = proposals_to_epoch_info(
-                &genesis_epoch_config,
-                [0; 32],
-                &EpochInfo::default(),
-                validators,
-                HashMap::default(),
-                validator_reward,
-                0,
-                genesis_protocol_version,
-                genesis_protocol_version,
-                false,
-            )?;
-            // Dummy block info.
-            // Artificial block we add to simplify implementation: dummy block is the
-            // parent of genesis block that points to itself.
-            // If we view it as block in epoch -1 and height -1, it naturally extends the
-            // EpochId formula using T-2 for T=1, and height field is unused.
-            let block_info = Arc::new(BlockInfo::default());
-            let mut store_update = epoch_manager.store.store_update();
-            epoch_manager.save_epoch_info(
-                &mut store_update,
-                &genesis_epoch_id,
-                Arc::new(epoch_info),
-            )?;
-            epoch_manager.save_block_info(&mut store_update, block_info)?;
-            store_update.commit()?;
+        if !epoch_manager.has_epoch_info(&EpochId::default())? {
+            epoch_manager.initialize_genesis_epoch_info(validators)?;
         }
         Ok(epoch_manager)
     }
@@ -733,7 +688,6 @@ impl EpochManager {
                 &validator_stake,
                 *block_info.total_supply(),
                 epoch_protocol_version,
-                self.genesis_protocol_version,
                 epoch_duration,
                 online_thresholds,
             )

--- a/chain/epoch-manager/src/reward_calculator.rs
+++ b/chain/epoch-manager/src/reward_calculator.rs
@@ -34,6 +34,7 @@ pub struct RewardCalculator {
     pub protocol_reward_rate: Rational32,
     pub protocol_treasury_account: AccountId,
     pub num_seconds_per_year: u64,
+    pub genesis_protocol_version: ProtocolVersion,
 }
 
 impl RewardCalculator {
@@ -45,6 +46,7 @@ impl RewardCalculator {
             protocol_reward_rate: config.protocol_reward_rate,
             protocol_treasury_account: config.protocol_treasury_account.clone(),
             num_seconds_per_year: NUM_SECONDS_IN_A_YEAR,
+            genesis_protocol_version: config.protocol_version,
         }
     }
 
@@ -57,13 +59,12 @@ impl RewardCalculator {
         validator_stake: &HashMap<AccountId, Balance>,
         total_supply: Balance,
         protocol_version: ProtocolVersion,
-        genesis_protocol_version: ProtocolVersion,
         epoch_duration: u64,
         online_thresholds: ValidatorOnlineThresholds,
     ) -> (HashMap<AccountId, Balance>, Balance) {
         let mut res = HashMap::new();
         let num_validators = validator_block_chunk_stats.len();
-        let use_hardcoded_value = genesis_protocol_version < protocol_version;
+        let use_hardcoded_value = protocol_version > self.genesis_protocol_version;
         let max_inflation_rate =
             if use_hardcoded_value { Rational32::new_raw(1, 20) } else { self.max_inflation_rate };
         let protocol_reward_rate = if use_hardcoded_value {
@@ -168,6 +169,7 @@ mod tests {
             protocol_reward_rate: Ratio::new(0, 1),
             protocol_treasury_account: "near".parse().unwrap(),
             num_seconds_per_year: 1000000,
+            genesis_protocol_version: PROTOCOL_VERSION,
         };
         let validator_block_chunk_stats = HashMap::from([
             (
@@ -192,7 +194,6 @@ mod tests {
             validator_block_chunk_stats,
             &validator_stake,
             total_supply,
-            PROTOCOL_VERSION,
             PROTOCOL_VERSION,
             epoch_length * NUM_NS_IN_SECOND,
             ValidatorOnlineThresholds {
@@ -222,6 +223,7 @@ mod tests {
             protocol_reward_rate: Ratio::new(0, 10),
             protocol_treasury_account: "near".parse().unwrap(),
             num_seconds_per_year: 1000,
+            genesis_protocol_version: PROTOCOL_VERSION,
         };
         let validator_block_chunk_stats = HashMap::from([
             (
@@ -257,7 +259,6 @@ mod tests {
             &validator_stake,
             total_supply,
             PROTOCOL_VERSION,
-            PROTOCOL_VERSION,
             epoch_length * NUM_NS_IN_SECOND,
             ValidatorOnlineThresholds {
                 online_min_threshold: Ratio::new(9, 10),
@@ -290,6 +291,7 @@ mod tests {
             protocol_reward_rate: Ratio::new(0, 10),
             protocol_treasury_account: "near".parse().unwrap(),
             num_seconds_per_year: 1000,
+            genesis_protocol_version: PROTOCOL_VERSION,
         };
         let validator_block_chunk_stats = HashMap::from([
             (
@@ -337,7 +339,6 @@ mod tests {
             &validator_stake,
             total_supply,
             PROTOCOL_VERSION,
-            PROTOCOL_VERSION,
             epoch_length * NUM_NS_IN_SECOND,
             ValidatorOnlineThresholds {
                 online_min_threshold: Ratio::new(9, 10),
@@ -372,6 +373,7 @@ mod tests {
             protocol_reward_rate: Ratio::new(0, 10),
             protocol_treasury_account: "near".parse().unwrap(),
             num_seconds_per_year: 1000,
+            genesis_protocol_version: PROTOCOL_VERSION,
         };
         let validator_block_chunk_stats = HashMap::from([
             // Blocks, chunks, endorsements
@@ -425,7 +427,6 @@ mod tests {
             &validator_stake,
             total_supply,
             PROTOCOL_VERSION,
-            PROTOCOL_VERSION,
             epoch_length * NUM_NS_IN_SECOND,
             ValidatorOnlineThresholds {
                 online_min_threshold: Ratio::new(9, 10),
@@ -460,6 +461,7 @@ mod tests {
             protocol_reward_rate: Ratio::new(0, 10),
             protocol_treasury_account: "near".parse().unwrap(),
             num_seconds_per_year: 1000,
+            genesis_protocol_version: PROTOCOL_VERSION,
         };
         let validator_block_chunk_stats = HashMap::from([
             // Blocks, chunks, endorsements - endorsement ratio cutoff is exceeded
@@ -513,7 +515,6 @@ mod tests {
             &validator_stake,
             total_supply,
             PROTOCOL_VERSION,
-            PROTOCOL_VERSION,
             epoch_length * NUM_NS_IN_SECOND,
             ValidatorOnlineThresholds {
                 online_min_threshold: Ratio::new(9, 10),
@@ -552,6 +553,7 @@ mod tests {
             protocol_reward_rate: Ratio::new(1, 10),
             protocol_treasury_account: "near".parse().unwrap(),
             num_seconds_per_year: 60 * 60 * 24 * 365,
+            genesis_protocol_version: PROTOCOL_VERSION,
         };
         let validator_block_chunk_stats = HashMap::from([(
             "test".parse().unwrap(),
@@ -570,7 +572,6 @@ mod tests {
             validator_block_chunk_stats,
             &validator_stake,
             total_supply,
-            PROTOCOL_VERSION,
             PROTOCOL_VERSION,
             epoch_length * NUM_NS_IN_SECOND,
             ValidatorOnlineThresholds {

--- a/chain/epoch-manager/src/test_utils.rs
+++ b/chain/epoch-manager/src/test_utils.rs
@@ -177,6 +177,7 @@ pub fn default_reward_calculator() -> RewardCalculator {
         protocol_reward_rate: Ratio::from_integer(0),
         protocol_treasury_account: "near".parse().unwrap(),
         num_seconds_per_year: NUM_SECONDS_IN_A_YEAR,
+        genesis_protocol_version: PROTOCOL_VERSION,
     }
 }
 
@@ -207,7 +208,6 @@ pub fn setup_epoch_manager(
     EpochManager::new(
         store,
         config,
-        PROTOCOL_VERSION,
         reward_calculator,
         validators
             .iter()
@@ -270,7 +270,6 @@ pub fn setup_epoch_manager_with_block_and_chunk_producers(
     let epoch_manager = EpochManager::new(
         store,
         config,
-        PROTOCOL_VERSION,
         default_reward_calculator(),
         validators
             .iter()


### PR DESCRIPTION
In EpochManager initialization, we had a code path setting up the genesis EpochInfo that relied on the genesis protocol version.

In this PR, we separate out the initialization of genesis EpochInfo for mainnet/testnet from the rest of the codebase making it easier to remove old code.

This is similar to what we did in #13158 