### PR TITLE
store: make `storage` field private

### DIFF
--- a/core/store/src/archive/cold_storage.rs
+++ b/core/store/src/archive/cold_storage.rs
@@ -311,7 +311,7 @@ pub fn update_cold_head(
     {
         let mut transaction = DBTransaction::new();
         transaction.set(DBCol::BlockMisc, COLD_HEAD_KEY.to_vec(), borsh::to_vec(&tip)?);
-        hot_store.storage.write(transaction)?;
+        hot_store.database().write(transaction)?;
 
         crate::metrics::COLD_HEAD_HEIGHT.set(*height as i64);
     }

--- a/core/store/src/db/database_tests.rs
+++ b/core/store/src/db/database_tests.rs
@@ -2,21 +2,16 @@
 //! Set of tests over the 'Database' interface, that we can run over multiple implementations
 //! to make sure that they are working correctly.
 
-use crate::db::{DBTransaction, Database, TestDB};
+use crate::db::{DBTransaction, TestDB};
 use crate::{DBCol, NodeStorage};
-use std::sync::Arc;
-
-// Returns test & rocksDB databases.
-fn test_and_rocksdb() -> Vec<Arc<dyn Database>> {
-    let (_tmp_dir, opener) = NodeStorage::test_opener();
-    let store = opener.open().unwrap().get_hot_store();
-    vec![TestDB::new(), store.storage.clone()]
-}
 
 /// Tests the behavior of the iterators. Iterators don't really work over cold storage, so we're not testing it here.
 #[test]
 fn test_db_iter() {
-    for db in test_and_rocksdb() {
+    let (_tmp_dir, opener) = NodeStorage::test_opener();
+    let store = opener.open().unwrap().get_hot_store();
+    let test_db = TestDB::new();
+    for db in [&*test_db as _, store.database()] {
         let mut transaction = DBTransaction::new();
         transaction.insert(DBCol::Block, "a".into(), "val_a".into());
         transaction.insert(DBCol::Block, "aa".into(), "val_aa".into());

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -812,12 +812,17 @@ mod tests {
 
     use super::*;
 
+    unsafe fn convert_db_to_rocksdb<'a>(db: &'a dyn Database) -> &'a RocksDB {
+        let ptr = db as *const _ as *const RocksDB;
+        unsafe { &*ptr }
+    }
+
     #[test]
     fn rocksdb_merge_sanity() {
         let (_tmp_dir, opener) = NodeStorage::test_opener();
         let store = opener.open().unwrap().get_hot_store();
-        let ptr = (&*store.storage) as *const (dyn Database + 'static);
-        let rocksdb = unsafe { &*(ptr as *const RocksDB) };
+        let database = store.database();
+        let rocksdb = unsafe { convert_db_to_rocksdb(database) };
         assert_eq!(store.get(DBCol::State, &[1; 8]).unwrap(), None);
         {
             let mut store_update = store.store_update();

--- a/core/store/src/node_storage/mod.rs
+++ b/core/store/src/node_storage/mod.rs
@@ -116,7 +116,7 @@ impl NodeStorage {
     /// store, the view client should use the split store and the cold store
     /// loop should use cold store.
     pub fn get_hot_store(&self) -> Store {
-        Store { storage: self.hot_storage.clone() }
+        Store::new(self.hot_storage.clone())
     }
 
     /// Returns the cold store. The cold store is only available in archival
@@ -128,7 +128,7 @@ impl NodeStorage {
     /// loop should use cold store.
     pub fn get_cold_store(&self) -> Option<Store> {
         match &self.cold_storage {
-            Some(cold_storage) => Some(Store { storage: cold_storage.clone() }),
+            Some(cold_storage) => Some(Store::new(cold_storage.clone())),
             None => None,
         }
     }
@@ -140,7 +140,7 @@ impl NodeStorage {
     pub fn get_recovery_store(&self) -> Option<Store> {
         match &self.cold_storage {
             Some(cold_storage) => {
-                Some(Store { storage: Arc::new(crate::db::RecoveryDB::new(cold_storage.clone())) })
+                Some(Store::new(Arc::new(crate::db::RecoveryDB::new(cold_storage.clone()))))
             }
             None => None,
         }
@@ -154,7 +154,7 @@ impl NodeStorage {
     /// store, the view client should use the split store and the cold store
     /// loop should use cold store.
     pub fn get_split_store(&self) -> Option<Store> {
-        self.get_split_db().map(|split_db| Store { storage: split_db })
+        self.get_split_db().map(|split_db| Store::new(split_db))
     }
 
     pub fn get_split_db(&self) -> Option<Arc<SplitDB>> {

--- a/core/store/src/store.rs
+++ b/core/store/src/store.rs
@@ -22,7 +22,7 @@ const STATE_FILE_END_MARK: u8 = 255;
 /// - The split database - access to both hot and cold databases
 #[derive(Clone)]
 pub struct Store {
-    pub(crate) storage: Arc<dyn Database>,
+    storage: Arc<dyn Database>,
 }
 
 impl StoreAdapter for Store {
@@ -34,6 +34,10 @@ impl StoreAdapter for Store {
 impl Store {
     pub fn new(storage: Arc<dyn Database>) -> Self {
         Self { storage }
+    }
+
+    pub fn database(&self) -> &dyn Database {
+        &*self.storage
     }
 
     /// Fetches value from given column.


### PR DESCRIPTION
No reason to leak implementation details all over the place. In particular the newly added `database` method ensures that users don't clone the `storage`'s `Arc` behind `Store`'s back and create new ad-hoc stuff with it.