### PR TITLE
wasmtime: always use v3 preparation

### DIFF
--- a/runtime/near-vm-runner/src/prepare.rs
+++ b/runtime/near-vm-runner/src/prepare.rs
@@ -25,7 +25,7 @@ pub fn prepare_contract(
     kind: VMKind,
 ) -> Result<Vec<u8>, PrepareError> {
     let features = crate::features::WasmFeatures::new(config);
-    if config.reftypes_bulk_memory {
+    if config.reftypes_bulk_memory || config.vm_kind == VMKind::Wasmtime {
         prepare_v3::prepare_contract(original_code, features, config, kind)
     } else {
         prepare_v2::prepare_contract(original_code, features, config, kind)

--- a/runtime/near-vm-runner/src/tests/regression_tests.rs
+++ b/runtime/near-vm-runner/src/tests/regression_tests.rs
@@ -82,7 +82,6 @@ fn slow_test_parallel_runtime_invocations() {
         let handle = std::thread::spawn(|| {
             for _ in 0..16 {
                 test_builder()
-                .only_near_vm()
                 .wat(
                     r#"
                       (module


### PR DESCRIPTION
v3 is ~required for wasmtime to work efficiently. The affected test time goes from 60 seconds to about 2 seconds (for wasmtime portion.) And so from 6 seconds total to ~8 seconds.

cc @rvolosatovs 