### PR TITLE
fix(det-accounts): store deposit in pre-initialization

### DIFF
--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -561,7 +561,11 @@ pub(crate) fn action_implicit_account_creation_transfer(
             .ok();
         }
         AccountType::NearDeterministicAccount => {
-            create_deterministic_account(account, &apply_state.config.fees.storage_usage_config);
+            create_deterministic_account(
+                account,
+                deposit,
+                &apply_state.config.fees.storage_usage_config,
+            );
         }
         // This panic is unreachable as this is an implicit account creation transfer.
         // `check_account_existence` would fail because `account_is_implicit` would return false for a Named account.

--- a/runtime/runtime/src/deterministic_account_id.rs
+++ b/runtime/runtime/src/deterministic_account_id.rs
@@ -58,7 +58,9 @@ pub(crate) fn action_deterministic_state_init(
     let storage_usage_config = &apply_state.config.fees.storage_usage_config;
     match AccountState::of(account.as_ref()) {
         AccountState::NonExisting => {
-            create_deterministic_account(account, storage_usage_config);
+            // Create with zero balance now and check later how much of the
+            // provided deposit is needed.
+            create_deterministic_account(account, Balance::ZERO, storage_usage_config);
             deploy_deterministic_account(
                 state_update,
                 account.as_mut().expect("account must exist now"),
@@ -136,6 +138,7 @@ pub(crate) fn action_deterministic_state_init(
 
 pub(crate) fn create_deterministic_account(
     account: &mut Option<Account>,
+    initial_balance: Balance,
     storage_usage_config: &StorageUsageConfig,
 ) {
     // Unlike `CreateAccount`, this account creation does not change
@@ -145,7 +148,7 @@ pub(crate) fn create_deterministic_account(
     // `AddKey`, `DeployContract`, or any other actions that only the
     // account owner is permitted to do.
     *account = Some(Account::new(
-        Balance::ZERO,
+        initial_balance,
         Balance::ZERO,
         AccountContract::None,
         storage_usage_config.num_bytes_account,

--- a/test-loop-tests/src/tests/deterministic_account_id.rs
+++ b/test-loop-tests/src/tests/deterministic_account_id.rs
@@ -39,7 +39,8 @@ use near_primitives::deterministic_account_id::{
     DeterministicAccountStateInit, DeterministicAccountStateInitV1,
 };
 use near_primitives::errors::{
-    ActionError, ActionErrorKind, ActionsValidationError, InvalidTxError, TxExecutionError,
+    ActionError, ActionErrorKind, ActionsValidationError, CompilationError, FunctionCallError,
+    InvalidTxError, TxExecutionError,
 };
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
@@ -340,6 +341,55 @@ fn test_deterministic_state_init_named_receiver() {
     env.shutdown();
 }
 
+/// Ensure we can pre-pay the balance for a deterministic account.
+///
+/// It is a required feature that one can send a Transfer to a non-existing
+/// deterministic account first and later initialize it without adding balance,
+/// even if more storage than the ZBA limit is used.
+#[test]
+fn test_deterministic_state_init_prepay_for_storage() {
+    if !ProtocolFeature::DeterministicAccountIds.enabled(PROTOCOL_VERSION) {
+        return;
+    }
+    let mut env = TestEnv::setup(Balance::from_near(100));
+    env.deploy_global_contract(GlobalContractDeployMode::AccountId);
+
+    let data = BTreeMap::from_iter([(b"key".to_vec(), vec![0u8; 100_000])]);
+    let (state_init, det_account) = env.new_deterministic_account_with_data(data.clone());
+
+    // Try once without pre-paying, must fail.
+    let outcome = env
+        .try_deploy_deterministic_account_with_data(data.clone(), Balance::ZERO)
+        .expect("should be able to send transaction");
+    assert_matches!(
+        outcome.status,
+        FinalExecutionStatus::Failure(TxExecutionError::ActionError(ActionError {
+            kind: ActionErrorKind::LackBalanceForState { .. },
+            index: _
+        }))
+    );
+
+    // Prepay
+    let required_for_storage = env.balance_for_storage(state_init);
+    env.fund_with_near_balance(det_account.clone(), required_for_storage);
+    assert_eq!(
+        required_for_storage,
+        env.get_account_state(det_account.clone()).amount,
+        "account should have been created and funded now"
+    );
+
+    // Contract can't be called, yet.
+    env.assert_test_contract_not_usable_on_account(det_account.clone());
+
+    // Try creating again, with zero balance again. Must succeed this time.
+    env.try_deploy_deterministic_account_with_data(data, Balance::ZERO)
+        .expect("should be able to send transaction")
+        .assert_success();
+    env.assert_test_contract_usable_on_account(det_account);
+
+    env.shutdown();
+}
+
 struct TestEnv {
     env: TestLoopEnv,
     runtime_config_store: RuntimeConfigStore,
@@ -506,9 +556,38 @@ impl TestEnv {
         )
     }
 
+    fn fund_with_near_balance(&mut self, receiver_id: AccountId, amount: Balance) {
+        let signer_id = self.independent_account();
+        let signer = create_user_test_signer(&signer_id);
+        let tx = SignedTransaction::send_money(
+            self.next_nonce(),
+            signer_id,
+            receiver_id,
+            &signer,
+            amount,
+            self.get_tx_block_hash(),
+        );
+        self.execute_tx(tx).assert_success();
+    }
+
     fn assert_test_contract_usable_on_account(&mut self, account_with_contract: AccountId) {
         let tx = self.call_test_contract_tx(self.independent_account(), account_with_contract);
         self.run_tx(tx);
+    }
+
+    fn assert_test_contract_not_usable_on_account(&mut self, account_with_contract: AccountId) {
+        let tx = self.call_test_contract_tx(self.independent_account(), account_with_contract);
+        let outcome = self.execute_tx(tx);
+
+        assert_matches!(
+            outcome.status,
+            FinalExecutionStatus::Failure(TxExecutionError::ActionError(ActionError {
+                kind: ActionErrorKind::FunctionCallError(FunctionCallError::CompilationError(
+                    CompilationError::CodeDoesNotExist { .. }
+                )),
+                index: _
+            }))
+        );
     }
 
     fn try_execute_tx(
@@ -552,6 +631,13 @@ impl TestEnv {
             tx,
             Duration::seconds(5),
         );
+    }
+
+    #[track_caller]
+    fn execute_tx(&mut self, tx: SignedTransaction) -> FinalExecutionOutcomeView {
+        TestLoopNode::for_account(&self.env.node_datas, &rpc_account_id())
+            .execute_tx(&mut self.env.test_loop, tx, Duration::seconds(5))
+            .unwrap()
     }
 
     fn global_contract_identifier(


### PR DESCRIPTION
It's an explicit feature in NEP-616  to allow sending a Transfer to a deterministic account id first, already creating the account but not allowing it to be called, yet.

This fixes a crucial bug in the pre-initialization creation, where the deposit was not deposit and just vanished instead.

`test_deterministic_state_init_prepay_for_storage` checks that the described feature works as expected and that the sent funds arrive at the receiver.