### PR TITLE
feat(forknet): label based selection

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -791,6 +791,8 @@ class GCloudNode(BaseNode):
     def __init__(self, *args, username=None, project=None, ssh_key_path=None):
         self.port = 24567
         self.rpc_port = 3030
+        # Everything you need to know about the GCloud instance
+        self.gcloud_instance = None
         if len(args) == 1:
             # Get existing instance assume it's ready to run.
             if isinstance(args[0], Machine):
@@ -847,8 +849,25 @@ class GCloudNode(BaseNode):
         return self
 
     def get_label(self, label_name: str) -> str:
-        #TODO: make it error resistant
-        return self.gcloud_instance.labels.get(label_name)
+        """
+        Get a specific label value.
+        This is the cached information from the GCloud instance.
+
+        Args:
+            label_name: The name of the label to retrieve
+
+        Returns:
+            The label value as a string, or None if the label doesn't exist
+        """
+        try:
+            if self.gcloud_instance and hasattr(self.gcloud_instance, 'labels'):
+                # labels is MutableMapping[str, str] - access like a dictionary
+                return self.gcloud_instance.labels.get(label_name)
+            return None
+        except Exception as e:
+            logger.error(
+                f"Failed to get label '{label_name}' from instance: {e}")
+            return None
 
     @retry(wait_fixed=1000, stop_max_attempt_number=3)
     def _download_binary(self, binary):

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -18,9 +18,14 @@ import traceback
 import typing
 import uuid
 from rc import gcloud
+from rc.machine import Machine
 from retrying import retry
 
 import base58
+
+# Google Cloud Compute API imports
+from google.cloud import compute_v1
+from google.cloud.compute_v1.types import AggregatedListInstancesRequest
 
 import network
 from configured_logger import logger
@@ -723,24 +728,86 @@ class LocalNode(BaseNode):
 
 class GCloudNode(BaseNode):
 
+    @staticmethod
+    def get_nodes_by_mocknet_id(mocknet_id,
+                                project,
+                                username,
+                                ssh_key_path=None):
+        """
+        Get all instances with the specified mocknet_id label.
+
+        Args:
+            mocknet_id: The mocknet_id label value to filter by
+            project: Google Cloud project ID
+            username: SSH username for the instances
+            ssh_key_path: Path to SSH key file
+
+        Returns:
+            List of GCloudNode instances
+        """
+        if ssh_key_path is None:
+            ssh_key_path = gcloud.SSH_KEY_PATH
+
+        # Initialize the Compute Engine client
+        client = compute_v1.InstancesClient()
+
+        # Use aggregated list to search across all zones efficiently
+        request = compute_v1.AggregatedListInstancesRequest(
+            project=project, filter=f'labels.mocknet_id={mocknet_id}')
+
+        instances = []
+        try:
+            logger.info(
+                f"Searching for instances with mocknet_id={mocknet_id} in project={project} (all zones)"
+            )
+
+            # Use the aggregated list iterator to handle pagination automatically
+            for zone_name, zone_data in client.aggregated_list(request=request):
+                # aggregated_list returns (zone_name, zone_data) tuples
+                if hasattr(zone_data, 'instances') and zone_data.instances:
+                    for instance in zone_data.instances:
+                        logger.info(
+                            f"Found instance: {instance.name} in zone: {zone_name}"
+                        )
+                        machine = Machine(
+                            name=instance.name,
+                            provider=gcloud.gcloud_provider,
+                            ip=instance.network_interfaces[0].access_configs[0].
+                            nat_i_p if instance.network_interfaces else None,
+                            username=username,
+                            project=project,
+                            ssh_key_path=ssh_key_path)
+                        instances.append(
+                            GCloudNode(machine).with_instance_info(instance))
+        except Exception as e:
+            logger.error(
+                f"Failed to list instances with mocknet_id {mocknet_id}: {e}")
+            return []
+
+        logger.info(
+            f"Found {len(instances)} instances with mocknet_id={mocknet_id}")
+        return instances
+
     def __init__(self, *args, username=None, project=None, ssh_key_path=None):
+        self.port = 24567
+        self.rpc_port = 3030
         if len(args) == 1:
-            name = args[0]
             # Get existing instance assume it's ready to run.
