### PR TITLE
feat(tracing): more spans

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -595,7 +595,7 @@ impl RuntimeAdapter for NightshadeRuntime {
     #[instrument(
         target = "runtime",
         level = "debug",
-        "prepare_transactions",
+        "runtime_prepare_transactions",
         skip_all,
         fields(
             height = prev_block.height + 1,

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -592,6 +592,17 @@ impl RuntimeAdapter for NightshadeRuntime {
         .map(|_vr| ())
     }
 
+    #[instrument(
+        target = "runtime",
+        level = "debug",
+        "prepare_transactions",
+        skip_all,
+        fields(
+            height = prev_block.height + 1,
+            shard_id = %shard_id,
+            tag_block_production = true
+        )
+    )]
     fn prepare_transactions(
         &self,
         storage_config: RuntimeStorageConfig,

--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -382,7 +382,7 @@ impl ChunkProducer {
     #[instrument(
         target = "client",
         level = "debug",
-        "prepare_transactions",
+        "producer_prepare_transactions",
         skip_all,
         fields(
             height = prev_block.header().height() + 1,

--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -379,6 +379,17 @@ impl ChunkProducer {
     }
 
     /// Prepares an ordered list of valid transactions from the pool up the limits.
+    #[instrument(
+        target = "client",
+        level = "debug",
+        "prepare_transactions",
+        skip_all,
+        fields(
+            height = prev_block.header().height() + 1,
+            shard_id = %shard_uid.shard_id(),
+            tag_block_production = true
+        )
+    )]
     fn prepare_transactions(
         &self,
         shard_uid: ShardUId,

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -25,6 +25,7 @@ use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
+use tracing::instrument;
 
 struct ShardTriesInner {
     store: TrieStoreAdapter,
@@ -388,6 +389,17 @@ impl ShardTries {
         self.apply_all_inner(trie_changes, shard_uid, true, store_update)
     }
 
+    #[instrument(
+        target = "memtrie",
+        level = "debug",
+        "prepare_transactions",
+        skip_all,
+        fields(
+            height = block_height,
+            shard_id = %shard_uid.shard_id(),
+            tag_block_production = true
+        )
+    )]
     pub fn apply_memtrie_changes(
         &self,
         trie_changes: &TrieChanges,

--- a/core/store/src/trie/shard_tries.rs
+++ b/core/store/src/trie/shard_tries.rs
@@ -392,7 +392,7 @@ impl ShardTries {
     #[instrument(
         target = "memtrie",
         level = "debug",
-        "prepare_transactions",
+        "apply_memtrie_changes",
         skip_all,
         fields(
             height = block_height,

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -219,7 +219,7 @@ impl TrieUpdate {
         target = "store::trie",
         "TrieUpdate::finalize",
         skip_all,
-        fields(committed.len = self.committed.len())
+        fields(committed.len = self.committed.len(), tag_block_production = true)
     )]
     pub fn finalize(self) -> Result<TrieUpdateResult, StorageError> {
         assert!(self.prospective.is_empty(), "Finalize cannot be called with uncommitted changes.");

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1361,6 +1361,7 @@ impl Runtime {
         num_transactions = signed_txs.len(),
         gas_burnt = tracing::field::Empty,
         compute_usage = tracing::field::Empty,
+        tag_block_production = true
     ))]
     pub fn apply(
         &self,
@@ -1506,6 +1507,13 @@ impl Runtime {
     ///
     /// Any transactions that fail to validate (e.g. invalid nonces, unknown signing keys,
     /// insufficient NEAR balance, etc.) will be skipped, producing no receipts.
+    #[instrument(
+        target = "runtime",
+        level = "debug",
+        "process_transactions",
+        skip_all,
+        fields(tag_block_production = true)
+    )]
     fn process_transactions(
         &self,
         processing_state: &mut ApplyProcessingReceiptState,
@@ -2068,6 +2076,13 @@ impl Runtime {
 
     /// Processes all receipts (local, delayed and incoming).
     /// Returns a structure containing the result of the processing.
+    #[instrument(
+        target = "runtime",
+        level = "debug",
+        "process_receipts",
+        skip_all,
+        fields(tag_block_production = true)
+    )]
     fn process_receipts(
         &self,
         processing_state: &mut ApplyProcessingReceiptState,
@@ -2130,6 +2145,13 @@ impl Runtime {
         })
     }
 
+    #[instrument(
+        target = "runtime",
+        level = "debug",
+        "validate_apply_state_update",
+        skip_all,
+        fields(tag_block_production = true)
+    )]
     fn validate_apply_state_update(
         &self,
         processing_state: ApplyProcessingReceiptState,
@@ -2137,7 +2159,6 @@ impl Runtime {
         receipt_sink: ReceiptSink,
         state_patch: SandboxStatePatch,
     ) -> Result<ApplyResult, RuntimeError> {
-        let _span = tracing::debug_span!(target: "runtime", "apply_commit").entered();
         let apply_state = processing_state.apply_state;
         let epoch_info_provider = processing_state.epoch_info_provider;
         let mut stats = processing_state.stats;


### PR DESCRIPTION
More spans for viewing things in traviz.

Tx preparation:
* `prepare_transactions`

Chunk application stages:
* apply
* `TrieUpdate::finalize`
* process_transactions
* validate_apply_state_update

Also `apply_memtrie_changes`

I might be abusing the `block_production` tag a bit. I'm using it as a marker for "I want this to be collected in benchmark spans". Maybe we could consider `tag_traviz` for spans that should be exported for traviz analysis?