### PR TITLE
nit(epoch-manager): update comment for is_next_block_epoch_start

### DIFF
--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -94,8 +94,8 @@ pub trait EpochManagerAdapter: Send + Sync {
     }
 
     /// Returns true, if given hash is last block in it's epoch.
-    fn is_next_block_epoch_start(&self, parent_hash: &CryptoHash) -> Result<bool, EpochError> {
-        let block_info = self.get_block_info(parent_hash)?;
+    fn is_next_block_epoch_start(&self, hash: &CryptoHash) -> Result<bool, EpochError> {
+        let block_info = self.get_block_info(hash)?;
         if block_info.is_genesis() {
             return Ok(true);
         }

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -93,7 +93,7 @@ pub trait EpochManagerAdapter: Send + Sync {
         }
     }
 
-    /// Returns true, if given hash is last block in it's epoch.
+    /// Returns true, if given hash is last block in its epoch.
     fn is_next_block_epoch_start(&self, hash: &CryptoHash) -> Result<bool, EpochError> {
         let block_info = self.get_block_info(hash)?;
         if block_info.is_genesis() {

--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -93,9 +93,9 @@ pub trait EpochManagerAdapter: Send + Sync {
         }
     }
 
-    /// Returns true, if given hash is last block in its epoch.
-    fn is_next_block_epoch_start(&self, hash: &CryptoHash) -> Result<bool, EpochError> {
-        let block_info = self.get_block_info(hash)?;
+    /// Returns true, if the block with the given `parent_hash` is last block in its epoch.
+    fn is_next_block_epoch_start(&self, parent_hash: &CryptoHash) -> Result<bool, EpochError> {
+        let block_info = self.get_block_info(parent_hash)?;
         if block_info.is_genesis() {
             return Ok(true);
         }


### PR DESCRIPTION
~Based on the code & the comment it seems is_next_block_epoch_start expects the hash of the block itself, not the parent hash. Renaming the param to avoid confusion.~

^ This was incorrect but probably can still update the comment as it confused me.