### PR TITLE
chore: cleanup opentelemetry filter in benches

### DIFF
--- a/benchmarks/sharded-bm/cases/log_patch.json
+++ b/benchmarks/sharded-bm/cases/log_patch.json
@@ -1,5 +1,5 @@
 {
     "rust_log": "transaction-generator=info,tokio_reactor=info,config=info,near=info,stats=info,telemetry=info,db=info,delay_detector=info,near-performance-metrics=info,state_viewer=info,warn",
     "verbose_module": null,
-    "opentelemetry": "client=debug,chain=debug,stateless_validation=debug,[{tag_block_production=\"true\"}]=debug,[{tag_witness_distribution=\"true\"}]=debug,[{tag_optimistic=\"true\"}]=debug,[{tag_chunk_distribution=\"true\"}]=debug,info"
+    "opentelemetry": "client=debug,chain=debug,[{tag_block_production=\"true\"}]=debug,[{tag_witness_distribution=\"true\"}]=debug,[{tag_optimistic=\"true\"}]=debug,[{tag_chunk_distribution=\"true\"}]=debug,info"
 }


### PR DESCRIPTION
Removing `stateless_validation` because it's included in other traviz specific tags. 