### PR TITLE
chore: reduce log level of pending pool

### DIFF
--- a/chain/chain/src/pending.rs
+++ b/chain/chain/src/pending.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::BlockHeight;
-use tracing::warn;
+use tracing::debug;
 
 use crate::metrics;
 use crate::missing_chunks::BlockLike;
@@ -26,7 +26,7 @@ impl<Block: BlockLike> PendingBlocksPool<Block> {
     pub fn add_block(&mut self, block: Block) {
         let height = block.height();
         if self.blocks.contains_key(&height) {
-            warn!(target: "chain", "Block {:?} already exists in pending blocks pool", block.hash());
+            debug!(target: "chain", "Block {:?} already exists in pending blocks pool", block.hash());
             return;
         }
         self.block_hashes.insert(block.hash());


### PR DESCRIPTION
It is too spammy and it is unfortunately standard behaviour because block producer seems to attempt processing its own block many times while waiting for optimistic block to be produced. I don't see performance issues with it, but log level must be reduced at least.

Some more context #13509

Actually, that's how it looks like for every node in forknet. It doesn't bring immediate issues, but it is also not something I expected. Every attempt to process block took 60ms here (I have 3s blocks here though) and they don't stop. For sequential chain client doesn't have any meaningful work to do anyway, but what about forks...
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/f72dd961-19cb-4324-b5fb-cd751f848b70" />
