### PR TITLE
feat(migrations): Migration to fix ordinal inconsistency

### DIFF
--- a/core/store/src/db/metadata.rs
+++ b/core/store/src/db/metadata.rs
@@ -2,7 +2,7 @@
 pub type DbVersion = u32;
 
 /// Current version of the database.
-pub const DB_VERSION: DbVersion = 45;
+pub const DB_VERSION: DbVersion = 46;
 
 /// Database version at which point DbKind was introduced.
 const DB_VERSION_WITH_KIND: DbVersion = 34;

--- a/core/store/src/migrations/ordinal_inconsistency/find.rs
+++ b/core/store/src/migrations/ordinal_inconsistency/find.rs
@@ -1,0 +1,191 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use near_chain_primitives::Error;
+use near_primitives::hash::CryptoHash;
+
+use crate::Store;
+
+use super::timer::WorkTimer;
+
+use super::OrdinalInconsistency;
+use super::read_db::{HashIndex, ReadDbData};
+
+pub fn find_ordinal_inconsistencies(
+    store: &Store,
+    print_max_inconsistencies: usize,
+) -> Result<Vec<OrdinalInconsistency>, Error> {
+    let db_data = Arc::new(super::read_db::read_db_data(store)?);
+
+    let num_threads = 128;
+    let (update_sender, update_receiver) =
+        std::sync::mpsc::sync_channel::<FindInconsistenciesUpdate>(8096);
+    let mut threads = Vec::with_capacity(num_threads);
+    for thread_id in 0..num_threads {
+        let db_data = db_data.clone();
+        let update_sender = update_sender.clone();
+        threads.push(std::thread::spawn(move || {
+            find_inconsistencies_thread(&db_data, &update_sender, thread_id, num_threads)
+        }));
+    }
+    std::mem::drop(update_sender);
+
+    let mut found_inconsistencies = Vec::new();
+    let mut timer = WorkTimer::new("Scan for inconsistencies", db_data.height_to_block_hash.len());
+
+    while let Ok(update) = update_receiver.recv() {
+        match update {
+            FindInconsistenciesUpdate::Inconsistency(inconsistency) => {
+                found_inconsistencies.push(inconsistency);
+            }
+            FindInconsistenciesUpdate::Processed(count) => {
+                timer.add_processed(count);
+            }
+        }
+    }
+    timer.finish();
+
+    for thread in threads {
+        thread.join().unwrap();
+    }
+
+    if found_inconsistencies.is_empty() {
+        tracing::info!(target: "db", "Found 0 ordinal inconsistencies");
+        return Ok(Vec::new());
+    }
+
+    let db_data: ReadDbData =
+        Arc::<ReadDbData>::try_unwrap(db_data).expect(" Should have exactly one owner");
+    let ReadDbData {
+        height_to_block_hash,
+        block_hash_to_ordinal,
+        ordinal_to_block_hash,
+        hash_to_index,
+    } = db_data;
+    std::mem::drop(height_to_block_hash);
+    std::mem::drop(block_hash_to_ordinal);
+    std::mem::drop(ordinal_to_block_hash);
+
+    // Convert HashIndex to CryptoHash
+    let mut timer = WorkTimer::new("Convert HashIndex to CryptoHash", hash_to_index.len());
+    let mut need_hash_for_index: HashSet<HashIndex> =
+        HashSet::with_capacity(found_inconsistencies.len() * 2);
+    for inconsistency in &found_inconsistencies {
+        need_hash_for_index.insert(inconsistency.correct_block_hash_index);
+        need_hash_for_index.insert(inconsistency.actual_block_hash_index);
+    }
+
+    let mut index_to_hash: HashMap<HashIndex, CryptoHash> =
+        HashMap::with_capacity(need_hash_for_index.len());
+    for (hash, index) in hash_to_index {
+        if need_hash_for_index.contains(&index) {
+            index_to_hash.insert(index, hash);
+        }
+        timer.add_processed(1);
+    }
+
+    let mut result = Vec::with_capacity(found_inconsistencies.len());
+    for inconsistency in found_inconsistencies {
+        let correct_block_hash =
+            index_to_hash.get(&inconsistency.correct_block_hash_index).cloned().unwrap();
+        let actual_block_hash =
+            index_to_hash.get(&inconsistency.actual_block_hash_index).cloned().unwrap();
+
+        result.push(OrdinalInconsistency {
+            block_height: inconsistency.block_height.into(),
+            block_ordinal: inconsistency.block_ordinal.into(),
+            correct_block_hash,
+            actual_block_hash,
+        });
+    }
+    result.sort_by_key(|i| i.block_height);
+
+    tracing::info!(target: "db", "Inconsistencies found:");
+    let print_inconsistency = |inconsistency: &OrdinalInconsistency| {
+        tracing::info!(
+            target: "db",
+            "Height: {}, Ordinal: {}, Correct Hash: {}, Actual Hash: {}",
+            inconsistency.block_height,
+            inconsistency.block_ordinal,
+            inconsistency.correct_block_hash,
+            inconsistency.actual_block_hash
+        );
+    };
+
+    if print_max_inconsistencies >= result.len() {
+        for inconsistency in result.iter().take(print_max_inconsistencies) {
+            print_inconsistency(inconsistency);
+        }
+    } else {
+        let print_first_num = print_max_inconsistencies / 2;
+        let print_last_num = print_max_inconsistencies - print_first_num;
+
+        for inconsistency in result.iter().take(print_first_num) {
+            print_inconsistency(inconsistency);
+        }
+        tracing::info!(target: "db", "[...] - Not printing {} inconsistencies to avoid spamming the logs", result.len() - print_max_inconsistencies);
+        for inconsistency in result.iter().rev().skip(result.len() - print_last_num) {
+            print_inconsistency(inconsistency);
+        }
+    }
+
+    tracing::info!(
+        target: "db",
+        "Found {} inconsistencies (min height: {}, max height: {})",
+        result.len(),
+        result.first().unwrap().block_height,
+        result.last().unwrap().block_height
+    );
+
+    Ok(result)
+}
+
+enum FindInconsistenciesUpdate {
+    Inconsistency(FoundInconsistency),
+    Processed(usize),
+}
+
+struct FoundInconsistency {
+    block_height: u32,
+    block_ordinal: u32,
+    correct_block_hash_index: HashIndex,
+    actual_block_hash_index: HashIndex,
+}
+
+fn find_inconsistencies_thread(
+    db_data: &super::read_db::ReadDbData,
+    update_sender: &std::sync::mpsc::SyncSender<FindInconsistenciesUpdate>,
+    thread_id: usize,
+    num_threads: usize,
+) {
+    let ReadDbData { height_to_block_hash, block_hash_to_ordinal, ordinal_to_block_hash, .. } =
+        &db_data;
+
+    let mut processed_counter = 0;
+
+    for i in (thread_id..height_to_block_hash.len()).step_by(num_threads) {
+        let (height, block_hash) = height_to_block_hash[i];
+
+        if let Some(block_ordinal) = block_hash_to_ordinal.get(&block_hash) {
+            if let Some(hash_at_ordinal) = ordinal_to_block_hash.get(&block_ordinal) {
+                if *hash_at_ordinal != block_hash {
+                    update_sender
+                        .send(FindInconsistenciesUpdate::Inconsistency(FoundInconsistency {
+                            block_height: (height).into(),
+                            block_ordinal: (*block_ordinal).into(),
+                            correct_block_hash_index: block_hash,
+                            actual_block_hash_index: *hash_at_ordinal,
+                        }))
+                        .unwrap();
+                }
+            }
+        }
+
+        processed_counter += 1;
+        if processed_counter == 1000 {
+            update_sender.send(FindInconsistenciesUpdate::Processed(processed_counter)).unwrap();
+            processed_counter = 0;
+        }
+    }
+    update_sender.send(FindInconsistenciesUpdate::Processed(processed_counter)).unwrap();
+}

