### PR TITLE
[nayduck] CI early exit on test failure

### DIFF
--- a/.github/workflows/nayduck_ci.yml
+++ b/.github/workflows/nayduck_ci.yml
@@ -39,6 +39,8 @@ jobs:
           # wait all the tests to finish
           while true; do
             TEST_RESULTS=$(curl -s https://nayduck.nearone.org/api/run/$RUN_ID)
+            TESTS_FAILED=$(jq '.tests | .[] | select(.status == "FAILED"") ' <<< ${TEST_RESULTS} )
+            if [ -n "$TESTS_FAILED" ]; then break; fi
             TESTS_NOT_READY=$(jq '.tests | .[] | select(.status == "RUNNING" or .status == "PENDING") ' <<< ${TEST_RESULTS} )
             if [ -z "$TESTS_NOT_READY" ]; then break; fi
             echo "Tests are not ready yet. Sleeping 1 minute..."


### PR DESCRIPTION
In the merge queue, a lot of times we know that a test has failed, yet the CI workflow waits for all the tests to complete before returning a failed exit status.

With this PR we do an early exit as soon as we see a failed nayduck test.

Note that this should still continue to execute ALL the tests in the nayduck test suite, just that the CI workflow exits early. This is useful when we want to get a list of all tests tha have failed.

Also note that in the merge queue, if a workflow fails, we `cancel` all downstream PRs in the merge queue. This would help speed that process up as well.