### PR TITLE
feat(parameters): Equalize cost of touching and reading trie nodes

### DIFF
--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -37,7 +37,7 @@ fn build_chain() {
         insta::assert_snapshot!(hash, @"24ZC3eGVvtFdTEok4wPGBzx3x61tWqQpves7nFvow2zf");
     } else {
         // cspell:disable-next-line
-        insta::assert_snapshot!(hash, @"6dPrdK9cqmJv5fRGBVMHTjFD1dPGeJqWTpJf1C32AXhT");
+        insta::assert_snapshot!(hash, @"29v1yk13bodFUYHAkTG8nRu2SvBScCEESreie3hEmc78");
     }
 
     for i in 1..5 {
@@ -57,7 +57,7 @@ fn build_chain() {
         insta::assert_snapshot!(hash, @"9enFQNcVUW65x3oW2iVdYSBxK9qFNETAixEQZLzXWeaQ");
     } else {
         // cspell:disable-next-line
-        insta::assert_snapshot!(hash, @"5c3drE3U9PTYLo2tMnwWZh8iX67NcDr8ozJg1MwwX28p");
+        insta::assert_snapshot!(hash, @"FwKRg6eY9dSgUWrN45ZxFTeJ8Eqgfwe6s3EboqD1PvhF");
     }
 }
 