--- a/core/store/src/migrations/ordinal_inconsistency/mod.rs
+++ b/core/store/src/migrations/ordinal_inconsistency/mod.rs
@@ -1,0 +1,16 @@
+mod find;
+mod read_db;
+mod repair;
+mod timer;
+
+pub use find::find_ordinal_inconsistencies;
+use near_primitives::hash::CryptoHash;
+use near_primitives::types::{BlockHeight, NumBlocks};
+pub use repair::repair_ordinal_inconsistencies;
+
+pub struct OrdinalInconsistency {
+    pub block_height: BlockHeight,
+    pub block_ordinal: NumBlocks,
+    pub correct_block_hash: CryptoHash,
+    pub actual_block_hash: CryptoHash,
+}

--- a/core/store/src/migrations/ordinal_inconsistency/read_db.rs
+++ b/core/store/src/migrations/ordinal_inconsistency/read_db.rs
@@ -1,0 +1,192 @@
+use std::collections::HashMap;
+
+use crate::adapter::StoreAdapter;
+use crate::adapter::chain_store::ChainStoreAdapter;
+use crate::{DBCol, Store};
+use borsh::BorshDeserialize;
+use near_chain_primitives::Error;
+use near_primitives::hash::CryptoHash;
+use near_primitives::merkle::PartialMerkleTree;
+use near_primitives::types::BlockHeight;
+
+use super::timer::WorkTimer;
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct HashIndex(u32);
+
+#[derive(Debug)]
+pub struct ReadDbData {
+    pub hash_to_index: HashMap<CryptoHash, HashIndex>,
+    pub height_to_block_hash: Vec<(u32, HashIndex)>,
+    pub block_hash_to_ordinal: HashMap<HashIndex, u32>,
+    pub ordinal_to_block_hash: HashMap<u32, HashIndex>,
+}
+
+pub fn read_db_data(store: &Store) -> Result<ReadDbData, Error> {
+    let chain_store = ChainStoreAdapter::new(store.clone());
+
+    let tip = chain_store.head()?;
+    let last_block_ordinal = chain_store.get_block_merkle_tree(&tip.last_block_hash)?.size();
+    let estimated_block_count: usize = (last_block_ordinal + 1).try_into().unwrap();
+
+    let (db_update_sender, db_update_receiver) =
+        std::sync::mpsc::sync_channel::<DbReadUpdate>(4096);
+    let store = chain_store.store();
+
+    let mut read_height_to_block_hash_timer =
+        WorkTimer::new("Read DBCol::BlockHeight", estimated_block_count);
+    let read_height_to_block_hash_thread = {
+        let store = store.clone();
+        let db_update_sender = db_update_sender.clone();
+        std::thread::spawn(move || read_height_to_block_hash(&store, &db_update_sender))
+    };
+    let mut read_block_hash_to_ordinal_timer =
+        WorkTimer::new("Read DBCol::BlockMerkleTree", estimated_block_count);
+    let read_block_hash_to_ordinal_thread = {
+        let store = store.clone();
+        let db_update_sender = db_update_sender.clone();
+        std::thread::spawn(move || read_block_hash_to_ordinal(&store, &db_update_sender))
+    };
+    let mut read_ordinal_to_block_hash_timer =
+        WorkTimer::new("Read DBCol::BlockOrdinal", estimated_block_count);
+    let read_ordinal_to_block_hash_thread = {
+        let db_update_sender = db_update_sender.clone();
+        std::thread::spawn(move || read_ordinal_to_block_hash(&store, &db_update_sender))
+    };
+    std::mem::drop(db_update_sender);
+
+    let mut hash_to_index: HashMap<CryptoHash, HashIndex> =
+        HashMap::with_capacity(estimated_block_count);
+    let mut height_to_hash: Vec<(u32, HashIndex)> = Vec::with_capacity(estimated_block_count);
+    let mut ordinal_to_hash: HashMap<u32, HashIndex> =
+        HashMap::with_capacity(estimated_block_count);
+    let mut hash_to_ordinal: HashMap<HashIndex, u32> =
+        HashMap::with_capacity(estimated_block_count);
+
+    let mut get_hash_index = |hash: CryptoHash| -> HashIndex {
+        let next_index = HashIndex(hash_to_index.len().try_into().unwrap());
+        *hash_to_index.entry(hash).or_insert(next_index)
+    };
+
+    while let Ok(db_update) = db_update_receiver.recv() {
+        match db_update {
+            DbReadUpdate::HeightToBlockHash(entries) => {
+                read_height_to_block_hash_timer.add_processed(entries.len());
+                for (height, block_hash) in entries {
+                    let hash_index = get_hash_index(block_hash);
+                    height_to_hash.push((height.try_into().unwrap(), hash_index));
+                }
+            }
+            DbReadUpdate::BlockHashToOrdinal(entries) => {
+                read_block_hash_to_ordinal_timer.add_processed(entries.len());
+                for (block_hash, ordinal) in entries {
+                    let hash_index = get_hash_index(block_hash);
+                    hash_to_ordinal.insert(hash_index, ordinal.try_into().unwrap());
+                }
+            }
+            DbReadUpdate::OrdinalToBlockHash(entries) => {
+                read_ordinal_to_block_hash_timer.add_processed(entries.len());
+                for (ordinal, block_hash) in entries {
+                    let hash_index = get_hash_index(block_hash);
+                    ordinal_to_hash.insert(ordinal.try_into().unwrap(), hash_index);
+                }
+            }
+            DbReadUpdate::FinishedReadingHeightToBlockHash => {
+                read_height_to_block_hash_timer.finish();
+            }
+            DbReadUpdate::FinishedReadingBlockHashToOrdinal => {
+                read_block_hash_to_ordinal_timer.finish();
+            }
+            DbReadUpdate::FinishedReadingOrdinalToBlockHash => {
+                read_ordinal_to_block_hash_timer.finish();
+            }
+        }
+    }
+
+    read_height_to_block_hash_thread.join().unwrap()?;
+    read_block_hash_to_ordinal_thread.join().unwrap()?;
+    read_ordinal_to_block_hash_thread.join().unwrap()?;
+
+    Ok(ReadDbData {
+        hash_to_index,
+        height_to_block_hash: height_to_hash,
+        block_hash_to_ordinal: hash_to_ordinal,
+        ordinal_to_block_hash: ordinal_to_hash,
+    })
+}
+
+enum DbReadUpdate {
+    HeightToBlockHash(Vec<(BlockHeight, CryptoHash)>),
+    BlockHashToOrdinal(Vec<(CryptoHash, u64)>),
+    OrdinalToBlockHash(Vec<(u64, CryptoHash)>),
+    FinishedReadingHeightToBlockHash,
+    FinishedReadingBlockHashToOrdinal,
+    FinishedReadingOrdinalToBlockHash,
+}
+
+impl DbReadUpdate {
+    fn batch_size() -> usize {
+        4096
+    }
+}
+
+fn read_height_to_block_hash(
+    store: &Store,
+    db_update_sender: &std::sync::mpsc::SyncSender<DbReadUpdate>,
+) -> Result<(), Error> {
+    read_db_column(store, DBCol::BlockHeight, |entries: Vec<(u64, CryptoHash)>| {
+        db_update_sender.send(DbReadUpdate::HeightToBlockHash(entries)).unwrap();
+    })?;
+    db_update_sender.send(DbReadUpdate::FinishedReadingHeightToBlockHash).unwrap();
+    Ok(())
+}
+
+fn read_block_hash_to_ordinal(
+    store: &Store,
+    db_update_sender: &std::sync::mpsc::SyncSender<DbReadUpdate>,
+) -> Result<(), Error> {
+    read_db_column(
+        store,
+        DBCol::BlockMerkleTree,
+        |entries: Vec<(CryptoHash, PartialMerkleTree)>| {
+            let entries = entries.into_iter().map(|(h, tree)| (h, tree.size())).collect();
+            db_update_sender.send(DbReadUpdate::BlockHashToOrdinal(entries)).unwrap();
+        },
+    )?;
+    db_update_sender.send(DbReadUpdate::FinishedReadingBlockHashToOrdinal).unwrap();
+    Ok(())
+}
+
+fn read_ordinal_to_block_hash(
+    store: &Store,
+    db_update_sender: &std::sync::mpsc::SyncSender<DbReadUpdate>,
+) -> Result<(), Error> {
+    read_db_column(store, DBCol::BlockOrdinal, |entries: Vec<(u64, CryptoHash)>| {
+        db_update_sender.send(DbReadUpdate::OrdinalToBlockHash(entries)).unwrap();
+    })?;
+    db_update_sender.send(DbReadUpdate::FinishedReadingOrdinalToBlockHash).unwrap();
+    Ok(())
+}
+
+fn read_db_column<KeyType: BorshDeserialize, ValueType: BorshDeserialize>(
+    store: &Store,
+    column: DBCol,
+    send_batch: impl Fn(Vec<(KeyType, ValueType)>),
+) -> Result<(), Error> {
+    let mut cur_batch = Vec::with_capacity(DbReadUpdate::batch_size());
+    let mut iter = store.iter_ser::<ValueType>(column);
+    while let Some(res) = iter.next() {
+        let (key_bytes, value) = res?;
+        let key = KeyType::try_from_slice(&key_bytes)?;
+
+        cur_batch.push((key, value));
+        if cur_batch.len() >= DbReadUpdate::batch_size() {
+            send_batch(cur_batch);
+            cur_batch = Vec::with_capacity(DbReadUpdate::batch_size());
+        }
+    }
+    if !cur_batch.is_empty() {
+        send_batch(cur_batch);
+    }
+    Ok(())
+}

