### PR TITLE
fix: canonicalize wasmtime NaNs

### DIFF
--- a/runtime/near-vm-runner/src/tests/runtime_errors.rs
+++ b/runtime/near-vm-runner/src/tests/runtime_errors.rs
@@ -635,7 +635,6 @@ fn test_nan_sign() {
 
     test_builder()
         .wat(code)
-        .skip_wasmtime()
         .expects(&[
             expect![[r#"
                 VMOutcome: balance 4 storage_usage 12 return data None burnt gas 110433335 used gas 110433335

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -154,7 +154,8 @@ pub(crate) fn default_wasmtime_config(c: &Config) -> wasmtime::Config {
         .signals_based_traps(true)
         // Configure linear memories such that explicit bounds-checking can be elided.
         .memory_reservation(1 << 32)
-        .memory_guard_size(1 << 32);
+        .memory_guard_size(1 << 32)
+        .cranelift_nan_canonicalization(true);
     config
 }
 


### PR DESCRIPTION
The Wasmer implementation canonicalizes NaNs, so we're matching that behaviour on the Wasmtime side.