### PR TITLE
Make TokioRuntimeHandle compatible with AsyncSender.

### DIFF
--- a/core/async/src/actix/wrapper.rs
+++ b/core/async/src/actix/wrapper.rs
@@ -5,6 +5,9 @@ use actix::{Actor, SyncArbiter};
 use crate::futures::DelayedActionRunner;
 use crate::messaging;
 
+/// Compatibility layer for actix messages.
+impl<T: actix::Message> messaging::Message for T {}
+
 /// Wrapper on top of a generic actor to make it implement actix::Actor trait. The wrapped actor
 /// should implement the Handler trait for all the messages it would like to handle.
 /// ActixWrapper is then used to create an actix actor that implements the CanSend trait.

--- a/core/async/src/messaging.rs
+++ b/core/async/src/messaging.rs
@@ -24,6 +24,12 @@ pub trait Actor {
     }
 }
 
+/// All handled messages shall implement this trait.
+/// TODO(#14005): The reason this exists is to allow CanSend<M> to be
+/// implemented at the same time as CanSend<MessageWithCallback<M, R>>. Once we
+/// remove MessageWithCallback, we should not need this anymore.
+pub trait Message {}
+
 /// Trait for handling a message.
 /// This works in unison with the [`CanSend`] trait. An actor implements the Handler trait for all
 /// messages it would like to handle, while the CanSend trait implements the logic to send the
@@ -31,6 +37,7 @@ pub trait Actor {
 /// Note that the actor is any struct that implements the Handler trait, not just actix actors.
 pub trait Handler<M, R = ()>
 where
+    M: Message,
     R: Send,
 {
     fn handle(&mut self, msg: M) -> R;
@@ -44,6 +51,7 @@ where
 /// HandlerWithContext, not both.
 pub trait HandlerWithContext<M, R = ()>
 where
+    M: Message,
     R: Send,
 {
     fn handle(&mut self, msg: M, ctx: &mut dyn DelayedActionRunner<Self>) -> R;
@@ -52,6 +60,7 @@ where
 impl<A, M, R> HandlerWithContext<M, R> for A
 where
     A: Actor + Handler<M, R>,
+    M: Message,
     R: Send,
 {
     fn handle(&mut self, msg: M, ctx: &mut dyn DelayedActionRunner<Self>) -> R {

--- a/test-loop-tests/src/tests/view_requests_to_archival_node.rs
+++ b/test-loop-tests/src/tests/view_requests_to_archival_node.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use itertools::Itertools;
-use near_async::messaging::Handler;
+use near_async::messaging::{Handler, Message};
 use near_async::test_loop::TestLoopV2;
 use near_async::test_loop::data::TestLoopDataHandle;
 use near_async::time::Duration;
@@ -129,6 +129,7 @@ impl<'a> ViewClientTester<'a> {
     /// Sends a message to the `[ViewClientActorInner]` for the client at position `idx`.
     fn send<M, R>(&mut self, request: M, idx: usize) -> R
     where
+        M: Message,
         R: Send,
         ViewClientActorInner: Handler<M, R>,
     {

--- a/test-loop-tests/src/utils/peer_manager_actor.rs
+++ b/test-loop-tests/src/utils/peer_manager_actor.rs
@@ -5,7 +5,8 @@ use itertools::Itertools;
 use near_async::actix::ActixResult;
 use near_async::futures::{DelayedActionRunnerExt as _, FutureSpawner, FutureSpawnerExt};
 use near_async::messaging::{
-    Actor, AsyncSender, CanSend, Handler, IntoMultiSender as _, IntoSender as _, SendAsync, Sender,
+    Actor, AsyncSender, CanSend, Handler, IntoMultiSender as _, IntoSender as _, Message,
+    SendAsync, Sender,
 };
 use near_async::test_loop::sender::TestLoopSender;
 use near_async::time::{Clock, Duration};
@@ -229,6 +230,7 @@ pub struct UnreachableActor {}
 
 impl<M, R> Handler<M, R> for UnreachableActor
 where
+    M: Message,
     R: Send,
 {
     fn handle(&mut self, _msg: M) -> R {


### PR DESCRIPTION
This PR implements `CanSend<MessageWithCallback<M, R>>` for `TokioRuntimeHandle`, acting as a compatibility layer with the current multisender-based adapter implementation. This allows us to easily migrate existing actors.

In order to implement `CanSend`, we had to introduce a new trait that messages must implement. This is because otherwise the `CanSend<M>` implementation conflicts with the `CanSend<MessageWithCallback<M, R>>` implementation, as `MessageWithCallback<M, R>` also satisfies `Debug + Send + 'static`. With a `Message` bound, since `MessageWithCallback` is not a `Message`, this avoids the conflict. The requirement of the `Message` trait for handlers is easily taken care of by having `actix::Message` automatically implement `Message`.