### PR TITLE
[chunk] 3/n Move some functions from `Block` to `Chunks`

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1093,8 +1093,7 @@ impl Chain {
             if let Some(encoded_chunk) =
                 self.chain_store.is_invalid_chunk(&chunk_header.chunk_hash())?
             {
-                let merkle_paths =
-                    Block::compute_chunk_headers_root(block.chunks().iter_deprecated()).1;
+                let merkle_paths = block.chunks().compute_chunk_headers_root().1;
                 let merkle_proof =
                     merkle_paths.get(shard_index).ok_or(Error::InvalidShardId(shard_id))?;
                 let chunk_proof = ChunkProofs {
@@ -3127,8 +3126,7 @@ impl Chain {
                     }
 
                     if let Error::InvalidChunkTransactionsOrder(chunk) = err {
-                        let merkle_paths =
-                            Block::compute_chunk_headers_root(block.chunks().iter_deprecated()).1;
+                        let merkle_paths = block.chunks().compute_chunk_headers_root().1;
                         let chunk_proof = ChunkProofs {
                             block_header: borsh::to_vec(&block.header())
                                 .expect("Failed to serialize"),

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1428,8 +1428,7 @@ impl ClientActorInner {
 
     fn send_block_metrics(&mut self, block: &Block) {
         let chunks_in_block = block.header().chunk_mask().iter().filter(|&&m| m).count();
-        let gas_used =
-            Block::compute_gas_used(block.chunks().iter_deprecated(), block.header().height());
+        let gas_used = block.chunks().compute_gas_used();
 
         let last_final_hash = block.header().last_final_block();
         let last_final_ds_hash = block.header().last_ds_final_block();

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -205,13 +205,19 @@ impl Block {
                 .collect_vec(),
         ));
 
-        let body = BlockBody::new(chunks, vrf_value, vrf_proof, chunk_endorsements);
+        let chunks_wrapper = Chunks::from_chunk_headers(&chunks, height);
         let prev_state_root = if cfg!(feature = "protocol_feature_spice") {
             // TODO(spice): include state root from the relevant previous executed block.
             CryptoHash::default()
         } else {
-            Block::compute_state_root(body.chunks())
+            chunks_wrapper.compute_state_root()
         };
+        let prev_chunk_outgoing_receipts_root =
+            chunks_wrapper.compute_chunk_prev_outgoing_receipts_root();
+        let chunk_headers_root = chunks_wrapper.compute_chunk_headers_root();
+        let chunk_tx_root = chunks_wrapper.compute_chunk_tx_root();
+        let outcome_root = chunks_wrapper.compute_outcome_root();
+        let body = BlockBody::new(chunks, vrf_value, vrf_proof, chunk_endorsements);
 
         let header = BlockHeader::new(
             latest_protocol_version,
@@ -219,10 +225,10 @@ impl Block {
             *prev.hash(),
             body.compute_hash(),
             prev_state_root,
-            Block::compute_chunk_prev_outgoing_receipts_root(body.chunks()),
-            Block::compute_chunk_headers_root(body.chunks()).0,
-            Block::compute_chunk_tx_root(body.chunks()),
-            Block::compute_outcome_root(body.chunks()),
+            prev_chunk_outgoing_receipts_root,
+            chunk_headers_root.0,
+            chunk_tx_root,
+            outcome_root,
             time,
             random_value,
             prev_validator_proposals,
@@ -270,10 +276,8 @@ impl Block {
         max_gas_price: Balance,
         gas_price_adjustment_rate: Rational32,
     ) -> bool {
-        let gas_used =
-            Self::compute_gas_used(self.chunks().iter_deprecated(), self.header().height());
-        let gas_limit =
-            Self::compute_gas_limit(self.chunks().iter_deprecated(), self.header().height());
+        let gas_used = self.chunks().compute_gas_used();
+        let gas_limit = self.chunks().compute_gas_limit();
         let expected_price = Self::compute_next_gas_price(
             gas_price,
             gas_used,
@@ -316,82 +320,6 @@ impl Block {
             U256::from(gas_price) * U256::from(numerator) / U256::from(denominator);
 
         next_gas_price.clamp(U256::from(min_gas_price), U256::from(max_gas_price)).as_u128()
-    }
-
-    pub fn compute_state_root<'a, T: IntoIterator<Item = &'a ShardChunkHeader>>(
-        chunks: T,
-    ) -> CryptoHash {
-        merklize(
-            &chunks.into_iter().map(|chunk| chunk.prev_state_root()).collect::<Vec<CryptoHash>>(),
-        )
-        .0
-    }
-
-    pub fn compute_chunk_prev_outgoing_receipts_root<
-        'a,
-        T: IntoIterator<Item = &'a ShardChunkHeader>,
-    >(
-        chunks: T,
-    ) -> CryptoHash {
-        merklize(
-            &chunks
-                .into_iter()
-                .map(|chunk| chunk.prev_outgoing_receipts_root())
-                .copied()
-                .collect::<Vec<CryptoHash>>(),
-        )
-        .0
-    }
-
-    pub fn compute_chunk_headers_root<'a, T: IntoIterator<Item = &'a ShardChunkHeader>>(
-        chunks: T,
-    ) -> (CryptoHash, Vec<MerklePath>) {
-        merklize(
-            &chunks
-                .into_iter()
-                .map(|chunk| ChunkHashHeight(chunk.chunk_hash().clone(), chunk.height_included()))
-                .collect::<Vec<ChunkHashHeight>>(),
-        )
-    }
-
-    pub fn compute_chunk_tx_root<'a, T: IntoIterator<Item = &'a ShardChunkHeader>>(
-        chunks: T,
-    ) -> CryptoHash {
-        merklize(
-            &chunks.into_iter().map(|chunk| chunk.tx_root()).copied().collect::<Vec<CryptoHash>>(),
-        )
-        .0
-    }
-
-    pub fn compute_outcome_root<'a, T: IntoIterator<Item = &'a ShardChunkHeader>>(
-        chunks: T,
-    ) -> CryptoHash {
-        merklize(
-            &chunks
-                .into_iter()
-                .map(|chunk| chunk.prev_outcome_root())
-                .copied()
-                .collect::<Vec<CryptoHash>>(),
-        )
-        .0
-    }
-
-    pub fn compute_gas_used<'a, T: IntoIterator<Item = &'a ShardChunkHeader>>(
-        chunks: T,
-        height: BlockHeight,
-    ) -> Gas {
-        chunks.into_iter().fold(0, |acc, chunk| {
-            if chunk.height_included() == height { acc + chunk.prev_gas_used() } else { acc }
-        })
-    }
-
-    pub fn compute_gas_limit<'a, T: IntoIterator<Item = &'a ShardChunkHeader>>(
-        chunks: T,
-        height: BlockHeight,
-    ) -> Gas {
-        chunks.into_iter().fold(0, |acc, chunk| {
-            if chunk.height_included() == height { acc + chunk.gas_limit() } else { acc }
-        })
     }
 
     pub fn validate_chunk_header_proof(
@@ -476,33 +404,31 @@ impl Block {
         // TODO(spice): check that block's state_root matches state_root corresponding to chunks of
         // the appropriate executed block from the past.
         if !cfg!(feature = "protocol_feature_spice") {
-            let state_root = Block::compute_state_root(self.chunks().iter_deprecated());
+            let state_root = self.chunks().compute_state_root();
             if self.header().prev_state_root() != &state_root {
                 return Err(InvalidStateRoot);
             }
         }
 
         // Check that chunk receipts root stored in the header matches the state root of the chunks
-        let chunk_receipts_root =
-            Block::compute_chunk_prev_outgoing_receipts_root(self.chunks().iter_deprecated());
+        let chunk_receipts_root = self.chunks().compute_chunk_prev_outgoing_receipts_root();
         if self.header().prev_chunk_outgoing_receipts_root() != &chunk_receipts_root {
             return Err(InvalidReceiptRoot);
         }
 
         // Check that chunk headers root stored in the header matches the chunk headers root of the chunks
-        let chunk_headers_root =
-            Block::compute_chunk_headers_root(self.chunks().iter_deprecated()).0;
+        let chunk_headers_root = self.chunks().compute_chunk_headers_root().0;
         if self.header().chunk_headers_root() != &chunk_headers_root {
             return Err(InvalidChunkHeaderRoot);
         }
 
         // Check that chunk tx root stored in the header matches the tx root of the chunks
-        let chunk_tx_root = Block::compute_chunk_tx_root(self.chunks().iter_deprecated());
+        let chunk_tx_root = self.chunks().compute_chunk_tx_root();
         if self.header().chunk_tx_root() != &chunk_tx_root {
             return Err(InvalidTransactionRoot);
         }
 
-        let outcome_root = Block::compute_outcome_root(self.chunks().iter_deprecated());
+        let outcome_root = self.chunks().compute_outcome_root();
         if self.header().outcome_root() != &outcome_root {
             return Err(InvalidTransactionRoot);
         }
@@ -670,6 +596,40 @@ impl<'a> Chunks<'a> {
         }
 
         BlockBandwidthRequests { shards_bandwidth_requests: result }
+    }
+
+    // Instance methods that use self's iterator methods
+    pub fn compute_state_root(&self) -> CryptoHash {
+        merklize(&self.iter().map(|chunk| chunk.prev_state_root()).collect_vec()).0
+    }
+
+    pub fn compute_chunk_prev_outgoing_receipts_root(&self) -> CryptoHash {
+        merklize(&self.iter().map(|chunk| *chunk.prev_outgoing_receipts_root()).collect_vec()).0
+    }
+
+    pub fn compute_chunk_headers_root(&self) -> (CryptoHash, Vec<MerklePath>) {
+        merklize(
+            &self
+                .iter()
+                .map(|chunk| ChunkHashHeight(chunk.chunk_hash().clone(), chunk.height_included()))
+                .collect_vec(),
+        )
+    }
+
+    pub fn compute_chunk_tx_root(&self) -> CryptoHash {
+        merklize(&self.iter().map(|chunk| *chunk.tx_root()).collect_vec()).0
+    }
+
+    pub fn compute_outcome_root(&self) -> CryptoHash {
+        merklize(&self.iter().map(|chunk| *chunk.prev_outcome_root()).collect_vec()).0
+    }
+
+    pub fn compute_gas_used(&self) -> Gas {
+        self.iter_new().fold(0, |acc, chunk| acc + chunk.prev_gas_used())
+    }
+
+    pub fn compute_gas_limit(&self) -> Gas {
+        self.iter_new().fold(0, |acc, chunk| acc + chunk.gas_limit())
     }
 }
 

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -34,7 +34,7 @@ use near_o11y::WithSpanContextExt;
 use near_o11y::testonly::{init_integration_logger, init_test_logger};
 use near_parameters::{ActionCosts, ExtCosts};
 use near_parameters::{RuntimeConfig, RuntimeConfigStore};
-use near_primitives::block::Approval;
+use near_primitives::block::{Approval, Chunks};
 use near_primitives::errors::TxExecutionError;
 use near_primitives::errors::{ActionError, ActionErrorKind, InvalidTxError};
 use near_primitives::genesis::GenesisId;
@@ -838,14 +838,13 @@ fn test_bad_chunk_mask() {
             chunk_headers[0] = chunk_header;
             let mut_block = Arc::make_mut(&mut block);
             mut_block.set_chunks(chunk_headers.clone());
-            mut_block
-                .mut_header()
-                .set_chunk_headers_root(Block::compute_chunk_headers_root(&chunk_headers).0);
-            mut_block.mut_header().set_chunk_tx_root(Block::compute_chunk_tx_root(&chunk_headers));
+            let chunks = Chunks::from_chunk_headers(&chunk_headers, mut_block.header().height());
+            mut_block.mut_header().set_chunk_headers_root(chunks.compute_chunk_headers_root().0);
+            mut_block.mut_header().set_chunk_tx_root(chunks.compute_chunk_tx_root());
             mut_block.mut_header().set_prev_chunk_outgoing_receipts_root(
-                Block::compute_chunk_prev_outgoing_receipts_root(&chunk_headers),
+                chunks.compute_chunk_prev_outgoing_receipts_root(),
             );
-            mut_block.mut_header().set_prev_state_root(Block::compute_state_root(&chunk_headers));
+            mut_block.mut_header().set_prev_state_root(chunks.compute_state_root());
             mut_block.mut_header().set_chunk_mask(vec![true, false]);
             let mess_with_chunk_mask = height == 4;
             if mess_with_chunk_mask {
@@ -1948,20 +1947,18 @@ fn test_validate_chunk_extra() {
         let chunk_headers = vec![chunk_header.clone()];
         let mut_block = Arc::make_mut(block);
         mut_block.set_chunks(chunk_headers.clone());
-        mut_block
-            .mut_header()
-            .set_chunk_headers_root(Block::compute_chunk_headers_root(&chunk_headers).0);
-        mut_block.mut_header().set_chunk_tx_root(Block::compute_chunk_tx_root(&chunk_headers));
+        let chunks = Chunks::from_chunk_headers(&chunk_headers, mut_block.header().height());
+        mut_block.mut_header().set_chunk_headers_root(chunks.compute_chunk_headers_root().0);
+        mut_block.mut_header().set_chunk_tx_root(chunks.compute_chunk_tx_root());
         mut_block.mut_header().set_prev_chunk_outgoing_receipts_root(
-            Block::compute_chunk_prev_outgoing_receipts_root(&chunk_headers),
+            chunks.compute_chunk_prev_outgoing_receipts_root(),
         );
-        mut_block.mut_header().set_prev_state_root(Block::compute_state_root(&chunk_headers));
+        mut_block.mut_header().set_prev_state_root(chunks.compute_state_root());
         mut_block.mut_header().set_chunk_mask(vec![true]);
         mut_block
             .mut_header()
             .set_chunk_endorsements(ChunkEndorsementsBitmap::from_endorsements(vec![vec![true]]));
-        let outcome_root = Block::compute_outcome_root(mut_block.chunks().iter_deprecated());
-        mut_block.mut_header().set_prev_outcome_root(outcome_root);
+        mut_block.mut_header().set_prev_outcome_root(chunks.compute_outcome_root());
         let endorsement =
             ChunkEndorsement::new(EpochId::default(), &chunk_header, &validator_signer);
         mut_block.set_chunk_endorsements(vec![vec![Some(Box::new(endorsement.signature()))]]);
@@ -2884,14 +2881,13 @@ fn test_fork_receipt_ids() {
         let chunk_headers = vec![chunk_header];
         let mut_block = Arc::make_mut(block);
         mut_block.set_chunks(chunk_headers.clone());
-        mut_block
-            .mut_header()
-            .set_chunk_headers_root(Block::compute_chunk_headers_root(&chunk_headers).0);
-        mut_block.mut_header().set_chunk_tx_root(Block::compute_chunk_tx_root(&chunk_headers));
+        let chunks = Chunks::from_chunk_headers(&chunk_headers, mut_block.header().height());
+        mut_block.mut_header().set_chunk_headers_root(chunks.compute_chunk_headers_root().0);
+        mut_block.mut_header().set_chunk_tx_root(chunks.compute_chunk_tx_root());
         mut_block.mut_header().set_prev_chunk_outgoing_receipts_root(
-            Block::compute_chunk_prev_outgoing_receipts_root(&chunk_headers),
+            chunks.compute_chunk_prev_outgoing_receipts_root(),
         );
-        mut_block.mut_header().set_prev_state_root(Block::compute_state_root(&chunk_headers));
+        mut_block.mut_header().set_prev_state_root(chunks.compute_state_root());
         mut_block.mut_header().set_chunk_mask(vec![true]);
         mut_block.mut_header().resign(&validator_signer);
         env.clients[0].process_block_test(block.clone().into(), Provenance::NONE).unwrap();
@@ -2942,14 +2938,13 @@ fn test_fork_execution_outcome() {
         let chunk_headers = vec![chunk_header];
         let mut_block = Arc::make_mut(block);
         mut_block.set_chunks(chunk_headers.clone());
-        mut_block
-            .mut_header()
-            .set_chunk_headers_root(Block::compute_chunk_headers_root(&chunk_headers).0);
-        mut_block.mut_header().set_chunk_tx_root(Block::compute_chunk_tx_root(&chunk_headers));
+        let chunks = Chunks::from_chunk_headers(&chunk_headers, mut_block.header().height());
+        mut_block.mut_header().set_chunk_headers_root(chunks.compute_chunk_headers_root().0);
+        mut_block.mut_header().set_chunk_tx_root(chunks.compute_chunk_tx_root());
         mut_block.mut_header().set_prev_chunk_outgoing_receipts_root(
-            Block::compute_chunk_prev_outgoing_receipts_root(&chunk_headers),
+            chunks.compute_chunk_prev_outgoing_receipts_root(),
         );
-        mut_block.mut_header().set_prev_state_root(Block::compute_state_root(&chunk_headers));
+        mut_block.mut_header().set_prev_state_root(chunks.compute_state_root());
         mut_block.mut_header().set_chunk_mask(vec![true]);
         mut_block.mut_header().resign(&validator_signer);
         env.clients[0].process_block_test(block.clone().into(), Provenance::NONE).unwrap();

--- a/integration-tests/src/tests/client/process_blocks2.rs
+++ b/integration-tests/src/tests/client/process_blocks2.rs
@@ -9,7 +9,7 @@ use near_crypto::vrf::Value;
 use near_crypto::{KeyType, PublicKey, Signature};
 use near_network::types::{NetworkRequests, PeerManagerMessageRequest};
 use near_primitives::bandwidth_scheduler::BandwidthRequests;
-use near_primitives::block::Block;
+use near_primitives::block::{Block, Chunks};
 use near_primitives::congestion_info::CongestionInfo;
 use near_primitives::network::PeerId;
 use near_primitives::optimistic_block::OptimisticBlock;
@@ -157,11 +157,12 @@ fn test_bad_shard_id() {
     modified_chunk.height_included = 2;
     chunks[0] = ShardChunkHeader::V3(modified_chunk);
     let mut_block = Arc::make_mut(&mut block);
-    mut_block.mut_header().set_chunk_headers_root(Block::compute_chunk_headers_root(&chunks).0);
-    mut_block.mut_header().set_prev_chunk_outgoing_receipts_root(
-        Block::compute_chunk_prev_outgoing_receipts_root(&chunks),
-    );
-    mut_block.set_chunks(chunks);
+    mut_block.set_chunks(chunks.clone());
+    let chunks = Chunks::from_chunk_headers(&chunks, mut_block.header().height());
+    mut_block.mut_header().set_chunk_headers_root(chunks.compute_chunk_headers_root().0);
+    mut_block
+        .mut_header()
+        .set_prev_chunk_outgoing_receipts_root(chunks.compute_chunk_prev_outgoing_receipts_root());
     let body_hash = mut_block.compute_block_body_hash().unwrap();
     mut_block.mut_header().set_block_body_hash(body_hash);
     mut_block.mut_header().resign(&validator_signer);

--- a/test-utils/testlib/src/process_blocks.rs
+++ b/test-utils/testlib/src/process_blocks.rs
@@ -1,4 +1,5 @@
 use near_chain::{Block, BlockHeader};
+use near_primitives::block::Chunks;
 use near_primitives::{
     stateless_validation::chunk_endorsements_bitmap::ChunkEndorsementsBitmap,
     test_utils::create_test_signer,
@@ -15,51 +16,48 @@ pub fn set_no_chunk_in_block(block: &mut Block, prev_block: &Block) {
     block.set_chunks(chunk_headers.clone());
     block.set_chunk_endorsements(vec![vec![]; chunk_headers.len()]);
     let block_body_hash = block.compute_block_body_hash();
+    let chunks = Chunks::from_chunk_headers(&chunk_headers, block.header().height());
     match block.mut_header() {
         BlockHeader::BlockHeaderV1(header) => {
-            header.inner_rest.chunk_headers_root =
-                Block::compute_chunk_headers_root(&chunk_headers).0;
-            header.inner_rest.chunk_tx_root = Block::compute_chunk_tx_root(&chunk_headers);
+            header.inner_rest.chunk_headers_root = chunks.compute_chunk_headers_root().0;
+            header.inner_rest.chunk_tx_root = chunks.compute_chunk_tx_root();
             header.inner_rest.prev_chunk_outgoing_receipts_root =
-                Block::compute_chunk_prev_outgoing_receipts_root(&chunk_headers);
-            header.inner_lite.prev_state_root = Block::compute_state_root(&chunk_headers);
-            header.inner_lite.prev_outcome_root = Block::compute_outcome_root(&chunk_headers);
+                chunks.compute_chunk_prev_outgoing_receipts_root();
+            header.inner_lite.prev_state_root = chunks.compute_state_root();
+            header.inner_lite.prev_outcome_root = chunks.compute_outcome_root();
             header.inner_rest.chunk_mask = vec![false];
             header.inner_rest.next_gas_price = prev_block.header().next_gas_price();
             header.inner_rest.total_supply += balance_burnt;
         }
         BlockHeader::BlockHeaderV2(header) => {
-            header.inner_rest.chunk_headers_root =
-                Block::compute_chunk_headers_root(&chunk_headers).0;
-            header.inner_rest.chunk_tx_root = Block::compute_chunk_tx_root(&chunk_headers);
+            header.inner_rest.chunk_headers_root = chunks.compute_chunk_headers_root().0;
+            header.inner_rest.chunk_tx_root = chunks.compute_chunk_tx_root();
             header.inner_rest.prev_chunk_outgoing_receipts_root =
-                Block::compute_chunk_prev_outgoing_receipts_root(&chunk_headers);
-            header.inner_lite.prev_state_root = Block::compute_state_root(&chunk_headers);
-            header.inner_lite.prev_outcome_root = Block::compute_outcome_root(&chunk_headers);
+                chunks.compute_chunk_prev_outgoing_receipts_root();
+            header.inner_lite.prev_state_root = chunks.compute_state_root();
+            header.inner_lite.prev_outcome_root = chunks.compute_outcome_root();
             header.inner_rest.chunk_mask = vec![false];
             header.inner_rest.next_gas_price = prev_block.header().next_gas_price();
             header.inner_rest.total_supply += balance_burnt;
         }
         BlockHeader::BlockHeaderV3(header) => {
-            header.inner_rest.chunk_headers_root =
-                Block::compute_chunk_headers_root(&chunk_headers).0;
-            header.inner_rest.chunk_tx_root = Block::compute_chunk_tx_root(&chunk_headers);
+            header.inner_rest.chunk_headers_root = chunks.compute_chunk_headers_root().0;
+            header.inner_rest.chunk_tx_root = chunks.compute_chunk_tx_root();
             header.inner_rest.prev_chunk_outgoing_receipts_root =
-                Block::compute_chunk_prev_outgoing_receipts_root(&chunk_headers);
-            header.inner_lite.prev_state_root = Block::compute_state_root(&chunk_headers);
-            header.inner_lite.prev_outcome_root = Block::compute_outcome_root(&chunk_headers);
+                chunks.compute_chunk_prev_outgoing_receipts_root();
+            header.inner_lite.prev_state_root = chunks.compute_state_root();
+            header.inner_lite.prev_outcome_root = chunks.compute_outcome_root();
             header.inner_rest.chunk_mask = vec![false];
             header.inner_rest.next_gas_price = prev_block.header().next_gas_price();
             header.inner_rest.total_supply += balance_burnt;
         }
         BlockHeader::BlockHeaderV4(header) => {
-            header.inner_rest.chunk_headers_root =
-                Block::compute_chunk_headers_root(&chunk_headers).0;
-            header.inner_rest.chunk_tx_root = Block::compute_chunk_tx_root(&chunk_headers);
+            header.inner_rest.chunk_headers_root = chunks.compute_chunk_headers_root().0;
+            header.inner_rest.chunk_tx_root = chunks.compute_chunk_tx_root();
             header.inner_rest.prev_chunk_outgoing_receipts_root =
-                Block::compute_chunk_prev_outgoing_receipts_root(&chunk_headers);
-            header.inner_lite.prev_state_root = Block::compute_state_root(&chunk_headers);
-            header.inner_lite.prev_outcome_root = Block::compute_outcome_root(&chunk_headers);
+                chunks.compute_chunk_prev_outgoing_receipts_root();
+            header.inner_lite.prev_state_root = chunks.compute_state_root();
+            header.inner_lite.prev_outcome_root = chunks.compute_outcome_root();
             header.inner_rest.chunk_mask = vec![false];
             header.inner_rest.next_gas_price = prev_block.header().next_gas_price();
             header.inner_rest.total_supply += balance_burnt;
@@ -67,13 +65,12 @@ pub fn set_no_chunk_in_block(block: &mut Block, prev_block: &Block) {
         }
         // Same as BlockHeader::BlockHeaderV4 branch but with inner_rest.chunk_endorsements field set.
         BlockHeader::BlockHeaderV5(header) => {
-            header.inner_rest.chunk_headers_root =
-                Block::compute_chunk_headers_root(&chunk_headers).0;
-            header.inner_rest.chunk_tx_root = Block::compute_chunk_tx_root(&chunk_headers);
+            header.inner_rest.chunk_headers_root = chunks.compute_chunk_headers_root().0;
+            header.inner_rest.chunk_tx_root = chunks.compute_chunk_tx_root();
             header.inner_rest.prev_chunk_outgoing_receipts_root =
-                Block::compute_chunk_prev_outgoing_receipts_root(&chunk_headers);
-            header.inner_lite.prev_state_root = Block::compute_state_root(&chunk_headers);
-            header.inner_lite.prev_outcome_root = Block::compute_outcome_root(&chunk_headers);
+                chunks.compute_chunk_prev_outgoing_receipts_root();
+            header.inner_lite.prev_state_root = chunks.compute_state_root();
+            header.inner_lite.prev_outcome_root = chunks.compute_outcome_root();
             header.inner_rest.chunk_mask = vec![false];
             header.inner_rest.next_gas_price = prev_block.header().next_gas_price();
             header.inner_rest.total_supply += balance_burnt;


### PR DESCRIPTION
Some functions better belong to the `Chunks` struct. These were originally a static function in `Block` and were taking the chunk headers as input.