### PR TITLE
refactor(spice): use block headers to get execution results

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -394,7 +394,11 @@ impl Chain {
             noop().into_multi_sender(),
         );
         let num_shards = runtime_adapter.get_shard_layout(PROTOCOL_VERSION).num_shards() as usize;
-        let spice_core_reader = SpiceCoreReader::new(store.chain_store(), epoch_manager.clone());
+        let spice_core_reader = SpiceCoreReader::new(
+            store.chain_store(),
+            epoch_manager.clone(),
+            chain_genesis.gas_limit,
+        );
         Ok(Chain {
             clock: clock.clone(),
             chain_store,
@@ -569,8 +573,11 @@ impl Chain {
         let max_num_shards =
             runtime_adapter.get_shard_layout(PROTOCOL_VERSION).num_shards() as usize;
         let apply_chunks_spawner = apply_chunks_spawner.into_spawner(max_num_shards);
-        let spice_core_reader =
-            SpiceCoreReader::new(chain_store.store().chain_store(), epoch_manager.clone());
+        let spice_core_reader = SpiceCoreReader::new(
+            chain_store.store().chain_store(),
+            epoch_manager.clone(),
+            chain_genesis.gas_limit,
+        );
         Ok(Chain {
             clock: clock.clone(),
             chain_store,

--- a/chain/chain/src/genesis.rs
+++ b/chain/chain/src/genesis.rs
@@ -196,22 +196,7 @@ impl Chain {
         shard_layout: &ShardLayout,
         shard_id: ShardId,
     ) -> Result<ChunkExtra, Error> {
-        Self::build_genesis_chunk_extra(&chain_store.store(), shard_layout, shard_id, &genesis)
-    }
-
-    pub fn build_genesis_chunk_extra(
-        store: &Store,
-        shard_layout: &ShardLayout,
-        shard_id: ShardId,
-        genesis: &Block,
-    ) -> Result<ChunkExtra, Error> {
         let shard_index = shard_layout.get_shard_index(shard_id)?;
-        let state_root = *get_genesis_state_roots(store)?
-            .ok_or_else(|| Error::Other("genesis state roots do not exist in the db".to_owned()))?
-            .get(shard_index)
-            .ok_or_else(|| {
-                Error::Other(format!("genesis state root does not exist for shard id {shard_id} shard index {shard_index}"))
-            })?;
         let gas_limit = genesis
             .chunks()
             .get(shard_index)
@@ -221,9 +206,29 @@ impl Chain {
                 ))
             })?
             .gas_limit();
-        let congestion_info =
-            genesis.block_congestion_info().get(&shard_id).map(|info| info.congestion_info);
-        Ok(Self::create_genesis_chunk_extra(&state_root, gas_limit, congestion_info))
+        Self::build_genesis_chunk_extra(&chain_store.store(), shard_layout, shard_id, gas_limit)
+    }
+
+    pub fn build_genesis_chunk_extra(
+        store: &Store,
+        shard_layout: &ShardLayout,
+        shard_id: ShardId,
+        gas_limit: Gas,
+    ) -> Result<ChunkExtra, Error> {
+        let shard_index = shard_layout.get_shard_index(shard_id)?;
+        let state_root = *get_genesis_state_roots(store)?
+            .ok_or_else(|| Error::Other("genesis state roots do not exist in the db".to_owned()))?
+            .get(shard_index)
+            .ok_or_else(|| {
+                Error::Other(format!("genesis state root does not exist for shard id {shard_id} shard index {shard_index}"))
+            })?;
+        let congestion_info = *near_store::get_genesis_congestion_infos(store)?
+            .ok_or_else(|| Error::Other("genesis congestion infos do not exist in the db".to_owned()))?
+            .get(shard_index)
+            .ok_or_else(|| {
+                Error::Other(format!("genesis congestion infos do not exist for shard id {shard_id} shard index {shard_index}"))
+            })?;
+        Ok(Self::create_genesis_chunk_extra(&state_root, gas_limit, Some(congestion_info)))
     }
 
     /// Saves the `[ChunkExtra]`s for all shards in the genesis block.

--- a/chain/chain/src/tests/spice_core_writer_actor.rs
+++ b/chain/chain/src/tests/spice_core_writer_actor.rs
@@ -8,6 +8,7 @@ use near_crypto::Signature;
 use near_o11y::testonly::init_test_logger;
 use near_primitives::block::Block;
 use near_primitives::block_body::SpiceCoreStatement;
+use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::sharding::ShardChunkHeader;
@@ -24,6 +25,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
 
+use crate::spice_core::SpiceCoreReader;
 use crate::spice_core_writer_actor::{
     ExecutionResultEndorsed, InvalidSpiceEndorsementError, ProcessChunkError, SpiceCoreWriterActor,
 };
@@ -47,7 +49,7 @@ fn test_process_chunk_endorsement_with_execution_result_already_present() {
         core_writer_actor.process_chunk_endorsement(endorsement).unwrap();
     }
     let execution_results =
-        core_writer_actor.core_reader.get_execution_results_by_shard_id(&block).unwrap();
+        core_writer_actor.core_reader.get_execution_results_by_shard_id(block.header()).unwrap();
     assert!(execution_results.contains_key(&chunk_header.shard_id()));
 
     let endorsement = test_chunk_endorsement(&test_validators()[0], &block, chunk_header);
@@ -80,7 +82,7 @@ fn test_process_chunk_endorsement_does_not_record_result_without_enough_endorsem
     core_writer_actor.process_chunk_endorsement(endorsement).unwrap();
 
     let execution_results =
-        core_writer_actor.core_reader.get_execution_results_by_shard_id(&block).unwrap();
+        core_writer_actor.core_reader.get_execution_results_by_shard_id(block.header()).unwrap();
     assert!(!execution_results.contains_key(&chunk_header.shard_id()));
 }
 
@@ -100,7 +102,7 @@ fn test_process_chunk_endorsement_does_not_record_result_with_enough_endorsement
     }
 
     let execution_results =
