### PR TITLE
fix: use borsh `object_length` instead of `to_vec(..).len()`

### DIFF
--- a/chain/chain/src/stateless_validation/metrics.rs
+++ b/chain/chain/src/stateless_validation/metrics.rs
@@ -166,10 +166,10 @@ fn record_witness_size_metrics_fallible(
         .observe(encoded_size as f64);
     CHUNK_STATE_WITNESS_MAIN_STATE_TRANSITION_SIZE
         .with_label_values(&[shard_id.as_str()])
-        .observe(borsh::to_vec(&witness.main_state_transition)?.len() as f64);
+        .observe(borsh::object_length(&witness.main_state_transition)? as f64);
     CHUNK_STATE_WITNESS_SOURCE_RECEIPT_PROOFS_SIZE
         .with_label_values(&[&shard_id.as_str()])
-        .observe(borsh::to_vec(&witness.source_receipt_proofs)?.len() as f64);
+        .observe(borsh::object_length(&witness.source_receipt_proofs)? as f64);
     Ok(())
 }
 

--- a/core/primitives/src/utils/compression.rs
+++ b/core/primitives/src/utils/compression.rs
@@ -98,7 +98,7 @@ mod tests {
         let (decompressed, decompressed_size) = compressed.decode().unwrap();
         assert_eq!(&decompressed, &data);
         assert_eq!(uncompressed_size, decompressed_size);
-        assert_eq!(borsh::to_vec(&data).unwrap().len(), uncompressed_size);
+        assert_eq!(borsh::object_length(&data).unwrap(), uncompressed_size);
     }
 
     #[test]
@@ -106,7 +106,7 @@ mod tests {
         // Encode exceeding limit is OK.
         let data = MyData(vec![42; 2000]);
         let (_, uncompressed_size) = CompressedMyData::encode(&data).unwrap();
-        assert_eq!(borsh::to_vec(&data).unwrap().len(), uncompressed_size);
+        assert_eq!(borsh::object_length(&data).unwrap(), uncompressed_size);
     }
 
     #[test]

--- a/integration-tests/src/env/test_env.rs
+++ b/integration-tests/src/env/test_env.rs
@@ -400,7 +400,7 @@ impl TestEnv {
         for (client_idx, partial_witness_adapter) in partial_witness_adapters.iter().enumerate() {
             while let Some(request) = partial_witness_adapter.pop_distribution_request() {
                 let DistributeStateWitnessRequest { state_witness, .. } = request;
-                let raw_witness_size = borsh::to_vec(&state_witness).unwrap().len();
+                let raw_witness_size = borsh::object_length(&state_witness).unwrap();
                 let key = state_witness.chunk_production_key();
                 let chunk_validators = self.clients[client_idx]
                     .epoch_manager

--- a/integration-tests/src/tests/features/stateless_validation.rs
+++ b/integration-tests/src/tests/features/stateless_validation.rs
@@ -348,7 +348,7 @@ fn test_chunk_state_witness_bad_shard_id() {
     let previous_block = env.clients[0].chain.head().unwrap().prev_block_hash;
     let invalid_shard_id = ShardId::new(1000000000);
     let witness = ChunkStateWitness::new_dummy(upper_height, invalid_shard_id, previous_block);
-    let witness_size = borsh::to_vec(&witness).unwrap().len();
+    let witness_size = borsh::object_length(&witness).unwrap();
 
     // Client should reject this ChunkStateWitness and the error message should mention "shard"
     tracing::info!(target: "test", "Processing invalid ChunkStateWitness");

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -268,7 +268,7 @@ pub(crate) fn validate_receipt(
 ) -> Result<(), ReceiptValidationError> {
     if mode == ValidateReceiptMode::NewReceipt {
         let receipt_size: u64 =
-            borsh::to_vec(receipt).unwrap().len().try_into().expect("Can't convert usize to u64");
+            borsh::object_length(receipt).unwrap().try_into().expect("Can't convert usize to u64");
         if receipt_size > limit_config.max_receipt_size {
             return Err(ReceiptValidationError::ReceiptSizeExceeded {
                 size: receipt_size,


### PR DESCRIPTION
This PR replaces usage of `borsh::to_vec` with `borsh::object_length` to determine the size of serialized data. This is much faster as it avoid memory allocation.