### PR TITLE
feat(wasmtime): enable pooling allocator

### DIFF
--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -41,7 +41,11 @@ thiserror.workspace = true
 tracing.workspace = true
 wasm-encoder = { workspace = true, optional = true }
 wasmparser = { workspace = true, optional = true }
-wasmtime = { workspace = true, features = ["parallel-compilation", "runtime"], optional = true }
+wasmtime = { workspace = true, features = [
+    "parallel-compilation",
+    "pooling-allocator",
+    "runtime",
+], optional = true }
 
 near-crypto.workspace = true
 near-o11y = { workspace = true, optional = true }

--- a/runtime/near-vm-runner/src/logic/errors.rs
+++ b/runtime/near-vm-runner/src/logic/errors.rs
@@ -41,7 +41,7 @@ pub enum VMRunnerError {
 /// See the doc comment on `VMResult` for an explanation what the difference
 /// between this and a `VMRunnerError` is. And see `PartialExecutionStatus`
 /// for what gets stored on chain.
-#[derive(Debug, PartialEq, Eq, strum::IntoStaticStr)]
+#[derive(Clone, Debug, PartialEq, Eq, strum::IntoStaticStr)]
 pub enum FunctionCallError {
     /// Wasm compilation error
     CompilationError(CompilationError),

--- a/runtime/near-vm-runner/src/prepare/prepare_v3.rs
+++ b/runtime/near-vm-runner/src/prepare/prepare_v3.rs
@@ -87,11 +87,16 @@ impl<'a> PrepareContext<'a> {
                 }
                 wp::Payload::MemorySection(reader) => {
                     // We do not want to include the implicit memory anymore as we normalized it by
-                    // importing the memory instead.
+                    // importing the memory instead in NearVm.
                     self.ensure_import_section();
                     self.validator
                         .memory_section(&reader)
                         .map_err(|_| PrepareError::Deserialization)?;
+                    if self.config.vm_kind == VMKind::Wasmtime {
+                        wasm_encoder::MemorySection::new()
+                            .memory(self.memory_type())
+                            .append_to(&mut self.output_code);
+                    }
                 }
                 wp::Payload::GlobalSection(reader) => {
                     self.ensure_import_section();
@@ -226,7 +231,9 @@ impl<'a> PrepareContext<'a> {
             };
             new_section.import(import.module, import.name, new_type);
         }
-        new_section.import("env", "memory", self.memory_import());
+        if self.config.vm_kind != VMKind::Wasmtime {
+            new_section.import("env", "memory", self.memory_type());
+        }
         // wasm_encoder a section with all imports and the imported standardized memory.
         new_section.append_to(&mut self.output_code);
         Ok(())
@@ -236,20 +243,22 @@ impl<'a> PrepareContext<'a> {
         if self.before_import_section {
             self.before_import_section = false;
             let mut new_section = wasm_encoder::ImportSection::new();
-            new_section.import("env", "memory", self.memory_import());
+            if self.config.vm_kind != VMKind::Wasmtime {
+                new_section.import("env", "memory", self.memory_type());
+            }
             // wasm_encoder a section with all imports and the imported standardized memory.
             new_section.append_to(&mut self.output_code);
         }
     }
 
-    fn memory_import(&self) -> wasm_encoder::EntityType {
-        wasm_encoder::EntityType::Memory(wasm_encoder::MemoryType {
+    fn memory_type(&self) -> wasm_encoder::MemoryType {
+        wasm_encoder::MemoryType {
             minimum: u64::from(self.config.limit_config.initial_memory_pages),
             maximum: Some(u64::from(self.config.limit_config.max_memory_pages)),
             memory64: false,
             shared: false,
             page_size_log2: None,
-        })
+        }
     }
 
     fn copy_section(

--- a/runtime/near-vm-runner/src/tests/compile_errors.rs
+++ b/runtime/near-vm-runner/src/tests/compile_errors.rs
@@ -281,14 +281,15 @@ pub fn test_stabilized_host_function() {
             r#"
 (module
   (import "env" "ripemd160" (func $ripemd160 (param i64 i64 i64)))
+  (memory 0 0)
+  (export "memory" (memory 0))
   (func (export "main")
     (call $ripemd160 (i64.const 0) (i64.const 0) (i64.const 0)))
 )"#,
         )
-        .opaque_error()
         .expects(&[
             expect![[r#"
-                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 7226376631 used gas 7226376631
+                VMOutcome: balance 4 storage_usage 12 return data None burnt gas 7242716056 used gas 7242716056
             "#]],
         ]);
 }

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -1,7 +1,7 @@
 use crate::errors::ContractPrecompilatonResult;
 use crate::logic::errors::{
-    CacheError, CompilationError, FunctionCallError, MethodResolveError, PrepareError,
-    VMLogicError, VMRunnerError, WasmTrap,
+    CacheError, CompilationError, FunctionCallError, MethodResolveError, VMLogicError,
+    VMRunnerError, WasmTrap,
 };
 use crate::logic::{Config, ExecutionResultState, GasCounter};
 use crate::logic::{External, MemSlice, MemoryLike, VMContext, VMLogic, VMOutcome};
@@ -16,69 +16,75 @@ use near_parameters::vm::VMKind;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::sync::Arc;
-use wasmtime::{Engine, ExternType, Instance, Linker, Memory, MemoryType, Module, Store, Strategy};
+use wasmtime::{
+    Engine, Extern, ExternType, Instance, InstancePre, Linker, Module, ModuleExport, Store,
+    StoreLimits, StoreLimitsBuilder, Strategy,
+};
 
 type Caller = wasmtime::Caller<'static, Ctx>;
 
-#[derive(Default)]
 pub struct Ctx {
     logic: Option<VMLogic<'static>>,
     caller: Arc<RefCell<Option<Caller>>>,
+    limits: StoreLimits,
+}
+
+const GUEST_PAGE_SIZE: usize = 1 << 16;
+
+impl Ctx {
+    fn new(logic: VMLogic<'static>, caller: Arc<RefCell<Option<Caller>>>) -> Self {
+        let memory_size = logic
+            .result_state
+            .config
+            .limit_config
+            .max_memory_pages
+            .try_into()
+            .unwrap_or(usize::MAX)
+            .saturating_mul(GUEST_PAGE_SIZE);
+        let limits = StoreLimitsBuilder::new().memories(1).memory_size(memory_size).build();
+        Self { logic: Some(logic), caller, limits }
+    }
 }
 
 #[derive(Clone)]
 pub struct WasmtimeMemory {
-    memory: Memory,
+    memory: Option<ModuleExport>,
     caller: Arc<RefCell<Option<Caller>>>,
 }
 
 impl WasmtimeMemory {
-    pub fn new(
-        caller: Arc<RefCell<Option<Caller>>>,
-        store: &mut Store<Ctx>,
-        initial_memory_bytes: u32,
-        max_memory_bytes: u32,
-    ) -> Result<Self, FunctionCallError> {
-        Ok(WasmtimeMemory {
-            memory: Memory::new(
-                store,
-                MemoryType::new(initial_memory_bytes, Some(max_memory_bytes)),
-            )
-            .map_err(|_| PrepareError::Memory)?,
-            caller,
-        })
-    }
-}
-
-impl WasmtimeMemory {
-    fn with_caller<T>(&self, func: impl FnOnce(&mut Caller) -> T) -> T {
+    fn with<T>(
+        &self,
+        func: impl FnOnce(&mut Caller, wasmtime::Memory) -> Result<T, ()>,
+    ) -> Result<T, ()> {
+        let Some(memory) = self.memory else { return Err(()) };
         let mut caller = self.caller.borrow_mut();
-        func(caller.as_mut().expect("caller missing"))
+        let caller = caller.as_mut().expect("caller missing");
+        let Some(Extern::Memory(memory)) = caller.get_module_export(&memory) else {
+            return Err(());
+        };
+        func(caller, memory)
     }
 }
 
 impl MemoryLike for WasmtimeMemory {
     fn fits_memory(&self, slice: MemSlice) -> Result<(), ()> {
         let end = slice.end::<usize>()?;
-        if end <= self.with_caller(|caller| self.memory.data_size(caller)) {
-            Ok(())
-        } else {
-            Err(())
-        }
+        self.with(|caller, memory| if end <= memory.data_size(caller) { Ok(()) } else { Err(()) })
     }
 
     fn view_memory(&self, slice: MemSlice) -> Result<Cow<[u8]>, ()> {
         let range = slice.range::<usize>()?;
-        self.with_caller(|caller| {
-            self.memory.data(caller).get(range).map(|slice| Cow::Owned(slice.to_vec())).ok_or(())
+        self.with(|caller, memory| {
+            memory.data(caller).get(range).map(|slice| Cow::Owned(slice.to_vec())).ok_or(())
         })
     }
 
     fn read_memory(&self, offset: u64, buffer: &mut [u8]) -> Result<(), ()> {
         let start = usize::try_from(offset).map_err(|_| ())?;
         let end = start.checked_add(buffer.len()).ok_or(())?;
-        self.with_caller(|caller| {
-            let memory = self.memory.data(caller).get(start..end).ok_or(())?;
+        self.with(|caller, memory| {
+            let memory = memory.data(caller).get(start..end).ok_or(())?;
             buffer.copy_from_slice(memory);
             Ok(())
         })
@@ -87,8 +93,8 @@ impl MemoryLike for WasmtimeMemory {
     fn write_memory(&mut self, offset: u64, buffer: &[u8]) -> Result<(), ()> {
         let start = usize::try_from(offset).map_err(|_| ())?;
         let end = start.checked_add(buffer.len()).ok_or(())?;
-        self.with_caller(|caller| {
-            let memory = self.memory.data_mut(caller).get_mut(start..end).ok_or(())?;
+        self.with(|caller, memory| {
+            let memory = memory.data_mut(caller).get_mut(start..end).ok_or(())?;
             memory.copy_from_slice(buffer);
             Ok(())
         })
@@ -233,52 +239,63 @@ impl WasmtimeVM {
         contract: &dyn Contract,
         mut gas_counter: GasCounter,
         method: &str,
-        closure: impl FnOnce(GasCounter, Module) -> VMResult<PreparedContract>,
+        closure: impl FnOnce(
+            GasCounter,
+            Result<(InstancePre<Ctx>, Option<ModuleExport>), FunctionCallError>,
+        ) -> VMResult<PreparedContract>,
     ) -> VMResult<PreparedContract> {
-        type MemoryCacheType = (u64, Result<Module, CompilationError>);
+        type MemoryCacheType = (
+            u64,
+            Result<
+                Result<(InstancePre<Ctx>, Option<ModuleExport>), FunctionCallError>,
+                CompilationError,
+            >,
+        );
         let to_any = |v: MemoryCacheType| -> Box<dyn std::any::Any + Send> { Box::new(v) };
         let key = get_contract_cache_key(contract.hash(), &self.config);
-        let (wasm_bytes, module_result) = cache.memory_cache().try_lookup(
+        let (wasm_bytes, pre_result) = cache.memory_cache().try_lookup(
             key,
             || {
                 let cache_record = cache.get(&key).map_err(CacheError::ReadError)?;
-                let Some(compiled_contract_info) = cache_record else {
-                    let Some(code) = contract.get_code() else {
-                        return Err(VMRunnerError::ContractCodeNotPresent);
-                    };
-                    return Ok(to_any((
-                        code.code().len() as u64,
-                        match self.compile_and_cache(&code, cache)? {
-                            Ok(serialized_module) => Ok(unsafe {
-                                Module::deserialize(&self.engine, serialized_module)
-                                    .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?
-                            }),
-                            Err(err) => Err(err),
-                        },
-                    )));
-                };
-                match &compiled_contract_info.compiled {
-                    CompiledContract::CompileModuleError(err) => Ok::<_, VMRunnerError>(to_any((
-                        compiled_contract_info.wasm_bytes,
-                        Err(err.clone()),
-                    ))),
-                    CompiledContract::Code(serialized_module) => {
-                        unsafe {
-                            // (UN-)SAFETY: the `serialized_module` must have been produced by
-                            // a prior call to `serialize`.
-                            //
-                            // In practice this is not necessarily true. One could have
-                            // forgotten to change the cache key when upgrading the version of
-                            // the near_vm library or the database could have had its data
-                            // corrupted while at rest.
-                            //
-                            // There should definitely be some validation in near_vm to ensure
-                            // we load what we think we load.
-                            let module = Module::deserialize(&self.engine, &serialized_module)
-                                .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?;
-                            Ok(to_any((compiled_contract_info.wasm_bytes, Ok(module))))
+                let (wasm_bytes, module) =
+                    if let Some(CompiledContractInfo { wasm_bytes, compiled }) = cache_record {
+                        match compiled {
+                            CompiledContract::CompileModuleError(err) => {
+                                return Ok(to_any((wasm_bytes, Err(err))));
+                            }
+                            CompiledContract::Code(module) => (wasm_bytes, module),
                         }
+                    } else {
+                        let Some(code) = contract.get_code() else {
+                            return Err(VMRunnerError::ContractCodeNotPresent);
+                        };
+                        let wasm_bytes = code.code().len() as u64;
+                        match self.compile_and_cache(&code, cache)? {
+                            Err(err) => return Ok(to_any((wasm_bytes, Err(err)))),
+                            Ok(module) => (wasm_bytes, module),
+                        }
+                    };
+                // (UN-)SAFETY: the `module` must have been produced by
+                // a prior call to `serialize`.
+                //
+                // In practice this is not necessarily true. One could have
+                // forgotten to change the cache key when upgrading the version of
+                // the near_vm library or the database could have had its data
+                // corrupted while at rest.
+                //
+                // There should definitely be some validation in near_vm to ensure
+                // we load what we think we load.
+                let module = unsafe { Module::deserialize(&self.engine, &module) }
+                    .map_err(|err| VMRunnerError::LoadingError(err.to_string()))?;
+                let memory = module.get_export_index("memory");
+                let mut linker = Linker::new(&self.engine);
+                link(&mut linker, &self.config);
+                match linker.instantiate_pre(&module) {
+                    Err(err) => {
+                        let err = err.into_vm_error()?;
+                        Ok(to_any((wasm_bytes, Ok(Err(err)))))
                     }
+                    Ok(pre) => Ok(to_any((wasm_bytes, Ok(Ok((pre, memory)))))),
                 }
             },
             move |value| {
@@ -296,14 +313,14 @@ impl WasmtimeVM {
             let result = PreparationResult::OutcomeAbort(e);
             return Ok(PreparedContract { config, gas_counter, result });
         }
-        match module_result {
-            Ok(module) => {
+        match pre_result {
+            Ok(res) => {
                 let result = gas_counter.after_loading_executable(&config, wasm_bytes);
                 if let Err(e) = result {
                     let result = PreparationResult::OutcomeAbort(e);
                     return Ok(PreparedContract { config, gas_counter, result });
                 }
-                closure(gas_counter, module)
+                closure(gas_counter, res)
             }
             Err(e) => {
                 let result =
@@ -336,38 +353,47 @@ impl crate::runner::VM for WasmtimeVM {
         method: &str,
     ) -> Box<dyn crate::PreparedContract> {
         let cache = cache.unwrap_or(&NoContractRuntimeCache);
-        let prepd = self.with_compiled_and_loaded(
-            cache,
-            code,
-            gas_counter,
-            method,
-            |gas_counter, module| {
+        let prepd =
+            self.with_compiled_and_loaded(cache, code, gas_counter, method, |gas_counter, pre| {
                 let config = Arc::clone(&self.config);
-                let Some(ExternType::Func(func_type)) = module.get_export(method) else {
-                    let e =
-                        FunctionCallError::MethodResolveError(MethodResolveError::MethodNotFound);
-                    let result = PreparationResult::OutcomeAbortButNopInOldProtocol(e);
-                    return Ok(PreparedContract { config, gas_counter, result });
-                };
-                if func_type.params().len() != 0 || func_type.results().len() != 0 {
-                    let e = FunctionCallError::MethodResolveError(
-                        MethodResolveError::MethodInvalidSignature,
-                    );
-                    let result = PreparationResult::OutcomeAbortButNopInOldProtocol(e);
-                    return Ok(PreparedContract { config, gas_counter, result });
-                }
+                match pre {
+                    Ok((pre, memory)) => {
+                        let Some(ExternType::Func(func_type)) = pre.module().get_export(method)
+                        else {
+                            let e = FunctionCallError::MethodResolveError(
+                                MethodResolveError::MethodNotFound,
+                            );
+                            let result = PreparationResult::OutcomeAbortButNopInOldProtocol(e);
+                            return Ok(PreparedContract { config, gas_counter, result });
+                        };
+                        if func_type.params().len() != 0 || func_type.results().len() != 0 {
+                            let e = FunctionCallError::MethodResolveError(
+                                MethodResolveError::MethodInvalidSignature,
+                            );
+                            let result = PreparationResult::OutcomeAbortButNopInOldProtocol(e);
+                            return Ok(PreparedContract { config, gas_counter, result });
+                        }
 
-                let result =
-                    PreparationResult::Ready(ReadyContract { module, method: method.into() });
-                Ok(PreparedContract { config, gas_counter, result })
-            },
-        );
+                        let result = PreparationResult::Ready(ReadyContract {
+                            pre,
+                            memory,
+                            method: method.into(),
+                        });
+                        Ok(PreparedContract { config, gas_counter, result })
+                    }
+                    Err(err) => {
+                        let result = PreparationResult::OutcomeAbort(err);
+                        Ok(PreparedContract { config, gas_counter, result })
+                    }
+                }
+            });
         Box::new(prepd)
     }
 }
 
 struct ReadyContract {
-    module: Module,
+    pre: InstancePre<Ctx>,
+    memory: Option<ModuleExport>,
     method: Box<str>,
 }
 
@@ -418,18 +444,6 @@ fn call(
     }
 }
 
-fn instantiate_and_call(
-    mut store: &mut Store<Ctx>,
-    linker: &Linker<Ctx>,
-    module: &Module,
-    method: &str,
-) -> Result<RunOutcome, VMRunnerError> {
-    match linker.instantiate(&mut store, module) {
-        Ok(instance) => call(store, instance, method),
-        Err(err) => err.into_vm_error().map(RunOutcome::Abort),
-    }
-}
-
 impl crate::PreparedContract for VMResult<PreparedContract> {
     fn run(
         self: Box<Self>,
@@ -439,7 +453,7 @@ impl crate::PreparedContract for VMResult<PreparedContract> {
     ) -> VMResult {
         let PreparedContract { config, gas_counter, result } = (*self)?;
         let result_state = ExecutionResultState::new(&context, gas_counter, config);
-        let ReadyContract { module, method } = match result {
+        let ReadyContract { pre, memory, method } = match result {
             PreparationResult::Ready(r) => r,
             PreparationResult::OutcomeAbortButNopInOldProtocol(e) => {
                 return Ok(VMOutcome::abort_but_nop_outcome_in_old_protocol(result_state, e));
@@ -449,39 +463,31 @@ impl crate::PreparedContract for VMResult<PreparedContract> {
             }
         };
 
-        let engine = module.engine();
-
-        let config = Arc::clone(&result_state.config);
-
-        let ctx = Ctx::default();
-
-        // Clone the caller for future access outside of the store's context
-        let caller = Arc::clone(&ctx.caller);
-        let mut store = Store::<Ctx>::new(engine, ctx);
-        let mut memory = WasmtimeMemory::new(
-            caller,
-            &mut store,
-            config.limit_config.initial_memory_pages,
-            config.limit_config.max_memory_pages,
-        )
-        .expect("failed to construct wasmtime memory");
+        let caller = Arc::default();
+        let mut memory = WasmtimeMemory { caller: Arc::clone(&caller), memory };
         let logic = VMLogic::new(ext, context, fees_config, result_state, &mut memory);
         // SAFETY:
         // Although the 'static here is a lie, we are pretty confident that the `VMLogic` here
         // only lives for the duration of the contract method call (which is covered by the original
         // lifetime).
-        store
-            .data_mut()
-            .logic
-            .replace(unsafe { transmute::<VMLogic<'_>, VMLogic<'static>>(logic) });
+        let logic = unsafe { transmute::<VMLogic<'_>, VMLogic<'static>>(logic) };
+        let ctx = Ctx::new(logic, caller);
 
-        let mut linker = Linker::new(engine);
-        // TODO: config could be accessed through `logic.result_state`, without this code having to
-        // figure it out...
-        link(&mut linker, memory.memory, &store, &config);
-        let res = instantiate_and_call(&mut store, &linker, &module, &method);
+        let mut store = Store::<Ctx>::new(pre.module().engine(), ctx);
+        store.limiter(|ctx| &mut ctx.limits);
+        let instance = match pre.instantiate(&mut store) {
+            Ok(instance) => instance,
+            Err(err) => {
+                let err = err.into_vm_error()?;
+                let logic = store.data_mut().logic.take().expect("logic missing");
+                return Ok(VMOutcome::abort(logic.result_state, err));
+            }
+        };
+
+        let res = call(&mut store, instance, &method);
         let logic = store.data_mut().logic.take().expect("logic missing");
-        lazy_drop(Box::new((linker, module)));
+        drop(store);
+        lazy_drop(Box::new(instance));
         match res? {
             RunOutcome::Ok => Ok(VMOutcome::ok(logic.result_state)),
             RunOutcome::AbortNop(error) => {
@@ -509,14 +515,7 @@ impl std::fmt::Display for ErrorContainer {
     }
 }
 
-fn link(
-    linker: &mut wasmtime::Linker<Ctx>,
-    memory: wasmtime::Memory,
-    store: &wasmtime::Store<Ctx>,
-    config: &Config,
-) {
-    linker.define(store, "env", "memory", memory).expect("cannot define memory");
-
+fn link(linker: &mut wasmtime::Linker<Ctx>, config: &Config) {
     macro_rules! add_import {
         (
           $mod:ident / $name:ident : $func:ident < [ $( $arg_name:ident : $arg_type:ident ),* ] -> [ $( $returns:ident ),* ] >

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -17,19 +17,19 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::sync::Arc;
 use wasmtime::{
-    Engine, Extern, ExternType, Instance, InstancePre, Linker, Module, ModuleExport, Store,
-    StoreLimits, StoreLimitsBuilder, Strategy,
+    Engine, Extern, ExternType, Instance, InstanceAllocationStrategy, InstancePre, Linker, Module,
+    ModuleExport, PoolingAllocationConfig, Store, StoreLimits, StoreLimitsBuilder, Strategy,
 };
 
 type Caller = wasmtime::Caller<'static, Ctx>;
+
+const GUEST_PAGE_SIZE: usize = 1 << 16;
 
 pub struct Ctx {
     logic: Option<VMLogic<'static>>,
     caller: Arc<RefCell<Option<Caller>>>,
     limits: StoreLimits,
 }
-
-const GUEST_PAGE_SIZE: usize = 1 << 16;
 
 impl Ctx {
     fn new(logic: VMLogic<'static>, caller: Arc<RefCell<Option<Caller>>>) -> Self {
@@ -159,8 +159,21 @@ pub(crate) fn default_wasmtime_config(c: &Config) -> wasmtime::Config {
     // - https://docs.wasmtime.dev/examples-fast-execution.html
     // - https://docs.wasmtime.dev/examples-fast-instantiation.html
 
+    let max_memory_size = usize::try_from(c.limit_config.max_memory_pages)
+        .unwrap_or(usize::MAX)
+        .saturating_mul(GUEST_PAGE_SIZE);
+    let mut pooling = PoolingAllocationConfig::default();
+    pooling
+        .max_memory_size(max_memory_size)
+        .table_elements(1_000_000)
+        .total_component_instances(0)
+        // Minimize page faults on Linux
+        .linear_memory_keep_resident(max_memory_size)
+        .table_keep_resident(1_000_000 * size_of::<*const ()>());
+
     let mut config = wasmtime::Config::from(features);
     config
+        .allocation_strategy(InstanceAllocationStrategy::Pooling(pooling))
         // From official documentation:
         // > Note that systems loading many modules may wish to disable this
         // > configuration option instead of leaving it on-by-default.


### PR DESCRIPTION
This change is based on top of #14057 as it would not do much on it's own.

This enables [pooling allocator](https://docs.wasmtime.dev/examples-fast-instantiation.html#enable-the-pooling-allocator) to optimize instantiation and minimize memory allocations.

Important thing to keep in mind, is that by default, at most 1000 instances may be active simultaneously, i.e. the runtime with only be able to handle a 1000 concurrent calls at any point of time, if a 1001st call would arrive, the instantiation would fail.

A potential solution here is to add a semaphore and *block* until engine has more capacity, but since that would affect performance, this seems to be undesirable - @nagisa please let me know if that aligns with the expectations here.