### PR TITLE
[limited replayability] Remove PEER_MIN_ALLOWED_PROTOCOL_VERSION

### DIFF
--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -315,7 +315,7 @@ pub fn make_handshake<R: Rng>(rng: &mut R, chain: &Chain) -> Handshake {
     let b_id = PeerId::new(b.public_key());
     Handshake {
         protocol_version: version::PROTOCOL_VERSION,
-        oldest_supported_version: version::PEER_MIN_ALLOWED_PROTOCOL_VERSION,
+        oldest_supported_version: version::MIN_SUPPORTED_PROTOCOL_VERSION,
         sender_peer_id: a_id,
         target_peer_id: b_id,
         sender_listen_port: Some(rng.r#gen()),

--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -45,9 +45,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::types::EpochId;
 use near_primitives::utils::DisplayOption;
-use near_primitives::version::{
-    PEER_MIN_ALLOWED_PROTOCOL_VERSION, PROTOCOL_VERSION, ProtocolVersion,
-};
+use near_primitives::version::{MIN_SUPPORTED_PROTOCOL_VERSION, PROTOCOL_VERSION, ProtocolVersion};
 use parking_lot::Mutex;
 use rand::seq::IteratorRandom;
 use rand::thread_rng;
@@ -474,7 +472,7 @@ impl PeerActor {
             };
         let handshake = Handshake {
             protocol_version: spec.protocol_version,
-            oldest_supported_version: PEER_MIN_ALLOWED_PROTOCOL_VERSION,
+            oldest_supported_version: MIN_SUPPORTED_PROTOCOL_VERSION,
             sender_peer_id: self.network_state.config.node_id(),
             target_peer_id: spec.peer_id,
             sender_listen_port: self.network_state.config.node_addr.as_ref().map(|a| a.port()),
@@ -564,7 +562,7 @@ impl PeerActor {
                 }
             }
             ConnectingStatus::Inbound { .. } => {
-                if PEER_MIN_ALLOWED_PROTOCOL_VERSION > handshake.protocol_version
+                if MIN_SUPPORTED_PROTOCOL_VERSION > handshake.protocol_version
                     || handshake.protocol_version > PROTOCOL_VERSION
                 {
                     tracing::debug!(
@@ -575,7 +573,7 @@ impl PeerActor {
                         self.my_node_info.clone(),
                         HandshakeFailureReason::ProtocolVersionMismatch {
                             version: PROTOCOL_VERSION,
-                            oldest_supported_version: PEER_MIN_ALLOWED_PROTOCOL_VERSION,
+                            oldest_supported_version: MIN_SUPPORTED_PROTOCOL_VERSION,
                         },
                     ));
                     return;
@@ -894,9 +892,9 @@ impl PeerActor {
                         // Retry the handshake with the common protocol version.
                         let common_version = std::cmp::min(version, PROTOCOL_VERSION);
                         if common_version < oldest_supported_version
-                            || common_version < PEER_MIN_ALLOWED_PROTOCOL_VERSION
+                            || common_version < MIN_SUPPORTED_PROTOCOL_VERSION
                         {
-                            tracing::warn!(target: "network", "Unable to connect to a node ({}) due to a network protocol version mismatch. Our version: {:?}, their: {:?}", peer_info, (PROTOCOL_VERSION, PEER_MIN_ALLOWED_PROTOCOL_VERSION), (version, oldest_supported_version));
+                            tracing::warn!(target: "network", "Unable to connect to a node ({}) due to a network protocol version mismatch. Our version: {:?}, their: {:?}", peer_info, (PROTOCOL_VERSION, MIN_SUPPORTED_PROTOCOL_VERSION), (version, oldest_supported_version));
                             self.stop(ctx, ClosingReason::HandshakeFailed);
                             return;
                         }

--- a/chain/network/src/peer/tests/communication.rs
+++ b/chain/network/src/peer/tests/communication.rs
@@ -13,7 +13,7 @@ use anyhow::Context as _;
 use assert_matches::assert_matches;
 use near_async::time;
 use near_o11y::testonly::init_test_logger;
-use near_primitives::version::{PEER_MIN_ALLOWED_PROTOCOL_VERSION, PROTOCOL_VERSION};
+use near_primitives::version::{MIN_SUPPORTED_PROTOCOL_VERSION, PROTOCOL_VERSION};
 use std::sync::Arc;
 
 #[allow(clippy::large_stack_frames)]
@@ -197,8 +197,8 @@ async fn test_handshake(outbound_encoding: Option<Encoding>, inbound_encoding: O
 
     // Send too old PROTOCOL_VERSION, expect ProtocolVersionMismatch
     let mut handshake = Handshake {
-        protocol_version: PEER_MIN_ALLOWED_PROTOCOL_VERSION - 1,
-        oldest_supported_version: PEER_MIN_ALLOWED_PROTOCOL_VERSION - 1,
+        protocol_version: MIN_SUPPORTED_PROTOCOL_VERSION - 1,
+        oldest_supported_version: MIN_SUPPORTED_PROTOCOL_VERSION - 1,
         sender_peer_id: outbound_cfg.id(),
         target_peer_id: inbound.cfg.id(),
         sender_listen_port: Some(outbound_port),

--- a/chain/network/src/peer_manager/tests/nonce.rs
+++ b/chain/network/src/peer_manager/tests/nonce.rs
@@ -62,7 +62,7 @@ async fn test_nonces() {
         let peer_id = PeerId::new(peer_key.public_key());
         let handshake = PeerMessage::Tier2Handshake(Handshake {
             protocol_version: version::PROTOCOL_VERSION,
-            oldest_supported_version: version::PEER_MIN_ALLOWED_PROTOCOL_VERSION,
+            oldest_supported_version: version::MIN_SUPPORTED_PROTOCOL_VERSION,
             sender_peer_id: peer_id.clone(),
             target_peer_id: pm.cfg.node_id(),
             // we have to set this even if we have no intention of listening since otherwise

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -432,8 +432,3 @@ const NIGHTLY_PROTOCOL_VERSION: ProtocolVersion = 149;
 /// Largest protocol version supported by the current binary.
 pub const PROTOCOL_VERSION: ProtocolVersion =
     if cfg!(feature = "nightly") { NIGHTLY_PROTOCOL_VERSION } else { STABLE_PROTOCOL_VERSION };
-
-/// Both, outgoing and incoming tcp connections to peers, will be rejected if `peer's`
-/// protocol version is lower than this.
-/// TODO(pugachag): revert back to `- 3` after mainnet is upgraded
-pub const PEER_MIN_ALLOWED_PROTOCOL_VERSION: ProtocolVersion = STABLE_PROTOCOL_VERSION - 4;

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -16,7 +16,6 @@ use crate::upgrade_schedule::ProtocolUpgradeVotingSchedule;
 /// near_primitives_core re-exports
 pub use near_primitives_core::types::ProtocolVersion;
 pub use near_primitives_core::version::MIN_SUPPORTED_PROTOCOL_VERSION;
-pub use near_primitives_core::version::PEER_MIN_ALLOWED_PROTOCOL_VERSION;
 pub use near_primitives_core::version::PROD_GENESIS_PROTOCOL_VERSION;
 pub use near_primitives_core::version::PROTOCOL_VERSION;
 pub use near_primitives_core::version::ProtocolFeature;


### PR DESCRIPTION
We now use `MIN_SUPPORTED_PROTOCOL_VERSION` in favor of `PEER_MIN_ALLOWED_PROTOCOL_VERSION`.

Technically `PEER_MIN_ALLOWED_PROTOCOL_VERSION` is no longer correct if it is below `MIN_SUPPORTED_PROTOCOL_VERSION`