### PR TITLE
chore(mirror): logging and error handling improvements

### DIFF
--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -1439,58 +1439,36 @@ impl<T: ChainAccess> TxMirror<T> {
             })?;
         for ch in source_block.chunks {
             for (idx, source_tx) in ch.transactions.into_iter().enumerate() {
-                if let Err(err) = self
-                    .add_tx_function_call_keys(
-                        &source_tx,
-                        MappedTxProvenance::TxCreateAccount(
-                            create_account_height,
-                            ch.shard_id,
-                            idx,
-                        ),
-                        create_account_height,
-                        &ref_hash,
-                        tracker,
-                        tx_block_queue,
-                        target_view_client,
-                        txs,
-                    )
-                    .await
-                {
-                    tracing::error!(
-                        target: "mirror",
-                        ?err,
-                        ?source_tx,
-                        "add_tx_function_call_keys failed as part of add_create_account_txs"
-                    )
-                }
+                self.add_tx_function_call_keys(
+                    &source_tx,
+                    MappedTxProvenance::TxCreateAccount(create_account_height, ch.shard_id, idx),
+                    create_account_height,
+                    &ref_hash,
+                    tracker,
+                    tx_block_queue,
+                    target_view_client,
+                    txs,
+                )
+                .await?
             }
             for (idx, receipt) in ch.receipts.iter().enumerate() {
                 // TODO: we're scanning the list of receipts for each block twice. Once here and then again
                 // when we queue that height's txs. Prob not a big deal but could fix that.
-                if let Err(err) = self
-                    .add_receipt_function_call_keys(
-                        receipt,
-                        MappedTxProvenance::ReceiptCreateAccount(
-                            create_account_height,
-                            ch.shard_id,
-                            idx,
-                        ),
+                self.add_receipt_function_call_keys(
+                    receipt,
+                    MappedTxProvenance::ReceiptCreateAccount(
                         create_account_height,
-                        &ref_hash,
-                        tracker,
-                        tx_block_queue,
-                        target_view_client,
-                        txs,
-                    )
-                    .await
-                {
-                    tracing::error!(
-                        target: "mirror",
-                        ?err,
-                        ?receipt,
-                        "add_receipt_function_call_keys failed as part of add_create_account_txs"
-                    )
-                }
+                        ch.shard_id,
+                        idx,
+                    ),
+                    create_account_height,
+                    &ref_hash,
+                    tracker,
+                    tx_block_queue,
+                    target_view_client,
+                    txs,
+                )
+                .await?;
             }
         }
         Ok(())


### PR DESCRIPTION
This PR address traffic generator (aka mirror) crashing with 160684617 image.

The initial error is:
```
thread 'tokio-runtime-worker' panicked at tools/mirror/src/lib.rs:1744:46:
called `Result::unwrap()` on an `Err` value: SendError { .. }
```
This is not a real issue, but early panic caused node crash without logging the actual error. This is addressed by returning error instead of unwrapping when `send` fails.

When final select in run function finishes receivers of some senders there are passed into spawned coroutines would be deallocated. This would cause send on those senders to return error. Since we were unwrapping before this change it would cause panic. This panic would show that some values weren't able to be send, but have no information about what is causing that - which is a reason why run finished and deallocated relevant receivers.

If we instead don't unwrap on send it should give opportunity for the run function result propagating and hopefully showing relevant result.
