### PR TITLE
feat(tracing): add send_chunk_endorsement span, add validator attribute

### DIFF
--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -201,6 +201,17 @@ pub(crate) fn send_chunk_endorsement_to_block_producers(
     signer: &ValidatorSigner,
     network_sender: &Sender<PeerManagerMessageRequest>,
 ) -> Option<ChunkEndorsement> {
+    let _span = tracing::debug_span!(
+        target: "client",
+        "send_chunk_endorsement",
+        chunk_hash = ?chunk_header.chunk_hash(),
+        height = %chunk_header.height_created(),
+        shard_id = ?chunk_header.shard_id(),
+        validator = %signer.validator_id(),
+        tag_block_production = true,
+    )
+    .entered();
+
     let epoch_id =
         epoch_manager.get_epoch_id_from_prev_block(chunk_header.prev_block_hash()).unwrap();
 

--- a/chain/client/src/stateless_validation/validate.rs
+++ b/chain/client/src/stateless_validation/validate.rs
@@ -130,6 +130,7 @@ pub fn validate_chunk_endorsement(
         "validate_chunk_endorsement",
         height = endorsement.chunk_production_key().height_created,
         shard_id = ?endorsement.chunk_production_key().shard_id,
+        validator = %endorsement.account_id(),
         tag_block_production = true
     )
     .entered();


### PR DESCRIPTION
This allows to match sent and received chunk endorsements. Nodes generate a `send_chunk_endorsement` span with their validator name and then we can match that to `validate_chunk_endorsement` span with the same validator name on the receiver node.

![image](https://github.com/user-attachments/assets/8f3fa2e2-f76d-4fe6-9559-10c523ba5fbc)
