### PR TITLE
parameters: remove always-true settings

### DIFF
--- a/core/parameters/res/runtime_configs/46.yaml
+++ b/core/parameters/res/runtime_configs/46.yaml
@@ -1,1 +1,0 @@
-math_extension: { old: false, new: true }

--- a/core/parameters/res/runtime_configs/53.yaml
+++ b/core/parameters/res/runtime_configs/53.yaml
@@ -12,4 +12,3 @@ action_deploy_contract_per_byte: {
 }
 max_length_storage_key: { old: 4_194_304, new: 2_048 }
 max_locals_per_contract: { new: 1_000_000 }
-function_call_weight: { old: false, new: true }

--- a/core/parameters/res/runtime_configs/55.yaml
+++ b/core/parameters/res/runtime_configs/55.yaml
@@ -1,1 +1,0 @@
-alt_bn128: { old: false, new: true }

--- a/core/parameters/res/runtime_configs/59.yaml
+++ b/core/parameters/res/runtime_configs/59.yaml
@@ -1,4 +1,3 @@
-ed25519_verify: { old: false, new: true }
 action_create_account: {
   old: {
     send_sir: 99_607_375_000,

--- a/core/parameters/res/runtime_configs/67.yaml
+++ b/core/parameters/res/runtime_configs/67.yaml
@@ -1,4 +1,3 @@
-yield_resume: { old: false, new: true }
 wasm_yield_create_base: { old: 300_000_000_000_000, new: 153_411_779_276 }
 wasm_yield_create_byte: { old: 300_000_000_000_000, new: 15_643_988 }
 wasm_yield_resume_base: { old: 300_000_000_000_000, new: 1_195_627_285_210 }

--- a/core/parameters/res/runtime_configs/parameters.snap
+++ b/core/parameters/res/runtime_configs/parameters.snap
@@ -198,13 +198,8 @@ disable_9393_fix                        false
 flat_storage_reads                      true
 implicit_account_creation               true
 fix_contract_loading_cost               false
-math_extension                          true
-ed25519_verify                          true
-alt_bn128                               true
-function_call_weight                    true
 vm_kind                                 NearVm
 eth_implicit_accounts                   true
-yield_resume                            true
 discard_custom_sections                 true
 max_congestion_incoming_gas             400_000_000_000_000_000
 max_congestion_outgoing_gas             10_000_000_000_000_000

--- a/core/parameters/res/runtime_configs/parameters.yaml
+++ b/core/parameters/res/runtime_configs/parameters.yaml
@@ -237,13 +237,8 @@ disable_9393_fix: false
 flat_storage_reads: false
 implicit_account_creation: false
 fix_contract_loading_cost: false
-math_extension: false
-ed25519_verify: false
-alt_bn128: false
-function_call_weight: false
 vm_kind: Wasmer0
 eth_implicit_accounts: false
-yield_resume: false
 discard_custom_sections: false
 
 

--- a/core/parameters/res/runtime_configs/parameters_testnet.yaml
+++ b/core/parameters/res/runtime_configs/parameters_testnet.yaml
@@ -232,13 +232,8 @@ disable_9393_fix: false
 flat_storage_reads: false
 implicit_account_creation: false
 fix_contract_loading_cost: false
-math_extension: false
-ed25519_verify: false
-alt_bn128: false
-function_call_weight: false
 vm_kind: Wasmer0
 eth_implicit_accounts: false
-yield_resume: false
 discard_custom_sections: false
 
 # TODO What should be the config for testnet?

--- a/core/parameters/src/parameter.rs
+++ b/core/parameters/src/parameter.rs
@@ -165,7 +165,6 @@ pub enum Parameter {
     MaxGasBurnt,
     MaxGasBurntView,
     MaxStackHeight,
-    ContractPrepareVersion,
     InitialMemoryPages,
     MaxMemoryPages,
     RegistersMemoryLimit,
@@ -198,13 +197,8 @@ pub enum Parameter {
     FlatStorageReads,
     ImplicitAccountCreation,
     FixContractLoadingCost,
-    MathExtension,
-    Ed25519Verify,
-    AltBn128,
-    FunctionCallWeight,
     VmKind,
     EthImplicitAccounts,
-    YieldResume,
     DiscardCustomSections,
 
     // Congestion Control
@@ -281,7 +275,6 @@ impl Parameter {
         [
             Parameter::MaxGasBurnt,
             Parameter::MaxStackHeight,
-            Parameter::ContractPrepareVersion,
             Parameter::InitialMemoryPages,
             Parameter::MaxMemoryPages,
             Parameter::RegistersMemoryLimit,

--- a/core/parameters/src/parameter_table.rs
+++ b/core/parameters/src/parameter_table.rs
@@ -325,12 +325,7 @@ impl TryFrom<&ParameterTable> for RuntimeConfig {
                     false => StorageGetMode::Trie,
                 },
                 implicit_account_creation: params.get(Parameter::ImplicitAccountCreation)?,
-                math_extension: params.get(Parameter::MathExtension)?,
-                ed25519_verify: params.get(Parameter::Ed25519Verify)?,
-                alt_bn128: params.get(Parameter::AltBn128)?,
-                function_call_weight: params.get(Parameter::FunctionCallWeight)?,
                 eth_implicit_accounts: params.get(Parameter::EthImplicitAccounts)?,
-                yield_resume_host_functions: params.get(Parameter::YieldResume)?,
             }),
             account_creation_config: AccountCreationConfig {
                 min_allowed_top_level_account_length: params

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__0.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__0.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": false,
-    "math_extension": false,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__129.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": true,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": true,
-    "yield_resume_host_functions": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__35.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__35.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": false,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__42.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__42.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": false,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__46.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__46.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__48.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__48.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__49.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__49.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__50.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__50.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__52.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__52.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__53.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__53.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__55.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__55.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": false,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__57.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__57.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": false,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__59.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__59.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__61.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__61.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__62.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__62.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__63.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__63.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__64.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__64.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__66.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__66.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__67.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__67.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__68.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__68.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__69.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__69.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__70.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__70.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": true,
-    "yield_resume_host_functions": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__72.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__72.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": true,
-    "yield_resume_host_functions": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__73.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__73.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": true,
-    "yield_resume_host_functions": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__74.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__74.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": true,
-    "yield_resume_host_functions": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__77.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__77.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": true,
-    "yield_resume_host_functions": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_0.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_0.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": false,
-    "math_extension": false,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": true,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": true,
-    "yield_resume_host_functions": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_35.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_35.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": false,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_42.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_42.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": false,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_46.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_46.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_48.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_48.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_49.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_49.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_50.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_50.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 200000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_52.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_52.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": false,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_53.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_53.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": false,
-    "alt_bn128": false,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_55.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_55.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": false,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_57.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_57.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": false,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_59.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_59.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_61.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_61.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 16384,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_62.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_62.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_63.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_63.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_64.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_64.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_66.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_66.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": false,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_67.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_67.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_68.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_68.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_69.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_69.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": false,
-    "yield_resume_host_functions": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_70.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_70.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": true,
-    "yield_resume_host_functions": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_72.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_72.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": true,
-    "yield_resume_host_functions": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_73.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_73.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": true,
-    "yield_resume_host_functions": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_74.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_74.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": true,
-    "yield_resume_host_functions": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_77.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_77.json.snap
@@ -202,12 +202,7 @@ expression: config_view
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": true,
-    "yield_resume_host_functions": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/snapshots/near_parameters__view__tests__runtime_config_view.snap
+++ b/core/parameters/src/snapshots/near_parameters__view__tests__runtime_config_view.snap
@@ -202,12 +202,7 @@ expression: "&view"
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": true,
-    "yield_resume_host_functions": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/core/parameters/src/view.rs
+++ b/core/parameters/src/view.rs
@@ -223,18 +223,8 @@ pub struct VMConfigView {
     pub fix_contract_loading_cost: bool,
     /// See [VMConfig::implicit_account_creation](crate::vm::Config::implicit_account_creation).
     pub implicit_account_creation: bool,
-    /// See [VMConfig::math_extension](crate::vm::Config::math_extension).
-    pub math_extension: bool,
-    /// See [VMConfig::ed25519_verify](crate::vm::Config::ed25519_verify).
-    pub ed25519_verify: bool,
-    /// See [VMConfig::alt_bn128](crate::vm::Config::alt_bn128).
-    pub alt_bn128: bool,
-    /// See [VMConfig::function_call_weight](crate::vm::Config::function_call_weight).
-    pub function_call_weight: bool,
     /// See [VMConfig::eth_implicit_accounts](crate::vm::Config::eth_implicit_accounts).
     pub eth_implicit_accounts: bool,
-    /// See [VMConfig::yield_resume_host_functions](`crate::vm::Config::yield_resume_host_functions).
-    pub yield_resume_host_functions: bool,
 
     /// Describes limits for VM and Runtime.
     ///
@@ -255,13 +245,8 @@ impl From<crate::vm::Config> for VMConfigView {
             storage_get_mode: config.storage_get_mode,
             fix_contract_loading_cost: config.fix_contract_loading_cost,
             implicit_account_creation: config.implicit_account_creation,
-            math_extension: config.math_extension,
-            ed25519_verify: config.ed25519_verify,
-            alt_bn128: config.alt_bn128,
-            function_call_weight: config.function_call_weight,
             vm_kind: config.vm_kind,
             eth_implicit_accounts: config.eth_implicit_accounts,
-            yield_resume_host_functions: config.yield_resume_host_functions,
         }
     }
 }
@@ -278,13 +263,8 @@ impl From<VMConfigView> for crate::vm::Config {
             storage_get_mode: view.storage_get_mode,
             fix_contract_loading_cost: view.fix_contract_loading_cost,
             implicit_account_creation: view.implicit_account_creation,
-            math_extension: view.math_extension,
-            ed25519_verify: view.ed25519_verify,
-            alt_bn128: view.alt_bn128,
-            function_call_weight: view.function_call_weight,
             vm_kind: view.vm_kind,
             eth_implicit_accounts: view.eth_implicit_accounts,
-            yield_resume_host_functions: view.yield_resume_host_functions,
         }
     }
 }

--- a/core/parameters/src/vm.rs
+++ b/core/parameters/src/vm.rs
@@ -165,23 +165,8 @@ pub struct Config {
     /// Enable the `ImplicitAccountCreation` protocol feature.
     pub implicit_account_creation: bool,
 
-    /// Enable the host functions added by the `MathExtension` protocol feature.
-    pub math_extension: bool,
-
-    /// Enable the host functions added by the `Ed25519Verify` protocol feature.
-    pub ed25519_verify: bool,
-
-    /// Enable the host functions added by the `AltBn128` protocol feature.
-    pub alt_bn128: bool,
-
-    /// Enable the `FunctionCallWeight` protocol feature.
-    pub function_call_weight: bool,
-
     /// Enable the `EthImplicitAccounts` protocol feature.
     pub eth_implicit_accounts: bool,
-
-    /// Enable the `promise_yield_create` and `promise_yield_resume` host functions.
-    pub yield_resume_host_functions: bool,
 
     /// Whether to discard custom sections.
     pub discard_custom_sections: bool,
@@ -211,12 +196,7 @@ impl Config {
     }
 
     pub fn enable_all_features(&mut self) {
-        self.yield_resume_host_functions = true;
         self.eth_implicit_accounts = true;
-        self.function_call_weight = true;
-        self.alt_bn128 = true;
-        self.ed25519_verify = true;
-        self.math_extension = true;
         self.implicit_account_creation = true;
     }
 }

--- a/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
+++ b/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
@@ -202,12 +202,7 @@ expression: "&view"
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
-    "math_extension": true,
-    "ed25519_verify": true,
-    "alt_bn128": true,
-    "function_call_weight": true,
     "eth_implicit_accounts": true,
-    "yield_resume_host_functions": true,
     "limit_config": {
       "max_gas_burnt": 300000000000000,
       "max_stack_height": 262144,

--- a/runtime/near-vm-runner/src/imports.rs
+++ b/runtime/near-vm-runner/src/imports.rs
@@ -70,6 +70,7 @@ macro_rules! imports {
     ) => {
         macro_rules! for_each_available_import {
             ($config:expr, $M:ident) => {$(
+                let _ = &$config;
                 $(#[cfg(feature = $feature_name)])?
                 if true $(&& ($config).$config_field)? {
                     $crate::imports::call_with_name!($M => $( @in $mod : )? $( @as $name : )? $func < [ $( $arg_name : $arg_type ),* ] -> [ $( $returns ),* ] >);
@@ -119,15 +120,15 @@ imports! {
     sha256<[value_len: u64, value_ptr: u64, register_id: u64] -> []>,
     keccak256<[value_len: u64, value_ptr: u64, register_id: u64] -> []>,
     keccak512<[value_len: u64, value_ptr: u64, register_id: u64] -> []>,
-    #[ed25519_verify] ed25519_verify<[sig_len: u64,
+    ed25519_verify<[sig_len: u64,
         sig_ptr: u64,
         msg_len: u64,
         msg_ptr: u64,
         pub_key_len: u64,
         pub_key_ptr: u64
     ] -> [u64]>,
-    #[math_extension] ripemd160<[value_len: u64, value_ptr: u64, register_id: u64] -> []>,
-    #[math_extension] ecrecover<[hash_len: u64, hash_ptr: u64, sign_len: u64, sig_ptr: u64, v: u64, malleability_flag: u64, register_id: u64] -> [u64]>,
+    ripemd160<[value_len: u64, value_ptr: u64, register_id: u64] -> []>,
+    ecrecover<[hash_len: u64, hash_ptr: u64, sign_len: u64, sig_ptr: u64, v: u64, malleability_flag: u64, register_id: u64] -> [u64]>,
     // #####################
     // # Miscellaneous API #
     // #####################
@@ -178,7 +179,7 @@ imports! {
         amount_ptr: u64,
         gas: u64
     ] -> []>,
-    #[function_call_weight] promise_batch_action_function_call_weight<[
+    promise_batch_action_function_call_weight<[
         promise_index: u64,
         method_name_len: u64,
         method_name_ptr: u64,
@@ -225,7 +226,7 @@ imports! {
     // #######################
     // # Promise API yield/resume #
     // #######################
-    #[yield_resume_host_functions] promise_yield_create<[
+    promise_yield_create<[
         method_name_len: u64,
         method_name_ptr: u64,
         arguments_len: u64,
@@ -234,7 +235,7 @@ imports! {
         gas_weight: u64,
         register_id: u64
     ] -> [u64]>,
-    #[yield_resume_host_functions] promise_yield_resume<[
+    promise_yield_resume<[
         data_id_len: u64,
         data_id_ptr: u64,
         payload_len: u64,
@@ -266,9 +267,9 @@ imports! {
     // #############
     // # Alt BN128 #
     // #############
-    #[alt_bn128] alt_bn128_g1_multiexp<[value_len: u64, value_ptr: u64, register_id: u64] -> []>,
-    #[alt_bn128] alt_bn128_g1_sum<[value_len: u64, value_ptr: u64, register_id: u64] -> []>,
-    #[alt_bn128] alt_bn128_pairing_check<[value_len: u64, value_ptr: u64] -> [u64]>,
+    alt_bn128_g1_multiexp<[value_len: u64, value_ptr: u64, register_id: u64] -> []>,
+    alt_bn128_g1_sum<[value_len: u64, value_ptr: u64, register_id: u64] -> []>,
+    alt_bn128_pairing_check<[value_len: u64, value_ptr: u64] -> [u64]>,
     // #############
     // # BLS12-381 #
     // #############


### PR DESCRIPTION
The most important thing to look out for here is that in the snapshot that corresponds to MIN_SUPPORTED_PROTOCOL_VERSION all of the removed features were `true` already.

This is a relatively low-impact change, but no reason to keep conditional logic like this anyway...