### PR TITLE
refactor(actor): standardize actor naming

### DIFF
--- a/benchmarks/transactions-generator/src/actor.rs
+++ b/benchmarks/transactions-generator/src/actor.rs
@@ -4,17 +4,17 @@ use near_async::futures::DelayedActionRunner;
 use near_async::messaging::{self};
 use near_async::tokio::TokioRuntimeHandle;
 
-pub struct GeneratorActorImpl {
+pub struct GeneratorActor {
     tx_generator: TxGenerator,
 }
 
-impl messaging::Actor for GeneratorActorImpl {
+impl messaging::Actor for GeneratorActor {
     fn start_actor(&mut self, ctx: &mut dyn DelayedActionRunner<Self>) {
         self.start(ctx)
     }
 }
 
-impl GeneratorActorImpl {
+impl GeneratorActor {
     pub fn start(&mut self, _ctx: &mut dyn DelayedActionRunner<Self>) {
         match self.tx_generator.start() {
             Err(err) => {
@@ -33,7 +33,7 @@ pub fn start_tx_generator(
     config: Config,
     client_sender: ClientSender,
     view_client_sender: ViewClientSender,
-) -> TokioRuntimeHandle<GeneratorActorImpl> {
+) -> TokioRuntimeHandle<GeneratorActor> {
     let tx_generator = TxGenerator::new(config, client_sender, view_client_sender).unwrap();
-    actor_system.spawn_tokio_actor(GeneratorActorImpl { tx_generator })
+    actor_system.spawn_tokio_actor(GeneratorActor { tx_generator })
 }

--- a/chain/client/src/adapter.rs
+++ b/chain/client/src/adapter.rs
@@ -1,16 +1,16 @@
-use crate::chunk_endorsement_handler::ChunkEndorsementHandler;
-use crate::client_actor::ClientActorInner;
-use crate::{RpcHandler, ViewClientActorInner};
+use crate::chunk_endorsement_handler::ChunkEndorsementHandlerActor;
+use crate::client_actor::ClientActor;
+use crate::{RpcHandlerActor, ViewClientActor};
 use near_async::messaging::{IntoAsyncSender, IntoSender};
 use near_async::multithread::MultithreadRuntimeHandle;
 use near_async::tokio::TokioRuntimeHandle;
 use near_network::client::ClientSenderForNetwork;
 
 pub fn client_sender_for_network(
-    client_addr: TokioRuntimeHandle<ClientActorInner>,
-    view_client_addr: MultithreadRuntimeHandle<ViewClientActorInner>,
-    rpc_handler: MultithreadRuntimeHandle<RpcHandler>,
-    chunk_endorsement_handler: MultithreadRuntimeHandle<ChunkEndorsementHandler>,
+    client_addr: TokioRuntimeHandle<ClientActor>,
+    view_client_addr: MultithreadRuntimeHandle<ViewClientActor>,
+    rpc_handler: MultithreadRuntimeHandle<RpcHandlerActor>,
+    chunk_endorsement_handler: MultithreadRuntimeHandle<ChunkEndorsementHandlerActor>,
 ) -> ClientSenderForNetwork {
     ClientSenderForNetwork {
         block: client_addr.clone().into_async_sender(),

--- a/chain/client/src/chunk_endorsement_handler.rs
+++ b/chain/client/src/chunk_endorsement_handler.rs
@@ -8,7 +8,7 @@ use near_performance_metrics_macros::perf;
 
 use crate::stateless_validation::chunk_endorsement::ChunkEndorsementTracker;
 
-impl Handler<ChunkEndorsementMessage> for ChunkEndorsementHandler {
+impl Handler<ChunkEndorsementMessage> for ChunkEndorsementHandlerActor {
     #[perf]
     fn handle(&mut self, msg: ChunkEndorsementMessage) {
         if let Err(err) = self.chunk_endorsement_tracker.process_chunk_endorsement(msg.0) {
@@ -17,22 +17,22 @@ impl Handler<ChunkEndorsementMessage> for ChunkEndorsementHandler {
     }
 }
 
-impl messaging::Actor for ChunkEndorsementHandler {}
+impl messaging::Actor for ChunkEndorsementHandlerActor {}
 
 pub fn spawn_chunk_endorsement_handler_actor(
     actor_system: ActorSystem,
     chunk_endorsement_tracker: Arc<ChunkEndorsementTracker>,
-) -> MultithreadRuntimeHandle<ChunkEndorsementHandler> {
-    let actor = ChunkEndorsementHandler::new(chunk_endorsement_tracker);
+) -> MultithreadRuntimeHandle<ChunkEndorsementHandlerActor> {
+    let actor = ChunkEndorsementHandlerActor::new(chunk_endorsement_tracker);
     actor_system.spawn_multithread_actor(4, move || actor.clone())
 }
 
 #[derive(Clone)]
-pub struct ChunkEndorsementHandler {
+pub struct ChunkEndorsementHandlerActor {
     chunk_endorsement_tracker: Arc<ChunkEndorsementTracker>,
 }
 
-impl ChunkEndorsementHandler {
+impl ChunkEndorsementHandlerActor {
     pub fn new(chunk_endorsement_tracker: Arc<ChunkEndorsementTracker>) -> Self {
         Self { chunk_endorsement_tracker }
     }

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -1,7 +1,7 @@
 //! Structs in this file are used for debug purposes, and might change at any time
 //! without backwards compatibility.
 use crate::chunk_inclusion_tracker::ChunkInclusionTracker;
-use crate::client_actor::ClientActorInner;
+use crate::client_actor::ClientActor;
 use itertools::Itertools;
 use near_async::messaging::Handler;
 use near_async::time::{Clock, Instant};
@@ -171,7 +171,7 @@ impl BlockProductionTracker {
     }
 }
 
-impl Handler<DebugStatus, Result<DebugStatusResponse, StatusError>> for ClientActorInner {
+impl Handler<DebugStatus, Result<DebugStatusResponse, StatusError>> for ClientActor {
     #[perf]
     fn handle(&mut self, msg: DebugStatus) -> Result<DebugStatusResponse, StatusError> {
         match msg {
@@ -302,7 +302,7 @@ fn get_prev_epoch_identifier(
     Some(ValidatorInfoIdentifier::EpochId(*prev_epoch_last_block_header.epoch_id()))
 }
 
-impl ClientActorInner {
+impl ClientActor {
     // Gets a list of block producers, chunk producers and chunk validators for a given epoch.
     fn get_validators_for_epoch(
         &self,

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -9,20 +9,20 @@ pub use near_client_primitives::types::{
 };
 
 pub use crate::chunk_endorsement_handler::{
-    ChunkEndorsementHandler, spawn_chunk_endorsement_handler_actor,
+    ChunkEndorsementHandlerActor, spawn_chunk_endorsement_handler_actor,
 };
 pub use crate::client::{AsyncComputationMultiSpawner, Client};
 #[cfg(feature = "test_features")]
 pub use crate::client_actor::NetworkAdversarialMessage;
 pub use crate::client_actor::{StartClientResult, start_client};
 pub use crate::config_updater::ConfigUpdater;
-pub use crate::rpc_handler::{RpcHandler, RpcHandlerConfig, spawn_rpc_handler_actor};
+pub use crate::rpc_handler::{RpcHandlerActor, RpcHandlerConfig, spawn_rpc_handler_actor};
 pub use crate::state_request_actor::StateRequestActor;
 pub use crate::stateless_validation::chunk_validation_actor::{
-    BlockNotificationMessage, ChunkValidationActorInner, ChunkValidationSender,
+    BlockNotificationMessage, ChunkValidationActor, ChunkValidationSender,
     ChunkValidationSenderForPartialWitness, HandleOrphanWitnessOutcome,
 };
-pub use crate::view_client_actor::ViewClientActorInner;
+pub use crate::view_client_actor::ViewClientActor;
 pub use chunk_producer::ProduceChunkResult;
 pub use near_chain::stateless_validation::processing_tracker::{
     ProcessingDoneTracker, ProcessingDoneWaiter,

--- a/chain/client/src/rpc_handler.rs
+++ b/chain/client/src/rpc_handler.rs
@@ -30,20 +30,20 @@ use std::sync::Arc;
 use crate::metrics;
 use near_async::multithread::MultithreadRuntimeHandle;
 
-impl Handler<ProcessTxRequest> for RpcHandler {
+impl Handler<ProcessTxRequest> for RpcHandlerActor {
     fn handle(&mut self, msg: ProcessTxRequest) {
         Handler::<ProcessTxRequest, ProcessTxResponse>::handle(self, msg);
     }
 }
 
-impl Handler<ProcessTxRequest, ProcessTxResponse> for RpcHandler {
+impl Handler<ProcessTxRequest, ProcessTxResponse> for RpcHandlerActor {
     fn handle(&mut self, msg: ProcessTxRequest) -> ProcessTxResponse {
         let ProcessTxRequest { transaction, is_forwarded, check_only } = msg;
         self.process_tx(transaction, is_forwarded, check_only)
     }
 }
 
-impl messaging::Actor for RpcHandler {}
+impl messaging::Actor for RpcHandlerActor {}
 
 pub fn spawn_rpc_handler_actor(
     actor_system: ActorSystem,
@@ -54,8 +54,8 @@ pub fn spawn_rpc_handler_actor(
     validator_signer: MutableValidatorSigner,
     runtime: Arc<dyn RuntimeAdapter>,
     network_adapter: PeerManagerAdapter,
-) -> MultithreadRuntimeHandle<RpcHandler> {
-    let actor = RpcHandler::new(
+) -> MultithreadRuntimeHandle<RpcHandlerActor> {
+    let actor = RpcHandlerActor::new(
         config.clone(),
         tx_pool,
         epoch_manager,
@@ -80,7 +80,7 @@ pub struct RpcHandlerConfig {
 /// Supposed to run multithreaded.
 /// Connects to the Client actor via (thread-safe) queues and pools to pass the data for consumption.
 #[derive(Clone)]
-pub struct RpcHandler {
+pub struct RpcHandlerActor {
     config: RpcHandlerConfig,
 
     tx_pool: Arc<Mutex<ShardedTransactionPool>>,
@@ -93,7 +93,7 @@ pub struct RpcHandler {
     network_adapter: PeerManagerAdapter,
 }
 
-impl RpcHandler {
+impl RpcHandlerActor {
     pub fn new(
         config: RpcHandlerConfig,
         tx_pool: Arc<Mutex<ShardedTransactionPool>>,

--- a/chain/client/src/stateless_validation/chunk_validation_actor.rs
+++ b/chain/client/src/stateless_validation/chunk_validation_actor.rs
@@ -72,7 +72,7 @@ pub struct BlockNotificationMessage {
 
 /// An actor for validating chunk state witnesses and orphan witnesses.
 #[derive(Clone)]
-pub struct ChunkValidationActorInner {
+pub struct ChunkValidationActor {
     chain_store: ChainStore,
     genesis_block: Arc<Block>,
     epoch_manager: Arc<dyn EpochManagerAdapter>,
@@ -88,9 +88,9 @@ pub struct ChunkValidationActorInner {
     rs: Arc<ReedSolomon>,
 }
 
-impl Actor for ChunkValidationActorInner {}
+impl Actor for ChunkValidationActor {}
 
-impl ChunkValidationActorInner {
+impl ChunkValidationActor {
     pub fn new(
         chain_store: ChainStore,
         genesis_block: Arc<Block>,
@@ -175,13 +175,13 @@ impl ChunkValidationActorInner {
         orphan_witness_pool_size: usize,
         max_orphan_witness_size: u64,
         num_actors: usize,
-    ) -> MultithreadRuntimeHandle<ChunkValidationActorInner> {
+    ) -> MultithreadRuntimeHandle<ChunkValidationActor> {
         // Create shared orphan witness pool
         let shared_orphan_pool =
             Arc::new(Mutex::new(OrphanStateWitnessPool::new(orphan_witness_pool_size)));
 
         actor_system.spawn_multithread_actor(num_actors, move || {
-            ChunkValidationActorInner::new_with_shared_pool(
+            ChunkValidationActor::new_with_shared_pool(
                 chain_store.clone(),
                 genesis_block.clone(),
                 epoch_manager.clone(),
@@ -587,7 +587,7 @@ impl ChunkValidationActorInner {
     }
 }
 
-impl Handler<ChunkStateWitnessMessage> for ChunkValidationActorInner {
+impl Handler<ChunkStateWitnessMessage> for ChunkValidationActor {
     #[perf]
     fn handle(&mut self, msg: ChunkStateWitnessMessage) {
         let _span = tracing::debug_span!(
@@ -605,7 +605,7 @@ impl Handler<ChunkStateWitnessMessage> for ChunkValidationActorInner {
     }
 }
 
-impl Handler<BlockNotificationMessage> for ChunkValidationActorInner {
+impl Handler<BlockNotificationMessage> for ChunkValidationActor {
     #[perf]
     fn handle(&mut self, msg: BlockNotificationMessage) {
         let BlockNotificationMessage { block } = msg;

--- a/chain/client/src/sync/epoch.rs
+++ b/chain/client/src/sync/epoch.rs
@@ -1,4 +1,4 @@
-use crate::client_actor::ClientActorInner;
+use crate::client_actor::ClientActor;
 use crate::metrics;
 use near_async::futures::{AsyncComputationSpawner, AsyncComputationSpawnerExt};
 use near_async::messaging::{CanSend, Handler};
@@ -875,7 +875,7 @@ impl EpochSync {
     }
 }
 
-impl Handler<EpochSyncRequestMessage> for ClientActorInner {
+impl Handler<EpochSyncRequestMessage> for ClientActor {
     #[perf]
     fn handle(&mut self, msg: EpochSyncRequestMessage) {
         if self.client.sync_handler.epoch_sync.config.ignore_epoch_sync_network_requests {
@@ -909,7 +909,7 @@ impl Handler<EpochSyncRequestMessage> for ClientActorInner {
     }
 }
 
-impl Handler<EpochSyncResponseMessage> for ClientActorInner {
+impl Handler<EpochSyncResponseMessage> for ClientActor {
     #[perf]
     fn handle(&mut self, msg: EpochSyncResponseMessage) {
         let (proof, _) = match msg.proof.decode() {

--- a/chain/client/src/view_client_actor.rs
+++ b/chain/client/src/view_client_actor.rs
@@ -78,7 +78,7 @@ pub struct ViewClientRequestManager {
 }
 
 /// View client provides currently committed (to the storage) view of the current chain and state.
-pub struct ViewClientActorInner {
+pub struct ViewClientActor {
     clock: Clock,
     pub adv: crate::adversarial::Controls,
     pub chain: Chain,
@@ -99,9 +99,9 @@ impl ViewClientRequestManager {
     }
 }
 
-impl Actor for ViewClientActorInner {}
+impl Actor for ViewClientActor {}
 
-impl ViewClientActorInner {
+impl ViewClientActor {
     pub fn spawn_multithread_actor(
         clock: Clock,
         actor_system: ActorSystem,
@@ -113,9 +113,9 @@ impl ViewClientActorInner {
         config: ClientConfig,
         adv: crate::adversarial::Controls,
         validator_signer: MutableValidatorSigner,
-    ) -> MultithreadRuntimeHandle<ViewClientActorInner> {
+    ) -> MultithreadRuntimeHandle<ViewClientActor> {
         actor_system.spawn_multithread_actor(config.view_client_threads, move || {
-            ViewClientActorInner::new(
+            ViewClientActor::new(
                 clock.clone(),
                 chain_genesis.clone(),
                 epoch_manager.clone(),
@@ -719,7 +719,7 @@ impl ViewClientActorInner {
     }
 }
 
-impl Handler<Query, Result<QueryResponse, QueryError>> for ViewClientActorInner {
+impl Handler<Query, Result<QueryResponse, QueryError>> for ViewClientActor {
     #[perf]
     fn handle(&mut self, msg: Query) -> Result<QueryResponse, QueryError> {
         tracing::debug!(target: "client", ?msg);
@@ -729,7 +729,7 @@ impl Handler<Query, Result<QueryResponse, QueryError>> for ViewClientActorInner 
 }
 
 /// Handles retrieving block from the chain.
-impl Handler<GetBlock, Result<BlockView, GetBlockError>> for ViewClientActorInner {
+impl Handler<GetBlock, Result<BlockView, GetBlockError>> for ViewClientActor {
     #[perf]
     fn handle(&mut self, msg: GetBlock) -> Result<BlockView, GetBlockError> {
         tracing::debug!(target: "client", ?msg);
@@ -745,7 +745,7 @@ impl Handler<GetBlock, Result<BlockView, GetBlockError>> for ViewClientActorInne
 }
 
 impl Handler<GetBlockWithMerkleTree, Result<(BlockView, Arc<PartialMerkleTree>), GetBlockError>>
-    for ViewClientActorInner
+    for ViewClientActor
 {
     #[perf]
     fn handle(
@@ -787,7 +787,7 @@ fn get_chunk_from_block(
     Ok(res)
 }
 
-impl Handler<GetShardChunk, Result<ShardChunk, GetChunkError>> for ViewClientActorInner {
+impl Handler<GetShardChunk, Result<ShardChunk, GetChunkError>> for ViewClientActor {
     #[perf]
     fn handle(&mut self, msg: GetShardChunk) -> Result<ShardChunk, GetChunkError> {
         tracing::debug!(target: "client", ?msg);
@@ -811,7 +811,7 @@ impl Handler<GetShardChunk, Result<ShardChunk, GetChunkError>> for ViewClientAct
     }
 }
 
-impl Handler<GetChunk, Result<ChunkView, GetChunkError>> for ViewClientActorInner {
+impl Handler<GetChunk, Result<ChunkView, GetChunkError>> for ViewClientActor {
     #[perf]
     fn handle(&mut self, msg: GetChunk) -> Result<ChunkView, GetChunkError> {
         tracing::debug!(target: "client", ?msg);
@@ -852,7 +852,7 @@ impl Handler<GetChunk, Result<ChunkView, GetChunkError>> for ViewClientActorInne
     }
 }
 
-impl Handler<TxStatus, Result<TxStatusView, TxStatusError>> for ViewClientActorInner {
+impl Handler<TxStatus, Result<TxStatusView, TxStatusError>> for ViewClientActor {
     #[perf]
     fn handle(&mut self, msg: TxStatus) -> Result<TxStatusView, TxStatusError> {
         tracing::debug!(target: "client", ?msg);
@@ -863,7 +863,7 @@ impl Handler<TxStatus, Result<TxStatusView, TxStatusError>> for ViewClientActorI
 }
 
 impl Handler<GetValidatorInfo, Result<EpochValidatorInfo, GetValidatorInfoError>>
-    for ViewClientActorInner
+    for ViewClientActor
 {
     #[perf]
     fn handle(
@@ -912,7 +912,7 @@ impl Handler<GetValidatorInfo, Result<EpochValidatorInfo, GetValidatorInfoError>
 }
 
 impl Handler<GetValidatorOrdered, Result<Vec<ValidatorStakeView>, GetValidatorInfoError>>
-    for ViewClientActorInner
+    for ViewClientActor
 {
     #[perf]
     fn handle(
@@ -930,7 +930,7 @@ impl Handler<GetValidatorOrdered, Result<Vec<ValidatorStakeView>, GetValidatorIn
 }
 /// Returns a list of change kinds per account in a store for a given block.
 impl Handler<GetStateChangesInBlock, Result<StateChangesKindsView, GetStateChangesError>>
-    for ViewClientActorInner
+    for ViewClientActor
 {
     #[perf]
     fn handle(
@@ -952,9 +952,7 @@ impl Handler<GetStateChangesInBlock, Result<StateChangesKindsView, GetStateChang
 }
 
 /// Returns a list of changes in a store for a given block filtering by the state changes request.
-impl Handler<GetStateChanges, Result<StateChangesView, GetStateChangesError>>
-    for ViewClientActorInner
-{
+impl Handler<GetStateChanges, Result<StateChangesView, GetStateChangesError>> for ViewClientActor {
     #[perf]
     fn handle(&mut self, msg: GetStateChanges) -> Result<StateChangesView, GetStateChangesError> {
         tracing::debug!(target: "client", ?msg);
@@ -972,7 +970,7 @@ impl Handler<GetStateChanges, Result<StateChangesView, GetStateChangesError>>
 
 /// Returns a list of changes in a store with causes for a given block.
 impl Handler<GetStateChangesWithCauseInBlock, Result<StateChangesView, GetStateChangesError>>
-    for ViewClientActorInner
+    for ViewClientActor
 {
     #[perf]
     fn handle(
@@ -999,7 +997,7 @@ impl
     Handler<
         GetStateChangesWithCauseInBlockForTrackedShards,
         Result<HashMap<ShardId, StateChangesView>, GetStateChangesError>,
-    > for ViewClientActorInner
+    > for ViewClientActor
 {
     #[perf]
     fn handle(
@@ -1049,7 +1047,7 @@ impl
     Handler<
         GetNextLightClientBlock,
         Result<Option<Arc<LightClientBlockView>>, GetNextLightClientBlockError>,
-    > for ViewClientActorInner
+    > for ViewClientActor
 {
     #[perf]
     fn handle(
@@ -1091,7 +1089,7 @@ impl
 }
 
 impl Handler<GetExecutionOutcome, Result<GetExecutionOutcomeResponse, GetExecutionOutcomeError>>
-    for ViewClientActorInner
+    for ViewClientActor
 {
     #[perf]
     fn handle(
@@ -1183,7 +1181,7 @@ impl
     Handler<
         GetExecutionOutcomesForBlock,
         Result<HashMap<ShardId, Vec<ExecutionOutcomeWithIdView>>, String>,
-    > for ViewClientActorInner
+    > for ViewClientActor
 {
     #[perf]
     fn handle(
@@ -1205,7 +1203,7 @@ impl
     }
 }
 
-impl Handler<GetReceipt, Result<Option<ReceiptView>, GetReceiptError>> for ViewClientActorInner {
+impl Handler<GetReceipt, Result<Option<ReceiptView>, GetReceiptError>> for ViewClientActor {
     #[perf]
     fn handle(&mut self, msg: GetReceipt) -> Result<Option<ReceiptView>, GetReceiptError> {
         tracing::debug!(target: "client", ?msg);
@@ -1219,9 +1217,7 @@ impl Handler<GetReceipt, Result<Option<ReceiptView>, GetReceiptError>> for ViewC
     }
 }
 
-impl Handler<GetBlockProof, Result<GetBlockProofResponse, GetBlockProofError>>
-    for ViewClientActorInner
-{
+impl Handler<GetBlockProof, Result<GetBlockProofResponse, GetBlockProofError>> for ViewClientActor {
     #[perf]
     fn handle(&mut self, msg: GetBlockProof) -> Result<GetBlockProofResponse, GetBlockProofError> {
         tracing::debug!(target: "client", ?msg);
@@ -1242,7 +1238,7 @@ impl Handler<GetBlockProof, Result<GetBlockProofResponse, GetBlockProofError>>
 }
 
 impl Handler<GetProtocolConfig, Result<ProtocolConfigView, GetProtocolConfigError>>
-    for ViewClientActorInner
+    for ViewClientActor
 {
     #[perf]
     fn handle(
@@ -1270,14 +1266,14 @@ use near_async::ActorSystem;
 use near_async::multithread::MultithreadRuntimeHandle;
 
 #[cfg(feature = "test_features")]
-impl Handler<NetworkAdversarialMessage> for ViewClientActorInner {
+impl Handler<NetworkAdversarialMessage> for ViewClientActor {
     fn handle(&mut self, msg: NetworkAdversarialMessage) {
         Handler::<NetworkAdversarialMessage, Option<u64>>::handle(self, msg);
     }
 }
 
 #[cfg(feature = "test_features")]
-impl Handler<NetworkAdversarialMessage, Option<u64>> for ViewClientActorInner {
+impl Handler<NetworkAdversarialMessage, Option<u64>> for ViewClientActor {
     #[perf]
     fn handle(&mut self, msg: NetworkAdversarialMessage) -> Option<u64> {
         tracing::debug!(target: "client", ?msg);
@@ -1308,7 +1304,7 @@ impl Handler<NetworkAdversarialMessage, Option<u64>> for ViewClientActorInner {
     }
 }
 
-impl Handler<TxStatusRequest, Option<Box<FinalExecutionOutcomeView>>> for ViewClientActorInner {
+impl Handler<TxStatusRequest, Option<Box<FinalExecutionOutcomeView>>> for ViewClientActor {
     #[perf]
     fn handle(&mut self, msg: TxStatusRequest) -> Option<Box<FinalExecutionOutcomeView>> {
         tracing::debug!(target: "client", ?msg);
@@ -1325,7 +1321,7 @@ impl Handler<TxStatusRequest, Option<Box<FinalExecutionOutcomeView>>> for ViewCl
     }
 }
 
-impl Handler<TxStatusResponse> for ViewClientActorInner {
+impl Handler<TxStatusResponse> for ViewClientActor {
     #[perf]
     fn handle(&mut self, msg: TxStatusResponse) {
         let TxStatusResponse(tx_result) = msg;
@@ -1347,7 +1343,7 @@ impl Handler<TxStatusResponse> for ViewClientActorInner {
     }
 }
 
-impl Handler<BlockRequest, Option<Arc<Block>>> for ViewClientActorInner {
+impl Handler<BlockRequest, Option<Arc<Block>>> for ViewClientActor {
     #[perf]
     fn handle(&mut self, msg: BlockRequest) -> Option<Arc<Block>> {
         tracing::debug!(target: "client", ?msg);
@@ -1358,7 +1354,7 @@ impl Handler<BlockRequest, Option<Arc<Block>>> for ViewClientActorInner {
     }
 }
 
-impl Handler<BlockHeadersRequest, Option<Vec<Arc<BlockHeader>>>> for ViewClientActorInner {
+impl Handler<BlockHeadersRequest, Option<Vec<Arc<BlockHeader>>>> for ViewClientActor {
     #[perf]
     fn handle(&mut self, msg: BlockHeadersRequest) -> Option<Vec<Arc<BlockHeader>>> {
         tracing::debug!(target: "client", ?msg);
@@ -1378,7 +1374,7 @@ impl Handler<BlockHeadersRequest, Option<Vec<Arc<BlockHeader>>>> for ViewClientA
 }
 
 impl Handler<AnnounceAccountRequest, Result<Vec<AnnounceAccount>, ReasonForBan>>
-    for ViewClientActorInner
+    for ViewClientActor
 {
     #[perf]
     fn handle(
@@ -1434,7 +1430,7 @@ impl Handler<AnnounceAccountRequest, Result<Vec<AnnounceAccount>, ReasonForBan>>
     }
 }
 
-impl Handler<GetGasPrice, Result<GasPriceView, GetGasPriceError>> for ViewClientActorInner {
+impl Handler<GetGasPrice, Result<GasPriceView, GetGasPriceError>> for ViewClientActor {
     #[perf]
     fn handle(&mut self, msg: GetGasPrice) -> Result<GasPriceView, GetGasPriceError> {
         tracing::debug!(target: "client", ?msg);
@@ -1446,7 +1442,7 @@ impl Handler<GetGasPrice, Result<GasPriceView, GetGasPriceError>> for ViewClient
 }
 
 impl Handler<GetMaintenanceWindows, Result<MaintenanceWindowsView, GetMaintenanceWindowsError>>
-    for ViewClientActorInner
+    for ViewClientActor
 {
     #[perf]
     fn handle(
@@ -1460,7 +1456,7 @@ impl Handler<GetMaintenanceWindows, Result<MaintenanceWindowsView, GetMaintenanc
 
 // TODO(cloud_archival) Consider the case of cloud head
 impl Handler<GetSplitStorageInfo, Result<SplitStorageInfoView, GetSplitStorageInfoError>>
-    for ViewClientActorInner
+    for ViewClientActor
 {
     fn handle(
         &mut self,

--- a/chain/jsonrpc/jsonrpc-tests/src/lib.rs
+++ b/chain/jsonrpc/jsonrpc-tests/src/lib.rs
@@ -9,7 +9,7 @@ use near_chain_configs::test_utils::TestClientConfigParams;
 use near_chain_configs::{ClientConfig, Genesis, MutableConfigValue, TrackedShardsConfig};
 use near_client::adversarial::Controls;
 use near_client::client_actor::SpiceClientConfig;
-use near_client::{RpcHandlerConfig, ViewClientActorInner, spawn_rpc_handler_actor, start_client};
+use near_client::{RpcHandlerConfig, ViewClientActor, spawn_rpc_handler_actor, start_client};
 use near_crypto::{KeyType, PublicKey};
 use near_epoch_manager::{EpochManager, shard_tracker::ShardTracker};
 use near_jsonrpc::{RpcConfig, create_jsonrpc_app};
@@ -122,7 +122,7 @@ pub fn create_test_setup_with_accounts_and_validity(
 
     // 6. Create ViewClientActor
     let adv = Controls::default();
-    let view_client_actor = ViewClientActorInner::spawn_multithread_actor(
+    let view_client_actor = ViewClientActor::spawn_multithread_actor(
         Clock::real(),
         actor_system.clone(),
         chain_genesis.clone(),

--- a/chain/rosetta-rpc/src/adapters/mod.rs
+++ b/chain/rosetta-rpc/src/adapters/mod.rs
@@ -1,7 +1,7 @@
 use near_async::messaging::CanSendAsync;
 use near_async::multithread::MultithreadRuntimeHandle;
 use near_chain_configs::Genesis;
-use near_client::ViewClientActorInner;
+use near_client::ViewClientActor;
 use near_primitives::types::Balance;
 use validated_operations::ValidatedOperation;
 
@@ -20,7 +20,7 @@ mod validated_operations;
 /// We choose to do a proper implementation for the genesis block later.
 async fn convert_genesis_records_to_transaction(
     genesis: &Genesis,
-    view_client_addr: &MultithreadRuntimeHandle<ViewClientActorInner>,
+    view_client_addr: &MultithreadRuntimeHandle<ViewClientActor>,
     block: &near_primitives::views::BlockView,
 ) -> crate::errors::Result<crate::models::Transaction> {
     let mut genesis_account_ids = std::collections::HashSet::new();
@@ -114,7 +114,7 @@ async fn convert_genesis_records_to_transaction(
 }
 
 pub(crate) async fn convert_block_to_transactions(
-    view_client_addr: &MultithreadRuntimeHandle<ViewClientActorInner>,
+    view_client_addr: &MultithreadRuntimeHandle<ViewClientActor>,
     block: &near_primitives::views::BlockView,
     currencies: &Option<Vec<crate::models::Currency>>,
 ) -> crate::errors::Result<Vec<crate::models::Transaction>> {
@@ -186,7 +186,7 @@ pub(crate) async fn convert_block_to_transactions(
 
 pub(crate) async fn collect_transactions(
     genesis: &Genesis,
-    view_client_addr: &MultithreadRuntimeHandle<ViewClientActorInner>,
+    view_client_addr: &MultithreadRuntimeHandle<ViewClientActor>,
     block: &near_primitives::views::BlockView,
     currencies: &Option<Vec<crate::models::Currency>>,
 ) -> crate::errors::Result<Vec<crate::models::Transaction>> {

--- a/chain/rosetta-rpc/src/adapters/nep141.rs
+++ b/chain/rosetta-rpc/src/adapters/nep141.rs
@@ -1,7 +1,7 @@
 use crate::models::{AccountIdentifier, Currency, FungibleTokenEvent};
 use near_async::messaging::CanSendAsync;
 use near_async::multithread::MultithreadRuntimeHandle;
-use near_client::ViewClientActorInner;
+use near_client::ViewClientActor;
 use near_primitives::{types::BlockId, views::ExecutionOutcomeWithIdView};
 use std::{collections::HashMap, str::FromStr};
 pub(crate) fn collect_nep141_events(
@@ -82,7 +82,7 @@ fn compose_rosetta_nep141_events(
 }
 
 pub(crate) async fn get_fungible_token_balance_for_account(
-    view_client_addr: &MultithreadRuntimeHandle<ViewClientActorInner>,
+    view_client_addr: &MultithreadRuntimeHandle<ViewClientActor>,
     block_header: &near_primitives::views::BlockHeaderView,
     contract_address: &String,
     account_identifier: &AccountIdentifier,

--- a/chain/rosetta-rpc/src/adapters/transactions.rs
+++ b/chain/rosetta-rpc/src/adapters/transactions.rs
@@ -2,7 +2,7 @@ use crate::models::{AccountIdentifier, Currency, FungibleTokenEvent};
 use near_account_id::AccountId;
 use near_async::messaging::CanSendAsync;
 use near_async::multithread::MultithreadRuntimeHandle;
-use near_client::ViewClientActorInner;
+use near_client::ViewClientActor;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::Balance;
 use near_primitives::views::{ExecutionOutcomeWithIdView, SignedTransactionView};
@@ -29,7 +29,7 @@ impl ExecutionToReceipts {
     /// transaction or receipt causing the execution to list of created
     /// receipts’ hashes.
     pub(crate) async fn for_block(
-        view_client_addr: &MultithreadRuntimeHandle<ViewClientActorInner>,
+        view_client_addr: &MultithreadRuntimeHandle<ViewClientActor>,
         block_hash: CryptoHash,
         currencies: &Option<Vec<Currency>>,
     ) -> crate::errors::Result<Self> {
@@ -161,7 +161,7 @@ fn convert_cause_to_transaction_id(
 }
 
 async fn get_predecessor_id_from_receipt_or_transaction(
-    view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
+    view_client: &MultithreadRuntimeHandle<ViewClientActor>,
     cause: &near_primitives::views::StateChangeCauseView,
     transactions_in_block: &HashMap<CryptoHash, SignedTransactionView>,
     receipts_in_block: &HashMap<CryptoHash, AccountId>,
@@ -200,7 +200,7 @@ async fn get_predecessor_id_from_receipt_or_transaction(
 }
 
 async fn get_predecessor_id_from_receipt_hash(
-    view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
+    view_client: &MultithreadRuntimeHandle<ViewClientActor>,
     receipt_id: CryptoHash,
 ) -> Option<AccountId> {
     let receipt_view =
@@ -276,7 +276,7 @@ impl<'a> RosettaTransactions<'a> {
 
 /// Returns Rosetta transactions which map to given account changes.
 pub(crate) async fn convert_block_changes_to_transactions(
-    view_client_addr: &MultithreadRuntimeHandle<ViewClientActorInner>,
+    view_client_addr: &MultithreadRuntimeHandle<ViewClientActor>,
     runtime_config: &near_parameters::RuntimeConfigView,
     block_hash: &CryptoHash,
     accounts_changes: near_primitives::views::StateChangesView,

--- a/chain/rosetta-rpc/src/lib.rs
+++ b/chain/rosetta-rpc/src/lib.rs
@@ -22,8 +22,8 @@ use near_async::messaging::CanSendAsync;
 use near_async::multithread::MultithreadRuntimeHandle;
 use near_async::tokio::TokioRuntimeHandle;
 use near_chain_configs::Genesis;
-use near_client::client_actor::ClientActorInner;
-use near_client::{RpcHandler, ViewClientActorInner};
+use near_client::client_actor::ClientActor;
+use near_client::{RpcHandlerActor, ViewClientActor};
 use near_o11y::span_wrapped_msg::SpanWrappedMessageExt;
 use near_primitives::{borsh::BorshDeserialize, types::Balance};
 
@@ -49,9 +49,9 @@ struct GenesisWithIdentifier {
 #[derive(Clone)]
 struct RosettaAppState {
     genesis: Arc<GenesisWithIdentifier>,
-    client_addr: TokioRuntimeHandle<ClientActorInner>,
-    view_client_addr: MultithreadRuntimeHandle<ViewClientActorInner>,
-    tx_handler_addr: MultithreadRuntimeHandle<RpcHandler>,
+    client_addr: TokioRuntimeHandle<ClientActor>,
+    view_client_addr: MultithreadRuntimeHandle<ViewClientActor>,
+    tx_handler_addr: MultithreadRuntimeHandle<RpcHandlerActor>,
     currencies: Option<Vec<models::Currency>>,
 }
 
@@ -60,7 +60,7 @@ struct RosettaAppState {
 /// `blockchain` and `network` must match and `sub_network_identifier` must not
 /// be provided.  On success returns client actor’s status response.
 async fn check_network_identifier(
-    client_addr: &TokioRuntimeHandle<ClientActorInner>,
+    client_addr: &TokioRuntimeHandle<ClientActor>,
     identifier: models::NetworkIdentifier,
 ) -> Result<near_client::StatusResponse, errors::ErrorKind> {
     if identifier.blockchain != BLOCKCHAIN {
@@ -1068,9 +1068,9 @@ pub fn start_rosetta_rpc(
     config: crate::config::RosettaRpcConfig,
     genesis: Genesis,
     genesis_block_hash: &near_primitives::hash::CryptoHash,
-    client_addr: TokioRuntimeHandle<ClientActorInner>,
-    view_client_addr: MultithreadRuntimeHandle<ViewClientActorInner>,
-    tx_handler_addr: MultithreadRuntimeHandle<RpcHandler>,
+    client_addr: TokioRuntimeHandle<ClientActor>,
+    view_client_addr: MultithreadRuntimeHandle<ViewClientActor>,
+    tx_handler_addr: MultithreadRuntimeHandle<RpcHandlerActor>,
     future_spawner: &dyn FutureSpawner,
 ) {
     let crate::config::RosettaRpcConfig { addr, cors_allowed_origins, limits, currencies } = config;

--- a/chain/rosetta-rpc/src/test.rs
+++ b/chain/rosetta-rpc/src/test.rs
@@ -4,10 +4,10 @@ use near_primitives::types::Balance;
 
 use crate::adapters::transactions::{ExecutionToReceipts, convert_block_changes_to_transactions};
 use near_async::multithread::MultithreadRuntimeHandle;
-use near_client::ViewClientActorInner;
+use near_client::ViewClientActor;
 
 pub async fn test_convert_block_changes_to_transactions(
-    view_client_addr: &MultithreadRuntimeHandle<ViewClientActorInner>,
+    view_client_addr: &MultithreadRuntimeHandle<ViewClientActor>,
     runtime_config: &RuntimeConfigView,
 ) {
     // cspell:ignore nfvalidator

--- a/chain/rosetta-rpc/src/utils.rs
+++ b/chain/rosetta-rpc/src/utils.rs
@@ -7,7 +7,7 @@ use futures::StreamExt;
 use near_async::messaging::CanSendAsync;
 use near_async::multithread::MultithreadRuntimeHandle;
 use near_chain_configs::ProtocolConfigView;
-use near_client::ViewClientActorInner;
+use near_client::ViewClientActor;
 use near_primitives::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_primitives::types::Balance;
 
@@ -296,7 +296,7 @@ impl RosettaAccountBalances {
 pub(crate) async fn query_account(
     block_id: near_primitives::types::BlockReference,
     account_id: near_primitives::types::AccountId,
-    view_client_addr: MultithreadRuntimeHandle<ViewClientActorInner>,
+    view_client_addr: MultithreadRuntimeHandle<ViewClientActor>,
 ) -> Result<
     (
         near_primitives::hash::CryptoHash,
@@ -333,7 +333,7 @@ pub(crate) async fn query_account(
 pub(crate) async fn query_accounts<R>(
     block_id: near_primitives::types::BlockReference,
     account_ids: impl Iterator<Item = near_primitives::types::AccountId>,
-    view_client_addr: MultithreadRuntimeHandle<ViewClientActorInner>,
+    view_client_addr: MultithreadRuntimeHandle<ViewClientActor>,
 ) -> Result<R, crate::errors::ErrorKind>
 where
     R: std::iter::FromIterator<(
@@ -369,7 +369,7 @@ pub(crate) async fn query_access_key(
     block_id: near_primitives::types::BlockReference,
     account_id: near_primitives::types::AccountId,
     public_key: near_crypto::PublicKey,
-    view_client_addr: &MultithreadRuntimeHandle<ViewClientActorInner>,
+    view_client_addr: &MultithreadRuntimeHandle<ViewClientActor>,
 ) -> Result<
     (
         near_primitives::hash::CryptoHash,
@@ -409,7 +409,7 @@ pub(crate) async fn query_access_key(
 
 pub(crate) async fn query_protocol_config(
     block_hash: near_primitives::hash::CryptoHash,
-    view_client_addr: &MultithreadRuntimeHandle<ViewClientActorInner>,
+    view_client_addr: &MultithreadRuntimeHandle<ViewClientActor>,
 ) -> crate::errors::Result<ProtocolConfigView> {
     view_client_addr
         .send_async(near_client::GetProtocolConfig(near_primitives::types::BlockReference::from(
@@ -473,7 +473,7 @@ where
 /// Returns `Ok(None)` if the block does not exist or is not final.
 pub(crate) async fn get_block_if_final(
     block_id: &near_primitives::types::BlockReference,
-    view_client_addr: &MultithreadRuntimeHandle<ViewClientActorInner>,
+    view_client_addr: &MultithreadRuntimeHandle<ViewClientActor>,
 ) -> Result<Option<near_primitives::views::BlockView>, models::Error> {
     let final_block = get_final_block(view_client_addr).await?;
     let is_query_by_height = match block_id {
@@ -520,7 +520,7 @@ pub(crate) async fn get_block_if_final(
 }
 
 pub(crate) async fn get_final_block(
-    view_client_addr: &MultithreadRuntimeHandle<ViewClientActorInner>,
+    view_client_addr: &MultithreadRuntimeHandle<ViewClientActor>,
 ) -> Result<near_primitives::views::BlockView, errors::ErrorKind> {
     view_client_addr
         .send_async(near_client::GetBlock(near_primitives::types::BlockReference::Finality(
@@ -531,7 +531,7 @@ pub(crate) async fn get_final_block(
 }
 
 pub(crate) async fn get_nonces(
-    view_client_addr: &MultithreadRuntimeHandle<ViewClientActorInner>,
+    view_client_addr: &MultithreadRuntimeHandle<ViewClientActor>,
     account_id: AccountId,
     public_keys: Vec<models::PublicKey>,
 ) -> Result<AccountBalanceResponseMetadata, models::Error> {

--- a/integration-tests/src/env/setup.rs
+++ b/integration-tests/src/env/setup.rs
@@ -26,14 +26,14 @@ use near_chunks::client::ShardsManagerResponse;
 use near_chunks::shards_manager_actor::{ShardsManagerActor, start_shards_manager};
 use near_chunks::test_utils::SynchronousShardsManagerAdapter;
 use near_client::adversarial::Controls;
-use near_client::client_actor::{ClientActorInner, SpiceClientConfig};
+use near_client::client_actor::{ClientActor, SpiceClientConfig};
 use near_client::{
-    AsyncComputationMultiSpawner, ChunkValidationActorInner, ChunkValidationSender,
+    AsyncComputationMultiSpawner, ChunkValidationActor, ChunkValidationSender,
     ChunkValidationSenderForPartialWitness, Client, PartialWitnessActor,
-    PartialWitnessSenderForClient, RpcHandler, RpcHandlerConfig, StartClientResult, SyncStatus,
-    ViewClientActorInner, spawn_chunk_endorsement_handler_actor, start_client,
+    PartialWitnessSenderForClient, RpcHandlerActor, RpcHandlerConfig, StartClientResult,
+    SyncStatus, ViewClientActor, spawn_chunk_endorsement_handler_actor, start_client,
 };
-use near_client::{ChunkEndorsementHandler, spawn_rpc_handler_actor};
+use near_client::{ChunkEndorsementHandlerActor, spawn_rpc_handler_actor};
 use near_crypto::{KeyType, PublicKey};
 use near_epoch_manager::shard_tracker::ShardTracker;
 use near_epoch_manager::{EpochManager, EpochManagerAdapter};
@@ -81,10 +81,10 @@ fn setup(
     genesis_time: Utc,
     chunk_distribution_config: Option<ChunkDistributionNetworkConfig>,
 ) -> (
-    TokioRuntimeHandle<ClientActorInner>,
-    MultithreadRuntimeHandle<ViewClientActorInner>,
-    MultithreadRuntimeHandle<RpcHandler>,
-    MultithreadRuntimeHandle<ChunkEndorsementHandler>,
+    TokioRuntimeHandle<ClientActor>,
+    MultithreadRuntimeHandle<ViewClientActor>,
+    MultithreadRuntimeHandle<RpcHandlerActor>,
+    MultithreadRuntimeHandle<ChunkEndorsementHandlerActor>,
     ShardsManagerAdapterForTest,
     PartialWitnessSenderForNetwork,
     tempfile::TempDir,
@@ -157,7 +157,7 @@ fn setup(
 
     let adv = Controls::default();
 
-    let view_client_addr = ViewClientActorInner::spawn_multithread_actor(
+    let view_client_addr = ViewClientActor::spawn_multithread_actor(
         clock.clone(),
         actor_system.clone(),
         chain_genesis.clone(),
@@ -291,8 +291,8 @@ pub fn setup_mock(
     peer_manager_mock: Box<
         dyn FnMut(
                 &PeerManagerMessageRequest,
-                TokioRuntimeHandle<ClientActorInner>,
-                MultithreadRuntimeHandle<ChunkEndorsementHandler>,
+                TokioRuntimeHandle<ClientActor>,
+                MultithreadRuntimeHandle<ChunkEndorsementHandlerActor>,
             ) -> PeerManagerMessageResponse
             + Send,
     >,
@@ -319,8 +319,8 @@ pub fn setup_mock_with_validity_period(
     mut peermanager_mock: Box<
         dyn FnMut(
                 &PeerManagerMessageRequest,
-                TokioRuntimeHandle<ClientActorInner>,
-                MultithreadRuntimeHandle<ChunkEndorsementHandler>,
+                TokioRuntimeHandle<ClientActor>,
+                MultithreadRuntimeHandle<ChunkEndorsementHandlerActor>,
             ) -> PeerManagerMessageResponse
             + Send,
     >,
@@ -370,9 +370,9 @@ pub fn setup_mock_with_validity_period(
 
 #[derive(Clone)]
 pub struct ActorHandlesForTesting {
-    pub client_actor: TokioRuntimeHandle<ClientActorInner>,
-    pub view_client_actor: MultithreadRuntimeHandle<ViewClientActorInner>,
-    pub rpc_handler_actor: MultithreadRuntimeHandle<RpcHandler>,
+    pub client_actor: TokioRuntimeHandle<ClientActor>,
+    pub view_client_actor: MultithreadRuntimeHandle<ViewClientActor>,
+    pub rpc_handler_actor: MultithreadRuntimeHandle<RpcHandlerActor>,
     pub shards_manager_adapter: ShardsManagerAdapterForTest,
     pub partial_witness_sender: PartialWitnessSenderForNetwork,
     // If testing something with runtime that needs runtime home dir users should make sure that
@@ -457,7 +457,7 @@ pub fn setup_client_with_runtime(
     partial_witness_adapter: PartialWitnessSenderForClient,
     validator_signer: MutableValidatorSigner,
     resharding_sender: ReshardingSender,
-) -> (Client, ChunkValidationActorInner) {
+) -> (Client, ChunkValidationActor) {
     let mut config = ClientConfig::test(TestClientConfigParams {
         skip_sync_wait: true,
         min_block_prod_time: 10,
@@ -509,7 +509,7 @@ pub fn setup_client_with_runtime(
     // Create chunk validation actor to use it later for SW validation
     let chain_store = client.chain.chain_store().clone();
     let genesis_block = client.chain.genesis_block();
-    let chunk_validation_inner = ChunkValidationActorInner::new(
+    let chunk_validation_inner = ChunkValidationActor::new(
         chain_store,
         genesis_block,
         epoch_manager,
@@ -593,7 +593,7 @@ pub fn setup_tx_request_handler(
     shard_tracker: ShardTracker,
     runtime: Arc<dyn RuntimeAdapter>,
     network_adapter: PeerManagerAdapter,
-) -> RpcHandler {
+) -> RpcHandlerActor {
     let client_config = ClientConfig::test(TestClientConfigParams {
         skip_sync_wait: true,
         min_block_prod_time: 10,
@@ -609,7 +609,7 @@ pub fn setup_tx_request_handler(
         transaction_validity_period: chain_genesis.transaction_validity_period,
     };
 
-    RpcHandler::new(
+    RpcHandlerActor::new(
         config,
         client.chunk_producer.sharded_tx_pool.clone(),
         epoch_manager,

--- a/integration-tests/src/env/test_env.rs
+++ b/integration-tests/src/env/test_env.rs
@@ -10,7 +10,7 @@ use near_chain::{ChainGenesis, ChainStoreAccess, Provenance};
 use near_chain_configs::{Genesis, GenesisConfig, ProtocolVersionCheckConfig};
 use near_chunks::client::ShardsManagerResponse;
 use near_chunks::test_utils::{MockClientAdapterForShardsManager, SynchronousShardsManagerAdapter};
-use near_client::{Client, DistributeStateWitnessRequest, RpcHandler};
+use near_client::{Client, DistributeStateWitnessRequest, RpcHandlerActor};
 use near_crypto::{InMemorySigner, Signer};
 use near_epoch_manager::shard_assignment::{account_id_to_shard_id, shard_id_to_uid};
 use near_network::client::ProcessTxResponse;
@@ -48,7 +48,7 @@ use time::ext::InstantExt as _;
 use crate::utils::mock_partial_witness_adapter::MockPartialWitnessAdapter;
 
 use near_chain::chain::ChunkStateWitnessMessage;
-use near_client::ChunkValidationActorInner;
+use near_client::ChunkValidationActor;
 
 use super::setup::{TEST_SEED, setup_client_with_runtime};
 use super::test_env_builder::TestEnvBuilder;
@@ -69,8 +69,8 @@ pub struct TestEnv {
     pub partial_witness_adapters: Vec<MockPartialWitnessAdapter>,
     pub shards_manager_adapters: Vec<SynchronousShardsManagerAdapter>,
     pub clients: Vec<Client>,
-    pub chunk_validation_actors: Vec<ChunkValidationActorInner>,
-    pub rpc_handlers: Vec<RpcHandler>,
+    pub chunk_validation_actors: Vec<ChunkValidationActor>,
+    pub rpc_handlers: Vec<RpcHandlerActor>,
     pub(crate) account_indices: AccountIndices,
     pub(crate) paused_blocks: Arc<Mutex<HashMap<CryptoHash, Arc<OnceLock<()>>>>>,
     // random seed to be inject in each client according to AccountId
@@ -220,7 +220,7 @@ impl TestEnv {
         self.account_indices.lookup_mut(&mut self.clients, account_id)
     }
 
-    pub fn rpc_handler(&self, account_id: &AccountId) -> &RpcHandler {
+    pub fn rpc_handler(&self, account_id: &AccountId) -> &RpcHandlerActor {
         self.account_indices.lookup(&self.rpc_handlers, account_id)
     }
 

--- a/integration-tests/src/env/test_env_builder.rs
+++ b/integration-tests/src/env/test_env_builder.rs
@@ -8,7 +8,7 @@ use near_chain_configs::{
     Genesis, GenesisConfig, MutableConfigValue, ProtocolVersionCheckConfig, TrackedShardsConfig,
 };
 use near_chunks::test_utils::MockClientAdapterForShardsManager;
-use near_client::{ChunkValidationActorInner, Client};
+use near_client::{ChunkValidationActor, Client};
 use near_epoch_manager::shard_tracker::ShardTracker;
 use near_epoch_manager::{EpochManager, EpochManagerHandle};
 use near_network::test_utils::MockPeerManagerAdapter;
@@ -519,7 +519,7 @@ impl TestEnvBuilder {
             })
             .collect_vec();
         let actor_system = ActorSystem::new();
-        let (clients, chunk_validation_actors): (Vec<Client>, Vec<ChunkValidationActorInner>) =
+        let (clients, chunk_validation_actors): (Vec<Client>, Vec<ChunkValidationActor>) =
             (0..num_clients)
                 .map(|i| {
                     let account_id = client_accounts[i].clone();

--- a/integration-tests/src/tests/features/orphan_chunk_state_witness.rs
+++ b/integration-tests/src/tests/features/orphan_chunk_state_witness.rs
@@ -8,9 +8,7 @@ use near_chain::stateless_validation::processing_tracker::{
 use near_chain::{Block, Provenance};
 use near_chain_configs::Genesis;
 use near_chain_configs::default_orphan_state_witness_max_size;
-use near_client::{
-    BlockNotificationMessage, ChunkValidationActorInner, HandleOrphanWitnessOutcome,
-};
+use near_client::{BlockNotificationMessage, ChunkValidationActor, HandleOrphanWitnessOutcome};
 use near_o11y::testonly::init_integration_logger;
 use near_primitives::sharding::ShardChunkHeaderV3;
 use near_primitives::sharding::{
@@ -49,7 +47,7 @@ struct OrphanWitnessTestEnv {
     witness: ChunkStateWitness,
     excluded_validator: AccountId,
     excluded_validator_idx: usize,
-    chunk_validation_actor: ChunkValidationActorInner,
+    chunk_validation_actor: ChunkValidationActor,
 }
 
 /// This function prepares a scenario in which an orphaned chunk witness will occur.

--- a/integration-tests/src/tests/nearcore/node_cluster.rs
+++ b/integration-tests/src/tests/nearcore/node_cluster.rs
@@ -9,8 +9,8 @@ use nearcore::{load_test_config, start_with_config};
 use near_async::multithread::MultithreadRuntimeHandle;
 use near_async::tokio::TokioRuntimeHandle;
 use near_async::{ActorSystem, shutdown_all_actors};
-use near_client::ViewClientActorInner;
-use near_client::client_actor::ClientActorInner;
+use near_client::ViewClientActor;
+use near_client::client_actor::ClientActor;
 use near_store::db::RocksDB;
 
 async fn start_nodes(
@@ -25,7 +25,7 @@ async fn start_nodes(
 ) -> (
     Genesis,
     Vec<String>,
-    Vec<(TokioRuntimeHandle<ClientActorInner>, MultithreadRuntimeHandle<ViewClientActorInner>)>,
+    Vec<(TokioRuntimeHandle<ClientActor>, MultithreadRuntimeHandle<ViewClientActor>)>,
 ) {
     init_integration_logger();
 
@@ -130,10 +130,7 @@ impl NodeCluster {
         F: FnOnce(
                 near_chain_configs::Genesis,
                 Vec<String>,
-                Vec<(
-                    TokioRuntimeHandle<ClientActorInner>,
-                    MultithreadRuntimeHandle<ViewClientActorInner>,
-                )>,
+                Vec<(TokioRuntimeHandle<ClientActor>, MultithreadRuntimeHandle<ViewClientActor>)>,
             ) -> R
             + 'static,
     {

--- a/integration-tests/src/tests/nearcore/stake_nodes.rs
+++ b/integration-tests/src/tests/nearcore/stake_nodes.rs
@@ -9,7 +9,7 @@ use rand::Rng;
 
 use crate::utils::genesis_helpers::genesis_hash;
 use near_chain_configs::{Genesis, TrackedShardsConfig};
-use near_client::{GetBlock, ProcessTxRequest, Query, RpcHandler, ViewClientActorInner};
+use near_client::{GetBlock, ProcessTxRequest, Query, RpcHandlerActor, ViewClientActor};
 use near_crypto::{InMemorySigner, Signer};
 use near_network::tcp;
 use near_network::test_utils::{convert_boot_nodes, wait_or_timeout};
@@ -24,7 +24,7 @@ use near_async::ActorSystem;
 use near_async::messaging::{CanSend, CanSendAsync};
 use near_async::multithread::MultithreadRuntimeHandle;
 use near_async::tokio::TokioRuntimeHandle;
-use near_client::client_actor::ClientActorInner;
+use near_client::client_actor::ClientActor;
 use near_client_primitives::types::Status;
 use near_o11y::span_wrapped_msg::SpanWrappedMessageExt;
 use near_store::db::RocksDB;
@@ -36,9 +36,9 @@ struct TestNode {
     account_id: AccountId,
     signer: Arc<Signer>,
     config: NearConfig,
-    client: TokioRuntimeHandle<ClientActorInner>,
-    view_client: MultithreadRuntimeHandle<ViewClientActorInner>,
-    tx_processor: MultithreadRuntimeHandle<RpcHandler>,
+    client: TokioRuntimeHandle<ClientActor>,
+    view_client: MultithreadRuntimeHandle<ViewClientActor>,
+    tx_processor: MultithreadRuntimeHandle<RpcHandlerActor>,
     genesis_hash: CryptoHash,
 }
 

--- a/integration-tests/src/tests/network/runner.rs
+++ b/integration-tests/src/tests/network/runner.rs
@@ -11,10 +11,10 @@ use near_chain_configs::{ClientConfig, Genesis, GenesisConfig, MutableConfigValu
 use near_chunks::shards_manager_actor::start_shards_manager;
 use near_client::adapter::client_sender_for_network;
 use near_client::client_actor::SpiceClientConfig;
-use near_client::{ChunkValidationActorInner, spawn_chunk_endorsement_handler_actor};
+use near_client::{ChunkValidationActor, spawn_chunk_endorsement_handler_actor};
 use near_client::{
-    PartialWitnessActor, RpcHandlerConfig, StartClientResult, StateRequestActor,
-    ViewClientActorInner, spawn_rpc_handler_actor, start_client,
+    PartialWitnessActor, RpcHandlerConfig, StartClientResult, StateRequestActor, ViewClientActor,
+    spawn_rpc_handler_actor, start_client,
 };
 use near_epoch_manager::EpochManager;
 use near_epoch_manager::shard_tracker::ShardTracker;
@@ -136,7 +136,7 @@ fn setup_network_node(
             spice_core_writer_sender: noop().into_sender(),
         },
     );
-    let view_client_addr = ViewClientActorInner::spawn_multithread_actor(
+    let view_client_addr = ViewClientActor::spawn_multithread_actor(
         Clock::real(),
         actor_system.clone(),
         chain_genesis,
@@ -187,7 +187,7 @@ fn setup_network_node(
     );
     let chain_store =
         ChainStore::new(runtime.store().clone(), false, genesis.config.genesis_height);
-    let chunk_validation_actor = ChunkValidationActorInner::spawn_multithread_actor(
+    let chunk_validation_actor = ChunkValidationActor::spawn_multithread_actor(
         actor_system.clone(),
         chain_store,
         Arc::new(genesis_block),

--- a/test-loop-tests/src/examples/raw_client.rs
+++ b/test-loop-tests/src/examples/raw_client.rs
@@ -7,7 +7,7 @@ use near_chain_configs::test_genesis::TestGenesisBuilder;
 use near_chain_configs::test_utils::TestClientConfigParams;
 use near_chain_configs::{ClientConfig, MutableConfigValue, TrackedShardsConfig};
 use near_chunks::shards_manager_actor::ShardsManagerActor;
-use near_client::client_actor::ClientActorInner;
+use near_client::client_actor::ClientActor;
 use near_client::sync_jobs_actor::SyncJobsActor;
 use near_client::{AsyncComputationMultiSpawner, Client};
 use near_epoch_manager::EpochManager;
@@ -129,7 +129,7 @@ fn test_raw_client_test_loop_setup() {
         Duration::milliseconds(100),
     );
 
-    let client_actor = ClientActorInner::new(
+    let client_actor = ClientActor::new(
         test_loop.clock(),
         client,
         PeerId::random(),

--- a/test-loop-tests/src/setup/setup.rs
+++ b/test-loop-tests/src/setup/setup.rs
@@ -16,17 +16,17 @@ use near_chunks::shards_manager_actor::ShardsManagerActor;
 use near_client::archive::cloud_archival_writer::create_cloud_archival_writer;
 use near_client::archive::cold_store_actor::create_cold_store_actor;
 use near_client::chunk_executor_actor::ChunkExecutorActor;
-use near_client::client_actor::ClientActorInner;
+use near_client::client_actor::ClientActor;
 use near_client::gc_actor::GCActor;
 use near_client::spice_chunk_validator_actor::SpiceChunkValidatorActor;
 use near_client::spice_data_distributor_actor::SpiceDataDistributorActor;
 use near_client::sync_jobs_actor::SyncJobsActor;
 use near_client::{
-    AsyncComputationMultiSpawner, ChunkEndorsementHandler, Client, PartialWitnessActor, RpcHandler,
-    RpcHandlerConfig, StateRequestActor, ViewClientActorInner,
+    AsyncComputationMultiSpawner, ChunkEndorsementHandlerActor, Client, PartialWitnessActor,
+    RpcHandlerActor, RpcHandlerConfig, StateRequestActor, ViewClientActor,
 };
 use near_client::{
-    ChunkValidationActorInner, ChunkValidationSender, ChunkValidationSenderForPartialWitness,
+    ChunkValidationActor, ChunkValidationSender, ChunkValidationSenderForPartialWitness,
 };
 use near_epoch_manager::EpochManager;
 use near_epoch_manager::shard_tracker::ShardTracker;
@@ -204,7 +204,7 @@ pub fn setup_client(
         } else {
             (epoch_manager.clone(), shard_tracker.clone(), runtime_adapter.clone())
         };
-    let view_client_actor = ViewClientActorInner::new(
+    let view_client_actor = ViewClientActor::new(
         test_loop.clock(),
         chain_genesis.clone(),
         view_epoch_manager.clone(),
@@ -242,7 +242,7 @@ pub fn setup_client(
     );
 
     let genesis_block = client.chain.genesis_block();
-    let chunk_validation_actor = ChunkValidationActorInner::new(
+    let chunk_validation_actor = ChunkValidationActor::new(
         client.chain.chain_store().clone(),
         genesis_block,
         epoch_manager.clone(),
@@ -275,7 +275,7 @@ pub fn setup_client(
     } else {
         noop().into_sender()
     };
-    let client_actor = ClientActorInner::new(
+    let client_actor = ClientActor::new(
         test_loop.clock(),
         client,
         peer_id.clone(),
@@ -298,7 +298,7 @@ pub fn setup_client(
         epoch_length: client_config.epoch_length,
         transaction_validity_period: genesis.config.transaction_validity_period,
     };
-    let rpc_handler = RpcHandler::new(
+    let rpc_handler = RpcHandlerActor::new(
         rpc_handler_config,
         client_actor.client.chunk_producer.sharded_tx_pool.clone(),
         epoch_manager.clone(),
@@ -308,7 +308,7 @@ pub fn setup_client(
         network_adapter.as_multi_sender(),
     );
     let chunk_endorsement_handler =
-        ChunkEndorsementHandler::new(client_actor.client.chunk_endorsement_tracker.clone());
+        ChunkEndorsementHandlerActor::new(client_actor.client.chunk_endorsement_tracker.clone());
 
     let chunk_validation_adapter = LateBoundSender::<ChunkValidationSenderForPartialWitness>::new();
 

--- a/test-loop-tests/src/setup/state.rs
+++ b/test-loop-tests/src/setup/state.rs
@@ -12,11 +12,11 @@ use near_chain_configs::{ClientConfig, Genesis};
 use near_chunks::shards_manager_actor::ShardsManagerActor;
 use near_client::archive::cloud_archival_writer::CloudArchivalWriterHandle;
 use near_client::archive::cold_store_actor::ColdStoreActor;
-use near_client::client_actor::ClientActorInner;
+use near_client::client_actor::ClientActor;
 use near_client::spice_data_distributor_actor::SpiceDataDistributorActor;
 use near_client::{
-    ChunkEndorsementHandler, PartialWitnessActor, RpcHandler, StateRequestActor,
-    ViewClientActorInner,
+    ChunkEndorsementHandlerActor, PartialWitnessActor, RpcHandlerActor, StateRequestActor,
+    ViewClientActor,
 };
 use near_jsonrpc::ViewClientSenderForRpc;
 use near_network::client::SpiceChunkEndorsementMessage;
@@ -82,11 +82,11 @@ pub struct NodeExecutionData {
     pub identifier: String,
     pub account_id: AccountId,
     pub peer_id: PeerId,
-    pub client_sender: TestLoopSender<ClientActorInner>,
-    pub view_client_sender: TestLoopSender<ViewClientActorInner>,
+    pub client_sender: TestLoopSender<ClientActor>,
+    pub view_client_sender: TestLoopSender<ViewClientActor>,
     pub state_request_sender: TestLoopSender<StateRequestActor>,
-    pub rpc_handler_sender: TestLoopSender<RpcHandler>,
-    pub chunk_endorsement_handler_sender: TestLoopSender<ChunkEndorsementHandler>,
+    pub rpc_handler_sender: TestLoopSender<RpcHandlerActor>,
+    pub chunk_endorsement_handler_sender: TestLoopSender<ChunkEndorsementHandlerActor>,
     pub shards_manager_sender: TestLoopSender<ShardsManagerActor>,
     pub partial_witness_sender: TestLoopSender<PartialWitnessActor>,
     pub peer_manager_sender: TestLoopSender<TestLoopPeerManagerActor>,

--- a/test-loop-tests/src/tests/bandwidth_scheduler.rs
+++ b/test-loop-tests/src/tests/bandwidth_scheduler.rs
@@ -25,7 +25,7 @@ use near_async::test_loop::sender::TestLoopSender;
 use near_async::time::Duration;
 use near_chain::{ChainStoreAccess, ReceiptFilter, get_incoming_receipts_for_shard};
 use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
-use near_client::{Client, RpcHandler};
+use near_client::{Client, RpcHandlerActor};
 use near_crypto::Signer;
 use near_primitives::account::{AccessKey, AccessKeyPermission};
 use near_primitives::action::{Action, FunctionCallAction};
@@ -611,7 +611,7 @@ impl WorkloadGenerator {
 
     pub fn run(
         &mut self,
-        client_sender: &TestLoopSender<RpcHandler>,
+        client_sender: &TestLoopSender<RpcHandlerActor>,
         client: &Client,
         future_spawner: &TestLoopFutureSpawner,
     ) {
@@ -662,7 +662,7 @@ impl WorkloadSender {
 
     pub fn run(
         &mut self,
-        client_sender: &TestLoopSender<RpcHandler>,
+        client_sender: &TestLoopSender<RpcHandlerActor>,
         client: &Client,
         future_spawner: &TestLoopFutureSpawner,
         rng: &mut ChaCha20Rng,
@@ -683,7 +683,7 @@ impl WorkloadSender {
 
     pub fn start_new_transaction(
         &mut self,
-        client_sender: &TestLoopSender<RpcHandler>,
+        client_sender: &TestLoopSender<RpcHandlerActor>,
         client: &Client,
         future_spawner: &TestLoopFutureSpawner,
         rng: &mut ChaCha20Rng,

--- a/test-loop-tests/src/tests/congestion_control.rs
+++ b/test-loop-tests/src/tests/congestion_control.rs
@@ -14,7 +14,7 @@ use near_async::test_loop::TestLoopV2;
 use near_async::test_loop::data::{TestLoopData, TestLoopDataHandle};
 use near_async::time::Duration;
 use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
-use near_client::client_actor::ClientActorInner;
+use near_client::client_actor::ClientActor;
 use near_o11y::testonly::init_test_logger;
 use near_parameters::RuntimeConfig;
 use near_primitives::errors::InvalidTxError;
@@ -229,7 +229,7 @@ fn do_call_contract(
 /// height is greater than the target height.
 fn height_condition(
     test_loop_data: &TestLoopData,
-    client_handle: &TestLoopDataHandle<ClientActorInner>,
+    client_handle: &TestLoopDataHandle<ClientActor>,
     target_height: BlockHeight,
 ) -> bool {
     test_loop_data.get(&client_handle).client.chain.head().unwrap().height > target_height

--- a/test-loop-tests/src/tests/consensus.rs
+++ b/test-loop-tests/src/tests/consensus.rs
@@ -9,7 +9,7 @@ use near_async::test_loop::sender::TestLoopSender;
 use near_async::time::Duration;
 use near_chain::Block;
 use near_chain_configs::test_genesis::TestEpochConfigBuilder;
-use near_client::client_actor::ClientActorInner;
+use near_client::client_actor::ClientActor;
 use near_epoch_manager::EpochManagerAdapter;
 use near_network::client::{BlockApproval, BlockResponse};
 use near_network::types::NetworkRequests;
@@ -321,7 +321,7 @@ struct NetworkHandlingData {
 
     current_epoch: EpochId,
     epoch_manager: Arc<dyn EpochManagerAdapter>,
-    client_senders: HashMap<AccountId, TestLoopSender<ClientActorInner>>,
+    client_senders: HashMap<AccountId, TestLoopSender<ClientActor>>,
     validators: Vec<Vec<AccountId>>,
 }
 

--- a/test-loop-tests/src/tests/create_delete_account.rs
+++ b/test-loop-tests/src/tests/create_delete_account.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use near_async::futures::{DelayedActionRunner, DelayedActionRunnerExt};
 use near_async::time::Duration;
 use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
-use near_client::client_actor::ClientActorInner;
+use near_client::client_actor::ClientActor;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::types::{AccountId, Balance};
 
@@ -33,8 +33,8 @@ fn do_call_contract(env: &mut TestLoopEnv, rpc_id: &AccountId, contract_id: &Acc
 
 /// Tracks latest block heights and checks that all chunks are produced.
 fn check_chunks(
-    actor: &ClientActorInner,
-    runner: &mut dyn DelayedActionRunner<ClientActorInner>,
+    actor: &ClientActor,
+    runner: &mut dyn DelayedActionRunner<ClientActor>,
     latest_block_height: std::cell::Cell<u64>,
 ) {
     let client = &actor.client;

--- a/test-loop-tests/src/tests/multinode_stateless_validators.rs
+++ b/test-loop-tests/src/tests/multinode_stateless_validators.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use near_async::messaging::Handler;
 use near_async::time::Duration;
 use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
-use near_client::{GetValidatorInfo, ViewClientActorInner};
+use near_client::{GetValidatorInfo, ViewClientActor};
 use near_o11y::testonly::init_test_logger;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::types::{AccountId, Balance, EpochId, EpochReference};
@@ -101,7 +101,7 @@ fn slow_test_stateless_validators_with_multi_test_loop() {
 
 /// Returns the CurrentEpochValidatorInfo for each validator account for the given epoch id.
 fn get_validator_info(
-    view_client: &mut ViewClientActorInner,
+    view_client: &mut ViewClientActor,
     epoch_id: EpochId,
 ) -> HashMap<AccountId, CurrentEpochValidatorInfo> {
     let validator_info: EpochValidatorInfo = view_client
@@ -116,7 +116,7 @@ fn get_validator_info(
 /// 3. Stake of both the block/chunk producers and chunk validators increase (due to rewards).
 /// TODO: Assert on the specific reward amount, currently it only checks that some amount is rewarded.
 fn assert_validator_info(
-    view_client: &mut ViewClientActorInner,
+    view_client: &mut ViewClientActor,
     epoch_id: EpochId,
     initial_epoch_id: EpochId,
     accounts: Vec<AccountId>,

--- a/test-loop-tests/src/tests/spice.rs
+++ b/test-loop-tests/src/tests/spice.rs
@@ -7,7 +7,7 @@ use near_async::messaging::{CanSend as _, Handler as _};
 use near_async::test_loop::data::TestLoopData;
 use near_async::time::Duration;
 use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
-use near_client::{ProcessTxRequest, Query, ViewClientActorInner};
+use near_client::{ProcessTxRequest, Query, ViewClientActor};
 use near_network::client::SpiceChunkEndorsementMessage;
 use near_network::types::NetworkRequests;
 use near_o11y::testonly::init_test_logger;
@@ -730,10 +730,7 @@ fn schedule_send_money_txs(
     (sent_txs, balance_changes)
 }
 
-fn query_view_account(
-    view_client: &mut ViewClientActorInner,
-    account_id: AccountId,
-) -> AccountView {
+fn query_view_account(view_client: &mut ViewClientActor, account_id: AccountId) -> AccountView {
     // Note that TestLoopNode::view_account_query doesn't work with spice yet.
     let query_response = view_client
         .handle(Query::new(

--- a/test-loop-tests/src/tests/view_requests_to_archival_node.rs
+++ b/test-loop-tests/src/tests/view_requests_to_archival_node.rs
@@ -9,7 +9,7 @@ use near_chain_configs::test_genesis::{TestEpochConfigBuilder, ValidatorsSpec};
 use near_client::{
     GetBlock, GetChunk, GetExecutionOutcomesForBlock, GetProtocolConfig, GetShardChunk,
     GetStateChanges, GetStateChangesInBlock, GetValidatorInfo, GetValidatorOrdered,
-    ViewClientActorInner,
+    ViewClientActor,
 };
 use near_network::client::BlockHeadersRequest;
 use near_o11y::testonly::init_test_logger;
@@ -119,7 +119,7 @@ struct ViewClientTester<'a> {
     test_loop: &'a mut TestLoopV2,
     /// List of data handles to the view client senders for sending the requests.
     /// Used to locate the right view client to send a request (by index).
-    handles: Vec<TestLoopDataHandle<ViewClientActorInner>>,
+    handles: Vec<TestLoopDataHandle<ViewClientActor>>,
     /// Cache of block height to Blocks (as they are called in multiple checks).
     block_cache: HashMap<BlockHeight, BlockView>,
 }
@@ -142,7 +142,7 @@ impl<'a> ViewClientTester<'a> {
     where
         M: Send + 'static,
         R: Send,
-        ViewClientActorInner: Handler<M, R>,
+        ViewClientActor: Handler<M, R>,
     {
         let view_client = self.test_loop.data.get_mut(&self.handles[idx]);
         view_client.handle(request)

--- a/test-loop-tests/src/utils/mod.rs
+++ b/test-loop-tests/src/utils/mod.rs
@@ -1,6 +1,6 @@
 use near_async::test_loop::data::TestLoopData;
 use near_client::Client;
-use near_client::client_actor::ClientActorInner;
+use near_client::client_actor::ClientActor;
 use near_primitives::types::{AccountId, BlockHeight};
 
 use crate::setup::env::TestLoopEnv;
@@ -76,7 +76,7 @@ pub(crate) fn retrieve_client_actor<'a>(
     node_datas: &'a [NodeExecutionData],
     test_loop_data: &'a mut TestLoopData,
     client_account_id: &AccountId,
-) -> &'a mut ClientActorInner {
+) -> &'a mut ClientActor {
     let client_handle = get_node_data(node_datas, client_account_id).client_sender.actor_handle();
     test_loop_data.get_mut(&client_handle)
 }

--- a/test-loop-tests/src/utils/receipts.rs
+++ b/test-loop-tests/src/utils/receipts.rs
@@ -7,7 +7,7 @@ use near_async::test_loop::data::TestLoopData;
 use near_chain::ChainStoreAccess;
 use near_chain::types::Tip;
 use near_client::Client;
-use near_client::client_actor::ClientActorInner;
+use near_client::client_actor::ClientActor;
 use near_epoch_manager::shard_assignment::account_id_to_shard_id;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{
@@ -84,7 +84,7 @@ pub fn check_receipts_presence_after_resharding_block(
 
 /// Asserts the presence of any receipt of type `kind` at the provided chain `tip`.
 pub fn check_receipts_at_block(
-    client_actor: &ClientActorInner,
+    client_actor: &ClientActor,
     account: &AccountId,
     kind: &ReceiptKind,
     tip: &Tip,

--- a/test-loop-tests/src/utils/resharding.rs
+++ b/test-loop-tests/src/utils/resharding.rs
@@ -40,7 +40,7 @@ use crate::utils::transactions::{
 };
 use crate::utils::{get_node_data, retrieve_client_actor};
 use near_chain::types::Tip;
-use near_client::client_actor::ClientActorInner;
+use near_client::client_actor::ClientActor;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::trie_key::TrieKey;
 use near_store::flat::FlatStorageStatus;
@@ -1290,7 +1290,7 @@ fn get_resharded_shard_uids(
 // Helper function to retrieve any key from the trie. This bypasses all intermediate layers
 // (caching, memtrie, flat-storage).
 fn get_trie_node_value<I: borsh::BorshDeserialize + Default>(
-    client_actor: &ClientActorInner,
+    client_actor: &ClientActor,
     shard_uid: ShardUId,
     prev_block_hash: &CryptoHash,
     key: TrieKey,

--- a/test-loop-tests/src/utils/rotating_validators_runner.rs
+++ b/test-loop-tests/src/utils/rotating_validators_runner.rs
@@ -7,7 +7,7 @@ use near_async::test_loop::data::{TestLoopData, TestLoopDataHandle};
 use near_async::time::Duration;
 use near_chain_configs::test_genesis::ValidatorsSpec;
 use near_client::ProcessTxRequest;
-use near_client::client_actor::ClientActorInner;
+use near_client::client_actor::ClientActor;
 use near_crypto::Signer;
 use near_primitives::test_utils::create_user_test_signer;
 use near_primitives::transaction::SignedTransaction;
@@ -104,13 +104,13 @@ impl RotatingValidatorsRunner {
         }
     }
 
-    fn client_actor_handle(env: &TestLoopEnv) -> TestLoopDataHandle<ClientActorInner> {
+    fn client_actor_handle(env: &TestLoopEnv) -> TestLoopDataHandle<ClientActor> {
         env.node_datas[0].client_sender.actor_handle()
     }
 
     fn client<'a>(
         data: &'a TestLoopData,
-        client_actor_handle: &TestLoopDataHandle<ClientActorInner>,
+        client_actor_handle: &TestLoopDataHandle<ClientActor>,
     ) -> &'a near_client::Client {
         &data.get(client_actor_handle).client
     }

--- a/test-loop-tests/src/utils/transactions.rs
+++ b/test-loop-tests/src/utils/transactions.rs
@@ -13,7 +13,7 @@ use near_async::test_loop::futures::TestLoopFutureSpawner;
 use near_async::test_loop::sender::TestLoopSender;
 use near_async::time::Duration;
 use near_chain::Error;
-use near_client::{Client, ProcessTxResponse, RpcHandler};
+use near_client::{Client, ProcessTxResponse, RpcHandlerActor};
 use near_crypto::Signer;
 use near_network::client::ProcessTxRequest;
 use near_primitives::action::{GlobalContractDeployMode, GlobalContractIdentifier};
@@ -632,7 +632,7 @@ impl TransactionRunner {
     /// It's meant to be called in `run_until`.
     pub fn poll(
         &mut self,
-        client_sender: &TestLoopSender<RpcHandler>,
+        client_sender: &TestLoopSender<RpcHandlerActor>,
         client: &Client,
         future_spawner: &TestLoopFutureSpawner,
     ) -> Poll<Result<FinalExecutionOutcomeView, InvalidTxError>> {
@@ -681,7 +681,7 @@ impl TransactionRunner {
     /// Useful for tests where the transaction is expected to be executed successfully.
     pub fn poll_assert_success(
         &mut self,
-        client_sender: &TestLoopSender<RpcHandler>,
+        client_sender: &TestLoopSender<RpcHandlerActor>,
         client: &Client,
         future_spawner: &TestLoopFutureSpawner,
     ) -> Poll<Vec<u8>> {
@@ -700,7 +700,7 @@ impl TransactionRunner {
     /// Send the transaction to the network.
     fn send_tx(
         &mut self,
-        client_sender: &TestLoopSender<RpcHandler>,
+        client_sender: &TestLoopSender<RpcHandlerActor>,
         future_spawner: &TestLoopFutureSpawner,
     ) {
         let process_tx_request = ProcessTxRequest {

--- a/tools/mirror/src/chain_tracker.rs
+++ b/tools/mirror/src/chain_tracker.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use anyhow::Context;
 use near_async::multithread::MultithreadRuntimeHandle;
-use near_client::ViewClientActorInner;
+use near_client::ViewClientActor;
 use near_crypto::{PublicKey, SecretKey};
 use near_indexer::StreamerMessage;
 use near_indexer_primitives::{IndexerExecutionOutcomeWithReceipt, IndexerTransactionWithOutcome};
@@ -234,7 +234,7 @@ impl TxTracker {
     //
     // So this function must be called before calling initialize_target_nonce() for a given access key
     async fn store_target_nonce(
-        target_view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
+        target_view_client: &MultithreadRuntimeHandle<ViewClientActor>,
         db: &DB,
         access_key: &(AccountId, PublicKey),
     ) -> anyhow::Result<()> {
@@ -288,7 +288,7 @@ impl TxTracker {
 
     pub(crate) async fn next_nonce(
         lock: &Mutex<Self>,
-        target_view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
+        target_view_client: &MultithreadRuntimeHandle<ViewClientActor>,
         db: &DB,
         signer_id: &AccountId,
         public_key: &PublicKey,
@@ -316,7 +316,7 @@ impl TxTracker {
     pub(crate) async fn insert_nonce(
         lock: &Mutex<Self>,
         tx_block_queue: &Mutex<VecDeque<MappedBlock>>,
-        target_view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
+        target_view_client: &MultithreadRuntimeHandle<ViewClientActor>,
         db: &DB,
         signer_id: &AccountId,
         public_key: &PublicKey,
@@ -402,7 +402,7 @@ impl TxTracker {
 
     async fn store_access_key_updates(
         block: &MappedBlock,
-        target_view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
+        target_view_client: &MultithreadRuntimeHandle<ViewClientActor>,
         db: &DB,
     ) -> anyhow::Result<()> {
         for c in &block.chunks {
@@ -474,7 +474,7 @@ impl TxTracker {
         lock: &Mutex<Self>,
         tx_block_queue: &Mutex<VecDeque<MappedBlock>>,
         block: MappedBlock,
-        target_view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
+        target_view_client: &MultithreadRuntimeHandle<ViewClientActor>,
         db: &DB,
     ) -> anyhow::Result<()> {
         Self::store_access_key_updates(&block, target_view_client, db).await?;

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -3,8 +3,8 @@ use async_trait::async_trait;
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_chain_configs::GenesisValidationMode;
 use near_chain_primitives::error::QueryError as RuntimeQueryError;
-use near_client::ViewClientActorInner;
-use near_client::{ProcessTxRequest, ProcessTxResponse, RpcHandler};
+use near_client::ViewClientActor;
+use near_client::{ProcessTxRequest, ProcessTxResponse, RpcHandlerActor};
 use near_client_primitives::types::{
     GetBlock, GetBlockError, GetChunkError, GetExecutionOutcomeError, GetReceiptError, Query,
     QueryError, Status,
@@ -51,7 +51,7 @@ pub use cli::MirrorCommand;
 use near_async::messaging::CanSendAsync;
 use near_async::multithread::MultithreadRuntimeHandle;
 use near_async::tokio::TokioRuntimeHandle;
-use near_client::client_actor::ClientActorInner;
+use near_client::client_actor::ClientActor;
 use near_o11y::span_wrapped_msg::SpanWrappedMessageExt;
 
 #[derive(strum::EnumIter)]
@@ -773,7 +773,7 @@ impl From<&MappedBlock> for TxBatch {
 }
 
 async fn account_exists(
-    view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
+    view_client: &MultithreadRuntimeHandle<ViewClientActor>,
     account_id: &AccountId,
 ) -> anyhow::Result<bool> {
     match view_client
@@ -797,7 +797,7 @@ async fn account_exists(
 }
 
 async fn fetch_access_key_nonce(
-    view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
+    view_client: &MultithreadRuntimeHandle<ViewClientActor>,
     account_id: &AccountId,
     public_key: &PublicKey,
 ) -> anyhow::Result<Option<Nonce>> {
@@ -870,7 +870,7 @@ impl<T: ChainAccess> TxMirror<T> {
     }
 
     async fn send_transactions<'a, I: Iterator<Item = &'a mut TargetChainTx>>(
-        target_client: &MultithreadRuntimeHandle<RpcHandler>,
+        target_client: &MultithreadRuntimeHandle<RpcHandlerActor>,
         txs: I,
     ) -> anyhow::Result<()> {
         for tx in txs {
@@ -931,7 +931,7 @@ impl<T: ChainAccess> TxMirror<T> {
 
     async fn map_actions(
         &self,
-        target_view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
+        target_view_client: &MultithreadRuntimeHandle<ViewClientActor>,
         tx: &SignedTransaction,
     ) -> anyhow::Result<(Vec<Action>, HashSet<(AccountId, PublicKey)>)> {
         let mut actions = Vec::new();
@@ -1021,7 +1021,7 @@ impl<T: ChainAccess> TxMirror<T> {
         &self,
         tracker: &Mutex<crate::chain_tracker::TxTracker>,
         tx_block_queue: &Mutex<VecDeque<MappedBlock>>,
-        target_view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
+        target_view_client: &MultithreadRuntimeHandle<ViewClientActor>,
         source_signer_id: AccountId,
         source_receiver_id: AccountId,
         target_signer_id: AccountId,
@@ -1102,7 +1102,7 @@ impl<T: ChainAccess> TxMirror<T> {
         &self,
         tracker: &Mutex<crate::chain_tracker::TxTracker>,
         tx_block_queue: &Mutex<VecDeque<MappedBlock>>,
-        target_view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
+        target_view_client: &MultithreadRuntimeHandle<ViewClientActor>,
         block_hash: CryptoHash,
         txs: &mut Vec<TargetChainTx>,
         predecessor_id: AccountId,
@@ -1256,7 +1256,7 @@ impl<T: ChainAccess> TxMirror<T> {
         &self,
         tracker: &Mutex<crate::chain_tracker::TxTracker>,
         tx_block_queue: &Mutex<VecDeque<MappedBlock>>,
-        target_view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
+        target_view_client: &MultithreadRuntimeHandle<ViewClientActor>,
         txs: &mut Vec<TargetChainTx>,
         receipt_id: &CryptoHash,
         receiver_id: &AccountId,
@@ -1373,7 +1373,7 @@ impl<T: ChainAccess> TxMirror<T> {
         ref_hash: &CryptoHash,
         tracker: &Mutex<crate::chain_tracker::TxTracker>,
         tx_block_queue: &Mutex<VecDeque<MappedBlock>>,
-        target_view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
+        target_view_client: &MultithreadRuntimeHandle<ViewClientActor>,
         txs: &mut Vec<TargetChainTx>,
     ) -> anyhow::Result<()> {
         // if signer and receiver are the same then the resulting local receipt
@@ -1417,7 +1417,7 @@ impl<T: ChainAccess> TxMirror<T> {
         ref_hash: &CryptoHash,
         tracker: &Mutex<crate::chain_tracker::TxTracker>,
         tx_block_queue: &Mutex<VecDeque<MappedBlock>>,
-        target_view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
+        target_view_client: &MultithreadRuntimeHandle<ViewClientActor>,
         txs: &mut Vec<TargetChainTx>,
     ) -> anyhow::Result<()> {
         if let ReceiptEnum::Action(r) | ReceiptEnum::PromiseYield(r) = receipt.receipt() {
@@ -1448,7 +1448,7 @@ impl<T: ChainAccess> TxMirror<T> {
         ref_hash: CryptoHash,
         tracker: &Mutex<crate::chain_tracker::TxTracker>,
         tx_block_queue: &Mutex<VecDeque<MappedBlock>>,
-        target_view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
+        target_view_client: &MultithreadRuntimeHandle<ViewClientActor>,
         txs: &mut Vec<TargetChainTx>,
     ) -> anyhow::Result<()> {
         let source_block =
@@ -1502,7 +1502,7 @@ impl<T: ChainAccess> TxMirror<T> {
         ref_hash: CryptoHash,
         tracker: &Mutex<crate::chain_tracker::TxTracker>,
         tx_block_queue: &Mutex<VecDeque<MappedBlock>>,
-        target_view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
+        target_view_client: &MultithreadRuntimeHandle<ViewClientActor>,
     ) -> anyhow::Result<MappedBlock> {
         let source_block =
             self.source_chain_access.get_txs(source_height).await.with_context(|| {
@@ -1618,7 +1618,7 @@ impl<T: ChainAccess> TxMirror<T> {
         &self,
         tracker: &Mutex<crate::chain_tracker::TxTracker>,
         tx_block_queue: &Mutex<VecDeque<MappedBlock>>,
-        target_view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
+        target_view_client: &MultithreadRuntimeHandle<ViewClientActor>,
         ref_hash: CryptoHash,
         have_stop_height: bool,
     ) -> anyhow::Result<()> {
@@ -1680,8 +1680,8 @@ impl<T: ChainAccess> TxMirror<T> {
         &self,
         tracker: &Mutex<crate::chain_tracker::TxTracker>,
         tx_block_queue: &Mutex<VecDeque<MappedBlock>>,
-        target_client: &MultithreadRuntimeHandle<RpcHandler>,
-        target_view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
+        target_client: &MultithreadRuntimeHandle<RpcHandlerActor>,
+        target_view_client: &MultithreadRuntimeHandle<ViewClientActor>,
         stakes: HashMap<(AccountId, PublicKey), AccountId>,
         source_hash: &CryptoHash,
         target_hash: &CryptoHash,
@@ -1723,7 +1723,7 @@ impl<T: ChainAccess> TxMirror<T> {
         tx_block_queue: Arc<Mutex<VecDeque<MappedBlock>>>,
         mut send_time: Pin<Box<tokio::time::Sleep>>,
         send_delay: Arc<Mutex<Duration>>,
-        target_client: MultithreadRuntimeHandle<RpcHandler>,
+        target_client: MultithreadRuntimeHandle<RpcHandlerActor>,
     ) -> anyhow::Result<()> {
         let mut sent_source_height = None;
 
@@ -1785,9 +1785,9 @@ impl<T: ChainAccess> TxMirror<T> {
         home_dir: PathBuf,
         db: Arc<DB>,
         clients_tx: tokio::sync::oneshot::Sender<(
-            TokioRuntimeHandle<ClientActorInner>,
-            MultithreadRuntimeHandle<ViewClientActorInner>,
-            MultithreadRuntimeHandle<RpcHandler>,
+            TokioRuntimeHandle<ClientActor>,
+            MultithreadRuntimeHandle<ViewClientActor>,
+            MultithreadRuntimeHandle<RpcHandlerActor>,
         )>,
         accounts_to_unstake: mpsc::Sender<HashMap<(AccountId, PublicKey), AccountId>>,
         target_height: Arc<RwLock<BlockHeight>>,
@@ -1853,8 +1853,8 @@ impl<T: ChainAccess> TxMirror<T> {
         &self,
         tracker: Arc<Mutex<crate::chain_tracker::TxTracker>>,
         tx_block_queue: Arc<Mutex<VecDeque<MappedBlock>>>,
-        target_client: MultithreadRuntimeHandle<RpcHandler>,
-        target_view_client: MultithreadRuntimeHandle<ViewClientActorInner>,
+        target_client: MultithreadRuntimeHandle<RpcHandlerActor>,
+        target_view_client: MultithreadRuntimeHandle<ViewClientActor>,
         mut blocks_sent: mpsc::Receiver<TxBatch>,
         mut accounts_to_unstake: mpsc::Receiver<HashMap<(AccountId, PublicKey), AccountId>>,
         send_delay: Arc<Mutex<Duration>>,
@@ -1917,7 +1917,7 @@ impl<T: ChainAccess> TxMirror<T> {
         }
     }
 
-    async fn target_chain_syncing(target_client: &TokioRuntimeHandle<ClientActorInner>) -> bool {
+    async fn target_chain_syncing(target_client: &TokioRuntimeHandle<ClientActor>) -> bool {
         target_client
             .send_async(Status { is_health_check: false, detailed: false }.span_wrap())
             .await
@@ -1927,7 +1927,7 @@ impl<T: ChainAccess> TxMirror<T> {
     }
 
     async fn target_chain_head(
-        target_view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
+        target_view_client: &MultithreadRuntimeHandle<ViewClientActor>,
     ) -> anyhow::Result<(BlockHeight, CryptoHash)> {
         let header = target_view_client
             .send_async(GetBlock(BlockReference::Finality(Finality::Final)))
@@ -1944,8 +1944,8 @@ impl<T: ChainAccess> TxMirror<T> {
         tx_block_queue: &Mutex<VecDeque<MappedBlock>>,
         target_stream: &mut mpsc::Receiver<StreamerMessage>,
         db: &DB,
-        target_view_client: &MultithreadRuntimeHandle<ViewClientActorInner>,
-        target_client: &TokioRuntimeHandle<ClientActorInner>,
+        target_view_client: &MultithreadRuntimeHandle<ViewClientActor>,
+        target_client: &TokioRuntimeHandle<ClientActor>,
     ) -> anyhow::Result<(BlockHeight, CryptoHash)> {
         let mut head = None;
 

--- a/tools/mirror/src/online.rs
+++ b/tools/mirror/src/online.rs
@@ -5,7 +5,7 @@ use near_async::ActorSystem;
 use near_async::messaging::CanSendAsync;
 use near_async::multithread::MultithreadRuntimeHandle;
 use near_chain_configs::GenesisValidationMode;
-use near_client::ViewClientActorInner;
+use near_client::ViewClientActor;
 use near_client_primitives::types::{
     GetBlock, GetBlockError, GetChunkError, GetExecutionOutcome, GetReceipt, GetShardChunk, Query,
 };
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 pub(crate) struct ChainAccess {
-    view_client: MultithreadRuntimeHandle<ViewClientActorInner>,
+    view_client: MultithreadRuntimeHandle<ViewClientActor>,
 }
 
 impl ChainAccess {


### PR DESCRIPTION
Standardizes actor struct naming by adding consistent 'Actor' suffix.

Renames:
- `ClientActorInner` → `ClientActor`
- `ViewClientActorInner` → `ViewClientActor`
- `ChunkValidationActorInner` → `ChunkValidationActor`
- `ChunkEndorsementHandler` → `ChunkEndorsementHandlerActor`
- `RpcHandler` → `RpcHandlerActor`
- `GeneratorActorImpl` → `GeneratorActor`

This improves naming consistency across the codebase.