### PR TITLE
feat(tracing): add chunk application spans to block production mode

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -786,7 +786,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         }
     }
 
-    #[instrument(target = "runtime", level = "info", skip_all, fields(shard_id = ?chunk.shard_id))]
+    #[instrument(target = "runtime", level = "info", skip_all, fields(height = block.height, shard_id = ?chunk.shard_id))]
     fn apply_chunk(
         &self,
         storage_config: RuntimeStorageConfig,

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -176,7 +176,6 @@ pub fn apply_old_chunk(
         "apply_old_chunk",
         height = block.height,
         ?shard_id,
-        height = block.height,
         ?apply_reason,
         tag_block_production = true)
     .entered();

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -122,8 +122,12 @@ pub fn apply_new_chunk(
         target: "chain",
         parent: parent_span,
         "apply_new_chunk",
+        height = block.height,
         ?shard_id,
-        ?apply_reason)
+        chunk_hash = ?chunk_header.chunk_hash(),
+        block_hash = ?block.block_hash,
+        ?apply_reason,
+        tag_block_production = true)
     .entered();
     let gas_limit = chunk_header.gas_limit();
 
@@ -170,8 +174,11 @@ pub fn apply_old_chunk(
         target: "chain",
         parent: parent_span,
         "apply_old_chunk",
+        height = block.height,
         ?shard_id,
-        ?apply_reason)
+        height = block.height,
+        ?apply_reason,
+        tag_block_production = true)
     .entered();
 
     let storage_config = RuntimeStorageConfig {


### PR DESCRIPTION
When reasoning about block production it's useful to know when the node is applying chunks, let's add those spans to the block production mode.

@Trisfald if you think it's too noisy we could make it _ext? or filter out in traviz.