### PR TITLE
feat(forknet): Allow multi host selection with partition

### DIFF
--- a/pytest/tests/mocknet/forknet_scenarios/base.py
+++ b/pytest/tests/mocknet/forknet_scenarios/base.py
@@ -263,7 +263,7 @@ class TestSetup:
                                          i * minutes,
                                          binary_idx=1,
                                          partition=PartitionSelector(
-                                             selector=(i, i),
+                                             partitions_range=(i, i),
                                              total_partitions=4))
 
     def schedule_binary_upgrade(self,

--- a/pytest/tests/mocknet/mirror.py
+++ b/pytest/tests/mocknet/mirror.py
@@ -768,18 +768,18 @@ class PartitionSelectorParser(Action):
                 parser.error(
                     f"Invalid input '{values}'. Expected format 'i/n' or 'i-j/n' where i is integer and 0 < i <= n."
                 )
-            selector = (i, i)
+            partitions_range = (i, i)
         else:
             i, j = int(match.group(1)), int(match.group(3))
             if i <= 0 or i > j or j > total_partitions:
                 parser.error(
                     f"Invalid input '{values}'. Expected format 'i/n' or 'i-j/n' where i and j are integers and 0 < i <= j <= n."
                 )
-            selector = (i, j)
+            partitions_range = (i, j)
 
         setattr(
             namespace, self.dest,
-            PartitionSelector(selector=selector,
+            PartitionSelector(partitions_range=partitions_range,
                               total_partitions=total_partitions))
 
 

--- a/pytest/tests/mocknet/utils.py
+++ b/pytest/tests/mocknet/utils.py
@@ -142,15 +142,15 @@ def build_stake_distribution(distribution_type: str | None,
 
 class PartitionSelector(BaseModel):
     # Range of partitions to select.
-    # The selector is a tuple of two integers, the first is the start index and the second is the end index.
+    # The partitions_range is a tuple of two integers, the first is the start index and the second is the end index.
     # The end index is inclusive.
-    selector: tuple[int, int]
+    partitions_range: tuple[int, int]
     # Number of partitions to split the nodes into.
     total_partitions: int
 
     def __call__(self, nodes: list) -> list:
         # For the results to be deterministic, the nodes must be sorted by name.
-        i, j = self.selector
+        i, j = self.partitions_range
         if len(nodes) < self.total_partitions:
             raise ValueError(
                 f'Partitioning {len(nodes)} nodes in {self.total_partitions} groups will result in empty groups.'


### PR DESCRIPTION
Example:
Select 4th partition out of 9:
`mirror --host-type nodes --select-partition 4/9 run-cmd --cmd "ls"`
Select partitions 4, 5 and 6:
`mirror --host-type nodes --select-partition 4-6/9 run-cmd --cmd "ls"`