### PR TITLE
feat(debug-ui): make shard transitions visible

### DIFF
--- a/tools/debug-ui/package-lock.json
+++ b/tools/debug-ui/package-lock.json
@@ -22,6 +22,7 @@
         "react-xarrows": "^2.0.2"
       },
       "devDependencies": {
+        "@types/lodash": "^4.17.16",
         "@typescript-eslint/eslint-plugin": "^5.52.0",
         "@typescript-eslint/parser": "^5.52.0",
         "eslint": "^8.34.0",
@@ -3920,6 +3921,13 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mime": {
       "version": "3.0.1",
@@ -21053,6 +21061,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
+    },
+    "@types/lodash": {
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
+      "dev": true
     },
     "@types/mime": {
       "version": "3.0.1",

--- a/tools/debug-ui/package.json
+++ b/tools/debug-ui/package.json
@@ -36,6 +36,7 @@
     ]
   },
   "devDependencies": {
+    "@types/lodash": "^4.17.16",
     "@typescript-eslint/eslint-plugin": "^5.52.0",
     "@typescript-eslint/parser": "^5.52.0",
     "eslint": "^8.34.0",

--- a/tools/debug-ui/src/EpochValidatorsView.scss
+++ b/tools/debug-ui/src/EpochValidatorsView.scss
@@ -138,6 +138,12 @@
     @extend .validator-role;
     background-color: lightblue;
 }
+.new-chunk-producer {
+    color: red;
+}
+.old-chunk-producer {
+    color: black;
+}
 
 .chunk-validator {
     @extend .validator-role;


### PR DESCRIPTION
for every chunk producers, new shards will be highlighted in red. 

<img width="1779" alt="image" src="https://github.com/user-attachments/assets/120898da-af2b-48c7-a83b-4fa40a3dd9c9" />
<img width="1779" alt="image" src="https://github.com/user-attachments/assets/712c5e16-6066-49fa-a4aa-e89b670921d2" />
<img width="1779" alt="image" src="https://github.com/user-attachments/assets/6e56efbf-b8fa-4ae7-9f21-1080a7554ef8" />

![image](https://github.com/user-attachments/assets/786abc0b-faf3-41f2-9cab-92f49e3137d4)