--- a/chain/jsonrpc/jsonrpc-tests/res/genesis_config.json
+++ b/chain/jsonrpc/jsonrpc-tests/res/genesis_config.json
@@ -1,5 +1,5 @@
 {
-  "protocol_version": 80,
+  "protocol_version": 81,
   "genesis_time": "1970-01-01T00:00:00.000000000Z",
   "chain_id": "sample",
   "genesis_height": 0,

--- a/core/parameters/res/runtime_configs/81.yaml
+++ b/core/parameters/res/runtime_configs/81.yaml
@@ -2,8 +2,8 @@
 # accesses. This enables simplifying trie access accounting.
 wasm_touching_trie_node: {
   old: { gas: 16_101_955_926, compute: 20_000_000_000 },
-  new: { gas: 2_280_000_000, compute: 20_000_000_000 }
+  new: { gas: 2_280_000_000, compute: 4_000_000_000 }
 }
 wasm_read_cached_trie_node: {
-  old: 2_280_000_000, new: { gas: 2_280_000_000, compute: 20_000_000_000 }
+  old: 2_280_000_000, new: { gas: 2_280_000_000, compute: 4_000_000_000 }
 }

--- a/core/parameters/res/runtime_configs/81.yaml
+++ b/core/parameters/res/runtime_configs/81.yaml
@@ -1,0 +1,9 @@
+# This change equalizes the cost of reading trie nodes for first and subsequent
+# accesses. This enables simplifying trie access accounting.
+wasm_touching_trie_node: {
+  old: { gas: 16_101_955_926, compute: 20_000_000_000 },
+  new: { gas: 2_280_000_000, compute: 20_000_000_000 }
+}
+wasm_read_cached_trie_node: {
+  old: 2_280_000_000, new: { gas: 2_280_000_000, compute: 20_000_000_000 }
+}

--- a/core/parameters/res/runtime_configs/parameters.snap
+++ b/core/parameters/res/runtime_configs/parameters.snap
@@ -134,8 +134,8 @@ wasm_storage_iter_create_to_byte                           0
 wasm_storage_iter_next_base                                0
 wasm_storage_iter_next_key_byte                            0
 wasm_storage_iter_next_value_byte                          0
-wasm_touching_trie_node                        2_280_000_000, compute:       20_000_000_000
-wasm_read_cached_trie_node                     2_280_000_000, compute:       20_000_000_000
+wasm_touching_trie_node                        2_280_000_000, compute:        4_000_000_000
+wasm_read_cached_trie_node                     2_280_000_000, compute:        4_000_000_000
 wasm_promise_and_base                          1_465_013_400
 wasm_promise_and_per_promise                       5_452_176
 wasm_promise_return                              560_152_386

--- a/core/parameters/res/runtime_configs/parameters.snap
+++ b/core/parameters/res/runtime_configs/parameters.snap
@@ -134,8 +134,8 @@ wasm_storage_iter_create_to_byte                           0
 wasm_storage_iter_next_base                                0
 wasm_storage_iter_next_key_byte                            0
 wasm_storage_iter_next_value_byte                          0
-wasm_touching_trie_node                       16_101_955_926, compute:       20_000_000_000
-wasm_read_cached_trie_node                     2_280_000_000
+wasm_touching_trie_node                        2_280_000_000, compute:       20_000_000_000
+wasm_read_cached_trie_node                     2_280_000_000, compute:       20_000_000_000
 wasm_promise_and_base                          1_465_013_400
 wasm_promise_and_per_promise                       5_452_176
 wasm_promise_return                              560_152_386

--- a/core/parameters/src/config_store.rs
+++ b/core/parameters/src/config_store.rs
@@ -57,7 +57,6 @@ static CONFIG_DIFFS: &[(ProtocolVersion, &str)] = &[
     (77, include_config!("77.yaml")),
     (78, include_config!("78.yaml")),
     (79, include_config!("79.yaml")),
-    // Equalizes the cost of reading trie nodes for first and subsequent accesses
     (81, include_config!("81.yaml")),
     (129, include_config!("129.yaml")),
     (149, include_config!("149.yaml")),
@@ -270,7 +269,6 @@ impl RuntimeConfigStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ExtCosts;
     use crate::cost::ActionCosts;
     use std::collections::HashSet;
 
@@ -434,28 +432,5 @@ mod tests {
         let store = RuntimeConfigStore::for_chain_id(near_primitives_core::chains::BENCHMARKNET);
         let config = store.get_config(PROTOCOL_VERSION);
         assert_eq!(config.witness_config.main_storage_proof_size_soft_limit, u64::MAX);
-    }
-
-    // This test ensures that the gas and compute costs for touching and reading
-    // a trie node remain equal. Please do not remove this check as the code
-    // may rely on this behavior after the version upgrade. For example, the
-    // code may no longer differentiate between touching a trie node for the
-    // first time and reading it again.
-    #[test]
-    fn test_equalize_trie_node_touch_and_read_cost() {
-        let store = RuntimeConfigStore::with_one_config(RuntimeConfig::test_protocol_version(
-            ProtocolFeature::EqualizeTrieNodeTouchAndReadCost.protocol_version(),
-        ));
-        for (_, config) in &store.store {
-            assert_eq!(
-                config.wasm_config.ext_costs.gas_cost(ExtCosts::touching_trie_node),
-                config.wasm_config.ext_costs.gas_cost(ExtCosts::read_cached_trie_node)
-            );
-
-            assert_eq!(
-                config.wasm_config.ext_costs.compute_cost(ExtCosts::touching_trie_node),
-                config.wasm_config.ext_costs.compute_cost(ExtCosts::read_cached_trie_node)
-            );
-        }
     }
 }

--- a/core/parameters/src/config_store.rs
+++ b/core/parameters/src/config_store.rs
@@ -57,6 +57,8 @@ static CONFIG_DIFFS: &[(ProtocolVersion, &str)] = &[
     (77, include_config!("77.yaml")),
     (78, include_config!("78.yaml")),
     (79, include_config!("79.yaml")),
+    // Equalizes the cost of reading trie nodes for first and subsequent accesses
+    (81, include_config!("81.yaml")),
     (129, include_config!("129.yaml")),
     (149, include_config!("149.yaml")),
 ];
@@ -268,6 +270,7 @@ impl RuntimeConfigStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ExtCosts;
     use crate::cost::ActionCosts;
     use std::collections::HashSet;
 
@@ -431,5 +434,28 @@ mod tests {
         let store = RuntimeConfigStore::for_chain_id(near_primitives_core::chains::BENCHMARKNET);
         let config = store.get_config(PROTOCOL_VERSION);
         assert_eq!(config.witness_config.main_storage_proof_size_soft_limit, u64::MAX);
+    }
+
+    // This test ensures that the gas and compute costs for touching and reading
+    // a trie node remain equal. Please do not remove this check as the code
+    // may rely on this behavior after the version upgrade. For example, the
+    // code may no longer differentiate between touching a trie node for the
+    // first time and reading it again.
+    #[test]
+    fn test_equalize_trie_node_touch_and_read_cost() {
+        let store = RuntimeConfigStore::with_one_config(RuntimeConfig::test_protocol_version(
+            ProtocolFeature::EqualizeTrieNodeTouchAndReadCost.protocol_version(),
+        ));
+        for (_, config) in &store.store {
+            assert_eq!(
+                config.wasm_config.ext_costs.gas_cost(ExtCosts::touching_trie_node),
+                config.wasm_config.ext_costs.gas_cost(ExtCosts::read_cached_trie_node)
+            );
+
+            assert_eq!(
+                config.wasm_config.ext_costs.compute_cost(ExtCosts::touching_trie_node),
+                config.wasm_config.ext_costs.compute_cost(ExtCosts::read_cached_trie_node)
+            );
+        }
     }
 }

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__149.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__149.json.snap
@@ -156,7 +156,7 @@ expression: config_view
       "storage_iter_next_base": 0,
       "storage_iter_next_key_byte": 0,
       "storage_iter_next_value_byte": 0,
