### PR TITLE
test: unignore test_request_chunk_restart

### DIFF
--- a/integration-tests/src/env/test_env.rs
+++ b/integration-tests/src/env/test_env.rs
@@ -82,16 +82,11 @@ pub struct StateWitnessPropagationOutput {
 }
 
 impl TestEnv {
-    pub fn default_builder() -> TestEnvBuilder {
-        let clock = Clock::real();
-        TestEnvBuilder::new(GenesisConfig::test(clock.clone())).clock(clock)
-    }
-
     pub fn builder(genesis_config: &GenesisConfig) -> TestEnvBuilder {
         TestEnvBuilder::new(genesis_config.clone())
     }
 
-    pub fn default_builder_with_genesis() -> TestEnvBuilder {
+    pub fn default_builder() -> TestEnvBuilder {
         let genesis = Genesis::test(vec!["test0".parse().unwrap()], 1);
         TestEnvBuilder::from_genesis(genesis)
     }

--- a/integration-tests/src/tests/client/chunks_management.rs
+++ b/integration-tests/src/tests/client/chunks_management.rs
@@ -575,8 +575,6 @@ fn ultra_slow_test_chunks_recovered_from_full_cop() {
     .run()
 }
 
-// TODO(#8269) Enable test after fixing the issue related to KeyValueRuntime. See env.restart()
-#[ignore]
 #[test]
 fn test_request_chunk_restart() {
     init_integration_logger();

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -855,7 +855,7 @@ fn test_process_invalid_tx() {
 #[test]
 fn test_time_attack() {
     init_test_logger();
-    let mut env = TestEnv::default_builder_with_genesis().clients_count(1).build();
+    let mut env = TestEnv::default_builder().clients_count(1).build();
     let client = &mut env.clients[0];
     let signer = client.validator_signer.get().unwrap();
     let genesis = client.chain.get_block_by_height(0).unwrap();
@@ -873,7 +873,7 @@ fn test_time_attack() {
 
 #[test]
 fn test_no_double_sign() {
-    let mut env = TestEnv::default_builder_with_genesis().build();
+    let mut env = TestEnv::default_builder().build();
     let _ = env.clients[0].produce_block(1).unwrap().unwrap();
     // Second time producing with the same height should fail.
     assert_eq!(env.clients[0].produce_block(1).unwrap(), None);
@@ -899,7 +899,7 @@ fn test_invalid_gas_price() {
 
 #[test]
 fn test_invalid_height_too_large() {
-    let mut env = TestEnv::default_builder_with_genesis().build();
+    let mut env = TestEnv::default_builder().build();
     let b1 = env.clients[0].produce_block(1).unwrap().unwrap();
     let _ = env.clients[0].process_block_test(b1.clone().into(), Provenance::PRODUCED).unwrap();
     let signer = Arc::new(create_test_signer("test0"));
@@ -931,7 +931,7 @@ fn test_invalid_height_too_old() {
 
 #[test]
 fn test_bad_orphan() {
-    let mut env = TestEnv::default_builder_with_genesis().build();
+    let mut env = TestEnv::default_builder().build();
     for i in 1..4 {
         env.produce_block(0, i);
     }
@@ -1912,7 +1912,7 @@ fn test_gas_price_overflow() {
 
 #[test]
 fn test_invalid_block_root() {
-    let mut env = TestEnv::default_builder_with_genesis().build();
+    let mut env = TestEnv::default_builder().build();
     let mut b1 = env.clients[0].produce_block(1).unwrap().unwrap();
     let signer = create_test_signer("test0");
     b1.mut_header().set_block_merkle_root(CryptoHash::default());
@@ -1935,7 +1935,7 @@ fn test_incorrect_validator_key_produce_block() {
 }
 
 fn test_block_merkle_proof_with_len(n: NumBlocks, rng: &mut StdRng) {
-    let mut env = TestEnv::default_builder_with_genesis().build();
+    let mut env = TestEnv::default_builder().build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let mut blocks = vec![genesis_block.clone()];
     let mut cur_height = genesis_block.header().height() + 1;
@@ -2005,7 +2005,7 @@ fn test_block_merkle_proof() {
 
 #[test]
 fn test_block_merkle_proof_same_hash() {
-    let env = TestEnv::default_builder_with_genesis().build();
+    let env = TestEnv::default_builder().build();
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let proof = env.clients[0]
         .chain
@@ -2115,7 +2115,7 @@ fn test_sync_hash_validity() {
 
 #[test]
 fn test_block_height_processed_orphan() {
-    let mut env = TestEnv::default_builder_with_genesis().build();
+    let mut env = TestEnv::default_builder().build();
     let block = env.clients[0].produce_block(1).unwrap().unwrap();
     let mut orphan_block = block;
     let validator_signer = create_test_signer("test0");

--- a/integration-tests/src/tests/client/process_blocks2.rs
+++ b/integration-tests/src/tests/client/process_blocks2.rs
@@ -27,7 +27,7 @@ use crate::env::test_env_builder::TestEnvBuilder;
 /// if the second block is not requested
 #[test]
 fn test_not_process_height_twice() {
-    let mut env = TestEnv::default_builder_with_genesis().build();
+    let mut env = TestEnv::default_builder().build();
     let block = env.clients[0].produce_block(1).unwrap().unwrap();
     // modify the block and resign it
     let mut duplicate_block = block.clone();


### PR DESCRIPTION
Part of #10634

Changing runtime of the test to the real runtime made it pass. This was the last use site of TestEnv::default_builder so I renamed default_builder_with_genesis to be the new default_builder.

default_builder_with_genesis would always work and make sure that the real epoch manager and runtime are used.