### PR TITLE
Fix GCS cred file path

### DIFF
--- a/chain/client/src/sync/external.rs
+++ b/chain/client/src/sync/external.rs
@@ -441,7 +441,7 @@ mod test {
         let bucket = String::from("state-parts");
         let connection = ExternalConnection::GCS {
             gcs_client: std::sync::Arc::new(
-                object_store::gcp::GoogleCloudStorageBuilder::new()
+                object_store::gcp::GoogleCloudStorageBuilder::from_env()
                     .with_bucket_name(&bucket)
                     .build()
                     .unwrap(),

--- a/chain/client/src/sync/state/mod.rs
+++ b/chain/client/src/sync/state/mod.rs
@@ -134,7 +134,7 @@ impl StateSync {
                     }
                     ExternalStorageLocation::GCS { bucket, .. } => ExternalConnection::GCS {
                         gcs_client: Arc::new(
-                            object_store::gcp::GoogleCloudStorageBuilder::new()
+                            object_store::gcp::GoogleCloudStorageBuilder::from_env()
                                 .with_bucket_name(bucket)
                                 .build()
                                 .unwrap(),

--- a/nearcore/src/state_sync.rs
+++ b/nearcore/src/state_sync.rs
@@ -85,7 +85,7 @@ impl StateSyncDumper {
                     tracing::info!(target: "state_sync_dump", "Set the environment variable 'SERVICE_ACCOUNT' to '{credentials_file:?}'");
                 }
                 ExternalConnection::GCS {
-                    gcs_client: Arc::new(object_store::gcp::GoogleCloudStorageBuilder::new().with_bucket_name(&bucket).build().unwrap()),
+                    gcs_client: Arc::new(object_store::gcp::GoogleCloudStorageBuilder::from_env().with_bucket_name(&bucket).build().unwrap()),
                     reqwest_client: Arc::new(reqwest::Client::default()),
                     bucket,
                 }

--- a/tools/state-parts-dump-check/src/cli.rs
+++ b/tools/state-parts-dump-check/src/cli.rs
@@ -231,7 +231,7 @@ fn create_external_connection(
     } else if let Some(bucket) = gcs_bucket {
         ExternalConnection::GCS {
             gcs_client: Arc::new(
-                object_store::gcp::GoogleCloudStorageBuilder::new()
+                object_store::gcp::GoogleCloudStorageBuilder::from_env()
                     .with_bucket_name(&bucket)
                     .build()
                     .unwrap(),

--- a/tools/state-viewer/src/state_parts.rs
+++ b/tools/state-viewer/src/state_parts.rs
@@ -225,13 +225,11 @@ fn create_external_connection(
         .expect("Failed to create an S3 bucket");
         ExternalConnection::S3 { bucket: Arc::new(bucket) }
     } else if let Some(bucket) = gcs_bucket {
-        if let Some(credentials_file) = credentials_file {
-            unsafe { std::env::set_var("SERVICE_ACCOUNT", &credentials_file) };
-        }
         ExternalConnection::GCS {
             gcs_client: Arc::new(
                 object_store::gcp::GoogleCloudStorageBuilder::new()
                     .with_bucket_name(&bucket)
+                    .with_service_account_path(&credentials_file.to_str().unwrap())
                     .build()
                     .unwrap(),
             ),

--- a/tools/state-viewer/src/state_parts.rs
+++ b/tools/state-viewer/src/state_parts.rs
@@ -229,7 +229,7 @@ fn create_external_connection(
             unsafe { std::env::set_var("SERVICE_ACCOUNT", &credentials_file) };
         }
         ExternalConnection::GCS {
-            gcs_client: Arc::new(
+            gcs_client: Arc::from_env(
                 object_store::gcp::GoogleCloudStorageBuilder::from_env()
                     .with_bucket_name(&bucket)
                     .build()

--- a/tools/state-viewer/src/state_parts.rs
+++ b/tools/state-viewer/src/state_parts.rs
@@ -225,11 +225,13 @@ fn create_external_connection(
         .expect("Failed to create an S3 bucket");
         ExternalConnection::S3 { bucket: Arc::new(bucket) }
     } else if let Some(bucket) = gcs_bucket {
+        if let Some(credentials_file) = credentials_file {
+            unsafe { std::env::set_var("SERVICE_ACCOUNT", &credentials_file) };
+        }
         ExternalConnection::GCS {
             gcs_client: Arc::new(
-                object_store::gcp::GoogleCloudStorageBuilder::new()
+                object_store::gcp::GoogleCloudStorageBuilder::from_env()
                     .with_bucket_name(&bucket)
-                    .with_service_account_path(&credentials_file.to_str().unwrap())
                     .build()
                     .unwrap(),
             ),

--- a/tools/state-viewer/src/state_parts.rs
+++ b/tools/state-viewer/src/state_parts.rs
@@ -230,7 +230,7 @@ fn create_external_connection(
         }
         ExternalConnection::GCS {
             gcs_client: Arc::new(
-                object_store::gcp::GoogleCloudStorageBuilder::new()
+                object_store::gcp::GoogleCloudStorageBuilder::from_env()
                     .with_bucket_name(&bucket)
                     .build()
                     .unwrap(),

--- a/tools/state-viewer/src/state_parts.rs
+++ b/tools/state-viewer/src/state_parts.rs
@@ -229,8 +229,8 @@ fn create_external_connection(
             unsafe { std::env::set_var("SERVICE_ACCOUNT", &credentials_file) };
         }
         ExternalConnection::GCS {
-            gcs_client: Arc::from_env(
-                object_store::gcp::GoogleCloudStorageBuilder::from_env()
+            gcs_client: Arc::new(
+                object_store::gcp::GoogleCloudStorageBuilder::new()
                     .with_bucket_name(&bucket)
                     .build()
                     .unwrap(),


### PR DESCRIPTION
Object_store lib builder need to be told explicitly to use env vars