### PR TITLE
perf: optimize TrieKey encoding where possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4911,6 +4911,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha3",
+ "smallvec",
  "smart-default",
  "strum",
  "tempfile",

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -40,6 +40,7 @@ serde_json.workspace = true
 serde_with.workspace = true
 schemars = { workspace = true, optional = true }
 sha3.workspace = true
+smallvec = { workspace = true, features = ["write"] }
 smart-default.workspace = true
 stdx.workspace = true
 strum.workspace = true


### PR DESCRIPTION
This is a pretty warm operation due to frequent accesses and heavy allocation. Using `SmallVec`s where possible should help with this. I also took the opportunity to get rid of the intermediate allocations internally where parts of the key are borsh-encoded.