### PR TITLE
test: only run `slow_test_parallel_runtime_invocations` on nearvm

### DIFF
--- a/runtime/near-vm-runner/src/tests/regression_tests.rs
+++ b/runtime/near-vm-runner/src/tests/regression_tests.rs
@@ -82,6 +82,7 @@ fn slow_test_parallel_runtime_invocations() {
         let handle = std::thread::spawn(|| {
             for _ in 0..16 {
                 test_builder()
+                .only_near_vm()
                 .wat(
                     r#"
                       (module


### PR DESCRIPTION
refs #14248 , will look into fixing the flaky test meanwhile