### PR TITLE
 feat(store): cache None values (for StateShardUIdMapping) 

### DIFF
--- a/core/store/src/adapter/trie_store.rs
+++ b/core/store/src/adapter/trie_store.rs
@@ -208,10 +208,11 @@ pub fn get_shard_uid_mapping(store: &Store, child_shard_uid: ShardUId) -> ShardU
 /// Get the `ShardUId` mapping for child_shard_uid. If the mapping does not exist, return None.
 fn maybe_get_shard_uid_mapping(store: &Store, child_shard_uid: ShardUId) -> Option<ShardUId> {
     store
-        .get_ser::<ShardUId>(DBCol::StateShardUIdMapping, &child_shard_uid.to_bytes())
+        .caching_get_ser::<ShardUId>(DBCol::StateShardUIdMapping, &child_shard_uid.to_bytes())
         .unwrap_or_else(|_| {
             panic!("get_shard_uid_mapping() failed for child_shard_uid = {}", child_shard_uid)
         })
+        .map(|v| *v)
 }
 
 /// Get the key for the given `shard_uid` and `hash`.

--- a/core/store/src/deserialized_column.rs
+++ b/core/store/src/deserialized_column.rs
@@ -31,6 +31,9 @@ pub(super) struct ColumnCache {
     /// of database into itself and return them directly to the caller. The write operation
     /// itself will take care of discarding dirty data.
     pub(super) active_flushes: u64,
+    /// If true, the cache will store `None` values in the cache,
+    /// which indicates that the key was not found in the database.
+    store_none_values: bool,
 }
 
 impl ColumnCache {
@@ -41,7 +44,19 @@ impl ColumnCache {
     fn new(capacity: usize) -> Option<Mutex<Self>> {
         let capacity = NonZeroUsize::new(capacity);
         let values = capacity.map(|cap| lru::LruCache::new(cap))?;
-        Some(Mutex::new(Self { values, active_flushes: 0 }))
+        Some(Mutex::new(Self { values, active_flushes: 0, store_none_values: false }))
+    }
+
+    fn with_none_values(inner: Option<Mutex<Self>>) -> Option<Mutex<Self>> {
+        if let Some(cache) = &inner {
+            let mut cache = cache.lock();
+            cache.store_none_values = true;
+        };
+        inner
+    }
+
+    pub(super) fn store_none_values(&self) -> bool {
+        self.store_none_values
     }
 }
 
@@ -64,7 +79,9 @@ impl Cache {
                 | DBCol::Block => ColumnCache::new(32),
                 | DBCol::ChunkExtra => ColumnCache::new(1024),
                 | DBCol::PartialChunks => ColumnCache::new(512),
-                | DBCol::StateShardUIdMapping => ColumnCache::new(32),
+                | DBCol::StateShardUIdMapping => ColumnCache::with_none_values(
+                    ColumnCache::new(32),
+                ),
                 _ => ColumnCache::disabled(),
             },
         }

--- a/core/store/src/deserialized_column.rs
+++ b/core/store/src/deserialized_column.rs
@@ -64,6 +64,7 @@ impl Cache {
                 | DBCol::Block => ColumnCache::new(32),
                 | DBCol::ChunkExtra => ColumnCache::new(1024),
                 | DBCol::PartialChunks => ColumnCache::new(512),
+                | DBCol::StateShardUIdMapping => ColumnCache::new(32),
                 _ => ColumnCache::disabled(),
             },
         }

--- a/core/store/src/deserialized_column.rs
+++ b/core/store/src/deserialized_column.rs
@@ -5,7 +5,7 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 pub(super) struct ColumnCache {
-    pub(super) values: lru::LruCache<Vec<u8>, Arc<dyn Any + Send + Sync>>,
+    pub(super) values: lru::LruCache<Vec<u8>, Option<Arc<dyn Any + Send + Sync>>>,
     /// A counter indicating the number of ongoing write transaction flushes.
     ///
     /// This cache and transactional write operation in the underlying database can be

--- a/core/store/src/store.rs
+++ b/core/store/src/store.rs
@@ -110,7 +110,12 @@ impl Store {
 
         let mut lock = cache.lock();
         if lock.active_flushes == 0 {
-            lock.values.put(key.into(), value.as_ref().map(|v| Arc::clone(v) as _));
+            if let Some(v) = value.as_ref() {
+                lock.values.put(key.into(), Some(Arc::clone(v) as _));
+            } else if lock.store_none_values() {
+                // If the cache is configured to store `None` values, we store it.
+                lock.values.put(key.into(), None);
+            }
         }
         Ok(value)
     }


### PR DESCRIPTION
While this is likely not enough to make a measurable impact on the total TPS by itself, IMO the 10-20ms savings in `postprocess_ready_block` is too much to ignore.

[Before](https://share.firefox.dev/3TmaZFg), [After](https://share.firefox.dev/4epPLja) The call path is: 
```
trie_store::maybe_get_shard_uid_mapping 
ShardTries::apply_insertions_inner 
ShardTries::apply_insertions 
ChainStoreUpdate::finalize
ChainStoreUpdate::commit
Chain::postprocess_ready_block 
```

Additionally I think caching this is better than hoisting it out of `trie_store` methods, as it seems along the lines of breaking the resharding mapping abstraction (which is already complex).