### PR TITLE
fix validators_info deserialization

### DIFF
--- a/chain/jsonrpc/openapi/openapi.json
+++ b/chain/jsonrpc/openapi/openapi.json
@@ -3283,6 +3283,7 @@
             "type": "array"
           },
           "shards_endorsed": {
+            "default": [],
             "description": "Shards this validator is assigned to as chunk validator in the current epoch.",
             "items": {
               "$ref": "#/components/schemas/ShardId"
@@ -3300,8 +3301,7 @@
           "stake",
           "shards",
           "num_produced_blocks",
-          "num_expected_blocks",
-          "shards_endorsed"
+          "num_expected_blocks"
         ],
         "type": "object"
       },

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -2290,6 +2290,7 @@ pub struct CurrentEpochValidatorInfo {
     #[serde(default)]
     pub num_expected_endorsements_per_shard: Vec<NumBlocks>,
     /// Shards this validator is assigned to as chunk validator in the current epoch.
+    #[serde(default)]
     pub shards_endorsed: Vec<ShardId>,
 }
 


### PR DESCRIPTION
This pull request introduces a minor change to the `CurrentEpochValidatorInfo` struct in `core/primitives/src/views.rs`. The change adds a `#[serde(default)]` attribute to the `shards_endorsed` field to ensure it is initialized with a default value during deserialization.