### PR TITLE
Revert "refactor: move reward values from genesis to epoch config"

### DIFF
--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -1072,6 +1072,7 @@ mod tests {
             90,
             90,
             0,
+            default_reward_calculator(),
             Rational32::new(0, 1),
         )
         .into_handle();

--- a/chain/epoch-manager/src/genesis.rs
+++ b/chain/epoch-manager/src/genesis.rs
@@ -22,9 +22,8 @@ impl EpochManager {
     pub fn initialize_genesis_epoch_info(
         &mut self,
         validators: Vec<ValidatorStake>,
-        treasury_account: AccountId,
     ) -> Result<(), EpochError> {
-        let genesis_epoch_info = self.make_genesis_epoch_info(validators, treasury_account)?;
+        let genesis_epoch_info = self.make_genesis_epoch_info(validators)?;
         // Dummy block info.
         // Artificial block we add to simplify implementation: dummy block is the
         // parent of genesis block that points to itself.
@@ -41,12 +40,14 @@ impl EpochManager {
     fn make_genesis_epoch_info(
         &self,
         validators: Vec<ValidatorStake>,
-        treasury_account: AccountId,
     ) -> Result<EpochInfo, EpochError> {
         // Missing genesis epoch, means that there is no validator initialize yet.
         let genesis_protocol_version = self.config.genesis_protocol_version();
         let genesis_epoch_config = self.config.for_protocol_version(genesis_protocol_version);
-        let validator_reward = HashMap::from([(treasury_account, Balance::ZERO)]);
+        let validator_reward = HashMap::from([(
+            self.reward_calculator.protocol_treasury_account.clone(),
+            Balance::ZERO,
+        )]);
 
         // use custom code for genesis protocol version 29 used in mainnet and testnet
         if genesis_protocol_version == PROD_GENESIS_PROTOCOL_VERSION {
@@ -54,7 +55,7 @@ impl EpochManager {
                 Self::prod_genesis(&genesis_epoch_config, [0; 32], validators, validator_reward);
             let digest = CryptoHash::hash_borsh(&genesis_epoch_info).to_string();
             if self.config.chain_id() == MAINNET {
-                assert_eq!(digest, "3jPL9nxi6A4Zzf1ptnBePJeitb6HeV5ShuRr4XVGv7wq");
+                assert_eq!(digest, "Hsc6BpTrd77H7J29w8uLXQY7bhfQzRDcFyo8Dj2CMZCj");
             }
             if self.config.chain_id() == TESTNET {
                 assert_eq!(digest, "6oVGdXcDaLErQ3nHRgZVZVHPkV5gfBjVtYkjWrByrb53");

--- a/chain/epoch-manager/src/lib.rs
+++ b/chain/epoch-manager/src/lib.rs
@@ -3,6 +3,7 @@
 pub use crate::adapter::EpochManagerAdapter;
 use crate::metrics::{PROTOCOL_VERSION_NEXT, PROTOCOL_VERSION_VOTES};
 pub use crate::reward_calculator::NUM_SECONDS_IN_A_YEAR;
+pub use crate::reward_calculator::RewardCalculator;
 use epoch_info_aggregator::EpochInfoAggregator;
 use itertools::Itertools;
 use near_cache::SyncLruCache;
@@ -34,7 +35,7 @@ use near_store::{DBCol, HEADER_HEAD_KEY, Store, StoreUpdate};
 use num_rational::BigRational;
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use primitive_types::U256;
-use reward_calculator::calculate_reward;
+use reward_calculator::ValidatorOnlineThresholds;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
@@ -121,6 +122,7 @@ pub struct EpochManager {
     store: Store,
     /// Current epoch config.
     config: AllEpochConfig,
+    reward_calculator: RewardCalculator,
 
     /// Cache of epoch information.
     epochs_info: SyncLruCache<EpochId, Arc<EpochInfo>>,
@@ -204,6 +206,7 @@ impl EpochManager {
         epoch_config_store: EpochConfigStore,
     ) -> Arc<EpochManagerHandle> {
         let epoch_length = genesis_config.epoch_length;
+        let reward_calculator = RewardCalculator::new(genesis_config, epoch_length);
         let all_epoch_config = AllEpochConfig::from_epoch_config_store(
             genesis_config.chain_id.as_str(),
             epoch_length,
@@ -211,22 +214,24 @@ impl EpochManager {
             genesis_config.protocol_version,
         );
         Arc::new(
-            Self::new(store, all_epoch_config, genesis_config.validators()).unwrap().into_handle(),
+            Self::new(store, all_epoch_config, reward_calculator, genesis_config.validators())
+                .unwrap()
+                .into_handle(),
         )
     }
 
     pub fn new(
         store: Store,
         config: AllEpochConfig,
+        reward_calculator: RewardCalculator,
         validators: Vec<ValidatorStake>,
     ) -> Result<Self, EpochError> {
         let epoch_info_aggregator =
             store.get_ser(DBCol::EpochInfo, AGGREGATOR_KEY)?.unwrap_or_default();
-        let genesis = config.genesis_protocol_version();
-        let treasury_account = config.for_protocol_version(genesis).protocol_treasury_account;
         let mut epoch_manager = EpochManager {
             store,
             config,
+            reward_calculator,
             epochs_info: SyncLruCache::new(EPOCH_CACHE_SIZE),
             blocks_info: SyncLruCache::new(BLOCK_CACHE_SIZE),
             epoch_id_to_start: SyncLruCache::new(EPOCH_CACHE_SIZE),
@@ -240,7 +245,7 @@ impl EpochManager {
             largest_final_height: 0,
         };
         if !epoch_manager.has_epoch_info(&EpochId::default())? {
-            epoch_manager.initialize_genesis_epoch_info(validators, treasury_account)?;
+            epoch_manager.initialize_genesis_epoch_info(validators)?;
         }
         Ok(epoch_manager)
     }
@@ -655,12 +660,23 @@ impl EpochManager {
                 }
             }
             let epoch_config = self.get_epoch_config(epoch_protocol_version);
-            calculate_reward(
+            // If ChunkEndorsementsInBlockHeader feature is enabled, we use the chunk validator kickout threshold
+            // as the cutoff threshold for the endorsement ratio to remap the ratio to 0 or 1.
+            let online_thresholds = ValidatorOnlineThresholds {
+                online_min_threshold: epoch_config.online_min_threshold,
+                online_max_threshold: epoch_config.online_max_threshold,
+                endorsement_cutoff_threshold: Some(
+                    epoch_config.chunk_validator_only_kickout_threshold,
+                ),
+            };
+            self.reward_calculator.calculate_reward(
                 validator_block_chunk_stats,
                 &validator_stake,
                 *block_info.total_supply(),
+                epoch_protocol_version,
                 epoch_duration,
-                &epoch_config,
+                online_thresholds,
+                epoch_config.max_inflation_rate,
             )
         };
         let next_next_epoch_config = self.config.for_protocol_version(next_next_epoch_version);

--- a/chain/epoch-manager/src/reward_calculator.rs
+++ b/chain/epoch-manager/src/reward_calculator.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 
-use near_primitives::epoch_manager::EpochConfig;
-use near_primitives::types::{AccountId, Balance, BlockChunkValidatorStats};
 use num_rational::Rational32;
 use primitive_types::{U256, U512};
+
+use near_chain_configs::GenesisConfig;
+use near_primitives::types::{AccountId, Balance, BlockChunkValidatorStats};
+use near_primitives::version::{PROD_GENESIS_PROTOCOL_VERSION, ProtocolVersion};
 
 use crate::validator_stats::get_validator_online_ratio;
 
@@ -12,7 +14,7 @@ pub const NUM_SECONDS_IN_A_YEAR: u64 = 24 * 60 * 60 * 365;
 
 /// Contains online thresholds for validators.
 #[derive(Clone, Debug)]
-struct ValidatorOnlineThresholds {
+pub struct ValidatorOnlineThresholds {
     /// Online minimum threshold below which validator doesn't receive reward.
     pub online_min_threshold: Rational32,
     /// Online maximum threshold above which validator gets full reward.
@@ -24,95 +26,127 @@ struct ValidatorOnlineThresholds {
     pub endorsement_cutoff_threshold: Option<u8>,
 }
 
-/// Calculate validator reward for an epoch based on their block and chunk production stats.
-/// Returns map of validators with their rewards and amount of newly minted tokens including to protocol's treasury.
-/// See spec <https://nomicon.io/Economics/Economic#validator-rewards-calculation>.
-pub fn calculate_reward(
-    validator_block_chunk_stats: HashMap<AccountId, BlockChunkValidatorStats>,
-    validator_stake: &HashMap<AccountId, Balance>,
-    total_supply: Balance,
-    epoch_duration_ns: u64,
-    epoch_config: &EpochConfig,
-) -> (HashMap<AccountId, Balance>, Balance) {
-    let online_thresholds = ValidatorOnlineThresholds {
-        online_min_threshold: epoch_config.online_min_threshold,
-        online_max_threshold: epoch_config.online_max_threshold,
-        endorsement_cutoff_threshold: Some(epoch_config.chunk_validator_only_kickout_threshold),
-    };
-    let mut res = HashMap::new();
-    let num_validators = validator_block_chunk_stats.len();
-    let epoch_total_reward = Balance::from_yoctonear(
-        (U256::from(*epoch_config.max_inflation_rate.numer() as u64)
-            * U256::from(total_supply.as_yoctonear())
-            * U256::from(epoch_duration_ns)
-            / (U256::from(NUM_SECONDS_IN_A_YEAR)
-                * U256::from(*epoch_config.max_inflation_rate.denom() as u64)
-                * U256::from(NUM_NS_IN_SECOND)))
-        .as_u128(),
-    );
-    let epoch_protocol_treasury = Balance::from_yoctonear(
-        (U256::from(epoch_total_reward.as_yoctonear())
-            * U256::from(*epoch_config.protocol_reward_rate.numer() as u64)
-            / U256::from(*epoch_config.protocol_reward_rate.denom() as u64))
-        .as_u128(),
-    );
-    res.insert(epoch_config.protocol_treasury_account.clone(), epoch_protocol_treasury);
-    if num_validators == 0 {
-        return (res, Balance::ZERO);
+#[derive(Clone, Debug)]
+pub struct RewardCalculator {
+    pub num_blocks_per_year: u64,
+    pub epoch_length: u64,
+    pub protocol_reward_rate: Rational32,
+    pub protocol_treasury_account: AccountId,
+    pub num_seconds_per_year: u64,
+    pub genesis_protocol_version: ProtocolVersion,
+}
+
+impl RewardCalculator {
+    pub fn new(config: &GenesisConfig, epoch_length: u64) -> Self {
+        RewardCalculator {
+            num_blocks_per_year: config.num_blocks_per_year,
+            epoch_length,
+            protocol_reward_rate: config.protocol_reward_rate,
+            protocol_treasury_account: config.protocol_treasury_account.clone(),
+            num_seconds_per_year: NUM_SECONDS_IN_A_YEAR,
+            genesis_protocol_version: config.protocol_version,
+        }
     }
-    let epoch_validator_reward = epoch_total_reward.checked_sub(epoch_protocol_treasury).unwrap();
-    let mut epoch_actual_reward = epoch_protocol_treasury;
-    let total_stake: Balance =
-        validator_stake.values().fold(Balance::ZERO, |sum, item| sum.checked_add(*item).unwrap());
-    for (account_id, stats) in validator_block_chunk_stats {
-        let production_ratio =
-            get_validator_online_ratio(&stats, online_thresholds.endorsement_cutoff_threshold);
-        let average_produced_numer = production_ratio.numer();
-        let average_produced_denom = production_ratio.denom();
 
-        let expected_blocks = stats.block_stats.expected;
-        let expected_chunks = stats.chunk_stats.expected();
-        let expected_endorsements = stats.chunk_stats.endorsement_stats().expected;
-
-        let online_min_numer = U256::from(*online_thresholds.online_min_threshold.numer() as u64);
-        let online_min_denom = U256::from(*online_thresholds.online_min_threshold.denom() as u64);
-        // If average of produced blocks below online min threshold, validator gets 0 reward.
-        let reward = if average_produced_numer * online_min_denom
-            < online_min_numer * average_produced_denom
-            || (expected_chunks == 0 && expected_blocks == 0 && expected_endorsements == 0)
-        {
-            Balance::ZERO
+    /// Calculate validator reward for an epoch based on their block and chunk production stats.
+    /// Returns map of validators with their rewards and amount of newly minted tokens including to protocol's treasury.
+    /// See spec <https://nomicon.io/Economics/Economic#validator-rewards-calculation>.
+    pub fn calculate_reward(
+        &self,
+        validator_block_chunk_stats: HashMap<AccountId, BlockChunkValidatorStats>,
+        validator_stake: &HashMap<AccountId, Balance>,
+        total_supply: Balance,
+        _protocol_version: ProtocolVersion,
+        epoch_duration: u64,
+        online_thresholds: ValidatorOnlineThresholds,
+        max_inflation_rate: Rational32,
+    ) -> (HashMap<AccountId, Balance>, Balance) {
+        let mut res = HashMap::new();
+        let num_validators = validator_block_chunk_stats.len();
+        let use_hardcoded_value = self.genesis_protocol_version == PROD_GENESIS_PROTOCOL_VERSION;
+        let protocol_reward_rate = if use_hardcoded_value {
+            Rational32::new_raw(1, 10)
         } else {
-            // cspell:ignore denum
-            let stake = *validator_stake
-                .get(&account_id)
-                .unwrap_or_else(|| panic!("{} is not a validator", account_id));
-            // Online reward multiplier is min(1., (uptime - online_threshold_min) / (online_threshold_max - online_threshold_min).
-            let online_max_numer =
-                U256::from(*online_thresholds.online_max_threshold.numer() as u64);
-            let online_max_denom =
-                U256::from(*online_thresholds.online_max_threshold.denom() as u64);
-            let online_numer =
-                online_max_numer * online_min_denom - online_min_numer * online_max_denom;
-            let mut uptime_numer = (average_produced_numer * online_min_denom
-                - online_min_numer * average_produced_denom)
-                * online_max_denom;
-            let uptime_denum = online_numer * average_produced_denom;
-            // Apply min between 1. and computed uptime.
-            uptime_numer = if uptime_numer > uptime_denum { uptime_denum } else { uptime_numer };
-            Balance::from_yoctonear(
-                (U512::from(epoch_validator_reward.as_yoctonear())
-                    * U512::from(uptime_numer)
-                    * U512::from(stake.as_yoctonear())
-                    / U512::from(uptime_denum)
-                    / U512::from(total_stake.as_yoctonear()))
-                .as_u128(),
-            )
+            self.protocol_reward_rate
         };
-        res.insert(account_id, reward);
-        epoch_actual_reward = epoch_actual_reward.checked_add(reward).unwrap();
+        let epoch_total_reward = Balance::from_yoctonear(
+            (U256::from(*max_inflation_rate.numer() as u64)
+                * U256::from(total_supply.as_yoctonear())
+                * U256::from(epoch_duration)
+                / (U256::from(self.num_seconds_per_year)
+                    * U256::from(*max_inflation_rate.denom() as u64)
+                    * U256::from(NUM_NS_IN_SECOND)))
+            .as_u128(),
+        );
+        let epoch_protocol_treasury = Balance::from_yoctonear(
+            (U256::from(epoch_total_reward.as_yoctonear())
+                * U256::from(*protocol_reward_rate.numer() as u64)
+                / U256::from(*protocol_reward_rate.denom() as u64))
+            .as_u128(),
+        );
+        res.insert(self.protocol_treasury_account.clone(), epoch_protocol_treasury);
+        if num_validators == 0 {
+            return (res, Balance::ZERO);
+        }
+        let epoch_validator_reward =
+            epoch_total_reward.checked_sub(epoch_protocol_treasury).unwrap();
+        let mut epoch_actual_reward = epoch_protocol_treasury;
+        let total_stake: Balance = validator_stake
+            .values()
+            .fold(Balance::ZERO, |sum, item| sum.checked_add(*item).unwrap());
+        for (account_id, stats) in validator_block_chunk_stats {
+            let production_ratio =
+                get_validator_online_ratio(&stats, online_thresholds.endorsement_cutoff_threshold);
+            let average_produced_numer = production_ratio.numer();
+            let average_produced_denom = production_ratio.denom();
+
+            let expected_blocks = stats.block_stats.expected;
+            let expected_chunks = stats.chunk_stats.expected();
+            let expected_endorsements = stats.chunk_stats.endorsement_stats().expected;
+
+            let online_min_numer =
+                U256::from(*online_thresholds.online_min_threshold.numer() as u64);
+            let online_min_denom =
+                U256::from(*online_thresholds.online_min_threshold.denom() as u64);
+            // If average of produced blocks below online min threshold, validator gets 0 reward.
+            let reward = if average_produced_numer * online_min_denom
+                < online_min_numer * average_produced_denom
+                || (expected_chunks == 0 && expected_blocks == 0 && expected_endorsements == 0)
+            {
+                Balance::ZERO
+            } else {
+                // cspell:ignore denum
+                let stake = *validator_stake
+                    .get(&account_id)
+                    .unwrap_or_else(|| panic!("{} is not a validator", account_id));
+                // Online reward multiplier is min(1., (uptime - online_threshold_min) / (online_threshold_max - online_threshold_min).
+                let online_max_numer =
+                    U256::from(*online_thresholds.online_max_threshold.numer() as u64);
+                let online_max_denom =
+                    U256::from(*online_thresholds.online_max_threshold.denom() as u64);
+                let online_numer =
+                    online_max_numer * online_min_denom - online_min_numer * online_max_denom;
+                let mut uptime_numer = (average_produced_numer * online_min_denom
+                    - online_min_numer * average_produced_denom)
+                    * online_max_denom;
+                let uptime_denum = online_numer * average_produced_denom;
+                // Apply min between 1. and computed uptime.
+                uptime_numer =
+                    if uptime_numer > uptime_denum { uptime_denum } else { uptime_numer };
+                Balance::from_yoctonear(
+                    (U512::from(epoch_validator_reward.as_yoctonear())
+                        * U512::from(uptime_numer)
+                        * U512::from(stake.as_yoctonear())
+                        / U512::from(uptime_denum)
+                        / U512::from(total_stake.as_yoctonear()))
+                    .as_u128(),
+                )
+            };
+            res.insert(account_id, reward);
+            epoch_actual_reward = epoch_actual_reward.checked_add(reward).unwrap();
+        }
+        (res, epoch_actual_reward)
     }
-    (res, epoch_actual_reward)
 }
 
 #[cfg(test)]
@@ -120,33 +154,22 @@ mod tests {
     use super::*;
     use near_primitives::epoch_manager::EpochConfigStore;
     use near_primitives::types::{BlockChunkValidatorStats, ChunkStats, ValidatorStats};
+    use near_primitives::version::{PROD_GENESIS_PROTOCOL_VERSION, PROTOCOL_VERSION};
     use num_rational::Ratio;
     use std::collections::HashMap;
-
-    fn default_epoch_length_and_duration() -> (u64, u64) {
-        (1000, NUM_NS_IN_SECOND * NUM_SECONDS_IN_A_YEAR)
-    }
-
-    fn create_test_epoch_config(
-        epoch_length: u64,
-        max_inflation_rate: Ratio<i32>,
-        chunk_validator_only_kickout_threshold: u8,
-    ) -> EpochConfig {
-        let mut epoch_config = EpochConfig::minimal();
-        epoch_config.epoch_length = epoch_length;
-        epoch_config.max_inflation_rate = max_inflation_rate;
-        epoch_config.protocol_reward_rate = Ratio::new(0, 1);
-        epoch_config.online_min_threshold = Ratio::new(9, 10);
-        epoch_config.online_max_threshold = Ratio::new(99, 100);
-        epoch_config.chunk_validator_only_kickout_threshold =
-            chunk_validator_only_kickout_threshold;
-
-        epoch_config
-    }
 
     #[test]
     fn test_zero_produced_and_expected() {
         let epoch_length = 1;
+        let max_inflation_rate = Ratio::new(0, 1);
+        let reward_calculator = RewardCalculator {
+            num_blocks_per_year: 1000000,
+            epoch_length,
+            protocol_reward_rate: Ratio::new(0, 1),
+            protocol_treasury_account: "near".parse().unwrap(),
+            num_seconds_per_year: 1000000,
+            genesis_protocol_version: PROTOCOL_VERSION,
+        };
         let validator_block_chunk_stats = HashMap::from([
             (
                 "test1".parse().unwrap(),
@@ -168,13 +191,18 @@ mod tests {
             ("test2".parse().unwrap(), Balance::from_yoctonear(100)),
         ]);
         let total_supply = Balance::from_yoctonear(1_000_000_000_000);
-        let epoch_config = create_test_epoch_config(epoch_length, Ratio::new(0, 1), 0);
-        let result = calculate_reward(
+        let result = reward_calculator.calculate_reward(
             validator_block_chunk_stats,
             &validator_stake,
             total_supply,
+            PROTOCOL_VERSION,
             epoch_length * NUM_NS_IN_SECOND,
-            &epoch_config,
+            ValidatorOnlineThresholds {
+                online_min_threshold: Ratio::new(9, 10),
+                online_max_threshold: Ratio::new(1, 1),
+                endorsement_cutoff_threshold: None,
+            },
+            max_inflation_rate,
         );
         assert_eq!(
             result.0,
@@ -189,8 +217,16 @@ mod tests {
     /// Test reward calculation when validators are not fully online.
     #[test]
     fn test_reward_validator_different_online() {
-        let (epoch_length, epoch_duration) = default_epoch_length_and_duration();
+        let epoch_length = 1000;
         let max_inflation_rate = Ratio::new(1, 100);
+        let reward_calculator = RewardCalculator {
+            num_blocks_per_year: 1000,
+            epoch_length,
+            protocol_reward_rate: Ratio::new(0, 10),
+            protocol_treasury_account: "near".parse().unwrap(),
+            num_seconds_per_year: 1000,
+            genesis_protocol_version: PROTOCOL_VERSION,
+        };
         let validator_block_chunk_stats = HashMap::from([
             (
                 "test1".parse().unwrap(),
@@ -220,13 +256,18 @@ mod tests {
             ("test3".parse().unwrap(), Balance::from_yoctonear(500_000)),
         ]);
         let total_supply = Balance::from_yoctonear(1_000_000_000);
-        let epoch_config = create_test_epoch_config(epoch_length, max_inflation_rate, 0);
-        let result = calculate_reward(
+        let result = reward_calculator.calculate_reward(
             validator_block_chunk_stats,
             &validator_stake,
             total_supply,
-            epoch_duration,
-            &epoch_config,
+            PROTOCOL_VERSION,
+            epoch_length * NUM_NS_IN_SECOND,
+            ValidatorOnlineThresholds {
+                online_min_threshold: Ratio::new(9, 10),
+                online_max_threshold: Ratio::new(99, 100),
+                endorsement_cutoff_threshold: None,
+            },
+            max_inflation_rate,
         );
         // Total reward is 10_000_000. Divided by 3 equal stake validators - each gets 3_333_333.
         // test1 with 94.5% online gets 50% because of linear between (0.99-0.9) online.
@@ -245,8 +286,16 @@ mod tests {
     /// Test reward calculation for chunk only or block only producers
     #[test]
     fn test_reward_chunk_only_producer() {
-        let (epoch_length, epoch_duration) = default_epoch_length_and_duration();
+        let epoch_length = 1000;
         let max_inflation_rate = Ratio::new(1, 100);
+        let reward_calculator = RewardCalculator {
+            num_blocks_per_year: 1000,
+            epoch_length,
+            protocol_reward_rate: Ratio::new(0, 10),
+            protocol_treasury_account: "near".parse().unwrap(),
+            num_seconds_per_year: 1000,
+            genesis_protocol_version: PROTOCOL_VERSION,
+        };
         let validator_block_chunk_stats = HashMap::from([
             (
                 "test1".parse().unwrap(),
@@ -288,13 +337,18 @@ mod tests {
             ("test4".parse().unwrap(), Balance::from_yoctonear(500_000)),
         ]);
         let total_supply = Balance::from_yoctonear(1_000_000_000);
-        let epoch_config = create_test_epoch_config(epoch_length, max_inflation_rate, 0);
-        let result = calculate_reward(
+        let result = reward_calculator.calculate_reward(
             validator_block_chunk_stats,
             &validator_stake,
             total_supply,
-            epoch_duration,
-            &epoch_config,
+            PROTOCOL_VERSION,
+            epoch_length * NUM_NS_IN_SECOND,
+            ValidatorOnlineThresholds {
+                online_min_threshold: Ratio::new(9, 10),
+                online_max_threshold: Ratio::new(99, 100),
+                endorsement_cutoff_threshold: None,
+            },
+            max_inflation_rate,
         );
         // Total reward is 10_000_000. Divided by 4 equal stake validators - each gets 2_500_000.
         // test1 with 94.5% online gets 50% because of linear between (0.99-0.9) online.
@@ -315,8 +369,16 @@ mod tests {
 
     #[test]
     fn test_reward_stateless_validation() {
-        let (epoch_length, epoch_duration) = default_epoch_length_and_duration();
+        let epoch_length = 1000;
         let max_inflation_rate = Ratio::new(1, 100);
+        let reward_calculator = RewardCalculator {
+            num_blocks_per_year: 1000,
+            epoch_length,
+            protocol_reward_rate: Ratio::new(0, 10),
+            protocol_treasury_account: "near".parse().unwrap(),
+            num_seconds_per_year: 1000,
+            genesis_protocol_version: PROTOCOL_VERSION,
+        };
         let validator_block_chunk_stats = HashMap::from([
             // Blocks, chunks, endorsements
             (
@@ -364,34 +426,48 @@ mod tests {
             ("test4".parse().unwrap(), Balance::from_yoctonear(500_000)),
         ]);
         let total_supply = Balance::from_yoctonear(1_000_000_000);
-        let epoch_config = create_test_epoch_config(epoch_length, max_inflation_rate, 0);
-        let result = calculate_reward(
+        let result = reward_calculator.calculate_reward(
             validator_block_chunk_stats,
             &validator_stake,
             total_supply,
-            epoch_duration,
-            &epoch_config,
+            PROTOCOL_VERSION,
+            epoch_length * NUM_NS_IN_SECOND,
+            ValidatorOnlineThresholds {
+                online_min_threshold: Ratio::new(9, 10),
+                online_max_threshold: Ratio::new(99, 100),
+                endorsement_cutoff_threshold: None,
+            },
+            max_inflation_rate,
         );
         // Total reward is 10_000_000. Divided by 4 equal stake validators - each gets 2_500_000.
+        // test1 with 94.5% online gets 50% because of linear between (0.99-0.9) online.
         {
             assert_eq!(
                 result.0,
                 HashMap::from([
                     ("near".parse().unwrap(), Balance::ZERO),
-                    ("test1".parse().unwrap(), Balance::from_yoctonear(1_750_000)),
+                    ("test1".parse().unwrap(), Balance::from_yoctonear(1_250_000)),
                     ("test2".parse().unwrap(), Balance::from_yoctonear(2_500_000)),
-                    ("test3".parse().unwrap(), Balance::from_yoctonear(1_944_444)),
+                    ("test3".parse().unwrap(), Balance::from_yoctonear(1_250_000)),
                     ("test4".parse().unwrap(), Balance::from_yoctonear(2_500_000))
                 ])
             );
-            assert_eq!(result.1, Balance::from_yoctonear(8_694_444));
+            assert_eq!(result.1, Balance::from_yoctonear(7_500_000));
         }
     }
 
     #[test]
     fn test_reward_stateless_validation_with_endorsement_cutoff() {
-        let (epoch_length, epoch_duration) = default_epoch_length_and_duration();
+        let epoch_length = 1000;
         let max_inflation_rate = Ratio::new(1, 100);
+        let reward_calculator = RewardCalculator {
+            num_blocks_per_year: 1000,
+            epoch_length,
+            protocol_reward_rate: Ratio::new(0, 10),
+            protocol_treasury_account: "near".parse().unwrap(),
+            num_seconds_per_year: 1000,
+            genesis_protocol_version: PROTOCOL_VERSION,
+        };
         let validator_block_chunk_stats = HashMap::from([
             // Blocks, chunks, endorsements - endorsement ratio cutoff is exceeded
             (
@@ -439,13 +515,18 @@ mod tests {
             ("test4".parse().unwrap(), Balance::from_yoctonear(500_000)),
         ]);
         let total_supply = Balance::from_yoctonear(1_000_000_000);
-        let epoch_config = create_test_epoch_config(epoch_length, max_inflation_rate, 50);
-        let result = calculate_reward(
+        let result = reward_calculator.calculate_reward(
             validator_block_chunk_stats,
             &validator_stake,
             total_supply,
-            epoch_duration,
-            &epoch_config,
+            PROTOCOL_VERSION,
+            epoch_length * NUM_NS_IN_SECOND,
+            ValidatorOnlineThresholds {
+                online_min_threshold: Ratio::new(9, 10),
+                online_max_threshold: Ratio::new(99, 100),
+                endorsement_cutoff_threshold: Some(50),
+            },
+            max_inflation_rate,
         );
         // "test2" does not get reward since its uptime ratio goes below online_min_threshold,
         // because its endorsement ratio is below the cutoff threshold.
@@ -470,6 +551,16 @@ mod tests {
     #[test]
     fn test_reward_no_overflow() {
         let epoch_length = 60 * 60 * 12;
+        let max_inflation_rate = Ratio::new(1, 40);
+        let reward_calculator = RewardCalculator {
+            num_blocks_per_year: 60 * 60 * 24 * 365,
+            // half a day
+            epoch_length,
+            protocol_reward_rate: Ratio::new(1, 10),
+            protocol_treasury_account: "near".parse().unwrap(),
+            num_seconds_per_year: 60 * 60 * 24 * 365,
+            genesis_protocol_version: PROTOCOL_VERSION,
+        };
         let validator_block_chunk_stats = HashMap::from([(
             "test".parse().unwrap(),
             BlockChunkValidatorStats {
@@ -484,42 +575,44 @@ mod tests {
             HashMap::from([("test".parse().unwrap(), Balance::from_near(500_000))]);
         // some hypothetical large total supply (100b)
         let total_supply = Balance::from_near(100_000_000_000);
-        let epoch_duration = epoch_length * NUM_NS_IN_SECOND;
-        let epoch_config = create_test_epoch_config(epoch_length, Ratio::new(1, 40), 0);
-        calculate_reward(
+        reward_calculator.calculate_reward(
             validator_block_chunk_stats,
             &validator_stake,
             total_supply,
-            epoch_duration,
-            &epoch_config,
+            PROTOCOL_VERSION,
+            epoch_length * NUM_NS_IN_SECOND,
+            ValidatorOnlineThresholds {
+                online_min_threshold: Ratio::new(9, 10),
+                online_max_threshold: Ratio::new(1, 1),
+                endorsement_cutoff_threshold: None,
+            },
+            max_inflation_rate,
         );
     }
 
     #[test]
     fn test_adjust_max_inflation() {
+        let epoch_length = 1;
         let account_id: AccountId = "test1".parse().unwrap();
+        let reward_calculator = RewardCalculator {
+            num_blocks_per_year: 1000000,
+            epoch_length,
+            protocol_reward_rate: Ratio::new(0, 1), // Unused, would only be used for genesis_protocol_version
+            protocol_treasury_account: "near".parse().unwrap(),
+            num_seconds_per_year: 1000000,
+            genesis_protocol_version: PROD_GENESIS_PROTOCOL_VERSION,
+        };
         let validator_stake = HashMap::from([(account_id.clone(), Balance::from_near(100))]);
         let total_supply = Balance::from_near(1_000_000_000);
-
-        // Expected reward for protocol version 80, calculated using the reward formula:
-        // epoch_total_reward = max_inflation_rate * total_supply * epoch_duration_ns / NUM_SECONDS_IN_A_YEAR / NUM_NS_IN_SECOND
-        // With parameters:
-        // - total_supply = 1_000_000_000 NEAR = 1_000_000_000_000_000_000_000_000_000 yoctoNEAR
-        // - epoch_duration_ns = NUM_NS_IN_SECOND = 1_000_000_000 (1 second)
-        // - max_inflation_rate = 1/20 = 0.05 (for protocol version 80)
-        // - NUM_SECONDS_IN_A_YEAR = 31_536_000
-        // Result: 0.05 * 1_000_000_000_000_000_000_000_000_000 * 1_000_000_000 / 31_536_000 / 1_000_000_000
-        //       = 1_585_489_599_188_229_325_215_626 yoctoNEAR
-        let reward = Balance::from_yoctonear(1_585_489_599_188_229_325_215_626);
 
         // Check rewards match the expected protocol version schedule.
         for chain_id in ["mainnet", "testnet"] {
             let epoch_configs = EpochConfigStore::for_chain_id(chain_id, None).unwrap();
             for (protocol_version, expected_total) in [
                 // Prior to inflation reduction
-                (80, reward),
+                (80, Balance::from_near(50)),
                 // After inflation reduction
-                (81, reward.saturating_div(2)),
+                (PROTOCOL_VERSION, Balance::from_near(25)),
             ] {
                 let epoch_config = epoch_configs.get_config(protocol_version);
                 let validator_block_chunk_stats = HashMap::from([(
@@ -529,13 +622,18 @@ mod tests {
                         chunk_stats: ChunkStats::default(),
                     },
                 )]);
-                let epoch_duration = NUM_NS_IN_SECOND;
-                let (rewards, total) = calculate_reward(
+                let (rewards, total) = reward_calculator.calculate_reward(
                     validator_block_chunk_stats,
                     &validator_stake,
                     total_supply,
-                    epoch_duration,
-                    &epoch_config,
+                    protocol_version,
+                    epoch_length * NUM_NS_IN_SECOND,
+                    ValidatorOnlineThresholds {
+                        online_min_threshold: Ratio::new(9, 10),
+                        online_max_threshold: Ratio::new(99, 100),
+                        endorsement_cutoff_threshold: None,
+                    },
+                    epoch_config.max_inflation_rate,
                 );
                 assert_eq!(expected_total, total);
                 let expected_protocol_reward = expected_total.checked_div(10).unwrap();
@@ -543,7 +641,7 @@ mod tests {
                     expected_total.checked_sub(expected_protocol_reward).unwrap();
                 assert_eq!(
                     Some(&expected_protocol_reward),
-                    rewards.get(&epoch_config.protocol_treasury_account),
+                    rewards.get(&reward_calculator.protocol_treasury_account),
                 );
                 assert_eq!(Some(&expected_validator_reward), rewards.get(&account_id));
             }

--- a/chain/epoch-manager/src/test_utils.rs
+++ b/chain/epoch-manager/src/test_utils.rs
@@ -1,3 +1,5 @@
+use crate::NUM_SECONDS_IN_A_YEAR;
+use crate::RewardCalculator;
 use crate::RngSeed;
 use crate::genesis::find_threshold;
 use crate::reward_calculator::NUM_NS_IN_SECOND;
@@ -164,8 +166,6 @@ pub fn epoch_config(
         shard_layout: ShardLayout::multi_shard(num_shards, 0),
         validator_max_kickout_stake_perc: 100,
         max_inflation_rate,
-        protocol_reward_rate: Ratio::new(1, 10),
-        protocol_treasury_account: "near".parse().unwrap(),
     };
     let config_store = EpochConfigStore::test_single_version(PROTOCOL_VERSION, epoch_config);
     AllEpochConfig::from_epoch_config_store(
@@ -181,6 +181,18 @@ pub fn stake(account_id: AccountId, amount: Balance) -> ValidatorStake {
     ValidatorStake::new(account_id, public_key, amount)
 }
 
+/// No-op reward calculator. Will produce no reward
+pub fn default_reward_calculator() -> RewardCalculator {
+    RewardCalculator {
+        num_blocks_per_year: 1,
+        epoch_length: 1,
+        protocol_reward_rate: Ratio::from_integer(0),
+        protocol_treasury_account: "near".parse().unwrap(),
+        num_seconds_per_year: NUM_SECONDS_IN_A_YEAR,
+        genesis_protocol_version: PROTOCOL_VERSION,
+    }
+}
+
 pub fn reward(info: Vec<(AccountId, Balance)>) -> HashMap<AccountId, Balance> {
     info.into_iter().collect()
 }
@@ -193,6 +205,7 @@ pub fn setup_epoch_manager(
     block_producer_kickout_threshold: u8,
     chunk_producer_kickout_threshold: u8,
     chunk_validator_only_kickout_threshold: u8,
+    reward_calculator: RewardCalculator,
     max_inflation_rate: Rational32,
 ) -> EpochManager {
     let store = create_test_store();
@@ -209,6 +222,7 @@ pub fn setup_epoch_manager(
     EpochManager::new(
         store,
         config,
+        reward_calculator,
         validators
             .iter()
             .map(|(account_id, balance)| stake(account_id.clone(), *balance))
@@ -233,6 +247,7 @@ pub fn setup_default_epoch_manager(
         block_producer_kickout_threshold,
         chunk_producer_kickout_threshold,
         0,
+        default_reward_calculator(),
         Ratio::new(0, 1),
     )
 }
@@ -278,6 +293,7 @@ pub fn setup_epoch_manager_with_block_and_chunk_producers(
     let epoch_manager = EpochManager::new(
         store,
         config,
+        default_reward_calculator(),
         validators
             .iter()
             .map(|(account_id, balance)| stake(account_id.clone(), *balance))

--- a/chain/epoch-manager/src/tests/mod.rs
+++ b/chain/epoch-manager/src/tests/mod.rs
@@ -1,12 +1,12 @@
 mod random_epochs;
 
 use super::*;
-use crate::reward_calculator::{NUM_NS_IN_SECOND, calculate_reward};
+use crate::reward_calculator::NUM_NS_IN_SECOND;
 use crate::test_utils::{
-    DEFAULT_TOTAL_SUPPLY, block_info, change_stake, epoch_config, epoch_info,
-    epoch_info_with_num_seats, hash_range, record_block, record_block_with_final_block_hash,
-    record_block_with_version, record_blocks, record_with_block_info, reward,
-    setup_default_epoch_manager, setup_epoch_manager, stake,
+    DEFAULT_TOTAL_SUPPLY, block_info, change_stake, default_reward_calculator, epoch_config,
+    epoch_info, epoch_info_with_num_seats, hash_range, record_block,
+    record_block_with_final_block_hash, record_block_with_version, record_blocks,
+    record_with_block_info, reward, setup_default_epoch_manager, setup_epoch_manager, stake,
 };
 use itertools::Itertools;
 use near_chain_configs::test_genesis::TestEpochConfigBuilder;
@@ -31,7 +31,7 @@ use near_primitives::validator_signer::ValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_store::ShardUId;
 use near_store::test_utils::create_test_store;
-use num_rational::Rational32;
+use num_rational::{Ratio, Rational32};
 use std::cmp::Ordering;
 use std::vec;
 
@@ -114,6 +114,7 @@ fn test_stake_validator() {
     let epoch_manager2 = EpochManager::new(
         epoch_manager.store.clone(),
         epoch_manager.config.clone(),
+        epoch_manager.reward_calculator,
         validators
             .iter()
             .map(|(account_id, balance)| stake(account_id.clone(), *balance))
@@ -128,8 +129,17 @@ fn test_validator_change_of_stake() {
     let amount_staked = Balance::from_yoctonear(1_000_000);
     let validators =
         vec![("test1".parse().unwrap(), amount_staked), ("test2".parse().unwrap(), amount_staked)];
-    let mut epoch_manager =
-        setup_epoch_manager(validators, 2, 1, 2, 90, 60, 0, Rational32::new(0, 1));
+    let mut epoch_manager = setup_epoch_manager(
+        validators,
+        2,
+        1,
+        2,
+        90,
+        60,
+        0,
+        default_reward_calculator(),
+        Rational32::new(0, 1),
+    );
 
     let h = hash_range(4);
     record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
@@ -364,7 +374,8 @@ fn test_validator_unstake() {
         stake("test1".parse().unwrap(), amount_staked),
         stake("test2".parse().unwrap(), amount_staked),
     ];
-    let mut epoch_manager = EpochManager::new(store, config, validators).unwrap();
+    let mut epoch_manager =
+        EpochManager::new(store, config, default_reward_calculator(), validators).unwrap();
     let h = hash_range(8);
     record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
     // test1 unstakes in epoch 1, and should be kicked out in epoch 3 (validators stored at h2).
@@ -471,8 +482,25 @@ fn test_validator_reward_one_validator() {
     let epoch_length = 2;
     let total_supply: Balance =
         validators.iter().fold(Balance::ZERO, |sum, (_, stake)| sum.checked_add(*stake).unwrap());
-    let mut epoch_manager =
-        setup_epoch_manager(validators, epoch_length, 1, 1, 90, 60, 0, Rational32::new(1, 40));
+    let reward_calculator = RewardCalculator {
+        num_blocks_per_year: 50,
+        epoch_length,
+        protocol_reward_rate: Ratio::new(1, 10),
+        protocol_treasury_account: "near".parse().unwrap(),
+        num_seconds_per_year: 50,
+        genesis_protocol_version: PROTOCOL_VERSION,
+    };
+    let mut epoch_manager = setup_epoch_manager(
+        validators,
+        epoch_length,
+        1,
+        1,
+        90,
+        60,
+        0,
+        reward_calculator.clone(),
+        Rational32::new(1, 40),
+    );
     let rng_seed = [0; 32];
     let h = hash_range(5);
 
@@ -514,13 +542,19 @@ fn test_validator_reward_one_validator() {
     let mut validator_stakes = HashMap::new();
     validator_stakes.insert("test2".parse().unwrap(), stake_amount);
 
-    let epoch_config = epoch_manager.get_epoch_config(PROTOCOL_VERSION);
-    let (validator_reward, inflation) = calculate_reward(
+    let max_inflation_rate = Ratio::new(1, 40);
+    let (validator_reward, inflation) = reward_calculator.calculate_reward(
         validator_online_ratio,
         &validator_stakes,
         total_supply,
+        PROTOCOL_VERSION,
         epoch_length * NUM_NS_IN_SECOND,
-        &epoch_config,
+        ValidatorOnlineThresholds {
+            online_min_threshold: Ratio::new(90, 100),
+            online_max_threshold: Ratio::new(99, 100),
+            endorsement_cutoff_threshold: None,
+        },
+        max_inflation_rate,
     );
     let test2_reward = *validator_reward.get(AccountIdRef::new_or_panic("test2")).unwrap();
     let protocol_reward = *validator_reward.get(AccountIdRef::new_or_panic("near")).unwrap();
@@ -551,8 +585,25 @@ fn test_validator_reward_weight_by_stake() {
         .unwrap()
         .checked_mul(validators.len().try_into().unwrap())
         .unwrap();
-    let mut epoch_manager =
-        setup_epoch_manager(validators, epoch_length, 1, 2, 90, 60, 0, Rational32::new(1, 40));
+    let reward_calculator = RewardCalculator {
+        num_blocks_per_year: 50,
+        epoch_length,
+        protocol_reward_rate: Ratio::new(1, 10),
+        protocol_treasury_account: "near".parse().unwrap(),
+        num_seconds_per_year: 50,
+        genesis_protocol_version: PROTOCOL_VERSION,
+    };
+    let mut epoch_manager = setup_epoch_manager(
+        validators,
+        epoch_length,
+        1,
+        2,
+        90,
+        60,
+        0,
+        reward_calculator.clone(),
+        Rational32::new(1, 40),
+    );
     let h = hash_range(5);
     record_with_block_info(
         &mut epoch_manager,
@@ -593,13 +644,19 @@ fn test_validator_reward_weight_by_stake() {
     let mut validators_stakes = HashMap::new();
     validators_stakes.insert("test1".parse().unwrap(), stake_amount1);
     validators_stakes.insert("test2".parse().unwrap(), stake_amount2);
-    let epoch_config = epoch_manager.get_epoch_config(PROTOCOL_VERSION);
-    let (validator_reward, inflation) = calculate_reward(
+    let max_inflation_rate = Ratio::new(1, 40);
+    let (validator_reward, inflation) = reward_calculator.calculate_reward(
         validator_online_ratio,
         &validators_stakes,
         total_supply,
+        PROTOCOL_VERSION,
         epoch_length * NUM_NS_IN_SECOND,
-        &epoch_config,
+        ValidatorOnlineThresholds {
+            online_min_threshold: Ratio::new(90, 100),
+            online_max_threshold: Ratio::new(99, 100),
+            endorsement_cutoff_threshold: None,
+        },
+        max_inflation_rate,
     );
     let test1_reward = *validator_reward.get(AccountIdRef::new_or_panic("test1")).unwrap();
     let test2_reward = *validator_reward.get(AccountIdRef::new_or_panic("test2")).unwrap();
@@ -640,6 +697,14 @@ fn test_reward_multiple_shards() {
         vec![("test1".parse().unwrap(), stake_amount), ("test2".parse().unwrap(), stake_amount)];
     let epoch_length = 10;
     let total_supply = stake_amount.checked_mul(validators.len().try_into().unwrap()).unwrap();
+    let reward_calculator = RewardCalculator {
+        num_blocks_per_year: 1_000_000,
+        epoch_length,
+        protocol_reward_rate: Ratio::new(1, 10),
+        protocol_treasury_account: "near".parse().unwrap(),
+        num_seconds_per_year: 1_000_000,
+        genesis_protocol_version: PROTOCOL_VERSION,
+    };
     let num_shards = 2;
     let epoch_manager = setup_epoch_manager(
         validators,
@@ -649,6 +714,7 @@ fn test_reward_multiple_shards() {
         90,
         60,
         0,
+        reward_calculator.clone(),
         Rational32::new(0, 1),
     )
     .into_handle();
@@ -704,13 +770,19 @@ fn test_reward_multiple_shards() {
     let mut validators_stakes = HashMap::new();
     validators_stakes.insert("test1".parse().unwrap(), stake_amount);
     validators_stakes.insert("test2".parse().unwrap(), stake_amount);
-    let epoch_config = epoch_manager.get_epoch_config(&init_epoch_id).unwrap();
-    let (validator_reward, inflation) = calculate_reward(
+    let max_inflation_rate = Ratio::new(1, 40);
+    let (validator_reward, inflation) = reward_calculator.calculate_reward(
         validator_online_ratio,
         &validators_stakes,
         total_supply,
+        PROTOCOL_VERSION,
         epoch_length * NUM_NS_IN_SECOND,
-        &epoch_config,
+        ValidatorOnlineThresholds {
+            online_min_threshold: Ratio::new(90, 100),
+            online_max_threshold: Ratio::new(99, 100),
+            endorsement_cutoff_threshold: None,
+        },
+        max_inflation_rate,
     );
     let test2_reward = *validator_reward.get(AccountIdRef::new_or_panic("test2")).unwrap();
     let protocol_reward = *validator_reward.get(AccountIdRef::new_or_panic("near")).unwrap();
@@ -800,7 +872,11 @@ fn test_expected_chunks() {
     let epoch_manager = EpochManager::new(
         create_test_store(),
         epoch_config,
-        validators.into_iter().map(|(account_id, balance)| stake(account_id, balance)).collect(),
+        default_reward_calculator(),
+        validators
+            .iter()
+            .map(|(account_id, balance)| stake(account_id.clone(), *balance))
+            .collect(),
     )
     .unwrap()
     .into_handle();
@@ -868,9 +944,18 @@ fn test_expected_chunks_prev_block_not_produced() {
     ];
     let epoch_length = 50;
     let total_supply = stake_amount.checked_mul(validators.len().try_into().unwrap()).unwrap();
-    let epoch_manager =
-        setup_epoch_manager(validators, epoch_length, 1, 3, 90, 90, 0, Rational32::new(0, 1))
-            .into_handle();
+    let epoch_manager = setup_epoch_manager(
+        validators,
+        epoch_length,
+        1,
+        3,
+        90,
+        90,
+        0,
+        default_reward_calculator(),
+        Rational32::new(0, 1),
+    )
+    .into_handle();
     let rng_seed = [0; 32];
     let hashes = hash_range((2 * epoch_length) as usize);
     record_block(&mut epoch_manager.write(), Default::default(), hashes[0], 0, vec![]);
@@ -957,8 +1042,26 @@ fn test_rewards_with_kickouts() {
         ("test3".parse().unwrap(), stake_amount),
     ];
     let epoch_length = 10;
-    let em = setup_epoch_manager(validators, epoch_length, 1, 3, 10, 10, 0, Rational32::new(1, 40))
-        .into_handle();
+    let reward_calculator = RewardCalculator {
+        num_blocks_per_year: 1,
+        epoch_length,
+        protocol_reward_rate: Ratio::new(1, 10),
+        protocol_treasury_account: "near".parse().unwrap(),
+        num_seconds_per_year: NUM_SECONDS_IN_A_YEAR,
+        genesis_protocol_version: PROTOCOL_VERSION,
+    };
+    let em = setup_epoch_manager(
+        validators,
+        epoch_length,
+        1,
+        3,
+        10,
+        10,
+        0,
+        reward_calculator,
+        Rational32::new(1, 40),
+    )
+    .into_handle();
 
     let mut height: BlockHeight = 0;
     let genesis_hash = hash(height.to_le_bytes().as_ref());
@@ -1070,8 +1173,17 @@ fn test_epoch_info_aggregator() {
     let validators =
         vec![("test1".parse().unwrap(), stake_amount), ("test2".parse().unwrap(), stake_amount)];
     let epoch_length = 5;
-    let mut em =
-        setup_epoch_manager(validators, epoch_length, 1, 2, 10, 10, 0, Rational32::new(0, 1));
+    let mut em = setup_epoch_manager(
+        validators,
+        epoch_length,
+        1,
+        2,
+        10,
+        10,
+        0,
+        default_reward_calculator(),
+        Rational32::new(0, 1),
+    );
     let h = hash_range(6);
     record_block(&mut em, Default::default(), h[0], 0, vec![]);
     record_block_with_final_block_hash(&mut em, h[0], h[1], h[0], 1, vec![]);
@@ -1106,8 +1218,17 @@ fn test_epoch_info_aggregator_data_loss() {
     let validators =
         vec![("test1".parse().unwrap(), stake_amount), ("test2".parse().unwrap(), stake_amount)];
     let epoch_length = 5;
-    let mut em =
-        setup_epoch_manager(validators, epoch_length, 1, 2, 10, 10, 0, Rational32::new(0, 1));
+    let mut em = setup_epoch_manager(
+        validators,
+        epoch_length,
+        1,
+        2,
+        10,
+        10,
+        0,
+        default_reward_calculator(),
+        Rational32::new(0, 1),
+    );
     let h = hash_range(6);
     record_block(&mut em, Default::default(), h[0], 0, vec![]);
     record_block(
@@ -1174,8 +1295,17 @@ fn test_epoch_info_aggregator_reorg_past_final_block() {
     let validators =
         vec![("test1".parse().unwrap(), stake_amount), ("test2".parse().unwrap(), stake_amount)];
     let epoch_length = 6;
-    let mut em =
-        setup_epoch_manager(validators, epoch_length, 1, 2, 10, 10, 0, Rational32::new(0, 1));
+    let mut em = setup_epoch_manager(
+        validators,
+        epoch_length,
+        1,
+        2,
+        10,
+        10,
+        0,
+        default_reward_calculator(),
+        Rational32::new(0, 1),
+    );
     let h = hash_range(6);
     record_block(&mut em, Default::default(), h[0], 0, vec![]);
     record_block_with_final_block_hash(&mut em, h[0], h[1], h[0], 1, vec![]);
@@ -1208,8 +1338,17 @@ fn test_epoch_info_aggregator_reorg_beginning_of_epoch() {
     let validators =
         vec![("test1".parse().unwrap(), stake_amount), ("test2".parse().unwrap(), stake_amount)];
     let epoch_length = 4;
-    let mut em =
-        setup_epoch_manager(validators, epoch_length, 1, 2, 10, 10, 0, Rational32::new(0, 1));
+    let mut em = setup_epoch_manager(
+        validators,
+        epoch_length,
+        1,
+        2,
+        10,
+        10,
+        0,
+        default_reward_calculator(),
+        Rational32::new(0, 1),
+    );
     let h = hash_range(10);
     record_block(&mut em, Default::default(), h[0], 0, vec![]);
     for i in 1..5 {
@@ -1291,8 +1430,18 @@ fn test_num_missing_blocks() {
     let validators =
         vec![("test1".parse().unwrap(), stake_amount), ("test2".parse().unwrap(), stake_amount)];
     let epoch_length = 2;
-    let em = setup_epoch_manager(validators, epoch_length, 1, 2, 10, 10, 0, Rational32::new(0, 1))
-        .into_handle();
+    let em = setup_epoch_manager(
+        validators,
+        epoch_length,
+        1,
+        2,
+        10,
+        10,
+        0,
+        default_reward_calculator(),
+        Rational32::new(0, 1),
+    )
+    .into_handle();
     let h = hash_range(8);
     record_block(&mut em.write(), Default::default(), h[0], 0, vec![]);
     record_block(&mut em.write(), h[0], h[1], 1, vec![]);
@@ -1338,8 +1487,18 @@ fn test_chunk_producer_kickout() {
         vec![("test1".parse().unwrap(), stake_amount), ("test2".parse().unwrap(), stake_amount)];
     let epoch_length = 10;
     let total_supply = stake_amount.checked_mul(validators.len().try_into().unwrap()).unwrap();
-    let em = setup_epoch_manager(validators, epoch_length, 4, 2, 90, 70, 0, Rational32::new(0, 1))
-        .into_handle();
+    let em = setup_epoch_manager(
+        validators,
+        epoch_length,
+        4,
+        2,
+        90,
+        70,
+        0,
+        default_reward_calculator(),
+        Rational32::new(0, 1),
+    )
+    .into_handle();
     let rng_seed = [0; 32];
     let hashes = hash_range((epoch_length + 2) as usize);
     record_block(&mut em.write(), Default::default(), hashes[0], 0, vec![]);
@@ -1419,6 +1578,7 @@ fn test_chunk_validator_kickout_using_production_stats() {
     let em = EpochManager::new(
         create_test_store(),
         epoch_config,
+        default_reward_calculator(),
         validators
             .iter()
             .map(|(account_id, balance)| stake(account_id.clone(), *balance))
@@ -1502,7 +1662,11 @@ fn test_chunk_validator_kickout_using_endorsement_stats() {
     let em = EpochManager::new(
         create_test_store(),
         epoch_config,
-        validators.into_iter().map(|(account_id, balance)| stake(account_id, balance)).collect(),
+        default_reward_calculator(),
+        validators
+            .iter()
+            .map(|(account_id, balance)| stake(account_id.clone(), *balance))
+            .collect(),
     )
     .unwrap()
     .into_handle();
@@ -1628,7 +1792,17 @@ fn test_fishermen() {
         ("test4".parse().unwrap(), fishermen_threshold.checked_div(2).unwrap()),
     ];
     let epoch_length = 4;
-    let em = setup_epoch_manager(validators, epoch_length, 1, 4, 90, 70, 0, Rational32::new(0, 1));
+    let em = setup_epoch_manager(
+        validators,
+        epoch_length,
+        1,
+        4,
+        90,
+        70,
+        0,
+        default_reward_calculator(),
+        Rational32::new(0, 1),
+    );
     let epoch_info = em.get_epoch_info(&EpochId::default()).unwrap();
     check_validators(&epoch_info, &[("test1", stake_amount), ("test2", stake_amount)]);
     check_stake_change(
@@ -1652,7 +1826,17 @@ fn test_fishermen_unstake() {
         ("test2".parse().unwrap(), fishermen_threshold),
         ("test3".parse().unwrap(), fishermen_threshold),
     ];
-    let mut em = setup_epoch_manager(validators, 2, 1, 1, 90, 70, 0, Rational32::new(0, 1));
+    let mut em = setup_epoch_manager(
+        validators,
+        2,
+        1,
+        1,
+        90,
+        70,
+        0,
+        default_reward_calculator(),
+        Rational32::new(0, 1),
+    );
     let h = hash_range(5);
     record_block(&mut em, CryptoHash::default(), h[0], 0, vec![]);
     // fishermen unstake
@@ -1937,7 +2121,10 @@ fn test_protocol_version_switch() {
         stake("test1".parse().unwrap(), amount_staked),
         stake("test2".parse().unwrap(), amount_staked),
     ];
-    let mut epoch_manager = EpochManager::new(store, config, validators).unwrap();
+    let mut reward_calculator = default_reward_calculator();
+    reward_calculator.genesis_protocol_version = 0;
+    let mut epoch_manager =
+        EpochManager::new(store, config, reward_calculator, validators).unwrap();
     let h = hash_range(8);
     record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
     for i in 1..6 {
@@ -1976,7 +2163,10 @@ fn test_protocol_version_switch_with_shard_layout_change() {
         stake("test1".parse().unwrap(), amount_staked),
         stake("test2".parse().unwrap(), amount_staked),
     ];
-    let mut epoch_manager = EpochManager::new(store, config, validators).unwrap();
+    let mut reward_calculator = default_reward_calculator();
+    reward_calculator.genesis_protocol_version = PROTOCOL_VERSION - 1;
+    let mut epoch_manager =
+        EpochManager::new(store, config, reward_calculator, validators).unwrap();
     let h = hash_range(8);
     record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
     for i in 1..8 {
@@ -2021,7 +2211,8 @@ fn test_protocol_version_switch_with_many_seats() {
     let config =
         AllEpochConfig::from_epoch_config_store("test-chain", 10, config_store, PROTOCOL_VERSION);
 
-    let mut epoch_manager = EpochManager::new(store, config, validators).unwrap();
+    let mut epoch_manager =
+        EpochManager::new(store, config, default_reward_calculator(), validators).unwrap();
     let h = hash_range(50);
     record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
     for i in 1..32 {
@@ -2058,7 +2249,10 @@ fn test_version_switch_kickout_old_version() {
         stake("test1".parse().unwrap(), large_stake),
         stake("test2".parse().unwrap(), small_stake),
     ];
-    let mut epoch_manager = EpochManager::new(store, config, validators).unwrap();
+    let mut reward_calculator = default_reward_calculator();
+    reward_calculator.genesis_protocol_version = version;
+    let mut epoch_manager =
+        EpochManager::new(store, config, reward_calculator, validators).unwrap();
 
     // Genesis block
     let genesis_hash = test_utils::fake_hash(0);

--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -283,8 +283,6 @@ impl From<&GenesisConfig> for EpochConfig {
                 .shuffle_shard_assignment_for_chunk_producers,
             validator_max_kickout_stake_perc: config.max_kickout_stake_perc,
             max_inflation_rate: config.max_inflation_rate,
-            protocol_reward_rate: config.protocol_reward_rate,
-            protocol_treasury_account: config.protocol_treasury_account.clone(),
         }
     }
 }

--- a/core/chain-configs/src/test_genesis.rs
+++ b/core/chain-configs/src/test_genesis.rs
@@ -43,8 +43,6 @@ pub struct TestEpochConfigBuilder {
     chunk_producer_assignment_changes_limit: NumSeats,
     shuffle_shard_assignment_for_chunk_producers: bool,
     max_inflation_rate: Rational32,
-    protocol_reward_rate: Rational32,
-    protocol_treasury_account: AccountId,
 
     // not used any more
     num_block_producer_seats_per_shard: Vec<NumSeats>,
@@ -141,8 +139,6 @@ impl Default for TestEpochConfigBuilder {
             chunk_producer_assignment_changes_limit: 5,
             shuffle_shard_assignment_for_chunk_producers: false,
             max_inflation_rate: Rational32::new(1, 40),
-            protocol_reward_rate: Rational32::new(1, 10),
-            protocol_treasury_account: "near".to_string().parse().unwrap(),
             // consider them ineffective
             num_block_producer_seats_per_shard: vec![1],
             genesis_protocol_version: None,
@@ -258,8 +254,6 @@ impl TestEpochConfigBuilder {
                 .shuffle_shard_assignment_for_chunk_producers,
             num_block_producer_seats_per_shard: self.num_block_producer_seats_per_shard,
             max_inflation_rate: self.max_inflation_rate,
-            protocol_reward_rate: self.protocol_reward_rate,
-            protocol_treasury_account: self.protocol_treasury_account,
         };
         tracing::debug!(?epoch_config);
         epoch_config
@@ -296,7 +290,7 @@ impl Default for TestGenesisBuilder {
             gas_limit: Gas::from_teragas(1000),
             transaction_validity_period: 100,
             protocol_treasury_account: "near".to_string().parse().unwrap(),
-            max_inflation_rate: Rational32::new(1, 40),
+            max_inflation_rate: Rational32::new(1, 1),
             user_accounts: vec![],
             dynamic_resharding: false,
             fishermen_threshold: Balance::ZERO,
@@ -304,7 +298,7 @@ impl Default for TestGenesisBuilder {
             online_max_threshold: Rational32::new(99, 100),
             gas_price_adjustment_rate: Rational32::new(0, 1),
             num_blocks_per_year: 86400,
-            protocol_reward_rate: Rational32::new(1, 10),
+            protocol_reward_rate: Rational32::new(0, 1),
             max_kickout_stake_perc: 100,
             minimum_stake_divisor: 10,
             protocol_upgrade_stake_threshold: Rational32::new(8, 10),

--- a/core/primitives/res/epoch_configs/mainnet/143.json
+++ b/core/primitives/res/epoch_configs/mainnet/143.json
@@ -131,10 +131,5 @@
   "max_inflation_rate": [
     1,
     40
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/mainnet/29.json
+++ b/core/primitives/res/epoch_configs/mainnet/29.json
@@ -45,10 +45,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/mainnet/48.json
+++ b/core/primitives/res/epoch_configs/mainnet/48.json
@@ -69,10 +69,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/mainnet/56.json
+++ b/core/primitives/res/epoch_configs/mainnet/56.json
@@ -69,10 +69,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/mainnet/64.json
+++ b/core/primitives/res/epoch_configs/mainnet/64.json
@@ -80,10 +80,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/mainnet/65.json
+++ b/core/primitives/res/epoch_configs/mainnet/65.json
@@ -87,10 +87,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/mainnet/69.json
+++ b/core/primitives/res/epoch_configs/mainnet/69.json
@@ -87,10 +87,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/mainnet/70.json
+++ b/core/primitives/res/epoch_configs/mainnet/70.json
@@ -87,10 +87,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/mainnet/71.json
+++ b/core/primitives/res/epoch_configs/mainnet/71.json
@@ -87,10 +87,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/mainnet/72.json
+++ b/core/primitives/res/epoch_configs/mainnet/72.json
@@ -87,10 +87,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/mainnet/75.json
+++ b/core/primitives/res/epoch_configs/mainnet/75.json
@@ -121,10 +121,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/mainnet/76.json
+++ b/core/primitives/res/epoch_configs/mainnet/76.json
@@ -131,10 +131,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/mainnet/78.json
+++ b/core/primitives/res/epoch_configs/mainnet/78.json
@@ -141,10 +141,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/mainnet/80.json
+++ b/core/primitives/res/epoch_configs/mainnet/80.json
@@ -141,10 +141,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/mainnet/81.json
+++ b/core/primitives/res/epoch_configs/mainnet/81.json
@@ -141,10 +141,5 @@
   "max_inflation_rate": [
     1,
     40
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/testnet/143.json
+++ b/core/primitives/res/epoch_configs/testnet/143.json
@@ -131,10 +131,5 @@
   "max_inflation_rate": [
     1,
     40
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/testnet/29.json
+++ b/core/primitives/res/epoch_configs/testnet/29.json
@@ -45,10 +45,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/testnet/48.json
+++ b/core/primitives/res/epoch_configs/testnet/48.json
@@ -69,10 +69,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/testnet/56.json
+++ b/core/primitives/res/epoch_configs/testnet/56.json
@@ -69,10 +69,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/testnet/64.json
+++ b/core/primitives/res/epoch_configs/testnet/64.json
@@ -80,10 +80,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/testnet/65.json
+++ b/core/primitives/res/epoch_configs/testnet/65.json
@@ -87,10 +87,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/testnet/69.json
+++ b/core/primitives/res/epoch_configs/testnet/69.json
@@ -87,10 +87,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/testnet/70.json
+++ b/core/primitives/res/epoch_configs/testnet/70.json
@@ -87,10 +87,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/testnet/71.json
+++ b/core/primitives/res/epoch_configs/testnet/71.json
@@ -87,10 +87,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/testnet/72.json
+++ b/core/primitives/res/epoch_configs/testnet/72.json
@@ -87,10 +87,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/testnet/75.json
+++ b/core/primitives/res/epoch_configs/testnet/75.json
@@ -121,10 +121,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/testnet/76.json
+++ b/core/primitives/res/epoch_configs/testnet/76.json
@@ -131,10 +131,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/testnet/78.json
+++ b/core/primitives/res/epoch_configs/testnet/78.json
@@ -141,10 +141,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/testnet/80.json
+++ b/core/primitives/res/epoch_configs/testnet/80.json
@@ -141,10 +141,5 @@
   "max_inflation_rate": [
     1,
     20
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/res/epoch_configs/testnet/81.json
+++ b/core/primitives/res/epoch_configs/testnet/81.json
@@ -141,10 +141,5 @@
   "max_inflation_rate": [
     1,
     40
-  ],
-  "protocol_reward_rate": [
-    1,
-    10
-  ],
-  "protocol_treasury_account": "near"
+  ]
 }

--- a/core/primitives/src/epoch_manager.rs
+++ b/core/primitives/src/epoch_manager.rs
@@ -73,10 +73,6 @@ pub struct EpochConfig {
     // #[default(false)]
     pub shuffle_shard_assignment_for_chunk_producers: bool,
     pub max_inflation_rate: Rational32,
-    // #[default(Rational32::new(1, 10))]
-    pub protocol_reward_rate: Rational32,
-    // #[default("near".parse().unwrap())]
-    pub protocol_treasury_account: AccountId,
 }
 
 impl EpochConfig {
@@ -128,8 +124,6 @@ impl EpochConfig {
             chunk_producer_assignment_changes_limit: 5,
             shuffle_shard_assignment_for_chunk_producers: false,
             max_inflation_rate: Rational32::new(1, 40),
-            protocol_reward_rate: Rational32::new(1, 10),
-            protocol_treasury_account: "near".parse().unwrap(),
         }
     }
 
@@ -159,8 +153,6 @@ impl EpochConfig {
             chunk_producer_assignment_changes_limit: 5,
             shuffle_shard_assignment_for_chunk_producers: false,
             max_inflation_rate: Rational32::new(1, 40),
-            protocol_reward_rate: Rational32::new(1, 10),
-            protocol_treasury_account: "near".parse().unwrap(),
         }
     }
 
@@ -189,8 +181,6 @@ impl EpochConfig {
             chunk_producer_assignment_changes_limit: 5,
             shuffle_shard_assignment_for_chunk_producers: false,
             max_inflation_rate: Rational32::new(1, 40),
-            protocol_reward_rate: Rational32::new(1, 10),
-            protocol_treasury_account: "near".parse().unwrap(),
         }
     }
 }


### PR DESCRIPTION
Reverts near/nearcore#14529

There's a mismatch between the treasury account provided in the genesis and the treasury account picked up by the epoch config.

See zulip issue [#nearone/private > Mainnet canaries crashed @ 💬](https://near.zulipchat.com/#narrow/channel/308695-nearone.2Fprivate/topic/Mainnet.20canaries.20crashed/near/558273265)