### PR TITLE
refactor: don't print "some other error" when things are okay

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1065,7 +1065,7 @@ impl Client {
                 }
             }
             Err(err) => {
-                debug!(target: "chain", err=err as &dyn std::error::Error, "when block processing");
+                debug!(target: "chain", err=err as &dyn std::error::Error, "when starting block processing");
             }
         }
         res


### PR DESCRIPTION
Use native error printing while at it.