### PR TITLE
feat: tweak sharded-bm config in non-invasive way

### DIFF
--- a/benchmarks/sharded-bm/cases/forknet/10_cp_1_rpc_10_shard/params.json
+++ b/benchmarks/sharded-bm/cases/forknet/10_cp_1_rpc_10_shard/params.json
@@ -1,13 +1,10 @@
 {
-    "chunk_producers": 10,
-    "rpcs": 1,
-    "base_config_patch": "../../base_config_patch.json",
-    "base_genesis_patch": "../../10_shards_genesis_patch.json",
-    "num_accounts": 100,
-    "tx_generator": {
-        "enabled": true
-    },
-    "forknet": {
-        "binary_url": "https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Linux/tx-generator-neard/neard"
-    }
+  "chunk_producers": 10,
+  "rpcs": 1,
+  "base_config_patch": "../../base_config_patch.json",
+  "base_genesis_patch": "../../10_shards_genesis_patch.json",
+  "num_accounts": 100,
+  "tx_generator": {
+    "enabled": true
+  }
 }

--- a/benchmarks/sharded-bm/cases/forknet/10_cp_1_rpc_10_shard/params.json
+++ b/benchmarks/sharded-bm/cases/forknet/10_cp_1_rpc_10_shard/params.json
@@ -1,10 +1,10 @@
 {
-  "chunk_producers": 10,
-  "rpcs": 1,
-  "base_config_patch": "../../base_config_patch.json",
-  "base_genesis_patch": "../../10_shards_genesis_patch.json",
-  "num_accounts": 100,
-  "tx_generator": {
-    "enabled": true
-  }
+    "chunk_producers": 10,
+    "rpcs": 1,
+    "base_config_patch": "../../base_config_patch.json",
+    "base_genesis_patch": "../../10_shards_genesis_patch.json",
+    "num_accounts": 100,
+    "tx_generator": {
+        "enabled": true
+    }
 }

--- a/benchmarks/sharded-bm/cases/forknet/20_cp_1_rpc_20_shard/params.json
+++ b/benchmarks/sharded-bm/cases/forknet/20_cp_1_rpc_20_shard/params.json
@@ -1,10 +1,10 @@
 {
-  "chunk_producers": 20,
-  "rpcs": 1,
-  "base_config_patch": "../../base_config_patch.json",
-  "base_genesis_patch": "../../20_shards_genesis_patch.json",
-  "num_accounts": 2,
-  "tx_generator": {
-    "enabled": true
-  }
+    "chunk_producers": 20,
+    "rpcs": 1,
+    "base_config_patch": "../../base_config_patch.json",
+    "base_genesis_patch": "../../20_shards_genesis_patch.json",
+    "num_accounts": 2,
+    "tx_generator": {
+        "enabled": true
+    }
 }

--- a/benchmarks/sharded-bm/cases/forknet/20_cp_1_rpc_20_shard/params.json
+++ b/benchmarks/sharded-bm/cases/forknet/20_cp_1_rpc_20_shard/params.json
@@ -1,13 +1,10 @@
 {
-    "chunk_producers": 20,
-    "rpcs": 1,
-    "base_config_patch": "../../base_config_patch.json",
-    "base_genesis_patch": "../../20_shards_genesis_patch.json",
-    "num_accounts": 2,
-    "tx_generator": {
-        "enabled": true
-    },
-    "forknet": {
-        "binary_url": "https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Linux/tx-generator-neard/neard"
-    }
+  "chunk_producers": 20,
+  "rpcs": 1,
+  "base_config_patch": "../../base_config_patch.json",
+  "base_genesis_patch": "../../20_shards_genesis_patch.json",
+  "num_accounts": 2,
+  "tx_generator": {
+    "enabled": true
+  }
 }

