### PR TITLE
chore(async): log msg execution as trace

### DIFF
--- a/core/async/src/multithread/sender.rs
+++ b/core/async/src/multithread/sender.rs
@@ -28,7 +28,7 @@ where
             function: Box::new(function),
         };
         if let Err(_) = self.send_message(message) {
-            tracing::info!(target: "multithread_runtime", seq, "Ignoring sync message, receiving actor is being shut down");
+            tracing::info!(target: "multithread_runtime", seq, "ignoring sync message, receiving actor is being shut down");
         }
     }
 }

--- a/core/async/src/tokio/runtime_handle.rs
+++ b/core/async/src/tokio/runtime_handle.rs
@@ -173,21 +173,21 @@ impl<A: Actor + Send + 'static> TokioRuntimeBuilder<A> {
             loop {
                 tokio::select! {
                     _ = self.system_cancellation_signal.cancelled() => {
-                        tracing::info!(target: "tokio_runtime", actor_name, "Shutting down Tokio runtime due to ActorSystem shutdown");
+                        tracing::info!(target: "tokio_runtime", actor_name, "shutting down Tokio runtime due to ActorSystem shutdown");
                         break;
                     }
                     _ = runtime_handle.cancel.cancelled() => {
-                        tracing::info!(target: "tokio_runtime", actor_name, "Shutting down Tokio runtime due to targeted cancellation");
+                        tracing::info!(target: "tokio_runtime", actor_name, "shutting down Tokio runtime due to targeted cancellation");
                         break;
                     }
                     _ = window_update_timer.tick() => {
-                        tracing::debug!(target: "tokio_runtime", "Advancing instrumentation window");
+                        tracing::trace!(target: "tokio_runtime", "advancing instrumentation window");
                         shared_instrumentation.with_thread_local_writer(|writer| writer.advance_window_if_needed());
                     }
                     Some(message) = receiver.recv() => {
                         let seq = message.seq;
                         shared_instrumentation.queue().dequeue(message.name);
-                        tracing::debug!(target: "tokio_runtime", seq, actor_name, "Executing message");
+                        tracing::trace!(target: "tokio_runtime", seq, actor_name, "executing message");
                         let dequeue_time_ns = shared_instrumentation.current_time().saturating_sub(message.enqueued_time_ns);
                         shared_instrumentation.with_thread_local_writer(|writer| writer.start_event(message.name, dequeue_time_ns));
                         (message.function)(&mut actor.actor, &mut runtime_handle);

--- a/core/async/src/tokio/sender.rs
+++ b/core/async/src/tokio/sender.rs
@@ -33,7 +33,7 @@ where
             function: Box::new(function),
         };
         if let Err(_) = self.send_message(message) {
-            tracing::info!(target: "tokio_runtime", seq, "Ignoring sync message, receiving actor is being shut down");
+            tracing::info!(target: "tokio_runtime", seq, "ignoring sync message, receiving actor is being shut down");
         }
     }
 }
@@ -70,7 +70,7 @@ where
 
 impl<A> FutureSpawner for TokioRuntimeHandle<A> {
     fn spawn_boxed(&self, description: &'static str, f: BoxFuture<'static, ()>) {
-        tracing::debug!(target: "tokio_runtime", description, "spawning future");
+        tracing::trace!(target: "tokio_runtime", description, "spawning future");
         self.runtime_handle.spawn(InstrumentingFuture::new(
             description,
             f,


### PR DESCRIPTION
I don't think we need to log each message's execution as debug which will have it logged in CI as is.
Perhaps it will improve flakiness of some pytests.

Also tried to apply some of the newer logging guidelines. Not sure if further changes are needed, but I think this is an improvement.