### PR TITLE
make optimistic_block_receiver async

### DIFF
--- a/chain/network/src/client.rs
+++ b/chain/network/src/client.rs
@@ -162,5 +162,5 @@ pub struct ClientSenderForNetwork {
     pub chunk_endorsement: AsyncSender<ChunkEndorsementMessage, ()>,
     pub epoch_sync_request: Sender<EpochSyncRequestMessage>,
     pub epoch_sync_response: Sender<EpochSyncResponseMessage>,
-    pub optimistic_block_receiver: Sender<OptimisticBlockMessage>,
+    pub optimistic_block_receiver: AsyncSender<OptimisticBlockMessage, ()>,
 }

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1127,7 +1127,12 @@ impl PeerActor {
                 PeerMessage::OptimisticBlock(ob) => {
                     network_state
                         .client
-                        .send(OptimisticBlockMessage { from_peer: peer_id, optimistic_block: ob });
+                        .send_async(OptimisticBlockMessage {
+                            from_peer: peer_id,
+                            optimistic_block: ob,
+                        })
+                        .await
+                        .ok();
                     None
                 }
                 msg => {


### PR DESCRIPTION
This is to make handling of the OptimisticBlockMessage messages in PeerActor non-blocking