### PR TITLE
refactor: `NewChunkData` can use `SignedValidPeriodTransactions` instead of passing components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4956,6 +4956,7 @@ dependencies = [
  "near-primitives-core",
  "near-store",
  "nearcore",
+ "node-runtime",
  "parking_lot 0.12.1",
  "state-viewer",
  "tracing",

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -92,6 +92,7 @@ use near_primitives::views::{
 use near_store::adapter::chain_store::ChainStoreAdapter;
 use near_store::get_genesis_state_roots;
 use near_store::{DBCol, StateSnapshotConfig};
+use node_runtime::SignedValidPeriodTransactions;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::cell::Cell;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -3266,11 +3267,12 @@ impl Chain {
             )?;
             let old_receipts = collect_receipts_from_response(&old_receipts);
             let receipts = [new_receipts, old_receipts].concat();
+            let transactions =
+                SignedValidPeriodTransactions::new(chunk.into_transactions(), tx_valid_list);
 
             ShardUpdateReason::NewChunk(NewChunkData {
                 chunk_header: chunk_header.clone(),
-                transactions: chunk.into_transactions(),
-                transaction_validity_check_results: tx_valid_list,
+                transactions,
                 receipts,
                 block,
                 storage_context,

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -34,6 +34,7 @@ use near_primitives::version::ProtocolFeature;
 use near_store::flat::BlockInfo;
 use near_store::trie::ops::resharding::RetainMode;
 use near_store::{PartialStorage, Trie};
+use node_runtime::SignedValidPeriodTransactions;
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
@@ -371,10 +372,13 @@ pub fn pre_validate_chunk_state_witness(
             shard_id: last_chunk_shard_id,
         }
     } else {
+        let transactions = SignedValidPeriodTransactions::new(
+            state_witness.transactions().clone(),
+            transaction_validity_check_results,
+        );
         MainTransition::NewChunk(NewChunkData {
             chunk_header: last_chunk_block.chunks().get(last_chunk_shard_index).unwrap().clone(),
-            transactions: state_witness.transactions().clone(),
-            transaction_validity_check_results,
+            transactions,
             receipts: receipts_to_apply,
             block: Chain::get_apply_chunk_block_context(
                 last_chunk_block,

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -10,7 +10,6 @@ use near_primitives::receipt::Receipt;
 use near_primitives::sandbox::state_patch::SandboxStatePatch;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::sharding::ShardChunkHeader;
-use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::Gas;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use node_runtime::SignedValidPeriodTransactions;
@@ -43,8 +42,7 @@ pub enum ShardUpdateResult {
 
 pub struct NewChunkData {
     pub chunk_header: ShardChunkHeader,
-    pub transactions: Vec<SignedTransaction>,
-    pub transaction_validity_check_results: Vec<bool>,
+    pub transactions: SignedValidPeriodTransactions,
     pub receipts: Vec<Receipt>,
     pub block: ApplyChunkBlockContext,
     pub storage_context: StorageContext,
@@ -118,14 +116,7 @@ pub fn apply_new_chunk(
     shard_context: ShardContext,
     runtime: &dyn RuntimeAdapter,
 ) -> Result<NewChunkResult, Error> {
-    let NewChunkData {
-        chunk_header,
-        transactions,
-        transaction_validity_check_results,
-        block,
-        receipts,
-        storage_context,
-    } = data;
+    let NewChunkData { chunk_header, transactions, block, receipts, storage_context } = data;
     let shard_id = shard_context.shard_uid.shard_id();
     let _span = tracing::debug_span!(
         target: "chain",
@@ -154,7 +145,7 @@ pub fn apply_new_chunk(
         },
         block,
         &receipts,
-        SignedValidPeriodTransactions::new(transactions, transaction_validity_check_results),
+        transactions,
     ) {
         Ok(apply_result) => {
             Ok(NewChunkResult { gas_limit, shard_uid: shard_context.shard_uid, apply_result })

--- a/tools/replay-archive/Cargo.toml
+++ b/tools/replay-archive/Cargo.toml
@@ -18,6 +18,7 @@ itertools.workspace = true
 parking_lot.workspace = true
 
 near-chain.workspace = true
+node-runtime.workspace = true
 near-chunks.workspace = true
 near-primitives.workspace = true
 near-primitives-core.workspace = true

--- a/tools/replay-archive/src/cli.rs
+++ b/tools/replay-archive/src/cli.rs
@@ -316,6 +316,7 @@ impl ReplayController {
 
             let transactions = SignedValidPeriodTransactions::new(
                 chunk.to_transactions().to_vec(),
+                // FIXME: see the `validate_chunk` thing above.
                 vec![true; chunk.to_transactions().len()],
             );
             ShardUpdateReason::NewChunk(NewChunkData {

--- a/tools/replay-archive/src/cli.rs
+++ b/tools/replay-archive/src/cli.rs
@@ -30,6 +30,7 @@ use near_primitives::types::{BlockHeight, Gas, ShardId};
 use near_state_viewer::progress_reporter::ProgressReporter;
 use near_store::{ShardUId, Store, get_genesis_state_roots};
 use nearcore::{NearConfig, NightshadeRuntime, NightshadeRuntimeExt, load_config};
+use node_runtime::SignedValidPeriodTransactions;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
@@ -313,11 +314,13 @@ impl ReplayController {
                 prev_chunk_header.height_included(),
             )?;
 
+            let transactions = SignedValidPeriodTransactions::new(
+                chunk.to_transactions().to_vec(),
+                vec![true; chunk.to_transactions().len()],
+            );
             ShardUpdateReason::NewChunk(NewChunkData {
                 chunk_header: chunk_header.clone(),
-                transactions: chunk.to_transactions().to_vec(),
-                // FIXME: see the `validate_chunk` thing above.
-                transaction_validity_check_results: vec![true; chunk.to_transactions().len()],
+                transactions,
                 receipts,
                 block: block_context,
                 storage_context,


### PR DESCRIPTION
Simplifies code a bit