-            self.instance_name = name
-            self.port = 24567
-            self.rpc_port = 3030
-            self.machine = gcloud.get(name,
-                                      username=username,
-                                      project=project,
-                                      ssh_key_path=ssh_key_path)
+            if isinstance(args[0], Machine):
+                self.machine = args[0]
+            elif isinstance(args[0], str):
+                name = args[0]
+                self.machine = gcloud.get(name,
+                                          username=username,
+                                          project=project,
+                                          ssh_key_path=ssh_key_path)
+            self.instance_name = self.machine.name
             self.ip = self.machine.ip
         elif len(args) == 4:
             # Create new instance from scratch
             instance_name, zone, node_dir, binary = args
             self.instance_name = instance_name
-            self.port = 24567
-            self.rpc_port = 3030
+
             self.node_dir = node_dir
             self.machine = gcloud.create(
                 name=instance_name,
@@ -774,6 +841,10 @@ class GCloudNode(BaseNode):
             os.path.join(node_dir, "node_key.json"))
         self.signer_key = Key.from_json_file(
             os.path.join(node_dir, "validator_key.json"))
+
+    def with_instance_info(self, instance):
+        self.gcloud_instance = instance
+        return self
 
     @retry(wait_fixed=1000, stop_max_attempt_number=3)
     def _download_binary(self, binary):

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -25,7 +25,7 @@ import base58
 
 # Google Cloud Compute API imports
 from google.cloud import compute_v1
-from google.cloud.compute_v1.types import AggregatedListInstancesRequest
+from google.cloud.compute_v1.types import AggregatedListInstancesRequest, Instance
 
 import network
 from configured_logger import logger
@@ -842,9 +842,13 @@ class GCloudNode(BaseNode):
         self.signer_key = Key.from_json_file(
             os.path.join(node_dir, "validator_key.json"))
 
-    def with_instance_info(self, instance):
+    def with_instance_info(self, instance: Instance):
         self.gcloud_instance = instance
         return self
+
+    def get_label(self, label_name: str) -> str:
+        #TODO: make it error resistant
+        return self.gcloud_instance.labels.get(label_name)
 
     @retry(wait_fixed=1000, stop_max_attempt_number=3)
     def _download_binary(self, binary):

--- a/pytest/lib/mocknet.py
+++ b/pytest/lib/mocknet.py
@@ -102,22 +102,12 @@ def get_node(hostname, project=PROJECT):
 
 
 def get_nodes(pattern=None, project=PROJECT):
-    machines = gcloud.list(
-        pattern=pattern,
+    return GCloudNode.get_nodes_by_mocknet_id(
+        mocknet_id=pattern,
         project=project,
         username=NODE_USERNAME,
         ssh_key_path=NODE_SSH_KEY_PATH,
     )
-    nodes = pmap(
-        lambda machine: GCloudNode(
-            machine.name,
-            username=NODE_USERNAME,
-            project=project,
-            ssh_key_path=NODE_SSH_KEY_PATH,
-        ),
-        machines,
-    )
-    return nodes
 
 
 # Needs to be in-sync with init.sh.tmpl in terraform.

--- a/pytest/requirements.txt
+++ b/pytest/requirements.txt
@@ -6,6 +6,7 @@ deepdiff
 json-rpc
 locust>=2.28
 geventhttpclient>=2.3.1
+google-cloud-compute>=1.0.0
 nearup
 numpy
 prometheus-client

--- a/pytest/tests/mocknet/local_test_node.py
+++ b/pytest/tests/mocknet/local_test_node.py
@@ -72,6 +72,9 @@ class LocalTestNeardRunner:
     def name(self):
         return self._name
 
+    def get_label(self, label_name: str) -> str:
+        return 'local-test-node'
+
     def ip_addr(self):
         return '0.0.0.0'
 

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -136,8 +136,7 @@ class CommandContext:
                 f'cannot give --chain-id, --start-height, --unique-id or --mocknet-id along with --local-test'
             )
             traffic_generator, nodes = local_test_node.get_nodes()
-            node_config.configure_nodes(nodes + to_list(traffic_generator),
-                                        node_config.TEST_CONFIG)
+            node_config.configure_nodes(nodes + to_list(traffic_generator))
         self.traffic_generator = traffic_generator
         self.nodes = nodes
 
@@ -157,8 +156,7 @@ class CommandContext:
                 f'must give all of --chain-id --start-height and --unique-id or --mocknet-id'
             )
         traffic_generator, nodes = remote_node.get_nodes(mocknet_id)
