### PR TITLE
fix(refcount): correct set_refcount() docs to match io::Result error semantics

### DIFF
--- a/core/store/src/db/refcount.rs
+++ b/core/store/src/db/refcount.rs
@@ -69,7 +69,8 @@ pub(crate) fn strip_refcount(mut bytes: Vec<u8>) -> Option<Vec<u8>> {
 /// This method assumes that the data already contains a reference count stored
 /// in the last 8 bytes. It overwrites this value with the new value.
 ///
-/// Returns None if the input bytes are too short to contain a refcount.
+/// Returns an error (`io::ErrorKind::InvalidData`) if the input bytes are too
+/// short to contain a refcount.
 pub(crate) fn set_refcount(data: &mut Vec<u8>, refcount: i64) -> io::Result<()> {
     const BYTE_COUNT: usize = std::mem::size_of::<i64>();
 


### PR DESCRIPTION
The set_refcount() docs incorrectly claimed it returns None for short inputs, but the function returns io::Result and yields Err(InvalidData) on insufficient length. Updated the comment to reflect the actual API, which matches all call sites (e.g., colddb) and tests. This avoids confusion for callers and keeps docs consistent with behavior.