### PR TITLE
nit: move produce_chunk span -> produce_chunk_internal

### DIFF
--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -124,14 +124,6 @@ impl ChunkProducer {
         }
     }
 
-    #[instrument(target = "client", level = "debug", "produce_chunk", skip_all, fields(
-        %next_height,
-        %shard_id,
-        ?epoch_id,
-        prev_block_hash = ?prev_block.header().hash(),
-        chunk_hash = tracing::field::Empty,
-        tag_block_production = true
-    ))]
     pub fn produce_chunk(
         &mut self,
         prev_block: &Block,
@@ -224,6 +216,14 @@ impl ChunkProducer {
         Ok(receipts_root)
     }
 
+    #[instrument(target = "client", level = "debug", "produce_chunk_internal", skip_all, fields(
+        %next_height,
+        %shard_id,
+        ?epoch_id,
+        prev_block_hash = ?prev_block.header().hash(),
+        chunk_hash = tracing::field::Empty,
+        tag_block_production = true
+    ))]
     fn produce_chunk_internal(
         &mut self,
         prev_block: &Block,


### PR DESCRIPTION
Recently (...) this span was moved to the top of produce_chunk function.
But this function returns quickly for shards that the chunk producer is not producing, resulting in lots of spans in the visualizations.

This PR moves it to the top of `produce_chunk_internal` and renames the span. Some alternatives we could do:
- Keep the name `produce_chunk`, just instrument `produce_chunk_internal`
- Keep the name `produce_chunk`, and enter the span once we pass the early return in `produce_chunk`