### PR TITLE
chore(ed25519-batch): use same messages for test / bench

### DIFF
--- a/core/crypto/ed25519-batch/benches/ed25519_benchmarks.rs
+++ b/core/crypto/ed25519-batch/benches/ed25519_benchmarks.rs
@@ -14,6 +14,9 @@
 
 use criterion::{Criterion, criterion_group};
 
+// Arbitrary message to sign
+const MESSAGE_TO_SIGN: &[u8] = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
 mod ed25519_benches {
     use super::*;
     use ed25519_dalek::Signature;
@@ -26,11 +29,10 @@ mod ed25519_benches {
     fn verify(c: &mut Criterion) {
         let mut csprng: ThreadRng = thread_rng();
         let keypair: SigningKey = SigningKey::generate(&mut csprng);
-        let msg: &[u8] = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        let sig: Signature = keypair.sign(msg);
+        let sig: Signature = keypair.sign(MESSAGE_TO_SIGN);
 
         c.bench_function("Ed25519 signature verification", move |b| {
-            b.iter(|| keypair.verify(msg, &sig))
+            b.iter(|| keypair.verify(MESSAGE_TO_SIGN, &sig))
         });
     }
 
@@ -46,9 +48,9 @@ mod ed25519_benches {
                 let mut csprng: ThreadRng = thread_rng();
                 let keypairs: Vec<SigningKey> =
                     (0..size).map(|_| SigningKey::generate(&mut csprng)).collect();
-                let msg: &[u8] = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-                let messages: Vec<&[u8]> = (0..size).map(|_| msg).collect();
-                let signatures: Vec<Signature> = keypairs.iter().map(|key| key.sign(msg)).collect();
+                let messages: Vec<&[u8]> = (0..size).map(|_| MESSAGE_TO_SIGN).collect();
+                let signatures: Vec<Signature> =
+                    keypairs.iter().map(|key| key.sign(MESSAGE_TO_SIGN)).collect();
                 let verifying_keys: Vec<_> =
                     keypairs.iter().map(|key| key.verifying_key()).collect();
 

--- a/core/crypto/ed25519-batch/benches/ed25519_benchmarks.rs
+++ b/core/crypto/ed25519-batch/benches/ed25519_benchmarks.rs
@@ -26,7 +26,7 @@ mod ed25519_benches {
     fn verify(c: &mut Criterion) {
         let mut csprng: ThreadRng = thread_rng();
         let keypair: SigningKey = SigningKey::generate(&mut csprng);
-        let msg: &[u8] = b"";
+        let msg: &[u8] = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let sig: Signature = keypair.sign(msg);
 
         c.bench_function("Ed25519 signature verification", move |b| {

--- a/core/crypto/ed25519-batch/benches/ed25519_benchmarks.rs
+++ b/core/crypto/ed25519-batch/benches/ed25519_benchmarks.rs
@@ -14,15 +14,13 @@
 
 use criterion::{Criterion, criterion_group};
 
-// Arbitrary message to sign
-const MESSAGE_TO_SIGN: &[u8] = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-
 mod ed25519_benches {
     use super::*;
     use ed25519_dalek::Signature;
     use ed25519_dalek::Signer;
     use ed25519_dalek::SigningKey;
     use near_crypto_ed25519_batch::safe_verify_batch;
+    use near_crypto_ed25519_batch::test_utils::MESSAGE_TO_SIGN;
     use rand::prelude::ThreadRng;
     use rand::thread_rng;
 

--- a/core/crypto/ed25519-batch/src/lib.rs
+++ b/core/crypto/ed25519-batch/src/lib.rs
@@ -9,3 +9,9 @@ mod signature;
 
 pub use batch::safe_verify_batch;
 pub use errors::SignatureError;
+
+pub mod test_utils {
+    // Arbitrary message tests and benchmarks can use to sign.
+    pub const MESSAGE_TO_SIGN: &[u8] =
+        b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+}

--- a/core/crypto/ed25519-batch/tests/ed25519.rs
+++ b/core/crypto/ed25519-batch/tests/ed25519.rs
@@ -14,12 +14,10 @@
 
 use ed25519_dalek::*;
 
-// Arbitrary message to sign
-const MESSAGE_TO_SIGN: &[u8] = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-
 mod integrations {
     use super::*;
     use near_crypto_ed25519_batch::safe_verify_batch;
+    use near_crypto_ed25519_batch::test_utils::MESSAGE_TO_SIGN;
     use rand::rngs::OsRng;
 
     #[test]

--- a/core/crypto/ed25519-batch/tests/ed25519.rs
+++ b/core/crypto/ed25519-batch/tests/ed25519.rs
@@ -1,8 +1,9 @@
-// cspell:ignore csprng dumbin jewellery
+// cspell:ignore csprng
 // This file is based on https://github.com/dalek-cryptography/curve25519-dalek/blob/curve25519-4.1.3/ed25519-dalek/benches/ed25519_benchmarks.rs
 // Modifications:
 // - Modified test for `safe_verify_batch_seven_signatures` to use `safe_verify_batch`.
 // - Removed other tests.
+// - Replaced messages with same message used in benchmarks
 //
 // This file is part of ed25519-dalek.
 // Copyright (c) 2017-2019 isis lovecruft
@@ -20,19 +21,14 @@ mod integrations {
 
     #[test]
     fn safe_verify_batch_seven_signatures() {
-        let messages: [&[u8]; 7] = [
-            b"Watch closely everyone, I'm going to show you how to kill a god.",
-            b"I'm not a cryptographer I just encrypt a lot.",
-            b"Still not a cryptographer.",
-            b"This is a test of the tsunami alert system. This is only a test.",
-            b"Fuck dumbin' it down, spit ice, skip jewellery: Molotov cocktails on me like accessories.",
-            b"Hey, I never cared about your bucks, so if I run up with a mask on, probably got a gas can too.",
-            b"And I'm not here to fill 'er up. Nope, we came to riot, here to incite, we don't want any of your stuff.", ];
+        let num_messages = 7;
+        let msg: &[u8] = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let messages: Vec<&[u8]> = (0..num_messages).map(|_| msg).collect();
         let mut csprng = OsRng;
         let mut verifying_keys: Vec<VerifyingKey> = Vec::new();
         let mut signatures: Vec<Signature> = Vec::new();
 
-        for msg in messages {
+        for msg in messages.iter() {
             let signing_key: SigningKey = SigningKey::generate(&mut csprng);
             signatures.push(signing_key.sign(msg));
             verifying_keys.push(signing_key.verifying_key());
@@ -51,14 +47,9 @@ mod integrations {
         use std::io::BufReader;
 
         // Same seven messages as safe_verify_batch_seven_signatures
-        let messages: [&[u8]; 7] = [
-            b"Watch closely everyone, I'm going to show you how to kill a god.",
-            b"I'm not a cryptographer I just encrypt a lot.",
-            b"Still not a cryptographer.",
-            b"This is a test of the tsunami alert system. This is only a test.",
-            b"Fuck dumbin' it down, spit ice, skip jewellery: Molotov cocktails on me like accessories.",
-            b"Hey, I never cared about your bucks, so if I run up with a mask on, probably got a gas can too.",
-            b"And I'm not here to fill 'er up. Nope, we came to riot, here to incite, we don't want any of your stuff.", ];
+        let num_messages = 7;
+        let msg: &[u8] = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let messages: Vec<&[u8]> = (0..num_messages).map(|_| msg).collect();
         let mut csprng = OsRng;
         let mut signing_keys: Vec<SigningKey> = Vec::new();
         let mut signatures: Vec<Signature> = Vec::new();
@@ -79,7 +70,7 @@ mod integrations {
             panic!("Problem in deserializing the test instances file");
         };
 
-        for msg in messages {
+        for msg in messages.iter() {
             let signing_key = SigningKey::generate(&mut csprng);
             signatures.push(signing_key.sign(msg));
             signing_keys.push(signing_key);

--- a/core/crypto/ed25519-batch/tests/ed25519.rs
+++ b/core/crypto/ed25519-batch/tests/ed25519.rs
@@ -28,7 +28,7 @@ mod integrations {
         let mut verifying_keys: Vec<VerifyingKey> = Vec::new();
         let mut signatures: Vec<Signature> = Vec::new();
 
-        for msg in messages.iter() {
+        for msg in &messages {
             let signing_key: SigningKey = SigningKey::generate(&mut csprng);
             signatures.push(signing_key.sign(msg));
             verifying_keys.push(signing_key.verifying_key());
@@ -70,7 +70,7 @@ mod integrations {
             panic!("Problem in deserializing the test instances file");
         };
 
-        for msg in messages.iter() {
+        for msg in &messages {
             let signing_key = SigningKey::generate(&mut csprng);
             signatures.push(signing_key.sign(msg));
             signing_keys.push(signing_key);

--- a/core/crypto/ed25519-batch/tests/ed25519.rs
+++ b/core/crypto/ed25519-batch/tests/ed25519.rs
@@ -14,6 +14,9 @@
 
 use ed25519_dalek::*;
 
+// Arbitrary message to sign
+const MESSAGE_TO_SIGN: &[u8] = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
 mod integrations {
     use super::*;
     use near_crypto_ed25519_batch::safe_verify_batch;
@@ -22,8 +25,7 @@ mod integrations {
     #[test]
     fn safe_verify_batch_seven_signatures() {
         let num_messages = 7;
-        let msg: &[u8] = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        let messages: Vec<&[u8]> = (0..num_messages).map(|_| msg).collect();
+        let messages: Vec<&[u8]> = (0..num_messages).map(|_| MESSAGE_TO_SIGN).collect();
         let mut csprng = OsRng;
         let mut verifying_keys: Vec<VerifyingKey> = Vec::new();
         let mut signatures: Vec<Signature> = Vec::new();
@@ -48,8 +50,7 @@ mod integrations {
 
         // Same seven messages as safe_verify_batch_seven_signatures
         let num_messages = 7;
-        let msg: &[u8] = b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        let messages: Vec<&[u8]> = (0..num_messages).map(|_| msg).collect();
+        let messages: Vec<&[u8]> = (0..num_messages).map(|_| MESSAGE_TO_SIGN).collect();
         let mut csprng = OsRng;
         let mut signing_keys: Vec<SigningKey> = Vec::new();
         let mut signatures: Vec<Signature> = Vec::new();


### PR DESCRIPTION
- Use same message for single signature benchmark as batch benchmark (for a more similar comparison across batch & single signature verification)
- Use same message as benchmarks in tests (some of the language included may be unnecessarily distracting eg https://github.com/near/nearcore/commit/45f4e859f21594cc6f8affdc6ad909db43c5a466#r164289156)

fyi @SimonRastikian 