### PR TITLE
[limited_replayability] Deprecate features GlobalContracts, BlockHeightForReceiptId, ProduceOptimisticBlock

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2347,12 +2347,10 @@ impl Chain {
             // TODO(spice): move incoming receipts collection inside apply_chunks_preprocessing
             HashMap::default()
         } else {
-            let receipts_shuffle_salt =
-                get_receipts_shuffle_salt(self.epoch_manager.as_ref(), &block)?;
             self.collect_incoming_receipts_from_chunks(
                 &block.chunks(),
                 &prev_hash,
-                receipts_shuffle_salt,
+                get_receipts_shuffle_salt(&block),
             )?
         };
 
@@ -2609,12 +2607,10 @@ impl Chain {
             let prev_block = self.chain_store.get_block(block.header().prev_hash())?.clone();
             let prev_hash = *prev_block.hash();
 
-            let receipts_shuffle_salt =
-                get_receipts_shuffle_salt(self.epoch_manager.as_ref(), &block)?;
             let receipts_by_shard = self.collect_incoming_receipts_from_chunks(
                 &block.chunks(),
                 &prev_hash,
-                receipts_shuffle_salt,
+                get_receipts_shuffle_salt(&block),
             )?;
 
             let work = self.apply_chunks_preprocessing(

--- a/chain/chain/src/sharding.rs
+++ b/chain/chain/src/sharding.rs
@@ -1,24 +1,13 @@
-use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::block::Block;
-use near_primitives::errors::EpochError;
 use near_primitives::hash::CryptoHash;
-use near_primitives::version::ProtocolFeature;
 use rand::SeedableRng;
 use rand::seq::SliceRandom;
 use rand_chacha::ChaCha20Rng;
 
 /// Gets salt for shuffling receipts grouped by **source shards** before
 /// processing them in the target shard.
-pub fn get_receipts_shuffle_salt<'a>(
-    epoch_manager: &dyn EpochManagerAdapter,
-    block: &'a Block,
-) -> Result<&'a CryptoHash, EpochError> {
-    let protocol_version = epoch_manager.get_epoch_protocol_version(&block.header().epoch_id())?;
-    if ProtocolFeature::BlockHeightForReceiptId.enabled(protocol_version) {
-        Ok(block.header().prev_hash())
-    } else {
-        Ok(block.hash())
-    }
+pub fn get_receipts_shuffle_salt(block: &Block) -> &CryptoHash {
+    block.header().prev_hash()
 }
 
 pub fn shuffle_receipt_proofs<ReceiptProofType>(

--- a/chain/chain/src/stateless_validation/chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/chunk_validation.rs
@@ -482,8 +482,7 @@ fn validate_source_receipt_proofs(
         )?;
 
         // Arrange the receipts in the order in which they should be applied.
-        let receipts_shuffle_salt = get_receipts_shuffle_salt(epoch_manager, block)?;
-        shuffle_receipt_proofs(&mut block_receipt_proofs, receipts_shuffle_salt);
+        shuffle_receipt_proofs(&mut block_receipt_proofs, get_receipts_shuffle_salt(block));
         for proof in block_receipt_proofs {
             receipts_to_apply.extend(proof.0.iter().cloned());
         }

--- a/chain/chain/src/stateless_validation/spice_chunk_validation.rs
+++ b/chain/chain/src/stateless_validation/spice_chunk_validation.rs
@@ -291,8 +291,7 @@ fn validate_source_receipts_proofs(
     receipt_proofs =
         filter_incoming_receipts_for_shard(shard_layout, shard_id, Arc::new(receipt_proofs))?;
 
-    let receipts_shuffle_salt = get_receipts_shuffle_salt(epoch_manager, &block)?;
-    shuffle_receipt_proofs(&mut receipt_proofs, receipts_shuffle_salt);
+    shuffle_receipt_proofs(&mut receipt_proofs, get_receipts_shuffle_salt(&block));
     Ok(receipt_proofs.into_iter().map(|proof| proof.0).flatten().collect())
 }
 

--- a/chain/client/src/chunk_executor_actor.rs
+++ b/chain/client/src/chunk_executor_actor.rs
@@ -349,8 +349,6 @@ impl ChunkExecutorActor {
         let epoch_id = block.header().epoch_id();
         let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
 
-        let receipts_shuffle_salt = get_receipts_shuffle_salt(self.epoch_manager.as_ref(), &block)?;
-
         let chunk_headers = &block.chunks();
         let mut jobs = Vec::new();
         // TODO(spice-resharding): Make sure shard logic is correct with resharding.
@@ -380,7 +378,7 @@ impl ChunkExecutorActor {
             let mut receipt_proofs = incoming_receipts
                 .remove(&shard_id)
                 .expect("expected receipts for all tracked shards");
-            shuffle_receipt_proofs(&mut receipt_proofs, receipts_shuffle_salt);
+            shuffle_receipt_proofs(&mut receipt_proofs, get_receipts_shuffle_salt(&block));
 
             let storage_context =
                 StorageContext { storage_data_source: StorageDataSource::Db, state_patch };

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -77,7 +77,7 @@ use near_primitives::network::{AnnounceAccount, PeerId};
 use near_primitives::types::{AccountId, BlockHeight};
 use near_primitives::unwrap_or_return;
 use near_primitives::utils::MaybeValidated;
-use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature, get_protocol_upgrade_schedule};
+use near_primitives::version::{PROTOCOL_VERSION, get_protocol_upgrade_schedule};
 use near_primitives::views::{DetailedDebugStatus, ValidatorInfo};
 #[cfg(feature = "test_features")]
 use near_store::DBCol;
@@ -1192,10 +1192,6 @@ impl ClientActorInner {
             }
         }
 
-        let protocol_version = self.client.epoch_manager.get_epoch_protocol_version(&epoch_id)?;
-        if !ProtocolFeature::ProduceOptimisticBlock.enabled(protocol_version) {
-            return Ok(());
-        }
         let optimistic_block_height = self.client.doomslug.get_timer_height();
         if me != self.client.epoch_manager.get_block_producer(&epoch_id, optimistic_block_height)? {
             return Ok(());

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -301,7 +301,8 @@ pub enum ProtocolFeature {
     #[deprecated]
     _DeprecatedBlockHeightForReceiptId,
     /// Enable optimistic block production.
-    ProduceOptimisticBlock,
+    #[deprecated]
+    _DeprecatedProduceOptimisticBlock,
     #[deprecated]
     _DeprecatedGlobalContracts,
     /// NEP: https://github.com/near/NEPs/pull/536
@@ -420,7 +421,7 @@ impl ProtocolFeature {
             ProtocolFeature::_DeprecatedSimpleNightshadeV5 => 76,
             ProtocolFeature::_DeprecatedGlobalContracts
             | ProtocolFeature::_DeprecatedBlockHeightForReceiptId
-            | ProtocolFeature::ProduceOptimisticBlock => 77,
+            | ProtocolFeature::_DeprecatedProduceOptimisticBlock => 77,
             ProtocolFeature::SimpleNightshadeV6
             | ProtocolFeature::VersionedStateWitness
             | ProtocolFeature::ChunkPartChecks

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -298,7 +298,8 @@ pub enum ProtocolFeature {
     /// Instead of sending code in the witness, the code checks the code-size using the internal trie nodes.
     ExcludeExistingCodeFromWitnessForCodeLen,
     /// Use the block height instead of the block hash to calculate the receipt ID.
-    BlockHeightForReceiptId,
+    #[deprecated]
+    _DeprecatedBlockHeightForReceiptId,
     /// Enable optimistic block production.
     ProduceOptimisticBlock,
     #[deprecated]
@@ -418,7 +419,7 @@ impl ProtocolFeature {
             ProtocolFeature::_DeprecatedSimpleNightshadeV4 => 75,
             ProtocolFeature::_DeprecatedSimpleNightshadeV5 => 76,
             ProtocolFeature::_DeprecatedGlobalContracts
-            | ProtocolFeature::BlockHeightForReceiptId
+            | ProtocolFeature::_DeprecatedBlockHeightForReceiptId
             | ProtocolFeature::ProduceOptimisticBlock => 77,
             ProtocolFeature::SimpleNightshadeV6
             | ProtocolFeature::VersionedStateWitness

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -301,7 +301,8 @@ pub enum ProtocolFeature {
     BlockHeightForReceiptId,
     /// Enable optimistic block production.
     ProduceOptimisticBlock,
-    GlobalContracts,
+    #[deprecated]
+    _DeprecatedGlobalContracts,
     /// NEP: https://github.com/near/NEPs/pull/536
     ///
     /// Reduce the number of gas refund receipts by charging the current gas
@@ -416,7 +417,7 @@ impl ProtocolFeature {
             | ProtocolFeature::_DeprecatedCurrentEpochStateSync => 74,
             ProtocolFeature::_DeprecatedSimpleNightshadeV4 => 75,
             ProtocolFeature::_DeprecatedSimpleNightshadeV5 => 76,
-            ProtocolFeature::GlobalContracts
+            ProtocolFeature::_DeprecatedGlobalContracts
             | ProtocolFeature::BlockHeightForReceiptId
             | ProtocolFeature::ProduceOptimisticBlock => 77,
             ProtocolFeature::SimpleNightshadeV6
@@ -449,7 +450,7 @@ impl ProtocolFeature {
 pub const PROD_GENESIS_PROTOCOL_VERSION: ProtocolVersion = 29;
 
 /// Minimum supported protocol version for the current binary
-pub const MIN_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = 77;
+pub const MIN_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = 80;
 
 /// Current protocol version used on the mainnet with all stable features.
 const STABLE_PROTOCOL_VERSION: ProtocolVersion = 82;

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -429,12 +429,8 @@ pub fn validate_action(
     match action {
         Action::CreateAccount(_) => Ok(()),
         Action::DeployContract(a) => validate_deploy_contract_action(limit_config, a),
-        Action::DeployGlobalContract(a) => {
-            validate_deploy_global_contract_action(limit_config, a, current_protocol_version)
-        }
-        Action::UseGlobalContract(_) => {
-            validate_use_global_contract_action(current_protocol_version)
-        }
+        Action::DeployGlobalContract(a) => validate_deploy_global_contract_action(limit_config, a),
+        Action::UseGlobalContract(_) => validate_use_global_contract_action(),
         Action::FunctionCall(a) => validate_function_call_action(limit_config, a),
         Action::Transfer(_) => Ok(()),
         Action::Stake(a) => validate_stake_action(a),
@@ -480,10 +476,7 @@ fn validate_deploy_contract_action(
 fn validate_deploy_global_contract_action(
     limit_config: &LimitConfig,
     action: &DeployGlobalContractAction,
-    current_protocol_version: ProtocolVersion,
 ) -> Result<(), ActionsValidationError> {
-    check_global_contracts_enabled(current_protocol_version)?;
-
     if action.code.len() as u64 > limit_config.max_contract_size {
         return Err(ActionsValidationError::ContractSizeExceeded {
             size: action.code.len() as u64,
@@ -495,10 +488,8 @@ fn validate_deploy_global_contract_action(
 }
 
 /// Validates `UseGlobalContractAction`.
-fn validate_use_global_contract_action(
-    current_protocol_version: ProtocolVersion,
-) -> Result<(), ActionsValidationError> {
-    check_global_contracts_enabled(current_protocol_version)
+fn validate_use_global_contract_action() -> Result<(), ActionsValidationError> {
+    Ok(())
 }
 
 /// Validates `FunctionCallAction`. Checks that the method name length doesn't exceed the limit and
@@ -648,18 +639,6 @@ fn truncate_string(s: &str, limit: usize) -> String {
         }
     }
     unreachable!()
-}
-
-fn check_global_contracts_enabled(
-    current_protocol_version: ProtocolVersion,
-) -> Result<(), ActionsValidationError> {
-    if !ProtocolFeature::GlobalContracts.enabled(current_protocol_version) {
-        return Err(ActionsValidationError::UnsupportedProtocolFeature {
-            protocol_feature: "GlobalContracts".to_owned(),
-            version: current_protocol_version,
-        });
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/tools/replay-archive/src/cli.rs
+++ b/tools/replay-archive/src/cli.rs
@@ -460,9 +460,8 @@ impl ReplayController {
         }
 
         let mut store_update = self.chain_store.store_update();
-        let receipts_shuffle_salt = get_receipts_shuffle_salt(self.epoch_manager.as_ref(), block)?;
         for (shard_id, mut receipts) in receipt_proofs_by_shard_id {
-            shuffle_receipt_proofs(&mut receipts, receipts_shuffle_salt);
+            shuffle_receipt_proofs(&mut receipts, get_receipts_shuffle_salt(block));
             store_update.save_incoming_receipt(&block_hash, shard_id, Arc::new(receipts));
         }
         store_update.commit().unwrap();


### PR DESCRIPTION
Mainnet is at protocol version 80, which means we can deprecate features before this.