### PR TITLE
test refactor: allow optional refund in macro

### DIFF
--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -468,7 +468,7 @@ macro_rules! option_tuplet_resolve {
     { $v:expr ; $j:expr ; ($opt:ident $(,)?)} => {
         let $opt = $v.get($j);
     };
-    // recursion, left popping one element from the vec at the time
+    // recursion, processing one element from the vec at the time
     { $v:expr ; $j:expr ; ($opt:ident $(,$more_opt:ident)+) } => {
         let $opt = $v.get($j);
         option_tuplet_resolve!( $v ; $j+1 ; ($($more_opt),*) );
@@ -476,7 +476,7 @@ macro_rules! option_tuplet_resolve {
 }
 
 /// Binds a tuple to a vector of Options.
-/// 
+///
 /// This is a wrapper around `tuplet` that allows adding optional parameters
 /// with a `?` prefix and a type declaration.
 /// # Examples:

--- a/runtime/runtime/tests/test_async_calls.rs
+++ b/runtime/runtime/tests/test_async_calls.rs
@@ -1036,10 +1036,10 @@ fn test_transfer_64len_hex() {
                         => [?ref1] );
 
     if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) {
+        assert!(ref1.is_none());
+    } else {
         let ref1 = ref1.unwrap();
         assert_refund!(group, ref1 @ "near_0");
-    } else {
-        assert!(ref1.is_none());
     }
     assert_refund!(group, ref0 @ "near_0");
 }

--- a/runtime/runtime/tests/test_async_calls.rs
+++ b/runtime/runtime/tests/test_async_calls.rs
@@ -603,7 +603,7 @@ fn test_simple_transfer() {
     if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) {
         assert!(ref1.is_none());
     } else {
-        let ref1 = ref1;
+        let ref1 = ref1.unwrap();
         assert_refund!(group, ref1 @ "near_0");
     }
 }


### PR DESCRIPTION
With changes coming with NEP-536, we have around 20 or so test that use the assert_receipt macro that need to optionally return a refund, depending on whether its on nightly or stable.

With this refactor, this change can be done without massive code duplication, which makes the code entirely unreadable.

Some previously changed tests already become nicer with this PR.
The other changes will come after, I'll wait adapting them until this has passed review..