--- a/core/store/src/migrations/ordinal_inconsistency/repair.rs
+++ b/core/store/src/migrations/ordinal_inconsistency/repair.rs
@@ -1,0 +1,34 @@
+use crate::{DBCol, Store};
+use near_chain_primitives::Error;
+use near_primitives::utils::index_to_bytes;
+
+use super::OrdinalInconsistency;
+
+pub fn repair_ordinal_inconsistencies(
+    store: &Store,
+    inconsistencies: &[OrdinalInconsistency],
+) -> Result<(), Error> {
+    let mut write_timer =
+        super::timer::WorkTimer::new("Repair ordinal inconsistencies", inconsistencies.len());
+
+    let write_batch_size = 1024;
+    for inconsistency_batch in inconsistencies.chunks(write_batch_size) {
+        let mut db_update = store.store_update();
+        for inconsistency in inconsistency_batch {
+            db_update.set_ser(
+                DBCol::BlockOrdinal,
+                &index_to_bytes(inconsistency.block_ordinal),
+                &inconsistency.correct_block_hash,
+            )?;
+        }
+        db_update.commit()?;
+
+        write_timer.add_processed(inconsistency_batch.len());
+    }
+
+    write_timer.finish();
+
+    tracing::info!(target: "db", "Successfully repaired {} ordinal inconsistencies", inconsistencies.len());
+
+    Ok(())
+}

