### PR TITLE
enable parallel endorsement validation

### DIFF
--- a/chain/client/src/chunk_inclusion_tracker.rs
+++ b/chain/client/src/chunk_inclusion_tracker.rs
@@ -117,7 +117,7 @@ impl ChunkInclusionTracker {
     pub fn prepare_chunk_headers_ready_for_inclusion(
         &mut self,
         prev_block_hash: &CryptoHash,
-        endorsement_tracker: &mut ChunkEndorsementTracker,
+        endorsement_tracker: &ChunkEndorsementTracker,
     ) -> Result<(), Error> {
         let Some(entry) = self.prev_block_to_chunk_hash_ready.get(prev_block_hash) else {
             return Ok(());

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -121,7 +121,7 @@ pub struct StartClientResult {
     pub client_arbiter_handle: actix::ArbiterHandle,
     pub resharding_handle: ReshardingHandle,
     pub tx_pool: Arc<Mutex<ShardedTransactionPool>>,
-    pub chunk_endorsement_tracker: Arc<Mutex<ChunkEndorsementTracker>>,
+    pub chunk_endorsement_tracker: Arc<ChunkEndorsementTracker>,
 }
 
 /// Starts client in a separate Arbiter (thread).
@@ -1105,10 +1105,10 @@ impl ClientActorInner {
             }
 
             {
-                let mut tracker = self.client.chunk_endorsement_tracker.lock();
-                self.client
-                    .chunk_inclusion_tracker
-                    .prepare_chunk_headers_ready_for_inclusion(prev_block_hash, &mut tracker)?;
+                self.client.chunk_inclusion_tracker.prepare_chunk_headers_ready_for_inclusion(
+                    prev_block_hash,
+                    &self.client.chunk_endorsement_tracker,
+                )?;
             }
             let num_chunks = self
                 .client

--- a/chain/client/src/rpc_handler.rs
+++ b/chain/client/src/rpc_handler.rs
@@ -46,8 +46,7 @@ impl Handler<ProcessTxRequest> for RpcHandler {
 impl Handler<ChunkEndorsementMessage> for RpcHandler {
     #[perf]
     fn handle(&mut self, msg: ChunkEndorsementMessage) {
-        let mut tracker = self.chunk_endorsement_tracker.lock();
-        if let Err(err) = tracker.process_chunk_endorsement(msg.0) {
+        if let Err(err) = self.chunk_endorsement_tracker.process_chunk_endorsement(msg.0) {
             tracing::error!(target: "client", ?err, "Error processing chunk endorsement");
         }
     }
@@ -58,7 +57,7 @@ impl messaging::Actor for RpcHandler {}
 pub fn spawn_rpc_handler_actor(
     config: RpcHandlerConfig,
     tx_pool: Arc<Mutex<ShardedTransactionPool>>,
-    chunk_endorsement_tracker: Arc<Mutex<ChunkEndorsementTracker>>,
+    chunk_endorsement_tracker: Arc<ChunkEndorsementTracker>,
     epoch_manager: Arc<dyn EpochManagerAdapter>,
     shard_tracker: ShardTracker,
     validator_signer: MutableValidatorSigner,
@@ -95,7 +94,7 @@ pub struct RpcHandler {
     config: RpcHandlerConfig,
 
     tx_pool: Arc<Mutex<ShardedTransactionPool>>,
-    chunk_endorsement_tracker: Arc<Mutex<ChunkEndorsementTracker>>,
+    chunk_endorsement_tracker: Arc<ChunkEndorsementTracker>,
 
     chain_store: ChainStoreAdapter,
     epoch_manager: Arc<dyn EpochManagerAdapter>,
@@ -109,7 +108,7 @@ impl RpcHandler {
     pub fn new(
         config: RpcHandlerConfig,
         tx_pool: Arc<Mutex<ShardedTransactionPool>>,
-        chunk_endorsement_tracker: Arc<Mutex<ChunkEndorsementTracker>>,
+        chunk_endorsement_tracker: Arc<ChunkEndorsementTracker>,
         epoch_manager: Arc<dyn EpochManagerAdapter>,
         shard_tracker: ShardTracker,
         validator_signer: MutableValidatorSigner,

--- a/chain/client/src/stateless_validation/state_witness_producer.rs
+++ b/chain/client/src/stateless_validation/state_witness_producer.rs
@@ -91,8 +91,7 @@ impl Client {
                 my_signer.as_ref(),
                 &self.network_adapter.clone().into_sender(),
             ) {
-                let mut tracker = self.chunk_endorsement_tracker.lock();
-                tracker.process_chunk_endorsement(endorsement)?;
+                self.chunk_endorsement_tracker.process_chunk_endorsement(endorsement)?;
             }
         }
 

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -719,7 +719,7 @@ impl ClientConfig {
             orphan_state_witness_pool_size: default_orphan_state_witness_pool_size(),
             orphan_state_witness_max_size: default_orphan_state_witness_max_size(),
             save_latest_witnesses: false,
-            transaction_request_handler_threads: 4,
+            transaction_request_handler_threads: 8,
         }
     }
 }

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -719,7 +719,7 @@ impl ClientConfig {
             orphan_state_witness_pool_size: default_orphan_state_witness_pool_size(),
             orphan_state_witness_max_size: default_orphan_state_witness_max_size(),
             save_latest_witnesses: false,
-            transaction_request_handler_threads: 8,
+            transaction_request_handler_threads: 4,
         }
     }
 }

--- a/integration-tests/src/env/test_env.rs
+++ b/integration-tests/src/env/test_env.rs
@@ -460,8 +460,7 @@ impl TestEnv {
                         tracing::warn!(target: "test", "Client not found for account_id {}", account_id);
                         return None;
                     }
-                    let mut tracker = self.client(&account_id).chunk_endorsement_tracker.lock();
-                    let processing_result = tracker.process_chunk_endorsement(endorsement);
+                    let processing_result = self.client(&account_id).chunk_endorsement_tracker.process_chunk_endorsement(endorsement);
                     if !allow_errors {
                         processing_result.unwrap();
                     }

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -2246,10 +2246,7 @@ fn test_validate_chunk_extra() {
     let client = &mut env.clients[0];
     client
         .chunk_inclusion_tracker
-        .prepare_chunk_headers_ready_for_inclusion(
-            block1.hash(),
-            &mut *client.chunk_endorsement_tracker.lock(),
-        )
+        .prepare_chunk_headers_ready_for_inclusion(block1.hash(), &client.chunk_endorsement_tracker)
         .unwrap();
     let block = client.produce_block_on(next_height + 2, *block1.hash()).unwrap().unwrap();
     let epoch_id = *block.header().epoch_id();


### PR DESCRIPTION
Removes a lock from endorsement tracker, and replaces it with a more granular lock to protect only the cache operations.

This enables to run the (expensive) endorsement validation outside the locked scope, so it can be processed in parallel.

tested: [sharded-bm](https://grafana.nearone.org/d/deg7e0doxn30gf/blockchain-performance?orgId=1&from=2025-05-07T13:30:00.000Z&to=2025-05-07T13:45:00.000Z&timezone=browser&var-chain_id=$__all&var-role=$__all&var-node_type=$__all&var-node_id=.%2Aslavas.%2A&var-shard_id=$__all&var-node_id-2=.%2Atps.%2A&refresh=10s)