### PR TITLE
crt: fix fees for linear operations

### DIFF
--- a/runtime/near-vm-runner/src/logic/tests/gas_counter.rs
+++ b/runtime/near-vm-runner/src/logic/tests/gas_counter.rs
@@ -877,7 +877,7 @@ fn test_memory_copy_aggregate_accounting() {
             Err: PrepareError: Error happened while deserializing the module.
         "#]],
         expect![[r#"
-            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 121441980 used gas 121441980
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 146947416 used gas 146947416
         "#]]]);
 
     test_builder()
@@ -899,7 +899,7 @@ fn test_memory_copy_aggregate_accounting() {
         "#]],
         // Gas use here should be roughly double that of the test above!
         expect![[r#"
-            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 142010880 used gas 142010880
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 167516316 used gas 167516316
         "#]]]);
 }
 
@@ -933,7 +933,7 @@ fn test_memory_copy_full_memory() {
             Err: PrepareError: Error happened while deserializing the module.
         "#]],
         expect![[r#"
-            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 276071358793941 used gas 276071358793941
+            VMOutcome: balance 4 storage_usage 12 return data None burnt gas 276071613848301 used gas 276071613848301
         "#]]]);
 }
 

--- a/runtime/near-vm-runner/src/near_vm_2_runner/runner.rs
+++ b/runtime/near-vm-runner/src/near_vm_2_runner/runner.rs
@@ -558,12 +558,12 @@ macro_rules! gas_cost {
     (@@$self:ident visit_block) => { Fee::ZERO };
     (@@$self:ident visit_end) => { Fee::ZERO };
     (@@$self:ident visit_else) => { Fee::ZERO };
-    (@@$self:ident visit_memory_init) => { Fee { linear: $self.0, constant: 0 } };
-    (@@$self:ident visit_memory_copy) => { Fee { linear: $self.0, constant: 0 } };
-    (@@$self:ident visit_memory_fill) => { Fee { linear: $self.0, constant: 0 } };
-    (@@$self:ident visit_table_init) => { Fee { linear: $self.0, constant: 0 } };
-    (@@$self:ident visit_table_copy) => { Fee { linear: $self.0, constant: 0 } };
-    (@@$self:ident visit_table_fill) => { Fee { linear: $self.0, constant: 0 } };
+    (@@$self:ident visit_memory_init) => { Fee { linear: $self.0, constant: 32 * $self.0 } };
+    (@@$self:ident visit_memory_copy) => { Fee { linear: $self.0, constant: 32 * $self.0 } };
+    (@@$self:ident visit_memory_fill) => { Fee { linear: $self.0, constant: 32 * $self.0 } };
+    (@@$self:ident visit_table_init) => { Fee { linear: $self.0, constant: 32 * $self.0 } };
+    (@@$self:ident visit_table_copy) => { Fee { linear: $self.0, constant: 32 * $self.0 } };
+    (@@$self:ident visit_table_fill) => { Fee { linear: $self.0, constant: 32 * $self.0 } };
     (@@$self:ident $visit:ident) => { Fee::constant($self.0) };
 }
 

--- a/runtime/near-vm-runner/src/prepare/prepare_v3.rs
+++ b/runtime/near-vm-runner/src/prepare/prepare_v3.rs
@@ -440,12 +440,12 @@ macro_rules! gas_cost {
     (@@$self:ident visit_block) => { Fee::ZERO };
     (@@$self:ident visit_end) => { Fee::ZERO };
     (@@$self:ident visit_else) => { Fee::ZERO };
-    (@@$self:ident visit_memory_init) => { Fee { linear: $self.0, constant: $self.0 } };
-    (@@$self:ident visit_memory_copy) => { Fee { linear: $self.0, constant: $self.0 } };
-    (@@$self:ident visit_memory_fill) => { Fee { linear: $self.0, constant: $self.0 } };
-    (@@$self:ident visit_table_init) => { Fee { linear: $self.0, constant: $self.0 } };
-    (@@$self:ident visit_table_copy) => { Fee { linear: $self.0, constant: $self.0 } };
-    (@@$self:ident visit_table_fill) => { Fee { linear: $self.0, constant: $self.0 } };
+    (@@$self:ident visit_memory_init) => { Fee { linear: $self.0, constant: 32 * $self.0 } };
+    (@@$self:ident visit_memory_copy) => { Fee { linear: $self.0, constant: 32 * $self.0 } };
+    (@@$self:ident visit_memory_fill) => { Fee { linear: $self.0, constant: 32 * $self.0 } };
+    (@@$self:ident visit_table_init) => { Fee { linear: $self.0, constant: 32 * $self.0 } };
+    (@@$self:ident visit_table_copy) => { Fee { linear: $self.0, constant: 32 * $self.0 } };
+    (@@$self:ident visit_table_fill) => { Fee { linear: $self.0, constant: 32 * $self.0 } };
     (@@$self:ident $visit:ident) => { Fee::constant($self.0) };
 }
 


### PR DESCRIPTION
One issue was that these fees were not the same between configs in prepare code and near_vm_2. The other was the constant fee for these operations: internally they are not particularly different from a host function call in that they require some special setup. Imposing a larger constant fee (determined by intuition and some eyeballing: 100 and 50 felt too much, 10 or 16 felt too little) ensures that users don't just call the somewhat more expensive 1-byte memcpys in a loop vs. opencoding such logic in-line.

There are follow-up tasks here worth working on: adding a proper parameter for these linear fees is one such task. I chose to go quick and dirty here, however, in order to have something ready quickly for 2.9 and also because I'm not feeling all that well today.