### PR TITLE
[ci] Fix macOS test exclusion condition in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
             type: nightly
             upload_profraws: true
             run_on_pr: true
+          # TODO(actix_migration): Enable the MacOS tests after jsonrpc migration is done
           - name: MacOS
             id: macos
             os: warp-macos-latest-arm64-6x
@@ -54,15 +55,14 @@ jobs:
         uses: actions/checkout@v4
 
       # Install all the required tools
-      - if: github.event_name != 'pull_request' || matrix.run_on_pr
+      - if: (github.event_name != 'pull_request' || matrix.run_on_pr) && matrix.id != 'macos'
         uses: taiki-e/install-action@7852930e42e73b6c323ae4435f5135b58754dfdd
         with:
           tool: just,cargo-nextest,cargo-llvm-cov
 
       # Run the tests
       - name: just nextest-slow ${{ matrix.type }} (with coverage)
-        # TODO(actix_migration): Enable the MacOS tests after jsonrpc migration is done
-        if: (github.event_name != 'pull_request' || matrix.run_on_pr) && matrix.type != 'spice' && matrix.type != 'macos'
+        if: (github.event_name != 'pull_request' || matrix.run_on_pr) && matrix.type != 'spice' && matrix.id != 'macos'
         run: |
           mkdir -p coverage/profraw/{unit,binaries}
           just codecov-ci "nextest-slow ${{ matrix.type }}"
@@ -75,19 +75,19 @@ jobs:
           just codecov-ci "nextest-spice"
 
       # Upload the coverage files
-      - if: github.event_name != 'pull_request' || matrix.run_on_pr
+      - if: (github.event_name != 'pull_request' || matrix.run_on_pr) && matrix.id != 'macos'
         run: |
           mv coverage/codecov/{new,unit-${{matrix.id}}}.json
           mv coverage/profraw/{new,unit/${{matrix.id}}}.tar.zst
           just tar-bins-for-coverage-ci
           mv coverage/profraw/binaries/{new,${{matrix.id}}}.tar.zst
-      - if: matrix.upload_profraws && (github.event_name != 'pull_request' || matrix.run_on_pr)
+      - if: matrix.upload_profraws && (github.event_name != 'pull_request' || matrix.run_on_pr) && matrix.id != 'macos'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-profraw-${{ github.sha }}-${{ matrix.name }}
           path: coverage/profraw
           retention-days: 2
-      - if: github.event_name != 'pull_request' || matrix.run_on_pr
+      - if: (github.event_name != 'pull_request' || matrix.run_on_pr) && matrix.id != 'macos'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-codecov-${{ github.sha }}-cargo_nextest-${{ matrix.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
             os: warp-macos-latest-arm64-6x
             type: stable
             upload_profraws: false
-            run_on_pr: false
+            run_on_pr: true
     timeout-minutes: 90
     steps:
       - if: github.event_name != 'pull_request' || matrix.run_on_pr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
             os: warp-macos-latest-arm64-6x
             type: stable
             upload_profraws: false
-            run_on_pr: true
+            run_on_pr: false
     timeout-minutes: 90
     steps:
       - if: github.event_name != 'pull_request' || matrix.run_on_pr


### PR DESCRIPTION
## Summary
- Fix macOS test exclusion condition from `matrix.type != 'macos'` to `matrix.id != 'macos'`
- Add macOS exclusions to all CI steps (install tools, upload coverage, upload artifacts)

## Background
Follow-up to #14197 which disabled macOS tests during actix migration. The previous condition was incorrect since macOS matrix has `type: stable`, not `type: 'macos'`.

## Changes
- Fixed test exclusion condition to use `matrix.id != 'macos'` 
- Added macOS exclusions to tool installation, coverage upload, and artifact upload steps
- Keeps macOS job as required check while properly skipping all test execution

🤖 Generated with [Claude Code](https://claude.ai/code)