### PR TITLE
doc: clarify near-cli version

### DIFF
--- a/docs/practices/workflows/run_a_node.md
+++ b/docs/practices/workflows/run_a_node.md
@@ -368,7 +368,7 @@ So we will use the official [NEAR CLI] utility.
 Install it via `npm`:
 
 ```console
-$ npm install -g near-cli
+$ npm install -g near-cli@3.4.2
 $ near -h
 Usage: near <command> [options]
 
@@ -470,7 +470,7 @@ binary we've built from source. The steps are:
 - Create configs with `cargo run --profile dev-release -p neard -- init`
 - Run the node with `cargo run --profile dev-release -p neard -- run`
 - Poke the node with `httpie` or
-- Install `near-cli` via `npm install -g near-cli`
+- Install `near-cli` via `npm install -g near-cli@3.4.2`
 - Submit transactions via `NEAR_ENV=local near create-account ...`
 
 In the [next chapter](./deploy_a_contract.md), we'll learn how to deploy a simple


### PR DESCRIPTION
The latest version of `near` install via `npm` as directed by the docs I get

```console
❯ near --version
4.0.13

❯ NEAR_ENV=local near state test.near
near state <accountId>

View account's state (balance, storage_usage, code_hash, etc...)

Options:
      --help       Show help  [boolean]
      --version    Show version number  [boolean]
  -v, --verbose    Prints out verbose output  [boolean] [default: false]
      --networkId  Which network to use. Supports: mainnet, testnet, custom  [string] [default: "local"]

Error: Unconfigured environment 'local'. Can be configured in src/config.js.
    at getConfig (/opt/homebrew/lib/node_modules/near-cli/config.js:40:15)
    at connect (/opt/homebrew/lib/node_modules/near-cli/utils/connect.js:17:20)
    at Object.viewAccount [as handler] (/opt/homebrew/lib/node_modules/near-cli/commands/account/state.js:19:22)
    at /opt/homebrew/lib/node_modules/near-cli/node_modules/yargs/build/index.cjs:1:8993
    at /opt/homebrew/lib/node_modules/near-cli/node_modules/yargs/build/index.cjs:1:4949
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)

```

Downgrading to `near-cli@3.4.2` fixes this issue:

```console
❯ npm install -g near-cli@3.4.2
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated @ledgerhq/hw-transport-u2f@5.36.0-deprecated: @ledgerhq/hw-transport-u2f is deprecated. Please use @ledgerhq/hw-transport-webusb or @ledgerhq/hw-transport-webhid. https://github.com/LedgerHQ/ledgerjs/blob/master/docs/migrate_webusb.md

added 90 packages, removed 35 packages, and changed 206 packages in 9s

37 packages are looking for funding
  run `npm fund` for details

❯ NEAR_ENV=local near state test.near
Loaded master account test.near key from /Users/miguel/.near/validator_key.json with public key = ed25519:5ZSvgM1ZaVrVnCxVkZ725daDmPhPwNnZfeRxaQHhxvjb
Account test.near
{
  amount: '1000000000000000000000000000000000',
  block_hash: 'CJiHVahamiMGLNaLmgorei2pvEyoWq53SUu4d2db5b5q',
  block_height: 4671,
  code_hash: '11111111111111111111111111111111',
  locked: '50007994293589029701412460539056',
  storage_paid_at: 0,
  storage_usage: 182,
  formattedAmount: '1,000,000,000'
}
```