### PR TITLE
chore: extra chunk checks (#13984)

### DIFF
--- a/chain/chain/src/validate.rs
+++ b/chain/chain/src/validate.rs
@@ -13,6 +13,7 @@ use near_primitives::sharding::{
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{BlockHeight, ShardId};
+use near_primitives::version::ProtocolFeature;
 use reed_solomon_erasure::galois_8::ReedSolomon;
 
 /// Gas limit cannot be adjusted for more than 0.1% at a time.
@@ -74,7 +75,7 @@ pub fn validate_chunk_with_chunk_extra(
     prev_chunk_extra: &ChunkExtra,
     prev_chunk_height_included: BlockHeight,
     chunk_header: &ShardChunkHeader,
-) -> Result<(), Error> {
+) -> Result<Vec<Receipt>, Error> {
     let outgoing_receipts = chain_store.get_outgoing_receipts_for_shard(
         epoch_manager,
         *prev_block_hash,
@@ -91,7 +92,48 @@ pub fn validate_chunk_with_chunk_extra(
         prev_chunk_extra,
         chunk_header,
         &outgoing_receipts_root,
-    )
+    )?;
+
+    Ok(outgoing_receipts)
+}
+
+pub fn validate_chunk_with_chunk_extra_and_roots(
+    chain_store: &ChainStore,
+    epoch_manager: &dyn EpochManagerAdapter,
+    prev_block_hash: &CryptoHash,
+    prev_chunk_extra: &ChunkExtra,
+    prev_chunk_height_included: BlockHeight,
+    chunk_header: &ShardChunkHeader,
+    new_transactions: &[SignedTransaction],
+    rs: &ReedSolomon,
+) -> Result<(), Error> {
+    let outgoing_receipts = validate_chunk_with_chunk_extra(
+        chain_store,
+        epoch_manager,
+        prev_block_hash,
+        prev_chunk_extra,
+        prev_chunk_height_included,
+        chunk_header,
+    )?;
+
+    let epoch_id = epoch_manager.get_epoch_id_from_prev_block(prev_block_hash)?;
+    let protocol_version = epoch_manager.get_epoch_protocol_version(&epoch_id)?;
+    if ProtocolFeature::ChunkPartChecks.enabled(protocol_version) {
+        let (tx_root, _) = merklize(new_transactions);
+        if tx_root != chunk_header.tx_root() {
+            return Err(Error::InvalidTxRoot);
+        }
+
+        validate_chunk_with_encoded_merkle_root(
+            chunk_header,
+            outgoing_receipts,
+            new_transactions.to_vec(),
+            rs,
+            chunk_header.shard_id(),
+        )
+    } else {
+        Ok(())
+    }
 }
 
 /// Validate that all next chunk information matches previous chunk extra.

--- a/chain/client/src/stateless_validation/chunk_validator/mod.rs
+++ b/chain/client/src/stateless_validation/chunk_validator/mod.rs
@@ -8,7 +8,7 @@ use near_async::messaging::{CanSend, Sender};
 use near_chain::stateless_validation::chunk_validation;
 use near_chain::stateless_validation::processing_tracker::ProcessingDoneTracker;
 use near_chain::types::RuntimeAdapter;
-use near_chain::validate::validate_chunk_with_chunk_extra;
+use near_chain::validate::validate_chunk_with_chunk_extra_and_roots;
 use near_chain::{Block, Chain};
 use near_chain_primitives::Error;
 use near_epoch_manager::EpochManagerAdapter;
@@ -126,13 +126,15 @@ impl ChunkValidator {
             epoch_manager.get_chunk_producer_info(&chunk_production_key)?.take_account_id();
 
         if let Ok(prev_chunk_extra) = chain.get_chunk_extra(&prev_block_hash, &shard_uid) {
-            match validate_chunk_with_chunk_extra(
+            match validate_chunk_with_chunk_extra_and_roots(
                 chain.chain_store(),
                 self.epoch_manager.as_ref(),
                 &prev_block_hash,
                 &prev_chunk_extra,
                 last_header.height_included(),
                 &chunk_header,
+                state_witness.new_transactions(),
+                self.rs.as_ref(),
             ) {
                 Ok(()) => {
                     send_chunk_endorsement_to_block_producers(

--- a/integration-tests/src/tests/client/process_blocks2.rs
+++ b/integration-tests/src/tests/client/process_blocks2.rs
@@ -313,7 +313,7 @@ fn test_bad_congestion_info_impl(mode: BadCongestionInfoMode) {
     let prev_block_hash = block.header().prev_hash();
     let client = &env.clients[0];
     let prev_chunk_extra = client.chain.get_chunk_extra(prev_block_hash, &shard_uid).unwrap();
-    let result: Result<(), near_chain::Error> = validate_chunk_with_chunk_extra(
+    let result: Result<_, near_chain::Error> = validate_chunk_with_chunk_extra(
         &client.chain.chain_store,
         client.epoch_manager.as_ref(),
         prev_block_hash,


### PR DESCRIPTION
The PR adds further chunk consistency checks. Validators will now reassemble the full payload from incoming data and derive a compact fingerprint over the segments, cross-checking the fingerprint for validity.

Discrepancies trigger an early exit and will be registered by a lightweight metric that has been added to track the cost per shard.