### PR TITLE
refactor: cleanups around `EncodedShardChunk::new()`

### DIFF
--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -1070,7 +1070,7 @@ impl ShardsManagerActor {
         // well.  Otherwise we won’t bother.
         let (parts, encoded_length) = reed_solomon_encode(
             &self.rs,
-            TransactionReceipt(chunk.transactions().to_vec(), outgoing_receipts.to_vec()),
+            &TransactionReceipt(chunk.transactions().to_vec(), outgoing_receipts.to_vec()),
         );
 
         if header.encoded_length() != encoded_length as u64 {
@@ -2018,7 +2018,7 @@ impl ShardsManagerActor {
         signer: &ValidatorSigner,
         rs: &ReedSolomon,
         protocol_version: ProtocolVersion,
-    ) -> Result<(EncodedShardChunk, Vec<MerklePath>), Error> {
+    ) -> (EncodedShardChunk, Vec<MerklePath>) {
         EncodedShardChunk::new(
             prev_block_hash,
             prev_state_root,
@@ -2039,7 +2039,6 @@ impl ShardsManagerActor {
             signer,
             protocol_version,
         )
-        .map_err(|err| err.into())
     }
 
     fn distribute_encoded_chunk(

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -171,8 +171,7 @@ impl ChunkTestFixture {
             &signer,
             &rs,
             PROTOCOL_VERSION,
-        )
-        .unwrap();
+        );
 
         let all_part_ords: Vec<u64> =
             (0..mock_chunk.content().parts.len()).map(|p| p as u64).collect();

--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -308,7 +308,7 @@ impl ChunkProducer {
             &*validator_signer,
             &mut self.reed_solomon_encoder,
             protocol_version,
-        )?;
+        );
 
         span.record("chunk_hash", tracing::field::debug(encoded_chunk.chunk_hash()));
         debug!(target: "client",

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -230,8 +230,7 @@ pub fn create_chunk(
             header.bandwidth_requests().cloned(),
             &*signer,
             PROTOCOL_VERSION,
-        )
-        .unwrap();
+        );
         swap(&mut chunk, &mut encoded_chunk);
         swap(&mut merkle_paths, &mut new_merkle_paths);
     }

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -183,7 +183,7 @@ pub fn make_chunk_parts(chunk: ShardChunk) -> Vec<PartialEncodedChunkPart> {
     let rs = ReedSolomon::new(total_shard_count, parity_shard_count).unwrap();
     let transaction_receipts =
         (chunk.transactions().to_vec(), chunk.prev_outgoing_receipts().to_vec());
-    let (parts, _) = reed_solomon_encode(&rs, transaction_receipts);
+    let (parts, _) = reed_solomon_encode(&rs, &transaction_receipts);
 
     let mut content = EncodedShardChunkBody { parts };
     let (_, merkle_paths) = content.get_merkle_hash_and_paths();

--- a/core/primitives/src/genesis/chunk.rs
+++ b/core/primitives/src/genesis/chunk.rs
@@ -109,8 +109,7 @@ fn genesis_chunk(
         BandwidthRequests::default_for_protocol_version(genesis_protocol_version),
         &EmptyValidatorSigner::default().into(),
         genesis_protocol_version,
-    )
-    .expect("Failed to decode genesis chunk");
+    );
     encoded_chunk
 }
 
@@ -125,7 +124,7 @@ pub fn prod_genesis_chunks(
 
     let rs = ShardChunkReedSolomon::new(1, 2).unwrap();
     let (transaction_receipts_parts, encoded_length) =
-        reed_solomon_encode(&rs, TransactionReceipt(vec![], vec![]));
+        reed_solomon_encode(&rs, &TransactionReceipt(vec![], vec![]));
     let content = EncodedShardChunkBody { parts: transaction_receipts_parts };
     let (encoded_merkle_root, _) = content.get_merkle_hash_and_paths();
 

--- a/core/primitives/src/reed_solomon.rs
+++ b/core/primitives/src/reed_solomon.rs
@@ -12,9 +12,9 @@ pub type ReedSolomonPart = Option<Box<[u8]>>;
 // Encode function takes a serializable object and returns a tuple of parts and length of encoded data
 pub fn reed_solomon_encode<T: BorshSerialize>(
     rs: &ReedSolomon,
-    data: T,
+    data: &T,
 ) -> (Vec<ReedSolomonPart>, usize) {
-    let mut bytes = borsh::to_vec(&data).unwrap();
+    let mut bytes = borsh::to_vec(data).unwrap();
     let encoded_length = bytes.len();
 
     let data_parts = rs.data_shard_count();

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -1234,10 +1234,10 @@ impl EncodedShardChunk {
         bandwidth_requests: Option<BandwidthRequests>,
         signer: &ValidatorSigner,
         protocol_version: ProtocolVersion,
-    ) -> Result<(Self, Vec<MerklePath>), std::io::Error> {
+    ) -> (Self, Vec<MerklePath>) {
         let (transaction_receipts_parts, encoded_length) = crate::reed_solomon::reed_solomon_encode(
             rs,
-            TransactionReceipt(transactions, prev_outgoing_receipts.to_vec()),
+            &TransactionReceipt(transactions, prev_outgoing_receipts.to_vec()),
         );
         let content = EncodedShardChunkBody { parts: transaction_receipts_parts };
         let (encoded_merkle_root, merkle_paths) = content.get_merkle_hash_and_paths();
@@ -1265,7 +1265,7 @@ impl EncodedShardChunk {
                 signer,
             );
             let chunk = EncodedShardChunkV2 { header: ShardChunkHeader::V2(header), content };
-            Ok((Self::V2(chunk), merkle_paths))
+            (Self::V2(chunk), merkle_paths)
         } else {
             let header = ShardChunkHeaderV3::new(
                 protocol_version,
@@ -1287,7 +1287,7 @@ impl EncodedShardChunk {
                 signer,
             );
             let chunk = EncodedShardChunkV2 { header: ShardChunkHeader::V3(header), content };
-            Ok((Self::V2(chunk), merkle_paths))
+            (Self::V2(chunk), merkle_paths)
         }
     }
 

--- a/core/store/benches/finalize_bench.rs
+++ b/core/store/benches/finalize_bench.rs
@@ -215,7 +215,6 @@ fn create_encoded_shard_chunk(
         &rs,
         100,
     )
-    .unwrap()
 }
 
 fn encoded_chunk_to_partial_encoded_chunk(


### PR DESCRIPTION
- It doesn't need to return a `Result`
- It can call encoding with a reference to the data

These changes will help in a future PR where I hope to be able to remove the cloning of receipts.

Part of https://github.com/near/nearcore/issues/13140