### PR TITLE
chain_store: track how long is the delay for tx validity check

### DIFF
--- a/chain/chain/src/metrics.rs
+++ b/chain/chain/src/metrics.rs
@@ -328,3 +328,12 @@ pub(crate) static STATE_TRANSITION_DATA_GC_TIME: LazyLock<Histogram> = LazyLock:
     )
     .unwrap()
 });
+
+pub(crate) static CHAIN_VALIDITY_PERIOD_CHECK_DELAY: LazyLock<Histogram> = LazyLock::new(|| {
+    try_create_histogram_with_buckets(
+        "near_chain_validity_period_check_delay",
+        "how far back in the past is the validity period we're checking (not 100% precise!)",
+        vec![5.0, 10.0, 20.0, 40.0, 60.0, 120.0, 180.0],
+    )
+    .unwrap()
+});


### PR DESCRIPTION
This can inform the size of the caches we should have in ChainStore from which validity period check later reads.

This metric is intended to be quick to compute and in no way 100% accurate (due to not necessarily handling multiple chains and such.)

Part of #12997