### PR TITLE
[ci] Temporarily disable macOS tests during actix migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,12 @@ jobs:
             type: nightly
             upload_profraws: true
             run_on_pr: true
-          # TODO(actix_migration): Enable the MacOS tests after jsonrpc migration is done
-          # - name: MacOS
-          #   id: macos
-          #   os: warp-macos-latest-arm64-6x
-          #   type: stable
-          #   upload_profraws: false
-          #   run_on_pr: false
+          - name: MacOS
+            id: macos
+            os: warp-macos-latest-arm64-6x
+            type: stable
+            upload_profraws: false
+            run_on_pr: false
     timeout-minutes: 90
     steps:
       - if: github.event_name != 'pull_request' || matrix.run_on_pr
@@ -62,7 +61,8 @@ jobs:
 
       # Run the tests
       - name: just nextest-slow ${{ matrix.type }} (with coverage)
-        if: (github.event_name != 'pull_request' || matrix.run_on_pr) && matrix.type != 'spice'
+        # TODO(actix_migration): Enable the MacOS tests after jsonrpc migration is done
+        if: (github.event_name != 'pull_request' || matrix.run_on_pr) && matrix.type != 'spice' && matrix.type != 'macos'
         run: |
           mkdir -p coverage/profraw/{unit,binaries}
           just codecov-ci "nextest-slow ${{ matrix.type }}"


### PR DESCRIPTION
## Summary

Temporarily disabling macOS CI tests due to catastrophic failures during actix migration. Heavy integration tests fail with AddrInUse panics on macOS but pass on Linux, likely due to shutdown inconsistencies in the intermediate state where actix and new actor system coexist.

## Plan

- Re-enable after actix migration is complete
- macOS support is secondary priority vs unblocking migration PRs

Relevant Zulip discussion: [#nearone/code-red > Temporarily disabling MacOS CI](https://near.zulipchat.com/#narrow/channel/524117-nearone.2Fcode-red/topic/Temporarily.20disabling.20MacOS.20CI/with/537926856)