### PR TITLE
nit: refactor: remove a bunch of `extern crate`

### DIFF
--- a/core/o11y/benches/metrics.rs
+++ b/core/o11y/benches/metrics.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate bencher;
-
-use bencher::Bencher;
+use bencher::{Bencher, benchmark_group, benchmark_main};
 use near_o11y::metrics::{IntCounter, IntCounterVec, try_create_int_counter_vec};
 use std::sync::LazyLock;
 

--- a/core/primitives/benches/serialization.rs
+++ b/core/primitives/benches/serialization.rs
@@ -1,8 +1,4 @@
-#[macro_use]
-extern crate bencher;
-
-use bencher::{Bencher, black_box};
-
+use bencher::{Bencher, benchmark_group, benchmark_main, black_box};
 use borsh::BorshDeserialize;
 use near_crypto::{KeyType, PublicKey, Signature};
 use near_primitives::account::Account;

--- a/core/store/benches/finalize_bench.rs
+++ b/core/store/benches/finalize_bench.rs
@@ -11,10 +11,7 @@
 //! `PartialEncodedChunk`. These have been observed to become quite large and
 //! have ab impact on the overall client performance.
 
-#[macro_use]
-extern crate bencher;
-
-use bencher::{Bencher, black_box};
+use bencher::{Bencher, benchmark_group, benchmark_main, black_box};
 use borsh::BorshSerialize;
 use near_chain::Chain;
 use near_crypto::{InMemorySigner, KeyType};

--- a/core/store/benches/store_bench.rs
+++ b/core/store/benches/store_bench.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate bencher;
-
-use bencher::{Bencher, black_box};
+use bencher::{Bencher, benchmark_group, benchmark_main, black_box};
 use near_primitives::errors::StorageError;
 use near_store::{DBCol, NodeStorage, Store};
 use std::time::{Duration, Instant};

--- a/core/store/benches/trie_bench.rs
+++ b/core/store/benches/trie_bench.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate bencher;
-
-use bencher::Bencher;
+use bencher::{Bencher, benchmark_group, benchmark_main};
 use near_primitives::shard_layout::ShardUId;
 use near_store::Trie;
 use near_store::test_utils::TestTriesBuilder;

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -1,7 +1,5 @@
 #![cfg_attr(enable_const_type_id, feature(const_type_id))]
 
-extern crate core;
-
 pub use crate::columns::DBCol;
 pub use crate::config::{Mode, StoreConfig};
 pub use crate::db::{

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate bencher;
-
-use bencher::Bencher;
+use bencher::{Bencher, benchmark_group, benchmark_main};
 use near_chain::{ChainStore, ChainStoreAccess, types::RuntimeAdapter};
 use near_chain_configs::GenesisValidationMode;
 use near_epoch_manager::EpochManager;

--- a/utils/near-cache/benches/cache.rs
+++ b/utils/near-cache/benches/cache.rs
@@ -1,11 +1,7 @@
-#[macro_use]
-extern crate bencher;
-
-use std::num::NonZeroUsize;
-
-use bencher::Bencher;
+use bencher::{Bencher, benchmark_group, benchmark_main};
 use lru::LruCache;
 use near_cache::SyncLruCache;
+use std::num::NonZeroUsize;
 
 fn bench_lru(bench: &mut Bencher) {
     bench.iter(|| {

--- a/utils/near-performance-metrics-macros/src/lib.rs
+++ b/utils/near-performance-metrics-macros/src/lib.rs
@@ -1,6 +1,3 @@
-extern crate proc_macro;
-extern crate syn;
-
 use proc_macro::TokenStream;
 use quote::quote;
 


### PR DESCRIPTION
replaces with `use ...`.

Just bugged me every time I saw the outdated `extern crate` being used.