### PR TITLE
[sync] rework external_backoff

### DIFF
--- a/chain/client/src/sync/state/external.rs
+++ b/chain/client/src/sync/state/external.rs
@@ -25,14 +25,12 @@ pub(super) struct StateSyncDownloadSourceExternal {
     pub chain_id: String,
     pub conn: ExternalConnection,
     pub timeout: Duration,
-    pub backoff: Duration,
 }
 
 impl StateSyncDownloadSourceExternal {
     async fn get_file_with_timeout(
         clock: Clock,
         timeout: Duration,
-        backoff: Duration,
         cancellation: CancellationToken,
         conn: ExternalConnection,
         shard_id: ShardId,
@@ -59,14 +57,6 @@ impl StateSyncDownloadSourceExternal {
             result = fut => {
                 match result {
                     Err(err) => {
-                        // A download error typically indicates that the file is not available yet. At the
-                        // start of the epoch it takes a while for dumpers to populate the external storage
-                        // with state files. This backoff period prevents spamming requests during that time.
-                        let deadline = clock.now() + backoff;
-                        tokio::select! {
-                            _ = clock.sleep_until(deadline) => {}
-                            _ = cancellation.cancelled() => {}
-                        }
                         increment_download_count(shard_id, typ, "external", "download_error");
                         tracing::debug!(target: "sync", ?shard_id, ?file_type, ?location, %err, "external download error");
                         Err(near_chain::Error::Other(format!("Failed to download: {}", err)))
@@ -88,7 +78,6 @@ impl StateSyncDownloadSource for StateSyncDownloadSourceExternal {
     ) -> BoxFuture<Result<ShardStateSyncResponseHeader, near_chain::Error>> {
         let clock = self.clock.clone();
         let timeout = self.timeout;
-        let backoff = self.backoff;
         let chain_id = self.chain_id.clone();
         let conn = self.conn.clone();
         let store = self.store.clone();
@@ -106,7 +95,6 @@ impl StateSyncDownloadSource for StateSyncDownloadSourceExternal {
             let data = Self::get_file_with_timeout(
                 clock,
                 timeout,
-                backoff,
                 cancel,
                 conn,
                 shard_id,
@@ -136,7 +124,6 @@ impl StateSyncDownloadSource for StateSyncDownloadSourceExternal {
     ) -> BoxFuture<Result<StatePart, near_chain::Error>> {
         let clock = self.clock.clone();
         let timeout = self.timeout;
-        let backoff = self.backoff;
         let chain_id = self.chain_id.clone();
         let conn = self.conn.clone();
         let store = self.store.clone();
@@ -159,7 +146,6 @@ impl StateSyncDownloadSource for StateSyncDownloadSourceExternal {
             let data = Self::get_file_with_timeout(
                 clock,
                 timeout,
-                backoff,
                 cancel,
                 conn,
                 shard_id,

--- a/chain/client/src/sync/state/mod.rs
+++ b/chain/client/src/sync/state/mod.rs
@@ -70,6 +70,13 @@ pub struct StateSync {
 
     /// Concurrency limits.
     concurrency_config: SyncConcurrency,
+
+    /// A minimum delay between attempts for the same state header/part.
+    /// Specifically important in the scenario that a node is configured
+    /// to sync only from external storage (no p2p requests). Usually a
+    /// failure there indicates the file is yet to be uploaded, in which
+    /// case we want to avoid spamming requests aggresively.
+    min_delay_before_reattempt: Duration,
 }
 
 impl StateSync {
@@ -148,7 +155,6 @@ impl StateSync {
                     chain_id: chain_id.to_string(),
                     conn: external,
                     timeout: external_timeout,
-                    backoff: external_backoff,
                 }) as Arc<dyn StateSyncDownloadSource>;
                 (
                     Some(fallback_source),
@@ -179,6 +185,14 @@ impl StateSync {
         };
         let computation_task_tracker = TaskTracker::new(usize::from(num_concurrent_computations));
 
+        let min_delay_before_reattempt = if num_attempts_before_fallback > 0 {
+            // No need to wait if p2p attempts are enabled
+            Duration::ZERO
+        } else {
+            // Avoid aggressively checking the external storage for requests which just failed
+            external_backoff
+        };
+
         Self {
             store,
             peer_source_state,
@@ -191,6 +205,7 @@ impl StateSync {
             chain_requests_sender,
             shard_syncs: HashMap::new(),
             concurrency_config: sync_config.concurrency,
+            min_delay_before_reattempt,
         }
     }
 
@@ -260,6 +275,7 @@ impl StateSync {
                         cancel.clone(),
                         self.future_spawner.clone(),
                         self.concurrency_config.per_shard,
+                        self.min_delay_before_reattempt,
                     );
                     let (sender, receiver) = oneshot::channel();
 

--- a/chain/client/src/sync/state/shard.rs
+++ b/chain/client/src/sync/state/shard.rs
@@ -5,6 +5,7 @@ use crate::sync::state::chain_requests::ChainFinalizationRequest;
 use futures::{StreamExt, TryStreamExt};
 use near_async::futures::{FutureSpawner, respawn_for_parallelism};
 use near_async::messaging::AsyncSender;
+use near_async::time::Duration;
 use near_chain::BlockHeader;
 use near_chain::types::RuntimeAdapter;
 use near_client_primitives::types::ShardSyncStatus;
@@ -69,6 +70,7 @@ pub(super) async fn run_state_sync_for_shard(
     cancel: CancellationToken,
     future_spawner: Arc<dyn FutureSpawner>,
     concurrency_limit: u8,
+    min_delay_before_reattempt: Duration,
 ) -> Result<(), near_chain::Error> {
     tracing::info!("Running state sync for shard {}", shard_id);
     *status.lock() = ShardSyncStatus::StateDownloadHeader;
@@ -128,6 +130,12 @@ pub(super) async fn run_state_sync_for_shard(
                 res.as_ref().err().map(|_| parts_to_download[task_index])
             })
             .collect();
+        // Wait before retrying the failed parts
+        let deadline = downloader.clock.now() + min_delay_before_reattempt;
+        tokio::select! {
+            _ = downloader.clock.sleep_until(deadline) => {}
+            _ = cancel.cancelled() => {}
+        }
     }
 
     return_if_cancelled!(cancel);


### PR DESCRIPTION
The intention of this timer was to prevent rapidly spamming failed requests to the external storage before a file is present there. However, the way it was implemented was by blocking one of the (strictly limited) state sync threads.

It does not make sense to block progress on other attempts (whether they may be for other parts, or from peers).