### PR TITLE
Update broken chunks_management.rs test link to new location in integ…

### DIFF
--- a/docs/practices/testing/README.md
+++ b/docs/practices/testing/README.md
@@ -82,7 +82,7 @@ in
 
 For an example of a test that launches multiple nodes, see
 `chunks_produced_and_distributed_common` in
-[tests/chunks_management.rs](https://github.com/near/nearcore/blob/master/chain/client/src/tests/chunks_management.rs).
+[integration-tests/src/tests/client/chunks_management.rs | Network chunk management test](https://github.com/near/nearcore/blob/master/integration-tests/src/tests/client/chunks_management.rs).
 The `setup_mock_all_validators` function is the key piece of infrastructure here.
 
 ## Runtime


### PR DESCRIPTION
…ration tests

Replaced the outdated link to chain/client/src/tests/chunks_management.rs with the correct path integration-tests/src/tests/client/chunks_management.rs in the testing practices README. This ensures that documentation references the current location of the network chunk management test in the nearcore repository.