### PR TITLE
Revert "runtime: parallel transaction processing (#13369)"

### DIFF
--- a/runtime/runtime/src/types.rs
+++ b/runtime/runtime/src/types.rs
@@ -1,4 +1,5 @@
 use near_primitives::transaction::SignedTransaction;
+use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 
 pub struct SignedValidPeriodTransactions {
     /// Transactions.
@@ -37,9 +38,11 @@ impl SignedValidPeriodTransactions {
             .filter_map(|(t, v)| v.then_some(t))
     }
 
-    pub fn into_iter_nonexpired_transactions(self) -> impl Iterator<Item = SignedTransaction> {
+    pub fn into_par_iter_nonexpired_transactions(
+        self,
+    ) -> impl ParallelIterator<Item = SignedTransaction> {
         self.transactions
-            .into_iter()
+            .into_par_iter()
             .zip(self.transaction_validity_check_passed)
             .filter_map(|(t, v)| v.then_some(t))
     }


### PR DESCRIPTION
This reverts commit 10f236066f276475143b5174e06eedcb673d6c49.

The reason is that #13369 has a negative impact on multi-node network performance, reducing maximum TPS by 10-15%