### PR TITLE
feat(chain): make storing StateChanges configurable

### DIFF
--- a/benchmarks/sharded-bm/cases/base_config_patch.json
+++ b/benchmarks/sharded-bm/cases/base_config_patch.json
@@ -67,6 +67,7 @@
         }
     },
     "save_tx_outcomes": false,
+    "save_state_changes": false,
     "gc_num_epochs_to_keep": 3,
     "save_untracked_partial_chunks_parts": false,
     "enable_early_prepare_transactions": true,

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -461,7 +461,8 @@ impl Chain {
             chain_config.save_trie_changes,
             transaction_validity_period,
         )
-        .with_save_tx_outcomes(chain_config.save_tx_outcomes);
+        .with_save_tx_outcomes(chain_config.save_tx_outcomes)
+        .with_save_state_changes(chain_config.save_state_changes);
         let state_sync_adapter = ChainStateSyncAdapter::new(
             clock.clone(),
             ChainStoreAdapter::new(chain_store.store()),

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -211,6 +211,8 @@ pub struct ChainConfig {
     pub save_trie_changes: bool,
     /// Whether to persist transaction outcomes on disk or not.
     pub save_tx_outcomes: bool,
+    /// Whether to persist state changes on disk or not.
+    pub save_state_changes: bool,
     /// Number of threads to execute background migration work.
     /// Currently used for flat storage background creation.
     pub background_migration_threads: usize,
@@ -225,6 +227,7 @@ impl ChainConfig {
         Self {
             save_trie_changes: true,
             save_tx_outcomes: true,
+            save_state_changes: true,
             background_migration_threads: 1,
             resharding_config: MutableConfigValue::new(
                 ReshardingConfig::test(),

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -283,6 +283,7 @@ impl Client {
         let chain_config = ChainConfig {
             save_trie_changes: config.save_trie_changes,
             save_tx_outcomes: config.save_tx_outcomes,
+            save_state_changes: config.save_state_changes,
             background_migration_threads: config.client_background_migration_threads,
             resharding_config: config.resharding_config.clone(),
             protocol_version_check: config.protocol_version_check,

--- a/chain/jsonrpc/openapi/openapi.json
+++ b/chain/jsonrpc/openapi/openapi.json
@@ -11558,6 +11558,10 @@
             "description": "Save observed instances of ChunkStateWitness to the database in DBCol::LatestChunkStateWitnesses.\nSaving the latest witnesses is useful for analysis and debugging.\nThis option can cause extra load on the database and is not recommended for production use.",
             "type": "boolean"
           },
+          "save_state_changes": {
+            "description": "Whether to persist state changes on disk or not.",
+            "type": "boolean"
+          },
           "save_trie_changes": {
             "description": "save_trie_changes should be set to true iff\n- archive if false - non-archival nodes need trie changes to perform garbage collection\n- archive is true, cold_store is configured and migration to split_storage is finished - node\nworking in split storage mode needs trie changes in order to do garbage collection on hot.",
             "type": "boolean"

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -801,6 +801,8 @@ pub struct ClientConfig {
     pub save_trie_changes: bool,
     /// Whether to persist transaction outcomes to disk or not.
     pub save_tx_outcomes: bool,
+    /// Whether to persist state changes on disk or not.
+    pub save_state_changes: bool,
     /// Whether to persist partial chunk parts for untracked shards or not.
     pub save_untracked_partial_chunks_parts: bool,
     /// Number of threads for ViewClientActor pool.

--- a/core/chain-configs/src/test_utils.rs
+++ b/core/chain-configs/src/test_utils.rs
@@ -308,6 +308,7 @@ impl ClientConfig {
             save_trie_changes: true,
             save_untracked_partial_chunks_parts: true,
             save_tx_outcomes: true,
+            save_state_changes: true,
             log_summary_style: LogSummaryStyle::Colored,
             view_client_threads: 1,
             chunk_validation_threads: 1,

--- a/integration-tests/src/env/setup.rs
+++ b/integration-tests/src/env/setup.rs
@@ -553,6 +553,7 @@ pub fn setup_synchronous_shards_manager(
         ChainConfig {
             save_trie_changes: true,
             save_tx_outcomes: true,
+            save_state_changes: true,
             background_migration_threads: 1,
             resharding_config: MutableConfigValue::new(
                 ReshardingConfig::default(),

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -296,6 +296,10 @@ pub struct Config {
     /// - All shards are tracked (i.e. node is an RPC node).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub save_tx_outcomes: Option<bool>,
+    /// Whether to persist state changes on disk or not.
+    /// If `None`, defaults to true (persist).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub save_state_changes: Option<bool>,
     /// Whether to persist partial chunk parts for untracked shards in the database.
     /// If `None`, defaults to true (persist).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -456,6 +460,7 @@ impl Default for Config {
             cloud_archival: None,
             cloud_archival_writer: None,
             save_trie_changes: None,
+            save_state_changes: None,
             save_tx_outcomes: None,
             save_untracked_partial_chunks_parts: None,
             log_summary_style: LogSummaryStyle::Colored,
@@ -715,6 +720,7 @@ impl NearConfig {
                 cloud_archival_writer: config.cloud_archival_writer,
                 save_trie_changes: config.save_trie_changes.unwrap_or(!config.archive),
                 save_tx_outcomes: config.save_tx_outcomes.unwrap_or(is_archive_or_rpc),
+                save_state_changes: config.save_state_changes.unwrap_or(true),
                 save_untracked_partial_chunks_parts: config
                     .save_untracked_partial_chunks_parts
                     .unwrap_or(true),

--- a/tools/speedy_sync/src/main.rs
+++ b/tools/speedy_sync/src/main.rs
@@ -260,6 +260,7 @@ fn load_snapshot(load_cmd: LoadCmd) {
         ChainConfig {
             save_trie_changes: near_config.client_config.save_trie_changes,
             save_tx_outcomes: near_config.client_config.save_tx_outcomes,
+            save_state_changes: near_config.client_config.save_state_changes,
             background_migration_threads: 1,
             resharding_config: MutableConfigValue::new(
                 ReshardingConfig::default(),


### PR DESCRIPTION
Makes storing StateChanges configurable.
These values are necessary for RPC & rosetta compatibility but not strictly necessary for validators to perform their duties. Therefore, validators may opt to disable persisting them as a performance measure.

Comparison to current master (which includes the fix for the rosetta issue): https://grafana.nearone.org/goto/bf4q03jgqdzpca?orgId=1
Comparison to last good weekly before the regression: https://grafana.nearone.org/goto/cf4q06vip9kaob?orgId=1