### PR TITLE
test(cloud_archival): Basic testloop

### DIFF
--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -271,6 +271,26 @@ pub struct CloudArchivalWriterConfig {
     pub polling_interval: Duration,
 }
 
+// A handle that allows the main process to interrupt cloud archival actor if needed.
+#[derive(Clone)]
+pub struct CloudArchivalHandle {
+    keep_going: Arc<AtomicBool>,
+}
+
+impl CloudArchivalHandle {
+    pub fn new() -> Self {
+        Self { keep_going: Arc::new(AtomicBool::new(true)) }
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        !self.get()
+    }
+
+    fn get(&self) -> bool {
+        self.keep_going.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
 /// Configures how to dump state to external storage.
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]

--- a/core/chain-configs/src/lib.rs
+++ b/core/chain-configs/src/lib.rs
@@ -10,9 +10,10 @@ pub mod test_utils;
 mod updatable_config;
 
 pub use client_config::{
-    ChunkDistributionNetworkConfig, ChunkDistributionUris, ClientConfig, CloudArchivalReaderConfig,
-    CloudArchivalWriterConfig, CloudStorageConfig, DEFAULT_GC_NUM_EPOCHS_TO_KEEP,
-    DEFAULT_STATE_PARTS_COMPRESSION_LEVEL, DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_EXTERNAL,
+    ChunkDistributionNetworkConfig, ChunkDistributionUris, ClientConfig, CloudArchivalHandle,
+    CloudArchivalReaderConfig, CloudArchivalWriterConfig, CloudStorageConfig,
+    DEFAULT_GC_NUM_EPOCHS_TO_KEEP, DEFAULT_STATE_PARTS_COMPRESSION_LEVEL,
+    DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_EXTERNAL,
     DEFAULT_STATE_SYNC_NUM_CONCURRENT_REQUESTS_ON_CATCHUP_EXTERNAL, DumpConfig, EpochSyncConfig,
     ExternalStorageConfig, ExternalStorageLocation, GCConfig, LogSummaryStyle,
     MIN_GC_NUM_EPOCHS_TO_KEEP, ProtocolVersionCheckConfig, ReshardingConfig, ReshardingHandle,

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -18,7 +18,7 @@ use near_chain::types::RuntimeAdapter;
 use near_chain::{
     Chain, ChainGenesis, PartialWitnessValidationThreadPool, WitnessCreationThreadPool,
 };
-use near_chain_configs::ReshardingHandle;
+use near_chain_configs::{CloudArchivalHandle, ReshardingHandle};
 use near_chunks::shards_manager_actor::start_shards_manager;
 use near_client::adapter::client_sender_for_network;
 use near_client::archive::cloud_archival_actor::create_cloud_archival_actor;
@@ -229,7 +229,7 @@ pub struct NearNode {
     pub cold_store_loop_handle: Option<Arc<AtomicBool>>,
     /// The `cloud_archival_handle` will only be set if the cloud archival writer is configured. It's a handle
     /// to control the cloud archival actor that archives data from the hot store to the cloud archival.
-    pub cloud_archival_handle: Option<Arc<AtomicBool>>,
+    pub cloud_archival_handle: Option<CloudArchivalHandle>,
     /// Contains handles to background threads that may be dumping state to S3.
     pub state_sync_dumper: StateSyncDumper,
     // A handle that allows the main process to interrupt resharding if needed.
@@ -348,9 +348,9 @@ pub fn start_with_config_and_synchronization(
         config.genesis.config.genesis_height,
         &storage,
     )?;
-    let cloud_archival_handle = if let Some((actor, keep_going)) = result {
+    let cloud_archival_handle = if let Some((actor, handle)) = result {
         let _cloud_archival_addr = actor_system.spawn_tokio_actor(actor);
-        Some(keep_going)
+        Some(handle)
     } else {
         None
     };

--- a/test-loop-tests/src/setup/setup.rs
+++ b/test-loop-tests/src/setup/setup.rs
@@ -11,8 +11,9 @@ use near_chain::state_snapshot_actor::{
 };
 use near_chain::types::RuntimeAdapter;
 use near_chain::{ApplyChunksSpawner, ChainGenesis};
-use near_chain_configs::{MutableConfigValue, ReshardingHandle};
+use near_chain_configs::{CloudArchivalHandle, MutableConfigValue, ReshardingHandle};
 use near_chunks::shards_manager_actor::ShardsManagerActor;
+use near_client::archive::cloud_archival_actor::CloudArchivalActor;
 use near_client::chunk_executor_actor::ChunkExecutorActor;
 use near_client::client_actor::ClientActorInner;
 use near_client::gc_actor::GCActor;
@@ -331,6 +332,21 @@ pub fn setup_client(
     // We don't send messages to `GCActor` so adapter is not needed.
     test_loop.data.register_actor(identifier, gc_actor, None);
 
+    let cloud_archival_sender = if let Some(config) = &client_config.cloud_archival_writer {
+        let cloud_archival_actor = CloudArchivalActor::new(
+            config.clone(),
+            genesis.config.genesis_height,
+            store,
+            genesis.config.genesis_height,
+            CloudArchivalHandle::new(),
+        );
+        let sender = LateBoundSender::new();
+        let sender = test_loop.data.register_actor(identifier, cloud_archival_actor, Some(sender));
+        Some(sender)
+    } else {
+        None
+    };
+
     let resharding_actor = ReshardingActor::new(
         epoch_manager.clone(),
         runtime_adapter.clone(),
@@ -454,6 +470,7 @@ pub fn setup_client(
         state_sync_dumper_handle,
         chunk_executor_sender,
         spice_chunk_validator_sender,
+        cloud_archival_sender,
     };
 
     // Add the client to the network shared state before returning data

--- a/test-loop-tests/src/setup/state.rs
+++ b/test-loop-tests/src/setup/state.rs
@@ -10,6 +10,7 @@ use near_chain::chain::ChunkStateWitnessMessage;
 use near_chain::resharding::resharding_actor::ReshardingActor;
 use near_chain_configs::{ClientConfig, Genesis};
 use near_chunks::shards_manager_actor::ShardsManagerActor;
+use near_client::archive::cloud_archival_actor::CloudArchivalActor;
 use near_client::chunk_executor_actor::{ChunkExecutorActor, ExecutorIncomingReceipts};
 use near_client::client_actor::ClientActorInner;
 use near_client::spice_chunk_validator_actor::SpiceChunkValidatorActor;
@@ -88,6 +89,7 @@ pub struct NodeExecutionData {
     pub state_sync_dumper_handle: TestLoopDataHandle<StateSyncDumper>,
     pub chunk_executor_sender: TestLoopSender<ChunkExecutorActor>,
     pub spice_chunk_validator_sender: TestLoopSender<SpiceChunkValidatorActor>,
+    pub cloud_archival_sender: Option<TestLoopSender<CloudArchivalActor>>,
 }
 
 impl From<&NodeExecutionData> for AccountId {

--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -1,0 +1,82 @@
+use std::collections::HashSet;
+
+use near_async::time::Duration;
+use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
+use near_chain_configs::test_utils::test_cloud_archival_configs;
+use near_o11y::testonly::init_test_logger;
+use near_primitives::shard_layout::ShardLayout;
+use near_primitives::types::AccountId;
+
+use crate::setup::builder::TestLoopBuilder;
+
+const EPOCH_LENGTH: u64 = 10;
+const GC_NUM_EPOCHS_TO_KEEP: u64 = 3;
+
+#[test]
+fn test_cloud_archival_base() {
+    init_test_logger();
+
+    let shard_layout = ShardLayout::multi_shard(3, 3);
+    let validator = "cp0";
+    let validator_client: AccountId = validator.parse().unwrap();
+    let validators_spec = ValidatorsSpec::desired_roles(&[validator], &[]);
+    let genesis = TestLoopBuilder::new_genesis_builder()
+        .epoch_length(EPOCH_LENGTH)
+        .validators_spec(validators_spec)
+        .shard_layout(shard_layout)
+        .build();
+    let epoch_config_store = TestEpochConfigBuilder::build_store_from_genesis(&genesis);
+
+    let archival_client: AccountId = "archival".parse().unwrap();
+    let all_clients = vec![archival_client.clone(), validator_client];
+    let archival_client_index = 0;
+    assert_eq!(all_clients[archival_client_index], archival_client);
+    let archival_clients: HashSet<AccountId> = [archival_client].into_iter().collect();
+
+    let mut env = TestLoopBuilder::new()
+        .genesis(genesis)
+        .epoch_config_store(epoch_config_store)
+        .clients(all_clients)
+        .archival_clients(archival_clients)
+        .gc_num_epochs_to_keep(GC_NUM_EPOCHS_TO_KEEP)
+        .config_modifier(move |config, client_index| {
+            if client_index != archival_client_index {
+                return;
+            }
+            let (_, writer_config) = test_cloud_archival_configs("");
+            config.cloud_archival_writer = Some(writer_config);
+        })
+        .build()
+        .warmup();
+
+    // Run the chain until it garbage collects blocks from the first epoch.
+    let client_handle = env.node_datas[archival_client_index].client_sender.actor_handle();
+    let target_height = EPOCH_LENGTH * (GC_NUM_EPOCHS_TO_KEEP + 1);
+    env.test_loop.run_until(
+        |test_loop_data| {
+            let chain = &test_loop_data.get(&client_handle).client.chain;
+            chain.head().unwrap().height >= target_height
+        },
+        Duration::seconds(target_height as i64),
+    );
+    let client = env.test_loop.data.get(&client_handle);
+    let cloud_archival_actor_handle = env.node_datas[archival_client_index]
+        .cloud_archival_sender
+        .as_ref()
+        .unwrap()
+        .actor_handle();
+    let cloud_archival_actor = env.test_loop.data.get(&cloud_archival_actor_handle);
+
+    let gc_tail = client.client.chain.chain_store().tail().unwrap();
+    let cloud_head = cloud_archival_actor.get_cloud_head();
+    assert!(cloud_head > gc_tail);
+    // TODO(cloud_archival) Fix GC for cloud archival (`get_gc_stop_height_impl()`) and uncomment the assert below.
+    //assert!(gc_tail > EPOCH_LENGTH);
+
+    env.shutdown_and_drain_remaining_events(Duration::seconds(10));
+}
+
+#[test]
+fn test_cloud_archival() {
+    test_cloud_archival_base();
+}

--- a/test-loop-tests/src/tests/mod.rs
+++ b/test-loop-tests/src/tests/mod.rs
@@ -3,6 +3,7 @@ mod bug_repro;
 mod catching_up;
 mod chunk_validator_kickout;
 mod chunks_management;
+mod cloud_archival;
 mod congestion_control;
 mod congestion_control_genesis_bootstrap;
 mod consensus;


### PR DESCRIPTION
Follow-up to https://github.com/near/nearcore/pull/14255

Changes
- Register `CloudArchivalActor` in testloop.
- Add a basic testloop test.
- Minor refactor, use `CloudArchivalHandle`.

**Notes**
- In a separe PR, I will attempt to enable the cold store actor in testloop.
- GC is currently not working for cloud archival because it assumes all archival nodes use cold store and blocks GC on `COLD_HEAD`.