### PR TITLE
[limited_replayability] Deprecate ReducedGasRefunds protocol feature

### DIFF
--- a/chain/chain/src/runtime/mod.rs
+++ b/chain/chain/src/runtime/mod.rs
@@ -614,8 +614,7 @@ impl RuntimeAdapter for NightshadeRuntime {
     ) -> Result<(), InvalidTxError> {
         let runtime_config = self.runtime_config_store.get_config(current_protocol_version);
 
-        let cost =
-            tx_cost(runtime_config, &validated_tx.to_tx(), gas_price, current_protocol_version)?;
+        let cost = tx_cost(runtime_config, &validated_tx.to_tx(), gas_price)?;
         let shard_uid = shard_layout
             .account_id_to_shard_uid(validated_tx.to_signed_tx().transaction.signer_id());
         let trie = self.tries.get_trie_for_shard(shard_uid, state_root);
@@ -836,23 +835,19 @@ impl RuntimeAdapter for NightshadeRuntime {
                     (&mut inserted.1, &mut inserted.2)
                 };
 
-                let verify_result = tx_cost(
-                    runtime_config,
-                    &validated_tx.to_tx(),
-                    prev_block.next_gas_price,
-                    protocol_version,
-                )
-                .map_err(InvalidTxError::from)
-                .and_then(|cost| {
-                    verify_and_charge_tx_ephemeral(
-                        runtime_config,
-                        signer,
-                        access_key,
-                        validated_tx.to_tx(),
-                        &cost,
-                        Some(next_block_height),
-                    )
-                });
+                let verify_result =
+                    tx_cost(runtime_config, &validated_tx.to_tx(), prev_block.next_gas_price)
+                        .map_err(InvalidTxError::from)
+                        .and_then(|cost| {
+                            verify_and_charge_tx_ephemeral(
+                                runtime_config,
+                                signer,
+                                access_key,
+                                validated_tx.to_tx(),
+                                &cost,
+                                Some(next_block_height),
+                            )
+                        });
 
                 match verify_result {
                     Ok(cost) => {

--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -100,7 +100,6 @@ pub async fn build_streamer_message(
                 .filter(|tx| tx.transaction.signer_id == tx.transaction.receiver_id)
                 .collect::<Vec<&IndexerTransactionWithOutcome>>(),
             &block,
-            protocol_config_view.protocol_version,
         )
         .await?;
 
@@ -261,7 +260,6 @@ async fn find_local_receipt_by_id_in_block(
 ) -> Result<Option<views::ReceiptView>, FailedToFetchData> {
     let chunks = client.fetch_block_new_chunks(&block, shard_tracker).await?;
 
-    let protocol_config_view = client.fetch_protocol_config(block.header.hash).await?;
     let mut shards_outcomes = client.fetch_outcomes(block.header.hash).await?;
 
     for chunk in chunks {
@@ -288,7 +286,6 @@ async fn find_local_receipt_by_id_in_block(
                 &runtime_config,
                 vec![&indexer_transaction],
                 &block,
-                protocol_config_view.protocol_version,
             )
             .await?;
 

--- a/chain/indexer/src/streamer/utils.rs
+++ b/chain/indexer/src/streamer/utils.rs
@@ -1,6 +1,5 @@
 use near_indexer_primitives::IndexerTransactionWithOutcome;
 use near_parameters::RuntimeConfig;
-use near_primitives::types::ProtocolVersion;
 use near_primitives::views;
 use node_runtime::config::tx_cost;
 
@@ -13,7 +12,6 @@ pub(crate) async fn convert_transactions_sir_into_local_receipts(
     runtime_config: &RuntimeConfig,
     txs: Vec<&IndexerTransactionWithOutcome>,
     block: &views::BlockView,
-    protocol_version: ProtocolVersion,
 ) -> Result<Vec<views::ReceiptView>, FailedToFetchData> {
     if txs.is_empty() {
         return Ok(vec![]);
@@ -44,8 +42,7 @@ pub(crate) async fn convert_transactions_sir_into_local_receipts(
                 },
             );
             // Can't use ValidatedTransaction here because transactions in a chunk can be invalid (RelaxedChunkValidation feature)
-            let cost =
-                tx_cost(&runtime_config, &tx, prev_block_gas_price, protocol_version).unwrap();
+            let cost = tx_cost(&runtime_config, &tx, prev_block_gas_price).unwrap();
             views::ReceiptView {
                 predecessor_id: indexer_tx.transaction.signer_id.clone(),
                 receiver_id: indexer_tx.transaction.receiver_id.clone(),

--- a/core/parameters/src/cost.rs
+++ b/core/parameters/src/cost.rs
@@ -2,7 +2,6 @@ use crate::parameter::Parameter;
 use enum_map::{EnumMap, enum_map};
 use near_account_id::AccountType;
 use near_primitives_core::types::{Balance, Compute, Gas};
-use near_primitives_core::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_schema_checker_lib::ProtocolSchema;
 use num_rational::Rational32;
 
@@ -494,18 +493,9 @@ impl RuntimeFeesConfig {
             storage_usage_config: StorageUsageConfig::test(),
             burnt_gas_reward: Rational32::new(3, 10),
             pessimistic_gas_price_inflation_ratio: Rational32::new(103, 100),
-            refund_gas_price_changes: !ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION),
-            gas_refund_penalty: if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) {
-                Rational32::new(5, 100)
-            } else {
-                Rational32::new(0, 100)
-            },
-            min_gas_refund_penalty: if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION)
-            {
-                Gas::from_teragas(1)
-            } else {
-                Gas::ZERO
-            },
+            refund_gas_price_changes: false,
+            gas_refund_penalty: Rational32::new(5, 100),
+            min_gas_refund_penalty: Gas::from_teragas(1),
             action_fees: enum_map::enum_map! {
                 ActionCosts::create_account => Fee::test_value(3_850_000_000_000),
                 ActionCosts::delete_account => Fee::test_value(147489000000),
@@ -542,7 +532,7 @@ impl RuntimeFeesConfig {
             storage_usage_config: StorageUsageConfig::free(),
             burnt_gas_reward: Rational32::from_integer(0),
             pessimistic_gas_price_inflation_ratio: Rational32::from_integer(0),
-            refund_gas_price_changes: !ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION),
+            refund_gas_price_changes: false,
             gas_refund_penalty: Rational32::from_integer(0),
             min_gas_refund_penalty: Gas::ZERO,
         }

--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -311,7 +311,8 @@ pub enum ProtocolFeature {
     /// price rather than a pessimistic gas price. Also, introduce a new fee of
     /// 5% for gas refunds and charge the signer this fee for gas refund
     /// receipts.
-    ReducedGasRefunds,
+    #[deprecated]
+    _DeprecatedReducedGasRefunds,
     /// Move from ChunkStateWitness being a single struct to a versioned enum.
     #[deprecated]
     _DeprecatedVersionedStateWitness,
@@ -427,7 +428,7 @@ impl ProtocolFeature {
             | ProtocolFeature::_DeprecatedVersionedStateWitness
             | ProtocolFeature::ChunkPartChecks
             | ProtocolFeature::SaturatingFloatToInt
-            | ProtocolFeature::ReducedGasRefunds => 78,
+            | ProtocolFeature::_DeprecatedReducedGasRefunds => 78,
             ProtocolFeature::IncreaseMaxCongestionMissedChunks => 79,
             ProtocolFeature::StatePartsCompression => 81,
             ProtocolFeature::Wasmtime => 82,

--- a/integration-tests/src/tests/nearcore/rpc_nodes.rs
+++ b/integration-tests/src/tests/nearcore/rpc_nodes.rs
@@ -20,7 +20,7 @@ use near_primitives::transaction::{PartialExecutionStatus, SignedTransaction};
 use near_primitives::types::{
     Balance, BlockId, BlockReference, EpochId, EpochReference, Finality, TransactionOrReceiptId,
 };
-use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature, ProtocolVersion};
+use near_primitives::version::{PROTOCOL_VERSION, ProtocolVersion};
 use near_primitives::views::{ExecutionOutcomeView, ExecutionStatusView, TxExecutionStatus};
 use std::ops::ControlFlow;
 use std::time::Duration;
@@ -233,8 +233,7 @@ async fn test_protocol_config_rpc() {
 
             let runtime_config_store = RuntimeConfigStore::new(None);
             let initial_runtime_config = runtime_config_store.get_config(ProtocolVersion::MIN);
-            let latest_runtime_config =
-                runtime_config_store.get_config(near_primitives::version::PROTOCOL_VERSION);
+            let latest_runtime_config = runtime_config_store.get_config(PROTOCOL_VERSION);
             assert_ne!(
                 config_response.config_view.runtime_config.storage_amount_per_byte,
                 initial_runtime_config.storage_amount_per_byte()
@@ -376,11 +375,6 @@ async fn slow_test_tx_not_enough_balance_must_return_error() {
                 }
                 sleep(std::time::Duration::from_millis(500)).await;
             }
-            let expected_cost = if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) {
-                "1100000000000044636512500000000000"
-            } else {
-                "1100000000000045306060187500000000"
-            };
             let res = client.broadcast_tx_commit(to_base64(&bytes)).await;
             match res {
                 Ok(_) => panic!("Transaction must not succeed"),
@@ -393,7 +387,7 @@ async fn slow_test_tx_not_enough_balance_must_return_error() {
                                 "NotEnoughBalance": {
                                     "signer_id": "near.0",
                                     "balance": "950000000000000000000000000000000", // If something changes in setup just update this value
-                                    "cost": expected_cost,
+                                    "cost": "1100000000000044636512500000000000",
                                 }
                             }
                         }})

--- a/integration-tests/src/tests/runtime/deployment.rs
+++ b/integration-tests/src/tests/runtime/deployment.rs
@@ -3,7 +3,7 @@ use near_chain_configs::Genesis;
 use near_parameters::RuntimeConfigStore;
 use near_primitives::transaction::{Action, DeployContractAction, SignedTransaction};
 use near_primitives::types::{AccountId, Balance};
-use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
+use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::FinalExecutionStatus;
 
 /// Tests if the maximum allowed contract can be deployed with current gas limits
@@ -54,9 +54,7 @@ fn test_deploy_max_size_contract() {
         )
         .unwrap();
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
-    let num_expected_receipts =
-        if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) { 1 } else { 2 };
-    assert_eq!(transaction_result.receipts_outcome.len(), num_expected_receipts);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
 
     // Deploy contract
     let wasm_binary = near_test_contracts::sized_contract(contract_size as usize);

--- a/integration-tests/src/tests/runtime/sanity_checks.rs
+++ b/integration-tests/src/tests/runtime/sanity_checks.rs
@@ -3,7 +3,7 @@ use near_chain_configs::Genesis;
 use near_parameters::{ExtCosts, RuntimeConfig, RuntimeConfigStore};
 use near_primitives::serialize::to_base64;
 use near_primitives::types::{AccountId, Balance, Gas};
-use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
+use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{
     CostGasUsed, ExecutionOutcomeWithIdView, ExecutionStatusView, FinalExecutionStatus,
 };
@@ -57,9 +57,7 @@ fn setup_runtime_node_with_contract(wasm_binary: &[u8]) -> RuntimeNode {
         )
         .unwrap();
     assert_eq!(tx_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
-    let num_expected_receipts =
-        if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) { 1 } else { 2 };
-    assert_eq!(tx_result.receipts_outcome.len(), num_expected_receipts);
+    assert_eq!(tx_result.receipts_outcome.len(), 1);
 
     let tx_result =
         node_user.deploy_contract(test_contract_account(), wasm_binary.to_vec()).unwrap();

--- a/integration-tests/src/tests/runtime/test_evil_contracts.rs
+++ b/integration-tests/src/tests/runtime/test_evil_contracts.rs
@@ -1,7 +1,6 @@
 use crate::node::{Node, RuntimeNode};
 use near_primitives::errors::{ActionError, ActionErrorKind, FunctionCallError};
 use near_primitives::types::{Balance, Gas};
-use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_primitives::views::FinalExecutionStatus;
 use std::mem::size_of;
 
@@ -26,9 +25,7 @@ fn setup_test_contract(wasm_binary: &[u8]) -> RuntimeNode {
         )
         .unwrap();
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
-    let num_expected_receipts =
-        if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) { 1 } else { 2 };
-    assert_eq!(transaction_result.receipts_outcome.len(), num_expected_receipts);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
 
     let transaction_result = node_user
         .deploy_contract("test_contract.alice.near".parse().unwrap(), wasm_binary.to_vec())

--- a/integration-tests/src/tests/runtime/test_yield_resume.rs
+++ b/integration-tests/src/tests/runtime/test_yield_resume.rs
@@ -1,6 +1,5 @@
 use crate::node::{Node, RuntimeNode};
 use near_primitives::types::{Balance, Gas};
-use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use near_primitives::views::FinalExecutionStatus;
 
 /// Initial balance used in tests.
@@ -22,9 +21,7 @@ fn setup_test_contract(wasm_binary: &[u8]) -> RuntimeNode {
         )
         .unwrap();
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
-    let num_expected_receipts =
-        if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) { 1 } else { 2 };
-    assert_eq!(transaction_result.receipts_outcome.len(), num_expected_receipts);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
 
     let transaction_result = node_user
         .deploy_contract("test_contract.alice.near".parse().unwrap(), wasm_binary.to_vec())

--- a/integration-tests/src/tests/standard_cases/mod.rs
+++ b/integration-tests/src/tests/standard_cases/mod.rs
@@ -468,9 +468,7 @@ pub fn transfer_tokens_to_implicit_account(node: impl Node, public_key: PublicKe
     let transaction_result =
         node_user.send_money(account_id.clone(), receiver_id.clone(), tokens_used).unwrap();
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
-    let num_expected_receipts =
-        if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) { 1 } else { 2 };
-    assert_eq!(transaction_result.receipts_outcome.len(), num_expected_receipts);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
     assert_eq!(node_user.get_access_key_nonce_for_signer(account_id).unwrap(), 1);
@@ -513,9 +511,7 @@ pub fn transfer_tokens_to_implicit_account(node: impl Node, public_key: PublicKe
         node_user.send_money(account_id.clone(), receiver_id.clone(), tokens_used).unwrap();
 
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
-    let num_expected_receipts =
-        if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) { 1 } else { 2 };
-    assert_eq!(transaction_result.receipts_outcome.len(), num_expected_receipts);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
     assert_eq!(node_user.get_access_key_nonce_for_signer(account_id).unwrap(), 2);
@@ -748,9 +744,7 @@ pub fn test_refund_on_send_money_to_non_existent_account(node: impl Node) {
             .into()
         )
     );
