### PR TITLE
feat: add promise batch host functions for global contracts

### DIFF
--- a/core/parameters/res/runtime_configs/78.yaml
+++ b/core/parameters/res/runtime_configs/78.yaml
@@ -7,16 +7,4 @@ pessimistic_gas_price_inflation:
     new: { numerator: 1, denominator: 1 },
   }
 refund_gas_price_changes: { old: true, new: false }
-gas_refund_penalty:
-  {
-    old: { numerator: 0, denominator: 100 },
-    new: { numerator: 5, denominator: 100 },
-  }
-min_gas_refund_penalty: {
-    old: 0,
-    # 1 Tgas
-    # Reasoning: https://github.com/near/NEPs/pull/536#issuecomment-2821455514
-    new: 1_000_000_000_000,
-  }
-
 global_contract_host_fns: { old: false, new: true }

--- a/core/parameters/res/runtime_configs/78.yaml
+++ b/core/parameters/res/runtime_configs/78.yaml
@@ -7,4 +7,16 @@ pessimistic_gas_price_inflation:
     new: { numerator: 1, denominator: 1 },
   }
 refund_gas_price_changes: { old: true, new: false }
+gas_refund_penalty:
+  {
+    old: { numerator: 0, denominator: 100 },
+    new: { numerator: 5, denominator: 100 },
+  }
+min_gas_refund_penalty: {
+    old: 0,
+    # 1 Tgas
+    # Reasoning: https://github.com/near/NEPs/pull/536#issuecomment-2821455514
+    new: 1_000_000_000_000,
+  }
 
+global_contract_host_fns: { old: false, new: true }

--- a/core/parameters/res/runtime_configs/parameters.snap
+++ b/core/parameters/res/runtime_configs/parameters.snap
@@ -236,3 +236,4 @@ action_use_global_contract_per_identifier_byte
 - send_not_sir:           47_683_715
 - execution:              64_572_944
 saturating_float_to_int                 true
+global_contract_host_fns                true

--- a/core/parameters/res/runtime_configs/parameters.yaml
+++ b/core/parameters/res/runtime_configs/parameters.yaml
@@ -246,6 +246,7 @@ vm_kind: Wasmer0
 eth_implicit_accounts: false
 discard_custom_sections: false
 saturating_float_to_int: false
+global_contract_host_fns: false
 
 
 # Congestion Control configuration

--- a/core/parameters/res/runtime_configs/parameters_testnet.yaml
+++ b/core/parameters/res/runtime_configs/parameters_testnet.yaml
@@ -241,6 +241,7 @@ vm_kind: Wasmer0
 eth_implicit_accounts: false
 discard_custom_sections: false
 saturating_float_to_int: false
+global_contract_host_fns: false
 
 # TODO What should be the config for testnet?
 

--- a/core/parameters/src/parameter.rs
+++ b/core/parameters/src/parameter.rs
@@ -235,6 +235,7 @@ pub enum Parameter {
     ActionUseGlobalContract,
     ActionUseGlobalContractPerIdentifierByte,
     SaturatingFloatToInt,
+    GlobalContractHostFns,
 }
 
 #[derive(

--- a/core/parameters/src/parameter_table.rs
+++ b/core/parameters/src/parameter_table.rs
@@ -329,6 +329,7 @@ impl TryFrom<&ParameterTable> for RuntimeConfig {
                 },
                 implicit_account_creation: params.get(Parameter::ImplicitAccountCreation)?,
                 eth_implicit_accounts: params.get(Parameter::EthImplicitAccounts)?,
+                global_contract_host_fns: params.get(Parameter::GlobalContractHostFns)?,
             }),
             account_creation_config: AccountCreationConfig {
                 min_allowed_top_level_account_length: params

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__0.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__0.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": false,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__129.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": true,
     "saturating_float_to_int": true,
+    "global_contract_host_fns": true,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": true,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__35.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__35.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__42.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__42.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__46.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__46.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__48.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__48.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__49.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__49.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__50.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__50.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__52.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__52.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__53.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__53.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__55.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__55.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__57.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__57.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__59.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__59.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__61.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__61.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__62.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__62.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__63.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__63.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__64.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__64.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__66.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__66.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__67.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__67.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__68.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__68.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__69.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__69.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__70.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__70.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": true,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__72.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__72.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": true,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__73.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__73.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": true,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__74.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__74.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": true,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__77.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__77.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": true,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__78.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__78.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": true,
     "saturating_float_to_int": true,
+    "global_contract_host_fns": true,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_0.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_0.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": false,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": true,
     "saturating_float_to_int": true,
+    "global_contract_host_fns": true,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": true,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_35.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_35.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_42.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_42.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_46.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_46.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_48.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_48.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_49.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_49.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_50.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_50.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_52.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_52.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_53.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_53.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_55.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_55.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_57.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_57.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_59.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_59.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "Trie",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_61.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_61.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_62.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_62.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_63.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_63.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_64.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_64.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_66.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_66.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_67.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_67.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_68.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_68.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_69.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_69.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": false,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_70.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_70.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": true,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_72.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_72.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": true,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_73.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_73.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": true,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_74.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_74.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": true,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_77.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_77.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": true,
     "saturating_float_to_int": false,
+    "global_contract_host_fns": false,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_78.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_78.json.snap
@@ -199,6 +199,7 @@ expression: config_view
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": true,
     "saturating_float_to_int": true,
+    "global_contract_host_fns": true,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/snapshots/near_parameters__view__tests__runtime_config_view.snap
+++ b/core/parameters/src/snapshots/near_parameters__view__tests__runtime_config_view.snap
@@ -199,6 +199,7 @@ expression: "&view"
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": true,
     "saturating_float_to_int": true,
+    "global_contract_host_fns": true,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/core/parameters/src/view.rs
+++ b/core/parameters/src/view.rs
@@ -216,6 +216,8 @@ pub struct VMConfigView {
     pub discard_custom_sections: bool,
     /// See [VMConfig::saturating_float_to_int](crate::vm::Config::saturating_float_to_int).
     pub saturating_float_to_int: bool,
+    /// See [VMConfig::global_contract_host_fns](crate::vm::Config::global_contract_host_fns).
+    pub global_contract_host_fns: bool,
 
     /// See [VMConfig::storage_get_mode](crate::vm::Config::storage_get_mode).
     pub storage_get_mode: crate::vm::StorageGetMode,
@@ -247,6 +249,7 @@ impl From<crate::vm::Config> for VMConfigView {
             vm_kind: config.vm_kind,
             eth_implicit_accounts: config.eth_implicit_accounts,
             saturating_float_to_int: config.saturating_float_to_int,
+            global_contract_host_fns: config.global_contract_host_fns,
         }
     }
 }
@@ -265,6 +268,7 @@ impl From<VMConfigView> for crate::vm::Config {
             vm_kind: view.vm_kind,
             eth_implicit_accounts: view.eth_implicit_accounts,
             saturating_float_to_int: view.saturating_float_to_int,
+            global_contract_host_fns: view.global_contract_host_fns,
         }
     }
 }

