### PR TITLE
feat: add adversarial feature to skip chunk production window

### DIFF
--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -42,6 +42,24 @@ pub enum AdvProduceChunksMode {
     ProduceWithoutTx,
     // Produce chunks but do not bother checking if included transactions pass validity check.
     ProduceWithoutTxValidityCheck,
+    // Randomly skip multiple chunks in a row.
+    SkipWindow {
+        // Size of the window in which to randomly pick a skip start.
+        window_size: u64,
+        // Number of consecutive chunks to skip when skipping is triggered.
+        skip_length: u64,
+    },
+}
+
+#[cfg(feature = "test_features")]
+/// State tracking for chunk skipping feature.
+pub struct ChunkSkippingState {
+    /// Start of the current window.
+    pub window_start: BlockHeight,
+    /// Height at which to start skipping.
+    pub skip_start: BlockHeight,
+    /// Height at which to stop skipping (exclusive).
+    pub skip_end: BlockHeight,
 }
 
 pub struct ProduceChunkResult {
@@ -60,6 +78,8 @@ pub struct ChunkProducer {
     pub produce_invalid_chunks: bool,
     #[cfg(feature = "test_features")]
     pub produce_invalid_tx_in_chunks: bool,
+    #[cfg(feature = "test_features")]
+    chunk_skipping_state: Option<ChunkSkippingState>,
 
     clock: Clock,
     /// If present, limits adding transactions from the transaction
@@ -96,6 +116,8 @@ impl ChunkProducer {
             produce_invalid_chunks: false,
             #[cfg(feature = "test_features")]
             produce_invalid_tx_in_chunks: false,
+            #[cfg(feature = "test_features")]
+            chunk_skipping_state: None,
             clock,
             chunk_transactions_time_limit,
             chain: chain_store.clone(),
@@ -404,9 +426,11 @@ impl ChunkProducer {
     }
 
     pub fn should_skip_chunk_production(
-        &self,
+        &mut self,
+        #[allow(unused)]
         next_block_height: BlockHeight,
-        _shard_id: ShardId,
+        #[allow(unused)]
+        shard_id: ShardId,
     ) -> bool {
         #[cfg(feature = "test_features")]
         if let Some(adv_produce_chunks) = &self.adv_produce_chunks {
@@ -415,14 +439,72 @@ impl ChunkProducer {
                     tracing::info!(
                         target: "adversary",
                         next_block_height,
-                        "skipping chunk production due to adversary configuration"
+                        "Skipping chunk production due to adversary configuration"
                     );
                     true
                 }
+                AdvProduceChunksMode::SkipWindow { window_size, skip_length } => self
+                    .should_skip_chunk_production_window(
+                        next_block_height,
+                        shard_id,
+                        *window_size,
+                        *skip_length,
+                    ),
                 AdvProduceChunksMode::Valid
                 | AdvProduceChunksMode::ProduceWithoutTx
                 | AdvProduceChunksMode::ProduceWithoutTxValidityCheck => false,
             };
+        }
+        false
+    }
+
+    #[cfg(feature = "test_features")]
+    pub fn should_skip_chunk_production_window(
+        &mut self,
+        next_block_height: BlockHeight,
+        shard_id: ShardId,
+        window_size: u64,
+        skip_length: u64,
+    ) -> bool {
+        let window_start = next_block_height / window_size * window_size;
+        // If new window or no state, pick new skip range
+        let need_new = match &self.chunk_skipping_state {
+            Some(state) => state.window_start != window_start,
+            None => true,
+        };
+        if need_new {
+            // Deterministic random: hash the window_start and shard_id to get a seed.
+            // This ensures different chunk producers for the same shard skip the same
+            // range.
+            let mut seed_bytes = vec![];
+            seed_bytes.extend_from_slice(&window_start.to_le_bytes());
+            seed_bytes.extend_from_slice(&shard_id.to_le_bytes());
+            let hash = near_primitives::hash::hash(&seed_bytes);
+            let max_offset = window_size - skip_length;
+            let offset =
+                u64::from_le_bytes(hash.as_ref()[0..8].try_into().unwrap()) % (max_offset + 1);
+            let skip_start = window_start + offset;
+            let skip_end = skip_start + skip_length;
+            self.chunk_skipping_state =
+                Some(ChunkSkippingState { window_start, skip_start, skip_end });
+            tracing::info!(
+                target: "adversary",
+                window_start,
+                skip_start,
+                skip_end,
+                "Scheduled chunk skipping in window"
+            );
+        }
+        let state = self.chunk_skipping_state.as_ref().unwrap();
+        if next_block_height >= state.skip_start && next_block_height < state.skip_end {
+            tracing::info!(
+                target: "adversary",
+                next_block_height,
+                skip_start = state.skip_start,
+                skip_end = state.skip_end,
+                "Skipping chunk production in skip window"
+            );
+            return true;
         }
         false
     }

--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -444,7 +444,7 @@ impl ChunkProducer {
     }
 
     #[cfg(feature = "test_features")]
-    pub fn should_skip_chunk_production_window(
+    fn should_skip_chunk_production_window(
         &self,
         next_block_height: BlockHeight,
         shard_id: ShardId,

--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -402,4 +402,28 @@ impl ChunkProducer {
         }
         Ok(prepared_transactions)
     }
+
+    pub fn should_skip_chunk_production(
+        &self,
+        next_block_height: BlockHeight,
+        _shard_id: ShardId,
+    ) -> bool {
+        #[cfg(feature = "test_features")]
+        if let Some(adv_produce_chunks) = &self.adv_produce_chunks {
+            return match adv_produce_chunks {
+                AdvProduceChunksMode::StopProduce => {
+                    tracing::info!(
+                        target: "adversary",
+                        next_block_height,
+                        "skipping chunk production due to adversary configuration"
+                    );
+                    true
+                }
+                AdvProduceChunksMode::Valid
+                | AdvProduceChunksMode::ProduceWithoutTx
+                | AdvProduceChunksMode::ProduceWithoutTxValidityCheck => false,
+            };
+        }
+        false
+    }
 }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1338,6 +1338,15 @@ impl JsonRpcHandler {
 
     fn adv_produce_chunks(&self, params: Value) -> Result<Value, RpcError> {
         let mode = crate::api::Params::parse(params)?;
+        if let near_client::client_actor::AdvProduceChunksMode::SkipWindow {
+            window_size,
+            skip_length,
+        } = &mode
+        {
+            if skip_length >= window_size {
+                return Err(RpcError::invalid_params("Expected skip_length < window_size"));
+            }
+        }
         self.client_sender.send(near_client::NetworkAdversarialMessage::AdvProduceChunks(mode));
         Ok(Value::String(String::new()))
     }

--- a/test-loop-tests/src/examples/missing_chunk.rs
+++ b/test-loop-tests/src/examples/missing_chunk.rs
@@ -4,7 +4,7 @@ use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_client::NetworkAdversarialMessage;
 use near_client::client_actor::AdvProduceChunksMode;
 use near_primitives::shard_layout::ShardLayout;
-use near_primitives::types::{AccountId, BlockHeight};
+use near_primitives::types::{AccountId, BlockHeight, NumShards};
 
 use crate::setup::builder::TestLoopBuilder;
 use crate::setup::env::TestLoopEnv;
@@ -62,6 +62,98 @@ fn missing_chunk_example_test() {
     assert_eq!(get_chunk_mask(&env, target_client, missing_chunk_heigh - 1), vec![true, true]);
     assert_eq!(get_chunk_mask(&env, target_client, missing_chunk_heigh), vec![false, true]);
     assert_eq!(get_chunk_mask(&env, target_client, missing_chunk_heigh + 1), vec![true, true]);
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(10));
+}
+
+#[test]
+fn missing_chunk_window_example_test() {
+    let validators = ["validator0", "validator1"];
+    let num_shards: NumShards = 2;
+    let shard_layout = ShardLayout::multi_shard(num_shards, 1);
+    let clients = validators.map(|acc| acc.parse::<AccountId>().unwrap()).to_vec();
+    let target_client = &clients[0];
+    let validators_spec = ValidatorsSpec::desired_roles(&validators, &[]);
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .shard_layout(shard_layout)
+        .validators_spec(validators_spec)
+        .build();
+    let epoch_config_store = TestEpochConfigBuilder::build_store_from_genesis(&genesis);
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store(epoch_config_store)
+        .clients(clients.clone())
+        .build()
+        .warmup();
+
+    let window_size = 5;
+    let skip_length = 2;
+    let window_start_height = 2 * window_size;
+    run_until_node_head_height(
+        &mut env,
+        target_client,
+        window_start_height - 2,
+        Duration::seconds(10),
+    );
+
+    for client in &clients {
+        send_adv_produce_chunks(
+            &env,
+            client,
+            AdvProduceChunksMode::SkipWindow { window_size, skip_length },
+        );
+    }
+
+    run_until_node_head_height(
+        &mut env,
+        target_client,
+        window_start_height + window_size - 1,
+        Duration::seconds(10),
+    );
+
+    #[derive(Clone)]
+    struct ShardMissingChunkState {
+        last_missing_height: Option<BlockHeight>,
+        missing_count: usize,
+    }
+    let mut shard_missing_chunk_states =
+        vec![
+            ShardMissingChunkState { last_missing_height: None, missing_count: 0 };
+            num_shards as usize
+        ];
+    for height in window_start_height..window_start_height + window_size {
+        let mask = get_chunk_mask(&env, target_client, height);
+        for (shard_id, has_chunk) in mask.into_iter().enumerate() {
+            if !has_chunk {
+                let shard_state = &mut shard_missing_chunk_states[shard_id];
+                shard_state.missing_count += 1;
+                if let Some(last_height) = shard_state.last_missing_height {
+                    assert_eq!(
+                        height,
+                        last_height + 1,
+                        "expected to have consecutive missing chunks for shard {shard_id}"
+                    )
+                }
+                shard_state.last_missing_height = Some(height);
+            }
+        }
+    }
+
+    for (shard_id, shard_state) in shard_missing_chunk_states.iter().enumerate() {
+        assert_eq!(
+            shard_state.missing_count, skip_length as usize,
+            "expected number of missing chunks to be equal to skip_length for shard {shard_id}"
+        );
+    }
+
+    // Note that this is not strictly true: probabilistically we can have the same
+    // skipped height sequence for both shards, but the probability is pretty low
+    // and we use deterministic rng so this should not cause any flakiness.
+    assert_ne!(
+        shard_missing_chunk_states[0].last_missing_height,
+        shard_missing_chunk_states[1].last_missing_height,
+        "expected to have different heights with missing chunk with high probability"
+    );
 
     env.shutdown_and_drain_remaining_events(Duration::seconds(10));
 }


### PR DESCRIPTION
This PR implements #13912 as part of adversarial behavior so we can have it in master.

New `AdvProduceChunksMode::SkipWindow` is added to allow skipping a sequence of `skip_length` chunks in a row deterministically randomly chosen in a window of size `window_size`. 

This allows us to test that network can recover after a long sequence of missing chunks.


