### PR TITLE
chore: remove deprecated RPC endpoints in pytests

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -263,13 +263,18 @@ class BaseNode(object):
         return json.loads(r.content)
 
     def send_tx(self, signed_tx):
-        return self.json_rpc('broadcast_tx_async',
-                             [base64.b64encode(signed_tx).decode('utf8')])
+        params = {
+            'signed_tx_base64': base64.b64encode(signed_tx).decode('utf8'),
+            "wait_until": "None"
+        }
+        return self.json_rpc('send_tx', params)
 
     def send_tx_and_wait(self, signed_tx, timeout):
-        return self.json_rpc('broadcast_tx_commit',
-                             [base64.b64encode(signed_tx).decode('utf8')],
-                             timeout=timeout)
+        params = {
+            'signed_tx_base64': base64.b64encode(signed_tx).decode('utf8'),
+            "wait_until": "EXECUTED"
+        }
+        return self.json_rpc('send_tx', params, timeout=timeout)
 
     def get_status(self,
                    check_storage: bool = True,
@@ -381,16 +386,6 @@ class BaseNode(object):
                 "account_id": acc,
                 "finality": finality
             })
-
-    def wait_at_least_one_block(self):
-        start_height = self.get_latest_block().height
-        timeout_sec = 5
-        started = time.monotonic()
-        while time.monotonic() - started < timeout_sec:
-            height = self.get_latest_block().height
-            if height > start_height:
-                break
-            time.sleep(0.2)
 
     def get_nonce_for_pk(self, acc, pk, finality='optimistic'):
         for access_key in self.get_access_key_list(acc,

--- a/pytest/lib/mocknet_helpers.py
+++ b/pytest/lib/mocknet_helpers.py
@@ -87,19 +87,6 @@ def retry_and_ignore_errors(f):
     return None
 
 
-def wait_at_least_one_block():
-    status = get_status()
-    start_height = status['sync_info']['latest_block_height']
-    timeout_sec = 5
-    started = time.monotonic()
-    while time.monotonic() - started < timeout_sec:
-        status = get_status()
-        height = status['sync_info']['latest_block_height']
-        if height > start_height:
-            break
-        time.sleep(1.0)
-
-
 def get_amount_yoctonear(account_id, addr=LOCAL_ADDR, port=RPC_PORT):
     j = json_rpc('query', {
         'request_type': 'view_account',

--- a/pytest/tests/mocknet/helpers/load_test_spoon_helper.py
+++ b/pytest/tests/mocknet/helpers/load_test_spoon_helper.py
@@ -124,7 +124,6 @@ def main():
         logger.info(
             f'Account {account.key.account_id} balance after initialization: {balance}'
         )
-        time.sleep(max(1.0, start_time + (i + 1) * delay - time.monotonic()))
 
     logger.info('Done deploying')
 

--- a/pytest/tests/mocknet/helpers/load_test_utils.py
+++ b/pytest/tests/mocknet/helpers/load_test_utils.py
@@ -201,10 +201,9 @@ def send_random_transactions(test_state):
 
 
 def init_ft(node_account):
-    tx_res = node_account.send_deploy_contract_tx(
+    tx_res = node_account.send_deploy_contract_tx_sync(
         '/home/ubuntu/fungible_token.wasm')
     logger.info(f'ft deployment {tx_res}')
-    mocknet_helpers.wait_at_least_one_block()
 
     s = f'{{"owner_id": "{node_account.key.account_id}", "total_supply": "{10**33}"}}'
     tx_res = node_account.send_call_contract_raw_tx(node_account.key.account_id,
@@ -215,24 +214,18 @@ def init_ft(node_account):
 
 def init_ft_account(node_account, account):
     s = f'{{"account_id": "{account.key.account_id}"}}'
-    tx_res = account.send_call_contract_raw_tx(node_account.key.account_id,
-                                               'storage_deposit',
-                                               s.encode('utf-8'),
-                                               (10**24) // 800)
+    tx_res = account.send_call_contract_raw_tx_sync(node_account.key.account_id,
+                                                    'storage_deposit',
+                                                    s.encode('utf-8'),
+                                                    (10**24) // 800)
     logger.info(f'Account {account.key.account_id} storage_deposit {tx_res}')
-
-    # The next transaction depends on the previous transaction succeeded.
-    # Sleeping for 1 second is the poor man's solution for waiting for that transaction to succeed.
-    # This works because the contracts are being deployed slow enough to keep block production above 1 bps.
-    mocknet_helpers.wait_at_least_one_block()
 
     s = f'{{"receiver_id": "{account.key.account_id}", "amount": "{10**18}"}}'
     logger.info(
         f'Calling function "ft_transfer" with arguments {s} on account {account.key.account_id}'
     )
-    tx_res = node_account.send_call_contract_raw_tx(node_account.key.account_id,
-                                                    'ft_transfer',
-                                                    s.encode('utf-8'), 1)
+    tx_res = node_account.send_call_contract_raw_tx_sync(
+        node_account.key.account_id, 'ft_transfer', s.encode('utf-8'), 1)
     logger.info(
         f'{node_account.key.account_id} ft_transfer to {account.key.account_id} {tx_res}'
     )

--- a/pytest/tests/mocknet/load_test_betanet.py
+++ b/pytest/tests/mocknet/load_test_betanet.py
@@ -78,7 +78,6 @@ def main(argv):
             logger.info(
                 f'Account {account.key.account_id} balance after initialization: {account.get_amount_yoctonear()}'
             )
-            mocknet_helpers.wait_at_least_one_block()
 
     total_tx_sent = 0
     start_time = time.monotonic()

--- a/pytest/tests/sanity/meta_tx.py
+++ b/pytest/tests/sanity/meta_tx.py
@@ -86,13 +86,6 @@ class TestMetaTransactions(unittest.TestCase):
 
         nodes[0].send_tx_and_wait(meta_tx, 100)
 
-        # send_tx_and_wait does not guarantee that all receipts changes are
-        # observable on RPC queries, yet.
-        # For meta transactions without refund, the access key is added in the
-        # last receipt of the transaction, which is not observable at this point.
-        # Waiting for one more block fixes that.
-        nodes[0].wait_at_least_one_block()
-
         self.assertEqual(check_account_status(nodes[0], CANDIDATE_ACCOUNT),
                          (2, CANDIDATE_STARTING_AMOUNT))
 

--- a/pytest/tests/sanity/rosetta.py
+++ b/pytest/tests/sanity/rosetta.py
@@ -697,7 +697,6 @@ class RosettaTestCase(unittest.TestCase):
                                                block_hash)
         res = self.node.send_tx_and_wait(tx, 100)
         logger.info(f'Storage deposit: {res}')
-        self.node.wait_at_least_one_block()
 
         ### 4. Rosetta ft_call
         ft_result = self.rosetta.ft_transfer(src=validator,


### PR DESCRIPTION
`broadcast_tx_async` and `broadcast_tx_commit` are both deprecated RPC endpoints. Instead, we can call the more convenient `send_tx` endpoint with appropriate `wait_until` parameter values.

See https://docs.near.org/api/rpc/transactions#send-tx. which also mentions:

> Using send_tx with wait_until = NONE is equal to legacy broadcast_tx_async method.
> Using send_tx with finality wait_until = EXECUTED_OPTIMISTIC is equal to legacy broadcast_tx_commit method.

However, for `send_tx_and_wait`, I'm even using `wait_until = FINAL`. This waits until all receipt, including refunds. are finalized. This allows removing some sleeps across pytests that were in place to ensure we can observe the full effect of the transaction.