-    let num_expected_receipts =
-        if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) { 2 } else { 3 };
-    assert_eq!(transaction_result.receipts_outcome.len(), num_expected_receipts);
+    assert_eq!(transaction_result.receipts_outcome.len(), 2);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
     let result1 = node_user.view_account(account_id).unwrap();
@@ -1532,9 +1526,7 @@ pub fn test_unstake_while_not_staked(node: impl Node) {
         )
         .unwrap();
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(Vec::new()));
-    let num_expected_receipts =
-        if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) { 1 } else { 2 };
-    assert_eq!(transaction_result.receipts_outcome.len(), num_expected_receipts);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     let transaction_result = node_user
         .stake(eve_dot_alice_account(), node.block_signer().public_key(), Balance::ZERO)
         .unwrap();
@@ -1643,9 +1635,7 @@ pub fn test_delete_account_fail(node: impl Node) {
             .into()
         )
     );
-    let num_expected_receipts =
-        if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) { 1 } else { 2 };
-    assert_eq!(transaction_result.receipts_outcome.len(), num_expected_receipts);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
     assert!(node.user().view_account(&bob_account()).is_ok());
     assert_eq!(
         node.user().view_account(&node.account_id().unwrap()).unwrap().amount,
@@ -1667,9 +1657,7 @@ pub fn test_delete_account_no_account(node: impl Node) {
             .into()
         )
     );
