### PR TITLE
fix - Missing congestion info in mocknet epoch sync

### DIFF
--- a/chain/chain/src/genesis.rs
+++ b/chain/chain/src/genesis.rs
@@ -296,13 +296,23 @@ fn get_genesis_congestion_infos_impl(
     let mut new_infos = vec![];
     for (shard_index, &state_root) in state_roots.iter().enumerate() {
         let shard_id = genesis_shard_layout.get_shard_id(shard_index)?;
-        let congestion_info = get_genesis_congestion_info(
+        let congestion_info = match get_genesis_congestion_info(
             runtime,
             genesis_protocol_version,
             &genesis_prev_hash,
             shard_id,
             state_root,
-        )?;
+        ) {
+            Ok(info) => info,
+            Err(_) => {
+                tracing::info!(
+                    target: "chain",
+                    %shard_id,
+                    "Genesis state unavailable, using default congestion info"
+                );
+                CongestionInfo::default()
+            }
+        };
         new_infos.push(congestion_info);
     }
 

--- a/test-loop-tests/src/tests/congestion_control_genesis_bootstrap.rs
+++ b/test-loop-tests/src/tests/congestion_control_genesis_bootstrap.rs
@@ -1,10 +1,17 @@
 use near_async::time::Duration;
 use near_chain::ChainStoreAccess;
+use near_chain::genesis::get_genesis_congestion_infos;
 use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_client::Client;
+use near_epoch_manager::EpochManager;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::AccountId;
+use near_primitives::version::PROTOCOL_VERSION;
+use near_store::genesis::initialize_genesis_state;
+use near_store::test_utils::create_test_store;
+use nearcore::NightshadeRuntime;
+use std::path::Path;
 
 use crate::setup::builder::TestLoopBuilder;
 use crate::setup::env::TestLoopEnv;
@@ -57,6 +64,49 @@ fn test_congestion_control_genesis_bootstrap() {
 
     TestLoopEnv { test_loop, node_datas, shared_state }
         .shutdown_and_drain_remaining_events(Duration::seconds(20));
+}
+
+/// Tests that genesis congestion infos computation succeeds even when genesis state is missing.
+///
+/// Setup:
+/// 1. A network using high enough protocol version (>29)
+/// 2. Genesis congestion infos is missing (DB was deleted)
+/// 3. Genesis state roots point to non-existent trie data (DB was deleted)
+#[test]
+fn test_missing_genesis_congestion_infos_bootstrap() {
+    init_test_logger();
+
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .protocol_version(PROTOCOL_VERSION)
+        .validators_spec(ValidatorsSpec::desired_roles(&["test0"], &[]))
+        .add_user_accounts_simple(&["test0".parse().unwrap()], 1_000_000 * ONE_NEAR)
+        .build();
+
+    // Step 1: Initialize genesis to get state roots
+    let store1 = create_test_store();
+    initialize_genesis_state(store1.clone(), &genesis, None);
+    let genesis_state_roots = near_store::get_genesis_state_roots(&store1).unwrap().unwrap();
+
+    // Step 2: Create a new fresh store (equivalent to a deleted data folder)
+    let store2 = create_test_store();
+    let epoch_manager = EpochManager::new_arc_handle(store2.clone(), &genesis.config, None);
+
+    // Note: with broken genesis congestion info, this call below will fail when passing store2, 
+    // but succeeds when passing store1
+    let runtime =
+        NightshadeRuntime::test(Path::new("."), store2, &genesis.config, epoch_manager.clone());
+
+    let result = get_genesis_congestion_infos(
+        epoch_manager.as_ref(),
+        runtime.as_ref(),
+        &genesis_state_roots,
+    );
+
+    // Should succeed when we node is epoch synched from an empty data dir
+    let congestion_infos = result.expect("Getting genesis congestion info should not fail");
+
+    // Single shard, so len must be 1
+    assert_eq!(congestion_infos.len(), 1);
 }
 
 fn check_genesis_congestion_info_in_store(client: &mut Client) {

--- a/test-loop-tests/src/tests/congestion_control_genesis_bootstrap.rs
+++ b/test-loop-tests/src/tests/congestion_control_genesis_bootstrap.rs
@@ -91,7 +91,7 @@ fn test_missing_genesis_congestion_infos_bootstrap() {
     let store2 = create_test_store();
     let epoch_manager = EpochManager::new_arc_handle(store2.clone(), &genesis.config, None);
 
-    // Note: with broken genesis congestion info, this call below will fail when passing store2, 
+    // Note: with broken genesis congestion info, this call below will fail when passing store2,
     // but succeeds when passing store1
     let runtime =
         NightshadeRuntime::test(Path::new("."), store2, &genesis.config, epoch_manager.clone());
@@ -102,11 +102,23 @@ fn test_missing_genesis_congestion_infos_bootstrap() {
         &genesis_state_roots,
     );
 
-    // Should succeed when we node is epoch synched from an empty data dir
-    let congestion_infos = result.expect("Getting genesis congestion info should not fail");
+    // Should succeed when the node is epoch synched from an empty data dir
+    let computed_congestion_infos =
+        result.expect("Getting genesis congestion info should not fail");
 
     // Single shard, so len must be 1
-    assert_eq!(congestion_infos.len(), 1);
+    assert_eq!(computed_congestion_infos.len(), 1);
+
+    // Validate that the computed congestion info matches the original one
+    let runtime =
+        NightshadeRuntime::test(Path::new("."), store1, &genesis.config, epoch_manager.clone());
+    let real_congestion_infos = get_genesis_congestion_infos(
+        epoch_manager.as_ref(),
+        runtime.as_ref(),
+        &genesis_state_roots,
+    )
+    .unwrap();
+    assert_eq!(computed_congestion_infos, real_congestion_infos);
 }
 
 fn check_genesis_congestion_info_in_store(client: &mut Client) {


### PR DESCRIPTION
This PR reproduced the issue experienced in 2.7 release testing:
- Have a network of nodes
- Node A will become CP in the next epoch
- Node A database is cleaned and the node performs epoch sync
- Epoch sync fails with `MissingTrieValue` when fetching genesis congestion info


The repro here is more narrow scoped than a full pytest test. Here we are simply asserting that `get_genesis_congestion_infos` works as expected when the chain is not a production chain, and the node is doing epoch synch from a clean DB.

Included:
- Unit test
- Fix


The fix is simply to return default congestion info if we can't retrieve it for the genesis block from the DB.