### PR TITLE
feat(tracing) - better span attributes

### DIFF
--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -281,7 +281,7 @@ impl RuntimeStorageConfig {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum BlockType {
     Normal,
     Optimistic,

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -126,6 +126,7 @@ pub fn apply_new_chunk(
         ?shard_id,
         chunk_hash = ?chunk_header.chunk_hash(),
         block_hash = ?block.block_hash,
+        block_type = ?block.block_type,
         ?apply_reason,
         tag_block_production = true)
     .entered();
@@ -175,6 +176,8 @@ pub fn apply_old_chunk(
         parent: parent_span,
         "apply_old_chunk",
         height = block.height,
+        block_hash = ?block.block_hash,
+        block_type = ?block.block_type,
         ?shard_id,
         ?apply_reason,
         tag_block_production = true)

--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -203,7 +203,7 @@ impl ChunkProducer {
 
     #[instrument(target = "client", level = "debug", "produce_chunk", skip_all, fields(
         height = next_height,
-        shard_id,
+        ?shard_id,
         ?epoch_id,
         chunk_hash = tracing::field::Empty,
         tag_block_production = true


### PR DESCRIPTION
* Fix `shard_id` attribute on `produce_chunk` span - without the `?` the attribute is not added correctly . Not sure why, but with `?` it works fine.
* Add `block_type` attribute to apply chunk spans - it allows to distinguish between applying chunks from normal and optimistic blocks
* Add `block_hash` to `apply_old_chunk`, it was missing for some reason