### PR TITLE
config: expose option to override rocksdb configuration

### DIFF
--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -562,7 +562,7 @@ macro_rules! define_cf_config_fields {
 
 // This macro invocation will generate the struct `RocksDbCfConfig`.
 define_cf_config_fields!(
-    (optimize_level_style_compaction, bytesize::ByteSize),
+    (memtable_memory_budget, bytesize::ByteSize),
     (level_zero_file_num_compaction_trigger, i32),
     (level_zero_slowdown_writes_trigger, i32),
     (level_zero_stop_writes_trigger, i32),
@@ -592,7 +592,7 @@ impl RocksDbCfConfig {
 
     pub fn high_load_defaults() -> Self {
         Self {
-            optimize_level_style_compaction: Some(bytesize::ByteSize::mib(1024)),
+            memtable_memory_budget: Some(bytesize::ByteSize::mib(1024)),
             level_zero_file_num_compaction_trigger: Some(8),
             level_zero_slowdown_writes_trigger: Some(32),
             level_zero_stop_writes_trigger: Some(64),
@@ -605,7 +605,7 @@ impl RocksDbCfConfig {
 
     pub fn medium_load_defaults() -> Self {
         Self {
-            optimize_level_style_compaction: Some(bytesize::ByteSize::mib(512)),
+            memtable_memory_budget: Some(bytesize::ByteSize::mib(512)),
             level_zero_file_num_compaction_trigger: Some(8),
             level_zero_slowdown_writes_trigger: Some(32),
             level_zero_stop_writes_trigger: Some(64),
@@ -618,7 +618,7 @@ impl RocksDbCfConfig {
 
     pub fn low_load_defaults() -> Self {
         Self {
-            optimize_level_style_compaction: Some(bytesize::ByteSize::mib(256)),
+            memtable_memory_budget: Some(bytesize::ByteSize::mib(256)),
             level_zero_file_num_compaction_trigger: Some(8),
             level_zero_slowdown_writes_trigger: Some(32),
             level_zero_stop_writes_trigger: Some(64),

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -659,7 +659,7 @@ fn rocksdb_column_options(col: DBCol, store_config: &StoreConfig, temp: Temperat
 
     // Column specific settings
     let RocksDbCfConfig {
-        optimize_level_style_compaction,
+        memtable_memory_budget,
         level_zero_file_num_compaction_trigger,
         level_zero_slowdown_writes_trigger,
         level_zero_stop_writes_trigger,
@@ -669,7 +669,7 @@ fn rocksdb_column_options(col: DBCol, store_config: &StoreConfig, temp: Temperat
         compaction_readahead_size,
     } = RocksDbCfConfig::resolve_for_column(col, &store_config.rocksdb);
 
-    if let Some(v) = optimize_level_style_compaction {
+    if let Some(v) = memtable_memory_budget {
         opts.optimize_level_style_compaction(v.as_u64() as usize);
     }
     if let Some(v) = level_zero_file_num_compaction_trigger {

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -646,27 +646,7 @@ fn rocksdb_column_options(col: DBCol, store_config: &StoreConfig, temp: Temperat
     }
 
     // Column specific settings
-    use crate::DBCol::*;
-    let group_cfg = match col {
-        PartialChunks | State | TrieChanges => store_config
-            .rocksdb
-            .cf_high_load
-            .clone()
-            .unwrap_or_default()
-            .apply_over(RocksDbCfConfig::high_load_defaults()),
-        FlatState | Chunks | StateChanges | Transactions => store_config
-            .rocksdb
-            .cf_medium_load
-            .clone()
-            .unwrap_or_default()
-            .apply_over(RocksDbCfConfig::medium_load_defaults()),
-        _ => store_config
-            .rocksdb
-            .cf_low_load
-            .clone()
-            .unwrap_or_default()
-            .apply_over(RocksDbCfConfig::low_load_defaults()),
-    };
+    let group_cfg = RocksDbCfConfig::resolve_for_column(col, &store_config.rocksdb);
 
     // Apply group defaults derived from group_cfg
     if let Some(v) = group_cfg.optimize_level_style_compaction {

--- a/core/store/src/db/rocksdb.rs
+++ b/core/store/src/db/rocksdb.rs
@@ -644,42 +644,26 @@ fn rocksdb_column_options(col: DBCol, store_config: &StoreConfig, temp: Temperat
         compaction_readahead_size,
     } = RocksDbCfConfig::resolve_for_column(col, &store_config.rocksdb);
 
-    if let Some(v) = memtable_memory_budget {
-        // Note that this function changes a lot of RocksDB parameters including:
-        //      write_buffer_size = memtable_memory_budget / 4
-        //      min_write_buffer_number_to_merge = 2
-        //      max_write_buffer_number = 6
-        //      level0_file_num_compaction_trigger = 2
-        //      target_file_size_base = memtable_memory_budget / 8
-        //      max_bytes_for_level_base = memtable_memory_budget
-        //      compaction_style = kCompactionStyleLevel
-        // Also it sets compression_per_level in a way that the first 2 levels have no compression and
-        // the rest use LZ4 compression.
-        // See the implementation here:
-        //      https://github.com/facebook/rocksdb/blob/c18c4a081c74251798ad2a1abf83bad417518481/options/options.cc#L588.
-        opts.optimize_level_style_compaction(v.as_u64() as usize);
-    }
-    if let Some(v) = level_zero_file_num_compaction_trigger {
-        opts.set_level_zero_file_num_compaction_trigger(v);
-    }
-    if let Some(v) = level_zero_slowdown_writes_trigger {
-        opts.set_level_zero_slowdown_writes_trigger(v);
-    }
-    if let Some(v) = level_zero_stop_writes_trigger {
-        opts.set_level_zero_stop_writes_trigger(v);
-    }
-    if let Some(v) = max_subcompactions {
-        opts.set_max_subcompactions(v as u32);
-    }
-    if let Some(v) = target_file_size_base {
-        opts.set_target_file_size_base(v.as_u64());
-    }
-    if let Some(v) = max_write_buffer_number {
-        opts.set_max_write_buffer_number(v);
-    }
-    if let Some(v) = compaction_readahead_size {
-        opts.set_compaction_readahead_size(v.as_u64() as usize);
-    }
+    // Note that this function changes a lot of RocksDB parameters including:
+    //      write_buffer_size = memtable_memory_budget / 4
+    //      min_write_buffer_number_to_merge = 2
+    //      max_write_buffer_number = 6
+    //      level0_file_num_compaction_trigger = 2
+    //      target_file_size_base = memtable_memory_budget / 8
+    //      max_bytes_for_level_base = memtable_memory_budget
+    //      compaction_style = kCompactionStyleLevel
+    // Also it sets compression_per_level in a way that the first 2 levels have no compression and
+    // the rest use LZ4 compression.
+    // See the implementation here:
+    //      https://github.com/facebook/rocksdb/blob/c18c4a081c74251798ad2a1abf83bad417518481/options/options.cc#L588.
+    opts.optimize_level_style_compaction(memtable_memory_budget.as_u64() as usize);
+    opts.set_level_zero_file_num_compaction_trigger(level_zero_file_num_compaction_trigger);
+    opts.set_level_zero_slowdown_writes_trigger(level_zero_slowdown_writes_trigger);
+    opts.set_level_zero_stop_writes_trigger(level_zero_stop_writes_trigger);
+    opts.set_max_subcompactions(max_subcompactions);
+    opts.set_target_file_size_base(target_file_size_base.as_u64());
+    opts.set_max_write_buffer_number(max_write_buffer_number);
+    opts.set_compaction_readahead_size(compaction_readahead_size.as_u64() as usize);
 
     opts
 }


### PR DESCRIPTION
This PR add the possibility to override RocksDB settings.

There are a few key requirements I wanted to enforce:
- the config is totally optional
- operators can override a single parameter (like `{ "cf_medium_load_overrides": { "max_write_buffer_number": 12 } }`
- the default config is the same as what we use in master
- columns config can be customized per category (all columns are split into high, medium, low "heaviness")
- adding a new config option in the code and forgetting to use it must trigger a compiler warning


Common RocksDB settings are defined through constants, while column presets (and overrides) are defined with a macro.