### PR TITLE
wasmtime: don't allow symbol names to make it into the error messages

### DIFF
--- a/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner/mod.rs
@@ -329,9 +329,12 @@ impl IntoVMError for anyhow::Error {
             };
             return Err(VMRunnerError::Nondeterministic(nondeterministic_message.into()));
         }
-        // FIXME: this can blow up in size and would get stored in the storage in case this was a
-        // production runtime. Something more proper should be done here.
-        Ok(FunctionCallError::LinkError { msg: format!("{:?}", cause) })
+        let description = if cause.is::<wasmtime::UnknownImportError>() {
+            "unknown or invalid import".to_string()
+        } else {
+            cause.to_string()
+        };
+        Ok(FunctionCallError::LinkError { msg: description })
     }
 }
 


### PR DESCRIPTION
Users control this datum and symbol names are effectively unlimited in length.