### PR TITLE
fix(test-loop-tests): silence annoying warning

### DIFF
--- a/test-loop-tests/src/utils/node.rs
+++ b/test-loop-tests/src/utils/node.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::task::Poll;
 
+#[cfg(feature = "test_features")]
 use near_async::messaging::CanSend;
 use near_async::test_loop::TestLoopV2;
 use near_async::test_loop::data::TestLoopData;
@@ -38,6 +39,7 @@ impl<'a> TestLoopNode<'a> {
         Self { data }
     }
 
+    #[allow(unused)]
     pub fn all(node_datas: &'a [NodeExecutionData]) -> Vec<Self> {
         node_datas.iter().map(|data| Self { data }).collect()
     }


### PR DESCRIPTION
Silence two warnings that pop up when running `cargo test`:
```shell
$ cargo nextest run test_wasmtime_artifact_output_stability
warning: unused import: `near_async::messaging::CanSend`
 --> test-loop-tests/src/utils/node.rs:4:5
  |
4 | use near_async::messaging::CanSend;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: associated function `all` is never used
  --> test-loop-tests/src/utils/node.rs:41:12
   |
30 | impl<'a> TestLoopNode<'a> {
   | ------------------------- associated function in this implementation
...
41 |     pub fn all(node_datas: &'a [NodeExecutionData]) -> Vec<Self> {
   |            ^^^
   |
   = note: `#[warn(dead_code)]` on by default
```

`CanSend` is used only in the `send_adversarial_message` method, which requires the `test_features` feature, without it it's an unused import.

The `all` function used in `missing_chunk_window_example_test`, but this test is also guarded by `test_features`, making the method unused when this feature is not enabled. This method makes sense without the feature, so I marked it `allow(unused)` instead of hiding it behind `test_features`.