### PR TITLE
feat(voting): one_by_one upgrade for protocol upgrade schedule override

### DIFF
--- a/core/primitives/src/upgrade_schedule.rs
+++ b/core/primitives/src/upgrade_schedule.rs
@@ -195,12 +195,12 @@ impl ProtocolUpgradeVotingSchedule {
         client_protocol_version: ProtocolVersion,
     ) -> Result<ProtocolUpgradeVotingScheduleRaw, ProtocolUpgradeVotingScheduleError> {
         // The special value "now" means that the upgrade should happen immediately.
-        if override_str.to_lowercase() == "now" {
-            return Ok(vec![]);
-        }
-
-        if override_str.to_lowercase() == "one_by_one" {
-            return Ok(Self::one_by_one(min_supported_protocol_version, client_protocol_version));
+        match override_str.to_lowercase() {
+            "now" => return Ok(vec![]),
+            "one_by_one" => return Ok(Self::one_by_one(
+                min_supported_protocol_version, 
+                client_protocol_version)),
+            _ => {},
         }
 
         let mut result = vec![];

--- a/core/primitives/src/upgrade_schedule.rs
+++ b/core/primitives/src/upgrade_schedule.rs
@@ -72,9 +72,8 @@ impl ProtocolUpgradeVotingSchedule {
         client_protocol_version: ProtocolVersion,
         mut schedule: ProtocolUpgradeVotingScheduleRaw,
     ) -> Result<Self, ProtocolUpgradeVotingScheduleError> {
-        let env_override: Result<String, env::VarError> =
-            env::var(NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE);
-        if let Ok(env_override) = env_override {
+        let env_override = env::var(NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE).ok();
+        if let Some(env_override) = env_override {
             schedule = Self::parse_override(
                 &env_override,
                 min_supported_protocol_version,

--- a/core/primitives/src/upgrade_schedule.rs
+++ b/core/primitives/src/upgrade_schedule.rs
@@ -194,13 +194,17 @@ impl ProtocolUpgradeVotingSchedule {
         min_supported_protocol_version: ProtocolVersion,
         client_protocol_version: ProtocolVersion,
     ) -> Result<ProtocolUpgradeVotingScheduleRaw, ProtocolUpgradeVotingScheduleError> {
-        // The special value "now" means that the upgrade should happen immediately.
-        match override_str.to_lowercase() {
+        match override_str.to_lowercase().as_str() {
+            // The special value "now" means that the upgrade should happen immediately, all versions at once.
             "now" => return Ok(vec![]),
-            "one_by_one" => return Ok(Self::one_by_one(
-                min_supported_protocol_version, 
-                client_protocol_version)),
-            _ => {},
+            // The special value "one_by_one" means that the upgrade should happen immediately every epoch.
+            "one_by_one" => {
+                return Ok(Self::one_by_one(
+                    min_supported_protocol_version,
+                    client_protocol_version,
+                ));
+            }
+            _ => {}
         }
 
         let mut result = vec![];

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -60,7 +60,12 @@ pub const PROTOCOL_UPGRADE_SCHEDULE: LazyLock<ProtocolUpgradeVotingSchedule> =
         // let v2_datetime = ProtocolUpgradeVotingSchedule::parse_datetime("2000-01-10 15:00:00").unwrap();
         //
         // let schedule = vec![(v1_datetime, v1_protocol_version), (v2_datetime, v2_protocol_version)];
-        // ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(PROTOCOL_VERSION, schedule).unwrap()
+        // ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(MIN_SUPPORTED_PROTOCOL_VERSION, PROTOCOL_VERSION, schedule).unwrap()
 
-        ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(PROTOCOL_VERSION, vec![]).unwrap()
+        ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(
+            MIN_SUPPORTED_PROTOCOL_VERSION,
+            PROTOCOL_VERSION,
+            vec![],
+        )
+        .unwrap()
     });

--- a/test-loop-tests/src/utils/setups.rs
+++ b/test-loop-tests/src/utils/setups.rs
@@ -82,6 +82,7 @@ pub fn two_upgrades_voting_schedule(
         (past_datetime_2, target_protocol_version),
     ];
     ProtocolUpgradeVotingSchedule::new_from_env_or_schedule(
+        target_protocol_version - 2,
         target_protocol_version,
         voting_schedule,
     )


### PR DESCRIPTION
This PR introduces a new field for `NEAR_TESTS_PROTOCOL_UPGRADE_OVERRIDE`.
`one_by_one` will set the voting schedule for all protocol versions in the past
to avoid upgrading multiple versions at the same time.

Tested with `cargo test --package near-primitives --lib upgrade_schedule::tests -- --show-output --test-threads=1` to avoid interference from `test_env_override`.