### PR TITLE
feat: spice: Add metric for execution head.

### DIFF
--- a/chain/chain/src/metrics.rs
+++ b/chain/chain/src/metrics.rs
@@ -58,6 +58,13 @@ pub static BLOCK_ORDINAL_HEAD: LazyLock<IntGauge> = LazyLock::new(|| {
     try_create_int_gauge("near_block_ordinal_head", "Ordinal of the current head of the blockchain")
         .unwrap()
 });
+pub static BLOCK_HEIGHT_SPICE_EXECUTION_HEAD: LazyLock<IntGauge> = LazyLock::new(|| {
+    try_create_int_gauge(
+        "near_block_height_spice_execution_head",
+        "Height of the latest executed block of the blockchain",
+    )
+    .unwrap()
+});
 pub static VALIDATOR_AMOUNT_STAKED: LazyLock<IntGauge> = LazyLock::new(|| {
     try_create_int_gauge(
         "near_validators_stake_total",

--- a/chain/client/src/chunk_executor_actor.rs
+++ b/chain/client/src/chunk_executor_actor.rs
@@ -450,6 +450,7 @@ impl ChunkExecutorActor {
             block_height=?block.header().height(),
             head_height=?self.chain_store.head().map(|tip| tip.height),
             "processing chunk application results");
+        near_chain::metrics::BLOCK_HEIGHT_SPICE_EXECUTION_HEAD.set(block.header().height() as i64);
         let epoch_id = self.epoch_manager.get_epoch_id(&block_hash)?;
         let shard_layout = self.epoch_manager.get_shard_layout(&epoch_id)?;
         for result in &results {


### PR DESCRIPTION
Having a metric would make it easier to evaluate if spice chunk executor is making progress and would allow to compare that progress to block production (by comparing new metric with existing `near_block_height_head` metric).

Part of https://github.com/near/nearcore/issues/13618