### PR TITLE
Migrate all `spawn_actix_actor` to `spawn_tokio_actor`.

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -195,7 +195,7 @@ pub fn start_client(
 
     let client_sender_for_sync_jobs = LateBoundSender::<ClientSenderForSyncJobs>::new();
     let sync_jobs_actor = SyncJobsActor::new(client_sender_for_sync_jobs.as_multi_sender());
-    let sync_jobs_actor_addr = sync_jobs_actor.spawn_actix_actor();
+    let sync_jobs_actor_addr = actor_system.spawn_tokio_actor(sync_jobs_actor);
 
     // Create chunk validation actor
     let genesis_block = client.chain.genesis_block();

--- a/chain/client/src/sync_jobs_actor.rs
+++ b/chain/client/src/sync_jobs_actor.rs
@@ -1,14 +1,9 @@
-use actix::Actor;
-use near_async::actix::wrapper::ActixWrapper;
 use near_async::messaging::{self, CanSend, Handler, Sender};
 use near_async::{MultiSend, MultiSenderFrom};
 use near_chain::chain::{BlockCatchUpRequest, BlockCatchUpResponse, do_apply_chunks};
 use near_o11y::span_wrapped_msg::{SpanWrapped, SpanWrappedMessageExt};
 use near_performance_metrics_macros::perf;
 use near_primitives::optimistic_block::BlockToApply;
-
-// Set the mailbox capacity for the SyncJobsActor from default 16 to 100.
-const MAILBOX_CAPACITY: usize = 100;
 
 #[derive(Clone, MultiSend, MultiSenderFrom)]
 pub struct ClientSenderForSyncJobs {
@@ -31,16 +26,6 @@ impl Handler<BlockCatchUpRequest> for SyncJobsActor {
 impl SyncJobsActor {
     pub fn new(client_sender: ClientSenderForSyncJobs) -> Self {
         Self { client_sender }
-    }
-
-    pub fn spawn_actix_actor(self) -> actix::Addr<ActixWrapper<Self>> {
-        let actix_wrapper = ActixWrapper::new(self);
-        let arbiter = actix::Arbiter::new().handle();
-        let addr = ActixWrapper::<Self>::start_in_arbiter(&arbiter, |ctx| {
-            ctx.set_mailbox_capacity(MAILBOX_CAPACITY);
-            actix_wrapper
-        });
-        addr
     }
 
     pub fn handle_block_catch_up_request(&mut self, msg: BlockCatchUpRequest) {

--- a/core/async/src/actix/wrapper.rs
+++ b/core/async/src/actix/wrapper.rs
@@ -1,6 +1,6 @@
 use std::ops::{Deref, DerefMut};
 
-use actix::{Actor, SyncArbiter};
+use actix::SyncArbiter;
 
 use crate::futures::DelayedActionRunner;
 use crate::messaging;
@@ -89,18 +89,6 @@ where
     fn handle(&mut self, msg: M, _ctx: &mut Self::Context) -> Self::Result {
         self.actor.handle(msg)
     }
-}
-
-/// Spawns an actix actor with the given actor. Returns the address of the actor and the arbiter
-/// Note that the actor should implement the Handler trait for all the messages it would like to handle.
-pub fn spawn_actix_actor<T>(actor: T) -> (actix::Addr<ActixWrapper<T>>, actix::ArbiterHandle)
-where
-    T: messaging::Actor + Unpin + Send + 'static,
-{
-    let actix_wrapper = ActixWrapper::new(actor);
-    let arbiter = actix::Arbiter::new().handle();
-    let addr = ActixWrapper::<T>::start_in_arbiter(&arbiter, |_| actix_wrapper);
-    (addr, arbiter)
 }
 
 /// Spawns the actor returned by the factory function in a SyncArbiter,


### PR DESCRIPTION
The following actors now use tokio-based runtime:
* ShardsManagerActor
* SyncJobsActor
* PartialWitnessActor
* ReshardingActor
* GCActor
* StateRequestActor

Actors still on Actix:
* All sync actors, such as ViewClientActor and RpcHandlerActor - requires replacement sync runtime implementation
* Network actors (PeerManagerActor and PeerActor) - requires partial migration to near-async framework as well as runtime cancellation implementation
* TelemetryActor - requires making the actor Send.