### PR TITLE
fix(debug): Fix reference to chunk_only_producers

### DIFF
--- a/chain/jsonrpc/res/epoch_info.html
+++ b/chain/jsonrpc/res/epoch_info.html
@@ -152,7 +152,7 @@
                 // Use 2 bits to encode the validator's role in a given epoch.
                 // 00 -- not participated
                 // 01 -- block producer
-                // 10 -- chunk only producer
+                // 10 -- chunk producer
                 epoch.block_producers.forEach(validator => {
                     let account_id = validator.account_id;
                     let value = 2 ** (index * 2);
@@ -260,7 +260,7 @@
                 <th>First block</th>
                 <th>Epoch start</th>
                 <th>Block producers</th>
-                <th>Chunk only producers</th>
+                <th>Chunk producers</th>
             </tr>
         </thead>
         <tbody class="js-tbody-epochs">

--- a/chain/jsonrpc/res/network_info.html
+++ b/chain/jsonrpc/res/network_info.html
@@ -14,7 +14,7 @@
                     data.status_response.EpochInfo.forEach(element => {
                         if (element.epoch_id == epoch_id) {
                             epoch_found = true;
-                            producers_callback(element.block_producers, element.chunk_only_producers);
+                            producers_callback(element.block_producers, element.chunk_producers);
                         }
                     });
                     // This can happen if we're in sync mode - in such case, still print the list of peers,


### PR DESCRIPTION
Trying to fix: `Uncaught TypeError: can't access property "length", epoch.chunk_only_producers is undefined` in `debug/pages/epoch_info`

And `TypeError: can't access property "forEach", chunk_producers is undefined` in `debug/pages/network_info`