### PR TITLE
chore: use serde::Serializer::collect_str to avoid String allocations

### DIFF
--- a/chain/rosetta-rpc/src/utils.rs
+++ b/chain/rosetta-rpc/src/utils.rs
@@ -207,7 +207,7 @@ where
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        serializer.collect_str(self)
     }
 }
 

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -681,7 +681,7 @@ impl serde::Serialize for Signature {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        serializer.collect_str(self)
     }
 }
 

--- a/core/primitives/src/shard_layout/mod.rs
+++ b/core/primitives/src/shard_layout/mod.rs
@@ -519,7 +519,7 @@ impl serde::Serialize for ShardUId {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        serializer.collect_str(self)
     }
 }
 


### PR DESCRIPTION
Replaced serialize_str(&self.to_string()) with serializer.collect_str(self) in three Serialize implementations: Signature in core/crypto/src/signature.rs, ShardUId in core/primitives/src/shard_layout/mod.rs, and SignedDiff in chain/rosetta-rpc/src/utils.rs. The switch removes an otherwise guaranteed heap allocation by leveraging existing Display implementations, aligns Signature with PublicKey and SecretKey which already use collect_str, and preserves the exact serialized output. This is the serde-recommended approach for serializing via Display and reduces overhead without any functional change.