### PR TITLE
chore: smaller buckets for chunk reconstructibility

### DIFF
--- a/chain/chunks/src/chunk_cache.rs
+++ b/chain/chunks/src/chunk_cache.rs
@@ -153,7 +153,7 @@ impl EncodedChunksCache {
             return;
         }
         let time_to_last_receipt = Instant::now().signed_duration_since(entry.created_at);
-        metrics::PARTIAL_CHUNK_TIME_TO_LAST_RECEIPT_PART
+        metrics::PARTIAL_CHUNK_TIME_TO_LAST_RECEIPT_PART_SECONDS
             .with_label_values(&[entry.header.shard_id().to_string().as_str()])
             .observe(time_to_last_receipt.as_seconds_f64());
         entry.received_all_receipts = true;
@@ -167,7 +167,7 @@ impl EncodedChunksCache {
             return;
         }
         let time_to_last_part = Instant::now().signed_duration_since(entry.created_at);
-        metrics::PARTIAL_CHUNK_TIME_TO_LAST_CHUNK_PART
+        metrics::PARTIAL_CHUNK_TIME_TO_LAST_CHUNK_PART_SECONDS
             .with_label_values(&[entry.header.shard_id().to_string().as_str()])
             .observe(time_to_last_part.as_seconds_f64());
         entry.received_all_parts = true;
@@ -181,7 +181,7 @@ impl EncodedChunksCache {
             return;
         }
         let time_to_reconstruct = Instant::now().signed_duration_since(entry.created_at);
-        metrics::PARTIAL_CHUNK_TIME_TO_RECONSTRUCT
+        metrics::PARTIAL_CHUNK_TIME_TO_RECONSTRUCT_SECONDS
             .with_label_values(&[entry.header.shard_id().to_string().as_str()])
             .observe(time_to_reconstruct.as_seconds_f64());
         entry.could_reconstruct = true;

--- a/chain/chunks/src/metrics.rs
+++ b/chain/chunks/src/metrics.rs
@@ -1,6 +1,5 @@
 use near_o11y::metrics::{
-    Counter, Histogram, exponential_buckets, fine_grained_time_buckets, try_create_histogram,
-    try_create_histogram_vec,
+    Counter, Histogram, exponential_buckets, try_create_histogram, try_create_histogram_vec,
 };
 use std::sync::LazyLock;
 

--- a/chain/chunks/src/metrics.rs
+++ b/chain/chunks/src/metrics.rs
@@ -52,7 +52,8 @@ pub static PARTIAL_CHUNK_TIME_TO_LAST_CHUNK_PART: LazyLock<near_o11y::metrics::H
             "near_partial_chunk_time_to_last_part",
             "Time taken from receiving the chunk header to receiving the last owned chunk part for completing the chunk",
             &["shard_id"],
-            Some(fine_grained_time_buckets()),
+            Some(exponential_buckets(0.001, 2.0, 9)
+            .unwrap()),
         )
         .unwrap()
     });
@@ -63,7 +64,8 @@ pub static PARTIAL_CHUNK_TIME_TO_LAST_RECEIPT_PART: LazyLock<near_o11y::metrics:
             "near_partial_chunk_time_to_last_receipt_part",
             "Time taken from receiving the chunk header to receiving the last needed receipt for completing the chunk",
             &["shard_id"],
-            Some(fine_grained_time_buckets()),
+            Some(exponential_buckets(0.001, 2.0, 9)
+            .unwrap()),
         )
         .unwrap()
     });
@@ -74,7 +76,8 @@ pub static PARTIAL_CHUNK_TIME_TO_RECONSTRUCT: LazyLock<near_o11y::metrics::Histo
         "near_partial_chunk_time_to_reconstruct",
         "Time taken from receiving the chunk header to having enough parts to reconstruct the chunk",
         &["shard_id"],
-        Some(fine_grained_time_buckets()),
+        Some(exponential_buckets(0.001, 2.0, 9)
+        .unwrap()),
     )
     .unwrap()
     });

--- a/chain/chunks/src/metrics.rs
+++ b/chain/chunks/src/metrics.rs
@@ -45,34 +45,36 @@ pub(crate) static PARTIAL_ENCODED_CHUNK_RESPONSE_DELAY: LazyLock<Histogram> = La
         .unwrap()
 });
 
-pub static PARTIAL_CHUNK_TIME_TO_LAST_CHUNK_PART: LazyLock<near_o11y::metrics::HistogramVec> =
-    LazyLock::new(|| {
-        try_create_histogram_vec(
-            "near_partial_chunk_time_to_last_part",
+pub static PARTIAL_CHUNK_TIME_TO_LAST_CHUNK_PART_SECONDS: LazyLock<
+    near_o11y::metrics::HistogramVec,
+> = LazyLock::new(|| {
+    try_create_histogram_vec(
+            "near_partial_chunk_time_to_last_part_seconds",
             "Time taken from receiving the chunk header to receiving the last owned chunk part for completing the chunk",
             &["shard_id"],
             Some(exponential_buckets(0.001, 2.0, 9)
             .unwrap()),
         )
         .unwrap()
-    });
+});
 
-pub static PARTIAL_CHUNK_TIME_TO_LAST_RECEIPT_PART: LazyLock<near_o11y::metrics::HistogramVec> =
-    LazyLock::new(|| {
-        try_create_histogram_vec(
-            "near_partial_chunk_time_to_last_receipt_part",
+pub static PARTIAL_CHUNK_TIME_TO_LAST_RECEIPT_PART_SECONDS: LazyLock<
+    near_o11y::metrics::HistogramVec,
+> = LazyLock::new(|| {
+    try_create_histogram_vec(
+            "near_partial_chunk_time_to_last_receipt_part_seconds",
             "Time taken from receiving the chunk header to receiving the last needed receipt for completing the chunk",
             &["shard_id"],
             Some(exponential_buckets(0.001, 2.0, 9)
             .unwrap()),
         )
         .unwrap()
-    });
+});
 
-pub static PARTIAL_CHUNK_TIME_TO_RECONSTRUCT: LazyLock<near_o11y::metrics::HistogramVec> =
+pub static PARTIAL_CHUNK_TIME_TO_RECONSTRUCT_SECONDS: LazyLock<near_o11y::metrics::HistogramVec> =
     LazyLock::new(|| {
         try_create_histogram_vec(
-        "near_partial_chunk_time_to_reconstruct",
+        "near_partial_chunk_time_to_reconstruct_seconds",
         "Time taken from receiving the chunk header to having enough parts to reconstruct the chunk",
         &["shard_id"],
         Some(exponential_buckets(0.001, 2.0, 9)


### PR DESCRIPTION
previous buckets were too large for small average values of close to 1ms