### PR TITLE
[2.6.4] Better ordinals

### DIFF
--- a/chain/chain/src/store/utils.rs
+++ b/chain/chain/src/store/utils.rs
@@ -252,7 +252,7 @@ pub fn retrieve_headers(
     let block_ordinal = chain_store.get_block_merkle_tree(&header.hash())?.size();
 
     let mut headers = vec![];
-    for i in 1..max_headers_returned {
+    for i in 1..=max_headers_returned {
         match chain_store
             .get_block_hash_from_ordinal(block_ordinal.saturating_add(i))
             .and_then(|block_hash| chain_store.get_block_header(&block_hash))

--- a/chain/chain/src/store/utils.rs
+++ b/chain/chain/src/store/utils.rs
@@ -246,13 +246,15 @@ pub fn retrieve_headers(
         None => return Ok(vec![]),
     };
 
-    // Block ordinals stored in db are off by one so adding 0 will return the next block after `header`.
-    // get_block_hash_from_ordinal(i).block_ordinal() == i + 1
-    // See #8177
+    // Use `get_block_merkle_tree` to get the block ordinal for this header.
+    // We can't use the `header.block_ordinal()` method because older block headers don't have this field.
+    // The same method is used in `get_locator` which creates the headers request and chain store when saving block ordinals.
+    let block_ordinal = chain_store.get_block_merkle_tree(&header.hash())?.size();
+
     let mut headers = vec![];
-    for i in 0..max_headers_returned {
+    for i in 1..max_headers_returned {
         match chain_store
-            .get_block_hash_from_ordinal(header.block_ordinal().saturating_add(i))
+            .get_block_hash_from_ordinal(block_ordinal.saturating_add(i))
             .and_then(|block_hash| chain_store.get_block_header(&block_hash))
         {
             Ok(h) => headers.push(h),

--- a/chain/client/src/sync/header.rs
+++ b/chain/client/src/sync/header.rs
@@ -341,6 +341,8 @@ impl HeaderSync {
         let store = chain.chain_store();
         let tip = store.header_head()?;
         // We could just get the ordinal from the header, but it's off by one: #8177.
+        // Note: older block headers don't have ordinals, so for them we can't get the ordinal from header,
+        // have to use get_block_merkle_tree.
         let tip_ordinal = store.get_block_merkle_tree(&tip.last_block_hash)?.size();
         let final_head = store.final_head()?;
         let final_head_ordinal = store.get_block_merkle_tree(&final_head.last_block_hash)?.size();


### PR DESCRIPTION
We can't use `header.block_ordinal()` because old headers don't have this field.
Let's use `get_block_merkle_tree` to get the block ordinal. It's also used for the same purpose in other parts of the codebase (e.g get_locator).