### PR TITLE
fix - Trie resharding resume when children memtries don't exist anymore

### DIFF
--- a/chain/chain/src/resharding/flat_storage_resharder.rs
+++ b/chain/chain/src/resharding/flat_storage_resharder.rs
@@ -403,16 +403,15 @@ impl FlatStorageResharder {
         match task_status {
             FlatStorageReshardingTaskResult::Successful { .. } => {
                 // Split shard completed successfully.
-                // Parent flat storage can be deleted from the FlatStoreManager.
-                // If FlatStoreManager has no reference to the shard, delete it manually.
-                if !self
-                    .runtime
-                    .get_flat_storage_manager()
-                    .remove_flat_storage_for_shard(parent_shard, &mut store_update)
-                    .unwrap()
-                {
-                    store_update.remove_flat_storage(parent_shard);
-                }
+
+                // NOTE: Parent flat storage cleanup has been moved to trie state resharder
+                // to ensure proper ordering.
+                //
+                // This change ensures that:
+                // 1. Flat storage resharding completes first
+                // 2. Trie state resharding can safely access/create child memtries
+                // 3. Parent flat storage is cleaned up only after all operations complete
+
                 // Children must perform catchup.
                 for child_shard in [left_child_shard, right_child_shard] {
                     store_update.set_flat_storage_status(

--- a/chain/chain/src/resharding/flat_storage_resharder.rs
+++ b/chain/chain/src/resharding/flat_storage_resharder.rs
@@ -1486,8 +1486,12 @@ mod tests {
         // Do the resharding.
         flat_storage_resharder.start_resharding_blocking_impl(parent_shard, split_params.clone());
 
-        // Verify parent shard is gone
-        assert_matches!(store.get_flat_storage_status(parent_shard), Ok(FlatStorageStatus::Empty));
+        // Verify parent shard is still in resharding state (not deleted yet).
+        // Parent flat storage cleanup happens in trie_state_resharder, not here.
+        assert_matches!(
+            store.get_flat_storage_status(parent_shard),
+            Ok(FlatStorageStatus::Resharding(_))
+        );
 
         // Both children shards should be in Ready state
         for child_shard in [split_params.left_child_shard, split_params.right_child_shard] {

--- a/chain/chain/src/resharding/trie_state_resharder.rs
+++ b/chain/chain/src/resharding/trie_state_resharder.rs
@@ -4,14 +4,17 @@ use std::sync::Arc;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_primitives::hash::CryptoHash;
-use near_store::adapter::trie_store::{TrieStoreUpdateAdapter, get_shard_uid_mapping};
+use near_primitives::types::{AccountId, BlockHeight};
+use near_store::adapter::trie_store::TrieStoreUpdateAdapter;
 use near_store::adapter::{StoreAdapter, StoreUpdateAdapter};
 use near_store::db::TRIE_STATE_RESHARDING_STATUS_KEY;
 use near_store::metrics::resharding::trie_state_metrics;
+use near_store::trie::ops::resharding::RetainMode;
 use near_store::{DBCol, StorageError};
 
 use crate::resharding::event_type::ReshardingSplitShardParams;
 use crate::types::RuntimeAdapter;
+use itertools::Itertools;
 use near_chain_configs::{MutableConfigValue, ReshardingConfig, ReshardingHandle};
 use near_chain_primitives::Error;
 use near_o11y::metrics::IntGauge;
@@ -52,9 +55,30 @@ struct TrieStateReshardingStatus {
     parent_shard_uid: ShardUId,
     left: Option<TrieStateReshardingChildStatus>,
     right: Option<TrieStateReshardingChildStatus>,
+    boundary_account: AccountId,
+    resharding_block_height: BlockHeight,
+    parent_state_root: CryptoHash,
 }
 
 impl TrieStateReshardingStatus {
+    fn new(
+        parent_shard_uid: ShardUId,
+        left: TrieStateReshardingChildStatus,
+        right: TrieStateReshardingChildStatus,
+        boundary_account: AccountId,
+        resharding_block_height: BlockHeight,
+        parent_state_root: CryptoHash,
+    ) -> Self {
+        Self {
+            parent_shard_uid,
+            left: Some(left),
+            right: Some(right),
+            boundary_account,
+            resharding_block_height,
+            parent_state_root,
+        }
+    }
+
     fn with_metrics(mut self) -> Self {
         for child in [&mut self.left, &mut self.right] {
             child.as_mut().map(|child| {
@@ -240,35 +264,30 @@ impl TrieStateResharder {
             *store.get_chunk_extra(&block_hash, &event.left_child_shard)?.state_root();
         let right_state_root =
             *store.get_chunk_extra(&block_hash, &event.right_child_shard)?.state_root();
+
+        // We need the parent state root for memtrie recreation.
+        let parent_state_root =
+            *store.get_chunk_extra(&block_hash, &event.parent_shard)?.state_root();
+
         tracing::debug!(
             target: "resharding",
             ?left_state_root,
             ?right_state_root,
+            ?parent_state_root,
             ?event.left_child_shard,
             ?event.right_child_shard,
-            "TrieStateResharding: child state roots"
+            ?event.parent_shard,
+            "TrieStateResharding: child and parent state roots"
         );
 
-        // If the child shard_uid mapping doesn't exist, it means we are not tracking the child shard.
-        let store = self.runtime.store();
-        let left_child =
-            if get_shard_uid_mapping(store, event.left_child_shard) != event.left_child_shard {
-                Some(TrieStateReshardingChildStatus::new(event.left_child_shard, left_state_root))
-            } else {
-                None
-            };
-        let right_child =
-            if get_shard_uid_mapping(store, event.right_child_shard) != event.right_child_shard {
-                Some(TrieStateReshardingChildStatus::new(event.right_child_shard, right_state_root))
-            } else {
-                None
-            };
-
-        let mut status = TrieStateReshardingStatus {
-            parent_shard_uid: event.parent_shard,
-            left: left_child,
-            right: right_child,
-        }
+        let mut status = TrieStateReshardingStatus::new(
+            event.parent_shard,
+            TrieStateReshardingChildStatus::new(event.left_child_shard, left_state_root),
+            TrieStateReshardingChildStatus::new(event.right_child_shard, right_state_root),
+            event.boundary_account.clone(),
+            event.resharding_block.height,
+            parent_state_root,
+        )
         .with_metrics();
         self.resharding_blocking_impl(&mut status)
     }
@@ -286,8 +305,89 @@ impl TrieStateResharder {
                 status.parent_shard_uid, parent_shard_uid
             )));
         }
+
+        // Before resuming, ensure child memtries exist for both children.
+        self.ensure_child_memtries_exist(&status)?;
+
         let mut status = status.with_metrics();
         self.resharding_blocking_impl(&mut status)
+    }
+
+    /// Ensures that child memtries exist for both children, recreating them if necessary.
+    fn ensure_child_memtries_exist(&self, status: &TrieStateReshardingStatus) -> Result<(), Error> {
+        let tries = self.runtime.get_tries();
+
+        let missing_children = [
+            status.left.as_ref().map(|child| (child.shard_uid, RetainMode::Left)),
+            status.right.as_ref().map(|child| (child.shard_uid, RetainMode::Right)),
+        ]
+        .into_iter()
+        .flatten()
+        .filter(|(shard_uid, _)| tries.get_memtries(*shard_uid).is_none())
+        .collect_vec();
+
+        if !missing_children.is_empty() {
+            self.recreate_child_memtries(status, missing_children)?;
+        }
+
+        Ok(())
+    }
+
+    fn recreate_child_memtries(
+        &self,
+        status: &TrieStateReshardingStatus,
+        missing_children: Vec<(ShardUId, RetainMode)>,
+    ) -> Result<(), Error> {
+        let tries = self.runtime.get_tries();
+        let parent_shard_uid = status.parent_shard_uid;
+        let boundary_account = &status.boundary_account;
+        let block_height = status.resharding_block_height;
+
+        let parent_trie = tries
+            .get_trie_for_shard(parent_shard_uid, status.parent_state_root)
+            .recording_reads_new_recorder();
+
+        if !parent_trie.has_memtries() {
+            return Err(Error::Other(format!(
+                "Parent memtrie for shard {parent_shard_uid} does not exist or is not loaded"
+            )));
+        }
+
+        let mut store_update = self.runtime.store().trie_store().store_update();
+
+        // Recreate each missing child memtrie.
+        for (child_shard_uid, retain_mode) in &missing_children {
+            tracing::info!(
+                target: "resharding",
+                ?child_shard_uid,
+                ?parent_shard_uid,
+                ?boundary_account,
+                ?retain_mode,
+                ?block_height,
+                "Recreating child memtrie from parent"
+            );
+
+            // Perform the shard split operation.
+            let trie_changes = parent_trie.retain_split_shard(boundary_account, *retain_mode)?;
+
+            tries.apply_insertions(&trie_changes, parent_shard_uid, &mut store_update);
+            tries.apply_memtrie_changes(&trie_changes, parent_shard_uid, block_height);
+
+            tracing::info!(
+                target: "resharding",
+                ?child_shard_uid,
+                new_root = ?trie_changes.new_root,
+                "Successfully recreated child memtrie from parent"
+            );
+        }
+
+        store_update.commit().unwrap();
+
+        // After creating all the child memtries, freeze the parent.
+        let children_shard_uids = missing_children.into_iter().map(|(uid, _)| uid).collect_vec();
+        tries.freeze_parent_memtrie(parent_shard_uid, children_shard_uids)?;
+
+        Ok(())
     }
 
     fn resharding_blocking_impl(
@@ -298,7 +398,35 @@ impl TrieStateResharder {
             self.process_batch_and_update_status(status)?;
         }
 
+        // If resharding completed successfully, clean up parent flat storage.
+        if status.done() {
+            self.cleanup_parent_flat_storage(status.parent_shard_uid);
+        }
+
         Ok(())
+    }
+
+    /// Cleans up parent flat storage after trie state resharding is complete.
+    fn cleanup_parent_flat_storage(&self, parent_shard_uid: ShardUId) {
+        tracing::info!(
+            target: "resharding",
+            ?parent_shard_uid,
+            "Trie state resharding complete, cleaning up parent flat storage"
+        );
+
+        let flat_store = self.runtime.store().flat_store();
+        let mut store_update = flat_store.store_update();
+
+        if !self
+            .runtime
+            .get_flat_storage_manager()
+            .remove_flat_storage_for_shard(parent_shard_uid, &mut store_update)
+            .unwrap()
+        {
+            store_update.remove_flat_storage(parent_shard_uid);
+        }
+
+        store_update.commit().unwrap();
     }
 }
 
@@ -353,21 +481,27 @@ mod tests {
         parent_shard: ShardUId,
         left_shard: ShardUId,
         right_shard: ShardUId,
+        parent_root: CryptoHash,
         left_root: CryptoHash,
         right_root: CryptoHash,
+        boundary_account: AccountId,
+        resharding_block_height: BlockHeight,
     }
 
     impl TestSetup {
         fn as_status(&self) -> TrieStateReshardingStatus {
-            TrieStateReshardingStatus {
-                parent_shard_uid: self.parent_shard,
-                left: Some(TrieStateReshardingChildStatus::new(self.left_shard, self.left_root)),
-                right: Some(TrieStateReshardingChildStatus::new(self.right_shard, self.right_root)),
-            }
+            TrieStateReshardingStatus::new(
+                self.parent_shard,
+                TrieStateReshardingChildStatus::new(self.left_shard, self.left_root),
+                TrieStateReshardingChildStatus::new(self.right_shard, self.right_root),
+                self.boundary_account.clone(),
+                self.resharding_block_height,
+                self.parent_root,
+            )
         }
     }
 
-    fn setup_test() -> TestSetup {
+    fn setup_test(create_child_memtries: bool) -> TestSetup {
         let shard_layout = ShardLayout::single_shard();
         let genesis = Genesis::from_accounts(
             Clock::real(),
@@ -428,7 +562,9 @@ mod tests {
             let trie_changes =
                 parent_trie.retain_split_shard(&boundary_account, retain_mode).unwrap();
             tries.apply_insertions(&trie_changes, parent_shard, &mut store_update);
-            tries.apply_memtrie_changes(&trie_changes, parent_shard, block_height);
+            if create_child_memtries {
+                tries.apply_memtrie_changes(&trie_changes, parent_shard, block_height);
+            }
             trie_changes.new_root
         });
         // Add a mapping from the child shards to the parent shard. This is not
@@ -438,14 +574,27 @@ mod tests {
         store_update.set_shard_uid_mapping(right_shard, parent_shard);
         store_update.commit().unwrap();
 
-        tries.freeze_parent_memtrie(parent_shard, children).unwrap();
+        if create_child_memtries {
+            tries.freeze_parent_memtrie(parent_shard, children).unwrap();
+        }
 
-        TestSetup { runtime, initial, parent_shard, left_shard, right_shard, left_root, right_root }
+        TestSetup {
+            runtime,
+            initial,
+            parent_shard,
+            left_shard,
+            right_shard,
+            parent_root,
+            left_root,
+            right_root,
+            boundary_account,
+            resharding_block_height: block_height,
+        }
     }
 
     #[test]
     fn test_trie_state_resharder() {
-        let test = setup_test();
+        let test = setup_test(true);
 
         let config = ChainConfig::test().resharding_config;
         let resharder = TrieStateResharder::new(
@@ -464,9 +613,8 @@ mod tests {
         assert_eq!(0, test.runtime.store().iter(DBCol::StateShardUIdMapping).count());
     }
 
-    #[test]
-    fn test_trie_state_resharder_interrupt_and_resume() {
-        let test = setup_test();
+    fn test_trie_state_resharder_interrupt_and_resume_impl(missing_child_memtries: bool) {
+        let test = setup_test(!missing_child_memtries);
 
         let config = ChainConfig::test().resharding_config;
         let resharder = TrieStateResharder::new(
@@ -481,6 +629,20 @@ mod tests {
             .resharding_config
             .update(ReshardingConfig { batch_size: ByteSize(1), ..ReshardingConfig::test() });
         let mut update_status = test.as_status();
+
+        if missing_child_memtries {
+            // Verify child memtries don't exist.
+            let tries = test.runtime.get_tries();
+            assert!(
+                tries.get_memtries(test.left_shard).is_none(),
+                "Left child memtrie should not exist"
+            );
+            assert!(
+                tries.get_memtries(test.right_shard).is_none(),
+                "Right child memtrie should not exist"
+            );
+        }
+
         resharder.process_batch_and_update_status(&mut update_status).unwrap();
 
         let got_status = resharder
@@ -513,6 +675,19 @@ mod tests {
         );
         resharder.resume(test.parent_shard).expect("resume should succeed");
 
+        if missing_child_memtries {
+            // Verify that child memtries were recreated during resume.
+            let tries = test.runtime.get_tries();
+            assert!(
+                tries.get_memtries(test.left_shard).is_some(),
+                "Left child memtrie should be recreated"
+            );
+            assert!(
+                tries.get_memtries(test.right_shard).is_some(),
+                "Right child memtrie should be recreated"
+            );
+        }
+
         // The resharding status should be None after completion.
         assert!(resharder.load_status().unwrap().is_none());
         check_child_tries_contain_all_keys(&test);
@@ -521,9 +696,19 @@ mod tests {
     }
 
     #[test]
+    fn test_trie_state_resharder_interrupt_and_resume() {
+        test_trie_state_resharder_interrupt_and_resume_impl(false);
+    }
+
+    #[test]
+    fn test_trie_state_resharder_with_missing_child_memtries() {
+        test_trie_state_resharder_interrupt_and_resume_impl(true);
+    }
+
+    #[test]
     #[should_panic(expected = "TrieStateReshardingStatus already exists")]
     fn test_trie_state_resharder_panic_on_implicit_resume() {
-        let test = setup_test();
+        let test = setup_test(true);
 
         let config = ChainConfig::test().resharding_config;
         let resharder = TrieStateResharder::new(

--- a/chain/chain/src/resharding/trie_state_resharder.rs
+++ b/chain/chain/src/resharding/trie_state_resharder.rs
@@ -360,9 +360,7 @@ impl TrieStateResharder {
             )?;
         }
 
-        let parent_trie = tries
-            .get_trie_for_shard(parent_shard_uid, status.parent_state_root)
-            .recording_reads_new_recorder();
+        let parent_trie = tries.get_trie_for_shard(parent_shard_uid, status.parent_state_root);
 
         if !parent_trie.has_memtries() {
             return Err(Error::Other(format!(

--- a/chain/chain/src/resharding/trie_state_resharder.rs
+++ b/chain/chain/src/resharding/trie_state_resharder.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::{AccountId, BlockHeight};
-use near_store::adapter::trie_store::TrieStoreUpdateAdapter;
+use near_store::adapter::trie_store::{TrieStoreUpdateAdapter, get_shard_uid_mapping};
 use near_store::adapter::{StoreAdapter, StoreUpdateAdapter};
 use near_store::db::TRIE_STATE_RESHARDING_STATUS_KEY;
 use near_store::metrics::resharding::trie_state_metrics;
@@ -63,16 +63,16 @@ struct TrieStateReshardingStatus {
 impl TrieStateReshardingStatus {
     fn new(
         parent_shard_uid: ShardUId,
-        left: TrieStateReshardingChildStatus,
-        right: TrieStateReshardingChildStatus,
+        left: Option<TrieStateReshardingChildStatus>,
+        right: Option<TrieStateReshardingChildStatus>,
         boundary_account: AccountId,
         resharding_block_height: BlockHeight,
         parent_state_root: CryptoHash,
     ) -> Self {
         Self {
             parent_shard_uid,
-            left: Some(left),
-            right: Some(right),
+            left,
+            right,
             boundary_account,
             resharding_block_height,
             parent_state_root,
@@ -280,10 +280,25 @@ impl TrieStateResharder {
             "TrieStateResharding: child and parent state roots"
         );
 
+        // If the child shard_uid mapping doesn't exist, it means we are not tracking the child shard.
+        let store = self.runtime.store();
+        let left_child =
+            if get_shard_uid_mapping(store, event.left_child_shard) != event.left_child_shard {
+                Some(TrieStateReshardingChildStatus::new(event.left_child_shard, left_state_root))
+            } else {
+                None
+            };
+        let right_child =
+            if get_shard_uid_mapping(store, event.right_child_shard) != event.right_child_shard {
+                Some(TrieStateReshardingChildStatus::new(event.right_child_shard, right_state_root))
+            } else {
+                None
+            };
+
         let mut status = TrieStateReshardingStatus::new(
             event.parent_shard,
-            TrieStateReshardingChildStatus::new(event.left_child_shard, left_state_root),
-            TrieStateReshardingChildStatus::new(event.right_child_shard, right_state_root),
+            left_child,
+            right_child,
             event.boundary_account.clone(),
             event.resharding_block.height,
             parent_state_root,
@@ -510,8 +525,8 @@ mod tests {
         fn as_status(&self) -> TrieStateReshardingStatus {
             TrieStateReshardingStatus::new(
                 self.parent_shard,
-                TrieStateReshardingChildStatus::new(self.left_shard, self.left_root),
-                TrieStateReshardingChildStatus::new(self.right_shard, self.right_root),
+                Some(TrieStateReshardingChildStatus::new(self.left_shard, self.left_root)),
+                Some(TrieStateReshardingChildStatus::new(self.right_shard, self.right_root)),
                 self.boundary_account.clone(),
                 self.resharding_block_height,
                 self.parent_root,

--- a/chain/chain/src/resharding/trie_state_resharder.rs
+++ b/chain/chain/src/resharding/trie_state_resharder.rs
@@ -343,6 +343,23 @@ impl TrieStateResharder {
         let boundary_account = &status.boundary_account;
         let block_height = status.resharding_block_height;
 
+        // Parent memtrie must be loaded before proceeding.
+        if tries.get_memtries(parent_shard_uid).is_none() {
+            tracing::info!(
+                target: "resharding",
+                ?parent_shard_uid,
+                parent_state_root = ?status.parent_state_root,
+                "Parent memtrie not loaded, loading it now"
+            );
+            tries.load_memtrie(&parent_shard_uid, Some(status.parent_state_root), false).map_err(
+                |e| {
+                    Error::Other(format!(
+                        "Failed to load parent memtrie for shard {parent_shard_uid}: {e}"
+                    ))
+                },
+            )?;
+        }
+
         let parent_trie = tries
             .get_trie_for_shard(parent_shard_uid, status.parent_state_root)
             .recording_reads_new_recorder();
@@ -473,6 +490,8 @@ mod tests {
     use crate::types::ChainConfig;
 
     use super::*;
+    use near_primitives::state::FlatStateValue;
+    use near_store::flat::{FlatStorageReadyStatus, FlatStorageStatus};
 
     type KeyValues = Vec<(Vec<u8>, Option<Vec<u8>>)>;
     struct TestSetup {
@@ -501,7 +520,7 @@ mod tests {
         }
     }
 
-    fn setup_test(create_child_memtries: bool) -> TestSetup {
+    fn setup_test(create_memtries: bool) -> TestSetup {
         let shard_layout = ShardLayout::single_shard();
         let genesis = Genesis::from_accounts(
             Clock::real(),
@@ -562,7 +581,7 @@ mod tests {
             let trie_changes =
                 parent_trie.retain_split_shard(&boundary_account, retain_mode).unwrap();
             tries.apply_insertions(&trie_changes, parent_shard, &mut store_update);
-            if create_child_memtries {
+            if create_memtries {
                 tries.apply_memtrie_changes(&trie_changes, parent_shard, block_height);
             }
             trie_changes.new_root
@@ -574,8 +593,41 @@ mod tests {
         store_update.set_shard_uid_mapping(right_shard, parent_shard);
         store_update.commit().unwrap();
 
-        if create_child_memtries {
+        if create_memtries {
             tries.freeze_parent_memtrie(parent_shard, children).unwrap();
+        } else {
+            // If not creating memtries, we need to set up flat storage properly
+            // so that the parent memtrie can be loaded later during resume.
+
+            // First, create flat storage for the parent shard.
+            runtime.get_flat_storage_manager().create_flat_storage_for_shard(parent_shard).unwrap();
+
+            // Second, populate flat storage with the trie data.
+            let flat_store = runtime.store().flat_store();
+            let mut store_update = flat_store.store_update();
+            let parent_trie = tries.get_trie_for_shard(parent_shard, parent_root);
+            let iter = parent_trie.lock_for_iter();
+            for item in iter.iter().unwrap() {
+                let (key, value) = item.unwrap();
+                store_update.set(parent_shard, key, Some(FlatStateValue::Inlined(value)));
+            }
+
+            // Third, set up flat storage status to Ready with the parent state root.
+            store_update.set_flat_storage_status(
+                parent_shard,
+                FlatStorageStatus::Ready(FlatStorageReadyStatus {
+                    flat_head: near_store::flat::BlockInfo {
+                        hash: parent_root,
+                        height: block_height,
+                        prev_hash: CryptoHash::default(),
+                    },
+                }),
+            );
+            store_update.commit().unwrap();
+
+            // Now unload the parent memtrie, so the test can verify
+            // it will get loaded correctly during resume.
+            tries.unload_memtrie(&parent_shard);
         }
 
         TestSetup {
@@ -613,8 +665,8 @@ mod tests {
         assert_eq!(0, test.runtime.store().iter(DBCol::StateShardUIdMapping).count());
     }
 
-    fn test_trie_state_resharder_interrupt_and_resume_impl(missing_child_memtries: bool) {
-        let test = setup_test(!missing_child_memtries);
+    fn test_trie_state_resharder_interrupt_and_resume_impl(missing_memtries: bool) {
+        let test = setup_test(!missing_memtries);
 
         let config = ChainConfig::test().resharding_config;
         let resharder = TrieStateResharder::new(
@@ -630,9 +682,13 @@ mod tests {
             .update(ReshardingConfig { batch_size: ByteSize(1), ..ReshardingConfig::test() });
         let mut update_status = test.as_status();
 
-        if missing_child_memtries {
-            // Verify child memtries don't exist.
+        if missing_memtries {
+            // Verify all memtries don't exist.
             let tries = test.runtime.get_tries();
+            assert!(
+                tries.get_memtries(test.parent_shard).is_none(),
+                "Parent memtrie should not exist"
+            );
             assert!(
                 tries.get_memtries(test.left_shard).is_none(),
                 "Left child memtrie should not exist"
@@ -675,9 +731,13 @@ mod tests {
         );
         resharder.resume(test.parent_shard).expect("resume should succeed");
 
-        if missing_child_memtries {
-            // Verify that child memtries were recreated during resume.
+        if missing_memtries {
+            // Verify that all memtries were loaded/recreated during resume.
             let tries = test.runtime.get_tries();
+            assert!(
+                tries.get_memtries(test.parent_shard).is_some(),
+                "Parent memtrie should be loaded"
+            );
             assert!(
                 tries.get_memtries(test.left_shard).is_some(),
                 "Left child memtrie should be recreated"
@@ -701,7 +761,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trie_state_resharder_with_missing_child_memtries() {
+    fn test_trie_state_resharder_with_missing_memtries() {
         test_trie_state_resharder_interrupt_and_resume_impl(true);
     }
 


### PR DESCRIPTION
For context, see the original PR: https://github.com/near/nearcore/pull/13730/

There is an issue with the UTs which I fixed here by adding an expect_memtries parameter.
This allows the UTs to start & interrupt a resharding without providing memtries, while still checking for them in the rest of the cases.