### PR TITLE
 cleanup(storage) remove mut from the storage opener 

### DIFF
--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -82,14 +82,7 @@ pub fn get_default_home() -> PathBuf {
 /// Opens node’s storage performing migrations and checks when necessary.
 ///
 /// If opened storage is an RPC store and `near_config.config.archive` is true,
-/// converts the storage to archival node.  Otherwise, if opening archival node
-/// with that field being false, prints a warning and sets the field to `true`.
-/// In other words, once store is archival, the node will act as archival nod
-/// regardless of settings in `config.json`.
-///
-/// The end goal is to get rid of `archive` option in `config.json` file and
-/// have the type of the node be determined purely based on kind of database
-/// being opened.
+/// converts the storage to archival node.
 pub fn open_storage(home_dir: &Path, near_config: &NearConfig) -> anyhow::Result<NodeStorage> {
     let migrator = migrations::Migrator::new(near_config);
     let opener = NodeStorage::opener(

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -90,7 +90,7 @@ pub fn get_default_home() -> PathBuf {
 /// The end goal is to get rid of `archive` option in `config.json` file and
 /// have the type of the node be determined purely based on kind of database
 /// being opened.
-pub fn open_storage(home_dir: &Path, near_config: &mut NearConfig) -> anyhow::Result<NodeStorage> {
+pub fn open_storage(home_dir: &Path, near_config: &NearConfig) -> anyhow::Result<NodeStorage> {
     let migrator = migrations::Migrator::new(near_config);
     let opener = NodeStorage::opener(
         home_dir,
@@ -184,7 +184,7 @@ pub fn open_storage(home_dir: &Path, near_config: &mut NearConfig) -> anyhow::Re
         },
     }.with_context(|| format!("unable to open database at {}", opener.path().display()))?;
 
-    near_config.config.archive = storage.is_archive()?;
+    assert_eq!(near_config.config.archive, storage.is_archive()?);
     Ok(storage)
 }
 

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -242,14 +242,14 @@ pub fn start_with_config(
 
 pub fn start_with_config_and_synchronization(
     home_dir: &Path,
-    mut config: NearConfig,
+    config: NearConfig,
     actor_system: ActorSystem,
     // 'shutdown_signal' will notify the corresponding `oneshot::Receiver` when an instance of
     // `ClientActor` gets dropped.
     shutdown_signal: Option<broadcast::Sender<()>>,
     config_updater: Option<ConfigUpdater>,
 ) -> anyhow::Result<NearNode> {
-    let storage = open_storage(home_dir, &mut config)?;
+    let storage = open_storage(home_dir, &config)?;
     if config.client_config.enable_statistics_export {
         let period = config.client_config.log_summary_period;
         spawn_db_metrics_loop(actor_system.clone(), &storage, period);

--- a/tools/database/src/analyze_contract_sizes.rs
+++ b/tools/database/src/analyze_contract_sizes.rs
@@ -78,8 +78,8 @@ impl AnalyzeContractSizesCommand {
         home: &PathBuf,
         genesis_validation: GenesisValidationMode,
     ) -> anyhow::Result<()> {
-        let mut near_config = load_config(home, genesis_validation).unwrap();
-        let node_storage = open_storage(&home, &mut near_config).unwrap();
+        let near_config = load_config(home, genesis_validation).unwrap();
+        let node_storage = open_storage(&home, &near_config).unwrap();
         let store = node_storage.get_split_store().unwrap_or_else(|| node_storage.get_hot_store());
         let chain_store = Rc::new(ChainStore::new(
             store.clone(),

--- a/tools/database/src/analyze_delayed_receipt.rs
+++ b/tools/database/src/analyze_delayed_receipt.rs
@@ -43,8 +43,8 @@ impl AnalyzeDelayedReceiptCommand {
         home: &PathBuf,
         genesis_validation: GenesisValidationMode,
     ) -> anyhow::Result<()> {
-        let mut near_config = load_config(home, genesis_validation).unwrap();
-        let node_storage = open_storage(&home, &mut near_config).unwrap();
+        let near_config = load_config(home, genesis_validation).unwrap();
+        let node_storage = open_storage(&home, &near_config).unwrap();
         let store = node_storage.get_split_store().unwrap_or_else(|| node_storage.get_hot_store());
         let chain_store = Rc::new(ChainStore::new(
             store.clone(),

--- a/tools/database/src/analyze_gas_usage.rs
+++ b/tools/database/src/analyze_gas_usage.rs
@@ -50,8 +50,8 @@ impl AnalyzeGasUsageCommand {
         genesis_validation: GenesisValidationMode,
     ) -> anyhow::Result<()> {
         // Create a ChainStore and EpochManager that will be used to read blockchain data.
-        let mut near_config = load_config(home, genesis_validation).unwrap();
-        let node_storage = open_storage(&home, &mut near_config).unwrap();
+        let near_config = load_config(home, genesis_validation).unwrap();
+        let node_storage = open_storage(&home, &near_config).unwrap();
         let store = node_storage.get_split_store().unwrap_or_else(|| node_storage.get_hot_store());
         let chain_store = Rc::new(ChainStore::new(
             store.clone(),

--- a/tools/database/src/memtrie.rs
+++ b/tools/database/src/memtrie.rs
@@ -376,10 +376,10 @@ impl ArchivalDataLossRecoveryCommand {
         let env_filter = EnvFilterBuilder::from_env().verbose(Some("memtrie")).finish()?;
         let _subscriber = default_subscriber(env_filter, &Default::default()).global();
 
-        let mut near_config =
+        let near_config =
             nearcore::config::load_config(&home, genesis_validation).expect("Error loading config");
 
-        let node_storage = nearcore::open_storage(&home, &mut near_config)?;
+        let node_storage = nearcore::open_storage(&home, &near_config)?;
         let store = node_storage.get_split_store().expect("SplitStore not found!");
         let cold_store = node_storage.get_cold_store().expect("ColdStore not found!");
         let cold_db = node_storage.cold_db().expect("ColdDB not found!");

--- a/tools/database/src/memtrie.rs
+++ b/tools/database/src/memtrie.rs
@@ -476,7 +476,7 @@ impl ArchivalDataLossRecoveryCommand {
         let shard_tracker = ShardTracker::new(
             near_config.client_config.tracked_shards_config.clone(),
             epoch_manager.clone(),
-            near_config.validator_signer.clone(),
+            near_config.validator_signer,
         );
         let resharding_manager =
             ReshardingManager::new(store, epoch_manager, shard_tracker, sender);

--- a/tools/database/src/run_migrations.rs
+++ b/tools/database/src/run_migrations.rs
@@ -10,9 +10,9 @@ impl RunMigrationsCommand {
         home_dir: &Path,
         genesis_validation: GenesisValidationMode,
     ) -> anyhow::Result<()> {
-        let mut near_config = nearcore::config::load_config(&home_dir, genesis_validation)
+        let near_config = nearcore::config::load_config(&home_dir, genesis_validation)
             .unwrap_or_else(|e| panic!("Error loading config: {:#}", e));
-        nearcore::open_storage(home_dir, &mut near_config)?;
+        nearcore::open_storage(home_dir, &near_config)?;
         Ok(())
     }
 }

--- a/tools/fork-network/src/cli.rs
+++ b/tools/fork-network/src/cli.rs
@@ -332,7 +332,7 @@ impl ForkNetworkCommand {
     // After this completes, almost every DB column can be removed, however this command doesn't delete anything itself.
     fn write_fork_info(
         &self,
-        near_config: &mut NearConfig,
+        near_config: &NearConfig,
         home_dir: &Path,
         shard_layout_override: &ShardLayoutOverride,
     ) -> anyhow::Result<()> {
@@ -421,7 +421,7 @@ impl ForkNetworkCommand {
 
     fn init(
         &self,
-        near_config: &mut NearConfig,
+        near_config: &NearConfig,
         home_dir: &Path,
         shard_layout_override: &ShardLayoutOverride,
     ) -> anyhow::Result<()> {
@@ -555,7 +555,7 @@ impl ForkNetworkCommand {
         epoch_length: u64,
         num_seats: &Option<NumSeats>,
         chain_id: &String,
-        near_config: &mut NearConfig,
+        near_config: &NearConfig,
         home_dir: &Path,
     ) -> anyhow::Result<()> {
         // 1. Open the state storage (maybe with DB migrations)

--- a/tools/mirror/src/key_util.rs
+++ b/tools/mirror/src/key_util.rs
@@ -51,11 +51,10 @@ pub(crate) fn keys_from_source_db(
 ) -> anyhow::Result<Vec<SecretAccessKey>> {
     let account_id: AccountId = account_id.parse().context("bad account ID")?;
 
-    let mut config =
-        nearcore::config::load_config(home.as_ref(), GenesisValidationMode::UnsafeFast)
-            .with_context(|| format!("Error loading config from {}", home.display()))?;
+    let config = nearcore::config::load_config(home.as_ref(), GenesisValidationMode::UnsafeFast)
+        .with_context(|| format!("Error loading config from {}", home.display()))?;
     let node_storage =
-        nearcore::open_storage(home.as_ref(), &mut config).context("failed opening storage")?;
+        nearcore::open_storage(home.as_ref(), &config).context("failed opening storage")?;
     let store = node_storage.get_hot_store();
     let chain = ChainStore::new(
         store.clone(),

--- a/tools/mirror/src/offline.rs
+++ b/tools/mirror/src/offline.rs
@@ -36,11 +36,11 @@ pub(crate) struct ChainAccess {
 
 impl ChainAccess {
     pub(crate) fn new<P: AsRef<Path>>(home: P) -> anyhow::Result<Self> {
-        let mut config =
+        let config =
             nearcore::config::load_config(home.as_ref(), GenesisValidationMode::UnsafeFast)
                 .with_context(|| format!("Error loading config from {:?}", home.as_ref()))?;
         let node_storage =
-            nearcore::open_storage(home.as_ref(), &mut config).context("failed opening storage")?;
+            nearcore::open_storage(home.as_ref(), &config).context("failed opening storage")?;
         let store = node_storage.get_hot_store();
         initialize_genesis_state(store.clone(), &config.genesis, Some(home.as_ref()));
         let chain = ChainStore::new(


### PR DESCRIPTION
Removed mut from the config parameter to open_storage and instead assert that config.archive has correct value. Mutating config is inconvenient and can be surprising. 

The first commit is the change, the rest is removing some other `mut`s from usages. 

Context: it annoyed me when working on the archival data loss recovery because I couldn't store some references from inside the config since it had to be mutable. 