### PR TITLE
fix: verify action receipt v2 protocol version

### DIFF
--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -344,6 +344,17 @@ fn validate_action_receipt(
     receiver: &AccountId,
     current_protocol_version: ProtocolVersion,
 ) -> Result<(), ReceiptValidationError> {
+    if matches!(receipt, VersionedActionReceipt::V2(_))
+        && !ProtocolFeature::DeterministicAccountIds.enabled(current_protocol_version)
+    {
+        return Err(ReceiptValidationError::ActionsValidation(
+            ActionsValidationError::UnsupportedProtocolFeature {
+                protocol_feature: "DeterministicAccountIds".to_owned(),
+                version: current_protocol_version,
+            },
+        ));
+    }
+
     if receipt.input_data_ids().len() as u64 > limit_config.max_number_input_data_dependencies {
         return Err(ReceiptValidationError::NumberInputDataDependenciesExceeded {
             number_of_input_data_dependencies: receipt.input_data_ids().len() as u64,


### PR DESCRIPTION
This PR introduces missing protocol version check for `ActionReceiptV2`. This prevents it from being included to the chain before it is supported by all nodes which is determined by `DeterministicAccountIds` protocol feature.