### PR TITLE
chore: update realistic 20 shard benchmark config

### DIFF
--- a/benchmarks/sharded-bm/cases/base_config_patch.json
+++ b/benchmarks/sharded-bm/cases/base_config_patch.json
@@ -22,11 +22,11 @@
             "nanos": 500000000
         },
         "max_block_production_delay": {
-            "secs": 6,
+            "secs": 30,
             "nanos": 0
         },
         "max_block_wait_delay": {
-            "secs": 9,
+            "secs": 30,
             "nanos": 0
         }
     }

--- a/benchmarks/sharded-bm/cases/forknet/realistic_20_cp_1_rpc_20_shard/config_patch.json
+++ b/benchmarks/sharded-bm/cases/forknet/realistic_20_cp_1_rpc_20_shard/config_patch.json
@@ -7,14 +7,6 @@
         "min_block_production_delay": {
             "secs": 1,
             "nanos": 300000000
-        },
-        "max_block_production_delay": {
-            "secs": 4,
-            "nanos": 0
-        },
-        "max_block_wait_delay": {
-            "secs": 6,
-            "nanos": 0
         }
     }
 }

--- a/benchmarks/sharded-bm/cases/forknet/realistic_20_cp_1_rpc_20_shard/epoch_configs/template.json
+++ b/benchmarks/sharded-bm/cases/forknet/realistic_20_cp_1_rpc_20_shard/epoch_configs/template.json
@@ -12,7 +12,7 @@
   "block_producer_kickout_threshold": 80,
   "chunk_producer_kickout_threshold": 80,
   "chunk_validator_only_kickout_threshold": 70,
-  "target_validator_mandates_per_shard": 14,
+  "target_validator_mandates_per_shard": 6,
   "validator_max_kickout_stake_perc": 30,
   "online_min_threshold": [
     90, 100

--- a/benchmarks/sharded-bm/cases/forknet/realistic_20_cp_1_rpc_20_shard/params.json
+++ b/benchmarks/sharded-bm/cases/forknet/realistic_20_cp_1_rpc_20_shard/params.json
@@ -7,7 +7,7 @@
     "account_rps": 250,
     "tx_generator": {
         "enabled": true,
-        "tps": 600,
+        "tps": 1050,
         "volume": 0
     },
     "forknet": {


### PR DESCRIPTION
Updating the realistic scenario with current top TPS

Also setting `max_block_production_delay` and `max_block_wait_delay` to 30s because they make analyzing results easier (IMO). In this way, I can increase TPS gradually, and stop once average block time increases significantly.