### PR TITLE
refactor: reorganise code a bit

### DIFF
--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -45,7 +45,7 @@ pub enum AdvProduceChunksMode {
 }
 
 pub struct ProduceChunkResult {
-    pub chunk: EncodedShardChunk,
+    pub encoded_chunk: EncodedShardChunk,
     pub encoded_chunk_parts_paths: Vec<MerklePath>,
     pub receipts: Vec<Receipt>,
 }
@@ -340,7 +340,7 @@ impl ChunkProducer {
         }
 
         Ok(Some(ProduceChunkResult {
-            chunk: encoded_chunk,
+            encoded_chunk,
             encoded_chunk_parts_paths: merkle_paths,
             receipts: outgoing_receipts,
         }))

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1717,7 +1717,7 @@ impl Client {
                 Ok(Some(result)) => {
                     let shard_chunk = self
                         .persist_and_distribute_encoded_chunk(
-                            result.chunk,
+                            result.encoded_chunk,
                             result.encoded_chunk_parts_paths,
                             result.receipts,
                             validator_id.clone(),

--- a/integration-tests/src/tests/client/benchmarks.rs
+++ b/integration-tests/src/tests/client/benchmarks.rs
@@ -4,14 +4,13 @@
 //! we want to test here are pretty heavy and its enough to run them once and
 //! note the wall-clock time.
 
+use crate::env::nightshade_setup::TestEnvNightshadeSetupExt;
+use crate::env::test_env::TestEnv;
 use near_chain_configs::Genesis;
 use near_client::test_utils::create_chunk_on_height;
 use near_client::{ProcessTxResponse, ProduceChunkResult};
 use near_crypto::InMemorySigner;
 use near_primitives::transaction::{Action, DeployContractAction, SignedTransaction};
-
-use crate::env::nightshade_setup::TestEnvNightshadeSetupExt;
-use crate::env::test_env::TestEnv;
 
 /// cspell:ignore txes
 /// How long does it take to produce a large chunk?
@@ -52,12 +51,12 @@ fn benchmark_large_chunk_production_time() {
     }
 
     let t = std::time::Instant::now();
-    let ProduceChunkResult { chunk, .. } = create_chunk_on_height(&mut env.clients[0], 0);
+    let ProduceChunkResult { encoded_chunk, .. } = create_chunk_on_height(&mut env.clients[0], 0);
     let time = t.elapsed();
 
-    let decoded_chunk = chunk.decode_chunk().unwrap();
+    let decoded_chunk = encoded_chunk.decode_chunk().unwrap();
 
-    let size = borsh::object_length(&chunk).unwrap();
+    let size = borsh::object_length(&encoded_chunk).unwrap();
     eprintln!("chunk size: {}kb", size / 1024);
     eprintln!("time to produce: {:0.2?}", time);
 

--- a/integration-tests/src/tests/client/invalid_txs.rs
+++ b/integration-tests/src/tests/client/invalid_txs.rs
@@ -90,12 +90,12 @@ fn test_invalid_transactions_no_panic() {
                 assert!(matches!(res, ProcessTxResponse::ValidTx))
             }
 
-            let (ProduceChunkResult { chunk, encoded_chunk_parts_paths, receipts }, _) =
+            let (ProduceChunkResult { encoded_chunk, encoded_chunk_parts_paths, receipts }, _) =
                 create_chunk(client, transactions);
 
             let shard_chunk = client
                 .persist_and_distribute_encoded_chunk(
-                    chunk,
+                    encoded_chunk,
                     encoded_chunk_parts_paths,
                     receipts,
                     client.validator_signer.get().unwrap().validator_id().clone(),
@@ -214,12 +214,12 @@ fn test_invalid_transactions_dont_invalidate_chunk() {
     let chunk_producer = env.get_chunk_producer_at_offset(&tip, 1, ShardId::new(0));
     let block_producer = env.get_block_producer_at_offset(&tip, 1);
     let client = env.client(&chunk_producer);
-    let (ProduceChunkResult { chunk, encoded_chunk_parts_paths, receipts }, _) =
+    let (ProduceChunkResult { encoded_chunk, encoded_chunk_parts_paths, receipts }, _) =
         create_chunk(client, chunk_transactions);
 
     let shard_chunk = client
         .persist_and_distribute_encoded_chunk(
-            chunk,
+            encoded_chunk,
             encoded_chunk_parts_paths,
             receipts,
             client.validator_signer.get().unwrap().validator_id().clone(),

--- a/integration-tests/src/tests/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/features/access_key_nonce_for_implicit_accounts.rs
@@ -233,12 +233,14 @@ fn test_chunk_transaction_validity() {
         env.produce_block(0, i);
     }
     let (
-        ProduceChunkResult { chunk, encoded_chunk_parts_paths: merkle_paths, receipts, .. },
+        ProduceChunkResult {
+            encoded_chunk, encoded_chunk_parts_paths: merkle_paths, receipts, ..
+        },
         block,
     ) = create_chunk(&mut env.clients[0], vec![validated_tx]);
     let validator_id = env.clients[0].validator_signer.get().unwrap().validator_id().clone();
     env.clients[0]
-        .persist_and_distribute_encoded_chunk(chunk, merkle_paths, receipts, validator_id)
+        .persist_and_distribute_encoded_chunk(encoded_chunk, merkle_paths, receipts, validator_id)
         .unwrap();
     let res = env.clients[0].process_block_test(block.into(), Provenance::NONE);
     match res.as_deref() {

--- a/integration-tests/src/utils/process_blocks.rs
+++ b/integration-tests/src/utils/process_blocks.rs
@@ -1,3 +1,5 @@
+use crate::env::nightshade_setup::TestEnvNightshadeSetupExt;
+use crate::env::test_env::TestEnv;
 use near_chain::{Block, Provenance};
 use near_chain_configs::Genesis;
 use near_client::ProcessTxResponse;
@@ -11,9 +13,6 @@ use near_primitives::types::{AccountId, BlockHeight};
 use near_primitives::version::PROTOCOL_VERSION;
 use near_vm_runner::logic::ProtocolVersion;
 use node_runtime::config::Rational32;
-
-use crate::env::nightshade_setup::TestEnvNightshadeSetupExt;
-use crate::env::test_env::TestEnv;
 
 pub fn set_block_protocol_version(
     block: &mut Block,


### PR DESCRIPTION
Completely non-functional changes.  Just reorganising code a bit.

- `EncodedShardChunk::new` is tidied up a bit
- `ProduceChunkResult::chunk` is renamed to `ProduceChunk::Result::encoded_chunk` to better suit the type


I needed these changes to prevent another PR from blowing up in complexity.