### PR TITLE
update `near-account-id` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4103,9 +4103,9 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "1.0.0-alpha.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d10d45a9c49c3e975c362cf4d1dc1d7b72a716b30394bea56ee2a8fb225f50b7"
+checksum = "4ed69d94899cfdfba16182bd681ad9e6b7f888e29532b04c56da9ae05a4c5bc4"
 dependencies = [
  "borsh",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,7 +233,7 @@ log = "0.4"
 lru = "0.12.3"
 memoffset = "0.8"
 more-asserts = "0.2"
-near-account-id = { version = "1.0.0-alpha.4", features = [
+near-account-id = { version = "1.1.1", features = [
     "internal_unstable",
     "serde",
     "borsh",


### PR DESCRIPTION
The new version in particular removes depending on `rc` in `borsh`.