### PR TITLE
feat: run very slow nayduck tests only as part of nightly

### DIFF
--- a/nightly/README.md
+++ b/nightly/README.md
@@ -1,7 +1,7 @@
 # Nightly tests lists
 
 The directory contains test list files which can be sent to NayDuck to
-request a run of the tests.  Most notably, `ci.txt` file contains
+request a run of the tests.  Most notably, `nightly.txt` file contains
 all the tests that NayDuck runs once a day on the head of the master
 branch of the repository.
 
@@ -164,7 +164,7 @@ those functions in a code fragment guarded by `if __name__ ==
 
 ### Check scripts
 
-Unless tests are included (potentially transitively) in `ci.txt`
+Unless tests are included (potentially transitively) in `nightly.txt`
 file, NayDuck won’t run them.  As part of pull request checks,
 verification is performed to make sure that no test is forgotten and
 all new tests are included in the nightly list.  That’s done by

--- a/nightly/ci.txt
+++ b/nightly/ci.txt
@@ -1,3 +1,5 @@
+# List of tests to be executed both as part of PR CI and nightly runs
+
 ./pytest.txt
 ./sandbox.txt
 ./expensive.txt

--- a/nightly/expensive.txt
+++ b/nightly/expensive.txt
@@ -76,6 +76,3 @@ expensive --timeout=10m test-loop-tests test_loop_tests tests::bandwidth_schedul
 expensive --timeout=10m test-loop-tests test_loop_tests tests::bandwidth_scheduler::ultra_slow_test_bandwidth_scheduler_three_shards_random_receipts --features nightly
 expensive test-loop-tests test_loop_tests tests::bandwidth_scheduler::ultra_slow_test_bandwidth_scheduler_four_shards_random_receipts_missing_chunks
 expensive test-loop-tests test_loop_tests tests::bandwidth_scheduler::ultra_slow_test_bandwidth_scheduler_four_shards_random_receipts_missing_chunks --features nightly
-
-# Estimator Warehouse (set timeout as 30 min)
-expensive --timeout=30m estimator-warehouse estimator_warehouse tests::ultra_slow_test_full_estimator

--- a/nightly/nightly-only.txt
+++ b/nightly/nightly-only.txt
@@ -1,0 +1,7 @@
+# List of tests to be executed only by the nightly runs, not as part of PR CI
+
+# Very expensive test: make sure Docker image can be build and run
+pytest --skip-build --timeout=30m sanity/docker.py
+
+# Estimator Warehouse
+expensive --timeout=30m estimator-warehouse estimator_warehouse tests::ultra_slow_test_full_estimator

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -1,0 +1,2 @@
+./ci.txt
+./nightly-only.txt

--- a/nightly/pytest-sanity.txt
+++ b/nightly/pytest-sanity.txt
@@ -222,6 +222,3 @@ pytest sanity/chunk_validator_failover.py --features nightly
 # TODO(#13296): Enable after fixing flaky test
 # pytest sanity/epoch_sync.py
 # pytest sanity/epoch_sync.py --features nightly
-
-# Very expensive test: make sure Docker image can be build and run
-pytest --skip-build --timeout=30m sanity/docker.py

--- a/scripts/check_nightly.py
+++ b/scripts/check_nightly.py
@@ -88,7 +88,7 @@ def main() -> typing.Optional[str]:
                 for test in expensive_tests_in_file(filepath):
                     print(f"  expensive test {test}")
                     if test not in nightly_txt_tests:
-                        return f"error: file {filepath} test {test} not in ci.txt"
+                        return f"error: file {filepath} test {test} not in nightly.txt"
                     # Marking nightly test as found.
                     nightly_txt_tests[test] = True
     for test, found in nightly_txt_tests.items():

--- a/scripts/nayduck.py
+++ b/scripts/nayduck.py
@@ -27,7 +27,7 @@ import typing
 
 REPO_DIR = pathlib.Path(__file__).resolve().parents[1]
 
-DEFAULT_TEST_FILE = "nightly/ci.txt"
+DEFAULT_TEST_FILE = "nightly/nightly.txt"
 NAYDUCK_BASE_HREF = "https://nayduck.nearone.org"
 
 


### PR DESCRIPTION
This PR makes `sanity/docker.py` and `estimator-warehouse ultra_slow_test_full_estimator` to be executed only as part of nayduck nightly run and not PR CI.

See [#core > Slow CI tests @ 💬](https://near.zulipchat.com/#narrow/channel/295558-core/topic/Slow.20CI.20tests/near/547642488) for the context.

Some references:
- related PR #13659 
- [nayduck code](https://github.com/Near-One/nayduck/blob/master/backend/scheduler.py#L258) for determining which tests to run as part of nightly
- [workflow definition](https://github.com/near/nearcore/blob/master/.github/workflows/nayduck_ci.yml#L47) for scheduling nayduck runs as part of CI