--- a/core/store/src/migrations/ordinal_inconsistency/timer.rs
+++ b/core/store/src/migrations/ordinal_inconsistency/timer.rs
@@ -1,0 +1,51 @@
+use std::time::Duration;
+
+pub struct WorkTimer {
+    name: String,
+    start: std::time::Instant,
+    last_report_time: std::time::Instant,
+    total: usize,
+    expected_total: usize,
+}
+
+impl WorkTimer {
+    pub fn new(name: impl ToString, expected_total: usize) -> Self {
+        let name = name.to_string();
+        tracing::info!(target: "db", "\"{}\": Started", name);
+        Self {
+            name,
+            start: std::time::Instant::now(),
+            last_report_time: std::time::Instant::now(),
+            total: 0,
+            expected_total,
+        }
+    }
+
+    pub fn add_processed(&mut self, processed: usize) {
+        self.total += processed;
+        if self.last_report_time.elapsed() > Duration::from_secs(5) {
+            tracing::info!(
+                target: "db",
+                "{}: {}/{} ({:.2}%) in {:.2?}, ETA: {:.2?}s",
+                self.name,
+                self.total,
+                self.expected_total,
+                (self.total as f64 / self.expected_total as f64) * 100.0,
+                self.start.elapsed(),
+                self.expected_total.saturating_sub(self.total) as f64 / self.total as f64
+                    * self.start.elapsed().as_secs_f64()
+            );
+            self.last_report_time = std::time::Instant::now();
+        }
+    }
+
+    pub fn finish(&self) {
+        tracing::info!(
+            target: "db",
+            "{}: Finished - processed {} in {:.2?}",
+            self.name,
+            self.total,
+            self.start.elapsed()
+        );
+    }
+}

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -91,6 +91,7 @@ impl<'a> near_store::StoreMigrator for Migrator<'a> {
             42 => near_store::migrations::migrate_42_to_43(store),
             43 => Ok(()), // DBCol::ChunkApplyStats column added, no need to perform a migration
             44 => near_store::migrations::migrate_44_to_45(store),
+            45 => near_store::migrations::migrate_45_to_46(store),
             DB_VERSION.. => unreachable!(),
         }
     }

