### PR TITLE
perf: further tune rocksdb with per column config 

### DIFF
--- a/benchmarks/sharded-bm/cases/base_config_patch.json
+++ b/benchmarks/sharded-bm/cases/base_config_patch.json
@@ -9,7 +9,9 @@
         }
     },
     "store": {
-       "load_mem_tries_for_tracked_shards": true
+       "load_mem_tries_for_tracked_shards": true,
+       "col_flat_state_cache_size": 32000000,
+       "max_open_files": 5000
     },
     "view_client_threads": 4,
     "produce_chunk_add_transactions_time_limit": {

--- a/benchmarks/sharded-bm/cases/base_config_patch.json
+++ b/benchmarks/sharded-bm/cases/base_config_patch.json
@@ -10,8 +10,7 @@
     },
     "store": {
        "load_mem_tries_for_tracked_shards": true,
-       "col_flat_state_cache_size": 32000000,
-       "max_open_files": 5000
+       "col_flat_state_cache_size": 32000000
     },
     "view_client_threads": 4,
     "produce_chunk_add_transactions_time_limit": {

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -205,8 +205,13 @@ impl StoreConfig {
             | DBCol::StateTransitionData
             | DBCol::OutgoingReceipts
             | DBCol::IncomingReceipts
+            | DBCol::TransactionResultForBlock
+            | DBCol::BlockHeader
+            | DBCol::Block
+            | DBCol::BlockMerkleTree
+            | DBCol::OutcomeIds
+            | DBCol::ChunkExtra
             | DBCol::FlatStateChanges => bytesize::ByteSize::mib(32),
-            // Less 'hot' columns get a smaller cache
             _ => bytesize::ByteSize::mib(16),
         }
     }

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -196,23 +196,7 @@ impl StoreConfig {
         match col {
             DBCol::State => self.col_state_cache_size,
             DBCol::FlatState => self.col_flat_state_cache_size,
-            DBCol::PartialChunks
-            | DBCol::TrieChanges
-            | DBCol::StateChanges
-            | DBCol::Chunks
-            | DBCol::Transactions
-            | DBCol::Receipts
-            | DBCol::StateTransitionData
-            | DBCol::OutgoingReceipts
-            | DBCol::IncomingReceipts
-            | DBCol::TransactionResultForBlock
-            | DBCol::BlockHeader
-            | DBCol::Block
-            | DBCol::BlockMerkleTree
-            | DBCol::OutcomeIds
-            | DBCol::ChunkExtra
-            | DBCol::FlatStateChanges => bytesize::ByteSize::mib(32),
-            _ => bytesize::ByteSize::mib(16),
+            _ => bytesize::ByteSize::mib(32),
         }
     }
 

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -196,7 +196,18 @@ impl StoreConfig {
         match col {
             DBCol::State => self.col_state_cache_size,
             DBCol::FlatState => self.col_flat_state_cache_size,
-            _ => bytesize::ByteSize::mib(32),
+            DBCol::PartialChunks
+            | DBCol::TrieChanges
+            | DBCol::StateChanges
+            | DBCol::Chunks
+            | DBCol::Transactions
+            | DBCol::Receipts
+            | DBCol::StateTransitionData
+            | DBCol::OutgoingReceipts
+            | DBCol::IncomingReceipts
+            | DBCol::FlatStateChanges => bytesize::ByteSize::mib(32),
+            // Less 'hot' columns get a smaller cache
+            _ => bytesize::ByteSize::mib(16),
         }
     }
 

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -547,7 +547,9 @@ fn common_rocksdb_options() -> Options {
         opts.set_level_zero_file_num_compaction_trigger(-1);
         opts.set_level_zero_stop_writes_trigger(100000000);
     } else {
-        opts.increase_parallelism(std::cmp::max(1, num_cpus::get() as i32 / 2));
+        let parallelism = std::cmp::max(1, num_cpus::get() as i32 * 3 / 5);
+        opts.increase_parallelism(parallelism);
+        opts.set_max_background_jobs(parallelism);
         opts.set_max_total_wal_size(bytesize::GIB);
     }
     opts
