### PR TITLE
fix(sharded_bm): set gcs_state_sync in handle_reset

### DIFF
--- a/pytest/tests/mocknet/sharded_bm.py
+++ b/pytest/tests/mocknet/sharded_bm.py
@@ -312,6 +312,7 @@ def handle_reset(args):
     reset_cmd_args = copy.deepcopy(args)
     reset_cmd_args.backup_id = "start"
     reset_cmd_args.yes = True
+    reset_cmd_args.gcs_state_sync = False
     reset_cmd(CommandContext(reset_cmd_args))
 
 


### PR DESCRIPTION
Otherwise I get:

```
  File "/Users/darioush/src3/nearcore/pytest/tests/mocknet/sharded_bm.py", line 614, in <module>
    main()
    ~~~~^^
  File "/Users/darioush/src3/nearcore/pytest/tests/mocknet/sharded_bm.py", line 604, in main
    handle_reset(args)
    ~~~~~~~~~~~~^^^^^^
  File "/Users/darioush/src3/nearcore/pytest/tests/mocknet/sharded_bm.py", line 315, in handle_reset
    reset_cmd(CommandContext(reset_cmd_args))
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/darioush/src3/nearcore/pytest/tests/mocknet/mirror.py", line 493, in reset_cmd
    _clear_state_parts_if_exists(_get_state_parts_location(args), nodes)
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/Users/darioush/src3/nearcore/pytest/tests/mocknet/mirror.py", line 376, in _get_state_parts_location
    if not args.gcs_state_sync:
           ^^^^^^^^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'gcs_state_sync'
```

Maybe there is a better fix?