### PR TITLE
feat: add host function promise_result_length

### DIFF
--- a/runtime/near-vm-runner/src/imports.rs
+++ b/runtime/near-vm-runner/src/imports.rs
@@ -177,6 +177,7 @@ imports! {
     #[deterministic_account_ids] promise_batch_action_state_init<[promise_idx: u64, code_len: u64, code_ptr: u64, amount_ptr: u64] -> [u64]>,
     #[deterministic_account_ids] promise_batch_action_state_init_by_account_id<[promise_idx: u64, account_id_len: u64, code_hash_ptr: u64, amount_ptr: u64] -> [u64]>,
     #[deterministic_account_ids] set_state_init_data_entry<[promise_idx: u64, action_index: u64, key_len: u64, key_ptr: u64, value_len: u64, value_ptr: u64] -> []>,
+    #[deterministic_account_ids] promise_result_length<[result_idx: u64] -> [u64]>,
     #[deterministic_account_ids] current_contract_code<[register_id: u64] -> [u64]>,
     #[deterministic_account_ids] refund_to_account_id<[register_id: u64] -> []>,
     // #######################

--- a/runtime/near-vm-runner/src/logic/tests/promises.rs
+++ b/runtime/near-vm-runner/src/logic/tests/promises.rs
@@ -31,6 +31,10 @@ fn test_promise_results() {
     assert_eq!(logic.promise_result(1, 0), Ok(2), "Failed promise must return code 2");
     assert_eq!(logic.promise_result(2, 0), Ok(0), "Pending promise must return 0");
 
+    assert_eq!(logic.promise_result_length(0), Ok(4), "must be length of success value");
+    assert_eq!(logic.promise_result_length(1), Ok(0), "failed promise has no length");
+    assert_eq!(logic.promise_result_length(2), Ok(0), "pending promise has no length");
+
     // Only promise with result should write data into register
     logic.assert_read_register(b"test", 0);
 }

--- a/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
@@ -3559,6 +3559,46 @@ pub fn promise_results_count(caller: &mut Caller<'_, Ctx>) -> Result<u64> {
     Ok(ctx.context.promise_results.len() as _)
 }
 
+/// A method to check how much memory [`Self::promise_result()`] would return.
+///
+/// If the current function is invoked by a callback, we can access the length of execution
+/// results of the promises that caused the callback. It can be used to prevent out-of-gas
+/// failures when reading too long execution result via [`Self::promise_result()`].
+///
+/// # Returns
+///
+/// * If promise result is complete and successful returns the length in bytes of the promise result;
+/// * If promise result is not complete or failed returns `0`;
+///
+/// # Errors
+///
+/// * If `result_idx` does not correspond to an existing result returns [`HostError::InvalidPromiseResultIndex`];
+/// * If called as view function returns [`HostError::ProhibitedInView`].
+///
+/// # Cost
+///
+/// `base` - the base cost for a simple host function call
+pub fn promise_result_length(caller: &mut Caller<'_, Ctx>, result_idx: u64) -> Result<u64> {
+    let ctx = caller.data_mut();
+    ctx.result_state.gas_counter.pay_base(base)?;
+    if ctx.context.is_view() {
+        return Err(HostError::ProhibitedInView {
+            method_name: "promise_result_length".to_string(),
+        }
+        .into());
+    }
+    match ctx
+        .context
+        .promise_results
+        .get(result_idx as usize)
+        .ok_or(HostError::InvalidPromiseResultIndex { result_idx })?
+    {
+        PromiseResult::Successful(data) => Ok(data.len() as u64),
+        PromiseResult::NotReady => Ok(0),
+        PromiseResult::Failed => Ok(0),
+    }
+}
+
 /// If the current function is invoked by a callback we can access the execution results of the
 /// promises that caused the callback. This function returns the result in blob format and
 /// places it into the register.


### PR DESCRIPTION
`promise_result_length` allows reading the length of `promise_result` without reading it.

This method is an essential feature for sharded contracts. Specifically a sharded FT implementation needs this to handle refunds properly.