### PR TITLE
[refactor] 1/n Introduce chunk iter_new, iter_old

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3053,8 +3053,8 @@ impl Chain {
         let chunk_headers = &block.chunks();
         let mut update_shard_args = vec![];
 
-        for chunk_header in chunk_headers.iter() {
-            let shard_id = chunk_header.shard_id();
+        for (shard_index, chunk_header) in chunk_headers.iter().enumerate() {
+            let shard_id = shard_layout.get_shard_id(shard_index)?;
             let block_context = Self::get_apply_chunk_block_context_from_block_header(
                 block.header(),
                 &chunk_headers,

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -56,7 +56,7 @@ use near_epoch_manager::shard_assignment::shard_id_to_uid;
 use near_epoch_manager::shard_tracker::ShardTracker;
 use near_epoch_manager::validate::validate_optimistic_block_relevant;
 use near_primitives::block::{
-    Block, BlockValidityError, ChunkType, Chunks, Tip, compute_bp_hash_from_validator_stakes,
+    Block, BlockValidityError, Chunks, Tip, compute_bp_hash_from_validator_stakes,
 };
 use near_primitives::block_header::BlockHeader;
 use near_primitives::challenge::{ChunkProofs, MaybeEncodedShardChunk};
@@ -3055,13 +3055,11 @@ impl Chain {
 
         for chunk_header in chunk_headers.iter() {
             let shard_id = chunk_header.shard_id();
-            let is_new_chunk = matches!(chunk_header, ChunkType::New(_));
-
             let block_context = Self::get_apply_chunk_block_context_from_block_header(
                 block.header(),
                 &chunk_headers,
                 prev_block.header(),
-                is_new_chunk,
+                chunk_header.is_new_chunk(),
             )?;
 
             let cached_shard_update_key =

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -56,7 +56,7 @@ use near_epoch_manager::shard_assignment::shard_id_to_uid;
 use near_epoch_manager::shard_tracker::ShardTracker;
 use near_epoch_manager::validate::validate_optimistic_block_relevant;
 use near_primitives::block::{
-    Block, BlockValidityError, Chunks, MaybeNew, Tip, compute_bp_hash_from_validator_stakes,
+    Block, BlockValidityError, ChunkType, Chunks, Tip, compute_bp_hash_from_validator_stakes,
 };
 use near_primitives::block_header::BlockHeader;
 use near_primitives::challenge::{ChunkProofs, MaybeEncodedShardChunk};
@@ -1166,10 +1166,7 @@ impl Chain {
         }
         let mut receipt_proofs_by_shard_id = HashMap::new();
 
-        for chunk_header in chunks.iter() {
-            let MaybeNew::New(chunk_header) = chunk_header else {
-                continue;
-            };
+        for chunk_header in chunks.iter_new() {
             let partial_encoded_chunk =
                 self.chain_store.get_partial_chunk(&chunk_header.chunk_hash()).unwrap();
             for receipt in partial_encoded_chunk.prev_outgoing_receipts() {
@@ -3056,9 +3053,9 @@ impl Chain {
         let chunk_headers = &block.chunks();
         let mut update_shard_args = vec![];
 
-        for (shard_index, chunk_header) in chunk_headers.iter().enumerate() {
-            let shard_id = shard_layout.get_shard_id(shard_index)?;
-            let is_new_chunk = matches!(chunk_header, MaybeNew::New(_));
+        for chunk_header in chunk_headers.iter() {
+            let shard_id = chunk_header.shard_id();
+            let is_new_chunk = matches!(chunk_header, ChunkType::New(_));
 
             let block_context = Self::get_apply_chunk_block_context_from_block_header(
                 block.header(),

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -6,10 +6,7 @@ use near_async::time::{Clock, Duration, FakeClock, Utc};
 use near_o11y::testonly::init_test_logger;
 #[cfg(feature = "test_features")]
 use near_primitives::optimistic_block::OptimisticBlock;
-use near_primitives::{
-    block::MaybeNew, hash::CryptoHash, sharding::ShardChunkHeader, test_utils::TestBlockBuilder,
-    version::PROTOCOL_VERSION,
-};
+use near_primitives::{hash::CryptoHash, test_utils::TestBlockBuilder, version::PROTOCOL_VERSION};
 use num_rational::Ratio;
 use std::sync::Arc;
 
@@ -271,28 +268,13 @@ fn block_chunk_headers_iter() {
     Arc::make_mut(&mut block).set_chunks(fake_headers);
 
     let chunks = block.chunks();
+    let old_headers_count = chunks.iter_old().count();
+    let new_headers_count = chunks.iter_new().count();
+    let raw_headers_count = chunks.iter().count();
 
-    let new_headers: Vec<&ShardChunkHeader> = chunks
-        .iter()
-        .filter_map(|chunk| match chunk {
-            MaybeNew::New(chunk) => Some(chunk),
-            _ => None,
-        })
-        .collect();
-
-    let old_headers: Vec<&ShardChunkHeader> = chunks
-        .iter()
-        .filter_map(|chunk| match chunk {
-            MaybeNew::Old(chunk) => Some(chunk),
-            _ => None,
-        })
-        .collect();
-
-    let raw_headers = chunks.iter_raw();
-
-    assert_eq!(old_headers.len(), 8);
-    assert_eq!(new_headers.len(), 8);
-    assert_eq!(raw_headers.count(), old_headers.len() + new_headers.len());
+    assert_eq!(old_headers_count, 8);
+    assert_eq!(new_headers_count, 8);
+    assert_eq!(raw_headers_count, old_headers_count + new_headers_count);
 }
 
 /// Check that if block is processed while optimistic block is in processing,

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -360,8 +360,9 @@ impl ClientActorInner {
                 block
                     .chunks()
                     .iter()
-                    .map(|chunk| {
-                        let shard_id = chunk.shard_id();
+                    .enumerate()
+                    .map(|(shard_index, chunk)| {
+                        let shard_id = shard_layout.get_shard_id(shard_index).unwrap();
                         let state_root_node = self.client.runtime_adapter.get_state_root_node(
                             shard_id,
                             epoch_start_block_header.hash(),

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -355,38 +355,31 @@ impl ClientActorInner {
             None => epoch_start_block_header.hash(),
         };
 
-        let shards_size_and_parts: Vec<(u64, u64)> = if let Ok(block) =
-            self.client.chain.get_block(hash_to_compute_shard_sizes)
-        {
-            block
-                .chunks()
-                .iter_raw()
-                .enumerate()
-                .map(|(shard_index, chunk)| {
-                    let shard_id = shard_layout.get_shard_id(shard_index);
-                    let Ok(shard_id) = shard_id else {
-                        tracing::error!("Failed to get shard id for shard index {}", shard_index);
-                        return (0, 0);
-                    };
-
-                    let state_root_node = self.client.runtime_adapter.get_state_root_node(
-                        shard_id,
-                        epoch_start_block_header.hash(),
-                        &chunk.prev_state_root(),
-                    );
-                    if let Ok(state_root_node) = state_root_node {
-                        (
-                            state_root_node.memory_usage,
-                            get_num_state_parts(state_root_node.memory_usage),
-                        )
-                    } else {
-                        (0, 0)
-                    }
-                })
-                .collect()
-        } else {
-            epoch_start_block_header.chunk_mask().iter().map(|_| (0, 0)).collect()
-        };
+        let shards_size_and_parts: Vec<(u64, u64)> =
+            if let Ok(block) = self.client.chain.get_block(hash_to_compute_shard_sizes) {
+                block
+                    .chunks()
+                    .iter()
+                    .map(|chunk| {
+                        let shard_id = chunk.shard_id();
+                        let state_root_node = self.client.runtime_adapter.get_state_root_node(
+                            shard_id,
+                            epoch_start_block_header.hash(),
+                            &chunk.prev_state_root(),
+                        );
+                        if let Ok(state_root_node) = state_root_node {
+                            (
+                                state_root_node.memory_usage,
+                                get_num_state_parts(state_root_node.memory_usage),
+                            )
+                        } else {
+                            (0, 0)
+                        }
+                    })
+                    .collect()
+            } else {
+                epoch_start_block_header.chunk_mask().iter().map(|_| (0, 0)).collect()
+            };
 
         let state_header_exists: Vec<bool> = shard_layout
             .shard_ids()

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -24,11 +24,10 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use itertools::Itertools;
 #[cfg(feature = "clock")]
 use near_primitives_core::types::ProtocolVersion;
-use near_primitives_core::types::ShardIndex;
 use near_schema_checker_lib::ProtocolSchema;
 use primitive_types::U256;
 use std::collections::BTreeMap;
-use std::ops::Index;
+use std::ops::Deref;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum BlockValidityError {
@@ -523,21 +522,39 @@ impl Block {
 }
 
 #[derive(Clone)]
-pub enum MaybeNew<'a, T> {
-    New(&'a T),
-    Old(&'a T),
+pub enum ChunkType<'a> {
+    New(&'a ShardChunkHeader),
+    Old(&'a ShardChunkHeader),
 }
 
-fn annotate_chunk(
-    chunk: &ShardChunkHeader,
-    block_height: BlockHeight,
-) -> MaybeNew<ShardChunkHeader> {
-    if chunk.is_new_chunk(block_height) { MaybeNew::New(chunk) } else { MaybeNew::Old(chunk) }
+/// Implements Deref for ChunkType to allow access to ShardChunkHeader methods directly.
+impl Deref for ChunkType<'_> {
+    type Target = ShardChunkHeader;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            ChunkType::New(chunk) => chunk,
+            ChunkType::Old(chunk) => chunk,
+        }
+    }
 }
 
-pub enum ChunksCollection<'a> {
+// For BlockV1, we store the chunks in a Vec, else we use a slice reference.
+enum ChunksCollection<'a> {
     V1(Vec<ShardChunkHeader>),
     V2(&'a [ShardChunkHeader]),
+}
+
+/// Implements Deref for ChunksCollection to allow access to [ShardChunkHeader] methods directly.
+impl Deref for ChunksCollection<'_> {
+    type Target = [ShardChunkHeader];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            ChunksCollection::V1(chunks) => chunks.as_ref(),
+            ChunksCollection::V2(chunks) => chunks,
+        }
+    }
 }
 
 pub struct Chunks<'a> {
@@ -545,15 +562,12 @@ pub struct Chunks<'a> {
     block_height: BlockHeight,
 }
 
-impl<'a> Index<ShardIndex> for Chunks<'a> {
-    type Output = ShardChunkHeader;
+/// Implements Deref for Chunks to allow access to [ShardChunkHeader] methods directly.
+impl Deref for Chunks<'_> {
+    type Target = [ShardChunkHeader];
 
-    /// Deprecated. Please use get instead, it's safer.
-    fn index(&self, index: usize) -> &Self::Output {
-        match &self.chunks {
-            ChunksCollection::V1(chunks) => &chunks[index],
-            ChunksCollection::V2(chunks) => &chunks[index],
-        }
+    fn deref(&self) -> &Self::Target {
+        &self.chunks
     }
 }
 
@@ -578,46 +592,36 @@ impl<'a> Chunks<'a> {
         Self { chunks: ChunksCollection::V2(chunk_headers), block_height }
     }
 
-    pub fn len(&self) -> usize {
-        match &self.chunks {
-            ChunksCollection::V1(chunks) => chunks.len(),
-            ChunksCollection::V2(chunks) => chunks.len(),
-        }
-    }
-
-    /// Deprecated, use `iter` instead. `iter_raw` is available if there is no need to
+    /// Deprecated, use `iter` instead. `iter_all` is available if there is no need to
     /// distinguish between old and new headers.
     pub fn iter_deprecated(&'a self) -> Box<dyn Iterator<Item = &'a ShardChunkHeader> + 'a> {
-        match &self.chunks {
-            ChunksCollection::V1(chunks) => Box::new(chunks.iter()),
-            ChunksCollection::V2(chunks) => Box::new(chunks.iter()),
-        }
+        Box::new(self.chunks.iter())
     }
 
+    /// Returns an iterator over all shard chunk headers, distinguishing between new and old chunks.
+    pub fn iter(&'a self) -> Box<dyn Iterator<Item = ChunkType<'a>> + 'a> {
+        Box::new(self.chunks.iter().map(|chunk| {
+            if chunk.is_new_chunk(self.block_height) {
+                ChunkType::New(chunk)
+            } else {
+                ChunkType::Old(chunk)
+            }
+        }))
+    }
+
+    /// Returns an iterator over all shard chunk headers, regardless of whether they are new or old.
     pub fn iter_raw(&'a self) -> Box<dyn Iterator<Item = &'a ShardChunkHeader> + 'a> {
-        match &self.chunks {
-            ChunksCollection::V1(chunks) => Box::new(chunks.iter()),
-            ChunksCollection::V2(chunks) => Box::new(chunks.iter()),
-        }
+        Box::new(self.chunks.iter())
     }
 
-    /// Returns an iterator over the shard chunk headers, differentiating between new and old chunks.
-    pub fn iter(&'a self) -> Box<dyn Iterator<Item = MaybeNew<'a, ShardChunkHeader>> + 'a> {
-        match &self.chunks {
-            ChunksCollection::V1(chunks) => {
-                Box::new(chunks.iter().map(|chunk| annotate_chunk(chunk, self.block_height)))
-            }
-            ChunksCollection::V2(chunks) => {
-                Box::new(chunks.iter().map(|chunk| annotate_chunk(chunk, self.block_height)))
-            }
-        }
+    /// Returns an iterator over the shard chunk headers that are old chunks.
+    pub fn iter_old(&'a self) -> Box<dyn Iterator<Item = &'a ShardChunkHeader> + 'a> {
+        Box::new(self.chunks.iter().filter(|chunk| !chunk.is_new_chunk(self.block_height)))
     }
 
-    pub fn get(&self, index: ShardIndex) -> Option<&ShardChunkHeader> {
-        match &self.chunks {
-            ChunksCollection::V1(chunks) => chunks.get(index),
-            ChunksCollection::V2(chunks) => chunks.get(index),
-        }
+    /// Returns an iterator over the shard chunk headers that are new chunks.
+    pub fn iter_new(&'a self) -> Box<dyn Iterator<Item = &'a ShardChunkHeader> + 'a> {
+        Box::new(self.chunks.iter().filter(|chunk| chunk.is_new_chunk(self.block_height)))
     }
 
     pub fn min_height_included(&self) -> Option<BlockHeight> {
@@ -647,17 +651,11 @@ impl<'a> Chunks<'a> {
     pub fn block_bandwidth_requests(&self) -> BlockBandwidthRequests {
         let mut result = BTreeMap::new();
 
-        for chunk in self.iter() {
-            // It's okay to take bandwidth requests from a missing chunk,
-            // the chunk was missing so it didn't send anything and still
-            // wants to send out the same receipts.
-            let chunk = match chunk {
-                MaybeNew::New(new_chunk) => new_chunk,
-                MaybeNew::Old(missing_chunk) => missing_chunk,
-            };
-
+        // It's okay to take bandwidth requests from a missing chunk,
+        // the chunk was missing so it didn't send anything and still
+        // wants to send out the same receipts.
+        for chunk in self.iter_raw() {
             let shard_id = chunk.shard_id();
-
             if let Some(bandwidth_requests) = chunk.bandwidth_requests() {
                 result.insert(shard_id, bandwidth_requests.clone());
             }

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -539,6 +539,12 @@ impl Deref for ChunkType<'_> {
     }
 }
 
+impl ChunkType<'_> {
+    pub fn is_new_chunk(&self) -> bool {
+        matches!(self, ChunkType::New(_))
+    }
+}
+
 // For BlockV1, we store the chunks in a Vec, else we use a slice reference.
 enum ChunksCollection<'a> {
     V1(Vec<ShardChunkHeader>),

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -521,6 +521,10 @@ impl Block {
     }
 }
 
+/// Distinguishes between new and old chunks.
+/// Note: Some of the data of the cold chunk may be incompatible with the current protocol version.
+/// Example in case of resharding, if the child shard chunk is missing in the first block.
+/// the shard_id of the old chunk may be different from the shard_id of the new chunk.
 #[derive(Clone, Debug)]
 pub enum ChunkType<'a> {
     New(&'a ShardChunkHeader),

--- a/test-loop-tests/src/tests/bandwidth_scheduler.rs
+++ b/test-loop-tests/src/tests/bandwidth_scheduler.rs
@@ -32,7 +32,6 @@ use near_primitives::action::{Action, FunctionCallAction};
 use near_primitives::bandwidth_scheduler::{
     BandwidthRequest, BandwidthRequests, BandwidthSchedulerParams,
 };
-use near_primitives::block::MaybeNew;
 use near_primitives::congestion_info::CongestionControl;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{
@@ -270,10 +269,7 @@ fn analyze_workload_blocks(
             .unwrap();
 
         // Go over all new chunks in a block
-        for chunk_header in block.chunks().iter() {
-            let MaybeNew::New(new_chunk) = chunk_header else {
-                continue;
-            };
+        for new_chunk in block.chunks().iter_new() {
             let shard_id = new_chunk.shard_id();
             let shard_index = cur_shard_layout.get_shard_index(shard_id).unwrap();
             let shard_uid = ShardUId::new(cur_shard_layout.version(), shard_id);

--- a/test-loop-tests/src/tests/global_contracts_distribution.rs
+++ b/test-loop-tests/src/tests/global_contracts_distribution.rs
@@ -7,7 +7,6 @@ use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_client::Client;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::action::{GlobalContractDeployMode, GlobalContractIdentifier};
-use near_primitives::block::MaybeNew;
 use near_primitives::epoch_manager::EpochConfigStore;
 use near_primitives::receipt::ReceiptEnum;
 use near_primitives::shard_layout::ShardLayout;
@@ -87,10 +86,9 @@ fn test_global_receipt_distribution_at_resharding_boundary() {
             .shard_layout;
         assert_eq!(block_shard_layout, env.new_shard_layout);
         let chunks = block.chunks();
-        let MaybeNew::New(chunk_header) = chunks.iter().nth(0).unwrap() else {
-            panic!("expected new chunk");
-        };
-        let chunk = env.client().chain.get_chunk(&chunk_header.compute_hash()).unwrap();
+        // Expect new chunk
+        assert!(chunks[0].is_new_chunk(block.header().height()));
+        let chunk = env.client().chain.get_chunk(&chunks[0].compute_hash()).unwrap();
         let [distribution_receipt] = chunk
             .prev_outgoing_receipts()
             .iter()

--- a/test-loop-tests/src/tests/max_receipt_size.rs
+++ b/test-loop-tests/src/tests/max_receipt_size.rs
@@ -4,7 +4,6 @@ use near_async::time::Duration;
 use near_chain::{ReceiptFilter, get_incoming_receipts_for_shard};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::action::{Action, FunctionCallAction};
-use near_primitives::block::MaybeNew;
 use near_primitives::errors::{
     ActionError, ActionErrorKind, FunctionCallError, InvalidTxError, ReceiptValidationError,
     TxExecutionError,
@@ -388,10 +387,7 @@ fn assert_oversized_receipt_occurred(test_loop: &TestLoopV2, node_datas: &[NodeE
             .unwrap();
 
         // Go over all new chunks in a block
-        for chunk_header in block.chunks().iter() {
-            let MaybeNew::New(new_chunk) = chunk_header else {
-                continue;
-            };
+        for new_chunk in block.chunks().iter_new() {
             let shard_id = new_chunk.shard_id();
             let prev_shard_index = epoch_manager
                 .get_prev_shard_id_from_prev_hash(block.header().prev_hash(), shard_id)

--- a/tools/state-viewer/src/apply_chain_range.rs
+++ b/tools/state-viewer/src/apply_chain_range.rs
@@ -94,7 +94,7 @@ fn apply_block_from_range(
     let epoch_id = block.header().epoch_id();
     let shard_uid = shard_id_to_uid(epoch_manager, shard_id, epoch_id).unwrap();
     let shard_index = shard_id_to_index(epoch_manager, shard_id, epoch_id).unwrap();
-    assert!(block.chunks().len() > 0);
+    assert!(!block.chunks().is_empty());
     let mut existing_chunk_extra = None;
     let mut prev_chunk_extra = None;
     let mut num_tx = 0;

--- a/tools/state-viewer/src/apply_chunk.rs
+++ b/tools/state-viewer/src/apply_chunk.rs
@@ -9,7 +9,6 @@ use near_epoch_manager::shard_assignment::shard_id_to_uid;
 use near_epoch_manager::{EpochManagerAdapter, EpochManagerHandle};
 use near_primitives::apply::ApplyChunkReason;
 use near_primitives::bandwidth_scheduler::BlockBandwidthRequests;
-use near_primitives::block::MaybeNew;
 use near_primitives::congestion_info::BlockCongestionInfo;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
@@ -126,10 +125,7 @@ pub fn apply_chunk(
     let mut shards_bandwidth_requests = BTreeMap::new();
     let mut shards_congestion_info = BTreeMap::new();
     for prev_chunk in prev_block.chunks().iter() {
-        let shard_id = match prev_chunk {
-            MaybeNew::New(new_chunk) => new_chunk.shard_id(),
-            MaybeNew::Old(missing_chunk) => missing_chunk.shard_id(),
-        };
+        let shard_id = prev_chunk.shard_id();
         let shard_uid =
             shard_id_to_uid(epoch_manager, shard_id, prev_block.header().epoch_id()).unwrap();
         let Ok(chunk_extra) = chain_store.get_chunk_extra(&prev_block_hash, &shard_uid) else {


### PR DESCRIPTION
This PR is the first step in trying to simplify the chunk iterators. We currently have iter_raw and iter_deprecated that are not too user friendly.

With this PR we make some major improvements to the iteration
- Now there are two new functions `iter_new` and `iter_old` to iterate over new and old chunks
- `ChunkType` now stores a new/old chunk but can dereference to the chunk header for easy access
- `Chunks` that is the container for the chunk headers can seamlessly dereference to `[ShardChunkHeader]` so that we can easily use methods like `len` and `index` on it.

Next PR in the series https://github.com/near/nearcore/pull/13784