### PR TITLE
Prepare `2.7.0-rc.4`

### DIFF
--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -60,10 +60,10 @@ pub fn get_protocol_upgrade_schedule(chain_id: &str) -> ProtocolUpgradeVotingSch
             schedule
         }
         TESTNET => {
-            // Voting starts Wednesday 02:00 UTC.
+            // Voting starts Tuesday 02:00 UTC.
             let v1_protocol_version = 79;
             let v1_datetime =
-                ProtocolUpgradeVotingSchedule::parse_datetime("2025-07-30 02:00:00").unwrap();
+                ProtocolUpgradeVotingSchedule::parse_datetime("2025-08-05 02:00:00").unwrap();
             let schedule = vec![(v1_datetime, v1_protocol_version)];
             schedule
         }


### PR DESCRIPTION
Prepare `2.7.0-rc.4` release
https://github.com/near/nearcore/pull/13969 already:
* Set neard version to `2.7.0-rc.4`
* Set crates version to `0.31.0-rc.4`

In this PR, we:
* Set voting date to Tuesday 2025-08-05 02:00 UTC - protocol upgrade will happen 7-14 hours later, on 2025-08-05 between 9:00 and 16:00 UTC.

According to our estimation tool the upgrade will happen around 2025-08-05 12:20 UTC

```
$ python3 debug_scripts/estimate_epoch_start_time.py  --url http://34.13.150.28:3030 --num_past_epochs 10 --num_future_epochs 20
Epoch -1: 06 hours, 51 minutes
Epoch -2: 06 hours, 52 minutes
Epoch -3: 06 hours, 55 minutes
Epoch -4: 06 hours, 53 minutes
Epoch -5: 06 hours, 51 minutes
Epoch -6: 06 hours, 52 minutes
Epoch -7: 06 hours, 53 minutes
Epoch -8: 06 hours, 50 minutes
Epoch -9: 06 hours, 52 minutes
Epoch -10: 06 hours, 51 minutes

Exponential weighted average epoch length: 06 hours, 52 minutes
Predicted start of epoch 1: 2025-07-31 15:26:47 UTC+0000 Thursday
Predicted start of epoch 2: 2025-07-31 22:19:14 UTC+0000 Thursday
Predicted start of epoch 3: 2025-08-01 05:11:40 UTC+0000 Friday
Predicted start of epoch 4: 2025-08-01 12:04:07 UTC+0000 Friday
Predicted start of epoch 5: 2025-08-01 18:56:33 UTC+0000 Friday
Predicted start of epoch 6: 2025-08-02 01:48:59 UTC+0000 Saturday
Predicted start of epoch 7: 2025-08-02 08:41:26 UTC+0000 Saturday
Predicted start of epoch 8: 2025-08-02 15:33:52 UTC+0000 Saturday
Predicted start of epoch 9: 2025-08-02 22:26:19 UTC+0000 Saturday
Predicted start of epoch 10: 2025-08-03 05:18:45 UTC+0000 Sunday
Predicted start of epoch 11: 2025-08-03 12:11:12 UTC+0000 Sunday
Predicted start of epoch 12: 2025-08-03 19:03:38 UTC+0000 Sunday
Predicted start of epoch 13: 2025-08-04 01:56:04 UTC+0000 Monday
Predicted start of epoch 14: 2025-08-04 08:48:31 UTC+0000 Monday
Predicted start of epoch 15: 2025-08-04 15:40:57 UTC+0000 Monday
Predicted start of epoch 16: 2025-08-04 22:33:24 UTC+0000 Monday
Predicted start of epoch 17: 2025-08-05 05:25:50 UTC+0000 Tuesday
Predicted start of epoch 18: 2025-08-05 12:18:17 UTC+0000 Tuesday
Predicted start of epoch 19: 2025-08-05 19:10:43 UTC+0000 Tuesday
Predicted start of epoch 20: 2025-08-06 02:03:09 UTC+0000 Wednesday
```

Voting date falls into epoch 16.
Protocol upgrade will happen at the start of epoch 18: around 2025-08-05 12:20 UTC Tuesday.