### PR TITLE
feat(sharded_bm.py): make start_height configurable using an argument

### DIFF
--- a/pytest/tests/mocknet/sharded_bm.py
+++ b/pytest/tests/mocknet/sharded_bm.py
@@ -532,6 +532,7 @@ def main():
         host_type="nodes",
         select_partition=None,
     )
+    parser.add_argument("--start_height")
 
     subparsers = parser.add_subparsers(
         dest='command',


### PR DESCRIPTION
`sharded_bm.py` uses a hardcoded start_height, assuming that all benchmarks use the same source image:
```python
START_HEIGHT = 138038232
```

Let's make it configurable with an argument.
For `onemilnet` I want to use a different height which doesn't have an associated image to make sure that the script works with an empty disk.

Example usage:
```bash
$ python3 tests/mocknet/sharded_bm.py --start_height 123456789 init
[2025-11-19 12:56:36] INFO: created configured logger, name test, level 20
[2025-11-19 12:56:37] INFO: created configured logger, name serializer, level 20
[2025-11-19 12:56:40] INFO: {'cp_instance_names': ['mocknet-mainnet-123456789-1m-net-5b642a', 'mocknet-mainnet-123456789-1m-net-cc5941', 'mocknet-mainnet-123456789-1m-net-f4e7bf', 'mocknet-mainnet-123456789-1m-net-ae3355'], 'tracing_server_internal_ip': None, 'tracing_server_external_ip': None}
....
```