### PR TITLE
perf: use `sort_unstable` in `TrieRecorder`

### DIFF
--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -139,7 +139,7 @@ impl TrieRecorder {
                 nodes.push(node.into_inner().0);
             }
         }
-        nodes.sort();
+        nodes.sort_unstable();
         PartialStorage { nodes: PartialState::TrieValues(nodes) }
     }
 


### PR DESCRIPTION
*Usually* unstable sort is going to be faster than a stable sort. It of course depends on data and making comparisons is difficult due to how different the stable and unstable sorting algorithms implemented in `libstd` are. In terms of requirements to the data ordering since the collection sorted is randomized, stable sorting is not providing any guarantees.