### PR TITLE
feat(tx_generator): limit number of transactions in a singe chunk

### DIFF
--- a/benchmarks/transactions-generator/Cargo.toml
+++ b/benchmarks/transactions-generator/Cargo.toml
@@ -23,7 +23,7 @@ near-async = { workspace = true }
 near-crypto = { workspace = true }
 near-network = { workspace = true }
 near-primitives = { workspace = true, features = ["clock", "test_utils"] }
-near-client.workspace = true
+near-client = { workspace = true, features = ["tx_generator"] }
 near-client-primitives.workspace = true
 node-runtime.workspace = true
 

--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -682,6 +682,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         transaction_groups: &mut dyn TransactionGroupIterator,
         chain_validate: &dyn Fn(&SignedTransaction) -> bool,
         time_limit: Option<Duration>,
+        transaction_num_limit: Option<usize>,
     ) -> Result<PreparedTransactions, Error> {
         let shard_uid = self.get_shard_uid_from_epoch_id(shard_id, &prev_block.next_epoch_id)?;
 
@@ -717,6 +718,7 @@ impl RuntimeAdapter for NightshadeRuntime {
             chain_validate,
             HashSet::new(),
             time_limit,
+            transaction_num_limit,
             None,
         ) // skip_tx_hashes is empty, so there will be no skipped transactions
         .map(|(prepared, _skipped)| prepared)
@@ -742,6 +744,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         chain_validate: &dyn Fn(&SignedTransaction) -> bool,
         skip_tx_hashes: HashSet<CryptoHash>,
         time_limit: Option<Duration>,
+        transaction_num_limit: Option<usize>,
         cancel: Option<Arc<AtomicBool>>,
     ) -> Result<(PreparedTransactions, SkippedTransactions), Error> {
         let start_time = std::time::Instant::now();
@@ -787,6 +790,13 @@ impl RuntimeAdapter for NightshadeRuntime {
             if let Some(time_limit) = &time_limit {
                 if start_time.elapsed() >= *time_limit {
                     result.limited_by = Some(PrepareTransactionsLimit::Time);
+                    break;
+                }
+            }
+
+            if let Some(tx_num_limit) = &transaction_num_limit {
+                if result.transactions.len() >= *tx_num_limit {
+                    result.limited_by = Some(PrepareTransactionsLimit::NumTransactions);
                     break;
                 }
             }

--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -1597,6 +1597,7 @@ fn prepare_transactions(
                 .is_ok()
         },
         default_produce_chunk_add_transactions_time_limit(),
+        None,
     )
 }
 
@@ -1637,6 +1638,7 @@ fn prepare_transactions_extra(
         },
         skip_tx_hashes,
         default_produce_chunk_add_transactions_time_limit(),
+        None,
         cancel,
     )
 }

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -384,6 +384,7 @@ pub enum PrepareTransactionsLimit {
     ReceiptCount,
     StorageProofSize,
     Cancelled,
+    NumTransactions,
 }
 
 /// Information used to prepare transactions, based on the previous block.
@@ -478,6 +479,7 @@ pub trait RuntimeAdapter: Send + Sync {
         transaction_groups: &mut dyn TransactionGroupIterator,
         chain_validate: &dyn Fn(&SignedTransaction) -> bool,
         time_limit: Option<Duration>,
+        transaction_num_limit: Option<usize>,
     ) -> Result<PreparedTransactions, Error>;
 
     /// `prepare_transactions` with extra options, used in early transaction preparation.
@@ -500,6 +502,7 @@ pub trait RuntimeAdapter: Send + Sync {
         chain_validate: &dyn Fn(&SignedTransaction) -> bool,
         skip_tx_hashes: HashSet<CryptoHash>,
         time_limit: Option<Duration>,
+        transaction_num_limit: Option<usize>,
         cancel: Option<Arc<AtomicBool>>,
     ) -> Result<(PreparedTransactions, SkippedTransactions), Error>;
 

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -106,6 +106,7 @@ sandbox = [
     "near-chain/sandbox",
     "near-o11y/sandbox",
 ]
+tx_generator = []
 
 [package.metadata.cargo-machete]
 ignored = ["rust-s3"]

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -24,6 +24,8 @@ pub use crate::stateless_validation::chunk_validation_actor::{
 };
 pub use crate::view_client_actor::ViewClientActor;
 pub use chunk_producer::ProduceChunkResult;
+#[cfg(feature = "tx_generator")]
+pub use chunk_producer::{TX_GENERATOR_TARGET, TxGeneratorTarget};
 pub use near_chain::stateless_validation::processing_tracker::{
     ProcessingDoneTracker, ProcessingDoneWaiter,
 };

