### PR TITLE
perf: avoid cloning ApplyChunkResult

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -178,14 +178,14 @@ impl ApplyChunksResultCache {
         }
     }
 
-    pub fn peek(
-        &self,
+    pub fn pop(
+        &mut self,
         key: &CachedShardUpdateKey,
         shard_id: ShardId,
         record_metric: bool,
-    ) -> Option<&ShardUpdateResult> {
+    ) -> Option<ShardUpdateResult> {
         let shard_id_label = shard_id.to_string();
-        if let Some(result) = self.cache.peek(key) {
+        if let Some(result) = self.cache.pop(key) {
             self.hits.set(self.hits.get() + 1);
             if record_metric {
                 metrics::APPLY_CHUNK_RESULTS_CACHE_HITS
@@ -2167,7 +2167,7 @@ impl Chain {
     /// to process the block and the block is valid.
     /// Note that this function does NOT introduce any changes to chain state.
     fn preprocess_block(
-        &self,
+        &mut self,
         block: &MaybeValidated<Arc<Block>>,
         provenance: &Provenance,
         invalid_chunks: &mut Vec<ShardChunkHeader>,
@@ -2949,7 +2949,7 @@ impl Chain {
     /// Creates jobs which will update shards for the given block and incoming
     /// receipts aggregated for it.
     fn apply_chunks_preprocessing(
-        &self,
+        &mut self,
         block: &Block,
         prev_block: &Block,
         incoming_receipts: &HashMap<ShardId, Vec<ReceiptProof>>,
@@ -3104,7 +3104,7 @@ impl Chain {
 
     /// This method returns the closure that is responsible for updating a shard.
     fn get_update_shard_job(
-        &self,
+        &mut self,
         cached_shard_update_key: CachedShardUpdateKey,
         block: ApplyChunkBlockContext,
         chunk_headers: &Chunks,
@@ -3133,13 +3133,12 @@ impl Chain {
         let is_new_chunk = chunk_header.is_new_chunk(block_height);
 
         if !cfg!(feature = "sandbox") {
-            if let Some(result) = self.apply_chunk_results_cache.peek(
+            if let Some(result) = self.apply_chunk_results_cache.pop(
                 &cached_shard_update_key,
                 shard_id,
                 matches!(block.block_type, BlockType::Normal),
             ) {
                 debug!(target: "chain", %shard_id, ?cached_shard_update_key, "Using cached ShardUpdate result");
-                let result = result.clone();
                 return Ok(Some((
                     shard_id,
                     cached_shard_update_key,

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -86,7 +86,7 @@ pub struct AcceptedBlock {
     pub provenance: Provenance,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ApplyChunkResult {
     pub trie_changes: WrappedTrieChanges,
     pub new_root: StateRoot,

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -16,7 +16,7 @@ use node_runtime::SignedValidPeriodTransactions;
 
 /// Result of updating a shard for some block when it has a new chunk for this
 /// shard.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct NewChunkResult {
     pub shard_uid: ShardUId,
     pub gas_limit: Gas,
@@ -25,7 +25,7 @@ pub struct NewChunkResult {
 
 /// Result of updating a shard for some block when it doesn't have a new chunk
 /// for this shard, so previous chunk header is copied.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct OldChunkResult {
     pub shard_uid: ShardUId,
     /// Note that despite the naming, no transactions are applied in this case.
@@ -34,7 +34,7 @@ pub struct OldChunkResult {
 }
 
 /// Result for a shard update for a single block.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum ShardUpdateResult {
     NewChunk(NewChunkResult),
     OldChunk(OldChunkResult),

--- a/chain/client/src/chunk_executor_actor.rs
+++ b/chain/client/src/chunk_executor_actor.rs
@@ -136,7 +136,7 @@ pub struct ProcessedBlock {
     pub block_hash: CryptoHash,
 }
 
-#[derive(actix::Message, Debug, Clone)]
+#[derive(actix::Message, Debug)]
 #[rtype(result = "()")]
 pub struct ExecutorApplyChunksDone {
     pub block_hash: CryptoHash,


### PR DESCRIPTION
This PR makes the tradeoff of not cloning `ShardUpdateResult` in exchange for passing `&mut self` to `get_update_shard_job`.

Alternatively we could "Arc<Mutex<...>>" the cache so it has interior mutability.
According to recent profiles it takes 10-20ms to clone it, but also I don't like this clone because it seems like the ShardUpdateResult doesn't need to be copied.