@@ -625,22 +627,36 @@ fn rocksdb_column_options(col: DBCol, store_config: &StoreConfig, temp: Temperat
     // See the implementation here:
     //      https://github.com/facebook/rocksdb/blob/c18c4a081c74251798ad2a1abf83bad417518481/options/options.cc#L588.
     // Increase memory budget to reduce flush/compaction frequency under heavy write load
-    let memtable_memory_budget = 1024 * bytesize::MIB as usize;
-    opts.optimize_level_style_compaction(memtable_memory_budget);
+    opts.optimize_level_style_compaction(512 * bytesize::MIB as usize);
     // Relax L0 triggers so background compaction interferes less with foreground writes
     opts.set_level_zero_file_num_compaction_trigger(8);
     opts.set_level_zero_slowdown_writes_trigger(32);
     opts.set_level_zero_stop_writes_trigger(64);
     // Allow more memtables in flight to absorb bursts
-    opts.set_max_write_buffer_number(8);
-
+    opts.set_max_write_buffer_number(4);
     // Larger target file size reduces number of files and compactions
     opts.set_target_file_size_base(128 * bytesize::MIB);
     // Help compaction read sequentially by adding readahead on the device
-    opts.set_compaction_readahead_size(4 * bytesize::MIB as usize);
+    opts.set_compaction_readahead_size(2 * bytesize::MIB as usize);
+
     if temp == Temperature::Hot && col.is_rc() {
         opts.set_merge_operator("refcount merge", RocksDB::refcount_merge, RocksDB::refcount_merge);
         opts.set_compaction_filter("empty value filter", RocksDB::empty_value_compaction_filter);
+    }
+
+    // Optimize write-heavy columns to boost compaction throughput
+    match col {
+        DBCol::PartialChunks => {
+            opts.optimize_level_style_compaction(1024 * bytesize::MIB as usize);
+            opts.set_level_zero_file_num_compaction_trigger(8);
+            opts.set_level_zero_slowdown_writes_trigger(48);
+            opts.set_level_zero_stop_writes_trigger(96);
+            opts.set_max_subcompactions(2);
+            opts.set_target_file_size_base(192 * bytesize::MIB);
+            opts.set_max_write_buffer_number(8);
+            opts.set_compaction_readahead_size(4 * bytesize::MIB as usize);
+        }
+        _ => {}
     }
     opts
 }

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -651,7 +651,7 @@ fn rocksdb_column_options(col: DBCol, store_config: &StoreConfig, temp: Temperat
             opts.set_max_subcompactions(2);
             opts.set_target_file_size_base(128 * bytesize::MIB);
             opts.set_max_write_buffer_number(8);
-            opts.set_compaction_readahead_size(4 * bytesize::MIB as usize);
+            opts.set_compaction_readahead_size(6 * bytesize::MIB as usize);
         }
         DBCol::FlatState | DBCol::Chunks | DBCol::StateChanges | DBCol::Transactions => {
             opts.optimize_level_style_compaction(512 * bytesize::MIB as usize);
@@ -660,7 +660,7 @@ fn rocksdb_column_options(col: DBCol, store_config: &StoreConfig, temp: Temperat
             opts.set_level_zero_stop_writes_trigger(64);
             opts.set_target_file_size_base(128 * bytesize::MIB);
             opts.set_max_write_buffer_number(6);
-            opts.set_compaction_readahead_size(3 * bytesize::MIB as usize);
+            opts.set_compaction_readahead_size(4 * bytesize::MIB as usize);
         }
         _ => {}
     }

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -547,10 +547,7 @@ fn common_rocksdb_options() -> Options {
         opts.set_level_zero_file_num_compaction_trigger(-1);
         opts.set_level_zero_stop_writes_trigger(100000000);
     } else {
-        let parallelism = std::cmp::max(1, num_cpus::get() as i32 * 3 / 5);
-        opts.increase_parallelism(parallelism);
-        opts.set_max_background_jobs(parallelism);
-        opts.set_max_total_wal_size(bytesize::GIB);
+        opts.increase_parallelism(std::cmp::max(1, num_cpus::get() as i32 / 2));
     }
     opts
 }

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -548,6 +548,7 @@ fn common_rocksdb_options() -> Options {
         opts.set_level_zero_stop_writes_trigger(100000000);
     } else {
         opts.increase_parallelism(std::cmp::max(1, num_cpus::get() as i32 / 2));
+        opts.set_max_total_wal_size(bytesize::GIB);
     }
     opts
 }

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -548,7 +548,7 @@ fn common_rocksdb_options() -> Options {
         opts.set_level_zero_stop_writes_trigger(100000000);
     } else {
         opts.increase_parallelism(std::cmp::max(1, num_cpus::get() as i32 / 2));
-        opts.set_max_total_wal_size(bytesize::GIB);
+        opts.set_max_total_wal_size(4 * bytesize::GIB);
     }
     opts
 }

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -643,24 +643,24 @@ fn rocksdb_column_options(col: DBCol, store_config: &StoreConfig, temp: Temperat
 
     // Optimize write-heavy columns to boost compaction throughput
     match col {
-        DBCol::PartialChunks => {
+        DBCol::PartialChunks | DBCol::State | DBCol::TrieChanges => {
             opts.optimize_level_style_compaction(1024 * bytesize::MIB as usize);
             opts.set_level_zero_file_num_compaction_trigger(8);
-            opts.set_level_zero_slowdown_writes_trigger(48);
-            opts.set_level_zero_stop_writes_trigger(96);
-            opts.set_max_subcompactions(3);
+            opts.set_level_zero_slowdown_writes_trigger(32);
+            opts.set_level_zero_stop_writes_trigger(64);
+            opts.set_max_subcompactions(2);
             opts.set_target_file_size_base(192 * bytesize::MIB);
             opts.set_max_write_buffer_number(8);
-            opts.set_compaction_readahead_size(4 * bytesize::MIB as usize);
+            opts.set_compaction_readahead_size(6 * bytesize::MIB as usize);
         }
-        DBCol::State | DBCol::TrieChanges => {
+        DBCol::FlatState | DBCol::Chunks | DBCol::StateChanges | DBCol::Transactions => {
             opts.optimize_level_style_compaction(512 * bytesize::MIB as usize);
             opts.set_level_zero_file_num_compaction_trigger(8);
             opts.set_level_zero_slowdown_writes_trigger(32);
             opts.set_level_zero_stop_writes_trigger(64);
             opts.set_target_file_size_base(128 * bytesize::MIB);
             opts.set_max_write_buffer_number(6);
-            opts.set_compaction_readahead_size(2 * bytesize::MIB as usize);
+            opts.set_compaction_readahead_size(4 * bytesize::MIB as usize);
         }
         _ => {}
     }

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -634,7 +634,7 @@ fn rocksdb_column_options(col: DBCol, store_config: &StoreConfig, temp: Temperat
     // Larger target file size reduces number of files and compactions
     opts.set_target_file_size_base(96 * bytesize::MIB);
     // Help compaction read sequentially by adding readahead on the device
-    opts.set_compaction_readahead_size(1 * bytesize::MIB as usize);
+    opts.set_compaction_readahead_size(2 * bytesize::MIB as usize);
 
     if temp == Temperature::Hot && col.is_rc() {
         opts.set_merge_operator("refcount merge", RocksDB::refcount_merge, RocksDB::refcount_merge);
@@ -649,9 +649,9 @@ fn rocksdb_column_options(col: DBCol, store_config: &StoreConfig, temp: Temperat
             opts.set_level_zero_slowdown_writes_trigger(32);
             opts.set_level_zero_stop_writes_trigger(64);
             opts.set_max_subcompactions(2);
-            opts.set_target_file_size_base(192 * bytesize::MIB);
+            opts.set_target_file_size_base(128 * bytesize::MIB);
             opts.set_max_write_buffer_number(8);
-            opts.set_compaction_readahead_size(6 * bytesize::MIB as usize);
+            opts.set_compaction_readahead_size(4 * bytesize::MIB as usize);
         }
         DBCol::FlatState | DBCol::Chunks | DBCol::StateChanges | DBCol::Transactions => {
             opts.optimize_level_style_compaction(512 * bytesize::MIB as usize);
@@ -660,7 +660,7 @@ fn rocksdb_column_options(col: DBCol, store_config: &StoreConfig, temp: Temperat
             opts.set_level_zero_stop_writes_trigger(64);
             opts.set_target_file_size_base(128 * bytesize::MIB);
             opts.set_max_write_buffer_number(6);
-            opts.set_compaction_readahead_size(4 * bytesize::MIB as usize);
+            opts.set_compaction_readahead_size(3 * bytesize::MIB as usize);
         }
         _ => {}
     }

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -627,7 +627,7 @@ fn rocksdb_column_options(col: DBCol, store_config: &StoreConfig, temp: Temperat
     // See the implementation here:
     //      https://github.com/facebook/rocksdb/blob/c18c4a081c74251798ad2a1abf83bad417518481/options/options.cc#L588.
     // Increase memory budget to reduce flush/compaction frequency under heavy write load
-    opts.optimize_level_style_compaction(512 * bytesize::MIB as usize);
+    opts.optimize_level_style_compaction(256 * bytesize::MIB as usize);
     // Relax L0 triggers so background compaction interferes less with foreground writes
     opts.set_level_zero_file_num_compaction_trigger(8);
     opts.set_level_zero_slowdown_writes_trigger(32);
@@ -635,9 +635,9 @@ fn rocksdb_column_options(col: DBCol, store_config: &StoreConfig, temp: Temperat
     // Allow more memtables in flight to absorb bursts
     opts.set_max_write_buffer_number(4);
     // Larger target file size reduces number of files and compactions
-    opts.set_target_file_size_base(128 * bytesize::MIB);
+    opts.set_target_file_size_base(96 * bytesize::MIB);
     // Help compaction read sequentially by adding readahead on the device
-    opts.set_compaction_readahead_size(2 * bytesize::MIB as usize);
+    opts.set_compaction_readahead_size(1 * bytesize::MIB as usize);
 
     if temp == Temperature::Hot && col.is_rc() {
         opts.set_merge_operator("refcount merge", RocksDB::refcount_merge, RocksDB::refcount_merge);
@@ -651,10 +651,19 @@ fn rocksdb_column_options(col: DBCol, store_config: &StoreConfig, temp: Temperat
             opts.set_level_zero_file_num_compaction_trigger(8);
             opts.set_level_zero_slowdown_writes_trigger(48);
             opts.set_level_zero_stop_writes_trigger(96);
-            opts.set_max_subcompactions(2);
+            opts.set_max_subcompactions(3);
             opts.set_target_file_size_base(192 * bytesize::MIB);
             opts.set_max_write_buffer_number(8);
             opts.set_compaction_readahead_size(4 * bytesize::MIB as usize);
+        }
+        DBCol::State | DBCol::TrieChanges => {
+            opts.optimize_level_style_compaction(512 * bytesize::MIB as usize);
+            opts.set_level_zero_file_num_compaction_trigger(8);
+            opts.set_level_zero_slowdown_writes_trigger(32);
+            opts.set_level_zero_stop_writes_trigger(64);
+            opts.set_target_file_size_base(128 * bytesize::MIB);
+            opts.set_max_write_buffer_number(6);
+            opts.set_compaction_readahead_size(2 * bytesize::MIB as usize);
         }
         _ => {}
     }

--- a/cspell.json
+++ b/cspell.json
@@ -359,6 +359,7 @@
         "structs",
         "subaccount",
         "subcmd",
+        "subcompactions",
         "subhandler",
         "sublinear",
         "subpaths",


### PR DESCRIPTION
This is the next iteration of rocksDB tuning based on benchmark data.

- Optimize store config for benchmarks
- Increase effective rocksDB parallelism through subcompaction jobs
- Shift more resource allocation to write heavy columns and reduce it for less used columns