### PR TITLE
feat(debug-ui): add BlockHashByOrdinal to entity debug

### DIFF
--- a/chain/jsonrpc-primitives/src/types/entity_debug.rs
+++ b/chain/jsonrpc-primitives/src/types/entity_debug.rs
@@ -1,7 +1,7 @@
 // This file contains structures for the Entity Debug UI.
 // They are to be sent to the UI as JSON.
 use crate::errors::RpcError;
-use near_primitives::types::{BlockHeight, EpochId, ShardId};
+use near_primitives::types::{BlockHeight, EpochId, NumBlocks, ShardId};
 use near_primitives::{hash::CryptoHash, shard_layout::ShardUId};
 use serde::{Deserialize, Serialize};
 
@@ -60,6 +60,7 @@ pub enum EntityQuery {
     AllShardsByEpochId { epoch_id: EpochId },
     BlockByHash { block_hash: CryptoHash },
     BlockHashByHeight { block_height: BlockHeight },
+    BlockHashByOrdinal { block_ordinal: NumBlocks },
     BlockHeaderByHash { block_hash: CryptoHash },
     BlockInfoByHash { block_hash: CryptoHash },
     BlockMerkleTreeByHash { block_hash: CryptoHash },

--- a/nearcore/src/entity_debug.rs
+++ b/nearcore/src/entity_debug.rs
@@ -31,7 +31,7 @@ use near_primitives::stateless_validation::stored_chunk_state_transition_data::{
 use near_primitives::transaction::{ExecutionOutcomeWithProof, SignedTransaction};
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{AccountId, Balance, BlockHeight, StateRoot};
-use near_primitives::utils::{get_block_shard_id, get_outcome_id_block_hash};
+use near_primitives::utils::{get_block_shard_id, get_outcome_id_block_hash, index_to_bytes};
 use near_primitives::views::{
     BlockHeaderView, BlockView, ChunkView, ExecutionOutcomeView, ReceiptView, SignedTransactionView,
 };
@@ -85,6 +85,12 @@ impl EntityDebugHandlerImpl {
                         &borsh::to_vec(&block_height).unwrap(),
                     )?
                     .ok_or_else(|| anyhow!("Block height not found"))?;
+                Ok(serialize_entity(&block_hash))
+            }
+            EntityQuery::BlockHashByOrdinal { block_ordinal } => {
+                let block_hash = store
+                    .get_ser::<CryptoHash>(DBCol::BlockOrdinal, &index_to_bytes(block_ordinal))?
+                    .ok_or_else(|| anyhow!("Block hash not found"))?;
                 Ok(serialize_entity(&block_hash))
             }
             EntityQuery::BlockHeaderByHash { block_hash } => {

--- a/tools/debug-ui/src/entity_debug/types.tsx
+++ b/tools/debug-ui/src/entity_debug/types.tsx
@@ -135,6 +135,7 @@ export type EntityQuery = {
     AllShardsByEpochId?: { epoch_id: string };
     BlockByHash?: { block_hash: string };
     BlockHashByHeight?: { block_height: number };
+    BlockHashByOrdinal?: { block_ordinal: number };
     BlockHeaderByHash?: { block_hash: string };
     BlockInfoByHash?: { block_hash: string };
     BlockMerkleTreeByHash?: { block_hash: string };
@@ -186,6 +187,7 @@ export const entityQueryTypes: EntityQueryType[] = [
     'AllShardsByEpochId',
     'BlockByHash',
     'BlockHashByHeight',
+    'BlockHashByOrdinal',
     'BlockHeaderByHash',
     'BlockInfoByHash',
     'BlockMerkleTreeByHash',
@@ -257,6 +259,7 @@ export const entityQueryKeyTypes: Record<EntityQueryType, EntityQueryKeySpec[]> 
     AllShardsByEpochId: [queryKey('epoch_id')],
     BlockByHash: [queryKey('block_hash')],
     BlockHashByHeight: [queryKey('block_height')],
+    BlockHashByOrdinal: [queryKey('block_ordinal')],
     BlockHeaderByHash: [queryKey('block_hash')],
     BlockInfoByHash: [queryKey('block_hash')],
     BlockMerkleTreeByHash: [queryKey('block_hash')],
@@ -302,6 +305,7 @@ export const entityQueryOutputType: Record<EntityQueryType, EntityType> = {
     AllShardsByEpochId: 'AllShards',
     BlockByHash: 'Block',
     BlockHashByHeight: 'BlockHash',
+    BlockHashByOrdinal: 'BlockHash',
     BlockHeaderByHash: 'BlockHeader',
     BlockInfoByHash: 'BlockInfo',
     BlockMerkleTreeByHash: 'BlockMerkleTree',


### PR DESCRIPTION
Add the ability to fetch block by its ordinal using the `DBCol::BlockOrdinal`:

![image](https://github.com/user-attachments/assets/8c4a9344-dead-4036-abca-7fd7a888bf17)
