### PR TITLE
chore(spice): mark cloud_archival test-loop tests as todo

### DIFF
--- a/test-loop-tests/src/tests/cloud_archival.rs
+++ b/test-loop-tests/src/tests/cloud_archival.rs
@@ -126,12 +126,16 @@ fn test_cloud_archival_base(params: TestCloudArchivalParameters) {
 
 /// Verifies that `cloud_head` progresses without crashes.
 #[test]
+// TODO(spice): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_basic() {
     test_cloud_archival_base(TestCloudArchivalParametersBuilder::default().build());
 }
 
 /// Verifies that both `cloud_head` and `cold_head` progress with cold DB enabled.
 #[test]
+// TODO(spice): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_with_cold() {
     test_cloud_archival_base(
         TestCloudArchivalParametersBuilder::default().enable_cold_storage(true).build(),
@@ -141,6 +145,8 @@ fn test_cloud_archival_with_cold() {
 /// Verifies that while the cloud writer is paused, GC stop never exceeds the first block
 /// of the epoch containing `cloud_head` and the writer catches up after resuming.
 #[test]
+// TODO(spice): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_resume() {
     let gc_period_num_blocks = MIN_GC_NUM_EPOCHS_TO_KEEP * MIN_EPOCH_LENGTH;
     // Pause the cloud writer long enough so that, if it were possible, GC could overtake
@@ -159,6 +165,8 @@ fn test_cloud_archival_resume() {
 
 /// Verifies that block data can be read from the cloud.
 #[test]
+// TODO(spice): Assess if this test is relevant for spice and if yes fix it.
+#[cfg_attr(feature = "protocol_feature_spice", ignore)]
 fn test_cloud_archival_read_block() {
     let block_height = Some(MIN_EPOCH_LENGTH / 2);
     test_cloud_archival_base(


### PR DESCRIPTION
These run as part of merge groups and are currently failing.
Let's fix it and make Linux Nexttest (spice) mandatory in merge groups.