### PR TITLE
increase the epoch-length in create-delete-account test

### DIFF
--- a/test-loop-tests/src/tests/create_delete_account.rs
+++ b/test-loop-tests/src/tests/create_delete_account.rs
@@ -110,5 +110,6 @@ fn test_create_delete_account() {
     // storage.
     do_delete_account(&mut env, &rpc_id, &new_account, &accounts[1]);
 
-    env.shutdown_and_drain_remaining_events(Duration::seconds(40));
+    env.test_loop.run_for(Duration::seconds(20));
+    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
 }

--- a/test-loop-tests/src/tests/create_delete_account.rs
+++ b/test-loop-tests/src/tests/create_delete_account.rs
@@ -59,7 +59,7 @@ fn test_create_delete_account() {
     init_test_logger();
     let builder = TestLoopBuilder::new();
 
-    let epoch_length = 5;
+    let epoch_length = 10;
     let accounts =
         (0..5).map(|i| format!("account{}", i).parse().unwrap()).collect::<Vec<AccountId>>();
     let clients = accounts.clone();
@@ -110,5 +110,5 @@ fn test_create_delete_account() {
     // storage.
     do_delete_account(&mut env, &rpc_id, &new_account, &accounts[1]);
 
-    env.shutdown_and_drain_remaining_events(Duration::seconds(20));
+    env.shutdown_and_drain_remaining_events(Duration::seconds(40));
 }


### PR DESCRIPTION
The small epoch lengh leads to some flaky behavior with `do_create_account` leading to unrelated failures. Those include producing one block with missing chunks due to `ChunkHeaderReadyForInclusion` never called for that particular block in the https://github.com/near/nearcore/pull/13259 . It has been verified that the stress tested network does not produce more blocks with missing chunks if the above PR is included. Together with the failures being only observable with only small epoch lengths (5,6) and for only a single block we have a strong evidence the failure is a noise. Increasing the epoch length for the tests makes the test stable against the changes.