### PR TITLE
fix - skip resharding when children are not tracked in next epoch

### DIFF
--- a/chain/chain/src/resharding/manager.rs
+++ b/chain/chain/src/resharding/manager.rs
@@ -108,8 +108,27 @@ impl ReshardingManager {
             return Ok(());
         }
 
+        let tracked_children_shards = split_shard_event
+            .children_shards()
+            .iter()
+            .filter(|child_shard_uid| {
+                self.shard_tracker.cares_about_shard_this_or_next_epoch(
+                    self.my_account_id.as_ref(),
+                    &split_shard_event.resharding_block.hash,
+                    child_shard_uid.shard_id(),
+                    true,
+                )
+            })
+            .copied()
+            .collect_vec();
+
+        if tracked_children_shards.is_empty() {
+            tracing::debug!(target: "resharding", "Not tracking any child shards, skipping");
+            return Ok(());
+        }
+
         // Reshard the State column by setting ShardUId mapping from children to ancestor.
-        self.set_state_shard_uid_mapping(&split_shard_event)?;
+        self.set_state_shard_uid_mapping(&split_shard_event, &tracked_children_shards)?;
 
         // Create temporary children memtries by freezing parent memtrie and referencing it.
         self.process_memtrie_resharding_storage_update(
@@ -132,20 +151,13 @@ impl ReshardingManager {
     fn set_state_shard_uid_mapping(
         &self,
         split_shard_event: &ReshardingSplitShardParams,
+        tracked_children: &[ShardUId],
     ) -> io::Result<()> {
         let mut store_update = self.store.trie_store().store_update();
         let parent_shard_uid = split_shard_event.parent_shard;
         let parent_shard_uid_prefix = get_shard_uid_mapping(&self.store, parent_shard_uid);
-        for child_shard_uid in split_shard_event.children_shards() {
-            // Set the mapping only if we are tracking the child shard.
-            if self.shard_tracker.cares_about_shard_this_or_next_epoch(
-                self.my_account_id.as_ref(),
-                &split_shard_event.resharding_block.hash,
-                child_shard_uid.shard_id(),
-                true,
-            ) {
-                store_update.set_shard_uid_mapping(child_shard_uid, parent_shard_uid_prefix);
-            }
+        for &child_shard_uid in tracked_children {
+            store_update.set_shard_uid_mapping(child_shard_uid, parent_shard_uid_prefix);
         }
         store_update.commit()
     }

--- a/test-loop-tests/src/tests/resharding_v3.rs
+++ b/test-loop-tests/src/tests/resharding_v3.rs
@@ -939,6 +939,44 @@ fn slow_test_resharding_v3_sync_child() {
     );
 }
 
+// Track parent shard before resharding, but do not track any child shard after resharding.
+// This test verifies that resharding is completely skipped when no children are tracked.
+#[test]
+fn slow_test_resharding_v3_skip_when_no_children_tracked() {
+    let account_in_stable_shard: AccountId = "account0".parse().unwrap();
+    let split_boundary_account: AccountId = NEW_BOUNDARY_ACCOUNT.parse().unwrap();
+    let base_shard_layout = get_base_shard_layout();
+    let new_shard_layout =
+        ShardLayout::derive_shard_layout(&base_shard_layout, split_boundary_account.clone());
+    let parent_shard_id = base_shard_layout.account_id_to_shard_id(&split_boundary_account);
+    let unrelated_shard_id = new_shard_layout.account_id_to_shard_id(&account_in_stable_shard);
+
+    // Track parent before resharding, then immediately switch to unrelated shard (no children tracked).
+    let tracked_shard_sequence =
+        vec![parent_shard_id, parent_shard_id, unrelated_shard_id, unrelated_shard_id];
+    let num_clients = 8;
+    let num_epochs_to_wait = DEFAULT_TESTLOOP_NUM_EPOCHS_TO_WAIT;
+    let tracked_shard_schedule = TrackedShardSchedule {
+        client_index: (num_clients - 1) as usize,
+        schedule: shard_sequence_to_schedule(tracked_shard_sequence, num_epochs_to_wait),
+    };
+
+    let parent_shard_uid = base_shard_layout.account_id_to_shard_uid(&split_boundary_account);
+
+    test_resharding_v3_base(
+        TestReshardingParametersBuilder::default()
+            .num_clients(num_clients)
+            .tracked_shard_schedule(Some(tracked_shard_schedule.clone()))
+            .add_loop_action(
+                crate::utils::resharding::check_resharding_skipped_when_no_children_tracked(
+                    parent_shard_uid,
+                    tracked_shard_schedule,
+                ),
+            )
+            .build(),
+    );
+}
+
 #[test]
 fn slow_test_resharding_v3_track_all_shards() {
     test_resharding_v3_base(


### PR DESCRIPTION
Do not perform resharding at all if the node does not track any children shard in next epoch.

Added:
- Fix
- Test