### PR TITLE
perf: optimize storage accesses during tx preparation

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -753,24 +753,18 @@ impl RuntimeAdapter for NightshadeRuntime {
                     assert_eq!(validated_tx.signer_id(), id);
                     (signer, key)
                 } else {
-                    let (signer_result, access_key_result) = rayon::join(
-                        || {
-                            get_account(&state_update, validated_tx.signer_id())
-                                .transpose()
-                                .and_then(|v| v.ok())
-                                .ok_or(Error::InvalidTransactions)
-                        },
-                        || {
-                            get_access_key(
-                                &state_update,
-                                validated_tx.signer_id(),
-                                validated_tx.public_key(),
-                            )
-                            .transpose()
-                            .and_then(|v| v.ok())
-                            .ok_or(Error::InvalidTransactions)
-                        },
-                    );
+                    let signer_result = get_account(&state_update, validated_tx.signer_id())
+                        .transpose()
+                        .and_then(|v| v.ok())
+                        .ok_or(Error::InvalidTransactions);
+                    let access_key_result = get_access_key(
+                        &state_update,
+                        validated_tx.signer_id(),
+                        validated_tx.public_key(),
+                    )
+                    .transpose()
+                    .and_then(|v| v.ok())
+                    .ok_or(Error::InvalidTransactions);
                     let inserted = signer_access_key.insert((
                         validated_tx.signer_id().clone(),
                         signer_result?,

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -47,7 +47,8 @@ use node_runtime::adapter::ViewRuntimeAdapter;
 use node_runtime::config::tx_cost;
 use node_runtime::state_viewer::{TrieViewer, ViewApplyState};
 use node_runtime::{
-    get_signer_and_access_key, validate_transaction, verify_and_charge_tx_ephemeral, ApplyState, Runtime, SignedValidPeriodTransactions, ValidatorAccountsUpdate
+    ApplyState, Runtime, SignedValidPeriodTransactions, ValidatorAccountsUpdate,
+    get_signer_and_access_key, validate_transaction, verify_and_charge_tx_ephemeral,
 };
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -142,7 +142,7 @@ pub fn set_tx_state_changes(
 }
 
 pub fn get_signer_and_access_key(
-    state_update: &TrieUpdate,
+    state_update: &dyn near_store::TrieAccess,
     validated_tx: &ValidatedTransaction,
 ) -> Result<(Account, AccessKey), InvalidTxError> {
     let signer_id = validated_tx.signer_id();


### PR DESCRIPTION
Unfortunately the throughput (with or without rayon) turned out to be within the error margin, so I chose to only keep mild refactors that are obviously reducing the work done:

* Only load access key and account once per group (which is grouped by account + access key);
  * This isn't particularly useful in the benchmark where most groups have just one transaction each, but should help other workloads;
* Don't bother committing or rolling back the `TrieUpdate`;
  * This was necessary in the past, but now `verify_and_charge_tx_ephemeral` only modifies the passed in account and access key if the transaction verifies (these TrieUpdate operations were relatively prominent in the profiles.)