### PR TITLE
workaround(o11y): Don't escape ansi codes in message (fix color output)

### DIFF
--- a/core/o11y/src/lib.rs
+++ b/core/o11y/src/lib.rs
@@ -18,6 +18,7 @@ mod log_counter;
 pub mod metrics;
 mod opentelemetry;
 mod reload;
+mod skip_ansi_escaping_message;
 pub mod span_wrapped_msg;
 mod subscriber;
 pub mod testonly;

--- a/core/o11y/src/reload.rs
+++ b/core/o11y/src/reload.rs
@@ -1,4 +1,5 @@
 use crate::opentelemetry::get_opentelemetry_filter;
+use crate::skip_ansi_escaping_message::SkipAnsiEscapingMessage;
 use crate::{BuildEnvFilterError, EnvFilterBuilder, OpenTelemetryLevel, log_config, log_counter};
 use opentelemetry_sdk::trace::Tracer;
 use std::sync::OnceLock;
@@ -21,7 +22,7 @@ static DEFAULT_OTLP_LEVEL: OnceLock<OpenTelemetryLevel> = OnceLock::new();
 
 pub(crate) type LogLayer<Inner> = Layered<
     Filtered<
-        fmt::Layer<Inner, fmt::format::DefaultFields, fmt::format::Format, NonBlocking>,
+        fmt::Layer<Inner, SkipAnsiEscapingMessage, fmt::format::Format, NonBlocking>,
         reload::Layer<EnvFilter, Inner>,
         Inner,
     >,
@@ -29,11 +30,7 @@ pub(crate) type LogLayer<Inner> = Layered<
 >;
 
 pub(crate) type SimpleLogLayer<Inner, W> = Layered<
-    Filtered<
-        fmt::Layer<Inner, fmt::format::DefaultFields, fmt::format::Format, W>,
-        EnvFilter,
-        Inner,
-    >,
+    Filtered<fmt::Layer<Inner, SkipAnsiEscapingMessage, fmt::format::Format, W>, EnvFilter, Inner>,
     Inner,
 >;
 

--- a/core/o11y/src/skip_ansi_escaping_message.rs
+++ b/core/o11y/src/skip_ansi_escaping_message.rs
@@ -1,0 +1,61 @@
+use tracing::field::{Field, Visit};
+use tracing_subscriber::field::{MakeVisitor, VisitFmt, VisitOutput};
+use tracing_subscriber::fmt::format::{DefaultFields, Writer};
+
+/// A wrapper around `DefaultFields` that does not escape ANSI sequences in the "message" field.
+/// This allows terminal to interpret them correctly, working around the issue introduced in
+/// `tracing-subscriber` 0.3.20, see https://github.com/tokio-rs/tracing/issues/3369.
+/// TODO: This is a temporary workaround until `tracing-subscriber` provides a built-in solution.
+pub struct SkipAnsiEscapingMessage {
+    f: DefaultFields,
+}
+
+impl SkipAnsiEscapingMessage {
+    pub fn new(f: DefaultFields) -> Self {
+        SkipAnsiEscapingMessage { f }
+    }
+}
+
+pub struct SkipAnsiEscapeMessageVisitor<'a> {
+    f: <DefaultFields as MakeVisitor<Writer<'a>>>::Visitor,
+    result: std::fmt::Result,
+}
+
+impl<'a> MakeVisitor<Writer<'a>> for SkipAnsiEscapingMessage {
+    type Visitor = SkipAnsiEscapeMessageVisitor<'a>;
+
+    fn make_visitor(&self, target: Writer<'a>) -> Self::Visitor {
+        SkipAnsiEscapeMessageVisitor { f: self.f.make_visitor(target), result: Ok(()) }
+    }
+}
+
+impl Visit for SkipAnsiEscapeMessageVisitor<'_> {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if self.result.is_err() {
+            return;
+        }
+        if field.name() == "message" {
+            // Actual workaround: do not escape ANSI sequences in the "message" field,
+            // so that terminal can interpret them correctly.
+            self.result = write!(self.f.writer(), "{:?}", value);
+            return;
+        }
+        // Everything else is handled normally.
+        self.f.record_debug(field, value);
+    }
+}
+
+impl VisitFmt for SkipAnsiEscapeMessageVisitor<'_> {
+    fn writer(&mut self) -> &mut dyn core::fmt::Write {
+        self.f.writer()
+    }
+}
+
+impl VisitOutput<std::fmt::Result> for SkipAnsiEscapeMessageVisitor<'_> {
+    fn finish(self) -> std::fmt::Result {
+        if self.result.is_err() {
+            return self.result;
+        }
+        self.f.finish()
+    }
+}

--- a/core/o11y/src/subscriber.rs
+++ b/core/o11y/src/subscriber.rs
@@ -2,6 +2,7 @@ use crate::opentelemetry::add_opentelemetry_layer;
 use crate::reload::{
     LogLayer, SimpleLogLayer, set_default_otlp_level, set_log_layer_handle, set_otlp_layer_handle,
 };
+use crate::skip_ansi_escaping_message::SkipAnsiEscapingMessage;
 use crate::{OpenTelemetryLevel, log_counter};
 use near_crypto::PublicKey;
 use near_primitives_core::types::AccountId;
@@ -112,6 +113,7 @@ where
         .with_ansi(ansi)
         .with_span_events(get_fmt_span(with_span_events))
         .with_writer(writer)
+        .map_fmt_fields(|f| SkipAnsiEscapingMessage::new(f))
         .with_filter(filter);
 
     subscriber.with(layer)
@@ -141,6 +143,7 @@ where
         .with_ansi(ansi)
         .with_span_events(get_fmt_span(with_span_events))
         .with_writer(writer)
+        .map_fmt_fields(|f| SkipAnsiEscapingMessage::new(f))
         .with_filter(filter);
 
     (subscriber.with(layer), handle)


### PR DESCRIPTION
This PR provides an alternative to https://github.com/near/nearcore/pull/14338 which seems a bit less hacky in exchange for being a bit more complex.