### PR TITLE
fix: flaky validator_node_restart

### DIFF
--- a/chain/network/src/peer_manager/tests/accounts_data.rs
+++ b/chain/network/src/peer_manager/tests/accounts_data.rs
@@ -312,6 +312,9 @@ async fn validator_node_restart() {
         drop(pm0);
         clock.set_utc(clock.now_utc() + downtime);
         cfg.node_key = data::make_secret_key(rng);
+        // The test is flaky when restarted on the same port because it can take some time
+        // after dropping pm0 before its listener is cleaned up. We use a new port instead.
+        cfg.node_addr = Some(tcp::ListenerAddr::reserve_for_test());
         let pm0 = start_pm(clock.clock(), TestDB::new(), cfg.clone(), chain.clone()).await;
         pm0.set_chain_info(chain_info.clone()).await;
 


### PR DESCRIPTION
We observed this test failing in CI with the following error:

```
thread 'tokio-runtime-worker' panicked at chain/network/src/peer_manager/peer_manager_actor.rs:272:29:
failed to start listening on server_addr=[::1]:31971 e=Os { code: 98, kind: AddrInUse, message: "Address already in use" }
```

During the test a node is stopped by dropping the PeerManagerActor, after which it is started again:

https://github.com/near/nearcore/blob/6d64f5e99181fd263d7bf9f6ccb5fdb8b7b63fda/chain/network/src/peer_manager/tests/accounts_data.rs#L311-L316

In a local environment I could reproduce the `AddrInUse` error by binding a TcpListener to the node's addr immediately after `drop(pm0)`. This happens because the TcpListener created by the peer manager is owned by a background task and it takes time to cancel the task and free the port after the peer manager is dropped. In local testing it takes under 1 ms but under load (parallel test execution) the time needed may be unpredictable.

We can avoid the contention entirely by restarting on a different port instead.

Note that the `downtime` referenced in the code is implemented by advancing a FakeClock and is not relevant with regards to freeing the port.