### PR TITLE
chore(epoch-manager): remove internal caches and use store-level caching

### DIFF
--- a/chain/epoch-manager/src/adapter.rs
+++ b/chain/epoch-manager/src/adapter.rs
@@ -813,7 +813,7 @@ impl EpochManagerAdapter for EpochManagerHandle {
     }
 
     fn get_epoch_start_from_epoch_id(&self, epoch_id: &EpochId) -> Result<BlockHeight, EpochError> {
-        self.read().get_epoch_start_from_epoch_id(epoch_id)
+        self.read().store.get_epoch_start(epoch_id)
     }
 
     fn get_shard_layout_from_protocol_version(

--- a/chain/epoch-manager/src/genesis.rs
+++ b/chain/epoch-manager/src/genesis.rs
@@ -31,8 +31,8 @@ impl EpochManager {
         // EpochId formula using T-2 for T=1, and height field is unused.
         let block_info = Arc::new(BlockInfo::default());
         let mut store_update = self.store.store_update();
-        self.save_epoch_info(&mut store_update, &EpochId::default(), Arc::new(genesis_epoch_info))?;
-        self.save_block_info(&mut store_update, block_info)?;
+        store_update.set_epoch_info(&EpochId::default(), &Arc::new(genesis_epoch_info));
+        store_update.set_block_info(&block_info);
         store_update.commit()?;
         Ok(())
     }

--- a/core/store/src/deserialized_column.rs
+++ b/core/store/src/deserialized_column.rs
@@ -82,6 +82,10 @@ impl Cache {
                 | DBCol::StateShardUIdMapping => ColumnCache::with_none_values(
                     ColumnCache::new(32),
                 ),
+                // Caching for epoch related columns
+                | DBCol::EpochInfo | DBCol::EpochStart => ColumnCache::new(32),
+                | DBCol::BlockInfo => ColumnCache::new(1024),
+                // Other columns are not cached for now.
                 _ => ColumnCache::disabled(),
             },
         }


### PR DESCRIPTION
Removes redundant caching layers from EpochManager (epochs_info, blocks_info, epoch_id_to_start) and consolidates caching at the store level. This simplifies the EpochManager implementation while maintaining performance through store-level caching for EpochInfo, BlockInfo, and EpochStart columns.