### PR TITLE
refactor: By creating an `Arc` earlier, save some `clone`ing

### DIFF
--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -1520,10 +1520,10 @@ impl<'a> ChainStoreUpdate<'a> {
         self.chain_store_cache_update.chunks.insert(chunk.chunk_hash(), Arc::new(chunk));
     }
 
-    pub fn save_partial_chunk(&mut self, partial_chunk: PartialEncodedChunk) {
+    pub fn save_partial_chunk(&mut self, partial_chunk: Arc<PartialEncodedChunk>) {
         self.chain_store_cache_update
             .partial_chunks
-            .insert(partial_chunk.chunk_hash(), Arc::new(partial_chunk));
+            .insert(partial_chunk.chunk_hash(), partial_chunk);
     }
 
     pub fn save_block_merkle_tree(

--- a/chain/chunks/src/logic.rs
+++ b/chain/chunks/src/logic.rs
@@ -15,6 +15,7 @@ use near_primitives::{
     },
     types::{AccountId, ShardId},
 };
+use std::sync::Arc;
 use tracing::{debug_span, error};
 
 pub fn need_receipt(
@@ -232,7 +233,7 @@ fn create_partial_chunk(
 }
 
 pub fn persist_chunk(
-    partial_chunk: PartialEncodedChunk,
+    partial_chunk: Arc<PartialEncodedChunk>,
     shard_chunk: Option<ShardChunk>,
     store: &mut ChainStore,
 ) -> Result<(), Error> {

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -2851,7 +2851,7 @@ mod test {
         );
 
         persist_chunk(
-            fixture.make_partial_encoded_chunk(&fixture.all_part_ords),
+            Arc::new(fixture.make_partial_encoded_chunk(&fixture.all_part_ords)),
             None,
             &mut fixture.chain_store,
         )
@@ -2928,7 +2928,7 @@ mod test {
             .unwrap();
 
         persist_chunk(
-            fixture.make_partial_encoded_chunk(partial_ords),
+            Arc::new(fixture.make_partial_encoded_chunk(partial_ords)),
             None,
             &mut fixture.chain_store,
         )
@@ -3019,7 +3019,7 @@ mod test {
             .unwrap();
 
         persist_chunk(
-            fixture.make_partial_encoded_chunk(partial_ords),
+            Arc::new(fixture.make_partial_encoded_chunk(partial_ords)),
             None,
             &mut fixture.chain_store,
         )

--- a/chain/client/src/chunk_distribution_network.rs
+++ b/chain/client/src/chunk_distribution_network.rs
@@ -441,14 +441,14 @@ mod tests {
             futures::future::ready(Ok(chunk))
         }
 
-        fn publish_chunk(
+        async fn publish_chunk(
             &mut self,
             chunk: &PartialEncodedChunk,
-        ) -> impl Future<Output = Result<Self::Response, Self::Error>> {
+        ) -> Result<Self::Response, Self::Error> {
             let prev_hash = *chunk.prev_block();
             let shard_id = chunk.shard_id();
             self.known_chunks.insert((prev_hash, shard_id), chunk.clone());
-            futures::future::ready(Ok(()))
+            Ok(())
         }
     }
 
@@ -466,11 +466,11 @@ mod tests {
             futures::future::ready(Err(()))
         }
 
-        fn publish_chunk(
+        async fn publish_chunk(
             &mut self,
             _chunk: &PartialEncodedChunk,
-        ) -> impl Future<Output = Result<Self::Response, Self::Error>> {
-            futures::future::ready(Err(()))
+        ) -> Result<Self::Response, Self::Error> {
+            Err(())
         }
     }
 


### PR DESCRIPTION
Puts `PartialEncodedChunk` in an `Arc` earlier and allows us to save a couple of `clone`s.