### PR TITLE
cleanup: no need to look up `BlockInfo::slashed()`

### DIFF
--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -88,31 +88,17 @@ impl EpochInfoProvider for EpochManagerHandle {
     fn validator_stake(
         &self,
         epoch_id: &EpochId,
-        last_block_hash: &CryptoHash,
         account_id: &AccountId,
     ) -> Result<Option<Balance>, EpochError> {
         let epoch_manager = self.read();
-        let last_block_info = epoch_manager.get_block_info(last_block_hash)?;
-        if last_block_info.slashed().contains_key(account_id) {
-            return Ok(None);
-        }
         let epoch_info = epoch_manager.get_epoch_info(epoch_id)?;
         Ok(epoch_info.get_validator_id(account_id).map(|id| epoch_info.validator_stake(*id)))
     }
 
-    fn validator_total_stake(
-        &self,
-        epoch_id: &EpochId,
-        last_block_hash: &CryptoHash,
-    ) -> Result<Balance, EpochError> {
+    fn validator_total_stake(&self, epoch_id: &EpochId) -> Result<Balance, EpochError> {
         let epoch_manager = self.read();
-        let last_block_info = epoch_manager.get_block_info(last_block_hash)?;
         let epoch_info = epoch_manager.get_epoch_info(epoch_id)?;
-        Ok(epoch_info
-            .validators_iter()
-            .filter(|info| !last_block_info.slashed().contains_key(info.account_id()))
-            .map(|info| info.stake())
-            .sum())
+        Ok(epoch_info.validators_iter().map(|info| info.stake()).sum())
     }
 
     fn minimum_stake(&self, prev_block_hash: &CryptoHash) -> Result<Balance, EpochError> {

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -1072,17 +1072,12 @@ impl EpochInfoProvider for MockEpochInfoProvider {
     fn validator_stake(
         &self,
         _epoch_id: &EpochId,
-        _last_block_hash: &CryptoHash,
         account_id: &AccountId,
     ) -> Result<Option<Balance>, EpochError> {
         Ok(self.validators.get(account_id).cloned())
     }
 
-    fn validator_total_stake(
-        &self,
-        _epoch_id: &EpochId,
-        _last_block_hash: &CryptoHash,
-    ) -> Result<Balance, EpochError> {
+    fn validator_total_stake(&self, _epoch_id: &EpochId) -> Result<Balance, EpochError> {
         Ok(self.validators.values().sum())
     }
 

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -1162,16 +1162,11 @@ pub trait EpochInfoProvider: Send + Sync {
     fn validator_stake(
         &self,
         epoch_id: &EpochId,
-        last_block_hash: &CryptoHash,
         account_id: &AccountId,
     ) -> Result<Option<Balance>, EpochError>;
 
     /// Get the total stake of the given epoch.
-    fn validator_total_stake(
-        &self,
-        epoch_id: &EpochId,
-        last_block_hash: &CryptoHash,
-    ) -> Result<Balance, EpochError>;
+    fn validator_total_stake(&self, epoch_id: &EpochId) -> Result<Balance, EpochError>;
 
     fn minimum_stake(&self, prev_block_hash: &CryptoHash) -> Result<Balance, EpochError>;
 

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -198,7 +198,6 @@ pub(crate) fn action_function_call(
         account.clone(),
         *action_hash,
         apply_state.epoch_id,
-        apply_state.prev_block_hash,
         apply_state.block_hash,
         apply_state.block_height,
         epoch_info_provider,

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -25,7 +25,6 @@ pub struct RuntimeExt<'a> {
     action_hash: CryptoHash,
     data_count: u64,
     epoch_id: EpochId,
-    prev_block_hash: CryptoHash,
     last_block_hash: CryptoHash,
     block_height: BlockHeight,
     epoch_info_provider: &'a dyn EpochInfoProvider,
@@ -82,7 +81,6 @@ impl<'a> RuntimeExt<'a> {
         account: Account,
         action_hash: CryptoHash,
         epoch_id: EpochId,
-        prev_block_hash: CryptoHash,
         last_block_hash: CryptoHash,
         block_height: BlockHeight,
         epoch_info_provider: &'a dyn EpochInfoProvider,
@@ -97,7 +95,6 @@ impl<'a> RuntimeExt<'a> {
             action_hash,
             data_count: 0,
             epoch_id,
-            prev_block_hash,
             last_block_hash,
             block_height,
             epoch_info_provider,
@@ -321,13 +318,13 @@ impl<'a> External for RuntimeExt<'a> {
 
     fn validator_stake(&self, account_id: &AccountId) -> ExtResult<Option<Balance>> {
         self.epoch_info_provider
-            .validator_stake(&self.epoch_id, &self.prev_block_hash, account_id)
+            .validator_stake(&self.epoch_id, account_id)
             .map_err(|e| ExternalError::ValidatorError(e).into())
     }
 
     fn validator_total_stake(&self) -> ExtResult<Balance> {
         self.epoch_info_provider
-            .validator_total_stake(&self.epoch_id, &self.prev_block_hash)
+            .validator_total_stake(&self.epoch_id)
             .map_err(|e| ExternalError::ValidatorError(e).into())
     }
 

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -271,7 +271,6 @@ impl TrieViewer {
             account,
             empty_hash,
             view_state.epoch_id,
-            view_state.prev_block_hash,
             view_state.block_hash,
             view_state.block_height,
             epoch_info_provider,


### PR DESCRIPTION
Part of https://github.com/near/nearcore/issues/13231.  I am intentionally creating a small PR here as I am experiencing some test failures with larger scopes and using smaller PRs to isolate the test failures.