### PR TITLE
add serde(default) for deprecated  fields

### DIFF
--- a/chain/jsonrpc/openapi/openapi.json
+++ b/chain/jsonrpc/openapi/openapi.json
@@ -2776,6 +2776,7 @@
                 "$ref": "#/components/schemas/NearToken"
               }
             ],
+            "default": "0",
             "description": "TODO(2271): deprecated."
           },
           "signature": {
@@ -2810,6 +2811,7 @@
                 "$ref": "#/components/schemas/NearToken"
               }
             ],
+            "default": "0",
             "description": "TODO(2271): deprecated."
           }
         },
@@ -2832,8 +2834,6 @@
           "validator_proposals",
           "chunk_mask",
           "gas_price",
-          "rent_paid",
-          "validator_reward",
           "total_supply",
           "challenges_result",
           "last_final_block",
@@ -3048,6 +3048,7 @@
                 "$ref": "#/components/schemas/NearToken"
               }
             ],
+            "default": "0",
             "description": "TODO(2271): deprecated."
           },
           "shard_id": {
@@ -3071,6 +3072,7 @@
                 "$ref": "#/components/schemas/NearToken"
               }
             ],
+            "default": "0",
             "description": "TODO(2271): deprecated."
           }
         },
@@ -3086,8 +3088,6 @@
           "shard_id",
           "gas_used",
           "gas_limit",
-          "rent_paid",
-          "validator_reward",
           "balance_burnt",
           "outgoing_receipts_root",
           "tx_root",

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -896,8 +896,10 @@ pub struct BlockHeaderView {
     pub gas_price: Balance,
     pub block_ordinal: Option<NumBlocks>,
     /// TODO(2271): deprecated.
+    #[serde(default)]
     pub rent_paid: Balance,
     /// TODO(2271): deprecated.
+    #[serde(default)]
     pub validator_reward: Balance,
     pub total_supply: Balance,
     // Deprecated
@@ -1073,8 +1075,10 @@ pub struct ChunkHeaderView {
     pub gas_used: Gas,
     pub gas_limit: Gas,
     /// TODO(2271): deprecated.
+    #[serde(default)]
     pub rent_paid: Balance,
     /// TODO(2271): deprecated.
+    #[serde(default)]
     pub validator_reward: Balance,
     pub balance_burnt: Balance,
     pub outgoing_receipts_root: CryptoHash,


### PR DESCRIPTION
This pull request makes improvements to the handling of deprecated fields `rent_paid` and `validator_reward` in both the Rust data structures and the OpenAPI specification. The main goal is to ensure these fields default to zero when not present, improving backward compatibility and API clarity.

**Rust struct improvements:**

* Added `default` attribute to the `rent_paid` and `validator_reward` fields in both `BlockHeaderView` and `ChunkHeaderView`, ensuring they default to zero if missing during deserialization. [[1]](diffhunk://#diff-1e4fc99d32e48420a9bd37050fa1412758cba37825851edea40cbdfcab406944L911-R915) [[2]](diffhunk://#diff-1e4fc99d32e48420a9bd37050fa1412758cba37825851edea40cbdfcab406944L1094-R1098)

**OpenAPI specification updates:**

* Added `"default": "0"` to the `rent_paid` and `validator_reward` schema definitions, clarifying their default values in API documentation. [[1]](diffhunk://#diff-59c921423af52ba4408b7244a9209e9ba8e4babbd2542fb32fdfbeabf16890d5R2761) [[2]](diffhunk://#diff-59c921423af52ba4408b7244a9209e9ba8e4babbd2542fb32fdfbeabf16890d5R2792) [[3]](diffhunk://#diff-59c921423af52ba4408b7244a9209e9ba8e4babbd2542fb32fdfbeabf16890d5R3025) [[4]](diffhunk://#diff-59c921423af52ba4408b7244a9209e9ba8e4babbd2542fb32fdfbeabf16890d5R3045)
* Removed `rent_paid` and `validator_reward` from the required fields lists in relevant OpenAPI response objects, reflecting their deprecated status and optionality. [[1]](diffhunk://#diff-59c921423af52ba4408b7244a9209e9ba8e4babbd2542fb32fdfbeabf16890d5L2814-L2815) [[2]](diffhunk://#diff-59c921423af52ba4408b7244a9209e9ba8e4babbd2542fb32fdfbeabf16890d5L3060-L3061)