### PR TITLE
feat(client): improve the metric about transaction preparation limits

### DIFF
--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -376,8 +376,17 @@ pub struct ApplyChunkShardContext<'a> {
 pub struct PreparedTransactions {
     /// Prepared transactions
     pub transactions: Vec<ValidatedTransaction>,
-    /// Describes which limit was hit when preparing the transactions.
-    pub limited_by: Option<PrepareTransactionsLimit>,
+    /// Describes what limited the number of prepared transactions.
+    pub limited_by: PrepareTransactionsLimit,
+}
+
+impl PreparedTransactions {
+    pub fn new() -> PreparedTransactions {
+        PreparedTransactions {
+            transactions: Vec::new(),
+            limited_by: PrepareTransactionsLimit::NoMoreTxsInPool,
+        }
+    }
 }
 
 /// Transactions that were taken out of the pool in prepare_transactions,
@@ -390,11 +399,17 @@ pub struct SkippedTransactions(pub Vec<ValidatedTransaction>);
 /// This enum describes which limit was hit when preparing transactions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum::AsRefStr)]
 pub enum PrepareTransactionsLimit {
+    /// No more transactions to pick from the transaction pool.
+    NoMoreTxsInPool,
+    /// Gas limit hit.
     Gas,
+    /// Total transactions size limit hit.
     Size,
+    /// Time limit hit.
     Time,
-    ReceiptCount,
+    /// Recorded storage size limit hit.
     StorageProofSize,
+    /// Transaction preparation was cancelled.
     Cancelled,
 }
 

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -80,12 +80,11 @@ pub static CHUNK_TRANSACTIONS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| 
     .unwrap()
 });
 
-pub(crate) static PRODUCED_CHUNKS_SOME_POOL_TRANSACTIONS_DID_NOT_FIT: LazyLock<IntCounterVec> =
+pub(crate) static PRODUCE_CHUNK_TRANSACTIONS_LIMITED_BY: LazyLock<IntCounterVec> =
     LazyLock::new(|| {
         try_create_int_counter_vec(
-        "near_produced_chunks_some_pool_transactions_did_not_fit",
-        "Total number of produced chunks where some transactions from the pool didn't fit in the chunk \
-        (since starting this node). The limited_by label specifies which limit was hit.",
+        "near_produce_chunk_transactions_limited_by",
+        "Records what limited the number of transaction included in chunks produced by this node",
         &["shard_id", "limited_by"],
     )
     .unwrap()

--- a/chain/client/src/prepare_transactions.rs
+++ b/chain/client/src/prepare_transactions.rs
@@ -125,7 +125,7 @@ impl PrepareTransactionsJob {
         // Run the job. The state is locked so no other methods will read or modify it
         // until the preparation finishes.
         let Some(mut iter) = tx_pool_guard.get_pool_iterator(inputs.shard_uid) else {
-            let result = PreparedTransactions { transactions: Vec::new(), limited_by: None };
+            let result = PreparedTransactions::new();
             *state = PrepareTransactionsJobState::Finished(Ok(result));
             return;
         };
@@ -142,7 +142,7 @@ impl PrepareTransactionsJob {
         drop(iter);
         match result {
             Ok((prepared, skipped)) => {
-                *state = if prepared.limited_by == Some(PrepareTransactionsLimit::Cancelled) {
+                *state = if prepared.limited_by == PrepareTransactionsLimit::Cancelled {
                     // In case of cancelled preparation discard the result
                     PrepareTransactionsJobState::Cancelled
                 } else {
@@ -252,7 +252,7 @@ mod tests {
     use std::sync::Arc;
 
     use near_chain::runtime::NightshadeRuntime;
-    use near_chain::types::PrepareTransactionsBlockContext;
+    use near_chain::types::{PrepareTransactionsBlockContext, PrepareTransactionsLimit};
     use near_chain_configs::test_genesis::TestGenesisBuilder;
     use near_chunks::client::ShardedTransactionPool;
     use near_epoch_manager::EpochManager;
@@ -361,7 +361,7 @@ mod tests {
             .take_result()
             .expect("result must be available after running the job")
             .expect("job must succeed");
-        assert_eq!(None, result.limited_by);
+        assert_eq!(PrepareTransactionsLimit::NoMoreTxsInPool, result.limited_by);
         assert_eq!(1, result.transactions.len());
 
         // Taking again returns None


### PR DESCRIPTION
We have a metric which shows us what kind of limit was hit when preparing transactions (gas, size, storage proof etc).
But the metric doesn't record anything when preparation didn't hit any of the limits and simply ran out of transactions to pick from the pool. This can be confusing, sometimes I see zero data in Grafana and I'm not sure whether no limits were hit or something broke with the metrics.
Let's also record when the preparation was limited by running out of transactions in the pool, this will make it easier to reason about the data. It will also make it consistent with another similar metric that we have - `CHUNK_RECEIPTS_LIMITED_BY`.

Apart from that I cleaned up a little bit to make things nicer and renamed the metric, as the previous name was unwieldy.