### PR TITLE
observability - update optimistic traces

### DIFF
--- a/benchmarks/sharded-bm/cases/log_patch.json
+++ b/benchmarks/sharded-bm/cases/log_patch.json
@@ -1,5 +1,5 @@
 {
     "rust_log": "transaction-generator=info,tokio_reactor=info,config=info,near=info,stats=info,telemetry=info,db=info,delay_detector=info,near-performance-metrics=info,state_viewer=info,warn",
     "verbose_module": null,
-    "opentelemetry": "client=debug,chain=debug,stateless_validation=debug,[{tag_block_production=\"true\"}]=debug,[{tag_witness_distribution=\"true\"}]=debug,info"
+    "opentelemetry": "client=debug,chain=debug,stateless_validation=debug,[{tag_block_production=\"true\"}]=debug,[{tag_witness_distribution=\"true\"}]=debug,[{tag_optimistic=\"true\"}]=debug,info"
 }

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1285,7 +1285,8 @@ impl Chain {
             "process_optimistic_block",
             hash = ?block.hash(),
             height = ?block.height(),
-            tag_block_production = true
+            tag_block_production = true,
+            tag_optimistic = true
         )
         .entered();
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -639,7 +639,7 @@ impl Client {
         height: BlockHeight,
     ) -> Result<Option<OptimisticBlock>, Error> {
         let _span =
-            tracing::debug_span!(target: "client", "produce_optimistic_block_on_head", height, tag_block_production = true)
+            tracing::debug_span!(target: "client", "produce_optimistic_block_on_head", height, tag_block_production = true, tag_optimistic = true)
                 .entered();
 
         let head = self.chain.head()?;
@@ -1074,7 +1074,7 @@ impl Client {
 
     /// Check optimistic block and start processing if is valid.
     pub fn receive_optimistic_block(&mut self, block: OptimisticBlock, peer_id: &PeerId) {
-        let _span = debug_span!(target: "client", "receive_optimistic_block").entered();
+        let _span = debug_span!(target: "client", "receive_optimistic_block", height = block.height(), tag_optimistic = true).entered();
         debug!(target: "client", ?block, ?peer_id, "Received optimistic block");
 
         // Pre-validate the optimistic block.

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1373,8 +1373,6 @@ impl ClientActorInner {
 
     /// Produce optimistic block if we are block producer for given `next_height` height.
     fn produce_optimistic_block(&mut self, next_height: BlockHeight) -> Result<(), Error> {
-        let _span = tracing::debug_span!(target: "client", "produce_optimistic_block", height=next_height, tag_optimistic = true)
-            .entered();
         // Check if optimistic block is already produced
         if self.client.is_optimistic_block_done(next_height) {
             return Ok(());

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1373,7 +1373,7 @@ impl ClientActorInner {
 
     /// Produce optimistic block if we are block producer for given `next_height` height.
     fn produce_optimistic_block(&mut self, next_height: BlockHeight) -> Result<(), Error> {
-        let _span = tracing::debug_span!(target: "client", "produce_optimistic_block", next_height)
+        let _span = tracing::debug_span!(target: "client", "produce_optimistic_block", height=next_height, tag_optimistic = true)
             .entered();
         // Check if optimistic block is already produced
         if self.client.is_optimistic_block_done(next_height) {
@@ -1396,7 +1396,6 @@ impl ClientActorInner {
         ));
 
         // We've produced the optimistic block, mark it as done so we don't produce it again.
-        // We’ve produced the optimistic block, mark it as done so we don't produce it again.
         self.client.save_optimistic_block(&optimistic_block);
         self.client.chain.optimistic_block_chunks.add_block(optimistic_block);
 


### PR DESCRIPTION
Updates optimistic traces to use consistent attributes. Also adds a new tag `tag_optimistic` to be used now for OB and in the future for optimistic witness.