### PR TITLE
[resharding] Fix check shard_uid_mapping

### DIFF
--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -18,7 +18,6 @@ use near_primitives::types::{
 use near_primitives::utils::{
     get_block_shard_id, get_block_shard_id_rev, get_outcome_id_block_hash, index_to_bytes,
 };
-use near_store::adapter::trie_store::get_shard_uid_mapping;
 use near_store::adapter::{StoreAdapter, StoreUpdateAdapter};
 use near_store::{DBCol, KeyForStateChanges, ShardTries, ShardUId};
 
@@ -1159,14 +1158,6 @@ fn gc_parent_shard_after_resharding(
         // Delete the state of the parent shard
         tracing::debug!(target: "garbage_collection", ?parent_shard_uid, "resharding state cleanup");
         trie_store_update.delete_shard_uid_prefixed_state(parent_shard_uid);
-
-        // Assert that the shard_uid mapping doesn't exist for any of the new shards in the new shard layout
-        for child_shard_uid in
-            shard_layout.get_children_shards_uids(parent_shard_uid.shard_id()).unwrap()
-        {
-            let mapped_shard_uid = get_shard_uid_mapping(&store, child_shard_uid);
-            assert_eq!(mapped_shard_uid, child_shard_uid, "Incomplete Resharding");
-        }
     }
     chain_store_update.merge(trie_store_update.into());
     Ok(())


### PR DESCRIPTION
With the new TrieStateResharder, we don't expect the shard_uid_mapping to exist after resharding is completed for all the newer resharding events.

However, it's possible for a node to still have the mapping from the previous resharding events.

With this PR, we are updating the code to remove this check. This was anyway not a strict requirement and it's fine to not have this check. It's creating more problems than it's solving.

We had a canary node failing. Context: [#nearone/private > mainnet node crash during garbage collection](https://near.zulipchat.com/#narrow/channel/308695-nearone.2Fprivate/topic/mainnet.20node.20crash.20during.20garbage.20collection/with/523037971)

Tested on canary node asrt-mainnet-canary-rpc-01-asia-east1-a-3fa54dd4