### PR TITLE
feat: Allow multiple split accounts in state-stats

### DIFF
--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -13,6 +13,7 @@ use near_jsonrpc::start_http_for_readonly_debug_querying;
 use near_network::tcp::ListenerAddr;
 use near_primitives::account::id::AccountId;
 use near_primitives::hash::CryptoHash;
+use near_primitives::shard_layout::ShardUId;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::trie_key::col;
 use near_primitives::types::{BlockHeight, ShardId, StateRoot};
@@ -831,11 +832,16 @@ impl StatePartsCmd {
 }
 
 #[derive(clap::Parser)]
-pub struct StateStatsCmd {}
+pub struct StateStatsCmd {
+    #[clap(long, default_value = "2", help = "How many parts split each printed shard into")]
+    split_parts: usize,
+    #[clap(long, help = "Print stats only for the given shard ID")]
+    shard_uid: Option<ShardUId>,
+}
 
 impl StateStatsCmd {
     pub fn run(self, home_dir: &Path, near_config: NearConfig, store: Store) {
-        print_state_stats(home_dir, store, near_config);
+        print_state_stats(home_dir, store, near_config, self.split_parts, self.shard_uid);
     }
 }
 


### PR DESCRIPTION
Example usage:
```
neard view-state state-stats --split-parts 20 --shard-uid s0.v3
...
2025-04-09T13:09:09.153624Z  INFO state_viewer: StateStats {
    total_size: 18.9 GB,
    total_count: 79432494,
    average_size: 238 B,
    split_accounts: [
        SplitAccount {
            account_id: AccountId(
                "0dv8qtcms0oi.users.kaiching",
            ),
            split: "945.6 MB (4%) : 171 B (0%) : 18.0 GB (94%)",
        },
        SplitAccount {
            account_id: AccountId(
                "11aab957e5862047806cd51c2c045f09ecde572d2e36f653b6827ecccb8fd775",
            ),
            split: "1.9 GB (9%) : 245 B (0%) : 17.0 GB (89%)",
        },
        SplitAccount {
            account_id: AccountId(
                "1dde638b634eed7f6ae8e108e18164cd74140c98098e2e59951fa1f7909b797a",
            ),
            split: "2.8 GB (14%) : 245 B (0%) : 16.1 GB (84%)",
        },
        SplitAccount {
            account_id: AccountId(
                "26630b533716c7ff719acad1879230d029825534cebb02c44e5e3bee28871185",
            ),
            split: "3.8 GB (19%) : 353 B (0%) : 15.1 GB (79%)",
        },
        SplitAccount {
            account_id: AccountId(
                "2z2ewykv63wf.users.kaiching",
            ),
            split: "4.7 GB (24%) : 171 B (0%) : 14.2 GB (74%)",
        },
        SplitAccount {
            account_id: AccountId(
                "3d84c77112e7b7d7b55f6600083e5d07afb0179141b26108e4898d6acbc61bc9",
            ),
            split: "5.7 GB (29%) : 1.0 KB (0%) : 13.2 GB (69%)",
        },
        SplitAccount {
            account_id: AccountId(
                "455d8e09a177ca26adddc46d5e254e31f43bdebbede48d684acd8a9dffa7ef6a",
            ),
            split: "6.6 GB (34%) : 245 B (0%) : 12.3 GB (64%)",
        },
        SplitAccount {
            account_id: AccountId(
                "4uko6w14xthz.users.kaiching",
            ),
            split: "7.6 GB (39%) : 171 B (0%) : 11.3 GB (59%)",
        },
        SplitAccount {
            account_id: AccountId(
                "5ad0f58087869d171c02b6f199e124f5835bc92e3cf7da7ad06453f7d77a6a39",
            ),
            split: "8.5 GB (44%) : 245 B (0%) : 10.4 GB (54%)",
        },
        SplitAccount {
            account_id: AccountId(
                "6309644980.tg",
            ),
            split: "9.5 GB (49%) : 143 B (0%) : 9.5 GB (49%)",
        },
        SplitAccount {
            account_id: AccountId(
                "6ab6bcf6f4596d7c95be40c0afcd7e7975cf7e06ae1dc401cc6fb2f2978f3a43",
            ),
            split: "10.4 GB (54%) : 245 B (0%) : 8.5 GB (44%)",
        },
        SplitAccount {
            account_id: AccountId(
                "7143736999.tg",
            ),
            split: "11.3 GB (59%) : 143 B (0%) : 7.6 GB (39%)",
        },
        SplitAccount {
            account_id: AccountId(
                "781477a7804b820fdd40fb5bc31f11a7e02c4f5d2732e45279e65d9590ff6c76",
            ),
            split: "12.3 GB (64%) : 245 B (0%) : 6.6 GB (34%)",
        },
        SplitAccount {
            account_id: AccountId(
                "8072456087.tg",
            ),
            split: "13.2 GB (69%) : 143 B (0%) : 5.7 GB (29%)",
        },
        SplitAccount {
            account_id: AccountId(
                "8e8703145d29ecc15777b3547b9ad1dca578a0101750bcb0707ab373336b5539",
            ),
            split: "14.2 GB (74%) : 245 B (0%) : 4.7 GB (24%)",
        },
        SplitAccount {
            account_id: AccountId(
                "97jfjtmw6lgq.users.kaiching",
            ),
            split: "15.1 GB (79%) : 171 B (0%) : 3.8 GB (19%)",
        },
        SplitAccount {
            account_id: AccountId(
                "a0kidgw9rqsp.users.kaiching",
            ),
            split: "16.1 GB (84%) : 171 B (0%) : 2.8 GB (14%)",
        },
        SplitAccount {
            account_id: AccountId(
                "ac6ncofp947k.users.kaiching",
            ),
            split: "17.0 GB (89%) : 171 B (0%) : 1.9 GB (9%)",
        },
        SplitAccount {
            account_id: AccountId(
                "alpha-x.raddx.near",
            ),
            split: "17.6 GB (93%) : 405.3 MB (2%) : 865.0 MB (4%)",
        },
    ],
    top_accounts: [
        StateStatsAccount {
            account_id: "802d89b6e511b335f05024a65161bce7efc3f311.factory.bridge.near",
            size: 56.6 MB,
        },
        StateStatsAccount {
            account_id: "438e48ed4ce6beecf503d43b9dbd3c30d516e7fd.factory.bridge.near",
            size: 106.9 MB,
        },
        StateStatsAccount {
            account_id: "aa-harvest-moon.near",
            size: 91.5 MB,
        },
        StateStatsAccount {
            account_id: "alpha-x.raddx.near",
            size: 405.3 MB,
        },
        StateStatsAccount {
            account_id: "asset-manager.orderly-network.near",
            size: 243.4 MB,
        },
    ],
}
```