### PR TITLE
feat(cloud_archival): `CloudArchivalConfig`

### DIFF
--- a/chain/client/src/archive/cold_store_actor.rs
+++ b/chain/client/src/archive/cold_store_actor.rs
@@ -132,7 +132,7 @@ impl ColdStoreActor {
         shard_tracker: ShardTracker,
         keep_going: Arc<AtomicBool>,
     ) -> Self {
-        debug_assert!(shard_tracker.is_valid_for_archival());
+        debug_assert!(shard_tracker.is_valid_for_cold_store());
         ColdStoreActor {
             split_storage_config,
             genesis_height,
@@ -437,7 +437,7 @@ pub fn create_cold_store_actor(
     let hot_tail_height = hot_store.chain_store().tail().unwrap_or(genesis_height);
 
     sanity_check(cold_head_height, hot_final_head_height, hot_tail_height)?;
-    debug_assert!(shard_tracker.is_valid_for_archival());
+    debug_assert!(shard_tracker.is_valid_for_cold_store());
 
     tracing::info!(target : "cold_store", "Creating the cold store actor");
 

--- a/chain/client/src/gc_actor.rs
+++ b/chain/client/src/gc_actor.rs
@@ -57,11 +57,6 @@ impl GCActor {
                 &self.shard_tracker,
             );
         }
-        // The ReshardingV3 mapping for archival nodes (#12578) was built under the assumption that
-        // once we start tracking a shard, we continue tracking all of its descendant shards.
-        // If this ever changes and this assertion needs to be removed, please make sure to
-        // properly handle the State Mapping.
-        debug_assert!(self.shard_tracker.is_valid_for_archival());
 
         // An archival node with split storage should perform garbage collection
         // on the hot storage. In order to determine if split storage is enabled

--- a/chain/epoch-manager/src/shard_tracker.rs
+++ b/chain/epoch-manager/src/shard_tracker.rs
@@ -285,16 +285,11 @@ impl ShardTracker {
         self.tracked_shards_config.tracks_all_shards()
     }
 
-    /// Returns whether the tracker configuration is valid for an archival node.
-    pub fn is_valid_for_archival(&self) -> bool {
-        match &self.tracked_shards_config {
-            TrackedShardsConfig::AllShards => true,
-            TrackedShardsConfig::Shards(shards) => !shards.is_empty(),
-            // `Accounts` config is likely to work as well,
-            // but this hasn't been fully tested or verified yet.
-            // Consider enabling support after proper validation.
-            _ => false,
-        }
+    /// Returns whether the tracker configuration is valid for cold store. Currently it is only valid if it
+    /// tracks given non-empty subset of shards. Tracking based on `Accounts` is likely to work as well, but
+    /// this hasn't been fully tested or verified yet. Consider enabling support after proper validation.
+    pub fn is_valid_for_cold_store(&self) -> bool {
+        self.tracked_shards_config.tracks_non_empty_subset_of_shards()
     }
 
     /// We want to guarantee that transactions are only applied once for each shard,

--- a/chain/jsonrpc/openapi/openapi.json
+++ b/chain/jsonrpc/openapi/openapi.json
@@ -3067,6 +3067,87 @@
         ],
         "type": "object"
       },
+      "CloudArchivalConfig": {
+        "description": "Configures cloud-based archival node.",
+        "properties": {
+          "archival_writer": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CloudArchivalWriterConfig"
+              },
+              {
+                "enum": [
+                  null
+                ],
+                "nullable": true
+              }
+            ],
+            "description": "Indicates whether the node is expected to write data to the cloud archival storage."
+          },
+          "cloud_storage": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CloudStorageConfig"
+              }
+            ],
+            "description": "Configures the external storage used by the archival node."
+          },
+          "is_archival_reader": {
+            "description": "Indicates whether the node acts as a cloud archival data reader.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "cloud_storage",
+          "is_archival_reader"
+        ],
+        "type": "object"
+      },
+      "CloudArchivalWriterConfig": {
+        "description": "Configuration for a cloud-based archival writer.",
+        "properties": {
+          "archive_block_data": {
+            "default": false,
+            "description": "Determines whether block-related data should be written to cloud storage.",
+            "type": "boolean"
+          },
+          "pooling_interval": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DurationAsStdSchemaProvider"
+              }
+            ],
+            "default": {
+              "nanos": 0,
+              "secs": 1
+            },
+            "description": "Interval at which the system checks for new blocks or chunks to archive."
+          }
+        },
+        "type": "object"
+      },
+      "CloudStorageConfig": {
+        "description": "Configures the external storage used by the archival node.",
+        "properties": {
+          "credentials_file": {
+            "description": "Location of a json file with credentials allowing write access to the bucket.",
+            "nullable": true,
+            "type": "string"
+          },
+          "storage": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExternalStorageLocation"
+              }
+            ],
+            "description": "The storage to persist the archival data."
+          }
+        },
+        "required": [
+          "storage"
+        ],
+        "type": "object"
+      },
       "CompilationError": {
         "oneOf": [
           {
@@ -9635,6 +9716,20 @@
             "format": "uint",
             "minimum": 0,
             "type": "integer"
+          },
+          "cloud_archival": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CloudArchivalConfig"
+              },
+              {
+                "enum": [
+                  null
+                ],
+                "nullable": true
+              }
+            ],
+            "description": "Configuration for a cloud-based archival node."
           },
           "doomslug_step_period": {
             "description": "Time between running doomslug timer.",

--- a/chain/jsonrpc/openapi/openapi.json
+++ b/chain/jsonrpc/openapi/openapi.json
@@ -3067,22 +3067,30 @@
         ],
         "type": "object"
       },
