### PR TITLE
[benchmark] use the block time to measure bps

### DIFF
--- a/benchmarks/sharded-bm/cases/forknet/20-shards/tx-generator-settings.json
+++ b/benchmarks/sharded-bm/cases/forknet/20-shards/tx-generator-settings.json
@@ -7,8 +7,8 @@
 		],
 		"controller": {
 			"target_block_production_time_s": 1.5,
-			"bps_filter_window_length": 40,
-			"gain_proportional": 60.0,
+			"bps_filter_window_length": 6,
+			"gain_proportional": 200.0,
 			"gain_integral": 0.0,
 			"gain_derivative": 0.0
 		}

--- a/benchmarks/sharded-bm/cases/forknet/20-shards/tx-generator-settings.json
+++ b/benchmarks/sharded-bm/cases/forknet/20-shards/tx-generator-settings.json
@@ -10,7 +10,8 @@
 			"bps_filter_window_length": 6,
 			"gain_proportional": 200.0,
 			"gain_integral": 0.0,
-			"gain_derivative": 0.0
+			"gain_derivative": 0.0,
+			"block_pause_threshold_ms": 3000,
 		}
 	}
 }

--- a/benchmarks/sharded-bm/cases/forknet/4-shards/tx-generator-settings.json
+++ b/benchmarks/sharded-bm/cases/forknet/4-shards/tx-generator-settings.json
@@ -10,7 +10,8 @@
 			"bps_filter_window_length": 6,
 			"gain_proportional": 300.0,
 			"gain_integral": 0,
-			"gain_derivative": 0.0
+			"gain_derivative": 0.0,
+			"block_pause_threshold_ms": 3000
 		}
 	}
 }

--- a/benchmarks/sharded-bm/cases/forknet/4-shards/tx-generator-settings.json
+++ b/benchmarks/sharded-bm/cases/forknet/4-shards/tx-generator-settings.json
@@ -7,8 +7,8 @@
 		],
 		"controller": {
 			"target_block_production_time_s": 1.5,
-			"bps_filter_window_length": 40,
-			"gain_proportional": 60.0,
+			"bps_filter_window_length": 6,
+			"gain_proportional": 300.0,
 			"gain_integral": 0,
 			"gain_derivative": 0.0
 		}

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -870,7 +870,7 @@ pub struct StatusResponse {
 }
 
 /// Contains main info about the block.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct BlockHeaderView {
     pub height: BlockHeight,


### PR DESCRIPTION
- use block time to measure BPS. Previously the block request time was used, which resulted in the noisy rate
- if we do not get new blocks for longer than 3s stop updating the rate and pause pushing new transactions
- adjust the averaging window and p-gain for 4- and 20- shards runs. The BPS is rock-solid. TPS still fluctuates quite a lot in the second half of the run.
  + [4-shards](https://grafana.nearone.org/d/deg7e0doxn30gf/blockchain-performance?orgId=1&from=2025-10-06T16:00:40.000Z&to=2025-10-06T17:32:12.000Z&timezone=utc&var-chain_id=$__all&var-role=$__all&var-node_type=$__all&var-node_id=.%2Abenchmark-.%2A&var-shard_id=$__all&refresh=10s)
  + [20-shards](https://grafana.nearone.org/d/deg7e0doxn30gf/blockchain-performance?orgId=1&from=2025-10-06T14:44:11.000Z&to=2025-10-06T15:54:44.000Z&timezone=utc&var-chain_id=$__all&var-role=$__all&var-node_type=$__all&var-node_id=.%2Abenchmark-.%2A&var-shard_id=$__all&refresh=10s)