### PR TITLE
chore(store): convert genesis_height to lazy initialization with OnceLock

### DIFF
--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -229,7 +229,7 @@ fn find_first_height_to_fetch(
 
     let min_height_to_search = max(
         height_to_fetch as i64 - DEBUG_MAX_BLOCKS_TO_SEARCH as i64,
-        chain_store.genesis_height() as i64,
+        chain_store.get_genesis_height() as i64,
     ) as u64;
     while height_to_fetch > min_height_to_search {
         let block_hashes = get_block_hashes_to_fetch(chain_store, height_to_fetch, final_height);
@@ -547,9 +547,10 @@ impl ClientActor {
         let mut height_to_fetch = starting_height.unwrap_or(header_head.height);
         height_to_fetch =
             find_first_height_to_fetch(chain_store, height_to_fetch, mode, final_head.height)?;
-        let min_height_to_fetch =
-            max(height_to_fetch as i64 - num_blocks as i64, chain_store.genesis_height() as i64)
-                as u64;
+        let min_height_to_fetch = max(
+            height_to_fetch as i64 - num_blocks as i64,
+            chain_store.get_genesis_height() as i64,
+        ) as u64;
 
         let mut block_hashes_to_force_fetch = HashSet::new();
         while height_to_fetch > min_height_to_fetch || !block_hashes_to_force_fetch.is_empty() {

--- a/core/store/src/adapter/chain_store.rs
+++ b/core/store/src/adapter/chain_store.rs
@@ -22,13 +22,13 @@ use near_primitives::utils::{get_block_shard_id, get_outcome_id_block_hash, inde
 use near_primitives::views::LightClientBlockView;
 use std::collections::{HashMap, HashSet};
 use std::io;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 #[derive(Clone)]
 pub struct ChainStoreAdapter {
     store: Store,
-    /// Genesis block height.
-    genesis_height: BlockHeight,
+    /// Genesis block height, lazily initialized.
+    genesis_height: OnceLock<BlockHeight>,
 }
 
 impl StoreAdapter for ChainStoreAdapter {
@@ -39,10 +39,7 @@ impl StoreAdapter for ChainStoreAdapter {
 
 impl ChainStoreAdapter {
     pub fn new(store: Store) -> Self {
-        let genesis_height = get_genesis_height(&store)
-            .expect("Store failed on fetching genesis height")
-            .expect("Genesis height not found in storage");
-        Self { store, genesis_height }
+        Self { store, genesis_height: OnceLock::new() }
     }
 
     pub fn store_update(&self) -> ChainStoreUpdateAdapter<'static> {
@@ -51,8 +48,13 @@ impl ChainStoreAdapter {
         }
     }
 
-    pub fn genesis_height(&self) -> BlockHeight {
-        self.genesis_height
+    /// Helper method to lazily initialize and retrieve the genesis height.
+    fn get_or_init_genesis_height(&self) -> BlockHeight {
+        *self.genesis_height.get_or_init(|| {
+            get_genesis_height(&self.store)
+                .expect("Store failed on fetching genesis height")
+                .expect("Genesis height not found in storage")
+        })
     }
 
     /// The chain head.
@@ -64,7 +66,7 @@ impl ChainStoreAdapter {
     pub fn tail(&self) -> Result<BlockHeight, Error> {
         self.store
             .get_ser(DBCol::BlockMisc, TAIL_KEY)
-            .map(|option| option.unwrap_or(self.genesis_height))
+            .map(|option| option.unwrap_or_else(|| self.get_or_init_genesis_height()))
             .map_err(|e| e.into())
     }
 
@@ -72,7 +74,7 @@ impl ChainStoreAdapter {
     pub fn chunk_tail(&self) -> Result<BlockHeight, Error> {
         self.store
             .get_ser(DBCol::BlockMisc, CHUNK_TAIL_KEY)
-            .map(|option| option.unwrap_or(self.genesis_height))
+            .map(|option| option.unwrap_or_else(|| self.get_or_init_genesis_height()))
             .map_err(|e| e.into())
     }
 
@@ -80,7 +82,7 @@ impl ChainStoreAdapter {
     pub fn fork_tail(&self) -> Result<BlockHeight, Error> {
         self.store
             .get_ser(DBCol::BlockMisc, FORK_TAIL_KEY)
-            .map(|option| option.unwrap_or(self.genesis_height))
+            .map(|option| option.unwrap_or_else(|| self.get_or_init_genesis_height()))
             .map_err(|e| e.into())
     }
 
@@ -135,7 +137,7 @@ impl ChainStoreAdapter {
     pub fn gc_stop_height(&self) -> Result<BlockHeight, Error> {
         match self.store.get_ser(DBCol::BlockMisc, GC_STOP_HEIGHT_KEY) {
             Ok(Some(height)) => Ok(height),
-            Ok(None) => Ok(self.genesis_height),
+            Ok(None) => Ok(self.get_or_init_genesis_height()),
             Err(e) => Err(e.into()),
         }
     }
@@ -172,7 +174,7 @@ impl ChainStoreAdapter {
     /// Get block height.
     pub fn get_block_height(&self, hash: &CryptoHash) -> Result<BlockHeight, Error> {
         if hash == &CryptoHash::default() {
-            Ok(self.genesis_height)
+            Ok(self.get_or_init_genesis_height())
         } else {
             Ok(self.get_block_header(hash)?.height())
         }
@@ -441,7 +443,7 @@ impl ChainStoreAdapter {
 
     /// Get height of genesis
     pub fn get_genesis_height(&self) -> BlockHeight {
-        self.genesis_height
+        self.get_or_init_genesis_height()
     }
 }
 


### PR DESCRIPTION
This PR converts the `genesis_height` field in `ChainStoreAdapter` from eager 
initialization to lazy initialization using `OnceLock<BlockHeight>`.

This change is required for unit tests of epoch manager with continuous epoch 
sync, where the test store object doesn't have `genesis_height` set in storage. 
Previously, `ChainStoreAdapter::new()` would panic when `get_genesis_height` 
returned `None`, making it impossible to construct the adapter with an 
incomplete test store.