### PR TITLE
fix(changelog): fix 2.9/2.10 release description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,8 @@
 ## [2.9.0]
 
 ### Protocol Changes
-Maximum inflation rate moved to epoch config
-Inflation rate reduction from 5% to 2.5%
+* Maximum inflation rate moved to epoch config
+* Inflation rate reduction from 5% to 2.5%
 
 ## [2.8.0]
 


### PR DESCRIPTION
2.9.0 was made as inflation reduction but changelog was not updated.
For master & cherry-pick to release branch.