### PR TITLE
[Draft] Implement gas key actions and transactions signed with gas keys

### DIFF
--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -35,6 +35,12 @@ pub enum QueryError {
         block_height: near_primitives::types::BlockHeight,
         block_hash: near_primitives::hash::CryptoHash,
     },
+    #[error("Gas key for public key {public_key} does not exist while viewing")]
+    UnknownGasKey {
+        public_key: near_crypto::PublicKey,
+        block_height: near_primitives::types::BlockHeight,
+        block_hash: near_primitives::hash::CryptoHash,
+    },
     #[error("Internal error occurred: {error_message}")]
     InternalError {
         error_message: String,

--- a/chain/chain/src/runtime/errors.rs
+++ b/chain/chain/src/runtime/errors.rs
@@ -104,6 +104,24 @@ impl QueryError {
         }
     }
 
+    pub fn from_view_gas_key_error(
+        error: node_runtime::state_viewer::errors::ViewGasKeyError,
+        block_height: near_primitives::types::BlockHeight,
+        block_hash: near_primitives::hash::CryptoHash,
+    ) -> Self {
+        match error {
+            node_runtime::state_viewer::errors::ViewGasKeyError::InvalidAccountId {
+                requested_account_id,
+            } => Self::InvalidAccount { requested_account_id, block_height, block_hash },
+            node_runtime::state_viewer::errors::ViewGasKeyError::GasKeyDoesNotExist {
+                public_key,
+            } => Self::UnknownGasKey { public_key, block_height, block_hash },
+            node_runtime::state_viewer::errors::ViewGasKeyError::InternalError {
+                error_message,
+            } => Self::InternalError { error_message, block_height, block_hash },
+        }
+    }
+
     pub fn from_epoch_error(
         error: near_primitives::errors::EpochError,
         block_height: near_primitives::types::BlockHeight,

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -417,6 +417,14 @@ pub enum QueryError {
         block_height: near_primitives::types::BlockHeight,
         block_hash: near_primitives::hash::CryptoHash,
     },
+    #[error(
+        "Gas key for public key {public_key} has never been observed on the node at block #{block_height}"
+    )]
+    UnknownGasKey {
+        public_key: near_crypto::PublicKey,
+        block_height: near_primitives::types::BlockHeight,
+        block_hash: near_primitives::hash::CryptoHash,
+    },
     #[error("Function call returned an error: {vm_error}")]
     ContractExecutionError {
         vm_error: String,

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -422,6 +422,11 @@ impl ViewClientActorInner {
                     block_height,
                     block_hash,
                 } => QueryError::UnknownAccessKey { public_key, block_height, block_hash },
+                near_chain::near_chain_primitives::error::QueryError::UnknownGasKey {
+                    public_key,
+                    block_height,
+                    block_hash,
+                } => QueryError::UnknownGasKey { public_key, block_height, block_hash },
                 near_chain::near_chain_primitives::error::QueryError::ContractExecutionError {
                     error_message,
                     block_hash,
@@ -459,6 +464,8 @@ impl ViewClientActorInner {
             | QueryRequest::ViewState { account_id, .. }
             | QueryRequest::ViewAccessKey { account_id, .. }
             | QueryRequest::ViewAccessKeyList { account_id, .. }
+            | QueryRequest::ViewGasKey { account_id, .. }
+            | QueryRequest::ViewGasKeyList { account_id }
             | QueryRequest::CallFunction { account_id, .. }
             | QueryRequest::ViewCode { account_id, .. } => {
                 account_id_to_shard_id(self.epoch_manager.as_ref(), account_id, &epoch_id)

--- a/chain/jsonrpc-primitives/src/types/query.rs
+++ b/chain/jsonrpc-primitives/src/types/query.rs
@@ -58,6 +58,12 @@ pub enum RpcQueryError {
         block_height: near_primitives::types::BlockHeight,
         block_hash: near_primitives::hash::CryptoHash,
     },
+    #[error("Gas key for public key {public_key} has never been observed on the node")]
+    UnknownGasKey {
+        public_key: near_crypto::PublicKey,
+        block_height: near_primitives::types::BlockHeight,
+        block_hash: near_primitives::hash::CryptoHash,
+    },
     #[error("Function call returned an error: {vm_error}")]
     ContractExecutionError {
         vm_error: String,
@@ -95,6 +101,8 @@ pub enum QueryResponseKind {
     CallResult(near_primitives::views::CallResult),
     AccessKey(near_primitives::views::AccessKeyView),
     AccessKeyList(near_primitives::views::AccessKeyList),
+    GasKey(near_primitives::views::GasKeyView),
+    GasKeyList(near_primitives::views::GasKeyList),
 }
 
 impl From<RpcQueryError> for crate::errors::RpcError {

--- a/chain/jsonrpc/src/api/query.rs
+++ b/chain/jsonrpc/src/api/query.rs
@@ -118,6 +118,9 @@ impl RpcFrom<QueryError> for RpcQueryError {
             QueryError::UnknownAccessKey { public_key, block_height, block_hash } => {
                 Self::UnknownAccessKey { public_key, block_height, block_hash }
             }
+            QueryError::UnknownGasKey { public_key, block_height, block_hash } => {
+                Self::UnknownGasKey { public_key, block_height, block_hash }
+            }
             QueryError::ContractExecutionError { vm_error, block_height, block_hash } => {
                 Self::ContractExecutionError { vm_error, block_height, block_hash }
             }
@@ -170,6 +173,12 @@ impl RpcFrom<near_primitives::views::QueryResponseKind>
             }
             near_primitives::views::QueryResponseKind::AccessKeyList(access_key_list) => {
                 Self::AccessKeyList(access_key_list)
+            }
+            near_primitives::views::QueryResponseKind::GasKey(gas_key_view) => {
+                Self::GasKey(gas_key_view)
+            }
+            near_primitives::views::QueryResponseKind::GasKeyList(gas_key_list) => {
+                Self::GasKeyList(gas_key_list)
             }
         }
     }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -362,6 +362,8 @@ impl JsonRpcHandler {
                     }
                     QueryRequest::ViewAccessKey { .. } => "query_view_access_key",
                     QueryRequest::ViewAccessKeyList { .. } => "query_view_access_key_list",
+                    QueryRequest::ViewGasKey { .. } => "query_view_gas_key",
+                    QueryRequest::ViewGasKeyList { .. } => "query_view_gas_key_list",
                     QueryRequest::CallFunction { .. } => "query_call_function",
                     QueryRequest::ViewGlobalContractCode { .. } => {
                         "query_view_global_contract_code"

--- a/chain/pool/src/lib.rs
+++ b/chain/pool/src/lib.rs
@@ -4,7 +4,7 @@ use near_o11y::metrics::prometheus::core::{AtomicI64, GenericGauge};
 use near_primitives::epoch_info::RngSeed;
 use near_primitives::hash::{CryptoHash, hash};
 use near_primitives::transaction::{SignedTransaction, ValidatedTransaction};
-use near_primitives::types::AccountId;
+use near_primitives::types::{AccountId, NonceIndex};
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::ops::Bound;
@@ -69,10 +69,19 @@ impl TransactionPool {
         }
     }
 
-    fn key(&self, account_id: &AccountId, public_key: &PublicKey) -> PoolKey {
+    /// Represents a unique key under which the transactions must have increasing nonces.
+    /// nonce_index is None for access key transactions, and Some(nonce_index) for gas key transactions.
+    fn key(
+        &self,
+        account_id: &AccountId,
+        public_key: &PublicKey,
+        nonce_index: Option<NonceIndex>,
+    ) -> PoolKey {
         let mut v = borsh::to_vec(&public_key).unwrap();
+        let nonce_index_encoded = borsh::to_vec(&nonce_index).unwrap();
         v.extend_from_slice(&self.key_seed);
         v.extend_from_slice(account_id.as_bytes());
+        v.extend_from_slice(&nonce_index_encoded);
         hash(&v)
     }
 
@@ -109,7 +118,7 @@ impl TransactionPool {
         let signer_id = validated_tx.signer_id();
         let signer_public_key = validated_tx.public_key();
         self.transactions
-            .entry(self.key(signer_id, signer_public_key))
+            .entry(self.key(signer_id, signer_public_key, validated_tx.nonce().nonce_index()))
             .or_insert_with(Vec::new)
             .push(validated_tx);
 
@@ -140,7 +149,11 @@ impl TransactionPool {
             let signer_id = signed_tx.transaction.signer_id();
             let signer_public_key = signed_tx.transaction.public_key();
             grouped_transactions
-                .entry(self.key(signer_id, signer_public_key))
+                .entry(self.key(
+                    signer_id,
+                    signer_public_key,
+                    signed_tx.transaction.nonce().nonce_index(),
+                ))
                 .or_insert_with(HashSet::new)
                 .insert(signed_tx.get_hash());
         }
@@ -233,7 +246,7 @@ impl<'a> TransactionGroupIterator for PoolIteratorWrapper<'a> {
             self.pool.last_used_key = key;
             let mut validated_txs =
                 self.pool.transactions.remove(&key).expect("just checked existence");
-            validated_txs.sort_by_key(|vt| std::cmp::Reverse(vt.nonce()));
+            validated_txs.sort_by_key(|vt| std::cmp::Reverse(vt.nonce().nonce()));
             self.sorted_groups.push_back(TransactionGroup {
                 key,
                 transactions: validated_txs,
@@ -381,7 +394,7 @@ mod tests {
         (
             prepare_transactions(&mut pool, expected_weight)
                 .iter()
-                .map(|tx| tx.transaction.nonce())
+                .map(|tx| tx.transaction.nonce().nonce())
                 .collect(),
             pool,
         )
@@ -455,8 +468,10 @@ mod tests {
         let (mut nonces, mut pool) = process_txs_to_nonces(transactions, 10);
         sort_pairs(&mut nonces[..6]);
         assert_eq!(nonces, vec![1, 21, 2, 22, 3, 23, 24, 25, 26, 27]);
-        let nonces: Vec<u64> =
-            prepare_transactions(&mut pool, 10).iter().map(|tx| tx.transaction.nonce()).collect();
+        let nonces: Vec<u64> = prepare_transactions(&mut pool, 10)
+            .iter()
+            .map(|tx| tx.transaction.nonce().nonce())
+            .collect();
         assert_eq!(nonces, vec![28, 29, 30, 31]);
     }
 
@@ -502,9 +517,9 @@ mod tests {
         assert_eq!(pool.len(), txs_to_check.len());
 
         let mut pool_txs = prepare_transactions(&mut pool, txs_to_check.len() as u32);
-        pool_txs.sort_by_key(|tx| tx.transaction.nonce());
+        pool_txs.sort_by_key(|tx| tx.transaction.nonce().nonce());
         let mut expected_txs = txs_to_check.to_vec();
-        expected_txs.sort_by_key(|tx| tx.nonce());
+        expected_txs.sort_by_key(|tx| tx.nonce().nonce());
         let expected_txs =
             expected_txs.into_iter().map(|vt| vt.into_signed_tx()).collect::<Vec<_>>();
 
@@ -524,7 +539,7 @@ mod tests {
         let mut pool_iter = pool.pool_iterator();
         while let Some(iter) = pool_iter.next() {
             while let Some(tx) = iter.next() {
-                if tx.nonce() & 1 == 1 {
+                if tx.nonce().nonce() & 1 == 1 {
                     res.push(tx);
                     break;
                 }
@@ -533,7 +548,7 @@ mod tests {
         drop(pool_iter);
         assert_eq!(pool.len(), 0);
         assert_eq!(pool.transaction_size(), 0);
-        let mut nonces: Vec<_> = res.into_iter().map(|tx| tx.nonce()).collect();
+        let mut nonces: Vec<_> = res.into_iter().map(|tx| tx.nonce().nonce()).collect();
         sort_pairs(&mut nonces[..4]);
         assert_eq!(nonces, vec![1, 21, 3, 23, 25, 27, 29, 31]);
     }
@@ -592,7 +607,8 @@ mod tests {
         let txs = prepare_transactions(&mut pool, 5);
         assert_eq!(txs.len(), 5);
         nonces.sort();
-        let mut new_nonces = txs.iter().map(|tx| tx.transaction.nonce()).collect::<Vec<_>>();
+        let mut new_nonces =
+            txs.iter().map(|tx| tx.transaction.nonce().nonce()).collect::<Vec<_>>();
         new_nonces.sort();
         assert_ne!(nonces, new_nonces);
     }
@@ -632,4 +648,6 @@ mod tests {
             }
         }
     }
+
+    // TODO(gaskey): Add tests for gas key transactions
 }

--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -487,6 +487,11 @@ impl From<NearActions> for Vec<crate::models::Operation> {
                 | near_primitives::transaction::Action::UseGlobalContract(_) => {
                     // TODO(#12639): Implement global contracts support, ignored for now.
                 }
+                near_primitives::action::Action::AddGasKey(_)
+                | near_primitives::action::Action::DeleteGasKey(_)
+                | near_primitives::action::Action::FundGasKey(_) => {
+                    // TODO(#12639): Implement gas key support, ignored for now.
+                }
             }
         }
         operations

--- a/core/primitives-core/src/account.rs
+++ b/core/primitives-core/src/account.rs
@@ -568,6 +568,43 @@ pub struct FunctionCallPermission {
     pub method_names: Vec<String>,
 }
 
+/// The current state of either an access key, or a specific nonce of a gas key. It's used to validate
+/// and charge transactions.
+pub enum AccountKeyState {
+    AccessKey(AccessKey),
+    GasKey { gas_key: GasKey, nonce_index: NonceIndex, nonce: Nonce },
+}
+
+impl AccountKeyState {
+    pub fn nonce(&self) -> Nonce {
+        match self {
+            AccountKeyState::AccessKey(access_key) => access_key.nonce,
+            AccountKeyState::GasKey { nonce, .. } => *nonce,
+        }
+    }
+
+    pub fn nonce_mut(&mut self) -> &mut Nonce {
+        match self {
+            AccountKeyState::AccessKey(access_key) => &mut access_key.nonce,
+            AccountKeyState::GasKey { nonce, .. } => nonce,
+        }
+    }
+
+    pub fn permission(&self) -> &AccessKeyPermission {
+        match self {
+            AccountKeyState::AccessKey(access_key) => &access_key.permission,
+            AccountKeyState::GasKey { gas_key, .. } => &gas_key.permission,
+        }
+    }
+
+    pub fn permission_mut(&mut self) -> &mut AccessKeyPermission {
+        match self {
+            AccountKeyState::AccessKey(access_key) => &mut access_key.permission,
+            AccountKeyState::GasKey { gas_key, .. } => &mut gas_key.permission,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -6,8 +6,8 @@
 use crate::account::{AccessKey, AccessKeyPermission, Account, FunctionCallPermission};
 use crate::action::delegate::{DelegateAction, SignedDelegateAction};
 use crate::action::{
-    DeployGlobalContractAction, GlobalContractDeployMode, GlobalContractIdentifier,
-    UseGlobalContractAction,
+    AddGasKeyAction, DeleteGasKeyAction, DeployGlobalContractAction, FundGasKeyAction,
+    GlobalContractDeployMode, GlobalContractIdentifier, UseGlobalContractAction,
 };
 use crate::bandwidth_scheduler::BandwidthRequests;
 use crate::block::{Block, BlockHeader, Tip};
@@ -232,24 +232,27 @@ pub struct GasKeyView {
     pub num_nonces: NonceIndex,
     pub balance: Balance,
     pub permission: AccessKeyPermissionView,
+    /// If requested, the nonces are included.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonces: Option<Vec<Nonce>>,
 }
 
-impl From<GasKey> for GasKeyView {
-    fn from(gas_key: GasKey) -> Self {
+impl GasKeyView {
+    pub fn from_gas_key_no_nonces(gas_key: GasKey) -> Self {
         Self {
             num_nonces: gas_key.num_nonces,
             balance: gas_key.balance,
             permission: gas_key.permission.into(),
+            nonces: None,
         }
     }
-}
 
-impl From<GasKeyView> for GasKey {
-    fn from(view: GasKeyView) -> Self {
+    pub fn from_gas_key_with_nonces(gas_key: GasKey, nonces: Vec<Nonce>) -> Self {
         Self {
-            num_nonces: view.num_nonces,
-            balance: view.balance,
-            permission: view.permission.into(),
+            num_nonces: gas_key.num_nonces,
+            balance: gas_key.balance,
+            permission: gas_key.permission.into(),
+            nonces: Some(nonces),
         }
     }
 }
@@ -305,6 +308,25 @@ impl FromIterator<AccessKeyInfoView> for AccessKeyList {
     }
 }
 
+#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct GasKeyInfoView {
+    pub public_key: PublicKey,
+    pub gas_key: GasKeyView,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct GasKeyList {
+    pub keys: Vec<GasKeyInfoView>,
+}
+
+impl From<Vec<GasKeyInfoView>> for GasKeyList {
+    fn from(keys: Vec<GasKeyInfoView>) -> Self {
+        Self { keys }
+    }
+}
+
 // cspell:words deepsize
 #[cfg_attr(feature = "deepsize_feature", derive(deepsize::DeepSizeOf))]
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -347,6 +369,8 @@ pub enum QueryResponseKind {
     CallResult(CallResult),
     AccessKey(AccessKeyView),
     AccessKeyList(AccessKeyList),
+    GasKey(GasKeyView),
+    GasKeyList(GasKeyList),
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -371,6 +395,14 @@ pub enum QueryRequest {
         public_key: PublicKey,
     },
     ViewAccessKeyList {
+        account_id: AccountId,
+    },
+    ViewGasKey {
+        account_id: AccountId,
+        public_key: PublicKey,
+        include_nonces: bool,
+    },
+    ViewGasKeyList {
         account_id: AccountId,
     },
     CallFunction {
@@ -1322,6 +1354,21 @@ pub enum ActionView {
     UseGlobalContractByAccountId {
         account_id: AccountId,
     },
+    AddGasKey {
+        public_key: PublicKey,
+        num_nonces: NonceIndex,
+        permission: AccessKeyPermissionView,
+    },
+    FundGasKey {
+        public_key: PublicKey,
+        #[serde(with = "dec_format")]
+        #[cfg_attr(feature = "schemars", schemars(with = "String"))]
+        deposit: Balance,
+    },
+    DeleteGasKey {
+        public_key: PublicKey,
+        num_nonces: NonceIndex,
+    },
 }
 
 impl From<Action> for ActionView {
@@ -1370,6 +1417,18 @@ impl From<Action> for ActionView {
                 GlobalContractIdentifier::AccountId(account_id) => {
                     ActionView::UseGlobalContractByAccountId { account_id }
                 }
+            },
+            Action::AddGasKey(action) => ActionView::AddGasKey {
+                public_key: action.public_key,
+                num_nonces: action.num_nonces,
+                permission: action.permission.into(),
+            },
+            Action::FundGasKey(action) => {
+                ActionView::FundGasKey { public_key: action.public_key, deposit: action.deposit }
+            }
+            Action::DeleteGasKey(action) => ActionView::DeleteGasKey {
+                public_key: action.public_key,
+                num_nonces: action.num_nonces,
             },
         }
     }
@@ -1430,6 +1489,19 @@ impl TryFrom<ActionView> for Action {
                     contract_identifier: GlobalContractIdentifier::AccountId(account_id),
                 }))
             }
+            ActionView::AddGasKey { public_key, num_nonces, permission } => {
+                Action::AddGasKey(Box::new(AddGasKeyAction {
+                    public_key,
+                    num_nonces,
+                    permission: permission.into(),
+                }))
+            }
+            ActionView::FundGasKey { public_key, deposit } => {
+                Action::FundGasKey(Box::new(FundGasKeyAction { public_key, deposit }))
+            }
+            ActionView::DeleteGasKey { public_key, num_nonces } => {
+                Action::DeleteGasKey(Box::new(DeleteGasKeyAction { public_key, num_nonces }))
+            }
         })
     }
 }
@@ -1448,6 +1520,8 @@ impl TryFrom<ActionView> for Action {
 pub struct SignedTransactionView {
     pub signer_id: AccountId,
     pub public_key: PublicKey,
+    /// Present for gas keys, missing for access keys.
+    pub nonce_index: Option<NonceIndex>,
     pub nonce: Nonce,
     pub receiver_id: AccountId,
     pub actions: Vec<ActionView>,
@@ -1468,7 +1542,16 @@ impl From<SignedTransaction> for SignedTransactionView {
         SignedTransactionView {
             signer_id: transaction.signer_id().clone(),
             public_key: transaction.public_key().clone(),
-            nonce: transaction.nonce(),
+            nonce_index: match transaction.nonce() {
+                crate::transaction::TransactionNonce::AccessKey { .. } => None,
+                crate::transaction::TransactionNonce::GasKey { nonce_index, .. } => {
+                    Some(nonce_index)
+                }
+            },
+            nonce: match transaction.nonce() {
+                crate::transaction::TransactionNonce::AccessKey { nonce } => nonce,
+                crate::transaction::TransactionNonce::GasKey { nonce, .. } => nonce,
+            },
             receiver_id: transaction.receiver_id().clone(),
             actions: transaction.take_actions().into_iter().map(|action| action.into()).collect(),
             signature: signed_tx.signature,
@@ -2632,7 +2715,11 @@ impl From<StateChangeValue> for StateChangeValueView {
                 Self::AccessKeyDeletion { account_id, public_key }
             }
             StateChangeValue::GasKeyUpdate { account_id, public_key, gas_key } => {
-                Self::GasKeyUpdate { account_id, public_key, gas_key: gas_key.into() }
+                Self::GasKeyUpdate {
+                    account_id,
+                    public_key,
+                    gas_key: GasKeyView::from_gas_key_no_nonces(gas_key),
+                }
             }
             StateChangeValue::GasKeyNonceUpdate { account_id, public_key, index, nonce } => {
                 Self::GasKeyNonceUpdate { account_id, public_key, index, nonce }

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -28,7 +28,7 @@ use near_vm_runner::FilesystemContractRuntimeCache;
 use near_vm_runner::logic::LimitConfig;
 use node_runtime::config::tx_cost;
 use node_runtime::{
-    ApplyState, Runtime, SignedValidPeriodTransactions, get_signer_and_access_key,
+    ApplyState, Runtime, SignedValidPeriodTransactions, get_signer_and_key_state,
     set_tx_state_changes, verify_and_charge_tx_ephemeral,
 };
 use std::collections::HashMap;
@@ -457,19 +457,19 @@ impl Testbed<'_> {
         let cost =
             tx_cost(&self.apply_state.config, &validated_tx.to_tx(), gas_price, PROTOCOL_VERSION)
                 .unwrap();
-        let (mut signer, mut access_key) = get_signer_and_access_key(&state_update, &validated_tx)
+        let (mut signer, mut key_state) = get_signer_and_key_state(&state_update, &validated_tx)
             .expect("getting signer and access key should not fail in estimator");
 
         verify_and_charge_tx_ephemeral(
             &self.apply_state.config,
             &mut signer,
-            &mut access_key,
+            &mut key_state,
             &validated_tx,
             &cost,
             block_height,
         )
         .expect("tx verification should not fail in estimator");
-        set_tx_state_changes(&mut state_update, &validated_tx, &signer, &access_key);
+        set_tx_state_changes(&mut state_update, &validated_tx, &signer, &key_state);
         clock.elapsed()
     }
 

--- a/runtime/runtime/src/adapter.rs
+++ b/runtime/runtime/src/adapter.rs
@@ -7,7 +7,7 @@ use near_primitives::types::{
     AccountId, BlockHeight, EpochHeight, EpochId, EpochInfoProvider, MerkleHash,
 };
 use near_primitives::version::ProtocolVersion;
-use near_primitives::views::ViewStateResult;
+use near_primitives::views::{GasKeyInfoView, GasKeyView, ViewStateResult};
 use near_vm_runner::ContractCode;
 
 /// Adapter for querying runtime.
@@ -57,6 +57,22 @@ pub trait ViewRuntimeAdapter {
         state_root: MerkleHash,
         account_id: &AccountId,
     ) -> Result<Vec<(PublicKey, AccessKey)>, crate::state_viewer::errors::ViewAccessKeyError>;
+
+    fn view_gas_key(
+        &self,
+        shard_uid: &ShardUId,
+        state_root: MerkleHash,
+        account_id: &AccountId,
+        public_key: &PublicKey,
+        include_nonces: bool,
+    ) -> Result<GasKeyView, crate::state_viewer::errors::ViewGasKeyError>;
+
+    fn view_gas_keys(
+        &self,
+        shard_uid: &ShardUId,
+        state_root: MerkleHash,
+        account_id: &AccountId,
+    ) -> Result<Vec<GasKeyInfoView>, crate::state_viewer::errors::ViewGasKeyError>;
 
     fn view_state(
         &self,

--- a/runtime/runtime/src/pipelining.rs
+++ b/runtime/runtime/src/pipelining.rs
@@ -242,6 +242,9 @@ impl ReceiptPreparationPipeline {
                 | Action::Stake(_)
                 | Action::AddKey(_)
                 | Action::DeleteKey(_)
+                | Action::AddGasKey(_)
+                | Action::FundGasKey(_)
+                | Action::DeleteGasKey(_)
                 | Action::DeleteAccount(_)
                 | Action::DeployGlobalContract(_) => {}
             }

--- a/runtime/runtime/src/state_viewer/errors.rs
+++ b/runtime/runtime/src/state_viewer/errors.rs
@@ -33,6 +33,16 @@ pub enum ViewAccessKeyError {
 }
 
 #[derive(thiserror::Error, Debug)]
+pub enum ViewGasKeyError {
+    #[error("Account ID \"{requested_account_id}\" is invalid")]
+    InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
+    #[error("Gas key for public key #{public_key} does not exist")]
+    GasKeyDoesNotExist { public_key: near_crypto::PublicKey },
+    #[error("Internal error: #{error_message}")]
+    InternalError { error_message: String },
+}
+
+#[derive(thiserror::Error, Debug)]
 pub enum ViewStateError {
     #[error("Account ID \"{requested_account_id}\" is invalid")]
     InvalidAccountId { requested_account_id: near_primitives::types::AccountId },
@@ -85,6 +95,12 @@ impl From<near_primitives::errors::StorageError> for ViewContractCodeError {
 }
 
 impl From<near_primitives::errors::StorageError> for ViewAccessKeyError {
+    fn from(storage_error: near_primitives::errors::StorageError) -> Self {
+        Self::InternalError { error_message: storage_error.to_string() }
+    }
+}
+
+impl From<near_primitives::errors::StorageError> for ViewGasKeyError {
     fn from(storage_error: near_primitives::errors::StorageError) -> Self {
         Self::InternalError { error_message: storage_error.to_string() }
     }

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -5,7 +5,7 @@ use crate::pipelining::ReceiptPreparationPipeline;
 use crate::receipt_manager::ReceiptManager;
 use near_crypto::{KeyType, PublicKey};
 use near_parameters::RuntimeConfigStore;
-use near_primitives::account::{AccessKey, Account};
+use near_primitives::account::{AccessKey, Account, GasKey};
 use near_primitives::action::GlobalContractIdentifier;
 use near_primitives::apply::ApplyChunkReason;
 use near_primitives::bandwidth_scheduler::BlockBandwidthRequests;
@@ -13,14 +13,14 @@ use near_primitives::borsh::BorshDeserialize;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{ActionReceipt, Receipt, ReceiptEnum, ReceiptV1};
 use near_primitives::transaction::FunctionCallAction;
-use near_primitives::trie_key::trie_key_parsers;
+use near_primitives::trie_key::trie_key_parsers::{self, parse_trie_key_gas_key_from_raw_key};
 use near_primitives::types::{
-    AccountId, BlockHeight, EpochHeight, EpochId, EpochInfoProvider, Gas, ShardId,
+    AccountId, BlockHeight, EpochHeight, EpochId, EpochInfoProvider, Gas, Nonce, ShardId,
 };
 use near_primitives::version::PROTOCOL_VERSION;
-use near_primitives::views::{StateItem, ViewStateResult};
+use near_primitives::views::{GasKeyView, StateItem, ViewStateResult};
 use near_primitives_core::config::ViewConfig;
-use near_store::{TrieUpdate, get_access_key, get_account};
+use near_store::{TrieUpdate, get_access_key, get_account, get_gas_key, get_gas_key_nonce};
 use near_vm_runner::logic::{ProtocolVersion, ReturnData};
 use near_vm_runner::{ContractCode, ContractRuntimeCache};
 use std::{str, sync::Arc, time::Instant};
@@ -146,6 +146,111 @@ impl TrieViewer {
                 })
                 .collect::<Result<Vec<_>, errors::ViewAccessKeyError>>();
         access_keys
+    }
+
+    pub fn view_gas_key(
+        &self,
+        state_update: &TrieUpdate,
+        account_id: &AccountId,
+        public_key: &PublicKey,
+        include_nonces: bool,
+    ) -> Result<near_primitives::views::GasKeyView, errors::ViewGasKeyError> {
+        let gas_key = get_gas_key(state_update, account_id, public_key)?.ok_or_else(|| {
+            errors::ViewGasKeyError::GasKeyDoesNotExist { public_key: public_key.clone() }
+        })?;
+        let nonces = if include_nonces {
+            let mut nonces = Vec::new();
+            for nonce_index in 0..gas_key.num_nonces {
+                let nonce = get_gas_key_nonce(state_update, account_id, public_key, nonce_index)?
+                    .ok_or_else(|| errors::ViewGasKeyError::InternalError {
+                    error_message: format!(
+                        "Unexpected missing nonce for gas key {:?} at index {}",
+                        public_key, nonce_index
+                    ),
+                })?;
+                nonces.push(nonce);
+            }
+            Some(nonces)
+        } else {
+            None
+        };
+        Ok(near_primitives::views::GasKeyView {
+            num_nonces: gas_key.num_nonces,
+            balance: gas_key.balance,
+            permission: gas_key.permission.into(),
+            nonces,
+        })
+    }
+
+    pub fn view_gas_keys(
+        &self,
+        state_update: &TrieUpdate,
+        account_id: &AccountId,
+    ) -> Result<Vec<near_primitives::views::GasKeyInfoView>, errors::ViewGasKeyError> {
+        let prefix = trie_key_parsers::get_raw_prefix_for_gas_keys(account_id);
+        let mut result: Vec<near_primitives::views::GasKeyInfoView> = Vec::new();
+        for raw_key in state_update.iter(&prefix)? {
+            let raw_key = raw_key?;
+            let trie_key = parse_trie_key_gas_key_from_raw_key(&raw_key).map_err(|err| {
+                errors::ViewGasKeyError::InternalError {
+                    error_message: format!("Failed to parse gas key from raw key: {:?}", err),
+                }
+            })?;
+            let near_primitives::trie_key::TrieKey::GasKey { public_key, index, .. } = &trie_key
+            else {
+                return Err(errors::ViewGasKeyError::InternalError {
+                    error_message: "Unexpected trie key type for gas key".to_string(),
+                });
+            };
+            if index.is_some() {
+                // This is a gas key nonce. The nonce should be for the last gas key that we've parsed.
+                let value =
+                    near_store::get::<Nonce>(state_update, &trie_key)?.ok_or_else(|| {
+                        errors::ViewGasKeyError::InternalError {
+                            error_message: "Unexpected missing trie value from iterator"
+                                .to_string(),
+                        }
+                    })?;
+                result
+                    .last_mut()
+                    .ok_or_else(|| errors::ViewGasKeyError::InternalError {
+                        error_message: "Unexpected gas key nonce without gas key".to_string(),
+                    })?
+                    .gas_key
+                    .nonces
+                    .as_mut()
+                    .unwrap()
+                    .push(value);
+            } else {
+                // This is a new gas key.
+                let value =
+                    near_store::get::<GasKey>(state_update, &trie_key)?.ok_or_else(|| {
+                        errors::ViewGasKeyError::InternalError {
+                            error_message: "Unexpected missing trie value from iterator"
+                                .to_string(),
+                        }
+                    })?;
+                let gas_key_view = GasKeyView::from_gas_key_with_nonces(value, Vec::new());
+                result.push(near_primitives::views::GasKeyInfoView {
+                    public_key: public_key.clone(),
+                    gas_key: gas_key_view,
+                });
+            }
+        }
+        // Sanity check that we've got all nonces for each gas key.
+        for key in &result {
+            if key.gas_key.num_nonces as usize != key.gas_key.nonces.as_ref().unwrap().len() {
+                return Err(errors::ViewGasKeyError::InternalError {
+                    error_message: format!(
+                        "Gas key {:?} has {} nonces in the trie, but specifies num_nonces = {}",
+                        key.public_key,
+                        key.gas_key.nonces.as_ref().unwrap().len(),
+                        key.gas_key.num_nonces
+                    ),
+                });
+            }
+        }
+        Ok(result)
     }
 
     pub fn view_state(

--- a/test-loop-tests/src/tests/gas_keys.rs
+++ b/test-loop-tests/src/tests/gas_keys.rs
@@ -1,0 +1,298 @@
+use crate::setup::builder::TestLoopBuilder;
+use crate::setup::env::TestLoopEnv;
+use crate::setup::state::NodeExecutionData;
+use crate::utils::ONE_NEAR;
+use crate::utils::client_queries::ClientQueries;
+use crate::utils::transactions::get_anchor_hash;
+use itertools::Itertools;
+use near_async::messaging::CanSend;
+use near_async::test_loop::TestLoopV2;
+use near_async::time::Duration;
+use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
+use near_client::ProcessTxRequest;
+use near_crypto::{InMemorySigner, KeyType, Signer};
+use near_o11y::testonly::init_test_logger;
+use near_primitives::account::{AccessKeyPermission, FunctionCallPermission};
+use near_primitives::action::{Action, AddGasKeyAction, FundGasKeyAction, TransferAction};
+use near_primitives::shard_layout::ShardLayout;
+use near_primitives::transaction::{SignedTransaction, TransactionNonce};
+use near_primitives::types::{AccountId, Nonce, NonceIndex};
+use near_primitives::views::AccessKeyPermissionView;
+use rand::Rng;
+
+#[test]
+fn test_gas_keys() {
+    init_test_logger();
+    let builder = TestLoopBuilder::new();
+
+    let num_accounts = 3;
+    let num_clients = 2;
+    let epoch_length = 10;
+    let shard_layout = ShardLayout::single_shard();
+    let accounts = (num_accounts - num_clients..num_accounts)
+        .map(|i| format!("account{}", i).parse().unwrap())
+        .collect::<Vec<AccountId>>();
+    let client_accounts = accounts.iter().take(num_clients).cloned().collect_vec();
+    let validators_spec = ValidatorsSpec::desired_roles(
+        &client_accounts.iter().map(|t| t.as_str()).collect_vec(),
+        &[],
+    );
+
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .epoch_length(epoch_length)
+        .shard_layout(shard_layout.clone())
+        .validators_spec(validators_spec)
+        .add_user_accounts_simple(&accounts, 1_000_000 * ONE_NEAR)
+        .genesis_height(10000)
+        .transaction_validity_period(1000)
+        .build();
+    let epoch_config_store = TestEpochConfigBuilder::build_store_from_genesis(&genesis);
+    let TestLoopEnv { mut test_loop, node_datas, .. } = builder
+        .genesis(genesis)
+        .epoch_config_store(epoch_config_store)
+        .clients(client_accounts)
+        .build()
+        .warmup();
+
+    let mut gas_keys = create_gas_keys(&mut test_loop, &node_datas, &accounts);
+
+    send_transfers_as_gas_keys(&mut test_loop, &node_datas, &mut gas_keys, &accounts);
+
+    test_loop.shutdown_and_drain_remaining_events(Duration::seconds(5));
+}
+
+struct GasKeySigner {
+    signer: Signer,
+    nonces: Vec<Nonce>,
+    is_full_access: bool,
+}
+
+fn create_gas_keys(
+    test_loop: &mut TestLoopV2,
+    node_datas: &[NodeExecutionData],
+    accounts: &[AccountId],
+) -> Vec<Vec<GasKeySigner>> {
+    let clients = node_datas
+        .iter()
+        .map(|test_data| &test_loop.data.get(&test_data.client_sender.actor_handle()).client)
+        .collect_vec();
+
+    let anchor_hash = get_anchor_hash(&clients);
+
+    let mut signers: Vec<Vec<Signer>> = Vec::new();
+    for (i, account) in accounts.iter().enumerate() {
+        let key1 = InMemorySigner::from_random(account.clone(), KeyType::ED25519);
+        let key2 = InMemorySigner::from_random(account.clone(), KeyType::SECP256K1);
+        signers.push(vec![Signer::InMemory(key1.clone()), Signer::InMemory(key2.clone())]);
+        let action1 = Action::AddGasKey(Box::new(AddGasKeyAction {
+            num_nonces: (i + 1) as u32,
+            public_key: key1.public_key(),
+            permission: AccessKeyPermission::FullAccess,
+        }));
+        let action2 = Action::AddGasKey(Box::new(AddGasKeyAction {
+            num_nonces: (i + 1) as u32,
+            public_key: key2.public_key(),
+            permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
+                allowance: None,
+                method_names: vec!["allowed".to_string()],
+                receiver_id: account.to_string(),
+            }),
+        }));
+        let action3 = Action::FundGasKey(Box::new(FundGasKeyAction {
+            public_key: key1.public_key(),
+            deposit: 100000 * ONE_NEAR,
+        }));
+        let action4 = Action::FundGasKey(Box::new(FundGasKeyAction {
+            public_key: key2.public_key(),
+            deposit: 100000 * ONE_NEAR,
+        }));
+        let tx = SignedTransaction::from_actions_v2(
+            TransactionNonce::AccessKey { nonce: 1 },
+            account.clone(),
+            account.clone(),
+            &InMemorySigner::test_signer(account),
+            vec![action1, action2, action3, action4],
+            anchor_hash,
+            0,
+        );
+        let process_tx_request =
+            ProcessTxRequest { transaction: tx, is_forwarded: false, check_only: false };
+        node_datas[i % clients.len()].rpc_handler_sender.send(process_tx_request);
+    }
+    // Give plenty of time for these transactions to complete.
+    test_loop.run_for(Duration::seconds(20));
+
+    let clients = node_datas
+        .iter()
+        .map(|test_data| &test_loop.data.get(&test_data.client_sender.actor_handle()).client)
+        .collect_vec();
+
+    let mut gas_key_signers: Vec<Vec<GasKeySigner>> = Vec::new();
+
+    for (i, (account, keys)) in accounts.iter().zip(&signers).enumerate() {
+        assert_eq!(clients.query_balance(account), 800000 * ONE_NEAR);
+        let gas_key_view1 = clients.query_gas_key(account, &keys[0].public_key());
+        assert_eq!(gas_key_view1.balance, 100000 * ONE_NEAR);
+        assert_eq!(gas_key_view1.nonces.as_ref().unwrap().len(), (i + 1) as usize);
+        assert!(matches!(gas_key_view1.permission, AccessKeyPermissionView::FullAccess));
+        let gas_key_view2 = clients.query_gas_key(account, &keys[1].public_key());
+        assert_eq!(gas_key_view2.balance, 100000 * ONE_NEAR);
+        assert_eq!(gas_key_view2.nonces.as_ref().unwrap().len(), (i + 1) as usize);
+        assert!(matches!(
+            gas_key_view2.permission,
+            AccessKeyPermissionView::FunctionCall{allowance: None, method_names, receiver_id } if method_names == vec!["allowed".to_string()] && receiver_id == account.to_string()
+        ));
+        gas_key_signers.push(vec![
+            GasKeySigner {
+                signer: keys[0].clone(),
+                nonces: gas_key_view1.nonces.unwrap(),
+                is_full_access: true,
+            },
+            GasKeySigner {
+                signer: keys[1].clone(),
+                nonces: gas_key_view2.nonces.unwrap(),
+                is_full_access: false,
+            },
+        ]);
+    }
+    gas_key_signers
+}
+
+fn send_transfers_as_gas_keys(
+    test_loop: &mut TestLoopV2,
+    node_datas: &[NodeExecutionData],
+    gas_keys: &mut [Vec<GasKeySigner>],
+    accounts: &[AccountId],
+) {
+    let clients = node_datas
+        .iter()
+        .map(|test_data| &test_loop.data.get(&test_data.client_sender.actor_handle()).client)
+        .collect_vec();
+
+    let anchor_hash = get_anchor_hash(&clients);
+
+    let mut expected_account_balances = accounts.iter().map(|_| 800000 * ONE_NEAR).collect_vec();
+    let mut expected_gas_key_balances = gas_keys
+        .iter()
+        .map(|keys| keys.iter().map(|_| 100000 * ONE_NEAR).collect_vec())
+        .collect_vec();
+
+    let gas_key_public_keys = gas_keys
+        .iter()
+        .map(|keys| keys.iter().map(|key| key.signer.public_key()).collect_vec())
+        .collect_vec();
+
+    for (from_index, account) in accounts.iter().enumerate() {
+        // The second key should fail, because it is a FunctionCall key only.
+        for (from_key_index, key) in gas_keys[from_index].iter_mut().enumerate() {
+            // Each nonce index can independently support a separate transaction sequence.
+            for (nonce_index, nonce) in key.nonces.iter_mut().enumerate() {
+                for (to_index, other_account) in accounts.iter().enumerate() {
+                    let deposit1 = random_deposit();
+                    let deposit2 = random_deposit();
+                    let deposit3 = random_deposit();
+                    let to_key_index = rand::thread_rng().gen_range(0..2);
+                    let use_old_nonce = rand::thread_rng().gen_bool(0.2);
+                    let tx = SignedTransaction::from_actions_v2(
+                        TransactionNonce::GasKey {
+                            nonce_index: nonce_index as NonceIndex,
+                            nonce: if use_old_nonce { *nonce } else { *nonce + 1 } as Nonce,
+                        },
+                        account.clone(),
+                        other_account.clone(),
+                        &key.signer,
+                        vec![
+                            // Transfer from gas key to an account.
+                            Action::Transfer(TransferAction { deposit: deposit1 }),
+                            // Transfer from gas key to gas key.
+                            Action::FundGasKey(Box::new(FundGasKeyAction {
+                                public_key: gas_key_public_keys[to_index][to_key_index].clone(),
+                                deposit: deposit2,
+                            })),
+                            // Transfer from gas key to a non-existent gas key which falls back to the account.
+                            Action::FundGasKey(Box::new(FundGasKeyAction {
+                                public_key: InMemorySigner::from_random(
+                                    other_account.clone(),
+                                    KeyType::ED25519,
+                                )
+                                .public_key(),
+                                deposit: deposit3,
+                            })),
+                        ],
+                        anchor_hash,
+                        0,
+                    );
+                    let process_tx_request = ProcessTxRequest {
+                        transaction: tx,
+                        is_forwarded: false,
+                        check_only: false,
+                    };
+                    if use_old_nonce {
+                        // If we use an old nonce, we're testing that reusing a nonce doesn't work.
+                        // So send it in later, so that we know this transaction is the one arriving
+                        // later for this nonce (and not the intended transaction).
+                        let rpc_handler_sender =
+                            node_datas[from_index % clients.len()].rpc_handler_sender.clone();
+                        test_loop.send_adhoc_event_with_delay(
+                            "send old nonce tx".to_string(),
+                            Duration::seconds(2),
+                            move |_| {
+                                rpc_handler_sender.send(process_tx_request);
+                            },
+                        );
+                    } else {
+                        node_datas[from_index % clients.len()]
+                            .rpc_handler_sender
+                            .send(process_tx_request);
+                    }
+
+                    if !use_old_nonce && key.is_full_access {
+                        // Update expected balances only for the transactions that are expected to succeed.
+                        expected_account_balances[to_index] += deposit1;
+                        expected_gas_key_balances[from_index][from_key_index] -= deposit1;
+
+                        expected_gas_key_balances[to_index][to_key_index] += deposit2;
+                        expected_gas_key_balances[from_index][from_key_index] -= deposit2;
+
+                        expected_account_balances[to_index] += deposit3;
+                        expected_gas_key_balances[from_index][from_key_index] -= deposit3;
+
+                        *nonce += 1;
+                    }
+                }
+            }
+        }
+    }
+    // Give plenty of time for these transactions to complete.
+    test_loop.run_for(Duration::seconds(20));
+
+    let clients = node_datas
+        .iter()
+        .map(|test_data| &test_loop.data.get(&test_data.client_sender.actor_handle()).client)
+        .collect_vec();
+    for (i, account) in accounts.iter().enumerate() {
+        assert_eq!(clients.query_balance(account), expected_account_balances[i]);
+        for (j, key) in gas_keys[i].iter().enumerate() {
+            let gas_key_view = clients.query_gas_key(account, &key.signer.public_key());
+            assert_eq!(
+                gas_key_view.balance, expected_gas_key_balances[i][j],
+                "Gas key balance mismatch for account: {}, key index: {}",
+                account, j
+            );
+            assert_eq!(
+                gas_key_view.nonces.as_ref().unwrap(),
+                &key.nonces,
+                "Gas key nonces mismatch for account: {}, key index: {}",
+                account,
+                j
+            );
+        }
+    }
+}
+
+fn random_deposit() -> u128 {
+    // Random deposit between 1 and 100 NEAR
+    let mut rng = rand::thread_rng();
+    let deposit = rng.gen_range(1..=100) * ONE_NEAR;
+    deposit
+}

--- a/test-loop-tests/src/tests/mod.rs
+++ b/test-loop-tests/src/tests/mod.rs
@@ -30,3 +30,4 @@ mod spice;
 mod state_sync;
 mod syncing;
 mod view_requests_to_archival_node;
+mod gas_keys;

--- a/test-loop-tests/src/utils/client_queries.rs
+++ b/test-loop-tests/src/utils/client_queries.rs
@@ -1,15 +1,17 @@
 use near_client::Client;
+use near_crypto::PublicKey;
 use near_epoch_manager::shard_assignment::{account_id_to_shard_id, shard_id_to_uid};
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::{AccountId, Balance, ShardId};
 use near_primitives::views::{
-    FinalExecutionOutcomeView, QueryRequest, QueryResponse, QueryResponseKind,
+    FinalExecutionOutcomeView, GasKeyView, QueryRequest, QueryResponse, QueryResponseKind,
 };
 
 pub trait ClientQueries {
     fn client_index_tracking_account(&self, account: &AccountId) -> usize;
     fn runtime_query(&self, account: &AccountId, query: QueryRequest) -> QueryResponse;
     fn query_balance(&self, account: &AccountId) -> Balance;
+    fn query_gas_key(&self, account_id: &AccountId, key: &PublicKey) -> GasKeyView;
     #[allow(unused)]
     fn view_call(&self, account: &AccountId, method: &str, args: &[u8]) -> Vec<u8>;
     #[allow(unused)]
@@ -79,6 +81,22 @@ where
         );
         if let QueryResponseKind::ViewAccount(account_view) = response.kind {
             account_view.amount
+        } else {
+            panic!("Wrong return value")
+        }
+    }
+
+    fn query_gas_key(&self, account_id: &AccountId, key: &PublicKey) -> GasKeyView {
+        let response = self.runtime_query(
+            account_id,
+            QueryRequest::ViewGasKey {
+                account_id: account_id.clone(),
+                public_key: key.clone(),
+                include_nonces: true,
+            },
+        );
+        if let QueryResponseKind::GasKey(gas_key_view) = response.kind {
+            gas_key_view
         } else {
             panic!("Wrong return value")
         }

--- a/tools/state-viewer/src/contract_accounts.rs
+++ b/tools/state-viewer/src/contract_accounts.rs
@@ -138,6 +138,9 @@ pub(crate) enum ActionType {
     Delegate,
     DeployGlobalContract,
     UseGlobalContract,
+    AddGasKey,
+    FundGasKey,
+    DeleteGasKey,
 }
 
 impl ContractAccount {
@@ -348,6 +351,9 @@ fn try_find_actions_spawned_by_receipt(
                                         ActionType::DeployGlobalContract
                                     }
                                     Action::UseGlobalContract(_) => ActionType::UseGlobalContract,
+                                    Action::AddGasKey(_) => ActionType::AddGasKey,
+                                    Action::FundGasKey(_) => ActionType::FundGasKey,
+                                    Action::DeleteGasKey(_) => ActionType::DeleteGasKey,
                                 };
                                 entry
                                     .actions


### PR DESCRIPTION
At a high level
* Introduce the `AddGasKey`, `FundGasKey`, and `DeleteGasKey` actions
* Implement these actions in the runtime
* Introduce `TransactionV2` which allows specifying a gas key instead of an access key
* Implement the execution of gas-key-signed transactions to deduct cost from the gas key instead of the account
* Implement view queries including RPCs for gas keys
* Implement support of gas keys in the transaction pool (i.e. group by gas key + nonce index)
* Add a test loop test for adding and funding gas keys, and running transactions signed with gas keys.

Several things missing:
* Need a new protocol version and to reject these new actions and transaction type if the protocol version is not enabled
* Need more tests for various cases of invoking these actions as well as the gas-key-signed transactions
* Need more tests for the rpc and view client