### PR TITLE
feat: increase validators number to 500

### DIFF
--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -37,7 +37,7 @@ fn build_chain() {
         insta::assert_snapshot!(hash, @"24ZC3eGVvtFdTEok4wPGBzx3x61tWqQpves7nFvow2zf");
     } else {
         // cspell:disable-next-line
-        insta::assert_snapshot!(hash, @"8786LxDz73XhJQroRrqBcxgDxAmntKR724w7vWPHPVq5");
+        insta::assert_snapshot!(hash, @"6dPrdK9cqmJv5fRGBVMHTjFD1dPGeJqWTpJf1C32AXhT");
     }
 
     for i in 1..5 {
@@ -57,7 +57,7 @@ fn build_chain() {
         insta::assert_snapshot!(hash, @"9enFQNcVUW65x3oW2iVdYSBxK9qFNETAixEQZLzXWeaQ");
     } else {
         // cspell:disable-next-line
-        insta::assert_snapshot!(hash, @"6amtpQxcJYguKKEh4DUpgzrtJQ1JSJ9ivW8VQqf9Z2v2");
+        insta::assert_snapshot!(hash, @"5c3drE3U9PTYLo2tMnwWZh8iX67NcDr8ozJg1MwwX28p");
     }
 }
 

--- a/chain/jsonrpc/jsonrpc-tests/res/genesis_config.json
+++ b/chain/jsonrpc/jsonrpc-tests/res/genesis_config.json
@@ -1,5 +1,5 @@
 {
-  "protocol_version": 79,
+  "protocol_version": 80,
   "genesis_time": "1970-01-01T00:00:00.000000000Z",
   "chain_id": "sample",
   "genesis_height": 0,

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -445,7 +445,7 @@ pub const PROD_GENESIS_PROTOCOL_VERSION: ProtocolVersion = 29;
 pub const MIN_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = 77;
 
 /// Current protocol version used on the mainnet with all stable features.
-const STABLE_PROTOCOL_VERSION: ProtocolVersion = 79;
+const STABLE_PROTOCOL_VERSION: ProtocolVersion = 80;
 
 // On nightly, pick big enough version to support all features.
 const NIGHTLY_PROTOCOL_VERSION: ProtocolVersion = 149;

--- a/core/primitives/res/epoch_configs/mainnet/80.json
+++ b/core/primitives/res/epoch_configs/mainnet/80.json
@@ -9,9 +9,11 @@
     100,
     100,
     100,
+    100,
     100
   ],
   "avg_hidden_validator_seats_per_shard": [
+    0,
     0,
     0,
     0,
@@ -43,6 +45,7 @@
   "shard_layout": {
     "V2": {
       "boundary_accounts": [
+        "650",
         "aurora",
         "aurora-0",
         "earn.kaiching",
@@ -52,7 +55,8 @@
         "tge-lockup.sweat"
       ],
       "shard_ids": [
-        0,
+        10,
+        11,
         1,
         8,
         9,
@@ -62,35 +66,34 @@
         5
       ],
       "id_to_index_map": {
-        "0": 0,
-        "1": 1,
-        "4": 6,
-        "5": 7,
-        "6": 4,
-        "7": 5,
-        "8": 2,
-        "9": 3
+        "1": 2,
+        "10": 0,
+        "11": 1,
+        "4": 7,
+        "5": 8,
+        "6": 5,
+        "7": 6,
+        "8": 3,
+        "9": 4
       },
       "index_to_id_map": {
-        "0": 0,
-        "1": 1,
-        "2": 8,
-        "3": 9,
-        "4": 6,
-        "5": 7,
-        "6": 4,
-        "7": 5
+        "0": 10,
+        "1": 11,
+        "2": 1,
+        "3": 8,
+        "4": 9,
+        "5": 6,
+        "6": 7,
+        "7": 4,
+        "8": 5
       },
       "shards_split_map": {
         "0": [
-          0
+          10,
+          11
         ],
         "1": [
           1
-        ],
-        "2": [
-          8,
-          9
         ],
         "4": [
           4
@@ -103,17 +106,24 @@
         ],
         "7": [
           7
+        ],
+        "8": [
+          8
+        ],
+        "9": [
+          9
         ]
       },
       "shards_parent_map": {
-        "0": 0,
         "1": 1,
+        "10": 0,
+        "11": 0,
         "4": 4,
         "5": 5,
         "6": 6,
         "7": 7,
-        "8": 2,
-        "9": 2
+        "8": 8,
+        "9": 9
       },
       "version": 3
     }
@@ -127,5 +137,5 @@
     62500
   ],
   "chunk_producer_assignment_changes_limit": 5,
-  "shuffle_shard_assignment_for_chunk_producers": true
+  "shuffle_shard_assignment_for_chunk_producers": false
 }

--- a/core/primitives/res/epoch_configs/testnet/143.json
+++ b/core/primitives/res/epoch_configs/testnet/143.json
@@ -24,7 +24,7 @@
   "block_producer_kickout_threshold": 80,
   "chunk_producer_kickout_threshold": 80,
   "chunk_validator_only_kickout_threshold": 70,
-  "target_validator_mandates_per_shard": 68,
+  "target_validator_mandates_per_shard": 105,
   "validator_max_kickout_stake_perc": 30,
   "online_min_threshold": [
     90,
@@ -119,7 +119,7 @@
     }
   },
   "num_chunk_producer_seats": 20,
