### PR TITLE
store: prototype pseudo-lock-free cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy 0.7.31",
@@ -5175,6 +5176,7 @@ dependencies = [
  "near-vm-runner",
  "num_cpus",
  "parking_lot 0.12.1",
+ "quick_cache",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
@@ -6758,6 +6760,18 @@ checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quick_cache"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b450dad8382b1b95061d5ca1eb792081fb082adf48c678791fe917509596d5f"
+dependencies = [
+ "ahash 0.8.11",
+ "equivalent",
+ "hashbrown 0.15.2",
+ "parking_lot 0.12.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -352,6 +352,7 @@ proc-macro2 = "1.0.64"
 prometheus = { version = "0.13.1", default-features = false }
 protobuf = "3.0.1"
 protobuf-codegen = "3.0.1"
+quick_cache = "0.6.14"
 quote = "1.0"
 rand = "0.8.5"
 rand_chacha = "0.3.1"

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -21,21 +21,22 @@ crossbeam.workspace = true
 dashmap = { workspace = true, features = ["raw-api"] }
 derive_more = { workspace = true, features = ["as_ref", "into"] }
 derive-where.workspace = true
-smallvec.workspace = true
 enum-map.workspace = true
 hex.workspace = true
-itoa.workspace = true
 itertools.workspace = true
+itoa.workspace = true
 lru.workspace = true
 num_cpus.workspace = true
 parking_lot.workspace = true
+quick_cache.workspace = true
 rand.workspace = true
 rayon.workspace = true
 reed-solomon-erasure.workspace = true
 rlimit.workspace = true
 rocksdb.workspace = true
-serde.workspace = true
 serde_json.workspace = true
+serde.workspace = true
+smallvec.workspace = true
 static_assertions.workspace = true
 stdx.workspace = true
 strum.workspace = true

--- a/core/store/src/deserialized_column.rs
+++ b/core/store/src/deserialized_column.rs
@@ -1,12 +1,22 @@
 use crate::DBCol;
-use parking_lot::Mutex;
+use quick_cache::sync::Cache as QuickCache;
 use std::any::Any;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+pub(super) struct PutTicket<'a>(&'a ColumnCache);
+
+impl<'a> Drop for PutTicket<'a> {
+    fn drop(&mut self) {
+        self.0.state.fetch_sub(ColumnCache::ONE_PUT_TICKET, Ordering::Release);
+    }
+}
 
 pub(super) struct ColumnCache {
-    pub(super) values: lru::LruCache<Vec<u8>, Arc<dyn Any + Send + Sync>>,
-    /// A counter indicating the number of ongoing write transaction flushes.
+    pub(super) values: QuickCache<Vec<u8>, Arc<dyn Any + Send + Sync>>,
+    /// A bitmask used for synchronization of the flush operations in this cache.
     ///
     /// This cache and transactional write operation in the underlying database can be
     /// difficult to synchronize, so instead any time there is an in-progress write operation
@@ -25,28 +35,84 @@ pub(super) struct ColumnCache {
     /// 3. DB write transaction is applied;
     /// 4. From this point on cache still serves data it recalls from step 2.
     ///
-    /// See the state machine constants for more information on how this is implemented.
+    /// This is solved with this state field which is built out out of the following bits:
     ///
-    /// Instead, any time this counter is non-zero, the cache will stop saving values read out
-    /// of database into itself and return them directly to the caller. The write operation
-    /// itself will take care of discarding dirty data.
-    pub(super) active_flushes: u64,
+    /// * 32 bits to indicate the number of ongoing insertions;
+    /// * 32 high bits to indicate the number of ongoing flushes.
+    ///
+    /// During a get operation a value can only be inserted in the cache if all high 32 bits are
+    /// zero. This means that no write operation is currently occurring and there is no risk for
+    /// non-coherent access. If any of the bits are non-zero, the value is not placed in the cache
+    /// and returned to the caller immediately.
+    ///
+    /// During a database write some of the high 32 bits will be set. At the same time the code
+    /// will wait for the low 32-bits to clear to 0 to indicate it can now make progress with
+    /// the eviction.
+    pub(super) state: AtomicU64,
 }
 
 impl ColumnCache {
-    fn disabled() -> Option<Mutex<Self>> {
+    pub(super) const ONE_WRITE_TICKET: u64 = 1 << 32;
+    pub(super) const WRITE_TICKET_MASK: u64 = 0xFFFF_FFFF_0000_0000;
+    pub(super) const ONE_PUT_TICKET: u64 = 1;
+
+    pub(super) fn try_acquire_put_ticket(&self) -> Result<PutTicket, ()> {
+        let result = self.state.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            if (current & Self::WRITE_TICKET_MASK) == 0 {
+                Some(current + Self::ONE_PUT_TICKET)
+            } else {
+                None
+            }
+        });
+        match result {
+            Ok(_) => Ok(PutTicket(self)),
+            Err(_) => Err(()),
+        }
+    }
+
+    pub(super) fn acquire_write_ticket(&self) {
+        self.state.fetch_add(Self::ONE_WRITE_TICKET, Ordering::Relaxed);
+    }
+
+    pub(super) fn release_write_ticket(&self) {
+        self.state.fetch_sub(Self::ONE_WRITE_TICKET, Ordering::Release);
+    }
+
+    pub(super) fn wait_write_tickets_only(&self) {
+        // This is an optimistic guess as to what the value of the state might
+        // be if there is no contention whatsoever.
+        let mut current_state = Self::ONE_WRITE_TICKET;
+        loop {
+            // This compare exchange serves two purposes -- first, it makes sure there
+            // are no PUT tickets active by comparing against 0x????_????_0000_0000
+            // (loop continues on while there is any, waiting for the put ticket to
+            // be released.)
+            let new = current_state & Self::WRITE_TICKET_MASK;
+            let Err(new_current_state) = self.state.compare_exchange(
+                current_state,
+                new,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) else {
+                return;
+            };
+            current_state = new_current_state;
+        }
+    }
+
+    fn disabled() -> Option<Self> {
         Self::new(0)
     }
 
-    fn new(capacity: usize) -> Option<Mutex<Self>> {
-        let capacity = NonZeroUsize::new(capacity);
-        let values = capacity.map(|cap| lru::LruCache::new(cap))?;
-        Some(Mutex::new(Self { values, active_flushes: 0 }))
+    fn new(capacity: usize) -> Option<Self> {
+        let capacity = NonZeroUsize::new(capacity)?;
+        let values = QuickCache::new(capacity.get());
+        Some(Self { values, state: AtomicU64::new(0) })
     }
 }
 
 pub struct Cache {
-    column_map: enum_map::EnumMap<DBCol, Option<Mutex<ColumnCache>>>,
+    column_map: enum_map::EnumMap<DBCol, Option<ColumnCache>>,
 }
 
 impl Cache {
@@ -80,7 +146,7 @@ impl Cache {
         }))
     }
 
-    pub(super) fn work_with(&self, col: DBCol) -> Option<&Mutex<ColumnCache>> {
+    pub(super) fn work_with(&self, col: DBCol) -> Option<&ColumnCache> {
         self.column_map[col].as_ref()
     }
 }


### PR DESCRIPTION
This is a prototype of a pseudo-lock-free cache implementation for store. It was mostly done [by the time it was confirmed that locks do not contend here](https://near.zulipchat.com/#narrow/channel/497211-core.2Fperformance-optimization/topic/Improvement.20staging.20area/near/522789366), but since I had it mostly written out, I figured I'd submit it.

I say pseudo-lock-free, because during `write` there is a spin-loop waiting for all outstanding put tickets to be released. However the put operation itself is fairly quick and the write tickets are taken at the beginning of the overall write operation, so for the most part if there is ever any spinning, it should be extremely brief.

Based on top of #13633.