### PR TITLE
ask object_storage to grab creds from environment

### DIFF
--- a/chain/client/src/sync/external.rs
+++ b/chain/client/src/sync/external.rs
@@ -441,7 +441,7 @@ mod test {
         let bucket = String::from("state-parts");
         let connection = ExternalConnection::GCS {
             gcs_client: std::sync::Arc::new(
-                object_store::gcp::GoogleCloudStorageBuilder::new()
+                object_store::gcp::GoogleCloudStorageBuilder::from_env()
                     .with_bucket_name(&bucket)
                     .build()
                     .unwrap(),

--- a/chain/client/src/sync/state/mod.rs
+++ b/chain/client/src/sync/state/mod.rs
@@ -134,7 +134,7 @@ impl StateSync {
                     }
                     ExternalStorageLocation::GCS { bucket, .. } => ExternalConnection::GCS {
                         gcs_client: Arc::new(
-                            object_store::gcp::GoogleCloudStorageBuilder::new()
+                            object_store::gcp::GoogleCloudStorageBuilder::from_env()
                                 .with_bucket_name(bucket)
                                 .build()
                                 .unwrap(),

--- a/nearcore/src/state_sync.rs
+++ b/nearcore/src/state_sync.rs
@@ -85,7 +85,7 @@ impl StateSyncDumper {
                     tracing::info!(target: "state_sync_dump", "Set the environment variable 'SERVICE_ACCOUNT' to '{credentials_file:?}'");
                 }
                 ExternalConnection::GCS {
-                    gcs_client: Arc::new(object_store::gcp::GoogleCloudStorageBuilder::new().with_bucket_name(&bucket).build().unwrap()),
+                    gcs_client: Arc::new(object_store::gcp::GoogleCloudStorageBuilder::from_env().with_bucket_name(&bucket).build().unwrap()),
                     reqwest_client: Arc::new(reqwest::Client::default()),
                     bucket,
                 }

--- a/tools/state-parts-dump-check/src/cli.rs
+++ b/tools/state-parts-dump-check/src/cli.rs
@@ -231,7 +231,7 @@ fn create_external_connection(
     } else if let Some(bucket) = gcs_bucket {
         ExternalConnection::GCS {
             gcs_client: Arc::new(
-                object_store::gcp::GoogleCloudStorageBuilder::new()
+                object_store::gcp::GoogleCloudStorageBuilder::from_env()
                     .with_bucket_name(&bucket)
                     .build()
                     .unwrap(),

--- a/tools/state-viewer/src/state_parts.rs
+++ b/tools/state-viewer/src/state_parts.rs
@@ -232,7 +232,7 @@ fn create_external_connection(
         }
         ExternalConnection::GCS {
             gcs_client: Arc::new(
-                object_store::gcp::GoogleCloudStorageBuilder::new()
+                object_store::gcp::GoogleCloudStorageBuilder::from_env()
                     .with_bucket_name(&bucket)
                     .build()
                     .unwrap(),


### PR DESCRIPTION
Ideally we'd use builder methods to set the creds as appropriate, but for a hotfix this seems more appropriate for the time being. We can fix this more properly later.