### PR TITLE
feat(debug_ui): add voting tracker based on epoch aggregator

### DIFF
--- a/tools/debug-ui/src/EpochValidatorsView.scss
+++ b/tools/debug-ui/src/EpochValidatorsView.scss
@@ -80,56 +80,56 @@
             border: none;
         }
 
-        th:nth-child(3) {
+        th:nth-child(4) {
             border-left: $current-border;
             border-top: $current-border;
             border-right: $current-border;
         }
 
-        th:nth-child(2) {
+        th:nth-child(3) {
             border-left: $next-border;
         }
     }
 
-    thead tr:nth-child(2) th,
+    thead tr:nth-child(3) th,
     tbody td {
-        &:nth-child(2) {
+        &:nth-child(3) {
             border-left: $next-border;
         }
 
-        &:nth-child(2),
         &:nth-child(3),
-        &:nth-child(4) {
+        &:nth-child(4),
+        &:nth-child(5) {
             &:not(:has(.kickout)):not(:has(.kickout-reason)) {
                 opacity: 0.5;
             }
         }
 
-        &:nth-child(5) {
+        &:nth-child(6) {
             border-left: $current-border;
         }
 
-        &:nth-child(9) {
+        &:nth-child(10) {
             border-right: $current-border;
         }
     }
 
-    thead tr:nth-child(2) th {
-        &:nth-child(5),
+    thead tr:nth-child(3) th {
         &:nth-child(6),
         &:nth-child(7),
         &:nth-child(8),
-        &:nth-child(9) {
+        &:nth-child(9),
+        &:nth-child(10){
             background-color: #d6ffd0;
         }
     }
 
     tbody tr:last-child td {
-        &:nth-child(5),
         &:nth-child(6),
         &:nth-child(7),
         &:nth-child(8),
-        &:nth-child(9) {
+        &:nth-child(9),
+        &:nth-child(10) {
             border-bottom: $current-border;
         }
     }


### PR DESCRIPTION
Only active in the epochs where the voting is happening.
It shows up in the epoch validators tab.
The majority version will turn green.
<img width="3474" height="1148" alt="image" src="https://github.com/user-attachments/assets/98b79532-bcbe-472c-972c-0b2f29a336f4" />

