### PR TITLE
fix: make proper check before moving block to pending pool

### DIFF
--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -71,9 +71,9 @@ pub enum Error {
     /// Chunks missing with header info.
     #[error("Chunks Missing: {0:?}")]
     ChunksMissing(Vec<ShardChunkHeader>),
-    /// Optimistic block in processing.
-    #[error("Optimistic block in processing")]
-    OptimisticBlockInProcessing,
+    /// Block is pending optimistic block execution.
+    #[error("Block Pending Optimistic Execution")]
+    BlockPendingOptimisticExecution,
     /// Block time is before parent block time.
     #[error("Invalid Block Time: block time {1} before previous {0}")]
     InvalidBlockPastTime(Utc, Utc),
@@ -270,7 +270,7 @@ impl Error {
             | Error::Orphan
             | Error::ChunkMissing(_)
             | Error::ChunksMissing(_)
-            | Error::OptimisticBlockInProcessing
+            | Error::BlockPendingOptimisticExecution
             | Error::InvalidChunkHeight
             | Error::IOErr(_)
             | Error::Other(_)
@@ -351,7 +351,7 @@ impl Error {
             Error::Orphan => "orphan",
             Error::ChunkMissing(_) => "chunk_missing",
             Error::ChunksMissing(_) => "chunks_missing",
-            Error::OptimisticBlockInProcessing => "optimistic_block_in_processing",
+            Error::BlockPendingOptimisticExecution => "block_pending_optimistic_execution",
             Error::InvalidChunkHeight => "invalid_chunk_height",
             Error::IOErr(_) => "io_err",
             Error::Other(_) => "other",

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1685,7 +1685,7 @@ impl Chain {
                             "Process block: missing chunks"
                         );
                     }
-                    Error::OptimisticBlockInProcessing => {
+                    Error::BlockPendingOptimisticExecution => {
                         let block_hash = *block.hash();
                         self.blocks_delay_tracker.mark_block_pending_execution(&block_hash);
                         let orphan = Orphan { block, provenance, added: self.clock.now() };
@@ -2963,15 +2963,33 @@ impl Chain {
             || self.epoch_manager.is_chunk_producer_for_epoch(&next_epoch_id, account_id)?)
     }
 
-    /// Check if there is an optimistic block in processing corresponding to
-    /// the given block.
-    fn has_optimistic_block_in_processing(
+    /// Check if the block should be pending execution, which means waiting
+    /// for optimistic block to be applied.
+    fn should_be_pending_execution(
         &self,
         block: &Block,
         cached_shard_update_keys: &[&CachedShardUpdateKey],
     ) -> bool {
-        self.blocks_in_processing
+        // If there is no matching optimistic block in processing, return false
+        // immediately.
+        if !self
+            .blocks_in_processing
             .has_optimistic_block_with(block.header().height(), cached_shard_update_keys)
+        {
+            return false;
+        }
+
+        // If we have optimistic block in processing and there are no pending
+        // blocks at this height, this block should be pending execution.
+        if !self.blocks_pending_execution.contains_key(&block.header().height()) {
+            return true;
+        }
+
+        // If there is already a pending block at this height, check if it is
+        // the same block. Otherwise we have multiple blocks at the same
+        // height. This is malicious case. To simplify behaviour, we process
+        // the block right away.
+        self.blocks_pending_execution.contains_block_hash(&block.hash())
     }
 
     /// Creates jobs which will update shards for the given block and incoming
@@ -3022,8 +3040,8 @@ impl Chain {
         // Otherwise there could be data races where optimistic block gets
         // postprocessed in the meantime, in case of which block would never
         // leave the pending pool.
-        if self.has_optimistic_block_in_processing(&block, &cached_shard_update_keys) {
-            return Err(Error::OptimisticBlockInProcessing);
+        if self.should_be_pending_execution(&block, &cached_shard_update_keys) {
+            return Err(Error::BlockPendingOptimisticExecution);
         }
 
         for (shard_index, (block_context, cached_shard_update_key)) in

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2970,17 +2970,8 @@ impl Chain {
         block: &Block,
         cached_shard_update_keys: &[&CachedShardUpdateKey],
     ) -> bool {
-        if !self
-            .blocks_in_processing
+        self.blocks_in_processing
             .has_optimistic_block_with(block.header().height(), cached_shard_update_keys)
-        {
-            return false;
-        }
-        // If there is already a pending block with given height which matches
-        // optimistic execution, this is very unlikely case relevant to epoch
-        // switch or malicious behaviour. To avoid getting stuck, allow only
-        // one of these blocks to be pending.
-        !self.blocks_pending_execution.contains_key(&block.header().height())
     }
 
     /// Creates jobs which will update shards for the given block and incoming

--- a/chain/chain/src/pending.rs
+++ b/chain/chain/src/pending.rs
@@ -9,7 +9,7 @@ use crate::missing_chunks::BlockLike;
 
 /// Blocks that are waiting for optimistic block to be applied.
 pub struct PendingBlocksPool<Block: BlockLike> {
-    /// Maps block height to block.
+    /// Maps block height to the pending block.
     /// For simplicity, store only one block per height. If there are more, it
     /// is the malicious case and we process such blocks without passing
     /// through this pool.

--- a/chain/chain/src/pending.rs
+++ b/chain/chain/src/pending.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{HashMap, HashSet};
 
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::BlockHeight;
@@ -13,14 +13,14 @@ pub struct PendingBlocksPool<Block: BlockLike> {
     /// For simplicity, store only one block per height. If there are more, it
     /// is the malicious case and we process such blocks without passing
     /// through this pool.
-    blocks: BTreeMap<BlockHeight, Block>,
+    blocks: HashMap<BlockHeight, Block>,
     /// Block hashes that are in the pending blocks pool.
     block_hashes: HashSet<CryptoHash>,
 }
 
 impl<Block: BlockLike> PendingBlocksPool<Block> {
     pub fn new() -> Self {
-        Self { blocks: BTreeMap::new(), block_hashes: HashSet::new() }
+        Self { blocks: HashMap::new(), block_hashes: HashSet::new() }
     }
 
     pub fn add_block(&mut self, block: Block) {

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -371,7 +371,7 @@ fn test_pending_block() {
 /// execution excessive in the regular flow.
 /// * If we receive the a different block with the same height, it is a
 /// malicious behaviour. We must process all these blocks anyway, because we
-/// don't know which one gets finalised. To simplify optimistic logic, we
+/// don't know which one gets finalized. To simplify optimistic logic, we
 /// skip pending pool and process block right away.
 #[cfg(feature = "test_features")]
 #[test]

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -342,7 +342,7 @@ fn test_pending_block() {
     };
 
     // Block must be rejected due to optimistic block in processing
-    assert_matches!(err, Error::OptimisticBlockInProcessing);
+    assert_matches!(err, Error::BlockPendingOptimisticExecution);
 
     // Verify the block is in the pending pool
     assert!(chain.blocks_pending_execution.contains_key(&block2.header().height()));
@@ -365,14 +365,19 @@ fn test_pending_block() {
     assert_eq!(chain.head().unwrap().height, 2);
 }
 
-/// Check that if chain receives two blocks which matches the same optimistic block,
-/// the first one gets pending but the second one gets processed, as this is likely
-/// malicious behaviour and processing blocks is a higher priority than apply chunk
-/// optimizations.
-/// We use two copies of the same block here.
+/// Check chain behaviour on processing blocks on same height:
+/// * If we receive the same block twice and it matches the optimistic block,
+/// it should be marked as pending both times, in order not to trigger chunk
+/// execution excessive in the regular flow.
+/// * If we receive the a different block with the same height, it is a
+/// malicious behaviour. We must process all these blocks anyway, because we
+/// don't know which one gets finalised. To simplify optimistic logic, we
+/// skip pending pool and process block right away.
 #[cfg(feature = "test_features")]
 #[test]
-fn test_pending_block_twice() {
+fn test_pending_block_same_height() {
+    use near_crypto::{KeyType, Signature};
+
     init_test_logger();
     let clock = Clock::real();
     let (mut chain, _, _, signer) = setup(clock.clone());
@@ -386,6 +391,17 @@ fn test_pending_block_twice() {
     // Create block 2 and its copy
     let block2 = TestBlockBuilder::new(clock, &block1, signer.clone()).build();
     let block2a = block2.clone();
+
+    // Create copy of block 2 with different hash.
+    // The content still matches the optimistic execution, but the hash is
+    // different.
+    // Approvals can be set arbitrarily because we process blocks in
+    // Provenance::PRODUCED mode.
+    let mut block2b = block2.clone();
+    let some_signature = Signature::from_parts(KeyType::ED25519, &[1; 64]).unwrap();
+    block2b.mut_header().set_approvals(vec![Some(Box::new(some_signature))]);
+    block2b.mut_header().resign(&*signer);
+    assert!(block2a.hash() != block2b.hash());
 
     // Create an optimistic block at height 2
     let optimistic_block = OptimisticBlock::adv_produce(
@@ -413,10 +429,14 @@ fn test_pending_block_twice() {
     let Err(err) = &result_a else {
         panic!("Block processing should not succeed");
     };
-    assert_matches!(err, Error::OptimisticBlockInProcessing);
+    assert_matches!(err, Error::BlockPendingOptimisticExecution);
 
-    // Check that processing the second copy is successful.
+    // Check that the copy is also marked as pending.
     let result_b = chain.process_block_test(&me, block2a);
+    assert_matches!(result_b, Err(Error::BlockPendingOptimisticExecution));
+
+    // Check that the copy with different hash is processed.
+    let result_b = chain.process_block_test(&me, block2b);
     assert_matches!(result_b, Ok(_));
     assert_eq!(chain.head().unwrap().height, 2);
 }


### PR DESCRIPTION
There is a tricky case of multiple blocks at the same height. Initially I solved it in the way - if there is already some pending block, just process all other blocks directly, as it is malicious case and we should treat it as simple as possible.

However, there is a case when a node receives the same block multiple times. Then the second copy of the block got always executed right away, negating the optimisation. Moreover, it always happened for the block producer of the block itself, because it redirected the block to itself from the network layer. Some reference: https://grafana.nearone.org/goto/FfChEuxHR?orgId=1

To solve this "multiple copy" issue, I also expose block hash from the pending block pool. If it is already there, every copy should be pending as well (and it won't be inserted multiple times). Blocks with different hashes will still ignore the optimisation, but as I said, it is very irregular case.

Adjusting some method names and tests to reflect that.