### PR TITLE
fix(spice): request data based on current block application

### DIFF
--- a/chain/client/src/spice_data_distributor_actor.rs
+++ b/chain/client/src/spice_data_distributor_actor.rs
@@ -844,9 +844,10 @@ impl SpiceDataDistributorActor {
 
         for from_shard_id in shard_layout.shard_ids() {
             // We need a receipts from a block only if we would want to apply a block after.
-            if shards_we_apply_in_next_block.contains(&from_shard_id) {
+            if shards_we_apply.contains(&from_shard_id) {
                 continue;
             }
+            // TODO(spice-resharding): Handle resharding
             for to_shard_id in shards_we_apply_in_next_block.iter().copied() {
                 new_ids.push(SpiceDataIdentifier::ReceiptProof {
                     block_hash: *block_hash,


### PR DESCRIPTION
We may not need to request receipts from peers if we apply previous block ourselves.

We don't need to request witnesses only if we apply the block witness is for. Before this PR the code mistakenly was making decisions whether we need a witness based on if we apply the next block, not current. If we weren't applying a block and are applying the next block, then we may unnecessarily request witness, and symmetrically we may fail to request witness.

Similarly for receipts when deciding to which shards we need receipts we need to consider the shards we would apply in next block, while using shards we apply in this block to know which we produce and don't need to request.

This particular behaviour is hard to unit-test so I omitted the tests. Generally scenarios like these we would need to handle and test carefully when implementing proper epoch transition handling with spice.

Generally this can be fixed later, but somehow I encountered this in forknet.