### PR TITLE
feat(sharded-bm): check for tx_generator feature

### DIFF
--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -61,6 +61,7 @@ anyhow.workspace = true
 rustc_version = "0.4"
 
 [features]
+tx_generator = ["nearcore/tx_generator"]
 default = ["json_rpc", "rosetta_rpc"]
 
 performance_stats = ["nearcore/performance_stats"]


### PR DESCRIPTION
There were couple feedbacks that it is easy to miss building neard with `tx_generator` feature.
This is a suggestion to fix it.

First, we have a build script which prints out list of Cargo features in the binary:
```
./neard --version
neard (release trunk) (build 1.36.1-2088-g05bd30882) (commit 05bd30882b00b41b3162c4b71d50cec8b37bfb90) (rustc 1.86.0) (min_protocol 75) (protocol 78) (db 45)
features: [default, json_rpc, rosetta_rpc, tx_generator]
```

However, for `tx_generator` to be included, it must be a `neard` feature. Adding it to its Cargo.toml; now the build command should look like `cargo build -p neard --features tx_generator`.

Second, we need to check downloaded binary version on all the nodes. I didn't find anything better than grepping `--version` output. If at least one node doesn't have tx_generator substring, script won't continue. But the launch should look like

```
./bench.sh init && \
./bench.sh start-nodes && \
sleep 10 && \
./bench.sh create-accounts && \
./bench.sh native-transfers
```

cc @miloserdow 