### PR TITLE
refactor: move `AccountContract` utilities off `TrieUpdate`

### DIFF
--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -2,6 +2,7 @@ use crate::types::AccountId;
 use crate::{action::GlobalContractIdentifier, hash::CryptoHash};
 use borsh::{BorshDeserialize, BorshSerialize, to_vec};
 use near_crypto::PublicKey;
+use near_primitives_core::account::AccountContract;
 use near_primitives_core::types::{NonceIndex, ShardId};
 use near_schema_checker_lib::ProtocolSchema;
 use std::mem::size_of;
@@ -485,6 +486,23 @@ impl TrieKey {
             TrieKey::GlobalContractCode { .. } => None,
             TrieKey::GasKey { account_id, .. } => Some(account_id.clone()),
         }
+    }
+
+    pub fn for_account_contract_code(
+        account_id: &AccountId,
+        account_contract: &AccountContract,
+    ) -> Option<Self> {
+        let trie_key = match account_contract {
+            AccountContract::None => return None,
+            AccountContract::Local(_) => Self::ContractCode { account_id: account_id.clone() },
+            AccountContract::Global(code_hash) => Self::GlobalContractCode {
+                identifier: GlobalContractCodeIdentifier::CodeHash(*code_hash),
+            },
+            AccountContract::GlobalByAccount(account_id) => Self::GlobalContractCode {
+                identifier: GlobalContractCodeIdentifier::AccountId(account_id.clone()),
+            },
+        };
+        Some(trie_key)
     }
 }
 

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -18,7 +18,7 @@ use config::{total_prepaid_send_fees, tx_cost};
 use congestion_control::ReceiptSink;
 pub use congestion_control::bootstrap_congestion_info;
 use global_contracts::{
-    action_deploy_global_contract, action_use_global_contract,
+    AccountContractStoreExt, action_deploy_global_contract, action_use_global_contract,
     apply_global_contract_distribution_receipt,
 };
 use itertools::Itertools;
@@ -393,8 +393,7 @@ impl Runtime {
             Action::FunctionCall(function_call) => {
                 let account = account.as_mut().expect(EXPECT_ACCOUNT_EXISTS);
                 let account_contract = account.contract();
-                let code_hash =
-                    state_update.get_account_contract_hash(account_contract.as_ref())?;
+                let code_hash = account_contract.hash(&state_update)?;
                 let contract =
                     preparation_pipeline.get_contract(receipt, code_hash, action_index, None);
                 let is_last_action = action_index + 1 == actions.len();


### PR DESCRIPTION
`TrieUpdate` is a relatively weird place to put common logic such as this, as it does not really have anything to do with account contracts and its API surface should be somewhat agnostic of the data it is working with.

But for the most part this is informed by the want to reuse this code with the new `StateUpdate` and this logic living inside `TrieUpdate` was bothering me quite some.

In fact this interface probably should take `&dyn TrieAccess` as an argument or something of that sort, but this is not easily achievable for `AccountContract::hash` due to `TrieAccess` not exposing accessors for `OptimizedValueRef`s. Left the argument as `TrieUpdate` for now, but in the future this will change (in a less involving way.)