### PR TITLE
fix - update realistic 20 shards benchmark load schedule

### DIFF
--- a/benchmarks/sharded-bm/cases/forknet/realistic_20_cp_1_rpc_20_shard/load-schedule.json
+++ b/benchmarks/sharded-bm/cases/forknet/realistic_20_cp_1_rpc_20_shard/load-schedule.json
@@ -1,9 +1,0 @@
-{
-   "schedule": [
-      { "tps": 2700, "duration_s": 300 },
-      { "tps": 2800, "duration_s": 300 },
-      { "tps": 2850, "duration_s": 300 },
-      { "tps": 2900, "duration_s": 300 },
-      { "tps": 3000, "duration_s": 300 }
-   ]	
-}

--- a/benchmarks/sharded-bm/cases/forknet/realistic_20_cp_1_rpc_20_shard/tx-generator-settings.json
+++ b/benchmarks/sharded-bm/cases/forknet/realistic_20_cp_1_rpc_20_shard/tx-generator-settings.json
@@ -1,0 +1,14 @@
+{
+	"tx_generator": {
+		"schedule": [
+			{ "tps": 1000, "duration_s": 180 }
+		],
+		"controller": {
+			"target_block_production_time_s": 1.5,
+			"bps_filter_window_length": 40,
+			"gain_proportional": 15,
+			"gain_integral": 0.0,
+			"gain_derivative": 0.0
+		}
+	}
+}


### PR DESCRIPTION
Fixing the realistic 20 shards benchmark scenario to use a brief warm up schedule that delegates quickly the TPS control to the PID controller.

Without this the benchmark can't be run manually.