### PR TITLE
feat: Rename `Experimental_changes` RPC method to simply `changes` (#13722)

### DIFF
--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -228,12 +228,21 @@ impl JsonRpcClient {
         call_method(&self.client, &self.server_addr, "EXPERIMENTAL_tx_status", request)
     }
 
+    #[deprecated(since = "2.7.0", note = "Use `changes` method instead")]
     #[allow(non_snake_case)]
     pub fn EXPERIMENTAL_changes(
         &self,
         request: RpcStateChangesInBlockByTypeRequest,
     ) -> RpcRequest<RpcStateChangesInBlockByTypeResponse> {
         call_method(&self.client, &self.server_addr, "EXPERIMENTAL_changes", request)
+    }
+
+    #[allow(non_snake_case)]
+    pub fn changes(
+        &self,
+        request: RpcStateChangesInBlockByTypeRequest,
+    ) -> RpcRequest<RpcStateChangesInBlockByTypeResponse> {
+        call_method(&self.client, &self.server_addr, "changes", request)
     }
 
     #[allow(non_snake_case)]

--- a/chain/jsonrpc/openapi/openapi.json
+++ b/chain/jsonrpc/openapi/openapi.json
@@ -410,6 +410,33 @@
         }
       }
     },
+    "/changes": {
+      "post": {
+        "operationId": "changes",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonRpcRequest_for_changes"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonRpcResponse_for_RpcStateChangesInBlockResponse_and_RpcError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/chunk": {
       "post": {
         "operationId": "chunk",
@@ -6519,6 +6546,33 @@
           "method"
         ],
         "title": "JsonRpcRequest_for_broadcast_tx_commit",
+        "type": "object"
+      },
+      "JsonRpcRequest_for_changes": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "jsonrpc": {
+            "type": "string"
+          },
+          "method": {
+            "enum": [
+              "changes"
+            ],
+            "type": "string"
+          },
+          "params": {
+            "$ref": "#/components/schemas/RpcStateChangesInBlockByTypeRequest"
+          }
+        },
+        "required": [
+          "jsonrpc",
+          "id",
+          "params",
+          "method"
+        ],
+        "title": "JsonRpcRequest_for_changes",
         "type": "object"
       },
       "JsonRpcRequest_for_chunk": {

--- a/chain/jsonrpc/openapi/src/main.rs
+++ b/chain/jsonrpc/openapi/src/main.rs
@@ -363,11 +363,15 @@ fn main() {
         &mut all_paths,
         "client_config".to_string(),
     );
-
     add_spec_for_path::<RpcStateChangesInBlockByTypeRequest, RpcStateChangesInBlockResponse>(
         &mut all_schemas,
         &mut all_paths,
         "EXPERIMENTAL_changes".to_string(),
+    );
+    add_spec_for_path::<RpcStateChangesInBlockByTypeRequest, RpcStateChangesInBlockResponse>(
+        &mut all_schemas,
+        &mut all_paths,
+        "changes".to_string(),
     );
     add_spec_for_path::<RpcStateChangesInBlockRequest, RpcStateChangesInBlockByTypeResponse>(
         &mut all_schemas,

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -420,6 +420,9 @@ impl JsonRpcHandler {
             "EXPERIMENTAL_changes" => {
                 process_method_call(request, |params| self.changes_in_block_by_type(params)).await
             }
+            "changes" => {
+                process_method_call(request, |params| self.changes_in_block_by_type(params)).await
+            }
             "EXPERIMENTAL_changes_in_block" => {
                 process_method_call(request, |params| self.changes_in_block(params)).await
             }

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -475,6 +475,10 @@ class BaseNode(object):
                              changes_in_block_request)
 
     def get_changes(self, changes_request):
+        return self.json_rpc('changes', changes_request)
+
+    # `EXPERIMENTAL_changes` is deprecated as of 2.7, use `get_changes` test instead
+    def get_experimental_changes(self, changes_request):
         return self.json_rpc('EXPERIMENTAL_changes', changes_request)
 
     def validators(self):


### PR DESCRIPTION
https://github.com/near/nearcore/pull/13722