### PR TITLE
refactor: various improvements around chunk production code

### DIFF
--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -154,7 +154,6 @@ impl ChunkProducer {
         if signer.validator_id() != &chunk_proposer {
             debug!(
                 target: "client",
-                me = ?signer.as_ref().validator_id(),
                 ?chunk_proposer,
                 "not a chunk producer for this height"
             );
@@ -254,7 +253,7 @@ impl ChunkProducer {
             }
         }
 
-        debug!(target: "client", me = ?validator_signer.validator_id(), "start producing the chunk");
+        debug!(target: "client", "start producing the chunk");
 
         let shard_uid = shard_id_to_uid(self.epoch_manager.as_ref(), shard_id, epoch_id)?;
         let chunk_extra = if cfg!(feature = "protocol_feature_spice") {
@@ -337,7 +336,6 @@ impl ChunkProducer {
         span.record("chunk_hash", tracing::field::debug(encoded_chunk.chunk_hash()));
         debug!(
             target: "client",
-            me = %validator_signer.validator_id(),
             num_filtered_transactions,
             num_outgoing_receipts = outgoing_receipts.len(),
             "finished producing the chunk"

--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -125,7 +125,7 @@ impl ChunkProducer {
     }
 
     #[instrument(target = "client", level = "debug", "produce_chunk", skip_all, fields(
-        height = next_height,
+        %next_height,
         %shard_id,
         ?epoch_id,
         prev_block_hash = ?prev_block.header().hash(),

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1695,28 +1695,6 @@ impl Client {
         for shard_id in self.epoch_manager.shard_ids(&epoch_id).unwrap() {
             let next_height = block.header().height() + 1;
             let epoch_manager = self.epoch_manager.as_ref();
-            let chunk_proposer = epoch_manager
-                .get_chunk_producer_info(&ChunkProductionKey {
-                    epoch_id,
-                    height_created: next_height,
-                    shard_id,
-                })
-                .unwrap()
-                .take_account_id();
-            if &chunk_proposer != &validator_id {
-                continue;
-            }
-
-            if self.chunk_producer.should_skip_chunk_production(next_height, shard_id) {
-                continue;
-            }
-
-            let _span = debug_span!(
-                target: "client",
-                "on_block_accepted",
-                prev_block_hash = ?*block.hash(),
-                %shard_id)
-            .entered();
             let _timer = metrics::PRODUCE_AND_DISTRIBUTE_CHUNK_TIME
                 .with_label_values(&[&shard_id.to_string()])
                 .start_timer();
@@ -1750,10 +1728,10 @@ impl Client {
 
             let ProduceChunkResult { chunk, encoded_chunk_parts_paths, receipts } = match result {
                 Ok(Some(res)) => res,
-                Ok(None) => return,
+                Ok(None) => continue,
                 Err(err) => {
-                    error!(target: "client", ?err, "Error producing chunk");
-                    return;
+                    error!(target: "client", ?shard_id, ?err, "error producing chunk");
+                    continue;
                 }
             };
             if !cfg!(feature = "protocol_feature_spice") {

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1709,7 +1709,7 @@ impl Client {
 
                 #[cfg(feature = "test_features")]
                 let chain_validate: &dyn Fn(&SignedTransaction) -> bool = {
-                    match self.chunk_producer.adv_produce_chunks {
+                    match self.chunk_producer.adversarial.produce_mode {
                         Some(AdvProduceChunksMode::ProduceWithoutTxValidityCheck) => &|_| true,
                         _ => &transaction_validity_check,
                     }

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -516,12 +516,12 @@ impl Handler<NetworkAdversarialMessage> for ClientActorInner {
             }
             NetworkAdversarialMessage::AdvProduceChunks(adv_produce_chunks) => {
                 info!(target: "adversary", mode=?adv_produce_chunks, "setting adversary produce chunks");
-                self.client.chunk_producer.adv_produce_chunks = Some(adv_produce_chunks);
+                self.client.chunk_producer.adversarial.produce_mode = Some(adv_produce_chunks);
                 None
             }
             NetworkAdversarialMessage::AdvInsertInvalidTransactions(on) => {
                 info!(target: "adversary", on, "invalid transactions");
-                self.client.chunk_producer.produce_invalid_tx_in_chunks = on;
+                self.client.chunk_producer.adversarial.produce_invalid_tx_in_chunks = on;
                 None
             }
         }

--- a/integration-tests/src/tests/features/adversarial_behaviors.rs
+++ b/integration-tests/src/tests/features/adversarial_behaviors.rs
@@ -343,6 +343,6 @@ fn test_banning_chunk_producer_when_seeing_invalid_chunk_base(
 fn slow_test_banning_chunk_producer_when_seeing_invalid_chunk() {
     init_test_logger();
     let mut test = AdversarialBehaviorTestData::new();
-    test.env.clients[7].chunk_producer.produce_invalid_chunks = true;
+    test.env.clients[7].chunk_producer.adversarial.produce_invalid_chunks = true;
     test_banning_chunk_producer_when_seeing_invalid_chunk_base(test);
 }

--- a/test-loop-tests/src/examples/missing_chunk.rs
+++ b/test-loop-tests/src/examples/missing_chunk.rs
@@ -3,6 +3,7 @@ use near_async::time::Duration;
 use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_client::NetworkAdversarialMessage;
 use near_client::client_actor::AdvProduceChunksMode;
+use near_o11y::testonly::init_test_logger;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::{AccountId, BlockHeight, NumShards};
 
@@ -14,6 +15,7 @@ use crate::utils::{get_node_client, get_node_data, run_until_node_head_height};
 /// Requires "test_features" feature to be enabled.
 #[test]
 fn missing_chunk_example_test() {
+    init_test_logger();
     let validators = ["validator0", "validator1"];
     let missing_chunk_heigh = 8;
     let shard_layout = ShardLayout::multi_shard(2, 1);
@@ -68,6 +70,7 @@ fn missing_chunk_example_test() {
 
 #[test]
 fn missing_chunk_window_example_test() {
+    init_test_logger();
     let validators = ["validator0", "validator1"];
     let num_shards: NumShards = 2;
     let shard_layout = ShardLayout::multi_shard(num_shards, 1);


### PR DESCRIPTION
- remove log fields that are already added by spans
- shorter log messages
- remove check if current validator is a chunk producer from client since we already check in chunk producer
- move `should_skip_chunk_production` check to `produce_chunk`
- remove `on_block_accepted` span, it looks like some kind of copy&paste fail, it doesn't belong there
- change `produce_chunk` handling in client to use `continue` instead of `return` since validator can be chunk producer for multiple shards
- group adversarial controls together into struct

example log:
`0.058s DEBUG check_triggers:try_process_unfinished_blocks:postprocess_ready_blocks{should_produce_chunk=true}:on_block_accepted_with_optional_chunk_produce{block_hash=EJRT7j3BjMgtBNqsd3QzAaLEKjapcSa6mNsTymLRwBDb status=Next provenance=PRODUCED skip_produce_chunk=false is_syncing=false sync_status=NoSync}:produce_chunks{validator_id=AccountId("validator1") block_height=2}:produce_chunk{next_height=3 shard_id=0 epoch_id=EpochId(11111111111111111111111111111111) prev_block_hash=EJRT7j3BjMgtBNqsd3QzAaLEKjapcSa6mNsTymLRwBDb tag_block_production=true chunk_hash=ChunkHash(DfVnvFGstUuNvGkAh8R3n4URaywofwXWAHsGZJfVXjWm)}: client: finished producing the chunk num_filtered_transactions=0 num_outgoing_receipts=0`