### PR TITLE
feat: get traces in python sharded-bm

### DIFF
--- a/pytest/tests/mocknet/sharded_bm.py
+++ b/pytest/tests/mocknet/sharded_bm.py
@@ -348,11 +348,11 @@ def handle_get_traces(args):
                 unit='iB',
                 unit_scale=True,
                 unit_divisor=1024,
-                bar_format='{desc}: {n_fmt} [{elapsed}, {rate_fmt}]') as pbar:
+                bar_format='{desc}: {n_fmt} [{elapsed}, {rate_fmt}]') as bar:
             for data in response.iter_content(block_size):
                 size = f.write(data)
                 total_bytes += size
-                pbar.update(size)
+                bar.update(size)
 
         logger.info(f"Downloaded size: {total_bytes/1024/1024:.1f}MB")
         logger.info(f"=> Trace saved to {trace_file}")


### PR DESCRIPTION
Replacement for bench.sh' get-traces https://github.com/near/nearcore/blob/89d1360/benchmarks/sharded-bm/bench.sh#L715.

`'Accept-Encoding': 'gzip, deflate, br'` handles compression. Progress bar reports 100s of MBs but in fact only 10s of MB are transferred via network.

### Examples

#### Default

`python tests/mocknet/sharded_bm.py get-traces`

Downloads traviz trace into the current folder, for the current time minus default lag of 10s, with length of 10s.

#### Full

`python tests/mocknet/sharded_bm.py get-traces --output-dir ~/data/traces --time '2025-06-02 10:32:41' --lag 0 --len 20`

Downloads trace into specified folder, ending with given datetime in UTC format, with zero lag and 20s length.