### PR TITLE
fix(sharded_bm.py): fix setcap on a local binary

### DIFF
--- a/pytest/tests/mocknet/sharded_bm.py
+++ b/pytest/tests/mocknet/sharded_bm.py
@@ -133,7 +133,8 @@ def handle_init(args):
         sys.exit(1)
 
     # if neard_binary_url is a local path - upload the file to each node
-    if os.path.isfile(args.neard_binary_url):
+    is_local_neard = os.path.isfile(args.neard_binary_url)
+    if is_local_neard:
         logger.info(f"handling local `neard` at {args.neard_binary_url}")
         local_path_on_remote = upload_local_neard(args)
         args.neard_binary_url = local_path_on_remote
@@ -154,7 +155,10 @@ def handle_init(args):
 
     # Grant CAP_SYS_NICE to neard binaries for realtime thread scheduling
     run_cmd_args = copy.deepcopy(args)
-    run_cmd_args.cmd = "sudo setcap cap_sys_nice+ep ~/.near/neard-runner/binaries/neard*"
+    if is_local_neard:
+        run_cmd_args.cmd = f"sudo setcap cap_sys_nice+ep \"{args.neard_binary_url}\""
+    else:
+        run_cmd_args.cmd = "sudo setcap cap_sys_nice+ep ~/.near/neard-runner/binaries/neard*"
     run_remote_cmd(CommandContext(run_cmd_args))
 
     upload_json_patches(args)


### PR DESCRIPTION
When a local file path is provided as binary url, `neard-runner` creates a symlink to the binary file and puts the symlink in `neard-runner/binaries`.
The problem is that we can't run `setcap` on a symlink, it has to be run on a real file. Trying to run it on a symlink causes an error:
```bash
$ sudo setcap cap_sys_nice+ep ~/.near/neard-runner/binaries/neard*
Failed to set capabilities on file `/home/ubuntu/.near/neard-runner/binaries/neard0' (Invalid argument)
The value of the capability argument is not permitted for a file. Or the file is not a regular (non-symlink) file
```

Let's fix the issue by running `setcap` on the actual file.