### PR TITLE
feat: add db column for receipt proofs for SPICE

### DIFF
--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -77,6 +77,7 @@ shadow_chunk_validation = []
 protocol_feature_spice = [
     "near-epoch-manager/protocol_feature_spice",
     "near-primitives/protocol_feature_spice",
+    "near-store/protocol_feature_spice",
 ]
 
 nightly = [

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -75,7 +75,8 @@ byzantine_asserts = ["near-chain/byzantine_asserts"]
 shadow_chunk_validation = ["near-chain/shadow_chunk_validation"]
 protocol_feature_spice = [
     "near-chain/protocol_feature_spice",
-    "near-epoch-manager/protocol_feature_spice"
+    "near-epoch-manager/protocol_feature_spice",
+    "near-store/protocol_feature_spice",
 ]
 test_features = [
     "near-network/test_features",

--- a/chain/client/src/chunk_executor_actor.rs
+++ b/chain/client/src/chunk_executor_actor.rs
@@ -31,8 +31,13 @@ use near_primitives::sandbox::state_patch::SandboxStatePatch;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::ReceiptProof;
 use near_primitives::sharding::ShardProof;
-use near_primitives::types::{EpochId, ShardId, ShardIndex};
+use near_primitives::types::EpochId;
+use near_primitives::types::{ShardId, ShardIndex};
+use near_primitives::utils::get_receipt_proof_key;
+use near_primitives::utils::get_receipt_proof_target_shard_prefix;
+use near_store::DBCol;
 use near_store::Store;
+use near_store::adapter::StoreAdapter;
 use node_runtime::SignedValidPeriodTransactions;
 use tracing::instrument;
 
@@ -43,8 +48,6 @@ pub struct ChunkExecutorActor {
     shard_tracker: ShardTracker,
     network_adapter: PeerManagerAdapter,
 
-    /// Receipts originating from block keyed by block hash.
-    block_receipts_cache: LruCache<CryptoHash, HashMap<(ShardId, ShardId), ReceiptProof>>,
     /// Next block hashes keyed by block hash.
     next_block_hashes: LruCache<CryptoHash, Vec<CryptoHash>>,
 
@@ -61,7 +64,6 @@ impl ChunkExecutorActor {
         epoch_manager: Arc<dyn EpochManagerAdapter>,
         shard_tracker: ShardTracker,
         network_adapter: PeerManagerAdapter,
-        block_receipts_cache_capacity: NonZeroUsize,
         next_block_hashes_cache_capacity: NonZeroUsize,
     ) -> Self {
         Self {
@@ -70,7 +72,6 @@ impl ChunkExecutorActor {
             epoch_manager,
             shard_tracker,
             network_adapter,
-            block_receipts_cache: LruCache::new(block_receipts_cache_capacity),
             next_block_hashes: LruCache::new(next_block_hashes_cache_capacity),
             genesis_hash,
         }
@@ -102,10 +103,11 @@ impl Handler<ExecutorIncomingReceipts> for ChunkExecutorActor {
         &mut self,
         ExecutorIncomingReceipts { block_hash, receipt_proofs }: ExecutorIncomingReceipts,
     ) {
-        let block_receipts =
-            self.block_receipts_cache.get_or_insert_mut(block_hash, || HashMap::new());
         for proof in receipt_proofs {
-            block_receipts.insert((proof.1.from_shard_id, proof.1.to_shard_id), proof);
+            if let Err(err) = save_receipt_proof(&self.chain_store.store(), &block_hash, &proof) {
+                tracing::error!(target: "chunk_executor", ?err, ?block_hash, "failed to save receipt proof");
+                return;
+            }
         }
 
         let Some(next_block_hashes) = self.next_block_hashes.get(&block_hash) else {
@@ -114,13 +116,6 @@ impl Handler<ExecutorIncomingReceipts> for ChunkExecutorActor {
             return;
         };
         for next_block_hash in next_block_hashes.clone() {
-            // TODO(spice): Avoid storing the same incoming receipts several times.. With many
-            // forks we would be saving the same incoming receipts associated with different blocks
-            // which is redundant.
-            if let Err(err) = self.try_save_incoming_receipts(&block_hash, &next_block_hash) {
-                tracing::warn!(target: "chunk_executor", %block_hash, ?err, "failed to save incoming receipts");
-            }
-
             if let Err(err) = self.try_apply_chunks(&next_block_hash) {
                 tracing::error!(target: "chunk_executor", ?err, ?block_hash, "failed to apply chunk for block hash");
             };
@@ -143,10 +138,6 @@ impl Handler<ExecutorBlock> for ChunkExecutorActor {
 
         self.next_block_hashes.get_or_insert_mut(*prev_block_hash, || Vec::new()).push(block_hash);
 
-        if let Err(err) = self.try_save_incoming_receipts(&prev_block_hash, &block_hash) {
-            tracing::warn!(target: "chunk_executor", %prev_block_hash, ?err, "failed to save incoming receipts");
-        }
-
         if let Err(err) = self.try_apply_chunks(&block_hash) {
             tracing::error!(target: "chunk_executor", ?err, ?block_hash, "failed to apply chunk for block hash");
         };
@@ -156,41 +147,39 @@ impl Handler<ExecutorBlock> for ChunkExecutorActor {
 impl ChunkExecutorActor {
     #[instrument(target = "chunk_executor", level = "debug", skip_all, fields(%block_hash))]
     fn try_apply_chunks(&mut self, block_hash: &CryptoHash) -> Result<(), Error> {
-        let epoch_id = self.epoch_manager.get_epoch_id(block_hash)?;
         let block = self.chain_store.get_block(block_hash)?;
         let header = block.header();
         let prev_block_hash = header.prev_hash();
-        // Genesis block has no outgoing receipts.
-        if *prev_block_hash != self.genesis_hash {
-            for shard_id in self.epoch_manager.shard_ids(&epoch_id)? {
-                if self.shard_tracker.cares_about_shard_this_or_next_epoch(block_hash, shard_id)
-                    && !self.chain_store.incoming_receipts_exist(&block_hash, shard_id)?
-                {
+        let mut all_receipts: HashMap<ShardId, Vec<ReceiptProof>> = HashMap::new();
+        let store = self.chain_store.store();
+        let prev_block_epoch_id = self.epoch_manager.get_epoch_id(prev_block_hash)?;
+        let all_shard_ids = self.epoch_manager.shard_ids(&prev_block_epoch_id)?;
+        for &shard_id in &all_shard_ids {
+            // TODO(spice-resharding): check if using `cares_about_shard_this_or_next_epoch`
+            // with shard_id from the prev block is correct in case of resharding
+            if self.shard_tracker.cares_about_shard_this_or_next_epoch(block_hash, shard_id) {
+                // Genesis block has no outgoing receipts.
+                if *prev_block_hash == self.genesis_hash {
+                    all_receipts.insert(shard_id, vec![]);
+                    continue;
+                }
+
+                let proofs = get_receipt_proofs_for_shard(&store, prev_block_hash, shard_id)?;
+                if proofs.len() != all_shard_ids.len() {
                     tracing::debug!(target: "chunk_executor", %block_hash, %prev_block_hash, "missing receipts to apply all tracked chunks for a block");
                     return Ok(());
                 }
+                all_receipts.insert(shard_id, proofs);
             }
         }
-        self.apply_chunks(block, SandboxStatePatch::default())
-    }
-
-    fn get_incoming_receipts(
-        &self,
-        block_hash: &CryptoHash,
-        prev_block_hash: &CryptoHash,
-        shard_id: ShardId,
-    ) -> Result<Arc<Vec<ReceiptProof>>, Error> {
-        // Genesis block has no outgoing receipts.
-        if *prev_block_hash == self.genesis_hash {
-            return Ok(Arc::new(Vec::new()));
-        }
-        self.chain_store.get_incoming_receipts(block_hash, shard_id)
+        self.apply_chunks(block, all_receipts, SandboxStatePatch::default())
     }
 
     // Logic here is based on Chain::apply_chunk_preprocessing
     fn apply_chunks(
         &mut self,
         block: Arc<Block>,
+        mut incoming_receipts: HashMap<ShardId, Vec<ReceiptProof>>,
         mut state_patch: SandboxStatePatch,
     ) -> Result<(), Error> {
         let block_hash = block.hash();
@@ -225,8 +214,9 @@ impl ChunkExecutorActor {
                 continue;
             }
             // TODO(spice-resharding): We may need to take resharding into account here.
-            let receipt_proofs = self.get_incoming_receipts(block_hash, prev_hash, shard_id)?;
-            let incoming_receipts = Some(&*receipt_proofs);
+            let receipt_proofs = incoming_receipts.get_mut(&shard_id).unwrap();
+            let shuffle_salt = block_hash;
+            shuffle_receipt_proofs(receipt_proofs, shuffle_salt);
 
             let storage_context =
                 StorageContext { storage_data_source: StorageDataSource::Db, state_patch };
@@ -241,7 +231,7 @@ impl ChunkExecutorActor {
                 shard_index,
                 &prev_block,
                 ApplyChunksMode::IsCaughtUp,
-                incoming_receipts,
+                receipt_proofs,
                 storage_context,
             );
             match job {
@@ -288,6 +278,9 @@ impl ChunkExecutorActor {
             results,
             should_save_state_transition_data,
         )?;
+        for (shard_id, receipt_proofs) in incoming_receipts {
+            chain_update.save_incoming_receipt(block.hash(), shard_id, Arc::new(receipt_proofs));
+        }
         chain_update.commit()?;
         Ok(())
     }
@@ -307,7 +300,7 @@ impl ChunkExecutorActor {
         shard_index: ShardIndex,
         prev_block: &Block,
         mode: ApplyChunksMode,
-        incoming_receipts: Option<&Vec<ReceiptProof>>,
+        incoming_receipts: &[ReceiptProof],
         storage_context: StorageContext,
     ) -> Result<Option<UpdateShardJob>, Error> {
         let prev_block_hash = prev_block.hash();
@@ -330,7 +323,7 @@ impl ChunkExecutorActor {
             let chunk = get_chunk_clone_from_header(&self.chain_store, chunk_header)?;
             let tx_valid_list =
                 self.chain_store.compute_transaction_validity(prev_block.header(), &chunk);
-            let receipts = collect_receipts(incoming_receipts.unwrap());
+            let receipts = collect_receipts(incoming_receipts);
 
             let shard_uid = &shard_context.shard_uid;
             let chunk_extra = self.chain_store.get_chunk_extra(prev_block_hash, shard_uid)?;
@@ -394,65 +387,6 @@ impl ChunkExecutorActor {
             DoomslugThresholdMode::NoApprovals,
         )
     }
-
-    /// Returns keys from block_receipts_cache for prev_block_hash that correspond to all incoming
-    /// receipts that we care about grouped by destination shard id.
-    /// Returns None if some of the receipts are still missing.
-    fn all_incoming_receipts_keys(
-        &mut self,
-        prev_block_hash: &CryptoHash,
-        block_hash: &CryptoHash,
-    ) -> Result<Option<Vec<(ShardId, ShardId)>>, Error> {
-        let Some(block_receipts) = self.block_receipts_cache.get(prev_block_hash) else {
-            return Ok(None);
-        };
-        let epoch_id = self.epoch_manager.get_epoch_id(prev_block_hash)?;
-        let shard_ids = self.epoch_manager.shard_ids(&epoch_id)?;
-
-        let mut keys = Vec::<(ShardId, ShardId)>::new();
-        for to_shard_id in &shard_ids {
-            // We cannot filter out correctly when receiving receipts since we may receive them
-            // before we know about the corresponding block and can decide which receipts we care
-            // about.
-            if !self.shard_tracker.cares_about_shard_this_or_next_epoch(&block_hash, *to_shard_id) {
-                continue;
-            }
-            for from_shard_id in &shard_ids {
-                if !block_receipts.contains_key(&(*from_shard_id, *to_shard_id)) {
-                    return Ok(None);
-                }
-                keys.push((*from_shard_id, *to_shard_id));
-            }
-        }
-        Ok(Some(keys))
-    }
-
-    #[instrument(target = "chunk_executor", level = "debug", skip_all, fields(%prev_block_hash, %block_hash))]
-    fn try_save_incoming_receipts(
-        &mut self,
-        prev_block_hash: &CryptoHash,
-        block_hash: &CryptoHash,
-    ) -> Result<(), Error> {
-        let Some(receipt_keys) = self.all_incoming_receipts_keys(prev_block_hash, block_hash)?
-        else {
-            tracing::debug!(target: "chunk_executor", ?prev_block_hash, ?block_hash, "haven't received all receipts yet");
-            return Ok(());
-        };
-
-        let mut block_receipts = self.block_receipts_cache.get(&prev_block_hash).unwrap().clone();
-        let mut chain_update = self.chain_update();
-        for keys in receipt_keys.chunk_by(|a, b| a.1 == b.1) {
-            let to_shard_id = keys[0].1;
-            let mut proofs = keys.iter().filter_map(|key| block_receipts.remove(key)).collect();
-            let shuffle_salt = block_hash;
-            shuffle_receipt_proofs(&mut proofs, shuffle_salt);
-
-            tracing::debug!(target: "chunk_executor", %prev_block_hash, ?to_shard_id, ?proofs, "saving incoming receipts");
-            chain_update.save_incoming_receipt(&block_hash, to_shard_id, Arc::new(proofs));
-        }
-        chain_update.commit()?;
-        Ok(())
-    }
 }
 
 /// Returns receipt proofs for specified chunk.
@@ -474,4 +408,30 @@ fn make_outgoing_receipts_proofs(
         result.push(ReceiptProof(receipts, shard_proof));
     }
     Ok(result)
+}
+
+fn save_receipt_proof(
+    store: &Store,
+    block_hash: &CryptoHash,
+    receipt_proof: &ReceiptProof,
+) -> Result<(), std::io::Error> {
+    let &ReceiptProof(_, ShardProof { from_shard_id, to_shard_id, .. }) = receipt_proof;
+    let key = get_receipt_proof_key(block_hash, from_shard_id, to_shard_id);
+    let value = borsh::to_vec(&receipt_proof)?;
+    let mut store_update = store.store_update();
+    store_update.set(DBCol::receipt_proofs(), &key, &value);
+    store_update.commit()?;
+    Ok(())
+}
+
+fn get_receipt_proofs_for_shard(
+    store: &Store,
+    block_hash: &CryptoHash,
+    to_shard_id: ShardId,
+) -> Result<Vec<ReceiptProof>, std::io::Error> {
+    let prefix = get_receipt_proof_target_shard_prefix(block_hash, to_shard_id);
+    store
+        .iter_prefix_ser::<ReceiptProof>(DBCol::receipt_proofs(), &prefix)
+        .map(|res| res.map(|kv| kv.1))
+        .collect()
 }

--- a/chain/epoch-manager/Cargo.toml
+++ b/chain/epoch-manager/Cargo.toml
@@ -38,7 +38,9 @@ near-chain-configs = { workspace = true, features = ["test_genesis"] }
 
 [features]
 default = ["near-primitives/rand"]
-protocol_feature_spice = []
+protocol_feature_spice = [
+    "near-store/protocol_feature_spice"
+]
 nightly = [
     "near-chain-configs/nightly",
     "near-o11y/nightly",

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -187,7 +187,6 @@ pub fn get_receipt_proof_key(
     const BYTES_LEN: usize = size_of::<CryptoHash>() + size_of::<ShardId>() + size_of::<ShardId>();
     let mut res = Vec::with_capacity(BYTES_LEN);
     res.extend_from_slice(block_hash.as_ref());
-    // append target shard first to enable prefix queries
     res.extend_from_slice(&to_shard_id.to_le_bytes());
     res.extend_from_slice(&from_shard_id.to_le_bytes());
     res
@@ -197,7 +196,7 @@ pub fn get_receipt_proof_target_shard_prefix(
     block_hash: &CryptoHash,
     to_shard_id: ShardId,
 ) -> Vec<u8> {
-    const BYTES_LEN: usize = size_of::<CryptoHash>() + size_of::<ShardId>() + size_of::<ShardId>();
+    const BYTES_LEN: usize = size_of::<CryptoHash>() + size_of::<ShardId>();
     let mut res = Vec::with_capacity(BYTES_LEN);
     res.extend_from_slice(block_hash.as_ref());
     res.extend_from_slice(&to_shard_id.to_le_bytes());

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -179,6 +179,31 @@ pub fn get_block_shard_id(block_hash: &CryptoHash, shard_id: ShardId) -> Vec<u8>
     res
 }
 
+pub fn get_receipt_proof_key(
+    block_hash: &CryptoHash,
+    from_shard_id: ShardId,
+    to_shard_id: ShardId,
+) -> Vec<u8> {
+    const BYTES_LEN: usize = size_of::<CryptoHash>() + size_of::<ShardId>() + size_of::<ShardId>();
+    let mut res = Vec::with_capacity(BYTES_LEN);
+    res.extend_from_slice(block_hash.as_ref());
+    // append target shard first to enable prefix queries
+    res.extend_from_slice(&to_shard_id.to_le_bytes());
+    res.extend_from_slice(&from_shard_id.to_le_bytes());
+    res
+}
+
+pub fn get_receipt_proof_target_shard_prefix(
+    block_hash: &CryptoHash,
+    to_shard_id: ShardId,
+) -> Vec<u8> {
+    const BYTES_LEN: usize = size_of::<CryptoHash>() + size_of::<ShardId>() + size_of::<ShardId>();
+    let mut res = Vec::with_capacity(BYTES_LEN);
+    res.extend_from_slice(block_hash.as_ref());
+    res.extend_from_slice(&to_shard_id.to_le_bytes());
+    res
+}
+
 pub fn get_block_shard_id_rev(
     key: &[u8],
 ) -> Result<(CryptoHash, ShardId), Box<dyn std::error::Error + Send + Sync>> {

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -102,3 +102,6 @@ protocol_schema = [
     "near-parameters/protocol_schema",
     "near-schema-checker-lib/protocol_schema",
 ]
+protocol_feature_spice = [
+    "near-primitives/protocol_feature_spice",
+]

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -282,14 +282,6 @@ impl ChainStoreAdapter {
         )
     }
 
-    pub fn incoming_receipts_exist(
-        &self,
-        block_hash: &CryptoHash,
-        shard_id: ShardId,
-    ) -> Result<bool, Error> {
-        Ok(self.store.exists(DBCol::IncomingReceipts, &get_block_shard_id(block_hash, shard_id))?)
-    }
-
     pub fn get_incoming_receipts(
         &self,
         block_hash: &CryptoHash,

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -329,9 +329,11 @@ pub enum DBCol {
     /// - *Rows*: BlockShardId (BlockHash || ShardId) - 40 bytes
     /// - *Column type*: `ChunkApplyStats`
     ChunkApplyStats,
-    /// Mapping from Block + Target Shard + Source Shard to the corresponding receipt proof
-    /// Each proof might prove multiple receipts.
-    /// - *Rows*: (block, shard, shard)
+    /// Mapping from Block Hash + Target Shard Id + Source Shard Id to Receipt Proof.
+    /// The receipts result from applying the chunk on the source shard of the corresponding block.
+    /// The key includes the target shard first to enable prefix queries for retrieving all incoming
+    /// receipts to the given shard.
+    /// - *Rows*: (BlockHash || ShardId || ShardId)
     /// - *Content type*: `near_primitives::sharding::ReceiptProof`
     #[cfg(feature = "protocol_feature_spice")]
     ReceiptProofs,

--- a/nearcore/Cargo.toml
+++ b/nearcore/Cargo.toml
@@ -100,6 +100,7 @@ json_rpc = ["near-jsonrpc", "near-jsonrpc-primitives"]
 protocol_feature_spice = [
     "near-epoch-manager/protocol_feature_spice",
     "near-primitives/protocol_feature_spice",
+    "near-store/protocol_feature_spice",
 ]
 
 nightly = [

--- a/test-loop-tests/Cargo.toml
+++ b/test-loop-tests/Cargo.toml
@@ -50,6 +50,7 @@ protocol_feature_spice = [
     "near-client/protocol_feature_spice",
     "near-epoch-manager/protocol_feature_spice",
     "nearcore/protocol_feature_spice",
+    "near-store/protocol_feature_spice",
 ]
 test_features = [
     "nearcore/test_features",

--- a/test-loop-tests/src/setup/setup.rs
+++ b/test-loop-tests/src/setup/setup.rs
@@ -300,7 +300,6 @@ pub fn setup_client(
         shard_tracker.clone(),
         network_adapter.as_multi_sender(),
         NonZeroUsize::new(1000).unwrap(),
-        NonZeroUsize::new(1000).unwrap(),
     );
 
     let chunk_executor_sender = test_loop.data.register_actor(


### PR DESCRIPTION
This PR adds `DBCol::ReceiptProofs` database column to store incoming receipts in SPICE.
Conditional compilation with `#[cfg(feature = "protocol_feature_spice")]` is needed here to prevent database changes in the stable protocol version.
Note that in SPICE we don't use `IncomingReceipts` column since it is only needed when handling missing chunks (see `get_incoming_receipts` fn usage).
`cargo test -p test-loop-tests --features=protocol_feature_spice -- spice` still passes.