### PR TITLE
feat(forknet): add support for scheduled commands in forknet

### DIFF
--- a/pytest/tests/mocknet/cmd_utils.py
+++ b/pytest/tests/mocknet/cmd_utils.py
@@ -15,7 +15,7 @@ def run_cmd(node, cmd, raise_on_fail=False, return_on_fail=False):
         if return_on_fail:
             return r
         if raise_on_fail:
-            raise msg
+            raise Exception(msg)
         sys.exit(msg)
     return r
 

--- a/pytest/tests/mocknet/cmd_utils.py
+++ b/pytest/tests/mocknet/cmd_utils.py
@@ -1,3 +1,8 @@
+"""
+Command utilities for the mocknet.
+
+This module provides utilities for executing commands on remote mocknet nodes.
+"""
 import sys
 from typing import Optional
 import base64

--- a/pytest/tests/mocknet/cmd_utils.py
+++ b/pytest/tests/mocknet/cmd_utils.py
@@ -28,7 +28,7 @@ def schedule_cmd(node,
     cmd_b64 = base64.b64encode(cmd.encode('utf-8')).decode('utf-8')
     scheduled_action = f'$(echo {cmd_b64} | base64 -d)'
     unit_name = f'mocknet-{schedule_ctx.id}'
-    on_active = schedule_ctx.timespec
+    on_active = schedule_ctx.time_spec
     scheduled_cmd = f"""systemd-run --user --same-dir --on-active="{on_active}" --timer-property=AccuracySec=100ms --unit {unit_name} sh -c "{scheduled_action}" """
     return run_cmd(node, scheduled_cmd, raise_on_fail, return_on_fail)
 

--- a/pytest/tests/mocknet/cmd_utils.py
+++ b/pytest/tests/mocknet/cmd_utils.py
@@ -20,7 +20,11 @@ def run_cmd(node, cmd, raise_on_fail=False, return_on_fail=False):
     return r
 
 
-def schedule_cmd(node, cmd, schedule_ctx: ScheduleContext, raise_on_fail=False, return_on_fail=False):
+def schedule_cmd(node,
+                 cmd,
+                 schedule_ctx: ScheduleContext,
+                 raise_on_fail=False,
+                 return_on_fail=False):
     cmd_b64 = base64.b64encode(cmd.encode('utf-8')).decode('utf-8')
     scheduled_action = f'$(echo {cmd_b64} | base64 -d)'
     unit_name = f'mocknet-{schedule_ctx.id}'

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -63,6 +63,11 @@ class JSONHandler(http.server.BaseHTTPRequestHandler):
                                    name="clear_env")
         self.dispatcher.add_method(server.neard_runner.do_add_env,
                                    name="add_env")
+
+        #self.dispatcher.add_method(server.neard_runner.do_list_scheduled_commands,
+        #                           name="list_scheduled_commands")
+        #self.dispatcher.add_method(server.neard_runner.do_cancel_scheduled_command,
+        #                           name="cancel_scheduled_command")
         super().__init__(request, client_address, server)
 
     def do_GET(self):
@@ -769,7 +774,7 @@ class NeardRunner:
         with self.lock:
             env_file_path = self.home_path('.env')
             open(env_file_path, 'w').close()
-            print(f'File {env_file_path} has been successfully cleared.')
+            logging.info(f'File {env_file_path} has been successfully cleared.')
 
     def do_add_env(self, key_values):
         with self.lock:

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -63,11 +63,6 @@ class JSONHandler(http.server.BaseHTTPRequestHandler):
                                    name="clear_env")
         self.dispatcher.add_method(server.neard_runner.do_add_env,
                                    name="add_env")
-
-        #self.dispatcher.add_method(server.neard_runner.do_list_scheduled_commands,
-        #                           name="list_scheduled_commands")
-        #self.dispatcher.add_method(server.neard_runner.do_cancel_scheduled_command,
-        #                           name="cancel_scheduled_command")
         super().__init__(request, client_address, server)
 
     def do_GET(self):

--- a/pytest/tests/mocknet/local_test_node.py
+++ b/pytest/tests/mocknet/local_test_node.py
@@ -92,7 +92,11 @@ class LocalTestNeardRunner:
         # handled by local_test_setup_cmd()
         return
 
-    def run_cmd(self, _schedule_ctx, cmd, raise_on_fail=False, return_on_fail=False):
+    def run_cmd(self,
+                _schedule_ctx,
+                cmd,
+                raise_on_fail=False,
+                return_on_fail=False):
         logger.error(
             "Does not make sense to run command on local host. The behavior may not be the desired one."
         )

--- a/pytest/tests/mocknet/local_test_node.py
+++ b/pytest/tests/mocknet/local_test_node.py
@@ -92,7 +92,7 @@ class LocalTestNeardRunner:
         # handled by local_test_setup_cmd()
         return
 
