### PR TITLE
feat(tracing) - number of transactions in chunk application spans

### DIFF
--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -127,6 +127,8 @@ pub fn apply_new_chunk(
         chunk_hash = ?chunk_header.chunk_hash(),
         block_type = ?block.block_type,
         ?apply_reason,
+        transactions_num = transactions.len(),
+        incoming_receipts_num = receipts.len(),
         tag_block_production = true)
     .entered();
     let gas_limit = chunk_header.gas_limit();

--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -222,6 +222,7 @@ impl ChunkProducer {
         ?epoch_id,
         prev_block_hash = ?prev_block.header().hash(),
         chunk_hash = tracing::field::Empty,
+        transactions_num = tracing::field::Empty,
         tag_block_production = true
     ))]
     fn produce_chunk_internal(
@@ -335,6 +336,7 @@ impl ChunkProducer {
 
         let encoded_chunk = chunk.to_encoded_shard_chunk();
         span.record("chunk_hash", tracing::field::debug(encoded_chunk.chunk_hash()));
+        span.record("transactions_num", tracing::field::display(num_filtered_transactions));
         debug!(
             target: "client",
             num_filtered_transactions,


### PR DESCRIPTION
Show number of transactions and receipts in the chunk production/application spans. Helps figure out what load is running on the network.