### PR TITLE
[limited replayability] Deprecate features GlobalContracts, BlockHeightForReceiptId, ProduceOptimisticBlock

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2396,13 +2396,11 @@ impl Chain {
             // TODO(spice): move incoming receipts collection inside apply_chunks_preprocessing
             HashMap::default()
         } else {
-            let receipts_shuffle_salt =
-                get_receipts_shuffle_salt(self.epoch_manager.as_ref(), &block)?;
             self.collect_incoming_receipts_from_chunks(
                 me,
                 &block.chunks(),
                 &prev_hash,
-                receipts_shuffle_salt,
+                get_receipts_shuffle_salt(&block),
             )?
         };
 
@@ -2649,13 +2647,11 @@ impl Chain {
             let prev_block = self.chain_store.get_block(block.header().prev_hash())?.clone();
             let prev_hash = *prev_block.hash();
 
-            let receipts_shuffle_salt =
-                get_receipts_shuffle_salt(self.epoch_manager.as_ref(), &block)?;
             let receipts_by_shard = self.collect_incoming_receipts_from_chunks(
                 me,
                 &block.chunks(),
                 &prev_hash,
-                receipts_shuffle_salt,
+                get_receipts_shuffle_salt(&block),
             )?;
 
             let work = self.apply_chunks_preprocessing(

--- a/chain/chain/src/sharding.rs
+++ b/chain/chain/src/sharding.rs
@@ -1,24 +1,13 @@
-use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::block::Block;
-use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
-use near_primitives::version::ProtocolFeature;
 use rand::SeedableRng;
 use rand::seq::SliceRandom;
 use rand_chacha::ChaCha20Rng;
 
 /// Gets salt for shuffling receipts grouped by **source shards** before
 /// processing them in the target shard.
-pub fn get_receipts_shuffle_salt<'a>(
-    epoch_manager: &dyn EpochManagerAdapter,
-    block: &'a Block,
-) -> Result<&'a CryptoHash, EpochError> {
-    let protocol_version = epoch_manager.get_epoch_protocol_version(&block.header().epoch_id())?;
-    if ProtocolFeature::BlockHeightForReceiptId.enabled(protocol_version) {
-        Ok(block.header().prev_hash())
-    } else {
-        Ok(block.hash())
-    }
+pub fn get_receipts_shuffle_salt<'a>(block: &'a Block) -> &'a CryptoHash {
+    block.header().prev_hash()
 }
 
 pub fn shuffle_receipt_proofs<ReceiptProofType>(

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -455,8 +455,7 @@ fn validate_source_receipt_proofs(
         )?;
 
         // Arrange the receipts in the order in which they should be applied.
-        let receipts_shuffle_salt = get_receipts_shuffle_salt(epoch_manager, block)?;
-        shuffle_receipt_proofs(&mut block_receipt_proofs, receipts_shuffle_salt);
+        shuffle_receipt_proofs(&mut block_receipt_proofs, get_receipts_shuffle_salt(block));
         for proof in block_receipt_proofs {
             receipts_to_apply.extend(proof.0.iter().cloned());
         }

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -71,7 +71,7 @@ use near_primitives::types::{AccountId, BlockHeight};
 use near_primitives::unwrap_or_return;
 use near_primitives::utils::MaybeValidated;
 use near_primitives::validator_signer::ValidatorSigner;
-use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature, get_protocol_upgrade_schedule};
+use near_primitives::version::{PROTOCOL_VERSION, get_protocol_upgrade_schedule};
 use near_primitives::views::{DetailedDebugStatus, ValidatorInfo};
 #[cfg(feature = "test_features")]
 use near_store::DBCol;
@@ -1131,10 +1131,6 @@ impl ClientActorInner {
             }
         }
 
