### PR TITLE
fix(resharding) - recovery tool for resharding archival data loss (#14185)

### DIFF
--- a/chain/chain/src/resharding/manager.rs
+++ b/chain/chain/src/resharding/manager.rs
@@ -17,9 +17,15 @@ use near_store::adapter::trie_store::get_shard_uid_mapping;
 use near_store::flat::BlockInfo;
 use near_store::trie::ops::resharding::RetainMode;
 use near_store::trie::outgoing_metadata::ReceiptGroupsQueue;
-use near_store::{ShardTries, ShardUId, Store, TrieAccess};
+use near_store::{ShardTries, ShardUId, Store, TrieAccess, TrieChanges};
+use std::collections::BTreeMap;
 use std::io;
 use std::sync::Arc;
+
+#[derive(Default)]
+pub struct SplitShardTrieChanges {
+    pub trie_changes: BTreeMap<ShardUId, TrieChanges>,
+}
 
 pub struct ReshardingManager {
     store: Store,
@@ -85,7 +91,14 @@ impl ReshardingManager {
             ReshardingEventType::from_shard_layout(&next_shard_layout, block_info)?;
         match resharding_event_type {
             Some(ReshardingEventType::SplitShard(split_shard_event)) => {
-                self.split_shard(chain_store_update, block, shard_uid, tries, split_shard_event)?;
+                self.split_shard(
+                    chain_store_update,
+                    block,
+                    shard_uid,
+                    tries,
+                    split_shard_event,
+                    false,
+                )?;
             }
             None => {
                 tracing::warn!(target: "resharding", ?resharding_event_type, "unsupported resharding event type, skipping");
@@ -101,11 +114,12 @@ impl ReshardingManager {
         shard_uid: ShardUId,
         tries: ShardTries,
         split_shard_event: ReshardingSplitShardParams,
-    ) -> Result<(), Error> {
+        allow_resharding_without_memtries: bool,
+    ) -> Result<SplitShardTrieChanges, Error> {
         if split_shard_event.parent_shard != shard_uid {
             let parent_shard = split_shard_event.parent_shard;
             tracing::debug!(target: "resharding", ?parent_shard, "ShardUId does not match event parent shard, skipping");
-            return Ok(());
+            return Ok(Default::default());
         }
 
         let tracked_children_shards = split_shard_event
@@ -124,25 +138,26 @@ impl ReshardingManager {
 
         if tracked_children_shards.is_empty() {
             tracing::debug!(target: "resharding", "Not tracking any child shards, skipping");
-            return Ok(());
+            return Ok(Default::default());
         }
 
         // Reshard the State column by setting ShardUId mapping from children to ancestor.
         self.set_state_shard_uid_mapping(&split_shard_event, &tracked_children_shards)?;
 
         // Create temporary children memtries by freezing parent memtrie and referencing it.
-        self.process_memtrie_resharding_storage_update(
+        let trie_changes = self.process_memtrie_resharding_storage_update(
             chain_store_update,
             block,
             tries,
             &split_shard_event,
+            allow_resharding_without_memtries,
         )?;
 
         // Trigger resharding by sending the event to the resharding actor.
         // This would subsequently trigger the resharding after resharding block is finalized.
         self.resharding_sender.send(ScheduleResharding { split_shard_event });
 
-        Ok(())
+        Ok(trie_changes)
     }
 
     /// Store in the database the mapping of ShardUId from children to the parent shard,
@@ -170,7 +185,8 @@ impl ReshardingManager {
         block: &Block,
         tries: ShardTries,
         split_shard_event: &ReshardingSplitShardParams,
-    ) -> Result<(), Error> {
+        allow_resharding_without_memtries: bool,
+    ) -> Result<SplitShardTrieChanges, Error> {
         let block_hash = block.hash();
         let block_height = block.header().height();
         let ReshardingSplitShardParams {
@@ -189,6 +205,8 @@ impl ReshardingManager {
             self.store.chain_store().get_chunk_extra(block_hash, parent_shard_uid)?;
         let mut store_update = self.store.trie_store().store_update();
 
+        let mut split_shard_trie_changes = SplitShardTrieChanges::default();
+
         for (new_shard_uid, retain_mode) in
             [(left_child_shard, RetainMode::Left), (right_child_shard, RetainMode::Right)]
         {
@@ -196,7 +214,7 @@ impl ReshardingManager {
                 .get_trie_for_shard(*parent_shard_uid, *parent_chunk_extra.state_root())
                 .recording_reads_new_recorder();
 
-            if !parent_trie.has_memtries() {
+            if !allow_resharding_without_memtries && !parent_trie.has_memtries() {
                 tracing::error!(
                     "Memtrie not loaded. Cannot process memtrie resharding storage
                      update for block {:?}, shard {:?}",
@@ -254,16 +272,23 @@ impl ReshardingManager {
             );
 
             tracing::info!(target: "resharding", ?new_shard_uid, ?trie_changes.new_root, "Child trie created");
+
+            split_shard_trie_changes.trie_changes.insert(*new_shard_uid, trie_changes);
         }
 
-        // After committing the split changes, the parent trie has the state root of both the children.
-        // Now we can freeze the parent memtrie and copy it to the children.
-        tries.freeze_parent_memtrie(*parent_shard_uid, split_shard_event.children_shards())?;
+        // After committing the split changes, the parent trie has the state
+        // root of both the children. Now we can freeze the parent memtrie and
+        // copy it to the children.
+        let parent_trie =
+            tries.get_trie_for_shard(*parent_shard_uid, *parent_chunk_extra.state_root());
+        if parent_trie.has_memtries() {
+            tries.freeze_parent_memtrie(*parent_shard_uid, split_shard_event.children_shards())?;
+        }
 
         chain_store_update.merge(store_update.into());
         chain_store_update.commit()?;
 
-        Ok(())
+        Ok(split_shard_trie_changes)
     }
 
     pub fn get_child_congestion_info(

--- a/core/store/src/archive/cold_storage.rs
+++ b/core/store/src/archive/cold_storage.rs
@@ -139,7 +139,7 @@ pub fn update_cold_db(
 // Correctly set the key and value on DBTransaction, taking reference counting
 // into account. For non-rc columns it just sets the value. For rc columns it
 // appends rc = 1 to the value and sets it.
-fn rc_aware_set(
+pub fn rc_aware_set(
     transaction: &mut DBTransaction,
     col: DBCol,
     key: Vec<u8>,

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -1673,8 +1673,7 @@ impl Trie {
         self.disk_iter_with_prune_condition(None)
     }
 
-    #[cfg(test)]
-    pub(crate) fn disk_iter_with_max_depth(
+    pub fn disk_iter_with_max_depth(
         &self,
         max_depth: usize,
     ) -> Result<DiskTrieIterator, StorageError> {

--- a/tools/database/src/commands.rs
+++ b/tools/database/src/commands.rs
@@ -7,7 +7,7 @@ use crate::analyze_high_load::HighLoadStatsCommand;
 use crate::compact::RunCompactionCommand;
 use crate::drop_column::DropColumnCommand;
 use crate::make_snapshot::MakeSnapshotCommand;
-use crate::memtrie::{LoadMemTrieCommand, SplitShardTrieCommand};
+use crate::memtrie::{ArchivalDataLossRecoveryCommand, LoadMemTrieCommand, SplitShardTrieCommand};
 use crate::rollback_to_26::RollbackTo26Command;
 use crate::run_migrations::RunMigrationsCommand;
 use crate::set_version::SetVersionCommand;
@@ -56,6 +56,8 @@ enum SubCommand {
     /// Splits given shard on a given boundary account and prints approximate
     /// RAM usage of the child shards.
     SplitShardTrie(SplitShardTrieCommand),
+    /// Recover the archival data that was lost during resharding.
+    ArchivalDataLossRecovery(ArchivalDataLossRecoveryCommand),
 
     /// Write CryptoHash to DB
     WriteCryptoHash(WriteCryptoHashCommand),
@@ -95,6 +97,7 @@ impl DatabaseCommand {
             SubCommand::StatePerf(cmd) => cmd.run(home),
             SubCommand::LoadMemTrie(cmd) => cmd.run(home, genesis_validation),
             SubCommand::SplitShardTrie(cmd) => cmd.run(home, genesis_validation),
+            SubCommand::ArchivalDataLossRecovery(cmd) => cmd.run(home, genesis_validation),
             SubCommand::WriteCryptoHash(cmd) => cmd.run(home, genesis_validation),
             SubCommand::HighLoadStats(cmd) => cmd.run(home),
             SubCommand::AnalyzeDelayedReceipt(cmd) => cmd.run(home, genesis_validation),

--- a/tools/database/src/memtrie.rs
+++ b/tools/database/src/memtrie.rs
@@ -1,7 +1,8 @@
 use crate::utils::open_rocksdb;
 use anyhow::Context;
 use near_async::messaging::{IntoMultiSender, noop};
-use near_chain::resharding::event_type::ReshardingSplitShardParams;
+use near_async::time::Instant;
+use near_chain::resharding::event_type::{ReshardingEventType, ReshardingSplitShardParams};
 use near_chain::resharding::manager::ReshardingManager;
 use near_chain::types::RuntimeAdapter;
 use near_chain::{ChainStore, ChainStoreAccess};
@@ -14,11 +15,14 @@ use near_primitives::block::{Block, Tip};
 use near_primitives::block_header::BlockHeader;
 use near_primitives::epoch_manager::EpochConfigStore;
 use near_primitives::shard_layout::ShardLayout;
-use near_primitives::types::{AccountId, ShardId};
+use near_primitives::types::{AccountId, ProtocolVersion, ShardId};
 use near_store::adapter::StoreAdapter;
 use near_store::adapter::chain_store::ChainStoreAdapter;
-use near_store::db::RocksDB;
+use near_store::adapter::trie_store::get_shard_uid_mapping;
+use near_store::archive::cold_storage::{join_two_keys, rc_aware_set};
 use near_store::db::rocksdb::snapshot::Snapshot;
+use near_store::db::{DBTransaction, Database, RocksDB};
+use near_store::flat::BlockInfo;
 use near_store::trie::mem::node::MemTrieNodeView;
 use near_store::{DBCol, HEAD_KEY, Mode, ShardTries, ShardUId, Temperature};
 use nearcore::{NightshadeRuntime, NightshadeRuntimeExt};
@@ -188,6 +192,7 @@ impl SplitShardTrieCommand {
         let shard_tracker = ShardTracker::new(
             near_config.client_config.tracked_shards_config.clone(),
             epoch_manager.clone(),
+            // MutableValidatorSigner::default(),
         );
         let my_account_id = near_config.validator_signer.get().map(|v| v.validator_id().clone());
         let resharding_manager =
@@ -208,6 +213,7 @@ impl SplitShardTrieCommand {
             self.shard_uid,
             shard_tries.clone(),
             split_params,
+            false,
         )?;
         println!("Resharding done");
 
@@ -270,5 +276,199 @@ impl<'a, 'b> MemtrieSizeCalculator<'a, 'b> {
         }
 
         Ok(total_size)
+    }
+}
+
+#[derive(clap::Parser)]
+pub struct ArchivalDataLossRecoveryCommand {
+    #[clap(long)]
+    protocol_version: ProtocolVersion,
+
+    #[clap(long, default_value_t = false)]
+    check_only: bool,
+}
+
+impl ArchivalDataLossRecoveryCommand {
+    pub fn run(
+        &self,
+        home: &Path,
+        genesis_validation: GenesisValidationMode,
+    ) -> anyhow::Result<()> {
+        let env_filter = EnvFilterBuilder::from_env().verbose(Some("memtrie")).finish()?;
+        let _subscriber = default_subscriber(env_filter, &Default::default()).global();
+
+        let mut near_config =
+            nearcore::config::load_config(&home, genesis_validation).expect("Error loading config");
+
+        let node_storage = nearcore::open_storage(&home, &mut near_config)?;
+        let store = node_storage.get_split_store().expect("SplitStore not found!");
+        let cold_store = node_storage.get_cold_store().expect("ColdStore not found!");
+        let cold_db = node_storage.cold_db().expect("ColdDB not found!");
+        let mut chain_store = ChainStore::new(
+            store.clone(),
+            true,
+            near_config.genesis.config.transaction_validity_period,
+        );
+
+        // Create epoch manager and runtime
+        let epoch_manager =
+            EpochManager::new_arc_handle(store.clone(), &near_config.genesis.config, Some(home));
+        let runtime = NightshadeRuntime::from_config(
+            home,
+            store.clone(),
+            &near_config,
+            epoch_manager.clone(),
+        );
+        let runtime = runtime.context("could not create the transaction runtime")?;
+
+        // Get the shard layout and ensure the protocol version upgrade actually
+        // contains a resharding.
+        let shard_layout =
+            epoch_manager.get_shard_layout_from_protocol_version(self.protocol_version);
+        let prev_shard_layout =
+            epoch_manager.get_shard_layout_from_protocol_version(self.protocol_version - 1);
+        assert_ne!(
+            shard_layout, prev_shard_layout,
+            "The provided protocol version does not contain a resharding."
+        );
+
+        println!("Searching for the first epoch of the provided protocol version");
+        // Find the fist epoch of the provided protocol version.
+        let head = store.chain_store().head()?;
+        let mut epoch_id = head.epoch_id;
+        loop {
+            let epoch_start_height = epoch_manager.get_epoch_start_from_epoch_id(&epoch_id)?;
+            let epoch_start_block_header =
+                store.chain_store().get_block_header_by_height(epoch_start_height)?;
+
+            let prev_block_hash = epoch_start_block_header.prev_hash();
+            let prev_epoch_id = epoch_manager.get_epoch_id(prev_block_hash)?;
+            let prev_protocol_version = epoch_manager.get_epoch_protocol_version(&prev_epoch_id)?;
+
+            if prev_protocol_version < self.protocol_version {
+                break;
+            }
+
+            epoch_id = prev_epoch_id;
+        }
+        println!("Found epoch id {epoch_id:?}");
+
+        // Find the resharding block. It is the last block of the previous epoch.
+        let epoch_start_height = epoch_manager.get_epoch_start_from_epoch_id(&epoch_id)?;
+        let epoch_start_block_hash =
+            store.chain_store().get_block_hash_by_height(epoch_start_height)?;
+        let epoch_start_block = store.chain_store().get_block(&epoch_start_block_hash)?;
+        let resharding_block_hash = epoch_start_block.header().prev_hash();
+        let resharding_block = store.chain_store().get_block(resharding_block_hash)?;
+        println!("Found resharding block {resharding_block_hash:?}");
+
+        // Prepare the resharding split shard params.
+        let resharding_block_info = BlockInfo {
+            hash: *resharding_block.hash(),
+            height: resharding_block.header().height(),
+            prev_hash: *resharding_block.header().prev_hash(),
+        };
+        let resharding_event =
+            ReshardingEventType::from_shard_layout(&shard_layout, resharding_block_info)?;
+        let resharding_event = resharding_event.expect("Could not create the resharding event");
+        let ReshardingEventType::SplitShard(split_shard_params) = resharding_event;
+        println!("Prepared split shard params: {split_shard_params:?}");
+
+        let shard_tries = runtime.get_tries();
+        if self.check_only {
+            Self::check_trie(
+                &shard_layout,
+                &shard_tries,
+                &epoch_start_block,
+                split_shard_params.left_child_shard,
+            );
+
+            Self::check_trie(
+                &shard_layout,
+                &shard_tries,
+                &epoch_start_block,
+                split_shard_params.right_child_shard,
+            );
+            return Ok(());
+        }
+
+        // Create resharding manager.
+        let sender = noop().into_multi_sender();
+        let shard_tracker = ShardTracker::new(
+            near_config.client_config.tracked_shards_config.clone(),
+            epoch_manager.clone(),
+            // MutableValidatorSigner::default(),
+        );
+        let resharding_manager =
+            ReshardingManager::new(store, epoch_manager, shard_tracker, None, sender);
+
+        println!("Starting resharding");
+        let chain_store_update = chain_store.store_update();
+        let trie_changes = resharding_manager.split_shard(
+            chain_store_update,
+            &resharding_block,
+            split_shard_params.parent_shard,
+            shard_tries,
+            split_shard_params,
+            true,
+        )?;
+        println!("Resharding done");
+
+        println!("Writing child trie changes");
+        let mut transaction = DBTransaction::new();
+        for (&child_shard_uid, child_trie_changes) in &trie_changes.trie_changes {
+            let mapped_shard_uid = get_shard_uid_mapping(&cold_store, child_shard_uid);
+            let insertions = child_trie_changes.insertions().len();
+            println!(
+                "shard_uid {child_shard_uid:?}, mapped shard_uid {mapped_shard_uid:?}, insertions {insertions}"
+            );
+
+            for op in child_trie_changes.insertions() {
+                let key = join_two_keys(&mapped_shard_uid.to_bytes(), op.hash().as_bytes());
+                let value = op.payload().to_vec();
+
+                rc_aware_set(&mut transaction, DBCol::State, key, value);
+            }
+        }
+        cold_db.write(transaction)?;
+
+        Ok(())
+    }
+
+    /// Iterate through the whole trie to ensure that all the trie nodes are
+    /// accessible. It should be used with the first block of the first epoch
+    /// with the new shard layout, the matching shard layout and the shard uid
+    /// of the child shard.
+    fn check_trie(
+        shard_layout: &ShardLayout,
+        shard_tries: &ShardTries,
+        block: &Block,
+        shard_uid: ShardUId,
+    ) {
+        println!("checking shard {shard_uid:?}");
+        let start_time = Instant::now();
+        let mut leaf_node_count = 0;
+
+        let shard_index = shard_layout.get_shard_index(shard_uid.shard_id()).unwrap();
+        let chunk_header = &block.chunks()[shard_index];
+
+        // TODO(wacban) - find the first new chunk in that shard and use that instead.
+        if shard_uid.shard_id() != chunk_header.shard_id() {
+            println!("Skipping check_trie due to missing chunk");
+            return;
+        }
+
+        let state_root = chunk_header.prev_state_root();
+        let trie = shard_tries.get_trie_for_shard(shard_uid, state_root);
+        let iter = trie.disk_iter_with_max_depth(6).expect("could not create disk iter");
+        for item in iter {
+            item.unwrap();
+            leaf_node_count += 1;
+        }
+
+        let elapsed = start_time.elapsed();
+        println!(
+            "finished checking shard {shard_uid:?}, elapsed: {elapsed:?}, node count: {leaf_node_count}"
+        );
     }
 }


### PR DESCRIPTION
Cherry-Pick #14185

This is a recovery tool for the data loss that happened during the recent reshardings. As the resharding implementation does not store any TrieChanges, the trie nodes inserted during resharding are never moved to the cold storage. Once the garbage collection removes those nodes they are lost and the archival node cannot serve some queries for some range of blocks after resharding.

This tool replays the resharding, extracts the TrieChanges and stores them directly into the cold db.

The check-only option allows checking if the trie is whole. 

This is not a fix to the original problem that caused the data loss, that will follow separately.