### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install jq json processor
         run: sudo apt-get update && sudo apt-get install jq
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Install all the required tools
       - uses: taiki-e/install-action@7852930e42e73b6c323ae4435f5135b58754dfdd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - if: github.event_name != 'pull_request' || matrix.run_on_pr
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Install all the required tools
       - if: github.event_name != 'pull_request' || matrix.run_on_pr
@@ -82,7 +82,7 @@ jobs:
     name: "Protobuf Backward Compatibility"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: bufbuild/buf-setup-action@1158f4fa81bc02e1ff62abcca6d516c9e24c77da
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -97,7 +97,7 @@ jobs:
       fail-fast: false
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: WarpBuilds/setup-python@v5
         with:
           python-version: 3.11
@@ -129,7 +129,7 @@ jobs:
     name: "Large pytest Tests"
     runs-on: warp-ubuntu-2204-x64-8x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: WarpBuilds/setup-python@v5
         with:
           python-version: 3.11
@@ -160,7 +160,7 @@ jobs:
     name: "Protocol Schema"
     runs-on: warp-ubuntu-2204-x64-8x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/install-action@7852930e42e73b6c323ae4435f5135b58754dfdd
         with:
           tool: just
@@ -170,7 +170,7 @@ jobs:
     name: "Style"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/install-action@7852930e42e73b6c323ae4435f5135b58754dfdd
         with:
           tool: just
@@ -185,7 +185,7 @@ jobs:
     name: "Cargo Fmt"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/install-action@7852930e42e73b6c323ae4435f5135b58754dfdd
         with:
           tool: just
@@ -195,7 +195,7 @@ jobs:
     name: "Cargo Clippy"
     runs-on: warp-ubuntu-2204-x64-8x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/install-action@7852930e42e73b6c323ae4435f5135b58754dfdd
         with:
           tool: just
@@ -205,7 +205,7 @@ jobs:
     name: "Rust Doctests"
     runs-on: warp-ubuntu-2204-x64-8x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/install-action@7852930e42e73b6c323ae4435f5135b58754dfdd
         with:
           tool: just
@@ -214,7 +214,7 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/install-action@7852930e42e73b6c323ae4435f5135b58754dfdd
         with:
           tool: just
@@ -225,7 +225,7 @@ jobs:
     name: "Cargo Deny"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/install-action@7852930e42e73b6c323ae4435f5135b58754dfdd
         with:
           tool: just,cargo-deny
@@ -235,7 +235,7 @@ jobs:
     name: "Themis"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/install-action@7852930e42e73b6c323ae4435f5135b58754dfdd
         with:
           tool: just
@@ -245,7 +245,7 @@ jobs:
     name: "Cargo machete (unused dependencies)"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/install-action@7852930e42e73b6c323ae4435f5135b58754dfdd
         with:
           tool: just,cargo-machete
@@ -255,7 +255,7 @@ jobs:
     name: "Non-default Configuration Builds"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/install-action@7852930e42e73b6c323ae4435f5135b58754dfdd
         with:
           tool: just
@@ -265,7 +265,7 @@ jobs:
     name: "Unused Dependencies"
     runs-on: warp-ubuntu-2204-x64-8x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/install-action@7852930e42e73b6c323ae4435f5135b58754dfdd
         with:
           tool: just,cargo-udeps
@@ -275,7 +275,7 @@ jobs:
     name: "Cargo Audit"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/install-action@7852930e42e73b6c323ae4435f5135b58754dfdd
         with:
           tool: cargo-audit
@@ -293,7 +293,7 @@ jobs:
           - type: unit
             profraws: unit
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1000 # have enough history to find the merge-base between PR and master
       - uses: actions/download-artifact@v4
@@ -340,7 +340,7 @@ jobs:
       - pytest_tests
       - pytest_nightly_tests
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@v4
         with:
           pattern: coverage-codecov-*
@@ -384,7 +384,7 @@ jobs:
             os: windows-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/install-action@7852930e42e73b6c323ae4435f5135b58754dfdd
         with:
           tool: just
@@ -395,7 +395,7 @@ jobs:
     name: "OpenAPI Spec"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/install-action@7852930e42e73b6c323ae4435f5135b58754dfdd
         with:
           tool: just

--- a/.github/workflows/lychee_lints.yml
+++ b/.github/workflows/lychee_lints.yml
@@ -15,7 +15,7 @@ jobs:
     name: "Lychee Lints"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # cspell:disable-next-line
       - uses: lycheeverse/lychee-action@2ac9f030ccdea0033e2510a23a67da2a2da98492
         with:

--- a/.github/workflows/mac_m1_binary.yml
+++ b/.github/workflows/mac_m1_binary.yml
@@ -40,13 +40,13 @@ jobs:
         # for release events we need to checkout all branches to be able to determine
         # later branch name
         if: ${{ github.event_name != 'workflow_dispatch' && github.event_name == 'release'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Checkout ${{ github.event.inputs.branch }} branch
         if: ${{ github.event_name == 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.branch }}
 

--- a/.github/workflows/master_fuzzer_binaries.yml
+++ b/.github/workflows/master_fuzzer_binaries.yml
@@ -23,7 +23,7 @@ jobs:
       - run: sudo swapon /swap-file
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
   
       - id: "auth"
         name: Authenticate with Google Cloud

--- a/.github/workflows/nayduck_ci.yml
+++ b/.github/workflows/nayduck_ci.yml
@@ -17,7 +17,7 @@ jobs:
         run: sudo apt install jq
 
       - name: Checkout nearcore repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install required python modules
         run: |

--- a/.github/workflows/nayduck_ci_dev.yml
+++ b/.github/workflows/nayduck_ci_dev.yml
@@ -15,7 +15,7 @@ jobs:
         run: sudo apt install jq
 
       - name: Checkout nearcore repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install required python modules
         run: |

--- a/.github/workflows/near_crates_publish.yml
+++ b/.github/workflows/near_crates_publish.yml
@@ -24,14 +24,14 @@ jobs:
     steps:
       - name: Checkout near/nearcore's ${{ github.event.inputs.branch }} branch
         if: ${{ github.event_name == 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch }}
 
       - name: Checkout nearcore repository
         if: ${{ github.event_name != 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/neard_assertion_binary.yml
+++ b/.github/workflows/neard_assertion_binary.yml
@@ -29,13 +29,13 @@ jobs:
 
       - name: Checkout ${{ github.event.inputs.branch }} branch
         if: ${{ github.event_name == 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.branch }}
 
       - name: Checkout nearcore repository
         if: ${{ github.event_name != 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Neard binary build and upload to S3
         run: ./scripts/binary_release.sh assertions-release

--- a/.github/workflows/neard_nightly_binary.yml
+++ b/.github/workflows/neard_nightly_binary.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Checkout ${{ github.event.inputs.branch }} branch
         if: ${{ github.event_name == 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.branch }}
 

--- a/.github/workflows/neard_release.yml
+++ b/.github/workflows/neard_release.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Checkout ${{ github.event.inputs.branch }} branch
         if: ${{ github.event_name == 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.branch }}
 
@@ -45,14 +45,14 @@ jobs:
         # for release events we need to checkout all branches to be able to determine
         # later branch name
         if: ${{ github.event_name != 'workflow_dispatch' && github.event_name == 'release'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Checkout repository for master branch
         # In case of master branch we want to checkout with depth 1
         if: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'release'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -106,7 +106,7 @@ jobs:
     steps:
       - name: Checkout ${{ github.event.inputs.branch }} branch
         if: ${{ github.event_name == 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.branch }}
 
@@ -114,14 +114,14 @@ jobs:
         # for release events we need to checkout all branches to be able to determine
         # later branch name
         if: ${{ github.event_name != 'workflow_dispatch' && github.event_name == 'release'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Checkout  repository for master branch
         # In case of master branch we want to checkout with depth 1
         if: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'release'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/neard_test_features_binary.yml
+++ b/.github/workflows/neard_test_features_binary.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Checkout ${{ github.event.inputs.branch }} branch
         if: ${{ github.event_name == 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.branch }}
 

--- a/.github/workflows/ondemand_fuzzer_binaries.yml
+++ b/.github/workflows/ondemand_fuzzer_binaries.yml
@@ -40,11 +40,11 @@ jobs:
 
       - name: Checkout Release/RC branch
         if: contains(fromJSON('["released", "prereleased"]'), github.event.action)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout ${{ github.event.inputs.branch_ref }} branch
         if: ${{ github.event_name == 'workflow_dispatch'}}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.branch_ref }}
 


### PR DESCRIPTION
GitHub-hosted runners now use Node 24, so actions/checkout@v5 is required. Minimum runner version v2.327.1. Workflows only updated—no functional changes.

See: https://github.com/actions/checkout/releases/tag/v5.0.0