-        let protocol_version = self.client.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
-        if !ProtocolFeature::ProduceOptimisticBlock.enabled(protocol_version) {
-            return Ok(());
-        }
         let optimistic_block_height = self.client.doomslug.get_timer_height();
         if me != self.client.epoch_manager.get_block_producer(&epoch_id, optimistic_block_height)? {
             return Ok(());

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -293,10 +293,13 @@ pub enum ProtocolFeature {
     /// Instead of sending code in the witness, the code checks the code-size using the internal trie nodes.
     ExcludeExistingCodeFromWitnessForCodeLen,
     /// Use the block height instead of the block hash to calculate the receipt ID.
-    BlockHeightForReceiptId,
+    #[deprecated]
+    _DeprecatedBlockHeightForReceiptId,
     /// Enable optimistic block production.
-    ProduceOptimisticBlock,
-    GlobalContracts,
+    #[deprecated]
+    _DeprecatedProduceOptimisticBlock,
+    #[deprecated]
+    _DeprecatedGlobalContracts,
     /// NEP: https://github.com/near/NEPs/pull/536
     ///
     /// Reduce the number of gas refund receipts by charging the current gas
@@ -393,9 +396,9 @@ impl ProtocolFeature {
             | ProtocolFeature::_DeprecatedCurrentEpochStateSync => 74,
             ProtocolFeature::SimpleNightshadeV4 => 75,
             ProtocolFeature::SimpleNightshadeV5 => 76,
-            ProtocolFeature::GlobalContracts
-            | ProtocolFeature::BlockHeightForReceiptId
-            | ProtocolFeature::ProduceOptimisticBlock => 77,
+            ProtocolFeature::_DeprecatedGlobalContracts
+            | ProtocolFeature::_DeprecatedBlockHeightForReceiptId
+            | ProtocolFeature::_DeprecatedProduceOptimisticBlock => 77,
             ProtocolFeature::SimpleNightshadeV6
             | ProtocolFeature::SaturatingFloatToInt
             | ProtocolFeature::ReducedGasRefunds => 78,
@@ -419,7 +422,7 @@ impl ProtocolFeature {
 pub const PROD_GENESIS_PROTOCOL_VERSION: ProtocolVersion = 29;
 
 /// Minimum supported protocol version for the current binary
-pub const MIN_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = 75;
+pub const MIN_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = 78;
 
 /// Current protocol version used on the mainnet with all stable features.
 const STABLE_PROTOCOL_VERSION: ProtocolVersion = 78;

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -3,13 +3,11 @@ use crate::block::BlockHeader;
 use crate::hash::{CryptoHash, hash};
 use crate::transaction::ValidatedTransactionHash;
 use crate::types::{NumSeats, NumShards, ShardId};
-use crate::version::ProtocolVersion;
 use chrono;
 use chrono::DateTime;
 use near_crypto::{ED25519PublicKey, Secp256K1PublicKey};
 use near_primitives_core::account::id::{AccountId, AccountType};
 use near_primitives_core::types::BlockHeight;
-use near_primitives_core::version::ProtocolFeature;
 use serde;
 use std::cmp::max;
 use std::convert::AsRef;
@@ -211,60 +209,43 @@ pub fn get_outcome_id_block_hash_rev(key: &[u8]) -> std::io::Result<(CryptoHash,
     Ok((outcome_id, block_hash))
 }
 
-/// Creates a new Receipt ID from a given signed transaction and a block height or hash.
-/// This method is backward compatible, so it takes the current protocol version.
+/// Creates a new Receipt ID from a given signed transaction and a block height.
 pub fn create_receipt_id_from_transaction(
-    protocol_version: ProtocolVersion,
     tx_hash: ValidatedTransactionHash,
-    block_hash: &CryptoHash,
     block_height: BlockHeight,
 ) -> CryptoHash {
-    create_hash_upgradable(protocol_version, &tx_hash.get_hash(), block_hash, block_height, 0)
+    create_hash_upgradable(&tx_hash.get_hash(), block_height, 0)
 }
 
-/// Creates a new Receipt ID from a given receipt id, a block height or hash and a new receipt index.
-/// This method is backward compatible, so it takes the current protocol version.
+/// Creates a new Receipt ID from a given receipt id, a block height and a receipt index.
 pub fn create_receipt_id_from_receipt_id(
-    protocol_version: ProtocolVersion,
     receipt_id: &CryptoHash,
-    block_hash: &CryptoHash,
     block_height: BlockHeight,
     receipt_index: usize,
 ) -> CryptoHash {
-    create_hash_upgradable(
-        protocol_version,
-        receipt_id,
-        block_hash,
-        block_height,
-        receipt_index as u64,
-    )
+    create_hash_upgradable(receipt_id, block_height, receipt_index as u64)
 }
 
-/// Creates a new action_hash from a given receipt, a block height or hash and an action index.
-/// This method is backward compatible, so it takes the current protocol version.
+/// Creates a new action_hash from a given receipt, a block height and an action index.
 pub fn create_action_hash_from_receipt_id(
-    protocol_version: ProtocolVersion,
     receipt_id: &CryptoHash,
-    block_hash: &CryptoHash,
     block_height: BlockHeight,
     action_index: usize,
 ) -> CryptoHash {
     // Action hash uses the same input as a new receipt ID, so to avoid hash conflicts we use the
-    // salt starting from the `u64` going backward.
+    // salt starting from the u64::MAX going backward.
     let salt = u64::MAX.wrapping_sub(action_index as u64);
-    create_hash_upgradable(protocol_version, receipt_id, block_hash, block_height, salt)
+    create_hash_upgradable(receipt_id, block_height, salt)
 }
 
 /// Creates a new Receipt ID from a given action hash, a block height or hash and a new receipt index.
 /// This method is backward compatible, so it takes the current protocol version.
 pub fn create_receipt_id_from_action_hash(
-    protocol_version: ProtocolVersion,
     action_hash: &CryptoHash,
-    block_hash: &CryptoHash,
     block_height: BlockHeight,
     receipt_index: u64,
 ) -> CryptoHash {
-    create_hash_upgradable(protocol_version, action_hash, block_hash, block_height, receipt_index)
+    create_hash_upgradable(action_hash, block_height, receipt_index)
 }
 
 /// Creates a unique random seed to be provided to `VMContext` from a give `action_hash` and
@@ -282,28 +263,12 @@ pub fn create_random_seed(action_hash: CryptoHash, random_seed: CryptoHash) -> V
     res.as_ref().to_vec()
 }
 
-/// Creates a new CryptoHash ID based on the protocol version.
-/// Before `CREATE_HASH_PROTOCOL_VERSION` it uses `create_nonce_with_nonce` with
-/// just `base` and `salt`.
-/// After `CREATE_HASH_PROTOCOL_VERSION` it uses `extra_hash` in addition to the `base` and `salt`.
-/// E.g. this `extra_hash` can be a block hash to distinguish receipts between forks.
-/// After ProtocolFeature::BlockHeightForReceiptId, the code uses `block_height` instead of `extra_hash`.
-/// This enables applying chunks using only the optimistic block, which does not yet have a block hash.
-fn create_hash_upgradable(
-    protocol_version: ProtocolVersion,
-    base: &CryptoHash,
-    extra_hash: &CryptoHash,
-    block_height: BlockHeight,
-    salt: u64,
-) -> CryptoHash {
-    const BYTES_LEN: usize = size_of::<CryptoHash>() + size_of::<CryptoHash>() + size_of::<u64>();
+/// Creates a new CryptoHash ID using block height and salt.
+fn create_hash_upgradable(base: &CryptoHash, block_height: BlockHeight, salt: u64) -> CryptoHash {
+    const BYTES_LEN: usize = size_of::<CryptoHash>() + size_of::<BlockHeight>() + size_of::<u64>();
     let mut bytes: Vec<u8> = Vec::with_capacity(BYTES_LEN);
     bytes.extend_from_slice(base.as_ref());
-    if ProtocolFeature::BlockHeightForReceiptId.enabled(protocol_version) {
-        bytes.extend_from_slice(block_height.to_le_bytes().as_ref())
-    } else {
-        bytes.extend_from_slice(extra_hash.as_ref())
-    }
+    bytes.extend_from_slice(block_height.to_le_bytes().as_ref());
     bytes.extend(index_to_bytes(salt));
     hash(&bytes)
 }
@@ -515,62 +480,27 @@ mod tests {
     fn test_create_hash_upgradable() {
         // cspell:ignore atata hohoho
         let base = hash(b"atata");
-        let extra_base = hash(b"hohoho");
-        let other_extra_base = hash(b"banana");
+        let other_base = hash(b"banana");
         let block_height: BlockHeight = 123_456_789;
         let other_block_height: BlockHeight = 123_123_123;
         let salt = 3;
 
-        // Check that for protocol versions post BlockHeightForReceiptId, the hash does not depend on block hash.
-        assert_eq!(
-            create_hash_upgradable(
-                ProtocolFeature::BlockHeightForReceiptId.protocol_version(),
-                &base,
-                &extra_base,
-                block_height,
-                salt,
-            ),
-            create_hash_upgradable(
-                ProtocolFeature::BlockHeightForReceiptId.protocol_version(),
-                &base,
-                &other_extra_base,
-                block_height,
-                salt
-            )
-        );
-        // Check that for protocol versions pre BlockHeightForReceiptId, the hash does not depend on block height.
-        assert_eq!(
-            create_hash_upgradable(
-                ProtocolFeature::BlockHeightForReceiptId.protocol_version() - 1,
-                &base,
-                &other_extra_base,
-                block_height,
-                salt,
-            ),
-            create_hash_upgradable(
-                ProtocolFeature::BlockHeightForReceiptId.protocol_version() - 1,
-                &base,
-                &other_extra_base,
-                other_block_height,
-                salt,
-            )
-        );
-        // Check that for protocol versions post BlockHeightForReceiptId, the hash changes if block height changes.
+        // Check that the hash changes if base hash changes
         assert_ne!(
-            create_hash_upgradable(
-                ProtocolFeature::BlockHeightForReceiptId.protocol_version(),
-                &base,
-                &other_extra_base,
-                block_height,
-                salt,
-            ),
-            create_hash_upgradable(
-                ProtocolFeature::BlockHeightForReceiptId.protocol_version(),
-                &base,
-                &other_extra_base,
-                other_block_height,
-                salt,
-            )
+            create_hash_upgradable(&base, block_height, salt),
+            create_hash_upgradable(&other_base, block_height, salt)
+        );
+
+        // Check that the hash changes if block height changes
+        assert_ne!(
+            create_hash_upgradable(&base, block_height, salt),
+            create_hash_upgradable(&base, other_block_height, salt)
+        );
+
+        // Check that the hash changes if salt changes
+        assert_ne!(
+            create_hash_upgradable(&base, block_height, salt),
+            create_hash_upgradable(&base, block_height, salt + 1)
         );
     }
 }

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -185,7 +185,6 @@ pub(crate) fn action_function_call(
         account.clone(),
         *action_hash,
         apply_state.epoch_id,
-        apply_state.block_hash,
         apply_state.block_height,
         epoch_info_provider,
         apply_state.current_protocol_version,

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -32,7 +32,6 @@ pub struct RuntimeExt<'a> {
     action_hash: CryptoHash,
     data_count: u64,
     epoch_id: EpochId,
-    last_block_hash: CryptoHash,
     block_height: BlockHeight,
     epoch_info_provider: &'a dyn EpochInfoProvider,
     current_protocol_version: ProtocolVersion,
@@ -88,7 +87,6 @@ impl<'a> RuntimeExt<'a> {
         account: Account,
         action_hash: CryptoHash,
         epoch_id: EpochId,
-        last_block_hash: CryptoHash,
         block_height: BlockHeight,
         epoch_info_provider: &'a dyn EpochInfoProvider,
         current_protocol_version: ProtocolVersion,
@@ -103,7 +101,6 @@ impl<'a> RuntimeExt<'a> {
             action_hash,
             data_count: 0,
             epoch_id,
-            last_block_hash,
             block_height,
             epoch_info_provider,
             current_protocol_version,
@@ -304,9 +301,7 @@ impl<'a> External for RuntimeExt<'a> {
 
     fn generate_data_id(&mut self) -> CryptoHash {
         let data_id = create_receipt_id_from_action_hash(
-            self.current_protocol_version,
             &self.action_hash,
-            &self.last_block_hash,
             self.block_height,
             self.data_count,
         );

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -156,13 +156,7 @@ impl ApplyState {
         parent_receipt_id: &CryptoHash,
         receipt_index: usize,
     ) -> CryptoHash {
-        create_receipt_id_from_receipt_id(
-            self.current_protocol_version,
-            parent_receipt_id,
-            &self.block_hash,
-            self.block_height,
-            receipt_index,
-        )
+        create_receipt_id_from_receipt_id(parent_receipt_id, self.block_height, receipt_index)
     }
 }
 
@@ -385,12 +379,8 @@ impl Runtime {
         set_tx_state_changes(state_update, validated_tx, &signer, &access_key);
         state_update
             .commit(StateChangeCause::TransactionProcessing { tx_hash: validated_tx.get_hash() });
-        let receipt_id = create_receipt_id_from_transaction(
-            apply_state.current_protocol_version,
-            validated_tx.to_hash(),
-            &apply_state.block_hash,
-            apply_state.block_height,
-        );
+        let receipt_id =
+            create_receipt_id_from_transaction(validated_tx.to_hash(), apply_state.block_height);
         let receipt = Receipt::V0(ReceiptV0 {
             predecessor_id: validated_tx.signer_id().clone(),
             receiver_id: validated_tx.receiver_id().clone(),
@@ -687,9 +677,7 @@ impl Runtime {
         // Executing actions one by one
         for (action_index, action) in action_receipt.actions.iter().enumerate() {
             let action_hash = create_action_hash_from_receipt_id(
-                apply_state.current_protocol_version,
                 receipt.receipt_id(),
-                &apply_state.block_hash,
                 apply_state.block_height,
                 action_index,
             );
@@ -2382,9 +2370,7 @@ fn resolve_promise_yield_timeouts(
         };
         if state_update.contains_key(&promise_yield_key, AccessOptions::DEFAULT)? {
             let new_receipt_id = create_receipt_id_from_receipt_id(
-                processing_state.protocol_version,
                 &queue_entry.data_id,
-                &apply_state.block_hash,
                 apply_state.block_height,
                 new_receipt_index,
             );

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -276,7 +276,6 @@ impl TrieViewer {
             account,
             empty_hash,
             view_state.epoch_id,
-            view_state.block_hash,
             view_state.block_height,
             epoch_info_provider,
             view_state.current_protocol_version,

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -569,21 +569,15 @@ fn test_apply_delayed_receipts_local_tx() {
             local_transactions[2].get_hash(), // tx 2
             local_transactions[3].get_hash(), // tx 3 - the TX is processed, but the receipt is delayed
             create_receipt_id_from_transaction(
-                PROTOCOL_VERSION,
                 ValidatedTransaction::new_for_test(local_transactions[0].clone()).to_hash(),
-                &apply_state.block_hash,
                 apply_state.block_height,
             ), // receipt for tx 0
             create_receipt_id_from_transaction(
-                PROTOCOL_VERSION,
                 ValidatedTransaction::new_for_test(local_transactions[1].clone()).to_hash(),
-                &apply_state.block_hash,
                 apply_state.block_height,
             ), // receipt for tx 1
             create_receipt_id_from_transaction(
-                PROTOCOL_VERSION,
                 ValidatedTransaction::new_for_test(local_transactions[2].clone()).to_hash(),
-                &apply_state.block_hash,
                 apply_state.block_height,
             ), // receipt for tx 2
         ],
@@ -614,15 +608,11 @@ fn test_apply_delayed_receipts_local_tx() {
         vec![
             local_transactions[4].get_hash(), // tx 4
             create_receipt_id_from_transaction(
-                PROTOCOL_VERSION,
                 ValidatedTransaction::new_for_test(local_transactions[4].clone()).to_hash(),
-                &apply_state.block_hash,
                 apply_state.block_height,
             ), // receipt for tx 4
             create_receipt_id_from_transaction(
-                PROTOCOL_VERSION,
                 ValidatedTransaction::new_for_test(local_transactions[3].clone()).to_hash(),
-                &apply_state.block_hash,
                 apply_state.block_height,
             ), // receipt for tx 3
             *receipts[0].receipt_id(),        // receipt #0
@@ -657,21 +647,15 @@ fn test_apply_delayed_receipts_local_tx() {
             local_transactions[7].get_hash(), // tx 7
             local_transactions[8].get_hash(), // tx 8
             create_receipt_id_from_transaction(
-                PROTOCOL_VERSION,
                 ValidatedTransaction::new_for_test(local_transactions[5].clone()).to_hash(),
-                &apply_state.block_hash,
                 apply_state.block_height,
             ), // receipt for tx 5
             create_receipt_id_from_transaction(
-                PROTOCOL_VERSION,
                 ValidatedTransaction::new_for_test(local_transactions[6].clone()).to_hash(),
-                &apply_state.block_hash,
                 apply_state.block_height,
             ), // receipt for tx 6
             create_receipt_id_from_transaction(
-                PROTOCOL_VERSION,
                 ValidatedTransaction::new_for_test(local_transactions[7].clone()).to_hash(),
-                &apply_state.block_hash,
                 apply_state.block_height,
             ), // receipt for tx 7
         ],
@@ -703,9 +687,7 @@ fn test_apply_delayed_receipts_local_tx() {
             *receipts[1].receipt_id(), // receipt #1
             *receipts[2].receipt_id(), // receipt #2
             create_receipt_id_from_transaction(
-                PROTOCOL_VERSION,
                 ValidatedTransaction::new_for_test(local_transactions[8].clone()).to_hash(),
-                &apply_state.block_hash,
                 apply_state.block_height,
             ), // receipt for tx 8
         ],

--- a/tools/replay-archive/src/cli.rs
+++ b/tools/replay-archive/src/cli.rs
@@ -460,9 +460,8 @@ impl ReplayController {
         }
 
         let mut store_update = self.chain_store.store_update();
-        let receipts_shuffle_salt = get_receipts_shuffle_salt(self.epoch_manager.as_ref(), block)?;
         for (shard_id, mut receipts) in receipt_proofs_by_shard_id {
-            shuffle_receipt_proofs(&mut receipts, receipts_shuffle_salt);
+            shuffle_receipt_proofs(&mut receipts, get_receipts_shuffle_salt(block));
             store_update.save_incoming_receipt(&block_hash, shard_id, Arc::new(receipts));
         }
         store_update.commit().unwrap();


### PR DESCRIPTION
Merge this in after 2.7 branch cut.

2.6 binary has STABLE_PROTOCOL_VERSION 77
2.7 binary has STABLE_PROTOCOL_VERSION 78

Future 2.8 binary, can have MIN_SUPPORTED_PROTOCOL_VERSION as 78 now.

For the PR to get merged in, we would have to wait for 2.7 binary to hit mainnet.