### PR TITLE
Revert "cleanup: deprecate bandwidth scheduler feature (#13402)"

### DIFF
--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -95,11 +95,15 @@ impl<'a> ChainUpdate<'a> {
                     ApplyChunkResult::compute_outcomes_proof(&apply_result.outcomes);
                 let shard_id = shard_uid.shard_id();
 
+                let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(prev_hash)?;
+                let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
+
                 // Save state root after applying transactions.
                 self.chain_store_update.save_chunk_extra(
                     block_hash,
                     &shard_uid,
                     ChunkExtra::new(
+                        protocol_version,
                         &apply_result.new_root,
                         outcome_root,
                         apply_result.validator_proposals,
@@ -455,6 +459,8 @@ impl<'a> ChainUpdate<'a> {
         let chunk_header = chunk.cloned_header();
         let gas_limit = chunk_header.gas_limit();
         let block = self.chain_store_update.get_block(block_header.hash())?;
+        let epoch_id = self.epoch_manager.get_epoch_id(block_header.hash())?;
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
         let transactions = chunk.to_transactions().to_vec();
         let transaction_validity = if let Some(prev_block_header) = prev_block_header {
             self.chain_store_update
@@ -507,6 +513,7 @@ impl<'a> ChainUpdate<'a> {
         self.chain_store_update.save_trie_changes(*block_header.hash(), apply_result.trie_changes);
 
         let chunk_extra = ChunkExtra::new(
+            protocol_version,
             &apply_result.new_root,
             outcome_root,
             apply_result.validator_proposals,

--- a/chain/chain/src/genesis.rs
+++ b/chain/chain/src/genesis.rs
@@ -163,9 +163,11 @@ impl Chain {
     fn create_genesis_chunk_extra(
         state_root: &StateRoot,
         gas_limit: Gas,
+        genesis_protocol_version: ProtocolVersion,
         congestion_info: Option<CongestionInfo>,
     ) -> ChunkExtra {
         ChunkExtra::new(
+            genesis_protocol_version,
             state_root,
             CryptoHash::default(),
             vec![],
@@ -173,7 +175,7 @@ impl Chain {
             gas_limit,
             0,
             congestion_info,
-            BandwidthRequests::empty(),
+            BandwidthRequests::default_for_protocol_version(genesis_protocol_version),
         )
     }
 
@@ -192,6 +194,7 @@ impl Chain {
         &self,
         shard_layout: &ShardLayout,
         shard_id: ShardId,
+        genesis_protocol_version: ProtocolVersion,
         congestion_info: Option<CongestionInfo>,
     ) -> Result<ChunkExtra, Error> {
         let shard_index = shard_layout.get_shard_index(shard_id)?;
@@ -211,7 +214,12 @@ impl Chain {
                 ))
             })?
             .gas_limit();
-        Ok(Self::create_genesis_chunk_extra(&state_root, gas_limit, congestion_info))
+        Ok(Self::create_genesis_chunk_extra(
+            &state_root,
+            gas_limit,
+            genesis_protocol_version,
+            congestion_info,
+        ))
     }
 
     /// Saves the `[ChunkExtra]`s for all shards in the genesis block.
@@ -235,6 +243,7 @@ impl Chain {
                 Self::create_genesis_chunk_extra(
                     state_root,
                     chunk_header.gas_limit(),
+                    genesis_protocol_version,
                     congestion_info,
                 )
             };

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -27,7 +27,7 @@ use near_primitives::stateless_validation::state_witness::{
     ChunkStateWitness, EncodedChunkStateWitness,
 };
 use near_primitives::types::chunk_extra::ChunkExtra;
-use near_primitives::types::{AccountId, ShardId, ShardIndex};
+use near_primitives::types::{AccountId, ProtocolVersion, ShardId, ShardIndex};
 use near_primitives::utils::compression::CompressedData;
 use near_store::flat::BlockInfo;
 use near_store::trie::ops::resharding::RetainMode;
@@ -359,8 +359,13 @@ pub fn pre_validate_chunk_state_witness(
             .block_congestion_info()
             .get(&last_chunk_shard_id)
             .map(|info| info.congestion_info);
-        let chunk_extra =
-            chain.genesis_chunk_extra(&shard_layout, last_chunk_shard_id, congestion_info)?;
+        let genesis_protocol_version = epoch_manager.get_epoch_protocol_version(&epoch_id)?;
+        let chunk_extra = chain.genesis_chunk_extra(
+            &shard_layout,
+            last_chunk_shard_id,
+            genesis_protocol_version,
+            congestion_info,
+        )?;
         MainTransition::Genesis {
             chunk_extra,
             block_hash: *last_chunk_block.hash(),
@@ -546,7 +551,8 @@ pub fn validate_chunk_state_witness(
                     runtime_adapter,
                 )?;
                 let outgoing_receipts = std::mem::take(&mut main_apply_result.outgoing_receipts);
-                let chunk_extra = apply_result_to_chunk_extra(main_apply_result, &chunk_header);
+                let chunk_extra =
+                    apply_result_to_chunk_extra(protocol_version, main_apply_result, &chunk_header);
 
                 (chunk_extra, outgoing_receipts)
             }
@@ -693,11 +699,13 @@ pub fn validate_chunk_state_witness(
 }
 
 pub fn apply_result_to_chunk_extra(
+    protocol_version: ProtocolVersion,
     apply_result: ApplyChunkResult,
     chunk: &ShardChunkHeader,
 ) -> ChunkExtra {
     let (outcome_root, _) = ApplyChunkResult::compute_outcomes_proof(&apply_result.outcomes);
     ChunkExtra::new(
+        protocol_version,
         &apply_result.new_root,
         outcome_root,
         apply_result.validator_proposals,

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -1199,7 +1199,7 @@ impl RuntimeAdapter for KeyValueRuntime {
             processed_yield_timeouts: vec![],
             applied_receipts_hash: hash(&borsh::to_vec(receipts).unwrap()),
             congestion_info: Some(Self::get_congestion_info()),
-            bandwidth_requests: BandwidthRequests::empty(),
+            bandwidth_requests: BandwidthRequests::default_for_protocol_version(PROTOCOL_VERSION),
             bandwidth_scheduler_state_hash: CryptoHash::default(),
             contract_updates: Default::default(),
             stats: ChunkApplyStatsV0::dummy(),

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -107,7 +107,8 @@ pub struct ApplyChunkResult {
     /// version and Some otherwise.
     pub congestion_info: Option<CongestionInfo>,
     /// Requests for bandwidth to send receipts to other shards.
-    pub bandwidth_requests: BandwidthRequests,
+    /// Will be None for protocol versions that don't have the BandwidthScheduler feature enabled.
+    pub bandwidth_requests: Option<BandwidthRequests>,
     /// Used only for a sanity check.
     pub bandwidth_scheduler_state_hash: CryptoHash,
     /// Contracts accessed and deployed while applying the chunk.

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -132,6 +132,7 @@ use near_primitives::types::{
 use near_primitives::unwrap_or_return;
 use near_primitives::utils::MaybeValidated;
 use near_primitives::validator_signer::ValidatorSigner;
+use near_primitives::version::ProtocolVersion;
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::chunk_store::ChunkStoreAdapter;
 use near_store::{DBCol, HEAD_KEY, HEADER_HEAD_KEY, Store};
@@ -2010,9 +2011,10 @@ impl ShardsManagerActor {
         prev_outgoing_receipts_root: CryptoHash,
         tx_root: CryptoHash,
         congestion_info: CongestionInfo,
-        bandwidth_requests: BandwidthRequests,
+        bandwidth_requests: Option<BandwidthRequests>,
         signer: &ValidatorSigner,
         rs: &ReedSolomon,
+        protocol_version: ProtocolVersion,
     ) -> (EncodedShardChunk, Vec<MerklePath>, Vec<Receipt>) {
         EncodedShardChunk::new(
             prev_block_hash,
@@ -2032,6 +2034,7 @@ impl ShardsManagerActor {
             congestion_info,
             bandwidth_requests,
             signer,
+            protocol_version,
         )
     }
 

--- a/chain/chunks/src/test_utils.rs
+++ b/chain/chunks/src/test_utils.rs
@@ -19,6 +19,7 @@ use near_primitives::stateless_validation::ChunkProductionKey;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::MerkleHash;
 use near_primitives::types::{AccountId, EpochId};
+use near_primitives::version::PROTOCOL_VERSION;
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::chunk_store::ChunkStoreAdapter;
 use near_store::set_genesis_height;
@@ -166,9 +167,10 @@ impl ChunkTestFixture {
             receipts_root,
             MerkleHash::default(),
             Default::default(),
-            BandwidthRequests::empty(),
+            BandwidthRequests::default_for_protocol_version(PROTOCOL_VERSION),
             &signer,
             &rs,
+            PROTOCOL_VERSION,
         );
 
         let all_part_ords: Vec<u64> =

--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -13,7 +13,6 @@ use near_client_primitives::debug::ChunkProduction;
 use near_client_primitives::types::Error;
 use near_epoch_manager::EpochManagerAdapter;
 use near_epoch_manager::shard_assignment::shard_id_to_uid;
-use near_primitives::bandwidth_scheduler::BandwidthRequests;
 use near_primitives::epoch_info::RngSeed;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{MerklePath, merklize};
@@ -280,16 +279,12 @@ impl ChunkProducer {
         )?;
 
         let outgoing_receipts_root = self.calculate_receipts_root(epoch_id, &outgoing_receipts)?;
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(epoch_id)?;
         let gas_used = chunk_extra.gas_used();
         #[cfg(feature = "test_features")]
         let gas_used = if self.produce_invalid_chunks { gas_used + 1 } else { gas_used };
 
         let congestion_info = chunk_extra.congestion_info();
-        let bandwidth_requests = chunk_extra.bandwidth_requests();
-        debug_assert!(
-            bandwidth_requests.is_some(),
-            "Expected bandwidth_request to be Some after BandwidthScheduler feature enabled"
-        );
         let (encoded_chunk, merkle_paths, outgoing_receipts) =
             ShardsManagerActor::create_encoded_shard_chunk(
                 prev_block_hash,
@@ -306,9 +301,10 @@ impl ChunkProducer {
                 outgoing_receipts_root,
                 tx_root,
                 congestion_info,
-                bandwidth_requests.cloned().unwrap_or_else(BandwidthRequests::empty),
+                chunk_extra.bandwidth_requests().cloned(),
                 &*validator_signer,
                 &mut self.reed_solomon_encoder,
+                protocol_version,
             );
 
         span.record("chunk_hash", tracing::field::debug(encoded_chunk.chunk_hash()));

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -13,7 +13,6 @@ use near_chain::test_utils::{wait_for_all_blocks_in_processing, wait_for_block_i
 use near_chain::{Chain, ChainStoreAccess, Provenance};
 use near_client_primitives::types::Error;
 use near_network::types::HighestHeightPeerInfo;
-use near_primitives::bandwidth_scheduler::BandwidthRequests;
 use near_primitives::block::Block;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{PartialMerkleTree, merklize};
@@ -219,8 +218,9 @@ pub fn create_chunk(
             decoded_chunk.prev_outgoing_receipts().to_vec(),
             header.prev_outgoing_receipts_root(),
             header.congestion_info(),
-            header.bandwidth_requests().cloned().unwrap_or_else(BandwidthRequests::empty),
+            header.bandwidth_requests().cloned(),
             &*signer,
+            PROTOCOL_VERSION,
         );
         swap(&mut encoded_chunk, &mut new_encoded_chunk);
         swap(&mut merkle_paths, &mut new_merkle_paths);

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -2832,6 +2832,7 @@ fn test_block_and_chunk_producer_not_kicked_out_for_low_endorsements() {
 
 fn test_chunk_header(h: &[CryptoHash], signer: &ValidatorSigner) -> ShardChunkHeader {
     ShardChunkHeader::V3(ShardChunkHeaderV3::new(
+        PROTOCOL_VERSION,
         h[0],
         h[2],
         h[2],
@@ -2846,7 +2847,7 @@ fn test_chunk_header(h: &[CryptoHash], signer: &ValidatorSigner) -> ShardChunkHe
         h[2],
         vec![],
         Default::default(),
-        BandwidthRequests::empty(),
+        BandwidthRequests::default_for_protocol_version(PROTOCOL_VERSION),
         signer,
     ))
 }

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -264,8 +264,7 @@ pub enum ProtocolFeature {
     #[deprecated]
     _DeprecatedExcludeContractCodeFromStateWitness,
     /// A scheduler which limits bandwidth for sending receipts between shards.
-    #[deprecated]
-    _DeprecatedBandwidthScheduler,
+    BandwidthScheduler,
     /// Indicates that the "sync_hash" used to identify the point in the chain to sync state to
     /// should no longer be the first block of the epoch, but a couple blocks after that in order
     /// to sync the current epoch's state. This is not strictly a protocol feature, but is included
@@ -388,7 +387,7 @@ impl ProtocolFeature {
             | ProtocolFeature::_DeprecatedFixChunkProducerStakingThreshold
             | ProtocolFeature::_DeprecatedRelaxedChunkValidation
             | ProtocolFeature::_DeprecatedRemoveCheckBalance
-            | ProtocolFeature::_DeprecatedBandwidthScheduler
+            | ProtocolFeature::BandwidthScheduler
             | ProtocolFeature::_DeprecatedCurrentEpochStateSync => 74,
             ProtocolFeature::SimpleNightshadeV4 => 75,
             ProtocolFeature::SimpleNightshadeV5 => 76,

--- a/core/primitives/src/bandwidth_scheduler.rs
+++ b/core/primitives/src/bandwidth_scheduler.rs
@@ -6,7 +6,8 @@ use bitvec::slice::BitSlice;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_parameters::RuntimeConfig;
 use near_primitives_core::hash::CryptoHash;
-use near_primitives_core::types::ShardId;
+use near_primitives_core::types::{ProtocolVersion, ShardId};
+use near_primitives_core::version::ProtocolFeature;
 use near_schema_checker_lib::ProtocolSchema;
 
 /// Represents size of receipts, in the context of cross-shard bandwidth, in bytes.
@@ -33,6 +34,16 @@ pub enum BandwidthRequests {
 impl BandwidthRequests {
     pub fn empty() -> BandwidthRequests {
         BandwidthRequests::V1(BandwidthRequestsV1 { requests: Vec::new() })
+    }
+
+    pub fn default_for_protocol_version(
+        protocol_version: ProtocolVersion,
+    ) -> Option<BandwidthRequests> {
+        if ProtocolFeature::BandwidthScheduler.enabled(protocol_version) {
+            Some(BandwidthRequests::empty())
+        } else {
+            None
+        }
     }
 }
 

--- a/core/primitives/src/genesis/chunk.rs
+++ b/core/primitives/src/genesis/chunk.rs
@@ -43,6 +43,7 @@ pub fn genesis_chunks(
 
         let encoded_chunk = genesis_chunk(
             &rs,
+            genesis_protocol_version,
             genesis_height,
             initial_gas_limit,
             shard_id,
@@ -61,6 +62,7 @@ pub fn genesis_chunks(
 // fields set to defaults. The remaining fields are set to the provided values.
 fn genesis_chunk(
     rs: &ShardChunkReedSolomon,
+    genesis_protocol_version: u32,
     genesis_height: u64,
     initial_gas_limit: u64,
     shard_id: ShardId,
@@ -83,8 +85,9 @@ fn genesis_chunk(
         vec![],
         CryptoHash::default(),
         congestion_info,
-        BandwidthRequests::empty(),
+        BandwidthRequests::default_for_protocol_version(genesis_protocol_version),
         &EmptyValidatorSigner::default().into(),
+        genesis_protocol_version,
     );
     encoded_chunk
 }

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -13,6 +13,7 @@ use crate::version::ProtocolVersion;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_crypto::Signature;
 use near_fmt::AbbrBytes;
+use near_primitives_core::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_schema_checker_lib::ProtocolSchema;
 use shard_chunk_header_inner::ShardChunkHeaderInnerV4;
 use std::cmp::Ordering;
@@ -234,6 +235,7 @@ impl ShardChunkHeaderV3 {
     }
 
     pub fn new(
+        protocol_version: ProtocolVersion,
         prev_block_hash: CryptoHash,
         prev_state_root: StateRoot,
         prev_outcome_root: CryptoHash,
@@ -248,26 +250,48 @@ impl ShardChunkHeaderV3 {
         tx_root: CryptoHash,
         prev_validator_proposals: Vec<ValidatorStake>,
         congestion_info: CongestionInfo,
-        bandwidth_requests: BandwidthRequests,
+        bandwidth_requests: Option<BandwidthRequests>,
         signer: &ValidatorSigner,
     ) -> Self {
-        let inner = ShardChunkHeaderInner::V4(ShardChunkHeaderInnerV4 {
-            prev_block_hash,
-            prev_state_root,
-            prev_outcome_root,
-            encoded_merkle_root,
-            encoded_length,
-            height_created: height,
-            shard_id,
-            prev_gas_used,
-            gas_limit,
-            prev_balance_burnt,
-            prev_outgoing_receipts_root,
-            tx_root,
-            prev_validator_proposals,
-            congestion_info,
-            bandwidth_requests,
-        });
+        let inner = if let Some(bandwidth_requests) = bandwidth_requests {
+            // `bandwidth_requests` can only be `Some` when bandwidth scheduler is enabled.
+            assert!(ProtocolFeature::BandwidthScheduler.enabled(protocol_version));
+
+            ShardChunkHeaderInner::V4(ShardChunkHeaderInnerV4 {
+                prev_block_hash,
+                prev_state_root,
+                prev_outcome_root,
+                encoded_merkle_root,
+                encoded_length,
+                height_created: height,
+                shard_id,
+                prev_gas_used,
+                gas_limit,
+                prev_balance_burnt,
+                prev_outgoing_receipts_root,
+                tx_root,
+                prev_validator_proposals,
+                congestion_info,
+                bandwidth_requests,
+            })
+        } else {
+            ShardChunkHeaderInner::V3(ShardChunkHeaderInnerV3 {
+                prev_block_hash,
+                prev_state_root,
+                prev_outcome_root,
+                encoded_merkle_root,
+                encoded_length,
+                height_created: height,
+                shard_id,
+                prev_gas_used,
+                gas_limit,
+                prev_balance_burnt,
+                prev_outgoing_receipts_root,
+                tx_root,
+                prev_validator_proposals,
+                congestion_info,
+            })
+        };
         Self::from_inner(inner, signer)
     }
 
@@ -290,6 +314,7 @@ impl ShardChunkHeader {
         let congestion_info = CongestionInfo::default();
 
         ShardChunkHeader::V3(ShardChunkHeaderV3::new(
+            PROTOCOL_VERSION,
             prev_block_hash,
             Default::default(),
             Default::default(),
@@ -304,7 +329,7 @@ impl ShardChunkHeader {
             Default::default(),
             Default::default(),
             congestion_info,
-            BandwidthRequests::empty(),
+            BandwidthRequests::default_for_protocol_version(PROTOCOL_VERSION),
             &EmptyValidatorSigner::default().into(),
         ))
     }
@@ -517,14 +542,23 @@ impl ShardChunkHeader {
         &self,
         version: ProtocolVersion,
     ) -> Result<(), BadHeaderForProtocolVersionError> {
+        const BANDWIDTH_SCHEDULER_VERSION: ProtocolVersion =
+            ProtocolFeature::BandwidthScheduler.protocol_version();
+
         let is_valid = match &self {
             ShardChunkHeader::V1(_) => false,
             ShardChunkHeader::V2(_) => false,
             ShardChunkHeader::V3(header) => match header.inner {
                 ShardChunkHeaderInner::V1(_) => false,
-                ShardChunkHeaderInner::V2(_) => false,
-                ShardChunkHeaderInner::V3(_) => false,
-                ShardChunkHeaderInner::V4(_) => true,
+                // In bandwidth scheduler version v3 and v4 are allowed. The first chunk in
+                // the bandwidth scheduler version will be v3 because the chunk extra for the
+                // last chunk of previous version doesn't have bandwidth requests.
+                // v2 is also allowed in the bandwidth scheduler version because there
+                // are multiple tests which upgrade from an old version directly to the
+                // latest version. TODO(#12328) - don't allow InnerV2 in bandwidth scheduler version.
+                ShardChunkHeaderInner::V2(_) => true,
+                ShardChunkHeaderInner::V3(_) => true,
+                ShardChunkHeaderInner::V4(_) => version >= BANDWIDTH_SCHEDULER_VERSION,
             },
         };
 
@@ -1172,8 +1206,9 @@ impl EncodedShardChunk {
         prev_outgoing_receipts: Vec<Receipt>,
         prev_outgoing_receipts_root: CryptoHash,
         congestion_info: CongestionInfo,
-        bandwidth_requests: BandwidthRequests,
+        bandwidth_requests: Option<BandwidthRequests>,
         signer: &ValidatorSigner,
+        protocol_version: ProtocolVersion,
     ) -> (Self, Vec<MerklePath>, Vec<Receipt>) {
         let signed_txs =
             validated_txs.into_iter().map(|validated_tx| validated_tx.into_signed_tx()).collect();
@@ -1186,6 +1221,7 @@ impl EncodedShardChunk {
         let (encoded_merkle_root, merkle_paths) = content.get_merkle_hash_and_paths();
 
         let header = ShardChunkHeader::V3(ShardChunkHeaderV3::new(
+            protocol_version,
             prev_block_hash,
             prev_state_root,
             prev_outcome_root,

--- a/core/store/benches/finalize_bench.rs
+++ b/core/store/benches/finalize_bench.rs
@@ -34,6 +34,7 @@ use near_primitives::transaction::{
 };
 use near_primitives::types::{AccountId, ShardId};
 use near_primitives::validator_signer::{InMemoryValidatorSigner, ValidatorSigner};
+use near_primitives::version::PROTOCOL_VERSION;
 use near_store::DBCol;
 use rand::prelude::SliceRandom;
 use reed_solomon_erasure::galois_8::ReedSolomon;
@@ -119,6 +120,7 @@ fn create_benchmark_receipts() -> Vec<Receipt> {
 
 fn create_chunk_header(height: u64, shard_id: ShardId) -> ShardChunkHeader {
     ShardChunkHeader::V3(ShardChunkHeaderV3::new(
+        PROTOCOL_VERSION,
         CryptoHash::default(),
         CryptoHash::default(),
         CryptoHash::default(),
@@ -133,7 +135,7 @@ fn create_chunk_header(height: u64, shard_id: ShardId) -> ShardChunkHeader {
         CryptoHash::default(),
         vec![],
         Default::default(),
-        BandwidthRequests::empty(),
+        BandwidthRequests::default_for_protocol_version(PROTOCOL_VERSION),
         &validator_signer(),
     ))
 }
@@ -202,9 +204,10 @@ fn create_encoded_shard_chunk(
         Default::default(),
         Default::default(),
         Default::default(),
-        BandwidthRequests::empty(),
+        BandwidthRequests::default_for_protocol_version(PROTOCOL_VERSION),
         &validator_signer(),
         &rs,
+        100,
     )
 }
 

--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -202,6 +202,7 @@ mod tests {
     use near_primitives::trie_key::TrieKey;
     use near_primitives::types::chunk_extra::ChunkExtra;
     use near_primitives::types::{StateChangeCause, StateRoot};
+    use near_primitives::version::PROTOCOL_VERSION;
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
 
@@ -532,6 +533,7 @@ mod tests {
         state_root: StateRoot,
     ) {
         let chunk_extra = ChunkExtra::new(
+            PROTOCOL_VERSION,
             &state_root,
             CryptoHash::default(),
             Vec::new(),
@@ -539,7 +541,7 @@ mod tests {
             0,
             0,
             Some(CongestionInfo::default()),
-            BandwidthRequests::empty(),
+            BandwidthRequests::default_for_protocol_version(PROTOCOL_VERSION),
         );
         let mut store_update = store.store_update();
         store_update

--- a/core/store/src/trie/outgoing_metadata.rs
+++ b/core/store/src/trie/outgoing_metadata.rs
@@ -6,8 +6,10 @@ use near_primitives::errors::StorageError;
 use near_primitives::receipt::TrieQueueIndices;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{Gas, ShardId};
+use near_primitives::version::ProtocolFeature;
 
 use near_schema_checker_lib::ProtocolSchema;
+use near_vm_runner::logic::ProtocolVersion;
 
 use crate::{TrieUpdate, get, set};
 
@@ -37,7 +39,12 @@ impl OutgoingMetadatas {
         trie: &dyn TrieAccess,
         shard_ids: impl IntoIterator<Item = ShardId>,
         groups_config: ReceiptGroupsConfig,
+        protocol_version: ProtocolVersion,
     ) -> Result<Self, StorageError> {
+        if !ProtocolFeature::BandwidthScheduler.enabled(protocol_version) {
+            return Ok(Self::new(groups_config));
+        }
+
         let mut metadatas = BTreeMap::new();
         for shard_id in shard_ids {
             let metadata = ReceiptGroupsQueue::load(trie, shard_id)?;

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -309,6 +309,7 @@ mod trie_recording_tests {
     use near_primitives::state::ValueRef;
     use near_primitives::types::StateRoot;
     use near_primitives::types::chunk_extra::ChunkExtra;
+    use near_primitives::version::PROTOCOL_VERSION;
     use rand::prelude::SliceRandom;
     use rand::{Rng, random, thread_rng};
     use std::cell::{Cell, RefCell};
@@ -367,6 +368,7 @@ mod trie_recording_tests {
 
         // ChunkExtra is needed for in-memory trie loading code to query state roots.
         let chunk_extra = ChunkExtra::new(
+            PROTOCOL_VERSION,
             &state_root,
             CryptoHash::default(),
             Vec::new(),
@@ -374,7 +376,7 @@ mod trie_recording_tests {
             0,
             0,
             Some(CongestionInfo::default()),
-            BandwidthRequests::empty(),
+            BandwidthRequests::default_for_protocol_version(PROTOCOL_VERSION),
         );
         let mut update_for_chunk_extra = tries_for_building.store_update();
         update_for_chunk_extra

--- a/core/store/src/utils/test_utils.rs
+++ b/core/store/src/utils/test_utils.rs
@@ -18,6 +18,7 @@ use near_primitives::state::FlatStateValue;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::StateRoot;
 use near_primitives::types::chunk_extra::ChunkExtra;
+use near_primitives::version::PROTOCOL_VERSION;
 use rand::Rng;
 use rand::seq::SliceRandom;
 use std::collections::HashMap;
@@ -155,6 +156,7 @@ impl TestTriesBuilder {
             // ChunkExtra is needed for in-memory trie loading code to query state roots.
             let congestion_info = Some(CongestionInfo::default());
             let chunk_extra = ChunkExtra::new(
+                PROTOCOL_VERSION,
                 &Trie::EMPTY_ROOT,
                 CryptoHash::default(),
                 Vec::new(),
@@ -162,7 +164,7 @@ impl TestTriesBuilder {
                 0,
                 0,
                 congestion_info,
-                BandwidthRequests::empty(),
+                BandwidthRequests::default_for_protocol_version(PROTOCOL_VERSION),
             );
             let mut update_for_chunk_extra = store.store_update();
             for shard_uid in &shard_uids {

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -11,7 +11,6 @@ use near_chain_configs::Genesis;
 use near_crypto::InMemorySigner;
 use near_epoch_manager::{EpochManager, EpochManagerAdapter, EpochManagerHandle};
 use near_primitives::account::{AccessKey, Account, AccountContract};
-use near_primitives::bandwidth_scheduler::BandwidthRequests;
 use near_primitives::block::Tip;
 use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::epoch_block_info::BlockInfo;
@@ -284,6 +283,7 @@ impl GenesisBuilder {
                 genesis.hash(),
                 &shard_uid,
                 ChunkExtra::new(
+                    self.genesis.config.protocol_version,
                     &state_root,
                     CryptoHash::default(),
                     vec![],
@@ -291,10 +291,7 @@ impl GenesisBuilder {
                     self.genesis.config.gas_limit,
                     0,
                     Some(congestion_info),
-                    chunk_header
-                        .bandwidth_requests()
-                        .cloned()
-                        .unwrap_or_else(BandwidthRequests::empty),
+                    chunk_header.bandwidth_requests().cloned(),
                 ),
             );
         }

--- a/integration-tests/src/tests/client/flat_storage.rs
+++ b/integration-tests/src/tests/client/flat_storage.rs
@@ -11,6 +11,7 @@ use near_primitives::shard_layout::{ShardLayout, ShardUId};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::ShardId;
+use near_primitives::version::ProtocolFeature;
 use near_primitives_core::types::BlockHeight;
 use near_store::adapter::StoreAdapter;
 use near_store::test_utils::create_test_store;
@@ -48,6 +49,15 @@ fn test_flat_storage_iter() {
         env.produce_block(0, height);
     }
 
+    // Since the BandwidthScheduler feature there is one more entry on every shard - BandwidthSchedulerState
+    // The test should expect one more entry on every shard.
+    let protocol_version_modifier =
+        if ProtocolFeature::BandwidthScheduler.enabled(genesis.config.protocol_version) {
+            1
+        } else {
+            0
+        };
+
     let [s0, s1, s2] = shard_layout.shard_ids().collect_vec()[..] else {
         panic!("Expected 3 shards in the shard layout!");
     };
@@ -62,10 +72,10 @@ fn test_flat_storage_iter() {
         }
 
         if shard_id == s0 {
+            let expected = 2 + protocol_version_modifier;
+            assert_eq!(expected, items.len());
             // Two entries - one for 'near' system account, the other for the contract.
             // (with newer protocol: +1 for BandwidthSchedulerState)
-            let expected = 3;
-            assert_eq!(expected, items.len());
             assert_eq!(
                 TrieKey::Account { account_id: "near".parse().unwrap() }.to_vec(),
                 items[0].as_ref().unwrap().0.to_vec()
@@ -74,7 +84,7 @@ fn test_flat_storage_iter() {
         if shard_id == s1 {
             // Two entries - one for account, the other for contract.
             // (with newer protocol: +1 for BandwidthSchedulerState)
-            let expected = 3;
+            let expected = 2 + protocol_version_modifier;
             assert_eq!(expected, items.len());
             assert_eq!(
                 TrieKey::Account { account_id: "test0".parse().unwrap() }.to_vec(),
@@ -84,7 +94,7 @@ fn test_flat_storage_iter() {
         if shard_id == s2 {
             // Test1 account was not created yet - so no entries.
             // (with newer protocol: +1 for BandwidthSchedulerState)
-            let expected = 1;
+            let expected = 0 + protocol_version_modifier;
             assert_eq!(expected, items.len());
         }
     }

--- a/integration-tests/src/tests/client/process_blocks2.rs
+++ b/integration-tests/src/tests/client/process_blocks2.rs
@@ -6,7 +6,6 @@ use near_chain_configs::Genesis;
 use near_crypto::vrf::Value;
 use near_crypto::{KeyType, PublicKey, Signature};
 use near_network::types::{NetworkRequests, PeerManagerMessageRequest};
-use near_primitives::bandwidth_scheduler::BandwidthRequests;
 use near_primitives::block::Block;
 use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::network::PeerId;
@@ -17,6 +16,7 @@ use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::ShardId;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::utils::MaybeValidated;
+use near_primitives::version::PROTOCOL_VERSION;
 use near_store::ShardUId;
 
 use crate::env::test_env::TestEnv;
@@ -78,6 +78,7 @@ fn test_bad_shard_id() {
     let outgoing_receipts_root = chunks.get(1).unwrap().prev_outgoing_receipts_root();
     let congestion_info = CongestionInfo::default();
     let mut modified_chunk = ShardChunkHeaderV3::new(
+        PROTOCOL_VERSION,
         *chunk.prev_block_hash(),
         chunk.prev_state_root(),
         chunk.prev_outcome_root(),
@@ -92,7 +93,7 @@ fn test_bad_shard_id() {
         chunk.tx_root(),
         chunk.prev_validator_proposals().collect(),
         congestion_info,
-        chunk.bandwidth_requests().cloned().unwrap_or_else(BandwidthRequests::empty),
+        chunk.bandwidth_requests().cloned(),
         &validator_signer,
     );
     modified_chunk.height_included = 2;
@@ -230,6 +231,7 @@ fn test_bad_congestion_info_impl(mode: BadCongestionInfoMode) {
     mode.corrupt(&mut congestion_info);
 
     let mut modified_chunk_header = ShardChunkHeaderV3::new(
+        PROTOCOL_VERSION,
         *chunk.prev_block_hash(),
         chunk.prev_state_root(),
         chunk.prev_outcome_root(),
@@ -244,7 +246,7 @@ fn test_bad_congestion_info_impl(mode: BadCongestionInfoMode) {
         chunk.tx_root(),
         chunk.prev_validator_proposals().collect(),
         congestion_info,
-        chunk.bandwidth_requests().cloned().unwrap_or_else(BandwidthRequests::empty),
+        chunk.bandwidth_requests().cloned(),
         &validator_signer,
     );
     modified_chunk_header.height_included = 2;

--- a/integration-tests/src/user/runtime_user.rs
+++ b/integration-tests/src/user/runtime_user.rs
@@ -155,14 +155,13 @@ impl RuntimeUser {
             receipts = apply_result.outgoing_receipts;
             txs = vec![];
 
-            apply_state.bandwidth_requests = BlockBandwidthRequests {
-                shards_bandwidth_requests: [(
-                    apply_state.shard_id,
-                    apply_result.bandwidth_requests,
-                )]
-                .into_iter()
-                .collect(),
-            };
+            if let Some(bandwidth_requests) = apply_result.bandwidth_requests {
+                apply_state.bandwidth_requests = BlockBandwidthRequests {
+                    shards_bandwidth_requests: [(apply_state.shard_id, bandwidth_requests)]
+                        .into_iter()
+                        .collect(),
+                };
+            }
             let mut have_queued_receipts = false;
             if let Some(congestion_info) = apply_result.congestion_info {
                 if congestion_info.receipt_bytes() > 0 {

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -387,11 +387,13 @@ impl Testbed<'_> {
                 .congestion_info
                 .insert(shard_uid.shard_id(), ExtendedCongestionInfo::new(congestion_info, 0));
         }
-        self.apply_state.bandwidth_requests = BlockBandwidthRequests {
-            shards_bandwidth_requests: [(shard_uid.shard_id(), apply_result.bandwidth_requests)]
-                .into_iter()
-                .collect(),
-        };
+        if let Some(bandwidth_requests) = apply_result.bandwidth_requests {
+            self.apply_state.bandwidth_requests = BlockBandwidthRequests {
+                shards_bandwidth_requests: [(shard_uid.shard_id(), bandwidth_requests)]
+                    .into_iter()
+                    .collect(),
+            };
+        }
 
         let mut total_burnt_gas = 0;
         if !allow_failures {

--- a/runtime/runtime/src/bandwidth_scheduler/scheduler.rs
+++ b/runtime/runtime/src/bandwidth_scheduler/scheduler.rs
@@ -155,7 +155,6 @@ use rand_chacha::ChaCha20Rng;
 
 /// How many bytes of outgoing receipts can be sent from one shard to another at the current height.
 /// Produced by the bandwidth scheduler.
-#[derive(Default)]
 pub struct GrantedBandwidth {
     pub granted: BTreeMap<(ShardId, ShardId), Bandwidth>,
 }

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -299,7 +299,7 @@ pub struct ApplyResult {
     pub delayed_receipts_count: u64,
     pub metrics: Option<metrics::ApplyMetrics>,
     pub congestion_info: Option<CongestionInfo>,
-    pub bandwidth_requests: BandwidthRequests,
+    pub bandwidth_requests: Option<BandwidthRequests>,
     /// Used only for a sanity check.
     pub bandwidth_scheduler_state_hash: CryptoHash,
     /// Contracts accessed and deployed while applying the chunk.
@@ -1550,6 +1550,7 @@ impl Runtime {
         let own_congestion_info =
             apply_state.own_congestion_info(&processing_state.state_update)?;
         let mut receipt_sink = ReceiptSink::new(
+            processing_state.protocol_version,
             &processing_state.state_update.trie,
             apply_state,
             own_congestion_info,
@@ -2255,9 +2256,10 @@ impl Runtime {
         metrics::report_recorded_column_sizes(&trie, &apply_state);
         let proof = trie.recorded_storage();
         let processed_yield_timeouts = promise_yield_result.processed_yield_timeouts;
-        let bandwidth_scheduler_state_hash =
-            receipt_sink.bandwidth_scheduler_output().scheduler_state_hash;
-
+        let bandwidth_scheduler_state_hash = receipt_sink
+            .bandwidth_scheduler_output()
+            .map(|o| o.scheduler_state_hash)
+            .unwrap_or_default();
         let outgoing_receipts =
             receipt_sink.finalize_stats_get_outgoing_receipts(&mut stats.receipt_sink);
         Ok(ApplyResult {
@@ -2340,7 +2342,7 @@ fn action_transfer_or_implicit_account_creation(
 fn missing_chunk_apply_result(
     delayed_receipts: &DelayedReceiptQueueWrapper,
     processing_state: ApplyProcessingState,
-    bandwidth_scheduler_output: &BandwidthSchedulerOutput,
+    bandwidth_scheduler_output: &Option<BandwidthSchedulerOutput>,
 ) -> Result<ApplyResult, RuntimeError> {
     let TrieUpdateResult { trie, trie_changes, state_changes, contract_updates } =
         processing_state.state_update.finalize()?;
@@ -2362,8 +2364,7 @@ fn missing_chunk_apply_result(
         .bandwidth_requests
         .shards_bandwidth_requests
         .get(&processing_state.apply_state.shard_id)
-        .cloned()
-        .unwrap_or_else(BandwidthRequests::empty);
+        .cloned();
 
     return Ok(ApplyResult {
         state_root: trie_changes.new_root,
@@ -2380,7 +2381,10 @@ fn missing_chunk_apply_result(
         metrics: None,
         congestion_info,
         bandwidth_requests: previous_bandwidth_requests,
-        bandwidth_scheduler_state_hash: bandwidth_scheduler_output.scheduler_state_hash,
+        bandwidth_scheduler_state_hash: bandwidth_scheduler_output
+            .as_ref()
+            .map(|o| o.scheduler_state_hash)
+            .unwrap_or_default(),
         contract_updates,
     });
 }
@@ -2703,10 +2707,8 @@ fn schedule_contract_preparation<'b, R: MaybeRefReceipt>(
 pub mod estimator {
     use super::{ReceiptSink, Runtime};
     use crate::ApplyState;
-    use crate::BandwidthSchedulerOutput;
     use crate::congestion_control::ReceiptSinkV2;
     use crate::pipelining::ReceiptPreparationPipeline;
-    use near_primitives::bandwidth_scheduler::BandwidthSchedulerParams;
     use near_primitives::chunk_apply_stats::{ChunkApplyStatsV0, ReceiptSinkStats};
     use near_primitives::congestion_info::CongestionInfo;
     use near_primitives::errors::RuntimeError;
@@ -2718,7 +2720,6 @@ pub mod estimator {
     use near_store::trie::receipts_column_helper::ShardsOutgoingReceiptBuffer;
     use near_store::{ShardUId, TrieUpdate};
     use std::collections::HashMap;
-    use std::num::NonZeroU64;
 
     pub fn apply_action_receipt(
         state_update: &mut TrieUpdate,
@@ -2741,13 +2742,8 @@ pub mod estimator {
             state_update,
             std::iter::once(shard_uid.shard_id()),
             ReceiptGroupsConfig::default_config(),
+            apply_state.current_protocol_version,
         )?;
-
-        let shard_layout = epoch_info_provider.shard_layout(&apply_state.epoch_id)?;
-        let params = BandwidthSchedulerParams::new(
-            NonZeroU64::new(shard_layout.num_shards()).expect("ShardLayout has zero shards!"),
-            &apply_state.config,
-        );
 
         let mut receipt_sink = ReceiptSink::V2(ReceiptSinkV2 {
             own_congestion_info: congestion_info,
@@ -2755,7 +2751,8 @@ pub mod estimator {
             outgoing_buffers: ShardsOutgoingReceiptBuffer::load(&state_update.trie)?,
             outgoing_receipts: Vec::new(),
             outgoing_metadatas,
-            bandwidth_scheduler_output: BandwidthSchedulerOutput::no_granted_bandwidth(params),
+            bandwidth_scheduler_output: None,
+            protocol_version: apply_state.current_protocol_version,
             stats: ReceiptSinkStats::default(),
         });
         let empty_pipeline = ReceiptPreparationPipeline::new(

--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -162,11 +162,11 @@ impl StandaloneRuntime {
         store_update.commit().unwrap();
         self.apply_state.block_height += 1;
 
-        self.apply_state.bandwidth_requests = BlockBandwidthRequests {
-            shards_bandwidth_requests: [(shard_id, apply_result.bandwidth_requests)]
-                .into_iter()
-                .collect(),
-        };
+        if let Some(bandwidth_requests) = apply_result.bandwidth_requests {
+            self.apply_state.bandwidth_requests = BlockBandwidthRequests {
+                shards_bandwidth_requests: [(shard_id, bandwidth_requests)].into_iter().collect(),
+            }
+        }
 
         let mut has_queued_receipts = false;
         if let Some(congestion_info) = apply_result.congestion_info {

--- a/test-loop-tests/src/tests/bandwidth_scheduler_protocol_upgrade.rs
+++ b/test-loop-tests/src/tests/bandwidth_scheduler_protocol_upgrade.rs
@@ -1,0 +1,23 @@
+use std::collections::HashMap;
+
+use near_primitives::version::ProtocolFeature;
+
+use super::protocol_upgrade::test_protocol_upgrade;
+
+#[test]
+fn test_bandwidth_scheduler_protocol_upgrade_no_missing_chunks() {
+    test_protocol_upgrade(
+        ProtocolFeature::BandwidthScheduler.protocol_version() - 1,
+        ProtocolFeature::BandwidthScheduler.protocol_version(),
+        HashMap::new(),
+    );
+}
+
+#[test]
+fn test_bandwidth_scheduler_protocol_upgrade_with_missing_chunks_two() {
+    test_protocol_upgrade(
+        ProtocolFeature::BandwidthScheduler.protocol_version() - 1,
+        ProtocolFeature::BandwidthScheduler.protocol_version(),
+        HashMap::from_iter([(0, 0..0), (1, -2..0), (2, 0..2), (3, -2..2)].into_iter()),
+    );
+}

--- a/test-loop-tests/src/tests/mod.rs
+++ b/test-loop-tests/src/tests/mod.rs
@@ -1,4 +1,5 @@
 mod bandwidth_scheduler;
+mod bandwidth_scheduler_protocol_upgrade;
 mod chunk_validator_kickout;
 mod chunks_management;
 mod congestion_control;

--- a/tools/replay-archive/src/cli.rs
+++ b/tools/replay-archive/src/cli.rs
@@ -26,7 +26,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
 use near_primitives::sharding::{ReceiptProof, ShardChunk, ShardChunkHeader, ShardProof};
 use near_primitives::types::chunk_extra::ChunkExtra;
-use near_primitives::types::{BlockHeight, Gas, ShardId};
+use near_primitives::types::{BlockHeight, Gas, ProtocolVersion, ShardId};
 use near_state_viewer::progress_reporter::ProgressReporter;
 use near_store::{ShardUId, Store, get_genesis_state_roots};
 use nearcore::{NearConfig, NightshadeRuntime, NightshadeRuntimeExt, load_config};
@@ -210,6 +210,9 @@ impl ReplayController {
 
         let block = self.chain_store.get_block(&block_hash)?;
 
+        let epoch_id = block.header().epoch_id();
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(epoch_id)?;
+
         self.validate_block(&block)?;
 
         self.update_epoch_manager(&block)?;
@@ -241,7 +244,14 @@ impl ReplayController {
             let shard_uid = shard_id_to_uid(self.epoch_manager.as_ref(), shard_id, epoch_id)
                 .context("Failed to get shard UID from shard id")?;
             let replay_output = self
-                .replay_chunk(&block, &prev_block, shard_uid, chunk_header, prev_chunk_header)
+                .replay_chunk(
+                    &block,
+                    &prev_block,
+                    shard_uid,
+                    chunk_header,
+                    prev_chunk_header,
+                    protocol_version,
+                )
                 .context("Failed to replay the chunk")?;
             total_gas_burnt += replay_output.chunk_extra.gas_used();
 
@@ -266,6 +276,7 @@ impl ReplayController {
         shard_uid: ShardUId,
         chunk_header: &ShardChunkHeader,
         prev_chunk_header: &ShardChunkHeader,
+        protocol_version: ProtocolVersion,
     ) -> Result<ReplayChunkOutput> {
         let span = tracing::debug_span!(target: "replay-archive", "replay_chunk").entered();
 
@@ -340,7 +351,8 @@ impl ReplayController {
                 apply_result,
             }) => {
                 let outgoing_receipts = apply_result.outgoing_receipts.clone();
-                let chunk_extra = apply_result_to_chunk_extra(apply_result, &chunk_header);
+                let chunk_extra =
+                    apply_result_to_chunk_extra(protocol_version, apply_result, &chunk_header);
                 ReplayChunkOutput { chunk_extra, outgoing_receipts }
             }
             ShardUpdateResult::OldChunk(OldChunkResult { shard_uid: _, apply_result }) => {

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -100,6 +100,8 @@ fn apply_block_from_range(
         .get_block_producer(block.header().epoch_id(), block.header().height())
         .unwrap();
 
+    let protocol_version =
+        epoch_manager.get_epoch_protocol_version(block.header().epoch_id()).unwrap();
     let apply_result = if block.header().is_genesis() {
         if verbose_output {
             println!("Skipping the genesis block #{}.", height);
@@ -236,6 +238,7 @@ fn apply_block_from_range(
 
     let (outcome_root, _) = ApplyChunkResult::compute_outcomes_proof(&apply_result.outcomes);
     let chunk_extra = ChunkExtra::new(
+        protocol_version,
         &apply_result.new_root,
         outcome_root,
         apply_result.validator_proposals.clone(),

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -306,6 +306,7 @@ fn apply_tx_in_chunk(
     );
 
     let head = chain_store.head()?.height;
+    let protocol_version = chain_store.head_header()?.latest_protocol_version();
     let mut chunk_hashes = vec![];
 
     for item in store.iter(DBCol::ChunkHashesByHeight) {
@@ -346,7 +347,10 @@ fn apply_tx_in_chunk(
         );
         let (apply_result, gas_limit) =
             apply_chunk(epoch_manager, runtime, chain_store, chunk_hash, None, None, storage)?;
-        println!("resulting chunk extra:\n{:?}", resulting_chunk_extra(&apply_result, gas_limit));
+        println!(
+            "resulting chunk extra:\n{:?}",
+            resulting_chunk_extra(&apply_result, gas_limit, protocol_version)
+        );
         results.push(apply_result);
     }
     Ok(results)
@@ -441,6 +445,7 @@ fn apply_receipt_in_chunk(
     println!("Receipt is not indexed; searching in chunks that haven't been applied...");
 
     let head = chain_store.head()?.height;
+    let protocol_version = chain_store.head_header()?.latest_protocol_version();
     let mut to_apply = HashSet::new();
     let mut non_applied_chunks = HashMap::new();
 
@@ -508,7 +513,7 @@ fn apply_receipt_in_chunk(
             None,
             storage,
         )?;
-        let chunk_extra = resulting_chunk_extra(&apply_result, gas_limit);
+        let chunk_extra = resulting_chunk_extra(&apply_result, gas_limit, protocol_version);
         println!("resulting chunk extra:\n{:?}", chunk_extra);
         results.push(apply_result);
     }

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -233,7 +233,20 @@ pub(crate) fn apply_chunk(
         None,
         storage,
     )?;
-    println!("resulting chunk extra:\n{:?}", resulting_chunk_extra(&apply_result, gas_limit));
+    let protocol_version = if let Some(height) = target_height {
+        // Retrieve the protocol version at the given height.
+        let block_hash = chain_store.get_block_hash_by_height(height)?;
+        chain_store.get_block(&block_hash)?.header().latest_protocol_version()
+    } else {
+        // No block height specified, fallback to current protocol version.
+        PROTOCOL_VERSION
+    };
+    // Most probably `PROTOCOL_VERSION` won't work if the target_height points to a time
+    // before congestion control has been introduced.
+    println!(
+        "resulting chunk extra:\n{:?}",
+        resulting_chunk_extra(&apply_result, gas_limit, protocol_version)
+    );
     Ok(())
 }
 


### PR DESCRIPTION
This reverts commit d5b685eff4d5d4801e47a1992ce6a65ae5aceba9.

Seems to be the reason nightly CI fails, ref https://github.com/near/nearcore/actions/runs/14673007665/job/41183659169.

cc @darioush 