### PR TITLE
fix: reduce log noise from closed network connection

### DIFF
--- a/chain/network/src/peer/peer_actor.rs
+++ b/chain/network/src/peer/peer_actor.rs
@@ -1654,7 +1654,7 @@ impl messaging::Handler<stream::Error> for PeerActor {
             },
             };
             log_assert!(expected, "unexpected closing reason: {err}");
-            tracing::info!(target: "network", ?err, peer_info = %this.peer_info, "closing connection");
+            tracing::debug!(target: "network", ?err, peer_info = %this.peer_info, "closing connection");
             this.stop(ClosingReason::StreamError);
         });
     }

--- a/core/async/src/tokio/runtime_handle.rs
+++ b/core/async/src/tokio/runtime_handle.rs
@@ -173,11 +173,11 @@ impl<A: Actor + Send + 'static> TokioRuntimeBuilder<A> {
             loop {
                 tokio::select! {
                     _ = self.system_cancellation_signal.cancelled() => {
-                        tracing::info!(target: "tokio_runtime", actor_name, "shutting down tokio runtime due to actor system shutdown");
+                        tracing::debug!(target: "tokio_runtime", actor_name, "shutting down tokio runtime due to actor system shutdown");
                         break;
                     }
                     _ = runtime_handle.cancel.cancelled() => {
-                        tracing::info!(target: "tokio_runtime", actor_name, "shutting down tokio runtime due to targeted cancellation");
+                        tracing::debug!(target: "tokio_runtime", actor_name, "shutting down tokio runtime due to targeted cancellation");
                         break;
                     }
                     _ = window_update_timer.tick() => {


### PR DESCRIPTION
Our node spams logs at info level with unnecessary information:
```
Dec 02 10:57:54 block-mainnet-validator-01-europe-west4-a-9efabb02 neard[2003]: 2025-12-02T10:57:54.575911Z INFO tokio_runtime: Shutting down Tokio runtime due to targeted cancellation actor_name="PeerActor"
Dec 02 10:57:54 block-mainnet-validator-01-europe-west4-a-9efabb02 neard[2003]: 2025-12-02T10:57:54.936785Z INFO network: Closing connection to Some(ed25519:Fc8H5cCGQuybcP1smTVs4X6BQD4irrxeeasNYNJwWzjF@142.132.158.172:24567) err=Recv(IO(Kind(UnexpectedEof)))
```

This is not actionable and happens under normal node operation, so reducing log level to debug.