### PR TITLE
Add database rollback-to26 command

### DIFF
--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -10,7 +10,7 @@ pub use crate::db::{
 use crate::db::{DBTransaction, Database, StoreStatistics, metadata};
 pub use crate::node_storage::opener::{
     StoreMigrator, StoreOpener, StoreOpenerError, checkpoint_hot_storage_and_cleanup_columns,
-    clear_columns,
+    clear_columns, rollback_database_from_27_to_26,
 };
 pub use crate::node_storage::{NodeStorage, Temperature};
 pub use crate::store::{Store, StoreUpdate};

--- a/tools/database/src/commands.rs
+++ b/tools/database/src/commands.rs
@@ -8,6 +8,7 @@ use crate::compact::RunCompactionCommand;
 use crate::drop_column::DropColumnCommand;
 use crate::make_snapshot::MakeSnapshotCommand;
 use crate::memtrie::{LoadMemTrieCommand, SplitShardTrieCommand};
+use crate::rollback_to_26::RollbackTo26Command;
 use crate::run_migrations::RunMigrationsCommand;
 use crate::set_version::SetVersionCommand;
 use crate::state_perf::StatePerfCommand;
@@ -68,6 +69,10 @@ enum SubCommand {
 
     /// Manually set database version
     SetVersion(SetVersionCommand),
+
+    /// Rollback the database from format used by neard 2.7 to the format used by neard 2.6.
+    /// Sets DB version to 44.
+    RollbackTo26(RollbackTo26Command),
 }
 
 impl DatabaseCommand {
@@ -95,6 +100,7 @@ impl DatabaseCommand {
             SubCommand::AnalyzeDelayedReceipt(cmd) => cmd.run(home, genesis_validation),
             SubCommand::AnalyzeContractSizes(cmd) => cmd.run(home, genesis_validation),
             SubCommand::SetVersion(cmd) => cmd.run(home, genesis_validation),
+            SubCommand::RollbackTo26(cmd) => cmd.run(home, genesis_validation),
         }
     }
 }

--- a/tools/database/src/lib.rs
+++ b/tools/database/src/lib.rs
@@ -10,6 +10,7 @@ mod compact;
 mod drop_column;
 mod make_snapshot;
 mod memtrie;
+mod rollback_to_26;
 mod run_migrations;
 mod set_version;
 mod state_perf;

--- a/tools/database/src/rollback_to_26.rs
+++ b/tools/database/src/rollback_to_26.rs
@@ -1,0 +1,44 @@
+use clap::Parser;
+use near_chain_configs::GenesisValidationMode;
+use std::path::Path;
+
+use crate::utils::get_user_confirmation;
+
+/// Rollback the database from format used by neard 2.7 to the format used by neard 2.6.
+/// Sets DB version to 44.
+#[derive(Parser)]
+pub(crate) struct RollbackTo26Command {
+    /// Don't ask for confirmation - use this flag to skip the confirmation prompt.
+    #[clap(long, action)]
+    no_confirmation: bool,
+}
+
+impl RollbackTo26Command {
+    pub(crate) fn run(
+        &self,
+        home_dir: &Path,
+        genesis_validation: GenesisValidationMode,
+    ) -> anyhow::Result<()> {
+        let config = nearcore::config::load_config(&home_dir, genesis_validation)?;
+
+        let get_confirmation: Box<dyn FnOnce() -> bool> = if self.no_confirmation {
+            Box::new(|| true)
+        } else {
+            Box::new(|| {
+                get_user_confirmation(
+                    "You are about to roll back the database from format used by neard 2.7 to the format used by neard 2.6.
+Do not interrupt the rollback operation, stopping the process in the middle of it could corrupt the database.
+Do you want to continue?",
+                )
+            })
+        };
+
+        near_store::rollback_database_from_27_to_26(
+            home_dir,
+            &config.config.store,
+            config.config.archival_config(),
+            get_confirmation,
+        )?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Analogous to https://github.com/near/nearcore/pull/13250, but only sets the DB version to `44`, as no additional column is introduced in `2.7.0`. Tested on localnet.