-    let num_expected_receipts =
-        if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) { 1 } else { 2 };
-    assert_eq!(transaction_result.receipts_outcome.len(), num_expected_receipts);
+    assert_eq!(transaction_result.receipts_outcome.len(), 1);
 }
 
 pub fn test_delete_account_while_staking(node: impl Node) {

--- a/runtime/runtime-params-estimator/src/estimator_context.rs
+++ b/runtime/runtime-params-estimator/src/estimator_context.rs
@@ -460,9 +460,7 @@ impl Testbed<'_> {
             PROTOCOL_VERSION,
         )
         .expect("expected no validation error");
-        let cost =
-            tx_cost(&self.apply_state.config, &validated_tx.to_tx(), gas_price, PROTOCOL_VERSION)
-                .unwrap();
+        let cost = tx_cost(&self.apply_state.config, &validated_tx.to_tx(), gas_price).unwrap();
         let (mut signer, mut access_key) = get_signer_and_access_key(&state_update, &validated_tx)
             .expect("getting signer and access key should not fail in estimator");
 

--- a/runtime/runtime/src/config.rs
+++ b/runtime/runtime/src/config.rs
@@ -3,11 +3,6 @@
 use near_primitives::account::AccessKeyPermission;
 use near_primitives::action::DeployGlobalContractAction;
 use near_primitives::errors::IntegerOverflowError;
-use near_primitives::version::ProtocolFeature;
-use near_vm_runner::logic::ProtocolVersion;
-use num_bigint::BigUint;
-use num_traits::cast::ToPrimitive;
-use num_traits::pow::Pow;
 // Just re-exporting RuntimeConfig for backwards compatibility.
 use near_parameters::{ActionCosts, RuntimeConfig, transfer_exec_fee, transfer_send_fee};
 pub use near_primitives::num_rational::Rational32;
@@ -29,19 +24,6 @@ pub struct TransactionCost {
     pub total_cost: Balance,
     /// The amount of tokens burnt by converting this transaction to a receipt.
     pub burnt_amount: Balance,
-}
-
-/// Multiplies `gas_price` by the power of `inflation_base` with exponent `inflation_exponent`.
-pub fn safe_gas_price_inflated(
-    gas_price: Balance,
-    inflation_base: Rational32,
-    inflation_exponent: u8,
-) -> Result<Balance, IntegerOverflowError> {
-    let numer = BigUint::from(*inflation_base.numer() as usize).pow(inflation_exponent as u32);
-    let denom = BigUint::from(*inflation_base.denom() as usize).pow(inflation_exponent as u32);
-    // Rounding up
-    let inflated_gas_price: BigUint = (numer * gas_price.as_yoctonear() + &denom - 1u8) / denom;
-    inflated_gas_price.to_u128().ok_or(IntegerOverflowError {}).map(Balance::from_yoctonear)
 }
 
 pub fn safe_gas_to_balance(gas_price: Balance, gas: Gas) -> Result<Balance, IntegerOverflowError> {
@@ -302,8 +284,7 @@ pub fn exec_fee(config: &RuntimeConfig, action: &Action, receiver_id: &AccountId
 pub fn tx_cost(
     config: &RuntimeConfig,
     tx: &Transaction,
-    gas_price: Balance,
-    protocol_version: ProtocolVersion,
+    receipt_gas_price: Balance,
 ) -> Result<TransactionCost, IntegerOverflowError> {
     let sender_is_receiver = tx.receiver_id() == tx.signer_id();
     let fees = &config.fees;
@@ -316,11 +297,6 @@ pub fn tx_cost(
     )?)?;
     let prepaid_gas = total_prepaid_gas(&tx.actions())?
         .checked_add_result(total_prepaid_send_fees(config, &tx.actions())?)?;
-    let receipt_gas_price = if ProtocolFeature::ReducedGasRefunds.enabled(protocol_version) {
-        gas_price
-    } else {
-        pessimistic_gas_price(gas_price, sender_is_receiver, fees, prepaid_gas)?
-    };
 
     let mut gas_remaining =
         prepaid_gas.checked_add_result(fees.fee(ActionCosts::new_action_receipt).exec_fee())?;
@@ -329,7 +305,7 @@ pub fn tx_cost(
         tx.actions(),
         tx.receiver_id(),
     )?)?;
-    let burnt_amount = safe_gas_to_balance(gas_price, gas_burnt)?;
+    let burnt_amount = safe_gas_to_balance(receipt_gas_price, gas_burnt)?;
     let remaining_gas_amount = safe_gas_to_balance(receipt_gas_price, gas_remaining)?;
     let mut total_cost = safe_add_balance(burnt_amount, remaining_gas_amount)?;
     total_cost = safe_add_balance(total_cost, total_deposit(&tx.actions())?)?;
@@ -403,71 +379,4 @@ pub fn total_prepaid_gas(actions: &[Action]) -> Result<Gas, IntegerOverflowError
         total_gas = total_gas.checked_add_result(action_gas)?;
     }
     Ok(total_gas)
