### PR TITLE
chore(forknet): move default configs from mirror init to host

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -230,6 +230,12 @@ class NeardRunner:
     def is_traffic_generator(self):
         return self.config.get('is_traffic_generator', False)
 
+    def want_state_dump(self):
+        return self.config.get('want_state_dump', False)
+
+    def can_validate(self):
+        return self.config.get('can_validate', False)
+
     def save_data(self):
         with open(self.home_path('data.json'), 'w') as f:
             json.dump(self.data, f, indent=2)
@@ -440,6 +446,14 @@ class NeardRunner:
         shutil.copyfile(self.setup_path('genesis.json'),
                         self.target_near_home_path('genesis.json'))
 
+    def set_node_type_config(self, role, can_validate, want_state_dump,
+                             mocknet_id):
+        self.config['role'] = role
+        self.config['can_validate'] = can_validate
+        self.config['want_state_dump'] = want_state_dump
+        self.config['mocknet_id'] = mocknet_id
+        self.save_config()
+
     # This RPC method tells to stop neard and re-initialize its home dir. This returns the
     # validator and node key that resulted from the initialization. We can't yet call amend-genesis
     # and compute state roots, because the caller of this method needs to hear back from
@@ -449,9 +463,25 @@ class NeardRunner:
     # this, it is pretty mandatory to implement some sort of client authentication, because without it,
     # anyone would be able to get us to download and run arbitrary code
     def do_new_test(self,
+                    mocknet_id,
+                    role,
+                    can_validate=True,
+                    want_state_dump=False,
                     rpc_port=3030,
                     protocol_port=24567,
                     validator_id=None):
+        if not isinstance(mocknet_id, str):
+            raise jsonrpc.exceptions.JSONRPCDispatchException(
+                code=-32600, message='mocknet_id argument not a string')
+        if not isinstance(role, str):
+            raise jsonrpc.exceptions.JSONRPCDispatchException(
+                code=-32600, message='role argument not a string')
+        if not isinstance(can_validate, bool):
+            raise jsonrpc.exceptions.JSONRPCDispatchException(
+                code=-32600, message='can_validate argument not a bool')
+        if not isinstance(want_state_dump, bool):
+            raise jsonrpc.exceptions.JSONRPCDispatchException(
+                code=-32600, message='want_state_dump argument not a bool')
         if not isinstance(rpc_port, int):
             raise jsonrpc.exceptions.JSONRPCDispatchException(
                 code=-32600, message='rpc_port argument not an int')
@@ -476,6 +506,9 @@ class NeardRunner:
                 os.remove(self.home_path('network_init.json'))
             except FileNotFoundError:
                 pass
+
+            self.set_node_type_config(role, can_validate, want_state_dump,
+                                      mocknet_id)
 
             self.reset_current_neard_path()
             self.save_data()
@@ -522,7 +555,8 @@ class NeardRunner:
                         num_seats=100,
                         new_chain_id=None,
                         protocol_version=None,
-                        genesis_time=None):
+                        genesis_time=None,
+                        state_sync_location=None):
         if not isinstance(validators, list):
             raise jsonrpc.exceptions.JSONRPCDispatchException(
                 code=-32600, message='validators argument not a list')
@@ -537,6 +571,15 @@ class NeardRunner:
         if len(boot_nodes) == 0:
             raise jsonrpc.exceptions.JSONRPCDispatchException(
                 code=-32600, message='boot_nodes argument must not be empty')
+
+        location = None
+        if state_sync_location is not None:
+            try:
+                location = json.loads(state_sync_location)
+            except json.JSONDecodeError:
+                raise jsonrpc.exceptions.JSONRPCDispatchException(
+                    code=-32600,
+                    message='state_sync_location argument not valid JSON')
 
         if genesis_time is None:
             raise jsonrpc.exceptions.JSONRPCDispatchException(
@@ -571,6 +614,7 @@ class NeardRunner:
                         'new_chain_id': new_chain_id,
                         'protocol_version': protocol_version,
                         'genesis_time': genesis_time,
+                        'state_sync_location': location,
                     }, f)
 
     def do_update_config(self, key_value):
@@ -1047,6 +1091,43 @@ class NeardRunner:
         backup_data = {'backup_id': backup_id, 'description': description}
         self.set_state(TestState.MAKING_BACKUP, data=backup_data)
 
+    def set_state_sync_config(self, config, location):
+        config['store']['state_snapshot_config'] = {
+            'state_snapshot_type': "Enabled"
+        }
+        if location is None:
+            return config
+
+        config['state_sync'] = config.get('state_sync', {})
+        config['state_sync']['sync'] = {
+            'ExternalStorage': {
+                'location': location
+            }
+        }
+        if self.want_state_dump():
+            config['state_sync']['dump'] = {'location': location}
+
+        return config
+
+    def set_boot_nodes(self, config, raw_boot_nodes, own_public_key):
+        boot_nodes = []
+        for b in raw_boot_nodes:
+            if own_public_key != b.split('@')[0]:
+                boot_nodes.append(b)
+        config['network']['boot_nodes'] = ','.join(boot_nodes)
+        return config
+
+    def set_shard_tracking_config(self, config):
+        # TODO: Enable saving witness after fixing the performance problems.
+        config['save_latest_witnesses'] = False
+        if self.can_validate():
+            config['tracked_shards'] = []
+            config['store']['load_mem_tries_for_tracked_shards'] = True
+        else:
+            config['tracked_shards'] = [0]
+            config['store']['load_mem_tries_for_tracked_shards'] = False
+        return config
+
     def network_init(self):
         # wait til we get a network_init RPC
         if not os.path.exists(self.home_path('validators.json')):