-    def run_cmd(self, cmd, raise_on_fail=False, return_on_fail=False):
+    def run_cmd(self, _schedule_ctx, cmd, raise_on_fail=False, return_on_fail=False):
         logger.error(
             "Does not make sense to run command on local host. The behavior may not be the desired one."
         )
@@ -136,7 +136,9 @@ class LocalTestNeardRunner:
             f'started neard runner process with pid {process.pid} listening on port {self.port}'
         )
 
-    def neard_runner_post(self, body):
+    def neard_runner_post(self, _schedule_ctx, body):
+        if _schedule_ctx is not None:
+            raise ValueError('Scheduling is not supported for local test node')
         return http_post(self.ip_addr(), self.port, body)
 
     def new_test_params(self):

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -85,7 +85,7 @@ def with_schedule_context(func):
         # Build the context
         context = ScheduleContext(
             id=getattr(args, 'schedule_id', None),
-            timespec=args.schedule_in,
+            time_spec=args.schedule_in,
         )
 
         return func(args, context, *func_args, **func_kwargs)

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -638,11 +638,12 @@ def build_parser():
 
 
 def register_schedule_subcommands(subparsers):
-    schedule_parser = subparsers.add_parser(
-        'schedule', help='Manage scheduled commands.')
-    subparsers = schedule_parser.add_subparsers(title='subcommands',
-                                       description='Manage scheduled commands.',
-                                       help='additional help')
+    schedule_parser = subparsers.add_parser('schedule',
+                                            help='Manage scheduled commands.')
+    subparsers = schedule_parser.add_subparsers(
+        title='subcommands',
+        description='Manage scheduled commands.',
+        help='additional help')
     cmd_subparsers = subparsers.add_parser(
         'cmd', help='Schedule commands to run in the future.')
     cmd_subparsers.add_argument(
@@ -665,9 +666,6 @@ def register_schedule_subcommands(subparsers):
         required=True)
     # register subcommands to schedule_subparsers
     register_subcommands(cmd_subcommands)
-
-    
-
 
 
 def register_base_commands(subparsers):

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -639,28 +639,35 @@ def build_parser():
 
 def register_schedule_subcommands(subparsers):
     schedule_parser = subparsers.add_parser(
-        'schedule', help='Schedule commands to run in the future.')
-    schedule_parser.add_argument(
+        'schedule', help='Manage scheduled commands.')
+    subparsers = schedule_parser.add_subparsers(title='subcommands',
+                                       description='Manage scheduled commands.',
+                                       help='additional help')
+    cmd_subparsers = subparsers.add_parser(
+        'cmd', help='Schedule commands to run in the future.')
+    cmd_subparsers.add_argument(
         '--schedule-in',
         type=str,
         help=
         'Schedule the command to run after the specified time. Can be in the format of "10s", "10m", "10h", "10d"'
     )