-}
-
-/// Calculates a maximum expected gas price increase during the execution of the transaction.
-///
-/// Note: this is no longer used with ProtocolFeature::ReducedGasRefunds
-fn pessimistic_gas_price(
-    gas_price: Balance,
-    sender_is_receiver: bool,
-    fees: &std::sync::Arc<near_parameters::RuntimeFeesConfig>,
-    prepaid_gas: Gas,
-) -> Result<Balance, IntegerOverflowError> {
-    // If signer is equals to receiver the receipt will be processed at the same block as this
-    // transaction. Otherwise it will processed in the next block and the gas might be inflated.
-    let initial_receipt_hop = if sender_is_receiver { 0 } else { 1 };
-    // The pessimistic gas pricing is a best-effort limit which can be breached in case of
-    // congestion when receipts are delayed before they execute. Hence there is not much
-    // value to tie this limit to the function call base cost. Making it constant limits
-    // overcharging to 6x, which was the value before the cost increase.
-    let minimum_new_receipt_gas = 4_855_842_000_000; // 4.855TGas.
-    // In case the config is free, we don't care about the maximum depth.
-    let receipt_gas_price = if gas_price.is_zero() {
-        Balance::ZERO
-    } else {
-        let maximum_depth = if minimum_new_receipt_gas > 0 {
-            prepaid_gas.checked_div(minimum_new_receipt_gas).unwrap().as_gas()
-        } else {
-            0
-        };
-        let inflation_exponent = u8::try_from(initial_receipt_hop + maximum_depth)
-            .map_err(|_| IntegerOverflowError {})?;
-        safe_gas_price_inflated(
-            gas_price,
-            fees.pessimistic_gas_price_inflation_ratio,
-            inflation_exponent,
-        )?
-    };
-    Ok(receipt_gas_price)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_safe_gas_price_inflated() {
-        assert_eq!(
-            safe_gas_price_inflated(Balance::from_yoctonear(10000), Rational32::new(101, 100), 1)
-                .unwrap(),
-            Balance::from_yoctonear(10100)
-        );
-        assert_eq!(
-            safe_gas_price_inflated(Balance::from_yoctonear(10000), Rational32::new(101, 100), 2)
-                .unwrap(),
-            Balance::from_yoctonear(10201)
-        );
-        // Rounded up
-        assert_eq!(
-            safe_gas_price_inflated(Balance::from_yoctonear(10000), Rational32::new(101, 100), 3)
-                .unwrap(),
-            Balance::from_yoctonear(10304)
-        );
-        assert_eq!(
-            safe_gas_price_inflated(Balance::from_yoctonear(10000), Rational32::new(101, 100), 32)
-                .unwrap(),
-            Balance::from_yoctonear(13750)
-        );
-    }
 }

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1809,29 +1809,25 @@ impl Runtime {
             let tx_hash = tx.hash();
             let block_height = processing_state.apply_state.block_height;
 
-            let cost = match tx_cost(
-                &processing_state.apply_state.config,
-                &tx.transaction,
-                gas_price,
-                protocol_version,
-            ) {
-                Ok(c) => c,
-                Err(error) => {
-                    metrics::TRANSACTION_PROCESSED_FAILED_TOTAL.inc();
-                    let tx_error = match error {
-                        IntegerOverflowError => InvalidTxError::CostOverflow,
-                    };
-                    let outcome = ExecutionOutcomeWithId::failed(tx, tx_error);
-                    let error = &error as &dyn std::error::Error;
-                    tracing::debug!(%tx_hash, error, "transaction cost calculation failed");
-                    Self::register_outcome(
-                        processing_state.protocol_version,
-                        &mut processing_state.outcomes,
-                        outcome,
-                    );
-                    continue;
-                }
-            };
+            let cost =
+                match tx_cost(&processing_state.apply_state.config, &tx.transaction, gas_price) {
+                    Ok(c) => c,
+                    Err(error) => {
+                        metrics::TRANSACTION_PROCESSED_FAILED_TOTAL.inc();
+                        let tx_error = match error {
+                            IntegerOverflowError => InvalidTxError::CostOverflow,
+                        };
+                        let outcome = ExecutionOutcomeWithId::failed(tx, tx_error);
+                        let error = &error as &dyn std::error::Error;
+                        tracing::debug!(%tx_hash, error, "transaction cost calculation failed");
+                        Self::register_outcome(
+                            processing_state.protocol_version,
+                            &mut processing_state.outcomes,
+                            outcome,
+                        );
+                        continue;
+                    }
+                };
 
             let verification_result = {
                 let mut account = accounts.get_mut(signer_id);

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -687,7 +687,7 @@ impl Runtime {
             GasRefundResult::default()
         } else {
             // Calculating and generating refunds
-            self.generate_refund_receipts(
+            self.refund_unspent_gas_and_deposits(
                 apply_state.gas_price,
                 receipt,
                 &action_receipt,
@@ -734,28 +734,13 @@ impl Runtime {
             .unwrap();
         // The balance that the current account should receive as a reward for function call
         // execution.
-        let receiver_reward = if apply_state.config.fees.refund_gas_price_changes {
-            // Use current gas price for reward calculation
-            let full_reward = safe_gas_to_balance(apply_state.gas_price, receiver_gas_reward)?;
-            // Pre NEP-536:
-            // When refunding the gas price difference, if we run a deficit,
-            // subtract it from contract rewards. This is a (arguably weird) bit
-            // of cross-financing the missing funds to pay gas at the current
-            // rate.
-            // We should charge the caller more but we can't at this point. The
-            // pessimistic gas pricing was not pessimistic enough, which may
-            // happen when receipts are delayed.
-            // To recover the losses, take as much as we can from the reward
-            // that rightfully belongs to the contract owner.
-            full_reward.saturating_sub(gas_refund_result.price_deficit)
-        } else {
-            // Use receipt gas price for reward calculation
-            safe_gas_to_balance(action_receipt.gas_price(), receiver_gas_reward)?
-            // Post NEP-536:
-            // No shenanigans here. We are not refunding gas price differences,
-            // we just use the receipt gas price and call it the correct price.
-            // No deficits to try and recover.
-        };
+        // Post NEP-536:
+        // No shenanigans here. We are not refunding gas price differences,
+        // we just use the receipt gas price and call it the correct price.
+        // No deficits to try and recover.
+        assert!(!apply_state.config.fees.refund_gas_price_changes, "NEP-536 is always enabled");
+        // Use receipt gas price for reward calculation
+        let receiver_reward = safe_gas_to_balance(action_receipt.gas_price(), receiver_gas_reward)?;
         if receiver_reward > Balance::ZERO {
             let mut account = get_account(state_update, account_id)?;
             if let Some(ref mut account) = account {
@@ -877,138 +862,6 @@ impl Runtime {
         })
     }
 
-    fn generate_refund_receipts(
-        &self,
-        current_gas_price: Balance,
-        receipt: &Receipt,
-        action_receipt: &VersionedActionReceipt,
-        result: &mut ActionResult,
-        config: &RuntimeConfig,
-    ) -> Result<GasRefundResult, RuntimeError> {
-        if config.fees.refund_gas_price_changes {
-            let price_deficit = self.refund_unspent_gas_and_unspent_gas_and_deposits(
-                current_gas_price,
-                receipt,
-                action_receipt,
-                result,
-                config,
-            )?;
-            Ok(GasRefundResult {
-                price_deficit,
-                price_surplus: Balance::ZERO,
-                refund_penalty: Balance::ZERO,
-            })
-        } else {
-            self.refund_unspent_gas_and_deposits(
-                current_gas_price,
-                receipt,
-                action_receipt,
-                result,
-                config,
-            )
-        }
-    }
-
-    /// How we used to handle refunds, prior to NEP-536.
-    ///
-    /// In the old model, we tried to always bill the user the exact gas price
-    /// of the block where the gas is spent. That means, a transaction uses a
-    /// different gas price on every hop. But gas is purchased all at the start,
-    /// at the receipt gas price.
-    ///
-    /// To deal with a price increase during execution, we charged a pessimistic
-    /// gas price. The pessimistic price is an estimation of how expensive gas
-    /// could realistically become while the transaction executes. It's not a
-    /// guaranteed to stay below that limit, though.
-    ///
-    /// The pessimistic price is usually several times higher than the real
-    /// execution price. Thus, it is important to refund the difference between
-    /// the purchase price and the execution price.
-    ///
-    /// NEP-536 removes this concept because we no longer want to waste runtime
-    /// throughput with a somewhat useless refund receipts for essentially every
-    /// function call.
-    fn refund_unspent_gas_and_unspent_gas_and_deposits(
-        &self,
-        current_gas_price: Balance,
-        receipt: &Receipt,
-        action_receipt: &VersionedActionReceipt,
-        result: &mut ActionResult,
-        config: &RuntimeConfig,
-    ) -> Result<Balance, RuntimeError> {
-        let total_deposit = total_deposit(&action_receipt.actions())?;
-        let prepaid_gas = total_prepaid_gas(&action_receipt.actions())?
-            .checked_add(total_prepaid_send_fees(config, &action_receipt.actions())?)
-            .ok_or(IntegerOverflowError)?;
-        let prepaid_exec_gas =
-            total_prepaid_exec_fees(config, &action_receipt.actions(), receipt.receiver_id())?
-                .checked_add(config.fees.fee(ActionCosts::new_action_receipt).exec_fee())
-                .ok_or(IntegerOverflowError)?;
-        let deposit_refund = if result.result.is_err() { total_deposit } else { Balance::ZERO };
-        let gas_refund = if result.result.is_err() {
-            prepaid_gas
-                .checked_add(prepaid_exec_gas)
-                .ok_or(IntegerOverflowError)?
-                .checked_sub(result.gas_burnt)
-                .unwrap()
-        } else {
-            prepaid_gas
-                .checked_add(prepaid_exec_gas)
-                .ok_or(IntegerOverflowError)?
-                .checked_sub(result.gas_used)
-                .unwrap()
-        };
-
-        // Refund for the unused portion of the gas at the price at which this gas was purchased.
-        let mut gas_balance_refund = safe_gas_to_balance(action_receipt.gas_price(), gas_refund)?;
-        let mut gas_deficit_amount = Balance::ZERO;
-        if current_gas_price > action_receipt.gas_price() {
-            // In a rare scenario, when the current gas price is higher than the purchased gas
-            // price, the difference is subtracted from the refund. If the refund doesn't have
-            // enough balance to cover the difference, then the remaining balance is considered
-            // the deficit and it's reported in the stats for the balance checker.
-            gas_deficit_amount = safe_gas_to_balance(
-                current_gas_price.checked_sub(action_receipt.gas_price()).unwrap(),
-                result.gas_burnt,
-            )?;
-            if gas_balance_refund >= gas_deficit_amount {
-                gas_balance_refund = gas_balance_refund.checked_sub(gas_deficit_amount).unwrap();
-                gas_deficit_amount = Balance::ZERO;
-            } else {
-                gas_deficit_amount = gas_deficit_amount.checked_sub(gas_balance_refund).unwrap();
-                gas_balance_refund = Balance::ZERO;
-            }
-        } else {
-            // Refund for the difference of the purchased gas price and the current gas price.
-            gas_balance_refund = safe_add_balance(
-                gas_balance_refund,
-                safe_gas_to_balance(
-                    action_receipt.gas_price().checked_sub(current_gas_price).unwrap(),
-                    result.gas_burnt,
-                )?,
-            )?;
-        }
-
-        if deposit_refund > Balance::ZERO {
-            result.new_receipts.push(Receipt::new_balance_refund(
-                receipt.balance_refund_receiver(),
-                deposit_refund,
-                receipt.priority(),
-            ));
-        }
-        if gas_balance_refund > Balance::ZERO {
-            // Gas refunds refund the allowance of the access key, so if the key exists on the
-            // account it will increase the allowance by the refund amount.
-            result.new_receipts.push(Receipt::new_gas_refund(
-                &action_receipt.signer_id(),
-                gas_balance_refund,
-                action_receipt.signer_public_key().clone(),
-                receipt.priority(),
-            ));
-        }
-        Ok(gas_deficit_amount)
-    }
-
     /// How we handle refunds since NEP-536.
     ///
     /// In this model, the user purchases gas at one price. This price stays the
@@ -1025,6 +878,7 @@ impl Runtime {
         result: &mut ActionResult,
         config: &RuntimeConfig,
     ) -> Result<GasRefundResult, RuntimeError> {
+        assert!(!config.fees.refund_gas_price_changes, "NEP-536 is always enabled");
         let total_deposit = total_deposit(&action_receipt.actions())?;
         let prepaid_gas = total_prepaid_gas(&action_receipt.actions())?
             .checked_add(total_prepaid_send_fees(config, &action_receipt.actions())?)

--- a/runtime/runtime/src/tests/apply.rs
+++ b/runtime/runtime/src/tests/apply.rs
@@ -845,18 +845,9 @@ fn test_apply_surplus_gas_for_transfer() {
         .checked_add(fees.fee(ActionCosts::transfer).exec_fee())
         .unwrap();
 
-    let expected_burnt_amount = if fees.refund_gas_price_changes {
-        GAS_PRICE.checked_mul(u128::from(exec_gas.as_gas())).unwrap()
-    } else {
-        gas_price.checked_mul(u128::from(exec_gas.as_gas())).unwrap()
-    };
-    let expected_receipts = if fees.refund_gas_price_changes {
-        // refund the surplus
-        1
-    } else {
-        // don't refund the surplus
-        0
-    };
+    assert!(!fees.refund_gas_price_changes);
+    let expected_burnt_amount = gas_price.checked_mul(u128::from(exec_gas.as_gas())).unwrap();
+    let expected_receipts = 0;
 
     assert!(result.stats.balance.gas_deficit_amount.is_zero());
     assert_eq!(result.stats.balance.tx_burnt_amount, expected_burnt_amount);
@@ -911,11 +902,9 @@ fn test_apply_deficit_gas_for_function_call_covered() {
             Gas::from_gas(gas).checked_add(expected_gas_burnt).unwrap().as_gas(),
         ))
         .unwrap();
-    let expected_gas_burnt_amount = if apply_state.config.fees.refund_gas_price_changes {
-        GAS_PRICE.checked_mul(u128::from(expected_gas_burnt.as_gas())).unwrap()
-    } else {
-        gas_price.checked_mul(u128::from(expected_gas_burnt.as_gas())).unwrap()
-    };
+    assert!(!apply_state.config.fees.refund_gas_price_changes);
+    let expected_gas_burnt_amount =
+        gas_price.checked_mul(u128::from(expected_gas_burnt.as_gas())).unwrap();
     // With gas refund penalties enabled, we should see a reduced refund value
     let unspent_gas: Gas = Gas::from_gas(
         (total_receipt_cost.checked_sub(expected_gas_burnt_amount).unwrap().as_yoctonear()
@@ -941,19 +930,15 @@ fn test_apply_deficit_gas_for_function_call_covered() {
             Default::default(),
         )
         .unwrap();
-    if apply_state.config.fees.refund_gas_price_changes {
-        // We used part of the prepaid gas to paying extra fees.
-        assert!(result.stats.balance.gas_deficit_amount.is_zero());
-    } else {
-        assert_eq!(
-            result.stats.balance.gas_deficit_amount,
-            GAS_PRICE
-                .checked_sub(gas_price)
-                .unwrap()
-                .checked_mul(u128::from(expected_gas_burnt.as_gas()))
-                .unwrap()
-        );
-    }
+    assert!(!apply_state.config.fees.refund_gas_price_changes);
+    assert_eq!(
+        result.stats.balance.gas_deficit_amount,
+        GAS_PRICE
+            .checked_sub(gas_price)
+            .unwrap()
+            .checked_mul(u128::from(expected_gas_burnt.as_gas()))
+            .unwrap()
+    );
     // The refund is less than the received amount.
     match result.outgoing_receipts[0].receipt() {
         ReceiptEnum::Action(ActionReceipt { actions, .. }) => {
@@ -1013,19 +998,11 @@ fn test_apply_deficit_gas_for_function_call_partial() {
             Gas::from_gas(gas).checked_add(expected_gas_burnt).unwrap().as_gas(),
         ))
         .unwrap();
-    let expected_deficit = if apply_state.config.fees.refund_gas_price_changes {
-        // Used full prepaid gas, but it still not enough to cover deficit.
-        let expected_gas_burnt_amount =
-            GAS_PRICE.checked_mul(u128::from(expected_gas_burnt.as_gas())).unwrap();
-        expected_gas_burnt_amount.checked_sub(total_receipt_cost).unwrap()
-    } else {
-        // The "deficit" is simply the value change due to gas price changes
-        GAS_PRICE
-            .checked_sub(gas_price)
-            .unwrap()
-            .checked_mul(u128::from(expected_gas_burnt.as_gas()))
-            .unwrap()
-    };
+    let expected_deficit = GAS_PRICE
+        .checked_sub(gas_price)
+        .unwrap()
+        .checked_mul(u128::from(expected_gas_burnt.as_gas()))
+        .unwrap();
 
     let result = runtime
         .apply(
@@ -1039,19 +1016,14 @@ fn test_apply_deficit_gas_for_function_call_partial() {
         )
         .unwrap();
     assert_eq!(result.stats.balance.gas_deficit_amount, expected_deficit);
-    if apply_state.config.fees.refund_gas_price_changes {
-        // Burnt all the fees + all prepaid gas.
-        assert_eq!(result.stats.balance.tx_burnt_amount, total_receipt_cost);
-        assert_eq!(result.outgoing_receipts.len(), 0);
-    } else {
-        // The deficit does not affect refunds in this config, hence we expect a
-        // normal refund of the unspent gas. However, this is small enough to
-        // cancel out, so we add the refund cost to tx_burnt and expect no
-        // refund. Like in the other case, this ends up burning all gas and not
-        // refunding anything.
-        assert_eq!(result.outgoing_receipts.len(), 0);
-        assert_eq!(result.stats.balance.tx_burnt_amount, total_receipt_cost);
-    }
+    assert!(!apply_state.config.fees.refund_gas_price_changes);
+    // The deficit does not affect refunds in this config, hence we expect a
+    // normal refund of the unspent gas. However, this is small enough to
+    // cancel out, so we add the refund cost to tx_burnt and expect no
+    // refund. Like in the other case, this ends up burning all gas and not
+    // refunding anything.
+    assert_eq!(result.outgoing_receipts.len(), 0);
+    assert_eq!(result.stats.balance.tx_burnt_amount, total_receipt_cost);
 }
 
 #[test]
@@ -1102,11 +1074,9 @@ fn test_apply_surplus_gas_for_function_call() {
             Gas::from_gas(gas).checked_add(expected_gas_burnt).unwrap().as_gas(),
         ))
         .unwrap();
-    let expected_gas_burnt_amount = if apply_state.config.fees.refund_gas_price_changes {
-        GAS_PRICE.checked_mul(u128::from(expected_gas_burnt.as_gas())).unwrap()
-    } else {
-        gas_price.checked_mul(u128::from(expected_gas_burnt.as_gas())).unwrap()
-    };
+    assert!(!apply_state.config.fees.refund_gas_price_changes);
+    let expected_gas_burnt_amount =
+        gas_price.checked_mul(u128::from(expected_gas_burnt.as_gas())).unwrap();
 
     // With gas refund penalties enabled, we should see a reduced refund value
     let unspent_gas = Gas::from_gas(

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -792,7 +792,7 @@ mod tests {
                 return;
             }
         };
-        let cost = match tx_cost(config, &validated_tx.to_tx(), gas_price, PROTOCOL_VERSION) {
+        let cost = match tx_cost(config, &validated_tx.to_tx(), gas_price) {
             Ok(c) => c,
             Err(err) => {
                 assert_eq!(InvalidTxError::from(err), expected_err);
@@ -836,8 +836,7 @@ mod tests {
         };
         let (mut signer, mut access_key) = get_signer_and_access_key(state_update, &validated_tx)?;
 
-        let transaction_cost =
-            tx_cost(config, &validated_tx.to_tx(), gas_price, current_protocol_version)?;
+        let transaction_cost = tx_cost(config, &validated_tx.to_tx(), gas_price)?;
         let vr = verify_and_charge_tx_ephemeral(
             config,
             &mut signer,

--- a/runtime/runtime/tests/runtime_group_tools/random_config.rs
+++ b/runtime/runtime/tests/runtime_group_tools/random_config.rs
@@ -1,7 +1,6 @@
 use near_parameters::{Fee, RuntimeConfig, RuntimeFeesConfig, StorageUsageConfig};
 use near_primitives::num_rational::Rational32;
 use near_primitives::types::{Balance, Gas};
-use near_primitives::version::{PROTOCOL_VERSION, ProtocolFeature};
 use rand::{Rng, RngCore, thread_rng};
 
 pub fn random_config() -> RuntimeConfig {
@@ -26,7 +25,7 @@ pub fn random_config() -> RuntimeConfig {
                 (101 + rng.next_u32() % 10).try_into().unwrap(),
                 100,
             ),
-            refund_gas_price_changes: !ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION),
+            refund_gas_price_changes: false,
             gas_refund_penalty: Rational32::new(rng.gen_range(0..=i32::MAX), i32::MAX),
             min_gas_refund_penalty: Gas::from_gas(rng.next_u64()),
         }),

--- a/runtime/runtime/tests/test_async_calls.rs
+++ b/runtime/runtime/tests/test_async_calls.rs
@@ -55,7 +55,7 @@ fn test_simple_func_call() {
         actions,
         a0, Action::FunctionCall(_function_call_action), {}
     );
-    assert_single_refund_prior_to_nep536(&group, &receipts);
+    assert!(receipts.is_empty(), "refund should have been avoided");
 }
 
 // single promise, no callback (A->B)
@@ -110,7 +110,7 @@ fn test_single_promise_no_callback() {
         }
     );
     let [r1, refunds @ ..] = &receipts else { panic!("Incorrect number of produced receipts") };
-    assert_single_refund_prior_to_nep536(&group, &refunds);
+    assert!(refunds.is_empty(), "refund should have been avoided");
 
     let receipts = &*assert_receipts!(group, "near_1" => r1 @ "near_2",
         ReceiptEnum::Action(ActionReceipt{actions, ..}) | ReceiptEnum::ActionV2(ActionReceiptV2{actions, ..}),
@@ -120,7 +120,7 @@ fn test_single_promise_no_callback() {
         assert_eq!(function_call_action.gas, GAS_2);
         assert!(function_call_action.deposit.is_zero());
     });
-    assert_single_refund_prior_to_nep536(&group, &receipts);
+    assert!(receipts.is_empty(), "refund should have been avoided");
 }
 
 // single promise with callback (A->B=>C)
@@ -183,7 +183,7 @@ fn test_single_promise_with_callback() {
         }
     );
     let [r1, r2, refunds @ ..] = &receipts else { panic!("Incorrect number of produced receipts") };
-    assert_single_refund_prior_to_nep536(&group, &refunds);
+    assert!(refunds.is_empty(), "refund should have been avoided");
 
     let data_id;
 
@@ -198,7 +198,7 @@ fn test_single_promise_with_callback() {
         assert_eq!(function_call_action.gas, GAS_2);
         assert!(function_call_action.deposit.is_zero());
     });
-    assert_single_refund_prior_to_nep536(&group, &receipts);
+    assert!(receipts.is_empty(), "refund should have been avoided");
 
     let receipts = &*assert_receipts!(group, "near_1" => r2 @ "near_3",
         ReceiptEnum::Action(ActionReceipt{actions, input_data_ids, ..}) | ReceiptEnum::ActionV2(ActionReceiptV2{actions, input_data_ids, ..}),
@@ -212,7 +212,7 @@ fn test_single_promise_with_callback() {
             assert!(function_call_action.deposit.is_zero());
         }
     );
-    assert_single_refund_prior_to_nep536(&group, &receipts);
+    assert!(receipts.is_empty(), "refund should have been avoided");
 }
 
 // two promises, no callbacks (A->B->C)
@@ -275,7 +275,7 @@ fn test_two_promises_no_callbacks() {
         }
     );
     let [r1, refunds @ ..] = &receipts else { panic!("must have outgoing receipt") };
-    assert_single_refund_prior_to_nep536(&group, &refunds);
+    assert!(refunds.is_empty(), "refund should have been avoided");
 
     let receipts = &*assert_receipts!(group, "near_1" => r1 @ "near_2",
         ReceiptEnum::Action(ActionReceipt{actions, ..}) | ReceiptEnum::ActionV2(ActionReceiptV2{actions, ..}),
@@ -287,7 +287,7 @@ fn test_two_promises_no_callbacks() {
         }
     );
     let [r2, refunds @ ..] = &receipts else { panic!("Incorrect number of produced receipts") };
-    assert_single_refund_prior_to_nep536(&group, &refunds);
+    assert!(refunds.is_empty(), "refund should have been avoided");
 
     let receipts = &*assert_receipts!(group, "near_2" => r2 @ "near_3",
         ReceiptEnum::Action(ActionReceipt{actions, ..}) | ReceiptEnum::ActionV2(ActionReceiptV2{actions, ..}),
@@ -298,7 +298,7 @@ fn test_two_promises_no_callbacks() {
             assert!(function_call_action.deposit.is_zero());
         }
     );
-    assert_single_refund_prior_to_nep536(&group, receipts);
+    assert!(receipts.is_empty(), "refund should have been avoided");
 }
 
 // two promises, with two callbacks (A->B->C=>D=>E) where call to E is initialized by completion of D.
@@ -381,7 +381,7 @@ fn test_two_promises_with_two_callbacks() {
     let [r1, cb1, refunds @ ..] = &receipts else {
         panic!("Incorrect number of produced receipts")
     };
-    assert_single_refund_prior_to_nep536(&group, refunds);
+    assert!(refunds.is_empty(), "refund should have been avoided");
 
     let receipts = &*assert_receipts!(group, "near_1" => r1 @ "near_2",
         ReceiptEnum::Action(ActionReceipt{actions, ..}) | ReceiptEnum::ActionV2(ActionReceiptV2{actions, ..}),
@@ -395,7 +395,7 @@ fn test_two_promises_with_two_callbacks() {
     let [r2, cb2, refunds @ ..] = &receipts else {
         panic!("Incorrect number of produced receipts")
     };
-    assert_single_refund_prior_to_nep536(&group, refunds);
+    assert!(refunds.is_empty(), "refund should have been avoided");
 
     let receipts = &*assert_receipts!(group, "near_2" => r2 @ "near_3",
         ReceiptEnum::Action(ActionReceipt{actions, ..}) | ReceiptEnum::ActionV2(ActionReceiptV2{actions, ..}),
@@ -406,7 +406,7 @@ fn test_two_promises_with_two_callbacks() {
             assert!(function_call_action.deposit.is_zero());
         }
     );
-    assert_single_refund_prior_to_nep536(&group, receipts);
+    assert!(receipts.is_empty(), "refund should have been avoided");
 
     let receipts = &*assert_receipts!(group, "near_2" => cb2 @ "near_4",
         ReceiptEnum::Action(ActionReceipt{actions, ..}) | ReceiptEnum::ActionV2(ActionReceiptV2{actions, ..}),
@@ -417,7 +417,7 @@ fn test_two_promises_with_two_callbacks() {
             assert!(function_call_action.deposit.is_zero());
         }
     );
-    assert_single_refund_prior_to_nep536(&group, receipts);
+    assert!(receipts.is_empty(), "refund should have been avoided");
 
     let receipts = &*assert_receipts!(group, "near_1" => cb1 @ "near_5",
         ReceiptEnum::Action(ActionReceipt{actions, ..}) | ReceiptEnum::ActionV2(ActionReceiptV2{actions, ..}),
@@ -428,7 +428,7 @@ fn test_two_promises_with_two_callbacks() {
             assert!(function_call_action.deposit.is_zero());
         }
     );
-    assert_single_refund_prior_to_nep536(&group, receipts);
+    assert!(receipts.is_empty(), "refund should have been avoided");
 }
 
 // Batch actions tests
@@ -487,7 +487,7 @@ fn test_single_promise_no_callback_batch() {
         }
     );
     let [r1, refunds @ ..] = &receipts else { panic!("Incorrect number of produced receipts") };
-    assert_single_refund_prior_to_nep536(&group, &refunds);
+    assert!(refunds.is_empty(), "refund should have been avoided");
 
     let receipts = &*assert_receipts!(group, "near_1" => r1 @ "near_2",
         ReceiptEnum::Action(ActionReceipt{actions, ..}) | ReceiptEnum::ActionV2(ActionReceiptV2{actions, ..}),
@@ -498,7 +498,7 @@ fn test_single_promise_no_callback_batch() {
             assert!(function_call_action.deposit.is_zero());
         }
     );
-    assert_single_refund_prior_to_nep536(&group, &receipts);
+    assert!(receipts.is_empty(), "refund should have been avoided");
 }
 
 // single promise with callback (A->B=>C) with batch actions
@@ -567,7 +567,7 @@ fn test_single_promise_with_callback_batch() {
         }
     );
     let [r1, r2, refunds @ ..] = &receipts else { panic!("Incorrect number of produced receipts") };
-    assert_single_refund_prior_to_nep536(&group, &refunds);
+    assert!(refunds.is_empty(), "refund should have been avoided");
 
     let data_id;
     let receipts = &*assert_receipts!(group, "near_1" => r1 @ "near_2",
@@ -582,7 +582,7 @@ fn test_single_promise_with_callback_batch() {
             assert!(function_call_action.deposit.is_zero());
         }
     );
-    assert_single_refund_prior_to_nep536(&group, &receipts);
+    assert!(receipts.is_empty(), "refund should have been avoided");
 
     let receipts = &*assert_receipts!(group, "near_1" => r2 @ "near_3",
         ReceiptEnum::Action(ActionReceipt{actions, input_data_ids, ..}) | ReceiptEnum::ActionV2(ActionReceiptV2{actions, input_data_ids, ..}),
@@ -596,12 +596,7 @@ fn test_single_promise_with_callback_batch() {
             assert!(function_call_action.deposit.is_zero());
         }
     );
-    if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) {
-        assert_eq!(receipts, [], "refund should have been avoided");
-    } else {
-        let [ref1] = &*receipts else { panic!("Incorrect number of refunds") };
-        assert_refund!(group, ref1 @ "near_0");
-    }
+    assert_eq!(receipts, [], "refund should have been avoided");
 }
 
 #[test]
