### PR TITLE
perf(memtries): Avoid re-serializing nodes when size/hash is known

### DIFF
--- a/core/store/src/trie/mem/memtrie_update.rs
+++ b/core/store/src/trie/mem/memtrie_update.rs
@@ -476,6 +476,7 @@ pub(super) fn construct_root_from_changes<A: ArenaMut>(
     let node_ids_with_hashes = &changes.node_ids_with_hashes;
     for (node_id, node_hash) in node_ids_with_hashes {
         let node = updated_nodes.get(*node_id).unwrap().as_ref().unwrap();
+        let memory_usage = node.memory_usage;
         let node = match &node.node {
             UpdatedMemTrieNode::Empty => unreachable!(),
             UpdatedMemTrieNode::Branch { children, value } => {
@@ -500,7 +501,8 @@ pub(super) fn construct_root_from_changes<A: ArenaMut>(
                 InputMemTrieNode::Leaf { value, extension }
             }
         };
-        let mem_node_id = MemTrieNodeId::new_with_hash(arena, node, *node_hash);
+        let mem_node_id =
+            MemTrieNodeId::new_with_hash_and_memory_usage(arena, node, *node_hash, memory_usage);
         updated_to_new_map.insert(*node_id, mem_node_id);
         last_node_id = Some(mem_node_id);
     }

--- a/core/store/src/trie/mem/node/encoding.rs
+++ b/core/store/src/trie/mem/node/encoding.rs
@@ -114,7 +114,7 @@ impl MemTrieNodeId {
     pub(crate) fn new_impl(
         arena: &mut impl ArenaMut,
         node: InputMemTrieNode,
-        node_hash: Option<CryptoHash>,
+        node_hash_and_memory_usage: Option<(CryptoHash, u64)>,
     ) -> Self {
         // We add reference to all the children when creating the node.
         // As for the refcount of this newly created node, it starts at 0.
@@ -136,10 +136,13 @@ impl MemTrieNodeId {
             _ => {}
         }
         // Prepare the raw node, for memory usage and hash computation.
-        let raw_node_with_size = if matches!(&node, InputMemTrieNode::Leaf { .. }) {
+        let node_hash_and_memory_usage = if matches!(&node, InputMemTrieNode::Leaf { .. }) {
             None
         } else {
-            Some(node.to_raw_trie_node_with_size_non_leaf(arena.memory()))
+            Some(node_hash_and_memory_usage.unwrap_or_else(|| {
+                let raw_node_with_size = node.to_raw_trie_node_with_size_non_leaf(arena.memory());
+                (raw_node_with_size.hash(), raw_node_with_size.memory_usage)
+            }))
         };
 
         // Finally, encode the data.
@@ -168,13 +171,10 @@ impl MemTrieNodeId {
                     arena,
                     ExtensionHeader::SERIALIZED_SIZE + extension_header.flexible_data_length(),
                 );
-                let raw_node_with_size = raw_node_with_size.unwrap();
+                let (node_hash, memory_usage) = node_hash_and_memory_usage.unwrap();
                 data.encode(ExtensionHeader {
                     common: CommonHeader { refcount: 0, kind: NodeKind::Extension },
-                    nonleaf: NonLeafHeader::new(
-                        raw_node_with_size.memory_usage,
-                        node_hash.unwrap_or_else(|| raw_node_with_size.hash()),
-                    ),
+                    nonleaf: NonLeafHeader::new(memory_usage, node_hash),
                     child: child.pos,
                     extension: extension_header,
                 });
@@ -187,13 +187,10 @@ impl MemTrieNodeId {
                     arena,
                     BranchHeader::SERIALIZED_SIZE + children_header.flexible_data_length(),
                 );
-                let raw_node_with_size = raw_node_with_size.unwrap();
+                let (node_hash, memory_usage) = node_hash_and_memory_usage.unwrap();
                 data.encode(BranchHeader {
                     common: CommonHeader { refcount: 0, kind: NodeKind::Branch },
-                    nonleaf: NonLeafHeader::new(
-                        raw_node_with_size.memory_usage,
-                        node_hash.unwrap_or_else(|| raw_node_with_size.hash()),
-                    ),
+                    nonleaf: NonLeafHeader::new(memory_usage, node_hash),
                     children: children_header,
                 });
                 data.encode_flexible(&children_header, &children);
@@ -208,13 +205,10 @@ impl MemTrieNodeId {
                         + children_header.flexible_data_length()
                         + value_header.flexible_data_length(),
                 );
-                let raw_node_with_size = raw_node_with_size.unwrap();
+                let (node_hash, memory_usage) = node_hash_and_memory_usage.unwrap();
                 data.encode(BranchWithValueHeader {
                     common: CommonHeader { refcount: 0, kind: NodeKind::BranchWithValue },
-                    nonleaf: NonLeafHeader::new(
-                        raw_node_with_size.memory_usage,
-                        node_hash.unwrap_or_else(|| raw_node_with_size.hash()),
-                    ),
+                    nonleaf: NonLeafHeader::new(memory_usage, node_hash),
                     children: children_header,
                     value: value_header,
                 });

--- a/core/store/src/trie/mem/node/mod.rs
+++ b/core/store/src/trie/mem/node/mod.rs
@@ -32,12 +32,13 @@ impl MemTrieNodeId {
         Self::new_impl(arena, input, None)
     }
 
-    pub fn new_with_hash(
+    pub fn new_with_hash_and_memory_usage(
         arena: &mut impl ArenaMut,
         input: InputMemTrieNode,
         hash: CryptoHash,
+        memory_usage: u64,
     ) -> Self {
-        Self::new_impl(arena, input, Some(hash))
+        Self::new_impl(arena, input, Some((hash, memory_usage)))
     }
 
     pub fn as_ptr<'a, M: ArenaMemory>(&self, arena: &'a M) -> MemTrieNodePtr<'a, M> {


### PR DESCRIPTION
Even when the node hash is computed (ie. we already serialized it once), during computing the new root, we end up calling `to_raw_trie_node_with_size_non_leaf` in apply_memtries with `new_with_hash`.

Since we already know the memory usage & hashes for the nodes as well we can pass it in and avoid the call to `to_raw_trie_node_with_size_non_leaf`. This could shorten the time of applying memtries.