### PR TITLE
feat: Shared buffers in runtime registers

### DIFF
--- a/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile_nightly.snap
+++ b/integration-tests/src/tests/runtime/snapshots/integration_tests__tests__runtime__sanity_checks__receipts_gas_profile_nightly.snap
@@ -312,7 +312,7 @@ expression: receipts_gas_profile
         CostGasUsed {
             cost_category: "WASM_HOST_COST",
             cost: "WRITE_REGISTER_BYTE",
-            gas_used: 1904583564,
+            gas_used: 1155675456,
         },
     ],
     [

--- a/runtime/near-vm-runner/src/logic/context.rs
+++ b/runtime/near-vm-runner/src/logic/context.rs
@@ -4,6 +4,7 @@ use near_primitives_core::config::ViewConfig;
 use near_primitives_core::types::{
     AccountId, Balance, BlockHeight, EpochHeight, Gas, StorageUsage,
 };
+use std::rc::Rc;
 
 #[derive(Clone)]
 /// Context for the contract execution.
@@ -27,7 +28,7 @@ pub struct VMContext {
     pub refund_to_account_id: AccountId,
     /// The input to the contract call.
     /// Encoded as base64 string to be able to pass input in borsh binary format.
-    pub input: Vec<u8>,
+    pub input: Rc<[u8]>,
     /// If this method execution is invoked directly as a callback by one or more contract calls
     /// the results of the methods that made the callback are stored in this collection.
     pub promise_results: std::sync::Arc<[PromiseResult]>,

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -767,11 +767,13 @@ impl<'a> VMLogic<'a> {
     pub fn input(&mut self, register_id: u64) -> Result<()> {
         self.result_state.gas_counter.pay_base(base)?;
 
-        self.registers.set(
+        let charge_bytes_gas = !self.config.deterministic_account_ids;
+        self.registers.set_rc_data(
             &mut self.result_state.gas_counter,
             &self.config.limit_config,
             register_id,
             Rc::clone(&self.context.input),
+            charge_bytes_gas,
         )
     }
 
@@ -3257,11 +3259,13 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
         {
             PromiseResult::NotReady => Ok(0),
             PromiseResult::Successful(data) => {
-                self.registers.set(
+                let charge_bytes_gas = !self.config.deterministic_account_ids;
+                self.registers.set_rc_data(
                     &mut self.result_state.gas_counter,
                     &self.config.limit_config,
                     register_id,
-                    data.as_ref(),
+                    Rc::clone(data),
+                    charge_bytes_gas,
                 )?;
                 Ok(1)
             }

--- a/runtime/near-vm-runner/src/logic/logic.rs
+++ b/runtime/near-vm-runner/src/logic/logic.rs
@@ -25,6 +25,7 @@ use near_primitives_core::types::{
     AccountId, Balance, Compute, EpochHeight, Gas, GasWeight, StorageUsage,
 };
 use std::mem::size_of;
+use std::rc::Rc;
 use std::sync::Arc;
 
 pub type Result<T, E = VMLogicError> = ::std::result::Result<T, E>;
@@ -770,7 +771,7 @@ impl<'a> VMLogic<'a> {
             &mut self.result_state.gas_counter,
             &self.config.limit_config,
             register_id,
-            self.context.input.as_slice(),
+            Rc::clone(&self.context.input),
         )
     }
 
@@ -3260,7 +3261,7 @@ bls12381_p2_decompress_base + bls12381_p2_decompress_element * num_elements`
                     &mut self.result_state.gas_counter,
                     &self.config.limit_config,
                     register_id,
-                    data.as_slice(),
+                    data.as_ref(),
                 )?;
                 Ok(1)
             }

--- a/runtime/near-vm-runner/src/logic/tests/context.rs
+++ b/runtime/near-vm-runner/src/logic/tests/context.rs
@@ -1,6 +1,10 @@
+use crate::logic::tests::helpers::assert_costs;
+use crate::map;
 use crate::{logic::tests::vm_logic_builder::VMLogicBuilder, tests::test_vm_config};
+use near_parameters::ExtCosts;
 use near_primitives_core::config::ViewConfig;
 use near_primitives_core::types::Balance;
+use near_primitives_core::version::{PROTOCOL_VERSION, ProtocolFeature};
 
 macro_rules! decl_test_bytes {
     ($testname:ident, $method:ident, $ctx:ident, $want:expr) => {
@@ -115,4 +119,27 @@ fn test_attached_deposit_view() {
     test_view(Balance::ZERO);
     test_view(Balance::from_yoctonear(1));
     test_view(Balance::MAX);
+}
+
+#[test]
+fn test_input_per_byte_gas_fee() {
+    const INPUT_SIZE: usize = 100;
+    let mut logic_builder = VMLogicBuilder::default();
+    logic_builder.context.input = [0u8; INPUT_SIZE].into();
+    let mut logic = logic_builder.build();
+
+    logic.input(0).expect("input() should succeed");
+
+    if ProtocolFeature::DeterministicAccountIds.enabled(PROTOCOL_VERSION) {
+        assert_costs(map! {
+          ExtCosts::base: 1,
+          ExtCosts::write_register_base: 1,
+        });
+    } else {
+        assert_costs(map! {
+          ExtCosts::base: 1,
+          ExtCosts::write_register_base: 1,
+          ExtCosts::write_register_byte: INPUT_SIZE as u64,
+        });
+    }
 }

--- a/runtime/near-vm-runner/src/logic/tests/promises.rs
+++ b/runtime/near-vm-runner/src/logic/tests/promises.rs
@@ -17,7 +17,7 @@ fn vm_receipts<'a>(ext: &'a MockedExternal) -> Vec<impl serde::Serialize + 'a> {
 #[test]
 fn test_promise_results() {
     let promise_results = [
-        PromiseResult::Successful(b"test".to_vec()),
+        PromiseResult::Successful(b"test".to_vec().into()),
         PromiseResult::Failed,
         PromiseResult::NotReady,
     ];

--- a/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
+++ b/runtime/near-vm-runner/src/logic/tests/vm_logic_builder.rs
@@ -72,7 +72,7 @@ fn get_context() -> VMContext {
         signer_account_pk: vec![0, 1, 2, 3, 4],
         predecessor_account_id: "carol.near".parse().unwrap(),
         refund_to_account_id: "david.near".parse().unwrap(),
-        input: vec![0, 1, 2, 3, 4],
+        input: std::rc::Rc::new([0, 1, 2, 3, 4]),
         promise_results: vec![].into(),
         block_height: 10,
         block_timestamp: 42,

--- a/runtime/near-vm-runner/src/logic/types.rs
+++ b/runtime/near-vm-runner/src/logic/types.rs
@@ -1,5 +1,6 @@
 use near_primitives_core::hash::CryptoHash;
 pub use near_primitives_core::types::*;
+use std::rc::Rc;
 
 pub type PublicKey = Vec<u8>;
 pub type PromiseIndex = u64;
@@ -36,7 +37,7 @@ impl ReturnData {
 pub enum PromiseResult {
     /// Current version of the protocol never returns `PromiseResult::NotReady`.
     NotReady,
-    Successful(Vec<u8>),
+    Successful(Rc<[u8]>),
     Failed,
 }
 

--- a/runtime/near-vm-runner/src/logic/vmstate.rs
+++ b/runtime/near-vm-runner/src/logic/vmstate.rs
@@ -8,6 +8,7 @@ use near_parameters::ExtCosts::*;
 use near_parameters::vm::LimitConfig;
 use std::borrow::Cow;
 use std::collections::hash_map::Entry;
+use std::rc::Rc;
 
 type Result<T> = ::std::result::Result<T, VMLogicError>;
 
@@ -115,7 +116,7 @@ impl<'a> Memory<'a> {
 #[derive(Default, Clone)]
 pub(crate) struct Registers {
     /// Values of each existing register.
-    registers: std::collections::HashMap<u64, Box<[u8]>>,
+    registers: std::collections::HashMap<u64, Rc<[u8]>>,
 
     /// Total memory usage as counted for the purposes of the contract
     /// execution.
@@ -168,7 +169,7 @@ impl Registers {
         data: T,
     ) -> Result<()>
     where
-        T: Into<Box<[u8]>> + AsRef<[u8]>,
+        T: Into<Rc<[u8]>> + AsRef<[u8]>,
     {
         let data_len =
             u64::try_from(data.as_ref().len()).map_err(|_| HostError::MemoryAccessViolation)?;
@@ -197,7 +198,7 @@ impl Registers {
         config: &LimitConfig,
         register_id: u64,
         data_len: u64,
-    ) -> Result<Entry<'a, u64, Box<[u8]>>> {
+    ) -> Result<Entry<'a, u64, Rc<[u8]>>> {
         if data_len > config.max_register_size {
             return Err(HostError::MemoryAccessViolation.into());
         }

--- a/runtime/near-vm-runner/src/tests.rs
+++ b/runtime/near-vm-runner/src/tests.rs
@@ -51,7 +51,7 @@ fn create_context(input: Vec<u8>) -> VMContext {
         signer_account_pk: Vec::from(&SIGNER_ACCOUNT_PK[..]),
         predecessor_account_id: PREDECESSOR_ACCOUNT_ID.parse().unwrap(),
         refund_to_account_id: REFUND_TO_ACCOUNT_ID.parse().unwrap(),
-        input,
+        input: std::rc::Rc::from(input),
         promise_results: Vec::new().into(),
         block_height: 10,
         block_timestamp: 42,

--- a/runtime/near-vm-runner/src/tests/fuzzers.rs
+++ b/runtime/near-vm-runner/src/tests/fuzzers.rs
@@ -46,7 +46,7 @@ pub fn create_context(input: Vec<u8>) -> VMContext {
         signer_account_pk: vec![0, 1, 2, 3, 4],
         predecessor_account_id: "carol".parse().unwrap(),
         refund_to_account_id: "david".parse().unwrap(),
-        input,
+        input: std::rc::Rc::from(input),
         promise_results: Vec::new().into(),
         block_height: 10,
         block_timestamp: 42,

--- a/runtime/near-vm-runner/src/tests/test_builder.rs
+++ b/runtime/near-vm-runner/src/tests/test_builder.rs
@@ -16,7 +16,7 @@ pub(crate) fn test_builder() -> TestBuilder {
         signer_account_pk: vec![0, 1, 2],
         predecessor_account_id: "carol".parse().unwrap(),
         refund_to_account_id: "david".parse().unwrap(),
-        input: Vec::new(),
+        input: std::rc::Rc::new([]),
         promise_results: Vec::new().into(),
         block_height: 10,
         block_timestamp: 42,

--- a/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
@@ -699,11 +699,13 @@ pub fn input(caller: &mut Caller<'_, Ctx>, register_id: u64) -> Result<()> {
     let ctx = caller.data_mut();
     ctx.result_state.gas_counter.pay_base(base)?;
 
-    ctx.registers.set(
+    let charge_bytes_gas = !ctx.config.deterministic_account_ids;
+    ctx.registers.set_rc_data(
         &mut ctx.result_state.gas_counter,
         &ctx.config.limit_config,
         register_id,
         Rc::clone(&ctx.context.input),
+        charge_bytes_gas,
     )
 }
 
@@ -3603,11 +3605,13 @@ pub fn promise_result(
     {
         PromiseResult::NotReady => Ok(0),
         PromiseResult::Successful(data) => {
-            ctx.registers.set(
+            let charge_bytes_gas = !ctx.config.deterministic_account_ids;
+            ctx.registers.set_rc_data(
                 &mut ctx.result_state.gas_counter,
                 &ctx.config.limit_config,
                 register_id,
                 Rc::clone(data),
+                charge_bytes_gas,
             )?;
             Ok(1)
         }

--- a/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/logic.rs
@@ -21,6 +21,7 @@ use near_primitives_core::account::AccountContract;
 use near_primitives_core::config::INLINE_DISK_VALUE_THRESHOLD;
 use near_primitives_core::hash::CryptoHash;
 use near_primitives_core::types::{AccountId, Balance, EpochHeight, Gas, GasWeight, StorageUsage};
+use std::rc::Rc;
 use wasmtime::{Caller, Extern, Memory};
 
 // Lookup the memory export and cache it on success.
@@ -702,7 +703,7 @@ pub fn input(caller: &mut Caller<'_, Ctx>, register_id: u64) -> Result<()> {
         &mut ctx.result_state.gas_counter,
         &ctx.config.limit_config,
         register_id,
-        ctx.context.input.as_slice(),
+        Rc::clone(&ctx.context.input),
     )
 }
 
@@ -3606,7 +3607,7 @@ pub fn promise_result(
                 &mut ctx.result_state.gas_counter,
                 &ctx.config.limit_config,
                 register_id,
-                data.as_slice(),
+                Rc::clone(data),
             )?;
             Ok(1)
         }

--- a/runtime/runtime-params-estimator/src/vm_estimator.rs
+++ b/runtime/runtime-params-estimator/src/vm_estimator.rs
@@ -24,7 +24,7 @@ pub(crate) fn create_context(input: Vec<u8>) -> VMContext {
         signer_account_pk: Vec::from(&SIGNER_ACCOUNT_PK[..]),
         predecessor_account_id: PREDECESSOR_ACCOUNT_ID.parse().unwrap(),
         refund_to_account_id: REFUND_TO_ACCOUNT_ID.parse().unwrap(),
-        input,
+        input: std::rc::Rc::from(input),
         promise_results: vec![].into(),
         block_height: 10,
         block_timestamp: 42,

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -41,6 +41,7 @@ use near_vm_runner::logic::{VMContext, VMOutcome};
 use near_vm_runner::{ContractCode, ContractRuntimeCache};
 use near_vm_runner::{PreparedContract, precompile_contract};
 use near_wallet_contract::{wallet_contract, wallet_contract_magic_bytes};
+use std::rc::Rc;
 use std::sync::Arc;
 
 /// Runs given function call with given context / apply state.
@@ -74,7 +75,7 @@ pub(crate) fn execute_function_call(
             .expect("Failed to serialize"),
         predecessor_account_id: predecessor_id.clone(),
         refund_to_account_id: action_receipt.refund_to().as_ref().unwrap_or(predecessor_id).clone(),
-        input: function_call.args.clone(),
+        input: Rc::from(function_call.args.clone()),
         promise_results,
         block_height: apply_state.block_height,
         block_timestamp: apply_state.block_timestamp,


### PR DESCRIPTION
Avoid copying data around in `promise_result` and `input` by using a shared buffer (`Rc<[u8]>`) instead of a `Vec<u8>`.

This is not only more efficient but also resolves a problem where cross-contract callbacks from untrusted sources can return large promises and therefore force a high amount of gas to be attached