### PR TITLE
fix: network crate test_util dependency

### DIFF
--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -50,7 +50,7 @@ near-chain-configs.workspace = true
 near-crypto.workspace = true
 near-performance-metrics.workspace = true
 near-performance-metrics-macros.workspace = true
-near-primitives = { workspace = true, features = ["rand", "solomon", "clock"] }
+near-primitives = { workspace = true, features = ["rand", "solomon", "clock", "test_utils"] }
 near-store.workspace = true
 near-schema-checker-lib.workspace = true
 


### PR DESCRIPTION
Restores ability to `cargo build` or `cargo nextest run` on just the network crate.