### PR TITLE
fix: NameError in `upload_key` by using correct parameter

### DIFF
--- a/pytest/tests/mocknet/locust.py
+++ b/pytest/tests/mocknet/locust.py
@@ -61,7 +61,7 @@ have the machine used for the master process in this list as well:''')
 
 
 def upload_key(node, filename):
-    node.machine.upload(args.funding_key,
+    node.machine.upload(filename,
                         '/home/ubuntu/locust/funding_key.json',
                         switch_user='ubuntu')
 


### PR DESCRIPTION
replaced `args.funding_key` with the `filename` argument inside `upload_key`.
`args` isn’t available in this scope, so it would raise a `NameError`.
since the function is already called with the proper path, referencing `filename` directly fixes the issue.
