### PR TITLE
[actix_migration] Use utoipa instead of paperclip for OpenApi Spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2252,7 +2252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3965,9 +3965,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mime_guess"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
@@ -5046,12 +5046,13 @@ dependencies = [
  "near-parameters",
  "near-primitives",
  "node-runtime",
- "paperclip",
  "serde",
  "serde_json",
  "strum",
  "thiserror 2.0.12",
  "tokio",
+ "utoipa",
+ "utoipa-swagger-ui",
 ]
 
 [[package]]
@@ -6195,79 +6196,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "paperclip"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa5b33308ca3f5902ccef8aa51f72dd71d6ee9f1c3cd04ac2e77eec33fe1da4f"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "once_cell",
- "paperclip-actix",
- "paperclip-core",
- "paperclip-macros",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_yaml",
- "thiserror 1.0.50",
- "url",
-]
-
-[[package]]
-name = "paperclip-actix"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8940953bde66d4de5c8d53269d2d5967b111baa711ba6c05d41897e7cbfd5119"
-dependencies = [
- "actix-service",
- "actix-web",
- "futures",
- "mime_guess",
- "once_cell",
- "paperclip-core",
- "paperclip-macros",
- "serde_json",
-]
-
-[[package]]
-name = "paperclip-core"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12a4febf76a64f14e03c19b000d9c2b333543e4485a47624d59afd7c6980536"
-dependencies = [
- "actix-web",
- "mime",
- "once_cell",
- "paperclip-macros",
- "pin-project-lite",
- "regex",
- "serde",
- "serde_json",
- "serde_yaml",
- "thiserror 1.0.50",
-]
-
-[[package]]
-name = "paperclip-macros"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "827a0067440b62e798bc3e8cfb7036a0f63c3adbb21fe6a56fb3d6f6d8fa53f8"
-dependencies = [
- "heck 0.4.0",
- "http 0.2.12",
- "lazy_static",
- "mime",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "strum",
- "strum_macros",
- "syn 1.0.103",
-]
-
-[[package]]
 name = "parity-scale-codec"
 version = "3.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6593,28 +6521,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.87",
 ]
 
 [[package]]
