### PR TITLE
perf: avoid re-allocating the transactions for validation

### DIFF
--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1780,7 +1780,7 @@ impl Runtime {
         let apply_state = &mut processing_state.apply_state;
         let state_update = &mut processing_state.state_update;
 
-        let tx_vec = signed_txs.into_iter_nonexpired_transactions().collect::<Vec<_>>();
+        let tx_vec = signed_txs.into_nonexpired_transactions();
         let tx_batches = TransactionBatches::new(&tx_vec);
 
         let batch_outputs = tx_batches

--- a/runtime/runtime/src/types.rs
+++ b/runtime/runtime/src/types.rs
@@ -37,11 +37,14 @@ impl SignedValidPeriodTransactions {
             .filter_map(|(t, v)| v.then_some(t))
     }
 
-    pub fn into_iter_nonexpired_transactions(self) -> impl Iterator<Item = SignedTransaction> {
+    pub fn into_nonexpired_transactions(mut self) -> Vec<SignedTransaction> {
+        let mut index = 0;
+        self.transactions.retain(|_| {
+            let retain = self.transaction_validity_check_passed[index];
+            index += 1;
+            retain
+        });
         self.transactions
-            .into_iter()
-            .zip(self.transaction_validity_check_passed)
-            .filter_map(|(t, v)| v.then_some(t))
     }
 
     pub fn len(&self) -> usize {


### PR DESCRIPTION
Since we're taking the values… by value, there is no reason to create a new vector for those values when we can "simply" use the original vector.