### PR TITLE
[resharding] Do not split state of untracked child shard

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -415,6 +415,8 @@ impl Chain {
         let resharding_manager = ReshardingManager::new(
             store.clone(),
             epoch_manager.clone(),
+            shard_tracker.clone(),
+            None, // No validator id for view client
             noop().into_multi_sender(),
         );
         let num_shards = runtime_adapter.get_shard_layout(PROTOCOL_VERSION).num_shards() as usize;
@@ -532,11 +534,12 @@ impl Chain {
         let tip = chain_store.head()?;
         let shard_layout = epoch_manager.get_shard_layout(&tip.epoch_id)?;
         let shard_uids = shard_layout.shard_uids().collect_vec();
+        let me = validator.get().map(|v| v.validator_id().clone());
         let tracked_shards: Vec<_> = shard_uids
             .iter()
             .filter(|shard_uid| {
                 shard_tracker.cares_about_shard(
-                    validator.get().map(|v| v.validator_id().clone()).as_ref(),
+                    me.as_ref(),
                     &tip.prev_block_hash,
                     shard_uid.shard_id(),
                     true,
@@ -570,8 +573,13 @@ impl Chain {
         // Even though the channel is unbounded, the channel size is practically bounded by the size
         // of blocks_in_processing, which is set to 5 now.
         let (sc, rc) = unbounded();
-        let resharding_manager =
-            ReshardingManager::new(chain_store.store(), epoch_manager.clone(), resharding_sender);
+        let resharding_manager = ReshardingManager::new(
+            chain_store.store(),
+            epoch_manager.clone(),
+            shard_tracker.clone(),
+            me,
+            resharding_sender,
+        );
 
         // The number of shards for the binary's latest `PROTOCOL_VERSION` is used as a thread limit. This assumes that:
         // a) The number of shards will not grow above this limit without the binary being updated (no dynamic resharding),

--- a/tools/database/src/memtrie.rs
+++ b/tools/database/src/memtrie.rs
@@ -6,6 +6,7 @@ use near_chain::resharding::manager::ReshardingManager;
 use near_chain::types::RuntimeAdapter;
 use near_chain::{ChainStore, ChainStoreAccess};
 use near_chain_configs::GenesisValidationMode;
+use near_epoch_manager::shard_tracker::ShardTracker;
 use near_epoch_manager::{EpochManager, EpochManagerAdapter};
 use near_o11y::default_subscriber;
 use near_o11y::env_filter::EnvFilterBuilder;
@@ -184,7 +185,13 @@ impl SplitShardTrieCommand {
 
         // Create resharding manager and prepare split params
         let sender = noop().into_multi_sender();
-        let resharding_manager = ReshardingManager::new(store, epoch_manager, sender);
+        let shard_tracker = ShardTracker::new(
+            near_config.client_config.tracked_shards_config.clone(),
+            epoch_manager.clone(),
+        );
+        let my_account_id = near_config.validator_signer.get().map(|v| v.validator_id().clone());
+        let resharding_manager =
+            ReshardingManager::new(store, epoch_manager, shard_tracker, my_account_id, sender);
         let chain_store_update = chain_store.store_update();
         let split_params = ReshardingSplitShardParams {
             parent_shard: self.shard_uid,


### PR DESCRIPTION
Related to the thread here: [#nearone/private > mainnet node crash during garbage collection @ 💬](https://near.zulipchat.com/#narrow/channel/308695-nearone.2Fprivate/topic/mainnet.20node.20crash.20during.20garbage.20collection/near/523304892)

High level, during resharding, in the TrieStateResharder, we were copying the state from parent shard_uid to the child shard_uid even for shards that the client was not tracking.

This had the unfortunate consequence that the memtrie was removed for these untracked shards and we were indirectly relying directly on the state column to iterate through state, which is super slow.

This PR fixes this issue where we are now only copying state in TrieStateResharder for tracked shards.

For testing, simply adding a debug assert in TrieStateResharder to check existence of memtrie was failing without the whole set of changes in this PR.

@staffik, we would need to cherry-pick this into the release as well.