### PR TITLE
feat(wasmtime): enable inlining

### DIFF
--- a/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
@@ -410,6 +410,7 @@ impl WasmtimeVM {
                     .memory_may_move(false)
                     .memory_reservation(max_memory_size.try_into().unwrap_or(u64::MAX))
                     .memory_reservation_for_growth(0)
+                    .compiler_inlining(true)
                     .cranelift_nan_canonicalization(true);
 
                 let config = Arc::clone(config);


### PR DESCRIPTION
Enable inlining. Note that the feature is still very fresh and just introduced in Wasmtime 36

https://docs.rs/wasmtime/latest/wasmtime/struct.Config.html#method.compiler_inlining