### PR TITLE
chore(forknet): deprecate legacy stateless parameter

### DIFF
--- a/benchmarks/sharded-bm/bench.sh
+++ b/benchmarks/sharded-bm/bench.sh
@@ -265,7 +265,7 @@ gen_forknet() {
     echo "Running new-test to initialize nodes and collect validator keys"
     $MIRROR --host-type nodes new-test --state-source empty --patches-path "${BENCHNET_DIR}/${CASE}" \
         --epoch-length ${EPOCH_LENGTH} --num-validators ${NUM_CHUNK_PRODUCERS} \
-        --new-chain-id ${FORKNET_NAME} --stateless-setup --yes
+        --new-chain-id ${FORKNET_NAME} --yes
     
     echo "Waiting for node initialization to complete..."
     $MIRROR --host-type nodes status

--- a/pytest/tests/mocknet/docs/mirror.md
+++ b/pytest/tests/mocknet/docs/mirror.md
@@ -83,7 +83,6 @@ mirror new-test \
   --genesis-protocol-version 71 \
   --num-validators 20 \
   --num-seats 20 \
-  --stateless-setup \
   --new-chain-id mocknet \
   --gcs-state-sync
 ```
@@ -95,8 +94,6 @@ mirror new-test \
 `--num-validators 20` How many of your GCP hosts you want to be added to the validator pool in genesis.
 
 `--num-seats 20` How many block producers do you want in your network. (WIP. Currently a dummy parameter)
-
-`--stateless-setup` Makes your nodes load the tracked shard in memory. 
 
 `--new-chain-id mocknet` Set the name of your chain id in genesis. Do not use `mainnet` or `testnet`. Typical value for this argument is `mocknet`. The chain_id in the grafana metrics is not set by this value, it is set by a value in terraform file. `chain_id` in metrics is always set to `mocknet.`
 

--- a/pytest/tests/mocknet/forknet_scenarios/base.py
+++ b/pytest/tests/mocknet/forknet_scenarios/base.py
@@ -157,7 +157,6 @@ class TestSetup:
         new_test_args.num_validators = self.node_hardware_config.num_chunk_validator_seats
         # Set all seats to the lower value. This will be increased later in epoch config.
         new_test_args.num_seats = self.node_hardware_config.num_chunk_producer_seats
-        new_test_args.stateless_setup = True
         new_test_args.new_chain_id = self.unique_id
         new_test_args.yes = True
         new_test_args.gcs_state_sync = self.has_state_dumper

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -904,7 +904,6 @@ def register_base_commands(subparsers):
     new_test_parser.add_argument('--num-seats', type=int)
     new_test_parser.add_argument('--new-chain-id', type=str)
     new_test_parser.add_argument('--genesis-protocol-version', type=int)
-    new_test_parser.add_argument('--stateless-setup', action='store_true')
     new_test_parser.add_argument(
         '--gcs-state-sync',
         action='store_true',

--- a/pytest/tests/mocknet/sharded_bm.py
+++ b/pytest/tests/mocknet/sharded_bm.py
@@ -175,7 +175,6 @@ def handle_init(args):
         new_chain_id=args.unique_id,
         genesis_protocol_version=None,
         gcs_state_sync=False,
-        stateless_setup=True,
         yes=True,
         **vars(args),
     )


### PR DESCRIPTION
This is a no-op.

`--stateless-setup` is an argument used during 2.0.0 release to make nodes load memtries. 
Now it is the default behaviour.