### PR TITLE
benchmark: use 600ms min block time

### DIFF
--- a/benchmarks/sharded-bm/cases/base_config_patch.json
+++ b/benchmarks/sharded-bm/cases/base_config_patch.json
@@ -46,8 +46,8 @@
     },
     "consensus": {
         "min_block_production_delay": {
-            "secs": 1,
-            "nanos": 300000000
+            "secs": 0,
+            "nanos": 600000000
         },
         "max_block_production_delay": {
             "secs": 30,


### PR DESCRIPTION
- Keep a lower minimum block time
- Let the tx-generator push transactions to reach and maintain the target BPS

The above changes makes the network more stable.