### PR TITLE
feat(wasmtime): ensure CoW is used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5497,6 +5497,7 @@ dependencies = [
  "finite-wasm 0.5.0",
  "finite-wasm 0.6.0",
  "hex",
+ "libc",
  "lru 0.12.3",
  "memoffset 0.8.0",
  "near-crypto",
@@ -5538,6 +5539,7 @@ dependencies = [
  "wasmprinter 0.235.0",
  "wasmtime",
  "wat",
+ "winapi",
  "zeropool-bn",
 ]
 

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -21,6 +21,7 @@ ed25519-dalek.workspace = true
 enum-map.workspace = true
 finite-wasm = { workspace = true, features = ["instrument"], optional = true }
 finite-wasm-6 = { workspace = true, features = ["instrument"], optional = true }
+libc.workspace = true
 lru.workspace = true
 memoffset = { workspace = true, optional = true }
 num-rational.workspace = true
@@ -63,6 +64,9 @@ near-vm-2-compiler-singlepass = { workspace = true, optional = true }
 near-vm-2-engine = { workspace = true, optional = true }
 near-vm-2-types = { workspace = true, optional = true }
 near-vm-2-vm = { workspace = true, optional = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+winapi.workspace = true
 
 [dev-dependencies]
 arbitrary.workspace = true

--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -1,3 +1,5 @@
+// cspell:ignore waitlist
+
 #![doc = include_str!("../README.md")]
 #![cfg_attr(enable_const_type_id, feature(const_type_id))]
 
@@ -42,4 +44,30 @@ pub mod internal {
     pub use crate::runner::VMKindExt;
     #[cfg(feature = "prepare")]
     pub use wasmparser;
+}
+
+/// Drop something somewhat lazily.
+///
+/// The memory destruction is sorta expensive process, but not expensive enough to offload it into
+/// a thread for individual instances.
+///
+/// Instead this method will gather up a number of things before initiating a release in a thread,
+/// thus working in batches of sorts and amortizing the thread overhead.
+#[cfg(any(all(feature = "near_vm", target_arch = "x86_64"), feature = "wasmtime_vm"))]
+pub(crate) fn lazy_drop(what: Box<dyn std::any::Any + Send>) {
+    // TODO: this would benefit from a lock-free array (should be straightforward enough to
+    // implement too...) But for the time being this mutex is not really contended much so…
+    // whatever.
+    const CHUNK_SIZE: usize = 8;
+    static WAITLIST: std::sync::OnceLock<parking_lot::Mutex<Vec<Box<dyn std::any::Any + Send>>>> =
+        std::sync::OnceLock::new();
+    let waitlist = WAITLIST.get_or_init(|| parking_lot::Mutex::new(Vec::with_capacity(CHUNK_SIZE)));
+    let mut waitlist = waitlist.lock();
+    if waitlist.capacity() > waitlist.len() {
+        waitlist.push(Box::new(what));
+    }
+    if waitlist.capacity() == waitlist.len() {
+        let chunk = std::mem::replace(&mut *waitlist, Vec::with_capacity(CHUNK_SIZE));
+        rayon::spawn(move || drop(chunk));
+    }
 }

--- a/runtime/near-vm-runner/src/near_vm_2_runner/runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_2_runner/runner.rs
@@ -1,5 +1,3 @@
-// cspell:ignore waitlist
-
 use super::{NearVmMemory, VM_CONFIG};
 use crate::cache::CompiledContractInfo;
 use crate::errors::ContractPrecompilatonResult;
@@ -13,7 +11,8 @@ use crate::logic::{
 use crate::near_vm_2_runner::{NearVmCompiler, NearVmEngine};
 use crate::runner::VMResult;
 use crate::{
-    CompiledContract, Contract, ContractCode, ContractRuntimeCache, get_contract_cache_key, imports,
+    CompiledContract, Contract, ContractCode, ContractRuntimeCache, get_contract_cache_key,
+    imports, lazy_drop,
 };
 use crate::{NoContractRuntimeCache, prepare};
 use finite_wasm::Fee;
@@ -32,8 +31,6 @@ use near_vm_2_vm::{
     Artifact, ExportFunction, ExportFunctionMetadata, Instantiatable, LinearMemory, LinearTable,
     MemoryStyle, Resolver, TrapCode, VMFunction, VMFunctionKind, VMMemory,
 };
-use parking_lot::Mutex;
-use std::any::Any;
 use std::mem::size_of;
 use std::sync::{Arc, OnceLock};
 
@@ -438,30 +435,6 @@ impl NearVM {
         }
 
         Ok(Ok(()))
-    }
-}
-
-/// Drop something somewhat lazily.
-///
-/// The memory destruction is sorta expensive process, but not expensive enough to offload it into
-/// a thread for individual instances.
-///
-/// Instead this method will gather up a number of things before initiating a release in a thread,
-/// thus working in batches of sorts and amortizing the thread overhead.
-fn lazy_drop(what: Box<dyn Any + Send>) {
-    // TODO: this would benefit from a lock-free array (should be straightforward enough to
-    // implement too...) But for the time being this mutex is not really contended much so…
-    // whatever.
-    const CHUNK_SIZE: usize = 8;
-    static WAITLIST: OnceLock<Mutex<Vec<Box<dyn Any + Send>>>> = OnceLock::new();
-    let waitlist = WAITLIST.get_or_init(|| Mutex::new(Vec::with_capacity(CHUNK_SIZE)));
-    let mut waitlist = waitlist.lock();
-    if waitlist.capacity() > waitlist.len() {
-        waitlist.push(Box::new(what));
-    }
-    if waitlist.capacity() == waitlist.len() {
-        let chunk = std::mem::replace(&mut *waitlist, Vec::with_capacity(CHUNK_SIZE));
-        rayon::spawn(move || drop(chunk));
     }
 }
 

--- a/runtime/near-vm-runner/src/near_vm_runner/runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_runner/runner.rs
@@ -1,5 +1,3 @@
-// cspell:ignore waitlist
-
 use super::{NearVmMemory, VM_CONFIG};
 use crate::cache::CompiledContractInfo;
 use crate::errors::ContractPrecompilatonResult;
@@ -13,7 +11,8 @@ use crate::logic::{
 use crate::near_vm_runner::{NearVmCompiler, NearVmEngine};
 use crate::runner::VMResult;
 use crate::{
-    CompiledContract, Contract, ContractCode, ContractRuntimeCache, get_contract_cache_key, imports,
+    CompiledContract, Contract, ContractCode, ContractRuntimeCache, get_contract_cache_key,
+    imports, lazy_drop,
 };
 use crate::{NoContractRuntimeCache, prepare};
 use memoffset::offset_of;
@@ -29,8 +28,6 @@ use near_vm_vm::{
     Artifact, ExportFunction, ExportFunctionMetadata, Instantiatable, LinearMemory, LinearTable,
     MemoryStyle, Resolver, TrapCode, VMFunction, VMFunctionKind, VMMemory,
 };
-use parking_lot::Mutex;
-use std::any::Any;
 use std::mem::size_of;
 use std::sync::{Arc, OnceLock};
 
@@ -434,30 +431,6 @@ impl NearVM {
         }
 
         Ok(Ok(()))
-    }
-}
-
-/// Drop something somewhat lazily.
-///
-/// The memory destruction is sorta expensive process, but not expensive enough to offload it into
-/// a thread for individual instances.
-///
-/// Instead this method will gather up a number of things before initiating a release in a thread,
-/// thus working in batches of sorts and amortizing the thread overhead.
-fn lazy_drop(what: Box<dyn Any + Send>) {
-    // TODO: this would benefit from a lock-free array (should be straightforward enough to
-    // implement too...) But for the time being this mutex is not really contended much so…
-    // whatever.
-    const CHUNK_SIZE: usize = 8;
-    static WAITLIST: OnceLock<Mutex<Vec<Box<dyn Any + Send>>>> = OnceLock::new();
-    let waitlist = WAITLIST.get_or_init(|| Mutex::new(Vec::with_capacity(CHUNK_SIZE)));
-    let mut waitlist = waitlist.lock();
-    if waitlist.capacity() > waitlist.len() {
-        waitlist.push(Box::new(what));
-    }
-    if waitlist.capacity() == waitlist.len() {
-        let chunk = std::mem::replace(&mut *waitlist, Vec::with_capacity(CHUNK_SIZE));
-        rayon::spawn(move || drop(chunk));
     }
 }
 

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -437,7 +437,7 @@ impl crate::PreparedContract for VMResult<PreparedContract> {
         // TODO: config could be accessed through `logic.result_state`, without this code having to
         // figure it out...
         link(&mut linker, memory_copy, &store, &config, &mut logic);
-        let res = instantiate_and_call(&mut store, &mut linker, &module, &method);
+        let res = instantiate_and_call(&mut store, &linker, &module, &method);
         lazy_drop(Box::new((linker, module, store)));
         match res? {
             RunOutcome::Ok => Ok(VMOutcome::ok(logic.result_state)),

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -8,7 +8,7 @@ use crate::logic::{External, MemSlice, MemoryLike, VMContext, VMLogic, VMOutcome
 use crate::runner::VMResult;
 use crate::{
     CompiledContract, CompiledContractInfo, Contract, ContractCode, ContractRuntimeCache,
-    NoContractRuntimeCache, get_contract_cache_key, imports, prepare,
+    NoContractRuntimeCache, get_contract_cache_key, imports, lazy_drop, prepare,
 };
 use near_parameters::RuntimeFeesConfig;
 use near_parameters::vm::VMKind;
@@ -16,8 +16,7 @@ use std::borrow::Cow;
 use std::cell::{RefCell, UnsafeCell};
 use std::ffi::c_void;
 use std::sync::Arc;
-use wasmtime::ExternType::Func;
-use wasmtime::{Engine, Linker, Memory, MemoryType, Module, Store, Strategy};
+use wasmtime::{Engine, ExternType, Instance, Linker, Memory, MemoryType, Module, Store, Strategy};
 
 type Caller = wasmtime::Caller<'static, ()>;
 thread_local! {
@@ -320,32 +319,18 @@ impl crate::runner::VM for WasmtimeVM {
             method,
             |gas_counter, module| {
                 let config = Arc::clone(&self.config);
-                match module.get_export(method) {
-                    Some(export) => match export {
-                        Func(func_type) => {
-                            if func_type.params().len() != 0 || func_type.results().len() != 0 {
-                                let e = FunctionCallError::MethodResolveError(
-                                    MethodResolveError::MethodInvalidSignature,
-                                );
-                                let result = PreparationResult::OutcomeAbortButNopInOldProtocol(e);
-                                return Ok(PreparedContract { config, gas_counter, result });
-                            }
-                        }
-                        _ => {
-                            let e = FunctionCallError::MethodResolveError(
-                                MethodResolveError::MethodNotFound,
-                            );
-                            let result = PreparationResult::OutcomeAbortButNopInOldProtocol(e);
-                            return Ok(PreparedContract { config, gas_counter, result });
-                        }
-                    },
-                    None => {
-                        let e = FunctionCallError::MethodResolveError(
-                            MethodResolveError::MethodNotFound,
-                        );
-                        let result = PreparationResult::OutcomeAbortButNopInOldProtocol(e);
-                        return Ok(PreparedContract { config, gas_counter, result });
-                    }
+                let Some(ExternType::Func(func_type)) = module.get_export(method) else {
+                    let e =
+                        FunctionCallError::MethodResolveError(MethodResolveError::MethodNotFound);
+                    let result = PreparationResult::OutcomeAbortButNopInOldProtocol(e);
+                    return Ok(PreparedContract { config, gas_counter, result });
+                };
+                if func_type.params().len() != 0 || func_type.results().len() != 0 {
+                    let e = FunctionCallError::MethodResolveError(
+                        MethodResolveError::MethodInvalidSignature,
+                    );
+                    let result = PreparationResult::OutcomeAbortButNopInOldProtocol(e);
+                    return Ok(PreparedContract { config, gas_counter, result });
                 }
 
                 let mut store = Store::new(module.engine(), ());
@@ -372,7 +357,7 @@ struct ReadyContract {
     store: Store<()>,
     memory: WasmtimeMemory,
     module: Module,
-    method: String,
+    method: Box<str>,
 }
 
 struct PreparedContract {
@@ -386,6 +371,43 @@ enum PreparationResult {
     OutcomeAbortButNopInOldProtocol(FunctionCallError),
     OutcomeAbort(FunctionCallError),
     Ready(ReadyContract),
+}
+
+enum RunOutcome {
+    Ok,
+    AbortNop(FunctionCallError),
+    Abort(FunctionCallError),
+}
+
+fn call(
+    mut store: &mut Store<()>,
+    instance: Instance,
+    method: &str,
+) -> Result<RunOutcome, VMRunnerError> {
+    let Some(func) = instance.get_func(&mut store, method) else {
+        return Ok(RunOutcome::AbortNop(FunctionCallError::MethodResolveError(
+            MethodResolveError::MethodNotFound,
+        )));
+    };
+    match func.typed(&mut store) {
+        Ok(run) => match run.call(store, ()) {
+            Ok(()) => Ok(RunOutcome::Ok),
+            Err(err) => err.into_vm_error().map(RunOutcome::Abort),
+        },
+        Err(err) => err.into_vm_error().map(RunOutcome::Abort),
+    }
+}
+
+fn instantiate_and_call(
+    mut store: &mut Store<()>,
+    linker: &Linker<()>,
+    module: &Module,
+    method: &str,
+) -> Result<RunOutcome, VMRunnerError> {
+    match linker.instantiate(&mut store, module) {
+        Ok(instance) => call(store, instance, method),
+        Err(err) => err.into_vm_error().map(RunOutcome::Abort),
+    }
 }
 
 impl crate::PreparedContract for VMResult<PreparedContract> {
@@ -415,23 +437,14 @@ impl crate::PreparedContract for VMResult<PreparedContract> {
         // TODO: config could be accessed through `logic.result_state`, without this code having to
         // figure it out...
         link(&mut linker, memory_copy, &store, &config, &mut logic);
-        match linker.instantiate(&mut store, &module) {
-            Ok(instance) => match instance.get_func(&mut store, &method) {
-                Some(func) => match func.typed::<(), ()>(&mut store) {
-                    Ok(run) => match run.call(&mut store, ()) {
-                        Ok(_) => Ok(VMOutcome::ok(logic.result_state)),
-                        Err(err) => Ok(VMOutcome::abort(logic.result_state, err.into_vm_error()?)),
-                    },
-                    Err(err) => Ok(VMOutcome::abort(logic.result_state, err.into_vm_error()?)),
-                },
-                None => {
-                    return Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(
-                        logic.result_state,
-                        FunctionCallError::MethodResolveError(MethodResolveError::MethodNotFound),
-                    ));
-                }
-            },
-            Err(err) => Ok(VMOutcome::abort(logic.result_state, err.into_vm_error()?)),
+        let res = instantiate_and_call(&mut store, &mut linker, &module, &method);
+        lazy_drop(Box::new((linker, module, store)));
+        match res? {
+            RunOutcome::Ok => Ok(VMOutcome::ok(logic.result_state)),
+            RunOutcome::AbortNop(error) => {
+                Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(logic.result_state, error))
+            }
+            RunOutcome::Abort(error) => Ok(VMOutcome::abort(logic.result_state, error)),
         }
     }
 }

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -373,6 +373,15 @@ enum PreparationResult {
     Ready(ReadyContract),
 }
 
+/// This enum allows us to replicate the various [`VMOutcome`] states without moving [`VMLogic`]
+///
+/// If function like [`call`] where to rely on [`VMOutcome::ok`], for example, it would require
+/// ownership of [`VMLogic`], to acquire the inner [`ExecutionResultState`].
+/// `run`, however, owns [`VMLogic`] and creates a mutable borrow,
+/// which is then stored in a thread-local static as a raw pointer.
+/// This means that we need to be very careful to ensure that the reference created is only dropped
+/// after the module method call has returned.
+/// Moving the [`VMLogic`] would break this assertion.
 enum RunOutcome {
     Ok,
     AbortNop(FunctionCallError),


### PR DESCRIPTION
Blocked on #13797

Refs https://github.com/bytecodealliance/wasmtime/issues/9660

Like before, performance metrics are somewhat inconsistent, but this appears to perform better than #13797 more often than not

For example:
after: 3689/3689 blocks applied in 25m at a rate of 2.5211/s (https://github.com/cosmonic-labs/nearcore/commit/887b6984904ecd837286b0e65279bd0c89b0a587)
   - second run: 1381/1381 blocks applied in 9m at a rate of 2.5862/s
   - third run: 704/704 blocks applied in 4m at a rate of 2.6271/s
   - fourth run: 258/258 blocks applied in 2m at a rate of 2.7532/s


before: 2021/2021 blocks applied in 13m at a rate of 2.5004/s (https://github.com/cosmonic-labs/nearcore/commit/b33a95afa9cbe1c4284c6dd3d1e047de2ab5a346)
   - second run: 1450/1450 blocks applied in 9m at a rate of 2.7035/s
   - third run: 361/361 blocks applied in 2m at a rate of 2.4921/s
   - fourth run: 151/151 blocks applied in 64s at a rate of 2.3775/s

for reference: Wasmer 1020/1020 blocks applied in 2m at a rate of 7.5312/s

The key important thing here is https://github.com/bytecodealliance/wasmtime/blob/18b42ef4e48e498026237013df8ed5af9da0d72d/crates/wasmtime/src/runtime/vm/memory.rs#L526-L530