### PR TITLE
add option to download extended perf data in mocknet pytest

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -323,6 +323,7 @@
         "SECP",
         "Seedable",
         "serde",
+        "schedstats",
         "schemars",
         "shardnet",
         "Shreyan",

--- a/pytest/tests/mocknet/helpers/get-profile.sh
+++ b/pytest/tests/mocknet/helpers/get-profile.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # 0. Get record duration (default: 10s)
 record_secs="${1:-10}"
+mode="${2:-simple}"
 
 # 1. Remove old files
 rm -f "$HOME/perf."*
@@ -19,16 +20,53 @@ if [ -z "$pid" ]; then
   exit 1
 fi
 
-# 4. Record perf
-echo "▶️ Recording perf data for PID $pid for ${record_secs}s..."
-perf record -e cpu-clock -F 1000 -g --call-graph dwarf,65528 \
-  -p "$pid" -o "$HOME/perf.data" -- sleep "$record_secs" 2>/dev/null
+# normal perf data
+gather_simple_perf() {
+  # 4. Record perf
+  echo "▶️ Recording perf data for PID $pid for ${record_secs}s..."
+  perf record -e cpu-clock -F 1000 -g --call-graph dwarf,65528 \
+      -p "$pid" -o "perf.data" -- sleep "${record_secs}"
 
-# 5. Convert to script
-output_file="$HOME/perf-$(hostname).script"
-echo "📜 Converting perf.data to ${output_file}"
-perf script -F +pid -i "$HOME/perf.data" > "${output_file}" 2>/dev/null
+  # 5. Convert to script
+  output_file="${HOME}/perf-$(hostname).script"
+  echo "📜 Converting perf.data to ${output_file}"
+  perf script -F +pid -i "perf.data" > "${output_file}" 2>/dev/null
 
-# 6. Compress
-gzip -f "${output_file}"
-echo "✅ Done: ${output_file}.gz"
+  # 6. Compress
+  gzip -f "${output_file}"
+  echo "✅ Done: ${output_file}.gz"
+}
+
+# extended perf data
+gather_extended_perf() {
+  sudo sysctl kernel.sched_schedstats=1
+  
+  output_dir="./perf-data"
+  mkdir -p ${output_dir}
+  
+  perf stat \
+    -p ${pid} \
+    --per-thread \
+    -- sleep "${record_secs}" &> "${output_dir}/perf-stat.out"
+
+  perf record -e cpu-clock -F1000 \
+    -g --call-graph fp,65528 \
+    -p ${pid} -o perf-on-cpu.data -- sleep "${record_secs}"
+  nice -n 19 perf script -F +pid -i perf-on-cpu.data > "${output_dir}/perf-on-cpu.script"
+
+  sudo perf record \
+    -e sched:sched_stat_sleep -e sched:sched_switch -e sched:sched_process_exit \
+    -g --call-graph fp,65528 \
+    -p ${pid} \
+    -o perf-off-cpu.data -- sleep "${record_secs}"
+  sudo chown ${USER} perf-off-cpu.data
+  nice -n 19 perf script -F +pid,+comm,+tid,+time,+ip,+sym -i perf-off-cpu.data > ${output_dir}/off-cpu-profile.script
+
+  nice -n 19 tar czf perf-data.tar.gz "${output_dir}"
+}
+
+if [ "$mode" = "extended" ]; then
+  gather_extended_perf
+else
+  gather_simple_perf
+fi

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -674,7 +674,9 @@ def _run_remote(hosts, cmd):
 
 def run_remote_cmd(ctx: CommandContext):
     targeted = ctx.get_targeted_with_schedule_ctx()
-    logger.info(f'Running cmd on {",".join([h.name() for h in targeted])}')
+    logger.info(
+        f'Running cmd `{ctx.args.cmd}` on {",".join([h.name() for h in targeted])}'
+    )
     _run_remote(targeted, ctx.args.cmd)
 
 

--- a/pytest/tests/mocknet/sharded_bm.py
+++ b/pytest/tests/mocknet/sharded_bm.py
@@ -432,7 +432,7 @@ def handle_get_traces(args):
             f"Failed to fetch traces: {response.status_code} {response.text}")
 
 
-def handle_get_profiles(args):
+def handle_get_profiles(args, extra):
     args = copy.deepcopy(args)
 
     # If no host filter is provided, target the first alphabetical cp instance.
@@ -442,15 +442,14 @@ def handle_get_profiles(args):
         logger.info(f"Targeting {machine}")
         args.host_filter = machine
 
-    run_cmd_args = copy.deepcopy(args)
-    run_cmd_args.cmd = f"bash {BENCHNET_DIR}/helpers/get-profile.sh {args.record_secs}"
-    run_remote_cmd(CommandContext(run_cmd_args))
+    extra_parameters = ' '.join(extra)
+    args.cmd = f"bash {BENCHNET_DIR}/helpers/get-profile.sh {extra_parameters}"
+    run_remote_cmd(CommandContext(args))
 
     os.makedirs(args.output_dir, exist_ok=True)
-    download_args = copy.deepcopy(args)
-    download_args.src = f"{REMOTE_HOME}/perf*.script.gz"
-    download_args.dst = args.output_dir
-    run_remote_download_file(CommandContext(download_args))
+    args.src = f"{REMOTE_HOME}/perf*.gz"
+    args.dst = args.output_dir
+    run_remote_download_file(CommandContext(args))
 
 
 def handle_start(args):
@@ -557,13 +556,16 @@ def main():
         help=
         'Filter to select specific hosts (default: first alphabetical cp instance)'
     )
-    get_profiles_parser.add_argument(
-        '--record-secs',
-        type=int,
-        default=10,
-        help='Number of seconds to record the profile (default: 10)')
 
-    args = parser.parse_args()
+    if '--' in sys.argv:
+        idx = sys.argv.index('--')
+        my_args = sys.argv[1:idx]
+        extra_args = sys.argv[idx + 1:]
+    else:
+        my_args = sys.argv[1:]
+        extra_args = []
+
+    args = parser.parse_args(my_args)
 
     # Route to appropriate handler based on command
     if args.command == 'init':
@@ -579,7 +581,7 @@ def main():
     elif args.command == 'get-traces':
         handle_get_traces(args)
     elif args.command == 'get-profiles':
-        handle_get_profiles(args)
+        handle_get_profiles(args, extra_args)
     else:
         parser.print_help()
 


### PR DESCRIPTION
Adds the "off-cpu" perf tracing and `perf stat` for the aggregate report.
This is mostly targeted for use in the CI benchmark runs.