### PR TITLE
refactor: spice: add DbCol to store all next block hashes.

### DIFF
--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -744,6 +744,9 @@ impl<'a> ChainStoreUpdate<'a> {
         // 3. Delete block_hash-indexed data
         self.gc_col(DBCol::Block, block_hash.as_bytes());
         self.gc_col(DBCol::NextBlockHashes, block_hash.as_bytes());
+        if cfg!(feature = "protocol_feature_spice") {
+            self.gc_col(DBCol::all_next_block_hashes(), block_hash.as_bytes());
+        }
         self.gc_col(DBCol::ChallengedBlocks, block_hash.as_bytes());
         self.gc_col(DBCol::BlocksToCatchup, block_hash.as_bytes());
         let storage_key = KeyForStateChanges::for_block(&block_hash);
@@ -1124,6 +1127,10 @@ impl<'a> ChainStoreUpdate<'a> {
             }
             #[cfg(feature = "protocol_feature_spice")]
             DBCol::ReceiptProofs => {
+                store_update.delete(col, key);
+            }
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::AllNextBlockHashes => {
                 store_update.delete(col, key);
             }
             DBCol::DbVersion

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -1808,6 +1808,17 @@ impl<'a> ChainStoreUpdate<'a> {
                     .block_hash_per_height
                     .insert(block.header().height(), map);
                 store_update.insert_ser(DBCol::Block, block.hash().as_ref(), block)?;
+                if cfg!(feature = "protocol_feature_spice") {
+                    let prev_hash = block.header().prev_hash();
+                    let mut prev_next_hashes =
+                        self.chain_store.get_all_next_block_hashes(prev_hash)?;
+                    prev_next_hashes.push(*block.hash());
+                    store_update.set_ser(
+                        DBCol::all_next_block_hashes(),
+                        prev_hash.as_ref(),
+                        &prev_next_hashes,
+                    )?;
+                }
             }
             // This is a BTreeMap because the update_sync_hashes() calls below must be done in order of height
             let mut headers_by_height: BTreeMap<BlockHeight, Vec<&BlockHeader>> = BTreeMap::new();

--- a/chain/client/src/chunk_executor_actor.rs
+++ b/chain/client/src/chunk_executor_actor.rs
@@ -71,10 +71,6 @@ pub struct ChunkExecutorActor {
     apply_chunks_spawner: Arc<dyn AsyncComputationSpawner>,
     myself_sender: Sender<ExecutorApplyChunksDone>,
 
-    /// Next block hashes keyed by block hash.
-    /// TODO(spice): test that this map is properly maintained or
-    /// replace it with DB
-    pending_next_blocks: HashMap<CryptoHash, HashSet<CryptoHash>>,
     blocks_in_execution: HashSet<CryptoHash>,
 
     // Hash of the genesis block.
@@ -110,7 +106,6 @@ impl ChunkExecutorActor {
             network_adapter,
             apply_chunks_spawner,
             myself_sender,
-            pending_next_blocks: HashMap::new(),
             blocks_in_execution: HashSet::new(),
             genesis_hash,
             validator_signer,
@@ -175,9 +170,9 @@ impl Handler<ProcessedBlock> for ChunkExecutorActor {
         match self.try_apply_chunks(&block_hash) {
             Ok(TryApplyChunksOutcome::Scheduled) => {}
             Ok(TryApplyChunksOutcome::NotReady) => {
-                if let Err(err) = self.add_pending_block(block_hash) {
-                    tracing::error!(target: "chunk_executor", ?err, ?block_hash, "failed to add pending block");
-                }
+                // We will retry applying it by looking at all next blocks after receiving
+                // additonal execution result endorsements or receipts.
+                tracing::debug!(target: "chunk_executor", %block_hash, "not yet ready for processing");
             }
             Ok(TryApplyChunksOutcome::BlockAlreadyAccepted) => {
                 tracing::warn!(
@@ -310,41 +305,21 @@ impl ChunkExecutorActor {
         Ok(TryApplyChunksOutcome::Scheduled)
     }
 
-    fn add_pending_block(&mut self, block_hash: CryptoHash) -> Result<(), Error> {
-        let block = self.chain_store.get_block(&block_hash)?;
-        let prev_block_hash = block.header().prev_hash();
-        self.pending_next_blocks.entry(*prev_block_hash).or_default().insert(block_hash);
-        Ok(())
-    }
-
     fn try_process_next_blocks(&mut self, block_hash: &CryptoHash) -> Result<(), Error> {
-        let Some(next_block_hashes) = self.pending_next_blocks.get(block_hash) else {
+        let next_block_hashes = self.chain_store.get_all_next_block_hashes(block_hash)?;
+        if next_block_hashes.is_empty() {
             // Next block wasn't received yet.
             tracing::debug!(target: "chunk_executor", %block_hash, "no next block hash is available");
             return Ok(());
-        };
-        let mut processed_blocks = HashSet::new();
-        for next_block_hash in next_block_hashes.clone() {
-            match self.try_apply_chunks(&next_block_hash)? {
-                TryApplyChunksOutcome::Scheduled => {
-                    processed_blocks.insert(next_block_hash);
-                }
-                TryApplyChunksOutcome::NotReady => {}
-                TryApplyChunksOutcome::BlockAlreadyAccepted => {
-                    tracing::warn!(
-                        target: "chunk_executor",
-                        ?block_hash,
-                        "not expected already executed block to be in the pending blocks"
-                    );
-                    // Still consider that block as processed to clean the state
-                    processed_blocks.insert(next_block_hash);
-                }
-            }
         }
-        let remaining_blocks = self.pending_next_blocks.get_mut(block_hash).unwrap();
-        remaining_blocks.retain(|hash| !processed_blocks.contains(hash));
-        if remaining_blocks.is_empty() {
-            self.pending_next_blocks.remove(&block_hash);
+        for next_block_hash in next_block_hashes {
+            match self.try_apply_chunks(&next_block_hash)? {
+                TryApplyChunksOutcome::Scheduled => {}
+                TryApplyChunksOutcome::NotReady => {
+                    tracing::debug!(target: "chunk_executor", %next_block_hash, "not yet ready for processing");
+                }
+                TryApplyChunksOutcome::BlockAlreadyAccepted => {}
+            }
         }
         Ok(())
     }

--- a/chain/client/src/spice_chunk_validator_actor.rs
+++ b/chain/client/src/spice_chunk_validator_actor.rs
@@ -1,8 +1,6 @@
 use std::collections::{HashMap, HashSet};
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 
-use lru::LruCache;
 use near_async::futures::{AsyncComputationSpawner, AsyncComputationSpawnerExt as _};
 use near_async::messaging::{Handler, IntoSender as _, Sender};
 use near_async::{MultiSend, MultiSenderFrom};
@@ -50,11 +48,6 @@ pub struct SpiceChunkValidatorActor {
     main_state_transition_result_cache: MainStateTransitionCache,
     validation_spawner: Arc<dyn AsyncComputationSpawner>,
 
-    // TODO(spice): Dedup with ChunkExecutorActor logic by storing next block hashes in db to allow
-    // access from both places.
-    /// Next block hashes keyed by block hash.
-    next_block_hashes: LruCache<CryptoHash, Vec<CryptoHash>>,
-
     rs: Arc<ReedSolomon>,
 }
 
@@ -67,7 +60,6 @@ impl SpiceChunkValidatorActor {
         runtime_adapter: Arc<dyn RuntimeAdapter>,
         epoch_manager: Arc<dyn EpochManagerAdapter>,
         network_adapter: PeerManagerAdapter,
-        next_block_hashes_cache_capacity: NonZeroUsize,
         validator_signer: MutableValidatorSigner,
         core_processor: CoreStatementsProcessor,
         chunk_endorsement_tracker: Arc<ChunkEndorsementTracker>,
@@ -88,7 +80,6 @@ impl SpiceChunkValidatorActor {
             runtime_adapter,
             epoch_manager,
             network_adapter,
-            next_block_hashes: LruCache::new(next_block_hashes_cache_capacity),
             validator_signer,
             core_processor,
             chunk_endorsement_tracker,
@@ -108,9 +99,6 @@ impl Handler<ProcessedBlock> for SpiceChunkValidatorActor {
                 return;
             }
         };
-        let header = block.header();
-        let prev_block_hash = header.prev_hash();
-        self.next_block_hashes.get_or_insert_mut(*prev_block_hash, || Vec::new()).push(block_hash);
 
         if let Some(signer) = self.validator_signer.get() {
             if let Err(err) = self.process_ready_pending_state_witnesses(block, signer) {
@@ -123,14 +111,16 @@ impl Handler<ProcessedBlock> for SpiceChunkValidatorActor {
 impl Handler<ExecutionResultEndorsed> for SpiceChunkValidatorActor {
     fn handle(&mut self, ExecutionResultEndorsed { block_hash }: ExecutionResultEndorsed) {
         if let Some(signer) = self.validator_signer.get() {
-            let next_blocks = self.next_block_hashes.get(&block_hash).cloned();
-            for next_block_hash in next_blocks.into_iter().flatten() {
-                let block = self.chain_store.get_block(&next_block_hash).expect(
+            let next_block_hashes =
+                self.chain_store.get_all_next_block_hashes(&block_hash).unwrap();
+            for next_block_hash in next_block_hashes {
+                let next_block = self.chain_store.get_block(&next_block_hash).expect(
                     "block added to next blocks only after it's processed so it should be in store",
                 );
-                if let Err(err) = self.process_ready_pending_state_witnesses(block, signer.clone())
+                if let Err(err) =
+                    self.process_ready_pending_state_witnesses(next_block, signer.clone())
                 {
-                    tracing::error!(target: "spice_chunk_validator", %block_hash, ?err, "failed to process ready pending state witnesses");
+                    tracing::error!(target: "spice_chunk_validator", %next_block_hash, %block_hash, ?err, "failed to process ready pending state witnesses");
                 }
             }
         }

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -390,6 +390,17 @@ impl ChainStoreAdapter {
             .unwrap_or_default())
     }
 
+    /// Returns a vector of all known processed next block hashes.
+    pub fn get_all_next_block_hashes(
+        &self,
+        block_hash: &CryptoHash,
+    ) -> Result<Vec<CryptoHash>, Error> {
+        Ok(self
+            .store
+            .get_ser(DBCol::all_next_block_hashes(), block_hash.as_ref())?
+            .unwrap_or_default())
+    }
+
     pub fn get_state_header(
         &self,
         shard_id: ShardId,

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -337,6 +337,11 @@ pub enum DBCol {
     /// - *Content type*: `near_primitives::sharding::ReceiptProof`
     #[cfg(feature = "protocol_feature_spice")]
     ReceiptProofs,
+    /// All known processed next block hashes regardless of canonical chain.
+    /// - *Rows*: BlockHash (CryptoHash)
+    /// - *Content type*: next block: Vec<BlockHash (CryptoHash)>
+    #[cfg(feature = "protocol_feature_spice")]
+    AllNextBlockHashes,
 }
 
 /// Defines different logical parts of a db key.
@@ -486,6 +491,8 @@ impl DBCol {
             | DBCol::ChunkApplyStats => true,
             #[cfg(feature = "protocol_feature_spice")]
             | DBCol::ReceiptProofs => true,
+            #[cfg(feature = "protocol_feature_spice")]
+            | DBCol::AllNextBlockHashes => false,
 
             // TODO
             DBCol::ChallengedBlocks => false,
@@ -629,12 +636,21 @@ impl DBCol {
             DBCol::ChunkApplyStats => &[DBKeyType::BlockHash, DBKeyType::ShardId],
             #[cfg(feature = "protocol_feature_spice")]
             DBCol::ReceiptProofs => &[DBKeyType::BlockHash, DBKeyType::ShardId, DBKeyType::ShardId],
+            #[cfg(feature = "protocol_feature_spice")]
+            DBCol::AllNextBlockHashes => &[DBKeyType::BlockHash],
         }
     }
 
     pub fn receipt_proofs() -> DBCol {
         #[cfg(feature = "protocol_feature_spice")]
         return DBCol::ReceiptProofs;
+        #[cfg(not(feature = "protocol_feature_spice"))]
+        panic!("Expected protocol_feature_spice to be enabled")
+    }
+
+    pub fn all_next_block_hashes() -> DBCol {
+        #[cfg(feature = "protocol_feature_spice")]
+        return DBCol::AllNextBlockHashes;
         #[cfg(not(feature = "protocol_feature_spice"))]
         panic!("Expected protocol_feature_spice to be enabled")
     }

--- a/test-loop-tests/src/setup/setup.rs
+++ b/test-loop-tests/src/setup/setup.rs
@@ -1,4 +1,3 @@
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use near_async::messaging::{IntoMultiSender, IntoSender, LateBoundSender, noop};
@@ -345,7 +344,6 @@ pub fn setup_client(
         runtime_adapter.clone(),
         epoch_manager.clone(),
         network_adapter.as_multi_sender(),
-        NonZeroUsize::new(1000).unwrap(),
         validator_signer.clone(),
         spice_core_processor,
         client_actor.client.chunk_endorsement_tracker.clone(),


### PR DESCRIPTION
Both for chunk validation and chunk execution in spice we may receive block before the we have enough endorsements for the result of the previous one. Without enough endorsements for the result of the previous block we cannot process any of the following ones.

Endorsements of the block hold no information on which blocks may follow next so in both cases we need a way to get next blocks to allow processing related chunks or witnesses.

Using DbCol to store next blocks allows both actors to use it without additional duplicated logic to track next block on each actor's side.

Part of https://github.com/near/nearcore/issues/13387