### PR TITLE
feat(tracing): witness distribution spans

### DIFF
--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -528,7 +528,8 @@ pub fn validate_chunk_state_witness_impl(
         "validate_chunk_state_witness",
         height = height_created,
         shard_id = %witness_chunk_shard_id,
-        tag_block_production = true
+        tag_block_production = true,
+        tag_witness_distribution = true,
     )
     .entered();
     let witness_shard_layout = epoch_manager.get_shard_layout(&epoch_id)?;

--- a/chain/chain/src/stateless_validation/state_witness.rs
+++ b/chain/chain/src/stateless_validation/state_witness.rs
@@ -51,6 +51,16 @@ impl ChainStore {
         chunk: &ShardChunk,
     ) -> Result<CreateWitnessResult, Error> {
         let chunk_header = chunk.cloned_header();
+        let _span = tracing::debug_span!(
+            target: "client",
+            "create_state_witness",
+            chunk_hash = ?chunk_header.chunk_hash(),
+            height = chunk_header.height_created(),
+            shard_id = %chunk_header.shard_id(),
+            tag_witness_distribution = true,
+        )
+        .entered();
+
         let epoch_id =
             epoch_manager.get_epoch_id_from_prev_block(chunk_header.prev_block_hash())?;
         let prev_chunk = self.get_chunk(&prev_chunk_header.chunk_hash())?;

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -283,12 +283,15 @@ impl Client {
         processing_done_tracker: Option<ProcessingDoneTracker>,
         signer: Option<Arc<ValidatorSigner>>,
     ) -> Result<(), Error> {
-        tracing::debug!(
+        let _span = tracing::debug_span!(
             target: "client",
-            chunk_hash=?witness.chunk_header().chunk_hash(),
-            shard_id=%witness.chunk_header().shard_id(),
             "process_chunk_state_witness",
-        );
+            chunk_hash = ?witness.chunk_header().chunk_hash(),
+            height = %witness.chunk_header().height_created(),
+            shard_id = %witness.chunk_header().shard_id(),
+            tag_witness_distribution = true,
+        )
+        .entered();
 
         // Chunk producers should not receive state witness from themselves.
         log_assert!(

--- a/chain/client/src/stateless_validation/partial_witness/partial_deploys_tracker.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_deploys_tracker.rs
@@ -46,7 +46,7 @@ impl CacheEntry {
             );
             return None;
         }
-        match self.parts.insert_part(part_ord, part.data) {
+        match self.parts.insert_part(part_ord, part.data, None) {
             InsertPartResult::Accepted => None,
             InsertPartResult::PartAlreadyAvailable => {
                 tracing::warn!(

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
@@ -270,7 +270,7 @@ impl PartialWitnessActor {
             chunk_hash = ?chunk_header.chunk_hash(),
             height = %chunk_header.height_created(),
             shard_id = %chunk_header.shard_id(),
-            ?chunk_validators,
+            chunk_validators_len = chunk_validators.len(),
             tag_witness_distribution = true,
         )
         .entered();

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_actor.rs
@@ -264,12 +264,16 @@ impl PartialWitnessActor {
         chunk_validators: &[AccountId],
         signer: &ValidatorSigner,
     ) -> Vec<(AccountId, PartialEncodedStateWitness)> {
-        tracing::debug!(
+        let _span = tracing::debug_span!(
             target: "client",
-            chunk_hash=?chunk_header.chunk_hash(),
-            ?chunk_validators,
             "generate_state_witness_parts",
-        );
+            chunk_hash = ?chunk_header.chunk_hash(),
+            height = %chunk_header.height_created(),
+            shard_id = %chunk_header.shard_id(),
+            ?chunk_validators,
+            tag_witness_distribution = true,
+        )
+        .entered();
 
         // Break the state witness into parts using Reed Solomon encoding.
         let encoder = self.witness_encoders.entry(chunk_validators.len());
@@ -341,6 +345,16 @@ impl PartialWitnessActor {
         chunk_validators: &[AccountId],
         signer: &ValidatorSigner,
     ) {
+        let _span = tracing::debug_span!(
+            target: "client",
+            "send_state_witness_parts",
+            chunk_hash = ?chunk_header.chunk_hash(),
+            height = %chunk_header.height_created(),
+            shard_id = %chunk_header.shard_id(),
+            tag_witness_distribution = true,
+        )
+        .entered();
+
         // Capture these values first, as the sources are consumed before calling record_witness_sent.
         let chunk_hash = chunk_header.chunk_hash();
         let witness_size_in_bytes = witness_bytes.size_bytes();
@@ -378,6 +392,15 @@ impl PartialWitnessActor {
         &self,
         partial_witness: PartialEncodedStateWitness,
     ) -> Result<(), Error> {
+        let _span = tracing::debug_span!(
+            target: "client",
+            "handle_partial_encoded_state_witness",
+            height = partial_witness.chunk_production_key().height_created,
+            shard_id = %partial_witness.chunk_production_key().shard_id,
+            part_ord = partial_witness.part_ord(),
+            tag_witness_distribution = true,
+        )
+        .entered();
         tracing::debug!(target: "client", ?partial_witness, "Receive PartialEncodedStateWitnessMessage");
         let signer = self.my_validator_signer()?;
         let validator_account_id = signer.validator_id().clone();
@@ -446,6 +469,15 @@ impl PartialWitnessActor {
         &self,
         partial_witness: PartialEncodedStateWitness,
     ) -> Result<(), Error> {
+        let _span = tracing::debug_span!(
+            target: "client",
+            "handle_partial_encoded_state_witness_forward",
+            height = partial_witness.chunk_production_key().height_created,
+            shard_id = %partial_witness.chunk_production_key().shard_id,
+            part_ord = partial_witness.part_ord(),
+            tag_witness_distribution = true,
+        )
+        .entered();
         tracing::debug!(target: "client", ?partial_witness, "Receive PartialEncodedStateWitnessForwardMessage");
 
         let signer = self.my_validator_signer()?;
@@ -829,6 +861,16 @@ impl PartialWitnessActor {
 }
 
 fn compress_witness(witness: &ChunkStateWitness) -> Result<EncodedChunkStateWitness, Error> {
+    let _span = tracing::debug_span!(
+        target: "client",
+        "compress_witness",
+        chunk_hash = ?witness.chunk_header().chunk_hash(),
+        height = %witness.chunk_header().height_created(),
+        shard_id = %witness.chunk_header().shard_id(),
+        tag_witness_distribution=true,
+    )
+    .entered();
+
     let shard_id_label = witness.chunk_header().shard_id().to_string();
     let encode_timer = near_chain::stateless_validation::metrics::CHUNK_STATE_WITNESS_ENCODE_TIME
         .with_label_values(&[shard_id_label.as_str()])

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
@@ -473,7 +473,7 @@ impl PartialEncodedStateWitnessTracker {
                 target: "client",
                 "send_witness_to_client",
                 chunk_hash = ?witness.chunk_header().chunk_hash(),
-                height_created = key.height_created,
+                height = key.height_created,
                 shard_id = %key.shard_id,
                 raw_witness_size = raw_witness_size,
                 tag_witness_distribution = true,

--- a/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
+++ b/chain/client/src/stateless_validation/partial_witness/partial_witness_tracker.rs
@@ -152,6 +152,17 @@ impl CacheEntry {
         partial_witness: PartialEncodedStateWitness,
         encoder: Arc<ReedSolomonEncoder>,
     ) {
+        let _span = tracing::debug_span!(
+            target: "client",
+            "process_witness_part",
+            height = partial_witness.chunk_production_key().height_created,
+            shard_id = %partial_witness.chunk_production_key().shard_id,
+            part_ord = partial_witness.part_ord(),
+            part_size = partial_witness.part_size(),
+            part_encoded_length = partial_witness.encoded_length(),
+            tag_witness_distribution = true,
+        )
+        .entered();
         if matches!(self.witness_parts, WitnessPartsState::Empty) {
             let parts = ReedSolomonPartsTracker::new(encoder, partial_witness.encoded_length());
             self.witness_parts = WitnessPartsState::WaitingParts(parts);
@@ -174,7 +185,17 @@ impl CacheEntry {
         }
         let part_ord = partial_witness.part_ord();
         let part = partial_witness.into_part();
-        match parts.insert_part(part_ord, part) {
+        let create_decode_span = move || {
+            tracing::debug_span!(
+                target: "client",
+                "decode_witness",
+                height = key.height_created,
+                shard_id = %key.shard_id,
+                tag_witness_distribution = true,
+            )
+            .entered()
+        };
+        match parts.insert_part(part_ord, part, Some(Box::new(create_decode_span))) {
             InsertPartResult::Accepted => {}
             InsertPartResult::PartAlreadyAvailable => {
                 tracing::warn!(
@@ -397,6 +418,7 @@ impl PartialEncodedStateWitnessTracker {
         let Some(entry) = parts_cache_by_shard.get_mut(&key) else {
             return Ok(());
         };
+
         let total_size: usize = if let Some((decode_result, accessed_contracts)) =
             entry.update(update)
         {
@@ -447,6 +469,16 @@ impl PartialEncodedStateWitnessTracker {
             values.extend(accessed_contracts.into_iter().map(|code| code.0.into()));
 
             tracing::debug!(target: "client", ?key, "Sending encoded witness to client.");
+            let _span = tracing::debug_span!(
+                target: "client",
+                "send_witness_to_client",
+                chunk_hash = ?witness.chunk_header().chunk_hash(),
+                height_created = key.height_created,
+                shard_id = %key.shard_id,
+                raw_witness_size = raw_witness_size,
+                tag_witness_distribution = true,
+            )
+            .entered();
             self.client_sender.send(ChunkStateWitnessMessage { witness, raw_witness_size });
 
             total_size

--- a/chain/client/src/stateless_validation/state_witness_producer.rs
+++ b/chain/client/src/stateless_validation/state_witness_producer.rs
@@ -30,7 +30,8 @@ impl Client {
             chunk_hash=?chunk_header.chunk_hash(),
             height,
             %shard_id,
-            tag_block_production = true
+            tag_block_production = true,
+            tag_witness_distribution = true,
         )
         .entered();
 

--- a/chain/client/src/stateless_validation/validate.rs
+++ b/chain/client/src/stateless_validation/validate.rs
@@ -68,6 +68,15 @@ pub fn validate_partial_encoded_state_witness(
 ) -> Result<ChunkRelevance, Error> {
     let ChunkProductionKey { shard_id, epoch_id, height_created } =
         partial_witness.chunk_production_key();
+    let _span = tracing::debug_span!(
+        target: "client",
+        "validate_partial_encoded_state_witness",
+        height = %height_created,
+        shard_id = %shard_id,
+        part_ord = partial_witness.part_ord(),
+        tag_witness_distribution = true,
+    )
+    .entered();
     let num_parts =
         epoch_manager.get_chunk_validator_assignments(&epoch_id, shard_id, height_created)?.len();
     if partial_witness.part_ord() >= num_parts {

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1130,7 +1130,7 @@ impl PeerManagerActor {
                     "send partial_encoded_state_witnesses",
                     height = partial_witness.chunk_production_key().height_created,
                     shard_id = %partial_witness.chunk_production_key().shard_id,
-                    part_owners = ?part_owners,
+                    part_owners_len = part_owners.len(),
                     tag_witness_distribution = true,
                 )
                 .entered();

--- a/chain/network/src/peer_manager/peer_manager_actor.rs
+++ b/chain/network/src/peer_manager/peer_manager_actor.rs
@@ -1119,6 +1119,22 @@ impl PeerManagerActor {
                 NetworkResponses::NoResponse
             }
             NetworkRequests::PartialEncodedStateWitness(validator_witness_tuple) => {
+                let Some(partial_witness) = validator_witness_tuple.first().map(|(_, w)| w) else {
+                    return NetworkResponses::NoResponse;
+                };
+                let part_owners = validator_witness_tuple
+                    .iter()
+                    .map(|(validator, _)| validator.clone())
+                    .collect::<Vec<_>>();
+                let _span = tracing::debug_span!(target: "network",
+                    "send partial_encoded_state_witnesses",
+                    height = partial_witness.chunk_production_key().height_created,
+                    shard_id = %partial_witness.chunk_production_key().shard_id,
+                    part_owners = ?part_owners,
+                    tag_witness_distribution = true,
+                )
+                .entered();
+
                 for (chunk_validator, partial_witness) in validator_witness_tuple {
                     self.state.send_message_to_account(
                         &self.clock,
@@ -1132,6 +1148,14 @@ impl PeerManagerActor {
                 chunk_validators,
                 partial_witness,
             ) => {
+                let _span = tracing::debug_span!(target: "network",
+                    "send partial_encoded_state_witness_forward",
+                    height = partial_witness.chunk_production_key().height_created,
+                    shard_id = %partial_witness.chunk_production_key().shard_id,
+                    part_ord = partial_witness.part_ord(),
+                    tag_witness_distribution = true,
+                )
+                .entered();
                 for chunk_validator in chunk_validators {
                     self.state.send_message_to_account(
                         &self.clock,

--- a/core/primitives/src/reed_solomon.rs
+++ b/core/primitives/src/reed_solomon.rs
@@ -4,6 +4,7 @@ use reed_solomon_erasure::galois_8::ReedSolomon;
 use std::collections::HashMap;
 use std::io::Error;
 use std::sync::Arc;
+use tracing::span::EnteredSpan;
 
 /// Type alias around what ReedSolomon represents data part as.
 /// This should help with making the code a bit more understandable.
@@ -227,7 +228,12 @@ impl<T: ReedSolomonEncoderDeserialize> ReedSolomonPartsTracker<T> {
         self.parts.get(part_ord).is_some_and(|part| part.is_some())
     }
 
-    pub fn insert_part(&mut self, part_ord: usize, part: Box<[u8]>) -> InsertPartResult<T> {
+    pub fn insert_part(
+        &mut self,
+        part_ord: usize,
+        part: Box<[u8]>,
+        create_decode_span: Option<Box<dyn Fn() -> EnteredSpan>>,
+    ) -> InsertPartResult<T> {
         if part_ord >= self.parts.len() {
             return InsertPartResult::InvalidPartOrd;
         }
@@ -240,6 +246,7 @@ impl<T: ReedSolomonEncoderDeserialize> ReedSolomonPartsTracker<T> {
         self.parts[part_ord] = Some(part);
 
         if self.has_enough_parts() {
+            let _decode_span = create_decode_span.map(|f| f());
             InsertPartResult::Decoded(self.encoder.decode(&mut self.parts, self.encoded_length))
         } else {
             InsertPartResult::Accepted


### PR DESCRIPTION
Add tracing spans to track witness distribution

New spans for:
* Creating the witness, compressing it, preparing parts, sending parts
* Receiving and forwarding the parts
* Decoding the witness and processing it in ClientActor

A new tag is added for witness distribution spans: `tag_witness_distribution`

It's possible to export both block production and witness distribution spans by using:
```json
"opentelemetry": "[{tag_block_production=\"true\"}]=debug,[{tag_witness_distribution=\"true\"}]=debug"
```

![image](https://github.com/user-attachments/assets/0417cf40-b946-4474-96ee-70ac2bdf9149)
