### PR TITLE
refactor: remove a clone for `SignedTransactions`

### DIFF
--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -535,7 +535,7 @@ impl<'a> ChainUpdate<'a> {
         let block = self.chain_store_update.get_block(block_header.hash())?;
         let epoch_id = self.epoch_manager.get_epoch_id(block_header.hash())?;
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
-        let transactions = chunk.transactions();
+        let transactions = chunk.transactions().to_vec();
         let transaction_validity = if let Some(prev_block_header) = prev_block_header {
             self.chain_store_update
                 .chain_store()
@@ -543,7 +543,7 @@ impl<'a> ChainUpdate<'a> {
         } else {
             vec![true; transactions.len()]
         };
-        let transactions = SignedValidPeriodTransactions::new(transactions, &transaction_validity);
+        let transactions = SignedValidPeriodTransactions::new(transactions, transaction_validity);
         let apply_result = self.runtime_adapter.apply_chunk(
             RuntimeStorageConfig::new(chunk_header.prev_state_root(), true),
             ApplyChunkReason::UpdateTrackedShard,
@@ -678,7 +678,7 @@ impl<'a> ChainUpdate<'a> {
                 block.block_bandwidth_requests(),
             ),
             &[],
-            SignedValidPeriodTransactions::new(&[], &[]),
+            SignedValidPeriodTransactions::empty(),
         )?;
         let flat_storage_manager = self.runtime_adapter.get_flat_storage_manager();
         let store_update = flat_storage_manager.save_flat_state_changes(

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -163,7 +163,7 @@ impl NightshadeRuntime {
         chunk: ApplyChunkShardContext,
         block: ApplyChunkBlockContext,
         receipts: &[Receipt],
-        transactions: node_runtime::SignedValidPeriodTransactions,
+        transactions: SignedValidPeriodTransactions,
         state_patch: SandboxStatePatch,
     ) -> Result<ApplyChunkResult, Error> {
         let ApplyChunkBlockContext {

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -48,8 +48,8 @@ use node_runtime::adapter::ViewRuntimeAdapter;
 use node_runtime::config::tx_cost;
 use node_runtime::state_viewer::{TrieViewer, ViewApplyState};
 use node_runtime::{
-    ApplyState, Runtime, ValidatorAccountsUpdate, set_tx_state_changes, validate_transaction,
-    verify_and_charge_tx_ephemeral,
+    ApplyState, Runtime, SignedValidPeriodTransactions, ValidatorAccountsUpdate,
+    set_tx_state_changes, validate_transaction, verify_and_charge_tx_ephemeral,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -163,7 +163,7 @@ impl NightshadeRuntime {
         chunk: ApplyChunkShardContext,
         block: ApplyChunkBlockContext,
         receipts: &[Receipt],
-        transactions: node_runtime::SignedValidPeriodTransactions<'_>,
+        transactions: node_runtime::SignedValidPeriodTransactions,
         state_patch: SandboxStatePatch,
     ) -> Result<ApplyChunkResult, Error> {
         let ApplyChunkBlockContext {
@@ -831,7 +831,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         chunk: ApplyChunkShardContext,
         block: ApplyChunkBlockContext,
         receipts: &[Receipt],
-        transactions: node_runtime::SignedValidPeriodTransactions<'_>,
+        transactions: SignedValidPeriodTransactions,
     ) -> Result<ApplyChunkResult, Error> {
         let shard_id = chunk.shard_id;
         let _timer = metrics::APPLYING_CHUNKS_TIME

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -217,7 +217,7 @@ impl TestEnv {
         &self,
         shard_id: ShardId,
         new_block_hash: CryptoHash,
-        transactions: &[SignedTransaction],
+        transactions: Vec<SignedTransaction>,
         receipts: &[Receipt],
         challenges_result: ChallengesResult,
     ) -> ApplyChunkResult {
@@ -245,7 +245,7 @@ impl TestEnv {
             BlockCongestionInfo::new(shards_congestion_info)
         };
         let transaction_validity = vec![true; transactions.len()];
-        let transactions = SignedValidPeriodTransactions::new(transactions, &transaction_validity);
+        let transactions = SignedValidPeriodTransactions::new(transactions, transaction_validity);
         self.runtime
             .apply_chunk(
                 RuntimeStorageConfig::new(state_root, true),
@@ -280,7 +280,7 @@ impl TestEnv {
         &self,
         shard_id: ShardId,
         new_block_hash: CryptoHash,
-        transactions: &[SignedTransaction],
+        transactions: Vec<SignedTransaction>,
         receipts: &[Receipt],
         challenges_result: ChallengesResult,
     ) -> (CryptoHash, Vec<ValidatorStake>, Vec<Receipt>) {
@@ -343,7 +343,7 @@ impl TestEnv {
             let (state_root, proposals, receipts) = self.update_runtime(
                 shard_id,
                 new_hash,
-                &transactions[shard_index],
+                transactions[shard_index].clone(),
                 self.last_receipts.get(&shard_id).map_or(&[], |v| v.as_slice()),
                 challenges_result.clone(),
             );
@@ -1729,7 +1729,7 @@ fn test_storage_proof_garbage() {
         priority: 0,
     });
     let apply_result =
-        env.apply_new_chunk(shard_id, hash(&[42]), &[], &[receipt], ChallengesResult::default());
+        env.apply_new_chunk(shard_id, hash(&[42]), vec![], &[receipt], ChallengesResult::default());
     let PartialState::TrieValues(storage_proof) = apply_result.proof.unwrap().nodes;
     let total_size: usize = storage_proof.iter().map(|v| v.len()).sum();
     assert_eq!(total_size / 1000_000, garbage_size_mb);

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -1045,7 +1045,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         chunk: ApplyChunkShardContext,
         block: ApplyChunkBlockContext,
         receipts: &[Receipt],
-        transactions: SignedValidPeriodTransactions<'_>,
+        transactions: SignedValidPeriodTransactions,
     ) -> Result<ApplyChunkResult, Error> {
         let mut tx_results = vec![];
         let shard_id = chunk.shard_id;

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -455,7 +455,7 @@ pub trait RuntimeAdapter: Send + Sync {
         chunk: ApplyChunkShardContext,
         block: ApplyChunkBlockContext,
         receipts: &[Receipt],
-        transactions: SignedValidPeriodTransactions<'_>,
+        transactions: SignedValidPeriodTransactions,
     ) -> Result<ApplyChunkResult, Error>;
 
     /// Query runtime with given `path` and `data`.

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -156,7 +156,7 @@ pub fn apply_new_chunk(
         },
         block,
         &receipts,
-        SignedValidPeriodTransactions::new(&transactions, &transaction_validity_check_results),
+        SignedValidPeriodTransactions::new(transactions, transaction_validity_check_results),
     ) {
         Ok(apply_result) => {
             Ok(NewChunkResult { gas_limit, shard_uid: shard_context.shard_uid, apply_result })
@@ -203,7 +203,7 @@ pub fn apply_old_chunk(
         },
         block,
         &[],
-        SignedValidPeriodTransactions::new(&[], &[]),
+        SignedValidPeriodTransactions::empty(),
     ) {
         Ok(apply_result) => Ok(OldChunkResult { shard_uid: shard_context.shard_uid, apply_result }),
         Err(err) => Err(err),

--- a/integration-tests/src/user/runtime_user.rs
+++ b/integration-tests/src/user/runtime_user.rs
@@ -108,6 +108,7 @@ impl RuntimeUser {
                 trie.set_charge_gas_for_trie_node_access(true);
                 trie
             };
+            let validity_check_results = vec![true; txs.len()];
             let apply_result = client
                 .runtime
                 .apply(
@@ -115,7 +116,7 @@ impl RuntimeUser {
                     &None,
                     &apply_state,
                     &receipts,
-                    SignedValidPeriodTransactions::new(&txs, &vec![true; txs.len()]),
+                    SignedValidPeriodTransactions::new(txs, validity_check_results),
                     &self.epoch_info_provider,
                     Default::default(),
                 )

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1590,7 +1590,7 @@ impl Runtime {
         let apply_state = &mut processing_state.apply_state;
         let state_update = &mut processing_state.state_update;
 
-        let signed_txs = signed_txs.par_into_iter_nonexpired_transactions();
+        let signed_txs = signed_txs.into_par_iter_nonexpired_transactions();
         for (tx_hash, result) in Self::parallel_validate_transactions(
             &apply_state.config,
             apply_state.gas_price,

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1416,7 +1416,7 @@ impl Runtime {
     /// the only alternative way to handle these transactions is to make the entire chunk invalid.
     #[instrument(target = "runtime", level = "debug", "apply", skip_all, fields(
         protocol_version = apply_state.current_protocol_version,
-        num_transactions = transactions.len(),
+        num_transactions = signed_txs.len(),
         gas_burnt = tracing::field::Empty,
         compute_usage = tracing::field::Empty,
     ))]
@@ -1426,11 +1426,11 @@ impl Runtime {
         validator_accounts_update: &Option<ValidatorAccountsUpdate>,
         apply_state: &ApplyState,
         incoming_receipts: &[Receipt],
-        transactions: SignedValidPeriodTransactions<'_>,
+        signed_txs: SignedValidPeriodTransactions,
         epoch_info_provider: &dyn EpochInfoProvider,
         state_patch: SandboxStatePatch,
     ) -> Result<ApplyResult, RuntimeError> {
-        metrics::TRANSACTION_APPLIED_TOTAL.inc_by(transactions.len() as u64);
+        metrics::TRANSACTION_APPLIED_TOTAL.inc_by(signed_txs.len() as u64);
 
         // state_patch must be empty unless this is sandbox build.  Thanks to
         // conditional compilation this always resolves to true so technically
@@ -1445,14 +1445,14 @@ impl Runtime {
         // 4. Process receipts.
         // 5. Validate and apply the state update.
         let mut processing_state =
-            ApplyProcessingState::new(&apply_state, trie, epoch_info_provider, transactions);
-        processing_state.stats.transactions_num = transactions.len().try_into().unwrap();
+            ApplyProcessingState::new(&apply_state, trie, epoch_info_provider);
+        processing_state.stats.transactions_num = signed_txs.len().try_into().unwrap();
         processing_state.stats.incoming_receipts_num = incoming_receipts.len().try_into().unwrap();
         processing_state.stats.is_new_chunk = !apply_state.is_new_chunk;
 
         if let Some(prefetcher) = &mut processing_state.prefetcher {
             // Prefetcher is allowed to fail
-            _ = prefetcher.prefetch_transactions_data(transactions);
+            _ = prefetcher.prefetch_transactions_data(&signed_txs);
         }
 
         // Step 1: update validator accounts.
@@ -1517,7 +1517,7 @@ impl Runtime {
         )?;
 
         // Step 3: process transactions.
-        self.process_transactions(&mut processing_state, &mut receipt_sink)?;
+        self.process_transactions(&mut processing_state, signed_txs, &mut receipt_sink)?;
 
         // Step 4: process receipts.
         let process_receipts_result =
@@ -1583,13 +1583,14 @@ impl Runtime {
     fn process_transactions<'a>(
         &self,
         processing_state: &mut ApplyProcessingReceiptState<'a>,
+        signed_txs: SignedValidPeriodTransactions,
         receipt_sink: &mut ReceiptSink,
     ) -> Result<(), RuntimeError> {
         let total = &mut processing_state.total;
         let apply_state = &mut processing_state.apply_state;
         let state_update = &mut processing_state.state_update;
 
-        let signed_txs = processing_state.transactions.par_iter_nonexpired_transactions().cloned();
+        let signed_txs = signed_txs.par_into_iter_nonexpired_transactions();
         for (tx_hash, result) in Self::parallel_validate_transactions(
             &apply_state.config,
             apply_state.gas_price,
@@ -2442,7 +2443,6 @@ struct ApplyProcessingState<'a> {
     prefetcher: Option<TriePrefetcher>,
     state_update: TrieUpdate,
     epoch_info_provider: &'a dyn EpochInfoProvider,
-    transactions: SignedValidPeriodTransactions<'a>,
     total: TotalResourceGuard,
     stats: ChunkApplyStatsV0,
 }
@@ -2452,7 +2452,6 @@ impl<'a> ApplyProcessingState<'a> {
         apply_state: &'a ApplyState,
         trie: Trie,
         epoch_info_provider: &'a dyn EpochInfoProvider,
-        transactions: SignedValidPeriodTransactions<'a>,
     ) -> Self {
         let protocol_version = apply_state.current_protocol_version;
         let prefetcher = TriePrefetcher::new_if_enabled(&trie);
@@ -2472,7 +2471,6 @@ impl<'a> ApplyProcessingState<'a> {
             prefetcher,
             state_update,
             epoch_info_provider,
-            transactions,
             total,
             stats,
         }
@@ -2496,7 +2494,6 @@ impl<'a> ApplyProcessingState<'a> {
             prefetcher: self.prefetcher,
             state_update: self.state_update,
             epoch_info_provider: self.epoch_info_provider,
-            transactions: self.transactions,
             total: self.total,
             stats: self.stats,
             outcomes: Vec::new(),
@@ -2516,7 +2513,6 @@ struct ApplyProcessingReceiptState<'a> {
     prefetcher: Option<TriePrefetcher>,
     state_update: TrieUpdate,
     epoch_info_provider: &'a dyn EpochInfoProvider,
-    transactions: SignedValidPeriodTransactions<'a>,
     total: TotalResourceGuard,
     stats: ChunkApplyStatsV0,
     outcomes: Vec<ExecutionOutcomeWithId>,

--- a/runtime/runtime/src/prefetch.rs
+++ b/runtime/runtime/src/prefetch.rs
@@ -197,10 +197,10 @@ impl TriePrefetcher {
     /// for some transactions may have been initiated.
     pub(crate) fn prefetch_transactions_data(
         &mut self,
-        transactions: SignedValidPeriodTransactions<'_>,
+        signed_txs: &SignedValidPeriodTransactions,
     ) -> Result<(), PrefetchError> {
         if self.prefetch_api.enable_receipt_prefetching {
-            for t in transactions.iter_nonexpired_transactions() {
+            for t in signed_txs.iter_nonexpired_transactions() {
                 let account_id = t.transaction.signer_id().clone();
                 let trie_key = TrieKey::Account { account_id };
                 self.prefetch_trie_key(trie_key)?;

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -557,7 +557,7 @@ fn test_apply_delayed_receipts_local_tx() {
             &None,
             &apply_state,
             &receipts[0..2],
-            SignedValidPeriodTransactions::new(&local_transactions[0..4], &[true; 4]),
+            SignedValidPeriodTransactions::new(local_transactions[0..4].to_vec(), vec![true; 4]),
             &epoch_info_provider,
             Default::default(),
         )
@@ -603,7 +603,7 @@ fn test_apply_delayed_receipts_local_tx() {
             &None,
             &apply_state,
             &receipts[2..3],
-            SignedValidPeriodTransactions::new(&local_transactions[4..5], &[true]),
+            SignedValidPeriodTransactions::new(local_transactions[4..5].to_vec(), vec![true]),
             &epoch_info_provider,
             Default::default(),
         )
@@ -643,7 +643,7 @@ fn test_apply_delayed_receipts_local_tx() {
             &None,
             &apply_state,
             &receipts[3..4],
-            SignedValidPeriodTransactions::new(&local_transactions[5..9], &[true; 4]),
+            SignedValidPeriodTransactions::new(local_transactions[5..9].to_vec(), vec![true; 4]),
             &epoch_info_provider,
             Default::default(),
         )
@@ -2743,7 +2743,7 @@ fn test_deploy_and_call_local_receipt() {
             &None,
             &apply_state,
             &[],
-            SignedValidPeriodTransactions::new(&[tx], &[true]),
+            SignedValidPeriodTransactions::new(vec![tx], vec![true]),
             &epoch_info_provider,
             Default::default(),
         )
@@ -2814,7 +2814,7 @@ fn test_deploy_and_call_local_receipts() {
             &None,
             &apply_state,
             &[],
-            SignedValidPeriodTransactions::new(&[tx1, tx2], &[true; 2]),
+            SignedValidPeriodTransactions::new(vec![tx1, tx2], vec![true; 2]),
             &epoch_info_provider,
             Default::default(),
         )
@@ -2912,7 +2912,7 @@ fn test_transaction_ordering_with_apply() {
     );
 
     let validity_flags = vec![true; txs.len()];
-    let signed_valid_period_txs = SignedValidPeriodTransactions::new(&txs, &validity_flags);
+    let signed_valid_period_txs = SignedValidPeriodTransactions::new(txs, validity_flags);
     let apply_result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
@@ -2991,7 +2991,7 @@ fn test_transaction_multiple_access_keys_with_apply() {
         );
 
     let validity_flags = vec![true; txs.len()];
-    let signed_valid_period_txs = SignedValidPeriodTransactions::new(&txs, &validity_flags);
+    let signed_valid_period_txs = SignedValidPeriodTransactions::new(txs.clone(), validity_flags);
     let apply_result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),
@@ -3022,7 +3022,7 @@ fn test_transaction_multiple_access_keys_with_apply() {
 #[test]
 fn test_expired_transaction() {
     let alice_signer = InMemorySigner::test_signer(&alice_account());
-    let expired_tx = [SignedTransaction::send_money(
+    let expired_tx = vec![SignedTransaction::send_money(
         1,
         alice_account(),
         alice_account(),
@@ -3036,7 +3036,7 @@ fn test_expired_transaction() {
         to_yocto(500_000),
         10u64.pow(15),
     );
-    let signed_valid_period_txs = SignedValidPeriodTransactions::new(&expired_tx, &[false]);
+    let signed_valid_period_txs = SignedValidPeriodTransactions::new(expired_tx, vec![false]);
     let apply_result = runtime
         .apply(
             tries.get_trie_for_shard(ShardUId::single_shard(), root),

--- a/runtime/runtime/src/types.rs
+++ b/runtime/runtime/src/types.rs
@@ -35,7 +35,7 @@ impl SignedValidPeriodTransactions {
         self.transactions
             .iter()
             .zip(&self.transaction_validity_check_passed)
-            .filter_map(|(tx, v)| v.then_some(tx))
+            .filter_map(|(t, v)| v.then_some(t))
     }
 
     pub fn par_into_iter_nonexpired_transactions(

--- a/runtime/runtime/src/types.rs
+++ b/runtime/runtime/src/types.rs
@@ -1,13 +1,12 @@
 use near_primitives::transaction::SignedTransaction;
-use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator as _, ParallelIterator};
+use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 
-#[derive(Clone, Copy)]
-pub struct SignedValidPeriodTransactions<'a> {
+pub struct SignedValidPeriodTransactions {
     /// Transactions.
     ///
     /// Not all of them may be valid. See the other fields. Access the transactions via
     /// [`Self::iter_nonexpired_transactions`] or similar accessors, as appropriate.
-    transactions: &'a [SignedTransaction],
+    transactions: Vec<SignedTransaction>,
     /// List of the transactions that are valid and should be processed by `apply`.
     ///
     /// This list is exactly the length of the corresponding `Self::transactions` field. Element at
@@ -17,31 +16,33 @@ pub struct SignedValidPeriodTransactions<'a> {
     ///
     /// All elements will be true for protocol versions where `RelaxedChunkValidation` is not
     /// enabled.
-    transaction_validity_check_passed: &'a [bool],
+    transaction_validity_check_passed: Vec<bool>,
 }
 
-impl<'a> SignedValidPeriodTransactions<'a> {
-    pub fn new(transactions: &'a [SignedTransaction], validity_check_results: &'a [bool]) -> Self {
+impl SignedValidPeriodTransactions {
+    pub fn new(transactions: Vec<SignedTransaction>, validity_check_results: Vec<bool>) -> Self {
         assert_eq!(transactions.len(), validity_check_results.len());
         Self { transactions, transaction_validity_check_passed: validity_check_results }
     }
 
     pub fn empty() -> Self {
-        Self::new(&[], &[])
+        Self::new(vec![], vec![])
     }
 
-    pub fn iter_nonexpired_transactions(&self) -> impl Iterator<Item = &'a SignedTransaction> {
+    pub fn iter_nonexpired_transactions<'a>(
+        &'a self,
+    ) -> impl Iterator<Item = &'a SignedTransaction> {
         self.transactions
-            .into_iter()
-            .zip(self.transaction_validity_check_passed.into_iter())
-            .filter_map(|(t, v)| v.then_some(t))
+            .iter()
+            .zip(&self.transaction_validity_check_passed)
+            .filter_map(|(tx, v)| v.then_some(tx))
     }
 
-    pub fn par_iter_nonexpired_transactions(
-        &self,
-    ) -> impl ParallelIterator<Item = &'a SignedTransaction> {
+    pub fn par_into_iter_nonexpired_transactions(
+        self,
+    ) -> impl ParallelIterator<Item = SignedTransaction> {
         self.transactions
-            .par_iter()
+            .into_par_iter()
             .zip(self.transaction_validity_check_passed)
             .filter_map(|(t, v)| v.then_some(t))
     }

--- a/runtime/runtime/src/types.rs
+++ b/runtime/runtime/src/types.rs
@@ -38,7 +38,7 @@ impl SignedValidPeriodTransactions {
             .filter_map(|(t, v)| v.then_some(t))
     }
 
-    pub fn par_into_iter_nonexpired_transactions(
+    pub fn into_par_iter_nonexpired_transactions(
         self,
     ) -> impl ParallelIterator<Item = SignedTransaction> {
         self.transactions

--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -140,7 +140,7 @@ impl StandaloneRuntime {
     pub fn process_block(
         &mut self,
         receipts: &[Receipt],
-        transactions: &[SignedTransaction],
+        transactions: Vec<SignedTransaction>,
     ) -> ProcessBlockOutcome {
         // TODO - the shard id is correct but the shard version is hardcoded. It
         // would be better to store the shard layout in self and read the uid
@@ -149,7 +149,7 @@ impl StandaloneRuntime {
         let shard_uid = ShardUId::new(0, shard_id);
         let trie = self.tries.get_trie_for_shard(shard_uid, self.root);
         let validity = vec![true; transactions.len()];
-        let transactions = SignedValidPeriodTransactions::new(transactions, &validity);
+        let transactions = SignedValidPeriodTransactions::new(transactions, validity);
         let apply_result = self
             .runtime
             .apply(
@@ -366,10 +366,12 @@ impl RuntimeGroup {
                     mut outgoing_receipts,
                     mut execution_outcomes,
                     mut has_queued_receipts,
-                } = runtime
-                    .process_block(&mailbox.incoming_receipts, &mailbox.incoming_transactions);
+                } = runtime.process_block(
+                    &mailbox.incoming_receipts,
+                    mailbox.incoming_transactions.clone(),
+                );
                 while has_queued_receipts {
-                    let process_outcome = runtime.process_block(&[], &[]);
+                    let process_outcome = runtime.process_block(&[], vec![]);
                     outgoing_receipts.extend(process_outcome.outgoing_receipts);
                     execution_outcomes.extend(process_outcome.execution_outcomes);
                     has_queued_receipts = process_outcome.has_queued_receipts;

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -152,7 +152,7 @@ fn apply_block_from_range(
         };
 
         let chain_store_update = ChainStoreUpdate::new(&mut read_chain_store);
-        let transactions = chunk.transactions();
+        let transactions = chunk.transactions().to_vec();
         let valid_txs = chain_store_update
             .chain_store()
             .compute_transaction_validity(prev_block.header(), &chunk);
@@ -214,7 +214,7 @@ fn apply_block_from_range(
                     block.block_bandwidth_requests(),
                 ),
                 &receipts,
-                SignedValidPeriodTransactions::new(&transactions, &valid_txs),
+                SignedValidPeriodTransactions::new(transactions, valid_txs),
             )
             .unwrap()
     } else {

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -107,7 +107,7 @@ pub fn apply_chunk(
     let prev_block_hash = chunk_header.prev_block_hash();
     let prev_state_root = chunk.prev_state_root();
 
-    let transactions = chunk.transactions();
+    let transactions = chunk.transactions().to_vec();
     let prev_block =
         chain_store.get_block(prev_block_hash).context("Failed getting chunk's prev block")?;
     let prev_epoch_id = prev_block.header().epoch_id();
@@ -208,7 +208,7 @@ pub fn apply_chunk(
                 bandwidth_requests: block_bandwidth_requests,
             },
             &receipts,
-            SignedValidPeriodTransactions::new(transactions, &valid_txs),
+            SignedValidPeriodTransactions::new(transactions, valid_txs),
         )?,
         chunk_header.gas_limit(),
     ))

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -106,7 +106,7 @@ pub(crate) fn apply_block(
         )
         .unwrap();
 
-        let transactions = chunk.transactions();
+        let transactions = chunk.transactions().to_vec();
         let valid_txs = chain_store.compute_transaction_validity(prev_block.header(), &chunk);
         runtime
             .apply_chunk(
@@ -126,7 +126,7 @@ pub(crate) fn apply_block(
                     block.block_bandwidth_requests(),
                 ),
                 &receipts,
-                SignedValidPeriodTransactions::new(transactions, &valid_txs),
+                SignedValidPeriodTransactions::new(transactions, valid_txs),
             )
             .unwrap()
     } else {


### PR DESCRIPTION
Part of https://github.com/near/nearcore/issues/13140. 

Similar to https://github.com/near/nearcore/pull/13122 which can be closed in favour of landing this.

- `SignedValidPeriodTransactions` take ownership of `SignedTransactions`
- Rework `ApplyProcessingReceiptState` and `ApplyProcessingState` to not store `SignedValidPeriodTransactions`
- This allows us from avoiding a clone in `process_transactions`.  We need to do a clone in `set_state_finalize` instead now.  However that is not part of chunk application but instead part of state sync.  And still, in this case we are not introducing a new clone just moving it to the top of the stack.

CC: @miloserdow.  As discussed in our chat, this should help with your PR and hopefully we will not have any clones in your work.