-        node_config.configure_nodes(nodes + to_list(traffic_generator),
-                                    node_config.REMOTE_CONFIG)
+        node_config.configure_nodes(nodes + to_list(traffic_generator))
         self.traffic_generator = traffic_generator
         self.nodes = nodes
 

--- a/pytest/tests/mocknet/node_config.py
+++ b/pytest/tests/mocknet/node_config.py
@@ -4,81 +4,52 @@ Mocknet node configuration.
 This module contains the configuration for the mocknet nodes.
 It is used to configure the nodes for the test.
 """
-import sys
+import logging
 
-
-# TODO: these should be identified by tags
-def _is_tracing_server(node):
-    return node.name().endswith('tracing-server')
-
-
-def _is_dumper(node):
-    return node.name().endswith('dumper')
-
-
-def _is_archival(node):
-    return '-archival-' in node.name()
-
-
-REMOTE_CONFIG = [
-    {
-        'node_matches': _is_dumper,
+CONFIG_BY_ROLE = {
+    'validator': {
+        'can_validate': True,
+        'want_state_dump': False,
+        'want_neard_runner': True,
+    },
+    'producer': {
+        'can_validate': True,
+        'want_state_dump': False,
+        'want_neard_runner': True,
+    },
+    'mocknet-archival': {
+        'can_validate': False,
+        'want_state_dump': False,
+        'want_neard_runner': True,
+    },
+    'state-dumper': {
         'can_validate': False,
         'want_state_dump': True,
         'want_neard_runner': True,
     },
-    {
-        'node_matches': _is_tracing_server,
-        'can_validate': False,
-        'want_state_dump': False,
-        'want_neard_runner': False,
-    },
-    {
-        'node_matches': _is_archival,
+    'traffic': {
         'can_validate': False,
         'want_state_dump': False,
         'want_neard_runner': True,
     },
-]
-
-
-def _is_two(node):
-    return node.name() == 'node2'
-
-
-def _is_three(node):
-    return node.name() == 'node3'
-
-
-TEST_CONFIG = [
-    # {
-    #     'node_matches': _is_two,
-    #     'can_validate': False,
-    #     'want_state_dump': True,
-    #     'want_neard_runner': True,
-    # },
-    # {
-    #     'node_matches': _is_three,
-    #     'can_validate': False,
-    #     'want_state_dump': False,
-    #     'want_neard_runner': False,
-    # },
-]
+    'mocknet-tracing-server': {
+        'can_validate': False,
+        'want_state_dump': False,
+        'want_neard_runner': False,
+    },
+}
 
 
 # set attributes (e.g. do we want this node to possibly validate?) on this particular node
-def configure_nodes(nodes, node_setup_config):
+def configure_nodes(nodes):
     for node in nodes:
-        node_config = None
-        for c in node_setup_config:
-            if c['node_matches'](node):
-                if node_config is not None:
-                    sys.exit(
-                        f'multiple node configuration matches for {node.name()}'
-                    )
-                node_config = c
-        if node_config is None:
+        role = node.role()
+        if role not in CONFIG_BY_ROLE:
+            logging.error(f'unknown role: {role}. Skipping node {node.name()}')
             continue
+
+        node_config = CONFIG_BY_ROLE[role]
+
         node.can_validate = node_config['can_validate']
         node.want_neard_runner = node_config['want_neard_runner']
         node.want_state_dump = node_config['want_state_dump']

--- a/pytest/tests/mocknet/node_handle.py
+++ b/pytest/tests/mocknet/node_handle.py
@@ -36,6 +36,9 @@ class NodeHandle:
     def name(self):
         return self.node.name()
 
+    def role(self):
+        return self.node.get_label('role')
+
     def ip_addr(self):
         return self.node.ip_addr()
 

--- a/pytest/tests/mocknet/remote_node.py
+++ b/pytest/tests/mocknet/remote_node.py
@@ -31,6 +31,9 @@ class RemoteNeardRunner:
     def name(self):
         return self.node.instance_name
 
+    def get_label(self, label_name: str) -> str:
+        return self.node.get_label(label_name)
+
     def ip_addr(self):
         return self.node.machine.ip
 


### PR DESCRIPTION
## Context
Previously the host clasification was done by hostname. 

## Proposed changes
This PR proposes a more reliable clasification using GCloud host labels.
This will remove the need to assign long names to hosts in forknet and fix the bug preventing overlapping mockent_ids such as: `test` and  `testing-something`.

This feature is required to enable chunk only validator hardware in mocknet. 