--- a/benchmarks/sharded-bm/cases/forknet/50_cp_1_rpc_50_shard/params.json
+++ b/benchmarks/sharded-bm/cases/forknet/50_cp_1_rpc_50_shard/params.json
@@ -1,10 +1,10 @@
 {
-  "chunk_producers": 50,
-  "rpcs": 1,
-  "base_config_patch": "../../base_config_patch.json",
-  "base_genesis_patch": "../../50_shards_genesis_patch.json",
-  "num_accounts": 20,
-  "tx_generator": {
-    "enabled": true
-  }
+    "chunk_producers": 50,
+    "rpcs": 1,
+    "base_config_patch": "../../base_config_patch.json",
+    "base_genesis_patch": "../../50_shards_genesis_patch.json",
+    "num_accounts": 20,
+    "tx_generator": {
+        "enabled": true
+    }
 }

--- a/benchmarks/sharded-bm/cases/forknet/50_cp_1_rpc_50_shard/params.json
+++ b/benchmarks/sharded-bm/cases/forknet/50_cp_1_rpc_50_shard/params.json
@@ -1,13 +1,10 @@
 {
-    "chunk_producers": 50,
-    "rpcs": 1,
-    "base_config_patch": "../../base_config_patch.json",
-    "base_genesis_patch": "../../50_shards_genesis_patch.json",
-    "num_accounts": 20,
-    "tx_generator": {
-        "enabled": true
-    },
-    "forknet": {
-        "binary_url": "https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Linux/tx-generator-neard/neard"
-    }
+  "chunk_producers": 50,
+  "rpcs": 1,
+  "base_config_patch": "../../base_config_patch.json",
+  "base_genesis_patch": "../../50_shards_genesis_patch.json",
+  "num_accounts": 20,
+  "tx_generator": {
+    "enabled": true
+  }
 }

--- a/benchmarks/sharded-bm/cases/forknet/5_cp_1_rpc_5_shard/params.json
+++ b/benchmarks/sharded-bm/cases/forknet/5_cp_1_rpc_5_shard/params.json
@@ -1,10 +1,10 @@
 {
-  "chunk_producers": 5,
-  "rpcs": 1,
-  "num_accounts": 50000,
-  "base_config_patch": "../../base_config_patch.json",
-  "base_genesis_patch": "../../5_shards_genesis_patch.json",
-  "tx_generator": {
-    "enabled": true
-  }
+    "chunk_producers": 5,
+    "rpcs": 1,
+    "num_accounts": 50000,
+    "base_config_patch": "../../base_config_patch.json",
+    "base_genesis_patch": "../../5_shards_genesis_patch.json",
+    "tx_generator": {
+        "enabled": true
+    }
 }

--- a/benchmarks/sharded-bm/cases/forknet/5_cp_1_rpc_5_shard/params.json
+++ b/benchmarks/sharded-bm/cases/forknet/5_cp_1_rpc_5_shard/params.json
@@ -1,13 +1,10 @@
 {
-    "chunk_producers": 5,
-    "rpcs": 1,
-    "num_accounts": 50000,
-    "base_config_patch": "../../base_config_patch.json",
-    "base_genesis_patch": "../../5_shards_genesis_patch.json",
-    "tx_generator": {
-        "enabled": true
-    },
-    "forknet": {
-        "binary_url": "https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Linux/tx-generator-neard/neard"
-    }
+  "chunk_producers": 5,
+  "rpcs": 1,
+  "num_accounts": 50000,
+  "base_config_patch": "../../base_config_patch.json",
+  "base_genesis_patch": "../../5_shards_genesis_patch.json",
+  "tx_generator": {
+    "enabled": true
+  }
 }

--- a/benchmarks/sharded-bm/cases/forknet/70_cp_1_rpc_70_shard/params.json
+++ b/benchmarks/sharded-bm/cases/forknet/70_cp_1_rpc_70_shard/params.json
@@ -1,11 +1,11 @@
 {
-  "chunk_producers": 70,
-  "rpcs": 1,
-  "base_config_patch": "../../base_config_patch.json",
-  "base_genesis_patch": "../../70_shards_genesis_patch.json",
-  "num_accounts": 4,
-  "account_rps": 2,
-  "tx_generator": {
-    "enabled": true
-  }
+    "chunk_producers": 70,
+    "rpcs": 1,
+    "base_config_patch": "../../base_config_patch.json",
+    "base_genesis_patch": "../../70_shards_genesis_patch.json",
+    "num_accounts": 4,
+    "account_rps": 2,
+    "tx_generator": {
+        "enabled": true
+    }
 }

