### PR TITLE
fix: make `--rpc-server-port` a number

### DIFF
--- a/pytest/endtoend/endtoend.py
+++ b/pytest/endtoend/endtoend.py
@@ -80,7 +80,7 @@ if __name__ == '__main__':
     parser.add_argument('--public-key', required=True)
     parser.add_argument('--private-key', required=True)
     parser.add_argument('--rpc-server-addr', required=True)
-    parser.add_argument('--rpc-server-port', required=True)
+    parser.add_argument('--rpc-server-port', type=int, required=True)
     parser.add_argument('--metrics-port', type=int, required=True)
 
     args = parser.parse_args()


### PR DESCRIPTION
The `--rpc-server-port` argument was coming in as a string, which was breaking things when a number was expected.
Added `type=int` so it’s parsed correctly now—no more `TypeError` when using it in networking functions.