### PR TITLE
perf: do not report expensive metrics by default

### DIFF
--- a/core/o11y/src/log_config.rs
+++ b/core/o11y/src/log_config.rs
@@ -20,6 +20,8 @@ pub struct LogConfig {
     /// individual spans with something like `debug,store::trie=trace` to have specific targets be
     /// more verbose than the default.
     pub opentelemetry: Option<String>,
+    /// Should we collect expensive metrics?
+    pub expensive_metrics: Option<bool>,
 }
 
 impl LogConfig {

--- a/core/o11y/src/metrics.rs
+++ b/core/o11y/src/metrics.rs
@@ -206,6 +206,20 @@ pub fn try_create_histogram_vec(
     Ok(histogram)
 }
 
+pub mod config {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    static STRAIN_FOR_METRICS: AtomicBool = AtomicBool::new(false);
+
+    pub fn strain_for_metrics(yes: bool) {
+        STRAIN_FOR_METRICS.store(yes, Ordering::Relaxed);
+    }
+
+    pub fn should_strain_for_metrics() -> bool {
+        STRAIN_FOR_METRICS.load(Ordering::Relaxed)
+    }
+}
+
 static EXCEPTIONS: LazyLock<HashSet<&str>> = LazyLock::new(|| {
     HashSet::from([
         "flat_storage_cached_changes_num_items",

--- a/core/o11y/src/reload.rs
+++ b/core/o11y/src/reload.rs
@@ -86,11 +86,12 @@ pub fn reload_log_config(config: Option<&log_config::LogConfig>) {
             config.rust_log.as_deref(),
             config.verbose_module.as_deref(),
             config.opentelemetry.as_deref(),
+            config.expensive_metrics,
         )
     } else {
         // When the LOG_CONFIG_FILENAME is not available, reset to the tracing and logging config
         // when the node was started.
-        reload(None, None, None)
+        reload(None, None, None, None)
     };
     match result {
         Ok(_) => {
@@ -118,7 +119,10 @@ pub fn reload(
     rust_log: Option<&str>,
     verbose_module: Option<&str>,
     opentelemetry: Option<&str>,
+    expensive_metrics: Option<bool>,
 ) -> Result<(), Vec<ReloadError>> {
+    crate::metrics::config::strain_for_metrics(expensive_metrics.unwrap_or_default());
+
     let log_reload_result = LOG_LAYER_RELOAD_HANDLE.get().map_or(
         Err(ReloadError::NoLogReloadHandle),
         |reload_handle| {

--- a/neard/src/cli.rs
+++ b/neard/src/cli.rs
@@ -598,7 +598,7 @@ impl RunCmd {
             .await;
             actix::System::current().stop();
             // Disable the subscriber to properly shutdown the tracer.
-            near_o11y::reload(Some("error"), None, Some("off")).unwrap();
+            near_o11y::reload(Some("error"), None, Some("off"), None).unwrap();
         });
         sys.run().unwrap();
         info!(target: "neard", "Waiting for RocksDB to gracefully shutdown");


### PR DESCRIPTION
For now there's just one – the recorded data size per column. It takes around 7% of the total SW validation time. This metric can be enabled on a per-node basis using `log_config.json` for development nodes.