-        core_writer_actor.core_reader.get_execution_results_by_shard_id(&block).unwrap();
+        core_writer_actor.core_reader.get_execution_results_by_shard_id(block.header()).unwrap();
     assert!(execution_results.contains_key(&chunk_header.shard_id()));
 }
 
@@ -361,14 +363,18 @@ fn test_handle_processed_block_for_block_with_endorsements() {
     core_writer_actor.handle_processed_block(*next_block.hash()).unwrap();
 
     assert!(
-        core_writer_actor.core_reader.get_execution_results_by_shard_id(&block).unwrap().is_empty()
+        core_writer_actor
+            .core_reader
+            .get_execution_results_by_shard_id(block.header())
+            .unwrap()
+            .is_empty()
     );
     for validator in in_core_validators {
         let endorsement = test_chunk_endorsement(&validator, &block, chunk_header);
         core_writer_actor.process_chunk_endorsement(endorsement).unwrap();
     }
     let execution_results =
-        core_writer_actor.core_reader.get_execution_results_by_shard_id(&block).unwrap();
+        core_writer_actor.core_reader.get_execution_results_by_shard_id(block.header()).unwrap();
     assert!(execution_results.contains_key(&chunk_header.shard_id()));
 }
 
@@ -392,7 +398,11 @@ fn test_handle_processed_block_for_block_with_final_endorsement_and_no_execution
         core_writer_actor.process_chunk_endorsement(endorsement).unwrap();
     }
     assert!(
-        core_writer_actor.core_reader.get_execution_results_by_shard_id(&block).unwrap().is_empty()
+        core_writer_actor
+            .core_reader
+            .get_execution_results_by_shard_id(block.header())
+            .unwrap()
+            .is_empty()
     );
 
     let block_core_statements = in_block_validators
@@ -408,7 +418,7 @@ fn test_handle_processed_block_for_block_with_final_endorsement_and_no_execution
     core_writer_actor.handle_processed_block(*next_block.hash()).unwrap();
 
     let execution_results =
