### PR TITLE
refactor: modify state only in case of a success

### DIFF
--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -140,6 +140,10 @@ pub fn get_signer_and_access_key(
     Ok((signer, access_key))
 }
 
+/// Verify nonce, balance and access key for the transaction given the account state.
+///
+/// This will only modify the `signer` and `access_key` with the new state if the function returns
+/// `Ok`.
 pub fn verify_and_charge_tx_ephemeral(
     config: &RuntimeConfig,
     signer: &mut Account,
@@ -156,11 +160,8 @@ pub fn verify_and_charge_tx_ephemeral(
     let signer_id = validated_tx.signer_id();
     let tx = validated_tx.to_tx();
     if tx.nonce() <= access_key.nonce {
-        return Err(InvalidTxError::InvalidNonce {
-            tx_nonce: tx.nonce(),
-            ak_nonce: access_key.nonce,
-        }
-        .into());
+        let err = InvalidTxError::InvalidNonce { tx_nonce: tx.nonce(), ak_nonce: access_key.nonce };
+        return Err(err.into());
     }
     if let Some(height) = block_height {
         let upper_bound =
@@ -169,24 +170,16 @@ pub fn verify_and_charge_tx_ephemeral(
             return Err(InvalidTxError::NonceTooLarge { tx_nonce: tx.nonce(), upper_bound }.into());
         }
     }
-    access_key.nonce = tx.nonce();
 
-    match signer.amount().checked_sub(total_cost) {
-        Some(new_amount) => signer.set_amount(new_amount),
-        None => {
-            return Err(InvalidTxError::NotEnoughBalance {
-                signer_id: signer_id.clone(),
-                balance: signer.amount(),
-                cost: total_cost,
-            }
-            .into());
-        }
-    }
+    let balance = signer.amount();
+    let Some(new_amount) = balance.checked_sub(total_cost) else {
+        let signer_id = signer_id.clone();
+        let err = InvalidTxError::NotEnoughBalance { signer_id, balance, cost: total_cost };
+        return Err(err.into());
+    };
 
-    if let AccessKeyPermission::FunctionCall(ref mut function_call_permission) =
-        access_key.permission
-    {
-        if let Some(ref mut allowance) = function_call_permission.allowance {
+    if let AccessKeyPermission::FunctionCall(ref mut perms) = access_key.permission {
+        if let Some(ref mut allowance) = perms.allowance {
             *allowance = allowance.checked_sub(total_cost).ok_or_else(|| {
                 InvalidTxError::InvalidAccessKeyError(InvalidAccessKeyError::NotEnoughAllowance {
                     account_id: signer_id.clone(),
@@ -201,11 +194,8 @@ pub fn verify_and_charge_tx_ephemeral(
     match check_storage_stake(&signer, config) {
         Ok(()) => {}
         Err(StorageStakingError::LackBalanceForStorageStaking(amount)) => {
-            return Err(InvalidTxError::LackBalanceForState {
-                signer_id: signer_id.clone(),
-                amount,
-            }
-            .into());
+            let err = InvalidTxError::LackBalanceForState { signer_id: signer_id.clone(), amount };
+            return Err(err.into());
         }
         Err(StorageStakingError::StorageError(err)) => {
             return Err(StorageError::StorageInconsistentState(err).into());
@@ -214,26 +204,22 @@ pub fn verify_and_charge_tx_ephemeral(
 
     if let AccessKeyPermission::FunctionCall(ref function_call_permission) = access_key.permission {
         if tx.actions().len() != 1 {
-            return Err(InvalidTxError::InvalidAccessKeyError(
-                InvalidAccessKeyError::RequiresFullAccess,
-            )
-            .into());
+            let err = InvalidAccessKeyError::RequiresFullAccess;
+            return Err(InvalidTxError::InvalidAccessKeyError(err).into());
         }
         if let Some(Action::FunctionCall(function_call)) = tx.actions().get(0) {
             if function_call.deposit > 0 {
-                return Err(InvalidTxError::InvalidAccessKeyError(
-                    InvalidAccessKeyError::DepositWithFunctionCall,
-                )
-                .into());
+                let err = InvalidAccessKeyError::DepositWithFunctionCall;
+                return Err(InvalidTxError::InvalidAccessKeyError(err).into());
             }
-            if tx.receiver_id() != &function_call_permission.receiver_id {
-                return Err(InvalidTxError::InvalidAccessKeyError(
-                    InvalidAccessKeyError::ReceiverMismatch {
-                        tx_receiver: tx.receiver_id().clone(),
-                        ak_receiver: function_call_permission.receiver_id.clone(),
-                    },
-                )
-                .into());
+            let tx_receiver = tx.receiver_id();
+            let ak_receiver = &function_call_permission.receiver_id;
+            if tx_receiver != ak_receiver {
+                let err = InvalidAccessKeyError::ReceiverMismatch {
+                    tx_receiver: tx_receiver.clone(),
+                    ak_receiver: ak_receiver.clone(),
+                };
+                return Err(InvalidTxError::InvalidAccessKeyError(err).into());
             }
             if !function_call_permission.method_names.is_empty()
                 && function_call_permission
@@ -241,21 +227,19 @@ pub fn verify_and_charge_tx_ephemeral(
                     .iter()
                     .all(|method_name| &function_call.method_name != method_name)
             {
-                return Err(InvalidTxError::InvalidAccessKeyError(
-                    InvalidAccessKeyError::MethodNameMismatch {
-                        method_name: function_call.method_name.clone(),
-                    },
-                )
-                .into());
+                let err = InvalidAccessKeyError::MethodNameMismatch {
+                    method_name: function_call.method_name.clone(),
+                };
+                return Err(InvalidTxError::InvalidAccessKeyError(err).into());
             }
         } else {
-            return Err(InvalidTxError::InvalidAccessKeyError(
-                InvalidAccessKeyError::RequiresFullAccess,
-            )
-            .into());
+            let err = InvalidAccessKeyError::RequiresFullAccess;
+            return Err(InvalidTxError::InvalidAccessKeyError(err).into());
         }
     };
 
+    access_key.nonce = tx.nonce();
+    signer.set_amount(new_amount);
     Ok(VerificationResult { gas_burnt, gas_remaining, receipt_gas_price, burnt_amount })
 }
 


### PR DESCRIPTION
It seems pretty weird that callers are responsible for rolling back the state changes made by this function when we can avoid making those changes in the first place. If nothing else it makes reasoning about the code simpler.

(also accompanied by some style changes that I made while trying to grok this function better.)