### PR TITLE
docs: add simple instructions about how to measure max TPS

### DIFF
--- a/benchmarks/sharded-bm/README.md
+++ b/benchmarks/sharded-bm/README.md
@@ -196,4 +196,3 @@ To use transaction injection you must enable it in `params.json`. To stop the in
 ```sh
 ./bench.sh stop-injection
 ```
-````

--- a/benchmarks/sharded-bm/README.md
+++ b/benchmarks/sharded-bm/README.md
@@ -162,6 +162,19 @@ Grafana mostly, [Blockchain utilization dashboard](https://grafana.nearone.org/g
     ./bench.sh mirror <ARGS>
     ```
 
+### Forknet - How to measure max TPS
+
+Follow these instructions to measure the maximum TPS of a network, to obtain a result similar to [this](https://github.com/near/nearcore/issues/13130#issuecomment-2797211286).
+
+- Setup the nodes and init the network in order to run the benchmarks using `CASE=cases/forknet/realistic_20_cp_1_rpc_20_shard/`
+- Set `tx_generator.tps` in `params.json` roughly 10% lower than the previous measured max TPS, or to a safe low value
+- Repeat this loop:
+  - Run `./bench.sh native-transfers`
+  - Observe **Transactions included in chunks** in [Blockchain utilization dashboard](https://grafana.nearone.org/goto/3bS1Lr2Ng?orgId=1), we can call this figure: *current TPS*
+  - Check if **Blocks per second** from the same dashboard is what you expect given the scenario's `neard` configuration (with 1.3s block time you should see >= 0.76 block/s)
+    - if YES: Set *max TPS* = *observed TPS*, increase `tx_generator.tps` by a small amount (e.g. 100) and repeat
+    - if NO: stop the experiment
+
 ### Known issues
 
 - It is not possible to configure the number of RPC nodes

--- a/benchmarks/sharded-bm/README.md
+++ b/benchmarks/sharded-bm/README.md
@@ -164,16 +164,23 @@ Grafana mostly, [Blockchain utilization dashboard](https://grafana.nearone.org/g
 
 ### Forknet - How to measure max TPS
 
-Follow these instructions to measure the maximum TPS of a network, to obtain a result similar to [this](https://github.com/near/nearcore/issues/13130#issuecomment-2797211286).
+Follow these steps to determine the maximum TPS (transactions per second) the network can handle, to build a report similar to [this example](https://github.com/near/nearcore/issues/13130#issuecomment-2797211286):
 
-- Setup the nodes and init the network in order to run the benchmarks using `CASE=cases/forknet/realistic_20_cp_1_rpc_20_shard/`
-- Set `tx_generator.tps` in `params.json` roughly 10% lower than the previous measured max TPS, or to a safe low value
-- Repeat this loop:
-  - Run `./bench.sh native-transfers`
-  - Observe **Transactions included in chunks** in [Blockchain utilization dashboard](https://grafana.nearone.org/goto/3bS1Lr2Ng?orgId=1), we can call this figure: *current TPS*
-  - Check if **Blocks per second** from the same dashboard is what you expect given the scenario's `neard` configuration (with 1.3s block time you should see >= 0.76 block/s)
-    - if YES: Set *max TPS* = *observed TPS*, increase `tx_generator.tps` by a small amount (e.g. 100) and repeat
-    - if NO: stop the experiment
+1. **Setup:** Initialize the nodes and network for benchmarking using the realistic scenario: `CASE=cases/forknet/realistic_20_cp_1_rpc_20_shard/`.
+2. **Start Low:** In `params.json`, set `tx_generator.tps` to about 90% of the previously measured max TPS, or to a conservative low value if unknown.
+3. **Iterative Testing:** Repeat the following steps:
+    - Run `./bench.sh native-transfers`.
+    - Let the network run for at least 15 minutes.
+    - In the [Blockchain utilization dashboard](https://grafana.nearone.org/goto/3bS1Lr2Ng?orgId=1), note the value for **Transactions included in chunks** (*current TPS*).
+    - Check **Blocks per second** in the same dashboard. Make sure it matches expectations for your `neard` config (e.g., with 1.3s block time, you should see ≥ 0.76 block/s).
+        - **If blocks per second is as expected:**  
+          - Update your *max TPS* to the observed *current TPS*.
+          - Increase `tx_generator.tps` by a small increment (e.g., 100).
+          - Repeat the loop to test the new TPS.
+        - **If blocks per second drops below expected:**  
+          - Stop the experiment. The previous *max TPS* is the network’s maximum sustainable throughput.
+
+The idea is to gradually increase the load (TPS) in small steps, starting from a safe value, until the network can no longer keep up.
 
 ### Known issues
 
@@ -189,3 +196,4 @@ To use transaction injection you must enable it in `params.json`. To stop the in
 ```sh
 ./bench.sh stop-injection
 ```
+````

--- a/benchmarks/sharded-bm/README.md
+++ b/benchmarks/sharded-bm/README.md
@@ -175,7 +175,7 @@ Follow these steps to determine the maximum TPS (transactions per second) the ne
     - Check **Blocks per second** in the same dashboard. Make sure it matches expectations for your `neard` config (e.g., with 1.3s block time, you should see ≥ 0.76 block/s).
         - **If blocks per second is as expected:**  
           - Update your *max TPS* to the observed *current TPS*.
-          - Increase `tx_generator.tps` by a small increment (e.g., 100).
+          - Increase `tx_generator.tps` by a small value (e.g., 100).
           - Repeat the loop to test the new TPS.
         - **If blocks per second drops below expected:**  
           - Stop the experiment. The previous *max TPS* is the network’s maximum sustainable throughput.


### PR DESCRIPTION
Adding a brief section with recommended steps to measure max TPS in a sharded benchmark on forknet.