### PR TITLE
feat(protocol-schema): add support for tuples

### DIFF
--- a/core/schema-checker/schema-checker-macro/src/lib.rs
+++ b/core/schema-checker/schema-checker-macro/src/lib.rs
@@ -174,6 +174,9 @@ mod helper {
                     }
                 }
             }
+            Type::Tuple(tuple) => {
+                quote! { (stringify!(#tuple), &[std::any::TypeId::of::<#tuple>()]) }
+            }
             _ => {
                 println!("Unsupported type: {:?}", ty);
                 quote! { (stringify!(#ty), &[std::any::TypeId::of::<#ty>()]) }


### PR DESCRIPTION
This does not actually change the way tuple type IDs are calculated (`TypeId::of` will properly consider changes to all of the fields.) All this does is get rid of a warning that can look pretty scary at first.