### PR TITLE
refactor: Remove ultra_slow_test_clear_old_data_too_many_heights

### DIFF
--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -119,9 +119,6 @@ expensive integration-tests integration_tests tests::client::sync_state_nodes::u
 expensive integration-tests integration_tests tests::client::sync_state_nodes::ultra_slow_test_dump_epoch_missing_chunk_in_last_block
 expensive integration-tests integration_tests tests::client::sync_state_nodes::ultra_slow_test_dump_epoch_missing_chunk_in_last_block --features nightly
 
-# other tests
-expensive --timeout=300 near-chain near_chain tests::garbage_collection::ultra_slow_test_clear_old_data_too_many_heights
-
 expensive integration-tests integration_tests tests::other_tests::test_simple::ultra_slow_test_2_10_multiple_nodes
 expensive integration-tests integration_tests tests::other_tests::test_simple::ultra_slow_test_2_10_multiple_nodes --features nightly
 expensive integration-tests integration_tests tests::other_tests::test_simple::ultra_slow_test_4_10_multiple_nodes


### PR DESCRIPTION
Follow-up to
https://github.com/near/nearcore/pull/13549#discussion_r2091565286c

The test was broken for 15 months and is now failing for a reason unrelated to the reason for which it was disabled.