### PR TITLE
fix: reduce produce chunk add tx time

### DIFF
--- a/benchmarks/sharded-bm/cases/base_config_patch.json
+++ b/benchmarks/sharded-bm/cases/base_config_patch.json
@@ -42,7 +42,7 @@
     "view_client_threads": 4,
     "produce_chunk_add_transactions_time_limit": {
         "secs": 0,
-        "nanos": 600000000
+        "nanos": 400000000
     },
     "consensus": {
         "min_block_production_delay": {


### PR DESCRIPTION
Rolling back to 400ms time limit for `produce_chunk`. Increasing it to 600ms made the benchmark more unstable.