### PR TITLE
fix(tracing): fix span attributes

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -623,7 +623,7 @@ impl Client {
         level = "debug",
         target = "client",
         skip_all,
-        fields(height, tag_block_production = true, tag_optimistic = true)
+        fields(%height, tag_block_production = true, tag_optimistic = true)
     )]
     pub fn produce_optimistic_block_on_head(
         &mut self,
@@ -714,7 +714,7 @@ impl Client {
         level = "debug",
         target = "client",
         skip_all,
-        fields(height, tag_block_production = true)
+        fields(%height, tag_block_production = true)
     )]
     pub fn produce_block_on_head(
         &mut self,
@@ -969,7 +969,7 @@ impl Client {
             hash = %block.hash(),
             height = block.header().height(),
             %peer_id,
-            was_requested
+            %was_requested
         )
     )]
     pub fn receive_block(
@@ -1013,7 +1013,7 @@ impl Client {
         level = "debug",
         target = "client",
         skip_all,
-        fields(was_requested, %peer_id)
+        fields(%was_requested, %peer_id)
     )]
     pub fn receive_block_impl(
         &mut self,
@@ -1219,7 +1219,7 @@ impl Client {
 
     /// Check if there are any blocks that has finished applying chunks, run post processing on these
     /// blocks.
-    #[instrument(level = "debug", target = "client", skip_all, fields(should_produce_chunk))]
+    #[instrument(level = "debug", target = "client", skip_all, fields(%should_produce_chunk))]
     pub fn postprocess_ready_blocks(
         &mut self,
         apply_chunks_done_sender: Option<ApplyChunksDoneSender>,
@@ -1533,7 +1533,7 @@ impl Client {
             %block_hash,
             ?status,
             ?provenance,
-            skip_produce_chunk,
+            %skip_produce_chunk,
             is_syncing = self.sync_handler.sync_status.is_syncing(),
             sync_status = ?self.sync_handler.sync_status
         )


### PR DESCRIPTION
It looks like https://github.com/near/nearcore/pull/14228 broke some span attributes.

For example the emitted `produce_block_on_head` spans didn't have the `height` attribute that they should have.
Putting `%` in front of the attribute makes things work correctly.