### PR TITLE
store: improve `TrieStoreAdapter::get_ser`

### DIFF
--- a/core/store/src/adapter/trie_store.rs
+++ b/core/store/src/adapter/trie_store.rs
@@ -1,16 +1,14 @@
-use std::io;
-use std::num::NonZero;
-use std::sync::Arc;
-
+use super::{StoreAdapter, StoreUpdateAdapter, StoreUpdateHolder};
+use crate::db::DBSlice;
+use crate::{DBCol, KeyForStateChanges, STATE_SNAPSHOT_KEY, Store, StoreUpdate, TrieChanges};
 use borsh::BorshDeserialize;
 use near_primitives::errors::{MissingTrieValue, MissingTrieValueContext, StorageError};
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::{ShardUId, get_block_shard_uid};
 use near_primitives::types::RawStateChangesWithTrieKey;
-
-use crate::{DBCol, KeyForStateChanges, STATE_SNAPSHOT_KEY, Store, StoreUpdate, TrieChanges};
-
-use super::{StoreAdapter, StoreUpdateAdapter, StoreUpdateHolder};
+use std::io;
+use std::num::NonZero;
+use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct TrieStoreAdapter {
@@ -32,21 +30,24 @@ impl TrieStoreAdapter {
         TrieStoreUpdateAdapter { store_update: StoreUpdateHolder::Owned(self.store.store_update()) }
     }
 
-    /// Replaces shard_uid prefix with a mapped value according to mapping strategy in Resharding V3.
-    /// For this, it does extra read from `DBCol::StateShardUIdMapping`.
-    ///
-    /// For more details, see `get_shard_uid_mapping()`.
-    pub fn get(&self, shard_uid: ShardUId, hash: &CryptoHash) -> Result<Arc<[u8]>, StorageError> {
+    fn get_ref(&self, shard_uid: ShardUId, hash: &CryptoHash) -> Result<DBSlice<'_>, StorageError> {
         let mapped_shard_uid = get_shard_uid_mapping(&self.store, shard_uid);
         let key = get_key_from_shard_uid_and_hash(mapped_shard_uid, hash);
-        let val = self
-            .store
+        self.store
             .get(DBCol::State, key.as_ref())
             .map_err(|_| StorageError::StorageInternalError)?
             .ok_or(StorageError::MissingTrieValue(MissingTrieValue {
                 context: MissingTrieValueContext::TrieStorage,
                 hash: *hash,
-            }))?;
+            }))
+    }
+
+    /// Replaces shard_uid prefix with a mapped value according to mapping strategy in Resharding V3.
+    /// For this, it does extra read from `DBCol::StateShardUIdMapping`.
+    ///
+    /// For more details, see `get_shard_uid_mapping()`.
+    pub fn get(&self, shard_uid: ShardUId, hash: &CryptoHash) -> Result<Arc<[u8]>, StorageError> {
+        let val = self.get_ref(shard_uid, hash)?;
         Ok(val.into())
     }
 
@@ -55,8 +56,8 @@ impl TrieStoreAdapter {
         shard_uid: ShardUId,
         hash: &CryptoHash,
     ) -> Result<T, StorageError> {
-        let bytes = self.get(shard_uid, hash)?;
-        T::try_from_slice(&bytes).map_err(|e| StorageError::StorageInconsistentState(e.to_string()))
+        let val = self.get_ref(shard_uid, hash)?;
+        T::try_from_slice(&val).map_err(|e| StorageError::StorageInconsistentState(e.to_string()))
     }
 
     pub fn get_state_snapshot_hash(&self) -> Result<CryptoHash, StorageError> {


### PR DESCRIPTION
Previous implementation would allocate a whole `Arc<[u8]>` thingy to immediately deallocate it shortly afterwards