### PR TITLE
feat: add rpc query for viewing global contract code

### DIFF
--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -53,6 +53,14 @@ pub enum QueryError {
         block_height: near_primitives::types::BlockHeight,
         block_hash: near_primitives::hash::CryptoHash,
     },
+    #[error(
+        "Global contract code with identifier {identifier:?} has never been observed on the node"
+    )]
+    NoGlobalContractCode {
+        identifier: near_primitives::action::GlobalContractIdentifier,
+        block_height: near_primitives::types::BlockHeight,
+        block_hash: near_primitives::hash::CryptoHash,
+    },
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/chain/chain/src/runtime/errors.rs
+++ b/chain/chain/src/runtime/errors.rs
@@ -59,6 +59,9 @@ impl QueryError {
             node_runtime::state_viewer::errors::ViewContractCodeError::NoContractCode {
                 contract_account_id,
             } => Self::NoContractCode { contract_account_id, block_height, block_hash },
+            node_runtime::state_viewer::errors::ViewContractCodeError::NoGlobalContractCode {
+                identifier,
+            } => Self::NoGlobalContractCode { identifier, block_height, block_hash },
         }
     }
 

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -436,6 +436,14 @@ pub enum QueryError {
         "Block either has never been observed on the node or has been garbage collected: {block_reference:?}"
     )]
     UnknownBlock { block_reference: near_primitives::types::BlockReference },
+    #[error(
+        "Global contract code with identifier {identifier:?} has never been observed on the node"
+    )]
+    NoGlobalContractCode {
+        identifier: near_primitives::action::GlobalContractIdentifier,
+        block_height: near_primitives::types::BlockHeight,
+        block_hash: near_primitives::hash::CryptoHash,
+    },
     // NOTE: Currently, the underlying errors are too broad, and while we tried to handle
     // expected cases, we cannot statically guarantee that no other errors will be returned
     // in the future.

--- a/chain/jsonrpc-primitives/src/types/query.rs
+++ b/chain/jsonrpc-primitives/src/types/query.rs
@@ -62,6 +62,14 @@ pub enum RpcQueryError {
         block_height: near_primitives::types::BlockHeight,
         block_hash: near_primitives::hash::CryptoHash,
     },
+    #[error(
+        "Global contract code with identifier {identifier:?} has never been observed on the node"
+    )]
+    NoGlobalContractCode {
+        identifier: near_primitives::action::GlobalContractIdentifier,
+        block_height: near_primitives::types::BlockHeight,
+        block_hash: near_primitives::hash::CryptoHash,
+    },
     #[error("The node reached its limits. Try again later. More details: {error_message}")]
     InternalError { error_message: String },
 }

--- a/chain/jsonrpc/src/api/query.rs
+++ b/chain/jsonrpc/src/api/query.rs
@@ -131,6 +131,9 @@ impl RpcFrom<QueryError> for RpcQueryError {
             QueryError::TooLargeContractState { contract_account_id, block_height, block_hash } => {
                 Self::TooLargeContractState { contract_account_id, block_height, block_hash }
             }
+            QueryError::NoGlobalContractCode { identifier, block_height, block_hash } => {
+                Self::NoGlobalContractCode { identifier, block_height, block_hash }
+            }
         }
     }
 }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -363,6 +363,12 @@ impl JsonRpcHandler {
                     QueryRequest::ViewAccessKey { .. } => "query_view_access_key",
                     QueryRequest::ViewAccessKeyList { .. } => "query_view_access_key_list",
                     QueryRequest::CallFunction { .. } => "query_call_function",
+                    QueryRequest::ViewGlobalContractCode { .. } => {
+                        "query_view_global_contract_code"
+                    }
+                    QueryRequest::ViewGlobalContractCodeByAccountId { .. } => {
+                        "query_view_global_contract_code_by_account_id"
+                    }
                 };
                 (metrics_name.to_string(), process_query_response(self.query(params).await))
             }

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -323,6 +323,12 @@ pub enum QueryRequest {
         #[serde(rename = "args_base64")]
         args: FunctionArgs,
     },
