### PR TITLE
fix: spice executor: fix should_apply_chunk to use prev_hash.

### DIFF
--- a/chain/client/src/chunk_executor_actor.rs
+++ b/chain/client/src/chunk_executor_actor.rs
@@ -351,7 +351,7 @@ impl ChunkExecutorActor {
             // If we don't care about shard we wouldn't have relevant incoming receipts.
             if !self.shard_tracker.should_apply_chunk(
                 ApplyChunksMode::IsCaughtUp,
-                block_hash,
+                prev_hash,
                 shard_id,
             ) {
                 continue;


### PR DESCRIPTION
Since we don't yet have resharding support for executor we cannot add a unit test to make sure we don't encounter a similar issue in the future.