### PR TITLE
[test] Disable flaky state_sync_massive_validator

### DIFF
--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -49,9 +49,10 @@ pytest --timeout=270 sanity/single_shard_tracking.py
 pytest --timeout=270 sanity/single_shard_tracking.py --features nightly
 
 pytest --timeout=3600 sanity/state_sync_massive.py
-pytest --timeout=3600 sanity/state_sync_massive_validator.py
 pytest --timeout=3600 sanity/state_sync_massive.py --features nightly
-pytest --timeout=3600 sanity/state_sync_massive_validator.py --features nightly
+# TODO(#13551): Enable after fixing flaky test. state_sync_massive_validator sometimes take 1 hour to run and timeout
+# pytest --timeout=15m sanity/state_sync_massive_validator.py
+# pytest --timeout=15m sanity/state_sync_massive_validator.py --features nightly
 
 # TODO(#12108): Enable the test again once decentralized state sync is implemented.
 # pytest sanity/state_sync_decentralized.py


### PR DESCRIPTION
[#general > nayduck @ 💬](https://near.zulipchat.com/#narrow/channel/295302-general/topic/nayduck/near/525948179)

state_sync_massive_validator either completes is 10-12 min or times out after 1 hour.

This creates the issue where we are unable to retry the test and nayduck times out after 1 hour. It doesn't make sense to have timeout of an hour.