### PR TITLE
chore: clippy warning in primitives-core

### DIFF
--- a/core/primitives-core/src/account.rs
+++ b/core/primitives-core/src/account.rs
@@ -196,7 +196,7 @@ impl Account {
     }
 
     #[inline]
-    pub fn contract(&self) -> Cow<AccountContract> {
+    pub fn contract(&self) -> Cow<'_, AccountContract> {
         match self {
             Self::V1(account) => {
                 Cow::Owned(AccountContract::from_local_code_hash(account.code_hash))


### PR DESCRIPTION
Newer versions of Rust / clippy will complain about this.

```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> core/primitives-core/src/account.rs:199:21
    |
199 |     pub fn contract(&self) -> Cow<AccountContract> {
    |                     ^^^^^     -------------------- the same lifetime is hidden here
    |                     |
    |                     the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
199 |     pub fn contract(&self) -> Cow<'_, AccountContract> {
    |                                   +++

warning: `near-primitives-core` (lib) generated 1 warning
```

CI already picks it up in the udeps check, when primitives-core is compiled indirectly through test contracts.