### PR TITLE
[actix_migration] Migrate OpenTelemetry from version 0.22 to 0.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6010,56 +6010,52 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.22.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
- "once_cell",
  "pin-project-lite",
- "thiserror 1.0.50",
- "urlencoding",
+ "thiserror 2.0.12",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.11.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7690dc77bf776713848c4faa6501157469017eaf332baccd4eb1cea928743d94"
+checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
 dependencies = [
  "async-trait",
  "bytes",
- "http 0.2.12",
+ "http 1.3.1",
  "opentelemetry",
- "reqwest 0.11.27",
+ "reqwest 0.12.4",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.15.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
 dependencies = [
- "async-trait",
- "futures-core",
- "http 0.2.12",
+ "http 1.3.1",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.11.27",
- "thiserror 1.0.50",
+ "reqwest 0.12.4",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.5.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -6069,28 +6065,24 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.14.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+checksum = "83d059a296a47436748557a353c5e6c5705b9470ef6c95cfc52c21a8814ddac2"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.22.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
 dependencies = [
- "async-trait",
- "crossbeam-channel",
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
- "once_cell",
  "opentelemetry",
- "ordered-float",
  "percent-encoding",
- "rand 0.8.5",
- "thiserror 1.0.50",
+ "rand 0.9.0",
+ "serde_json",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
 ]
@@ -6482,9 +6474,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -6492,12 +6484,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -8568,19 +8560,19 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.11.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
  "async-trait",
- "base64 0.21.0",
+ "base64 0.22.1",
  "bytes",
- "http 0.2.12",
- "http-body 0.4.6",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
  "percent-encoding",
  "pin-project",
  "prost",
- "tokio",
  "tokio-stream",
  "tower-layer",
  "tower-service",
@@ -8681,9 +8673,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.23.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
+checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
 dependencies = [
  "js-sys",
  "once_cell",
@@ -8853,12 +8845,6 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf16_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -337,10 +337,10 @@ okapi = { git = "https://github.com/near/near-okapi-fork.git", rev = "fd7de89e13
 object_store = { version = "0.12", features = ["gcp"] }
 oneshot = { version = "0.1.11", features = ["std"] }
 openssl-probe = "0.1.4"
-opentelemetry = { version = "0.22.0", features = ["trace"] }
-opentelemetry_sdk = { version = "0.22.0", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.15.0", default-features = false, features = ["http-proto", "reqwest-client", "trace"] }
-opentelemetry-semantic-conventions = "0.14.0"
+opentelemetry = { version = "0.30", features = ["trace"] }
+opentelemetry_sdk = { version = "0.30", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.30", default-features = false, features = ["http-proto", "reqwest-client", "trace"] }
+opentelemetry-semantic-conventions = "0.30" 
 ordered-float = { version = "4.2.0", features = ["serde", "borsh"] }
 parking_lot = "0.12.1"
 percent-encoding = "2.2.0"
@@ -416,7 +416,7 @@ toml = "0.5.8"
 tqdm = "0.4.4"
 tracing = { version = "0.1.40", features = ["std"] }
 tracing-appender = "0.2.3"
-tracing-opentelemetry = "0.23.0"
+tracing-opentelemetry = "0.31"
 tracing-span-tree = "0.1"
 tracing-subscriber = { version = "0.3.18", features = [
     "env-filter",


### PR DESCRIPTION
## Summary

This PR migrates the OpenTelemetry dependencies from version 0.22 to 0.30, addressing build issues and modernizing the telemetry integration.

### Key Changes

#### Dependency Updates
- `opentelemetry`: 0.22.0 → 0.30
- `opentelemetry_sdk`: 0.22.0 → 0.30  
- `opentelemetry-otlp`: 0.15.0 → 0.30
- `opentelemetry-semantic-conventions`: 0.14.0 → 0.30
- `tracing-opentelemetry`: 0.23.0 → 0.31

#### API Migration (`core/o11y/src/opentelemetry.rs`)
- **Removed deprecated pipeline API**: Replaced `opentelemetry_otlp::new_pipeline()` with `SpanExporter::builder()`
- **Updated tracer provider creation**: Use `SdkTracerProvider::builder()` with direct configuration
- **Modernized resource creation**: Use `Resource::builder().with_attributes()` instead of `Resource::new()`
- **Updated span processor**: Use `BatchSpanProcessor::builder()` for explicit batch processing control
- **Simplified configuration**: Environment variables (`OTEL_BSP_MAX_QUEUE_SIZE`, `OTEL_BSP_MAX_CONCURRENT_EXPORTS`) are now automatically handled by the SDK

### Benefits
- **Standards compliance**: Follows OpenTelemetry 0.30 API patterns
- **Better maintainability**: Cleaner, more explicit configuration
- **Automatic env var handling**: SDK automatically respects standard OpenTelemetry environment variables
- **Future-proof**: Aligned with current OpenTelemetry Rust ecosystem

### Testing
- ✅ All builds pass (`cargo check`)
- ✅ Code quality checks pass (`cargo clippy --all-features --all-targets`)
- ✅ Code formatting applied (`cargo fmt`)

🤖 Generated with [Claude Code](https://claude.ai/code)