### PR TITLE
fix(mirror): keep tracked shards backwards compatible

### DIFF
--- a/pytest/lib/mocknet.py
+++ b/pytest/lib/mocknet.py
@@ -1020,7 +1020,7 @@ def update_config_file(
         for node_key, node_ip in zip(all_node_pks, node_ips)
     ]
 
-    config_json['tracked_shards_config'] = 'AllShards'
+    config_json['tracked_shards'] = [0]
     config_json['archive'] = True
     config_json['archival_peer_connections_lower_bound'] = 1
     config_json['network']['boot_nodes'] = ','.join(node_addresses)
@@ -1049,7 +1049,7 @@ def create_and_upload_config_file_from_default(nodes,
         nodes[0],
         '/home/ubuntu/.near-tmp/config.json',
     )
-    config_json['tracked_shards_config'] = 'AllShards'
+    config_json['tracked_shards'] = [0, 1, 2, 3]
     config_json['archive'] = True
     config_json['archival_peer_connections_lower_bound'] = 1
     node_addresses = [get_node_addr(node, 24567) for node in nodes]

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -385,7 +385,7 @@ class NeardRunner:
         config['rpc']['addr'] = f'0.0.0.0:{rpc_port}'
         config['network']['addr'] = f'0.0.0.0:{protocol_port}'
         self.data['neard_addr'] = config['rpc']['addr']
-        config['tracked_shards_config'] = 'AllShard'
+        config['tracked_shards'] = [0, 1, 2, 3]
         config['log_summary_style'] = 'plain'
         config['network']['skip_sync_wait'] = False
         if self.legacy_records:

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -385,7 +385,7 @@ class NeardRunner:
         config['rpc']['addr'] = f'0.0.0.0:{rpc_port}'
         config['network']['addr'] = f'0.0.0.0:{protocol_port}'
         self.data['neard_addr'] = config['rpc']['addr']
-        config['tracked_shards_config'] = 'AllShards'
+        config['tracked_shards_config'] = 'AllShard'
         config['log_summary_style'] = 'plain'
         config['network']['skip_sync_wait'] = False
         if self.legacy_records:

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -355,7 +355,7 @@ def _apply_stateless_config(args, node):
     # TODO: Enable saving witness after fixing the performance problems.
     do_update_config(node, 'save_latest_witnesses=false')
     if not node.want_state_dump:
-        do_update_config(node, 'tracked_shards_config="NoShards"')
+        do_update_config(node, 'tracked_shards=[]')
         do_update_config(node, 'store.load_mem_tries_for_tracked_shards=true')
     if not args.local_test:
         node.run_cmd(


### PR DESCRIPTION
The new shard tracking config is not known by 2.6 release. We will keep using the old config until the next release.
