### PR TITLE
wip: reprocessing blocks, optionally recommitting columns selectively

### DIFF
--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -75,6 +75,8 @@ pub enum Provenance {
     SYNC,
     /// Block we produced ourselves.
     PRODUCED,
+    /// Reprocessing a block that was already processed.
+    REPROCESS,
 }
 
 /// Information about processed block.

--- a/core/store/src/store.rs
+++ b/core/store/src/store.rs
@@ -471,6 +471,19 @@ impl StoreUpdate {
         self.transaction.merge(other.transaction)
     }
 
+    pub fn retain_columns<F>(&mut self, filter: F)
+    where
+        F: Fn(&DBCol) -> bool,
+    {
+        self.transaction.ops.retain(|op| match op {
+            DBOp::Set { col, .. }
+            | DBOp::Insert { col, .. }
+            | DBOp::UpdateRefcount { col, .. }
+            | DBOp::Delete { col, .. } => filter(col),
+            DBOp::DeleteAll { col } | DBOp::DeleteRange { col, .. } => filter(col),
+        });
+    }
+
     #[tracing::instrument(
         level = "trace",
         target = "store::update",


### PR DESCRIPTION
for feedback on the general approach

This PR introduces prerequisites for reprocessing blocks. The changes add a new `Provenance::REPROCESS` variant, implement reprocessing logic, and enable selective column filtering during store updates.