### PR TITLE
create outcome for each transaction in the processed chunk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5531,6 +5531,7 @@ dependencies = [
  "near-vm-runner",
  "near-wallet-contract",
  "num-bigint 0.3.3",
+ "num-integer",
  "num-traits",
  "parking_lot 0.12.1",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5513,6 +5513,7 @@ dependencies = [
  "base64 0.21.0",
  "borsh",
  "bytesize 1.1.0",
+ "crossbeam-utils",
  "dashmap",
  "ed25519-dalek",
  "enum-map",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,7 @@ criterion = { version = "0.7.0", default-features = false, features = [
 ] }
 crossbeam = "0.8"
 crossbeam-channel = "0.5.8"
+crossbeam-utils = "0.8"
 csv = "1.2.1"
 curve25519-dalek = { version = "4.1.3", default-features = false }
 dashmap = { version = "6", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -305,6 +305,7 @@ num-bigint = "0.3"
 num_cpus = "1.11"
 num-rational = { version = "0.3.1", features = ["serde"] }
 num-traits = "0.2.15"
+num-integer = "0.1.46"
 
 okapi = { git = "https://github.com/near/near-okapi-fork.git", rev = "fd7de89e130ab99a546f04e3faefcd53044f98d0", features = ["schemars-alpha"] } # Upstream crate can be used as soon as schemars 1.0 is supported https://github.com/GREsau/okapi/pull/161
 object_store = { version = "0.12", features = ["gcp"] }

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -36,7 +36,7 @@ fn build_chain() {
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
         // cspell:disable-next-line
-        insta::assert_snapshot!(hash, @"EAc2t48pf5BtysasG98CYcuMwovGVSqexpckKCvtDfco");
+        insta::assert_snapshot!(hash, @"DPEV3B69QAFVK55yVtwrbxbGBoZvwHG7QtezJv8Yk3R4");
     } else {
         // cspell:disable-next-line
         insta::assert_snapshot!(hash, @"29v1yk13bodFUYHAkTG8nRu2SvBScCEESreie3hEmc78");
@@ -56,7 +56,7 @@ fn build_chain() {
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
         // cspell:disable-next-line
-        insta::assert_snapshot!(hash, @"HgcqkqdeLB4PrY6212BtPYkkK7p7cCxnsYsFL62VAeLK");
+        insta::assert_snapshot!(hash, @"Aeimt3DNKXHMrGTY7gPB4YZ6xAnXguyDHYDUeabzJMLR");
     } else {
         // cspell:disable-next-line
         insta::assert_snapshot!(hash, @"FwKRg6eY9dSgUWrN45ZxFTeJ8Eqgfwe6s3EboqD1PvhF");

--- a/chain/chain/src/tests/simple_chain.rs
+++ b/chain/chain/src/tests/simple_chain.rs
@@ -36,7 +36,7 @@ fn build_chain() {
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
         // cspell:disable-next-line
-        insta::assert_snapshot!(hash, @"DPEV3B69QAFVK55yVtwrbxbGBoZvwHG7QtezJv8Yk3R4");
+        insta::assert_snapshot!(hash, @"92FxojHuVNjHq91GuwyCVZXCH4cxJKmmsrbpmUuJ9Yfh");
     } else {
         // cspell:disable-next-line
         insta::assert_snapshot!(hash, @"29v1yk13bodFUYHAkTG8nRu2SvBScCEESreie3hEmc78");
@@ -56,7 +56,7 @@ fn build_chain() {
     let hash = chain.head().unwrap().last_block_hash;
     if cfg!(feature = "nightly") {
         // cspell:disable-next-line
-        insta::assert_snapshot!(hash, @"Aeimt3DNKXHMrGTY7gPB4YZ6xAnXguyDHYDUeabzJMLR");
+        insta::assert_snapshot!(hash, @"GT96L4juwtGQH2sfq6aARf5fjn6xL8oczfH8khcUZXqN");
     } else {
         // cspell:disable-next-line
         insta::assert_snapshot!(hash, @"FwKRg6eY9dSgUWrN45ZxFTeJ8Eqgfwe6s3EboqD1PvhF");

--- a/chain/jsonrpc/openapi/openapi.json
+++ b/chain/jsonrpc/openapi/openapi.json
@@ -9028,7 +9028,7 @@
         "oneOf": [
           {
             "additionalProperties": false,
-            "description": "Create an (sub)account using a transaction `receiver_id` as an ID for\na new account ID must pass validation rules described here\n<http://nomicon.io/Primitives/Account.html>.",
+            "description": "Create an (sub)account using a transaction `receiver_id` as an ID for\na new account ID must pass validation rules described here\n<https://nomicon.io/DataStructures/Account>.",
             "properties": {
               "CreateAccount": {
                 "$ref": "#/components/schemas/CreateAccountAction"

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -327,6 +327,7 @@ pub enum ProtocolFeature {
     StatePartsCompression,
     /// NEP: https://github.com/near/NEPs/pull/616
     DeterministicAccountIds,
+    InvalidTxGenerateOutcomes,
 }
 
 impl ProtocolFeature {
@@ -433,6 +434,7 @@ impl ProtocolFeature {
             ProtocolFeature::ShuffleShardAssignments => 143,
             ProtocolFeature::ExcludeExistingCodeFromWitnessForCodeLen => 148,
             ProtocolFeature::DeterministicAccountIds => 150,
+            ProtocolFeature::InvalidTxGenerateOutcomes => 151,
             // Place features that are not yet in Nightly below this line.
         }
     }
@@ -452,7 +454,7 @@ pub const MIN_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = 77;
 const STABLE_PROTOCOL_VERSION: ProtocolVersion = 81;
 
 // On nightly, pick big enough version to support all features.
-const NIGHTLY_PROTOCOL_VERSION: ProtocolVersion = 150;
+const NIGHTLY_PROTOCOL_VERSION: ProtocolVersion = 152;
 
 /// Largest protocol version supported by the current binary.
 pub const PROTOCOL_VERSION: ProtocolVersion =

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -454,7 +454,7 @@ pub const MIN_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = 77;
 const STABLE_PROTOCOL_VERSION: ProtocolVersion = 81;
 
 // On nightly, pick big enough version to support all features.
-const NIGHTLY_PROTOCOL_VERSION: ProtocolVersion = 152;
+const NIGHTLY_PROTOCOL_VERSION: ProtocolVersion = 151;
 
 /// Largest protocol version supported by the current binary.
 pub const PROTOCOL_VERSION: ProtocolVersion =

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -568,6 +568,17 @@ pub struct ExecutionOutcomeWithId {
 }
 
 impl ExecutionOutcomeWithId {
+    pub fn failed(transaction: &SignedTransaction, error: InvalidTxError) -> Self {
+        Self {
+            id: transaction.get_hash(),
+            outcome: ExecutionOutcome {
+                executor_id: transaction.transaction.signer_id().clone(),
+                status: ExecutionStatus::Failure(TxExecutionError::InvalidTxError(error)),
+                ..Default::default()
+            },
+        }
+    }
+
     pub fn to_hashes(&self) -> Vec<CryptoHash> {
         let mut result = Vec::with_capacity(2 + self.outcome.logs.len());
         result.push(self.id);

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 base64 = { workspace = true, optional = true }
 borsh.workspace = true
 bytesize.workspace = true
+crossbeam-utils.workspace = true
 dashmap.workspace = true
 ed25519-dalek.workspace = true
 itertools.workspace = true

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -20,6 +20,7 @@ ed25519-dalek.workspace = true
 itertools.workspace = true
 num-bigint.workspace = true
 num-traits.workspace = true
+num-integer.workspace = true
 parking_lot.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1943,6 +1943,10 @@ impl Runtime {
             metrics::TRANSACTION_PROCESSED_SUCCESSFULLY_TOTAL.inc();
         }
 
+        if ProtocolFeature::InvalidTxGenerateOutcomes.enabled(protocol_version) {
+            debug_assert!(processing_state.outcomes.len() == num_transactions);
+        }
+
         processing_state
             .metrics
             .tx_processing_done(processing_state.total.gas, processing_state.total.compute);

--- a/runtime/runtime/src/types.rs
+++ b/runtime/runtime/src/types.rs
@@ -51,4 +51,11 @@ impl SignedValidPeriodTransactions {
     pub fn len(&self) -> usize {
         self.transactions.len()
     }
+
+    /// get references to underlying fields
+    pub fn get_potentially_expired_transactions_and_expiration_flags(
+        &self,
+    ) -> (&[SignedTransaction], &[bool]) {
+        (&self.transactions, &self.transaction_validity_check_passed)
+    }
 }


### PR DESCRIPTION
Transactions that fail validation were dropped previously and now the outcome will be registered in the `state_change` with the `Failed` status.

- Extracted the single transaction processing into a function making sure that every transaction generates an outcome (apart from `RuntimeError` cases that result in chunk being dropped)
- added the Protocol feature to include every outcome into the `state_change` instead of quietly dropping the transactions that failed validation.
- added new error to signal the overflow when calculating the total gas burnt by the chunk. This one I am not really sure about. This may not be actionable by the party generating the transaction and the case may be better handled by throwing `RuntimeError` and dropping the chunk as the transaction gas usage alone has been already validated before.