### PR TITLE
[async] 4/n Nuke MessageWithCallback

### DIFF
--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -6,7 +6,7 @@ use crate::types::{
 };
 use futures::{Future, FutureExt};
 use near_async::Message;
-use near_async::messaging::{AsyncSendError, CanSend, CanSendAsync, Handler, MessageWithCallback};
+use near_async::messaging::{AsyncSendError, CanSend, CanSendAsync, Handler};
 use near_crypto::{KeyType, SecretKey};
 use near_primitives::hash::hash;
 use near_primitives::network::PeerId;
@@ -142,24 +142,6 @@ impl Handler<StopSignal> for PeerManagerActor {
 pub struct MockPeerManagerAdapter {
     pub requests: Arc<RwLock<VecDeque<PeerManagerMessageRequest>>>,
     pub notify: Notify,
-}
-
-impl CanSend<MessageWithCallback<PeerManagerMessageRequest, PeerManagerMessageResponse>>
-    for MockPeerManagerAdapter
-{
-    fn send(
-        &self,
-        message: MessageWithCallback<PeerManagerMessageRequest, PeerManagerMessageResponse>,
-    ) {
-        self.requests.write().push_back(message.message);
-        self.notify.notify_one();
-        (message.callback)(
-            std::future::ready(Ok(PeerManagerMessageResponse::NetworkResponses(
-                NetworkResponses::NoResponse,
-            )))
-            .boxed(),
-        );
-    }
 }
 
 impl CanSend<PeerManagerMessageRequest> for MockPeerManagerAdapter {

--- a/core/async/src/functional.rs
+++ b/core/async/src/functional.rs
@@ -1,4 +1,4 @@
-use crate::messaging::{AsyncSendError, CanSend, CanSendAsync, MessageWithCallback};
+use crate::messaging::{AsyncSendError, CanSend, CanSendAsync};
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use std::marker::PhantomData;
@@ -32,16 +32,6 @@ impl<M: 'static, R: Send + 'static, F: Fn(M) -> R + Send + Sync + 'static>
 {
     pub fn new(f: F) -> Self {
         Self { f, _phantom: PhantomData }
-    }
-}
-
-impl<M: 'static, R: Send + 'static, F: Fn(M) -> R + Send + Sync + 'static>
-    CanSend<MessageWithCallback<M, R>> for SendAsyncFunction<M, R, F>
-{
-    fn send(&self, message: MessageWithCallback<M, R>) {
-        let MessageWithCallback { message, callback: responder } = message;
-        let result = Ok((self.f)(message));
-        responder(async move { result }.boxed());
     }
 }
 

--- a/core/async/src/multithread/sender.rs
+++ b/core/async/src/multithread/sender.rs
@@ -3,9 +3,7 @@ use std::fmt::Debug;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 
-use crate::messaging::{
-    AsyncSendError, CanSend, CanSendAsync, Handler, Message, MessageWithCallback,
-};
+use crate::messaging::{AsyncSendError, CanSend, CanSendAsync, Handler, Message};
 use crate::multithread::runtime_handle::{MultithreadRuntimeHandle, MultithreadRuntimeMessage};
 use crate::{next_message_sequence_num, pretty_type_name};
 
@@ -26,30 +24,6 @@ where
         let message = MultithreadRuntimeMessage { seq, function: Box::new(function) };
         if let Err(_) = self.sender.send(message) {
             tracing::info!(target: "multithread_runtime", seq, "Ignoring sync message, receiving actor is being shut down");
-        }
-    }
-}
-
-// Compatibility layer for multi-send style adapters.
-impl<A, M, R> CanSend<MessageWithCallback<M, R>> for MultithreadRuntimeHandle<A>
-where
-    A: Handler<M, R> + 'static,
-    M: Message + Debug + Send + 'static,
-    R: Send + 'static,
-{
-    fn send(&self, message: MessageWithCallback<M, R>) {
-        let seq = next_message_sequence_num();
-        let message_type = pretty_type_name::<A>();
-        tracing::trace!(target: "multithread_runtime", seq, message_type, "sending sync message with callback");
-
-        let function = move |actor: &mut A| {
-            let result = actor.handle(message.message);
-            (message.callback)(std::future::ready(Ok(result)).boxed());
-        };
-
-        let message = MultithreadRuntimeMessage { seq, function: Box::new(function) };
-        if let Err(_) = self.sender.send(message) {
-            tracing::info!(target: "multithread_runtime", seq, "Ignoring sync message with callback, receiving actor is being shut down");
         }
     }
 }

--- a/core/async/src/test_loop/sender.rs
+++ b/core/async/src/test_loop/sender.rs
@@ -4,9 +4,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::futures::DelayedActionRunner;
-use crate::messaging::{
-    Actor, AsyncSendError, CanSend, CanSendAsync, HandlerWithContext, Message, MessageWithCallback,
-};
+use crate::messaging::{Actor, AsyncSendError, CanSend, CanSendAsync, HandlerWithContext, Message};
 use crate::time::Duration;
 
 use super::PendingEventsSender;
@@ -91,29 +89,6 @@ where
         let callback = move |data: &mut TestLoopData| {
             let actor = data.get_mut(&this.actor_handle);
             actor.handle(msg, &mut this);
-        };
-        self.pending_events_sender.send_with_delay(
-            description,
-            Box::new(callback),
-            self.sender_delay,
-        );
-    }
-}
-
-impl<M, R, A> CanSend<MessageWithCallback<M, R>> for TestLoopSender<A>
-where
-    M: Message + Debug + Send + 'static,
-    A: Actor + HandlerWithContext<M, R> + 'static,
-    R: 'static + Send,
-{
-    fn send(&self, msg: MessageWithCallback<M, R>) {
-        let mut this = self.clone();
-        let description = format!("{}({:?})", pretty_type_name::<A>(), &msg.message);
-        let callback = move |data: &mut TestLoopData| {
-            let MessageWithCallback { message: msg, callback } = msg;
-            let actor = data.get_mut(&this.actor_handle);
-            let result = actor.handle(msg, &mut this);
-            callback(async move { Ok(result) }.boxed());
         };
         self.pending_events_sender.send_with_delay(
             description,


### PR DESCRIPTION
This PR gets rid of `MessageWithCallback` :)

Follow up of https://github.com/near/nearcore/pull/14427