### PR TITLE
[cleanup] Remove reference of simple_v1 ShardLayout

### DIFF
--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -405,15 +405,6 @@ impl ShardLayout {
         })
     }
 
-    /// Test-only helper to create a simple multi-shard ShardLayout with the provided boundaries.
-    /// The shard ids are deterministic but arbitrary in order to test the non-contiguous ShardIds.
-    #[cfg(all(feature = "test_utils", feature = "rand"))]
-    pub fn simple_v1(boundary_accounts: &[&str]) -> ShardLayout {
-        // TODO these test methods should go into a different namespace
-        let boundary_accounts = boundary_accounts.iter().map(|a| a.parse().unwrap()).collect();
-        Self::multi_shard_custom(boundary_accounts, 1)
-    }
-
     /// Return a V0 ShardLayout
     #[deprecated(note = "Use multi_shard() instead")]
     pub fn v0(num_shards: NumShards, version: ShardVersion) -> Self {

--- a/integration-tests/src/tests/features/in_memory_tries.rs
+++ b/integration-tests/src/tests/features/in_memory_tries.rs
@@ -35,7 +35,9 @@ fn slow_test_in_memory_trie_node_consistency() {
     let mut clock = FakeClock::new(Utc::UNIX_EPOCH);
 
     let epoch_length = 9000;
-    let shard_layout = ShardLayout::simple_v1(&["account3", "account5", "account7"]);
+    let boundary_accounts =
+        ["account3", "account5", "account7"].iter().map(|a| a.parse().unwrap()).collect();
+    let shard_layout = ShardLayout::multi_shard_custom(boundary_accounts, 1);
     let validators_spec = ValidatorsSpec::desired_roles(&["account0", "account1"], &[]);
 
     let genesis = TestGenesisBuilder::new()
@@ -408,7 +410,9 @@ fn test_in_memory_trie_consistency_with_state_sync_base_case(track_all_shards: b
 
     let mut clock = FakeClock::new(Utc::UNIX_EPOCH);
 
-    let shard_layout = ShardLayout::simple_v1(&["account3", "account5", "account7"]);
+    let boundary_accounts =
+        ["account3", "account5", "account7"].iter().map(|a| a.parse().unwrap()).collect();
+    let shard_layout = ShardLayout::multi_shard_custom(boundary_accounts, 1);
     let validators_spec = ValidatorsSpec::desired_roles(
         &accounts[0..NUM_VALIDATORS].iter().map(|a| a.as_str()).collect::<Vec<_>>(),
         &[],

--- a/test-loop-tests/src/examples/multinode.rs
+++ b/test-loop-tests/src/examples/multinode.rs
@@ -23,7 +23,9 @@ fn slow_test_client_with_multi_test_loop() {
     let clients = accounts.iter().take(NUM_CLIENTS).cloned().collect_vec();
 
     let epoch_length = 10;
-    let shard_layout = ShardLayout::simple_v1(&["account3", "account5", "account7"]);
+    let boundary_accounts =
+        ["account3", "account5", "account7"].iter().map(|&a| a.parse().unwrap()).collect();
+    let shard_layout = ShardLayout::multi_shard_custom(boundary_accounts, 1);
     let validators_spec =
         ValidatorsSpec::desired_roles(&clients.iter().map(|t| t.as_str()).collect_vec(), &[]);
     let genesis = TestLoopBuilder::new_genesis_builder()

--- a/test-loop-tests/src/examples/simple.rs
+++ b/test-loop-tests/src/examples/simple.rs
@@ -49,11 +49,14 @@ fn test_client_with_simple_test_loop() {
     let accounts =
         (0..100).map(|i| format!("account{}", i).parse().unwrap()).collect::<Vec<AccountId>>();
 
+    let boundary_accounts =
+        ["account3", "account5", "account7"].iter().map(|&a| a.parse().unwrap()).collect();
+
     let genesis = TestGenesisBuilder::new()
         .genesis_time_from_clock(&test_loop.clock())
         .protocol_version(PROTOCOL_VERSION)
         .genesis_height(10000)
-        .shard_layout(ShardLayout::simple_v1(&["account3", "account5", "account7"]))
+        .shard_layout(ShardLayout::multi_shard_custom(boundary_accounts, 1))
         .transaction_validity_period(1000)
         .epoch_length(10)
         .validators_spec(ValidatorsSpec::desired_roles(&["account0"], &[]))

--- a/test-loop-tests/src/tests/chunk_validator_kickout.rs
+++ b/test-loop-tests/src/tests/chunk_validator_kickout.rs
@@ -61,7 +61,9 @@ fn run_test_chunk_validator_kickout(accounts: Vec<AccountId>, test_case: TestCas
             None
         };
 
-    let shard_layout = ShardLayout::simple_v1(&["account2", "account4", "account6"]);
+    let boundary_accounts =
+        ["account2", "account4", "account6"].iter().map(|&a| a.parse().unwrap()).collect();
+    let shard_layout = ShardLayout::multi_shard_custom(boundary_accounts, 1);
     let validators_spec =
         ValidatorsSpec::desired_roles(block_and_chunk_producers, chunk_validators_only);
 

--- a/test-loop-tests/src/tests/congestion_control.rs
+++ b/test-loop-tests/src/tests/congestion_control.rs
@@ -74,7 +74,9 @@ fn setup(accounts: &Vec<AccountId>) -> (TestLoopEnv, AccountId) {
     let [rpc_id] = rpcs else { panic!("Expected exactly one rpc node") };
 
     let epoch_length = 10;
-    let shard_layout = ShardLayout::simple_v1(&["account3", "account5", "account7"]);
+    let boundary_accounts =
+        ["account3", "account5", "account7"].iter().map(|a| a.parse().unwrap()).collect();
+    let shard_layout = ShardLayout::multi_shard_custom(boundary_accounts, 1);
     let validators_spec = ValidatorsSpec::desired_roles(&producers, &validators);
 
     let genesis = TestLoopBuilder::new_genesis_builder()

--- a/test-loop-tests/src/tests/congestion_control_genesis_bootstrap.rs
+++ b/test-loop-tests/src/tests/congestion_control_genesis_bootstrap.rs
@@ -25,7 +25,9 @@ fn test_congestion_control_genesis_bootstrap() {
     let clients: Vec<AccountId> = accounts.iter().map(|account| account.parse().unwrap()).collect();
 
     let epoch_length = 100;
-    let shard_layout = ShardLayout::simple_v1(&["account3", "account5", "account7"]);
+    let boundary_accounts =
+        ["account3", "account5", "account7"].iter().map(|a| a.parse().unwrap()).collect();
+    let shard_layout = ShardLayout::multi_shard_custom(boundary_accounts, 1);
     let validators_spec = ValidatorsSpec::desired_roles(&accounts[0..1], &accounts[1..2]);
 
     let genesis = TestLoopBuilder::new_genesis_builder()

--- a/test-loop-tests/src/tests/contract_distribution_cross_shard.rs
+++ b/test-loop-tests/src/tests/contract_distribution_cross_shard.rs
@@ -83,7 +83,8 @@ fn setup(accounts: &Vec<AccountId>) -> (TestLoopEnv, AccountId) {
     let clients = accounts.iter().take(NUM_VALIDATORS + NUM_RPC).cloned().collect_vec();
     let rpc_id = accounts[NUM_VALIDATORS].clone();
 
-    let shard_layout = ShardLayout::simple_v1(&["account4"]);
+    let boundary_accounts = ["account4"].iter().map(|a| a.parse().unwrap()).collect();
+    let shard_layout = ShardLayout::multi_shard_custom(boundary_accounts, 1);
     let validators_spec =
         ValidatorsSpec::desired_roles(&block_and_chunk_producers, &chunk_validators_only);
 

--- a/test-loop-tests/src/tests/epoch_sync.rs
+++ b/test-loop-tests/src/tests/epoch_sync.rs
@@ -28,7 +28,9 @@ fn setup_initial_blockchain(transaction_validity_period: BlockHeightDelta) -> Te
     let clients = accounts.iter().take(NUM_CLIENTS).cloned().collect_vec();
 
     let epoch_length = 10;
-    let shard_layout = ShardLayout::simple_v1(&["account3", "account5", "account7"]);
+    let boundary_accounts =
+        ["account3", "account5", "account7"].iter().map(|&a| a.parse().unwrap()).collect();
+    let shard_layout = ShardLayout::multi_shard_custom(boundary_accounts, 1);
     let validators_spec =
         ValidatorsSpec::desired_roles(&clients.iter().map(|t| t.as_str()).collect_vec(), &[]);
 

--- a/test-loop-tests/src/tests/global_contracts.rs
+++ b/test-loop-tests/src/tests/global_contracts.rs
@@ -192,7 +192,8 @@ impl GlobalContractsTestEnv {
         let [account_shard_0, account_shard_1, deploy_account, rpc] =
             ["account0", "account2", "account", "rpc"].map(|acc| acc.parse::<AccountId>().unwrap());
 
-        let shard_layout = ShardLayout::simple_v1(&["account1"]);
+        let boundary_accounts = ["account1"].iter().map(|&a| a.parse().unwrap()).collect();
+        let shard_layout = ShardLayout::multi_shard_custom(boundary_accounts, 1);
         let block_and_chunk_producers = ["cp0", "cp1"];
         let chunk_validators_only = ["cv0", "cv1"];
         let validators_spec =

--- a/test-loop-tests/src/tests/in_memory_tries.rs
+++ b/test-loop-tests/src/tests/in_memory_tries.rs
@@ -27,7 +27,8 @@ fn test_load_memtrie_after_empty_chunks() {
     let num_clients = 2;
     let epoch_length = 5;
     // Set 2 shards, first of which doesn't have any validators.
-    let shard_layout = ShardLayout::simple_v1(&["account1"]);
+    let boundary_accounts = ["account1"].iter().map(|a| a.parse().unwrap()).collect();
+    let shard_layout = ShardLayout::multi_shard_custom(boundary_accounts, 1);
     let accounts = (num_accounts - num_clients..num_accounts)
         .map(|i| format!("account{}", i).parse().unwrap())
         .collect::<Vec<AccountId>>();

--- a/test-loop-tests/src/tests/malicious_chunk_producer.rs
+++ b/test-loop-tests/src/tests/malicious_chunk_producer.rs
@@ -26,7 +26,7 @@ fn test_producer_with_expired_transactions() {
     let validators_spec = ValidatorsSpec::desired_roles(&[chunk_producer], &validators);
     let genesis = TestLoopBuilder::new_genesis_builder()
         .epoch_length(10)
-        .shard_layout(ShardLayout::simple_v1(&[]))
+        .shard_layout(ShardLayout::multi_shard_custom(vec![], 1))
         .validators_spec(validators_spec)
         .add_user_accounts_simple(&accounts, 1_000_000 * ONE_NEAR)
         .genesis_height(10000)

--- a/test-loop-tests/src/tests/multinode_stateless_validators.rs
+++ b/test-loop-tests/src/tests/multinode_stateless_validators.rs
@@ -41,7 +41,9 @@ fn slow_test_stateless_validators_with_multi_test_loop() {
         .collect_vec();
     let clients = accounts.iter().take(NUM_VALIDATORS).cloned().collect_vec();
 
-    let shard_layout = ShardLayout::simple_v1(&["account3", "account5", "account7"]);
+    let boundary_accounts =
+        ["account3", "account5", "account7"].iter().map(|a| a.parse().unwrap()).collect();
+    let shard_layout = ShardLayout::multi_shard_custom(boundary_accounts, 1);
     let validators_spec =
         ValidatorsSpec::desired_roles(&block_and_chunk_producers, &chunk_validators_only);
     let genesis = TestLoopBuilder::new_genesis_builder()

--- a/test-loop-tests/src/tests/state_sync.rs
+++ b/test-loop-tests/src/tests/state_sync.rs
@@ -33,11 +33,11 @@ const GENESIS_HEIGHT: BlockHeight = 10000;
 
 const EPOCH_LENGTH: BlockHeightDelta = 10;
 
-fn get_boundary_accounts(num_shards: usize) -> Vec<String> {
+fn get_boundary_accounts(num_shards: usize) -> Vec<AccountId> {
     if num_shards > 27 {
         todo!("don't know how to include more than 27 shards yet!");
     }
-    let mut boundary_accounts = Vec::<String>::new();
+    let mut boundary_accounts = Vec::<AccountId>::new();
     for c in b'a'..=b'z' {
         if boundary_accounts.len() + 1 >= num_shards {
             break;
@@ -46,22 +46,22 @@ fn get_boundary_accounts(num_shards: usize) -> Vec<String> {
         while boundary_account.len() < AccountId::MIN_LEN {
             boundary_account.push('0');
         }
-        boundary_accounts.push(boundary_account);
+        boundary_accounts.push(boundary_account.parse().unwrap());
     }
     boundary_accounts
 }
 
-fn generate_accounts(boundary_accounts: &[String]) -> Vec<Vec<(AccountId, Nonce)>> {
+fn generate_accounts(boundary_accounts: &[AccountId]) -> Vec<Vec<(AccountId, Nonce)>> {
     let accounts_per_shard = 5;
     let mut accounts = Vec::new();
     let mut account_base = "0";
-    for a in boundary_accounts {
+    for account in boundary_accounts {
         accounts.push(
             (0..accounts_per_shard)
                 .map(|i| (format!("{}{}", account_base, i).parse().unwrap(), 1))
                 .collect::<Vec<_>>(),
         );
-        account_base = a.as_str();
+        account_base = account.as_str();
     }
     accounts.push(
         (0..accounts_per_shard)
@@ -128,9 +128,7 @@ fn setup_initial_blockchain(
     let boundary_accounts = get_boundary_accounts(num_shards);
     let accounts =
         if generate_shard_accounts { Some(generate_accounts(&boundary_accounts)) } else { None };
-
-    let shard_layout =
-        ShardLayout::simple_v1(&boundary_accounts.iter().map(|s| s.as_str()).collect::<Vec<_>>());
+    let shard_layout = ShardLayout::multi_shard_custom(boundary_accounts, 1);
     let validators_spec = ValidatorsSpec::raw(
         validators,
         num_block_producer_seats as NumSeats,

--- a/test-loop-tests/src/tests/view_requests_to_archival_node.rs
+++ b/test-loop-tests/src/tests/view_requests_to_archival_node.rs
@@ -63,7 +63,9 @@ fn slow_test_view_requests_to_archival_node() {
     // Contains the account of the non-validator archival node.
     let archival_clients: HashSet<AccountId> =
         vec![all_clients[NUM_VALIDATORS].clone()].into_iter().collect();
-    let shard_layout = ShardLayout::simple_v1(&["account3", "account5", "account7"]);
+    let boundary_accounts =
+        ["account3", "account5", "account7"].iter().map(|a| a.parse().unwrap()).collect();
+    let shard_layout = ShardLayout::multi_shard_custom(boundary_accounts, 1);
     let genesis = TestLoopBuilder::new_genesis_builder()
         .epoch_length(EPOCH_LENGTH)
         .shard_layout(shard_layout.clone())

--- a/test-loop-tests/src/utils/setups.rs
+++ b/test-loop-tests/src/utils/setups.rs
@@ -35,7 +35,9 @@ pub fn standard_setup_1() -> TestLoopEnv {
     let [_rpc_id] = rpcs else { panic!("Expected exactly one rpc node") };
 
     let epoch_length = 10;
-    let shard_layout = ShardLayout::simple_v1(&["account3", "account5", "account7"]);
+    let boundary_accounts =
+        ["account3", "account5", "account7"].iter().map(|&a| a.parse().unwrap()).collect();
+    let shard_layout = ShardLayout::multi_shard_custom(boundary_accounts, 1);
     let validators_spec = ValidatorsSpec::desired_roles(&producers, &validators);
     let genesis = TestLoopBuilder::new_genesis_builder()
         .epoch_length(epoch_length)


### PR DESCRIPTION
Removing `simple_v1` in favor of `multi_shard_custom`