### PR TITLE
fix - Trie resharding resume when children memtries don't exist anymore

### DIFF
--- a/chain/chain/src/resharding/flat_storage_resharder.rs
+++ b/chain/chain/src/resharding/flat_storage_resharder.rs
@@ -1393,8 +1393,12 @@ mod tests {
         // Do the resharding.
         flat_storage_resharder.start_resharding_blocking_impl(parent_shard, split_params.clone());
 
-        // Verify parent shard is gone
-        assert_matches!(store.get_flat_storage_status(parent_shard), Ok(FlatStorageStatus::Empty));
+        // Verify parent shard is still in resharding state (not deleted yet).
+        // Parent flat storage cleanup happens in trie_state_resharder, not here.
+        assert_matches!(
+            store.get_flat_storage_status(parent_shard),
+            Ok(FlatStorageStatus::Resharding(_))
+        );
 
         // Both children shards should be in Ready state
         for child_shard in [split_params.left_child_shard, split_params.right_child_shard] {

--- a/chain/chain/src/resharding/flat_storage_resharder.rs
+++ b/chain/chain/src/resharding/flat_storage_resharder.rs
@@ -162,13 +162,31 @@ impl FlatStorageResharder {
             }
             FlatStorageReshardingStatus::SplittingParent(status) => {
                 let parent_shard_uid = shard_uid;
-                info!(target: "resharding", ?parent_shard_uid, ?status, "resuming flat storage shard split");
-                // On resume, flat storage status is already set correctly and read from DB.
-                // Thus, we don't need to care about cancelling other existing resharding events.
-                // However, we don't know the current state of children shards,
-                // so it's better to clean them.
-                self.clean_children_shards(&status)?;
-                self.start_resharding_blocking_impl(parent_shard_uid, status);
+
+                // Check if children's flat storages are already in Ready status to skip flat storage resharding
+                // and go directly to Trie resharding.
+                let all_children_done = [status.left_child_shard, status.right_child_shard]
+                    .iter()
+                    .all(|&child_shard| {
+                        matches!(
+                            self.runtime
+                                .get_flat_storage_manager()
+                                .get_flat_storage_status(child_shard),
+                            FlatStorageStatus::Ready(_)
+                        )
+                    });
+
+                if all_children_done {
+                    info!(target: "resharding", ?parent_shard_uid, ?status, "all children shards are ready, skipping resharding");
+                    return Ok(());
+                } else {
+                    info!(target: "resharding", ?parent_shard_uid, ?status, "resuming flat storage shard split");
+                    // On resume, flat storage status is already set correctly and read from DB.
+                    // Thus, we don't need to care about cancelling other existing resharding events.
+                    // Children are not both ready, so we need to clean them and restart resharding.
+                    self.clean_children_shards(&status)?;
+                    self.start_resharding_blocking_impl(parent_shard_uid, status);
+                }
             }
             FlatStorageReshardingStatus::CatchingUp(_) => {
                 info!(target: "resharding", ?shard_uid, ?resharding_status, "resuming flat storage shard catchup");

--- a/chain/chain/src/resharding/trie_state_resharder.rs
+++ b/chain/chain/src/resharding/trie_state_resharder.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::{AccountId, BlockHeight};
-use near_store::adapter::trie_store::TrieStoreUpdateAdapter;
+use near_store::adapter::trie_store::{TrieStoreUpdateAdapter, get_shard_uid_mapping};
 use near_store::adapter::{StoreAdapter, StoreUpdateAdapter};
 use near_store::db::TRIE_STATE_RESHARDING_STATUS_KEY;
 use near_store::metrics::resharding::trie_state_metrics;
@@ -63,16 +63,16 @@ struct TrieStateReshardingStatus {
 impl TrieStateReshardingStatus {
     fn new(
         parent_shard_uid: ShardUId,
-        left: TrieStateReshardingChildStatus,
-        right: TrieStateReshardingChildStatus,
+        left: Option<TrieStateReshardingChildStatus>,
+        right: Option<TrieStateReshardingChildStatus>,
         boundary_account: AccountId,
         resharding_block_height: BlockHeight,
         parent_state_root: CryptoHash,
     ) -> Self {
         Self {
             parent_shard_uid,
-            left: Some(left),
-            right: Some(right),
+            left,
+            right,
             boundary_account,
             resharding_block_height,
             parent_state_root,
@@ -251,10 +251,25 @@ impl TrieStateResharder {
             "TrieStateResharding: child and parent state roots"
         );
 
+        // If the child shard_uid mapping doesn't exist, it means we are not tracking the child shard.
+        let store = self.runtime.store();
+        let left_child =
+            if get_shard_uid_mapping(store, event.left_child_shard) != event.left_child_shard {
+                Some(TrieStateReshardingChildStatus::new(event.left_child_shard, left_state_root))
+            } else {
+                None
+            };
+        let right_child =
+            if get_shard_uid_mapping(store, event.right_child_shard) != event.right_child_shard {
+                Some(TrieStateReshardingChildStatus::new(event.right_child_shard, right_state_root))
+            } else {
+                None
+            };
+
         let mut status = TrieStateReshardingStatus::new(
             event.parent_shard,
-            TrieStateReshardingChildStatus::new(event.left_child_shard, left_state_root),
-            TrieStateReshardingChildStatus::new(event.right_child_shard, right_state_root),
+            left_child,
+            right_child,
             event.boundary_account.clone(),
             event.resharding_block.height,
             parent_state_root,
@@ -481,8 +496,8 @@ mod tests {
         fn as_status(&self) -> TrieStateReshardingStatus {
             TrieStateReshardingStatus::new(
                 self.parent_shard,
-                TrieStateReshardingChildStatus::new(self.left_shard, self.left_root),
-                TrieStateReshardingChildStatus::new(self.right_shard, self.right_root),
+                Some(TrieStateReshardingChildStatus::new(self.left_shard, self.left_root)),
+                Some(TrieStateReshardingChildStatus::new(self.right_shard, self.right_root)),
                 self.boundary_account.clone(),
                 self.resharding_block_height,
                 self.parent_root,

--- a/chain/chain/src/resharding/trie_state_resharder.rs
+++ b/chain/chain/src/resharding/trie_state_resharder.rs
@@ -288,7 +288,7 @@ impl TrieStateResharder {
     fn ensure_child_memtries_exist(&self, status: &TrieStateReshardingStatus) -> Result<(), Error> {
         let tries = self.runtime.get_tries();
 
-        let missing_children = [
+        let children_missing_memtrie = [
             status.left.as_ref().map(|child| (child.shard_uid, RetainMode::Left)),
             status.right.as_ref().map(|child| (child.shard_uid, RetainMode::Right)),
         ]
@@ -297,8 +297,8 @@ impl TrieStateResharder {
         .filter(|(shard_uid, _)| tries.get_memtries(*shard_uid).is_none())
         .collect_vec();
 
-        if !missing_children.is_empty() {
-            self.recreate_child_memtries(status, missing_children)?;
+        if !children_missing_memtrie.is_empty() {
+            self.recreate_child_memtries(status, children_missing_memtrie)?;
         }
 
         Ok(())
@@ -491,6 +491,16 @@ mod tests {
         }
     }
 
+    /// Sets up a test environment for trie state resharding.
+    ///
+    /// # Parameters
+    ///
+    /// * `create_memtries`:
+    ///   - `true`: Creates and keeps all memtries (parent + children) in memory.
+    ///     This simulates the normal case where memtries are available during resharding.
+    ///   - `false`: Skips creation of children memtries, unloads the parent memtrie and
+    ///     sets up flat storage instead. This simulates resharding interruption and recovery
+    ///     where memtries need to be loaded from flat storage during resume().
     fn setup_test(create_memtries: bool) -> TestSetup {
         let shard_layout = ShardLayout::single_shard();
         let genesis = Genesis::from_accounts(

--- a/chain/chain/src/resharding/trie_state_resharder.rs
+++ b/chain/chain/src/resharding/trie_state_resharder.rs
@@ -322,13 +322,11 @@ impl TrieStateResharder {
                 parent_state_root = ?status.parent_state_root,
                 "Parent memtrie not loaded, loading it now"
             );
-            tries.load_memtrie(&parent_shard_uid, Some(status.parent_state_root), false).map_err(
-                |e| {
-                    Error::Other(format!(
-                        "Failed to load parent memtrie for shard {parent_shard_uid}: {e}"
-                    ))
-                },
-            )?;
+            tries.load_memtrie(&parent_shard_uid, None, true).map_err(|e| {
+                Error::Other(format!(
+                    "Failed to load parent memtrie for shard {parent_shard_uid}: {e}"
+                ))
+            })?;
         }
 
         let parent_trie = tries.get_trie_for_shard(parent_shard_uid, status.parent_state_root);
@@ -447,7 +445,7 @@ mod tests {
     use near_async::time::Clock;
     use near_chain_configs::Genesis;
     use near_epoch_manager::EpochManager;
-    use near_primitives::shard_layout::ShardLayout;
+    use near_primitives::shard_layout::{ShardLayout, get_block_shard_uid};
     use near_primitives::trie_key::TrieKey;
     use near_store::Trie;
     use near_store::test_utils::{
@@ -459,7 +457,10 @@ mod tests {
     use crate::types::ChainConfig;
 
     use super::*;
+    use near_primitives::bandwidth_scheduler::BandwidthRequests;
+    use near_primitives::congestion_info::CongestionInfo;
     use near_primitives::state::FlatStateValue;
+    use near_primitives::types::chunk_extra::ChunkExtra;
     use near_store::flat::{FlatStorageReadyStatus, FlatStorageStatus};
 
     type KeyValues = Vec<(Vec<u8>, Option<Vec<u8>>)>;
@@ -603,6 +604,24 @@ mod tests {
                 }),
             );
             store_update.commit().unwrap();
+
+            // Fourth, create ChunkExtra for the flat storage head so load_memtrie can find the state root.
+            let mut chain_store_update = runtime.store().store_update();
+            let chunk_extra = ChunkExtra::new(
+                &parent_root,
+                CryptoHash::default(),
+                Vec::new(),
+                0,
+                0,
+                0,
+                Some(CongestionInfo::default()),
+                BandwidthRequests::empty(),
+            );
+            let block_shard_uid = get_block_shard_uid(&parent_root, &parent_shard);
+            chain_store_update
+                .set_ser(near_store::DBCol::ChunkExtra, &block_shard_uid, &chunk_extra)
+                .unwrap();
+            chain_store_update.commit().unwrap();
 
             // Now unload the parent memtrie, so the test can verify
             // it will get loaded correctly during resume.

--- a/chain/chain/src/resharding/trie_state_resharder.rs
+++ b/chain/chain/src/resharding/trie_state_resharder.rs
@@ -331,9 +331,7 @@ impl TrieStateResharder {
             )?;
         }
 
-        let parent_trie = tries
-            .get_trie_for_shard(parent_shard_uid, status.parent_state_root)
-            .recording_reads_new_recorder();
+        let parent_trie = tries.get_trie_for_shard(parent_shard_uid, status.parent_state_root);
 
         if !parent_trie.has_memtries() {
             return Err(Error::Other(format!(


### PR DESCRIPTION
This PR is an attempt to fix the following issue:

- Node crashes during TrieResharding
- FlatStorage(FS) resharding completed, so the parent shard FS doesn't exist anymore, and the children FS have caught up to some undefined block height in the next epoch
- Resuming TrieResharding doesn't work because it needs to build memtries from the children FS at resharding hash! ⚠️ 


This solution's strategy is:
- Post-pone deletion of parent shard FS to when TrieResharding is completed
- Enhancing `TrieStateReshardingStatus` (😢 ) with more data needed to recreate memtries on the fly
- In `resume` we make sure the memtries for children exist, forcibly recreating them if necessary
- Add a test that we are able to resume Trie resharding whether or not children memtries exist