@@ -656,7 +651,7 @@ fn test_simple_transfer() {
     );
     let [r1, refunds @ ..] = &receipts else { panic!("Incorrect number of produced receipts") };
 
-    assert_single_refund_prior_to_nep536(&group, &refunds);
+    assert!(refunds.is_empty(), "refund should have been avoided");
 
     let refunds = assert_receipts!(group, "near_1" => r1 @ "near_2",
         ReceiptEnum::Action(ActionReceipt{actions, ..}) | ReceiptEnum::ActionV2(ActionReceiptV2{actions, ..}),
@@ -667,12 +662,7 @@ fn test_simple_transfer() {
         }
     );
     // For gas price difference
-    if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) {
-        assert_eq!(refunds, [], "refund should have been avoided");
-    } else {
-        let [ref1] = &*refunds else { panic!("Incorrect number of refunds") };
-        assert_refund!(group, ref1 @ "near_0");
-    }
+    assert_eq!(refunds, [], "refund should have been avoided");
 }
 
 #[test]
@@ -734,7 +724,7 @@ fn test_create_account_with_transfer_and_full_key() {
         }
     );
     let [r1, refunds @ ..] = &receipts else { panic!("Incorrect number of produced receipts") };
-    assert_single_refund_prior_to_nep536(&group, refunds);
+    assert!(refunds.is_empty(), "refund should have been avoided");
 
     let refunds = assert_receipts!(group, "near_1" => r1 @ "near_2",
         ReceiptEnum::Action(ActionReceipt{actions, ..}) | ReceiptEnum::ActionV2(ActionReceiptV2{actions, ..}),
@@ -752,12 +742,7 @@ fn test_create_account_with_transfer_and_full_key() {
     );
 
     // For gas price difference
-    if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) {
-        assert_eq!(refunds, [], "refund should have been avoided");
-    } else {
-        let [ref1] = &*refunds else { panic!("Incorrect number of refunds") };
-        assert_refund!(group, ref1 @ "near_0");
-    }
+    assert_eq!(refunds, [], "refund should have been avoided");
 }
 
 #[test]
