### PR TITLE
[actor] Better logging of actor shutdown

### DIFF
--- a/core/async/src/multithread/runtime_handle.rs
+++ b/core/async/src/multithread/runtime_handle.rs
@@ -1,4 +1,5 @@
 use crate::messaging::Actor;
+use crate::pretty_type_name;
 use std::sync::Arc;
 
 /// MultithreadRuntimeMessage is a type alias for a boxed function that can be sent to the multithread runtime,
@@ -66,12 +67,14 @@ where
         loop {
             crossbeam_channel::select! {
                 recv(cancellation_signal) -> _ => {
-                    tracing::info!(target: "multithread_runtime", "cancellation received, exiting loop.");
+                    let actor_name = pretty_type_name::<A>();
+                    tracing::info!(target: "multithread_runtime", actor_name, "cancellation received, exiting loop.");
                     return;
                 }
                 recv(receiver) -> message => {
                     let Ok(message) = message else {
-                        tracing::warn!(target: "multithread_runtime", "message queue closed, exiting event loop.");
+                    let actor_name = pretty_type_name::<A>();
+                        tracing::warn!(target: "multithread_runtime", actor_name, "message queue closed, exiting event loop.");
                         return;
                     };
                     let seq = message.seq;

--- a/core/async/src/tokio/runtime_handle.rs
+++ b/core/async/src/tokio/runtime_handle.rs
@@ -4,6 +4,7 @@ use tokio::sync::mpsc;
 
 use crate::futures::{DelayedActionRunner, FutureSpawner};
 use crate::messaging::Actor;
+use crate::pretty_type_name;
 use crate::tokio::runtime::AsyncDroppableRuntime;
 use tokio::runtime::Runtime;
 use tokio_util::sync::CancellationToken;
@@ -131,11 +132,13 @@ impl<A: Actor + Send + 'static> TokioRuntimeBuilder<A> {
             loop {
                 tokio::select! {
                     _ = self.system_cancellation_signal.cancelled() => {
-                        tracing::info!(target: "tokio_runtime", "Shutting down Tokio runtime due to ActorSystem shutdown");
+                        let actor_name = pretty_type_name::<A>();
+                        tracing::info!(target: "tokio_runtime", actor_name, "Shutting down Tokio runtime due to ActorSystem shutdown");
                         break;
                     }
                     _ = runtime_handle.cancel.cancelled() => {
-                        tracing::debug!(target: "tokio_runtime", "Shutting down Tokio runtime due to targeted cancellation");
+                        let actor_name = pretty_type_name::<A>();
+                        tracing::info!(target: "tokio_runtime", actor_name, "Shutting down Tokio runtime due to targeted cancellation");
                         break;
                     }
                     Some(message) = receiver.recv() => {


### PR DESCRIPTION
Recently we identified issues with the shutdown process for actors. This PR introduces some better logging for actor shutdown.

See [#releases/2.10 > panic on shutdown (restarting state sync)](https://near.zulipchat.com/#narrow/channel/524130-releases.2F2.2E10/topic/panic.20on.20shutdown.20.28restarting.20state.20sync.29/with/541537025)

See https://github.com/near/nearcore/issues/14125