### PR TITLE
chore: fix shared reference issue in test account initialization

### DIFF
--- a/pytest/tests/mocknet/helpers/load_test_utils.py
+++ b/pytest/tests/mocknet/helpers/load_test_utils.py
@@ -27,7 +27,7 @@ class TestState:
         self.test_accounts = test_accounts
         self.max_tps_per_node = max_tps_per_node
         self.rpc_infos = rpc_infos
-        self.function_call_state = [[]] * len(self.test_accounts)
+        self.function_call_state = [[] for _ in range(len(self.test_accounts))]
 
     def random_account(self):
         return random.choice(self.test_accounts)


### PR DESCRIPTION
`self.function_call_state = [[]] * len(self.test_accounts)` was causing all test accounts to share the same list, which led to unexpected side effects. now each account gets its own independent list, so updates to one won’t affect the others.