### PR TITLE
fix(spice): remove obsolete todos from executor.

### DIFF
--- a/chain/client/src/chunk_executor_actor.rs
+++ b/chain/client/src/chunk_executor_actor.rs
@@ -949,11 +949,11 @@ fn new_execution_result(
     ChunkExecutionResult { chunk_extra, outgoing_receipts_root }
 }
 
+// We depend on stored receipts for distribution, so we need to store receipt proof and not only
+// Vec<Receipt>.
 pub(crate) fn save_receipt_proof(
     store_update: &mut StoreUpdate,
     block_hash: &CryptoHash,
-    // We depend on stored receipts for distribution. Because of this we need to store receipt proof
-    // and not only Vec<Receipt>.
     receipt_proof: &ReceiptProof,
 ) -> Result<(), std::io::Error> {
     let &ReceiptProof(_, ShardProof { from_shard_id, to_shard_id, .. }) = receipt_proof;


### PR DESCRIPTION
Since we depend in distribution on receipt proofs being available in store we cannot store receipts without proofs as todos suggested.