### PR TITLE
Fixing compilation on Mac for indexer

### DIFF
--- a/.cargo/config.profiling.toml
+++ b/.cargo/config.profiling.toml
@@ -1,5 +1,9 @@
 [build]
 rustflags = ["-Cforce-unwind-tables=y", "-Cforce-frame-pointers=y"]
 
+[env]
+# Keep parity with the default config so CI builds consistently.
+LZMA_API_STATIC = "1"
+
 [target.'cfg(target_arch = "x86_64")']
 rustflags = ["-Ctarget-feature=+sse2,+ssse3,+sse4.1,+sse4.2,+popcnt,+fma,+bmi1,+bmi2,+lzcnt,+movbe,+pclmulqdq", "-Cforce-unwind-tables=y", "-Cforce-frame-pointers=y"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,5 +5,9 @@
 # to get a useful backtrace on panic.
 rustflags = ["-Cforce-unwind-tables=y"]
 
+[env]
+# Force bundled liblzma to avoid missing system libraries on macOS builds.
+LZMA_API_STATIC = "1"
+
 [target.'cfg(target_arch = "x86_64")']
 rustflags = ["-Ctarget-feature=+sse2,+ssse3,+sse4.1,+sse4.2,+popcnt,+fma,+bmi1,+bmi2,+lzcnt,+movbe,+pclmulqdq", "-Cforce-unwind-tables=y"]


### PR DESCRIPTION
Currently on `master` getting following errors doing `cargo build` in `tools/indexer/example`:

```
          ld: warning: object file (/private/var/folders/cx/zcf38xp557x1y2n66vb6nkz00000gn/T/rustcOvzRvg/libsecp256k1_sys-6835b9481246d625.rlib[5](fce6141bfa9bf74c-secp256k1.o)) was built for newer 'macOS' version (26.1) than being linked (11.0)
          Undefined symbols for architecture arm64:
            "_lzma_code", referenced from:
                nearcore::download_file::AutoXzDecoder::decompress::_$u7b$$u7b$closure$u7d$$u7d$::h124c66fd43cb05e2 in indexer_example-a873eb7606cda024.indexer_example.b4f2e3cd85b132c4-cgu.0.rcgu.o
            "_lzma_end", referenced from:
                nearcore::download_file::run_download_file::_$u7b$$u7b$closure$u7d$$u7d$::h7710d4c6a45a9b99 in indexer_example-a873eb7606cda024.indexer_example.b4f2e3cd85b132c4-cgu.0.rcgu.o
                nearcore::download_file::run_download_file::_$u7b$$u7b$closure$u7d$$u7d$::h7710d4c6a45a9b99 in indexer_example-a873eb7606cda024.indexer_example.b4f2e3cd85b132c4-cgu.0.rcgu.o
                core::ptr::drop_in_place$LT$nearcore..download_file..download_file_impl..$u7b$$u7b$closure$u7d$$u7d$$GT$::h03b4d318a63a6bbd in indexer_example-a873eb7606cda024.indexer_example.b4f2e3cd85b132c4-cgu.0.rcgu.o
                core::ptr::drop_in_place$LT$nearcore..download_file..download_file_impl..$u7b$$u7b$closure$u7d$$u7d$$GT$::h03b4d318a63a6bbd in indexer_example-a873eb7606cda024.indexer_example.b4f2e3cd85b132c4-cgu.0.rcgu.o
                core::ptr::drop_in_place$LT$nearcore..download_file..AutoXzDecoder$GT$::hc76f7afee5d09a6f in indexer_example-a873eb7606cda024.indexer_example.b4f2e3cd85b132c4-cgu.0.rcgu.o
            "_lzma_stream_decoder", referenced from:
                nearcore::download_file::run_download_file::_$u7b$$u7b$closure$u7d$$u7d$::h7710d4c6a45a9b99 in indexer_example-a873eb7606cda024.indexer_example.b4f2e3cd85b132c4-cgu.0.rcgu.o
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Attached change fixes the compilation of `lzma` library.