-        core_writer_actor.core_reader.get_execution_results_by_shard_id(&block).unwrap();
+        core_writer_actor.core_reader.get_execution_results_by_shard_id(block.header()).unwrap();
     assert!(execution_results.contains_key(&chunk_header.shard_id()));
 }
 
@@ -440,7 +450,7 @@ fn test_handle_processed_block_for_block_with_execution_results() {
     process_block(&mut chain, next_block.clone());
     core_writer_actor.handle_processed_block(*next_block.hash()).unwrap();
     let execution_results =
-        core_writer_actor.core_reader.get_execution_results_by_shard_id(&block).unwrap();
+        core_writer_actor.core_reader.get_execution_results_by_shard_id(block.header()).unwrap();
     assert_eq!(execution_results.get(&chunk_header.shard_id()), Some(&Arc::new(execution_result)));
 }
 
@@ -459,13 +469,17 @@ fn test_handle_processed_block_processes_pending_endorsements() {
     }
 
     assert!(
-        core_writer_actor.core_reader.get_execution_results_by_shard_id(&block).unwrap().is_empty()
+        core_writer_actor
+            .core_reader
+            .get_execution_results_by_shard_id(block.header())
+            .unwrap()
+            .is_empty()
     );
     process_block(&mut chain, block.clone());
     core_writer_actor.handle_processed_block(*block.hash()).unwrap();
 
     let execution_results =
-        core_writer_actor.core_reader.get_execution_results_by_shard_id(&block).unwrap();
+        core_writer_actor.core_reader.get_execution_results_by_shard_id(block.header()).unwrap();
     assert_eq!(
         execution_results.get(&chunk_header.shard_id()),
         Some(&Arc::new(test_execution_result_for_chunk(&chunk_header)))
@@ -499,13 +513,17 @@ fn test_handle_processed_block_processes_pending_endorsements_with_invalid_endor
     }
 
     assert!(
-        core_writer_actor.core_reader.get_execution_results_by_shard_id(&block).unwrap().is_empty()
+        core_writer_actor
+            .core_reader
+            .get_execution_results_by_shard_id(block.header())
+            .unwrap()
+            .is_empty()
     );
     process_block(&mut chain, block.clone());
     core_writer_actor.handle_processed_block(*block.hash()).unwrap();
 
     let execution_results =
