### PR TITLE
feat: 650

### DIFF
--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -258,7 +258,7 @@ pub enum ProtocolFeature {
     SimpleNightshadeV4,
     /// Resharding V3 - Adding "earn.kaiching" boundary.
     SimpleNightshadeV5,
-    /// Resharding V3 - Adding "750" boundary.
+    /// Resharding V3 - Adding "650" boundary.
     SimpleNightshadeV6,
     /// Exclude contract code from the chunk state witness and distribute it to chunk validators separately.
     #[deprecated]

--- a/core/primitives/res/epoch_configs/mainnet/78.json
+++ b/core/primitives/res/epoch_configs/mainnet/78.json
@@ -45,7 +45,7 @@
   "shard_layout": {
     "V2": {
       "boundary_accounts": [
-        "750",
+        "650",
         "aurora",
         "aurora-0",
         "earn.kaiching",

--- a/core/primitives/res/epoch_configs/testnet/78.json
+++ b/core/primitives/res/epoch_configs/testnet/78.json
@@ -45,7 +45,7 @@
   "shard_layout": {
     "V2": {
       "boundary_accounts": [
-        "750",
+        "650",
         "aurora",
         "aurora-0",
         "earn.kaiching",


### PR DESCRIPTION
650

Split on this boundary is almost even for RAM. The difference of estimated disk usage is also small.
```
Parent shard size: 26509189503 bytes
Splitting shard s0.v3 at account 650...
Resharding done
Shard s10.v3: state root: DjyRAdNdmsunbYQryyxQxYGHPGJD4nHHXGC6xAGSJJEC
Root disk size: 26351334360 bytes
Shard s11.v3: state root: DahZjNS7vNpk9NKUJKm3Gy2HVPQz7A76dTCSfREvXK5L
Root disk size: 24861279727 bytes
Left child state size: 13503644169 bytes
Right child state size: 13005548061 bytes
```