-      "touching_trie_node": 16101955926,
+      "touching_trie_node": 2280000000,
       "read_cached_trie_node": 2280000000,
       "promise_and_base": 1465013400,
       "promise_and_per_promise": 5452176,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__81.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__81.json.snap
@@ -202,7 +202,7 @@ expression: config_view
     "global_contract_host_fns": true,
     "reftypes_bulk_memory": false,
     "storage_get_mode": "FlatStorage",
-    "fix_contract_loading_cost": true,
+    "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
     "limit_config": {

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_129.json.snap
@@ -156,7 +156,7 @@ expression: config_view
       "storage_iter_next_base": 0,
       "storage_iter_next_key_byte": 0,
       "storage_iter_next_value_byte": 0,
-      "touching_trie_node": 16101955926,
+      "touching_trie_node": 2280000000,
       "read_cached_trie_node": 2280000000,
       "promise_and_base": 1465013400,
       "promise_and_per_promise": 5452176,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_149.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_149.json.snap
@@ -156,7 +156,7 @@ expression: config_view
       "storage_iter_next_base": 0,
       "storage_iter_next_key_byte": 0,
       "storage_iter_next_value_byte": 0,
-      "touching_trie_node": 16101955926,
+      "touching_trie_node": 2280000000,
       "read_cached_trie_node": 2280000000,
       "promise_and_base": 1465013400,
       "promise_and_per_promise": 5452176,

--- a/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_81.json.snap
+++ b/core/parameters/src/snapshots/near_parameters__config_store__tests__testnet_81.json.snap
@@ -202,7 +202,7 @@ expression: config_view
     "global_contract_host_fns": true,
     "reftypes_bulk_memory": false,
     "storage_get_mode": "FlatStorage",
-    "fix_contract_loading_cost": true,
+    "fix_contract_loading_cost": false,
     "implicit_account_creation": true,
     "eth_implicit_accounts": true,
     "limit_config": {

--- a/core/parameters/src/snapshots/near_parameters__view__tests__runtime_config_view.snap
+++ b/core/parameters/src/snapshots/near_parameters__view__tests__runtime_config_view.snap
@@ -156,7 +156,7 @@ expression: "&view"
       "storage_iter_next_base": 0,
       "storage_iter_next_key_byte": 0,
       "storage_iter_next_value_byte": 0,
-      "touching_trie_node": 16101955926,
+      "touching_trie_node": 2280000000,
       "read_cached_trie_node": 2280000000,
       "promise_and_base": 1465013400,
       "promise_and_per_promise": 5452176,

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -320,10 +320,6 @@ pub enum ProtocolFeature {
     /// It improves UX during long ranges of missing chunks, as transactions
     /// are much less likely to get rejected with ShardStuck error.
     IncreaseMaxCongestionMissedChunks,
-    /// Equalizes the cost of reading trie nodes for first and subsequent accesses.
-    /// After this version, `wasm_touching_trie_node` and `wasm_read_cached_trie_node`
-    /// will have the same cost.
-    EqualizeTrieNodeTouchAndReadCost,
 
     RefTypesBulkMemory,
     SaturatingFloatToInt,
@@ -425,7 +421,6 @@ impl ProtocolFeature {
             | ProtocolFeature::SaturatingFloatToInt
             | ProtocolFeature::ReducedGasRefunds => 78,
             ProtocolFeature::IncreaseMaxCongestionMissedChunks => 79,
-            ProtocolFeature::EqualizeTrieNodeTouchAndReadCost => 81,
 
             // Nightly features:
             ProtocolFeature::FixContractLoadingCost => 129,

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -320,6 +320,10 @@ pub enum ProtocolFeature {
     /// It improves UX during long ranges of missing chunks, as transactions
     /// are much less likely to get rejected with ShardStuck error.
     IncreaseMaxCongestionMissedChunks,
+    /// Equalizes the cost of reading trie nodes for first and subsequent accesses.
+    /// After this version, `wasm_touching_trie_node` and `wasm_read_cached_trie_node`
+    /// will have the same cost.
+    EqualizeTrieNodeTouchAndReadCost,
 
     RefTypesBulkMemory,
     SaturatingFloatToInt,
@@ -421,6 +425,7 @@ impl ProtocolFeature {
             | ProtocolFeature::SaturatingFloatToInt
             | ProtocolFeature::ReducedGasRefunds => 78,
             ProtocolFeature::IncreaseMaxCongestionMissedChunks => 79,
+            ProtocolFeature::EqualizeTrieNodeTouchAndReadCost => 81,
 
             // Nightly features:
             ProtocolFeature::FixContractLoadingCost => 129,
@@ -445,7 +450,7 @@ pub const PROD_GENESIS_PROTOCOL_VERSION: ProtocolVersion = 29;
 pub const MIN_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = 77;
 
 /// Current protocol version used on the mainnet with all stable features.
-const STABLE_PROTOCOL_VERSION: ProtocolVersion = 80;
+const STABLE_PROTOCOL_VERSION: ProtocolVersion = 81;
 
 // On nightly, pick big enough version to support all features.
 const NIGHTLY_PROTOCOL_VERSION: ProtocolVersion = 149;

--- a/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
+++ b/core/primitives/src/snapshots/near_primitives__views__tests__runtime_config_view.snap
@@ -156,7 +156,7 @@ expression: "&view"
       "storage_iter_next_base": 0,
       "storage_iter_next_key_byte": 0,
       "storage_iter_next_value_byte": 0,
-      "touching_trie_node": 16101955926,
+      "touching_trie_node": 2280000000,
       "read_cached_trie_node": 2280000000,
       "promise_and_base": 1465013400,
       "promise_and_per_promise": 5452176,

--- a/integration-tests/src/tests/features/chunk_nodes_cache.rs
+++ b/integration-tests/src/tests/features/chunk_nodes_cache.rs
@@ -108,8 +108,12 @@ fn compare_node_counts() {
     let signer = InMemorySigner::test_signer(&"test0".parse().unwrap());
     let tx_node_counts: Vec<TrieNodesCount> = (0..4)
         .map(|i| {
-            let touching_trie_node_cost: Gas = 16_101_955_926;
-            let read_cached_trie_node_cost: Gas = 2_280_000_000;
+            let runtime_config =
+                env.clients[0].runtime_adapter.get_runtime_config(PROTOCOL_VERSION);
+            let touching_trie_node_cost: Gas =
+                runtime_config.wasm_config.ext_costs.gas_cost(ExtCosts::touching_trie_node);
+            let read_cached_trie_node_cost: Gas =
+                runtime_config.wasm_config.ext_costs.gas_cost(ExtCosts::read_cached_trie_node);
             let num_blocks = if i < 1 { num_blocks } else { 2 * epoch_length };
             let tx_hash = process_transaction(&mut env, &signer, num_blocks, PROTOCOL_VERSION);
 

--- a/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile.snap
+++ b/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile.snap
@@ -257,7 +257,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "TOUCHING_TRIE_NODE",
-            gas_used: 32203911852,
+            gas_used: 4560000000,
         },
         CostGasUsed {
             cost_category: "WASM_HOST_COST",

--- a/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile_nightly.snap
+++ b/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile_nightly.snap
@@ -257,7 +257,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "TOUCHING_TRIE_NODE",
-            gas_used: 32203911852,
+            gas_used: 4560000000,
         },
         CostGasUsed {
             cost_category: "WASM_HOST_COST",

--- a/runtime/runtime-params-estimator/src/cost.rs
+++ b/runtime/runtime-params-estimator/src/cost.rs
@@ -584,6 +584,13 @@ pub enum Cost {
     /// for this are a bit involved but roughly speaking, it just forces values
     /// out of CPU caches so that they are always read from memory.
     ReadCachedTrieNode,
+    /// Estimates the cost of accessing a trie node by iterating the trie and
+    /// dividing the total cost by the number of nodes accessed.
+    ///
+    /// Used to estimate the unified cost of `touching_trie_node` and
+    /// `read_cached_trie_node`, as original cost estimations did not use
+    /// memtries.
+    ReadTrieNodeEstimateByIteration,
     /// Estimates `promise_and_base` which is charged for every call to
     /// `promise_and`. This should cover the base cost for creating receipt
     /// dependencies.

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -324,7 +324,9 @@ impl Testbed<'_> {
         caching_storage
     }
 
-    pub(crate) fn clear_caches(&self) {
+    pub(crate) fn clear_caches(&mut self) {
+        // Clear trie access tracker state
+        self.apply_state.trie_access_tracker_state = Default::default();
         // Flush out writes hanging in memtable
         self.tries.store().store().flush().unwrap();
 
@@ -511,17 +513,12 @@ impl Testbed<'_> {
         // will be at the same number.
         let tip_height = self.config.finality_lag;
         let tip = fs_fake_block_height_to_hash(tip_height as u64);
-        let mut trie = self.tries.get_trie_with_block_hash_for_shard(
+        self.tries.get_trie_with_block_hash_for_shard(
             ShardUId::single_shard(),
             self.root,
             &tip,
             false,
-        );
-        if self.config.memtrie {
-            // Allows measuring number of touched trie nodes
-            trie.set_use_trie_accounting_cache(true);
-        }
-        trie
+        )
     }
 }
 

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -511,12 +511,17 @@ impl Testbed<'_> {
         // will be at the same number.
         let tip_height = self.config.finality_lag;
         let tip = fs_fake_block_height_to_hash(tip_height as u64);
-        self.tries.get_trie_with_block_hash_for_shard(
+        let mut trie = self.tries.get_trie_with_block_hash_for_shard(
             ShardUId::single_shard(),
             self.root,
             &tip,
             false,
-        )
+        );
+        if self.config.memtrie {
+            // Allows measuring number of touched trie nodes
+            trie.set_use_trie_accounting_cache(true);
+        }
+        trie
     }
 }
 

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -506,7 +506,7 @@ impl Testbed<'_> {
     }
 
     /// Instantiate a new trie for the estimator.
-    fn trie(&self) -> near_store::Trie {
+    pub(crate) fn trie(&self) -> near_store::Trie {
         // We generated `finality_lag` fake blocks earlier, so the fake height
         // will be at the same number.
         let tip_height = self.config.finality_lag;

--- a/runtime/runtime-params-estimator/src/gas_cost.rs
+++ b/runtime/runtime-params-estimator/src/gas_cost.rs
@@ -212,6 +212,13 @@ impl GasCost {
             serde_json::Value::Null
         }
     }
+
+    pub(crate) fn round_nanos(mut self) -> Self {
+        if let Some(time_ns) = &mut self.time_ns {
+            *time_ns = time_ns.round();
+        }
+        self
+    }
 }
 
 /// Defines what negative solutions are allowed in a least-squares result.

--- a/runtime/runtime-params-estimator/src/trie.rs
+++ b/runtime/runtime-params-estimator/src/trie.rs
@@ -204,7 +204,13 @@ pub(crate) fn read_trie_node_estimate_by_iteration(
         TrieKey::Account { account_id: testbed.transaction_builder().random_account() }.to_vec();
     // Use recorder to get number of trie nodes accessed and the total approximate bytes read.
     let trie = testbed.trie().recording_reads_new_recorder();
-    assert!(trie.has_memtries(), "Run estimator with --memtries");
+    if !trie.has_memtries() {
+        eprintln!(
+            "Cannot estimate trie node read cost, no memtries available. \
+             Run with --memtries to enable memtries."
+        );
+        return GasCost::zero();
+    }
 
     let start = GasCost::measure(testbed.config.metric);
     {

--- a/runtime/runtime-params-estimator/src/trie.rs
+++ b/runtime/runtime-params-estimator/src/trie.rs
@@ -3,10 +3,12 @@ use crate::gas_cost::{GasCost, NonNegativeTolerance};
 use crate::utils::{aggregate_per_block_measurements, overhead_per_measured_block, percentiles};
 use near_parameters::ExtCosts;
 use near_primitives::hash::{CryptoHash, hash};
+use near_primitives::trie_key::TrieKey;
 use near_store::trie::AccessTracker;
 use near_store::{TrieCachingStorage, TrieStorage};
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::ops::Bound;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -190,6 +192,34 @@ pub(crate) fn read_node_from_accounting_cache(testbed: &mut Testbed) -> GasCost 
     }
 
     base_case
+}
+
+/// Estimate the cost of reading a trie node by iterating over the trie until
+/// the `max_read_bytes` limit is reached.
+pub(crate) fn read_trie_node_estimate_by_iteration(
+    testbed: &mut Testbed,
+    max_read_bytes: usize,
+) -> GasCost {
+    let start_account =
+        TrieKey::Account { account_id: testbed.transaction_builder().random_account() }.to_vec();
+    // Use recorder to get number of trie nodes accessed and the total approximate bytes read.
+    let trie = testbed.trie().recording_reads_new_recorder();
+    assert!(trie.has_memtries(), "Run estimator with --memtries");
+
+    let start = GasCost::measure(testbed.config.metric);
+    {
+        let locked_trie = trie.lock_for_iter();
+        let mut iter = locked_trie.iter().expect("Failed to get iterator");
+        iter.seek(Bound::Included(&start_account)).expect("Failed to seek");
+        iter.take_while(|_| trie.recorded_storage_size() < max_read_bytes).for_each(|_| {});
+    }
+
+    let accessed_nodes = trie.recorded_storage().expect("recorded storage missing").nodes.len();
+    let cost = start.elapsed();
+
+    // Round to nanos otherwise precise ratio math with different denoms may overflow.
+    // Expected to take several hundreds to few thousands of nanos.
+    (cost / accessed_nodes as u64).round_nanos()
 }
 
 #[derive(Debug, Default)]

--- a/runtime/runtime-params-estimator/src/trie.rs
+++ b/runtime/runtime-params-estimator/src/trie.rs
@@ -217,8 +217,9 @@ pub(crate) fn read_trie_node_estimate_by_iteration(
     let accessed_nodes = trie.recorded_storage().expect("recorded storage missing").nodes.len();
     let cost = start.elapsed();
 
-    // Round to nanos otherwise precise ratio math with different denoms may overflow.
-    // Expected to take several hundreds to few thousands of nanos.
+    // Round to nanos, using precise rational math with different denominators
+    // may overflow. Expected to take several hundreds to few thousands of
+    // nanos.
     (cost / accessed_nodes as u64).round_nanos()
 }
 

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -633,3 +633,27 @@ fn base64(s: &[u8]) -> String {
     use base64::Engine;
     base64::engine::general_purpose::STANDARD.encode(s)
 }
+
+#[cfg(test)]
+mod tests {
+    use near_parameters::{ExtCosts, RuntimeConfig};
+
+    // This test ensures that the gas and compute costs for touching and reading
+    // a trie node remain equal. Please do not remove this check as the code
+    // may rely on this behavior after the version upgrade. For example, the
+    // code may no longer differentiate between touching a trie node for the
+    // first time and reading it again.
+    #[test]
+    fn test_equalize_trie_node_touch_and_read_cost() {
+        let config = RuntimeConfig::test();
+        assert_eq!(
+            config.wasm_config.ext_costs.gas_cost(ExtCosts::touching_trie_node),
+            config.wasm_config.ext_costs.gas_cost(ExtCosts::read_cached_trie_node)
+        );
+
+        assert_eq!(
+            config.wasm_config.ext_costs.compute_cost(ExtCosts::touching_trie_node),
+            config.wasm_config.ext_costs.compute_cost(ExtCosts::read_cached_trie_node)
+        );
+    }
+}


### PR DESCRIPTION
This change reduces the gas cost for `wasm_touching_trie_node` and increases the compute cost of  `wasm_read_cached_trie_node`, so they can be interchangeable in the future.

I also added a test to ensure they would not unintentionally diverge to different values in the future.