### PR TITLE
fix(network): Enable TCP_NODELAY on all peer connections

### DIFF
--- a/chain/network/src/tcp.rs
+++ b/chain/network/src/tcp.rs
@@ -85,7 +85,9 @@ impl Socket {
 
 impl Stream {
     fn new(stream: tokio::net::TcpStream, type_: StreamType) -> std::io::Result<Self> {
-        stream.set_nodelay(true)?;
+        if let Err(err) = stream.set_nodelay(true) {
+            tracing::warn!(target: "network", "Failed to set TCP_NODELAY: {}", err);
+        }
         Ok(Self { peer_addr: stream.peer_addr()?, local_addr: stream.local_addr()?, stream, type_ })
     }
 

--- a/chain/network/src/tcp.rs
+++ b/chain/network/src/tcp.rs
@@ -85,6 +85,7 @@ impl Socket {
 
 impl Stream {
     fn new(stream: tokio::net::TcpStream, type_: StreamType) -> std::io::Result<Self> {
+        stream.set_nodelay(true)?;
         Ok(Self { peer_addr: stream.peer_addr()?, local_addr: stream.local_addr()?, stream, type_ })
     }
 

--- a/cspell.json
+++ b/cspell.json
@@ -415,7 +415,9 @@
         "zadd",
         "zstd",
         "Zulip",
-        "zulipchat"
+        "zulipchat",
+        "nodelay",
+        "NODELAY",
     ],
     "ignoreWords": [
         "euxo",


### PR DESCRIPTION
Enable TCP_NODELAY to reduce the latency of sending network messages to other peers.
Helps deliver endorsements faster and increases validator's endorsement rate.