--- a/benchmarks/sharded-bm/cases/forknet/70_cp_1_rpc_70_shard/params.json
+++ b/benchmarks/sharded-bm/cases/forknet/70_cp_1_rpc_70_shard/params.json
@@ -1,14 +1,11 @@
 {
-    "chunk_producers": 70,
-    "rpcs": 1,
-    "base_config_patch": "../../base_config_patch.json",
-    "base_genesis_patch": "../../70_shards_genesis_patch.json",
-    "num_accounts": 4,
-    "account_rps": 2,
-    "tx_generator": {
-        "enabled": true
-    },
-    "forknet": {
-        "binary_url": "https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Linux/tx-generator-neard/neard"
-    }
+  "chunk_producers": 70,
+  "rpcs": 1,
+  "base_config_patch": "../../base_config_patch.json",
+  "base_genesis_patch": "../../70_shards_genesis_patch.json",
+  "num_accounts": 4,
+  "account_rps": 2,
+  "tx_generator": {
+    "enabled": true
+  }
 }

--- a/benchmarks/sharded-bm/cases/forknet/realistic_20_cp_1_rpc_20_shard/params.json
+++ b/benchmarks/sharded-bm/cases/forknet/realistic_20_cp_1_rpc_20_shard/params.json
@@ -1,11 +1,11 @@
 {
-  "chunk_producers": 20,
-  "rpcs": 1,
-  "base_config_patch": "../../base_config_patch.json",
-  "base_genesis_patch": "../../20_shards_genesis_patch.json",
-  "num_accounts": 50000,
-  "account_rps": 250,
-  "tx_generator": {
-    "enabled": true
-  }
+    "chunk_producers": 20,
+    "rpcs": 1,
+    "base_config_patch": "../../base_config_patch.json",
+    "base_genesis_patch": "../../20_shards_genesis_patch.json",
+    "num_accounts": 50000,
+    "account_rps": 250,
+    "tx_generator": {
+        "enabled": true
+    }
 }

--- a/benchmarks/sharded-bm/cases/forknet/realistic_20_cp_1_rpc_20_shard/params.json
+++ b/benchmarks/sharded-bm/cases/forknet/realistic_20_cp_1_rpc_20_shard/params.json
@@ -1,15 +1,11 @@
-
 {
-    "chunk_producers": 20,
-    "rpcs": 1,
-    "base_config_patch": "../../base_config_patch.json",
-    "base_genesis_patch": "../../20_shards_genesis_patch.json",
-    "num_accounts": 50000,
-    "account_rps": 250,
-    "tx_generator": {
-        "enabled": true
-    },
-    "forknet": {
-        "binary_url": "https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Linux/tx-generator-neard/neard"
-    }
+  "chunk_producers": 20,
+  "rpcs": 1,
+  "base_config_patch": "../../base_config_patch.json",
+  "base_genesis_patch": "../../20_shards_genesis_patch.json",
+  "num_accounts": 50000,
+  "account_rps": 250,
+  "tx_generator": {
+    "enabled": true
+  }
 }

--- a/benchmarks/sharded-bm/cases/local/1_node_10_shard/params.json
+++ b/benchmarks/sharded-bm/cases/local/1_node_10_shard/params.json
@@ -1,10 +1,10 @@
 {
-    "chunk_producers": 1,
-    "rpcs": 0,
-    "base_config_patch": "../../base_config_patch.json",
-    "base_genesis_patch": "../../10_shards_genesis_patch.json",
-    "num_accounts": 100,
-    "channel_buffer_size": 30000,
-    "requests_per_second": 3800,
-    "num_transfers": 30000
+  "chunk_producers": 1,
+  "rpcs": 0,
+  "base_config_patch": "../../base_config_patch.json",
+  "base_genesis_patch": "../../10_shards_genesis_patch.json",
+  "num_accounts": 100,
+  "channel_buffer_size": 30000,
+  "requests_per_second": 3800,
+  "num_transfers": 30000
 }

