### PR TITLE
fix(debug_ui) - fix shard id in latest blocks

### DIFF
--- a/tools/debug-ui/src/LatestBlocksView.tsx
+++ b/tools/debug-ui/src/LatestBlocksView.tsx
@@ -227,8 +227,7 @@ const BlocksTable = ({ rows, knownProducers, expandAll, hideMissingHeights }: Bl
         tableRows.push(
             <tr
                 key={block.block_hash}
-                className={`block-row ${row.block.is_on_canonical_chain ? '' : 'not-on-canonical-chain'
-                    }`}>
+                className={`block-row ${row.block.is_on_canonical_chain ? '' : 'not-on-canonical-chain'}`}>
                 <td className="graph-node-cell">
                     <div
                         id={`graph-node-${i}`}


### PR DESCRIPTION
Disclaimer: I have absolutely zero knowledge about typescript. 

Fixing the bad ui for showing shard ids in debug ui. 

Before:
![Screenshot 2025-04-25 at 14 37 16](https://github.com/user-attachments/assets/3420aad8-b7c0-4c71-9724-477368269519)

After:
![Screenshot 2025-04-25 at 14 36 35](https://github.com/user-attachments/assets/f089227a-5bc3-4f69-8e27-75314d505afe)

Resharding:
![Screenshot 2025-04-25 at 17 38 19](https://github.com/user-attachments/assets/e1d38805-4680-4561-b5a6-f9c53c2f868e)

