### PR TITLE
[actix_migration] Simplify jsonrpc-client lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4556,6 +4556,7 @@ dependencies = [
  "reqwest 0.12.4",
  "serde",
  "serde_json",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -426,6 +426,7 @@ tracing-subscriber = { version = "0.3.18", features = [
 ] }
 trybuild = "1.0.11"
 turn = "0.9"
+url = "2.5.0"
 wasm-encoder = "0.236"
 wasmparser = "0.78" # TODO: unify at least the versions of wasmparser we have in our codebase
 wasmprinter = "0.236"

--- a/chain/jsonrpc/client/Cargo.toml
+++ b/chain/jsonrpc/client/Cargo.toml
@@ -16,6 +16,7 @@ futures.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 serde.workspace = true
 serde_json.workspace = true
+url.workspace = true
 
 near-jsonrpc-primitives.workspace = true
 near-primitives.workspace = true

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -17,6 +17,7 @@ use near_primitives::views::{
 };
 use reqwest::Client;
 use std::time::Duration;
+use url::Url;
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
@@ -92,114 +93,61 @@ where
     R: serde::de::DeserializeOwned + 'static,
 {
     let client = client.clone();
-    let url = format!("{}/{}", server_addr, method);
+    let server_addr = Url::parse(server_addr).expect("Invalid server address");
+    let url = server_addr.join(method).unwrap();
 
     async move {
-        let response = client.get(&url).send().await.map_err(|err| err.to_string())?;
+        let response = client.get(url).send().await.map_err(|err| err.to_string())?;
         let bytes = response.bytes().await.map_err(|err| format!("Payload error: {err}"))?;
         serde_json::from_slice(&bytes).map_err(|err| err.to_string())
     }
     .boxed()
 }
 
-/// Expands a variable list of parameters into its serializable form. Is needed to make the params
-/// of a nullary method equal to `[]` instead of `()` and thus make sure it serializes to `[]`
-/// instead of `null`.
-/// cspell:ignore nullary
-#[doc(hidden)]
-macro_rules! expand_params {
-    () => ([] as [(); 0]);
-    ($($arg_name:ident,)+) => (($($arg_name,)+))
+/// JsonRPC client that uses reqwest for HTTP transport
+pub struct JsonRpcClient {
+    pub server_addr: String,
+    pub client: Client,
 }
-
-/// Generates a simple HTTP client with automatic serialization and deserialization.
-/// Method calls get correct types automatically.
-/// cspell:ignore selff
-macro_rules! http_client {
-    (
-        $(#[$struct_attr:meta])*
-        pub struct $struct_name:ident {$(
-            $(#[$attr:meta])*
-            pub fn $method:ident(&mut $selff:ident $(, $arg_name:ident: $arg_ty:ty)*)
-                -> HttpRequest<$return_ty:ty>;
-        )*}
-    ) => (
-        $(#[$struct_attr])*
-        pub struct $struct_name {
-            server_addr: String,
-            client: Client,
-        }
-
-        impl $struct_name {
-            /// Creates a new HTTP client backed by the given transport implementation.
-            pub fn new(server_addr: &str, client: Client) -> Self {
-                $struct_name { server_addr: server_addr.to_string(), client }
-            }
-
-            $(
-                $(#[$attr])*
-                pub fn $method(&$selff $(, $arg_name: $arg_ty)*)
-                    -> HttpRequest<$return_ty>
-                {
-                    let method = stringify!($method);
-                    let params = expand_params!($($arg_name,)*);
-                    call_http_get(&$selff.client, &$selff.server_addr, &method, params)
-                }
-            )*
-        }
-    )
-}
-
-/// Generates JSON-RPC 2.0 client structs with automatic serialization
-/// and deserialization. Method calls get correct types automatically.
-macro_rules! jsonrpc_client {
-    (
-        $(#[$struct_attr:meta])*
-        pub struct $struct_name:ident {$(
-            $(#[$attr:meta])*
-            pub fn $method:ident(&$selff:ident $(, $arg_name:ident: $arg_ty:ty)*)
-                -> RpcRequest<$return_ty:ty>;
-        )*}
-    ) => (
-        $(#[$struct_attr])*
-        pub struct $struct_name {
-            pub server_addr: String,
-            pub client: Client,
-        }
-
-        impl $struct_name {
-            /// Creates a new RPC client backed by the given transport implementation.
-            pub fn new(server_addr: &str, client: Client) -> Self {
-                $struct_name { server_addr: server_addr.to_string(), client }
-            }
-
-            $(
-                $(#[$attr])*
-                pub fn $method(&$selff $(, $arg_name: $arg_ty)*)
-                    -> RpcRequest<$return_ty>
-                {
-                    let method = stringify!($method);
-                    let params = expand_params!($($arg_name,)*);
-                    call_method(&$selff.client, &$selff.server_addr, &method, params)
-                }
-            )*
-        }
-    )
-}
-
-jsonrpc_client!(pub struct JsonRpcClient {
-    pub fn broadcast_tx_async(&self, tx: String) -> RpcRequest<String>;
-    pub fn broadcast_tx_commit(&self, tx: String) -> RpcRequest<RpcTransactionResponse>;
-    pub fn status(&self) -> RpcRequest<StatusResponse>;
-    #[allow(non_snake_case)]
-    pub fn EXPERIMENTAL_genesis_config(&self) -> RpcRequest<serde_json::Value>;
-    pub fn genesis_config(&self) -> RpcRequest<serde_json::Value>;
-    pub fn health(&self) -> RpcRequest<()>;
-    pub fn chunk(&self, id: ChunkId) -> RpcRequest<ChunkView>;
-    pub fn gas_price(&self, block_id: MaybeBlockId) -> RpcRequest<GasPriceView>;
-});
 
 impl JsonRpcClient {
+    /// Creates a new RPC client backed by reqwest HTTP client
+    pub fn new(server_addr: &str, client: Client) -> Self {
+        JsonRpcClient { server_addr: server_addr.to_string(), client }
+    }
+
+    pub fn broadcast_tx_async(&self, tx: String) -> RpcRequest<String> {
+        call_method(&self.client, &self.server_addr, "broadcast_tx_async", [tx])
+    }
+
+    pub fn broadcast_tx_commit(&self, tx: String) -> RpcRequest<RpcTransactionResponse> {
+        call_method(&self.client, &self.server_addr, "broadcast_tx_commit", [tx])
+    }
+
+    pub fn status(&self) -> RpcRequest<StatusResponse> {
+        call_method(&self.client, &self.server_addr, "status", [] as [(); 0])
+    }
+
+    #[allow(non_snake_case)]
+    pub fn EXPERIMENTAL_genesis_config(&self) -> RpcRequest<serde_json::Value> {
+        call_method(&self.client, &self.server_addr, "EXPERIMENTAL_genesis_config", [] as [(); 0])
+    }
+
+    pub fn genesis_config(&self) -> RpcRequest<serde_json::Value> {
+        call_method(&self.client, &self.server_addr, "genesis_config", [] as [(); 0])
+    }
+
+    pub fn health(&self) -> RpcRequest<()> {
+        call_method(&self.client, &self.server_addr, "health", [] as [(); 0])
+    }
+
+    pub fn chunk(&self, id: ChunkId) -> RpcRequest<ChunkView> {
+        call_method(&self.client, &self.server_addr, "chunk", id)
+    }
+
+    pub fn gas_price(&self, block_id: MaybeBlockId) -> RpcRequest<GasPriceView> {
+        call_method(&self.client, &self.server_addr, "gas_price", [block_id])
+    }
     /// This is a soft-deprecated method to do query RPC request with a path and data positional
     /// parameters.
     pub fn query_by_path(
@@ -321,9 +269,22 @@ pub fn new_client(server_addr: &str) -> JsonRpcClient {
     JsonRpcClient::new(server_addr, create_client())
 }
 
-http_client!(pub struct HttpClient {
-    pub fn status(&mut self) -> HttpRequest<StatusResponse>;
-});
+/// HTTP client for simple REST endpoints
+pub struct HttpClient {
+    server_addr: String,
+    client: Client,
+}
+
+impl HttpClient {
+    /// Creates a new HTTP client backed by the given transport implementation.
+    pub fn new(server_addr: &str, client: Client) -> Self {
+        HttpClient { server_addr: server_addr.to_string(), client }
+    }
+
+    pub fn status(&self) -> HttpRequest<StatusResponse> {
+        call_http_get(&self.client, &self.server_addr, "status", [] as [(); 0])
+    }
+}
 
 /// Create new HTTP client that connects to the given address.
 pub fn new_http_client(server_addr: &str) -> HttpClient {


### PR DESCRIPTION
This library was unnecessarily complicated with macros that weren't required. This PR simplifies the code.

Additionally, we fix a bug where in `call_http_get` we were joining URL `server_addr` and `method` incorrectly (or rather in an error prone way) using string format.