### PR TITLE
state sync: correctly handle missing blocks

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1699,12 +1699,7 @@ impl Chain {
         let tail_block = self.get_block(&tail_block_hash)?;
 
         let new_tail = tail_block.header().height();
-        let new_chunk_tail = tail_block
-            .chunks()
-            .iter_deprecated()
-            .map(|chunk| chunk.height_included())
-            .min()
-            .unwrap();
+        let new_chunk_tail = tail_block.chunks().min_height_included().unwrap();
         tracing::debug!(target: "sync", ?new_tail, ?new_chunk_tail, "adjusting tail for sync blocks");
 
         let tip = Tip::from_header(prev_block.header());

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1418,13 +1418,8 @@ impl Chain {
             Chain::get_prev_chunk_headers(self.epoch_manager.as_ref(), &prev_block)?;
         let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(&prev_block_hash)?;
 
-        let (is_caught_up, _) = self.get_catchup_and_state_sync_infos(
-            &epoch_id,
-            None,
-            &prev_block_hash,
-            prev_prev_hash,
-            me,
-        )?;
+        let (is_caught_up, _) =
+            self.get_catchup_and_state_sync_infos(None, &prev_block_hash, prev_prev_hash, me)?;
 
         let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
         let chunks = Chunks::from_chunk_headers(&chunk_headers, block_height);
@@ -2388,7 +2383,6 @@ impl Chain {
         }
 
         let (is_caught_up, state_sync_info) = self.get_catchup_and_state_sync_infos(
-            header.epoch_id(),
             Some(header.hash()),
             &prev_hash,
             prev_prev_hash,
@@ -2495,7 +2489,6 @@ impl Chain {
     /// returns it as well.
     fn get_catchup_and_state_sync_infos(
         &self,
-        epoch_id: &EpochId,
         block_hash: Option<&CryptoHash>,
         prev_hash: &CryptoHash,
         prev_prev_hash: &CryptoHash,
@@ -2516,7 +2509,7 @@ impl Chain {
         // we consider that we are caught up, otherwise not
         let state_sync_info = match block_hash {
             Some(block_hash) => {
-                self.shard_tracker.get_state_sync_info(me, epoch_id, block_hash, prev_hash)?
+                self.shard_tracker.get_state_sync_info(me, block_hash, prev_hash)?
             }
             None => None,
         };

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1694,37 +1694,23 @@ impl Chain {
         let prev_hash = *header.prev_hash();
         let prev_block = self.get_block(&prev_hash)?;
 
-        // TODO(current_epoch_state_sync): fix this when syncing to the current epoch's state
-        // The congestion control added a dependency on the prev block when
-        // applying chunks in a block. This means that we need to keep the
-        // blocks at sync hash, prev hash and prev prev hash.
-        // Due to epoch finalization restrictions these blocks have consecutive heights,
-        // so the height of the prev prev block is sync_height - 2.
-        let mut new_tail = prev_block.header().height().saturating_sub(1);
+        // Check which blocks were downloaded during state sync
+        // and set the tail and chunk tail accordingly
+        let tail_block_hash = self
+            .get_extra_sync_block_hashes(&prev_hash)
+            .into_iter()
+            .min_by_key(|block_hash| self.get_block_header(block_hash).unwrap().height())
+            .unwrap_or(prev_hash);
+        let tail_block = self.get_block(&tail_block_hash)?;
 
-        // In case there are missing chunks we need to keep more than just the
-        // sync hash block. The logic below adjusts the new_tail so that every
-        // shard is guaranteed to have at least one new chunk in the blocks
-        // leading to the sync hash block.
-        let min_height_included = prev_block
+        let new_tail = tail_block.header().height();
+        let new_chunk_tail = tail_block
             .chunks()
             .iter_deprecated()
             .map(|chunk| chunk.height_included())
             .min()
             .unwrap();
-
-        tracing::debug!(target: "sync", ?min_height_included, ?new_tail, "adjusting tail for missing chunks");
-        new_tail = std::cmp::min(new_tail, min_height_included.saturating_sub(1));
-
-        // In order to find the right new_chunk_tail we need to find the minimum
-        // of chunk height_created for chunks in the new tail block.
-        let new_tail_block = self.get_block_by_height(new_tail)?;
-        let new_chunk_tail = new_tail_block
-            .chunks()
-            .iter_deprecated()
-            .map(|chunk| chunk.height_created())
-            .min()
-            .unwrap();
+        tracing::debug!(target: "sync", ?new_tail, ?new_chunk_tail, "adjusting tail for sync blocks");
 
         let tip = Tip::from_header(prev_block.header());
         let final_head = Tip::from_header(self.genesis.header());
@@ -2167,7 +2153,16 @@ impl Chain {
 
         let shard_layout = self.epoch_manager.get_shard_layout(epoch_id)?;
 
-        let last_final_block = self.get_block(&last_final_block_hash)?;
+        // If the full block is not available, skip getting candidate.
+        // This is possible if the node just went through state sync.
+        let Ok(last_final_block) = self.get_block(&last_final_block_hash) else {
+            tracing::warn!(
+                "get_new_flat_storage_head could not get last final block {}",
+                last_final_block_hash
+            );
+            return Ok(None);
+        };
+
         let last_final_block_epoch_id = last_final_block.header().epoch_id();
         // If shard layout was changed, the update is impossible so we skip
         // getting candidate.
@@ -3514,28 +3509,13 @@ impl Chain {
             return Ok(SnapshotAction::None);
         }
 
-        let is_epoch_boundary =
-            self.epoch_manager.is_next_block_epoch_start(&head.last_block_hash)?;
-        let next_block_epoch =
-            self.epoch_manager.get_epoch_id_from_prev_block(&head.last_block_hash)?;
-        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&next_block_epoch)?;
-
-        if !ProtocolFeature::CurrentEpochStateSync.enabled(protocol_version) {
-            if is_epoch_boundary {
-                // Here we return head.last_block_hash as the prev_hash of the first block of the next epoch
-                Ok(SnapshotAction::MakeSnapshot(head.last_block_hash))
-            } else {
-                Ok(SnapshotAction::None)
-            }
+        let is_sync_prev = self.state_sync_adapter.is_sync_prev_hash(&head)?;
+        if is_sync_prev {
+            // Here the head block is the prev block of what the sync hash will be, and the previous
+            // block is the point in the chain we want to snapshot state for
+            Ok(SnapshotAction::MakeSnapshot(head.last_block_hash))
         } else {
-            let is_sync_prev = self.state_sync_adapter.is_sync_prev_hash(&head)?;
-            if is_sync_prev {
-                // Here the head block is the prev block of what the sync hash will be, and the previous
-                // block is the point in the chain we want to snapshot state for
-                Ok(SnapshotAction::MakeSnapshot(head.last_block_hash))
-            } else {
-                Ok(SnapshotAction::None)
-            }
+            Ok(SnapshotAction::None)
         }
     }
 

--- a/chain/chain/src/state_sync/utils.rs
+++ b/chain/chain/src/state_sync/utils.rs
@@ -284,7 +284,6 @@ impl Chain {
     ///
     ///  - set_state_finalize upon completing state sync
     ///  - collect_incoming_receipts_from_chunks when processing blocks after state sync
-    ///
     pub fn get_extra_sync_block_hashes(&self, sync_prev_hash: &CryptoHash) -> Vec<CryptoHash> {
         // Get the sync prev block. It's possible that the block is not yet available.
         // It's ok because we will retry this method later.
@@ -293,9 +292,9 @@ impl Chain {
         };
 
         let min_height_included =
-            sync_prev_block.chunks().iter_deprecated().map(|chunk| chunk.height_included()).min();
+            sync_prev_block.chunks().iter_raw().map(|chunk| chunk.height_included()).min();
         let Some(min_height_included) = min_height_included else {
-            tracing::warn!(target: "sync", ?sync_prev_hash, "get_sync_needed_block_hashes: Cannot find the min block height");
+            tracing::warn!(target: "sync", ?sync_prev_hash, "get_extra_sync_block_hashes: Cannot find the min block height");
             return vec![];
         };
 
@@ -304,7 +303,7 @@ impl Chain {
         loop {
             let next_header = self.get_block_header(&next_hash);
             let Ok(next_header) = next_header else {
-                tracing::error!(target: "sync", hash=?next_hash, "get_sync_needed_block_hashes: Cannot get block header");
+                tracing::error!(target: "sync", hash=?next_hash, "get_extra_sync_block_hashes: Cannot get block header");
                 break;
             };
 

--- a/chain/chain/src/state_sync/utils.rs
+++ b/chain/chain/src/state_sync/utils.rs
@@ -2,7 +2,6 @@ use near_chain_primitives::error::Error;
 use near_primitives::block::Tip;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::EpochId;
-use near_primitives::version::ProtocolFeature;
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::chain_store::ChainStoreAdapter;
 use near_store::{DBCol, Store, StoreUpdate};
@@ -243,7 +242,6 @@ pub(crate) fn is_sync_prev_hash(chain_store: &ChainStoreAdapter, tip: &Tip) -> R
 }
 
 impl Chain {
-    // TODO(current_epoch_state_sync): move state sync related code to state sync files
     /// Find the hash that should be used as the reference point when requesting state sync
     /// headers and parts from other nodes for the epoch the block with hash `block_hash` belongs to.
     /// If syncing to the state of that epoch (the new way), this block hash might not yet be known,
@@ -255,23 +253,11 @@ impl Chain {
             return Ok(None);
         }
         let header = self.get_block_header(block_hash)?;
-        let protocol_version = self.epoch_manager.get_epoch_protocol_version(header.epoch_id())?;
-        if ProtocolFeature::CurrentEpochStateSync.enabled(protocol_version) {
-            self.chain_store.get_current_epoch_sync_hash(header.epoch_id())
-        } else {
-            // In the first epoch, it doesn't make sense to sync state to the previous epoch.
-            if header.epoch_id() == &EpochId::default() {
-                return Ok(None);
-            }
-            Ok(Some(*self.epoch_manager.get_block_info(block_hash)?.epoch_first_block()))
-        }
+        self.chain_store.get_current_epoch_sync_hash(header.epoch_id())
     }
 
     /// Select the block hash we are using to sync state. It will sync with the state before applying the
     /// content of such block.
-    ///
-    /// The selected block will always be the first block on a new epoch:
-    /// <https://github.com/nearprotocol/nearcore/issues/2021#issuecomment-583039862>.
     pub fn find_sync_hash(&self) -> Result<Option<CryptoHash>, Error> {
         let header_head = self.header_head()?;
         let sync_hash = match self.get_sync_hash(&header_head.last_block_hash)? {
@@ -290,45 +276,45 @@ impl Chain {
         Ok(Some(sync_hash))
     }
 
-    /// Returns the list of extra block hashes for blocks that should be
-    /// downloaded before the state sync. The extra blocks are needed when there
-    /// are missing chunks in blocks leading to the sync hash block. We need to
-    /// ensure that for every shard we have at least one new chunk.
+    /// Returns the hashes of all extra blocks which must be downloaded for state sync.
+    /// Excludes the sync hash block and its prev block.
     ///
-    /// This is implemented by finding the minimum height included of the sync
-    /// hash block and finding all blocks till that height.
-    pub fn get_extra_sync_block_hashes(&self, block_hash: CryptoHash) -> Vec<CryptoHash> {
-        // Get the block. It's possible that the block is not yet available.
+    /// For each shard, the node needs blocks going back to (and including)
+    /// the last new chunk before the sync hash block, to be used in:
+    ///
+    ///  - set_state_finalize upon completing state sync
+    ///  - collect_incoming_receipts_from_chunks when processing blocks after state sync
+    ///
+    pub fn get_extra_sync_block_hashes(&self, sync_prev_hash: &CryptoHash) -> Vec<CryptoHash> {
+        // Get the sync prev block. It's possible that the block is not yet available.
         // It's ok because we will retry this method later.
-        let block = self.get_block(&block_hash);
-        let Ok(block) = block else {
+        let Ok(sync_prev_block) = self.get_block(&sync_prev_hash) else {
             return vec![];
         };
 
         let min_height_included =
-            block.chunks().iter_deprecated().map(|chunk| chunk.height_included()).min();
+            sync_prev_block.chunks().iter_deprecated().map(|chunk| chunk.height_included()).min();
         let Some(min_height_included) = min_height_included else {
-            tracing::warn!(target: "sync", ?block_hash, "get_extra_sync_block_hashes: Cannot find the min block height");
+            tracing::warn!(target: "sync", ?sync_prev_hash, "get_sync_needed_block_hashes: Cannot find the min block height");
             return vec![];
         };
 
         let mut extra_block_hashes = vec![];
-        let mut next_hash = *block.header().prev_hash();
+        let mut next_hash = *sync_prev_block.header().prev_hash();
         loop {
             let next_header = self.get_block_header(&next_hash);
             let Ok(next_header) = next_header else {
-                tracing::error!(target: "sync", hash=?next_hash, "get_extra_sync_block_hashes: Cannot get block header");
+                tracing::error!(target: "sync", hash=?next_hash, "get_sync_needed_block_hashes: Cannot get block header");
                 break;
             };
 
-            if next_header.height() + 1 < min_height_included {
+            if next_header.height() < min_height_included {
                 break;
             }
-
             extra_block_hashes.push(next_hash);
+
             next_hash = *next_header.prev_hash();
         }
-
         extra_block_hashes
     }
 }

--- a/chain/chain/src/state_sync/utils.rs
+++ b/chain/chain/src/state_sync/utils.rs
@@ -291,9 +291,7 @@ impl Chain {
             return vec![];
         };
 
-        let min_height_included =
-            sync_prev_block.chunks().iter_raw().map(|chunk| chunk.height_included()).min();
-        let Some(min_height_included) = min_height_included else {
+        let Some(min_height_included) = sync_prev_block.chunks().min_height_included() else {
             tracing::warn!(target: "sync", ?sync_prev_hash, "get_extra_sync_block_hashes: Cannot find the min block height");
             return vec![];
         };

--- a/chain/client/src/sync/handler.rs
+++ b/chain/client/src/sync/handler.rs
@@ -23,10 +23,10 @@ use std::sync::Arc;
 // A small helper macro to unwrap a result of some state sync operation. If the
 // result is an error this macro will log it and return from the function.
 #[macro_export]
-macro_rules! unwrap_and_report_state_sync_result (($obj: expr) => (match $obj {
+macro_rules! unwrap_and_report_state_sync_result (($obj: ident) => (match $obj {
     Ok(v) => v,
     Err(err) => {
-        tracing::error!(target: "sync", "Sync: Unexpected error: {}", err);
+        tracing::error!(target: "sync", "Sync: Unexpected error: {}: {}", stringify!($obj), err);
         return None;
     }
 }));
@@ -110,7 +110,8 @@ impl SyncHandler {
         );
         unwrap_and_report_state_sync_result!(header_sync_result);
         // Only body / state sync if header height is close to the latest.
-        let header_head = unwrap_and_report_state_sync_result!(chain.header_head());
+        let chain_header_head = chain.header_head();
+        let header_head = unwrap_and_report_state_sync_result!(chain_header_head);
 
         // We should state sync if it's already started or if we have enough
         // headers and blocks. The should_state_sync method may run block sync.
@@ -151,7 +152,7 @@ impl SyncHandler {
         // Waiting for all the sync blocks to be available because they are
         // needed to finalize state sync.
         if !blocks_to_request.is_empty() {
-            tracing::debug!(target: "sync", "waiting for sync blocks");
+            tracing::debug!(target: "sync", "waiting for sync blocks {:?}", blocks_to_request);
             return Some(SyncHandlerRequest::NeedRequestBlocks(blocks_to_request));
         }
 
@@ -323,7 +324,7 @@ impl SyncHandler {
         let prev_hash = *block_header.prev_hash();
 
         let mut needed_block_hashes = vec![prev_hash, sync_hash];
-        let mut extra_block_hashes = chain.get_extra_sync_block_hashes(prev_hash);
+        let mut extra_block_hashes = chain.get_extra_sync_block_hashes(&prev_hash);
         tracing::trace!(target: "sync", ?needed_block_hashes, ?extra_block_hashes, "request_sync_blocks: block hashes for state sync");
         needed_block_hashes.append(&mut extra_block_hashes);
         let mut blocks_to_request = vec![];

--- a/chain/client/src/sync/handler.rs
+++ b/chain/client/src/sync/handler.rs
@@ -152,7 +152,7 @@ impl SyncHandler {
         // Waiting for all the sync blocks to be available because they are
         // needed to finalize state sync.
         if !blocks_to_request.is_empty() {
-            tracing::debug!(target: "sync", "waiting for sync blocks {:?}", blocks_to_request);
+            tracing::debug!(target: "sync", ?blocks_to_request, "waiting for sync blocks");
             return Some(SyncHandlerRequest::NeedRequestBlocks(blocks_to_request));
         }
 

--- a/chain/epoch-manager/src/shard_tracker.rs
+++ b/chain/epoch-manager/src/shard_tracker.rs
@@ -338,7 +338,6 @@ impl ShardTracker {
     pub fn get_state_sync_info(
         &self,
         me: &Option<AccountId>,
-        epoch_id: &EpochId,
         block_hash: &CryptoHash,
         prev_hash: &CryptoHash,
     ) -> Result<Option<StateSyncInfo>, Error> {
@@ -347,11 +346,9 @@ impl ShardTracker {
             Ok(None)
         } else {
             tracing::debug!(target: "chain", "Downloading state for {:?}, I'm {:?}", shards_to_state_sync, me);
-            let protocol_version = self.epoch_manager.get_epoch_protocol_version(epoch_id)?;
             // Note that this block is the first block in an epoch because this function is only called
             // in get_catchup_and_state_sync_infos() when that is the case.
-            let state_sync_info =
-                StateSyncInfo::new(protocol_version, *block_hash, shards_to_state_sync);
+            let state_sync_info = StateSyncInfo::new(*block_hash, shards_to_state_sync);
             Ok(Some(state_sync_info))
         }
     }

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -221,7 +221,7 @@ pub enum ProtocolFeature {
     /// should no longer be the first block of the epoch, but a couple blocks after that in order
     /// to sync the current epoch's state. This is not strictly a protocol feature, but is included
     /// here to coordinate among nodes
-    CurrentEpochStateSync,
+    _DeprecatedCurrentEpochStateSync,
     /// Relaxed validation of transactions included in a chunk.
     ///
     /// Chunks no longer become entirely invalid in case invalid transactions are included in the
@@ -268,10 +268,12 @@ impl ProtocolFeature {
             ProtocolFeature::_DeprecatedCreateHash => 38,
             ProtocolFeature::_DeprecatedDeleteKeyStorageUsage => 40,
             ProtocolFeature::_DeprecatedShardChunkHeaderUpgrade => 41,
-            ProtocolFeature::_DeprecatedCreateReceiptIdSwitchToCurrentBlock | ProtocolFeature::_DeprecatedLowerStorageCost => 42,
+            ProtocolFeature::_DeprecatedCreateReceiptIdSwitchToCurrentBlock
+            | ProtocolFeature::_DeprecatedLowerStorageCost => 42,
             ProtocolFeature::_DeprecatedDeleteActionRestriction => 43,
             ProtocolFeature::_DeprecatedFixApplyChunks => 44,
-            ProtocolFeature::_DeprecatedRectifyInflation | ProtocolFeature::_DeprecatedAccessKeyNonceRange => 45,
+            ProtocolFeature::_DeprecatedRectifyInflation
+            | ProtocolFeature::_DeprecatedAccessKeyNonceRange => 45,
             ProtocolFeature::_DeprecatedAccountVersions
             | ProtocolFeature::_DeprecatedTransactionSizeLimit
             | ProtocolFeature::_DeprecatedFixStorageUsage
@@ -326,11 +328,8 @@ impl ProtocolFeature {
             | ProtocolFeature::FixChunkProducerStakingThreshold
             | ProtocolFeature::_DeprecatedRelaxedChunkValidation
             | ProtocolFeature::_DeprecatedRemoveCheckBalance
-            // BandwidthScheduler and CurrentEpochStateSync must be enabled
-            // before ReshardingV3! When releasing this feature please make sure
-            // to schedule separate protocol upgrades for these features.
             | ProtocolFeature::BandwidthScheduler
-            | ProtocolFeature::CurrentEpochStateSync => 74,
+            | ProtocolFeature::_DeprecatedCurrentEpochStateSync => 74,
             ProtocolFeature::SimpleNightshadeV4 => 75,
             ProtocolFeature::SimpleNightshadeV5 => 76,
             ProtocolFeature::GlobalContracts
@@ -372,18 +371,3 @@ pub const PROTOCOL_VERSION: ProtocolVersion =
 /// protocol version is lower than this.
 /// TODO(pugachag): revert back to `- 3` after mainnet is upgraded
 pub const PEER_MIN_ALLOWED_PROTOCOL_VERSION: ProtocolVersion = STABLE_PROTOCOL_VERSION - 4;
-
-#[cfg(test)]
-mod tests {
-    use super::ProtocolFeature;
-
-    #[test]
-    fn test_resharding_dependencies() {
-        let state_sync = ProtocolFeature::CurrentEpochStateSync.protocol_version();
-        let bandwidth_scheduler = ProtocolFeature::BandwidthScheduler.protocol_version();
-        let resharding_v3 = ProtocolFeature::SimpleNightshadeV4.protocol_version();
-
-        assert!(state_sync < resharding_v3);
-        assert!(bandwidth_scheduler < resharding_v3);
-    }
-}

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -659,7 +659,7 @@ impl<'a> Chunks<'a> {
         }
     }
 
-    pub fn min_height_included(&self) -> Option<u64> {
+    pub fn min_height_included(&self) -> Option<BlockHeight> {
         self.iter_raw().map(|chunk| chunk.height_included()).min()
     }
 

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -659,6 +659,10 @@ impl<'a> Chunks<'a> {
         }
     }
 
+    pub fn min_height_included(&self) -> Option<u64> {
+        self.iter_raw().map(|chunk| chunk.height_included()).min()
+    }
+
     pub fn block_congestion_info(&self) -> BlockCongestionInfo {
         let mut result = BTreeMap::new();
 

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -102,24 +102,12 @@ pub enum StateSyncInfo {
 }
 
 impl StateSyncInfo {
-    fn new_previous_epoch(epoch_first_block: CryptoHash, shards: Vec<ShardId>) -> Self {
-        Self::V0(StateSyncInfoV0 { sync_hash: epoch_first_block, shards })
-    }
-
-    fn new_current_epoch(epoch_first_block: CryptoHash, shards: Vec<ShardId>) -> Self {
-        Self::V1(StateSyncInfoV1 { epoch_first_block, sync_hash: None, shards })
-    }
-
     pub fn new(
-        protocol_version: ProtocolVersion,
+        _protocol_version: ProtocolVersion,
         epoch_first_block: CryptoHash,
         shards: Vec<ShardId>,
     ) -> Self {
-        if ProtocolFeature::CurrentEpochStateSync.enabled(protocol_version) {
-            Self::new_current_epoch(epoch_first_block, shards)
-        } else {
-            Self::new_previous_epoch(epoch_first_block, shards)
-        }
+        Self::V1(StateSyncInfoV1 { epoch_first_block, sync_hash: None, shards })
     }
 
     /// Block hash that identifies this state sync struct on disk

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -102,11 +102,7 @@ pub enum StateSyncInfo {
 }
 
 impl StateSyncInfo {
-    pub fn new(
-        _protocol_version: ProtocolVersion,
-        epoch_first_block: CryptoHash,
-        shards: Vec<ShardId>,
-    ) -> Self {
+    pub fn new(epoch_first_block: CryptoHash, shards: Vec<ShardId>) -> Self {
         Self::V1(StateSyncInfoV1 { epoch_first_block, sync_hash: None, shards })
     }
 

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -1826,7 +1826,7 @@ fn test_gc_tail_update() {
         )
         .unwrap();
     env.process_block(1, blocks.pop().unwrap(), Provenance::NONE);
-    assert_eq!(env.clients[1].chain.chain_store().tail().unwrap(), prev_sync_height - 1);
+    assert_eq!(env.clients[1].chain.chain_store().tail().unwrap(), prev_sync_height);
 }
 
 /// Test that transaction does not become invalid when there is some gas price change.
@@ -2093,18 +2093,10 @@ fn test_sync_hash_validity() {
             env.produce_block(0, height);
             height += 1;
         }
-        let expected_sync_height =
-            if ProtocolFeature::CurrentEpochStateSync.enabled(PROTOCOL_VERSION) {
-                // This assumes that all shards have new chunks in every block, which should be true
-                // with TestEnv::produce_block()
-                epoch_start + 3
-            } else {
-                // No sync hash in the first epoch
-                if epoch_start < epoch_length {
-                    continue;
-                }
-                epoch_start
-            };
+
+        // This assumes that all shards have new chunks in every block, which should be true
+        // with TestEnv::produce_block()
+        let expected_sync_height = epoch_start + 3;
 
         for h in epoch_start..height {
             let header = env.clients[0].chain.get_block_header_by_height(h).unwrap();
@@ -3693,13 +3685,9 @@ mod contract_precompilation_tests {
             start_height,
         );
 
-        let sync_height = if ProtocolFeature::CurrentEpochStateSync.enabled(PROTOCOL_VERSION) {
-            // `height` is one more than the start of the epoch. Produce two more blocks with chunks,
-            // and then one more than that so the node will generate the needed snapshot.
-            produce_blocks_from_height(&mut env, 4, height) - 2
-        } else {
-            height - 1
-        };
+        // `height` is one more than the start of the epoch. Produce two more blocks with chunks,
+        // and then one more than that so the node will generate the needed snapshot.
+        let sync_height = produce_blocks_from_height(&mut env, 4, height) - 2;
 
         // Perform state sync for the second client.
         state_sync_on_height(&mut env, sync_height);
@@ -3806,13 +3794,9 @@ mod contract_precompilation_tests {
             height,
         );
 
-        let sync_height = if ProtocolFeature::CurrentEpochStateSync.enabled(PROTOCOL_VERSION) {
-            // `height` is one more than the start of the epoch. Produce two more blocks with chunks,
-            // and then one more than that so the node will generate the needed snapshot.
-            produce_blocks_from_height(&mut env, 4, height) - 2
-        } else {
-            height - 1
-        };
+        // `height` is one more than the start of the epoch. Produce two more blocks with chunks,
+        // and then one more than that so the node will generate the needed snapshot.
+        let sync_height = produce_blocks_from_height(&mut env, 4, height) - 2;
 
         // Perform state sync for the second client on the last produced height.
         state_sync_on_height(&mut env, sync_height);
@@ -3884,15 +3868,9 @@ mod contract_precompilation_tests {
             env.tx_request_handlers[0].process_tx(delete_account_tx, false, false),
             ProcessTxResponse::ValidTx
         );
-        // `height` is the first block of a new epoch (which has not been produced yet),
-        // so if we want to state sync the old way, we produce `EPOCH_LENGTH` + 1 new blocks
-        // to get to produce the first block of the next epoch. If we want to state sync the new
-        // way, we produce two more than that, plus one more so that the node will generate the needed snapshot.
-        let sync_height = if ProtocolFeature::CurrentEpochStateSync.enabled(PROTOCOL_VERSION) {
-            produce_blocks_from_height(&mut env, EPOCH_LENGTH + 5, height) - 2
-        } else {
-            produce_blocks_from_height(&mut env, EPOCH_LENGTH + 1, height) - 1
-        };
+        // `height` is the first block of a new epoch (which has not been produced yet).
+        // We produce two more than that, plus one more so that the node will generate the needed snapshot.
+        let sync_height = produce_blocks_from_height(&mut env, EPOCH_LENGTH + 5, height) - 2;
 
         // Perform state sync for the second client.
         state_sync_on_height(&mut env, sync_height);

--- a/integration-tests/src/tests/client/sync_state_nodes.rs
+++ b/integration-tests/src/tests/client/sync_state_nodes.rs
@@ -20,7 +20,6 @@ use near_primitives::state_sync::StatePartKey;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{BlockId, BlockReference, EpochId, EpochReference, ShardId};
 use near_primitives::utils::MaybeValidated;
-use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_store::DBCol;
 use near_store::adapter::StoreUpdateAdapter;
 use nearcore::{load_test_config, start_with_config};
@@ -476,31 +475,16 @@ fn ultra_slow_test_dump_epoch_missing_chunk_in_last_block() {
             let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
 
             let next_epoch_start = epoch_length + 1;
-            let protocol_version = env.clients[0]
-                .epoch_manager
-                .get_epoch_protocol_version(&EpochId::default())
-                .unwrap();
             // Note that the height to skip here refers to the height at which not to produce chunks for the next block, so really
             // one before the block height that will have no chunks. The sync_height is the height of the sync_hash block.
-            let (start_skipping_chunks, stop_skipping_chunks, sync_height) =
-                if ProtocolFeature::CurrentEpochStateSync.enabled(protocol_version) {
-                    // At the beginning of the epoch, produce two blocks with chunks and then start skipping chunks.
-                    // The very first block in the epoch does not count towards the number of new chunks we tally when computing
-                    // the sync hash. So after those two blocks, the tally is 1.
-                    let start_skipping_chunks = next_epoch_start + 1;
-                    // Then we will skip `num_chunks_missing` chunks.
-                    let stop_skipping_chunks = start_skipping_chunks + num_chunks_missing;
-                    // Then after one more with new chunks, the next one after that will be the sync block.
-                    let sync_height = stop_skipping_chunks + 2;
-                    (start_skipping_chunks, stop_skipping_chunks, sync_height)
-                } else {
-                    // here the sync hash is the first hash of the epoch
-                    let sync_height = next_epoch_start;
-                    // skip chunks before the epoch start, but not including the one right before the epochs start.
-                    let start_skipping_chunks = sync_height - num_chunks_missing - 1;
-                    let stop_skipping_chunks = sync_height - 1;
-                    (start_skipping_chunks, stop_skipping_chunks, sync_height)
-                };
+            // At the beginning of the epoch, produce two blocks with chunks and then start skipping chunks.
+            // The very first block in the epoch does not count towards the number of new chunks we tally when computing
+            // the sync hash. So after those two blocks, the tally is 1.
+            let start_skipping_chunks = next_epoch_start + 1;
+            // Then we will skip `num_chunks_missing` chunks.
+            let stop_skipping_chunks = start_skipping_chunks + num_chunks_missing;
+            // Then after one more with new chunks, the next one after that will be the sync block.
+            let sync_height = stop_skipping_chunks + 2;
 
             assert!(sync_height < 2 * epoch_length + 1);
 
@@ -748,13 +732,9 @@ fn slow_test_state_sync_headers() {
                 };
                 tracing::info!(epoch_start_height, "got epoch_start_height");
 
-                let sync_height =
-                    if ProtocolFeature::CurrentEpochStateSync.enabled(PROTOCOL_VERSION) {
-                        // here since there's only one block/chunk producer, we assume that no blocks will be missing chunks.
-                        epoch_start_height + 3
-                    } else {
-                        epoch_start_height
-                    };
+                // here since there's only one block/chunk producer, we assume that no blocks will be missing chunks.
+                let sync_height = epoch_start_height + 3;
+
                 let block_id = BlockReference::BlockId(BlockId::Height(sync_height));
                 let block_view = view_client1.send(GetBlock(block_id).with_span_context()).await;
                 let Ok(Ok(block_view)) = block_view else {
@@ -933,13 +913,9 @@ fn slow_test_state_sync_headers_no_tracked_shards() {
                     return ControlFlow::Continue(());
                 }
 
-                let sync_height =
-                    if ProtocolFeature::CurrentEpochStateSync.enabled(PROTOCOL_VERSION) {
-                        // here since there's only one block/chunk producer, we assume that no blocks will be missing chunks.
-                        epoch_start_height + 3
-                    } else {
-                        epoch_start_height
-                    };
+                // here since there's only one block/chunk producer, we assume that no blocks will be missing chunks.
+                let sync_height = epoch_start_height + 3;
+
                 let block_id = BlockReference::BlockId(BlockId::Height(sync_height));
                 let block_view = view_client2.send(GetBlock(block_id).with_span_context()).await;
                 let Ok(Ok(block_view)) = block_view else {

--- a/test-loop-tests/src/tests/state_sync.rs
+++ b/test-loop-tests/src/tests/state_sync.rs
@@ -15,9 +15,9 @@ use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{
     AccountId, AccountInfo, BlockHeight, BlockHeightDelta, Nonce, NumSeats, ShardId,
 };
-use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
+use near_primitives::version::PROTOCOL_VERSION;
 
-use crate::setup::builder::TestLoopBuilder;
+use crate::setup::builder::{NodeStateBuilder, TestLoopBuilder};
 use crate::setup::drop_condition::DropCondition;
 use crate::setup::env::TestLoopEnv;
 use crate::setup::state::NodeExecutionData;
@@ -28,7 +28,9 @@ use itertools::Itertools;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
-const EPOCH_LENGTH: BlockHeightDelta = 40;
+const GENESIS_HEIGHT: BlockHeight = 10000;
+
+const EPOCH_LENGTH: BlockHeightDelta = 10;
 
 fn get_boundary_accounts(num_shards: usize) -> Vec<String> {
     if num_shards > 27 {
@@ -75,6 +77,15 @@ struct TestState {
     skip_block_height: Option<BlockHeight>,
 }
 
+fn sync_height() -> BlockHeight {
+    // It would probably be better not to rely on this height calculation, since that makes
+    // some assumptions about the state sync protocol that ideally tests wouldn't make. In the future
+    // it would be nice to modify `drop_blocks_by_height()` to allow for more complex logic to decide
+    // whether to drop the block, and be more robust to state sync protocol changes. But for now this
+    // will trigger the behavior we want and it's quite a bit easier.
+    GENESIS_HEIGHT + EPOCH_LENGTH + 4
+}
+
 fn setup_initial_blockchain(
     num_validators: usize,
     num_block_producer_seats: usize,
@@ -119,8 +130,6 @@ fn setup_initial_blockchain(
     let accounts =
         if generate_shard_accounts { Some(generate_accounts(&boundary_accounts)) } else { None };
 
-    let epoch_length = 10;
-    let genesis_height = 10000;
     let shard_layout =
         ShardLayout::simple_v1(&boundary_accounts.iter().map(|s| s.as_str()).collect::<Vec<_>>());
     let validators_spec = ValidatorsSpec::raw(
@@ -133,8 +142,8 @@ fn setup_initial_blockchain(
     let mut genesis_builder = TestGenesisBuilder::new()
         .genesis_time_from_clock(&builder.clock())
         .protocol_version(PROTOCOL_VERSION)
-        .genesis_height(genesis_height)
-        .epoch_length(epoch_length)
+        .genesis_height(GENESIS_HEIGHT)
+        .epoch_length(EPOCH_LENGTH)
         .shard_layout(shard_layout.clone())
         .transaction_validity_period(1000)
         .validators_spec(validators_spec.clone());
@@ -149,7 +158,7 @@ fn setup_initial_blockchain(
     let genesis = genesis_builder.build();
 
     let epoch_config = TestEpochConfigBuilder::new()
-        .epoch_length(epoch_length)
+        .epoch_length(EPOCH_LENGTH)
         .shard_layout(shard_layout)
         .validators_spec(validators_spec)
         // shuffle the shard assignment so that nodes will have to state sync to catch up future tracked shards.
@@ -164,16 +173,7 @@ fn setup_initial_blockchain(
         builder.genesis(genesis).epoch_config_store(epoch_config_store).clients(clients).build();
 
     let skip_block_height = if let Some(delta) = skip_block_sync_height_delta {
-        // It would probably be better not to rely on this height calculation, since that makes
-        // some assumptions about the state sync protocol that ideally tests wouldn't make. In the future
-        // it would be nice to modify `drop_blocks_by_height()` to allow for more complex logic to decide
-        // whether to drop the block, and be more robust to state sync protocol changes. But for now this
-        // will trigger the behavior we want and it's quite a bit easier.
-        let sync_height = if ProtocolFeature::CurrentEpochStateSync.enabled(PROTOCOL_VERSION) {
-            genesis_height + epoch_length + 4
-        } else {
-            genesis_height + epoch_length + 1
-        };
+        let sync_height = sync_height();
         let height = if delta >= 0 {
             sync_height.saturating_add(delta as BlockHeight)
         } else {
@@ -310,7 +310,7 @@ fn produce_chunks(
                     .map(|test_data| &data.get(&test_data.client_sender.actor_handle()).client)
                     .collect_vec();
                 let new_tip = get_smallest_height_head(&clients);
-                new_tip.height != tip.height
+                new_tip.height > tip.height
             },
             timeout,
         );
@@ -325,7 +325,13 @@ fn produce_chunks(
         let new_tip = get_smallest_height_head(&clients);
 
         let header = clients[0].chain.get_block_header(&tip.last_block_hash).unwrap();
-        tracing::debug!("chunk mask for #{} {:?}", header.height(), header.chunk_mask());
+        tracing::debug!(
+            "chunk mask for #{} {:?} {} {:?}",
+            header.height(),
+            header.chunk_mask(),
+            tip.last_block_hash,
+            tip.epoch_id
+        );
 
         if new_tip.epoch_id != tip.epoch_id {
             epoch_id_switches += 1;
@@ -361,12 +367,70 @@ fn run_test(state: TestState) {
             let handle = env.node_datas[0].client_sender.actor_handle();
             let client = &data.get(&handle).client;
             let tip = client.chain.head().unwrap();
+            let header = client.chain.get_block_header(&tip.last_block_hash).unwrap();
+            tracing::debug!(
+                "chunk mask for #{} {:?} {} {:?}",
+                header.height(),
+                header.chunk_mask(),
+                tip.last_block_hash,
+                tip.epoch_id
+            );
             tip.epoch_id != Default::default()
         },
         first_epoch_time,
     );
 
     produce_chunks(&mut env, accounts, skip_block_height);
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(3));
+}
+
+fn run_test_with_added_node(state: TestState) {
+    let TestState { mut env, mut accounts, skip_block_height } = state;
+
+    if let Some(accounts) = accounts.as_mut() {
+        send_txs_between_shards(&mut env.test_loop, &env.node_datas, accounts);
+    }
+
+    // TODO: due to current limitations of TestLoop we have to wait for the
+    // sync hash block before starting the new node.
+    let sync_hash = await_sync_hash(&mut env);
+
+    // Add new node which will sync from scratch.
+    let genesis = env.shared_state.genesis.clone();
+    let tempdir_path = env.shared_state.tempdir.path().to_path_buf();
+    let account_id: AccountId = "sync-from-scratch".parse().unwrap();
+    let new_node_state = NodeStateBuilder::new(genesis, tempdir_path)
+        .account_id(account_id.clone())
+        .config_modifier(move |config| {
+            // Lower the threshold at which state sync is chosen over block sync
+            config.block_fetch_horizon = 5;
+            // If tracked_shards is non-empty the node tracks all shards
+            config.tracked_shards = vec![ShardId::new(0)];
+        })
+        .build();
+    env.add_node(account_id.as_str(), new_node_state);
+
+    env.test_loop.run_until(
+        |data| {
+            let handle = env.node_datas.last().unwrap().client_sender.actor_handle();
+            let client = &data.get(&handle).client;
+            let new_tip = client.chain.head().unwrap();
+            if new_tip.height > GENESIS_HEIGHT {
+                // Make sure the node catches up through state sync, not block sync.
+                // It will skip straight from genesis to the sync prev block.
+                let sync_header = client.chain.get_block_header(&sync_hash).unwrap();
+                assert!(new_tip.last_block_hash == *sync_header.prev_hash());
+                true
+            } else {
+                false
+            }
+        },
+        Duration::seconds(3),
+    );
+
+    produce_chunks(&mut env, accounts.clone(), skip_block_height);
+
     env.shutdown_and_drain_remaining_events(Duration::seconds(3));
 }
 
@@ -379,7 +443,7 @@ struct StateSyncTest {
     // If true, generate several extra accounts per shard. We have a test with this disabled
     // to test state syncing shards without any account data
     generate_shard_accounts: bool,
-    chunks_produced: &'static [(ShardId, &'static [bool])],
+    chunks_produced: Vec<(ShardId, Vec<bool>)>,
     // If Some(), this delta represents the delta with respect to the expected "sync_hash" block. So
     // a value of 0 will have us generate a skip on the first block that will probably be the sync_hash,
     // and a value of 1 will have us skip the one after that.
@@ -387,105 +451,227 @@ struct StateSyncTest {
     extra_node_shard_schedule: Option<Vec<Vec<ShardId>>>,
 }
 
-static TEST_CASES: &[StateSyncTest] = &[
-    // The first two make no modifications to chunks_produced, and all chunks should be produced. This is the normal case
-    StateSyncTest {
+fn run_state_sync_test_case(t: StateSyncTest) {
+    tracing::info!("run test: {:?}", t);
+    let state = setup_initial_blockchain(
+        t.num_validators,
+        t.num_block_producer_seats,
+        t.num_chunk_producer_seats,
+        t.num_shards,
+        t.generate_shard_accounts,
+        t.chunks_produced
+            .iter()
+            .map(|(shard_id, produced)| (*shard_id, produced.to_vec()))
+            .collect(),
+        t.skip_block_sync_height_delta,
+        &t.extra_node_shard_schedule,
+    );
+    run_test(state);
+
+    tracing::info!("run test with added node: {:?}", t);
+    let state = setup_initial_blockchain(
+        t.num_validators,
+        t.num_block_producer_seats,
+        t.num_chunk_producer_seats,
+        t.num_shards,
+        t.generate_shard_accounts,
+        t.chunks_produced
+            .iter()
+            .map(|(shard_id, produced)| (*shard_id, produced.to_vec()))
+            .collect(),
+        t.skip_block_sync_height_delta,
+        &t.extra_node_shard_schedule,
+    );
+    run_test_with_added_node(state);
+}
+
+// The normal case with 2 nodes and no missing chunks.
+#[test]
+fn slow_test_state_sync_simple_two_node() {
+    init_test_logger();
+    let t = StateSyncTest {
         num_validators: 2,
         num_block_producer_seats: 2,
         num_chunk_producer_seats: 2,
         num_shards: 2,
         generate_shard_accounts: true,
-        chunks_produced: &[],
+        chunks_produced: vec![],
         skip_block_sync_height_delta: None,
         extra_node_shard_schedule: None,
-    },
-    StateSyncTest {
+    };
+    run_state_sync_test_case(t);
+}
+
+// The normal case with 5 nodes and no missing chunks.
+#[test]
+fn slow_test_state_sync_simple_five_node() {
+    init_test_logger();
+    let t = StateSyncTest {
         num_validators: 5,
         num_block_producer_seats: 4,
         num_chunk_producer_seats: 4,
         num_shards: 4,
         generate_shard_accounts: true,
-        chunks_produced: &[],
+        chunks_produced: vec![],
         skip_block_sync_height_delta: None,
         extra_node_shard_schedule: None,
-    },
-    // In this test we have 2 validators and 4 shards, and we don't generate any extra accounts.
-    // That makes 3 accounts including the "near" account. This means at least one shard will have no
-    // accounts in it, so we check that corner case here.
-    StateSyncTest {
+    };
+    run_state_sync_test_case(t);
+}
+
+// In this test we have 2 validators and 4 shards, and we don't generate any extra accounts.
+// That makes 3 accounts including the "near" account. This means at least one shard will have no
+// accounts in it, so we check that corner case here.
+#[test]
+fn slow_test_state_sync_empty_shard() {
+    init_test_logger();
+    let t = StateSyncTest {
         num_validators: 2,
         num_block_producer_seats: 2,
         num_chunk_producer_seats: 2,
         num_shards: 4,
         generate_shard_accounts: false,
-        chunks_produced: &[],
+        chunks_produced: vec![],
         skip_block_sync_height_delta: None,
         extra_node_shard_schedule: None,
-    },
-    // Now we miss some chunks at the beginning of the epoch
-    StateSyncTest {
-        num_validators: 5,
-        num_block_producer_seats: 4,
-        num_chunk_producer_seats: 4,
-        num_shards: 4,
-        generate_shard_accounts: true,
-        chunks_produced: &[
-            (ShardId::new(0), &[false]),
-            (ShardId::new(1), &[true]),
-            (ShardId::new(2), &[true]),
-            (ShardId::new(3), &[true]),
-        ],
-        skip_block_sync_height_delta: None,
-        extra_node_shard_schedule: None,
-    },
-    StateSyncTest {
-        num_validators: 5,
-        num_block_producer_seats: 4,
-        num_chunk_producer_seats: 4,
-        num_shards: 4,
-        generate_shard_accounts: true,
-        chunks_produced: &[(ShardId::new(0), &[true, false]), (ShardId::new(1), &[true, false])],
-        skip_block_sync_height_delta: None,
-        extra_node_shard_schedule: None,
-    },
-    StateSyncTest {
-        num_validators: 5,
-        num_block_producer_seats: 4,
-        num_chunk_producer_seats: 4,
-        num_shards: 4,
-        generate_shard_accounts: true,
-        chunks_produced: &[
-            (ShardId::new(0), &[false, true]),
-            (ShardId::new(2), &[true, false, true]),
-        ],
-        skip_block_sync_height_delta: None,
-        extra_node_shard_schedule: None,
-    },
-];
+    };
+    run_state_sync_test_case(t);
+}
 
+// Miss a chunk in the first block of the new epoch; it won't affect the sync hash
 #[test]
-fn slow_test_state_sync_current_epoch() {
+fn slow_test_state_sync_miss_chunks_first_block() {
     init_test_logger();
+    let chunks_produced = vec![
+        (ShardId::new(0), vec![false]),
+        (ShardId::new(1), vec![true]),
+        (ShardId::new(2), vec![true]),
+        (ShardId::new(3), vec![true]),
+    ];
+    let t = StateSyncTest {
+        num_validators: 5,
+        num_block_producer_seats: 4,
+        num_chunk_producer_seats: 4,
+        num_shards: 4,
+        generate_shard_accounts: true,
+        chunks_produced,
+        skip_block_sync_height_delta: None,
+        extra_node_shard_schedule: None,
+    };
+    run_state_sync_test_case(t);
+}
 
-    // TODO: make these separate #[test]s, because looping over them like this makes
-    // us wait for each one in succession instead of letting cargo test run them in parallel
-    for t in TEST_CASES.iter() {
-        tracing::info!("run test: {:?}", t);
-        let state = setup_initial_blockchain(
-            t.num_validators,
-            t.num_block_producer_seats,
-            t.num_chunk_producer_seats,
-            t.num_shards,
-            t.generate_shard_accounts,
-            t.chunks_produced
-                .iter()
-                .map(|(shard_id, produced)| (*shard_id, produced.to_vec()))
-                .collect(),
-            t.skip_block_sync_height_delta,
-            &t.extra_node_shard_schedule,
-        );
-        run_test(state);
-    }
+// Miss chunks in the second block of the new epoch;
+// the sync hash will be one block later than usual
+#[test]
+fn slow_test_state_sync_miss_chunks_second_block() {
+    init_test_logger();
+    let chunks_produced =
+        vec![(ShardId::new(0), vec![true, false]), (ShardId::new(1), vec![true, false])];
+    let t = StateSyncTest {
+        num_validators: 5,
+        num_block_producer_seats: 4,
+        num_chunk_producer_seats: 4,
+        num_shards: 4,
+        generate_shard_accounts: true,
+        chunks_produced,
+        skip_block_sync_height_delta: None,
+        extra_node_shard_schedule: None,
+    };
+    run_state_sync_test_case(t);
+}
+
+// Miss chunks in the third block of the new epoch;
+// the sync hash will be one block later than usual
+#[test]
+fn slow_test_state_sync_miss_chunks_third_block() {
+    init_test_logger();
+    let chunks_produced = vec![
+        (ShardId::new(0), vec![true, true, false]),
+        (ShardId::new(2), vec![true, true, false]),
+    ];
+    let t = StateSyncTest {
+        num_validators: 5,
+        num_block_producer_seats: 4,
+        num_chunk_producer_seats: 4,
+        num_shards: 4,
+        generate_shard_accounts: true,
+        chunks_produced,
+        skip_block_sync_height_delta: None,
+        extra_node_shard_schedule: None,
+    };
+    run_state_sync_test_case(t);
+}
+
+// Make the sync block have missing chunks
+#[test]
+fn slow_test_state_sync_miss_chunks_sync_block() {
+    init_test_logger();
+    let chunks_produced = vec![
+        (ShardId::new(0), vec![true, true, true, false]),
+        (ShardId::new(1), vec![true, true, true, false]),
+    ];
+    let t = StateSyncTest {
+        num_validators: 5,
+        num_block_producer_seats: 4,
+        num_chunk_producer_seats: 4,
+        num_shards: 4,
+        generate_shard_accounts: true,
+        chunks_produced,
+        skip_block_sync_height_delta: None,
+        extra_node_shard_schedule: None,
+    };
+    run_state_sync_test_case(t);
+}
+
+// Make the sync prev block have a missing chunk.
+// Notice that the sync hash is one block later than usual because of shard 3.
+// Shard 1 will be missing a chunk in the prev block.
+#[test]
+fn slow_test_state_sync_miss_chunks_sync_prev_block() {
+    init_test_logger();
+    let chunks_produced = vec![
+        (ShardId::new(1), vec![true, true, true, false]),
+        (ShardId::new(3), vec![true, false, true, true]),
+    ];
+    let t = StateSyncTest {
+        num_validators: 5,
+        num_block_producer_seats: 4,
+        num_chunk_producer_seats: 4,
+        num_shards: 4,
+        generate_shard_accounts: true,
+        chunks_produced,
+        skip_block_sync_height_delta: None,
+        extra_node_shard_schedule: None,
+    };
+    run_state_sync_test_case(t);
+}
+
+// Combination of different cases:
+//  - Shard 0 has multiple chunk misses leading up to the sync hash block
+//  - Shard 1 has multiple misses leading up to and including the sync hash block
+//  - Shard 2 misses chunks early
+//  - Shard 3 has no missing chunks until the sync hash block
+#[test]
+fn slow_test_state_sync_miss_chunks_multiple() {
+    init_test_logger();
+    let chunks_produced = vec![
+        (ShardId::new(0), vec![true, true, true, false, false, true]),
+        (ShardId::new(1), vec![true, true, true, false, false, false]),
+        (ShardId::new(2), vec![false, false, false, true, true, true]),
+        (ShardId::new(3), vec![true, true, true, true, true, false]),
+    ];
+    let t = StateSyncTest {
+        num_validators: 5,
+        num_block_producer_seats: 4,
+        num_chunk_producer_seats: 4,
+        num_shards: 4,
+        generate_shard_accounts: true,
+        chunks_produced,
+        skip_block_sync_height_delta: None,
+        extra_node_shard_schedule: None,
+    };
+    run_state_sync_test_case(t);
 }
 
 // This adds an extra node with an explicit tracked shards schedule to test more corner cases.
@@ -501,7 +687,7 @@ fn slow_test_state_sync_untrack_then_track() {
         num_chunk_producer_seats: 4,
         num_shards: 5,
         generate_shard_accounts: true,
-        chunks_produced: &[],
+        chunks_produced: vec![],
         skip_block_sync_height_delta: None,
         extra_node_shard_schedule: Some(vec![
             vec![ShardId::new(0), ShardId::new(1)],
@@ -510,21 +696,7 @@ fn slow_test_state_sync_untrack_then_track() {
             vec![ShardId::new(0), ShardId::new(3)],
         ]),
     };
-    let state = setup_initial_blockchain(
-        params.num_validators,
-        params.num_block_producer_seats,
-        params.num_chunk_producer_seats,
-        params.num_shards,
-        params.generate_shard_accounts,
-        params
-            .chunks_produced
-            .iter()
-            .map(|(shard_id, produced)| (*shard_id, produced.to_vec()))
-            .collect(),
-        params.skip_block_sync_height_delta,
-        &params.extra_node_shard_schedule,
-    );
-    run_test(state);
+    run_state_sync_test_case(params);
 }
 
 // Here we drop the block that's supposed to be the sync hash after the first full epoch,
@@ -545,25 +717,11 @@ fn slow_test_state_sync_from_fork() {
         num_chunk_producer_seats: 4,
         num_shards: 5,
         generate_shard_accounts: true,
-        chunks_produced: &[],
+        chunks_produced: vec![],
         skip_block_sync_height_delta: Some(0),
         extra_node_shard_schedule: None,
     };
-    let state = setup_initial_blockchain(
-        params.num_validators,
-        params.num_block_producer_seats,
-        params.num_chunk_producer_seats,
-        params.num_shards,
-        params.generate_shard_accounts,
-        params
-            .chunks_produced
-            .iter()
-            .map(|(shard_id, produced)| (*shard_id, produced.to_vec()))
-            .collect(),
-        params.skip_block_sync_height_delta,
-        &params.extra_node_shard_schedule,
-    );
-    run_test(state);
+    run_state_sync_test_case(params);
 }
 
 // This is the same as the above test_state_sync_from_fork() except we tweak some parameters so that
@@ -583,25 +741,11 @@ fn slow_test_state_sync_to_fork() {
         num_chunk_producer_seats: 4,
         num_shards: 5,
         generate_shard_accounts: true,
-        chunks_produced: &[],
+        chunks_produced: vec![],
         skip_block_sync_height_delta: Some(0),
         extra_node_shard_schedule: None,
     };
-    let state = setup_initial_blockchain(
-        params.num_validators,
-        params.num_block_producer_seats,
-        params.num_chunk_producer_seats,
-        params.num_shards,
-        params.generate_shard_accounts,
-        params
-            .chunks_produced
-            .iter()
-            .map(|(shard_id, produced)| (*shard_id, produced.to_vec()))
-            .collect(),
-        params.skip_block_sync_height_delta,
-        &params.extra_node_shard_schedule,
-    );
-    run_test(state);
+    run_state_sync_test_case(params);
 }
 
 // This one tests what happens when we skip a block after the sync block. This checks a corner case where
@@ -618,28 +762,14 @@ fn slow_test_state_sync_fork_after_sync() {
         num_chunk_producer_seats: 4,
         num_shards: 5,
         generate_shard_accounts: true,
-        chunks_produced: &[],
+        chunks_produced: vec![],
         skip_block_sync_height_delta: Some(1),
         extra_node_shard_schedule: None,
     };
-    let state = setup_initial_blockchain(
-        params.num_validators,
-        params.num_block_producer_seats,
-        params.num_chunk_producer_seats,
-        params.num_shards,
-        params.generate_shard_accounts,
-        params
-            .chunks_produced
-            .iter()
-            .map(|(shard_id, produced)| (*shard_id, produced.to_vec()))
-            .collect(),
-        params.skip_block_sync_height_delta,
-        &params.extra_node_shard_schedule,
-    );
-    run_test(state);
+    run_state_sync_test_case(params);
 }
 
-// This one tests what happens when we skip a block before the sync block, for good measure.
+// This one tests what happens when we skip a block before the sync block.
 #[test]
 fn slow_test_state_sync_fork_before_sync() {
     init_test_logger();
@@ -650,25 +780,11 @@ fn slow_test_state_sync_fork_before_sync() {
         num_chunk_producer_seats: 4,
         num_shards: 5,
         generate_shard_accounts: true,
-        chunks_produced: &[],
+        chunks_produced: vec![],
         skip_block_sync_height_delta: Some(-1),
         extra_node_shard_schedule: None,
     };
-    let state = setup_initial_blockchain(
-        params.num_validators,
-        params.num_block_producer_seats,
-        params.num_chunk_producer_seats,
-        params.num_shards,
-        params.generate_shard_accounts,
-        params
-            .chunks_produced
-            .iter()
-            .map(|(shard_id, produced)| (*shard_id, produced.to_vec()))
-            .collect(),
-        params.skip_block_sync_height_delta,
-        &params.extra_node_shard_schedule,
-    );
-    run_test(state);
+    run_state_sync_test_case(params);
 }
 
 fn await_sync_hash(env: &mut TestLoopEnv) -> CryptoHash {
@@ -677,6 +793,14 @@ fn await_sync_hash(env: &mut TestLoopEnv) -> CryptoHash {
             let handle = env.node_datas[0].client_sender.actor_handle();
             let client = &data.get(&handle).client;
             let tip = client.chain.head().unwrap();
+            let header = client.chain.get_block_header(&tip.last_block_hash).unwrap();
+            tracing::debug!(
+                "chunk mask for #{} {:?} {} {:?}",
+                header.height(),
+                header.chunk_mask(),
+                tip.last_block_hash,
+                tip.epoch_id
+            );
             if tip.epoch_id == Default::default() {
                 return false;
             }
@@ -687,7 +811,9 @@ fn await_sync_hash(env: &mut TestLoopEnv) -> CryptoHash {
     let client_handle = env.node_datas[0].client_sender.actor_handle();
     let client = &env.test_loop.data.get(&client_handle).client;
     let tip = client.chain.head().unwrap();
-    client.chain.get_sync_hash(&tip.last_block_hash).unwrap().unwrap()
+    let sync_hash = client.chain.get_sync_hash(&tip.last_block_hash).unwrap().unwrap();
+    tracing::debug!("await_sync_hash: {sync_hash}");
+    sync_hash
 }
 
 // cspell:ignore reqs

--- a/test-loop-tests/src/tests/state_sync.rs
+++ b/test-loop-tests/src/tests/state_sync.rs
@@ -647,10 +647,34 @@ fn slow_test_state_sync_miss_chunks_sync_prev_block() {
     run_state_sync_test_case(t);
 }
 
+// Create missing chunks leading up to the last new chunk included
+// before the sync hash block
+#[test]
+fn slow_test_state_sync_miss_chunks_before_last_chunk_included() {
+    init_test_logger();
+    let chunks_produced = vec![
+        (ShardId::new(0), vec![false, true, false, false, true, false]),
+        (ShardId::new(1), vec![false, true, false, false, true, true]),
+        (ShardId::new(2), vec![false, true, false, true, false, false]),
+        (ShardId::new(3), vec![false, true, false, true, false, true]),
+    ];
+    let t = StateSyncTest {
+        num_validators: 5,
+        num_block_producer_seats: 4,
+        num_chunk_producer_seats: 4,
+        num_shards: 4,
+        generate_shard_accounts: true,
+        chunks_produced,
+        skip_block_sync_height_delta: None,
+        extra_node_shard_schedule: None,
+    };
+    run_state_sync_test_case(t);
+}
+
 // Combination of different cases:
 //  - Shard 0 has multiple chunk misses leading up to the sync hash block
 //  - Shard 1 has multiple misses leading up to and including the sync hash block
-//  - Shard 2 misses chunks early
+//  - Shard 2 has missing chunks leading up to the last chunk included before sync hash block
 //  - Shard 3 has no missing chunks until the sync hash block
 #[test]
 fn slow_test_state_sync_miss_chunks_multiple() {
@@ -658,7 +682,7 @@ fn slow_test_state_sync_miss_chunks_multiple() {
     let chunks_produced = vec![
         (ShardId::new(0), vec![true, true, true, false, false, true]),
         (ShardId::new(1), vec![true, true, true, false, false, false]),
-        (ShardId::new(2), vec![false, false, false, true, true, true]),
+        (ShardId::new(2), vec![false, true, false, false, true, true]),
         (ShardId::new(3), vec![true, true, true, true, true, false]),
     ];
     let t = StateSyncTest {


### PR DESCRIPTION
This PR addresses issues related to the `CurrentEpochStateSync` change. Several functions are updated to correctly handle these scenarios:

-  Heights of blocks leading up to the sync hash block may not be contiguous due to missing blocks.
- The last final block before the sync block might not be present in storage after state sync (and may even belong to the previous epoch).

Test loop state sync tests are expanded to cover:
- Starting a new node from genesis state and having it state sync to nodes far ahead.
- Cases with missing chunks in the blocks leading up to the sync hash block.

Old code gated by `!ProtocolFeature::CurrentEpochStateSync.enabled(protocol_version)` is removed.

Apart from adding tests, I checked all references to last final block (`git grep last_final_block`) to catch any places we assume that the last final block must be available in storage.

-----

These issues occurred because:

- Previously, the sync hash was always chosen to be the last block of the epoch. Epochs always end with three consecutive blocks, allowing assumptions about block heights and availability of the most recent final block. With the sync hash moved to the new epoch, these assumptions are no longer valid.
- State sync test loop tests did not cover scenarios in which a node initiates state sync from far behind the chain. Nodes were already tracking the chain, using state sync only to rotate tracked shards. In such cases the node has the full block history and avoids many of the state sync codepaths. 

-----

The critical fixes are in:
- `reset_heads_post_state_sync`, which previously assumed existence of certain heights [here](https://github.com/near/nearcore/blob/ac76adf0bf13e9d60409de69acd40324b32b8f2e/chain/chain/src/chain.rs#L1703) and [here](https://github.com/near/nearcore/blob/ac76adf0bf13e9d60409de69acd40324b32b8f2e/chain/chain/src/chain.rs#L1717). 
- `clear_state_transition_data`, which assumes availability of the last final block [here](https://github.com/saketh-are/nearcore/blob/1eacfd251680fc4f409b2a5f900df0d2c6985648/chain/chain/src/garbage_collection.rs#L313).
- `get_new_flat_storage_head`, which assumes availability of the last final block [here](https://github.com/saketh-are/nearcore/blob/1eacfd251680fc4f409b2a5f900df0d2c6985648/chain/chain/src/chain.rs#L2170).

The most interesting test case is `slow_test_state_sync_fork_before_sync`, in which:
- The block at height 10015 is the sync hash block.
- The canonical chain is missing the height 10013.
- The last final block is 10010.

Running it with an added node syncing from scratch is sufficient to hit all codepaths of interest.