### PR TITLE
Chore: trigger crates publish on RC releases

### DIFF
--- a/.github/workflows/near_crates_publish.yml
+++ b/.github/workflows/near_crates_publish.yml
@@ -4,7 +4,7 @@ name: Near Crates Publish
 
 on:
   release:
-    types: [released]
+    types: [published]
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
Before it was happening only on full releases