--- a/chain/client/src/prepare_transactions.rs
+++ b/chain/client/src/prepare_transactions.rs
@@ -27,6 +27,7 @@ pub struct PrepareTransactionsJobInputs {
     pub tx_validity_period_check: Box<dyn Fn(&SignedTransaction) -> bool + Send + 'static>,
     pub prev_chunk_tx_hashes: HashSet<CryptoHash>,
     pub time_limit: Option<Duration>,
+    pub transaction_num_limit: Option<usize>,
 }
 
 impl PrepareTransactionsJobInputs {
@@ -53,6 +54,7 @@ impl PrepareTransactionsJobInputs {
             tx_validity_period_check: Box::new(|_| true),
             prev_chunk_tx_hashes: HashSet::new(),
             time_limit: None,
+            transaction_num_limit: None,
         }
     }
 }
@@ -137,6 +139,7 @@ impl PrepareTransactionsJob {
             &inputs.tx_validity_period_check,
             inputs.prev_chunk_tx_hashes,
             inputs.time_limit,
+            inputs.transaction_num_limit,
             Some((&self).cancel.clone()),
         );
         drop(iter);

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -59,7 +59,7 @@ anyhow.workspace = true
 rustc_version = "0.4"
 
 [features]
-tx_generator = ["nearcore/tx_generator"]
+tx_generator = ["nearcore/tx_generator", "near-client/tx_generator"]
 default = ["json_rpc", "rosetta_rpc"]
 protocol_feature_spice = [
   "near-client/protocol_feature_spice",


### PR DESCRIPTION
This PR changes how `transaction-generator` works on workloads controlled by the PID controller.

Currently how it works is that `transaction-generator` decides what should be the current TPS and starts generating transactions at this TPS rate. Chunk producer picks up all transactions from the pool that it can and puts them in a chunk. Controller observes the recent block times and adjusts TPS rate accordingly. With this the TPS on chain roughly correspond to the TPS set requested by `transaction-generator`.

But there is a problem with chunk size variance - for some reason some of the chunks are smaller or bigger than other ones, they can differ by as much as 25%. This variance causes one shard to do more work than others, causing desync and lowering chain throughput.

This PR changes things to ensure that chunks are exactly as large as the TPS rate set by `transaction-generator` would suggest. The chunk producer becomes aware of the current TPS rate through the `TX_GENERATOR_TARGET` variable, and picks exactly as many transactions as it should from the pool (`target_tps * target_block_production_time_s` transactions per chunk). So for example when `target_tps= 20_000` and `target_block_production_time_s = 1.7`, the chunk will contain exactly `20_000 * 1.7 = 34000` transactions.

Transactions are generated at a rate that's 1.2x higher than the target tps to ensure that transaction pool is always full and the chunk producer can pick as many transactions as it wants. The pool has a size limit, so there is no OOM issues when transactions are submitted faster than they're consumed. Once the size limit is hit, transaction pool starts to silently drop new incoming transactions until space frees up.

The PR doesn't change how transaction generation works with the static TPS schedule. It seems that chunk variance is less of an issue there.

Run on maser (`664af1fea20511418434ec2add98763d90ac8edd`): 20 shards, Peak 309k TPS [grafana](https://grafana.nearone.org/d/deg7e0doxn30gf/blockchain-performance?orgId=1&from=2025-11-24T21:07:58.000Z&to=2025-11-24T22:50:06.000Z&timezone=utc&var-chain_id=$__all&var-role=$__all&var-node_type=$__all&var-node_id=.%2Amastr.%2A&var-shard_id=$__all&refresh=1m) [workflow](https://github.com/Near-One/infra-ops/actions/runs/19649028337)
Run on this branch(`2445e568c61a354e16cb784112d8e99e50b9e809`): 20 shards, peak 331 TPs [grafana](https://grafana.nearone.org/d/deg7e0doxn30gf/blockchain-performance?orgId=1&from=2025-11-24T21:17:09.000Z&to=2025-11-24T22:51:25.000Z&timezone=utc&var-chain_id=$__all&var-role=$__all&var-node_type=$__all&var-node_id=.%2Atxlimit.%2A&var-shard_id=$__all&refresh=1m) [workflow](https://github.com/Near-One/infra-ops/actions/runs/19649242462)

Around 7% gain

There's still an issue that `tx_generator` can suggest different TPS rates on different nodes, causing a bit of desync. Can be fixed in another PR.