### PR TITLE
ci: use warp windows builder for publishable package check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,7 @@ jobs:
             os: warp-ubuntu-2204-x64-2x
           - name: Windows
             id: win
-            os: windows-latest
+            os: warp-windows-latest-x64-2x
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,7 @@ jobs:
             os: warp-ubuntu-2204-x64-2x
           - name: Windows
             id: win
-            os: warp-windows-latest-x64-2x
+            os: warp-windows-latest-x64-4x
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This job takes the longest time to run by far (15 minutes) with the next slowest job (publishable check on linux & large pytest checks) running in 8.5~9 minutes.

This is going to result in having to pay for this job, but 15 minutes is way outside of our self-imposed end-to-end CI limit of 10 minutes.