### PR TITLE
near-tracing: pin mongodb version

### DIFF
--- a/tracing/docker-compose.yml
+++ b/tracing/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - ${MONGO_DATA_DIR:-./tracing-data}:/data/db
 
   mongo-express:
-    image: mongo-express
+    image: mongo-express:1.0.2
     restart: always
     ports:
       - ${MONGO_EXPRESS_PORT:-8081}:8081


### PR DESCRIPTION
Pin mongo to make sure that we always use the same version on all machines