### PR TITLE
crt: use lightly steamed contracts for nearvm2 as well

### DIFF
--- a/runtime/near-vm-runner/src/prepare/prepare_v2.rs
+++ b/runtime/near-vm-runner/src/prepare/prepare_v2.rs
@@ -368,10 +368,9 @@ pub(crate) fn prepare_contract(
     kind: VMKind,
 ) -> Result<Vec<u8>, PrepareError> {
     let lightly_steamed = PrepareContext::new(original_code, features, config).run()?;
-
-    if kind == VMKind::NearVm {
-        // Built-in near-vm code instruments code for itself.
-        return Ok(lightly_steamed);
+    match kind {
+        VMKind::NearVm | VMKind::NearVm2 => return Ok(lightly_steamed),
+        VMKind::Wasmer0 | VMKind::Wasmtime | VMKind::Wasmer2 => {}
     }
 
     let res = finite_wasm::Analysis::new()

--- a/runtime/near-vm-runner/src/prepare/prepare_v3.rs
+++ b/runtime/near-vm-runner/src/prepare/prepare_v3.rs
@@ -369,9 +369,9 @@ pub(crate) fn prepare_contract(
 ) -> Result<Vec<u8>, PrepareError> {
     let lightly_steamed = PrepareContext::new(original_code, features, config).run()?;
 
-    if kind == VMKind::NearVm {
-        // Built-in near-vm code instruments code for itself.
-        return Ok(lightly_steamed);
+    match kind {
+        VMKind::NearVm | VMKind::NearVm2 => return Ok(lightly_steamed),
+        VMKind::Wasmer0 | VMKind::Wasmtime | VMKind::Wasmer2 => {}
     }
 
     let res = finite_wasm_6::Analysis::new()


### PR DESCRIPTION
This has not been noticed so far because our canary nodes do not really run new protocol versions. This would've only come up after a protocol version change.