### PR TITLE
fix: correctly disable tracing if not needed

### DIFF
--- a/benchmarks/sharded-bm/bench.sh
+++ b/benchmarks/sharded-bm/bench.sh
@@ -118,16 +118,16 @@ start_neard0() {
     local cmd_suffix=""
     local tracing_ip=${2:-$TRACING_SERVER_INTERNAL_IP}
     local neard_cmd="${FORKNET_NEARD_PATH} --home ${NEAR_HOME} run"
-    local tracing_address=""
+    local tracing_env=""
 
     if [ ! -z "${tracing_ip}" ]; then
         echo "Tracing server internal IP: ${tracing_ip}"
-        tracing_address="http://${tracing_ip}:4317/"
+        tracing_env="OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://${tracing_ip}:4317/"
     else
         echo "Tracing server internal IP is not set."
     fi
 
-    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=${tracing_address} nohup ${neard_cmd} > ${FORKNET_NEARD_LOG} 2>&1 &
+    ${tracing_env} nohup ${neard_cmd} > ${FORKNET_NEARD_LOG} 2>&1 &
 }
 
 start_nodes_local() {

--- a/benchmarks/sharded-bm/bench.sh
+++ b/benchmarks/sharded-bm/bench.sh
@@ -118,16 +118,15 @@ start_neard0() {
     local cmd_suffix=""
     local tracing_ip=${2:-$TRACING_SERVER_INTERNAL_IP}
     local neard_cmd="${FORKNET_NEARD_PATH} --home ${NEAR_HOME} run"
-    local tracing_env=""
 
     if [ ! -z "${tracing_ip}" ]; then
         echo "Tracing server internal IP: ${tracing_ip}"
-        tracing_env="OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://${tracing_ip}:4317/"
+        export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://${tracing_ip}:4317/"
     else
         echo "Tracing server internal IP is not set."
     fi
 
-    ${tracing_env} nohup ${neard_cmd} > ${FORKNET_NEARD_LOG} 2>&1 &
+    nohup ${neard_cmd} > ${FORKNET_NEARD_LOG} 2>&1 &
 }
 
 start_nodes_local() {

--- a/benchmarks/sharded-bm/bench.sh
+++ b/benchmarks/sharded-bm/bench.sh
@@ -361,6 +361,10 @@ edit_log_config() {
 tweak_config_forknet() {
     gen_localnet_for_forknet
     fetch_forknet_details
+    if [ ! -z "${TRACING_SERVER_INTERNAL_IP}" ]; then
+        FORKNET_ENV="${FORKNET_ENV} TRACING_SERVER_INTERNAL_IP=${TRACING_SERVER_INTERNAL_IP}"
+    fi
+
     local cwd=$(pwd)
     cd ${PYTEST_PATH}
     $MIRROR --host-type nodes upload-file --src ${cwd}/bench.sh --dst ${BENCHNET_DIR}
@@ -391,6 +395,9 @@ tweak_config_forknet_node() {
         '.network.addr |= $val' ${CONFIG} >tmp.$$.json && mv tmp.$$.json ${CONFIG} || rm tmp.$$.json
     jq --arg val "0.0.0.0:3030" \
         '.rpc.addr |= $val' ${CONFIG} >tmp.$$.json && mv tmp.$$.json ${CONFIG} || rm tmp.$$.json
+    if [ -z "${TRACING_SERVER_INTERNAL_IP}" ]; then
+        jq '.opentelemetry = null' ${LOG_CONFIG} >tmp.$$.json && mv tmp.$$.json ${LOG_CONFIG} || rm tmp.$$.json
+    fi
     if [ -n "$boot_nodes" ]; then
         jq --arg val "${boot_nodes}" \
             '.network.boot_nodes |= $val' ${CONFIG} >tmp.$$.json && mv tmp.$$.json ${CONFIG} || rm tmp.$$.json


### PR DESCRIPTION
Fixes a few issues when tracing node is not present:
- neard not able to start
- log spam about missing tracing endpoint