### PR TITLE
fix(ci): run only large pytest tests on merge only

### DIFF
--- a/.github/workflows/nayduck_ci.yml
+++ b/.github/workflows/nayduck_ci.yml
@@ -79,6 +79,7 @@ jobs:
   pytest_tests:
     name: "Large pytest Tests"
     runs-on: warp-ubuntu-2204-x64-8x
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
       - uses: WarpBuilds/setup-python@v5


### PR DESCRIPTION
#14513 moved `pytest_tests` to a different workflow and I expected that to be enough to run those only as part of merge queue, not on PR update.
`if` condition is copy&pasted from `nayduck_tests` to address the issue.