### PR TITLE
codecov: fix flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,22 +338,22 @@ jobs:
         with:
           files: unit-linux.json
           fail_ci_if_error: true
-          flags: unittests,linux
+          flags: unittests
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
           files: unit-linux-nightly.json
           fail_ci_if_error: true
-          flags: unittests,linux-nightly
+          flags: unittests-nightly
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
           files: py.json
           fail_ci_if_error: true
-          flags: pytests,backward-compatibility,linux
+          flags: pytests
       - uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
         with:
           files: py-nightly.json
           fail_ci_if_error: true
-          flags: pytests,db-migration,linux
+          flags: pytests-nightly
 
   publishable_packages_check:
     name: "Cargo check publishable packages separately"


### PR DESCRIPTION
CodeCov UI at complains that uploads are invalid due to multiple flags being specified for each upload. As seen e.g. in
https://app.codecov.io/gh/near/nearcore/commit/3d620e7cc9b6be1d1a225d55ec643b8339e1bc34

There's also some documentation on this here:
https://docs.codecov.com/docs/flags#one-to-one-relationship-of-flags-to-uploads

Address this by always specifying one flag for each of the uploads only...