### PR TITLE
fix(tokio_runtime): prevent expensive fmts for messages

### DIFF
--- a/core/async/src/futures.rs
+++ b/core/async/src/futures.rs
@@ -77,7 +77,7 @@ impl FutureSpawner for TokioRuntimeFutureSpawner {
 pub trait DelayedActionRunner<T> {
     fn run_later_boxed(
         &mut self,
-        name: &str,
+        name: &'static str,
         dur: Duration,
         f: Box<dyn FnOnce(&mut T, &mut dyn DelayedActionRunner<T>) + Send + 'static>,
     );
@@ -86,7 +86,7 @@ pub trait DelayedActionRunner<T> {
 pub trait DelayedActionRunnerExt<T> {
     fn run_later(
         &mut self,
-        name: &str,
+        name: &'static str,
         dur: Duration,
         f: impl FnOnce(&mut T, &mut dyn DelayedActionRunner<T>) + Send + 'static,
     );
@@ -98,7 +98,7 @@ where
 {
     fn run_later(
         &mut self,
-        name: &str,
+        name: &'static str,
         dur: Duration,
         f: impl FnOnce(&mut T, &mut dyn DelayedActionRunner<T>) + Send + 'static,
     ) {
@@ -109,7 +109,7 @@ where
 impl<T> DelayedActionRunnerExt<T> for dyn DelayedActionRunner<T> + '_ {
     fn run_later(
         &mut self,
-        name: &str,
+        name: &'static str,
         dur: Duration,
         f: impl FnOnce(&mut T, &mut dyn DelayedActionRunner<T>) + Send + 'static,
     ) {

--- a/core/async/src/tokio/sender.rs
+++ b/core/async/src/tokio/sender.rs
@@ -1,5 +1,6 @@
 use std::any::type_name;
 use std::fmt::Debug;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use futures::FutureExt;
 use futures::future::BoxFuture;
@@ -10,19 +11,22 @@ use crate::messaging::{
 };
 use crate::tokio::runtime_handle::{TokioRuntimeHandle, TokioRuntimeMessage};
 
+static SEQUENCE_NUM: AtomicU64 = AtomicU64::new(0);
+
 impl<A, M> CanSend<M> for TokioRuntimeHandle<A>
 where
     A: HandlerWithContext<M> + 'static,
     M: Message + Debug + Send + 'static,
 {
     fn send(&self, message: M) {
-        let description = format!("{}({:?})", pretty_type_name::<A>(), &message);
-        tracing::debug!(target: "tokio_runtime", "Sending sync message: {}", description);
+        let seq = SEQUENCE_NUM.fetch_add(1, Ordering::Relaxed);
+        let handler = pretty_type_name::<A>();
+        tracing::trace!(target: "tokio_runtime", seq, handler, ?message, "sending sync message");
 
         let function =
             |actor: &mut A, ctx: &mut dyn DelayedActionRunner<A>| actor.handle(message, ctx);
 
-        let message = TokioRuntimeMessage { description, function: Box::new(function) };
+        let message = TokioRuntimeMessage { seq, function: Box::new(function) };
         self.sender.send(message).unwrap();
     }
 }
@@ -35,15 +39,22 @@ where
     R: Send + 'static,
 {
     fn send(&self, message: MessageWithCallback<M, R>) {
-        let description = format!("{}({:?})", pretty_type_name::<A>(), &message);
-        tracing::debug!(target: "tokio_runtime", "Sending sync message with callback: {}", description);
+        let seq = SEQUENCE_NUM.fetch_add(1, Ordering::Relaxed);
+        let handler = pretty_type_name::<A>();
+        tracing::trace!(
+            target: "tokio_runtime",
+            seq,
+            handler,
+            ?message,
+            "sending sync message with callback"
+        );
 
         let function = move |actor: &mut A, ctx: &mut dyn DelayedActionRunner<A>| {
             let result = actor.handle(message.message, ctx);
             (message.callback)(std::future::ready(Ok(result)).boxed());
         };
 
-        let message = TokioRuntimeMessage { description, function: Box::new(function) };
+        let message = TokioRuntimeMessage { seq, function: Box::new(function) };
         self.sender.send(message).unwrap();
     }
 }
@@ -55,17 +66,16 @@ where
     R: Debug + Send + 'static,
 {
     fn send_async(&self, message: M) -> BoxFuture<'static, Result<R, AsyncSendError>> {
-        let description = format!("{}({:?})", pretty_type_name::<A>(), &message);
-        tracing::debug!(target: "tokio_runtime", "Sending async message: {}", description);
-
+        let seq = SEQUENCE_NUM.fetch_add(1, Ordering::Relaxed);
+        let handler = pretty_type_name::<A>();
+        tracing::trace!(target: "tokio_runtime", seq, handler, ?message, "sending async message");
         let (sender, receiver) = tokio::sync::oneshot::channel();
         let future = async move { receiver.await.map_err(|_| AsyncSendError::Dropped) };
         let function = move |actor: &mut A, ctx: &mut dyn DelayedActionRunner<A>| {
             let result = actor.handle(message, ctx);
             sender.send(result).unwrap();
         };
-
-        let message = TokioRuntimeMessage { description, function: Box::new(function) };
+        let message = TokioRuntimeMessage { seq, function: Box::new(function) };
         self.sender.send(message).unwrap();
         future.boxed()
     }
@@ -73,7 +83,7 @@ where
 
 impl<A> FutureSpawner for TokioRuntimeHandle<A> {
     fn spawn_boxed(&self, description: &'static str, f: BoxFuture<'static, ()>) {
-        tracing::debug!(target: "tokio_runtime", "Spawning future: FutureSpawn({})", description);
+        tracing::debug!(target: "tokio_runtime", description, "spawning future");
         self.runtime.spawn(f);
     }
 }
@@ -84,18 +94,17 @@ where
 {
     fn run_later_boxed(
         &mut self,
-        name: &str,
+        name: &'static str,
         dur: near_time::Duration,
         f: Box<dyn FnOnce(&mut A, &mut dyn DelayedActionRunner<A>) + Send + 'static>,
     ) {
-        let description = format!("DelayedAction {}({:?})", pretty_type_name::<A>(), name);
-        tracing::debug!(target: "tokio_runtime", "Sending delayed action: {}", description);
-
+        let seq = SEQUENCE_NUM.fetch_add(1, Ordering::Relaxed);
+        tracing::debug!(target: "tokio_runtime", seq, name, "sending delayed action");
         let sender = self.sender.clone();
         self.runtime.spawn(async move {
             tokio::time::sleep(dur.unsigned_abs()).await;
             let function = move |actor: &mut A, ctx: &mut dyn DelayedActionRunner<A>| f(actor, ctx);
-            let message = TokioRuntimeMessage { description, function: Box::new(function) };
+            let message = TokioRuntimeMessage { seq, function: Box::new(function) };
             sender.send(message).unwrap();
         });
     }


### PR DESCRIPTION
Printing a debug representation every time a message sent not once but twice is a significant waste of time, especially when messages can be multiple hundreds of kilobytes long. It also makes it extremely difficult to follow the logs themselves.

This keeps formatting of message contents at a an even more verbose log level (`TRACE`) and makes a point of only printing out the message contents only once. The "execute"-to-"send" logs can be tied back to each other using a sequence number of the messages. These are both super cheap to store and efficient to compute.

Fixes #14085
Fixes #14077