### PR TITLE
chore: fixed arg count bug

### DIFF
--- a/pytest/tests/mocknet/helpers/genesis_updater.py
+++ b/pytest/tests/mocknet/helpers/genesis_updater.py
@@ -23,7 +23,7 @@ def str_to_bool(arg):
 
 def main(argv):
     logger.info(argv)
-    assert len(argv) == 17
+    assert len(argv) == 18
 
     genesis_filename_in = argv[1]
     records_filename_in = argv[2]


### PR DESCRIPTION
was only grabbing 16 args + script name, now it handles 17 + script name (18 total in argv). no more off-by-one crash.