### PR TITLE
chore(release): Update release docker tagging and AWS binary upload (#14577)

### DIFF
--- a/.github/workflows/neard_release.yml
+++ b/.github/workflows/neard_release.yml
@@ -71,10 +71,29 @@ jobs:
           if [ -z "$BRANCH" ]; then
             BRANCH=$(git branch -r --contains=${{ github.ref_name }} | head -n1 | cut -c3- | cut -d / -f 2)
           fi
-          aws s3 cp --acl public-read latest s3://build.nearprotocol.com/nearcore/$(uname)/${BRANCH}/latest
+          UPLOAD_TARGETS=()
+          if [ -n "$BRANCH" ]; then
+            UPLOAD_TARGETS+=("$BRANCH")
+          fi
+          if [ "${{ github.event_name }}" = "release" ]; then
+            RELEASE_TAG="${{ github.event.release.tag_name }}"
+             if [ -n "$RELEASE_TAG" ] && [ "$BRANCH" != "$RELEASE_TAG" ]; then
+              UPLOAD_TARGETS+=("$RELEASE_TAG")
+            fi
+          fi
+
+          if [ ${#UPLOAD_TARGETS[@]} -eq 0 ]; then
+            echo "Unable to determine upload target for latest metadata" >&2
+            exit 1
+          fi
+
+          for target in "${UPLOAD_TARGETS[@]}"; do
+            aws s3 cp --acl public-read latest s3://build.nearprotocol.com/nearcore/$(uname)/${target}/latest
+          done
       
       - name: Trigger release metadata update workflow
-        if: github.event_name != 'workflow_dispatch' && github.event_name == 'release'
+        if: github.event_name == 'release'
+        # TODO: Make the distinction between release (mainnet) and pre-release (testnet)
         run: |
           curl -L -X POST -H "Accept: application/vnd.github+json" \
           --fail-with-body \
@@ -122,14 +141,31 @@ jobs:
             BRANCH=$(git branch -r --contains=${{ github.ref_name }} | head -n1 | cut -c3- | cut -d / -f 2)
           fi
 
-          DOCKER_TAGS="nearprotocol/nearcore:${BRANCH},nearprotocol/nearcore:${BRANCH}-${COMMIT}"
-
-          if [[ ${BRANCH} == "master" ]];
-          then
-            DOCKER_TAGS="${DOCKER_TAGS},nearprotocol/nearcore:latest"
+          TAGS=()
+          if [ "$GITHUB_EVENT_NAME" = "release" ]; then
+            TAGS+=("${GITHUB_REF_NAME}")
+            TAGS+=("${GITHUB_REF_NAME}-${COMMIT}")
+            if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+              TAGS+=("pre-release")
+            else
+              TAGS+=("release")
+            fi
+          else
+            TAGS+=("$BRANCH")
+            TAGS+=("$BRANCH-${COMMIT}")
           fi
 
-          echo "DOCKER_TAGS=${DOCKER_TAGS}" >> $GITHUB_ENV
+          if [[ ${BRANCH} == "master" ]]; then
+            TAGS+=("latest")
+          fi
+          
+          DOCKER_TAGS=()
+          for tag in "${TAGS[@]}"; do
+            DOCKER_TAGS+=("nearprotocol/nearcore:$tag")
+          done
+
+          CSV=$(IFS=','; echo "${DOCKER_TAGS[*]}")
+          echo "DOCKER_TAGS=${CSV}" >> $GITHUB_ENV
 
       - name: Build and push Docker image to Dockerhub
         uses: Warpbuilds/build-push-action@v6
@@ -141,4 +177,4 @@ jobs:
           build-args: |
             make_target=neard-release 
           tags: ${{ env.DOCKER_TAGS }}
-  
+

--- a/cspell.json
+++ b/cspell.json
@@ -113,6 +113,7 @@
         "dontcare",
         "doomslug",
         "doomslugs",
+        "dryrun",
         "dynasm",
         "dynasmrt",
         "ellipsifies",

--- a/scripts/binary_release.sh
+++ b/scripts/binary_release.sh
@@ -22,41 +22,75 @@ fi
 
 COMMIT=$(git rev-parse HEAD)
 
+RELEASE_TAG=""
+# the release commit is assigned multiple tags. Only use the tag from the git run.
+if [ "${GITHUB_EVENT_NAME}" = "release" ] && [ -n "${GITHUB_REF_NAME}" ]; then
+  RELEASE_TAG="${GITHUB_REF_NAME}"
+fi
+
 os=$(uname)
 arch=$(uname -m)
 os_and_arch=${os}-${arch}
 
 # cspell:words czvf
 function tar_binary {
+  if [ "${DRY_RUN}" = "true" ]; then
+    echo "DRY RUN MODE: Would run 'tar -C $1 -czvf $1.tar.gz ${os_and_arch}'"
+    touch $1.tar.gz
+    return
+  fi
   mkdir -p $1/${os_and_arch}
   cp target/release/$1 $1/${os_and_arch}/
   tar -C $1 -czvf $1.tar.gz ${os_and_arch}
 }
 
-make $release
+if [ "${DRY_RUN}" = "true" ]; then
+  echo "DRY RUN MODE: Would run 'make $release'"
+else
+  make $release
+fi
 
 function upload_binary {
+  DRY_RUN_FLAG=""
+  if [ "${DRY_RUN}" = "true" ]; then
+    DRY_RUN_FLAG="--dryrun"
+  fi
+
   if [ "$release" = "release" ]
   then
     tar_binary $1
     tar_file=$1.tar.gz
-    aws s3 cp --acl public-read target/release/$1 s3://build.nearprotocol.com/nearcore/${os}/${BRANCH}/$1
-    aws s3 cp --acl public-read target/release/$1 s3://build.nearprotocol.com/nearcore/${os}/${BRANCH}/${COMMIT}/$1
-    aws s3 cp --acl public-read target/release/$1 s3://build.nearprotocol.com/nearcore/${os}/${BRANCH}/${COMMIT}/stable/$1
 
-    aws s3 cp --acl public-read target/release/$1 s3://build.nearprotocol.com/nearcore/${os_and_arch}/${BRANCH}/$1
-    aws s3 cp --acl public-read target/release/$1 s3://build.nearprotocol.com/nearcore/${os_and_arch}/${BRANCH}/${COMMIT}/$1
-    aws s3 cp --acl public-read target/release/$1 s3://build.nearprotocol.com/nearcore/${os_and_arch}/${BRANCH}/${COMMIT}/stable/$1
+    # TODO: Do not publish the branch name for release events.
+    upload_targets=()
+    if [ -n "${BRANCH}" ]; then
+      upload_targets+=("${BRANCH}")
+    fi
+    if [ -n "${RELEASE_TAG}" ] && [ "${BRANCH}" != "${RELEASE_TAG}" ]; then
+      upload_targets+=("${RELEASE_TAG}")
+    fi
 
-    aws s3 cp --acl public-read ${tar_file} s3://build.nearprotocol.com/nearcore/${os_and_arch}/${BRANCH}/${tar_file}
-    aws s3 cp --acl public-read ${tar_file} s3://build.nearprotocol.com/nearcore/${os_and_arch}/${BRANCH}/${COMMIT}/${tar_file}
-    aws s3 cp --acl public-read ${tar_file} s3://build.nearprotocol.com/nearcore/${os_and_arch}/${BRANCH}/${COMMIT}/stable/${tar_file}
+    if [ ${#upload_targets[@]} -eq 0 ]; then
+      echo "Unable to determine upload target for release artifacts" >&2
+      exit 1
+    fi
+
+    sources=("target/release/$1" "${tar_file}")
+    destinations=("$1" "${tar_file}")
+    
+    for target in "${upload_targets[@]}"; do  
+      for i in "${!sources[@]}"; do
+        src=${sources[$i]}
+        dst=${destinations[$i]}
+        aws s3 cp --acl public-read ${src} s3://build.nearprotocol.com/nearcore/${os_and_arch}/${target}/${dst} ${DRY_RUN_FLAG}
+        aws s3 cp --acl public-read ${src} s3://build.nearprotocol.com/nearcore/${os_and_arch}/${target}/${COMMIT}/${dst} ${DRY_RUN_FLAG}
+        aws s3 cp --acl public-read ${src} s3://build.nearprotocol.com/nearcore/${os_and_arch}/${target}/${COMMIT}/stable/${dst} ${DRY_RUN_FLAG}
+      done
+    done
 
   else
     folder="${release%-release}"
-    aws s3 cp --acl public-read target/release/$1 s3://build.nearprotocol.com/nearcore/${os}/${BRANCH}/${folder}/$1
-    aws s3 cp --acl public-read target/release/$1 s3://build.nearprotocol.com/nearcore/${os}/${BRANCH}/${COMMIT}/${folder}/$1
-    aws s3 cp --acl public-read target/release/$1 s3://build.nearprotocol.com/nearcore/${os_and_arch}/${BRANCH}/${COMMIT}/${folder}/$1
+    aws s3 cp --acl public-read target/release/$1 s3://build.nearprotocol.com/nearcore/${os_and_arch}/${BRANCH}/${COMMIT}/${folder}/$1 ${DRY_RUN_FLAG}
   fi
 }
 


### PR DESCRIPTION

Propagate release tag to S3 artefacts and docker hub

Limit AWS uploads to arch-specific paths. We now have `ARM` and `x86` so we need to avoid using `os` as it is ambiguous.


# test
## Simulate a release event with a release tag          
```
GITHUB_EVENT_NAME=release GITHUB_REF_NAME=2.42.0 DRY_RUN=true ./scripts/binary_release.sh
```
```
DRY RUN MODE: Would run 'make release'
DRY RUN MODE: Would run 'tar -C neard -czvf neard.tar.gz Darwin-arm64'
(dryrun) upload: target/release/neard to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/neard
(dryrun) upload: target/release/neard to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/84c9f84f72b872f6e9207aa86f388f549a8fe87d/neard
(dryrun) upload: target/release/neard to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/84c9f84f72b872f6e9207aa86f388f549a8fe87d/stable/neard
(dryrun) upload: ./neard.tar.gz to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/neard.tar.gz
(dryrun) upload: ./neard.tar.gz to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/84c9f84f72b872f6e9207aa86f388f549a8fe87d/neard.tar.gz
(dryrun) upload: ./neard.tar.gz to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/84c9f84f72b872f6e9207aa86f388f549a8fe87d/stable/neard.tar.gz
(dryrun) upload: target/release/neard to s3://build.nearprotocol.com/nearcore/Darwin-arm64/2.42.0/neard
(dryrun) upload: target/release/neard to s3://build.nearprotocol.com/nearcore/Darwin-arm64/2.42.0/84c9f84f72b872f6e9207aa86f388f549a8fe87d/neard
(dryrun) upload: target/release/neard to s3://build.nearprotocol.com/nearcore/Darwin-arm64/2.42.0/84c9f84f72b872f6e9207aa86f388f549a8fe87d/stable/neard
(dryrun) upload: ./neard.tar.gz to s3://build.nearprotocol.com/nearcore/Darwin-arm64/2.42.0/neard.tar.gz
(dryrun) upload: ./neard.tar.gz to s3://build.nearprotocol.com/nearcore/Darwin-arm64/2.42.0/84c9f84f72b872f6e9207aa86f388f549a8fe87d/neard.tar.gz
(dryrun) upload: ./neard.tar.gz to s3://build.nearprotocol.com/nearcore/Darwin-arm64/2.42.0/84c9f84f72b872f6e9207aa86f388f549a8fe87d/stable/neard.tar.gz
DRY RUN MODE: Would run 'tar -C near-sandbox -czvf near-sandbox.tar.gz Darwin-arm64'
(dryrun) upload: target/release/near-sandbox to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/near-sandbox
(dryrun) upload: target/release/near-sandbox to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/84c9f84f72b872f6e9207aa86f388f549a8fe87d/near-sandbox
(dryrun) upload: target/release/near-sandbox to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/84c9f84f72b872f6e9207aa86f388f549a8fe87d/stable/near-sandbox
(dryrun) upload: ./near-sandbox.tar.gz to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/near-sandbox.tar.gz
(dryrun) upload: ./near-sandbox.tar.gz to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/84c9f84f72b872f6e9207aa86f388f549a8fe87d/near-sandbox.tar.gz
(dryrun) upload: ./near-sandbox.tar.gz to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/84c9f84f72b872f6e9207aa86f388f549a8fe87d/stable/near-sandbox.tar.gz
(dryrun) upload: target/release/near-sandbox to s3://build.nearprotocol.com/nearcore/Darwin-arm64/2.42.0/near-sandbox
(dryrun) upload: target/release/near-sandbox to s3://build.nearprotocol.com/nearcore/Darwin-arm64/2.42.0/84c9f84f72b872f6e9207aa86f388f549a8fe87d/near-sandbox
(dryrun) upload: target/release/near-sandbox to s3://build.nearprotocol.com/nearcore/Darwin-arm64/2.42.0/84c9f84f72b872f6e9207aa86f388f549a8fe87d/stable/near-sandbox
(dryrun) upload: ./near-sandbox.tar.gz to s3://build.nearprotocol.com/nearcore/Darwin-arm64/2.42.0/near-sandbox.tar.gz
(dryrun) upload: ./near-sandbox.tar.gz to s3://build.nearprotocol.com/nearcore/Darwin-arm64/2.42.0/84c9f84f72b872f6e9207aa86f388f549a8fe87d/near-sandbox.tar.gz
(dryrun) upload: ./near-sandbox.tar.gz to s3://build.nearprotocol.com/nearcore/Darwin-arm64/2.42.0/84c9f84f72b872f6e9207aa86f388f549a8fe87d/stable/near-sandbox.tar.gz
```

## Simulate manual workflow dispatch
```
GITHUB_EVENT_NAME=workflow_dispatch DRY_RUN=true ./scripts/binary_release.sh
```
```
DRY RUN MODE: Would run 'make release'
DRY RUN MODE: Would run 'tar -C neard -czvf neard.tar.gz Darwin-arm64'
(dryrun) upload: target/release/neard to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/neard
(dryrun) upload: target/release/neard to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/84c9f84f72b872f6e9207aa86f388f549a8fe87d/neard
(dryrun) upload: target/release/neard to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/84c9f84f72b872f6e9207aa86f388f549a8fe87d/stable/neard
(dryrun) upload: ./neard.tar.gz to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/neard.tar.gz
(dryrun) upload: ./neard.tar.gz to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/84c9f84f72b872f6e9207aa86f388f549a8fe87d/neard.tar.gz
(dryrun) upload: ./neard.tar.gz to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/84c9f84f72b872f6e9207aa86f388f549a8fe87d/stable/neard.tar.gz
DRY RUN MODE: Would run 'tar -C near-sandbox -czvf near-sandbox.tar.gz Darwin-arm64'
(dryrun) upload: target/release/near-sandbox to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/near-sandbox
(dryrun) upload: target/release/near-sandbox to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/84c9f84f72b872f6e9207aa86f388f549a8fe87d/near-sandbox
(dryrun) upload: target/release/near-sandbox to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/84c9f84f72b872f6e9207aa86f388f549a8fe87d/stable/near-sandbox
(dryrun) upload: ./near-sandbox.tar.gz to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/near-sandbox.tar.gz
(dryrun) upload: ./near-sandbox.tar.gz to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/84c9f84f72b872f6e9207aa86f388f549a8fe87d/near-sandbox.tar.gz
(dryrun) upload: ./near-sandbox.tar.gz to s3://build.nearprotocol.com/nearcore/Darwin-arm64/codex/modify-docker-image-tagging-logic/84c9f84f72b872f6e9207aa86f388f549a8fe87d/stable/near-sandbox.tar.gz
```