### PR TITLE
test: run cache determinism tests on Wasmtime

### DIFF
--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -132,7 +132,7 @@ fn make_cached_contract_call_vm(
 }
 
 #[test]
-#[cfg(feature = "near_vm")]
+#[cfg(all(feature = "near_vm", target_arch = "x86_64"))]
 fn test_near_vm_artifact_output_stability() {
     use crate::near_vm_runner::NearVM;
     use crate::prepare;

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -1,6 +1,3 @@
-//! Tests that `ContractRuntimeCache` is working correctly. Currently testing only wasmer code, so disabled outside of x86_64
-#![cfg(target_arch = "x86_64")]
-
 use super::{create_context, test_vm_config, with_vm_variants};
 use crate::cache::{CompiledContractInfo, ContractRuntimeCache};
 use crate::logic::Config;
@@ -23,8 +20,8 @@ fn test_caches_compilation_error() {
     with_vm_variants(&config, |vm_kind: VMKind| {
         // The cache is currently properly implemented only for NearVM
         match vm_kind {
-            VMKind::NearVm | VMKind::NearVm2 => {}
-            VMKind::Wasmer0 | VMKind::Wasmer2 | VMKind::Wasmtime => return,
+            VMKind::NearVm | VMKind::NearVm2 | VMKind::Wasmtime => {}
+            VMKind::Wasmer0 | VMKind::Wasmer2 => return,
         }
         let cache = MockContractRuntimeCache::default();
         let code = [42; 1000];
@@ -63,8 +60,8 @@ fn test_does_not_cache_io_error() {
     let config = Arc::new(test_vm_config());
     with_vm_variants(&config, |vm_kind: VMKind| {
         match vm_kind {
-            VMKind::NearVm | VMKind::NearVm2 => {}
-            VMKind::Wasmer0 | VMKind::Wasmer2 | VMKind::Wasmtime => return,
+            VMKind::NearVm | VMKind::NearVm2 | VMKind::Wasmtime => {}
+            VMKind::Wasmer0 | VMKind::Wasmer2 => return,
         }
 
         let code = near_test_contracts::trivial_contract();

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -174,7 +174,10 @@ impl WasmtimeVM {
     }
 
     #[tracing::instrument(target = "vm", level = "debug", "WasmtimeVM::compile_uncached", skip_all)]
-    fn compile_uncached(&self, code: &ContractCode) -> Result<Vec<u8>, CompilationError> {
+    pub(crate) fn compile_uncached(
+        &self,
+        code: &ContractCode,
+    ) -> Result<Vec<u8>, CompilationError> {
         let start = std::time::Instant::now();
         let prepared_code = prepare::prepare_contract(code.code(), &self.config, VMKind::Wasmtime)
             .map_err(CompilationError::PrepareError)?;


### PR DESCRIPTION
Closes #13790 

The fuzzer test is effectively a duplicate of `slow_test_near_vm_is_reproducible_fuzzer`: https://github.com/near/nearcore/blob/3e3b52c7f57b5cdd01256c4d9e27a5b51ef16f3b/runtime/near-vm-runner/src/tests/fuzzers.rs#L119-L143