-        core_writer_actor.core_reader.get_execution_results_by_shard_id(&block).unwrap();
+        core_writer_actor.core_reader.get_execution_results_by_shard_id(block.header()).unwrap();
     assert_eq!(
         execution_results.get(&chunk_header.shard_id()),
         Some(&Arc::new(test_execution_result_for_chunk(&chunk_header)))
@@ -697,6 +715,14 @@ fn setup() -> (Chain, SpiceCoreWriterActor) {
     setup_with_senders(noop().into_sender(), noop().into_sender())
 }
 
+fn core_reader(chain: &Chain) -> SpiceCoreReader {
+    SpiceCoreReader::new(
+        chain.chain_store().chain_store(),
+        chain.epoch_manager.clone(),
+        Gas::from_teragas(100),
+    )
+}
+
 fn setup_with_senders(
     chunk_executor_sender: Sender<ExecutionResultEndorsed>,
     spice_chunk_validator_sender: Sender<ExecutionResultEndorsed>,
@@ -721,6 +747,7 @@ fn setup_with_senders(
     let core_writer_actor = SpiceCoreWriterActor::new(
         chain.chain_store().chain_store(),
         chain.epoch_manager.clone(),
+        core_reader(&chain),
         chunk_executor_sender,
         spice_chunk_validator_sender,
     );
@@ -732,6 +759,7 @@ fn setup_with_genesis(genesis: Genesis) -> (Chain, SpiceCoreWriterActor) {
     let core_writer_actor = SpiceCoreWriterActor::new(
         chain.chain_store().chain_store(),
         chain.epoch_manager.clone(),
+        core_reader(&chain),
         noop().into_sender(),
         noop().into_sender(),
     );

--- a/chain/client/src/chunk_executor_actor.rs
+++ b/chain/client/src/chunk_executor_actor.rs
@@ -109,7 +109,8 @@ impl ChunkExecutorActor {
         core_writer_sender: Sender<SpiceChunkEndorsementMessage>,
         data_distributor_adapter: SpiceDataDistributorAdapter,
     ) -> Self {
-        let core_reader = SpiceCoreReader::new(store.chain_store(), epoch_manager.clone());
+        let core_reader =
+            SpiceCoreReader::new(store.chain_store(), epoch_manager.clone(), genesis.gas_limit);
         Self {
             chain_store: ChainStore::new(store, true, genesis.transaction_validity_period),
             runtime_adapter,
@@ -299,7 +300,8 @@ impl TryApplyChunksOutcome {
         epoch_manager: &dyn EpochManagerAdapter,
         prev_block: &Block,
     ) -> Result<Self, Error> {
-        let execution_results = core_reader.get_execution_results_by_shard_id(&prev_block)?;
+        let execution_results =
+            core_reader.get_execution_results_by_shard_id(prev_block.header())?;
         let shard_layout = epoch_manager.get_shard_layout(prev_block.header().epoch_id())?;
         let missing_shard_ids = shard_layout
             .shard_ids()
@@ -365,7 +367,7 @@ impl ChunkExecutorActor {
         let store = self.chain_store.store();
 
         let Some(prev_block_execution_results) =
-            self.core_reader.get_block_execution_results(&prev_block)?
+            self.core_reader.get_block_execution_results(prev_block.header())?
         else {
             return TryApplyChunksOutcome::missing_execution_results(
                 &self.core_reader,
@@ -868,10 +870,11 @@ impl ChunkExecutorActor {
         block_hash: &CryptoHash,
     ) -> Result<ReceiptVerificationContext, Error> {
         let block = self.chain_store.get_block(block_hash)?;
-        if !self.core_reader.all_execution_results_exist(&block)? {
+        if !self.core_reader.all_execution_results_exist(block.header())? {
             return Ok(ReceiptVerificationContext::NotReady);
         }
-        let execution_results = self.core_reader.get_execution_results_by_shard_id(&block)?;
+        let execution_results =
+            self.core_reader.get_execution_results_by_shard_id(block.header())?;
         Ok(ReceiptVerificationContext::Ready { execution_results })
     }
 

--- a/chain/client/src/spice_chunk_validator_actor.rs
+++ b/chain/client/src/spice_chunk_validator_actor.rs
@@ -61,7 +61,8 @@ impl SpiceChunkValidatorActor {
         core_writer_sender: Sender<SpiceChunkEndorsementMessage>,
         validation_spawner: ApplyChunksSpawner,
     ) -> Self {
-        let core_reader = SpiceCoreReader::new(store.chain_store(), epoch_manager.clone());
+        let core_reader =
+            SpiceCoreReader::new(store.chain_store(), epoch_manager.clone(), genesis.gas_limit);
         // TODO(spice): Assess if this limit still makes sense for spice.
         // See ChunkValidator::new in c/c/s/s/chunk_validator/mod.rs for rationale used currently.
         let validation_thread_limit =
@@ -188,7 +189,7 @@ impl SpiceChunkValidatorActor {
         let prev_block = self.chain_store.get_block(block.header().prev_hash())?;
 
         let Some(prev_block_execution_results) =
-            self.core_reader.get_block_execution_results(&prev_block)?
+            self.core_reader.get_block_execution_results(prev_block.header())?
         else {
             tracing::debug!(
                 target: "spice_chunk_validator",
@@ -213,7 +214,7 @@ impl SpiceChunkValidatorActor {
         let prev_hash = *block.header().prev_hash();
         let prev_block = self.chain_store.get_block(&prev_hash)?;
         let Some(prev_block_execution_results) =
-            self.core_reader.get_block_execution_results(&prev_block)?
+            self.core_reader.get_block_execution_results(prev_block.header())?
         else {
             tracing::debug!(
                 target: "spice_chunk_validator",

--- a/chain/client/src/spice_data_distributor_actor.rs
+++ b/chain/client/src/spice_data_distributor_actor.rs
@@ -286,6 +286,7 @@ impl SpiceDataDistributorActor {
         chain_store: ChainStoreAdapter,
         validator_signer: MutableValidatorSigner,
         shard_tracker: ShardTracker,
+        core_reader: SpiceCoreReader,
         network_adapter: PeerManagerAdapter,
         executor_sender: Sender<ExecutorIncomingUnverifiedReceipts>,
         witness_validator_sender: Sender<SpanWrapped<SpiceChunkStateWitnessMessage>>,
@@ -293,7 +294,6 @@ impl SpiceDataDistributorActor {
         const RECENTLY_DECODED_DATA_CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(100).unwrap();
         const DATA_PARTS_RATIO: f64 = 0.6;
         const PENDING_PARTIAL_DATA_CAP: NonZeroUsize = NonZeroUsize::new(10).unwrap();
-        let core_reader = SpiceCoreReader::new(chain_store.clone(), epoch_manager.clone());
         Self {
             // TODO(spice): Evaluate whether the same data parts ratio makes sense for all data
             // distributed.

--- a/chain/client/src/tests/spice_chunk_executor_actor.rs
+++ b/chain/client/src/tests/spice_chunk_executor_actor.rs
@@ -7,6 +7,7 @@ use near_async::test_utils::FakeDelayedActionRunner;
 use near_async::time::Clock;
 use near_chain::ApplyChunksIterationMode;
 use near_chain::ChainStoreAccess;
+use near_chain::spice_core::SpiceCoreReader;
 use near_chain::spice_core_writer_actor::ExecutionResultEndorsed;
 use near_chain::spice_core_writer_actor::ProcessedBlock;
 use near_chain::spice_core_writer_actor::SpiceCoreWriterActor;
@@ -25,6 +26,7 @@ use near_epoch_manager::shard_tracker::ShardTracker;
 use near_network::client::SpiceChunkEndorsementMessage;
 use near_network::types::{NetworkRequests, PeerManagerAdapter, PeerManagerMessageRequest};
 use near_o11y::testonly::init_test_logger;
+use near_primitives::gas::Gas;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{Receipt, ReceiptPriority};
 use near_primitives::shard_layout::ShardLayout;
@@ -145,6 +147,7 @@ impl TestActor {
         let core_writer_actor = Arc::new(RwLock::new(SpiceCoreWriterActor::new(
             runtime.store().chain_store(),
             epoch_manager.clone(),
+            core_reader(&chain),
             noop().into_sender(),
             noop().into_sender(),
         )));
@@ -209,6 +212,14 @@ impl TestActor {
         self.actor.handle(msg);
         self.run_internal_events();
     }
+}
+
+fn core_reader(chain: &Chain) -> SpiceCoreReader {
+    SpiceCoreReader::new(
+        chain.chain_store.store().chain_store(),
+        chain.epoch_manager.clone(),
+        Gas::from_teragas(100),
+    )
 }
 
 fn setup_with_shards(
@@ -947,8 +958,12 @@ fn test_witness_is_valid() {
         else {
             continue;
         };
-        let prev_block_execution_results =
-            actor.actor.core_reader.get_block_execution_results(&prev_block).unwrap().unwrap();
+        let prev_block_execution_results = actor
+            .actor
+            .core_reader
+            .get_block_execution_results(prev_block.header())
+            .unwrap()
+            .unwrap();
         let pre_validation_result = spice_pre_validate_chunk_state_witness(
             &state_witness,
             &block,

--- a/nearcore/src/lib.rs
+++ b/nearcore/src/lib.rs
@@ -11,6 +11,7 @@ use near_async::time::{self, Clock};
 use near_chain::rayon_spawner::RayonAsyncComputationSpawner;
 use near_chain::resharding::resharding_actor::ReshardingActor;
 pub use near_chain::runtime::NightshadeRuntime;
+use near_chain::spice_core::SpiceCoreReader;
 use near_chain::spice_core_writer_actor::SpiceCoreWriterActor;
 use near_chain::state_snapshot_actor::{
     SnapshotCallbacks, StateSnapshotActor, get_delete_snapshot_callback, get_make_snapshot_callback,
@@ -268,9 +269,15 @@ fn spawn_spice_actors(
     >,
     spice_core_writer_adapter: &Arc<LateBoundSender<TokioRuntimeHandle<SpiceCoreWriterActor>>>,
 ) {
+    let spice_core_reader = SpiceCoreReader::new(
+        runtime.store().chain_store(),
+        epoch_manager.clone(),
+        chain_genesis.gas_limit,
+    );
     let spice_core_writer_actor = SpiceCoreWriterActor::new(
         runtime.store().chain_store(),
         epoch_manager.clone(),
+        spice_core_reader.clone(),
         chunk_executor_adapter.as_sender(),
         spice_chunk_validator_adapter.as_sender(),
     );
@@ -282,6 +289,7 @@ fn spawn_spice_actors(
         runtime.store().chain_store(),
         validator_signer.clone(),
         shard_tracker.clone(),
+        spice_core_reader,
         network_adapter.clone(),
         chunk_executor_adapter.as_sender(),
         spice_chunk_validator_adapter.as_sender(),

--- a/test-loop-tests/src/setup/setup.rs
+++ b/test-loop-tests/src/setup/setup.rs
@@ -5,6 +5,7 @@ use near_async::test_loop::TestLoopV2;
 use near_async::time::Duration;
 use near_chain::resharding::resharding_actor::ReshardingActor;
 use near_chain::runtime::NightshadeRuntime;
+use near_chain::spice_core::SpiceCoreReader;
 use near_chain::spice_core_writer_actor::SpiceCoreWriterActor;
 use near_chain::state_snapshot_actor::{
     SnapshotCallbacks, StateSnapshotActor, get_delete_snapshot_callback, get_make_snapshot_callback,
@@ -392,9 +393,16 @@ pub fn setup_client(
         client_config.resharding_config.clone(),
     );
 
+    let spice_core_reader = SpiceCoreReader::new(
+        runtime_adapter.store().chain_store(),
+        epoch_manager.clone(),
+        chain_genesis.gas_limit,
+    );
+
     let spice_core_writer_actor = SpiceCoreWriterActor::new(
         runtime_adapter.store().chain_store(),
         epoch_manager.clone(),
+        spice_core_reader.clone(),
         chunk_executor_adapter.as_sender(),
         spice_chunk_validator_adapter.as_sender(),
     );
@@ -404,6 +412,7 @@ pub fn setup_client(
         runtime_adapter.store().chain_store(),
         validator_signer.clone(),
         shard_tracker.clone(),
+        spice_core_reader,
         network_adapter.as_multi_sender(),
         chunk_executor_adapter.as_sender(),
         spice_chunk_validator_adapter.as_sender(),

--- a/test-loop-tests/src/tests/spice.rs
+++ b/test-loop-tests/src/tests/spice.rs
@@ -657,9 +657,12 @@ fn test_spice_chain_with_missing_chunks() {
             }
         }
 
-        if !client.chain.spice_core_reader.all_execution_results_exist(&block).unwrap() {
-            let execution_results =
-                client.chain.spice_core_reader.get_execution_results_by_shard_id(&block).unwrap();
+        if !client.chain.spice_core_reader.all_execution_results_exist(block.header()).unwrap() {
+            let execution_results = client
+                .chain
+                .spice_core_reader
+                .get_execution_results_by_shard_id(block.header())
+                .unwrap();
             missed_execution = true;
             println!(
                 "not all execution result for block at height: {}; execution_results: {:?}",


### PR DESCRIPTION
The main reason we couldn't use headers before is because we needed block to build genesis chunk extra. With this refactoring genesis chunk extra can be build without a block though now we need to store genesis gas limit in spice core reader.

Using a header in API instead of blocks would allow using it in places where we already get header without the need to request the block as well. For example when preprocessing the block we would need execution results for last certified block check gas price (we would have to use last certification block execution result for gas price calculations) here: https://github.com/near/nearcore/blob/db9ce5b21f2f8a9ee235acaa442a165c775f90b9/chain/chain/src/chain.rs#L2313