@@ -1058,15 +1139,17 @@ class NeardRunner:
             node_key = json.load(f)
         with open(self.target_near_home_path('config.json'), 'r') as f:
             config = json.load(f)
-        boot_nodes = []
-        for b in n['boot_nodes']:
-            if node_key['public_key'] != b.split('@')[0]:
-                boot_nodes.append(b)
 
-        config['network']['boot_nodes'] = ','.join(boot_nodes)
+        config = self.set_boot_nodes(config, n['boot_nodes'],
+                                     node_key['public_key'])
+        config = self.set_state_sync_config(config, n['state_sync_location'])
+        config = self.set_shard_tracking_config(config)
+
         with open(self.target_near_home_path('config.json'), 'w') as f:
             config = json.dump(config, f, indent=2)
 
+        # TODO(CV support): If the node has state, build the genesis and publish it.
+        #                   If the node has no state, download the genesis from the setup bucket.
         new_chain_id = n.get('new_chain_id')
 
         if n['state_source'] == 'empty':

--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -1118,13 +1118,11 @@ class NeardRunner:
         return config
 
     def set_shard_tracking_config(self, config):
-        # TODO: Enable saving witness after fixing the performance problems.
-        config['save_latest_witnesses'] = False
         if self.can_validate():
-            config['tracked_shards'] = []
+            config['tracked_shards_config'] = "NoShards"
             config['store']['load_mem_tries_for_tracked_shards'] = True
         else:
-            config['tracked_shards'] = [0]
+            config['tracked_shards_config'] = "AllShards"
             config['store']['load_mem_tries_for_tracked_shards'] = False
         return config
 

--- a/pytest/tests/mocknet/node_handle.py
+++ b/pytest/tests/mocknet/node_handle.py
@@ -143,8 +143,12 @@ class NodeHandle:
     def neard_runner_stop(self):
         return self.neard_runner_jsonrpc('stop')
 
-    def neard_runner_new_test(self):
+    def neard_runner_new_test(self, mocknet_id):
         params = self.node.new_test_params()
+        params['mocknet_id'] = mocknet_id
+        params['role'] = self.role()
+        params['can_validate'] = self.can_validate
+        params['want_state_dump'] = self.want_state_dump
         return self.neard_runner_jsonrpc('new_test', params)
 
     def neard_runner_network_init(self,
@@ -156,7 +160,8 @@ class NodeHandle:
                                   num_seats,
                                   new_chain_id,
                                   protocol_version,
-                                  genesis_time=None):
+                                  genesis_time=None,
+                                  state_sync_location=None):
         params = {
             'validators': validators,
             'boot_nodes': boot_nodes,
@@ -169,6 +174,8 @@ class NodeHandle:
         }
         if genesis_time is not None:
             params['genesis_time'] = genesis_time
+        if state_sync_location is not None:
+            params['state_sync_location'] = state_sync_location
         return self.neard_runner_jsonrpc('network_init', params=params)
 
     def neard_runner_ready(self):

--- a/pytest/tests/mocknet/release_scenarios/base.py
+++ b/pytest/tests/mocknet/release_scenarios/base.py
@@ -58,6 +58,7 @@ class TestSetup:
         init_args = copy.deepcopy(self.args)
         init_args.neard_upgrade_binary_url = ''
         init_args.yes = True
+        init_args.gcs_state_sync = self.has_state_dumper
         hard_reset_cmd(CommandContext(init_args))
 
         # Traffic node should always run the latest binary to avoid restarting it.
@@ -122,9 +123,6 @@ class TestSetup:
         new_test_args.patches_path = None
 
         new_test_cmd(CommandContext(new_test_args))
-
-        if self.has_archival:
-            self._setup_archival()
 
     def wait_for_network_to_be_ready(self):
         """
@@ -196,7 +194,8 @@ class TestSetup:
         """
         Amend the configs for the test.
         """
-        pass
+        if self.has_archival:
+            self._setup_archival()
 
     def start_network(self):
         """

--- a/pytest/tests/mocknet/remote_node.py
+++ b/pytest/tests/mocknet/remote_node.py
@@ -129,7 +129,7 @@ class RemoteNeardRunner:
         return json.loads(r.stdout)
 
     def new_test_params(self):
-        return []
+        return {}
 
     def get_validators(self):
         return self.node.get_validators()


### PR DESCRIPTION
During the init, mirror.py sends configs to the host that can be inferred locally. Let the host decide the default configs to reduce the number of requests done to the hosts.

The possibility to update the configs is not hindered by this change. Use `mirror update-config`