### PR TITLE
perf: config to disable saving untracked partial chunks parts

### DIFF
--- a/benchmarks/sharded-bm/cases/base_config_patch.json
+++ b/benchmarks/sharded-bm/cases/base_config_patch.json
@@ -67,5 +67,6 @@
         }
     },
     "save_tx_outcomes": false,
-    "gc_num_epochs_to_keep": 3
+    "gc_num_epochs_to_keep": 3,
+    "save_untracked_partial_chunks_parts": false
 }

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -811,6 +811,8 @@ pub struct ClientConfig {
     pub save_trie_changes: bool,
     /// Whether to persist transaction outcomes to disk or not.
     pub save_tx_outcomes: bool,
+    /// Whether to persist partial chunk parts for untracked shards or not.
+    pub save_untracked_partial_chunks_parts: bool,
     /// Number of threads for ViewClientActor pool.
     pub view_client_threads: usize,
     /// Number of threads for ChunkValidationActor pool.
@@ -949,6 +951,7 @@ impl ClientConfig {
             cloud_archival_reader: None,
             cloud_archival_writer: None,
             save_trie_changes,
+            save_untracked_partial_chunks_parts: true,
             save_tx_outcomes: true,
             log_summary_style: LogSummaryStyle::Colored,
             view_client_threads: 1,

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -848,6 +848,23 @@ impl PartialEncodedChunk {
             Self::V2(chunk) => chunk.header.shard_id(),
         }
     }
+
+    /// Creates a clone of this partial chunk without the parts, keeping only
+    /// the header and receipts.
+    pub fn clone_without_parts(&self) -> Self {
+        match self {
+            Self::V1(chunk) => Self::V1(PartialEncodedChunkV1 {
+                header: chunk.header.clone(),
+                parts: Vec::new(),
+                prev_outgoing_receipts: chunk.prev_outgoing_receipts.clone(),
+            }),
+            Self::V2(chunk) => Self::V2(PartialEncodedChunkV2 {
+                header: chunk.header.clone(),
+                parts: Vec::new(),
+                prev_outgoing_receipts: chunk.prev_outgoing_receipts.clone(),
+            }),
+        }
+    }
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq, ProtocolSchema)]

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -300,6 +300,10 @@ pub struct Config {
     /// - All shards are tracked (i.e. node is an RPC node).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub save_tx_outcomes: Option<bool>,
+    /// Whether to persist partial chunk parts for untracked shards in the database.
+    /// If `None`, defaults to true (persist).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub save_untracked_partial_chunks_parts: Option<bool>,
     pub log_summary_style: LogSummaryStyle,
     #[serde(with = "near_async::time::serde_duration_as_std")]
     pub log_summary_period: Duration,
@@ -443,6 +447,7 @@ impl Default for Config {
             cloud_archival_writer: None,
             save_trie_changes: None,
             save_tx_outcomes: None,
+            save_untracked_partial_chunks_parts: None,
             log_summary_style: LogSummaryStyle::Colored,
             log_summary_period: default_log_summary_period(),
             gc: GCConfig::default(),
@@ -711,6 +716,9 @@ impl NearConfig {
                 cloud_archival_writer: config.cloud_archival_writer,
                 save_trie_changes: config.save_trie_changes.unwrap_or(!config.archive),
                 save_tx_outcomes: config.save_tx_outcomes.unwrap_or(is_archive_or_rpc),
+                save_untracked_partial_chunks_parts: config
+                    .save_untracked_partial_chunks_parts
+                    .unwrap_or(true),
                 log_summary_style: config.log_summary_style,
                 gc: config.gc,
                 view_client_threads: config.view_client_threads,


### PR DESCRIPTION
## Reasoning

We don't strictly need to store `PartialChunks` parts if we don't track a shard in benchmarks. 

- Parts are in the memory cache anyway (for a while); CP keeps them for 3 epochs
- This reduces write pressure by a good 20%
- Leaked `PartialChunks` are less "impactful"

## Changes

- Add config option to disable persisting chunk parts, active only in benchmarks

## Caveats

It turns out we still need receipts and `PartialChunks` header .. so the workaround is to avoid storing the parts which are the biggest contributor to size.

## Results

This makes the GC+compaction combo work as expected. Also less write pressure in general on the disk

<img width="634" height="339" alt="image" src="https://github.com/user-attachments/assets/6806d204-f35d-4446-850b-1bdd723d536d" />

