### PR TITLE
nit: add partial_chunk_exists

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1101,13 +1101,13 @@ impl Chain {
             }
             match chunk_header {
                 ChunkType::New(chunk_header) => {
-                    if let Err(_) = self.chain_store.get_partial_chunk(chunk_hash) {
+                    if !self.chain_store.partial_chunk_exists(chunk_hash)? {
                         missing.push(chunk_header.clone());
                     } else if self
                         .shard_tracker
                         .cares_about_shard_this_or_next_epoch(&parent_hash, shard_id)
                     {
-                        if let Err(_) = self.chain_store.get_chunk(chunk_hash) {
+                        if !self.chain_store.chunk_exists(chunk_hash)? {
                             missing.push(chunk_header.clone());
                         }
                     }
@@ -1265,6 +1265,8 @@ impl Chain {
             );
             return;
         }
+
+        // Optimistically prepare transactions
 
         match self.process_optimistic_block(block, chunks, apply_chunks_done_sender) {
             Ok(()) => {

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1266,8 +1266,6 @@ impl Chain {
             return;
         }
 
-        // Optimistically prepare transactions
-
         match self.process_optimistic_block(block, chunks, apply_chunks_done_sender) {
             Ok(()) => {
                 debug!(

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -99,6 +99,8 @@ pub trait ChainStoreAccess {
     fn block_exists(&self, h: &CryptoHash) -> Result<bool, Error>;
     /// Does this chunk exist?
     fn chunk_exists(&self, h: &ChunkHash) -> Result<bool, Error>;
+    /// Does this partial chunk exist?
+    fn partial_chunk_exists(&self, h: &ChunkHash) -> Result<bool, Error>;
     /// Get previous header.
     fn get_previous_header(&self, header: &BlockHeader) -> Result<Arc<BlockHeader>, Error>;
     /// Get chunk extra info for given block hash + shard id.
@@ -889,6 +891,10 @@ impl ChainStoreAccess for ChainStore {
         ChainStoreAdapter::chunk_exists(self, h)
     }
 
+    fn partial_chunk_exists(&self, h: &ChunkHash) -> Result<bool, Error> {
+        ChainStoreAdapter::partial_chunk_exists(self, h)
+    }
+
     /// Get previous header.
     fn get_previous_header(&self, header: &BlockHeader) -> Result<Arc<BlockHeader>, Error> {
         ChainStoreAdapter::get_previous_header(self, header)
@@ -1186,6 +1192,11 @@ impl<'a> ChainStoreAccess for ChainStoreUpdate<'a> {
     fn chunk_exists(&self, h: &ChunkHash) -> Result<bool, Error> {
         Ok(self.chain_store_cache_update.chunks.contains_key(h)
             || self.chain_store.chunk_exists(h)?)
+    }
+
+    fn partial_chunk_exists(&self, h: &ChunkHash) -> Result<bool, Error> {
+        Ok(self.chain_store_cache_update.partial_chunks.contains_key(h)
+            || self.chain_store.partial_chunk_exists(h)?)
     }
 
     /// Get previous header.

--- a/chain/chunks/src/logic.rs
+++ b/chain/chunks/src/logic.rs
@@ -187,7 +187,7 @@ pub fn persist_chunk(
     store: &mut ChainStore,
 ) -> Result<(), Error> {
     let mut update = store.store_update();
-    if update.get_partial_chunk(&partial_chunk.chunk_hash()).is_err() {
+    if !update.partial_chunk_exists(&partial_chunk.chunk_hash())? {
         update.save_partial_chunk(partial_chunk);
     }
     if let Some(shard_chunk) = shard_chunk {

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -248,6 +248,11 @@ impl ChainStoreAdapter {
         self.store.exists(DBCol::Chunks, h.as_ref()).map_err(|e| e.into())
     }
 
+    /// Does this partial chunk exist?
+    pub fn partial_chunk_exists(&self, h: &ChunkHash) -> Result<bool, Error> {
+        self.store.exists(DBCol::PartialChunks, h.as_ref()).map_err(|e| e.into())
+    }
+
     /// Returns encoded chunk if it's invalid otherwise None.
     pub fn is_invalid_chunk(
         &self,


### PR DESCRIPTION
Maybe helpful with this (starting OB processing earlier), by avoiding de-serializing the partial chunk

<img width="1362" height="431" alt="Screenshot 2025-07-31 at 11 55 27 AM" src="https://github.com/user-attachments/assets/38aa4296-5eab-4b74-93d4-20190737e4f0" />
