### PR TITLE
Prepare 2.6.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,7 +1292,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chainsync-loadtest"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "cold-store-tool"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "congestion-model"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "bytesize",
  "chrono",
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "estimator-warehouse"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-csv-to-json"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-populate"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "borsh",
  "clap",
@@ -3356,7 +3356,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-example"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3604,7 +3604,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "keypair-generator"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "clap",
  "near-crypto",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "mock-node"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4134,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "near-actix-test-utils"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix-rt",
  "near-store",
@@ -4142,7 +4142,7 @@ dependencies = [
 
 [[package]]
 name = "near-amend-genesis"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4161,7 +4161,7 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "derive_more 1.0.0",
@@ -4181,7 +4181,7 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -4191,7 +4191,7 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "bencher",
  "lru 0.12.3",
@@ -4200,7 +4200,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -4254,7 +4254,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "near-crypto",
  "near-primitives",
@@ -4289,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "assert_matches",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "near-client"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4390,7 +4390,7 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "chrono",
@@ -4410,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "blake2",
  "bolero",
@@ -4448,7 +4448,7 @@ dependencies = [
 
 [[package]]
 name = "near-database-tool"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4474,7 +4474,7 @@ dependencies = [
 
 [[package]]
 name = "near-dump-test-contract"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "borsh",
  "chrono",
@@ -4527,7 +4527,7 @@ dependencies = [
 
 [[package]]
 name = "near-flat-storage"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4546,14 +4546,14 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "near-primitives-core",
 ]
 
 [[package]]
 name = "near-fork-network"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -4579,7 +4579,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -4606,7 +4606,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "near-primitives",
  "serde",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4645,7 +4645,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-adversarial-primitives"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "near-primitives",
  "serde",
@@ -4653,7 +4653,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix-http",
  "awc",
@@ -4666,7 +4666,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-fuzz"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "arbitrary",
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -4700,7 +4700,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-tests"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "awc",
@@ -4726,7 +4726,7 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -4736,7 +4736,7 @@ dependencies = [
 
 [[package]]
 name = "near-mirror"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4781,7 +4781,7 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -4842,7 +4842,7 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "base64 0.21.0",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "assert_matches",
  "borsh",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "quote",
  "syn 2.0.87",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "near-ping"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -4932,7 +4932,7 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "borsh",
  "near-crypto",
@@ -4943,7 +4943,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "arbitrary",
  "base64 0.21.0",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "near-replay-archive-tool"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "actix-cors",
@@ -5068,14 +5068,14 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "inventory",
 ]
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "inventory",
  "near-schema-checker-core",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5093,11 +5093,11 @@ dependencies = [
 
 [[package]]
 name = "near-stable-hasher"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 
 [[package]]
 name = "near-state-parts"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5116,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "near-state-parts-dump-check"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "actix-web",
@@ -5139,11 +5139,11 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 
 [[package]]
 name = "near-store"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5196,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "awc",
@@ -5214,7 +5214,7 @@ dependencies = [
 
 [[package]]
 name = "near-test-contracts"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "arbitrary",
  "rand",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -5236,7 +5236,7 @@ dependencies = [
 
 [[package]]
 name = "near-transactions-generator"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "near-undo-block"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5272,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -5288,7 +5288,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-test-derive"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5320,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -5341,7 +5341,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -5414,7 +5414,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner-fuzz"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -5428,7 +5428,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-api"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -5456,14 +5456,14 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-generator"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "near-vm-types"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "bolero",
  "indexmap 2.7.0",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "backtrace",
  "cc",
@@ -5494,7 +5494,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-wast"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
  "near-vm-test-api",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
  "near-primitives-core",
@@ -5513,7 +5513,7 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5583,7 +5583,7 @@ dependencies = [
 
 [[package]]
 name = "neard"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "assert_matches",
  "base64 0.21.0",
@@ -6609,7 +6609,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-schema-check"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "inventory",
  "near-chain",
@@ -6981,7 +6981,7 @@ dependencies = [
 
 [[package]]
 name = "restaked"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "clap",
  "integration-tests",
@@ -7120,7 +7120,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-params-estimator"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7161,7 +7161,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "bolero",
  "cpu-time",
@@ -7189,7 +7189,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester-fuzz"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "libfuzzer-sys",
  "runtime-tester",
@@ -7808,7 +7808,7 @@ dependencies = [
 
 [[package]]
 name = "speedy_sync"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "borsh",
  "clap",
@@ -7851,7 +7851,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-viewer"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -7903,7 +7903,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-usage-delta-calculator"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -7918,7 +7918,7 @@ dependencies = [
 
 [[package]]
 name = "store-validator"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "clap",
  "near-chain",
@@ -8111,7 +8111,7 @@ dependencies = [
 
 [[package]]
 name = "test-loop-tests"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "actix",
  "assert_matches",
@@ -8146,7 +8146,7 @@ dependencies = [
 
 [[package]]
 name = "testlib"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "bytesize",
  "near-chain",
@@ -8162,7 +8162,7 @@ dependencies = [
 
 [[package]]
 name = "themis"
-version = "0.0.0"
+version = "2.6.0-rc.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 # anything to the list of stable crates.
 # Only bump  0.x.* to 0.(x+1).0 on any nearcore release as nearcore does not guarantee
 # semver compatibility. i.e. api can change without a protocol upgrade.
-version = "0.20.1"
+version = "0.30.0"
 exclude = ["neard"]
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.0.0"                               # managed by cargo-workspaces, see below
+version = "2.6.0-rc.1"                               # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2024"
 rust-version = "1.85.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 # anything to the list of stable crates.
 # Only bump  0.x.* to 0.(x+1).0 on any nearcore release as nearcore does not guarantee
 # semver compatibility. i.e. api can change without a protocol upgrade.
-version = "0.30.0"
+version = "0.30.0-rc.1"
 exclude = ["neard"]
 
 [workspace]

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -57,5 +57,14 @@ pub const PROTOCOL_UPGRADE_SCHEDULE: LazyLock<ProtocolUpgradeVotingSchedule> =
         // let schedule = vec![(v1_datetime, v1_protocol_version), (v2_datetime, v2_protocol_version)];
         // ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(PROTOCOL_VERSION, schedule).unwrap()
 
-        ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(PROTOCOL_VERSION, vec![]).unwrap()
+        // Voting starts Monday 19:00 UTC.
+        let v1_protocol_version = 77;
+        let v1_datetime =
+            ProtocolUpgradeVotingSchedule::parse_datetime("2025-04-14 19:00:00").unwrap();
+
+        ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(
+            PROTOCOL_VERSION,
+            vec![(v1_datetime, v1_protocol_version)],
+        )
+        .unwrap()
     });


### PR DESCRIPTION
Prepare 2.6.0-rc.1 release

* Set neard version to `2.6.0-rc.1`
* Set crates version to `0.30.0`
* Set voting date to Monday 2025-04-14 19:00 UTC - protocol upgrade will happen 12-24 hours later, on 2025-04-15 between 7:00 and 19:00 UTC.

According to our estimation tool the upgrade will happen at 2025-04-15 10:48:15 UTC

```
$ python3 estimate_epoch_start_time.py --chain_id testnet --num_future_epochs 30 --voting_date "2025-04-14 19:00:00"
Epoch -1: 11 hours, 38 minutes
Epoch -2: 11 hours, 40 minutes
Epoch -3: 11 hours, 41 minutes
Epoch -4: 12 hours, 14 minutes

Exponential weighted average epoch length: 11 hours, 47 minutes
Predicted start of epoch 1: 2025-04-03 15:46:07 UTC+0000 Thursday
Predicted start of epoch 2: 2025-04-04 03:33:42 UTC+0000 Friday
Predicted start of epoch 3: 2025-04-04 15:21:17 UTC+0000 Friday
Predicted start of epoch 4: 2025-04-05 03:08:53 UTC+0000 Saturday
Predicted start of epoch 5: 2025-04-05 14:56:28 UTC+0000 Saturday
Predicted start of epoch 6: 2025-04-06 02:44:03 UTC+0000 Sunday
Predicted start of epoch 7: 2025-04-06 14:31:39 UTC+0000 Sunday
Predicted start of epoch 8: 2025-04-07 02:19:14 UTC+0000 Monday
Predicted start of epoch 9: 2025-04-07 14:06:49 UTC+0000 Monday
Predicted start of epoch 10: 2025-04-08 01:54:25 UTC+0000 Tuesday
Predicted start of epoch 11: 2025-04-08 13:42:00 UTC+0000 Tuesday
Predicted start of epoch 12: 2025-04-09 01:29:36 UTC+0000 Wednesday
Predicted start of epoch 13: 2025-04-09 13:17:11 UTC+0000 Wednesday
Predicted start of epoch 14: 2025-04-10 01:04:46 UTC+0000 Thursday
Predicted start of epoch 15: 2025-04-10 12:52:22 UTC+0000 Thursday
Predicted start of epoch 16: 2025-04-11 00:39:57 UTC+0000 Friday
Predicted start of epoch 17: 2025-04-11 12:27:32 UTC+0000 Friday
Predicted start of epoch 18: 2025-04-12 00:15:08 UTC+0000 Saturday
Predicted start of epoch 19: 2025-04-12 12:02:43 UTC+0000 Saturday
Predicted start of epoch 20: 2025-04-12 23:50:18 UTC+0000 Saturday
Predicted start of epoch 21: 2025-04-13 11:37:54 UTC+0000 Sunday
Predicted start of epoch 22: 2025-04-13 23:25:29 UTC+0000 Sunday
Predicted start of epoch 23: 2025-04-14 11:13:05 UTC+0000 Monday
Predicted start of epoch 24: 2025-04-14 23:00:40 UTC+0000 Monday
Predicted start of epoch 25: 2025-04-15 10:48:15 UTC+0000 Tuesday
Predicted start of epoch 26: 2025-04-15 22:35:51 UTC+0000 Tuesday
Predicted start of epoch 27: 2025-04-16 10:23:26 UTC+0000 Wednesday
Predicted start of epoch 28: 2025-04-16 22:11:01 UTC+0000 Wednesday
Predicted start of epoch 29: 2025-04-17 09:58:37 UTC+0000 Thursday
Predicted start of epoch 30: 2025-04-17 21:46:12 UTC+0000 Thursday

Voting date falls into epoch 23.
Protocol upgrade will happen at the start of epoch 25: 2025-04-15 10:48:15 UTC+0000 Tuesday
```