### PR TITLE
chore: make `get_split_parent_shard_ids` infallible

### DIFF
--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -1151,7 +1151,7 @@ fn gc_parent_shard_after_resharding(
     let shard_layout = epoch_manager.get_shard_layout_from_prev_block(block_hash)?;
     let store = chain_store_update.store();
     let mut trie_store_update = store.trie_store().store_update();
-    for parent_shard_uid in shard_layout.get_split_parent_shard_uids()? {
+    for parent_shard_uid in shard_layout.get_split_parent_shard_uids() {
         // Delete the state of the parent shard
         tracing::debug!(target: "garbage_collection", ?parent_shard_uid, "resharding state cleanup");
         trie_store_update.delete_shard_uid_prefixed_state(parent_shard_uid);

--- a/core/primitives/src/shard_layout.rs
+++ b/core/primitives/src/shard_layout.rs
@@ -702,10 +702,12 @@ impl ShardLayout {
 
     /// Returns all the shards from the previous shard layout that were
     /// split into multiple shards in this shard layout.
-    pub fn get_split_parent_shard_ids(&self) -> Result<BTreeSet<ShardId>, ShardLayoutError> {
+    pub fn get_split_parent_shard_ids(&self) -> BTreeSet<ShardId> {
         let mut parent_shard_ids = BTreeSet::new();
         for shard_id in self.shard_ids() {
-            let parent_shard_id = self.try_get_parent_shard_id(shard_id)?;
+            let parent_shard_id = self
+                .try_get_parent_shard_id(shard_id)
+                .expect("shard_id belongs to the shard layout");
             let Some(parent_shard_id) = parent_shard_id else {
                 continue;
             };
@@ -714,17 +716,17 @@ impl ShardLayout {
             }
             parent_shard_ids.insert(parent_shard_id);
         }
-        Ok(parent_shard_ids)
+        parent_shard_ids
     }
 
     /// Returns all the shards from the previous shard layout that were
     /// split into multiple shards in this shard layout.
-    pub fn get_split_parent_shard_uids(&self) -> Result<BTreeSet<ShardUId>, ShardLayoutError> {
-        let parent_shard_ids = self.get_split_parent_shard_ids()?;
-        Ok(parent_shard_ids
+    pub fn get_split_parent_shard_uids(&self) -> BTreeSet<ShardUId> {
+        let parent_shard_ids = self.get_split_parent_shard_ids();
+        parent_shard_ids
             .into_iter()
             .map(|shard_id| ShardUId::new(self.version(), shard_id))
-            .collect())
+            .collect()
     }
 }
 

--- a/runtime/runtime/src/congestion_control.rs
+++ b/runtime/runtime/src/congestion_control.rs
@@ -11,7 +11,7 @@ use near_primitives::bandwidth_scheduler::{
 };
 use near_primitives::chunk_apply_stats::{ChunkApplyStatsV0, ReceiptSinkStats, ReceiptsStats};
 use near_primitives::congestion_info::{CongestionControl, CongestionInfo, CongestionInfoV1};
-use near_primitives::errors::{EpochError, IntegerOverflowError, RuntimeError};
+use near_primitives::errors::{IntegerOverflowError, RuntimeError};
 use near_primitives::receipt::{
     Receipt, ReceiptEnum, ReceiptOrStateStoredReceipt, StateStoredReceipt,
     StateStoredReceiptMetadata,
@@ -217,10 +217,7 @@ impl ReceiptSinkV2 {
         let shard_layout = epoch_info_provider.shard_layout(&apply_state.epoch_id)?;
         let (shard_ids, parent_shard_ids) =
             if ProtocolFeature::SimpleNightshadeV4.enabled(protocol_version) {
-                (
-                    shard_layout.shard_ids().collect_vec(),
-                    shard_layout.get_split_parent_shard_ids().map_err(Into::<EpochError>::into)?,
-                )
+                (shard_layout.shard_ids().collect_vec(), shard_layout.get_split_parent_shard_ids())
             } else {
                 (self.outgoing_limit.keys().copied().collect_vec(), BTreeSet::new())
             };


### PR DESCRIPTION
Since `try_get_parent_shard_id` only returns an error if an invalid shard ID is used,
I think the following code:
```
for shard_id in self.shard_ids() {
    let parent_shard_id = self.try_get_parent_shard_id(shard_id)
```
cannot fail. So we can assume that `get_split_parent_shard_ids` will never fail either, and simplify it accordingly.