### PR TITLE
perf: statically avoid recording partial storage coverage

### DIFF
--- a/core/store/src/trie/ops/tests.rs
+++ b/core/store/src/trie/ops/tests.rs
@@ -120,7 +120,8 @@ fn run(initial_entries: Vec<(Vec<u8>, Vec<u8>)>, retain_multi_ranges: Vec<Range<
         retain_split_shard_custom_ranges_for_trie(&partial_trie, &retain_multi_ranges);
 
     let entries = if mem_state_root != StateRoot::default() {
-        let trie = Trie::new(Arc::new(TrieMemoryPartialStorage::default()), mem_state_root, None);
+        let trie =
+            Trie::new(Arc::new(TrieMemoryPartialStorage::<false>::default()), mem_state_root, None);
         STMemTrieIterator::new(MemTrieIteratorInner::new(&memtries, &trie), None)
             .unwrap()
             .map(|e| e.unwrap())


### PR DESCRIPTION
Visited nodes are only really interesting for only a couple callsites.
Everything else does not care in the least. So its a wasted work in many
cases, including pretty hot uses such as applying a chunk (during SW
validation.)

With the goal of making absolutely sure there is nothing else to squeeze
out of this sponge lets statically at compile time compile out most of
this logic.

Co-authored-by: Darioush Jalali <darioush.jalali@nearone.org>