### PR TITLE
[resharding] Rewrite state column gc

### DIFF
--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -1139,8 +1139,8 @@ fn gc_parent_shard_after_resharding(
     block_hash: &CryptoHash,
 ) -> Result<(), Error> {
     // If we are GC'ing the resharding block, i.e. the last block of the epoch, clear out state for the parent shard
-    if !epoch_manager.is_last_block_in_finished_epoch(block_hash)?
-        || !epoch_manager.will_shard_layout_change(block_hash)?
+    if !epoch_manager.will_shard_layout_change(block_hash)?
+        || !epoch_manager.is_last_block_in_finished_epoch(block_hash)?
     {
         return Ok(());
     }

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::{fmt, io};
 
+use itertools::Itertools;
 use near_chain_configs::GCConfig;
 use near_chain_primitives::Error;
 use near_epoch_manager::EpochManagerAdapter;
@@ -19,7 +20,7 @@ use near_primitives::utils::{
 };
 use near_store::adapter::trie_store::get_shard_uid_mapping;
 use near_store::adapter::{StoreAdapter, StoreUpdateAdapter};
-use near_store::{DBCol, KeyForStateChanges, ShardTries, ShardUId, StoreUpdate};
+use near_store::{DBCol, KeyForStateChanges, ShardTries, ShardUId};
 
 use crate::types::RuntimeAdapter;
 use crate::{Chain, ChainStore, ChainStoreAccess, ChainStoreUpdate, metrics};
@@ -246,7 +247,7 @@ impl ChainStore {
                 .values()
                 .flatten()
                 .cloned()
-                .collect::<Vec<_>>();
+                .collect_vec();
             let epoch_manager = epoch_manager.clone();
             let mut chain_store_update = self.store_update();
             if let Some(block_hash) = blocks_current_height.first() {
@@ -263,31 +264,25 @@ impl ChainStore {
                 }
                 debug_assert_eq!(blocks_current_height.len(), 1);
 
-                // Do not clean up immediately, as we still need the State in order to run gc for this block.
-                let potential_shards_for_cleanup = get_potential_shards_for_cleanup(
-                    &chain_store_update,
-                    &epoch_manager,
-                    shard_tracker,
-                    block_hash,
-                )?;
-
                 chain_store_update.clear_block_data(
                     epoch_manager.as_ref(),
                     *block_hash,
                     GCMode::Canonical(tries.clone()),
                 )?;
-                gc_blocks_remaining -= 1;
+                gc_parent_shard_after_resharding(
+                    &mut chain_store_update,
+                    epoch_manager.as_ref(),
+                    block_hash,
+                )?;
+                gc_state(
+                    &mut chain_store_update,
+                    epoch_manager.as_ref(),
+                    block_hash,
+                    shard_tracker,
+                    me,
+                )?;
 
-                if let Some(potential_shards_for_cleanup) = potential_shards_for_cleanup {
-                    gc_state(
-                        &mut chain_store_update,
-                        block_hash,
-                        potential_shards_for_cleanup,
-                        &epoch_manager,
-                        shard_tracker,
-                        me,
-                    )?;
-                }
+                gc_blocks_remaining -= 1;
             }
             chain_store_update.update_tail(height)?;
             chain_store_update.commit()?;
@@ -407,7 +402,7 @@ impl ChainStore {
             .values()
             .flatten()
             .cloned()
-            .collect::<Vec<_>>();
+            .collect_vec();
         for block_hash in &blocks_current_height {
             let mut current_hash = *block_hash;
             loop {
@@ -479,7 +474,7 @@ impl ChainStore {
                 .values()
                 .flatten()
                 .cloned()
-                .collect::<Vec<_>>();
+                .collect_vec();
             for block_hash in blocks_current_height {
                 let epoch_manager = epoch_manager.clone();
                 let mut chain_store_update = self.store_update();
@@ -652,8 +647,7 @@ impl<'a> ChainStoreUpdate<'a> {
         if shard_layout != next_shard_layout {
             shard_uids_to_gc.extend(next_shard_layout.shard_uids());
         }
-        let unique_shard_uids_to_gc = shard_uids_to_gc.into_iter().collect::<HashSet<_>>();
-        unique_shard_uids_to_gc.into_iter().collect()
+        shard_uids_to_gc.into_iter().unique().collect_vec()
     }
 
     // Clearing block data of `block_hash`, if on a fork.
@@ -1134,133 +1128,104 @@ impl<'a> ChainStoreUpdate<'a> {
     }
 }
 
-/// Returns shards that we tracked in an epoch, given a hash of the last block in the epoch.
-/// The block has to be available, so this function has to be called before gc is run for the block.
+/// Cleans up the state of the parent shard once we stop tracking the epoch where the resharding happened.
 ///
-/// Note that validator ID or shard tracking config could have change since the epoch passed,
-/// so we have to rely on what is stored in the database to figure out tracked shards.
-/// We rely on `TrieChanges` column to preserve what shards this node tracked at that time.
-fn get_potential_shards_for_cleanup(
-    chain_store_update: &ChainStoreUpdate,
-    epoch_manager: &Arc<dyn EpochManagerAdapter>,
-    shard_tracker: &ShardTracker,
+/// When we are GC'ing the last block of the epoch where a resharding happened, we need to cleanup the
+/// state of the parent shard. This is done by iterating through the new shard layout and deleting the
+/// state of the parent shard for each child shard.
+fn gc_parent_shard_after_resharding(
+    chain_store_update: &mut ChainStoreUpdate,
+    epoch_manager: &dyn EpochManagerAdapter,
     block_hash: &CryptoHash,
-) -> Result<Option<Vec<ShardUId>>, Error> {
-    if shard_tracker.tracks_all_shards()
-        || !epoch_manager.is_last_block_in_finished_epoch(block_hash)?
-    {
-        return Ok(None);
+) -> Result<(), Error> {
+    // If we are GC'ing the resharding block, i.e. the last block of the epoch, clear out state for the parent shard
+    if !epoch_manager.will_shard_layout_change(block_hash)? {
+        return Ok(());
     }
-    let block = chain_store_update
-        .get_block(block_hash)
-        .expect("block data is not expected to be already cleaned");
-    let epoch_id = block.header().epoch_id();
-    let shard_layout = epoch_manager.get_shard_layout(epoch_id).expect("epoch id must exist");
-    let mut tracked_shards = vec![];
+
+    let _span = tracing::debug_span!(target: "garbage_collection", "gc_resharding").entered();
+
+    // Given block_hash is the resharding block, shard_layout is the shard layout of the next epoch
+    let shard_layout = epoch_manager.get_shard_layout_from_prev_block(block_hash)?;
+    let store = chain_store_update.store();
+    let mut trie_store_update = store.trie_store().store_update();
+    for parent_shard_uid in shard_layout.get_split_parent_shard_uids()? {
+        // Delete the state of the parent shard
+        tracing::info!(target: "garbage_collection", ?parent_shard_uid, "resharding state cleanup");
+        trie_store_update.delete_shard_uid_prefixed_state(parent_shard_uid);
+    }
+    chain_store_update.merge(trie_store_update.into());
+
+    // Assert that the shard_uid mapping doesn't exist for any of the shards in the new shard layout
     for shard_uid in shard_layout.shard_uids() {
-        if chain_store_update
-            .store()
-            .exists(DBCol::TrieChanges, &get_block_shard_uid(&block_hash, &shard_uid))?
-        {
-            tracked_shards.push(shard_uid);
-        }
+        assert_eq!(get_shard_uid_mapping(&store, shard_uid), shard_uid, "Incomplete Resharding");
     }
-    Ok(Some(tracked_shards))
+
+    Ok(())
 }
 
 /// State cleanup for single shard tracking. Removes State of shards that are no longer in use.
 ///
-/// It has to be run after we clear block data for the `last_block_hash_in_gced_epoch`.
-/// `potential_shards_for_cleanup` are shards that were tracked in the gc-ed epoch,
-/// and these are shards that we potentially no longer use and that can be cleaned up.
-/// We do not clean up a shard if it has been tracked in any epoch later,
-/// or we care about it in the current or the next epoch (relative to Head).
-///
-/// With ReshardingV3, we use State mapping (see DBCol::StateShardUIdMapping),
-/// where each `ShardUId` is potentially mapped to its ancestor to get the database key prefix.
-/// We only remove a shard State if all its descendants are ready to be cleaned up,
-/// in which case, we also remove the mapping from `StateShardUIdMapping`.
+/// block_hash is the last block of the epoch we are cleaning up.
+/// We start by listing all the shard_uids that belong to the epoch we are cleaning up.
+/// We filter out the shard_uids that we are currently tracking.
+/// We filter out any other shard_uids that we may be tracking from the cleanup epoch upto current epoch.
+/// This is done by reverse iterating over the epochs from the chain head to cleanup epoch.
 fn gc_state(
     chain_store_update: &mut ChainStoreUpdate,
-    last_block_hash_in_gced_epoch: &CryptoHash,
-    potential_shards_for_cleanup: Vec<ShardUId>,
-    epoch_manager: &Arc<dyn EpochManagerAdapter>,
+    epoch_manager: &dyn EpochManagerAdapter,
+    block_hash: &CryptoHash,
     shard_tracker: &ShardTracker,
     me: Option<&AccountId>,
 ) -> Result<(), Error> {
-    let _span = tracing::debug_span!(target: "garbage_collection", "gc_state").entered();
-    if potential_shards_for_cleanup.is_empty() || shard_tracker.tracks_all_shards() {
+    // Return if we are not dealing with the last block of the epoch
+    if !epoch_manager.is_last_block_in_finished_epoch(block_hash)? {
         return Ok(());
     }
+
+    let _span = tracing::debug_span!(target: "garbage_collection", "gc_state").entered();
+
+    // Get block_info for the latest block
+    let latest_block_hash = chain_store_update.head()?.last_block_hash;
+    let mut block_info = epoch_manager.get_block_info(&latest_block_hash)?;
+
+    // Get all the shards that belong to the epoch we are cleaning up
+    let mut shards_to_cleanup = epoch_manager
+        .get_shard_layout(epoch_manager.get_block_info(block_hash)?.epoch_id())?
+        .shard_uids()
+        .filter(|shard_uid| {
+            // Remove shards that we are tracking right now
+            !shard_tracker.cares_about_shard_this_or_next_epoch(
+                me,
+                block_info.prev_hash(),
+                shard_uid.shard_id(),
+                true,
+            )
+        })
+        .collect_vec();
+
+    // reverse iterate over the epochs
     let store = chain_store_update.store();
-    let mut potential_shards_to_cleanup: HashSet<ShardUId> = potential_shards_for_cleanup
-        .iter()
-        .map(|shard_uid| get_shard_uid_mapping(&store, *shard_uid))
-        .collect();
+    while !shards_to_cleanup.is_empty() && block_info.hash() != block_hash {
+        shards_to_cleanup.retain(|shard_uid| {
+            // If shard_uid exists in the TrieChanges column, this means we are tracking the shard_uid.
+            let trie_changes_key = get_block_shard_uid(&block_info.hash(), shard_uid);
+            !store.exists(DBCol::TrieChanges, &trie_changes_key).unwrap()
+        });
 
-    let last_block_hash = chain_store_update.head()?.last_block_hash;
-    let last_block_info = epoch_manager.get_block_info(&last_block_hash)?;
-    let current_shard_layout = epoch_manager.get_shard_layout(last_block_info.epoch_id())?;
-    // Do not clean up shards that we care about in the current or the next epoch.
-    // Most of the time, `potential_shards_to_cleanup` will become empty as we do not change tracked shards often.
-    for shard_uid in current_shard_layout.shard_uids() {
-        if !shard_tracker.cares_about_shard_this_or_next_epoch(
-            me,
-            last_block_info.prev_hash(),
-            shard_uid.shard_id(),
-            true,
-        ) {
-            continue;
-        }
-        let mapped_shard_uid = get_shard_uid_mapping(&store, shard_uid);
-        potential_shards_to_cleanup.remove(&mapped_shard_uid);
-    }
-
-    let mut block_info = last_block_info;
-    loop {
-        if potential_shards_to_cleanup.is_empty() {
-            return Ok(());
-        }
+        // Get the block info for prev_epoch last_block_hash
         let epoch_first_block_info =
             epoch_manager.get_block_info(block_info.epoch_first_block())?;
         let prev_epoch_last_block_hash = epoch_first_block_info.prev_hash();
-        if prev_epoch_last_block_hash == last_block_hash_in_gced_epoch {
-            break;
-        }
         block_info = epoch_manager.get_block_info(prev_epoch_last_block_hash)?;
-        let shard_layout = epoch_manager.get_shard_layout(block_info.epoch_id())?;
-        // Do not clean up shards that were tracked in any epoch after the gc-ed epoch.
-        for shard_uid in shard_layout.shard_uids() {
-            if !store
-                .exists(DBCol::TrieChanges, &get_block_shard_uid(&block_info.hash(), &shard_uid))?
-            {
-                continue;
-            }
-            let mapped_shard_uid = get_shard_uid_mapping(&store, shard_uid);
-            potential_shards_to_cleanup.remove(&mapped_shard_uid);
-        }
-    }
-    let shards_to_cleanup = potential_shards_to_cleanup;
-
-    // Find ShardUId mappings to shards that we will clean up.
-    let mut shard_uid_mappings_to_remove = vec![];
-    for kv in store.iter_ser::<ShardUId>(DBCol::StateShardUIdMapping) {
-        let (child_shard_uid_bytes, parent_shard_uid) = kv?;
-        if shards_to_cleanup.contains(&parent_shard_uid) {
-            shard_uid_mappings_to_remove.push(child_shard_uid_bytes);
-        }
     }
 
     // Delete State of `shards_to_cleanup` and associated ShardUId mapping.
-    tracing::info!(target: "garbage_collection", ?shards_to_cleanup, ?shard_uid_mappings_to_remove, "state_cleanup");
+    tracing::info!(target: "garbage_collection", ?shards_to_cleanup, "state_cleanup");
     let mut trie_store_update = store.trie_store().store_update();
     for shard_uid_prefix in shards_to_cleanup {
         trie_store_update.delete_shard_uid_prefixed_state(shard_uid_prefix);
     }
-    let mut store_update: StoreUpdate = trie_store_update.into();
-    for child_shard_uid_bytes in shard_uid_mappings_to_remove {
-        store_update.delete(DBCol::StateShardUIdMapping, &child_shard_uid_bytes);
-    }
-    chain_store_update.merge(store_update);
+    chain_store_update.merge(trie_store_update.into());
     Ok(())
 }

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -716,6 +716,16 @@ impl ShardLayout {
         }
         Ok(parent_shard_ids)
     }
+
+    /// Returns all the shards from the previous shard layout that were
+    /// split into multiple shards in this shard layout.
+    pub fn get_split_parent_shard_uids(&self) -> Result<BTreeSet<ShardUId>, ShardLayoutError> {
+        let parent_shard_ids = self.get_split_parent_shard_ids()?;
+        Ok(parent_shard_ids
+            .into_iter()
+            .map(|shard_id| ShardUId::new(self.version(), shard_id))
+            .collect())
+    }
 }
 
 // Validates the shards_split_map and derives the shards_parent_map from it.
@@ -1234,6 +1244,12 @@ mod tests {
                 ])),
             )
         );
+
+        // In case we are changing the shard layout version from hardcoded 3,
+        // make sure that we correctly return the shard_uid of the parent shards in
+        // get_split_parent_shard_uids function.
+        assert_eq!(base_layout.version(), 3);
+        assert_eq!(base_layout.version(), derived_layout.version());
     }
 
     // Check that the ShardLayout::multi_shard method returns interesting shard

--- a/test-loop-tests/src/tests/resharding_v3.rs
+++ b/test-loop-tests/src/tests/resharding_v3.rs
@@ -1276,6 +1276,11 @@ fn slow_test_resharding_v3_buffered_receipts_towards_splitted_shard() {
     test_resharding_v3_base(params);
 }
 
+/// This test sends large (3MB) receipts from a stable shard to shard that will be split into two.
+/// These large receipts are buffered and at the resharding boundary the stable shard's outgoing
+/// buffer contains receipts to the shard that was split. Bandwidth requests to the child where the
+/// receipts will be sent must include the receipts stored in outgoing buffer to the parent shard,
+/// otherwise there will be no bandwidth grants to send them.
 #[test]
 fn slow_test_resharding_v3_large_receipts_towards_splitted_shard() {
     let account_in_left_child: AccountId = "account4".parse().unwrap();

--- a/test-loop-tests/src/tests/resharding_v3.rs
+++ b/test-loop-tests/src/tests/resharding_v3.rs
@@ -71,9 +71,6 @@ const DEFAULT_TESTLOOP_NUM_EPOCHS_TO_WAIT: u64 = 8;
 /// To be used in tests with shard shuffling enabled, to cover more configurations of shard assignment.
 const INCREASED_TESTLOOP_NUM_EPOCHS_TO_WAIT: u64 = 12;
 
-/// Default shard layout version used in resharding tests.
-const DEFAULT_SHARD_LAYOUT_VERSION: u64 = 2;
-
 /// Account used in resharding tests as a split boundary.
 const NEW_BOUNDARY_ACCOUNT: &str = "account6";
 
@@ -81,7 +78,6 @@ const NEW_BOUNDARY_ACCOUNT: &str = "account6";
 #[builder(pattern = "owned", build_fn(skip))]
 #[allow(unused)]
 struct TestReshardingParameters {
-    base_shard_layout_version: u64,
     base_protocol_version: u32,
     /// Number of accounts.
     num_accounts: u64,
@@ -261,9 +257,6 @@ impl TestReshardingParametersBuilder {
             base_protocol_version: self
                 .base_protocol_version
                 .unwrap_or(ProtocolFeature::SimpleNightshadeV4.protocol_version() - 1),
-            base_shard_layout_version: self
-                .base_shard_layout_version
-                .unwrap_or(DEFAULT_SHARD_LAYOUT_VERSION),
             num_accounts,
             num_clients,
             num_producers,
@@ -339,22 +332,12 @@ impl TestReshardingParametersBuilder {
     }
 }
 
-fn get_base_shard_layout(version: u64) -> ShardLayout {
+fn get_base_shard_layout() -> ShardLayout {
     let boundary_accounts = vec!["account1".parse().unwrap(), "account3".parse().unwrap()];
-    match version {
-        1 => {
-            let shards_split_map = vec![vec![ShardId::new(0), ShardId::new(1), ShardId::new(2)]];
-            #[allow(deprecated)]
-            ShardLayout::v1(boundary_accounts, Some(shards_split_map), 3)
-        }
-        2 => {
-            let shard_ids = vec![ShardId::new(5), ShardId::new(3), ShardId::new(6)];
-            let shards_split_map = [(ShardId::new(0), shard_ids.clone())].into_iter().collect();
-            let shards_split_map = Some(shards_split_map);
-            ShardLayout::v2(boundary_accounts, shard_ids, shards_split_map)
-        }
-        _ => panic!("Unsupported shard layout version {}", version),
-    }
+    let shard_ids = vec![ShardId::new(5), ShardId::new(3), ShardId::new(6)];
+    let shards_split_map = [(ShardId::new(0), shard_ids.clone())].into_iter().collect();
+    let shards_split_map = Some(shards_split_map);
+    ShardLayout::v2(boundary_accounts, shard_ids, shards_split_map)
 }
 
 fn setup_global_contracts(
@@ -442,7 +425,7 @@ fn test_resharding_v3_base(params: TestReshardingParameters) {
         base_epoch_config.chunk_validator_only_kickout_threshold = 0;
     }
 
-    let base_shard_layout = get_base_shard_layout(params.base_shard_layout_version);
+    let base_shard_layout = get_base_shard_layout();
     base_epoch_config.shard_layout = base_shard_layout.clone();
     let mut new_boundary_account = params.new_boundary_account;
     let epoch_config =
@@ -734,7 +717,7 @@ fn slow_test_resharding_v3_two_splits_one_after_another_at_single_node() {
     let first_resharding_boundary_account: AccountId = NEW_BOUNDARY_ACCOUNT.parse().unwrap();
     let second_resharding_boundary_account: AccountId = "account2".parse().unwrap();
 
-    let base_shard_layout = get_base_shard_layout(DEFAULT_SHARD_LAYOUT_VERSION);
+    let base_shard_layout = get_base_shard_layout();
     let first_resharding_shard_layout = ShardLayout::derive_shard_layout(
         &base_shard_layout,
         first_resharding_boundary_account.clone(),
@@ -790,7 +773,7 @@ fn slow_test_resharding_v3_two_splits_one_after_another_at_single_node() {
 fn slow_test_resharding_v3_state_cleanup() {
     let account_in_stable_shard: AccountId = "account0".parse().unwrap();
     let split_boundary_account: AccountId = NEW_BOUNDARY_ACCOUNT.parse().unwrap();
-    let base_shard_layout = get_base_shard_layout(DEFAULT_SHARD_LAYOUT_VERSION);
+    let base_shard_layout = get_base_shard_layout();
     let new_shard_layout =
         ShardLayout::derive_shard_layout(&base_shard_layout, split_boundary_account.clone());
     let parent_shard_id = base_shard_layout.account_id_to_shard_id(&split_boundary_account);
@@ -809,7 +792,7 @@ fn slow_test_resharding_v3_state_cleanup() {
         TestReshardingParametersBuilder::default()
             .num_clients(num_clients)
             .tracked_shard_schedule(Some(tracked_shard_schedule.clone()))
-            .add_loop_action(check_state_cleanup(tracked_shard_schedule, num_epochs_to_wait, false))
+            .add_loop_action(check_state_cleanup(tracked_shard_schedule, num_epochs_to_wait))
             .build(),
     );
 }
@@ -819,7 +802,7 @@ fn slow_test_resharding_v3_state_cleanup() {
 fn slow_test_resharding_v3_do_not_track_children_after_resharding() {
     let account_in_stable_shard: AccountId = "account0".parse().unwrap();
     let split_boundary_account: AccountId = NEW_BOUNDARY_ACCOUNT.parse().unwrap();
-    let base_shard_layout = get_base_shard_layout(DEFAULT_SHARD_LAYOUT_VERSION);
+    let base_shard_layout = get_base_shard_layout();
     let new_shard_layout =
         ShardLayout::derive_shard_layout(&base_shard_layout, split_boundary_account.clone());
     let parent_shard_id = base_shard_layout.account_id_to_shard_id(&split_boundary_account);
@@ -837,7 +820,7 @@ fn slow_test_resharding_v3_do_not_track_children_after_resharding() {
         TestReshardingParametersBuilder::default()
             .num_clients(num_clients)
             .tracked_shard_schedule(Some(tracked_shard_schedule.clone()))
-            .add_loop_action(check_state_cleanup(tracked_shard_schedule, num_epochs_to_wait, false))
+            .add_loop_action(check_state_cleanup(tracked_shard_schedule, num_epochs_to_wait))
             .build(),
     );
 }
@@ -850,7 +833,7 @@ fn slow_test_resharding_v3_do_not_track_children_after_resharding() {
 fn slow_test_resharding_v3_stop_track_child_for_5_epochs() {
     let account_in_stable_shard: AccountId = "account0".parse().unwrap();
     let split_boundary_account: AccountId = NEW_BOUNDARY_ACCOUNT.parse().unwrap();
-    let base_shard_layout = get_base_shard_layout(DEFAULT_SHARD_LAYOUT_VERSION);
+    let base_shard_layout = get_base_shard_layout();
     let new_shard_layout =
         ShardLayout::derive_shard_layout(&base_shard_layout, split_boundary_account.clone());
     let parent_shard_id = base_shard_layout.account_id_to_shard_id(&split_boundary_account);
@@ -878,7 +861,7 @@ fn slow_test_resharding_v3_stop_track_child_for_5_epochs() {
         TestReshardingParametersBuilder::default()
             .num_clients(num_clients)
             .tracked_shard_schedule(Some(tracked_shard_schedule.clone()))
-            .add_loop_action(check_state_cleanup(tracked_shard_schedule, num_epochs_to_wait, false))
+            .add_loop_action(check_state_cleanup(tracked_shard_schedule, num_epochs_to_wait))
             .num_epochs_to_wait(num_epochs_to_wait)
             .build(),
     );
@@ -893,7 +876,7 @@ fn slow_test_resharding_v3_stop_track_child_for_5_epochs() {
 fn slow_test_resharding_v3_stop_track_child_for_5_epochs_with_sibling_in_between() {
     let account_in_stable_shard: AccountId = "account0".parse().unwrap();
     let split_boundary_account: AccountId = NEW_BOUNDARY_ACCOUNT.parse().unwrap();
-    let base_shard_layout = get_base_shard_layout(DEFAULT_SHARD_LAYOUT_VERSION);
+    let base_shard_layout = get_base_shard_layout();
     let new_shard_layout =
         ShardLayout::derive_shard_layout(&base_shard_layout, split_boundary_account.clone());
     let parent_shard_id = base_shard_layout.account_id_to_shard_id(&split_boundary_account);
@@ -921,7 +904,7 @@ fn slow_test_resharding_v3_stop_track_child_for_5_epochs_with_sibling_in_between
         TestReshardingParametersBuilder::default()
             .num_clients(num_clients)
             .tracked_shard_schedule(Some(tracked_shard_schedule.clone()))
-            .add_loop_action(check_state_cleanup(tracked_shard_schedule, num_epochs_to_wait, true))
+            .add_loop_action(check_state_cleanup(tracked_shard_schedule, num_epochs_to_wait))
             .num_epochs_to_wait(num_epochs_to_wait)
             .build(),
     );
@@ -933,7 +916,7 @@ fn slow_test_resharding_v3_stop_track_child_for_5_epochs_with_sibling_in_between
 fn slow_test_resharding_v3_sync_child() {
     let account_in_stable_shard: AccountId = "account0".parse().unwrap();
     let split_boundary_account: AccountId = NEW_BOUNDARY_ACCOUNT.parse().unwrap();
-    let base_shard_layout = get_base_shard_layout(DEFAULT_SHARD_LAYOUT_VERSION);
+    let base_shard_layout = get_base_shard_layout();
     let new_shard_layout =
         ShardLayout::derive_shard_layout(&base_shard_layout, split_boundary_account.clone());
     let child_shard_id = new_shard_layout.account_id_to_shard_id(&split_boundary_account);
@@ -951,7 +934,7 @@ fn slow_test_resharding_v3_sync_child() {
         TestReshardingParametersBuilder::default()
             .num_clients(num_clients)
             .tracked_shard_schedule(Some(tracked_shard_schedule.clone()))
-            .add_loop_action(check_state_cleanup(tracked_shard_schedule, num_epochs_to_wait, false))
+            .add_loop_action(check_state_cleanup(tracked_shard_schedule, num_epochs_to_wait))
             .build(),
     );
 }
@@ -1079,7 +1062,7 @@ fn slow_test_resharding_v3_shard_shuffling() {
 fn slow_test_resharding_v3_shard_shuffling_untrack_then_track() {
     let account_in_stable_shard: AccountId = "account0".parse().unwrap();
     let split_boundary_account: AccountId = NEW_BOUNDARY_ACCOUNT.parse().unwrap();
-    let base_shard_layout = get_base_shard_layout(DEFAULT_SHARD_LAYOUT_VERSION);
+    let base_shard_layout = get_base_shard_layout();
     let new_shard_layout =
         ShardLayout::derive_shard_layout(&base_shard_layout, split_boundary_account.clone());
     let parent_shard_id = base_shard_layout.account_id_to_shard_id(&split_boundary_account);
@@ -1099,7 +1082,7 @@ fn slow_test_resharding_v3_shard_shuffling_untrack_then_track() {
         .num_epochs_to_wait(num_epochs_to_wait)
         .num_clients(num_clients)
         .tracked_shard_schedule(Some(tracked_shard_schedule.clone()))
-        .add_loop_action(check_state_cleanup(tracked_shard_schedule, num_epochs_to_wait, true))
+        .add_loop_action(check_state_cleanup(tracked_shard_schedule, num_epochs_to_wait))
         .build();
     test_resharding_v3_base(params);
 }
@@ -1235,13 +1218,14 @@ fn slow_test_resharding_v3_delayed_receipts_right_child() {
     test_resharding_v3_base(params);
 }
 
-fn test_resharding_v3_split_parent_buffered_receipts_base(base_shard_layout_version: u64) {
+#[test]
+#[cfg_attr(not(feature = "test_features"), ignore)]
+fn slow_test_resharding_v3_split_parent_buffered_receipts() {
     let receiver_account: AccountId = "account0".parse().unwrap();
     let account_in_parent: AccountId = "account4".parse().unwrap();
     let account_in_left_child: AccountId = "account4".parse().unwrap();
     let account_in_right_child: AccountId = "account6".parse().unwrap();
     let params = TestReshardingParametersBuilder::default()
-        .base_shard_layout_version(base_shard_layout_version)
         .deploy_test_contract(receiver_account.clone())
         .limit_outgoing_gas(true)
         .add_loop_action(call_burn_gas_contract(
@@ -1265,25 +1249,12 @@ fn test_resharding_v3_split_parent_buffered_receipts_base(base_shard_layout_vers
 
 #[test]
 #[cfg_attr(not(feature = "test_features"), ignore)]
-fn slow_test_resharding_v3_split_parent_buffered_receipts_v1() {
-    test_resharding_v3_split_parent_buffered_receipts_base(1);
-}
-
-#[test]
-#[cfg_attr(not(feature = "test_features"), ignore)]
-fn slow_test_resharding_v3_split_parent_buffered_receipts_v2() {
-    test_resharding_v3_split_parent_buffered_receipts_base(2);
-}
-
-fn test_resharding_v3_buffered_receipts_towards_splitted_shard_base(
-    base_shard_layout_version: u64,
-) {
+fn slow_test_resharding_v3_buffered_receipts_towards_splitted_shard() {
     let account_in_left_child: AccountId = "account4".parse().unwrap();
     let account_in_right_child: AccountId = "account6".parse().unwrap();
     let account_in_stable_shard: AccountId = "account1".parse().unwrap();
 
     let params = TestReshardingParametersBuilder::default()
-        .base_shard_layout_version(base_shard_layout_version)
         .deploy_test_contract(account_in_left_child.clone())
         .deploy_test_contract(account_in_right_child.clone())
         .limit_outgoing_gas(true)
@@ -1306,29 +1277,12 @@ fn test_resharding_v3_buffered_receipts_towards_splitted_shard_base(
 }
 
 #[test]
-#[cfg_attr(not(feature = "test_features"), ignore)]
-fn slow_test_resharding_v3_buffered_receipts_towards_splitted_shard_v1() {
-    test_resharding_v3_buffered_receipts_towards_splitted_shard_base(1);
-}
-
-#[test]
-#[cfg_attr(not(feature = "test_features"), ignore)]
-fn slow_test_resharding_v3_buffered_receipts_towards_splitted_shard_v2() {
-    test_resharding_v3_buffered_receipts_towards_splitted_shard_base(2);
-}
-
-/// This test sends large (3MB) receipts from a stable shard to shard that will be split into two.
-/// These large receipts are buffered and at the resharding boundary the stable shard's outgoing
-/// buffer contains receipts to the shard that was split. Bandwidth requests to the child where the
-/// receipts will be sent must include the receipts stored in outgoing buffer to the parent shard,
-/// otherwise there will be no bandwidth grants to send them.
-fn test_resharding_v3_large_receipts_towards_splitted_shard_base(base_shard_layout_version: u64) {
+fn slow_test_resharding_v3_large_receipts_towards_splitted_shard() {
     let account_in_left_child: AccountId = "account4".parse().unwrap();
     let account_in_right_child: AccountId = "account6".parse().unwrap();
     let account_in_stable_shard: AccountId = "account1".parse().unwrap();
 
     let params = TestReshardingParametersBuilder::default()
-        .base_shard_layout_version(base_shard_layout_version)
         .deploy_test_contract(account_in_left_child.clone())
         .deploy_test_contract(account_in_right_child.clone())
         .deploy_test_contract(account_in_stable_shard.clone())
@@ -1346,16 +1300,6 @@ fn test_resharding_v3_large_receipts_towards_splitted_shard_base(base_shard_layo
         ))
         .build();
     test_resharding_v3_base(params);
-}
-
-#[test]
-fn slow_test_resharding_v3_large_receipts_towards_splitted_shard_v1() {
-    test_resharding_v3_large_receipts_towards_splitted_shard_base(1);
-}
-
-#[test]
-fn slow_test_resharding_v3_large_receipts_towards_splitted_shard_v2() {
-    test_resharding_v3_large_receipts_towards_splitted_shard_base(2);
 }
 
 #[test]
@@ -1396,20 +1340,9 @@ fn slow_test_resharding_v3_outgoing_receipts_from_splitted_shard() {
 }
 
 #[test]
-fn slow_test_resharding_v3_load_memtrie_v1() {
-    let params = TestReshardingParametersBuilder::default()
-        .base_shard_layout_version(1)
-        .load_memtries_for_tracked_shards(false)
-        .build();
-    test_resharding_v3_base(params);
-}
-
-#[test]
-fn slow_test_resharding_v3_load_memtrie_v2() {
-    let params = TestReshardingParametersBuilder::default()
-        .base_shard_layout_version(2)
-        .load_memtries_for_tracked_shards(false)
-        .build();
+fn slow_test_resharding_v3_load_memtrie() {
+    let params =
+        TestReshardingParametersBuilder::default().load_memtries_for_tracked_shards(false).build();
     test_resharding_v3_base(params);
 }
 
@@ -1496,7 +1429,7 @@ fn slow_test_resharding_v3_yield_timeout() {
 fn slow_test_resharding_v3_promise_yield_indices_gc_correctness() {
     let account_in_left_child: AccountId = "account4".parse().unwrap();
     let account_in_right_child: AccountId = "account6".parse().unwrap();
-    let base_shard_layout = get_base_shard_layout(DEFAULT_SHARD_LAYOUT_VERSION);
+    let base_shard_layout = get_base_shard_layout();
     let shard_layout_after_resharding =
         ShardLayout::derive_shard_layout(&base_shard_layout, NEW_BOUNDARY_ACCOUNT.parse().unwrap());
     let params = TestReshardingParametersBuilder::default()
@@ -1520,7 +1453,7 @@ fn slow_test_resharding_v3_promise_yield_indices_gc_correctness() {
 fn slow_test_resharding_v3_delayed_receipts_gc_correctness() {
     let account_in_left_child: AccountId = "account4".parse().unwrap();
     let account_in_right_child: AccountId = "account6".parse().unwrap();
-    let base_shard_layout = get_base_shard_layout(DEFAULT_SHARD_LAYOUT_VERSION);
+    let base_shard_layout = get_base_shard_layout();
     let shard_layout_after_resharding =
         ShardLayout::derive_shard_layout(&base_shard_layout, NEW_BOUNDARY_ACCOUNT.parse().unwrap());
     let params = TestReshardingParametersBuilder::default()

--- a/test-loop-tests/src/utils/resharding.rs
+++ b/test-loop-tests/src/utils/resharding.rs
@@ -783,7 +783,7 @@ fn check_has_the_only_shard_state(client: &Client, the_only_shard_uid: ShardUId)
         let shard_uid = ShardUId::try_from_slice(&key[0..8]).unwrap();
         shard_uid_prefixes.insert(shard_uid);
     }
-    assert_eq!(shard_uid_prefixes, [the_only_shard_uid].into());
+    assert_eq!(shard_uid_prefixes.into_iter().collect_vec(), [the_only_shard_uid]);
 }
 
 /// Loop action testing state cleanup.

--- a/test-loop-tests/src/utils/resharding.rs
+++ b/test-loop-tests/src/utils/resharding.rs
@@ -775,43 +775,24 @@ fn retain_the_only_shard_state(client: &Client, the_only_shard_uid: ShardUId) {
 }
 
 /// Asserts that all other shards State except `the_only_shard_uid` have been cleaned-up.
-///
-/// `expect_shard_uid_is_mapped` means that `the_only_shard_uid` should use an ancestor
-/// ShardUId as the db key prefix.
-fn check_has_the_only_shard_state(
-    client: &Client,
-    _the_only_shard_uid: ShardUId,
-    _expect_shard_uid_is_mapped: bool,
-) {
-    let store = client.chain.chain_store.store().trie_store();
+fn check_has_the_only_shard_state(client: &Client, the_only_shard_uid: ShardUId) {
+    let store = client.chain.chain_store.store();
     let mut shard_uid_prefixes = HashSet::new();
-    for kv in store.store().iter_raw_bytes(DBCol::State) {
+    for kv in store.iter_raw_bytes(DBCol::State) {
         let (key, _) = kv.unwrap();
         let shard_uid = ShardUId::try_from_slice(&key[0..8]).unwrap();
         shard_uid_prefixes.insert(shard_uid);
     }
-    // TODO(resharding): Handle GC after TrieStateResharder
-    // let mapped_shard_uid = get_shard_uid_mapping(&store.store(), the_only_shard_uid);
-    // if expect_shard_uid_is_mapped {
-    //     assert_ne!(mapped_shard_uid, the_only_shard_uid);
-    // } else {
-    //     assert_eq!(mapped_shard_uid, the_only_shard_uid);
-    // };
-    // let shard_uid_prefixes = shard_uid_prefixes.into_iter().collect_vec();
-    // assert_eq!(shard_uid_prefixes, [mapped_shard_uid]);
+    assert_eq!(shard_uid_prefixes, [the_only_shard_uid].into());
 }
 
 /// Loop action testing state cleanup.
 /// It assumes single shard tracking and it waits for `num_epochs_to_wait`.
 /// Then it checks whether the last shard tracked by the client
 /// is the only ShardUId prefix for nodes in the State column.
-///
-/// Pass `expect_shard_uid_is_mapped` as true if it is expected at the end of the test
-/// that the last tracked shard will use an ancestor ShardUId as a db key prefix.
 pub(crate) fn check_state_cleanup(
     tracked_shard_schedule: TrackedShardSchedule,
     num_epochs_to_wait: u64,
-    expect_shard_uid_is_mapped: bool,
 ) -> LoopAction {
     let client_index = tracked_shard_schedule.client_index;
     let latest_height = Cell::new(0);
@@ -854,7 +835,7 @@ pub(crate) fn check_state_cleanup(
                 return;
             }
             // At this point, we should only have State from the last tracked shard.
-            check_has_the_only_shard_state(&client, tracked_shard_uid, expect_shard_uid_is_mapped);
+            check_has_the_only_shard_state(&client, tracked_shard_uid);
             done.set(true);
         },
     );


### PR DESCRIPTION
Update the state garbage collection code to take into account the new solution for refcount issue in resharding.

I don't completely understand what the old solution was doing, but the new solution divides gc into two parts, one specific to resharding, where we are simply deleting the parent shard_uid state, and second, deleting untracked shard_uids.

The logic to find untracked shard_uids is updated and simplified.

Don't worry if the old code and new code don't make 100% sense. I took several days to figure out what exactly is going on :)