### PR TITLE
refactor(chain): scope test helper to test module

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3493,10 +3493,6 @@ impl Chain {
         self.chain_store.transaction_validity_period
     }
 
-    pub fn set_transaction_validity_period(&mut self, to: BlockHeightDelta) {
-        self.chain_store.transaction_validity_period = to;
-    }
-
     /// Check if block is known: head, orphan, in processing or in store.
     /// Returns Err(Error) if any error occurs when checking store
     ///         Ok(Err(BlockKnownError)) if the block is known

--- a/chain/chain/src/store/mod.rs
+++ b/chain/chain/src/store/mod.rs
@@ -2225,12 +2225,20 @@ impl<'a> ChainStoreUpdate<'a> {
 #[cfg(test)]
 mod tests {
     use near_async::time::Clock;
+    use near_primitives::types::BlockHeightDelta;
     use std::sync::Arc;
 
+    use crate::Chain;
     use crate::test_utils::get_chain;
     use near_primitives::errors::InvalidTxError;
     use near_primitives::test_utils::TestBlockBuilder;
     use near_primitives::test_utils::create_test_signer;
+
+    impl Chain {
+        pub fn set_transaction_validity_period(&mut self, to: BlockHeightDelta) {
+            self.chain_store.transaction_validity_period = to;
+        }
+    }
 
     #[test]
     fn test_tx_validity_long_fork() {


### PR DESCRIPTION
Moves the `set_transaction_validity_period` method from the main `Chain` implementation to a test-scoped impl block. This method is only used in tests, so scoping it appropriately makes the intent clearer and keeps test-only code separate from production code.