### PR TITLE
refactor: use send_tx_and_wait in `deploy_call_*_contract` tests

### DIFF
--- a/core/primitives/src/receipt.rs
+++ b/core/primitives/src/receipt.rs
@@ -1,4 +1,4 @@
-use crate::action::{GlobalContractIdentifier, base64};
+use crate::action::GlobalContractIdentifier;
 use crate::errors::EpochError;
 use crate::hash::CryptoHash;
 use crate::shard_layout::ShardLayout;
@@ -1024,7 +1024,7 @@ impl fmt::Debug for GlobalContractDistributionReceiptV1 {
             .field("id", &self.id)
             .field("target_shard", &self.target_shard)
             .field("already_delivered_shards", &self.already_delivered_shards)
-            .field("code", &format_args!("{}", base64(&self.code)))
+            .field("code", &..)
             .finish()
     }
 }

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -1196,7 +1196,8 @@ def apply_config_changes(node_dir: str,
     for k, v in client_config_change.items():
         if not (k in allowed_missing_configs or k in config_json):
             raise ValueError(f'Unknown configuration option: {k}')
-        if k in config_json and isinstance(v, dict):
+        if k in config_json and isinstance(config_json[k], dict) and isinstance(
+                v, dict):
             config_json[k].update(v)
         else:
             # Support keys in the form of "a.b.c".

--- a/pytest/tests/contracts/deploy_call_global_smart_contract.py
+++ b/pytest/tests/contracts/deploy_call_global_smart_contract.py
@@ -20,9 +20,7 @@ def test_deploy_global_contract():
     n = 2
     val_client_config_changes = {
         i: {
-            "tracked_shards_config": {
-                "Accounts": [f"test{i}"]
-            },
+            "tracked_shards_config": "NoShards",
         } for i in range(n)
     }
     rpc_client_config_changes = {n: {"tracked_shards_config": "AllShards"}}
@@ -44,12 +42,12 @@ def test_deploy_global_contract():
     deploy_mode = GlobalContractDeployMode()
     deploy_mode.enum = 'codeHash'
     deploy_mode.codeHash = ()
-    deploy_global_contract(nodes[0], test_contract, deploy_mode, 10)
+    deploy_global_contract(rpc, nodes[0], test_contract, deploy_mode, 10)
 
     identifier = GlobalContractIdentifier()
     identifier.enum = "codeHash"
     identifier.codeHash = hashlib.sha256(test_contract).digest()
-    use_global_contract(nodes[1], identifier, 20)
+    use_global_contract(rpc, nodes[1], identifier, 20)
 
     call_contract(rpc, nodes[0], nodes[1].signer_key.account_id, 30)
     call_contract(rpc, nodes[1], nodes[1].signer_key.account_id, 40)
@@ -58,19 +56,19 @@ def test_deploy_global_contract():
     deploy_mode = GlobalContractDeployMode()
     deploy_mode.enum = 'accountId'
     deploy_mode.accountId = ()
-    deploy_global_contract(nodes[0], test_contract, deploy_mode, 50)
+    deploy_global_contract(rpc, nodes[0], test_contract, deploy_mode, 50)
 
     identifier = GlobalContractIdentifier()
     identifier.enum = "accountId"
     identifier.accountId = nodes[0].signer_key.account_id
-    use_global_contract(nodes[1], identifier, 60)
+    use_global_contract(rpc, nodes[1], identifier, 60)
 
     call_contract(rpc, nodes[0], nodes[1].signer_key.account_id, 70)
     call_contract(rpc, nodes[1], nodes[1].signer_key.account_id, 80)
 
 
 def call_contract(rpc, node, contract_id, nonce):
-    last_block_hash = node.get_latest_block().hash_bytes
+    last_block_hash = rpc.get_latest_block().hash_bytes
     tx = sign_function_call_tx(node.signer_key, contract_id, 'log_something',
                                [], 150 * GGAS, 1, nonce, last_block_hash)
     res = rpc.send_tx_and_wait(tx, 10)
@@ -78,24 +76,32 @@ def call_contract(rpc, node, contract_id, nonce):
     assert res['result']['receipts_outcome'][0]['outcome']['logs'][0] == 'hello'
 
 
-def deploy_global_contract(node, contract, deploy_mode, nonce):
-    last_block_hash = node.get_latest_block().hash_bytes
+def deploy_global_contract(rpc, node, contract, deploy_mode, nonce):
+    last_block_hash = rpc.get_latest_block().hash_bytes
     tx = sign_deploy_global_contract_tx(node.signer_key, contract, deploy_mode,
                                         nonce, last_block_hash)
-    res = node.send_tx_and_wait_until(tx, "EXECUTED", 10)
+    res = rpc.send_tx_and_wait(tx, 10)
     print("deploy", res)
+    assert "SuccessValue" in res['result']['status']
+
+
+def use_global_contract(rpc, node, identifier, nonce):
+    """
+    Uses up-to 5 nonces past the supplied `nonce` for retries.
+    """
+    last_block_hash = rpc.get_latest_block().hash_bytes
+
     # transaction becoming "Executed" does not imply that the global contract distribution receipt
-    # has been executed on all nodes and therefore we can't use transaction execution as a cue that
-    # it can already be deployed to an account (used.)
-    time.sleep(5)
-
-
-def use_global_contract(node, identifier, nonce):
-    last_block_hash = node.get_latest_block().hash_bytes
-    tx = sign_use_global_contract_tx(node.signer_key, identifier, nonce,
-                                     last_block_hash)
-    res = node.send_tx_and_wait(tx, 10)
-    print("use", res)
+    # has been executed on all nodes and therefore we can't use deploy's finality status as a cue
+    # that it can already be deployed to an account (used.) We'll try a few times to mitigate.
+    for attempt in range(5):
+        tx = sign_use_global_contract_tx(node.signer_key, identifier,
+                                         nonce + attempt, last_block_hash)
+        res = rpc.send_tx_and_wait(tx, 10)
+        print("use", res)
+        if "SuccessValue" in res['result']['status']:
+            return
+    assert false, "5 attempts to use contract did not succeed"
 
 
 if __name__ == '__main__':

--- a/pytest/tests/contracts/deploy_call_smart_contract.py
+++ b/pytest/tests/contracts/deploy_call_smart_contract.py
@@ -21,14 +21,15 @@ def test_deploy_contract():
     last_block_hash = nodes[0].get_latest_block().hash_bytes
     tx = sign_deploy_contract_tx(nodes[0].signer_key, load_test_contract(), 10,
                                  last_block_hash)
-    nodes[0].send_tx(tx)
-    time.sleep(3)
+    res = nodes[0].send_tx_and_wait(tx, 5)
+    print("deploy", res)
 
     last_block_hash = nodes[1].get_latest_block().hash_bytes
     tx = sign_function_call_tx(nodes[0].signer_key,
                                nodes[0].signer_key.account_id, 'log_something',
                                [], 150 * GGAS, 1, 20, last_block_hash)
     res = nodes[1].send_tx_and_wait(tx, 20)
+    print("call", res)
     import json
     print(json.dumps(res, indent=2))
     assert res['result']['receipts_outcome'][0]['outcome']['logs'][0] == 'hello'


### PR DESCRIPTION
Sleeping an arbitrary amount is prone to fail due to small timing changes.

This change also picks up some assorted improvements that reduce log spam or make configuration patches not explode pytest when given dicts for initially non-dict values.