@@ -859,12 +844,7 @@ fn test_account_factory() {
     );
     let [r1, r2, refunds @ ..] = &receipts else { panic!("Incorrect number of produced receipts") };
     // For gas price difference
-    if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) {
-        assert_eq!(refunds, [], "refund should have been avoided");
-    } else {
-        let [refund] = &refunds else { panic!("Incorrect number of refunds") };
-        assert_refund!(group, refund @ "near_0");
-    }
+    assert_eq!(refunds, [], "refund should have been avoided");
 
     let data_id;
     let receipts = &*assert_receipts!(group, "near_1" => r1 @ "near_2",
@@ -898,7 +878,7 @@ fn test_account_factory() {
     );
     let [r3, refunds @ ..] = &receipts else { panic!("Incorrect number of produced receipts") };
     // For gas price difference
-    assert_single_refund_prior_to_nep536(&group, &refunds);
+    assert!(refunds.is_empty(), "refund should have been avoided");
 
     let receipts = &*assert_receipts!(group, "near_1" => r2 @ "near_2",
         ReceiptEnum::Action(ActionReceipt{actions, input_data_ids, ..}) | ReceiptEnum::ActionV2(ActionReceiptV2{actions, input_data_ids, ..}),
@@ -913,7 +893,7 @@ fn test_account_factory() {
     );
     let [r4, refunds @ ..] = &receipts else { panic!("Incorrect number of produced receipts") };
     // For gas price difference
-    assert_single_refund_prior_to_nep536(&group, &refunds);
+    assert!(refunds.is_empty(), "refund should have been avoided");
 
     let receipts = &*assert_receipts!(group, "near_2" => r3 @ "near_0",
         ReceiptEnum::Action(ActionReceipt{actions, ..}) | ReceiptEnum::ActionV2(ActionReceiptV2{actions, ..}),
@@ -924,7 +904,7 @@ fn test_account_factory() {
             assert!(function_call_action.deposit.is_zero());
         }
     );
-    assert_single_refund_prior_to_nep536(&group, receipts);
+    assert!(receipts.is_empty(), "refund should have been avoided");
 
     let receipts = &*assert_receipts!(group, "near_2" => r4 @ "near_1",
         ReceiptEnum::Action(ActionReceipt{actions, ..}) | ReceiptEnum::ActionV2(ActionReceiptV2{actions, ..}),
@@ -936,7 +916,7 @@ fn test_account_factory() {
             assert!(function_call_action.deposit.is_zero());
         }
     );
-    assert_single_refund_prior_to_nep536(&group, receipts);
+    assert!(receipts.is_empty(), "refund should have been avoided");
 }
 
 #[test]
@@ -1028,7 +1008,7 @@ fn test_create_account_add_key_call_delete_key_delete_account() {
     let [r1, refunds @ ..] = &receipts else { panic!("must have outgoing receipt") };
 
     // For gas price difference
-    assert_single_refund_prior_to_nep536(&group, &refunds);
+    assert!(refunds.is_empty(), "refund should have been avoided");
 
     let receipts = &*assert_receipts!(group, "near_1" => r1 @ "near_3",
         ReceiptEnum::Action(ActionReceipt{actions, ..}) | ReceiptEnum::ActionV2(ActionReceiptV2{actions, ..}),
@@ -1060,12 +1040,7 @@ fn test_create_account_add_key_call_delete_key_delete_account() {
 
     let [r2, r3, refunds @ ..] = &receipts else { panic!("must have 2 outgoing receipts") };
     // For gas price difference
-    if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) {
-        assert_eq!(refunds, [], "refund should have been avoided");
-    } else {
-        let [refund] = &refunds else { panic!("Incorrect number of refunds") };
-        assert_refund!(group, refund @ "near_0");
-    }
+    assert_eq!(refunds, [], "refund should have been avoided");
 
     let receipts = &*assert_receipts!(group, "near_3" => r2 @ "near_0",
         ReceiptEnum::Action(ActionReceipt{actions, ..}) | ReceiptEnum::ActionV2(ActionReceiptV2{actions, ..}),
@@ -1077,12 +1052,7 @@ fn test_create_account_add_key_call_delete_key_delete_account() {
         }
     );
     // For gas price difference
-    if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) {
-        assert_eq!(receipts[..], [], "refund should have been avoided");
-    } else {
-        let [refund] = &receipts[..] else { panic!("Incorrect number of refunds") };
-        assert_refund!(group, refund @ "near_0");
-    }
+    assert_eq!(receipts[..], [], "refund should have been avoided");
 
     // last receipt is refund for deleted account balance, going to near_2
     assert_refund!(group, r3 @ "near_2");
@@ -1146,7 +1116,7 @@ fn test_transfer_64len_hex() {
         }
     );
     let [r1, refunds @ ..] = &receipts else { panic!("Incorrect number of produced receipts") };
-    assert_single_refund_prior_to_nep536(&group, &refunds);
+    assert!(refunds.is_empty(), "refund should have been avoided");
 
     let refunds = assert_receipts!(group, "near_1" => r1 @ account_id.as_str(),
     ReceiptEnum::Action(ActionReceipt{actions, ..}) | ReceiptEnum::ActionV2(ActionReceiptV2{actions, ..}),
@@ -1157,12 +1127,7 @@ fn test_transfer_64len_hex() {
        }
     );
 
-    if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) {
-        assert_eq!(refunds, [], "refund should have been avoided");
-    } else {
-        let [ref1] = &*refunds else { panic!("Incorrect number of refunds") };
-        assert_refund!(group, ref1 @ "near_0");
-    }
+    assert_eq!(refunds, [], "refund should have been avoided");
 }
 
 #[test]
