### PR TITLE
fix(resharding) - recovery tool for resharding archival data loss

### DIFF
--- a/chain/chain/src/resharding/manager.rs
+++ b/chain/chain/src/resharding/manager.rs
@@ -16,9 +16,15 @@ use near_store::adapter::trie_store::get_shard_uid_mapping;
 use near_store::flat::BlockInfo;
 use near_store::trie::ops::resharding::RetainMode;
 use near_store::trie::outgoing_metadata::ReceiptGroupsQueue;
-use near_store::{ShardTries, ShardUId, Store, TrieAccess};
+use near_store::{ShardTries, ShardUId, Store, TrieAccess, TrieChanges};
+use std::collections::BTreeMap;
 use std::io;
 use std::sync::Arc;
+
+#[derive(Default)]
+pub struct SplitShardTrieChanges {
+    pub trie_changes: BTreeMap<ShardUId, TrieChanges>,
+}
 
 pub struct ReshardingManager {
     store: Store,
@@ -98,11 +104,11 @@ impl ReshardingManager {
         shard_uid: ShardUId,
         tries: ShardTries,
         split_shard_event: ReshardingSplitShardParams,
-    ) -> Result<(), Error> {
+    ) -> Result<SplitShardTrieChanges, Error> {
         if split_shard_event.parent_shard != shard_uid {
             let parent_shard = split_shard_event.parent_shard;
             tracing::debug!(target: "resharding", ?parent_shard, "ShardUId does not match event parent shard, skipping");
-            return Ok(());
+            return Ok(Default::default());
         }
 
         let tracked_children_shards = split_shard_event
@@ -119,14 +125,14 @@ impl ReshardingManager {
 
         if tracked_children_shards.is_empty() {
             tracing::debug!(target: "resharding", "Not tracking any child shards, skipping");
-            return Ok(());
+            return Ok(Default::default());
         }
 
         // Reshard the State column by setting ShardUId mapping from children to ancestor.
         self.set_state_shard_uid_mapping(&split_shard_event, &tracked_children_shards)?;
 
         // Create temporary children memtries by freezing parent memtrie and referencing it.
-        self.process_memtrie_resharding_storage_update(
+        let trie_changes = self.process_memtrie_resharding_storage_update(
             chain_store_update,
             block,
             tries,
@@ -137,7 +143,7 @@ impl ReshardingManager {
         // This would subsequently trigger the resharding after resharding block is finalized.
         self.resharding_sender.send(ScheduleResharding { split_shard_event });
 
-        Ok(())
+        Ok(trie_changes)
     }
 
     /// Store in the database the mapping of ShardUId from children to the parent shard,
@@ -165,7 +171,7 @@ impl ReshardingManager {
         block: &Block,
         tries: ShardTries,
         split_shard_event: &ReshardingSplitShardParams,
-    ) -> Result<(), Error> {
+    ) -> Result<SplitShardTrieChanges, Error> {
         let block_hash = block.hash();
         let block_height = block.header().height();
         let ReshardingSplitShardParams {
@@ -184,6 +190,8 @@ impl ReshardingManager {
             self.store.chain_store().get_chunk_extra(block_hash, parent_shard_uid)?;
         let mut store_update = self.store.trie_store().store_update();
 
+        let mut split_shard_trie_changes = SplitShardTrieChanges::default();
+
         for (new_shard_uid, retain_mode) in
             [(left_child_shard, RetainMode::Left), (right_child_shard, RetainMode::Right)]
         {
@@ -191,15 +199,16 @@ impl ReshardingManager {
                 .get_trie_for_shard(*parent_shard_uid, *parent_chunk_extra.state_root())
                 .recording_reads_new_recorder();
 
-            if !parent_trie.has_memtries() {
-                tracing::error!(
-                    "Memtrie not loaded. Cannot process memtrie resharding storage
-                     update for block {:?}, shard {:?}",
-                    block_hash,
-                    parent_shard_uid,
-                );
-                return Err(Error::Other("Memtrie not loaded".to_string()));
-            }
+            // TODO(wacban) - nocommit - do it properly
+            // if !parent_trie.has_memtries() {
+            //     tracing::error!(
+            //         "Memtrie not loaded. Cannot process memtrie resharding storage
+            //          update for block {:?}, shard {:?}",
+            //         block_hash,
+            //         parent_shard_uid,
+            //     );
+            //     return Err(Error::Other("Memtrie not loaded".to_string()));
+            // }
 
             tracing::info!(
                 target: "resharding", ?new_shard_uid, ?retain_mode,
@@ -253,16 +262,19 @@ impl ReshardingManager {
             );
 
             tracing::info!(target: "resharding", ?new_shard_uid, ?trie_changes.new_root, "Child trie created");
+
+            split_shard_trie_changes.trie_changes.insert(*new_shard_uid, trie_changes);
         }
 
+        // TODO(wacban) - nocommit - do it properly
         // After committing the split changes, the parent trie has the state root of both the children.
         // Now we can freeze the parent memtrie and copy it to the children.
-        tries.freeze_parent_memtrie(*parent_shard_uid, split_shard_event.children_shards())?;
+        // tries.freeze_parent_memtrie(*parent_shard_uid, split_shard_event.children_shards())?;
 
         chain_store_update.merge(store_update.into());
         chain_store_update.commit()?;
 
-        Ok(())
+        Ok(split_shard_trie_changes)
     }
 
     pub fn get_child_congestion_info(

--- a/core/store/src/archive/cold_storage.rs
+++ b/core/store/src/archive/cold_storage.rs
@@ -146,7 +146,7 @@ pub fn update_cold_db(
 // Correctly set the key and value on DBTransaction, taking reference counting
 // into account. For non-rc columns it just sets the value. For rc columns it
 // appends rc = 1 to the value and sets it.
-fn rc_aware_set(
+pub fn rc_aware_set(
     transaction: &mut DBTransaction,
     col: DBCol,
     key: Vec<u8>,

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -406,7 +406,7 @@ impl Database for RocksDB {
                 target = "store::db::rocksdb",
                 message = "making a write batch took a very long time, make smaller transactions!",
                 ?elapsed,
-                backtrace = %std::backtrace::Backtrace::force_capture()
+                // backtrace = %std::backtrace::Backtrace::force_capture()
             );
         }
         self.db.write(batch).map_err(io::Error::other)

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -887,6 +887,7 @@ impl Trie {
             }
             Err(err) => {
                 writeln!(f, "Error when reading: {}", err).expect("write failed");
+                panic!("MissingTrieValue");
             }
         };
     }
@@ -1042,7 +1043,8 @@ impl Trie {
         let (bytes, raw_node, mem_usage) = match self.retrieve_raw_node(hash, true, opts) {
             Ok(Some((bytes, raw_node))) => (bytes, raw_node.node, raw_node.memory_usage),
             Ok(None) => return writeln!(f, "{spaces}EmptyNode"),
-            Err(err) => return writeln!(f, "{spaces}error {err}"),
+            // Err(err) => return writeln!(f, "{spaces}error {err}"),
+            Err(err) => panic!("Error retrieving raw node: {err}"),
         };
 
         let children = match raw_node {

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -91,7 +91,7 @@ pub fn get_default_home() -> PathBuf {
 /// The end goal is to get rid of `archive` option in `config.json` file and
 /// have the type of the node be determined purely based on kind of database
 /// being opened.
-pub fn open_storage(home_dir: &Path, near_config: &mut NearConfig) -> anyhow::Result<NodeStorage> {
+pub fn open_storage(home_dir: &Path, near_config: &NearConfig) -> anyhow::Result<NodeStorage> {
     let migrator = migrations::Migrator::new(near_config);
     let opener = NodeStorage::opener(
         home_dir,
@@ -185,7 +185,7 @@ pub fn open_storage(home_dir: &Path, near_config: &mut NearConfig) -> anyhow::Re
         },
     }.with_context(|| format!("unable to open database at {}", opener.path().display()))?;
 
-    near_config.config.archive = storage.is_archive()?;
+    assert_eq!(near_config.config.archive, storage.is_archive()?);
     Ok(storage)
 }
 

--- a/tools/database/src/commands.rs
+++ b/tools/database/src/commands.rs
@@ -7,7 +7,10 @@ use crate::analyze_high_load::HighLoadStatsCommand;
 use crate::compact::RunCompactionCommand;
 use crate::drop_column::DropColumnCommand;
 use crate::make_snapshot::MakeSnapshotCommand;
-use crate::memtrie::{FindBoundaryAccountCommand, LoadMemTrieCommand, SplitShardTrieCommand};
+use crate::memtrie::{
+    ArchivalDataLossRecoveryCommand, FindBoundaryAccountCommand, LoadMemTrieCommand,
+    SplitShardTrieCommand,
+};
 use crate::run_migrations::RunMigrationsCommand;
 use crate::set_version::SetVersionCommand;
 use crate::state_perf::StatePerfCommand;
@@ -57,6 +60,8 @@ enum SubCommand {
     SplitShardTrie(SplitShardTrieCommand),
     /// Find a split account for the given shard based on `memory_usage` stored in trie nodes.
     FindBoundaryAccount(FindBoundaryAccountCommand),
+    /// Recover the archival data that was lost during resharding.
+    ArchivalDataLossRecovery(ArchivalDataLossRecoveryCommand),
 
     /// Write CryptoHash to DB
     WriteCryptoHash(WriteCryptoHashCommand),
@@ -93,6 +98,7 @@ impl DatabaseCommand {
             SubCommand::LoadMemTrie(cmd) => cmd.run(home, genesis_validation),
             SubCommand::SplitShardTrie(cmd) => cmd.run(home, genesis_validation),
             SubCommand::FindBoundaryAccount(cmd) => cmd.run(home, genesis_validation),
+            SubCommand::ArchivalDataLossRecovery(cmd) => cmd.run(home, genesis_validation),
             SubCommand::WriteCryptoHash(cmd) => cmd.run(home, genesis_validation),
             SubCommand::HighLoadStats(cmd) => cmd.run(home),
             SubCommand::AnalyzeDelayedReceipt(cmd) => cmd.run(home, genesis_validation),

--- a/tools/database/src/memtrie.rs
+++ b/tools/database/src/memtrie.rs
@@ -2,7 +2,8 @@ use crate::utils::open_rocksdb;
 use anyhow::Context;
 use bytesize::ByteSize;
 use near_async::messaging::{IntoMultiSender, noop};
-use near_chain::resharding::event_type::ReshardingSplitShardParams;
+use near_async::time::Instant;
+use near_chain::resharding::event_type::{ReshardingEventType, ReshardingSplitShardParams};
 use near_chain::resharding::manager::ReshardingManager;
 use near_chain::types::RuntimeAdapter;
 use near_chain::{ChainStore, ChainStoreAccess};
@@ -15,11 +16,14 @@ use near_primitives::block::{Block, Tip};
 use near_primitives::block_header::BlockHeader;
 use near_primitives::epoch_manager::EpochConfigStore;
 use near_primitives::shard_layout::ShardLayout;
-use near_primitives::types::{AccountId, ShardId};
+use near_primitives::types::{AccountId, ProtocolVersion, ShardId};
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::chain_store::ChainStoreAdapter;
-use near_store::db::RocksDB;
+use near_store::adapter::trie_store::get_shard_uid_mapping;
+use near_store::archive::cold_storage::{join_two_keys, rc_aware_set};
 use near_store::db::rocksdb::snapshot::Snapshot;
+use near_store::db::{DBTransaction, Database, RocksDB};
+use near_store::flat::BlockInfo;
 use near_store::trie::find_trie_split;
 use near_store::trie::mem::node::MemTrieNodeView;
 use near_store::{DBCol, HEAD_KEY, Mode, ShardTries, ShardUId, Temperature};
@@ -350,5 +354,190 @@ impl FindBoundaryAccountCommand {
         );
 
         Ok(())
+    }
+}
+
+#[derive(clap::Parser)]
+pub struct ArchivalDataLossRecoveryCommand {
+    #[clap(long)]
+    protocol_version: ProtocolVersion,
+
+    #[clap(long, default_value_t = false)]
+    check_only: bool,
+}
+
+impl ArchivalDataLossRecoveryCommand {
+    pub fn run(
+        &self,
+        home: &Path,
+        genesis_validation: GenesisValidationMode,
+    ) -> anyhow::Result<()> {
+        let env_filter = EnvFilterBuilder::from_env().verbose(Some("memtrie")).finish()?;
+        let _subscriber = default_subscriber(env_filter, &Default::default()).global();
+
+        let near_config =
+            nearcore::config::load_config(&home, genesis_validation).expect("Error loading config");
+        let genesis_config = &near_config.genesis.config;
+
+        let node_storage = nearcore::open_storage(&home, &near_config)?;
+        let store = node_storage.get_split_store().expect("SplitStore not found!");
+        let cold_store = node_storage.get_cold_store().expect("ColdStore not found!");
+        let cold_db = node_storage.cold_db().expect("ColdDB not found!");
+        let mut chain_store = ChainStore::new(
+            store.clone(),
+            true,
+            near_config.genesis.config.transaction_validity_period,
+        );
+
+        // Create epoch manager and runtime
+        let epoch_manager =
+            EpochManager::new_arc_handle(store.clone(), &genesis_config, Some(home));
+        let runtime = NightshadeRuntime::from_config(
+            home,
+            store.clone(),
+            &near_config,
+            epoch_manager.clone(),
+        );
+        let runtime = runtime.context("could not create the transaction runtime")?;
+
+        // Get the shard layout and ensure the protocol version upgrade actually
+        // contains a resharding.
+        let shard_layout =
+            epoch_manager.get_shard_layout_from_protocol_version(self.protocol_version);
+        let prev_shard_layout =
+            epoch_manager.get_shard_layout_from_protocol_version(self.protocol_version - 1);
+        assert_ne!(
+            shard_layout, prev_shard_layout,
+            "The provided protocol version does not contain a resharding."
+        );
+
+        println!("Searching for the first epoch of the provided protocol version");
+        // Find the fist epoch of the provided protocol version.
+        let head = store.chain_store().head()?;
+        let mut epoch_id = head.epoch_id;
+        loop {
+            let epoch_start_height = epoch_manager.get_epoch_start_from_epoch_id(&epoch_id)?;
+            let epoch_start_block_header =
+                store.chain_store().get_block_header_by_height(epoch_start_height)?;
+
+            let prev_block_hash = epoch_start_block_header.prev_hash();
+            let prev_epoch_id = epoch_manager.get_epoch_id(prev_block_hash)?;
+            let prev_protocol_version = epoch_manager.get_epoch_protocol_version(&prev_epoch_id)?;
+
+            if prev_protocol_version < self.protocol_version {
+                break;
+            }
+
+            epoch_id = prev_epoch_id;
+        }
+        println!("Found epoch id {epoch_id:?}");
+
+        // Find the resharding block. It is the last block of the previous epoch.
+        let epoch_start_height = epoch_manager.get_epoch_start_from_epoch_id(&epoch_id)?;
+        let epoch_start_block_hash =
+            store.chain_store().get_block_hash_by_height(epoch_start_height)?;
+        let epoch_start_block = store.chain_store().get_block(&epoch_start_block_hash)?;
+        let resharding_block_hash = epoch_start_block.header().prev_hash();
+        let resharding_block = store.chain_store().get_block(resharding_block_hash)?;
+        println!("Found resharding block {resharding_block_hash:?}");
+
+        // Prepare the resharding split shard params.
+        let resharding_block_info = BlockInfo {
+            hash: *resharding_block.hash(),
+            height: resharding_block.header().height(),
+            prev_hash: *resharding_block.header().prev_hash(),
+        };
+        let resharding_event =
+            ReshardingEventType::from_shard_layout(&shard_layout, resharding_block_info)?;
+        let resharding_event = resharding_event.expect("Could not create the resharding event");
+        let ReshardingEventType::SplitShard(split_shard_params) = resharding_event;
+        println!("Prepared split shard params: {split_shard_params:?}");
+
+        let shard_tries = runtime.get_tries();
+        if self.check_only {
+            Self::check_trie(
+                &shard_layout,
+                &shard_tries,
+                &resharding_block,
+                split_shard_params.left_child_shard,
+            );
+
+            Self::check_trie(
+                &shard_layout,
+                &shard_tries,
+                &resharding_block,
+                split_shard_params.right_child_shard,
+            );
+            return Ok(());
+        }
+
+        // Create resharding manager.
+        let sender = noop().into_multi_sender();
+        let shard_tracker = ShardTracker::new(
+            near_config.client_config.tracked_shards_config.clone(),
+            epoch_manager.clone(),
+            near_config.validator_signer.clone(),
+        );
+        let resharding_manager =
+            ReshardingManager::new(store, epoch_manager, shard_tracker, sender);
+
+        println!("Starting resharding");
+        let chain_store_update = chain_store.store_update();
+        let trie_changes = resharding_manager.split_shard(
+            chain_store_update,
+            &resharding_block,
+            split_shard_params.parent_shard,
+            shard_tries,
+            split_shard_params,
+        )?;
+        println!("Resharding done");
+
+        println!("Writing child trie changes");
+        let mut transaction = DBTransaction::new();
+        for (&child_shard_uid, child_trie_changes) in trie_changes.trie_changes.iter() {
+            let mapped_shard_uid = get_shard_uid_mapping(&cold_store, child_shard_uid);
+            let insertions = child_trie_changes.insertions().len();
+            println!(
+                "shard_uid {child_shard_uid:?}, mapped shard_uid {mapped_shard_uid:?}, insertions {insertions}"
+            );
+
+            for op in child_trie_changes.insertions() {
+                let key = join_two_keys(&mapped_shard_uid.to_bytes(), op.hash().as_bytes());
+                let value = op.payload().to_vec();
+
+                rc_aware_set(&mut transaction, DBCol::State, key, value);
+            }
+        }
+        cold_db.write(transaction)?;
+
+        Ok(())
+    }
+
+    fn check_trie(
+        shard_layout: &ShardLayout,
+        shard_tries: &ShardTries,
+        block: &Block,
+        shard_uid: ShardUId,
+    ) {
+        println!("checking shard {shard_uid:?}");
+        let start_time = Instant::now();
+        let mut node_count = 0;
+
+        let child_index = shard_layout.get_shard_index(shard_uid.shard_id()).unwrap();
+        let child_header = &block.chunks()[child_index];
+        assert_eq!(shard_uid.shard_id(), child_header.shard_id());
+
+        let child_state_root = child_header.prev_state_root();
+        let child_trie = shard_tries.get_trie_for_shard(shard_uid, child_state_root);
+        let iter_lock = child_trie.lock_for_iter();
+        for item in iter_lock.iter().unwrap() {
+            item.unwrap();
+            node_count += 1;
+        }
+
+        let elapsed = start_time.elapsed();
+        println!(
+            "finished checking shard {shard_uid:?}, elapsed: {elapsed:?}, node count: {node_count}"
+        );
     }
 }


### PR DESCRIPTION
This is a recovery tool for the data loss that happened during the recent reshardings. As the resharding implementation does not store any TrieChanges, the trie nodes inserted during resharding are never moved to the cold storage. Once the garbage collection removes those nodes they are lost and the archival node cannot serve some queries for some range of blocks after resharding. 

This tool replays the resharding, extracts the TrieChanges and stores them directly into the cold db. 

I tested it on my own archival node where I was able to recover the data and confirm that the reported query that was broken for fast near works fine. 
```
http POST '34.6.25.108:3030' \
     jsonrpc=2.0 \
     id=dontcare \
     method=query \
     params:='{
     "request_type": "call_function",
     "block_id": 160156315,
     "account_id": "astro-stakers.poolv1.near",
     "method_name": "get_reward_fee_fraction",
     "args_base64": ""
 }'
```

The check-only option allows checking if the trie is whole. I need to work on it a bit more because it's slow and doesn't work if there was a missing chunk in the first block of the new shard layout. 

This is not a fix to the original problem that caused the data loss, that will follow separately. 