### PR TITLE
[state_part] Simplify get_trie_nodes_for_part_with_flat_storage

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -399,24 +399,12 @@ impl NightshadeRuntime {
 
         let trie_with_state =
             self.tries.get_trie_with_block_hash_for_shard(shard_uid, *state_root, &prev_hash, true);
-        let (path_boundary_nodes, nibbles_begin, nibbles_end) = match trie_with_state
-            .get_state_part_boundaries(part_id)
-        {
-            Ok(res) => res,
-            Err(err) => {
-                error!(target: "runtime", ?err, part_id.idx, part_id.total, %prev_hash, %state_root, %shard_id, "Can't get trie nodes for state part boundaries");
-                return Err(err.into());
-            }
-        };
 
         let trie_nodes = self.tries.get_trie_nodes_for_part_from_snapshot(
             shard_uid,
             state_root,
             &prev_hash,
             part_id,
-            path_boundary_nodes,
-            nibbles_begin,
-            nibbles_end,
             trie_with_state,
         );
         let state_part = borsh::to_vec(&match trie_nodes {

--- a/core/store/src/trie/state_snapshot.rs
+++ b/core/store/src/trie/state_snapshot.rs
@@ -191,9 +191,6 @@ impl ShardTries {
         state_root: &StateRoot,
         block_hash: &CryptoHash,
         part_id: PartId,
-        path_boundary_nodes: PartialState,
-        nibbles_begin: Vec<u8>,
-        nibbles_end: Vec<u8>,
         state_trie: Trie,
     ) -> Result<PartialState, StorageError> {
         let guard = self.state_snapshot().try_read().ok_or(SnapshotError::LockWouldBlock)?;
@@ -213,13 +210,7 @@ impl ShardTries {
         let flat_storage_chunk_view = data.flat_storage_manager.chunk_view(shard_uid, *block_hash);
 
         let snapshot_trie = Trie::new(storage, *state_root, flat_storage_chunk_view);
-        snapshot_trie.get_trie_nodes_for_part_with_flat_storage(
-            part_id,
-            path_boundary_nodes,
-            nibbles_begin,
-            nibbles_end,
-            &state_trie,
-        )
+        snapshot_trie.get_trie_nodes_for_part_with_flat_storage(part_id, &state_trie)
     }
 
     /// Makes a snapshot of the current state of the DB, if one is not already available.


### PR DESCRIPTION
`get_state_part_boundaries` can easily be inside the `get_trie_nodes_for_part_with_flat_storage` function here. No need to call it externally and pass in the parameters.