### PR TITLE
chore: record OB hits/misses only on processing Block

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -28,8 +28,8 @@ use crate::store::{
     ChainStore, ChainStoreAccess, ChainStoreUpdate, MerkleProofAccess, ReceiptFilter,
 };
 use crate::types::{
-    AcceptedBlock, ApplyChunkBlockContext, BlockEconomicsConfig, ChainConfig, RuntimeAdapter,
-    StorageDataSource,
+    AcceptedBlock, ApplyChunkBlockContext, BlockEconomicsConfig, BlockType, ChainConfig,
+    RuntimeAdapter, StorageDataSource,
 };
 pub use crate::update_shard::{
     NewChunkData, NewChunkResult, OldChunkData, OldChunkResult, ShardContext, StorageContext,
@@ -242,20 +242,25 @@ impl ApplyChunksResultCache {
         &self,
         key: &CachedShardUpdateKey,
         shard_id: ShardId,
+        record_metric: bool,
     ) -> Option<&ShardUpdateResult> {
         let shard_id_label = shard_id.to_string();
         if let Some(result) = self.cache.peek(key) {
             self.hits.set(self.hits.get() + 1);
-            metrics::APPLY_CHUNK_RESULTS_CACHE_HITS
-                .with_label_values(&[shard_id_label.as_str()])
-                .inc();
+            if record_metric {
+                metrics::APPLY_CHUNK_RESULTS_CACHE_HITS
+                    .with_label_values(&[shard_id_label.as_str()])
+                    .inc();
+            }
             return Some(result);
         }
 
         self.misses.set(self.misses.get() + 1);
-        metrics::APPLY_CHUNK_RESULTS_CACHE_MISSES
-            .with_label_values(&[shard_id_label.as_str()])
-            .inc();
+        if record_metric {
+            metrics::APPLY_CHUNK_RESULTS_CACHE_MISSES
+                .with_label_values(&[shard_id_label.as_str()])
+                .inc();
+        }
         None
     }
 
@@ -1329,6 +1334,7 @@ impl Chain {
         for (shard_index, prev_chunk_header) in prev_chunk_headers.iter().enumerate() {
             let shard_id = shard_layout.get_shard_id(shard_index)?;
             let block_context = ApplyChunkBlockContext {
+                block_type: BlockType::Optimistic,
                 height: block_height,
                 // TODO: consider removing this field completely to avoid
                 // confusion with real block hash.
@@ -3188,9 +3194,11 @@ impl Chain {
         let is_new_chunk = chunk_header.is_new_chunk(block_height);
 
         if !cfg!(feature = "sandbox") {
-            if let Some(result) =
-                self.apply_chunk_results_cache.peek(&cached_shard_update_key, shard_id)
-            {
+            if let Some(result) = self.apply_chunk_results_cache.peek(
+                &cached_shard_update_key,
+                shard_id,
+                matches!(block.block_type, BlockType::Normal),
+            ) {
                 debug!(target: "chain", ?shard_id, ?cached_shard_update_key, "Using cached ShardUpdate result");
                 let result = result.clone();
                 return Ok(Some((

--- a/chain/chain/src/chain_update.rs
+++ b/chain/chain/src/chain_update.rs
@@ -5,7 +5,7 @@ use crate::metrics::{SHARD_LAYOUT_NUM_SHARDS, SHARD_LAYOUT_VERSION};
 use crate::store::utils::get_block_header_on_chain_by_height;
 use crate::store::{ChainStore, ChainStoreAccess, ChainStoreUpdate};
 use crate::types::{
-    ApplyChunkBlockContext, ApplyChunkResult, ApplyChunkShardContext, RuntimeAdapter,
+    ApplyChunkBlockContext, ApplyChunkResult, ApplyChunkShardContext, BlockType, RuntimeAdapter,
     RuntimeStorageConfig,
 };
 use crate::update_shard::{NewChunkResult, OldChunkResult, ShardUpdateResult};
@@ -474,6 +474,7 @@ impl<'a> ChainUpdate<'a> {
                 is_new_chunk: true,
             },
             ApplyChunkBlockContext {
+                block_type: BlockType::Normal,
                 height: chunk_header.height_included(),
                 block_hash: *block_header.hash(),
                 prev_block_hash: *chunk_header.prev_block_hash(),

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -162,6 +162,7 @@ impl NightshadeRuntime {
         state_patch: SandboxStatePatch,
     ) -> Result<ApplyChunkResult, Error> {
         let ApplyChunkBlockContext {
+            block_type: _,
             height: block_height,
             block_hash,
             ref prev_block_hash,

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::rayon_spawner::RayonAsyncComputationSpawner;
-use crate::types::{ChainConfig, RuntimeStorageConfig};
+use crate::types::{BlockType, ChainConfig, RuntimeStorageConfig};
 use crate::{Chain, ChainGenesis, ChainStoreAccess, DoomslugThresholdMode};
 use assert_matches::assert_matches;
 use near_async::messaging::{IntoMultiSender, noop};
@@ -243,6 +243,7 @@ impl TestEnv {
                     is_new_chunk: true,
                 },
                 ApplyChunkBlockContext {
+                    block_type: BlockType::Normal,
                     height,
                     block_hash: new_block_hash,
                     prev_block_hash,

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -282,7 +282,14 @@ impl RuntimeStorageConfig {
 }
 
 #[derive(Clone)]
+pub enum BlockType {
+    Normal,
+    Optimistic,
+}
+
+#[derive(Clone)]
 pub struct ApplyChunkBlockContext {
+    pub block_type: BlockType,
     pub height: BlockHeight,
     pub block_hash: CryptoHash,
     pub prev_block_hash: CryptoHash,
@@ -301,6 +308,7 @@ impl ApplyChunkBlockContext {
         bandwidth_requests: BlockBandwidthRequests,
     ) -> Self {
         Self {
+            block_type: BlockType::Normal,
             height: header.height(),
             block_hash: *header.hash(),
             prev_block_hash: *header.prev_hash(),

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, anyhow};
 use borsh::BorshDeserialize;
 use near_chain::chain::collect_receipts_from_response;
 use near_chain::types::{
-    ApplyChunkBlockContext, ApplyChunkResult, ApplyChunkShardContext, RuntimeAdapter,
+    ApplyChunkBlockContext, ApplyChunkResult, ApplyChunkShardContext, BlockType, RuntimeAdapter,
 };
 use near_chain::{ChainStore, ChainStoreAccess, ReceiptFilter, get_incoming_receipts_for_shard};
 use near_epoch_manager::shard_assignment::shard_id_to_uid;
@@ -183,6 +183,7 @@ pub fn apply_chunk(
                 is_new_chunk: true,
             },
             ApplyChunkBlockContext {
+                block_type: BlockType::Normal,
                 height: target_height,
                 block_timestamp: prev_timestamp + 1_000_000_000,
                 prev_block_hash: *prev_block_hash,


### PR DESCRIPTION
Currently we record "chunk result cache" hits and misses whenever we call `get_update_shard_job`, regardless of block type.
But it makes hits/misses metric harder to use. We care only whether chunk application was successfully skipped while processing full block, for optimistic block it will be miss anyway.

For that I introduce block type into the application block context. That's a bit excessive but solves the issue with minimal change, I think it's worth it.
As a result, for benchmark runs misses stay completely at 0, if all OBs are distributed and created perfectly. https://grafana.nearone.org/goto/LYjlJXxNR?orgId=1