### PR TITLE
feat(recording): use record_with in more places

### DIFF
--- a/core/store/src/trie/mem/iter.rs
+++ b/core/store/src/trie/mem/iter.rs
@@ -41,9 +41,7 @@ impl<'a> GenericTrieInternalStorage<MemTrieNodeId, FlatStateValue> for MemTrieIt
         let view = node.as_ptr(self.memtrie.arena.memory()).view();
         if opts.enable_state_witness_recording {
             if let Some(recorder) = &self.trie.recorder {
-                recorder.record_with(&view.node_hash(), || {
-                    borsh::to_vec(&view.to_raw_trie_node_with_size()).unwrap().into()
-                });
+                recorder.record_memtrie_node(&view);
             }
         }
         let node = MemTrieNode::from_existing_node_view(view);

--- a/core/store/src/trie/mem/iter.rs
+++ b/core/store/src/trie/mem/iter.rs
@@ -41,9 +41,9 @@ impl<'a> GenericTrieInternalStorage<MemTrieNodeId, FlatStateValue> for MemTrieIt
         let view = node.as_ptr(self.memtrie.arena.memory()).view();
         if opts.enable_state_witness_recording {
             if let Some(recorder) = &self.trie.recorder {
-                let raw_node_serialized =
-                    borsh::to_vec(&view.to_raw_trie_node_with_size()).unwrap();
-                recorder.record(&view.node_hash(), raw_node_serialized.into());
+                recorder.record_with(&view.node_hash(), || {
+                    borsh::to_vec(&view.to_raw_trie_node_with_size()).unwrap().into()
+                });
             }
         }
         let node = MemTrieNode::from_existing_node_view(view);

--- a/core/store/src/trie/mem/memtrie_update.rs
+++ b/core/store/src/trie/mem/memtrie_update.rs
@@ -114,10 +114,11 @@ impl<'a> TrieChangesTracker<'a> {
 
     fn record<M: ArenaMemory>(&mut self, node: &MemTrieNodeView<'a, M>) {
         let node_hash = node.node_hash();
-        let raw_node_serialized = borsh::to_vec(&node.to_raw_trie_node_with_size()).unwrap();
         *self.refcount_deleted_hashes.entry(node_hash).or_default() += 1;
         if let Some(recorder) = self.recorder.as_mut() {
-            recorder.record(&node_hash, raw_node_serialized.into());
+            recorder.record_with(&node_hash, || {
+                borsh::to_vec(&node.to_raw_trie_node_with_size()).unwrap().into()
+            });
         }
     }
 

--- a/core/store/src/trie/mem/memtrie_update.rs
+++ b/core/store/src/trie/mem/memtrie_update.rs
@@ -116,9 +116,7 @@ impl<'a> TrieChangesTracker<'a> {
         let node_hash = node.node_hash();
         *self.refcount_deleted_hashes.entry(node_hash).or_default() += 1;
         if let Some(recorder) = self.recorder.as_mut() {
-            recorder.record_with(&node_hash, || {
-                borsh::to_vec(&node.to_raw_trie_node_with_size()).unwrap().into()
-            });
+            recorder.record_memtrie_node(node);
         }
     }
 

--- a/core/store/src/trie/mem/mod.rs
+++ b/core/store/src/trie/mem/mod.rs
@@ -13,6 +13,8 @@ pub(crate) mod nibbles_utils;
 pub mod node;
 mod parallel_loader;
 
+pub(crate) use arena::ArenaMemory;
+
 /// Check this, because in the code we conveniently assume usize is 8 bytes.
 /// In-memory trie can't possibly work under 32-bit anyway.
 #[cfg(not(target_pointer_width = "64"))]

--- a/core/store/src/trie/trie_recording.rs
+++ b/core/store/src/trie/trie_recording.rs
@@ -1,3 +1,5 @@
+use super::mem::ArenaMemory;
+use super::mem::node::MemTrieNodeView;
 use super::{Trie, TrieChanges, TrieRefcountDeltaMap};
 use crate::{NibbleSlice, PartialStorage, RawTrieNode, RawTrieNodeWithSize};
 use borsh::BorshDeserialize;
@@ -116,6 +118,13 @@ impl TrieRecorder {
             self.upper_bound_size.fetch_add(size, Ordering::Release).checked_add(size).unwrap();
             self.size.fetch_add(size, Ordering::Release);
         }
+    }
+
+    /// Convenience function to record memtrie nodes
+    pub fn record_memtrie_node<M: ArenaMemory>(&self, node_view: &MemTrieNodeView<'_, M>) {
+        self.record_with(&node_view.node_hash(), || {
+            borsh::to_vec(&node_view.to_raw_trie_node_with_size()).unwrap().into()
+        });
     }
 
     pub fn record_key_removal(&self) {


### PR DESCRIPTION
Follow up on https://github.com/near/nearcore/pull/13988

There are two more places where we can use `record_with` to do less serialization.

Speeds up chunk application by another ~10%

Before: application time: 108.4ms, applications per second: 9.22
After: application time: 95.1ms, applications per second: 10.51