### PR TITLE
[ci] run Cargo check publishable packages only in merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,6 +367,7 @@ jobs:
   publishable_packages_check:
     name: "Cargo check publishable packages separately"
     runs-on: ${{ matrix.os }}
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
I've noticed the [Cargo check publishable packages separately (Windows, win, windows-latest)](https://github.com/near/nearcore/actions/runs/15063554183/job/42343254085#logs) takes upwards of 15 min to complete. To improve upon efficiency and time to merge queue it makes sense to only run this CI in the merge queue.