### PR TITLE
state_sync: fix attempt logic for parts (#13891)

### DIFF
--- a/chain/client/src/sync/state/downloader.rs
+++ b/chain/client/src/sync/state/downloader.rs
@@ -161,9 +161,13 @@ impl StateSyncDownloader {
             }
 
             let attempt = || async {
-                let source = if fallback_source.is_some()
-                    && num_prior_attempts >= num_attempts_before_fallback
-                {
+                // We cannot assume that either source is infallible. We cycle attempts
+                // to the available sources until one of them gives us the state successfully.
+                let cycle_length = num_attempts_before_fallback + 1;
+                let use_fallback = fallback_source.is_some()
+                    && num_prior_attempts % cycle_length == num_attempts_before_fallback;
+
+                let source = if use_fallback {
                     fallback_source.as_ref().unwrap().as_ref()
                 } else {
                     preferred_source.as_ref()

--- a/chain/client/src/sync/state/external.rs
+++ b/chain/client/src/sync/state/external.rs
@@ -42,9 +42,11 @@ impl StateSyncDownloadSourceExternal {
             StateFileType::StateHeader => "header",
             StateFileType::StatePart { .. } => "part",
         };
+        tracing::debug!(target: "sync", ?shard_id, ?file_type, ?location, "external download starting");
         tokio::select! {
             _ = clock.sleep_until(deadline) => {
                 increment_download_count(shard_id, typ, "external", "timeout");
+                tracing::debug!(target: "sync", ?shard_id, ?file_type, ?location, "external download timed out");
                 Err(near_chain::Error::Other("Timeout".to_owned()))
             }
             _ = cancellation.cancelled() => {
@@ -63,6 +65,7 @@ impl StateSyncDownloadSourceExternal {
                             _ = cancellation.cancelled() => {}
                         }
                         increment_download_count(shard_id, typ, "external", "download_error");
+                        tracing::debug!(target: "sync", ?shard_id, ?file_type, ?location, %err, "external download error");
                         Err(near_chain::Error::Other(format!("Failed to download: {}", err)))
                     }
                     Ok(res) => Ok(res)

--- a/chain/client/src/sync/state/network.rs
+++ b/chain/client/src/sync/state/network.rs
@@ -72,7 +72,7 @@ impl StateSyncDownloadSourcePeerSharedState {
         };
 
         let Some(request) = self.pending_requests.get(&key) else {
-            tracing::debug!(target: "sync", "Received {:?} expecting {:?}", key, self.pending_requests.keys());
+            tracing::debug!(target: "sync", "Received {:?} from {}", key, peer_id);
             return Err(near_chain::Error::Other("Unexpected state response".to_owned()));
         };
 
@@ -188,7 +188,10 @@ impl StateSyncDownloadSourcePeer {
             }
         };
 
-        let state_value = PendingPeerRequestValue { peer_id: Some(request_sent_to_peer), sender };
+        tracing::debug!(target: "sync", ?key, ?request_sent_to_peer, "p2p request sent");
+
+        let state_value =
+            PendingPeerRequestValue { peer_id: Some(request_sent_to_peer.clone()), sender };
 
         // Ensures that the key is removed from the map of pending requests when this scope exits,
         // whether on success or timeout.
@@ -202,6 +205,7 @@ impl StateSyncDownloadSourcePeer {
         select! {
             _ = clock.sleep_until(deadline) => {
                 increment_download_count(key.shard_id, typ, "network", "timeout");
+                tracing::debug!(target: "sync", ?key, ?request_sent_to_peer, "p2p request timed out");
                 Err(near_chain::Error::Other("Timeout".to_owned()))
             }
             _ = cancel.cancelled() => {
@@ -211,6 +215,7 @@ impl StateSyncDownloadSourcePeer {
             result = receiver => {
                 match result {
                     Ok(result) => {
+                        tracing::debug!(target: "sync", ?key, ?request_sent_to_peer, "p2p request succeeded");
                         increment_download_count(key.shard_id, typ, "network", "success");
                         Ok(result)
                     }

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -119,9 +119,6 @@ impl ViewClientRequestManager {
 impl Actor for ViewClientActorInner {}
 
 impl ViewClientActorInner {
-    /// Maximum number of state requests allowed per `view_client_throttle_period`.
-    const MAX_NUM_STATE_REQUESTS: usize = 30;
-
     pub fn spawn_actix_actor(
         clock: Clock,
         validator: MutableValidatorSigner,
@@ -697,7 +694,7 @@ impl ViewClientActorInner {
                 break;
             }
         }
-        if cache.len() >= Self::MAX_NUM_STATE_REQUESTS {
+        if cache.len() >= self.config.view_client_num_state_requests_per_throttle_period {
             return true;
         }
         cache.push_back(now);

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -475,6 +475,10 @@ pub fn default_view_client_throttle_period() -> Duration {
     Duration::seconds(30)
 }
 
+pub fn default_view_client_num_state_requests_per_throttle_period() -> usize {
+    30
+}
+
 pub fn default_trie_viewer_state_size_limit() -> Option<u64> {
     Some(50_000)
 }
@@ -640,9 +644,11 @@ pub struct ClientConfig {
     pub save_trie_changes: bool,
     /// Number of threads for ViewClientActor pool.
     pub view_client_threads: usize,
-    /// Number of seconds between state requests for view client.
+    /// Throttling window for state requests (headers and parts).
     #[cfg_attr(feature = "schemars", schemars(with = "DurationSchemarsProvider"))]
     pub view_client_throttle_period: Duration,
+    /// Maximum number of state requests served per `view_client_throttle_period`
+    pub view_client_num_state_requests_per_throttle_period: usize,
     /// Upper bound of the byte size of contract state that is still viewable. None is no limit
     pub trie_viewer_state_size_limit: Option<u64>,
     /// Max burnt gas per view method.  If present, overrides value stored in
@@ -763,6 +769,7 @@ impl ClientConfig {
             log_summary_style: LogSummaryStyle::Colored,
             view_client_threads: 1,
             view_client_throttle_period: Duration::seconds(1),
+            view_client_num_state_requests_per_throttle_period: 30,
             trie_viewer_state_size_limit: None,
             max_gas_burnt_view: None,
             enable_statistics_export: true,

--- a/core/chain-configs/src/lib.rs
+++ b/core/chain-configs/src/lib.rs
@@ -26,7 +26,8 @@ pub use client_config::{
     default_state_sync_retry_backoff, default_sync_check_period, default_sync_height_threshold,
     default_sync_max_block_requests, default_sync_step_period, default_transaction_pool_size_limit,
     default_trie_viewer_state_size_limit, default_tx_routing_height_horizon,
-    default_view_client_threads, default_view_client_throttle_period,
+    default_view_client_num_state_requests_per_throttle_period, default_view_client_threads,
+    default_view_client_throttle_period,
 };
 pub use genesis_config::{
     Genesis, GenesisChangeConfig, GenesisConfig, GenesisContents, GenesisRecords,

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -28,7 +28,8 @@ use near_chain_configs::{
     default_state_sync_retry_backoff, default_sync_check_period, default_sync_height_threshold,
     default_sync_max_block_requests, default_sync_step_period, default_transaction_pool_size_limit,
     default_trie_viewer_state_size_limit, default_tx_routing_height_horizon,
-    default_view_client_threads, default_view_client_throttle_period, get_initial_supply,
+    default_view_client_num_state_requests_per_throttle_period, default_view_client_threads,
+    default_view_client_throttle_period, get_initial_supply,
 };
 use near_config_utils::{DownloadConfigType, ValidationError, ValidationErrors};
 use near_crypto::{InMemorySigner, KeyFile, KeyType, PublicKey, Signer};
@@ -291,6 +292,8 @@ pub struct Config {
     pub view_client_threads: usize,
     #[serde(with = "near_async::time::serde_duration_as_std")]
     pub view_client_throttle_period: Duration,
+    /// Maximum number of state requests served per `view_client_throttle_period`
+    pub view_client_num_state_requests_per_throttle_period: usize,
     pub trie_viewer_state_size_limit: Option<u64>,
     /// If set, overrides value in genesis configuration.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -399,6 +402,8 @@ impl Default for Config {
             gc: GCConfig::default(),
             view_client_threads: default_view_client_threads(),
             view_client_throttle_period: default_view_client_throttle_period(),
+            view_client_num_state_requests_per_throttle_period:
+                default_view_client_num_state_requests_per_throttle_period(),
             trie_viewer_state_size_limit: default_trie_viewer_state_size_limit(),
             max_gas_burnt_view: None,
             store: near_store::StoreConfig::default(),
@@ -593,6 +598,8 @@ impl NearConfig {
                 gc: config.gc,
                 view_client_threads: config.view_client_threads,
                 view_client_throttle_period: config.view_client_throttle_period,
+                view_client_num_state_requests_per_throttle_period: config
+                    .view_client_num_state_requests_per_throttle_period,
                 trie_viewer_state_size_limit: config.trie_viewer_state_size_limit,
                 max_gas_burnt_view: config.max_gas_burnt_view,
                 enable_statistics_export: config.store.enable_statistics_export,

--- a/pytest/lib/state_sync_lib.py
+++ b/pytest/lib/state_sync_lib.py
@@ -25,6 +25,12 @@ def get_state_sync_config_p2p(tracked_shards_config):
     state_parts_dir = str(pathlib.Path(tempfile.gettempdir()) / "state_parts")
 
     config = {
+        # Throttle view clients aggressively so that some p2p requests will fail.
+        "view_client_num_state_requests_per_throttle_period": 1,
+        "view_client_throttle_period": {
+            "secs": 2,
+            "nanos": 0
+        },
         "consensus.state_sync_external_timeout": {
             "secs": 0,
             "nanos": 500000000

--- a/pytest/tests/sanity/state_sync_decentralized.py
+++ b/pytest/tests/sanity/state_sync_decentralized.py
@@ -7,6 +7,7 @@
 import unittest
 import sys
 import pathlib
+from collections import defaultdict
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2] / 'lib'))
 
@@ -120,11 +121,11 @@ class StateSyncValidatorShardSwap(unittest.TestCase):
 
             num_headers = 0
             num_parts = 0
-            num_retries = 0
+            num_failed = defaultdict(int)
 
             for key, value in down:
                 if key['result'] != 'success':
-                    num_retries += 1
+                    num_failed[key['source']] += 1
                     continue
 
                 if key['source'] != 'network':
@@ -140,9 +141,9 @@ class StateSyncValidatorShardSwap(unittest.TestCase):
             print(
                 f"Node {i} downloaded {num_headers} state headers and {num_parts} parts from peers"
             )
-            if num_retries > 0:
+            if num_failed:
                 print(
-                    f"WARN: Node {i} made {num_retries} unsuccessful requests for state data"
+                    f"WARN: Node {i} made {dict(num_failed)} unsuccessful requests for state data"
                 )
             assert num_headers > 0 and num_parts > 0, f"Node {i} did not state sync, but is expected to in this test"
 


### PR DESCRIPTION
Similar to #13464, which fixed this logic for headers.

The old code carries the assumption that the fallback source will work eventually. Rather we should continue making attempts to both sources until the needed part is obtained.

The fix should be included to the 2.7 release.

---

As a follow up, it should be possible to test this by adding a fake bucket in the state_sync_decentralized.py pytest. We can also introduce some random failures of the p2p requests to make sure the bucket gets hit (unsuccessfully).