--- a/core/parameters/src/vm.rs
+++ b/core/parameters/src/vm.rs
@@ -171,6 +171,9 @@ pub struct Config {
     /// Whether to enable saturating float-to-integer wasm operators.
     pub saturating_float_to_int: bool,
 
+    /// Whether to enable global contract related host functions.
+    pub global_contract_host_fns: bool,
+
     /// Describes limits for VM and Runtime.
     pub limit_config: LimitConfig,
 }
@@ -197,6 +200,7 @@ impl Config {
 
     pub fn enable_all_features(&mut self) {
         self.eth_implicit_accounts = true;
+        self.global_contract_host_fns = true;
         self.implicit_account_creation = true;
     }
 }

--- a/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
+++ b/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
@@ -199,6 +199,7 @@ expression: "&view"
     "vm_kind": "<REDACTED>",
     "discard_custom_sections": true,
     "saturating_float_to_int": true,
+    "global_contract_host_fns": true,
     "storage_get_mode": "FlatStorage",
     "fix_contract_loading_cost": false,
     "implicit_account_creation": true,

--- a/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile.snap
+++ b/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile.snap
@@ -46,6 +46,16 @@ expression: receipts_gas_profile
         },
         CostGasUsed {
             cost_category: "ACTION_COST",
+            cost: "DEPLOY_GLOBAL_CONTRACT_BASE",
+            gas_used: 369531500000,
+        },
+        CostGasUsed {
+            cost_category: "ACTION_COST",
+            cost: "DEPLOY_GLOBAL_CONTRACT_BYTE",
+            gas_used: 3242492620,
+        },
+        CostGasUsed {
+            cost_category: "ACTION_COST",
             cost: "FUNCTION_CALL_BASE",
             gas_used: 1800000000000,
         },
@@ -102,7 +112,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "BASE",
-            gas_used: 17209927215,
+            gas_used: 17739463437,
         },
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
@@ -147,12 +157,12 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "READ_MEMORY_BASE",
-            gas_used: 182690424000,
+            gas_used: 187910150400,
         },
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "READ_MEMORY_BYTE",
-            gas_used: 4744063584,
+            gas_used: 5002554228,
         },
         CostGasUsed {
             cost_category: "WASM_HOST_COST",

--- a/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile_nightly.snap
+++ b/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile_nightly.snap
@@ -46,6 +46,16 @@ expression: receipts_gas_profile
         },
         CostGasUsed {
             cost_category: "ACTION_COST",
+            cost: "DEPLOY_GLOBAL_CONTRACT_BASE",
+            gas_used: 369531500000,
+        },
+        CostGasUsed {
+            cost_category: "ACTION_COST",
+            cost: "DEPLOY_GLOBAL_CONTRACT_BYTE",
+            gas_used: 3242492620,
+        },
+        CostGasUsed {
+            cost_category: "ACTION_COST",
             cost: "FUNCTION_CALL_BASE",
             gas_used: 1800000000000,
         },