@@ -1229,7 +1194,7 @@ fn test_create_transfer_64len_hex_fail() {
     println!("receipts: {:?}", receipts);
 
     let [r1, refunds @ ..] = &receipts else { panic!("Incorrect number of produced receipts") };
-    assert_single_refund_prior_to_nep536(&group, &refunds);
+    assert!(refunds.is_empty(), "refund should have been avoided");
 
     let receipts = &*assert_receipts!(group, "near_1" => r1 @ account_id.as_str(),
         ReceiptEnum::Action(ActionReceipt{actions, ..}) | ReceiptEnum::ActionV2(ActionReceiptV2{actions, ..}),
@@ -1247,7 +1212,7 @@ fn test_create_transfer_64len_hex_fail() {
     assert_refund!(group, deposit_refund @ "near_1");
 
     // For gas price difference
-    assert_single_refund_prior_to_nep536(&group, &refunds);
+    assert!(refunds.is_empty(), "refund should have been avoided");
 }
 
 // redirect the balance refund using `promise_refund_to`
@@ -1345,17 +1310,5 @@ fn test_refund_to() {
         assert_refund!(group, deposit_refund @ "near_3");
     } else {
         assert_refund!(group, deposit_refund @ "near_1");
-    }
-}
-
-#[track_caller]
-fn assert_single_refund_prior_to_nep536(group: &RuntimeGroup, receipts: &[CryptoHash]) {
-    use near_primitives::transaction::*;
-
-    if ProtocolFeature::ReducedGasRefunds.enabled(PROTOCOL_VERSION) {
-        assert_eq!(receipts, [], "refund should have been avoided");
-    } else {
-        let [refund] = &receipts[..] else { panic!("Incorrect number of refunds") };
-        assert_refund!(group, refund @ "near_0");
     }
 }


### PR DESCRIPTION
Additionally adding asserts in the codebase to check `refund_gas_price_changes` is always false.