### PR TITLE
refactor: remove unnecessary `Arc` in various `get_chunk` 

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3448,9 +3448,7 @@ impl Chain {
         self.chain_store.get_block(&tip.last_block_hash)
     }
 
-    /// Gets a chunk from hash.
-    #[inline]
-    pub fn get_chunk(&self, chunk_hash: &ChunkHash) -> Result<Arc<ShardChunk>, Error> {
+    pub fn get_chunk(&self, chunk_hash: &ChunkHash) -> Result<ShardChunk, Error> {
         self.chain_store.get_chunk(chunk_hash)
     }
 

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -552,7 +552,7 @@ impl<'a> ChainStoreUpdate<'a> {
             let chunk_hashes = self.chain_store().get_all_chunk_hashes_by_height(height)?;
             for chunk_hash in chunk_hashes {
                 // 1. Delete chunk-related data
-                let chunk = self.get_chunk(&chunk_hash)?.clone();
+                let chunk = self.get_chunk(&chunk_hash)?;
                 debug_assert_eq!(chunk.cloned_header().height_created(), height);
                 for transaction in chunk.to_transactions() {
                     self.gc_col(DBCol::Transactions, transaction.get_hash().as_bytes());
@@ -883,7 +883,7 @@ impl<'a> ChainStoreUpdate<'a> {
         let chunk_hashes = self.chain_store().get_all_chunk_hashes_by_height(height)?;
         for chunk_hash in chunk_hashes {
             // 1. Delete chunk-related data
-            let chunk = self.get_chunk(&chunk_hash)?.clone();
+            let chunk = self.get_chunk(&chunk_hash)?;
             debug_assert_eq!(chunk.cloned_header().height_created(), height);
             for transaction in chunk.to_transactions() {
                 self.gc_col(DBCol::Transactions, transaction.get_hash().as_bytes());

--- a/chain/chunks/src/logic.rs
+++ b/chain/chunks/src/logic.rs
@@ -214,7 +214,7 @@ pub fn persist_chunk(
         update.save_partial_chunk(partial_chunk);
     }
     if let Some(shard_chunk) = shard_chunk {
-        if update.get_chunk(&shard_chunk.chunk_hash()).is_err() {
+        if !update.chunk_exists(&shard_chunk.chunk_hash())? {
             update.save_chunk(shard_chunk);
         }
     }

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -206,7 +206,7 @@ impl ChainStoreAdapter {
     }
 
     /// Get full chunk.
-    pub fn get_chunk(&self, chunk_hash: &ChunkHash) -> Result<Arc<ShardChunk>, Error> {
+    pub fn get_chunk(&self, chunk_hash: &ChunkHash) -> Result<ShardChunk, Error> {
         match self.store.get_ser(DBCol::Chunks, chunk_hash.as_ref()) {
             Ok(Some(shard_chunk)) => Ok(shard_chunk),
             _ => Err(Error::ChunkMissing(chunk_hash.clone())),

--- a/core/store/src/adapter/chunk_store.rs
+++ b/core/store/src/adapter/chunk_store.rs
@@ -33,7 +33,7 @@ impl ChunkStoreAdapter {
             .ok_or_else(|| ChunkAccessError::ChunkMissing(chunk_hash.clone()))
     }
 
-    pub fn get_chunk(&self, chunk_hash: &ChunkHash) -> Result<Arc<ShardChunk>, ChunkAccessError> {
+    pub fn get_chunk(&self, chunk_hash: &ChunkHash) -> Result<ShardChunk, ChunkAccessError> {
         self.store
             .get_ser(DBCol::Chunks, chunk_hash.as_ref())
             .expect("Borsh should not have failed here")

--- a/integration-tests/src/tests/client/invalid_txs.rs
+++ b/integration-tests/src/tests/client/invalid_txs.rs
@@ -147,7 +147,6 @@ fn test_invalid_transactions_no_panic() {
 #[test]
 #[cfg(feature = "nightly")]
 fn test_invalid_transactions_dont_invalidate_chunk() {
-    use near_chain::ChainStoreAccess as _;
     near_o11y::testonly::init_test_logger();
     let accounts =
         vec!["test0".parse().unwrap(), "test1".parse().unwrap(), "test2".parse().unwrap()];

--- a/integration-tests/src/tests/features/access_key_nonce_for_implicit_accounts.rs
+++ b/integration-tests/src/tests/features/access_key_nonce_for_implicit_accounts.rs
@@ -4,7 +4,7 @@ use crate::utils::process_blocks::produce_blocks_from_height;
 use assert_matches::assert_matches;
 use near_async::messaging::CanSend;
 use near_chain::orphan::NUM_ORPHAN_ANCESTORS_CHECK;
-use near_chain::{ChainStoreAccess as _, Error, Provenance};
+use near_chain::{Error, Provenance};
 use near_chain_configs::{Genesis, NEAR_BASE};
 use near_chunks::metrics::PARTIAL_ENCODED_CHUNK_FORWARD_CACHED_WITHOUT_HEADER;
 use near_client::test_utils::create_chunk;

--- a/integration-tests/src/tests/features/congestion_control.rs
+++ b/integration-tests/src/tests/features/congestion_control.rs
@@ -173,7 +173,7 @@ fn head_chunk_header(env: &TestEnv, shard_id: ShardId) -> ShardChunkHeader {
     chunks.get(shard_index).expect("chunk header must be available").clone()
 }
 
-fn head_chunk(env: &TestEnv, shard_id: ShardId) -> Arc<ShardChunk> {
+fn head_chunk(env: &TestEnv, shard_id: ShardId) -> ShardChunk {
     let chunk_header = head_chunk_header(&env, shard_id);
     env.clients[0].chain.get_chunk(&chunk_header.chunk_hash()).expect("chunk must be available")
 }

--- a/tools/replay-archive/src/cli.rs
+++ b/tools/replay-archive/src/cli.rs
@@ -288,7 +288,7 @@ impl ReplayController {
 
         self.validate_chunk(
             is_new_chunk,
-            chunk.as_ref(),
+            &chunk,
             chunk_header,
             prev_block_hash,
             prev_chunk_header,

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -874,7 +874,7 @@ pub(crate) fn view_genesis(
 fn read_genesis_from_store(
     chain_store: &ChainStore,
     genesis_height: u64,
-) -> Result<(Block, Vec<Arc<ShardChunk>>), Error> {
+) -> Result<(Block, Vec<ShardChunk>), Error> {
     let genesis_hash = chain_store.get_block_hash_by_height(genesis_height)?;
     let genesis_block = chain_store.get_block(&genesis_hash)?;
     let mut genesis_chunks = vec![];

--- a/tools/state-viewer/src/tx_dump.rs
+++ b/tools/state-viewer/src/tx_dump.rs
@@ -1,5 +1,4 @@
 use near_chain::ChainStore;
-use near_chain::ChainStoreAccess;
 use near_primitives::account::id::AccountId;
 use near_primitives::block::Block;
 use near_primitives::transaction::SignedTransaction;


### PR DESCRIPTION
We have many different functions called `get_chunk`.  Most of them are looking up the chunk from the DB so do not need to unnecessarily wrap the returned chunk inside an `Arc`.  This PR tidies this up.  The benefit of not unwrapping a struct in Arc is that it makes it possible to consume it without having to actually copy the data out of it.