### PR TITLE
[test] Move test_get_execution_outcome_tx_failure back to nayduck

### DIFF
--- a/integration-tests/src/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/src/tests/nearcore/rpc_nodes.rs
@@ -211,7 +211,7 @@ fn ultra_slow_test_get_execution_outcome_tx_success() {
 }
 
 #[test]
-fn slow_test_get_execution_outcome_tx_failure() {
+fn ultra_slow_test_get_execution_outcome_tx_failure() {
     test_get_execution_outcome(false);
 }
 
@@ -412,7 +412,7 @@ fn slow_test_tx_not_enough_balance_must_return_error() {
 }
 
 #[test]
-fn test_check_unknown_tx_must_return_error() {
+fn slow_test_check_unknown_tx_must_return_error() {
     init_integration_logger();
 
     let cluster = NodeCluster::default()

--- a/integration-tests/src/tests/nearcore/stake_nodes.rs
+++ b/integration-tests/src/tests/nearcore/stake_nodes.rs
@@ -469,7 +469,7 @@ fn ultra_slow_test_validator_join() {
 /// Checks that during the first epoch, total_supply matches total_supply in genesis.
 /// Checks that during the second epoch, total_supply matches the expected inflation rate.
 #[test]
-fn test_inflation() {
+fn slow_test_inflation() {
     heavy_test(|| {
         let num_nodes = 1;
         let dirs = (0..num_nodes)

--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -61,6 +61,8 @@ expensive integration-tests integration_tests tests::nearcore::sync_nodes::ultra
 
 expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_get_execution_outcome_tx_success
 expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_get_execution_outcome_tx_success --features nightly
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_get_execution_outcome_tx_failure
+expensive integration-tests integration_tests tests::nearcore::rpc_nodes::ultra_slow_test_get_execution_outcome_tx_failure --features nightly
 expensive integration-tests integration_tests tests::nearcore::run_nodes::ultra_slow_test_run_nodes_1_2_1
 expensive integration-tests integration_tests tests::nearcore::run_nodes::ultra_slow_test_run_nodes_1_2_1 --features nightly
 expensive integration-tests integration_tests tests::nearcore::run_nodes::ultra_slow_test_run_nodes_1_2_2


### PR DESCRIPTION
Based on flakiness seen [here](https://github.com/near/nearcore/actions/runs/15537333892/attempts/1?pr=13685), I'm moving `slow_test_get_execution_outcome_tx_failure` back to nayduck.

Also marking a couple of tests as slow.