### PR TITLE
doc: fix "Deploy a contract" documentation

### DIFF
--- a/docs/practices/workflows/deploy_a_contract.md
+++ b/docs/practices/workflows/deploy_a_contract.md
@@ -176,7 +176,7 @@ declare the `hello` export:
 
 #![no_std]
 
-extern "C" {
+unsafe extern "C" {
     fn value_return(len: u64, ptr: u64);
 }
 


### PR DESCRIPTION
- remove misplaced `$` in `near` invocation examples
- mark `extern "C"` as `unsafe`, which seems to be required in `cargo 1.87.0 (99624be96 2025-05-06)`:
```
error: extern blocks must be unsafe
 --> src/lib.rs:3:1
  |
3 | / extern "C" {
4 | |     fn value_return(len: u64, ptr: u64);
5 | | }
  | |_^

error: could not compile `hello-near` (lib) due to 1 previous error
```