### PR TITLE
fix: fix assertion

### DIFF
--- a/runtime/near-vm/types/src/memory_view.rs
+++ b/runtime/near-vm/types/src/memory_view.rs
@@ -61,7 +61,10 @@ where
 
     /// Creates a subarray view from this `MemoryView`.
     pub fn subarray(&self, start: u32, end: u32) -> Self {
-        assert!((start as usize) < self.length, "The range start is greater than or equal to current length");
+        assert!(
+            (start as usize) < self.length,
+            "The range start is greater than or equal to current length"
+        );
         assert!((end as usize) <= self.length, "The range end is bigger than current length");
 
         Self {


### PR DESCRIPTION
Semantically, the subarray should extract the range [start, end) with a length of end - start. 
The first assertion's message indicates assertion will fail when start > self.length, while actually it will failed when start >= self.length, so the first assertion should be changed into `assert!((start as usize) < self.length, "The range start is greater than or equal to current length");`.
The second assertion should be changed into `assert!((end as usize) <= self.length, "The range end is bigger than current length");` based on semantic.
```rust
/// Creates a subarray view from this `MemoryView`.
pub fn subarray(&self, start: u32, end: u32) -> Self {
    assert!((start as usize) < self.length, "The range start is bigger than current length");
    assert!((end as usize) < self.length, "The range end is bigger than current length");

    Self {
        ptr: unsafe { self.ptr.add(start as usize) },
        length: (end - start) as usize,
        _phantom: PhantomData,
    }
}
```