### PR TITLE
observability: add produce_chunk_internal span

### DIFF
--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -221,6 +221,7 @@ impl ChunkProducer {
         %shard_id,
         ?epoch_id,
         prev_block_hash = ?prev_block.header().hash(),
+        chunk_hash = tracing::field::Empty,
         tag_block_production = true
     ))]
     fn produce_chunk_internal(

--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -124,14 +124,6 @@ impl ChunkProducer {
         }
     }
 
-    #[instrument(target = "client", level = "debug", "produce_chunk", skip_all, fields(
-        %next_height,
-        %shard_id,
-        ?epoch_id,
-        prev_block_hash = ?prev_block.header().hash(),
-        chunk_hash = tracing::field::Empty,
-        tag_block_production = true
-    ))]
     pub fn produce_chunk(
         &mut self,
         prev_block: &Block,
@@ -224,6 +216,13 @@ impl ChunkProducer {
         Ok(receipts_root)
     }
 
+    #[instrument(target = "client", level = "debug", "produce_chunk_internal", skip_all, fields(
+        height=%next_height,
+        %shard_id,
+        ?epoch_id,
+        prev_block_hash = ?prev_block.header().hash(),
+        tag_block_production = true
+    ))]
     fn produce_chunk_internal(
         &mut self,
         prev_block: &Block,


### PR DESCRIPTION
Adding a new span `produce_chunk_internal` with the following properties:
- contains attribute `height` in order to be linked to other spans in traviz
- emit only when chunk is actually produced

I also removed the old "produce_chunk" span because I don't see anymore use case for that.