--- a/benchmarks/sharded-bm/cases/local/1_node_10_shard/params.json
+++ b/benchmarks/sharded-bm/cases/local/1_node_10_shard/params.json
@@ -1,10 +1,10 @@
 {
-  "chunk_producers": 1,
-  "rpcs": 0,
-  "base_config_patch": "../../base_config_patch.json",
-  "base_genesis_patch": "../../10_shards_genesis_patch.json",
-  "num_accounts": 100,
-  "channel_buffer_size": 30000,
-  "requests_per_second": 3800,
-  "num_transfers": 30000
+    "chunk_producers": 1,
+    "rpcs": 0,
+    "base_config_patch": "../../base_config_patch.json",
+    "base_genesis_patch": "../../10_shards_genesis_patch.json",
+    "num_accounts": 100,
+    "channel_buffer_size": 30000,
+    "requests_per_second": 3800,
+    "num_transfers": 30000
 }

--- a/benchmarks/sharded-bm/cases/local/1_node_1_shard/params.json
+++ b/benchmarks/sharded-bm/cases/local/1_node_1_shard/params.json
@@ -1,10 +1,10 @@
 {
-    "chunk_producers": 1,
-    "rpcs": 0,
-    "base_config_patch": "../../base_config_patch.json",
-    "base_genesis_patch": "../../1_shard_genesis_patch.json",
-    "num_accounts": 1000,
-    "channel_buffer_size": 60000,
-    "requests_per_second": 4000,
-    "num_transfers": 300000
+  "chunk_producers": 1,
+  "rpcs": 0,
+  "base_config_patch": "../../base_config_patch.json",
+  "base_genesis_patch": "../../1_shard_genesis_patch.json",
+  "num_accounts": 1000,
+  "channel_buffer_size": 60000,
+  "requests_per_second": 4000,
+  "num_transfers": 300000
 }

--- a/benchmarks/sharded-bm/cases/local/1_node_1_shard/params.json
+++ b/benchmarks/sharded-bm/cases/local/1_node_1_shard/params.json
@@ -1,10 +1,10 @@
 {
-  "chunk_producers": 1,
-  "rpcs": 0,
-  "base_config_patch": "../../base_config_patch.json",
-  "base_genesis_patch": "../../1_shard_genesis_patch.json",
-  "num_accounts": 1000,
-  "channel_buffer_size": 60000,
-  "requests_per_second": 4000,
-  "num_transfers": 300000
+    "chunk_producers": 1,
+    "rpcs": 0,
+    "base_config_patch": "../../base_config_patch.json",
+    "base_genesis_patch": "../../1_shard_genesis_patch.json",
+    "num_accounts": 1000,
+    "channel_buffer_size": 60000,
+    "requests_per_second": 4000,
+    "num_transfers": 300000
 }

--- a/benchmarks/sharded-bm/cases/local/1_node_50_shard/params.json
+++ b/benchmarks/sharded-bm/cases/local/1_node_50_shard/params.json
@@ -1,10 +1,10 @@
 {
-    "chunk_producers": 1,
-    "rpcs": 0,
-    "base_config_patch": "../../base_config_patch.json",
-    "base_genesis_patch": "../../50_shards_genesis_patch.json",
-    "num_accounts": 20,
-    "channel_buffer_size": 6000,
-    "requests_per_second": 2200,
-    "num_transfers": 6000
+  "chunk_producers": 1,
+  "rpcs": 0,
+  "base_config_patch": "../../base_config_patch.json",
+  "base_genesis_patch": "../../50_shards_genesis_patch.json",
+  "num_accounts": 20,
+  "channel_buffer_size": 6000,
+  "requests_per_second": 2200,
+  "num_transfers": 6000
 }

