### PR TITLE
feat(forknet): Add forknet release scenarios

### DIFF
--- a/pytest/tests/mocknet/docs/release_forknet.md
+++ b/pytest/tests/mocknet/docs/release_forknet.md
@@ -14,7 +14,7 @@ The `release_forknet.py` script is used to run release test scenarios.
 2. Create the nodes:
 
 ```bash
-python python tests/mocknet/release_forknet.py --unique-id token --test-case test2.7 create
+python tests/mocknet/release_forknet.py --unique-id UNIQUE-ID --test-case test2.7 create
 ```
 
 3. Start the test

--- a/pytest/tests/mocknet/docs/release_forknet.md
+++ b/pytest/tests/mocknet/docs/release_forknet.md
@@ -6,7 +6,7 @@ The `release_forknet.py` script is used to run release test scenarios.
 * GCP access (SRE)
 * Infra-ops access (SRE)
 * Install gcloud tools locally [link](https://cloud.google.com/sdk/docs/install)
-* Undestand the basics of forknet from [mirror](mirror.md)
+* Understand the basics of forknet from [mirror](mirror.md)
 
 ## Usage
 
@@ -14,17 +14,17 @@ The `release_forknet.py` script is used to run release test scenarios.
 2. Create the nodes:
 
 ```bash
-python python tests/mocknet/release_forknet.py --unique-id tttest --test-case test2.7 create
+python python tests/mocknet/release_forknet.py --unique-id token --test-case test2.7 create
 ```
 
 3. Start the test
 ```bash
-python python tests/mocknet/release_forknet.py --unique-id tttest --test-case test2.7 start_test --neard-upgrade-binary-url $NEARD_UPGRADE_BINARY_URL
+python python tests/mocknet/release_forknet.py --unique-id token --test-case test2.7 start_test --neard-upgrade-binary-url $NEARD_UPGRADE_BINARY_URL
 ```
 
 4. Stop the test and free the nodes
 ```bash
-python python tests/mocknet/release_forknet.py --unique-id tttest --test-case test2.7 destroy
+python python tests/mocknet/release_forknet.py --unique-id token --test-case test2.7 destroy
 ```
 
 ## Adding testcase

--- a/pytest/tests/mocknet/docs/release_forknet.md
+++ b/pytest/tests/mocknet/docs/release_forknet.md
@@ -1,0 +1,62 @@
+# Release Forknet Tool
+
+The `release_forknet.py` script is used to run release test scenarios.
+
+## Prerequisites
+* GCP access (SRE)
+* Infra-ops access (SRE)
+* Install gcloud tools locally [link](https://cloud.google.com/sdk/docs/install)
+* Undestand the basics of forknet from [mirror](mirror.md)
+
+## Usage
+
+1. Go to `pytest` directory.
+2. Create the nodes:
+
+```bash
+python python tests/mocknet/release_forknet.py --unique-id tttest --test-case test2.7 create
+```
+
+3. Start the test
+```bash
+python python tests/mocknet/release_forknet.py --unique-id tttest --test-case test2.7 start_test --neard-upgrade-binary-url $NEARD_UPGRADE_BINARY_URL
+```
+
+4. Stop the test and free the nodes
+```bash
+python python tests/mocknet/release_forknet.py --unique-id tttest --test-case test2.7 destroy
+```
+
+## Adding testcase
+The test case functions will be executed sequentially in the order defined in [release_forknet.py](../release_forknet.py).
+To add a new test scenario:
+
+1. Create a new class in `tests/mocknet/release_scenarios/` that inherits from `TestSetup` base class
+
+2. Define required parameters in `__init__`:
+   ```python
+   def __init__(self, args):
+       # Set base binary URL for initial network state
+       args.neard_binary_url = 'https://...'
+       super().__init__(args)
+
+       # Required parameters:
+       self.start_height = 123456789  # Forknet image height
+       self.args.start_height = self.start_height
+       self.validators = 21  # Total validator count
+       self.block_producers = 18  # Number of block producers
+       self.epoch_len = 18000  # Epoch length in blocks
+       self.genesis_protocol_version = 77  # Protocol version
+
+       # Optional parameters:
+       self.has_archival = True  # Enable archival nodes
+       self.has_state_dumper = False  # Enable state dumper
+       self.regions = None  # List of GCP regions, None for default
+   ```
+
+3. Override methods to customize behavior:
+   - `amend_configs()` - Modify node configs before start
+   - `before_test_setup()` - Run commands before test creation
+   - `after_test_start()` - Run commands after test starts
+
+4. Add your class to the list of testcases under [TEST_CASES](../release_scenarios/__init__.py).

--- a/pytest/tests/mocknet/release_forknet.py
+++ b/pytest/tests/mocknet/release_forknet.py
@@ -1,0 +1,145 @@
+"""
+This script is used to run a release tests on a forknet.
+"""
+
+from argparse import ArgumentParser
+import sys
+import pathlib
+import subprocess
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
+from configured_logger import logger
+
+from release_scenarios import get_test_case, get_available_test_cases
+
+CHAIN_ID = "mainnet"
+
+
+def call_gh_workflow(action,
+                     unique_id,
+                     start_height,
+                     regions=None,
+                     validators=None,
+                     has_archival=None,
+                     has_state_dumper=None,
+                     tracing_server=None):
+    cmd = "gh workflow run mocknet_terraform.yml --repo Near-One/infra-ops "
+    cmd += f"-f action={action} "
+    cmd += f"-f unique_id={unique_id} "
+    cmd += f"-f start_height={start_height} "
+    if regions:
+        cmd += f"-f location_set={regions} "
+    if validators != None:
+        cmd += f"-f validators={validators} "
+    if has_archival != None:
+        cmd += f"-f archival_nodes={'true' if has_archival else 'false'} "
+    if has_state_dumper != None:
+        cmd += f"-f state_dumper={'true' if has_state_dumper else 'false'} "
+    if tracing_server != None:
+        cmd += f"-f tracing_server={'true' if tracing_server else 'false'} "
+    logger.info(f"Calling GH workflow with command: {cmd}")
+    result = subprocess.run(cmd, shell=True)
+    logger.info(
+        f"GH workflow call completed with return code: {result.returncode}")
+    return result.returncode
+
+
+def handle_create(args):
+    """
+    Create the infrastructure for the test case.
+    """
+    test_setup = get_test_case(args.test_case, args)
+    unique_id = args.unique_id
+    start_height = test_setup.start_height
+    regions = test_setup.regions
+    num_validators = test_setup.validators
+    has_archival = test_setup.has_archival
+    has_state_dumper = test_setup.has_state_dumper
+    tracing_server = test_setup.tracing_server
+    call_gh_workflow('apply', unique_id, start_height, regions, num_validators,
+                     has_archival, has_state_dumper, tracing_server)
+
+
+def handle_destroy(args):
+    test_setup = get_test_case(args.test_case, args)
+    unique_id = args.unique_id
+    start_height = test_setup.start_height
+    call_gh_workflow('destroy', unique_id, start_height)
+
+
+def handle_start_test(args):
+    test_setup = get_test_case(args.test_case, args)
+    test_setup.init_env()
+    test_setup.before_test_setup()
+    test_setup.new_test()
+    test_setup.wait_for_network_to_be_ready()
+    test_setup.amend_epoch_config()
+    test_setup.amend_configs_before_test_start()
+    test_setup.start_network()
+    test_setup.after_test_start()
+
+
+def main():
+    parser = ArgumentParser(
+        description='Forknet cluster parameters to launch a release test')
+    parser.set_defaults(
+        chain_id=CHAIN_ID,
+        local_test=False,
+        host_type="all",
+        host_filter=None,
+        select_partition=None,
+    )
+
+    parser.add_argument(
+        '--unique-id',
+        help='Unique ID for the test case',
+        required=True,
+    )
+
+    parser.add_argument(
+        '--test-case',
+        help=
+        f'Name of the test case to run (available test cases: {", ".join(get_available_test_cases())})',
+        required=True,
+    )
+
+    subparsers = parser.add_subparsers(
+        dest='command',
+        help='Available commands',
+    )
+
+    create_parser = subparsers.add_parser('create',
+                                          help='Create the infrastructure')
+
+    destroy_parser = subparsers.add_parser('destroy',
+                                           help='Destroy the infrastructure')
+
+    start_parser = subparsers.add_parser('start_test',
+                                         help='Start the release test')
+    start_parser.add_argument(
+        '--neard-binary-url',
+        help=
+        'URL of the neard binary to start with. Can be set in the test case class.',
+    )
+
+    start_parser.add_argument(
+        '--neard-upgrade-binary-url',
+        help=
+        'URL of the neard binary to upgrade to. Can be set in the test case class.',
+    )
+
+    args = parser.parse_args()
+
+    # Route to appropriate handler based on command
+    if args.command == 'create':
+        handle_create(args)
+    elif args.command == 'destroy':
+        handle_destroy(args)
+    elif args.command == 'start_test':
+        handle_start_test(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == '__main__':
+    main()

--- a/pytest/tests/mocknet/release_scenarios/__init__.py
+++ b/pytest/tests/mocknet/release_scenarios/__init__.py
@@ -1,0 +1,34 @@
+from .test27 import Test27, Test27Small
+
+# Dictionary mapping test case names to their classes
+TEST_CASES = {
+    'test2.7': Test27,
+    'test2.7-small': Test27Small,
+    # Add more test cases here as needed
+}
+
+
+def get_test_case(test_case_name, args):
+    """
+    Get a test case instance by name.
+
+    Args:
+        test_case_name (str): Name of the test case
+        args: Arguments object to pass to the test case constructor
+
+    Returns:
+        TestSetup: Instance of the requested test case
+    """
+    if test_case_name not in TEST_CASES:
+        available_cases = list(TEST_CASES.keys())
+        raise ValueError(
+            f"Unknown test case: {test_case_name}. Available test cases: {available_cases}"
+        )
+
+    test_class = TEST_CASES[test_case_name]
+    return test_class(args)
+
+
+def get_available_test_cases():
+    """Get a list of all available test case names."""
+    return list(TEST_CASES.keys())

--- a/pytest/tests/mocknet/release_scenarios/base.py
+++ b/pytest/tests/mocknet/release_scenarios/base.py
@@ -1,0 +1,245 @@
+"""
+This script is used to define release tests for forknet.
+"""
+
+import copy
+import pathlib
+import sys
+import tempfile
+import time
+
+from mirror import (CommandContext, amend_binaries_cmd, clear_scheduled_cmds,
+                    get_nodes_status, hard_reset_cmd, new_test_cmd,
+                    run_remote_cmd, run_remote_download_file,
+                    run_remote_upload_file, start_nodes_cmd, start_traffic_cmd,
+                    stop_nodes_cmd, update_config_cmd)
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
+from configured_logger import logger
+
+
+class TestSetup:
+    """
+    Base class for all test cases.
+    Do not use this class directly, use the subclasses instead and initialize the
+    variables in the __init__ method.
+    """
+
+    def __init__(self, args):
+        self.args = args
+        # The forknet image height.
+        self.args.start_height = None
+        self.start_height = None
+        # The unique id of the forknet.
+        self.unique_id = args.unique_id
+
+        self.has_archival = False
+        self.has_state_dumper = False
+        self.tracing_server = False
+        # The GCP regions to be used for the nodes.
+        self.regions = None
+        # The number of validators.
+        self.validators = None
+        # The number of block producers. The rest will be chunk validators.
+        self.block_producers = None
+        # The base binary url to be used for the nodes.
+        self.neard_binary_url = None
+        # The new binary url to be used for the nodes.
+        self.neard_upgrade_binary_url = getattr(args,
+                                                'neard_upgrade_binary_url', '')
+
+    def init_env(self):
+        """
+        Setup the forknet environment for the test.
+        """
+        logger.info(
+            f"Initializing environment for test case {self.args.test_case}")
+        # Load test state orchestrator
+        init_args = copy.deepcopy(self.args)
+        init_args.neard_upgrade_binary_url = ''
+        init_args.yes = True
+        hard_reset_cmd(CommandContext(init_args))
+
+        # Traffic node should always run the latest binary to avoid restarting it.
+        if self.neard_upgrade_binary_url != '':
+            logger.info(f"Amending binaries on traffic node.")
+            amend_binaries_args = copy.deepcopy(self.args)
+            amend_binaries_args.binary_idx = 0
+            amend_binaries_args.epoch_height = None
+            amend_binaries_args.neard_binary_url = self.neard_upgrade_binary_url
+            amend_binaries_args.host_type = 'traffic'
+            amend_binaries_cmd(CommandContext(amend_binaries_args))
+
+        # Clear scheduled commands.
+        logger.info(f"Clearing scheduled commands.")
+        clear_args = copy.deepcopy(self.args)
+        clear_args.filter = '*'
+        clear_scheduled_cmds(CommandContext(clear_args))
+
+    def before_test_setup(self):
+        """
+        This command will be called before the test case is created.
+        """
+        pass
+
+    def _setup_archival(self):
+        """
+        Setup archival for the test.
+        """
+        # TODO: move this to a helper script on the hosts.
+        cfg_args = copy.deepcopy(self.args)
+        cfg_args.host_filter = '.*archiv.*'
+        cfg_args.set = ';'.join([
+            'archive=true', 'gc_num_epochs_to_keep=3', 'save_trie_changes=true',
+            'split_storage.enable_split_storage_view_client=true',
+            'cold_store.path="/home/ubuntu/.near/cold"', 'tracked_shards=[0]',
+            'store.load_mem_tries_for_tracked_shards=false'
+        ])
+        update_config_cmd(CommandContext(cfg_args))
+
+        run_args = copy.deepcopy(self.args)
+        run_args.host_filter = '.*archiv.*'
+        run_args.cmd = "rm -rf /home/ubuntu/.near/cold /home/ubuntu/.near/validator_key.json && /home/ubuntu/.near/neard-runner/binaries/neard0 database change-db-kind --new-kind Hot change-hot"
+        run_remote_cmd(CommandContext(run_args))
+
+    def new_test(self):
+        """
+        Create a new test case.
+        """
+
+        new_test_args = copy.deepcopy(self.args)
+        new_test_args.epoch_length = self.epoch_len
+        new_test_args.genesis_protocol_version = self.genesis_protocol_version
+        new_test_args.num_validators = self.validators
+        new_test_args.num_seats = self.block_producers
+        new_test_args.stateless_setup = True
+        new_test_args.new_chain_id = self.unique_id
+        new_test_args.yes = True
+        new_test_args.gcs_state_sync = self.has_state_dumper
+        new_test_args.state_source = 'dump'
+        new_test_args.patches_path = None
+
+        new_test_cmd(CommandContext(new_test_args))
+
+        if self.has_archival:
+            self._setup_archival()
+
+    def wait_for_network_to_be_ready(self):
+        """
+        Wait for the network to be ready.
+        """
+        ctx = CommandContext(self.args)
+        while True:
+            nodes = ctx.get_targeted()
+            not_ready_nodes = get_nodes_status(nodes)
+            if len(not_ready_nodes) == 0:
+                break
+            logger.info(
+                f"Waiting for network to be ready. {len(not_ready_nodes)} nodes not ready."
+            )
+            time.sleep(1)
+        logger.info("Network is ready.")
+
+    def _share_epoch_configs(self):
+        """
+        Share the latest epoch configs with the nodes.
+        """
+        # Download the epoch configs from the traffic node.
+        # It potentially has the latest epoch configs.
+        tmp_dir = tempfile.mkdtemp()
+        download_args = copy.deepcopy(self.args)
+        download_args.host_type = 'traffic'
+        download_args.src = "~/.near/target/epoch_configs"
+        download_args.dst = tmp_dir
+        run_remote_download_file(CommandContext(download_args))
+
+        # Copy the epoch configs to the rest of the nodes.
+        upload_args = copy.deepcopy(self.args)
+        upload_args.host_type = 'nodes'
+        upload_args.src = f'{tmp_dir}/epoch_configs/*'
+        upload_args.dst = '~/.near/epoch_configs/'
+        run_remote_upload_file(CommandContext(upload_args))
+
+    def _amend_epoch_config(self, jq_field):
+        # TODO: move this in the helper scripts on the hosts.
+        """
+        Amend the epoch config with the given jq field.
+        """
+        jq_cmd = f"""-type f -name "*.json" -exec sh -c 'jq "{jq_field}" $1 > $1.tmp && mv $1.tmp $1' _ {{}} \;"""
+        cmd_node = f"find ~/.near/epoch_configs/ {jq_cmd}"
+        cmd_traffic = f"find ~/.near/target/epoch_configs/ {jq_cmd}"
+        run_cmd_args = copy.deepcopy(self.args)
+        run_cmd_args.host_type = 'nodes'
+        run_cmd_args.cmd = cmd_node
+        run_remote_cmd(CommandContext(run_cmd_args))
+        run_cmd_args.host_type = 'traffic'
+        run_cmd_args.cmd = cmd_traffic
+        run_remote_cmd(CommandContext(run_cmd_args))
+
+    def _reduce_chunk_validators_stake(self):
+        """
+        Reduce the stake of the chunk validators to avoid accidntally becoming the block producers.
+        """
+        # TODO: install the near validator tools and setup the environment.
+        # TODO: run the validator tools to reduce the stake of the chunk validators.
+        pass
+
+    def amend_epoch_config(self):
+        self._share_epoch_configs()
+        self._amend_epoch_config(
+            f".num_chunk_validator_seats = {self.validators}")
+        self._reduce_chunk_validators_stake()
+
+    def amend_configs_before_test_start(self):
+        """
+        Amend the configs for the test.
+        """
+        pass
+
+    def start_network(self):
+        """
+        mirror start-nodes
+        """
+        start_nodes_args = copy.deepcopy(self.args)
+        start_nodes_args.batch_interval_millis = None
+        start_traffic_cmd(CommandContext(start_nodes_args))
+
+    def _schedule_upgrade_nodes_every_n_minutes(self, minutes):
+        """
+        Make 4 batches of upgrades.
+        Stop the nodes, amend the binaries, and start the nodes.
+        """
+        if self.neard_upgrade_binary_url == '':
+            return
+
+        for i in range(1, 5):
+            stop_nodes_args = copy.deepcopy(self.args)
+            stop_nodes_args.host_type = 'nodes'
+            stop_nodes_args.select_partition = (i, 4)
+            stop_nodes_args.schedule_in = f"{(i * minutes)}m"
+            stop_nodes_args.schedule_id = f"up-stop-{i}"
+            stop_nodes_cmd(CommandContext(stop_nodes_args))
+
+            amend_binaries_args = copy.deepcopy(self.args)
+            amend_binaries_args.binary_idx = 0
+            amend_binaries_args.epoch_height = None
+            amend_binaries_args.neard_binary_url = self.neard_upgrade_binary_url
+            amend_binaries_args.host_type = 'nodes'
+            amend_binaries_args.select_partition = (i, 4)
+            amend_binaries_args.schedule_in = f"{(i * minutes * 60 + 20)}"
+            amend_binaries_args.schedule_id = f"up-change-{i}"
+            amend_binaries_cmd(CommandContext(amend_binaries_args))
+
+            start_nodes_args = copy.deepcopy(self.args)
+            start_nodes_args.host_type = 'nodes'
+            start_nodes_args.select_partition = (i, 4)
+            start_nodes_args.schedule_in = f"{(i*minutes + 1)}m"
+            start_nodes_args.schedule_id = f"up-start-{i}"
+            start_nodes_cmd(CommandContext(start_nodes_args))
+
+    def after_test_start(self):
+        """
+        Use this event to run any commands after the test is started.
+        """
+        # Schedule the nodes to upgrade to the new binary every n minutes.
+        # self._schedule_upgrade_nodes_every_n_minutes(40)

--- a/pytest/tests/mocknet/release_scenarios/base.py
+++ b/pytest/tests/mocknet/release_scenarios/base.py
@@ -88,7 +88,7 @@ class TestSetup:
         """
         # TODO: move this to a helper script on the hosts.
         cfg_args = copy.deepcopy(self.args)
-        cfg_args.host_filter = '.*archiv.*'
+        cfg_args.host_filter = '.*archival.*'
         cfg_args.set = ';'.join([
             'archive=true', 'gc_num_epochs_to_keep=3', 'save_trie_changes=true',
             'split_storage.enable_split_storage_view_client=true',
@@ -98,7 +98,7 @@ class TestSetup:
         update_config_cmd(CommandContext(cfg_args))
 
         run_args = copy.deepcopy(self.args)
-        run_args.host_filter = '.*archiv.*'
+        run_args.host_filter = '.*archival.*'
         run_args.cmd = "rm -rf /home/ubuntu/.near/cold /home/ubuntu/.near/validator_key.json && /home/ubuntu/.near/neard-runner/binaries/neard0 database change-db-kind --new-kind Hot change-hot"
         run_remote_cmd(CommandContext(run_args))
 
@@ -178,7 +178,7 @@ class TestSetup:
 
     def _reduce_chunk_validators_stake(self):
         """
-        Reduce the stake of the chunk validators to avoid accidntally becoming the block producers.
+        Reduce the stake of the chunk validators to avoid accidentally becoming the block producers.
         """
         # TODO: install the near validator tools and setup the environment.
         # TODO: run the validator tools to reduce the stake of the chunk validators.

--- a/pytest/tests/mocknet/release_scenarios/test27.py
+++ b/pytest/tests/mocknet/release_scenarios/test27.py
@@ -1,0 +1,74 @@
+"""
+Test case classes for release tests on forknet.
+"""
+from .base import TestSetup
+import copy
+
+
+class Test27(TestSetup):
+    """
+    Test case 2.7:
+    - upgrade from 2.6.3 to 2.7
+    """
+
+    def __init__(self, args):
+        args.neard_binary_url = 'https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/Linux/2.6.3_forknet/neard'
+        super().__init__(args)
+        self.start_height = 149655594
+        self.args.start_height = self.start_height
+        self.validators = 21
+        self.block_producers = 18
+        self.epoch_len = 18000  # roughly 2h 30m @ 2bps
+        self.genesis_protocol_version = 77
+        self.has_archival = True
+        self.regions = None
+        self.upgrade_interval_minutes = 40  # Within the first 2 epochs
+
+    def amend_configs(self):
+        super().amend_configs()
+        cfg_args = copy.deepcopy(self.args)
+        # Reduce the block production delay for this release test.
+        # These configs will be default in 2.7
+        cfg_args.set = ';'.join([
+            'consensus.min_block_production_delay={"secs":0,"nanos":600000000}',
+            'consensus.max_block_production_delay={"secs":1,"nanos":800000000}',
+            'consensus.chunk_wait_mult=[1,3]',
+            'consensus.doomslug_step_period={"secs":0,"nanos":10000000}',
+        ])
+        update_config_cmd(CommandContext(cfg_args))
+
+    def after_test_start(self):
+        """
+        Use this event to run any commands after the test is started.
+        """
+        super().after_test_start()
+        self._schedule_upgrade_nodes_every_n_minutes(
+            self.upgrade_interval_minutes)
+
+
+class Test27Small(Test27):
+    """
+    Smaller test case for 2.7:
+    Short epoch length, long blocks.
+    Less validators.
+    """
+
+    def __init__(self, args):
+        super().__init__(args)
+        self.validators = 9
+        self.block_producers = 8
+        self.epoch_len = 5000
+        self.has_archival = True
+        self.regions = None
+        self.upgrade_interval_minutes = 5  # Within the first 2 epochs
+
+    def amend_configs(self):
+        super().amend_configs()
+        cfg_args = copy.deepcopy(self.args)
+        cfg_args.set = ';'.join([
+            'consensus.min_block_production_delay={"secs":1,"nanos":300000000}',
+            'consensus.max_block_production_delay={"secs":3,"nanos":0}',
+            'consensus.chunk_wait_mult=[1,6]',
+            'consensus.doomslug_step_period={"secs":0,"nanos":100000000}'
+        ])
+        update_config_cmd(CommandContext(cfg_args))


### PR DESCRIPTION
This pull request adds a framework for running release tests in a Forknet environment. It includes new scripts, test definitions, and updates to existing infrastructure to simplify setting up and managing release test scenarios.

## New Forknet Release Testing Framework
- Added `release_forknet.py` to manage Forknet release test lifecycles — create infra, run tests, and clean up. Supports commands like `create`, `start_test`, and `destroy`.
- Introduced a `TestSetup` base class in `release_scenarios/base.py` to standardize how test cases initialize environments, update configs, and check network readiness.
- Added `Test27` and `Test27Small` in `release_scenarios/test27.py` to test upgrades from 2.6.3 to 2.7 with configurable validator and epoch settings.
- Created a test registry in `release_scenarios/__init__.py` to map test case names to classes and list available tests.

## Infrastructure Updates
- Updated `mirror.py`:
  - Added `--yes` flag to skip confirmation for hard reset.
  - Improved type handling in `get_targeted()` and other minor fixes.

## Documentation
- Added `release_forknet.md` with usage instructions, prerequisites, CLI commands, and how to define new test cases.
