### PR TITLE
fix: hook setup quirks

### DIFF
--- a/scripts/setup_hooks.sh
+++ b/scripts/setup_hooks.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 HOOK_DIR=$(git rev-parse --show-toplevel)/.git/hooks
-ln -s -f ${DIR}/pre-commit ${HOOK_DIR}
+ln -s -f "${DIR}/pre-commit" "${HOOK_DIR}/pre-commit"


### PR DESCRIPTION
* redirect errors in `cd` so they don’t spam
* make `ln` point to `/pre-commit` instead of nuking the whole `hooks` dir
* quote vars to avoid path-with-space issues

now it behaves as expected
