### PR TITLE
wip: pending tx queue, use uncertified chunks

### DIFF
--- a/chain/chain/src/runtime/tests.rs
+++ b/chain/chain/src/runtime/tests.rs
@@ -1650,6 +1650,7 @@ fn prepare_transactions_extra(
                 .check_transaction_validity_period(&block.header(), tx.transaction.block_hash())
                 .is_ok()
         },
+        None,
         skip_tx_hashes,
         default_produce_chunk_add_transactions_time_limit(),
         cancel,

--- a/chain/chain/src/spice_core.rs
+++ b/chain/chain/src/spice_core.rs
@@ -422,7 +422,7 @@ impl SpiceCoreReader {
     }
 }
 
-fn get_uncertified_chunks(
+pub fn get_uncertified_chunks(
     chain_store: &ChainStoreAdapter,
     block_hash: &CryptoHash,
 ) -> Result<Vec<SpiceUncertifiedChunkInfo>, Error> {
@@ -445,7 +445,7 @@ fn get_uncertified_chunks(
     }
 }
 
-fn get_block_execution_results(block: &Block) -> HashMap<&SpiceChunkId, &ChunkExecutionResult> {
+pub fn get_block_execution_results(block: &Block) -> HashMap<&SpiceChunkId, &ChunkExecutionResult> {
     block
         .spice_core_statements()
         .iter()

--- a/chain/client/src/chunk_producer.rs
+++ b/chain/client/src/chunk_producer.rs
@@ -128,13 +128,16 @@ impl ChunkProducer {
             clock,
             chunk_transactions_time_limit,
             chain: chain_store.clone(),
-            epoch_manager,
-            runtime_adapter,
+            epoch_manager: epoch_manager.clone(),
+            runtime_adapter: runtime_adapter.clone(),
             sharded_tx_pool: Arc::new(Mutex::new(ShardedTransactionPool::new(
                 rng_seed,
                 transaction_pool_size_limit,
             ))),
-            pending_txs: Arc::new(Mutex::new(ShardedPendingTransactionQueue::new())),
+            pending_txs: Arc::new(Mutex::new(ShardedPendingTransactionQueue::new(
+                runtime_adapter,
+                epoch_manager,
+            ))),
             reed_solomon_encoder: ReedSolomon::new(data_parts, parity_parts).unwrap(),
             chunk_production_info: lru::LruCache::new(
                 NonZeroUsize::new(PRODUCTION_TIMES_CACHE_SIZE).unwrap(),

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -33,6 +33,7 @@ use near_chain::chain::{
 use near_chain::orphan::OrphanMissingChunks;
 use near_chain::rayon_spawner::RayonAsyncComputationSpawner;
 use near_chain::resharding::types::ReshardingSender;
+use near_chain::spice_core::get_block_execution_results;
 use near_chain::state_snapshot_actor::SnapshotCallbacks;
 use near_chain::test_utils::format_hash;
 use near_chain::types::{ChainConfig, LatestKnown, RuntimeAdapter};
@@ -373,6 +374,16 @@ impl Client {
             config.transaction_pool_size_limit,
             multi_spawner.prepare_transactions,
         );
+        {
+            // Initialize pending transaction queue from the current head
+            let mut guard = chunk_producer.pending_txs.lock();
+            guard.reset_from_uncertified_chunks(
+                &chain.head()?.last_block_hash,
+                &chain.chain_store(),
+                &shard_tracker,
+                epoch_manager.as_ref(),
+            )?;
+        }
 
         let chunk_distribution_network = ChunkDistributionNetwork::from_config(&config);
         Ok(Self {
@@ -455,6 +466,47 @@ impl Client {
                 let transactions = chunk.to_transactions();
                 let mut pool_guard = self.chunk_producer.sharded_tx_pool.lock();
                 pool_guard.remove_transactions(shard_uid, transactions);
+            }
+        }
+        Ok(())
+    }
+
+    pub fn add_transactions_for_block_to_pending_queue(&self, block: &Block) -> Result<(), Error> {
+        let epoch_id = self.epoch_manager.get_epoch_id(block.hash())?;
+        for chunk_header in block.chunks().iter_new() {
+            // We can directly get the shard_id from the chunk_header as we are guaranteed new chunk via iter_new
+            let shard_id = chunk_header.shard_id();
+            let shard_uid = shard_id_to_uid(self.epoch_manager.as_ref(), shard_id, &epoch_id)?;
+            if self
+                .shard_tracker
+                .cares_about_shard_this_or_next_epoch(block.header().prev_hash(), shard_id)
+            {
+                // By now the chunk must be in store, otherwise the block would have been orphaned
+                let chunk = self.chain.get_chunk(&chunk_header.chunk_hash()).unwrap();
+                let mut guard = self.chunk_producer.pending_txs.lock();
+                guard
+                    .get_queue_mut(shard_uid)
+                    .add_transactions(*block.hash(), chunk.into_transactions());
+            }
+        }
+        Ok(())
+    }
+
+    pub fn remove_certified_transactions_for_block_from_pending_queue(
+        &self,
+        block: &Block,
+    ) -> Result<(), Error> {
+        let block_execution_results = get_block_execution_results(block);
+        for chunk_id in block_execution_results.keys() {
+            let epoch_id = self.epoch_manager.get_epoch_id(&chunk_id.block_hash)?;
+            let shard_id = chunk_id.shard_id;
+            let shard_uid = shard_id_to_uid(self.epoch_manager.as_ref(), shard_id, &epoch_id)?;
+            if self
+                .shard_tracker
+                .cares_about_shard_this_or_next_epoch(block.header().prev_hash(), shard_id)
+            {
+                let mut guard = self.chunk_producer.pending_txs.lock();
+                guard.get_queue_mut(shard_uid).remove_transactions(&chunk_id.block_hash);
             }
         }
         Ok(())
@@ -1633,6 +1685,9 @@ impl Client {
         }
 
         if let Some(signer) = self.validator_signer.get() {
+            if let Err(err) = self.reconcile_pending_transaction_queue(status.clone(), &block) {
+                tracing::debug!(target: "client", ?err, "failed to reconcile pending transaction queue");
+            }
             if !self.reconcile_transaction_pool(status, &block) {
                 return;
             }
@@ -1666,6 +1721,42 @@ impl Client {
         // Notify chunk validation actor about the new block for orphan witness processing
         let block_notification = BlockNotificationMessage { block: block.clone() };
         self.chunk_validation_sender.block_notification.send(block_notification);
+    }
+
+    fn reconcile_pending_transaction_queue(
+        &self,
+        status: BlockStatus,
+        block: &Block,
+    ) -> Result<(), Error> {
+        match status {
+            BlockStatus::Next => {
+                self.add_transactions_for_block_to_pending_queue(block)?;
+                self.remove_certified_transactions_for_block_from_pending_queue(block)
+            }
+            BlockStatus::Fork => {
+                // It's a fork, no need to reconcile transactions or produce chunks.
+                Ok(())
+            }
+            BlockStatus::Reorg(_) => {
+                // If there is a re-org, just reset the pending tx queue based on uncertified chunks.
+                self.reset_pending_transaction_queue_from_uncertified_chunks(block.hash())
+            }
+        }
+    }
+
+    fn reset_pending_transaction_queue_from_uncertified_chunks(
+        &self,
+        block_hash: &CryptoHash,
+    ) -> Result<(), Error> {
+        let mut guard = self.chunk_producer.pending_txs.lock();
+        guard
+            .reset_from_uncertified_chunks(
+                block_hash,
+                &self.chain.chain_store,
+                &self.shard_tracker,
+                &*self.epoch_manager,
+            )
+            .map_err(|e| e.into())
     }
 
     /// Reconcile the transaction pool after processing a block.

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -50,6 +50,7 @@ pub mod debug;
 pub mod gc_actor;
 mod info;
 pub mod metrics;
+mod pending_transaction_queue;
 mod prepare_transactions;
 mod rpc_handler;
 pub mod spice_chunk_validator_actor;

--- a/chain/client/src/pending_transaction_queue.rs
+++ b/chain/client/src/pending_transaction_queue.rs
@@ -1,27 +1,39 @@
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::Arc;
 
 use near_chain::spice_core::get_uncertified_chunks;
+use near_chain::types::RuntimeAdapter;
 use near_chain_primitives::Error;
+use near_crypto::PublicKey;
 use near_epoch_manager::EpochManagerAdapter;
 use near_epoch_manager::shard_assignment::shard_id_to_uid;
 use near_epoch_manager::shard_tracker::ShardTracker;
 use near_primitives::hash::CryptoHash;
-use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::ShardId;
+use near_primitives::transaction::{SignedTransaction, TransactionKey};
+use near_primitives::types::{AccountId, Balance, EpochId, ShardId};
 use near_store::ShardUId;
+use near_store::adapter::StoreAdapter;
 use near_store::adapter::chain_store::ChainStoreAdapter;
+use node_runtime::config::tx_cost;
 
 pub struct ShardedPendingTransactionQueue {
+    runtime_adapter: Arc<dyn RuntimeAdapter>,
+    epoch_manager: Arc<dyn EpochManagerAdapter>,
     queues: HashMap<ShardUId, PendingTransactionQueue>,
 }
 
 impl ShardedPendingTransactionQueue {
-    pub fn new() -> Self {
-        Self { queues: HashMap::new() }
+    pub fn new(
+        runtime_adapter: Arc<dyn RuntimeAdapter>,
+        epoch_manager: Arc<dyn EpochManagerAdapter>,
+    ) -> Self {
+        Self { runtime_adapter, epoch_manager, queues: HashMap::new() }
     }
 
     pub fn get_queue_mut(&mut self, shard_uid: ShardUId) -> &mut PendingTransactionQueue {
-        self.queues.entry(shard_uid).or_insert_with(PendingTransactionQueue::new)
+        self.queues.entry(shard_uid).or_insert_with(|| {
+            PendingTransactionQueue::new(self.runtime_adapter.clone(), self.epoch_manager.clone())
+        })
     }
 
     pub fn reset_from_uncertified_chunks(
@@ -29,7 +41,6 @@ impl ShardedPendingTransactionQueue {
         head: &CryptoHash,
         store: &ChainStoreAdapter,
         shard_tracker: &ShardTracker,
-        epoch_manager: &dyn EpochManagerAdapter,
     ) -> Result<(), Error> {
         self.queues.clear();
         let chunk_infos = get_uncertified_chunks(store, head)?;
@@ -41,6 +52,7 @@ impl ShardedPendingTransactionQueue {
         }
         for (block_hash, shard_ids) in shard_ids_by_block_hash {
             let block = store.get_block(&block_hash)?;
+            let prev_block_header = store.get_block_header(&block.header().prev_hash())?;
             // Spice does not have missing chunks so we can use iter_new here.
             for chunk_header in block.chunks().iter_new() {
                 let shard_id = chunk_header.shard_id();
@@ -52,39 +64,154 @@ impl ShardedPendingTransactionQueue {
                     continue;
                 }
                 let epoch_id = block.header().epoch_id();
-                let chunk = store.get_chunk(&chunk_header.chunk_hash())?;
-                self.get_queue_mut(shard_id_to_uid(epoch_manager, shard_id, epoch_id)?)
-                    .add_transactions(block_hash, chunk.into_transactions());
+                let chunk = store.chunk_store().get_chunk(&chunk_header.chunk_hash())?;
+                // TODO(spice): Gas price should be calculated properly.
+                let gas_price = prev_block_header.next_gas_price();
+                self.get_queue_mut(shard_id_to_uid(&*self.epoch_manager, shard_id, epoch_id)?)
+                    .add_transactions(
+                        block_hash,
+                        block.header().epoch_id(),
+                        gas_price,
+                        chunk.into_transactions(),
+                    );
             }
         }
         Ok(())
     }
 }
 
-/// A queue that holds transactions that are included in blocks,
-/// but not yet executed for a given shard.
+/// A queue that holds summarized, per payer information about transactions that
+/// are included in blocks, but not yet executed for a given shard.
 pub struct PendingTransactionQueue {
-    pending_txs: VecDeque<(CryptoHash, Vec<SignedTransaction>)>,
+    runtime_adapter: Arc<dyn RuntimeAdapter>,
+    epoch_manager: Arc<dyn EpochManagerAdapter>,
+    pending_txs: VecDeque<(CryptoHash, PendingTransactionSummary)>,
+    summary: PendingTransactionSummary,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub enum PayerKey {
+    Account { account_id: AccountId },
+    GasKey { account_id: AccountId, public_key: PublicKey },
+}
+
+/// Information about pending transactions for a given account or (account, gas key) pair.
+/// Summarized at the chunk and overall level.
+#[derive(Default)]
+pub struct PendingTransactionInfo {
+    count: usize,
+    cost: Balance,
+    num_contract_deploys: usize,
+}
+
+struct PendingTransactionSummary(HashMap<PayerKey, PendingTransactionInfo>);
+
+impl PendingTransactionSummary {
+    fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    fn add(&mut self, key: PayerKey, info: &PendingTransactionInfo) {
+        let entry = self.0.entry(key).or_default();
+        entry.count += info.count;
+        entry.cost = entry.cost.checked_add(info.cost).unwrap();
+        entry.num_contract_deploys += info.num_contract_deploys;
+    }
+
+    fn subtract(&mut self, key: &PayerKey, info: &PendingTransactionInfo) {
+        if let Some(entry) = self.0.get_mut(key) {
+            entry.count -= info.count;
+            entry.cost = entry.cost.checked_sub(info.cost).unwrap();
+            entry.num_contract_deploys -= info.num_contract_deploys;
+            if entry.count == 0 {
+                self.0.remove(key);
+            }
+        }
+    }
+
+    fn add_summary(&mut self, other: &PendingTransactionSummary) {
+        for (key, info) in &other.0 {
+            self.add(key.clone(), info);
+        }
+    }
+
+    fn subtract_summary(&mut self, other: &PendingTransactionSummary) {
+        for (key, info) in &other.0 {
+            self.subtract(key, info);
+        }
+    }
 }
 
 impl PendingTransactionQueue {
-    fn new() -> Self {
-        Self { pending_txs: VecDeque::new() }
-    }
-
-    pub fn add_transactions(&mut self, block_hash: CryptoHash, txs: Vec<SignedTransaction>) {
-        self.pending_txs.push_back((block_hash, txs));
-    }
-
-    pub fn remove_transactions(
-        &mut self,
-        block_hash: &CryptoHash,
-    ) -> Option<Vec<SignedTransaction>> {
-        if let Some(pos) = self.pending_txs.iter().position(|(hash, _)| hash == block_hash) {
-            let (_, txs) = self.pending_txs.remove(pos).unwrap();
-            Some(txs)
-        } else {
-            None
+    fn new(
+        runtime_adapter: Arc<dyn RuntimeAdapter>,
+        epoch_manager: Arc<dyn EpochManagerAdapter>,
+    ) -> Self {
+        Self {
+            runtime_adapter,
+            epoch_manager,
+            pending_txs: VecDeque::new(),
+            summary: PendingTransactionSummary::new(),
         }
+    }
+
+    fn calculate_total_cost(
+        &self,
+        tx: &SignedTransaction,
+        gas_price: Balance,
+        epoch_id: &EpochId,
+    ) -> Balance {
+        // TODO(spice): Handle error properly.
+        let protocol_version = self.epoch_manager.get_epoch_protocol_version(epoch_id).unwrap();
+        let runtime_config = self.runtime_adapter.get_runtime_config(protocol_version);
+        // TODO(spice): Handle error (overflow) properly.
+        tx_cost(runtime_config, &tx.transaction, gas_price).unwrap().total_cost
+    }
+
+    fn num_contract_deploys(&self, tx: &SignedTransaction) -> usize {
+        tx.transaction
+            .actions()
+            .iter()
+            .filter(|action| {
+                matches!(action, near_primitives::transaction::Action::DeployContract(_))
+            })
+            .count()
+    }
+
+    pub fn add_transactions(
+        &mut self,
+        block_hash: CryptoHash,
+        epoch_id: &EpochId,
+        gas_price: Balance,
+        txs: Vec<SignedTransaction>,
+    ) {
+        let mut chunk_summary = PendingTransactionSummary::new();
+        for tx in txs {
+            let account_id = tx.transaction.signer_id().clone();
+            let key = match tx.transaction.key() {
+                TransactionKey::AccessKey { .. } => PayerKey::Account { account_id },
+                TransactionKey::GasKey { public_key, .. } => {
+                    PayerKey::GasKey { account_id, public_key }
+                }
+            };
+            let cost = self.calculate_total_cost(&tx, gas_price, epoch_id);
+            let num_contract_deploys = self.num_contract_deploys(&tx);
+            chunk_summary
+                .add(key, &PendingTransactionInfo { count: 1, cost, num_contract_deploys });
+        }
+        self.summary.add_summary(&chunk_summary);
+        self.pending_txs.push_back((block_hash, chunk_summary));
+    }
+
+    pub fn remove_transactions(&mut self, block_hash: &CryptoHash) {
+        // TODO(spice): Enforce that removed element is at the front of the queue.
+        if let Some(pos) = self.pending_txs.iter().position(|(hash, _)| hash == block_hash) {
+            let (_, chunk_summary) = self.pending_txs.remove(pos).unwrap();
+            self.summary.subtract_summary(&chunk_summary);
+        }
+    }
+
+    pub fn get(&self, key: &PayerKey) -> Option<&PendingTransactionInfo> {
+        self.summary.0.get(key)
     }
 }

--- a/chain/client/src/pending_transaction_queue.rs
+++ b/chain/client/src/pending_transaction_queue.rs
@@ -1,0 +1,90 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use near_chain::spice_core::get_uncertified_chunks;
+use near_chain_primitives::Error;
+use near_epoch_manager::EpochManagerAdapter;
+use near_epoch_manager::shard_assignment::shard_id_to_uid;
+use near_epoch_manager::shard_tracker::ShardTracker;
+use near_primitives::hash::CryptoHash;
+use near_primitives::transaction::SignedTransaction;
+use near_primitives::types::ShardId;
+use near_store::ShardUId;
+use near_store::adapter::chain_store::ChainStoreAdapter;
+
+pub struct ShardedPendingTransactionQueue {
+    queues: HashMap<ShardUId, PendingTransactionQueue>,
+}
+
+impl ShardedPendingTransactionQueue {
+    pub fn new() -> Self {
+        Self { queues: HashMap::new() }
+    }
+
+    pub fn get_queue_mut(&mut self, shard_uid: ShardUId) -> &mut PendingTransactionQueue {
+        self.queues.entry(shard_uid).or_insert_with(PendingTransactionQueue::new)
+    }
+
+    pub fn reset_from_uncertified_chunks(
+        &mut self,
+        head: &CryptoHash,
+        store: &ChainStoreAdapter,
+        shard_tracker: &ShardTracker,
+        epoch_manager: &dyn EpochManagerAdapter,
+    ) -> Result<(), Error> {
+        self.queues.clear();
+        let chunk_infos = get_uncertified_chunks(store, head)?;
+        let mut shard_ids_by_block_hash: HashMap<CryptoHash, HashSet<ShardId>> = HashMap::new();
+        for chunk_info in chunk_infos {
+            let block_hash = chunk_info.chunk_id.block_hash;
+            let shard_id = chunk_info.chunk_id.shard_id;
+            shard_ids_by_block_hash.entry(block_hash).or_default().insert(shard_id);
+        }
+        for (block_hash, shard_ids) in shard_ids_by_block_hash {
+            let block = store.get_block(&block_hash)?;
+            // Spice does not have missing chunks so we can use iter_new here.
+            for chunk_header in block.chunks().iter_new() {
+                let shard_id = chunk_header.shard_id();
+                // TODO(spice-resharding): Is this correct?
+                if !shard_tracker.cares_about_shard(block.header().prev_hash(), shard_id) {
+                    continue;
+                }
+                if !shard_ids.contains(&chunk_header.shard_id()) {
+                    continue;
+                }
+                let epoch_id = block.header().epoch_id();
+                let chunk = store.get_chunk(&chunk_header.chunk_hash())?;
+                self.get_queue_mut(shard_id_to_uid(epoch_manager, shard_id, epoch_id)?)
+                    .add_transactions(block_hash, chunk.into_transactions());
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A queue that holds transactions that are included in blocks,
+/// but not yet executed for a given shard.
+pub struct PendingTransactionQueue {
+    pending_txs: VecDeque<(CryptoHash, Vec<SignedTransaction>)>,
+}
+
+impl PendingTransactionQueue {
+    fn new() -> Self {
+        Self { pending_txs: VecDeque::new() }
+    }
+
+    pub fn add_transactions(&mut self, block_hash: CryptoHash, txs: Vec<SignedTransaction>) {
+        self.pending_txs.push_back((block_hash, txs));
+    }
+
+    pub fn remove_transactions(
+        &mut self,
+        block_hash: &CryptoHash,
+    ) -> Option<Vec<SignedTransaction>> {
+        if let Some(pos) = self.pending_txs.iter().position(|(hash, _)| hash == block_hash) {
+            let (_, txs) = self.pending_txs.remove(pos).unwrap();
+            Some(txs)
+        } else {
+            None
+        }
+    }
+}

--- a/chain/client/src/prepare_transactions.rs
+++ b/chain/client/src/prepare_transactions.rs
@@ -135,6 +135,7 @@ impl PrepareTransactionsJob {
             inputs.prev_block_context,
             &mut iter,
             &inputs.tx_validity_period_check,
+            None,
             inputs.prev_chunk_tx_hashes,
             inputs.time_limit,
             Some((&self).cancel.clone()),

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -19,6 +19,7 @@ use crate::verifier::{
 pub use crate::verifier::{
     ZERO_BALANCE_ACCOUNT_STORAGE_LIMIT, get_signer_and_access_key, set_tx_state_changes,
     validate_transaction, verify_and_charge_tx_ephemeral,
+    verify_and_charge_tx_ephemeral_with_min_required_balance,
 };
 use ahash::RandomState as AHashRandomState;
 use bandwidth_scheduler::{BandwidthSchedulerOutput, run_bandwidth_scheduler};


### PR DESCRIPTION
This PR attempts to use the uncertified chunks to handle initialization and reorgs for the pending tx queue.
In the case the chain extends to the next block (most common path), the chunks are directly added and the execution results (certified chunks) are removed from the data structure directly.