### PR TITLE
feat(recording): avoid reserialization when a node has already been recorded

### DIFF
--- a/core/store/src/trie/mem/loading.rs
+++ b/core/store/src/trie/mem/loading.rs
@@ -284,10 +284,13 @@ mod tests {
             );
 
             // Check that the accessed nodes are consistent with those from disk.
-            for (node_hash, serialized_node) in nodes_accessed {
+            for node_view in nodes_accessed {
+                let node_hash = node_view.node_hash();
+                let serialized_node =
+                    borsh::to_vec(&node_view.to_raw_trie_node_with_size()).unwrap();
                 let expected_serialized_node =
                     trie.internal_retrieve_trie_node(&node_hash, false, opts).unwrap();
-                assert_eq!(expected_serialized_node, serialized_node);
+                assert_eq!(&*expected_serialized_node, &serialized_node);
             }
         }
     }

--- a/core/store/src/trie/mem/memtries.rs
+++ b/core/store/src/trie/mem/memtries.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, HashMap};
-use std::sync::Arc;
 
 use near_primitives::errors::StorageError;
 use near_primitives::hash::CryptoHash;
@@ -19,7 +18,7 @@ use super::flexible_data::value::ValueView;
 use super::iter::{MemTrieIteratorInner, STMemTrieIterator};
 use super::lookup::memtrie_lookup;
 use super::memtrie_update::{MemTrieUpdate, TrackingMode, construct_root_from_changes};
-use super::node::{MemTrieNodeId, MemTrieNodePtr};
+use super::node::{MemTrieNodeId, MemTrieNodePtr, MemTrieNodeView};
 
 /// `MemTries` (logically) owns the memory of multiple tries.
 /// Tries may share nodes with each other via refcounting. The way the
@@ -224,12 +223,12 @@ impl MemTries {
 
     /// Looks up a key in the memtrie with the given state_root and returns the value if found.
     /// Additionally, it returns a list of nodes that were accessed during the lookup.
-    pub fn lookup(
-        &self,
+    pub fn lookup<'a>(
+        &'a self,
         state_root: &CryptoHash,
         key: &[u8],
-        nodes_accessed: Option<&mut Vec<(CryptoHash, Arc<[u8]>)>>,
-    ) -> Result<Option<ValueView>, StorageError> {
+        nodes_accessed: Option<&mut Vec<MemTrieNodeView<'a, HybridArenaMemory>>>,
+    ) -> Result<Option<ValueView<'a>>, StorageError> {
         let root = self.get_root(state_root)?;
         Ok(memtrie_lookup(root, key, nodes_accessed))
     }

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -95,11 +95,24 @@ impl TrieRecorder {
     }
 
     pub fn record(&self, hash: &CryptoHash, node: Arc<[u8]>) {
-        let size = node.len();
-        let times_seen = self.recorded.entry(*hash).or_insert_with(|| node.into()).increment();
+        self.record_with(hash, move || node);
+    }
+
+    /// Just like "record", but takes a function which returns the serialized node.
+    /// Allows to avoid re-serializing the node when it has already been recorded.
+    pub fn record_with(&self, hash: &CryptoHash, get_serialized_node: impl FnOnce() -> Arc<[u8]>) {
+        let mut size_from_first_insert: Option<usize> = None;
+        self.recorded
+            .entry(*hash)
+            .or_insert_with(|| {
+                let serialized = get_serialized_node();
+                size_from_first_insert = Some(serialized.len());
+                serialized.into()
+            })
+            .increment();
 
         // Only do size accounting if this is the first time we see this value.
-        if times_seen == 1 {
+        if let Some(size) = size_from_first_insert {
             self.upper_bound_size.fetch_add(size, Ordering::Release).checked_add(size).unwrap();
             self.size.fetch_add(size, Ordering::Release);
         }


### PR DESCRIPTION
For every visited trie node we calculate its hash and serialize it before passing it to the recorder.
Serializing can be expensive - e.g. for branch nodes `to_children` often has to hash all 16 children to get the serialized representation.
Let's make sure that we serialize each node only once, the first time it's recorded. Subsequent visits to the node will see that the node has already been recorded and skip serialization, saving some performance.


### Performance gain
On my machine this speeds up chunk application by ~20%

Workload: single shard native transfers, memtrie storage, chunk with 3625 transactions and 4152 incoming receipts
Before: `application time: 134.4ms, applications per second: 7.44`
After: `application time: 110.9ms, applications per second: 9.02`

Flamegraph before: ![master](https://github.com/user-attachments/assets/908676b6-84d0-4ff4-9713-2eddde1b4752)
Flamegraph after: ![opt](https://github.com/user-attachments/assets/0133e4ff-f292-4535-bc29-6794e507d2d8)
