### PR TITLE
fix: missing 30 → 31 migration in `StoreMigrator`

### DIFF
--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -71,7 +71,9 @@ impl<'a> near_store::StoreMigrator for Migrator<'a> {
 
     fn migrate(&self, store: &Store, version: DbVersion) -> anyhow::Result<()> {
         match version {
-            0..=31 => unreachable!(),
+            0..=29 => unreachable!(),
+            30 => migrate_30_to_31(store, self.config),
+            31 => Ok(()),
             32 => near_store::migrations::migrate_32_to_33(store),
             33 => {
                 near_store::migrations::migrate_33_to_34(store, self.config.client_config.archive)


### PR DESCRIPTION
noticed that the migration from version 30 to 31 was never triggered because the entire `0..=31` range was marked as unreachable.

updated the match block so that:

* `0..=29` still panics as before,
* version `30` now properly calls `migrate_30_to_31(store, self.config)`,
* version `31` cleanly returns `Ok(())`.

this ensures the migration path actually runs as intended.