--- a/tools/database/src/commands.rs
+++ b/tools/database/src/commands.rs
@@ -8,6 +8,7 @@ use crate::compact::RunCompactionCommand;
 use crate::drop_column::DropColumnCommand;
 use crate::make_snapshot::MakeSnapshotCommand;
 use crate::memtrie::{LoadMemTrieCommand, SplitShardTrieCommand};
+use crate::ordinal_inconsistency::OrdinalInconsistencyCommand;
 use crate::run_migrations::RunMigrationsCommand;
 use crate::set_version::SetVersionCommand;
 use crate::state_perf::StatePerfCommand;
@@ -68,6 +69,10 @@ enum SubCommand {
 
     /// Manually set database version
     SetVersion(SetVersionCommand),
+
+    /// TODO
+    #[clap(subcommand)]
+    OrdinalInconsistency(OrdinalInconsistencyCommand),
 }
 
 impl DatabaseCommand {
@@ -95,6 +100,7 @@ impl DatabaseCommand {
             SubCommand::AnalyzeDelayedReceipt(cmd) => cmd.run(home, genesis_validation),
             SubCommand::AnalyzeContractSizes(cmd) => cmd.run(home, genesis_validation),
             SubCommand::SetVersion(cmd) => cmd.run(home, genesis_validation),
+            SubCommand::OrdinalInconsistency(cmd) => cmd.run(home, genesis_validation),
         }
     }
 }

