### PR TITLE
Fix Typos in Documentation and Source Code

### DIFF
--- a/chain/network/src/peer_manager/tests/tier1.rs
+++ b/chain/network/src/peer_manager/tests/tier1.rs
@@ -402,7 +402,7 @@ async fn stun_self_discovery() {
         stun_server2.addr().to_string(),
     ]);
 
-    tracing::info!(target:"test", "spawn a node and advertize AccountData.");
+    tracing::info!(target:"test", "spawn a node and advertise AccountData.");
     let pm = start_pm(clock.clock(), TestDB::new(), cfg, chain.clone()).await;
     let chain_info = peer_manager::testonly::make_chain_info(&chain, &[&pm.cfg]);
     pm.set_chain_info(chain_info).await;

--- a/docs/architecture/next/catchup_and_state_sync.md
+++ b/docs/architecture/next/catchup_and_state_sync.md
@@ -31,7 +31,7 @@ We're looking at the performance of state sync:
 * allowing user to ask for many at once
 * allowing user to provide a bitmask of parts that are required (therefore allowing the server to return only the ones that it already cached).
 
-### Better performance on the requestor side
+### Better performance on the requester side
 
 Currently the parts are applied only once all of them are downloaded - instead we should try to apply them in parallel - after each part is received.
 

--- a/runtime/near-vm-2/compiler/README.md
+++ b/runtime/near-vm-2/compiler/README.md
@@ -7,7 +7,7 @@ This crate is the base for Compiler implementations.
 
 It performs the translation from a Wasm module into a basic
 `ModuleInfo`, but leaves the Wasm function bytecode translation to the
-compiler implementor.
+compiler implementer.
 
 Here are some of the Compilers provided by Wasmer:
 

--- a/runtime/near-vm-2/vm/src/instance/ref.rs
+++ b/runtime/near-vm-2/vm/src/instance/ref.rs
@@ -52,7 +52,7 @@ impl InstanceInner {
     #[inline]
     pub(crate) fn as_ref(&self) -> &Instance {
         // SAFETY: The pointer is properly aligned, it is
-        // “dereferencable”, it points to an initialized memory of
+        // “dereferenceable”, it points to an initialized memory of
         // `Instance`, and the reference has the lifetime `'a`.
         unsafe { self.instance.as_ref() }
     }


### PR DESCRIPTION


---


## Description
This pull request corrects several minor typos across documentation and source files:
- Fixed spelling errors in comments and log messages.
- Updated terminology for consistency (e.g., "requestor" → "requester", "advertize" → "advertise").

---