--- a/benchmarks/sharded-bm/cases/local/1_node_50_shard/params.json
+++ b/benchmarks/sharded-bm/cases/local/1_node_50_shard/params.json
@@ -1,10 +1,10 @@
 {
-  "chunk_producers": 1,
-  "rpcs": 0,
-  "base_config_patch": "../../base_config_patch.json",
-  "base_genesis_patch": "../../50_shards_genesis_patch.json",
-  "num_accounts": 20,
-  "channel_buffer_size": 6000,
-  "requests_per_second": 2200,
-  "num_transfers": 6000
+    "chunk_producers": 1,
+    "rpcs": 0,
+    "base_config_patch": "../../base_config_patch.json",
+    "base_genesis_patch": "../../50_shards_genesis_patch.json",
+    "num_accounts": 20,
+    "channel_buffer_size": 6000,
+    "requests_per_second": 2200,
+    "num_transfers": 6000
 }

--- a/benchmarks/sharded-bm/cases/local/1_node_5_shard/params.json
+++ b/benchmarks/sharded-bm/cases/local/1_node_5_shard/params.json
@@ -1,10 +1,10 @@
 {
-  "chunk_producers": 1,
-  "rpcs": 0,
-  "base_config_patch": "../../base_config_patch.json",
-  "base_genesis_patch": "../../5_shards_genesis_patch.json",
-  "num_accounts": 200,
-  "channel_buffer_size": 30000,
-  "requests_per_second": 3900,
-  "num_transfers": 70000
+    "chunk_producers": 1,
+    "rpcs": 0,
+    "base_config_patch": "../../base_config_patch.json",
+    "base_genesis_patch": "../../5_shards_genesis_patch.json",
+    "num_accounts": 200,
+    "channel_buffer_size": 30000,
+    "requests_per_second": 3900,
+    "num_transfers": 70000
 }

--- a/benchmarks/sharded-bm/cases/local/1_node_5_shard/params.json
+++ b/benchmarks/sharded-bm/cases/local/1_node_5_shard/params.json
@@ -1,10 +1,10 @@
 {
-    "chunk_producers": 1,
-    "rpcs": 0,
-    "base_config_patch": "../../base_config_patch.json",
-    "base_genesis_patch": "../../5_shards_genesis_patch.json",
-    "num_accounts": 200,
-    "channel_buffer_size": 30000,
-    "requests_per_second": 3900,
-    "num_transfers": 70000
+  "chunk_producers": 1,
+  "rpcs": 0,
+  "base_config_patch": "../../base_config_patch.json",
+  "base_genesis_patch": "../../5_shards_genesis_patch.json",
+  "num_accounts": 200,
+  "channel_buffer_size": 30000,
+  "requests_per_second": 3900,
+  "num_transfers": 70000
 }

--- a/benchmarks/sharded-bm/cases/local/3_cp_1_rpc_10_shard/params.json
+++ b/benchmarks/sharded-bm/cases/local/3_cp_1_rpc_10_shard/params.json
@@ -1,10 +1,10 @@
 {
-  "chunk_producers": 3,
-  "rpcs": 1,
-  "base_config_patch": "../../base_config_patch.json",
-  "base_genesis_patch": "../../10_shards_genesis_patch.json",
-  "num_accounts": 100,
-  "channel_buffer_size": 30000,
-  "requests_per_second": 2700,
-  "num_transfers": 30000
+    "chunk_producers": 3,
+    "rpcs": 1,
+    "base_config_patch": "../../base_config_patch.json",
+    "base_genesis_patch": "../../10_shards_genesis_patch.json",
+    "num_accounts": 100,
+    "channel_buffer_size": 30000,
+    "requests_per_second": 2700,
+    "num_transfers": 30000
 }