-  "num_chunk_validator_seats": 300,
+  "num_chunk_validator_seats": 500,
   "num_chunk_only_producer_seats": 0,
   "minimum_validators_per_shard": 1,
   "minimum_stake_ratio": [

--- a/core/primitives/res/epoch_configs/testnet/80.json
+++ b/core/primitives/res/epoch_configs/testnet/80.json
@@ -1,17 +1,19 @@
 {
   "epoch_length": 43200,
-  "num_block_producer_seats": 100,
+  "num_block_producer_seats": 20,
   "num_block_producer_seats_per_shard": [
-    100,
-    100,
-    100,
-    100,
-    100,
-    100,
-    100,
-    100
+    20,
+    20,
+    20,
+    20,
+    20,
+    20,
+    20,
+    20,
+    20
   ],
   "avg_hidden_validator_seats_per_shard": [
+    0,
     0,
     0,
     0,
@@ -43,6 +45,7 @@
   "shard_layout": {
     "V2": {
       "boundary_accounts": [
+        "650",
         "aurora",
         "aurora-0",
         "earn.kaiching",
@@ -52,7 +55,8 @@
         "tge-lockup.sweat"
       ],
       "shard_ids": [
-        0,
+        10,
+        11,
         1,
         8,
         9,
@@ -62,35 +66,34 @@
         5
       ],
       "id_to_index_map": {
-        "0": 0,
-        "1": 1,
-        "4": 6,
-        "5": 7,
-        "6": 4,
-        "7": 5,
-        "8": 2,
-        "9": 3
+        "1": 2,
+        "10": 0,
+        "11": 1,
+        "4": 7,
+        "5": 8,
+        "6": 5,
+        "7": 6,
+        "8": 3,
+        "9": 4
       },
       "index_to_id_map": {
-        "0": 0,
-        "1": 1,
-        "2": 8,
-        "3": 9,
-        "4": 6,
-        "5": 7,
-        "6": 4,
-        "7": 5
+        "0": 10,
+        "1": 11,
+        "2": 1,
+        "3": 8,
+        "4": 9,
+        "5": 6,
+        "6": 7,
+        "7": 4,
+        "8": 5
       },
       "shards_split_map": {
         "0": [
-          0
+          10,
+          11
         ],
         "1": [
           1
-        ],
-        "2": [
-          8,
-          9
         ],
         "4": [
           4
@@ -103,22 +106,29 @@
         ],
         "7": [
           7
+        ],
+        "8": [
+          8
+        ],
+        "9": [
+          9
         ]
       },
       "shards_parent_map": {
-        "0": 0,
         "1": 1,
+        "10": 0,
+        "11": 0,
         "4": 4,
         "5": 5,
         "6": 6,
         "7": 7,
-        "8": 2,
-        "9": 2
+        "8": 8,
+        "9": 9
       },
       "version": 3
     }
   },
-  "num_chunk_producer_seats": 100,
+  "num_chunk_producer_seats": 20,
   "num_chunk_validator_seats": 500,
   "num_chunk_only_producer_seats": 0,
   "minimum_validators_per_shard": 1,
@@ -127,5 +137,5 @@
     62500
   ],
   "chunk_producer_assignment_changes_limit": 5,
-  "shuffle_shard_assignment_for_chunk_producers": true
+  "shuffle_shard_assignment_for_chunk_producers": false
 }

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -304,6 +304,7 @@ static CONFIGS: &[(&str, ProtocolVersion, &str)] = &[
     include_config!("mainnet", 75, "75.json"),
     include_config!("mainnet", 76, "76.json"),
     include_config!("mainnet", 78, "78.json"),
+    include_config!("mainnet", 80, "80.json"),
     include_config!("mainnet", 143, "143.json"),
     // Epoch configs for testnet (genesis protocol version is 29).
     include_config!("testnet", 29, "29.json"),
@@ -318,6 +319,7 @@ static CONFIGS: &[(&str, ProtocolVersion, &str)] = &[
     include_config!("testnet", 75, "75.json"),
     include_config!("testnet", 76, "76.json"),
     include_config!("testnet", 78, "78.json"),
+    include_config!("testnet", 80, "80.json"),
     include_config!("testnet", 143, "143.json"),
 ];
 
@@ -521,6 +523,15 @@ mod tests {
             EpochConfigStore::load_epoch_config_from_file_system(tmp_dir.path().to_str().unwrap()),
         );
         assert_ne!(loaded_epoch_configs.store, loaded_after_insert_epoch_configs.store);
+    }
+
+    #[test]
+    fn test_protocol_upgrade_80() {
+        for chain_id in ["mainnet", "testnet"] {
+            let epoch_configs = EpochConfigStore::for_chain_id(chain_id, None).unwrap();
+            let epoch_config = epoch_configs.get_config(80);
+            assert_eq!(epoch_config.num_chunk_validator_seats, 500);
+        }
     }
 
     fn parse_config_file(chain_id: &str, protocol_version: ProtocolVersion) -> Option<EpochConfig> {


### PR DESCRIPTION
And increase number of validator mandates per shard to 105, as discussed here [#nearone/private > 2.8 release - more partial seats @ 💬](https://near.zulipchat.com/#narrow/channel/308695-nearone.2Fprivate/topic/2.2E8.20release.20-.20more.20partial.20seats/near/532980422)

Next step is to cherry-pick this on 2.8.0.

@VanBarbascu could you remind why we wanted to create protocol version 81? No one seems to use 80 so far.