--- a/tools/database/src/lib.rs
+++ b/tools/database/src/lib.rs
@@ -10,6 +10,7 @@ mod compact;
 mod drop_column;
 mod make_snapshot;
 mod memtrie;
+mod ordinal_inconsistency;
 mod run_migrations;
 mod set_version;
 mod state_perf;

--- a/tools/database/src/ordinal_inconsistency.rs
+++ b/tools/database/src/ordinal_inconsistency.rs
@@ -1,0 +1,73 @@
+use std::path::PathBuf;
+
+use near_chain_configs::GenesisValidationMode;
+use near_store::DBCol;
+use near_store::migrations::ordinal_inconsistency::{
+    find_ordinal_inconsistencies, repair_ordinal_inconsistencies,
+};
+
+use crate::utils::get_user_confirmation;
+
+#[derive(clap::Parser)]
+#[clap(subcommand_required = true, arg_required_else_help = true)]
+pub(crate) enum OrdinalInconsistencyCommand {
+    Find(FindCommand),
+    FindAndRepair(FindAndRepairCommand),
+}
+
+#[derive(clap::Args)]
+pub(crate) struct FindCommand {
+    #[clap(long, default_value_t = 100)]
+    pub print_max_inconsistencies: usize,
+}
+
+#[derive(clap::Args)]
+pub(crate) struct FindAndRepairCommand {
+    #[clap(long, default_value_t = 100)]
+    pub print_max_inconsistencies: usize,
+
+    #[clap(long)]
+    pub noconfirm: bool,
+}
+
+impl OrdinalInconsistencyCommand {
+    pub(crate) fn run(
+        &self,
+        home: &PathBuf,
+        genesis_validation: GenesisValidationMode,
+    ) -> anyhow::Result<()> {
+        let mut near_config = nearcore::config::load_config(home, genesis_validation)?;
+        let node_storage = nearcore::open_storage(home, &mut near_config)?;
+
+        // Hot store is enough, cold store doesn't contain the affected columns.
+        assert_eq!(DBCol::BlockHeight.is_cold(), false);
+        assert_eq!(DBCol::BlockOrdinal.is_cold(), false);
+        assert_eq!(DBCol::BlockMerkleTree.is_cold(), false);
+        let store = node_storage.get_hot_store();
+
+        match self {
+            OrdinalInconsistencyCommand::Find(find_cmd) => {
+                find_ordinal_inconsistencies(&store, find_cmd.print_max_inconsistencies).unwrap();
+            }
+            OrdinalInconsistencyCommand::FindAndRepair(scan_and_fix_cmd) => {
+                let inconsistencies = find_ordinal_inconsistencies(
+                    &store,
+                    scan_and_fix_cmd.print_max_inconsistencies,
+                )
+                .unwrap();
+                if inconsistencies.is_empty() {
+                    return Ok(());
+                }
+
+                if !scan_and_fix_cmd.noconfirm {
+                    if !get_user_confirmation(&format!("Continue with repair?")) {
+                        println!("Cancelling...");
+                        return Ok(());
+                    }
+                }
+                repair_ordinal_inconsistencies(&store, &inconsistencies).unwrap();
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
`DBCol::BlockOrdinal` contains the mapping from block ordinal to the block hash of the block with this ordinal on the canonical chain.

Sadly in the past there was a bug which caused this column to become partially corrupted - sometimes on forks the wrong block was written under the ordinal. Instead of the one on canonical chain the column contains the block that was rejected in the fork.

This migration scans the whole database and fixes the corruption.

The corruption seems to occur only for old heights (before #59_548_749 or 2022-02-15) so it doesn't affect the current nodes, but it can cause problems for header sync which recently switched from using heights to ordinals.

### Example corruption

For example on an RPC node started from a snapshot which contains all headers I saw this inconsistency:
```console
Ordinal -> block hash (DBCol::BlockOrdinal)
2116475 -> AhXgjqQ8hNHWx7tVsaAd8mk8msP21FDkX18VQ7HKLejD
2116476 -> 9btLMzvf24R2tyFRFZBcMXX33QjR5u48DMyR7z4W5Bi7
2116477 -> 8Jtd8geiNYxAD1qtkiLG33ATNriLrwrpEw3RUp6zgmPb

block hash -> header.height (DBCol::BlockHeader)
AhXgjqQ8hNHWx7tVsaAd8mk8msP21FDkX18VQ7HKLejD -> 11937055
9btLMzvf24R2tyFRFZBcMXX33QjR5u48DMyR7z4W5Bi7 -> 11937056
6a3uce5vi3BXmuuKheoZh33z5vuZYTcyUY3FXiwRvjKe -> 11937057
8Jtd8geiNYxAD1qtkiLG33ATNriLrwrpEw3RUp6zgmPb -> 11937058

height -> block hash (DBCol::BlockHeight)
11937055 -> AhXgjqQ8hNHWx7tVsaAd8mk8msP21FDkX18VQ7HKLejD
11937056 -> not found
11937057 -> 6a3uce5vi3BXmuuKheoZh33z5vuZYTcyUY3FXiwRvjKe
11937058 -> 8Jtd8geiNYxAD1qtkiLG33ATNriLrwrpEw3RUp6zgmPb

block hash -> ordinal (merkleproof.size) (DBCol::BlockMerkleTree)
AhXgjqQ8hNHWx7tVsaAd8mk8msP21FDkX18VQ7HKLejD -> 2116475
9btLMzvf24R2tyFRFZBcMXX33QjR5u48DMyR7z4W5Bi7 -> 2116476
6a3uce5vi3BXmuuKheoZh33z5vuZYTcyUY3FXiwRvjKe -> 2116476
8Jtd8geiNYxAD1qtkiLG33ATNriLrwrpEw3RUp6zgmPb -> 2116477
```

Here we can see that at height `11937056` there was the `9btLMzvf24R2tyFRFZBcMXX33QjR5u48DMyR7z4W5Bi7` block with ordinal `2116476` and it got saved to the `BlocKOrdinal` column.
But after that at height `11937057` there's block `6a3uce5vi3BXmuuKheoZh33z5vuZYTcyUY3FXiwRvjKe` with the same ordinal `2116476`.

There was a fork - block `9btLMzvf24R2tyFRFZBcMXX33QjR5u48DMyR7z4W5Bi7` was rejected and doesn't exist on the canonical chain. Only block `6a3uce5vi3BXmuuKheoZh33z5vuZYTcyUY3FXiwRvjKe` is present on the canonical chain and its hash should be saved to the `BlockOrdinal` column under index `2116476`

### Previous migration
There's actually a previous db migration that fixed this exact issue: `do_migrate_30_to_31`, but it only covers blocks after height `47_443_088`, which isn't enough, there are lower heights where this corruption occurs. 

On my node I observed inconsistencies between the block heights:  11_850_793 - 59_548_749

### Implementation

To fix the inconsistencies I used the same logic as in `do_migrate_30_to_31`:
* For every height get hash of the block at this height on the canonical chain using the `BlockHeight` column (skip if it's missing)
* Find block ordinal for this block by taking the size of its merkle proof tree using the `BlockMerkleTree` column. This is a trick that we use in many other places in the codebase, you can search for things like `self.get_block_merkle_tree(&t.last_block_hash)?.size()`
* Read block hash under this ordinal using the `BlockOrdinal` column. If it doesn't match the hash of the block at current height, then there's an inconsistency and we should write the correct block hash under this ordinal

The scan covers all of the entries.
We have ~14 million entries in each of these columns. I think that doing this many random reads from rocksdb would take forever, so I took a different approach - I first sequentially read all of the columns into memory and then do random accesses on the in-memory data.
This makes the runtime reasonable  - around 13 minutes to read all the data and then a few seconds to analyze and repair the inconsistencies.

The column are small enough to load into memory. Doing it naively consumes around 30GB of RAM which is a bit above our minimal hardware specs for RPC nodes, so I optimized it down to ~17GB by doing two things:
* Used u32 instead of u64 for heights and ordinals
* Assigned a u32 index to every observed block hash and use that everywhere instead of the whole 32-byte hash.

### Performance
The migration takes around 13 minutes and requires ~17GB of RAM.

I made a bit of effort to reduce tha RAM usage from 32GB in the initial implementation to the current 17GB in order to fit under the 24GB minimal hardware requirements for RPC nodes.

Most of the time is spent on reading database columns into memory. After that finding and repairing the inconsistencies takes only a few seconds.
For the first two minutes it's bottlenecked on the CPU of the thread that receives read db data and puts it into hashmaps. After that the bottleneck switches to disk while it reads the `DBCol::BlockMerkleTree` column and CPU stays at 20%.

There is some potential for further optimization, but I think 13 minutes is good enough and I'm afraid of increasing complexity further.

### Database command

There is also a database command which allows to manually scan for inconsistencies and repair them.
```console
neard database ordinal-inconsistency find
neard database ordinal-inconsistency find-and-repair
````
It's useful for testing/benchmarking the tool and allows us to check for these inconsistencies in the future.

Be aware that running this branch on an older database will migrate the database to version 46, fix corruptions during migration, and then run the tool on the fixed database. To avoid this you can manually set database version (`database set-version`) to 46 and then run the tool. Although it'll still create new columns that are incompatible with older non-master neard versions.


### Draft
For now marking a draft, it needs some more love before merging - comments, tests?, better error handling, test on epoch synced nodes etc.