### PR TITLE
[resharding] Set trie_state_resharding_status before flat storage resharding

### DIFF
--- a/chain/chain/src/resharding/resharding_actor.rs
+++ b/chain/chain/src/resharding/resharding_actor.rs
@@ -202,6 +202,13 @@ impl ReshardingActor {
     ) {
         self.resharding_started.insert(parent_shard_uid);
 
+        if let Err(err) =
+            self.trie_state_resharder.initialize_trie_state_resharding_status(&resharding_event)
+        {
+            tracing::error!(target: "resharding", ?err, "Failed to initialize trie state resharding status");
+            return;
+        }
+
         // This is a long running task and would block the actor
         if let Err(err) = self.flat_storage_resharder.start_resharding_blocking(&resharding_event) {
             tracing::error!(target: "resharding", ?err, "Failed to start flat storage resharding");


### PR DESCRIPTION
Related to issue in 2.7 release related to resuming trie resharding

[#nearone/private > resume trie resharding issue (2.7 release)](https://near.zulipchat.com/#narrow/channel/308695-nearone.2Fprivate/topic/resume.20trie.20resharding.20issue.20.282.2E7.20release.29/with/524478858)

More context on the thread, but high level, we want to set the trie_state_resharding_status at the beginning of resharding so that a future call to resume resharding can read it.