### PR TITLE
fix(indexer): make local_receipts optional to maintain backward compatibility

### DIFF
--- a/chain/indexer-primitives/src/lib.rs
+++ b/chain/indexer-primitives/src/lib.rs
@@ -19,6 +19,7 @@ pub struct IndexerChunkView {
     pub receipts: Vec<views::ReceiptView>,
     /// Receipts generated in this chunk from transactions with `signer_id`
     /// equal to `receiver_id`.
+    #[serde(default)]
     pub local_receipts: Vec<views::ReceiptView>,
 }
 


### PR DESCRIPTION
FastNear reported an issue with `IndexerChunkView`:
> 2.10 broke compatibility of old blocks due to introduction of local receipts in the IndexerChunkView. Need to mark them as optional in serde otherwise previous blocks can't be decoded.