### PR TITLE
fix(forknet): fix neard-runner error handling

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -692,7 +692,11 @@ class NeardRunner:
             logging.error(
                 f'Update binaries failed. Wrong params: url: {neard_binary_url}, height:{epoch_height}, idx:{binary_idx}'
             )
-            raise jsonrpc.exceptions.JSONRPCInvalidParams()
+            raise jsonrpc.exceptions.JSONRPCDispatchException(
+                code=-32602,
+                message=
+                f'Invalid binary params: url: {neard_binary_url}, height:{epoch_height}, idx:{binary_idx}'
+            )
 
         if 'binaries' not in self.config:
             self.config['binaries'] = []

--- a/pytest/tests/mocknet/release_scenarios/base.py
+++ b/pytest/tests/mocknet/release_scenarios/base.py
@@ -61,8 +61,10 @@ class TestSetup:
         hard_reset_cmd(CommandContext(init_args))
 
         # Traffic node should always run the latest binary to avoid restarting it.
-        if self.neard_upgrade_binary_url != '':
-            logger.info(f"Amending binaries on traffic node.")
+        if self.neard_upgrade_binary_url is not None and self.neard_upgrade_binary_url != '':
+            logger.info(
+                f"Amending binaries on traffic node with url: {self.neard_upgrade_binary_url}"
+            )
             amend_binaries_args = copy.deepcopy(self.args)
             amend_binaries_args.binary_idx = 0
             amend_binaries_args.epoch_height = None


### PR DESCRIPTION
This pull request makes improvements to error handling and logging in the mocknet testing helpers, specifically around binary updates and environment initialization. The changes enhance the clarity of error messages and log outputs, making debugging easier.