### PR TITLE
Prepare `2.7.0` mainnet release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,7 +1248,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chainsync-loadtest"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "cold-store-tool"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "congestion-model"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "bytesize",
  "chrono",
@@ -2255,7 +2255,7 @@ dependencies = [
 
 [[package]]
 name = "estimator-warehouse"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-csv-to-json"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "genesis-populate"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "borsh",
  "clap",
@@ -3344,7 +3344,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-example"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3579,7 +3579,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "keypair-generator"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "clap",
  "near-crypto",
@@ -4024,7 +4024,7 @@ dependencies = [
 
 [[package]]
 name = "mock-node"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4104,7 +4104,7 @@ dependencies = [
 
 [[package]]
 name = "near-actix-test-utils"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix-rt",
  "near-store",
@@ -4113,7 +4113,7 @@ dependencies = [
 
 [[package]]
 name = "near-amend-genesis"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "futures",
@@ -4151,7 +4151,7 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -4161,7 +4161,7 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "bencher",
  "lru 0.12.3",
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -4223,7 +4223,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "near-crypto",
  "near-primitives",
@@ -4259,7 +4259,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "assert_matches",
@@ -4288,7 +4288,7 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -4296,7 +4296,7 @@ dependencies = [
 
 [[package]]
 name = "near-client"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4353,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "near-chain-configs",
@@ -4370,7 +4370,7 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "blake2",
  "bolero",
@@ -4409,7 +4409,7 @@ dependencies = [
 
 [[package]]
 name = "near-database-tool"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4435,7 +4435,7 @@ dependencies = [
 
 [[package]]
 name = "near-dump-test-contract"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4444,7 +4444,7 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -4458,7 +4458,7 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -4482,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "near-flat-storage"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4499,14 +4499,14 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "near-primitives-core",
 ]
 
 [[package]]
 name = "near-fork-network"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -4533,7 +4533,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "near-primitives",
  "serde",
@@ -4566,7 +4566,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -4590,7 +4590,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-adversarial-primitives"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "near-primitives",
  "serde",
@@ -4598,7 +4598,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "awc",
  "futures",
@@ -4610,7 +4610,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-fuzz"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "arbitrary",
@@ -4628,7 +4628,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-openapi-spec"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "near-chain-configs",
  "near-crypto",
@@ -4643,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -4661,7 +4661,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-tests"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "awc",
@@ -4690,7 +4690,7 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -4700,7 +4700,7 @@ dependencies = [
 
 [[package]]
 name = "near-mirror"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -4744,7 +4744,7 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -4799,7 +4799,7 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "base64 0.21.0",
@@ -4828,7 +4828,7 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "assert_matches",
  "borsh",
@@ -4849,7 +4849,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "bytesize",
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "quote",
  "syn 2.0.87",
@@ -4869,7 +4869,7 @@ dependencies = [
 
 [[package]]
 name = "near-ping"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "borsh",
  "near-crypto",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "arbitrary",
  "assert_matches",
@@ -4946,7 +4946,7 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "arbitrary",
  "base64 0.21.0",
@@ -4969,7 +4969,7 @@ dependencies = [
 
 [[package]]
 name = "near-replay-archive-tool"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "actix-cors",
@@ -5020,14 +5020,14 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "inventory",
 ]
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "inventory",
  "near-schema-checker-core",
@@ -5036,7 +5036,7 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5045,11 +5045,11 @@ dependencies = [
 
 [[package]]
 name = "near-stable-hasher"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 
 [[package]]
 name = "near-state-parts"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -5067,7 +5067,7 @@ dependencies = [
 
 [[package]]
 name = "near-state-parts-dump-check"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "actix-web",
@@ -5090,11 +5090,11 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 
 [[package]]
 name = "near-store"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5147,7 +5147,7 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "awc",
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "near-test-contracts"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "arbitrary",
  "rand 0.8.5",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "parking_lot 0.12.1",
  "schemars 1.0.0-alpha.17",
@@ -5187,7 +5187,7 @@ dependencies = [
 
 [[package]]
 name = "near-transactions-generator"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -5208,7 +5208,7 @@ dependencies = [
 
 [[package]]
 name = "near-undo-block"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5224,7 +5224,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -5239,7 +5239,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "dynasm",
  "dynasmrt",
@@ -5258,7 +5258,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-test-derive"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "pretty_assertions",
  "proc-macro2",
@@ -5269,7 +5269,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "backtrace",
  "finite-wasm",
@@ -5287,7 +5287,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -5349,7 +5349,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner-fuzz"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "libfuzzer-sys",
  "near-parameters",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-api"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -5388,14 +5388,14 @@ dependencies = [
 
 [[package]]
 name = "near-vm-test-generator"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "near-vm-types"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "bolero",
  "indexmap 2.7.0",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "backtrace",
  "cc",
@@ -5426,7 +5426,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-wast"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "near-vm-test-api",
@@ -5436,7 +5436,7 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "near-primitives-core",
@@ -5445,7 +5445,7 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5508,7 +5508,7 @@ dependencies = [
 
 [[package]]
 name = "neard"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -5578,7 +5578,7 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "assert_matches",
  "base64 0.21.0",
@@ -6493,7 +6493,7 @@ dependencies = [
 
 [[package]]
 name = "protocol-schema-check"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "inventory",
  "near-chain",
@@ -6927,7 +6927,7 @@ dependencies = [
 
 [[package]]
 name = "restaked"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "clap",
  "integration-tests",
@@ -7034,7 +7034,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-params-estimator"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "bs58 0.4.0",
@@ -7071,7 +7071,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "bolero",
  "cpu-time",
@@ -7099,7 +7099,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-tester-fuzz"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "libfuzzer-sys",
  "runtime-tester",
@@ -7781,7 +7781,7 @@ dependencies = [
 
 [[package]]
 name = "speedy_sync"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "borsh",
  "clap",
@@ -7823,7 +7823,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "state-viewer"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -7874,7 +7874,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-usage-delta-calculator"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -7889,7 +7889,7 @@ dependencies = [
 
 [[package]]
 name = "store-validator"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "clap",
  "near-chain",
@@ -8096,7 +8096,7 @@ dependencies = [
 
 [[package]]
 name = "test-loop-tests"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "actix",
  "assert_matches",
@@ -8132,7 +8132,7 @@ dependencies = [
 
 [[package]]
 name = "testlib"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "bytesize",
  "near-chain",
@@ -8148,7 +8148,7 @@ dependencies = [
 
 [[package]]
 name = "themis"
-version = "2.7.0-rc.4"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "2.7.0-rc.4"                               # managed by cargo-workspaces, see below
+version = "2.7.0"                               # managed by cargo-workspaces, see below
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2024"
 rust-version = "1.86.0"
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 # anything to the list of stable crates.
 # Only bump  0.x.* to 0.(x+1).0 on any nearcore release as nearcore does not guarantee
 # semver compatibility. i.e. api can change without a protocol upgrade.
-version = "0.31.0-rc.4"
+version = "0.31.0"
 exclude = ["neard"]
 
 [workspace]

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -56,7 +56,11 @@ pub fn get_protocol_upgrade_schedule(chain_id: &str) -> ProtocolUpgradeVotingSch
     // let schedule = vec![(v1_datetime, v1_protocol_version), (v2_datetime, v2_protocol_version)];
     let schedule = match chain_id {
         MAINNET => {
-            let schedule = vec![];
+            // Voting starts Monday 01:00 UTC.
+            let v1_protocol_version = 79;
+            let v1_datetime =
+                ProtocolUpgradeVotingSchedule::parse_datetime("2025-08-18 01:00:00").unwrap();
+            let schedule = vec![(v1_datetime, v1_protocol_version)];
             schedule
         }
         TESTNET => {


### PR DESCRIPTION
Prepare `2.7.0` mainnet release

* Set neard version to `2.7.0`
* Set crates version to `0.31.0`
* Set voting date to Monday 2025-08-18 01:00 UTC - protocol upgrade will happen 7-14 hours later, on 2025-08-18 between 8:00 and 15:00 UTC.

According to our estimation tool the upgrade will happen around 2025-08-18 11:30 UTC

```
$ python3 debug_scripts/estimate_epoch_start_time.py  --url http://34.12.57.51:3030 --num_past_epochs 10 --num_future_epochs 30
Epoch -1: 07 hours, 19 minutes
Epoch -2: 07 hours, 18 minutes
Epoch -3: 07 hours, 18 minutes
Epoch -4: 07 hours, 18 minutes
Epoch -5: 07 hours, 18 minutes
Epoch -6: 07 hours, 19 minutes
Epoch -7: 07 hours, 25 minutes
Epoch -8: 07 hours, 24 minutes
Epoch -9: 07 hours, 20 minutes
Epoch -10: 07 hours, 19 minutes

Exponential weighted average epoch length: 07 hours, 20 minutes
Predicted start of epoch 1: 2025-08-11 18:03:10 UTC+0000 Monday
Predicted start of epoch 2: 2025-08-12 01:23:11 UTC+0000 Tuesday
Predicted start of epoch 3: 2025-08-12 08:43:12 UTC+0000 Tuesday
Predicted start of epoch 4: 2025-08-12 16:03:14 UTC+0000 Tuesday
Predicted start of epoch 5: 2025-08-12 23:23:15 UTC+0000 Tuesday
Predicted start of epoch 6: 2025-08-13 06:43:16 UTC+0000 Wednesday
Predicted start of epoch 7: 2025-08-13 14:03:17 UTC+0000 Wednesday
Predicted start of epoch 8: 2025-08-13 21:23:18 UTC+0000 Wednesday
Predicted start of epoch 9: 2025-08-14 04:43:19 UTC+0000 Thursday
Predicted start of epoch 10: 2025-08-14 12:03:20 UTC+0000 Thursday
Predicted start of epoch 11: 2025-08-14 19:23:21 UTC+0000 Thursday
Predicted start of epoch 12: 2025-08-15 02:43:22 UTC+0000 Friday
Predicted start of epoch 13: 2025-08-15 10:03:23 UTC+0000 Friday
Predicted start of epoch 14: 2025-08-15 17:23:25 UTC+0000 Friday
Predicted start of epoch 15: 2025-08-16 00:43:26 UTC+0000 Saturday
Predicted start of epoch 16: 2025-08-16 08:03:27 UTC+0000 Saturday
Predicted start of epoch 17: 2025-08-16 15:23:28 UTC+0000 Saturday
Predicted start of epoch 18: 2025-08-16 22:43:29 UTC+0000 Saturday
Predicted start of epoch 19: 2025-08-17 06:03:30 UTC+0000 Sunday
Predicted start of epoch 20: 2025-08-17 13:23:31 UTC+0000 Sunday
Predicted start of epoch 21: 2025-08-17 20:43:32 UTC+0000 Sunday
Predicted start of epoch 22: 2025-08-18 04:03:33 UTC+0000 Monday
Predicted start of epoch 23: 2025-08-18 11:23:35 UTC+0000 Monday
Predicted start of epoch 24: 2025-08-18 18:43:36 UTC+0000 Monday
Predicted start of epoch 25: 2025-08-19 02:03:37 UTC+0000 Tuesday
Predicted start of epoch 26: 2025-08-19 09:23:38 UTC+0000 Tuesday
Predicted start of epoch 27: 2025-08-19 16:43:39 UTC+0000 Tuesday
Predicted start of epoch 28: 2025-08-20 00:03:40 UTC+0000 Wednesday
Predicted start of epoch 29: 2025-08-20 07:23:41 UTC+0000 Wednesday
Predicted start of epoch 30: 2025-08-20 14:43:42 UTC+0000 Wednesday
```

Voting date falls into epoch 21.
Protocol upgrade will happen at the start of epoch 23: around 2025-08-18 11:30 UTC Monday