### PR TITLE
fix(network): Accept handshake from new nodes

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -593,10 +593,13 @@ impl PeerActor {
                 }
             }
             ConnectingStatus::Inbound { .. } => {
-                if MIN_SUPPORTED_PROTOCOL_VERSION > handshake.protocol_version {
+                if MIN_SUPPORTED_PROTOCOL_VERSION > handshake.protocol_version
+                    || handshake.oldest_supported_version > PROTOCOL_VERSION
+                {
                     tracing::debug!(
                         target: "network",
                         version = handshake.protocol_version,
+                        oldest_supported_version = handshake.oldest_supported_version,
                         "Received connection from node with unsupported PROTOCOL_VERSION.");
                     self.send_message(&PeerMessage::HandshakeFailure(
                         self.my_node_info.clone(),

--- a/chain/network/src/peer/tests/communication.rs
+++ b/chain/network/src/peer/tests/communication.rs
@@ -229,7 +229,8 @@ async fn test_handshake(outbound_encoding: Option<Encoding>, inbound_encoding: O
         PeerMessage::HandshakeFailure(_, HandshakeFailureReason::ProtocolVersionMismatch { .. })
     );
 
-    // Send too new PROTOCOL_VERSION, expect ProtocolVersionMismatch
+    // Fix protocol_version.
+    // Break oldest_supported_version, expect ProtocolVersionMismatch.
     handshake.protocol_version = PROTOCOL_VERSION + 1;
     handshake.oldest_supported_version = PROTOCOL_VERSION + 1;
     outbound.write(&PeerMessage::Tier2Handshake(handshake.clone())).await;


### PR DESCRIPTION
### Context
Nodes with newer protocol versions are not allowed to initiate a connection with non upgraded node, they need to wait for the other side to initiate the connection.

### Solution
Relax the acceptance condition

### Test
Setup:
```
target/debug/neard localnet --shards 8 --validators 4 --tracked-shards none

~/tmp/neard_old --home ~/.near/node0 run 2>&1 | tee ~/.near/node0/logs.txt &
~/tmp/neard_old --home ~/.near/node1 run 2>&1 | tee ~/.near/node1/logs.txt &
~/tmp/neard_patched --home ~/.near/node2 run 2>&1 | tee ~/.near/node2/logs.txt &
~/tmp/neard_patched --home ~/.near/node3 run 2>&1 | tee ~/.near/node3/logs.txt &
```

Check should fail with version mismatch.
```
PEER=0 ; target/debug/neard ping --chain-id mainnet --peer "`jq -r '.network.public_addrs[]|.' ~/.near/node$PEER/config.json`" --protocol-version 88
```

Check should not fail with version mismatch.
```
PEER=2 ; target/debug/neard ping --chain-id mainnet --peer "`jq -r '.network.public_addrs[]|.' ~/.near/node$PEER/config.json`" --protocol-version 89
```