### PR TITLE
fix(tracing): set attribute name back to 'height'

### DIFF
--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -530,7 +530,7 @@ pub fn validate_chunk_state_witness(
     let span = tracing::debug_span!(
         target: "client",
         "validate_chunk_state_witness",
-        height_created,
+        height = height_created,
         shard_id = ?witness_chunk_shard_id,
         tag_block_production = true
     )


### PR DESCRIPTION
https://github.com/near/nearcore/pull/13632 changed the name of this attribute from `height` to `height_created`, which broke a bunch of stuff in traviz that relied on the name being `height`. Let's change it back to `height`.