### PR TITLE
state sync: measure time spent to validate parts

### DIFF
--- a/chain/chain/src/runtime/metrics.rs
+++ b/chain/chain/src/runtime/metrics.rs
@@ -98,6 +98,16 @@ pub(crate) static STATE_SYNC_OBTAIN_PART_DELAY: LazyLock<HistogramVec> = LazyLoc
     .unwrap()
 });
 
+pub(crate) static STATE_SYNC_VALIDATE_PART_DELAY: LazyLock<HistogramVec> = LazyLock::new(|| {
+    try_create_histogram_vec(
+        "near_state_sync_validate_part_delay_sec",
+        "Latency of validating a state part",
+        &["shard_id", "result"],
+        Some(exponential_buckets(0.001, 2.0, 20).unwrap()),
+    )
+    .unwrap()
+});
+
 pub(crate) static STATE_SYNC_APPLY_PART_DELAY: LazyLock<HistogramVec> = LazyLock::new(|| {
     try_create_histogram_vec(
         "near_state_sync_apply_part_delay_sec",

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -741,11 +741,17 @@ fn test_state_sync() {
     root_node_wrong.data = std::sync::Arc::new([123]);
     assert!(!new_env.runtime.validate_state_root_node(&root_node_wrong, &env.state_roots[0]));
     assert!(!new_env.runtime.validate_state_part(
+        ShardId::new(0),
         &Trie::EMPTY_ROOT,
         PartId::new(0, 1),
         &state_part
     ));
-    new_env.runtime.validate_state_part(&env.state_roots[0], PartId::new(0, 1), &state_part);
+    new_env.runtime.validate_state_part(
+        ShardId::new(0),
+        &env.state_roots[0],
+        PartId::new(0, 1),
+        &state_part,
+    );
     let epoch_id = &new_env.head.epoch_id;
     new_env
         .runtime

--- a/chain/chain/src/state_sync/adapter.rs
+++ b/chain/chain/src/state_sync/adapter.rs
@@ -529,7 +529,7 @@ impl ChainStateSyncAdapter {
         let shard_state_header = self.get_state_header(shard_id, sync_hash)?;
         let chunk = shard_state_header.take_chunk();
         let state_root = *chunk.take_header().take_inner().prev_state_root();
-        if !self.runtime_adapter.validate_state_part(&state_root, part_id, data) {
+        if !self.runtime_adapter.validate_state_part(shard_id, &state_root, part_id, data) {
             byzantine_assert!(false);
             return Err(Error::Other(format!(
                 "set_state_part failed: validate_state_part failed. state_root={:?}",

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -484,7 +484,13 @@ pub trait RuntimeAdapter: Send + Sync {
 
     /// Validate state part that expected to be given state root with provided data.
     /// Returns false if the resulting part doesn't match the expected one.
-    fn validate_state_part(&self, state_root: &StateRoot, part_id: PartId, data: &[u8]) -> bool;
+    fn validate_state_part(
+        &self,
+        shard_id: ShardId,
+        state_root: &StateRoot,
+        part_id: PartId,
+        data: &[u8],
+    ) -> bool;
 
     /// Should be executed after accepting all the parts to set up a new state.
     fn apply_state_part(

--- a/chain/client/src/sync/state/downloader.rs
+++ b/chain/client/src/sync/state/downloader.rs
@@ -187,6 +187,7 @@ impl StateSyncDownloader {
                     )
                     .await?;
                 if runtime_adapter.validate_state_part(
+                    shard_id,
                     &state_root,
                     PartId { idx: part_id, total: num_state_parts },
                     &part,

--- a/tools/state-viewer/src/state_parts.rs
+++ b/tools/state-viewer/src/state_parts.rs
@@ -413,6 +413,7 @@ async fn load_state_parts(
             }
             LoadAction::Validate => {
                 assert!(chain.runtime_adapter.validate_state_part(
+                    shard_id,
                     &state_root,
                     PartId::new(part_id, num_parts),
                     &part


### PR DESCRIPTION
Addresses a gap in our metrics. We measure time to generate parts, time to transfer them, and time to apply them. This validation step is separate from the full application process and also takes a non-trivial amount of time.

I deployed it to testnet and observed that received parts typically take .5-1s to validate.