### PR TITLE
state sync: minor cleanups

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -48,7 +48,7 @@ use near_epoch_manager::shard_assignment::shard_id_to_uid;
 use near_epoch_manager::shard_tracker::ShardTracker;
 use near_network::types::{AccountKeys, ChainInfo, PeerManagerMessageRequest, SetChainInfo};
 use near_network::types::{
-    HighestHeightPeerInfo, NetworkRequests, PeerManagerAdapter, ReasonForBan,
+    NetworkRequests, PeerManagerAdapter, ReasonForBan,
 };
 use near_primitives::block::{Approval, ApprovalInner, ApprovalMessage, Block, BlockHeader, Tip};
 use near_primitives::block_header::ApprovalType;
@@ -2116,7 +2116,6 @@ impl Client {
     /// Walks through all the ongoing state syncs for future epochs and processes them
     pub fn run_catchup(
         &mut self,
-        highest_height_peers: &[HighestHeightPeerInfo],
         block_catch_up_task_scheduler: &Sender<BlockCatchUpRequest>,
         apply_chunks_done_sender: Option<ApplyChunksDoneSender>,
     ) -> Result<(), Error> {
@@ -2173,7 +2172,6 @@ impl Client {
             match state_sync.run(
                 sync_hash,
                 status,
-                highest_height_peers,
                 state_sync_info.shards(),
             )? {
                 StateSyncResult::InProgress => {}

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1572,7 +1572,6 @@ impl ClientActorInner {
             // An extra scope to limit the lifetime of the span.
             let _span = tracing::debug_span!(target: "client", "catchup").entered();
             if let Err(err) = self.client.run_catchup(
-                &self.network_info.highest_height_peers,
                 &self.sync_jobs_sender.block_catch_up,
                 Some(self.client.myself_sender.apply_chunks_done.clone()),
             ) {

--- a/chain/client/src/sync/handler.rs
+++ b/chain/client/src/sync/handler.rs
@@ -154,7 +154,6 @@ impl SyncHandler {
         let state_sync_result = self.state_sync.run(
             sync_hash,
             state_sync_status,
-            &highest_height_peers,
             &shards_to_sync,
         );
         let state_sync_result = unwrap_and_report_state_sync_result!(state_sync_result);

--- a/chain/client/src/sync/state/mod.rs
+++ b/chain/client/src/sync/state/mod.rs
@@ -23,7 +23,7 @@ use near_chain_configs::{
 use near_client_primitives::types::{ShardSyncStatus, StateSyncStatus};
 use near_epoch_manager::EpochManagerAdapter;
 use near_network::types::{
-    HighestHeightPeerInfo, PeerManagerMessageRequest, PeerManagerMessageResponse,
+    PeerManagerMessageRequest, PeerManagerMessageResponse,
 };
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
@@ -211,16 +211,11 @@ impl StateSync {
         &mut self,
         sync_hash: CryptoHash,
         sync_status: &mut StateSyncStatus,
-        highest_height_peers: &[HighestHeightPeerInfo],
         tracking_shards: &[ShardId],
     ) -> Result<StateSyncResult, near_chain::Error> {
         let _span =
             tracing::debug_span!(target: "sync", "run_sync", sync_type = "StateSync").entered();
         tracing::debug!(%sync_hash, ?tracking_shards, "syncing state");
-
-        self.peer_source_state.lock().set_highest_peers(
-            highest_height_peers.iter().map(|info| info.peer_info.id.clone()).collect(),
-        );
 
         let mut all_done = true;
         for shard_id in tracking_shards {

--- a/chain/client/src/sync/state/network.rs
+++ b/chain/client/src/sync/state/network.rs
@@ -34,7 +34,6 @@ pub(super) struct StateSyncDownloadSourcePeer {
 
 #[derive(Default)]
 pub(super) struct StateSyncDownloadSourcePeerSharedState {
-    highest_height_peers: Vec<PeerId>,
     /// Tracks pending requests we have sent to peers. The requests are indexed by
     /// (shard ID, sync hash, part ID or header), and the value is the peer ID we
     /// expect the response from, as well as a channel sender to complete the future
@@ -85,11 +84,6 @@ impl StateSyncDownloadSourcePeerSharedState {
         let value = self.pending_requests.remove(&key).unwrap();
         let _ = value.sender.send(data);
         Ok(())
-    }
-
-    /// Sets the peers that are eligible for querying state sync headers/parts.
-    pub fn set_highest_peers(&mut self, peers: Vec<PeerId>) {
-        self.highest_height_peers = peers;
     }
 }
 

--- a/chain/client/src/sync/state/network.rs
+++ b/chain/client/src/sync/state/network.rs
@@ -50,7 +50,7 @@ struct PendingPeerRequestKey {
 }
 
 struct PendingPeerRequestValue {
-    peer_id: Option<PeerId>, // present for headers, not for parts
+    peer_id: PeerId,
     sender: oneshot::Sender<ShardStateSyncResponse>,
 }
 
@@ -76,7 +76,7 @@ impl StateSyncDownloadSourcePeerSharedState {
             return Err(near_chain::Error::Other("Unexpected state response".to_owned()));
         };
 
-        if request.peer_id.as_ref().is_some_and(|expecting_peer_id| expecting_peer_id != &peer_id) {
+        if request.peer_id != peer_id {
             return Err(near_chain::Error::Other(
                 "Unexpected state response (wrong sender)".to_owned(),
             ));
@@ -190,8 +190,7 @@ impl StateSyncDownloadSourcePeer {
 
         tracing::debug!(target: "sync", ?key, ?request_sent_to_peer, "p2p request sent");
 
-        let state_value =
-            PendingPeerRequestValue { peer_id: Some(request_sent_to_peer.clone()), sender };
+        let state_value = PendingPeerRequestValue { peer_id: request_sent_to_peer.clone(), sender };
 
         // Ensures that the key is removed from the map of pending requests when this scope exits,
         // whether on success or timeout.

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -12,7 +12,6 @@ use near_chain::chain::{BlockCatchUpRequest, do_apply_chunks};
 use near_chain::test_utils::{wait_for_all_blocks_in_processing, wait_for_block_in_processing};
 use near_chain::{ChainStoreAccess, Provenance};
 use near_client_primitives::types::Error;
-use near_network::types::HighestHeightPeerInfo;
 use near_primitives::bandwidth_scheduler::BandwidthRequests;
 use near_primitives::block::Block;
 use near_primitives::hash::CryptoHash;
@@ -263,7 +262,6 @@ pub fn create_chunk(
 /// and the catchup process can't catch up on these blocks yet.
 pub fn run_catchup(
     client: &mut Client,
-    highest_height_peers: &[HighestHeightPeerInfo],
 ) -> Result<(), Error> {
     let block_messages = Arc::new(RwLock::new(vec![]));
     let block_inside_messages = block_messages.clone();
@@ -272,7 +270,7 @@ pub fn run_catchup(
     });
     let _ = System::new();
     loop {
-        client.run_catchup(highest_height_peers, &block_catch_up, None)?;
+        client.run_catchup(&block_catch_up, None)?;
         let mut catchup_done = true;
         for msg in block_messages.write().drain(..) {
             let results =


### PR DESCRIPTION
Couple of trivial refactors on legacy code in state sync.

1. Following the changes in #13377, the expected peer_id for a pending request is always known. The type does not need to be an Option anymore.
2. `highest_height_peers` are not used anymore at all in state sync.