### PR TITLE
refactor: improvements to `decode_encoded_chunk`

### DIFF
--- a/chain/chunks/src/logic.rs
+++ b/chain/chunks/src/logic.rs
@@ -167,7 +167,7 @@ pub fn decode_encoded_chunk(
     .entered();
 
     let shard_chunk = encoded_chunk.decode_chunk().map_err(|err| {
-        error!(target: "chunks", ?chunk_hash, ?me, "Reconstructed, but failed to decoded chunk");
+        error!(target: "chunks", ?chunk_hash, ?me, "reconstructed, but failed to decode chunk");
         err
     })?;
     if !validate_chunk_proofs(&shard_chunk, epoch_manager)? {

--- a/chain/chunks/src/logic.rs
+++ b/chain/chunks/src/logic.rs
@@ -174,10 +174,8 @@ pub fn decode_encoded_chunk(
         return Err(Error::InvalidChunk);
     }
 
-    span.record("chunk_hash", format!("{:?}", chunk_hash));
     span.record("encoded_length", encoded_chunk.encoded_length());
     span.record("num_tx", shard_chunk.to_transactions().len());
-    span.record("me", format!("{:?}", me));
 
     let partial_chunk = create_partial_chunk(
         encoded_chunk,

--- a/chain/chunks/src/logic.rs
+++ b/chain/chunks/src/logic.rs
@@ -163,6 +163,9 @@ pub fn decode_encoded_chunk(
         "decode_encoded_chunk",
         height_included = encoded_chunk.cloned_header().height_included(),
         shard_id = ?encoded_chunk.cloned_header().shard_id(),
+        encoded_length = tracing::field::Empty,
+        num_tx = tracing::field::Empty,
+        me = me.map(tracing::field::debug),
         ?chunk_hash)
     .entered();
 

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -2885,10 +2885,7 @@ mod test {
         );
 
         let mut update = fixture.chain_store.store_update();
-        let shard_chunk = fixture
-            .mock_encoded_chunk
-            .decode_chunk(fixture.epoch_manager.num_data_parts())
-            .unwrap();
+        let shard_chunk = fixture.mock_encoded_chunk.decode_chunk().unwrap();
         update.save_chunk(shard_chunk);
         update.commit().unwrap();
 
@@ -2977,10 +2974,7 @@ mod test {
             .unwrap();
 
         let mut update = fixture.chain_store.store_update();
-        let shard_chunk = fixture
-            .mock_encoded_chunk
-            .decode_chunk(fixture.epoch_manager.num_data_parts())
-            .unwrap();
+        let shard_chunk = fixture.mock_encoded_chunk.decode_chunk().unwrap();
         update.save_chunk(shard_chunk);
         update.commit().unwrap();
 
@@ -3109,10 +3103,7 @@ mod test {
             Duration::hours(1),
         );
         let mut update = fixture.chain_store.store_update();
-        let shard_chunk = fixture
-            .mock_encoded_chunk
-            .decode_chunk(fixture.epoch_manager.num_data_parts())
-            .unwrap();
+        let shard_chunk = fixture.mock_encoded_chunk.decode_chunk().unwrap();
         update.save_chunk(shard_chunk);
         update.commit().unwrap();
 
@@ -3145,10 +3136,7 @@ mod test {
             Duration::hours(1),
         );
         let mut update = fixture.chain_store.store_update();
-        let shard_chunk = fixture
-            .mock_encoded_chunk
-            .decode_chunk(fixture.epoch_manager.num_data_parts())
-            .unwrap();
+        let shard_chunk = fixture.mock_encoded_chunk.decode_chunk().unwrap();
         update.save_chunk(shard_chunk);
         update.commit().unwrap();
 

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -199,7 +199,7 @@ pub fn create_chunk(
         // The best way it to decode chunk, replace transactions and then recreate encoded chunk.
         let total_parts = client.chain.epoch_manager.num_total_parts();
         let data_parts = client.chain.epoch_manager.num_data_parts();
-        let decoded_chunk = chunk.decode_chunk(data_parts).unwrap();
+        let decoded_chunk = chunk.decode_chunk().unwrap();
         let parity_parts = total_parts - data_parts;
         let rs = ReedSolomon::new(data_parts, parity_parts).unwrap();
 

--- a/core/primitives/src/genesis/chunk.rs
+++ b/core/primitives/src/genesis/chunk.rs
@@ -50,7 +50,7 @@ pub fn genesis_chunks(
             state_root,
             congestion_info,
         );
-        let mut chunk = encoded_chunk.decode_chunk(1).expect("Failed to decode genesis chunk");
+        let mut chunk = encoded_chunk.decode_chunk().expect("Failed to decode genesis chunk");
         chunk.set_height_included(genesis_height);
         chunks.push(chunk);
     }

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -1295,11 +1295,10 @@ impl EncodedShardChunk {
         PartialEncodedChunkWithArcReceipts { header, parts, prev_outgoing_receipts }
     }
 
-    pub fn decode_chunk(&self, data_parts: usize) -> Result<ShardChunk, std::io::Error> {
+    pub fn decode_chunk(&self) -> Result<ShardChunk, std::io::Error> {
         let _span = debug_span!(
             target: "sharding",
             "decode_chunk",
-            data_parts,
             height_included = self.cloned_header().height_included(),
             shard_id = ?self.cloned_header().shard_id(),
             chunk_hash = ?self.chunk_hash())

--- a/integration-tests/src/tests/client/benchmarks.rs
+++ b/integration-tests/src/tests/client/benchmarks.rs
@@ -55,7 +55,7 @@ fn benchmark_large_chunk_production_time() {
     let ProduceChunkResult { chunk, .. } = create_chunk_on_height(&mut env.clients[0], 0);
     let time = t.elapsed();
 
-    let decoded_chunk = chunk.decode_chunk(0).unwrap();
+    let decoded_chunk = chunk.decode_chunk().unwrap();
 
     let size = borsh::object_length(&chunk).unwrap();
     eprintln!("chunk size: {}kb", size / 1024);


### PR DESCRIPTION
- `decode_chunk()` doesn't need to know how many data parts.
- reorganise the code a bit in `decode_encoded_chunk` to make it more straightforward to understand.

Helps with https://github.com/near/nearcore/issues/13140