### PR TITLE
fix(state-snapshot): use default store config for state snapshot (#14212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@
 
 ### Protocol Changes
 * Increase number of validators from 300 to 500. To maintain the chain safety, we increase the number of mandates per shard to 105.
+
 ### Non-protocol Changes
-* Added a neard subcommand tool that can be used to recover data that was lost
-  due to bug in resharding. ([#14185](https://github.com/near/nearcore/pull/14185))
+* Added a neard subcommand tool that can be used to recover data that was lost due to bug in resharding. ([#14185](https://github.com/near/nearcore/pull/14185))
+* Fix an issue in the state snapshot migration, specifically when the hot database path is an absolute path.
 
 ## [2.7.1]
 

--- a/chain/chain/src/runtime/test_utils.rs
+++ b/chain/chain/src/runtime/test_utils.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use near_chain_configs::{DEFAULT_GC_NUM_EPOCHS_TO_KEEP, GenesisConfig};
 use near_epoch_manager::EpochManagerHandle;
 use near_parameters::RuntimeConfigStore;
-use near_store::config::STATE_SNAPSHOT_DIR;
 use near_store::{StateSnapshotConfig, Store, TrieConfig};
 use near_vm_runner::{ContractRuntimeCache, FilesystemContractRuntimeCache};
 
@@ -29,7 +28,7 @@ impl NightshadeRuntime {
             Some(runtime_config_store),
             DEFAULT_GC_NUM_EPOCHS_TO_KEEP,
             Default::default(),
-            StateSnapshotConfig::enabled(home_dir, "data", STATE_SNAPSHOT_DIR),
+            StateSnapshotConfig::enabled(home_dir.join("data")),
         )
     }
 
@@ -53,7 +52,7 @@ impl NightshadeRuntime {
             runtime_config_store,
             gc_num_epochs_to_keep,
             trie_config,
-            StateSnapshotConfig::enabled(home_dir, "data", STATE_SNAPSHOT_DIR),
+            StateSnapshotConfig::enabled(home_dir.join("data")),
         )
     }
 

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -137,7 +137,7 @@ impl TestEnv {
             Some(runtime_config_store),
             DEFAULT_GC_NUM_EPOCHS_TO_KEEP,
             Default::default(),
-            StateSnapshotConfig::enabled(dir.path(), "data", "state_snapshot"),
+            StateSnapshotConfig::enabled(dir.path().join("data")),
         );
         let state_roots = get_genesis_state_roots(&store).unwrap().unwrap();
         let genesis_hash = hash(&[0]);

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -10,8 +10,6 @@ use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_time::Duration;
 use std::{collections::HashMap, str::FromStr};
 
-pub const STATE_SNAPSHOT_DIR: &str = "state_snapshot";
-
 // known cache access patterns per prominent contract account
 // used to derive config `per_account_max_bytes`
 const PER_ACCOUNT_CACHE_SIZE: &[(&'static str, bytesize::ByteSize)] = &[
@@ -119,6 +117,11 @@ pub struct StoreConfig {
 }
 
 impl StoreConfig {
+    /// StoreConfig used for state snapshot database.
+    pub fn state_snapshot_store_config() -> Self {
+        Self::default()
+    }
+
     pub fn enable_state_snapshot(&mut self) {
         self.state_snapshot_config.state_snapshot_type = StateSnapshotType::Enabled;
     }

--- a/core/store/src/node_storage/opener.rs
+++ b/core/store/src/node_storage/opener.rs
@@ -1,8 +1,10 @@
-use crate::config::{ArchivalConfig, STATE_SNAPSHOT_DIR, StateSnapshotType};
+use crate::config::{ArchivalConfig, StateSnapshotType};
 use crate::db::rocksdb::RocksDB;
 use crate::db::rocksdb::snapshot::{Snapshot, SnapshotError, SnapshotRemoveError};
 use crate::metadata::{DB_VERSION, DbKind, DbMetadata, DbVersion};
-use crate::{DBCol, DBTransaction, Mode, NodeStorage, Store, StoreConfig, Temperature};
+use crate::{
+    DBCol, DBTransaction, Mode, NodeStorage, StateSnapshotConfig, Store, StoreConfig, Temperature,
+};
 use std::sync::Arc;
 
 #[derive(Debug, thiserror::Error)]
@@ -279,7 +281,11 @@ impl<'a> StoreOpener<'a> {
         }
 
         let state_snapshots_dir = match self.hot.config.state_snapshot_config.state_snapshot_type {
-            StateSnapshotType::Enabled => self.hot.path.join(STATE_SNAPSHOT_DIR),
+            StateSnapshotType::Enabled => {
+                // At this point, the self.hot.path was built from home_dir and store_config.path.
+                let config = StateSnapshotConfig::enabled(&self.hot.path);
+                config.state_snapshots_dir().unwrap().to_path_buf()
+            }
             StateSnapshotType::Disabled => {
                 tracing::debug!(target: "db_opener", "State snapshots are disabled, skipping state snapshots migration");
                 return Ok(());
@@ -295,6 +301,7 @@ impl<'a> StoreOpener<'a> {
             return Ok(());
         }
 
+        let config = StoreConfig::state_snapshot_store_config();
         for entry in std::fs::read_dir(state_snapshots_dir)? {
             let entry = entry?;
             let snapshot_path = entry.path();
@@ -307,7 +314,7 @@ impl<'a> StoreOpener<'a> {
                 continue;
             }
 
-            let opener = NodeStorage::opener(&snapshot_path, &self.hot.config, None)
+            let opener = NodeStorage::opener(&snapshot_path, &config, None)
                 .with_migrator(self.migrator.unwrap());
             let _ = opener.open_in_mode(Mode::ReadWrite)?;
         }
@@ -680,8 +687,8 @@ pub fn checkpoint_hot_storage_and_cleanup_columns(
         .map_err(StoreOpenerError::CheckpointError)?;
 
     // As only path from config is used in StoreOpener, default config with custom path will do.
-    let mut config = StoreConfig::default();
-    config.path = Some(checkpoint_path);
+    let config =
+        StoreConfig { path: Some(checkpoint_path), ..StoreConfig::state_snapshot_store_config() };
     let opener = NodeStorage::opener(checkpoint_base_path, &config, None);
     // This will create all the column families that were dropped by create_checkpoint(),
     // but all the data and associated files that were in them previously should be gone.

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -10,7 +10,7 @@ pub use crate::trie::nibble_slice::NibbleSlice;
 pub use crate::trie::prefetching_trie_storage::{PrefetchApi, PrefetchError};
 pub use crate::trie::shard_tries::{KeyForStateChanges, ShardTries, WrappedTrieChanges};
 pub use crate::trie::state_snapshot::{
-    STATE_SNAPSHOT_COLUMNS, SnapshotError, StateSnapshot, StateSnapshotConfig, state_snapshots_dir,
+    STATE_SNAPSHOT_COLUMNS, SnapshotError, StateSnapshot, StateSnapshotConfig,
 };
 pub use crate::trie::trie_storage::{TrieCache, TrieCachingStorage, TrieDBStorage, TrieStorage};
 use borsh::{BorshDeserialize, BorshSerialize};

--- a/core/store/src/trie/state_snapshot.rs
+++ b/core/store/src/trie/state_snapshot.rs
@@ -137,29 +137,15 @@ pub enum StateSnapshotConfig {
     Enabled { state_snapshots_dir: PathBuf },
 }
 
-pub fn state_snapshots_dir(
-    home_dir: impl AsRef<Path>,
-    hot_store_path: impl AsRef<Path>,
-    state_snapshots_subdir: impl AsRef<Path>,
-) -> PathBuf {
-    home_dir.as_ref().join(hot_store_path).join(state_snapshots_subdir)
-}
-
 impl StateSnapshotConfig {
-    pub fn enabled(
-        home_dir: impl AsRef<Path>,
-        hot_store_path: impl AsRef<Path>,
-        state_snapshots_subdir: impl AsRef<Path>,
-    ) -> Self {
+    const STATE_SNAPSHOT_DIR: &str = "state_snapshot";
+
+    pub fn enabled(hot_store_path: impl AsRef<Path>) -> Self {
         // Assumptions:
         // * RocksDB checkpoints are taken instantly and for free, because the filesystem supports hard links.
         // * The best place for checkpoints is within the `hot_store_path`, because that directory is often a separate disk.
         Self::Enabled {
-            state_snapshots_dir: state_snapshots_dir(
-                home_dir,
-                hot_store_path,
-                state_snapshots_subdir,
-            ),
+            state_snapshots_dir: hot_store_path.as_ref().join(Self::STATE_SNAPSHOT_DIR),
         }
     }
 
@@ -379,7 +365,7 @@ impl ShardTries {
             .ok_or_else(|| anyhow::anyhow!("{snapshot_path:?} needs to have a parent dir"))?;
         tracing::debug!(target: "state_snapshot", ?snapshot_path, ?parent_path);
 
-        let store_config = StoreConfig::default();
+        let store_config = StoreConfig::state_snapshot_store_config();
 
         let opener = NodeStorage::opener(&snapshot_path, &store_config, None);
         let storage = opener.open_in_mode(Mode::ReadOnly)?;

--- a/integration-tests/src/tests/client/state_snapshot.rs
+++ b/integration-tests/src/tests/client/state_snapshot.rs
@@ -10,9 +10,8 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::transaction::SignedTransaction;
 use near_store::adapter::StoreAdapter;
-use near_store::config::{STATE_SNAPSHOT_DIR, StateSnapshotType};
+use near_store::config::StateSnapshotType;
 use near_store::flat::FlatStorageManager;
-use near_store::trie::state_snapshots_dir;
 use near_store::{
     Mode, ShardTries, StateSnapshotConfig, StoreConfig, TrieConfig, config::TrieCacheConfig,
     test_utils::create_test_store,
@@ -61,11 +60,10 @@ fn set_up_test_env_for_state_snapshots(
 ) -> StateSnapshotTestEnv {
     let home_dir =
         tempfile::Builder::new().prefix("storage").tempdir().unwrap().path().to_path_buf();
-    let state_snapshots_dir = state_snapshots_dir(&home_dir, "data", STATE_SNAPSHOT_DIR);
+    let enabled_state_snapshot_config = StateSnapshotConfig::enabled(home_dir.join("data"));
+    let state_snapshots_dir = enabled_state_snapshot_config.state_snapshots_dir().unwrap().into();
     let state_snapshot_config = match snapshot_type {
-        StateSnapshotType::Enabled => {
-            StateSnapshotConfig::Enabled { state_snapshots_dir: state_snapshots_dir.clone() }
-        }
+        StateSnapshotType::Enabled => enabled_state_snapshot_config,
         StateSnapshotType::Disabled => StateSnapshotConfig::Disabled,
     };
 

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -52,7 +52,7 @@ use near_primitives::version::PROTOCOL_VERSION;
 #[cfg(feature = "rosetta_rpc")]
 use near_rosetta_rpc::RosettaRpcConfig;
 use near_store::config::{
-    ArchivalConfig, ArchivalStoreConfig, STATE_SNAPSHOT_DIR, SplitStorageConfig, StateSnapshotType,
+    ArchivalConfig, ArchivalStoreConfig, SplitStorageConfig, StateSnapshotType,
 };
 use near_store::{StateSnapshotConfig, Store, TrieConfig};
 use near_telemetry::TelemetryConfig;
@@ -699,9 +699,7 @@ impl NightshadeRuntime {
         let state_snapshot_config =
             match config.config.store.state_snapshot_config.state_snapshot_type {
                 StateSnapshotType::Enabled => StateSnapshotConfig::enabled(
-                    home_dir,
-                    config.config.store.path.as_ref().unwrap_or(&"data".into()),
-                    STATE_SNAPSHOT_DIR,
+                    home_dir.join(config.config.store.path.as_ref().unwrap_or(&"data".into())),
                 ),
                 StateSnapshotType::Disabled => StateSnapshotConfig::Disabled,
             };


### PR DESCRIPTION
Fix state snapshot migration infinite recustion when using absolute `store.path`.

The fix is in the first commit.
The other commits are for refactoring.
In the refactoring I aim to standardize the way we build the path for snapshots.