--- a/benchmarks/sharded-bm/cases/local/3_cp_1_rpc_10_shard/params.json
+++ b/benchmarks/sharded-bm/cases/local/3_cp_1_rpc_10_shard/params.json
@@ -1,10 +1,10 @@
 {
-    "chunk_producers": 3,
-    "rpcs": 1,
-    "base_config_patch": "../../base_config_patch.json",
-    "base_genesis_patch": "../../10_shards_genesis_patch.json",
-    "num_accounts": 100,
-    "channel_buffer_size": 30000,
-    "requests_per_second": 2700,
-    "num_transfers": 30000
+  "chunk_producers": 3,
+  "rpcs": 1,
+  "base_config_patch": "../../base_config_patch.json",
+  "base_genesis_patch": "../../10_shards_genesis_patch.json",
+  "num_accounts": 100,
+  "channel_buffer_size": 30000,
+  "requests_per_second": 2700,
+  "num_transfers": 30000
 }

--- a/pytest/tests/mocknet/docs/sharded_bm.md
+++ b/pytest/tests/mocknet/docs/sharded_bm.md
@@ -57,8 +57,19 @@ If you want to tweak some non-critical parameters, modify locally the json patch
 For more critical changes, like changing neard binary, you must call `init`. You can either:
 
 * give flag `--neard-binary-url URL` which takes the highest priority;
-* otherwise, value of env var `NEARD_BINARY_URL` will be taken, if set;
-* otherwise, `binary_url` from `CASE` will be taken.
+* otherwise, value of env var `NEARD_BINARY_URL` will be taken.
+
+### Critical parameters
+
+* Genesis
+* Epoch config
+* `params.json`
+
+### Non-critical parameters
+
+* `config.json`
+* `log_config.json`
+* Load schedule
 
 ## Other docs
 

--- a/pytest/tests/mocknet/docs/sharded_bm.md
+++ b/pytest/tests/mocknet/docs/sharded_bm.md
@@ -52,10 +52,9 @@ python tests/mocknet/sharded_bm.py reset
 
 ## Tweaking
 
-For now, if you want to change load schedule, it is easier to run `python tests/mocknet/sharded_bm.py init` again.
-TODO: make it faster.
+If you want to tweak some non-critical parameters, modify locally the json patches in `CASE` and then run `python tests/mocknet/sharded_bm.py tweak-config`.
 
-Changing neard binary also requires calling `init`. You can either:
+For more critical changes, like changing neard binary, you must call `init`. You can either:
 
 * give flag `--neard-binary-url URL` which takes the highest priority;
 * otherwise, value of env var `NEARD_BINARY_URL` will be taken, if set;

--- a/pytest/tests/mocknet/docs/sharded_bm.md
+++ b/pytest/tests/mocknet/docs/sharded_bm.md
@@ -61,9 +61,9 @@ For more critical changes, like changing neard binary, you must call `init`. You
 
 ### Critical parameters
 
-* Genesis
-* Epoch config
-* `params.json`
+* Genesis - because it defines fundamental chain parameters, like gas limit, and changing them may break validation rules.
+* Epoch config - because it defines parameters for the epoch duration, and changing them in the middle of epoch may do the same.
+* `params.json` - because it defines the initial cluster setup and doesn't change experiment if it was already launched.
 
 ### Non-critical parameters
 

--- a/pytest/tests/mocknet/sharded_bm.py
+++ b/pytest/tests/mocknet/sharded_bm.py
@@ -110,9 +110,9 @@ def handle_init(args):
         args.neard_binary_url = os.environ['NEARD_BINARY_URL']
     else:
         logger.info(
-            f"Using neard binary URL from benchmark params: {args.bm_params['forknet']['binary_url']}"
+            "Please provide neard binary URL via CLI or env var NEARD_BINARY_URL"
         )
-        args.neard_binary_url = args.bm_params['forknet']['binary_url']
+        sys.exit(1)
 
     init_args = SimpleNamespace(
         neard_upgrade_binary_url="",

--- a/pytest/tests/mocknet/sharded_bm.py
+++ b/pytest/tests/mocknet/sharded_bm.py
@@ -85,6 +85,19 @@ def fetch_forknet_details(forknet_name, bm_params):
     }
 
 
