### PR TITLE
fix(benchmarks): add max_inflation_rate to epoch_config templates

### DIFF
--- a/benchmarks/sharded-bm/cases/forknet/10_cp_1_rpc_10_shard/epoch_configs/template.json
+++ b/benchmarks/sharded-bm/cases/forknet/10_cp_1_rpc_10_shard/epoch_configs/template.json
@@ -58,5 +58,9 @@
      1, 62500
   ],
   "chunk_producer_assignment_changes_limit": 5,
-  "shuffle_shard_assignment_for_chunk_producers": false
+  "shuffle_shard_assignment_for_chunk_producers": false,
+  "max_inflation_rate": [
+    1,
+    40
+  ]
 }

--- a/benchmarks/sharded-bm/cases/forknet/20-shards/epoch_configs/template.json
+++ b/benchmarks/sharded-bm/cases/forknet/20-shards/epoch_configs/template.json
@@ -70,5 +70,9 @@
     1, 62500
   ],
   "chunk_producer_assignment_changes_limit": 5,
-  "shuffle_shard_assignment_for_chunk_producers": false
+  "shuffle_shard_assignment_for_chunk_producers": false,
+  "max_inflation_rate": [
+    1,
+    40
+  ]
 }

--- a/benchmarks/sharded-bm/cases/forknet/4-shards/epoch_configs/template.json
+++ b/benchmarks/sharded-bm/cases/forknet/4-shards/epoch_configs/template.json
@@ -54,5 +54,9 @@
     1, 62500
   ],
   "chunk_producer_assignment_changes_limit": 5,
-  "shuffle_shard_assignment_for_chunk_producers": false
+  "shuffle_shard_assignment_for_chunk_producers": false,
+  "max_inflation_rate": [
+    1,
+    40
+  ]
 }

--- a/benchmarks/sharded-bm/cases/forknet/50-shards/epoch_configs/template.json
+++ b/benchmarks/sharded-bm/cases/forknet/50-shards/epoch_configs/template.json
@@ -86,5 +86,9 @@
      1, 62500
   ],
   "chunk_producer_assignment_changes_limit": 5,
-  "shuffle_shard_assignment_for_chunk_producers": false
+  "shuffle_shard_assignment_for_chunk_producers": false,
+  "max_inflation_rate": [
+    1,
+    40
+  ]
 }

--- a/benchmarks/sharded-bm/cases/forknet/70_cp_1_rpc_70_shard/epoch_configs/template.json
+++ b/benchmarks/sharded-bm/cases/forknet/70_cp_1_rpc_70_shard/epoch_configs/template.json
@@ -102,5 +102,9 @@
      1, 62500
   ],
   "chunk_producer_assignment_changes_limit": 5,
-  "shuffle_shard_assignment_for_chunk_producers": false
+  "shuffle_shard_assignment_for_chunk_producers": false,
+  "max_inflation_rate": [
+    1,
+    40
+  ]
 }


### PR DESCRIPTION
With https://github.com/near/nearcore/commit/ff9ab9062070556fdb258bb44953051a3e4dd399 it is now necessary to specify this configuration.

Run with fix: https://grafana.nearone.org/goto/df297dyx6j668e?orgId=1
https://github.com/Near-One/infra-ops/actions/runs/18824216437/job/53704484515