### PR TITLE
fix(spice): handle last endorsement arriving in block

### DIFF
--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "clock")]
 use crate::block::BlockHeader;
 use crate::hash::{CryptoHash, hash};
-use crate::types::{NumSeats, NumShards, ShardId};
+use crate::types::{ChunkExecutionResultHash, NumSeats, NumShards, ShardId};
 use chrono;
 use chrono::DateTime;
 use near_crypto::{ED25519PublicKey, Secp256K1PublicKey};
@@ -223,6 +223,10 @@ pub fn get_endorsements_key(
 
 pub fn get_execution_results_key(block_hash: &CryptoHash, shard_id: ShardId) -> Vec<u8> {
     get_block_shard_id(block_hash, shard_id)
+}
+
+pub fn get_uncertified_execution_results_key(hash: &ChunkExecutionResultHash) -> Vec<u8> {
+    hash.0.as_ref().to_vec()
 }
 
 pub fn get_block_shard_id_rev(

--- a/core/store/src/columns.rs
+++ b/core/store/src/columns.rs
@@ -357,6 +357,12 @@ pub enum DBCol {
     /// - *Content type*: ([near_primitives::types::ChunkExecutionResult])
     #[cfg(feature = "protocol_feature_spice")]
     ExecutionResults,
+    /// For each spice execution result endorsement contains corresponding execution result.
+    /// May contain both certified and uncertified execution results.
+    /// - *Rows*: ([near_primitives::types::ChunkExecutionResultHash])
+    /// - *Content type*: ([near_primitives::types::ChunkExecutionResult])
+    #[cfg(feature = "protocol_feature_spice")]
+    UncertifiedExecutionResults,
     /// For spice contains uncertified chunks for this block and all it's ancestry.
     /// - *Rows*: BlockHash (CryptoHash)
     /// - *Content type*: Vec<[near_primitives::types::SpiceUncertifiedChunkInfo]>
@@ -400,6 +406,7 @@ pub enum DBKeyType {
     InvalidWitnessesKey,
     InvalidWitnessIndex,
     SpiceEndorsementKey,
+    ChunkExecutionResultHash,
 }
 
 impl DBCol {
@@ -427,7 +434,9 @@ impl DBCol {
             | DBCol::PartialChunks
             | DBCol::TransactionResultForBlock => true,
             #[cfg(feature = "protocol_feature_spice")]
-            DBCol::UncertifiedChunks | DBCol::ExecutionResults => true,
+            DBCol::UncertifiedChunks
+            | DBCol::ExecutionResults
+            | DBCol::UncertifiedExecutionResults => true,
             _ => false,
         }
     }
@@ -520,6 +529,8 @@ impl DBCol {
             | DBCol::Endorsements => false,
             #[cfg(feature = "protocol_feature_spice")]
             | DBCol::ExecutionResults => false,
+            #[cfg(feature = "protocol_feature_spice")]
+            | DBCol::UncertifiedExecutionResults => false,
             #[cfg(feature = "protocol_feature_spice")]
             | DBCol::UncertifiedChunks => false,
             // TODO
@@ -673,6 +684,8 @@ impl DBCol {
             #[cfg(feature = "protocol_feature_spice")]
             DBCol::ExecutionResults => &[DBKeyType::BlockHash, DBKeyType::ShardId],
             #[cfg(feature = "protocol_feature_spice")]
+            DBCol::UncertifiedExecutionResults => &[DBKeyType::ChunkExecutionResultHash],
+            #[cfg(feature = "protocol_feature_spice")]
             DBCol::UncertifiedChunks => &[DBKeyType::BlockHash],
         }
     }
@@ -701,6 +714,13 @@ impl DBCol {
     pub fn execution_results() -> DBCol {
         #[cfg(feature = "protocol_feature_spice")]
         return DBCol::ExecutionResults;
+        #[cfg(not(feature = "protocol_feature_spice"))]
+        panic!("Expected protocol_feature_spice to be enabled")
+    }
+
+    pub fn uncertified_execution_results() -> DBCol {
+        #[cfg(feature = "protocol_feature_spice")]
+        return DBCol::UncertifiedExecutionResults;
         #[cfg(not(feature = "protocol_feature_spice"))]
         panic!("Expected protocol_feature_spice to be enabled")
     }


### PR DESCRIPTION
This PR fixes a following bug:

1. Node can receive all but last endorsement required for certification of execution result.
2. Node receives a block that contains the last endorsement, but no execution result (since node creating a block didn't know about other endorsements yet).
3. Node records the final endorsement, but doesn't record execution result. This results in inconsistent state: we have enough endorsements, but no execution result. If the node was to create a block at this point that block would be invalid since it would cause chain to have enough endorsements and have a missing corresponding execution result.

Part of https://github.com/near/nearcore/issues/13388