+def upload_json_patches(args):
+    """Upload the json patches to the benchmark directory."""
+    upload_file_args = copy.deepcopy(args)
+    upload_file_args.src = f"{SOURCE_BENCHNET_DIR}/cases"
+    upload_file_args.dst = BENCHNET_DIR
+    run_remote_upload_file(CommandContext(upload_file_args))
+
+    upload_file_args = copy.deepcopy(args)
+    upload_file_args.src = "tests/mocknet/helpers"
+    upload_file_args.dst = BENCHNET_DIR
+    run_remote_upload_file(CommandContext(upload_file_args))
+
+
 def handle_init(args):
     """Handle the init command - initialize the benchmark before running it."""
 
@@ -116,15 +129,7 @@ def handle_init(args):
 
     # TODO: check neard binary version
 
-    upload_file_args = copy.deepcopy(args)
-    upload_file_args.src = f"{SOURCE_BENCHNET_DIR}/cases"
-    upload_file_args.dst = BENCHNET_DIR
-    run_remote_upload_file(CommandContext(upload_file_args))
-
-    upload_file_args = copy.deepcopy(args)
-    upload_file_args.src = "tests/mocknet/helpers"
-    upload_file_args.dst = BENCHNET_DIR
-    run_remote_upload_file(CommandContext(upload_file_args))
+    upload_json_patches(args)
 
     new_test_cmd_args = SimpleNamespace(
         state_source="empty",
@@ -167,7 +172,7 @@ def handle_init(args):
         )
         run_env_cmd(CommandContext(env_cmd_args))
 
-    handle_apply_json_patches(args)
+    apply_json_patches(args)
 
     start_nodes(args)
 
@@ -189,8 +194,8 @@ def handle_init(args):
     stop_nodes(args)
 
 
-def handle_apply_json_patches(args):
-    """Handle the apply-json-patches command."""
+def apply_json_patches(args):
+    """Apply the json patches to the genesis, config and log_config."""
     genesis = f"{NEAR_HOME}/genesis.json"
     base_genesis_patch = f"{BENCHNET_DIR}/{args.case}/{args.bm_params['base_genesis_patch']}"
 
@@ -230,6 +235,19 @@ def stop_nodes(args, disable_tx_generator=False):
         "
 
         run_remote_cmd(CommandContext(run_cmd_args))
+
+
+def handle_tweak_config(args):
+    """
+    Handle the tweak-config command.
+
+    Used when you want to tweak non-critical parameters of the benchmark, such
+    as block production time, load schedule, log levels.
+    Note that for critical parameters like number of accounts per shard you 
+    must reinitialize the benchmark!
+    """
+    upload_json_patches(args)
+    apply_json_patches(args)
 
 
 def handle_stop(args):
@@ -424,8 +442,8 @@ def main():
     )
 
     subparsers.add_parser(
-        'apply-json-patches',
-        help='Apply the patches to genesis, config and log_config',
+        'tweak-config',
+        help='Reupload and apply the patches to genesis, config and log_config',
     )
 
     start_parser = subparsers.add_parser('start', help='Start the benchmark')
@@ -470,8 +488,8 @@ def main():
     # Route to appropriate handler based on command
     if args.command == 'init':
         handle_init(args)
-    elif args.command == 'apply-json-patches':
-        handle_apply_json_patches(args)
+    elif args.command == 'tweak-config':
+        handle_tweak_config(args)
     elif args.command == 'stop':
         handle_stop(args)
     elif args.command == 'start':


### PR DESCRIPTION
I misunderstood before why we needed tweak_config, but that seems like a nice usecase. https://github.com/near/nearcore/pull/13645#discussion_r2123197381
Now, if you want to make a slight change, like reduce block production time, you can run `tweak-config`, it will update configs on all nodes, and you will not have to reinit cluster again.
`apply-json-patches` didn't make sense because it didn't upload updated files.

Testing: the different profiles here https://grafana.nearone.org/goto/Xl6ljWYNg?orgId=1 were resulting only from calling start, stop and tweak-config.