### PR TITLE
fix(rpc_user): wait for finality in commit_transaction

### DIFF
--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -6,7 +6,7 @@ use near_jsonrpc_primitives::types::changes::{
     RpcStateChangesInBlockByTypeRequest, RpcStateChangesInBlockByTypeResponse,
 };
 use near_jsonrpc_primitives::types::transactions::{
-    RpcTransactionResponse, RpcTransactionStatusRequest,
+    RpcSendTransactionRequest, RpcTransactionResponse, RpcTransactionStatusRequest,
 };
 use near_jsonrpc_primitives::types::validator::RpcValidatorsOrderedRequest;
 use near_primitives::hash::CryptoHash;
@@ -278,6 +278,15 @@ impl JsonRpcClient {
             _ => EpochReference::Latest,
         };
         call_method(&self.client, &self.server_addr, "validators", epoch_reference)
+    }
+
+    pub fn send_tx(
+        &self,
+        signed_transaction: near_primitives::transaction::SignedTransaction,
+        wait_until: near_primitives::views::TxExecutionStatus,
+    ) -> RpcRequest<RpcTransactionResponse> {
+        let request = RpcSendTransactionRequest { signed_transaction, wait_until };
+        call_method(&self.client, &self.server_addr, "send_tx", request)
     }
 }
 


### PR DESCRIPTION
The RPC user used in our integration test used the (deprecated) broadcast_tx_commit method, plus a manual wait-another-block loop to ensure the transaction is actually committed.

This works most of the time but not always. Specifically, I ran into issues while removing refund receipts in #13370. This means that sometimes we see the last receipt but it has not been applied yet.

Using the newer replacement "send_tx" lets us specify to wait for finality, solving the problem cleanly.

Docs on deprecated method:
https://docs.near.org/api/rpc/transactions#send-transaction-await

Docs on new method:
https://docs.near.org/api/rpc/transactions#send-tx