### PR TITLE
fix(spice): gc uncertified execution results only once.

### DIFF
--- a/test-loop-tests/src/utils/node.rs
+++ b/test-loop-tests/src/utils/node.rs
@@ -67,6 +67,10 @@ impl<'a> TestLoopNode<'a> {
         &test_loop_data.get(&client_handle).client
     }
 
+    pub fn tail(&self, test_loop_data: &TestLoopData) -> BlockHeight {
+        self.client(test_loop_data).chain.tail().unwrap()
+    }
+
     pub fn head(&self, test_loop_data: &TestLoopData) -> Arc<Tip> {
         self.client(test_loop_data).chain.head().unwrap()
     }


### PR DESCRIPTION
Gc-ing the same column more than once results in a panic in store: https://github.com/near/nearcore/blob/5852156634d419667fdc621460d9d32407b081b1/core/store/src/store.rs#L511

I also added a test that fails without this change to catch any similar issues wtih GC.