### PR TITLE
fix(mocknet): disable opentelemetry export

### DIFF
--- a/pytest/tests/mocknet/helpers/neard_runner.py
+++ b/pytest/tests/mocknet/helpers/neard_runner.py
@@ -1042,7 +1042,6 @@ class NeardRunner:
         logging.info("Creating log_config.json with default log filter.")
         with open(log_config_path, 'w') as log_config_file:
             config_json = {
-                'opentelemetry': default_log_filter,
                 'rust_log': default_log_filter,
             }
             json.dump(config_json, log_config_file, indent=2)


### PR DESCRIPTION
We don't have tracing server setup for forknet, so remove `opentelemetry` from `log_config.json` to keep it disabled. Otherwise it spams logs with `ERROR opentelemetry_sdk:  name="BatchSpanProcessor.ExportError" error="Operation failed: status: Unavailable, message: \"tcp connect error\", details: [], metadata: MetadataMap { headers: {} }"`.