### PR TITLE
Fix broken link to process_blocks.rs in testing documentation

### DIFF
--- a/docs/practices/testing/README.md
+++ b/docs/practices/testing/README.md
@@ -69,7 +69,7 @@ predefined timeout.
 
 For the most basic example of using this infrastructure see `produce_two_blocks`
 in
-[`tests/process_blocks.rs`](https://github.com/near/nearcore/blob/master/chain/client/src/tests/process_blocks.rs).
+[`tests/process_blocks.rs`](https://github.com/near/nearcore/blob/master/integration-tests/src/tests/client/process_blocks.rs).
 
 1. The callback (`Box::new(move |msg, _ctx, _| { ...`) is what is executed
    whenever the client sends a message. The return value of the callback is sent


### PR DESCRIPTION
Replaced the outdated link to process_blocks.rs in the testing practices documentation with the correct path: integration-tests/src/tests/client/process_blocks.rs. This ensures that readers are directed to the current location of the example test file.