### PR TITLE
refactor: improve block_sync logging

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1419,7 +1419,7 @@ impl Chain {
 
         // Validate header and then add to the chain.
         for header in &headers {
-            match self.ensure_header_unknown(header)? {
+            match self.ensure_block_header_unknown(header)? {
                 Ok(_) => {}
                 Err(_) => continue,
             }
@@ -3331,7 +3331,7 @@ impl Chain {
     /// Returns Err(Error) if any error occurs when checking store
     ///         Ok(Err(BlockKnownError)) if the block header is known
     ///         Ok(Ok()) otherwise
-    pub fn ensure_header_unknown(
+    pub fn ensure_block_header_unknown(
         &self,
         header: &BlockHeader,
     ) -> Result<Result<(), BlockKnownError>, Error> {

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3311,7 +3311,6 @@ impl Chain {
     ///         Ok(Err(BlockKnownError)) if the block is known
     ///         Ok(Ok()) otherwise
     pub fn check_block_known(&self, block_hash: &CryptoHash) -> Result<BlockKnowledge, Error> {
-        // TODO: Change the return type to Result<BlockKnownStatusEnum, Error>.
         let head = self.chain_store().head()?;
         // Quick in-memory check for fast-reject any block handled recently.
         if block_hash == &head.last_block_hash || block_hash == &head.prev_block_hash {
@@ -3338,7 +3337,6 @@ impl Chain {
     ///         Ok(Err(BlockKnownError)) if the block header is known
     ///         Ok(Ok()) otherwise
     pub fn check_block_header_known(&self, header: &BlockHeader) -> Result<BlockKnowledge, Error> {
-        // TODO: Change the return type to Result<BlockKnownStatusEnum, Error>.
         let header_head = self.chain_store().header_head()?;
         if header.hash() == &header_head.last_block_hash
             || header.hash() == &header_head.prev_block_hash
@@ -3353,7 +3351,6 @@ impl Chain {
     ///         Ok(Err(BlockKnownError)) if the block is in the store
     ///         Ok(Ok()) otherwise
     fn check_block_known_store(&self, block_hash: &CryptoHash) -> Result<BlockKnowledge, Error> {
-        // TODO: Change the return type to Result<BlockKnownStatusEnum, Error>.
         if self.chain_store().block_exists(block_hash)? {
             Ok(BlockKnowledge::Known(BlockKnownError::KnownInStore))
         } else {

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1427,8 +1427,8 @@ impl Chain {
         // Validate header and then add to the chain.
         for header in &headers {
             match self.check_block_header_known(header)? {
-                BlockKnowledge::Unknown => {},
-                BlockKnowledge::Known(_) => continue
+                BlockKnowledge::Unknown => {}
+                BlockKnowledge::Known(_) => continue,
             }
 
             self.validate_header(header, &Provenance::SYNC)?;
@@ -2191,7 +2191,7 @@ impl Chain {
 
         // Check if we have already processed this block previously.
         if let BlockKnowledge::Known(err) = self.check_block_known(header.hash())? {
-            return Err(Error::BlockKnown(err))
+            return Err(Error::BlockKnown(err));
         }
 
         // Delay hitting the db for current chain head until we know this block is not already known.

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3332,7 +3332,7 @@ impl Chain {
         self.check_block_known_store(block_hash)
     }
 
-    /// Check if block header is known
+    /// Check if block header is known.
     /// Returns Err(Error) if any error occurs when checking store
     ///         Ok(Err(BlockKnownError)) if the block header is known
     ///         Ok(Ok()) otherwise

--- a/chain/chain/src/lib.rs
+++ b/chain/chain/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(enable_const_type_id, feature(const_type_id))]
 
 pub use block_processing_utils::BlockProcessingArtifact;
-pub use chain::{Chain, check_known, collect_receipts};
+pub use chain::{Chain, collect_receipts};
 pub use chain_update::ChainUpdate;
 pub use doomslug::{
     ChunksReadiness, Doomslug, DoomslugBlockProductionReadiness, DoomslugThresholdMode,

--- a/chain/client/src/sync/block.rs
+++ b/chain/client/src/sync/block.rs
@@ -181,39 +181,58 @@ impl BlockSync {
         // the rest of the logic succeeds.
         // TODO: If this code fails we should retry ASAP. Shouldn't we?
         let chain_head = chain.head()?;
+        let header_head = chain.header_head()?;
+        let _span = tracing::debug_span!(
+            target: "sync",
+            "block_sync",
+            head_last_block_hash = ?chain_head.last_block_hash,
+            head_height = chain_head.height,
+            header_head_height = header_head.height,
+        )
+        .entered();
+
         self.last_request =
             Some(BlockSyncRequest { head: chain_head.last_block_hash, when: self.clock.now_utc() });
 
         // The last block on the canonical chain that is processed (is in store).
         let reference_hash = self.get_last_processed_block(chain)?;
 
-        // Look ahead for max_block_requests block headers and add requests for
-        // blocks that we don't have yet.
-        let mut requests = vec![];
-        let mut next_hash = reference_hash;
-        for _ in 0..max_block_requests {
-            match chain.chain_store().get_next_block_hash(&next_hash) {
-                Ok(hash) => next_hash = hash,
-                Err(e) => match e {
-                    near_chain::Error::DBNotFoundErr(_) => break,
-                    _ => return Err(e),
-                },
-            }
-            if let Ok(_) = check_known(chain, &next_hash)? {
-                let next_height = chain.get_block_header(&next_hash)?.height();
-                requests.push((next_height, next_hash));
-            }
-        }
-
-        let header_head = chain.header_head()?;
         // Assume that peers are configured to keep as many epochs does this
         // node and expect peers to have blocks in the range
         // [gc_stop_height, header_head.last_block_hash].
         let gc_stop_height = chain.runtime_adapter.get_gc_stop_height(&header_head.last_block_hash);
 
+        // Look ahead for max_block_requests block headers and add requests for
+        // blocks that we don't have yet.
+        let mut next_hash = reference_hash;
         let mut num_requests = 0;
-        for (height, hash) in requests {
-            let request_from_archival = self.archive && height < gc_stop_height;
+        for _ in 0..max_block_requests {
+            next_hash = match chain.chain_store().get_next_block_hash(&next_hash) {
+                Ok(hash) => hash,
+                Err(e) => match e {
+                    near_chain::Error::DBNotFoundErr(_) => {
+                        debug!(
+                            target: "sync",
+                            block_hash = ?next_hash,
+                            "next block hash is not found"
+                        );
+                        break;
+                    }
+                    _ => return Err(e),
+                },
+            };
+            if let Err(err) = check_known(chain, &next_hash)? {
+                debug!(
+                    target: "sync",
+                    block_hash = ?next_hash,
+                    ?err,
+                    "block is known"
+                );
+                continue;
+            }
+
+            let next_height = chain.get_block_header(&next_hash)?.height();
+            let request_from_archival = self.archive && next_height < gc_stop_height;
             // Assume that heads of `highest_height_peers` are ahead of the blocks we're requesting.
             let peer = if request_from_archival {
                 // Normal peers are unlikely to have old blocks, request from an archival node.
@@ -228,36 +247,33 @@ impl BlockSync {
             if let Some(peer) = peer {
                 debug!(
                     target: "sync",
-                    head_height = chain_head.height,
-                    header_head_height = header_head.height,
-                    block_hash = ?hash,
-                    block_height = height,
+                    block_hash = ?next_hash,
+                    block_height = next_height,
                     request_from_archival,
                     peer = ?peer.peer_info.id,
                     num_peers = highest_height_peers.len(),
-                    "Block sync: requested block"
+                    "requested block"
                 );
                 self.network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
-                    NetworkRequests::BlockRequest { hash, peer_id: peer.peer_info.id.clone() },
+                    NetworkRequests::BlockRequest {
+                        hash: next_hash,
+                        peer_id: peer.peer_info.id.clone(),
+                    },
                 ));
                 num_requests += 1;
             } else {
                 warn!(
                     target: "sync",
-                    head_height = chain_head.height,
-                    header_head_height = header_head.height,
-                    block_hash = ?hash,
-                    block_height = height,
+                    block_hash = ?next_hash,
+                    block_height = next_height,
                     request_from_archival,
-                    "Block sync: No available peers to request a block from");
+                    "no available peers to request a block from");
             }
         }
         debug!(
             target: "sync",
-            head_height = chain_head.height,
-            header_head_height = header_head.height,
             num_requests,
-            "Block sync: requested blocks");
+            "requested blocks");
         Ok(())
     }
 

--- a/chain/client/src/sync/block.rs
+++ b/chain/client/src/sync/block.rs
@@ -2,6 +2,7 @@ use near_async::messaging::CanSend;
 use near_async::time::{Clock, Duration, Utc};
 use near_chain::Chain;
 use near_chain::ChainStoreAccess;
+use near_chain::chain::BlockKnowledge;
 use near_client_primitives::types::SyncStatus;
 use near_network::types::PeerManagerMessageRequest;
 use near_network::types::{HighestHeightPeerInfo, NetworkRequests, PeerManagerAdapter};
@@ -223,7 +224,7 @@ impl BlockSync {
                     _ => return Err(e),
                 },
             };
-            if let Err(err) = chain.ensure_block_unknown(&next_hash)? {
+            if let BlockKnowledge::Known(err) = chain.check_block_known(&next_hash)? {
                 debug!(
                     target: "sync",
                     block_hash = ?next_hash,


### PR DESCRIPTION
- add `#[instrument]` for `block_sync` function extracting common fields
- directly send request as part of `for _ in 0..max_block_requests` instead of accumulating `requests`
- log when next block hash is not found
- log when block is known
- the following functions are renamed and moved as member functions to `Chain`: `check_header_known`, `check_known`, `check_known_store` 
- `BlockKnowledge` enum is introduced to replace `Result<(), BlockKnownError>`