### PR TITLE
fix: sharded-bm json updater

### DIFF
--- a/pytest/tests/mocknet/helpers/json_updater.py
+++ b/pytest/tests/mocknet/helpers/json_updater.py
@@ -25,9 +25,11 @@ def deep_merge(original: dict, patch: dict) -> dict:
             result[key] = value
             continue
 
+        assert type(result[key]) == type(
+            value
+        ), f"Cannot merge values of different types: {type(result[key])} and {type(value)}"
         if isinstance(result[key], dict):
             # If both values are dictionaries, merge them recursively
-            assert isinstance(value, dict)
             result[key] = deep_merge(result[key], value)
         else:
             # For non-dictionary values, overwrite with patch value

--- a/pytest/tests/mocknet/helpers/json_updater.py
+++ b/pytest/tests/mocknet/helpers/json_updater.py
@@ -25,9 +25,13 @@ def deep_merge(original: dict, patch: dict) -> dict:
             result[key] = value
             continue
 
-        assert isinstance(result[key], dict) == isinstance(value, dict)
         if isinstance(result[key], dict):
+            # If both values are dictionaries, merge them recursively
+            assert isinstance(value, dict)
             result[key] = deep_merge(result[key], value)
+        else:
+            # For non-dictionary values, overwrite with patch value
+            result[key] = value
 
     return result
 


### PR DESCRIPTION
Somehow I missed the most important case where both keys are present in configs.
Andrea flagged this by saying that log_config is not impacted.