### PR TITLE
fix(bench.sh): use lowercase mirror.py

### DIFF
--- a/benchmarks/sharded-bm/bench.sh
+++ b/benchmarks/sharded-bm/bench.sh
@@ -81,7 +81,7 @@ if [ "${RUN_ON_FORKNET}" = true ]; then
     NUM_SHARDS=$(jq '.shard_layout.V2.shard_ids | length' ${GENESIS} 2>/dev/null) || true
     NODE_BINARY_URL=$(jq -r '.forknet.binary_url' ${BM_PARAMS})
     VALIDATOR_KEY=${NEAR_HOME}/validator_key.json
-    MIRROR="${VIRTUAL_ENV}/python3 tests/mocknet/MIRROR.py --chain-id mainnet --start-height ${FORKNET_START_HEIGHT} \
+    MIRROR="${VIRTUAL_ENV}/python3 tests/mocknet/mirror.py --chain-id mainnet --start-height ${FORKNET_START_HEIGHT} \
         --unique-id ${FORKNET_NAME}"
     echo "Forknet name: ${FORKNET_NAME}"
 else


### PR DESCRIPTION
The bench.sh script contains uppercase "MIRROR.py", but the actual file is "mirror.py" (lowercase).
I think this works on Mac, but it doesn't work on Linux where it complains that it can't find the MIRROR.py file.
Let's make it lowercase to fix the script on Linux.