### PR TITLE
fix(tests): set vm_kind manually, make x86 wasmtime tests pass

### DIFF
--- a/core/parameters/src/config_store.rs
+++ b/core/parameters/src/config_store.rs
@@ -252,6 +252,17 @@ impl RuntimeConfigStore {
             })
             .1
     }
+
+    /// Returns a mutable borrow of `RuntimeConfig` for the corresponding protocol version.
+    pub fn get_config_mut(&mut self, protocol_version: ProtocolVersion) -> &mut Arc<RuntimeConfig> {
+        self.store
+            .range_mut((Bound::Unbounded, Bound::Included(protocol_version)))
+            .next_back()
+            .unwrap_or_else(|| {
+                panic!("Not found RuntimeConfig for protocol version {}", protocol_version)
+            })
+            .1
+    }
 }
 
 #[cfg(test)]

--- a/runtime/near-vm-runner/src/logic/tests/context.rs
+++ b/runtime/near-vm-runner/src/logic/tests/context.rs
@@ -92,7 +92,7 @@ fn test_attached_deposit_view() {
         let mut logic_builder = VMLogicBuilder::default();
         let context = &mut logic_builder.context;
         context.view_config =
-            Some(ViewConfig { max_gas_burnt: test_vm_config().limit_config.max_gas_burnt });
+            Some(ViewConfig { max_gas_burnt: test_vm_config(None).limit_config.max_gas_burnt });
         context.account_balance = 0;
         context.attached_deposit = amount;
         let mut logic = logic_builder.build();

--- a/runtime/near-vm-runner/src/logic/tests/gas_counter.rs
+++ b/runtime/near-vm-runner/src/logic/tests/gas_counter.rs
@@ -832,7 +832,7 @@ fn create_promise_dependency(logic: &mut TestVMLogic) -> Result<(), VMLogicError
 /// Given the limit in gas, compute the corresponding limit in wasm ops for use
 /// with [`VMLogic::gas`] function.
 fn op_limit(gas_limit: Gas) -> u32 {
-    (gas_limit / (test_vm_config().regular_op_cost as u64)) as u32
+    (gas_limit / (test_vm_config(None).regular_op_cost as u64)) as u32
 }
 
 fn test_pk() -> Vec<u8> {

--- a/runtime/near-vm-runner/src/logic/tests/registers.rs
+++ b/runtime/near-vm-runner/src/logic/tests/registers.rs
@@ -61,7 +61,7 @@ fn test_max_register_size() {
 #[test]
 fn test_max_register_memory_limit() {
     let mut logic_builder = VMLogicBuilder::free();
-    let mut config = test_vm_config();
+    let mut config = test_vm_config(None);
     config.make_free();
     logic_builder.config = config.clone();
     let mut logic = logic_builder.build();

--- a/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
+++ b/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
@@ -16,7 +16,7 @@ pub(super) struct VMLogicBuilder {
 impl Default for VMLogicBuilder {
     fn default() -> Self {
         VMLogicBuilder {
-            config: test_vm_config(),
+            config: test_vm_config(None),
             fees_config: RuntimeFeesConfig::test(),
             ext: MockedExternal::default(),
             memory: MockedMemory::default(),
@@ -52,7 +52,7 @@ impl VMLogicBuilder {
     pub fn free() -> Self {
         VMLogicBuilder {
             config: {
-                let mut config = test_vm_config();
+                let mut config = test_vm_config(None);
                 config.make_free();
                 config
             },

--- a/runtime/near-vm-runner/src/logic/vmstate.rs
+++ b/runtime/near-vm-runner/src/logic/vmstate.rs
@@ -273,7 +273,7 @@ mod tests {
             let costs = ExtCostsConfig::test();
             Self {
                 gas: GasCounter::new(costs, u64::MAX, 0, u64::MAX, false),
-                cfg: test_vm_config().limit_config,
+                cfg: test_vm_config(None).limit_config,
                 regs: Default::default(),
             }
         }

--- a/runtime/near-vm-runner/src/prepare.rs
+++ b/runtime/near-vm-runner/src/prepare.rs
@@ -48,8 +48,8 @@ mod tests {
 
     #[test]
     fn internal_memory_declaration() {
-        let config = test_vm_config();
-        with_vm_variants(&config, |kind| {
+        with_vm_variants(|kind| {
+            let config = test_vm_config(Some(kind));
             let r = parse_and_prepare_wat(&config, kind, r#"(module (memory 1 1))"#);
             assert_matches!(r, Ok(_));
         })
@@ -57,12 +57,11 @@ mod tests {
 
     #[test]
     fn memory_imports() {
-        let config = test_vm_config();
+        with_vm_variants(|kind| {
+            let config = test_vm_config(Some(kind));
+            // This test assumes that maximum page number is configured to a certain number.
+            assert_eq!(config.limit_config.max_memory_pages, 2048);
 
-        // This test assumes that maximum page number is configured to a certain number.
-        assert_eq!(config.limit_config.max_memory_pages, 2048);
-
-        with_vm_variants(&config, |kind| {
             let r = parse_and_prepare_wat(
                 &config,
                 kind,
@@ -102,8 +101,8 @@ mod tests {
 
     #[test]
     fn multiple_valid_memory_are_disabled() {
-        let config = test_vm_config();
-        with_vm_variants(&config, |kind| {
+        with_vm_variants(|kind| {
+            let config = test_vm_config(Some(kind));
             // Our preparation and sanitization pass assumes a single memory, so we should fail when
             // there are multiple specified.
             let r = parse_and_prepare_wat(
@@ -129,8 +128,8 @@ mod tests {
 
     #[test]
     fn imports() {
-        let config = test_vm_config();
-        with_vm_variants(&config, |kind| {
+        with_vm_variants(|kind| {
+            let config = test_vm_config(Some(kind));
             // nothing can be imported from non-"env" module for now.
             let r = parse_and_prepare_wat(
                 &config,

--- a/runtime/near-vm-runner/src/prepare/prepare_v2.rs
+++ b/runtime/near-vm-runner/src/prepare/prepare_v2.rs
@@ -446,7 +446,7 @@ mod test {
 
     #[test]
     fn v2_preparation_wasmtime_generates_valid_contract_fuzzer() {
-        let mut config = test_vm_config();
+        let mut config = test_vm_config(Some(VMKind::Wasmtime));
         config.reftypes_bulk_memory = false;
         let features = crate::features::WasmFeatures::new(&config);
         bolero::check!().for_each(|input: &[u8]| {
@@ -472,7 +472,7 @@ mod test {
 
     #[test]
     fn v2_preparation_near_vm_generates_valid_contract_fuzzer() {
-        let mut config = test_vm_config();
+        let mut config = test_vm_config(Some(VMKind::NearVm));
         config.reftypes_bulk_memory = false;
         let features = crate::features::WasmFeatures::new(&config);
         bolero::check!().for_each(|input: &[u8]| {

--- a/runtime/near-vm-runner/src/prepare/prepare_v3.rs
+++ b/runtime/near-vm-runner/src/prepare/prepare_v3.rs
@@ -449,7 +449,7 @@ mod test {
 
     #[test]
     fn v3_preparation_wasmtime_generates_valid_contract_fuzzer() {
-        let config = test_vm_config();
+        let config = test_vm_config(Some(VMKind::Wasmtime));
         let features = crate::features::WasmFeatures::new(&config);
         bolero::check!().for_each(|input: &[u8]| {
             // DO NOT use ArbitraryModule. We do want modules that may be invalid here, if they
@@ -474,7 +474,7 @@ mod test {
 
     #[test]
     fn v3_preparation_near_vm_generates_valid_contract_fuzzer() {
-        let config = test_vm_config();
+        let config = test_vm_config(Some(VMKind::NearVm2));
         let features = crate::features::WasmFeatures::new(&config);
         bolero::check!().for_each(|input: &[u8]| {
             // DO NOT use ArbitraryModule. We do want modules that may be invalid here, if they

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -19,19 +19,16 @@ const SIGNER_ACCOUNT_ID: &str = "bob";
 const SIGNER_ACCOUNT_PK: [u8; 3] = [0, 1, 2];
 const PREDECESSOR_ACCOUNT_ID: &str = "carol";
 
-pub(crate) fn test_vm_config() -> near_parameters::vm::Config {
+pub(crate) fn test_vm_config(vm_kind: Option<VMKind>) -> near_parameters::vm::Config {
     let store = RuntimeConfigStore::test();
     let config = store.get_config(PROTOCOL_VERSION).wasm_config.clone();
     near_parameters::vm::Config {
-        vm_kind: config.vm_kind.replace_with_wasmtime_if_unsupported(),
+        vm_kind: vm_kind.unwrap_or_else(|| config.vm_kind.replace_with_wasmtime_if_unsupported()),
         ..near_parameters::vm::Config::clone(&config)
     }
 }
 
-pub(crate) fn with_vm_variants(
-    #[allow(unused)] cfg: &near_parameters::vm::Config,
-    runner: impl Fn(VMKind) -> (),
-) {
+pub(crate) fn with_vm_variants(runner: impl Fn(VMKind) -> ()) {
     #[allow(unused)]
     let run = move |kind| {
         println!("running test with {kind:?}");

--- a/runtime/near-vm-runner/src/tests/cache.rs
+++ b/runtime/near-vm-runner/src/tests/cache.rs
@@ -16,8 +16,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 #[test]
 fn test_caches_compilation_error() {
-    let config = Arc::new(test_vm_config());
-    with_vm_variants(&config, |vm_kind: VMKind| {
+    with_vm_variants(|vm_kind: VMKind| {
+        let config = Arc::new(test_vm_config(Some(vm_kind)));
         // The cache is currently properly implemented only for NearVM
         match vm_kind {
             VMKind::NearVm | VMKind::NearVm2 | VMKind::Wasmtime => {}
@@ -57,8 +57,8 @@ fn test_caches_compilation_error() {
 
 #[test]
 fn test_does_not_cache_io_error() {
-    let config = Arc::new(test_vm_config());
-    with_vm_variants(&config, |vm_kind: VMKind| {
+    with_vm_variants(|vm_kind: VMKind| {
+        let config = Arc::new(test_vm_config(Some(vm_kind)));
         match vm_kind {
             VMKind::NearVm | VMKind::NearVm2 | VMKind::Wasmtime => {}
             VMKind::Wasmer0 | VMKind::Wasmer2 => return,
@@ -168,7 +168,7 @@ fn test_near_vm_artifact_output_stability() {
     for seed in seeds {
         let contract = ContractCode::new(near_test_contracts::arbitrary_contract(seed), None);
 
-        let mut config = test_vm_config();
+        let mut config = test_vm_config(Some(VMKind::NearVm));
         config.reftypes_bulk_memory = false; // FIXME: ProtocolFeature::RefTypesBulkMemory
         let prepared_code =
             prepare::prepare_contract(contract.code(), &config, VMKind::NearVm).unwrap();

--- a/runtime/near-vm-runner/src/tests/fuzzers.rs
+++ b/runtime/near-vm-runner/src/tests/fuzzers.rs
@@ -66,7 +66,7 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMResult {
     let method_name = find_entry_point(code).unwrap_or_else(|| "main".to_string());
     let mut context = create_context(vec![]);
     context.prepaid_gas = 10u64.pow(14);
-    let config = test_vm_config();
+    let config = test_vm_config(Some(vm_kind));
     let fees = Arc::new(RuntimeFeesConfig::test());
     let gas_counter = context.make_gas_counter(&config);
     let mut res = vm_kind
@@ -93,7 +93,7 @@ fn run_fuzz(code: &ContractCode, vm_kind: VMKind) -> VMResult {
 #[test]
 #[cfg(feature = "prepare")]
 fn slow_test_current_vm_does_not_crash_fuzzer() {
-    let config = test_vm_config();
+    let config = test_vm_config(None);
     if config.vm_kind.is_available() {
         bolero::check!().with_arbitrary::<ArbitraryModule>().for_each(
             |module: &ArbitraryModule| {
@@ -124,7 +124,7 @@ fn slow_test_near_vm_is_reproducible_fuzzer() {
 
     bolero::check!().with_arbitrary::<ArbitraryModule>().for_each(|module: &ArbitraryModule| {
         let code = ContractCode::new(module.0.to_bytes(), None);
-        let config = std::sync::Arc::new(test_vm_config());
+        let config = std::sync::Arc::new(test_vm_config(Some(VMKind::NearVm)));
         let mut first_hash = None;
         for _ in 0..3 {
             let vm = NearVM::new(config.clone());
@@ -150,7 +150,7 @@ fn slow_test_wasmtime_vm_is_reproducible_fuzzer() {
 
     bolero::check!().with_arbitrary::<ArbitraryModule>().for_each(|module: &ArbitraryModule| {
         let code = ContractCode::new(module.0.to_bytes(), None);
-        let config = std::sync::Arc::new(test_vm_config());
+        let config = Arc::new(test_vm_config(Some(VMKind::Wasmtime)));
         let mut first_hash = None;
         for _ in 0..3 {
             let vm = WasmtimeVM::new(config.clone());

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -170,7 +170,7 @@ impl TestBuilder {
         I::IntoIter: ExactSizeIterator,
     {
         self.protocol_versions.sort();
-        let runtime_config_store = RuntimeConfigStore::new(None);
+        let mut runtime_config_store = RuntimeConfigStore::new(None);
         let wants = wants.into_iter();
         assert_eq!(
             wants.len(),
@@ -187,7 +187,10 @@ impl TestBuilder {
                     continue;
                 }
 
-                let runtime_config = runtime_config_store.get_config(protocol_version);
+                let runtime_config = runtime_config_store.get_config_mut(protocol_version);
+                Arc::get_mut(&mut Arc::get_mut(runtime_config).unwrap().wasm_config)
+                    .unwrap()
+                    .vm_kind = vm_kind;
                 let mut fake_external = MockedExternal::with_code(self.code.clone_for_tests());
                 let config = runtime_config.wasm_config.clone();
                 let fees = Arc::new(RuntimeFeesConfig::test());

--- a/runtime/near-vm-runner/src/tests/ts_contract.rs
+++ b/runtime/near-vm-runner/src/tests/ts_contract.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 
 #[test]
 pub fn test_ts_contract() {
-    let config = Arc::new(test_vm_config());
-    with_vm_variants(&config, |vm_kind: VMKind| {
+    with_vm_variants(|vm_kind: VMKind| {
+        let config = Arc::new(test_vm_config(Some(vm_kind)));
         let code = ContractCode::new(near_test_contracts::ts_contract().to_vec(), None);
         let mut fake_external = MockedExternal::with_code(code);
         let context = create_context(Vec::new());

--- a/runtime/near-vm-runner/src/tests/wasm_validation.rs
+++ b/runtime/near-vm-runner/src/tests/wasm_validation.rs
@@ -104,8 +104,8 @@ static EXPECTED_UNSUPPORTED: &[(&str, &str)] = &[
 #[test]
 #[cfg(feature = "prepare")]
 fn ensure_fails_verification() {
-    let config = test_vm_config();
-    with_vm_variants(&config, |kind| {
+    with_vm_variants(|kind| {
+        let config = test_vm_config(Some(kind));
         for (feature_name, wat) in EXPECTED_UNSUPPORTED {
             let wasm = wat::parse_str(wat).expect("parsing test wat should succeed");
             if let Ok(_) = crate::prepare::prepare_contract(&wasm, &config, kind) {


### PR DESCRIPTION
`with_vm_variants` used to take an unused config argument that read from the parameters list and defaulted to the NearVM case on x86, which caused a misconfiguration when Wasmtime was enabled.

This change removes that unused config argument and defines it inside the closure, as well as making the `vm_kind` an optional arg for `test_vm_config()` to ensure the correct `vm_kind` is used.