### PR TITLE
fix(optimistic-block) - reduce log level to debug to reduce spam

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1953,7 +1953,7 @@ impl Chain {
         for (shard_id, cached_shard_update_key, apply_result) in apply_result.into_iter() {
             match apply_result {
                 Ok(result) => {
-                    info!(
+                    debug!(
                         target: "chain", ?prev_block_hash, block_height,
                         ?shard_id, ?cached_shard_update_key,
                         "Caching ShardUpdate result from OptimisticBlock"

--- a/chain/chain/src/missing_chunks.rs
+++ b/chain/chain/src/missing_chunks.rs
@@ -324,7 +324,7 @@ impl OptimisticBlockChunksPool {
             return;
         }
 
-        tracing::info!(
+        tracing::debug!(
             target: "chunks",
             ?prev_block_hash,
             optimistic_block_hash = ?block.hash(),


### PR DESCRIPTION
These two optimistic block logs are spamming output. Let's reduce their log-level to debug.

refs: [zulip](https://near.zulipchat.com/#narrow/channel/308695-nearone.2Fprivate/topic/2.2E6.2E0-rc.2E2/near/513021767)