### PR TITLE
fix: take inflation rate from genesis for forknets

### DIFF
--- a/chain/epoch-manager/src/reward_calculator.rs
+++ b/chain/epoch-manager/src/reward_calculator.rs
@@ -58,7 +58,7 @@ impl RewardCalculator {
         validator_block_chunk_stats: HashMap<AccountId, BlockChunkValidatorStats>,
         validator_stake: &HashMap<AccountId, Balance>,
         total_supply: Balance,
-        protocol_version: ProtocolVersion,
+        _protocol_version: ProtocolVersion,
         epoch_duration: u64,
         online_thresholds: ValidatorOnlineThresholds,
     ) -> (HashMap<AccountId, Balance>, Balance) {

--- a/chain/epoch-manager/src/reward_calculator.rs
+++ b/chain/epoch-manager/src/reward_calculator.rs
@@ -5,7 +5,7 @@ use primitive_types::{U256, U512};
 
 use near_chain_configs::GenesisConfig;
 use near_primitives::types::{AccountId, Balance, BlockChunkValidatorStats};
-use near_primitives::version::ProtocolVersion;
+use near_primitives::version::{PROD_GENESIS_PROTOCOL_VERSION, ProtocolVersion};
 
 use crate::validator_stats::get_validator_online_ratio;
 
@@ -64,7 +64,12 @@ impl RewardCalculator {
     ) -> (HashMap<AccountId, Balance>, Balance) {
         let mut res = HashMap::new();
         let num_validators = validator_block_chunk_stats.len();
-        let use_hardcoded_value = protocol_version > self.genesis_protocol_version;
+        // For mainnet and testnet, use hardcoded values of 5% inflation and
+        // 10% protocol reward rate.
+        // For other chains, use the values from the genesis config.
+        // TODO: make them configurable based on protocol version, e.g. by
+        // moving to the epoch config.
+        let use_hardcoded_value = self.genesis_protocol_version == PROD_GENESIS_PROTOCOL_VERSION;
         let max_inflation_rate =
             if use_hardcoded_value { Rational32::new_raw(1, 20) } else { self.max_inflation_rate };
         let protocol_reward_rate = if use_hardcoded_value {


### PR DESCRIPTION
There is some annoying part of code where for all reasonable protocol versions inflation rate is always set to 5%, even though we have `max_inflation_rate` parameter in genesis.
If forknet depends on the exact order of validators, non-zero rewards may break it.

Based on #3294, `use_hardcoded_value` is just a hack to override inflation. This hack was introduced because we didn't have epoch config store yet. `max_inflation_rate` should be moved to epoch config, especially if we decide to change inflation.

For now, let's change condition for `use_hardcoded_value` to checking whether we are on mainnet or testnet. Due to limited replayability, it is equivalent.
For forknets though, `max_inflation_rate` will be taken from their genesis, as forknet engineers should expect.