### PR TITLE
2.6.2: Don't crash when nodelay is not supported

### DIFF
--- a/chain/network/src/tcp.rs
+++ b/chain/network/src/tcp.rs
@@ -85,7 +85,9 @@ impl Socket {
 
 impl Stream {
     fn new(stream: tokio::net::TcpStream, type_: StreamType) -> std::io::Result<Self> {
-        stream.set_nodelay(true)?;
+        if let Err(err) = stream.set_nodelay(true) {
+            tracing::warn!(target: "network", "Failed to set TCP_NODELAY: {}", err);
+        }
         Ok(Self { peer_addr: stream.peer_addr()?, local_addr: stream.local_addr()?, stream, type_ })
     }
 


### PR DESCRIPTION
Make the code more resilient - don't crash if set_nodelay returns an error