### PR TITLE
fix(forknet): fix tracked shard config compatibility

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -385,6 +385,8 @@ class NeardRunner:
         config['rpc']['addr'] = f'0.0.0.0:{rpc_port}'
         config['network']['addr'] = f'0.0.0.0:{protocol_port}'
         self.data['neard_addr'] = config['rpc']['addr']
+        if 'tracked_shards_config' in config:
+            del config['tracked_shards_config']
         config['tracked_shards'] = [0, 1, 2, 3]
         config['log_summary_style'] = 'plain'
         config['network']['skip_sync_wait'] = False


### PR DESCRIPTION
If the binary creates the new `tracked_shards_config`, wipe it. `mirror` only works with old `tracked_shard` config for compatibility with 2.6.3. 