### PR TITLE
fix: Get rid of `NETWORK_LEGACY_TELEMETRY_URL`

### DIFF
--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -117,7 +117,6 @@ pub const CONFIG_FILENAME: &str = "config.json";
 pub const NODE_KEY_FILE: &str = "node_key.json";
 pub const VALIDATOR_KEY_FILE: &str = "validator_key.json";
 
-pub const NETWORK_LEGACY_TELEMETRY_URL: &str = "https://explorer.{}.near.org/api/nodes";
 pub const NETWORK_TELEMETRY_URL: &str = "https://telemetry.nearone.org/nodes";
 
 fn default_doomslug_step_period() -> Duration {
@@ -993,7 +992,6 @@ pub fn init_configs(
             if test_seed.is_some() {
                 bail!("Test seed is not supported for {chain_id}");
             }
-            config.telemetry.endpoints.push(NETWORK_LEGACY_TELEMETRY_URL.replace("{}", &chain_id));
             config.telemetry.endpoints.push(NETWORK_TELEMETRY_URL.to_string());
             config.state_sync = Some(StateSyncConfig::gcs_default());
         }


### PR DESCRIPTION
Closes #14219
