### PR TITLE
refactor: remove PrepareTransactionsChunkContext

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -1,8 +1,8 @@
 use crate::Error;
 use crate::types::{
     ApplyChunkBlockContext, ApplyChunkResult, ApplyChunkShardContext,
-    PrepareTransactionsBlockContext, PrepareTransactionsChunkContext, PrepareTransactionsLimit,
-    PreparedTransactions, RuntimeAdapter, RuntimeStorageConfig, StorageDataSource, Tip,
+    PrepareTransactionsBlockContext, PrepareTransactionsLimit, PreparedTransactions,
+    RuntimeAdapter, RuntimeStorageConfig, StorageDataSource, Tip,
 };
 use borsh::BorshDeserialize;
 use errors::FromStateViewerErrors;
@@ -577,14 +577,13 @@ impl RuntimeAdapter for NightshadeRuntime {
     fn prepare_transactions(
         &self,
         storage_config: RuntimeStorageConfig,
-        chunk: PrepareTransactionsChunkContext,
+        shard_id: ShardId,
         prev_block: PrepareTransactionsBlockContext,
         transaction_groups: &mut dyn TransactionGroupIterator,
         chain_validate: &dyn Fn(&SignedTransaction) -> bool,
         time_limit: Option<Duration>,
     ) -> Result<PreparedTransactions, Error> {
         let start_time = std::time::Instant::now();
-        let PrepareTransactionsChunkContext { shard_id, .. } = chunk;
 
         let epoch_id = self.epoch_manager.get_epoch_id_from_prev_block(&prev_block.block_hash)?;
         let protocol_version = self.epoch_manager.get_epoch_protocol_version(&epoch_id)?;

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -1406,10 +1406,7 @@ fn prepare_transactions(
 
     env.runtime.prepare_transactions(
         storage_config,
-        PrepareTransactionsChunkContext {
-            shard_id,
-            gas_limit: env.runtime.genesis_config.gas_limit,
-        },
+        shard_id,
         PrepareTransactionsBlockContext {
             next_gas_price: env.runtime.genesis_config.min_gas_price,
             height: env.head.height,

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -369,10 +369,6 @@ impl From<&Block> for PrepareTransactionsBlockContext {
         }
     }
 }
-pub struct PrepareTransactionsChunkContext {
-    pub shard_id: ShardId,
-    pub gas_limit: Gas,
-}
 
 /// Bridge between the chain and the runtime.
 /// Main function is to update state given transactions.
@@ -435,7 +431,7 @@ pub trait RuntimeAdapter: Send + Sync {
     fn prepare_transactions(
         &self,
         storage: RuntimeStorageConfig,
-        chunk: PrepareTransactionsChunkContext,
+        shard_id: ShardId,
         prev_block: PrepareTransactionsBlockContext,
         transaction_groups: &mut dyn TransactionGroupIterator,
         chain_validate: &dyn Fn(&SignedTransaction) -> bool,

--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -2,9 +2,7 @@ use crate::debug::PRODUCTION_TIMES_CACHE_SIZE;
 use crate::metrics;
 use itertools::Itertools;
 use near_async::time::{Clock, Duration, Instant};
-use near_chain::types::{
-    PrepareTransactionsChunkContext, PreparedTransactions, RuntimeAdapter, RuntimeStorageConfig,
-};
+use near_chain::types::{PreparedTransactions, RuntimeAdapter, RuntimeStorageConfig};
 use near_chain::{Block, Chain, ChainStore};
 use near_chain_configs::MutableConfigValue;
 use near_chunks::client::ShardedTransactionPool;
@@ -385,7 +383,7 @@ impl ChunkProducer {
             };
             self.runtime_adapter.prepare_transactions(
                 storage_config,
-                PrepareTransactionsChunkContext { shard_id, gas_limit: chunk_extra.gas_limit() },
+                shard_id,
                 prev_block.into(),
                 &mut iter,
                 chain_validate,


### PR DESCRIPTION
Since congestion control, transactions gas limit is decided based on runtime config + congestion. Total chunk gas limit is used only when receipts are executed, here the field was simply not used. 

This is convenient for switching to prev prev block.