### PR TITLE
fix: missing global contract in det-account init

### DIFF
--- a/runtime/runtime/src/deterministic_account_id.rs
+++ b/runtime/runtime/src/deterministic_account_id.rs
@@ -82,6 +82,9 @@ pub(crate) fn action_deterministic_state_init(
             // Account already exists, do nothing.
         }
     }
+    if result.result.is_err() {
+        return Ok(());
+    }
     debug_assert!(
         matches!(AccountState::of(account.as_ref()), AccountState::Active),
         "account must be active now"
@@ -171,6 +174,9 @@ fn deploy_deterministic_account(
         current_protocol_version,
         result,
     )?;
+    if result.result.is_err() {
+        return Ok(());
+    }
 
     // Step 2: insert provided key-value pairs
     let mut required_storage_usage = account.storage_usage();


### PR DESCRIPTION
When deploying a deterministic account and referencing a global contract that doesn't exist, the receipt fails.

This fix ensures an early return and avoids additional work after the error was found. Specifically, the data is not copied to a temporary state change which will be dropped anyway.