### PR TITLE
fix chunk being dropped if the previous block is not ready

### DIFF
--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -189,7 +189,7 @@ pub(crate) struct ChunkRequestInfo {
     last_requested: time::Instant,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum HandleNetworkRequestResult {
     Ok,
     /// request failed and could be retried after some duration

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -159,6 +159,7 @@ pub enum ChunkStatus {
     Invalid,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum ProcessPartialEncodedChunkResult {
     /// The information included in the partial encoded chunk is already known, no processing is needed
@@ -173,7 +174,7 @@ pub enum ProcessPartialEncodedChunkResult {
     NeedBlock,
     /// PartialEncodedChunkMessage is received earlier than Block for the same height.
     /// The chunk has been dropped without processing any part of it.
-    NeedsBlockChunkDropped,
+    NeedsBlockChunkDropped(Box<PartialEncodedChunk>),
 }
 
 #[derive(Clone, Debug)]
@@ -189,11 +190,12 @@ pub(crate) struct ChunkRequestInfo {
     last_requested: time::Instant,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum HandleNetworkRequestResult {
     Ok,
     /// request failed and could be retried after some duration
-    RetryProcessing(Duration),
+    RetryProcessing(Box<ShardsManagerRequestFromNetwork>, Duration),
     Err,
 }
 
@@ -316,11 +318,11 @@ impl HandlerWithContext<ShardsManagerRequestFromNetwork> for ShardsManagerActor 
         msg: ShardsManagerRequestFromNetwork,
         ctx: &mut dyn DelayedActionRunner<Self>,
     ) {
-        match self.handle_network_request(msg.clone()) {
+        match self.handle_network_request(msg) {
             // Schedule retry processing the message once again if requested
-            HandleNetworkRequestResult::RetryProcessing(duration) => {
+            HandleNetworkRequestResult::RetryProcessing(msg, duration) => {
                 ctx.run_later("retry processing chunk request", duration, move |this, _ctx| {
-                    this.handle_network_request(msg);
+                    this.handle_network_request(*msg);
                 })
             }
             _ => {}
@@ -1570,7 +1572,9 @@ impl ShardsManagerActor {
                         partial_encoded_chunk.header.height_created(),
                         partial_encoded_chunk.header.shard_id()
                     );
-                    return Ok(ProcessPartialEncodedChunkResult::NeedsBlockChunkDropped);
+                    return Ok(ProcessPartialEncodedChunkResult::NeedsBlockChunkDropped(Box::new(
+                        PartialEncodedChunk::V2(partial_encoded_chunk.into_inner()),
+                    )));
                 }
                 _ => return Err(chain_error.into()),
             },
@@ -2202,8 +2206,10 @@ impl ShardsManagerActor {
         match request {
             ShardsManagerRequestFromNetwork::ProcessPartialEncodedChunk(partial_encoded_chunk) => {
                 match self.process_partial_encoded_chunk(partial_encoded_chunk.into(), me) {
-                    Ok(ProcessPartialEncodedChunkResult::NeedsBlockChunkDropped) => {
-                        return HandleNetworkRequestResult::RetryProcessing(RETRY_CHUNK_PROCESSING_DELAY);
+                    Ok(ProcessPartialEncodedChunkResult::NeedsBlockChunkDropped(chunk)) => {
+                        return HandleNetworkRequestResult::RetryProcessing(
+                            Box::new(ShardsManagerRequestFromNetwork::ProcessPartialEncodedChunk(*chunk)),
+                            RETRY_CHUNK_PROCESSING_DELAY);
                     },
                     Ok(_)=> { return HandleNetworkRequestResult::Ok; }
                     Err(e) => {

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -173,7 +173,7 @@ pub enum ProcessPartialEncodedChunkResult {
     NeedBlock,
     /// PartialEncodedChunkMessage is received earlier than Block for the same height.
     /// The chunk has been dropped without processing any part of it.
-    NeedBlockChunkDropped,
+    NeedsBlockChunkDropped,
 }
 
 #[derive(Clone, Debug)]
@@ -191,11 +191,9 @@ pub(crate) struct ChunkRequestInfo {
 
 #[derive(Clone, Debug)]
 pub enum HandleNetworkRequestResult {
-    /// request handled successfully
     Ok,
-    /// request failed in a way that may be worth retrying to process it after a certain duration
+    /// request failed and could be retried after some duration
     RetryProcessing(Duration),
-    /// failure
     Err,
 }
 
@@ -320,9 +318,9 @@ impl HandlerWithContext<ShardsManagerRequestFromNetwork> for ShardsManagerActor 
     ) {
         match self.handle_network_request(msg.clone()) {
             // Schedule retry processing the message once again if requested
-            HandleNetworkRequestResult::RetryProcessing(dt) => {
-                ctx.run_later("retry processing chunk request", dt, move |this, _ctx| {
-                    let _ = this.handle_network_request(msg);
+            HandleNetworkRequestResult::RetryProcessing(duration) => {
+                ctx.run_later("retry processing chunk request", duration, move |this, _ctx| {
+                    this.handle_network_request(msg);
                 })
             }
             _ => {}
@@ -1572,7 +1570,7 @@ impl ShardsManagerActor {
                         partial_encoded_chunk.header.height_created(),
                         partial_encoded_chunk.header.shard_id()
                     );
-                    return Ok(ProcessPartialEncodedChunkResult::NeedBlockChunkDropped);
+                    return Ok(ProcessPartialEncodedChunkResult::NeedsBlockChunkDropped);
                 }
                 _ => return Err(chain_error.into()),
             },
@@ -2204,7 +2202,7 @@ impl ShardsManagerActor {
         match request {
             ShardsManagerRequestFromNetwork::ProcessPartialEncodedChunk(partial_encoded_chunk) => {
                 match self.process_partial_encoded_chunk(partial_encoded_chunk.into(), me) {
-                    Ok(ProcessPartialEncodedChunkResult::NeedBlockChunkDropped) => {
+                    Ok(ProcessPartialEncodedChunkResult::NeedsBlockChunkDropped) => {
                         return HandleNetworkRequestResult::RetryProcessing(RETRY_CHUNK_PROCESSING_DELAY);
                     },
                     Ok(_)=> { return HandleNetworkRequestResult::Ok; }

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -159,7 +159,6 @@ pub enum ChunkStatus {
     Invalid,
 }
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum ProcessPartialEncodedChunkResult {
     /// The information included in the partial encoded chunk is already known, no processing is needed
@@ -190,7 +189,6 @@ pub(crate) struct ChunkRequestInfo {
     last_requested: time::Instant,
 }
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum HandleNetworkRequestResult {
     Ok,
@@ -1567,7 +1565,7 @@ impl ShardsManagerActor {
         {
             Err(Error::ChainError(chain_error)) => match chain_error {
                 // validate_chunk_header returns DBNotFoundError if the previous block is not ready
-                // in this case, we return NeedBlock instead of error
+                // in this case, we still return valid result instead of error.
                 near_chain::Error::DBNotFoundErr(_) => {
                     debug!(
                         target:"client",

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -90,7 +90,7 @@ use ::time::ext::InstantExt as _;
 use actix::Actor;
 use near_async::actix_wrapper::ActixWrapper;
 use near_async::futures::{DelayedActionRunner, DelayedActionRunnerExt};
-use near_async::messaging::{self, Handler, Sender};
+use near_async::messaging::{self, Handler, HandlerWithContext, Sender};
 use near_async::time::Duration;
 use near_async::time::{self, Clock};
 use near_chain::byzantine_assert;
@@ -169,7 +169,11 @@ pub enum ProcessPartialEncodedChunkResult {
     NeedMorePartsOrReceipts,
     /// PartialEncodedChunkMessage is received earlier than Block for the same height.
     /// Without the block we cannot restore the epoch and save encoded chunk data.
+    /// The chunk is partially processed.
     NeedBlock,
+    /// PartialEncodedChunkMessage is received earlier than Block for the same height.
+    /// The chunk has been dropped without processing any part of it.
+    NeedBlockChunkDropped,
 }
 
 #[derive(Clone, Debug)]
@@ -183,6 +187,16 @@ pub(crate) struct ChunkRequestInfo {
     shard_id: ShardId,
     added: time::Instant,
     last_requested: time::Instant,
+}
+
+#[derive(Clone, Debug)]
+pub enum HandleNetworkRequestResult {
+    /// request handled successfully
+    Ok,
+    /// request failed in a way that may be worth retrying to process it after a certain duration
+    RetryProcessing(Duration),
+    /// failure
+    Err,
 }
 
 struct RequestPool {
@@ -297,13 +311,24 @@ impl Handler<ShardsManagerRequestFromClient> for ShardsManagerActor {
     }
 }
 
-impl Handler<ShardsManagerRequestFromNetwork> for ShardsManagerActor {
+impl HandlerWithContext<ShardsManagerRequestFromNetwork> for ShardsManagerActor {
     #[perf]
-    fn handle(&mut self, msg: ShardsManagerRequestFromNetwork) {
-        self.handle_network_request(msg);
+    fn handle(
+        &mut self,
+        msg: ShardsManagerRequestFromNetwork,
+        ctx: &mut dyn DelayedActionRunner<Self>,
+    ) {
+        match self.handle_network_request(msg.clone()) {
+            // Schedule retry processing the message once again if requested
+            HandleNetworkRequestResult::RetryProcessing(dt) => {
+                ctx.run_later("retry processing chunk request", dt, move |this, _ctx| {
+                    let _ = this.handle_network_request(msg);
+                })
+            }
+            _ => {}
+        }
     }
 }
-
 pub fn start_shards_manager(
     epoch_manager: Arc<dyn EpochManagerAdapter>,
     view_epoch_manager: Arc<dyn EpochManagerAdapter>,
@@ -1547,7 +1572,7 @@ impl ShardsManagerActor {
                         partial_encoded_chunk.header.height_created(),
                         partial_encoded_chunk.header.shard_id()
                     );
-                    return Ok(ProcessPartialEncodedChunkResult::NeedBlock);
+                    return Ok(ProcessPartialEncodedChunkResult::NeedBlockChunkDropped);
                 }
                 _ => return Err(chain_error.into()),
             },
@@ -2163,7 +2188,11 @@ impl ShardsManagerActor {
         }
     }
 
-    pub fn handle_network_request(&mut self, request: ShardsManagerRequestFromNetwork) {
+    pub fn handle_network_request(
+        &mut self,
+        request: ShardsManagerRequestFromNetwork,
+    ) -> HandleNetworkRequestResult {
+        const RETRY_CHUNK_PROCESSING_DELAY: Duration = Duration::milliseconds(10);
         let _span = tracing::debug_span!(
             target: "chunks",
             "shards_manager_request_from_network",
@@ -2174,19 +2203,28 @@ impl ShardsManagerActor {
         let me = me.as_ref();
         match request {
             ShardsManagerRequestFromNetwork::ProcessPartialEncodedChunk(partial_encoded_chunk) => {
-                if let Err(e) = self.process_partial_encoded_chunk(partial_encoded_chunk.into(), me)
-                {
-                    warn!(target: "chunks", "Error processing partial encoded chunk: {:?}", e);
+                match self.process_partial_encoded_chunk(partial_encoded_chunk.into(), me) {
+                    Ok(ProcessPartialEncodedChunkResult::NeedBlockChunkDropped) => {
+                        return HandleNetworkRequestResult::RetryProcessing(RETRY_CHUNK_PROCESSING_DELAY);
+                    },
+                    Ok(_)=> { return HandleNetworkRequestResult::Ok; }
+                    Err(e) => {
+                        warn!(target: "chunks", "Error processing partial encoded chunk: {:?}", e);
+                        return HandleNetworkRequestResult::Err;
+                    },
                 }
             }
             ShardsManagerRequestFromNetwork::ProcessPartialEncodedChunkForward(
                 partial_encoded_chunk_forward,
             ) => {
-                if let Err(e) =
-                    self.process_partial_encoded_chunk_forward(partial_encoded_chunk_forward, me)
-                {
-                    warn!(target: "chunks", "Error processing partial encoded chunk forward: {:?}", e);
-                }
+                self.process_partial_encoded_chunk_forward(partial_encoded_chunk_forward, me)
+                    .map_or_else(
+                        |e| {
+                        warn!(target: "chunks", "Error processing partial encoded chunk forward: {:?}", e);
+                        return HandleNetworkRequestResult::Err;
+                        },
+                        |_|{ return HandleNetworkRequestResult::Ok; }
+                    )
             }
             ShardsManagerRequestFromNetwork::ProcessPartialEncodedChunkResponse {
                 partial_encoded_chunk_response,
@@ -2195,11 +2233,14 @@ impl ShardsManagerActor {
                 metrics::PARTIAL_ENCODED_CHUNK_RESPONSE_DELAY.observe(
                     (self.clock.now().signed_duration_since(received_time)).as_seconds_f64(),
                 );
-                if let Err(e) =
-                    self.process_partial_encoded_chunk_response(partial_encoded_chunk_response, me)
-                {
-                    warn!(target: "chunks", "Error processing partial encoded chunk response: {:?}", e);
-                }
+                self.process_partial_encoded_chunk_response(partial_encoded_chunk_response, me)
+                    .map_or_else(
+                        |e| {
+                            warn!(target: "chunks", "Error processing partial encoded chunk response: {:?}", e);
+                            return HandleNetworkRequestResult::Err;
+                        },
+                        |_| { return HandleNetworkRequestResult::Ok; }
+                    )
             }
             ShardsManagerRequestFromNetwork::ProcessPartialEncodedChunkRequest {
                 partial_encoded_chunk_request,
@@ -2210,6 +2251,7 @@ impl ShardsManagerActor {
                     route_back,
                     me,
                 );
+                HandleNetworkRequestResult::Ok
             }
         }
     }


### PR DESCRIPTION
The `ProcessPartialEncodedChunk` was returning OK while dropping the chunk in case there was not enough information to validate it.
This lead to some test-loop tests being prone to have missing chunks and failing with low probability or for unrelated changes.
In particular this fixes the slow tests for the https://github.com/near/nearcore/pull/13259.
The condition for this failure to occur seem also relevant for the prod.

# Context
[failing logs](https://drive.google.com/file/d/1Qs22FmLl4joeLQM5xd5aXsxGfKSPIlvo)

```
 2.642s  INFO test: Observed new block at height 10021, chunk_mask: [true, true, false, true]
...
thread 'tests::protocol_upgrade::slow_test_protocol_upgrade_not_latest' panicked at test-loop-tests/src/tests/protocol_upgrade.rs:194:5:
assertion `left == right` failed
  left: {0: [10021]}
...
     SIGABRT [  26.064s] test-loop-tests tests::protocol_upgrade::slow_test_protocol_upgrade_no_missing_chunks
     SIGABRT [  26.157s] test-loop-tests tests::protocol_upgrade::slow_test_protocol_upgrade_not_latest
```

## Deep dive
- Endorsement for the shard_0 received. Not very relevant, but changing the order of endorsement processing triggered the failure
```
74587: 2.493s  INFO test_loop: TEST_LOOP_EVENT_START {"current_index":10313,"total_events":10333,"identifier":"account1","current_event":"RpcHandler(ChunkEndorsementMessage(V2(ChunkEndorsementV2 { inner: ChunkEndorsementInner { chunk_hash: ChunkHash(CDwdYKc81V9DcfejrCYg4o3f1foNmFhVexd8ow4dMTtu), signature_differentiator: \"ChunkEndorsement\" }, signature: ed25519:5SeD28s68KqKbq3LT6KYy1BurvDaXiYJHUsECSNixE58wzg9AfYoZZE6YDAW5SNnctDYUnGAi1CpBr3Bep3tGD2F, metadata: ChunkEndorsementMetadata { account_id: AccountId(\"account0\"), shard_id: 0, epoch_id: EpochId(9XAoMWjGorcnX65ZFPxniuELkPKgPUNgni8VztMLf9ct), height_created: 10021 }, metadata_signature: ed25519:5uHF8nfnWU7z7QGWivS27XX8e7NYENDhoUy51FzpVubrg1e7u6p9MCjodrd9omPyWrmBXkK1hPKMSrEzHznKf2Vb })))","current_time_ms":12210,"event_ignored":false}
```
- event leading to chunk miss: `ProcessPartialEncodedChunk` network request
```
74591: 2.494s  INFO test_loop: TEST_LOOP_EVENT_START {"current_index":10320,"total_events":10333,"identifier":"account1","current_event":"ShardsManagerActor(ProcessPartialEncodedChunk(V2(PartialEncodedChunkV2 { header: V3(ShardChunkHeaderV3 { inner: V4(ShardChunkHeaderInnerV4 { prev_block_hash: HsMzsCoiKgexSAfqWVrxkrtLHZDuqQiUwV8kAaP8DRTo, prev_state_root: 46VZV3Ap3E5Z47SQmYumHGUxfVNzDWz4Nn1KScSsCGLq, prev_outcome_root: 11111111111111111111111111111111, encoded_merkle_root: 6xxoqYzsgrudgaVRsTV29KvdTstNYVUxis55KNLg6XtX, encoded_length: 8, height_created: 10021, shard_id: 0, prev_gas_used: 0, gas_limit: 1000000000000000, prev_balance_burnt: 0, prev_outgoing_receipts_root: 4BHcxeVAKYf5qkB1Nfi7UpBgsm4voeDVKgKP6QRVnAkf, tx_root: 11111111111111111111111111111111, prev_validator_proposals: [], congestion_info: V1(CongestionInfoV1 { delayed_receipts_gas: 0, buffered_receipts_gas: 0, receipt_bytes: 0, allowed_shard: 0 }), bandwidth_requests: V1(BandwidthRequestsV1 { requests: [] }) }), height_included: 0, signature: ed25519:4PUdvCAmH7MBrS8Md6RcMsAjt3u1mtQrcM7bjySYgcFb3HfhXHSo8UqzfwmxXvP13KD9XL6pZWzZDPRTrzYXTczX, hash: ChunkHash(CDwdYKc81V9DcfejrCYg4o3f1foNmFhVexd8ow4dMTtu) }), parts: [PartialEncodedChunkPart { part_ord: 1, part: AAAAAAAAAAA=, merkle_proof: [MerklePathItem { hash: B4pi7cFHKDhh1A9JFXCPtkUv3Zu1LzaocJErSZnkkx2c, direction: Left }] }], prev_outgoing_receipts: [ReceiptProof([], ShardProof { from_shard_id: 0, to_shard_id: 3, proof: [MerklePathItem { hash: 3zyE2CiodJRft97aKkjDE1RuretEJKZDmYGFBXQQEeNU, direction: Right }, MerklePathItem { hash: 9PgSAakpZ9c3KfJya3aP5kYpqG3B228nJqW7obfVoEdr, direction: Right }] }), ReceiptProof([], ShardProof { from_shard_id: 0, to_shard_id: 1, proof: [MerklePathItem { hash: FdDtHkTE2Gqgdud2j9P2fGBoV3AJtwN3NZKu61fvz1Tv, direction: Left }, MerklePathItem { hash: 9PgSAakpZ9c3KfJya3aP5kYpqG3B228nJqW7obfVoEdr, direction: Right }] }), ReceiptProof([], ShardProof { from_shard_id: 0, to_shard_id: 2, proof: [MerklePathItem { hash: H4Rd6SGeEBTbxkitsCdzfu9xL9HtZ2eHoPCQXUeZ6bW4, direction: Left }, MerklePathItem { hash: 9B2Q4uqytJaDnSpRAgc8hiwq4XAZCAdRmo2iveLmn4sy, direction: Left }] })] })))","current_time_ms":12210,"event_ignored":false}
```
- `Dropping partial encoded chunk` for the `shard_id=0`. The original code returns OK, no part of the chunk processing is done.
```
74592: 2.494s DEBUG shards_manager_request_from_network{type="ProcessPartialEncodedChunk"}:process_partial_encoded_chunk{chunk_hash=ChunkHash(CDwdYKc81V9DcfejrCYg4o3f1foNmFhVexd8ow4dMTtu) shard_id=0 height_created=10021 height_included=0}:validate_chunk_header{chunk_hash=ChunkHash(CDwdYKc81V9DcfejrCYg4o3f1foNmFhVexd8ow4dMTtu)}: chunks: close time.busy=73.7Âµs time.idle=507ns
74593: 2.494s DEBUG shards_manager_request_from_network{type="ProcessPartialEncodedChunk"}:process_partial_encoded_chunk{chunk_hash=ChunkHash(CDwdYKc81V9DcfejrCYg4o3f1foNmFhVexd8ow4dMTtu) shard_id=0 height_created=10021 height_included=0}: client: Dropping partial encoded chunk ChunkHash(CDwdYKc81V9DcfejrCYg4o3f1foNmFhVexd8ow4dMTtu) height 10021, shard_id 0 because we don't have enough information to validate it
```
- Same for shard_id=2. Happens right after but fails differently (`NeedBlock prev_block_hash=...`). Most of the processing has been done on this chunk. And eventually it does end up in the block. Most probably the chain state has updated in the background between these 2 events.
```
74611: 2.494s  INFO test_loop: TEST_LOOP_EVENT_START {"current_index":10325,"total_events":10337,"identifier":"account1","current_event":"ShardsManagerActor(ProcessPartialEncodedChunk(V2(PartialEncodedChunkV2 { header: V3(ShardChunkHeaderV3 { inner: V4(ShardChunkHeaderInnerV4 { prev_block_hash: HsMzsCoiKgexSAfqWVrxkrtLHZDuqQiUwV8kAaP8DRTo, prev_state_root: 8os71MyfNnRuxSF86yyfN8pgEnf7Rm7y3F8sYhNy5FX3, prev_outcome_root: 11111111111111111111111111111111, encoded_merkle_root: 6xxoqYzsgrudgaVRsTV29KvdTstNYVUxis55KNLg6XtX, encoded_length: 8, height_created: 10021, shard_id: 2, prev_gas_used: 0, gas_limit: 1000000000000000, prev_balance_burnt: 0, prev_outgoing_receipts_root: 4BHcxeVAKYf5qkB1Nfi7UpBgsm4voeDVKgKP6QRVnAkf, tx_root: 11111111111111111111111111111111, prev_validator_proposals: [], congestion_info: V1(CongestionInfoV1 { delayed_receipts_gas: 0, buffered_receipts_gas: 0, receipt_bytes: 0, allowed_shard: 2 }), bandwidth_requests: V1(BandwidthRequestsV1 { requests: [] }) }), height_included: 0, signature: ed25519:3zDgqJeXn3YgixsUFEqKxd67ddLMkLJ838GXQZNGYq6GAw8cMRzfu1CVmARbMC4U2yGSCmUX93EVDsuuvmhKoCMj, hash: ChunkHash(EwjCnyCqhWmnSKYvVyw2XPZmbTwRpr8fv5a1t43ccEPQ) }), parts: [PartialEncodedChunkPart { part_ord: 1, part: AAAAAAAAAAA=, merkle_proof: [MerklePathItem { hash: B4pi7cFHKDhh1A9JFXCPtkUv3Zu1LzaocJErSZnkkx2c, direction: Left }] }], prev_outgoing_receipts: [ReceiptProof([], ShardProof { from_shard_id: 2, to_shard_id: 3, proof: [MerklePathItem { hash: 3zyE2CiodJRft97aKkjDE1RuretEJKZDmYGFBXQQEeNU, direction: Right }, MerklePathItem { hash: 9PgSAakpZ9c3KfJya3aP5kYpqG3B228nJqW7obfVoEdr, direction: Right }] }), ReceiptProof([], ShardProof { from_shard_id: 2, to_shard_id: 1, proof: [MerklePathItem { hash: FdDtHkTE2Gqgdud2j9P2fGBoV3AJtwN3NZKu61fvz1Tv, direction: Left }, MerklePathItem { hash: 9PgSAakpZ9c3KfJya3aP5kYpqG3B228nJqW7obfVoEdr, direction: Right }] }), ReceiptProof([], ShardProof { from_shard_id: 2, to_shard_id: 2, proof: [MerklePathItem { hash: H4Rd6SGeEBTbxkitsCdzfu9xL9HtZ2eHoPCQXUeZ6bW4, direction: Left }, MerklePathItem { hash: 9B2Q4uqytJaDnSpRAgc8hiwq4XAZCAdRmo2iveLmn4sy, direction: Left }] })] })))","current_time_ms":12210,"event_ignored":false}
 2.494s DEBUG shards_manager_request_from_network{type="ProcessPartialEncodedChunk"}:process_partial_encoded_chunk{chunk_hash=ChunkHash(EwjCnyCqhWmnSKYvVyw2XPZmbTwRpr8fv5a1t43ccEPQ) shard_id=2 height_created=10021 height_included=0}: chunks: Process partial encoded chunk parts=[1]
 2.494s DEBUG shards_manager_request_from_network{type="ProcessPartialEncodedChunk"}:process_partial_encoded_chunk{chunk_hash=ChunkHash(EwjCnyCqhWmnSKYvVyw2XPZmbTwRpr8fv5a1t43ccEPQ) shard_id=2 height_created=10021 height_included=0}: chunks: num_parts_in_cache=0 total_needed=1
 2.494s DEBUG shards_manager_request_from_network{type="ProcessPartialEncodedChunk"}:process_partial_encoded_chunk{chunk_hash=ChunkHash(EwjCnyCqhWmnSKYvVyw2XPZmbTwRpr8fv5a1t43ccEPQ) shard_id=2 height_created=10021 height_included=0}:validate_chunk_header{chunk_hash=ChunkHash(EwjCnyCqhWmnSKYvVyw2XPZmbTwRpr8fv5a1t43ccEPQ)}: chunks: close time.busy=78.7Âµs time.idle=467ns
 2.494s DEBUG shards_manager_request_from_network{type="ProcessPartialEncodedChunk"}:process_partial_encoded_chunk{chunk_hash=ChunkHash(EwjCnyCqhWmnSKYvVyw2XPZmbTwRpr8fv5a1t43ccEPQ) shard_id=2 height_created=10021 height_included=0}:try_process_chunk_parts_and_receipts{height_included=0 chunk_hash=ChunkHash(EwjCnyCqhWmnSKYvVyw2XPZmbTwRpr8fv5a1t43ccEPQ)}: chunks: NeedBlock prev_block_hash=HsMzsCoiKgexSAfqWVrxkrtLHZDuqQiUwV8kAaP8DRTo
```
- block postprocessed, chain updated
```
74671: 2.495s  INFO test_loop: TEST_LOOP_EVENT_START {"current_index":10331,"total_events":10345,"identifier":"account1","current_event":"ClientActorInner(ApplyChunksDoneMessage)","current_time_ms":12210,"event_ignored":false}
74688: 2.495s DEBUG check_triggers:try_process_unfinished_blocks:postprocess_ready_blocks{should_produce_chunk=true}:postprocess_ready_blocks_chain:postprocess_ready_block{height=10020}:postprocess_block_only:ChainUpdate::postprocess_block: chain: Head updated to HsMzsCoiKgexSAfqWVrxkrtLHZDuqQiUwV8kAaP8DRTo at 10020
```
- other chunks processed completely
```
74960: 2.502s  INFO test_loop: TEST_LOOP_EVENT_START {"current_index":10368,"total_events":10378,"identifier":"account0","current_event":"ShardsManagerActor(ProcessPartialEncodedChunk(V2(PartialEncodedChunkV2 { header: V3(ShardChunkHeaderV3 { inner: V4(ShardChunkHeaderInnerV4 { prev_block_hash: HsMzsCoiKgexSAfqWVrxkrtLHZDuqQiUwV8kAaP8DRTo, prev_state_root: GGgF6K66cpNxSB9HCcjE8xntqaf1WeGaWb4MSa8KRLJA, prev_outcome_root: 11111111111111111111111111111111, encoded_merkle_root: 6xxoqYzsgrudgaVRsTV29KvdTstNYVUxis55KNLg6XtX, encoded_length: 8, height_created: 10021, shard_id: 3, prev_gas_used: 0, gas_limit: 1000000000000000, prev_balance_burnt: 0, prev_outgoing_receipts_root: 4BHcxeVAKYf5qkB1Nfi7UpBgsm4voeDVKgKP6QRVnAkf, tx_root: 11111111111111111111111111111111, prev_validator_proposals: [], congestion_info: V1(CongestionInfoV1 { delayed_receipts_gas: 0, buffered_receipts_gas: 0, receipt_bytes: 0, allowed_shard: 3 }), bandwidth_requests: V1(BandwidthRequestsV1 { requests: [] }) }), height_included: 0, signature: ed25519:4L5hxj3GY9EJgP1xLpRJfgJ1k7gmDjxj6EmuVjbXP4RV5SL44d9FpJu5KmCun6sm8AceduGg1PUpcgQua5AAtS4n, hash: ChunkHash(FeAwm16pdrU8sqzX13qKFuEWgBvSRcFiPCi1QY5XrCkT) }), parts: [PartialEncodedChunkPart { part_ord: 0, part: AAAAAAAAAAA=, merkle_proof: [MerklePathItem { hash: B4pi7cFHKDhh1A9JFXCPtkUv3Zu1LzaocJErSZnkkx2c, direction: Right }] }], prev_outgoing_receipts: [ReceiptProof([], ShardProof { from_shard_id: 3, to_shard_id: 1, proof: [MerklePathItem { hash: FdDtHkTE2Gqgdud2j9P2fGBoV3AJtwN3NZKu61fvz1Tv, direction: Left }, MerklePathItem { hash: 9PgSAakpZ9c3KfJya3aP5kYpqG3B228nJqW7obfVoEdr, direction: Right }] }), ReceiptProof([], ShardProof { from_shard_id: 3, to_shard_id: 0, proof: [MerklePathItem { hash: 2D6nXCY8d2VXDhostqLpoWmMyJ67sYspY34HsediyVXs, direction: Right }, MerklePathItem { hash: 9B2Q4uqytJaDnSpRAgc8hiwq4XAZCAdRmo2iveLmn4sy, direction: Left }] }), ReceiptProof([], ShardProof { from_shard_id: 3, to_shard_id: 2, proof: [MerklePathItem { hash: H4Rd6SGeEBTbxkitsCdzfu9xL9HtZ2eHoPCQXUeZ6bW4, direction: Left }, MerklePathItem { hash: 9B2Q4uqytJaDnSpRAgc8hiwq4XAZCAdRmo2iveLmn4sy, direction: Left }] })] })))","current_time_ms":12220,"event_ignored":false}
 2.502s DEBUG shards_manager_request_from_network{type="ProcessPartialEncodedChunk"}:process_partial_encoded_chunk{chunk_hash=ChunkHash(FeAwm16pdrU8sqzX13qKFuEWgBvSRcFiPCi1QY5XrCkT) shard_id=3 height_created=10021 height_included=0}: chunks: Process partial encoded chunk parts=[0]
```

# Suggested Fix
Instead of dropping the chunk in case we do not yet have the data to validate it, we can reschedule processing it and see if the data may have arrived in the meantime.