### PR TITLE
fix(benchmarks): missing quotes

### DIFF
--- a/benchmarks/sharded-bm/cases/forknet/20-shards/tx-generator-settings.json
+++ b/benchmarks/sharded-bm/cases/forknet/20-shards/tx-generator-settings.json
@@ -2,7 +2,7 @@
 	"tx_generator": {
 		"accounts_path": "{{near_accounts_path}}",
 		"receiver_accounts_path": "{{near_receiver_accounts_path}}",
-		"receivers_from_senders_ratio": {{near_receivers_from_senders_ratio}},
+		"receivers_from_senders_ratio": "{{near_receivers_from_senders_ratio}}",
 		"sender_accounts_zipf_skew": 1.0,
 		"receiver_accounts_zipf_skew": 1.0,
 		"schedule": [

--- a/benchmarks/sharded-bm/cases/forknet/4-shards/tx-generator-settings.json
+++ b/benchmarks/sharded-bm/cases/forknet/4-shards/tx-generator-settings.json
@@ -2,7 +2,7 @@
 	"tx_generator": {
 		"accounts_path": "{{near_accounts_path}}",
 		"receiver_accounts_path": "{{near_receiver_accounts_path}}",
-		"receivers_from_senders_ratio": {{near_receivers_from_senders_ratio}},
+		"receivers_from_senders_ratio": "{{near_receivers_from_senders_ratio}}",
 		"sender_accounts_zipf_skew": 1.0,
 		"receiver_accounts_zipf_skew": 1.0,
 		"schedule": [

--- a/benchmarks/sharded-bm/cases/forknet/50-shards/tx-generator-settings.json
+++ b/benchmarks/sharded-bm/cases/forknet/50-shards/tx-generator-settings.json
@@ -2,7 +2,7 @@
 	"tx_generator": {
 		"accounts_path": "{{near_accounts_path}}",
 		"receiver_accounts_path": "{{near_receiver_accounts_path}}",
-		"receivers_from_senders_ratio": {{near_receivers_from_senders_ratio}},
+		"receivers_from_senders_ratio": "{{near_receivers_from_senders_ratio}}",
 		"sender_accounts_zipf_skew": 1.0,
 		"receiver_accounts_zipf_skew": 1.0,
 		"schedule": [

--- a/benchmarks/sharded-bm/cases/forknet/64-shards/tx-generator-settings.json
+++ b/benchmarks/sharded-bm/cases/forknet/64-shards/tx-generator-settings.json
@@ -2,7 +2,7 @@
 	"tx_generator": {
 		"accounts_path": "{{near_accounts_path}}",
 		"receiver_accounts_path": "{{near_receiver_accounts_path}}",
-		"receivers_from_senders_ratio": {{near_receivers_from_senders_ratio}},
+		"receivers_from_senders_ratio": "{{near_receivers_from_senders_ratio}}",
 		"sender_accounts_zipf_skew": 1.0,
 		"receiver_accounts_zipf_skew": 1.0,
 		"schedule": [


### PR DESCRIPTION
the input must be valid json for `jq` to parse it.