### PR TITLE
perf: deserialized cache for `DBCol::PartialChunks`

### DIFF
--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -228,7 +228,7 @@ impl ChainStoreAdapter {
         &self,
         chunk_hash: &ChunkHash,
     ) -> Result<Arc<PartialEncodedChunk>, Error> {
-        match self.store.get_ser(DBCol::PartialChunks, chunk_hash.as_ref()) {
+        match self.store.caching_get_ser(DBCol::PartialChunks, chunk_hash.as_ref()) {
             Ok(Some(shard_chunk)) => Ok(shard_chunk),
             _ => Err(Error::ChunkMissing(chunk_hash.clone())),
         }

--- a/core/store/src/adapter/chunk_store.rs
+++ b/core/store/src/adapter/chunk_store.rs
@@ -28,7 +28,7 @@ impl ChunkStoreAdapter {
         chunk_hash: &ChunkHash,
     ) -> Result<Arc<PartialEncodedChunk>, ChunkAccessError> {
         self.store
-            .get_ser(DBCol::PartialChunks, chunk_hash.as_ref())
+            .caching_get_ser(DBCol::PartialChunks, chunk_hash.as_ref())
             .expect("Borsh should not have failed here")
             .ok_or_else(|| ChunkAccessError::ChunkMissing(chunk_hash.clone()))
     }

--- a/core/store/src/deserialized_column.rs
+++ b/core/store/src/deserialized_column.rs
@@ -63,6 +63,7 @@ impl Cache {
                 // the transaction isn't going to be very old most of the time.
                 | DBCol::Block => ColumnCache::new(32),
                 | DBCol::ChunkExtra => ColumnCache::new(1024),
+                | DBCol::PartialChunks => ColumnCache::new(512),
                 _ => ColumnCache::disabled(),
             },
         }


### PR DESCRIPTION
Deserializing this type seems pretty expensive and partial chunks get queried repeatedly during critical path. The number of values cached is roughly arbitrary. There is probably just $SHARDS chunks that will be queried at any given time, but I didn't want to bring through configuration variables through to the cache so I went with a number that exceeds any shard count we might consider longer term?