### PR TITLE
perf: deserialized cache for `ShardChunk`?

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3550,7 +3550,7 @@ impl Chain {
         self.chain_store.get_block(&tip.last_block_hash)
     }
 
-    pub fn get_chunk(&self, chunk_hash: &ChunkHash) -> Result<ShardChunk, Error> {
+    pub fn get_chunk(&self, chunk_hash: &ChunkHash) -> Result<Arc<ShardChunk>, Error> {
         self.chain_store.get_chunk(chunk_hash)
     }
 

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -1073,7 +1073,11 @@ impl<'a> ChainStoreUpdate<'a> {
         if let Some(arced_chunk) = self.chain_store_cache_update.chunks.get(chunk_hash) {
             Ok(Arc::clone(arced_chunk))
         } else {
-            self.chain_store.get_chunk(chunk_hash).map(ArcedShardChunk::from).map(Arc::new)
+            self.chain_store
+                .get_chunk(chunk_hash)
+                .map(|v| ShardChunk::clone(&v))
+                .map(ArcedShardChunk::from)
+                .map(Arc::new)
         }
     }
 }

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -402,7 +402,7 @@ pub(crate) fn block_chunks_exist(
                 );
                 if cares_about_shard || will_care_about_shard {
                     unwrap_or_err_db!(
-                        sv.store.get_ser::<ShardChunk>(
+                        sv.store.caching_get_ser::<ShardChunk>(
                             DBCol::Chunks,
                             chunk_header.chunk_hash().as_ref()
                         ),
@@ -633,7 +633,7 @@ pub(crate) fn trie_changes_chunk_extra_exists(
         let chunk_hash = chunk_header.chunk_hash();
         // 6. ShardChunk with `chunk_hash` should be available
         unwrap_or_err_db!(
-            sv.store.get_ser::<ShardChunk>(DBCol::Chunks, chunk_hash.as_ref()),
+            sv.store.caching_get_ser::<ShardChunk>(DBCol::Chunks, chunk_hash.as_ref()),
             "Can't get Chunk from storage with ChunkHash {:?}",
             chunk_hash
         );
@@ -661,7 +661,7 @@ pub(crate) fn chunk_of_height_exists(
 ) -> Result<(), StoreValidatorError> {
     for chunk_hash in chunk_hashes {
         let shard_chunk = unwrap_or_err_db!(
-            sv.store.get_ser::<ShardChunk>(DBCol::Chunks, chunk_hash.as_ref()),
+            sv.store.caching_get_ser::<ShardChunk>(DBCol::Chunks, chunk_hash.as_ref()),
             "Can't get Chunk from storage with ChunkHash {:?}",
             chunk_hash
         );

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -216,8 +216,8 @@ impl ChainStoreAdapter {
     }
 
     /// Get full chunk.
-    pub fn get_chunk(&self, chunk_hash: &ChunkHash) -> Result<ShardChunk, Error> {
-        match self.store.get_ser(DBCol::Chunks, chunk_hash.as_ref()) {
+    pub fn get_chunk(&self, chunk_hash: &ChunkHash) -> Result<Arc<ShardChunk>, Error> {
+        match self.store.caching_get_ser(DBCol::Chunks, chunk_hash.as_ref()) {
             Ok(Some(shard_chunk)) => Ok(shard_chunk),
             _ => Err(Error::ChunkMissing(chunk_hash.clone())),
         }

--- a/core/store/src/adapter/chunk_store.rs
+++ b/core/store/src/adapter/chunk_store.rs
@@ -33,9 +33,9 @@ impl ChunkStoreAdapter {
             .ok_or_else(|| ChunkAccessError::ChunkMissing(chunk_hash.clone()))
     }
 
-    pub fn get_chunk(&self, chunk_hash: &ChunkHash) -> Result<ShardChunk, ChunkAccessError> {
+    pub fn get_chunk(&self, chunk_hash: &ChunkHash) -> Result<Arc<ShardChunk>, ChunkAccessError> {
         self.store
-            .get_ser(DBCol::Chunks, chunk_hash.as_ref())
+            .caching_get_ser(DBCol::Chunks, chunk_hash.as_ref())
             .expect("Borsh should not have failed here")
             .ok_or_else(|| ChunkAccessError::ChunkMissing(chunk_hash.clone()))
     }

--- a/core/store/src/deserialized_column.rs
+++ b/core/store/src/deserialized_column.rs
@@ -62,6 +62,7 @@ impl Cache {
                 // The cache isn't particularly large – it is expected that the block referenced in
                 // the transaction isn't going to be very old most of the time.
                 | DBCol::Block => ColumnCache::new(32),
+                | DBCol::Chunks => ColumnCache::new(512),
                 | DBCol::ChunkExtra => ColumnCache::new(1024),
                 _ => ColumnCache::disabled(),
             },

--- a/integration-tests/src/tests/features/congestion_control.rs
+++ b/integration-tests/src/tests/features/congestion_control.rs
@@ -173,7 +173,7 @@ fn head_chunk_header(env: &TestEnv, shard_id: ShardId) -> ShardChunkHeader {
     chunks.get(shard_index).expect("chunk header must be available").clone()
 }
 
-fn head_chunk(env: &TestEnv, shard_id: ShardId) -> ShardChunk {
+fn head_chunk(env: &TestEnv, shard_id: ShardId) -> Arc<ShardChunk> {
     let chunk_header = head_chunk_header(&env, shard_id);
     env.clients[0].chain.get_chunk(&chunk_header.chunk_hash()).expect("chunk must be available")
 }

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -875,7 +875,7 @@ pub(crate) fn view_genesis(
 fn read_genesis_from_store(
     chain_store: &ChainStore,
     genesis_height: u64,
-) -> Result<(Arc<Block>, Vec<ShardChunk>), Error> {
+) -> Result<(Arc<Block>, Vec<Arc<ShardChunk>>), Error> {
     let genesis_hash = chain_store.get_block_hash_by_height(genesis_height)?;
     let genesis_block = chain_store.get_block(&genesis_hash)?;
     let mut genesis_chunks = vec![];


### PR DESCRIPTION
I'm still not entirely sure on this one. It is indeed the next most expensive column after `PartialChunks` (addressed in https://github.com/near/nearcore/pull/13727) but at the same time most of the cost comes from `get_chunk_clone_from_header` which clones the whole `ShardChunk` anyway in order to mutate it. And then there's this weird `ArcedShardChunk` too.

What's nice is that these `ShardChunk`s get accessed relatively rarely which makes them largely a non-factor in the absolute terms of time use. So I have my reservations on whether this cache will help much.