### PR TITLE
feat: remove recording storage on prepare_transactions

### DIFF
--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -348,7 +348,6 @@ pub enum PrepareTransactionsLimit {
     Size,
     Time,
     ReceiptCount,
-    StorageProofSize,
 }
 
 pub struct PrepareTransactionsBlockContext {


### PR DESCRIPTION
Since `RelaxedChunkValidation` we don't call `prepare_transactions` on chunk validators, thus we don't need to send storage proof for it. To my surprise, it didn't improve performance, but we should still do it to simplify logic.