### PR TITLE
[actix migration] Move some tests off of run_actix.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3451,6 +3451,7 @@ dependencies = [
  "thiserror 2.0.16",
  "time",
  "tokio",
+ "tokio-util",
  "tracing",
  "wat",
 ]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -32,6 +32,7 @@ tempfile.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 tracing.workspace = true
 wat.workspace = true
 

--- a/integration-tests/src/env/setup.rs
+++ b/integration-tests/src/env/setup.rs
@@ -3,11 +3,7 @@
 #![allow(clippy::arc_with_non_send_sync)]
 
 use crate::utils::peer_manager_mock::PeerManagerMock;
-use actix::{Actor, Context};
-use near_async::actix::futures::ActixFutureSpawner;
-use near_async::messaging::{
-    IntoMultiSender, IntoSender, LateBoundSender, SendAsync, Sender, noop,
-};
+use near_async::messaging::{CanSend, IntoMultiSender, IntoSender, LateBoundSender, Sender, noop};
 use near_async::time::{Clock, Duration, Utc};
 use near_chain::rayon_spawner::RayonAsyncComputationSpawner;
 use near_chain::resharding::resharding_actor::ReshardingActor;
@@ -71,6 +67,7 @@ pub const MAX_BLOCK_PROD_TIME: Duration = Duration::milliseconds(200);
 /// Sets up ClientActor and ViewClientActor viewing the same store/runtime.
 fn setup(
     clock: Clock,
+    actor_system: ActorSystem,
     validators: Vec<AccountId>,
     epoch_length: BlockHeightDelta,
     account_id: AccountId,
@@ -143,7 +140,6 @@ fn setup(
     let shard_tracker =
         ShardTracker::new(TrackedShardsConfig::AllShards, epoch_manager.clone(), signer.clone());
 
-    let actor_system = ActorSystem::new();
     let telemetry =
         TelemetryActor::spawn_tokio_actor(actor_system.clone(), TelemetryConfig::default());
     let config = {
@@ -215,7 +211,7 @@ fn setup(
         shard_tracker.clone(),
         runtime.clone(),
         PeerId::new(PublicKey::empty(KeyType::ED25519)),
-        Arc::new(ActixFutureSpawner),
+        actor_system.new_future_spawner().into(),
         network_adapter.clone(),
         shards_manager_adapter_for_client.as_sender(),
         signer.clone(),
@@ -280,21 +276,23 @@ fn setup(
 /// Sets up ClientActor and ViewClientActor with mock PeerManager.
 pub fn setup_mock(
     clock: Clock,
+    actor_system: ActorSystem,
     validators: Vec<AccountId>,
     account_id: AccountId,
     skip_sync_wait: bool,
     enable_doomslug: bool,
     peer_manager_mock: Box<
         dyn FnMut(
-            &PeerManagerMessageRequest,
-            &mut Context<PeerManagerMock>,
-            TokioRuntimeHandle<ClientActorInner>,
-            MultithreadRuntimeHandle<RpcHandler>,
-        ) -> PeerManagerMessageResponse,
+                &PeerManagerMessageRequest,
+                TokioRuntimeHandle<ClientActorInner>,
+                MultithreadRuntimeHandle<RpcHandler>,
+            ) -> PeerManagerMessageResponse
+            + Send,
     >,
 ) -> ActorHandlesForTesting {
     setup_mock_with_validity_period(
         clock,
+        actor_system,
         validators,
         account_id,
         skip_sync_wait,
@@ -306,17 +304,18 @@ pub fn setup_mock(
 
 pub fn setup_mock_with_validity_period(
     clock: Clock,
+    actor_system: ActorSystem,
     validators: Vec<AccountId>,
     account_id: AccountId,
     skip_sync_wait: bool,
     enable_doomslug: bool,
     mut peermanager_mock: Box<
         dyn FnMut(
-            &PeerManagerMessageRequest,
-            &mut Context<PeerManagerMock>,
-            TokioRuntimeHandle<ClientActorInner>,
-            MultithreadRuntimeHandle<RpcHandler>,
-        ) -> PeerManagerMessageResponse,
+                &PeerManagerMessageRequest,
+                TokioRuntimeHandle<ClientActorInner>,
+                MultithreadRuntimeHandle<RpcHandler>,
+            ) -> PeerManagerMessageResponse
+            + Send,
     >,
     transaction_validity_period: NumBlocks,
 ) -> ActorHandlesForTesting {
@@ -330,6 +329,7 @@ pub fn setup_mock_with_validity_period(
         runtime_tempdir,
     ) = setup(
         clock.clone(),
+        actor_system.clone(),
         validators,
         10,
         account_id,
@@ -347,10 +347,9 @@ pub fn setup_mock_with_validity_period(
     let client_addr1 = client_addr.clone();
     let rpc_handler_addr1 = rpc_handler_addr.clone();
 
-    let network_actor = PeerManagerMock::new(move |msg, ctx| {
-        peermanager_mock(&msg, ctx, client_addr1.clone(), rpc_handler_addr1.clone())
-    })
-    .start();
+    let network_actor = actor_system.spawn_tokio_actor(PeerManagerMock::new(move |msg| {
+        peermanager_mock(&msg, client_addr1.clone(), rpc_handler_addr1.clone())
+    }));
 
     network_adapter.bind(network_actor);
 
@@ -380,6 +379,7 @@ pub struct ActorHandlesForTesting {
 /// Sets up ClientActor and ViewClientActor without network.
 pub fn setup_no_network(
     clock: Clock,
+    actor_system: ActorSystem,
     validators: Vec<AccountId>,
     account_id: AccountId,
     skip_sync_wait: bool,
@@ -387,6 +387,7 @@ pub fn setup_no_network(
 ) -> ActorHandlesForTesting {
     setup_no_network_with_validity_period(
         clock,
+        actor_system,
         validators,
         account_id,
         skip_sync_wait,
@@ -397,6 +398,7 @@ pub fn setup_no_network(
 
 pub fn setup_no_network_with_validity_period(
     clock: Clock,
+    actor_system: ActorSystem,
     validators: Vec<AccountId>,
     account_id: AccountId,
     skip_sync_wait: bool,
@@ -406,11 +408,12 @@ pub fn setup_no_network_with_validity_period(
     let my_account_id = account_id.clone();
     setup_mock_with_validity_period(
         clock,
+        actor_system,
         validators,
         account_id,
         skip_sync_wait,
         enable_doomslug,
-        Box::new(move |request, _, _client, rpc_handler| {
+        Box::new(move |request, _client, rpc_handler| {
             // Handle network layer sending messages to self
             match request {
                 PeerManagerMessageRequest::NetworkRequests(NetworkRequests::ChunkEndorsement(
@@ -418,10 +421,7 @@ pub fn setup_no_network_with_validity_period(
                     endorsement,
                 )) => {
                     if account_id == &my_account_id {
-                        let future =
-                            rpc_handler.send_async(ChunkEndorsementMessage(endorsement.clone()));
-                        // Don't ignore the future or else the message may not actually be handled.
-                        actix::spawn(future);
+                        rpc_handler.send(ChunkEndorsementMessage(endorsement.clone()));
                     }
                 }
                 _ => {}
@@ -434,6 +434,7 @@ pub fn setup_no_network_with_validity_period(
 
 pub fn setup_client_with_runtime(
     clock: Clock,
+    actor_system: ActorSystem,
     num_validator_seats: NumSeats,
     enable_doomslug: bool,
     network_adapter: PeerManagerAdapter,
@@ -487,7 +488,7 @@ pub fn setup_client_with_runtime(
         multi_spawner,
         partial_witness_adapter,
         resharding_sender,
-        Arc::new(ActixFutureSpawner),
+        actor_system.new_future_spawner().into(),
         noop().into_multi_sender(), // state sync ignored for these tests
         noop().into_multi_sender(), // apply chunks ping not necessary for these tests
         chunk_validation_sender,

--- a/integration-tests/src/env/test_env.rs
+++ b/integration-tests/src/env/test_env.rs
@@ -52,6 +52,7 @@ use near_client::ChunkValidationActorInner;
 
 use super::setup::{TEST_SEED, setup_client_with_runtime};
 use super::test_env_builder::TestEnvBuilder;
+use near_async::ActorSystem;
 
 /// Timeout used in tests that wait for a specific chunk endorsement to appear
 const CHUNK_ENDORSEMENTS_TIMEOUT: Duration = Duration::seconds(10);
@@ -60,6 +61,7 @@ const CHUNK_ENDORSEMENTS_TIMEOUT: Duration = Duration::seconds(10);
 /// This environment can simulate near nodes without network and it can be configured to use different runtimes.
 pub struct TestEnv {
     pub clock: Clock,
+    pub actor_system: ActorSystem,
     pub chain_genesis: ChainGenesis,
     pub validators: Vec<AccountId>,
     pub network_adapters: Vec<Arc<MockPeerManagerAdapter>>,
@@ -678,6 +680,7 @@ impl TestEnv {
         let num_validator_seats = self.validators.len() as NumSeats;
         let (client, chunk_validation_inner) = setup_client_with_runtime(
             self.clock.clone(),
+            self.actor_system.clone(),
             num_validator_seats,
             false,
             self.network_adapters[idx].clone().as_multi_sender(),

--- a/integration-tests/src/node/mod.rs
+++ b/integration-tests/src/node/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 pub use crate::node::process_node::ProcessNode;
 pub use crate::node::runtime_node::RuntimeNode;
 pub use crate::node::thread_node::ThreadNode;
-use crate::user::{AsyncUser, User};
+use crate::user::User;
 use near_chain_configs::Genesis;
 use near_chain_configs::MutableConfigValue;
 use near_chain_configs::TrackedShardsConfig;
@@ -81,10 +81,6 @@ pub trait Node: Send + Sync {
     fn is_running(&self) -> bool;
 
     fn user(&self) -> Box<dyn User>;
-
-    fn async_user(&self) -> Box<dyn AsyncUser> {
-        unimplemented!()
-    }
 
     fn as_thread_ref(&self) -> &ThreadNode {
         unimplemented!()

--- a/integration-tests/src/tests/client/maintenance_windows.rs
+++ b/integration-tests/src/tests/client/maintenance_windows.rs
@@ -1,91 +1,84 @@
-use futures::{FutureExt, future};
-use near_actix_test_utils::run_actix;
 use near_async::time::Clock;
 use near_client_primitives::types::GetMaintenanceWindows;
 use near_o11y::testonly::init_test_logger;
 
 use crate::env::setup::setup_no_network;
+use near_async::ActorSystem;
 use near_async::messaging::CanSendAsync;
 
 /// get maintenance window from view client
-#[test]
-fn test_get_maintenance_windows_for_validator() {
+#[tokio::test]
+async fn test_get_maintenance_windows_for_validator() {
     init_test_logger();
-    run_actix(async {
-        let actor_handles = setup_no_network(
-            Clock::real(),
-            vec!["test".parse().unwrap(), "other".parse().unwrap()],
-            "other".parse().unwrap(),
-            true,
-            true,
-        );
-        let actor = actor_handles
-            .view_client_actor
-            .send_async(GetMaintenanceWindows { account_id: "test".parse().unwrap() });
+    let actor_system = ActorSystem::new();
+    let actor_handles = setup_no_network(
+        Clock::real(),
+        actor_system.clone(),
+        vec!["test".parse().unwrap(), "other".parse().unwrap()],
+        "other".parse().unwrap(),
+        true,
+        true,
+    );
+    let res = actor_handles
+        .view_client_actor
+        .send_async(GetMaintenanceWindows { account_id: "test".parse().unwrap() })
+        .await;
 
-        // With test setup we get the following:
-        //
-        // shard_ids: [ShardId(0)]
-        // #0
-        // block producer: other
-        // chunk producer for shard 0: test
-        // #1
-        // block producer: test
-        // chunk producer for shard 0: test
-        // #2
-        // block producer: test
-        // chunk producer for shard 0: other
-        // #3
-        // block producer: other
-        // chunk producer for shard 0: other
-        // #4
-        // block producer: test
-        // chunk producer for shard 0: test
-        // #5
-        // block producer: other
-        // chunk producer for shard 0: other
-        // #6
-        // block producer: other
-        // chunk producer for shard 0: test
-        // #7
-        // block producer: test
-        // chunk producer for shard 0: other
-        // #8
-        // block producer: test
-        // chunk producer for shard 0: other
-        // #9
-        // block producer: test
-        // chunk producer for shard 0: other
-        //
-        // Maintenance heights are heights where account not a block or chunk producer
-        let actor = actor.then(|res| {
-            assert_eq!(res.unwrap().unwrap(), [3..4, 5..6]);
-            near_async::shutdown_all_actors();
-            future::ready(())
-        });
-        actix::spawn(actor);
-    });
+    // With test setup we get the following:
+    //
+    // shard_ids: [ShardId(0)]
+    // #0
+    // block producer: other
+    // chunk producer for shard 0: test
+    // #1
+    // block producer: test
+    // chunk producer for shard 0: test
+    // #2
+    // block producer: test
+    // chunk producer for shard 0: other
+    // #3
+    // block producer: other
+    // chunk producer for shard 0: other
+    // #4
+    // block producer: test
+    // chunk producer for shard 0: test
+    // #5
+    // block producer: other
+    // chunk producer for shard 0: other
+    // #6
+    // block producer: other
+    // chunk producer for shard 0: test
+    // #7
+    // block producer: test
+    // chunk producer for shard 0: other
+    // #8
+    // block producer: test
+    // chunk producer for shard 0: other
+    // #9
+    // block producer: test
+    // chunk producer for shard 0: other
+    //
+    // Maintenance heights are heights where account not a block or chunk producer
+    assert_eq!(res.unwrap().unwrap(), [3..4, 5..6]);
+    actor_system.stop();
 }
 
-#[test]
-fn test_get_maintenance_windows_for_not_validator() {
+#[tokio::test]
+async fn test_get_maintenance_windows_for_not_validator() {
     init_test_logger();
-    run_actix(async {
-        let actor_handles = setup_no_network(
-            Clock::real(),
-            vec!["test".parse().unwrap()],
-            "other".parse().unwrap(),
-            true,
-            true,
-        );
-        let actor = actor_handles
-            .view_client_actor
-            .send_async(GetMaintenanceWindows { account_id: "alice".parse().unwrap() });
-        let actor = actor.then(|res| {
-            assert_eq!(res.unwrap().unwrap(), vec![0..10]);
-            near_async::shutdown_all_actors();
-            future::ready(())
-        });
-        actix::spawn(actor);
-    });
+    let actor_system = ActorSystem::new();
+    let actor_handles = setup_no_network(
+        Clock::real(),
+        actor_system.clone(),
+        vec!["test".parse().unwrap()],
+        "other".parse().unwrap(),
+        true,
+        true,
+    );
+    let res = actor_handles
+        .view_client_actor
+        .send_async(GetMaintenanceWindows { account_id: "alice".parse().unwrap() })
+        .await;
+    assert_eq!(res.unwrap().unwrap(), vec![0..10]);
+    actor_system.stop();
 }

--- a/integration-tests/src/tests/client/query_client.rs
+++ b/integration-tests/src/tests/client/query_client.rs
@@ -1,6 +1,5 @@
 use crate::env::setup::setup_no_network;
-use futures::{FutureExt, future};
-use near_actix_test_utils::run_actix;
+use near_async::ActorSystem;
 use near_async::messaging::CanSendAsync;
 use near_async::time::{Clock, Duration};
 use near_client::{
@@ -22,185 +21,164 @@ use near_primitives::views::{QueryRequest, QueryResponseKind};
 use num_rational::Ratio;
 
 /// Query account from view client
-#[test]
-fn query_client() {
+#[tokio::test]
+async fn query_client() {
     init_test_logger();
-    run_actix(async {
-        let actor_handles = setup_no_network(
-            Clock::real(),
-            vec!["test".parse().unwrap()],
-            "other".parse().unwrap(),
-            true,
-            true,
-        );
-        let actor = actor_handles.view_client_actor.send_async(Query::new(
+    let actor_system = ActorSystem::new();
+    let actor_handles = setup_no_network(
+        Clock::real(),
+        actor_system.clone(),
+        vec!["test".parse().unwrap()],
+        "other".parse().unwrap(),
+        true,
+        true,
+    );
+    let res = actor_handles
+        .view_client_actor
+        .send_async(Query::new(
             BlockReference::latest(),
             QueryRequest::ViewAccount { account_id: "test".parse().unwrap() },
-        ));
-        let actor = actor.then(|res| {
-            match res.unwrap().unwrap().kind {
-                QueryResponseKind::ViewAccount(_) => (),
-                _ => panic!("Invalid response"),
-            }
-            near_async::shutdown_all_actors();
-            future::ready(())
-        });
-        actix::spawn(actor);
-    });
+        ))
+        .await;
+    match res.unwrap().unwrap().kind {
+        QueryResponseKind::ViewAccount(_) => (),
+        _ => panic!("Invalid response"),
+    }
+    actor_system.stop();
 }
 
 /// When we receive health check and the latest block's timestamp is in the future, the client
 /// should not crash.
-#[test]
-fn query_status_not_crash() {
+#[tokio::test]
+async fn query_status_not_crash() {
     init_test_logger();
-    run_actix(async {
-        let actor_handles = setup_no_network(
-            Clock::real(),
-            vec!["test".parse().unwrap()],
-            "other".parse().unwrap(),
-            true,
-            false,
-        );
-        let signer = create_test_signer("test");
-        let actor = actor_handles.view_client_actor.send_async(GetBlockWithMerkleTree::latest());
-        let actor = actor.then(move |res| {
-            let (block, block_merkle_tree) = res.unwrap().unwrap();
-            let mut block_merkle_tree = PartialMerkleTree::clone(&block_merkle_tree);
-            let header: BlockHeader = block.header.clone().into();
-            block_merkle_tree.insert(*header.hash());
-            let mut next_block = Block::produce(
-                PROTOCOL_VERSION,
-                &header,
-                block.header.height + 1,
-                header.block_ordinal() + 1,
-                block.chunks.iter().cloned().map(|c| c.into()).collect(),
-                vec![vec![]; block.chunks.len()],
-                EpochId(block.header.next_epoch_id),
-                EpochId(block.header.hash),
-                None,
-                vec![],
-                Ratio::from_integer(0),
-                0,
-                100,
-                None,
-                &signer,
-                block.header.next_bp_hash,
-                block_merkle_tree.root(),
-                Clock::real(),
-                None,
-                None,
-                None,
-            );
-            let timestamp = next_block.header().timestamp();
-            next_block
-                .mut_header()
-                .set_timestamp((timestamp + Duration::seconds(60)).unix_timestamp_nanos() as u64);
-            next_block.mut_header().resign(&signer);
+    let actor_system = ActorSystem::new();
+    let actor_handles = setup_no_network(
+        Clock::real(),
+        actor_system.clone(),
+        vec!["test".parse().unwrap()],
+        "other".parse().unwrap(),
+        true,
+        false,
+    );
+    let signer = create_test_signer("test");
+    let res = actor_handles.view_client_actor.send_async(GetBlockWithMerkleTree::latest()).await;
+    let (block, block_merkle_tree) = res.unwrap().unwrap();
+    let mut block_merkle_tree = PartialMerkleTree::clone(&block_merkle_tree);
+    let header: BlockHeader = block.header.clone().into();
+    block_merkle_tree.insert(*header.hash());
+    let mut next_block = Block::produce(
+        PROTOCOL_VERSION,
+        &header,
+        block.header.height + 1,
+        header.block_ordinal() + 1,
+        block.chunks.iter().cloned().map(|c| c.into()).collect(),
+        vec![vec![]; block.chunks.len()],
+        EpochId(block.header.next_epoch_id),
+        EpochId(block.header.hash),
+        None,
+        vec![],
+        Ratio::from_integer(0),
+        0,
+        100,
+        None,
+        &signer,
+        block.header.next_bp_hash,
+        block_merkle_tree.root(),
+        Clock::real(),
+        None,
+        None,
+        None,
+    );
+    let timestamp = next_block.header().timestamp();
+    next_block
+        .mut_header()
+        .set_timestamp((timestamp + Duration::seconds(60)).unix_timestamp_nanos() as u64);
+    next_block.mut_header().resign(&signer);
 
-            actix::spawn(
-                actor_handles
-                    .client_actor
-                    .send_async(
-                        BlockResponse {
-                            block: next_block.into(),
-                            peer_id: PeerInfo::random().id,
-                            was_requested: false,
-                        }
-                        .span_wrap(),
-                    )
-                    .then(move |_| {
-                        actix::spawn(
-                            actor_handles
-                                .client_actor
-                                .send_async(
-                                    Status { is_health_check: true, detailed: false }.span_wrap(),
-                                )
-                                .then(move |_| {
-                                    near_async::shutdown_all_actors();
-                                    future::ready(())
-                                }),
-                        );
-                        future::ready(())
-                    }),
-            );
-            future::ready(())
-        });
-        actix::spawn(actor);
-        near_network::test_utils::wait_or_panic(5000);
-    });
+    let _ = actor_handles
+        .client_actor
+        .send_async(
+            BlockResponse {
+                block: next_block.into(),
+                peer_id: PeerInfo::random().id,
+                was_requested: false,
+            }
+            .span_wrap(),
+        )
+        .await;
+
+    let _ = actor_handles
+        .client_actor
+        .send_async(Status { is_health_check: true, detailed: false }.span_wrap())
+        .await;
+
+    actor_system.stop();
 }
 
-#[test]
-fn test_execution_outcome_for_chunk() {
+#[tokio::test]
+async fn test_execution_outcome_for_chunk() {
     init_test_logger();
-    run_actix(async {
-        let actor_handles = setup_no_network(
-            Clock::real(),
-            vec!["test".parse().unwrap()],
-            "test".parse().unwrap(),
-            true,
-            false,
-        );
-        let signer = InMemorySigner::test_signer(&"test".parse().unwrap());
+    let actor_system = ActorSystem::new();
+    let actor_handles = setup_no_network(
+        Clock::real(),
+        actor_system.clone(),
+        vec!["test".parse().unwrap()],
+        "test".parse().unwrap(),
+        true,
+        false,
+    );
+    let signer = InMemorySigner::test_signer(&"test".parse().unwrap());
 
-        actix::spawn(async move {
-            let block_hash = actor_handles
-                .view_client_actor
-                .send_async(GetBlock::latest())
-                .await
-                .unwrap()
-                .unwrap()
-                .header
-                .hash;
+    let block_hash = actor_handles
+        .view_client_actor
+        .send_async(GetBlock::latest())
+        .await
+        .unwrap()
+        .unwrap()
+        .header
+        .hash;
 
-            let transaction = SignedTransaction::send_money(
-                1,
-                "test".parse().unwrap(),
-                "near".parse().unwrap(),
-                &signer,
-                10,
-                block_hash,
-            );
-            let tx_hash = transaction.get_hash();
-            let res = actor_handles
-                .rpc_handler_actor
-                .send_async(ProcessTxRequest {
-                    transaction,
-                    is_forwarded: false,
-                    check_only: false,
-                })
-                .await
-                .unwrap();
-            assert!(matches!(res, ProcessTxResponse::ValidTx));
+    let transaction = SignedTransaction::send_money(
+        1,
+        "test".parse().unwrap(),
+        "near".parse().unwrap(),
+        &signer,
+        10,
+        block_hash,
+    );
+    let tx_hash = transaction.get_hash();
+    let res = actor_handles
+        .rpc_handler_actor
+        .send_async(ProcessTxRequest { transaction, is_forwarded: false, check_only: false })
+        .await
+        .unwrap();
+    assert!(matches!(res, ProcessTxResponse::ValidTx));
 
-            actix::clock::sleep(std::time::Duration::from_millis(500)).await;
-            let block_hash = actor_handles
-                .view_client_actor
-                .send_async(TxStatus {
-                    tx_hash,
-                    signer_account_id: "test".parse().unwrap(),
-                    fetch_receipt: false,
-                })
-                .await
-                .unwrap()
-                .unwrap()
-                .into_outcome()
-                .unwrap()
-                .transaction_outcome
-                .block_hash;
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    let block_hash = actor_handles
+        .view_client_actor
+        .send_async(TxStatus {
+            tx_hash,
+            signer_account_id: "test".parse().unwrap(),
+            fetch_receipt: false,
+        })
+        .await
+        .unwrap()
+        .unwrap()
+        .into_outcome()
+        .unwrap()
+        .transaction_outcome
+        .block_hash;
 
-            let mut execution_outcomes_in_block = actor_handles
-                .view_client_actor
-                .send_async(GetExecutionOutcomesForBlock { block_hash })
-                .await
-                .unwrap()
-                .unwrap();
-            assert_eq!(execution_outcomes_in_block.len(), 1);
-            let outcomes = execution_outcomes_in_block.remove(&ShardId::new(0)).unwrap();
-            assert_eq!(outcomes[0].id, tx_hash);
-            near_async::shutdown_all_actors();
-        });
-        near_network::test_utils::wait_or_panic(5000);
-    });
+    let mut execution_outcomes_in_block = actor_handles
+        .view_client_actor
+        .send_async(GetExecutionOutcomesForBlock { block_hash })
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(execution_outcomes_in_block.len(), 1);
+    let outcomes = execution_outcomes_in_block.remove(&ShardId::new(0)).unwrap();
+    assert_eq!(outcomes[0].id, tx_hash);
+    actor_system.stop();
 }

--- a/integration-tests/src/tests/client/sync_state_nodes.rs
+++ b/integration-tests/src/tests/client/sync_state_nodes.rs
@@ -63,15 +63,12 @@ fn slow_test_sync_state_nodes() {
                     .expect("start_with_config");
 
             let view_client2_holder = Arc::new(RwLock::new(None));
-            let arbiters_holder = Arc::new(RwLock::new(vec![]));
-            let arbiters_holder2 = arbiters_holder;
             let actor_system = actor_system.clone();
 
             WaitOrTimeoutActor::new(
                 Box::new(move |_ctx| {
                     if view_client2_holder.read().is_none() {
                         let view_client2_holder2 = view_client2_holder.clone();
-                        let arbiters_holder2 = arbiters_holder2.clone();
                         let genesis2 = genesis.clone();
                         let dir2 = dir2.clone();
                         let actor_system = actor_system.clone();
@@ -81,7 +78,6 @@ fn slow_test_sync_state_nodes() {
                             match &res {
                                 Ok(Ok(b)) if b.header.height >= 101 => {
                                     let mut view_client2_holder2 = view_client2_holder2.write();
-                                    let mut arbiters_holder2 = arbiters_holder2.write();
 
                                     if view_client2_holder2.is_none() {
                                         let mut near2 =
@@ -92,9 +88,7 @@ fn slow_test_sync_state_nodes() {
                                             convert_boot_nodes(vec![("test1", *port1)]);
 
                                         let nearcore::NearNode {
-                                            view_client: view_client2,
-                                            arbiters,
-                                            ..
+                                            view_client: view_client2, ..
                                         } = start_with_config(
                                             dir2.path(),
                                             near2,
@@ -102,7 +96,6 @@ fn slow_test_sync_state_nodes() {
                                         )
                                         .expect("start_with_config");
                                         *view_client2_holder2 = Some(view_client2);
-                                        *arbiters_holder2 = arbiters;
                                     }
                                 }
                                 Ok(Ok(b)) if b.header.height < 101 => {
@@ -214,15 +207,12 @@ fn ultra_slow_test_sync_state_nodes_multishard() {
             start_with_config(dir4.path(), near4, actor_system.clone()).expect("start_with_config");
 
             let view_client2_holder = Arc::new(RwLock::new(None));
-            let arbiter_holder = Arc::new(RwLock::new(vec![]));
-            let arbiter_holder2 = arbiter_holder;
             let actor_system = actor_system.clone();
 
             WaitOrTimeoutActor::new(
                 Box::new(move |_ctx| {
                     if view_client2_holder.read().is_none() {
                         let view_client2_holder2 = view_client2_holder.clone();
-                        let arbiter_holder2 = arbiter_holder2.clone();
                         let genesis2 = genesis.clone();
                         let dir2 = dir2.clone();
 
@@ -232,7 +222,6 @@ fn ultra_slow_test_sync_state_nodes_multishard() {
                             match &res {
                                 Ok(Ok(b)) if b.header.height >= 101 => {
                                     let mut view_client2_holder2 = view_client2_holder2.write();
-                                    let mut arbiter_holder2 = arbiter_holder2.write();
 
                                     if view_client2_holder2.is_none() {
                                         let mut near2 = load_test_config("test2", port2, genesis2);
@@ -250,9 +239,7 @@ fn ultra_slow_test_sync_state_nodes_multishard() {
                                             ]);
 
                                         let nearcore::NearNode {
-                                            view_client: view_client2,
-                                            arbiters,
-                                            ..
+                                            view_client: view_client2, ..
                                         } = start_with_config(
                                             dir2.path(),
                                             near2,
@@ -260,7 +247,6 @@ fn ultra_slow_test_sync_state_nodes_multishard() {
                                         )
                                         .expect("start_with_config");
                                         *view_client2_holder2 = Some(view_client2);
-                                        *arbiter_holder2 = arbiters;
                                     }
                                 }
                                 Ok(Ok(b)) if b.header.height < 101 => {
@@ -373,21 +359,17 @@ fn ultra_slow_test_sync_state_dump() {
                 .expect("start_with_config");
 
             let view_client2_holder = Arc::new(RwLock::new(None));
-            let arbiters_holder = Arc::new(RwLock::new(vec![]));
-            let arbiters_holder2 = arbiters_holder;
             let actor_system = actor_system.clone();
 
             wait_or_timeout(1000, 120000, || async {
                 if view_client2_holder.read().is_none() {
                     let view_client2_holder2 = view_client2_holder.clone();
-                    let arbiters_holder2 = arbiters_holder2.clone();
                     let genesis2 = genesis.clone();
 
                     match view_client1.send_async(GetBlock::latest()).await {
                         // FIXME: this is not the right check after the sync hash was moved to sync the current epoch's state
                         Ok(Ok(b)) if b.header.height >= genesis.config.epoch_length + 2 => {
                             let mut view_client2_holder2 = view_client2_holder2.write();
-                            let mut arbiters_holder2 = arbiters_holder2.write();
 
                             if view_client2_holder2.is_none() {
                                 let mut near2 = load_test_config("test2", port2, genesis2);
@@ -417,12 +399,10 @@ fn ultra_slow_test_sync_state_dump() {
                                         external_storage_fallback_threshold: 0,
                                     });
 
-                                let nearcore::NearNode {
-                                    view_client: view_client2, arbiters, ..
-                                } = start_with_config(dir2.path(), near2, actor_system.clone())
-                                    .expect("start_with_config");
+                                let nearcore::NearNode { view_client: view_client2, .. } =
+                                    start_with_config(dir2.path(), near2, actor_system.clone())
+                                        .expect("start_with_config");
                                 *view_client2_holder2 = Some(view_client2);
-                                *arbiters_holder2 = arbiters;
                             }
                         }
                         Ok(Ok(b)) if b.header.height <= state_sync_horizon => {

--- a/integration-tests/src/tests/nearcore/node_cluster.rs
+++ b/integration-tests/src/tests/nearcore/node_cluster.rs
@@ -1,4 +1,3 @@
-use actix_rt::ArbiterHandle;
 use futures::future;
 use near_actix_test_utils::{run_actix, spawn_interruptible};
 use near_chain_configs::{Genesis, TrackedShardsConfig};
@@ -27,11 +26,7 @@ fn start_nodes(
 ) -> (
     Genesis,
     Vec<String>,
-    Vec<(
-        TokioRuntimeHandle<ClientActorInner>,
-        MultithreadRuntimeHandle<ViewClientActorInner>,
-        Vec<ArbiterHandle>,
-    )>,
+    Vec<(TokioRuntimeHandle<ClientActorInner>, MultithreadRuntimeHandle<ViewClientActorInner>)>,
 ) {
     init_integration_logger();
 
@@ -74,9 +69,9 @@ fn start_nodes(
     for (i, near_config) in near_configs.into_iter().enumerate() {
         let dir = temp_dir.join(format!("node{i}"));
         std::fs::create_dir(&dir).unwrap();
-        let nearcore::NearNode { client, view_client, arbiters, .. } =
+        let nearcore::NearNode { client, view_client, .. } =
             start_with_config(&dir, near_config, actor_system.clone()).expect("start_with_config");
-        res.push((client, view_client, arbiters))
+        res.push((client, view_client))
     }
     (genesis, rpc_addrs, res)
 }
@@ -137,7 +132,6 @@ impl NodeCluster {
             Vec<(
                 TokioRuntimeHandle<ClientActorInner>,
                 MultithreadRuntimeHandle<ViewClientActorInner>,
-                Vec<actix_rt::ArbiterHandle>,
             )>,
         ) -> R,
     {

--- a/integration-tests/src/tests/network/rosetta_rpc.rs
+++ b/integration-tests/src/tests/network/rosetta_rpc.rs
@@ -1,25 +1,25 @@
-use near_actix_test_utils::run_actix;
 use near_async::time::Clock;
 use near_parameters::{RuntimeConfig, RuntimeConfigView};
 
 use crate::env::setup::setup_no_network;
+use near_async::ActorSystem;
 
-#[test]
-fn test_convert_block_changes_to_transactions() {
-    run_actix(async {
-        let runtime_config: RuntimeConfigView = RuntimeConfig::test().into();
-        let actor_handles = setup_no_network(
-            Clock::real(),
-            vec!["test".parse().unwrap()],
-            "other".parse().unwrap(),
-            true,
-            false,
-        );
-        near_rosetta_rpc::test::test_convert_block_changes_to_transactions(
-            &actor_handles.view_client_actor,
-            &runtime_config,
-        )
-        .await;
-        near_async::shutdown_all_actors();
-    });
+#[tokio::test]
+async fn test_convert_block_changes_to_transactions() {
+    let actor_system = ActorSystem::new();
+    let runtime_config: RuntimeConfigView = RuntimeConfig::test().into();
+    let actor_handles = setup_no_network(
+        Clock::real(),
+        actor_system.clone(),
+        vec!["test".parse().unwrap()],
+        "other".parse().unwrap(),
+        true,
+        false,
+    );
+    near_rosetta_rpc::test::test_convert_block_changes_to_transactions(
+        &actor_handles.view_client_actor,
+        &runtime_config,
+    )
+    .await;
+    actor_system.stop();
 }

--- a/integration-tests/src/user/mod.rs
+++ b/integration-tests/src/user/mod.rs
@@ -1,7 +1,5 @@
 use std::sync::Arc;
 
-use futures::{FutureExt, future::LocalBoxFuture};
-
 use near_crypto::{PublicKey, Signer};
 use near_jsonrpc_primitives::errors::ServerError;
 use near_primitives::account::AccessKey;
@@ -11,10 +9,9 @@ use near_primitives::receipt::Receipt;
 use near_primitives::test_utils::create_user_test_signer;
 use near_primitives::transaction::{
     Action, AddKeyAction, CreateAccountAction, DeleteAccountAction, DeleteKeyAction,
-    DeployContractAction, ExecutionOutcome, FunctionCallAction, SignedTransaction, StakeAction,
-    TransferAction,
+    DeployContractAction, FunctionCallAction, SignedTransaction, StakeAction, TransferAction,
 };
-use near_primitives::types::{AccountId, Balance, BlockHeight, Gas, MerkleHash, ShardId};
+use near_primitives::types::{AccountId, Balance, BlockHeight, Gas, ShardId};
 use near_primitives::views::{
     AccessKeyView, AccountView, BlockView, CallResult, ChunkView, ContractCodeView,
     ExecutionOutcomeView, FinalExecutionOutcomeView, ViewStateResult,
@@ -322,59 +319,4 @@ pub trait User {
             vec![Action::Delegate(Box::new(signed_delegate_action))],
         )
     }
-}
-
-/// Same as `User` by provides async API that can be used inside tokio.
-pub trait AsyncUser: Send + Sync {
-    fn view_account(
-        &self,
-        account_id: &AccountId,
-    ) -> LocalBoxFuture<'static, Result<AccountView, ServerError>>;
-
-    fn view_balance(
-        &self,
-        account_id: &AccountId,
-    ) -> LocalBoxFuture<'static, Result<Balance, ServerError>> {
-        self.view_account(account_id).map(|res| res.map(|acc| acc.amount)).boxed_local()
-    }
-
-    fn view_state(
-        &self,
-        account_id: &AccountId,
-    ) -> LocalBoxFuture<'static, Result<ViewStateResult, ServerError>>;
-
-    fn add_transaction(
-        &self,
-        transaction: SignedTransaction,
-    ) -> LocalBoxFuture<'static, Result<(), ServerError>>;
-
-    fn add_receipts(
-        &self,
-        receipts: &[Receipt],
-    ) -> LocalBoxFuture<'static, Result<(), ServerError>>;
-
-    fn get_account_nonce(
-        &self,
-        account_id: &AccountId,
-    ) -> LocalBoxFuture<'static, Result<u64, ServerError>>;
-
-    fn get_best_height(&self) -> LocalBoxFuture<'static, Result<BlockHeight, ServerError>>;
-
-    fn get_transaction_result(
-        &self,
-        hash: &CryptoHash,
-    ) -> LocalBoxFuture<'static, Result<ExecutionOutcome, ServerError>>;
-
-    fn get_transaction_final_result(
-        &self,
-        hash: &CryptoHash,
-    ) -> LocalBoxFuture<'static, Result<FinalExecutionOutcomeView, ServerError>>;
-
-    fn get_state_root(&self) -> LocalBoxFuture<'static, Result<MerkleHash, ServerError>>;
-
-    fn get_access_key(
-        &self,
-        account_id: &AccountId,
-        public_key: &PublicKey,
-    ) -> LocalBoxFuture<'static, Result<Option<AccessKey>, ServerError>>;
 }


### PR DESCRIPTION
This is for integration tests that don't run any actix actors anymore - do not use `run_actix`; instead use the new actor system as well as stock tokio.