### PR TITLE
fix: reuse protocol version 83 for InvalidTxGenerateOutcomes

### DIFF
--- a/core/primitives-core/src/version.rs
+++ b/core/primitives-core/src/version.rs
@@ -434,8 +434,7 @@ impl ProtocolFeature {
             | ProtocolFeature::_DeprecatedReducedGasRefunds => 78,
             ProtocolFeature::IncreaseMaxCongestionMissedChunks => 79,
             ProtocolFeature::StatePartsCompression | ProtocolFeature::DeterministicAccountIds => 82,
-            ProtocolFeature::Wasmtime => 83,
-            ProtocolFeature::InvalidTxGenerateOutcomes => 84,
+            ProtocolFeature::Wasmtime | ProtocolFeature::InvalidTxGenerateOutcomes => 83,
 
             // Nightly features:
             ProtocolFeature::FixContractLoadingCost => 129,
@@ -461,7 +460,7 @@ pub const PROD_GENESIS_PROTOCOL_VERSION: ProtocolVersion = 29;
 pub const MIN_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = 80;
 
 /// Current protocol version used on the mainnet with all stable features.
-const STABLE_PROTOCOL_VERSION: ProtocolVersion = 84;
+const STABLE_PROTOCOL_VERSION: ProtocolVersion = 83;
 
 // On nightly, pick big enough version to support all features.
 const NIGHTLY_PROTOCOL_VERSION: ProtocolVersion = 149;


### PR DESCRIPTION
#14549 introduces separate protocol version for `ProtocolFeature::InvalidTxGenerateOutcomes` which is unnecessary since  protocol version 83 is not released yet. 