### PR TITLE
distribute receipts and chunks to BPs of the next epoch

### DIFF
--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -1908,6 +1908,8 @@ impl ShardsManagerActor {
         let forward =
             PartialEncodedChunkForwardMsg::from_header_and_parts(chunk_header, owned_parts);
 
+        // Here we concatenate the lists of block producers for the current epoch
+        // and for the next. The loop below performs deduplication.
         let next_epoch_id = self.epoch_manager.get_next_epoch_id(latest_block_hash)?;
         let this_epoch_block_producers =
             self.epoch_manager.get_epoch_block_producers_ordered(&epoch_id)?;

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -2076,6 +2076,17 @@ impl ShardsManagerActor {
             entry.push(part_ord);
         }
 
+        // Receipt proofs need to be distributed to the block producers of the next epoch
+        // because they already start tracking the shard in the current epoch.
+        let next_epoch_id = self.epoch_manager.get_next_epoch_id(prev_block_hash)?;
+        let next_epoch_block_producers =
+            self.epoch_manager.get_epoch_block_producers_ordered(&next_epoch_id)?;
+        for bp in next_epoch_block_producers {
+            if !block_producer_mapping.contains_key(bp.account_id()) {
+                block_producer_mapping.insert(bp.account_id().clone(), vec![]);
+            }
+        }
+
         let receipt_proofs = make_outgoing_receipts_proofs(
             &chunk_header,
             outgoing_receipts,


### PR DESCRIPTION
When a node transitions from CV -> CP for a shard, it starts to track the shard in the epoch before it becomes a chunk producer. When tracking the shard, it needs to receive the chunks for the shard as well as outgoing receipt proofs from other shards.

If they are not distributed eagerly the node will have to use the ChunkRequest/ChunkResponse pattern and incur significant additional latency during block processing. This in turn delays endorsement of chunks for the following block, causing the node's performance as a chunk validator to suffer.