### PR TITLE
apply-range: automatically process all shards in parallel

### DIFF
--- a/benchmarks/transactions-generator/src/account.rs
+++ b/benchmarks/transactions-generator/src/account.rs
@@ -58,7 +58,7 @@ pub fn accounts_from_path(path: &Path) -> anyhow::Result<Vec<Account>> {
 
     // Otherwise, proceed with the original directory reading logic
     let mut accounts = vec![];
-    for entry in fs::read_dir(path)? {
+    for entry in fs::read_dir(path).context(format!("read {path:?} dir"))? {
         let entry = entry?;
         let file_type = entry.file_type()?;
         if !file_type.is_file() {

--- a/benchmarks/transactions-generator/src/actix_actor.rs
+++ b/benchmarks/transactions-generator/src/actix_actor.rs
@@ -20,7 +20,7 @@ impl GeneratorActorImpl {
     pub fn start(&mut self, _ctx: &mut dyn DelayedActionRunner<Self>) {
         match self.tx_generator.start() {
             Err(err) => {
-                tracing::error!(target: "transaction-generator", "Error: {err}");
+                tracing::error!(target: "transaction-generator", "Error: {err:?}");
             }
             Ok(_) => {
                 tracing::info!(target: "transaction-generator",

--- a/docs/practices/workflows/benchmarking_chunk_application_on_native_transfers.md
+++ b/docs/practices/workflows/benchmarking_chunk_application_on_native_transfers.md
@@ -73,12 +73,12 @@ To change TPS edit the `tx-generator-settings.json` file (without `.in` !) and r
 First, make sure all deltas in flat storage are applied and written:
 
 ```shell
-./neard --home .near view-state --read-write apply-range --shard-id 0 --storage flat sequential
+./neard --home .near view-state --read-write apply-range --storage flat sequential
 ```
 
 Then move flat head back 32 blocks to a height that had chunks with high load
 ```shell
-./neard --home .near flat-storage move-flat-head --shard-id 0 --version 0 back --blocks 32
+./neard --home .near flat-storage move-flat-head back --blocks 32
 ```
 
 ### Benchmarking chunk application
@@ -86,17 +86,17 @@ Then move flat head back 32 blocks to a height that had chunks with high load
 Run these commands to benchmark chunk application at the height to which the flat head was moved.
 
 ```shell
-./neard --home .near view-state apply-range --shard-id 0 --storage flat benchmark
+./neard --home .near view-state apply-range --storage flat benchmark
 ```
 
 or
 
 ```shell
-./neard --home .near view-state apply-range --shard-id 0 --storage memtrie benchmark
+./neard --home .near view-state apply-range --storage memtrie benchmark
 ```
 
 or
 
 ```shell
-./neard --home .near view-state apply-range --shard-id 0 --storage recorded benchmark
+./neard --home .near view-state apply-range --storage recorded benchmark
 ```

--- a/docs/practices/workflows/profiling.md
+++ b/docs/practices/workflows/profiling.md
@@ -273,14 +273,14 @@ achieve that today.
 First, make sure all deltas in flat storage are applied and written:
 
 ```
-neard view-state --read-write apply-range --shard-id $SHARD_ID --storage flat sequential
+neard view-state --read-write apply-range --storage flat sequential
 ```
 
 You will need to do this for all shards you're interested in profiling. Then pick a block or a
 range of blocks you want to re-apply and set the flat head to the specified height:
 
 ```
-neard flat-storage move-flat-head --shard-id 0 --version 0 back --blocks 17
+neard flat-storage move-flat-head back --blocks 17
 ```
 
 Finally the following commands will apply the block or blocks from the height in various different
@@ -290,15 +290,18 @@ forget to run these commands under the profiler :)
 ```
 # Apply blocks from current flat head to the highest known block height in sequence
 # using the memtrie storage (note that after this you will need to move the flat head again)
-neard view-state --read-write apply-range --shard-id 0 --storage memtrie sequential
+neard view-state --read-write apply-range --storage memtrie sequential
 # Same but with flat storage
-neard view-state --read-write apply-range --shard-id 0 --storage flat sequential
+neard view-state --read-write apply-range --storage flat sequential
 
 # Repeatedly apply a single block at the flat head using the memtrie storage.
 # Will not modify the storage on the disk.
-neard view-state apply-range --shard-id 0 --storage memtrie benchmark
+neard view-state apply-range --storage memtrie benchmark
 # Same but with flat storage
-neard view-state apply-range --shard-id 0 --storage flat benchmark
+neard view-state apply-range --storage flat benchmark
 # Same but with recorded storage
-neard view-state apply-range --shard-id 0 --storage recorded benchmark
+neard view-state apply-range --storage recorded benchmark
 ```
+
+Note that all of these commands operate on all shards at the same time. You can specify
+`--shard-id` argument to pick just one shard to operate with.

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -7,11 +7,13 @@ use near_chain::{ChainStore, ChainStoreAccess};
 use near_chain_configs::GenesisValidationMode;
 use near_epoch_manager::shard_assignment::shard_id_to_uid;
 use near_epoch_manager::{EpochManager, EpochManagerAdapter, EpochManagerHandle};
+use near_primitives::epoch_manager;
 use near_primitives::errors::EpochError;
 use near_primitives::shard_layout::ShardVersion;
 use near_primitives::state::FlatStateValue;
 use near_primitives::types::{BlockHeight, ShardId};
 use near_store::adapter::StoreAdapter;
+use near_store::adapter::chain_store::ChainStoreAdapter;
 use near_store::adapter::flat_store::FlatStoreAdapter;
 use near_store::flat::{
     FlatStateChanges, FlatStateDelta, FlatStateDeltaMetadata, FlatStorageStatus,
@@ -124,9 +126,7 @@ pub enum MoveFlatHeadMode {
 #[derive(Parser)]
 pub struct MoveFlatHeadCmd {
     #[clap(long)]
-    shard_id: ShardId,
-    #[clap(long)]
-    version: ShardVersion,
+    shard_uid: Vec<ShardUId>,
     #[clap(subcommand)]
     mode: MoveFlatHeadMode,
 }
@@ -381,7 +381,7 @@ impl FlatStorageCommand {
         &self,
         epoch_manager: &dyn EpochManagerAdapter,
         runtime: &dyn RuntimeAdapter,
-        chain_store: ChainStore,
+        chain_store: ChainStoreAdapter,
         mut shard_uid: ShardUId,
         blocks: usize,
     ) -> anyhow::Result<()> {
@@ -495,7 +495,7 @@ impl FlatStorageCommand {
             store_update.commit()?;
 
             height = prev_height;
-            println!("moved to {height}");
+            println!("moved to {height} on {shard_uid}");
         }
         Ok(())
     }
@@ -509,31 +509,56 @@ impl FlatStorageCommand {
     ) -> anyhow::Result<()> {
         let (_, epoch_manager, runtime, chain_store, _) =
             Self::get_db(&opener, home_dir, &near_config, near_store::Mode::ReadWriteExisting);
+        let shard_uids = if cmd.shard_uid.is_empty() {
+            let tip = chain_store.final_head().unwrap();
+            let shard_layout = epoch_manager.get_shard_layout(&tip.epoch_id).unwrap();
+            shard_layout
+                .shard_ids()
+                .map(|sid| {
+                    shard_id_to_uid(epoch_manager.as_ref(), sid, &tip.epoch_id)
+                        .expect("generate shard uid")
+                })
+                .collect::<Vec<_>>()
+        } else {
+            cmd.shard_uid.clone()
+        };
 
-        let shard_uid = ShardUId::new(cmd.version, cmd.shard_id);
-        let flat_storage_manager = runtime.get_flat_storage_manager();
-        flat_storage_manager.create_flat_storage_for_shard(shard_uid)?;
-        let flat_storage = flat_storage_manager.get_flat_storage_for_shard(shard_uid).unwrap();
-
-        match cmd.mode {
-            MoveFlatHeadMode::Forward { new_flat_head_height } => {
-                let header = chain_store.get_block_header_by_height(new_flat_head_height)?;
-                println!("Moving flat head for shard {shard_uid} forward to header: {header:?}");
-                flat_storage.update_flat_head(header.hash())?;
+        std::thread::scope(move |s| {
+            for shard_uid in shard_uids {
+                let runtime = runtime.clone();
+                let flat_storage_manager = runtime.get_flat_storage_manager();
+                flat_storage_manager.create_flat_storage_for_shard(shard_uid)?;
+                let flat_storage =
+                    flat_storage_manager.get_flat_storage_for_shard(shard_uid).unwrap();
+                let chain_store = chain_store.clone();
+                let epoch_manager = epoch_manager.clone();
+                s.spawn(move || match cmd.mode {
+                    MoveFlatHeadMode::Forward { new_flat_head_height } => {
+                        let header = chain_store
+                            .get_block_header_by_height(new_flat_head_height)
+                            .expect("get block header by height");
+                        println!(
+                            "Moving flat head for shard {shard_uid} forward to header: {header:?}"
+                        );
+                        flat_storage
+                            .update_flat_head(header.hash())
+                            .expect("move flat head forward");
+                    }
+                    MoveFlatHeadMode::Back { blocks } => {
+                        println!("Moving flat head for shard {shard_uid} back by {blocks} blocks");
+                        self.move_flat_head_back(
+                            epoch_manager.as_ref(),
+                            runtime.as_ref(),
+                            chain_store,
+                            shard_uid,
+                            blocks,
+                        )
+                        .expect("move flat head back");
+                    }
+                });
             }
-            MoveFlatHeadMode::Back { blocks } => {
-                println!("Moving flat head for shard {shard_uid} back by {blocks} blocks");
-                self.move_flat_head_back(
-                    epoch_manager.as_ref(),
-                    runtime.as_ref(),
-                    chain_store,
-                    shard_uid,
-                    blocks,
-                )?;
-            }
-        }
-
-        Ok(())
+            Ok(())
+        })
     }
 
     pub fn run(

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -301,8 +301,6 @@ impl ApplyChunkCmd {
 #[derive(clap::Parser, Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ApplyRangeMode {
     /// Applies chunks one after another in order of increasing heights.
-    ///
-    /// Great for profiling.
     Sequential {
         /// If true, saves state transitions for state witness generation.
         #[clap(long)]
@@ -323,8 +321,9 @@ pub struct ApplyRangeCmd {
     start_index: Option<BlockHeight>,
     #[clap(long)]
     end_index: Option<BlockHeight>,
-    #[clap(long, default_value = "0")]
-    shard_id: ShardId,
+    /// All shards by default (if not specified.) Can be provided multiple times.
+    #[clap(long)]
+    shard_id: Vec<ShardId>,
     #[clap(long)]
     verbose_output: bool,
     #[clap(long, value_parser)]

--- a/tools/state-viewer/src/commands.rs
+++ b/tools/state-viewer/src/commands.rs
@@ -34,7 +34,7 @@ use near_primitives::apply::ApplyChunkReason;
 use near_primitives::block::Block;
 use near_primitives::chains::MAINNET;
 use near_primitives::epoch_info::EpochInfo;
-use near_primitives::epoch_manager::EpochConfigStore;
+use near_primitives::epoch_manager::{self, EpochConfigStore};
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::sharding::{ChunkHash, ShardChunk};
@@ -243,7 +243,7 @@ pub(crate) fn apply_range(
     storage: StorageSource,
     start_index: Option<BlockHeight>,
     end_index: Option<BlockHeight>,
-    shard_id: ShardId,
+    shard_id: Vec<ShardId>,
     verbose_output: bool,
     csv_file: Option<PathBuf>,
     home_dir: &Path,
@@ -266,22 +266,47 @@ pub(crate) fn apply_range(
         epoch_manager.clone(),
     )
     .expect("could not create the transaction runtime");
-    apply_chain_range(
-        mode,
-        read_store,
-        write_store.clone(),
-        &near_config.genesis,
-        start_index,
-        end_index,
-        shard_id,
-        epoch_manager.as_ref(),
-        runtime,
-        verbose_output,
-        csv_file.as_mut(),
-        only_contracts,
-        storage,
-    );
-    maybe_print_db_stats(write_store);
+    let shard_ids = if shard_id.is_empty() {
+        let chain_store = ChainStore::new(
+            read_store.clone(),
+            false,
+            near_config.genesis.config.transaction_validity_period,
+        );
+        let final_head = chain_store.final_head().unwrap();
+        let shard_layout = epoch_manager.get_shard_layout(&final_head.epoch_id).unwrap();
+        shard_layout.shard_ids().collect::<Vec<_>>()
+    } else {
+        shard_id
+    };
+
+    let genesis = &near_config.genesis;
+    let write_store_clone = write_store.clone();
+    std::thread::scope(move |s| {
+        for shard_id in shard_ids {
+            let read_store = read_store.clone();
+            let write_store = write_store.clone();
+            let epoch_manager = epoch_manager.clone();
+            let runtime = runtime.clone();
+            s.spawn(move || {
+                apply_chain_range(
+                    mode,
+                    read_store,
+                    write_store,
+                    genesis,
+                    start_index,
+                    end_index,
+                    shard_id,
+                    epoch_manager.as_ref(),
+                    runtime.clone(),
+                    verbose_output,
+                    None, // csv_file.as_mut(),
+                    only_contracts,
+                    storage,
+                )
+            });
+        }
+    });
+    maybe_print_db_stats(write_store_clone);
 }
 
 pub(crate) fn apply_receipt(

--- a/tools/state-viewer/src/latest_witnesses.rs
+++ b/tools/state-viewer/src/latest_witnesses.rs
@@ -137,7 +137,7 @@ impl GenerateWitnessesCmd {
             crate::cli::StorageSource::TrieFree,
             Some(start_height),
             Some(end_height),
-            self.shard_id,
+            vec![self.shard_id],
             false,
             None,
             home_dir,


### PR DESCRIPTION
Not only does this make the "regular" use of apply-range faster, it also works as a more realistic benchmark, since we never really apply chunks in isolation.

The implementation is pretty naive – it just goes as fast as possible for each individual shard. No synchronization or barriers between shards here.

The original behaviour is still available by passing in `--shard-id` if needed.