### PR TITLE
feat: enable Wasmtime parallel compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9254,6 +9254,7 @@ dependencies = [
  "postcard",
  "psm",
  "pulley-interpreter",
+ "rayon",
  "rustix 0.38.44",
  "serde",
  "serde_derive",

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -41,7 +41,7 @@ thiserror.workspace = true
 tracing.workspace = true
 wasm-encoder = { workspace = true, optional = true }
 wasmparser = { workspace = true, optional = true }
-wasmtime = { workspace = true, features = ["runtime"], optional = true }
+wasmtime = { workspace = true, features = ["parallel-compilation", "runtime"], optional = true }
 
 near-crypto.workspace = true
 near-o11y = { workspace = true, optional = true }


### PR DESCRIPTION
This feature flag, [which is enabled by default in Wasmtime](https://github.com/bytecodealliance/wasmtime/blob/ef7a29619789b2a43fd04a0aff81438696e5c8be/Cargo.toml#L443), turns on parallel compilation using [rayon](https://docs.rs/rayon/latest/rayon/)

Running a synthetic benchmark from https://github.com/cosmonic-labs/nearcore/commit/e9b038b9a68e87b61056337fc758e5891a96a81f on GCP `n2d-standard-8`.

Before:

```
test wasmtime_ft_transfer  ... bench: 301,324,308 ns/iter (+/- 5,026,087)
```

After:

```
test wasmtime_ft_transfer  ... bench: 133,858,110 ns/iter (+/- 7,693,557)
```

This seems to be a pretty-straightfoward change, but I am happy to run more comprehensive/time-consuming set of benchmarks to support it if desired
