### PR TITLE
stats: use checked arithmetic for info display (#13854)

### DIFF
--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -722,14 +722,14 @@ pub fn display_sync_status(
             let percent = if highest_height <= start_height {
                 0.0
             } else {
-                (((min(current_height, highest_height) - start_height) * 100) as f64)
-                    / ((highest_height - start_height) as f64)
+                ((min(current_height, highest_height).saturating_sub(*start_height) * 100) as f64)
+                    / (highest_height.saturating_sub(*start_height) as f64)
             };
             format!(
                 "#{:>8} Downloading headers {:.2}% ({} left; at {})",
                 head.height,
                 percent,
-                highest_height - current_height,
+                highest_height.saturating_sub(*current_height),
                 current_height
             )
         }
@@ -744,7 +744,7 @@ pub fn display_sync_status(
                 "#{:>8} Downloading blocks {:.2}% ({} left; at {})",
                 head.height,
                 percent,
-                highest_height - current_height,
+                highest_height.saturating_sub(*current_height),
                 current_height
             )
         }


### PR DESCRIPTION
Apparently there are some instances where data can end up producing an arithmetic overflow. I opted to use `saturating_sub` over other options as this is a display code only and any weird overflows really should mean things like "approximately 0 blocks" anyway.