### PR TITLE
Prepare 2.6.0-rc.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,7 +1292,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chainsync-loadtest"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "cold-store-tool"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "congestion-model"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "bytesize",
  "chrono",
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "estimator-warehouse"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-csv-to-json"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "chrono",
  "clap",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-populate"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "borsh",
  "clap",
@@ -3356,7 +3356,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-example"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3604,7 +3604,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "keypair-generator"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "clap",
  "near-crypto",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "mock-node"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4134,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "near-actix-test-utils"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix-rt",
  "near-store",
@@ -4142,7 +4142,7 @@ dependencies = [
 
 [[package]]
 name = "near-amend-genesis"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4161,7 +4161,7 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "derive_more 1.0.0",
@@ -4181,7 +4181,7 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -4191,7 +4191,7 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "bencher",
  "lru 0.12.3",
@@ -4200,7 +4200,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -4254,7 +4254,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "near-crypto",
  "near-primitives",
@@ -4289,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "assert_matches",
@@ -4321,7 +4321,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "near-client"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4390,7 +4390,7 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "chrono",
@@ -4410,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "blake2",
  "bolero",
@@ -4448,7 +4448,7 @@ dependencies = [
 
 [[package]]
 name = "near-database-tool"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4474,7 +4474,7 @@ dependencies = [
 
 [[package]]
 name = "near-dump-test-contract"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "borsh",
  "chrono",
@@ -4527,7 +4527,7 @@ dependencies = [
 
 [[package]]
 name = "near-flat-storage"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4546,14 +4546,14 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "near-primitives-core",
 ]
 
 [[package]]
 name = "near-fork-network"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -4579,7 +4579,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -4606,7 +4606,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "near-primitives",
  "serde",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4645,7 +4645,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-adversarial-primitives"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "near-primitives",
  "serde",
@@ -4653,7 +4653,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix-http",
  "awc",
@@ -4666,7 +4666,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-fuzz"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "arbitrary",
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -4700,7 +4700,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-tests"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "awc",
@@ -4726,7 +4726,7 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -4736,7 +4736,7 @@ dependencies = [
 
 [[package]]
 name = "near-mirror"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4781,7 +4781,7 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -4842,7 +4842,7 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "base64 0.21.0",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "assert_matches",
  "borsh",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "quote",
  "syn 2.0.87",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "near-ping"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -4932,7 +4932,7 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "borsh",
  "near-crypto",
@@ -4943,7 +4943,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "arbitrary",
  "base64 0.21.0",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "near-replay-archive-tool"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "actix-cors",
@@ -5068,14 +5068,14 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "inventory",
 ]
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "inventory",
  "near-schema-checker-core",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5093,11 +5093,11 @@ dependencies = [
 
 [[package]]
 name = "near-stable-hasher"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 
 [[package]]
 name = "near-state-parts"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5116,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "near-state-parts-dump-check"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "actix-web",
@@ -5139,11 +5139,11 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 
 [[package]]
 name = "near-store"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5196,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "awc",
@@ -5214,7 +5214,7 @@ dependencies = [
 
 [[package]]
 name = "near-test-contracts"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "arbitrary",
  "rand",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -5236,7 +5236,7 @@ dependencies = [
 
 [[package]]
 name = "near-transactions-generator"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "near-undo-block"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5272,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -5288,7 +5288,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-test-derive"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5320,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -5341,7 +5341,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -5414,7 +5414,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner-fuzz"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -5428,7 +5428,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-api"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -5456,14 +5456,14 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-generator"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "near-vm-types"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "bolero",
  "indexmap 2.7.0",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "backtrace",
  "cc",
@@ -5494,7 +5494,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-wast"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
  "near-vm-test-api",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
  "near-primitives-core",
@@ -5513,7 +5513,7 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5583,7 +5583,7 @@ dependencies = [
 
 [[package]]
 name = "neard"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "assert_matches",
  "base64 0.21.0",
@@ -6609,7 +6609,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-schema-check"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "inventory",
  "near-chain",
@@ -6981,7 +6981,7 @@ dependencies = [
 
 [[package]]
 name = "restaked"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "clap",
  "integration-tests",
@@ -7120,7 +7120,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-params-estimator"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7161,7 +7161,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "bolero",
  "cpu-time",
@@ -7189,7 +7189,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester-fuzz"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "libfuzzer-sys",
  "runtime-tester",
@@ -7808,7 +7808,7 @@ dependencies = [
 
 [[package]]
 name = "speedy_sync"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "borsh",
  "clap",
@@ -7851,7 +7851,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-viewer"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "anyhow",
@@ -7903,7 +7903,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-usage-delta-calculator"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -7918,7 +7918,7 @@ dependencies = [
 
 [[package]]
 name = "store-validator"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "clap",
  "near-chain",
@@ -8111,7 +8111,7 @@ dependencies = [
 
 [[package]]
 name = "test-loop-tests"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "actix",
  "assert_matches",
@@ -8146,7 +8146,7 @@ dependencies = [
 
 [[package]]
 name = "testlib"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "bytesize",
  "near-chain",
@@ -8162,7 +8162,7 @@ dependencies = [
 
 [[package]]
 name = "themis"
-version = "2.6.0-rc.1"
+version = "2.6.0-rc.2"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "2.6.0-rc.1"                               # managed by cargo-workspaces, see below
+version = "2.6.0-rc.2"                               # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2024"
 rust-version = "1.85.0"
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 # anything to the list of stable crates.
 # Only bump  0.x.* to 0.(x+1).0 on any nearcore release as nearcore does not guarantee
 # semver compatibility. i.e. api can change without a protocol upgrade.
-version = "0.30.0-rc.1"
+version = "0.30.0-rc.2"
 exclude = ["neard"]
 
 [workspace]

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1613,13 +1613,8 @@ impl Chain {
             Chain::get_prev_chunk_headers(self.epoch_manager.as_ref(), &prev_block)?;
         let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(&prev_block_hash)?;
 
-        let (is_caught_up, _) = self.get_catchup_and_state_sync_infos(
-            &epoch_id,
-            None,
-            &prev_block_hash,
-            prev_prev_hash,
-            me,
-        )?;
+        let (is_caught_up, _) =
+            self.get_catchup_and_state_sync_infos(None, &prev_block_hash, prev_prev_hash, me)?;
 
         let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
         let chunks = Chunks::from_chunk_headers(&chunk_headers, block_height);
@@ -1889,37 +1884,18 @@ impl Chain {
         let prev_hash = *header.prev_hash();
         let prev_block = self.get_block(&prev_hash)?;
 
-        // TODO(current_epoch_state_sync): fix this when syncing to the current epoch's state
-        // The congestion control added a dependency on the prev block when
-        // applying chunks in a block. This means that we need to keep the
-        // blocks at sync hash, prev hash and prev prev hash.
-        // Due to epoch finalization restrictions these blocks have consecutive heights,
-        // so the height of the prev prev block is sync_height - 2.
-        let mut new_tail = prev_block.header().height().saturating_sub(1);
+        // Check which blocks were downloaded during state sync
+        // and set the tail and chunk tail accordingly
+        let tail_block_hash = self
+            .get_extra_sync_block_hashes(&prev_hash)
+            .into_iter()
+            .min_by_key(|block_hash| self.get_block_header(block_hash).unwrap().height())
+            .unwrap_or(prev_hash);
+        let tail_block = self.get_block(&tail_block_hash)?;
 
-        // In case there are missing chunks we need to keep more than just the
-        // sync hash block. The logic below adjusts the new_tail so that every
-        // shard is guaranteed to have at least one new chunk in the blocks
-        // leading to the sync hash block.
-        let min_height_included = prev_block
-            .chunks()
-            .iter_deprecated()
-            .map(|chunk| chunk.height_included())
-            .min()
-            .unwrap();
-
-        tracing::debug!(target: "sync", ?min_height_included, ?new_tail, "adjusting tail for missing chunks");
-        new_tail = std::cmp::min(new_tail, min_height_included.saturating_sub(1));
-
-        // In order to find the right new_chunk_tail we need to find the minimum
-        // of chunk height_created for chunks in the new tail block.
-        let new_tail_block = self.get_block_by_height(new_tail)?;
-        let new_chunk_tail = new_tail_block
-            .chunks()
-            .iter_deprecated()
-            .map(|chunk| chunk.height_created())
-            .min()
-            .unwrap();
+        let new_tail = tail_block.header().height();
+        let new_chunk_tail = tail_block.chunks().min_height_included().unwrap();
+        tracing::debug!(target: "sync", ?new_tail, ?new_chunk_tail, "adjusting tail for sync blocks");
 
         let tip = Tip::from_header(prev_block.header());
         let final_head = Tip::from_header(self.genesis.header());
@@ -2366,7 +2342,16 @@ impl Chain {
 
         let shard_layout = self.epoch_manager.get_shard_layout(epoch_id)?;
 
-        let last_final_block = self.get_block(&last_final_block_hash)?;
+        // If the full block is not available, skip getting candidate.
+        // This is possible if the node just went through state sync.
+        let Ok(last_final_block) = self.get_block(&last_final_block_hash) else {
+            tracing::warn!(
+                "get_new_flat_storage_head could not get last final block {}",
+                last_final_block_hash
+            );
+            return Ok(None);
+        };
+
         let last_final_block_epoch_id = last_final_block.header().epoch_id();
         // If shard layout was changed, the update is impossible so we skip
         // getting candidate.
@@ -2592,7 +2577,6 @@ impl Chain {
         }
 
         let (is_caught_up, state_sync_info) = self.get_catchup_and_state_sync_infos(
-            header.epoch_id(),
             Some(header.hash()),
             &prev_hash,
             prev_prev_hash,
@@ -2700,7 +2684,6 @@ impl Chain {
     /// returns it as well.
     fn get_catchup_and_state_sync_infos(
         &self,
-        epoch_id: &EpochId,
         block_hash: Option<&CryptoHash>,
         prev_hash: &CryptoHash,
         prev_prev_hash: &CryptoHash,
@@ -2721,7 +2704,7 @@ impl Chain {
         // we consider that we are caught up, otherwise not
         let state_sync_info = match block_hash {
             Some(block_hash) => {
-                self.shard_tracker.get_state_sync_info(me, epoch_id, block_hash, prev_hash)?
+                self.shard_tracker.get_state_sync_info(me, block_hash, prev_hash)?
             }
             None => None,
         };
@@ -3771,31 +3754,19 @@ impl Chain {
             self.epoch_manager.is_next_block_epoch_start(&head.last_block_hash)?;
         let will_shard_layout_change =
             self.epoch_manager.will_shard_layout_change(&head.last_block_hash)?;
-        let next_block_epoch =
-            self.epoch_manager.get_epoch_id_from_prev_block(&head.last_block_hash)?;
-        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&next_block_epoch)?;
 
         let tries = self.runtime_adapter.get_tries();
         let snapshot_config = tries.state_snapshot_config();
         match snapshot_config.state_snapshot_type {
             // For every epoch, we snapshot if the next block is the state sync "sync_hash" block
             StateSnapshotType::EveryEpoch => {
-                if !ProtocolFeature::CurrentEpochStateSync.enabled(protocol_version) {
-                    if is_epoch_boundary {
-                        // Here we return head.last_block_hash as the prev_hash of the first block of the next epoch
-                        Ok(SnapshotAction::MakeSnapshot(head.last_block_hash))
-                    } else {
-                        Ok(SnapshotAction::None)
-                    }
+                let is_sync_prev = self.state_sync_adapter.is_sync_prev_hash(&head)?;
+                if is_sync_prev {
+                    // Here the head block is the prev block of what the sync hash will be, and the previous
+                    // block is the point in the chain we want to snapshot state for
+                    Ok(SnapshotAction::MakeSnapshot(head.last_block_hash))
                 } else {
-                    let is_sync_prev = self.state_sync_adapter.is_sync_prev_hash(&head)?;
-                    if is_sync_prev {
-                        // Here the head block is the prev block of what the sync hash will be, and the previous
-                        // block is the point in the chain we want to snapshot state for
-                        Ok(SnapshotAction::MakeSnapshot(head.last_block_hash))
-                    } else {
-                        Ok(SnapshotAction::None)
-                    }
+                    Ok(SnapshotAction::None)
                 }
             }
             // For resharding only, we snapshot if next block would be in a different shard layout

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2314,7 +2314,7 @@ impl Chain {
         for (shard_id, cached_shard_update_key, apply_result) in apply_result.into_iter() {
             match apply_result {
                 Ok(result) => {
-                    info!(
+                    debug!(
                         target: "chain", ?prev_block_hash, block_height,
                         ?shard_id, ?cached_shard_update_key,
                         "Caching ShardUpdate result from OptimisticBlock"

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -364,27 +364,13 @@ impl ChainStore {
         // Get header we were syncing into.
         let header = self.get_block_header(&sync_hash)?;
         let prev_hash = *header.prev_hash();
+        let prev_header = self.get_block_header(&prev_hash)?;
         let sync_height = header.height();
-        // TODO(current_epoch_state_sync): fix this when syncing to the current epoch's state
-        // The congestion control added a dependency on the prev block when
-        // applying chunks in a block. This means that we need to keep the
-        // blocks at sync hash, prev hash and prev prev hash. The heigh of that
-        // block is sync_height - 2.
-        let mut gc_height = std::cmp::min(head.height + 1, sync_height - 2);
+        let prev_height = prev_header.height();
 
-        // In case there are missing chunks we need to keep more than just the
-        // sync hash block. The logic below adjusts the gc_height so that every
-        // shard is guaranteed to have at least one new chunk in the blocks
-        // leading to the sync hash block.
-        let prev_block = self.get_block(&prev_hash);
-        if let Ok(prev_block) = prev_block {
-            let min_height_included =
-                prev_block.chunks().iter_deprecated().map(|chunk| chunk.height_included()).min();
-            if let Some(min_height_included) = min_height_included {
-                tracing::debug!(target: "sync", ?min_height_included, ?gc_height, "adjusting gc_height for missing chunks");
-                gc_height = std::cmp::min(gc_height, min_height_included - 1);
-            };
-        }
+        // After state sync we may need a few additional blocks leading up to the sync prev block.
+        // For simplicity we'll GC them and allow state sync to re-download exactly what it needs.
+        let gc_height = std::cmp::min(head.height + 1, prev_height);
 
         // GC all the data from current tail up to `gc_height`. In case tail points to a height where
         // there is no block, we need to make sure that the last block before tail is cleaned.

--- a/chain/chain/src/missing_chunks.rs
+++ b/chain/chain/src/missing_chunks.rs
@@ -324,7 +324,7 @@ impl OptimisticBlockChunksPool {
             return;
         }
 
-        tracing::info!(
+        tracing::debug!(
             target: "chunks",
             ?prev_block_hash,
             optimistic_block_hash = ?block.hash(),

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -447,7 +447,7 @@ impl NightshadeRuntime {
 
         let trie_with_state =
             self.tries.get_trie_with_block_hash_for_shard(shard_uid, *state_root, &prev_hash, true);
-        let (partial_state, nibbles_begin, nibbles_end) = match trie_with_state
+        let (path_boundary_nodes, nibbles_begin, nibbles_end) = match trie_with_state
             .get_state_part_boundaries(part_id)
         {
             Ok(res) => res,
@@ -457,12 +457,17 @@ impl NightshadeRuntime {
             }
         };
 
-        // TODO: Make it impossible for the snapshot data to be deleted while the snapshot is in use.
-        let snapshot_trie = self
-            .tries
-            .get_trie_with_block_hash_for_shard_from_snapshot(shard_uid, *state_root, &prev_hash)
-            .map_err(|err| Error::Other(err.to_string()))?;
-        let state_part = borsh::to_vec(&match snapshot_trie.get_trie_nodes_for_part_with_flat_storage(part_id, partial_state, nibbles_begin, nibbles_end, &trie_with_state) {
+        let trie_nodes = self.tries.get_trie_nodes_for_part_from_snapshot(
+            shard_uid,
+            state_root,
+            &prev_hash,
+            part_id,
+            path_boundary_nodes,
+            nibbles_begin,
+            nibbles_end,
+            trie_with_state,
+        );
+        let state_part = borsh::to_vec(&match trie_nodes {
             Ok(partial_state) => partial_state,
             Err(err) => {
                 error!(target: "runtime", ?err, part_id.idx, part_id.total, %prev_hash, %state_root, %shard_id, "Can't get trie nodes for state part");

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1739,12 +1739,11 @@ impl ClientActorInner {
 
     /// Checks if the node is syncing its State and applies special logic in
     /// that case. A node usually ignores blocks that are too far ahead, but in
-    /// case of a node syncing its state it is looking for 2 specific blocks:
-    /// * The first block of the new epoch
-    /// * The last block of the prev epoch
+    /// case of a node syncing its state it is looking for specific blocks:
     ///
-    /// Additionally if there were missing chunks in the blocks leading to the
-    /// sync hash block we need to store extra blocks.
+    /// - The sync hash block
+    /// - The prev block
+    /// - Extra blocks before the prev block needed for incoming receipts
     ///
     /// Returns whether the node is syncing its state.
     fn maybe_receive_state_sync_blocks(&mut self, block: &Block) -> bool {
@@ -1761,14 +1760,15 @@ impl ClientActorInner {
         let block: MaybeValidated<Block> = (*block).clone().into();
         let block_hash = *block.hash();
 
-        let extra_block_hashes = self.client.chain.get_extra_sync_block_hashes(*header.prev_hash());
-        tracing::trace!(target: "sync", ?extra_block_hashes, "maybe_receive_state_sync_blocks: Extra block hashes for state sync");
-
-        // Notice that two blocks are saved differently:
+        // Notice that the blocks are saved differently:
         // * save_orphan() for the sync hash block
         // * save_block() for the prev block and all the extra blocks
-        // TODO why is that the case? Shouldn't the block without a parent block
-        // be the orphan?
+        //
+        // The sync hash block is saved to the orphan pool where it will
+        // wait to be processed after state sync is completed.
+        //
+        // The other blocks do not need to be processed and are saved
+        // directly to storage.
 
         if block_hash == sync_hash {
             // The first block of the new epoch.
@@ -1794,6 +1794,9 @@ impl ClientActorInner {
             }
             return true;
         }
+
+        let extra_block_hashes = self.client.chain.get_extra_sync_block_hashes(&header.prev_hash());
+        tracing::trace!(target: "sync", ?extra_block_hashes, "maybe_receive_state_sync_blocks: Extra block hashes for state sync");
 
         if extra_block_hashes.contains(&block_hash) {
             if let Err(err) = self.client.chain.validate_block(&block) {

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
@@ -465,7 +465,7 @@ impl PartialEncodedStateWitnessTracker {
             if let Some((evicted_key, evicted_entry)) =
                 parts_cache.push(key.clone(), CacheEntry::new(key.shard_id))
             {
-                tracing::warn!(
+                tracing::debug!(
                     target: "client",
                     ?evicted_key,
                     data_parts_present = ?evicted_entry.data_parts_present(),

--- a/chain/client/src/sync/handler.rs
+++ b/chain/client/src/sync/handler.rs
@@ -23,10 +23,10 @@ use std::sync::Arc;
 // A small helper macro to unwrap a result of some state sync operation. If the
 // result is an error this macro will log it and return from the function.
 #[macro_export]
-macro_rules! unwrap_and_report_state_sync_result (($obj: expr) => (match $obj {
+macro_rules! unwrap_and_report_state_sync_result (($obj: ident) => (match $obj {
     Ok(v) => v,
     Err(err) => {
-        tracing::error!(target: "sync", "Sync: Unexpected error: {}", err);
+        tracing::error!(target: "sync", "Sync: Unexpected error: {}: {}", stringify!($obj), err);
         return None;
     }
 }));
@@ -110,7 +110,8 @@ impl SyncHandler {
         );
         unwrap_and_report_state_sync_result!(header_sync_result);
         // Only body / state sync if header height is close to the latest.
-        let header_head = unwrap_and_report_state_sync_result!(chain.header_head());
+        let chain_header_head = chain.header_head();
+        let header_head = unwrap_and_report_state_sync_result!(chain_header_head);
 
         // We should state sync if it's already started or if we have enough
         // headers and blocks. The should_state_sync method may run block sync.
@@ -151,7 +152,7 @@ impl SyncHandler {
         // Waiting for all the sync blocks to be available because they are
         // needed to finalize state sync.
         if !blocks_to_request.is_empty() {
-            tracing::debug!(target: "sync", "waiting for sync blocks");
+            tracing::debug!(target: "sync", ?blocks_to_request, "waiting for sync blocks");
             return Some(SyncHandlerRequest::NeedRequestBlocks(blocks_to_request));
         }
 
@@ -327,7 +328,7 @@ impl SyncHandler {
         let prev_hash = *block_header.prev_hash();
 
         let mut needed_block_hashes = vec![prev_hash, sync_hash];
-        let mut extra_block_hashes = chain.get_extra_sync_block_hashes(prev_hash);
+        let mut extra_block_hashes = chain.get_extra_sync_block_hashes(&prev_hash);
         tracing::trace!(target: "sync", ?needed_block_hashes, ?extra_block_hashes, "request_sync_blocks: block hashes for state sync");
         needed_block_hashes.append(&mut extra_block_hashes);
         let mut blocks_to_request = vec![];

--- a/chain/epoch-manager/src/shard_tracker.rs
+++ b/chain/epoch-manager/src/shard_tracker.rs
@@ -338,7 +338,6 @@ impl ShardTracker {
     pub fn get_state_sync_info(
         &self,
         me: &Option<AccountId>,
-        epoch_id: &EpochId,
         block_hash: &CryptoHash,
         prev_hash: &CryptoHash,
     ) -> Result<Option<StateSyncInfo>, Error> {
@@ -347,11 +346,9 @@ impl ShardTracker {
             Ok(None)
         } else {
             tracing::debug!(target: "chain", "Downloading state for {:?}, I'm {:?}", shards_to_state_sync, me);
-            let protocol_version = self.epoch_manager.get_epoch_protocol_version(epoch_id)?;
             // Note that this block is the first block in an epoch because this function is only called
             // in get_catchup_and_state_sync_infos() when that is the case.
-            let state_sync_info =
-                StateSyncInfo::new(protocol_version, *block_hash, shards_to_state_sync);
+            let state_sync_info = StateSyncInfo::new(*block_hash, shards_to_state_sync);
             Ok(Some(state_sync_info))
         }
     }

--- a/chain/indexer/src/streamer/fetchers.rs
+++ b/chain/indexer/src/streamer/fetchers.rs
@@ -160,7 +160,7 @@ async fn fetch_single_chunk(
 
 /// Fetches all chunks belonging to given block.
 /// Includes transactions and receipts in custom struct (to provide more info).
-pub(crate) async fn fetch_block_chunks(
+pub(crate) async fn fetch_block_new_chunks(
     client: &Addr<near_client::ViewClientActor>,
     block: &views::BlockView,
     shard_tracker: &ShardTracker,
@@ -171,7 +171,7 @@ pub(crate) async fn fetch_block_chunks(
         .iter()
         .filter(|chunk| {
             shard_tracker.cares_about_shard(None, &block.header.prev_hash, chunk.shard_id, false)
-                && chunk.height_included == block.header.height
+                && chunk.is_new_chunk(block.header.height)
         })
         .map(|chunk| fetch_single_chunk(&client, chunk.chunk_hash))
         .collect();

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -200,7 +200,7 @@ pub enum ProtocolFeature {
     /// should no longer be the first block of the epoch, but a couple blocks after that in order
     /// to sync the current epoch's state. This is not strictly a protocol feature, but is included
     /// here to coordinate among nodes
-    CurrentEpochStateSync,
+    _DeprecatedCurrentEpochStateSync,
     /// Relaxed validation of transactions included in a chunk.
     ///
     /// Chunks no longer become entirely invalid in case invalid transactions are included in the
@@ -290,11 +290,8 @@ impl ProtocolFeature {
             | ProtocolFeature::FixChunkProducerStakingThreshold
             | ProtocolFeature::RelaxedChunkValidation
             | ProtocolFeature::RemoveCheckBalance
-            // BandwidthScheduler and CurrentEpochStateSync must be enabled
-            // before ReshardingV3! When releasing this feature please make sure
-            // to schedule separate protocol upgrades for these features.
             | ProtocolFeature::BandwidthScheduler
-            | ProtocolFeature::CurrentEpochStateSync => 74,
+            | ProtocolFeature::_DeprecatedCurrentEpochStateSync => 74,
             ProtocolFeature::SimpleNightshadeV4 => 75,
             ProtocolFeature::SimpleNightshadeV5 => 76,
             ProtocolFeature::GlobalContracts
@@ -333,18 +330,3 @@ pub const PROTOCOL_VERSION: ProtocolVersion =
 /// protocol version is lower than this.
 /// TODO(pugachag): revert back to `- 3` after mainnet is upgraded
 pub const PEER_MIN_ALLOWED_PROTOCOL_VERSION: ProtocolVersion = STABLE_PROTOCOL_VERSION - 4;
-
-#[cfg(test)]
-mod tests {
-    use super::ProtocolFeature;
-
-    #[test]
-    fn test_resharding_dependencies() {
-        let state_sync = ProtocolFeature::CurrentEpochStateSync.protocol_version();
-        let bandwidth_scheduler = ProtocolFeature::BandwidthScheduler.protocol_version();
-        let resharding_v3 = ProtocolFeature::SimpleNightshadeV4.protocol_version();
-
-        assert!(state_sync < resharding_v3);
-        assert!(bandwidth_scheduler < resharding_v3);
-    }
-}

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -831,6 +831,10 @@ impl<'a> Chunks<'a> {
         }
     }
 
+    pub fn min_height_included(&self) -> Option<BlockHeight> {
+        self.iter_raw().map(|chunk| chunk.height_included()).min()
+    }
+
     pub fn block_congestion_info(&self) -> BlockCongestionInfo {
         let mut result = BTreeMap::new();
 

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -102,24 +102,8 @@ pub enum StateSyncInfo {
 }
 
 impl StateSyncInfo {
-    fn new_previous_epoch(epoch_first_block: CryptoHash, shards: Vec<ShardId>) -> Self {
-        Self::V0(StateSyncInfoV0 { sync_hash: epoch_first_block, shards })
-    }
-
-    fn new_current_epoch(epoch_first_block: CryptoHash, shards: Vec<ShardId>) -> Self {
+    pub fn new(epoch_first_block: CryptoHash, shards: Vec<ShardId>) -> Self {
         Self::V1(StateSyncInfoV1 { epoch_first_block, sync_hash: None, shards })
-    }
-
-    pub fn new(
-        protocol_version: ProtocolVersion,
-        epoch_first_block: CryptoHash,
-        shards: Vec<ShardId>,
-    ) -> Self {
-        if ProtocolFeature::CurrentEpochStateSync.enabled(protocol_version) {
-            Self::new_current_epoch(epoch_first_block, shards)
-        } else {
-            Self::new_previous_epoch(epoch_first_block, shards)
-        }
     }
 
     /// Block hash that identifies this state sync struct on disk

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -3,7 +3,7 @@ use super::mem::memtries::MemTries;
 use super::state_snapshot::{StateSnapshot, StateSnapshotConfig};
 use crate::adapter::StoreAdapter;
 use crate::adapter::trie_store::{TrieStoreAdapter, TrieStoreUpdateAdapter};
-use crate::flat::{FlatStorageManager, FlatStorageStatus};
+use crate::flat::FlatStorageManager;
 use crate::trie::config::TrieConfig;
 use crate::trie::mem::loading::load_trie_from_flat_state_and_delta;
 use crate::trie::prefetching_trie_storage::PrefetchingThreadsHandle;
@@ -109,7 +109,11 @@ impl ShardTries {
         skip_all,
         fields(is_view)
     )]
-    fn get_trie_cache_for(&self, shard_uid: ShardUId, is_view: bool) -> Option<TrieCache> {
+    pub(crate) fn get_trie_cache_for(
+        &self,
+        shard_uid: ShardUId,
+        is_view: bool,
+    ) -> Option<TrieCache> {
         self.trie_cache_enabled(shard_uid, is_view).then(|| {
             let caches_to_use = if is_view { &self.0.view_caches } else { &self.0.caches };
             let mut caches = caches_to_use.lock().expect(POISONED_LOCK_ERR);
@@ -172,22 +176,6 @@ impl ShardTries {
 
     pub fn get_trie_for_shard(&self, shard_uid: ShardUId, state_root: StateRoot) -> Trie {
         self.get_trie_for_shard_internal(shard_uid, state_root, false, None)
-    }
-
-    pub fn get_trie_with_block_hash_for_shard_from_snapshot(
-        &self,
-        shard_uid: ShardUId,
-        state_root: StateRoot,
-        block_hash: &CryptoHash,
-    ) -> Result<Trie, StorageError> {
-        let (store, flat_storage_manager) = self.get_state_snapshot(block_hash)?;
-        let cache = self
-            .get_trie_cache_for(shard_uid, true)
-            .expect("trie cache should be enabled for view calls");
-        let storage = Arc::new(TrieCachingStorage::new(store, cache, shard_uid, true, None));
-        let flat_storage_chunk_view = flat_storage_manager.chunk_view(shard_uid, *block_hash);
-
-        Ok(Trie::new(storage, state_root, flat_storage_chunk_view))
     }
 
     pub fn get_trie_with_block_hash_for_shard(
@@ -430,17 +418,6 @@ impl ShardTries {
             );
             None
         }
-    }
-
-    /// Returns the status of the given shard of flat storage in the state snapshot.
-    /// `sync_prev_prev_hash` needs to match the block hash that identifies that snapshot.
-    pub fn get_snapshot_flat_storage_status(
-        &self,
-        sync_prev_prev_hash: CryptoHash,
-        shard_uid: ShardUId,
-    ) -> Result<FlatStorageStatus, StorageError> {
-        let (_store, manager) = self.get_state_snapshot(&sync_prev_prev_hash)?;
-        Ok(manager.get_flat_storage_status(shard_uid))
     }
 
     /// Retains in-memory tries for given shards, i.e. unload tries from memory for shards that are NOT

--- a/core/store/src/trie/state_snapshot.rs
+++ b/core/store/src/trie/state_snapshot.rs
@@ -11,11 +11,18 @@ use near_primitives::errors::EpochError;
 use near_primitives::errors::StorageError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardUId;
+use near_primitives::state::PartialState;
+use near_primitives::state_part::PartId;
 use near_primitives::types::ShardIndex;
+use near_primitives::types::StateRoot;
 use std::error::Error;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::sync::TryLockError;
+
+use super::Trie;
+use super::TrieCachingStorage;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum SnapshotError {
@@ -159,20 +166,61 @@ pub const STATE_SNAPSHOT_COLUMNS: &[DBCol] = &[
 type ShardIndexesAndUIds = Vec<(ShardIndex, ShardUId)>;
 
 impl ShardTries {
-    pub fn get_state_snapshot(
+    /// Returns the status of the given shard of flat storage in the state snapshot.
+    /// `sync_prev_prev_hash` needs to match the block hash that identifies that snapshot.
+    pub fn get_snapshot_flat_storage_status(
         &self,
+        sync_prev_prev_hash: CryptoHash,
+        shard_uid: ShardUId,
+    ) -> Result<FlatStorageStatus, StorageError> {
+        let guard = self.state_snapshot().try_read().map_err(SnapshotError::from)?;
+        let data = guard.as_ref().ok_or(SnapshotError::SnapshotNotFound(sync_prev_prev_hash))?;
+        if &data.prev_block_hash != &sync_prev_prev_hash {
+            Err(SnapshotError::IncorrectSnapshotRequested(
+                sync_prev_prev_hash,
+                data.prev_block_hash,
+            )
+            .into())
+        } else {
+            Ok(data.flat_storage_manager.get_flat_storage_status(shard_uid))
+        }
+    }
+
+    pub fn get_trie_nodes_for_part_from_snapshot(
+        &self,
+        shard_uid: ShardUId,
+        state_root: &StateRoot,
         block_hash: &CryptoHash,
-    ) -> Result<(TrieStoreAdapter, FlatStorageManager), SnapshotError> {
-        // Taking this lock can last up to 10 seconds, if the snapshot happens to be re-created.
-        let guard = self.state_snapshot().try_read()?;
+        part_id: PartId,
+        path_boundary_nodes: PartialState,
+        nibbles_begin: Vec<u8>,
+        nibbles_end: Vec<u8>,
+        state_trie: Trie,
+    ) -> Result<PartialState, StorageError> {
+        let guard = self.state_snapshot().try_read().map_err(SnapshotError::from)?;
         let data = guard.as_ref().ok_or(SnapshotError::SnapshotNotFound(*block_hash))?;
         if &data.prev_block_hash != block_hash {
             return Err(SnapshotError::IncorrectSnapshotRequested(
                 *block_hash,
                 data.prev_block_hash,
-            ));
-        }
-        Ok((data.store.clone(), data.flat_storage_manager.clone()))
+            )
+            .into());
+        };
+        let cache = self
+            .get_trie_cache_for(shard_uid, true)
+            .expect("trie cache should be enabled for view calls");
+        let storage =
+            Arc::new(TrieCachingStorage::new(data.store.clone(), cache, shard_uid, true, None));
+        let flat_storage_chunk_view = data.flat_storage_manager.chunk_view(shard_uid, *block_hash);
+
+        let snapshot_trie = Trie::new(storage, *state_root, flat_storage_chunk_view);
+        snapshot_trie.get_trie_nodes_for_part_with_flat_storage(
+            part_id,
+            path_boundary_nodes,
+            nibbles_begin,
+            nibbles_end,
+            &state_trie,
+        )
     }
 
     /// Makes a snapshot of the current state of the DB, if one is not already available.

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -6,6 +6,7 @@ use crate::contract::ContractStorage;
 use crate::trie::TrieAccess;
 use crate::trie::{KeyLookupMode, TrieChanges};
 use near_primitives::account::AccountContract;
+use near_primitives::action::GlobalContractIdentifier;
 use near_primitives::apply::ApplyChunkReason;
 use near_primitives::hash::{CryptoHash, hash};
 use near_primitives::stateless_validation::contract_distribution::ContractUpdates;
@@ -183,6 +184,8 @@ impl TrieUpdate {
         self.prospective.insert(trie_key.to_vec(), TrieKeyValueUpdate { trie_key, value: None });
     }
 
+    // Deprecated, will be removed when ExcludeExistingCodeFromWitnessForCodeLen is stabilized.
+    // `get_account_contract_code` should be used instead.
     pub fn get_code(
         &self,
         account_id: AccountId,
@@ -190,6 +193,21 @@ impl TrieUpdate {
     ) -> Result<Option<ContractCode>, StorageError> {
         let key = TrieKey::ContractCode { account_id };
         self.get(&key).map(|opt| opt.map(|code| ContractCode::new(code, Some(code_hash))))
+    }
+
+    pub fn get_account_contract_code(
+        &self,
+        account_id: &AccountId,
+        account_contract: &AccountContract,
+    ) -> Result<Option<ContractCode>, StorageError> {
+        let Some(key) = Self::account_contract_code_trie_key(account_id, account_contract) else {
+            return Ok(None);
+        };
+        let code_hash = match account_contract {
+            AccountContract::None | AccountContract::GlobalByAccount(_) => None,
+            AccountContract::Local(hash) | AccountContract::Global(hash) => Some(*hash),
+        };
+        self.get(&key).map(|opt| opt.map(|code| ContractCode::new(code, code_hash)))
     }
 
     /// Returns the size (in num bytes) of the contract code for the given account.
@@ -362,15 +380,9 @@ impl TrieUpdate {
         // Only record the call if trie contains the contract (with the given hash) being called deployed to the given account.
         // This avoids recording contracts that do not exist or are newly-deployed to the account.
         // Note that the check below to see if the contract exists has no side effects (not charging gas or recording trie nodes)
-        let trie_key = match account_contract {
-            AccountContract::None => return Ok(()),
-            AccountContract::Local(_) => TrieKey::ContractCode { account_id },
-            AccountContract::Global(code_hash) => TrieKey::GlobalContractCode {
-                identifier: GlobalContractCodeIdentifier::CodeHash(*code_hash),
-            },
-            AccountContract::GlobalByAccount(account_id) => TrieKey::GlobalContractCode {
-                identifier: GlobalContractCodeIdentifier::AccountId(account_id.clone()),
-            },
+        let Some(trie_key) = Self::account_contract_code_trie_key(&account_id, account_contract)
+        else {
+            return Ok(());
         };
         let contract_ref = self
             .trie
@@ -390,6 +402,49 @@ impl TrieUpdate {
             self.contract_storage.record_call(code_hash);
         }
         Ok(())
+    }
+
+    pub fn get_account_contract_hash(
+        &self,
+        contract: &AccountContract,
+    ) -> Result<CryptoHash, StorageError> {
+        let hash = match contract {
+            AccountContract::None => CryptoHash::default(),
+            AccountContract::Local(code_hash) | AccountContract::Global(code_hash) => *code_hash,
+            AccountContract::GlobalByAccount(account_id) => {
+                let identifier = GlobalContractIdentifier::AccountId(account_id.clone());
+                let key = TrieKey::GlobalContractCode { identifier: identifier.into() };
+                let value_ref =
+                    self.get_ref(&key, KeyLookupMode::MemOrFlatOrTrie)?.ok_or_else(|| {
+                        let TrieKey::GlobalContractCode { identifier } = key else {
+                            unreachable!()
+                        };
+                        StorageError::StorageInconsistentState(format!(
+                            "Global contract identifier not found {:?}",
+                            identifier
+                        ))
+                    })?;
+                value_ref.value_hash()
+            }
+        };
+        Ok(hash)
+    }
+
+    fn account_contract_code_trie_key(
+        account_id: &AccountId,
+        account_contract: &AccountContract,
+    ) -> Option<TrieKey> {
+        let trie_key = match account_contract {
+            AccountContract::None => return None,
+            AccountContract::Local(_) => TrieKey::ContractCode { account_id: account_id.clone() },
+            AccountContract::Global(code_hash) => TrieKey::GlobalContractCode {
+                identifier: GlobalContractCodeIdentifier::CodeHash(*code_hash),
+            },
+            AccountContract::GlobalByAccount(account_id) => TrieKey::GlobalContractCode {
+                identifier: GlobalContractCodeIdentifier::AccountId(account_id.clone()),
+            },
+        };
+        Some(trie_key)
     }
 }
 

--- a/integration-tests/src/tests/client/sync_state_nodes.rs
+++ b/integration-tests/src/tests/client/sync_state_nodes.rs
@@ -20,7 +20,6 @@ use near_primitives::state_sync::StatePartKey;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{BlockId, BlockReference, EpochId, EpochReference, ShardId};
 use near_primitives::utils::MaybeValidated;
-use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_store::DBCol;
 use near_store::adapter::StoreUpdateAdapter;
 use nearcore::{load_test_config, start_with_config};
@@ -476,31 +475,16 @@ fn ultra_slow_test_dump_epoch_missing_chunk_in_last_block() {
             let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
 
             let next_epoch_start = epoch_length + 1;
-            let protocol_version = env.clients[0]
-                .epoch_manager
-                .get_epoch_protocol_version(&EpochId::default())
-                .unwrap();
             // Note that the height to skip here refers to the height at which not to produce chunks for the next block, so really
             // one before the block height that will have no chunks. The sync_height is the height of the sync_hash block.
-            let (start_skipping_chunks, stop_skipping_chunks, sync_height) =
-                if ProtocolFeature::CurrentEpochStateSync.enabled(protocol_version) {
-                    // At the beginning of the epoch, produce two blocks with chunks and then start skipping chunks.
-                    // The very first block in the epoch does not count towards the number of new chunks we tally when computing
-                    // the sync hash. So after those two blocks, the tally is 1.
-                    let start_skipping_chunks = next_epoch_start + 1;
-                    // Then we will skip `num_chunks_missing` chunks.
-                    let stop_skipping_chunks = start_skipping_chunks + num_chunks_missing;
-                    // Then after one more with new chunks, the next one after that will be the sync block.
-                    let sync_height = stop_skipping_chunks + 2;
-                    (start_skipping_chunks, stop_skipping_chunks, sync_height)
-                } else {
-                    // here the sync hash is the first hash of the epoch
-                    let sync_height = next_epoch_start;
-                    // skip chunks before the epoch start, but not including the one right before the epochs start.
-                    let start_skipping_chunks = sync_height - num_chunks_missing - 1;
-                    let stop_skipping_chunks = sync_height - 1;
-                    (start_skipping_chunks, stop_skipping_chunks, sync_height)
-                };
+            // At the beginning of the epoch, produce two blocks with chunks and then start skipping chunks.
+            // The very first block in the epoch does not count towards the number of new chunks we tally when computing
+            // the sync hash. So after those two blocks, the tally is 1.
+            let start_skipping_chunks = next_epoch_start + 1;
+            // Then we will skip `num_chunks_missing` chunks.
+            let stop_skipping_chunks = start_skipping_chunks + num_chunks_missing;
+            // Then after one more with new chunks, the next one after that will be the sync block.
+            let sync_height = stop_skipping_chunks + 2;
 
             assert!(sync_height < 2 * epoch_length + 1);
 
@@ -748,13 +732,9 @@ fn slow_test_state_sync_headers() {
                 };
                 tracing::info!(epoch_start_height, "got epoch_start_height");
 
-                let sync_height =
-                    if ProtocolFeature::CurrentEpochStateSync.enabled(PROTOCOL_VERSION) {
-                        // here since there's only one block/chunk producer, we assume that no blocks will be missing chunks.
-                        epoch_start_height + 3
-                    } else {
-                        epoch_start_height
-                    };
+                // here since there's only one block/chunk producer, we assume that no blocks will be missing chunks.
+                let sync_height = epoch_start_height + 3;
+
                 let block_id = BlockReference::BlockId(BlockId::Height(sync_height));
                 let block_view = view_client1.send(GetBlock(block_id).with_span_context()).await;
                 let Ok(Ok(block_view)) = block_view else {
@@ -933,13 +913,9 @@ fn slow_test_state_sync_headers_no_tracked_shards() {
                     return ControlFlow::Continue(());
                 }
 
-                let sync_height =
-                    if ProtocolFeature::CurrentEpochStateSync.enabled(PROTOCOL_VERSION) {
-                        // here since there's only one block/chunk producer, we assume that no blocks will be missing chunks.
-                        epoch_start_height + 3
-                    } else {
-                        epoch_start_height
-                    };
+                // here since there's only one block/chunk producer, we assume that no blocks will be missing chunks.
+                let sync_height = epoch_start_height + 3;
+
                 let block_id = BlockReference::BlockId(BlockId::Height(sync_height));
                 let block_view = view_client2.send(GetBlock(block_id).with_span_context()).await;
                 let Ok(Ok(block_view)) = block_view else {

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -27,8 +27,7 @@ use metrics::ApplyMetrics;
 pub use near_crypto;
 use near_parameters::{ActionCosts, RuntimeConfig};
 pub use near_primitives;
-use near_primitives::account::{AccessKey, Account, AccountContract};
-use near_primitives::action::GlobalContractIdentifier;
+use near_primitives::account::{AccessKey, Account};
 use near_primitives::bandwidth_scheduler::{BandwidthRequests, BlockBandwidthRequests};
 use near_primitives::chunk_apply_stats::{BalanceStats, ChunkApplyStatsV0};
 use near_primitives::congestion_info::{BlockCongestionInfo, CongestionInfo};
@@ -65,8 +64,8 @@ use near_primitives_core::version::ProtocolFeature;
 use near_store::trie::receipts_column_helper::DelayedReceiptQueue;
 use near_store::trie::update::TrieUpdateResult;
 use near_store::{
-    KeyLookupMode, PartialStorage, StorageError, Trie, TrieAccess, TrieChanges, TrieUpdate, get,
-    get_account, get_postponed_receipt, get_promise_yield_receipt, get_pure, get_received_data,
+    PartialStorage, StorageError, Trie, TrieAccess, TrieChanges, TrieUpdate, get, get_account,
+    get_postponed_receipt, get_promise_yield_receipt, get_pure, get_received_data,
     has_received_data, remove_account, remove_postponed_receipt, remove_promise_yield_receipt, set,
     set_access_key, set_account, set_postponed_receipt, set_promise_yield_receipt,
     set_received_data,
@@ -538,31 +537,8 @@ impl Runtime {
             Action::FunctionCall(function_call) => {
                 let account = account.as_mut().expect(EXPECT_ACCOUNT_EXISTS);
                 let account_contract = account.contract();
-
-                let code_hash = match account_contract.as_ref() {
-                    AccountContract::None => CryptoHash::default(),
-                    AccountContract::Local(code_hash) | AccountContract::Global(code_hash) => {
-                        *code_hash
-                    }
-                    AccountContract::GlobalByAccount(account_id) => {
-                        let identifier = GlobalContractIdentifier::AccountId(account_id.clone());
-                        let key = TrieKey::GlobalContractCode { identifier: identifier.into() };
-                        let value_ref = state_update
-                            .get_ref(&key, KeyLookupMode::MemOrFlatOrTrie)?
-                            .ok_or_else(|| {
-                                let TrieKey::GlobalContractCode { identifier } = key else {
-                                    unreachable!()
-                                };
-                                RuntimeError::StorageError(StorageError::StorageInconsistentState(
-                                    format!(
-                                        "Global contract identifier not found {:?}",
-                                        identifier
-                                    ),
-                                ))
-                            })?;
-                        value_ref.value_hash()
-                    }
-                };
+                let code_hash =
+                    state_update.get_account_contract_hash(account_contract.as_ref())?;
                 let contract =
                     preparation_pipeline.get_contract(receipt, code_hash, action_index, None);
                 let is_last_action = action_index + 1 == actions.len();

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -92,11 +92,11 @@ impl TrieViewer {
         account_id: &AccountId,
     ) -> Result<ContractCode, errors::ViewContractCodeError> {
         let account = self.view_account(state_update, account_id)?;
-        state_update
-            .get_code(account_id.clone(), account.local_contract_hash().unwrap_or_default())?
-            .ok_or_else(|| errors::ViewContractCodeError::NoContractCode {
+        state_update.get_account_contract_code(account_id, account.contract().as_ref())?.ok_or_else(
+            || errors::ViewContractCodeError::NoContractCode {
                 contract_account_id: account_id.clone(),
-            })
+            },
+        )
     }
 
     pub fn view_access_key(
@@ -258,12 +258,8 @@ impl TrieViewer {
             state_update.contract_storage(),
         );
         let view_config = Some(ViewConfig { max_gas_burnt: self.max_gas_burnt_view });
-        let contract = pipeline.get_contract(
-            &receipt,
-            account.local_contract_hash().unwrap_or_default(),
-            0,
-            view_config.clone(),
-        );
+        let code_hash = state_update.get_account_contract_hash(account.contract().as_ref())?;
+        let contract = pipeline.get_contract(&receipt, code_hash, 0, view_config.clone());
 
         let mut runtime_ext = RuntimeExt::new(
             &mut state_update,

--- a/tools/state-parts-dump-check/src/cli.rs
+++ b/tools/state-parts-dump-check/src/cli.rs
@@ -15,8 +15,7 @@ use near_primitives::state_sync::ShardStateSyncResponseHeader;
 use near_primitives::types::{
     BlockHeight, BlockId, BlockReference, EpochId, EpochReference, Finality, ShardId, StateRoot,
 };
-use near_primitives::version::ProtocolFeature;
-use near_primitives::views::{BlockView, ChunkHeaderView};
+use near_primitives::views::ChunkHeaderView;
 use near_store::Trie;
 use nearcore::state_sync::extract_part_id_from_part_file_name;
 use std::collections::{HashMap, HashSet};
@@ -869,15 +868,6 @@ fn chunk_state_roots(chunks: &[ChunkHeaderView]) -> HashMap<ShardId, CryptoHash>
     chunks.iter().map(|chunk| (chunk.shard_id, chunk.prev_state_root)).collect()
 }
 
-async fn get_prev_epoch_state_roots(
-    rpc_client: &JsonRpcClient,
-    epoch_id: CryptoHash,
-) -> anyhow::Result<HashMap<ShardId, CryptoHash>> {
-    let prev_epoch_last_block_response =
-        get_previous_epoch_last_block_response(rpc_client, epoch_id).await?;
-    Ok(chunk_state_roots(&prev_epoch_last_block_response.chunks))
-}
-
 async fn get_current_epoch_state_roots(
     rpc_client: &JsonRpcClient,
     epoch_id: CryptoHash,
@@ -957,22 +947,15 @@ async fn get_processing_epoch_information(
 
     let latest_epoch_height = latest_epoch_response.epoch_height;
 
-    let state_roots = if ProtocolFeature::CurrentEpochStateSync
-        .enabled(protocol_config.config_view.protocol_version)
-    {
-        let Some(roots) = get_current_epoch_state_roots(
-            rpc_client,
-            latest_epoch_id,
-            latest_block_response.header.height,
-            &protocol_config.config_view.shard_layout,
-        )
-        .await?
-        else {
-            return Ok(None);
-        };
-        roots
-    } else {
-        get_prev_epoch_state_roots(rpc_client, latest_epoch_id).await?
+    let Some(state_roots) = get_current_epoch_state_roots(
+        rpc_client,
+        latest_epoch_id,
+        latest_block_response.header.height,
+        &protocol_config.config_view.shard_layout,
+    )
+    .await?
+    else {
+        return Ok(None);
     };
 
     Ok(Some(DumpCheckIterInfo {
@@ -981,25 +964,4 @@ async fn get_processing_epoch_information(
         shard_layout: protocol_config.config_view.shard_layout,
         state_roots,
     }))
-}
-
-async fn get_previous_epoch_last_block_response(
-    rpc_client: &JsonRpcClient,
-    current_epoch_id: CryptoHash,
-) -> anyhow::Result<BlockView> {
-    let current_epoch_response = rpc_client
-        .validators(Some(EpochReference::EpochId(EpochId(current_epoch_id))))
-        .await
-        .or_else(|_| Err(anyhow!("validators_by_epoch_id for current_epoch_id failed")))?;
-    let current_epoch_first_block_height = current_epoch_response.epoch_start_height;
-    let current_epoch_first_block_response = rpc_client
-        .block_by_id(BlockId::Height(current_epoch_first_block_height))
-        .await
-        .or_else(|_| Err(anyhow!("block_by_id failed for current_epoch_first_block_height")))?;
-    let prev_epoch_last_block_hash = current_epoch_first_block_response.header.prev_hash;
-    let prev_epoch_last_block_response = rpc_client
-        .block_by_id(BlockId::Hash(prev_epoch_last_block_hash))
-        .await
-        .or_else(|_| Err(anyhow!("block_by_id failed for prev_epoch_last_block_hash")))?;
-    Ok(prev_epoch_last_block_response)
 }


### PR DESCRIPTION
Changes needed for the 2.6.0-rc.2 release. Includes cherry-picks discussed on zulip and removal of some spammy logs.

* af300c15acc779c6dd1cb58d983ac2dc9d74ddd1 is cherry-picked from https://github.com/near/nearcore/pull/13410, I couldn't directly cherry-pick #13258 because of merge conflicts.
* 93ec1c6f5d303f0d5449c4519c976b648bbec5a2 is cherry-picked from https://github.com/near/nearcore/pull/13411