### PR TITLE
fix(json-rpc): ensure tx status only skips refunds

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -273,6 +273,13 @@ class BaseNode(object):
                              [base64.b64encode(signed_tx).decode('utf8')],
                              timeout=timeout)
 
+    def send_tx_and_wait_until(self, signed_tx, wait_until, timeout):
+        params = {
+            'signed_tx_base64': base64.b64encode(signed_tx).decode('utf8'),
+            "wait_until": wait_until
+        }
+        return self.json_rpc('send_tx', params, timeout=timeout)
+
     def get_status(self,
                    check_storage: bool = True,
                    timeout: float = 4,


### PR DESCRIPTION
The current implementation for checking the execution status has this optimization to avoid waiting for refund receipts.

It assumes the last receipt is always a refund. This has never been true in a general sense but because the protocol almost always had to include a refund, this bug went under the radar.

Now with the adoption of NEP-536 to reduce the gas refunds, users have been running into this bug on testnet. See #13872.

The proposed solution in this PR is to check if an outgoing receipt actually is a refund receipt before excluding it.

## Testing strategy

Run `python3 tests/sanity/rpc_tx_status.py` to check that a tx result with wait_for="EXECUTED_OPTIMISTIC" includes the receipts for a cross-contract function call. Run it before the commit with the TX to see that it previously failed.