### PR TITLE
feat(tx_generator): emit a span when tx_generator changes tps rate

### DIFF
--- a/benchmarks/transactions-generator/src/lib.rs
+++ b/benchmarks/transactions-generator/src/lib.rs
@@ -526,6 +526,12 @@ impl TxGenerator {
                             tracing::warn!(target: "transaction-generator", rate, "controller suggested tps is out of range, clamping");
                             rate = rate.clamp(1.0, 100000.0);
                         }
+                        let _span = tracing::debug_span!(
+                            "update_tx_generator_rate",
+                            %height,
+                            %rate,
+                            tag_block_production = true)
+                        .entered();
                         let micros = ((1_000_000.0 * TX_GENERATOR_TASK_COUNT as f64) / rate) as u64;
                         tx_tps_values
                             .send(tokio::time::Duration::from_micros(micros))


### PR DESCRIPTION
This allows to see what transaction generation rate the transaction generator is setting for each height. `rate` meaning one-shard TPS.

<img width="341" height="395" alt="image" src="https://github.com/user-attachments/assets/a4602dbd-0912-4a14-9781-605f043bb9ab" />
