### PR TITLE
docs: Fix incorrect path

### DIFF
--- a/benchmarks/synth-bm/README.md
+++ b/benchmarks/synth-bm/README.md
@@ -6,5 +6,5 @@ This crate provides tooling for benchmarking synthetic workloads. It is based on
 
 - [] Automatically measure TPS when transactions are sent with `wait_until: NONE`.
 - [] Enable removing `--nonce` parameters by querying the nonce from the network.
-- [] Add support for [other workloads](~/pytest/tests/loadtest/locust/):
+- [] Add support for [other workloads](../../pytest/tests/loadtest/locust/):
   - [] ft transfers


### PR DESCRIPTION
## Fix incorrect path in synth-bm README

- This PR fixes an incorrect path reference in the benchmarks/synth-bm/README.md file. 
- The link to the locust workloads directory was using a tilde path (`~/pytest/tests/loadtest/locust/`) which doesn't correctly resolve in the repository context. 
- Changed to use the proper relative path (`../../pytest/tests/loadtest/locust/`) instead, ensuring the link correctly points to the locust workload examples.