### PR TITLE
chore: fix warning

### DIFF
--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -5,8 +5,8 @@ use assert_matches::assert_matches;
 use near_async::time::{Clock, Duration, FakeClock, Utc};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::{
-    block::MaybeNew, hash::CryptoHash, optimistic_block::OptimisticBlock,
-    sharding::ShardChunkHeader, test_utils::TestBlockBuilder, version::PROTOCOL_VERSION,
+    block::MaybeNew, hash::CryptoHash, sharding::ShardChunkHeader, test_utils::TestBlockBuilder,
+    version::PROTOCOL_VERSION,
 };
 use num_rational::Ratio;
 


### PR DESCRIPTION
removing unused dependency in tests