### PR TITLE
fix(json-rpc): ensure tx status only skips refunds (#13979)

### DIFF
--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -493,15 +493,6 @@ impl ViewClientActorInner {
                 .flat_map(|outcome| &outcome.outcome.receipt_ids),
         );
 
-        // refund receipt == last receipt in outcome.receipt_ids
-        let mut awaiting_non_refund_receipt_ids: HashSet<&CryptoHash> =
-            HashSet::from_iter(&execution_outcome.transaction_outcome.outcome.receipt_ids);
-        awaiting_non_refund_receipt_ids.extend(execution_outcome.receipts_outcome.iter().flat_map(
-            |outcome| {
-                outcome.outcome.receipt_ids.split_last().map(|(_, ids)| ids).unwrap_or_else(|| &[])
-            },
-        ));
-
         let executed_receipt_ids: HashSet<&CryptoHash> = execution_outcome
             .receipts_outcome
             .iter()
@@ -513,6 +504,40 @@ impl ViewClientActorInner {
                 }
             })
             .collect();
+
+        // Optimization for end-user TX latency: If the last outgoing receipt of
+        // an outcome is a refund receipt, we don't wait for that and consider
+        // the transaction executed or finalized a block earlier.
+        let mut awaiting_non_refund_receipt_ids = awaiting_receipt_ids.clone();
+        for outcome in &execution_outcome.receipts_outcome {
+            let receipt_ids = outcome.outcome.receipt_ids.as_slice();
+            let Some(last_receipt_id) = receipt_ids.last() else {
+                continue;
+            };
+
+            // no need to apply the optimization for already executed receipts
+            if executed_receipt_ids.contains(last_receipt_id) {
+                continue;
+            }
+            // need the full receipt to determine if this is a refund or not
+            // Note: We can't read from DBCol::Receipts here because we store it there too late
+            // This means we have to read outgoing receipts, which isn't ideal.
+            // but since this is only triggered for receipts that are not
+            // executed yet, this is a rare case. And whenever we hit it, this is
+            // recent data that was written probably within the last second and
+            // should be fast to retrieve.
+            let outgoing_receipts = self.outgoing_receipts_for_outcome(outcome)?;
+            let Some(last_receipt) =
+                outgoing_receipts.iter().find(|receipt| receipt.receipt_id() == last_receipt_id)
+            else {
+                // if we can't fetch the receipt, be conservative and assume we have to wait
+                continue;
+            };
+            // predecessor_id == "system" means this is a refund receipt
+            if last_receipt.predecessor_id().is_system() {
+                awaiting_non_refund_receipt_ids.remove(last_receipt_id);
+            }
+        }
 
         let executed_ignoring_refunds =
             awaiting_non_refund_receipt_ids.is_subset(&executed_receipt_ids);
@@ -548,6 +573,25 @@ impl ViewClientActorInner {
             Err(_) => TxExecutionStatus::Executed,
             Ok(_) => TxExecutionStatus::Final,
         })
+    }
+
+    /// Read the receipts that are outgoing from the given execution outcome,
+    /// even before they have been validated on chain and stored in
+    /// DbCol::Receipts.
+    fn outgoing_receipts_for_outcome(
+        &self,
+        outcome: &ExecutionOutcomeWithIdView,
+    ) -> Result<Arc<Vec<Receipt>>, TxStatusError> {
+        let epoch_id = &self.epoch_manager.get_epoch_id(&outcome.block_hash).into_chain_error()?;
+        let shard_id = account_id_to_shard_id(
+            self.epoch_manager.as_ref(),
+            &outcome.outcome.executor_id,
+            epoch_id,
+        )
+        .into_chain_error()?;
+        let outgoing_receipts =
+            self.chain.chain_store().get_outgoing_receipts(&outcome.block_hash, shard_id)?;
+        Ok(outgoing_receipts)
     }
 
     fn get_tx_status(

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -273,6 +273,13 @@ class BaseNode(object):
                              [base64.b64encode(signed_tx).decode('utf8')],
                              timeout=timeout)
 
+    def send_tx_and_wait_until(self, signed_tx, wait_until, timeout):
+        params = {
+            'signed_tx_base64': base64.b64encode(signed_tx).decode('utf8'),
+            "wait_until": wait_until
+        }
+        return self.json_rpc('send_tx', params, timeout=timeout)
+
     def get_status(self,
                    check_storage: bool = True,
                    timeout: float = 4,


### PR DESCRIPTION
The current implementation for checking the execution status has this optimization to avoid waiting for refund receipts.

It assumes the last receipt is always a refund. This has never been true in a general sense but because the protocol almost always had to include a refund, this bug went under the radar.

Now with the adoption of NEP-536 to reduce the gas refunds, users have been running into this bug on testnet. See #13872.

The proposed solution in this PR is to check if an outgoing receipt actually is a refund receipt before excluding it.

## Testing strategy

Run `python3 tests/sanity/rpc_tx_status.py` to check that a tx result with wait_for="EXECUTED_OPTIMISTIC" includes the receipts for a cross-contract function call. Run it before the commit with the TX to see that it previously failed.