### PR TITLE
feat: `SimpleNightshadeV6`: shard 0 split at account `600`

### DIFF
--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -35,7 +35,7 @@ fn build_chain() {
     if cfg!(feature = "nightly") {
         insta::assert_snapshot!(hash, @"24ZC3eGVvtFdTEok4wPGBzx3x61tWqQpves7nFvow2zf");
     } else {
-        insta::assert_snapshot!(hash, @"H9Zwj5FbNS5qHQQy82CN4vmUgQL2ZKuYqxAmf1uiZASW");
+        insta::assert_snapshot!(hash, @"t1RB3jTh9mMtkQ1YFWxGMYefGcppSLYcJjvH7BXoSTz");
     }
 
     for i in 1..5 {
@@ -53,7 +53,7 @@ fn build_chain() {
     if cfg!(feature = "nightly") {
         insta::assert_snapshot!(hash, @"9enFQNcVUW65x3oW2iVdYSBxK9qFNETAixEQZLzXWeaQ");
     } else {
-        insta::assert_snapshot!(hash, @"5GJyJaskWo6dM6mqKUni4HktC7mBcPJ1Be2wpyQM3Ryc");
+        insta::assert_snapshot!(hash, @"2HKQZ9swQZnWwv23TF6uYBfQ9up7faG3zvDDvjgvSgkf");
     }
 }
 

--- a/chain/jsonrpc/jsonrpc-tests/res/genesis_config.json
+++ b/chain/jsonrpc/jsonrpc-tests/res/genesis_config.json
@@ -1,5 +1,5 @@
 {
-  "protocol_version": 77,
+  "protocol_version": 78,
   "genesis_time": "1970-01-01T00:00:00.000000000Z",
   "chain_id": "sample",
   "genesis_height": 0,

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -213,6 +213,8 @@ pub enum ProtocolFeature {
     SimpleNightshadeV4,
     /// Resharding V3 - Adding "earn.kaiching" boundary.
     SimpleNightshadeV5,
+    /// Resharding V3 - Adding "600" boundary.
+    SimpleNightshadeV6,
     /// Exclude contract code from the chunk state witness and distribute it to chunk validators separately.
     ExcludeContractCodeFromStateWitness,
     /// A scheduler which limits bandwidth for sending receipts between shards.
@@ -335,6 +337,7 @@ impl ProtocolFeature {
             ProtocolFeature::GlobalContracts
             | ProtocolFeature::BlockHeightForReceiptId
             | ProtocolFeature::ProduceOptimisticBlock => 77,
+            ProtocolFeature::SimpleNightshadeV6 => 78,
 
             // Nightly features:
             ProtocolFeature::FixContractLoadingCost => 129,
@@ -358,7 +361,7 @@ pub const PROD_GENESIS_PROTOCOL_VERSION: ProtocolVersion = 29;
 pub const MIN_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = 75;
 
 /// Current protocol version used on the mainnet with all stable features.
-const STABLE_PROTOCOL_VERSION: ProtocolVersion = 77;
+const STABLE_PROTOCOL_VERSION: ProtocolVersion = 78;
 
 // On nightly, pick big enough version to support all features.
 const NIGHTLY_PROTOCOL_VERSION: ProtocolVersion = 149;

--- a/core/primitives/res/epoch_configs/mainnet/78.json
+++ b/core/primitives/res/epoch_configs/mainnet/78.json
@@ -1,0 +1,141 @@
+{
+  "epoch_length": 43200,
+  "num_block_producer_seats": 100,
+  "num_block_producer_seats_per_shard": [
+    100,
+    100,
+    100,
+    100,
+    100,
+    100,
+    100,
+    100,
+    100
+  ],
+  "avg_hidden_validator_seats_per_shard": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
+  "block_producer_kickout_threshold": 80,
+  "chunk_producer_kickout_threshold": 80,
+  "chunk_validator_only_kickout_threshold": 70,
+  "target_validator_mandates_per_shard": 68,
+  "validator_max_kickout_stake_perc": 30,
+  "online_min_threshold": [
+    90,
+    100
+  ],
+  "online_max_threshold": [
+    99,
+    100
+  ],
+  "fishermen_threshold": "340282366920938463463374607431768211455",
+  "minimum_stake_divisor": 10,
+  "protocol_upgrade_stake_threshold": [
+    4,
+    5
+  ],
+  "shard_layout": {
+    "V2": {
+      "boundary_accounts": [
+        "600",
+        "aurora",
+        "aurora-0",
+        "earn.kaiching",
+        "game.hot.tg",
+        "game.hot.tg-0",
+        "kkuuue2akv_1630967379.near",
+        "tge-lockup.sweat"
+      ],
+      "shard_ids": [
+        10,
+        11,
+        1,
+        8,
+        9,
+        6,
+        7,
+        4,
+        5
+      ],
+      "id_to_index_map": {
+        "1": 2,
+        "10": 0,
+        "11": 1,
+        "4": 7,
+        "5": 8,
+        "6": 5,
+        "7": 6,
+        "8": 3,
+        "9": 4
+      },
+      "index_to_id_map": {
+        "0": 10,
+        "1": 11,
+        "2": 1,
+        "3": 8,
+        "4": 9,
+        "5": 6,
+        "6": 7,
+        "7": 4,
+        "8": 5
+      },
+      "shards_split_map": {
+        "0": [
+          10,
+          11
+        ],
+        "1": [
+          1
+        ],
+        "4": [
+          4
+        ],
+        "5": [
+          5
+        ],
+        "6": [
+          6
+        ],
+        "7": [
+          7
+        ],
+        "8": [
+          8
+        ],
+        "9": [
+          9
+        ]
+      },
+      "shards_parent_map": {
+        "1": 1,
+        "10": 0,
+        "11": 0,
+        "4": 4,
+        "5": 5,
+        "6": 6,
+        "7": 7,
+        "8": 8,
+        "9": 9
+      },
+      "version": 3
+    }
+  },
+  "num_chunk_producer_seats": 100,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 0,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    62500
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
+}

--- a/core/primitives/res/epoch_configs/testnet/78.json
+++ b/core/primitives/res/epoch_configs/testnet/78.json
@@ -1,0 +1,141 @@
+{
+  "epoch_length": 43200,
+  "num_block_producer_seats": 20,
+  "num_block_producer_seats_per_shard": [
+    20,
+    20,
+    20,
+    20,
+    20,
+    20,
+    20,
+    20,
+    20
+  ],
+  "avg_hidden_validator_seats_per_shard": [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0
+  ],
+  "block_producer_kickout_threshold": 80,
+  "chunk_producer_kickout_threshold": 80,
+  "chunk_validator_only_kickout_threshold": 70,
+  "target_validator_mandates_per_shard": 68,
+  "validator_max_kickout_stake_perc": 30,
+  "online_min_threshold": [
+    90,
+    100
+  ],
+  "online_max_threshold": [
+    99,
+    100
+  ],
+  "fishermen_threshold": "340282366920938463463374607431768211455",
+  "minimum_stake_divisor": 10,
+  "protocol_upgrade_stake_threshold": [
+    4,
+    5
+  ],
+  "shard_layout": {
+    "V2": {
+      "boundary_accounts": [
+        "600",
+        "aurora",
+        "aurora-0",
+        "earn.kaiching",
+        "game.hot.tg",
+        "game.hot.tg-0",
+        "kkuuue2akv_1630967379.near",
+        "tge-lockup.sweat"
+      ],
+      "shard_ids": [
+        10,
+        11,
+        1,
+        8,
+        9,
+        6,
+        7,
+        4,
+        5
+      ],
+      "id_to_index_map": {
+        "1": 2,
+        "10": 0,
+        "11": 1,
+        "4": 7,
+        "5": 8,
+        "6": 5,
+        "7": 6,
+        "8": 3,
+        "9": 4
+      },
+      "index_to_id_map": {
+        "0": 10,
+        "1": 11,
+        "2": 1,
+        "3": 8,
+        "4": 9,
+        "5": 6,
+        "6": 7,
+        "7": 4,
+        "8": 5
+      },
+      "shards_split_map": {
+        "0": [
+          10,
+          11
+        ],
+        "1": [
+          1
+        ],
+        "4": [
+          4
+        ],
+        "5": [
+          5
+        ],
+        "6": [
+          6
+        ],
+        "7": [
+          7
+        ],
+        "8": [
+          8
+        ],
+        "9": [
+          9
+        ]
+      },
+      "shards_parent_map": {
+        "1": 1,
+        "10": 0,
+        "11": 0,
+        "4": 4,
+        "5": 5,
+        "6": 6,
+        "7": 7,
+        "8": 8,
+        "9": 9
+      },
+      "version": 3
+    }
+  },
+  "num_chunk_producer_seats": 20,
+  "num_chunk_validator_seats": 300,
+  "num_chunk_only_producer_seats": 0,
+  "minimum_validators_per_shard": 1,
+  "minimum_stake_ratio": [
+    1,
+    62500
+  ],
+  "chunk_producer_assignment_changes_limit": 5,
+  "shuffle_shard_assignment_for_chunk_producers": false
+}

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -291,6 +291,7 @@ static CONFIGS: &[(&str, ProtocolVersion, &str)] = &[
     include_config!("mainnet", 72, "72.json"),
     include_config!("mainnet", 75, "75.json"),
     include_config!("mainnet", 76, "76.json"),
+    include_config!("mainnet", 78, "78.json"),
     include_config!("mainnet", 143, "143.json"),
     // Epoch configs for testnet (genesis protocol version is 29).
     include_config!("testnet", 29, "29.json"),
@@ -304,6 +305,7 @@ static CONFIGS: &[(&str, ProtocolVersion, &str)] = &[
     include_config!("testnet", 72, "72.json"),
     include_config!("testnet", 75, "75.json"),
     include_config!("testnet", 76, "76.json"),
+    include_config!("mainnet", 78, "78.json"),
     include_config!("testnet", 143, "143.json"),
 ];
 

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -561,8 +561,15 @@ impl ShardLayout {
         ShardLayout::derive_shard_layout(&base_shard_layout, new_boundary_account)
     }
 
+    /// Returns the simple nightshade layout, version 6, with new boundary account "600".
+    pub fn get_simple_nightshade_layout_v6() -> ShardLayout {
+        let base_shard_layout = Self::get_simple_nightshade_layout_v5();
+        let new_boundary_account = "600".parse().unwrap();
+        ShardLayout::derive_shard_layout(&base_shard_layout, new_boundary_account)
+    }
+
     /// This layout is used only in resharding tests. It allows testing of any features which were
-    /// introduced after the last layout upgrade in production. Currently it is built on top of V3.
+    /// introduced after the last layout upgrade in production. Currently, it is built on top of V3.
     #[cfg(feature = "nightly")]
     pub fn get_simple_nightshade_layout_testonly() -> ShardLayout {
         #[allow(deprecated)]
@@ -683,7 +690,7 @@ impl ShardLayout {
     /// Return the parent shard id for a given shard in the shard layout. Only
     /// calls this function for shard layout that has parent shard layout.
     /// Returns an error if `shard_id` is an invalid shard id in the current
-    /// layout or if the shard is has no parent in this shard layout.
+    /// layout or if the shard has no parent in this shard layout.
     pub fn get_parent_shard_id(&self, shard_id: ShardId) -> Result<ShardId, ShardLayoutError> {
         let parent_shard_id = self.try_get_parent_shard_id(shard_id)?;
         parent_shard_id.ok_or(ShardLayoutError::NoParentError { shard_id })
@@ -747,7 +754,7 @@ impl ShardLayout {
         match self {
             Self::V0(v0) => v0.num_shards,
             Self::V1(v1) => (v1.boundary_accounts.len() + 1) as NumShards,
-            Self::V2(v2) => (v2.shard_ids.len()) as NumShards,
+            Self::V2(v2) => v2.shard_ids.len() as NumShards,
         }
     }
 
@@ -778,7 +785,7 @@ impl ShardLayout {
 
     /// Returns an iterator that returns the ShardInfos for every shard in
     /// this shard layout. This method should be preferred over calling
-    /// shard_ids().enumerate(). Today the result of shard_ids() is sorted but
+    /// shard_ids().enumerate(). Today the result of shard_ids() is sorted, but
     /// it may be changed in the future.
     pub fn shard_infos(&self) -> impl Iterator<Item = ShardInfo> + '_ {
         self.shard_uids()
@@ -822,7 +829,7 @@ impl ShardLayout {
         }
     }
 
-    /// Returns all of the shards from the previous shard layout that were
+    /// Returns all the shards from the previous shard layout that were
     /// split into multiple shards in this shard layout.
     pub fn get_split_parent_shard_ids(&self) -> Result<BTreeSet<ShardId>, ShardLayoutError> {
         let mut parent_shard_ids = BTreeSet::new();
@@ -857,7 +864,7 @@ fn validate_and_derive_shard_parent_map_v2(
             assert_eq!(parent_shard_id, child_shard_id);
         } else {
             // The parent shards with multiple children shards are split.
-            // The parent shard id should not longer be used.
+            // The parent shard id should no longer be used.
             assert!(!shard_ids.contains(&parent_shard_id));
         }
     }
@@ -1314,6 +1321,7 @@ mod tests {
         let v3 = ShardLayout::get_simple_nightshade_layout_v3();
         let v4 = ShardLayout::get_simple_nightshade_layout_v4();
         let v5 = ShardLayout::get_simple_nightshade_layout_v5();
+        let v6 = ShardLayout::get_simple_nightshade_layout_v6();
 
         insta::assert_snapshot!(serde_json::to_string_pretty(&v0).unwrap(), @r###"
         {
@@ -1573,6 +1581,95 @@ mod tests {
               "7": 7,
               "8": 2,
               "9": 2
+            },
+            "version": 3
+          }
+        }
+        "###);
+
+        insta::assert_snapshot!(serde_json::to_string_pretty(&v6).unwrap(), @r###"
+        {
+          "V2": {
+            "boundary_accounts": [
+              "600",
+              "aurora",
+              "aurora-0",
+              "earn.kaiching",
+              "game.hot.tg",
+              "game.hot.tg-0",
+              "kkuuue2akv_1630967379.near",
+              "tge-lockup.sweat"
+            ],
+            "shard_ids": [
+              10,
+              11,
+              1,
+              8,
+              9,
+              6,
+              7,
+              4,
+              5
+            ],
+            "id_to_index_map": {
+              "1": 2,
+              "10": 0,
+              "11": 1,
+              "4": 7,
+              "5": 8,
+              "6": 5,
+              "7": 6,
+              "8": 3,
+              "9": 4
+            },
+            "index_to_id_map": {
+              "0": 10,
+              "1": 11,
+              "2": 1,
+              "3": 8,
+              "4": 9,
+              "5": 6,
+              "6": 7,
+              "7": 4,
+              "8": 5
+            },
+            "shards_split_map": {
+              "0": [
+                10,
+                11
+              ],
+              "1": [
+                1
+              ],
+              "4": [
+                4
+              ],
+              "5": [
+                5
+              ],
+              "6": [
+                6
+              ],
+              "7": [
+                7
+              ],
+              "8": [
+                8
+              ],
+              "9": [
+                9
+              ]
+            },
+            "shards_parent_map": {
+              "1": 1,
+              "10": 0,
+              "11": 0,
+              "4": 4,
+              "5": 5,
+              "6": 6,
+              "7": 7,
+              "8": 8,
+              "9": 9
             },
             "version": 3
           }


### PR DESCRIPTION
Shard `0` is currently the biggest one.
```
    total_size: 18.8 GB,
    total_count: 78866834,
    average_size: 238 B,
    middle_account: StateStatsAccount {
        account_id: "6318411008.tg",
        size: 143 B,
    },
    split_size: "9.4 GB : 143 B : 9.4 GB",
    split_percent: "49:0:49",
```

The split account providing most even split would be `6318411008.tg`, but `600` was chosen instead as it is easier to memorize.