-      "CloudArchivalConfig": {
-        "description": "Configures cloud-based archival node.",
+      "CloudArchivalReaderConfig": {
+        "description": "Configuration for a cloud-based archival reader.",
         "properties": {
-          "archival_writer": {
-            "anyOf": [
+          "cloud_storage": {
+            "allOf": [
               {
-                "$ref": "#/components/schemas/CloudArchivalWriterConfig"
-              },
-              {
-                "enum": [
-                  null
-                ],
-                "nullable": true
+                "$ref": "#/components/schemas/CloudStorageConfig"
               }
             ],
-            "description": "Indicates whether the node is expected to write data to the cloud archival storage."
+            "description": "Configures the external storage used by the archival node."
+          }
+        },
+        "required": [
+          "cloud_storage"
+        ],
+        "type": "object"
+      },
+      "CloudArchivalWriterConfig": {
+        "description": "Configuration for a cloud-based archival writer. If this config is present, the writer is enabled and\nwrites chunk-related data based on the tracked shards. This config also controls additional archival\nbehavior such as block data and polling interval.",
+        "properties": {
+          "archive_block_data": {
+            "default": false,
+            "description": "Determines whether block-related data should be written to cloud storage.",
+            "type": "boolean"
           },
           "cloud_storage": {
             "allOf": [
@@ -3092,26 +3100,7 @@
             ],
             "description": "Configures the external storage used by the archival node."
           },
-          "is_archival_reader": {
-            "description": "Indicates whether the node acts as a cloud archival data reader.",
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "cloud_storage",
-          "is_archival_reader"
-        ],
-        "type": "object"
-      },
-      "CloudArchivalWriterConfig": {
-        "description": "Configuration for a cloud-based archival writer.",
-        "properties": {
-          "archive_block_data": {
-            "default": false,
-            "description": "Determines whether block-related data should be written to cloud storage.",
-            "type": "boolean"
-          },
-          "pooling_interval": {
+          "polling_interval": {
             "allOf": [
               {
                 "$ref": "#/components/schemas/DurationAsStdSchemaProvider"
@@ -3124,13 +3113,16 @@
             "description": "Interval at which the system checks for new blocks or chunks to archive."
           }
         },
+        "required": [
+          "cloud_storage"
+        ],
         "type": "object"
       },
       "CloudStorageConfig": {
         "description": "Configures the external storage used by the archival node.",
         "properties": {
           "credentials_file": {
-            "description": "Location of a json file with credentials allowing write access to the bucket.",
+            "description": "Location of a json file with credentials allowing access to the bucket.",
             "nullable": true,
             "type": "string"
           },
@@ -3699,7 +3691,7 @@
         "description": "Configures how to dump state to external storage.",
         "properties": {
           "credentials_file": {
-            "description": "Location of a json file with credentials allowing write access to the bucket.",
+            "description": "Location of a json file with credentials allowing access to the bucket.",
             "nullable": true,
             "type": "string"
           },
@@ -9717,10 +9709,10 @@
             "minimum": 0,
             "type": "integer"
           },
-          "cloud_archival": {
+          "cloud_archival_reader": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/CloudArchivalConfig"
+                "$ref": "#/components/schemas/CloudArchivalReaderConfig"
               },
               {
                 "enum": [
@@ -9729,7 +9721,21 @@
                 "nullable": true
               }
             ],
-            "description": "Configuration for a cloud-based archival node."
+            "description": "Configuration for a cloud-based archival reader."
+          },
+          "cloud_archival_writer": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CloudArchivalWriterConfig"
+              },
+              {
+                "enum": [
+                  null
+                ],
+                "nullable": true
+              }
+            ],
+            "description": "Configuration for a cloud-based archival writer. If this config is present, the writer is enabled and\nwrites chunk-related data based on the tracked shards."
           },
           "doomslug_step_period": {
             "description": "Time between running doomslug timer.",

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -224,7 +224,7 @@ fn default_state_parts_compression_level() -> i32 {
     DEFAULT_STATE_PARTS_COMPRESSION_LEVEL
 }
 
-/// Configures the external storage used by archival node.
+/// Configures the external storage used by the archival node.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CloudStorageConfig {
@@ -239,11 +239,11 @@ pub struct CloudStorageConfig {
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CloudArchivalConfig {
-    /// Configures the external storage used by archival node.
+    /// Configures the external storage used by the archival node.
     pub cloud_storage: CloudStorageConfig,
-    /// Whether the node acts as cloud archival data reader. In such a case it is supposed to have cold store
-    /// and RPC enabled.
+    /// Indicates whether the node acts as a cloud archival data reader.
     pub is_archival_reader: bool,
+    /// Indicates whether the node is expected to write data to the cloud archival storage.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub archival_writer: Option<CloudArchivalWriterConfig>,
 }
@@ -252,14 +252,15 @@ fn default_archival_writer_pooling_interval() -> Duration {
     Duration::seconds(1)
 }
 
-/// Configures cloud-based archival writer.
+/// Configuration for a cloud-based archival writer.
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CloudArchivalWriterConfig {
+    /// Determines whether block-related data should be written to cloud storage.
     #[serde(default)]
     pub archive_block_data: bool,
 
-    /// How often to check if there are new blocks/chunks to archive.
+    /// Interval at which the system checks for new blocks or chunks to archive.
     #[serde(with = "near_time::serde_duration_as_std")]
     #[cfg_attr(feature = "schemars", schemars(with = "DurationAsStdSchemaProvider"))]
     #[serde(default = "default_archival_writer_pooling_interval")]
@@ -810,7 +811,7 @@ pub struct ClientConfig {
     pub state_sync_enabled: bool,
     /// Options for syncing state.
     pub state_sync: StateSyncConfig,
-    /// Configuration for cloud-based archival node.
+    /// Configuration for a cloud-based archival node.
     pub cloud_archival: Option<CloudArchivalConfig>,
     /// Options for epoch sync.
     pub epoch_sync: EpochSyncConfig,

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -207,7 +207,7 @@ pub struct ExternalStorageConfig {
     pub external_storage_fallback_threshold: u64,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum ExternalStorageLocation {
     S3 {
@@ -229,7 +229,7 @@ fn default_state_parts_compression_level() -> i32 {
 }
 
 /// Configures the external storage used by the archival node.
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct CloudStorageConfig {
     /// The storage to persist the archival data.

--- a/core/chain-configs/src/lib.rs
+++ b/core/chain-configs/src/lib.rs
@@ -10,9 +10,9 @@ pub mod test_utils;
 mod updatable_config;
 
 pub use client_config::{
-    ChunkDistributionNetworkConfig, ChunkDistributionUris, ClientConfig, CloudArchivalConfig,
-    CloudStorageConfig, DEFAULT_GC_NUM_EPOCHS_TO_KEEP, DEFAULT_STATE_PARTS_COMPRESSION_LEVEL,
-    DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_EXTERNAL,
+    ChunkDistributionNetworkConfig, ChunkDistributionUris, ClientConfig, CloudArchivalReaderConfig,
+    CloudArchivalWriterConfig, CloudStorageConfig, DEFAULT_GC_NUM_EPOCHS_TO_KEEP,
+    DEFAULT_STATE_PARTS_COMPRESSION_LEVEL, DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_EXTERNAL,
     DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_ON_CATCHUP_EXTERNAL, DumpConfig, EpochSyncConfig,
     ExternalStorageConfig, ExternalStorageLocation, GCConfig, LogSummaryStyle,
     MIN_GC_NUM_EPOCHS_TO_KEEP, ProtocolVersionCheckConfig, ReshardingConfig, ReshardingHandle,

--- a/core/chain-configs/src/lib.rs
+++ b/core/chain-configs/src/lib.rs
@@ -10,8 +10,8 @@ pub mod test_utils;
 mod updatable_config;
 
 pub use client_config::{
-    ChunkDistributionNetworkConfig, ChunkDistributionUris, ClientConfig,
-    DEFAULT_GC_NUM_EPOCHS_TO_KEEP, DEFAULT_STATE_PARTS_COMPRESSION_LEVEL,
+    ChunkDistributionNetworkConfig, ChunkDistributionUris, ClientConfig, CloudArchivalConfig,
+    CloudStorageConfig, DEFAULT_GC_NUM_EPOCHS_TO_KEEP, DEFAULT_STATE_PARTS_COMPRESSION_LEVEL,
     DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_EXTERNAL,
     DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_ON_CATCHUP_EXTERNAL, DumpConfig, EpochSyncConfig,
     ExternalStorageConfig, ExternalStorageLocation, GCConfig, LogSummaryStyle,

--- a/core/store/src/archive/cloud_storage.rs
+++ b/core/store/src/archive/cloud_storage.rs
@@ -2,10 +2,10 @@ use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use near_chain_configs::CloudStorageConfig;
 use near_primitives::types::BlockHeight;
 
 use crate::Store;
-use crate::config::CloudStorageConfig;
 
 /// Represents the external storage for archival data.
 pub struct CloudStorage;

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -665,30 +665,6 @@ pub struct PrefetchConfig {
     pub method_name: String,
 }
 
-/// Configures the external storage used by the archival nodes.
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-pub struct CloudStorageConfig {
-    /// The storage to persist the archival data.
-    pub storage: CloudStorageLocation,
-}
-
-// TODO(cloud_archival) Implement these options. Consider replacing this with `ExternalStorageLocation`.
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-pub enum CloudStorageLocation {
-    /// Archival data is persisted in the filesystem.
-    /// NOTE: This option not implemented yet.
-    Filesystem {
-        /// Root directory containing the archival storage files.
-        _path: std::path::PathBuf,
-    },
-    /// Archival data is persisted in the Google Cloud Storage.
-    /// NOTE: This option not implemented yet.
-    GCS {
-        /// GCS bucket containing the archival storage objects.
-        _bucket: String,
-    },
-}
-
 #[cfg(test)]
 mod tests {
     use super::{RocksDbConfig, StoreConfig};

--- a/core/store/src/node_storage/mod.rs
+++ b/core/store/src/node_storage/mod.rs
@@ -1,9 +1,9 @@
 pub(super) mod opener;
 
 use crate::archive::cloud_storage::CloudStorage;
-use crate::config::CloudStorageConfig;
 use crate::db::{Database, SplitDB, metadata};
 use crate::{Store, StoreConfig};
+use near_chain_configs::CloudStorageConfig;
 use opener::StoreOpener;
 use std::io;
 use std::str::FromStr;

--- a/core/store/src/node_storage/opener.rs
+++ b/core/store/src/node_storage/opener.rs
@@ -1,5 +1,7 @@
+use near_chain_configs::CloudStorageConfig;
+
 use crate::archive::cloud_storage::CloudStorageOpener;
-use crate::config::{CloudStorageConfig, StateSnapshotType};
+use crate::config::StateSnapshotType;
 use crate::db::rocksdb::RocksDB;
 use crate::db::rocksdb::snapshot::{Snapshot, SnapshotError, SnapshotRemoveError};
 use crate::metadata::{DB_VERSION, DbKind, DbMetadata, DbVersion};

--- a/genesis-tools/genesis-populate/src/main.rs
+++ b/genesis-tools/genesis-populate/src/main.rs
@@ -39,7 +39,7 @@ fn main() {
         home_dir,
         &near_config.config.store,
         near_config.config.cold_store.as_ref(),
-        near_config.config.cloud_storage.as_ref(),
+        near_config.config.cloud_storage_config(),
     )
     .open()
     .unwrap()

--- a/nearcore/benches/store.rs
+++ b/nearcore/benches/store.rs
@@ -30,7 +30,7 @@ fn read_trie_items(bench: &mut Bencher, shard_index: ShardIndex, shard_id: Shard
             &home_dir,
             &near_config.config.store,
             near_config.config.cold_store.as_ref(),
-            near_config.config.cloud_storage.as_ref(),
+            near_config.config.cloud_storage_config(),
         )
         .open_in_mode(mode)
         .unwrap()

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -333,7 +333,7 @@ pub struct Config {
     /// Options for syncing state.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state_sync: Option<StateSyncConfig>,
-    /// Configuration for cloud-based archival node.
+    /// Configuration for a cloud-based archival node.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cloud_archival: Option<CloudArchivalConfig>,
     /// Options for epoch sync

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -606,16 +606,22 @@ impl Config {
         )
     }
 
-    /// Returns the cloud storage config.
-    ///
-    /// Writer bucket access is at least as strong as reader access, so if the node is configured as both a
-    /// writer and a reader, the writer's config is returned.
+    /// Returns the cloud storage config. Checks if configs are equal if both cloud archival reader and
+    /// writers are enabled.
     pub fn cloud_storage_config(&self) -> Option<&CloudStorageConfig> {
-        if let Some(cloud_archival_writer) = &self.cloud_archival_writer {
-            return Some(&cloud_archival_writer.cloud_storage);
+        if let (Some(reader), Some(writer)) =
+            (&self.cloud_archival_reader, &self.cloud_archival_writer)
+        {
+            assert_eq!(
+                reader.cloud_storage, writer.cloud_storage,
+                "Cloud archival reader and writer storage configs are not equal."
+            );
         }
-        if let Some(cloud_archival_reader) = &self.cloud_archival_reader {
-            return Some(&cloud_archival_reader.cloud_storage);
+        if let Some(reader) = &self.cloud_archival_reader {
+            return Some(&reader.cloud_storage);
+        }
+        if let Some(writer) = &self.cloud_archival_writer {
+            return Some(&writer.cloud_storage);
         }
         None
     }

--- a/nearcore/src/config_validate.rs
+++ b/nearcore/src/config_validate.rs
@@ -247,7 +247,8 @@ impl<'a> ConfigValidator<'a> {
         let tracked_shards = self.config.tracked_shards_config();
         if cloud_archival.is_archival_reader && !tracked_shards.tracks_all_shards() {
             let error_message =
-                "`cloud_archival` is configured in reader mode, but it does not track all shards.".to_string();
+                "`cloud_archival` is configured in reader mode, but it does not track all shards."
+                    .to_string();
             self.validation_errors.push_config_semantics_error(error_message);
         }
 

--- a/nearcore/src/config_validate.rs
+++ b/nearcore/src/config_validate.rs
@@ -234,20 +234,20 @@ impl<'a> ConfigValidator<'a> {
         }
         if cloud_archival.is_archival_reader && self.config.cold_store.is_none() {
             let error_message =
-                "`cloud_archival` is configured in the reader node but `cold_store` is missing."
+                "`cloud_archival` is configured in reader mode, but `cold_store` is missing."
                     .to_string();
             self.validation_errors.push_config_semantics_error(error_message);
         }
         if !cloud_archival.is_archival_reader && self.config.rpc.is_some() {
             let error_message =
-                "`cloud_archival` isn't configured in the reader node but `rpc` is enabled."
+                "`cloud_archival` is not configured in reader mode, yet `rpc` is enabled."
                     .to_string();
             self.validation_errors.push_config_semantics_error(error_message);
         }
         let tracked_shards = self.config.tracked_shards_config();
         if cloud_archival.is_archival_reader && !tracked_shards.tracks_all_shards() {
             let error_message =
-                "`cloud_archival` is configured in the reader node but it does not track all shards".to_string();
+                "`cloud_archival` is configured in reader mode, but it does not track all shards.".to_string();
             self.validation_errors.push_config_semantics_error(error_message);
         }
 
@@ -259,7 +259,7 @@ impl<'a> ConfigValidator<'a> {
             && !archival_writer.archive_block_data
         {
             let error_message =
-                "`cloud_archival` must track a shard unless it's meant to `archive_block_data` only".to_string();
+                "`cloud_archival` must track at least one shard unless it is configured to `archive_block_data` only.".to_string();
             self.validation_errors.push_config_semantics_error(error_message);
         }
     }

--- a/nearcore/src/config_validate.rs
+++ b/nearcore/src/config_validate.rs
@@ -1,4 +1,4 @@
-use near_chain_configs::{DumpConfig, ExternalStorageLocation, StateSyncConfig, SyncConfig};
+use near_chain_configs::{DumpConfig, ExternalStorageLocation, SyncConfig};
 use near_config_utils::{ValidationError, ValidationErrors};
 use std::collections::HashSet;
 use std::path::Path;
@@ -31,13 +31,10 @@ impl<'a> ConfigValidator<'a> {
 
     /// this function would check all conditions, and add all error messages to ConfigValidator.errors
     fn validate_all_conditions(&mut self) {
-        self.validate_cold_store_config();
         self.validate_cloud_archival_config();
+        self.validate_cold_store_config();
+        self.validate_state_sync_config();
         self.validate_tracked_shards_config();
-
-        if let Some(state_sync) = &self.config.state_sync {
-            self.validate_state_sync_config(&state_sync);
-        }
 
         if self.config.consensus.min_block_production_delay
             > self.config.consensus.max_block_production_delay
@@ -143,7 +140,10 @@ impl<'a> ConfigValidator<'a> {
         }
     }
 
-    fn validate_state_sync_config(&mut self, state_sync: &StateSyncConfig) {
+    fn validate_state_sync_config(&mut self) {
+        let Some(state_sync) = &self.config.state_sync else {
+            return;
+        };
         if let Some(dump_config) = &state_sync.dump {
             self.validate_state_dumper_config(dump_config);
         }
@@ -223,15 +223,43 @@ impl<'a> ConfigValidator<'a> {
     }
 
     fn validate_cloud_archival_config(&mut self) {
-        if !self.config.archive && self.config.cloud_storage.is_some() {
+        let Some(cloud_archival) = &self.config.cloud_archival else {
+            return;
+        };
+
+        if !self.config.archive {
             let error_message =
-                "`archive` is false, but `cloud_storage` is configured.".to_string();
+                "`archive` is false, but `cloud_archival` is configured.".to_string();
             self.validation_errors.push_config_semantics_error(error_message);
         }
-        // TODO(cloud_archival) Allow for cloud storage independently of cold store.
-        if self.config.cloud_storage.is_some() && self.config.cold_store.is_none() {
+        if cloud_archival.is_archival_reader && self.config.cold_store.is_none() {
             let error_message =
-                "`cloud_storage` is configured but `cold_store` is not.".to_string();
+                "`cloud_archival` is configured in the reader node but `cold_store` is missing."
+                    .to_string();
+            self.validation_errors.push_config_semantics_error(error_message);
+        }
+        if !cloud_archival.is_archival_reader && self.config.rpc.is_some() {
+            let error_message =
+                "`cloud_archival` isn't configured in the reader node but `rpc` is enabled."
+                    .to_string();
+            self.validation_errors.push_config_semantics_error(error_message);
+        }
+        let tracked_shards = self.config.tracked_shards_config();
+        if cloud_archival.is_archival_reader && !tracked_shards.tracks_all_shards() {
+            let error_message =
+                "`cloud_archival` is configured in the reader node but it does not track all shards".to_string();
+            self.validation_errors.push_config_semantics_error(error_message);
+        }
+
+        let Some(archival_writer) = &cloud_archival.archival_writer else {
+            return;
+        };
+
+        if !tracked_shards.tracks_non_empty_subset_of_shards()
+            && !archival_writer.archive_block_data
+        {
+            let error_message =
+                "`cloud_archival` must track a shard unless it's meant to `archive_block_data` only".to_string();
             self.validation_errors.push_config_semantics_error(error_message);
         }
     }
@@ -270,7 +298,7 @@ impl<'a> ConfigValidator<'a> {
 
 #[cfg(test)]
 mod tests {
-    use near_chain_configs::TrackedShardsConfig;
+    use near_chain_configs::{StateSyncConfig, TrackedShardsConfig};
 
     use super::*;
 

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -95,7 +95,7 @@ pub fn open_storage(home_dir: &Path, near_config: &mut NearConfig) -> anyhow::Re
         home_dir,
         &near_config.config.store,
         near_config.config.cold_store.as_ref(),
-        near_config.config.cloud_storage.as_ref(),
+        near_config.config.cloud_storage_config(),
     )
     .with_migrator(&migrator);
     let storage = match opener.open() {

--- a/runtime/runtime-params-estimator/src/main.rs
+++ b/runtime/runtime-params-estimator/src/main.rs
@@ -190,7 +190,7 @@ fn run_estimation(cli_args: CliArgs) -> anyhow::Result<Option<CostTable>> {
             &state_dump_path,
             &near_config.config.store,
             near_config.config.cold_store.as_ref(),
-            near_config.config.cloud_storage.as_ref(),
+            near_config.config.cloud_storage_config(),
         )
         .open()
         .unwrap()

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
         home_dir,
         &near_config.config.store,
         near_config.config.cold_store.as_ref(),
-        near_config.config.cloud_storage.as_ref(),
+        near_config.config.cloud_storage_config(),
     )
     .open()
     .unwrap()

--- a/tools/cold-store/src/cli.rs
+++ b/tools/cold-store/src/cli.rs
@@ -116,7 +116,7 @@ impl ColdStoreCommand {
             home_dir,
             &near_config.config.store,
             near_config.config.cold_store.as_ref(),
-            near_config.config.cloud_storage.as_ref(),
+            near_config.config.cloud_storage_config(),
         );
 
         match self.subcmd {
@@ -139,7 +139,7 @@ impl ColdStoreCommand {
             home_dir,
             &near_config.config.store,
             near_config.config.cold_store.as_ref(),
-            near_config.config.cloud_storage.as_ref(),
+            near_config.config.cloud_storage_config(),
         )
     }
 }

--- a/tools/database/src/adjust_database.rs
+++ b/tools/database/src/adjust_database.rs
@@ -35,7 +35,7 @@ impl ChangeDbKindCommand {
             home_dir,
             &near_config.config.store,
             near_config.config.cold_store.as_ref(),
-            near_config.config.cloud_storage.as_ref(),
+            near_config.config.cloud_storage_config(),
         );
 
         let storage = opener.open()?;

--- a/tools/database/src/analyze_high_load.rs
+++ b/tools/database/src/analyze_high_load.rs
@@ -84,7 +84,7 @@ impl HighLoadStatsCommand {
             home,
             &near_config.store,
             near_config.cold_store.as_ref(),
-            near_config.cloud_storage.as_ref(),
+            near_config.cloud_storage_config(),
         );
         let storage = opener.open()?;
         let store = std::sync::Arc::new(

--- a/tools/database/src/set_version.rs
+++ b/tools/database/src/set_version.rs
@@ -24,7 +24,7 @@ impl SetVersionCommand {
             home_dir,
             &near_config.config.store,
             near_config.config.cold_store.as_ref(),
-            near_config.config.cloud_storage.as_ref(),
+            near_config.config.cloud_storage_config(),
         );
         let storage = opener.open_unsafe()?;
         let store = storage.get_hot_store();

--- a/tools/database/src/write_to_db.rs
+++ b/tools/database/src/write_to_db.rs
@@ -34,7 +34,7 @@ impl WriteCryptoHashCommand {
             home_dir,
             &near_config.config.store,
             near_config.config.cold_store.as_ref(),
-            near_config.config.cloud_storage.as_ref(),
+            near_config.config.cloud_storage_config(),
         );
 
         let storage = opener.open()?;

--- a/tools/flat-storage/src/commands.rs
+++ b/tools/flat-storage/src/commands.rs
@@ -569,7 +569,7 @@ impl FlatStorageCommand {
             home_dir,
             &near_config.config.store,
             near_config.config.cold_store.as_ref(),
-            near_config.config.cloud_storage.as_ref(),
+            near_config.config.cloud_storage_config(),
         );
 
         match &self.subcmd {

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -844,7 +844,7 @@ impl<T: ChainAccess> TxMirror<T> {
                     target_home,
                     &target_config.config.store,
                     target_config.config.cold_store.as_ref(),
-                    target_config.config.cloud_storage.as_ref(),
+                    target_config.config.cloud_storage_config(),
                 )
                 .path()
                 .join("mirror");

--- a/tools/mock-node/src/setup.rs
+++ b/tools/mock-node/src/setup.rs
@@ -91,7 +91,7 @@ pub fn setup_mock_node(
         home_dir,
         &near_config.config.store,
         near_config.config.cold_store.as_ref(),
-        near_config.config.cloud_storage.as_ref(),
+        near_config.config.cloud_storage_config(),
     )
     .open()
     .context("failed opening storage")?

--- a/tools/replay-archive/src/replaydb.rs
+++ b/tools/replay-archive/src/replaydb.rs
@@ -150,7 +150,7 @@ pub(crate) fn open_storage_for_replay(
         home_dir,
         &near_config.config.store,
         near_config.config.cold_store.as_ref(),
-        near_config.config.cloud_storage.as_ref(),
+        near_config.config.cloud_storage_config(),
     );
     let split_storage = opener.open_in_mode(Mode::ReadOnly).context("Failed to open storage")?;
     match split_storage.get_split_db() {

--- a/tools/speedy_sync/src/main.rs
+++ b/tools/speedy_sync/src/main.rs
@@ -231,7 +231,7 @@ fn load_snapshot(load_cmd: LoadCmd) {
         home_dir,
         &Default::default(),
         near_config.config.cold_store.as_ref(),
-        near_config.config.cloud_storage.as_ref(),
+        near_config.config.cloud_storage_config(),
     )
     .open()
     .unwrap()

--- a/tools/state-viewer/src/cli.rs
+++ b/tools/state-viewer/src/cli.rs
@@ -153,7 +153,7 @@ impl StateViewerSubCommand {
             home_dir,
             &near_config.config.store,
             near_config.config.cold_store.as_ref(),
-            near_config.config.cloud_storage.as_ref(),
+            near_config.config.cloud_storage_config(),
         );
 
         let storage = store_opener.open_in_mode(mode).unwrap();

--- a/tools/state-viewer/src/replay_headers.rs
+++ b/tools/state-viewer/src/replay_headers.rs
@@ -274,7 +274,7 @@ fn create_replay_store(home_dir: &Path, near_config: &NearConfig) -> Store {
         home_dir,
         &near_config.config.store,
         near_config.config.cold_store.as_ref(),
-        near_config.config.cloud_storage.as_ref(),
+        near_config.config.cloud_storage_config(),
     );
     let storage = store_opener.open_in_mode(Mode::ReadOnly).unwrap();
 

--- a/tools/undo-block/src/cli.rs
+++ b/tools/undo-block/src/cli.rs
@@ -25,7 +25,7 @@ impl UndoBlockCommand {
             home_dir,
             &near_config.config.store,
             near_config.config.cold_store.as_ref(),
-            near_config.config.cloud_storage.as_ref(),
+            near_config.config.cloud_storage_config(),
         );
 
         let storage = store_opener.open_in_mode(Mode::ReadWrite).unwrap();


### PR DESCRIPTION
Changes:
- Introduce `CloudArchivalReaderConfig` and `CloudArchivalWriterConfig` configs with validation.
- Minor refactor and cleanup.

This PR prepares the ground for introducing the cloud archival loop, which will save blobs to a bucket.

**Note**: Config validation tests will come in a separate PR.