### PR TITLE
fix(test): deterministic order for test_view_gas_keys

### DIFF
--- a/runtime/runtime/src/gas_keys.rs
+++ b/runtime/runtime/src/gas_keys.rs
@@ -459,7 +459,7 @@ mod tests {
             add_gas_key_to_account(&mut state_update, &mut account, &account_id, &public_key2);
 
         let viewer = TrieViewer::default();
-        let gas_keys = viewer.view_gas_keys(&state_update, &account_id).unwrap();
+        let mut gas_keys = viewer.view_gas_keys(&state_update, &account_id).unwrap();
         let expected_nonce = initial_nonce_value(TEST_GAS_KEY_BLOCK_HEIGHT);
         let mut expected = vec![
             GasKeyInfoView {
@@ -471,7 +471,10 @@ mod tests {
                 gas_key: GasKeyView::new(gas_key2, vec![expected_nonce; TEST_NUM_NONCES as usize]),
             },
         ];
-        expected.sort_by_key(|k| k.public_key.clone()); // Sort by public_key to match trie iterator order
+        // Sort both expected and actual gas keys by public_key to ensure consistent order for comparison
+        // as the API does not include an ordering guarantee.
+        expected.sort_by_key(|k| k.public_key.clone());
+        gas_keys.sort_by_key(|k| k.public_key.clone());
         assert_eq!(expected, gas_keys);
     }
 


### PR DESCRIPTION
Fixing this to avoid sporadic test failures.