### PR TITLE
Implement concurrent Flatstorage resharding catchup

### DIFF
--- a/chain/chain/src/resharding/flat_storage_resharder.rs
+++ b/chain/chain/src/resharding/flat_storage_resharder.rs
@@ -2,6 +2,7 @@
 //!
 //! See [FlatStorageResharder] for more details about how the resharding takes place.
 
+use std::collections::VecDeque;
 use std::fmt::{Debug, Formatter};
 use std::iter;
 use std::sync::Arc;
@@ -124,16 +125,12 @@ impl FlatStorageResharder {
             }
         }
 
-        for child_shard in [left_child_shard, right_child_shard] {
-            match self.shard_catchup_task_blocking(child_shard) {
-                // All good.
-                FlatStorageReshardingTaskResult::Successful { .. } => {}
-                // The task has been cancelled. Nothing else to do.
-                FlatStorageReshardingTaskResult::Cancelled => {}
-                FlatStorageReshardingTaskResult::Failed => {
-                    panic!("impossible to recover from a flat storage shard catchup failure!")
-                }
+        // Process both children in an interleaved manner
+        match self.shard_catchup_task_interleaved(&[left_child_shard, right_child_shard]) {
+            FlatStorageReshardingTaskResult::Failed => {
+                panic!("impossible to recover from a flat storage shard catchup failure!")
             }
+            _ => {}
         }
     }
 
@@ -173,7 +170,7 @@ impl FlatStorageResharder {
             }
             FlatStorageReshardingStatus::CatchingUp(_) => {
                 info!(target: "resharding", ?shard_uid, ?resharding_status, "resuming flat storage shard catchup");
-                match self.shard_catchup_task_blocking(shard_uid) {
+                match self.shard_catchup_task_interleaved(&[shard_uid]) {
                     // All good.
                     FlatStorageReshardingTaskResult::Successful { .. } => {}
                     FlatStorageReshardingTaskResult::Failed => {
@@ -503,40 +500,205 @@ impl FlatStorageResharder {
         Ok(iter)
     }
 
-    /// Task to perform catchup and creation of a flat storage shard spawned from a previous
-    /// resharding operation. May be a long operation time-wise. This task can't be cancelled
-    fn shard_catchup_task_blocking(&self, shard_uid: ShardUId) -> FlatStorageReshardingTaskResult {
-        // Exit early if the task has already been cancelled.
-        if self.handle.is_cancelled() {
-            return FlatStorageReshardingTaskResult::Cancelled;
+    /// Performs catchup for multiple shards in an interleaved manner.
+    ///
+    /// This function processes multiple shards simultaneously by rotating between them in a
+    /// round-robin fashion, allowing all shards to make progress concurrently. This is done
+    /// to avoid running into deadlocks with the state snapshot actor logic.
+    fn shard_catchup_task_interleaved(
+        &self,
+        shard_uids: &[ShardUId],
+    ) -> FlatStorageReshardingTaskResult {
+        if shard_uids.is_empty() {
+            return FlatStorageReshardingTaskResult::Successful { num_batches_done: 0 };
         }
-        info!(target: "resharding", ?shard_uid, "flat storage shard catchup task started");
-        let metrics = FlatStorageReshardingShardCatchUpMetrics::new(&shard_uid);
-        // Apply deltas and then create the flat storage.
-        let (num_batches_done, flat_head) = match self
-            .shard_catchup_apply_deltas_blocking(shard_uid, &metrics)
-        {
-            Ok(ShardCatchupApplyDeltasOutcome::Succeeded(num_batches_done, tip)) => {
-                (num_batches_done, tip)
-            }
-            Ok(ShardCatchupApplyDeltasOutcome::Cancelled) => {
+
+        info!(target: "resharding", ?shard_uids, "flat storage interleaved shard catchup task started");
+        // Delay between every batch.
+        let batch_delay = self.resharding_config.get().batch_delay.unsigned_abs();
+
+        // Create state trackers to track catchup progress of all shards.
+        let mut shard_states: Vec<ShardCatchupState> =
+            shard_uids.iter().map(|&shard_uid| ShardCatchupState::new(shard_uid)).collect();
+
+        // Create metrics for each shard
+        let metrics: Vec<FlatStorageReshardingShardCatchUpMetrics> = shard_uids
+            .iter()
+            .map(|&shard_uid| FlatStorageReshardingShardCatchUpMetrics::new(&shard_uid))
+            .collect();
+
+        // We want to process all shards in round-robin and for this we use a queue.
+        let mut shard_queue: VecDeque<usize> = (0..shard_states.len()).collect();
+        let mut total_batches = 0;
+
+        loop {
+            if self.handle.is_cancelled() {
                 return FlatStorageReshardingTaskResult::Cancelled;
             }
-            Err(err) => {
-                error!(target: "resharding", ?shard_uid, ?err, "flat storage shard catchup delta application failed!");
-                return FlatStorageReshardingTaskResult::Failed;
+
+            // If all shards are done the task is finished.
+            if shard_queue.is_empty() {
+                break;
             }
+
+            // Get the next shard to process.
+            let current_idx = shard_queue.pop_front().unwrap();
+
+            match self
+                .process_shard_catchup_batch(&mut shard_states[current_idx], &metrics[current_idx])
+            {
+                Ok(ShardCatchupBatchResult::BatchCompleted) => {
+                    total_batches += 1;
+                    // Re-add to back of queue for next round.
+                    shard_queue.push_back(current_idx);
+                }
+                Ok(ShardCatchupBatchResult::ShardCompleted) => {
+                    total_batches += 1;
+                    info!(target: "resharding", shard_uid = ?shard_states[current_idx].shard_uid, "shard catchup completed");
+                }
+                Err(err) => {
+                    error!(target: "resharding", shard_uid = ?shard_states[current_idx].shard_uid, ?err, "shard catchup batch failed");
+                    return FlatStorageReshardingTaskResult::Failed;
+                }
+            }
+
+            std::thread::sleep(batch_delay);
+        }
+
+        info!(target: "resharding", ?shard_uids, total_batches, "interleaved shard catchup completed");
+        FlatStorageReshardingTaskResult::Successful { num_batches_done: total_batches }
+    }
+
+    /// Process a single batch for a shard during interleaved catchup.
+    fn process_shard_catchup_batch(
+        &self,
+        state: &mut ShardCatchupState,
+        metrics: &FlatStorageReshardingShardCatchUpMetrics,
+    ) -> Result<ShardCatchupBatchResult, Error> {
+        match state.phase {
+            ShardCatchupPhase::ApplyingDeltas => {
+                if let Some(flat_head) = self.process_delta_batch(state, metrics)? {
+                    state.flat_head = Some(flat_head);
+                    state.phase = ShardCatchupPhase::Finalizing;
+                }
+                state.num_batches_done += 1;
+                Ok(ShardCatchupBatchResult::BatchCompleted)
+            }
+            ShardCatchupPhase::Finalizing => {
+                let flat_head = state.flat_head.as_ref().unwrap();
+                let chain_store = self.runtime.store().chain_store();
+                let header = chain_store.get_block_header(&flat_head.hash)?;
+                let tip = Tip::from_header(&header);
+                self.shard_catchup_finalize_storage(state.shard_uid, &tip, metrics)?;
+                state.phase = ShardCatchupPhase::Completed;
+                Ok(ShardCatchupBatchResult::ShardCompleted)
+            }
+            ShardCatchupPhase::Completed => Ok(ShardCatchupBatchResult::ShardCompleted),
+        }
+    }
+
+    /// Processes a single batch of flat storage deltas for a shard during interleaved catchup.
+    ///
+    /// This function processes up to `catch_up_blocks` worth of deltas in a single batch,
+    /// updating the shard's flat head and applying state changes to storage.
+    ///
+    /// Returns `Some(BlockInfo)` if all deltas have been processed (shard caught up to chain head),
+    /// or `None` if more deltas remain to be processed.
+    fn process_delta_batch(
+        &self,
+        state: &ShardCatchupState,
+        metrics: &FlatStorageReshardingShardCatchUpMetrics,
+    ) -> Result<Option<BlockInfo>, Error> {
+        let catch_up_blocks = self.resharding_config.get().catch_up_blocks;
+        let shard_uid = state.shard_uid;
+
+        info!(target: "resharding", ?shard_uid, ?catch_up_blocks, "flat storage shard catchup: delta application");
+
+        let status = self
+            .runtime
+            .store()
+            .flat_store()
+            .get_flat_storage_status(shard_uid)
+            .map_err(|e| Into::<StorageError>::into(e))?;
+
+        let FlatStorageStatus::Resharding(FlatStorageReshardingStatus::CatchingUp(mut flat_head)) =
+            status
+        else {
+            return Err(Error::Other(format!(
+                "unexpected resharding catchup flat storage status for {}: {:?}",
+                shard_uid, &status
+            )));
         };
-        match self.shard_catchup_finalize_storage(shard_uid, &flat_head, &metrics) {
-            Ok(_) => {
-                let task_status = FlatStorageReshardingTaskResult::Successful { num_batches_done };
-                info!(target: "resharding", ?shard_uid, ?task_status, "flat storage shard catchup task finished");
-                task_status
+
+        let chain_store = self.runtime.store().chain_store();
+        let chain_final_head = chain_store.final_head()?;
+
+        // If we reached the desired new flat head, we're done with deltas.
+        if is_flat_head_on_par_with_chain(&flat_head.hash, &chain_final_head) {
+            return Ok(Some(flat_head));
+        }
+
+        let mut merged_changes = FlatStateChanges::default();
+        let store = self.runtime.store().flat_store();
+        let mut store_update = store.store_update();
+
+        // Merge deltas from the next blocks until we reach the batch limit.
+        for _ in 0..catch_up_blocks {
+            let _span = tracing::debug_span!(
+                target: "resharding",
+                "shard_catchup_apply_deltas/batch",
+                ?shard_uid,
+                ?flat_head,
+                batch_id = ?state.num_batches_done)
+            .entered();
+
+            debug_assert!(
+                flat_head.height <= chain_final_head.height,
+                "flat head: {:?}",
+                &flat_head,
+            );
+
+            if is_flat_head_on_par_with_chain(&flat_head.hash, &chain_final_head) {
+                break;
             }
-            Err(err) => {
-                error!(target: "resharding", ?shard_uid, ?err, "flat storage shard catchup finalize failed!");
-                FlatStorageReshardingTaskResult::Failed
+            if self.coordinate_snapshot(flat_head.height) {
+                debug!(target: "resharding", ?shard_uid, "shard catchup on pause because of snapshot coordination");
+                break;
             }
+
+            let next_hash = chain_store.get_next_block_hash(&flat_head.hash)?;
+            let next_header = chain_store.get_block_header(&next_hash)?;
+            flat_head = BlockInfo {
+                hash: *next_header.hash(),
+                height: next_header.height(),
+                prev_hash: *next_header.prev_hash(),
+            };
+
+            if let Some(changes) = store
+                .get_delta(shard_uid, flat_head.hash)
+                .map_err(|err| Into::<StorageError>::into(err))?
+            {
+                merged_changes.merge(changes);
+                store_update.remove_delta(shard_uid, flat_head.hash);
+            }
+        }
+
+        // Commit all changes to store.
+        merged_changes.apply_to_flat_state(&mut store_update, shard_uid);
+        store_update.set_flat_storage_status(
+            shard_uid,
+            FlatStorageStatus::Resharding(FlatStorageReshardingStatus::CatchingUp(flat_head)),
+        );
+        store_update.commit()?;
+
+        // Update metrics with current head height progress.
+        metrics.set_head_height(flat_head.height);
+
+        // Check if we've reached the chain head after this batch.
+        if is_flat_head_on_par_with_chain(&flat_head.hash, &chain_final_head) {
+            Ok(Some(flat_head))
+        } else {
+            Ok(None)
         }
     }
 
@@ -549,115 +711,6 @@ impl FlatStorageResharder {
             return false;
         };
         height >= min_chunk_prev_height
-    }
-
-    /// Applies flat storage deltas in batches on a shard that is in catchup status.
-    ///
-    /// This function can either:
-    /// - Finish successfully, returning the number of delta batches applied and the final tip of the flat storage.
-    /// - Be cancelled
-    /// - Be postponed, to let other operations run on this intermediate state of flat storage (example state sync snapshot).
-    fn shard_catchup_apply_deltas_blocking(
-        &self,
-        shard_uid: ShardUId,
-        metrics: &FlatStorageReshardingShardCatchUpMetrics,
-    ) -> Result<ShardCatchupApplyDeltasOutcome, Error> {
-        // How many block heights of deltas are applied in a single commit.
-        let catch_up_blocks = self.resharding_config.get().catch_up_blocks;
-        // Delay between every batch.
-        let batch_delay = self.resharding_config.get().batch_delay.unsigned_abs();
-
-        info!(target: "resharding", ?shard_uid, ?batch_delay, ?catch_up_blocks, "flat storage shard catchup: starting delta apply");
-
-        let mut num_batches_done: usize = 0;
-
-        let status = self
-            .runtime
-            .store()
-            .flat_store()
-            .get_flat_storage_status(shard_uid)
-            .map_err(|e| Into::<StorageError>::into(e))?;
-        let FlatStorageStatus::Resharding(FlatStorageReshardingStatus::CatchingUp(mut flat_head)) =
-            status
-        else {
-            return Err(Error::Other(format!(
-                "unexpected resharding catchup flat storage status for {}: {:?}",
-                shard_uid, &status
-            )));
-        };
-
-        let chain_store = self.runtime.store().chain_store();
-        loop {
-            let _span = tracing::debug_span!(
-                target: "resharding",
-                "shard_catchup_apply_deltas/batch",
-                ?shard_uid,
-                ?flat_head,
-                batch_id = ?num_batches_done)
-            .entered();
-            let chain_final_head = chain_store.final_head()?;
-
-            // If we reached the desired new flat head, we can terminate the delta application step.
-            if is_flat_head_on_par_with_chain(&flat_head.hash, &chain_final_head) {
-                return Ok(ShardCatchupApplyDeltasOutcome::Succeeded(
-                    num_batches_done,
-                    Tip::from_header(&chain_store.get_block_header(&flat_head.hash)?),
-                ));
-            }
-
-            let mut merged_changes = FlatStateChanges::default();
-            let store = self.runtime.store().flat_store();
-            let mut store_update = store.store_update();
-
-            // Merge deltas from the next blocks until we reach chain final head.
-            for _ in 0..catch_up_blocks {
-                debug_assert!(
-                    flat_head.height <= chain_final_head.height,
-                    "flat head: {:?}",
-                    &flat_head,
-                );
-                // Stop if we reached the desired new flat head.
-                if is_flat_head_on_par_with_chain(&flat_head.hash, &chain_final_head) {
-                    break;
-                }
-                if self.coordinate_snapshot(flat_head.height) {
-                    break;
-                }
-                let next_hash = chain_store.get_next_block_hash(&flat_head.hash)?;
-                let next_header = chain_store.get_block_header(&next_hash)?;
-                flat_head = BlockInfo {
-                    hash: *next_header.hash(),
-                    height: next_header.height(),
-                    prev_hash: *next_header.prev_hash(),
-                };
-                if let Some(changes) = store
-                    .get_delta(shard_uid, flat_head.hash)
-                    .map_err(|err| Into::<StorageError>::into(err))?
-                {
-                    merged_changes.merge(changes);
-                    store_update.remove_delta(shard_uid, flat_head.hash);
-                }
-            }
-
-            // Commit all changes to store.
-            merged_changes.apply_to_flat_state(&mut store_update, shard_uid);
-            store_update.set_flat_storage_status(
-                shard_uid,
-                FlatStorageStatus::Resharding(FlatStorageReshardingStatus::CatchingUp(flat_head)),
-            );
-            store_update.commit()?;
-
-            num_batches_done += 1;
-            metrics.set_head_height(flat_head.height);
-
-            if self.handle.is_cancelled() {
-                return Ok(ShardCatchupApplyDeltasOutcome::Cancelled);
-            }
-
-            // Sleep between batches in order to throttle resharding and leave some resource for the
-            // regular node operation.
-            std::thread::sleep(batch_delay);
-        }
     }
 
     /// Creates a flat storage entry for a shard that completed catchup. Also clears leftover data.
@@ -877,11 +930,36 @@ enum FlatStorageReshardingTaskResult {
     Cancelled,
 }
 
-/// Outcome of the task that applies deltas during shard catchup.
-enum ShardCatchupApplyDeltasOutcome {
-    /// Contains the number of delta batches applied and the final tip of the flat storage.
-    Succeeded(usize, Tip),
-    Cancelled,
+/// State tracker for a single shard during interleaved catchup processing.
+struct ShardCatchupState {
+    shard_uid: ShardUId,
+    phase: ShardCatchupPhase,
+    flat_head: Option<BlockInfo>,
+    num_batches_done: usize,
+}
+
+impl ShardCatchupState {
+    fn new(shard_uid: ShardUId) -> Self {
+        Self {
+            shard_uid,
+            phase: ShardCatchupPhase::ApplyingDeltas,
+            flat_head: None,
+            num_batches_done: 0,
+        }
+    }
+}
+
+/// The current phase of shard catchup processing.
+enum ShardCatchupPhase {
+    ApplyingDeltas,
+    Finalizing,
+    Completed,
+}
+
+/// Result of processing a single batch for a shard.
+enum ShardCatchupBatchResult {
+    BatchCompleted,
+    ShardCompleted,
 }
 
 #[cfg(test)]
@@ -1135,7 +1213,7 @@ mod tests {
         flat_storage_resharder.handle.stop();
 
         // Execute task - should be cancelled
-        let task_result = flat_storage_resharder.shard_catchup_task_blocking(parent_shard);
+        let task_result = flat_storage_resharder.shard_catchup_task_interleaved(&[parent_shard]);
         assert_matches!(task_result, FlatStorageReshardingTaskResult::Cancelled);
 
         // Verify both left and right child shards are still in CatchingUp state to allow resume

--- a/chain/chain/src/state_snapshot_actor.rs
+++ b/chain/chain/src/state_snapshot_actor.rs
@@ -8,7 +8,7 @@ use near_primitives::block::Block;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::types::{BlockHeight, EpochHeight, ShardIndex};
-use near_store::flat::FlatStorageManager;
+use near_store::flat::{FlatStorageManager, FlatStorageReshardingStatus, FlatStorageStatus};
 use near_store::{ShardTries, StateSnapshotConfig};
 use std::sync::Arc;
 
@@ -92,6 +92,19 @@ impl StateSnapshotActor {
         };
         let Some(min_height) = min_height else {
             // storage split + catchup is in progress and not all shards have reached the catchup phase yet. Can't proceed
+            let not_ready_shards: Vec<ShardUId> = shard_indexes_and_uids
+                .iter()
+                .filter_map(|(_idx, shard_uid)| {
+                    match self.flat_storage_manager.get_flat_storage_status(*shard_uid) {
+                        FlatStorageStatus::Resharding(FlatStorageReshardingStatus::CatchingUp(
+                            _,
+                        )) => None,
+                        FlatStorageStatus::Resharding(_) => Some(*shard_uid),
+                        _ => None,
+                    }
+                })
+                .collect();
+            tracing::info!(target: "state_snapshot", ?not_ready_shards, "Waiting for resharding: shards not in catchup phase");
             return Ok(true);
         };
         // Proceed if the catchup code is already reasonably close to being finished. This is not a correctness issue,
@@ -99,7 +112,11 @@ impl StateSnapshotActor {
         // some reason lots of deltas to apply (e.g. the sync hash is 1000s of blocks past the start of the epoch because of missed
         // chunks), then we'll duplicate a lot of work that's being done by the resharding catchup code. So we might as well just
         // come back later after most of that work has already been done.
-        Ok(min_height + 10 < min_chunk_prev_height)
+        let should_wait = min_height + 10 < min_chunk_prev_height;
+        if should_wait {
+            tracing::debug!(target: "state_snapshot", min_height, min_chunk_prev_height, "Waiting for resharding catchup");
+        }
+        Ok(should_wait)
     }
 
     pub fn handle_create_snapshot_request(


### PR DESCRIPTION
This changes the FlatStorageResharder logic from:
- Catching up children 1
  - Apply all batches 
- Catching up children 2
  - Apply all batches

To:

- Catchup both childrens
  - Alternate batches from child 1 and 2


The reason for this change is to solve the following issue:
- Child 1 applies N block heights deltas as part of catchup
- Child 1 catchup is interrupted because state snapshot takes over
- State snapshot waits until all shards are < 10 heights away from chain
- Child 2 is > 10 heights away from chain, waiting to start catchup as soon as child 1 finishes
- Child 1 can never finish because state snapshot is waiting on child 2 to catchup..