### PR TITLE
Update Wasmer features documentation link to current URL

### DIFF
--- a/runtime/near-vm/compiler/src/error.rs
+++ b/runtime/near-vm/compiler/src/error.rs
@@ -33,7 +33,7 @@ pub enum CompileError {
     /// The compiler cannot compile for the given target.
     /// This can refer to the OS, the chipset or any other aspect of the target system.
     #[error(
-        "The target {0} is not yet supported (see https://docs.wasmer.io/ecosystem/wasmer/wasmer-features)"
+        "The target {0} is not yet supported (see https://docs.wasmer.io/runtime/features)"
     )]
     UnsupportedTarget(String),
 


### PR DESCRIPTION
Replaced the outdated Wasmer features documentation link (https://docs.wasmer.io/ecosystem/wasmer/wasmer-features) with the current and correct URL (https://docs.wasmer.io/runtime/features) in the UnsupportedTarget error message. This ensures users are directed to the latest official documentation regarding supported Wasmer features and targets.