### PR TITLE
feat: make debug ui latest blocks page slightly more compact

### DIFF
--- a/tools/debug-ui/src/LatestBlocksView.tsx
+++ b/tools/debug-ui/src/LatestBlocksView.tsx
@@ -165,7 +165,7 @@ const BlocksTable = ({ rows, knownProducers, expandAll, hideMissingHeights }: Bl
             <th>Chain</th>
             <th>Height</th>
             <th>{'Hash & creator'}</th>
-            <th>Processing Time (ms)</th>
+            <th><span title="Processing Time (ms)">Proc. Time (ms)</span></th>
             <th>Block Delay (s)</th>
             <th>Gas price ratio</th>
             {[...shardIds].map((shard_id) => (
@@ -259,7 +259,7 @@ const BlocksTable = ({ rows, knownProducers, expandAll, hideMissingHeights }: Bl
                     />
                 </td>
                 <td>{block.processing_time_ms}</td>
-                <td>{row.blockDelay ?? ''}</td>
+                <td>{row.blockDelay?.toFixed(3) ?? ''}</td>
                 <td>{block.gas_price_ratio}</td>
                 {block.full_block_missing && <td colSpan={numShards * 3}>header only</td>}
                 {chunkCells}


### PR DESCRIPTION
- Change `Processing Time (ms)` header to `Proc. Time (ms)` with a tooltip
- Display block delay with exactly exactly 3 digits digits after the decimal point

Before:
<img width="1253" height="572" alt="Screenshot 2025-07-11 at 16 46 08" src="https://github.com/user-attachments/assets/a0e99201-7766-447b-a957-0560d5bba743" />

After:
<img width="1218" height="561" alt="Screenshot 2025-07-11 at 16 46 31" src="https://github.com/user-attachments/assets/f8183141-ff69-4140-a550-a2c1a9c2b55e" />
