### PR TITLE
fix: include DB version bump for StatePartsApplied

### DIFF
--- a/core/store/src/db/metadata.rs
+++ b/core/store/src/db/metadata.rs
@@ -2,7 +2,7 @@
 pub type DbVersion = u32;
 
 /// Current version of the database.
-pub const DB_VERSION: DbVersion = 45;
+pub const DB_VERSION: DbVersion = 46;
 
 /// Database version at which point DbKind was introduced.
 const DB_VERSION_WITH_KIND: DbVersion = 34;

--- a/nearcore/src/migrations.rs
+++ b/nearcore/src/migrations.rs
@@ -42,6 +42,7 @@ impl<'a> near_store::StoreMigrator for Migrator<'a> {
             42 => near_store::migrations::migrate_42_to_43(store),
             43 => Ok(()), // DBCol::ChunkApplyStats column added, no need to perform a migration
             44 => near_store::migrations::migrate_44_to_45(store),
+            45 => Ok(()), // DBCol::StatePartsApplied column added, no need to perform a migration
             DB_VERSION.. => unreachable!(),
         }
     }


### PR DESCRIPTION
gc logic was already added, but these were missed here:
https://github.com/near/nearcore/pull/14232