### PR TITLE
fix(test) - fix and reenable slow_chunk

### DIFF
--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -185,10 +185,8 @@ pytest sanity/meta_tx.py --features nightly
 # pytest --timeout=120 sanity/resharding_error_handling.py --features nightly
 
 # Tests for slow chunks and extreme undercharging
-# TODO(#12847): this test is broken after an adjustment to the contracts on the workers.
-# This should be uncommented again after we find the issue and fix it.
-# pytest sanity/slow_chunk.py
-# pytest sanity/slow_chunk.py --features nightly
+pytest sanity/slow_chunk.py
+pytest sanity/slow_chunk.py --features nightly
 
 pytest sanity/large_witness.py --features nightly
 

--- a/pytest/tests/sanity/slow_chunk.py
+++ b/pytest/tests/sanity/slow_chunk.py
@@ -15,7 +15,7 @@ from configured_logger import logger
 from cluster import start_cluster
 from utils import load_test_contract, poll_blocks
 
-GGAS = 10**9
+TGAS = 10**12
 
 
 class SlowChunkTest(unittest.TestCase):
@@ -99,7 +99,7 @@ class SlowChunkTest(unittest.TestCase):
             node.signer_key.account_id,
             'sleep',
             duration_bytes,
-            150 * GGAS,
+            150 * TGAS,
             1,
             20,
             block_hash,


### PR DESCRIPTION
The test was previously failing due to not enough gas 😱 That was because there wasn't enough gas attached 🤯 Fixing it by attaching more gas 🎉 

https://nayduck.nearone.org/#/run/2171

I will close the linked issue when merged. 