### PR TITLE
feat(debug-ui): make it possible to show/hide block and chunk fields 

### DIFF
--- a/tools/debug-ui/src/LatestBlocksView.scss
+++ b/tools/debug-ui/src/LatestBlocksView.scss
@@ -26,6 +26,21 @@
         margin-bottom: 10px;
     }
 
+    .toggle-fields {
+        display: flex;
+        margin-top: 10px;
+        margin-bottom: 10px;
+
+        .toggle-fields-label {
+            align-content: center;
+            width: 100px;
+        }
+
+        .toggle-button-enabled {
+            box-shadow: inset 0 0 2px 20px lightgray;
+        }
+    }
+
     button {
         margin-right: 8px;
     }


### PR DESCRIPTION
Currently Latest Blocks page contains quite a few block and chunk fields that we are no always interested in.
This PR adds toggle buttons on top of the table to allow showing/hiding corresponding fields:
<img width="589" height="84" alt="Screenshot 2025-07-11 at 22 33 28" src="https://github.com/user-attachments/assets/81bd8aec-0319-4bdf-9328-cd5ac670d9d9" />

The goal here is to make the table more compact and enabled adding more fields in the future without overloading user with unnecessary information.

By default only Block Delay and Chunk Gas Used is enabled.

Before:
<img width="1253" height="534" alt="Screenshot 2025-07-11 at 22 35 00" src="https://github.com/user-attachments/assets/2433cb90-ff2e-41f2-8b78-38550fe2de23" />

After:
<img width="1338" height="622" alt="Screenshot 2025-07-11 at 22 35 17" src="https://github.com/user-attachments/assets/0d22a7d8-93cb-4177-ab4c-2758fd3552d1" />
