### PR TITLE
feat(spice): apply chunk asynchronously

### DIFF
--- a/chain/client/src/chunk_executor_actor.rs
+++ b/chain/client/src/chunk_executor_actor.rs
@@ -318,7 +318,7 @@ impl ChunkExecutorActor {
 
         let apply_done_sender = self.myself_sender.clone();
         self.apply_chunks_spawner.spawn("apply_chunks", move || {
-            let mut apply_results =  Vec::new();
+            let mut apply_results = Vec::new();
             let block_hash = *block.hash();
             for (shard_id, _, result) in do_apply_chunks(BlockToApply::Normal(block_hash), block.header().height(), jobs) {
                 match result {

--- a/test-loop-tests/src/setup/setup.rs
+++ b/test-loop-tests/src/setup/setup.rs
@@ -1,4 +1,3 @@
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use near_async::messaging::{IntoMultiSender, IntoSender, LateBoundSender, noop};
@@ -299,7 +298,8 @@ pub fn setup_client(
         epoch_manager.clone(),
         shard_tracker.clone(),
         network_adapter.as_multi_sender(),
-        NonZeroUsize::new(1000).unwrap(),
+        Arc::new(test_loop.async_computation_spawner(identifier, |_| Duration::milliseconds(80))),
+        chunk_executor_adapter.as_sender(),
     );
 
     let chunk_executor_sender = test_loop.data.register_actor(

--- a/test-loop-tests/src/tests/spice.rs
+++ b/test-loop-tests/src/tests/spice.rs
@@ -87,7 +87,7 @@ fn test_spice_chain() {
         let view_client = test_loop_data.get_mut(&view_client_handle);
 
         let query_response = view_client.handle(Query::new(
-            BlockReference::latest(),
+            BlockReference::Finality(near_primitives::types::Finality::Final),
             QueryRequest::ViewAccount { account_id: account.clone() },
         ));
 


### PR DESCRIPTION
The main goal of this PR is to move expensive chunk application outside of actor thread, just like we currently do as part of block processing and stateless validation.

Implementation notes:
- We send `ExecutorApplyChunksDone` message back to chunk executor actor so that database changes are happen as part of the actor thread. This is needed because `ChainStore` is not thread safe. As an alternative we could create a new instance of `ChainStore` for every chunk application.
- We keep track of blocks that are currently applied with `blocks_in_execution`. Also we check database for existence of the corresponding chunk extras to verify if the block was already processed.
- A requirement for previous block to be executed is added in order to start applying chunks for the current block. Alternatively we could reject receipt proof for the shards we track and then we would have to wait until actor saves receipt proof itself to the database.
- Sending messages back to the same actor with `myself_sender` is monkey-see-monkey-do based on `Client`'s implementation of the same concept.
- `pending_next_blocks` is changed from `LruCache` to regular `HashMap` that is actively maintained up to date through removal of the processed blocks. This is better because no blocks should be dropped, so cache eviction could hide potential issues. Later we need to add a metric to monitor the size of the map to make sure it is properly cleared and doesn't grow in size of time (that would indicate a bug in the implementation).
- Block reference in the test is changed from `BlockReference::latest()` to `BlockReference::Finality(near_primitives::types::Finality::Final)` in order to make it work. With async chunk application query on the latest block fails because chunks are not applied yet hence chunk extra is missing. Using final block introduces enough delay to make it work, but that is just a temporary fix while we look for the proper solution.