### PR TITLE
feat(sync): avoid reapplying state parts

### DIFF
--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -1017,6 +1017,7 @@ impl<'a> ChainStoreUpdate<'a> {
         for part_id in 0..num_parts {
             let key = borsh::to_vec(&StatePartKey(sync_hash, shard_id, part_id))?;
             self.gc_col(DBCol::StateParts, &key);
+            self.gc_col(DBCol::StatePartsApplied, &key);
         }
         Ok(())
     }

--- a/chain/chain/src/garbage_collection.rs
+++ b/chain/chain/src/garbage_collection.rs
@@ -1108,7 +1108,7 @@ impl<'a> ChainStoreUpdate<'a> {
             DBCol::ChunkHashesByHeight => {
                 store_update.delete(col, key);
             }
-            DBCol::StateParts => {
+            DBCol::StateParts | DBCol::StatePartsApplied => {
                 store_update.delete(col, key);
             }
             DBCol::State => {

--- a/chain/client/src/sync/state/shard.rs
+++ b/chain/client/src/sync/state/shard.rs
@@ -266,7 +266,7 @@ fn create_flat_storage_for_shard(
 #[derive(Debug, PartialEq, Eq)]
 pub enum StatePartApplyResult {
     Applied,
-    Skipped,
+    AlreadyApplied,
 }
 
 async fn apply_state_part(
@@ -287,10 +287,7 @@ async fn apply_state_part(
     let already_applied = store.exists(DBCol::StatePartsApplied, &key_bytes)?;
     if already_applied {
         tracing::debug!(target: "sync", ?key, "State part already applied, skipping");
-        if key.1 == ShardId::new(3) && key.2 == 0 {
-            tracing::debug!(target: "sync", ?key, "Applied state part xxx");
-        }
-        return Ok(StatePartApplyResult::Skipped);
+        return Ok(StatePartApplyResult::AlreadyApplied);
     }
     return_if_cancelled!(cancel);
     let handle =
@@ -315,9 +312,6 @@ async fn apply_state_part(
         &state_part,
         &epoch_id,
     )?;
-    if key.1 == ShardId::new(3) && key.2 == 0 {
-        tracing::debug!(target: "sync", ?key, "Applied state part xxx");
-    }
     tracing::debug!(target: "sync", ?key, "Applied state part");
 
     // Mark part as applied.
@@ -432,6 +426,6 @@ mod tests {
         .unwrap();
 
         // Should be skipped
-        assert_eq!(result, StatePartApplyResult::Skipped);
+        assert_eq!(result, StatePartApplyResult::AlreadyApplied);
     }
 }

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -118,6 +118,10 @@ pub enum DBCol {
     /// - *Rows*: StatePartKey (BlockHash || ShardId || PartId (u64))
     /// - *Content type*: state part (bytes)
     StateParts,
+    /// Contains information about which state parts we've applied.
+    /// - *Rows*: StatePartKey (BlockHash || ShardId || PartId (u64))
+    /// - *Content type*: bool (just a marker that we've applied this part)
+    StatePartsApplied,
     /// Contains mapping from epoch_id to epoch start (first block height of the epoch)
     /// - *Rows*: EpochId (CryptoHash)  -- TODO: where does the epoch_id come from? it looks like blockHash..
     /// - *Content type*: BlockHeight (int)
@@ -528,8 +532,8 @@ impl DBCol {
             DBCol::BlockRefCount => false,
             // InvalidChunks is only needed at head when accepting new chunks.
             DBCol::InvalidChunks => false,
-            // StateParts is only needed while syncing.
-            DBCol::StateParts => false,
+            // StateParts, StatePartsApplied is only needed while syncing.
+            DBCol::StateParts | DBCol::StatePartsApplied => false,
             // TrieChanges is only needed for GC.
             DBCol::TrieChanges => false,
             // StateDlInfos is only needed when syncing and it is not immutable.
@@ -616,7 +620,9 @@ impl DBCol {
             DBCol::InvalidChunks => &[DBKeyType::ChunkHash],
             DBCol::_BlockExtra => &[DBKeyType::BlockHash],
             DBCol::BlockPerHeight => &[DBKeyType::BlockHeight],
-            DBCol::StateParts => &[DBKeyType::BlockHash, DBKeyType::ShardId, DBKeyType::PartId],
+            DBCol::StateParts | DBCol::StatePartsApplied => {
+                &[DBKeyType::BlockHash, DBKeyType::ShardId, DBKeyType::PartId]
+            }
             DBCol::EpochStart => &[DBKeyType::EpochId],
             DBCol::AccountAnnouncements => &[DBKeyType::AccountId],
             DBCol::NextBlockHashes => &[DBKeyType::PreviousBlockHash],


### PR DESCRIPTION
Prior to this change it's possible for state parts to be re-applied if state sync is interrupted at that stage.
This PR introduces a new DB column to track which state parts are applied to avoid this issue.

Additionally, it will avoid deleting the flat storage if any parts are applied and avoid recreating the flat storage if it was already completed.

https://github.com/near/nearcore/issues/14032