### PR TITLE
fix: use "vendored" feature for utoipa-swagger-ui to allow reproducible builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8812,8 +8812,15 @@ dependencies = [
  "serde_json",
  "url",
  "utoipa",
+ "utoipa-swagger-ui-vendored",
  "zip",
 ]
+
+[[package]]
+name = "utoipa-swagger-ui-vendored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -398,7 +398,7 @@ trybuild = "1.0.11"
 turn = "0.9"
 url = "2.5.0"
 utoipa = "5.4"
-utoipa-swagger-ui = "9"
+utoipa-swagger-ui = {version = "9", features = ["vendored"]}
 wasm-encoder = "0.236"
 wasmparser = "0.78" # TODO: unify at least the versions of wasmparser we have in our codebase
 wasmparser-236 = { package = "wasmparser", version = "0.236" }


### PR DESCRIPTION
Closes #14668 