### PR TITLE
fix: ImportedMemory32Fill mapping to near_vm_imported_memory32_fill

### DIFF
--- a/runtime/near-vm/vm/src/libcalls.rs
+++ b/runtime/near-vm/vm/src/libcalls.rs
@@ -830,7 +830,7 @@ impl LibCall {
             Self::Memory32Copy => near_vm_memory32_copy as usize,
             Self::ImportedMemory32Copy => near_vm_imported_memory32_copy as usize,
             Self::Memory32Fill => near_vm_memory32_fill as usize,
-            Self::ImportedMemory32Fill => near_vm_memory32_fill as usize,
+            Self::ImportedMemory32Fill => near_vm_imported_memory32_fill as usize,
             Self::Memory32Init => near_vm_memory32_init as usize,
             Self::DataDrop => near_vm_data_drop as usize,
             Self::Probestack => near_vm_probestack as usize,


### PR DESCRIPTION
The libcall mapping for ImportedMemory32Fill in runtime/near-vm/vm/src/libcalls.rs incorrectly returned the function pointer for the local memory fill (near_vm_memory32_fill) rather than the imported variant (near_vm_imported_memory32_fill). This mismatch is inconsistent with the already-correct to_function_name() mapping and with the existing split implementations in instance/mod.rs where local and imported memories are handled differently (local_memory_fill vs imported_memory_fill). Since the engine’s linker embeds the pointer produced by LibCall::function_pointer() (see engine/src/universal/link.rs), using the local fill for an imported-memory libcall would route the call through the wrong code path, potentially causing out-of-bounds checks to be applied to the wrong memory or even silent misbehavior if indices overlap. The change aligns the function pointer mapping with the intended semantics and naming, matching the pattern used by other imported memory/table libcalls and eliminating a correctness hazard without affecting local-memory behavior.