@@ -7352,6 +7258,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "025908b8682a26ba8d12f6f2d66b987584a4a87bc024abc5bbc12553a8cd178a"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6065f1a4392b71819ec1ea1df1120673418bf386f50de1d6f54204d836d4349c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "shellexpand",
+ "syn 2.0.87",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6cc0c81648b20b70c491ff8cce00c1c3b223bb8ed2b5d41f0e54c6c4c0a3594"
+dependencies = [
+ "sha2 0.10.6",
+ "walkdir",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7436,7 +7377,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7449,7 +7390,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7889,6 +7830,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8299,7 +8249,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8946,12 +8896,9 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.6.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
-]
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
@@ -9023,6 +8970,47 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "utoipa"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
+dependencies = [
+ "indexmap 2.7.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "154517adf0d0b6e22e8e1f385628f14fcaa3db43531dc74303d3edef89d6dfe5"
+dependencies = [
+ "actix-web",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "utoipa",
+ "zip",
+]
 
 [[package]]
 name = "uuid"
@@ -10044,6 +10032,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,7 +342,6 @@ opentelemetry_sdk = { version = "0.22.0", features = ["rt-tokio"] }
 opentelemetry-otlp = "0.15.0"
 opentelemetry-semantic-conventions = "0.14.0"
 ordered-float = { version = "4.2.0", features = ["serde", "borsh"] }
-paperclip = { version = "0.9.0", features = ["actix4"] }
 parking_lot = "0.12.1"
 percent-encoding = "2.2.0"
 pin-project = "1.0"

--- a/chain/rosetta-rpc/Cargo.toml
+++ b/chain/rosetta-rpc/Cargo.toml
@@ -19,12 +19,13 @@ derive_more = { workspace = true, features = ["as_ref", "from", "from_str"] }
 futures.workspace = true
 hex.workspace = true
 insta.workspace = true
-paperclip.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+utoipa = { version = "4", features = ["actix_extras", "chrono"] }
+utoipa-swagger-ui = { version = "4", features = ["actix-web"] }
 
 near-account-id.workspace = true
 near-async.workspace = true

--- a/chain/rosetta-rpc/src/models.rs
+++ b/chain/rosetta-rpc/src/models.rs
@@ -1,15 +1,13 @@
-// cspell:words Apiv frunk
-use paperclip::actix::{Apiv2Schema, api_v2_errors};
-
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::{BlockHeight, Nonce};
+use utoipa::ToSchema;
 
 use crate::utils::{BlobInHexString, BorshInHexString, SignedDiff};
 
 /// An AccountBalanceRequest is utilized to make a balance request on the
 /// /account/balance endpoint. If the block_identifier is populated, a
 /// historical balance query should be performed.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct AccountBalanceRequest {
     pub network_identifier: NetworkIdentifier,
 
@@ -25,7 +23,7 @@ pub(crate) struct AccountBalanceRequest {
 /// an account has a balance for each AccountIdentifier describing it (ex: an
 /// ERC-20 token balance on a few smart contracts), an account balance request
 /// must be made with each AccountIdentifier.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub(crate) struct AccountBalanceResponse {
     pub block_identifier: BlockIdentifier,
@@ -41,14 +39,14 @@ pub(crate) struct AccountBalanceResponse {
 }
 // Account-based blockchains that utilize a nonce or sequence number should
 // include that number in the metadata.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct AccountBalanceResponseMetadata {
     pub nonces: Vec<Nonce>,
 }
 /// The account_identifier uniquely identifies an account within a network. All
 /// fields in the account_identifier are utilized to determine this uniqueness
 /// (including the metadata field, if populated).
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct AccountIdentifier {
     /// The address may be a cryptographic public key (or some encoding of it)
     /// or a provided username.
@@ -78,9 +76,7 @@ impl std::str::FromStr for AccountIdentifier {
     }
 }
 
-#[derive(
-    Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize, Apiv2Schema,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct AccountIdentifierMetadata {
     pub public_keys: Vec<PublicKey>,
 }
@@ -90,7 +86,7 @@ pub(crate) struct AccountIdentifierMetadata {
 /// the correctness of a Rosetta Server implementation. It is expected that
 /// these clients will error if they receive some response that contains any of
 /// the above information that is not specified here.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct Allow {
     /// All Operation.Status this implementation supports. Any status that is
     /// returned during parsing that is not listed here will cause client
@@ -114,7 +110,7 @@ pub(crate) struct Allow {
 
 /// Amount is some Value of a Currency. It is considered invalid to specify a
 /// Value without a Currency.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct Amount {
     /// Value of the transaction in atomic units represented as an
     /// arbitrary-sized signed integer.  For example, 1 BTC would be represented
@@ -158,7 +154,7 @@ impl Amount {
 /// requested and received a block identified by a specific BlockIdentifier,
 /// all future calls for that same BlockIdentifier must return the same block
 /// contents.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct Block {
     pub block_identifier: BlockIdentifier,
 
@@ -177,7 +173,7 @@ pub(crate) struct Block {
 }
 
 /// The block_identifier uniquely identifies a block in a particular network.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct BlockIdentifier {
     /// This is also known as the block height.
     pub index: i64,
@@ -200,7 +196,7 @@ impl From<&near_primitives::views::BlockView> for BlockIdentifier {
 }
 
 /// A BlockRequest is utilized to make a block request on the /block endpoint.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct BlockRequest {
     pub network_identifier: NetworkIdentifier,
 
@@ -209,7 +205,7 @@ pub(crate) struct BlockRequest {
 
 /// A BlockResponse includes a fully-populated block or a partially-populated
 /// block with a list of other transactions to fetch (other_transactions).
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct BlockResponse {
     pub block: Option<Block>,
 
@@ -224,7 +220,7 @@ pub(crate) struct BlockResponse {
 
 /// A BlockTransactionRequest is used to fetch a Transaction included in a block
 /// that is not returned in a BlockResponse.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct BlockTransactionRequest {
     pub network_identifier: NetworkIdentifier,
 
@@ -234,7 +230,7 @@ pub(crate) struct BlockTransactionRequest {
 }
 
 /// A BlockTransactionResponse contains information about a block transaction.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct BlockTransactionResponse {
     pub transaction: Transaction,
 }
@@ -245,7 +241,7 @@ pub(crate) struct BlockTransactionResponse {
 /// Metadata is provided in the request because some blockchains
 /// allow for multiple address types (i.e. different address
 /// for validators vs normal accounts).
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct ConstructionDeriveRequest {
     pub network_identifier: NetworkIdentifier,
     pub public_key: PublicKey,
@@ -257,7 +253,7 @@ pub(crate) struct ConstructionDeriveRequest {
 
 /// ConstructionDeriveResponse is returned by the `/construction/derive`
 /// endpoint.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct ConstructionDeriveResponse {
     pub account_identifier: AccountIdentifier,
     /* Rosetta Spec also optionally provides:
@@ -292,7 +288,7 @@ pub(crate) struct ConstructionDeriveResponse {
 /// and a suggested fee multiplier, the max fee will set an
 /// upper bound on the suggested fee (regardless of the
 /// multiplier provided).
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct ConstructionPreprocessRequest {
     pub network_identifier: NetworkIdentifier,
     pub operations: Vec<Operation>,
@@ -304,7 +300,7 @@ pub(crate) struct ConstructionPreprocessRequest {
      * pub metadata: Option<serde_json::Value>, */
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct ConstructionMetadataOptions {
     pub signer_account_id: super::types::AccountId,
 }
@@ -318,7 +314,7 @@ pub(crate) struct ConstructionMetadataOptions {
 /// `required_public_keys` with the AccountIdentifiers associated with the
 /// desired PublicKeys. If it is not necessary to retrieve any PublicKeys
 /// for construction, `required_public_keys` should be omitted.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct ConstructionPreprocessResponse {
     pub options: ConstructionMetadataOptions,
     pub required_public_keys: Vec<AccountIdentifier>,
@@ -332,7 +328,7 @@ pub(crate) struct ConstructionPreprocessResponse {
 /// Optionally, the request can also include an array
 /// of PublicKeys associated with the AccountIdentifiers
 /// returned in ConstructionPreprocessResponse.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct ConstructionMetadataRequest {
     pub network_identifier: NetworkIdentifier,
 
@@ -347,7 +343,7 @@ pub(crate) struct ConstructionMetadataRequest {
     pub public_keys: Vec<PublicKey>,
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct ConstructionMetadata {
     pub signer_public_access_key_nonce: u64,
     pub recent_block_hash: String,
@@ -355,7 +351,7 @@ pub(crate) struct ConstructionMetadata {
 
 /// The ConstructionMetadataResponse returns network-specific metadata used for
 /// transaction construction.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct ConstructionMetadataResponse {
     pub metadata: ConstructionMetadata,
 }
@@ -367,7 +363,7 @@ pub(crate) struct ConstructionMetadataResponse {
 /// Optionally, the request can also include an array
 /// of PublicKeys associated with the AccountIdentifiers
 /// returned in ConstructionPreprocessResponse.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct ConstructionPayloadsRequest {
     pub network_identifier: NetworkIdentifier,
     pub operations: Vec<Operation>,
@@ -379,7 +375,7 @@ pub(crate) struct ConstructionPayloadsRequest {
 /// contains an unsigned transaction blob (that is usually needed to construct
 /// a network transaction from a collection of signatures) and an
 /// array of payloads that must be signed by the caller.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct ConstructionPayloadsResponse {
     pub unsigned_transaction: BorshInHexString<near_primitives::transaction::Transaction>,
     pub payloads: Vec<SigningPayload>,
@@ -389,7 +385,7 @@ pub(crate) struct ConstructionPayloadsResponse {
 /// endpoint. It contains the unsigned transaction blob returned by
 /// `/construction/payloads` and all required signatures to create
 /// a network transaction.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct ConstructionCombineRequest {
     pub network_identifier: NetworkIdentifier,
     pub unsigned_transaction: BorshInHexString<near_primitives::transaction::Transaction>,
@@ -399,7 +395,7 @@ pub(crate) struct ConstructionCombineRequest {
 /// ConstructionCombineResponse is returned by `/construction/combine`.
 /// The network payload will be sent directly to the
 /// `construction/submit` endpoint.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct ConstructionCombineResponse {
     pub signed_transaction: BorshInHexString<near_primitives::transaction::SignedTransaction>,
 }
@@ -407,7 +403,7 @@ pub(crate) struct ConstructionCombineResponse {
 /// ConstructionParseRequest is the input to the `/construction/parse`
 /// endpoint. It allows the caller to parse either an unsigned or
 /// signed transaction.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct ConstructionParseRequest {
     pub network_identifier: NetworkIdentifier,
     pub signed: bool,
@@ -420,7 +416,7 @@ pub(crate) struct ConstructionParseRequest {
 /// ConstructionParseResponse contains an array of operations that occur in
 /// a transaction blob. This should match the array of operations provided
 /// to `/construction/preprocess` and `/construction/payloads`.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct ConstructionParseResponse {
     pub operations: Vec<Operation>,
 
@@ -434,7 +430,7 @@ pub(crate) struct ConstructionParseResponse {
 }
 
 /// The transaction submission request includes a signed transaction.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct ConstructionSubmitRequest {
     pub network_identifier: NetworkIdentifier,
 
@@ -444,7 +440,7 @@ pub(crate) struct ConstructionSubmitRequest {
 /// TransactionIdentifierResponse contains the transaction_identifier of a
 /// transaction that was submitted to either `/construction/hash` or
 /// `/construction/submit`.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct TransactionIdentifierResponse {
     pub transaction_identifier: TransactionIdentifier,
     /* Rosetta Spec also optionally provides:
@@ -454,7 +450,7 @@ pub(crate) struct TransactionIdentifierResponse {
 }
 
 /// ConstructionHashRequest is the input to the /construction/hash endpoint.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct ConstructionHashRequest {
     pub network_identifier: NetworkIdentifier,
 
@@ -464,7 +460,7 @@ pub(crate) struct ConstructionHashRequest {
 /// Currency is composed of a canonical Symbol and Decimals. This Decimals value
 /// is used to convert an Amount.Value from atomic units (Satoshi) to standard
 /// units (Bitcoins).
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct Currency {
     /// Canonical symbol associated with a currency.
     pub symbol: String,
@@ -481,7 +477,7 @@ pub struct Currency {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<CurrencyMetadata>,
 }
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 
 pub struct CurrencyMetadata {
     pub contract_address: String,
@@ -506,8 +502,7 @@ impl FromIterator<Currency> for std::collections::HashMap<String, Currency> {
 }
 /// Instead of utilizing HTTP status codes to describe node errors (which often
 /// do not have a good analog), rich errors are returned using this object.
-#[api_v2_errors(code = 500, description = "See the inner `code` value to get more details")]
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct Error {
     /// Code is a network-specific error code. If desired, this code can be
     /// equivalent to an HTTP status code.
@@ -573,21 +568,21 @@ where
 
 impl actix_web::ResponseError for Error {
     fn error_response(&self) -> actix_web::HttpResponse {
-        let data = paperclip::actix::web::Json(self);
+        let data = actix_web::web::Json(self);
         actix_web::HttpResponse::InternalServerError().json(data)
     }
 }
 
 /// A MempoolResponse contains all transaction identifiers in the mempool for a
 /// particular network_identifier.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct MempoolResponse {
     pub transaction_identifiers: Vec<TransactionIdentifier>,
 }
 
 /// A MempoolTransactionRequest is utilized to retrieve a transaction from the
 /// mempool.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct MempoolTransactionRequest {
     pub network_identifier: NetworkIdentifier,
 
@@ -597,7 +592,7 @@ pub(crate) struct MempoolTransactionRequest {
 /// A MempoolTransactionResponse contains an estimate of a mempool transaction.
 /// It may not be possible to know the full impact of a transaction in the
 /// mempool (ex: fee paid).
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct MempoolTransactionResponse {
     pub transaction: Transaction,
     /* Rosetta Spec also optionally provides:
@@ -608,7 +603,7 @@ pub(crate) struct MempoolTransactionResponse {
 
 /// A MetadataRequest is utilized in any request where the only argument is
 /// optional metadata.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct MetadataRequest {
     // Rosetta Spec optionally provides, but we don't have any use for it:
     // #[serde(skip_serializing_if = "Option::is_none")]
@@ -617,7 +612,7 @@ pub(crate) struct MetadataRequest {
 
 /// The network_identifier specifies which network a particular object is
 /// associated with.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct NetworkIdentifier {
     pub blockchain: String,
 
@@ -630,7 +625,7 @@ pub(crate) struct NetworkIdentifier {
     pub sub_network_identifier: Option<SubNetworkIdentifier>,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Copy, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub(crate) enum SyncStage {
     AwaitingPeers,
@@ -648,7 +643,7 @@ pub(crate) enum SyncStage {
 /// sync status. It is often used to indicate that an implementation is healthy
 /// when it cannot be queried until some sync phase occurs. If an
 /// implementation is immediately queryable, this model is often not populated.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct SyncStatus {
     pub current_index: i64,
 
@@ -661,14 +656,14 @@ pub(crate) struct SyncStatus {
 
 /// A NetworkListResponse contains all NetworkIdentifiers that the node can
 /// serve information for.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct NetworkListResponse {
     pub network_identifiers: Vec<NetworkIdentifier>,
 }
 
 /// NetworkOptionsResponse contains information about the versioning of the node
 /// and the allowed operation statuses, operation types, and errors.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct NetworkOptionsResponse {
     pub version: Version,
 
@@ -677,7 +672,7 @@ pub(crate) struct NetworkOptionsResponse {
 
 /// A NetworkRequest is utilized to retrieve some data specific exclusively to a
 /// NetworkIdentifier.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct NetworkRequest {
     pub network_identifier: NetworkIdentifier,
     /* Rosetta Spec also optionally provides:
@@ -691,7 +686,7 @@ pub(crate) struct NetworkRequest {
 /// should populate the optional `oldest_block_identifier` field with the oldest
 /// block available to query. If this is not populated, it is assumed that the
 /// `genesis_block_identifier` is the oldest queryable block.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct NetworkStatusResponse {
     pub current_block_identifier: BlockIdentifier,
 
@@ -716,7 +711,7 @@ pub(crate) struct NetworkStatusResponse {
     Copy,
     PartialEq,
     Eq,
-    Apiv2Schema,
+    ToSchema,
     serde::Serialize,
     serde::Deserialize,
     strum::EnumIter,
@@ -746,14 +741,7 @@ pub(crate) enum OperationType {
 }
 
 #[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Apiv2Schema,
-    serde::Serialize,
-    serde::Deserialize,
-    strum::EnumIter,
+    Debug, Clone, Copy, PartialEq, ToSchema, serde::Serialize, serde::Deserialize, strum::EnumIter,
 )]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub(crate) enum OperationStatusKind {
@@ -774,14 +762,14 @@ impl OperationStatusKind {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub(crate) enum OperationMetadataTransferFeeType {
     GasPrepayment,
     GasRefund,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct OperationMetadata {
     /// Has to be specified for TRANSFER operations which represent gas prepayments or gas refunds
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -850,7 +838,7 @@ impl OperationMetadata {
 /// Operations contain all balance-changing information within a transaction.
 /// They are always one-sided (only affect 1 AccountIdentifier) and can
 /// succeed or fail independently from a Transaction.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct Operation {
     pub operation_identifier: OperationIdentifier,
 
@@ -895,7 +883,7 @@ pub(crate) struct Operation {
 /// in several places. For example, borsh de-/serialization relies on it. If the
 /// invariant is broken, we may end up with a `Transaction` or `Receipt` that we
 /// can serialize but deserializing it back causes a parsing error.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct NonDelegateActionOperation(crate::models::Operation);
 
 impl From<NonDelegateActionOperation> for crate::models::Operation {
@@ -928,7 +916,7 @@ impl From<IsDelegateOperation> for crate::errors::ErrorKind {
 
 /// The operation_identifier uniquely identifies an operation within a
 /// transaction.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct OperationIdentifier {
     /// The operation index is used to ensure each operation has a unique
     /// identifier within a transaction. This index is only relative to the
@@ -961,7 +949,7 @@ impl OperationIdentifier {
 
 /// OperationStatus is utilized to indicate which Operation status are
 /// considered successful.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct OperationStatus {
     /// The status is the network-specific status of the operation.
     pub status: OperationStatusKind,
@@ -979,7 +967,7 @@ pub(crate) struct OperationStatus {
 /// When fetching data by BlockIdentifier, it may be possible to only specify
 /// the index or hash. If neither property is specified, it is assumed that the
 /// client is making a request at the current block.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct PartialBlockIdentifier {
     #[serde(skip_serializing_if = "Option::is_none")]
     index: Option<i64>,
@@ -1013,7 +1001,7 @@ impl TryFrom<PartialBlockIdentifier> for near_primitives::types::BlockReference 
 }
 
 /// A Peer is a representation of a node's peer.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct Peer {
     pub peer_id: String,
     /* Rosetta Spec also optionally provides:
@@ -1022,7 +1010,7 @@ pub(crate) struct Peer {
      * pub metadata: Option<serde_json::Value>, */
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, ToSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub(crate) enum SubAccount {
     LiquidBalanceForStorage,
@@ -1038,7 +1026,7 @@ impl From<SubAccount> for crate::models::SubAccountIdentifier {
 /// An account may have state specific to a contract address (ERC-20 token)
 /// and/or a stake (delegated balance). The sub_account_identifier should
 /// specify which state (if applicable) an account instantiation refers to.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct SubAccountIdentifier {
     /// The SubAccount address may be a cryptographic value or some other
     /// identifier (ex: bonded) that uniquely specifies a SubAccount.
@@ -1056,7 +1044,7 @@ pub(crate) struct SubAccountIdentifier {
 /// In blockchains with sharded state, the SubNetworkIdentifier is required to
 /// query some object on a specific shard. This identifier is optional for all
 /// non-sharded blockchains.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct SubNetworkIdentifier {
     pub network: String,
     /* Rosetta Spec also optionally provides:
@@ -1068,14 +1056,12 @@ pub(crate) struct SubNetworkIdentifier {
 /// The timestamp of the block in milliseconds since the Unix Epoch. The
 /// timestamp is stored in milliseconds because some blockchains produce blocks
 /// more often than once a second.
-#[derive(
-    Debug, Clone, PartialEq, PartialOrd, Apiv2Schema, serde::Serialize, serde::Deserialize,
-)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, ToSchema, serde::Serialize, serde::Deserialize)]
 pub(crate) struct Timestamp(i64);
 
 /// Transactions contain an array of Operations that are attributable to the
 /// same TransactionIdentifier.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct Transaction {
     pub transaction_identifier: TransactionIdentifier,
 
@@ -1098,7 +1084,7 @@ pub(crate) struct Transaction {
 
 /// Transaction related to another [`Transaction`] such as matching transfer or
 /// a cross-shard transaction.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct RelatedTransaction {
     // Rosetta API defines an optional network_identifier field as well but
     // since all our related transactions are always on the same network we can
@@ -1110,7 +1096,7 @@ pub(crate) struct RelatedTransaction {
     pub direction: RelatedTransactionDirection,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Copy, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum RelatedTransactionDirection {
     /// Direction indicating a transaction relation is from parent to child.
@@ -1126,7 +1112,7 @@ impl RelatedTransaction {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub(crate) enum TransactionType {
     Block,
@@ -1136,7 +1122,7 @@ pub(crate) enum TransactionType {
 }
 
 /// Extra data for Transaction
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct TransactionMetadata {
     #[serde(rename = "type")]
     pub(crate) type_: TransactionType,
@@ -1144,7 +1130,7 @@ pub(crate) struct TransactionMetadata {
 
 /// The transaction_identifier uniquely identifies a transaction in a particular
 /// network and block or in the mempool.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct TransactionIdentifier {
     /// Any transactions that are attributable only to a block (ex: a block
     /// event) should use the hash of the block as the identifier.
@@ -1183,7 +1169,7 @@ impl TransactionIdentifier {
 
 /// The Version object is utilized to inform the client of the versions of
 /// different components of the Rosetta implementation.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct Version {
     /// The rosetta_version is the version of the Rosetta interface the
     /// implementation adheres to. This can be useful for clients looking to
@@ -1210,7 +1196,7 @@ pub(crate) struct Version {
 /// PublicKey contains a public key byte array for a particular CurveType
 /// encoded in hex. Note that there is no PrivateKey struct as this is NEVER the
 /// concern of an implementation.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct PublicKey {
     /// Hex-encoded public key bytes in the format specified by the CurveType.
     pub hex_bytes: BlobInHexString<Vec<u8>>,
@@ -1240,7 +1226,7 @@ impl TryFrom<&PublicKey> for near_crypto::PublicKey {
 }
 
 /// CurveType is the type of cryptographic curve associated with a PublicKey.
-#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum CurveType {
     /// `y (255-bits) || x-sign-bit (1-bit)` - 32 bytes (<https://ed25519.cr.yp.to/ed25519-20110926.pdf>)
@@ -1262,7 +1248,7 @@ impl From<near_crypto::KeyType> for CurveType {
 /// address using the specified SignatureType. SignatureType can be optionally
 /// populated if there is a restriction on the signature scheme that can be used
 /// to sign the payload.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct SigningPayload {
     /// The account identifier that should sign the payload.
     pub account_identifier: AccountIdentifier,
@@ -1274,7 +1260,7 @@ pub(crate) struct SigningPayload {
 /// keypairs used to produce the signature, the signature (encoded in hex), and
 /// the SignatureType. PublicKey is often times not known during construction of
 /// the signing payloads but may be needed to combine signatures properly.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct Signature {
     pub signing_payload: SigningPayload,
     pub public_key: PublicKey,
@@ -1294,7 +1280,7 @@ impl TryFrom<&Signature> for near_crypto::Signature {
 
 // cspell:ignore Schnorr Zilliqa
 /// SignatureType is the type of a cryptographic signature.
-#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum SignatureType {
     /// `R (32-byte) || s (32-bytes)` - `64 bytes`
@@ -1394,7 +1380,7 @@ pub(crate) struct EventBase {
     pub contract_account_id: AccountIdentifier,
     pub status: near_primitives::views::ExecutionStatusView,
 }
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct FtEvent {
     pub affected_id: AccountIdentifier,
     pub involved_id: Option<AccountIdentifier>,
@@ -1404,7 +1390,7 @@ pub(crate) struct FtEvent {
     pub cause: String,
     pub memo: Option<String>,
 }
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct FTMetadataResponse {
     pub spec: String,
     pub name: String,
@@ -1415,7 +1401,7 @@ pub(crate) struct FTMetadataResponse {
     pub decimals: u32,
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct FTAccountBalanceResponse {
     pub amount: u128,
 }

--- a/chain/rosetta-rpc/src/models.rs
+++ b/chain/rosetta-rpc/src/models.rs
@@ -23,6 +23,7 @@ pub(crate) struct AccountBalanceRequest {
 /// an account has a balance for each AccountIdentifier describing it (ex: an
 /// ERC-20 token balance on a few smart contracts), an account balance request
 /// must be made with each AccountIdentifier.
+/// cspell:words frunk
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub(crate) struct AccountBalanceResponse {

--- a/chain/rosetta-rpc/src/models.rs
+++ b/chain/rosetta-rpc/src/models.rs
@@ -42,6 +42,7 @@ pub(crate) struct AccountBalanceResponse {
 // include that number in the metadata.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct AccountBalanceResponseMetadata {
+    #[schema(value_type = Vec<u64>)]
     pub nonces: Vec<Nonce>,
 }
 /// The account_identifier uniquely identifies an account within a network. All
@@ -51,6 +52,7 @@ pub(crate) struct AccountBalanceResponseMetadata {
 pub(crate) struct AccountIdentifier {
     /// The address may be a cryptographic public key (or some encoding of it)
     /// or a provided username.
+    #[schema(value_type = String)]
     pub address: super::types::AccountId,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -116,6 +118,7 @@ pub(crate) struct Amount {
     /// Value of the transaction in atomic units represented as an
     /// arbitrary-sized signed integer.  For example, 1 BTC would be represented
     /// by a value of 100000000.
+    #[schema(value_type = String)]
     pub value: crate::utils::SignedDiff<near_primitives::types::Balance>,
 
     pub currency: Currency,
@@ -303,6 +306,7 @@ pub(crate) struct ConstructionPreprocessRequest {
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct ConstructionMetadataOptions {
+    #[schema(value_type = String)]
     pub signer_account_id: super::types::AccountId,
 }
 
@@ -378,6 +382,7 @@ pub(crate) struct ConstructionPayloadsRequest {
 /// array of payloads that must be signed by the caller.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct ConstructionPayloadsResponse {
+    #[schema(value_type = String)]
     pub unsigned_transaction: BorshInHexString<near_primitives::transaction::Transaction>,
     pub payloads: Vec<SigningPayload>,
 }
@@ -389,6 +394,7 @@ pub(crate) struct ConstructionPayloadsResponse {
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct ConstructionCombineRequest {
     pub network_identifier: NetworkIdentifier,
+    #[schema(value_type = String)]
     pub unsigned_transaction: BorshInHexString<near_primitives::transaction::Transaction>,
     pub signatures: Vec<Signature>,
 }
@@ -398,6 +404,7 @@ pub(crate) struct ConstructionCombineRequest {
 /// `construction/submit` endpoint.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct ConstructionCombineResponse {
+    #[schema(value_type = String)]
     pub signed_transaction: BorshInHexString<near_primitives::transaction::SignedTransaction>,
 }
 
@@ -411,6 +418,7 @@ pub(crate) struct ConstructionParseRequest {
     /// This must be either the unsigned transaction blob returned by
     /// `/construction/payloads` or the signed transaction blob
     /// returned by `/construction/combine`.
+    #[schema(value_type = String)]
     pub transaction: BlobInHexString<Vec<u8>>,
 }
 
@@ -435,6 +443,7 @@ pub(crate) struct ConstructionParseResponse {
 pub(crate) struct ConstructionSubmitRequest {
     pub network_identifier: NetworkIdentifier,
 
+    #[schema(value_type = String)]
     pub signed_transaction: BorshInHexString<near_primitives::transaction::SignedTransaction>,
 }
 
@@ -455,6 +464,7 @@ pub(crate) struct TransactionIdentifierResponse {
 pub(crate) struct ConstructionHashRequest {
     pub network_identifier: NetworkIdentifier,
 
+    #[schema(value_type = String)]
     pub signed_transaction: BorshInHexString<near_primitives::transaction::SignedTransaction>,
 }
 
@@ -785,15 +795,18 @@ pub(crate) struct OperationMetadata {
     // pub access_key: Option<TODO>,
     /// Has to be specified for DEPLOY_CONTRACT operation
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>)]
     pub code: Option<BlobInHexString<Vec<u8>>>,
     /// Has to be specified for FUNCTION_CALL operation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub method_name: Option<String>,
     /// Has to be specified for FUNCTION_CALL operation
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>)]
     pub args: Option<BlobInHexString<Vec<u8>>>,
     /// Has to be specified for FUNCTION_CALL operation
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>)]
     pub attached_gas: Option<crate::utils::SignedDiff<near_primitives::types::Gas>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub predecessor_id: Option<AccountIdentifier>,
@@ -801,9 +814,11 @@ pub(crate) struct OperationMetadata {
     pub contract_address: Option<String>,
     /// Has to be specified for DELEGATE_ACTION operation
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<u64>)]
     pub max_block_height: Option<near_primitives::types::BlockHeight>,
     /// Has to be specified for DELEGATE_ACTION operation
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<u64>)]
     pub nonce: Option<Nonce>,
     /// Has to be specified for SIGNED_DELEGATE_ACTION operation
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1200,6 +1215,7 @@ pub(crate) struct Version {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, ToSchema)]
 pub(crate) struct PublicKey {
     /// Hex-encoded public key bytes in the format specified by the CurveType.
+    #[schema(value_type = String)]
     pub hex_bytes: BlobInHexString<Vec<u8>>,
     pub curve_type: CurveType,
 }
@@ -1253,6 +1269,7 @@ impl From<near_crypto::KeyType> for CurveType {
 pub(crate) struct SigningPayload {
     /// The account identifier that should sign the payload.
     pub account_identifier: AccountIdentifier,
+    #[schema(value_type = String)]
     pub hex_bytes: BlobInHexString<Vec<u8>>,
     pub signature_type: Option<SignatureType>,
 }
@@ -1266,6 +1283,7 @@ pub(crate) struct Signature {
     pub signing_payload: SigningPayload,
     pub public_key: PublicKey,
     pub signature_type: SignatureType,
+    #[schema(value_type = String)]
     pub hex_bytes: BlobInHexString<Vec<u8>>,
 }
 
@@ -1385,6 +1403,7 @@ pub(crate) struct EventBase {
 pub(crate) struct FtEvent {
     pub affected_id: AccountIdentifier,
     pub involved_id: Option<AccountIdentifier>,
+    #[schema(value_type = String)]
     pub delta: SignedDiff<u128>,
     pub symbol: String,
     pub decimals: u32,

--- a/chain/rosetta-rpc/src/types.rs
+++ b/chain/rosetta-rpc/src/types.rs
@@ -1,5 +1,9 @@
 use std::fmt;
 
+use utoipa::ToSchema;
+use utoipa::openapi::RefOr;
+use utoipa::openapi::schema::{ObjectBuilder, Schema, SchemaType};
+
 #[derive(
     Eq,
     Ord,
@@ -24,9 +28,11 @@ impl fmt::Debug for AccountId {
     }
 }
 
-use paperclip::v2::{models::DataType, schema::TypedData};
-impl TypedData for AccountId {
-    fn data_type() -> DataType {
-        DataType::String
+impl ToSchema<'_> for AccountId {
+    fn schema() -> (&'static str, RefOr<Schema>) {
+        (
+            "AccountId",
+            RefOr::T(Schema::Object(ObjectBuilder::new().schema_type(SchemaType::String).build())),
+        )
     }
 }

--- a/chain/rosetta-rpc/src/utils.rs
+++ b/chain/rosetta-rpc/src/utils.rs
@@ -8,6 +8,9 @@ use futures::StreamExt;
 use near_chain_configs::ProtocolConfigView;
 use near_client::ViewClientActor;
 use near_primitives::borsh::{self, BorshDeserialize, BorshSerialize};
+use utoipa::ToSchema;
+use utoipa::openapi::RefOr;
+use utoipa::openapi::schema::{ObjectBuilder, Schema, SchemaType};
 
 #[derive(Debug, Clone, PartialEq, derive_more::AsRef, derive_more::From)]
 pub(crate) struct BorshInHexString<T: BorshSerialize + BorshDeserialize>(T);
@@ -21,12 +24,15 @@ where
     }
 }
 
-impl<T> paperclip::v2::schema::TypedData for BorshInHexString<T>
+impl<T> ToSchema<'_> for BorshInHexString<T>
 where
     T: BorshSerialize + BorshDeserialize,
 {
-    fn data_type() -> paperclip::v2::models::DataType {
-        paperclip::v2::models::DataType::String
+    fn schema() -> (&'static str, RefOr<Schema>) {
+        (
+            "BorshInHexString",
+            RefOr::T(Schema::Object(ObjectBuilder::new().schema_type(SchemaType::String).build())),
+        )
     }
 }
 
@@ -78,12 +84,15 @@ where
 #[as_ref(forward)]
 pub(crate) struct BlobInHexString<T: AsRef<[u8]> + From<Vec<u8>>>(T);
 
-impl<T> paperclip::v2::schema::TypedData for BlobInHexString<T>
+impl<T> ToSchema<'_> for BlobInHexString<T>
 where
     T: AsRef<[u8]> + From<Vec<u8>>,
 {
-    fn data_type() -> paperclip::v2::models::DataType {
-        paperclip::v2::models::DataType::String
+    fn schema() -> (&'static str, RefOr<Schema>) {
+        (
+            "BlobInHexString",
+            RefOr::T(Schema::Object(ObjectBuilder::new().schema_type(SchemaType::String).build())),
+        )
     }
 }
 
@@ -141,12 +150,15 @@ where
     absolute_difference: T,
 }
 
-impl<T> paperclip::v2::schema::TypedData for SignedDiff<T>
+impl<T> ToSchema<'_> for SignedDiff<T>
 where
     T: Copy + PartialEq,
 {
-    fn data_type() -> paperclip::v2::models::DataType {
-        paperclip::v2::models::DataType::String
+    fn schema() -> (&'static str, RefOr<Schema>) {
+        (
+            "SignedDiff",
+            RefOr::T(Schema::Object(ObjectBuilder::new().schema_type(SchemaType::String).build())),
+        )
     }
 }
 

--- a/chain/rosetta-rpc/src/utils.rs
+++ b/chain/rosetta-rpc/src/utils.rs
@@ -8,9 +8,6 @@ use futures::StreamExt;
 use near_chain_configs::ProtocolConfigView;
 use near_client::ViewClientActor;
 use near_primitives::borsh::{self, BorshDeserialize, BorshSerialize};
-use utoipa::ToSchema;
-use utoipa::openapi::RefOr;
-use utoipa::openapi::schema::{ObjectBuilder, Schema, SchemaType};
 
 #[derive(Debug, Clone, PartialEq, derive_more::AsRef, derive_more::From)]
 pub(crate) struct BorshInHexString<T: BorshSerialize + BorshDeserialize>(T);
@@ -21,18 +18,6 @@ where
 {
     pub fn into_inner(self) -> T {
         self.0
-    }
-}
-
-impl<T> ToSchema<'_> for BorshInHexString<T>
-where
-    T: BorshSerialize + BorshDeserialize,
-{
-    fn schema() -> (&'static str, RefOr<Schema>) {
-        (
-            "BorshInHexString",
-            RefOr::T(Schema::Object(ObjectBuilder::new().schema_type(SchemaType::String).build())),
-        )
     }
 }
 
@@ -83,18 +68,6 @@ where
 #[derive(Debug, Clone, Eq, PartialEq, derive_more::AsRef, derive_more::From)]
 #[as_ref(forward)]
 pub(crate) struct BlobInHexString<T: AsRef<[u8]> + From<Vec<u8>>>(T);
-
-impl<T> ToSchema<'_> for BlobInHexString<T>
-where
-    T: AsRef<[u8]> + From<Vec<u8>>,
-{
-    fn schema() -> (&'static str, RefOr<Schema>) {
-        (
-            "BlobInHexString",
-            RefOr::T(Schema::Object(ObjectBuilder::new().schema_type(SchemaType::String).build())),
-        )
-    }
-}
 
 impl<T> BlobInHexString<T>
 where
@@ -148,18 +121,6 @@ where
 {
     is_positive: bool,
     absolute_difference: T,
-}
-
-impl<T> ToSchema<'_> for SignedDiff<T>
-where
-    T: Copy + PartialEq,
-{
-    fn schema() -> (&'static str, RefOr<Schema>) {
-        (
-            "SignedDiff",
-            RefOr::T(Schema::Object(ObjectBuilder::new().schema_type(SchemaType::String).build())),
-        )
-    }
 }
 
 impl From<u64> for SignedDiff<u64> {

--- a/cspell.json
+++ b/cspell.json
@@ -413,6 +413,7 @@
         "upto",
         "useragent",
         "usize",
+        "utoipa",
         "valgrind",
         "valset",
         "Vecs",

--- a/deny.toml
+++ b/deny.toml
@@ -55,7 +55,6 @@ skip = [
 
     # many crates haven't updated to syn 2.0 yet.
     { name = "syn", version = "=1.0.103" },
-    { name = "heck", version = "=0.4.0" }, # paperclip
 
     # ubiquituous dependencies that are prone to duplication due to frequent "breaking" releases.
     { name = "windows-sys", version = "<0.60" },

--- a/deny.toml
+++ b/deny.toml
@@ -55,6 +55,7 @@ skip = [
 
     # many crates haven't updated to syn 2.0 yet.
     { name = "syn", version = "=1.0.103" },
+    { name = "heck", version = "=0.4.0" },
 
     # ubiquituous dependencies that are prone to duplication due to frequent "breaking" releases.
     { name = "windows-sys", version = "<0.60" },


### PR DESCRIPTION
This is required as part of the effort to migrate from actix_web to axum.

We use paperclip for openapi spec but paperclip doesn't support axum. This PR changes from using paperclip to utoipa libraty.