### PR TITLE
[resharding] Allow negative refcount

### DIFF
--- a/core/store/src/db/refcount.rs
+++ b/core/store/src/db/refcount.rs
@@ -18,6 +18,7 @@
 //! values by adding the reference counts.  When the reference count reaches
 //! zero RocksDB removes the key from the database.
 
+use std::cmp::Ordering;
 use std::io;
 
 use rocksdb::compaction_filter::Decision;
@@ -100,7 +101,8 @@ pub(crate) fn encode_negative_refcount(rc: std::num::NonZeroU32) -> [u8; 8] {
 ///
 /// Extracts reference count from all provided value and sums them together and
 /// returns result depending on rc:
-/// - rc <= 0 ⇒ empty,
+/// - rc = 0 ⇒ empty,
+/// - rc < 0 ⇒ encoded reference count,
 /// - rc > 0 ⇒ value with encoded reference count.
 ///
 /// Assumes that all provided values with positive reference count have the same
@@ -120,10 +122,11 @@ pub(crate) fn refcount_merge<'a>(
         rc += delta;
     }
 
-    // TODO(resharding) We should preserve negative refcounts, but we don't because of ReshardingV3.
-    // Resharding can result in some data being double deleted, that would result in negative refcount forever
-    // and lead to issue if the same data will be reintroduced later.
-    if rc <= 0 { Vec::new() } else { [payload.unwrap_or(b""), &rc.to_le_bytes()].concat() }
+    match rc.cmp(&0) {
+        Ordering::Less => rc.to_le_bytes().to_vec(),
+        Ordering::Equal => Vec::new(),
+        Ordering::Greater => [payload.unwrap_or(b""), &rc.to_le_bytes()].concat(),
+    }
 }
 
 /// Iterator treats empty value as no value and strips refcount
@@ -261,11 +264,11 @@ mod test {
         test(b"", &[b"foo\x02\0\0\0\0\0\0\0", MINUS_ONE, MINUS_ONE]);
         test(b"", &[b"foo\x02\0\0\0\0\0\0\0", MINUS_TWO]);
 
-        test(b"", &[MINUS_ONE]);
-        test(b"", &[b"", MINUS_ONE]);
-        test(b"", &[ZERO, MINUS_ONE]);
-        test(b"", &[b"foo\x01\0\0\0\0\0\0\0", MINUS_TWO]);
-        test(b"", &[b"foo\x01\0\0\0\0\0\0\0", MINUS_ONE, MINUS_ONE]);
+        test(MINUS_ONE, &[MINUS_ONE]);
+        test(MINUS_ONE, &[b"", MINUS_ONE]);
+        test(MINUS_ONE, &[ZERO, MINUS_ONE]);
+        test(MINUS_ONE, &[b"foo\x01\0\0\0\0\0\0\0", MINUS_TWO]);
+        test(MINUS_ONE, &[b"foo\x01\0\0\0\0\0\0\0", MINUS_ONE, MINUS_ONE]);
 
         test(b"foo\x02\0\0\0\0\0\0\0", &[b"foo\x01\0\0\0\0\0\0\0", b"foo\x01\0\0\0\0\0\0\0"]);
         test(b"foo\x01\0\0\0\0\0\0\0", &[b"foo\x01\0\0\0\0\0\0\0"]);


### PR DESCRIPTION
Claping refcounts to 0 was originally introduced in PR https://github.com/near/nearcore/pull/12784/ as a solution to a potential issue with GC of parent shard_uid state when accessed from both children after resharding.

With the new TrieStateResharder as a proper fix where we are replicating the state from parent to both children, we no longer need this fix.