@@ -102,7 +112,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "BASE",
-            gas_used: 17209927215,
+            gas_used: 17739463437,
         },
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
@@ -147,12 +157,12 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "READ_MEMORY_BASE",
-            gas_used: 182690424000,
+            gas_used: 187910150400,
         },
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "READ_MEMORY_BYTE",
-            gas_used: 4744063584,
+            gas_used: 5002554228,
         },
         CostGasUsed {
             cost_category: "WASM_HOST_COST",

--- a/runtime/near-test-contracts/congestion-control-test-contract/src/lib.rs
+++ b/runtime/near-test-contracts/congestion-control-test-contract/src/lib.rs
@@ -76,6 +76,8 @@ extern "C" {
     // #######################
     fn promise_batch_action_create_account(promise_index: u64);
     fn promise_batch_action_deploy_contract(promise_index: u64, code_len: u64, code_ptr: u64);
+    fn promise_batch_action_deploy_global_contract(promise_index: u64, code_len: u64, code_ptr: u64);
+    fn promise_batch_action_deploy_global_contract_by_account_id(promise_index: u64, code_len: u64, code_ptr: u64);
     fn promise_batch_action_function_call(
         promise_index: u64,
         method_name_len: u64,

--- a/runtime/near-test-contracts/congestion-control-test-contract/src/lib.rs
+++ b/runtime/near-test-contracts/congestion-control-test-contract/src/lib.rs
@@ -78,6 +78,8 @@ extern "C" {
     fn promise_batch_action_deploy_contract(promise_index: u64, code_len: u64, code_ptr: u64);
     fn promise_batch_action_deploy_global_contract(promise_index: u64, code_len: u64, code_ptr: u64);
     fn promise_batch_action_deploy_global_contract_by_account_id(promise_index: u64, code_len: u64, code_ptr: u64);
+    fn promise_batch_action_use_global_contract(promise_index: u64, code_hash_len: u64, code_hash_ptr: u64);
+    fn promise_batch_action_use_global_contract_by_account_id(promise_index: u64, account_id_len: u64, account_id_ptr: u64);
     fn promise_batch_action_function_call(
         promise_index: u64,
         method_name_len: u64,

--- a/runtime/near-test-contracts/contract-for-fuzzing-rs/src/lib.rs
+++ b/runtime/near-test-contracts/contract-for-fuzzing-rs/src/lib.rs
@@ -76,6 +76,8 @@ extern "C" {
     fn promise_batch_action_deploy_contract(promise_index: u64, code_len: u64, code_ptr: u64);
     fn promise_batch_action_deploy_global_contract(promise_index: u64, code_len: u64, code_ptr: u64);
     fn promise_batch_action_deploy_global_contract_by_account_id(promise_index: u64, code_len: u64, code_ptr: u64);
+    fn promise_batch_action_use_global_contract(promise_index: u64, code_hash_len: u64, code_hash_ptr: u64);
+    fn promise_batch_action_use_global_contract_by_account_id(promise_index: u64, account_id_len: u64, account_id_ptr: u64);
     fn promise_batch_action_function_call(
         promise_index: u64,
         method_name_len: u64,

--- a/runtime/near-test-contracts/contract-for-fuzzing-rs/src/lib.rs
+++ b/runtime/near-test-contracts/contract-for-fuzzing-rs/src/lib.rs
@@ -74,6 +74,8 @@ extern "C" {
     // #######################
     fn promise_batch_action_create_account(promise_index: u64);
     fn promise_batch_action_deploy_contract(promise_index: u64, code_len: u64, code_ptr: u64);
+    fn promise_batch_action_deploy_global_contract(promise_index: u64, code_len: u64, code_ptr: u64);
+    fn promise_batch_action_deploy_global_contract_by_account_id(promise_index: u64, code_len: u64, code_ptr: u64);
     fn promise_batch_action_function_call(
         promise_index: u64,
         method_name_len: u64,

--- a/runtime/near-test-contracts/estimator-contract/src/lib.rs
+++ b/runtime/near-test-contracts/estimator-contract/src/lib.rs
@@ -130,6 +130,8 @@ extern "C" {
     fn promise_batch_action_deploy_contract(promise_index: u64, code_len: u64, code_ptr: u64);
     fn promise_batch_action_deploy_global_contract(promise_index: u64, code_len: u64, code_ptr: u64);
     fn promise_batch_action_deploy_global_contract_by_account_id(promise_index: u64, code_len: u64, code_ptr: u64);
+    fn promise_batch_action_use_global_contract(promise_index: u64, code_hash_len: u64, code_hash_ptr: u64);
+    fn promise_batch_action_use_global_contract_by_account_id(promise_index: u64, account_id_len: u64, account_id_ptr: u64);
     fn promise_batch_action_function_call(
         promise_index: u64,
         method_name_len: u64,

--- a/runtime/near-test-contracts/estimator-contract/src/lib.rs
+++ b/runtime/near-test-contracts/estimator-contract/src/lib.rs
@@ -128,6 +128,8 @@ extern "C" {
     // #######################
     fn promise_batch_action_create_account(promise_index: u64);
     fn promise_batch_action_deploy_contract(promise_index: u64, code_len: u64, code_ptr: u64);
+    fn promise_batch_action_deploy_global_contract(promise_index: u64, code_len: u64, code_ptr: u64);
+    fn promise_batch_action_deploy_global_contract_by_account_id(promise_index: u64, code_len: u64, code_ptr: u64);
     fn promise_batch_action_function_call(
         promise_index: u64,
         method_name_len: u64,

--- a/runtime/near-test-contracts/test-contract-rs/src/lib.rs
+++ b/runtime/near-test-contracts/test-contract-rs/src/lib.rs
@@ -76,6 +76,8 @@ extern "C" {
     fn promise_batch_action_deploy_contract(promise_index: u64, code_len: u64, code_ptr: u64);
     fn promise_batch_action_deploy_global_contract(promise_index: u64, code_len: u64, code_ptr: u64);
     fn promise_batch_action_deploy_global_contract_by_account_id(promise_index: u64, code_len: u64, code_ptr: u64);
+    fn promise_batch_action_use_global_contract(promise_index: u64, code_hash_len: u64, code_hash_ptr: u64);
+    fn promise_batch_action_use_global_contract_by_account_id(promise_index: u64, account_id_len: u64, account_id_ptr: u64);
     fn promise_batch_action_function_call(
         promise_index: u64,
         method_name_len: u64,
@@ -837,6 +839,24 @@ fn call_promise() {
                     promise_index,
                     code.len() as u64,
                     code.as_ptr() as u64,
+                );
+                promise_index
+            } else if let Some(action) = arg.get("action_use_global_contract") {
+                let promise_index = action["promise_index"].as_i64().unwrap() as u64;
+                let code_hash = from_base64(action["code_hash"].as_str().unwrap());
+                promise_batch_action_use_global_contract(
+                    promise_index,
+                    code_hash.len() as u64,
+                    code_hash.as_ptr() as u64,
+                );
+                promise_index
+            } else if let Some(action) = arg.get("action_use_global_contract_by_account_id") {
+                let promise_index = action["promise_index"].as_i64().unwrap() as u64;
+                let account_id = action["account_id"].as_str().unwrap().as_bytes();
+                promise_batch_action_use_global_contract_by_account_id(
+                    promise_index,
+                    account_id.len() as u64,
+                    account_id.as_ptr() as u64,
                 );
                 promise_index
             } else if let Some(action) = arg.get("action_function_call") {

--- a/runtime/near-test-contracts/test-contract-rs/src/lib.rs
+++ b/runtime/near-test-contracts/test-contract-rs/src/lib.rs
@@ -74,6 +74,8 @@ extern "C" {
     // #######################
     fn promise_batch_action_create_account(promise_index: u64);
     fn promise_batch_action_deploy_contract(promise_index: u64, code_len: u64, code_ptr: u64);
+    fn promise_batch_action_deploy_global_contract(promise_index: u64, code_len: u64, code_ptr: u64);
+    fn promise_batch_action_deploy_global_contract_by_account_id(promise_index: u64, code_len: u64, code_ptr: u64);
     fn promise_batch_action_function_call(
         promise_index: u64,
         method_name_len: u64,
@@ -819,6 +821,24 @@ fn call_promise() {
                     code.as_ptr() as u64,
                 );
                 promise_index
+            } else if let Some(action) = arg.get("action_deploy_global_contract") {
+                let promise_index = action["promise_index"].as_i64().unwrap() as u64;
+                let code = from_base64(action["code"].as_str().unwrap());
+                promise_batch_action_deploy_global_contract(
+                    promise_index,
+                    code.len() as u64,
+                    code.as_ptr() as u64,
+                );
+                promise_index
+            } else if let Some(action) = arg.get("action_deploy_global_contract_by_account_id") {
+                let promise_index = action["promise_index"].as_i64().unwrap() as u64;
+                let code = from_base64(action["code"].as_str().unwrap());
+                promise_batch_action_deploy_global_contract_by_account_id(
+                    promise_index,
+                    code.len() as u64,
+                    code.as_ptr() as u64,
+                );
+                promise_index
             } else if let Some(action) = arg.get("action_function_call") {
                 let promise_index = action["promise_index"].as_i64().unwrap() as u64;
                 let method_name = action["method_name"].as_str().unwrap().as_bytes();
@@ -1386,6 +1406,16 @@ pub unsafe fn sanity_check() {
         &amount_non_zero as *const u128 as *const u64 as u64,
     );
     promise_batch_action_deploy_contract(
+        batch_promise_idx,
+        contract_code.len() as u64,
+        contract_code.as_ptr() as u64,
+    );
+    promise_batch_action_deploy_global_contract(
+        batch_promise_idx,
+        contract_code.len() as u64,
+        contract_code.as_ptr() as u64,
+    );
+    promise_batch_action_deploy_global_contract_by_account_id(
         batch_promise_idx,
         contract_code.len() as u64,
         contract_code.as_ptr() as u64,

--- a/runtime/near-test-contracts/test-contract-rs/src/lib.rs
+++ b/runtime/near-test-contracts/test-contract-rs/src/lib.rs
@@ -74,9 +74,13 @@ extern "C" {
     // #######################
     fn promise_batch_action_create_account(promise_index: u64);
     fn promise_batch_action_deploy_contract(promise_index: u64, code_len: u64, code_ptr: u64);
+    #[cfg(feature = "latest_protocol")]
     fn promise_batch_action_deploy_global_contract(promise_index: u64, code_len: u64, code_ptr: u64);
+    #[cfg(feature = "latest_protocol")]
     fn promise_batch_action_deploy_global_contract_by_account_id(promise_index: u64, code_len: u64, code_ptr: u64);
+    #[cfg(feature = "latest_protocol")]
     fn promise_batch_action_use_global_contract(promise_index: u64, code_hash_len: u64, code_hash_ptr: u64);
+    #[cfg(feature = "latest_protocol")]
     fn promise_batch_action_use_global_contract_by_account_id(promise_index: u64, account_id_len: u64, account_id_ptr: u64);
     fn promise_batch_action_function_call(
         promise_index: u64,
@@ -823,42 +827,6 @@ fn call_promise() {
                     code.as_ptr() as u64,
                 );
                 promise_index
-            } else if let Some(action) = arg.get("action_deploy_global_contract") {
-                let promise_index = action["promise_index"].as_i64().unwrap() as u64;
-                let code = from_base64(action["code"].as_str().unwrap());
-                promise_batch_action_deploy_global_contract(
-                    promise_index,
-                    code.len() as u64,
-                    code.as_ptr() as u64,
-                );
-                promise_index
-            } else if let Some(action) = arg.get("action_deploy_global_contract_by_account_id") {
-                let promise_index = action["promise_index"].as_i64().unwrap() as u64;
-                let code = from_base64(action["code"].as_str().unwrap());
-                promise_batch_action_deploy_global_contract_by_account_id(
-                    promise_index,
-                    code.len() as u64,
-                    code.as_ptr() as u64,
-                );
-                promise_index
-            } else if let Some(action) = arg.get("action_use_global_contract") {
-                let promise_index = action["promise_index"].as_i64().unwrap() as u64;
-                let code_hash = from_base64(action["code_hash"].as_str().unwrap());
-                promise_batch_action_use_global_contract(
-                    promise_index,
-                    code_hash.len() as u64,
-                    code_hash.as_ptr() as u64,
-                );
-                promise_index
-            } else if let Some(action) = arg.get("action_use_global_contract_by_account_id") {
-                let promise_index = action["promise_index"].as_i64().unwrap() as u64;
-                let account_id = action["account_id"].as_str().unwrap().as_bytes();
-                promise_batch_action_use_global_contract_by_account_id(
-                    promise_index,
-                    account_id.len() as u64,
-                    account_id.as_ptr() as u64,
-                );
-                promise_index
             } else if let Some(action) = arg.get("action_function_call") {
                 let promise_index = action["promise_index"].as_i64().unwrap() as u64;
                 let method_name = action["method_name"].as_str().unwrap().as_bytes();
@@ -1430,11 +1398,13 @@ pub unsafe fn sanity_check() {
         contract_code.len() as u64,
         contract_code.as_ptr() as u64,
     );
+    #[cfg(feature = "latest_protocol")]
     promise_batch_action_deploy_global_contract(
         batch_promise_idx,
         contract_code.len() as u64,
         contract_code.as_ptr() as u64,
     );
+    #[cfg(feature = "latest_protocol")]
     promise_batch_action_deploy_global_contract_by_account_id(
         batch_promise_idx,
         contract_code.len() as u64,

--- a/runtime/near-vm-runner/src/imports.rs
+++ b/runtime/near-vm-runner/src/imports.rs
@@ -170,6 +170,8 @@ imports! {
     // #######################
     promise_batch_action_create_account<[promise_index: u64] -> []>,
     promise_batch_action_deploy_contract<[promise_index: u64, code_len: u64, code_ptr: u64] -> []>,
+    promise_batch_action_deploy_global_contract<[promise_index: u64, code_len: u64, code_ptr: u64] -> []>,
+    promise_batch_action_deploy_global_contract_by_account_id<[promise_index: u64, code_len: u64, code_ptr: u64] -> []>,
     promise_batch_action_function_call<[
         promise_index: u64,
         method_name_len: u64,

--- a/runtime/near-vm-runner/src/imports.rs
+++ b/runtime/near-vm-runner/src/imports.rs
@@ -172,6 +172,8 @@ imports! {
     promise_batch_action_deploy_contract<[promise_index: u64, code_len: u64, code_ptr: u64] -> []>,
     #[global_contract_host_fns] promise_batch_action_deploy_global_contract<[promise_index: u64, code_len: u64, code_ptr: u64] -> []>,
     #[global_contract_host_fns] promise_batch_action_deploy_global_contract_by_account_id<[promise_index: u64, code_len: u64, code_ptr: u64] -> []>,
+    #[global_contract_host_fns] promise_batch_action_use_global_contract<[promise_index: u64, code_hash_len: u64, code_hash_ptr: u64] -> []>,
+    #[global_contract_host_fns] promise_batch_action_use_global_contract_by_account_id<[promise_index: u64, account_id_len: u64, account_id_ptr: u64] -> []>,
     promise_batch_action_function_call<[
         promise_index: u64,
         method_name_len: u64,

--- a/runtime/near-vm-runner/src/imports.rs
+++ b/runtime/near-vm-runner/src/imports.rs
@@ -170,8 +170,8 @@ imports! {
     // #######################
     promise_batch_action_create_account<[promise_index: u64] -> []>,
     promise_batch_action_deploy_contract<[promise_index: u64, code_len: u64, code_ptr: u64] -> []>,
-    promise_batch_action_deploy_global_contract<[promise_index: u64, code_len: u64, code_ptr: u64] -> []>,
-    promise_batch_action_deploy_global_contract_by_account_id<[promise_index: u64, code_len: u64, code_ptr: u64] -> []>,
+    #[global_contract_host_fns] promise_batch_action_deploy_global_contract<[promise_index: u64, code_len: u64, code_ptr: u64] -> []>,
+    #[global_contract_host_fns] promise_batch_action_deploy_global_contract_by_account_id<[promise_index: u64, code_len: u64, code_ptr: u64] -> []>,
     promise_batch_action_function_call<[
         promise_index: u64,
         method_name_len: u64,

--- a/runtime/near-vm-runner/src/logic/dependencies.rs
+++ b/runtime/near-vm-runner/src/logic/dependencies.rs
@@ -1,6 +1,6 @@
 //! External dependencies of the near-vm-logic.
 use super::VMLogicError;
-use super::types::ReceiptIndex;
+use super::types::{GlobalContractDeployMode, ReceiptIndex};
 use near_crypto::PublicKey;
 use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::{AccountId, Balance, Gas, GasWeight, Nonce};
@@ -343,6 +343,24 @@ pub trait External {
         &mut self,
         receipt_index: ReceiptIndex,
         code: Vec<u8>,
+    ) -> Result<(), VMLogicError>;
+
+    /// Attach the [`DeployGlobalContractAction`] action to an existing receipt.
+    ///
+    /// # Arguments
+    ///
+    /// * `receipt_index` - an index of Receipt to append an action
+    /// * `code` - a Wasm code to attach
+    /// * `mode` - contract deploy mode
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `receipt_index` does not refer to a known receipt.
+    fn append_action_deploy_global_contract(
+        &mut self,
+        receipt_index: ReceiptIndex,
+        code: Vec<u8>,
+        mode: GlobalContractDeployMode,
     ) -> Result<(), VMLogicError>;
 
     /// Attach the [`FunctionCallAction`] action to an existing receipt.

--- a/runtime/near-vm-runner/src/logic/dependencies.rs
+++ b/runtime/near-vm-runner/src/logic/dependencies.rs
@@ -1,6 +1,6 @@
 //! External dependencies of the near-vm-logic.
 use super::VMLogicError;
-use super::types::{GlobalContractDeployMode, ReceiptIndex};
+use super::types::{GlobalContractDeployMode, GlobalContractIdentifier, ReceiptIndex};
 use near_crypto::PublicKey;
 use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::{AccountId, Balance, Gas, GasWeight, Nonce};
@@ -361,6 +361,22 @@ pub trait External {
         receipt_index: ReceiptIndex,
         code: Vec<u8>,
         mode: GlobalContractDeployMode,
+    ) -> Result<(), VMLogicError>;
+
+    /// Attach the [`UseGlobalContractAction`] action to an existing receipt.
+    ///
+    /// # Arguments
+    ///
+    /// * `receipt_index` - an index of Receipt to append an action
+    /// * `contract_id` - identifier of the contract to use
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `receipt_index` does not refer to a known receipt.
+    fn append_action_use_global_contract(
+        &mut self,
+        receipt_index: ReceiptIndex,
+        contract_id: GlobalContractIdentifier,
     ) -> Result<(), VMLogicError>;
 
     /// Attach the [`FunctionCallAction`] action to an existing receipt.

--- a/runtime/near-vm-runner/src/logic/errors.rs
+++ b/runtime/near-vm-runner/src/logic/errors.rs
@@ -276,6 +276,8 @@ pub enum HostError {
     RecordedStorageExceeded {
         limit: ByteSize,
     },
+    /// Contract code hash is malformed.
+    ContractCodeHashMalformed,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -519,6 +521,7 @@ impl std::fmt::Display for HostError {
                 "Size of the recorded trie storage proof has exceeded the allowed limit ({})",
                 limit
             ),
+            ContractCodeHashMalformed => write!(f, "contract code hash is malformed"),
         }
     }
 }

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -2221,7 +2221,7 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
         let (receipt_idx, sir) = self.promise_idx_to_receipt_idx_with_sir(promise_idx)?;
 
         self.pay_action_base(ActionCosts::deploy_global_contract_base, sir)?;
-        self.pay_action_per_byte(ActionCosts::deploy_global_contract_base, code_len, sir)?;
+        self.pay_action_per_byte(ActionCosts::deploy_global_contract_byte, code_len, sir)?;
 
         self.ext.append_action_deploy_global_contract(receipt_idx, code, mode)?;
         Ok(())

--- a/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
+++ b/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
@@ -1,6 +1,6 @@
 use crate::ContractCode;
 use crate::logic::dependencies::{Result, StorageAccessTracker};
-use crate::logic::types::ReceiptIndex;
+use crate::logic::types::{GlobalContractDeployMode, ReceiptIndex};
 use crate::logic::{External, ValuePtr};
 use near_primitives_core::hash::{CryptoHash, hash};
 use near_primitives_core::types::{AccountId, Balance, Gas, GasWeight};
@@ -24,6 +24,11 @@ pub enum MockAction {
     DeployContract {
         receipt_index: ReceiptIndex,
         code: Vec<u8>,
+    },
+    DeployGlobalContract {
+        receipt_index: ReceiptIndex,
+        code: Vec<u8>,
+        mode: GlobalContractDeployMode,
     },
     FunctionCallWeight {
         receipt_index: ReceiptIndex,
@@ -234,6 +239,16 @@ impl External for MockedExternal {
         code: Vec<u8>,
     ) -> Result<(), crate::logic::VMLogicError> {
         self.action_log.push(MockAction::DeployContract { receipt_index, code });
+        Ok(())
+    }
+
+    fn append_action_deploy_global_contract(
+        &mut self,
+        receipt_index: ReceiptIndex,
+        code: Vec<u8>,
+        mode: crate::logic::types::GlobalContractDeployMode,
+    ) -> Result<(), crate::logic::VMLogicError> {
+        self.action_log.push(MockAction::DeployGlobalContract { receipt_index, code, mode });
         Ok(())
     }
 

--- a/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
+++ b/runtime/near-vm-runner/src/logic/mocks/mock_external.rs
@@ -1,6 +1,6 @@
 use crate::ContractCode;
 use crate::logic::dependencies::{Result, StorageAccessTracker};
-use crate::logic::types::{GlobalContractDeployMode, ReceiptIndex};
+use crate::logic::types::{GlobalContractDeployMode, GlobalContractIdentifier, ReceiptIndex};
 use crate::logic::{External, ValuePtr};
 use near_primitives_core::hash::{CryptoHash, hash};
 use near_primitives_core::types::{AccountId, Balance, Gas, GasWeight};
@@ -29,6 +29,10 @@ pub enum MockAction {
         receipt_index: ReceiptIndex,
         code: Vec<u8>,
         mode: GlobalContractDeployMode,
+    },
+    UseGlobalContract {
+        receipt_index: ReceiptIndex,
+        contract_id: GlobalContractIdentifier,
     },
     FunctionCallWeight {
         receipt_index: ReceiptIndex,
@@ -249,6 +253,15 @@ impl External for MockedExternal {
         mode: crate::logic::types::GlobalContractDeployMode,
     ) -> Result<(), crate::logic::VMLogicError> {
         self.action_log.push(MockAction::DeployGlobalContract { receipt_index, code, mode });
+        Ok(())
+    }
+
+    fn append_action_use_global_contract(
+        &mut self,
+        receipt_index: ReceiptIndex,
+        contract_id: crate::logic::types::GlobalContractIdentifier,
+    ) -> Result<(), crate::logic::VMLogicError> {
+        self.action_log.push(MockAction::UseGlobalContract { receipt_index, contract_id });
         Ok(())
     }
 

--- a/runtime/near-vm-runner/src/logic/tests/gas_counter.rs
+++ b/runtime/near-vm-runner/src/logic/tests/gas_counter.rs
@@ -491,10 +491,10 @@ fn out_of_gas_deploy_global_contract_base() {
     );
 
     check_action_gas_exceeds_attached(
-        ActionCosts::deploy_contract_base,
+        ActionCosts::deploy_global_contract_base,
         1,
         expect!["119677812659 burnt 10000000000000 used"],
-        deploy_contract,
+        deploy_global_contract,
     );
 }
 
@@ -508,10 +508,10 @@ fn out_of_gas_deploy_global_contract_byte() {
     );
 
     check_action_gas_exceeds_attached(
-        ActionCosts::deploy_contract_byte,
+        ActionCosts::deploy_global_contract_byte,
         26,
         expect!["304443562909 burnt 10000000000000 used"],
-        deploy_contract,
+        deploy_global_contract,
     );
 }
 

--- a/runtime/near-vm-runner/src/logic/tests/gas_counter.rs
+++ b/runtime/near-vm-runner/src/logic/tests/gas_counter.rs
@@ -483,6 +483,49 @@ fn deploy_contract(logic: &mut TestVMLogic) -> Result<(), VMLogicError> {
 
 /// see longer comment above for how this test works
 #[test]
+fn out_of_gas_deploy_global_contract_base() {
+    check_action_gas_exceeds_limit(
+        ActionCosts::deploy_global_contract_base,
+        1,
+        deploy_global_contract,
+    );
+
+    check_action_gas_exceeds_attached(
+        ActionCosts::deploy_contract_base,
+        1,
+        expect!["119677812659 burnt 10000000000000 used"],
+        deploy_contract,
+    );
+}
+
+/// see longer comment above for how this test works
+#[test]
+fn out_of_gas_deploy_global_contract_byte() {
+    check_action_gas_exceeds_limit(
+        ActionCosts::deploy_global_contract_byte,
+        26,
+        deploy_global_contract,
+    );
+
+    check_action_gas_exceeds_attached(
+        ActionCosts::deploy_contract_byte,
+        26,
+        expect!["304443562909 burnt 10000000000000 used"],
+        deploy_contract,
+    );
+}
+
+/// function to trigger base + 26 bytes global contract deployment costs (26 is arbitrary)
+fn deploy_global_contract(logic: &mut TestVMLogic) -> Result<(), VMLogicError> {
+    let account_id = "rick.test";
+    let idx = promise_batch_create(logic, account_id)?;
+    let code = logic.internal_mem_write(b"lorem ipsum with length 26");
+    logic.promise_batch_action_deploy_global_contract(idx, code.len, code.ptr)?;
+    Ok(())
+}
+
+/// see longer comment above for how this test works
+#[test]
 fn out_of_gas_function_call_base() {
     check_action_gas_exceeds_limit(ActionCosts::function_call_base, 1, cross_contract_call);
     check_action_gas_exceeds_limit(

--- a/runtime/near-vm-runner/src/logic/tests/gas_counter.rs
+++ b/runtime/near-vm-runner/src/logic/tests/gas_counter.rs
@@ -6,6 +6,7 @@ use crate::logic::{HostError, VMLogicError};
 use crate::tests::test_vm_config;
 use expect_test::expect;
 use near_parameters::{ActionCosts, ExtCosts, Fee};
+use near_primitives_core::hash::CryptoHash;
 
 #[test]
 fn test_dont_burn_gas_when_exceeding_attached_gas_limit() {
@@ -521,6 +522,76 @@ fn deploy_global_contract(logic: &mut TestVMLogic) -> Result<(), VMLogicError> {
     let idx = promise_batch_create(logic, account_id)?;
     let code = logic.internal_mem_write(b"lorem ipsum with length 26");
     logic.promise_batch_action_deploy_global_contract(idx, code.len, code.ptr)?;
+    Ok(())
+}
+
+/// see longer comment above for how this test works
+#[test]
+fn out_of_gas_use_global_contract_base() {
+    check_action_gas_exceeds_limit(ActionCosts::use_global_contract_base, 1, use_global_contract);
+    check_action_gas_exceeds_limit(
+        ActionCosts::use_global_contract_base,
+        1,
+        use_global_contract_by_account_id,
+    );
+
+    check_action_gas_exceeds_attached(
+        ActionCosts::use_global_contract_base,
+        1,
+        expect!["119700620657 burnt 10000000000000 used"],
+        use_global_contract,
+    );
+    check_action_gas_exceeds_attached(
+        ActionCosts::use_global_contract_base,
+        1,
+        expect!["125644575182 burnt 10000000000000 used"],
+        use_global_contract_by_account_id,
+    );
+}
+
+/// see longer comment above for how this test works
+#[test]
+fn out_of_gas_use_global_contract_byte() {
+    check_action_gas_exceeds_limit(ActionCosts::use_global_contract_byte, 32, use_global_contract);
+    check_action_gas_exceeds_limit(
+        ActionCosts::use_global_contract_byte,
+        10,
+        use_global_contract_by_account_id,
+    );
+
+    check_action_gas_exceeds_attached(
+        ActionCosts::use_global_contract_byte,
+        32,
+        expect!["304466370967 burnt 10000000000000 used"],
+        use_global_contract,
+    );
+    check_action_gas_exceeds_attached(
+        ActionCosts::use_global_contract_byte,
+        10,
+        expect!["310410325272 burnt 10000000000000 used"],
+        use_global_contract_by_account_id,
+    );
+}
+
+/// function to trigger base + 32 bytes use global contract costs (32 is the length of `CryptoHash`)
+fn use_global_contract(logic: &mut TestVMLogic) -> Result<(), VMLogicError> {
+    let account_id = "rick.test";
+    let idx = promise_batch_create(logic, account_id)?;
+    let code_hash = logic.internal_mem_write(CryptoHash::hash_bytes(b"arbitrary").as_bytes());
+    logic.promise_batch_action_use_global_contract(idx, code_hash.len, code_hash.ptr)?;
+    Ok(())
+}
+
+/// function to trigger base + 10 bytes use global contract costs (10 is arbitrary)
+fn use_global_contract_by_account_id(logic: &mut TestVMLogic) -> Result<(), VMLogicError> {
+    let account_id = "rick.test";
+    let idx = promise_batch_create(logic, account_id)?;
+    let account_id = logic.internal_mem_write(b"alice.near");
+    logic.promise_batch_action_use_global_contract_by_account_id(
+        idx,
+        account_id.len,
+        account_id.ptr,
+    )?;
     Ok(())
 }
 

--- a/runtime/near-vm-runner/src/logic/tests/miscs.rs
+++ b/runtime/near-vm-runner/src/logic/tests/miscs.rs
@@ -387,11 +387,20 @@ fn test_contract_size_limit() {
     let promise_id = logic
         .promise_batch_create(account_id.len, account_id.ptr)
         .expect("Number of promises is under the limit");
+
     logic
         .promise_batch_action_deploy_contract(promise_id, limit, 0)
         .expect("The length of the contract code is under the limit");
     assert_eq!(
         logic.promise_batch_action_deploy_contract(promise_id, limit + 1, 0),
+        Err(HostError::ContractSizeExceeded { size: limit + 1, limit }.into())
+    );
+
+    logic
+        .promise_batch_action_deploy_global_contract(promise_id, limit, 0)
+        .expect("The length of the contract code is under the limit");
+    assert_eq!(
+        logic.promise_batch_action_deploy_global_contract(promise_id, limit + 1, 0),
         Err(HostError::ContractSizeExceeded { size: limit + 1, limit }.into())
     );
 }

--- a/runtime/near-vm-runner/src/logic/tests/promises.rs
+++ b/runtime/near-vm-runner/src/logic/tests/promises.rs
@@ -4,6 +4,7 @@ use crate::logic::tests::vm_logic_builder::VMLogicBuilder;
 use crate::logic::types::PromiseResult;
 
 use near_crypto::PublicKey;
+use near_primitives_core::hash::CryptoHash;
 use serde_json;
 
 fn vm_receipts<'a>(ext: &'a MockedExternal) -> Vec<impl serde::Serialize + 'a> {
@@ -361,6 +362,86 @@ fn test_promise_batch_action_deploy_global_contract() {
                 101
               ],
               "mode": "CodeHash"
+            }
+          }
+        ]"#]]
+    .assert_eq(&serde_json::to_string_pretty(&vm_receipts(&logic_builder.ext)).unwrap());
+}
+
+#[test]
+fn test_promise_batch_action_use_global_contract() {
+    let mut logic_builder = VMLogicBuilder::default();
+    let mut logic = logic_builder.build();
+    let index = promise_create(&mut logic, b"rick.test", 0, 0).expect("should create a promise");
+
+    let index_ptr = logic.internal_mem_write(&index.to_le_bytes()).ptr;
+    let code_hash = logic.internal_mem_write(CryptoHash::hash_bytes(b"arbitrary").as_bytes());
+    let malformed_code_hash = logic.internal_mem_write(b"not a valid CryptoHash repr");
+
+    logic
+        .promise_batch_action_use_global_contract(123, code_hash.len, code_hash.ptr)
+        .expect_err("shouldn't accept not existent promise index");
+    let non_receipt =
+        logic.promise_and(index_ptr, 1u64).expect("should create a non-receipt promise");
+    logic
+        .promise_batch_action_use_global_contract(non_receipt, code_hash.len, code_hash.ptr)
+        .expect_err("shouldn't accept non-receipt promise index");
+    logic
+        .promise_batch_action_use_global_contract(
+            123,
+            malformed_code_hash.len,
+            malformed_code_hash.ptr,
+        )
+        .expect_err("shouldn't accept malformed code hash");
+
+    logic
+        .promise_batch_action_use_global_contract(index, code_hash.len, code_hash.ptr)
+        .expect("should add an action to deploy contract");
+    assert_eq!(logic.used_gas().unwrap(), 5262559186522);
+    expect_test::expect![[r#"
+        [
+          {
+            "CreateReceipt": {
+              "receipt_indices": [],
+              "receiver_id": "rick.test"
+            }
+          },
+          {
+            "FunctionCallWeight": {
+              "receipt_index": 0,
+              "method_name": [
+                112,
+                114,
+                111,
+                109,
+                105,
+                115,
+                101,
+                95,
+                99,
+                114,
+                101,
+                97,
+                116,
+                101
+              ],
+              "args": [
+                97,
+                114,
+                103,
+                115
+              ],
+              "attached_deposit": 0,
+              "prepaid_gas": 0,
+              "gas_weight": 0
+            }
+          },
+          {
+            "UseGlobalContract": {
+              "receipt_index": 0,
+              "contract_id": {
+                "CodeHash": "A6buRpeED4eLGiYvbboigf7WSicK52xwKtdRNFwKcFgv"
+              }
             }
           }
         ]"#]]

--- a/runtime/near-vm-runner/src/logic/tests/promises.rs
+++ b/runtime/near-vm-runner/src/logic/tests/promises.rs
@@ -310,7 +310,7 @@ fn test_promise_batch_action_deploy_global_contract() {
     logic
         .promise_batch_action_deploy_global_contract(index, code.len, code.ptr)
         .expect("should add an action to deploy contract");
-    assert_eq!(logic.used_gas().unwrap(), 7472882202158);
+    assert_eq!(logic.used_gas().unwrap(), 5256154080152);
     expect_test::expect![[r#"
         [
           {
@@ -360,7 +360,7 @@ fn test_promise_batch_action_deploy_global_contract() {
                 108,
                 101
               ],
-              "mode": "code_hash",
+              "mode": "CodeHash"
             }
           }
         ]"#]]

--- a/runtime/near-vm-runner/src/logic/tests/view_method.rs
+++ b/runtime/near-vm-runner/src/logic/tests/view_method.rs
@@ -25,6 +25,8 @@ fn test_prohibited_view_methods() {
     test_prohibited!(promise_batch_then, 0, 0, 0);
     test_prohibited!(promise_batch_action_create_account, 0);
     test_prohibited!(promise_batch_action_deploy_contract, 0, 0, 0);
+    test_prohibited!(promise_batch_action_deploy_global_contract, 0, 0, 0);
+    test_prohibited!(promise_batch_action_deploy_global_contract_by_account_id, 0, 0, 0);
     test_prohibited!(promise_batch_action_function_call, 0, 0, 0, 0, 0, 0, 0);
     test_prohibited!(promise_batch_action_transfer, 0, 0);
     test_prohibited!(promise_batch_action_stake, 0, 0, 0, 0);

--- a/runtime/near-vm-runner/src/logic/tests/view_method.rs
+++ b/runtime/near-vm-runner/src/logic/tests/view_method.rs
@@ -27,6 +27,8 @@ fn test_prohibited_view_methods() {
     test_prohibited!(promise_batch_action_deploy_contract, 0, 0, 0);
     test_prohibited!(promise_batch_action_deploy_global_contract, 0, 0, 0);
     test_prohibited!(promise_batch_action_deploy_global_contract_by_account_id, 0, 0, 0);
+    test_prohibited!(promise_batch_action_use_global_contract, 0, 0, 0);
+    test_prohibited!(promise_batch_action_use_global_contract_by_account_id, 0, 0, 0);
     test_prohibited!(promise_batch_action_function_call, 0, 0, 0, 0, 0, 0, 0);
     test_prohibited!(promise_batch_action_transfer, 0, 0);
     test_prohibited!(promise_batch_action_stake, 0, 0, 0, 0);

--- a/runtime/near-vm-runner/src/logic/types.rs
+++ b/runtime/near-vm-runner/src/logic/types.rs
@@ -1,3 +1,4 @@
+use near_primitives_core::hash::CryptoHash;
 pub use near_primitives_core::types::*;
 
 pub type PublicKey = Vec<u8>;
@@ -42,4 +43,20 @@ pub enum PromiseResult {
 pub enum GlobalContractDeployMode {
     CodeHash,
     AccountId,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub enum GlobalContractIdentifier {
+    CodeHash(CryptoHash),
+    AccountId(AccountId),
+}
+
+impl GlobalContractIdentifier {
+    /// Corresponds to `near_primitives::action::GlobalContractIdentifier::len` impl
+    pub fn len(&self) -> usize {
+        match &self {
+            Self::CodeHash(_) => 32,
+            Self::AccountId(account_id) => account_id.len(),
+        }
+    }
 }

--- a/runtime/near-vm-runner/src/logic/types.rs
+++ b/runtime/near-vm-runner/src/logic/types.rs
@@ -37,3 +37,9 @@ pub enum PromiseResult {
     Successful(Vec<u8>),
     Failed,
 }
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub enum GlobalContractDeployMode {
+    CodeHash,
+    AccountId,
+}

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -12,7 +12,7 @@ use near_store::contract::ContractStorage;
 use near_store::trie::{AccessOptions, AccessTracker};
 use near_store::{KeyLookupMode, TrieUpdate, TrieUpdateValuePtr, has_promise_yield_receipt};
 use near_vm_runner::logic::errors::{AnyError, InconsistentStateError, VMLogicError};
-use near_vm_runner::logic::types::ReceiptIndex;
+use near_vm_runner::logic::types::{GlobalContractDeployMode, ReceiptIndex};
 use near_vm_runner::logic::{External, StorageAccessTracker, ValuePtr};
 use near_vm_runner::{Contract, ContractCode};
 use near_wallet_contract::wallet_contract;
@@ -385,6 +385,15 @@ impl<'a> External for RuntimeExt<'a> {
         code: Vec<u8>,
     ) -> Result<(), VMLogicError> {
         self.receipt_manager.append_action_deploy_contract(receipt_index, code)
+    }
+
+    fn append_action_deploy_global_contract(
+        &mut self,
+        receipt_index: ReceiptIndex,
+        code: Vec<u8>,
+        mode: GlobalContractDeployMode,
+    ) -> Result<(), VMLogicError> {
+        self.receipt_manager.append_action_deploy_global_contract(receipt_index, code, mode)
     }
 
     fn append_action_function_call_weight(

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -12,7 +12,9 @@ use near_store::contract::ContractStorage;
 use near_store::trie::{AccessOptions, AccessTracker};
 use near_store::{KeyLookupMode, TrieUpdate, TrieUpdateValuePtr, has_promise_yield_receipt};
 use near_vm_runner::logic::errors::{AnyError, InconsistentStateError, VMLogicError};
-use near_vm_runner::logic::types::{GlobalContractDeployMode, ReceiptIndex};
+use near_vm_runner::logic::types::{
+    GlobalContractDeployMode, GlobalContractIdentifier, ReceiptIndex,
+};
 use near_vm_runner::logic::{External, StorageAccessTracker, ValuePtr};
 use near_vm_runner::{Contract, ContractCode};
 use near_wallet_contract::wallet_contract;
@@ -394,6 +396,14 @@ impl<'a> External for RuntimeExt<'a> {
         mode: GlobalContractDeployMode,
     ) -> Result<(), VMLogicError> {
         self.receipt_manager.append_action_deploy_global_contract(receipt_index, code, mode)
+    }
+
+    fn append_action_use_global_contract(
+        &mut self,
+        receipt_index: ReceiptIndex,
+        contract_id: GlobalContractIdentifier,
+    ) -> Result<(), VMLogicError> {
+        self.receipt_manager.append_use_deploy_global_contract(receipt_index, contract_id)
     }
 
     fn append_action_function_call_weight(

--- a/runtime/runtime/src/receipt_manager.rs
+++ b/runtime/runtime/src/receipt_manager.rs
@@ -1,7 +1,8 @@
 use near_crypto::PublicKey;
 use near_primitives::action::{
     Action, AddKeyAction, CreateAccountAction, DeleteAccountAction, DeleteKeyAction,
-    DeployContractAction, FunctionCallAction, StakeAction, TransferAction,
+    DeployContractAction, DeployGlobalContractAction, FunctionCallAction, StakeAction,
+    TransferAction,
 };
 use near_primitives::errors::RuntimeError;
 use near_primitives::receipt::DataReceiver;
@@ -10,6 +11,7 @@ use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::{AccountId, Balance, Gas, GasWeight, Nonce};
 use near_vm_runner::logic::HostError;
 use near_vm_runner::logic::VMLogicError;
+use near_vm_runner::logic::types::GlobalContractDeployMode;
 use std::collections::HashMap;
 
 use crate::config::safe_add_gas;
@@ -238,6 +240,41 @@ impl ReceiptManager {
         code: Vec<u8>,
     ) -> Result<(), VMLogicError> {
         self.append_action(receipt_index, Action::DeployContract(DeployContractAction { code }));
+        Ok(())
+    }
+
+    /// Attach the [`DeployGlobalContractAction`] action to an existing receipt.
+    ///
+    /// # Arguments
+    ///
+    /// * `receipt_index` - an index of Receipt to append an action
+    /// * `code` - a Wasm code to attach
+    /// * `mode` - contract deploy mode
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `receipt_index` does not refer to a known receipt.
+    pub(super) fn append_action_deploy_global_contract(
+        &mut self,
+        receipt_index: ReceiptIndex,
+        code: Vec<u8>,
+        mode: GlobalContractDeployMode,
+    ) -> Result<(), VMLogicError> {
+        let deploy_mode = match mode {
+            GlobalContractDeployMode::CodeHash => {
+                near_primitives::action::GlobalContractDeployMode::CodeHash
+            }
+            GlobalContractDeployMode::AccountId => {
+                near_primitives::action::GlobalContractDeployMode::AccountId
+            }
+        };
+        self.append_action(
+            receipt_index,
+            Action::DeployGlobalContract(DeployGlobalContractAction {
+                code: code.into(),
+                deploy_mode,
+            }),
+        );
         Ok(())
     }
 

--- a/runtime/runtime/src/tests/mod.rs
+++ b/runtime/runtime/src/tests/mod.rs
@@ -121,3 +121,21 @@ fn test_get_account_from_trie() {
     let get_res = get_account(&new_state_update, &account_id).unwrap().unwrap();
     assert_eq!(test_account, get_res);
 }
+
+/// This test checks that `len` fn implementation of `near_vm_runner::logic::types::GlobalContractIdentifier`
+/// matches the `near_primitives::action::GlobalContractIdentifier` to ensure the same costs
+/// are charged when using `promise_batch_action_use_global_contract` host functions and converting
+/// transactions to receipts.
+#[test]
+fn test_vm_types_global_contract_identifier_len() {
+    let code_hash = CryptoHash::hash_bytes(b"arbitrary");
+    assert_eq!(
+        near_vm_runner::logic::types::GlobalContractIdentifier::CodeHash(code_hash).len(),
+        near_primitives::action::GlobalContractIdentifier::CodeHash(code_hash).len()
+    );
+    let account_id: AccountId = "alice.near".parse().unwrap();
+    assert_eq!(
+        near_vm_runner::logic::types::GlobalContractIdentifier::AccountId(account_id.clone()).len(),
+        near_primitives::action::GlobalContractIdentifier::AccountId(account_id).len()
+    );
+}


### PR DESCRIPTION
This PR introduces host functions for deploying and using global contracts:
```
    fn promise_batch_action_deploy_global_contract(promise_index: u64, code_len: u64, code_ptr: u64);
    fn promise_batch_action_deploy_global_contract_by_account_id(promise_index: u64, code_len: u64, code_ptr: u64);
    fn promise_batch_action_use_global_contract(promise_index: u64, code_hash_len: u64, code_hash_ptr: u64);
    fn promise_batch_action_use_global_contract_by_account_id(promise_index: u64, account_id_len: u64, account_id_ptr: u64);
```


We use separate functions for deployments by hash and by account id to keep it consistent with `DeployGlobalContract` and `DeployGlobalContractByAccountId` action views. The same applies for using global contract by hash and by account_id.

Implementation is "monkey see, monkey do" based on other `promise_batch_action_deploy_contract`.

`global_contract_host_fns` runtime config param is added to ensure that new functions become available as part of protocol version 78.

Closes #13373.