### PR TITLE
feat: spice: Add CI rule to run spice tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,13 @@ jobs:
             type: stable
             upload_profraws: true
             run_on_pr: true
+          # TODO(#13341): Remove separate spice test checks once spice tests can run as part of nightly or stable tests.
+          - name: Linux Spice
+            id: linux-spice
+            os: warp-ubuntu-2204-x64-16x
+            type: spice
+            upload_profraws: true
+            run_on_pr: true
           - name: Linux Nightly
             id: linux-nightly
             os: warp-ubuntu-2204-x64-16x
@@ -54,10 +61,17 @@ jobs:
 
       # Run the tests
       - name: just nextest-slow ${{ matrix.type }} (with coverage)
-        if: github.event_name != 'pull_request' || matrix.run_on_pr
+        if: (github.event_name != 'pull_request' || matrix.run_on_pr) && matrix.type != 'spice'
         run: |
           mkdir -p coverage/profraw/{unit,binaries}
           just codecov-ci "nextest-slow ${{ matrix.type }}"
+
+      # Run spice tests.
+      - name: just nextest-spice (with coverage)
+        if: matrix.type == 'spice'
+        run: |
+          mkdir -p coverage/profraw/{unit,binaries}
+          just codecov-ci "nextest-spice"
 
       # Upload the coverage files
       - if: github.event_name != 'pull_request' || matrix.run_on_pr

--- a/Justfile
+++ b/Justfile
@@ -28,6 +28,7 @@ test-ci *FLAGS: check-cargo-fmt \
                 check-cargo-udeps \
                 (nextest "stable" FLAGS) \
                 (nextest "nightly" FLAGS) \
+                nextest-spice \
                 doctests
 # order them with the fastest / most likely to fail checks first
 # when changing this, remember to adjust the CI workflow in parallel, as CI runs each of these in a separate job
@@ -52,6 +53,10 @@ nextest TYPE *FLAGS:
 
 nextest-slow TYPE *FLAGS: (nextest TYPE "--ignore-default-filter -E 'default() + test(/^(.*::slow_test|slow_test)/)'" FLAGS)
 nextest-all TYPE *FLAGS: (nextest TYPE "--ignore-default-filter -E 'all()'" FLAGS)
+
+# TODO(#13341): Remove once spice tests can run as part of nightly or stable tests.
+spice_test_filterset := "-E 'all() & (test(/^chunk_executor_actor/) + test(spice))'"
+nextest-spice *FLAGS: (nextest "stable" "--features protocol_feature_spice" "--ignore-default-filter" spice_test_filterset FLAGS)
 
 doctests:
     cargo test --doc


### PR DESCRIPTION
As is when spice codepaths are enabled existing tests would fail so we cannot run them as part of nightly yet.

Eventually we will fix the tests and use protocol feature instead of conditional compilation, but since we are starting to add unit-tests already it would be useful in the meantime to run them as part of CI.

Part of https://github.com/near/nearcore/issues/13341