+    ViewGlobalContractCode {
+        code_hash: CryptoHash,
+    },
+    ViewGlobalContractCodeByAccountId {
+        account_id: AccountId,
+    },
 }
 
 fn is_false(v: &bool) -> bool {

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -191,6 +191,19 @@ impl TrieUpdate {
             .map(|opt| opt.map(|code| ContractCode::new(code, code_hash)))
     }
 
+    pub fn get_global_contract_code(
+        &self,
+        identifier: GlobalContractCodeIdentifier,
+    ) -> Result<Option<ContractCode>, StorageError> {
+        let code_hash = match identifier {
+            GlobalContractCodeIdentifier::CodeHash(hash) => Some(hash),
+            GlobalContractCodeIdentifier::AccountId(_) => None,
+        };
+        let key = TrieKey::GlobalContractCode { identifier };
+        self.get(&key, AccessOptions::DEFAULT)
+            .map(|opt| opt.map(|code| ContractCode::new(code, code_hash)))
+    }
+
     /// Returns the size (in num bytes) of the contract code for the given account.
     ///
     /// This is different from `get_code` in that it does not read the code from storage.

--- a/integration-tests/src/user/runtime_user.rs
+++ b/integration-tests/src/user/runtime_user.rs
@@ -289,7 +289,7 @@ impl User for RuntimeUser {
     fn view_contract_code(&self, account_id: &AccountId) -> Result<ContractCodeView, String> {
         let state_update = self.client.read().get_state_update();
         self.trie_viewer
-            .view_contract_code(&state_update, account_id)
+            .view_account_contract_code(&state_update, account_id)
             .map(|contract_code| {
                 let hash = *contract_code.hash();
                 ContractCodeView { hash, code: contract_code.into_code() }

--- a/runtime/runtime/src/adapter.rs
+++ b/runtime/runtime/src/adapter.rs
@@ -1,6 +1,7 @@
 use crate::near_primitives::shard_layout::ShardUId;
 use near_crypto::PublicKey;
 use near_primitives::account::{AccessKey, Account};
+use near_primitives::action::GlobalContractIdentifier;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::{
     AccountId, BlockHeight, EpochHeight, EpochId, EpochInfoProvider, MerkleHash,
@@ -66,4 +67,11 @@ pub trait ViewRuntimeAdapter {
         prefix: &[u8],
         include_proof: bool,
     ) -> Result<ViewStateResult, crate::state_viewer::errors::ViewStateError>;
+
+    fn view_global_contract_code(
+        &self,
+        shard_uid: &ShardUId,
+        state_root: MerkleHash,
+        identifier: GlobalContractIdentifier,
+    ) -> Result<ContractCode, crate::state_viewer::errors::ViewContractCodeError>;
 }

--- a/runtime/runtime/src/state_viewer/errors.rs
+++ b/runtime/runtime/src/state_viewer/errors.rs
@@ -18,6 +18,8 @@ pub enum ViewContractCodeError {
     NoContractCode { contract_account_id: near_primitives::types::AccountId },
     #[error("Internal error: #{error_message}")]
     InternalError { error_message: String },
+    #[error("Contract code for global contract ID {identifier:?} does not exist")]
+    NoGlobalContractCode { identifier: near_primitives::action::GlobalContractIdentifier },
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -6,6 +6,7 @@ use crate::receipt_manager::ReceiptManager;
 use near_crypto::{KeyType, PublicKey};
 use near_parameters::RuntimeConfigStore;
 use near_primitives::account::{AccessKey, Account};
+use near_primitives::action::GlobalContractIdentifier;
 use near_primitives::apply::ApplyChunkReason;
 use near_primitives::bandwidth_scheduler::BlockBandwidthRequests;
 use near_primitives::borsh::BorshDeserialize;
@@ -85,7 +86,7 @@ impl TrieViewer {
         })
     }
 
-    pub fn view_contract_code(
+    pub fn view_account_contract_code(
         &self,
         state_update: &TrieUpdate,
         account_id: &AccountId,
@@ -96,6 +97,16 @@ impl TrieViewer {
                 contract_account_id: account_id.clone(),
             },
         )
+    }
+
+    pub fn view_global_contract_code(
+        &self,
+        state_update: &TrieUpdate,
+        identifier: GlobalContractIdentifier,
+    ) -> Result<ContractCode, errors::ViewContractCodeError> {
+        state_update
+            .get_global_contract_code(identifier.clone().into())?
+            .ok_or(errors::ViewContractCodeError::NoGlobalContractCode { identifier })
     }
 
     pub fn view_access_key(


### PR DESCRIPTION
This PR adds `QueryRequest` for retrieving global contract code. This is needed because `ViewCode` query only allows retrieving contracted used as part of the specified accounts. Global contracts deployed separately, so we need to have a dedicated view query.

2 separate enum variants are introduced for queries by hash (`ViewGlobalContractCode`) and by account id (`ViewGlobalContractCodeByAccountId`) to have simple API and keep it consistent with `DeployGlobalContract`/`UseGlobalContract` actions.

`QueryResponseKind::ViewCode` is reused for the response.

Also `QueryError::NoGlobalContractCode` error is introduced, similar to `NoContractCode`.

Closes #13531.