### PR TITLE
refactor: one step closer to storing `ValidatedTransactions` in `TransactionReceipt` 

### DIFF
--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -124,7 +124,7 @@ use near_primitives::sharding::{
     TransactionReceipt,
 };
 use near_primitives::stateless_validation::ChunkProductionKey;
-use near_primitives::transaction::SignedTransaction;
+use near_primitives::transaction::ValidatedTransaction;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{
     AccountId, Balance, BlockHeight, BlockHeightDelta, EpochId, Gas, MerkleHash, ShardId, StateRoot,
@@ -1961,7 +1961,7 @@ impl ShardsManagerActor {
         gas_limit: Gas,
         prev_balance_burnt: Balance,
         prev_validator_proposals: Vec<ValidatorStake>,
-        transactions: Vec<SignedTransaction>,
+        validated_txs: Vec<ValidatedTransaction>,
         prev_outgoing_receipts: Vec<Receipt>,
         prev_outgoing_receipts_root: CryptoHash,
         tx_root: CryptoHash,
@@ -1983,7 +1983,7 @@ impl ShardsManagerActor {
             prev_balance_burnt,
             tx_root,
             prev_validator_proposals,
-            transactions,
+            validated_txs,
             prev_outgoing_receipts,
             prev_outgoing_receipts_root,
             congestion_info,

--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -296,11 +296,7 @@ impl ChunkProducer {
                 chunk_extra.gas_limit(),
                 chunk_extra.balance_burnt(),
                 chunk_extra.validator_proposals().collect(),
-                prepared_transactions
-                    .transactions
-                    .into_iter()
-                    .map(|vt| vt.into_signed_tx())
-                    .collect::<Vec<_>>(),
+                prepared_transactions.transactions,
                 outgoing_receipts,
                 outgoing_receipts_root,
                 tx_root,

--- a/core/store/benches/finalize_bench.rs
+++ b/core/store/benches/finalize_bench.rs
@@ -29,7 +29,9 @@ use near_primitives::sharding::{
     PartialEncodedChunkV2, ReceiptProof, ShardChunk, ShardChunkHeader, ShardChunkHeaderV3,
     ShardChunkV2, ShardProof,
 };
-use near_primitives::transaction::{Action, FunctionCallAction, SignedTransaction};
+use near_primitives::transaction::{
+    Action, FunctionCallAction, SignedTransaction, ValidatedTransaction,
+};
 use near_primitives::types::{AccountId, ShardId};
 use near_primitives::validator_signer::{InMemoryValidatorSigner, ValidatorSigner};
 use near_primitives::version::PROTOCOL_VERSION;
@@ -182,7 +184,7 @@ fn create_shard_chunk(
 }
 
 fn create_encoded_shard_chunk(
-    transactions: Vec<SignedTransaction>,
+    validated_txs: Vec<ValidatedTransaction>,
     receipts: Vec<Receipt>,
 ) -> (EncodedShardChunk, Vec<Vec<MerklePathItem>>, Vec<Receipt>) {
     let rs = ReedSolomon::new(33, 67).unwrap();
@@ -197,7 +199,7 @@ fn create_encoded_shard_chunk(
         Default::default(),
         Default::default(),
         Default::default(),
-        transactions,
+        validated_txs,
         receipts,
         Default::default(),
         Default::default(),

--- a/integration-tests/src/tests/client/invalid_txs.rs
+++ b/integration-tests/src/tests/client/invalid_txs.rs
@@ -1,14 +1,13 @@
+use crate::env::nightshade_setup::TestEnvNightshadeSetupExt;
+use crate::env::test_env::TestEnv;
 use near_chain::{Chain, Provenance};
 use near_chain_configs::Genesis;
-use near_client::test_utils::create_chunk_with_transactions;
+use near_client::test_utils::create_chunk;
 use near_client::{ProcessTxResponse, ProduceChunkResult};
 use near_primitives::account::id::AccountIdRef;
 use near_primitives::test_utils::create_user_test_signer;
-use near_primitives::transaction::SignedTransaction;
+use near_primitives::transaction::{SignedTransaction, ValidatedTransaction};
 use near_primitives::types::{AccountId, ShardId};
-
-use crate::env::nightshade_setup::TestEnvNightshadeSetupExt;
-use crate::env::test_env::TestEnv;
 
 const ONE_NEAR: u128 = 1_000_000_000_000_000_000_000_000;
 
@@ -34,7 +33,7 @@ fn test_invalid_transactions_no_panic() {
     let tip = env.clients[0].chain.head().unwrap();
     let sender_account = accounts[0].clone();
     let receiver_account = accounts[1].clone();
-    let invalid_transactions = vec![
+    let invalid_txs = vec![
         // transaction with invalid balance
         SignedTransaction::send_money(
             1,
@@ -63,6 +62,10 @@ fn test_invalid_transactions_no_panic() {
             tip.last_block_hash,
         ),
     ];
+    let invalid_txs = invalid_txs
+        .into_iter()
+        .map(|signed_tx| ValidatedTransaction::new_for_test(signed_tx))
+        .collect::<Vec<_>>();
     // Need to create a valid transaction with the same accounts touched in order to have some state witness generated
     let valid_tx = SignedTransaction::send_money(
         1,
@@ -73,7 +76,7 @@ fn test_invalid_transactions_no_panic() {
         tip.last_block_hash,
     );
     let mut start_height = 1;
-    for tx in invalid_transactions {
+    for tx in invalid_txs {
         for height in start_height..start_height + 3 {
             let tip = env.clients[0].chain.head().unwrap();
             let chunk_producer = env.get_chunk_producer_at_offset(&tip, 1, ShardId::new(0));
@@ -88,7 +91,7 @@ fn test_invalid_transactions_no_panic() {
             }
 
             let (ProduceChunkResult { chunk, encoded_chunk_parts_paths, receipts }, _) =
-                create_chunk_with_transactions(client, transactions);
+                create_chunk(client, transactions);
 
             let shard_chunk = client
                 .persist_and_distribute_encoded_chunk(
@@ -202,13 +205,17 @@ fn test_invalid_transactions_dont_invalidate_chunk() {
             tip.last_block_hash,
         ),
     ];
+    let chunk_transactions = chunk_transactions
+        .into_iter()
+        .map(|signed_tx| ValidatedTransaction::new_for_test(signed_tx))
+        .collect();
 
     let tip = env.clients[0].chain.head().unwrap();
     let chunk_producer = env.get_chunk_producer_at_offset(&tip, 1, ShardId::new(0));
     let block_producer = env.get_block_producer_at_offset(&tip, 1);
     let client = env.client(&chunk_producer);
     let (ProduceChunkResult { chunk, encoded_chunk_parts_paths, receipts }, _) =
-        create_chunk_with_transactions(client, chunk_transactions);
+        create_chunk(client, chunk_transactions);
 
     let shard_chunk = client
         .persist_and_distribute_encoded_chunk(


### PR DESCRIPTION
`TransactionReceipt` only ever stores `ValidatedTransactions`.  This PR updates one call paths to pass in validated txs instead of signed txs.  

Ultimately, if we can refactor the other call site to use validated txs as well, then it will become quite straightforward for a chunk producer to skip a number of duplicate steps when it later applies the chunk.

Part of: https://github.com/near/nearcore/issues/13140