-    schedule_parser.add_argument(
+    cmd_subparsers.add_argument(
         '--schedule-id',
         type=str,
         help=
         'The id of the scheduled command. If not provided, random string will be generated.'
     )
-
-    # Add nested subparsers under 'schedule'
-    schedule_subparsers = schedule_parser.add_subparsers(
+    # Add all existing commands under 'cmd'
+    cmd_subcommands = cmd_subparsers.add_subparsers(
         title='subcommands',
         description='valid subcommands',
         help='additional help',
         required=True)
     # register subcommands to schedule_subparsers
-    register_subcommands(schedule_subparsers)
+    register_subcommands(cmd_subcommands)
+
+    
+
 
 
 def register_base_commands(subparsers):

--- a/pytest/tests/mocknet/node_config.py
+++ b/pytest/tests/mocknet/node_config.py
@@ -1,4 +1,13 @@
+"""
+Mocknet node configuration.
+
+This module contains the configuration for the mocknet nodes.
+It is used to configure the nodes for the test.
+"""
 import sys
+from typing import Optional
+from node_handle import NodeHandle
+from utils import ScheduleContext
 
 
 # TODO: these should be identified by tags
@@ -61,8 +70,11 @@ TEST_CONFIG = [
 
 
 # set attributes (e.g. do we want this node to possibly validate?) on this particular node
-def configure_nodes(nodes, node_setup_config):
+# schedule_ctx is optional, it is used to set the schedule context on the remote node only
+def configure_nodes(nodes: list[NodeHandle], node_setup_config,
+                    schedule_ctx: Optional[ScheduleContext]):
     for node in nodes:
+        node.schedule_ctx = schedule_ctx
         node_config = None
         for c in node_setup_config:
             if c['node_matches'](node):

--- a/pytest/tests/mocknet/node_config.py
+++ b/pytest/tests/mocknet/node_config.py
@@ -5,9 +5,6 @@ This module contains the configuration for the mocknet nodes.
 It is used to configure the nodes for the test.
 """
 import sys
-from typing import Optional
-from node_handle import NodeHandle
-from utils import ScheduleContext
 
 
 # TODO: these should be identified by tags
@@ -70,11 +67,8 @@ TEST_CONFIG = [
 
 
 # set attributes (e.g. do we want this node to possibly validate?) on this particular node
-# schedule_ctx is optional, it is used to set the schedule context on the remote node only
-def configure_nodes(nodes: list[NodeHandle], node_setup_config,
-                    schedule_ctx: Optional[ScheduleContext]):
+def configure_nodes(nodes, node_setup_config):
     for node in nodes:
-        node.schedule_ctx = schedule_ctx
         node_config = None
         for c in node_setup_config:
             if c['node_matches'](node):

--- a/pytest/tests/mocknet/node_handle.py
+++ b/pytest/tests/mocknet/node_handle.py
@@ -6,7 +6,7 @@ import pathlib
 import requests
 import sys
 import time
-from typing import Optional
+from typing import Optional, Self
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 
@@ -22,6 +22,16 @@ class NodeHandle:
         self.want_state_dump = want_state_dump
         self.want_neard_runner = True
         self.schedule_ctx = None
+
+    def with_schedule_ctx(self,
+                          schedule_ctx: Optional[ScheduleContext]) -> Self:
+        """
+        Sets the schedule context in the node.
+        If schedule is set, all the commands will be scheduled.
+        If schedule is not set, all the commands will be executed now.
+        """
+        self.schedule_ctx = schedule_ctx
+        return self
 
     def name(self):
         return self.node.name()

--- a/pytest/tests/mocknet/node_handle.py
+++ b/pytest/tests/mocknet/node_handle.py
@@ -164,15 +164,13 @@ class NodeHandle:
     def neard_runner_update_binaries(self,
                                      neard_binary_url=None,
                                      epoch_height=None,
-                                     binary_idx=None,
-                                     scheduling_context=None):
+                                     binary_idx=None):
         return self.neard_runner_jsonrpc(
             'update_binaries',
             params={
                 'neard_binary_url': neard_binary_url,
                 'epoch_height': epoch_height,
                 'binary_idx': binary_idx,
-                'scheduling_context': scheduling_context,
             })
 
     def neard_update_config(self, key_value):

--- a/pytest/tests/mocknet/node_handle.py
+++ b/pytest/tests/mocknet/node_handle.py
@@ -188,14 +188,3 @@ class NodeHandle:
     def neard_clear_env(self, schedule_ctx: Optional[ScheduleContext]):
         return self.neard_runner_jsonrpc(schedule_ctx, 'clear_env')
 
-    def neard_runner_list_scheduled_commands(self):
-        #return self.neard_runner_jsonrpc('list_scheduled_commands')
-        pass
-
-    def neard_runner_cancel_scheduled_command(self, schedule_ctx: Optional[ScheduleContext], command_id):
-        #return self.neard_runner_jsonrpc(
-        #    'cancel_scheduled_command',
-        #    params={
-        #        'command_id': command_id,
-        #    })
-        pass

--- a/pytest/tests/mocknet/node_handle.py
+++ b/pytest/tests/mocknet/node_handle.py
@@ -3,6 +3,7 @@ import requests
 import sys
 import time
 from typing import Optional
+
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 
 from configured_logger import logger
@@ -36,8 +37,13 @@ class NodeHandle:
         self.node.upload_neard_runner()
         self.node.update_python()
 
-    def run_cmd(self, schedule_ctx: Optional[ScheduleContext], cmd, raise_on_fail=False, return_on_fail=False):
-        return self.node.run_cmd(schedule_ctx, cmd, raise_on_fail, return_on_fail)
+    def run_cmd(self,
+                schedule_ctx: Optional[ScheduleContext],
+                cmd,
+                raise_on_fail=False,
+                return_on_fail=False):
+        return self.node.run_cmd(schedule_ctx, cmd, raise_on_fail,
+                                 return_on_fail)
 
     def upload_file(self, src, dst):
         return self.node.upload_file(src, dst)
@@ -78,7 +84,10 @@ class NodeHandle:
     # Same as neard_runner_jsonrpc() without checking the error
     # This should maybe be the behavior everywhere, and callers
     # should handle errors themselves
-    def neard_runner_jsonrpc_nocheck(self, schedule_ctx: Optional[ScheduleContext], method, params=[]):
+    def neard_runner_jsonrpc_nocheck(self,
+                                     schedule_ctx: Optional[ScheduleContext],
+                                     method,
+                                     params=[]):
         body = {
             'method': method,
             'params': params,
@@ -87,8 +96,12 @@ class NodeHandle:
         }
         return self.node.neard_runner_post(schedule_ctx, body)
 
-    def neard_runner_jsonrpc(self, schedule_ctx: Optional[ScheduleContext], method, params=[]):
-        response = self.neard_runner_jsonrpc_nocheck(schedule_ctx, method, params)
+    def neard_runner_jsonrpc(self,
+                             schedule_ctx: Optional[ScheduleContext],
+                             method,
+                             params=[]):
+        response = self.neard_runner_jsonrpc_nocheck(schedule_ctx, method,
+                                                     params)
         if getattr(response, 'result', None) is not None:
             # TODO: errors should be handled better here in general but just exit for now
             sys.exit(
@@ -96,7 +109,9 @@ class NodeHandle:
             )
         return getattr(response, 'result', None)
 
-    def neard_runner_start(self, schedule_ctx: Optional[ScheduleContext], batch_interval_millis=None):
+    def neard_runner_start(self,
+                           schedule_ctx: Optional[ScheduleContext],
+                           batch_interval_millis=None):
         if batch_interval_millis is None:
             params = []
         else:
@@ -140,8 +155,12 @@ class NodeHandle:
     def neard_runner_version(self):
         return self.neard_runner_jsonrpc_nocheck(None, 'version')
 
-    def neard_runner_make_backup(self, schedule_ctx: Optional[ScheduleContext], backup_id, description=None):
-        return self.neard_runner_jsonrpc(schedule_ctx, 'make_backup',
+    def neard_runner_make_backup(self,
+                                 schedule_ctx: Optional[ScheduleContext],
+                                 backup_id,
+                                 description=None):
+        return self.neard_runner_jsonrpc(schedule_ctx,
+                                         'make_backup',
                                          params={
                                              'backup_id': backup_id,
                                              'description': description
@@ -150,8 +169,11 @@ class NodeHandle:
     def neard_runner_ls_backups(self):
         return self.neard_runner_jsonrpc(None, 'ls_backups')
 
-    def neard_runner_reset(self, schedule_ctx: Optional[ScheduleContext], backup_id=None):
-        return self.neard_runner_jsonrpc(schedule_ctx, 'reset',
+    def neard_runner_reset(self,
+                           schedule_ctx: Optional[ScheduleContext],
+                           backup_id=None):
+        return self.neard_runner_jsonrpc(schedule_ctx,
+                                         'reset',
                                          params={'backup_id': backup_id})
 
     def neard_runner_update_binaries(self,
@@ -160,7 +182,8 @@ class NodeHandle:
                                      epoch_height=None,
                                      binary_idx=None,
                                      scheduling_context=None):
-        return self.neard_runner_jsonrpc(schedule_ctx,
+        return self.neard_runner_jsonrpc(
+            schedule_ctx,
             'update_binaries',
             params={
                 'neard_binary_url': neard_binary_url,
@@ -169,16 +192,20 @@ class NodeHandle:
                 'scheduling_context': scheduling_context,
             })
 
-    def neard_update_config(self, schedule_ctx: Optional[ScheduleContext], key_value):
-        return self.neard_runner_jsonrpc(schedule_ctx,
+    def neard_update_config(self, schedule_ctx: Optional[ScheduleContext],
+                            key_value):
+        return self.neard_runner_jsonrpc(
+            schedule_ctx,
             'update_config',
             params={
                 "key_value": key_value,
             },
         )
 
-    def neard_update_env(self, schedule_ctx: Optional[ScheduleContext], key_value):
-        return self.neard_runner_jsonrpc(schedule_ctx,
+    def neard_update_env(self, schedule_ctx: Optional[ScheduleContext],
+                         key_value):
+        return self.neard_runner_jsonrpc(
+            schedule_ctx,
             'add_env',
             params={
                 "key_values": key_value,
@@ -187,4 +214,3 @@ class NodeHandle:
 
     def neard_clear_env(self, schedule_ctx: Optional[ScheduleContext]):
         return self.neard_runner_jsonrpc(schedule_ctx, 'clear_env')
-

--- a/pytest/tests/mocknet/node_handle.py
+++ b/pytest/tests/mocknet/node_handle.py
@@ -1,3 +1,7 @@
+"""
+This is an abstraction over the node.
+The actual implementation differs between local and remote nodes.
+"""
 import pathlib
 import requests
 import sys
@@ -17,6 +21,7 @@ class NodeHandle:
         self.can_validate = can_validate
         self.want_state_dump = want_state_dump
         self.want_neard_runner = True
+        self.schedule_ctx = None
 
     def name(self):
         return self.node.name()
@@ -37,12 +42,8 @@ class NodeHandle:
         self.node.upload_neard_runner()
         self.node.update_python()
 
-    def run_cmd(self,
-                schedule_ctx: Optional[ScheduleContext],
-                cmd,
-                raise_on_fail=False,
-                return_on_fail=False):
-        return self.node.run_cmd(schedule_ctx, cmd, raise_on_fail,
+    def run_cmd(self, cmd, raise_on_fail=False, return_on_fail=False):
+        return self.node.run_cmd(self.schedule_ctx, cmd, raise_on_fail,
                                  return_on_fail)
 
     def upload_file(self, src, dst):
@@ -84,46 +85,37 @@ class NodeHandle:
     # Same as neard_runner_jsonrpc() without checking the error
     # This should maybe be the behavior everywhere, and callers
     # should handle errors themselves
-    def neard_runner_jsonrpc_nocheck(self,
-                                     schedule_ctx: Optional[ScheduleContext],
-                                     method,
-                                     params=[]):
+    def neard_runner_jsonrpc_nocheck(self, method, params=[]):
         body = {
             'method': method,
             'params': params,
             'id': 'dontcare',
             'jsonrpc': '2.0'
         }
-        return self.node.neard_runner_post(schedule_ctx, body)
+        return self.node.neard_runner_post(self.schedule_ctx, body)
 
-    def neard_runner_jsonrpc(self,
-                             schedule_ctx: Optional[ScheduleContext],
-                             method,
-                             params=[]):
-        response = self.neard_runner_jsonrpc_nocheck(schedule_ctx, method,
-                                                     params)
-        if getattr(response, 'result', None) is not None:
+    def neard_runner_jsonrpc(self, method, params=[]):
+        response = self.neard_runner_jsonrpc_nocheck(method, params)
+        if response.get('error', None) is not None:
             # TODO: errors should be handled better here in general but just exit for now
             sys.exit(
                 f'bad response trying to send {method} JSON RPC to neard runner on {self.node.name()}:\n{response}'
             )
-        return getattr(response, 'result', None)
+        return response.get('result', None)
 
-    def neard_runner_start(self,
-                           schedule_ctx: Optional[ScheduleContext],
-                           batch_interval_millis=None):
+    def neard_runner_start(self, batch_interval_millis=None):
         if batch_interval_millis is None:
             params = []
         else:
             params = {'batch_interval_millis': batch_interval_millis}
-        return self.neard_runner_jsonrpc(schedule_ctx, 'start', params=params)
+        return self.neard_runner_jsonrpc('start', params=params)
 
-    def neard_runner_stop(self, schedule_ctx: Optional[ScheduleContext]):
-        return self.neard_runner_jsonrpc(schedule_ctx, 'stop')
+    def neard_runner_stop(self):
+        return self.neard_runner_jsonrpc('stop')
 
     def neard_runner_new_test(self):
         params = self.node.new_test_params()
-        return self.neard_runner_jsonrpc(None, 'new_test', params)
+        return self.neard_runner_jsonrpc('new_test', params)
 
     def neard_runner_network_init(self,
                                   validators,
@@ -147,43 +139,34 @@ class NodeHandle:
         }
         if genesis_time is not None:
             params['genesis_time'] = genesis_time
-        return self.neard_runner_jsonrpc(None, 'network_init', params=params)
+        return self.neard_runner_jsonrpc('network_init', params=params)
 
     def neard_runner_ready(self):
-        return self.neard_runner_jsonrpc(None, 'ready')
+        return self.neard_runner_jsonrpc('ready')
 
     def neard_runner_version(self):
-        return self.neard_runner_jsonrpc_nocheck(None, 'version')
+        return self.neard_runner_jsonrpc_nocheck('version')
 
-    def neard_runner_make_backup(self,
-                                 schedule_ctx: Optional[ScheduleContext],
-                                 backup_id,
-                                 description=None):
-        return self.neard_runner_jsonrpc(schedule_ctx,
-                                         'make_backup',
+    def neard_runner_make_backup(self, backup_id, description=None):
+        return self.neard_runner_jsonrpc('make_backup',
                                          params={
                                              'backup_id': backup_id,
                                              'description': description
                                          })
 
     def neard_runner_ls_backups(self):
-        return self.neard_runner_jsonrpc(None, 'ls_backups')
+        return self.neard_runner_jsonrpc('ls_backups')
 
-    def neard_runner_reset(self,
-                           schedule_ctx: Optional[ScheduleContext],
-                           backup_id=None):
-        return self.neard_runner_jsonrpc(schedule_ctx,
-                                         'reset',
+    def neard_runner_reset(self, backup_id=None):
+        return self.neard_runner_jsonrpc('reset',
                                          params={'backup_id': backup_id})
 
     def neard_runner_update_binaries(self,
-                                     schedule_ctx: Optional[ScheduleContext],
                                      neard_binary_url=None,
                                      epoch_height=None,
                                      binary_idx=None,
                                      scheduling_context=None):
         return self.neard_runner_jsonrpc(
-            schedule_ctx,
             'update_binaries',
             params={
                 'neard_binary_url': neard_binary_url,
@@ -192,25 +175,17 @@ class NodeHandle:
                 'scheduling_context': scheduling_context,
             })
 
-    def neard_update_config(self, schedule_ctx: Optional[ScheduleContext],
-                            key_value):
-        return self.neard_runner_jsonrpc(
-            schedule_ctx,
-            'update_config',
-            params={
-                "key_value": key_value,
-            },
-        )
+    def neard_update_config(self, key_value):
+        return self.neard_runner_jsonrpc('update_config',
+                                         params={
+                                             "key_value": key_value,
+                                         })
 
-    def neard_update_env(self, schedule_ctx: Optional[ScheduleContext],
-                         key_value):
-        return self.neard_runner_jsonrpc(
-            schedule_ctx,
-            'add_env',
-            params={
-                "key_values": key_value,
-            },
-        )
+    def neard_update_env(self, key_value):
+        return self.neard_runner_jsonrpc('add_env',
+                                         params={
+                                             "key_values": key_value,
+                                         })
 
-    def neard_clear_env(self, schedule_ctx: Optional[ScheduleContext]):
-        return self.neard_runner_jsonrpc(schedule_ctx, 'clear_env')
+    def neard_clear_env(self):
+        return self.neard_runner_jsonrpc('clear_env')

--- a/pytest/tests/mocknet/remote_node.py
+++ b/pytest/tests/mocknet/remote_node.py
@@ -110,14 +110,13 @@ class RemoteNeardRunner:
         # followed by a new quote started with ' and the rest of the string, to get any single quotes
         # in method or params into the command correctly
         body = body.replace("'", "'\"'\"'")
+        cmd = f'curl localhost:3000 -d \'{body}\''
         if schedule_ctx is not None:
-            r = cmd_utils.schedule_cmd(self.node,
-                                       f'curl localhost:3000 -d \'{body}\'',
-                                       schedule_ctx)
+            r = cmd_utils.schedule_cmd(self.node, cmd, schedule_ctx)
             logger.info('{0}:\nstdout:\n{1.stdout}\nstderr:\n{1.stderr}'.format(
                 self.name(), r))
-            return
-        r = cmd_utils.run_cmd(self.node, f'curl localhost:3000 -d \'{body}\'')
+            return {'result': r}
+        r = cmd_utils.run_cmd(self.node, cmd)
         return json.loads(r.stdout)
 
     def new_test_params(self):

--- a/pytest/tests/mocknet/remote_node.py
+++ b/pytest/tests/mocknet/remote_node.py
@@ -18,6 +18,7 @@ from utils import ScheduleContext
 
 from configured_logger import logger
 
+
 class RemoteNeardRunner:
 
     def __init__(self, node, neard_runner_home):
@@ -55,11 +56,16 @@ class RemoteNeardRunner:
                             os.path.join(self.neard_runner_home, 'config.json'),
                             config)
 
-    def run_cmd(self, schedule_ctx: Optional[ScheduleContext], cmd, raise_on_fail=False, return_on_fail=False):
+    def run_cmd(self,
+                schedule_ctx: Optional[ScheduleContext],
+                cmd,
+                raise_on_fail=False,
+                return_on_fail=False):
         if schedule_ctx is None:
             r = cmd_utils.run_cmd(self.node, cmd, raise_on_fail, return_on_fail)
         else:
-            r = cmd_utils.schedule_cmd(self.node, cmd, schedule_ctx, raise_on_fail, return_on_fail)
+            r = cmd_utils.schedule_cmd(self.node, cmd, schedule_ctx,
+                                       raise_on_fail, return_on_fail)
         return r
 
     def upload_file(self, src, dst):
@@ -105,8 +111,12 @@ class RemoteNeardRunner:
         # in method or params into the command correctly
         body = body.replace("'", "'\"'\"'")
         if schedule_ctx is not None:
-            r = cmd_utils.schedule_cmd(self.node, f'curl localhost:3000 -d \'{body}\'', schedule_ctx, raise_on_fail=True)
-            logger.info('{0}:\nstdout:\n{1.stdout}\nstderr:\n{1.stderr}'.format(self.name(), r))
+            r = cmd_utils.schedule_cmd(self.node,
+                                       f'curl localhost:3000 -d \'{body}\'',
+                                       schedule_ctx,
+                                       raise_on_fail=True)
+            logger.info('{0}:\nstdout:\n{1.stdout}\nstderr:\n{1.stderr}'.format(
+                self.name(), r))
             return
         r = cmd_utils.run_cmd(self.node, f'curl localhost:3000 -d \'{body}\'')
         return json.loads(r.stdout)

--- a/pytest/tests/mocknet/remote_node.py
+++ b/pytest/tests/mocknet/remote_node.py
@@ -113,8 +113,7 @@ class RemoteNeardRunner:
         if schedule_ctx is not None:
             r = cmd_utils.schedule_cmd(self.node,
                                        f'curl localhost:3000 -d \'{body}\'',
-                                       schedule_ctx,
-                                       raise_on_fail=True)
+                                       schedule_ctx)
             logger.info('{0}:\nstdout:\n{1.stdout}\nstderr:\n{1.stderr}'.format(
                 self.name(), r))
             return

--- a/pytest/tests/mocknet/remote_node.py
+++ b/pytest/tests/mocknet/remote_node.py
@@ -6,13 +6,17 @@ import pathlib
 import json
 import os
 import sys
+from functools import wraps
+from typing import Optional
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 
 import cmd_utils
 from node_handle import NodeHandle
 import mocknet
+from utils import ScheduleContext
 
+from configured_logger import logger
 
 class RemoteNeardRunner:
 
@@ -51,8 +55,11 @@ class RemoteNeardRunner:
                             os.path.join(self.neard_runner_home, 'config.json'),
                             config)
 
-    def run_cmd(self, cmd, raise_on_fail=False, return_on_fail=False):
-        r = cmd_utils.run_cmd(self.node, cmd, raise_on_fail, return_on_fail)
+    def run_cmd(self, schedule_ctx: Optional[ScheduleContext], cmd, raise_on_fail=False, return_on_fail=False):
+        if schedule_ctx is None:
+            r = cmd_utils.run_cmd(self.node, cmd, raise_on_fail, return_on_fail)
+        else:
+            r = cmd_utils.schedule_cmd(self.node, cmd, schedule_ctx, raise_on_fail, return_on_fail)
         return r
 
     def upload_file(self, src, dst):
@@ -91,12 +98,16 @@ class RemoteNeardRunner:
 
         self.node.machine.run(SYSTEMD_RUN_NEARD_RUNNER_CMD)
 
-    def neard_runner_post(self, body):
+    def neard_runner_post(self, schedule_ctx: Optional[ScheduleContext], body):
         body = json.dumps(body)
         # '"'"' will be interpreted as ending the first quote and then concatenating it with "'",
         # followed by a new quote started with ' and the rest of the string, to get any single quotes
         # in method or params into the command correctly
         body = body.replace("'", "'\"'\"'")
+        if schedule_ctx is not None:
+            r = cmd_utils.schedule_cmd(self.node, f'curl localhost:3000 -d \'{body}\'', schedule_ctx, raise_on_fail=True)
+            logger.info('{0}:\nstdout:\n{1.stdout}\nstderr:\n{1.stderr}'.format(self.name(), r))
+            return
         r = cmd_utils.run_cmd(self.node, f'curl localhost:3000 -d \'{body}\'')
         return json.loads(r.stdout)
 

--- a/pytest/tests/mocknet/utils.py
+++ b/pytest/tests/mocknet/utils.py
@@ -1,8 +1,9 @@
 from typing import Optional
+from datetime import datetime
 
 
 class ScheduleContext:
 
     def __init__(self, id: Optional[str], timespec: str):
-        self.id = id or datetime.datetime.utcnow().isoformat()
+        self.id = id or str(int(datetime.utcnow().timestamp()))
         self.timespec = timespec

--- a/pytest/tests/mocknet/utils.py
+++ b/pytest/tests/mocknet/utils.py
@@ -1,6 +1,8 @@
 from typing import Optional
 
+
 class ScheduleContext:
+
     def __init__(self, id: Optional[str], timespec: str):
         self.id = id or datetime.datetime.utcnow().isoformat()
         self.timespec = timespec

--- a/pytest/tests/mocknet/utils.py
+++ b/pytest/tests/mocknet/utils.py
@@ -4,6 +4,6 @@ from datetime import datetime
 
 class ScheduleContext:
 
-    def __init__(self, id: Optional[str], timespec: str):
+    def __init__(self, id: Optional[str], time_spec: str):
         self.id = id or str(int(datetime.utcnow().timestamp()))
-        self.timespec = timespec
+        self.time_spec = time_spec

--- a/pytest/tests/mocknet/utils.py
+++ b/pytest/tests/mocknet/utils.py
@@ -1,0 +1,6 @@
+from typing import Optional
+
+class ScheduleContext:
+    def __init__(self, id: Optional[str], timespec: str):
+        self.id = id or datetime.datetime.utcnow().isoformat()
+        self.timespec = timespec


### PR DESCRIPTION
This PR introduces new commands to the mirror tool.
```
mirror schedule cmd
mirror schedule list
mirror schedule clear
```
`schedule cmd` can be applied to a subset of mirror commands to make them execute at a later time on the targeted host.

some example of usage:
## Create
```
(pytest_env) ➜  pytest git:(forknet/scheduled_commands_systemd) ✗ mirror --host-filter cf7c schedule cmd --schedule-in 20h --schedule-id act1 env --key-value "EEEEE=debug,network=info"
[2025-05-14 18:30:17] INFO: created configured logger, name test, level 20
[2025-05-14 18:30:18] INFO: created configured logger, name serializer, level 20
[2025-05-14 18:30:26] INFO: mocknet-mainnet-142274930-release26-cf7c:
stdout:

stderr:
Running timer as unit: mocknet-act1.timer
Will run service as unit: mocknet-act1.service

(pytest_env) ➜  pytest git:(forknet/scheduled_commands_systemd) ✗ mirror --host-filter cf7c schedule cmd --schedule-in 2h --schedule-id act2 env --key-value "EEEEE=debug,network=info"
[2025-05-14 18:30:37] INFO: created configured logger, name test, level 20
[2025-05-14 18:30:38] INFO: created configured logger, name serializer, level 20
[2025-05-14 18:30:45] INFO: mocknet-mainnet-142274930-release26-cf7c:
stdout:

stderr:
Running timer as unit: mocknet-act2.timer
Will run service as unit: mocknet-act2.service
```

## List
```
(pytest_env) ➜  pytest git:(forknet/scheduled_commands_systemd) ✗ mirror  --host-filter cf7c schedule list                                                                         	 
[2025-05-14 18:34:54] INFO: created configured logger, name test, level 20
[2025-05-14 18:34:55] INFO: created configured logger, name serializer, level 20
[2025-05-14 18:35:02] INFO: Getting schedule from mocknet-mainnet-142274930-release26-cf7c
[2025-05-14 18:35:03] INFO: mocknet-mainnet-142274930-release26-cf7c:
stdout:
mocknet-act1.timer
/usr/bin/sh -c curl localhost:3000 -d '{"method": "add_env", "params": {"key_values": ["EEEEE=debug,network=info"]}, "id": "dontcare", "jsonrpc": "2.0"}'
Wed 2025-05-14 17:34:13 UTC

mocknet-act2.timer
/usr/bin/sh -c curl localhost:3000 -d '{"method": "add_env", "params": {"key_values": ["EEEEE=debug,network=info"]}, "id": "dontcare", "jsonrpc": "2.0"}'
Wed 2025-05-14 17:34:42 UTC
```
## Delete

without .timer will fail
```
(pytest_env) ➜  pytest git:(forknet/scheduled_commands_systemd) ✗ mirror  --host-filter cf7c schedule clear --filter act1
[2025-05-14 18:36:11] INFO: created configured logger, name test, level 20
[2025-05-14 18:36:12] INFO: created configured logger, name serializer, level 20
[2025-05-14 18:36:19] INFO: Clearing scheduled commands matching "mocknet-act1" from mocknet-mainnet-142274930-release26-cf7c
[2025-05-14 18:36:19] INFO: mocknet-mainnet-142274930-release26-cf7c:
stderr:
Warning: Stopping mocknet-act1.service, but it can still be activated by:
  mocknet-act1.timer
```

```
(pytest_env) ➜  pytest git:(forknet/scheduled_commands_systemd) ✗ mirror  --host-filter cf7c schedule clear --filter "act1*"    
[2025-05-14 18:36:36] INFO: created configured logger, name test, level 20
[2025-05-14 18:36:37] INFO: created configured logger, name serializer, level 20
[2025-05-14 18:36:43] INFO: Clearing scheduled commands matching "mocknet-act1*" from mocknet-mainnet-142274930-release26-cf7c
[2025-05-14 18:36:44] INFO: mocknet-mainnet-142274930-release26-cf7c:
```



## Create without id
```
(pytest_env) ➜  pytest git:(forknet/scheduled_commands_systemd) ✗ mirror --host-filter cf7c schedule cmd --schedule-in 2h env --key-value "EEEEE=debug,network=info"
[2025-05-14 18:40:22] INFO: created configured logger, name test, level 20
[2025-05-14 18:40:22] INFO: created configured logger, name serializer, level 20
[2025-05-14 18:40:31] INFO: mocknet-mainnet-142274930-release26-cf7c:
stdout:

stderr:
Running timer as unit: mocknet-1747240831.timer
Will run service as unit: mocknet-1747240831.service
```


## Create a run-cmd 
```
mirror --host-filter cf7c schedule cmd --schedule-in 2m run-cmd --cmd "date; ls; touch a" 	 
[2025-05-14 18:42:47] INFO: created configured logger, name test, level 20
[2025-05-14 18:42:48] INFO: created configured logger, name serializer, level 20
[2025-05-14 18:42:56] INFO: Running cmd on mocknet-mainnet-142274930-release26-cf7c
[2025-05-14 18:42:57] INFO: mocknet-mainnet-142274930-release26-cf7c:
stderr:
Running timer as unit: mocknet-1747240976.timer
Will run service as unit: mocknet-1747240976.service
```

```
mirror  --host-filter cf7c schedule list                                            	 
[2025-05-14 18:43:27] INFO: created configured logger, name test, level 20
[2025-05-14 18:43:28] INFO: created configured logger, name serializer, level 20
[2025-05-14 18:43:35] INFO: Getting schedule from mocknet-mainnet-142274930-release26-cf7c
[2025-05-14 18:43:36] INFO: mocknet-mainnet-142274930-release26-cf7c:
stdout:
.timer
/usr/bin/sh -c date; ls; touch a
Wed 2025-05-14 17:42:57 UTC
```
checking the execution on host
```
journalctl --user -u "mocknet-1747240976.*"
May 14 17:42:57 mocknet-mainnet-142274930-release26-cf7c systemd[19144]: Started /usr/bin/sh -c date; ls; touch a.
May 14 17:44:57 mocknet-mainnet-142274930-release26-cf7c systemd[19144]: Started /usr/bin/sh -c date; ls; touch a.
May 14 17:44:57 mocknet-mainnet-142274930-release26-cf7c sh[21106]: g.json
May 14 17:44:57 mocknet-mainnet-142274930-release26-cf7c sh[21106]: logs
May 14 17:44:57 mocknet-mainnet-142274930-release26-cf7c sh[21106]: neard-logs
```

