### PR TITLE
fix(clippy) - small clippy fix

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1001,7 +1001,7 @@ impl ClientActorInner {
         Ok(Some(new_latest_known))
     }
 
-    #[allow(clippy::needless_pass_by_ref_mut)]
+    #[allow(clippy::needless_pass_by_ref_mut)] // &mut self is needed with the sandbox feature
     fn pre_block_production(&mut self) -> Result<(), Error> {
         #[cfg(feature = "sandbox")]
         {
@@ -1016,7 +1016,7 @@ impl ClientActorInner {
         Ok(())
     }
 
-    #[allow(clippy::needless_pass_by_ref_mut)]
+    #[allow(clippy::needless_pass_by_ref_mut)] // &mut self is needed with the sandbox feature
     fn post_block_production(&mut self) {
         #[cfg(feature = "sandbox")]
         if self.fastforward_delta > 0 {


### PR DESCRIPTION
Running `cargo clippy --tests` with `clippy 0.1.86 (05f9846f89 2025-03-31)`  produces this warning:

```console
    Checking near-store v0.0.0 (/home/jan/code/nearcore/core/store)
error: this argument is a mutable reference, but not used mutably
    --> chain/client/src/client_actor.rs:1004:29
     |
1004 |     fn pre_block_production(&mut self) -> Result<(), Error> {
     |                             ^^^^^^^^^ help: consider changing to: `&self`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut
     = note: requested on the command line with `-D clippy::needless-pass-by-ref-mut`

error: this argument is a mutable reference, but not used mutably
    --> chain/client/src/client_actor.rs:1018:30
     |
1018 |     fn post_block_production(&mut self) {
     |                              ^^^^^^^^^ help: consider changing to: `&self`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut
```

But `&mut self` is needed when the sandbox feature is enabled. Let's add `allow` statement to ignore this lint.