### PR TITLE
fix: use correct error type for outcome root validation

### DIFF
--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -456,7 +456,7 @@ impl Block {
 
         let outcome_root = self.chunks().compute_outcome_root();
         if self.header().outcome_root() != &outcome_root {
-            return Err(InvalidTransactionRoot);
+            return Err(InvalidReceiptRoot);
         }
 
         // Check that chunk included root stored in the header matches the chunk included root of the chunks


### PR DESCRIPTION
Fix incorrect error type in Block::check_validity() method

- Change InvalidTransactionRoot to InvalidReceiptRoot when validating outcome_root
- This provides more accurate error reporting for outcome root mismatches
- Improves debugging and error handling consistency