### PR TITLE
refactor: move single-use utilities away from `TrieUpdate`

### DIFF
--- a/core/primitives/src/action/mod.rs
+++ b/core/primitives/src/action/mod.rs
@@ -217,18 +217,18 @@ impl GlobalContractIdentifier {
 }
 
 #[derive(Debug)]
-pub enum LocalContractError {
+pub enum ContractIsLocalError {
     NotDeployed,
     Deployed(CryptoHash),
 }
 
-impl std::error::Error for LocalContractError {}
+impl std::error::Error for ContractIsLocalError {}
 
-impl fmt::Display for LocalContractError {
+impl fmt::Display for ContractIsLocalError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
-            LocalContractError::NotDeployed => "contract is not deployed",
-            LocalContractError::Deployed(_) => "a locally deployed contract is deployed",
+            ContractIsLocalError::NotDeployed => "contract is not deployed",
+            ContractIsLocalError::Deployed(_) => "a locally deployed contract is deployed",
         })
     }
 }
@@ -239,11 +239,11 @@ impl fmt::Display for LocalContractError {
 /// If conversion is not possible, the conversion error can be inspected to obtain information
 /// about the local error.
 impl TryFrom<AccountContract> for GlobalContractIdentifier {
-    type Error = LocalContractError;
+    type Error = ContractIsLocalError;
     fn try_from(value: AccountContract) -> Result<Self, Self::Error> {
         match value {
-            AccountContract::None => Err(LocalContractError::NotDeployed),
-            AccountContract::Local(h) => Err(LocalContractError::Deployed(h)),
+            AccountContract::None => Err(ContractIsLocalError::NotDeployed),
+            AccountContract::Local(h) => Err(ContractIsLocalError::Deployed(h)),
             AccountContract::Global(h) => Ok(GlobalContractIdentifier::CodeHash(h)),
             AccountContract::GlobalByAccount(a) => Ok(GlobalContractIdentifier::AccountId(a)),
         }

--- a/core/primitives/src/action/mod.rs
+++ b/core/primitives/src/action/mod.rs
@@ -223,7 +223,6 @@ impl TryFrom<AccountContract> for GlobalContractIdentifier {
     }
 }
 
-
 impl GlobalContractIdentifier {
     pub fn len(&self) -> usize {
         match self {

--- a/core/primitives/src/action/mod.rs
+++ b/core/primitives/src/action/mod.rs
@@ -3,7 +3,7 @@ pub mod delegate;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_crypto::PublicKey;
 use near_primitives_core::{
-    account::AccessKey,
+    account::{AccessKey, AccountContract},
     hash::CryptoHash,
     serialize::dec_format,
     types::{AccountId, Balance, Gas},
@@ -206,6 +206,23 @@ impl From<GlobalContractCodeIdentifier> for GlobalContractIdentifier {
         }
     }
 }
+
+/// Extract [`GlobalContractIdentifier`] out of [`AccountContract`] if it represents a global
+/// contract.
+///
+/// If conversion is not possible, returns information about locally deployed contract.
+impl TryFrom<AccountContract> for GlobalContractIdentifier {
+    type Error = Option<CryptoHash>;
+    fn try_from(value: AccountContract) -> Result<Self, Self::Error> {
+        match value {
+            AccountContract::None => Err(None),
+            AccountContract::Local(h) => Err(Some(h)),
+            AccountContract::Global(h) => Ok(GlobalContractIdentifier::CodeHash(h)),
+            AccountContract::GlobalByAccount(a) => Ok(GlobalContractIdentifier::AccountId(a)),
+        }
+    }
+}
+
 
 impl GlobalContractIdentifier {
     pub fn len(&self) -> usize {

--- a/core/primitives/src/action/mod.rs
+++ b/core/primitives/src/action/mod.rs
@@ -210,7 +210,7 @@ impl From<GlobalContractCodeIdentifier> for GlobalContractIdentifier {
 /// Extract [`GlobalContractIdentifier`] out of [`AccountContract`] if it represents a global
 /// contract.
 ///
-/// If conversion is not possible, returns information about locally deployed contract.
+/// If conversion is not possible, returns information about the locally deployed contract.
 impl TryFrom<AccountContract> for GlobalContractIdentifier {
     type Error = Option<CryptoHash>;
     fn try_from(value: AccountContract) -> Result<Self, Self::Error> {

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -489,12 +489,14 @@ impl TrieKey {
     }
 
     pub fn for_account_contract_code(
-        local_account_id: impl FnOnce() -> AccountId,
+        local_account_id: &AccountId,
         account_contract: &AccountContract,
     ) -> Option<Self> {
         let trie_key = match account_contract {
             AccountContract::None => return None,
-            AccountContract::Local(_) => Self::ContractCode { account_id: local_account_id() },
+            AccountContract::Local(_) => {
+                Self::ContractCode { account_id: local_account_id.clone() }
+            }
             AccountContract::Global(code_hash) => Self::GlobalContractCode {
                 identifier: GlobalContractCodeIdentifier::CodeHash(*code_hash),
             },

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -2,7 +2,6 @@ use crate::types::AccountId;
 use crate::{action::GlobalContractIdentifier, hash::CryptoHash};
 use borsh::{BorshDeserialize, BorshSerialize, to_vec};
 use near_crypto::PublicKey;
-use near_primitives_core::account::AccountContract;
 use near_primitives_core::types::{NonceIndex, ShardId};
 use near_schema_checker_lib::ProtocolSchema;
 use std::mem::size_of;
@@ -486,25 +485,6 @@ impl TrieKey {
             TrieKey::GlobalContractCode { .. } => None,
             TrieKey::GasKey { account_id, .. } => Some(account_id.clone()),
         }
-    }
-
-    pub fn for_account_contract_code(
-        local_account_id: &AccountId,
-        account_contract: &AccountContract,
-    ) -> Option<Self> {
-        let trie_key = match account_contract {
-            AccountContract::None => return None,
-            AccountContract::Local(_) => {
-                Self::ContractCode { account_id: local_account_id.clone() }
-            }
-            AccountContract::Global(code_hash) => Self::GlobalContractCode {
-                identifier: GlobalContractCodeIdentifier::CodeHash(*code_hash),
-            },
-            AccountContract::GlobalByAccount(account_id) => Self::GlobalContractCode {
-                identifier: GlobalContractCodeIdentifier::AccountId(account_id.clone()),
-            },
-        };
-        Some(trie_key)
     }
 }
 

--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -489,12 +489,12 @@ impl TrieKey {
     }
 
     pub fn for_account_contract_code(
-        account_id: &AccountId,
+        local_account_id: impl FnOnce() -> AccountId,
         account_contract: &AccountContract,
     ) -> Option<Self> {
         let trie_key = match account_contract {
             AccountContract::None => return None,
-            AccountContract::Local(_) => Self::ContractCode { account_id: account_id.clone() },
+            AccountContract::Local(_) => Self::ContractCode { account_id: local_account_id() },
             AccountContract::Global(code_hash) => Self::GlobalContractCode {
                 identifier: GlobalContractCodeIdentifier::CodeHash(*code_hash),
             },

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -5,7 +5,7 @@ use crate::contract::ContractStorage;
 use crate::trie::TrieAccess;
 use crate::trie::{KeyLookupMode, TrieChanges};
 use near_primitives::account::AccountContract;
-use near_primitives::action::GlobalContractIdentifier;
+use near_primitives::action::{GlobalContractIdentifier, LocalContractError};
 use near_primitives::apply::ApplyChunkReason;
 use near_primitives::hash::{CryptoHash, hash};
 use near_primitives::stateless_validation::contract_distribution::ContractUpdates;
@@ -307,8 +307,8 @@ impl TrieUpdate {
         // newly-deployed to the account. Note that the check below to see if the contract exists
         // has no side effects (not charging gas or recording trie nodes)
         let trie_key = match GlobalContractIdentifier::try_from(account_contract.clone()) {
-            Err(None) => return Ok(()),
-            Err(Some(_)) => TrieKey::ContractCode { account_id },
+            Err(LocalContractError::NotDeployed) => return Ok(()),
+            Err(LocalContractError::Deployed(_)) => TrieKey::ContractCode { account_id },
             Ok(identifier) => TrieKey::GlobalContractCode { identifier: identifier.into() },
         };
         let contract_ref = self

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -5,7 +5,7 @@ use crate::contract::ContractStorage;
 use crate::trie::TrieAccess;
 use crate::trie::{KeyLookupMode, TrieChanges};
 use near_primitives::account::AccountContract;
-use near_primitives::action::{GlobalContractIdentifier, LocalContractError};
+use near_primitives::action::{GlobalContractIdentifier, ContractIsLocalError};
 use near_primitives::apply::ApplyChunkReason;
 use near_primitives::hash::{CryptoHash, hash};
 use near_primitives::stateless_validation::contract_distribution::ContractUpdates;
@@ -307,8 +307,8 @@ impl TrieUpdate {
         // newly-deployed to the account. Note that the check below to see if the contract exists
         // has no side effects (not charging gas or recording trie nodes)
         let trie_key = match GlobalContractIdentifier::try_from(account_contract.clone()) {
-            Err(LocalContractError::NotDeployed) => return Ok(()),
-            Err(LocalContractError::Deployed(_)) => TrieKey::ContractCode { account_id },
+            Err(ContractIsLocalError::NotDeployed) => return Ok(()),
+            Err(ContractIsLocalError::Deployed(_)) => TrieKey::ContractCode { account_id },
             Ok(identifier) => TrieKey::GlobalContractCode { identifier: identifier.into() },
         };
         let contract_ref = self

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -5,7 +5,7 @@ use crate::contract::ContractStorage;
 use crate::trie::TrieAccess;
 use crate::trie::{KeyLookupMode, TrieChanges};
 use near_primitives::account::AccountContract;
-use near_primitives::action::{GlobalContractIdentifier, ContractIsLocalError};
+use near_primitives::action::{ContractIsLocalError, GlobalContractIdentifier};
 use near_primitives::apply::ApplyChunkReason;
 use near_primitives::hash::{CryptoHash, hash};
 use near_primitives::stateless_validation::contract_distribution::ContractUpdates;

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -5,6 +5,7 @@ use crate::contract::ContractStorage;
 use crate::trie::TrieAccess;
 use crate::trie::{KeyLookupMode, TrieChanges};
 use near_primitives::account::AccountContract;
+use near_primitives::action::GlobalContractIdentifier;
 use near_primitives::apply::ApplyChunkReason;
 use near_primitives::hash::{CryptoHash, hash};
 use near_primitives::stateless_validation::contract_distribution::ContractUpdates;
@@ -294,18 +295,21 @@ impl TrieUpdate {
         account_contract: &AccountContract,
         apply_reason: ApplyChunkReason,
     ) -> Result<(), StorageError> {
-        // The recording of contracts when they are excluded from the witness are only for distributing them to the validators,
-        // and not needed for validating the chunks, thus we skip the recording if we are not applying the chunk for updating the shard.
+        // The recording of contracts when they are excluded from the witness are only for
+        // distributing them to the validators, and not needed for validating the chunks, thus we
+        // skip the recording if we are not applying the chunk for updating the shard.
         if apply_reason != ApplyChunkReason::UpdateTrackedShard {
             return Ok(());
         }
 
-        // Only record the call if trie contains the contract (with the given hash) being called deployed to the given account.
-        // This avoids recording contracts that do not exist or are newly-deployed to the account.
-        // Note that the check below to see if the contract exists has no side effects (not charging gas or recording trie nodes)
-        let Some(trie_key) = TrieKey::for_account_contract_code(&account_id, account_contract)
-        else {
-            return Ok(());
+        // Only record the call if trie contains the contract (with the given hash) being called
+        // deployed to the given account. This avoids recording contracts that do not exist or are
+        // newly-deployed to the account. Note that the check below to see if the contract exists
+        // has no side effects (not charging gas or recording trie nodes)
+        let trie_key = match GlobalContractIdentifier::try_from(account_contract.clone()) {
+            Err(None) => return Ok(()),
+            Err(Some(_)) => TrieKey::ContractCode { account_id },
+            Ok(identifier) => TrieKey::GlobalContractCode { identifier: identifier.into() },
         };
         let contract_ref = self
             .trie

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -8,7 +8,7 @@ use near_primitives::account::AccountContract;
 use near_primitives::apply::ApplyChunkReason;
 use near_primitives::hash::{CryptoHash, hash};
 use near_primitives::stateless_validation::contract_distribution::ContractUpdates;
-use near_primitives::trie_key::{GlobalContractCodeIdentifier, TrieKey};
+use near_primitives::trie_key::TrieKey;
 use near_primitives::types::{
     AccountId, RawStateChange, RawStateChanges, RawStateChangesWithTrieKey, StateChangeCause,
     StateRoot,
@@ -303,7 +303,7 @@ impl TrieUpdate {
         // Only record the call if trie contains the contract (with the given hash) being called deployed to the given account.
         // This avoids recording contracts that do not exist or are newly-deployed to the account.
         // Note that the check below to see if the contract exists has no side effects (not charging gas or recording trie nodes)
-        let Some(trie_key) = TrieKey::for_account_contract_code(|| account_id, account_contract)
+        let Some(trie_key) = TrieKey::for_account_contract_code(&account_id, account_contract)
         else {
             return Ok(());
         };

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -29,7 +29,7 @@ use near_primitives_core::account::id::AccountType;
 use near_primitives_core::version::ProtocolFeature;
 use near_store::trie::AccessOptions;
 use near_store::{
-    StorageError, TrieAccess as _, TrieUpdate, enqueue_promise_yield_timeout, get_access_key,
+    StorageError, TrieAccess, TrieUpdate, enqueue_promise_yield_timeout, get_access_key,
     get_promise_yield_indices, remove_access_key, remove_account, set_access_key,
     set_promise_yield_indices,
 };
@@ -635,8 +635,8 @@ pub(crate) fn action_delete_account(
     Ok(())
 }
 
-/// Returns the storage usage for the contract code with the given `code_hash` and deployed to the given `account_id`.
-/// If no contract was deployed to the account, returns `0`.
+/// Returns the storage usage for the contract code with the given `code_hash` and deployed to the
+/// given `account_id`. If no contract was deployed to the account, returns `0`.
 ///
 /// This implements different behaviors based on the protocol version:
 /// If `ExcludeExistingCodeFromWitnessForCodeLen` is enabled then the code-length is obtained without reading
@@ -652,10 +652,7 @@ fn get_code_len_or_default(
             state_update.get_code_len(account_id, code_hash)?
         } else {
             let key = near_primitives::trie_key::TrieKey::ContractCode { account_id };
-            state_update
-                .get(&key, AccessOptions::DEFAULT)
-                .map(|opt| opt.map(|code| ContractCode::new(code, Some(code_hash))))?
-                .map(|contract| contract.code().len())
+            state_update.get(&key, AccessOptions::DEFAULT)?.map(|code| code.len())
         };
     debug_assert!(
         code_len.is_some() || code_hash == CryptoHash::default(),

--- a/runtime/runtime/src/global_contracts.rs
+++ b/runtime/runtime/src/global_contracts.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 
 use near_primitives::account::{Account, AccountContract};
 use near_primitives::action::{
-    DeployGlobalContractAction, GlobalContractDeployMode, GlobalContractIdentifier,
-    ContractIsLocalError, UseGlobalContractAction,
+    ContractIsLocalError, DeployGlobalContractAction, GlobalContractDeployMode,
+    GlobalContractIdentifier, UseGlobalContractAction,
 };
 use near_primitives::chunk_apply_stats::ChunkApplyStatsV0;
 use near_primitives::errors::{ActionErrorKind, RuntimeError};

--- a/runtime/runtime/src/global_contracts.rs
+++ b/runtime/runtime/src/global_contracts.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use near_primitives::account::{Account, AccountContract};
 use near_primitives::action::{
     DeployGlobalContractAction, GlobalContractDeployMode, GlobalContractIdentifier,
-    LocalContractError, UseGlobalContractAction,
+    ContractIsLocalError, UseGlobalContractAction,
 };
 use near_primitives::chunk_apply_stats::ChunkApplyStatsV0;
 use near_primitives::errors::{ActionErrorKind, RuntimeError};
@@ -245,8 +245,8 @@ impl AccountContractAccessExt for AccountContract {
     ) -> Result<Option<ContractCode>, StorageError> {
         let local_hash = match GlobalContractIdentifier::try_from(self) {
             Ok(identifier) => return identifier.code(store),
-            Err(LocalContractError::NotDeployed) => return Ok(None),
-            Err(LocalContractError::Deployed(local_hash)) => local_hash,
+            Err(ContractIsLocalError::NotDeployed) => return Ok(None),
+            Err(ContractIsLocalError::Deployed(local_hash)) => local_hash,
         };
         let key = TrieKey::ContractCode { account_id: local_account_id.clone() };
         let code = store.get(&key, AccessOptions::DEFAULT)?;
@@ -256,8 +256,8 @@ impl AccountContractAccessExt for AccountContract {
     fn hash(self, store: &TrieUpdate) -> Result<CryptoHash, StorageError> {
         match GlobalContractIdentifier::try_from(self) {
             Ok(gci) => return gci.hash(store),
-            Err(LocalContractError::NotDeployed) => return Ok(CryptoHash::default()),
-            Err(LocalContractError::Deployed(local_hash)) => Ok(local_hash),
+            Err(ContractIsLocalError::NotDeployed) => return Ok(CryptoHash::default()),
+            Err(ContractIsLocalError::Deployed(local_hash)) => Ok(local_hash),
         }
     }
 }

--- a/runtime/runtime/src/global_contracts.rs
+++ b/runtime/runtime/src/global_contracts.rs
@@ -232,7 +232,7 @@ pub(crate) trait AccountContractStoreExt {
     fn hash(&self, store: &TrieUpdate) -> Result<CryptoHash, StorageError>;
     fn code(
         &self,
-        account_id: &AccountId,
+        local_account_id: impl FnOnce() -> AccountId,
         store: &TrieUpdate,
     ) -> Result<Option<ContractCode>, StorageError>;
 }
@@ -240,10 +240,10 @@ pub(crate) trait AccountContractStoreExt {
 impl AccountContractStoreExt for AccountContract {
     fn code(
         &self,
-        account_id: &AccountId,
+        local_account_id: impl FnOnce() -> AccountId,
         store: &TrieUpdate,
     ) -> Result<Option<ContractCode>, StorageError> {
-        let Some(key) = TrieKey::for_account_contract_code(account_id, self) else {
+        let Some(key) = TrieKey::for_account_contract_code(local_account_id, self) else {
             return Ok(None);
         };
         let code_hash = match self {

--- a/runtime/runtime/src/global_contracts.rs
+++ b/runtime/runtime/src/global_contracts.rs
@@ -272,7 +272,7 @@ impl GlobalContractAccessExt for GlobalContractIdentifier {
         if let GlobalContractIdentifier::CodeHash(crypto_hash) = self {
             return Ok(crypto_hash);
         }
-        let key = TrieKey::GlobalContractCode { identifier: self.clone().into() };
+        let key = TrieKey::GlobalContractCode { identifier: self.into() };
         let value_ref = store
             .get_ref(&key, KeyLookupMode::MemOrFlatOrTrie, AccessOptions::DEFAULT)?
             .ok_or_else(|| {

--- a/runtime/runtime/src/global_contracts.rs
+++ b/runtime/runtime/src/global_contracts.rs
@@ -249,9 +249,8 @@ impl AccountContractAccessExt for AccountContract {
             Err(Some(local_hash)) => local_hash,
         };
         let key = TrieKey::ContractCode { account_id: local_account_id.clone() };
-        store
-            .get(&key, AccessOptions::DEFAULT)
-            .map(|opt| opt.map(|code| ContractCode::new(code, Some(local_hash))))
+        let code = store.get(&key, AccessOptions::DEFAULT)?;
+        Ok(code.map(|code| ContractCode::new(code, Some(local_hash))))
     }
 
     fn hash(self, store: &TrieUpdate) -> Result<CryptoHash, StorageError> {
@@ -292,8 +291,7 @@ impl GlobalContractAccessExt for GlobalContractIdentifier {
             GlobalContractIdentifier::AccountId(_) => None,
             GlobalContractIdentifier::CodeHash(hash) => Some(hash),
         };
-        store
-            .get(&key, AccessOptions::DEFAULT)
-            .map(|opt| opt.map(|code| ContractCode::new(code, code_hash)))
+        let code = store.get(&key, AccessOptions::DEFAULT)?;
+        Ok(code.map(|code| ContractCode::new(code, code_hash)))
     }
 }

--- a/runtime/runtime/src/global_contracts.rs
+++ b/runtime/runtime/src/global_contracts.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use near_primitives::account::{Account, AccountContract};
 use near_primitives::action::{
     DeployGlobalContractAction, GlobalContractDeployMode, GlobalContractIdentifier,
-    UseGlobalContractAction,
+    LocalContractError, UseGlobalContractAction,
 };
 use near_primitives::chunk_apply_stats::ChunkApplyStatsV0;
 use near_primitives::errors::{ActionErrorKind, RuntimeError};
@@ -245,8 +245,8 @@ impl AccountContractAccessExt for AccountContract {
     ) -> Result<Option<ContractCode>, StorageError> {
         let local_hash = match GlobalContractIdentifier::try_from(self) {
             Ok(identifier) => return identifier.code(store),
-            Err(None) => return Ok(None),
-            Err(Some(local_hash)) => local_hash,
+            Err(LocalContractError::NotDeployed) => return Ok(None),
+            Err(LocalContractError::Deployed(local_hash)) => local_hash,
         };
         let key = TrieKey::ContractCode { account_id: local_account_id.clone() };
         let code = store.get(&key, AccessOptions::DEFAULT)?;
@@ -256,8 +256,8 @@ impl AccountContractAccessExt for AccountContract {
     fn hash(self, store: &TrieUpdate) -> Result<CryptoHash, StorageError> {
         match GlobalContractIdentifier::try_from(self) {
             Ok(gci) => return gci.hash(store),
-            Err(None) => return Ok(CryptoHash::default()),
-            Err(Some(local_hash)) => Ok(local_hash),
+            Err(LocalContractError::NotDeployed) => return Ok(CryptoHash::default()),
+            Err(LocalContractError::Deployed(local_hash)) => Ok(local_hash),
         }
     }
 }

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -18,7 +18,7 @@ use config::{total_prepaid_send_fees, tx_cost};
 use congestion_control::ReceiptSink;
 pub use congestion_control::bootstrap_congestion_info;
 use global_contracts::{
-    AccountContractStoreExt, action_deploy_global_contract, action_use_global_contract,
+    AccountContractAccessExt, action_deploy_global_contract, action_use_global_contract,
     apply_global_contract_distribution_receipt,
 };
 use itertools::Itertools;
@@ -393,7 +393,7 @@ impl Runtime {
             Action::FunctionCall(function_call) => {
                 let account = account.as_mut().expect(EXPECT_ACCOUNT_EXISTS);
                 let account_contract = account.contract();
-                let code_hash = account_contract.hash(&state_update)?;
+                let code_hash = account_contract.into_owned().hash(&state_update)?;
                 let contract =
                     preparation_pipeline.get_contract(receipt, code_hash, action_index, None);
                 let is_last_action = action_index + 1 == actions.len();

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -1,7 +1,7 @@
 use crate::ApplyState;
 use crate::actions::execute_function_call;
 use crate::ext::RuntimeExt;
-use crate::global_contracts::AccountContractStoreExt as _;
+use crate::global_contracts::{AccountContractAccessExt, GlobalContractAccessExt};
 use crate::pipelining::ReceiptPreparationPipeline;
 use crate::receipt_manager::ReceiptManager;
 use near_crypto::{KeyType, PublicKey};
@@ -91,7 +91,7 @@ impl TrieViewer {
         account_id: &AccountId,
     ) -> Result<ContractCode, errors::ViewContractCodeError> {
         let account = self.view_account(state_update, account_id)?;
-        account.contract().code(account_id, &state_update)?.ok_or_else(|| {
+        account.contract().into_owned().code(account_id, &state_update)?.ok_or_else(|| {
             errors::ViewContractCodeError::NoContractCode {
                 contract_account_id: account_id.clone(),
             }
@@ -104,7 +104,8 @@ impl TrieViewer {
         identifier: GlobalContractIdentifier,
     ) -> Result<ContractCode, errors::ViewContractCodeError> {
         identifier
-            .code(&(), state_update)?
+            .clone()
+            .code(state_update)?
             .ok_or(errors::ViewContractCodeError::NoGlobalContractCode { identifier })
     }
 
@@ -264,7 +265,7 @@ impl TrieViewer {
             state_update.contract_storage(),
         );
         let view_config = Some(ViewConfig { max_gas_burnt: self.max_gas_burnt_view });
-        let code_hash = account.contract().hash(&state_update)?;
+        let code_hash = account.contract().into_owned().hash(&state_update)?;
         let contract = pipeline.get_contract(&receipt, code_hash, 0, view_config.clone());
 
         let mut runtime_ext = RuntimeExt::new(

--- a/runtime/runtime/src/state_viewer/mod.rs
+++ b/runtime/runtime/src/state_viewer/mod.rs
@@ -6,7 +6,7 @@ use crate::pipelining::ReceiptPreparationPipeline;
 use crate::receipt_manager::ReceiptManager;
 use near_crypto::{KeyType, PublicKey};
 use near_parameters::RuntimeConfigStore;
-use near_primitives::account::{AccessKey, Account, AccountContract};
+use near_primitives::account::{AccessKey, Account};
 use near_primitives::action::GlobalContractIdentifier;
 use near_primitives::apply::ApplyChunkReason;
 use near_primitives::bandwidth_scheduler::BlockBandwidthRequests;
@@ -14,15 +14,14 @@ use near_primitives::borsh::BorshDeserialize;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{ActionReceipt, Receipt, ReceiptEnum, ReceiptV1};
 use near_primitives::transaction::FunctionCallAction;
-use near_primitives::trie_key::{TrieKey, trie_key_parsers};
+use near_primitives::trie_key::trie_key_parsers;
 use near_primitives::types::{
     AccountId, BlockHeight, EpochHeight, EpochId, EpochInfoProvider, Gas, ShardId,
 };
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{StateItem, ViewStateResult};
 use near_primitives_core::config::ViewConfig;
-use near_store::trie::AccessOptions;
-use near_store::{TrieAccess as _, TrieUpdate, get_access_key, get_account};
+use near_store::{TrieUpdate, get_access_key, get_account};
 use near_vm_runner::logic::{ProtocolVersion, ReturnData};
 use near_vm_runner::{ContractCode, ContractRuntimeCache};
 use std::{str, sync::Arc, time::Instant};
@@ -92,7 +91,7 @@ impl TrieViewer {
         account_id: &AccountId,
     ) -> Result<ContractCode, errors::ViewContractCodeError> {
         let account = self.view_account(state_update, account_id)?;
-        account.contract().code(|| account_id.clone(), &state_update)?.ok_or_else(|| {
+        account.contract().code(account_id, &state_update)?.ok_or_else(|| {
             errors::ViewContractCodeError::NoContractCode {
                 contract_account_id: account_id.clone(),
             }
@@ -104,12 +103,8 @@ impl TrieViewer {
         state_update: &TrieUpdate,
         identifier: GlobalContractIdentifier,
     ) -> Result<ContractCode, errors::ViewContractCodeError> {
-        let account_contract = match &identifier {
-            GlobalContractIdentifier::CodeHash(hash) => AccountContract::Global(*hash),
-            GlobalContractIdentifier::AccountId(a) => AccountContract::GlobalByAccount(a.clone()),
-        };
-        account_contract
-            .code(|| unreachable!(), state_update)?
+        identifier
+            .code(&(), state_update)?
             .ok_or(errors::ViewContractCodeError::NoGlobalContractCode { identifier })
     }
 


### PR DESCRIPTION
These utility functions seem weird to have on a `TrieUpdate`. Usually I
would've considered adding an extension trait similar as for #14192, but
in this case these functions are only used once and adding an extension
trait seemed excessive. Especially when one of the uses is going away
shortly and the other is straightforward to replace with code that
already exists (that same `AccountContract` extension trait.)