### PR TITLE
feat(traces): add shard_id attribute to on_chunk_completed span

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1329,6 +1329,7 @@ impl Client {
         fields(
             hash = ?partial_chunk.chunk_hash(),
             height = ?partial_chunk.height_created(),
+            shard_id = %partial_chunk.shard_id(),
             tag_block_production = true
         )
     )]


### PR DESCRIPTION
This will make the `shard_id` visible in `on_chunk_completed` spans.
Currently there's only height:

<img width="216" height="138" alt="image" src="https://github.com/user-attachments/assets/92fe98b2-c858-4fe0-8599-7fc3b7491101" />
