### PR TITLE
[test] Disable flaky slow_test_state_sync_headers_no_tracked_shards test

### DIFF
--- a/integration-tests/src/tests/client/sync_state_nodes.rs
+++ b/integration-tests/src/tests/client/sync_state_nodes.rs
@@ -833,6 +833,7 @@ fn slow_test_state_sync_headers() {
 }
 
 #[test]
+#[ignore] // TODO: Fix flaky test
 // Tests StateRequestHeader and StateRequestPart.
 fn slow_test_state_sync_headers_no_tracked_shards() {
     heavy_test(|| {


### PR DESCRIPTION
## Summary
- Disable flaky `slow_test_state_sync_headers_no_tracked_shards` test by adding `#[ignore]` attribute

This has caused headaches in simple runs. I've seen this enough time to disable the test.
<img width="319" height="262" alt="image" src="https://github.com/user-attachments/assets/d7a9080d-5441-4849-b671-2e7896ca9407" />

https://github.com/near/nearcore/actions/runs/17504038433/job/49724754482?pr=14162